### PR TITLE
feat(inference): QuaRot + LoRA counter-rotation & Metal kernel (ADR-045 steps 1+2)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -2013,6 +2013,60 @@ kernel void add_and_copy(
     residual[gid] = r;
     dst[gid] = r;
 }
+
+// ===== LoRA GEMV Phase 1: intermediate = A @ x (ADR-045 step 2) =====
+// A is row-major float32 [rank, K]. One threadgroup per rank-row.
+// 128 threads (4 simdgroups × 32), simd_sum reduction over K.
+// Dispatch: threadgroups=(rank, 1, 1), threads=(32, 4, 1)
+kernel void lora_gemv_a(
+    device const float* x       [[buffer(0)]],
+    device const float* A       [[buffer(1)]],
+    device float* intermediate  [[buffer(2)]],
+    constant uint& rank_val     [[buffer(3)]],
+    constant uint& K            [[buffer(4)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint  tiisg [[thread_index_in_simdgroup]],
+    uint  sgitg [[simdgroup_index_in_threadgroup]])
+{
+    uint r = tgpig.x;
+    if (r >= rank_val) return;
+
+    device const float* row = A + r * K;
+    float partial = 0.0f;
+    for (uint k = tiisg + sgitg * 32; k < K; k += 128) {
+        partial += row[k] * x[k];
+    }
+    partial = simd_sum(partial);
+
+    threadgroup float sg_sums[4];
+    if (tiisg == 0) sg_sums[sgitg] = partial;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (sgitg == 0 && tiisg == 0) {
+        intermediate[r] = sg_sums[0] + sg_sums[1] + sg_sums[2] + sg_sums[3];
+    }
+}
+
+// ===== LoRA GEMV Phase 2: y += scale * B @ intermediate (ADR-045 step 2) =====
+// B is row-major float32 [N, rank]. One thread per output element.
+// rank ≤ 64, so the inner loop is trivially short — no reduction needed.
+// Dispatch: threadgroups=(ceil(N/256), 1, 1), threads=(256, 1, 1)
+kernel void lora_gemv_b_accum(
+    device const float* intermediate  [[buffer(0)]],
+    device const float* B             [[buffer(1)]],
+    device float* y                   [[buffer(2)]],
+    constant uint& N                  [[buffer(3)]],
+    constant uint& rank_val           [[buffer(4)]],
+    constant float& scale             [[buffer(5)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= N) return;
+    device const float* row = B + gid * rank_val;
+    float sum = 0.0f;
+    for (uint j = 0; j < rank_val; j++) {
+        sum += row[j] * intermediate[j];
+    }
+    y[gid] += scale * sum;
+}
 "#;
 
     const MSL_Q4_TILED_SOURCE: &str = concat!(
@@ -2572,6 +2626,9 @@ kernel void add_and_copy(
         gdn_precompute_keys: Option<ComputePipelineState>,
         gdn_recurrence_sharded: Option<ComputePipelineState>,
         gdn_norm_silu: Option<ComputePipelineState>,
+        // ADR-045: LoRA GEMV kernels (always compiled, zero cost when unused)
+        lora_gemv_a: ComputePipelineState,
+        lora_gemv_b_accum: ComputePipelineState,
     }
 
     // -----------------------------------------------------------------------
@@ -3334,6 +3391,8 @@ kernel void add_and_copy(
                 topk_select50_merge: make_pipeline("logits_topk_select50_merge")?,
                 decode_attn_partial: make_pipeline("decode_attention_flash_partial")?,
                 decode_attn_reduce: make_pipeline("decode_attention_flash_reduce")?,
+                lora_gemv_a: make_pipeline("lora_gemv_a")?,
+                lora_gemv_b_accum: make_pipeline("lora_gemv_b_accum")?,
             };
 
             // Upload per-layer weights
@@ -7728,6 +7787,53 @@ kernel void add_and_copy(
             }
         }
 
+        /// Dispatch LoRA GEMV: y += scale * B @ (A @ x).
+        ///
+        /// Two-phase dispatch:
+        /// - Phase 1: intermediate[rank] = A[rank, K] @ x[K]
+        /// - Phase 2: y[N] += scale * B[N, rank] @ intermediate[rank]
+        ///
+        /// `intermediate_buf` must be at least `rank * 4` bytes.
+        #[allow(clippy::too_many_arguments)]
+        fn dispatch_lora_gemv(
+            &self,
+            enc: &ComputeCommandEncoderRef,
+            x: &Buffer,
+            a_buf: &Buffer,
+            b_buf: &Buffer,
+            y: &Buffer,
+            intermediate_buf: &Buffer,
+            rank: u32,
+            n: u32,
+            k: u32,
+            scale: f32,
+        ) {
+            // Phase 1: intermediate = A @ x
+            enc.set_compute_pipeline_state(&self.engine.pipelines.lora_gemv_a);
+            enc.set_buffer(0, Some(x), 0);
+            enc.set_buffer(1, Some(a_buf), 0);
+            enc.set_buffer(2, Some(intermediate_buf), 0);
+            enc.set_bytes(3, 4, &rank as *const u32 as *const _);
+            enc.set_bytes(4, 4, &k as *const u32 as *const _);
+            enc.dispatch_thread_groups(
+                MTLSize::new(rank as u64, 1, 1),
+                MTLSize::new(32, 4, 1), // 128 threads = 4 simdgroups
+            );
+
+            // Phase 2: y += scale * B @ intermediate
+            enc.set_compute_pipeline_state(&self.engine.pipelines.lora_gemv_b_accum);
+            enc.set_buffer(0, Some(intermediate_buf), 0);
+            enc.set_buffer(1, Some(b_buf), 0);
+            enc.set_buffer(2, Some(y), 0);
+            enc.set_bytes(3, 4, &n as *const u32 as *const _);
+            enc.set_bytes(4, 4, &rank as *const u32 as *const _);
+            enc.set_bytes(5, 4, &scale as *const f32 as *const _);
+            enc.dispatch_thread_groups(
+                MTLSize::new(n.div_ceil(256) as u64, 1, 1),
+                MTLSize::new(256, 1, 1),
+            );
+        }
+
         fn dispatch_rms_norm(
             &self,
             enc: &ComputeCommandEncoderRef,
@@ -9052,6 +9158,8 @@ kernel void add_and_copy(
                 topk_select50_merge: make_pipeline("logits_topk_select50_merge")?,
                 decode_attn_partial: make_pipeline("decode_attention_flash_partial")?,
                 decode_attn_reduce: make_pipeline("decode_attention_flash_reduce")?,
+                lora_gemv_a: make_pipeline("lora_gemv_a")?,
+                lora_gemv_b_accum: make_pipeline("lora_gemv_b_accum")?,
             };
 
             let hidden = cfg.hidden_size;
@@ -11375,6 +11483,127 @@ kernel void decode_attention_reference(
             );
             // Cleanup; ignore errors (the dir may have been removed by other tests).
             let _ = std::fs::remove_dir_all(&tmp);
+        }
+
+        #[test]
+        fn lora_gemv_kernel_matches_cpu_reference() {
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let rank: u32 = 16;
+            let k: u32 = 1024;
+            let n: u32 = 512;
+            let scale: f32 = 0.5;
+
+            // Synthetic data
+            let mut rng_state = 0xCAFE_BABE_u64;
+            let mut rand_f32 = || -> f32 {
+                rng_state = rng_state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                ((rng_state >> 11) as u32 as f32 / u32::MAX as f32) - 0.5
+            };
+            let x: Vec<f32> = (0..k).map(|_| rand_f32()).collect();
+            let a: Vec<f32> = (0..(rank * k)).map(|_| rand_f32()).collect();
+            let b: Vec<f32> = (0..(n * rank)).map(|_| rand_f32()).collect();
+            let mut y_init: Vec<f32> = (0..n).map(|_| rand_f32()).collect();
+
+            // CPU reference: y += scale * B @ (A @ x)
+            let mut intermediate_cpu = vec![0.0f32; rank as usize];
+            for r in 0..rank as usize {
+                let row = &a[r * k as usize..(r + 1) * k as usize];
+                intermediate_cpu[r] = row.iter().zip(x.iter()).map(|(a, b)| a * b).sum();
+            }
+            let mut y_expected = y_init.clone();
+            for i in 0..n as usize {
+                let row = &b[i * rank as usize..(i + 1) * rank as usize];
+                let dot: f32 = row
+                    .iter()
+                    .zip(intermediate_cpu.iter())
+                    .map(|(a, b)| a * b)
+                    .sum();
+                y_expected[i] += scale * dot;
+            }
+
+            // GPU execution
+            let opts = CompileOptions::new();
+            let library = device
+                .new_library_with_source(MSL_SOURCE, &opts)
+                .expect("MSL compile");
+            let pipeline_a = {
+                let f = library
+                    .get_function("lora_gemv_a", None)
+                    .expect("lora_gemv_a");
+                device
+                    .new_compute_pipeline_state_with_function(&f)
+                    .expect("pipeline lora_gemv_a")
+            };
+            let pipeline_b = {
+                let f = library
+                    .get_function("lora_gemv_b_accum", None)
+                    .expect("lora_gemv_b_accum");
+                device
+                    .new_compute_pipeline_state_with_function(&f)
+                    .expect("pipeline lora_gemv_b_accum")
+            };
+
+            let make_buf = |data: &[f32], label: &str| -> Buffer {
+                device.new_buffer_with_data(
+                    data.as_ptr() as *const _,
+                    (data.len() * 4) as u64,
+                    MTLResourceOptions::StorageModeShared,
+                )
+            };
+            let x_buf = make_buf(&x, "x");
+            let a_buf = make_buf(&a, "A");
+            let b_buf = make_buf(&b, "B");
+            let y_buf = make_buf(&y_init, "y");
+            let inter_buf =
+                device.new_buffer((rank as u64) * 4, MTLResourceOptions::StorageModeShared);
+
+            let queue = device.new_command_queue();
+            let cmd = queue.new_command_buffer();
+            let enc = cmd.new_compute_command_encoder();
+
+            // Phase 1
+            enc.set_compute_pipeline_state(&pipeline_a);
+            enc.set_buffer(0, Some(&x_buf), 0);
+            enc.set_buffer(1, Some(&a_buf), 0);
+            enc.set_buffer(2, Some(&inter_buf), 0);
+            enc.set_bytes(3, 4, &rank as *const u32 as *const _);
+            enc.set_bytes(4, 4, &k as *const u32 as *const _);
+            enc.dispatch_thread_groups(MTLSize::new(rank as u64, 1, 1), MTLSize::new(32, 4, 1));
+
+            // Phase 2
+            enc.set_compute_pipeline_state(&pipeline_b);
+            enc.set_buffer(0, Some(&inter_buf), 0);
+            enc.set_buffer(1, Some(&b_buf), 0);
+            enc.set_buffer(2, Some(&y_buf), 0);
+            enc.set_bytes(3, 4, &n as *const u32 as *const _);
+            enc.set_bytes(4, 4, &rank as *const u32 as *const _);
+            enc.set_bytes(5, 4, &scale as *const f32 as *const _);
+            enc.dispatch_thread_groups(
+                MTLSize::new(n.div_ceil(256) as u64, 1, 1),
+                MTLSize::new(256, 1, 1),
+            );
+
+            enc.end_encoding();
+            cmd.commit();
+            cmd.wait_until_completed();
+
+            // Read back and compare
+            let y_gpu: &[f32] =
+                unsafe { std::slice::from_raw_parts(y_buf.contents() as *const f32, n as usize) };
+
+            let max_diff = y_expected
+                .iter()
+                .zip(y_gpu.iter())
+                .map(|(e, g)| (e - g).abs())
+                .fold(0.0f32, f32::max);
+            assert!(
+                max_diff < 1e-3,
+                "LoRA GEMV GPU vs CPU diverged: max_abs_diff={max_diff}"
+            );
         }
     }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -7787,53 +7787,6 @@ kernel void lora_gemv_b_accum(
             }
         }
 
-        /// Dispatch LoRA GEMV: y += scale * B @ (A @ x).
-        ///
-        /// Two-phase dispatch:
-        /// - Phase 1: intermediate[rank] = A[rank, K] @ x[K]
-        /// - Phase 2: y[N] += scale * B[N, rank] @ intermediate[rank]
-        ///
-        /// `intermediate_buf` must be at least `rank * 4` bytes.
-        #[allow(clippy::too_many_arguments)]
-        fn dispatch_lora_gemv(
-            &self,
-            enc: &ComputeCommandEncoderRef,
-            x: &Buffer,
-            a_buf: &Buffer,
-            b_buf: &Buffer,
-            y: &Buffer,
-            intermediate_buf: &Buffer,
-            rank: u32,
-            n: u32,
-            k: u32,
-            scale: f32,
-        ) {
-            // Phase 1: intermediate = A @ x
-            enc.set_compute_pipeline_state(&self.engine.pipelines.lora_gemv_a);
-            enc.set_buffer(0, Some(x), 0);
-            enc.set_buffer(1, Some(a_buf), 0);
-            enc.set_buffer(2, Some(intermediate_buf), 0);
-            enc.set_bytes(3, 4, &rank as *const u32 as *const _);
-            enc.set_bytes(4, 4, &k as *const u32 as *const _);
-            enc.dispatch_thread_groups(
-                MTLSize::new(rank as u64, 1, 1),
-                MTLSize::new(32, 4, 1), // 128 threads = 4 simdgroups
-            );
-
-            // Phase 2: y += scale * B @ intermediate
-            enc.set_compute_pipeline_state(&self.engine.pipelines.lora_gemv_b_accum);
-            enc.set_buffer(0, Some(intermediate_buf), 0);
-            enc.set_buffer(1, Some(b_buf), 0);
-            enc.set_buffer(2, Some(y), 0);
-            enc.set_bytes(3, 4, &n as *const u32 as *const _);
-            enc.set_bytes(4, 4, &rank as *const u32 as *const _);
-            enc.set_bytes(5, 4, &scale as *const f32 as *const _);
-            enc.dispatch_thread_groups(
-                MTLSize::new(n.div_ceil(256) as u64, 1, 1),
-                MTLSize::new(256, 1, 1),
-            );
-        }
-
         fn dispatch_rms_norm(
             &self,
             enc: &ComputeCommandEncoderRef,
@@ -11506,7 +11459,7 @@ kernel void decode_attention_reference(
             let x: Vec<f32> = (0..k).map(|_| rand_f32()).collect();
             let a: Vec<f32> = (0..(rank * k)).map(|_| rand_f32()).collect();
             let b: Vec<f32> = (0..(n * rank)).map(|_| rand_f32()).collect();
-            let mut y_init: Vec<f32> = (0..n).map(|_| rand_f32()).collect();
+            let y_init: Vec<f32> = (0..n).map(|_| rand_f32()).collect();
 
             // CPU reference: y += scale * B @ (A @ x)
             let mut intermediate_cpu = vec![0.0f32; rank as usize];
@@ -11547,17 +11500,17 @@ kernel void decode_attention_reference(
                     .expect("pipeline lora_gemv_b_accum")
             };
 
-            let make_buf = |data: &[f32], label: &str| -> Buffer {
+            let make_buf = |data: &[f32]| -> Buffer {
                 device.new_buffer_with_data(
                     data.as_ptr() as *const _,
                     (data.len() * 4) as u64,
                     MTLResourceOptions::StorageModeShared,
                 )
             };
-            let x_buf = make_buf(&x, "x");
-            let a_buf = make_buf(&a, "A");
-            let b_buf = make_buf(&b, "B");
-            let y_buf = make_buf(&y_init, "y");
+            let x_buf = make_buf(&x);
+            let a_buf = make_buf(&a);
+            let b_buf = make_buf(&b);
+            let y_buf = make_buf(&y_init);
             let inter_buf =
                 device.new_buffer((rank as u64) * 4, MTLResourceOptions::StorageModeShared);
 

--- a/crates/inference/src/quant/quarot/lora.rs
+++ b/crates/inference/src/quant/quarot/lora.rs
@@ -110,12 +110,19 @@ impl RotationReport {
 
 /// A single LoRA layer's mutable references for rotation correction.
 pub struct LoraLayerMut<'a> {
+    /// Transformer layer index (0-based).
     pub layer_idx: usize,
+    /// Projection module name (e.g., `"q_proj"`, `"o_proj"`).
     pub module: &'a str,
+    /// A matrix, row-major `(rank × d_in)`. Modified for input-side modules.
     pub a: &'a mut [f32],
+    /// B matrix, row-major `(d_out × rank)`. Modified for output-side modules.
     pub b: &'a mut [f32],
+    /// LoRA rank (inner dimension).
     pub rank: usize,
+    /// Input dimension of the base projection.
     pub d_in: usize,
+    /// Output dimension of the base projection.
     pub d_out: usize,
 }
 

--- a/crates/inference/src/quant/quarot/lora.rs
+++ b/crates/inference/src/quant/quarot/lora.rs
@@ -1,0 +1,367 @@
+//! Counter-rotation for LoRA adapters on QuaRot-converted models (ADR-045).
+//!
+//! When a LoRA adapter trained on an unrotated model is applied to a
+//! QuaRot-converted base, the adapter's A matrices see the rotated
+//! activation `R · h` instead of `h`. The fix is exact: replace A with
+//! `A_cr = A · R^T` at adapter load time. Then at runtime:
+//!
+//! ```text
+//! s · B · A_cr · (R · h) = s · B · (A · R^T) · (R · h) = s · B · A · h  ✓
+//! ```
+//!
+//! The correction is absorbed once (microseconds) and adds zero runtime cost.
+
+use crate::error::InferenceError;
+use crate::quant::quarot::hadamard::RandomizedHadamard;
+use crate::quant::quarot::plan::{AbsorptionSide, RotationPlan};
+use crate::quant::quarot::rotation::absorb_input_rotation;
+
+/// Counter-rotate a single LoRA A matrix for a QuaRot-converted base.
+///
+/// Computes `A_cr = A · R^T` in-place, where A is row-major `(rank × d_in)`.
+///
+/// Mathematically identical to input-side absorption: applying R to each row
+/// of A yields `A · R^T` (see `rotation.rs` §Implementation for the proof).
+///
+/// # Errors
+///
+/// Returns an error if `a.len() != rank * d_in` or `rotation.dim() != d_in`.
+pub fn counter_rotate_a(
+    a: &mut [f32],
+    rank: usize,
+    d_in: usize,
+    rotation: &RandomizedHadamard,
+) -> Result<(), InferenceError> {
+    absorb_input_rotation(a, rank, d_in, rotation)
+}
+
+/// Returns `true` if a LoRA module's A matrix needs counter-rotation.
+///
+/// A module needs counter-rotation iff the base weight was absorbed on the
+/// input side (`W ← W · R^T`), because the adapter's A matrix then receives
+/// the rotated activation `R · h` instead of `h`.
+///
+/// Output-side projections (o_proj, down_proj, out_proj) do NOT need
+/// counter-rotation — their A matrices receive internal state that is
+/// unaffected by the residual-stream rotation.
+pub fn needs_counter_rotation(plan: &RotationPlan, module: &str) -> bool {
+    matches!(
+        plan.absorption_for_module(module),
+        Some(AbsorptionSide::InputSide)
+    )
+}
+
+/// Summary of a counter-rotation pass over an adapter's A matrices.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CounterRotationReport {
+    /// (layer_idx, module) pairs that were counter-rotated.
+    pub rotated: Vec<(usize, String)>,
+    /// (layer_idx, module) pairs skipped (output-side or not in plan).
+    pub skipped: Vec<(usize, String)>,
+}
+
+/// Counter-rotate all A matrices in an adapter that target input-side projections.
+///
+/// Iterates over `layers` (each entry is `(layer_idx, module_name, a_matrix, rank, d_in)`)
+/// and applies `A_cr = A · R^T` to those where the plan indicates input-side absorption.
+///
+/// This is the batch primitive. Callers holding a `LoraAdapter` (in `lattice-tune`)
+/// should extract their layers into this format and call this function.
+///
+/// # Arguments
+///
+/// * `layers` — mutable iterator of `(layer_idx, module, &mut a, rank, d_in)`
+/// * `seed` — QuaRot seed (from the `.q4` artifact's `config.json`)
+/// * `hidden_dim` — hidden dimension (must be power of two; determines R's size)
+/// * `plan` — rotation plan identifying which modules are input-side
+///
+/// # Errors
+///
+/// Returns an error if `hidden_dim` is not a valid Hadamard dimension or if
+/// any A matrix has inconsistent dimensions.
+pub fn counter_rotate_layers<'a, I>(
+    layers: I,
+    seed: u64,
+    hidden_dim: usize,
+    plan: &RotationPlan,
+) -> Result<CounterRotationReport, InferenceError>
+where
+    I: IntoIterator<Item = (usize, &'a str, &'a mut [f32], usize, usize)>,
+{
+    let rotation = RandomizedHadamard::new(seed, hidden_dim)?;
+    let mut report = CounterRotationReport {
+        rotated: Vec::new(),
+        skipped: Vec::new(),
+    };
+
+    for (layer_idx, module, a, rank, d_in) in layers {
+        if needs_counter_rotation(plan, module) {
+            if d_in != hidden_dim {
+                return Err(InferenceError::Inference(format!(
+                    "counter_rotate_layers: layer {layer_idx} module '{module}' has d_in={d_in} \
+                     but hidden_dim={hidden_dim}"
+                )));
+            }
+            counter_rotate_a(a, rank, d_in, &rotation)?;
+            report.rotated.push((layer_idx, module.to_string()));
+        } else {
+            report.skipped.push((layer_idx, module.to_string()));
+        }
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthetic_vector(len: usize, seed: u64) -> Vec<f32> {
+        let mut state = seed;
+        (0..len)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                let bits = (state >> 11) as u32;
+                (bits as f32 / u32::MAX as f32) - 0.5
+            })
+            .collect()
+    }
+
+    fn matvec(mat: &[f32], rows: usize, cols: usize, x: &[f32]) -> Vec<f32> {
+        assert_eq!(x.len(), cols);
+        (0..rows)
+            .map(|r| {
+                mat[r * cols..(r + 1) * cols]
+                    .iter()
+                    .zip(x.iter())
+                    .map(|(a, b)| a * b)
+                    .sum()
+            })
+            .collect()
+    }
+
+    fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+        a.iter()
+            .zip(b.iter())
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0_f32, f32::max)
+    }
+
+    #[test]
+    fn counter_rotation_correctness() {
+        // Validates: B · (A · R^T) · (R · h) == B · A · h
+        let d_in = 64; // hidden_dim (power of two)
+        let d_out = 32;
+        let rank = 8;
+        let seed = 0xC0FFEE_u64;
+
+        let r = RandomizedHadamard::new(seed, d_in).unwrap();
+        let a = synthetic_vector(rank * d_in, 1);
+        let b = synthetic_vector(d_out * rank, 2);
+        let h = synthetic_vector(d_in, 3);
+
+        // Original: B · (A · h)
+        let a_h = matvec(&a, rank, d_in, &h);
+        let original = matvec(&b, d_out, rank, &a_h);
+
+        // Counter-rotated path: B · (A_cr · (R · h))
+        let mut a_cr = a.clone();
+        counter_rotate_a(&mut a_cr, rank, d_in, &r).unwrap();
+        let mut h_rot = h.clone();
+        r.apply(&mut h_rot).unwrap();
+        let a_cr_rh = matvec(&a_cr, rank, d_in, &h_rot);
+        let counter_rotated = matvec(&b, d_out, rank, &a_cr_rh);
+
+        let delta = max_abs_diff(&original, &counter_rotated);
+        assert!(
+            delta < 1e-4,
+            "B·A_cr·(R·h) should equal B·A·h: max_abs_diff={delta}"
+        );
+    }
+
+    #[test]
+    fn counter_rotation_naive_is_wrong() {
+        // Without counter-rotation, B · A · (R · h) ≠ B · A · h
+        let d_in = 64;
+        let d_out = 16;
+        let rank = 4;
+        let seed = 42_u64;
+
+        let r = RandomizedHadamard::new(seed, d_in).unwrap();
+        let a = synthetic_vector(rank * d_in, 10);
+        let b = synthetic_vector(d_out * rank, 11);
+        let h = synthetic_vector(d_in, 12);
+
+        // Original: B · A · h
+        let a_h = matvec(&a, rank, d_in, &h);
+        let original = matvec(&b, d_out, rank, &a_h);
+
+        // Naive (no counter-rotation): B · A · (R · h)
+        let mut h_rot = h.clone();
+        r.apply(&mut h_rot).unwrap();
+        let a_rh = matvec(&a, rank, d_in, &h_rot);
+        let naive = matvec(&b, d_out, rank, &a_rh);
+
+        let delta = max_abs_diff(&original, &naive);
+        assert!(
+            delta > 0.1,
+            "without counter-rotation the error should be large: max_abs_diff={delta}"
+        );
+    }
+
+    #[test]
+    fn counter_rotation_is_exact_for_orthogonal_r() {
+        // R^T · R = I, so the correction is exact (not approximate)
+        let d_in = 128;
+        let rank = 16;
+        let seed = 0xDEAD_BEEF_u64;
+
+        let r = RandomizedHadamard::new(seed, d_in).unwrap();
+        let a = synthetic_vector(rank * d_in, 20);
+        let h = synthetic_vector(d_in, 21);
+
+        // A · h
+        let a_h = matvec(&a, rank, d_in, &h);
+
+        // A_cr · (R · h) = (A · R^T) · (R · h) should equal A · (R^T · R · h) = A · h
+        let mut a_cr = a.clone();
+        counter_rotate_a(&mut a_cr, rank, d_in, &r).unwrap();
+        let mut h_rot = h.clone();
+        r.apply(&mut h_rot).unwrap();
+        let a_cr_rh = matvec(&a_cr, rank, d_in, &h_rot);
+
+        let delta = max_abs_diff(&a_h, &a_cr_rh);
+        assert!(
+            delta < 5e-4,
+            "A_cr·(R·h) should exactly equal A·h (orthogonal R): max_abs_diff={delta}"
+        );
+    }
+
+    #[test]
+    fn needs_counter_rotation_input_side_modules() {
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+        let input_side = [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "gate_proj",
+            "up_proj",
+            "in_proj_qkv",
+            "in_proj_z",
+            "in_proj_b",
+            "in_proj_a",
+        ];
+        for module in input_side {
+            assert!(
+                needs_counter_rotation(&plan, module),
+                "{module} should need counter-rotation (input-side)"
+            );
+        }
+    }
+
+    #[test]
+    fn needs_counter_rotation_output_side_modules() {
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+        let output_side = ["o_proj", "down_proj", "out_proj"];
+        for module in output_side {
+            assert!(
+                !needs_counter_rotation(&plan, module),
+                "{module} should NOT need counter-rotation (output-side)"
+            );
+        }
+    }
+
+    #[test]
+    fn needs_counter_rotation_unknown_module() {
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+        assert!(!needs_counter_rotation(&plan, "some_random_proj"));
+        assert!(!needs_counter_rotation(&plan, "conv1d"));
+    }
+
+    #[test]
+    fn counter_rotate_layers_batch() {
+        let d_in = 64;
+        let rank = 4;
+        let seed = 7_u64;
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+
+        let mut a_q = synthetic_vector(rank * d_in, 100);
+        let mut a_o = synthetic_vector(rank * d_in, 101);
+        let mut a_gate = synthetic_vector(rank * d_in, 102);
+        let mut a_down = synthetic_vector(rank * d_in, 103);
+
+        let a_q_orig = a_q.clone();
+        let a_o_orig = a_o.clone();
+        let a_gate_orig = a_gate.clone();
+        let a_down_orig = a_down.clone();
+
+        let layers: Vec<(usize, &str, &mut [f32], usize, usize)> = vec![
+            (0, "q_proj", a_q.as_mut_slice(), rank, d_in),
+            (0, "o_proj", a_o.as_mut_slice(), rank, d_in),
+            (1, "gate_proj", a_gate.as_mut_slice(), rank, d_in),
+            (1, "down_proj", a_down.as_mut_slice(), rank, d_in),
+        ];
+
+        let report = counter_rotate_layers(layers, seed, d_in, &plan).unwrap();
+
+        assert_eq!(report.rotated.len(), 2);
+        assert_eq!(report.skipped.len(), 2);
+        assert!(report.rotated.contains(&(0, "q_proj".into())));
+        assert!(report.rotated.contains(&(1, "gate_proj".into())));
+        assert!(report.skipped.contains(&(0, "o_proj".into())));
+        assert!(report.skipped.contains(&(1, "down_proj".into())));
+
+        // Input-side modules were modified
+        assert_ne!(a_q, a_q_orig);
+        assert_ne!(a_gate, a_gate_orig);
+        // Output-side modules were NOT modified
+        assert_eq!(a_o, a_o_orig);
+        assert_eq!(a_down, a_down_orig);
+    }
+
+    #[test]
+    fn counter_rotate_layers_dimension_mismatch_rejected() {
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+        let mut a = synthetic_vector(4 * 32, 200);
+
+        let layers: Vec<(usize, &str, &mut [f32], usize, usize)> =
+            vec![(0, "q_proj", a.as_mut_slice(), 4, 32)]; // d_in=32 but hidden_dim=64
+
+        let result = counter_rotate_layers(layers, 7, 64, &plan);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn counter_rotation_deterministic_across_calls() {
+        let d_in = 64;
+        let rank = 8;
+        let seed = 99_u64;
+        let a = synthetic_vector(rank * d_in, 300);
+
+        let r = RandomizedHadamard::new(seed, d_in).unwrap();
+        let mut a1 = a.clone();
+        let mut a2 = a.clone();
+        counter_rotate_a(&mut a1, rank, d_in, &r).unwrap();
+        counter_rotate_a(&mut a2, rank, d_in, &r).unwrap();
+
+        assert_eq!(a1, a2, "same seed must produce identical counter-rotation");
+    }
+
+    #[test]
+    fn counter_rotation_different_seeds_differ() {
+        let d_in = 64;
+        let rank = 8;
+        let a = synthetic_vector(rank * d_in, 400);
+
+        let r1 = RandomizedHadamard::new(1, d_in).unwrap();
+        let r2 = RandomizedHadamard::new(2, d_in).unwrap();
+        let mut a1 = a.clone();
+        let mut a2 = a.clone();
+        counter_rotate_a(&mut a1, rank, d_in, &r1).unwrap();
+        counter_rotate_a(&mut a2, rank, d_in, &r2).unwrap();
+
+        assert_ne!(a1, a2, "different seeds should produce different rotations");
+    }
+}

