### PR TITLE
feat(inference): differential attention module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: rustfmt, clippy
+      - name: Pin the real toolchain bin on PATH
+        # Some macos-latest runner images ship ~/.cargo/bin/cargo as a copy of
+        # rustup-init rather than the rustup proxy, so `cargo fmt` fails with
+        # "error: unexpected argument 'fmt'". rustup itself is unaffected — resolve
+        # the real toolchain bin dir through it and put it first on PATH so every
+        # later step (cache, clean, ci.sh) gets a working cargo. No-op on healthy
+        # images and on Linux.
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -113,6 +113,10 @@ name = "attention_bench"
 harness = true
 
 [[bench]]
+name = "differential_attention_bench"
+harness = false
+
+[[bench]]
 name = "gated_attention_bench"
 harness = false
 

--- a/crates/inference/benches/differential_attention_bench.rs
+++ b/crates/inference/benches/differential_attention_bench.rs
@@ -1,0 +1,312 @@
+//! Benchmarks for differential attention (`apply_differential_attention`).
+//!
+//! Measures:
+//! - `apply_differential_attention` throughput at representative sequence lengths.
+//! - Overhead of the differential mechanism vs a plain GQA-style single-softmax baseline
+//!   (the cost of the second softmax + subtract + sub-RMSNorm).
+//!
+//! Run with:
+//!   cargo bench --bench differential_attention_bench
+//!
+//! Results are printed to stdout.
+
+use lattice_inference::attention::differential::{
+    DiffAttnConfig, DiffAttnScratch, DiffLambdaParams, apply_differential_attention,
+};
+use lattice_inference::attention::gqa::{GqaConfig, GqaScratch, apply_gqa_attention};
+use std::hint::black_box;
+use std::time::Instant;
+
+// ===================================================================
+// Utilities
+// ===================================================================
+
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        self.state = self
+            .state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        (self.state >> 32) as u32
+    }
+
+    fn next_f32(&mut self) -> f32 {
+        (self.next_u32() as f32) / (u32::MAX as f32) - 0.5
+    }
+}
+
+fn random_vec(len: usize, rng: &mut Lcg) -> Vec<f32> {
+    (0..len).map(|_| rng.next_f32()).collect()
+}
+
+fn iterations_for_seq(seq_len: usize) -> usize {
+    match seq_len {
+        0..=64 => 2_000,
+        65..=256 => 500,
+        _ => 100,
+    }
+}
+
+fn average_us<F>(iters: usize, mut f: F) -> f64
+where
+    F: FnMut(),
+{
+    let start = Instant::now();
+    for _ in 0..iters {
+        f();
+    }
+    start.elapsed().as_secs_f64() * 1_000_000.0 / iters as f64
+}
+
+// ===================================================================
+// Benchmark shapes
+// ===================================================================
+
+/// (name, num_heads, num_kv_heads, head_dim, layer_depth)
+const MODEL_CASES: &[(&str, usize, usize, usize, usize)] = &[
+    // Small/toy
+    ("diff-2h-mha-hd8", 2, 2, 8, 1),
+    // Medium — analogous to a 4-head GQA config
+    ("diff-4h-gqa-2kv-hd16", 4, 2, 16, 3),
+    // Larger, comparable to small transformer layers
+    ("diff-8h-gqa-2kv-hd32", 8, 2, 32, 6),
+];
+
+const SEQ_LENS: &[usize] = &[64, 256, 512];
+
+// ===================================================================
+// Benchmark: apply_differential_attention throughput
+// ===================================================================
+
+fn bench_diff_attn() {
+    println!(
+        "\n=== apply_differential_attention ===\n{:<26} {:>8} {:>12} {:>12}",
+        "model", "seq_len", "avg_us", "tok/ms"
+    );
+    println!(
+        "{:<26} {:>8} {:>12} {:>12}",
+        "--------------------------", "--------", "------------", "------------",
+    );
+
+    for &(name, num_heads, num_kv_heads, head_dim, layer_depth) in MODEL_CASES {
+        let cfg = DiffAttnConfig {
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            layer_depth,
+        };
+
+        for &seq_len in SEQ_LENS {
+            let mut rng = Lcg::new((seq_len as u64) ^ ((head_dim as u64) << 16));
+
+            let q = random_vec(seq_len * cfg.q_dim(), &mut rng);
+            let k = random_vec(seq_len * cfg.k_dim(), &mut rng);
+            let v = random_vec(seq_len * cfg.v_dim(), &mut rng);
+            let params = DiffLambdaParams {
+                lambda_q1: random_vec(head_dim, &mut rng)
+                    .into_iter()
+                    .map(|x| x * 0.1)
+                    .collect(),
+                lambda_k1: random_vec(head_dim, &mut rng)
+                    .into_iter()
+                    .map(|x| x * 0.1)
+                    .collect(),
+                lambda_q2: random_vec(head_dim, &mut rng)
+                    .into_iter()
+                    .map(|x| x * 0.1)
+                    .collect(),
+                lambda_k2: random_vec(head_dim, &mut rng)
+                    .into_iter()
+                    .map(|x| x * 0.1)
+                    .collect(),
+            };
+            let subln_w = vec![1.0_f32; 2 * head_dim];
+            let mut out = vec![0.0_f32; seq_len * cfg.out_dim()];
+            let mut scratch = DiffAttnScratch::default();
+
+            // Warm-up
+            for _ in 0..20 {
+                apply_differential_attention(
+                    black_box(&q),
+                    black_box(&k),
+                    black_box(&v),
+                    black_box(&params),
+                    black_box(&subln_w),
+                    1e-6,
+                    black_box(&mut out),
+                    seq_len,
+                    &cfg,
+                    &mut scratch,
+                );
+            }
+
+            let iters = iterations_for_seq(seq_len);
+            let us = average_us(iters, || {
+                apply_differential_attention(
+                    black_box(&q),
+                    black_box(&k),
+                    black_box(&v),
+                    black_box(&params),
+                    black_box(&subln_w),
+                    1e-6,
+                    black_box(&mut out),
+                    seq_len,
+                    &cfg,
+                    &mut scratch,
+                );
+                black_box(&out);
+            });
+
+            let tok_per_ms = seq_len as f64 / us * 1_000.0;
+            println!("{name:<26} {seq_len:>8} {us:>12.3} {tok_per_ms:>12.1}");
+        }
+    }
+}
+
+// ===================================================================
+// Benchmark: differential vs GQA baseline overhead
+//
+// GQA attention (apply_gqa_attention) does one softmax per head-pair.
+// Differential attention does two softmax passes per head-pair + subtract + subln.
+// This section shows the marginal cost of the differential mechanism.
+//
+// NOTE: GQA and differential have different buffer layouts (GQA uses the
+// standard embed_dim = num_heads*head_dim; differential uses 2*num_heads
+// packed heads). We compare them at the same "effective" model size:
+// a GQA config with (2*num_heads, num_kv_heads, head_dim) covering the same
+// parameter count as the differential config's Q/K projections.
+// ===================================================================
+
+fn bench_overhead_vs_gqa() {
+    println!(
+        "\n=== overhead: differential vs GQA-baseline (same Q/K projection size) ===\n{:<26} {:>8} {:>14} {:>14} {:>10}",
+        "model", "seq_len", "gqa_us", "diff_us", "overhead"
+    );
+    println!(
+        "{:<26} {:>8} {:>14} {:>14} {:>10}",
+        "--------------------------", "--------", "--------------", "--------------", "----------",
+    );
+
+    // Only benchmark at seq_len=256 to keep output concise
+    const BENCH_SEQ: usize = 256;
+
+    for &(name, num_heads, num_kv_heads, head_dim, layer_depth) in MODEL_CASES {
+        let diff_cfg = DiffAttnConfig {
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            layer_depth,
+        };
+
+        // GQA with the same packed head count (2*num_heads Q heads, same KV heads)
+        // and same head_dim. This matches the same Q/K projection sizes.
+        let gqa_cfg = GqaConfig {
+            num_heads: 2 * num_heads,       // packed heads
+            num_kv_heads: 2 * num_kv_heads, // packed KV heads
+            head_dim,
+        };
+
+        let seq_len = BENCH_SEQ;
+        let mut rng = Lcg::new((seq_len as u64) ^ 0xDEAD_BEEF);
+
+        // Differential inputs
+        let dq = random_vec(seq_len * diff_cfg.q_dim(), &mut rng);
+        let dk = random_vec(seq_len * diff_cfg.k_dim(), &mut rng);
+        let dv = random_vec(seq_len * diff_cfg.v_dim(), &mut rng);
+        let params = DiffLambdaParams {
+            lambda_q1: vec![0.0; head_dim],
+            lambda_k1: vec![0.0; head_dim],
+            lambda_q2: vec![0.0; head_dim],
+            lambda_k2: vec![0.0; head_dim],
+        };
+        let subln_w = vec![1.0_f32; 2 * head_dim];
+        let mut dout = vec![0.0_f32; seq_len * diff_cfg.out_dim()];
+        let mut dscratch = DiffAttnScratch::default();
+
+        // GQA inputs (same total Q/K/V bytes as differential)
+        let gq = random_vec(seq_len * gqa_cfg.q_dim(), &mut rng);
+        let gk = random_vec(seq_len * gqa_cfg.kv_dim(), &mut rng);
+        let gv = random_vec(seq_len * gqa_cfg.kv_dim(), &mut rng);
+        let mut gout = vec![0.0_f32; seq_len * gqa_cfg.q_dim()];
+        let mut gscratch = GqaScratch::default();
+
+        // Warm-up both
+        for _ in 0..20 {
+            apply_differential_attention(
+                black_box(&dq),
+                black_box(&dk),
+                black_box(&dv),
+                black_box(&params),
+                black_box(&subln_w),
+                1e-6,
+                black_box(&mut dout),
+                seq_len,
+                &diff_cfg,
+                &mut dscratch,
+            );
+            apply_gqa_attention(
+                black_box(&gq),
+                black_box(&gk),
+                black_box(&gv),
+                black_box(&mut gout),
+                seq_len,
+                gqa_cfg,
+                &mut gscratch,
+            );
+        }
+
+        let iters = iterations_for_seq(seq_len);
+
+        let us_gqa = average_us(iters, || {
+            apply_gqa_attention(
+                black_box(&gq),
+                black_box(&gk),
+                black_box(&gv),
+                black_box(&mut gout),
+                seq_len,
+                gqa_cfg,
+                &mut gscratch,
+            );
+            black_box(&gout);
+        });
+
+        let us_diff = average_us(iters, || {
+            apply_differential_attention(
+                black_box(&dq),
+                black_box(&dk),
+                black_box(&dv),
+                black_box(&params),
+                black_box(&subln_w),
+                1e-6,
+                black_box(&mut dout),
+                seq_len,
+                &diff_cfg,
+                &mut dscratch,
+            );
+            black_box(&dout);
+        });
+
+        let overhead = us_diff / us_gqa;
+        println!("{name:<26} {seq_len:>8} {us_gqa:>14.3} {us_diff:>14.3} {overhead:>9.2}x");
+    }
+}
+
+// ===================================================================
+// Entry point
+// ===================================================================
+
+fn main() {
+    println!("Differential Attention Benchmark");
+    println!("=================================");
+    bench_diff_attn();
+    bench_overhead_vs_gqa();
+    println!();
+}

--- a/crates/inference/benches/differential_attention_bench.rs
+++ b/crates/inference/benches/differential_attention_bench.rs
@@ -3,10 +3,14 @@
 //! Measures:
 //! - `apply_differential_attention` throughput at representative sequence lengths.
 //! - Cost of the differential mechanism, isolated against a single-softmax baseline
-//!   that has the *same loop topology* (per-KV-head / per-pair) as the differential
-//!   kernel. The difference is exactly: second Q/K extract + second GEMM + second
-//!   softmax + subtract + sub-RMSNorm. This controls for kernel topology, which a
-//!   comparison against the batched `apply_gqa_attention` would not.
+//!   that has the *same loop topology* (per-KV-head / per-pair) **and the same
+//!   per-pair scratch-slab layout** as the differential kernel. The only working-set
+//!   difference is the differential kernel's second score slab (`scores2`), which is
+//!   itself part of the mechanism. The gap between the two is therefore: second Q/K
+//!   extract + second GEMM + second softmax (its `scores2` slab) + subtract +
+//!   sub-RMSNorm. This controls for both kernel topology and scratch-buffer
+//!   cache-layout, which a comparison against the batched `apply_gqa_attention`
+//!   would not.
 //!
 //! Run with:
 //!   cargo bench --bench differential_attention_bench
@@ -177,38 +181,48 @@ fn bench_diff_attn() {
 }
 
 // ===================================================================
-// Single-softmax baseline — SAME loop topology as the differential kernel
+// Single-softmax baseline — SAME loop topology AND scratch layout as the
+// differential kernel.
 //
 // Mirrors apply_differential_attention's per-KV-head / per-pair structure
-// exactly, but computes only ONE softmax map: no second Q/K extract, no
-// second GEMM, no second softmax, no subtract, no sub-RMSNorm. The gap
-// between this and the differential kernel is the mechanism cost, with
-// loop topology held constant. (A comparison against the *batched*
-// apply_gqa_attention would conflate topology with mechanism.)
+// and its per-pair scratch-slab indexing exactly, but computes only ONE
+// softmax map: no second Q/K extract, no second GEMM, no second softmax
+// (and no `scores2` slab), no subtract, no sub-RMSNorm. The gap between
+// this and the differential kernel is the mechanism cost, with both loop
+// topology and scratch-buffer cache-layout held constant. (A comparison
+// against the *batched* apply_gqa_attention would conflate topology with
+// mechanism.)
 // ===================================================================
 
 #[derive(Default)]
 struct SingleSoftmaxScratch {
+    /// Per-pair score slabs `[num_heads, seq_len, seq_len]` — mirrors
+    /// `DiffAttnScratch::scores1` exactly. (The differential kernel additionally
+    /// holds `scores2` of the same shape; that second slab IS the mechanism.)
     scores: Vec<f32>,
     v_head_t: Vec<f32>,
     q_packed: Vec<f32>,
     k_packed: Vec<f32>,
+    /// Per-pair context slabs `[num_heads, seq_len, 2*head_dim]` — mirrors
+    /// `DiffAttnScratch::context` exactly.
     context: Vec<f32>,
 }
 
 impl SingleSoftmaxScratch {
     fn reserve_for(&mut self, seq_len: usize, cfg: &DiffAttnConfig) {
+        let n_pairs = cfg.num_heads;
         let v_head_dim = 2 * cfg.head_dim;
-        self.scores.resize(seq_len * seq_len, 0.0);
+        self.scores.resize(n_pairs * seq_len * seq_len, 0.0);
         self.v_head_t.resize(v_head_dim * seq_len, 0.0);
         self.q_packed.resize(seq_len * cfg.head_dim, 0.0);
         self.k_packed.resize(seq_len * cfg.head_dim, 0.0);
-        self.context.resize(seq_len * v_head_dim, 0.0);
+        self.context.resize(n_pairs * seq_len * v_head_dim, 0.0);
     }
 }
 
 /// Single-softmax attention with the same per-KV-head / per-pair loop topology
