### PR TITLE
test(perf): add performance regression tests for CI

### DIFF
--- a/benches/BASELINE.md
+++ b/benches/BASELINE.md
@@ -1,0 +1,73 @@
+# Lattice Performance Baseline
+
+**Date**: 2026-05-23
+**Commit**: ac38f20 (main, post ADR-057 LoRA lifecycle merge)
+**Platform**: Apple Silicon (aarch64 / Darwin)
+**Rust**: stable (release profile, LTO)
+
+## Inference Benchmarks (`lattice-inference`)
+
+### Attention Kernel (standard, synthetic)
+
+| Seq Len | Time/op  | Throughput    |
+| ------- | -------- | ------------- |
+| 16      | 96.6 us  | 31.8 Melem/s  |
+| 32      | 125.6 us | 97.8 Melem/s  |
+| 64      | 230.6 us | 213.1 Melem/s |
+| 128     | 506.1 us | 388.5 Melem/s |
+
+### Batch Encoding
+
+| Batch Size | Time/op  | Throughput   |
+| ---------- | -------- | ------------ |
+| 32         | 180.6 ms | 177.2 elem/s |
+
+### Logits Projection (matmul_bt)
+
+| Variant          | Time/op  | Throughput    |
+| ---------------- | -------- | ------------- |
+| scalar           | 443.5 ms | 1.15 Gelem/s  |
+| matmul_bt (SIMD) | 42.4 ms  | 11.99 Gelem/s |
+
+**matmul_bt speedup over scalar: 10.5x**
+
+### Tokenizer BPE
+
+| Input Size | Time/op  | Throughput   |
+| ---------- | -------- | ------------ |
+| 4096 chars | 111.7 us | 30.7 Melem/s |
+
+## Embed Benchmarks (`lattice-embed`)
+
+### SIMD Distance Operations (dim=768)
+
+| Operation             | Time/op | GFLOPS |
+| --------------------- | ------- | ------ |
+| cosine (scalar)       | 797 ns  | 2.9    |
+| cosine (SIMD, full)   | 31 ns   | 74.3   |
+| dot_product (f32)     | 26 ns   | 29.5   |
+| normalize (SIMD)      | 77 ns   | 15.0   |
+| euclidean_dist (SIMD) | 28 ns   | 41.1   |
+| dot_product (int8)    | 287 ns  | 2.7    |
+| cosine (int8)         | 370 ns  | 6.2    |
+
+**f32 cosine SIMD speedup: 25.7x over scalar**
+**int8 dot product: 2.2x over scalar** (room for improvement)
+
+## Key Observations
+
+1. **matmul_bt** is already well-optimized on macOS (Accelerate/AMX), 10.5x
+   over scalar
+2. **f32 SIMD** distance ops are excellent (25-40x speedup)
+3. **int8 SIMD** has significant room for improvement (only 2.2x)
+4. **Attention kernel** throughput scales well with seq_len
+5. **Elementwise ops** (rms_norm, silu, elementwise_mul) have NO SIMD paths —
+   pure scalar
+
+## Optimization Targets (prioritized)
+
+1. **Elementwise SIMD** — rms_norm, silu, elementwise_mul (0 SIMD, called
+   4x/layer/token)
+2. **Int8 dot product** — 2.2x vs target of ~8-10x
+3. **Attention decode path** — single-token (seq_len=1) specialization
+4. **matmul_bt non-macOS** — tiling improvements for Linux/aarch64

