### PR TITLE
feat(inference): add MTP decode throughput benchmark

### DIFF
--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -170,5 +170,10 @@ name = "metal_decode_bench"
 harness = false
 required-features = ["metal-gpu", "f16"]
 
+[[bench]]
+name = "mtp_decode"
+harness = false
+required-features = ["metal-gpu", "f16"]
+
 [lints]
 workspace = true

--- a/crates/inference/benches/mtp_decode.rs
+++ b/crates/inference/benches/mtp_decode.rs
@@ -117,6 +117,7 @@ fn bench_baseline(c: &mut Criterion) {
             seed: Some(42),
             stop_token_ids: vec![],
             enable_thinking: false,
+            enable_mtp: Some(false),
         };
 
         let history = vec![ChatMessage::user(BENCH_PROMPT)];
@@ -214,13 +215,10 @@ fn bench_mtp(c: &mut Criterion) {
             seed: Some(42),
             stop_token_ids: vec![],
             enable_thinking: false,
+            enable_mtp: Some(true),
         };
 
         let history = vec![ChatMessage::user(BENCH_PROMPT)];
-
-        // SAFETY: set once before measurement, cleared after. Criterion runs
-        // bench functions sequentially in the main thread; no concurrent readers.
-        unsafe { std::env::set_var("LATTICE_MTP", "1") };
 
         state.reset_state();
         let warmup = state.chat_completion(&history, &tokenizer, &gen_cfg);
@@ -247,9 +245,6 @@ fn bench_mtp(c: &mut Criterion) {
         });
 
         group.finish();
-
-        // SAFETY: same single-threaded context as the set_var above.
-        unsafe { std::env::remove_var("LATTICE_MTP") };
     }
 }
 

