### PR TITLE
fix(inference): close external-review functional gaps in generate path

### DIFF
--- a/crates/inference/src/error.rs
+++ b/crates/inference/src/error.rs
@@ -22,6 +22,9 @@ pub enum InferenceError {
     },
     Io(std::io::Error),
     Inference(String),
+    /// Caller-supplied input was invalid (empty prompt, token ID out of
+    /// range, etc.) — distinct from a missing model or runtime failure.
+    InvalidInput(String),
 }
 
 impl Display for InferenceError {
@@ -51,6 +54,7 @@ impl Display for InferenceError {
             ),
             Self::Io(err) => write!(f, "IO error: {err}"),
             Self::Inference(msg) => write!(f, "Inference error: {msg}"),
+            Self::InvalidInput(msg) => write!(f, "Invalid input: {msg}"),
         }
     }
 }
@@ -67,5 +71,16 @@ impl std::error::Error for InferenceError {
 impl From<std::io::Error> for InferenceError {
     fn from(value: std::io::Error) -> Self {
         Self::Io(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_input_display() {
+        let e = InferenceError::InvalidInput("Empty prompt".into());
+        assert_eq!(e.to_string(), "Invalid input: Empty prompt");
     }
 }

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -164,7 +164,7 @@ pub fn generate(
     let prompt_len = tokenized.real_length;
 
     if prompt_len == 0 {
-        return Err(InferenceError::ModelNotFound("Empty prompt".into()));
+        return Err(InferenceError::InvalidInput("Empty prompt".into()));
     }
 
     // 2. Initialize KV cache and scratch (allocate once per request)
@@ -285,7 +285,7 @@ fn forward_with_cache<'a>(
     for (i, &tok) in input_ids.iter().enumerate() {
         let tok = tok as usize;
         if tok >= cfg.vocab_size {
-            return Err(InferenceError::ModelNotFound(format!(
+            return Err(InferenceError::InvalidInput(format!(
                 "Token ID {tok} exceeds vocab size {}",
                 cfg.vocab_size
             )));

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -227,15 +227,15 @@ pub fn generate(
         }
     }
 
-    // 7. Detokenize.
-    // The Tokenizer trait does not expose a decode method; callers needing decoded text
-    // should use BpeTokenizer::token_for_id + byte_decode_token directly.
-    let _ = tokenizer; // suppress unused-variable warning
-    let text = String::new();
+    // 7. Detokenize via the tokenizer's decode (BpeTokenizer implements
+    // GPT-2 byte-level decode; only non-generative encoder tokenizers
+    // return None, in which case text is empty but token_ids still carry
+    // the result).
+    let decoded = tokenizer.decode(&generated_ids).unwrap_or_default();
     let full_text = if config.include_prompt {
-        prompt.to_string()
+        format!("{prompt}{decoded}")
     } else {
-        text
+        decoded
     };
 
     Ok(GenerateOutput {

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -231,11 +231,19 @@ pub struct Sampler {
 }
 
 impl Sampler {
-    /// **Unstable**: construct sampler.
+    /// **Unstable**: construct sampler with a non-deterministic seed.
+    ///
+    /// Seeded from the system clock so independent samplers (e.g. concurrent
+    /// requests) do not produce identical token streams. Use
+    /// [`with_seed`](Self::with_seed) for reproducible sampling.
     pub fn new(config: SamplingConfig) -> Self {
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0x853c_49e6_748f_ea9b);
         Self {
             config,
-            rng: Rng::new(42),
+            rng: Rng::new(seed),
             recent_tokens: Vec::new(),
             max_recent: 64,
             candidate_scratch: Vec::new(),

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -602,6 +602,11 @@ impl Tokenizer for BpeTokenizer {
             .collect()
     }
 
+    fn decode(&self, ids: &[u32]) -> Option<String> {
+        let encoded: String = ids.iter().filter_map(|&id| self.token_for_id(id)).collect();
+        Some(byte_decode_token(&encoded))
+    }
+
     fn vocab_size(&self) -> usize {
         self.inner.id_to_token.len()
     }
@@ -906,5 +911,18 @@ mod tests {
         assert_eq!(batch[1].input_ids.len(), 2);
         assert_eq!(batch[0].attention_mask, vec![1, 0]);
         assert_eq!(batch[1].attention_mask, vec![1, 1]);
+    }
+
+    #[test]
+    fn test_bpe_decode_roundtrip() {
+        let tokenizer = synthetic_bpe();
+        // Mirrors test_bpe_merge_hello_world: "hello world" → [11, 16].
+        let ids = tokenizer.tokenize_to_ids("hello world");
+        assert_eq!(ids, vec![11, 16]);
+        // Regression: decode must reverse the byte-level encoding (the "Ġ"
+        // prefix maps back to a space), not return an empty string — the
+        // prior generate.rs detokenize block discarded the text entirely.
+        assert_eq!(tokenizer.decode(&ids), Some("hello world".to_string()));
+        assert_eq!(tokenizer.decode(&[]), Some(String::new()));
     }
 }

--- a/crates/inference/src/tokenizer/common.rs
+++ b/crates/inference/src/tokenizer/common.rs
@@ -82,6 +82,17 @@ pub trait Tokenizer: Send + Sync {
             "tokenize_pair is not implemented for this tokenizer".into(),
         ))
     }
+
+    /// **Stable**: decode token IDs back to text.
+    ///
+    /// Returns `None` for tokenizers that do not support detokenization —
+    /// encoder-only embedding tokenizers (WordPiece/SentencePiece for
+    /// BERT/BGE) have no generative decode use. Generative tokenizers
+    /// (`BpeTokenizer`) override this with a real implementation.
+    fn decode(&self, ids: &[u32]) -> Option<String> {
+        let _ = ids;
+        None
+    }
 }
 
 /// Pad an ID sequence and explicit token type IDs to a fixed target length.


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes the **functional** findings from an external code review of the generate path. Perf findings (LRU O(n²), GDN per-token allocs) are deliberately out of scope — make-it-work first.

## 1. Detokenization was a no-op (`generate.rs` returned `text = ""`)

The object-safe `Tokenizer` trait exposed no `decode`, so the CPU `generate()` path discarded all output text.

- `tokenizer/common.rs`: added object-safe defaulted `Tokenizer::decode(&[u32]) -> Option<String>` (default `None` — non-breaking; encoder-only WordPiece/SentencePiece for BERT/BGE have no generative decode use).
- `tokenizer/bpe.rs`: override reusing existing `token_for_id` + tested `byte_decode_token`. No new decode logic.
- `generate.rs`: decode `generated_ids`; also fixed a latent bug where `include_prompt` returned only the prompt and dropped generated text.
- Test `test_bpe_decode_roundtrip`: `"hello world" → [11,16] → decode → "hello world"`.

> Note: the review's broader "benchmark cannot be evaluated" conclusion was incorrect — `bench_decode_ab`/`chat_metal` use the Metal `chat_completion` path (`forward/metal_qwen35.rs`, `decode_tokens`), which is verified working and **untouched here**.

## 2. `Sampler::new()` hardcoded RNG seed 42

Every sampler produced an identical token stream (a server would correlate all users). Now seeded from the system clock, matching the Metal path's existing pattern; `with_seed()` retained for reproducible/test sampling. All bare `Sampler::new()` tests are greedy/temp-0 (RNG unused) → unaffected.

## 3. Wrong error variant for input validation

`generate.rs` reported "empty prompt" / "token out of range" as `InferenceError::ModelNotFound`. Added a dedicated `InvalidInput` variant (the enum's own doc states additive variants are backward-compatible) + Display arm + test.

## Validation

`cargo fmt` clean · `cargo check --workspace` ✓ (embed/tune unaffected) · 37 sampling/error/generate/bpe tests pass · pre-commit (workspace check + deno doc-lint) passed. Commits `0cf3d14` + `2deac08`. Metal/Qwen3.5 decode path unchanged.