### PR TITLE
feat(tune): end-to-end LoRA lifecycle integration tests

### DIFF
--- a/benches/BASELINE.md
+++ b/benches/BASELINE.md
@@ -1,0 +1,73 @@
+# Lattice Performance Baseline
+
+**Date**: 2026-05-23
+**Commit**: ac38f20 (main, post ADR-057 LoRA lifecycle merge)
+**Platform**: Apple Silicon (aarch64 / Darwin)
+**Rust**: stable (release profile, LTO)
+
+## Inference Benchmarks (`lattice-inference`)
+
+### Attention Kernel (standard, synthetic)
+
+| Seq Len | Time/op  | Throughput    |
+| ------- | -------- | ------------- |
+| 16      | 96.6 us  | 31.8 Melem/s  |
+| 32      | 125.6 us | 97.8 Melem/s  |
+| 64      | 230.6 us | 213.1 Melem/s |
+| 128     | 506.1 us | 388.5 Melem/s |
+
+### Batch Encoding
+
+| Batch Size | Time/op  | Throughput   |
+| ---------- | -------- | ------------ |
+| 32         | 180.6 ms | 177.2 elem/s |
+
+### Logits Projection (matmul_bt)
+
+| Variant          | Time/op  | Throughput    |
+| ---------------- | -------- | ------------- |
+| scalar           | 443.5 ms | 1.15 Gelem/s  |
+| matmul_bt (SIMD) | 42.4 ms  | 11.99 Gelem/s |
+
+**matmul_bt speedup over scalar: 10.5x**
+
+### Tokenizer BPE
+
+| Input Size | Time/op  | Throughput   |
+| ---------- | -------- | ------------ |
+| 4096 chars | 111.7 us | 30.7 Melem/s |
+
+## Embed Benchmarks (`lattice-embed`)
+
+### SIMD Distance Operations (dim=768)
+
+| Operation             | Time/op | GFLOPS |
+| --------------------- | ------- | ------ |
+| cosine (scalar)       | 797 ns  | 2.9    |
+| cosine (SIMD, full)   | 31 ns   | 74.3   |
+| dot_product (f32)     | 26 ns   | 29.5   |
+| normalize (SIMD)      | 77 ns   | 15.0   |
+| euclidean_dist (SIMD) | 28 ns   | 41.1   |
+| dot_product (int8)    | 287 ns  | 2.7    |
+| cosine (int8)         | 370 ns  | 6.2    |
+
+**f32 cosine SIMD speedup: 25.7x over scalar**
+**int8 dot product: 2.2x over scalar** (room for improvement)
+
+## Key Observations
+
+1. **matmul_bt** is already well-optimized on macOS (Accelerate/AMX), 10.5x
+   over scalar
+2. **f32 SIMD** distance ops are excellent (25-40x speedup)
+3. **int8 SIMD** has significant room for improvement (only 2.2x)
+4. **Attention kernel** throughput scales well with seq_len
+5. **Elementwise ops** (rms_norm, silu, elementwise_mul) have NO SIMD paths —
+   pure scalar
+
+## Optimization Targets (prioritized)
+
+1. **Elementwise SIMD** — rms_norm, silu, elementwise_mul (0 SIMD, called
+   4x/layer/token)
+2. **Int8 dot product** — 2.2x vs target of ~8-10x
+3. **Attention decode path** — single-token (seq_len=1) specialization
+4. **matmul_bt non-macOS** — tiling improvements for Linux/aarch64

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -62,5 +62,9 @@ criterion = { version = "0.5", features = ["html_reports"] }
 name = "train_bench"
 harness = false
 
