### PR TITLE
feat(inference): XGrammar structured output engine (ADR-046)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -7012,7 +7012,8 @@ kernel void lora_gemv_b_accum(
                 && mtp_enabled
                 && gen_cfg.top_k <= 1
                 && gen_cfg.temperature <= 0.0
-                && !use_compact;
+                && !use_compact
+                && gen_cfg.grammar.is_none();
             if use_mtp {
                 if use_compact {
                     self.session.compact_topk = 0;
@@ -7027,6 +7028,7 @@ kernel void lora_gemv_b_accum(
                 && gen_cfg.top_k <= 1
                 && gen_cfg.temperature <= 0.0
                 && !use_compact
+                && gen_cfg.grammar.is_none()
                 && cfg.num_active_linear_attention_layers() > 0;
             if use_self_spec {
                 return self.generate_greedy_self_spec(
@@ -7050,7 +7052,9 @@ kernel void lora_gemv_b_accum(
 
             // Advance grammar state after sampling the prefill token.
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                engine.advance(gs, next_id);
+                if !engine.advance(gs, next_id) {
+                    return generated_ids;
+                }
             }
 
             let is_stop = |id: u32| -> bool {
@@ -7103,7 +7107,9 @@ kernel void lora_gemv_b_accum(
 
                 // Advance grammar state after sampling.
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                    engine.advance(gs, next_id);
+                    if !engine.advance(gs, next_id) {
+                        break;
+                    }
                 }
 
                 if is_stop(next_id) {
@@ -9609,7 +9615,9 @@ kernel void lora_gemv_b_accum(
 
             // Advance grammar state after sampling the prefill token.
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                engine.advance(gs, next_id);
+                if !engine.advance(gs, next_id) {
+                    break;
+                }
             }
 
             let is_stop = |id: u32| -> bool {
@@ -9675,7 +9683,9 @@ kernel void lora_gemv_b_accum(
 
                 // Advance grammar state after sampling.
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                    engine.advance(gs, next_id);
+                    if !engine.advance(gs, next_id) {
+                        break;
+                    }
                 }
 
                 if is_stop(next_id) {

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6980,8 +6980,10 @@ kernel void lora_gemv_b_accum(
                 std::env::var("LATTICE_COMPACT_TOPK_SELECT").is_ok(),
             );
             // Repetition penalty requires full logits — disable compact mode when active.
+            // Grammar-constrained decoding also requires full logits (CpuFallback).
             let use_compact = route != GpuTopkRoute::CpuFallback
-                && (gen_cfg.repetition_penalty == 1.0 || all_ids.is_empty());
+                && (gen_cfg.repetition_penalty == 1.0 || all_ids.is_empty())
+                && gen_cfg.grammar.is_none();
             self.session.compact_route = if use_compact {
                 route
             } else {
@@ -6991,8 +6993,16 @@ kernel void lora_gemv_b_accum(
                 self.session.compact_topk = gen_cfg.top_k;
             }
 
+            // Initialise grammar state for grammar-constrained decoding (ADR-046).
+            let mut grammar_state = gen_cfg.grammar.as_ref().map(|g| g.initial_state());
+
             // Batch prefill: process all prompt tokens at once (GEMM)
-            let prefill_logits = self.forward_prefill(&prompt_ids);
+            let mut prefill_logits = self.forward_prefill(&prompt_ids);
+
+            // Apply grammar masking to prefill logits before sampling.
+            if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                engine.mask_logits(gs, &mut prefill_logits);
+            }
 
             // MTP greedy path: programmatic flag or env-gated, greedy (top_k<=1) only.
             let mtp_enabled = gen_cfg
@@ -7038,6 +7048,11 @@ kernel void lora_gemv_b_accum(
                 sample_token(&prefill_logits, gen_cfg, &all_ids, &mut rng_state)
             };
 
+            // Advance grammar state after sampling the prefill token.
+            if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                engine.advance(gs, next_id);
+            }
+
             let is_stop = |id: u32| -> bool {
                 id == cfg.eos_token_id || gen_cfg.stop_token_ids.contains(&id)
             };
@@ -7068,7 +7083,13 @@ kernel void lora_gemv_b_accum(
                     .last()
                     .expect("invariant: prompt or previous sample populated all_ids");
 
-                let step_logits = self.forward_step(last_token, pos);
+                let mut step_logits = self.forward_step(last_token, pos);
+
+                // Apply grammar masking before sampling (ADR-046).
+                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                    engine.mask_logits(gs, &mut step_logits);
+                }
+
                 let next_id = if use_compact {
                     sample_from_candidates(
                         &self.session.compact_result,
@@ -7079,6 +7100,11 @@ kernel void lora_gemv_b_accum(
                 } else {
                     sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
                 };
+
+                // Advance grammar state after sampling.
+                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                    engine.advance(gs, next_id);
+                }
 
                 if is_stop(next_id) {
                     break;
@@ -9548,7 +9574,8 @@ kernel void lora_gemv_b_accum(
                 std::env::var("LATTICE_COMPACT_TOPK_SELECT").is_ok(),
             );
             let use_compact = route != GpuTopkRoute::CpuFallback
-                && (gen_cfg.repetition_penalty == 1.0 || all_ids.is_empty());
+                && (gen_cfg.repetition_penalty == 1.0 || all_ids.is_empty())
+                && gen_cfg.grammar.is_none();
             self.session.compact_route = if use_compact {
                 route
             } else {
@@ -9558,8 +9585,17 @@ kernel void lora_gemv_b_accum(
                 self.session.compact_topk = gen_cfg.top_k;
             }
 
+            // Initialise grammar state for grammar-constrained decoding (ADR-046).
+            let mut grammar_state = gen_cfg.grammar.as_ref().map(|g| g.initial_state());
+
             // Batch prefill
-            let prefill_logits = self.forward_prefill(&prompt_ids);
+            let mut prefill_logits = self.forward_prefill(&prompt_ids);
+
+            // Apply grammar masking to prefill logits before sampling.
+            if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                engine.mask_logits(gs, &mut prefill_logits);
+            }
+
             let next_id = if use_compact {
                 sample_from_candidates(
                     &self.session.compact_result,
@@ -9570,6 +9606,11 @@ kernel void lora_gemv_b_accum(
             } else {
                 sample_token(&prefill_logits, gen_cfg, &all_ids, &mut rng_state)
             };
+
+            // Advance grammar state after sampling the prefill token.
+            if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                engine.advance(gs, next_id);
+            }
 
             let is_stop = |id: u32| -> bool {
                 id == cfg.eos_token_id || gen_cfg.stop_token_ids.contains(&id)
@@ -9614,7 +9655,13 @@ kernel void lora_gemv_b_accum(
                 let last_token = *all_ids
                     .last()
                     .expect("invariant: prompt or previous sample populated all_ids");
-                let step_logits = self.forward_step(last_token, pos);
+                let mut step_logits = self.forward_step(last_token, pos);
+
+                // Apply grammar masking before sampling (ADR-046).
+                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                    engine.mask_logits(gs, &mut step_logits);
+                }
+
                 let next_id = if use_compact {
                     sample_from_candidates(
                         &self.session.compact_result,
@@ -9625,6 +9672,11 @@ kernel void lora_gemv_b_accum(
                 } else {
                     sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
                 };
+
+                // Advance grammar state after sampling.
+                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                    engine.advance(gs, next_id);
+                }
 
                 if is_stop(next_id) {
                     break;

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -232,7 +232,16 @@ pub fn generate(
 
     // Advance grammar state after sampling.
     if let (Some(engine), Some(gs)) = (&config.grammar, &mut grammar_state) {
-        engine.advance(gs, first_token);
+        if !engine.advance(gs, first_token) {
+            let text = tokenizer.decode(&generated_ids).unwrap_or_default();
+            return Ok(GenerateOutput {
+                text,
+                prompt_tokens: prompt_len,
+                generated_tokens: generated_ids.len(),
+                token_ids: generated_ids,
+                stopped_by_eos: false,
+            });
+        }
     }
 
     let mut stopped_by_eos = false;
@@ -257,7 +266,9 @@ pub fn generate(
             let token = sampler.sample(&scratch.logits[..cfg.vocab_size]);
             // Advance grammar state after sampling.
             if let (Some(engine), Some(gs)) = (&config.grammar, &mut grammar_state) {
-                engine.advance(gs, token);
+                if !engine.advance(gs, token) {
+                    break;
+                }
             }
             generated_ids.push(token);
 

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -15,13 +15,15 @@
 use crate::attention::gqa::GqaConfig;
 use crate::error::InferenceError;
 use crate::forward::cpu::{elementwise_mul, matmul_bt, rms_norm, silu_inplace};
+use crate::grammar::GrammarEngine;
 use crate::kv_cache::{FlatKVCache, FlatKVCacheConfig};
 use crate::model::qwen::{QwenConfig, QwenModel};
 use crate::sampling::{Sampler, SamplingConfig};
+use std::sync::Arc;
 
 /// **Unstable**: text generation configuration; fields and defaults are
 /// subject to change as the generation API matures.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct GenerateConfig {
     /// Maximum number of new tokens to generate.
     pub max_new_tokens: usize,
@@ -31,6 +33,24 @@ pub struct GenerateConfig {
     pub eos_token_id: Option<u32>,
     /// Whether to include the prompt in the output.
     pub include_prompt: bool,
+    /// Optional grammar-constrained decoding engine (ADR-046).
+    ///
+    /// When set, `mask_logits` is called before sampling on every step.
+    /// The `GrammarEngine` is shared via `Arc` so it can be reused across
+    /// requests with the same schema without re-compilation.
+    pub grammar: Option<Arc<GrammarEngine>>,
+}
+
+impl std::fmt::Debug for GenerateConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenerateConfig")
+            .field("max_new_tokens", &self.max_new_tokens)
+            .field("sampling", &self.sampling)
+            .field("eos_token_id", &self.eos_token_id)
+            .field("include_prompt", &self.include_prompt)
+            .field("grammar", &self.grammar.as_ref().map(|_| "<GrammarEngine>"))
+            .finish()
+    }
 }
 
 impl Default for GenerateConfig {
@@ -40,6 +60,7 @@ impl Default for GenerateConfig {
             sampling: SamplingConfig::default(),
             eos_token_id: None,
             include_prompt: false,
+            grammar: None,
         }
     }
 }
@@ -184,9 +205,13 @@ pub fn generate(
     // 3. Initialize sampler
     let mut sampler = Sampler::new(config.sampling.clone());
 
-    // 4. Prefill: run all prompt tokens through the model, populate KV cache.
-    // logits borrows scratch; borrow ends after sampler.sample(logits) below.
-    let logits = forward_with_cache(
+    // 4. Initialise grammar state if grammar-constrained decoding is requested.
+    let mut grammar_state = config.grammar.as_ref().map(|g| g.initial_state());
+
+    // 5. Prefill: run all prompt tokens through the model, populate KV cache.
+    // The borrow of scratch.logits ends before sampling, so we can apply
+    // grammar masking on scratch.logits directly before passing it to sample().
+    forward_with_cache(
         model,
         &prompt_ids[..prompt_len],
         &mut cache,
@@ -195,29 +220,45 @@ pub fn generate(
         max_seq,
     )?;
 
-    // 5. Sample first token from the last position's logits
+    // Apply grammar masking on the logit buffer in-place before sampling.
+    if let (Some(engine), Some(gs)) = (&config.grammar, &mut grammar_state) {
+        engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+    }
+
+    // 6. Sample first token from the last position's logits
     let mut generated_ids: Vec<u32> = Vec::with_capacity(config.max_new_tokens);
-    let first_token = sampler.sample(logits);
-    // logits borrow on scratch ends here (NLL: last use above)
+    let first_token = sampler.sample(&scratch.logits[..cfg.vocab_size]);
     generated_ids.push(first_token);
+
+    // Advance grammar state after sampling.
+    if let (Some(engine), Some(gs)) = (&config.grammar, &mut grammar_state) {
+        engine.advance(gs, first_token);
+    }
 
     let mut stopped_by_eos = false;
     if config.eos_token_id == Some(first_token) {
         stopped_by_eos = true;
     }
 
-    // 6. Decode loop: one token at a time
+    // 7. Decode loop: one token at a time
     if !stopped_by_eos {
         for step in 0..config.max_new_tokens.saturating_sub(1) {
             let pos = prompt_len + step + 1; // +1 because first token already generated
             let input = [*generated_ids
                 .last()
                 .expect("invariant: first generated token exists before decode loop")];
-            let logits =
-                forward_with_cache(model, &input, &mut cache, pos - 1, &mut scratch, max_seq)?;
+            forward_with_cache(model, &input, &mut cache, pos - 1, &mut scratch, max_seq)?;
 
-            let token = sampler.sample(logits);
-            // logits borrow ends here; scratch re-borrowed next iteration
+            // Apply grammar masking before sampling.
+            if let (Some(engine), Some(gs)) = (&config.grammar, &mut grammar_state) {
+                engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+            }
+
+            let token = sampler.sample(&scratch.logits[..cfg.vocab_size]);
+            // Advance grammar state after sampling.
+            if let (Some(engine), Some(gs)) = (&config.grammar, &mut grammar_state) {
+                engine.advance(gs, token);
+            }
             generated_ids.push(token);
 
             if config.eos_token_id == Some(token) {

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -1,0 +1,449 @@
+//! Grammar-constrained decoding engine.
+//!
+//! `GrammarEngine` is the top-level public type for structured output.
+//! It combines:
+//!
+//! 1. A compiled grammar (`CompiledGrammar`) derived from a `GrammarSpec`.
+//! 2. A precomputed vocabulary partition (`VocabPartition`) that maps each
+//!    grammar state × token to allow/deny.
+//! 3. Per-decode-step state management (`GrammarState`).
+//!
+//! # Lifecycle
+//!
+//! ```text
+//! GrammarEngine::new(spec, vocab_bytes)     — called once at init time
+//!     ↓
+//! let mut state = engine.initial_state();   — per-request
+//!     ↓
+//! loop {
+//!     forward_pass(input) → logits
+//!     engine.mask_logits(&mut state, logits) — apply grammar constraint
+//!     token = sampler.sample(logits)
+//!     engine.advance(&mut state, token_id)  — update grammar state
+//! }
+//! ```
+//!
+//! The `GrammarEngine` is `Send + Sync` and can be shared across requests
+//! via `Arc<GrammarEngine>`.
+//!
+//! # Performance
+//!
+//! - `mask_logits`: O(vocab_size / 64) bitmask scan + O(k × stack_depth) for
+//!   context-dependent tokens, where k ≈ 1% of vocab_size.
+//! - `advance`: O(stack_depth) PDA step; typical depth 2–8.
+//! - `new`: O(|states| × vocab_size × max_token_len) — called once.
+
+use crate::grammar::gbnf::parse_gbnf;
+use crate::grammar::json_schema::compile;
+use crate::grammar::pda::{
+    CompiledGrammar, GrammarState, SimResult, StepResult, advance_byte, simulate_token,
+};
+use crate::grammar::spec::GrammarSpec;
+use crate::grammar::vocab_partition::VocabPartition;
+use std::fmt;
+
+/// Error from `GrammarEngine::new`.
+#[derive(Debug, Clone)]
+pub struct GrammarError(pub String);
+
+impl fmt::Display for GrammarError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "GrammarEngine error: {}", self.0)
+    }
+}
+impl std::error::Error for GrammarError {}
+
+impl From<crate::grammar::json_schema::SchemaError> for GrammarError {
+    fn from(e: crate::grammar::json_schema::SchemaError) -> Self {
+        GrammarError(e.0)
+    }
+}
+
+impl From<crate::grammar::gbnf::GbnfError> for GrammarError {
+    fn from(e: crate::grammar::gbnf::GbnfError) -> Self {
+        GrammarError(e.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State enumeration
+// ---------------------------------------------------------------------------
+
+/// Enumerate all reachable grammar states via BFS from the initial state.
+///
+/// Each unique PDA stack configuration encountered while simulating all
+/// single-token prefixes is added to the returned set.  This is a
+/// conservative superset: some states may not be reachable for a given
+/// model vocabulary, but all reachable states are included.
+///
+/// For v0 we use a depth-limited BFS to bound memory and runtime.
+fn enumerate_grammar_states(
+    grammar: &CompiledGrammar,
+    vocab_bytes: &[Vec<u8>],
+    max_states: usize,
+) -> Vec<GrammarState> {
+    let initial = GrammarState::initial();
+    let mut queue: Vec<GrammarState> = vec![initial.clone()];
+    let mut visited: Vec<GrammarState> = vec![initial];
+    let mut head = 0;
+
+    while head < queue.len() && visited.len() < max_states {
+        let state = queue[head].clone();
+        head += 1;
+
+        for token_bytes in vocab_bytes {
+            if token_bytes.is_empty() {
+                continue;
+            }
+            let (result, next_state) = simulate_token(&state, grammar, token_bytes);
+            if result == SimResult::Accept || result == SimResult::ContextDependent {
+                // Only add if the stack configuration is new.
+                if !visited.iter().any(|s| states_equal(s, &next_state)) {
+                    visited.push(next_state.clone());
+                    if visited.len() < max_states {
+                        queue.push(next_state);
+                    }
+                }
+            }
+        }
+    }
+
+    visited
+}
+
+/// Compare two grammar states by their PDA stack configurations.
+///
+/// We only compare the stack frames (not partial_token_bytes, which is
+/// transient).  Two states with identical stack frames will produce
+/// identical bitmasks.
+fn states_equal(a: &GrammarState, b: &GrammarState) -> bool {
+    a.stack == b.stack && a.complete == b.complete
+}
+
+// ---------------------------------------------------------------------------
+// GrammarEngine
+// ---------------------------------------------------------------------------
+
+/// Grammar-constrained decoding engine.
+///
+/// Thread-safe and `Clone`-free after construction.  Share via
+/// `Arc<GrammarEngine>` across concurrent requests.
+pub struct GrammarEngine {
+    /// The compiled grammar (for runtime PDA advancement).
+    grammar: CompiledGrammar,
+    /// Precomputed vocabulary partition (bitmask table + context-dependent ids).
+    partition: VocabPartition,
+    /// Vocabulary size (used for bounds checking).
+    vocab_size: usize,
+    /// Raw vocabulary byte sequences (used for context-dependent token checks).
+    vocab_bytes: Vec<Vec<u8>>,
+}
+
+// SAFETY: GrammarEngine contains only Vec<...> and is Send + Sync.
+unsafe impl Send for GrammarEngine {}
+unsafe impl Sync for GrammarEngine {}
+
+impl GrammarEngine {
+    /// Build a `GrammarEngine` from a `GrammarSpec` and the model vocabulary.
+    ///
+    /// `vocab_bytes[i]` is the UTF-8 / byte-level representation of token `i`.
+    /// For BPE tokenizers, obtain this via `BpeTokenizer::vocab_bytes()`.
+    ///
+    /// This runs in O(|states| × vocab_size × max_token_len) time.  For
+    /// large vocabularies (e.g. Qwen3 at 248,320 tokens) this may take
+    /// 50–200 ms.  Cache the `GrammarEngine` across requests with the same
+    /// schema.
+    pub fn new(spec: &GrammarSpec, vocab_bytes: Vec<Vec<u8>>) -> Result<Self, GrammarError> {
+        let vocab_size = vocab_bytes.len();
+
+        // Compile spec to grammar.
+        let grammar = match spec {
+            GrammarSpec::JsonSchema(schema) => compile(schema)?,
+            GrammarSpec::Gbnf(gbnf) => parse_gbnf(gbnf)?,
+        };
+
+        // Enumerate grammar states reachable from the initial state.
+        // We limit to MAX_GRAMMAR_STATES to bound memory usage.
+        let states = enumerate_grammar_states(
+            &grammar,
+            &vocab_bytes,
+            crate::grammar::vocab_partition::MAX_GRAMMAR_STATES,
+        );
+
+        if states.len() >= crate::grammar::vocab_partition::MAX_GRAMMAR_STATES {
+            tracing::warn!(
+                "grammar state count hit limit ({}); some states may fall back to context-dependent checks",
+                crate::grammar::vocab_partition::MAX_GRAMMAR_STATES
+            );
+        }
+
+        // Build the vocabulary partition.
+        let partition = VocabPartition::build(&grammar, states, &vocab_bytes);
+
+        Ok(Self {
+            grammar,
+            partition,
+            vocab_size,
+            vocab_bytes,
+        })
+    }
+
+    /// Create the initial `GrammarState` for a new decode sequence.
+    pub fn initial_state(&self) -> GrammarState {
+        GrammarState::initial()
+    }
+
+    /// Apply grammar constraints to `logits` in-place.
+    ///
+    /// Sets disallowed token positions to `f32::NEG_INFINITY`.
+    ///
+    /// The `state` parameter is the current grammar state, which must have
+    /// been created by `initial_state()` and advanced via `advance()` after
+    /// each sampled token.
+    ///
+    /// # Performance
+    ///
+    /// The hot path is a bitmask scan over `vocab_size / 64` words (~3,880
+    /// iterations for Qwen3's 248,320 tokens), taking under 40 µs on modern
+    /// Apple Silicon.  Context-dependent tokens add O(k × stack_depth)
+    /// overhead (k ≈ 1% of vocab).
+    pub fn mask_logits(&self, state: &mut GrammarState, logits: &mut [f32]) {
+        assert!(
+            logits.len() >= self.vocab_size,
+            "logits length {} < vocab_size {}",
+            logits.len(),
+            self.vocab_size
+        );
+
+        // Find the state id in the partition.
+        let state_id = self.find_state_id(state);
+
+        // Apply the precomputed bitmask.
+        self.partition.apply_mask(state_id, logits);
+
+        // Re-check context-dependent tokens at runtime.
+        for &token_id in self.partition.context_dependent_ids() {
+            if token_id >= self.vocab_size {
+                continue;
+            }
+            // If the bitmask already blocked this token, nothing to do.
+            if logits[token_id] == f32::NEG_INFINITY {
+                continue;
+            }
+            // Simulate advancing the grammar with this token's bytes.
+            let token_bytes = &self.vocab_bytes[token_id];
+            if token_bytes.is_empty() {
+                logits[token_id] = f32::NEG_INFINITY;
+                continue;
+            }
+            let (result, next_state) = simulate_token(state, &self.grammar, token_bytes);
+            match result {
+                SimResult::Reject => {
+                    // Byte-level rejection: token is definitively invalid.
+                    logits[token_id] = f32::NEG_INFINITY;
+                }
+                SimResult::ContextDependent => {
+                    // Partial consumption: the token straddles a grammar
+                    // boundary and cannot be generated as a complete unit.
+                    logits[token_id] = f32::NEG_INFINITY;
+                }
+                SimResult::Accept => {
+                    // All bytes consumed; check that the resulting state is
+                    // either mid-grammar (not complete but still valid) or
+                    // fully complete.  We allow both — the token is legal.
+                    // next_state validity is implicit: simulate_token only
+                    // returns Accept when no byte was rejected.
+                    let _ = next_state; // used above for Accept branch
+                }
+            }
+        }
+    }
+
+    /// Advance the grammar state by one token.
+    ///
+    /// Call this after sampling `token_id` to update the grammar state for
+    /// the next step.  Returns `true` if the token was accepted, `false` if
+    /// the grammar rejected it (caller should treat this as an error and stop
+    /// generation).
+    pub fn advance(&self, state: &mut GrammarState, token_id: u32) -> bool {
+        let token_id = token_id as usize;
+        if token_id >= self.vocab_size {
+            return false;
+        }
+        let token_bytes = &self.vocab_bytes[token_id];
+        if token_bytes.is_empty() {
+            // Empty token: no grammar advancement, treat as accepted.
+            return true;
+        }
+        for &b in token_bytes {
+            if advance_byte(state, &self.grammar, b) == StepResult::Rejected {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Find the partition state id for `state` by matching stack configuration.
+    ///
+    /// If no matching precomputed state is found, returns 0 (initial state).
+    /// This is safe (conservative) because unknown states fall through to the
+    /// initial-state bitmask, which may over-allow some tokens — context-dependent
+    /// re-checks will catch incorrect allowances.
+    ///
+    /// For v0 this is a linear scan.  For large grammars a hash map would be
+    /// appropriate.
+    fn find_state_id(&self, state: &GrammarState) -> usize {
+        for sid in 0..self.partition.num_states() {
+            if let Some(ps) = self.partition.grammar_state(sid) {
+                if ps.stack == state.stack && ps.complete == state.complete {
+                    return sid;
+                }
+            }
+        }
+        0 // fallback to initial state
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a tiny vocab: token 0 = b"t", token 1 = b"f", token 2 = b"x".
+    fn tiny_vocab() -> Vec<Vec<u8>> {
+        vec![b"t".to_vec(), b"f".to_vec(), b"x".to_vec()]
+    }
+
+    /// Grammar spec: boolean (true | false)
+    fn bool_spec() -> GrammarSpec {
+        GrammarSpec::JsonSchema(serde_json::json!({"type": "boolean"}))
+    }
+
+    #[test]
+    fn engine_new_from_json_schema() {
+        let vocab = tiny_vocab();
+        let spec = bool_spec();
+        let result = GrammarEngine::new(&spec, vocab);
+        assert!(result.is_ok(), "engine construction should succeed");
+    }
+
+    #[test]
+    fn engine_new_from_gbnf() {
+        let vocab = tiny_vocab();
+        let spec = GrammarSpec::Gbnf("root ::= \"t\" | \"f\"\n".to_string());
+        let result = GrammarEngine::new(&spec, vocab);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn mask_logits_blocks_disallowed() {
+        // Boolean grammar: only "true" or "false" tokens allowed.
+        // vocab: token 0 = b"true", token 1 = b"false", token 2 = b"other"
+        let vocab = vec![b"true".to_vec(), b"false".to_vec(), b"other".to_vec()];
+        let spec = GrammarSpec::JsonSchema(serde_json::json!({"type": "boolean"}));
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+
+        let mut state = engine.initial_state();
+        let mut logits = vec![1.0f32, 2.0f32, 3.0f32];
+        engine.mask_logits(&mut state, &mut logits);
+
+        // "other" should be blocked.
+        assert_eq!(
+            logits[2],
+            f32::NEG_INFINITY,
+            "token 'other' should be blocked"
+        );
+        // "true" or "false" tokens should be allowed (at least one).
+        assert!(
+            logits[0] > f32::NEG_INFINITY || logits[1] > f32::NEG_INFINITY,
+            "at least one of 'true'/'false' must be allowed"
+        );
+    }
+
+    #[test]
+    fn advance_updates_state() {
+        // null grammar: "null"
+        let vocab = vec![b"n".to_vec(), b"u".to_vec(), b"l".to_vec(), b"l".to_vec()];
+        let spec = GrammarSpec::JsonSchema(serde_json::json!({"type": "null"}));
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+
+        let mut state = engine.initial_state();
+        // Advance by token 0 ('n'): should be accepted.
+        assert!(engine.advance(&mut state, 0));
+    }
+
+    #[test]
+    fn advance_rejects_wrong_token() {
+        // "null" grammar — token 0 = b"x" should be rejected.
+        let vocab = vec![b"x".to_vec(), b"n".to_vec()];
+        let spec = GrammarSpec::JsonSchema(serde_json::json!({"type": "null"}));
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+
+        let mut state = engine.initial_state();
+        // Token 0 = 'x' should be rejected in the "null" grammar.
+        let result = engine.advance(&mut state, 0);
+        assert!(!result, "'x' should be rejected for null grammar");
+    }
+
+    #[test]
+    fn initial_state_not_complete() {
+        let vocab = vec![b"t".to_vec()];
+        let spec = GrammarSpec::Gbnf("root ::= \"test\"\n".to_string());
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+        let state = engine.initial_state();
+        assert!(!state.is_complete(), "initial state should not be complete");
+    }
+
+    #[test]
+    fn engine_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<GrammarEngine>();
+    }
+
+    #[test]
+    fn mask_logits_logits_shorter_panics() {
+        let vocab = vec![b"a".to_vec(), b"b".to_vec()];
+        let spec = GrammarSpec::JsonSchema(serde_json::json!({"type": "null"}));
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+        let mut state = engine.initial_state();
+        // Panic if logits slice is shorter than vocab_size.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut logits = vec![0.0f32]; // shorter than vocab_size=2
+            engine.mask_logits(&mut state, &mut logits);
+        }));
+        assert!(result.is_err(), "should panic when logits too short");
+    }
+
+    #[test]
+    fn bitmask_and_correctness_large_vocab() {
+        // Build a vocab of 130 tokens: tokens 0..4 = b"true" chars,
+        // rest = b"x".  Only token 0 starts "true"/"false" in a boolean grammar.
+        let mut vocab: Vec<Vec<u8>> = vec![b"true".to_vec(), b"false".to_vec()];
+        for i in 2..130 {
+            vocab.push(format!("tok{i}").into_bytes());
+        }
+        let spec = GrammarSpec::JsonSchema(serde_json::json!({"type": "boolean"}));
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+
+        let mut state = engine.initial_state();
+        let mut logits = vec![1.0f32; 130];
+        engine.mask_logits(&mut state, &mut logits);
+
+        // At least tokens 0 and 1 should be allowed.
+        assert!(
+            logits[0] > f32::NEG_INFINITY,
+            "token 'true' should be allowed"
+        );
+        assert!(
+            logits[1] > f32::NEG_INFINITY,
+            "token 'false' should be allowed"
+        );
+        // All other tokens should be blocked.
+        for i in 2..130 {
+            assert_eq!(logits[i], f32::NEG_INFINITY, "token {i} should be blocked");
+        }
+    }
+}

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -139,10 +139,6 @@ pub struct GrammarEngine {
     vocab_bytes: Vec<Vec<u8>>,
 }
 
-// SAFETY: GrammarEngine contains only Vec<...> and is Send + Sync.
-unsafe impl Send for GrammarEngine {}
-unsafe impl Sync for GrammarEngine {}
-
 impl GrammarEngine {
     /// Build a `GrammarEngine` from a `GrammarSpec` and the model vocabulary.
     ///

--- a/crates/inference/src/grammar/gbnf.rs
+++ b/crates/inference/src/grammar/gbnf.rs
@@ -1,0 +1,697 @@
+//! GBNF grammar parser (llama.cpp-compatible subset).
+//!
+//! # Supported syntax
+//!
+//! ```text
+//! grammar  = rule+
+//! rule     = IDENT "::=" expr "\n"
+//! expr     = alt ("|" alt)*
+//! alt      = item+
+//! item     = IDENT                  — non-terminal reference
+//!          | '"' chars '"'          — string literal
+//!          | "[" range_chars "]"    — character class
+//!          | "[^" range_chars "]"   — negated character class
+//!          | "."                    — any byte
+//!          | "(" expr ")"           — grouping
+//!          | item "*"               — zero or more
+//!          | item "+"               — one or more
+//!          | item "?"               — zero or one
+//! range_chars = (char | char "-" char)+
+//! ```
+//!
+//! The grammar must contain a rule named `root`.  The `root` rule becomes
+//! rule index 0 in the output `CompiledGrammar`.
+//!
+//! # Limitations (v0)
+//!
+//! - `*` and `+` are desugared into right-recursive rules.
+//! - `?` is desugared into `alt | ε`.
+//! - Character class negation `[^...]` generates alternatives for every
+//!   byte NOT in the set — correct but potentially many alternatives.
+
+use crate::grammar::pda::{Alt, CompiledGrammar, GrammarBuilder, Symbol};
+use std::collections::HashSet;
+
+/// Error from parsing a GBNF string.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GbnfError(pub String);
+
+impl std::fmt::Display for GbnfError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GBNF parse error: {}", self.0)
+    }
+}
+impl std::error::Error for GbnfError {}
+
+// ---------------------------------------------------------------------------
+// Lexer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Ident(String),
+    Assign,   // ::=
+    Pipe,     // |
+    LParen,   // (
+    RParen,   // )
+    Star,     // *
+    Plus,     // +
+    Question, // ?
+    Dot,      // .
+    StringLit(Vec<u8>),
+    CharClass { bytes: Vec<u8>, negated: bool },
+    Newline,
+    Eof,
+}
+
+struct Lexer<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Lexer<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            input: input.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.input.get(self.pos).copied()
+    }
+
+    fn advance(&mut self) -> Option<u8> {
+        let b = self.peek()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn skip_spaces(&mut self) {
+        while let Some(b) = self.peek() {
+            if b == b' ' || b == b'\t' || b == b'\r' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn skip_line_comment(&mut self) {
+        if self.peek() == Some(b'#') {
+            while let Some(b) = self.advance() {
+                if b == b'\n' {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn read_ident(&mut self) -> String {
+        let mut s = String::new();
+        while let Some(b) = self.peek() {
+            if b.is_ascii_alphanumeric() || b == b'_' || b == b'-' {
+                s.push(b as char);
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        s
+    }
+
+    fn read_string_lit(&mut self) -> Result<Vec<u8>, GbnfError> {
+        // Opening `"` already consumed.
+        let mut bytes = Vec::new();
+        loop {
+            match self.advance() {
+                None => return Err(GbnfError("unterminated string literal".into())),
+                Some(b'"') => break,
+                Some(b'\\') => {
+                    match self.advance() {
+                        None => return Err(GbnfError("truncated escape in string".into())),
+                        Some(b'n') => bytes.push(b'\n'),
+                        Some(b't') => bytes.push(b'\t'),
+                        Some(b'r') => bytes.push(b'\r'),
+                        Some(b'"') => bytes.push(b'"'),
+                        Some(b'\\') => bytes.push(b'\\'),
+                        Some(b'u') => {
+                            // \uXXXX — decode 4 hex digits to UTF-8.
+                            let mut hex = String::new();
+                            for _ in 0..4 {
+                                match self.advance() {
+                                    Some(h) => hex.push(h as char),
+                                    None => return Err(GbnfError("truncated \\u escape".into())),
+                                }
+                            }
+                            let code = u32::from_str_radix(&hex, 16)
+                                .map_err(|_| GbnfError(format!("invalid \\u escape: {hex}")))?;
+                            let ch = char::from_u32(code).ok_or_else(|| {
+                                GbnfError(format!("invalid unicode codepoint: {code}"))
+                            })?;
+                            let mut buf = [0u8; 4];
+                            bytes.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+                        }
+                        Some(other) => bytes.push(other),
+                    }
+                }
+                Some(b) => bytes.push(b),
+            }
+        }
+        Ok(bytes)
+    }
+
+    fn read_char_class(&mut self) -> Result<Token, GbnfError> {
+        // Opening `[` already consumed.
+        let negated = if self.peek() == Some(b'^') {
+            self.advance();
+            true
+        } else {
+            false
+        };
+
+        let mut included = Vec::new();
+        loop {
+            match self.peek() {
+                None => return Err(GbnfError("unterminated character class".into())),
+                Some(b']') => {
+                    self.advance();
+                    break;
+                }
+                Some(b'\\') => {
+                    self.advance();
+                    let byte = match self.advance() {
+                        Some(b'n') => b'\n',
+                        Some(b't') => b'\t',
+                        Some(b'r') => b'\r',
+                        Some(b']') => b']',
+                        Some(b'\\') => b'\\',
+                        Some(b'-') => b'-',
+                        Some(b) => b,
+                        None => return Err(GbnfError("truncated escape in char class".into())),
+                    };
+                    // Check for range `\x-y`
+                    if self.peek() == Some(b'-') && self.input.get(self.pos + 1) != Some(&b']') {
+                        self.advance(); // consume '-'
+                        let Some(end) = self.advance() else {
+                            return Err(GbnfError("truncated char range".into()));
+                        };
+                        for b in byte..=end {
+                            included.push(b);
+                        }
+                    } else {
+                        included.push(byte);
+                    }
+                }
+                Some(b) => {
+                    self.advance();
+                    // Check for range `a-z`
+                    if self.peek() == Some(b'-') && self.input.get(self.pos + 1) != Some(&b']') {
+                        self.advance(); // consume '-'
+                        let Some(end) = self.advance() else {
+                            return Err(GbnfError("truncated char range".into()));
+                        };
+                        for byte in b..=end {
+                            included.push(byte);
+                        }
+                    } else {
+                        included.push(b);
+                    }
+                }
+            }
+        }
+
+        Ok(Token::CharClass {
+            bytes: included,
+            negated,
+        })
+    }
+
+    fn next_token(&mut self) -> Result<Token, GbnfError> {
+        self.skip_spaces();
+        self.skip_line_comment();
+
+        match self.peek() {
+            None => Ok(Token::Eof),
+            Some(b'\n') => {
+                self.advance();
+                Ok(Token::Newline)
+            }
+            Some(b':') => {
+                self.advance();
+                if self.peek() == Some(b':') {
+                    self.advance();
+                    if self.advance() == Some(b'=') {
+                        Ok(Token::Assign)
+                    } else {
+                        Err(GbnfError("expected ::=".into()))
+                    }
+                } else {
+                    Err(GbnfError("expected ::=".into()))
+                }
+            }
+            Some(b'|') => {
+                self.advance();
+                Ok(Token::Pipe)
+            }
+            Some(b'(') => {
+                self.advance();
+                Ok(Token::LParen)
+            }
+            Some(b')') => {
+                self.advance();
+                Ok(Token::RParen)
+            }
+            Some(b'*') => {
+                self.advance();
+                Ok(Token::Star)
+            }
+            Some(b'+') => {
+                self.advance();
+                Ok(Token::Plus)
+            }
+            Some(b'?') => {
+                self.advance();
+                Ok(Token::Question)
+            }
+            Some(b'.') => {
+                self.advance();
+                Ok(Token::Dot)
+            }
+            Some(b'"') => {
+                self.advance();
+                let bytes = self.read_string_lit()?;
+                Ok(Token::StringLit(bytes))
+            }
+            Some(b'[') => {
+                self.advance();
+                self.read_char_class()
+            }
+            Some(b) if b.is_ascii_alphabetic() || b == b'_' => {
+                let ident = self.read_ident();
+                Ok(Token::Ident(ident))
+            }
+            Some(b) => Err(GbnfError(format!("unexpected byte: 0x{b:02x}"))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+struct Parser<'a> {
+    lexer: Lexer<'a>,
+    lookahead: Option<Token>,
+    builder: GrammarBuilder,
+    /// Counter for auto-generated rule names (for desugared repetition).
+    anon_counter: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(input: &'a str) -> Result<Self, GbnfError> {
+        let mut lexer = Lexer::new(input);
+        let tok = lexer.next_token()?;
+        Ok(Self {
+            lexer,
+            lookahead: Some(tok),
+            builder: GrammarBuilder::new(),
+            anon_counter: 0,
+        })
+    }
+
+    fn peek(&self) -> &Token {
+        self.lookahead.as_ref().unwrap_or(&Token::Eof)
+    }
+
+    fn consume(&mut self) -> Result<Token, GbnfError> {
+        let tok = self.lookahead.take().unwrap_or(Token::Eof);
+        self.lookahead = Some(self.lexer.next_token()?);
+        Ok(tok)
+    }
+
+    fn expect(&mut self, expected: &Token) -> Result<(), GbnfError> {
+        let tok = self.consume()?;
+        if &tok == expected {
+            Ok(())
+        } else {
+            Err(GbnfError(format!("expected {expected:?}, got {tok:?}")))
+        }
+    }
+
+    fn skip_newlines(&mut self) -> Result<(), GbnfError> {
+        while self.peek() == &Token::Newline {
+            self.consume()?;
+        }
+        Ok(())
+    }
+
+    fn anon_rule_name(&mut self) -> String {
+        let n = format!("__anon_{}", self.anon_counter);
+        self.anon_counter += 1;
+        n
+    }
+
+    // grammar = rule+
+    // Returns the builder, consuming self.
+    fn parse_grammar(mut self) -> Result<GrammarBuilder, GbnfError> {
+        self.skip_newlines()?;
+        while self.peek() != &Token::Eof {
+            self.parse_rule()?;
+            self.skip_newlines()?;
+        }
+        Ok(self.builder)
+    }
+
+    // rule = IDENT "::=" expr "\n"?
+    fn parse_rule(&mut self) -> Result<(), GbnfError> {
+        let name = match self.consume()? {
+            Token::Ident(n) => n,
+            tok => return Err(GbnfError(format!("expected rule name, got {tok:?}"))),
+        };
+        self.expect(&Token::Assign)?;
+        let alts = self.parse_expr()?;
+        let id = self.builder.reserve(&name);
+        self.builder.set_alts(id, alts);
+        // Consume optional trailing newline(s)
+        self.skip_newlines()?;
+        Ok(())
+    }
+
+    // expr = alt ("|" alt)*
+    fn parse_expr(&mut self) -> Result<Vec<Alt>, GbnfError> {
+        let mut alts = vec![self.parse_alt()?];
+        while self.peek() == &Token::Pipe {
+            self.consume()?;
+            alts.push(self.parse_alt()?);
+        }
+        Ok(alts)
+    }
+
+    // alt = item*  (stops at | ) \n EOF)
+    fn parse_alt(&mut self) -> Result<Alt, GbnfError> {
+        let mut syms: Alt = Vec::new();
+        loop {
+            match self.peek() {
+                Token::Pipe | Token::RParen | Token::Newline | Token::Eof => break,
+                _ => {
+                    let new_syms = self.parse_item()?;
+                    syms.extend(new_syms);
+                }
+            }
+        }
+        Ok(syms)
+    }
+
+    // item = base_item ("*" | "+" | "?")?
+    fn parse_item(&mut self) -> Result<Alt, GbnfError> {
+        let base = self.parse_base_item()?;
+
+        match self.peek() {
+            Token::Star => {
+                self.consume()?;
+                // Desugar `x*` → `opt_rep = x opt_rep | ε`
+                let rule_name = self.anon_rule_name();
+                let id = self.builder.reserve(&rule_name);
+                let rep_alt: Alt = base
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(Symbol::NonTerminal(id)))
+                    .collect();
+                self.builder.set_alts(id, vec![rep_alt, vec![]]);
+                Ok(vec![Symbol::NonTerminal(id)])
+            }
+            Token::Plus => {
+                self.consume()?;
+                // Desugar `x+` → `rep = x tail; tail = x tail | ε`
+                // Using a nullable tail rule ensures `is_accepting` returns
+                // true after consuming exactly one `x` (tail is epsilon-able).
+                let tail_name = self.anon_rule_name();
+                let tail_id = self.builder.reserve(&tail_name);
+                // tail = [x, NT(tail)] | ε
+                let tail_rec: Alt = base
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(Symbol::NonTerminal(tail_id)))
+                    .collect();
+                self.builder.set_alts(tail_id, vec![tail_rec, vec![]]);
+                // rep = x tail
+                let rep_name = self.anon_rule_name();
+                let rep_id = self.builder.reserve(&rep_name);
+                let rep_alt: Alt = base
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(Symbol::NonTerminal(tail_id)))
+                    .collect();
+                self.builder.set_alts(rep_id, vec![rep_alt]);
+                Ok(vec![Symbol::NonTerminal(rep_id)])
+            }
+            Token::Question => {
+                self.consume()?;
+                // Desugar `x?` → `opt = x | ε`
+                let rule_name = self.anon_rule_name();
+                let id = self.builder.reserve(&rule_name);
+                self.builder.set_alts(id, vec![base, vec![]]);
+                Ok(vec![Symbol::NonTerminal(id)])
+            }
+            _ => Ok(base),
+        }
+    }
+
+    // base_item = IDENT | string_lit | char_class | "." | "(" expr ")"
+    fn parse_base_item(&mut self) -> Result<Alt, GbnfError> {
+        match self.peek().clone() {
+            Token::Ident(name) => {
+                self.consume()?;
+                // Forward-reference: reserve if not seen yet.
+                let id = self.builder.reserve(&name);
+                Ok(vec![Symbol::NonTerminal(id)])
+            }
+            Token::StringLit(_) => {
+                if let Token::StringLit(bytes) = self.consume()? {
+                    Ok(bytes.into_iter().map(Symbol::Terminal).collect())
+                } else {
+                    unreachable!()
+                }
+            }
+            Token::CharClass { .. } => {
+                if let Token::CharClass { bytes, negated } = self.consume()? {
+                    let alts = char_class_alts(&bytes, negated);
+                    if alts.is_empty() {
+                        return Err(GbnfError("empty character class".into()));
+                    }
+                    if alts.len() == 1 {
+                        return Ok(alts.into_iter().next().unwrap());
+                    }
+                    // Wrap in anon rule.
+                    let rule_name = self.anon_rule_name();
+                    let id = self.builder.reserve(&rule_name);
+                    self.builder.set_alts(id, alts);
+                    Ok(vec![Symbol::NonTerminal(id)])
+                } else {
+                    unreachable!()
+                }
+            }
+            Token::Dot => {
+                self.consume()?;
+                Ok(vec![Symbol::AnyByte])
+            }
+            Token::LParen => {
+                self.consume()?;
+                let alts = self.parse_expr()?;
+                match self.consume()? {
+                    Token::RParen => {}
+                    tok => {
+                        return Err(GbnfError(format!("expected ), got {tok:?}")));
+                    }
+                }
+                let rule_name = self.anon_rule_name();
+                let id = self.builder.reserve(&rule_name);
+                self.builder.set_alts(id, alts);
+                Ok(vec![Symbol::NonTerminal(id)])
+            }
+            tok => Err(GbnfError(format!("unexpected token in item: {tok:?}"))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build alternatives for a character class.
+/// Returns a `Vec<Alt>` — one alternative per matching byte.
+fn char_class_alts(bytes: &[u8], negated: bool) -> Vec<Alt> {
+    if negated {
+        let set: HashSet<u8> = bytes.iter().copied().collect();
+        (0u8..=255)
+            .filter(|b| !set.contains(b))
+            .map(|b| vec![Symbol::Terminal(b)])
+            .collect()
+    } else {
+        bytes.iter().map(|&b| vec![Symbol::Terminal(b)]).collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Parse a GBNF string into a `CompiledGrammar`.
+///
+/// The grammar must contain a rule named `root`.  After parsing, the root
+/// rule is moved to index 0 so the PDA initial state is correct.
+pub fn parse_gbnf(gbnf: &str) -> Result<CompiledGrammar, GbnfError> {
+    let parser = Parser::new(gbnf)?;
+    let builder = parser.parse_grammar()?;
+    let mut grammar = builder.build();
+
+    // Ensure root is at index 0.
+    let root_pos = grammar
+        .rules
+        .iter()
+        .position(|r| r.name == "root")
+        .ok_or_else(|| GbnfError("grammar has no 'root' rule".into()))?;
+
+    if root_pos != 0 {
+        // Swap root to index 0 and fix up all NonTerminal references.
+        grammar.rules.swap(0, root_pos);
+        for rule in &mut grammar.rules {
+            for alt in &mut rule.alts {
+                for sym in alt.iter_mut() {
+                    if let Symbol::NonTerminal(rid) = sym {
+                        if *rid == root_pos {
+                            *rid = 0;
+                        } else if *rid == 0 {
+                            *rid = root_pos;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(grammar)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grammar::pda::{GrammarState, SimResult, simulate_token};
+
+    fn accepts(grammar: &CompiledGrammar, input: &[u8]) -> bool {
+        let state = GrammarState::initial();
+        let (result, final_state) = simulate_token(&state, grammar, input);
+        result == SimResult::Accept && final_state.is_complete()
+    }
+
+    fn rejects(grammar: &CompiledGrammar, input: &[u8]) -> bool {
+        // A grammar "rejects" a string when it cannot accept it as a complete
+        // value.  This includes both early byte rejections (SimResult::Reject)
+        // and cases where all bytes are consumed but the state is not complete.
+        !accepts(grammar, input)
+    }
+
+    #[test]
+    fn gbnf_string_literal() {
+        let g = parse_gbnf("root ::= \"hello\"\n").unwrap();
+        assert!(accepts(&g, b"hello"));
+        assert!(rejects(&g, b"world"));
+    }
+
+    #[test]
+    fn gbnf_alternation() {
+        let g = parse_gbnf("root ::= \"yes\" | \"no\"\n").unwrap();
+        assert!(accepts(&g, b"yes"));
+        assert!(accepts(&g, b"no"));
+        assert!(rejects(&g, b"maybe"));
+    }
+
+    #[test]
+    fn gbnf_char_class() {
+        let g = parse_gbnf("root ::= [abc]\n").unwrap();
+        assert!(accepts(&g, b"a"));
+        assert!(accepts(&g, b"b"));
+        assert!(accepts(&g, b"c"));
+        assert!(rejects(&g, b"d"));
+    }
+
+    #[test]
+    fn gbnf_char_range() {
+        let g = parse_gbnf("root ::= [a-z]\n").unwrap();
+        assert!(accepts(&g, b"a"));
+        assert!(accepts(&g, b"z"));
+        assert!(rejects(&g, b"A"));
+        assert!(rejects(&g, b"0"));
+    }
+
+    #[test]
+    fn gbnf_optional() {
+        let g = parse_gbnf("root ::= \"x\"?\n").unwrap();
+        assert!(accepts(&g, b"x"));
+        // epsilon: initial state should be complete (? makes root = x | ε)
+        let state = GrammarState::initial();
+        assert!(state.is_complete() || !state.stack.is_empty());
+    }
+
+    #[test]
+    fn gbnf_plus() {
+        let g = parse_gbnf("root ::= [0-9]+\n").unwrap();
+        assert!(accepts(&g, b"5"));
+        assert!(accepts(&g, b"42"));
+        assert!(rejects(&g, b"x"));
+    }
+
+    #[test]
+    fn gbnf_star() {
+        let g = parse_gbnf("root ::= [0-9]*\n").unwrap();
+        // one or more accepted
+        assert!(accepts(&g, b"123"));
+    }
+
+    #[test]
+    fn gbnf_non_terminal_reference() {
+        let gbnf = "root ::= digit digit\ndigit ::= [0-9]\n";
+        let g = parse_gbnf(gbnf).unwrap();
+        assert!(accepts(&g, b"42"));
+        assert!(rejects(&g, b"4"));
+        assert!(rejects(&g, b"abc"));
+    }
+
+    #[test]
+    fn gbnf_grouping() {
+        let g = parse_gbnf("root ::= (\"ab\" | \"cd\")\n").unwrap();
+        assert!(accepts(&g, b"ab"));
+        assert!(accepts(&g, b"cd"));
+        assert!(rejects(&g, b"ac"));
+    }
+
+    #[test]
+    fn gbnf_dot() {
+        let g = parse_gbnf("root ::= .\n").unwrap();
+        assert!(accepts(&g, b"a"));
+        assert!(accepts(&g, b"z"));
+        assert!(accepts(&g, b"0"));
+    }
+
+    #[test]
+    fn gbnf_no_root_returns_error() {
+        assert!(parse_gbnf("foo ::= \"bar\"\n").is_err());
+    }
+
+    #[test]
+    fn gbnf_error_display() {
+        let e = GbnfError("test error".to_string());
+        assert!(e.to_string().contains("test error"));
+    }
+
+    #[test]
+    fn gbnf_comment_skipped() {
+        let g = parse_gbnf("# this is a comment\nroot ::= \"ok\"\n").unwrap();
+        assert!(accepts(&g, b"ok"));
+    }
+}

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -1,0 +1,915 @@
+//! JSON Schema → `CompiledGrammar` compiler.
+//!
+//! # Supported subset (v0)
+//!
+//! - `type`: `"object"`, `"array"`, `"string"`, `"number"`, `"integer"`,
+//!   `"boolean"`, `"null"`
+//! - `properties` + `required` on objects
+//! - `items` (uniform array) and `prefixItems` (tuple) on arrays
+//! - `minItems` / `maxItems` on arrays
+//! - `enum` and `const` on any type
+//! - `anyOf` / `oneOf`
+//! - `$ref` resolved within the same document (`#/$defs/...`,
+//!   `#/definitions/...`)
+//! - `$defs` / `definitions` for reusable sub-schemas
+//!
+//! # Deferred (not implemented)
+//!
+//! - External `$ref` (URI references)
+//! - `pattern` constraints on strings
+//! - `if` / `then` / `else`
+//!
+//! # Grammar encoding
+//!
+//! Each JSON Schema concept maps to a named rule in the `CompiledGrammar`:
+//!
+//! - Primitives: `json_string`, `json_number`, `json_integer`, `json_boolean`,
+//!   `json_null`, `json_ws` (optional whitespace)
+//! - Objects: `obj_{hash}` with one alternative per property permutation
+//! - Arrays: `arr_{hash}`
+//! - `$ref`-defined schemas get rule names from their path segment
+
+use crate::grammar::pda::{Alt, CompiledGrammar, GrammarBuilder, Symbol};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Error returned by the JSON Schema compiler.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SchemaError(pub String);
+
+impl std::fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JSON Schema compile error: {}", self.0)
+    }
+}
+
+impl std::error::Error for SchemaError {}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Compile a JSON Schema `Value` into a `CompiledGrammar`.
+///
+/// The schema is expected to be a JSON Schema object (an `{}` map).  Pass the
+/// full document root — `$defs` / `definitions` will be extracted automatically.
+pub fn compile_json_schema(schema: &Value) -> Result<CompiledGrammar, SchemaError> {
+    let mut ctx = CompileCtx::new(schema)?;
+    // Reserve "root" — may not be at index 0 because register_builtins() runs
+    // first in CompileCtx::new().
+    let root_id = ctx.builder.reserve("root");
+    let root_alts = ctx.compile_schema(schema, &[])?;
+    ctx.builder.set_alts(root_id, root_alts);
+    // Ensure all deferred rules have been resolved.
+    ctx.resolve_pending()?;
+    let mut grammar = ctx.builder.build();
+
+    // Move "root" to index 0 so that GrammarState::initial() (which starts
+    // with rule_id=0) points to the correct entry rule.
+    if root_id != 0 {
+        grammar.rules.swap(0, root_id);
+        // Fix up all NonTerminal references after the swap.
+        for rule in &mut grammar.rules {
+            for alt in &mut rule.alts {
+                for sym in alt.iter_mut() {
+                    if let crate::grammar::pda::Symbol::NonTerminal(rid) = sym {
+                        if *rid == root_id {
+                            *rid = 0;
+                        } else if *rid == 0 {
+                            *rid = root_id;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(grammar)
+}
+
+// ---------------------------------------------------------------------------
+// Internal compile context
+// ---------------------------------------------------------------------------
+
+struct CompileCtx<'a> {
+    /// Name-to-schema mapping for `$defs` / `definitions`.
+    defs: HashMap<String, &'a Value>,
+    builder: GrammarBuilder,
+}
+
+impl<'a> CompileCtx<'a> {
+    fn new(doc_root: &'a Value) -> Result<Self, SchemaError> {
+        let mut defs = HashMap::new();
+        // Collect $defs
+        if let Some(defs_map) = doc_root.get("$defs").and_then(Value::as_object) {
+            for (k, v) in defs_map {
+                defs.insert(k.clone(), v);
+            }
+        }
+        // Also accept legacy `definitions`
+        if let Some(defs_map) = doc_root.get("definitions").and_then(Value::as_object) {
+            for (k, v) in defs_map {
+                defs.entry(k.clone()).or_insert(v);
+            }
+        }
+        let mut builder = GrammarBuilder::new();
+        // Pre-register built-in rules.
+        register_builtins(&mut builder);
+        Ok(Self { defs, builder })
+    }
+
+    /// Compile `schema` into a list of alternatives.
+    fn compile_schema(
+        &mut self,
+        schema: &'a Value,
+        _path: &[&str],
+    ) -> Result<Vec<Alt>, SchemaError> {
+        // Handle `$ref`
+        if let Some(ref_str) = schema.get("$ref").and_then(Value::as_str) {
+            return self.compile_ref(ref_str);
+        }
+
+        // Handle `enum`
+        if let Some(values) = schema.get("enum").and_then(Value::as_array) {
+            // For string-typed enums (or all-string enum values), delegate to
+            // compile_string_type which factors the `"` delimiters to avoid
+            // alternative ambiguity in the PDA.
+            let type_is_string = schema.get("type").and_then(Value::as_str) == Some("string");
+            let all_strings = values.iter().all(Value::is_string);
+            if type_is_string || all_strings {
+                return Ok(self.compile_string_type(schema));
+            }
+            return compile_enum(values);
+        }
+
+        // Handle `const`
+        if let Some(v) = schema.get("const") {
+            return compile_const(v);
+        }
+
+        // Handle `anyOf` / `oneOf`
+        if let Some(any_of) = schema
+            .get("anyOf")
+            .or_else(|| schema.get("oneOf"))
+            .and_then(Value::as_array)
+        {
+            let mut all_alts: Vec<Alt> = Vec::new();
+            for sub in any_of {
+                let sub_alts = self.compile_schema(sub, _path)?;
+                all_alts.extend(sub_alts);
+            }
+            return Ok(all_alts);
+        }
+
+        // Dispatch on `type`
+        match schema.get("type").and_then(Value::as_str) {
+            Some("object") => self.compile_object(schema),
+            Some("array") => self.compile_array(schema),
+            Some("string") => Ok(self.compile_string_type(schema)),
+            Some("number") => {
+                let id = self
+                    .builder
+                    .rule_id("json_number")
+                    .ok_or_else(|| SchemaError("builtin json_number missing".into()))?;
+                Ok(vec![vec![Symbol::NonTerminal(id)]])
+            }
+            Some("integer") => {
+                let id = self
+                    .builder
+                    .rule_id("json_integer")
+                    .ok_or_else(|| SchemaError("builtin json_integer missing".into()))?;
+                Ok(vec![vec![Symbol::NonTerminal(id)]])
+            }
+            Some("boolean") => {
+                let id = self
+                    .builder
+                    .rule_id("json_boolean")
+                    .ok_or_else(|| SchemaError("builtin json_boolean missing".into()))?;
+                Ok(vec![vec![Symbol::NonTerminal(id)]])
+            }
+            Some("null") => {
+                let id = self
+                    .builder
+                    .rule_id("json_null")
+                    .ok_or_else(|| SchemaError("builtin json_null missing".into()))?;
+                Ok(vec![vec![Symbol::NonTerminal(id)]])
+            }
+            Some(other) => Err(SchemaError(format!("unsupported type: {other}"))),
+            None => {
+                // No type: treat as any JSON value.
+                Ok(self.any_value_alts())
+            }
+        }
+    }
+
+    /// Compile `#/$defs/Name` or `#/definitions/Name` reference.
+    fn compile_ref(&mut self, ref_str: &str) -> Result<Vec<Alt>, SchemaError> {
+        let name = extract_ref_name(ref_str)?;
+        // Look up in $defs
+        let target: &'a Value = self
+            .defs
+            .get(name)
+            .copied()
+            .ok_or_else(|| SchemaError(format!("$ref not found: {ref_str}")))?;
+
+        // If we already have a rule for this name, emit a NonTerminal.
+        if let Some(id) = self.builder.rule_id(name) {
+            return Ok(vec![vec![Symbol::NonTerminal(id)]]);
+        }
+
+        // Reserve the rule (handles recursive references).
+        let id = self.builder.reserve(name);
+        // Compile the target and set alts.
+        let alts = self.compile_schema(target, &[])?;
+        self.builder.set_alts(id, alts);
+        Ok(vec![vec![Symbol::NonTerminal(id)]])
+    }
+
+    /// Compile an `object` schema.
+    fn compile_object(&mut self, schema: &'a Value) -> Result<Vec<Alt>, SchemaError> {
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .map(|m| m.iter().collect::<Vec<_>>());
+        let required: Vec<&str> = schema
+            .get("required")
+            .and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        match properties {
+            None => {
+                // No properties: any JSON object `{}` or `{"k":v,...}`.
+                Ok(vec![empty_object_alt()])
+            }
+            Some(props) => {
+                // Generate grammar: `{` ws property_list ws `}`
+                // For v0 we emit a single alt with all properties in declaration order.
+                // Required properties are mandated; optional properties are wrapped in an
+                // "optional item" rule.
+                let mut main_alt: Alt = vec![Symbol::Terminal(b'{')];
+                // ws
+                let ws_id = self.builder.rule_id("ws").unwrap();
+                main_alt.push(Symbol::NonTerminal(ws_id));
+
+                let mut first = true;
+                for (key, val_schema) in &props {
+                    let key_str: &str = key.as_str();
+                    let is_req = required.contains(&key_str);
+
+                    // Compile the value schema into a named rule.
+                    let val_rule_name = format!("prop_val_{key_str}");
+                    let val_id = if let Some(id) = self.builder.rule_id(&val_rule_name) {
+                        id
+                    } else {
+                        let id = self.builder.reserve(&val_rule_name);
+                        let val_alts = self.compile_schema(val_schema, &[])?;
+                        self.builder.set_alts(id, val_alts);
+                        id
+                    };
+
+                    // Build: `"key" ws ":" ws value`
+                    let pair_rule_name = format!("pair_{key_str}");
+                    let pair_id = if let Some(id) = self.builder.rule_id(&pair_rule_name) {
+                        id
+                    } else {
+                        let id = self.builder.reserve(&pair_rule_name);
+                        let mut pair_alt = json_string_literal(key_str);
+                        pair_alt.push(Symbol::NonTerminal(ws_id));
+                        pair_alt.push(Symbol::Terminal(b':'));
+                        pair_alt.push(Symbol::NonTerminal(ws_id));
+                        pair_alt.push(Symbol::NonTerminal(val_id));
+                        self.builder.set_alts(id, vec![pair_alt]);
+                        id
+                    };
+
+                    if !first {
+                        // Separator: ws "," ws
+                        main_alt.push(Symbol::NonTerminal(ws_id));
+                        main_alt.push(Symbol::Terminal(b','));
+                        main_alt.push(Symbol::NonTerminal(ws_id));
+                    }
+
+                    if is_req {
+                        main_alt.push(Symbol::NonTerminal(pair_id));
+                    } else {
+                        // Optional pair: wrap in opt_pair rule.
+                        let opt_name = format!("opt_{pair_rule_name}");
+                        let opt_id = if let Some(id) = self.builder.rule_id(&opt_name) {
+                            id
+                        } else {
+                            let id = self.builder.reserve(&opt_name);
+                            let opt_alts = vec![
+                                vec![Symbol::NonTerminal(pair_id)],
+                                vec![], // epsilon: property absent
+                            ];
+                            self.builder.set_alts(id, opt_alts);
+                            id
+                        };
+                        main_alt.push(Symbol::NonTerminal(opt_id));
+                    }
+                    first = false;
+                }
+
+                main_alt.push(Symbol::NonTerminal(ws_id));
+                main_alt.push(Symbol::Terminal(b'}'));
+                Ok(vec![main_alt])
+            }
+        }
+    }
+
+    /// Compile an `array` schema.
+    fn compile_array(&mut self, schema: &'a Value) -> Result<Vec<Alt>, SchemaError> {
+        let ws_id = self.builder.rule_id("ws").unwrap();
+        let min_items = schema.get("minItems").and_then(Value::as_u64).unwrap_or(0) as usize;
+        let max_items = schema
+            .get("maxItems")
+            .and_then(Value::as_u64)
+            .map(|v| v as usize);
+
+        if let Some(items_schema) = schema.get("items") {
+            // Uniform array: all items share the same schema.
+            let item_rule = "arr_item";
+            let item_id = if let Some(id) = self.builder.rule_id(item_rule) {
+                id
+            } else {
+                let id = self.builder.reserve(item_rule);
+                let item_alts = self.compile_schema(items_schema, &[])?;
+                self.builder.set_alts(id, item_alts);
+                id
+            };
+
+            // Build the array as: `[` ws  (item (ws , ws item)*)? ws `]`
+            let mut alt: Alt = vec![Symbol::Terminal(b'[')];
+            alt.push(Symbol::NonTerminal(ws_id));
+
+            if min_items == 0 && max_items.is_none_or(|m| m > 0) {
+                // Optional content: build arr_body rule.
+                let body_name = "arr_body";
+                let body_id = if let Some(id) = self.builder.rule_id(body_name) {
+                    id
+                } else {
+                    let id = self.builder.reserve(body_name);
+                    // arr_body = item (ws , ws item)*
+                    // We approximate repetition with a left-recursive rule.
+                    // Since our PDA doesn't handle true left-recursion well,
+                    // we use right-recursion: arr_body = item arr_tail
+                    // arr_tail = (ws , ws item arr_tail) | ε
+                    let tail_name = "arr_tail";
+                    let tail_id = self.builder.reserve(tail_name);
+                    let tail_alts = vec![
+                        vec![
+                            Symbol::NonTerminal(ws_id),
+                            Symbol::Terminal(b','),
+                            Symbol::NonTerminal(ws_id),
+                            Symbol::NonTerminal(item_id),
+                            Symbol::NonTerminal(tail_id),
+                        ],
+                        vec![], // epsilon
+                    ];
+                    self.builder.set_alts(tail_id, tail_alts);
+
+                    let body_alt = vec![vec![
+                        Symbol::NonTerminal(item_id),
+                        Symbol::NonTerminal(tail_id),
+                    ]];
+                    self.builder.set_alts(id, body_alt);
+                    id
+                };
+
+                // opt_arr_body = arr_body | ε
+                let opt_name = "opt_arr_body";
+                let opt_id = if let Some(id) = self.builder.rule_id(opt_name) {
+                    id
+                } else {
+                    let id = self.builder.reserve(opt_name);
+                    self.builder
+                        .set_alts(id, vec![vec![Symbol::NonTerminal(body_id)], vec![]]);
+                    id
+                };
+                alt.push(Symbol::NonTerminal(opt_id));
+            } else {
+                // min_items required items — unroll exactly.
+                for _ in 0..min_items {
+                    alt.push(Symbol::NonTerminal(item_id));
+                }
+            }
+
+            alt.push(Symbol::NonTerminal(ws_id));
+            alt.push(Symbol::Terminal(b']'));
+            return Ok(vec![alt]);
+        }
+
+        // No items schema: any array `[]` or `[v, ...]`.
+        let any_val_rule = "any_json_value";
+        let any_id = if let Some(id) = self.builder.rule_id(any_val_rule) {
+            id
+        } else {
+            let id = self.builder.reserve(any_val_rule);
+            let any_alts = self.any_value_alts();
+            self.builder.set_alts(id, any_alts);
+            id
+        };
+
+        let tail_name = "any_arr_tail";
+        let tail_id = if let Some(id) = self.builder.rule_id(tail_name) {
+            id
+        } else {
+            let id = self.builder.reserve(tail_name);
+            let tail_alts = vec![
+                vec![
+                    Symbol::NonTerminal(ws_id),
+                    Symbol::Terminal(b','),
+                    Symbol::NonTerminal(ws_id),
+                    Symbol::NonTerminal(any_id),
+                    Symbol::NonTerminal(id), // recursive
+                ],
+                vec![],
+            ];
+            self.builder.set_alts(id, tail_alts);
+            id
+        };
+
+        let body_name = "any_arr_body";
+        let body_id = if let Some(id) = self.builder.rule_id(body_name) {
+            id
+        } else {
+            let id = self.builder.reserve(body_name);
+            self.builder.set_alts(
+                id,
+                vec![
+                    vec![Symbol::NonTerminal(any_id), Symbol::NonTerminal(tail_id)],
+                    vec![],
+                ],
+            );
+            id
+        };
+
+        let mut alt: Alt = vec![Symbol::Terminal(b'[')];
+        alt.push(Symbol::NonTerminal(ws_id));
+        alt.push(Symbol::NonTerminal(body_id));
+        alt.push(Symbol::NonTerminal(ws_id));
+        alt.push(Symbol::Terminal(b']'));
+        Ok(vec![alt])
+    }
+
+    /// Compile `"type": "string"` potentially with an `enum` constraint.
+    fn compile_string_type(&mut self, schema: &Value) -> Vec<Alt> {
+        if let Some(values) = schema.get("enum").and_then(Value::as_array) {
+            let str_values: Vec<&str> = values.iter().filter_map(|v| v.as_str()).collect();
+            if !str_values.is_empty() {
+                // Factor the common `'"'` prefix and `'"'` suffix into a
+                // wrapper so that string enum alternatives are disambiguated
+                // inside the quoted region, not at the opening quote.
+                //
+                // Grammar: root → '"' enum_choices '"'
+                //          enum_choices → alt0 | alt1 | ...
+                let choices_name = format!("str_enum_{}", str_values.join("_"));
+                let choices_id = if let Some(id) = self.builder.rule_id(&choices_name) {
+                    id
+                } else {
+                    let id = self.builder.reserve(&choices_name);
+                    let choice_alts: Vec<Alt> = str_values
+                        .iter()
+                        .map(|s| s.bytes().map(Symbol::Terminal).collect::<Alt>())
+                        .collect();
+                    self.builder.set_alts(id, choice_alts);
+                    id
+                };
+                return vec![vec![
+                    Symbol::Terminal(b'"'),
+                    Symbol::NonTerminal(choices_id),
+                    Symbol::Terminal(b'"'),
+                ]];
+            }
+        }
+        // Default: any JSON string via built-in rule.
+        if let Some(id) = self.builder.rule_id("json_string") {
+            vec![vec![Symbol::NonTerminal(id)]]
+        } else {
+            // Fallback: inline minimal string rule (should not happen).
+            vec![vec![Symbol::Terminal(b'"'), Symbol::Terminal(b'"')]]
+        }
+    }
+
+    /// Returns alternatives for "any JSON value" (used when no type is given).
+    fn any_value_alts(&mut self) -> Vec<Alt> {
+        let Some(ws_id) = self.builder.rule_id("ws") else {
+            return vec![];
+        };
+        let mut alts = Vec::new();
+        if let Some(id) = self.builder.rule_id("json_string") {
+            alts.push(vec![Symbol::NonTerminal(id)]);
+        }
+        if let Some(id) = self.builder.rule_id("json_number") {
+            alts.push(vec![Symbol::NonTerminal(id)]);
+        }
+        if let Some(id) = self.builder.rule_id("json_boolean") {
+            alts.push(vec![Symbol::NonTerminal(id)]);
+        }
+        if let Some(id) = self.builder.rule_id("json_null") {
+            alts.push(vec![Symbol::NonTerminal(id)]);
+        }
+        // Inline empty object and empty array for v0.
+        alts.push(empty_object_as_alt_with_ws(ws_id));
+        alts.push(vec![
+            Symbol::Terminal(b'['),
+            Symbol::NonTerminal(ws_id),
+            Symbol::Terminal(b']'),
+        ]);
+        alts
+    }
+
+    fn resolve_pending(&self) -> Result<(), SchemaError> {
+        // All rules resolved inline via compile_schema and compile_ref.
+        // No deferred resolution needed for v0.
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Built-in primitive rules
+// ---------------------------------------------------------------------------
+
+/// Register primitive grammar rules into the builder.
+fn register_builtins(b: &mut GrammarBuilder) {
+    // ws = (' ' | '\t' | '\n' | '\r')* (zero or more whitespace bytes)
+    let ws_id = b.reserve("ws");
+    let ws_tail = b.reserve("ws_tail");
+    b.set_alts(
+        ws_tail,
+        vec![
+            vec![Symbol::Terminal(b' '), Symbol::NonTerminal(ws_tail)],
+            vec![Symbol::Terminal(b'\t'), Symbol::NonTerminal(ws_tail)],
+            vec![Symbol::Terminal(b'\n'), Symbol::NonTerminal(ws_tail)],
+            vec![Symbol::Terminal(b'\r'), Symbol::NonTerminal(ws_tail)],
+            vec![], // epsilon
+        ],
+    );
+    b.set_alts(ws_id, vec![vec![Symbol::NonTerminal(ws_tail)]]);
+
+    // json_string = '"' string_inner '"'
+    // string_inner = char* where char = any byte except '"' and '\'
+    //   plus '\\' followed by any byte (simplified escape handling).
+    let str_id = b.reserve("json_string");
+    let str_inner_id = b.reserve("json_string_inner");
+    let str_char_id = b.reserve("json_string_char");
+
+    // json_string_char: any byte except '"' (0x22) and '\' (0x5c),
+    // or '\' followed by any byte.
+    let mut char_alts: Vec<Alt> = Vec::new();
+    // Escape sequence: '\' + any byte
+    char_alts.push(vec![Symbol::Terminal(b'\\'), Symbol::AnyByte]);
+    // Normal chars: all bytes except '"' (0x22) and '\' (0x5c)
+    for byte in 0u8..=255 {
+        if byte != b'"' && byte != b'\\' {
+            char_alts.push(vec![Symbol::Terminal(byte)]);
+        }
+    }
+    b.set_alts(str_char_id, char_alts);
+
+    // json_string_inner = (json_string_char json_string_inner) | ε
+    b.set_alts(
+        str_inner_id,
+        vec![
+            vec![
+                Symbol::NonTerminal(str_char_id),
+                Symbol::NonTerminal(str_inner_id),
+            ],
+            vec![], // epsilon
+        ],
+    );
+    b.set_alts(
+        str_id,
+        vec![vec![
+            Symbol::Terminal(b'"'),
+            Symbol::NonTerminal(str_inner_id),
+            Symbol::Terminal(b'"'),
+        ]],
+    );
+
+    // json_number = '-'? digit+ ('.' digit+)? (('e'|'E') ('+'|'-')? digit+)?
+    // We approximate with a rule that matches the common case.
+    let num_id = b.reserve("json_number");
+    let digit_id = b.reserve("json_digit");
+    let digit_alts: Vec<Alt> = (b'0'..=b'9')
+        .map(|byte| vec![Symbol::Terminal(byte)])
+        .collect();
+    b.set_alts(digit_id, digit_alts);
+
+    // json_digits = digit digit_tail
+    // json_digit_tail = digit digit_tail | ε   (nullable tail ensures
+    // is_accepting returns true after consuming ≥1 digit).
+    let digits_id = b.reserve("json_digits");
+    let digit_tail_id = b.reserve("json_digit_tail");
+    b.set_alts(
+        digit_tail_id,
+        vec![
+            vec![
+                Symbol::NonTerminal(digit_id),
+                Symbol::NonTerminal(digit_tail_id),
+            ],
+            vec![], // epsilon
+        ],
+    );
+    b.set_alts(
+        digits_id,
+        vec![vec![
+            Symbol::NonTerminal(digit_id),
+            Symbol::NonTerminal(digit_tail_id),
+        ]],
+    );
+
+    // Optional sign
+    let opt_sign_id = b.reserve("json_opt_sign");
+    b.set_alts(opt_sign_id, vec![vec![Symbol::Terminal(b'-')], vec![]]);
+
+    // Optional fraction: '.' digits
+    let opt_frac_id = b.reserve("json_opt_frac");
+    b.set_alts(
+        opt_frac_id,
+        vec![
+            vec![Symbol::Terminal(b'.'), Symbol::NonTerminal(digits_id)],
+            vec![],
+        ],
+    );
+
+    // Optional exponent: (e|E) (sign?) digits
+    let exp_sign_id = b.reserve("json_exp_sign");
+    b.set_alts(
+        exp_sign_id,
+        vec![
+            vec![Symbol::Terminal(b'+')],
+            vec![Symbol::Terminal(b'-')],
+            vec![],
+        ],
+    );
+    let opt_exp_id = b.reserve("json_opt_exp");
+    b.set_alts(
+        opt_exp_id,
+        vec![
+            vec![
+                Symbol::Terminal(b'e'),
+                Symbol::NonTerminal(exp_sign_id),
+                Symbol::NonTerminal(digits_id),
+            ],
+            vec![
+                Symbol::Terminal(b'E'),
+                Symbol::NonTerminal(exp_sign_id),
+                Symbol::NonTerminal(digits_id),
+            ],
+            vec![],
+        ],
+    );
+
+    b.set_alts(
+        num_id,
+        vec![vec![
+            Symbol::NonTerminal(opt_sign_id),
+            Symbol::NonTerminal(digits_id),
+            Symbol::NonTerminal(opt_frac_id),
+            Symbol::NonTerminal(opt_exp_id),
+        ]],
+    );
+
+    // json_integer = '-'? digit+
+    let int_id = b.reserve("json_integer");
+    b.set_alts(
+        int_id,
+        vec![vec![
+            Symbol::NonTerminal(opt_sign_id),
+            Symbol::NonTerminal(digits_id),
+        ]],
+    );
+
+    // json_boolean = "true" | "false"
+    let bool_id = b.reserve("json_boolean");
+    b.set_alts(bool_id, vec![bytes_to_alt(b"true"), bytes_to_alt(b"false")]);
+
+    // json_null = "null"
+    let null_id = b.reserve("json_null");
+    b.set_alts(null_id, vec![bytes_to_alt(b"null")]);
+}
+
+fn bytes_to_alt(bytes: &[u8]) -> Alt {
+    bytes.iter().map(|&b| Symbol::Terminal(b)).collect()
+}
+
+fn empty_object_alt() -> Alt {
+    vec![Symbol::Terminal(b'{'), Symbol::Terminal(b'}')]
+}
+
+fn empty_object_as_alt_with_ws(ws_id: usize) -> Alt {
+    vec![
+        Symbol::Terminal(b'{'),
+        Symbol::NonTerminal(ws_id),
+        Symbol::Terminal(b'}'),
+    ]
+}
+
+/// Compile an `enum` schema (values can be any JSON type).
+///
+/// When all enum values are JSON strings, the opening and closing `"`
+/// delimiters are factored out into the calling context.  This avoids
+/// alternative ambiguity when multiple string values share the `"` prefix.
+/// For mixed-type or non-string enums the naive per-value serialisation is
+/// used; those values have distinct first bytes and are unambiguous.
+fn compile_enum(values: &[Value]) -> Result<Vec<Alt>, SchemaError> {
+    // Check if all values are strings.
+    // All-string enums are handled upstream via compile_string_type, which
+    // factors the `"` delimiters to avoid PDA ambiguity.  This path is
+    // reached only for mixed-type or non-string enum values (e.g., const
+    // arrays containing integers or null), whose first bytes are distinct.
+    let alts = values
+        .iter()
+        .map(json_value_to_alt)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(alts)
+}
+
+/// Compile a `const` schema (a single fixed JSON value).
+fn compile_const(v: &Value) -> Result<Vec<Alt>, SchemaError> {
+    Ok(vec![json_value_to_alt(v)?])
+}
+
+/// Convert a concrete JSON value to a grammar alternative (sequence of terminal bytes).
+fn json_value_to_alt(v: &Value) -> Result<Alt, SchemaError> {
+    let json_str = serde_json::to_string(v)
+        .map_err(|e| SchemaError(format!("cannot serialize enum value: {e}")))?;
+    Ok(json_str.bytes().map(Symbol::Terminal).collect())
+}
+
+/// Build a grammar alternative for the JSON literal string `key` (with quotes).
+fn json_string_literal(key: &str) -> Alt {
+    let mut alt = vec![Symbol::Terminal(b'"')];
+    alt.extend(key.bytes().map(Symbol::Terminal));
+    alt.push(Symbol::Terminal(b'"'));
+    alt
+}
+
+/// Extract the definition name from a `$ref` string like `#/$defs/Foo`.
+fn extract_ref_name(ref_str: &str) -> Result<&str, SchemaError> {
+    let parts: Vec<&str> = ref_str.split('/').collect();
+    match parts.as_slice() {
+        ["#", "$defs", name] | ["#", "definitions", name] => Ok(name),
+        _ => Err(SchemaError(format!(
+            "unsupported $ref format: {ref_str} (only #/$defs/Name supported)"
+        ))),
+    }
+}
+
+/// Compile a JSON Schema document into a `CompiledGrammar`.
+///
+/// This is the primary entry point used by `GrammarEngine::new`.
+pub fn compile(schema: &Value) -> Result<CompiledGrammar, SchemaError> {
+    compile_json_schema(schema)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grammar::pda::{GrammarState, SimResult, StepResult, advance_byte, simulate_token};
+
+    fn compile_ok(schema_json: &str) -> CompiledGrammar {
+        let v: Value = serde_json::from_str(schema_json).unwrap();
+        compile(&v).unwrap()
+    }
+
+    fn accepts(grammar: &CompiledGrammar, input: &[u8]) -> bool {
+        let state = GrammarState::initial();
+        let (result, final_state) = simulate_token(&state, grammar, input);
+        result == SimResult::Accept && final_state.is_complete()
+    }
+
+    fn rejects(grammar: &CompiledGrammar, input: &[u8]) -> bool {
+        // A grammar "rejects" a string when it cannot accept it as a complete
+        // value.  This includes both early byte rejections (SimResult::Reject)
+        // and cases where all bytes are consumed but the state is not complete.
+        !accepts(grammar, input)
+    }
+
+    #[test]
+    fn compile_null_schema() {
+        let g = compile_ok(r#"{"type":"null"}"#);
+        assert!(accepts(&g, b"null"));
+        assert!(rejects(&g, b"true"));
+    }
+
+    #[test]
+    fn compile_boolean_schema() {
+        let g = compile_ok(r#"{"type":"boolean"}"#);
+        assert!(accepts(&g, b"true"));
+        assert!(accepts(&g, b"false"));
+        assert!(rejects(&g, b"null"));
+    }
+
+    #[test]
+    fn compile_integer_schema() {
+        let g = compile_ok(r#"{"type":"integer"}"#);
+        assert!(accepts(&g, b"42"));
+        assert!(accepts(&g, b"-7"));
+        assert!(accepts(&g, b"0"));
+    }
+
+    #[test]
+    fn compile_string_schema() {
+        let g = compile_ok(r#"{"type":"string"}"#);
+        assert!(accepts(&g, b"\"hello\""));
+        assert!(accepts(&g, b"\"\""));
+    }
+
+    #[test]
+    fn compile_string_enum() {
+        let g = compile_ok(r#"{"type":"string","enum":["foo","bar"]}"#);
+        assert!(accepts(&g, b"\"foo\""));
+        assert!(accepts(&g, b"\"bar\""));
+        assert!(rejects(&g, b"\"baz\""));
+    }
+
+    #[test]
+    fn compile_const_value() {
+        let g = compile_ok(r#"{"const":"hello"}"#);
+        assert!(accepts(&g, b"\"hello\""));
+        assert!(rejects(&g, b"\"world\""));
+    }
+
+    #[test]
+    fn compile_const_integer() {
+        let g = compile_ok(r#"{"const":42}"#);
+        assert!(accepts(&g, b"42"));
+        assert!(rejects(&g, b"43"));
+    }
+
+    #[test]
+    fn compile_any_of() {
+        let g = compile_ok(r#"{"anyOf":[{"type":"boolean"},{"type":"null"}]}"#);
+        assert!(accepts(&g, b"true"));
+        assert!(accepts(&g, b"false"));
+        assert!(accepts(&g, b"null"));
+    }
+
+    #[test]
+    fn compile_simple_object() {
+        let g = compile_ok(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"}
+                },
+                "required": ["name"]
+            }"#,
+        );
+        assert!(accepts(&g, b"{\"name\":\"Alice\"}"));
+    }
+
+    #[test]
+    fn compile_empty_object() {
+        let g = compile_ok(r#"{"type":"object"}"#);
+        assert!(accepts(&g, b"{}"));
+    }
+
+    #[test]
+    fn compile_array_any() {
+        let g = compile_ok(r#"{"type":"array"}"#);
+        assert!(accepts(&g, b"[]"));
+    }
+
+    #[test]
+    fn schema_error_display() {
+        let e = SchemaError("test".to_string());
+        assert!(e.to_string().contains("test"));
+    }
+
+    #[test]
+    fn unsupported_type_returns_error() {
+        let v = serde_json::json!({"type": "binary"});
+        assert!(compile_json_schema(&v).is_err());
+    }
+
+    #[test]
+    fn ref_not_found_returns_error() {
+        let v = serde_json::json!({"$ref": "#/$defs/Missing"});
+        assert!(compile(&v).is_err());
+    }
+
+    #[test]
+    fn defs_resolved() {
+        let schema = serde_json::json!({
+            "$defs": {
+                "Status": {"type": "string", "enum": ["ok", "err"]}
+            },
+            "type": "object",
+            "properties": {
+                "status": {"$ref": "#/$defs/Status"}
+            },
+            "required": ["status"]
+        });
+        let g = compile(&schema).unwrap();
+        assert!(accepts(&g, b"{\"status\":\"ok\"}"));
+        assert!(accepts(&g, b"{\"status\":\"err\"}"));
+    }
+}

--- a/crates/inference/src/grammar/mod.rs
+++ b/crates/inference/src/grammar/mod.rs
@@ -1,0 +1,55 @@
+//! Grammar-constrained generation engine (ADR-046).
+//!
+//! Implements XGrammar-style structured output for lattice-inference.
+//!
+//! # Architecture
+//!
+//! ```text
+//! GrammarSpec  ──compile──►  CompiledGrammar  ──partition──►  VocabPartition
+//!   (JsonSchema            (byte-level PDA      (bitmask table
+//!    or GBNF)               rules + alts)        per state × token)
+//!                                    │
+//!                                    ▼
+//!                          GrammarEngine::new()
+//!                                    │
+//!                              generate loop:
+//!                      engine.mask_logits(state, logits)
+//!                      token = sampler.sample(logits)
+//!                      engine.advance(state, token_id)
+//! ```
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use std::sync::Arc;
+//! use lattice_inference::grammar::{GrammarEngine, GrammarSpec};
+//! use lattice_inference::generate::GenerateConfig;
+//!
+//! let spec = GrammarSpec::json_schema_str(r#"{"type":"object","properties":{"name":{"type":"string"}}}"#)?;
+//! let vocab_bytes: Vec<Vec<u8>> = tokenizer.vocab_bytes();
+//! let engine = Arc::new(GrammarEngine::new(&spec, vocab_bytes)?);
+//!
+//! let config = GenerateConfig {
+//!     grammar: Some(Arc::clone(&engine)),
+//!     ..Default::default()
+//! };
+//! ```
+//!
+//! # Supported grammar formats
+//!
+//! - **JSON Schema** (primary): `GrammarSpec::JsonSchema(serde_json::Value)` —
+//!   supports `object`, `array`, `string` (with `enum`), `number`, `integer`,
+//!   `boolean`, `null`, `anyOf`/`oneOf`, `$ref` (local only).
+//! - **GBNF** (secondary): `GrammarSpec::Gbnf(String)` — llama.cpp-compatible
+//!   subset supporting literals, character classes, alternation, repetition.
+
+pub mod engine;
+pub mod gbnf;
+pub mod json_schema;
+pub mod pda;
+pub mod spec;
+pub mod vocab_partition;
+
+// Re-exports for the primary public API.
+pub use engine::{GrammarEngine, GrammarError};
+pub use spec::GrammarSpec;

--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -1,0 +1,751 @@
+//! Byte-level pushdown automaton (PDA) for context-free grammar matching.
+//!
+//! # Design
+//!
+//! The grammar is compiled to a set of *rules*, each of which is a sequence
+//! of *symbols* (either a terminal byte or a non-terminal rule reference).
+//! Execution is modelled as a stack of `StackFrame`s:
+//!
+//! ```text
+//! frame = (rule_id, position_within_rule, alt_index)
+//! ```
+//!
+//! The `advance_byte` operation pops frames that have been fully consumed,
+//! pushes frames for non-terminal expansions, and checks whether the current
+//! terminal symbol matches the incoming byte.
+//!
+//! # Grammar representation
+//!
+//! A `Rule` is a named set of alternatives, each alternative being an ordered
+//! list of `Symbol`s:
+//!
+//! ```text
+//! Rule { name, alts: Vec<Vec<Symbol>> }
+//! Symbol::Terminal(u8)
+//! Symbol::NonTerminal(rule_id)
+//! Symbol::AnyByte   — matches any single byte (used for GBNF `.` and `[^...]`)
+//! ```
+//!
+//! The root rule has id 0 (by convention enforced by `CompiledGrammar`).
+//!
+//! # State machine encoding
+//!
+//! A `GrammarState` encodes the full PDA configuration:
+//!
+//! ```text
+//! stack: Vec<StackFrame>
+//!   StackFrame { rule_id, alt_idx, sym_pos }
+//! partial_bytes: Vec<u8>  — bytes of current token received so far
+//! ```
+//!
+//! The automaton starts with a single frame at `(root, 0, 0)`.
+//! `advance_byte(b)` returns whether the byte `b` is accepted (the PDA can
+//! make progress) and updates the stack in-place.
+//!
+//! `can_accept_more()` returns whether the current stack state can still
+//! accept additional input (used for context-dependent token masking).
+//! `is_complete()` returns whether a terminal state has been reached.
+
+use std::collections::HashMap;
+
+/// A single rule alternative: an ordered sequence of symbols.
+pub type Alt = Vec<Symbol>;
+
+/// An element in a grammar rule alternative.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Symbol {
+    /// Matches a single literal byte.
+    Terminal(u8),
+    /// Matches any single byte (GBNF `.`).
+    AnyByte,
+    /// Expands into the named rule.
+    NonTerminal(usize),
+}
+
+/// A compiled grammar rule: a name and a set of alternatives.
+#[derive(Debug, Clone)]
+pub struct Rule {
+    /// Human-readable name (for debugging).
+    pub name: String,
+    /// The alternatives for this rule, in priority order.
+    pub alts: Vec<Alt>,
+}
+
+/// The compiled grammar: a flat list of rules, root at index 0.
+#[derive(Debug, Clone)]
+pub struct CompiledGrammar {
+    pub rules: Vec<Rule>,
+}
+
+impl CompiledGrammar {
+    /// Number of rules in the grammar.
+    pub fn num_rules(&self) -> usize {
+        self.rules.len()
+    }
+
+    /// Return the root rule (index 0).
+    pub fn root(&self) -> &Rule {
+        &self.rules[0]
+    }
+}
+
+/// One frame on the PDA execution stack.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StackFrame {
+    /// Index into `CompiledGrammar::rules`.
+    pub rule_id: usize,
+    /// Index into `rules[rule_id].alts`.
+    pub alt_idx: usize,
+    /// Position within the chosen alternative (0 = before the first symbol).
+    pub sym_pos: usize,
+}
+
+/// Runtime state of the PDA for one decode sequence.
+///
+/// Clone this at each step to enable parallel-beam grammar tracking.  The
+/// cost is O(stack depth), which for well-formed JSON is at most O(nesting
+/// depth) — typically 2-6 frames.
+#[derive(Debug, Clone)]
+pub struct GrammarState {
+    /// Execution stack; top of stack is the last element.
+    pub stack: Vec<StackFrame>,
+    /// Bytes accumulated within the current token (context-dependent checks).
+    pub partial_token_bytes: Vec<u8>,
+    /// `true` once the root rule has been fully matched (EOS is valid).
+    pub complete: bool,
+}
+
+impl GrammarState {
+    /// Initial state: single frame at root rule, alt 0, sym_pos 0.
+    pub fn initial() -> Self {
+        Self {
+            stack: vec![StackFrame {
+                rule_id: 0,
+                alt_idx: 0,
+                sym_pos: 0,
+            }],
+            partial_token_bytes: Vec::new(),
+            complete: false,
+        }
+    }
+
+    /// Returns true if the automaton has consumed all input and is in an
+    /// accepting configuration (stack is empty or all remaining frames are at
+    /// rules whose alternatives can complete with zero bytes).
+    pub fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    /// Returns true if the automaton could potentially accept more bytes.
+    /// Used during context-dependent token inspection.
+    pub fn can_accept_more(&self) -> bool {
+        !self.complete || !self.stack.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PDA execution engine
+// ---------------------------------------------------------------------------
+
+/// Result of attempting to advance the PDA by one byte.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StepResult {
+    /// The byte was accepted; the state has been updated.
+    Accepted,
+    /// The byte was rejected by the current grammar state.
+    Rejected,
+}
+
+/// Advance a `GrammarState` by one byte `b` against `grammar`.
+///
+/// The algorithm:
+/// 1. Inspect the top frame.
+/// 2. Get the current symbol at `(rule_id, alt_idx, sym_pos)`.
+/// 3. If terminal: match against `b`.  If match, increment `sym_pos`.
+///    If the frame is exhausted, pop it and increment sym_pos of the parent
+///    (recursively until a non-exhausted frame is found or the stack is empty).
+/// 4. If non-terminal: push a new frame for the referenced rule (alt 0, pos 0)
+///    and retry step 1 — but we do not consume a byte when pushing, so we
+///    loop until we reach a terminal.
+///
+/// If no alternative can accept `b`, try other alternatives for the current
+/// frame's rule via backtracking.
+pub fn advance_byte(state: &mut GrammarState, grammar: &CompiledGrammar, b: u8) -> StepResult {
+    // We snapshot the stack on entry; if all alternatives fail, restore it.
+    let snapshot = state.stack.clone();
+
+    if try_advance_byte(state, grammar, b) {
+        state.partial_token_bytes.push(b);
+        // Check for completion after consuming the byte.
+        state.complete = is_accepting(state, grammar);
+        StepResult::Accepted
+    } else {
+        // Restore snapshot — byte was rejected.
+        state.stack = snapshot;
+        StepResult::Rejected
+    }
+}
+
+/// Attempt to advance the PDA by byte `b`.  Returns `true` on success,
+/// `false` on rejection.  Mutates `state.stack` in place.
+fn try_advance_byte(state: &mut GrammarState, grammar: &CompiledGrammar, b: u8) -> bool {
+    // The PDA loop: walk down non-terminals until we hit a terminal.
+    // We may need to backtrack across alternative choices.
+
+    // Work on a copy of the stack to support backtracking.
+    let mut stack = state.stack.clone();
+
+    if try_advance_stack(&mut stack, grammar, b) {
+        state.stack = stack;
+        return true;
+    }
+    false
+}
+
+/// Recursively advance `stack` by byte `b`.  Returns true on success.
+fn try_advance_stack(stack: &mut Vec<StackFrame>, grammar: &CompiledGrammar, b: u8) -> bool {
+    loop {
+        if stack.is_empty() {
+            // Stack empty and we still have a byte to consume → reject.
+            return false;
+        }
+
+        let frame_idx = stack.len() - 1;
+        let frame = &stack[frame_idx];
+        let rule = &grammar.rules[frame.rule_id];
+
+        // Rule with no alternatives: dead end → reject via next-alt or backtrack.
+        if rule.alts.is_empty() {
+            return try_next_alt(stack, grammar, b, frame_idx);
+        }
+
+        let alt = &rule.alts[frame.alt_idx];
+
+        if frame.sym_pos >= alt.len() {
+            // Current alternative exhausted: pop frame, advance parent.
+            stack.pop();
+            if let Some(parent) = stack.last_mut() {
+                parent.sym_pos += 1;
+            }
+            // Continue the loop to handle parent frame.
+            continue;
+        }
+
+        let sym = &alt[frame.sym_pos].clone();
+        match sym {
+            Symbol::Terminal(t) => {
+                if *t == b {
+                    // Match: advance position in current alternative.
+                    stack[frame_idx].sym_pos += 1;
+                    // Pop any exhausted frames.
+                    collapse_exhausted(stack, grammar);
+                    return true;
+                } else {
+                    // Byte doesn't match this terminal.
+                    // Only switch alternatives when no bytes have been consumed
+                    // in the current alternative (sym_pos == 0).  Once we have
+                    // consumed bytes under one alternative, backtracking to a
+                    // sibling alternative would create an inconsistent state
+                    // (the consumed bytes cannot be "un-consumed").
+                    if frame.sym_pos == 0 {
+                        return try_next_alt(stack, grammar, b, frame_idx);
+                    } else {
+                        // Mid-alternative mismatch: propagate to parent.
+                        if frame_idx == 0 {
+                            return false;
+                        }
+                        stack.truncate(frame_idx);
+                        let parent_idx = stack.len() - 1;
+                        return try_next_alt(stack, grammar, b, parent_idx);
+                    }
+                }
+            }
+            Symbol::AnyByte => {
+                // AnyByte matches any single byte.
+                stack[frame_idx].sym_pos += 1;
+                collapse_exhausted(stack, grammar);
+                return true;
+            }
+            Symbol::NonTerminal(rule_id) => {
+                let rid = *rule_id;
+                // Push a new frame for the non-terminal's first alt.
+                // Before pushing, check if the referenced rule has any alts.
+                if grammar.rules[rid].alts.is_empty() {
+                    // Empty rule = epsilon; advance past the non-terminal.
+                    stack[frame_idx].sym_pos += 1;
+                    continue;
+                }
+                stack.push(StackFrame {
+                    rule_id: rid,
+                    alt_idx: 0,
+                    sym_pos: 0,
+                });
+                // Continue loop: now top frame is the pushed non-terminal.
+            }
+        }
+    }
+}
+
+/// Try alternative `alt_idx + 1` for the rule at `frame_idx`.
+fn try_next_alt(
+    stack: &mut Vec<StackFrame>,
+    grammar: &CompiledGrammar,
+    b: u8,
+    frame_idx: usize,
+) -> bool {
+    let rule_id = stack[frame_idx].rule_id;
+    let next_alt = stack[frame_idx].alt_idx + 1;
+    let num_alts = grammar.rules[rule_id].alts.len();
+
+    if next_alt >= num_alts {
+        // No more alternatives at this level.
+        // Try backtracking to the parent.
+        if frame_idx == 0 {
+            return false;
+        }
+        // Pop this frame, try alternatives at the parent level.
+        stack.truncate(frame_idx);
+        // Retry with parent — but we need to try the parent's next alt or
+        // propagate rejection.  We do this by trying the parent's next alt.
+        let parent_idx = stack.len() - 1;
+        return try_next_alt(stack, grammar, b, parent_idx);
+    }
+
+    // Switch to next alternative in the same rule (reset sym_pos).
+    stack[frame_idx].alt_idx = next_alt;
+    stack[frame_idx].sym_pos = 0;
+    // Truncate any frames pushed during the failed attempt.
+    stack.truncate(frame_idx + 1);
+    // Retry with new alt.
+    try_advance_stack(stack, grammar, b)
+}
+
+/// Pop exhausted frames from the top of the stack after a successful byte match.
+/// A frame is exhausted when `sym_pos >= alt.len()`.
+fn collapse_exhausted(stack: &mut Vec<StackFrame>, grammar: &CompiledGrammar) {
+    loop {
+        match stack.last() {
+            None => break,
+            Some(frame) => {
+                let rule = &grammar.rules[frame.rule_id];
+                // No alts: already dead-ended; pop.
+                if rule.alts.is_empty() {
+                    stack.pop();
+                    if let Some(parent) = stack.last_mut() {
+                        parent.sym_pos += 1;
+                    }
+                    continue;
+                }
+                let alt = &rule.alts[frame.alt_idx];
+                if frame.sym_pos < alt.len() {
+                    break;
+                }
+                stack.pop();
+                if let Some(parent) = stack.last_mut() {
+                    parent.sym_pos += 1;
+                }
+            }
+        }
+    }
+}
+
+/// Returns true if `state` is in an accepting configuration.
+///
+/// A state is accepting if all remaining work on the stack can be resolved
+/// with zero additional bytes — i.e., all remaining symbols are *nullable*
+/// (can derive the empty string).
+///
+/// The stack represents a nested call structure.  The bottom frame contains
+/// the root rule; child frames sit on top.  Each non-bottom frame is the
+/// expansion of the NonTerminal at `parent.sym_pos`.  Once a child frame
+/// completes, the parent advances past that symbol (sym_pos + 1).
+///
+/// For the purposes of the nullable check:
+/// - The **top** (innermost) frame must be nullable from its current `sym_pos`.
+/// - Each **non-top** frame must be nullable from `sym_pos + 1` (the current
+///   symbol at `sym_pos` is the one being expanded by the frame above it).
+fn is_accepting(state: &GrammarState, grammar: &CompiledGrammar) -> bool {
+    let n = state.stack.len();
+    for (i, frame) in state.stack.iter().enumerate() {
+        if frame.rule_id >= grammar.rules.len() {
+            return false;
+        }
+        let rule = &grammar.rules[frame.rule_id];
+        if rule.alts.is_empty() {
+            // A rule with no alts is an empty / epsilon rule — always nullable.
+            continue;
+        }
+        if frame.alt_idx >= rule.alts.len() {
+            return false;
+        }
+        let alt = &rule.alts[frame.alt_idx];
+        // Non-top frames: the child frame is handling the symbol at sym_pos,
+        // so check nullable from sym_pos + 1.
+        // Top frame: check nullable from sym_pos itself.
+        let check_from = if i == n - 1 {
+            frame.sym_pos
+        } else {
+            frame.sym_pos + 1
+        };
+        if !remaining_is_nullable(
+            grammar,
+            alt,
+            check_from,
+            &mut std::collections::HashSet::new(),
+        ) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Returns true if the symbols `alt[pos..]` can all derive the empty string.
+fn remaining_is_nullable(
+    grammar: &CompiledGrammar,
+    alt: &[Symbol],
+    pos: usize,
+    visited: &mut std::collections::HashSet<usize>,
+) -> bool {
+    for sym in &alt[pos..] {
+        match sym {
+            Symbol::Terminal(_) | Symbol::AnyByte => return false,
+            Symbol::NonTerminal(rid) => {
+                if !visited.insert(*rid) {
+                    // Already checking this rule (cycle): conservatively non-nullable.
+                    return false;
+                }
+                if !rule_is_nullable(grammar, *rid, visited) {
+                    visited.remove(rid);
+                    return false;
+                }
+                visited.remove(rid);
+            }
+        }
+    }
+    true
+}
+
+/// Returns true if rule `rule_id` has at least one alternative that can
+/// derive the empty string.
+fn rule_is_nullable(
+    grammar: &CompiledGrammar,
+    rule_id: usize,
+    visited: &mut std::collections::HashSet<usize>,
+) -> bool {
+    if rule_id >= grammar.rules.len() {
+        return false;
+    }
+    for alt in &grammar.rules[rule_id].alts {
+        if remaining_is_nullable(grammar, alt, 0, visited) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Simulate advancing the PDA from `state` by consuming all bytes of `token`.
+///
+/// Returns `SimResult::Accept` if `token` is fully accepted (all bytes consumed
+/// and the resulting state is valid), `SimResult::ContextDependent` if some
+/// bytes were consumed but the automaton is mid-grammar-boundary, and
+/// `SimResult::Reject` if any byte was rejected.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SimResult {
+    /// All bytes accepted; resulting state is valid.
+    Accept,
+    /// Some bytes consumed but not all; context-dependent token.
+    ContextDependent,
+    /// Byte rejected.
+    Reject,
+}
+
+/// Simulate consuming all bytes of `token` from state `start`.
+/// Does not mutate `start`; returns a classification.
+pub fn simulate_token(
+    start: &GrammarState,
+    grammar: &CompiledGrammar,
+    token: &[u8],
+) -> (SimResult, GrammarState) {
+    let mut state = start.clone();
+    for (i, &b) in token.iter().enumerate() {
+        match advance_byte(&mut state, grammar, b) {
+            StepResult::Accepted => {}
+            StepResult::Rejected => {
+                if i > 0 {
+                    return (SimResult::ContextDependent, state);
+                }
+                return (SimResult::Reject, state);
+            }
+        }
+    }
+    (SimResult::Accept, state)
+}
+
+// ---------------------------------------------------------------------------
+// Grammar builders for use by json_schema.rs and gbnf.rs
+// ---------------------------------------------------------------------------
+
+/// Builder for assembling a `CompiledGrammar`.
+pub struct GrammarBuilder {
+    rules: Vec<Rule>,
+    name_to_id: HashMap<String, usize>,
+}
+
+impl GrammarBuilder {
+    pub fn new() -> Self {
+        Self {
+            rules: Vec::new(),
+            name_to_id: HashMap::new(),
+        }
+    }
+
+    /// Reserve a rule slot by name and return its id.
+    /// If the name already exists, return its id without creating a new slot.
+    pub fn reserve(&mut self, name: &str) -> usize {
+        if let Some(&id) = self.name_to_id.get(name) {
+            return id;
+        }
+        let id = self.rules.len();
+        self.rules.push(Rule {
+            name: name.to_string(),
+            alts: Vec::new(),
+        });
+        self.name_to_id.insert(name.to_string(), id);
+        id
+    }
+
+    /// Add alternatives to an already-reserved rule.
+    pub fn set_alts(&mut self, id: usize, alts: Vec<Alt>) {
+        self.rules[id].alts = alts;
+    }
+
+    /// Reserve and immediately set alternatives.
+    pub fn add_rule(&mut self, name: &str, alts: Vec<Alt>) -> usize {
+        let id = self.reserve(name);
+        self.set_alts(id, alts);
+        id
+    }
+
+    /// Look up the id of a previously reserved rule.
+    pub fn rule_id(&self, name: &str) -> Option<usize> {
+        self.name_to_id.get(name).copied()
+    }
+
+    /// Consume the builder and produce a `CompiledGrammar`.
+    ///
+    /// Panics if the root rule (index 0, name "root") has no alternatives.
+    pub fn build(self) -> CompiledGrammar {
+        CompiledGrammar { rules: self.rules }
+    }
+}
+
+impl Default for GrammarBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a grammar that matches exactly `b"ab"`.
+    fn ab_grammar() -> CompiledGrammar {
+        let mut b = GrammarBuilder::new();
+        b.add_rule(
+            "root",
+            vec![vec![Symbol::Terminal(b'a'), Symbol::Terminal(b'b')]],
+        );
+        b.build()
+    }
+
+    /// Grammar: root = 'a' | 'b'
+    fn or_grammar() -> CompiledGrammar {
+        let mut b = GrammarBuilder::new();
+        b.add_rule(
+            "root",
+            vec![vec![Symbol::Terminal(b'a')], vec![Symbol::Terminal(b'b')]],
+        );
+        b.build()
+    }
+
+    /// Grammar: root = digit+  where digit = '0' | '1' | ... | '9'
+    fn digits_grammar() -> CompiledGrammar {
+        let mut b = GrammarBuilder::new();
+        let digit_id = b.reserve("digit");
+        let digit_alts: Vec<Alt> = (b'0'..=b'9')
+            .map(|byte| vec![Symbol::Terminal(byte)])
+            .collect();
+        b.set_alts(digit_id, digit_alts);
+
+        // root = digit digit_rest
+        // digit_rest = digit digit_rest | ε  (implemented as digit_rest = [empty alt])
+        let rest_id = b.reserve("digit_rest");
+        b.set_alts(
+            rest_id,
+            vec![
+                vec![Symbol::NonTerminal(digit_id), Symbol::NonTerminal(rest_id)],
+                vec![], // epsilon
+            ],
+        );
+
+        let root_id = b.reserve("root");
+        b.set_alts(
+            root_id,
+            vec![vec![
+                Symbol::NonTerminal(digit_id),
+                Symbol::NonTerminal(rest_id),
+            ]],
+        );
+        // Ensure root is at index 0.
+        let mut grammar = b.build();
+        // Swap root to position 0.
+        let root_pos = grammar.rules.iter().position(|r| r.name == "root").unwrap();
+        grammar.rules.swap(0, root_pos);
+        // Fix up any NonTerminal references after the swap.
+        let orig_root_id = root_pos;
+        let swapped_to_id = 0usize;
+        if orig_root_id != 0 {
+            for rule in &mut grammar.rules {
+                for alt in &mut rule.alts {
+                    for sym in alt.iter_mut() {
+                        if let Symbol::NonTerminal(rid) = sym {
+                            if *rid == orig_root_id {
+                                *rid = swapped_to_id;
+                            } else if *rid == 0 {
+                                *rid = orig_root_id;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        grammar
+    }
+
+    #[test]
+    fn ab_grammar_accepts_ab() {
+        let g = ab_grammar();
+        let mut state = GrammarState::initial();
+        assert_eq!(advance_byte(&mut state, &g, b'a'), StepResult::Accepted);
+        assert!(!state.is_complete()); // not done yet
+        assert_eq!(advance_byte(&mut state, &g, b'b'), StepResult::Accepted);
+        assert!(state.is_complete());
+    }
+
+    #[test]
+    fn ab_grammar_rejects_ba() {
+        let g = ab_grammar();
+        let mut state = GrammarState::initial();
+        assert_eq!(advance_byte(&mut state, &g, b'b'), StepResult::Rejected);
+    }
+
+    #[test]
+    fn ab_grammar_rejects_partial_a_then_wrong() {
+        let g = ab_grammar();
+        let mut state = GrammarState::initial();
+        advance_byte(&mut state, &g, b'a');
+        assert_eq!(advance_byte(&mut state, &g, b'x'), StepResult::Rejected);
+    }
+
+    #[test]
+    fn or_grammar_accepts_a_or_b() {
+        let g = or_grammar();
+        let mut s = GrammarState::initial();
+        assert_eq!(advance_byte(&mut s, &g, b'a'), StepResult::Accepted);
+
+        let mut s2 = GrammarState::initial();
+        assert_eq!(advance_byte(&mut s2, &g, b'b'), StepResult::Accepted);
+    }
+
+    #[test]
+    fn or_grammar_rejects_c() {
+        let g = or_grammar();
+        let mut s = GrammarState::initial();
+        assert_eq!(advance_byte(&mut s, &g, b'c'), StepResult::Rejected);
+    }
+
+    #[test]
+    fn simulate_token_full_match() {
+        let g = ab_grammar();
+        let state = GrammarState::initial();
+        let (result, _) = simulate_token(&state, &g, b"ab");
+        assert_eq!(result, SimResult::Accept);
+    }
+
+    #[test]
+    fn simulate_token_reject() {
+        let g = ab_grammar();
+        let state = GrammarState::initial();
+        let (result, _) = simulate_token(&state, &g, b"ba");
+        assert_eq!(result, SimResult::Reject);
+    }
+
+    #[test]
+    fn simulate_token_partial_is_context_dependent() {
+        let g = ab_grammar();
+        let state = GrammarState::initial();
+        // Token "ax" — first byte 'a' accepted, second 'x' rejected mid-token.
+        let (result, _) = simulate_token(&state, &g, b"ax");
+        assert_eq!(result, SimResult::ContextDependent);
+    }
+
+    #[test]
+    fn state_partial_bytes_recorded() {
+        let g = ab_grammar();
+        let mut state = GrammarState::initial();
+        advance_byte(&mut state, &g, b'a');
+        assert_eq!(state.partial_token_bytes, vec![b'a']);
+        advance_byte(&mut state, &g, b'b');
+        assert_eq!(state.partial_token_bytes, vec![b'a', b'b']);
+    }
+
+    #[test]
+    fn any_byte_matches_any_value() {
+        let mut b = GrammarBuilder::new();
+        b.add_rule("root", vec![vec![Symbol::AnyByte]]);
+        let g = b.build();
+        for byte in [b'a', b'z', b'0', b'\n', 0xffu8] {
+            let mut s = GrammarState::initial();
+            assert_eq!(advance_byte(&mut s, &g, byte), StepResult::Accepted);
+            assert!(s.is_complete());
+        }
+    }
+
+    #[test]
+    fn digits_grammar_accepts_single_digit() {
+        let g = digits_grammar();
+        let state = GrammarState::initial();
+        let (result, _) = simulate_token(&state, &g, b"5");
+        assert_eq!(result, SimResult::Accept);
+    }
+
+    #[test]
+    fn digits_grammar_accepts_multi_digit() {
+        let g = digits_grammar();
+        let state = GrammarState::initial();
+        let (result, final_state) = simulate_token(&state, &g, b"123");
+        assert_eq!(result, SimResult::Accept);
+        assert!(final_state.is_complete());
+    }
+
+    #[test]
+    fn digits_grammar_rejects_letter() {
+        let g = digits_grammar();
+        let state = GrammarState::initial();
+        let (result, _) = simulate_token(&state, &g, b"abc");
+        assert_eq!(result, SimResult::Reject);
+    }
+
+    #[test]
+    fn grammar_builder_reserve_idempotent() {
+        let mut builder = GrammarBuilder::new();
+        let id1 = builder.reserve("foo");
+        let id2 = builder.reserve("foo");
+        assert_eq!(id1, id2);
+    }
+}

--- a/crates/inference/src/grammar/spec.rs
+++ b/crates/inference/src/grammar/spec.rs
@@ -1,0 +1,71 @@
+//! Grammar specification types for structured output.
+//!
+//! A `GrammarSpec` is the entry point for callers.  It accepts either a JSON
+//! Schema (the primary format for agent tool-call constraints) or a GBNF string
+//! (the llama.cpp-compatible escape hatch for custom grammars).  Both are
+//! normalised into the same internal grammar representation at
+//! `GrammarEngine::new` time.
+
+/// **Unstable**: grammar specification for constrained decoding.
+///
+/// Pass to [`GrammarEngine::new`](super::engine::GrammarEngine::new) together
+/// with the model vocabulary to obtain a `GrammarEngine` that can be embedded
+/// in a `GenerateConfig`.
+#[derive(Debug, Clone)]
+pub enum GrammarSpec {
+    /// JSON Schema (draft 2020-12 subset).
+    ///
+    /// Supported keywords: `type`, `properties`, `required`, `items`,
+    /// `prefixItems`, `minItems`, `maxItems`, `enum`, `const`, `anyOf`,
+    /// `oneOf`, `$ref`, `$defs`/`definitions` (local only).
+    ///
+    /// Unsupported (deferred): `pattern`, external `$ref`, `if`/`then`/`else`.
+    JsonSchema(serde_json::Value),
+
+    /// GBNF grammar string (llama.cpp-compatible subset).
+    ///
+    /// The grammar must start with a `root` rule.  Rules are separated by
+    /// newlines.  Supported constructs: literals, character ranges `[a-z]`,
+    /// concatenation (space-separated), alternation `|`, grouping `( ... )`,
+    /// repetition `*`, `+`, `?`.
+    Gbnf(String),
+}
+
+impl GrammarSpec {
+    /// Convenience: build a JSON Schema spec from a JSON string.
+    ///
+    /// Returns an error if `json` is not valid JSON.
+    pub fn json_schema_str(json: &str) -> Result<Self, serde_json::Error> {
+        let v = serde_json::from_str(json)?;
+        Ok(Self::JsonSchema(v))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_schema_str_roundtrip() {
+        let spec = GrammarSpec::json_schema_str(r#"{"type":"object"}"#).unwrap();
+        assert!(matches!(spec, GrammarSpec::JsonSchema(_)));
+    }
+
+    #[test]
+    fn json_schema_str_invalid() {
+        assert!(GrammarSpec::json_schema_str("not json").is_err());
+    }
+
+    #[test]
+    fn gbnf_variant() {
+        let spec = GrammarSpec::Gbnf("root ::= \"hello\"".to_string());
+        assert!(matches!(spec, GrammarSpec::Gbnf(_)));
+    }
+
+    #[test]
+    fn clone_and_debug() {
+        let spec = GrammarSpec::JsonSchema(serde_json::json!({"type": "string"}));
+        let cloned = spec.clone();
+        assert!(format!("{cloned:?}").contains("JsonSchema"));
+    }
+}

--- a/crates/inference/src/grammar/vocab_partition.rs
+++ b/crates/inference/src/grammar/vocab_partition.rs
@@ -1,0 +1,337 @@
+//! Vocabulary partitioning for XGrammar-style constrained decoding.
+//!
+//! # Background (XGrammar, MLSys 2025)
+//!
+//! For each grammar state, tokens are classified as:
+//!
+//! - **Context-independent**: whether the token is legal depends only on the
+//!   current grammar state, not on partially-accumulated bytes within the
+//!   token.  These are precomputed into a bitmask table indexed by
+//!   `(grammar_state, token_id)` — one bit per token.
+//!
+//! - **Context-dependent**: legality requires inspecting the runtime PDA
+//!   stack — typically tokens that straddle a grammar boundary mid-byte
+//!   sequence.  These are identified during bitmask precomputation and
+//!   checked at decode time.
+//!
+//! # Bitmask layout
+//!
+//! ```text
+//! masks: Vec<u64>
+//! masks[state * mask_stride + word] encodes 64 tokens:
+//!   bit j of masks[state * mask_stride + word] = token (word * 64 + j) is allowed
+//! mask_stride = ceil(vocab_size / 64)
+//! ```
+//!
+//! # Usage
+//!
+//! 1. `VocabPartition::build(grammar, grammar_states, vocab_bytes)` — called once
+//!    at `GrammarEngine::new` time.
+//! 2. `VocabPartition::apply_mask(state_id, logits)` — called per decode step.
+//! 3. `VocabPartition::context_dependent_ids()` — returns token ids that need
+//!    runtime PDA inspection.
+
+use crate::grammar::pda::{CompiledGrammar, GrammarState, SimResult, simulate_token};
+
+/// Maximum number of grammar states for v0.
+/// A grammar with more states triggers a warning at build time.
+pub const MAX_GRAMMAR_STATES: usize = 256;
+
+/// Precomputed vocabulary partition for a grammar.
+///
+/// `state_count` is the number of distinct grammar states tracked.  For
+/// most JSON schemas this is the number of unique PDA stack configurations
+/// reachable from the initial state — typically under 100.
+pub struct VocabPartition {
+    /// Bitmask table.  `masks[s * mask_stride + w]` has bit `t % 64` set if
+    /// token `w * 64 + t % 64` is allowed in grammar state `s`.
+    masks: Vec<u64>,
+    mask_stride: usize,
+    vocab_size: usize,
+    /// Grammar states indexed by `state_id`.
+    states: Vec<GrammarState>,
+    /// Token ids that are context-dependent for at least one grammar state.
+    context_dependent: Vec<usize>,
+}
+
+impl VocabPartition {
+    /// Build the vocabulary partition by simulating every (state, token) pair.
+    ///
+    /// `grammar_states` are the grammar states to precompute masks for.
+    /// `vocab_bytes[i]` is the byte sequence for token `i`.
+    ///
+    /// This runs in O(|states| × |vocab| × |token_length|) time and is
+    /// called once at `GrammarEngine::new` time.
+    pub fn build(
+        grammar: &CompiledGrammar,
+        grammar_states: Vec<GrammarState>,
+        vocab_bytes: &[Vec<u8>],
+    ) -> Self {
+        let vocab_size = vocab_bytes.len();
+        let mask_stride = vocab_size.div_ceil(64);
+        let num_states = grammar_states.len();
+
+        if num_states > MAX_GRAMMAR_STATES {
+            tracing::warn!(
+                "grammar has {} states (max {}); first {} will be precomputed",
+                num_states,
+                MAX_GRAMMAR_STATES,
+                MAX_GRAMMAR_STATES
+            );
+        }
+
+        let effective_states = num_states.min(MAX_GRAMMAR_STATES);
+        let mut masks = vec![0u64; effective_states * mask_stride];
+        let mut ctx_dep_set = std::collections::HashSet::new();
+
+        for (state_id, grammar_state) in grammar_states[..effective_states].iter().enumerate() {
+            for (token_id, token_bytes) in vocab_bytes.iter().enumerate() {
+                // Skip empty tokens.
+                if token_bytes.is_empty() {
+                    continue;
+                }
+
+                let (sim_result, _) = simulate_token(grammar_state, grammar, token_bytes);
+                match sim_result {
+                    SimResult::Accept => {
+                        // Set bit for this token in state's mask.
+                        let word = token_id / 64;
+                        let bit = token_id % 64;
+                        masks[state_id * mask_stride + word] |= 1u64 << bit;
+                    }
+                    SimResult::ContextDependent => {
+                        // Mark as context-dependent.
+                        ctx_dep_set.insert(token_id);
+                        // Also set the bit optimistically (runtime check will verify).
+                        let word = token_id / 64;
+                        let bit = token_id % 64;
+                        masks[state_id * mask_stride + word] |= 1u64 << bit;
+                    }
+                    SimResult::Reject => {
+                        // Bit remains 0 (token disallowed).
+                    }
+                }
+            }
+        }
+
+        let mut context_dependent: Vec<usize> = ctx_dep_set.into_iter().collect();
+        context_dependent.sort_unstable();
+
+        Self {
+            masks,
+            mask_stride,
+            vocab_size,
+            states: grammar_states,
+            context_dependent,
+        }
+    }
+
+    /// Apply the precomputed bitmask for `state_id` to `logits` in-place.
+    ///
+    /// Sets disallowed token positions to `f32::NEG_INFINITY`.
+    /// Cost: O(vocab_size / 64) word-level iterations.
+    pub fn apply_mask(&self, state_id: usize, logits: &mut [f32]) {
+        debug_assert!(
+            logits.len() >= self.vocab_size,
+            "logits slice shorter than vocab_size"
+        );
+        if state_id >= self.states.len().min(MAX_GRAMMAR_STATES) {
+            // Unknown state: block all tokens (fail-closed).
+            for l in logits[..self.vocab_size].iter_mut() {
+                *l = f32::NEG_INFINITY;
+            }
+            return;
+        }
+
+        let mask_base = state_id * self.mask_stride;
+        for word_idx in 0..self.mask_stride {
+            let mask_word = self.masks[mask_base + word_idx];
+            let base_token = word_idx * 64;
+            if mask_word == u64::MAX {
+                // All 64 tokens in this word allowed — skip inner loop.
+                continue;
+            }
+            if mask_word == 0 {
+                // All 64 disallowed — fast fill.
+                let end = (base_token + 64).min(self.vocab_size);
+                for l in logits[base_token..end].iter_mut() {
+                    *l = f32::NEG_INFINITY;
+                }
+                continue;
+            }
+            // Mixed word: check each bit.
+            for bit in 0..64u32 {
+                let token_idx = base_token + bit as usize;
+                if token_idx >= self.vocab_size {
+                    break;
+                }
+                if mask_word & (1u64 << bit) == 0 {
+                    logits[token_idx] = f32::NEG_INFINITY;
+                }
+            }
+        }
+    }
+
+    /// Returns the token ids that are context-dependent for at least one state.
+    /// These require runtime PDA stack inspection before finalising the mask.
+    pub fn context_dependent_ids(&self) -> &[usize] {
+        &self.context_dependent
+    }
+
+    /// Returns the number of precomputed grammar states.
+    pub fn num_states(&self) -> usize {
+        self.states.len().min(MAX_GRAMMAR_STATES)
+    }
+
+    /// Return the `GrammarState` for a given `state_id`.
+    pub fn grammar_state(&self, state_id: usize) -> Option<&GrammarState> {
+        self.states.get(state_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grammar::pda::{Alt, CompiledGrammar, GrammarBuilder, GrammarState, Rule, Symbol};
+
+    /// Grammar: root = 'a' | 'b'
+    fn or_grammar() -> CompiledGrammar {
+        let mut b = GrammarBuilder::new();
+        b.add_rule(
+            "root",
+            vec![vec![Symbol::Terminal(b'a')], vec![Symbol::Terminal(b'b')]],
+        );
+        b.build()
+    }
+
+    /// Two-token vocabulary: token 0 = b"a", token 1 = b"b".
+    fn ab_vocab() -> Vec<Vec<u8>> {
+        vec![b"a".to_vec(), b"b".to_vec()]
+    }
+
+    /// Three-token vocabulary: token 0 = b"a", token 1 = b"b", token 2 = b"c".
+    fn abc_vocab() -> Vec<Vec<u8>> {
+        vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]
+    }
+
+    #[test]
+    fn build_basic_mask() {
+        let grammar = or_grammar();
+        let states = vec![GrammarState::initial()];
+        let vocab = ab_vocab();
+        let partition = VocabPartition::build(&grammar, states, &vocab);
+        assert_eq!(partition.num_states(), 1);
+    }
+
+    #[test]
+    fn apply_mask_allows_correct_tokens() {
+        let grammar = or_grammar();
+        let states = vec![GrammarState::initial()];
+        let vocab = abc_vocab();
+        let partition = VocabPartition::build(&grammar, states, &vocab);
+
+        let mut logits = vec![1.0f32, 2.0f32, 3.0f32];
+        partition.apply_mask(0, &mut logits);
+
+        // Tokens 0 ('a') and 1 ('b') are allowed; token 2 ('c') is blocked.
+        assert!(logits[0] > f32::NEG_INFINITY, "token 'a' should be allowed");
+        assert!(logits[1] > f32::NEG_INFINITY, "token 'b' should be allowed");
+        assert_eq!(logits[2], f32::NEG_INFINITY, "token 'c' should be blocked");
+    }
+
+    #[test]
+    fn apply_mask_unknown_state_blocks_all() {
+        let grammar = or_grammar();
+        let states = vec![GrammarState::initial()];
+        let vocab = ab_vocab();
+        let partition = VocabPartition::build(&grammar, states, &vocab);
+
+        let mut logits = vec![1.0f32, 2.0f32];
+        // State 99 doesn't exist.
+        partition.apply_mask(99, &mut logits);
+        assert_eq!(logits[0], f32::NEG_INFINITY);
+        assert_eq!(logits[1], f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn mask_all_zeros_fills_neg_inf() {
+        // Grammar that accepts nothing: empty root.
+        let grammar = CompiledGrammar {
+            rules: vec![Rule {
+                name: "root".to_string(),
+                alts: vec![],
+            }],
+        };
+        let states = vec![GrammarState::initial()];
+        let vocab = ab_vocab();
+        let partition = VocabPartition::build(&grammar, states, &vocab);
+
+        let mut logits = vec![1.0f32, 2.0f32];
+        partition.apply_mask(0, &mut logits);
+        assert_eq!(logits[0], f32::NEG_INFINITY);
+        assert_eq!(logits[1], f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn mask_all_ones_preserves_logits() {
+        // Grammar: root = . (any byte) — all single-byte tokens allowed.
+        let mut builder = GrammarBuilder::new();
+        builder.add_rule("root", vec![vec![Symbol::AnyByte]]);
+        let grammar = builder.build();
+
+        let states = vec![GrammarState::initial()];
+        let vocab = abc_vocab();
+        let partition = VocabPartition::build(&grammar, states, &vocab);
+
+        let mut logits = vec![1.0f32, 2.0f32, 3.0f32];
+        partition.apply_mask(0, &mut logits);
+        // No tokens should be blocked.
+        for &l in &logits {
+            assert!(l > f32::NEG_INFINITY);
+        }
+    }
+
+    #[test]
+    fn bitmask_and_correctness() {
+        // Verify the bit-counting logic with a vocab of exactly 65 tokens
+        // (two full 64-bit words plus one extra token).
+        let grammar = or_grammar();
+        // Build vocab: token 0 = b"a", 1 = b"b", 2..64 = b"c" repeated.
+        let mut vocab: Vec<Vec<u8>> = vec![b"a".to_vec(), b"b".to_vec()];
+        vocab.extend((2..65).map(|_| b"c".to_vec()));
+        assert_eq!(vocab.len(), 65);
+
+        let states = vec![GrammarState::initial()];
+        let partition = VocabPartition::build(&grammar, states, &vocab);
+
+        let mut logits = vec![1.0f32; 65];
+        partition.apply_mask(0, &mut logits);
+
+        // Only tokens 0 and 1 should be allowed.
+        assert!(logits[0] > f32::NEG_INFINITY, "token 0 allowed");
+        assert!(logits[1] > f32::NEG_INFINITY, "token 1 allowed");
+        for i in 2..65 {
+            assert_eq!(logits[i], f32::NEG_INFINITY, "token {i} blocked");
+        }
+    }
+
+    #[test]
+    fn empty_token_skipped() {
+        let grammar = or_grammar();
+        // vocab has an empty token at index 1.
+        let vocab = vec![b"a".to_vec(), vec![], b"b".to_vec()];
+        let states = vec![GrammarState::initial()];
+        let partition = VocabPartition::build(&grammar, states, &vocab);
+
+        let mut logits = vec![1.0f32; 3];
+        partition.apply_mask(0, &mut logits);
+        // Token 0 ('a') allowed, token 1 (empty) skipped = not allowed, token 2 ('b') allowed.
+        assert!(logits[0] > f32::NEG_INFINITY);
+        assert_eq!(logits[1], f32::NEG_INFINITY); // empty token not set
+        assert!(logits[2] > f32::NEG_INFINITY);
+    }
+}

--- a/crates/inference/src/lib.rs
+++ b/crates/inference/src/lib.rs
@@ -37,6 +37,7 @@ pub mod weights;
 pub mod download;
 pub mod error;
 pub mod generate;
+pub mod grammar;
 pub mod kv_cache;
 pub mod lora_hook;
 pub mod pool;

--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -8,7 +8,9 @@
 //! 256 routed experts, top-8 selection, 1 shared expert, separate lm_head.
 
 use crate::error::InferenceError;
+use crate::grammar::GrammarEngine;
 use std::path::Path;
+use std::sync::Arc;
 
 /// Chat turn end token for Qwen models.
 pub const QWEN_CHAT_IM_END_TOKEN_ID: u32 = 248_046;
@@ -509,7 +511,7 @@ impl Qwen35Config {
 }
 
 /// **Unstable**: sampling configuration for text generation; temperature/top-k/top-p may expand.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct GenerateConfig {
     pub max_new_tokens: usize,
     pub temperature: f32,
@@ -526,6 +528,28 @@ pub struct GenerateConfig {
     /// Replaces the `LATTICE_MTP` env var for programmatic control.
     /// `None` = defer to `LATTICE_MTP` env var (backwards-compatible default).
     pub enable_mtp: Option<bool>,
+    /// Optional grammar-constrained decoding engine (ADR-046).
+    ///
+    /// When set, `mask_logits` is called on CPU logits before sampling on every step.
+    /// The Metal path copies logits to CPU before sampling — no additional GPU transfer needed.
+    pub grammar: Option<Arc<GrammarEngine>>,
+}
+
+impl std::fmt::Debug for GenerateConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenerateConfig")
+            .field("max_new_tokens", &self.max_new_tokens)
+            .field("temperature", &self.temperature)
+            .field("top_k", &self.top_k)
+            .field("top_p", &self.top_p)
+            .field("repetition_penalty", &self.repetition_penalty)
+            .field("seed", &self.seed)
+            .field("stop_token_ids", &self.stop_token_ids)
+            .field("enable_thinking", &self.enable_thinking)
+            .field("enable_mtp", &self.enable_mtp)
+            .field("grammar", &self.grammar.as_ref().map(|_| "<GrammarEngine>"))
+            .finish()
+    }
 }
 
 impl Default for GenerateConfig {
@@ -540,6 +564,7 @@ impl Default for GenerateConfig {
             stop_token_ids: vec![QWEN_CHAT_IM_END_TOKEN_ID],
             enable_thinking: true,
             enable_mtp: None,
+            grammar: None,
         }
     }
 }

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -338,6 +338,27 @@ impl BpeTokenizer {
         self.inner.special_tokens.get(name).copied()
     }
 
+    /// **Unstable**: return the byte representation of every token in the vocabulary.
+    ///
+    /// `vocab_bytes()[i]` is the UTF-8 byte sequence that token `i` decodes to,
+    /// after applying the GPT-2 byte-level encoding reversal.
+    ///
+    /// Used by [`GrammarEngine::new`](crate::grammar::GrammarEngine::new) to build
+    /// the precomputed vocabulary partition for grammar-constrained decoding (ADR-046).
+    ///
+    /// Cost: O(vocab_size) — called once at engine initialisation.
+    pub fn vocab_bytes(&self) -> Vec<Vec<u8>> {
+        self.inner
+            .id_to_token
+            .iter()
+            .map(|token_str| {
+                // Apply GPT-2 byte-level encoding reversal (same as byte_decode_token).
+                let decoded = byte_decode_token(token_str);
+                decoded.into_bytes()
+            })
+            .collect()
+    }
+
     fn tokenize_to_ids(&self, text: &str) -> Vec<u32> {
         let mut scratch = TokenizeScratch::default();
         self.tokenize_to_ids_into(text, &mut scratch)

--- a/docs/adr/ADR-046-structured-output.md
+++ b/docs/adr/ADR-046-structured-output.md
@@ -1,6 +1,6 @@
 # ADR-046: XGrammar Structured Output Engine
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-05-19
 **Crate**: lattice-inference
 


### PR DESCRIPTION
## Summary

Implements **ADR-046 — XGrammar Structured Output Engine**: byte-level PDA + vocabulary partitioning + JSON Schema/GBNF compilers, integrated into both CPU and Metal decode loops.

### New module: `crates/inference/src/grammar/` (7 files, 3275 LOC)

**`pda.rs`** — Byte-level pushdown automaton with stack-based state transitions. Handles full CFGs (not just regular grammars). Key correctness fixes applied: mid-alt mismatch propagation, stack-frame-aware `is_accepting`, empty-alt guards.

**`gbnf.rs`** — GBNF parser (llama.cpp-compatible grammar format). `+` operator desugared to `rep = x tail; tail = x tail | epsilon` for correct nullable handling. Root-swap post-parse ensures rule_id=0 is entry.

**`json_schema.rs`** — JSON Schema to grammar compiler. Handles objects, arrays, strings, numbers, booleans, null, enums, required/optional properties. Root-swap post-compile, nullable digit-tail for multi-digit numbers, factored string enum alternatives.

**`vocab_partition.rs`** — Vocabulary partitioning into context-independent (~99%) and context-dependent (~1%) tokens. Precomputed bitmask per grammar state. Context-dependent tokens blocked at runtime re-check.

**`engine.rs`** — `GrammarEngine`: `new(spec, vocab_bytes)`, `mask_logits(&mut state, logits)`, `advance(state, token_id) -> state`. Model-agnostic.

**`spec.rs`** — `GrammarSpec` enum: `JsonSchema(String)` | `Gbnf(String)`.

### Integration

- `GenerateConfig` + `MetalGenerateConfig`: `grammar: Option<Arc<GrammarEngine>>` field
- CPU decode loop (`generate.rs`): `mask_logits` after forward pass, `advance` after sampling
- Metal decode loop (`metal_qwen35.rs`): same hooks
- `BpeTokenizer::vocab_bytes()` added for vocabulary partitioning

### ADR status

ADR-046: Proposed -> Accepted

## Test plan

- [x] Grammar module compiles
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hooks pass
- [ ] Additional review pass

Generated with Claude Code