--- a/crates/inference/src/quant/quarot/lora.rs
+++ b/crates/inference/src/quant/quarot/lora.rs
@@ -81,8 +81,6 @@ pub enum LoraRotationApplied {
     CounterRotatedA,
     /// B was rotated: `B ← R · B` (output-side projection)
     RotatedB,
-    /// Module not in plan — no rotation applied.
-    NotInPlan,
 }
 
 /// Summary of a rotation pass over an adapter's matrices.
@@ -108,14 +106,6 @@ impl RotationReport {
             .filter(|(_, _, r)| *r == LoraRotationApplied::RotatedB)
             .count()
     }
-
-    /// Number of layers not in plan (no rotation applied).
-    pub fn num_not_in_plan(&self) -> usize {
-        self.entries
-            .iter()
-            .filter(|(_, _, r)| *r == LoraRotationApplied::NotInPlan)
-            .count()
-    }
 }
 
 /// A single LoRA layer's mutable references for rotation correction.
@@ -134,7 +124,8 @@ pub struct LoraLayerMut<'a> {
 /// For each layer:
 /// - **Input-side** module: `A ← A · R^T` (counter-rotate A)
 /// - **Output-side** module: `B ← R · B` (rotate B into residual basis)
-/// - **Not in plan**: no modification
+/// - **Not in plan**: **ERROR** — refuses unknown targets to prevent silent
+///   basis-composition failures on QuaRot bases
 ///
 /// # Arguments
 ///
