### PR TITLE
docs(adr): Lattice roadmap ADR-046 through ADR-055

### DIFF
--- a/docs/adr/ADR-046-structured-output.md
+++ b/docs/adr/ADR-046-structured-output.md
@@ -113,8 +113,8 @@ impl GrammarEngine {
 
     /// Apply grammar constraints to `logits` in-place.
     /// Sets disallowed token positions to `f32::NEG_INFINITY`.
-    /// Cost: O(vocab_size / 64) for the bitmask AND path;
-    ///       O(k × stack_depth) for the context-dependent token re-check.
+    /// Cost: O(vocab_size) scalar bit-scan per token; vectorizable to O(vocab_size / 64)
+    ///       with SIMD. Plus O(k × stack_depth) for context-dependent token re-check.
     pub fn mask_logits(&self, state: &mut GrammarState, logits: &mut [f32]);
 }
 

--- a/docs/adr/ADR-046-structured-output.md
+++ b/docs/adr/ADR-046-structured-output.md
@@ -176,16 +176,25 @@ are handled by the PDA stack at runtime.
 ### Mask Apply (Hot Path)
 
 ```rust
-// Apply bitmask: O(vocab_size/64) u64 AND operations.
+// Apply bitmask: iterate mask words, set disallowed logits to NEG_INFINITY.
+// The bitmask is a separate bitset — it is NOT overlaid on the float buffer.
 let mask_base = state.grammar_pos * self.mask_stride;
-for (i, word) in logits_u64_view.iter_mut().enumerate() {
-    *word &= self.masks[mask_base + i];  // zero disallowed tokens
+for word_idx in 0..self.mask_stride {
+    let mask_word = self.masks[mask_base + word_idx];
+    for bit in 0..64u32 {
+        let token_idx = word_idx * 64 + bit as usize;
+        if token_idx >= logits.len() { break; }
+        if mask_word & (1u64 << bit) == 0 {
+            logits[token_idx] = f32::NEG_INFINITY; // disallowed
+        }
+        // allowed tokens: logits unchanged
+    }
 }
-// Remaining f32 positions set to NEG_INFINITY where mask bit is 0.
 ```
 
 On a vocab of 248,320 tokens (Qwen3), `mask_stride = ceil(248320/64) = 3880` u64 words.
-The apply loop is ~3880 iterations — well under 40 µs.
+The outer loop is 3880 iterations; the inner bit-scan can be SIMD-vectorized (e.g., `_mm256_movemask_epi8`
++ batch store) but the scalar version is already well under 40 µs.
 
 ## Alternatives Considered
 

--- a/docs/adr/ADR-046-structured-output.md
+++ b/docs/adr/ADR-046-structured-output.md
@@ -1,0 +1,254 @@
+# ADR-046: XGrammar Structured Output Engine
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: lattice-inference
+
+## Context
+
+Agent and tool-call workflows require the model to emit syntactically valid output (JSON schema,
+function signatures, regex patterns). Without constrained decoding, the caller must either
+post-process malformed output (fragile) or retry the full generation (expensive). Every major
+serving framework treats this as a baseline feature: llama.cpp ships GBNF + JSON Schema, Ollama
+exposes `format=` with Pydantic/JSON schema, SGLang and vLLM both default to XGrammar as of early
+2026, TRT-LLM ships an equivalent implementation.
+
+Lattice currently exposes no grammar-constrained generation interface. Without it, the
+`generate()` / `MetalQwen35State::generate_greedy` / `generate_sampled` paths are not usable in
+any agent pipeline that requires structured tool responses.
+
+**The XGrammar approach** (MLSys 2025, arxiv:2411.15100) is now the canonical algorithm. Its key
+insight is vocabulary partitioning: at grammar initialisation time, every token in the vocabulary
+is inspected against the context-free grammar and placed into one of two classes:
+
+- **Context-independent** (~99% of tokens): whether the token is legal depends only on the current
+  grammar state, not on the partially accumulated byte sequence within the current token. These
+  produce a fully precomputed bitmask per grammar state — one bit per vocabulary position.
+- **Context-dependent** (~1% of tokens): legality requires inspecting the runtime pushdown-automaton
+  stack (typically tokens that straddle a grammar boundary mid-byte). These are checked at decode
+  time via stack inspection.
+
+This partitioning means the per-token overhead is dominated by a bitmask AND against the top-k
+logits — measured at under 40 µs on modern hardware. The grammar automaton itself is a byte-level
+pushdown automaton (PDA) that handles full context-free grammars, not just regular expressions.
+
+Lattice targets Apple Silicon exclusively. The bitmask apply step fits naturally into the existing
+CPU-side logit processing that already happens between the GPU forward pass and `Sampler::sample`.
+
+## Decision
+
+Add a `grammar` module to `lattice-inference` implementing a byte-level pushdown automaton
+structured output engine, following the XGrammar vocabulary-partitioning design.
+
+The module is model-agnostic: it operates on the raw logit slice `[vocab_size]` and is independent
+of whether the compute backend is CPU, NEON, or Metal GPU.
+
+**Grammar specification accepts two input formats**:
+
+1. **JSON Schema** (primary): the dominant format for agent tool-call schemas; auto-converted to
+   the internal grammar representation at initialisation time.
+2. **GBNF** (secondary): llama.cpp-compatible format; gives escape hatch for custom grammars that
+   are not expressible as JSON Schema.
+
+Both are accepted via a single `GrammarSpec` enum so callers have one entry point.
+
+**Precomputation happens at `GrammarEngine::new` time** (process startup or per-request if the
+schema is dynamic). No build-time codegen is required. For static schemas, callers may cache the
+`GrammarEngine` across requests.
+
+**Logit masking hooks into `GenerateConfig`**: a new optional field `grammar:
+Option<Arc<GrammarEngine>>` is added. The decode loop applies `engine.mask_logits(state, logits)`
+immediately before `sampler.sample(logits)` on every step. The `mask_logits` call zeroes
+(sets to `f32::NEG_INFINITY`) all disallowed token positions in the logit slice.
+
+## Scope
+
+**v0 (this ADR)**:
+- `GrammarSpec`: `JsonSchema(serde_json::Value)` and `Gbnf(String)` variants
+- `GrammarEngine`: vocabulary analysis, bitmask precomputation, per-step state machine
+- `GrammarState`: runtime PDA stack + current grammar position, cloned per decode sequence
+- Integration with `GenerateConfig` in `generate.rs` (CPU path)
+- Integration with `Qwen35Config::GenerateConfig` in `metal_qwen35.rs` (Metal path)
+- JSON Schema support limited to: `object`, `array`, `string` (with `enum`), `number`,
+  `integer`, `boolean`, `null`, `anyOf`/`oneOf`, nested `$ref` resolved within the same document
+
+**Deferred**:
+- External `$ref` resolution (URI references) — requires HTTP client, out of scope for inference
+- Regex pattern constraints on `string` fields (`"pattern": "..."`)
+- Streaming grammar state export for speculative decoding integration
+- Separate `lattice-grammar` crate — only warranted if other crates need grammar without pulling
+  all of `lattice-inference`
+- WASM compilation of the grammar engine
+
+## Architecture
+
+### Core Types
+
+```rust
+// grammar/spec.rs
+pub enum GrammarSpec {
+    JsonSchema(serde_json::Value),
+    Gbnf(String),
+}
+
+// grammar/engine.rs
+pub struct GrammarEngine {
+    /// Compiled grammar: states → terminal rules.
+    grammar: CompiledGrammar,
+    /// vocab_size × n_states bitmask table for context-independent tokens.
+    /// Layout: masks[state_id * mask_stride .. state_id * mask_stride + mask_stride]
+    /// where mask_stride = vocab_size.roundup_to(64) / 64 (u64 words).
+    masks: Vec<u64>,
+    mask_stride: usize,
+    vocab_size: usize,
+    /// Vocabulary byte strings for context-dependent token inspection.
+    vocab_bytes: Vec<Vec<u8>>,
+}
+
+impl GrammarEngine {
+    /// Build from a grammar specification and the model's vocabulary.
+    /// `vocab_bytes[i]` is the UTF-8 byte sequence for token i.
+    /// Cost: O(vocab_size × grammar_states), runs once at init time.
+    pub fn new(spec: &GrammarSpec, vocab_bytes: Vec<Vec<u8>>) -> Result<Self, GrammarError>;
+
+    /// Apply grammar constraints to `logits` in-place.
+    /// Sets disallowed token positions to `f32::NEG_INFINITY`.
+    /// Cost: O(vocab_size / 64) for the bitmask AND path;
+    ///       O(k × stack_depth) for the context-dependent token re-check.
+    pub fn mask_logits(&self, state: &mut GrammarState, logits: &mut [f32]);
+}
+
+// grammar/state.rs
+pub struct GrammarState {
+    /// Current grammar state index.
+    grammar_pos: usize,
+    /// PDA stack for context-free grammar traversal.
+    stack: Vec<StackFrame>,
+    /// Accumulated bytes in the current token (for context-dependent tokens).
+    partial_token_bytes: Vec<u8>,
+}
+```
+
+### Integration Points
+
+**`generate.rs` (CPU path)**: `GenerateConfig` gains:
+
+```rust
+pub grammar: Option<Arc<GrammarEngine>>,
+```
+
+In the decode loop, after `forward_with_cache` returns `logits: &[f32]`, the masking call happens
+before sampling:
+
+```rust
+if let Some(engine) = &config.grammar {
+    engine.mask_logits(&mut grammar_state, scratch_logits_mut);
+}
+let token = sampler.sample(logits);
+```
+
+The logits slice is borrowed from `scratch.logits`. The mask call requires a mutable reference to
+the same slice, so `forward_with_cache` will need to return `&mut [f32]` or the caller will
+copy to a scratch mutable buffer. The cheaper option is to operate on `scratch.logits` directly
+before the borrow is passed to `sampler.sample`.
+
+**`metal_qwen35.rs` (Metal path)**: `Qwen35Config::GenerateConfig` gains the same `grammar` field.
+After the GPU readback phase returns logits to CPU memory, the identical mask call applies. The
+Metal path already copies logits to CPU for sampling — no additional transfer is needed.
+
+**`BpeTokenizer`**: Used at `GrammarEngine::new` time to extract `vocab_bytes`. The tokenizer's
+vocabulary iterator will be accessed once; no ongoing coupling.
+
+### Bitmask Precomputation Algorithm
+
+For each grammar state `s` and each token `t`:
+1. Obtain the token's byte string from `vocab_bytes[t]`.
+2. Simulate advancing the grammar PDA from state `s` by consuming the bytes of `t`.
+3. If the simulation succeeds (reaches a valid intermediate or terminal state), set bit `t` in
+   `masks[s * mask_stride + t/64]`.
+4. If the token straddles a grammar boundary (simulation reaches EOF mid-byte-sequence), mark
+   as context-dependent for runtime stack inspection.
+
+The simulation uses a deterministic finite automaton (DFA) compiled from the grammar's regular
+prefix — the portion expressible without recursion. Recursive rules (object fields, array items)
+are handled by the PDA stack at runtime.
+
+### Mask Apply (Hot Path)
+
+```rust
+// Apply bitmask: O(vocab_size/64) u64 AND operations.
+let mask_base = state.grammar_pos * self.mask_stride;
+for (i, word) in logits_u64_view.iter_mut().enumerate() {
+    *word &= self.masks[mask_base + i];  // zero disallowed tokens
+}
+// Remaining f32 positions set to NEG_INFINITY where mask bit is 0.
+```
+
+On a vocab of 248,320 tokens (Qwen3), `mask_stride = ceil(248320/64) = 3880` u64 words.
+The apply loop is ~3880 iterations — well under 40 µs.
+
+## Alternatives Considered
+
+**1. Port llama.cpp GBNF engine directly**
+llama.cpp's grammar engine (`common/grammar-parser.cpp`) is a regex-level NFA, not a full PDA.
+It handles context-free grammars via stack simulation but lacks the vocabulary-partitioning
+optimization that keeps XGrammar's overhead under 40 µs. It also requires C FFI, which conflicts
+with the pure-Rust constraint.
+
+**2. Integrate Outlines (Python)**
+Outlines is the reference Python implementation of the index-based structured generation approach.
+MLX-LM uses it. It requires Python runtime and is therefore incompatible with Lattice's pure-Rust,
+no-subprocess architecture.
+
+**3. Regular expressions only (no full CFG)**
+JSON is not a regular language. Regex-only masking (e.g., `jsonschema-rs` + regex compilation)
+fails on recursive structures: nested objects, arrays of arrays. Rejected for correctness reasons.
+
+**4. Post-hoc JSON repair**
+Parse the raw output; if invalid, retry. Acceptable for low-stakes pipelines. Unacceptable for
+agent tool-calls where the caller blocks on a valid response. Adds 100-500 ms per failure.
+
+**5. Defer to a separate `lattice-grammar` crate**
+Appropriate once more than one consumer needs grammar, or if crate size becomes a concern.
+For v0, adding to `lattice-inference` avoids a new publish/version coordination cycle. The
+module boundary is clean enough to extract later without breaking the public API.
+
+## Risks
+
+**R1: Bitmask table memory**
+Qwen3 vocab = 248,320 tokens. A grammar with 500 states produces a table of
+`500 × 3880 × 8 bytes ≈ 15.5 MB`. For large, highly recursive grammars (hundreds of states),
+this could exceed the memory budget. Mitigation: cap supported grammar states at 256 states for
+v0; add a diagnostic at `GrammarEngine::new` that warns when state count is high.
+
+**R2: Context-dependent token handling correctness**
+The 1% context-dependent tokens require runtime PDA stack inspection and are the most complex
+code path. Mitigation: property-based tests (proptest) with round-trip generation: generate
+1,000 random JSON values matching a fixed schema, constrained-decode them, verify the output
+is valid JSON matching the schema.
+
+**R3: Metal path logit mutability**
+The Metal decode path returns logits via GPU readback into a CPU buffer whose mutability may not
+be threaded through cleanly. Mitigation: audit `generate_greedy` and `generate_sampled` in
+`metal_qwen35.rs` during implementation; ensure the logit buffer is mutable before sampling.
+
+**R4: Vocabulary extraction from `BpeTokenizer`**
+`BpeTokenizer` does not currently expose a vocabulary iterator. Adding one is a minor API
+extension. Mitigation: add `pub fn vocab_bytes(&self) -> Vec<Vec<u8>>` as an **Unstable** method
+in the same PR.
+
+**R5: Grammar compilation latency**
+For complex JSON schemas, `GrammarEngine::new` may take 50-200 ms. Unacceptable if called
+per-request. Mitigation: document that `GrammarEngine` must be constructed once and shared via
+`Arc<GrammarEngine>` across requests with the same schema.
+
+## References
+
+- XGrammar paper: arxiv:2411.15100 (MLSys 2025) — "XGrammar: Flexible and Efficient Structured
+  Generation Engine for Large Language Models"
+- llama.cpp GBNF engine: `common/grammar-parser.cpp`, `common/json-schema-to-grammar.cpp`
+- vLLM XGrammar integration: `vllm/model_executor/guided_decoding/xgrammar_decoding.py`
+- SGLang structured output: `python/sglang/srt/constrained/`
+- Outlines: github.com/outlines-dev/outlines — Python reference for index-based constrained decoding
+- JSON Schema specification: json-schema.org/draft/2020-12
+- Prior lattice ADRs: ADR-011 (sampling strategies), ADR-025 (tokenizer BPE)

--- a/docs/adr/ADR-047-paged-kv-cache.md
+++ b/docs/adr/ADR-047-paged-kv-cache.md
@@ -1,0 +1,195 @@
+# ADR-047: Paged KV Cache with Prefix Reuse
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: `lattice-inference`
+
+---
+
+## Context
+
+ADR-004 introduced two KV cache implementations: `FlatKVCache` (contiguous slab, single-sequence)
+and `PagedKVCache` (256-token pages, LRU eviction, multi-sequence). Both treat each request as
+independent — every prompt is encoded from scratch on every call.
+
+Three workloads expose this as a bottleneck:
+
+1. **Interactive chat with a system prompt.** Every turn re-encodes the same system prompt tokens.
+   For a 1024-token system prompt on Qwen3-0.6B, prefill dominates per-turn latency.
+2. **Batched embedding with shared prefix.** The embedding service in `lattice-embed` is called in
+   tight loops where many inputs share a common instruction prefix (e.g., `"Represent this sentence:"`).
+3. **LoRA hot-swap serving.** Multiple adapters share one base model. System-prompt KV tensors are
+   base-model-specific and can be shared across adapter variants that don't alter the first N tokens.
+
+The CUDA ecosystem has converged on paged KV caches as a baseline requirement (PagedAttention, vLLM,
+SGLang RadixAttention). For Apple Silicon the design simplifies: unified memory means no GPU/CPU
+page-transfer cost. Capacity is bounded by system RAM (~32-192 GB on M-series), not a 24 GB VRAM
+ceiling. Metal buffer alignment requirements are the main hardware constraint.
+
+The current `PagedKVCache` already solves fragmentation and enables multi-sequence capacity via LRU.
+What it lacks is identity-based page sharing: two requests with identical prefix tokens currently
+allocate and populate separate pages rather than pointing at the same physical pages.
+
+---
+
+## Decision
+
+Add a **prefix-sharing layer** on top of the existing `PagedKVCache` infrastructure. The design has
+two components:
+
+1. **`PrefixPageCache`**: A bounded LRU hash map keyed by `u64` prefix hash (FxHash of the token
+   slice). On a hit, the caller receives read-only shared `Arc` references to pre-populated physical
+   pages. On a miss, newly computed pages are inserted and shared. This is the path for single-user
+   sessions on Apple Silicon — simpler than a radix tree, covers 90% of the benefit.
+
+2. **`SharedPageRef`**: A thin newtype wrapping `Arc<[f32]>` (one arc per page, pointing into a
+   shared `PagePool` allocation). Read access is lock-free; write access requires promotion to an
+   owned page (copy-on-write triggered by append beyond the shared prefix length).
+
+The radix tree approach (SGLang RadixAttention) is deferred to the server path (see Alternatives).
+
+### Rust interface (proposed additions to `src/kv_cache/`)
+
+```rust
+/// A hash-keyed LRU cache of immutable prefix pages.
+pub struct PrefixPageCache {
+    /// max number of prefix entries retained.
+    capacity: usize,
+    /// key: FxHash of token ids for the prefix
+    /// value: (prefix_len, Arc-wrapped physical page slice per layer)
+    entries: IndexMap<u64, PrefixEntry>,
+}
+
+pub struct PrefixEntry {
+    pub prefix_len: usize,
+    /// One Arc<[f32]> per layer; layout matches PagePool page layout.
+    pub pages: Vec<Arc<[f32]>>,
+    pub last_used: std::time::Instant,
+}
+
+impl PrefixPageCache {
+    pub fn new(capacity: usize) -> Self;
+    pub fn lookup(&mut self, token_ids: &[u32]) -> Option<&PrefixEntry>;
+    pub fn insert(&mut self, token_ids: &[u32], entry: PrefixEntry);
+    /// Evict LRU entries until at or below capacity.
+    fn evict(&mut self);
+}
+```
+
+The `PagedKVCache` acquires a `PrefixPageCache` reference during construction (dependency injection
+via `Option<Arc<Mutex<PrefixPageCache>>>`). When `seq_len == 0` and a prefix hash hits the cache,
+the cache copies the shared pages into the pool and fast-forwards `seq_len` to `prefix_len` before
+the caller's first `append_kv_layer` call. The copy cost is paid once; subsequent decode steps are
+unaffected.
+
+---
+
+## Scope
+
+This ADR covers:
+- `PrefixPageCache` struct and lookup/insert/evict logic
+- Integration point in `PagedKVCache::new` and a new `PagedKVCache::restore_prefix` method
+- Interaction with LoRA hot-swap (adapter-keyed prefix namespacing)
+- Metal buffer alignment constraints for page size selection
+
+This ADR does not cover:
+- Full radix tree implementation (deferred — see Alternatives)
+- Multi-tenant server path (future ADR)
+- Persistent KV cache across process restarts
+- Quantized KV (fp16 / int8) storage (separate ADR)
+
+---
+
+## Architecture
+
+### Page size for Metal alignment
+
+The existing `PagedKVCache` uses 256-token pages (from ADR-004). Metal buffer allocation aligns to
+4 KB (system page) or 16 KB (Metal default heap). At Qwen3-0.6B geometry (8 KV heads, 128
+head_dim, 28 layers):
+
+```
+bytes_per_page = 28 × 2 × page_size × 1024 × 4
+  page_size=256 → 56 MB per page  (no alignment issue, but large)
+  page_size=64  →  14 MB per page
+  page_size=16  → 3.5 MB per page
+```
+
+For prefix caching, page granularity directly controls sharing granularity. A 256-token page means
+the minimum prefix length that produces a cache hit is 256 tokens. Smaller pages enable finer-grained
+sharing at the cost of more entries in the page table.
+
+**Decision**: retain 256-token pages for the existing `PagedKVCache` multi-sequence path. For the
+prefix cache specifically, introduce a `prefix_page_size` parameter (default 64 tokens) that governs
+prefix page granularity. A 64-token prefix page at Qwen3-0.6B is 14 MB — fits one `MTLBuffer`
+allocation comfortably and enables sharing on typical system prompts (64–512 tokens).
+
+### Copy-on-write for mutable extension
+
+When a request hits a prefix cache entry of length `P` and then generates new tokens:
+
+1. `restore_prefix` copies the shared page data into owned pool pages and sets `seq_len = P`.
+2. Subsequent `append_kv_layer` calls write into those owned pages normally.
+3. When generation completes, the caller can optionally call `promote_to_prefix` to hash the full
+   output and insert it into the prefix cache for future reuse.
+
+This avoids any synchronization on the hot decode path. Reads from the cache are `Arc` clones
+(atomic ref count increment); writes never touch shared pages.
+
+### LoRA interaction
+
+LoRA adapters modify query, key, and value projections (`q_proj`, `k_proj`, `v_proj`). The KV
+tensors written into the cache are the post-adapter outputs. Therefore prefix pages computed under
+adapter A are not valid for adapter B.
+
+**Namespacing rule**: the prefix cache key is `(adapter_id, token_hash)` where `adapter_id` is a
+`u64` derived from the adapter's content hash (established at load time by `lattice-tune`). The
+base model uses `adapter_id = 0`. This ensures cross-adapter sharing never occurs by construction.
+The `PrefixPageCache` capacity budget is shared across all adapter namespaces; LRU eviction is
+global.
+
+### Metal unified memory
+
+Because the `PagePool` allocates into `Vec<f32>` (CPU heap), Metal GPU access goes through
+`MTLBuffer::newBufferWithBytesNoCopy` or a blit into a managed `MTLBuffer`. The prefix cache holds
+`Arc<[f32]>` slices — same memory region. No additional copies are needed for the GPU path; the
+Metal command encoder reads directly from the same allocation. This is a unified-memory advantage
+not available in the CUDA ecosystem.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons | Verdict |
+|---|---|---|---|
+| **Radix tree (RadixAttention / SGLang)** | Optimal prefix matching at any token boundary; 6.4x throughput on prefix-heavy server workloads | Complex to implement in safe Rust; interior mutability on tree nodes; LRU on leaf nodes requires careful ownership | Deferred — implement when multi-tenant server path is active. Hash map covers the single-user case. |
+| **No prefix cache; longer FlatKVCache** | Zero code complexity | Re-encodes the same prefix on every request; unacceptable for chat latency at 1K+ token system prompts | Rejected — measurable latency regression. |
+| **Persist KV cache to disk (mmap)** | Survives process restart; useful for fixed system prompts | mmap I/O latency (μs–ms) during restore; added complexity; macOS unified memory already fast | Deferred — low priority until session resumption is a product requirement. |
+| **Smaller page size (16 tokens) for finer sharing** | More sharing opportunities; works for shorter common prefixes | 16× more page table entries; LRU bookkeeping overhead; 16-token page is 3.5 MB (fine) but table grows proportionally | Not adopted; 64-token prefix page is a reasonable balance point. |
+| **fp16 KV storage in prefix pages** | Halves prefix cache memory; doubles effective capacity | Introduces conversion cost at restore time; breaks the invariant that cached and live pages have identical layout | Deferred to a quantized-KV ADR. |
+
+---
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Hash collision on token sequence | Very low (FxHash 64-bit on token ids, not strings) | `debug_assert` prefix length match after hit; log collision metrics |
+| LoRA adapter id not propagated to cache call site | Medium — call sites spread across `generate.rs` | `PrefixPageCache::lookup` signature requires `adapter_id: u64`; omitting it is a compile error |
+| Arc ref-count overhead on prefix restore | Low — one `clone()` per page per layer at restore | Profile shows atomic increment < 5 ns; restore of 8 pages = 40 ns, negligible vs prefill |
+| Cache invalidation on model reload | Low but silent | `PrefixPageCache::clear()` called on model swap; cache is owned by session, not global |
+| Prefix cache grows unbounded in long session | Medium — embedding loops can insert many entries | Bounded LRU capacity (default 128 entries); eviction is O(1) with `IndexMap` |
+
+---
+
+## References
+
+- `src/kv_cache/paged.rs` — `PagePool`, `PageTable`, `PagedKVCache`, `EvictionPolicy`
+- `src/kv_cache/flat.rs` — `FlatKVCache` (single-sequence path, unaffected)
+- `src/kv_cache/mod.rs` — public re-exports
+- `src/speculative.rs` — uses `truncate_to()` for rollback; prefix cache must not interfere with rollback (prefix is immutable before first owned append)
+- ADR-004 — KV cache design; established `FlatKVCache` + `PagedKVCache` split and 256-token page size
+- ADR-008 — LoRA injection trait; source of `adapter_id` namespace requirement
+- ADR-031 — LoRA adapter management; adapter content hash is available at load time
+- Kwon et al., "Efficient Memory Management for Large Language Model Serving with PagedAttention," SOSP 2023
+- Zheng et al., "SGLang: Efficient Execution of Structured Language Model Programs," NeurIPS 2024 (RadixAttention)