-/// as `apply_differential_attention`, minus the differential mechanism.
+/// and per-pair scratch-slab layout as `apply_differential_attention`, minus the
+/// differential mechanism.
 fn single_softmax_baseline(
     q_buf: &[f32],
     k_buf: &[f32],
@@ -258,17 +272,20 @@ fn single_softmax_baseline(
                     .copy_from_slice(&k_buf[ks..ks + head_dim]);
             }
 
-            // One GEMM, scale + causal mask, one softmax.
+            // One GEMM, scale + causal mask, one softmax — into this pair's slab,
+            // mirroring the differential kernel's per-pair `scores1` indexing.
+            let score_off = pair_h * seq_len * seq_len;
+            let score_slice = &mut scratch.scores[score_off..score_off + seq_len * seq_len];
             matmul_bt(
                 &scratch.q_packed[..seq_len * head_dim],
                 &scratch.k_packed[..seq_len * head_dim],
-                &mut scratch.scores[..seq_len * seq_len],
+                score_slice,
                 seq_len,
                 head_dim,
                 seq_len,
             );
             for qi in 0..seq_len {
-                let row = &mut scratch.scores[qi * seq_len..(qi + 1) * seq_len];
+                let row = &mut score_slice[qi * seq_len..(qi + 1) * seq_len];
                 for (ki, v) in row.iter_mut().enumerate() {
                     if ki <= qi {
                         *v *= scale;
@@ -295,11 +312,14 @@ fn single_softmax_baseline(
                 row[valid..].fill(0.0);
             }
 
-            // One GEMM with V, scale, write out.
+            // One GEMM with V, scale, write out — into this pair's context slab,
+            // mirroring the differential kernel's per-pair `context` indexing.
+            let ctx_off = pair_h * seq_len * v_head_dim;
+            let ctx_slice = &mut scratch.context[ctx_off..ctx_off + seq_len * v_head_dim];
             matmul_bt(
-                &scratch.scores[..seq_len * seq_len],
+                score_slice,
                 &scratch.v_head_t[..v_head_dim * seq_len],
-                &mut scratch.context[..seq_len * v_head_dim],
+                ctx_slice,
                 seq_len,
                 seq_len,
                 v_head_dim,
@@ -308,7 +328,7 @@ fn single_softmax_baseline(
                 let src = pos * v_head_dim;
                 let dst = pos * out_row_stride + pair_h * v_head_dim;
                 for d in 0..v_head_dim {
-                    attn_out[dst + d] = scratch.context[src + d] * out_scale;
+                    attn_out[dst + d] = ctx_slice[src + d] * out_scale;
                 }
             }
         }

--- a/crates/inference/benches/differential_attention_bench.rs
+++ b/crates/inference/benches/differential_attention_bench.rs
@@ -2,8 +2,11 @@
 //!
 //! Measures:
 //! - `apply_differential_attention` throughput at representative sequence lengths.
-//! - Overhead of the differential mechanism vs a plain GQA-style single-softmax baseline
-//!   (the cost of the second softmax + subtract + sub-RMSNorm).
+//! - Cost of the differential mechanism, isolated against a single-softmax baseline
+//!   that has the *same loop topology* (per-KV-head / per-pair) as the differential
+//!   kernel. The difference is exactly: second Q/K extract + second GEMM + second
+//!   softmax + subtract + sub-RMSNorm. This controls for kernel topology, which a
+//!   comparison against the batched `apply_gqa_attention` would not.
 //!
 //! Run with:
 //!   cargo bench --bench differential_attention_bench
@@ -13,9 +16,11 @@
 use lattice_inference::attention::differential::{
     DiffAttnConfig, DiffAttnScratch, DiffLambdaParams, apply_differential_attention,
 };
-use lattice_inference::attention::gqa::{GqaConfig, GqaScratch, apply_gqa_attention};
+use lattice_inference::forward::cpu::matmul_bt;
 use std::hint::black_box;
 use std::time::Instant;
+
+const MASK_VALUE: f32 = -10_000.0_f32;
 
 // ===================================================================
 // Utilities
@@ -172,55 +177,175 @@ fn bench_diff_attn() {
 }
 
 // ===================================================================
-// Benchmark: differential vs GQA baseline overhead
+// Single-softmax baseline — SAME loop topology as the differential kernel
 //
-// GQA attention (apply_gqa_attention) does one softmax per head-pair.
-// Differential attention does two softmax passes per head-pair + subtract + subln.
-// This section shows the marginal cost of the differential mechanism.
-//
-// NOTE: GQA and differential have different buffer layouts (GQA uses the
-// standard embed_dim = num_heads*head_dim; differential uses 2*num_heads
-// packed heads). We compare them at the same "effective" model size:
-// a GQA config with (2*num_heads, num_kv_heads, head_dim) covering the same
-// parameter count as the differential config's Q/K projections.
+// Mirrors apply_differential_attention's per-KV-head / per-pair structure
+// exactly, but computes only ONE softmax map: no second Q/K extract, no
+// second GEMM, no second softmax, no subtract, no sub-RMSNorm. The gap
+// between this and the differential kernel is the mechanism cost, with
+// loop topology held constant. (A comparison against the *batched*
+// apply_gqa_attention would conflate topology with mechanism.)
 // ===================================================================
 
-fn bench_overhead_vs_gqa() {
+#[derive(Default)]
+struct SingleSoftmaxScratch {
+    scores: Vec<f32>,
+    v_head_t: Vec<f32>,
+    q_packed: Vec<f32>,
+    k_packed: Vec<f32>,
+    context: Vec<f32>,
+}
+
+impl SingleSoftmaxScratch {
+    fn reserve_for(&mut self, seq_len: usize, cfg: &DiffAttnConfig) {
+        let v_head_dim = 2 * cfg.head_dim;
+        self.scores.resize(seq_len * seq_len, 0.0);
+        self.v_head_t.resize(v_head_dim * seq_len, 0.0);
+        self.q_packed.resize(seq_len * cfg.head_dim, 0.0);
+        self.k_packed.resize(seq_len * cfg.head_dim, 0.0);
+        self.context.resize(seq_len * v_head_dim, 0.0);
+    }
+}
+
+/// Single-softmax attention with the same per-KV-head / per-pair loop topology
+/// as `apply_differential_attention`, minus the differential mechanism.
+fn single_softmax_baseline(
+    q_buf: &[f32],
+    k_buf: &[f32],
+    v_buf: &[f32],
+    attn_out: &mut [f32],
+    seq_len: usize,
+    cfg: &DiffAttnConfig,
+    scratch: &mut SingleSoftmaxScratch,
+) {
+    if seq_len == 0 {
+        return;
+    }
+    scratch.reserve_for(seq_len, cfg);
+
+    let head_dim = cfg.head_dim;
+    let v_head_dim = 2 * head_dim;
+    let n_rep = cfg.n_rep();
+    let scale = (head_dim as f32).powf(-0.5);
+    let out_scale = 1.0 - cfg.lambda_init();
+
+    let q_row_stride = cfg.q_dim();
+    let k_row_stride = cfg.k_dim();
+    let v_row_stride = cfg.v_dim();
+    let out_row_stride = cfg.out_dim();
+
+    for kv_h in 0..cfg.num_kv_heads {
+        // Extract + transpose V for this KV head.
+        let v_head_offset = kv_h * v_head_dim;
+        for pos in 0..seq_len {
+            let src_off = pos * v_row_stride + v_head_offset;
+            for d in 0..v_head_dim {
+                scratch.v_head_t[d * seq_len + pos] = v_buf[src_off + d];
+            }
+        }
+
+        let pair_start = kv_h * n_rep;
+        for pair_h in pair_start..pair_start + n_rep {
+            // Extract the FIRST packed Q head and FIRST packed K head only.
+            let q_ph = 2 * pair_h;
+            let k_ph = 2 * kv_h;
+            for pos in 0..seq_len {
+                let qs = pos * q_row_stride + q_ph * head_dim;
+                scratch.q_packed[pos * head_dim..pos * head_dim + head_dim]
+                    .copy_from_slice(&q_buf[qs..qs + head_dim]);
+                let ks = pos * k_row_stride + k_ph * head_dim;
+                scratch.k_packed[pos * head_dim..pos * head_dim + head_dim]
+                    .copy_from_slice(&k_buf[ks..ks + head_dim]);
+            }
+
+            // One GEMM, scale + causal mask, one softmax.
+            matmul_bt(
+                &scratch.q_packed[..seq_len * head_dim],
+                &scratch.k_packed[..seq_len * head_dim],
+                &mut scratch.scores[..seq_len * seq_len],
+                seq_len,
+                head_dim,
+                seq_len,
+            );
+            for qi in 0..seq_len {
+                let row = &mut scratch.scores[qi * seq_len..(qi + 1) * seq_len];
+                for (ki, v) in row.iter_mut().enumerate() {
+                    if ki <= qi {
+                        *v *= scale;
+                    } else {
+                        *v = MASK_VALUE;
+                    }
+                }
+                let valid = qi + 1;
+                let max_val = row[..valid]
+                    .iter()
+                    .copied()
+                    .fold(f32::NEG_INFINITY, f32::max);
+                let mut sum = 0.0_f32;
+                for v in &mut row[..valid] {
+                    *v = (*v - max_val).exp();
+                    sum += *v;
+                }
+                if sum > 0.0 {
+                    let inv = 1.0 / sum;
+                    for v in &mut row[..valid] {
+                        *v *= inv;
+                    }
+                }
+                row[valid..].fill(0.0);
+            }
+
+            // One GEMM with V, scale, write out.
+            matmul_bt(
+                &scratch.scores[..seq_len * seq_len],
+                &scratch.v_head_t[..v_head_dim * seq_len],
+                &mut scratch.context[..seq_len * v_head_dim],
+                seq_len,
+                seq_len,
+                v_head_dim,
+            );
+            for pos in 0..seq_len {
+                let src = pos * v_head_dim;
+                let dst = pos * out_row_stride + pair_h * v_head_dim;
+                for d in 0..v_head_dim {
+                    attn_out[dst + d] = scratch.context[src + d] * out_scale;
+                }
+            }
+        }
+    }
+}
+
+// ===================================================================
+// Benchmark: differential mechanism overhead (topology-controlled)
+// ===================================================================
+
+fn bench_mechanism_overhead() {
     println!(
-        "\n=== overhead: differential vs GQA-baseline (same Q/K projection size) ===\n{:<26} {:>8} {:>14} {:>14} {:>10}",
-        "model", "seq_len", "gqa_us", "diff_us", "overhead"
+        "\n=== differential mechanism overhead (vs same-topology single-softmax baseline) ===\n{:<26} {:>8} {:>14} {:>14} {:>10}",
+        "model", "seq_len", "baseline_us", "diff_us", "overhead"
     );
     println!(
         "{:<26} {:>8} {:>14} {:>14} {:>10}",
         "--------------------------", "--------", "--------------", "--------------", "----------",
     );
 
-    // Only benchmark at seq_len=256 to keep output concise
     const BENCH_SEQ: usize = 256;
 
     for &(name, num_heads, num_kv_heads, head_dim, layer_depth) in MODEL_CASES {
-        let diff_cfg = DiffAttnConfig {
+        let cfg = DiffAttnConfig {
             num_heads,
             num_kv_heads,
             head_dim,
             layer_depth,
         };
 
-        // GQA with the same packed head count (2*num_heads Q heads, same KV heads)
-        // and same head_dim. This matches the same Q/K projection sizes.
-        let gqa_cfg = GqaConfig {
-            num_heads: 2 * num_heads,       // packed heads
-            num_kv_heads: 2 * num_kv_heads, // packed KV heads
-            head_dim,
-        };
-
         let seq_len = BENCH_SEQ;
         let mut rng = Lcg::new((seq_len as u64) ^ 0xDEAD_BEEF);
 
-        // Differential inputs
-        let dq = random_vec(seq_len * diff_cfg.q_dim(), &mut rng);
-        let dk = random_vec(seq_len * diff_cfg.k_dim(), &mut rng);
-        let dv = random_vec(seq_len * diff_cfg.v_dim(), &mut rng);
+        // Shared inputs — both kernels read the same Q/K/V buffers.
+        let q = random_vec(seq_len * cfg.q_dim(), &mut rng);
+        let k = random_vec(seq_len * cfg.k_dim(), &mut rng);
+        let v = random_vec(seq_len * cfg.v_dim(), &mut rng);
         let params = DiffLambdaParams {
             lambda_q1: vec![0.0; head_dim],
             lambda_k1: vec![0.0; head_dim],
@@ -228,74 +353,70 @@ fn bench_overhead_vs_gqa() {
             lambda_k2: vec![0.0; head_dim],
         };
         let subln_w = vec![1.0_f32; 2 * head_dim];
-        let mut dout = vec![0.0_f32; seq_len * diff_cfg.out_dim()];
-        let mut dscratch = DiffAttnScratch::default();
 
-        // GQA inputs (same total Q/K/V bytes as differential)
-        let gq = random_vec(seq_len * gqa_cfg.q_dim(), &mut rng);
-        let gk = random_vec(seq_len * gqa_cfg.kv_dim(), &mut rng);
-        let gv = random_vec(seq_len * gqa_cfg.kv_dim(), &mut rng);
-        let mut gout = vec![0.0_f32; seq_len * gqa_cfg.q_dim()];
-        let mut gscratch = GqaScratch::default();
+        let mut diff_out = vec![0.0_f32; seq_len * cfg.out_dim()];
+        let mut diff_scratch = DiffAttnScratch::default();
+        let mut base_out = vec![0.0_f32; seq_len * cfg.out_dim()];
+        let mut base_scratch = SingleSoftmaxScratch::default();
 
-        // Warm-up both
+        // Warm-up both.
         for _ in 0..20 {
             apply_differential_attention(
-                black_box(&dq),
-                black_box(&dk),
-                black_box(&dv),
+                black_box(&q),
+                black_box(&k),
+                black_box(&v),
                 black_box(&params),
                 black_box(&subln_w),
                 1e-6,
-                black_box(&mut dout),
+                black_box(&mut diff_out),
                 seq_len,
-                &diff_cfg,
-                &mut dscratch,
+                &cfg,
+                &mut diff_scratch,
             );
-            apply_gqa_attention(
-                black_box(&gq),
-                black_box(&gk),
-                black_box(&gv),
-                black_box(&mut gout),
+            single_softmax_baseline(
+                black_box(&q),
+                black_box(&k),
+                black_box(&v),
+                black_box(&mut base_out),
                 seq_len,
-                gqa_cfg,
-                &mut gscratch,
+                &cfg,
+                &mut base_scratch,
             );
         }
 
         let iters = iterations_for_seq(seq_len);
 
-        let us_gqa = average_us(iters, || {
-            apply_gqa_attention(
-                black_box(&gq),
-                black_box(&gk),
-                black_box(&gv),
-                black_box(&mut gout),
+        let us_base = average_us(iters, || {
+            single_softmax_baseline(
+                black_box(&q),
+                black_box(&k),
+                black_box(&v),
+                black_box(&mut base_out),
                 seq_len,
-                gqa_cfg,
-                &mut gscratch,
+                &cfg,
+                &mut base_scratch,
             );
-            black_box(&gout);
+            black_box(&base_out);
         });
 
         let us_diff = average_us(iters, || {
             apply_differential_attention(
-                black_box(&dq),
-                black_box(&dk),
-                black_box(&dv),
+                black_box(&q),
+                black_box(&k),
+                black_box(&v),
                 black_box(&params),
                 black_box(&subln_w),
                 1e-6,
-                black_box(&mut dout),
+                black_box(&mut diff_out),
                 seq_len,
-                &diff_cfg,
-                &mut dscratch,
+                &cfg,
+                &mut diff_scratch,
             );
-            black_box(&dout);
+            black_box(&diff_out);
         });
 
-        let overhead = us_diff / us_gqa;
-        println!("{name:<26} {seq_len:>8} {us_gqa:>14.3} {us_diff:>14.3} {overhead:>9.2}x");
+        let overhead = us_diff / us_base;
+        println!("{name:<26} {seq_len:>8} {us_base:>14.3} {us_diff:>14.3} {overhead:>9.2}x");
     }
 }
 
@@ -307,6 +428,6 @@ fn main() {
     println!("Differential Attention Benchmark");
     println!("=================================");
     bench_diff_attn();
-    bench_overhead_vs_gqa();
+    bench_mechanism_overhead();
     println!();
 }

--- a/crates/inference/src/attention/differential.rs
+++ b/crates/inference/src/attention/differential.rs
@@ -58,10 +58,23 @@ impl DiffAttnConfig {
     }
 
     /// **Unstable**: GQA repeat factor per KV head: `num_heads / num_kv_heads`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_kv_heads == 0` or `num_heads` is not divisible by it. Real
+    /// `assert!`s (not `debug_assert`) — this is a public method, so a release
+    /// caller passing an invalid config must fail loudly rather than divide by
+    /// zero or silently floor a non-divisible ratio.
     #[inline]
     pub fn n_rep(&self) -> usize {
-        debug_assert!(self.num_kv_heads > 0);
-        debug_assert_eq!(self.num_heads % self.num_kv_heads, 0);
+        assert!(self.num_kv_heads > 0, "num_kv_heads must be > 0");
+        assert_eq!(
+            self.num_heads % self.num_kv_heads,
+            0,
+            "num_heads ({}) must be divisible by num_kv_heads ({})",
+            self.num_heads,
+            self.num_kv_heads
+        );
         self.num_heads / self.num_kv_heads
     }
 
@@ -909,5 +922,20 @@ mod tests {
             &cfg,
             &mut scratch,
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "num_kv_heads must be > 0")]
+    fn test_n_rep_zero_num_kv_heads_panics() {
+        // `n_rep()` is public — a direct caller in release must fail loudly,
+        // not hit a raw divide-by-zero.
+        let _ = make_cfg(4, 0, 8, 0).n_rep();
+    }
+
+    #[test]
+    #[should_panic(expected = "must be divisible")]
+    fn test_n_rep_non_divisible_panics() {
+        // Non-divisible config must panic, not silently floor 5/2 → 2.
+        let _ = make_cfg(5, 2, 8, 0).n_rep();
     }
 }

--- a/crates/inference/src/attention/differential.rs
+++ b/crates/inference/src/attention/differential.rs
@@ -1,0 +1,794 @@
+//! Differential attention for the Differential Transformer (Ye et al., ICLR 2025).
+//!
+//! Implements the exact reference algorithm from Microsoft's
+//! `unilm/Diff-Transformer/multihead_flashdiff_1.py`, adapted to Lattice conventions:
+//!
+//! - Q and K are split into two halves along the head dimension (`2*num_heads` packed heads).
+//! - Two independent causal softmax attention maps are computed.
+//! - The second map (scaled by a learnable `lambda_full`) is subtracted from the first.
+//! - A sub-layer RMSNorm is applied over the `2*head_dim`-wide value context.
+//! - The result is scaled by `(1 - lambda_init)` to compensate for the subtraction.
+//!
+//! **Caller responsibility**: Q and K must already have RoPE applied. Linear projections are
+//! the caller's responsibility. This module owns the dual-softmax-subtract math, the lambda
+//! computation, the sub-RMSNorm, and the final scale.
+//!
+//! See arXiv:2410.05258 for the full algorithm.
+
+// ===================================================================
+// Configuration
+// ===================================================================
+
+/// **Unstable**: configuration for one differential attention layer.
+///
+/// `embed_dim = 2 * num_heads * head_dim` in the reference architecture.
+/// Q/K projections produce `2*num_heads` packed heads of `head_dim` each.
+/// V projections produce `num_kv_heads` heads, each `2*head_dim` wide.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DiffAttnConfig {
+    /// Post-split logical head count (pairs). `num_heads` Q-pairs → `2*num_heads` packed Q heads.
+    pub num_heads: usize,
+    /// KV head count for GQA. `num_heads % num_kv_heads == 0` must hold.
+    pub num_kv_heads: usize,
+    /// Per-half head dimension. Each packed head (Q or K) has `head_dim` elements.
+    pub head_dim: usize,
+    /// 0-based layer index, used to compute `lambda_init`.
+    pub layer_depth: usize,
+}
+
+impl DiffAttnConfig {
+    /// **Unstable**: depth-scheduled lambda initializer: `0.8 - 0.6 * exp(-0.3 * depth)`.
+    ///
+    /// At depth 0: `0.8 - 0.6 = 0.2`. Increases monotonically toward 0.8.
+    #[inline]
+    pub fn lambda_init(&self) -> f32 {
+        0.8 - 0.6 * (-0.3 * self.layer_depth as f32).exp()
+    }
+
+    /// **Unstable**: total packed Q-head count: `2 * num_heads`.
+    #[inline]
+    pub fn q_heads_packed(&self) -> usize {
+        2 * self.num_heads
+    }
+
+    /// **Unstable**: total packed KV-head count: `2 * num_kv_heads`.
+    #[inline]
+    pub fn kv_heads_packed(&self) -> usize {
+        2 * self.num_kv_heads
+    }
+
+    /// **Unstable**: GQA repeat factor per KV head: `num_heads / num_kv_heads`.
+    #[inline]
+    pub fn n_rep(&self) -> usize {
+        debug_assert!(self.num_kv_heads > 0);
+        debug_assert_eq!(self.num_heads % self.num_kv_heads, 0);
+        self.num_heads / self.num_kv_heads
+    }
+
+    /// **Unstable**: total Q-buffer dimension: `2 * num_heads * head_dim`.
+    #[inline]
+    pub fn q_dim(&self) -> usize {
+        self.q_heads_packed() * self.head_dim
+    }
+
+    /// **Unstable**: total K-buffer dimension: `2 * num_kv_heads * head_dim`.
+    #[inline]
+    pub fn k_dim(&self) -> usize {
+        self.kv_heads_packed() * self.head_dim
+    }
+
+    /// **Unstable**: total V-buffer dimension: `num_kv_heads * 2 * head_dim`.
+    /// V heads are `2*head_dim` wide (not split).
+    #[inline]
+    pub fn v_dim(&self) -> usize {
+        self.num_kv_heads * 2 * self.head_dim
+    }
+
+    /// **Unstable**: output dimension: `num_heads * 2 * head_dim`.
+    #[inline]
+    pub fn out_dim(&self) -> usize {
+        self.num_heads * 2 * self.head_dim
+    }
+}
+
+// ===================================================================
+// Lambda reparameterization
+// ===================================================================
+
+/// **Unstable**: learnable lambda reparameterization vectors for one layer.
+///
+/// `lambda_full = exp(lq1·lk1) - exp(lq2·lk2) + lambda_init`
+///
+/// Each vector has `head_dim` elements. Initialized near zero so that at init
+/// `lambda_full ≈ lambda_init`.
+pub struct DiffLambdaParams {
+    /// Shape: `[head_dim]`
+    pub lambda_q1: Vec<f32>,
+    /// Shape: `[head_dim]`
+    pub lambda_k1: Vec<f32>,
+    /// Shape: `[head_dim]`
+    pub lambda_q2: Vec<f32>,
+    /// Shape: `[head_dim]`
+    pub lambda_k2: Vec<f32>,
+}
+
+/// **Unstable**: compute `lambda_full = exp(lq1·lk1) - exp(lq2·lk2) + lambda_init`.
+///
+/// The dot products are over `head_dim`. The result can be any real value; it is
+/// NOT clamped (negative lambda_full is valid and meaningful in the reference).
+#[inline]
+pub fn compute_lambda_full(params: &DiffLambdaParams, lambda_init: f32) -> f32 {
+    debug_assert_eq!(params.lambda_q1.len(), params.lambda_k1.len());
+    debug_assert_eq!(params.lambda_q2.len(), params.lambda_k2.len());
+    debug_assert_eq!(params.lambda_q1.len(), params.lambda_q2.len());
+
+    let dot1: f32 = params
+        .lambda_q1
+        .iter()
+        .zip(params.lambda_k1.iter())
+        .map(|(&q, &k)| q * k)
+        .sum();
+    let dot2: f32 = params
+        .lambda_q2
+        .iter()
+        .zip(params.lambda_k2.iter())
+        .map(|(&q, &k)| q * k)
+        .sum();
+
+    dot1.exp() - dot2.exp() + lambda_init
+}
+
+// ===================================================================
+// Scratch buffers
+// ===================================================================
+
+/// **Unstable**: pre-allocated scratch buffers for differential attention; layout may grow.
+#[derive(Default, Clone, Debug)]
+pub struct DiffAttnScratch {
+    /// Scores for the first softmax map (packed head 2h): `[num_heads, seq_len, seq_len]`.
+    scores1: Vec<f32>,
+    /// Scores for the second softmax map (packed head 2h+1): `[num_heads, seq_len, seq_len]`.
+    scores2: Vec<f32>,
+    /// V head transposed for one KV head: `[2*head_dim, seq_len]`.
+    v_head_t: Vec<f32>,
+    /// Extracted contiguous K packed head: `[seq_len, head_dim]`.
+    k_packed: Vec<f32>,
+    /// Extracted contiguous Q packed head: `[seq_len, head_dim]`.
+    q_packed: Vec<f32>,
+    /// Per-head context before subln: `[num_heads, seq_len, 2*head_dim]`.
+    context: Vec<f32>,
+}
+
+impl DiffAttnScratch {
+    /// **Unstable**: resize all scratch buffers to accommodate the given sequence length and config.
+    pub fn reserve_for(&mut self, seq_len: usize, cfg: &DiffAttnConfig) {
+        let n_pairs = cfg.num_heads;
+        let v_head_dim = 2 * cfg.head_dim; // V is 2*head_dim wide per KV head
+        self.scores1.resize(n_pairs * seq_len * seq_len, 0.0_f32);
+        self.scores2.resize(n_pairs * seq_len * seq_len, 0.0_f32);
+        self.v_head_t.resize(v_head_dim * seq_len, 0.0_f32);
+        self.k_packed.resize(seq_len * cfg.head_dim, 0.0_f32);
+        self.q_packed.resize(seq_len * cfg.head_dim, 0.0_f32);
+        self.context.resize(n_pairs * seq_len * v_head_dim, 0.0_f32);
+    }
+}
+
+// ===================================================================
+// Core kernel
+// ===================================================================
+
+const MASK_VALUE: f32 = -10_000.0_f32;
+
+/// **Unstable**: apply causal differential attention (prefill, multi-token).
+///
+/// Implements the exact DIFF Transformer algorithm from arXiv:2410.05258 §3.
+///
+/// # Buffer layouts
+///
+/// - `q_buf`: `[seq_len, 2*num_heads*head_dim]` — packed Q heads, interleaved per token
+/// - `k_buf`: `[seq_len, 2*num_kv_heads*head_dim]` — packed K heads
+/// - `v_buf`: `[seq_len, num_kv_heads*(2*head_dim)]` — V heads, each `2*head_dim` wide
+/// - `subln_weight`: `[2*head_dim]` — RMSNorm gamma for the sub-layer norm
+/// - `attn_out`: `[seq_len, num_heads*(2*head_dim)]` — output, interleaved per pair
+///
+/// Q and K must already have RoPE applied. Causal masking is applied internally via
+/// additive `-10000.0` (ADR-010 design choice #2).
+///
+/// # Panics
+///
+/// Panics if buffer lengths are inconsistent with `seq_len` and `cfg`.
+#[allow(clippy::too_many_arguments)]
+pub fn apply_differential_attention(
+    q_buf: &[f32],
+    k_buf: &[f32],
+    v_buf: &[f32],
+    lambda_params: &DiffLambdaParams,
+    subln_weight: &[f32],
+    subln_eps: f32,
+    attn_out: &mut [f32],
+    seq_len: usize,
+    cfg: &DiffAttnConfig,
+    scratch: &mut DiffAttnScratch,
+) {
+    use crate::forward::cpu::matmul_bt;
+
+    assert_eq!(
+        q_buf.len(),
+        seq_len * cfg.q_dim(),
+        "q_buf length mismatch: expected {} got {}",
+        seq_len * cfg.q_dim(),
+        q_buf.len()
+    );
+    assert_eq!(
+        k_buf.len(),
+        seq_len * cfg.k_dim(),
+        "k_buf length mismatch: expected {} got {}",
+        seq_len * cfg.k_dim(),
+        k_buf.len()
+    );
+    assert_eq!(
+        v_buf.len(),
+        seq_len * cfg.v_dim(),
+        "v_buf length mismatch: expected {} got {}",
+        seq_len * cfg.v_dim(),
+        v_buf.len()
+    );
+    assert_eq!(
+        subln_weight.len(),
+        2 * cfg.head_dim,
+        "subln_weight length must be 2*head_dim"
+    );
+    assert_eq!(
+        attn_out.len(),
+        seq_len * cfg.out_dim(),
+        "attn_out length mismatch: expected {} got {}",
+        seq_len * cfg.out_dim(),
+        attn_out.len()
+    );
+    assert_eq!(
+        cfg.num_heads % cfg.num_kv_heads,
+        0,
+        "num_heads must be divisible by num_kv_heads"
+    );
+
+    if seq_len == 0 {
+        return;
+    }
+
+    scratch.reserve_for(seq_len, cfg);
+
+    let lambda_init = cfg.lambda_init();
+    let lambda_full = compute_lambda_full(lambda_params, lambda_init);
+    let scale = (cfg.head_dim as f32).powf(-0.5);
+
+    // n_pairs = cfg.num_heads (logical head pairs) — used for scratch reservation in reserve_for
+    let head_dim = cfg.head_dim;
+    let v_head_dim = 2 * head_dim;
+    let n_rep = cfg.n_rep();
+
+    // Strides for the packed buffers.
+    // q_buf row: [2*num_heads * head_dim] — packed heads interleaved by token
+    let q_row_stride = cfg.q_dim(); // 2 * num_heads * head_dim
+    // k_buf row: [2*num_kv_heads * head_dim]
+    let k_row_stride = cfg.k_dim(); // 2 * num_kv_heads * head_dim
+    // v_buf row: [num_kv_heads * 2 * head_dim]
+    let v_row_stride = cfg.v_dim(); // num_kv_heads * 2 * head_dim
+    // attn_out row: [num_heads * 2 * head_dim]
+    let out_row_stride = cfg.out_dim(); // num_heads * 2 * head_dim
+
+    // For each logical pair h (0..n_pairs), packed heads 2h and 2h+1 form the pair.
+    // With GQA, pair h maps to KV head h / n_rep. Each KV head covers n_rep pairs.
+    // We iterate per KV head to share the K/V extraction.
+    for kv_h in 0..cfg.num_kv_heads {
+        // ------------------------------------------------------------------
+        // Extract and transpose V for this KV head: [2*head_dim, seq_len]
+        // V head kv_h occupies columns [kv_h * v_head_dim .. (kv_h+1) * v_head_dim]
+        // ------------------------------------------------------------------
+        let v_head_offset = kv_h * v_head_dim;
+        let v_t = &mut scratch.v_head_t[..v_head_dim * seq_len];
+        for pos in 0..seq_len {
+            let src_off = pos * v_row_stride + v_head_offset;
+            let v_row = &v_buf[src_off..src_off + v_head_dim];
+            for d in 0..v_head_dim {
+                v_t[d * seq_len + pos] = v_row[d];
+            }
+        }
+
+        // For each of the n_rep Q pairs that share this KV head:
+        let pair_start = kv_h * n_rep;
+        let pair_end = pair_start + n_rep;
+
+        for pair_h in pair_start..pair_end {
+            // Packed Q head indices for this pair: 2*pair_h and 2*pair_h+1
+            let q_h0 = 2 * pair_h; // first packed Q head index
+            let q_h1 = 2 * pair_h + 1; // second packed Q head index
+            // Packed K head indices for this KV head: 2*kv_h and 2*kv_h+1
+            let k_h0 = 2 * kv_h;
+            let k_h1 = 2 * kv_h + 1;
+
+            // ------------------------------------------------------------------
+            // scores1[pair_h]: Q head 2*pair_h @ K head 2*kv_h ^T
+            // scores2[pair_h]: Q head 2*pair_h+1 @ K head 2*kv_h+1 ^T
+            // ------------------------------------------------------------------
+            for (q_ph, k_ph, scores_target) in [
+                (q_h0, k_h0, &mut scratch.scores1),
+                (q_h1, k_h1, &mut scratch.scores2),
+            ] {
+                // Extract contiguous Q packed head: [seq_len, head_dim]
+                let q_packed = &mut scratch.q_packed[..seq_len * head_dim];
+                for pos in 0..seq_len {
+                    let src_off = pos * q_row_stride + q_ph * head_dim;
+                    q_packed[pos * head_dim..pos * head_dim + head_dim]
+                        .copy_from_slice(&q_buf[src_off..src_off + head_dim]);
+                }
+
+                // Extract contiguous K packed head: [seq_len, head_dim]
+                let k_packed = &mut scratch.k_packed[..seq_len * head_dim];
+                for pos in 0..seq_len {
+                    let src_off = pos * k_row_stride + k_ph * head_dim;
+                    k_packed[pos * head_dim..pos * head_dim + head_dim]
+                        .copy_from_slice(&k_buf[src_off..src_off + head_dim]);
+                }
+
+                // GEMM: [seq_len, head_dim] @ [seq_len, head_dim]^T -> [seq_len, seq_len]
+                let score_off = pair_h * seq_len * seq_len;
+                let score_slice = &mut scores_target[score_off..score_off + seq_len * seq_len];
+                matmul_bt(q_packed, k_packed, score_slice, seq_len, head_dim, seq_len);
+
+                // Scale + additive causal mask
+                for qi in 0..seq_len {
+                    let row = &mut score_slice[qi * seq_len..(qi + 1) * seq_len];
+                    for (ki, v) in row.iter_mut().enumerate() {
+                        if ki <= qi {
+                            *v *= scale;
+                        } else {
+                            *v = MASK_VALUE;
+                        }
+                    }
+                }
+
+                // Softmax (numerically stable, two-pass)
+                for qi in 0..seq_len {
+                    let row = &mut score_slice[qi * seq_len..(qi + 1) * seq_len];
+                    let valid = qi + 1;
+                    let max_val = row[..valid]
+                        .iter()
+                        .copied()
+                        .fold(f32::NEG_INFINITY, f32::max);
+                    let mut sum = 0.0_f32;
+                    for v in &mut row[..valid] {
+                        *v = (*v - max_val).exp();
+                        sum += *v;
+                    }
+                    if sum > 0.0 {
+                        let inv = 1.0 / sum;
+                        for v in &mut row[..valid] {
+                            *v *= inv;
+                        }
+                    }
+                    row[valid..].fill(0.0);
+                }
+            }
+
+            // ------------------------------------------------------------------
+            // Differential subtraction: attn_weights = scores1[pair_h] - lambda_full * scores2[pair_h]
+            // Result is [seq_len, seq_len]. Can be negative — no clamp.
+            // ------------------------------------------------------------------
+            let s1_off = pair_h * seq_len * seq_len;
+            let s2_off = pair_h * seq_len * seq_len;
+            // Build the differential scores in place in scores1 (we no longer need s1 separately).
+            for i in 0..(seq_len * seq_len) {
+                scratch.scores1[s1_off + i] -= lambda_full * scratch.scores2[s2_off + i];
+            }
+
+            // ------------------------------------------------------------------
+            // Context = differential_scores @ V^T: [seq_len, 2*head_dim]
+            // scores1: [seq_len, seq_len] (row-major)
+            // v_t: [2*head_dim, seq_len] (transposed V)
+            // matmul_bt(A[M,K], B[N,K]^T, C[M,N]) computes A @ B^T
+            // We want C[seq_len, v_head_dim] = scores[seq_len, seq_len] @ V[seq_len, v_head_dim]
+            // Rewrite as C = scores @ V^T^T — but V is already transposed as v_t[v_head_dim, seq_len]
+            // matmul_bt(scores[seq,seq], v_t[v_hd,seq], ctx[seq,v_hd], seq, seq, v_hd)
+            // = scores @ v_t^T which is scores @ V  ✓
+            // ------------------------------------------------------------------
+            let ctx_off = pair_h * seq_len * v_head_dim;
+            let ctx_slice = &mut scratch.context[ctx_off..ctx_off + seq_len * v_head_dim];
+            let diff_scores = &scratch.scores1[s1_off..s1_off + seq_len * seq_len];
+            matmul_bt(
+                diff_scores,
+                &scratch.v_head_t[..v_head_dim * seq_len],
+                ctx_slice,
+                seq_len,
+                seq_len,
+                v_head_dim,
+            );
+
+            // ------------------------------------------------------------------
+            // Sub-layer RMSNorm: over 2*head_dim, applied per (head, position)
+            // using crate rms_norm which handles num_tokens rows of `hidden` width.
+            // ------------------------------------------------------------------
+            // rms_norm(x, gamma, hidden, eps) operates row-by-row, treating
+            // ctx_slice as [seq_len, v_head_dim] tokens.
+            {
+                use crate::forward::cpu::rms_norm;
+                rms_norm(ctx_slice, subln_weight, v_head_dim, subln_eps);
+            }
+
+            // ------------------------------------------------------------------
+            // Scale by (1 - lambda_init) and write to attn_out
+            // ------------------------------------------------------------------
+            let scale_factor = 1.0 - lambda_init;
+            for pos in 0..seq_len {
+                let src_off = pos * v_head_dim;
+                let dst_off = pos * out_row_stride + pair_h * v_head_dim;
+                let src = &ctx_slice[src_off..src_off + v_head_dim];
+                let dst = &mut attn_out[dst_off..dst_off + v_head_dim];
+                for (d, s) in dst.iter_mut().zip(src.iter()) {
+                    *d = s * scale_factor;
+                }
+            }
+        }
+    }
+}
+
+// ===================================================================
+// Tests
+// ===================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // Deterministic data generator (matches gated.rs / gated_attention_test.rs)
+    // ---------------------------------------------------------------
+
+    fn det_data(len: usize, seed: u64) -> Vec<f32> {
+        let mut state = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            state ^= state << 7;
+            state ^= state >> 9;
+            state = state.wrapping_mul(0x2545_f491_4f6c_dd1d);
+            let mantissa = ((state >> 41) as u32) & 0x007f_ffff;
+            let x = f32::from_bits(0x3f80_0000 | mantissa) - 1.5;
+            out.push(x);
+        }
+        out
+    }
+
+    #[allow(dead_code)]
+    fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+        assert_eq!(a.len(), b.len());
+        a.iter()
+            .zip(b.iter())
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0_f32, f32::max)
+    }
+
+    fn make_cfg(
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        depth: usize,
+    ) -> DiffAttnConfig {
+        DiffAttnConfig {
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            layer_depth: depth,
+        }
+    }
+
+    fn zero_lambda_params(head_dim: usize) -> DiffLambdaParams {
+        DiffLambdaParams {
+            lambda_q1: vec![0.0; head_dim],
+            lambda_k1: vec![0.0; head_dim],
+            lambda_q2: vec![0.0; head_dim],
+            lambda_k2: vec![0.0; head_dim],
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // test_lambda_init_schedule
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_lambda_init_schedule() {
+        // lambda_init(0) = 0.8 - 0.6 * exp(0) = 0.8 - 0.6 = 0.2
+        let cfg0 = make_cfg(2, 2, 4, 0);
+        let li0 = cfg0.lambda_init();
+        assert!(
+            (li0 - 0.2).abs() < 1e-6,
+            "lambda_init(0) expected 0.2, got {li0}"
+        );
+
+        // lambda_init increases toward 0.8 as depth grows
+        let prev_cfg = make_cfg(2, 2, 4, 5);
+        let li5 = prev_cfg.lambda_init();
+        let cfg10 = make_cfg(2, 2, 4, 10);
+        let li10 = cfg10.lambda_init();
+        assert!(li5 > li0, "lambda_init should increase with depth");
+        assert!(li10 > li5, "lambda_init should increase with depth");
+        assert!(li10 < 0.8, "lambda_init should approach but stay below 0.8");
+
+        // Monotone property: test many depths
+        let mut prev = cfg0.lambda_init();
+        for d in 1..=50 {
+            let cur = make_cfg(2, 2, 4, d).lambda_init();
+            assert!(
+                cur > prev,
+                "lambda_init not monotone at depth {d}: cur={cur} prev={prev}"
+            );
+            prev = cur;
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // test_compute_lambda_full
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_compute_lambda_full() {
+        // All zeros: lambda_full = exp(0) - exp(0) + lambda_init = 1 - 1 + lambda_init = lambda_init
+        let params = zero_lambda_params(4);
+        let lambda_init = 0.3;
+        let lf = compute_lambda_full(&params, lambda_init);
+        assert!(
+            (lf - lambda_init).abs() < 1e-6,
+            "all-zero params: lambda_full expected {lambda_init}, got {lf}"
+        );
+
+        // Hand-compute for non-trivial values.
+        // lq1 = [1, 0, 0, 0], lk1 = [2, 0, 0, 0] → dot1 = 2 → exp(2) ≈ 7.389056
+        // lq2 = [0, 1, 0, 0], lk2 = [0, 1, 0, 0] → dot2 = 1 → exp(1) ≈ 2.718282
+        // lambda_full = exp(2) - exp(1) + 0.3 ≈ 7.389056 - 2.718282 + 0.3 ≈ 4.970774
+        let params2 = DiffLambdaParams {
+            lambda_q1: vec![1.0, 0.0, 0.0, 0.0],
+            lambda_k1: vec![2.0, 0.0, 0.0, 0.0],
+            lambda_q2: vec![0.0, 1.0, 0.0, 0.0],
+            lambda_k2: vec![0.0, 1.0, 0.0, 0.0],
+        };
+        let expected = 2.0f32.exp() - 1.0f32.exp() + 0.3;
+        let got = compute_lambda_full(&params2, 0.3);
+        assert!(
+            (got - expected).abs() < 1e-5,
+            "hand-computed lambda_full: expected {expected}, got {got}"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // test_diff_attn_shapes
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_diff_attn_shapes() {
+        let cfg = make_cfg(2, 2, 4, 0);
+        let seq_len = 5;
+        let q = det_data(seq_len * cfg.q_dim(), 1);
+        let k = det_data(seq_len * cfg.k_dim(), 2);
+        let v = det_data(seq_len * cfg.v_dim(), 3);
+        let params = zero_lambda_params(cfg.head_dim);
+        let subln_w = vec![1.0f32; 2 * cfg.head_dim];
+        let mut out = vec![0.0f32; seq_len * cfg.out_dim()];
+        let mut scratch = DiffAttnScratch::default();
+
+        apply_differential_attention(
+            &q,
+            &k,
+            &v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+
+        assert_eq!(
+            out.len(),
+            seq_len * cfg.num_heads * 2 * cfg.head_dim,
+            "output length must be seq_len * num_heads * 2 * head_dim"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // test_diff_attn_single_head_single_token
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_diff_attn_single_head_single_token() {
+        // seq_len=1, num_heads=1, num_kv_heads=1, head_dim=2
+        // With seq_len=1 there is only one token attending to itself.
+        // scores1[0,0] = softmax([q0·k0*scale]) = [1.0]
+        // scores2[0,0] = softmax([q1·k1*scale]) = [1.0]
+        // With lambda_full = lambda_init (zero lambda params), and v = [v0, v1] for 2*head_dim:
+        // context = (1 - lambda_full * 1) * v = (1 - lambda_init) * v (after subln with gamma=1)
+        let head_dim = 2_usize;
+        let cfg = make_cfg(1, 1, head_dim, 3); // depth=3 → lambda_init ≈ 0.469
+        let lambda_init = cfg.lambda_init();
+
+        let seq_len = 1_usize;
+        // q_buf: [1, 2*1*2=4], k_buf: [1, 2*1*2=4], v_buf: [1, 1*2*2=4]
+        // Use constant q, k so all dot products equal some value d.
+        // scores1 and scores2 will both be [[1.0]] (single token, softmax of one element = 1)
+        let q = vec![1.0f32, 0.0, 1.0, 0.0]; // head 0: q0=[1,0], q1=[1,0]
+        let k = vec![1.0f32, 0.0, 1.0, 0.0]; // k head 0 packed: k0=[1,0], k1=[1,0]
+        let v = vec![2.0f32, 3.0, 0.0, 0.0]; // v head 0 (2*head_dim=4): [2,3,0,0]
+
+        let params = zero_lambda_params(head_dim); // lambda_full = lambda_init
+        let subln_w = vec![1.0f32; 2 * head_dim]; // identity gamma
+        let mut out = vec![0.0f32; seq_len * cfg.out_dim()]; // [1, 1*4=4]
+        let mut scratch = DiffAttnScratch::default();
+
+        apply_differential_attention(
+            &q,
+            &k,
+            &v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+
+        // diff_attn = 1.0 - lambda_init * 1.0 = 1 - lambda_init (applied to each v element)
+        // after subln (gamma=1, x is already unit-rms up to precision) and scale (1-lambda_init)
+        // The expected output for each v element e_i: subln(e_i) * (1-lambda_init)
+        // With gamma=1, rms_norm just normalizes. But we can check it's finite and non-zero.
+        assert!(out[0].is_finite(), "output must be finite");
+        // The subtraction (1 - lambda_init)*v_part should yield positive values where v is positive.
+        // With lambda_init < 1, (1-lambda_init) > 0, so output direction matches v.
+        let scale_factor = 1.0 - lambda_init;
+        assert!(
+            scale_factor > 0.0,
+            "scale factor (1-lambda_init) must be positive"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // test_diff_attn_causal_masking
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_diff_attn_causal_masking() {
+        // Verify position i attends only to j <= i.
+        // Strategy: set v[pos] = pos+1 for position `pos`. If the output at position 0
+        // is influenced by position 1's value, the test will catch a masking bug.
+        //
+        // With seq_len=3, pos=0 should only see v[0], not v[1] or v[2].
+        // We set v[1] and v[2] to very large values; if causal masking is correct,
+        // they won't contaminate output[0].
+        let head_dim = 2_usize;
+        let cfg = make_cfg(1, 1, head_dim, 0);
+        let seq_len = 3_usize;
+
+        let q = det_data(seq_len * cfg.q_dim(), 101);
+        let k = det_data(seq_len * cfg.k_dim(), 202);
+
+        // v[0] = [1, 1, 1, 1], v[1] = v[2] = very large
+        let mut v = vec![0.0f32; seq_len * cfg.v_dim()];
+        let v_head_dim = 2 * head_dim;
+        // position 0
+        for d in 0..v_head_dim {
+            v[0 * v_head_dim + d] = 1.0;
+        }
+        // positions 1 and 2 get huge values
+        for pos in 1..seq_len {
+            for d in 0..v_head_dim {
+                v[pos * v_head_dim + d] = 1e6;
+            }
+        }
+
+        let params = zero_lambda_params(head_dim);
+        let subln_w = vec![1.0f32; 2 * head_dim];
+        let mut out = vec![0.0f32; seq_len * cfg.out_dim()];
+        let mut scratch = DiffAttnScratch::default();
+
+        apply_differential_attention(
+            &q,
+            &k,
+            &v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+
+        // output[0] should NOT be anywhere near 1e6
+        let out_pos0_max = out[..v_head_dim]
+            .iter()
+            .copied()
+            .fold(f32::NEG_INFINITY, f32::max);
+        assert!(
+            out_pos0_max.abs() < 1e4,
+            "position 0 attended to future positions! out_pos0_max = {out_pos0_max}"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // test_lambda_zero_recovers_difference
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_lambda_zero_recovers_difference() {
+        // If both softmax maps are identical AND lambda_full = 0, then
+        // the differential = s1 - 0*s2 = s1 = standard attention.
+        //
+        // We force lambda_full ≈ 0 by using params where exp(dot1) - exp(dot2) = -lambda_init,
+        // which is numerically tricky. Instead, test the simpler invariant:
+        // if lambda_full = 1 and both softmax maps are identical (which happens
+        // when q0 == q1 and k0 == k1 for all tokens), the differential weights sum to 0,
+        // and the output should be ~0.
+        //
+        // lambda_full = 1 is achieved when exp(dot1) - exp(dot2) + lambda_init = 1
+        // → exp(dot1) - exp(dot2) = 1 - lambda_init
+        // This is hard to hit exactly. Instead we directly test that with equal
+        // q0==q1 / k0==k1 and zero-lambda params (lambda_full=lambda_init),
+        // the differential weight matrix is (1-lambda_init) * s1, which is nonzero.
+        // The lambda_full==1 case (zero output) requires lambda_params tuning — we skip
+        // exact-zero but verify the subtraction direction instead.
+        let head_dim = 4_usize;
+        let cfg = make_cfg(1, 1, head_dim, 0); // lambda_init = 0.2
+        let seq_len = 3_usize;
+
+        // Make q0 == q1 and k0 == k1 for every position so both softmax maps are identical.
+        // q_buf layout: [seq_len, 2*num_heads*head_dim] = [seq_len, 2*head_dim]
+        // Positions: q[pos * 2*head_dim .. pos * 2*head_dim + 2*head_dim]
+        // First head_dim = head 0 (q0), second head_dim = head 1 (q1)
+        let mut q = vec![0.0f32; seq_len * cfg.q_dim()];
+        let mut k = vec![0.0f32; seq_len * cfg.k_dim()];
+        for pos in 0..seq_len {
+            let base = pos * cfg.q_dim();
+            // q0 == q1 for all positions
+            for d in 0..head_dim {
+                q[base + d] = det_data(1, (pos * head_dim + d) as u64)[0];
+                q[base + head_dim + d] = q[base + d]; // q1 = q0
+            }
+            let kbase = pos * cfg.k_dim();
+            for d in 0..head_dim {
+                k[kbase + d] = det_data(1, (pos * head_dim + d + 1000) as u64)[0];
+                k[kbase + head_dim + d] = k[kbase + d]; // k1 = k0
+            }
+        }
+        let v = det_data(seq_len * cfg.v_dim(), 77);
+        let params = zero_lambda_params(head_dim); // lambda_full = lambda_init = 0.2
+        let subln_w = vec![1.0f32; 2 * head_dim];
+        let mut out = vec![0.0f32; seq_len * cfg.out_dim()];
+        let mut scratch = DiffAttnScratch::default();
+
+        apply_differential_attention(
+            &q,
+            &k,
+            &v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+
+        // With q0==q1 and k0==k1, both softmax maps are identical.
+        // differential = s1 - lambda_init*s1 = (1-lambda_init)*s1 ≠ 0.
+        // The output should be non-trivially non-zero (confirming the subtraction works).
+        let any_nonzero = out.iter().any(|&x| x.abs() > 1e-8);
+        assert!(
+            any_nonzero,
+            "output should be non-zero when lambda_full = lambda_init < 1"
+        );
+
+        // Now verify the subtraction direction: with identical maps and lambda_init=0.2,
+        // the effective weight is (1-lambda_init)=0.8× the single-map weights.
+        // Output should be proportional to (1-lambda_init) * standard attention output.
+        // We can't easily verify the exact proportionality here without an oracle,
+        // but the non-zero check and shape check together confirm the path runs correctly.
+    }
+}

--- a/crates/inference/src/attention/differential.rs
+++ b/crates/inference/src/attention/differential.rs
@@ -219,6 +219,21 @@ pub fn apply_differential_attention(
 ) {
     use crate::forward::cpu::matmul_bt;
 
+    // Config validation — must precede the buffer-length asserts below. `cfg.q_dim()`,
+    // `k_dim()`, etc. silently collapse to 0 when `num_heads` or `head_dim` is 0, which
+    // would make those length checks vacuously pass; and `num_kv_heads == 0` would reach
+    // a raw divide-by-zero in the `%` check and in `cfg.n_rep()`.
+    assert!(cfg.num_heads > 0, "num_heads must be > 0");
+    assert!(cfg.num_kv_heads > 0, "num_kv_heads must be > 0");
+    assert!(cfg.head_dim > 0, "head_dim must be > 0");
+    assert_eq!(
+        cfg.num_heads % cfg.num_kv_heads,
+        0,
+        "num_heads ({}) must be divisible by num_kv_heads ({})",
+        cfg.num_heads,
+        cfg.num_kv_heads
+    );
+
     assert_eq!(
         q_buf.len(),
         seq_len * cfg.q_dim(),
@@ -251,11 +266,6 @@ pub fn apply_differential_attention(
         "attn_out length mismatch: expected {} got {}",
         seq_len * cfg.out_dim(),
         attn_out.len()
-    );
-    assert_eq!(
-        cfg.num_heads % cfg.num_kv_heads,
-        0,
-        "num_heads must be divisible by num_kv_heads"
     );
     for (name, v) in [
         ("lambda_q1", &lambda_params.lambda_q1),
@@ -828,6 +838,76 @@ mod tests {
         assert!(
             max_abs < 1e-3,
             "identical maps with lambda_full≈1 must yield ~0 output, got max_abs={max_abs}"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Config validation guards
+    //
+    // Each guard fires before any buffer is inspected, so empty buffers
+    // are sufficient to reach (and only reach) the assertion under test.
+    // ---------------------------------------------------------------
+
+    #[test]
+    #[should_panic(expected = "num_heads must be > 0")]
+    fn test_zero_num_heads_panics() {
+        let cfg = make_cfg(0, 1, 4, 0);
+        let params = zero_lambda_params(4);
+        let mut out: Vec<f32> = vec![];
+        let mut scratch = DiffAttnScratch::default();
+        apply_differential_attention(
+            &[],
+            &[],
+            &[],
+            &params,
+            &[],
+            1e-6,
+            &mut out,
+            1,
+            &cfg,
+            &mut scratch,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "num_kv_heads must be > 0")]
+    fn test_zero_num_kv_heads_panics() {
+        let cfg = make_cfg(2, 0, 4, 0);
+        let params = zero_lambda_params(4);
+        let mut out: Vec<f32> = vec![];
+        let mut scratch = DiffAttnScratch::default();
+        apply_differential_attention(
+            &[],
+            &[],
+            &[],
+            &params,
+            &[],
+            1e-6,
+            &mut out,
+            1,
+            &cfg,
+            &mut scratch,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "head_dim must be > 0")]
+    fn test_zero_head_dim_panics() {
+        let cfg = make_cfg(2, 2, 0, 0);
+        let params = zero_lambda_params(0);
+        let mut out: Vec<f32> = vec![];
+        let mut scratch = DiffAttnScratch::default();
+        apply_differential_attention(
+            &[],
+            &[],
+            &[],
+            &params,
+            &[],
+            1e-6,
+            &mut out,
+            1,
+            &cfg,
+            &mut scratch,
         );
     }
 }

--- a/crates/inference/src/attention/differential.rs
+++ b/crates/inference/src/attention/differential.rs
@@ -116,11 +116,18 @@ pub struct DiffLambdaParams {
 ///
 /// The dot products are over `head_dim`. The result can be any real value; it is
 /// NOT clamped (negative lambda_full is valid and meaningful in the reference).
+///
+/// # Panics
+///
+/// Panics if the four lambda vectors do not all have equal length. A real
+/// `assert_eq!` (not `debug_assert`) — a misloaded checkpoint with mismatched
+/// shapes must fail loudly, not silently truncate via `zip()` in release.
 #[inline]
 pub fn compute_lambda_full(params: &DiffLambdaParams, lambda_init: f32) -> f32 {
-    debug_assert_eq!(params.lambda_q1.len(), params.lambda_k1.len());
-    debug_assert_eq!(params.lambda_q2.len(), params.lambda_k2.len());
-    debug_assert_eq!(params.lambda_q1.len(), params.lambda_q2.len());
+    let len = params.lambda_q1.len();
+    assert_eq!(params.lambda_k1.len(), len, "lambda_k1 length != lambda_q1");
+    assert_eq!(params.lambda_q2.len(), len, "lambda_q2 length != lambda_q1");
+    assert_eq!(params.lambda_k2.len(), len, "lambda_k2 length != lambda_q1");
 
     let dot1: f32 = params
         .lambda_q1
@@ -250,6 +257,20 @@ pub fn apply_differential_attention(
         0,
         "num_heads must be divisible by num_kv_heads"
     );
+    for (name, v) in [
+        ("lambda_q1", &lambda_params.lambda_q1),
+        ("lambda_k1", &lambda_params.lambda_k1),
+        ("lambda_q2", &lambda_params.lambda_q2),
+        ("lambda_k2", &lambda_params.lambda_k2),
+    ] {
+        assert_eq!(
+            v.len(),
+            cfg.head_dim,
+            "{name} length must equal head_dim ({}), got {}",
+            cfg.head_dim,
+            v.len()
+        );
+    }
 
     if seq_len == 0 {
         return;
@@ -656,97 +677,124 @@ mod tests {
     #[test]
     fn test_diff_attn_causal_masking() {
         // Verify position i attends only to j <= i.
-        // Strategy: set v[pos] = pos+1 for position `pos`. If the output at position 0
-        // is influenced by position 1's value, the test will catch a masking bug.
         //
-        // With seq_len=3, pos=0 should only see v[0], not v[1] or v[2].
-        // We set v[1] and v[2] to very large values; if causal masking is correct,
-        // they won't contaminate output[0].
+        // Differential test: run two inputs that differ ONLY in the V values at
+        // future positions (1, 2). If causal masking is correct, out[pos 0] must
+        // be bit-identical between the two runs — position 0 cannot see future V.
+        //
+        // A magnitude bound would NOT catch a broken mask here: the sub-layer
+        // RMSNorm normalizes a contaminated row back to O(1), hiding the leak.
         let head_dim = 2_usize;
         let cfg = make_cfg(1, 1, head_dim, 0);
         let seq_len = 3_usize;
+        let v_head_dim = 2 * head_dim;
 
         let q = det_data(seq_len * cfg.q_dim(), 101);
         let k = det_data(seq_len * cfg.k_dim(), 202);
+        let params = zero_lambda_params(head_dim);
+        let subln_w = vec![1.0f32; 2 * head_dim];
 
-        // v[0] = [1, 1, 1, 1], v[1] = v[2] = very large
-        let mut v = vec![0.0f32; seq_len * cfg.v_dim()];
-        let v_head_dim = 2 * head_dim;
-        // position 0
-        for d in 0..v_head_dim {
-            v[0 * v_head_dim + d] = 1.0;
-        }
-        // positions 1 and 2 get huge values
+        // Base V.
+        let v_base = det_data(seq_len * cfg.v_dim(), 303);
+
+        // Variant V: identical at position 0, perturbed at future positions 1 and 2.
+        let mut v_perturbed = v_base.clone();
         for pos in 1..seq_len {
             for d in 0..v_head_dim {
-                v[pos * v_head_dim + d] = 1e6;
+                v_perturbed[pos * v_head_dim + d] += 12_345.0;
             }
         }
 
-        let params = zero_lambda_params(head_dim);
-        let subln_w = vec![1.0f32; 2 * head_dim];
-        let mut out = vec![0.0f32; seq_len * cfg.out_dim()];
-        let mut scratch = DiffAttnScratch::default();
+        let run = |v: &[f32]| {
+            let mut out = vec![0.0f32; seq_len * cfg.out_dim()];
+            let mut scratch = DiffAttnScratch::default();
+            apply_differential_attention(
+                &q,
+                &k,
+                v,
+                &params,
+                &subln_w,
+                1e-6,
+                &mut out,
+                seq_len,
+                &cfg,
+                &mut scratch,
+            );
+            out
+        };
 
-        apply_differential_attention(
-            &q,
-            &k,
-            &v,
-            &params,
-            &subln_w,
-            1e-6,
-            &mut out,
-            seq_len,
-            &cfg,
-            &mut scratch,
-        );
+        let out_base = run(&v_base);
+        let out_perturbed = run(&v_perturbed);
 
-        // output[0] should NOT be anywhere near 1e6
-        let out_pos0_max = out[..v_head_dim]
-            .iter()
-            .copied()
-            .fold(f32::NEG_INFINITY, f32::max);
+        // Position 0's output must be unchanged — it cannot attend to future V.
+        for d in 0..v_head_dim {
+            assert_eq!(
+                out_base[d].to_bits(),
+                out_perturbed[d].to_bits(),
+                "position 0 changed when only future V changed — causal mask leak at dim {d}"
+            );
+        }
+        // Sanity: a later position SHOULD change (otherwise the perturbation was a no-op).
+        let pos2_changed = (0..v_head_dim).any(|d| {
+            let off = 2 * cfg.out_dim() + d;
+            out_base[off] != out_perturbed[off]
+        });
         assert!(
-            out_pos0_max.abs() < 1e4,
-            "position 0 attended to future positions! out_pos0_max = {out_pos0_max}"
+            pos2_changed,
+            "position 2 should be affected by the future-V perturbation"
         );
     }
 
     // ---------------------------------------------------------------
-    // test_lambda_zero_recovers_difference
+    // test_lambda_one_zeroes_identical_maps
     // ---------------------------------------------------------------
 
     #[test]
-    fn test_lambda_zero_recovers_difference() {
-        // If both softmax maps are identical AND lambda_full = 0, then
-        // the differential = s1 - 0*s2 = s1 = standard attention.
+    fn test_lambda_one_zeroes_identical_maps() {
+        // Invariant: if the two softmax maps are identical AND lambda_full == 1,
+        // then differential = s1 - 1·s2 = 0, so the output collapses to ~0.
         //
-        // We force lambda_full ≈ 0 by using params where exp(dot1) - exp(dot2) = -lambda_init,
-        // which is numerically tricky. Instead, test the simpler invariant:
-        // if lambda_full = 1 and both softmax maps are identical (which happens
-        // when q0 == q1 and k0 == k1 for all tokens), the differential weights sum to 0,
-        // and the output should be ~0.
+        // Identical maps: q0 == q1 and k0 == k1 for every position → matmul + softmax
+        // produce bit-identical s1 and s2.
+        // lambda_full == 1: lambda_full = exp(dot1) - exp(dot2) + lambda_init.
+        //   Set dot2 = 0 (zero lambda_q2/k2) → exp(dot2) = 1.
+        //   Need exp(dot1) = 2 - lambda_init → dot1 = ln(2 - lambda_init), achieved
+        //   via lambda_q1 = [ln(2-lambda_init), 0, ...], lambda_k1 = [1, 0, ...].
         //
-        // lambda_full = 1 is achieved when exp(dot1) - exp(dot2) + lambda_init = 1
-        // → exp(dot1) - exp(dot2) = 1 - lambda_init
-        // This is hard to hit exactly. Instead we directly test that with equal
-        // q0==q1 / k0==k1 and zero-lambda params (lambda_full=lambda_init),
-        // the differential weight matrix is (1-lambda_init) * s1, which is nonzero.
-        // The lambda_full==1 case (zero output) requires lambda_params tuning — we skip
-        // exact-zero but verify the subtraction direction instead.
+        // Tolerance: the f32 ln→exp round-trip leaves lambda_full ≈ 1.0 ± ~1e-7
+        // rather than exactly 1.0, so `diff` is a tiny non-zero residual. The
+        // sub-layer RMSNorm's eps floor (1e-6) then scales that residual up to
+        // ~1e-5 magnitude. A 1e-3 bound is still decisive: it would FAIL by 2-3
+        // orders of magnitude if the subtraction were removed (output ≈ 0.8),
+        // sign-flipped (≈ 1.6), or lambda ignored (≈ 0.8) — unlike the previous
+        // "output is nonzero" check, which all three of those would pass.
         let head_dim = 4_usize;
         let cfg = make_cfg(1, 1, head_dim, 0); // lambda_init = 0.2
         let seq_len = 3_usize;
+        let lambda_init = cfg.lambda_init();
 
-        // Make q0 == q1 and k0 == k1 for every position so both softmax maps are identical.
-        // q_buf layout: [seq_len, 2*num_heads*head_dim] = [seq_len, 2*head_dim]
-        // Positions: q[pos * 2*head_dim .. pos * 2*head_dim + 2*head_dim]
-        // First head_dim = head 0 (q0), second head_dim = head 1 (q1)
+        // lambda params engineered so compute_lambda_full ≈ 1.0.
+        let mut lambda_q1 = vec![0.0f32; head_dim];
+        let mut lambda_k1 = vec![0.0f32; head_dim];
+        lambda_q1[0] = (2.0 - lambda_init).ln();
+        lambda_k1[0] = 1.0;
+        let params = DiffLambdaParams {
+            lambda_q1,
+            lambda_k1,
+            lambda_q2: vec![0.0f32; head_dim],
+            lambda_k2: vec![0.0f32; head_dim],
+        };
+        let lambda_full = compute_lambda_full(&params, lambda_init);
+        assert!(
+            (lambda_full - 1.0).abs() < 1e-5,
+            "test setup error: lambda_full should be ≈1.0, got {lambda_full}"
+        );
+
+        // q0 == q1 and k0 == k1 for every position → both softmax maps identical.
         let mut q = vec![0.0f32; seq_len * cfg.q_dim()];
         let mut k = vec![0.0f32; seq_len * cfg.k_dim()];
         for pos in 0..seq_len {
             let base = pos * cfg.q_dim();
-            // q0 == q1 for all positions
             for d in 0..head_dim {
                 q[base + d] = det_data(1, (pos * head_dim + d) as u64)[0];
                 q[base + head_dim + d] = q[base + d]; // q1 = q0
@@ -758,7 +806,6 @@ mod tests {
             }
         }
         let v = det_data(seq_len * cfg.v_dim(), 77);
-        let params = zero_lambda_params(head_dim); // lambda_full = lambda_init = 0.2
         let subln_w = vec![1.0f32; 2 * head_dim];
         let mut out = vec![0.0f32; seq_len * cfg.out_dim()];
         let mut scratch = DiffAttnScratch::default();
@@ -776,19 +823,11 @@ mod tests {
             &mut scratch,
         );
 
-        // With q0==q1 and k0==k1, both softmax maps are identical.
-        // differential = s1 - lambda_init*s1 = (1-lambda_init)*s1 ≠ 0.
-        // The output should be non-trivially non-zero (confirming the subtraction works).
-        let any_nonzero = out.iter().any(|&x| x.abs() > 1e-8);
+        // diff = s1 - lambda_full·s2 ≈ 0 → context ≈ 0 → output ≈ 0.
+        let max_abs = out.iter().copied().fold(0.0f32, |m, x| m.max(x.abs()));
         assert!(
-            any_nonzero,
-            "output should be non-zero when lambda_full = lambda_init < 1"
+            max_abs < 1e-3,
+            "identical maps with lambda_full≈1 must yield ~0 output, got max_abs={max_abs}"
         );
-
-        // Now verify the subtraction direction: with identical maps and lambda_init=0.2,
-        // the effective weight is (1-lambda_init)=0.8× the single-map weights.
-        // Output should be proportional to (1-lambda_init) * standard attention output.
-        // We can't easily verify the exact proportionality here without an oracle,
-        // but the non-zero check and shape check together confirm the path runs correctly.
     }
 }

--- a/crates/inference/src/attention/mod.rs
+++ b/crates/inference/src/attention/mod.rs
@@ -1,3 +1,4 @@
+pub mod differential;
 pub mod flash;
 pub mod flash_causal;
 pub mod gated;

--- a/crates/inference/tests/differential_attention_test.rs
+++ b/crates/inference/tests/differential_attention_test.rs
@@ -467,3 +467,124 @@ fn test_scratch_reuse() {
         );
     }
 }
+
+/// Independent check of the GQA head-mapping convention.
+///
+/// The naive reference (`ref_differential_attention`) derives the KV head for
+/// query-pair `h` as `h / n_rep` — the *same* integer-division mapping the kernel
+/// uses. A shared misunderstanding of the grouping (contiguous vs. interleaved)
+/// would pass both, so that oracle alone cannot validate it.
+///
+/// This test removes the `/ n_rep` derivation from the oracle path entirely. GQA
+/// is *defined* as MHA with each KV head physically replicated `n_rep` times in
+/// contiguous order (`repeat_kv`; in Microsoft's reference this is what
+/// `flash_attn_func` does internally). So:
+///
+///   1. Run a GQA config (`num_kv_heads < num_heads`) on K/V data with distinct
+///      KV heads.
+///   2. Build an MHA config (`num_kv_heads == num_heads`, `n_rep == 1` — no
+///      grouping logic in the compute path) whose K/V buffers are the GQA buffers
+///      with each KV head materialized `n_rep` times, using a *hardcoded* pair→KV
+///      table rather than `/ n_rep`.
+///   3. The two outputs must be bit-identical: query-pair `h` sees the same Q/K/V
+///      in both runs, so every matmul/softmax/norm is the same arithmetic on the
+///      same bytes.
+///
+/// If the kernel's grouping convention disagreed with contiguous `repeat_kv`, the
+/// GQA run would diverge from the materialized-MHA run.
+///
+/// This does not replace a capture from the actual flash-attn reference (which
+/// needs CUDA hardware), but it closes the "shared derivation" gap: the oracle
+/// here decides the grouping by explicit data placement, not by the kernel's own
+/// indexing formula.
+#[test]
+fn test_gqa_equals_materialized_mha() {
+    // GQA config: 4 query-pairs, 2 KV heads → n_rep = 2.
+    let gqa_cfg = DiffAttnConfig {
+        num_heads: 4,
+        num_kv_heads: 2,
+        head_dim: 4,
+        layer_depth: 3,
+    };
+    // Contiguous repeat_kv for num_heads=4, num_kv_heads=2: query-pair h is served
+    // by KV head h/2 → [0, 0, 1, 1]. Written as a literal, NOT computed via
+    // `/ n_rep`, so this oracle shares no grouping derivation with the kernel.
+    const PAIR_TO_KV: [usize; 4] = [0, 0, 1, 1];
+
+    let seq_len = 5;
+    let head_dim = gqa_cfg.head_dim;
+    let v_head_dim = 2 * head_dim;
+
+    let (q, k_gqa, v_gqa, params, subln_w) = make_inputs(&gqa_cfg, seq_len, 4242);
+
+    // MHA config: one KV head per query-pair (n_rep = 1). head_dim is unchanged,
+    // so `params` and `subln_w` from make_inputs are valid for both configs.
+    let mha_cfg = DiffAttnConfig {
+        num_heads: gqa_cfg.num_heads,
+        num_kv_heads: gqa_cfg.num_heads,
+        head_dim,
+        layer_depth: gqa_cfg.layer_depth,
+    };
+
+    // Materialize K: MHA KV head `m` holds GQA KV head `PAIR_TO_KV[m]`'s two
+    // packed K heads.
+    let gqa_k_stride = gqa_cfg.k_dim();
+    let mha_k_stride = mha_cfg.k_dim();
+    let mut k_mha = vec![0.0_f32; seq_len * mha_k_stride];
+    for pos in 0..seq_len {
+        for (mha_kv, &gqa_kv) in PAIR_TO_KV.iter().enumerate() {
+            for half in 0..2 {
+                let src = pos * gqa_k_stride + (2 * gqa_kv + half) * head_dim;
+                let dst = pos * mha_k_stride + (2 * mha_kv + half) * head_dim;
+                k_mha[dst..dst + head_dim].copy_from_slice(&k_gqa[src..src + head_dim]);
+            }
+        }
+    }
+
+    // Materialize V: MHA KV head `m` holds GQA KV head `PAIR_TO_KV[m]`'s V head.
+    let gqa_v_stride = gqa_cfg.v_dim();
+    let mha_v_stride = mha_cfg.v_dim();
+    let mut v_mha = vec![0.0_f32; seq_len * mha_v_stride];
+    for pos in 0..seq_len {
+        for (mha_kv, &gqa_kv) in PAIR_TO_KV.iter().enumerate() {
+            let src = pos * gqa_v_stride + gqa_kv * v_head_dim;
+            let dst = pos * mha_v_stride + mha_kv * v_head_dim;
+            v_mha[dst..dst + v_head_dim].copy_from_slice(&v_gqa[src..src + v_head_dim]);
+        }
+    }
+
+    // Q is never grouped, and q_dim/out_dim depend only on num_heads (identical
+    // between the two configs) — so the Q buffer and output shape are shared.
+    assert_eq!(gqa_cfg.q_dim(), mha_cfg.q_dim());
+    assert_eq!(gqa_cfg.out_dim(), mha_cfg.out_dim());
+
+    let run = |cfg: &DiffAttnConfig, k: &[f32], v: &[f32]| {
+        let mut out = vec![0.0_f32; seq_len * cfg.out_dim()];
+        let mut scratch = DiffAttnScratch::default();
+        apply_differential_attention(
+            &q,
+            k,
+            v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut out,
+            seq_len,
+            cfg,
+            &mut scratch,
+        );
+        out
+    };
+
+    let out_gqa = run(&gqa_cfg, &k_gqa, &v_gqa);
+    let out_mha = run(&mha_cfg, &k_mha, &v_mha);
+
+    for (i, (g, m)) in out_gqa.iter().zip(out_mha.iter()).enumerate() {
+        assert_eq!(
+            g.to_bits(),
+            m.to_bits(),
+            "GQA output diverged from materialized-MHA at index {i}: {g} vs {m} \
+             — kernel head-grouping disagrees with contiguous repeat_kv"
+        );
+    }
+}

--- a/crates/inference/tests/differential_attention_test.rs
+++ b/crates/inference/tests/differential_attention_test.rs
@@ -1,0 +1,448 @@
+//! Self-contained integration test for differential attention.
+//!
+//! # Reference
+//!
+//! HuggingFace `transformers` does not ship a DIFF Transformer model. The reference
+//! is Microsoft's `unilm/Diff-Transformer/multihead_flashdiff_1.py` algorithm,
+//! transcribed exactly to Rust in `ref_differential_attention` below. The implementation
+//! under test (`apply_differential_attention`) is verified against this reference within
+//! `max_abs_diff <= 1e-4`.
+//!
+//! # Buffer conventions
+//!
+//! - `q_buf`:  `[seq_len, 2*num_heads*head_dim]`
+//! - `k_buf`:  `[seq_len, 2*num_kv_heads*head_dim]`
+//! - `v_buf`:  `[seq_len, num_kv_heads*(2*head_dim)]`
+//! - `out`:    `[seq_len, num_heads*(2*head_dim)]`
+//!
+//! Run:
+//!   cargo test --test differential_attention_test
+
+use lattice_inference::attention::differential::{
+    DiffAttnConfig, DiffAttnScratch, DiffLambdaParams, apply_differential_attention,
+    compute_lambda_full,
+};
+use lattice_inference::forward::cpu::matmul_bt;
+
+// ===================================================================
+// Deterministic PRNG (xorshift64 + float extraction)
+//
+// Matches the generator used in gated_attention_test.rs and all other
+// integration tests in this crate.
+// ===================================================================
+
+fn det_data(len: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        state ^= state << 7;
+        state ^= state >> 9;
+        state = state.wrapping_mul(0x2545_f491_4f6c_dd1d);
+        let mantissa = ((state >> 41) as u32) & 0x007f_ffff;
+        let x = f32::from_bits(0x3f80_0000 | mantissa) - 1.5;
+        out.push(x);
+    }
+    out
+}
+
+fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "length mismatch in max_abs_diff");
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0_f32, f32::max)
+}
+
+// ===================================================================
+// Reference implementation
+//
+// A naive, unoptimized, exact-math transcription of the Microsoft
+// DIFF Transformer algorithm (multihead_flashdiff_1.py).
+// No approximations; uses f32::exp throughout.
+// ===================================================================
+
+/// Compute a single row of softmax over the causal prefix.
+///
+/// `row` has length `seq_len`; only indices `0..=qi` are valid (causal).
+/// Invalid positions are masked with `-10000.0` before softmax.
+fn ref_softmax_causal_row(row: &mut [f32], qi: usize) {
+    let seq_len = row.len();
+    for ki in 0..seq_len {
+        if ki > qi {
+            row[ki] = -10_000.0_f32;
+        }
+    }
+    let valid = qi + 1;
+    let max_val = row[..valid]
+        .iter()
+        .copied()
+        .fold(f32::NEG_INFINITY, f32::max);
+    let mut sum = 0.0_f32;
+    for v in &mut row[..valid] {
+        *v = (*v - max_val).exp();
+        sum += *v;
+    }
+    if sum > 0.0 {
+        let inv = 1.0 / sum;
+        for v in &mut row[..valid] {
+            *v *= inv;
+        }
+    }
+    // Zero out the masked tail (they hold -10000 before exp; set to 0 after softmax).
+    row[valid..].fill(0.0);
+}
+
+/// RMSNorm a single row in-place.
+///
+/// `row` has length `hidden = 2*head_dim`. `gamma` has the same length.
+fn ref_rms_norm_row(row: &mut [f32], gamma: &[f32], eps: f32) {
+    let hidden = row.len();
+    let sum_sq: f32 = row.iter().map(|&x| x * x).sum();
+    let rms = (sum_sq / hidden as f32 + eps).sqrt();
+    let inv_rms = 1.0 / rms;
+    for (v, &g) in row.iter_mut().zip(gamma.iter()) {
+        *v = *v * inv_rms * g;
+    }
+}
+
+/// Reference: naive differential attention matching multihead_flashdiff_1.py.
+///
+/// Inputs:
+/// - `q_buf`:  `[seq_len, 2*num_heads*head_dim]`
+/// - `k_buf`:  `[seq_len, 2*num_kv_heads*head_dim]`
+/// - `v_buf`:  `[seq_len, num_kv_heads*2*head_dim]`
+/// - `subln_weight`: `[2*head_dim]` RMSNorm gamma
+///
+/// Output: `[seq_len, num_heads*2*head_dim]`
+#[allow(clippy::too_many_arguments)]
+fn ref_differential_attention(
+    q_buf: &[f32],
+    k_buf: &[f32],
+    v_buf: &[f32],
+    lambda_params: &DiffLambdaParams,
+    subln_weight: &[f32],
+    subln_eps: f32,
+    seq_len: usize,
+    cfg: &DiffAttnConfig,
+) -> Vec<f32> {
+    let num_heads = cfg.num_heads;
+    let num_kv_heads = cfg.num_kv_heads;
+    let head_dim = cfg.head_dim;
+    let v_head_dim = 2 * head_dim;
+    let n_rep = num_heads / num_kv_heads;
+
+    let lambda_init = cfg.lambda_init();
+    let lambda_full = compute_lambda_full(lambda_params, lambda_init);
+    let scale = (head_dim as f32).powf(-0.5);
+
+    // Packed buffer strides
+    let q_stride = 2 * num_heads * head_dim; // q_buf row width
+    let k_stride = 2 * num_kv_heads * head_dim; // k_buf row width
+    let v_stride = num_kv_heads * v_head_dim; // v_buf row width
+    let out_stride = num_heads * v_head_dim; // output row width
+
+    let mut out = vec![0.0_f32; seq_len * out_stride];
+
+    for pair_h in 0..num_heads {
+        let kv_h = pair_h / n_rep;
+        let q_h0 = 2 * pair_h; // first packed Q head
+        let q_h1 = 2 * pair_h + 1; // second packed Q head
+        let k_h0 = 2 * kv_h; // first packed K head
+        let k_h1 = 2 * kv_h + 1; // second packed K head
+
+        // Extract Q heads: [seq_len, head_dim]
+        let mut q0 = vec![0.0_f32; seq_len * head_dim];
+        let mut q1 = vec![0.0_f32; seq_len * head_dim];
+        for pos in 0..seq_len {
+            let src0 = pos * q_stride + q_h0 * head_dim;
+            let src1 = pos * q_stride + q_h1 * head_dim;
+            q0[pos * head_dim..pos * head_dim + head_dim]
+                .copy_from_slice(&q_buf[src0..src0 + head_dim]);
+            q1[pos * head_dim..pos * head_dim + head_dim]
+                .copy_from_slice(&q_buf[src1..src1 + head_dim]);
+        }
+
+        // Extract K heads: [seq_len, head_dim]
+        let mut k0 = vec![0.0_f32; seq_len * head_dim];
+        let mut k1 = vec![0.0_f32; seq_len * head_dim];
+        for pos in 0..seq_len {
+            let src0 = pos * k_stride + k_h0 * head_dim;
+            let src1 = pos * k_stride + k_h1 * head_dim;
+            k0[pos * head_dim..pos * head_dim + head_dim]
+                .copy_from_slice(&k_buf[src0..src0 + head_dim]);
+            k1[pos * head_dim..pos * head_dim + head_dim]
+                .copy_from_slice(&k_buf[src1..src1 + head_dim]);
+        }
+
+        // Extract V head: [seq_len, v_head_dim]
+        let mut v_head = vec![0.0_f32; seq_len * v_head_dim];
+        for pos in 0..seq_len {
+            let src = pos * v_stride + kv_h * v_head_dim;
+            v_head[pos * v_head_dim..pos * v_head_dim + v_head_dim]
+                .copy_from_slice(&v_buf[src..src + v_head_dim]);
+        }
+
+        // Compute attention scores: [seq_len, seq_len] for each half
+        let mut scores1 = vec![0.0_f32; seq_len * seq_len];
+        let mut scores2 = vec![0.0_f32; seq_len * seq_len];
+
+        // scores = Q @ K^T, scale + causal mask + softmax
+        matmul_bt(&q0, &k0, &mut scores1, seq_len, head_dim, seq_len);
+        matmul_bt(&q1, &k1, &mut scores2, seq_len, head_dim, seq_len);
+
+        for qi in 0..seq_len {
+            // scale
+            for ki in 0..=qi {
+                scores1[qi * seq_len + ki] *= scale;
+                scores2[qi * seq_len + ki] *= scale;
+            }
+            ref_softmax_causal_row(&mut scores1[qi * seq_len..(qi + 1) * seq_len], qi);
+            ref_softmax_causal_row(&mut scores2[qi * seq_len..(qi + 1) * seq_len], qi);
+        }
+
+        // Differential subtraction: scores1 - lambda_full * scores2
+        for i in 0..(seq_len * seq_len) {
+            scores1[i] -= lambda_full * scores2[i];
+        }
+
+        // Context: [seq_len, v_head_dim] = diff_scores @ V
+        let mut context = vec![0.0_f32; seq_len * v_head_dim];
+        for qi in 0..seq_len {
+            for kj in 0..seq_len {
+                let w = scores1[qi * seq_len + kj];
+                for d in 0..v_head_dim {
+                    context[qi * v_head_dim + d] += w * v_head[kj * v_head_dim + d];
+                }
+            }
+        }
+
+        // Sub-layer RMSNorm per position
+        for qi in 0..seq_len {
+            let row = &mut context[qi * v_head_dim..(qi + 1) * v_head_dim];
+            ref_rms_norm_row(row, subln_weight, subln_eps);
+        }
+
+        // Scale by (1 - lambda_init) and write output
+        let scale_factor = 1.0 - lambda_init;
+        for pos in 0..seq_len {
+            let src_off = pos * v_head_dim;
+            let dst_off = pos * out_stride + pair_h * v_head_dim;
+            for d in 0..v_head_dim {
+                out[dst_off + d] = context[src_off + d] * scale_factor;
+            }
+        }
+    }
+
+    out
+}
+
+// ===================================================================
+// Helper: build test config and random inputs
+// ===================================================================
+
+fn make_inputs(
+    cfg: &DiffAttnConfig,
+    seq_len: usize,
+    seed: u64,
+) -> (Vec<f32>, Vec<f32>, Vec<f32>, DiffLambdaParams, Vec<f32>) {
+    let q = det_data(seq_len * cfg.q_dim(), seed);
+    let k = det_data(seq_len * cfg.k_dim(), seed + 1);
+    let v = det_data(seq_len * cfg.v_dim(), seed + 2);
+    let params = DiffLambdaParams {
+        lambda_q1: det_data(cfg.head_dim, seed + 3),
+        lambda_k1: det_data(cfg.head_dim, seed + 4),
+        lambda_q2: det_data(cfg.head_dim, seed + 5),
+        lambda_k2: det_data(cfg.head_dim, seed + 6),
+    };
+    // Scale down lambda params so exp(dot) stays reasonable
+    let scale_down = |v: Vec<f32>| v.into_iter().map(|x| x * 0.1).collect::<Vec<_>>();
+    let params = DiffLambdaParams {
+        lambda_q1: scale_down(params.lambda_q1),
+        lambda_k1: scale_down(params.lambda_k1),
+        lambda_q2: scale_down(params.lambda_q2),
+        lambda_k2: scale_down(params.lambda_k2),
+    };
+    let subln_w = vec![1.0_f32; 2 * cfg.head_dim];
+    (q, k, v, params, subln_w)
+}
+
+// ===================================================================
+// Integration tests
+// ===================================================================
+
+/// Test case parameters: (seq_len, num_heads, num_kv_heads, head_dim, layer_depth, name)
+const TEST_CASES: &[(usize, usize, usize, usize, usize, &str)] = &[
+    // MHA: single head, short sequence
+    (1, 1, 1, 4, 0, "mha-1h-seq1"),
+    (3, 1, 1, 4, 0, "mha-1h-seq3"),
+    // MHA: multiple heads
+    (5, 2, 2, 4, 1, "mha-2h-seq5"),
+    (8, 4, 4, 8, 3, "mha-4h-seq8"),
+    // GQA: num_kv_heads < num_heads
+    (4, 4, 2, 4, 2, "gqa-4h-2kv-seq4"),
+    (6, 4, 1, 4, 5, "gqa-4h-1kv-seq6"),
+    // Larger head_dim
+    (5, 2, 1, 8, 10, "gqa-2h-1kv-hd8-seq5"),
+];
+
+/// Core correctness test: optimized kernel matches naive reference within 1e-4.
+#[test]
+fn test_diff_attn_matches_reference() {
+    const TOLERANCE: f32 = 1e-4;
+
+    for &(seq_len, num_heads, num_kv_heads, head_dim, layer_depth, name) in TEST_CASES {
+        let cfg = DiffAttnConfig {
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            layer_depth,
+        };
+        let (q, k, v, params, subln_w) = make_inputs(&cfg, seq_len, (seq_len as u64) * 1009);
+
+        let ref_out =
+            ref_differential_attention(&q, &k, &v, &params, &subln_w, 1e-6, seq_len, &cfg);
+
+        let mut opt_out = vec![0.0_f32; seq_len * cfg.out_dim()];
+        let mut scratch = DiffAttnScratch::default();
+        apply_differential_attention(
+            &q,
+            &k,
+            &v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut opt_out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+
+        let diff = max_abs_diff(&opt_out, &ref_out);
+        assert!(
+            diff <= TOLERANCE,
+            "case '{name}': max_abs_diff={diff} exceeds {TOLERANCE}"
+        );
+    }
+}
+
+/// Verify the output has the correct length for all test cases.
+#[test]
+fn test_diff_attn_output_length() {
+    for &(seq_len, num_heads, num_kv_heads, head_dim, layer_depth, name) in TEST_CASES {
+        let cfg = DiffAttnConfig {
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            layer_depth,
+        };
+        let expected_len = seq_len * num_heads * 2 * head_dim;
+        let (q, k, v, params, subln_w) = make_inputs(&cfg, seq_len, 42);
+        let mut out = vec![0.0_f32; expected_len];
+        let mut scratch = DiffAttnScratch::default();
+        apply_differential_attention(
+            &q,
+            &k,
+            &v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+        assert_eq!(
+            out.len(),
+            expected_len,
+            "case '{name}': output len mismatch"
+        );
+    }
+}
+
+/// Verify causal masking: position 0's output must not depend on position 1's V.
+///
+/// Injects a very large value at v[pos=1] and checks that out[pos=0] stays bounded.
+#[test]
+fn test_causal_masking_integration() {
+    let cfg = DiffAttnConfig {
+        num_heads: 2,
+        num_kv_heads: 1,
+        head_dim: 4,
+        layer_depth: 0,
+    };
+    let seq_len = 4;
+    let (q, k, mut v, params, subln_w) = make_inputs(&cfg, seq_len, 777);
+
+    // Spike v at position 1
+    let v_head_dim = 2 * cfg.head_dim;
+    let v_stride = cfg.num_kv_heads * v_head_dim;
+    for d in 0..v_head_dim {
+        v[1 * v_stride + d] = 1e8;
+    }
+
+    let mut out = vec![0.0_f32; seq_len * cfg.out_dim()];
+    let mut scratch = DiffAttnScratch::default();
+    apply_differential_attention(
+        &q,
+        &k,
+        &v,
+        &params,
+        &subln_w,
+        1e-6,
+        &mut out,
+        seq_len,
+        &cfg,
+        &mut scratch,
+    );
+
+    let out_stride = cfg.out_dim();
+    let max_pos0 = out[..out_stride]
+        .iter()
+        .copied()
+        .fold(f32::NEG_INFINITY, f32::max);
+    assert!(
+        max_pos0.abs() < 1e6,
+        "position 0 contaminated by future position 1: max_pos0={max_pos0}"
+    );
+}
+
+/// Verify that scratch buffer reuse across calls does not corrupt results.
+///
+/// Call `apply_differential_attention` twice with different inputs on the same scratch.
+/// Both outputs must match their respective references.
+#[test]
+fn test_scratch_reuse() {
+    const TOL: f32 = 1e-4;
+
+    let cfg = DiffAttnConfig {
+        num_heads: 2,
+        num_kv_heads: 2,
+        head_dim: 4,
+        layer_depth: 2,
+    };
+    let mut scratch = DiffAttnScratch::default();
+
+    for (seed, seq_len) in [(100_u64, 3_usize), (200, 5)] {
+        let (q, k, v, params, subln_w) = make_inputs(&cfg, seq_len, seed);
+        let ref_out =
+            ref_differential_attention(&q, &k, &v, &params, &subln_w, 1e-6, seq_len, &cfg);
+        let mut opt_out = vec![0.0_f32; seq_len * cfg.out_dim()];
+        apply_differential_attention(
+            &q,
+            &k,
+            &v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut opt_out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+        let diff = max_abs_diff(&opt_out, &ref_out);
+        assert!(
+            diff <= TOL,
+            "scratch reuse seed={seed} seq_len={seq_len}: max_abs_diff={diff} exceeds {TOL}"
+        );
+    }
+}

--- a/crates/inference/tests/differential_attention_test.rs
+++ b/crates/inference/tests/differential_attention_test.rs
@@ -359,9 +359,11 @@ fn test_diff_attn_output_length() {
     }
 }
 
-/// Verify causal masking: position 0's output must not depend on position 1's V.
+/// Verify causal masking: position 0's output must not depend on future V.
 ///
-/// Injects a very large value at v[pos=1] and checks that out[pos=0] stays bounded.
+/// Differential test: run two inputs that differ ONLY in V at positions 1..seq_len.
+/// `out[pos 0]` must be bit-identical between the runs. A magnitude bound would NOT
+/// catch a leak — the sub-layer RMSNorm renormalizes a contaminated row back to O(1).
 #[test]
 fn test_causal_masking_integration() {
     let cfg = DiffAttnConfig {
@@ -371,38 +373,57 @@ fn test_causal_masking_integration() {
         layer_depth: 0,
     };
     let seq_len = 4;
-    let (q, k, mut v, params, subln_w) = make_inputs(&cfg, seq_len, 777);
+    let (q, k, v_base, params, subln_w) = make_inputs(&cfg, seq_len, 777);
 
-    // Spike v at position 1
     let v_head_dim = 2 * cfg.head_dim;
     let v_stride = cfg.num_kv_heads * v_head_dim;
-    for d in 0..v_head_dim {
-        v[1 * v_stride + d] = 1e8;
+
+    // Variant: identical at position 0, perturbed at all future positions.
+    let mut v_perturbed = v_base.clone();
+    for pos in 1..seq_len {
+        for d in 0..v_stride {
+            v_perturbed[pos * v_stride + d] += 9_876.0;
+        }
     }
 
-    let mut out = vec![0.0_f32; seq_len * cfg.out_dim()];
-    let mut scratch = DiffAttnScratch::default();
-    apply_differential_attention(
-        &q,
-        &k,
-        &v,
-        &params,
-        &subln_w,
-        1e-6,
-        &mut out,
-        seq_len,
-        &cfg,
-        &mut scratch,
-    );
+    let run = |v: &[f32]| {
+        let mut out = vec![0.0_f32; seq_len * cfg.out_dim()];
+        let mut scratch = DiffAttnScratch::default();
+        apply_differential_attention(
+            &q,
+            &k,
+            v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+        out
+    };
 
+    let out_base = run(&v_base);
+    let out_perturbed = run(&v_perturbed);
     let out_stride = cfg.out_dim();
-    let max_pos0 = out[..out_stride]
-        .iter()
-        .copied()
-        .fold(f32::NEG_INFINITY, f32::max);
+
+    // Position 0 must be unchanged — it cannot attend to future V.
+    for d in 0..out_stride {
+        assert_eq!(
+            out_base[d].to_bits(),
+            out_perturbed[d].to_bits(),
+            "position 0 changed when only future V changed — causal mask leak at dim {d}"
+        );
+    }
+    // Sanity: the last position SHOULD change, or the perturbation was a no-op.
+    let last_changed = (0..out_stride).any(|d| {
+        let off = (seq_len - 1) * out_stride + d;
+        out_base[off] != out_perturbed[off]
+    });
     assert!(
-        max_pos0.abs() < 1e6,
-        "position 0 contaminated by future position 1: max_pos0={max_pos0}"
+        last_changed,
+        "last position should be affected by the future-V perturbation"
     );
 }
 

--- a/docs/adr/ADR-041-differential-attention.md
+++ b/docs/adr/ADR-041-differential-attention.md
@@ -39,7 +39,7 @@ Public surface:
 
 3. **Subtract scores, then one V matmul**: The reference computes `attn1 = softmax1 @ v` and `attn2 = softmax2 @ v` separately, then `attn1 - lambda_full·attn2`. The kernel instead computes `(softmax1 - lambda_full·softmax2) @ v` — a single V matmul. This is exactly equivalent by linearity of matrix multiplication and saves one GEMM per head pair.
 
-4. **GQA via post-split head mapping**: `multihead_flashdiff_1.py` *defines* a `repeat_kv` helper but does **not** call it — it splits Q/K into `q1/q2/k1/k2` first (with `num_heads` / `num_kv_heads` heads respectively), then passes them to `flash_attn_func`, which performs standard GQA grouping internally. The standard convention `kv_head = query_head // n_rep` therefore applies to the *post-split* logical heads. The kernel maps logical pair `h` to KV head `h / n_rep`, packed K heads `2·(h/n_rep)` and `2·(h/n_rep)+1`. This was verified against the Microsoft source — an earlier reading that assumed `repeat_kv` was applied to the pre-split `2·num_kv_heads` axis was wrong.
+4. **GQA via post-split head mapping**: `multihead_flashdiff_1.py` *defines* a `repeat_kv` helper but does **not** call it — it splits Q/K into `q1/q2/k1/k2` first (with `num_heads` / `num_kv_heads` heads respectively), then passes them to `flash_attn_func`, which performs standard GQA grouping internally. The standard convention `kv_head = query_head // n_rep` therefore applies to the *post-split* logical heads. The kernel maps logical pair `h` to KV head `h / n_rep`, packed K heads `2·(h/n_rep)` and `2·(h/n_rep)+1`. This was verified against the Microsoft source — an earlier reading that assumed `repeat_kv` was applied to the pre-split `2·num_kv_heads` axis was wrong. `test_gqa_equals_materialized_mha` guards it: a GQA run must produce bit-identical output to a pure-MHA run (`n_rep = 1`) whose KV heads are materialized in contiguous `repeat_kv` order.
 
 5. **Additive `-10,000.0` causal mask**: Consistent with ADR-010 design choice #2 — avoids the NaN risk of `-inf` on fully-masked rows. The softmax loop only iterates the causal prefix, so masked positions are also explicitly zeroed.
 
@@ -64,12 +64,12 @@ Public surface:
 
 - Differential attention is independently testable and benchmarkable (6 unit tests, 4 integration tests, dedicated benchmark).
 - When a DIFF Transformer checkpoint becomes a target, the math is already implemented and validated.
-- Benchmark isolates the differential mechanism cost (second Q/K extract + second GEMM + second softmax + subtract + sub-RMSNorm) at ~1.8–2.2x a single-softmax baseline with identical loop topology. The comparison is topology-controlled: a comparison against the batched `apply_gqa_attention` would conflate kernel topology with mechanism cost.
+- Benchmark isolates the differential mechanism cost (second Q/K extract + second GEMM + second softmax + subtract + sub-RMSNorm) at ~1.5–2.0x a single-softmax baseline (measured: 1.97x / 1.96x / 1.48x for the 2h / 4h-GQA / 8h-GQA shapes at seq_len 256; the ratio shrinks at larger head counts as the shared per-pair scratch traffic grows). The baseline has identical loop topology *and* identical per-pair scratch-slab layout, so the only working-set difference is the differential kernel's `scores2` slab — itself part of the mechanism. A comparison against the batched `apply_gqa_attention` would instead conflate kernel topology and scratch cache-layout with mechanism cost.
 
 **Negative**:
 
 - Sixth attention module adds a sixth test suite to maintain.
-- The integration test's reference and the optimized kernel share the GQA head-mapping convention. The mapping was manually verified against the Microsoft source, but a fully independent oracle (e.g. tracked vectors from a PyTorch run of the actual reference) would be stronger. MHA cases (`n_rep = 1`) are unambiguous and independently meaningful.
+- The integration test's naive reference (`ref_differential_attention`) shares the `pair_h / n_rep` GQA head-mapping derivation with the kernel, so on its own it cannot catch a shared grouping misunderstanding (contiguous vs. interleaved). `test_gqa_equals_materialized_mha` closes most of this gap: it runs a GQA config against an MHA config (`n_rep = 1`, no grouping logic in the compute path) whose KV heads are physically materialized in contiguous `repeat_kv` order via a hardcoded pair→KV table, and asserts bit-identical output — the oracle there decides the grouping by explicit data placement, not by the kernel's own indexing formula. The remaining gap is a capture from the actual flash-attn reference, which requires CUDA hardware that Lattice's CI does not have.
 
 **Risks**:
 

--- a/docs/adr/ADR-041-differential-attention.md
+++ b/docs/adr/ADR-041-differential-attention.md
@@ -64,7 +64,7 @@ Public surface:
 
 - Differential attention is independently testable and benchmarkable (6 unit tests, 4 integration tests, dedicated benchmark).
 - When a DIFF Transformer checkpoint becomes a target, the math is already implemented and validated.
-- Benchmark shows the differential mechanism (second softmax + subtract + sub-RMSNorm) costs only ~4–11% over a same-sized plain GQA kernel.
+- Benchmark isolates the differential mechanism cost (second Q/K extract + second GEMM + second softmax + subtract + sub-RMSNorm) at ~1.8–2.2x a single-softmax baseline with identical loop topology. The comparison is topology-controlled: a comparison against the batched `apply_gqa_attention` would conflate kernel topology with mechanism cost.
 
 **Negative**:
 

--- a/docs/adr/ADR-041-differential-attention.md
+++ b/docs/adr/ADR-041-differential-attention.md
@@ -62,9 +62,9 @@ Public surface:
 
 **Positive**:
 
-- Differential attention is independently testable and benchmarkable (6 unit tests, 4 integration tests, dedicated benchmark).
+- Differential attention is independently testable and benchmarkable (11 unit tests, 5 integration tests, dedicated benchmark).
 - When a DIFF Transformer checkpoint becomes a target, the math is already implemented and validated.
-- Benchmark isolates the differential mechanism cost (second Q/K extract + second GEMM + second softmax + subtract + sub-RMSNorm) at ~1.5–2.0x a single-softmax baseline (measured: 1.97x / 1.96x / 1.48x for the 2h / 4h-GQA / 8h-GQA shapes at seq_len 256; the ratio shrinks at larger head counts as the shared per-pair scratch traffic grows). The baseline has identical loop topology *and* identical per-pair scratch-slab layout, so the only working-set difference is the differential kernel's `scores2` slab — itself part of the mechanism. A comparison against the batched `apply_gqa_attention` would instead conflate kernel topology and scratch cache-layout with mechanism cost.
+- Benchmark isolates the differential mechanism cost (second Q/K extract + second GEMM + second softmax + subtract + sub-RMSNorm) at roughly **2x** a single-softmax baseline — observed in the ~1.9–2.1x band across the 2h-MHA / 4h-GQA / 8h-GQA shapes at seq_len 256, roughly flat across head counts. This is an unstabilized wall-clock microbenchmark with ±0.1x run-to-run variance, not a statistically rigorous measurement; treat it as an order-of-magnitude check, not a precise figure. The baseline has identical loop topology *and* identical per-pair scratch-slab layout, so the only working-set difference is the differential kernel's `scores2` slab — itself part of the mechanism. A comparison against the batched `apply_gqa_attention` would instead conflate kernel topology and scratch cache-layout with mechanism cost.
 
 **Negative**:
 

--- a/docs/adr/ADR-041-differential-attention.md
+++ b/docs/adr/ADR-041-differential-attention.md
@@ -1,0 +1,97 @@
+# ADR-041: Differential Attention
+
+**Status**: Accepted\
+**Date**: 2026-05-14\
+**Crate**: `lattice-inference`\
+**Extends**: ADR-010 (Attention Mechanisms)
+
+---
+
+## Context
+
+Differential attention, introduced in the Differential Transformer (Ye et al., Microsoft, ICLR 2025, arXiv:2410.05258), splits Q and K each into two halves along the head dimension, computes two independent causal softmax attention maps, and subtracts the second (scaled by a learnable `lambda_full`) from the first. The subtraction cancels the low-signal "attention-sink" mass that vanilla softmax attention accumulates on irrelevant tokens, producing sparser, more focused attention. The paper reports gains on long-context retrieval, hallucination reduction, and in-context learning.
+
+No model checkpoint currently loaded by Lattice uses differential attention — it is a distinct Transformer variant, not part of Qwen3 or BERT. (An earlier internal research note incorrectly claimed Qwen3 required it; the fact-check corrected this.) This ADR therefore adds differential attention as a **standalone module** with no model wiring, so it is available when a DIFF Transformer checkpoint becomes a target.
+
+An earlier research note also oversimplified the mechanism (scalar lambda, missing sub-layer norm, wrong V shape). The implementation here follows the **exact** reference algorithm from Microsoft's `unilm/Diff-Transformer/multihead_flashdiff_1.py`.
+
+---
+
+## Decision
+
+Implement differential attention as a **sixth attention module** at `src/attention/differential.rs`, following the `gqa.rs` convention: the core function takes Q/K/V already projected and with RoPE already applied; linear projections and RoPE are the caller's responsibility.
+
+Public surface:
+
+- **`DiffAttnConfig`** — `num_heads`, `num_kv_heads`, `head_dim`, `layer_depth`. Helper methods for `lambda_init()`, packed head counts, and buffer dimensions.
+- **`DiffLambdaParams`** — the four learnable reparameterization vectors (`lambda_q1/k1/q2/k2`, each `[head_dim]`).
+- **`compute_lambda_full()`** — `exp(lq1·lk1) - exp(lq2·lk2) + lambda_init`.
+- **`DiffAttnScratch`** — pre-allocated scratch buffers (follows `GqaScratch`).
+- **`apply_differential_attention()`** — the causal prefill kernel.
+
+---
+
+## Key Design Choices
+
+1. **Faithful to `multihead_flashdiff_1.py`, not the simplified note**: `lambda_full` is the reparameterized form `exp(lq1·lk1) - exp(lq2·lk2) + lambda_init` (dot products over `head_dim`), not a loaded scalar. `lambda_init = 0.8 - 0.6·exp(-0.3·depth)` is depth-scheduled. The subtracted result is **not** clamped or ReLU'd — negative attention weights are valid. A sub-layer RMSNorm over `2·head_dim` is applied after the value matmul and before the `(1 - lambda_init)` scale; the paper's ablation shows removing it degrades training stability.
+
+2. **V is not split**: Q and K are split into `2·num_heads` / `2·num_kv_heads` packed heads of `head_dim` each. V keeps `num_kv_heads` heads, but each head is `2·head_dim` wide. The split applies only to the query/key similarity computation, not the value projection.
+
+3. **Subtract scores, then one V matmul**: The reference computes `attn1 = softmax1 @ v` and `attn2 = softmax2 @ v` separately, then `attn1 - lambda_full·attn2`. The kernel instead computes `(softmax1 - lambda_full·softmax2) @ v` — a single V matmul. This is exactly equivalent by linearity of matrix multiplication and saves one GEMM per head pair.
+
+4. **GQA via post-split head mapping**: `multihead_flashdiff_1.py` *defines* a `repeat_kv` helper but does **not** call it — it splits Q/K into `q1/q2/k1/k2` first (with `num_heads` / `num_kv_heads` heads respectively), then passes them to `flash_attn_func`, which performs standard GQA grouping internally. The standard convention `kv_head = query_head // n_rep` therefore applies to the *post-split* logical heads. The kernel maps logical pair `h` to KV head `h / n_rep`, packed K heads `2·(h/n_rep)` and `2·(h/n_rep)+1`. This was verified against the Microsoft source — an earlier reading that assumed `repeat_kv` was applied to the pre-split `2·num_kv_heads` axis was wrong.
+
+5. **Additive `-10,000.0` causal mask**: Consistent with ADR-010 design choice #2 — avoids the NaN risk of `-inf` on fully-masked rows. The softmax loop only iterates the causal prefix, so masked positions are also explicitly zeroed.
+
+6. **Standalone, not wired into a model**: There is no checkpoint to load, so wiring differential attention into a forward pass would be speculative. The module is independently testable and benchmarkable; model integration is deferred until a concrete checkpoint target exists.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons | Why Not |
+|---|---|---|---|
+| Implement the simplified scalar-lambda version from the original research note | Less code | Diverges from the reference; would not load real DIFF Transformer weights; missing the load-bearing sub-layer norm | Correctness requires the faithful algorithm |
+| Wire differential attention into a model forward pass now | "Complete" feature | No checkpoint exists to validate against; speculative wiring | Defer until a checkpoint target is identified |
+| Two separate V matmuls (mirror the reference exactly) | Trivially matches reference structure | One extra GEMM per head pair for no numerical benefit | `(s1 - λ·s2) @ v` is exactly equivalent and cheaper |
+| `multihead_flashdiff_2.py` as the reference | Supports packages without custom qk/v dims | `flashdiff_1` is the "Recommended" reference and is simpler | `flashdiff_1` is canonical |
+
+---
+
+## Consequences
+
+**Positive**:
+
+- Differential attention is independently testable and benchmarkable (6 unit tests, 4 integration tests, dedicated benchmark).
+- When a DIFF Transformer checkpoint becomes a target, the math is already implemented and validated.
+- Benchmark shows the differential mechanism (second softmax + subtract + sub-RMSNorm) costs only ~4–11% over a same-sized plain GQA kernel.
+
+**Negative**:
+
+- Sixth attention module adds a sixth test suite to maintain.
+- The integration test's reference and the optimized kernel share the GQA head-mapping convention. The mapping was manually verified against the Microsoft source, but a fully independent oracle (e.g. tracked vectors from a PyTorch run of the actual reference) would be stronger. MHA cases (`n_rep = 1`) are unambiguous and independently meaningful.
+
+**Risks**:
+
+- No checkpoint validation: the implementation matches the *algorithm* in `multihead_flashdiff_1.py`, but has never been run against real trained DIFF Transformer weights. Weight-key naming, the exact RoPE variant (the reference uses `interleaved=True`), and projection layout conventions will need verification when a checkpoint is integrated.
+- The lambda reparameterization vectors must be loaded per-layer from a checkpoint; the current module accepts them as a caller-supplied struct but does not define a weight-loading path.
+
+---
+
+## References
+
+### Papers
+
+- Ye et al. (2025) — "Differential Transformer" — arXiv:2410.05258 — <https://arxiv.org/abs/2410.05258> — ICLR 2025. The mechanism, the depth-scheduled `lambda_init`, and the sub-layer-norm ablation.
+
+### Reference implementation
+
+- Microsoft `unilm` — `Diff-Transformer/multihead_flashdiff_1.py` — <https://github.com/microsoft/unilm/blob/master/Diff-Transformer/multihead_flashdiff_1.py>. The exact algorithm transcribed by this module: head splitting, `lambda_full` reparameterization, `subln`, `(1 - lambda_init)` scale, and the post-split GQA semantics (via `flash_attn_func`, not `repeat_kv`).
+
+### Internal
+
+- `src/attention/differential.rs` — `DiffAttnConfig`, `DiffLambdaParams`, `compute_lambda_full()`, `DiffAttnScratch`, `apply_differential_attention()`
+- `crates/inference/tests/differential_attention_test.rs` — naive reference oracle and parity test
+- `crates/inference/benches/differential_attention_bench.rs` — throughput and overhead-vs-GQA benchmark
+- ADR-010 — Attention Mechanisms (parent ADR for all attention variants)
+- ADR-040 — Gated Attention (sibling attention-mechanism ADR)

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -2,7 +2,7 @@
 
 Global ADR index for the Lattice project. Numbered sequentially, grouped by crate.
 
-## lattice-inference (ADR-001 to ADR-011, ADR-040+)
+## lattice-inference (ADR-001 to ADR-011, ADR-040 to ADR-041)
 
 | ADR                                            | Title                                |
 | ---------------------------------------------- | ------------------------------------ |
@@ -18,6 +18,7 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | [010](ADR-010-attention-mechanisms.md)         | Attention Mechanisms                 |
 | [011](ADR-011-sampling-strategies.md)          | Sampling Strategies                  |
 | [040](ADR-040-gated-attention.md)              | Gated Attention (G1 SDPA-Output)     |
+| [041](ADR-041-differential-attention.md)       | Differential Attention               |
 
 ## lattice-embed (ADR-012 to ADR-019)
 


### PR DESCRIPTION
## Summary

- Add differential attention (DIFF Transformer, Ye et al., ICLR 2025, arXiv:2410.05258) as a standalone `attention/differential.rs` module
- Faithful to Microsoft's reference `multihead_flashdiff_1.py` — not the simplified scalar-lambda version from the original research note
- Mechanism 2 of 3 in the bench-oriented attention-mechanism series (Mechanism 1, gated attention, merged in #4)

## What changed

**`attention/differential.rs`** — new module:
- `DiffAttnConfig` (num_heads, num_kv_heads, head_dim, layer_depth) with `lambda_init()` = `0.8 - 0.6·exp(-0.3·depth)`
- `DiffLambdaParams` + `compute_lambda_full()` = `exp(lq1·lk1) - exp(lq2·lk2) + lambda_init` (reparameterized, not a scalar; real `assert_eq!` on vector shapes)
- `apply_differential_attention()` — causal prefill kernel: dual softmax, subtract, sub-layer RMSNorm over `2·head_dim`, scale by `(1 - lambda_init)`; validates config (`num_heads`/`num_kv_heads`/`head_dim > 0` + divisibility) and lambda vectors against `cfg.head_dim` at entry
- 11 unit tests

**Correctness details verified against the Microsoft source:**
- V is **not** split — `num_kv_heads` heads, each `2·head_dim` wide
- No clamp on the subtracted result — negative weights are valid
- Sub-layer RMSNorm is load-bearing (paper ablation)
- GQA: `flashdiff_1` splits Q/K **first**, then `flash_attn_func` does standard `head // n_rep` grouping — `repeat_kv` is defined but never called. Kernel matches this.
- Kernel computes `(s1 - λ·s2) @ v` (one V matmul) — equivalent to the reference's `(s1@v) - λ·(s2@v)` by linearity, one GEMM cheaper

**Standalone** — no checkpoint uses differential attention yet, so it is not wired into any model forward pass. Pure addition, no refactor.

## Benchmark (Apple Silicon, seq=256)

| Config | throughput | mechanism overhead |
|---|---|---|
| 2h-MHA hd=8 | ~650 tok/ms | ~2.0x |
| 4h-GQA-2kv hd=16 | ~320 tok/ms | ~2.0x |
| 8h-GQA-2kv hd=32 | ~148 tok/ms | ~2.0x |

"Mechanism overhead" is measured against a **single-softmax baseline with the same per-pair loop topology *and* the same per-pair scratch-slab layout** as the differential kernel — isolating the cost of the second Q/K extract + second GEMM + second softmax + subtract + sub-RMSNorm. The only working-set difference is the differential kernel's `scores2` slab, which is itself part of the mechanism. (A comparison against the batched `apply_gqa_attention` would conflate kernel topology and scratch cache-layout with mechanism cost.)

The overhead sits in the **~1.9–2.1x band, roughly flat across head counts**. This is an unstabilized wall-clock microbenchmark with ±0.1x run-to-run variance — treat it as an order-of-magnitude check, not a precise figure. (The table values are rounded; throughput in particular drifts run to run.)

## Test plan

- [x] `cargo test -p lattice-inference --lib attention::differential` — 11/11 pass (incl. 5 config-guard `should_panic` tests)
- [x] `cargo test --test differential_attention_test` — 5/5 pass (naive reference oracle + GQA-vs-materialized-MHA independence check, within 1e-4 / bit-identical)
- [x] `cargo test -p lattice-inference --lib` — 345 pass, 7 ignored, 0 failed (no regressions)
- [x] `cargo clippy -p lattice-inference --lib --bench differential_attention_bench --test differential_attention_test -- -D warnings` — clean
- [x] `cargo fmt -p lattice-inference --check` — clean
- [x] `cargo bench --bench differential_attention_bench` — runs

## Known limitation

No checkpoint validation: the implementation matches the *algorithm*, but has never run against real trained DIFF Transformer weights. Weight-key naming, the RoPE variant, and projection layout will need verification when a checkpoint is integrated. See ADR-041 Risks.

## ADR

ADR-041 records the design — faithful-to-reference algorithm, the matmul simplification, the post-split GQA mapping, and the no-checkpoint-validation risk.

## Review fixes (round 1)

- Causal-mask tests strengthened: differential test (two inputs differing only in future V → out[pos 0] bit-identical) instead of a magnitude bound that RMSNorm would mask
- `compute_lambda_full`: real `assert_eq!` on vector shapes (was debug-only — `zip()` would silently truncate in release)
- `test_lambda_one_zeroes_identical_maps`: rewritten from a vacuous "output != 0" check to an exact invariant (identical maps + lambda_full≈1 → output ≈0)
- Benchmark: replaced the topology-conflating "vs batched GQA" comparison with a same-topology single-softmax baseline

## Review fixes (round 2)

- **Config validation**: `apply_differential_attention` computed `num_heads % num_kv_heads` before any `num_kv_heads > 0` check — a zero `num_kv_heads` hit a raw divide-by-zero panic, and `head_dim = 0` could proceed. Added explicit `num_heads`/`num_kv_heads`/`head_dim > 0` guards plus the divisibility check at function entry, *before* the buffer-length asserts (which collapse to vacuous when `q_dim()` etc. are 0). Three `should_panic` tests cover the guards.
- **Benchmark isolation**: the single-softmax baseline reused one `scores`/`context` buffer while the differential kernel indexes per-pair `scores1`/`scores2`/`context` slabs, so the reported overhead folded in scratch cache-layout differences. The baseline now mirrors the differential kernel's per-pair slab layout exactly (minus `scores2` — that second slab is the mechanism).
- **GQA mapping independence**: the naive reference shared the `pair_h / n_rep` derivation with the kernel, so it could not catch a shared grouping misunderstanding. Added `test_gqa_equals_materialized_mha` — a GQA run must produce bit-identical output to a pure-MHA run (`n_rep = 1`, no grouping logic in the compute path) whose KV heads are physically materialized in contiguous `repeat_kv` order via a hardcoded pair→KV table. The oracle decides grouping by explicit data placement, not the kernel's indexing formula. (A capture from the actual flash-attn reference is still stronger but needs CUDA hardware CI lacks.)

## Review fixes (round 3)

- **Benchmark claims corrected**: round 2's ADR/PR pinned `1.97x / 1.96x / 1.48x` and a "ratio shrinks at larger head counts" narrative — both wrong. The `1.48x` was an anomalous single sample; five reruns give a tight ~1.9–2.1x band, roughly flat (8h is consistently the *highest* on this machine, not the lowest). ADR and table now state the honest range and explicitly flag this as a noisy wall-clock microbenchmark, not a precise figure.
- **`DiffAttnConfig::n_rep()` hardened**: was `debug_assert!`-only, so a release caller of this public method could divide by zero (`num_kv_heads = 0`) or silently floor a non-divisible config. Now uses real `assert!`s, consistent with `compute_lambda_full` and the kernel entry guards. Two `should_panic` tests added.
- **ADR test counts corrected**: stale "6 unit / 4 integration" → actual "11 unit / 5 integration".

🤖 Generated with [Claude Code](https://claude.com/claude-code)