@@ -145,8 +136,10 @@ pub struct LoraLayerMut<'a> {
 ///
 /// # Errors
 ///
-/// Returns an error if `hidden_dim` is not a valid Hadamard dimension or if
-/// any matrix has inconsistent dimensions with the rotation.
+/// Returns an error if:
+/// - `hidden_dim` is not a valid Hadamard dimension
+/// - Any matrix has inconsistent dimensions with the rotation
+/// - Any module is not in the plan (fail-closed: unknown targets are rejected)
 pub fn rotate_adapter_for_quarot(
     layers: Vec<LoraLayerMut<'_>>,
     seed: u64,
@@ -191,11 +184,13 @@ pub fn rotate_adapter_for_quarot(
                 ));
             }
             None => {
-                report.entries.push((
-                    layer.layer_idx,
-                    layer.module.to_string(),
-                    LoraRotationApplied::NotInPlan,
-                ));
+                return Err(InferenceError::Inference(format!(
+                    "rotate_adapter_for_quarot: layer {} targets module '{}' which is \
+                     not in the rotation plan. On a QuaRot base, unknown adapter targets \
+                     risk silent basis-composition failures. Check module name spelling \
+                     or update the plan.",
+                    layer.layer_idx, layer.module
+                )));
             }
         }
     }
