### PR TITLE
verify(inference): flip ADR-051 + ADR-052 to Accepted; add MTP draft-logit equivalence test

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -11910,6 +11910,161 @@ kernel void decode_attention_reference(
             (cfg, weights)
         }
 
+        fn rotate_embedding_rows_for_test(
+            weights: &mut ModelWeights,
+            hidden: usize,
+            rot: &crate::quant::quarot::hadamard::RandomizedHadamard,
+        ) {
+            for row in weights.embed_tokens.chunks_exact_mut(hidden) {
+                rot.apply(row).unwrap();
+            }
+        }
+
+        fn synthetic_mtp_weights_for_test(device: &Device, cfg: &Qwen35Config) -> MetalMtpWeights {
+            let hidden = cfg.hidden_size;
+            let inter = cfg.intermediate_size;
+            let q_dim = cfg.full_q_dim();
+            let kv_dim = cfg.full_kv_dim();
+
+            // fc shape: [hidden, 2*hidden]; identity on the embedding half so MTP
+            // output equals the normed embedding when attention/MLP weights are zero.
+            let mut fc = vec![0.0f32; hidden * 2 * hidden];
+            for i in 0..hidden {
+                fc[i * (2 * hidden) + i] = 1.0;
+            }
+
+            MetalMtpWeights {
+                fc: make_buffer_f16(device, &fc, "test.mtp.fc"),
+                pre_fc_norm_embedding: make_buffer(
+                    device,
+                    &vec![1.0; hidden],
+                    "test.mtp.pre_fc_norm_embedding",
+                ),
+                pre_fc_norm_hidden: make_buffer(
+                    device,
+                    &vec![1.0; hidden],
+                    "test.mtp.pre_fc_norm_hidden",
+                ),
+                layers: vec![MetalMtpLayerWeights {
+                    input_layernorm: make_buffer(device, &vec![1.0; hidden], "test.mtp.input_ln"),
+                    post_attention_layernorm: make_buffer(
+                        device,
+                        &vec![1.0; hidden],
+                        "test.mtp.post_attn_ln",
+                    ),
+                    q_proj: make_buffer_f16(
+                        device,
+                        &vec![0.0; 2 * q_dim * hidden],
+                        "test.mtp.q_proj",
+                    ),
+                    k_proj: make_buffer_f16(device, &vec![0.0; kv_dim * hidden], "test.mtp.k_proj"),
+                    v_proj: make_buffer_f16(device, &vec![0.0; kv_dim * hidden], "test.mtp.v_proj"),
+                    o_proj: make_buffer_f16(device, &vec![0.0; hidden * q_dim], "test.mtp.o_proj"),
+                    q_norm: make_buffer(device, &vec![1.0; cfg.head_dim], "test.mtp.q_norm"),
+                    k_norm: make_buffer(device, &vec![1.0; cfg.head_dim], "test.mtp.k_norm"),
+                    mlp: MetalMtpDenseMlpWeights {
+                        gate_proj: make_buffer_f16(
+                            device,
+                            &vec![0.0; inter * hidden],
+                            "test.mtp.gate_proj",
+                        ),
+                        up_proj: make_buffer_f16(
+                            device,
+                            &vec![0.0; inter * hidden],
+                            "test.mtp.up_proj",
+                        ),
+                        down_proj: make_buffer_f16(
+                            device,
+                            &vec![0.0; hidden * inter],
+                            "test.mtp.down_proj",
+                        ),
+                    },
+                }],
+                norm: make_buffer(device, &vec![1.0; hidden], "test.mtp.norm"),
+            }
+        }
+
+        fn metal_state_with_synthetic_mtp_for_test(
+            weights: &ModelWeights,
+            cfg: &Qwen35Config,
+            rotation: Option<crate::quant::quarot::hadamard::RandomizedHadamard>,
+        ) -> MetalQwen35State {
+            let mut engine = MetalQwen35Engine::new(weights, cfg)
+                .expect("tiny MetalQwen35Engine with MTP fixture constructs");
+            engine.mtp_weights = Some(synthetic_mtp_weights_for_test(&engine.device, cfg));
+            engine.quarot_rotation = rotation;
+            let session = engine.new_session(16).expect("tiny MTP session constructs");
+            MetalQwen35State {
+                engine,
+                session,
+                lora: None,
+            }
+        }
+
+        // ADR-051 §"Verification" line 213: MTP draft-logit equivalence test.
+        // Verifies that counter-rotating MTP inputs (apply_inverse) and re-rotating the
+        // MTP output (apply) before the shared lm_head produces logits identical to the
+        // unrotated reference path, within Metal f16/Q8 quantization tolerance.
+        #[test]
+        fn mtp_draft_logit_equivalence_with_quarot_counter_rotation() {
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+
+            let (mut cfg, reference_weights) = tiny_metal_qwen35_fixture();
+            cfg.mtp_num_hidden_layers = 1;
+
+            let seed = 0x51_51_51_u64;
+            let rotation =
+                crate::quant::quarot::hadamard::RandomizedHadamard::new(seed, cfg.hidden_size)
+                    .unwrap();
+
+            // Build rotated weights independently (ModelWeights has no Clone).
+            let (_, mut rotated_weights) = tiny_metal_qwen35_fixture();
+            rotate_embedding_rows_for_test(&mut rotated_weights, cfg.hidden_size, &rotation);
+
+            let mut reference_state =
+                metal_state_with_synthetic_mtp_for_test(&reference_weights, &cfg, None);
+            let mut rotated_state = metal_state_with_synthetic_mtp_for_test(
+                &rotated_weights,
+                &cfg,
+                Some(rotation.clone()),
+            );
+
+            // Inject a realistic pre-final hidden state. Both paths get the same
+            // mathematical vector; the rotated path gets R applied so that
+            // apply_inverse inside mtp_forward_one recovers the original.
+            let h_original: Vec<f32> = (0..cfg.hidden_size)
+                .map(|i| ((i as f32) * 0.013).sin() * 0.25)
+                .collect();
+            let mut h_rotated = h_original.clone();
+            rotation.apply(&mut h_rotated).unwrap();
+            reference_state.session.last_pre_final_hidden = h_original;
+            rotated_state.session.last_pre_final_hidden = h_rotated;
+
+            let reference = reference_state.mtp_forward_one(42_u32, 0_usize);
+            let rotated = rotated_state.mtp_forward_one(42_u32, 0_usize);
+
+            assert_eq!(reference.logits.len(), cfg.vocab_size);
+            assert_eq!(rotated.logits.len(), cfg.vocab_size);
+            let max_abs_diff = reference
+                .logits
+                .iter()
+                .zip(rotated.logits.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0_f32, f32::max);
+            // Tolerance is wider than the non-rotated golden-logit tests (1e-4) because
+            // the Hadamard rotation spreads each embedding row across all 512 dimensions,
+            // and the subsequent f16 roundtrip in embed_tokens + RMSNorm amplification
+            // (~sqrt(hidden)) introduces ~0.02 per-logit error on the rotated path.
+            // A missing or wrong counter-rotation would produce O(10) error, so 0.05
+            // is tight enough to catch implementation defects.
+            assert!(
+                max_abs_diff < 0.05,
+                "MTP draft logits diverged after QuaRot counter-rotation: max_abs_diff={max_abs_diff}"
+            );
+        }
+
         #[test]
         fn test_metal_qwen35_golden_logit_snapshot_forward_step_token_42_pos_0() {
             let Some(_) = Device::system_default() else {

--- a/docs/adr/ADR-051-quarot-mtp-rotation.md
+++ b/docs/adr/ADR-051-quarot-mtp-rotation.md
@@ -1,6 +1,6 @@
 # ADR-051: QuaRot-MTP Rotation Reconciliation
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-05-19
 **Crate**: `lattice-inference`
 

--- a/docs/adr/ADR-052-gdn-speculative-state.md
+++ b/docs/adr/ADR-052-gdn-speculative-state.md
@@ -1,6 +1,6 @@
 # ADR-052: GDN State Management for Speculative Rollback
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-05-19
 **Crate**: `lattice-inference`
 


### PR DESCRIPTION
## Summary

Verifies and flips two speculative-decoding ADRs from Proposed → Accepted, after confirming all existing implementation evidence + writing the one missing test ADR-051 required.

- **ADR-051** (QuaRot MTP Rotation Reconciliation): all existing rotation + counter-rotation paths confirmed via 7 file:line evidence points. New test `mtp_draft_logit_equivalence_with_quarot_counter_rotation` added per ADR-051:212-213. Exercises all three production counter-rotation sites in `mtp_forward_one`.
- **ADR-052** (GDN State Management for Speculative Rollback): all existing snapshot/restore paths (CPU + Metal) confirmed. Existing tests pass: `gdn::tests` (18/18), `speculative` (46/46), `snapshot_gdn_states_roundtrips_through_metal_buffers` (1/1 metal-gpu).

## Changes

| File | Change |
|------|--------|
| `crates/inference/src/forward/metal_qwen35.rs` | +155 lines: 3 test helpers + 1 new test (`mtp_draft_logit_equivalence_with_quarot_counter_rotation`) |
| `docs/adr/ADR-051-quarot-mtp-rotation.md` | Status: `Proposed` → `Accepted` |
| `docs/adr/ADR-052-gdn-speculative-state.md` | Status: `Proposed` → `Accepted` |

Total: 3 files, +157 / -2.

## Test plan

- [x] `cargo test -p lattice-inference --release` — 614/614 pass
- [x] `cargo test -p lattice-inference --release --features metal-gpu --lib` — 657/658 pass (1 PRE-EXISTING failure, `test_metal_qwen35_golden_logit_snapshot_forward_step_token_42_pos_0`, confirmed via `git stash` to predate this branch)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] New test asserts max_abs_diff ~0.016 against tolerance 0.05; without counter-rotation, divergence would be O(10)

## Design notes

The new test uses synthetic fixtures (hidden=512, vocab=64, 1 MTP layer) — one unrotated reference, one Hadamard-rotated with `quarot_rotation = Some(rot)`. Tolerance 0.05 reflects f16 roundtrip + RMSNorm noise floor; tighter tolerances (e.g., 1e-4) fail on the rotated path due to legitimate floating-point amplification, not algorithmic error.

## Out of scope

- ADR-050 (rejection sampling) — separate PR, depends on these two
- Full-model integration test (synthetic fixtures only)
- Pre-existing Metal golden-logit failure — to be filed as separate follow-up issue

🤖 Generated by `show unimpl-adr-sweep` (play `lattice-speculative-verify`)