### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.1.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.1.1", path = "../inference", optional = true, features = ["f16"] }
 
 # Time
 chrono = { workspace = true }

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -23,7 +23,7 @@ inference-hook = ["dep:lattice-inference"]
 sqlite = ["dep:rusqlite", "serde"]
 
 [dependencies]
-lattice-fann = { version = "0.1.0", path = "../fann" }
+lattice-fann = { version = "0.1.1", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -44,7 +44,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook (optional — for LoRA adapter injection)
-lattice-inference = { version = "0.1.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.1.1", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"


### PR DESCRIPTION
## Summary
- Workspace version 0.1.0 → 0.1.1
- Internal path deps updated (embed→inference, tune→fann, tune→inference)
- Release build verified

## Test plan
- [x] `cargo build --workspace --release` clean
- [x] Pre-commit passed (fmt + clippy + doc lint)
- [ ] CI green