### PR TITLE
chore: bump workspace to v0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.1.1", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.1.2", path = "../inference", optional = true, features = ["f16"] }
 
 # Time
 chrono = { workspace = true }

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -23,7 +23,7 @@ inference-hook = ["dep:lattice-inference"]
 sqlite = ["dep:rusqlite", "serde"]
 
 [dependencies]
-lattice-fann = { version = "0.1.1", path = "../fann" }
+lattice-fann = { version = "0.1.2", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -44,7 +44,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook (optional — for LoRA adapter injection)
-lattice-inference = { version = "0.1.1", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.1.2", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"


### PR DESCRIPTION
## Summary

- Bumps all 5 crates from 0.1.1 → 0.1.2
- Covers: gated attention (ADR-040), differential attention (ADR-041), native sparse attention (ADR-042), LoRA serving CI tests + Qwen3.5-0.8B support (ADR-043), `partial_rotary_factor` parsing fix

## Changed files

- `Cargo.toml` — workspace version
- `crates/embed/Cargo.toml` — internal dep on `lattice-inference`
- `crates/tune/Cargo.toml` — internal deps on `lattice-fann` and `lattice-inference`

## Test plan

- [x] `cargo check --workspace` — all 5 crates resolve at 0.1.2
- [x] Pre-commit hooks pass (clippy + doc lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)