@@ -459,7 +454,6 @@ mod tests {
 
         assert_eq!(report.num_a_rotated(), 1);
         assert_eq!(report.num_b_rotated(), 1);
-        assert_eq!(report.num_not_in_plan(), 0);
 
         // q_proj: A was modified, B was NOT
         assert_ne!(a_q, a_q_orig);
@@ -470,7 +464,7 @@ mod tests {
     }
 
     #[test]
-    fn rotate_adapter_unknown_module_is_not_in_plan() {
+    fn rotate_adapter_unknown_module_rejected() {
         let hidden_dim = 64;
         let rank = 4;
         let seed = 7_u64;
@@ -478,8 +472,6 @@ mod tests {
 
         let mut a = synthetic_vector(rank * hidden_dim, 200);
         let mut b = synthetic_vector(hidden_dim * rank, 201);
-        let a_orig = a.clone();
-        let b_orig = b.clone();
 
         let layers = vec![LoraLayerMut {
             layer_idx: 0,
@@ -491,10 +483,39 @@ mod tests {
             d_out: hidden_dim,
         }];
 
-        let report = rotate_adapter_for_quarot(layers, seed, hidden_dim, &plan).unwrap();
-        assert_eq!(report.num_not_in_plan(), 1);
-        assert_eq!(a, a_orig);
-        assert_eq!(b, b_orig);
+        let err = rotate_adapter_for_quarot(layers, seed, hidden_dim, &plan).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("conv1d") && msg.contains("not in the rotation plan"),
+            "should reject unknown module: {msg}"
+        );
+    }
+
+    #[test]
+    fn rotate_adapter_misspelled_target_rejected() {
+        let hidden_dim = 64;
+        let rank = 4;
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+
+        let mut a = synthetic_vector(rank * hidden_dim, 210);
+        let mut b = synthetic_vector(hidden_dim * rank, 211);
+
+        let layers = vec![LoraLayerMut {
+            layer_idx: 3,
+            module: "qproj", // misspelled — should be "q_proj"
+            a: a.as_mut_slice(),
+            b: b.as_mut_slice(),
+            rank,
+            d_in: hidden_dim,
+            d_out: hidden_dim,
+        }];
+
+        let err = rotate_adapter_for_quarot(layers, 7, hidden_dim, &plan).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("qproj") && msg.contains("not in the rotation plan"),
+            "should reject misspelled module: {msg}"
+        );
     }
 
     #[test]

--- a/crates/inference/src/quant/quarot/lora.rs
+++ b/crates/inference/src/quant/quarot/lora.rs
@@ -1,27 +1,30 @@
-//! Counter-rotation for LoRA adapters on QuaRot-converted models (ADR-045).
+//! Rotation correction for LoRA adapters on QuaRot-converted models (ADR-045).
 //!
 //! When a LoRA adapter trained on an unrotated model is applied to a
-//! QuaRot-converted base, the adapter's A matrices see the rotated
-//! activation `R · h` instead of `h`. The fix is exact: replace A with
-//! `A_cr = A · R^T` at adapter load time. Then at runtime:
+//! QuaRot-converted base, both A and B matrices may need rotation correction
+//! depending on the base projection's absorption side:
 //!
-//! ```text
-//! s · B · A_cr · (R · h) = s · B · (A · R^T) · (R · h) = s · B · A · h  ✓
-//! ```
+//! **Input-side projections** (q/k/v_proj, gate/up_proj, in_proj_*):
+//! The base weight absorbed `W ← W · R^T`, so the input activation is `R · h`.
+//! Fix: `A_cr = A · R^T`. Then `B · A_cr · (R·h) = B · A · h` ✓
 //!
-//! The correction is absorbed once (microseconds) and adds zero runtime cost.
+//! **Output-side projections** (o_proj, down_proj, out_proj):
+//! The base weight absorbed `W ← R · W`, so its output is in the rotated basis.
+//! The LoRA delta must also be in the rotated basis.
+//! Fix: `B_rot = R · B`. Then `B_rot · A · x = R · (B · A · x)` ✓
+//!
+//! Both corrections are exact (R is orthogonal) and absorbed at load time — zero
+//! runtime cost.
 
 use crate::error::InferenceError;
 use crate::quant::quarot::hadamard::RandomizedHadamard;
 use crate::quant::quarot::plan::{AbsorptionSide, RotationPlan};
-use crate::quant::quarot::rotation::absorb_input_rotation;
+use crate::quant::quarot::rotation::{absorb_input_rotation, absorb_output_rotation};
 
-/// Counter-rotate a single LoRA A matrix for a QuaRot-converted base.
+/// Counter-rotate a single LoRA A matrix for an input-side QuaRot projection.
 ///
 /// Computes `A_cr = A · R^T` in-place, where A is row-major `(rank × d_in)`.
-///
-/// Mathematically identical to input-side absorption: applying R to each row
-/// of A yields `A · R^T` (see `rotation.rs` §Implementation for the proof).
+/// Applies R to each row — mathematically identical to input-side absorption.
 ///
 /// # Errors
 ///
@@ -35,15 +38,27 @@ pub fn counter_rotate_a(
     absorb_input_rotation(a, rank, d_in, rotation)
 }
 
-/// Returns `true` if a LoRA module's A matrix needs counter-rotation.
+/// Rotate a single LoRA B matrix for an output-side QuaRot projection.
 ///
-/// A module needs counter-rotation iff the base weight was absorbed on the
-/// input side (`W ← W · R^T`), because the adapter's A matrix then receives
-/// the rotated activation `R · h` instead of `h`.
+/// Computes `B_rot = R · B` in-place, where B is row-major `(d_out × rank)`.
+/// Applies R to each column — mathematically identical to output-side absorption.
 ///
-/// Output-side projections (o_proj, down_proj, out_proj) do NOT need
-/// counter-rotation — their A matrices receive internal state that is
-/// unaffected by the residual-stream rotation.
+/// After this, the LoRA delta `B_rot · A · x = R · (B · A · x)` is in the
+/// rotated residual basis, matching the base projection's rotated output.
+///
+/// # Errors
+///
+/// Returns an error if `b.len() != d_out * rank` or `rotation.dim() != d_out`.
+pub fn rotate_b_output_side(
+    b: &mut [f32],
+    d_out: usize,
+    rank: usize,
+    rotation: &RandomizedHadamard,
+) -> Result<(), InferenceError> {
+    absorb_output_rotation(b, d_out, rank, rotation)
+}
+
+/// Returns `true` if a LoRA module's A matrix needs counter-rotation (input-side).
 pub fn needs_counter_rotation(plan: &RotationPlan, module: &str) -> bool {
     matches!(
         plan.absorption_for_module(module),
@@ -51,61 +66,137 @@ pub fn needs_counter_rotation(plan: &RotationPlan, module: &str) -> bool {
     )
 }
 
-/// Summary of a counter-rotation pass over an adapter's A matrices.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CounterRotationReport {
-    /// (layer_idx, module) pairs that were counter-rotated.
-    pub rotated: Vec<(usize, String)>,
-    /// (layer_idx, module) pairs skipped (output-side or not in plan).
-    pub skipped: Vec<(usize, String)>,
+/// Returns `true` if a LoRA module's B matrix needs output-side rotation.
+pub fn needs_b_rotation(plan: &RotationPlan, module: &str) -> bool {
+    matches!(
+        plan.absorption_for_module(module),
+        Some(AbsorptionSide::OutputSide)
+    )
 }
 
-/// Counter-rotate all A matrices in an adapter that target input-side projections.
+/// What rotation was applied to a LoRA layer's matrices.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoraRotationApplied {
+    /// A was counter-rotated: `A ← A · R^T` (input-side projection)
+    CounterRotatedA,
+    /// B was rotated: `B ← R · B` (output-side projection)
+    RotatedB,
+    /// Module not in plan — no rotation applied.
+    NotInPlan,
+}
+
+/// Summary of a rotation pass over an adapter's matrices.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RotationReport {
+    /// (layer_idx, module, what_was_applied) for each processed layer.
+    pub entries: Vec<(usize, String, LoraRotationApplied)>,
+}
+
+impl RotationReport {
+    /// Number of layers where A was counter-rotated (input-side).
+    pub fn num_a_rotated(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|(_, _, r)| *r == LoraRotationApplied::CounterRotatedA)
+            .count()
+    }
+
+    /// Number of layers where B was rotated (output-side).
+    pub fn num_b_rotated(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|(_, _, r)| *r == LoraRotationApplied::RotatedB)
+            .count()
+    }
+
+    /// Number of layers not in plan (no rotation applied).
+    pub fn num_not_in_plan(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|(_, _, r)| *r == LoraRotationApplied::NotInPlan)
+            .count()
+    }
+}
+
+/// A single LoRA layer's mutable references for rotation correction.
+pub struct LoraLayerMut<'a> {
+    pub layer_idx: usize,
+    pub module: &'a str,
+    pub a: &'a mut [f32],
+    pub b: &'a mut [f32],
+    pub rank: usize,
+    pub d_in: usize,
+    pub d_out: usize,
+}
+
+/// Apply rotation corrections to all LoRA layers for a QuaRot-converted base.
 ///
-/// Iterates over `layers` (each entry is `(layer_idx, module_name, a_matrix, rank, d_in)`)
-/// and applies `A_cr = A · R^T` to those where the plan indicates input-side absorption.
-///
-/// This is the batch primitive. Callers holding a `LoraAdapter` (in `lattice-tune`)
-/// should extract their layers into this format and call this function.
+/// For each layer:
+/// - **Input-side** module: `A ← A · R^T` (counter-rotate A)
+/// - **Output-side** module: `B ← R · B` (rotate B into residual basis)
+/// - **Not in plan**: no modification
 ///
 /// # Arguments
 ///
-/// * `layers` — mutable iterator of `(layer_idx, module, &mut a, rank, d_in)`
-/// * `seed` — QuaRot seed (from the `.q4` artifact's `config.json`)
+/// * `layers` — mutable references to each LoRA layer's A and B matrices
+/// * `seed` — QuaRot seed (from the `.q4` artifact metadata)
 /// * `hidden_dim` — hidden dimension (must be power of two; determines R's size)
-/// * `plan` — rotation plan identifying which modules are input-side
+/// * `plan` — rotation plan identifying absorption side per module
 ///
 /// # Errors
 ///
 /// Returns an error if `hidden_dim` is not a valid Hadamard dimension or if
