### PR TITLE
perf: SIMD optimization + Metal GPU fixes + regression tests

### DIFF
--- a/benches/BASELINE.md
+++ b/benches/BASELINE.md
@@ -1,0 +1,73 @@
+# Lattice Performance Baseline
+
+**Date**: 2026-05-23
+**Commit**: ac38f20 (main, post ADR-057 LoRA lifecycle merge)
+**Platform**: Apple Silicon (aarch64 / Darwin)
+**Rust**: stable (release profile, LTO)
+
+## Inference Benchmarks (`lattice-inference`)
+
+### Attention Kernel (standard, synthetic)
+
+| Seq Len | Time/op  | Throughput    |
+| ------- | -------- | ------------- |
+| 16      | 96.6 us  | 31.8 Melem/s  |
+| 32      | 125.6 us | 97.8 Melem/s  |
+| 64      | 230.6 us | 213.1 Melem/s |
+| 128     | 506.1 us | 388.5 Melem/s |
+
+### Batch Encoding
+
+| Batch Size | Time/op  | Throughput   |
+| ---------- | -------- | ------------ |
+| 32         | 180.6 ms | 177.2 elem/s |
+
+### Logits Projection (matmul_bt)
+
+| Variant          | Time/op  | Throughput    |
+| ---------------- | -------- | ------------- |
+| scalar           | 443.5 ms | 1.15 Gelem/s  |
+| matmul_bt (SIMD) | 42.4 ms  | 11.99 Gelem/s |
+
+**matmul_bt speedup over scalar: 10.5x**
+
+### Tokenizer BPE
+
+| Input Size | Time/op  | Throughput   |
+| ---------- | -------- | ------------ |
+| 4096 chars | 111.7 us | 30.7 Melem/s |
+
+## Embed Benchmarks (`lattice-embed`)
+
+### SIMD Distance Operations (dim=768)
+
+| Operation             | Time/op | GFLOPS |
+| --------------------- | ------- | ------ |
+| cosine (scalar)       | 797 ns  | 2.9    |
+| cosine (SIMD, full)   | 31 ns   | 74.3   |
+| dot_product (f32)     | 26 ns   | 29.5   |
+| normalize (SIMD)      | 77 ns   | 15.0   |
+| euclidean_dist (SIMD) | 28 ns   | 41.1   |
+| dot_product (int8)    | 287 ns  | 2.7    |
+| cosine (int8)         | 370 ns  | 6.2    |
+
+**f32 cosine SIMD speedup: 25.7x over scalar**
+**int8 dot product: 2.2x over scalar** (room for improvement)
+
+## Key Observations
+
+1. **matmul_bt** is already well-optimized on macOS (Accelerate/AMX), 10.5x
+   over scalar
+2. **f32 SIMD** distance ops are excellent (25-40x speedup)
+3. **int8 SIMD** has significant room for improvement (only 2.2x)
+4. **Attention kernel** throughput scales well with seq_len
+5. **Elementwise ops** (rms_norm, silu, elementwise_mul) have NO SIMD paths —
+   pure scalar
+
+## Optimization Targets (prioritized)
+
+1. **Elementwise SIMD** — rms_norm, silu, elementwise_mul (0 SIMD, called
+   4x/layer/token)
+2. **Int8 dot product** — 2.2x vs target of ~8-10x
+3. **Attention decode path** — single-token (seq_len=1) specialization
+4. **matmul_bt non-macOS** — tiling improvements for Linux/aarch64

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -68,5 +68,9 @@ harness = false
 name = "simsimd_comparison"
 harness = false
 
