### PR TITLE
feat(tune): batch LoRA training loop with train_lora API

### DIFF
--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -56,6 +56,11 @@ required-features = ["safetensors", "inference-hook"]
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "train_bench"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/tune/benches/train_bench.rs
+++ b/crates/tune/benches/train_bench.rs
@@ -1,0 +1,103 @@
+//! Benchmark for the batch LoRA training loop.
+//!
+//! Measures [`train_lora`] throughput as a function of sample count (batch_size
+//! parameter is informational; the loop is sequential).
+//!
+//! Groups:
+//!   lora/train_loop — num_epochs=5, batch_size ∈ {10, 50, 100}
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer};
+use lattice_tune::{LoraTrainConfig, TrainSample, train_lora};
+use std::collections::HashMap;
+
+const D_IN: usize = 64;
+const D_OUT: usize = 64;
+const RANK: usize = 4;
+const NUM_EPOCHS: usize = 5;
+
+/// Build a deterministic pseudo-random f32 from two indices (no external rand crate).
+fn pseudo_f32(seed: u64, idx: u64) -> f32 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    (seed, idx).hash(&mut h);
+    // Map to (-0.5, 0.5) so the initial weights are centred.
+    h.finish() as f32 / u64::MAX as f32 - 0.5
+}
+
+fn make_adapter() -> LoraAdapter {
+    let config = LoraConfig {
+        rank: RANK,
+        alpha: RANK as f32, // scale = 1.0
+        target_modules: vec!["q_proj".into()],
+    };
+    let mut layers = HashMap::new();
+    layers.insert(
+        (0usize, "q_proj".to_string()),
+        LoraLayer {
+            // A: (rank, d_in)
+            a: (0..(RANK * D_IN))
+                .map(|i| pseudo_f32(1, i as u64) * 0.01)
+                .collect(),
+            // B: (d_out, rank)
+            b: (0..(D_OUT * RANK))
+                .map(|i| pseudo_f32(2, i as u64) * 0.01)
+                .collect(),
+            d_in: D_IN,
+            d_out: D_OUT,
+            rank: RANK,
+        },
+    );
+    LoraAdapter::new(config, layers)
+}
+
+fn make_samples(n: usize) -> Vec<TrainSample> {
+    (0..n)
+        .map(|i| TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: (0..D_IN)
+                .map(|j| pseudo_f32(3 + i as u64, j as u64))
+                .collect(),
+            target_delta: (0..D_OUT)
+                .map(|j| pseudo_f32(1000 + i as u64, j as u64) * 0.1)
+                .collect(),
+        })
+        .collect()
+}
+
+fn bench_train_loop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lora/train_loop");
+
+    for &n_samples in &[10usize, 50, 100] {
+        let samples = make_samples(n_samples);
+
+        group.bench_with_input(
+            BenchmarkId::new("num_samples", n_samples),
+            &n_samples,
+            |b, _| {
+                b.iter(|| {
+                    // Re-create adapter each iteration so weights start fresh.
+                    let mut adapter = make_adapter();
+                    let config = LoraTrainConfig {
+                        learning_rate: 0.01,
+                        num_epochs: NUM_EPOCHS,
+                        batch_size: n_samples,
+                    };
+                    train_lora(
+                        black_box(&mut adapter),
+                        black_box(&samples),
+                        black_box(&config),
+                    )
+                    .expect("train_lora must not fail in bench")
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_train_loop);
+criterion_main!(benches);

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -149,7 +149,9 @@ pub use train::{
 pub use train::{GpuTrainer, GpuTrainerBuilder};
 
 // LoRA re-exports
-pub use lora::{LoraAdapter, LoraConfig, LoraLayer};
+pub use lora::{
+    LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+};
 
 // Registry re-exports
 pub use registry::{
@@ -168,7 +170,9 @@ pub mod prelude {
         LabelingResult, TeacherConfig, TeacherProvider,
     };
     pub use crate::error::{Result, TuneError};
-    pub use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    pub use crate::lora::{
+        LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+    };
     pub use crate::registry::{
         LiveModel, ModelMetadata, ModelRegistry, ModelStatus, RegisteredModel, RollbackController,
         RollbackRecord, ShadowComparison, ShadowConfig, ShadowSession, ShadowState, StorageBackend,

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -37,11 +37,13 @@ mod apply;
 pub mod online;
 #[cfg(feature = "safetensors")]
 mod safetensors;
+pub mod train;
 
 pub use apply::apply_lora;
 pub use online::{AdaptStepResult, adapt_step};
 #[cfg(feature = "safetensors")]
 pub use safetensors::{load_peft_safetensors, save_peft_safetensors};
+pub use train::{LoraTrainConfig, TrainResult, TrainSample, train_lora};
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -1,0 +1,252 @@
+//! Batch LoRA training loop (ADR-057, perf-opt-train-loop).
+//!
+//! Provides [`train_lora`] which iterates over a slice of [`TrainSample`]s for
+//! multiple epochs, calling [`adapt_step`] for each sample and accumulating per-epoch
+//! MSE loss statistics.
+
+use super::{LoraAdapter, online::adapt_step};
+use crate::error::TuneError;
+
+/// Configuration for a batch LoRA training run.
+#[derive(Debug, Clone)]
+pub struct LoraTrainConfig {
+    /// SGD step size applied inside each [`adapt_step`] call.
+    pub learning_rate: f32,
+    /// Number of full passes over the sample set.
+    pub num_epochs: usize,
+    /// Batch size (informational; does not affect the current sequential loop).
+    pub batch_size: usize,
+}
+
+/// A single training sample: one (input, target_delta) pair for one LoRA layer.
+#[derive(Debug, Clone)]
+pub struct TrainSample {
+    /// Transformer layer index (0-based).
+    pub layer_idx: usize,
+    /// Module name, e.g. `"q_proj"`.
+    pub module: String,
+    /// Input activation vector; length must equal the layer's `d_in`.
+    pub input: Vec<f32>,
+    /// Target LoRA output correction; length must equal the layer's `d_out`.
+    pub target_delta: Vec<f32>,
+}
+
+/// Summary statistics from a completed [`train_lora`] run.
+#[derive(Debug, Clone)]
+pub struct TrainResult {
+    /// Average MSE loss recorded in the final epoch.
+    pub final_loss: f32,
+    /// Average MSE loss per epoch (length == `num_epochs`).
+    pub epoch_losses: Vec<f32>,
+    /// Total number of [`adapt_step`] calls executed (`num_epochs * samples.len()`).
+    pub total_steps: usize,
+}
+
+/// Run a multi-epoch batch LoRA training loop.
+///
+/// Iterates over all `samples` in order for each epoch (no shuffling, ensuring
+/// deterministic behaviour), calling [`adapt_step`] once per sample and
+/// accumulating the per-step MSE loss.
+///
+/// # Arguments
+///
+/// * `adapter` – Mutable LoRA adapter whose weights are updated in place.
+/// * `samples` – Slice of training samples; must be non-empty.
+/// * `config`  – Hyper-parameters for the training run.
+///
+/// # Errors
+///
+/// * [`TuneError::Training`]         – `samples` is empty.
+/// * [`TuneError::InvalidConfig`]    – `batch_size == 0` or `num_epochs == 0`.
+/// * [`TuneError::Training`] – A sample references a `(layer_idx, module)` pair
+///   that is not present in the adapter.
+/// * [`TuneError::DimensionMismatch`] – A sample's `input` or `target_delta` has the
+///   wrong length for its LoRA layer.
+pub fn train_lora(
+    adapter: &mut LoraAdapter,
+    samples: &[TrainSample],
+    config: &LoraTrainConfig,
+) -> Result<TrainResult, TuneError> {
+    if samples.is_empty() {
+        return Err(TuneError::Training(
+            "no training samples provided".to_string(),
+        ));
+    }
+    if config.batch_size == 0 {
+        return Err(TuneError::InvalidConfig(
+            "batch_size must be > 0".to_string(),
+        ));
+    }
+    if config.num_epochs == 0 {
+        return Err(TuneError::InvalidConfig(
+            "num_epochs must be > 0".to_string(),
+        ));
+    }
+
+    let mut epoch_losses = Vec::with_capacity(config.num_epochs);
+
+    for _ in 0..config.num_epochs {
+        let mut epoch_loss_sum = 0.0f32;
+
+        for sample in samples {
+            let step_result = adapt_step(
+                adapter,
+                sample.layer_idx,
+                &sample.module,
+                &sample.input,
+                &sample.target_delta,
+                config.learning_rate,
+            )?;
+            epoch_loss_sum += step_result.loss;
+        }
+
+        let avg = epoch_loss_sum / samples.len() as f32;
+        epoch_losses.push(avg);
+    }
+
+    let final_loss = *epoch_losses
+        .last()
+        .expect("num_epochs > 0 guaranteed above");
+    let total_steps = config.num_epochs * samples.len();
+
+    Ok(TrainResult {
+        final_loss,
+        epoch_losses,
+        total_steps,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    use std::collections::HashMap;
+
+    /// rank=2, d_in=3, d_out=2, scale=1.0 (alpha=2.0, rank=2)
+    fn make_small_adapter() -> LoraAdapter {
+        let config = LoraConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["q_proj".into()],
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![
+                    1.0, 0.5, 0.0, // row 0
+                    0.0, 0.5, 1.0, // row 1
+                ],
+                b: vec![
+                    1.0, 0.0, // row 0
+                    0.0, 1.0, // row 1
+                ],
+                d_in: 3,
+                d_out: 2,
+                rank: 2,
+            },
+        );
+        LoraAdapter::new(config, layers)
+    }
+
+    /// Build a synthetic sample whose target_delta is the initial LoRA output for the given
+    /// input, slightly perturbed — this gives a reachable regression target without
+    /// requiring a warm-up forward pass from the caller.
+    fn make_samples(n: usize) -> Vec<TrainSample> {
+        // Use varied inputs so samples span different directions in weight-space.
+        (0..n)
+            .map(|i| {
+                let fi = i as f32;
+                TrainSample {
+                    layer_idx: 0,
+                    module: "q_proj".to_string(),
+                    // d_in = 3
+                    input: vec![fi * 0.1 + 0.1, fi * 0.2 + 0.2, fi * 0.3 + 0.3],
+                    // d_out = 2  — target is something the network can learn toward
+                    target_delta: vec![fi * 0.05, fi * 0.05 + 0.1],
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_train_convergence() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 10,
+            batch_size: 5,
+        };
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.epoch_losses.len(), 10);
+        assert_eq!(result.total_steps, 50);
+        assert!(
+            result.epoch_losses.last().unwrap() < result.epoch_losses.first().unwrap(),
+            "loss must decrease over 10 epochs: first={:.6}, last={:.6}",
+            result.epoch_losses.first().unwrap(),
+            result.epoch_losses.last().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_train_empty_batch() {
+        let mut adapter = make_small_adapter();
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 5,
+            batch_size: 1,
+        };
+
+        let err =
+            train_lora(&mut adapter, &[], &config).expect_err("empty samples must return Err");
+        assert!(
+            matches!(err, TuneError::Training(_)),
+            "expected Training variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_dimension_mismatch() {
+        let mut adapter = make_small_adapter();
+        // d_in for layer (0, "q_proj") is 3, but we pass a 2-element input.
+        let bad_samples = vec![TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: vec![1.0, 2.0], // wrong length (d_in=3)
+            target_delta: vec![1.0, 1.0],
+        }];
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 1,
+            batch_size: 1,
+        };
+
+        let err = train_lora(&mut adapter, &bad_samples, &config)
+            .expect_err("dimension mismatch must return Err");
+        assert!(
+            matches!(err, TuneError::DimensionMismatch { .. }),
+            "expected DimensionMismatch variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_metrics() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 3,
+            batch_size: 5,
+        };
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.total_steps, 15, "3 epochs × 5 samples = 15 steps");
+        assert_eq!(result.epoch_losses.len(), 3, "one loss entry per epoch");
+    }
+}

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -34,9 +34,9 @@ pub struct TrainSample {
 /// Summary statistics from a completed [`train_lora`] run.
 #[derive(Debug, Clone)]
 pub struct TrainResult {
-    /// Average MSE loss recorded in the final epoch.
+    /// Average per-sample SSE loss recorded in the final epoch.
     pub final_loss: f32,
-    /// Average MSE loss per epoch (length == `num_epochs`).
+    /// Average per-sample SSE loss per epoch (length == `num_epochs`).
     pub epoch_losses: Vec<f32>,
     /// Total number of [`adapt_step`] calls executed (`num_epochs * samples.len()`).
     pub total_steps: usize,
@@ -72,6 +72,11 @@ pub fn train_lora(
             "no training samples provided".to_string(),
         ));
     }
+    if !config.learning_rate.is_finite() || config.learning_rate <= 0.0 {
+        return Err(TuneError::InvalidConfig(
+            "learning_rate must be finite and positive".to_string(),
+        ));
+    }
     if config.batch_size == 0 {
         return Err(TuneError::InvalidConfig(
             "batch_size must be > 0".to_string(),
@@ -104,9 +109,10 @@ pub fn train_lora(
         epoch_losses.push(avg);
     }
 
-    let final_loss = *epoch_losses
+    let final_loss = epoch_losses
         .last()
-        .expect("num_epochs > 0 guaranteed above");
+        .copied()
+        .ok_or_else(|| TuneError::InvalidConfig("num_epochs produced no losses".into()))?;
     let total_steps = config.num_epochs * samples.len();
 
     Ok(TrainResult {
@@ -248,5 +254,25 @@ mod tests {
 
         assert_eq!(result.total_steps, 15, "3 epochs × 5 samples = 15 steps");
         assert_eq!(result.epoch_losses.len(), 3, "one loss entry per epoch");
+    }
+
+    #[test]
+    fn test_train_rejects_invalid_learning_rate() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(3);
+
+        for bad_lr in [0.0, -0.1, f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let config = LoraTrainConfig {
+                learning_rate: bad_lr,
+                num_epochs: 1,
+                batch_size: 1,
+            };
+            let err = train_lora(&mut adapter, &samples, &config)
+                .expect_err(&format!("lr={bad_lr} must be rejected"));
+            assert!(
+                matches!(err, TuneError::InvalidConfig(_)),
+                "expected InvalidConfig for lr={bad_lr}, got {err:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `train_lora()` in `crates/tune/src/lora/train.rs` — batch training over samples across epochs
- Calls `adapt_step` per sample, tracks per-epoch MSE loss
- Exports `LoraTrainConfig`, `TrainSample`, `TrainResult` from `lattice-tune`
- Includes criterion training benchmark (`crates/tune/benches/train_bench.rs`)

## Tests
- `test_train_convergence` — 10 epochs, loss decreases
- `test_train_empty_batch` — empty samples returns error
- `test_train_dimension_mismatch` — wrong input dims returns DimensionMismatch
- `test_train_metrics` — 3 epochs x 5 samples = 15 steps, 3 epoch_losses

## Merge sequence
**PR 6 of 10** — independent of inference PRs, merge after bench-baseline

## Test plan
- [ ] `cargo test -p lattice-tune` (all 4 new tests pass)
- [ ] `cargo clippy --workspace -- -D warnings`
- [ ] `RUSTC_WRAPPER= cargo bench -p lattice-tune --bench train_bench --no-run` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)