-/// any A matrix has inconsistent dimensions.
-pub fn counter_rotate_layers<'a, I>(
-    layers: I,
+/// any matrix has inconsistent dimensions with the rotation.
+pub fn rotate_adapter_for_quarot(
+    layers: Vec<LoraLayerMut<'_>>,
     seed: u64,
     hidden_dim: usize,
     plan: &RotationPlan,
-) -> Result<CounterRotationReport, InferenceError>
-where
-    I: IntoIterator<Item = (usize, &'a str, &'a mut [f32], usize, usize)>,
-{
+) -> Result<RotationReport, InferenceError> {
     let rotation = RandomizedHadamard::new(seed, hidden_dim)?;
-    let mut report = CounterRotationReport {
-        rotated: Vec::new(),
-        skipped: Vec::new(),
+    let mut report = RotationReport {
+        entries: Vec::with_capacity(layers.len()),
     };
 
-    for (layer_idx, module, a, rank, d_in) in layers {
-        if needs_counter_rotation(plan, module) {
-            if d_in != hidden_dim {
-                return Err(InferenceError::Inference(format!(
-                    "counter_rotate_layers: layer {layer_idx} module '{module}' has d_in={d_in} \
-                     but hidden_dim={hidden_dim}"
-                )));
+    for layer in layers {
+        match plan.absorption_for_module(layer.module) {
+            Some(AbsorptionSide::InputSide) => {
+                if layer.d_in != hidden_dim {
+                    return Err(InferenceError::Inference(format!(
+                        "rotate_adapter_for_quarot: layer {} module '{}' has d_in={} \
+                         but hidden_dim={hidden_dim}",
+                        layer.layer_idx, layer.module, layer.d_in
+                    )));
+                }
+                counter_rotate_a(layer.a, layer.rank, layer.d_in, &rotation)?;
+                report.entries.push((
+                    layer.layer_idx,
+                    layer.module.to_string(),
+                    LoraRotationApplied::CounterRotatedA,
+                ));
             }
-            counter_rotate_a(a, rank, d_in, &rotation)?;
-            report.rotated.push((layer_idx, module.to_string()));
-        } else {
-            report.skipped.push((layer_idx, module.to_string()));
+            Some(AbsorptionSide::OutputSide) => {
+                if layer.d_out != hidden_dim {
+                    return Err(InferenceError::Inference(format!(
+                        "rotate_adapter_for_quarot: layer {} module '{}' has d_out={} \
+                         but hidden_dim={hidden_dim}",
+                        layer.layer_idx, layer.module, layer.d_out
+                    )));
+                }
+                rotate_b_output_side(layer.b, layer.d_out, layer.rank, &rotation)?;
+                report.entries.push((
+                    layer.layer_idx,
+                    layer.module.to_string(),
+                    LoraRotationApplied::RotatedB,
+                ));
+            }
+            None => {
+                report.entries.push((
+                    layer.layer_idx,
+                    layer.module.to_string(),
+                    LoraRotationApplied::NotInPlan,
+                ));
+            }
         }
     }
 
@@ -149,10 +240,12 @@ mod tests {
             .fold(0.0_f32, f32::max)
     }
 
+    // --- Input-side tests (A counter-rotation) ---
+
     #[test]
-    fn counter_rotation_correctness() {
-        // Validates: B · (A · R^T) · (R · h) == B · A · h
-        let d_in = 64; // hidden_dim (power of two)
+    fn input_side_counter_rotation_correctness() {
+        // B · (A · R^T) · (R · h) == B · A · h
+        let d_in = 64;
         let d_out = 32;
         let rank = 8;
         let seed = 0xC0FFEE_u64;
@@ -162,11 +255,9 @@ mod tests {
         let b = synthetic_vector(d_out * rank, 2);
         let h = synthetic_vector(d_in, 3);
 
-        // Original: B · (A · h)
         let a_h = matvec(&a, rank, d_in, &h);
         let original = matvec(&b, d_out, rank, &a_h);
 
-        // Counter-rotated path: B · (A_cr · (R · h))
         let mut a_cr = a.clone();
         counter_rotate_a(&mut a_cr, rank, d_in, &r).unwrap();
         let mut h_rot = h.clone();
@@ -182,8 +273,7 @@ mod tests {
     }
 
     #[test]
-    fn counter_rotation_naive_is_wrong() {
-        // Without counter-rotation, B · A · (R · h) ≠ B · A · h
+    fn input_side_naive_is_wrong() {
         let d_in = 64;
         let d_out = 16;
         let rank = 4;
@@ -194,11 +284,9 @@ mod tests {
         let b = synthetic_vector(d_out * rank, 11);
         let h = synthetic_vector(d_in, 12);
 
-        // Original: B · A · h
         let a_h = matvec(&a, rank, d_in, &h);
         let original = matvec(&b, d_out, rank, &a_h);
 
-        // Naive (no counter-rotation): B · A · (R · h)
         let mut h_rot = h.clone();
         r.apply(&mut h_rot).unwrap();
         let a_rh = matvec(&a, rank, d_in, &h_rot);
@@ -211,33 +299,72 @@ mod tests {
         );
     }
 
+    // --- Output-side tests (B rotation) ---
+
     #[test]
-    fn counter_rotation_is_exact_for_orthogonal_r() {
-        // R^T · R = I, so the correction is exact (not approximate)
-        let d_in = 128;
-        let rank = 16;
-        let seed = 0xDEAD_BEEF_u64;
+    fn output_side_b_rotation_correctness() {
+        // For output-side: base does W' = R·W, output is R·(W·x).
+        // LoRA delta must also be rotated: (R·B)·A·x = R·(B·A·x) ✓
+        let d_out = 64; // hidden_dim (output goes to residual stream)
+        let rank = 8;
+        let d_in_internal = 32; // internal dimension (not hidden_dim)
+        let seed = 0xBEEF_u64;
 
-        let r = RandomizedHadamard::new(seed, d_in).unwrap();
-        let a = synthetic_vector(rank * d_in, 20);
-        let h = synthetic_vector(d_in, 21);
+        let r = RandomizedHadamard::new(seed, d_out).unwrap();
+        let a = synthetic_vector(rank * d_in_internal, 50);
+        let b = synthetic_vector(d_out * rank, 51);
+        let x = synthetic_vector(d_in_internal, 52);
 
-        // A · h
-        let a_h = matvec(&a, rank, d_in, &h);
+        // Original unrotated delta: B · A · x
+        let a_x = matvec(&a, rank, d_in_internal, &x);
+        let original_delta = matvec(&b, d_out, rank, &a_x);
 
-        // A_cr · (R · h) = (A · R^T) · (R · h) should equal A · (R^T · R · h) = A · h
-        let mut a_cr = a.clone();
-        counter_rotate_a(&mut a_cr, rank, d_in, &r).unwrap();
-        let mut h_rot = h.clone();
-        r.apply(&mut h_rot).unwrap();
-        let a_cr_rh = matvec(&a_cr, rank, d_in, &h_rot);
+        // Expected: R · (B · A · x)
+        let mut expected = original_delta.clone();
+        r.apply(&mut expected).unwrap();
 
-        let delta = max_abs_diff(&a_h, &a_cr_rh);
+        // With B_rot = R · B: B_rot · A · x should equal R · (B · A · x)
+        let mut b_rot = b.clone();
+        rotate_b_output_side(&mut b_rot, d_out, rank, &r).unwrap();
+        let b_rot_a_x = matvec(&b_rot, d_out, rank, &a_x);
+
+        let delta = max_abs_diff(&expected, &b_rot_a_x);
         assert!(
-            delta < 5e-4,
-            "A_cr·(R·h) should exactly equal A·h (orthogonal R): max_abs_diff={delta}"
+            delta < 1e-4,
+            "(R·B)·A·x should equal R·(B·A·x): max_abs_diff={delta}"
         );
     }
+
+    #[test]
+    fn output_side_naive_skip_is_wrong() {
+        // Without B rotation, the delta is in the wrong basis
+        let d_out = 64;
+        let rank = 4;
+        let d_in_internal = 16;
+        let seed = 123_u64;
+
+        let r = RandomizedHadamard::new(seed, d_out).unwrap();
+        let a = synthetic_vector(rank * d_in_internal, 60);
+        let b = synthetic_vector(d_out * rank, 61);
+        let x = synthetic_vector(d_in_internal, 62);
+
+        // Unrotated delta
+        let a_x = matvec(&a, rank, d_in_internal, &x);
+        let unrotated_delta = matvec(&b, d_out, rank, &a_x);
+
+        // Expected rotated delta
+        let mut expected = unrotated_delta.clone();
+        r.apply(&mut expected).unwrap();
+
+        // The unrotated delta does NOT match the expected rotated delta
+        let delta = max_abs_diff(&unrotated_delta, &expected);
+        assert!(
+            delta > 0.1,
+            "skipping B rotation should produce large error: max_abs_diff={delta}"
+        );
+    }
+
+    // --- Module lookup tests ---
 
     #[test]
     fn needs_counter_rotation_input_side_modules() {
@@ -256,80 +383,157 @@ mod tests {
         for module in input_side {
             assert!(
                 needs_counter_rotation(&plan, module),
-                "{module} should need counter-rotation (input-side)"
+                "{module} should need A counter-rotation (input-side)"
+            );
+            assert!(
+                !needs_b_rotation(&plan, module),
+                "{module} should NOT need B rotation"
             );
         }
     }
 
     #[test]
-    fn needs_counter_rotation_output_side_modules() {
+    fn needs_b_rotation_output_side_modules() {
         let plan = RotationPlan::qwen35_residual_stream_linear_layers();
         let output_side = ["o_proj", "down_proj", "out_proj"];
         for module in output_side {
             assert!(
+                needs_b_rotation(&plan, module),
+                "{module} should need B rotation (output-side)"
+            );
+            assert!(
                 !needs_counter_rotation(&plan, module),
-                "{module} should NOT need counter-rotation (output-side)"
+                "{module} should NOT need A counter-rotation"
             );
         }
     }
 
     #[test]
-    fn needs_counter_rotation_unknown_module() {
+    fn unknown_module_needs_neither() {
         let plan = RotationPlan::qwen35_residual_stream_linear_layers();
         assert!(!needs_counter_rotation(&plan, "some_random_proj"));
-        assert!(!needs_counter_rotation(&plan, "conv1d"));
+        assert!(!needs_b_rotation(&plan, "some_random_proj"));
     }
 
+    // --- Batch API tests ---
+
     #[test]
-    fn counter_rotate_layers_batch() {
-        let d_in = 64;
+    fn rotate_adapter_batch_applies_both_sides() {
+        let hidden_dim = 64;
         let rank = 4;
         let seed = 7_u64;
         let plan = RotationPlan::qwen35_residual_stream_linear_layers();
 
-        let mut a_q = synthetic_vector(rank * d_in, 100);
-        let mut a_o = synthetic_vector(rank * d_in, 101);
-        let mut a_gate = synthetic_vector(rank * d_in, 102);
-        let mut a_down = synthetic_vector(rank * d_in, 103);
+        let mut a_q = synthetic_vector(rank * hidden_dim, 100);
+        let mut b_q = synthetic_vector(hidden_dim * rank, 101); // d_out != hidden for q_proj (2*q_dim), but test uses hidden
+        let mut a_o = synthetic_vector(rank * hidden_dim, 102);
+        let mut b_o = synthetic_vector(hidden_dim * rank, 103);
 
         let a_q_orig = a_q.clone();
+        let b_q_orig = b_q.clone();
         let a_o_orig = a_o.clone();
-        let a_gate_orig = a_gate.clone();
-        let a_down_orig = a_down.clone();
+        let b_o_orig = b_o.clone();
 
-        let layers: Vec<(usize, &str, &mut [f32], usize, usize)> = vec![
-            (0, "q_proj", a_q.as_mut_slice(), rank, d_in),
-            (0, "o_proj", a_o.as_mut_slice(), rank, d_in),
-            (1, "gate_proj", a_gate.as_mut_slice(), rank, d_in),
-            (1, "down_proj", a_down.as_mut_slice(), rank, d_in),
+        let layers = vec![
+            LoraLayerMut {
+                layer_idx: 0,
+                module: "q_proj",
+                a: a_q.as_mut_slice(),
+                b: b_q.as_mut_slice(),
+                rank,
+                d_in: hidden_dim,
+                d_out: hidden_dim,
+            },
+            LoraLayerMut {
+                layer_idx: 0,
+                module: "o_proj",
+                a: a_o.as_mut_slice(),
+                b: b_o.as_mut_slice(),
+                rank,
+                d_in: hidden_dim,
+                d_out: hidden_dim,
+            },
         ];
 
-        let report = counter_rotate_layers(layers, seed, d_in, &plan).unwrap();
+        let report = rotate_adapter_for_quarot(layers, seed, hidden_dim, &plan).unwrap();
 
-        assert_eq!(report.rotated.len(), 2);
-        assert_eq!(report.skipped.len(), 2);
-        assert!(report.rotated.contains(&(0, "q_proj".into())));
-        assert!(report.rotated.contains(&(1, "gate_proj".into())));
-        assert!(report.skipped.contains(&(0, "o_proj".into())));
-        assert!(report.skipped.contains(&(1, "down_proj".into())));
+        assert_eq!(report.num_a_rotated(), 1);
+        assert_eq!(report.num_b_rotated(), 1);
+        assert_eq!(report.num_not_in_plan(), 0);
 
-        // Input-side modules were modified
+        // q_proj: A was modified, B was NOT
         assert_ne!(a_q, a_q_orig);
-        assert_ne!(a_gate, a_gate_orig);
-        // Output-side modules were NOT modified
+        assert_eq!(b_q, b_q_orig);
+        // o_proj: B was modified, A was NOT
         assert_eq!(a_o, a_o_orig);
-        assert_eq!(a_down, a_down_orig);
+        assert_ne!(b_o, b_o_orig);
     }
 
     #[test]
-    fn counter_rotate_layers_dimension_mismatch_rejected() {
+    fn rotate_adapter_unknown_module_is_not_in_plan() {
+        let hidden_dim = 64;
+        let rank = 4;
+        let seed = 7_u64;
         let plan = RotationPlan::qwen35_residual_stream_linear_layers();
-        let mut a = synthetic_vector(4 * 32, 200);
 
-        let layers: Vec<(usize, &str, &mut [f32], usize, usize)> =
-            vec![(0, "q_proj", a.as_mut_slice(), 4, 32)]; // d_in=32 but hidden_dim=64
+        let mut a = synthetic_vector(rank * hidden_dim, 200);
+        let mut b = synthetic_vector(hidden_dim * rank, 201);
+        let a_orig = a.clone();
+        let b_orig = b.clone();
 
-        let result = counter_rotate_layers(layers, 7, 64, &plan);
+        let layers = vec![LoraLayerMut {
+            layer_idx: 0,
+            module: "conv1d",
+            a: a.as_mut_slice(),
+            b: b.as_mut_slice(),
+            rank,
+            d_in: hidden_dim,
+            d_out: hidden_dim,
+        }];
+
+        let report = rotate_adapter_for_quarot(layers, seed, hidden_dim, &plan).unwrap();
+        assert_eq!(report.num_not_in_plan(), 1);
+        assert_eq!(a, a_orig);
+        assert_eq!(b, b_orig);
+    }
+
+    #[test]
+    fn rotate_adapter_input_side_dimension_mismatch_rejected() {
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+        let mut a = synthetic_vector(4 * 32, 300);
+        let mut b = synthetic_vector(64 * 4, 301);
+
+        let layers = vec![LoraLayerMut {
+            layer_idx: 0,
+            module: "q_proj",
+            a: a.as_mut_slice(),
+            b: b.as_mut_slice(),
+            rank: 4,
+            d_in: 32, // mismatch: hidden_dim=64 but d_in=32
+            d_out: 64,
+        }];
+
+        let result = rotate_adapter_for_quarot(layers, 7, 64, &plan);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rotate_adapter_output_side_dimension_mismatch_rejected() {
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+        let mut a = synthetic_vector(4 * 64, 400);
+        let mut b = synthetic_vector(32 * 4, 401);
+
+        let layers = vec![LoraLayerMut {
+            layer_idx: 0,
+            module: "o_proj",
+            a: a.as_mut_slice(),
+            b: b.as_mut_slice(),
+            rank: 4,
+            d_in: 64,
+            d_out: 32, // mismatch: hidden_dim=64 but d_out=32
+        }];
+
+        let result = rotate_adapter_for_quarot(layers, 7, 64, &plan);
         assert!(result.is_err());
     }
 
@@ -338,7 +542,7 @@ mod tests {
         let d_in = 64;
         let rank = 8;
         let seed = 99_u64;
-        let a = synthetic_vector(rank * d_in, 300);
+        let a = synthetic_vector(rank * d_in, 500);
 
         let r = RandomizedHadamard::new(seed, d_in).unwrap();
         let mut a1 = a.clone();
@@ -350,18 +554,18 @@ mod tests {
     }
 
     #[test]
-    fn counter_rotation_different_seeds_differ() {
-        let d_in = 64;
+    fn b_rotation_deterministic_across_calls() {
+        let d_out = 64;
         let rank = 8;
-        let a = synthetic_vector(rank * d_in, 400);
+        let seed = 99_u64;
+        let b = synthetic_vector(d_out * rank, 600);
 
-        let r1 = RandomizedHadamard::new(1, d_in).unwrap();
-        let r2 = RandomizedHadamard::new(2, d_in).unwrap();
-        let mut a1 = a.clone();
-        let mut a2 = a.clone();
-        counter_rotate_a(&mut a1, rank, d_in, &r1).unwrap();
-        counter_rotate_a(&mut a2, rank, d_in, &r2).unwrap();
+        let r = RandomizedHadamard::new(seed, d_out).unwrap();
+        let mut b1 = b.clone();
+        let mut b2 = b.clone();
+        rotate_b_output_side(&mut b1, d_out, rank, &r).unwrap();
+        rotate_b_output_side(&mut b2, d_out, rank, &r).unwrap();
 
-        assert_ne!(a1, a2, "different seeds should produce different rotations");
+        assert_eq!(b1, b2, "same seed must produce identical B rotation");
     }
 }

--- a/crates/inference/src/quant/quarot/mod.rs
+++ b/crates/inference/src/quant/quarot/mod.rs
@@ -7,6 +7,7 @@ pub mod forward_equivalence;
 pub mod hadamard;
 pub mod io;
 pub mod lm_head;
+pub mod lora;
 pub mod pipeline;
 pub mod plan;
 pub mod rmsnorm_fusion;

--- a/crates/inference/src/quant/quarot/plan.rs
+++ b/crates/inference/src/quant/quarot/plan.rs
@@ -326,6 +326,22 @@ impl RotationPlan {
             .map(|rule| rule.rotation)
     }
 
+    /// Look up the absorption side for a LoRA module name (e.g., `"q_proj"`).
+    ///
+    /// Returns `Some(InputSide)` or `Some(OutputSide)` if any plan rule's
+    /// pattern ends with `"{module}.weight"`, or `None` if the module is not
+    /// in the plan (e.g., not a residual-stream projection).
+    ///
+    /// Used by the counter-rotation logic (ADR-045) to decide which adapter
+    /// A matrices need `A_cr = A · R^T`.
+    pub fn absorption_for_module(&self, module: &str) -> Option<AbsorptionSide> {
+        let suffix = format!("{module}.weight");
+        self.rules
+            .iter()
+            .find(|rule| rule.pattern.ends_with(&suffix))
+            .map(|rule| rule.rotation.side)
+    }
+
     /// Number of pattern rules in the plan. Useful for dimensional sanity
     /// checks but not for runtime dispatch.
     pub fn rule_count(&self) -> usize {
@@ -818,6 +834,47 @@ mod tests {
             max_abs_diff < 1e-3,
             "MLP pair output should equal R · y_original: max_abs_diff={max_abs_diff}"
         );
+    }
+
+    #[test]
+    fn absorption_for_module_input_side() {
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+        for module in [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "gate_proj",
+            "up_proj",
+            "in_proj_qkv",
+            "in_proj_z",
+            "in_proj_b",
+            "in_proj_a",
+        ] {
+            assert_eq!(
+                plan.absorption_for_module(module),
+                Some(AbsorptionSide::InputSide),
+                "{module} should be InputSide"
+            );
+        }
+    }
+
+    #[test]
+    fn absorption_for_module_output_side() {
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+        for module in ["o_proj", "down_proj", "out_proj"] {
+            assert_eq!(
+                plan.absorption_for_module(module),
+                Some(AbsorptionSide::OutputSide),
+                "{module} should be OutputSide"
+            );
+        }
+    }
+
+    #[test]
+    fn absorption_for_module_unknown() {
+        let plan = RotationPlan::qwen35_residual_stream_linear_layers();
+        assert_eq!(plan.absorption_for_module("conv1d"), None);
+        assert_eq!(plan.absorption_for_module("norm"), None);
     }
 
     #[test]

--- a/crates/inference/src/quant/quarot/plan.rs
+++ b/crates/inference/src/quant/quarot/plan.rs
@@ -332,8 +332,9 @@ impl RotationPlan {
     /// pattern ends with `"{module}.weight"`, or `None` if the module is not
     /// in the plan (e.g., not a residual-stream projection).
     ///
-    /// Used by the counter-rotation logic (ADR-045) to decide which adapter
-    /// A matrices need `A_cr = A · R^T`.
+    /// Used by the adapter rotation logic (ADR-045) to decide:
+    /// - `InputSide` → counter-rotate A: `A_cr = A · R^T`
+    /// - `OutputSide` → rotate B: `B_rot = R · B`
     pub fn absorption_for_module(&self, module: &str) -> Option<AbsorptionSide> {
         let suffix = format!("{module}.weight");
         self.rules

--- a/docs/adr/ADR-045-quarot-lora-composition.md
+++ b/docs/adr/ADR-045-quarot-lora-composition.md
@@ -1,6 +1,6 @@
 # ADR-045: QuaRot + LoRA Composition at Inference Time
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-05-16
 **Author**: Ocean (HaiyangLi)
 **Depends on**: ADR-044 (QuaRot rotated quantization, v0 shipped in v0.2.0)
@@ -44,15 +44,25 @@ With a LoRA adapter `(B, A)` trained on the **unrotated** model:
 - **QuaRot runtime (naive)**: `W_rot · (R · h) + s · B · A · (R · h) = W · h + s · B · A · R · h` ✗
 - **Discrepancy**: `B · A · R · h ≠ B · A · h` (the adapter sees the rotated activation)
 
-**Fix — counter-rotate A at load time:**
+**Fix — rotate adapter matrices at load time:**
 
+**Input-side projections** (A receives rotated input `R · h`):
 Replace `A` with `A_cr = A · R^T`. Then at runtime:
 
 ```
 s · B · A_cr · (R · h) = s · B · (A · R^T) · (R · h) = s · B · A · R^T · R · h = s · B · A · h  ✓
 ```
 
-The correction is **exact** (R is orthogonal: `R^T · R = I`). Zero approximation error. Zero runtime overhead — the counter-rotation is absorbed into A at adapter load time.
+**Output-side projections** (output must be in rotated residual basis):
+Replace `B` with `B_rot = R · B`. Then at runtime:
+
+```
+s · B_rot · A · x = s · (R · B) · A · x = R · (s · B · A · x)  ✓
+```
+
+The delta lands in the rotated residual basis, matching the base projection's output.
+
+Both corrections are **exact** (R is orthogonal: `R^T · R = I`). Zero approximation error. Zero runtime overhead — the rotations are absorbed at adapter load time.
 
 ### Cost of counter-rotation
 
@@ -94,19 +104,23 @@ Cost: `rank × d_in × d_in` FLOPs. For rank=16, d=1024: **16.8M FLOPs** — mic
 
 The rotation `R` is the **residual-stream** rotation. It's absorbed input-side into projections that consume the residual stream directly. From the `RotationPlan` (ADR-044 step 3a):
 
-| Projection | Absorbs R? | LoRA target? | Counter-rotate A? |
-|-----------|-----------|-------------|-------------------|
-| `q_proj` | Yes (input) | Yes | **Yes** |
-| `k_proj` | Yes (input) | Yes | **Yes** |
-| `v_proj` | Yes (input) | Yes | **Yes** |
-| `o_proj` | No (output-side absorption) | Yes | **No** — A sees the attention output, not the residual stream |
-| `gate_proj` | Yes (input) | Yes | **Yes** |
-| `up_proj` | Yes (input) | Yes | **Yes** |
-| `down_proj` | No (output-side) | Yes | **No** |
-| `in_proj_qkv` (GDN) | Yes (input) | Possible | **Yes** |
-| `out_proj` (GDN) | No (output-side) | Possible | **No** |
+| Projection | Absorbs R? | LoRA target? | Rotate A? | Rotate B? |
+|-----------|-----------|-------------|-----------|-----------|
+| `q_proj` | Yes (input) | Yes | **A ← A·R^T** | No |
+| `k_proj` | Yes (input) | Yes | **A ← A·R^T** | No |
+| `v_proj` | Yes (input) | Yes | **A ← A·R^T** | No |
+| `o_proj` | Yes (output) | Yes | No | **B ← R·B** |
+| `gate_proj` | Yes (input) | Yes | **A ← A·R^T** | No |
+| `up_proj` | Yes (input) | Yes | **A ← A·R^T** | No |
+| `down_proj` | Yes (output) | Yes | No | **B ← R·B** |
+| `in_proj_qkv` (GDN) | Yes (input) | Possible | **A ← A·R^T** | No |
+| `out_proj` (GDN) | Yes (output) | Possible | No | **B ← R·B** |
 
-Rule: **counter-rotate A if and only if the projection absorbs R on the input side** (i.e., `RotationPlan` has `AbsorbSide::Right` or `AbsorbSide::Input` for that tensor). The plan data structure already encodes this — reuse it at adapter load time.
+Rules:
+- **Input-side** (`W ← W·R^T`): counter-rotate A so `B·(A·R^T)·(R·h) = B·A·h` ✓
+- **Output-side** (`W ← R·W`): rotate B so `(R·B)·A·x = R·(B·A·x)` — delta lands in rotated residual basis ✓
+
+The plan data structure already encodes which side each projection uses — reuse it at adapter load time.
 
 ### Metal LoRA kernel design
 

--- a/docs/adr/ADR-045-quarot-lora-composition.md
+++ b/docs/adr/ADR-045-quarot-lora-composition.md
@@ -20,7 +20,7 @@ The next step is **LoRA adapter injection on top of the QuaRot Q4 base**. This c
 | `LoraConfig` (rank, alpha, targets) | `crates/tune/src/lora/mod.rs` | Active |
 | CPU forward LoRA injection | `crates/inference/src/model/qwen35/model.rs:17` | Active — `Qwen35Model.lora` field, called per projection |
 | Metal Q4 forward path | `crates/inference/src/forward/metal_qwen35.rs` | Active — **NO LoRA injection** |
-| QuaRot seed in artifact | `config.json` in quantize_quarot output | Stored as conversion metadata |
+| QuaRot seed in artifact | `config.json` in quantize_quarot output | **NOT YET PERSISTED** — caller must supply seed explicitly (see §Prerequisites) |
 | `RandomizedHadamard` reconstruction | `crates/inference/src/quant/quarot/` | Active — deterministic from seed |
 
 ### Gaps
@@ -160,11 +160,12 @@ Two options:
 - Testable independently: LoRA kernel can be validated against CPU reference without touching the Q4 path.
 - Fusion becomes a v2 optimization if profiling shows dispatch overhead matters.
 
-The LoRA Metal kernel computes:
+The LoRA Metal kernels (two-phase separate dispatch):
 ```
-// Phase 1: A_cr @ x → intermediate (rank × 1)
-// Phase 2: B @ intermediate → delta (d_out × 1)
-// Phase 3: output[i] += scale * delta[i]
+// Phase 1 (lora_gemv_a): A' @ x → intermediate (rank × 1)
+// Phase 2 (lora_gemv_b_accum): output[i] += scale * B'[i,:] @ intermediate
+// A' = A_cr for input-side modules; A' = A for output-side modules
+// B' = B for input-side modules; B' = B_rot for output-side modules
 ```
 
 For rank ≤ 64 and d ≤ 4096, this is a small matmul — a single threadgroup can handle it. No tiling needed at these dimensions.
@@ -176,8 +177,8 @@ For rank ≤ 64 and d ≤ 4096, this is a small matmul — a single threadgroup 
 pub fn load_lora_adapter(
     &mut self,
     adapter: &LoraAdapter,      // from lattice-tune
-    quarot_seed: Option<u64>,   // None = no counter-rotation (unrotated base)
-    plan: Option<&RotationPlan>, // which projections were input-absorbed
+    quarot_seed: Option<u64>,   // None = no rotation correction (unrotated base)
+    plan: Option<&RotationPlan>, // which projections need which correction
 ) -> Result<(), String>;
 
 pub fn unload_lora_adapter(&mut self);
@@ -185,11 +186,13 @@ pub fn unload_lora_adapter(&mut self);
 
 When `quarot_seed` is `Some(seed)`:
 1. Reconstruct `R` from seed + hidden_dim.
-2. For each (layer, module) in the adapter where `plan` says input-side absorption: compute `A_cr = A · R^T`.
-3. Upload `B` and `A_cr` (or unmodified `A` for output-side projections) to Metal buffers.
-4. Set internal flag so the forward path dispatches the LoRA kernel after each adapted Q4 GEMV.
+2. Call `rotate_adapter_for_quarot` which, for each (layer, module):
+   - Input-side: computes `A_cr = A · R^T`, uploads `(B, A_cr)` to Metal buffers.
+   - Output-side: computes `B_rot = R · B`, uploads `(B_rot, A)` to Metal buffers.
+   - Unknown module: **errors** (fail-closed).
+3. Set internal flag so the forward path dispatches the LoRA kernel after each adapted Q4 GEMV.
 
-When `quarot_seed` is `None` (unrotated Q4 base): skip counter-rotation, upload A/B directly.
+When `quarot_seed` is `None` (unrotated Q4 base): skip rotation correction, upload A/B directly.
 
 ### Testing strategy
 
@@ -211,23 +214,23 @@ When `quarot_seed` is `None` (unrotated Q4 base): skip counter-rotation, upload 
 
 ## Implementation Steps
 
-| Step | Scope | Blocked by |
-|------|-------|-----------|
-| 1 | Counter-rotation library: `quarot::lora::counter_rotate_adapter(adapter, seed, plan) -> LoraAdapter` | Nothing (pure math, uses existing `RandomizedHadamard`) |
-| 2 | Metal LoRA kernel: `lora_gemv.metal` shader + Rust dispatch wrapper | Nothing (independent of step 1) |
-| 3 | `MetalQwen35State::load_lora_adapter` API: orchestrates counter-rotation + buffer upload | Steps 1 + 2 |
+| Step | Scope | Status |
+|------|-------|--------|
+| 1 | Adapter rotation library: `quarot::lora::rotate_adapter_for_quarot(layers, seed, hidden_dim, plan)` — input-side A counter-rotation + output-side B rotation, fail-closed for unknown targets | **Done** (PR #35) |
+| 2 | Metal LoRA GEMV kernels: `lora_gemv_a` + `lora_gemv_b_accum` MSL shaders, pipeline compilation | **Done** (PR #35) |
+| 3 | `MetalQwen35State::load_lora_adapter` API: orchestrates rotation + buffer upload + Rust dispatch wrapper | Steps 1 + 2 |
 | 4 | Forward path integration: dispatch LoRA kernel after each adapted Q4 GEMV | Step 3 |
 | 5 | End-to-end validation: PPL with adapter vs CPU reference path | Step 4 |
 | 6 | `bin/chat_metal` adapter flag: `--lora-dir <PATH>` for interactive use | Step 4 |
 
-Steps 1 and 2 are independent — parallelize.
+Steps 1 and 2 are independent — parallelized in PR #35.
 
 ## Success Criteria
 
 - PPL with a PEFT adapter on the QuaRot Q4 base matches PPL on the CPU unrotated path with the same adapter (within Q4 quantization noise, < 0.1 PPL).
-- Adapter load time < 500ms for rank-16 adapters on Qwen3.5-0.8B (dominated by the counter-rotation matmul + Metal buffer upload, not I/O).
+- Adapter load time < 500ms for rank-16 adapters on Qwen3.5-0.8B (dominated by the WHT rotation + Metal buffer upload, not I/O).
 - Zero runtime overhead when no adapter is loaded (existing `NoopLoraHook` pattern: the LoRA kernel dispatch is branch-gated on adapter presence).
-- The counter-rotation is invisible to the user: `load_lora_adapter` auto-detects whether the base is QuaRot (from config) and applies the correction internally.
+- The rotation correction is invisible to the user: `load_lora_adapter` applies the correction when `quarot_seed` is provided. Auto-detection from artifact metadata is a future enhancement (requires converter update per §Prerequisites).
 
 ## Alternatives Considered
 

--- a/docs/adr/ADR-045-quarot-lora-composition.md
+++ b/docs/adr/ADR-045-quarot-lora-composition.md
@@ -1,0 +1,216 @@
+# ADR-045: QuaRot + LoRA Composition at Inference Time
+
+**Status**: Proposed
+**Date**: 2026-05-16
+**Author**: Ocean (HaiyangLi)
+**Depends on**: ADR-044 (QuaRot rotated quantization, v0 shipped in v0.2.0)
+
+## Context
+
+ADR-044 shipped rotation-aware Q4 quantization: Hadamard rotation absorbed into weight matrices, RMSNorm fusion, forward-equivalence validated. The Metal Q4 forward path (`MetalQwen35State`) runs Qwen3.5-0.8B at 23.96 PPL (vs 25.57 naive Q4) — same memory, better quality.
+
+The next step is **LoRA adapter injection on top of the QuaRot Q4 base**. This combines the best quantized base (QuaRot Q4) with personalization (LoRA). Nobody has shipped this combination — it requires rotation-aware adapter composition that no existing inference engine implements.
+
+### What exists in lattice today
+
+| Component | Location | Status |
+|-----------|----------|--------|
+| `LoraHook` trait | `crates/inference/src/lora_hook.rs` | Active, CPU-only |
+| `LoraAdapter` / `LoraLayer` | `crates/tune/src/lora/mod.rs` | Active, loads PEFT safetensors |
+| `LoraConfig` (rank, alpha, targets) | `crates/tune/src/lora/mod.rs` | Active |
+| CPU forward LoRA injection | `crates/inference/src/model/qwen35/model.rs:17` | Active — `Qwen35Model.lora` field, called per projection |
+| Metal Q4 forward path | `crates/inference/src/forward/metal_qwen35.rs` | Active — **NO LoRA injection** |
+| QuaRot seed in artifact | `config.json` in quantize_quarot output | Stored as conversion metadata |
+| `RandomizedHadamard` reconstruction | `crates/inference/src/quant/quarot/` | Active — deterministic from seed |
+
+### Gaps
+
+1. **Metal forward has no adapter injection.** The Q4 GEMV runs entirely on GPU; the current `LoraHook` trait operates on CPU `&[f32]` slices. Calling it would require GPU→CPU→GPU round-trips per projection per token — unacceptable latency.
+2. **No counter-rotation logic.** Adapters trained on the unrotated model produce deltas in the wrong basis when the base weights are rotated.
+3. **No GPU-native adapter kernel.** Need a Metal compute shader that fuses `Q4_GEMV(W_rot, x) + scale * B @ (A @ x)` or at minimum a separate `LoRA_GEMV` dispatch composable with the existing Q4 path.
+
+## Decision
+
+### The Math (counter-rotation derivation)
+
+In a QuaRot-converted model, the residual stream carries `h_rot = R · h` instead of `h`. For a linear projection with weight `W`:
+
+- **Original**: `y = W · h`
+- **QuaRot runtime**: input is `R · h`, weight is `W_rot = W · R^T`. Output: `W_rot · (R · h) = W · R^T · R · h = W · h` ✓
+
+With a LoRA adapter `(B, A)` trained on the **unrotated** model:
+
+- **Original**: `y = W · h + s · B · A · h`
+- **QuaRot runtime (naive)**: `W_rot · (R · h) + s · B · A · (R · h) = W · h + s · B · A · R · h` ✗
+- **Discrepancy**: `B · A · R · h ≠ B · A · h` (the adapter sees the rotated activation)
+
+**Fix — counter-rotate A at load time:**
+
+Replace `A` with `A_cr = A · R^T`. Then at runtime:
+
+```
+s · B · A_cr · (R · h) = s · B · (A · R^T) · (R · h) = s · B · A · R^T · R · h = s · B · A · h  ✓
+```
+
+The correction is **exact** (R is orthogonal: `R^T · R = I`). Zero approximation error. Zero runtime overhead — the counter-rotation is absorbed into A at adapter load time.
+
+### Cost of counter-rotation
+
+Per LoRA layer: one matmul `A_cr = A · R^T` where:
+- `A` is `(rank × d_in)`, typically rank ∈ {4, 8, 16, 32, 64}
+- `R^T` is `(d_in × d_in)`, for Qwen3.5-0.8B `d_in = 1024`
+
+Cost: `rank × d_in × d_in` FLOPs. For rank=16, d=1024: **16.8M FLOPs** — microseconds on any hardware. One-time at adapter load.
+
+`R` is not stored — it's reconstructed from the seed via `RandomizedHadamard::new(seed, dim)`. The seed is already in the QuaRot artifact's metadata. Memory for R: `d × d × 4 bytes` = 4 MB for d=1024. Transient (freed after counter-rotation).
+
+### Architecture
+
+```
+┌──────────────────────────────────────────────────���──────┐
+│  Adapter Load (one-time, CPU)                           │
+│                                                         │
+│  1. Load PEFT safetensors → LoraAdapter (A, B per layer)│
+│  2. Read seed from QuaRot artifact config.json          │
+│  3. Reconstruct R = RandomizedHadamard(seed, d)         │
+│  4. For each (layer, module) with absorption rule:      │
+│     A_cr = A · R^T    (counter-rotate)                  │
+│  5. Upload B, A_cr to Metal buffers                     │
+│  6. Drop R (transient)                                  │
+└─────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│  Metal Forward (per token, GPU)                         │
+│                                                         │
+│  For each adapted projection in layer:                  │
+│    base_out = Q4_GEMV(W_rot, x)        [existing]      │
+│    lora_out = scale * B @ (A_cr @ x)   [new kernel]    │
+│    out = base_out + lora_out                            │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Which projections get counter-rotated?
+
+The rotation `R` is the **residual-stream** rotation. It's absorbed input-side into projections that consume the residual stream directly. From the `RotationPlan` (ADR-044 step 3a):
+
+| Projection | Absorbs R? | LoRA target? | Counter-rotate A? |
+|-----------|-----------|-------------|-------------------|
+| `q_proj` | Yes (input) | Yes | **Yes** |
+| `k_proj` | Yes (input) | Yes | **Yes** |
+| `v_proj` | Yes (input) | Yes | **Yes** |
+| `o_proj` | No (output-side absorption) | Yes | **No** — A sees the attention output, not the residual stream |
+| `gate_proj` | Yes (input) | Yes | **Yes** |
+| `up_proj` | Yes (input) | Yes | **Yes** |
+| `down_proj` | No (output-side) | Yes | **No** |
+| `in_proj_qkv` (GDN) | Yes (input) | Possible | **Yes** |
+| `out_proj` (GDN) | No (output-side) | Possible | **No** |
+
+Rule: **counter-rotate A if and only if the projection absorbs R on the input side** (i.e., `RotationPlan` has `AbsorbSide::Right` or `AbsorbSide::Input` for that tensor). The plan data structure already encodes this — reuse it at adapter load time.
+
+### Metal LoRA kernel design
+
+Two options:
+
+**(a) Fused kernel**: `out = Q4_GEMV(W, x) + scale * B @ (A @ x)` in a single dispatch. Maximum throughput (one pass over x, one output write). Complex kernel; tightly couples Q4 layout to LoRA.
+
+**(b) Separate dispatch**: existing `Q4_GEMV(W, x)` writes to output buffer; new `LoRA_GEMV(B, A, x, scale)` adds to the same buffer. Two dispatches, slightly more overhead, but decoupled and testable independently.
+
+**Decision: (b) separate dispatch for v1.** Rationale:
+- The Q4 GEMV kernel is already complex and battle-tested; don't destabilize it.
+- The LoRA GEMV is `d_out × rank + rank × d_in` FLOPs — tiny relative to the Q4 GEMV (which is `d_out × d_in / block_size`). The dispatch overhead is negligible vs the actual compute.
+- Testable independently: LoRA kernel can be validated against CPU reference without touching the Q4 path.
+- Fusion becomes a v2 optimization if profiling shows dispatch overhead matters.
+
+The LoRA Metal kernel computes:
+```
+// Phase 1: A_cr @ x → intermediate (rank × 1)
+// Phase 2: B @ intermediate → delta (d_out × 1)
+// Phase 3: output[i] += scale * delta[i]
+```
+
+For rank ≤ 64 and d ≤ 4096, this is a small matmul — a single threadgroup can handle it. No tiling needed at these dimensions.
+
+### API surface
+
+```rust
+// In MetalQwen35State (or a new MetalLoraState wrapper):
+pub fn load_lora_adapter(
+    &mut self,
+    adapter: &LoraAdapter,      // from lattice-tune
+    quarot_seed: Option<u64>,   // None = no counter-rotation (unrotated base)
+    plan: Option<&RotationPlan>, // which projections were input-absorbed
+) -> Result<(), String>;
+
+pub fn unload_lora_adapter(&mut self);
+```
+
+When `quarot_seed` is `Some(seed)`:
+1. Reconstruct `R` from seed + hidden_dim.
+2. For each (layer, module) in the adapter where `plan` says input-side absorption: compute `A_cr = A · R^T`.
+3. Upload `B` and `A_cr` (or unmodified `A` for output-side projections) to Metal buffers.
+4. Set internal flag so the forward path dispatches the LoRA kernel after each adapted Q4 GEMV.
+
+When `quarot_seed` is `None` (unrotated Q4 base): skip counter-rotation, upload A/B directly.
+
+### Testing strategy
+
+| Test | What it validates |
+|------|-------------------|
+| Counter-rotation unit test | `B · (A · R^T) · (R · h) == B · A · h` for random A, B, h, R |
+| Metal LoRA kernel vs CPU reference | `GPU_LoRA_GEMV(B, A, x) == scale * B @ (A @ x)` on synthetic data |
+| End-to-end PPL with identity adapter | PPL unchanged when adapter is all-zeros (no-op injection) |
+| End-to-end PPL unrotated-base + adapter | Match CPU LoraHook path on `Qwen35Model` |
+| End-to-end PPL QuaRot-base + counter-rotated adapter | Match CPU path with manually counter-rotated adapter |
+| LoRA load/unload cycle | No memory leak, state resets cleanly |
+
+### Risks
+
+1. **Adapter compatibility**: adapters trained on a different tokenizer / model revision won't match. Gate on config hash at load time.
+2. **Multi-adapter / MoLoRA**: this spec covers single-adapter injection. MoLoRA (mixture routing) is a v2 extension — the KG already has the W2-barycenter theory (`W2-Barycenter-Adapter-Blending`, `MoLoRA-W2-Covariance-Gap-Analysis`). The counter-rotation applies identically to each expert's A matrix.
+3. **Adapter rank explosion at Q4 precision**: the Q4 GEMV operates in reduced precision; the LoRA addition is f32/f16. This is actually *good* — the adapter delta is the high-precision correction on top of the quantized base. No precision loss on the personalization signal.
+4. **GDN layers**: Qwen3.5's GDN (Gated Delta Network) layers have `in_proj_qkv`, `in_proj_z`, `in_proj_a`, `in_proj_b`, `out_proj`. If users target these with LoRA (uncommon but possible), the same counter-rotation logic applies — the plan already covers them.
+
+## Implementation Steps
+
+| Step | Scope | Blocked by |
+|------|-------|-----------|
+| 1 | Counter-rotation library: `quarot::lora::counter_rotate_adapter(adapter, seed, plan) -> LoraAdapter` | Nothing (pure math, uses existing `RandomizedHadamard`) |
+| 2 | Metal LoRA kernel: `lora_gemv.metal` shader + Rust dispatch wrapper | Nothing (independent of step 1) |
+| 3 | `MetalQwen35State::load_lora_adapter` API: orchestrates counter-rotation + buffer upload | Steps 1 + 2 |
+| 4 | Forward path integration: dispatch LoRA kernel after each adapted Q4 GEMV | Step 3 |
+| 5 | End-to-end validation: PPL with adapter vs CPU reference path | Step 4 |
+| 6 | `bin/chat_metal` adapter flag: `--lora-dir <PATH>` for interactive use | Step 4 |
+
+Steps 1 and 2 are independent — parallelize.
+
+## Success Criteria
+
+- PPL with a PEFT adapter on the QuaRot Q4 base matches PPL on the CPU unrotated path with the same adapter (within Q4 quantization noise, < 0.1 PPL).
+- Adapter load time < 500ms for rank-16 adapters on Qwen3.5-0.8B (dominated by the counter-rotation matmul + Metal buffer upload, not I/O).
+- Zero runtime overhead when no adapter is loaded (existing `NoopLoraHook` pattern: the LoRA kernel dispatch is branch-gated on adapter presence).
+- The counter-rotation is invisible to the user: `load_lora_adapter` auto-detects whether the base is QuaRot (from config) and applies the correction internally.
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons | Verdict |
+|------------|------|------|---------|
+| Train adapters in the rotated basis | No load-time transform needed | Requires rotated model at train time; not backwards-compatible with existing PEFT adapters | Reject for v1 (offer as v2 "native QuaRot LoRA training" mode) |
+| Runtime rotation of adapter output (`R · (B · A · x)`) | No adapter modification | Per-token `d×d` matmul overhead on GPU — unacceptable for decode latency | Reject |
+| CPU-side LoRA with GPU→CPU→GPU round-trip | Reuses existing `LoraHook` trait | Round-trip latency kills decode throughput (~5× slower) | Reject |
+| Fused Q4+LoRA kernel | Maximum throughput | Couples Q4 layout to LoRA; complex; hard to test | Defer to v2 optimization |
+
+## References
+
+- ADR-044: QuaRot rotated quantization (this builds on)
+- ADR-043: LoRA serving verification (existing LoRA correctness framework)
+- KG: `LoRA-Low-Rank-Adaptation` (e916fb8b), `LoraAdapter` (2d2ee731), `LoraHook` (7668f8d9)
+- KG: `QuaRot (Ashkboos 2024)` (86ec6a4f) — now `status: implemented`
+- KG: `W2-Barycenter-Adapter-Blending` (e6a40019) — MoLoRA v2 extension
+- Hu et al. 2021, "LoRA: Low-Rank Adaptation of Large Language Models", arXiv:2106.09685
+- Ashkboos et al. 2024, "QuaRot: Outlier-Free 4-Bit Inference in Rotated LLMs", arXiv:2404.00456
+
+## Knowledge Graph
+
+- New entity on first implementation PR: `QuaRot-LoRA-Composition` (kind: concept, type: technique, status: proposed → implemented)
+- Edges: `extends` → `QuaRot (Ashkboos 2024)`, `extends` → `LoRA-Low-Rank-Adaptation`, `implements` from the code entity once shipped

--- a/docs/adr/ADR-045-quarot-lora-composition.md
+++ b/docs/adr/ADR-045-quarot-lora-composition.md
@@ -64,29 +64,35 @@ The delta lands in the rotated residual basis, matching the base projection's ou
 
 Both corrections are **exact** (R is orthogonal: `R^T · R = I`). Zero approximation error. Zero runtime overhead — the rotations are absorbed at adapter load time.
 
-### Cost of counter-rotation
+### Cost of adapter rotation
 
-Per LoRA layer: one matmul `A_cr = A · R^T` where:
-- `A` is `(rank × d_in)`, typically rank ∈ {4, 8, 16, 32, 64}
-- `R^T` is `(d_in × d_in)`, for Qwen3.5-0.8B `d_in = 1024`
+The `RandomizedHadamard` operates in-place via Walsh-Hadamard transforms (`O(d log d)` per vector), NOT dense matrix multiplication. No `d × d` matrix is materialized.
 
-Cost: `rank × d_in × d_in` FLOPs. For rank=16, d=1024: **16.8M FLOPs** — microseconds on any hardware. One-time at adapter load.
+Per LoRA layer:
+- **Input-side** (A rotation): `rank` WHT applications of length `d_in`. Cost: `O(rank × d_in × log(d_in))`. For rank=16, d=1024: ~160K FLOPs.
+- **Output-side** (B rotation): `rank` WHT applications of length `d_out`. Cost: `O(rank × d_out × log(d_out))`. Same order.
 
-`R` is not stored — it's reconstructed from the seed via `RandomizedHadamard::new(seed, dim)`. The seed is already in the QuaRot artifact's metadata. Memory for R: `d × d × 4 bytes` = 4 MB for d=1024. Transient (freed after counter-rotation).
+Memory: only a sign vector (`d × 4 bytes` = 4 KB for d=1024) plus the activation buffer being transformed in-place. No dense R matrix.
+
+`R` is reconstructed from the seed via `RandomizedHadamard::new(seed, dim)`. The seed MUST be persisted in the QuaRot artifact metadata (see §Prerequisites below).
 
 ### Architecture
 
 ```
-┌──────────────────────────────────────────────────���──────┐
+┌─────────────────────────────────────────────────────────┐
 │  Adapter Load (one-time, CPU)                           │
 │                                                         │
 │  1. Load PEFT safetensors → LoraAdapter (A, B per layer)│
-│  2. Read seed from QuaRot artifact config.json          │
+│  2. Read seed from QuaRot artifact metadata             │
 │  3. Reconstruct R = RandomizedHadamard(seed, d)         │
-│  4. For each (layer, module) with absorption rule:      │
-│     A_cr = A · R^T    (counter-rotate)                  │
-│  5. Upload B, A_cr to Metal buffers                     │
-│  6. Drop R (transient)                                  │
+│  4. For each (layer, module):                           │
+│     - Input-side:  A_cr = A · R^T  (counter-rotate A)  │
+│     - Output-side: B_rot = R · B   (rotate B)          │
+│     - Not in plan: ERROR (refuse unknown targets)       │
+│  5. Upload corrected matrices to Metal buffers:         │
+│     - Input-side:  upload (B, A_cr)                     │
+│     - Output-side: upload (B_rot, A)                    │
+│  6. Drop sign vector (transient)                        │
 └─────────────────────────────────────────────────────────┘
                          │
                          ▼
@@ -95,10 +101,28 @@ Cost: `rank × d_in × d_in` FLOPs. For rank=16, d=1024: **16.8M FLOPs** — mic
 │                                                         │
 │  For each adapted projection in layer:                  │
 │    base_out = Q4_GEMV(W_rot, x)        [existing]      │
-│    lora_out = scale * B @ (A_cr @ x)   [new kernel]    │
+│    lora_out = scale * B' @ (A' @ x)    [new kernel]    │
 │    out = base_out + lora_out                            │
+│  (B' and A' are whichever was rotated at load time)     │
 └─────────────────────────────────────────────────────────┘
 ```
+
+### Prerequisites (dependencies on prior work)
+
+The QuaRot converter (`quantize_quarot`) MUST persist rotation metadata in the output artifact. Without it, the adapter loader cannot reconstruct the correct `RandomizedHadamard`. Required fields (to be added in a converter update):
+
+```json
+{
+  "quarot": {
+    "kind": "randomized_hadamard",
+    "seed": 12648430,
+    "hidden_dim": 1024,
+    "plan": "qwen35_residual_stream_linear_layers"
+  }
+}
+```
+
+Until this metadata exists, the caller must supply the seed explicitly. The `load_lora_adapter` API accepts `quarot_seed: Option<u64>` for this reason — `None` means no rotation correction (unrotated base), `Some(seed)` triggers the correction. A future version will auto-detect from artifact metadata and refuse to load an adapter against a QuaRot base without it.
 
 ### Which projections get counter-rotated?
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -2,7 +2,7 @@
 
 Global ADR index for the Lattice project. Numbered sequentially, grouped by crate.
 
-## lattice-inference (ADR-001 to ADR-011, ADR-040 to ADR-044)
+## lattice-inference (ADR-001 to ADR-011, ADR-040 to ADR-045)
 
 | ADR                                            | Title                                |
 | ---------------------------------------------- | ------------------------------------ |
@@ -22,6 +22,7 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | [042](ADR-042-native-sparse-attention.md)      | Native Sparse Attention              |
 | [043](ADR-043-lora-serving-verification.md)    | LoRA Serving Verification            |
 | [044](ADR-044-quarot-rotated-quantization.md)  | QuaRot Hadamard-Rotated Quantization |
+| [045](ADR-045-quarot-lora-composition.md)      | QuaRot + LoRA Composition            |
 
 ## lattice-embed (ADR-012 to ADR-019)
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

- **Step 1**: Adapter rotation library (`quarot::lora`) — for input-side projections, computes `A_cr = A · R^T`; for output-side projections, computes `B_rot = R · B`. Both corrections are exact and absorbed at adapter load time (zero runtime cost).
- **Step 2**: Metal LoRA GEMV kernels — two-phase MSL shaders (`lora_gemv_a` + `lora_gemv_b_accum`) for GPU-native adapter injection. Separate from Q4 GEMV, independently testable.
- **ADR-045**: Full spec for QuaRot + LoRA composition at inference time (status: Accepted).

Steps 1 and 2 are independent primitives (per ADR-045's dependency graph). Steps 3-6 (integration into the forward path) follow in subsequent PRs.

## Test plan

- [x] 14 unit tests for rotation correctness (both sides), module lookup, batch API, fail-closed unknown targets, misspelled target rejection
- [x] 3 tests for `RotationPlan::absorption_for_module` helper
- [x] Metal GPU test: `lora_gemv_kernel_matches_cpu_reference` (rank=16, K=1024, N=512, validates GPU output against CPU reference within 1e-3)
- [x] Full workspace test suite (1210+ tests, 0 failures)
- [ ] End-to-end PPL validation with adapter (step 5, blocked on step 3/4 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)