+[[bench]]
+name = "e2e_bench"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -56,6 +56,11 @@ required-features = ["safetensors", "inference-hook"]
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "train_bench"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/tune/benches/e2e_bench.rs
+++ b/crates/tune/benches/e2e_bench.rs
@@ -1,0 +1,116 @@
+//! End-to-end LoRA lifecycle benchmark: train → apply at varied ranks.
+//!
+//! Measures the full `train_lora` + `apply_lora` cycle for a realistic
+//! adapter size (d_in=64, d_out=64, 50 samples, 10 epochs) across
+//! ranks [2, 4, 8].
+//!
+//! Group: `lora/e2e_rank`
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer, apply_lora};
+use lattice_tune::{LoraTrainConfig, TrainSample, train_lora};
+use std::collections::HashMap;
+
+const D_IN: usize = 64;
+const D_OUT: usize = 64;
+const N_SAMPLES: usize = 50;
+const NUM_EPOCHS: usize = 10;
+
+/// Deterministic pseudo-random f32 in (-0.5, 0.5) — no external rand crate.
+fn pseudo_f32(seed: u64, idx: u64) -> f32 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    (seed, idx).hash(&mut h);
+    h.finish() as f32 / u64::MAX as f32 - 0.5
+}
+
+fn make_adapter(rank: usize) -> LoraAdapter {
+    let config = LoraConfig {
+        rank,
+        alpha: rank as f32, // scale = 1.0
+        target_modules: vec!["q_proj".into()],
+    };
+    let mut layers = HashMap::new();
+    layers.insert(
+        (0usize, "q_proj".to_string()),
+        LoraLayer {
+            a: (0..rank * D_IN)
+                .map(|i| pseudo_f32(1, i as u64) * 0.02)
+                .collect(),
+            b: (0..D_OUT * rank)
+                .map(|i| pseudo_f32(2, i as u64) * 0.02)
+                .collect(),
+            d_in: D_IN,
+            d_out: D_OUT,
+            rank,
+        },
+    );
+    LoraAdapter::new(config, layers)
+}
+
+fn make_samples() -> Vec<TrainSample> {
+    (0..N_SAMPLES)
+        .map(|i| TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: (0..D_IN)
+                .map(|j| pseudo_f32(3 + i as u64, j as u64))
+                .collect(),
+            target_delta: (0..D_OUT)
+                .map(|j| pseudo_f32(1000 + i as u64, j as u64) * 0.1)
+                .collect(),
+        })
+        .collect()
+}
+
+/// Fixed input vector for the apply phase.
+fn make_input() -> Vec<f32> {
+    (0..D_IN).map(|i| pseudo_f32(9999, i as u64)).collect()
+}
+
+fn bench_e2e_rank(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lora/e2e_rank");
+
+    let samples = make_samples();
+    let input = make_input();
+
+    for &rank in &[2usize, 4, 8] {
+        group.bench_with_input(BenchmarkId::new("rank", rank), &rank, |b, &rank| {
+            b.iter(|| {
+                // Train phase — re-create adapter each iteration for fresh weights.
+                let mut adapter = make_adapter(rank);
+                let train_cfg = LoraTrainConfig {
+                    learning_rate: 0.01,
+                    num_epochs: NUM_EPOCHS,
+                    batch_size: N_SAMPLES,
+                };
+                train_lora(
+                    black_box(&mut adapter),
+                    black_box(&samples),
+                    black_box(&train_cfg),
+                )
+                .expect("train_lora must not fail in bench");
+
+                // Apply phase — one forward pass with the trained adapter.
+                let layer = adapter
+                    .layers
+                    .get(&(0usize, "q_proj".to_string()))
+                    .expect("layer must exist");
+                let scale = adapter.config.scale();
+                let mut out = vec![0.0f32; D_OUT];
+                apply_lora(
+                    black_box(layer),
+                    black_box(scale),
+                    black_box(&input),
+                    black_box(&mut out),
+                );
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_e2e_rank);
+criterion_main!(benches);

--- a/crates/tune/benches/train_bench.rs
+++ b/crates/tune/benches/train_bench.rs
@@ -1,0 +1,103 @@
+//! Benchmark for the batch LoRA training loop.
+//!
+//! Measures [`train_lora`] throughput as a function of sample count (batch_size
+//! parameter is informational; the loop is sequential).
+//!
+//! Groups:
+//!   lora/train_loop — num_epochs=5, batch_size ∈ {10, 50, 100}
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer};
+use lattice_tune::{LoraTrainConfig, TrainSample, train_lora};
+use std::collections::HashMap;
+
+const D_IN: usize = 64;
+const D_OUT: usize = 64;
+const RANK: usize = 4;
+const NUM_EPOCHS: usize = 5;
+
+/// Build a deterministic pseudo-random f32 from two indices (no external rand crate).
+fn pseudo_f32(seed: u64, idx: u64) -> f32 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    (seed, idx).hash(&mut h);
+    // Map to (-0.5, 0.5) so the initial weights are centred.
+    h.finish() as f32 / u64::MAX as f32 - 0.5
+}
+
+fn make_adapter() -> LoraAdapter {
+    let config = LoraConfig {
+        rank: RANK,
+        alpha: RANK as f32, // scale = 1.0
+        target_modules: vec!["q_proj".into()],
+    };
+    let mut layers = HashMap::new();
+    layers.insert(
+        (0usize, "q_proj".to_string()),
+        LoraLayer {
+            // A: (rank, d_in)
+            a: (0..(RANK * D_IN))
+                .map(|i| pseudo_f32(1, i as u64) * 0.01)
+                .collect(),
+            // B: (d_out, rank)
+            b: (0..(D_OUT * RANK))
+                .map(|i| pseudo_f32(2, i as u64) * 0.01)
+                .collect(),
+            d_in: D_IN,
+            d_out: D_OUT,
+            rank: RANK,
+        },
+    );
+    LoraAdapter::new(config, layers)
+}
+
+fn make_samples(n: usize) -> Vec<TrainSample> {
+    (0..n)
+        .map(|i| TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: (0..D_IN)
+                .map(|j| pseudo_f32(3 + i as u64, j as u64))
+                .collect(),
+            target_delta: (0..D_OUT)
+                .map(|j| pseudo_f32(1000 + i as u64, j as u64) * 0.1)
+                .collect(),
+        })
+        .collect()
+}
+
+fn bench_train_loop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lora/train_loop");
+
+    for &n_samples in &[10usize, 50, 100] {
+        let samples = make_samples(n_samples);
+
+        group.bench_with_input(
+            BenchmarkId::new("num_samples", n_samples),
+            &n_samples,
+            |b, _| {
+                b.iter(|| {
+                    // Re-create adapter each iteration so weights start fresh.
+                    let mut adapter = make_adapter();
+                    let config = LoraTrainConfig {
+                        learning_rate: 0.01,
+                        num_epochs: NUM_EPOCHS,
+                        batch_size: n_samples,
+                    };
+                    train_lora(
+                        black_box(&mut adapter),
+                        black_box(&samples),
+                        black_box(&config),
+                    )
+                    .expect("train_lora must not fail in bench")
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_train_loop);
+criterion_main!(benches);

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -149,7 +149,9 @@ pub use train::{
 pub use train::{GpuTrainer, GpuTrainerBuilder};
 
 // LoRA re-exports
-pub use lora::{LoraAdapter, LoraConfig, LoraLayer};
+pub use lora::{
+    LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+};
 
 // Registry re-exports
 pub use registry::{
@@ -168,7 +170,9 @@ pub mod prelude {
         LabelingResult, TeacherConfig, TeacherProvider,
     };
     pub use crate::error::{Result, TuneError};
-    pub use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    pub use crate::lora::{
+        LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+    };
     pub use crate::registry::{
         LiveModel, ModelMetadata, ModelRegistry, ModelStatus, RegisteredModel, RollbackController,
         RollbackRecord, ShadowComparison, ShadowConfig, ShadowSession, ShadowState, StorageBackend,

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -37,11 +37,13 @@ mod apply;
 pub mod online;
 #[cfg(feature = "safetensors")]
 mod safetensors;
+pub mod train;
 
 pub use apply::apply_lora;
 pub use online::{AdaptStepResult, adapt_step};
 #[cfg(feature = "safetensors")]
 pub use safetensors::{load_peft_safetensors, save_peft_safetensors};
+pub use train::{LoraTrainConfig, TrainResult, TrainSample, train_lora};
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -1,0 +1,252 @@
+//! Batch LoRA training loop (ADR-057, perf-opt-train-loop).
+//!
+//! Provides [`train_lora`] which iterates over a slice of [`TrainSample`]s for
+//! multiple epochs, calling [`adapt_step`] for each sample and accumulating per-epoch
+//! MSE loss statistics.
+
+use super::{LoraAdapter, online::adapt_step};
+use crate::error::TuneError;
+
+/// Configuration for a batch LoRA training run.
+#[derive(Debug, Clone)]
+pub struct LoraTrainConfig {
+    /// SGD step size applied inside each [`adapt_step`] call.
+    pub learning_rate: f32,
+    /// Number of full passes over the sample set.
+    pub num_epochs: usize,
+    /// Batch size (informational; does not affect the current sequential loop).
+    pub batch_size: usize,
+}
+
+/// A single training sample: one (input, target_delta) pair for one LoRA layer.
+#[derive(Debug, Clone)]
+pub struct TrainSample {
+    /// Transformer layer index (0-based).
+    pub layer_idx: usize,
+    /// Module name, e.g. `"q_proj"`.
+    pub module: String,
+    /// Input activation vector; length must equal the layer's `d_in`.
+    pub input: Vec<f32>,
+    /// Target LoRA output correction; length must equal the layer's `d_out`.
+    pub target_delta: Vec<f32>,
+}
+
+/// Summary statistics from a completed [`train_lora`] run.
+#[derive(Debug, Clone)]
+pub struct TrainResult {
+    /// Average MSE loss recorded in the final epoch.
+    pub final_loss: f32,
+    /// Average MSE loss per epoch (length == `num_epochs`).
+    pub epoch_losses: Vec<f32>,
+    /// Total number of [`adapt_step`] calls executed (`num_epochs * samples.len()`).
+    pub total_steps: usize,
+}
+
+/// Run a multi-epoch batch LoRA training loop.
+///
+/// Iterates over all `samples` in order for each epoch (no shuffling, ensuring
+/// deterministic behaviour), calling [`adapt_step`] once per sample and
+/// accumulating the per-step MSE loss.
+///
+/// # Arguments
+///
+/// * `adapter` – Mutable LoRA adapter whose weights are updated in place.
+/// * `samples` – Slice of training samples; must be non-empty.
+/// * `config`  – Hyper-parameters for the training run.
+///
+/// # Errors
+///
+/// * [`TuneError::Training`]         – `samples` is empty.
+/// * [`TuneError::InvalidConfig`]    – `batch_size == 0` or `num_epochs == 0`.
+/// * [`TuneError::Training`] – A sample references a `(layer_idx, module)` pair
+///   that is not present in the adapter.
+/// * [`TuneError::DimensionMismatch`] – A sample's `input` or `target_delta` has the
+///   wrong length for its LoRA layer.
+pub fn train_lora(
+    adapter: &mut LoraAdapter,
+    samples: &[TrainSample],
+    config: &LoraTrainConfig,
+) -> Result<TrainResult, TuneError> {
+    if samples.is_empty() {
+        return Err(TuneError::Training(
+            "no training samples provided".to_string(),
+        ));
+    }
+    if config.batch_size == 0 {
+        return Err(TuneError::InvalidConfig(
+            "batch_size must be > 0".to_string(),
+        ));
+    }
+    if config.num_epochs == 0 {
+        return Err(TuneError::InvalidConfig(
+            "num_epochs must be > 0".to_string(),
+        ));
+    }
+
+    let mut epoch_losses = Vec::with_capacity(config.num_epochs);
+
+    for _ in 0..config.num_epochs {
+        let mut epoch_loss_sum = 0.0f32;
+
+        for sample in samples {
+            let step_result = adapt_step(
+                adapter,
+                sample.layer_idx,
+                &sample.module,
+                &sample.input,
+                &sample.target_delta,
+                config.learning_rate,
+            )?;
+            epoch_loss_sum += step_result.loss;
+        }
+
+        let avg = epoch_loss_sum / samples.len() as f32;
+        epoch_losses.push(avg);
+    }
+
+    let final_loss = *epoch_losses
+        .last()
+        .expect("num_epochs > 0 guaranteed above");
+    let total_steps = config.num_epochs * samples.len();
+
+    Ok(TrainResult {
+        final_loss,
+        epoch_losses,
+        total_steps,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    use std::collections::HashMap;
+
+    /// rank=2, d_in=3, d_out=2, scale=1.0 (alpha=2.0, rank=2)
+    fn make_small_adapter() -> LoraAdapter {
+        let config = LoraConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["q_proj".into()],
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![
+                    1.0, 0.5, 0.0, // row 0
+                    0.0, 0.5, 1.0, // row 1
+                ],
+                b: vec![
+                    1.0, 0.0, // row 0
+                    0.0, 1.0, // row 1
+                ],
+                d_in: 3,
+                d_out: 2,
+                rank: 2,
+            },
+        );
+        LoraAdapter::new(config, layers)
+    }
+
+    /// Build a synthetic sample whose target_delta is the initial LoRA output for the given
+    /// input, slightly perturbed — this gives a reachable regression target without
+    /// requiring a warm-up forward pass from the caller.
+    fn make_samples(n: usize) -> Vec<TrainSample> {
+        // Use varied inputs so samples span different directions in weight-space.
+        (0..n)
+            .map(|i| {
+                let fi = i as f32;
+                TrainSample {
+                    layer_idx: 0,
+                    module: "q_proj".to_string(),
+                    // d_in = 3
+                    input: vec![fi * 0.1 + 0.1, fi * 0.2 + 0.2, fi * 0.3 + 0.3],
+                    // d_out = 2  — target is something the network can learn toward
+                    target_delta: vec![fi * 0.05, fi * 0.05 + 0.1],
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_train_convergence() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 10,
+            batch_size: 5,
+        };
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.epoch_losses.len(), 10);
+        assert_eq!(result.total_steps, 50);
+        assert!(
+            result.epoch_losses.last().unwrap() < result.epoch_losses.first().unwrap(),
+            "loss must decrease over 10 epochs: first={:.6}, last={:.6}",
+            result.epoch_losses.first().unwrap(),
+            result.epoch_losses.last().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_train_empty_batch() {
+        let mut adapter = make_small_adapter();
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 5,
+            batch_size: 1,
+        };
+
+        let err =
+            train_lora(&mut adapter, &[], &config).expect_err("empty samples must return Err");
+        assert!(
+            matches!(err, TuneError::Training(_)),
+            "expected Training variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_dimension_mismatch() {
+        let mut adapter = make_small_adapter();
+        // d_in for layer (0, "q_proj") is 3, but we pass a 2-element input.
+        let bad_samples = vec![TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: vec![1.0, 2.0], // wrong length (d_in=3)
+            target_delta: vec![1.0, 1.0],
+        }];
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 1,
+            batch_size: 1,
+        };
+
+        let err = train_lora(&mut adapter, &bad_samples, &config)
+            .expect_err("dimension mismatch must return Err");
+        assert!(
+            matches!(err, TuneError::DimensionMismatch { .. }),
+            "expected DimensionMismatch variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_metrics() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 3,
+            batch_size: 5,
+        };
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.total_steps, 15, "3 epochs × 5 samples = 15 steps");
+        assert_eq!(result.epoch_losses.len(), 3, "one loss entry per epoch");
+    }
+}

--- a/crates/tune/tests/e2e_lora.rs
+++ b/crates/tune/tests/e2e_lora.rs
@@ -161,8 +161,6 @@ fn test_train_convergence_quality() {
 #[cfg(feature = "safetensors")]
 #[test]
 fn test_save_load_roundtrip() {
-    use lattice_tune::lora::{load_peft_safetensors, save_peft_safetensors};
-
     let mut adapter = make_test_adapter();
 
     // Train briefly so weights are non-trivial.

--- a/crates/tune/tests/e2e_lora.rs
+++ b/crates/tune/tests/e2e_lora.rs
@@ -1,0 +1,284 @@
+//! End-to-end LoRA lifecycle integration tests.
+//!
+//! Exercises the full pipeline: create adapter → train → apply → verify.
+//! Each test name describes the lifecycle phase it validates.
+
+use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer, apply_lora};
+use lattice_tune::{LoraTrainConfig, TrainSample, train_lora};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+/// rank=2, d_in=8, d_out=4 with non-zero initial weights so the initial
+/// apply_lora output is detectable before training begins.
+fn make_test_adapter() -> LoraAdapter {
+    let config = LoraConfig {
+        rank: 2,
+        alpha: 2.0, // scale = alpha / rank = 1.0
+        target_modules: vec!["q_proj".into()],
+    };
+
+    let mut layers = HashMap::new();
+    // A: (rank=2, d_in=8) — row-major, all 0.1
+    // B: (d_out=4, rank=2) — row-major, all 0.1
+    layers.insert(
+        (0usize, "q_proj".to_string()),
+        LoraLayer {
+            a: vec![0.1; 2 * 8],
+            b: vec![0.1; 4 * 2],
+            d_in: 8,
+            d_out: 4,
+            rank: 2,
+        },
+    );
+    LoraAdapter::new(config, layers)
+}
+
+/// Build a small set of regression samples for (layer=0, module="q_proj").
+/// The target_delta is chosen so a gradient can drive the adapter towards it.
+fn make_train_samples(n: usize) -> Vec<TrainSample> {
+    (0..n)
+        .map(|i| {
+            let fi = i as f32;
+            TrainSample {
+                layer_idx: 0,
+                module: "q_proj".to_string(),
+                // d_in = 8
+                input: (0..8).map(|j| (fi + j as f32) * 0.05 + 0.1).collect(),
+                // d_out = 4 — target is reachable by the low-rank adapter
+                target_delta: (0..4).map(|j| fi * 0.1 + j as f32 * 0.02).collect(),
+            }
+        })
+        .collect()
+}
+
+/// Capture the apply_lora output for layer 0 / q_proj given a fixed input.
+fn capture_apply_output(adapter: &LoraAdapter) -> Vec<f32> {
+    let layer = adapter
+        .layers
+        .get(&(0usize, "q_proj".to_string()))
+        .expect("layer (0, q_proj) must exist");
+    let scale = adapter.config.scale();
+    let x: Vec<f32> = (0..8).map(|i| i as f32 * 0.1 + 0.5).collect();
+    let mut out = vec![0.0f32; 4];
+    apply_lora(layer, scale, &x, &mut out);
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: train changes adapter weights and shifts apply_lora output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_train_and_apply() {
+    let mut adapter = make_test_adapter();
+
+    // Capture apply_lora output BEFORE training.
+    let out_before = capture_apply_output(&adapter);
+
+    // Train 20 epochs.
+    let samples = make_train_samples(5);
+    let config = LoraTrainConfig {
+        learning_rate: 0.02,
+        num_epochs: 20,
+        batch_size: 5,
+    };
+    let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+    // Capture apply_lora output AFTER training.
+    let out_after = capture_apply_output(&adapter);
+
+    // Output must have changed — weights moved.
+    assert_ne!(
+        out_before, out_after,
+        "apply_lora output must differ after training"
+    );
+
+    // Loss must have decreased over the run.
+    let first = result.epoch_losses[0];
+    let last = result.epoch_losses[result.epoch_losses.len() - 1];
+    assert!(
+        last < first,
+        "final loss {last:.6} must be less than initial loss {first:.6}"
+    );
+
+    // Structural invariants on TrainResult.
+    assert_eq!(result.epoch_losses.len(), 20);
+    assert_eq!(result.total_steps, 20 * 5);
+    assert_eq!(result.final_loss, last);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: convergence quality — loss drops below threshold after 50 epochs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_train_convergence_quality() {
+    let mut adapter = make_test_adapter();
+
+    // Use a constant-target sample so convergence is tight.
+    let samples = vec![TrainSample {
+        layer_idx: 0,
+        module: "q_proj".to_string(),
+        // Fixed input
+        input: vec![1.0f32; 8],
+        // Fixed target that the adapter CAN reach
+        target_delta: vec![0.0f32; 4],
+    }];
+
+    let config = LoraTrainConfig {
+        learning_rate: 0.05,
+        num_epochs: 50,
+        batch_size: 1,
+    };
+    let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+    // Loss should fall substantially; exact threshold depends on scale.
+    // With lr=0.05, 50 epochs, and zero target the loss converges fast.
+    assert!(
+        result.final_loss < 0.5,
+        "final_loss {:.6} should be < 0.5 after 50 epochs",
+        result.final_loss
+    );
+
+    // Epoch losses must be non-increasing (or at worst flat).
+    for pair in result.epoch_losses.windows(2) {
+        assert!(
+            pair[1] <= pair[0] + 1e-6,
+            "loss increased: epoch N={:.6}, epoch N+1={:.6}",
+            pair[0],
+            pair[1]
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: train → save → load → apply gives identical output
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "safetensors")]
+#[test]
+fn test_save_load_roundtrip() {
+    use lattice_tune::lora::{load_peft_safetensors, save_peft_safetensors};
+
+    let mut adapter = make_test_adapter();
+
+    // Train briefly so weights are non-trivial.
+    let samples = make_train_samples(5);
+    let config = LoraTrainConfig {
+        learning_rate: 0.01,
+        num_epochs: 10,
+        batch_size: 5,
+    };
+    train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+    // Capture apply_lora output of the trained adapter.
+    let out_trained = capture_apply_output(&adapter);
+
+    // Save to a temporary file.
+    let dir = tempfile::tempdir().expect("tempdir must succeed");
+    let path = dir.path().join("adapter_e2e.safetensors");
+    adapter
+        .save_safetensors(&path)
+        .expect("save_safetensors must succeed");
+
+    // Reload from disk.
+    let loaded = LoraAdapter::from_safetensors(&path).expect("from_safetensors must succeed");
+
+    // The loaded adapter must reproduce the same apply_lora output.
+    let out_loaded = capture_apply_output(&loaded);
+
+    assert_eq!(
+        out_trained.len(),
+        out_loaded.len(),
+        "output length mismatch after round-trip"
+    );
+    for (i, (a, b)) in out_trained.iter().zip(out_loaded.iter()).enumerate() {
+        assert!(
+            (a - b).abs() < 1e-5,
+            "output[{i}] mismatch after round-trip: trained={a:.8} loaded={b:.8}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: error paths — empty samples and dimension mismatches
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_train_error_empty_samples() {
+    use lattice_tune::TuneError;
+
+    let mut adapter = make_test_adapter();
+    let config = LoraTrainConfig {
+        learning_rate: 0.01,
+        num_epochs: 5,
+        batch_size: 1,
+    };
+
+    let err = train_lora(&mut adapter, &[], &config).expect_err("empty samples must return Err");
+    assert!(
+        matches!(err, TuneError::Training(_)),
+        "expected Training variant, got {err:?}"
+    );
+}
+
+#[test]
+fn test_train_error_dimension_mismatch() {
+    use lattice_tune::TuneError;
+
+    let mut adapter = make_test_adapter();
+    // d_in for (0, "q_proj") is 8; pass 3 elements.
+    let bad_sample = TrainSample {
+        layer_idx: 0,
+        module: "q_proj".to_string(),
+        input: vec![1.0, 2.0, 3.0], // wrong length
+        target_delta: vec![0.0; 4],
+    };
+    let config = LoraTrainConfig {
+        learning_rate: 0.01,
+        num_epochs: 1,
+        batch_size: 1,
+    };
+
+    let err = train_lora(&mut adapter, &[bad_sample], &config)
+        .expect_err("dimension mismatch must return Err");
+    assert!(
+        matches!(err, TuneError::DimensionMismatch { .. }),
+        "expected DimensionMismatch variant, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: adapter.apply() delegates to apply_lora correctly post-training
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_adapter_apply_method_post_training() {
+    let mut adapter = make_test_adapter();
+
+    let samples = make_train_samples(5);
+    let config = LoraTrainConfig {
+        learning_rate: 0.01,
+        num_epochs: 5,
+        batch_size: 5,
+    };
+    train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+    // adapter.apply() must agree with apply_lora on the same layer.
+    let x: Vec<f32> = (0..8).map(|i| i as f32 * 0.1 + 0.5).collect();
+
+    let mut out_via_apply = vec![0.0f32; 4];
+    adapter.apply(0, "q_proj", &x, &mut out_via_apply);
+
+    let direct = capture_apply_output(&adapter);
+
+    for (i, (a, b)) in out_via_apply.iter().zip(direct.iter()).enumerate() {
+        assert!(
+            (a - b).abs() < 1e-6,
+            "apply() vs apply_lora mismatch at index {i}: {a:.8} vs {b:.8}"
+        );
+    }
+}

--- a/scripts/bench_all.sh
+++ b/scripts/bench_all.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run all synthetic benchmarks (no model weights required).
+# Usage: ./scripts/bench_all.sh [--save DIR]
+#
+# Skips: e2e_bench, metal_decode_bench (require model weights)
+
+SAVE_DIR="${1:-.}"
+TIMESTAMP=$(date -Iseconds)
+
+echo "=== Lattice Benchmark Suite ==="
+echo "Date: $TIMESTAMP"
+echo "Platform: $(uname -m) / $(uname -s)"
+echo ""
+
+INFERENCE_BENCHES=(
+    inference_bench
+    inference_perf
+    attention_bench
+    compute_attention_bench
+    decode_attn_bench
+    differential_attention_bench
+    gated_attention_bench
+    native_sparse_attention_bench
+    kv_cache_layout_bench
+    tokenizer_bench
+    topk_readback
+    mtp_decode
+)
+
+EMBED_BENCHES=(
+    simd
+    simd_bench
+    embeddings
+)
+
+echo "--- inference benches ---"
+for bench in "${INFERENCE_BENCHES[@]}"; do
+    echo ">> $bench"
+    RUSTC_WRAPPER= cargo bench -p lattice-inference --bench "$bench" 2>&1 || echo "FAILED: $bench"
+    echo ""
+done
+
+echo "--- embed benches ---"
+for bench in "${EMBED_BENCHES[@]}"; do
+    echo ">> $bench"
+    RUSTC_WRAPPER= cargo bench -p lattice-embed --bench "$bench" 2>&1 || echo "FAILED: $bench"
+    echo ""
+done
+
+echo "=== Done ==="


### PR DESCRIPTION
## Summary
- Add `crates/tune/tests/e2e_lora.rs` with 5 integration tests covering the full train→apply→save→load lifecycle
- Add `crates/tune/benches/e2e_bench.rs` benchmarking full train+apply cycle at rank=[2,4,8]
- Tests cover: training effect on weights, convergence quality, safetensors round-trip, error handling, apply method consistency

## Merge sequence
**PR 8 of 10** — depends on train-loop (#67) and train-optimizer (#7)

## Test plan
- [ ] `cargo test -p lattice-tune` (all tests pass)
- [ ] `cargo clippy --workspace -- -D warnings`
- [ ] `RUSTC_WRAPPER= cargo bench -p lattice-tune --bench e2e_bench --no-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)