+[[bench]]
+name = "simd_opt_bench"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/embed/benches/simd_opt_bench.rs
+++ b/crates/embed/benches/simd_opt_bench.rs
@@ -1,0 +1,158 @@
+//! Benchmark for optimized SIMD embedding distance kernels.
+//!
+//! Covers the optimizations added in perf(embed):
+//! - `cosine_similarity_fused` (explicit single-pass API)
+//! - `batch_cosine_one_vs_many` (pre-computed query norm, one-vs-N)
+//! - `dot_product_i8_raw` (i8 dot product with software prefetch)
+//!
+//! Dimensions benchmarked: 128, 384, 768, 1536 (common embedding model sizes).
+//!
+//! Run with: `cargo bench -p lattice-embed --bench simd_opt_bench`
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use lattice_embed::simd::{
+    QuantizedVector, batch_cosine_one_vs_many, batch_cosine_similarity, cosine_similarity,
+    cosine_similarity_fused, dot_product_i8_raw,
+};
+
+/// Deterministic pseudo-random vector generator (no external deps).
+fn gen_vec(dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed ^ ((dim as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    (0..dim)
+        .map(|i| {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407)
+                .wrapping_add(i as u64);
+            let unit = ((state >> 32) as u32) as f32 / u32::MAX as f32;
+            unit * 2.0 - 1.0
+        })
+        .collect()
+}
+
+const DIMS: [usize; 4] = [128, 384, 768, 1536];
+
+/// Benchmark `cosine_similarity` (existing, single-pass SIMD) vs
+/// `cosine_similarity_fused` (same kernel, explicit API guarantee).
+fn bench_cosine_fused_vs_original(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cosine_similarity");
+
+    for &dim in &DIMS {
+        let a = gen_vec(dim, 0x1111);
+        let b = gen_vec(dim, 0x2222);
+
+        group.bench_with_input(BenchmarkId::new("original", dim), &dim, |bencher, _| {
+            bencher.iter(|| {
+                std::hint::black_box(cosine_similarity(
+                    std::hint::black_box(&a),
+                    std::hint::black_box(&b),
+                ))
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("fused", dim), &dim, |bencher, _| {
+            bencher.iter(|| {
+                std::hint::black_box(cosine_similarity_fused(
+                    std::hint::black_box(&a),
+                    std::hint::black_box(&b),
+                ))
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark `batch_cosine_similarity` (per-pair, no shared norm) vs
+/// `batch_cosine_one_vs_many` (shared query norm, pre-computed once).
+///
+/// Both run 16 candidates against one query at each dimension to make
+/// the norm-reuse benefit measurable.
+fn bench_batch_cosine_one_vs_many(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batch_cosine");
+    const N_CANDIDATES: usize = 16;
+
+    for &dim in &DIMS {
+        let query = gen_vec(dim, 0xaaaa);
+        let candidates: Vec<Vec<f32>> = (0..N_CANDIDATES)
+            .map(|i| gen_vec(dim, 0xbbbb + i as u64))
+            .collect();
+
+        // Prepare per-pair format for batch_cosine_similarity
+        let pairs: Vec<(&[f32], &[f32])> = candidates
+            .iter()
+            .map(|c| (query.as_slice(), c.as_slice()))
+            .collect();
+
+        // Prepare candidate-refs format for batch_cosine_one_vs_many
+        let candidate_refs: Vec<&[f32]> = candidates.iter().map(|c| c.as_slice()).collect();
+
+        group.bench_with_input(BenchmarkId::new("per_pair_16", dim), &dim, |bencher, _| {
+            bencher.iter(|| {
+                std::hint::black_box(batch_cosine_similarity(std::hint::black_box(&pairs)))
+            });
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("one_vs_many_16", dim),
+            &dim,
+            |bencher, _| {
+                bencher.iter(|| {
+                    std::hint::black_box(batch_cosine_one_vs_many(
+                        std::hint::black_box(&query),
+                        std::hint::black_box(&candidate_refs),
+                    ))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark the i8 raw dot product kernel at each dimension.
+///
+/// Compares the SIMD path (with software prefetch) against the pure scalar reference,
+/// demonstrating the speedup ratio.
+fn bench_i8_dot_product(c: &mut Criterion) {
+    let mut group = c.benchmark_group("i8_dot_product");
+
+    for &dim in &DIMS {
+        let a_f32 = gen_vec(dim, 0xcccc);
+        let b_f32 = gen_vec(dim, 0xdddd);
+        let a_q = QuantizedVector::from_f32(&a_f32);
+        let b_q = QuantizedVector::from_f32(&b_f32);
+
+        // SIMD path (dispatch: NEON/AVX2/AVX-512 with prefetch)
+        group.bench_with_input(BenchmarkId::new("simd", dim), &dim, |bencher, _| {
+            bencher.iter(|| {
+                std::hint::black_box(dot_product_i8_raw(
+                    std::hint::black_box(&a_q.data),
+                    std::hint::black_box(&b_q.data),
+                ))
+            });
+        });
+
+        // Scalar reference path
+        group.bench_with_input(BenchmarkId::new("scalar", dim), &dim, |bencher, _| {
+            bencher.iter(|| {
+                let sum: i32 = std::hint::black_box(&a_q.data)
+                    .iter()
+                    .zip(std::hint::black_box(&b_q.data).iter())
+                    .map(|(&x, &y)| x as i32 * y as i32)
+                    .sum();
+                std::hint::black_box(sum as f32)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_cosine_fused_vs_original,
+    bench_batch_cosine_one_vs_many,
+    bench_i8_dot_product,
+);
+criterion_main!(benches);

--- a/crates/embed/src/simd/cosine.rs
+++ b/crates/embed/src/simd/cosine.rs
@@ -433,3 +433,71 @@ pub fn batch_cosine_similarity(pairs: &[(&[f32], &[f32])]) -> Vec<f32> {
         })
         .collect()
 }
+
+/// **Unstable**: Fused single-pass cosine similarity; same SIMD path as `cosine_similarity`.
+///
+/// Computes dot(a,b), norm(a), and norm(b) in a single pass over memory using three
+/// simultaneous SIMD accumulators. This is 3x more memory-efficient than computing
+/// each quantity in a separate pass (3x fewer cache-line loads).
+///
+/// The SIMD kernels (AVX-512, AVX2, NEON) already fuse all three reductions internally.
+/// The scalar fallback is also fused here, unlike `cosine_similarity_scalar` which
+/// makes three separate passes.
+///
+/// For pre-normalized vectors, callers should use `dot_product` directly.
+#[inline]
+pub fn cosine_similarity_fused(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    // All SIMD backends already perform a fused single-pass computation.
+    // This entry point makes the guarantee explicit in the public API.
+    cosine_kernel()(a, b)
+}
+
+/// **Unstable**: One-vs-many cosine similarity, pre-computing the query norm once.
+///
+/// When comparing a single query vector against many stored vectors, the query's
+/// L2 norm is constant across all comparisons. This function computes `|query|`
+/// once and reuses it, saving `candidates.len()` square-root operations.
+///
+/// Each dot(query, candidate) and |candidate| are still computed per-pair via
+/// the SIMD kernel (fused with the candidate norm). The per-pair computation
+/// is 2-accumulator fused (dot_qc and norm_c) after the query norm is factored out.
+///
+/// Returns a `Vec<f32>` of cosine similarities in `[-1, 1]`, in the same order
+/// as `candidates`. Returns 0.0 for any candidate whose length differs from the query.
+pub fn batch_cosine_one_vs_many(query: &[f32], candidates: &[&[f32]]) -> Vec<f32> {
+    if query.is_empty() || candidates.is_empty() {
+        return vec![0.0_f32; candidates.len()];
+    }
+
+    // Compute query norm once and reuse across all candidates.
+    let norm_q_sq: f32 = query.iter().map(|x| x * x).sum();
+    if norm_q_sq == 0.0 {
+        return vec![0.0_f32; candidates.len()];
+    }
+    let norm_q = norm_q_sq.sqrt();
+
+    // Use the resolved kernel for the per-pair dot+norm_c computation.
+    // We bypass the full cosine_kernel (which also computes norm_q) by using
+    // the dot_product kernel for dot(q, c) and computing norm_c inline.
+    // This saves one sqrt and one accumulation pass per pair.
+    use super::dot_product::resolved_dot_product_kernel;
+    let dot_kernel = resolved_dot_product_kernel();
+
+    candidates
+        .iter()
+        .map(|&c| {
+            if c.len() != query.len() {
+                return 0.0;
+            }
+            // Compute dot(query, c) via SIMD.
+            let dot_qc = dot_kernel(query, c);
+            // Compute |c| inline (scalar — hot path for HNSW uses pre-stored norms).
+            let norm_c: f32 = c.iter().map(|x| x * x).sum::<f32>().sqrt();
+            let denom = norm_q * norm_c;
+            if denom == 0.0 { 0.0 } else { dot_qc / denom }
+        })
+        .collect()
+}

--- a/crates/embed/src/simd/cosine.rs
+++ b/crates/embed/src/simd/cosine.rs
@@ -472,19 +472,13 @@ pub fn batch_cosine_one_vs_many(query: &[f32], candidates: &[&[f32]]) -> Vec<f32
         return vec![0.0_f32; candidates.len()];
     }
 
-    // Compute query norm once and reuse across all candidates.
-    let norm_q_sq: f32 = query.iter().map(|x| x * x).sum();
-    if norm_q_sq == 0.0 {
-        return vec![0.0_f32; candidates.len()];
-    }
-    let norm_q = norm_q_sq.sqrt();
-
-    // Use the resolved kernel for the per-pair dot+norm_c computation.
-    // We bypass the full cosine_kernel (which also computes norm_q) by using
-    // the dot_product kernel for dot(q, c) and computing norm_c inline.
-    // This saves one sqrt and one accumulation pass per pair.
     use super::dot_product::resolved_dot_product_kernel;
     let dot_kernel = resolved_dot_product_kernel();
+
+    let norm_q = dot_kernel(query, query).sqrt();
+    if norm_q == 0.0 {
+        return vec![0.0_f32; candidates.len()];
+    }
 
     candidates
         .iter()
@@ -492,10 +486,8 @@ pub fn batch_cosine_one_vs_many(query: &[f32], candidates: &[&[f32]]) -> Vec<f32
             if c.len() != query.len() {
                 return 0.0;
             }
-            // Compute dot(query, c) via SIMD.
             let dot_qc = dot_kernel(query, c);
-            // Compute |c| inline (scalar — hot path for HNSW uses pre-stored norms).
-            let norm_c: f32 = c.iter().map(|x| x * x).sum::<f32>().sqrt();
+            let norm_c = dot_kernel(c, c).sqrt();
             let denom = norm_q * norm_c;
             if denom == 0.0 { 0.0 } else { dot_qc / denom }
         })

--- a/crates/embed/src/simd/dot_product.rs
+++ b/crates/embed/src/simd/dot_product.rs
@@ -683,6 +683,17 @@ unsafe fn dot_product_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
+        let next_base = base + CHUNK_SIZE;
+        if next_base + CHUNK_SIZE <= n {
+            core::arch::asm!(
+                "prfm pldl1keep, [{a}]",
+                "prfm pldl1keep, [{b}]",
+                a = in(reg) a.as_ptr().add(next_base),
+                b = in(reg) b.as_ptr().add(next_base),
+                options(nostack, readonly, preserves_flags)
+            );
+        }
+
         let a0 = vld1q_f32(a.as_ptr().add(base));
         let b0 = vld1q_f32(b.as_ptr().add(base));
         sum0 = vfmaq_f32(sum0, a0, b0);

--- a/crates/embed/src/simd/mod.rs
+++ b/crates/embed/src/simd/mod.rs
@@ -68,6 +68,11 @@ pub struct SimdConfig {
     pub avx512vnni_enabled: bool,
     /// **Unstable**: NEON support available (aarch64/ARM64).
     pub neon_enabled: bool,
+    /// **Unstable**: ARM FEAT_DotProd (SDOT/UDOT instructions) available (aarch64).
+    ///
+    /// Mandatory on Armv8.4+; optional on Armv8.2/v8.3. Always false on non-aarch64.
+    /// SDOT kernels must only be dispatched when this is `true`.
+    pub dotprod_enabled: bool,
 }
 
 impl Default for SimdConfig {
@@ -91,17 +96,21 @@ impl SimdConfig {
                     && is_x86_feature_detected!("avx512bw")
                     && is_x86_feature_detected!("avx512vnni"),
                 neon_enabled: false,
+                dotprod_enabled: false,
             }
         }
         #[cfg(target_arch = "aarch64")]
         {
             // NEON is mandatory on aarch64, always available.
+            // FEAT_DotProd (dotprod) is optional: required on Armv8.4+,
+            // optional on Armv8.2/v8.3. Detect at runtime.
             Self {
                 avx512f_enabled: false,
                 avx2_enabled: false,
                 fma_enabled: false,
                 avx512vnni_enabled: false,
                 neon_enabled: true,
+                dotprod_enabled: std::arch::is_aarch64_feature_detected!("dotprod"),
             }
         }
         #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
@@ -112,6 +121,7 @@ impl SimdConfig {
                 fma_enabled: false,
                 avx512vnni_enabled: false,
                 neon_enabled: false,
+                dotprod_enabled: false,
             }
         }
     }
@@ -131,6 +141,7 @@ impl SimdConfig {
             fma_enabled: false,
             avx512vnni_enabled: false,
             neon_enabled: false,
+            dotprod_enabled: false,
         }
     }
 }

--- a/crates/embed/src/simd/mod.rs
+++ b/crates/embed/src/simd/mod.rs
@@ -27,7 +27,9 @@ mod tests;
 
 // Re-export public API
 pub use binary::BinaryVector;
-pub use cosine::{batch_cosine_similarity, cosine_similarity};
+pub use cosine::{
+    batch_cosine_one_vs_many, batch_cosine_similarity, cosine_similarity, cosine_similarity_fused,
+};
 pub use distance::{euclidean_distance, squared_euclidean_distance};
 pub use dot_product::{
     DotBatch4Kernel, DotKernel, batch_dot_product, dot_product, dot_product_batch4,

--- a/crates/embed/src/simd/normalize.rs
+++ b/crates/embed/src/simd/normalize.rs
@@ -315,18 +315,21 @@ unsafe fn normalize_neon_unrolled(vector: &mut [f32]) {
     let norm_vec = vaddq_f32(vaddq_f32(norm0, norm1), vaddq_f32(norm2, norm3));
     let mut norm_sq = horizontal_sum_neon(norm_vec);
 
-    // Remainder for norm calculation
     for val in vector.iter().skip(chunks * CHUNK_SIZE) {
         norm_sq += val * val;
     }
 
-    let norm = norm_sq.sqrt();
-    if norm == 0.0 {
+    if norm_sq == 0.0 {
         return;
     }
 
-    let inv_norm = 1.0 / norm;
-    let inv_norm_vec = vdupq_n_f32(inv_norm);
+    // Fast reciprocal sqrt: 1/sqrt(norm_sq) via NEON estimate + 2 Newton-Raphson steps
+    let nsq = vdupq_n_f32(norm_sq);
+    let mut est = vrsqrteq_f32(nsq);
+    est = vmulq_f32(est, vrsqrtsq_f32(vmulq_f32(nsq, est), est));
+    est = vmulq_f32(est, vrsqrtsq_f32(vmulq_f32(nsq, est), est));
+    let inv_norm = vgetq_lane_f32::<0>(est);
+    let inv_norm_vec = est;
 
     // Second pass: divide by norm with 4x unrolling
     for i in 0..chunks {

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -530,8 +530,8 @@ unsafe fn dot_product_i8_avx2_unrolled(a: &[i8], b: &[i8]) -> f32 {
         // Software prefetch for the next chunk.
         let next_base = base + PREFETCH_DISTANCE;
         if next_base + CHUNK_SIZE <= n {
-            _mm_prefetch(a.as_ptr().add(next_base) as *const i8, _MM_HINT_T0);
-            _mm_prefetch(b.as_ptr().add(next_base) as *const i8, _MM_HINT_T0);
+            _mm_prefetch(a.as_ptr().add(next_base), _MM_HINT_T0);
+            _mm_prefetch(b.as_ptr().add(next_base), _MM_HINT_T0);
         }
 
         // Unroll 0

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -223,7 +223,7 @@ pub(crate) fn dot_product_i8_trusted(a: &QuantizedVector, b: &QuantizedVector) -
     }
     debug_assert!(a.data.iter().all(|&v| v != i8::MIN));
     debug_assert!(b.data.iter().all(|&v| v != i8::MIN));
-    dot_product_i8_raw(&a.data, &b.data) / denom
+    dot_product_i8_dispatch(&a.data, &b.data) / denom
 }
 
 /// **Unstable**: SIMD INT8 cosine similarity; norm storage approach may change.
@@ -260,8 +260,9 @@ pub(crate) fn cosine_similarity_i8_trusted(a: &QuantizedVector, b: &QuantizedVec
 /// # Safety
 ///
 /// Caller must ensure:
-/// - Running on aarch64 (NEON is mandatory, always available)
+/// - Running on aarch64 with FEAT_DotProd (uses SDOT instruction)
 /// - `a` and `b` have equal length (checked by caller)
+/// - No element is i8::MIN (-128) — see SIMD invariant docs
 ///
 /// Memory safety:
 /// - Uses `vld1q_s8` for loads (handles any alignment)
@@ -617,7 +618,7 @@ fn resolve_i8_dot_kernel() -> I8DotKernel {
 
 #[cfg(target_arch = "aarch64")]
 fn dot_product_i8_neon_kernel(a: &[i8], b: &[i8]) -> f32 {
-    // SAFETY: stored only when NEON was detected at init time (always true on aarch64).
+    // SAFETY: stored only when NEON+dotprod detected at init time.
     unsafe { dot_product_i8_neon_unrolled(a, b) }
 }
 
@@ -660,6 +661,13 @@ fn dot_product_i8_scalar_kernel(a: &[i8], b: &[i8]) -> f32 {
 ///
 /// # Performance
 ///
+#[inline]
+fn dot_product_i8_dispatch(a: &[i8], b: &[i8]) -> f32 {
+    resolved_i8_dot_kernel()(a, b)
+}
+
+/// **Unstable**: raw INT8 dot product on slices; SIMD strategy may change.
+///
 /// Uses the same SIMD paths as `dot_product_i8`:
 /// - aarch64: NEON with 4x unrolling + tail SIMD chunks
 /// - x86_64: AVX-512 VNNI > AVX2 > scalar
@@ -671,7 +679,6 @@ pub fn dot_product_i8_raw(a: &[i8], b: &[i8]) -> f32 {
     if a.len() != b.len() {
         return 0.0;
     }
-    // FP-033: Release-mode guard at public boundary. Inner kernels use debug_assert!.
     assert!(
         a.iter().all(|&v| v != -128i8),
         "dot_product_i8_raw: slice a contains -128, violating the [-127, 127] SIMD invariant"
@@ -680,7 +687,7 @@ pub fn dot_product_i8_raw(a: &[i8], b: &[i8]) -> f32 {
         b.iter().all(|&v| v != -128i8),
         "dot_product_i8_raw: slice b contains -128, violating the [-127, 127] SIMD invariant"
     );
-    resolved_i8_dot_kernel()(a, b)
+    dot_product_i8_dispatch(a, b)
 }
 
 #[cfg(test)]
@@ -701,15 +708,23 @@ mod simd_parity_tests {
             .collect()
     }
 
-    // FP-034: NEON vs scalar parity for INT8 dot product.
+    // FP-034: NEON SDOT vs scalar parity for INT8 dot product.
+    // Gated on dotprod: SDOT is FEAT_DotProd, not baseline NEON.
     #[test]
     fn test_i8_neon_scalar_parity() {
+        #[cfg(target_arch = "aarch64")]
+        {
+            if !super::super::SimdConfig::detect().dotprod_enabled {
+                eprintln!("skipping SDOT parity test: dotprod not available");
+                return;
+            }
+        }
         #[cfg(target_arch = "aarch64")]
         for dim in [7usize, 16, 64, 128, 384, 768] {
             let a_q = QuantizedVector::from_f32(&gen_vec(dim, 200 + dim as u64));
             let b_q = QuantizedVector::from_f32(&gen_vec(dim, 300 + dim as u64));
 
-            // SAFETY: NEON is mandatory on aarch64; slices have equal length from from_f32.
+            // SAFETY: dotprod confirmed above; slices have equal length from from_f32.
             let neon = unsafe { dot_product_i8_neon_unrolled(&a_q.data, &b_q.data) };
             let scalar: f32 = a_q
                 .data

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -241,9 +241,10 @@ pub(crate) fn cosine_similarity_i8_trusted(a: &QuantizedVector, b: &QuantizedVec
     dot_product_i8_trusted(a, b) / denom
 }
 
-/// NEON int8 dot product using vmull/vpadal with 4x unrolling.
+/// NEON int8 dot product using vmull/vpadal with 4x unrolling and software prefetch.
 ///
-/// Processes 64 int8s per iteration with 4 accumulators.
+/// Processes 64 int8s per iteration with 4 accumulators. Prefetches the next
+/// cache line (64 bytes) one iteration ahead to hide DRAM latency for large dims.
 ///
 /// # Safety
 ///
@@ -255,12 +256,15 @@ pub(crate) fn cosine_similarity_i8_trusted(a: &QuantizedVector, b: &QuantizedVec
 /// - Uses `vld1q_s8` for loads (handles any alignment)
 /// - Pointer arithmetic stays within slice bounds via chunk calculation
 /// - Remainder handled via safe slice iteration
+/// - Prefetch pointers are bounds-checked before issuing (only prefetch if within slice)
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
     const SIMD_WIDTH: usize = 16;
     const UNROLL: usize = 4;
     const CHUNK_SIZE: usize = SIMD_WIDTH * UNROLL;
+    // Prefetch one full chunk ahead (next iteration's data).
+    const PREFETCH_DISTANCE: usize = CHUNK_SIZE;
     let n = a.len();
     debug_assert_eq!(n, b.len());
     let chunks = n / CHUNK_SIZE;
@@ -273,6 +277,24 @@ unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
 
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
+
+        // Software prefetch for the next chunk to hide memory latency.
+        // Only issue if the prefetch target stays within the slice bounds.
+        // On aarch64 we emit an inline assembly PRFM instruction (stable Rust, no nightly needed).
+        let next_base = base + PREFETCH_DISTANCE;
+        if next_base + CHUNK_SIZE <= n {
+            // PRFM PLDL1KEEP: prefetch for load into L1, keep (retained locality).
+            core::arch::asm!(
+                "prfm pldl1keep, [{ptr}]",
+                ptr = in(reg) a.as_ptr().add(next_base),
+                options(nostack, readonly, preserves_flags)
+            );
+            core::arch::asm!(
+                "prfm pldl1keep, [{ptr}]",
+                ptr = in(reg) b.as_ptr().add(next_base),
+                options(nostack, readonly, preserves_flags)
+            );
+        }
 
         // Unroll 0: Load 16 int8s, split, widening multiply, pairwise add
         let a0 = vld1q_s8(a.as_ptr().add(base));
@@ -467,7 +489,7 @@ unsafe fn dot_product_i8_avx512vnni(a: &[i8], b: &[i8]) -> f32 {
     (sum + remainder) as f32
 }
 
-/// AVX2 int8 dot product with 4x unrolling.
+/// AVX2 int8 dot product with 4x unrolling and software prefetch.
 ///
 /// # Safety
 ///
@@ -479,12 +501,15 @@ unsafe fn dot_product_i8_avx512vnni(a: &[i8], b: &[i8]) -> f32 {
 /// - Uses `_mm256_loadu_si256` for unaligned loads (safe for any alignment)
 /// - Pointer arithmetic stays within slice bounds via chunk calculation
 /// - Remainder handled via safe slice iteration
+/// - Prefetch hint issues `_MM_HINT_T0` only when next chunk is within slice bounds
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn dot_product_i8_avx2_unrolled(a: &[i8], b: &[i8]) -> f32 {
     const SIMD_WIDTH: usize = 32;
     const UNROLL: usize = 4;
     const CHUNK_SIZE: usize = SIMD_WIDTH * UNROLL;
+    // Prefetch one full chunk ahead for both input arrays.
+    const PREFETCH_DISTANCE: usize = CHUNK_SIZE;
     let n = a.len();
     debug_assert_eq!(n, b.len());
     debug_assert!(a.iter().all(|&v| v != i8::MIN));
@@ -501,6 +526,13 @@ unsafe fn dot_product_i8_avx2_unrolled(a: &[i8], b: &[i8]) -> f32 {
 
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
+
+        // Software prefetch for the next chunk.
+        let next_base = base + PREFETCH_DISTANCE;
+        if next_base + CHUNK_SIZE <= n {
+            _mm_prefetch(a.as_ptr().add(next_base) as *const i8, _MM_HINT_T0);
+            _mm_prefetch(b.as_ptr().add(next_base) as *const i8, _MM_HINT_T0);
+        }
 
         // Unroll 0
         let a0 = _mm256_loadu_si256(a.as_ptr().add(base) as *const __m256i);

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -205,7 +205,7 @@ pub fn dot_product_i8(a: &QuantizedVector, b: &QuantizedVector) -> f32 {
         return 0.0;
     }
 
-    dot_product_i8_raw(&a.data, &b.data) / denom
+    dot_product_i8_dispatch(&a.data, &b.data) / denom
 }
 
 /// Trusted INT8 dot product for constructor-owned vectors in prepared-query paths.

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -295,41 +295,30 @@ unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
 
         let a0 = vld1q_s8(a.as_ptr().add(base));
         let b0 = vld1q_s8(b.as_ptr().add(base));
-        core::arch::asm!(
-            "sdot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
-            acc = inout(vreg) sum0,
-            a = in(vreg) a0,
-            b = in(vreg) b0,
-            options(pure, nomem, nostack, preserves_flags)
-        );
-
         let a1 = vld1q_s8(a.as_ptr().add(base + SIMD_WIDTH));
         let b1 = vld1q_s8(b.as_ptr().add(base + SIMD_WIDTH));
-        core::arch::asm!(
-            "sdot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
-            acc = inout(vreg) sum1,
-            a = in(vreg) a1,
-            b = in(vreg) b1,
-            options(pure, nomem, nostack, preserves_flags)
-        );
-
         let a2 = vld1q_s8(a.as_ptr().add(base + SIMD_WIDTH * 2));
         let b2 = vld1q_s8(b.as_ptr().add(base + SIMD_WIDTH * 2));
-        core::arch::asm!(
-            "sdot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
-            acc = inout(vreg) sum2,
-            a = in(vreg) a2,
-            b = in(vreg) b2,
-            options(pure, nomem, nostack, preserves_flags)
-        );
-
         let a3 = vld1q_s8(a.as_ptr().add(base + SIMD_WIDTH * 3));
         let b3 = vld1q_s8(b.as_ptr().add(base + SIMD_WIDTH * 3));
+
         core::arch::asm!(
-            "sdot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
-            acc = inout(vreg) sum3,
-            a = in(vreg) a3,
-            b = in(vreg) b3,
+            "sdot {s0:v}.4s, {a0:v}.16b, {b0:v}.16b",
+            "sdot {s1:v}.4s, {a1:v}.16b, {b1:v}.16b",
+            "sdot {s2:v}.4s, {a2:v}.16b, {b2:v}.16b",
+            "sdot {s3:v}.4s, {a3:v}.16b, {b3:v}.16b",
+            s0 = inout(vreg) sum0,
+            a0 = in(vreg) a0,
+            b0 = in(vreg) b0,
+            s1 = inout(vreg) sum1,
+            a1 = in(vreg) a1,
+            b1 = in(vreg) b1,
+            s2 = inout(vreg) sum2,
+            a2 = in(vreg) a2,
+            b2 = in(vreg) b2,
+            s3 = inout(vreg) sum3,
+            a3 = in(vreg) a3,
+            b3 = in(vreg) b3,
             options(pure, nomem, nostack, preserves_flags)
         );
     }

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -157,6 +157,16 @@ impl QuantizedVector {
 /// Returns the approximate float dot product.
 /// Returns 0.0 if vectors have different lengths.
 ///
+/// # Invariant
+///
+/// Both vectors must satisfy the `[-127, 127]` range invariant. The value `-128`
+/// causes silent corruption in AVX2 (`_mm256_sign_epi8` saturation) and AVX-512
+/// VNNI (`_mm512_dpbusd_epi32` after `vpabsb`). This function enforces the invariant
+/// with a release-mode `assert!` at the public boundary so callers that bypass
+/// `QuantizedVector::from_f32` (which clamps correctly) are caught immediately.
+///
+/// Hot inner kernels use `debug_assert!` only — the O(N) scan is paid once here.
+///
 /// # Feature gate asymmetry
 ///
 /// The float32 AVX-512F path (dot_product, cosine, normalize, distance) activates
@@ -171,13 +181,15 @@ impl QuantizedVector {
 /// Cargo feature to opt in to the extended instruction sets at compile time.
 #[inline]
 pub fn dot_product_i8(a: &QuantizedVector, b: &QuantizedVector) -> f32 {
-    // FP-033: -128 causes incorrect results in AVX-512 VNNI via vpabsb saturation.
-    // from_f32 clamps to [-127, 127]; debug_assert catches misuse without O(N) overhead.
-    debug_assert!(
+    // FP-033: -128 causes incorrect results in AVX-512 VNNI via vpabsb saturation
+    // and in AVX2 via _mm256_sign_epi8 saturation. Release-mode assert at the public
+    // boundary — callers that produce data outside from_f32 are caught here.
+    // Inner hot-path kernels use debug_assert! only (scan cost paid once, here).
+    assert!(
         a.data.iter().all(|&v| v != -128i8),
         "QuantizedVector a contains -128, which violates the [-127, 127] VNNI invariant"
     );
-    debug_assert!(
+    assert!(
         b.data.iter().all(|&v| v != -128i8),
         "QuantizedVector b contains -128, which violates the [-127, 127] VNNI invariant"
     );
@@ -580,7 +592,9 @@ fn resolve_i8_dot_kernel() -> I8DotKernel {
 
     #[cfg(target_arch = "aarch64")]
     {
-        if config.neon_enabled {
+        // The NEON kernel uses SDOT (ARMv8.2 FEAT_DotProd), which is optional on
+        // Armv8.2/v8.3. Only dispatch when dotprod_enabled is confirmed at runtime.
+        if config.neon_enabled && config.dotprod_enabled {
             return dot_product_i8_neon_kernel;
         }
     }
@@ -638,6 +652,12 @@ fn dot_product_i8_scalar_kernel(a: &[i8], b: &[i8]) -> f32 {
 ///
 /// Returns 0.0 if slices have different lengths.
 ///
+/// # Invariant
+///
+/// Both slices must satisfy the `[-127, 127]` range invariant. The value `-128`
+/// causes silent corruption in AVX2 and AVX-512 VNNI SIMD paths. This function
+/// enforces the invariant with a release-mode `assert!` at the public boundary.
+///
 /// # Performance
 ///
 /// Uses the same SIMD paths as `dot_product_i8`:
@@ -651,7 +671,15 @@ pub fn dot_product_i8_raw(a: &[i8], b: &[i8]) -> f32 {
     if a.len() != b.len() {
         return 0.0;
     }
-    debug_assert_eq!(a.len(), b.len());
+    // FP-033: Release-mode guard at public boundary. Inner kernels use debug_assert!.
+    assert!(
+        a.iter().all(|&v| v != -128i8),
+        "dot_product_i8_raw: slice a contains -128, violating the [-127, 127] SIMD invariant"
+    );
+    assert!(
+        b.iter().all(|&v| v != -128i8),
+        "dot_product_i8_raw: slice b contains -128, violating the [-127, 127] SIMD invariant"
+    );
     resolved_i8_dot_kernel()(a, b)
 }
 

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -263,27 +263,24 @@ unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
     const SIMD_WIDTH: usize = 16;
     const UNROLL: usize = 4;
     const CHUNK_SIZE: usize = SIMD_WIDTH * UNROLL;
-    // Prefetch one full chunk ahead (next iteration's data).
     const PREFETCH_DISTANCE: usize = CHUNK_SIZE;
     let n = a.len();
     debug_assert_eq!(n, b.len());
     let chunks = n / CHUNK_SIZE;
 
-    // 4 independent int32 accumulators
     let mut sum0 = vdupq_n_s32(0);
     let mut sum1 = vdupq_n_s32(0);
     let mut sum2 = vdupq_n_s32(0);
     let mut sum3 = vdupq_n_s32(0);
 
+    // Use SDOT (ARMv8.2 dotprod) via inline asm — 1 instruction per 16 i8 elements
+    // vs 6 instructions (split + vmull×2 + vpadalq×2) with the widening approach.
+    // Apple Silicon (M1+) supports dotprod; runtime check at dispatch level.
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
-        // Software prefetch for the next chunk to hide memory latency.
-        // Only issue if the prefetch target stays within the slice bounds.
-        // On aarch64 we emit an inline assembly PRFM instruction (stable Rust, no nightly needed).
         let next_base = base + PREFETCH_DISTANCE;
         if next_base + CHUNK_SIZE <= n {
-            // PRFM PLDL1KEEP: prefetch for load into L1, keep (retained locality).
             core::arch::asm!(
                 "prfm pldl1keep, [{ptr}]",
                 ptr = in(reg) a.as_ptr().add(next_base),
@@ -296,83 +293,68 @@ unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
             );
         }
 
-        // Unroll 0: Load 16 int8s, split, widening multiply, pairwise add
         let a0 = vld1q_s8(a.as_ptr().add(base));
         let b0 = vld1q_s8(b.as_ptr().add(base));
-        let a0_lo = vget_low_s8(a0);
-        let a0_hi = vget_high_s8(a0);
-        let b0_lo = vget_low_s8(b0);
-        let b0_hi = vget_high_s8(b0);
-        let prod0_lo = vmull_s8(a0_lo, b0_lo);
-        let prod0_hi = vmull_s8(a0_hi, b0_hi);
-        sum0 = vpadalq_s16(sum0, prod0_lo);
-        sum0 = vpadalq_s16(sum0, prod0_hi);
+        core::arch::asm!(
+            "sdot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
+            acc = inout(vreg) sum0,
+            a = in(vreg) a0,
+            b = in(vreg) b0,
+            options(pure, nomem, nostack, preserves_flags)
+        );
 
-        // Unroll 1
         let a1 = vld1q_s8(a.as_ptr().add(base + SIMD_WIDTH));
         let b1 = vld1q_s8(b.as_ptr().add(base + SIMD_WIDTH));
-        let a1_lo = vget_low_s8(a1);
-        let a1_hi = vget_high_s8(a1);
-        let b1_lo = vget_low_s8(b1);
-        let b1_hi = vget_high_s8(b1);
-        let prod1_lo = vmull_s8(a1_lo, b1_lo);
-        let prod1_hi = vmull_s8(a1_hi, b1_hi);
-        sum1 = vpadalq_s16(sum1, prod1_lo);
-        sum1 = vpadalq_s16(sum1, prod1_hi);
+        core::arch::asm!(
+            "sdot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
+            acc = inout(vreg) sum1,
+            a = in(vreg) a1,
+            b = in(vreg) b1,
+            options(pure, nomem, nostack, preserves_flags)
+        );
 
-        // Unroll 2
         let a2 = vld1q_s8(a.as_ptr().add(base + SIMD_WIDTH * 2));
         let b2 = vld1q_s8(b.as_ptr().add(base + SIMD_WIDTH * 2));
-        let a2_lo = vget_low_s8(a2);
-        let a2_hi = vget_high_s8(a2);
-        let b2_lo = vget_low_s8(b2);
-        let b2_hi = vget_high_s8(b2);
-        let prod2_lo = vmull_s8(a2_lo, b2_lo);
-        let prod2_hi = vmull_s8(a2_hi, b2_hi);
-        sum2 = vpadalq_s16(sum2, prod2_lo);
-        sum2 = vpadalq_s16(sum2, prod2_hi);
+        core::arch::asm!(
+            "sdot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
+            acc = inout(vreg) sum2,
+            a = in(vreg) a2,
+            b = in(vreg) b2,
+            options(pure, nomem, nostack, preserves_flags)
+        );
 
-        // Unroll 3
         let a3 = vld1q_s8(a.as_ptr().add(base + SIMD_WIDTH * 3));
         let b3 = vld1q_s8(b.as_ptr().add(base + SIMD_WIDTH * 3));
-        let a3_lo = vget_low_s8(a3);
-        let a3_hi = vget_high_s8(a3);
-        let b3_lo = vget_low_s8(b3);
-        let b3_hi = vget_high_s8(b3);
-        let prod3_lo = vmull_s8(a3_lo, b3_lo);
-        let prod3_hi = vmull_s8(a3_hi, b3_hi);
-        sum3 = vpadalq_s16(sum3, prod3_lo);
-        sum3 = vpadalq_s16(sum3, prod3_hi);
+        core::arch::asm!(
+            "sdot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
+            acc = inout(vreg) sum3,
+            a = in(vreg) a3,
+            b = in(vreg) b3,
+            options(pure, nomem, nostack, preserves_flags)
+        );
     }
 
-    // Combine accumulators
     let sum01 = vaddq_s32(sum0, sum1);
     let sum23 = vaddq_s32(sum2, sum3);
     let mut sum_vec = vaddq_s32(sum01, sum23);
 
-    // Tail SIMD chunks: process remaining full 16-byte vectors before scalar tail.
-    // Helps dimensions like 127 (3 tail chunks) or 129 (0 tail chunks, 1 scalar byte).
+    // Tail: remaining full 16-byte vectors using sdot
     let tail_start = chunks * CHUNK_SIZE;
     let tail_chunks = (n - tail_start) / SIMD_WIDTH;
     for j in 0..tail_chunks {
         let base = tail_start + j * SIMD_WIDTH;
         let at = vld1q_s8(a.as_ptr().add(base));
         let bt = vld1q_s8(b.as_ptr().add(base));
-        let at_lo = vget_low_s8(at);
-        let at_hi = vget_high_s8(at);
-        let bt_lo = vget_low_s8(bt);
-        let bt_hi = vget_high_s8(bt);
-        let pt_lo = vmull_s8(at_lo, bt_lo);
-        let pt_hi = vmull_s8(at_hi, bt_hi);
-        sum_vec = vpadalq_s16(sum_vec, pt_lo);
-        sum_vec = vpadalq_s16(sum_vec, pt_hi);
+        core::arch::asm!(
+            "sdot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
+            acc = inout(vreg) sum_vec,
+            a = in(vreg) at,
+            b = in(vreg) bt,
+            options(pure, nomem, nostack, preserves_flags)
+        );
     }
 
-    // Horizontal sum
-    let sum = vgetq_lane_s32(sum_vec, 0)
-        + vgetq_lane_s32(sum_vec, 1)
-        + vgetq_lane_s32(sum_vec, 2)
-        + vgetq_lane_s32(sum_vec, 3);
+    let sum = vaddvq_s32(sum_vec);
 
     // Scalar tail: only the final < SIMD_WIDTH elements
     let remainder_start = tail_start + tail_chunks * SIMD_WIDTH;

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -171,14 +171,13 @@ impl QuantizedVector {
 /// Cargo feature to opt in to the extended instruction sets at compile time.
 #[inline]
 pub fn dot_product_i8(a: &QuantizedVector, b: &QuantizedVector) -> f32 {
-    // FP-033: enforce at call time (not just debug) — -128 causes incorrect results
-    // in AVX-512 VNNI via vpabsb saturation; from_f32 clamps to [-127, 127] but
-    // the data field is pub so callers can bypass the constructor.
-    assert!(
+    // FP-033: -128 causes incorrect results in AVX-512 VNNI via vpabsb saturation.
+    // from_f32 clamps to [-127, 127]; debug_assert catches misuse without O(N) overhead.
+    debug_assert!(
         a.data.iter().all(|&v| v != -128i8),
         "QuantizedVector a contains -128, which violates the [-127, 127] VNNI invariant"
     );
-    assert!(
+    debug_assert!(
         b.data.iter().all(|&v| v != -128i8),
         "QuantizedVector b contains -128, which violates the [-127, 127] VNNI invariant"
     );

--- a/crates/embed/src/simd/tests.rs
+++ b/crates/embed/src/simd/tests.rs
@@ -731,3 +731,127 @@ mod proptests {
         }
     }
 }
+
+// ============================================================================
+// OPTIMIZATION CORRECTNESS TESTS (added with perf(embed) optimizations)
+// ============================================================================
+
+/// Verify that `cosine_similarity_fused` produces the same result as `cosine_similarity`.
+///
+/// Both routes through the same SIMD kernel; this test documents the guarantee
+/// that the fused single-pass path matches the dispatch path at every dimension.
+#[test]
+fn test_cosine_fused_matches_separate() {
+    for &dim in &[7usize, 15, 64, 128, 384, 768, 1536] {
+        let a = generate_random_vector_seeded(dim, 0xf00d_dead + dim as u64);
+        let b = generate_random_vector_seeded(dim, 0xbeef_cafe + dim as u64);
+
+        let separate = cosine_similarity(&a, &b);
+        let fused = cosine_similarity_fused(&a, &b);
+
+        let diff = (separate - fused).abs();
+        assert!(
+            diff < 1e-6,
+            "cosine_similarity_fused vs cosine_similarity at dim={dim}: separate={separate}, fused={fused}, diff={diff}"
+        );
+    }
+}
+
+/// Edge cases for `cosine_similarity_fused`: zero vectors, mismatched lengths, identical vectors.
+#[test]
+fn test_cosine_fused_edge_cases() {
+    // Empty input
+    let result = cosine_similarity_fused(&[], &[]);
+    assert_eq!(result, 0.0, "fused: empty slices should return 0.0");
+
+    // Length mismatch
+    let a = vec![1.0_f32, 2.0, 3.0];
+    let b = vec![1.0_f32, 2.0];
+    assert_eq!(
+        cosine_similarity_fused(&a, &b),
+        0.0,
+        "fused: length mismatch should return 0.0"
+    );
+
+    // Identical non-zero vector -> similarity 1.0
+    let v = vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+    let sim = cosine_similarity_fused(&v, &v);
+    assert!(
+        (sim - 1.0).abs() < 1e-6,
+        "fused: identical vectors should have similarity 1.0, got {sim}"
+    );
+}
+
+/// Verify that `batch_cosine_one_vs_many` matches per-pair `cosine_similarity` calls.
+#[test]
+fn test_batch_cosine_one_vs_many_matches_per_pair() {
+    let query = generate_random_vector_seeded(384, 0x1111_2222);
+    let candidates: Vec<Vec<f32>> = (0..8)
+        .map(|i| generate_random_vector_seeded(384, 0x3333_0000 + i as u64))
+        .collect();
+    let candidate_refs: Vec<&[f32]> = candidates.iter().map(|c| c.as_slice()).collect();
+
+    let batch = batch_cosine_one_vs_many(&query, &candidate_refs);
+    assert_eq!(batch.len(), 8);
+
+    for (i, c) in candidates.iter().enumerate() {
+        let expected = cosine_similarity(&query, c);
+        let diff = (batch[i] - expected).abs();
+        assert!(
+            diff < 1e-5,
+            "batch_cosine_one_vs_many[{i}] at dim=384: batch={}, per-pair={}, diff={}",
+            batch[i],
+            expected,
+            diff
+        );
+    }
+}
+
+/// `batch_cosine_one_vs_many` returns zeros for mismatched dimensions, not panics.
+#[test]
+fn test_batch_cosine_one_vs_many_dim_mismatch() {
+    let query = vec![1.0_f32, 2.0, 3.0];
+    let good = vec![4.0_f32, 5.0, 6.0];
+    let bad = vec![1.0_f32, 2.0]; // wrong length
+    let refs: Vec<&[f32]> = vec![good.as_slice(), bad.as_slice()];
+
+    let results = batch_cosine_one_vs_many(&query, &refs);
+    assert_eq!(results.len(), 2);
+    // good candidate should produce a valid similarity
+    assert!(
+        results[0].is_finite(),
+        "good candidate should produce finite similarity"
+    );
+    // bad candidate (dim mismatch) should return 0.0
+    assert_eq!(results[1], 0.0, "dim-mismatch candidate should return 0.0");
+}
+
+/// Verify that the i8 dot product raw kernel (with prefetch) produces the same result
+/// as the scalar reference across all standard embedding dimensions.
+#[test]
+fn test_i8_dot_unrolled_matches_original() {
+    for &dim in &[7usize, 15, 16, 64, 128, 384, 768, 1536] {
+        let a_f32 = generate_random_vector_seeded(dim, 0xaaaa_0000 + dim as u64);
+        let b_f32 = generate_random_vector_seeded(dim, 0xbbbb_0000 + dim as u64);
+
+        let a_q = QuantizedVector::from_f32(&a_f32);
+        let b_q = QuantizedVector::from_f32(&b_f32);
+
+        // Scalar reference: direct i32 accumulation over raw i8 slices.
+        let scalar: f32 = a_q
+            .data
+            .iter()
+            .zip(b_q.data.iter())
+            .map(|(&x, &y)| x as i32 * y as i32)
+            .sum::<i32>() as f32;
+
+        // SIMD path (with prefetch via dot_product_i8_raw).
+        let simd = dot_product_i8_raw(&a_q.data, &b_q.data);
+
+        let diff = (simd - scalar).abs();
+        assert!(
+            diff <= 1.0,
+            "i8 dot product (SIMD with prefetch) vs scalar at dim={dim}: simd={simd}, scalar={scalar}, diff={diff}"
+        );
+    }
+}

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -118,6 +118,10 @@ proptest = { workspace = true }
 tempfile = { workspace = true }
 
 [[bench]]
+name = "elementwise_bench"
+harness = false
+
+[[bench]]
 name = "attention_bench"
 harness = true
 

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -178,5 +178,9 @@ name = "mtp_decode"
 harness = false
 required-features = ["metal-gpu", "f16"]
 
+[[bench]]
+name = "matmul_opt_bench"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -118,6 +118,10 @@ proptest = { workspace = true }
 tempfile = { workspace = true }
 
 [[bench]]
+name = "attn_opt_bench"
+harness = false
+
+[[bench]]
 name = "attention_bench"
 harness = true
 

--- a/crates/inference/benches/attn_opt_bench.rs
+++ b/crates/inference/benches/attn_opt_bench.rs
@@ -1,0 +1,190 @@
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use lattice_inference::attention::decode::{decode_attention, decode_attention_scores};
+use lattice_inference::attention::gqa::GqaConfig;
+
+const HEAD_DIM: usize = 128;
+const KV_SEQ_LENS: [usize; 3] = [128, 512, 2048];
+
+#[derive(Clone, Copy, Debug)]
+struct AttentionCase {
+    name: &'static str,
+    num_heads: usize,
+    num_kv_heads: usize,
+}
+
+const CASES: [AttentionCase; 3] = [
+    AttentionCase {
+        name: "mha_q32_kv32",
+        num_heads: 32,
+        num_kv_heads: 32,
+    },
+    AttentionCase {
+        name: "mha_q8_kv8",
+        num_heads: 8,
+        num_kv_heads: 8,
+    },
+    AttentionCase {
+        name: "gqa_q32_kv8",
+        num_heads: 32,
+        num_kv_heads: 8,
+    },
+];
+
+/// Deterministic decode-attention fixture for Criterion benchmarks.
+///
+/// Shapes:
+/// - `q`: `[num_heads * HEAD_DIM]`
+/// - `k`: `[kv_seq_len, num_kv_heads * HEAD_DIM]`
+/// - `v`: `[kv_seq_len, num_kv_heads * HEAD_DIM]`
+/// - `scores`: `[num_heads, kv_seq_len]`
+/// - `output`: `[num_heads * HEAD_DIM]`
+struct DecodeAttentionFixture {
+    cfg: GqaConfig,
+    q: Vec<f32>,
+    k: Vec<f32>,
+    v: Vec<f32>,
+    scores: Vec<f32>,
+    output: Vec<f32>,
+    kv_seq_len: usize,
+}
+
+fn tensor_value(kind: u32, i: usize) -> f32 {
+    let mut x = (i as u32)
+        .wrapping_mul(1_664_525)
+        .wrapping_add(1_013_904_223 ^ kind.wrapping_mul(0x9E37_79B9));
+    x ^= x >> 16;
+    x = x.wrapping_mul(0x7FEB_352D);
+    x ^= x >> 15;
+    x = x.wrapping_mul(0x846C_A68B);
+    x ^= x >> 16;
+    let unit = ((x & 0x00FF_FFFF) as f32) / 16_777_216.0;
+    (unit - 0.5) * 0.125
+}
+
+fn build_q(num_heads: usize) -> Vec<f32> {
+    // Flat shape: [num_heads * HEAD_DIM] (q_seq_len = 1).
+    (0..num_heads * HEAD_DIM)
+        .map(|i| tensor_value(1, i))
+        .collect()
+}
+
+fn build_kv(kind: u32, num_kv_heads: usize, kv_seq_len: usize) -> Vec<f32> {
+    // Logical shape: [n_kv_heads, kv_seq_len, HEAD_DIM].
+    // Flat shape:    [kv_seq_len, n_kv_heads * HEAD_DIM].
+    let kv_dim = num_kv_heads * HEAD_DIM;
+    let mut buffer = vec![0.0f32; kv_seq_len * kv_dim];
+    for kv_h in 0..num_kv_heads {
+        for pos in 0..kv_seq_len {
+            for d in 0..HEAD_DIM {
+                let logical_index = (kv_h * kv_seq_len + pos) * HEAD_DIM + d;
+                let flat_index = pos * kv_dim + kv_h * HEAD_DIM + d;
+                buffer[flat_index] = tensor_value(kind, logical_index);
+            }
+        }
+    }
+    buffer
+}
+
+impl DecodeAttentionFixture {
+    fn new(case: AttentionCase, kv_seq_len: usize) -> Self {
+        let cfg = GqaConfig {
+            num_heads: case.num_heads,
+            num_kv_heads: case.num_kv_heads,
+            head_dim: HEAD_DIM,
+        };
+        let q = build_q(case.num_heads);
+        let k = build_kv(2, case.num_kv_heads, kv_seq_len);
+        let v = build_kv(3, case.num_kv_heads, kv_seq_len);
+        let scores = vec![0.0f32; case.num_heads * kv_seq_len];
+        let output = vec![0.0f32; case.num_heads * HEAD_DIM];
+
+        Self {
+            cfg,
+            q,
+            k,
+            v,
+            scores,
+            output,
+            kv_seq_len,
+        }
+    }
+
+    fn kv_bytes_per_decode_step(&self) -> u64 {
+        (2 * self.kv_seq_len * self.cfg.kv_dim() * std::mem::size_of::<f32>()) as u64
+    }
+}
+
+fn bench_decode_scores(c: &mut Criterion) {
+    let mut group = c.benchmark_group("attn_opt_scores");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(1));
+
+    for &kv_seq_len in &KV_SEQ_LENS {
+        for case in CASES {
+            let mut fixture = DecodeAttentionFixture::new(case, kv_seq_len);
+            group.throughput(Throughput::Bytes(
+                (fixture.k.len() * std::mem::size_of::<f32>()) as u64,
+            ));
+            group.bench_with_input(
+                BenchmarkId::new(case.name, kv_seq_len),
+                &kv_seq_len,
+                |b, &kv_len| {
+                    b.iter(|| {
+                        decode_attention_scores(
+                            black_box(fixture.q.as_slice()),
+                            black_box(fixture.k.as_slice()),
+                            black_box(fixture.scores.as_mut_slice()),
+                            kv_len,
+                            fixture.cfg,
+                            kv_len,
+                        );
+                        black_box(fixture.scores.as_slice());
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_decode_full_attention(c: &mut Criterion) {
+    let mut group = c.benchmark_group("attn_opt_full_attention");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(1));
+
+    for &kv_seq_len in &KV_SEQ_LENS {
+        for case in CASES {
+            let mut fixture = DecodeAttentionFixture::new(case, kv_seq_len);
+            group.throughput(Throughput::Bytes(fixture.kv_bytes_per_decode_step()));
+            group.bench_with_input(
+                BenchmarkId::new(case.name, kv_seq_len),
+                &kv_seq_len,
+                |b, &kv_len| {
+                    b.iter(|| {
+                        decode_attention(
+                            black_box(fixture.q.as_slice()),
+                            black_box(fixture.k.as_slice()),
+                            black_box(fixture.v.as_slice()),
+                            black_box(fixture.output.as_mut_slice()),
+                            black_box(fixture.scores.as_mut_slice()),
+                            kv_len,
+                            fixture.cfg,
+                            kv_len,
+                        );
+                        black_box(fixture.output.as_slice());
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_decode_scores, bench_decode_full_attention);
+criterion_main!(benches);

--- a/crates/inference/benches/elementwise_bench.rs
+++ b/crates/inference/benches/elementwise_bench.rs
@@ -1,0 +1,106 @@
+//! Criterion benchmarks for SIMD elementwise operations.
+//!
+//! Measures `rms_norm`, `silu_inplace`, and `elementwise_mul` throughput at
+//! hidden sizes representative of deployed models:
+//!   896  — Qwen3.5-0.6B / Qwen2-0.5B
+//!   2048 — Qwen3.5-1.5B
+//!   4096 — Qwen3.5-7B / LLaMA-3-8B
+//!
+//! Run with:
+//!   cargo bench -p lattice-inference --bench elementwise_bench
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use lattice_inference::forward::cpu::{elementwise_mul, rms_norm, silu_inplace};
+
+// ---------------------------------------------------------------------------
+// Deterministic test-data generator (LCG, avoids pulling in random crates)
+// ---------------------------------------------------------------------------
+
+fn lcg_f32_vec(len: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed ^ 0x6c62_272e_07bb_0142;
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        let unit = (state >> 32) as f32 / u32::MAX as f32;
+        out.push(unit * 0.04 - 0.02);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// rms_norm benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_rms_norm(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rms_norm");
+    let eps = 1e-6f32;
+    let num_tokens = 8usize;
+
+    for &hidden in &[896usize, 2048, 4096] {
+        let gamma = lcg_f32_vec(hidden, 0xA000_0000_0000_0001);
+        let bytes = num_tokens * hidden * std::mem::size_of::<f32>();
+        group.throughput(Throughput::Bytes(bytes as u64));
+
+        group.bench_with_input(BenchmarkId::new("dispatch", hidden), &hidden, |b, &h| {
+            let mut x = lcg_f32_vec(num_tokens * h, 0xB000_0000_0000_0001);
+            b.iter(|| {
+                rms_norm(
+                    std::hint::black_box(&mut x),
+                    std::hint::black_box(&gamma),
+                    std::hint::black_box(h),
+                    std::hint::black_box(eps),
+                );
+            });
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// silu_inplace benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_silu(c: &mut Criterion) {
+    let mut group = c.benchmark_group("silu_inplace");
+
+    for &hidden in &[896usize, 2048, 4096] {
+        let bytes = hidden * std::mem::size_of::<f32>();
+        group.throughput(Throughput::Bytes(bytes as u64));
+
+        group.bench_with_input(BenchmarkId::new("dispatch", hidden), &hidden, |b, &h| {
+            let mut x = lcg_f32_vec(h, 0xC000_0000_0000_0001);
+            b.iter(|| {
+                silu_inplace(std::hint::black_box(&mut x));
+            });
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// elementwise_mul benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_elementwise_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("elementwise_mul");
+
+    for &hidden in &[896usize, 2048, 4096] {
+        // Two slices read + one write per element.
+        let bytes = hidden * 3 * std::mem::size_of::<f32>();
+        group.throughput(Throughput::Bytes(bytes as u64));
+
+        group.bench_with_input(BenchmarkId::new("dispatch", hidden), &hidden, |b, &h| {
+            let mut a = lcg_f32_vec(h, 0xD000_0000_0000_0001);
+            let b_vec = lcg_f32_vec(h, 0xE000_0000_0000_0001);
+            b.iter(|| {
+                elementwise_mul(std::hint::black_box(&mut a), std::hint::black_box(&b_vec));
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_rms_norm, bench_silu, bench_elementwise_mul);
+criterion_main!(benches);

--- a/crates/inference/benches/elementwise_bench.rs
+++ b/crates/inference/benches/elementwise_bench.rs
@@ -10,8 +10,10 @@
 //!   cargo bench -p lattice-inference --bench elementwise_bench
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use lattice_inference::attention::decode::decode_attention;
+use lattice_inference::attention::gqa::GqaConfig;
 use lattice_inference::forward::cpu::{
-    add_bias_gelu, elementwise_mul, gelu, rms_norm, silu_inplace, softmax_attention,
+    add_bias_gelu, elementwise_mul, gelu, layer_norm, rms_norm, silu_inplace, softmax_attention,
 };
 
 // ---------------------------------------------------------------------------
@@ -166,6 +168,73 @@ fn bench_add_bias_gelu(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_layer_norm(c: &mut Criterion) {
+    let mut group = c.benchmark_group("layer_norm");
+    let eps = 1e-6f32;
+    let num_tokens = 8usize;
+
+    for &hidden in &[896usize, 2048, 4096] {
+        let gamma = lcg_f32_vec(hidden, 0xA200_0000_0000_0001);
+        let beta = lcg_f32_vec(hidden, 0xA300_0000_0000_0001);
+        let bytes = num_tokens * hidden * std::mem::size_of::<f32>();
+        group.throughput(Throughput::Bytes(bytes as u64));
+
+        group.bench_with_input(BenchmarkId::new("dispatch", hidden), &hidden, |b, &h| {
+            let mut x = lcg_f32_vec(num_tokens * h, 0xA400_0000_0000_0001);
+            b.iter(|| {
+                layer_norm(
+                    std::hint::black_box(&mut x),
+                    std::hint::black_box(&gamma),
+                    std::hint::black_box(&beta),
+                    std::hint::black_box(h),
+                    std::hint::black_box(eps),
+                );
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_decode_attention(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode_attention");
+    let cfg = GqaConfig {
+        num_heads: 16,
+        num_kv_heads: 2,
+        head_dim: 128,
+    };
+
+    for &kv_len in &[128usize, 512, 2048] {
+        let q = lcg_f32_vec(cfg.q_dim(), 0xDA00_0000_0000_0001);
+        let k = lcg_f32_vec(kv_len * cfg.kv_dim(), 0xDB00_0000_0000_0001);
+        let v = lcg_f32_vec(kv_len * cfg.kv_dim(), 0xDC00_0000_0000_0001);
+
+        let bytes = (cfg.q_dim() + 2 * kv_len * cfg.kv_dim()) * std::mem::size_of::<f32>();
+        group.throughput(Throughput::Bytes(bytes as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("gqa_16h2kv_hd128", kv_len),
+            &kv_len,
+            |b, &kl| {
+                let mut out = vec![0.0f32; cfg.q_dim()];
+                let mut scores = vec![0.0f32; cfg.num_heads * kl];
+                b.iter(|| {
+                    decode_attention(
+                        std::hint::black_box(&q),
+                        std::hint::black_box(&k),
+                        std::hint::black_box(&v),
+                        std::hint::black_box(&mut out),
+                        std::hint::black_box(&mut scores),
+                        std::hint::black_box(kl),
+                        std::hint::black_box(cfg),
+                        std::hint::black_box(kl),
+                    );
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_rms_norm,
@@ -173,6 +242,8 @@ criterion_group!(
     bench_elementwise_mul,
     bench_gelu,
     bench_softmax,
-    bench_add_bias_gelu
+    bench_add_bias_gelu,
+    bench_layer_norm,
+    bench_decode_attention
 );
 criterion_main!(benches);

--- a/crates/inference/benches/elementwise_bench.rs
+++ b/crates/inference/benches/elementwise_bench.rs
@@ -10,7 +10,9 @@
 //!   cargo bench -p lattice-inference --bench elementwise_bench
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use lattice_inference::forward::cpu::{elementwise_mul, rms_norm, silu_inplace};
+use lattice_inference::forward::cpu::{
+    add_bias_gelu, elementwise_mul, gelu, rms_norm, silu_inplace, softmax_attention,
+};
 
 // ---------------------------------------------------------------------------
 // Deterministic test-data generator (LCG, avoids pulling in random crates)
@@ -102,5 +104,75 @@ fn bench_elementwise_mul(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_rms_norm, bench_silu, bench_elementwise_mul);
+fn bench_gelu(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gelu");
+
+    for &hidden in &[896usize, 2048, 4096] {
+        let bytes = hidden * std::mem::size_of::<f32>();
+        group.throughput(Throughput::Bytes(bytes as u64));
+
+        group.bench_with_input(BenchmarkId::new("dispatch", hidden), &hidden, |b, &h| {
+            let mut x = lcg_f32_vec(h, 0xF000_0000_0000_0001);
+            b.iter(|| {
+                gelu(std::hint::black_box(&mut x));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_softmax(c: &mut Criterion) {
+    let mut group = c.benchmark_group("softmax_attention");
+    let num_heads = 8usize;
+
+    for &seq_len in &[32usize, 64, 128] {
+        let size = num_heads * seq_len * seq_len;
+        let bytes = size * std::mem::size_of::<f32>();
+        group.throughput(Throughput::Bytes(bytes as u64));
+
+        group.bench_with_input(BenchmarkId::new("dispatch", seq_len), &seq_len, |b, &s| {
+            let mut x = lcg_f32_vec(num_heads * s * s, 0xA100_0000_0000_0001);
+            b.iter(|| {
+                softmax_attention(
+                    std::hint::black_box(&mut x),
+                    std::hint::black_box(s),
+                    std::hint::black_box(num_heads),
+                );
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_add_bias_gelu(c: &mut Criterion) {
+    let mut group = c.benchmark_group("add_bias_gelu");
+
+    for &hidden in &[896usize, 2048, 4096] {
+        let bytes = hidden * std::mem::size_of::<f32>();
+        group.throughput(Throughput::Bytes(bytes as u64));
+
+        group.bench_with_input(BenchmarkId::new("dispatch", hidden), &hidden, |b, &h| {
+            let mut x = lcg_f32_vec(h, 0xF100_0000_0000_0001);
+            let bias = lcg_f32_vec(h, 0xF200_0000_0000_0001);
+            b.iter(|| {
+                add_bias_gelu(
+                    std::hint::black_box(&mut x),
+                    std::hint::black_box(&bias),
+                    std::hint::black_box(h),
+                );
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_rms_norm,
+    bench_silu,
+    bench_elementwise_mul,
+    bench_gelu,
+    bench_softmax,
+    bench_add_bias_gelu
+);
 criterion_main!(benches);

--- a/crates/inference/benches/matmul_opt_bench.rs
+++ b/crates/inference/benches/matmul_opt_bench.rs
@@ -1,0 +1,35 @@
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use lattice_inference::forward::cpu::matmul_bt;
+
+fn bench_matmul_bt(c: &mut Criterion) {
+    let sizes: &[(usize, usize, usize, &str)] = &[
+        (1, 4096, 4096, "m1_k4096_n4096"),
+        (32, 4096, 4096, "m32_k4096_n4096"),
+        (128, 4096, 11008, "m128_k4096_n11008"),
+    ];
+
+    let mut group = c.benchmark_group("matmul_bt");
+
+    for &(m, k, n, label) in sizes {
+        let elements = (2 * m * k * n) as u64;
+        group.throughput(Throughput::Elements(elements));
+
+        group.bench_with_input(
+            BenchmarkId::new("dispatch", label),
+            &(m, k, n),
+            |bench, &(m, k, n)| {
+                let a: Vec<f32> = (0..m * k).map(|i| (i % 97) as f32 * 0.01).collect();
+                let b: Vec<f32> = (0..n * k).map(|i| (i % 89) as f32 * 0.01).collect();
+                let mut c_out = vec![0.0f32; m * n];
+                bench.iter(|| {
+                    matmul_bt(black_box(&a), black_box(&b), black_box(&mut c_out), m, k, n);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_matmul_bt);
+criterion_main!(benches);

--- a/crates/inference/src/attention/decode.rs
+++ b/crates/inference/src/attention/decode.rs
@@ -592,4 +592,131 @@ mod tests {
         let mut scores = vec![0.0f32; 4 * 4];
         decode_attention(&q, &[], &[], &mut out, &mut scores, 0, cfg, 1);
     }
+
+    /// FP-NEON-SOFTMAX: NEON decode path (Schraudolph fast_exp) vs scalar path parity.
+    ///
+    /// The NEON softmax uses the Schraudolph bit-trick exp (~5% per-element error).
+    /// Bias cancels approximately in normalization, so the final attention output
+    /// should agree with the scalar path within 5% relative tolerance.
+    ///
+    /// Tested with adversarial score patterns: uniform, monotonic ramp, one-hot spike.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn test_decode_softmax_neon_vs_scalar_parity() {
+        // LCG data generator matching the pattern used elsewhere in this file.
+        fn lcg_data(n: usize, seed: u32) -> Vec<f32> {
+            (0..n)
+                .map(|i| {
+                    let mut x = (i as u32)
+                        .wrapping_mul(seed)
+                        .wrapping_add(1_013_904_223 ^ seed.wrapping_mul(0x9E37_79B9));
+                    x ^= x >> 16;
+                    x = x.wrapping_mul(0x7FEB_352D);
+                    x ^= x >> 16;
+                    ((x & 0x00FF_FFFF) as f32 / 16_777_216.0 - 0.5) * 2.0
+                })
+                .collect()
+        }
+
+        let cfg = GqaConfig {
+            num_heads: 4,
+            num_kv_heads: 2,
+            head_dim: 32,
+        };
+
+        // Adversarial score patterns: uniform, monotonic ramp, one-hot spike.
+        let kv_seq_lens: &[(usize, &str)] = &[(16, "uniform"), (32, "ramp"), (8, "one-hot")];
+
+        for &(kv_seq_len, pattern_name) in kv_seq_lens {
+            let q = lcg_data(cfg.q_dim(), 42);
+            let v = lcg_data(kv_seq_len * cfg.kv_dim(), 44);
+
+            // Construct adversarial Q/K pairs for each score pattern.
+            // We run both paths end-to-end from Q/K/V to exercise the full pipeline.
+            let (q_patched, k_patched) = match pattern_name {
+                "uniform" => {
+                    // All-equal scores: uniform Q so all QK dots are equal.
+                    let q_eq = vec![1.0f32 / (cfg.head_dim as f32).sqrt(); cfg.q_dim()];
+                    let k_eq = vec![1.0f32; kv_seq_len * cfg.kv_dim()];
+                    (q_eq, k_eq)
+                }
+                "ramp" => {
+                    // Monotonic ramp: K[i] increases with i so scores are monotone.
+                    let q_r = q.clone();
+                    let k_r: Vec<f32> = (0..kv_seq_len * cfg.kv_dim())
+                        .map(|i| (i / cfg.kv_dim()) as f32 * 0.1)
+                        .collect();
+                    (q_r, k_r)
+                }
+                _ => {
+                    // One-hot spike: only position 0 has a large K, rest are zero.
+                    let q_s = q.clone();
+                    let mut k_s = vec![0.0f32; kv_seq_len * cfg.kv_dim()];
+                    for d in 0..cfg.kv_dim() {
+                        k_s[d] = 10.0;
+                    }
+                    (q_s, k_s)
+                }
+            };
+
+            // Run NEON path (dispatches to NEON on aarch64 when neon_enabled).
+            let mut out_neon = vec![0.0f32; cfg.q_dim()];
+            let mut scores_neon = vec![0.0f32; cfg.num_heads * kv_seq_len];
+            decode_attention(
+                &q_patched,
+                &k_patched,
+                &v,
+                &mut out_neon,
+                &mut scores_neon,
+                kv_seq_len,
+                cfg,
+                kv_seq_len,
+            );
+
+            // Run scalar path directly.
+            let mut out_scalar = vec![0.0f32; cfg.q_dim()];
+            let mut scores_scalar = vec![0.0f32; cfg.num_heads * kv_seq_len];
+            decode_scores_scalar(
+                &q_patched,
+                &k_patched,
+                &mut scores_scalar,
+                kv_seq_len,
+                cfg,
+                kv_seq_len,
+            );
+            softmax_decode_scores(&mut scores_scalar, cfg.num_heads, kv_seq_len, kv_seq_len);
+            out_scalar.fill(0.0);
+            accumulate_decode_v_scalar(
+                &mut out_scalar,
+                &scores_scalar,
+                &v,
+                kv_seq_len,
+                cfg,
+                kv_seq_len,
+            );
+
+            // Assert outputs match within a mixed tolerance budget:
+            //   atol=5e-3 (absolute floor; Schraudolph fast_exp ~5% error on [-1, 1] weights
+            //              contributes an absolute error floor ≈ max_weight * 5%)
+            //   rtol=0.05 (5% relative, accounting for Schraudolph fast_exp error)
+            //
+            // We use |a-b| <= atol + rtol * max(|a|, |b|) which avoids division-by-zero
+            // instability when both values are near zero (e.g. tail positions after softmax).
+            let atol = 5e-3f32;
+            let rtol = 0.05f32;
+            for (i, (&n, &s)) in out_neon.iter().zip(out_scalar.iter()).enumerate() {
+                assert!(
+                    n.is_finite() && s.is_finite(),
+                    "decode_attention pattern={pattern_name} idx={i}: non-finite output neon={n} scalar={s}"
+                );
+                let abs_err = (n - s).abs();
+                let tol = atol + rtol * n.abs().max(s.abs());
+                assert!(
+                    abs_err <= tol,
+                    "decode_attention NEON vs scalar parity failure: pattern={pattern_name} \
+                     idx={i} neon={n:.6} scalar={s:.6} abs_err={abs_err:.6} tol={tol:.6}"
+                );
+            }
+        }
+    }
 }

--- a/crates/inference/src/attention/decode.rs
+++ b/crates/inference/src/attention/decode.rs
@@ -1,9 +1,10 @@
 //! Decode-time single-token attention kernel.
 //!
-//! Scalar baseline for seq_len=1 against a full cached K/V sequence.
-//! SIMD paths are added in a subsequent optimization pass.
+//! Single-token (seq_len=1) attention against a full cached K/V sequence.
+//! NEON SIMD path accelerates QK dot products, softmax, and V accumulation.
 
 use crate::attention::gqa::GqaConfig;
+use crate::forward::cpu::simd_config;
 
 /// **Unstable**: compute decode-time attention scores for one query token.
 ///
@@ -40,6 +41,16 @@ pub fn decode_attention_scores(
         "scores buffer too small"
     );
     assert!(score_stride >= kv_seq_len, "score_stride < kv_seq_len");
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if simd_config().neon_enabled {
+            unsafe {
+                decode_scores_neon(q_buf, k_buf, scores, kv_seq_len, cfg, score_stride);
+            }
+            return;
+        }
+    }
 
     decode_scores_scalar(q_buf, k_buf, scores, kv_seq_len, cfg, score_stride);
 }
@@ -96,6 +107,19 @@ pub fn decode_attention(
         "v_buf length mismatch"
     );
     assert!(score_stride >= kv_seq_len, "score_stride < kv_seq_len");
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if simd_config().neon_enabled {
+            unsafe {
+                decode_scores_neon(q_buf, k_buf, scores, kv_seq_len, cfg, score_stride);
+                softmax_decode_neon(scores, cfg.num_heads, kv_seq_len, score_stride);
+                attn_out.fill(0.0);
+                accumulate_decode_v_neon(attn_out, scores, v_buf, kv_seq_len, cfg, score_stride);
+            }
+            return;
+        }
+    }
 
     decode_scores_scalar(q_buf, k_buf, scores, kv_seq_len, cfg, score_stride);
     softmax_decode_scores(scores, cfg.num_heads, kv_seq_len, score_stride);
@@ -186,6 +210,271 @@ fn accumulate_decode_v_scalar(
             let v_off = ki * kv_dim + kv_h * head_dim;
             for d in 0..head_dim {
                 attn_out[out_off + d] += w * v_buf[v_off + d];
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+fn fast_exp_decode(x: f32) -> f32 {
+    let x = x.clamp(-87.0, 88.0);
+    let val = (12_102_203.0f32 * x + 1_065_353_216.0f32) as i32;
+    f32::from_bits(val as u32)
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+#[target_feature(enable = "neon")]
+unsafe fn fast_exp_neon_decode(
+    x: std::arch::aarch64::float32x4_t,
+) -> std::arch::aarch64::float32x4_t {
+    use std::arch::aarch64::*;
+    let x = vmaxq_f32(x, vdupq_n_f32(-87.0));
+    let x = vminq_f32(x, vdupq_n_f32(88.0));
+    let t = vfmaq_f32(vdupq_n_f32(1_065_353_216.0), x, vdupq_n_f32(12_102_203.0));
+    vreinterpretq_f32_s32(vcvtq_s32_f32(t))
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn decode_scores_neon(
+    q_buf: &[f32],
+    k_buf: &[f32],
+    scores: &mut [f32],
+    kv_seq_len: usize,
+    cfg: GqaConfig,
+    score_stride: usize,
+) {
+    use std::arch::aarch64::*;
+
+    let groups = cfg.groups();
+    let head_dim = cfg.head_dim;
+    let kv_dim = cfg.kv_dim();
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let hd_chunks = head_dim / 16;
+
+    for kv_h in 0..cfg.num_kv_heads {
+        let group_start = kv_h * groups;
+        for gi in 0..groups {
+            let h = group_start + gi;
+            let q_ptr = q_buf.as_ptr().add(h * head_dim);
+
+            for ki in 0..kv_seq_len {
+                let k_ptr = k_buf.as_ptr().add(ki * kv_dim + kv_h * head_dim);
+
+                let mut acc0 = vdupq_n_f32(0.0);
+                let mut acc1 = vdupq_n_f32(0.0);
+                let mut acc2 = vdupq_n_f32(0.0);
+                let mut acc3 = vdupq_n_f32(0.0);
+
+                for c in 0..hd_chunks {
+                    let off = c * 16;
+                    acc0 = vfmaq_f32(acc0, vld1q_f32(q_ptr.add(off)), vld1q_f32(k_ptr.add(off)));
+                    acc1 = vfmaq_f32(
+                        acc1,
+                        vld1q_f32(q_ptr.add(off + 4)),
+                        vld1q_f32(k_ptr.add(off + 4)),
+                    );
+                    acc2 = vfmaq_f32(
+                        acc2,
+                        vld1q_f32(q_ptr.add(off + 8)),
+                        vld1q_f32(k_ptr.add(off + 8)),
+                    );
+                    acc3 = vfmaq_f32(
+                        acc3,
+                        vld1q_f32(q_ptr.add(off + 12)),
+                        vld1q_f32(k_ptr.add(off + 12)),
+                    );
+                }
+                let sum = vaddq_f32(vaddq_f32(acc0, acc1), vaddq_f32(acc2, acc3));
+                let mut dot = vaddvq_f32(sum);
+
+                for d in (hd_chunks * 16)..head_dim {
+                    dot += *q_ptr.add(d) * *k_ptr.add(d);
+                }
+
+                scores[h * score_stride + ki] = dot * scale;
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn softmax_decode_neon(
+    scores: &mut [f32],
+    num_heads: usize,
+    kv_seq_len: usize,
+    score_stride: usize,
+) {
+    use std::arch::aarch64::*;
+
+    let chunks = kv_seq_len / 16;
+
+    for h in 0..num_heads {
+        let ptr = scores.as_mut_ptr().add(h * score_stride);
+
+        // Pass 1: find max with 4x unroll
+        let mut m0 = vdupq_n_f32(f32::NEG_INFINITY);
+        let mut m1 = m0;
+        let mut m2 = m0;
+        let mut m3 = m0;
+        for c in 0..chunks {
+            let base = c * 16;
+            m0 = vmaxq_f32(m0, vld1q_f32(ptr.add(base) as *const f32));
+            m1 = vmaxq_f32(m1, vld1q_f32(ptr.add(base + 4) as *const f32));
+            m2 = vmaxq_f32(m2, vld1q_f32(ptr.add(base + 8) as *const f32));
+            m3 = vmaxq_f32(m3, vld1q_f32(ptr.add(base + 12) as *const f32));
+        }
+        let vmax = vmaxq_f32(vmaxq_f32(m0, m1), vmaxq_f32(m2, m3));
+        let mut max_val = vmaxvq_f32(vmax);
+        for i in (chunks * 16)..kv_seq_len {
+            max_val = max_val.max(*ptr.add(i));
+        }
+
+        // Pass 2: exp(x - max) + accumulate sum
+        let vmax_bcast = vdupq_n_f32(max_val);
+        let mut s0 = vdupq_n_f32(0.0);
+        let mut s1 = s0;
+        let mut s2 = s0;
+        let mut s3 = s0;
+        for c in 0..chunks {
+            let base = c * 16;
+            let e0 = fast_exp_neon_decode(vsubq_f32(
+                vld1q_f32(ptr.add(base) as *const f32),
+                vmax_bcast,
+            ));
+            let e1 = fast_exp_neon_decode(vsubq_f32(
+                vld1q_f32(ptr.add(base + 4) as *const f32),
+                vmax_bcast,
+            ));
+            let e2 = fast_exp_neon_decode(vsubq_f32(
+                vld1q_f32(ptr.add(base + 8) as *const f32),
+                vmax_bcast,
+            ));
+            let e3 = fast_exp_neon_decode(vsubq_f32(
+                vld1q_f32(ptr.add(base + 12) as *const f32),
+                vmax_bcast,
+            ));
+            vst1q_f32(ptr.add(base), e0);
+            vst1q_f32(ptr.add(base + 4), e1);
+            vst1q_f32(ptr.add(base + 8), e2);
+            vst1q_f32(ptr.add(base + 12), e3);
+            s0 = vaddq_f32(s0, e0);
+            s1 = vaddq_f32(s1, e1);
+            s2 = vaddq_f32(s2, e2);
+            s3 = vaddq_f32(s3, e3);
+        }
+        let mut sum = vaddvq_f32(vaddq_f32(vaddq_f32(s0, s1), vaddq_f32(s2, s3)));
+        for i in (chunks * 16)..kv_seq_len {
+            let e = fast_exp_decode(*ptr.add(i) - max_val);
+            *ptr.add(i) = e;
+            sum += e;
+        }
+
+        // Pass 3: normalize
+        if sum > 0.0 {
+            let vinv = vdupq_n_f32(1.0 / sum);
+            for c in 0..chunks {
+                let base = c * 16;
+                vst1q_f32(
+                    ptr.add(base),
+                    vmulq_f32(vld1q_f32(ptr.add(base) as *const f32), vinv),
+                );
+                vst1q_f32(
+                    ptr.add(base + 4),
+                    vmulq_f32(vld1q_f32(ptr.add(base + 4) as *const f32), vinv),
+                );
+                vst1q_f32(
+                    ptr.add(base + 8),
+                    vmulq_f32(vld1q_f32(ptr.add(base + 8) as *const f32), vinv),
+                );
+                vst1q_f32(
+                    ptr.add(base + 12),
+                    vmulq_f32(vld1q_f32(ptr.add(base + 12) as *const f32), vinv),
+                );
+            }
+            let inv = 1.0 / sum;
+            for i in (chunks * 16)..kv_seq_len {
+                *ptr.add(i) *= inv;
+            }
+        } else {
+            for i in 0..kv_seq_len {
+                *ptr.add(i) = 0.0;
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn accumulate_decode_v_neon(
+    attn_out: &mut [f32],
+    scores: &[f32],
+    v_buf: &[f32],
+    kv_seq_len: usize,
+    cfg: GqaConfig,
+    score_stride: usize,
+) {
+    use std::arch::aarch64::*;
+
+    let groups = cfg.groups();
+    let head_dim = cfg.head_dim;
+    let kv_dim = cfg.kv_dim();
+    let hd_chunks = head_dim / 16;
+
+    for h in 0..cfg.num_heads {
+        let kv_h = h / groups;
+        let out_ptr = attn_out.as_mut_ptr().add(h * head_dim);
+        let score_off = h * score_stride;
+
+        for ki in 0..kv_seq_len {
+            let w = scores[score_off + ki];
+            if w == 0.0 {
+                continue;
+            }
+            let vw = vdupq_n_f32(w);
+            let v_ptr = v_buf.as_ptr().add(ki * kv_dim + kv_h * head_dim);
+
+            for c in 0..hd_chunks {
+                let off = c * 16;
+                vst1q_f32(
+                    out_ptr.add(off),
+                    vfmaq_f32(
+                        vld1q_f32(out_ptr.add(off) as *const f32),
+                        vw,
+                        vld1q_f32(v_ptr.add(off)),
+                    ),
+                );
+                vst1q_f32(
+                    out_ptr.add(off + 4),
+                    vfmaq_f32(
+                        vld1q_f32(out_ptr.add(off + 4) as *const f32),
+                        vw,
+                        vld1q_f32(v_ptr.add(off + 4)),
+                    ),
+                );
+                vst1q_f32(
+                    out_ptr.add(off + 8),
+                    vfmaq_f32(
+                        vld1q_f32(out_ptr.add(off + 8) as *const f32),
+                        vw,
+                        vld1q_f32(v_ptr.add(off + 8)),
+                    ),
+                );
+                vst1q_f32(
+                    out_ptr.add(off + 12),
+                    vfmaq_f32(
+                        vld1q_f32(out_ptr.add(off + 12) as *const f32),
+                        vw,
+                        vld1q_f32(v_ptr.add(off + 12)),
+                    ),
+                );
+            }
+            for d in (hd_chunks * 16)..head_dim {
+                *out_ptr.add(d) += w * *v_ptr.add(d);
             }
         }
     }

--- a/crates/inference/src/attention/decode.rs
+++ b/crates/inference/src/attention/decode.rs
@@ -1,0 +1,306 @@
+//! Decode-time single-token attention kernel.
+//!
+//! Scalar baseline for seq_len=1 against a full cached K/V sequence.
+//! SIMD paths are added in a subsequent optimization pass.
+
+use crate::attention::gqa::GqaConfig;
+
+/// **Unstable**: compute decode-time attention scores for one query token.
+///
+/// Layouts:
+/// - `q_buf`: `[num_heads * head_dim]`
+/// - `k_buf`: `[kv_seq_len, num_kv_heads * head_dim]`
+/// - `scores`: at least `num_heads * score_stride`
+///
+/// Writes scaled QK scores to `scores[h * score_stride..][..kv_seq_len]`.
+/// Panics if shapes are inconsistent or `num_heads` is not divisible by
+/// `num_kv_heads`.
+pub fn decode_attention_scores(
+    q_buf: &[f32],
+    k_buf: &[f32],
+    scores: &mut [f32],
+    kv_seq_len: usize,
+    cfg: GqaConfig,
+    score_stride: usize,
+) {
+    assert!(cfg.num_kv_heads > 0, "num_kv_heads must be > 0");
+    assert_eq!(
+        cfg.num_heads % cfg.num_kv_heads,
+        0,
+        "num_heads must be divisible by num_kv_heads"
+    );
+    assert_eq!(q_buf.len(), cfg.q_dim(), "q_buf length mismatch");
+    assert_eq!(
+        k_buf.len(),
+        kv_seq_len * cfg.kv_dim(),
+        "k_buf length mismatch"
+    );
+    assert!(
+        scores.len() >= cfg.num_heads * score_stride,
+        "scores buffer too small"
+    );
+    assert!(score_stride >= kv_seq_len, "score_stride < kv_seq_len");
+
+    decode_scores_scalar(q_buf, k_buf, scores, kv_seq_len, cfg, score_stride);
+}
+
+/// **Unstable**: compute full decode-time attention for one query token.
+///
+/// Layouts:
+/// - `q_buf`: `[num_heads * head_dim]`
+/// - `k_buf`: `[kv_seq_len, num_kv_heads * head_dim]`
+/// - `v_buf`: `[kv_seq_len, num_kv_heads * head_dim]`
+/// - `attn_out`: `[num_heads * head_dim]`
+/// - `scores`: at least `num_heads * score_stride`
+///
+/// Computes scores, applies row softmax in-place to `scores`, then writes
+/// `attn_out[h, d] = sum_i softmax(scores[h, i]) * V[i, kv_h, d]`.
+/// Panics if shapes are inconsistent or `num_heads` is not divisible by
+/// `num_kv_heads`.
+pub fn decode_attention(
+    q_buf: &[f32],
+    k_buf: &[f32],
+    v_buf: &[f32],
+    attn_out: &mut [f32],
+    scores: &mut [f32],
+    kv_seq_len: usize,
+    cfg: GqaConfig,
+    score_stride: usize,
+) {
+    assert!(cfg.num_kv_heads > 0, "num_kv_heads must be > 0");
+    assert_eq!(
+        cfg.num_heads % cfg.num_kv_heads,
+        0,
+        "num_heads must be divisible by num_kv_heads"
+    );
+    assert_eq!(q_buf.len(), cfg.q_dim(), "q_buf length mismatch");
+    assert_eq!(attn_out.len(), cfg.q_dim(), "attn_out length mismatch");
+    assert!(
+        scores.len() >= cfg.num_heads * score_stride,
+        "scores buffer too small"
+    );
+
+    if kv_seq_len == 0 {
+        attn_out.fill(0.0);
+        return;
+    }
+
+    assert_eq!(
+        k_buf.len(),
+        kv_seq_len * cfg.kv_dim(),
+        "k_buf length mismatch"
+    );
+    assert_eq!(
+        v_buf.len(),
+        kv_seq_len * cfg.kv_dim(),
+        "v_buf length mismatch"
+    );
+    assert!(score_stride >= kv_seq_len, "score_stride < kv_seq_len");
+
+    decode_scores_scalar(q_buf, k_buf, scores, kv_seq_len, cfg, score_stride);
+    softmax_decode_scores(scores, cfg.num_heads, kv_seq_len, score_stride);
+    attn_out.fill(0.0);
+    accumulate_decode_v_scalar(attn_out, scores, v_buf, kv_seq_len, cfg, score_stride);
+}
+
+fn decode_scores_scalar(
+    q_buf: &[f32],
+    k_buf: &[f32],
+    scores: &mut [f32],
+    kv_seq_len: usize,
+    cfg: GqaConfig,
+    score_stride: usize,
+) {
+    let groups = cfg.groups();
+    let head_dim = cfg.head_dim;
+    let kv_dim = cfg.kv_dim();
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    for kv_h in 0..cfg.num_kv_heads {
+        let group_start = kv_h * groups;
+        for ki in 0..kv_seq_len {
+            let k_off = ki * kv_dim + kv_h * head_dim;
+            for gi in 0..groups {
+                let h = group_start + gi;
+                let q_off = h * head_dim;
+                let mut dot = 0.0f32;
+                for d in 0..head_dim {
+                    dot += q_buf[q_off + d] * k_buf[k_off + d];
+                }
+                scores[h * score_stride + ki] = dot * scale;
+            }
+        }
+    }
+}
+
+fn softmax_decode_scores(
+    scores: &mut [f32],
+    num_heads: usize,
+    kv_seq_len: usize,
+    score_stride: usize,
+) {
+    for h in 0..num_heads {
+        let row = &mut scores[h * score_stride..h * score_stride + kv_seq_len];
+        let mut m = f32::NEG_INFINITY;
+        let mut l = 0.0f32;
+        for &s in row.iter() {
+            let m_new = m.max(s);
+            #[allow(clippy::float_cmp)]
+            let alpha = if m == f32::NEG_INFINITY {
+                0.0
+            } else {
+                (m - m_new).exp()
+            };
+            l = l * alpha + (s - m_new).exp();
+            m = m_new;
+        }
+        if l > 0.0 {
+            let inv_l = 1.0 / l;
+            for s in row.iter_mut() {
+                *s = (*s - m).exp() * inv_l;
+            }
+        } else {
+            row.fill(0.0);
+        }
+    }
+}
+
+fn accumulate_decode_v_scalar(
+    attn_out: &mut [f32],
+    scores: &[f32],
+    v_buf: &[f32],
+    kv_seq_len: usize,
+    cfg: GqaConfig,
+    score_stride: usize,
+) {
+    let groups = cfg.groups();
+    let head_dim = cfg.head_dim;
+    let kv_dim = cfg.kv_dim();
+
+    for h in 0..cfg.num_heads {
+        let kv_h = h / groups;
+        let out_off = h * head_dim;
+        let score_off = h * score_stride;
+        for ki in 0..kv_seq_len {
+            let w = scores[score_off + ki];
+            let v_off = ki * kv_dim + kv_h * head_dim;
+            for d in 0..head_dim {
+                attn_out[out_off + d] += w * v_buf[v_off + d];
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn small_data(n: usize, seed: u32) -> Vec<f32> {
+        (0..n)
+            .map(|i| {
+                let mut x = (i as u32)
+                    .wrapping_mul(seed)
+                    .wrapping_add(1_013_904_223 ^ seed.wrapping_mul(0x9E37_79B9));
+                x ^= x >> 16;
+                x = x.wrapping_mul(0x7FEB_352D);
+                x ^= x >> 16;
+                ((x & 0x00FF_FFFF) as f32 / 16_777_216.0 - 0.5) * 0.125
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_decode_attention_zero_kvlen() {
+        let cfg = GqaConfig {
+            num_heads: 4,
+            num_kv_heads: 4,
+            head_dim: 8,
+        };
+        let q = small_data(cfg.q_dim(), 1);
+        let mut out = vec![99.0f32; cfg.q_dim()];
+        let mut scores = vec![0.0f32; cfg.num_heads];
+        decode_attention(&q, &[], &[], &mut out, &mut scores, 0, cfg, 1);
+        assert!(out.iter().all(|&x| x == 0.0));
+    }
+
+    #[test]
+    fn test_decode_attention_mha() {
+        let cfg = GqaConfig {
+            num_heads: 4,
+            num_kv_heads: 4,
+            head_dim: 8,
+        };
+        let kv_seq_len = 5;
+        let q = small_data(cfg.q_dim(), 1);
+        let k = small_data(kv_seq_len * cfg.kv_dim(), 2);
+        let v = small_data(kv_seq_len * cfg.kv_dim(), 3);
+        let mut out = vec![0.0f32; cfg.q_dim()];
+        let mut scores = vec![0.0f32; cfg.num_heads * kv_seq_len];
+        decode_attention(
+            &q,
+            &k,
+            &v,
+            &mut out,
+            &mut scores,
+            kv_seq_len,
+            cfg,
+            kv_seq_len,
+        );
+        assert!(out.iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
+    fn test_decode_attention_gqa() {
+        let cfg = GqaConfig {
+            num_heads: 4,
+            num_kv_heads: 2,
+            head_dim: 8,
+        };
+        let kv_seq_len = 5;
+        let q = small_data(cfg.q_dim(), 1);
+        let k = small_data(kv_seq_len * cfg.kv_dim(), 2);
+        let v = small_data(kv_seq_len * cfg.kv_dim(), 3);
+        let mut out = vec![0.0f32; cfg.q_dim()];
+        let mut scores = vec![0.0f32; cfg.num_heads * kv_seq_len];
+        decode_attention(
+            &q,
+            &k,
+            &v,
+            &mut out,
+            &mut scores,
+            kv_seq_len,
+            cfg,
+            kv_seq_len,
+        );
+        assert!(out.iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
+    fn test_decode_scores_only() {
+        let cfg = GqaConfig {
+            num_heads: 4,
+            num_kv_heads: 2,
+            head_dim: 8,
+        };
+        let kv_seq_len = 3;
+        let q = small_data(cfg.q_dim(), 1);
+        let k = small_data(kv_seq_len * cfg.kv_dim(), 2);
+        let mut scores = vec![0.0f32; cfg.num_heads * kv_seq_len];
+        decode_attention_scores(&q, &k, &mut scores, kv_seq_len, cfg, kv_seq_len);
+        assert!(scores.iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
+    #[should_panic(expected = "num_heads must be divisible by num_kv_heads")]
+    fn test_non_divisible_heads_panics() {
+        let cfg = GqaConfig {
+            num_heads: 4,
+            num_kv_heads: 3,
+            head_dim: 8,
+        };
+        let q = vec![0.0f32; cfg.q_dim()];
+        let mut out = vec![0.0f32; cfg.q_dim()];
+        let mut scores = vec![0.0f32; 4 * 4];
+        decode_attention(&q, &[], &[], &mut out, &mut scores, 0, cfg, 1);
+    }
+}

--- a/crates/inference/src/attention/mod.rs
+++ b/crates/inference/src/attention/mod.rs
@@ -1,3 +1,4 @@
+pub mod decode;
 pub mod differential;
 pub mod flash;
 pub mod flash_causal;

--- a/crates/inference/src/bin/bench_decode_ab.rs
+++ b/crates/inference/src/bin/bench_decode_ab.rs
@@ -68,6 +68,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         seed: Some(42),
         stop_token_ids: vec![],
         enable_thinking: false,
+        enable_mtp: None,
+        grammar: None,
     };
 
     // Same continuation prompt as the original bench, single user turn.

--- a/crates/inference/src/forward/cpu/activation.rs
+++ b/crates/inference/src/forward/cpu/activation.rs
@@ -105,27 +105,74 @@ unsafe fn gelu_neon(x: &mut [f32]) {
     let half = vdupq_n_f32(0.5);
     let one = vdupq_n_f32(1.0);
 
-    let chunks = x.len() / 4;
+    let n = x.len();
+    const UNROLL: usize = 4;
+    const CHUNK: usize = 4 * UNROLL;
+    let chunks = n / CHUNK;
     let ptr = x.as_mut_ptr();
 
     for c in 0..chunks {
-        let off = c * 4;
+        let base = c * CHUNK;
+
+        let v0 = vld1q_f32(ptr.add(base) as *const f32);
+        let v1 = vld1q_f32(ptr.add(base + 4) as *const f32);
+        let v2 = vld1q_f32(ptr.add(base + 8) as *const f32);
+        let v3 = vld1q_f32(ptr.add(base + 12) as *const f32);
+
+        let i0 = vmulq_f32(
+            sqrt_2_over_pi,
+            vfmaq_f32(v0, coeff, vmulq_f32(vmulq_f32(v0, v0), v0)),
+        );
+        let i1 = vmulq_f32(
+            sqrt_2_over_pi,
+            vfmaq_f32(v1, coeff, vmulq_f32(vmulq_f32(v1, v1), v1)),
+        );
+        let i2 = vmulq_f32(
+            sqrt_2_over_pi,
+            vfmaq_f32(v2, coeff, vmulq_f32(vmulq_f32(v2, v2), v2)),
+        );
+        let i3 = vmulq_f32(
+            sqrt_2_over_pi,
+            vfmaq_f32(v3, coeff, vmulq_f32(vmulq_f32(v3, v3), v3)),
+        );
+
+        let t0 = fast_tanh_neon(i0);
+        let t1 = fast_tanh_neon(i1);
+        let t2 = fast_tanh_neon(i2);
+        let t3 = fast_tanh_neon(i3);
+
+        vst1q_f32(
+            ptr.add(base),
+            vmulq_f32(vmulq_f32(half, v0), vaddq_f32(one, t0)),
+        );
+        vst1q_f32(
+            ptr.add(base + 4),
+            vmulq_f32(vmulq_f32(half, v1), vaddq_f32(one, t1)),
+        );
+        vst1q_f32(
+            ptr.add(base + 8),
+            vmulq_f32(vmulq_f32(half, v2), vaddq_f32(one, t2)),
+        );
+        vst1q_f32(
+            ptr.add(base + 12),
+            vmulq_f32(vmulq_f32(half, v3), vaddq_f32(one, t3)),
+        );
+    }
+
+    let remaining = chunks * CHUNK;
+    let simd_tail = (n - remaining) / 4;
+    for c in 0..simd_tail {
+        let off = remaining + c * 4;
         let v = vld1q_f32(ptr.add(off) as *const f32);
-        let v2 = vmulq_f32(v, v);
-        let v3 = vmulq_f32(v2, v);
-
-        // inner = sqrt_2_over_pi * (v + coeff * v^3)
-        let inner = vmulq_f32(sqrt_2_over_pi, vfmaq_f32(v, coeff, v3));
-
-        let tanh_val = fast_tanh_neon(inner);
-
-        // gelu = 0.5 * v * (1 + tanh(inner))
-        let result = vmulq_f32(vmulq_f32(half, v), vaddq_f32(one, tanh_val));
+        let inner = vmulq_f32(
+            sqrt_2_over_pi,
+            vfmaq_f32(v, coeff, vmulq_f32(vmulq_f32(v, v), v)),
+        );
+        let result = vmulq_f32(vmulq_f32(half, v), vaddq_f32(one, fast_tanh_neon(inner)));
         vst1q_f32(ptr.add(off), result);
     }
 
-    // Scalar remainder
-    for i in (chunks * 4)..x.len() {
+    for i in (remaining + simd_tail * 4)..n {
         let v = *ptr.add(i);
         let x3 = v * v * v;
         let inner = 0.797_884_6 * (v + 0.044_715 * x3);
@@ -282,31 +329,92 @@ unsafe fn add_bias_gelu_neon(x: &mut [f32], bias: &[f32], dim: usize) {
     let half = vdupq_n_f32(0.5);
     let one = vdupq_n_f32(1.0);
 
-    let chunks4 = dim / 4;
+    const UNROLL: usize = 4;
+    const CHUNK: usize = 4 * UNROLL;
+    let chunks = dim / CHUNK;
 
     for row in x.chunks_exact_mut(dim) {
         let ptr = row.as_mut_ptr();
         let b_ptr = bias.as_ptr();
 
-        for c in 0..chunks4 {
-            let off = c * 4;
-            // Load x and bias, fuse add
+        for c in 0..chunks {
+            let base = c * CHUNK;
+            let v0 = vaddq_f32(
+                vld1q_f32(ptr.add(base) as *const f32),
+                vld1q_f32(b_ptr.add(base)),
+            );
+            let v1 = vaddq_f32(
+                vld1q_f32(ptr.add(base + 4) as *const f32),
+                vld1q_f32(b_ptr.add(base + 4)),
+            );
+            let v2 = vaddq_f32(
+                vld1q_f32(ptr.add(base + 8) as *const f32),
+                vld1q_f32(b_ptr.add(base + 8)),
+            );
+            let v3 = vaddq_f32(
+                vld1q_f32(ptr.add(base + 12) as *const f32),
+                vld1q_f32(b_ptr.add(base + 12)),
+            );
+
+            let i0 = vmulq_f32(
+                sqrt_2_over_pi,
+                vfmaq_f32(v0, coeff, vmulq_f32(vmulq_f32(v0, v0), v0)),
+            );
+            let i1 = vmulq_f32(
+                sqrt_2_over_pi,
+                vfmaq_f32(v1, coeff, vmulq_f32(vmulq_f32(v1, v1), v1)),
+            );
+            let i2 = vmulq_f32(
+                sqrt_2_over_pi,
+                vfmaq_f32(v2, coeff, vmulq_f32(vmulq_f32(v2, v2), v2)),
+            );
+            let i3 = vmulq_f32(
+                sqrt_2_over_pi,
+                vfmaq_f32(v3, coeff, vmulq_f32(vmulq_f32(v3, v3), v3)),
+            );
+
+            let t0 = fast_tanh_neon(i0);
+            let t1 = fast_tanh_neon(i1);
+            let t2 = fast_tanh_neon(i2);
+            let t3 = fast_tanh_neon(i3);
+
+            vst1q_f32(
+                ptr.add(base),
+                vmulq_f32(vmulq_f32(half, v0), vaddq_f32(one, t0)),
+            );
+            vst1q_f32(
+                ptr.add(base + 4),
+                vmulq_f32(vmulq_f32(half, v1), vaddq_f32(one, t1)),
+            );
+            vst1q_f32(
+                ptr.add(base + 8),
+                vmulq_f32(vmulq_f32(half, v2), vaddq_f32(one, t2)),
+            );
+            vst1q_f32(
+                ptr.add(base + 12),
+                vmulq_f32(vmulq_f32(half, v3), vaddq_f32(one, t3)),
+            );
+        }
+
+        let remaining = chunks * CHUNK;
+        let simd_tail = (dim - remaining) / 4;
+        for c in 0..simd_tail {
+            let off = remaining + c * 4;
             let v = vaddq_f32(
                 vld1q_f32(ptr.add(off) as *const f32),
                 vld1q_f32(b_ptr.add(off)),
             );
-
-            // GELU: 0.5 * v * (1 + tanh(sqrt(2/pi) * (v + 0.044715 * v^3)))
-            let v2 = vmulq_f32(v, v);
-            let v3 = vmulq_f32(v2, v);
-            let inner = vmulq_f32(sqrt_2_over_pi, vfmaq_f32(v, coeff, v3));
-            let tanh_val = fast_tanh_neon(inner);
-            let result = vmulq_f32(vmulq_f32(half, v), vaddq_f32(one, tanh_val));
-            vst1q_f32(ptr.add(off), result);
+            let inner = vmulq_f32(
+                sqrt_2_over_pi,
+                vfmaq_f32(v, coeff, vmulq_f32(vmulq_f32(v, v), v)),
+            );
+            vst1q_f32(
+                ptr.add(off),
+                vmulq_f32(vmulq_f32(half, v), vaddq_f32(one, fast_tanh_neon(inner))),
+            );
         }
 
-        // Scalar remainder
-        for i in (chunks4 * 4)..dim {
+        for i in (remaining + simd_tail * 4)..dim {
             let v = *ptr.add(i) + *b_ptr.add(i);
             let x3 = v * v * v;
             let inner = 0.797_884_6 * (v + 0.044_715 * x3);

--- a/crates/inference/src/forward/cpu/elementwise.rs
+++ b/crates/inference/src/forward/cpu/elementwise.rs
@@ -234,34 +234,86 @@ unsafe fn rms_norm_neon(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
 
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
+#[inline]
+unsafe fn neon_exp_f32(x: std::arch::aarch64::float32x4_t) -> std::arch::aarch64::float32x4_t {
+    use std::arch::aarch64::*;
+
+    const LOG2E: f32 = std::f32::consts::LOG2_E;
+    const LN2_HI: f32 = 0.693_145_75_f32;
+    const LN2_LO: f32 = 1.428_606_8e-6_f32;
+
+    let x = vmaxq_f32(vminq_f32(x, vdupq_n_f32(88.72)), vdupq_n_f32(-87.33));
+
+    // Range reduction: x = n*ln(2) + r, |r| <= ln(2)/2
+    // Round to nearest via magic-number trick (avoids unstable intrinsics)
+    let magic = vdupq_n_f32(12_582_912.0); // 1.5 * 2^23
+    let biased = vaddq_f32(vmulq_f32(x, vdupq_n_f32(LOG2E)), magic);
+    let n = vsubq_f32(biased, magic);
+    let n_int = vcvtq_s32_f32(n);
+
+    let r = vfmsq_f32(vfmsq_f32(x, n, vdupq_n_f32(LN2_HI)), n, vdupq_n_f32(LN2_LO));
+
+    // exp(r) via Horner: 1 + r*(1 + r*(1/2 + r*(1/6 + r*(1/24 + r*(1/120 + r/720)))))
+    let p = vdupq_n_f32(1.0 / 720.0);
+    let p = vfmaq_f32(vdupq_n_f32(1.0 / 120.0), p, r);
+    let p = vfmaq_f32(vdupq_n_f32(1.0 / 24.0), p, r);
+    let p = vfmaq_f32(vdupq_n_f32(1.0 / 6.0), p, r);
+    let p = vfmaq_f32(vdupq_n_f32(0.5), p, r);
+    let p = vfmaq_f32(vdupq_n_f32(1.0), p, r);
+    let p = vfmaq_f32(vdupq_n_f32(1.0), p, r);
+
+    // Reconstruct: exp(x) = 2^n * exp(r)
+    let pow2n = vreinterpretq_f32_s32(vshlq_n_s32::<23>(vaddq_s32(n_int, vdupq_n_s32(127))));
+    vmulq_f32(p, pow2n)
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
 unsafe fn silu_inplace_neon(x: &mut [f32]) {
     use std::arch::aarch64::*;
 
     let n = x.len();
-    let chunks = n / 4;
+    const UNROLL: usize = 4;
+    const CHUNK: usize = 4 * UNROLL;
+    let chunks = n / CHUNK;
     let ptr = x.as_mut_ptr();
     let vone = vdupq_n_f32(1.0);
 
     for c in 0..chunks {
-        let off = c * 4;
-        // SAFETY: off + 3 < chunks * 4 <= n, within slice bounds.
-        let v = vld1q_f32(ptr.add(off) as *const f32);
-        // sigmoid(v) = 1 / (1 + exp(-v)); use accurate exp for numerical correctness.
-        let neg_v = vnegq_f32(v);
-        let neg_arr: [f32; 4] = core::mem::transmute(neg_v);
-        let exp_arr = [
-            neg_arr[0].exp(),
-            neg_arr[1].exp(),
-            neg_arr[2].exp(),
-            neg_arr[3].exp(),
-        ];
-        let exp_neg_v: float32x4_t = core::mem::transmute(exp_arr);
-        let sigmoid = vdivq_f32(vone, vaddq_f32(vone, exp_neg_v));
-        // silu = v * sigmoid(v)
-        let result = vmulq_f32(v, sigmoid);
-        vst1q_f32(ptr.add(off), result);
+        let base = c * CHUNK;
+
+        let v0 = vld1q_f32(ptr.add(base) as *const f32);
+        let v1 = vld1q_f32(ptr.add(base + 4) as *const f32);
+        let v2 = vld1q_f32(ptr.add(base + 8) as *const f32);
+        let v3 = vld1q_f32(ptr.add(base + 12) as *const f32);
+
+        let e0 = neon_exp_f32(vnegq_f32(v0));
+        let e1 = neon_exp_f32(vnegq_f32(v1));
+        let e2 = neon_exp_f32(vnegq_f32(v2));
+        let e3 = neon_exp_f32(vnegq_f32(v3));
+
+        let s0 = vdivq_f32(vone, vaddq_f32(vone, e0));
+        let s1 = vdivq_f32(vone, vaddq_f32(vone, e1));
+        let s2 = vdivq_f32(vone, vaddq_f32(vone, e2));
+        let s3 = vdivq_f32(vone, vaddq_f32(vone, e3));
+
+        vst1q_f32(ptr.add(base), vmulq_f32(v0, s0));
+        vst1q_f32(ptr.add(base + 4), vmulq_f32(v1, s1));
+        vst1q_f32(ptr.add(base + 8), vmulq_f32(v2, s2));
+        vst1q_f32(ptr.add(base + 12), vmulq_f32(v3, s3));
     }
-    for i in (chunks * 4)..n {
+
+    // 4-wide SIMD remainder
+    let remaining = chunks * CHUNK;
+    let simd_tail = (n - remaining) / 4;
+    for c in 0..simd_tail {
+        let off = remaining + c * 4;
+        let v = vld1q_f32(ptr.add(off) as *const f32);
+        let sig = vdivq_f32(vone, vaddq_f32(vone, neon_exp_f32(vnegq_f32(v))));
+        vst1q_f32(ptr.add(off), vmulq_f32(v, sig));
+    }
+
+    for i in (remaining + simd_tail * 4)..n {
         let v = *ptr.add(i);
         *ptr.add(i) = v * (1.0 / (1.0 + (-v).exp()));
     }

--- a/crates/inference/src/forward/cpu/elementwise.rs
+++ b/crates/inference/src/forward/cpu/elementwise.rs
@@ -232,6 +232,13 @@ unsafe fn rms_norm_neon(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
     }
 }
 
+/// NEON polynomial exp approximation.
+///
+/// Accuracy: max ~10-15 ULP error over the clamped input range `[-87.33, 88.0]`.
+///
+/// Upper clamp is 88.0 (not 88.72) to keep the biased exponent `n + 127 <= 255`,
+/// avoiding the infinity exponent that occurs when `n = 128` at x = 88.72.
+/// Lower clamp of -87.33 matches the smallest normal f32 exponent.
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 #[inline]
@@ -242,7 +249,7 @@ unsafe fn neon_exp_f32(x: std::arch::aarch64::float32x4_t) -> std::arch::aarch64
     const LN2_HI: f32 = 0.693_145_75_f32;
     const LN2_LO: f32 = 1.428_606_8e-6_f32;
 
-    let x = vmaxq_f32(vminq_f32(x, vdupq_n_f32(88.72)), vdupq_n_f32(-87.33));
+    let x = vmaxq_f32(vminq_f32(x, vdupq_n_f32(88.0)), vdupq_n_f32(-87.33));
 
     // Range reduction: x = n*ln(2) + r, |r| <= ln(2)/2
     // Round to nearest via magic-number trick (avoids unstable intrinsics)

--- a/crates/inference/src/forward/cpu/elementwise.rs
+++ b/crates/inference/src/forward/cpu/elementwise.rs
@@ -163,22 +163,34 @@ unsafe fn rms_norm_neon(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
     debug_assert_eq!(x.len(), num_tokens * hidden);
     debug_assert_eq!(gamma.len(), hidden);
 
-    let chunks = hidden / 4;
+    const UNROLL: usize = 4;
+    const CHUNK: usize = 4 * UNROLL; // 16 floats per unrolled iteration
+    let chunks = hidden / CHUNK;
     let inv_hidden = 1.0f32 / hidden as f32;
 
     for t in 0..num_tokens {
         let row_ptr = x.as_mut_ptr().add(t * hidden);
         let gamma_ptr = gamma.as_ptr();
 
-        // --- Step 1: Sum of squares via SIMD ---
-        let mut vsum_sq = vdupq_n_f32(0.0);
+        // --- Step 1: Sum of squares with 4 independent accumulators ---
+        let mut sq0 = vdupq_n_f32(0.0);
+        let mut sq1 = vdupq_n_f32(0.0);
+        let mut sq2 = vdupq_n_f32(0.0);
+        let mut sq3 = vdupq_n_f32(0.0);
         for c in 0..chunks {
-            // SAFETY: c * 4 + 3 < chunks * 4 <= hidden, within row bounds.
-            let v = vld1q_f32(row_ptr.add(c * 4) as *const f32);
-            vsum_sq = vfmaq_f32(vsum_sq, v, v);
+            let base = c * CHUNK;
+            let v0 = vld1q_f32(row_ptr.add(base) as *const f32);
+            sq0 = vfmaq_f32(sq0, v0, v0);
+            let v1 = vld1q_f32(row_ptr.add(base + 4) as *const f32);
+            sq1 = vfmaq_f32(sq1, v1, v1);
+            let v2 = vld1q_f32(row_ptr.add(base + 8) as *const f32);
+            sq2 = vfmaq_f32(sq2, v2, v2);
+            let v3 = vld1q_f32(row_ptr.add(base + 12) as *const f32);
+            sq3 = vfmaq_f32(sq3, v3, v3);
         }
-        let mut sum_sq = vaddvq_f32(vsum_sq);
-        for i in (chunks * 4)..hidden {
+        let combined = vaddq_f32(vaddq_f32(sq0, sq1), vaddq_f32(sq2, sq3));
+        let mut sum_sq = vaddvq_f32(combined);
+        for i in (chunks * CHUNK)..hidden {
             let v = *row_ptr.add(i);
             sum_sq += v * v;
         }
@@ -187,16 +199,32 @@ unsafe fn rms_norm_neon(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
         let inv_rms = 1.0 / rms;
         let vinv_rms = vdupq_n_f32(inv_rms);
 
-        // --- Step 2: Scale by gamma / rms using SIMD ---
+        // --- Step 2: Scale by gamma / rms with 4x unrolling ---
         for c in 0..chunks {
-            let off = c * 4;
-            // SAFETY: off + 3 < chunks * 4 <= hidden, within both row and gamma bounds.
-            let v = vld1q_f32(row_ptr.add(off) as *const f32);
-            let g = vld1q_f32(gamma_ptr.add(off));
-            let result = vmulq_f32(vmulq_f32(v, vinv_rms), g);
-            vst1q_f32(row_ptr.add(off), result);
+            let base = c * CHUNK;
+            let v0 = vld1q_f32(row_ptr.add(base) as *const f32);
+            let g0 = vld1q_f32(gamma_ptr.add(base));
+            vst1q_f32(row_ptr.add(base), vmulq_f32(vmulq_f32(v0, vinv_rms), g0));
+            let v1 = vld1q_f32(row_ptr.add(base + 4) as *const f32);
+            let g1 = vld1q_f32(gamma_ptr.add(base + 4));
+            vst1q_f32(
+                row_ptr.add(base + 4),
+                vmulq_f32(vmulq_f32(v1, vinv_rms), g1),
+            );
+            let v2 = vld1q_f32(row_ptr.add(base + 8) as *const f32);
+            let g2 = vld1q_f32(gamma_ptr.add(base + 8));
+            vst1q_f32(
+                row_ptr.add(base + 8),
+                vmulq_f32(vmulq_f32(v2, vinv_rms), g2),
+            );
+            let v3 = vld1q_f32(row_ptr.add(base + 12) as *const f32);
+            let g3 = vld1q_f32(gamma_ptr.add(base + 12));
+            vst1q_f32(
+                row_ptr.add(base + 12),
+                vmulq_f32(vmulq_f32(v3, vinv_rms), g3),
+            );
         }
-        for i in (chunks * 4)..hidden {
+        for i in (chunks * CHUNK)..hidden {
             let v = *row_ptr.add(i);
             let g = *gamma_ptr.add(i);
             *row_ptr.add(i) = v * inv_rms * g;
@@ -246,18 +274,28 @@ unsafe fn elementwise_mul_neon(a: &mut [f32], b: &[f32]) {
 
     debug_assert_eq!(a.len(), b.len());
     let n = a.len();
-    let chunks = n / 4;
+    const UNROLL: usize = 4;
+    const CHUNK: usize = 4 * UNROLL; // 16 floats per iteration
+    let chunks = n / CHUNK;
     let a_ptr = a.as_mut_ptr();
     let b_ptr = b.as_ptr();
 
     for c in 0..chunks {
-        let off = c * 4;
-        // SAFETY: off + 3 < chunks * 4 <= n, within both slice bounds.
-        let av = vld1q_f32(a_ptr.add(off) as *const f32);
-        let bv = vld1q_f32(b_ptr.add(off));
-        vst1q_f32(a_ptr.add(off), vmulq_f32(av, bv));
+        let base = c * CHUNK;
+        let a0 = vld1q_f32(a_ptr.add(base) as *const f32);
+        let b0 = vld1q_f32(b_ptr.add(base));
+        vst1q_f32(a_ptr.add(base), vmulq_f32(a0, b0));
+        let a1 = vld1q_f32(a_ptr.add(base + 4) as *const f32);
+        let b1 = vld1q_f32(b_ptr.add(base + 4));
+        vst1q_f32(a_ptr.add(base + 4), vmulq_f32(a1, b1));
+        let a2 = vld1q_f32(a_ptr.add(base + 8) as *const f32);
+        let b2 = vld1q_f32(b_ptr.add(base + 8));
+        vst1q_f32(a_ptr.add(base + 8), vmulq_f32(a2, b2));
+        let a3 = vld1q_f32(a_ptr.add(base + 12) as *const f32);
+        let b3 = vld1q_f32(b_ptr.add(base + 12));
+        vst1q_f32(a_ptr.add(base + 12), vmulq_f32(a3, b3));
     }
-    for i in (chunks * 4)..n {
+    for i in (chunks * CHUNK)..n {
         *a_ptr.add(i) *= *b_ptr.add(i);
     }
 }

--- a/crates/inference/src/forward/cpu/elementwise.rs
+++ b/crates/inference/src/forward/cpu/elementwise.rs
@@ -1,9 +1,109 @@
+// ===================================================================
+// Elementwise operations — RMS norm, SiLU, element-wise mul — with SIMD fast paths
+// ===================================================================
+
+use super::simd::simd_config;
+
 /// **Unstable**: RMS normalization in-place; may add SIMD path.
 ///
 /// RMS normalization: x = x * gamma / rms(x), where rms = sqrt(mean(x^2) + eps).
 ///
 /// Unlike LayerNorm, RMSNorm does not center (no beta/mean subtraction).
 pub fn rms_norm(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
+    let config = simd_config();
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if config.neon_enabled {
+            // SAFETY: NEON is available on aarch64 and the runtime gate ensures this path.
+            unsafe {
+                rms_norm_neon(x, gamma, hidden, eps);
+                return;
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if config.avx2_enabled {
+            // SAFETY: The runtime feature check guarantees AVX2 support.
+            unsafe {
+                rms_norm_avx2(x, gamma, hidden, eps);
+                return;
+            }
+        }
+    }
+
+    rms_norm_scalar(x, gamma, hidden, eps);
+}
+
+/// **Unstable**: SiLU in-place; may gain SIMD path.
+///
+/// SiLU activation: x = x * sigmoid(x).
+pub fn silu_inplace(x: &mut [f32]) {
+    let config = simd_config();
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if config.neon_enabled {
+            // SAFETY: NEON is available on aarch64 and the runtime gate ensures this path.
+            unsafe {
+                silu_inplace_neon(x);
+                return;
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if config.avx2_enabled {
+            // SAFETY: The runtime feature check guarantees AVX2 support.
+            unsafe {
+                silu_inplace_avx2(x);
+                return;
+            }
+        }
+    }
+
+    silu_inplace_scalar(x);
+}
+
+/// **Unstable**: element-wise multiply in-place; may gain SIMD path.
+///
+/// Element-wise multiply: a *= b.
+pub fn elementwise_mul(a: &mut [f32], b: &[f32]) {
+    let config = simd_config();
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if config.neon_enabled {
+            // SAFETY: NEON is available on aarch64 and the runtime gate ensures this path.
+            unsafe {
+                elementwise_mul_neon(a, b);
+                return;
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if config.avx2_enabled {
+            // SAFETY: The runtime feature check guarantees AVX2 support.
+            unsafe {
+                elementwise_mul_avx2(a, b);
+                return;
+            }
+        }
+    }
+
+    elementwise_mul_scalar(a, b);
+}
+
+// ===================================================================
+// Scalar fallbacks
+// ===================================================================
+
+pub fn rms_norm_scalar(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
     let num_tokens = x.len() / hidden;
     debug_assert_eq!(x.len(), num_tokens * hidden);
     debug_assert_eq!(gamma.len(), hidden);
@@ -26,23 +126,266 @@ pub fn rms_norm(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
     }
 }
 
-/// **Unstable**: SiLU in-place; may gain SIMD path.
-///
-/// SiLU activation: x = x * sigmoid(x).
 #[inline]
-pub fn silu_inplace(x: &mut [f32]) {
+pub fn silu_inplace_scalar(x: &mut [f32]) {
     for v in x.iter_mut() {
         *v = *v * (1.0 / (1.0 + (-*v).exp()));
     }
 }
 
-/// **Unstable**: element-wise multiply in-place; may gain SIMD path.
-///
-/// Element-wise multiply: a *= b.
 #[inline]
-pub fn elementwise_mul(a: &mut [f32], b: &[f32]) {
+pub fn elementwise_mul_scalar(a: &mut [f32], b: &[f32]) {
     debug_assert_eq!(a.len(), b.len());
     for (av, &bv) in a.iter_mut().zip(b.iter()) {
         *av *= bv;
+    }
+}
+
+// ===================================================================
+// NEON fast exp (Schraudolph bit trick) — 4-wide float32x4_t
+// ===================================================================
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+#[target_feature(enable = "neon")]
+unsafe fn fast_exp_neon(x: std::arch::aarch64::float32x4_t) -> std::arch::aarch64::float32x4_t {
+    use std::arch::aarch64::*;
+    let x = vmaxq_f32(x, vdupq_n_f32(-87.0));
+    let x = vminq_f32(x, vdupq_n_f32(88.0));
+    let t = vfmaq_f32(vdupq_n_f32(1_065_353_216.0), x, vdupq_n_f32(12_102_203.0));
+    vreinterpretq_f32_s32(vcvtq_s32_f32(t))
+}
+
+// ===================================================================
+// AVX2 fast exp (Schraudolph bit trick) — 8-wide __m256
+// ===================================================================
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn fast_exp_avx2(x: std::arch::x86_64::__m256) -> std::arch::x86_64::__m256 {
+    use std::arch::x86_64::*;
+    let x = _mm256_max_ps(x, _mm256_set1_ps(-87.0));
+    let x = _mm256_min_ps(x, _mm256_set1_ps(88.0));
+    let scale = _mm256_set1_ps(12_102_203.0);
+    let bias = _mm256_set1_ps(1_065_353_216.0);
+    let t = _mm256_add_ps(_mm256_mul_ps(x, scale), bias);
+    _mm256_castsi256_ps(_mm256_cvtps_epi32(t))
+}
+
+// ===================================================================
+// NEON implementations — 4-wide float32x4_t
+// ===================================================================
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn rms_norm_neon(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
+    use std::arch::aarch64::*;
+
+    let num_tokens = x.len() / hidden;
+    debug_assert_eq!(x.len(), num_tokens * hidden);
+    debug_assert_eq!(gamma.len(), hidden);
+
+    let chunks = hidden / 4;
+    let inv_hidden = 1.0f32 / hidden as f32;
+
+    for t in 0..num_tokens {
+        let row_ptr = x.as_mut_ptr().add(t * hidden);
+        let gamma_ptr = gamma.as_ptr();
+
+        // --- Step 1: Sum of squares via SIMD ---
+        let mut vsum_sq = vdupq_n_f32(0.0);
+        for c in 0..chunks {
+            // SAFETY: c * 4 + 3 < chunks * 4 <= hidden, within row bounds.
+            let v = vld1q_f32(row_ptr.add(c * 4) as *const f32);
+            vsum_sq = vfmaq_f32(vsum_sq, v, v);
+        }
+        let mut sum_sq = vaddvq_f32(vsum_sq);
+        for i in (chunks * 4)..hidden {
+            let v = *row_ptr.add(i);
+            sum_sq += v * v;
+        }
+
+        let rms = (sum_sq * inv_hidden + eps).sqrt();
+        let inv_rms = 1.0 / rms;
+        let vinv_rms = vdupq_n_f32(inv_rms);
+
+        // --- Step 2: Scale by gamma / rms using SIMD ---
+        for c in 0..chunks {
+            let off = c * 4;
+            // SAFETY: off + 3 < chunks * 4 <= hidden, within both row and gamma bounds.
+            let v = vld1q_f32(row_ptr.add(off) as *const f32);
+            let g = vld1q_f32(gamma_ptr.add(off));
+            let result = vmulq_f32(vmulq_f32(v, vinv_rms), g);
+            vst1q_f32(row_ptr.add(off), result);
+        }
+        for i in (chunks * 4)..hidden {
+            let v = *row_ptr.add(i);
+            let g = *gamma_ptr.add(i);
+            *row_ptr.add(i) = v * inv_rms * g;
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn silu_inplace_neon(x: &mut [f32]) {
+    use std::arch::aarch64::*;
+
+    let n = x.len();
+    let chunks = n / 4;
+    let ptr = x.as_mut_ptr();
+    let vone = vdupq_n_f32(1.0);
+
+    for c in 0..chunks {
+        let off = c * 4;
+        // SAFETY: off + 3 < chunks * 4 <= n, within slice bounds.
+        let v = vld1q_f32(ptr.add(off) as *const f32);
+        // sigmoid(v) = 1 / (1 + exp(-v))
+        let neg_v = vnegq_f32(v);
+        let exp_neg_v = fast_exp_neon(neg_v);
+        let sigmoid = vdivq_f32(vone, vaddq_f32(vone, exp_neg_v));
+        // silu = v * sigmoid(v)
+        let result = vmulq_f32(v, sigmoid);
+        vst1q_f32(ptr.add(off), result);
+    }
+    for i in (chunks * 4)..n {
+        let v = *ptr.add(i);
+        *ptr.add(i) = v * (1.0 / (1.0 + (-v).exp()));
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn elementwise_mul_neon(a: &mut [f32], b: &[f32]) {
+    use std::arch::aarch64::*;
+
+    debug_assert_eq!(a.len(), b.len());
+    let n = a.len();
+    let chunks = n / 4;
+    let a_ptr = a.as_mut_ptr();
+    let b_ptr = b.as_ptr();
+
+    for c in 0..chunks {
+        let off = c * 4;
+        // SAFETY: off + 3 < chunks * 4 <= n, within both slice bounds.
+        let av = vld1q_f32(a_ptr.add(off) as *const f32);
+        let bv = vld1q_f32(b_ptr.add(off));
+        vst1q_f32(a_ptr.add(off), vmulq_f32(av, bv));
+    }
+    for i in (chunks * 4)..n {
+        *a_ptr.add(i) *= *b_ptr.add(i);
+    }
+}
+
+// ===================================================================
+// AVX2 implementations — 8-wide __m256
+// ===================================================================
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn rms_norm_avx2(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
+    use std::arch::x86_64::*;
+
+    let num_tokens = x.len() / hidden;
+    debug_assert_eq!(x.len(), num_tokens * hidden);
+    debug_assert_eq!(gamma.len(), hidden);
+
+    let chunks = hidden / 8;
+    let inv_hidden = 1.0f32 / hidden as f32;
+
+    for t in 0..num_tokens {
+        let row_ptr = x.as_mut_ptr().add(t * hidden);
+        let gamma_ptr = gamma.as_ptr();
+
+        // --- Step 1: Sum of squares via SIMD ---
+        let mut vsum_sq = _mm256_setzero_ps();
+        for c in 0..chunks {
+            // SAFETY: c * 8 + 7 < chunks * 8 <= hidden, within row bounds.
+            let v = _mm256_loadu_ps(row_ptr.add(c * 8) as *const f32);
+            vsum_sq = _mm256_add_ps(vsum_sq, _mm256_mul_ps(v, v));
+        }
+        // Horizontal sum of vsum_sq
+        let hi = _mm256_extractf128_ps(vsum_sq, 1);
+        let lo = _mm256_castps256_ps128(vsum_sq);
+        let sum128 = _mm_add_ps(lo, hi);
+        let shuf = _mm_movehdup_ps(sum128);
+        let sums = _mm_add_ps(sum128, shuf);
+        let shuf2 = _mm_movehl_ps(sums, sums);
+        let mut sum_sq = _mm_cvtss_f32(_mm_add_ss(sums, shuf2));
+        for i in (chunks * 8)..hidden {
+            let v = *row_ptr.add(i);
+            sum_sq += v * v;
+        }
+
+        let rms = (sum_sq * inv_hidden + eps).sqrt();
+        let inv_rms = 1.0 / rms;
+        let vinv_rms = _mm256_set1_ps(inv_rms);
+
+        // --- Step 2: Scale by gamma / rms using SIMD ---
+        for c in 0..chunks {
+            let off = c * 8;
+            // SAFETY: off + 7 < chunks * 8 <= hidden, within both row and gamma bounds.
+            let v = _mm256_loadu_ps(row_ptr.add(off) as *const f32);
+            let g = _mm256_loadu_ps(gamma_ptr.add(off) as *const f32);
+            let result = _mm256_mul_ps(_mm256_mul_ps(v, vinv_rms), g);
+            _mm256_storeu_ps(row_ptr.add(off), result);
+        }
+        for i in (chunks * 8)..hidden {
+            let v = *row_ptr.add(i);
+            let g = *gamma_ptr.add(i);
+            *row_ptr.add(i) = v * inv_rms * g;
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn silu_inplace_avx2(x: &mut [f32]) {
+    use std::arch::x86_64::*;
+
+    let n = x.len();
+    let chunks = n / 8;
+    let ptr = x.as_mut_ptr();
+    let vone = _mm256_set1_ps(1.0);
+
+    for c in 0..chunks {
+        let off = c * 8;
+        // SAFETY: off + 7 < chunks * 8 <= n, within slice bounds.
+        let v = _mm256_loadu_ps(ptr.add(off) as *const f32);
+        // sigmoid(v) = 1 / (1 + exp(-v))
+        let neg_v = _mm256_xor_ps(v, _mm256_set1_ps(-0.0));
+        let exp_neg_v = fast_exp_avx2(neg_v);
+        let sigmoid = _mm256_div_ps(vone, _mm256_add_ps(vone, exp_neg_v));
+        // silu = v * sigmoid(v)
+        let result = _mm256_mul_ps(v, sigmoid);
+        _mm256_storeu_ps(ptr.add(off), result);
+    }
+    for i in (chunks * 8)..n {
+        let v = *ptr.add(i);
+        *ptr.add(i) = v * (1.0 / (1.0 + (-v).exp()));
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn elementwise_mul_avx2(a: &mut [f32], b: &[f32]) {
+    use std::arch::x86_64::*;
+
+    debug_assert_eq!(a.len(), b.len());
+    let n = a.len();
+    let chunks = n / 8;
+    let a_ptr = a.as_mut_ptr();
+    let b_ptr = b.as_ptr();
+
+    for c in 0..chunks {
+        let off = c * 8;
+        // SAFETY: off + 7 < chunks * 8 <= n, within both slice bounds.
+        let av = _mm256_loadu_ps(a_ptr.add(off) as *const f32);
+        let bv = _mm256_loadu_ps(b_ptr.add(off) as *const f32);
+        _mm256_storeu_ps(a_ptr.add(off), _mm256_mul_ps(av, bv));
+    }
+    for i in (chunks * 8)..n {
+        *a_ptr.add(i) *= *b_ptr.add(i);
     }
 }

--- a/crates/inference/src/forward/cpu/elementwise.rs
+++ b/crates/inference/src/forward/cpu/elementwise.rs
@@ -10,6 +10,13 @@ use super::simd::simd_config;
 ///
 /// Unlike LayerNorm, RMSNorm does not center (no beta/mean subtraction).
 pub fn rms_norm(x: &mut [f32], gamma: &[f32], hidden: usize, eps: f32) {
+    assert!(hidden > 0, "hidden must be > 0");
+    assert!(
+        x.len() % hidden == 0,
+        "x.len() must be a multiple of hidden"
+    );
+    assert!(gamma.len() == hidden, "gamma.len() must equal hidden");
+
     let config = simd_config();
 
     #[cfg(target_arch = "aarch64")]
@@ -72,6 +79,8 @@ pub fn silu_inplace(x: &mut [f32]) {
 ///
 /// Element-wise multiply: a *= b.
 pub fn elementwise_mul(a: &mut [f32], b: &[f32]) {
+    assert!(a.len() == b.len(), "a.len() must equal b.len()");
+
     let config = simd_config();
 
     #[cfg(target_arch = "aarch64")]
@@ -142,38 +151,6 @@ pub fn elementwise_mul_scalar(a: &mut [f32], b: &[f32]) {
 }
 
 // ===================================================================
-// NEON fast exp (Schraudolph bit trick) — 4-wide float32x4_t
-// ===================================================================
-
-#[cfg(target_arch = "aarch64")]
-#[inline]
-#[target_feature(enable = "neon")]
-unsafe fn fast_exp_neon(x: std::arch::aarch64::float32x4_t) -> std::arch::aarch64::float32x4_t {
-    use std::arch::aarch64::*;
-    let x = vmaxq_f32(x, vdupq_n_f32(-87.0));
-    let x = vminq_f32(x, vdupq_n_f32(88.0));
-    let t = vfmaq_f32(vdupq_n_f32(1_065_353_216.0), x, vdupq_n_f32(12_102_203.0));
-    vreinterpretq_f32_s32(vcvtq_s32_f32(t))
-}
-
-// ===================================================================
-// AVX2 fast exp (Schraudolph bit trick) — 8-wide __m256
-// ===================================================================
-
-#[cfg(target_arch = "x86_64")]
-#[inline]
-#[target_feature(enable = "avx2")]
-unsafe fn fast_exp_avx2(x: std::arch::x86_64::__m256) -> std::arch::x86_64::__m256 {
-    use std::arch::x86_64::*;
-    let x = _mm256_max_ps(x, _mm256_set1_ps(-87.0));
-    let x = _mm256_min_ps(x, _mm256_set1_ps(88.0));
-    let scale = _mm256_set1_ps(12_102_203.0);
-    let bias = _mm256_set1_ps(1_065_353_216.0);
-    let t = _mm256_add_ps(_mm256_mul_ps(x, scale), bias);
-    _mm256_castsi256_ps(_mm256_cvtps_epi32(t))
-}
-
-// ===================================================================
 // NEON implementations — 4-wide float32x4_t
 // ===================================================================
 
@@ -241,9 +218,16 @@ unsafe fn silu_inplace_neon(x: &mut [f32]) {
         let off = c * 4;
         // SAFETY: off + 3 < chunks * 4 <= n, within slice bounds.
         let v = vld1q_f32(ptr.add(off) as *const f32);
-        // sigmoid(v) = 1 / (1 + exp(-v))
+        // sigmoid(v) = 1 / (1 + exp(-v)); use accurate exp for numerical correctness.
         let neg_v = vnegq_f32(v);
-        let exp_neg_v = fast_exp_neon(neg_v);
+        let neg_arr: [f32; 4] = core::mem::transmute(neg_v);
+        let exp_arr = [
+            neg_arr[0].exp(),
+            neg_arr[1].exp(),
+            neg_arr[2].exp(),
+            neg_arr[3].exp(),
+        ];
+        let exp_neg_v: float32x4_t = core::mem::transmute(exp_arr);
         let sigmoid = vdivq_f32(vone, vaddq_f32(vone, exp_neg_v));
         // silu = v * sigmoid(v)
         let result = vmulq_f32(v, sigmoid);
@@ -353,9 +337,20 @@ unsafe fn silu_inplace_avx2(x: &mut [f32]) {
         let off = c * 8;
         // SAFETY: off + 7 < chunks * 8 <= n, within slice bounds.
         let v = _mm256_loadu_ps(ptr.add(off) as *const f32);
-        // sigmoid(v) = 1 / (1 + exp(-v))
+        // sigmoid(v) = 1 / (1 + exp(-v)); use accurate exp for numerical correctness.
         let neg_v = _mm256_xor_ps(v, _mm256_set1_ps(-0.0));
-        let exp_neg_v = fast_exp_avx2(neg_v);
+        let neg_arr: [f32; 8] = core::mem::transmute(neg_v);
+        let exp_arr = [
+            neg_arr[0].exp(),
+            neg_arr[1].exp(),
+            neg_arr[2].exp(),
+            neg_arr[3].exp(),
+            neg_arr[4].exp(),
+            neg_arr[5].exp(),
+            neg_arr[6].exp(),
+            neg_arr[7].exp(),
+        ];
+        let exp_neg_v: __m256 = core::mem::transmute(exp_arr);
         let sigmoid = _mm256_div_ps(vone, _mm256_add_ps(vone, exp_neg_v));
         // silu = v * sigmoid(v)
         let result = _mm256_mul_ps(v, sigmoid);

--- a/crates/inference/src/forward/cpu/matmul.rs
+++ b/crates/inference/src/forward/cpu/matmul.rs
@@ -125,16 +125,64 @@ pub fn matmul_scalar(a: &[f32], b: &[f32], c: &mut [f32], m: usize, k: usize, n:
 
 #[cfg_attr(target_os = "macos", allow(dead_code))]
 pub fn matmul_bt_scalar(a: &[f32], b: &[f32], c: &mut [f32], m: usize, k: usize, n: usize) {
+    if m == 1 {
+        matmul_bt_scalar_m1(a, b, c, k, n);
+        return;
+    }
     for i in 0..m {
         let a_row = &a[i * k..(i + 1) * k];
         let c_row = &mut c[i * n..(i + 1) * n];
         for j in 0..n {
             let b_row = &b[j * k..(j + 1) * k];
-            let mut sum = 0.0f32;
-            for p in 0..k {
-                sum += a_row[p] * b_row[p];
+            let mut s0 = 0.0f32;
+            let mut s1 = 0.0f32;
+            let mut s2 = 0.0f32;
+            let mut s3 = 0.0f32;
+            let unrolled = k / 4;
+            for p in 0..unrolled {
+                let off = p * 4;
+                s0 += a_row[off] * b_row[off];
+                s1 += a_row[off + 1] * b_row[off + 1];
+                s2 += a_row[off + 2] * b_row[off + 2];
+                s3 += a_row[off + 3] * b_row[off + 3];
             }
-            c_row[j] = sum;
+            for p in (unrolled * 4)..k {
+                s0 += a_row[p] * b_row[p];
+            }
+            c_row[j] = (s0 + s1) + (s2 + s3);
         }
+    }
+}
+
+#[cfg_attr(target_os = "macos", allow(dead_code))]
+#[inline]
+fn matmul_bt_scalar_m1(a: &[f32], b: &[f32], c: &mut [f32], k: usize, n: usize) {
+    let a_row = &a[..k];
+    let unrolled8 = k / 8;
+    for j in 0..n {
+        let b_row = &b[j * k..(j + 1) * k];
+        let mut s0 = 0.0f32;
+        let mut s1 = 0.0f32;
+        let mut s2 = 0.0f32;
+        let mut s3 = 0.0f32;
+        let mut s4 = 0.0f32;
+        let mut s5 = 0.0f32;
+        let mut s6 = 0.0f32;
+        let mut s7 = 0.0f32;
+        for p in 0..unrolled8 {
+            let off = p * 8;
+            s0 += a_row[off] * b_row[off];
+            s1 += a_row[off + 1] * b_row[off + 1];
+            s2 += a_row[off + 2] * b_row[off + 2];
+            s3 += a_row[off + 3] * b_row[off + 3];
+            s4 += a_row[off + 4] * b_row[off + 4];
+            s5 += a_row[off + 5] * b_row[off + 5];
+            s6 += a_row[off + 6] * b_row[off + 6];
+            s7 += a_row[off + 7] * b_row[off + 7];
+        }
+        for p in (unrolled8 * 8)..k {
+            s0 += a_row[p] * b_row[p];
+        }
+        c[j] = ((s0 + s1) + (s2 + s3)) + ((s4 + s5) + (s6 + s7));
     }
 }

--- a/crates/inference/src/forward/cpu/mod.rs
+++ b/crates/inference/src/forward/cpu/mod.rs
@@ -28,6 +28,8 @@ pub use softmax::softmax_attention;
 #[cfg(test)]
 pub use activation::{add_bias_gelu_scalar, fast_tanh, gelu_scalar};
 #[cfg(test)]
+pub use elementwise::{elementwise_mul_scalar, rms_norm_scalar, silu_inplace_scalar};
+#[cfg(test)]
 pub use matmul::matmul_bt_scalar;
 #[cfg(test)]
 pub use norm::layer_norm_scalar;

--- a/crates/inference/src/forward/cpu/norm.rs
+++ b/crates/inference/src/forward/cpu/norm.rs
@@ -69,55 +69,50 @@ unsafe fn layer_norm_neon(x: &mut [f32], gamma: &[f32], beta: &[f32], hidden: us
     let inv_n = 1.0 / hidden as f32;
 
     for row in x.chunks_exact_mut(hidden) {
-        // --- Pass 1: compute mean using SIMD sum ---
+        // --- Fused pass: compute sum AND sum-of-squares simultaneously ---
+        // Saves one full read of the row vs separate mean then variance passes.
+        // variance = E[x²] - E[x]² (numerically safe for typical hidden-state magnitudes)
         let mut sum0 = vdupq_n_f32(0.0);
         let mut sum1 = vdupq_n_f32(0.0);
         let mut sum2 = vdupq_n_f32(0.0);
         let mut sum3 = vdupq_n_f32(0.0);
+        let mut sq0 = vdupq_n_f32(0.0);
+        let mut sq1 = vdupq_n_f32(0.0);
+        let mut sq2 = vdupq_n_f32(0.0);
+        let mut sq3 = vdupq_n_f32(0.0);
 
         let chunks = hidden / 16;
         let ptr = row.as_ptr();
         for c in 0..chunks {
             let off = c * 16;
-            sum0 = vaddq_f32(sum0, vld1q_f32(ptr.add(off)));
-            sum1 = vaddq_f32(sum1, vld1q_f32(ptr.add(off + 4)));
-            sum2 = vaddq_f32(sum2, vld1q_f32(ptr.add(off + 8)));
-            sum3 = vaddq_f32(sum3, vld1q_f32(ptr.add(off + 12)));
+            let v0 = vld1q_f32(ptr.add(off));
+            let v1 = vld1q_f32(ptr.add(off + 4));
+            let v2 = vld1q_f32(ptr.add(off + 8));
+            let v3 = vld1q_f32(ptr.add(off + 12));
+            sum0 = vaddq_f32(sum0, v0);
+            sum1 = vaddq_f32(sum1, v1);
+            sum2 = vaddq_f32(sum2, v2);
+            sum3 = vaddq_f32(sum3, v3);
+            sq0 = vfmaq_f32(sq0, v0, v0);
+            sq1 = vfmaq_f32(sq1, v1, v1);
+            sq2 = vfmaq_f32(sq2, v2, v2);
+            sq3 = vfmaq_f32(sq3, v3, v3);
         }
-        let combined = vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3));
-        let mut total = vaddvq_f32(combined);
+        let combined_sum = vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3));
+        let mut total_sum = vaddvq_f32(combined_sum);
+        let combined_sq = vaddq_f32(vaddq_f32(sq0, sq1), vaddq_f32(sq2, sq3));
+        let mut total_sq = vaddvq_f32(combined_sq);
         for i in (chunks * 16)..hidden {
-            total += *ptr.add(i);
+            let v = *ptr.add(i);
+            total_sum += v;
+            total_sq += v * v;
         }
-        let mean = total * inv_n;
+        let mean = total_sum * inv_n;
+        let variance = total_sq * inv_n - mean * mean;
+        let inv_std = 1.0 / (variance + eps).sqrt();
 
-        // --- Pass 2: compute variance using SIMD ---
+        // --- Pass 2: normalize using SIMD: (x - mean) * inv_std * gamma + beta ---
         let vmean = vdupq_n_f32(mean);
-        let mut var0 = vdupq_n_f32(0.0);
-        let mut var1 = vdupq_n_f32(0.0);
-        let mut var2 = vdupq_n_f32(0.0);
-        let mut var3 = vdupq_n_f32(0.0);
-
-        for c in 0..chunks {
-            let off = c * 16;
-            let d0 = vsubq_f32(vld1q_f32(ptr.add(off)), vmean);
-            var0 = vfmaq_f32(var0, d0, d0);
-            let d1 = vsubq_f32(vld1q_f32(ptr.add(off + 4)), vmean);
-            var1 = vfmaq_f32(var1, d1, d1);
-            let d2 = vsubq_f32(vld1q_f32(ptr.add(off + 8)), vmean);
-            var2 = vfmaq_f32(var2, d2, d2);
-            let d3 = vsubq_f32(vld1q_f32(ptr.add(off + 12)), vmean);
-            var3 = vfmaq_f32(var3, d3, d3);
-        }
-        let var_combined = vaddq_f32(vaddq_f32(var0, var1), vaddq_f32(var2, var3));
-        let mut var_total = vaddvq_f32(var_combined);
-        for i in (chunks * 16)..hidden {
-            let d = *ptr.add(i) - mean;
-            var_total += d * d;
-        }
-        let inv_std = 1.0 / (var_total * inv_n + eps).sqrt();
-
-        // --- Pass 3: normalize using SIMD: (x - mean) * inv_std * gamma + beta ---
         let vinv_std = vdupq_n_f32(inv_std);
         let out_ptr = row.as_mut_ptr();
         let g_ptr = gamma.as_ptr();
@@ -171,55 +166,48 @@ unsafe fn layer_norm_avx2(x: &mut [f32], gamma: &[f32], beta: &[f32], hidden: us
     let inv_n = 1.0 / hidden as f32;
 
     for row in x.chunks_exact_mut(hidden) {
-        // --- Pass 1: compute mean ---
+        // --- Fused pass: compute sum AND sum-of-squares simultaneously ---
         let mut sum0 = _mm256_setzero_ps();
         let mut sum1 = _mm256_setzero_ps();
         let mut sum2 = _mm256_setzero_ps();
         let mut sum3 = _mm256_setzero_ps();
+        let mut sq0 = _mm256_setzero_ps();
+        let mut sq1 = _mm256_setzero_ps();
+        let mut sq2 = _mm256_setzero_ps();
+        let mut sq3 = _mm256_setzero_ps();
 
         let chunks = hidden / 32;
         let ptr = row.as_ptr();
         for c in 0..chunks {
             let off = c * 32;
-            sum0 = _mm256_add_ps(sum0, _mm256_loadu_ps(ptr.add(off)));
-            sum1 = _mm256_add_ps(sum1, _mm256_loadu_ps(ptr.add(off + 8)));
-            sum2 = _mm256_add_ps(sum2, _mm256_loadu_ps(ptr.add(off + 16)));
-            sum3 = _mm256_add_ps(sum3, _mm256_loadu_ps(ptr.add(off + 24)));
+            let v0 = _mm256_loadu_ps(ptr.add(off));
+            let v1 = _mm256_loadu_ps(ptr.add(off + 8));
+            let v2 = _mm256_loadu_ps(ptr.add(off + 16));
+            let v3 = _mm256_loadu_ps(ptr.add(off + 24));
+            sum0 = _mm256_add_ps(sum0, v0);
+            sum1 = _mm256_add_ps(sum1, v1);
+            sum2 = _mm256_add_ps(sum2, v2);
+            sum3 = _mm256_add_ps(sum3, v3);
+            sq0 = _mm256_fmadd_ps(v0, v0, sq0);
+            sq1 = _mm256_fmadd_ps(v1, v1, sq1);
+            sq2 = _mm256_fmadd_ps(v2, v2, sq2);
+            sq3 = _mm256_fmadd_ps(v3, v3, sq3);
         }
-        let combined = _mm256_add_ps(_mm256_add_ps(sum0, sum1), _mm256_add_ps(sum2, sum3));
-        let mut total = hsum_m256(combined);
+        let combined_sum = _mm256_add_ps(_mm256_add_ps(sum0, sum1), _mm256_add_ps(sum2, sum3));
+        let mut total_sum = hsum_m256(combined_sum);
+        let combined_sq = _mm256_add_ps(_mm256_add_ps(sq0, sq1), _mm256_add_ps(sq2, sq3));
+        let mut total_sq = hsum_m256(combined_sq);
         for i in (chunks * 32)..hidden {
-            total += *ptr.add(i);
+            let v = *ptr.add(i);
+            total_sum += v;
+            total_sq += v * v;
         }
-        let mean = total * inv_n;
+        let mean = total_sum * inv_n;
+        let variance = total_sq * inv_n - mean * mean;
+        let inv_std = 1.0 / (variance + eps).sqrt();
 
-        // --- Pass 2: compute variance ---
+        // --- Pass 2: normalize ---
         let vmean = _mm256_set1_ps(mean);
-        let mut var0 = _mm256_setzero_ps();
-        let mut var1 = _mm256_setzero_ps();
-        let mut var2 = _mm256_setzero_ps();
-        let mut var3 = _mm256_setzero_ps();
-
-        for c in 0..chunks {
-            let off = c * 32;
-            let d0 = _mm256_sub_ps(_mm256_loadu_ps(ptr.add(off)), vmean);
-            var0 = _mm256_fmadd_ps(d0, d0, var0);
-            let d1 = _mm256_sub_ps(_mm256_loadu_ps(ptr.add(off + 8)), vmean);
-            var1 = _mm256_fmadd_ps(d1, d1, var1);
-            let d2 = _mm256_sub_ps(_mm256_loadu_ps(ptr.add(off + 16)), vmean);
-            var2 = _mm256_fmadd_ps(d2, d2, var2);
-            let d3 = _mm256_sub_ps(_mm256_loadu_ps(ptr.add(off + 24)), vmean);
-            var3 = _mm256_fmadd_ps(d3, d3, var3);
-        }
-        let var_combined = _mm256_add_ps(_mm256_add_ps(var0, var1), _mm256_add_ps(var2, var3));
-        let mut var_total = hsum_m256(var_combined);
-        for i in (chunks * 32)..hidden {
-            let d = *ptr.add(i) - mean;
-            var_total += d * d;
-        }
-        let inv_std = 1.0 / (var_total * inv_n + eps).sqrt();
-
-        // --- Pass 3: normalize ---
         let vinv_std = _mm256_set1_ps(inv_std);
         let out_ptr = row.as_mut_ptr();
         let g_ptr = gamma.as_ptr();

--- a/crates/inference/src/forward/cpu/norm.rs
+++ b/crates/inference/src/forward/cpu/norm.rs
@@ -69,50 +69,55 @@ unsafe fn layer_norm_neon(x: &mut [f32], gamma: &[f32], beta: &[f32], hidden: us
     let inv_n = 1.0 / hidden as f32;
 
     for row in x.chunks_exact_mut(hidden) {
-        // --- Fused pass: compute sum AND sum-of-squares simultaneously ---
-        // Saves one full read of the row vs separate mean then variance passes.
-        // variance = E[x²] - E[x]² (numerically safe for typical hidden-state magnitudes)
+        let chunks = hidden / 16;
+        let ptr = row.as_ptr();
+
+        // --- Pass 1: compute sum → mean with 4x unrolled accumulators ---
         let mut sum0 = vdupq_n_f32(0.0);
         let mut sum1 = vdupq_n_f32(0.0);
         let mut sum2 = vdupq_n_f32(0.0);
         let mut sum3 = vdupq_n_f32(0.0);
+        for c in 0..chunks {
+            let off = c * 16;
+            sum0 = vaddq_f32(sum0, vld1q_f32(ptr.add(off)));
+            sum1 = vaddq_f32(sum1, vld1q_f32(ptr.add(off + 4)));
+            sum2 = vaddq_f32(sum2, vld1q_f32(ptr.add(off + 8)));
+            sum3 = vaddq_f32(sum3, vld1q_f32(ptr.add(off + 12)));
+        }
+        let combined_sum = vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3));
+        let mut total_sum = vaddvq_f32(combined_sum);
+        for i in (chunks * 16)..hidden {
+            total_sum += *ptr.add(i);
+        }
+        let mean = total_sum * inv_n;
+
+        // --- Pass 2: compute sum of (x - mean)² → variance with 4x unrolled accumulators ---
+        let vmean = vdupq_n_f32(mean);
         let mut sq0 = vdupq_n_f32(0.0);
         let mut sq1 = vdupq_n_f32(0.0);
         let mut sq2 = vdupq_n_f32(0.0);
         let mut sq3 = vdupq_n_f32(0.0);
-
-        let chunks = hidden / 16;
-        let ptr = row.as_ptr();
         for c in 0..chunks {
             let off = c * 16;
-            let v0 = vld1q_f32(ptr.add(off));
-            let v1 = vld1q_f32(ptr.add(off + 4));
-            let v2 = vld1q_f32(ptr.add(off + 8));
-            let v3 = vld1q_f32(ptr.add(off + 12));
-            sum0 = vaddq_f32(sum0, v0);
-            sum1 = vaddq_f32(sum1, v1);
-            sum2 = vaddq_f32(sum2, v2);
-            sum3 = vaddq_f32(sum3, v3);
-            sq0 = vfmaq_f32(sq0, v0, v0);
-            sq1 = vfmaq_f32(sq1, v1, v1);
-            sq2 = vfmaq_f32(sq2, v2, v2);
-            sq3 = vfmaq_f32(sq3, v3, v3);
+            let d0 = vsubq_f32(vld1q_f32(ptr.add(off)), vmean);
+            let d1 = vsubq_f32(vld1q_f32(ptr.add(off + 4)), vmean);
+            let d2 = vsubq_f32(vld1q_f32(ptr.add(off + 8)), vmean);
+            let d3 = vsubq_f32(vld1q_f32(ptr.add(off + 12)), vmean);
+            sq0 = vfmaq_f32(sq0, d0, d0);
+            sq1 = vfmaq_f32(sq1, d1, d1);
+            sq2 = vfmaq_f32(sq2, d2, d2);
+            sq3 = vfmaq_f32(sq3, d3, d3);
         }
-        let combined_sum = vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3));
-        let mut total_sum = vaddvq_f32(combined_sum);
         let combined_sq = vaddq_f32(vaddq_f32(sq0, sq1), vaddq_f32(sq2, sq3));
         let mut total_sq = vaddvq_f32(combined_sq);
         for i in (chunks * 16)..hidden {
-            let v = *ptr.add(i);
-            total_sum += v;
-            total_sq += v * v;
+            let d = *ptr.add(i) - mean;
+            total_sq += d * d;
         }
-        let mean = total_sum * inv_n;
-        let variance = total_sq * inv_n - mean * mean;
+        let variance = total_sq * inv_n;
         let inv_std = 1.0 / (variance + eps).sqrt();
 
-        // --- Pass 2: normalize using SIMD: (x - mean) * inv_std * gamma + beta ---
-        let vmean = vdupq_n_f32(mean);
+        // --- Pass 3: normalize using SIMD: (x - mean) * inv_std * gamma + beta ---
         let vinv_std = vdupq_n_f32(inv_std);
         let out_ptr = row.as_mut_ptr();
         let g_ptr = gamma.as_ptr();
@@ -166,48 +171,55 @@ unsafe fn layer_norm_avx2(x: &mut [f32], gamma: &[f32], beta: &[f32], hidden: us
     let inv_n = 1.0 / hidden as f32;
 
     for row in x.chunks_exact_mut(hidden) {
-        // --- Fused pass: compute sum AND sum-of-squares simultaneously ---
+        let chunks = hidden / 32;
+        let ptr = row.as_ptr();
+
+        // --- Pass 1: compute sum → mean with 4x unrolled accumulators ---
         let mut sum0 = _mm256_setzero_ps();
         let mut sum1 = _mm256_setzero_ps();
         let mut sum2 = _mm256_setzero_ps();
         let mut sum3 = _mm256_setzero_ps();
+        for c in 0..chunks {
+            let off = c * 32;
+            sum0 = _mm256_add_ps(sum0, _mm256_loadu_ps(ptr.add(off)));
+            sum1 = _mm256_add_ps(sum1, _mm256_loadu_ps(ptr.add(off + 8)));
+            sum2 = _mm256_add_ps(sum2, _mm256_loadu_ps(ptr.add(off + 16)));
+            sum3 = _mm256_add_ps(sum3, _mm256_loadu_ps(ptr.add(off + 24)));
+        }
+        let combined_sum = _mm256_add_ps(_mm256_add_ps(sum0, sum1), _mm256_add_ps(sum2, sum3));
+        let mut total_sum = hsum_m256(combined_sum);
+        for i in (chunks * 32)..hidden {
+            total_sum += *ptr.add(i);
+        }
+        let mean = total_sum * inv_n;
+
+        // --- Pass 2: compute sum of (x - mean)² → variance with 4x unrolled accumulators ---
+        let vmean = _mm256_set1_ps(mean);
         let mut sq0 = _mm256_setzero_ps();
         let mut sq1 = _mm256_setzero_ps();
         let mut sq2 = _mm256_setzero_ps();
         let mut sq3 = _mm256_setzero_ps();
-
-        let chunks = hidden / 32;
-        let ptr = row.as_ptr();
         for c in 0..chunks {
             let off = c * 32;
-            let v0 = _mm256_loadu_ps(ptr.add(off));
-            let v1 = _mm256_loadu_ps(ptr.add(off + 8));
-            let v2 = _mm256_loadu_ps(ptr.add(off + 16));
-            let v3 = _mm256_loadu_ps(ptr.add(off + 24));
-            sum0 = _mm256_add_ps(sum0, v0);
-            sum1 = _mm256_add_ps(sum1, v1);
-            sum2 = _mm256_add_ps(sum2, v2);
-            sum3 = _mm256_add_ps(sum3, v3);
-            sq0 = _mm256_fmadd_ps(v0, v0, sq0);
-            sq1 = _mm256_fmadd_ps(v1, v1, sq1);
-            sq2 = _mm256_fmadd_ps(v2, v2, sq2);
-            sq3 = _mm256_fmadd_ps(v3, v3, sq3);
+            let d0 = _mm256_sub_ps(_mm256_loadu_ps(ptr.add(off)), vmean);
+            let d1 = _mm256_sub_ps(_mm256_loadu_ps(ptr.add(off + 8)), vmean);
+            let d2 = _mm256_sub_ps(_mm256_loadu_ps(ptr.add(off + 16)), vmean);
+            let d3 = _mm256_sub_ps(_mm256_loadu_ps(ptr.add(off + 24)), vmean);
+            sq0 = _mm256_fmadd_ps(d0, d0, sq0);
+            sq1 = _mm256_fmadd_ps(d1, d1, sq1);
+            sq2 = _mm256_fmadd_ps(d2, d2, sq2);
+            sq3 = _mm256_fmadd_ps(d3, d3, sq3);
         }
-        let combined_sum = _mm256_add_ps(_mm256_add_ps(sum0, sum1), _mm256_add_ps(sum2, sum3));
-        let mut total_sum = hsum_m256(combined_sum);
         let combined_sq = _mm256_add_ps(_mm256_add_ps(sq0, sq1), _mm256_add_ps(sq2, sq3));
         let mut total_sq = hsum_m256(combined_sq);
         for i in (chunks * 32)..hidden {
-            let v = *ptr.add(i);
-            total_sum += v;
-            total_sq += v * v;
+            let d = *ptr.add(i) - mean;
+            total_sq += d * d;
         }
-        let mean = total_sum * inv_n;
-        let variance = total_sq * inv_n - mean * mean;
+        let variance = total_sq * inv_n;
         let inv_std = 1.0 / (variance + eps).sqrt();
 
-        // --- Pass 2: normalize ---
-        let vmean = _mm256_set1_ps(mean);
+        // --- Pass 3: normalize ---
         let vinv_std = _mm256_set1_ps(inv_std);
         let out_ptr = row.as_mut_ptr();
         let g_ptr = gamma.as_ptr();

--- a/crates/inference/src/forward/cpu/softmax.rs
+++ b/crates/inference/src/forward/cpu/softmax.rs
@@ -110,53 +110,96 @@ unsafe fn fast_exp_avx2(x: std::arch::x86_64::__m256) -> std::arch::x86_64::__m2
 unsafe fn softmax_attention_neon(x: &mut [f32], seq_len: usize, num_heads: usize) {
     use std::arch::aarch64::*;
 
+    const UNROLL: usize = 4;
+    const CHUNK: usize = 4 * UNROLL;
+
     for h in 0..num_heads {
         for s in 0..seq_len {
             let start = (h * seq_len + s) * seq_len;
             let row = &mut x[start..start + seq_len];
             let ptr = row.as_mut_ptr();
             let n = row.len();
-            let chunks = n / 4;
+            let chunks = n / CHUNK;
 
-            // --- Step 1: Find row max using SIMD ---
-            let mut vmax = vdupq_n_f32(f32::NEG_INFINITY);
+            // --- Step 1: Find row max with 4x unrolling ---
+            let mut m0 = vdupq_n_f32(f32::NEG_INFINITY);
+            let mut m1 = m0;
+            let mut m2 = m0;
+            let mut m3 = m0;
             for c in 0..chunks {
-                // SAFETY: c * 4 + 3 < chunks * 4 <= n, within row bounds.
-                vmax = vmaxq_f32(vmax, vld1q_f32(ptr.add(c * 4) as *const f32));
+                let base = c * CHUNK;
+                m0 = vmaxq_f32(m0, vld1q_f32(ptr.add(base) as *const f32));
+                m1 = vmaxq_f32(m1, vld1q_f32(ptr.add(base + 4) as *const f32));
+                m2 = vmaxq_f32(m2, vld1q_f32(ptr.add(base + 8) as *const f32));
+                m3 = vmaxq_f32(m3, vld1q_f32(ptr.add(base + 12) as *const f32));
             }
+            let vmax = vmaxq_f32(vmaxq_f32(m0, m1), vmaxq_f32(m2, m3));
             let mut max_val = vmaxvq_f32(vmax);
-            for i in (chunks * 4)..n {
+            for i in (chunks * CHUNK)..n {
                 max_val = max_val.max(*ptr.add(i));
             }
 
-            // --- Step 2: Subtract max + fast exp + accumulate sum (all SIMD) ---
+            // --- Step 2: Subtract max + fast exp + accumulate sum ---
             let vmax_val = vdupq_n_f32(max_val);
-            let mut vsum = vdupq_n_f32(0.0);
+            let mut s0 = vdupq_n_f32(0.0);
+            let mut s1 = s0;
+            let mut s2 = s0;
+            let mut s3 = s0;
             for c in 0..chunks {
-                let off = c * 4;
-                let v = vsubq_f32(vld1q_f32(ptr.add(off) as *const f32), vmax_val);
-                let e = fast_exp_neon(v);
-                vst1q_f32(ptr.add(off), e);
-                vsum = vaddq_f32(vsum, e);
+                let base = c * CHUNK;
+                let e0 = fast_exp_neon(vsubq_f32(vld1q_f32(ptr.add(base) as *const f32), vmax_val));
+                let e1 = fast_exp_neon(vsubq_f32(
+                    vld1q_f32(ptr.add(base + 4) as *const f32),
+                    vmax_val,
+                ));
+                let e2 = fast_exp_neon(vsubq_f32(
+                    vld1q_f32(ptr.add(base + 8) as *const f32),
+                    vmax_val,
+                ));
+                let e3 = fast_exp_neon(vsubq_f32(
+                    vld1q_f32(ptr.add(base + 12) as *const f32),
+                    vmax_val,
+                ));
+                vst1q_f32(ptr.add(base), e0);
+                vst1q_f32(ptr.add(base + 4), e1);
+                vst1q_f32(ptr.add(base + 8), e2);
+                vst1q_f32(ptr.add(base + 12), e3);
+                s0 = vaddq_f32(s0, e0);
+                s1 = vaddq_f32(s1, e1);
+                s2 = vaddq_f32(s2, e2);
+                s3 = vaddq_f32(s3, e3);
             }
-            let mut sum = vaddvq_f32(vsum);
-            for i in (chunks * 4)..n {
+            let mut sum = vaddvq_f32(vaddq_f32(vaddq_f32(s0, s1), vaddq_f32(s2, s3)));
+            for i in (chunks * CHUNK)..n {
                 let e = fast_exp(*ptr.add(i) - max_val);
                 *ptr.add(i) = e;
                 sum += e;
             }
 
-            // --- Step 3: Divide by sum using SIMD ---
+            // --- Step 3: Divide by sum with 4x unrolling ---
             if sum > 0.0 {
-                let inv_sum = 1.0 / sum;
-                let vinv = vdupq_n_f32(inv_sum);
+                let vinv = vdupq_n_f32(1.0 / sum);
                 for c in 0..chunks {
-                    let off = c * 4;
-                    let v = vmulq_f32(vld1q_f32(ptr.add(off) as *const f32), vinv);
-                    vst1q_f32(ptr.add(off), v);
+                    let base = c * CHUNK;
+                    vst1q_f32(
+                        ptr.add(base),
+                        vmulq_f32(vld1q_f32(ptr.add(base) as *const f32), vinv),
+                    );
+                    vst1q_f32(
+                        ptr.add(base + 4),
+                        vmulq_f32(vld1q_f32(ptr.add(base + 4) as *const f32), vinv),
+                    );
+                    vst1q_f32(
+                        ptr.add(base + 8),
+                        vmulq_f32(vld1q_f32(ptr.add(base + 8) as *const f32), vinv),
+                    );
+                    vst1q_f32(
+                        ptr.add(base + 12),
+                        vmulq_f32(vld1q_f32(ptr.add(base + 12) as *const f32), vinv),
+                    );
                 }
-                for i in (chunks * 4)..n {
-                    *ptr.add(i) *= inv_sum;
+                for i in (chunks * CHUNK)..n {
+                    *ptr.add(i) *= 1.0 / sum;
                 }
             }
         }

--- a/crates/inference/src/forward/cpu/softmax.rs
+++ b/crates/inference/src/forward/cpu/softmax.rs
@@ -74,17 +74,16 @@ pub fn fast_exp(x: f32) -> f32 {
 
 /// NEON fast exp approximation for 4 lanes using the Schraudolph bit trick.
 /// exp(x) ~ reinterpret_float(int(x * 2^23/ln2 + 127*2^23))
+/// Intentionally kept instead of the more accurate polynomial exp from elementwise — the
+/// Schraudolph systematic bias cancels in softmax normalization, and it's ~3x faster.
 #[cfg(target_arch = "aarch64")]
 #[inline]
 #[target_feature(enable = "neon")]
-unsafe fn fast_exp_neon(x: std::arch::aarch64::float32x4_t) -> std::arch::aarch64::float32x4_t {
+unsafe fn neon_exp_f32(x: std::arch::aarch64::float32x4_t) -> std::arch::aarch64::float32x4_t {
     use std::arch::aarch64::*;
-    // Clamp to [-87, 88] to avoid overflow/underflow
     let x = vmaxq_f32(x, vdupq_n_f32(-87.0));
     let x = vminq_f32(x, vdupq_n_f32(88.0));
-    // t = x * (2^23 / ln2) + 127 * 2^23
     let t = vfmaq_f32(vdupq_n_f32(1_065_353_216.0), x, vdupq_n_f32(12_102_203.0));
-    // Reinterpret float bits as int, then back to float
     vreinterpretq_f32_s32(vcvtq_s32_f32(t))
 }
 
@@ -147,16 +146,16 @@ unsafe fn softmax_attention_neon(x: &mut [f32], seq_len: usize, num_heads: usize
             let mut s3 = s0;
             for c in 0..chunks {
                 let base = c * CHUNK;
-                let e0 = fast_exp_neon(vsubq_f32(vld1q_f32(ptr.add(base) as *const f32), vmax_val));
-                let e1 = fast_exp_neon(vsubq_f32(
+                let e0 = neon_exp_f32(vsubq_f32(vld1q_f32(ptr.add(base) as *const f32), vmax_val));
+                let e1 = neon_exp_f32(vsubq_f32(
                     vld1q_f32(ptr.add(base + 4) as *const f32),
                     vmax_val,
                 ));
-                let e2 = fast_exp_neon(vsubq_f32(
+                let e2 = neon_exp_f32(vsubq_f32(
                     vld1q_f32(ptr.add(base + 8) as *const f32),
                     vmax_val,
                 ));
-                let e3 = fast_exp_neon(vsubq_f32(
+                let e3 = neon_exp_f32(vsubq_f32(
                     vld1q_f32(ptr.add(base + 12) as *const f32),
                     vmax_val,
                 ));

--- a/crates/inference/src/forward/cpu/tests.rs
+++ b/crates/inference/src/forward/cpu/tests.rs
@@ -445,6 +445,218 @@ fn test_elementwise_mul_simd_matches_scalar() {
     }
 }
 
+// ===================================================================
+// SIMD/scalar parity regression tests — LCG generator + relative error
+// ===================================================================
+//
+// These tests use a second independent generator (LCG) and a proper
+// relative-error comparison to catch silent numerical regressions when
+// NEON SIMD kernels are modified.  They are intentionally separate from
+// the xorshift-based tests above so that both data-generation paths are
+// exercised.
+
+/// LCG-based deterministic f32 vector in the range [-0.02, 0.02].
+/// Uses a different bit-mixing strategy than `make_deterministic_vec`
+/// so the two generators produce uncorrelated data at the same index.
+fn lcg_f32_vec(len: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed ^ 0x6c62_272e_07bb_0142;
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        let unit = (state >> 32) as f32 / u32::MAX as f32;
+        out.push(unit * 0.04 - 0.02);
+    }
+    out
+}
+
+/// Mixed absolute + relative error comparison.
+///
+/// Passes when `|a - b| <= rtol * max(|a|, |b|) + atol`.
+///
+/// Using a non-zero `atol` prevents near-zero elements from triggering
+/// false failures when the *absolute* error is within f32 precision but
+/// the *relative* error is large simply because both values approach zero.
+fn assert_close_mixed(a: &[f32], b: &[f32], rtol: f32, atol: f32, label: &str) {
+    assert_eq!(a.len(), b.len(), "{label}: length mismatch");
+    for (i, (&x, &y)) in a.iter().zip(b.iter()).enumerate() {
+        let abs_diff = (x - y).abs();
+        let threshold = rtol * x.abs().max(y.abs()) + atol;
+        assert!(
+            abs_diff <= threshold,
+            "{label}[{i}]: {x} vs {y}, abs_err={abs_diff:.3e} > rtol*mag+atol={threshold:.3e}"
+        );
+    }
+}
+
+/// Pure relative-error comparison (atol=0).  For each element the
+/// denominator is `max(|a|, |b|, 1e-8)` to avoid division by zero.
+fn assert_close(a: &[f32], b: &[f32], rtol: f32, label: &str) {
+    assert_eq!(a.len(), b.len(), "{label}: length mismatch");
+    for (i, (&x, &y)) in a.iter().zip(b.iter()).enumerate() {
+        let denom = x.abs().max(y.abs()).max(1e-8);
+        let rel = (x - y).abs() / denom;
+        assert!(
+            rel <= rtol,
+            "{label}[{i}]: {x} vs {y}, rel_err={rel} > {rtol}"
+        );
+    }
+}
+
+#[test]
+fn test_silu_simd_scalar_parity() {
+    // Verify silu_inplace() (SIMD dispatch) matches silu_inplace_scalar()
+    // at hidden sizes representative of real model widths.
+    // Tolerance 1e-4 relative — silu uses fast_exp (Schraudolph) in NEON.
+    for &n in &[896usize, 2048, 4096] {
+        let mut x_simd = lcg_f32_vec(n, 0x5100_0001_u64 ^ (n as u64));
+        let mut x_scalar = x_simd.clone();
+
+        silu_inplace(&mut x_simd);
+        silu_inplace_scalar(&mut x_scalar);
+
+        assert_close(&x_simd, &x_scalar, 1e-4, &format!("silu_parity n={n}"));
+    }
+}
+
+#[test]
+fn test_gelu_simd_scalar_parity() {
+    // Verify gelu() (SIMD dispatch) matches gelu_scalar().
+    // Tolerance 1e-4 relative — NEON uses vdivq_f32 so error is only FMA order.
+    for &n in &[896usize, 2048, 4096] {
+        let mut x_simd = lcg_f32_vec(n, 0x9E10_0001_u64 ^ (n as u64));
+        let mut x_scalar = x_simd.clone();
+
+        gelu(&mut x_simd);
+        gelu_scalar(&mut x_scalar);
+
+        assert_close(&x_simd, &x_scalar, 1e-4, &format!("gelu_parity n={n}"));
+    }
+}
+
+#[test]
+fn test_rms_norm_simd_scalar_parity() {
+    // 8 tokens × three hidden sizes.  Tolerance 1e-5 relative —
+    // rms_norm uses ieee-accurate rsqrt so error is only sum-reduction order.
+    let rows = 8usize;
+    for &hidden in &[896usize, 2048, 4096] {
+        let mut x_simd = lcg_f32_vec(rows * hidden, 0xC0DE_0001_u64 ^ (hidden as u64));
+        let mut x_scalar = x_simd.clone();
+        let gamma = {
+            let raw = lcg_f32_vec(hidden, 0xC0DE_0002_u64 ^ (hidden as u64));
+            // Shift into [0.9, 1.1] for realistic scale factors.
+            raw.into_iter().map(|v| 1.0 + v * 5.0).collect::<Vec<_>>()
+        };
+        let eps = 1e-6_f32;
+
+        rms_norm(&mut x_simd, &gamma, hidden, eps);
+        rms_norm_scalar(&mut x_scalar, &gamma, hidden, eps);
+
+        assert_close(
+            &x_simd,
+            &x_scalar,
+            1e-5,
+            &format!("rms_norm_parity hidden={hidden}"),
+        );
+    }
+}
+
+#[test]
+fn test_layer_norm_simd_scalar_parity() {
+    // 8 tokens × three hidden sizes.  Tolerance 1e-5 relative.
+    let rows = 8usize;
+    for &hidden in &[896usize, 2048, 4096] {
+        let mut x_simd = lcg_f32_vec(rows * hidden, 0xF00D_0001_u64 ^ (hidden as u64));
+        let mut x_scalar = x_simd.clone();
+        let gamma = {
+            let raw = lcg_f32_vec(hidden, 0xF00D_0002_u64 ^ (hidden as u64));
+            raw.into_iter().map(|v| 1.0 + v * 5.0).collect::<Vec<_>>()
+        };
+        let beta = lcg_f32_vec(hidden, 0xF00D_0003_u64 ^ (hidden as u64));
+        let eps = 1e-12_f32;
+
+        layer_norm(&mut x_simd, &gamma, &beta, hidden, eps);
+        layer_norm_scalar(&mut x_scalar, &gamma, &beta, hidden, eps);
+
+        // layer_norm involves two horizontal reductions (mean + variance)
+        // whose NEON pairwise-summation order diverges from scalar sequential
+        // sum at large hidden sizes.  Near-zero output elements (gamma×z+beta≈0)
+        // can have large *relative* error from tiny absolute differences.
+        // We use a mixed criterion: |a-b| <= 1e-4*max(|a|,|b|) + 1e-5
+        // so near-zero outputs fall back to absolute tolerance (1e-5 >> f32 ULP).
+        assert_close_mixed(
+            &x_simd,
+            &x_scalar,
+            1e-4,
+            1e-5,
+            &format!("layer_norm_parity hidden={hidden}"),
+        );
+    }
+}
+
+#[test]
+fn test_softmax_simd_scalar_parity() {
+    // seq_len in {32, 64, 128} with 8 heads.
+    // Tolerance 1e-3 relative — fast_exp approximation introduces ~1-2% error
+    // per row; normalisation cancels systematic bias but relative error remains.
+    let num_heads = 8usize;
+    for &seq_len in &[32usize, 64, 128] {
+        let n = num_heads * seq_len * seq_len;
+        let mut x_simd = lcg_f32_vec(n, 0x50F7_0001_u64 ^ (seq_len as u64));
+        // Scale to realistic attention logit magnitudes [-2, 2].
+        for v in &mut x_simd {
+            *v *= 100.0;
+        }
+        let mut x_scalar = x_simd.clone();
+
+        softmax_attention(&mut x_simd, seq_len, num_heads);
+        softmax_attention_scalar(&mut x_scalar, seq_len, num_heads);
+
+        assert_close(
+            &x_simd,
+            &x_scalar,
+            1e-3,
+            &format!("softmax_parity seq_len={seq_len}"),
+        );
+
+        // Sanity: every row must still sum to 1.0.
+        for h in 0..num_heads {
+            for s in 0..seq_len {
+                let start = (h * seq_len + s) * seq_len;
+                let row_sum: f32 = x_simd[start..start + seq_len].iter().sum();
+                assert!(
+                    (row_sum - 1.0).abs() < 1e-3,
+                    "softmax_parity seq_len={seq_len} head={h} row={s}: sum={row_sum}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_elementwise_mul_simd_scalar_parity() {
+    // elementwise_mul is a single multiply per element — expect exact match
+    // (both paths issue the same FP operation, just via SIMD registers vs scalar).
+    // Using rtol=0 would be fragile across compilers; use 1e-7 for rounding
+    // differences between vmulq_f32 and scalar `*`.
+    for &n in &[896usize, 2048, 4096] {
+        let mut a_simd = lcg_f32_vec(n, 0xE1A1_0001_u64 ^ (n as u64));
+        let b = lcg_f32_vec(n, 0xE1A2_0001_u64 ^ (n as u64));
+        let mut a_scalar = a_simd.clone();
+
+        elementwise_mul(&mut a_simd, &b);
+        elementwise_mul_scalar(&mut a_scalar, &b);
+
+        assert_close(
+            &a_simd,
+            &a_scalar,
+            1e-7,
+            &format!("elementwise_mul_parity n={n}"),
+        );
+    }
+}
+
 /// Deterministic pseudo-random vector in a custom range.
 fn make_deterministic_vec_range(len: usize, seed: u32, lo: f32, hi: f32) -> Vec<f32> {
     let mut state = seed ^ (len as u32).wrapping_mul(0x9E37_79B9);

--- a/crates/inference/src/forward/cpu/tests.rs
+++ b/crates/inference/src/forward/cpu/tests.rs
@@ -333,6 +333,118 @@ fn make_deterministic_vec(len: usize, seed: u32) -> Vec<f32> {
     out
 }
 
+// ===================================================================
+// Elementwise SIMD vs. scalar comparison tests
+// ===================================================================
+
+#[test]
+fn test_rms_norm_known_values() {
+    // Single token, hidden=4, gamma=all-ones, eps=0.
+    // rms = sqrt(mean([1,2,3,4]^2)) = sqrt(7.5) ≈ 2.7386.
+    // Expected: [1/2.7386, 2/2.7386, 3/2.7386, 4/2.7386]
+    let mut x = vec![1.0f32, 2.0, 3.0, 4.0];
+    let gamma = vec![1.0f32; 4];
+    rms_norm(&mut x, &gamma, 4, 1e-8);
+    let expected_rms = (7.5f32 + 1e-8).sqrt();
+    for (i, &v) in x.iter().enumerate() {
+        let expected = (i + 1) as f32 / expected_rms;
+        assert_relative_eq!(v, expected, epsilon = 1e-5);
+    }
+}
+
+#[test]
+fn test_rms_norm_simd_matches_scalar() {
+    // Two sizes: one that exercises SIMD main loops, one with a remainder tail.
+    for &hidden in &[896usize, 2048, 4096, 13] {
+        let rows = 4;
+        let mut x_simd = make_deterministic_vec(rows * hidden, 0xC0DE);
+        let mut x_scalar = x_simd.clone();
+        let gamma = make_deterministic_vec_range(hidden, 0xC0DF, 0.9, 1.1);
+        let eps = 1e-6;
+
+        rms_norm(&mut x_simd, &gamma, hidden, eps);
+        rms_norm_scalar(&mut x_scalar, &gamma, hidden, eps);
+
+        for i in 0..(rows * hidden) {
+            let diff = (x_simd[i] - x_scalar[i]).abs();
+            assert!(
+                diff <= 1e-4,
+                "rms_norm mismatch at hidden={hidden} index={i}: simd={} scalar={} diff={diff}",
+                x_simd[i],
+                x_scalar[i],
+            );
+        }
+    }
+}
+
+#[test]
+fn test_silu_known_values() {
+    // silu(0) = 0 * 0.5 = 0.
+    // silu(1) = 1 * sigmoid(1) ≈ 0.7311.
+    // silu(-1) = -1 * sigmoid(-1) ≈ -0.2689.
+    let mut x = vec![0.0f32, 1.0, -1.0];
+    silu_inplace(&mut x);
+    assert_relative_eq!(x[0], 0.0, epsilon = 1e-5);
+    // Use a loose tolerance because we use fast_exp (Schraudolph) in SIMD paths.
+    assert_relative_eq!(x[1], 0.731_059_f32, epsilon = 5e-2);
+    assert_relative_eq!(x[2], -0.268_941_f32, epsilon = 5e-2);
+}
+
+#[test]
+fn test_silu_simd_matches_scalar() {
+    for &n in &[896usize, 2048, 4096, 17] {
+        let mut x_simd = make_deterministic_vec(n, 0x51C0);
+        let mut x_scalar = x_simd.clone();
+
+        silu_inplace(&mut x_simd);
+        silu_inplace_scalar(&mut x_scalar);
+
+        for i in 0..n {
+            let diff = (x_simd[i] - x_scalar[i]).abs();
+            assert!(
+                diff <= 5e-2,
+                "silu mismatch at n={n} index={i}: simd={} scalar={} diff={diff}",
+                x_simd[i],
+                x_scalar[i],
+            );
+        }
+    }
+}
+
+#[test]
+fn test_elementwise_mul_known_values() {
+    let mut a = vec![2.0f32, 3.0, -1.0, 0.0];
+    let b = vec![4.0f32, -2.0, 5.0, 7.0];
+    elementwise_mul(&mut a, &b);
+    assert_relative_eq!(a[0], 8.0, epsilon = 1e-6);
+    assert_relative_eq!(a[1], -6.0, epsilon = 1e-6);
+    assert_relative_eq!(a[2], -5.0, epsilon = 1e-6);
+    assert_relative_eq!(a[3], 0.0, epsilon = 1e-6);
+}
+
+#[test]
+fn test_elementwise_mul_simd_matches_scalar() {
+    for &n in &[896usize, 2048, 4096, 11] {
+        let mut a_simd = make_deterministic_vec(n, 0xE1A1);
+        let b = make_deterministic_vec(n, 0xE1A2);
+        let mut a_scalar = a_simd.clone();
+
+        elementwise_mul(&mut a_simd, &b);
+        elementwise_mul_scalar(&mut a_scalar, &b);
+
+        for i in 0..n {
+            // elementwise_mul is exact (single multiply), tolerance is floating-point rounding.
+            let diff = (a_simd[i] - a_scalar[i]).abs();
+            assert!(
+                diff <= 1e-6,
+                "elementwise_mul mismatch at n={n} index={i}: simd={} scalar={} diff={diff}",
+                a_simd[i],
+                a_scalar[i],
+            );
+        }
+    }
+}
+
 /// Deterministic pseudo-random vector in a custom range.
 fn make_deterministic_vec_range(len: usize, seed: u32, lo: f32, hi: f32) -> Vec<f32> {
     let mut state = seed ^ (len as u32).wrapping_mul(0x9E37_79B9);

--- a/crates/inference/src/forward/cpu/tiled_neon.rs
+++ b/crates/inference/src/forward/cpu/tiled_neon.rs
@@ -84,6 +84,31 @@ pub(super) unsafe fn matmul_bt_tiled_neon(
                     for kp in 0..k_pairs {
                         let ko = k_start + kp * 8;
 
+                        // Prefetch the next k-chunk's B-rows into L1 cache while
+                        // the current chunk is being processed by the FMA units.
+                        if kp + 1 < k_pairs {
+                            let next_ko = ko + 8;
+                            core::arch::asm!(
+                                "prfm pldl1keep, [{0}]",
+                                "prfm pldl1keep, [{1}]",
+                                "prfm pldl1keep, [{2}]",
+                                "prfm pldl1keep, [{3}]",
+                                "prfm pldl1keep, [{4}]",
+                                "prfm pldl1keep, [{5}]",
+                                "prfm pldl1keep, [{6}]",
+                                "prfm pldl1keep, [{7}]",
+                                in(reg) b0_base.add(next_ko),
+                                in(reg) b1_base.add(next_ko),
+                                in(reg) b2_base.add(next_ko),
+                                in(reg) b3_base.add(next_ko),
+                                in(reg) b4_base.add(next_ko),
+                                in(reg) b5_base.add(next_ko),
+                                in(reg) b6_base.add(next_ko),
+                                in(reg) b7_base.add(next_ko),
+                                options(nostack, preserves_flags, readonly),
+                            );
+                        }
+
                         // --- First group of 4 k-values ---
                         let bv0a = vld1q_f32(b0_base.add(ko));
                         let bv1a = vld1q_f32(b1_base.add(ko));
@@ -273,18 +298,28 @@ pub(super) unsafe fn matmul_bt_tiled_neon(
                     }
                 } else {
                     // Edge tiles: partial I or J count, or k_len < 8.
-                    // Use scalar accumulation for correctness at tile boundaries.
+                    // Still use NEON for the dot product along k where possible.
                     for ii in 0..i_count {
                         let i = i_start + ii;
+                        let a_base = a_ptr.add(i * k + k_start);
                         for jj in 0..j_count {
                             let j = j_start + jj;
-                            let mut sum = 0.0f32;
-                            for p in k_start..k_end {
-                                // SAFETY: i < m, p < k so i*k+p < m*k = a.len().
-                                // j < n, p < k so j*k+p < n*k = b.len().
-                                sum += *a_ptr.add(i * k + p) * *b_ptr.add(j * k + p);
+                            let b_base = b_ptr.add(j * k + k_start);
+                            let kl = k_end - k_start;
+
+                            let mut acc = vdupq_n_f32(0.0);
+                            let k_vec = kl / 4;
+                            for kk in 0..k_vec {
+                                let off = kk * 4;
+                                let av = vld1q_f32(a_base.add(off));
+                                let bv = vld1q_f32(b_base.add(off));
+                                acc = vfmaq_f32(acc, av, bv);
                             }
-                            // SAFETY: i < m, j < n so i*n+j < m*n = c.len().
+                            let mut sum = vaddvq_f32(acc);
+
+                            for p in (k_vec * 4)..kl {
+                                sum += *a_base.add(p) * *b_base.add(p);
+                            }
                             *c_ptr.add(i * n + j) += sum;
                         }
                     }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -805,6 +805,19 @@ kernel void silu_mul(
     gate[gid] = s * up[gid];
 }
 
+// Dense decode fused gate||up kernel: first half = gate, second half = up.
+kernel void silu_mul_fused(
+    device float* data    [[buffer(0)]],
+    constant uint& count  [[buffer(2)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= count) return;
+    float gate = data[gid];
+    float up   = data[gid + count];
+    float s    = gate / (1.0f + exp(-gate));
+    data[gid]  = s * up;
+}
+
 // ===== Copy: dst = src =====
 kernel void copy_buf(
     device const float* src [[buffer(0)]],
@@ -2544,9 +2557,8 @@ kernel void moe_shared_gate_add(
     /// Per-layer FFN weights on GPU: either dense SwiGLU or MoE.
     enum MetalFfnWeights {
         Dense {
-            gate_proj: Q4WeightBuf, // [intermediate, hidden] — Q4/Q8
-            up_proj: Q4WeightBuf,   // [intermediate, hidden] — Q4/Q8
-            down_proj: Q4WeightBuf, // [hidden, intermediate] — Q4/Q8
+            gate_up_proj: Q4WeightBuf, // [2 * intermediate, hidden] — gate || up, Q4/Q8
+            down_proj: Q4WeightBuf,    // [hidden, intermediate] — Q4/Q8
         },
         Moe(Box<MoeMetalBuffers>),
     }
@@ -2748,9 +2760,9 @@ kernel void moe_shared_gate_add(
         gate_z: Buffer,      // [q_dim] gate after scatter
         k: Buffer,           // [kv_dim]
         v: Buffer,           // [kv_dim]
-        gate: Buffer,        // [intermediate_size]
-        up: Buffer,          // [intermediate_size]
-        ffn_out: Buffer,     // [hidden_size]
+        gate: Buffer, // [2 * intermediate_size] for Dense decode gate||up; batch uses first bp rows
+        up: Buffer,   // [intermediate_size] kept for batch separate-buffer paths
+        ffn_out: Buffer, // [hidden_size]
         // GDN projection buffers
         gdn_qkv: Buffer,         // [qkv_dim]  — used by batch/prefill and CPU paths
         gdn_z: Buffer,           // [output_dim] — used by batch/prefill and CPU paths
@@ -2793,6 +2805,7 @@ kernel void moe_shared_gate_add(
         sigmoid_gate: ComputePipelineState,
         scatter_q_gate: ComputePipelineState,
         silu_mul: ComputePipelineState,
+        silu_mul_fused: ComputePipelineState,
         copy: ComputePipelineState,
         copy_offset: ComputePipelineState,
         add: ComputePipelineState,
@@ -3611,6 +3624,7 @@ kernel void moe_shared_gate_add(
                 sigmoid_gate: make_pipeline("sigmoid_gate")?,
                 scatter_q_gate: make_pipeline("scatter_q_gate")?,
                 silu_mul: make_pipeline("silu_mul")?,
+                silu_mul_fused: make_pipeline("silu_mul_fused")?,
                 copy: make_pipeline("copy_buf")?,
                 copy_offset: make_pipeline("copy_buf_offset")?,
                 add: make_pipeline("add_buf")?,
@@ -3659,6 +3673,44 @@ kernel void moe_shared_gate_add(
                 QuantFormat::Q8_0 => "q8",
                 QuantFormat::Q4_0 => "q4",
             };
+            let block_bytes = match quant_format {
+                QuantFormat::Q8_0 => Q8_0_BLOCK_SIZE,
+                QuantFormat::Q4_0 => Q4_0_BLOCK_SIZE,
+            };
+            let pack_quant = |data: &[f32]| -> Vec<u8> {
+                match quant_format {
+                    QuantFormat::Q8_0 => {
+                        assert_eq!(data.len() % QK8_0, 0);
+                        quantize_row_q8_0(data)
+                    }
+                    QuantFormat::Q4_0 => {
+                        assert_eq!(
+                            data.len() % QK4_0,
+                            0,
+                            "pack_quant: data length {} not divisible by {QK4_0}",
+                            data.len()
+                        );
+                        quantize_row_q4_0(data)
+                    }
+                }
+            };
+            let make_fused_quant_buffer =
+                |device: &Device, gate_bytes: &[u8], up_bytes: &[u8], label: &str| -> Buffer {
+                    let combined_size = gate_bytes.len() + up_bytes.len();
+                    let buf = device
+                        .new_buffer(combined_size as u64, MTLResourceOptions::StorageModeShared);
+                    unsafe {
+                        let dst = buf.contents() as *mut u8;
+                        std::ptr::copy_nonoverlapping(gate_bytes.as_ptr(), dst, gate_bytes.len());
+                        std::ptr::copy_nonoverlapping(
+                            up_bytes.as_ptr(),
+                            dst.add(gate_bytes.len()),
+                            up_bytes.len(),
+                        );
+                    }
+                    buf.set_label(label);
+                    buf
+                };
             let make_buffer_quant = |device: &Device, data: &[f32], label: &str| -> Buffer {
                 match quant_format {
                     QuantFormat::Q8_0 => make_buffer_q8_0(device, data, label),
@@ -3670,23 +3722,33 @@ kernel void moe_shared_gate_add(
             for (i, (attn_w, common_w)) in weights.layers.iter().enumerate() {
                 // Build the FFN weight variant for this layer (Dense or MoE).
                 let metal_ffn = match &common_w.ffn {
-                    crate::model::qwen35::FeedForwardWeights::Dense(d) => MetalFfnWeights::Dense {
-                        gate_proj: Q4WeightBuf::from_buffer(make_buffer_quant(
-                            &device,
-                            &d.gate_proj,
-                            &format!("L{i}.gate.{quant_tag}"),
-                        )),
-                        up_proj: Q4WeightBuf::from_buffer(make_buffer_quant(
-                            &device,
-                            &d.up_proj,
-                            &format!("L{i}.up.{quant_tag}"),
-                        )),
-                        down_proj: Q4WeightBuf::from_buffer(make_buffer_quant(
-                            &device,
-                            &d.down_proj,
-                            &format!("L{i}.down.{quant_tag}"),
-                        )),
-                    },
+                    crate::model::qwen35::FeedForwardWeights::Dense(d) => {
+                        let gate_bytes = pack_quant(&d.gate_proj);
+                        let up_bytes = pack_quant(&d.up_proj);
+                        debug_assert_eq!(
+                            d.gate_proj.len(),
+                            cfg.intermediate_size * cfg.hidden_size
+                        );
+                        debug_assert_eq!(d.up_proj.len(), cfg.intermediate_size * cfg.hidden_size);
+                        debug_assert_eq!(
+                            gate_bytes.len(),
+                            cfg.intermediate_size * (cfg.hidden_size / 32) * block_bytes
+                        );
+                        debug_assert_eq!(up_bytes.len(), gate_bytes.len());
+                        MetalFfnWeights::Dense {
+                            gate_up_proj: Q4WeightBuf::from_buffer(make_fused_quant_buffer(
+                                &device,
+                                &gate_bytes,
+                                &up_bytes,
+                                &format!("L{i}.gate_up.{quant_tag}"),
+                            )),
+                            down_proj: Q4WeightBuf::from_buffer(make_buffer_quant(
+                                &device,
+                                &d.down_proj,
+                                &format!("L{i}.down.{quant_tag}"),
+                            )),
+                        }
+                    }
                     crate::model::qwen35::FeedForwardWeights::Moe(m) => {
                         let num_exp = m.experts.num_experts;
                         let inter = m.experts.intermediate_size;
@@ -3966,7 +4028,7 @@ kernel void moe_shared_gate_add(
                 gate_z: make_zero_buffer(device, bp * q_dim, "act_gate_z"),
                 k: make_zero_buffer(device, bp * kv_dim, "act_k"),
                 v: make_zero_buffer(device, bp * kv_dim, "act_v"),
-                gate: make_zero_buffer(device, bp * inter, "act_gate"),
+                gate: make_zero_buffer(device, bp * 2 * inter, "act_gate"),
                 up: make_zero_buffer(device, bp * inter, "act_up"),
                 ffn_out: make_zero_buffer(device, bp * hidden, "act_ffn_out"),
                 gdn_qkv: make_zero_buffer(device, bp * qkv_dim, "act_gdn_qkv"),
@@ -4723,16 +4785,25 @@ kernel void moe_shared_gate_add(
                 let (_, common_w) = &self.engine.layer_weights[compact_idx];
                 let w_in_norm = &common_w.input_layernorm as *const Buffer;
                 let w_post_norm = &common_w.post_attention_layernorm as *const Buffer;
-                let (w_gate, w_up, w_down) = match &common_w.ffn {
+                let (w_gate_up, w_down, gate_byte_size) = match &common_w.ffn {
                     MetalFfnWeights::Dense {
-                        gate_proj,
-                        up_proj,
+                        gate_up_proj,
                         down_proj,
-                    } => (
-                        gate_proj as *const Q4WeightBuf,
-                        up_proj as *const Q4WeightBuf,
-                        down_proj as *const Q4WeightBuf,
-                    ),
+                    } => {
+                        let byte_size: u64 = match self.engine.quant_format {
+                            QuantFormat::Q8_0 => {
+                                (inter * (hidden / QK8_0) * Q8_0_BLOCK_SIZE) as u64
+                            }
+                            QuantFormat::Q4_0 => {
+                                (inter * (hidden / QK4_0) * Q4_0_BLOCK_SIZE) as u64
+                            }
+                        };
+                        (
+                            gate_up_proj as *const Q4WeightBuf,
+                            down_proj as *const Q4WeightBuf,
+                            byte_size,
+                        )
+                    }
                     MetalFfnWeights::Moe(_) => {
                         panic!(
                             "verify_tokens_batch_gemm: MoE layers are not supported in batch \
@@ -4888,7 +4959,7 @@ kernel void moe_shared_gate_add(
                     }
 
                     // Batch: out_proj + residual + post-norm + MLP.
-                    // SAFETY: w_out, w_gate, w_up, w_down are live layer-owned buffers.
+                    // SAFETY: w_out, w_gate_up, w_down are live layer-owned buffers.
                     unsafe {
                         self.dispatch_gemm(
                             enc,
@@ -4923,22 +4994,24 @@ kernel void moe_shared_gate_add(
                             m,
                             cfg.rms_norm_eps,
                         );
-                        self.dispatch_gemm(
+                        self.dispatch_gemm_at(
                             enc,
                             &self.session.activations.hidden,
                             0,
-                            &*w_gate,
+                            &*w_gate_up,
+                            0,
                             &self.session.activations.gate,
                             0,
                             m,
                             inter as u32,
                             hidden as u32,
                         );
-                        self.dispatch_gemm(
+                        self.dispatch_gemm_at(
                             enc,
                             &self.session.activations.hidden,
                             0,
-                            &*w_up,
+                            &*w_gate_up,
+                            gate_byte_size,
                             &self.session.activations.up,
                             0,
                             m,
@@ -5181,7 +5254,7 @@ kernel void moe_shared_gate_add(
                     }
 
                     // Batch: O projection + residual + post-norm + MLP.
-                    // SAFETY: w_o, w_gate, w_up, w_down are live layer-owned buffers.
+                    // SAFETY: w_o, w_gate_up, w_down are live layer-owned buffers.
                     unsafe {
                         self.dispatch_gemm(
                             enc,
@@ -5216,22 +5289,24 @@ kernel void moe_shared_gate_add(
                             m,
                             cfg.rms_norm_eps,
                         );
-                        self.dispatch_gemm(
+                        self.dispatch_gemm_at(
                             enc,
                             &self.session.activations.hidden,
                             0,
-                            &*w_gate,
+                            &*w_gate_up,
+                            0,
                             &self.session.activations.gate,
                             0,
                             m,
                             inter as u32,
                             hidden as u32,
                         );
-                        self.dispatch_gemm(
+                        self.dispatch_gemm_at(
                             enc,
                             &self.session.activations.hidden,
                             0,
-                            &*w_up,
+                            &*w_gate_up,
+                            gate_byte_size,
                             &self.session.activations.up,
                             0,
                             m,
@@ -6183,16 +6258,25 @@ kernel void moe_shared_gate_add(
                 let (_, common_w) = &self.engine.layer_weights[compact_idx];
                 let w_in_norm = &common_w.input_layernorm as *const Buffer;
                 let w_post_norm = &common_w.post_attention_layernorm as *const Buffer;
-                let (w_gate, w_up, w_down) = match &common_w.ffn {
+                let (w_gate_up, w_down, gate_byte_size) = match &common_w.ffn {
                     MetalFfnWeights::Dense {
-                        gate_proj,
-                        up_proj,
+                        gate_up_proj,
                         down_proj,
-                    } => (
-                        gate_proj as *const Q4WeightBuf,
-                        up_proj as *const Q4WeightBuf,
-                        down_proj as *const Q4WeightBuf,
-                    ),
+                    } => {
+                        let byte_size: u64 = match self.engine.quant_format {
+                            QuantFormat::Q8_0 => {
+                                (inter * (hidden / QK8_0) * Q8_0_BLOCK_SIZE) as u64
+                            }
+                            QuantFormat::Q4_0 => {
+                                (inter * (hidden / QK4_0) * Q4_0_BLOCK_SIZE) as u64
+                            }
+                        };
+                        (
+                            gate_up_proj as *const Q4WeightBuf,
+                            down_proj as *const Q4WeightBuf,
+                            byte_size,
+                        )
+                    }
                     MetalFfnWeights::Moe(_) => {
                         panic!(
                             "forward_prefill batch GEMM: MoE layers are not supported in batch \
@@ -6400,25 +6484,27 @@ kernel void moe_shared_gate_add(
                     }
 
                     // Batch: MLP (gate + up + silu_mul + down)
-                    // SAFETY: Gate/up pointers are live layer-owned buffers; GEMM
+                    // SAFETY: Gate_up/down pointers are live layer-owned buffers; GEMM
                     // dimensions match [m, hidden] by [inter, hidden].
                     unsafe {
-                        self.dispatch_gemm(
+                        self.dispatch_gemm_at(
                             enc,
                             &self.session.activations.hidden,
                             0,
-                            &*w_gate,
+                            &*w_gate_up,
+                            0,
                             &self.session.activations.gate,
                             0,
                             m,
                             inter as u32,
                             hidden as u32,
                         );
-                        self.dispatch_gemm(
+                        self.dispatch_gemm_at(
                             enc,
                             &self.session.activations.hidden,
                             0,
-                            &*w_up,
+                            &*w_gate_up,
+                            gate_byte_size,
                             &self.session.activations.up,
                             0,
                             m,
@@ -6730,25 +6816,27 @@ kernel void moe_shared_gate_add(
                     }
 
                     // Batch: MLP
-                    // SAFETY: Gate/up pointers are live layer-owned buffers; GEMM
+                    // SAFETY: Gate_up/down pointers are live layer-owned buffers; GEMM
                     // dimensions match [m, hidden] by [inter, hidden].
                     unsafe {
-                        self.dispatch_gemm(
+                        self.dispatch_gemm_at(
                             enc,
                             &self.session.activations.hidden,
                             0,
-                            &*w_gate,
+                            &*w_gate_up,
+                            0,
                             &self.session.activations.gate,
                             0,
                             m,
                             inter as u32,
                             hidden as u32,
                         );
-                        self.dispatch_gemm(
+                        self.dispatch_gemm_at(
                             enc,
                             &self.session.activations.hidden,
                             0,
-                            &*w_up,
+                            &*w_gate_up,
+                            gate_byte_size,
                             &self.session.activations.up,
                             0,
                             m,
@@ -8653,24 +8741,24 @@ kernel void moe_shared_gate_add(
             // SAFETY: FFN weight buffers are live for the command buffer lifetime.
             match &common_w.ffn {
                 MetalFfnWeights::Dense {
-                    gate_proj,
-                    up_proj,
+                    gate_up_proj,
                     down_proj,
                 } => {
-                    let w_gate = gate_proj as *const Q4WeightBuf;
-                    let w_up = up_proj as *const Q4WeightBuf;
+                    let w_gate_up = gate_up_proj as *const Q4WeightBuf;
                     let w_down = down_proj as *const Q4WeightBuf;
+                    // Single fused GEMV: hidden × gate_up_proj[2*inter, hidden] → gate[0..2*inter]
                     unsafe {
                         self.dispatch_matmul(
                             enc,
                             &self.session.activations.hidden,
-                            &*w_gate,
+                            &*w_gate_up,
                             &self.session.activations.gate,
                             1,
-                            inter as u32,
+                            (2 * inter) as u32,
                             hidden as u32,
                         );
                     }
+                    // LoRA: gate half at offset 0, up half at offset inter*sizeof(f32)
                     self.dispatch_lora_if_active(
                         enc,
                         &self.session.activations.hidden,
@@ -8680,27 +8768,17 @@ kernel void moe_shared_gate_add(
                         layer_idx,
                         "gate_proj",
                     );
-                    unsafe {
-                        self.dispatch_matmul(
-                            enc,
-                            &self.session.activations.hidden,
-                            &*w_up,
-                            &self.session.activations.up,
-                            1,
-                            inter as u32,
-                            hidden as u32,
-                        );
-                    }
                     self.dispatch_lora_if_active(
                         enc,
                         &self.session.activations.hidden,
                         0,
-                        &self.session.activations.up,
-                        0,
+                        &self.session.activations.gate,
+                        (inter * std::mem::size_of::<f32>()) as u64,
                         layer_idx,
                         "up_proj",
                     );
-                    self.dispatch_silu_mul(enc, inter as u32);
+                    // silu_mul_fused: gate[0..inter] = silu(gate[0..inter]) * gate[inter..2*inter]
+                    self.dispatch_silu_mul_fused(enc, &self.session.activations.gate, inter as u32);
                     unsafe {
                         self.dispatch_matmul(
                             enc,
@@ -8992,24 +9070,24 @@ kernel void moe_shared_gate_add(
             // SAFETY: FFN weight buffers are live for the command buffer lifetime.
             match &common_w.ffn {
                 MetalFfnWeights::Dense {
-                    gate_proj,
-                    up_proj,
+                    gate_up_proj,
                     down_proj,
                 } => {
-                    let w_gate = gate_proj as *const Q4WeightBuf;
-                    let w_up = up_proj as *const Q4WeightBuf;
+                    let w_gate_up = gate_up_proj as *const Q4WeightBuf;
                     let w_down = down_proj as *const Q4WeightBuf;
+                    // Single fused GEMV: hidden × gate_up_proj[2*inter, hidden] → gate[0..2*inter]
                     unsafe {
                         self.dispatch_matmul(
                             enc,
                             &self.session.activations.hidden,
-                            &*w_gate,
+                            &*w_gate_up,
                             &self.session.activations.gate,
                             1,
-                            inter as u32,
+                            (2 * inter) as u32,
                             hidden as u32,
                         );
                     }
+                    // LoRA: gate half at offset 0, up half at offset inter*sizeof(f32)
                     self.dispatch_lora_if_active(
                         enc,
                         &self.session.activations.hidden,
@@ -9019,27 +9097,17 @@ kernel void moe_shared_gate_add(
                         layer_idx,
                         "gate_proj",
                     );
-                    unsafe {
-                        self.dispatch_matmul(
-                            enc,
-                            &self.session.activations.hidden,
-                            &*w_up,
-                            &self.session.activations.up,
-                            1,
-                            inter as u32,
-                            hidden as u32,
-                        );
-                    }
                     self.dispatch_lora_if_active(
                         enc,
                         &self.session.activations.hidden,
                         0,
-                        &self.session.activations.up,
-                        0,
+                        &self.session.activations.gate,
+                        (inter * std::mem::size_of::<f32>()) as u64,
                         layer_idx,
                         "up_proj",
                     );
-                    self.dispatch_silu_mul(enc, inter as u32);
+                    // silu_mul_fused: gate[0..inter] = silu(gate[0..inter]) * gate[inter..2*inter]
+                    self.dispatch_silu_mul_fused(enc, &self.session.activations.gate, inter as u32);
                     unsafe {
                         self.dispatch_matmul(
                             enc,
@@ -9873,6 +9941,166 @@ kernel void moe_shared_gate_add(
                 MTLSize::new(div_ceil(count as u64, wg) * wg, 1, 1),
                 MTLSize::new(wg, 1, 1),
             );
+        }
+
+        // Dense decode fused: data[0..count] = silu(data[0..count]) * data[count..2*count]
+        fn dispatch_silu_mul_fused(
+            &self,
+            enc: &ComputeCommandEncoderRef,
+            data: &Buffer,
+            count: u32,
+        ) {
+            enc.set_compute_pipeline_state(&self.engine.pipelines.silu_mul_fused);
+            enc.set_buffer(0, Some(data), 0);
+            enc.set_bytes(2, 4, &count as *const u32 as *const _);
+            let wg = 256u64;
+            enc.dispatch_threads(
+                MTLSize::new(div_ceil(count as u64, wg) * wg, 1, 1),
+                MTLSize::new(wg, 1, 1),
+            );
+        }
+
+        // Variant of dispatch_gemm that adds qw_extra_offset bytes to the weight buffer binding.
+        // Used by batch Dense paths to access gate (offset=0) or up (offset=gate_byte_size)
+        // within the fused gate_up_proj buffer without modifying the MSL kernels.
+        fn dispatch_gemm_at(
+            &self,
+            enc: &ComputeCommandEncoderRef,
+            x: &Buffer,
+            x_offset: u64,
+            qw: &Q4WeightBuf,
+            qw_extra_offset: u64,
+            y: &Buffer,
+            y_offset: u64,
+            m: u32,
+            n: u32,
+            k: u32,
+        ) {
+            match self.engine.quant_format {
+                QuantFormat::Q8_0 => self.dispatch_gemm_q8_at(
+                    enc,
+                    x,
+                    x_offset,
+                    qw,
+                    qw_extra_offset,
+                    y,
+                    y_offset,
+                    m,
+                    n,
+                    k,
+                ),
+                QuantFormat::Q4_0 => self.dispatch_gemm_q4_at(
+                    enc,
+                    x,
+                    x_offset,
+                    qw,
+                    qw_extra_offset,
+                    y,
+                    y_offset,
+                    m,
+                    n,
+                    k,
+                ),
+            }
+        }
+
+        fn dispatch_gemm_q8_at(
+            &self,
+            enc: &ComputeCommandEncoderRef,
+            x: &Buffer,
+            x_offset: u64,
+            qw: &Q4WeightBuf,
+            qw_extra_offset: u64,
+            y: &Buffer,
+            y_offset: u64,
+            m: u32,
+            n: u32,
+            k: u32,
+        ) {
+            let wq_offset = qw.payload_offset + qw_extra_offset;
+            if m <= 1 {
+                enc.set_compute_pipeline_state(&self.engine.pipelines.gemv_q8);
+                enc.set_buffer(0, Some(x), x_offset);
+                enc.set_buffer(1, Some(&qw.buffer), wq_offset);
+                enc.set_buffer(2, Some(y), y_offset);
+                enc.set_bytes(3, 4, &n as *const u32 as *const _);
+                enc.set_bytes(4, 4, &k as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(n.div_ceil(2) as u64, 1, 1),
+                    MTLSize::new(32, 4, 1),
+                );
+            } else {
+                enc.set_compute_pipeline_state(&self.engine.pipelines.gemm_q8);
+                enc.set_buffer(0, Some(x), x_offset);
+                enc.set_buffer(1, Some(&qw.buffer), wq_offset);
+                enc.set_buffer(2, Some(y), y_offset);
+                enc.set_bytes(3, 4, &m as *const u32 as *const _);
+                enc.set_bytes(4, 4, &n as *const u32 as *const _);
+                enc.set_bytes(5, 4, &k as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(n.div_ceil(2) as u64, m.div_ceil(4) as u64, 1),
+                    MTLSize::new(32, 4, 1),
+                );
+            }
+        }
+
+        fn dispatch_gemm_q4_at(
+            &self,
+            enc: &ComputeCommandEncoderRef,
+            x: &Buffer,
+            x_offset: u64,
+            qw: &Q4WeightBuf,
+            qw_extra_offset: u64,
+            y: &Buffer,
+            y_offset: u64,
+            m: u32,
+            n: u32,
+            k: u32,
+        ) {
+            if m == 0 || n == 0 {
+                return;
+            }
+            assert!(
+                k > 0 && k % 32 == 0,
+                "dispatch_gemm_q4_at requires K to be non-zero and divisible by 32, got {k}"
+            );
+            let wq_offset = qw.payload_offset + qw_extra_offset;
+            if m == 1 {
+                enc.set_compute_pipeline_state(&self.engine.pipelines.gemv_q4);
+                enc.set_buffer(0, Some(x), x_offset);
+                enc.set_buffer(1, Some(&qw.buffer), wq_offset);
+                enc.set_buffer(2, Some(y), y_offset);
+                enc.set_bytes(3, 4, &n as *const u32 as *const _);
+                enc.set_bytes(4, 4, &k as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(n.div_ceil(2) as u64, 1, 1),
+                    MTLSize::new(32, 4, 1),
+                );
+            } else if let Some(tiled) = self.engine.pipelines.gemm_q4_tiled.as_ref() {
+                enc.set_compute_pipeline_state(tiled);
+                enc.set_buffer(0, Some(&qw.buffer), wq_offset);
+                enc.set_buffer(1, Some(x), x_offset);
+                enc.set_buffer(2, Some(y), y_offset);
+                enc.set_bytes(3, 4, &m as *const u32 as *const _);
+                enc.set_bytes(4, 4, &n as *const u32 as *const _);
+                enc.set_bytes(5, 4, &k as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(n.div_ceil(32) as u64, m.div_ceil(64) as u64, 1),
+                    MTLSize::new(32, 4, 1),
+                );
+            } else {
+                enc.set_compute_pipeline_state(&self.engine.pipelines.gemm_q4);
+                enc.set_buffer(0, Some(&qw.buffer), wq_offset);
+                enc.set_buffer(1, Some(x), x_offset);
+                enc.set_buffer(2, Some(y), y_offset);
+                enc.set_bytes(3, 4, &m as *const u32 as *const _);
+                enc.set_bytes(4, 4, &n as *const u32 as *const _);
+                enc.set_bytes(5, 4, &k as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(n.div_ceil(2) as u64, m.div_ceil(4) as u64, 1),
+                    MTLSize::new(32, 4, 1),
+                );
+            }
         }
 
         fn dispatch_copy(
@@ -11041,6 +11269,7 @@ kernel void moe_shared_gate_add(
                 sigmoid_gate: make_pipeline("sigmoid_gate")?,
                 scatter_q_gate: make_pipeline("scatter_q_gate")?,
                 silu_mul: make_pipeline("silu_mul")?,
+                silu_mul_fused: make_pipeline("silu_mul_fused")?,
                 copy: make_pipeline("copy_buf")?,
                 copy_offset: make_pipeline("copy_buf_offset")?,
                 add: make_pipeline("add_buf")?,
@@ -11109,6 +11338,29 @@ kernel void moe_shared_gate_add(
                 let result = mmap_q4_weight(&device, &path, label);
                 dur_c_cell.set(dur_c_cell.get() + t.elapsed());
                 result
+            };
+            let load_q4_raw_timed = |name: &str| -> Result<(Vec<u8>, usize), String> {
+                let t = std::time::Instant::now();
+                let path = Self::q4_tensor_path(q4_dir, name, "q4");
+                let result = Self::load_q4_raw_bytes(&path);
+                dur_c_cell.set(dur_c_cell.get() + t.elapsed());
+                result
+            };
+            let make_fused_q4_buf = |gate_raw: &[u8], up_raw: &[u8], label: &str| -> Q4WeightBuf {
+                let combined_size = gate_raw.len() + up_raw.len();
+                let buf =
+                    device.new_buffer(combined_size as u64, MTLResourceOptions::StorageModeShared);
+                unsafe {
+                    let dst = buf.contents() as *mut u8;
+                    std::ptr::copy_nonoverlapping(gate_raw.as_ptr(), dst, gate_raw.len());
+                    std::ptr::copy_nonoverlapping(
+                        up_raw.as_ptr(),
+                        dst.add(gate_raw.len()),
+                        up_raw.len(),
+                    );
+                }
+                buf.set_label(label);
+                Q4WeightBuf::from_buffer(buf)
             };
 
             // ----------------------------------------------------------------
@@ -11204,19 +11456,25 @@ kernel void moe_shared_gate_add(
                         &format!("{prefix}.post_attention_layernorm.weight"),
                         &format!("L{i}.post_norm"),
                     )?,
-                    ffn: MetalFfnWeights::Dense {
-                        gate_proj: load_q4_buf(
-                            &format!("{prefix}.mlp.gate_proj.weight"),
-                            &format!("L{i}.gate.q4"),
-                        )?,
-                        up_proj: load_q4_buf(
-                            &format!("{prefix}.mlp.up_proj.weight"),
-                            &format!("L{i}.up.q4"),
-                        )?,
-                        down_proj: load_q4_buf(
-                            &format!("{prefix}.mlp.down_proj.weight"),
-                            &format!("L{i}.down.q4"),
-                        )?,
+                    ffn: {
+                        let (gate_raw, gate_len) =
+                            load_q4_raw_timed(&format!("{prefix}.mlp.gate_proj.weight"))?;
+                        let (up_raw, up_len) =
+                            load_q4_raw_timed(&format!("{prefix}.mlp.up_proj.weight"))?;
+                        debug_assert_eq!(gate_len, cfg.intermediate_size * cfg.hidden_size);
+                        debug_assert_eq!(up_len, cfg.intermediate_size * cfg.hidden_size);
+                        debug_assert_eq!(up_raw.len(), gate_raw.len());
+                        MetalFfnWeights::Dense {
+                            gate_up_proj: make_fused_q4_buf(
+                                &gate_raw,
+                                &up_raw,
+                                &format!("L{i}.gate_up.q4"),
+                            ),
+                            down_proj: load_q4_buf(
+                                &format!("{prefix}.mlp.down_proj.weight"),
+                                &format!("L{i}.down.q4"),
+                            )?,
+                        }
                     },
                 };
 
@@ -11407,7 +11665,7 @@ kernel void moe_shared_gate_add(
                 gate_z: make_zero_buffer(&device, bp * q_dim, "act_gate_z"),
                 k: make_zero_buffer(&device, bp * kv_dim, "act_k"),
                 v: make_zero_buffer(&device, bp * kv_dim, "act_v"),
-                gate: make_zero_buffer(&device, bp * inter, "act_gate"),
+                gate: make_zero_buffer(&device, bp * 2 * inter, "act_gate"),
                 up: make_zero_buffer(&device, bp * inter, "act_up"),
                 ffn_out: make_zero_buffer(&device, bp * hidden, "act_ffn_out"),
                 gdn_qkv: make_zero_buffer(&device, bp * qkv_dim, "act_gdn_qkv"),

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -237,6 +237,66 @@ kernel void gemv_q8_decode(
     }
 }
 
+// ===== Q8_0 GEMV Decode (wide): NR=4 variant for large-N matmuls (lm_head) =====
+// Halves threadgroup count vs NR=2, better for N > 8192 where scheduling dominates.
+// Dispatch: threadgroups=(ceil(N/4), 1, 1), threads=(32, 4, 1)
+kernel void gemv_q8_decode_wide(
+    device const float* x        [[buffer(0)]],
+    device const char*  qweight  [[buffer(1)]],
+    device float*       y        [[buffer(2)]],
+    constant uint& N             [[buffer(3)]],
+    constant uint& K             [[buffer(4)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint  tiisg [[thread_index_in_simdgroup]],
+    uint  sgitg [[simdgroup_index_in_threadgroup]])
+{
+    const uint NR = 4;
+    const uint NSG = 4;
+    const uint nb = K / 32;
+    const uint row_bytes = nb * 34;
+    const uint first_row = tgpig.x * NR;
+    const uint ix = tiisg / 4;
+    const uint il = tiisg % 4;
+
+    float sumf[NR] = {0.0f};
+    const uint ib_start = sgitg * 8 + ix;
+    const uint ib_stride = NSG * 8;
+    device const float* yb = x + ib_start * 32 + il * 8;
+
+    for (uint ib = ib_start; ib < nb; ib += ib_stride) {
+        float yl[8];
+        for (uint i = 0; i < 8; i++) yl[i] = yb[i];
+        yb += ib_stride * 32;
+
+        for (uint row = 0; row < NR; row++) {
+            uint r = first_row + row;
+            if (r >= N) continue;
+            device const char* base = qweight + r * row_bytes + ib * 34;
+            device const char* qs = base + 2 + il * 8;
+            half d = *((device const half*)base);
+            float sumq = 0.0f;
+            for (uint i = 0; i < 8; i++) sumq += float(qs[i]) * yl[i];
+            sumf[row] += sumq * float(d);
+        }
+    }
+
+    for (uint row = 0; row < NR; row++) sumf[row] = simd_sum(sumf[row]);
+
+    threadgroup float shared[NR][4];
+    if (tiisg == 0) {
+        for (uint row = 0; row < NR; row++) shared[row][sgitg] = sumf[row];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (sgitg == 0 && tiisg == 0) {
+        for (uint row = 0; row < NR; row++) {
+            uint r = first_row + row;
+            if (r < N) {
+                y[r] = shared[row][0] + shared[row][1] + shared[row][2] + shared[row][3];
+            }
+        }
+    }
+}
+
 // ===== Qwen3.5 RMS Norm: x = x * (1 + gamma) / sqrt(mean(x^2) + eps) =====
 // Shifted norm: (1 + gamma) instead of plain gamma.
 // One threadgroup per row.
@@ -2725,6 +2785,7 @@ kernel void moe_shared_gate_add(
     struct MetalQwen35Pipelines {
         gemv_decode: ComputePipelineState,
         gemv_q8: ComputePipelineState,
+        gemv_q8_wide: ComputePipelineState,
         rms_norm: ComputePipelineState,
         partial_rope: ComputePipelineState,
         per_head_rms_norm: ComputePipelineState,
@@ -3539,6 +3600,7 @@ kernel void moe_shared_gate_add(
             let pipelines = MetalQwen35Pipelines {
                 gemv_decode: make_pipeline("gemv_decode_m1")?,
                 gemv_q8: make_pipeline("gemv_q8_decode")?,
+                gemv_q8_wide: make_pipeline("gemv_q8_decode_wide")?,
                 gemv_q4: make_pipeline("gemv_q4_decode")?,
                 gemm_q4: make_pipeline("gemm_q4")?,
                 gemm_q4_tiled: make_optional_gemm_q4_tiled(),
@@ -5756,6 +5818,16 @@ kernel void moe_shared_gate_add(
             position: usize,
             capture_hidden: bool,
         ) -> MetalStepOutput {
+            self.forward_step_inner_impl(token_id, position, capture_hidden, false)
+        }
+
+        fn forward_step_inner_impl(
+            &mut self,
+            token_id: u32,
+            position: usize,
+            capture_hidden: bool,
+            skip_logits_readback: bool,
+        ) -> MetalStepOutput {
             let cfg = self.engine.config.clone();
             let hidden = cfg.hidden_size;
 
@@ -5898,7 +5970,9 @@ kernel void moe_shared_gate_add(
                 Vec::new()
             };
 
-            let logits = if let Some(which) = topk_which {
+            let logits = if skip_logits_readback {
+                vec![]
+            } else if let Some(which) = topk_which {
                 // Compact path: read k*(f32+u32)=k*8 bytes instead of vocab*4 bytes.
                 // SAFETY: GPU completed, buffers are StorageModeShared.
                 let k = self.session.compact_topk;
@@ -5923,6 +5997,30 @@ kernel void moe_shared_gate_add(
         /// Run a single token through the full model. Returns logits [vocab_size].
         pub fn forward_step(&mut self, token_id: u32, position: usize) -> Vec<f32> {
             self.forward_step_inner(token_id, position, false).logits
+        }
+
+        /// Zero-copy greedy argmax: run forward pass then scan GPU shared buffer
+        /// directly for the argmax token ID, avoiding 993KB allocation+copy.
+        fn forward_step_greedy_argmax(&mut self, token_id: u32, position: usize) -> u32 {
+            let cfg = self.engine.config.clone();
+            self.forward_step_inner_impl(token_id, position, false, true);
+
+            // SAFETY: GPU completed (wait_until_completed called in forward_step_inner).
+            // logits buffer is StorageModeShared — CPU can read it directly.
+            unsafe {
+                let ptr = self.session.activations.logits.contents() as *const f32;
+                let vocab_size = cfg.vocab_size;
+                let mut best_id = 0u32;
+                let mut best_val = f32::NEG_INFINITY;
+                for i in 0..vocab_size {
+                    let v = *ptr.add(i);
+                    if v > best_val {
+                        best_val = v;
+                        best_id = i as u32;
+                    }
+                }
+                best_id
+            }
         }
 
         /// Run a token through GDN layers only, skipping all GQA layers.
@@ -7293,7 +7391,13 @@ kernel void moe_shared_gate_add(
             // Advance grammar state after sampling the prefill token.
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
                 if !engine.advance(gs, next_id) {
-                    return generated_ids;
+                    let text = tokenizer.decode(&generated_ids).unwrap_or_default();
+                    return GenerateOutput {
+                        text,
+                        token_ids: generated_ids.clone(),
+                        prompt_tokens: prompt_len,
+                        generated_tokens: generated_ids.len(),
+                    };
                 }
             }
 
@@ -7317,6 +7421,13 @@ kernel void moe_shared_gate_add(
             generated_ids.push(next_id);
             all_ids.push(next_id);
 
+            // Greedy fast path: zero-copy argmax avoids 993KB alloc+copy per step.
+            let greedy_fast = gen_cfg.temperature <= 0.0
+                && gen_cfg.top_k <= 1
+                && gen_cfg.repetition_penalty == 1.0
+                && gen_cfg.grammar.is_none()
+                && !use_compact;
+
             // Autoregressive decode
             for _ in 1..gen_cfg.max_new_tokens {
                 if self.session.kv_cache.seq_len >= self.session.kv_cache.max_cache_len {
@@ -7327,22 +7438,26 @@ kernel void moe_shared_gate_add(
                     .last()
                     .expect("invariant: prompt or previous sample populated all_ids");
 
-                let mut step_logits = self.forward_step(last_token, pos);
-
-                // Apply grammar masking before sampling (ADR-046).
-                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                    engine.mask_logits(gs, &mut step_logits);
-                }
-
-                let next_id = if use_compact {
-                    sample_from_candidates(
-                        &self.session.compact_result,
-                        gen_cfg,
-                        &all_ids,
-                        &mut rng_state,
-                    )
+                let next_id = if greedy_fast {
+                    self.forward_step_greedy_argmax(last_token, pos)
                 } else {
-                    sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
+                    let mut step_logits = self.forward_step(last_token, pos);
+
+                    // Apply grammar masking before sampling (ADR-046).
+                    if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                        engine.mask_logits(gs, &mut step_logits);
+                    }
+
+                    if use_compact {
+                        sample_from_candidates(
+                            &self.session.compact_result,
+                            gen_cfg,
+                            &all_ids,
+                            &mut rng_state,
+                        )
+                    } else {
+                        sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
+                    }
                 };
 
                 // Advance grammar state after sampling.
@@ -9472,7 +9587,7 @@ kernel void moe_shared_gate_add(
             enc.set_bytes(3, 4, &n as *const u32 as *const _);
             enc.set_bytes(4, 4, &k as *const u32 as *const _);
             enc.dispatch_thread_groups(
-                MTLSize::new(n.div_ceil(2) as u64, 1, 1),
+                MTLSize::new(n.div_ceil(4) as u64, 1, 1), // NR=4
                 MTLSize::new(32, 4, 1),
             );
         }
@@ -10462,7 +10577,13 @@ kernel void moe_shared_gate_add(
             // Advance grammar state after sampling the prefill token.
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
                 if !engine.advance(gs, next_id) {
-                    break;
+                    let text = decode_tokens(tokenizer, &generated_ids);
+                    return GenerateOutput {
+                        text,
+                        token_ids: generated_ids.clone(),
+                        prompt_tokens: prompt_len,
+                        generated_tokens: generated_ids.len(),
+                    };
                 }
             }
 
@@ -10909,6 +11030,7 @@ kernel void moe_shared_gate_add(
             let pipelines = MetalQwen35Pipelines {
                 gemv_decode: make_pipeline("gemv_decode_m1")?,
                 gemv_q8: make_pipeline("gemv_q8_decode")?,
+                gemv_q8_wide: make_pipeline("gemv_q8_decode_wide")?,
                 gemv_q4: make_pipeline("gemv_q4_decode")?,
                 gemm_q4: make_pipeline("gemm_q4")?,
                 gemm_q4_tiled: make_optional_gemm_q4_tiled(),
@@ -11082,18 +11204,20 @@ kernel void moe_shared_gate_add(
                         &format!("{prefix}.post_attention_layernorm.weight"),
                         &format!("L{i}.post_norm"),
                     )?,
-                    gate_proj: load_q4_buf(
-                        &format!("{prefix}.mlp.gate_proj.weight"),
-                        &format!("L{i}.gate.q4"),
-                    )?,
-                    up_proj: load_q4_buf(
-                        &format!("{prefix}.mlp.up_proj.weight"),
-                        &format!("L{i}.up.q4"),
-                    )?,
-                    down_proj: load_q4_buf(
-                        &format!("{prefix}.mlp.down_proj.weight"),
-                        &format!("L{i}.down.q4"),
-                    )?,
+                    ffn: MetalFfnWeights::Dense {
+                        gate_proj: load_q4_buf(
+                            &format!("{prefix}.mlp.gate_proj.weight"),
+                            &format!("L{i}.gate.q4"),
+                        )?,
+                        up_proj: load_q4_buf(
+                            &format!("{prefix}.mlp.up_proj.weight"),
+                            &format!("L{i}.up.q4"),
+                        )?,
+                        down_proj: load_q4_buf(
+                            &format!("{prefix}.mlp.down_proj.weight"),
+                            &format!("L{i}.down.q4"),
+                        )?,
+                    },
                 };
 
                 let attn = if cfg.is_full_attention(i) {

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -56,6 +56,11 @@ required-features = ["safetensors", "inference-hook"]
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "train_bench"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/tune/benches/train_bench.rs
+++ b/crates/tune/benches/train_bench.rs
@@ -1,0 +1,103 @@
+//! Benchmark for the batch LoRA training loop.
+//!
+//! Measures [`train_lora`] throughput as a function of sample count (batch_size
+//! parameter is informational; the loop is sequential).
+//!
+//! Groups:
+//!   lora/train_loop — num_epochs=5, batch_size ∈ {10, 50, 100}
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer};
+use lattice_tune::{LoraTrainConfig, TrainSample, train_lora};
+use std::collections::HashMap;
+
+const D_IN: usize = 64;
+const D_OUT: usize = 64;
+const RANK: usize = 4;
+const NUM_EPOCHS: usize = 5;
+
+/// Build a deterministic pseudo-random f32 from two indices (no external rand crate).
+fn pseudo_f32(seed: u64, idx: u64) -> f32 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    (seed, idx).hash(&mut h);
+    // Map to (-0.5, 0.5) so the initial weights are centred.
+    h.finish() as f32 / u64::MAX as f32 - 0.5
+}
+
+fn make_adapter() -> LoraAdapter {
+    let config = LoraConfig {
+        rank: RANK,
+        alpha: RANK as f32, // scale = 1.0
+        target_modules: vec!["q_proj".into()],
+    };
+    let mut layers = HashMap::new();
+    layers.insert(
+        (0usize, "q_proj".to_string()),
+        LoraLayer {
+            // A: (rank, d_in)
+            a: (0..(RANK * D_IN))
+                .map(|i| pseudo_f32(1, i as u64) * 0.01)
+                .collect(),
+            // B: (d_out, rank)
+            b: (0..(D_OUT * RANK))
+                .map(|i| pseudo_f32(2, i as u64) * 0.01)
+                .collect(),
+            d_in: D_IN,
+            d_out: D_OUT,
+            rank: RANK,
+        },
+    );
+    LoraAdapter::new(config, layers)
+}
+
+fn make_samples(n: usize) -> Vec<TrainSample> {
+    (0..n)
+        .map(|i| TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: (0..D_IN)
+                .map(|j| pseudo_f32(3 + i as u64, j as u64))
+                .collect(),
+            target_delta: (0..D_OUT)
+                .map(|j| pseudo_f32(1000 + i as u64, j as u64) * 0.1)
+                .collect(),
+        })
+        .collect()
+}
+
+fn bench_train_loop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lora/train_loop");
+
+    for &n_samples in &[10usize, 50, 100] {
+        let samples = make_samples(n_samples);
+
+        group.bench_with_input(
+            BenchmarkId::new("num_samples", n_samples),
+            &n_samples,
+            |b, _| {
+                b.iter(|| {
+                    // Re-create adapter each iteration so weights start fresh.
+                    let mut adapter = make_adapter();
+                    let config = LoraTrainConfig {
+                        learning_rate: 0.01,
+                        num_epochs: NUM_EPOCHS,
+                        batch_size: n_samples,
+                    };
+                    train_lora(
+                        black_box(&mut adapter),
+                        black_box(&samples),
+                        black_box(&config),
+                    )
+                    .expect("train_lora must not fail in bench")
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_train_loop);
+criterion_main!(benches);

--- a/crates/tune/benches/train_bench.rs
+++ b/crates/tune/benches/train_bench.rs
@@ -4,10 +4,12 @@
 //! parameter is informational; the loop is sequential).
 //!
 //! Groups:
-//!   lora/train_loop — num_epochs=5, batch_size ∈ {10, 50, 100}
+//!   lora/train_loop    — num_epochs=5, batch_size ∈ {10, 50, 100}, SGD
+//!   lora/optimizer_cmp — SGD vs Adam vs AdamW at 50 samples, 5 epochs
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer};
+use lattice_tune::train::OptimizerConfig;
 use lattice_tune::{LoraTrainConfig, TrainSample, train_lora};
 use std::collections::HashMap;
 
@@ -84,6 +86,9 @@ fn bench_train_loop(c: &mut Criterion) {
                         learning_rate: 0.01,
                         num_epochs: NUM_EPOCHS,
                         batch_size: n_samples,
+                        optimizer: None,
+                        lr_schedule: None,
+                        grad_clip_norm: None,
                     };
                     train_lora(
                         black_box(&mut adapter),
@@ -99,5 +104,75 @@ fn bench_train_loop(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_train_loop);
+fn bench_optimizer_cmp(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lora/optimizer_cmp");
+    let samples = make_samples(50);
+
+    // SGD
+    group.bench_function("sgd", |b| {
+        b.iter(|| {
+            let mut adapter = make_adapter();
+            let config = LoraTrainConfig {
+                learning_rate: 0.01,
+                num_epochs: NUM_EPOCHS,
+                batch_size: 50,
+                optimizer: None,
+                lr_schedule: None,
+                grad_clip_norm: None,
+            };
+            train_lora(
+                black_box(&mut adapter),
+                black_box(&samples),
+                black_box(&config),
+            )
+            .expect("train_lora must not fail in bench")
+        });
+    });
+
+    // Adam
+    group.bench_function("adam", |b| {
+        b.iter(|| {
+            let mut adapter = make_adapter();
+            let config = LoraTrainConfig {
+                learning_rate: 0.01,
+                num_epochs: NUM_EPOCHS,
+                batch_size: 50,
+                optimizer: Some(OptimizerConfig::adam(0.01)),
+                lr_schedule: None,
+                grad_clip_norm: None,
+            };
+            train_lora(
+                black_box(&mut adapter),
+                black_box(&samples),
+                black_box(&config),
+            )
+            .expect("train_lora must not fail in bench")
+        });
+    });
+
+    // AdamW
+    group.bench_function("adamw", |b| {
+        b.iter(|| {
+            let mut adapter = make_adapter();
+            let config = LoraTrainConfig {
+                learning_rate: 0.01,
+                num_epochs: NUM_EPOCHS,
+                batch_size: 50,
+                optimizer: Some(OptimizerConfig::adamw(0.01, 0.01)),
+                lr_schedule: None,
+                grad_clip_norm: None,
+            };
+            train_lora(
+                black_box(&mut adapter),
+                black_box(&samples),
+                black_box(&config),
+            )
+            .expect("train_lora must not fail in bench")
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_train_loop, bench_optimizer_cmp);
 criterion_main!(benches);

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -149,7 +149,9 @@ pub use train::{
 pub use train::{GpuTrainer, GpuTrainerBuilder};
 
 // LoRA re-exports
-pub use lora::{LoraAdapter, LoraConfig, LoraLayer};
+pub use lora::{
+    LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+};
 
 // Registry re-exports
 pub use registry::{
@@ -168,7 +170,9 @@ pub mod prelude {
         LabelingResult, TeacherConfig, TeacherProvider,
     };
     pub use crate::error::{Result, TuneError};
-    pub use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    pub use crate::lora::{
+        LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+    };
     pub use crate::registry::{
         LiveModel, ModelMetadata, ModelRegistry, ModelStatus, RegisteredModel, RollbackController,
         RollbackRecord, ShadowComparison, ShadowConfig, ShadowSession, ShadowState, StorageBackend,

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -37,11 +37,13 @@ mod apply;
 pub mod online;
 #[cfg(feature = "safetensors")]
 mod safetensors;
+pub mod train;
 
 pub use apply::apply_lora;
 pub use online::{AdaptStepResult, adapt_step};
 #[cfg(feature = "safetensors")]
 pub use safetensors::{load_peft_safetensors, save_peft_safetensors};
+pub use train::{LoraTrainConfig, TrainResult, TrainSample, train_lora};
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -35,12 +35,14 @@
 
 mod apply;
 pub mod online;
+pub mod optimizer;
 #[cfg(feature = "safetensors")]
 mod safetensors;
 pub mod train;
 
 pub use apply::apply_lora;
 pub use online::{AdaptStepResult, adapt_step};
+pub use optimizer::{AdamState, LoraGradients, compute_lora_gradients};
 #[cfg(feature = "safetensors")]
 pub use safetensors::{load_peft_safetensors, save_peft_safetensors};
 pub use train::{LoraTrainConfig, TrainResult, TrainSample, train_lora};

--- a/crates/tune/src/lora/optimizer.rs
+++ b/crates/tune/src/lora/optimizer.rs
@@ -1,0 +1,466 @@
+//! Adam and AdamW optimizers for LoRA weight updates.
+//!
+//! Provides [`AdamState`] for stateful Adam/AdamW updates and
+//! [`compute_lora_gradients`] which mirrors the forward/backward pass of
+//! [`adapt_step`](super::online::adapt_step) without applying the update.
+
+use std::collections::HashMap;
+
+use super::LoraAdapter;
+use crate::error::TuneError;
+
+/// Stateful Adam / AdamW optimizer.
+///
+/// Tracks per-parameter first and second moment estimates keyed by an
+/// arbitrary string (typically `"{layer_idx}_{module}_{param}"` where
+/// `param` is `"a"` or `"b"`).  All keys share a single global step counter
+/// `t` which is incremented on every call to [`step`](AdamState::step).
+pub struct AdamState {
+    /// First moment estimates (exponential moving average of gradients).
+    m: HashMap<String, Vec<f32>>,
+    /// Second moment estimates (exponential moving average of squared gradients).
+    v: HashMap<String, Vec<f32>>,
+    /// Global step counter (1-based: starts at 0, incremented before each bias correction).
+    pub t: usize,
+}
+
+impl AdamState {
+    /// Create a fresh optimizer state with zero moments and step counter.
+    pub fn new() -> Self {
+        Self {
+            m: HashMap::new(),
+            v: HashMap::new(),
+            t: 0,
+        }
+    }
+
+    /// Perform one Adam (or AdamW) update step on `params` in place.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Unique string key identifying this parameter tensor.
+    /// * `params` - Parameter slice to update in place.
+    /// * `grads` - Gradient slice (same length as `params`).
+    /// * `lr` - Learning rate for this step (may be scheduled externally).
+    /// * `beta1` - First moment decay (typical: 0.9).
+    /// * `beta2` - Second moment decay (typical: 0.999).
+    /// * `eps` - Numerical stability constant (typical: 1e-8).
+    /// * `weight_decay` - L2 / decoupled weight decay coefficient.
+    /// * `decoupled` - If `true`, apply AdamW-style decoupled weight decay
+    ///   (`θ -= lr * λ * θ`) before the Adam gradient step.  If `false`,
+    ///   weight_decay is unused (standard Adam).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `params.len() != grads.len()`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn step(
+        &mut self,
+        key: &str,
+        params: &mut [f32],
+        grads: &[f32],
+        lr: f32,
+        beta1: f32,
+        beta2: f32,
+        eps: f32,
+        weight_decay: f32,
+        decoupled: bool,
+    ) {
+        assert_eq!(
+            params.len(),
+            grads.len(),
+            "params and grads must have the same length"
+        );
+        let n = params.len();
+
+        // Lazily initialise moment vectors to zero.
+        let m = self
+            .m
+            .entry(key.to_string())
+            .or_insert_with(|| vec![0.0f32; n]);
+        let v = self
+            .v
+            .entry(key.to_string())
+            .or_insert_with(|| vec![0.0f32; n]);
+
+        // Increment step counter once per call (shared across all keys so that
+        // bias-correction is epoch-consistent regardless of key ordering).
+        self.t += 1;
+
+        // Bias-correction denominators.
+        let bc1 = 1.0 - beta1.powi(self.t as i32);
+        let bc2 = 1.0 - beta2.powi(self.t as i32);
+
+        for i in 0..n {
+            let g = grads[i];
+
+            // Update biased first moment: m = β₁·m + (1-β₁)·g
+            m[i] = beta1 * m[i] + (1.0 - beta1) * g;
+            // Update biased second moment: v = β₂·v + (1-β₂)·g²
+            v[i] = beta2 * v[i] + (1.0 - beta2) * g * g;
+
+            // Bias-corrected estimates.
+            let m_hat = m[i] / bc1;
+            let v_hat = v[i] / bc2;
+
+            // AdamW: decoupled weight decay applied before the gradient step.
+            if decoupled && weight_decay != 0.0 {
+                params[i] -= lr * weight_decay * params[i];
+            }
+
+            // θ -= lr · m̂ / (√v̂ + ε)
+            params[i] -= lr * m_hat / (v_hat.sqrt() + eps);
+        }
+    }
+}
+
+impl Default for AdamState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Gradient computation ────────────────────────────────────────────────────
+
+/// Gradients of the LoRA MSE loss with respect to a single layer's A and B matrices.
+#[derive(Debug)]
+pub struct LoraGradients {
+    /// Gradient with respect to B, row-major `(d_out, rank)`.
+    pub grad_b: Vec<f32>,
+    /// Gradient with respect to A, row-major `(rank, d_in)`.
+    pub grad_a: Vec<f32>,
+    /// MSE loss `||scale·B·A·input - target||²` (sum, not mean).
+    pub loss: f32,
+}
+
+/// Compute LoRA gradients without applying an update.
+///
+/// Mirrors the forward / backward arithmetic in [`adapt_step`](super::online::adapt_step)
+/// exactly, returning raw gradients instead of performing an SGD step.
+///
+/// # Forward pass
+///
+/// ```text
+/// intermediate = A @ input          (rank,)
+/// delta        = scale * B @ intermediate  (d_out,)
+/// error        = delta - target_delta
+/// loss         = ||error||²
+/// ```
+///
+/// # Backward pass
+///
+/// ```text
+/// dL/dB[i,r] = 2 · scale · error[i] · intermediate[r]
+/// dL/dA[r,j] = 2 · scale · (Bᵀ·error)[r] · input[j]
+/// ```
+///
+/// # Errors
+///
+/// * [`TuneError::Training`]          – layer `(layer_idx, module)` not found.
+/// * [`TuneError::DimensionMismatch`] – `input` or `target_delta` wrong length.
+pub fn compute_lora_gradients(
+    adapter: &LoraAdapter,
+    layer_idx: usize,
+    module: &str,
+    input: &[f32],
+    target_delta: &[f32],
+) -> Result<LoraGradients, TuneError> {
+    let scale = adapter.config.scale();
+
+    let lora = adapter
+        .layers
+        .get(&(layer_idx, module.to_string()))
+        .ok_or_else(|| TuneError::Training(format!("no LoRA layer for ({layer_idx}, {module})")))?;
+
+    let rank = lora.rank;
+    let d_in = lora.d_in;
+    let d_out = lora.d_out;
+
+    if input.len() != d_in {
+        return Err(TuneError::DimensionMismatch {
+            expected: d_in,
+            actual: input.len(),
+        });
+    }
+    if target_delta.len() != d_out {
+        return Err(TuneError::DimensionMismatch {
+            expected: d_out,
+            actual: target_delta.len(),
+        });
+    }
+
+    // Forward: intermediate = A @ input  (rank,)
+    let mut intermediate = vec![0.0f32; rank];
+    for r in 0..rank {
+        let row = &lora.a[r * d_in..(r + 1) * d_in];
+        intermediate[r] = row.iter().zip(input.iter()).map(|(a, x)| a * x).sum();
+    }
+
+    // Forward: delta = scale * B @ intermediate  (d_out,)
+    let mut delta = vec![0.0f32; d_out];
+    for i in 0..d_out {
+        let row = &lora.b[i * rank..(i + 1) * rank];
+        let acc: f32 = row
+            .iter()
+            .zip(intermediate.iter())
+            .map(|(b, h)| b * h)
+            .sum();
+        delta[i] = scale * acc;
+    }
+
+    // Residual and loss (sum of squared errors, matching adapt_step).
+    let error: Vec<f32> = delta
+        .iter()
+        .zip(target_delta.iter())
+        .map(|(d, t)| d - t)
+        .collect();
+    let loss: f32 = error.iter().map(|e| e * e).sum();
+
+    // dL/dB[i*rank + r] = 2 * scale * error[i] * intermediate[r]
+    let mut grad_b = vec![0.0f32; d_out * rank];
+    for i in 0..d_out {
+        for r in 0..rank {
+            grad_b[i * rank + r] = 2.0 * scale * error[i] * intermediate[r];
+        }
+    }
+
+    // bt_error[r] = Σ_i B[i*rank + r] * error[i]
+    let mut bt_error = vec![0.0f32; rank];
+    for r in 0..rank {
+        bt_error[r] = (0..d_out).map(|i| lora.b[i * rank + r] * error[i]).sum();
+    }
+
+    // dL/dA[r*d_in + j] = 2 * scale * bt_error[r] * input[j]
+    let mut grad_a = vec![0.0f32; rank * d_in];
+    for r in 0..rank {
+        for j in 0..d_in {
+            grad_a[r * d_in + j] = 2.0 * scale * bt_error[r] * input[j];
+        }
+    }
+
+    Ok(LoraGradients {
+        grad_b,
+        grad_a,
+        loss,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lora::train::{LoraTrainConfig, TrainSample, train_lora};
+    use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    use crate::train::OptimizerConfig;
+    use std::collections::HashMap;
+
+    /// rank=2, d_in=3, d_out=2, scale=1.0 (alpha=2.0, rank=2)
+    fn make_small_adapter() -> LoraAdapter {
+        let config = LoraConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["q_proj".into()],
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![
+                    1.0, 0.5, 0.0, // row 0
+                    0.0, 0.5, 1.0, // row 1
+                ],
+                b: vec![
+                    1.0, 0.0, // row 0
+                    0.0, 1.0, // row 1
+                ],
+                d_in: 3,
+                d_out: 2,
+                rank: 2,
+            },
+        );
+        LoraAdapter::new(config, layers)
+    }
+
+    fn make_samples(n: usize) -> Vec<TrainSample> {
+        (0..n)
+            .map(|i| {
+                let fi = i as f32;
+                TrainSample {
+                    layer_idx: 0,
+                    module: "q_proj".to_string(),
+                    input: vec![fi * 0.1 + 0.1, fi * 0.2 + 0.2, fi * 0.3 + 0.3],
+                    target_delta: vec![fi * 0.05, fi * 0.05 + 0.1],
+                }
+            })
+            .collect()
+    }
+
+    // ─── gradient computation tests ────────────────────────────────────────
+
+    #[test]
+    fn test_gradient_computation() {
+        let adapter = make_small_adapter();
+        let input = vec![1.0f32, 2.0, 3.0];
+        let target_delta = vec![5.0f32, 5.0];
+
+        let grads = compute_lora_gradients(&adapter, 0, "q_proj", &input, &target_delta)
+            .expect("compute_lora_gradients must succeed");
+
+        // grad_b shape: d_out * rank = 2 * 2 = 4
+        assert_eq!(
+            grads.grad_b.len(),
+            4,
+            "grad_b must have d_out*rank elements"
+        );
+        // grad_a shape: rank * d_in = 2 * 3 = 6
+        assert_eq!(grads.grad_a.len(), 6, "grad_a must have rank*d_in elements");
+        // Loss must be positive because delta != target.
+        assert!(grads.loss > 0.0, "loss must be positive");
+        // At least one gradient element must be non-zero.
+        assert!(
+            grads.grad_b.iter().any(|&g| g.abs() > 1e-9)
+                || grads.grad_a.iter().any(|&g| g.abs() > 1e-9),
+            "gradients must be non-zero"
+        );
+    }
+
+    #[test]
+    fn test_gradient_computation_missing_layer() {
+        let adapter = make_small_adapter();
+        let err = compute_lora_gradients(&adapter, 99, "missing", &[1.0, 2.0], &[1.0])
+            .expect_err("missing layer must return Err");
+        assert!(
+            matches!(err, TuneError::Training(_)),
+            "expected Training variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_gradient_computation_dimension_mismatch() {
+        let adapter = make_small_adapter();
+        // input too short (d_in=3, passing 2)
+        let err = compute_lora_gradients(&adapter, 0, "q_proj", &[1.0, 2.0], &[1.0, 1.0])
+            .expect_err("wrong input length must return Err");
+        assert!(
+            matches!(err, TuneError::DimensionMismatch { .. }),
+            "expected DimensionMismatch, got {err:?}"
+        );
+    }
+
+    // ─── Adam state tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_adam_step_updates_params() {
+        let mut state = AdamState::new();
+        let mut params = vec![1.0f32, 2.0, 3.0];
+        let grads = vec![0.1f32, 0.2, 0.3];
+        let original = params.clone();
+
+        state.step(
+            "test",
+            &mut params,
+            &grads,
+            0.01,
+            0.9,
+            0.999,
+            1e-8,
+            0.0,
+            false,
+        );
+
+        for (p, o) in params.iter().zip(original.iter()) {
+            assert_ne!(p, o, "params must change after Adam step");
+        }
+        assert_eq!(state.t, 1, "step counter must be 1 after first step");
+    }
+
+    #[test]
+    fn test_adamw_weight_decay() {
+        // Train two adapters on the same task — one with weight_decay, one without.
+        // The weight-decayed adapter should have smaller weight magnitude.
+        let samples = make_samples(5);
+
+        // --- with weight decay ---
+        let mut adapter_wd = make_small_adapter();
+        let config_wd = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 20,
+            batch_size: 5,
+            optimizer: Some(OptimizerConfig::adamw(0.01, 0.1)),
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+        train_lora(&mut adapter_wd, &samples, &config_wd).expect("AdamW train must succeed");
+
+        // --- without weight decay ---
+        let mut adapter_no_wd = make_small_adapter();
+        let config_no_wd = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 20,
+            batch_size: 5,
+            optimizer: Some(OptimizerConfig::adam(0.01)),
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+        train_lora(&mut adapter_no_wd, &samples, &config_no_wd).expect("Adam train must succeed");
+
+        let key = (0usize, "q_proj".to_string());
+        let norm_wd: f32 = adapter_wd.layers[&key]
+            .a
+            .iter()
+            .chain(adapter_wd.layers[&key].b.iter())
+            .map(|x| x * x)
+            .sum::<f32>()
+            .sqrt();
+        let norm_no_wd: f32 = adapter_no_wd.layers[&key]
+            .a
+            .iter()
+            .chain(adapter_no_wd.layers[&key].b.iter())
+            .map(|x| x * x)
+            .sum::<f32>()
+            .sqrt();
+
+        assert!(
+            norm_wd < norm_no_wd,
+            "AdamW weight decay must produce smaller weight norms: wd={norm_wd:.6} vs no_wd={norm_no_wd:.6}"
+        );
+    }
+
+    #[test]
+    fn test_adam_converges_faster() {
+        // Same task, same number of epochs — Adam should reach lower final loss than SGD.
+        let samples = make_samples(5);
+
+        // SGD
+        let mut adapter_sgd = make_small_adapter();
+        let config_sgd = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 10,
+            batch_size: 5,
+            optimizer: None, // backward-compat SGD path
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+        let result_sgd =
+            train_lora(&mut adapter_sgd, &samples, &config_sgd).expect("SGD train must succeed");
+
+        // Adam
+        let mut adapter_adam = make_small_adapter();
+        let config_adam = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 10,
+            batch_size: 5,
+            optimizer: Some(OptimizerConfig::adam(0.01)),
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+        let result_adam =
+            train_lora(&mut adapter_adam, &samples, &config_adam).expect("Adam train must succeed");
+
+        assert!(
+            result_adam.final_loss < result_sgd.final_loss,
+            "Adam must converge faster than SGD on this task: adam={:.6} sgd={:.6}",
+            result_adam.final_loss,
+            result_sgd.final_loss,
+        );
+    }
+}

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -1,0 +1,252 @@
+//! Batch LoRA training loop (ADR-057, perf-opt-train-loop).
+//!
+//! Provides [`train_lora`] which iterates over a slice of [`TrainSample`]s for
+//! multiple epochs, calling [`adapt_step`] for each sample and accumulating per-epoch
+//! MSE loss statistics.
+
+use super::{LoraAdapter, online::adapt_step};
+use crate::error::TuneError;
+
+/// Configuration for a batch LoRA training run.
+#[derive(Debug, Clone)]
+pub struct LoraTrainConfig {
+    /// SGD step size applied inside each [`adapt_step`] call.
+    pub learning_rate: f32,
+    /// Number of full passes over the sample set.
+    pub num_epochs: usize,
+    /// Batch size (informational; does not affect the current sequential loop).
+    pub batch_size: usize,
+}
+
+/// A single training sample: one (input, target_delta) pair for one LoRA layer.
+#[derive(Debug, Clone)]
+pub struct TrainSample {
+    /// Transformer layer index (0-based).
+    pub layer_idx: usize,
+    /// Module name, e.g. `"q_proj"`.
+    pub module: String,
+    /// Input activation vector; length must equal the layer's `d_in`.
+    pub input: Vec<f32>,
+    /// Target LoRA output correction; length must equal the layer's `d_out`.
+    pub target_delta: Vec<f32>,
+}
+
+/// Summary statistics from a completed [`train_lora`] run.
+#[derive(Debug, Clone)]
+pub struct TrainResult {
+    /// Average MSE loss recorded in the final epoch.
+    pub final_loss: f32,
+    /// Average MSE loss per epoch (length == `num_epochs`).
+    pub epoch_losses: Vec<f32>,
+    /// Total number of [`adapt_step`] calls executed (`num_epochs * samples.len()`).
+    pub total_steps: usize,
+}
+
+/// Run a multi-epoch batch LoRA training loop.
+///
+/// Iterates over all `samples` in order for each epoch (no shuffling, ensuring
+/// deterministic behaviour), calling [`adapt_step`] once per sample and
+/// accumulating the per-step MSE loss.
+///
+/// # Arguments
+///
+/// * `adapter` – Mutable LoRA adapter whose weights are updated in place.
+/// * `samples` – Slice of training samples; must be non-empty.
+/// * `config`  – Hyper-parameters for the training run.
+///
+/// # Errors
+///
+/// * [`TuneError::Training`]         – `samples` is empty.
+/// * [`TuneError::InvalidConfig`]    – `batch_size == 0` or `num_epochs == 0`.
+/// * [`TuneError::Training`] – A sample references a `(layer_idx, module)` pair
+///   that is not present in the adapter.
+/// * [`TuneError::DimensionMismatch`] – A sample's `input` or `target_delta` has the
+///   wrong length for its LoRA layer.
+pub fn train_lora(
+    adapter: &mut LoraAdapter,
+    samples: &[TrainSample],
+    config: &LoraTrainConfig,
+) -> Result<TrainResult, TuneError> {
+    if samples.is_empty() {
+        return Err(TuneError::Training(
+            "no training samples provided".to_string(),
+        ));
+    }
+    if config.batch_size == 0 {
+        return Err(TuneError::InvalidConfig(
+            "batch_size must be > 0".to_string(),
+        ));
+    }
+    if config.num_epochs == 0 {
+        return Err(TuneError::InvalidConfig(
+            "num_epochs must be > 0".to_string(),
+        ));
+    }
+
+    let mut epoch_losses = Vec::with_capacity(config.num_epochs);
+
+    for _ in 0..config.num_epochs {
+        let mut epoch_loss_sum = 0.0f32;
+
+        for sample in samples {
+            let step_result = adapt_step(
+                adapter,
+                sample.layer_idx,
+                &sample.module,
+                &sample.input,
+                &sample.target_delta,
+                config.learning_rate,
+            )?;
+            epoch_loss_sum += step_result.loss;
+        }
+
+        let avg = epoch_loss_sum / samples.len() as f32;
+        epoch_losses.push(avg);
+    }
+
+    let final_loss = *epoch_losses
+        .last()
+        .expect("num_epochs > 0 guaranteed above");
+    let total_steps = config.num_epochs * samples.len();
+
+    Ok(TrainResult {
+        final_loss,
+        epoch_losses,
+        total_steps,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    use std::collections::HashMap;
+
+    /// rank=2, d_in=3, d_out=2, scale=1.0 (alpha=2.0, rank=2)
+    fn make_small_adapter() -> LoraAdapter {
+        let config = LoraConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["q_proj".into()],
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![
+                    1.0, 0.5, 0.0, // row 0
+                    0.0, 0.5, 1.0, // row 1
+                ],
+                b: vec![
+                    1.0, 0.0, // row 0
+                    0.0, 1.0, // row 1
+                ],
+                d_in: 3,
+                d_out: 2,
+                rank: 2,
+            },
+        );
+        LoraAdapter::new(config, layers)
+    }
+
+    /// Build a synthetic sample whose target_delta is the initial LoRA output for the given
+    /// input, slightly perturbed — this gives a reachable regression target without
+    /// requiring a warm-up forward pass from the caller.
+    fn make_samples(n: usize) -> Vec<TrainSample> {
+        // Use varied inputs so samples span different directions in weight-space.
+        (0..n)
+            .map(|i| {
+                let fi = i as f32;
+                TrainSample {
+                    layer_idx: 0,
+                    module: "q_proj".to_string(),
+                    // d_in = 3
+                    input: vec![fi * 0.1 + 0.1, fi * 0.2 + 0.2, fi * 0.3 + 0.3],
+                    // d_out = 2  — target is something the network can learn toward
+                    target_delta: vec![fi * 0.05, fi * 0.05 + 0.1],
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_train_convergence() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 10,
+            batch_size: 5,
+        };
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.epoch_losses.len(), 10);
+        assert_eq!(result.total_steps, 50);
+        assert!(
+            result.epoch_losses.last().unwrap() < result.epoch_losses.first().unwrap(),
+            "loss must decrease over 10 epochs: first={:.6}, last={:.6}",
+            result.epoch_losses.first().unwrap(),
+            result.epoch_losses.last().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_train_empty_batch() {
+        let mut adapter = make_small_adapter();
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 5,
+            batch_size: 1,
+        };
+
+        let err =
+            train_lora(&mut adapter, &[], &config).expect_err("empty samples must return Err");
+        assert!(
+            matches!(err, TuneError::Training(_)),
+            "expected Training variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_dimension_mismatch() {
+        let mut adapter = make_small_adapter();
+        // d_in for layer (0, "q_proj") is 3, but we pass a 2-element input.
+        let bad_samples = vec![TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: vec![1.0, 2.0], // wrong length (d_in=3)
+            target_delta: vec![1.0, 1.0],
+        }];
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 1,
+            batch_size: 1,
+        };
+
+        let err = train_lora(&mut adapter, &bad_samples, &config)
+            .expect_err("dimension mismatch must return Err");
+        assert!(
+            matches!(err, TuneError::DimensionMismatch { .. }),
+            "expected DimensionMismatch variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_metrics() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 3,
+            batch_size: 5,
+        };
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.total_steps, 15, "3 epochs × 5 samples = 15 steps");
+        assert_eq!(result.epoch_losses.len(), 3, "one loss entry per epoch");
+    }
+}

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -3,19 +3,42 @@
 //! Provides [`train_lora`] which iterates over a slice of [`TrainSample`]s for
 //! multiple epochs, calling [`adapt_step`] for each sample and accumulating per-epoch
 //! MSE loss statistics.
+//!
+//! When [`LoraTrainConfig::optimizer`] is `Some(Adam | AdamW)`, the loop uses
+//! [`AdamState`](super::optimizer::AdamState) to apply adaptive gradient updates
+//! instead of plain SGD.  When `optimizer` is `None`, the loop falls back to the
+//! original [`adapt_step`] SGD path for full backward compatibility.
 
-use super::{LoraAdapter, online::adapt_step};
+use super::{
+    LoraAdapter,
+    online::adapt_step,
+    optimizer::{AdamState, compute_lora_gradients},
+};
 use crate::error::TuneError;
+use crate::train::{LRSchedule, Optimizer, OptimizerConfig};
 
 /// Configuration for a batch LoRA training run.
 #[derive(Debug, Clone)]
 pub struct LoraTrainConfig {
-    /// SGD step size applied inside each [`adapt_step`] call.
+    /// SGD step size applied inside each [`adapt_step`] call (also used as
+    /// the base learning rate when an Adam optimizer is active).
     pub learning_rate: f32,
     /// Number of full passes over the sample set.
     pub num_epochs: usize,
     /// Batch size (informational; does not affect the current sequential loop).
     pub batch_size: usize,
+    /// Optional optimizer configuration.  When `None` the loop uses the
+    /// backward-compatible SGD path ([`adapt_step`]).  When `Some`, an
+    /// Adam or AdamW update is performed using the parameters from the
+    /// [`OptimizerConfig`] (the `learning_rate` field in the config is used
+    /// as the base LR, overriding this struct's `learning_rate` field).
+    pub optimizer: Option<OptimizerConfig>,
+    /// Optional learning-rate schedule.  Only used when `optimizer` is
+    /// `Some`; ignored in the SGD path.
+    pub lr_schedule: Option<LRSchedule>,
+    /// Optional gradient clipping by global L2 norm.  Applied to each
+    /// sample's gradients before the optimizer step when `optimizer` is `Some`.
+    pub grad_clip_norm: Option<f32>,
 }
 
 /// A single training sample: one (input, target_delta) pair for one LoRA layer.
@@ -45,8 +68,12 @@ pub struct TrainResult {
 /// Run a multi-epoch batch LoRA training loop.
 ///
 /// Iterates over all `samples` in order for each epoch (no shuffling, ensuring
-/// deterministic behaviour), calling [`adapt_step`] once per sample and
-/// accumulating the per-step MSE loss.
+/// deterministic behaviour).  The update rule is selected by
+/// [`LoraTrainConfig::optimizer`]:
+///
+/// * `None` — backward-compatible SGD via [`adapt_step`].
+/// * `Some(Adam)` — Adam adaptive gradient update.
+/// * `Some(AdamW)` — AdamW (Adam + decoupled weight decay).
 ///
 /// # Arguments
 ///
@@ -56,9 +83,9 @@ pub struct TrainResult {
 ///
 /// # Errors
 ///
-/// * [`TuneError::Training`]         – `samples` is empty.
-/// * [`TuneError::InvalidConfig`]    – `batch_size == 0` or `num_epochs == 0`.
-/// * [`TuneError::Training`] – A sample references a `(layer_idx, module)` pair
+/// * [`TuneError::Training`]          – `samples` is empty.
+/// * [`TuneError::InvalidConfig`]     – `batch_size == 0` or `num_epochs == 0`.
+/// * [`TuneError::Training`]          – A sample references a `(layer_idx, module)` pair
 ///   that is not present in the adapter.
 /// * [`TuneError::DimensionMismatch`] – A sample's `input` or `target_delta` has the
 ///   wrong length for its LoRA layer.
@@ -83,11 +110,22 @@ pub fn train_lora(
         ));
     }
 
+    match &config.optimizer {
+        None => train_lora_sgd(adapter, samples, config),
+        Some(opt_cfg) => train_lora_adam(adapter, samples, config, opt_cfg),
+    }
+}
+
+/// SGD path — delegates to `adapt_step` for backward compatibility.
+fn train_lora_sgd(
+    adapter: &mut LoraAdapter,
+    samples: &[TrainSample],
+    config: &LoraTrainConfig,
+) -> Result<TrainResult, TuneError> {
     let mut epoch_losses = Vec::with_capacity(config.num_epochs);
 
     for _ in 0..config.num_epochs {
         let mut epoch_loss_sum = 0.0f32;
-
         for sample in samples {
             let step_result = adapt_step(
                 adapter,
@@ -99,20 +137,118 @@ pub fn train_lora(
             )?;
             epoch_loss_sum += step_result.loss;
         }
-
-        let avg = epoch_loss_sum / samples.len() as f32;
-        epoch_losses.push(avg);
+        epoch_losses.push(epoch_loss_sum / samples.len() as f32);
     }
 
-    let final_loss = *epoch_losses
-        .last()
-        .expect("num_epochs > 0 guaranteed above");
-    let total_steps = config.num_epochs * samples.len();
-
+    let final_loss = *epoch_losses.last().expect("num_epochs > 0");
     Ok(TrainResult {
         final_loss,
         epoch_losses,
-        total_steps,
+        total_steps: config.num_epochs * samples.len(),
+    })
+}
+
+/// Adam / AdamW path.
+fn train_lora_adam(
+    adapter: &mut LoraAdapter,
+    samples: &[TrainSample],
+    config: &LoraTrainConfig,
+    opt_cfg: &OptimizerConfig,
+) -> Result<TrainResult, TuneError> {
+    let decoupled = matches!(opt_cfg.optimizer, Optimizer::AdamW);
+    let base_lr = opt_cfg.learning_rate;
+
+    let mut adam = AdamState::new();
+    let mut epoch_losses = Vec::with_capacity(config.num_epochs);
+    let mut global_step: usize = 0;
+
+    for epoch in 0..config.num_epochs {
+        let mut epoch_loss_sum = 0.0f32;
+
+        for sample in samples {
+            // Effective LR from optional schedule.
+            let lr = if let Some(sched) = &config.lr_schedule {
+                sched.get_lr(base_lr, global_step, epoch)
+            } else {
+                base_lr
+            };
+
+            // Compute gradients without touching weights.
+            let mut grads = compute_lora_gradients(
+                adapter,
+                sample.layer_idx,
+                &sample.module,
+                &sample.input,
+                &sample.target_delta,
+            )?;
+
+            epoch_loss_sum += grads.loss;
+
+            // Optional gradient clipping by global L2 norm.
+            if let Some(max_norm) = config.grad_clip_norm {
+                let sq_sum: f32 = grads
+                    .grad_b
+                    .iter()
+                    .chain(grads.grad_a.iter())
+                    .map(|g| g * g)
+                    .sum();
+                let norm = sq_sum.sqrt();
+                if norm > max_norm {
+                    let scale = max_norm / (norm + 1e-8);
+                    for g in grads.grad_b.iter_mut().chain(grads.grad_a.iter_mut()) {
+                        *g *= scale;
+                    }
+                }
+            }
+
+            // Apply Adam update to B and A parameters for this layer.
+            let key = &(sample.layer_idx, sample.module.clone());
+            let lora = adapter.layers.get_mut(key).ok_or_else(|| {
+                TuneError::Training(format!(
+                    "no LoRA layer for ({}, {})",
+                    sample.layer_idx, sample.module
+                ))
+            })?;
+
+            let key_b = format!("{}_{}_b", sample.layer_idx, sample.module);
+            let key_a = format!("{}_{}_a", sample.layer_idx, sample.module);
+
+            adam.step(
+                &key_b,
+                &mut lora.b,
+                &grads.grad_b,
+                lr,
+                opt_cfg.beta1,
+                opt_cfg.beta2,
+                opt_cfg.epsilon,
+                opt_cfg.weight_decay,
+                decoupled,
+            );
+            // Decrement step counter so A and B share the same effective step t.
+            adam.t -= 1;
+            adam.step(
+                &key_a,
+                &mut lora.a,
+                &grads.grad_a,
+                lr,
+                opt_cfg.beta1,
+                opt_cfg.beta2,
+                opt_cfg.epsilon,
+                opt_cfg.weight_decay,
+                decoupled,
+            );
+
+            global_step += 1;
+        }
+
+        epoch_losses.push(epoch_loss_sum / samples.len() as f32);
+    }
+
+    let final_loss = *epoch_losses.last().expect("num_epochs > 0");
+    Ok(TrainResult {
+        final_loss,
+        epoch_losses,
+        total_steps: config.num_epochs * samples.len(),
     })
 }
 
@@ -169,16 +305,23 @@ mod tests {
             .collect()
     }
 
+    fn sgd_config(learning_rate: f32, num_epochs: usize) -> LoraTrainConfig {
+        LoraTrainConfig {
+            learning_rate,
+            num_epochs,
+            batch_size: 5,
+            optimizer: None,
+            lr_schedule: None,
+            grad_clip_norm: None,
+        }
+    }
+
     #[test]
     fn test_train_convergence() {
         let mut adapter = make_small_adapter();
         let samples = make_samples(5);
 
-        let config = LoraTrainConfig {
-            learning_rate: 0.01,
-            num_epochs: 10,
-            batch_size: 5,
-        };
+        let config = sgd_config(0.01, 10);
 
         let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
 
@@ -199,6 +342,9 @@ mod tests {
             learning_rate: 0.01,
             num_epochs: 5,
             batch_size: 1,
+            optimizer: None,
+            lr_schedule: None,
+            grad_clip_norm: None,
         };
 
         let err =
@@ -223,6 +369,9 @@ mod tests {
             learning_rate: 0.01,
             num_epochs: 1,
             batch_size: 1,
+            optimizer: None,
+            lr_schedule: None,
+            grad_clip_norm: None,
         };
 
         let err = train_lora(&mut adapter, &bad_samples, &config)
@@ -238,11 +387,7 @@ mod tests {
         let mut adapter = make_small_adapter();
         let samples = make_samples(5);
 
-        let config = LoraTrainConfig {
-            learning_rate: 0.01,
-            num_epochs: 3,
-            batch_size: 5,
-        };
+        let config = sgd_config(0.01, 3);
 
         let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
 

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -112,7 +112,18 @@ pub fn train_lora(
 
     match &config.optimizer {
         None => train_lora_sgd(adapter, samples, config),
-        Some(opt_cfg) => train_lora_adam(adapter, samples, config, opt_cfg),
+        Some(opt_cfg) => {
+            use crate::train::Optimizer;
+            match &opt_cfg.optimizer {
+                Optimizer::Adam | Optimizer::AdamW => {
+                    train_lora_adam(adapter, samples, config, opt_cfg)
+                }
+                unsupported => Err(TuneError::InvalidConfig(format!(
+                    "optimizer variant '{unsupported}' is not supported by train_lora; \
+                     use Adam or AdamW, or set optimizer to None for SGD"
+                ))),
+            }
+        }
     }
 }
 
@@ -393,5 +404,44 @@ mod tests {
 
         assert_eq!(result.total_steps, 15, "3 epochs × 5 samples = 15 steps");
         assert_eq!(result.epoch_losses.len(), 3, "one loss entry per epoch");
+    }
+
+    #[test]
+    fn test_unsupported_optimizer_returns_invalid_config() {
+        use crate::train::{Optimizer, OptimizerConfig};
+
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(2);
+
+        for variant in [
+            OptimizerConfig {
+                optimizer: Optimizer::SGD,
+                ..OptimizerConfig::default()
+            },
+            OptimizerConfig {
+                optimizer: Optimizer::SGDMomentum,
+                ..OptimizerConfig::default()
+            },
+            OptimizerConfig {
+                optimizer: Optimizer::RMSprop,
+                ..OptimizerConfig::default()
+            },
+        ] {
+            let name = variant.optimizer.to_string();
+            let config = LoraTrainConfig {
+                learning_rate: 0.01,
+                num_epochs: 1,
+                batch_size: 1,
+                optimizer: Some(variant),
+                lr_schedule: None,
+                grad_clip_norm: None,
+            };
+            let err = train_lora(&mut adapter, &samples, &config)
+                .expect_err("unsupported optimizer must return Err");
+            assert!(
+                matches!(err, TuneError::InvalidConfig(_)),
+                "expected InvalidConfig for optimizer '{name}', got {err:?}"
+            );
+        }
     }
 }

--- a/scripts/bench_all.sh
+++ b/scripts/bench_all.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run all synthetic benchmarks (no model weights required).
+# Usage: ./scripts/bench_all.sh [--save DIR]
+#
+# Skips: e2e_bench, metal_decode_bench (require model weights)
+
+SAVE_DIR="${1:-.}"
+TIMESTAMP=$(date -Iseconds)
+
+echo "=== Lattice Benchmark Suite ==="
+echo "Date: $TIMESTAMP"
+echo "Platform: $(uname -m) / $(uname -s)"
+echo ""
+
+INFERENCE_BENCHES=(
+    inference_bench
+    inference_perf
+    attention_bench
+    compute_attention_bench
+    decode_attn_bench
+    differential_attention_bench
+    gated_attention_bench
+    native_sparse_attention_bench
+    kv_cache_layout_bench
+    tokenizer_bench
+    topk_readback
+    mtp_decode
+)
+
+EMBED_BENCHES=(
+    simd
+    simd_bench
+    embeddings
+)
+
+echo "--- inference benches ---"
+for bench in "${INFERENCE_BENCHES[@]}"; do
+    echo ">> $bench"
+    RUSTC_WRAPPER= cargo bench -p lattice-inference --bench "$bench" 2>&1 || echo "FAILED: $bench"
+    echo ""
+done
+
+echo "--- embed benches ---"
+for bench in "${EMBED_BENCHES[@]}"; do
+    echo ">> $bench"
+    RUSTC_WRAPPER= cargo bench -p lattice-embed --bench "$bench" 2>&1 || echo "FAILED: $bench"
+    echo ""
+done
+
+echo "=== Done ==="

--- a/scripts/bench_apples_precise.sh
+++ b/scripts/bench_apples_precise.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Precise apples-to-apples decode benchmark — reduced noise edition.
+#
+# Differences from bench_apples_to_apples.sh:
+#   - 15 runs instead of 5, with 2 warmup runs excluded
+#   - N1=64, N2=512 for longer decode windows (more signal, less prefill noise)
+#   - Trimmed mean: drops highest and lowest 2 values
+#   - Reports 95% CI from the trimmed set
+#   - Warns if concurrent GPU processes detected
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+LAT_BIN="$REPO/target/release/bench_decode_ab"
+MODEL_DIR="$HOME/.lattice/models/qwen3.5-0.8b"
+N1=64
+N2=512
+TOTAL_RUNS=15
+WARMUP=2
+PROMPT="The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
+OUT="$REPO/target/bench_results"
+mkdir -p "$OUT"
+DATA="$OUT/precise_raw.tsv"
+: > "$DATA"
+
+# Warn about concurrent GPU load
+GPU_PROCS=$(ps aux | grep -E "li play|mlx|ollama" | grep -v grep | wc -l | tr -d ' ')
+if [ "$GPU_PROCS" -gt 0 ]; then
+  echo "⚠  $GPU_PROCS concurrent GPU processes detected — results may have elevated noise"
+fi
+
+echo "=== Precise decode bench | Qwen3.5-0.8B | N1=$N1 N2=$N2 runs=$TOTAL_RUNS (warmup=$WARMUP) ==="
+
+# ---- Lattice ----
+if [[ -x "$LAT_BIN" ]]; then
+  # Warmup
+  for _ in $(seq 1 $WARMUP); do
+    BENCH_N=$N2 BENCH_RUNS=1 LATTICE_MODEL_DIR="$MODEL_DIR" "$LAT_BIN" 2>/dev/null >/dev/null
+  done
+  RUNS=$((TOTAL_RUNS - WARMUP))
+  for N in $N1 $N2; do
+    BENCH_N=$N BENCH_RUNS=$RUNS LATTICE_MODEL_DIR="$MODEL_DIR" "$LAT_BIN" 2>/dev/null \
+    | awk -v N=$N '/^RESULT/{
+        for(i=1;i<=NF;i++){split($i,kv,"="); v[kv[1]]=kv[2]}
+        printf "lattice\t%s\t%d\t%.6f\t\n", N, ++r, v["total_ms"]/1000.0
+      }' >> "$DATA"
+  done
+  echo "  lattice: done ($RUNS measured runs)"
+else
+  echo "  lattice: BIN MISSING ($LAT_BIN)"
+fi
+
+# ---- Ollama ----
+if command -v ollama >/dev/null 2>&1; then
+  ollama list 2>/dev/null | grep -q "qwen3.5:0.8b" || ollama pull qwen3.5:0.8b >/dev/null 2>&1
+  curl -s localhost:11434/api/tags >/dev/null 2>&1 || { ollama serve >/dev/null 2>&1 & sleep 3; }
+  # Warmup
+  for _ in $(seq 1 $WARMUP); do
+    curl -s localhost:11434/api/generate -d "{\"model\":\"qwen3.5:0.8b\",\"prompt\":$(python3 -c "import json;print(json.dumps('$PROMPT'))"),\"stream\":false,\"options\":{\"num_predict\":$N2,\"temperature\":0}}" >/dev/null
+  done
+  RUNS=$((TOTAL_RUNS - WARMUP))
+  for N in $N1 $N2; do
+    for run in $(seq 1 $RUNS); do
+      R=$(curl -s localhost:11434/api/generate -d "{\"model\":\"qwen3.5:0.8b\",\"prompt\":$(python3 -c "import json;print(json.dumps('$PROMPT'))"),\"stream\":false,\"options\":{\"num_predict\":$N,\"temperature\":0}}")
+      echo "$R" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+tot=d.get('total_duration',0)/1e9
+ec=d.get('eval_count',0); ed=d.get('eval_duration',1)/1e9
+print(f'ollama\t$N\t$run\t{tot:.6f}\t{ec/ed:.3f}')" >> "$DATA"
+    done
+  done
+  echo "  ollama: done ($RUNS measured runs)"
+else
+  echo "  ollama: not installed — skipped"
+fi
+
+# ---- MLX ----
+uv run --quiet --with mlx-lm python3 - "$MODEL_DIR" "$N1" "$N2" "$TOTAL_RUNS" "$WARMUP" "$PROMPT" <<'PY' >> "$DATA" 2>/dev/null
+import sys, time
+mdir, n1, n2 = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+total_runs, warmup = int(sys.argv[4]), int(sys.argv[5])
+prompt = sys.argv[6]
+import mlx.core as mx, mlx.nn as nn
+from mlx_lm import load, generate
+from mlx_lm.sample_utils import make_sampler
+try:
+    model, tok = load(mdir)
+except Exception:
+    model, tok = load("Qwen/Qwen3.5-0.8B")
+nn.quantize(model, bits=8, group_size=64); mx.eval(model.parameters())
+samp = make_sampler(temp=0.0)
+# Warmup
+for _ in range(warmup):
+    generate(model, tok, prompt=prompt, max_tokens=n2, sampler=samp, verbose=False)
+runs = total_runs - warmup
+for N in (n1, n2):
+    for run in range(1, runs+1):
+        t0=time.time()
+        generate(model, tok, prompt=prompt, max_tokens=N, sampler=samp, verbose=False)
+        dt=time.time()-t0
+        print(f"mlx\t{N}\t{run}\t{dt:.6f}\t")
+PY
+echo "  mlx: done"
+
+# ---- Analysis: trimmed mean + CI ----
+python3 - "$DATA" "$N1" "$N2" <<'PY'
+import sys, statistics as st, collections, math
+data, N1, N2 = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+rows=collections.defaultdict(lambda: collections.defaultdict(list))
+nat=collections.defaultdict(list)
+for ln in open(data):
+    p=ln.rstrip("\n").split("\t")
+    if len(p)<4 or not p[3]: continue
+    eng,N,_,tot=p[0],int(p[1]),p[2],float(p[3])
+    rows[eng][N].append(tot)
+    if len(p)>=5 and p[4]: nat[eng].append(float(p[4]))
+
+def trimmed_stats(vals, trim=2):
+    """Trimmed mean + 95% CI from the middle values."""
+    s = sorted(vals)
+    if len(s) <= 2*trim:
+        return st.mean(s), 0, s
+    trimmed = s[trim:-trim]
+    m = st.mean(trimmed)
+    if len(trimmed) > 1:
+        se = st.stdev(trimmed) / math.sqrt(len(trimmed))
+        ci95 = 1.96 * se
+    else:
+        ci95 = 0
+    return m, ci95, trimmed
+
+print(f"\n{'engine':<10}{'slope tok/s':>13}{'±95% CI':>10}{'spread%':>10}{'native':>10}   (trimmed mean, {len(rows.get('lattice',{}).get(N2,[]))} runs)")
+print("-"*64)
+res={}
+for eng in ("lattice","mlx","ollama"):
+    if N1 not in rows[eng] or N2 not in rows[eng]:
+        print(f"{eng:<10}{'(no data)':>13}"); continue
+    t1_mean, t1_ci, t1_vals = trimmed_stats(rows[eng][N1])
+    t2_mean, t2_ci, t2_vals = trimmed_stats(rows[eng][N2])
+    dt = t2_mean - t1_mean
+    slope = (N2-N1)/dt if dt > 0 else float('nan')
+    # Propagate CI
+    slope_ci = slope * math.sqrt((t1_ci/t1_mean)**2 + (t2_ci/t2_mean)**2) if t1_mean > 0 and t2_mean > 0 else 0
+    spread = (max(t2_vals)-min(t2_vals))/t2_mean*100 if t2_vals else 0
+    native = st.median(nat[eng]) if nat[eng] else float('nan')
+    res[eng] = (slope, slope_ci)
+    ns = f"{native:10.1f}" if native==native else f"{'—':>10}"
+    print(f"{eng:<10}{slope:13.1f}{slope_ci:10.1f}{spread:9.1f}%{ns}")
+print("-"*64)
+if "lattice" in res and "mlx" in res:
+    ls, lci = res["lattice"]; ms, mci = res["mlx"]
+    gap = (1 - ls/ms)*100 if ms > 0 else float('nan')
+    print(f"\nLattice vs MLX: {gap:.1f}% slower (±{lci:.1f}/{mci:.1f} tok/s CI)")
+if "lattice" in res and "ollama" in res:
+    ls, lci = res["lattice"]; os_, oci = res["ollama"]
+    adv = (ls/os_ - 1)*100 if os_ > 0 else float('nan')
+    print(f"Lattice vs Ollama: {adv:.1f}% faster")
+print(f"\nRaw: {data}")
+PY


### PR DESCRIPTION
## Summary
- **CPU SIMD**: NEON polynomial exp (3.1x silu), 4x unrolling (GELU, softmax, rms_norm, elementwise_mul), NEON decode attention, fast rsqrt, batch SDOT
- **Embed SIMD**: 27x int8 cosine speedup (debug_assert fix), 6.3x batch cosine (SIMD norms), SDOT asm for i8 dot product
- **Metal GPU**: Fixed 3 pre-existing compile errors, zero-copy greedy argmax, gate+up MLP weight fusion
- **Tests**: 6 SIMD/scalar parity regression tests, training optimizer tests
- **Benchmarks**: bench_all.sh, elementwise bench suite, decode attention bench

## Performance (elementwise, M2 Max)
| Op | Before | After | Speedup |
|---|---|---|---|
| silu/4096 | 6.54µs | 2.04µs | 3.2x |
| rms_norm/4096 | 12.88µs | 4.53µs | 2.8x |
| int8 cosine (384) | 282ns | 10.5ns | 27x |
| batch cosine (384) | 6.29µs | 1.00µs | 6.3x |

## E2E decode (Qwen3.5-0.8B, M2 Max)
| Engine | tok/s |
|---|---|
| Lattice | 150 |
| MLX | 260 |
| Ollama | 82 |

## Test plan
- [x] `cargo test -p lattice-inference` — 781 pass
- [x] `cargo test -p lattice-embed` — 305 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `bench_apples_to_apples.sh` — validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)