--- a/crates/inference/benches/mtp_decode.rs
+++ b/crates/inference/benches/mtp_decode.rs
@@ -1,0 +1,234 @@
+//! MTP decode throughput benchmark.
+//!
+//! Measures end-to-end decode tok/s for two paths:
+//!   - **baseline**: single-token greedy decode (no MTP).
+//!   - **mtp**: MTP-enabled greedy decode (`LATTICE_MTP=1` code path).
+//!
+//! Both use `chat_completion` on the same prompt and token budget.  Criterion
+//! handles statistical sampling; the `LATTICE_MTP` env var is set/cleared
+//! around the MTP benchmark function.
+//!
+//! # Env
+//! - `LATTICE_MODEL_DIR`  — path to model dir (default `~/.lattice/models/qwen3.5-0.8b`).
+//!   If the dir does not contain `config.json` the benchmark group is skipped.
+//!
+//! # Run
+//! ```text
+//! cargo bench -p lattice-inference --features metal-gpu,f16 -- mtp_decode
+//! ```
+//!
+//! # CI note
+//! The benchmark compiles unconditionally but the body is gated on
+//! `#[cfg(all(target_os = "macos", feature = "metal-gpu"))]` and the
+//! model-dir existence check, so no GPU calls occur in CI.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::path::PathBuf;
+use std::time::Duration;
+
+// ---------------------------------------------------------------------------
+// Shared constants
+// ---------------------------------------------------------------------------
+
+/// Number of tokens requested per benchmark iteration.
+const N_TOKENS: usize = 32;
+
+/// Prompt used for both baseline and MTP runs.
+const BENCH_PROMPT: &str = "The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a";
+
+// ---------------------------------------------------------------------------
+// Model loading helper
+// ---------------------------------------------------------------------------
+
+/// Resolve the model directory from env or the default cache location.
+fn model_dir() -> Option<PathBuf> {
+    let dir = if let Ok(v) = std::env::var("LATTICE_MODEL_DIR") {
+        PathBuf::from(v)
+    } else {
+        let home = std::env::var("HOME").ok()?;
+        PathBuf::from(format!("{home}/.lattice/models/qwen3.5-0.8b"))
+    };
+    if dir.join("config.json").exists() {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: baseline (no MTP)
+// ---------------------------------------------------------------------------
+
+fn bench_baseline(c: &mut Criterion) {
+    #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+    {
+        let _ = c;
+        eprintln!("SKIP mtp_decode/baseline: requires macOS + metal-gpu feature");
+        return;
+    }
+
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    {
+        use lattice_inference::forward::metal_qwen35::{ChatMessage, MetalQwen35State};
+        use lattice_inference::model::{GenerateConfig, Qwen35Model};
+
+        let Some(dir) = model_dir() else {
+            eprintln!(
+                "SKIP mtp_decode/baseline: model not found.\n\
+                 Set LATTICE_MODEL_DIR or place model at ~/.lattice/models/qwen3.5-0.8b"
+            );
+            return;
+        };
+
+        let model = match Qwen35Model::from_safetensors(&dir) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("SKIP mtp_decode/baseline: model load failed: {e}");
+                return;
+            }
+        };
+        let cfg = model.config().clone();
+        let tokenizer = model.tokenizer();
+
+        let mut state = match MetalQwen35State::new(model.weights(), &cfg, 4096) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("SKIP mtp_decode/baseline: Metal init failed: {e}");
+                return;
+            }
+        };
+
+        // Greedy, no thinking — mirrors bench_decode_ab methodology.
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: N_TOKENS,
+            temperature: 0.0,
+            top_k: 1,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            seed: Some(42),
+            stop_token_ids: vec![],
+            enable_thinking: false,
+        };
+
+        let history = vec![ChatMessage::user(BENCH_PROMPT)];
+
+        // Warmup outside criterion's measurement loop.
+        state.reset_state();
+        let _ = state.chat_completion(&history, tokenizer, &gen_cfg);
+
+        let mut group = c.benchmark_group("mtp_decode");
+        group.warm_up_time(Duration::from_secs(5));
+        group.measurement_time(Duration::from_secs(20));
+        group.sample_size(10);
+        group.throughput(Throughput::Elements(N_TOKENS as u64));
+
+        group.bench_function(BenchmarkId::new("greedy", "baseline"), |b| {
+            b.iter(|| {
+                state.reset_state();
+                let out = state.chat_completion(&history, tokenizer, &gen_cfg);
+                // Return a value so the compiler cannot elide the call.
+                out.completion_tokens
+            });
+        });
+
+        group.finish();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: MTP-enabled
+// ---------------------------------------------------------------------------
+
+fn bench_mtp(c: &mut Criterion) {
+    #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+    {
+        let _ = c;
+        eprintln!("SKIP mtp_decode/mtp: requires macOS + metal-gpu feature");
+        return;
+    }
+
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    {
+        use lattice_inference::forward::metal_qwen35::{ChatMessage, MetalQwen35State};
+        use lattice_inference::model::{GenerateConfig, Qwen35Model};
+
+        let Some(dir) = model_dir() else {
+            eprintln!(
+                "SKIP mtp_decode/mtp: model not found.\n\
+                 Set LATTICE_MODEL_DIR or place model at ~/.lattice/models/qwen3.5-0.8b"
+            );
+            return;
+        };
+
+        let model = match Qwen35Model::from_safetensors(&dir) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("SKIP mtp_decode/mtp: model load failed: {e}");
+                return;
+            }
+        };
+        let cfg = model.config().clone();
+        let tokenizer = model.tokenizer();
+
+        let mut state = match MetalQwen35State::new(model.weights(), &cfg, 4096) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("SKIP mtp_decode/mtp: Metal init failed: {e}");
+                return;
+            }
+        };
+
+        // MTP path requires top_k <= 1 and temperature <= 0.0 (checked inside
+        // generate before branching to generate_greedy_mtp).
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: N_TOKENS,
+            temperature: 0.0,
+            top_k: 1,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            seed: Some(42),
+            stop_token_ids: vec![],
+            enable_thinking: false,
+        };
+
+        let history = vec![ChatMessage::user(BENCH_PROMPT)];
+
+        // Activate the MTP code path for both warmup and measurement.
+        // SAFETY: criterion runs bench functions sequentially.  No other thread
+        // reads LATTICE_MTP while this function executes.
+        unsafe {
+            std::env::set_var("LATTICE_MTP", "1");
+        }
+
+        // Warmup.
+        state.reset_state();
+        let _ = state.chat_completion(&history, tokenizer, &gen_cfg);
+
+        let mut group = c.benchmark_group("mtp_decode");
+        group.warm_up_time(Duration::from_secs(5));
+        group.measurement_time(Duration::from_secs(20));
+        group.sample_size(10);
+        group.throughput(Throughput::Elements(N_TOKENS as u64));
+
+        group.bench_function(BenchmarkId::new("greedy", "mtp"), |b| {
+            b.iter(|| {
+                state.reset_state();
+                let out = state.chat_completion(&history, tokenizer, &gen_cfg);
+                out.completion_tokens
+            });
+        });
+
+        group.finish();
+
+        unsafe {
+            std::env::remove_var("LATTICE_MTP");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Criterion entry points
+// ---------------------------------------------------------------------------
+
+criterion_group!(benches, bench_baseline, bench_mtp);
+criterion_main!(benches);

--- a/crates/inference/benches/mtp_decode.rs
+++ b/crates/inference/benches/mtp_decode.rs
@@ -1,16 +1,18 @@
 //! MTP decode throughput benchmark.
 //!
 //! Measures end-to-end decode tok/s for two paths:
-//!   - **baseline**: single-token greedy decode (no MTP).
-//!   - **mtp**: MTP-enabled greedy decode (`LATTICE_MTP=1` code path).
+//!   - **baseline**: greedy decode (MTP weights loaded but MTP gate disabled).
+//!   - **mtp**: MTP-enabled greedy decode.
 //!
-//! Both use `chat_completion` on the same prompt and token budget.  Criterion
-//! handles statistical sampling; the `LATTICE_MTP` env var is set/cleared
-//! around the MTP benchmark function.
+//! Both paths load the **Q4-quantized** model via `from_q4_dir`, which is the
+//! only constructor that populates MTP weights.  The f32 `new()` constructor
+//! never loads MTP weights, so it cannot benchmark the MTP path.
 //!
 //! # Env
-//! - `LATTICE_MODEL_DIR`  — path to model dir (default `~/.lattice/models/qwen3.5-0.8b`).
-//!   If the dir does not contain `config.json` the benchmark group is skipped.
+//! - `LATTICE_MODEL_DIR` — path to Q4 model dir (default `~/.lattice/models/qwen3.5-0.8b-q4`).
+//!   Must contain `config.json` and `mtp_fc_weight.q4`.  Skipped if missing.
+//! - `LATTICE_TOKENIZER_DIR` — path to dir with `tokenizer.json`
+//!   (default `~/.lattice/models/qwen3.5-0.8b`).
 //!
 //! # Run
 //! ```text
@@ -18,46 +20,45 @@
 //! ```
 //!
 //! # CI note
-//! The benchmark compiles unconditionally but the body is gated on
-//! `#[cfg(all(target_os = "macos", feature = "metal-gpu"))]` and the
-//! model-dir existence check, so no GPU calls occur in CI.
+//! Gated on `#[cfg(all(target_os = "macos", feature = "metal-gpu"))]` and
+//! model-dir existence, so no GPU calls occur in CI.
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::path::PathBuf;
 use std::time::Duration;
 
-// ---------------------------------------------------------------------------
-// Shared constants
-// ---------------------------------------------------------------------------
-
-/// Number of tokens requested per benchmark iteration.
 const N_TOKENS: usize = 32;
 
-/// Prompt used for both baseline and MTP runs.
-const BENCH_PROMPT: &str = "The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a";
+const BENCH_PROMPT: &str =
+    "Explain the theory of general relativity in simple terms, covering spacetime curvature and";
 
-// ---------------------------------------------------------------------------
-// Model loading helper
-// ---------------------------------------------------------------------------
-
-/// Resolve the model directory from env or the default cache location.
-fn model_dir() -> Option<PathBuf> {
+fn q4_model_dir() -> Option<PathBuf> {
     let dir = if let Ok(v) = std::env::var("LATTICE_MODEL_DIR") {
         PathBuf::from(v)
     } else {
         let home = std::env::var("HOME").ok()?;
-        PathBuf::from(format!("{home}/.lattice/models/qwen3.5-0.8b"))
+        PathBuf::from(format!("{home}/.lattice/models/qwen3.5-0.8b-q4"))
     };
-    if dir.join("config.json").exists() {
+    if dir.join("config.json").exists() && dir.join("mtp_fc_weight.q4").exists() {
         Some(dir)
     } else {
         None
     }
 }
 
-// ---------------------------------------------------------------------------
-// Benchmark: baseline (no MTP)
-// ---------------------------------------------------------------------------
+fn tokenizer_dir() -> Option<PathBuf> {
+    let dir = if let Ok(v) = std::env::var("LATTICE_TOKENIZER_DIR") {
+        PathBuf::from(v)
+    } else {
+        let home = std::env::var("HOME").ok()?;
+        PathBuf::from(format!("{home}/.lattice/models/qwen3.5-0.8b"))
+    };
+    if dir.join("tokenizer.json").exists() {
+        Some(dir)
+    } else {
+        None
+    }
+}
 
 fn bench_baseline(c: &mut Criterion) {
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
@@ -70,35 +71,43 @@ fn bench_baseline(c: &mut Criterion) {
     #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
     {
         use lattice_inference::forward::metal_qwen35::{ChatMessage, MetalQwen35State};
-        use lattice_inference::model::{GenerateConfig, Qwen35Model};
+        use lattice_inference::model::qwen35_config::{GenerateConfig, Qwen35Config};
+        use lattice_inference::tokenizer::bpe::BpeTokenizer;
 
-        let Some(dir) = model_dir() else {
-            eprintln!(
-                "SKIP mtp_decode/baseline: model not found.\n\
-                 Set LATTICE_MODEL_DIR or place model at ~/.lattice/models/qwen3.5-0.8b"
-            );
+        let Some(dir) = q4_model_dir() else {
+            eprintln!("SKIP mtp_decode/baseline: Q4 model not found (need mtp_fc_weight.q4)");
+            return;
+        };
+        let Some(tok_dir) = tokenizer_dir() else {
+            eprintln!("SKIP mtp_decode/baseline: tokenizer.json not found");
             return;
         };
 
-        let model = match Qwen35Model::from_safetensors(&dir) {
-            Ok(m) => m,
+        let cfg = match Qwen35Config::from_config_json(&dir.join("config.json")) {
+            Ok(c) => c,
             Err(e) => {
-                eprintln!("SKIP mtp_decode/baseline: model load failed: {e}");
+                eprintln!("SKIP mtp_decode/baseline: config parse failed: {e}");
                 return;
             }
         };
-        let cfg = model.config().clone();
-        let tokenizer = model.tokenizer();
 
-        let mut state = match MetalQwen35State::new(model.weights(), &cfg, 4096) {
+        let tok_path = tok_dir.join("tokenizer.json");
+        let tokenizer = match BpeTokenizer::from_tokenizer_json(&tok_path) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("SKIP mtp_decode/baseline: tokenizer load failed: {e}");
+                return;
+            }
+        };
+
+        let mut state = match MetalQwen35State::from_q4_dir(&dir, &tok_path, &cfg, 4096) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("SKIP mtp_decode/baseline: Metal init failed: {e}");
+                eprintln!("SKIP mtp_decode/baseline: Metal Q4 init failed: {e}");
                 return;
             }
         };
 
-        // Greedy, no thinking — mirrors bench_decode_ab methodology.
         let gen_cfg = GenerateConfig {
             max_new_tokens: N_TOKENS,
             temperature: 0.0,
@@ -112,21 +121,26 @@ fn bench_baseline(c: &mut Criterion) {
 
         let history = vec![ChatMessage::user(BENCH_PROMPT)];
 
-        // Warmup outside criterion's measurement loop.
         state.reset_state();
-        let _ = state.chat_completion(&history, tokenizer, &gen_cfg);
+        let warmup = state.chat_completion(&history, &tokenizer, &gen_cfg);
+        let actual_tokens = warmup.completion_tokens;
+        if actual_tokens < N_TOKENS {
+            eprintln!(
+                "WARN mtp_decode/baseline: warmup produced {actual_tokens}/{N_TOKENS} tokens \
+                 (early stop). Throughput based on actual count."
+            );
+        }
 
         let mut group = c.benchmark_group("mtp_decode");
         group.warm_up_time(Duration::from_secs(5));
         group.measurement_time(Duration::from_secs(20));
         group.sample_size(10);
-        group.throughput(Throughput::Elements(N_TOKENS as u64));
+        group.throughput(Throughput::Elements(actual_tokens as u64));
 
         group.bench_function(BenchmarkId::new("greedy", "baseline"), |b| {
             b.iter(|| {
                 state.reset_state();
-                let out = state.chat_completion(&history, tokenizer, &gen_cfg);
-                // Return a value so the compiler cannot elide the call.
+                let out = state.chat_completion(&history, &tokenizer, &gen_cfg);
                 out.completion_tokens
             });
         });
@@ -134,10 +148,6 @@ fn bench_baseline(c: &mut Criterion) {
         group.finish();
     }
 }
-
-// ---------------------------------------------------------------------------
-// Benchmark: MTP-enabled
-// ---------------------------------------------------------------------------
 
 fn bench_mtp(c: &mut Criterion) {
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
@@ -150,36 +160,51 @@ fn bench_mtp(c: &mut Criterion) {
     #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
     {
         use lattice_inference::forward::metal_qwen35::{ChatMessage, MetalQwen35State};
-        use lattice_inference::model::{GenerateConfig, Qwen35Model};
+        use lattice_inference::model::qwen35_config::{GenerateConfig, Qwen35Config};
+        use lattice_inference::tokenizer::bpe::BpeTokenizer;
 
-        let Some(dir) = model_dir() else {
+        let Some(dir) = q4_model_dir() else {
+            eprintln!("SKIP mtp_decode/mtp: Q4 model not found (need mtp_fc_weight.q4)");
+            return;
+        };
+        let Some(tok_dir) = tokenizer_dir() else {
+            eprintln!("SKIP mtp_decode/mtp: tokenizer.json not found");
+            return;
+        };
+
+        let cfg = match Qwen35Config::from_config_json(&dir.join("config.json")) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("SKIP mtp_decode/mtp: config parse failed: {e}");
+                return;
+            }
+        };
+
+        let tok_path = tok_dir.join("tokenizer.json");
+        let tokenizer = match BpeTokenizer::from_tokenizer_json(&tok_path) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("SKIP mtp_decode/mtp: tokenizer load failed: {e}");
+                return;
+            }
+        };
+
+        let mut state = match MetalQwen35State::from_q4_dir(&dir, &tok_path, &cfg, 4096) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("SKIP mtp_decode/mtp: Metal Q4 init failed: {e}");
+                return;
+            }
+        };
+
+        if !state.has_mtp() {
             eprintln!(
-                "SKIP mtp_decode/mtp: model not found.\n\
-                 Set LATTICE_MODEL_DIR or place model at ~/.lattice/models/qwen3.5-0.8b"
+                "SKIP mtp_decode/mtp: model loaded but MTP weights absent \
+                 (mtp_num_hidden_layers=0 or mtp files missing)"
             );
             return;
         };
 
-        let model = match Qwen35Model::from_safetensors(&dir) {
-            Ok(m) => m,
-            Err(e) => {
-                eprintln!("SKIP mtp_decode/mtp: model load failed: {e}");
-                return;
-            }
-        };
-        let cfg = model.config().clone();
-        let tokenizer = model.tokenizer();
-
-        let mut state = match MetalQwen35State::new(model.weights(), &cfg, 4096) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("SKIP mtp_decode/mtp: Metal init failed: {e}");
-                return;
-            }
-        };
-
-        // MTP path requires top_k <= 1 and temperature <= 0.0 (checked inside
-        // generate before branching to generate_greedy_mtp).
         let gen_cfg = GenerateConfig {
             max_new_tokens: N_TOKENS,
             temperature: 0.0,
@@ -193,42 +218,40 @@ fn bench_mtp(c: &mut Criterion) {
 
         let history = vec![ChatMessage::user(BENCH_PROMPT)];
 
-        // Activate the MTP code path for both warmup and measurement.
-        // SAFETY: criterion runs bench functions sequentially.  No other thread
-        // reads LATTICE_MTP while this function executes.
-        unsafe {
-            std::env::set_var("LATTICE_MTP", "1");
-        }
+        // SAFETY: set once before measurement, cleared after. Criterion runs
+        // bench functions sequentially in the main thread; no concurrent readers.
+        unsafe { std::env::set_var("LATTICE_MTP", "1") };
 
-        // Warmup.
         state.reset_state();
-        let _ = state.chat_completion(&history, tokenizer, &gen_cfg);
+        let warmup = state.chat_completion(&history, &tokenizer, &gen_cfg);
+        let actual_tokens = warmup.completion_tokens;
+        if actual_tokens < N_TOKENS {
+            eprintln!(
+                "WARN mtp_decode/mtp: warmup produced {actual_tokens}/{N_TOKENS} tokens \
+                 (early stop). Throughput based on actual count."
+            );
+        }
 
         let mut group = c.benchmark_group("mtp_decode");
         group.warm_up_time(Duration::from_secs(5));
         group.measurement_time(Duration::from_secs(20));
         group.sample_size(10);
-        group.throughput(Throughput::Elements(N_TOKENS as u64));
+        group.throughput(Throughput::Elements(actual_tokens as u64));
 
         group.bench_function(BenchmarkId::new("greedy", "mtp"), |b| {
             b.iter(|| {
                 state.reset_state();
-                let out = state.chat_completion(&history, tokenizer, &gen_cfg);
+                let out = state.chat_completion(&history, &tokenizer, &gen_cfg);
                 out.completion_tokens
             });
         });
 
         group.finish();
 
-        unsafe {
-            std::env::remove_var("LATTICE_MTP");
-        }
+        // SAFETY: same single-threaded context as the set_var above.
+        unsafe { std::env::remove_var("LATTICE_MTP") };
     }
 }
-
-// ---------------------------------------------------------------------------
-// Criterion entry points
-// ---------------------------------------------------------------------------
 
 criterion_group!(benches, bench_baseline, bench_mtp);
 criterion_main!(benches);

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6609,9 +6609,12 @@ kernel void lora_gemv_b_accum(
             // Batch prefill: process all prompt tokens at once (GEMM)
             let prefill_logits = self.forward_prefill(&prompt_ids);
 
-            // MTP greedy path: env-gated, greedy (top_k<=1) only.
+            // MTP greedy path: programmatic flag or env-gated, greedy (top_k<=1) only.
+            let mtp_enabled = gen_cfg
+                .enable_mtp
+                .unwrap_or_else(|| std::env::var("LATTICE_MTP").is_ok());
             let use_mtp = self.session.mtp.is_some()
-                && std::env::var("LATTICE_MTP").is_ok()
+                && mtp_enabled
                 && gen_cfg.top_k <= 1
                 && gen_cfg.temperature <= 0.0
                 && !use_compact;

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -3817,6 +3817,11 @@ kernel void lora_gemv_b_accum(
             })
         }
 
+        /// Returns `true` if MTP weights were loaded and the session has an active MTP state.
+        pub fn has_mtp(&self) -> bool {
+            self.session.mtp.is_some()
+        }
+
         /// Returns the expected `(d_in, d_out)` for a LoRA projection given the layer type.
         ///
         /// Returns an error if `module` is not valid for the layer type at `layer_idx`,
@@ -12705,6 +12710,11 @@ impl MetalQwen35State {
         _max_cache_len: usize,
     ) -> Result<Self, String> {
         Err("Metal GPU not available (requires macOS + metal-gpu feature)".into())
+    }
+
+    /// Stub: always returns false without metal-gpu feature.
+    pub fn has_mtp(&self) -> bool {
+        false
     }
 
     /// **Unstable**: Metal single-token forward step stub.

--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -514,6 +514,10 @@ pub struct GenerateConfig {
     pub stop_token_ids: Vec<u32>,
     /// When false, caller prepends `QWEN3_NO_THINK_SYSTEM_MSG` to disable chain-of-thought.
     pub enable_thinking: bool,
+    /// Enable multi-token prediction when the model has MTP weights loaded.
+    /// Replaces the `LATTICE_MTP` env var for programmatic control.
+    /// `None` = defer to `LATTICE_MTP` env var (backwards-compatible default).
+    pub enable_mtp: Option<bool>,
 }
 
 impl Default for GenerateConfig {
@@ -527,6 +531,7 @@ impl Default for GenerateConfig {
             seed: None,
             stop_token_ids: vec![QWEN_CHAT_IM_END_TOKEN_ID],
             enable_thinking: true,
+            enable_mtp: None,
         }
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Criterion benchmark measuring end-to-end decode throughput for baseline greedy vs MTP-enabled greedy on Q4-quantized Qwen3.5-0.8B.

- Uses `MetalQwen35State::from_q4_dir()` — the only constructor that loads MTP weights
- **Explicit route control** via `GenerateConfig::enable_mtp`:
  - Baseline: `enable_mtp: Some(false)` — immune to inherited `LATTICE_MTP` env
  - MTP: `enable_mtp: Some(true)` — no `unsafe set_var` needed
  - Default (`None`): falls back to `LATTICE_MTP` env var for CLI callers
- Throughput based on actual `completion_tokens` from warmup, not hardcoded count
- CI-safe: gated on `macOS + metal-gpu` feature and model directory existence
- Adds `has_mtp()` accessor to `MetalQwen35State`

## Test plan

- [x] `cargo check -p lattice-inference --bench mtp_decode --features metal-gpu,f16`: compiles
- [x] `cargo bench -p lattice-inference --bench mtp_decode --features metal-gpu,f16 --no-run`: links
- [x] `cargo test -p lattice-inference --lib`: 576 passed, 7 ignored
- [x] `cargo clippy -p lattice-inference -- -D warnings`: clean
- [x] No `unsafe` blocks in benchmark code
- [x] `enable_mtp: Some(false)` prevents baseline contamination from inherited env
- [x] Model dir detection: skips gracefully when Q4 model or MTP weights absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)