### PR TITLE
docs: agent-attribution policy + PR/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: A reproducible incorrect behavior in lattice
+title: ""
+labels: bug
+---
+
+<!--
+Attribution: if you are an AI agent filing this issue via someone's gh CLI,
+START the body with a blockquote attribution line per AGENTS.md. Example:
+
+> _Issue authored by Claude (Anthropic agent) on behalf of @<handle>._
+
+Delete this comment block for human-filed issues.
+-->
+
+## What happened
+
+<!-- Concrete observed behavior. Paste exact error output. -->
+
+## What you expected
+
+<!-- The behavior you expected and why. Link to docs/ADR if relevant. -->
+
+## Reproduction
+
+<!-- Smallest case that triggers the bug.
+     Include: crate version, host (arch, OS), feature flags, command. -->
+
+```rust
+// minimal repro
+```
+
+```text
+// exact command + output
+```
+
+## Environment
+
+- lattice crate(s) + version:
+- Rust version (`rustc --version`):
+- Host: `<os>` `<arch>` (e.g., `macOS 14.x aarch64`)
+- Feature flags used:
+
+## Additional context
+
+<!-- Logs, traces, related issues, prior debugging. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Read AGENTS.md first"
+    url: https://github.com/ohdearquant/lattice/blob/main/AGENTS.md
+    about: "Coding conventions, crate ownership, AI-assisted contribution policy. Read before filing."

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,42 @@
+---
+name: Feature request / design proposal
+about: Propose a new model, attention variant, quantization scheme, or capability
+title: ""
+labels: enhancement
+---
+
+<!--
+Attribution: if you are an AI agent filing this issue via someone's gh CLI,
+START the body with a blockquote attribution line per AGENTS.md. Example:
+
+> _Issue authored by Claude (Anthropic agent) on behalf of @<handle>._
+
+Delete this comment block for human-filed issues.
+-->
+
+## Problem
+
+<!-- What capability gap or pain point motivates this. Be concrete. -->
+
+## Proposal
+
+<!-- The smallest change that addresses the problem.
+     For architectural / interface changes, write the ADR draft inline or
+     link to a docs/adr/ADR-NNN draft in this issue. -->
+
+## Alternatives considered
+
+<!-- Other approaches and why this one wins. -->
+
+## Acceptance criteria
+
+<!-- Checklist a reviewer can use to decide "done": tests, benches, docs,
+     ADR landed, capability table updated, etc. -->
+
+- [ ]
+- [ ]
+- [ ]
+
+## Out of scope
+
+<!-- What this proposal intentionally does NOT cover (defer to follow-up). -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!--
+Attribution: if you are an AI agent authoring this PR description via someone's
+gh CLI session, START the body with a blockquote attribution line per AGENTS.md
+§AI-Assisted Contribution Policy. Example:
+
+> _PR description authored by Claude (Anthropic agent) on behalf of @<handle>._
+
+Human-authored PRs: delete this comment block.
+-->
+
+## Summary
+
+<!-- 1-3 bullets: what changed and why. Match the actual diff. -->
+
+## Test plan
+
+<!-- Concrete commands and outcomes. Tick boxes as they pass.
+     For performance-sensitive changes, include cargo bench output. -->
+
+- [ ] `cargo test --workspace`
+- [ ] `cargo clippy --workspace -- -D warnings`
+- [ ] `cargo fmt --all -- --check`
+
+## ADR
+
+<!-- If this PR introduces a significant feature or architectural change,
+     link to the ADR (docs/adr/ADR-NNN-*.md). Update docs/adr/INDEX.md in
+     the same PR. See docs/_templates/ADR_TEMPLATE.md.
+     For small fixes, write "n/a — small fix, no ADR." -->
+
+## AI-assisted contribution checklist
+
+<!-- Required if any part of this diff was AI-generated (code, tests, docs,
+     or this PR body). Delete the section if fully human-authored. -->
+
+- [ ] Every claim in this PR description matches the actual diff
+- [ ] SIMD intrinsics, if any, were manually verified — not just reviewed by an AI
+- [ ] Any agent-authored comment / PR body / issue starts with the attribution line from AGENTS.md
+- [ ] `cargo test` output included for any behavior-changing code; `cargo bench` output for perf-sensitive changes
+
+## Out of scope
+
+<!-- What this PR intentionally does NOT do, so reviewers can stop asking.
+     If part of a multi-PR series, note which step this is. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,17 @@ Pure Rust inference engine. Apache-2.0. github.com/ohdearquant/lattice
 - Every claim in a PR description must match the actual diff.
 - SIMD code requires manual verification — AI models cannot reason about intrinsic correctness.
 - Include `cargo test` and `cargo bench` output for performance-sensitive changes.
+- **Agent-authored GitHub content must be attributed.** When an AI agent (Claude, codex, etc.) authors a PR body, issue, or comment via a human's `gh` CLI session, the content must start with an attribution line so reviewers can distinguish agent-written prose from human-written prose. Required format:
+
+  ```
+  > _Comment authored by <Agent name> (<provider>) on behalf of @<github-handle>._
+  ```
+
+  Examples:
+  - `> _Comment authored by Claude (Anthropic agent) on behalf of @ohdearquant._`
+  - `> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._`
+
+  The attribution goes at the top of the body, in blockquote-italic form so it renders distinctly on GitHub. Co-authored-by trailers in commits are separate and still required per the commit-message convention.
 
 ## Common Rules
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant. Attribution per the policy this PR introduces._

## Summary

Adds a repo-wide convention for distinguishing agent-authored from human-authored GitHub content, plus the templates that scaffold it.

- `AGENTS.md` — new policy item under §AI-Assisted Contribution Policy: agent-authored PR bodies, issues, and comments must start with a blockquote attribution line.
- `.github/PULL_REQUEST_TEMPLATE.md` — new template with Summary / Test plan / ADR / AI-assisted checklist / Out-of-scope sections. Top-of-file HTML comment prompts agents to add the attribution line.
- `.github/ISSUE_TEMPLATE/bug_report.md` — repro + environment template, same attribution prompt.
- `.github/ISSUE_TEMPLATE/feature_request.md` — proposal + acceptance criteria template.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, links to AGENTS.md as the first-read resource.

## Required attribution format

```
> _<Body type> authored by <Agent name> (<provider>) on behalf of @<github-handle>._
```

Examples:
- `> _Comment authored by Claude (Anthropic agent) on behalf of @ohdearquant._`
- `> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._`

Blockquote-italic so it renders distinctly on GitHub. Goes at the top of the body. Co-authored-by trailers in commits are separate and still required per the commit-message convention.

## Why scaffold via templates

The AGENTS.md rule alone is a passive document. The templates make the prompt active — every new PR or issue surfaces the attribution-line instruction in an HTML comment at the top of the textarea, where an agent sees it before typing. This reduces the "I forgot to add the line" failure mode.

## Test plan

- [x] AGENTS.md change reviewable diff
- [x] This PR body follows the policy (attribution line at top)
- [x] PR template includes the AI-assisted checklist tied back to AGENTS.md
- [x] Issue templates render with the attribution prompt as a comment

## Why split from PR #15

This rule is repo-wide and unrelated to QuaRot Hadamard primitives. Originally landed in PR #15; review round 4 flagged scope contamination. Moved here as its own logical change.

## Out of scope

- Enforcement mechanism (e.g., CI check that flags PR bodies without an attribution line when the diff contains co-authored-by AI trailers). Could be a follow-up.
- Updating existing AI-authored issues/comments retroactively — only future content is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
