### PR TITLE
chore: bump workspace to v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.1.2", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.2.0", path = "../inference", optional = true, features = ["f16"] }
 
 # Time
 chrono = { workspace = true }

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -23,7 +23,7 @@ inference-hook = ["dep:lattice-inference"]
 sqlite = ["dep:rusqlite", "serde"]
 
 [dependencies]
-lattice-fann = { version = "0.1.2", path = "../fann" }
+lattice-fann = { version = "0.2.0", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -44,7 +44,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook (optional — for LoRA adapter injection)
-lattice-inference = { version = "0.1.2", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.2.0", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

- Bumps all 5 crates from 0.1.2 → 0.2.0 (next minor).
- Internal path-dep version pins updated to match.
- First minor release shipping QuaRot v0 (ADR-044 steps 1–4, PRs #15–#33).

## Test plan

- [x] `cargo build --release --workspace` — passes.
- [x] Pre-commit checks (cargo check + doc lint) — passes.
- [ ] `make publish-dry` — deferred to post-merge (requires clean git state).