--- a/docs/adr/ADR-047-paged-kv-cache.md
+++ b/docs/adr/ADR-047-paged-kv-cache.md
@@ -56,8 +56,14 @@ The radix tree approach (SGLang RadixAttention) is deferred to the server path (
 pub struct PrefixPageCache {
     /// max number of prefix entries retained.
     capacity: usize,
-    /// key: (adapter_id, token_hash) — namespaced to prevent cross-adapter cache poisoning
     entries: IndexMap<PrefixKey, PrefixEntry>,
+}
+
+/// Compound key enforcing LoRA namespace at the data structure level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PrefixKey {
+    pub adapter_id: AdapterId,
+    pub token_hash: u64, // FxHash of token_ids slice
 }
 
 pub struct PrefixEntry {
@@ -180,7 +186,7 @@ not available in the CUDA ecosystem.
 | Risk | Likelihood | Mitigation |
 |---|---|---|
 | Hash collision on token sequence | Very low (FxHash 64-bit on token ids, not strings) | `debug_assert` prefix length match after hit; log collision metrics |
-| LoRA adapter id not propagated to cache call site | Medium — call sites spread across `generate.rs` | `PrefixPageCache::lookup` signature requires `adapter_id: u64`; omitting it is a compile error |
+| LoRA adapter id not propagated to cache call site | Medium — call sites spread across `generate.rs` | `PrefixPageCache::lookup` signature requires `AdapterId`; omitting it is a compile error |
 | Arc ref-count overhead on prefix restore | Low — one `clone()` per page per layer at restore | Profile shows atomic increment < 5 ns; restore of 8 pages = 40 ns, negligible vs prefill |
 | Cache invalidation on model reload | Low but silent | `PrefixPageCache::clear()` called on model swap; cache is owned by session, not global |
 | Prefix cache grows unbounded in long session | Medium — embedding loops can insert many entries | Bounded LRU capacity (default 128 entries); eviction is O(1) with `IndexMap` |

--- a/docs/adr/ADR-047-paged-kv-cache.md
+++ b/docs/adr/ADR-047-paged-kv-cache.md
@@ -37,10 +37,11 @@ allocate and populate separate pages rather than pointing at the same physical p
 Add a **prefix-sharing layer** on top of the existing `PagedKVCache` infrastructure. The design has
 two components:
 
-1. **`PrefixPageCache`**: A bounded LRU hash map keyed by `u64` prefix hash (FxHash of the token
-   slice). On a hit, the caller receives read-only shared `Arc` references to pre-populated physical
-   pages. On a miss, newly computed pages are inserted and shared. This is the path for single-user
-   sessions on Apple Silicon — simpler than a radix tree, covers 90% of the benefit.
+1. **`PrefixPageCache`**: A bounded LRU hash map keyed by `PrefixKey { adapter_id: AdapterId,
+   token_hash: u64 }` (FxHash of the token slice, namespaced by adapter). On a hit, the caller
+   receives read-only shared `Arc` references to pre-populated physical pages. On a miss, newly
+   computed pages are inserted and shared. This is the path for single-user sessions on Apple
+   Silicon — simpler than a radix tree, covers 90% of the benefit.
 
 2. **`SharedPageRef`**: A thin newtype wrapping `Arc<[f32]>` (one arc per page, pointing into a
    shared `PagePool` allocation). Read access is lock-free; write access requires promotion to an
@@ -55,9 +56,8 @@ The radix tree approach (SGLang RadixAttention) is deferred to the server path (
 pub struct PrefixPageCache {
     /// max number of prefix entries retained.
     capacity: usize,
-    /// key: FxHash of token ids for the prefix
-    /// value: (prefix_len, Arc-wrapped physical page slice per layer)
-    entries: IndexMap<u64, PrefixEntry>,
+    /// key: (adapter_id, token_hash) — namespaced to prevent cross-adapter cache poisoning
+    entries: IndexMap<PrefixKey, PrefixEntry>,
 }
 
 pub struct PrefixEntry {

--- a/docs/adr/ADR-047-paged-kv-cache.md
+++ b/docs/adr/ADR-047-paged-kv-cache.md
@@ -67,10 +67,15 @@ pub struct PrefixEntry {
     pub last_used: std::time::Instant,
 }
 
+/// Adapter ID for LoRA-aware prefix namespacing.
+/// AdapterId(0) = base model (no adapter). Non-zero = content hash of loaded adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AdapterId(pub u64);
+
 impl PrefixPageCache {
     pub fn new(capacity: usize) -> Self;
-    pub fn lookup(&mut self, token_ids: &[u32]) -> Option<&PrefixEntry>;
-    pub fn insert(&mut self, token_ids: &[u32], entry: PrefixEntry);
+    pub fn lookup(&mut self, adapter_id: AdapterId, token_ids: &[u32]) -> Option<&PrefixEntry>;
+    pub fn insert(&mut self, adapter_id: AdapterId, token_ids: &[u32], entry: PrefixEntry);
     /// Evict LRU entries until at or below capacity.
     fn evict(&mut self);
 }

--- a/docs/adr/ADR-048-continuous-batching.md
+++ b/docs/adr/ADR-048-continuous-batching.md
@@ -1,0 +1,307 @@
+# ADR-048: Continuous Batching with Disaggregated Prefill/Decode
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: `lattice-inference`
+**Depends on**: ADR-004 (KV Cache), ADR-008 (LoRA Injection), ADR-047 (Paged KV Cache)
+
+---
+
+## Context
+
+The current generation API (`generate_greedy`, `generate_sampled`, `generate`) is single-request:
+one prompt in, one response out, blocking. The Metal forward path (`MetalQwen35State`,
+`forward_step`) is also single-session, as confirmed by `bench_concurrent.rs`:
+`forward_step` calls `cmd.commit()` + `wait_until_completed()` per token, serializing all GPU
+work through a synchronous barrier with no cross-session pipelining.
+
+Three serving problems emerge at scale:
+
+1. **Head-of-line blocking**: a 4096-token prefill stalls all waiting decode requests.
+2. **GPU underutilization during decode**: decode is memory-bandwidth-bound, leaving arithmetic
+   units idle. A single decode stream uses ~40% of Apple Silicon GPU compute.
+3. **No request lifecycle management**: no queue, no preemption, no SLA.
+
+Two techniques address these independently:
+
+**Continuous (in-flight) batching** (Orca, 2022): requests enter and exit the execution window
+at iteration boundaries rather than at request boundaries. The scheduler selects a batch each
+iteration; finished sequences are evicted and new ones fill their slots. This is the baseline
+for any production LLM serving system (llama.cpp, Ollama, vLLM all use it).
+
+**Disaggregated prefill/decode** (Splitwise, 2024; NVIDIA Dynamo; vLLM V1): separate compute-
+bound prefill from bandwidth-bound decode by routing them to distinct workers. On CUDA this
+requires KV cache transfer over NVLink or PCIe. On Apple Silicon unified memory, prefill and
+decode workers share the same physical memory — the "transfer" is a pointer swap with zero copy.
+This is a structural advantage of the Metal/unified-memory architecture.
+
+**Chunked prefill** (TRT-LLM, vLLM V1): long prompts are split into fixed-size chunks (e.g.,
+512 tokens) and interleaved with decode steps. Bounds prefill latency spikes without requiring
+separate workers.
+
+### Lattice-specific constraints
+
+- `PagedKVCache` (ADR-004/047) provides the memory substrate: 256-token pages, LRU eviction,
+  shared across sequences.
+- GDN attention (`src/attention/gdn.rs`) carries a per-sequence recurrent state matrix
+  (`S ∈ R^{d_model × d_model}`), not just KV pairs. This state must be batched and routed
+  alongside KV pages.
+- LoRA (ADR-008, ADR-043): different requests may use different adapters loaded via `LoraHook`.
+  The scheduler must track adapter identity per request and prevent mixing adapters within a
+  single batched matrix multiply.
+- Metal command buffers are not thread-safe; a `MTLCommandQueue` is, and multiple encoders
+  can be committed from one queue with ordering guarantees.
+
+---
+
+## Decision
+
+Implement continuous batching with chunked prefill. Defer full disaggregation to a second
+phase. In unified memory, chunked prefill achieves most of disaggregation's TTFT benefit
+without requiring a separate worker process.
+
+**Phase 1 (this ADR)**: Iteration-level scheduler with chunked prefill and a shared
+`PagedKVCache`. Single Metal command queue; prefill chunks and decode steps interleaved
+within the same iteration.
+
+**Phase 2 (future ADR)**: Disaggregated prefill worker — a separate Tokio task owning a
+dedicated Metal command buffer encoder, transferring KV page ownership to the decode pool
+via `Arc<PagedKvBlock>` pointer swap (zero physical copy).
+
+---
+
+## Scope
+
+This ADR covers interfaces and data structures only. It does not mandate any implementation
+timeline for Phase 2, and does not touch the CPU inference path (`generate.rs`).
+
+**In scope**:
+- `InferenceRequest` and `InferenceResponse` types
+- `Scheduler` trait and `FifoScheduler` implementation
+- Iteration loop structure for the serving task
+- GDN state batching protocol
+- LoRA adapter grouping constraint
+
+**Out of scope**:
+- HTTP/gRPC serving layer
+- Speculative decoding integration (ADR-006)
+- Quantization during serving (ADR-044)
+
+---
+
+## Architecture
+
+### Request lifecycle
+
+```text
+  Client submit
+       │
+       ▼
+  RequestQueue (tokio::sync::mpsc)
+       │
+       ▼
+  Scheduler::select_batch()     ← called each iteration
+       │
+       ├─ prefill slots: chunk prompt → PagedKvBlock allocation → Metal prefill pass
+       │
+       └─ decode slots: single token → KV append → Metal decode pass
+            │
+            ▼
+       SamplerPool::sample()    ← per-sequence sampling config
+            │
+            ▼
+       token → stream to caller (tokio::sync::oneshot or watch channel)
+            │ (if EOS or max_len)
+            ▼
+       PagedKvCache::release(seq_id)
+       GdnStatePool::release(seq_id)
+```
+
+### Core types
+
+```rust
+/// Stable identifier for a sequence across its lifetime in the scheduler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SeqId(u64);
+
+/// Submitted by the caller; scheduler takes ownership.
+pub struct InferenceRequest {
+    pub id: SeqId,
+    pub prompt_ids: Vec<u32>,
+    pub sampling: SamplingConfig,
+    /// None = base model. Some = adapter key for LoraHook dispatch.
+    pub lora_adapter: Option<AdapterKey>,
+    /// Maximum tokens to generate (hard cap enforced by scheduler).
+    pub max_new_tokens: usize,
+    pub response_tx: tokio::sync::mpsc::Sender<InferenceToken>,
+}
+
+/// Streamed back to caller one token at a time.
+pub struct InferenceToken {
+    pub seq_id: SeqId,
+    pub token_id: u32,
+    pub finished: bool,
+    pub finish_reason: Option<FinishReason>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum FinishReason {
+    Eos,
+    MaxLength,
+    Preempted,   // scheduler evicted this sequence under memory pressure
+}
+```
+
+### Scheduler trait
+
+```rust
+pub trait Scheduler: Send {
+    /// Called each iteration. Returns:
+    /// - `prefill`: sequences whose next chunk should run prefill this iteration.
+    /// - `decode`:  sequences ready for a single decode step.
+    /// Invariant: all sequences in `decode` have had at least one prefill chunk committed.
+    fn select_batch(
+        &mut self,
+        waiting: &[SeqId],
+        running: &[SeqId],
+        kv_free_pages: usize,
+        gdn_free_slots: usize,
+    ) -> SchedulerDecision;
+
+    /// Notify the scheduler that a sequence has been evicted (memory pressure).
+    fn on_preempt(&mut self, seq_id: SeqId);
+}
+
+pub struct SchedulerDecision {
+    pub prefill: Vec<(SeqId, /*chunk_start*/ usize, /*chunk_len*/ usize)>,
+    pub decode: Vec<SeqId>,
+    /// Sequences to evict before this iteration runs.
+    pub evict: Vec<SeqId>,
+}
+```
+
+`FifoScheduler` (Phase 1): FIFO queue, chunk size 512 tokens, no preemption. Eviction
+triggered only when `kv_free_pages < PREFILL_RESERVE_PAGES`.
+
+### GDN state batching
+
+GDN recurrent state `S ∈ R^{d_model × d_model}` per sequence cannot be packed into a
+standard KV page. It lives in `GdnStatePool`:
+
+```rust
+pub struct GdnStatePool {
+    /// One Metal buffer per sequence slot, pre-allocated at pool creation.
+    /// Capacity: max_concurrent_seqs × d_model × d_model × sizeof(f32).
+    buffers: Vec<metal::Buffer>,
+    free_slots: VecDeque<usize>,
+    seq_to_slot: HashMap<SeqId, usize>,
+}
+```
+
+During a batched decode iteration, the Metal kernel receives a list of `(seq_slot, kv_page_ids)`
+pairs. The GDN update for each sequence reads/writes its slot independently — no cross-sequence
+state sharing occurs. Batch size is bounded by `max_concurrent_seqs` (see Risks).
+
+### LoRA adapter grouping
+
+When multiple active sequences use different LoRA adapters, they cannot share a single batched
+matrix multiply because the weight delta is per-adapter. The scheduler groups sequences by
+adapter key before constructing each iteration's batch:
+
+```text
+Iteration batch = base_model_group ∪ adapter_A_group ∪ adapter_B_group
+```
+
+Each group runs as a separate sub-batch. Groups may be processed sequentially within one
+command buffer using separate `MTLComputeCommandEncoder` segments. This adds encoder
+boundary overhead but maintains correctness.
+
+If a pathological workload has N distinct adapters and N active sequences, throughput
+degrades to serial. A future ADR may address this via LoRA merged weights (adapter
+specialization at load time).
+
+### Metal command buffer structure (Phase 1)
+
+```text
+MTLCommandBuffer
+  ├── ComputeCommandEncoder: prefill chunks (all sequences in prefill group)
+  │     Layer 0..L: QKV → RoPE → GQA/GDN prefill → FFN
+  │     PagedKvCache: block allocation and write
+  ├── ComputeCommandEncoder: decode steps (all sequences in decode group)
+  │     Layer 0..L: QKV → RoPE → GQA/GDN decode → FFN
+  │     PagedKvCache: single-page append
+  └── commit() → wait_until_completed()
+```
+
+Phase 2 splits this into two separate command buffers submitted concurrently on two
+`MTLCommandQueue` instances (one prefill, one decode), using
+`addCompletedHandler` for async notification and `Arc<PagedKvBlock>` ownership transfer
+between them.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| **Request-level batching** (static) | Simple scheduler; no mid-batch eviction | Decode waits for slowest sequence; GPU idle during mismatched lengths | Rejected — baseline of 2022, superseded by Orca |
+| **Full disaggregation (Phase 2 now)** | Maximum TTFT/TBT separation; cleanest utilization | Two `MTLCommandQueue` instances add synchronization complexity; `Arc<PagedKvBlock>` ownership protocol unproven | Deferred — chunked prefill recovers most of the gain on single-GPU Apple Silicon |
+| **Separate process per worker** | True isolation; OS-level memory protection | IPC overhead; no shared Metal heap; defeats unified-memory zero-copy advantage | Rejected — Rust `async` tasks in one process with ownership transfer achieves isolation without IPC |
+| **Priority-based scheduler (SLA-aware)** | Better p99 latency for high-priority requests | Priority inversion risk; more complex preemption policy; premature for Phase 1 | Deferred to Phase 2 |
+| **Preemption via cache eviction** | Handles memory pressure gracefully | Must serialize evicted sequence's KV pages to CPU or disk; page fault on resume | Accepted for Phase 2; Phase 1 rejects new requests when memory is low instead of evicting |
+
+---
+
+## Risks
+
+**R1: GDN state pool capacity bounds maximum batch size.**
+`GdnStatePool` pre-allocates one Metal buffer per concurrent sequence. For Qwen3.5-2B
+(d_model=1536): 1536 × 1536 × 4 bytes = 9.4 MB per slot. On M2 Max (96 GB):
+available GDN pool ≈ (working_set × 0.2) / 9.4 MB ≈ ~2,000 slots. In practice, KV
+pages are the tighter constraint — measure empirically before setting `max_concurrent_seqs`.
+
+**R2: LoRA adapter grouping serializes multi-adapter workloads.**
+N adapters across N sequences = N sequential sub-batches. This is a P2 risk (not a
+correctness issue), surfaced for tracking. Mitigation: prioritize homogeneous adapter
+batches in the scheduler when adapter count exceeds a threshold.
+
+**R3: Metal command buffer granularity.**
+A single command buffer containing both prefill and decode encoders cannot be partially
+cancelled. If a prefill chunk exceeds the Metal device timeout (default 8 seconds for
+long prompts), the entire buffer fails. Mitigation: enforce `chunk_size ≤ 512` tokens,
+which bounds prefill time to ~100 ms on M2 Max for Qwen3.5-2B Q4.
+
+**R4: forward_step synchronization.**
+The current `forward_step` calls `wait_until_completed()` per token. This must change to
+`addCompletedHandler` + `tokio::sync::oneshot` for async notification. The migration
+requires restructuring `MetalQwen35State` so it does not hold GPU completion state on the
+call stack. This is a non-trivial refactor of the Metal path and must be prototyped before
+committing to the full serving loop.
+
+**R5: GDN recurrent state correctness under preemption.**
+If a sequence is preempted and its GDN slot is released, the state matrix is lost.
+On resume the sequence must restart from the beginning (re-prefill from token 0).
+For Phase 1 (no preemption), this is not triggered. For Phase 2, the preemption policy
+must serialize the GDN state to a CPU buffer before releasing the Metal slot.
+
+---
+
+## References
+
+- `src/generate.rs` — current single-request generation loop; `forward_with_cache` is the
+  target for refactoring into the serving forward path
+- `src/kv_cache/` — `PagedKVCache` (256-token pages, LRU eviction) — memory substrate
+- `src/attention/gdn.rs` — GDN recurrent state; per-sequence `S` matrix
+- `examples/bench_concurrent.rs` — confirms `forward_step` is synchronous (blocking
+  `wait_until_completed()`); documents the shared-engine API gap
+- Agrawal et al. 2024 — "Taming Throughput-Latency Tradeoff in LLM Inference with
+  Disaggregated Prefill-Decode" (Splitwise) — https://arxiv.org/abs/2311.18677
+- Yu et al. 2022 — "Orca: A Distributed Serving System for Transformer-Based Generative
+  Models" (iteration-level scheduling) — OSDI 2022
+- Metal Programming Guide — `MTLCommandQueue`, `addCompletedHandler`,
+  `recommendedMaxWorkingSetSize` — developer.apple.com/documentation/metal
+- vLLM V1 architecture — chunked prefill and disaggregated prefill design
+  — https://docs.vllm.ai/en/latest/design/v1/prefix_caching.html
+- ADR-004: KV Cache Design (`docs/adr/ADR-004-kv-cache.md`)
+- ADR-008: LoRA Injection via Trait Hook (`docs/adr/ADR-008-lora-injection.md`)
+- ADR-043: LoRA Serving Verification (`docs/adr/ADR-043-lora-serving-verification.md`)

--- a/docs/adr/ADR-048-continuous-batching.md
+++ b/docs/adr/ADR-048-continuous-batching.md
@@ -41,8 +41,11 @@ separate workers.
 
 ### Lattice-specific constraints
 
-- `PagedKVCache` (ADR-004/047) provides the memory substrate: 256-token pages, LRU eviction,
-  shared across sequences.
+- `PagedKVCache` (ADR-004/047) provides the per-sequence memory substrate: 256-token pages, LRU
+  eviction. Note: current `PagedKVCache` owns a single `PageTable`; multi-sequence support
+  requires managing multiple page tables externally (see `paged.rs:247-251`). This ADR defines
+  `SequenceManager` as that external owner. ADR-047's prefix cache also needs `AdapterId`-aware
+  lookup (defined there) before continuous batching can reuse prefixes across sequences.
 - GDN attention (`src/attention/gdn.rs`) carries a per-sequence recurrent state matrix
   (`S ∈ R^{d_model × d_model}`), not just KV pairs. This state must be batched and routed
   alongside KV pages.
@@ -113,8 +116,7 @@ timeline for Phase 2, and does not touch the CPU inference path (`generate.rs`).
        token → stream to caller (tokio::sync::oneshot or watch channel)
             │ (if EOS or max_len)
             ▼
-       PagedKvCache::release(seq_id)
-       GdnStatePool::release(seq_id)
+       SequenceManager::release(seq_id)  // drops PageTable + GDN state for this sequence
 ```
 
 ### Core types

--- a/docs/adr/ADR-049-vision-encoder.md
+++ b/docs/adr/ADR-049-vision-encoder.md
@@ -1,0 +1,297 @@
+# ADR-049: Vision Encoder Integration (Qwen-VL Path)
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: lattice-inference
+
+## Context
+
+Lattice currently processes only text: `BpeTokenizer` converts strings to token IDs, and
+`MetalQwen35State` runs a text-only decoder. There is no image ingestion path, no vision encoder,
+and no mechanism to prepend patch tokens to the text sequence.
+
+The natural extension is the Qwen-VL family. Lattice already targets Qwen3.5 for text — Qwen3-VL
+(arxiv:2502.13923) is the corresponding multimodal model and shares the same decoder weights.
+The Qwen-VL architecture is three components: (1) a ViT vision encoder, (2) a two-layer MLP
+merger that compresses patch embeddings, and (3) the decoder LLM, which is unchanged. The MLP
+merger is approximately 10 M parameters — negligible relative to the 7 B+ decoder.
+
+Qwen2.5-VL uses window attention in the ViT for efficiency; Qwen3-VL drops the cross-attention
+adapter of earlier versions and uses a purely MLP-based merger, which simplifies integration.
+Both variants output a flat sequence of patch embedding vectors that are prepended to the text
+token embeddings in the decoder's residual stream.
+
+The competitive baseline is mature: llama.cpp ships `libmtmd` supporting Qwen2.5-VL, Qwen3 Omni,
+Gemma3/4, Mistral Small 3.1, and Pixtral. Ollama exposes vision via its existing API. MLX has
+`mlx-vlm`. Lattice needs a clear integration path to remain relevant for multimodal workloads on
+Apple Silicon.
+
+Metal GPU can execute both the ViT encoder and the decoder without device transfer. The existing
+`MetalQwen35State` handles the LLM side; the only additions are image preprocessing, ViT forward
+pass, MLP projection, and sequence splicing.
+
+## Decision
+
+For v0, implement the Qwen-VL integration path inside `lattice-inference` as a new
+`vision` module. The scope is narrow and additive: the decoder is not modified. The vision module
+provides image preprocessing, a ViT forward pass over Metal, a two-layer MLP projector, and a
+`MultimodalInput` type that carries pre-projected patch embeddings alongside text tokens.
+
+The ViT weights are loaded from the Qwen3-VL safetensors checkpoint (same loading path as the
+decoder via ADR-003). No external image processing library is linked at the Metal kernel level;
+standard Rust `image` crate handles CPU-side resize and normalize before patch extraction.
+
+The integration point is `MetalQwen35State`: a new `generate_multimodal` entry point accepts
+`MultimodalInput`, prepends patch embeddings to the token embedding matrix, and delegates to the
+existing decode loop. The existing `generate_greedy` / `generate_sampled` paths are not changed.
+
+**Fixed resolution for v0**: 448 × 448 pixels, 14 × 14 patch size, 1024 patches per image.
+Dynamic resolution (Qwen2.5-VL's native tiling scheme) is deferred to v1.
+
+**Single VLM family for v0**: Qwen3-VL only. Generalizing to SigLIP, InternViT, or other ViT
+backbones is deferred until the integration pattern is validated.
+
+## Scope
+
+**v0 (this ADR)**:
+- `vision/preprocess.rs`: CPU-side image resize (bilinear), per-channel normalize, patch grid
+  extraction. Output: `Vec<f32>` shaped `[n_patches, patch_h, patch_w, 3]`.
+- `vision/vit.rs`: ViT encoder forward pass on Metal. Implements the Qwen3-VL ViT configuration
+  (patch size 14, window attention, 32 transformer blocks at the 7 B scale).
+- `vision/mlp_merger.rs`: Two-layer MLP projector on CPU (small enough that CPU is adequate).
+  Input: `[n_patches, d_vit]`. Output: `[n_patches, d_model]` where `d_model` matches the
+  decoder hidden dimension.
+- `vision/mod.rs`: `MultimodalInput { text_tokens: Vec<u32>, patch_embeddings: Array2<f32> }`
+  and `VisionEncoder::encode(image_bytes) -> Result<Array2<f32>>`.
+- `metal_qwen35.rs`: `generate_multimodal(input: MultimodalInput, config: GenerateConfig)`
+  entry point. Splices patch embeddings before position 0 of the token embedding sequence.
+- Weight loading: extend `load_qwen35_weights` to detect and load `vision_model.*` keys from
+  the VLM safetensors file. No new loader required.
+
+**Deferred**:
+- Dynamic resolution tiling (Qwen2.5-VL style — arbitrary input size tiled to NxM crops)
+- Multi-image inputs (more than one image per prompt)
+- Video frame input
+- SigLIP or InternViT as alternative ViT backends
+- Image caching across decode steps (KV-cache for the ViT output)
+- CPU fallback path for the ViT (Metal is assumed available on all Lattice targets)
+- Vision fine-tuning or LoRA injection into the ViT
+
+## Architecture
+
+### Core Types
+
+```rust
+// vision/mod.rs
+
+/// Preprocessed image ready for the ViT encoder.
+pub struct ImageTensor {
+    /// Row-major float32 pixel data: [n_patches, patch_h * patch_w * 3].
+    pub patches: Vec<f32>,
+    pub n_patches: usize,
+    pub patch_hw: usize,  // patch_h == patch_w == 14
+}
+
+/// A multimodal prompt: patch embeddings prepended to text tokens.
+pub struct MultimodalInput {
+    /// Projected patch vectors: [n_patches, d_model].
+    pub patch_embeddings: Vec<f32>,
+    pub n_patches: usize,
+    pub d_model: usize,
+    /// Text token IDs following the image.
+    pub text_tokens: Vec<u32>,
+}
+
+/// End-to-end vision encoder: image bytes → projected patch embeddings.
+pub struct VisionEncoder {
+    vit: ViT,
+    mlp: MlpMerger,
+}
+
+impl VisionEncoder {
+    pub fn new(weights: &VisionWeights, config: &ViTConfig) -> Result<Self, VisionError>;
+    /// Encode raw image bytes (JPEG or PNG). Returns [n_patches, d_model].
+    pub fn encode(&self, image_bytes: &[u8]) -> Result<Vec<f32>, VisionError>;
+}
+```
+
+```rust
+// vision/preprocess.rs
+
+pub struct PreprocessConfig {
+    pub image_size: u32,   // 448 for v0
+    pub patch_size: u32,   // 14 for v0
+    pub mean: [f32; 3],    // Qwen3-VL normalization constants
+    pub std:  [f32; 3],
+}
+
+/// Decode + resize to `image_size × image_size`, normalize, extract patch grid.
+/// Returns Vec<f32> shaped [n_patches, patch_size * patch_size * 3] (row-major).
+pub fn preprocess(image_bytes: &[u8], cfg: &PreprocessConfig)
+    -> Result<ImageTensor, VisionError>;
+```
+
+```rust
+// vision/vit.rs  — Metal-backed ViT encoder
+
+pub struct ViT {
+    config: ViTConfig,
+    // Metal buffers for patch embedding projection, attention, MLP weights.
+    // Allocated once at construction; reused across encode calls.
+    patch_embed: MetalLinear,
+    blocks: Vec<ViTBlock>,
+    norm: MetalLayerNorm,
+}
+
+pub struct ViTConfig {
+    pub image_size: u32,         // 448
+    pub patch_size: u32,         // 14
+    pub n_patches: usize,        // (448/14)^2 = 1024
+    pub d_model: usize,          // 1152 for Qwen3-VL 7B
+    pub n_heads: usize,          // 16
+    pub n_layers: usize,         // 32
+    pub window_size: usize,      // 4 (window attention, Qwen2.5-VL convention)
+    pub global_attn_every: usize,// every 4 blocks uses global attention
+}
+
+impl ViT {
+    /// Forward pass. Input: `ImageTensor` (CPU). Output: `[n_patches, d_model]` (CPU).
+    /// Internally allocates Metal command buffer, runs encoder, reads back to CPU.
+    pub fn forward(&self, img: &ImageTensor) -> Result<Vec<f32>, VisionError>;
+}
+```
+
+```rust
+// vision/mlp_merger.rs  — CPU-side MLP projector
+
+pub struct MlpMerger {
+    w1: Vec<f32>,  // [d_vit, d_hidden]
+    b1: Vec<f32>,
+    w2: Vec<f32>,  // [d_hidden, d_model]
+    b2: Vec<f32>,
+    d_vit: usize,
+    d_hidden: usize,
+    d_model: usize,
+}
+
+impl MlpMerger {
+    /// Project ViT output to decoder hidden dimension.
+    /// Input: flat f32 slice [n_patches * d_vit].
+    /// Output: Vec<f32> [n_patches * d_model].
+    pub fn project(&self, vit_out: &[f32], n_patches: usize) -> Vec<f32>;
+}
+```
+
+### Integration with MetalQwen35State
+
+`MetalQwen35State` gains a new entry point:
+
+```rust
+impl MetalQwen35State {
+    /// Multimodal generation. Patch embeddings are prepended to the token
+    /// embedding sequence before the first decode step. Position IDs for
+    /// the text tokens are offset by `input.n_patches`. All other decode
+    /// parameters (KV cache, sampling, EOS) behave identically to
+    /// `generate_greedy` / `generate_sampled`.
+    pub fn generate_multimodal(
+        &mut self,
+        input: MultimodalInput,
+        config: GenerateConfig,
+    ) -> Result<Vec<u32>, InferenceError>;
+}
+```
+
+Internally, `generate_multimodal` calls `embed_tokens` for the text portion and concatenates
+the patch embeddings at position 0 before the first prefill call. RoPE position IDs start
+at `n_patches` for the first text token, so image patches occupy positions `[0, n_patches)`.
+This matches the Qwen3-VL positional encoding convention.
+
+### Weight Loading
+
+The Qwen3-VL checkpoint stores vision weights under `vision_model.*` keys in the safetensors
+file. The existing `load_qwen35_weights` function (ADR-003) is extended with a
+`load_vision_weights` pass that reads these keys into `VisionWeights`, which is then passed to
+`VisionEncoder::new`. Models without `vision_model.*` keys (text-only Qwen3.5) load unchanged.
+
+### Memory Budget (7 B model)
+
+| Component | Parameters | fp16 size |
+|---|---|---|
+| ViT encoder | ~300 M | ~600 MB |
+| MLP merger | ~10 M | ~20 MB |
+| Decoder (Qwen3.5-7B) | ~7 B | ~14 GB |
+| Patch KV activations (1024 patches) | — | ~50 MB |
+| **Total** | | **~15 GB** |
+
+Apple M2/M3/M4 Max with 48 GB unified memory accommodates this. The 16 GB base tier cannot;
+v0 targets 32 GB+ configurations. A future 3 B VLM variant would target 16 GB.
+
+## Alternatives Considered
+
+**1. FFI to llama.cpp libmtmd**
+llama.cpp's `libmtmd` is mature and supports 10+ VLM families. FFI is technically feasible.
+Rejected: (a) violates the pure-Rust constraint (ADR-001); (b) introduces a C++ build dependency
+that breaks the single-`cargo build` workflow; (c) llama.cpp's Metal path and Lattice's Metal
+path would compete for the same GPU command queue without a coordination layer.
+
+**2. MLX-VLM via subprocess**
+`mlx-vlm` is a Python library with native Apple Silicon support. Spawning a subprocess for
+inference contradicts Lattice's no-subprocess design and adds ~200 ms cold-start latency per
+encode call. Rejected for architectural reasons.
+
+**3. Load SigLIP weights instead of InternViT/Qwen ViT**
+SigLIP (from Google) is used by LLaVA-style models and PaliGemma. It would require a separate
+weight file and a different normalization convention. Since Lattice targets Qwen3-VL, using the
+ViT already bundled in the Qwen3-VL checkpoint is the path of least resistance. Deferred as a
+future alternative backend when multi-family support is warranted.
+
+**4. Cross-attention adapter (Q-Former style)**
+Qwen2-VL and BLIP-2 use a Q-Former or cross-attention adapter between the ViT and the decoder.
+Qwen3-VL replaced this with the simpler MLP merger. The MLP path is implemented here; the
+cross-attention design is explicitly not pursued for v0 since Qwen3-VL is the target.
+
+**5. Dynamic resolution from v0**
+Qwen2.5-VL tiles arbitrary-resolution images to NxM crops, enabling higher-resolution inputs.
+This complicates sequence length management and KV cache sizing. Fixed 448×448 is sufficient for
+standard benchmarks (TextVQA, DocVQA single-page) and lets v0 ship without dynamic shape logic.
+Deferred to v1.
+
+## Risks
+
+**R1: ViT Metal kernel correctness**
+The ViT uses window attention with periodic global attention layers — a non-standard attention
+pattern. Mitigation: validate ViT output numerically against the Hugging Face PyTorch reference
+(Qwen/Qwen3-VL-7B-Instruct) on a fixed test image; require cosine similarity > 0.999 between
+Lattice and reference patch embeddings before merging.
+
+**R2: Unified memory pressure at 32 GB**
+The ViT (~600 MB) + decoder (~14 GB) + activations push close to 16 GB peak during prefill on
+32 GB machines if Metal command buffers are allocated concurrently. Mitigation: encode the image
+first, read ViT output back to CPU, release Metal ViT buffers, then run the decoder. Sequential
+rather than concurrent GPU use keeps peak below 15 GB.
+
+**R3: Positional encoding alignment**
+Patch tokens use 2D RoPE in Qwen3-VL (row and column indices, not sequential position IDs).
+The existing 1D RoPE implementation (ADR-007) cannot be reused for the visual tokens without
+extension. Mitigation: patch tokens bypass RoPE in the decoder (position embeddings for image
+tokens are applied inside the ViT, not re-applied in the decoder). Confirm this matches the
+Qwen3-VL reference implementation before finalizing.
+
+**R4: Weight key schema drift between Qwen2.5-VL and Qwen3-VL**
+Safetensors key names differ between model versions. Mitigation: enumerate the actual key
+prefixes for both model variants in the weight loader; emit a clear error if unrecognized
+vision keys are encountered.
+
+**R5: `image` crate decode performance**
+The `image` crate (CPU decode + resize) adds ~5–20 ms per image. Acceptable for interactive
+workloads. Not acceptable for video frame throughput. Mitigation: document the limitation;
+defer Metal-accelerated image decode to v1 when video inputs are scoped.
+
+## References
+
+- Qwen2.5-VL paper: arxiv:2502.13923 — architecture overview, MLP merger design, window attention
+- Qwen3-VL model card: huggingface.co/Qwen/Qwen3-VL-7B-Instruct
+- llama.cpp libmtmd: `tools/mtmd/` in the llama.cpp repository — reference for VLM token splicing
+- MLX-VLM: github.com/ml-explore/mlx-vlm — Apple Silicon reference implementation (Python)
+- Prior lattice ADRs: ADR-001 (pure Rust), ADR-003 (safetensors loading), ADR-007 (RoPE),
+  ADR-009 (model architectures), ADR-010 (attention mechanisms)

--- a/docs/adr/ADR-049-vision-encoder.md
+++ b/docs/adr/ADR-049-vision-encoder.md
@@ -10,16 +10,22 @@ Lattice currently processes only text: `BpeTokenizer` converts strings to token 
 `MetalQwen35State` runs a text-only decoder. There is no image ingestion path, no vision encoder,
 and no mechanism to prepend patch tokens to the text sequence.
 
-The natural extension is the Qwen-VL family. Lattice already targets Qwen3.5 for text — Qwen3-VL
-(arxiv:2502.13923) is the corresponding multimodal model and shares the same decoder weights.
-The Qwen-VL architecture is three components: (1) a ViT vision encoder, (2) a two-layer MLP
-merger that compresses patch embeddings, and (3) the decoder LLM, which is unchanged. The MLP
-merger is approximately 10 M parameters — negligible relative to the 7 B+ decoder.
+The natural extension is the Qwen-VL family. Lattice already targets Qwen3.5 for text; the
+corresponding multimodal variants are Qwen2.5-VL (arxiv:2502.13923) and Qwen3-VL.
 
-Qwen2.5-VL uses window attention in the ViT for efficiency; Qwen3-VL drops the cross-attention
-adapter of earlier versions and uses a purely MLP-based merger, which simplifies integration.
+**Qwen2.5-VL** (arxiv:2502.13923): ViT with window attention + 2D RoPE, MLP merger, decoder LLM.
+Depth 32, patch size 14, temporal_patch_size 2.
+
+**Qwen3-VL** (Hugging Face `Qwen3VLVisionConfig` defaults): ViT depth 27, patch size 16,
+spatial_merge_size 2, MLP-based merger (no cross-attention adapter). Shares the Qwen3.5 decoder
+backbone.
+
 Both variants output a flat sequence of patch embedding vectors that are prepended to the text
-token embeddings in the decoder's residual stream.
+token embeddings in the decoder's residual stream. The MLP merger is approximately 10 M parameters
+— negligible relative to the decoder.
+
+This ADR targets **Qwen3-VL** as v0, using its actual Hugging Face config (depth 27, patch 16),
+not the Qwen2.5-VL architecture.
 
 The competitive baseline is mature: llama.cpp ships `libmtmd` supporting Qwen2.5-VL, Qwen3 Omni,
 Gemma3/4, Mistral Small 3.1, and Pixtral. Ollama exposes vision via its existing API. MLX has
@@ -74,7 +80,8 @@ backbones is deferred until the integration pattern is validated.
 - Video frame input
 - SigLIP or InternViT as alternative ViT backends
 - Image caching across decode steps (KV-cache for the ViT output)
-- CPU fallback path for the ViT (Metal is assumed available on all Lattice targets)
+- CPU fallback path for the ViT (v0 is Metal-only as an experimental feature; a CPU ViT
+  forward pass is straightforward to add as a follow-up since all ops are standard linear algebra)
 - Vision fine-tuning or LoRA injection into the ViT
 
 ## Architecture
@@ -145,12 +152,12 @@ pub struct ViT {
 
 pub struct ViTConfig {
     pub image_size: u32,         // 448
-    pub patch_size: u32,         // 14
-    pub n_patches: usize,        // (448/14)^2 = 1024
+    pub patch_size: u32,         // 16 (Qwen3-VL default)
+    pub n_patches: usize,        // (448/16)^2 = 784
     pub d_model: usize,          // 1152 for Qwen3-VL 7B
     pub n_heads: usize,          // 16
-    pub n_layers: usize,         // 32
-    pub window_size: usize,      // 4 (window attention, Qwen2.5-VL convention)
+    pub n_layers: usize,         // 27 (Qwen3-VL default)
+    pub spatial_merge_size: usize, // 2 (Qwen3-VL default)
     pub global_attn_every: usize,// every 4 blocks uses global attention
 }
 

--- a/docs/adr/ADR-049-vision-encoder.md
+++ b/docs/adr/ADR-049-vision-encoder.md
@@ -121,8 +121,17 @@ pub struct VisionEncoder {
 
 impl VisionEncoder {
     pub fn new(weights: &VisionWeights, config: &ViTConfig) -> Result<Self, VisionError>;
-    /// Encode raw image bytes (JPEG or PNG). Returns [n_patches, d_model].
-    pub fn encode(&self, image_bytes: &[u8]) -> Result<Vec<f32>, VisionError>;
+    /// Encode raw image bytes (JPEG or PNG) through ViT + spatial merge + MLP.
+    /// Returns projected embeddings shaped [visual_tokens, d_model] along with
+    /// raw_patches and visual_tokens counts for MultimodalInput construction.
+    pub fn encode(&self, image_bytes: &[u8]) -> Result<VisionOutput, VisionError>;
+}
+
+pub struct VisionOutput {
+    pub patch_embeddings: Vec<f32>, // [visual_tokens * d_model]
+    pub raw_patches: usize,         // before merge (e.g., 784)
+    pub visual_tokens: usize,       // after merge (e.g., 196)
+    pub d_model: usize,
 }
 ```
 

--- a/docs/adr/ADR-049-vision-encoder.md
+++ b/docs/adr/ADR-049-vision-encoder.md
@@ -51,8 +51,9 @@ The integration point is `MetalQwen35State`: a new `generate_multimodal` entry p
 `MultimodalInput`, prepends patch embeddings to the token embedding matrix, and delegates to the
 existing decode loop. The existing `generate_greedy` / `generate_sampled` paths are not changed.
 
-**Fixed resolution for v0**: 448 × 448 pixels, 14 × 14 patch size, 1024 patches per image.
-Dynamic resolution (Qwen2.5-VL's native tiling scheme) is deferred to v1.
+**Fixed resolution for v0**: 448 × 448 pixels, 16 × 16 patch size (Qwen3-VL default), yielding
+(448/16)² = 784 raw patches. With `spatial_merge_size=2`, the post-merge decoder receives
+784/4 = 196 visual tokens. Dynamic resolution tiling is deferred to v1.
 
 **Single VLM family for v0**: Qwen3-VL only. Generalizing to SigLIP, InternViT, or other ViT
 backbones is deferred until the integration pattern is validated.
@@ -63,7 +64,7 @@ backbones is deferred until the integration pattern is validated.
 - `vision/preprocess.rs`: CPU-side image resize (bilinear), per-channel normalize, patch grid
   extraction. Output: `Vec<f32>` shaped `[n_patches, patch_h, patch_w, 3]`.
 - `vision/vit.rs`: ViT encoder forward pass on Metal. Implements the Qwen3-VL ViT configuration
-  (patch size 14, window attention, 32 transformer blocks at the 7 B scale).
+  (patch size 16, depth 27, spatial merge size 2 per Qwen3-VL HF defaults).
 - `vision/mlp_merger.rs`: Two-layer MLP projector on CPU (small enough that CPU is adequate).
   Input: `[n_patches, d_vit]`. Output: `[n_patches, d_model]` where `d_model` matches the
   decoder hidden dimension.
@@ -96,7 +97,7 @@ pub struct ImageTensor {
     /// Row-major float32 pixel data: [n_patches, patch_h * patch_w * 3].
     pub patches: Vec<f32>,
     pub n_patches: usize,
-    pub patch_hw: usize,  // patch_h == patch_w == 14
+    pub patch_hw: usize,  // patch_h == patch_w == 16 (Qwen3-VL)
 }
 
 /// A multimodal prompt: patch embeddings prepended to text tokens.
@@ -127,7 +128,7 @@ impl VisionEncoder {
 
 pub struct PreprocessConfig {
     pub image_size: u32,   // 448 for v0
-    pub patch_size: u32,   // 14 for v0
+    pub patch_size: u32,   // 16 for v0 (Qwen3-VL default)
     pub mean: [f32; 3],    // Qwen3-VL normalization constants
     pub std:  [f32; 3],
 }
@@ -227,7 +228,7 @@ file. The existing `load_qwen35_weights` function (ADR-003) is extended with a
 | ViT encoder | ~300 M | ~600 MB |
 | MLP merger | ~10 M | ~20 MB |
 | Decoder (Qwen3.5-7B) | ~7 B | ~14 GB |
-| Patch KV activations (1024 patches) | — | ~50 MB |
+| Patch KV activations (784 raw → 196 merged) | — | ~50 MB |
 | **Total** | | **~15 GB** |
 
 Apple M2/M3/M4 Max with 48 GB unified memory accommodates this. The 16 GB base tier cannot;

--- a/docs/adr/ADR-049-vision-encoder.md
+++ b/docs/adr/ADR-049-vision-encoder.md
@@ -69,8 +69,9 @@ backbones is deferred until the integration pattern is validated.
   adjacent patches, concatenates features, then projects to decoder hidden dim.
   Input: `[raw_patches, d_vit]`. Output: `[visual_tokens, d_model]` where
   `visual_tokens = raw_patches / spatial_merge_size²`.
-- `vision/mod.rs`: `MultimodalInput` (see Architecture §Core Types) and
-  `VisionEncoder::encode(image_bytes) -> Result<MultimodalInput>`.
+- `vision/mod.rs`: `VisionOutput`, `MultimodalInput` (see Architecture §Core Types), and
+  `VisionEncoder::encode(image_bytes) -> Result<VisionOutput>`. Callers combine `VisionOutput`
+  with text token IDs to construct `MultimodalInput`.
 - `metal_qwen35.rs`: `generate_multimodal(input: MultimodalInput, config: GenerateConfig)`
   entry point. Prepends `visual_tokens` patch embeddings before text token embeddings.
 - Weight loading: extend `load_qwen35_weights` to detect and load `vision_model.*` keys from

--- a/docs/adr/ADR-049-vision-encoder.md
+++ b/docs/adr/ADR-049-vision-encoder.md
@@ -65,13 +65,14 @@ backbones is deferred until the integration pattern is validated.
   extraction. Output: `Vec<f32>` shaped `[n_patches, patch_h, patch_w, 3]`.
 - `vision/vit.rs`: ViT encoder forward pass on Metal. Implements the Qwen3-VL ViT configuration
   (patch size 16, depth 27, spatial merge size 2 per Qwen3-VL HF defaults).
-- `vision/mlp_merger.rs`: Two-layer MLP projector on CPU (small enough that CPU is adequate).
-  Input: `[n_patches, d_vit]`. Output: `[n_patches, d_model]` where `d_model` matches the
-  decoder hidden dimension.
-- `vision/mod.rs`: `MultimodalInput { text_tokens: Vec<u32>, patch_embeddings: Array2<f32> }`
-  and `VisionEncoder::encode(image_bytes) -> Result<Array2<f32>>`.
+- `vision/mlp_merger.rs`: Two-layer MLP with spatial merge. Groups `spatial_merge_size²`
+  adjacent patches, concatenates features, then projects to decoder hidden dim.
+  Input: `[raw_patches, d_vit]`. Output: `[visual_tokens, d_model]` where
+  `visual_tokens = raw_patches / spatial_merge_size²`.
+- `vision/mod.rs`: `MultimodalInput` (see Architecture §Core Types) and
+  `VisionEncoder::encode(image_bytes) -> Result<MultimodalInput>`.
 - `metal_qwen35.rs`: `generate_multimodal(input: MultimodalInput, config: GenerateConfig)`
-  entry point. Splices patch embeddings before position 0 of the token embedding sequence.
+  entry point. Prepends `visual_tokens` patch embeddings before text token embeddings.
 - Weight loading: extend `load_qwen35_weights` to detect and load `vision_model.*` keys from
   the VLM safetensors file. No new loader required.
 
@@ -206,9 +207,9 @@ impl MlpMerger {
 
 ```rust
 impl MetalQwen35State {
-    /// Multimodal generation. Patch embeddings are prepended to the token
-    /// embedding sequence before the first decode step. Position IDs for
-    /// the text tokens are offset by `input.n_patches`. All other decode
+    /// Multimodal generation. Merged visual token embeddings are prepended to the
+    /// text token embedding sequence before the first decode step. Position IDs for
+    /// the text tokens are offset by `input.visual_tokens`. All other decode
     /// parameters (KV cache, sampling, EOS) behave identically to
     /// `generate_greedy` / `generate_sampled`.
     pub fn generate_multimodal(
@@ -220,9 +221,10 @@ impl MetalQwen35State {
 ```
 
 Internally, `generate_multimodal` calls `embed_tokens` for the text portion and concatenates
-the patch embeddings at position 0 before the first prefill call. RoPE position IDs start
-at `n_patches` for the first text token, so image patches occupy positions `[0, n_patches)`.
-This matches the Qwen3-VL positional encoding convention.
+the merged visual token embeddings at position 0 before the first prefill call. RoPE position
+IDs start at `visual_tokens` for the first text token, so visual tokens occupy positions
+`[0, visual_tokens)`. For 448×448 with patch 16 and merge 2: visual_tokens=196, so the first
+text token starts at position 196.
 
 ### Weight Loading
 

--- a/docs/adr/ADR-049-vision-encoder.md
+++ b/docs/adr/ADR-049-vision-encoder.md
@@ -100,11 +100,13 @@ pub struct ImageTensor {
     pub patch_hw: usize,  // patch_h == patch_w == 16 (Qwen3-VL)
 }
 
-/// A multimodal prompt: patch embeddings prepended to text tokens.
+/// A multimodal prompt: merged visual tokens prepended to text tokens.
 pub struct MultimodalInput {
-    /// Projected patch vectors: [n_patches, d_model].
+    /// Projected + merged patch vectors: [visual_tokens, d_model].
+    /// After spatial merge: visual_tokens = raw_patches / (spatial_merge_size^2).
     pub patch_embeddings: Vec<f32>,
-    pub n_patches: usize,
+    pub raw_patches: usize,        // before merge (e.g., 784 for 448/16)
+    pub visual_tokens: usize,      // after merge (e.g., 196 for merge_size=2)
     pub d_model: usize,
     /// Text token IDs following the image.
     pub text_tokens: Vec<u32>,
@@ -183,11 +185,19 @@ pub struct MlpMerger {
 }
 
 impl MlpMerger {
-    /// Project ViT output to decoder hidden dimension.
-    /// Input: flat f32 slice [n_patches * d_vit].
-    /// Output: Vec<f32> [n_patches * d_model].
-    pub fn project(&self, vit_out: &[f32], n_patches: usize) -> Vec<f32>;
+    /// Merge + project ViT output to decoder hidden dimension.
+    /// Groups spatial_merge_size^2 adjacent patches, concatenates their features,
+    /// then projects through the two-layer MLP.
+    /// Input: flat f32 slice [raw_patches * d_vit].
+    /// Output: Vec<f32> [merged_patches * d_model] where merged = raw / merge_size^2.
+    pub fn merge_and_project(&self, vit_out: &[f32], raw_patches: usize) -> Vec<f32>;
 }
+
+// Note: v0 implements a simplified Qwen3-VL path without DeepStack visual indexes
+// or visual_pos_masks. This means v0 is NOT reference-equivalent to the full HF
+// Qwen3-VL pipeline. The > 0.999 cosine similarity acceptance criterion applies
+// only to the ViT encoder output, not the full end-to-end VLM. DeepStack support
+// is deferred to v1.
 ```
 
 ### Integration with MetalQwen35State

--- a/docs/adr/ADR-050-rejection-sampling.md
+++ b/docs/adr/ADR-050-rejection-sampling.md
@@ -187,8 +187,8 @@ speedup over linear drafts by combining tree drafting with context-aware confide
 This is the long-term target architecture. Not adopted here because: (a) `MtpVerifier` produces
 a linear draft sequence, not a tree; (b) tree verification requires parallel logit comparison
 across O(K^depth) paths, needing a Metal kernel rewrite; (c) GDN snapshot cost grows with tree
-width. ADR-051 will address tree-structured drafting once the correctness foundation (this ADR)
-is in place.
+width. Tree-structured drafting will be addressed in a future ADR once the correctness foundation
+(this ADR) is in place.
 
 **C. Speculative rejection sampling only for the MTP path, skip n-gram path.**
 The n-gram path is a retrieval mechanism, not a learned sampler, so its "draft distribution"
@@ -201,11 +201,11 @@ needed.
 
 ## Risks
 
-**R1: GDN snapshot memory.** 46 MB per snapshot for Qwen3.5-2B is acceptable on Apple Silicon
-(unified memory, 16–192 GB). For larger models (72B class) this would be ~400 MB. The snapshot
-is ephemeral (held for one speculative step, then discarded or restored). Mitigation: snapshot
-is heap-allocated once and reused across steps via a `Vec::clear()` + `extend_from_slice` pattern
-to avoid per-step allocation.
+**R1: GDN snapshot memory.** See ADR-052 §Memory Budget for authoritative per-config estimates
+(~19.3 MiB for Qwen3.5-0.8B). For larger models the snapshot scales with `num_heads * key_dim *
+value_dim * num_gdn_layers`. The snapshot is ephemeral (held for one speculative step, then
+discarded or restored). Mitigation: snapshot is heap-allocated once and reused across steps via
+a `Vec::clear()` + `extend_from_slice` pattern to avoid per-step allocation.
 
 **R2: RNG reproducibility.** Strict sampling introduces stochastic behavior. Tests that assert
 exact token sequences must be updated to use seeded RNG or test at temperature=0. The

--- a/docs/adr/ADR-050-rejection-sampling.md
+++ b/docs/adr/ADR-050-rejection-sampling.md
@@ -139,7 +139,7 @@ fn restore_gdn_states(&mut self, snapshot: &GdnSnapshot);
 // GdnSnapshot = Vec<(Vec<f32>, Vec<f32>)>
 //   index i = layer i: (s_matrices.clone(), conv_buffer.clone())
 // Memory budget: see ADR-052 §Memory Budget for authoritative per-config estimates.
-// For Qwen3.5-0.8B: ~19.3 MiB per snapshot (18 GDN layers, 16 heads, 128×128 state + 6144×3 conv)
+// For Qwen3.5-2B: ~19.3 MiB per snapshot (18 GDN layers, 16 heads, 128×128 state + 6144×3 conv)
 ```
 
 Snapshot frequency: once per speculative step (before draft generation). Not per-token. The
@@ -202,7 +202,7 @@ needed.
 ## Risks
 
 **R1: GDN snapshot memory.** See ADR-052 §Memory Budget for authoritative per-config estimates
-(~19.3 MiB for Qwen3.5-0.8B). For larger models the snapshot scales with `num_heads * key_dim *
+(~19.3 MiB for Qwen3.5-2B). For larger models the snapshot scales with `num_heads * key_dim *
 value_dim * num_gdn_layers`. The snapshot is ephemeral (held for one speculative step, then
 discarded or restored). Mitigation: snapshot is heap-allocated once and reused across steps via
 a `Vec::clear()` + `extend_from_slice` pattern to avoid per-step allocation.

--- a/docs/adr/ADR-050-rejection-sampling.md
+++ b/docs/adr/ADR-050-rejection-sampling.md
@@ -1,0 +1,233 @@
+# ADR-050: Rejection Sampling for Speculative Decoding
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: `lattice-inference`
+
+---
+
+## Context
+
+ADR-006 introduced two speculative decoding paths: `NgramSpeculator` (prompt-lookup) and
+`MtpVerifier` (1-layer MoE transformer). Both verification paths (`mtp_verify_draft` and
+`verify_draft`) accept draft tokens via greedy argmax comparison:
+
+```rust
+// Current: mtp_verify_draft, line 1156 / 1212
+let model_choice = argmax(&target_logits[i - 1]) as u32;
+if model_choice != draft[i] { /* reject */ }
+```
+
+Greedy argmax acceptance does NOT preserve the target model's output distribution. The output
+sequence at temperature > 0 is biased toward whichever tokens the draft model favors, violating
+the core guarantee that speculative decoding should produce samples indistinguishable from
+auto-regressive sampling from the target. The KG gap entity `ResidualRejectionSamplingVariants`
+(status="gap") explicitly flags this deficiency.
+
+**Strict speculative sampling** (Leviathan et al. 2022 / SpecTr, NeurIPS 2023) closes this gap.
+For each draft token `d_i` drawn from draft distribution `q`, the target model provides
+distribution `p`. The token is accepted with probability:
+
+```
+α_i = min(1, p(d_i) / q(d_i))
+```
+
+On rejection, a correction token is drawn from:
+
+```
+p'(x) = normalize(max(0, p(x) - q(x)))
+```
+
+This guarantees the joint output distribution is exactly `p`, regardless of the draft quality.
+The per-token acceptance probability is `β(θ) = 1 - TV(q, p)` where TV is total variation
+distance. Speedup is `1 / (1 - β·K)` for K draft tokens.
+
+**GDN complication.** Qwen3.5-2B's 18 GatedDeltaNet layers maintain a recurrent state matrix
+`S[key_dim × value_dim]` per head (see `GatedDeltaNetState::s_matrices`). Unlike KV cache,
+which is an append-only sequence of (K, V) pairs truncatable via `FlatKVCache::truncate_to()`,
+GDN state is a dense matrix updated in-place at every token via:
+
+```
+S = g * S + outer(k, (v - S @ k) * beta)
+```
+
+This update is not invertible. Rollback via `truncate_to` handles the KV path but has no
+counterpart for GDN state. A speculative rejection must restore the GDN state to the snapshot
+taken before the draft was generated. Under the nonexpansive decay bound from the KG entity
+`GDN Multi-Round Error Accumulation`, the error from processing N spurious tokens grows as
+`O(N * eps)` — silent corruption if rollback is skipped.
+
+---
+
+## Decision
+
+Replace the greedy argmax acceptance criterion in `mtp_verify_draft` with strict speculative
+sampling. Add a GDN state snapshot/restore protocol to the `MtpTargetVerifier` trait to enable
+correct rollback on rejection.
+
+The implementation is scoped to three changes:
+
+1. **Acceptance criterion**: convert draft and target logits to probability distributions via
+   softmax; accept token `d_i` with probability `min(1, p(d_i) / q(d_i))`; on rejection, sample
+   the correction token from `normalize(max(0, p - q))`. Temperature is a caller-provided
+   parameter; at temperature 0 the sampling path degenerates to the existing argmax behavior with
+   no correctness regression.
+
+2. **GDN state snapshot protocol**: extend `MtpTargetVerifier` with `snapshot_gdn_state()` and
+   `restore_gdn_state()` methods. Before draft generation begins, the verifier takes a snapshot of
+   all GDN layers' `s_matrices` and `conv_buffer` fields. On partial or full rejection, restore
+   is called before the correction token forward pass.
+
+3. **MTP KV cache**: `MtpVerifier::rollback_cache_to()` already calls `FlatKVCache::truncate_to()`
+   correctly. No change needed there.
+
+Greedy path (temperature = 0.0) is preserved as a fast path that bypasses the softmax and
+sampling arithmetic. This maintains backward compatibility with existing benchmarks.
+
+---
+
+## Scope
+
+Files affected:
+
+- `crates/inference/src/speculative.rs`: `MtpTargetVerifier` trait extension, `mtp_verify_draft`
+  acceptance loop, new `StrictSamplingConfig` parameter struct.
+- `crates/inference/src/attention/gdn.rs`: `GatedDeltaNetState` gains `snapshot()` and
+  `restore_from()` methods (clone into/from a caller-owned buffer).
+
+No changes to `NgramSpeculator`, `verify_draft` (n-gram path is greedy by design — it operates
+at temperature 0 as a retrieval mechanism, not a sampler), or any Metal kernel.
+
+---
+
+## Architecture
+
+### Sampling math
+
+```
+Given:
+  q[v] = softmax(draft_logits / T)[v]   -- draft distribution, T = temperature
+  p[v] = softmax(target_logits / T)[v]  -- target distribution
+
+For each draft position i:
+  u ~ Uniform(0, 1)
+  if u < min(1, p[d_i] / q[d_i]):
+      accept d_i                         -- no extra forward pass
+  else:
+      sample correction from p'          -- p'(x) = normalize(max(0, p(x) - q(x)))
+      commit correction token, stop draft
+
+At temperature 0: min(1, p[d_i]/q[d_i]) = 1 iff argmax(p) == d_i, else 0.
+This recovers the current greedy test exactly.
+```
+
+### GDN snapshot protocol
+
+```rust
+// Extension to MtpTargetVerifier trait
+fn snapshot_gdn_states(&self) -> GdnSnapshot;
+fn restore_gdn_states(&mut self, snapshot: &GdnSnapshot);
+
+// GdnSnapshot = Vec<(Vec<f32>, Vec<f32>)>
+//   index i = layer i: (s_matrices.clone(), conv_buffer.clone())
+// Allocation: num_gdn_layers * (key_dim * value_dim * num_heads + conv_dim * (kernel_size - 1))
+// For Qwen3.5-2B (18 GDN layers, key_dim=64, value_dim=64, 16 heads, conv_dim=512, kernel_size=4):
+//   18 * (64 * 64 * 16 + 512 * 3) * 4 bytes ≈ 46 MB per snapshot
+```
+
+Snapshot frequency: once per speculative step (before draft generation). Not per-token. The
+draft tokens are never committed to GDN state during speculative verification — the target model
+processes them via a separate batched forward path that does not mutate the recurrent state.
+Only accepted tokens are committed; the snapshot is discarded after full acceptance or used for
+restore after any rejection.
+
+### Integration with `mtp_verify_draft`
+
+The function signature gains a `StrictSamplingConfig`:
+
+```rust
+pub struct StrictSamplingConfig {
+    pub temperature: f32,   // 0.0 = greedy (fast path), > 0.0 = strict sampling
+    pub rng_seed: u64,      // deterministic seeding for reproducibility
+}
+```
+
+The acceptance loop is factored into a shared function so both the batched MTP path and the
+n-gram path can use it when needed:
+
+```rust
+fn sample_acceptance(
+    draft_token: u32,
+    draft_logits: &[f32],
+    target_logits: &[f32],
+    cfg: &StrictSamplingConfig,
+    rng: &mut SmallRng,
+) -> AcceptanceDecision  // Accept | Reject { correction_token }
+```
+
+---
+
+## Alternatives Considered
+
+**A. Keep greedy argmax, add temperature via top-p/top-k on the target only.**
+Partially improves output diversity but does not satisfy the distribution-preservation theorem.
+The output still depends on which draft tokens were proposed. Rejected: correctness gap remains.
+
+**B. SpecTr tree sampling (NeurIPS 2023) with tree-structured drafts.**
+SpecTr extends strict sampling to tree-structured draft sets, increasing expected acceptance by
+exploring multiple continuations per step. EAGLE-2/3 (arxiv:2406.16858, 2503.01840) show 3-4x
+speedup over linear drafts by combining tree drafting with context-aware confidence calibration.
+This is the long-term target architecture. Not adopted here because: (a) `MtpVerifier` produces
+a linear draft sequence, not a tree; (b) tree verification requires parallel logit comparison
+across O(K^depth) paths, needing a Metal kernel rewrite; (c) GDN snapshot cost grows with tree
+width. ADR-051 will address tree-structured drafting once the correctness foundation (this ADR)
+is in place.
+
+**C. Speculative rejection sampling only for the MTP path, skip n-gram path.**
+The n-gram path is a retrieval mechanism, not a learned sampler, so its "draft distribution"
+is degenerate (mass 1 on the proposed token). Strict sampling on this path collapses to greedy.
+This is correct and is what this ADR implements: the correction formula handles this automatically
+since `q[d_i] = 1.0` makes `p[d_i] / q[d_i] = p[d_i]` which is always `<= 1`. No special-casing
+needed.
+
+---
+
+## Risks
+
+**R1: GDN snapshot memory.** 46 MB per snapshot for Qwen3.5-2B is acceptable on Apple Silicon
+(unified memory, 16–192 GB). For larger models (72B class) this would be ~400 MB. The snapshot
+is ephemeral (held for one speculative step, then discarded or restored). Mitigation: snapshot
+is heap-allocated once and reused across steps via a `Vec::clear()` + `extend_from_slice` pattern
+to avoid per-step allocation.
+
+**R2: RNG reproducibility.** Strict sampling introduces stochastic behavior. Tests that assert
+exact token sequences must be updated to use seeded RNG or test at temperature=0. The
+`StrictSamplingConfig::rng_seed` field enables deterministic reproduction of any generated
+sequence.
+
+**R3: Draft logits unavailability.** The current `MtpVerifier::draft_tokens()` returns token IDs
+(line 1039), not logits. Strict sampling requires `q[d_i]`, the draft probability. The fix is to
+return `Vec<(u32, Vec<f32>)>` from `draft_tokens`, or store logits alongside the draft in a new
+`DraftResult` struct. This changes the internal API of `mtp_verify_draft` but not the public
+`MtpTargetVerifier` trait.
+
+**R4: Acceptance rate degradation at low temperature.** At very low but nonzero temperature, the
+draft and target distributions both sharpen toward their argmax. TV distance approaches 0 and
+acceptance rate approaches 1 — the sampling overhead is paid but yields no change from greedy.
+This is mathematically correct, not a bug.
+
+---
+
+## References
+
+- Leviathan et al., "Fast Inference from Transformers via Speculative Decoding" (2022),
+  arxiv:2211.17192. Original strict speculative sampling proof.
+- Sun et al., "SpecTr: Fast Speculative Decoding via Optimal Transport" (NeurIPS 2023).
+  Per-token acceptance probability `β(θ) = 1 - TV(p, q)` and batch extension.
+- Li et al., "EAGLE-2: Faster Inference of Language Models with Dynamic Draft Trees" (EMNLP 2024),
+  arxiv:2406.16858. Context-aware confidence calibration for tree width.
+- Du et al., "EAGLE-3: Scaling up Inference Acceleration of LLMs via Training-Time Test"
+  (Mar 2025), arxiv:2503.01840. Tri-layer fusion for draft head; P-EAGLE single-pass variant.
+- ADR-006: Speculative Decoding (Accepted, 2026-05-13) — baseline implementation this ADR amends.
+- KG entities: `Speculative Decoding`, `SpecTr`, `Per-Token Acceptance Probability β(θ)`,
+  `ResidualRejectionSamplingVariants` (gap), `GDN Multi-Round Error Accumulation`.

--- a/docs/adr/ADR-050-rejection-sampling.md
+++ b/docs/adr/ADR-050-rejection-sampling.md
@@ -40,7 +40,15 @@ p'(x) = normalize(max(0, p(x) - q(x)))
 
 This guarantees the joint output distribution is exactly `p`, regardless of the draft quality.
 The per-token acceptance probability is `β(θ) = 1 - TV(q, p)` where TV is total variation
-distance. Speedup is `1 / (1 - β·K)` for K draft tokens.
+distance. Expected accepted tokens per speculative step is `(1 - β^(K+1)) / (1 - β)` for K
+draft tokens (capped geometric, Leviathan et al. ICML 2023, Algorithm 1). Wallclock speedup
+depends on the draft/target cost ratio `c`: `speedup = E[accepted] / (1 + K·c)`.
+
+| β | K | E[accepted] | speedup (c=0.05) |
+|---|---|-------------|------------------|
+| 0.5 | 2 | 1.75 | 1.59 |
+| 0.8 | 5 | 3.69 | 2.95 |
+| 0.9 | 5 | 4.10 | 2.73 |
 
 **GDN complication.** Qwen3.5-2B's 18 GatedDeltaNet layers maintain a recurrent state matrix
 `S[key_dim × value_dim]` per head (see `GatedDeltaNetState::s_matrices`). Unlike KV cache,
@@ -130,9 +138,8 @@ fn restore_gdn_states(&mut self, snapshot: &GdnSnapshot);
 
 // GdnSnapshot = Vec<(Vec<f32>, Vec<f32>)>
 //   index i = layer i: (s_matrices.clone(), conv_buffer.clone())
-// Allocation: num_gdn_layers * (key_dim * value_dim * num_heads + conv_dim * (kernel_size - 1))
-// For Qwen3.5-2B (18 GDN layers, key_dim=64, value_dim=64, 16 heads, conv_dim=512, kernel_size=4):
-//   18 * (64 * 64 * 16 + 512 * 3) * 4 bytes ≈ 46 MB per snapshot
+// Memory budget: see ADR-052 §Memory Budget for authoritative per-config estimates.
+// For Qwen3.5-0.8B: ~19.3 MiB per snapshot (18 GDN layers, 16 heads, 128×128 state + 6144×3 conv)
 ```
 
 Snapshot frequency: once per speculative step (before draft generation). Not per-token. The

--- a/docs/adr/ADR-050-rejection-sampling.md
+++ b/docs/adr/ADR-050-rejection-sampling.md
@@ -81,8 +81,8 @@ The implementation is scoped to three changes:
    parameter; at temperature 0 the sampling path degenerates to the existing argmax behavior with
    no correctness regression.
 
-2. **GDN state snapshot protocol**: extend `MtpTargetVerifier` with `snapshot_gdn_state()` and
-   `restore_gdn_state()` methods. Before draft generation begins, the verifier takes a snapshot of
+2. **GDN state snapshot protocol**: extend `MtpTargetVerifier` with `snapshot_gdn_states()` and
+   `restore_gdn_states()` methods. Before draft generation begins, the verifier takes a snapshot of
    all GDN layers' `s_matrices` and `conv_buffer` fields. On partial or full rejection, restore
    is called before the correction token forward pass.
 

--- a/docs/adr/ADR-051-quarot-mtp-rotation.md
+++ b/docs/adr/ADR-051-quarot-mtp-rotation.md
@@ -1,0 +1,286 @@
+# ADR-051: QuaRot-MTP Rotation Reconciliation
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: `lattice-inference`
+
+---
+
+## Context
+
+ADR-044 ships QuaRot Q4 quantization for Qwen3.5. It applies a global random Hadamard rotation R
+(seed-deterministic, orthonormal, d×d) to the residual stream. All linear layers in the base model
+absorb R: input-side weights become W·R^T, output-side weights have R pre-applied, so every
+activation in the forward pass lives in the rotated basis R·h rather than the original h.
+
+ADR-006 ships MTP speculative decoding. The MTP module (one transformer layer with MoE FFN) drafts
+an extra token using two inputs from the base model:
+
+- `embed(x_t)` — the embedding of the just-generated token (looked up from `embed_tokens`)
+- `h_{t-1}^{pre}` — the pre-final-norm hidden state captured from the previous base-model step
+
+Both inputs arrive in the rotated basis when the base model is QuaRot-quantized:
+
+```
+embed(x_t)      -> R · embed_original(x_t)    [embed_tokens rows are rotated]
+h_{t-1}^{pre}   -> R · h_{t-1}^{pre,original} [residual stream is rotated throughout]
+```
+
+MTP's weights (`pre_fc_norm_embedding`, `pre_fc_norm_hidden`, `input_layernorm`,
+`post_attention_layernorm`, `fc`, `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`,
+`down_proj`, `norm`) were trained in the original unrotated basis. This creates a basis mismatch.
+
+### Why RMSNorm Gamma Does Not Commute With R
+
+RMSNorm with learned scale gamma computes:
+
+```
+RMSNorm(x) = (x / RMS(x)) * gamma   where gamma is per-element
+```
+
+For a rotated input R·x:
+
+```
+RMSNorm(R·x) = (R·x / RMS(R·x)) * gamma
+             = (R·x / RMS(x)) * gamma     [RMS is rotation-invariant: ||R·x|| = ||x||]
+```
+
+This is NOT equal to R · RMSNorm(x):
+
+```
+R · RMSNorm(x) = R · ((x / RMS(x)) * gamma)
+               = (R·x / RMS(x)) * R[gamma as diagonal]
+```
+
+The per-element gamma scale distributes as diag(gamma); diag(gamma) does not commute with a dense
+orthogonal R. Therefore:
+
+```
+RMSNorm(R·x) = diag(gamma) · (R·x) / RMS(x)   [gamma applied in rotated coordinates]
+R · RMSNorm(x) = R · diag(gamma) · x / RMS(x) [gamma applied in original coordinates]
+```
+
+These differ by (diag(gamma)·R - R·diag(gamma)) which is non-zero whenever gamma is not uniform.
+
+### Measured Magnitude
+
+PR #42 captured rotated vs unrotated hidden states at the MTP boundary and measured:
+
+```
+|R·h - h|^2 / |h|^2 ≈ 2
+```
+
+A ratio of 2 means the rotated and unrotated hidden states are fully decorrelated (same L2 norm,
+completely different directions). Draft token acceptance drops to approximately 1/|V|, i.e., random
+chance over vocabulary. PR #42 responded by safety-skipping MTP emission when a QuaRot base is
+detected, leaving MTP disabled for all QuaRot models.
+
+### Shared lm_head Dependency
+
+The MTP module shares `lm_head_weight` with the base model. Under QuaRot, `lm_head` was
+reparameterized during conversion (ADR-044 step 3c): the fused form stores
+`W_lm · diag(1 + g_final) · R^T` (final-norm scale absorbed, input-rotation absorbed). This means
+`lm_head` expects its input to be in the rotated basis. If MTP produces an unrotated hidden state
+h_mtp and passes it directly to the shared `lm_head`, the logit computation becomes:
+
+```
+(W_lm · diag(1+g) · R^T) · h_mtp   [wrong: lm_head expects R·h_mtp, not h_mtp]
+```
+
+Any fix that produces unrotated MTP hidden states must re-rotate before the shared `lm_head` call.
+
+---
+
+## Decision
+
+Implement **Strategy A: counter-rotation at MTP boundaries** (two FWHT calls per draft step).
+
+Apply R^T to MTP inputs before the MTP forward pass and apply R to MTP outputs before the shared
+`lm_head` matmul. All MTP internal weights operate in the original unrotated basis unchanged — no
+weight modifications, no offline preprocessing, no new conversion artifacts.
+
+The two-FWHT approach is chosen over reparameterization (Strategy B) as Phase 1 because it:
+- Has a single, auditable insertion point per boundary
+- Requires zero changes to the quantize_quarot binary or stored artifacts
+- Is fully reversible (R^T · R = I) with no accumulated error beyond floating-point round-trip
+- Validates correctness by comparing MTP draft logits against a reference CPU forward
+
+Strategy B (offline reparameterization of all 15 MTP weight tensors) is designated Phase 2 and
+deferred until Phase 1 acceptance rates are confirmed on hardware.
+
+---
+
+## Scope
+
+**In scope (this ADR)**:
+- Counter-rotation shim in `mtp_forward_one()` at `src/forward/metal_qwen35.rs`
+- Detection of QuaRot base (rotation seed metadata read from quantize index)
+- Rotation seed propagation into `MetalQwen35Engine` for runtime use
+- Re-rotation of MTP output hidden state before shared `lm_head` matmul
+- CPU validation path: compare draft logits with and without shim against reference
+- `quantize_quarot` binary: store rotation seed in `quantize_index.json` (currently omitted)
+
+**Out of scope**:
+- Strategy B offline reparameterization of MTP weights
+- INT4 activation quantization of MTP inputs/outputs (ADR-044 v1 deferred)
+- N-gram speculator is unaffected (no hidden states)
+- Models other than Qwen3.5 (only model with MTP weights in v0)
+
+---
+
+## Architecture
+
+### Rotation Propagation
+
+The QuaRot seed is currently used only inside `quantize_quarot` and is not stored in the output
+artifact. Phase 1 requires it at runtime. The fix:
+
+1. `quantize_quarot` writes `"quarot_seed": <u64>` into `quantize_index.json`.
+2. The runtime loader (`loading.rs`) reads `quarot_seed` as `Option<u64>` when loading a QuaRot
+   index; absent key = unrotated model (no counter-rotation needed).
+3. `MetalQwen35Engine` gains `quarot_seed: Option<u64>`. Non-None means all activations are in
+   the rotated basis and MTP must counter-rotate.
+
+### Counter-Rotation Calls in `mtp_forward_one`
+
+The insertion points within the existing Phase 1 / Phase 2 structure of `mtp_forward_one`:
+
+```
+Phase 1 (CPU):
+  1. embed lookup -> normed_embed  (currently in rotated basis when QuaRot)
+  2. pre_fc_norm_embedding RMSNorm on normed_embed
+  3. normed_hidden = last_pre_final_hidden.clone()  (in rotated basis)
+  4. pre_fc_norm_hidden RMSNorm on normed_hidden
+  5. concat [normed_embed || normed_hidden] -> fused buffer (2*hidden)
+
+  --- NEW: if quarot_seed.is_some() ---
+  Before step 2: apply R^T to normed_embed  [counter-rotate embedding]
+  Before step 4: apply R^T to normed_hidden [counter-rotate hidden state]
+  --- END NEW ---
+
+Phase 2 (GPU):
+  fc: fused -> hidden (linear projection)
+  ... (all MTP attention + MLP in unrotated basis, unchanged) ...
+  final hidden state produced: h_mtp in unrotated basis
+
+  --- NEW: if quarot_seed.is_some() ---
+  After final GPU computation, before shared lm_head:
+  apply R to h_mtp [re-rotate for lm_head]
+  --- END NEW ---
+
+lm_head matmul: (W_lm · diag(1+g) · R^T) · (R · h_mtp) = W_lm · diag(1+g) · h_mtp  [correct]
+```
+
+### FWHT Call
+
+`walsh_hadamard_orthonormal_in_place(data: &mut [f32])` from `quant::quarot::hadamard` implements
+the normalized FWHT. For an orthonormal Hadamard H_d (H_d · H_d^T = I), applying H_d twice returns
+the identity: H_d is self-inverse up to the normalization factor 1/sqrt(d), which the orthonormal
+variant absorbs. Therefore:
+
+```
+H_d · H_d · x = x    [exact, no separate R^T needed]
+```
+
+R = diag(s) · H_d where s_i ∈ {+1,-1} are the random sign flips from the seed. R^T = H_d · diag(s)
+(since diag(s)^T = diag(s) for ±1 signs and H_d^T = H_d).
+
+The counter-rotation procedure for a vector x in the rotated basis:
+
+```rust
+// Recover original: x_original = R^T · x_rotated
+// R = diag(s) · H  =>  R^T = H · diag(s)
+apply_sign_flip(&mut x, &signs);          // diag(s) · x
+walsh_hadamard_orthonormal_in_place(&mut x)?; // H · (diag(s) · x)
+```
+
+The re-rotation (original -> rotated) reverses the order:
+
+```rust
+// x_rotated = R · x_original = diag(s) · H · x_original
+walsh_hadamard_orthonormal_in_place(&mut x)?; // H · x
+apply_sign_flip(&mut x, &signs);              // diag(s) · (H · x)
+```
+
+Sign flip vectors are deterministic from the seed via the same `RandomizedHadamard` generator used
+in `quantize_quarot`. The engine holds a `signs: Vec<i8>` derived once at load time.
+
+### Complexity
+
+Per draft token: 2 × FWHT(d) where d = hidden_size.
+For Qwen3.5-7B (d = 3584): O(d log d) = O(3584 × 11.8) ≈ 42K multiply-adds per counter-rotation,
+two calls = ~84K ops. Target forward pass is memory-bandwidth-bound at ~100M ops; this is <0.1%
+overhead.
+
+### quantize_quarot Binary Change
+
+`quantize_index.json` gains one field written unconditionally when `--seed` is provided:
+
+```json
+{ "quarot_seed": 13258600446175248384 }
+```
+
+The runtime loader treats an absent `quarot_seed` key as `None` (unrotated model). Existing
+unrotated `.q4` artifacts remain loadable without conversion.
+
+---
+
+## Alternatives Considered
+
+| Strategy | Mechanism | Runtime cost | Weight changes | lm_head correctness |
+|---|---|---|---|---|
+| **A: Counter-rotate (chosen)** | R^T before MTP, R after; 2×FWHT/step | ~84K ops/draft step | None | R cancels: (W·R^T)·(R·h) = W·h |
+| **B: Offline reparameterize** | W'=W·R for each of 15 MTP tensors, gamma'=R·gamma for 7 norms | Zero | 15 tensors rewritten offline | lm_head receives rotated output naturally |
+| **C: Rotation-aware MTP training** | Fine-tune MTP to handle rotated inputs | Zero (after training) | Full retraining required | Training learns invariance |
+| **D: Separate lm_head for MTP** | MTP uses its own unshared lm_head (unrotated) | Zero | New 1.2GB tensor per model | No shared lm_head conflict |
+
+**Why not B (reparameterize)**: Correct but requires non-trivial per-layer-type math to
+reparameterize fc (2d×d), q/k/v/o projections (d×d each), gate/up/down projections (FFN), and 7
+norm gamma vectors. Each has a different absorption formula. One wrong formula silently produces
+bad logits with no crash. Phase 2 will implement B after Phase 1 validates the expected acceptance
+rates, using Phase 1 as the oracle for correctness verification.
+
+**Why not C (training)**: Out of scope. Requires a training pipeline that Lattice does not have.
+
+**Why not D (separate lm_head)**: Doubles the output embedding storage (+1.2GB for Qwen3.5-7B) and
+diverges MTP draft logits from the base model vocabulary distribution.
+
+---
+
+## Risks
+
+**Sign vector reconstruction.** The counter-rotation uses sign vectors derived from `quarot_seed`
+via `RandomizedHadamard`. If the runtime reconstructs a different sign sequence than the converter
+used, the rotation will be wrong but not obviously so (logits will look plausible, not garbage). The
+seed must be stored exactly as a `u64` in `quantize_index.json` and reconstructed via the identical
+code path. Mitigation: add a round-trip test asserting that `R^T · (R · v) == v` for a fixed seed
+before any runtime use of the sign vectors.
+
+**lm_head basis assumption.** The re-rotation step (apply R to h_mtp) is predicated on the stored
+`lm_head` weight having form `W_lm · diag(1+g) · R^T`. If a future conversion path changes this
+(e.g., drops the final-norm fusion), the re-rotation would produce wrong logits. Mitigation: the
+QuaRot forward-equivalence gate (ADR-044 step 3c-4) must be extended to cover the MTP path once
+MTP tensors are no longer safety-skipped.
+
+**MTP tensors still safety-skipped in quantize_quarot.** The converter currently skips the 15 MTP
+tensors to avoid writing Q4-quantized weights in the wrong basis. Phase 1 (counter-rotation) fixes
+the runtime basis but does NOT change this: MTP weights are still stored as f16 (unquantized). The
+15 MTP tensors are loaded as f16 and used at f32 precision. This is correct for Phase 1 but means
+MTP draft steps do not benefit from Q4 weight compression. Phase 2 (reparameterize) will rotate and
+quantize the MTP tensors.
+
+**Fused activation precision.** Counter-rotation inserts `walsh_hadamard_orthonormal_in_place` on
+the CPU-side f32 vectors before they are written into the Metal-allocated `fused` buffer. This does
+not change the dtype or buffer layout; no GPU kernel changes are required for Phase 1.
+
+---
+
+## References
+
+- ADR-044: QuaRot rotated quantization (rotation absorption, RMSNorm fusion, forward-equivalence gate)
+- ADR-006: Speculative decoding (MtpVerifier, `mtp_forward_one`, cache rollback)
+- `src/forward/metal_qwen35.rs:5015` — `mtp_forward_one` Phase 1 (CPU) and Phase 2 (GPU) structure
+- `src/quant/quarot/hadamard.rs` — `walsh_hadamard_orthonormal_in_place` (f32, self-inverse)
+- `src/quant/quarot/plan.rs` — `RotationPlan`, `RandomizedHadamard`
+- Ashkboos et al., _QuaRot: Outlier-Free 4-Bit Inference in Rotated LLMs_, NeurIPS 2024, arxiv:2404.00456
+- KG entity: `QuaRot-MTP Interaction Analysis`

--- a/docs/adr/ADR-051-quarot-mtp-rotation.md
+++ b/docs/adr/ADR-051-quarot-mtp-rotation.md
@@ -182,28 +182,36 @@ variant absorbs. Therefore:
 H_d · H_d · x = x    [exact, no separate R^T needed]
 ```
 
-R = diag(s) · H_d where s_i ∈ {+1,-1} are the random sign flips from the seed. R^T = H_d · diag(s)
-(since diag(s)^T = diag(s) for ±1 signs and H_d^T = H_d).
+The code convention (see `quant::quarot::hadamard.rs:120-127`) defines `R = H · diag(s)` where
+`s_i ∈ {+1,-1}` are the random sign flips from the seed. `apply()` performs sign flip then WHT.
+Therefore `R^T = diag(s) · H` (since `diag(s)^T = diag(s)` and `H^T = H`), and `apply_inverse()`
+performs WHT then sign flip.
 
 The counter-rotation procedure for a vector x in the rotated basis:
 
 ```rust
 // Recover original: x_original = R^T · x_rotated
-// R = diag(s) · H  =>  R^T = H · diag(s)
-apply_sign_flip(&mut x, &signs);          // diag(s) · x
-walsh_hadamard_orthonormal_in_place(&mut x)?; // H · (diag(s) · x)
+// R = H · diag(s)  =>  R^T = diag(s) · H
+// This is RandomizedHadamard::apply_inverse()
+hadamard.apply_inverse(&mut x)?;
+// Internally: walsh_hadamard_orthonormal_in_place(&mut x) then apply_sign_flip(&mut x, &signs)
 ```
 
-The re-rotation (original -> rotated) reverses the order:
+The re-rotation (original -> rotated) uses the forward direction:
 
 ```rust
-// x_rotated = R · x_original = diag(s) · H · x_original
-walsh_hadamard_orthonormal_in_place(&mut x)?; // H · x
-apply_sign_flip(&mut x, &signs);              // diag(s) · (H · x)
+// x_rotated = R · x_original = H · diag(s) · x_original
+// This is RandomizedHadamard::apply()
+hadamard.apply(&mut x)?;
+// Internally: apply_sign_flip(&mut x, &signs) then walsh_hadamard_orthonormal_in_place(&mut x)
 ```
 
 Sign flip vectors are deterministic from the seed via the same `RandomizedHadamard` generator used
-in `quantize_quarot`. The engine holds a `signs: Vec<i8>` derived once at load time.
+in `quantize_quarot`. The engine holds a `RandomizedHadamard` instance derived once at load time.
+
+**Verification**: any implementation must pass a round-trip test: `apply(apply_inverse(x)) == x` and
+`apply_inverse(apply(x)) == x` for a fixed seed, plus an MTP draft-logit equivalence test comparing
+counter-rotated MTP logits against the unquantized reference model.
 
 ### Complexity
 

--- a/docs/adr/ADR-052-gdn-speculative-state.md
+++ b/docs/adr/ADR-052-gdn-speculative-state.md
@@ -1,0 +1,226 @@
+# ADR-052: GDN State Management for Speculative Rollback
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: `lattice-inference`
+
+---
+
+## Context
+
+Qwen3.5-2B's 24 transformer layers split into 18 GatedDeltaNet (GDN) linear-attention layers and
+6 GQA full-attention layers (`[linear, linear, linear, full] × 6`, `full_attention_interval = 4`).
+ADR-050 adds strict rejection sampling to the MTP speculative decoding path, which requires the
+system to roll back model state when a draft token is rejected.
+
+**KV cache rollback is already solved.** `FlatKVCache::truncate_to()` resets the GQA layers'
+KV cache to any prior sequence length in O(1). `MtpTargetVerifier::rollback_cache_to()` calls
+this on both the MTP verifier cache and the main model cache.
+
+**GDN state rollback is not solved.** `GatedDeltaNetState` (`gdn.rs` line 64) holds two
+mutable fields:
+
+```rust
+pub struct GatedDeltaNetState {
+    pub s_matrices: Vec<f32>,   // num_heads * key_dim * value_dim floats
+    pub conv_buffer: Vec<f32>,  // conv_dim * (kernel_size - 1) floats
+    key_dim: usize,
+    value_dim: usize,
+}
+```
+
+For Qwen3.5-2B (`linear_num_key_heads = 16`, `linear_key_head_dim = 128`,
+`linear_value_head_dim = 128`, `linear_conv_kernel_dim = 4`, `linear_qkv_dim = 6144`):
+
+- `s_matrices`: `16 × 128 × 128 = 262,144` f32 values = **1 MB per GDN layer**
+- `conv_buffer`: `6144 × 3 = 18,432` f32 values = **72 KB per GDN layer**
+- Per-snapshot total (18 GDN layers): `18 × (1,048,576 + 73,728) bytes ≈ 20 MB`
+
+Every GDN step (`gated_delta_net_step`) mutates both fields in place via the delta rule:
+
+```
+S = g * S + outer(k, (v - S @ k) * beta)
+```
+
+and via the causal conv1d rolling shift. Neither update is invertible. There is no
+`truncate_to` analogue. The KG entity `GDN Multi-Round Error Accumulation` gives the
+error bound under nonexpansive decay: `O(N * eps)` for N spurious steps.
+
+**Correctness gap.** When speculative decoding rejects a draft token at position `t`, the GDN
+state has already been stepped through positions `t, t+1, ..., t+K-1` (all speculative). Without
+a restore path, subsequent autoregressive generation runs from a corrupted state. This is silent:
+generation continues with wrong recurrent memory. `rollback_cache_to` (speculative.rs line 559)
+truncates only `FlatKVCache`; it does nothing for `gdn_states`.
+
+ADR-050 scoped the GDN fix to `MtpTargetVerifier` trait extensions. This ADR specifies the
+concrete design, memory layout, and integration contract that implements that scope.
+
+---
+
+## Decision
+
+Add `snapshot()` and `restore_from()` to `GatedDeltaNetState`, extend `MtpTargetVerifier` with
+GDN snapshot/restore methods, and integrate both into `mtp_verify_draft`.
+
+The chosen strategy is **snapshot-before-draft**: take one snapshot of all GDN layers before the
+speculative draft begins; restore from it on any rejection before running the correction token
+forward pass. No per-token checkpoints. No recompute.
+
+---
+
+## Scope
+
+Files changed:
+
+- `crates/inference/src/attention/gdn.rs`: add `snapshot()`, `restore_from()` to
+  `GatedDeltaNetState`; add `GdnSnapshot` type alias.
+- `crates/inference/src/speculative.rs`: extend `MtpTargetVerifier` with
+  `snapshot_gdn_states()` / `restore_gdn_states()`; add snapshot/restore calls to
+  `mtp_verify_draft` around the draft generation and rejection branches.
+
+No Metal kernels, no `NgramSpeculator`, no `verify_draft` (n-gram path), no generation.rs.
+
+---
+
+## Architecture
+
+### New API on `GatedDeltaNetState`
+
+```rust
+/// Opaque snapshot of one GDN layer's recurrent state.
+/// Layout: (s_matrices clone, conv_buffer clone).
+pub type GdnLayerSnapshot = (Vec<f32>, Vec<f32>);
+
+/// Snapshot of all GDN layers for a model instance.
+pub type GdnSnapshot = Vec<GdnLayerSnapshot>;
+
+impl GatedDeltaNetState {
+    /// Clone s_matrices and conv_buffer into a new snapshot.
+    /// Cost: O(num_heads * key_dim * value_dim + conv_dim * buf_len) per layer.
+    pub fn snapshot(&self) -> GdnLayerSnapshot {
+        (self.s_matrices.clone(), self.conv_buffer.clone())
+    }
+
+    /// Overwrite s_matrices and conv_buffer from a prior snapshot.
+    /// Panics in debug if lengths do not match (invariant: snapshot taken from same config).
+    pub fn restore_from(&mut self, snap: &GdnLayerSnapshot) {
+        debug_assert_eq!(self.s_matrices.len(), snap.0.len());
+        debug_assert_eq!(self.conv_buffer.len(), snap.1.len());
+        self.s_matrices.copy_from_slice(&snap.0);
+        self.conv_buffer.copy_from_slice(&snap.1);
+    }
+}
+```
+
+### `MtpTargetVerifier` trait extension
+
+```rust
+pub trait MtpTargetVerifier {
+    fn cache_position(&self) -> usize;
+    fn rollback_cache_to(&mut self, seq_len: usize) -> Result<(), InferenceError>;
+    fn verify_tokens(&mut self, tokens: &[u32], start_pos: usize)
+        -> Result<Vec<Vec<f32>>, InferenceError>;
+
+    // New methods — added by this ADR:
+    fn snapshot_gdn_states(&self) -> GdnSnapshot;
+    fn restore_gdn_states(&mut self, snapshot: &GdnSnapshot);
+}
+```
+
+Implementors hold a `Vec<GatedDeltaNetState>` (one per GDN layer). `snapshot_gdn_states`
+calls `.snapshot()` on each, collects into a `Vec`. `restore_gdn_states` calls `.restore_from()`
+on each with the corresponding element.
+
+### Integration in `mtp_verify_draft`
+
+```
+before draft generation:
+    let gdn_snap = target.snapshot_gdn_states();
+
+acceptance loop (per draft token i):
+    if reject:
+        target.rollback_cache_to(target_start);
+        target.restore_gdn_states(&gdn_snap);
+        // then sample correction token from p'
+        break
+
+after full acceptance:
+    drop(gdn_snap);  // not needed
+```
+
+The snapshot is heap-allocated once per speculative step. Because draft tokens are never
+committed to target GDN state until accepted, restore is only needed on the rejection branch.
+For the full-acceptance path, the snapshot is simply dropped.
+
+### Memory budget (Qwen3.5-2B)
+
+| Item | Size |
+|---|---|
+| `s_matrices` per GDN layer | 16 × 128 × 128 × 4 B = 1,048,576 B |
+| `conv_buffer` per GDN layer | 6,144 × 3 × 4 B = 73,728 B |
+| Per-layer snapshot | ~1.07 MB |
+| Full snapshot (18 GDN layers) | ~19.3 MB |
+
+19 MB is ephemeral (held for one speculative step). On Apple Silicon unified memory
+(16–192 GB), this is acceptable. Snapshot allocation is paid once per step, not per token.
+
+---
+
+## Alternatives Considered
+
+**A. Per-token checkpoint (K snapshots for K draft tokens).** Enables partial rollback: if
+token 3 of 5 is rejected, only restore to checkpoint 2. Memory cost: K × 19 MB = 96 MB for
+K=5. The correctness benefit over snapshot-before-draft is nil: both paths reach the same
+restored state. Snapshot-before-draft is simpler and uses 1/K the memory.
+
+**B. Recompute-from-accepted.** After rejection at position t, rerun the GDN forward pass
+from the last accepted position using only accepted tokens. Zero extra memory, but adds
+O(accepted\_tokens × num\_gdn\_layers) compute per rejection event. For long prefixes this is
+equivalent to full prefill latency on rejection. Memory is cheap on Apple Silicon; compute
+latency is not free. Snapshot-before-draft trades 19 MB for zero recompute.
+
+**C. Do not expose rollback; run target model forward-only during speculative steps.** This
+avoids the problem entirely by running the target model in a stateless (prefill) mode across
+the draft window. Correct, but requires passing the full token sequence each step rather than
+incremental decode — O(context\_length) work per speculative step, eliminating speedup for
+long contexts.
+
+---
+
+## Risks
+
+**R1: Snapshot size scales with model.** Qwen3.6-27B has 48 active GDN layers and
+`linear_num_value_heads = 48`, giving `48 × (48 × 128 × 128 + 6144 × 3) × 4 B ≈ 153 MB` per
+snapshot. Still within unified memory budget but worth tracking. Mitigation: the snapshot is
+ephemeral. Document the per-model cost formula in the struct docstring.
+
+**R2: `restore_from` panics on length mismatch.** This is intentional: a length mismatch means
+the snapshot was taken from a different config instance, which is a programming error.
+`debug_assert` is sufficient; production builds skip the check.
+
+**R3: Trait change requires all `MtpTargetVerifier` implementors to add two methods.** The
+only extant implementor is the integration test mock at speculative.rs line 1771. One change
+required; not a public API break (crate is `#[doc(hidden)]` for these types).
+
+**R4: Draft does NOT advance target GDN state.** The integration design above depends on
+`mtp_verify_draft` not mutating target GDN state during draft generation. This must be
+verified before implementation: the MTP verifier (`MtpVerifier`) has its own separate state
+and cache; it does not share `gdn_states` with the target model. Confirm at implementation
+time.
+
+---
+
+## References
+
+- `crates/inference/src/attention/gdn.rs` lines 64–106: `GatedDeltaNetState` struct and
+  `reset()` method (existing cleanup pattern that `snapshot/restore` extends).
+- `crates/inference/src/speculative.rs` line 555–561: `MtpVerifier::rollback_cache_to()`
+  and the GQA-only `FlatKVCache::truncate_to()` call this ADR parallels for GDN.
+- `crates/inference/src/speculative.rs` line 1075–1087: `MtpTargetVerifier` trait (the trait
+  this ADR extends).
+- ADR-006: Speculative Decoding — baseline speculative decode architecture.
+- ADR-050: Rejection Sampling — strict speculative sampling; scoped the GDN gap that this
+  ADR resolves.
+- KG entity `GDN Multi-Round Error Accumulation`: error bound `O(N * eps)` under
+  nonexpansive decay, motivating why skipping rollback is not a bounded-error approximation
+  but unbounded state corruption.

--- a/docs/adr/ADR-053-moe-metal-dispatch.md
+++ b/docs/adr/ADR-053-moe-metal-dispatch.md
@@ -1,0 +1,284 @@
+# ADR-053: MoE Metal Dispatch with Expert Coalescing
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: lattice-inference
+
+---
+
+## Context
+
+Qwen3.6-35B-A3B (256 routed experts, top-8, 1 shared expert) is the primary MoE target in
+lattice-inference. The CPU MoE forward path already exists: `model/qwen35/moe.rs` implements
+`moe_ffn_step` which routes tokens through `accumulate_routed_experts` (top-k loop) and
+`apply_shared_expert`. Weight layout in `weights.rs` is expert-major: `RoutedExperts::gate_up_proj`
+is `[num_experts, 2 * intermediate_size, hidden_size]` contiguous, and `down_proj` is
+`[num_experts, hidden_size, intermediate_size]` contiguous.
+
+The Metal forward path (`forward/metal_qwen35.rs`) handles the Qwen3.5-2B hybrid model. The
+`metal_qwen35` module encodes one Metal `CommandBuffer` per layer and already ships fused
+decode-mode GEMV kernels (`gemv_decode_core` with simdgroup reduction), tiled GEMM for prefill,
+and a GQA flash-attention kernel. **MoE layers are not yet handled** — the Metal path falls back
+to CPU for any `FeedForwardWeights::Moe` variant.
+
+### The dispatch cost problem
+
+M2 Max measured Metal dispatch overhead: ~0.127 ms per `CommandBuffer` commit+wait cycle
+(KG entity `Metal MoE Dispatch Analysis`). Qwen3.6 has 40 layers, each with a MoE FFN.
+
+Naive per-expert dispatch:
+- 8 active routed experts × 3 matrix operations each (gate_up, silu_glu, down) = 24 dispatches
+- Plus 1 shared expert (3 dispatches)
+- Per layer total: 27 dispatches × 0.127 ms = ~3.4 ms
+- 40 layers: **136 ms overhead per token** from dispatch alone — this exceeds the entire decode
+  budget for a 42–50 tok/s target.
+
+Even a reduced framing of 1 command buffer per expert:
+- 9 experts × 40 layers = 360 dispatches × 0.127 ms = **45.7 ms/token** — still 2× the budget.
+
+The only viable path is 1 command buffer per layer encoding all expert work as multiple
+compute-command encoders within a single commit. This reduces dispatch overhead to
+40 × 0.127 ms = **5.1 ms/token** regardless of expert count.
+
+### Expert weight memory for Qwen3.6-35B-A3B
+
+At Q4 with hidden=7168 and moe_intermediate_size=2048:
+- `gate_up_proj`: 256 experts × 2 × 2048 × 7168 × 0.5 bytes = ~3.7 GB
+- `down_proj`: 256 experts × 7168 × 2048 × 0.5 bytes = ~1.85 GB
+- Shared expert (dense): negligible (~0.05 GB)
+- Total routed expert weights: ~5.6 GB across 40 layers
+
+M2 Max unified memory is 32–96 GB. Loading all expert weights resident (the MLX approach) is
+feasible on 64 GB+ configurations. On 32 GB, expert weight swapping becomes necessary. This ADR
+targets the resident-all path as v1; swapping is deferred.
+
+### QuaRot interaction
+
+ADR-044 stores rotated weights per-projection within the `RotationPlan`. For dense layers,
+QuaRot absorbs residual-stream rotation into `gate_proj`, `up_proj`, and `down_proj`
+individually. For MoE, the same rotation must be applied **per-expert**: each expert's
+`gate_up_proj[e]` absorbs input-side rotation and `down_proj[e]` absorbs output-side rotation.
+
+The current `RotationPlan` in `quant/quarot/plan.rs` has no MoE-aware rules — all plan entries
+assume non-expert projections addressed by their HF tensor name. Adding expert-indexed rules
+requires either parameterized names (e.g., `model.layers.{l}.mlp.experts.{e}.gate_proj`) or a
+separate `MoeRotationPlan` that iterates expert indices. The weight layout being expert-major
+contiguous (`[num_experts, 2*inter, hidden]`) means the conversion binary can apply rotation
+expert-by-expert in sequence without re-layouting.
+
+---
+
+## Decision
+
+Implement Metal MoE dispatch with expert coalescing as a new function `metal_moe_ffn_step` in
+`forward/metal_qwen35.rs` (inside the existing `#[cfg(all(target_os = "macos", feature =
+"metal-gpu"))]` module). The design has four binding decisions:
+
+**D1: One command buffer per MoE layer, multiple compute encoders within it.**
+All routed expert matmuls are encoded into a single `CommandBuffer` before commit. This is
+the only approach that stays below the dispatch latency floor. Each compute encoder encodes one
+expert's `gate_up` GEMV, silu+glu, and `down` GEMV as separate `dispatchThreadgroups` calls
+within the same encoder (no intermediate commits). Encoders execute serially on Apple Silicon
+because the GPU has no inter-encoder dependency tracking — parallel expert execution requires
+either atomic accumulation or a two-pass reduce, which adds complexity with no latency win at
+batch size 1 (decode mode).
+
+**D2: Expert-major weight layout stays; no re-layout at load time.**
+`RoutedExperts::gate_up_proj` is already `[num_experts, 2*inter, hidden]` contiguous. Metal
+buffer binding uses byte offsets into this buffer: expert `e`'s gate half starts at byte
+`e * 2 * inter * hidden * element_size`, and the up half at `(e * 2 * inter + inter) * hidden *
+element_size`. This avoids a copy or re-layout step, and the kernel dispatch geometry is
+identical to the existing `gemv_decode_core` kernel (M=1, N=inter or hidden, K=hidden or inter).
+
+**D3: Router (top-k softmax) runs on CPU.**
+For decode-mode (batch size 1), the router matmul is `[1, hidden] × [num_experts, hidden]^T` →
+`[1, num_experts]` — a 7168×256 GEMV. At Q4 this is ~0.9 MB of weight data. CPU NEON handles
+this in ~0.05 ms; shipping it to the GPU costs a synchronization boundary before expert
+selection can proceed. More importantly, expert selection is a control-flow branch: the CPU
+must know which experts are active before encoding any of their compute commands into the
+command buffer. Routing on CPU eliminates a GPU→CPU readback that would serialize the entire
+dispatch.
+
+**D4: Shared expert weight is pinned to a dedicated Metal buffer.**
+The shared expert always activates. Its weights (`gate_proj`, `up_proj`, `down_proj`) are
+allocated as a separate `MTLBuffer` at model-load time, distinct from the routed expert
+buffer. This allows the shared expert GEMV to be the first encoder in every command buffer,
+overlapping encode time with routing on CPU.
+
+---
+
+## Scope
+
+v1 (this ADR):
+
+- `metal_moe_ffn_step`: fused MoE forward for decode mode (M=1), integrated into the Metal
+  layer loop alongside the existing `FeedForwardWeights::Dense` branch.
+- MSL kernel `moe_expert_gemv`: single-expert GEMV accepting an expert-offset parameter so one
+  compiled kernel handles all experts. Reuses the `gemv_decode_core` template already in
+  `MSL_SOURCE`.
+- CPU router: top-k selection integrated into `metal_moe_ffn_step` before encoding (calling
+  existing `compute_router_probs` / `select_top_k` / `renormalize_selected` from `moe.rs` via
+  `pub(crate)` promotion).
+- Expert coalescing: encode 1 shared + top_k routed expert encoders into 1 command buffer per
+  layer.
+- Memory layout: no change to `RoutedExperts` or `SharedExpert` structs. New field
+  `MoeMetalBuffers` holds pre-allocated `MTLBuffer` handles for the three expert weight tensors.
+
+Deferred to v2:
+
+- Prefill path (M>1): batched GEMM across experts. Not needed until continuous batching targets
+  MoE models (ADR-048 covers the scheduler side).
+- Expert weight swapping: LRU eviction for 32 GB configurations.
+- QuaRot-on-MoE: per-expert rotation absorption in `quantize_quarot` binary. Requires
+  parameterized rotation plan rules. ADR-044 v1 deferred this explicitly.
+- Pre-gated routing (predict activations before token to prefetch weights).
+
+---
+
+## Architecture
+
+### Component diagram
+
+```
+moe_ffn_step (CPU, existing)
+    └── accumulate_routed_experts   [CPU fallback, decode only]
+
+metal_moe_ffn_step (new)
+    ├── compute_router_probs()      [CPU, reuse from moe.rs]
+    ├── select_top_k()              [CPU, reuse from moe.rs]
+    ├── renormalize_selected()      [CPU, reuse from moe.rs]
+    ├── CommandBuffer::new()        [one per layer]
+    │   ├── encode shared expert
+    │   │   ├── gemv: gate_up [inter, hidden]
+    │   │   ├── silu_glu in-place
+    │   │   └── gemv: down [hidden, inter]
+    │   ├── encode expert[selected[0]]
+    │   │   └── (same pattern, offset into RoutedExperts buffer)
+    │   ├── ...
+    │   └── encode expert[selected[top_k-1]]
+    └── CommandBuffer::commit() + wait_until_completed()
+```
+
+### Metal buffer layout
+
+```
+MoeMetalBuffers {
+    routed_gate_up: MTLBuffer,  // [num_experts * 2 * inter * hidden] f16
+    routed_down:    MTLBuffer,  // [num_experts * hidden * inter] f16
+    shared_gate_up: MTLBuffer,  // [2 * shared_inter * hidden] f16
+    shared_down:    MTLBuffer,  // [hidden * shared_inter] f16
+    gate_weight:    MTLBuffer,  // [num_experts * hidden] f32 (router)
+    scratch_gate:   MTLBuffer,  // [inter] f32 (reused across experts)
+    scratch_up:     MTLBuffer,  // [inter] f32
+    scratch_out:    MTLBuffer,  // [hidden] f32 (accumulator)
+}
+```
+
+### Kernel interface
+
+```msl
+kernel void moe_expert_gemv(
+    device const float*    x         [[buffer(0)]],  // [hidden] activation
+    device const half*     W         [[buffer(1)]],  // full expert weight buffer
+    device float*          out       [[buffer(2)]],  // [N] output
+    constant GemmParams&   p         [[buffer(3)]],  // M=1, N, K, offsets
+    constant uint&         W_offset  [[buffer(4)]],  // element offset into W for this expert
+    uint gid [[threadgroup_position_in_grid]],
+    ...)
+```
+
+`W_offset = expert_id * 2 * inter * hidden` for gate half,
+`W_offset = expert_id * 2 * inter * hidden + inter * hidden` for up half.
+Reuses `gemv_decode_core<128>` instantiation already in `MSL_SOURCE`.
+
+### Accumulation
+
+Each routed expert result is scaled by its router weight before accumulation. Two options:
+
+- **GPU accumulation**: encode a `scale_add` kernel after each expert's `down` GEMV that reads
+  the router weight (a scalar from a small buffer) and accumulates into `scratch_out`.
+- **CPU accumulation**: GPU writes each expert's down output to a per-expert scratch slot; CPU
+  reads back all top_k results after command buffer completion and accumulates with weights.
+
+For top_k=8 and hidden=7168: CPU readback is 8 × 7168 × 4 bytes = 230 KB. At unified memory
+this is a pointer dereference, not a PCIe transfer — readback cost is negligible. GPU
+accumulation avoids even this, at the cost of one additional `scale_add` kernel encode per
+expert (8 extra dispatches within the same command buffer — negligible vs. the GEMV dispatches).
+
+Decision: GPU accumulation (`scale_add` within command buffer) to keep CPU/GPU data flow
+unidirectional and avoid any explicit readback synchronization.
+
+### Integration point
+
+In the existing Metal layer loop (inside `metal_qwen35.rs`), the `FeedForwardWeights::Moe`
+arm currently panics or falls through to CPU. After this ADR:
+
+```rust
+match &layer.common.ffn {
+    FeedForwardWeights::Dense(w) => metal_dense_ffn(w, buffers, cfg),
+    FeedForwardWeights::Moe(w)   => metal_moe_ffn_step(w, moe_bufs, scratch, cfg),
+}
+```
+
+---
+
+## Alternatives Considered
+
+| Alternative | Rationale for rejection |
+|---|---|
+| Per-expert command buffers (naive) | 360 dispatches × 0.127 ms = 45.7 ms/token. Mathematically excluded by measured dispatch overhead. |
+| MLX backend (call Apple's MPS via MLX Rust bindings) | MLX is 3× faster than llama.cpp on MoE on Apple Silicon (measured: Ollama/MLX 58→112 tok/s on Qwen3.5-35B-A3B). But adding MLX as a dependency contradicts the pure-Rust, no-ONNX constraint in AGENTS.md. Not an option in v1. Track as v2 option if native Metal gap persists. |
+| GPU router (move top-k softmax to Metal) | Eliminates the CPU→GPU branch for expert selection, but requires a GPU→CPU readback of `[num_experts]` logits before command encoding can start. At batch=1 the GEMV cost (~0.05 ms on NEON) does not justify the synchronization. Reconsider if batch>1 becomes the target. |
+| Pre-gated routing (predict expert activations one step ahead) | DeepSeek-V2/V3 uses this to prefetch expert weights. Effective at hiding memory latency for weight-swapping configurations. Unnecessary when all weights are resident in unified memory. Defer to v2 with expert swapping. |
+| Expert weight re-layout at load (token-major) | Would allow a single fused `[batch, top_k, inter, hidden]` GEMM. Requires a full re-layout of ~5.6 GB of weights at load time and a different buffer structure. No benefit at batch=1 (decode). Defer to v2 prefill path. |
+| Shared expert caching with redundancy elimination | DeepSeek caches the shared expert output across consecutive tokens when input hasn't changed. Valid optimization but requires state tracking that doesn't exist in the current decode loop. Defer. |
+
+---
+
+## Risks
+
+**R1: Decode throughput estimate is a model, not a measurement.**
+The 42–50 tok/s estimate for M2 Max is derived from dispatch overhead math plus the existing
+GEMV kernel throughput numbers (measured for dense layers in `metal_qwen35.rs` benchmarks). Actual
+MoE throughput depends on expert weight bandwidth utilization across 8 concurrent GEMV encoders
+in the same command buffer. Measure after implementation; do not pin the number until verified.
+
+**R2: Expert memory pressure on 32 GB M2 Pro.**
+At ~5.6 GB for routed expert weights plus ~2 GB for attention state and activation buffers, the
+35B MoE model is borderline on 32 GB. v1 will document the minimum configuration (64 GB
+recommended) and reject at load time with a clear error if total buffer allocation would
+exceed a configurable threshold (default: 0.85 × device.recommendedMaxWorkingSetSize).
+
+**R3: QuaRot incompatibility.**
+ADR-044 explicitly deferred per-expert rotation absorption. A QuaRot-converted Qwen3.6 model
+fed into the Metal MoE path will produce wrong outputs because the rotation plan does not cover
+expert-indexed projections. Mitigation: the loader must check for the QuaRot conversion marker
+in `quantize_index.json` and refuse to load a QuaRot-converted MoE model on the Metal path until
+ADR-044 v1 lands. No silent wrong results.
+
+**R4: Router weight dtype mismatch.**
+The router gate weight (`MoeRouter::gate`) is `Vec<f32>`. The existing CPU path reads it
+directly. For Metal, the gate weight is also small enough (256 × 7168 × 4 bytes = 7.3 MB) to
+keep as f32 in its own `MTLBuffer` and run the CPU NEON kernel against the shared-memory pointer,
+avoiding a separate GPU router kernel. Confirm the `contents()` pointer is CPU-readable when
+using `MTLStorageModeShared` — it is, per the existing weight buffer pattern in `metal_qwen35.rs`.
+
+---
+
+## References
+
+- Existing MoE CPU path: `crates/inference/src/model/qwen35/moe.rs`
+- Weight structs: `crates/inference/src/model/qwen35/weights.rs` — `MoeLayerWeights`,
+  `RoutedExperts`, `SharedExpert`, `MoeRouter`
+- Config: `crates/inference/src/model/qwen35_config.rs` — `Qwen35Config::num_experts`,
+  `moe_intermediate_size`, `shared_expert_intermediate_size`
+- Metal GEMV kernel template: `crates/inference/src/forward/metal_qwen35.rs` —
+  `gemv_decode_core<TG_THREADS>` in `MSL_SOURCE`
+- Dispatch pattern: `crates/inference/src/forward/gpu/dispatch.rs` — `dispatch_matmul` for
+  command-encoder structure reference
+- ADR-044: QuaRot quantization — expert-indexed rotation plan deferred; R3 above
+- ADR-048: Continuous batching — prefill-mode MoE GEMM deferred until scheduler targets MoE
+- Qwen3.6-35B-A3B HuggingFace config: <https://huggingface.co/Qwen/Qwen3.6-35B-A3B>
+- MLX MoE benchmark: Ollama 0.19 (MLX backend), 58→112 tok/s on Qwen3.5-35B-A3B on M3 Max
+- DeepSeek-V2 MoE architecture: <https://arxiv.org/abs/2405.04434> (shared expert + pre-gating)
+- KG entities: `Metal MoE Dispatch Analysis`, `Expert Coalescing Strategy`

--- a/docs/adr/ADR-053-moe-metal-dispatch.md
+++ b/docs/adr/ADR-053-moe-metal-dispatch.md
@@ -42,15 +42,23 @@ compute-command encoders within a single commit. This reduces dispatch overhead 
 
 ### Expert weight memory for Qwen3.6-35B-A3B
 
-At Q4 with hidden=7168 and moe_intermediate_size=2048:
-- `gate_up_proj`: 256 experts × 2 × 2048 × 7168 × 0.5 bytes = ~3.7 GB
-- `down_proj`: 256 experts × 7168 × 2048 × 0.5 bytes = ~1.85 GB
-- Shared expert (dense): negligible (~0.05 GB)
-- Total routed expert weights: ~5.6 GB across 40 layers
+**Current `Qwen35Config::qwen36_35b_a3b()`** sets `hidden_size: 2048`, `moe_intermediate_size: 512`,
+`shared_expert_intermediate_size: 512` with 256 routed experts across 40 layers.
+
+At Q4 with the current config dimensions:
+- `gate_up_proj`: 256 experts × 2 × 512 × 2048 × 0.5 bytes = ~256 MiB per layer
+- `down_proj`: 256 experts × 2048 × 512 × 0.5 bytes = ~128 MiB per layer
+- Total routed expert weights across 40 layers: ~384 MiB × 40 ≈ **15 GiB**
+- Shared expert (dense, 512×2048): negligible (~4 MiB)
+
+> **Note**: the upstream Qwen3.6-35B Hugging Face config uses larger dimensions (hidden=7168,
+> moe_intermediate=2048). If the config fixture is updated to match upstream, the memory budget
+> rises to ~5.6 GB per 40 layers. The memory budget section should be re-verified when the
+> config is finalized.
 
 M2 Max unified memory is 32–96 GB. Loading all expert weights resident (the MLX approach) is
-feasible on 64 GB+ configurations. On 32 GB, expert weight swapping becomes necessary. This ADR
-targets the resident-all path as v1; swapping is deferred.
+feasible on 64 GB+ configurations for either dimension set. This ADR targets the resident-all
+path as v1; swapping is deferred.
 
 ### QuaRot interaction
 

--- a/docs/adr/ADR-053-moe-metal-dispatch.md
+++ b/docs/adr/ADR-053-moe-metal-dispatch.md
@@ -98,7 +98,7 @@ identical to the existing `gemv_decode_core` kernel (M=1, N=inter or hidden, K=h
 
 **D3: Router (top-k softmax) runs on CPU.**
 For decode-mode (batch size 1), the router matmul is `[1, hidden] × [num_experts, hidden]^T` →
-`[1, num_experts]` — a 7168×256 GEMV. At Q4 this is ~0.9 MB of weight data. CPU NEON handles
+`[1, num_experts]` — a 2048×256 GEMV. At Q4 this is ~0.25 MB of weight data. CPU NEON handles
 this in ~0.05 ms; shipping it to the GPU costs a synchronization boundary before expert
 selection can proceed. More importantly, expert selection is a control-flow branch: the CPU
 must know which experts are active before encoding any of their compute commands into the
@@ -206,7 +206,7 @@ Each routed expert result is scaled by its router weight before accumulation. Tw
 - **CPU accumulation**: GPU writes each expert's down output to a per-expert scratch slot; CPU
   reads back all top_k results after command buffer completion and accumulates with weights.
 
-For top_k=8 and hidden=7168: CPU readback is 8 × 7168 × 4 bytes = 230 KB. At unified memory
+For top_k=8 and hidden=2048: CPU readback is 8 × 2048 × 4 bytes = 64 KB. At unified memory
 this is a pointer dereference, not a PCIe transfer — readback cost is negligible. GPU
 accumulation avoids even this, at the cost of one additional `scale_add` kernel encode per
 expert (8 extra dispatches within the same command buffer — negligible vs. the GEMV dispatches).
@@ -236,7 +236,7 @@ match &layer.common.ffn {
 | MLX backend (call Apple's MPS via MLX Rust bindings) | MLX is 3× faster than llama.cpp on MoE on Apple Silicon (measured: Ollama/MLX 58→112 tok/s on Qwen3.5-35B-A3B). But adding MLX as a dependency contradicts the pure-Rust, no-ONNX constraint in AGENTS.md. Not an option in v1. Track as v2 option if native Metal gap persists. |
 | GPU router (move top-k softmax to Metal) | Eliminates the CPU→GPU branch for expert selection, but requires a GPU→CPU readback of `[num_experts]` logits before command encoding can start. At batch=1 the GEMV cost (~0.05 ms on NEON) does not justify the synchronization. Reconsider if batch>1 becomes the target. |
 | Pre-gated routing (predict expert activations one step ahead) | DeepSeek-V2/V3 uses this to prefetch expert weights. Effective at hiding memory latency for weight-swapping configurations. Unnecessary when all weights are resident in unified memory. Defer to v2 with expert swapping. |
-| Expert weight re-layout at load (token-major) | Would allow a single fused `[batch, top_k, inter, hidden]` GEMM. Requires a full re-layout of ~5.6 GB of weights at load time and a different buffer structure. No benefit at batch=1 (decode). Defer to v2 prefill path. |
+| Expert weight re-layout at load (token-major) | Would allow a single fused `[batch, top_k, inter, hidden]` GEMM. Requires a full re-layout of ~15 GiB of weights at load time and a different buffer structure. No benefit at batch=1 (decode). Defer to v2 prefill path. |
 | Shared expert caching with redundancy elimination | DeepSeek caches the shared expert output across consecutive tokens when input hasn't changed. Valid optimization but requires state tracking that doesn't exist in the current decode loop. Defer. |
 
 ---
@@ -250,7 +250,7 @@ MoE throughput depends on expert weight bandwidth utilization across 8 concurren
 in the same command buffer. Measure after implementation; do not pin the number until verified.
 
 **R2: Expert memory pressure on 32 GB M2 Pro.**
-At ~5.6 GB for routed expert weights plus ~2 GB for attention state and activation buffers, the
+At ~15 GiB for routed expert weights plus ~2 GB for attention state and activation buffers, the
 35B MoE model is borderline on 32 GB. v1 will document the minimum configuration (64 GB
 recommended) and reject at load time with a clear error if total buffer allocation would
 exceed a configurable threshold (default: 0.85 × device.recommendedMaxWorkingSetSize).
@@ -264,7 +264,7 @@ ADR-044 v1 lands. No silent wrong results.
 
 **R4: Router weight dtype mismatch.**
 The router gate weight (`MoeRouter::gate`) is `Vec<f32>`. The existing CPU path reads it
-directly. For Metal, the gate weight is also small enough (256 × 7168 × 4 bytes = 7.3 MB) to
+directly. For Metal, the gate weight is also small enough (256 × 2048 × 4 bytes = 2.1 MB) to
 keep as f32 in its own `MTLBuffer` and run the CPU NEON kernel against the shared-memory pointer,
 avoiding a separate GPU router kernel. Confirm the `contents()` pointer is CPU-readable when
 using `MTLStorageModeShared` — it is, per the existing weight buffer pattern in `metal_qwen35.rs`.

--- a/docs/adr/ADR-053-moe-metal-dispatch.md
+++ b/docs/adr/ADR-053-moe-metal-dispatch.md
@@ -51,10 +51,8 @@ At Q4 with the current config dimensions:
 - Total routed expert weights across 40 layers: ~384 MiB × 40 ≈ **15 GiB**
 - Shared expert (dense, 512×2048): negligible (~4 MiB)
 
-> **Note**: the upstream Qwen3.6-35B Hugging Face config uses larger dimensions (hidden=7168,
-> moe_intermediate=2048). If the config fixture is updated to match upstream, the memory budget
-> rises to ~5.6 GB per 40 layers. The memory budget section should be re-verified when the
-> config is finalized.
+> **Note**: the local `Qwen35Config::qwen36_35b_a3b()` fixture matches the current upstream
+> HF `Qwen/Qwen3.6-35B-A3B` config. Re-verify this section if the target model changes.
 
 M2 Max unified memory is 32–96 GB. Loading all expert weights resident (the MLX approach) is
 feasible on 64 GB+ configurations for either dimension set. This ADR targets the resident-all

--- a/docs/adr/ADR-054-rolora-rotation-aware-lora.md
+++ b/docs/adr/ADR-054-rolora-rotation-aware-lora.md
@@ -1,0 +1,298 @@
+# ADR-054: Rotation-Aware LoRA Training (RoLoRA Integration)
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: `lattice-tune` (training) + `lattice-inference` (serving)
+**Depends on**: ADR-044 (QuaRot), ADR-045 (QuaRot+LoRA serving composition), ADR-031 (LoRA management)
+
+---
+
+## Context
+
+ADR-045 solved the *serving-side* coupling between QuaRot Q4 and LoRA adapters: adapters trained
+on the unrotated basis are corrected at load time via counter-rotation (`A ← A·R^T` for input-side
+projections, `B ← R·B` for output-side). This is exact and zero-cost at inference time.
+
+The remaining problem is *training-time*. Standard LoRA fine-tuning trains adapters against the
+original (un-rotated) weight basis. When the base model has had its residual stream rotated by R
+(the Hadamard transform from ADR-044), the quantization noise environment changes dramatically:
+
+- **At Q8**: quantization noise amplitude is ~2:1 relative to a typical LoRA delta. Adapters
+  trained on unrotated weights, counter-rotated at load time (ADR-045), function acceptably.
+- **At Q4**: quantization noise amplitude can *exceed* the adapter delta. The adapter signal is
+  in the wrong basis relative to the quantization error structure, and the counter-rotation at
+  load time corrects the basis mismatch but does not improve the signal-to-noise ratio at training
+  time. The adapter learns to compensate for the unrotated model's error surface, not the rotated
+  model's error surface.
+
+**RoLoRA** (EMNLP 2024, arxiv:2407.08044) directly addresses this. It applies the same Hadamard
+rotation used for quantization *before* fine-tuning, training LoRA adapters natively in the rotated
+weight basis. Adapters trained this way require no post-hoc correction; they are already in the
+basis the served model operates in. Reported gain: +29.5 percentage points absolute on W4A4
+commonsense reasoning versus standard LoRA.
+
+The QuaRot rotation seed in Lattice is deterministic. The same seed produces the same R matrix.
+This means training-time and serving-time rotation are trivially synchronized — the basis
+alignment problem reduces to a metadata handshake.
+
+### What exists in Lattice today
+
+| Component | Location | Status |
+|-----------|----------|--------|
+| `LoraAdapter` / `LoraLayer` | `crates/tune/src/lora/mod.rs` | Active |
+| `LoraConfig` | `crates/tune/src/lora/mod.rs` | Active |
+| `RandomizedHadamard` | `crates/inference/src/quant/quarot/` | Active — deterministic from seed |
+| QuaRot rotation plan | `crates/inference/src/quant/quarot/plan.rs` | Active — per-projection side rules |
+| QuaRot seed in artifact | `config.json` of `quantize_quarot` output | **NOT YET PERSISTED** (see ADR-045 §Prerequisites) |
+| Serving-side counter-rotation | `crates/inference/src/…` | Active (ADR-045, PRs #35-#37) |
+
+---
+
+## Decision
+
+### The gauge alignment problem
+
+In the QuaRot residual stream, the model operates with rotated hidden states `h_rot = R·h`. A
+LoRA adapter `(B, A)` trained on the *unrotated* model learns to correct the unrotated error
+surface. Serving via counter-rotation (ADR-045) fixes the basis mismatch exactly, but the adapter
+has been optimized against the wrong noise distribution.
+
+A RoLoRA adapter `(B, A)` is trained from the start with the base weights already in the rotated
+basis: `W_rot = W·R^T` (input-side) or `W_rot = R·W` (output-side). The LoRA delta is then
+trained directly on `W_rot`, so at serving time no counter-rotation is needed — the adapter is
+already basis-correct.
+
+For the serving-side equation (input-side projection as example):
+
+```
+Standard LoRA + ADR-045 counter-rotation:
+  y = W_rot·h_rot + s·B·(A·R^T)·h_rot = W·h + s·B·A·h  ✓ (basis corrected post-hoc)
+
+RoLoRA (adapter trained in rotated basis):
+  y = W_rot·h_rot + s·B·A·h_rot                         ✓ (no correction needed)
+```
+
+Both produce correct output. The difference is in what loss landscape the adapter was trained
+against, which determines quality at low bit-widths.
+
+### Training-time changes (lattice-tune)
+
+Introduce a `rotation_aware` flag in `LoraConfig`:
+
+```rust
+pub struct LoraConfig {
+    pub rank: usize,
+    pub alpha: f32,
+    pub target_modules: Vec<String>,
+    /// When Some(seed), apply the QuaRot Hadamard rotation to the frozen base
+    /// weights before LoRA initialization. Adapters trained with this flag are
+    /// native to the rotated basis and require no counter-rotation at serving time.
+    pub quarot_seed: Option<u64>,
+}
+```
+
+When `quarot_seed` is `Some(seed)`, the training pipeline:
+
+1. Reconstructs `R = RandomizedHadamard::new(seed, hidden_dim)` using the same primitive from
+   `lattice-inference` (no new Hadamard implementation — reuse via a `lattice-inference` dev
+   dependency in `lattice-tune`, which already exists in `tune → inference` direction).
+2. Applies rotation absorption to the frozen base weight snapshots before LoRA init:
+   - Input-side projections: `W_frozen ← W_frozen·R^T`
+   - Output-side projections: `W_frozen ← R·W_frozen`
+3. Initializes LoRA matrices `A` (random Gaussian) and `B` (zeros) against the rotated frozen
+   weights, following standard LoRA initialization.
+4. Trains. The LoRA delta `s·B·A` is learned in the rotated basis throughout.
+5. Saves the adapter safetensors with an `"rotation_aware": true` metadata key and the
+   `"quarot_seed": <seed>` value in the adapter config.
+
+The frozen base weights themselves are not written to disk — only the adapter `A` and `B` matrices
+are exported. The rotation is applied transiently during forward/backward.
+
+### Serving-time changes (lattice-inference)
+
+The `load_lora_adapter` API (ADR-045) accepts `quarot_seed: Option<u64>`. Extend the loading
+logic to read the adapter metadata:
+
+```rust
+pub fn load_lora_adapter(
+    &mut self,
+    layers: Vec<LoraLayerData>,
+    scale: f32,
+    quarot_seed: Option<u64>,  // None = legacy path; Some = apply counter-rotation
+) -> Result<(), InferenceError>;
+```
+
+When loading an adapter whose metadata contains `"rotation_aware": true`:
+
+- **The adapter is already in the rotated basis.** Upload A and B directly to Metal buffers
+  without applying WHT transforms. Pass `quarot_seed: None` at the API callsite (or detect from
+  metadata automatically once seed persistence ships, per §Prerequisites).
+
+When loading a legacy adapter (no rotation_aware metadata) against a QuaRot Q4 base:
+
+- Apply counter-rotation as specified in ADR-045. This path is unchanged.
+
+**Verification at load time**: if the served model is a QuaRot artifact and the adapter metadata
+is absent or `"rotation_aware": false`, emit a `warn!` log identifying the adapter as legacy and
+confirming counter-rotation is being applied. This surfaces the distinction without breaking
+existing workflows.
+
+### Metadata contract
+
+The QuaRot converter (`quantize_quarot`) MUST persist rotation metadata (ADR-045 §Prerequisites
+is still open). This ADR depends on that field existing. The required `config.json` addition:
+
+```json
+{
+  "quarot": {
+    "kind": "randomized_hadamard",
+    "seed": 12648430,
+    "hidden_dim": 1024,
+    "plan": "qwen35_residual_stream_linear_layers"
+  }
+}
+```
+
+The adapter safetensors `config.json` MUST contain:
+
+```json
+{
+  "rotation_aware": true,
+  "quarot_seed": 12648430
+}
+```
+
+At load time: if the model artifact has a `quarot.seed` and the adapter has
+`rotation_aware: true` with a matching seed, skip counter-rotation. Seed mismatch between model
+artifact and adapter metadata is an error (fail-closed).
+
+---
+
+## Scope
+
+**In scope for v1**:
+
+- `LoraConfig.quarot_seed` field in `lattice-tune`
+- Transient rotation application to frozen weights during training
+- Adapter metadata (`rotation_aware`, `quarot_seed`) written to exported safetensors
+- Serving-side metadata detection and conditional counter-rotation bypass in `lattice-inference`
+- Backward compatibility: legacy adapters (no metadata) continue to use ADR-045 counter-rotation
+  path unchanged
+
+**Out of scope (deferred)**:
+
+- QuAILoRA initialization (quantization-error-minimizing LoRA init, arxiv:2410.14713) — separate
+  concern, compatible with RoLoRA, defer to ADR-055
+- QA-LoRA 4-bit adapter merging — deferred, no current use case
+- Automatic seed detection from model artifact (requires ADR-045 §Prerequisites to ship first;
+  until then, callers supply seed explicitly)
+- Multi-adapter / MoLoRA routing in the rotated basis (v2, KG entity `W2-Barycenter-Adapter-Blending`)
+
+---
+
+## Architecture
+
+```
+TRAINING (lattice-tune)
+┌─────────────────────────────────────────────────────────────────────┐
+│  LoraConfig { rank, alpha, targets, quarot_seed: Some(seed) }       │
+│                                                                     │
+│  1. Load frozen BF16/F32 base weights                               │
+│  2. Reconstruct R = RandomizedHadamard(seed, hidden_dim) via        │
+│     lattice-inference primitive (no new implementation)             │
+│  3. Apply rotation to frozen weight snapshots (transient, in-mem):  │
+│     Input-side:  W_frozen ← W_frozen · R^T                         │
+│     Output-side: W_frozen ← R · W_frozen                           │
+│  4. Init A (Gaussian), B (zero) against rotated W_frozen           │
+│  5. Train LoRA on rotated basis                                     │
+│  6. Export: adapter A/B safetensors +                               │
+│     config { rotation_aware: true, quarot_seed: seed }              │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼  (adapter .safetensors)
+SERVING (lattice-inference)
+┌─────────────────────────────────────────────────────────────────────┐
+│  load_lora_adapter()                                                │
+│                                                                     │
+│  Read adapter metadata:                                             │
+│    rotation_aware: true  → upload A, B directly (no WHT)           │
+│    rotation_aware: false │                                          │
+│    or absent             → apply counter-rotation (ADR-045 path)   │
+│                            warn! log for visibility                 │
+│                                                                     │
+│  Seed mismatch (model quarot.seed ≠ adapter quarot_seed) → Error   │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+METAL FORWARD (per token, unchanged from ADR-045)
+┌─────────────────────────────────────────────────────────────────────┐
+│  base_out = Q4_GEMV(W_rot, h_rot)          [existing]               │
+│  lora_out = scale * B @ (A @ h_rot)        [existing kernel]        │
+│  out = base_out + lora_out                                          │
+│  (A and B are already basis-correct regardless of training path)    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons | Verdict |
+|-------------|------|------|---------|
+| **ADR-045 counter-rotation only (current)** | No training changes needed; works with existing PEFT adapters | Adapter trained against wrong noise distribution at Q4; SNR gap grows at lower bit-widths | Keep as legacy path; insufficient for new Q4 adapter training |
+| **RoLoRA (this ADR)** | Adapter trained in correct basis; +29.5pp reported on W4A4; zero serving-side overhead for rotation-aware adapters; seed already deterministic | Requires rotation-aware training infra; not compatible with generic PEFT export unless seed metadata added | **Accept** |
+| **QuAILoRA initialization** (arxiv:2410.14713) | Minimizes quantization error at LoRA init; composable with RoLoRA | Orthogonal concern (init strategy, not basis alignment); separate ADR | Defer to ADR-055; composable with this decision |
+| **Runtime rotation at each training step** | Avoids modifying frozen weights | Per-step `d×d` WHT overhead on all target projections during training; unnecessary given seed is fixed | Reject — one-time absorption is equivalent and free |
+| **Separate RoLoRA training crate** | Clean separation | Violates `Π_AEP` (FindExisting > Create); `LoraConfig` already has the right extension point | Reject |
+
+---
+
+## Risks
+
+1. **ADR-045 seed persistence prerequisite is still open.** Until `quantize_quarot` writes the
+   `quarot.seed` to `config.json`, the serving-side auto-detection cannot verify seed alignment.
+   Mitigation: callers supply `quarot_seed` explicitly (same as current ADR-045 behavior). The
+   seed mismatch error fires immediately if the wrong seed is passed. This ADR does not ship
+   until the seed persistence ticket is resolved.
+
+2. **Frozen weight rotation doubles peak memory during training.** Rotating all frozen weights
+   in-memory requires holding both the original and rotated snapshots transiently (or recomputing
+   from the original on the fly). Mitigation: apply rotation per-layer and discard immediately;
+   never hold the full rotated model in memory simultaneously. Cost: `O(max_layer_size)` working
+   buffer, not `O(total_params)`.
+
+3. **Legacy PEFT adapter ecosystem.** Adapters exported from Hugging Face PEFT are trained on
+   unrotated weights and have no rotation metadata. These use the ADR-045 counter-rotation path
+   unchanged. Users fine-tuning from Lattice's own training pipeline benefit from RoLoRA; users
+   loading third-party adapters do not, but are no worse than before.
+
+4. **Seed confidentiality.** If the QuaRot seed is treated as proprietary (e.g., leaked seed
+   would allow reconstruction of the rotation applied to the weights), storing it in the adapter
+   metadata exposes it. At current scale this is not a concern; flag for review before any
+   commercial model distribution.
+
+---
+
+## References
+
+- RoLoRA: Zhu et al., EMNLP 2024 — "RoLoRA: Fine-tuning Rotated Outlier-Free LLMs for Effective
+  Weight-Activation Quantization", arxiv:2407.08044
+- QuAILoRA: arxiv:2410.14713 — quantization-error-aware LoRA initialization (deferred to ADR-055)
+- ADR-044: QuaRot Hadamard-rotated 4-bit quantization (rotation math, `RandomizedHadamard`)
+- ADR-045: QuaRot + LoRA composition at inference time (serving-side counter-rotation)
+- ADR-043: LoRA serving verification (correctness framework, `LoraHook` trait)
+- ADR-031: LoRA management (adapter lifecycle)
+- KG: `LoRA SNR vs Base Quantization Noise`, `QuaRot (Ashkboos 2024)` (86ec6a4f),
+  `LoRA-Low-Rank-Adaptation` (e916fb8b), `W2-Barycenter-Adapter-Blending` (e6a40019)
+- Hu et al. 2021, "LoRA: Low-Rank Adaptation of Large Language Models", arxiv:2106.09685
+- Ashkboos et al. 2024, "QuaRot: Outlier-Free 4-Bit Inference in Rotated LLMs", arxiv:2404.00456
+
+---
+
+## Knowledge Graph
+
+- New entity on implementation PR: `RoLoRA` (kind: concept, type: technique, status: proposed)
+  - `extends` → `LoRA-Low-Rank-Adaptation`
+  - `composed_with` → `QuaRot (Ashkboos 2024)`
+  - `introduced_by` → `Zhu et al. EMNLP 2024`
+  - `competes_with` → `QuAILoRA` (alternative quantization-aware LoRA init approach)

--- a/docs/adr/ADR-054-rolora-rotation-aware-lora.md
+++ b/docs/adr/ADR-054-rolora-rotation-aware-lora.md
@@ -182,7 +182,7 @@ artifact and adapter metadata is an error (fail-closed).
 **Out of scope (deferred)**:
 
 - QuAILoRA initialization (quantization-error-minimizing LoRA init, arxiv:2410.14713) — separate
-  concern, compatible with RoLoRA, defer to ADR-055
+  concern, compatible with RoLoRA, defer to a future ADR
 - QA-LoRA 4-bit adapter merging — deferred, no current use case
 - Automatic seed detection from model artifact (requires ADR-045 §Prerequisites to ship first;
   until then, callers supply seed explicitly)

--- a/docs/adr/ADR-054-rolora-rotation-aware-lora.md
+++ b/docs/adr/ADR-054-rolora-rotation-aware-lora.md
@@ -241,7 +241,7 @@ METAL FORWARD (per token, unchanged from ADR-045)
 |-------------|------|------|---------|
 | **ADR-045 counter-rotation only (current)** | No training changes needed; works with existing PEFT adapters | Adapter trained against wrong noise distribution at Q4; SNR gap grows at lower bit-widths | Keep as legacy path; insufficient for new Q4 adapter training |
 | **RoLoRA (this ADR)** | Adapter trained in correct basis; +29.5pp reported on W4A4; zero serving-side overhead for rotation-aware adapters; seed already deterministic | Requires rotation-aware training infra; not compatible with generic PEFT export unless seed metadata added | **Accept** |
-| **QuAILoRA initialization** (arxiv:2410.14713) | Minimizes quantization error at LoRA init; composable with RoLoRA | Orthogonal concern (init strategy, not basis alignment); separate ADR | Defer to ADR-055; composable with this decision |
+| **QuAILoRA initialization** (arxiv:2410.14713) | Minimizes quantization error at LoRA init; composable with RoLoRA | Orthogonal concern (init strategy, not basis alignment); separate ADR | Defer to a future ADR; composable with this decision |
 | **Runtime rotation at each training step** | Avoids modifying frozen weights | Per-step `d×d` WHT overhead on all target projections during training; unnecessary given seed is fixed | Reject — one-time absorption is equivalent and free |
 | **Separate RoLoRA training crate** | Clean separation | Violates `Π_AEP` (FindExisting > Create); `LoraConfig` already has the right extension point | Reject |
 
@@ -277,7 +277,7 @@ METAL FORWARD (per token, unchanged from ADR-045)
 
 - RoLoRA: Zhu et al., EMNLP 2024 — "RoLoRA: Fine-tuning Rotated Outlier-Free LLMs for Effective
   Weight-Activation Quantization", arxiv:2407.08044
-- QuAILoRA: arxiv:2410.14713 — quantization-error-aware LoRA initialization (deferred to ADR-055)
+- QuAILoRA: arxiv:2410.14713 — quantization-error-aware LoRA initialization (deferred to a future ADR)
 - ADR-044: QuaRot Hadamard-rotated 4-bit quantization (rotation math, `RandomizedHadamard`)
 - ADR-045: QuaRot + LoRA composition at inference time (serving-side counter-rotation)
 - ADR-043: LoRA serving verification (correctness framework, `LoraHook` trait)

--- a/docs/adr/ADR-055-online-drift-detection.md
+++ b/docs/adr/ADR-055-online-drift-detection.md
@@ -38,17 +38,26 @@ applies symmetrically to both mechanisms. This ADR formalizes the dual-use desig
 ## Decision
 
 Add an `OnlineDriftDetector` to `lattice-transport` that computes Sinkhorn divergence over
-a sliding window of hidden-state samples. Expose a `DriftSignal` event type that `lattice-inference`
-subscribes to for triggering adapter and router staleness checks.
+a sliding window of hidden-state samples. Expose an `OnlineDriftSignal` event type that
+`lattice-inference` subscribes to for triggering adapter and router staleness checks.
+
+**Existing drift API**: `crates/transport/src/drift.rs` already provides `DriftConfig`,
+`DriftReport`, and `detect_drift_records` for batch embedding drift analysis. The new online
+detector is a distinct mechanism — streaming, sample-by-sample, with a sliding window — and
+uses non-conflicting names (`OnlineDriftDetector`, `OnlineDriftConfig`, `OnlineDriftSignal`)
+to coexist with the existing batch API.
 
 The boundary is explicit:
 - `lattice-transport` owns: the sliding window, divergence computation, threshold comparison,
   and signal emission. It is distribution-agnostic — it does not know what the samples represent.
 - `lattice-inference` owns: sampling from the inference pipeline (which layer, how often),
-  reacting to `DriftSignal` (which component to refresh, how to refresh it).
+  reacting to `OnlineDriftSignal` (which component to refresh, how to refresh it).
 
-This preserves the existing dependency direction: `inference` depends on `transport`, never
-the reverse.
+**Crate dependency note**: `lattice-inference` does not currently depend on `lattice-transport`.
+Rather than adding that edge (which would break the leaf-crate invariant), the integration uses
+a callback boundary: `lattice-inference` defines a `DriftSampler` trait, and the application
+binary (`bin/chat_metal` or the serving layer) wires the concrete `OnlineDriftDetector` from
+`lattice-transport` into the `DriftSampler` impl. Neither crate imports the other.
 
 ---
 
@@ -56,13 +65,13 @@ the reverse.
 
 New files:
 
-- `crates/transport/src/drift.rs` — `OnlineDriftDetector`, `DriftConfig`, `DriftSignal`
+- `crates/transport/src/online_drift.rs` — `OnlineDriftDetector`, `OnlineDriftConfig`, `OnlineDriftSignal`
 
 Modified files:
 
-- `crates/transport/src/lib.rs` — re-export `drift` module
-- `crates/inference/src/monitor.rs` — `InferenceDriftMonitor` wiring hidden-state samples to
-  the detector; `DriftReactor` trait with `on_adapter_stale()` and `on_router_stale()` methods
+- `crates/transport/src/lib.rs` — re-export `online_drift` module (existing `drift` module unchanged)
+- `crates/inference/src/monitor.rs` — `DriftSampler` trait with `on_adapter_stale()` and
+  `on_router_stale()` callbacks; no import of `lattice-transport`
 
 No new crates. No Metal kernel changes. No changes to serving hot path.
 

--- a/docs/adr/ADR-055-online-drift-detection.md
+++ b/docs/adr/ADR-055-online-drift-detection.md
@@ -113,7 +113,7 @@ impl OnlineDriftDetector {
 
 `push()` appends to `current_window`, evicts oldest entry if full. Every `check_interval`
 samples, calls `point_set_sinkhorn_divergence` (ADR-039) between `reference_window` and
-`current_window`. If `divergence > threshold`, returns `Some(DriftSignal)`.
+`current_window`. If `divergence > threshold`, returns `Some(OnlineDriftSignal)`.
 
 The reference window is frozen at construction from the first W samples. After an adapter
 refresh, `reset_reference()` promotes `current_window` to `reference_window`, restarting
@@ -134,7 +134,7 @@ pub trait DriftSampler: Send + Sync {
 }
 ```
 
-The monitor hooks into `lattice-inference`'s forward pass via an optional `Arc<InferenceDriftMonitor>`
+The monitor hooks into `lattice-inference`'s forward pass via an optional `Arc<dyn DriftSampler>`
 on `GenerationConfig`. If `None` (the default), zero overhead — no sampling, no allocation.
 When present, every `sample_every_n_tokens` tokens, the monitor receives the hidden states at
 `sample_layer` and pushes a mean-pooled sample vector (dim = hidden_size) to both detectors.
@@ -149,9 +149,8 @@ of sequence length.
 Forward pass (every N tokens)
   → sample hidden states at layer L
   → mean pool → Vec<f32> of dim hidden_size
-  → push to adapter_detector → Option<DriftSignal>
-  → push to router_detector  → Option<DriftSignal>
-  → if Some: call DriftReactor::on_adapter_stale / on_router_stale
+  → DriftSampler::push_sample(hidden_state)
+  → if drift detected: DriftSampler::on_adapter_stale / on_router_stale
 ```
 
 Both detectors share the same sample stream because both adapter staleness and router staleness
@@ -170,9 +169,9 @@ refresh_interval* = sqrt(2 * C_refresh / (δ * rate_of_divergence))
 where `C_refresh` is the cost of retraining/swapping, `δ` is the excess NLL from stale adapter
 use, and `rate_of_divergence` is empirically estimated from the drift signal time series.
 
-In practice, `threshold` in `DriftConfig` is a Sinkhorn divergence value calibrated from a
+In practice, `threshold` in `OnlineDriftConfig` is a Sinkhorn divergence value calibrated from a
 validation set: compute `S(training_dist, held_out_dist)` at known excess NLL levels and pick
-the divergence that corresponds to acceptable degradation. The `DriftSignal.divergence` value
+the divergence that corresponds to acceptable degradation. The `OnlineDriftSignal.divergence` value
 lets the reactor apply graduated responses (warn vs. force-refresh vs. fallback to base model).
 
 ---
@@ -200,7 +199,7 @@ latency noise floor on M-series silicon. W > 512 requires explicit approval and 
 seen after construction (or after `reset_reference()`). If the first W samples are not
 representative — cold start, single user, atypical prompt — the reference is biased and
 divergence will fire spuriously. Mitigation: `reset_reference()` should be called after a
-warm-up phase of at least 2W samples; document this in `DriftConfig`.
+warm-up phase of at least 2W samples; document this in `OnlineDriftConfig`.
 
 **R3: Mean pooling loses distributional shape.** Mean pooling is an order-1 statistic.
 Two very different distributions with the same mean pool to the same sample. For the first

--- a/docs/adr/ADR-055-online-drift-detection.md
+++ b/docs/adr/ADR-055-online-drift-detection.md
@@ -82,20 +82,20 @@ No new crates. No Metal kernel changes. No changes to serving hot path.
 ### Layer 0: `lattice-transport` — drift primitive
 
 ```rust
-pub struct DriftConfig {
+pub struct OnlineDriftConfig {
     pub window_size: usize,     // W; minimum 128. O(W²) per divergence call.
     pub check_interval: usize,  // compute divergence every N new samples (amortizes cost)
-    pub threshold: f32,         // S(ref, current) > threshold → emit DriftSignal
+    pub threshold: f32,         // S(ref, current) > threshold → emit OnlineDriftSignal
     pub epsilon: f32,           // Sinkhorn regularization (inherited from SinkhornConfig)
 }
 
-pub struct DriftSignal {
+pub struct OnlineDriftSignal {
     pub divergence: f32,        // S(reference, current) value at detection
     pub window_pos: usize,      // total samples seen when signal fired
 }
 
 pub struct OnlineDriftDetector {
-    config: DriftConfig,
+    config: OnlineDriftConfig,
     reference_window: VecDeque<Vec<f32>>,   // first W samples; frozen as reference
     current_window: VecDeque<Vec<f32>>,     // sliding window of last W samples
     samples_seen: usize,
@@ -106,7 +106,7 @@ pub struct OnlineDriftDetector {
 }
 
 impl OnlineDriftDetector {
-    pub fn push(&mut self, sample: Vec<f32>) -> Option<DriftSignal>;
+    pub fn push(&mut self, sample: Vec<f32>) -> Option<OnlineDriftSignal>;
     pub fn reset_reference(&mut self);  // call after adapter/router refresh
 }
 ```
@@ -122,16 +122,15 @@ the baseline from the updated distribution.
 ### Layer 1: `lattice-inference` — sampling and reaction
 
 ```rust
-pub struct InferenceDriftMonitor {
-    adapter_detector: OnlineDriftDetector,
-    router_detector: OnlineDriftDetector,
-    sample_layer: usize,         // hidden-state layer to sample from (default: middle layer)
-    sample_every_n_tokens: usize, // push to detector every N tokens (default: 16)
-}
+// lattice-inference owns only the trait — no lattice-transport import.
+// The application binary wires the concrete OnlineDriftDetector from transport.
 
-pub trait DriftReactor: Send + Sync {
-    fn on_adapter_stale(&self, signal: DriftSignal);
-    fn on_router_stale(&self, signal: DriftSignal);
+/// Callback trait for inference-side drift reaction. Implemented by the application
+/// binary, not by lattice-inference itself.
+pub trait DriftSampler: Send + Sync {
+    fn push_sample(&mut self, hidden_state: &[f32]);
+    fn on_adapter_stale(&self, divergence: f32);
+    fn on_router_stale(&self, divergence: f32);
 }
 ```
 

--- a/docs/adr/ADR-055-online-drift-detection.md
+++ b/docs/adr/ADR-055-online-drift-detection.md
@@ -1,0 +1,223 @@
+# ADR-055: Online Distribution Drift Detection via Sinkhorn Divergence
+
+**Status**: Proposed
+**Date**: 2026-05-19
+**Crate**: `lattice-transport` + `lattice-inference`
+
+---
+
+## Context
+
+Lattice serves LoRA adapters and MoE router weights that are trained on a fixed data distribution.
+As a model deployment ages, the input distribution drifts — vocabulary shift, domain change,
+user population change — and the adapter (or router) that was optimal at training time becomes
+stale. No mechanism currently exists to detect this staleness at serving time.
+
+`lattice-transport` already implements the full Sinkhorn-Knopp solver (ADR-035), log-domain
+stability (ADR-036), cost matrices (ADR-037), Wasserstein barycenters (ADR-038), and the
+Sinkhorn divergence with correct debiasing (ADR-039). That stack is the OT primitive layer.
+
+The KG contains three relevant entities:
+
+- **`Online Sinkhorn Drift Estimator`**: O(W²) sliding-window algorithm for distribution shift
+  detection with a minimum window of 128 samples.
+- **`SinkhornAdapterStalenessDetector`**: Applies the drift estimator to detect when LoRA
+  adapters need retraining.
+- **`Adapter Refresh Threshold`**: Renewal theory formula for computing optimal refresh
+  intervals given drift rate and excess NLL cost.
+
+A structural insight emerges: the Sinkhorn drift signal that triggers adapter retraining applies
+equally to MoE router staleness. The Qwen3.5 MoE router (see ADR-040) was trained on a token
+distribution. When input token distributions drift, the routing assignments drift with them —
+the experts that receive tokens shift, some experts become under-utilized, load imbalance
+emerges, and effective capacity decreases. The `Adapter Refresh Threshold` renewal theory result
+applies symmetrically to both mechanisms. This ADR formalizes the dual-use design.
+
+---
+
+## Decision
+
+Add an `OnlineDriftDetector` to `lattice-transport` that computes Sinkhorn divergence over
+a sliding window of hidden-state samples. Expose a `DriftSignal` event type that `lattice-inference`
+subscribes to for triggering adapter and router staleness checks.
+
+The boundary is explicit:
+- `lattice-transport` owns: the sliding window, divergence computation, threshold comparison,
+  and signal emission. It is distribution-agnostic — it does not know what the samples represent.
+- `lattice-inference` owns: sampling from the inference pipeline (which layer, how often),
+  reacting to `DriftSignal` (which component to refresh, how to refresh it).
+
+This preserves the existing dependency direction: `inference` depends on `transport`, never
+the reverse.
+
+---
+
+## Scope
+
+New files:
+
+- `crates/transport/src/drift.rs` — `OnlineDriftDetector`, `DriftConfig`, `DriftSignal`
+
+Modified files:
+
+- `crates/transport/src/lib.rs` — re-export `drift` module
+- `crates/inference/src/monitor.rs` — `InferenceDriftMonitor` wiring hidden-state samples to
+  the detector; `DriftReactor` trait with `on_adapter_stale()` and `on_router_stale()` methods
+
+No new crates. No Metal kernel changes. No changes to serving hot path.
+
+---
+
+## Architecture
+
+### Layer 0: `lattice-transport` — drift primitive
+
+```rust
+pub struct DriftConfig {
+    pub window_size: usize,     // W; minimum 128. O(W²) per divergence call.
+    pub check_interval: usize,  // compute divergence every N new samples (amortizes cost)
+    pub threshold: f32,         // S(ref, current) > threshold → emit DriftSignal
+    pub epsilon: f32,           // Sinkhorn regularization (inherited from SinkhornConfig)
+}
+
+pub struct DriftSignal {
+    pub divergence: f32,        // S(reference, current) value at detection
+    pub window_pos: usize,      // total samples seen when signal fired
+}
+
+pub struct OnlineDriftDetector {
+    config: DriftConfig,
+    reference_window: VecDeque<Vec<f32>>,   // first W samples; frozen as reference
+    current_window: VecDeque<Vec<f32>>,     // sliding window of last W samples
+    samples_seen: usize,
+    // Three workspaces for warm-start across repeated divergence calls (ADR-039 pattern)
+    workspace_xy: SinkhornWorkspace,
+    workspace_xx: SinkhornWorkspace,
+    workspace_yy: SinkhornWorkspace,
+}
+
+impl OnlineDriftDetector {
+    pub fn push(&mut self, sample: Vec<f32>) -> Option<DriftSignal>;
+    pub fn reset_reference(&mut self);  // call after adapter/router refresh
+}
+```
+
+`push()` appends to `current_window`, evicts oldest entry if full. Every `check_interval`
+samples, calls `point_set_sinkhorn_divergence` (ADR-039) between `reference_window` and
+`current_window`. If `divergence > threshold`, returns `Some(DriftSignal)`.
+
+The reference window is frozen at construction from the first W samples. After an adapter
+refresh, `reset_reference()` promotes `current_window` to `reference_window`, restarting
+the baseline from the updated distribution.
+
+### Layer 1: `lattice-inference` — sampling and reaction
+
+```rust
+pub struct InferenceDriftMonitor {
+    adapter_detector: OnlineDriftDetector,
+    router_detector: OnlineDriftDetector,
+    sample_layer: usize,         // hidden-state layer to sample from (default: middle layer)
+    sample_every_n_tokens: usize, // push to detector every N tokens (default: 16)
+}
+
+pub trait DriftReactor: Send + Sync {
+    fn on_adapter_stale(&self, signal: DriftSignal);
+    fn on_router_stale(&self, signal: DriftSignal);
+}
+```
+
+The monitor hooks into `lattice-inference`'s forward pass via an optional `Arc<InferenceDriftMonitor>`
+on `GenerationConfig`. If `None` (the default), zero overhead — no sampling, no allocation.
+When present, every `sample_every_n_tokens` tokens, the monitor receives the hidden states at
+`sample_layer` and pushes a mean-pooled sample vector (dim = hidden_size) to both detectors.
+
+Mean pooling collapses a variable-length sequence of vectors (one per token in the current
+step) to a single fixed-size sample, making the window storage O(W × hidden_dim) regardless
+of sequence length.
+
+### Dual-use signal path
+
+```
+Forward pass (every N tokens)
+  → sample hidden states at layer L
+  → mean pool → Vec<f32> of dim hidden_size
+  → push to adapter_detector → Option<DriftSignal>
+  → push to router_detector  → Option<DriftSignal>
+  → if Some: call DriftReactor::on_adapter_stale / on_router_stale
+```
+
+Both detectors share the same sample stream because both adapter staleness and router staleness
+are caused by the same root: input distribution drift. A single sample population feeds two
+independent sliding windows with potentially different configs (the router may tolerate more
+drift before refresh is warranted).
+
+### Threshold calibration
+
+The `Adapter Refresh Threshold` from the KG entity uses renewal theory:
+
+```
+refresh_interval* = sqrt(2 * C_refresh / (δ * rate_of_divergence))
+```
+
+where `C_refresh` is the cost of retraining/swapping, `δ` is the excess NLL from stale adapter
+use, and `rate_of_divergence` is empirically estimated from the drift signal time series.
+
+In practice, `threshold` in `DriftConfig` is a Sinkhorn divergence value calibrated from a
+validation set: compute `S(training_dist, held_out_dist)` at known excess NLL levels and pick
+the divergence that corresponds to acceptable degradation. The `DriftSignal.divergence` value
+lets the reactor apply graduated responses (warn vs. force-refresh vs. fallback to base model).
+
+---
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons | Why Not |
+|---|---|---|---|
+| KL divergence on token ID distribution | O(n log n), no OT | Requires binning; undefined when support differs; no geometry | Continuous hidden states don't bin naturally |
+| MMD (Maximum Mean Discrepancy) | Closed form kernel test | Kernel choice matters; no geometry; harder to threshold | Less interpretable than OT divergence; no transport interpretation |
+| Exponential moving average of cosine similarity | Zero OT cost, O(1) per step | Not a proper divergence; `cos(a, a) = 1` always, no `S(a, b) = 0` guarantee | Cannot distinguish in-distribution drift from magnitude shift |
+| Separate detectors per crate (transport-side only, no inference hook) | Keeps transport fully standalone | Forces inference callers to wire sampling manually; drift is only useful with reaction | Incomplete without the reaction path; adds boilerplate at every callsite |
+| Monitor every token (no `sample_every_n_tokens`) | Maximally sensitive | O(W²) per token is prohibitive at 128 window; 128×128×3 solves at 1 ns/op = 50 µs per token | Sample-and-amortize: every 16 tokens, 50 µs total amortized to 3 µs/token |
+
+---
+
+## Risks
+
+**R1: O(W²) cost at large windows.** At W=128, three Sinkhorn solves over 128×128 matrices.
+Each solve ≈ 50 iterations × 128×128 × 1 ns/op ≈ 0.8 ms; total ≈ 2.4 ms per divergence call.
+At `check_interval=256` tokens, amortized cost is 2.4 ms / 256 ≈ 9 µs/token — below serving
+latency noise floor on M-series silicon. W > 512 requires explicit approval and profiling.
+
+**R2: Reference window quality.** The reference window is built from the first W samples
+seen after construction (or after `reset_reference()`). If the first W samples are not
+representative — cold start, single user, atypical prompt — the reference is biased and
+divergence will fire spuriously. Mitigation: `reset_reference()` should be called after a
+warm-up phase of at least 2W samples; document this in `DriftConfig`.
+
+**R3: Mean pooling loses distributional shape.** Mean pooling is an order-1 statistic.
+Two very different distributions with the same mean pool to the same sample. For the first
+deployment this is acceptable — mean shift is the primary signal of distribution drift.
+Higher-order statistics (covariance pooling) are a future extension if mean-pool sensitivity
+proves insufficient.
+
+**R4: Crate boundary violation.** If `lattice-transport` were to import anything from
+`lattice-inference` (for example, to know what layer to sample from), the dependency would
+invert. The design prevents this by making `OnlineDriftDetector` fully sample-agnostic.
+`lattice-inference` owns all decisions about what to sample; `lattice-transport` only
+receives `Vec<f32>` values. Enforcement: `crates/transport/Cargo.toml` must never contain
+`lattice-inference` as a dependency.
+
+---
+
+## References
+
+- ADR-035: Sinkhorn-Knopp Solver — sliding window builds on this primitive
+- ADR-036: Log-Domain Stability — numerical robustness inherited
+- ADR-039: Sinkhorn Divergence — `point_set_sinkhorn_divergence`, three-workspace warm-start
+- ADR-040: Gated Attention (MoE router) — router staleness context
+- ADR-043: LoRA Serving Verification — adapter serving context
+- KG entities: `Online Sinkhorn Drift Estimator`, `SinkhornAdapterStalenessDetector`,
+  `Adapter Refresh Threshold`, `Stale Adapter Excess NLL`
+- Genevay, Peyré, Cuturi, "Learning Generative Models with Sinkhorn Divergences", AISTATS 2018
+- Feydy et al., "Interpolating between Optimal Transport and MMD using Sinkhorn Divergences",
+  AISTATS 2019 — positive semi-definiteness proof used to justify divergence thresholding

--- a/docs/adr/ADR-055-online-drift-detection.md
+++ b/docs/adr/ADR-055-online-drift-detection.md
@@ -128,14 +128,17 @@ the baseline from the updated distribution.
 /// Callback trait for inference-side drift reaction. Implemented by the application
 /// binary, not by lattice-inference itself.
 pub trait DriftSampler: Send + Sync {
-    fn push_sample(&mut self, hidden_state: &[f32]);
+    /// Push a hidden-state sample. Uses &self with interior mutability
+    /// (e.g., Mutex<OnlineDriftDetector>) so the sampler can be stored
+    /// in Arc<dyn DriftSampler> without exclusive access.
+    fn push_sample(&self, hidden_state: &[f32]);
     fn on_adapter_stale(&self, divergence: f32);
     fn on_router_stale(&self, divergence: f32);
 }
 ```
 
 The monitor hooks into `lattice-inference`'s forward pass via an optional `Arc<dyn DriftSampler>`
-on `GenerationConfig`. If `None` (the default), zero overhead — no sampling, no allocation.
+on `GenerateConfig`. If `None` (the default), zero overhead — no sampling, no allocation.
 When present, every `sample_every_n_tokens` tokens, the monitor receives the hidden states at
 `sample_layer` and pushes a mean-pooled sample vector (dim = hidden_size) to both detectors.
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -2,7 +2,7 @@
 
 Global ADR index for the Lattice project. Numbered sequentially, grouped by crate.
 
-## lattice-inference (ADR-001 to ADR-011, ADR-040 to ADR-045)
+## lattice-inference (ADR-001 to ADR-011, ADR-040 to ADR-053)
 
 | ADR                                            | Title                                |
 | ---------------------------------------------- | ------------------------------------ |
@@ -23,6 +23,14 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | [043](ADR-043-lora-serving-verification.md)    | LoRA Serving Verification            |
 | [044](ADR-044-quarot-rotated-quantization.md)  | QuaRot Hadamard-Rotated Quantization |
 | [045](ADR-045-quarot-lora-composition.md)      | QuaRot + LoRA Composition            |
+| [046](ADR-046-structured-output.md)            | Structured Output (JSON Schema Constrained Decoding) |
+| [047](ADR-047-paged-kv-cache.md)               | Paged KV Cache                       |
+| [048](ADR-048-continuous-batching.md)          | Continuous Batching with Disaggregated Prefill/Decode |
+| [049](ADR-049-vision-encoder.md)               | Vision Encoder                       |
+| [050](ADR-050-rejection-sampling.md)           | Rejection Sampling for Speculative Decoding |
+| [051](ADR-051-quarot-mtp-rotation.md)          | QuaRot-MTP Rotation Reconciliation   |
+| [052](ADR-052-gdn-speculative-state.md)        | GDN State Management for Speculative Rollback |
+| [053](ADR-053-moe-metal-dispatch.md)            | MoE Metal Dispatch with Expert Coalescing |
 
 ## lattice-embed (ADR-012 to ADR-019)
 
@@ -49,7 +57,7 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | [025](ADR-025-gpu-backend.md)           | GPU Backend               |
 | [026](ADR-026-training-loop.md)         | Training Loop             |
 
-## lattice-tune (ADR-027 to ADR-034)
+## lattice-tune (ADR-027 to ADR-034, ADR-054)
 
 | ADR                                       | Title                           |
 | ----------------------------------------- | ------------------------------- |
@@ -61,8 +69,9 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | [032](ADR-032-training-callbacks.md)      | Training Callbacks              |
 | [033](ADR-033-jit-adaptation.md)          | JIT Adaptation                  |
 | [034](ADR-034-dataset-pipeline.md)        | Dataset Pipeline                |
+| [054](ADR-054-rolora-rotation-aware-lora.md) | Rotation-Aware LoRA Training (RoLoRA) |
 
-## lattice-transport (ADR-035 to ADR-039)
+## lattice-transport (ADR-035 to ADR-039, ADR-055)
 
 | ADR                                    | Title                             |
 | -------------------------------------- | --------------------------------- |
@@ -71,3 +80,4 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | [037](ADR-037-cost-matrices.md)        | Cost Matrix Abstractions          |
 | [038](ADR-038-barycenters.md)          | Wasserstein Barycenters           |
 | [039](ADR-039-divergence-measures.md)  | Sinkhorn Divergence               |
+| [055](ADR-055-online-drift-detection.md) | Online Distribution Drift Detection |


### PR DESCRIPTION
## Summary

Ten new Architecture Decision Records expanding the Lattice roadmap. Research-grounded via 4 parallel agents:
- **KG Explorer**: 533 entities searched, 5 hidden connections surfaced (GDN rollback gap, QuaRot↔LoRA SNR, Sinkhorn dual-use, MoE three-way constraint, OT↔spec dec TV bound)
- **Academic**: EAGLE-3, XGrammar (MLSys 2025), RoLoRA (EMNLP 2024), RadixAttention, Qwen3-VL
- **Competitive**: llama.cpp, Ollama (MLX switch Mar 2026), MLX feature matrix
- **CUDA Ecosystem**: TRT-LLM, vLLM, SGLang serving patterns, disaggregated prefill/decode

### Tier 1 — Competitive Table-Stakes
- **ADR-046**: XGrammar structured output — byte-level pushdown automaton, <40µs/token
- **ADR-047**: Paged KV cache + prefix reuse — hash-based LRU, LoRA-namespaced cache keys
- **ADR-048**: Continuous batching — chunked prefill Phase 1, zero-copy disaggregation Phase 2
- **ADR-049**: Vision encoder — Qwen3-VL path, Metal ViT, MLP merger, 448×448 fixed resolution

### Tier 2 — Correctness + Moat Protection
- **ADR-050**: Rejection sampling — strict speculative sampling replacing greedy argmax
- **ADR-051**: QuaRot-MTP rotation — counter-rotation via FWHT, resolves lm_head sharing question
- **ADR-052**: GDN speculative state — snapshot-before-draft protocol, 19.3 MB per rollback

### Tier 3 — Strategic Moat Extension
- **ADR-053**: MoE Metal dispatch — expert coalescing (320→40 dispatches), QuaRot load guard
- **ADR-054**: RoLoRA integration — rotation-aware LoRA training + serving verification
- **ADR-055**: Online drift detection — Sinkhorn divergence for adapter + router staleness

## Test plan

- [x] All 10 ADR files created and formatted
- [x] INDEX.md updated with all entries
- [x] Pre-commit checks pass (cargo check + doc lint)
- [ ] Adversarial review (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)