--- a/crates/embed/tests/perf_regression.rs
+++ b/crates/embed/tests/perf_regression.rs
@@ -1,0 +1,65 @@
+//! Performance regression tests for lattice-embed.
+//!
+//! These are pass/fail time-bounded assertions, not benchmarks.
+//! Bounds are deliberately generous (50-100x over expected) to remain
+//! stable across debug builds and CI variance.
+
+use std::time::Instant;
+
+use lattice_embed::utils::{cosine_similarity, dot_product, normalize};
+
+#[test]
+fn cosine_similarity_not_catastrophically_slow() {
+    // cosine_similarity at dim=384, 10 000 iterations must finish in < 2s.
+    // SIMD path: ~90ns/iter -> 10k iters ~900µs; 2s gives >2000x slack.
+    // Scalar debug path: ~650ns/iter -> 10k iters ~6.5ms; still well under 2s.
+    let dim = 384usize;
+    let a: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.001).collect();
+    let b: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.002 + 0.1).collect();
+
+    let start = Instant::now();
+    for _ in 0..10_000 {
+        let _sim = cosine_similarity(&a, &b);
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 2,
+        "cosine_similarity regression: 10k iters at dim=384 took {elapsed:?}, expected < 2s"
+    );
+}
+
+#[test]
+fn dot_product_not_catastrophically_slow() {
+    // dot_product at dim=768, 10 000 iterations must finish in < 2s.
+    let dim = 768usize;
+    let a: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.001).collect();
+    let b: Vec<f32> = (0..dim).map(|i| 1.0 / (i as f32 + 1.0)).collect();
+
+    let start = Instant::now();
+    for _ in 0..10_000 {
+        let _dp = dot_product(&a, &b);
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 2,
+        "dot_product regression: 10k iters at dim=768 took {elapsed:?}, expected < 2s"
+    );
+}
+
+#[test]
+fn normalize_not_catastrophically_slow() {
+    // normalize at dim=384, 5 000 iterations must finish in < 2s.
+    let dim = 384usize;
+
+    let start = Instant::now();
+    for i in 0..5_000 {
+        // Re-initialize each iter to keep the vector non-zero.
+        let mut v: Vec<f32> = (0..dim).map(|j| ((i + j) as f32) * 0.001 + 0.1).collect();
+        normalize(&mut v);
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 2,
+        "normalize regression: 5000 iters at dim=384 took {elapsed:?}, expected < 2s"
+    );
+}

--- a/crates/inference/tests/perf_regression.rs
+++ b/crates/inference/tests/perf_regression.rs
@@ -1,0 +1,101 @@
+//! Performance regression tests for lattice-inference.
+//!
+//! These are pass/fail time-bounded assertions, not benchmarks.
+//! Bounds are deliberately generous (50-100x over expected) to remain
+//! stable across debug builds and CI variance.
+
+use std::time::Instant;
+
+#[test]
+fn matmul_bt_not_catastrophically_slow() {
+    // matmul_bt at (m=4, k=512, n=512): 100 iterations must finish in < 5s (debug).
+    // Expected scalar path ~500µs/iter -> 100 iters ~50ms; 5s gives 100x slack.
+    let m = 4usize;
+    let k = 512usize;
+    let n = 512usize;
+    let a = vec![1.0f32; m * k];
+    let b = vec![1.0f32; n * k]; // matmul_bt: B is (n, k) row-major
+    let mut c = vec![0.0f32; m * n];
+
+    let start = Instant::now();
+    for _ in 0..100 {
+        lattice_inference::forward::matmul_bt(&a, &b, &mut c, m, k, n);
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 5,
+        "matmul_bt regression: 100 iters at (m=4,k=512,n=512) took {elapsed:?}, expected < 5s"
+    );
+}
+
+#[test]
+fn matmul_not_catastrophically_slow() {
+    // matmul (A * B) at (m=4, k=128, n=128): 100 iterations must finish in < 5s.
+    let m = 4usize;
+    let k = 128usize;
+    let n = 128usize;
+    let a = vec![1.0f32; m * k];
+    let b = vec![1.0f32; k * n];
+    let start = Instant::now();
+    for _ in 0..100 {
+        let _c = lattice_inference::forward::matmul(&a, &b, m, k, n);
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 5,
+        "matmul regression: 100 iters at (m=4,k=128,n=128) took {elapsed:?}, expected < 5s"
+    );
+}
+
+#[test]
+fn rms_norm_not_catastrophically_slow() {
+    // rms_norm at hidden=512, 1000 iterations must finish in < 2s.
+    // Expected: ~5µs/iter -> 1000 iters ~5ms; 2s gives 400x slack.
+    let hidden = 512usize;
+    let num_tokens = 4usize;
+    let mut x = vec![0.5f32; num_tokens * hidden];
+    let gamma = vec![1.0f32; hidden];
+
+    let start = Instant::now();
+    for _ in 0..1000 {
+        lattice_inference::forward::rms_norm(&mut x, &gamma, hidden, 1e-6);
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 2,
+        "rms_norm regression: 1000 iters at hidden=512 took {elapsed:?}, expected < 2s"
+    );
+}
+
+#[test]
+fn silu_inplace_not_catastrophically_slow() {
+    // silu_inplace at len=2048, 2000 iterations must finish in < 2s.
+    let mut x = vec![0.5f32; 2048];
+
+    let start = Instant::now();
+    for _ in 0..2000 {
+        lattice_inference::forward::silu_inplace(&mut x);
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 2,
+        "silu_inplace regression: 2000 iters at len=2048 took {elapsed:?}, expected < 2s"
+    );
+}
+
+#[test]
+fn elementwise_mul_not_catastrophically_slow() {
+    // elementwise_mul at len=2048, 2000 iterations must finish in < 2s.
+    let mut a = vec![2.0f32; 2048];
+    let b = vec![0.5f32; 2048];
+
+    let start = Instant::now();
+    for _ in 0..2000 {
+        lattice_inference::forward::elementwise_mul(&mut a, &b);
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 2,
+        "elementwise_mul regression: 2000 iters at len=2048 took {elapsed:?}, expected < 2s"
+    );
+}

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -56,6 +56,11 @@ required-features = ["safetensors", "inference-hook"]
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "train_bench"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/tune/benches/train_bench.rs
+++ b/crates/tune/benches/train_bench.rs
@@ -1,0 +1,103 @@
+//! Benchmark for the batch LoRA training loop.
+//!
+//! Measures [`train_lora`] throughput as a function of sample count (batch_size
+//! parameter is informational; the loop is sequential).
+//!
+//! Groups:
+//!   lora/train_loop — num_epochs=5, batch_size ∈ {10, 50, 100}
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer};
+use lattice_tune::{LoraTrainConfig, TrainSample, train_lora};
+use std::collections::HashMap;
+
+const D_IN: usize = 64;
+const D_OUT: usize = 64;
+const RANK: usize = 4;
+const NUM_EPOCHS: usize = 5;
+
+/// Build a deterministic pseudo-random f32 from two indices (no external rand crate).
+fn pseudo_f32(seed: u64, idx: u64) -> f32 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    (seed, idx).hash(&mut h);
+    // Map to (-0.5, 0.5) so the initial weights are centred.
+    h.finish() as f32 / u64::MAX as f32 - 0.5
+}
+
+fn make_adapter() -> LoraAdapter {
+    let config = LoraConfig {
+        rank: RANK,
+        alpha: RANK as f32, // scale = 1.0
+        target_modules: vec!["q_proj".into()],
+    };
+    let mut layers = HashMap::new();
+    layers.insert(
+        (0usize, "q_proj".to_string()),
+        LoraLayer {
+            // A: (rank, d_in)
+            a: (0..(RANK * D_IN))
+                .map(|i| pseudo_f32(1, i as u64) * 0.01)
+                .collect(),
+            // B: (d_out, rank)
+            b: (0..(D_OUT * RANK))
+                .map(|i| pseudo_f32(2, i as u64) * 0.01)
+                .collect(),
+            d_in: D_IN,
+            d_out: D_OUT,
+            rank: RANK,
+        },
+    );
+    LoraAdapter::new(config, layers)
+}
+
+fn make_samples(n: usize) -> Vec<TrainSample> {
+    (0..n)
+        .map(|i| TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: (0..D_IN)
+                .map(|j| pseudo_f32(3 + i as u64, j as u64))
+                .collect(),
+            target_delta: (0..D_OUT)
+                .map(|j| pseudo_f32(1000 + i as u64, j as u64) * 0.1)
+                .collect(),
+        })
+        .collect()
+}
+
+fn bench_train_loop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lora/train_loop");
+
+    for &n_samples in &[10usize, 50, 100] {
+        let samples = make_samples(n_samples);
+
+        group.bench_with_input(
+            BenchmarkId::new("num_samples", n_samples),
+            &n_samples,
+            |b, _| {
+                b.iter(|| {
+                    // Re-create adapter each iteration so weights start fresh.
+                    let mut adapter = make_adapter();
+                    let config = LoraTrainConfig {
+                        learning_rate: 0.01,
+                        num_epochs: NUM_EPOCHS,
+                        batch_size: n_samples,
+                    };
+                    train_lora(
+                        black_box(&mut adapter),
+                        black_box(&samples),
+                        black_box(&config),
+                    )
+                    .expect("train_lora must not fail in bench")
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_train_loop);
+criterion_main!(benches);

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -149,7 +149,9 @@ pub use train::{
 pub use train::{GpuTrainer, GpuTrainerBuilder};
 
 // LoRA re-exports
-pub use lora::{LoraAdapter, LoraConfig, LoraLayer};
+pub use lora::{
+    LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+};
 
 // Registry re-exports
 pub use registry::{
@@ -168,7 +170,9 @@ pub mod prelude {
         LabelingResult, TeacherConfig, TeacherProvider,
     };
     pub use crate::error::{Result, TuneError};
-    pub use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    pub use crate::lora::{
+        LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+    };
     pub use crate::registry::{
         LiveModel, ModelMetadata, ModelRegistry, ModelStatus, RegisteredModel, RollbackController,
         RollbackRecord, ShadowComparison, ShadowConfig, ShadowSession, ShadowState, StorageBackend,

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -37,11 +37,13 @@ mod apply;
 pub mod online;
 #[cfg(feature = "safetensors")]
 mod safetensors;
+pub mod train;
 
 pub use apply::apply_lora;
 pub use online::{AdaptStepResult, adapt_step};
 #[cfg(feature = "safetensors")]
 pub use safetensors::{load_peft_safetensors, save_peft_safetensors};
+pub use train::{LoraTrainConfig, TrainResult, TrainSample, train_lora};
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -1,0 +1,252 @@
+//! Batch LoRA training loop (ADR-057, perf-opt-train-loop).
+//!
+//! Provides [`train_lora`] which iterates over a slice of [`TrainSample`]s for
+//! multiple epochs, calling [`adapt_step`] for each sample and accumulating per-epoch
+//! MSE loss statistics.
+
+use super::{LoraAdapter, online::adapt_step};
+use crate::error::TuneError;
+
+/// Configuration for a batch LoRA training run.
+#[derive(Debug, Clone)]
+pub struct LoraTrainConfig {
+    /// SGD step size applied inside each [`adapt_step`] call.
+    pub learning_rate: f32,
+    /// Number of full passes over the sample set.
+    pub num_epochs: usize,
+    /// Batch size (informational; does not affect the current sequential loop).
+    pub batch_size: usize,
+}
+
+/// A single training sample: one (input, target_delta) pair for one LoRA layer.
+#[derive(Debug, Clone)]
+pub struct TrainSample {
+    /// Transformer layer index (0-based).
+    pub layer_idx: usize,
+    /// Module name, e.g. `"q_proj"`.
+    pub module: String,
+    /// Input activation vector; length must equal the layer's `d_in`.
+    pub input: Vec<f32>,
+    /// Target LoRA output correction; length must equal the layer's `d_out`.
+    pub target_delta: Vec<f32>,
+}
+
+/// Summary statistics from a completed [`train_lora`] run.
+#[derive(Debug, Clone)]
+pub struct TrainResult {
+    /// Average MSE loss recorded in the final epoch.
+    pub final_loss: f32,
+    /// Average MSE loss per epoch (length == `num_epochs`).
+    pub epoch_losses: Vec<f32>,
+    /// Total number of [`adapt_step`] calls executed (`num_epochs * samples.len()`).
+    pub total_steps: usize,
+}
+
+/// Run a multi-epoch batch LoRA training loop.
+///
+/// Iterates over all `samples` in order for each epoch (no shuffling, ensuring
+/// deterministic behaviour), calling [`adapt_step`] once per sample and
+/// accumulating the per-step MSE loss.
+///
+/// # Arguments
+///
+/// * `adapter` – Mutable LoRA adapter whose weights are updated in place.
+/// * `samples` – Slice of training samples; must be non-empty.
+/// * `config`  – Hyper-parameters for the training run.
+///
+/// # Errors
+///
+/// * [`TuneError::Training`]         – `samples` is empty.
+/// * [`TuneError::InvalidConfig`]    – `batch_size == 0` or `num_epochs == 0`.
+/// * [`TuneError::Training`] – A sample references a `(layer_idx, module)` pair
+///   that is not present in the adapter.
+/// * [`TuneError::DimensionMismatch`] – A sample's `input` or `target_delta` has the
+///   wrong length for its LoRA layer.
+pub fn train_lora(
+    adapter: &mut LoraAdapter,
+    samples: &[TrainSample],
+    config: &LoraTrainConfig,
+) -> Result<TrainResult, TuneError> {
+    if samples.is_empty() {
+        return Err(TuneError::Training(
+            "no training samples provided".to_string(),
+        ));
+    }
+    if config.batch_size == 0 {
+        return Err(TuneError::InvalidConfig(
+            "batch_size must be > 0".to_string(),
+        ));
+    }
+    if config.num_epochs == 0 {
+        return Err(TuneError::InvalidConfig(
+            "num_epochs must be > 0".to_string(),
+        ));
+    }
+
+    let mut epoch_losses = Vec::with_capacity(config.num_epochs);
+
+    for _ in 0..config.num_epochs {
+        let mut epoch_loss_sum = 0.0f32;
+
+        for sample in samples {
+            let step_result = adapt_step(
+                adapter,
+                sample.layer_idx,
+                &sample.module,
+                &sample.input,
+                &sample.target_delta,
+                config.learning_rate,
+            )?;
+            epoch_loss_sum += step_result.loss;
+        }
+
+        let avg = epoch_loss_sum / samples.len() as f32;
+        epoch_losses.push(avg);
+    }
+
+    let final_loss = *epoch_losses
+        .last()
+        .expect("num_epochs > 0 guaranteed above");
+    let total_steps = config.num_epochs * samples.len();
+
+    Ok(TrainResult {
+        final_loss,
+        epoch_losses,
+        total_steps,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    use std::collections::HashMap;
+
+    /// rank=2, d_in=3, d_out=2, scale=1.0 (alpha=2.0, rank=2)
+    fn make_small_adapter() -> LoraAdapter {
+        let config = LoraConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["q_proj".into()],
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![
+                    1.0, 0.5, 0.0, // row 0
+                    0.0, 0.5, 1.0, // row 1
+                ],
+                b: vec![
+                    1.0, 0.0, // row 0
+                    0.0, 1.0, // row 1
+                ],
+                d_in: 3,
+                d_out: 2,
+                rank: 2,
+            },
+        );
+        LoraAdapter::new(config, layers)
+    }
+
+    /// Build a synthetic sample whose target_delta is the initial LoRA output for the given
+    /// input, slightly perturbed — this gives a reachable regression target without
+    /// requiring a warm-up forward pass from the caller.
+    fn make_samples(n: usize) -> Vec<TrainSample> {
+        // Use varied inputs so samples span different directions in weight-space.
+        (0..n)
+            .map(|i| {
+                let fi = i as f32;
+                TrainSample {
+                    layer_idx: 0,
+                    module: "q_proj".to_string(),
+                    // d_in = 3
+                    input: vec![fi * 0.1 + 0.1, fi * 0.2 + 0.2, fi * 0.3 + 0.3],
+                    // d_out = 2  — target is something the network can learn toward
+                    target_delta: vec![fi * 0.05, fi * 0.05 + 0.1],
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_train_convergence() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 10,
+            batch_size: 5,
+        };
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.epoch_losses.len(), 10);
+        assert_eq!(result.total_steps, 50);
+        assert!(
+            result.epoch_losses.last().unwrap() < result.epoch_losses.first().unwrap(),
+            "loss must decrease over 10 epochs: first={:.6}, last={:.6}",
+            result.epoch_losses.first().unwrap(),
+            result.epoch_losses.last().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_train_empty_batch() {
+        let mut adapter = make_small_adapter();
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 5,
+            batch_size: 1,
+        };
+
+        let err =
+            train_lora(&mut adapter, &[], &config).expect_err("empty samples must return Err");
+        assert!(
+            matches!(err, TuneError::Training(_)),
+            "expected Training variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_dimension_mismatch() {
+        let mut adapter = make_small_adapter();
+        // d_in for layer (0, "q_proj") is 3, but we pass a 2-element input.
+        let bad_samples = vec![TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: vec![1.0, 2.0], // wrong length (d_in=3)
+            target_delta: vec![1.0, 1.0],
+        }];
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 1,
+            batch_size: 1,
+        };
+
+        let err = train_lora(&mut adapter, &bad_samples, &config)
+            .expect_err("dimension mismatch must return Err");
+        assert!(
+            matches!(err, TuneError::DimensionMismatch { .. }),
+            "expected DimensionMismatch variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_metrics() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 3,
+            batch_size: 5,
+        };
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.total_steps, 15, "3 epochs × 5 samples = 15 steps");
+        assert_eq!(result.epoch_losses.len(), 3, "one loss entry per epoch");
+    }
+}

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -72,6 +72,11 @@ pub fn train_lora(
             "no training samples provided".to_string(),
         ));
     }
+    if !config.learning_rate.is_finite() || config.learning_rate <= 0.0 {
+        return Err(TuneError::InvalidConfig(
+            "learning_rate must be finite and positive".to_string(),
+        ));
+    }
     if config.batch_size == 0 {
         return Err(TuneError::InvalidConfig(
             "batch_size must be > 0".to_string(),
@@ -104,9 +109,10 @@ pub fn train_lora(
         epoch_losses.push(avg);
     }
 
-    let final_loss = *epoch_losses
+    let final_loss = epoch_losses
         .last()
-        .expect("num_epochs > 0 guaranteed above");
+        .copied()
+        .ok_or_else(|| TuneError::InvalidConfig("num_epochs produced no losses".into()))?;
     let total_steps = config.num_epochs * samples.len();
 
     Ok(TrainResult {

--- a/crates/tune/tests/perf_regression.rs
+++ b/crates/tune/tests/perf_regression.rs
@@ -1,0 +1,98 @@
+//! Performance regression tests for lattice-tune.
+//!
+//! These are pass/fail time-bounded assertions, not benchmarks.
+//! Bounds are deliberately generous (50-100x over expected) to remain
+//! stable across debug builds and CI variance.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use lattice_tune::{LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainSample, train_lora};
+
+fn make_adapter(rank: usize, d_in: usize, d_out: usize) -> LoraAdapter {
+    let config = LoraConfig {
+        rank,
+        alpha: rank as f32,
+        target_modules: vec!["q_proj".to_string()],
+    };
+    let mut layers = HashMap::new();
+    // A: (rank, d_in), B: (d_out, rank) — initialize with small values
+    let a: Vec<f32> = (0..rank * d_in).map(|i| (i as f32) * 0.01).collect();
+    let b: Vec<f32> = (0..d_out * rank).map(|i| (i as f32) * 0.01).collect();
+    layers.insert(
+        (0, "q_proj".to_string()),
+        LoraLayer {
+            a,
+            b,
+            d_in,
+            d_out,
+            rank,
+        },
+    );
+    LoraAdapter::new(config, layers)
+}
+
+fn make_samples(n: usize, d_in: usize, d_out: usize) -> Vec<TrainSample> {
+    (0..n)
+        .map(|i| {
+            let fi = i as f32;
+            TrainSample {
+                layer_idx: 0,
+                module: "q_proj".to_string(),
+                input: (0..d_in).map(|j| fi * 0.01 + j as f32 * 0.001).collect(),
+                target_delta: (0..d_out).map(|j| fi * 0.005 + j as f32 * 0.002).collect(),
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn train_lora_not_catastrophically_slow() {
+    // rank=2, d_in=16, d_out=8, 20 samples, 5 epochs must finish in < 2s.
+    // Expected: the inner loop is simple matmul + SGD; 100 adapt_step calls
+    // at tiny dimensions should complete in <<1ms total.
+    // 2s gives >1000x slack over expected debug runtime.
+    let mut adapter = make_adapter(2, 16, 8);
+    let samples = make_samples(20, 16, 8);
+    let config = LoraTrainConfig {
+        learning_rate: 0.01,
+        num_epochs: 5,
+        batch_size: 4,
+    };
+
+    let start = Instant::now();
+    let result = train_lora(&mut adapter, &samples, &config).expect("train_lora failed");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_secs() < 2,
+        "train_lora regression: 20 samples × 5 epochs took {elapsed:?}, expected < 2s"
+    );
+    // Sanity: result shape is consistent
+    assert_eq!(result.epoch_losses.len(), 5);
+    assert_eq!(result.total_steps, 100);
+}
+
+#[test]
+fn train_lora_repeated_not_catastrophically_slow() {
+    // Run train_lora 50 times (rank=2, d_in=8, d_out=4, 10 samples, 2 epochs).
+    // 50 runs × ~2ms expected each = ~100ms total; 5s gives 50x slack in debug.
+    let config = LoraTrainConfig {
+        learning_rate: 0.01,
+        num_epochs: 2,
+        batch_size: 4,
+    };
+    let samples = make_samples(10, 8, 4);
+
+    let start = Instant::now();
+    for _ in 0..50 {
+        let mut adapter = make_adapter(2, 8, 4);
+        train_lora(&mut adapter, &samples, &config).expect("train_lora failed");
+    }
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_secs() < 5,
+        "train_lora repeated regression: 50 runs took {elapsed:?}, expected < 5s"
+    );
+}

--- a/scripts/bench_all.sh
+++ b/scripts/bench_all.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run all synthetic benchmarks (no model weights required).
+# Usage: ./scripts/bench_all.sh [--save DIR]
+#
+# Skips: e2e_bench, metal_decode_bench (require model weights)
+
+SAVE_DIR="${1:-.}"
+TIMESTAMP=$(date -Iseconds)
+
+echo "=== Lattice Benchmark Suite ==="
+echo "Date: $TIMESTAMP"
+echo "Platform: $(uname -m) / $(uname -s)"
+echo ""
+
+INFERENCE_BENCHES=(
+    inference_bench
+    inference_perf
+    attention_bench
+    compute_attention_bench
+    decode_attn_bench
+    differential_attention_bench
+    gated_attention_bench
+    native_sparse_attention_bench
+    kv_cache_layout_bench
+    tokenizer_bench
+    topk_readback
+    mtp_decode
+)
+
+EMBED_BENCHES=(
+    simd
+    simd_bench
+    embeddings
+)
+
+echo "--- inference benches ---"
+for bench in "${INFERENCE_BENCHES[@]}"; do
+    echo ">> $bench"
+    RUSTC_WRAPPER= cargo bench -p lattice-inference --bench "$bench" 2>&1 || echo "FAILED: $bench"
+    echo ""
+done
+
+echo "--- embed benches ---"
+for bench in "${EMBED_BENCHES[@]}"; do
+    echo ">> $bench"
+    RUSTC_WRAPPER= cargo bench -p lattice-embed --bench "$bench" 2>&1 || echo "FAILED: $bench"
+    echo ""
+done
+
+echo "=== Done ==="


### PR DESCRIPTION
## Summary
- Add `crates/inference/tests/perf_regression.rs` — 5 regression tests (matmul_bt, matmul, rms_norm, silu, elementwise_mul)
- Add `crates/embed/tests/perf_regression.rs` — 3 regression tests (cosine, dot_product, normalize)
- Add `crates/tune/tests/perf_regression.rs` — 2 regression tests (train_lora single + repeated)
- All use `std::time::Instant` with generous bounds (50-400x slack for debug mode CI)

## Merge sequence
**PR 9 of 10** — depends on inference + embed + tune PRs (2-8)

## Test plan
- [ ] `cargo test --workspace` (all 10 perf regression tests pass)
- [ ] `cargo clippy --workspace -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)