### PR TITLE
feat(ci): ADR-058 CPU perf regression tracking

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -1,0 +1,155 @@
+name: bench-regression
+# ADR-058 — PR gate: run CPU benches against the perf-baselines branch and
+# fail if any bench regresses >7% with 95% CI confirmation.
+#
+# Bypass via PR label `bench-allow-regression` (the gate job is skipped).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/inference/src/forward/cpu/**'
+      - 'crates/inference/src/attention/**'
+      - 'crates/inference/benches/elementwise_cpu_bench.rs'
+      - 'crates/inference/benches/attention_bench.rs'
+      - 'crates/inference/Cargo.toml'
+      - 'crates/embed/src/simd/**'
+      - 'crates/embed/benches/simd.rs'
+      - 'crates/embed/Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/bench-regression.yml'
+      - 'scripts/perf-bench-gate.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write  # to post the report comment
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+
+jobs:
+  gate:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'bench-allow-regression') }}
+    name: gate (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    # ADR-058 step 3: keep in advisory mode for the first 7 days, then remove.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            arch: aarch64-linux
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: bench-${{ matrix.arch }}
+
+      - name: Fetch perf-baselines (or skip if missing)
+        id: fetch_baseline
+        run: |
+          if git ls-remote --exit-code https://github.com/${{ github.repository }} perf-baselines >/dev/null 2>&1; then
+            git fetch --depth=1 https://github.com/${{ github.repository }} perf-baselines:perf-baselines
+            mkdir -p .perf-baselines
+            git --work-tree=.perf-baselines checkout perf-baselines -- "${{ matrix.arch }}" 2>/dev/null || true
+            if [ -d ".perf-baselines/${{ matrix.arch }}" ]; then
+              echo "have_baseline=true" >> "$GITHUB_OUTPUT"
+              mkdir -p target/criterion
+              cp -r ".perf-baselines/${{ matrix.arch }}/." target/criterion/
+            else
+              echo "have_baseline=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "have_baseline=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build benches
+        run: |
+          cargo bench -p lattice-inference --bench elementwise_cpu_bench --no-run
+          cargo bench -p lattice-embed --bench simd --no-run
+
+      - name: Run benches against baseline
+        if: steps.fetch_baseline.outputs.have_baseline == 'true'
+        run: |
+          cargo bench -p lattice-inference --bench elementwise_cpu_bench -- --baseline base --noplot
+          cargo bench -p lattice-embed --bench simd -- --baseline base --noplot
+
+      - name: Run benches without baseline (seed)
+        if: steps.fetch_baseline.outputs.have_baseline == 'false'
+        run: |
+          cargo bench -p lattice-inference --bench elementwise_cpu_bench -- --save-baseline base --noplot
+          cargo bench -p lattice-embed --bench simd -- --save-baseline base --noplot
+
+      - name: Apply gate
+        id: gate
+        if: steps.fetch_baseline.outputs.have_baseline == 'true'
+        run: |
+          python3 scripts/perf-bench-gate.py target/criterion "${{ matrix.arch }}" \
+            --out report-${{ matrix.arch }}.md \
+          && echo "gate=pass" >> "$GITHUB_OUTPUT" \
+          || echo "gate=fail" >> "$GITHUB_OUTPUT"
+
+      - name: Note seed run
+        if: steps.fetch_baseline.outputs.have_baseline == 'false'
+        run: |
+          mkdir -p .
+          cat > report-${{ matrix.arch }}.md <<EOF
+          ### \`${{ matrix.arch }}\` — no baseline available
+
+          The \`perf-baselines\` branch has no data for this arch yet. Run
+          \`bench-update.yml\` on \`main\` to seed it. This PR is not gated.
+          EOF
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-report-${{ matrix.arch }}
+          path: report-${{ matrix.arch }}.md
+
+      - name: Fail if gate failed
+        if: steps.gate.outputs.gate == 'fail'
+        run: exit 1
+
+  comment:
+    name: post PR comment
+    needs: gate
+    if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'bench-allow-regression') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: reports/
+          pattern: bench-report-*
+
+      - name: Compose comment
+        id: compose
+        run: |
+          {
+            echo "## Perf regression report (ADR-058)"
+            echo
+            for f in reports/bench-report-*/report-*.md; do
+              [ -f "$f" ] && cat "$f" && echo
+            done
+            echo
+            echo "_Gate is in advisory mode (Rollout step 3, ADR-058 §Rollout). Failures do not block merge for the first 7 days._"
+          } > body.md
+          {
+            echo "body<<EOF"
+            cat body.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post / update comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: bench-regression
+          message: ${{ steps.compose.outputs.body }}

--- a/.github/workflows/bench-update.yml
+++ b/.github/workflows/bench-update.yml
@@ -1,0 +1,170 @@
+name: bench-update
+# ADR-058 — runs CPU benches on `main` and updates the `perf-baselines` orphan branch.
+# Triggers:
+#   - push to main with relevant path changes
+#   - weekly cron (Mon 06:00 UTC) to refresh baselines even without code change
+#   - manual workflow_dispatch (used to seed the branch the first time)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/inference/src/forward/cpu/**'
+      - 'crates/inference/src/attention/**'
+      - 'crates/inference/benches/elementwise_cpu_bench.rs'
+      - 'crates/inference/benches/attention_bench.rs'
+      - 'crates/inference/Cargo.toml'
+      - 'crates/embed/src/simd/**'
+      - 'crates/embed/benches/simd.rs'
+      - 'crates/embed/Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/bench-update.yml'
+      - 'scripts/perf-bench-snapshot.py'
+      - 'scripts/perf-baselines-readme.py'
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write  # required to push the orphan perf-baselines branch
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+
+jobs:
+  bench:
+    name: bench (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            arch: aarch64-linux
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need history for commit SHA + dates
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: bench-${{ matrix.arch }}
+
+      - name: Build benches
+        run: |
+          cargo bench -p lattice-inference --bench elementwise_cpu_bench --no-run
+          cargo bench -p lattice-embed --bench simd --no-run
+
+      - name: Run benches (save baseline)
+        run: |
+          cargo bench -p lattice-inference --bench elementwise_cpu_bench -- --save-baseline base --noplot
+          cargo bench -p lattice-embed --bench simd -- --save-baseline base --noplot
+
+      - name: Snapshot to history JSON
+        run: |
+          mkdir -p artifacts
+          python3 scripts/perf-bench-snapshot.py \
+            target/criterion \
+            "${{ matrix.arch }}" \
+            "${{ github.sha }}" \
+            --out artifacts/snapshot.json
+
+      - name: Upload baseline + snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-data-${{ matrix.arch }}
+          path: |
+            target/criterion/**
+            artifacts/snapshot.json
+          retention-days: 14
+
+  publish:
+    name: publish to perf-baselines
+    needs: bench
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (for scripts)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Save scripts from main
+        run: |
+          mkdir -p .keep
+          cp scripts/perf-bench-snapshot.py scripts/perf-baselines-readme.py .keep/
+
+      - name: Fetch or create perf-baselines (separate checkout)
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if git ls-remote --exit-code origin perf-baselines >/dev/null 2>&1; then
+            git clone --depth=200 --branch=perf-baselines \
+              "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
+              .perf-baselines
+          else
+            git clone --depth=1 \
+              "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
+              .perf-baselines
+            cd .perf-baselines
+            git checkout --orphan perf-baselines
+            git rm -rf . 2>/dev/null || true
+            mkdir -p history
+            echo "# perf-baselines (auto-managed by bench-update.yml)" > README.md
+            git add README.md history
+            git commit -m "init perf-baselines orphan branch"
+            git push origin perf-baselines
+            cd ..
+          fi
+
+      - name: Download all bench artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: bench-artifacts/
+
+      - name: Stage baselines + history snapshots
+        run: |
+          set -e
+          for arch in x86_64-linux aarch64-linux; do
+            src="bench-artifacts/bench-data-$arch"
+            if [ ! -d "$src" ]; then
+              echo "no artifacts for $arch — skipping"
+              continue
+            fi
+
+            # Copy criterion baseline data into <arch>/<bench>/<test>/base/
+            mkdir -p ".perf-baselines/$arch"
+            if [ -d "$src/target/criterion" ]; then
+              rsync -a --delete "$src/target/criterion/" ".perf-baselines/$arch/"
+            fi
+
+            # Append history snapshot
+            ts=$(date -u +%Y%m%dT%H%M%S)
+            short_sha=$(echo "${GITHUB_SHA}" | cut -c1-7)
+            cp "$src/artifacts/snapshot.json" \
+               ".perf-baselines/history/${ts}_${short_sha}_${arch}.json"
+          done
+
+      - name: Regenerate README
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python3 .keep/perf-baselines-readme.py .perf-baselines
+
+      - name: Commit + push perf-baselines
+        run: |
+          cd .perf-baselines
+          git add -A
+          if git diff --cached --quiet; then
+            echo "no changes to perf-baselines"
+            exit 0
+          fi
+          short_sha=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          git commit -m "bench: baseline update for main@${short_sha}"
+          git push origin perf-baselines

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check clippy test fmt fmt-check build clean ci publish publish-dry lint-docs
+.PHONY: check clippy test fmt fmt-check build clean ci publish publish-dry lint-docs bench-ci bench-gate
 
 check:
 	cargo check --workspace
@@ -33,3 +33,26 @@ publish-dry:
 
 publish:
 	./scripts/publish.sh
+
+# ADR-058: run the same CPU benches CI does, save as new baseline.
+bench-ci:
+	cargo bench -p lattice-inference --bench elementwise_cpu_bench -- --save-baseline local --noplot
+	cargo bench -p lattice-embed --bench simd -- --save-baseline local --noplot
+
+# ADR-058: compare current CPU bench results against the perf-baselines branch
+# checked into ./.cache/perf-baselines. Auto-detects local arch label.
+bench-gate:
+	@if [ ! -d .cache/perf-baselines ]; then \
+		git clone --depth=1 --branch=perf-baselines \
+			$$(git remote get-url origin) .cache/perf-baselines || \
+			{ echo "no perf-baselines branch yet — run bench-update.yml on main first"; exit 1; }; \
+	else \
+		git -C .cache/perf-baselines pull --ff-only; \
+	fi
+	@arch=$$(uname -m | sed 's/arm64/aarch64/')-$$(uname -s | tr A-Z a-z); \
+		echo "arch: $$arch"; \
+		mkdir -p target/criterion; \
+		cp -r .cache/perf-baselines/$$arch/. target/criterion/ 2>/dev/null || { echo "no baseline for $$arch"; exit 1; }; \
+		cargo bench -p lattice-inference --bench elementwise_cpu_bench -- --baseline base --noplot; \
+		cargo bench -p lattice-embed --bench simd -- --baseline base --noplot; \
+		python3 scripts/perf-bench-gate.py target/criterion "$$arch-local"

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -178,5 +178,9 @@ name = "mtp_decode"
 harness = false
 required-features = ["metal-gpu", "f16"]
 
+[[bench]]
+name = "elementwise_cpu_bench"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/inference/benches/elementwise_cpu_bench.rs
+++ b/crates/inference/benches/elementwise_cpu_bench.rs
@@ -1,0 +1,177 @@
+//! Criterion benches for CPU elementwise / norm / activation / softmax kernels.
+//!
+//! Gated by ADR-058 — used as the reference baseline for the perf-regression CI
+//! workflow. The bench list is intentionally narrow: only the ops that appear
+//! in the per-token decode CPU path on hidden sizes the Qwen3.5-0.8B uses.
+//!
+//! Deterministic LCG inputs make run-to-run noise come from the runner, not
+//! from the data.
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use lattice_inference::forward::cpu::{
+    add_bias_gelu, elementwise_mul, gelu, layer_norm, rms_norm, silu_inplace, softmax_attention,
+};
+use std::time::Duration;
+
+struct Lcg(u64);
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (self.0 >> 32) as u32
+    }
+    fn next_f32(&mut self) -> f32 {
+        (self.next_u32() as f32) / (u32::MAX as f32) - 0.5
+    }
+}
+
+fn random_vec(len: usize, seed: u64) -> Vec<f32> {
+    let mut rng = Lcg::new(seed);
+    (0..len).map(|_| rng.next_f32()).collect()
+}
+
+fn bench_rms_norm(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rms_norm");
+    for hidden in [896usize, 4096] {
+        let gamma = random_vec(hidden, 1);
+        let buf_proto = random_vec(hidden, 2);
+        group.throughput(Throughput::Elements(hidden as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(hidden), &hidden, |b, &h| {
+            let mut buf = buf_proto.clone();
+            b.iter(|| {
+                rms_norm(black_box(&mut buf), black_box(&gamma), h, 1e-6);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_layer_norm(c: &mut Criterion) {
+    let mut group = c.benchmark_group("layer_norm");
+    for hidden in [896usize, 4096] {
+        let gamma = random_vec(hidden, 3);
+        let beta = random_vec(hidden, 4);
+        let buf_proto = random_vec(hidden, 5);
+        group.throughput(Throughput::Elements(hidden as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(hidden), &hidden, |b, &h| {
+            let mut buf = buf_proto.clone();
+            b.iter(|| {
+                layer_norm(
+                    black_box(&mut buf),
+                    black_box(&gamma),
+                    black_box(&beta),
+                    h,
+                    1e-6,
+                );
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_silu_inplace(c: &mut Criterion) {
+    let mut group = c.benchmark_group("silu_inplace");
+    for hidden in [896usize, 4096] {
+        let buf_proto = random_vec(hidden, 6);
+        group.throughput(Throughput::Elements(hidden as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(hidden), &hidden, |b, _| {
+            let mut buf = buf_proto.clone();
+            b.iter(|| {
+                silu_inplace(black_box(&mut buf));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_gelu(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gelu");
+    for hidden in [896usize, 4096] {
+        let buf_proto = random_vec(hidden, 7);
+        group.throughput(Throughput::Elements(hidden as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(hidden), &hidden, |b, _| {
+            let mut buf = buf_proto.clone();
+            b.iter(|| {
+                gelu(black_box(&mut buf));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_add_bias_gelu(c: &mut Criterion) {
+    let mut group = c.benchmark_group("add_bias_gelu");
+    for hidden in [896usize, 4096] {
+        let bias = random_vec(hidden, 8);
+        let buf_proto = random_vec(hidden, 9);
+        group.throughput(Throughput::Elements(hidden as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(hidden), &hidden, |b, &h| {
+            let mut buf = buf_proto.clone();
+            b.iter(|| {
+                add_bias_gelu(black_box(&mut buf), black_box(&bias), h);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_softmax_attention(c: &mut Criterion) {
+    let mut group = c.benchmark_group("softmax_attention");
+    // Buffer shape is (num_heads, seq_len, seq_len) — full attention matrix.
+    // Single-head keeps the bench focused on the kernel itself, not multi-head dispatch.
+    for seq_len in [128usize, 512] {
+        let num_heads = 1usize;
+        let total = num_heads * seq_len * seq_len;
+        let buf_proto = random_vec(total, 10);
+        group.throughput(Throughput::Elements((seq_len * seq_len) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(seq_len), &seq_len, |b, &s| {
+            let mut buf = buf_proto.clone();
+            b.iter(|| {
+                softmax_attention(black_box(&mut buf), s, num_heads);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_elementwise_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("elementwise_mul");
+    let hidden = 4096usize;
+    let b_vec = random_vec(hidden, 11);
+    let buf_proto = random_vec(hidden, 12);
+    group.throughput(Throughput::Elements(hidden as u64));
+    group.bench_with_input(
+        BenchmarkId::from_parameter(hidden),
+        &hidden,
+        |bencher, _| {
+            let mut buf = buf_proto.clone();
+            bencher.iter(|| {
+                elementwise_mul(black_box(&mut buf), black_box(&b_vec));
+            });
+        },
+    );
+    group.finish();
+}
+
+fn criterion_cfg() -> Criterion {
+    Criterion::default()
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(3))
+        .sample_size(50)
+}
+
+criterion_group! {
+    name = elementwise_cpu;
+    config = criterion_cfg();
+    targets =
+        bench_rms_norm,
+        bench_layer_norm,
+        bench_silu_inplace,
+        bench_gelu,
+        bench_add_bias_gelu,
+        bench_softmax_attention,
+        bench_elementwise_mul,
+}
+criterion_main!(elementwise_cpu);

--- a/docs/adr/ADR-058-cpu-perf-regression-ci.md
+++ b/docs/adr/ADR-058-cpu-perf-regression-ci.md
@@ -1,0 +1,247 @@
+# ADR-058: CPU Performance Regression Tracking in CI
+
+**Status**: Draft
+**Date**: 2026-05-24
+**Crate**: workspace (CI infrastructure, touches lattice-inference + lattice-embed bench surfaces)
+
+## Context
+
+The decode hot path on Apple Silicon depends on tight CPU SIMD kernels (NEON elementwise/norm ops in `crates/inference/src/forward/cpu/`, int8 dot products in `crates/embed/src/simd/quantized.rs`, decode-attention QK/softmax/V in `crates/inference/src/attention/decode.rs`). These kernels are easy to break in non-obvious ways — recent examples from PR #76 alone:
+
+1. Fused `E[x²]-E[x]²` variance in `layer_norm` introduced catastrophic cancellation on large-offset inputs; reverting to two-pass cost ~3% layer_norm throughput but was correctness-required.
+2. Restoring the `-128` validation scan on the public `dot_product_i8` entry point cost a measurable percentage of int8 throughput before being moved behind a `_dispatch` indirection.
+3. Tightening the polynomial `exp` upper clamp from 88.72 → 88.0 — no measurable impact, but easy to imagine a similar change costing 5% of softmax throughput.
+
+The end-to-end decode bench (`scripts/bench_apples_to_apples.sh`) catches macro regressions but is too noisy to attribute them: on a busy M2 Max with 5–10 concurrent `li play` processes, lattice decode throughput swings by 25% (issue #77). We cannot use noisy end-to-end numbers as a merge gate.
+
+The GPU path cannot run on GitHub Actions runners (no Metal). But the CPU paths can — and they account for elementwise activations, normalization, the int8 embed path, decode attention reductions, and the entire CPU fallback for systems without GPU acceleration.
+
+**Currently absent**: any automated mechanism to catch CPU regressions per commit. Criterion benches exist (`crates/inference/benches/elementwise_bench.rs`, `crates/embed/benches/quantized_bench.rs`, etc.) but run on-demand only, with no baseline retention or comparison gate.
+
+### Constraints
+
+- **No paid services.** Bencher.dev and similar are out. Self-hosted only.
+- **Free GitHub-hosted runners only.** No self-hosted M-series runner for now (separate decision).
+- **GH Actions noise.** Shared runners exhibit run-to-run variance; threshold must be loose enough to not flake, tight enough to catch real regressions.
+- **Cross-architecture coverage.** Both NEON (aarch64 Linux via `ubuntu-24.04-arm`) and AVX2 (x86_64 Linux via `ubuntu-latest`) must be gated separately — a regression in only one path is still a regression.
+- **Trend visibility.** Ocean wants "very granular" tracking — not just "did this PR regress" but "how has performance evolved over time."
+
+## Decision
+
+Introduce a baseline-comparing CI workflow with a version-tracked baseline branch.
+
+### D1: Baseline storage — orphan `perf-baselines` branch
+
+A long-lived orphan branch holds Criterion baseline data. Layout:
+
+```text
+perf-baselines/
+  README.md                    # human-readable trend summary, regenerated each update
+  aarch64-linux/
+    elementwise_bench/
+      base/                    # Criterion's --save-baseline=base output
+        new/estimates.json     # per-bench medians + CIs
+        ...
+    quantized_bench/
+      base/
+    decode_bench/
+      base/
+  x86_64-linux/
+    elementwise_bench/
+      base/
+    ...
+  history/
+    2026-05-24_<sha>_aarch64.json    # rolled-up summary per main commit, per arch
+    2026-05-24_<sha>_x86_64.json
+```
+
+The orphan branch contains no source code, only baseline data — never merged into main, never affected by main rebases.
+
+**Rationale**: explicit history via `git log perf-baselines`. Cheap (Criterion JSON is ~10KB per bench × ~20 benches × 2 archs = ~400KB total). Reproducible — anyone can `git checkout perf-baselines` and inspect a 30-day-old baseline. No bot tokens beyond `GITHUB_TOKEN` (built-in).
+
+### D2: Two workflows — update + gate
+
+**Workflow A: `bench-update.yml`** (runs on push to `main`)
+
+Triggers: `push` to `main`, paths-filter on CPU-relevant directories (D5 below). Plus a weekly schedule (`cron: '0 6 * * 1'`) to refresh baselines even when no relevant file changed — guards against environmental drift on the runner side.
+
+Matrix: `{ os: ubuntu-latest, arch: x86_64 }` × `{ os: ubuntu-24.04-arm, arch: aarch64 }`.
+
+Steps per matrix job:
+
+1. Checkout `main` (current SHA).
+2. Build benches in release with `RUSTFLAGS="-C target-cpu=native"` (matches `bench_apples_*.sh` settings).
+3. `cargo bench --bench <name> -- --save-baseline base --noplot`.
+4. Append summary JSON to `perf-baselines/history/<date>_<sha>_<arch>.json`.
+5. Commit + push `perf-baselines` branch (force-with-lease against itself, since it's orphan).
+
+**Workflow B: `bench-regression.yml`** (runs on PRs)
+
+Triggers: `pull_request` to `main`, paths-filter (D5).
+
+Matrix: same `{x86_64, aarch64}`.
+
+Steps per matrix job:
+
+1. Checkout PR HEAD into `./pr`.
+2. Checkout `perf-baselines` branch into `./baselines` (sparse, only the matching `<arch>-linux/` subdir).
+3. Restore `./pr/target/criterion/<bench>/base/` from `./baselines/<arch>-linux/<bench>/base/`.
+4. Build PR benches: `cargo bench --bench <name> -- --baseline base --noplot`.
+5. Parse `target/criterion/<bench>/<test>/change/estimates.json` for each bench/test pair.
+6. Apply gate logic (D3) and emit GH check + PR comment.
+
+### D3: Gate logic
+
+For each `(arch, bench, test)` triple, Criterion reports `change.estimates.mean.point_estimate` (relative change, e.g. `-0.05` = 5% faster, `+0.12` = 12% slower) along with a 95% confidence interval (`change.estimates.mean.confidence_interval.{lower,upper}_bound`).
+
+**The threshold is applied to the _lower bound_ of the 95% CI of the change, not the point estimate.** A regression "counts" only when Criterion is statistically confident that the change exceeds the threshold — eliminating most noise-driven false positives.
+
+| CI-lower-bound of change               | Action                                                                             |
+| -------------------------------------- | ---------------------------------------------------------------------------------- |
+| ≤ +3%                                  | Pass silently                                                                      |
+| +3% to +7%                             | Pass with PR-comment warning ("⚠ minor regression confirmed: ..."), no merge block |
+| > +7%                                  | Fail the check, block merge                                                        |
+| Point estimate < −3% AND CI-upper < 0% | Pass with celebratory PR comment ("🚀 confirmed improvement: ...")                 |
+
+PRs may bypass the >7% fail by applying the label `bench-allow-regression`. The PR comment must then quote the rationale (e.g. "intentional: layer_norm two-pass revert for numerical stability, see ADR-058 context"). The label is intentionally awkward to apply — protects against accidental bypass.
+
+**Why 7% on CI-lower-bound**: a naive 7% threshold on the raw point estimate would produce unacceptable flake — shared-runner variance puts the P95 of single-bench point-estimate noise around ±7%, so with ~25 measurements per workflow run the per-PR false-positive rate would approach 70%. Using the _lower bound of Criterion's own 95% CI_ requires the run to be statistically confident the regression is real before it can cross the threshold, which collapses noise-driven flakes back to <2% per PR while preserving 7% sensitivity to genuine kernel slowdowns. If observed false-positive rate is still >5% after the 7-day shadow period (D2/Rollout step 3), tighten the CI-confidence threshold from 95% → 99% rather than weakening the 7% sensitivity.
+
+**Anti-game**: the lower-bound rule means a single noisy run with a wide CI passes — but that single run also doesn't update the baseline (only push-to-main does). The PR author cannot escape a real regression by re-running until they get lucky variance; the regression remains, and a subsequent confident measurement will catch it.
+
+### D4: Bench scope (Phase 1)
+
+Phase 1 includes every bench whose result is _directly_ informative for per-token decode CPU work AND whose target code exists on `main` today. The decode-attention NEON kernels live in `crates/inference/src/attention/decode.rs` which is currently unmerged (PR #76); they enter the suite via Phase 2.
+
+| Crate     | Bench file              | Status          | Group                                                                                                                                                 |
+| --------- | ----------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| inference | `elementwise_cpu_bench` | NEW in this ADR | `rms_norm/4096`, `layer_norm/4096`, `silu_inplace/4096`, `gelu/4096`, `add_bias_gelu/4096`, `softmax_attention/{seq=128,512}`, `elementwise_mul/4096` |
+| embed     | `simd` (existing)       | EXISTING        | `simd_dot_product`, `simd_normalize`, `int8_quantization`, `int8_vs_float32_cosine`, `int8_batch_cosine`                                              |
+
+**Implementation note for `elementwise_cpu_bench`**: targets the public functions exported from `lattice_inference::forward::cpu::*` — `rms_norm`, `layer_norm`, `silu_inplace`, `gelu`, `add_bias_gelu`, `softmax_attention`, `elementwise_mul`. Deterministic LCG-seeded inputs. Two hidden sizes (4096 for the Qwen3.5-0.8B FFN dimension, 896 for the model dimension) where size variation is informative. ~120 LOC.
+
+Phase 2 (deferred until PR #76 merges): add `decode_attn_cpu_bench` covering decode-step QK dot, softmax, V accumulation kernels from `crates/inference/src/attention/decode.rs`. The bench list is config-driven (`.github/perf-benches.json`) so adding it after PR #76 lands is a one-line PR.
+
+Phase 3 (deferred): synthetic "CPU portion of one decode step" bench — sequence of `rms_norm → qkv_projection → attention → ffn → residual` on Qwen3.5-0.8B-sized buffers. Closer to end-to-end signal. Deferred because realistic buffer construction without the full model loader requires fixture work that doesn't earn its keep until Phase 1 + 2 demonstrate the workflow value.
+
+### D5: Path filters
+
+Both workflows trigger only when relevant paths change:
+
+```yaml
+paths:
+  - "crates/inference/src/forward/cpu/**"
+  - "crates/inference/src/attention/decode.rs"
+  - "crates/inference/src/attention/standard.rs"
+  - "crates/inference/benches/**"
+  - "crates/embed/src/simd/**"
+  - "crates/embed/benches/**"
+  - "Cargo.toml"
+  - "Cargo.lock"
+  - ".github/workflows/bench-*.yml"
+```
+
+Plus `workflow_dispatch` for manual runs. Plus the weekly cron on the update workflow (D2).
+
+### D6: Trend visibility — auto-generated `perf-baselines/README.md`
+
+The `bench-update.yml` workflow regenerates `perf-baselines/README.md` at the end of every run on main. The regenerator (`scripts/perf-baselines-readme.py`, lives in main and is invoked by the workflow against the checked-out `perf-baselines` branch) produces:
+
+**Section 1 — Headline (per arch)**
+
+```
+## aarch64-linux (last update: 2026-05-24 14:00 UTC, commit a1b2c3d)
+- 30-day worst regression:  +11% rms_norm/4096 (commit f9e8d7c, "perf: revert layer_norm fusion")
+- 30-day best improvement:  -23% silu_inplace/4096 (commit 4842197, "perf: 4x unroll silu NEON")
+- All-time best (current):  silu_inplace/4096 = 1.98 µs (commit 4842197, 2026-05-22)
+```
+
+**Section 2 — Sparkline table (per arch, per bench)**
+
+A markdown table where each row is a bench, each cell is one of the last 20 measurements on main. Cells render as relative throughput vs the row's all-time best, with a tiny ASCII sparkline using only block characters (▁▂▃▄▅▆▇█). Example row:
+
+```
+| silu_inplace/4096 | ▇▇▆▆▇▇▇▇▆▇▇▇▇▇▆▇▇▇█▇ | best: 1.98µs | latest: 2.04µs (+3%) |
+```
+
+**Section 3 — Per-bench drill-down (one collapsible `<details>` per bench)**
+
+Inside each, the last 30 commits with: SHA (linked to commit), date, point estimate, 95% CI bounds, change% from previous, change% from all-time best. Sortable by clicking column headers? — no, that's JS. Just sorted reverse-chronologically.
+
+**Why this shape**: renders natively on GitHub when browsing the branch. No external dependencies — only Python stdlib in the regenerator. Sparklines use Unicode block characters that render in any monospace terminal or GitHub's markdown viewer. The file is human-readable raw (in `cat`) and rich on GitHub.
+
+The regenerator is deterministic — given identical `history/` contents it produces byte-identical output, so the README only changes when the underlying data changes.
+
+### D7: Local reproduction
+
+A `make bench-ci` target builds and runs the exact same matrix locally on the developer's host (without the baseline comparison — that requires `perf-baselines` checkout). A `make bench-gate` target checks out `perf-baselines` into `./.cache/perf-baselines/`, restores the baseline for the local arch, runs benches, and prints the same change% table the CI would compute. Lets developers preview the gate before pushing.
+
+## Consequences
+
+### Positive
+
+- **Catches micro-regressions before merge.** Every SIMD kernel change is now version-tracked at the bench level.
+- **Cross-arch coverage at zero marginal cost.** GH Actions ARM runners are free; we get NEON validation that local x86 dev boxes can't provide and vice versa.
+- **Trend history is forever-queryable.** `git log perf-baselines -- aarch64-linux/elementwise_bench` shows every regression and recovery on that bench, with commit messages.
+- **No third-party dependency.** Entire stack is GH Actions + Criterion + git. Survives indefinitely without any external service.
+- **Force-pushable orphan branch never affects main.** No risk of accidentally polluting main history with bench data.
+
+### Negative
+
+- **2x bench wall time per PR** (build baseline + build current). Mitigation: `Swatinem/rust-cache` for deps; Criterion bench builds themselves are seconds, not minutes.
+- **Noise tolerance is real.** Even with a 10% threshold, ~5% of bench runs may flake-warn. The `bench-allow-regression` label and the warning band (5-10%) give an honest escape valve without weakening the hard gate.
+- **No Apple Silicon coverage in CI.** Metal GPU regressions and M-series-specific NEON behavior remain caught only by local `bench_apples_precise.sh` runs. This ADR explicitly does not solve the Apple Silicon CI problem — see Alternatives Considered §A3.
+- **Bench shape is now part of the contract.** Renaming a Criterion bench group requires updating `perf-baselines` (it'll appear as a "new bench, no baseline" rather than a regression). Document this in `perf-baselines/README.md`.
+
+### Risks
+
+- **`perf-baselines` branch corruption.** If a force-push lands wrong, baselines for all benches reset. Mitigation: keep daily history snapshots under `history/`; can restore by checking out an old commit on the perf-baselines branch.
+- **Path-filter false negatives.** A change to, say, `crates/inference/src/lib.rs` that affects inlining in a hot path won't trigger the bench. Mitigation: weekly cron baseline-refresh on main catches drift; consider expanding paths filter in Phase 2.
+- **Criterion's change-detection statistical model.** Criterion uses a Welch's t-test on samples — its `regressed` flag is more conservative than our 10% threshold. We use the raw `change.point_estimate` directly to enforce our own threshold, but we surface Criterion's verdict alongside in PR comments for cases where the t-test disagrees (e.g. very high variance in one run).
+
+## Alternatives Considered
+
+### A1: Criterion-internal regression detection only (no baseline branch)
+
+Just use `cargo bench --baseline previous` and rely on Criterion's built-in `regressed` field. Rejected because:
+
+- No trend history across commits.
+- Baseline must be re-established on every PR, doubling cost.
+- Criterion's statistical test isn't tunable per-bench — some benches need stricter thresholds than others.
+
+### A2: Bencher.dev or Codspeed (paid hosted services)
+
+Rejected by Ocean directive: "we can do it ourselves, no need to pay for these kinds of stuff."
+
+### A3: Self-hosted Apple Silicon runner
+
+Would solve the Metal GPU CI gap and give M-series-accurate NEON numbers. Rejected for now because:
+
+- Operational cost: a Mac mini M2 idle in a closet is not free (electricity, security patches, network).
+- Single point of failure: if the runner dies, all perf CI dies.
+- Security review: self-hosted runners need careful isolation from secrets.
+
+Revisit if Phase 3 (synthetic decode CPU bench) proves insufficient to catch M-series-specific issues, or if Metal GPU regressions become a recurring problem.
+
+### A4: Run benches inside the existing `ci.yml` workflow
+
+Bench wall time (~5-10 min on shared runners) would double the CI duration for every PR, even ones touching only docs or unrelated crates. The path-filter + separate workflow approach keeps perf CI off the critical path for non-CPU PRs.
+
+## Rollout
+
+1. **D-day**: merge this ADR (Draft → Accepted).
+2. **+1 day**: add `attention_bench.rs` (D4 Implementation note), implement `scripts/perf-baselines-readme.py`, implement `bench-update.yml`. Trigger `workflow_dispatch` manually to seed `perf-baselines` branch with current main as baseline for both archs.
+3. **+2 days**: implement `bench-regression.yml` in advisory mode (`continue-on-error: true`) for 7 days. Collect false-positive rate from real PRs.
+4. **+9 days**: enable gating (remove `continue-on-error`).
+5. **+30 days**: review observed flake rate:
+   - <2% flake: keep 7% threshold + 95% CI confirmation (the chosen configuration).
+   - 2-5% flake: tighten CI confirmation from 95% → 99%, keep 7% threshold.
+   - 5% flake: raise threshold to 10%, keep 95% CI. (Acknowledges hardware variance is genuinely higher than expected.)
+
+## References
+
+- Criterion JSON output schema: <https://bheisler.github.io/criterion.rs/book/user_guide/csv_output.html>
+- GitHub-hosted runner specs: <https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners>
+- ARM runner availability: <https://github.blog/2024-09-03-arm64-on-github-actions-powering-faster-more-efficient-build-systems/>
+- Issue #77 — GPU contention variance (M2 Max local bench noise)
+- PR #76 — context for catastrophic-cancellation revert (layer_norm two-pass)

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -4,33 +4,33 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 
 ## lattice-inference (ADR-001 to ADR-011, ADR-040 to ADR-053)
 
-| ADR                                            | Title                                |
-| ---------------------------------------------- | ------------------------------------ |
-| [001](ADR-001-pure-rust-transformer-engine.md) | Pure Rust Transformer Engine         |
-| [002](ADR-002-simd-dispatch.md)                | SIMD Dispatch Strategy               |
-| [003](ADR-003-safetensors-loading.md)          | SafeTensors Weight Loading           |
-| [004](ADR-004-kv-cache.md)                     | KV Cache Design                      |
-| [005](ADR-005-tokenizer-architecture.md)       | Tokenizer Architecture               |
-| [006](ADR-006-speculative-decoding.md)         | Speculative Decoding                 |
-| [007](ADR-007-rope-positional-encoding.md)     | Rotary Positional Encoding (RoPE)    |
-| [008](ADR-008-lora-injection.md)               | LoRA Injection via Trait Hook        |
-| [009](ADR-009-model-architectures.md)          | Model Architectures (BERT and Qwen3) |
-| [010](ADR-010-attention-mechanisms.md)         | Attention Mechanisms                 |
-| [011](ADR-011-sampling-strategies.md)          | Sampling Strategies                  |
-| [040](ADR-040-gated-attention.md)              | Gated Attention (G1 SDPA-Output)     |
-| [041](ADR-041-differential-attention.md)       | Differential Attention               |
-| [042](ADR-042-native-sparse-attention.md)      | Native Sparse Attention              |
-| [043](ADR-043-lora-serving-verification.md)    | LoRA Serving Verification            |
-| [044](ADR-044-quarot-rotated-quantization.md)  | QuaRot Hadamard-Rotated Quantization |
-| [045](ADR-045-quarot-lora-composition.md)      | QuaRot + LoRA Composition            |
-| [046](ADR-046-structured-output.md)            | Structured Output (JSON Schema Constrained Decoding) |
-| [047](ADR-047-paged-kv-cache.md)               | Paged KV Cache                       |
+| ADR                                            | Title                                                 |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| [001](ADR-001-pure-rust-transformer-engine.md) | Pure Rust Transformer Engine                          |
+| [002](ADR-002-simd-dispatch.md)                | SIMD Dispatch Strategy                                |
+| [003](ADR-003-safetensors-loading.md)          | SafeTensors Weight Loading                            |
+| [004](ADR-004-kv-cache.md)                     | KV Cache Design                                       |
+| [005](ADR-005-tokenizer-architecture.md)       | Tokenizer Architecture                                |
+| [006](ADR-006-speculative-decoding.md)         | Speculative Decoding                                  |
+| [007](ADR-007-rope-positional-encoding.md)     | Rotary Positional Encoding (RoPE)                     |
+| [008](ADR-008-lora-injection.md)               | LoRA Injection via Trait Hook                         |
+| [009](ADR-009-model-architectures.md)          | Model Architectures (BERT and Qwen3)                  |
+| [010](ADR-010-attention-mechanisms.md)         | Attention Mechanisms                                  |
+| [011](ADR-011-sampling-strategies.md)          | Sampling Strategies                                   |
+| [040](ADR-040-gated-attention.md)              | Gated Attention (G1 SDPA-Output)                      |
+| [041](ADR-041-differential-attention.md)       | Differential Attention                                |
+| [042](ADR-042-native-sparse-attention.md)      | Native Sparse Attention                               |
+| [043](ADR-043-lora-serving-verification.md)    | LoRA Serving Verification                             |
+| [044](ADR-044-quarot-rotated-quantization.md)  | QuaRot Hadamard-Rotated Quantization                  |
+| [045](ADR-045-quarot-lora-composition.md)      | QuaRot + LoRA Composition                             |
+| [046](ADR-046-structured-output.md)            | Structured Output (JSON Schema Constrained Decoding)  |
+| [047](ADR-047-paged-kv-cache.md)               | Paged KV Cache                                        |
 | [048](ADR-048-continuous-batching.md)          | Continuous Batching with Disaggregated Prefill/Decode |
-| [049](ADR-049-vision-encoder.md)               | Vision Encoder                       |
-| [050](ADR-050-rejection-sampling.md)           | Rejection Sampling for Speculative Decoding |
-| [051](ADR-051-quarot-mtp-rotation.md)          | QuaRot-MTP Rotation Reconciliation   |
-| [052](ADR-052-gdn-speculative-state.md)        | GDN State Management for Speculative Rollback |
-| [053](ADR-053-moe-metal-dispatch.md)            | MoE Metal Dispatch with Expert Coalescing |
+| [049](ADR-049-vision-encoder.md)               | Vision Encoder                                        |
+| [050](ADR-050-rejection-sampling.md)           | Rejection Sampling for Speculative Decoding           |
+| [051](ADR-051-quarot-mtp-rotation.md)          | QuaRot-MTP Rotation Reconciliation                    |
+| [052](ADR-052-gdn-speculative-state.md)        | GDN State Management for Speculative Rollback         |
+| [053](ADR-053-moe-metal-dispatch.md)           | MoE Metal Dispatch with Expert Coalescing             |
 
 ## lattice-embed (ADR-012 to ADR-019)
 
@@ -75,11 +75,17 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 
 ## lattice-transport (ADR-035 to ADR-039, ADR-055)
 
-| ADR                                    | Title                             |
-| -------------------------------------- | --------------------------------- |
-| [035](ADR-035-sinkhorn-solver.md)      | Sinkhorn-Knopp Balanced OT Solver |
-| [036](ADR-036-log-domain-stability.md) | Log-Domain Numerical Stability    |
-| [037](ADR-037-cost-matrices.md)        | Cost Matrix Abstractions          |
-| [038](ADR-038-barycenters.md)          | Wasserstein Barycenters           |
-| [039](ADR-039-divergence-measures.md)  | Sinkhorn Divergence               |
+| ADR                                      | Title                               |
+| ---------------------------------------- | ----------------------------------- |
+| [035](ADR-035-sinkhorn-solver.md)        | Sinkhorn-Knopp Balanced OT Solver   |
+| [036](ADR-036-log-domain-stability.md)   | Log-Domain Numerical Stability      |
+| [037](ADR-037-cost-matrices.md)          | Cost Matrix Abstractions            |
+| [038](ADR-038-barycenters.md)            | Wasserstein Barycenters             |
+| [039](ADR-039-divergence-measures.md)    | Sinkhorn Divergence                 |
 | [055](ADR-055-online-drift-detection.md) | Online Distribution Drift Detection |
+
+## workspace / CI (ADR-058)
+
+| ADR                                      | Title                                     |
+| ---------------------------------------- | ----------------------------------------- |
+| [058](ADR-058-cpu-perf-regression-ci.md) | CPU Performance Regression Tracking in CI |

--- a/scripts/perf-baselines-readme.py
+++ b/scripts/perf-baselines-readme.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Regenerate perf-baselines/README.md from history/ snapshots.
+
+Run on the orphan `perf-baselines` branch after `bench-update.yml` adds a new
+snapshot. Reads every `history/<timestamp>_<sha>_<arch>.json`, produces a
+trend-rich README that renders natively on GitHub.
+
+Sparklines use Unicode block characters (▁▂▃▄▅▆▇█), 8-step quantized.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+SPARK_CHARS = "▁▂▃▄▅▆▇█"
+HISTORY_DEPTH_SPARK = 20
+HISTORY_DEPTH_DRILL = 30
+HEADLINE_WINDOW_DAYS = 30
+GITHUB_REPO_ENV = "GITHUB_REPOSITORY"  # owner/repo from GH Actions
+
+
+@dataclass
+class Snapshot:
+    commit: str
+    date: str           # ISO 8601
+    arch: str
+    benches: dict[str, float]   # bench_name -> ns (point estimate)
+
+
+def load_history(history_dir: Path) -> list[Snapshot]:
+    snaps: list[Snapshot] = []
+    for f in sorted(history_dir.glob("*.json")):
+        try:
+            d = json.loads(f.read_text())
+            snaps.append(Snapshot(
+                commit=d["commit"],
+                date=d["date"],
+                arch=d["arch"],
+                benches={k: v["ns"] for k, v in d["benches"].items()},
+            ))
+        except (KeyError, json.JSONDecodeError) as e:
+            print(f"warn: skipping malformed {f.name}: {e}", file=sys.stderr)
+    return snaps
+
+
+def sparkline(values: list[float]) -> str:
+    """Lower is faster, so flip: max becomes ▁ (best), min becomes █ (worst)."""
+    if not values or all(v == values[0] for v in values):
+        return SPARK_CHARS[0] * len(values)
+    vmin, vmax = min(values), max(values)
+    span = vmax - vmin
+    out = []
+    for v in values:
+        # invert: faster (smaller) = lower block
+        norm = (v - vmin) / span
+        idx = int(norm * (len(SPARK_CHARS) - 1) + 0.5)
+        idx = max(0, min(len(SPARK_CHARS) - 1, idx))
+        out.append(SPARK_CHARS[idx])
+    return "".join(out)
+
+
+def format_ns(ns: float) -> str:
+    if ns >= 1e6: return f"{ns / 1e6:.2f}ms"
+    if ns >= 1e3: return f"{ns / 1e3:.2f}µs"
+    return f"{ns:.1f}ns"
+
+
+def commit_link(sha: str) -> str:
+    repo = os.environ.get(GITHUB_REPO_ENV, "")
+    short = sha[:7]
+    if repo:
+        return f"[`{short}`](https://github.com/{repo}/commit/{sha})"
+    return f"`{short}`"
+
+
+def render_arch_section(arch: str, snaps: list[Snapshot]) -> str:
+    """Section 1+2 for a single arch."""
+    arch_snaps = [s for s in snaps if s.arch == arch]
+    arch_snaps.sort(key=lambda s: s.date)
+    if not arch_snaps:
+        return f"## `{arch}`\n\n_No history yet._\n"
+
+    latest = arch_snaps[-1]
+    out = [f"## `{arch}`\n"]
+    out.append(f"Last update: **{latest.date}**, commit {commit_link(latest.commit)}\n")
+
+    # Per-bench: best, latest, delta from best, sparkline of last N
+    bench_names = sorted({n for s in arch_snaps for n in s.benches})
+    out.append("| Bench | Trend (last 20) | Best | Latest | Δ from best |")
+    out.append("|---|---|---:|---:|---:|")
+    for bn in bench_names:
+        series = [s.benches[bn] for s in arch_snaps if bn in s.benches]
+        if not series: continue
+        best = min(series)
+        latest_val = series[-1]
+        delta = (latest_val - best) / best * 100.0
+        spark = sparkline(series[-HISTORY_DEPTH_SPARK:])
+        delta_str = f"+{delta:.1f}%" if delta >= 0 else f"{delta:.1f}%"
+        out.append(f"| `{bn}` | {spark} | {format_ns(best)} | {format_ns(latest_val)} | {delta_str} |")
+    out.append("")
+
+    # Headline regressions/improvements over last N days
+    if len(arch_snaps) >= 2:
+        worst_reg = None  # (pct, bench, snap, prev_val)
+        best_imp = None
+        for i in range(1, len(arch_snaps)):
+            for bn in arch_snaps[i].benches:
+                if bn not in arch_snaps[i - 1].benches: continue
+                cur = arch_snaps[i].benches[bn]
+                prev = arch_snaps[i - 1].benches[bn]
+                if prev == 0: continue
+                delta = (cur - prev) / prev * 100.0
+                if worst_reg is None or delta > worst_reg[0]:
+                    worst_reg = (delta, bn, arch_snaps[i], prev)
+                if best_imp is None or delta < best_imp[0]:
+                    best_imp = (delta, bn, arch_snaps[i], prev)
+        out.append("**Headlines:**")
+        if worst_reg and worst_reg[0] > 0:
+            d, bn, s, _ = worst_reg
+            out.append(f"- Worst step-regression: **+{d:.1f}%** on `{bn}` at commit {commit_link(s.commit)} ({s.date})")
+        if best_imp and best_imp[0] < 0:
+            d, bn, s, _ = best_imp
+            out.append(f"- Best step-improvement: **{d:.1f}%** on `{bn}` at commit {commit_link(s.commit)} ({s.date})")
+        out.append("")
+
+    return "\n".join(out)
+
+
+def render_drilldown(arch: str, snaps: list[Snapshot]) -> str:
+    arch_snaps = sorted([s for s in snaps if s.arch == arch], key=lambda s: s.date)
+    if not arch_snaps: return ""
+    bench_names = sorted({n for s in arch_snaps for n in s.benches})
+    out = [f"### `{arch}` per-bench history"]
+    for bn in bench_names:
+        out.append(f"<details><summary>{bn}</summary>\n")
+        out.append("| Commit | Date | ns | Δ vs prev |\n|---|---|---:|---:|")
+        history = [(s.commit, s.date, s.benches[bn]) for s in arch_snaps if bn in s.benches]
+        history = history[-HISTORY_DEPTH_DRILL:]
+        prev = None
+        for commit, date, ns in history:
+            if prev is None or prev == 0:
+                delta = "—"
+            else:
+                d = (ns - prev) / prev * 100.0
+                delta = f"+{d:.2f}%" if d >= 0 else f"{d:.2f}%"
+            out.append(f"| {commit_link(commit)} | {date} | {format_ns(ns)} | {delta} |")
+            prev = ns
+        out.append("\n</details>\n")
+    return "\n".join(out)
+
+
+def main() -> int:
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    history_dir = root / "history"
+    if not history_dir.exists():
+        print(f"error: {history_dir} does not exist", file=sys.stderr)
+        return 1
+
+    snaps = load_history(history_dir)
+    if not snaps:
+        print(f"warn: no snapshots in {history_dir}", file=sys.stderr)
+
+    archs = sorted({s.arch for s in snaps})
+
+    parts = [
+        "# Lattice CPU Perf Baselines",
+        "",
+        "_Auto-generated by `scripts/perf-baselines-readme.py` from `history/*.json`._",
+        "_See [ADR-058](../docs/adr/ADR-058-cpu-perf-regression-ci.md) for the scoring rules._",
+        "",
+        "Lower numbers are faster. Trend sparkline reads left → right (oldest → newest); "
+        "block height encodes time relative to the row's span (`▁` = fastest, `█` = slowest).",
+        "",
+    ]
+    for arch in archs:
+        parts.append(render_arch_section(arch, snaps))
+    parts.append("---\n")
+    for arch in archs:
+        parts.append(render_drilldown(arch, snaps))
+
+    out = "\n".join(parts).rstrip() + "\n"
+    (root / "README.md").write_text(out)
+    print(f"wrote {root / 'README.md'} ({len(out)} bytes, {len(snaps)} snapshots, {len(archs)} archs)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Parse Criterion change reports and apply the ADR-058 regression gate.
+
+For every Criterion bench under target/criterion/, read change/estimates.json
+(produced when running with --baseline <name>). Apply the rule:
+
+  CI-lower of change in (-inf, +3%]    : pass silently
+  CI-lower of change in (+3%, +7%]     : warn (PR-comment only, no fail)
+  CI-lower of change in (+7%, +inf)    : FAIL
+  Point estimate < -3% AND CI-upper<0% : celebrate
+
+Usage:
+  perf-bench-gate.py <criterion_root> <arch_label> [--out report.md]
+
+Exit codes:
+  0 — pass (no FAILs)
+  1 — at least one FAIL (regression > 7% confirmed by 95% CI)
+  2 — parse error / bad input
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Thresholds — ADR-058 §D3. Edit here; the workflow imports nothing else.
+WARN_PCT = 3.0   # CI-lower above this => warning
+FAIL_PCT = 7.0   # CI-lower above this => FAIL
+CELEBRATE_PCT = -3.0  # point estimate below this AND CI-upper<0 => celebrate
+
+
+@dataclass
+class BenchResult:
+    name: str            # e.g. "rms_norm/4096"
+    point: float         # change.estimates.mean.point_estimate (fraction, not %)
+    ci_low: float
+    ci_high: float
+    new_ns: float        # new median time, nanoseconds
+    old_ns: float        # baseline median time, nanoseconds
+
+    @property
+    def point_pct(self) -> float: return self.point * 100.0
+    @property
+    def ci_low_pct(self) -> float: return self.ci_low * 100.0
+    @property
+    def ci_high_pct(self) -> float: return self.ci_high * 100.0
+
+    def verdict(self) -> str:
+        if self.ci_low_pct > FAIL_PCT:
+            return "FAIL"
+        if self.ci_low_pct > WARN_PCT:
+            return "WARN"
+        if self.point_pct < CELEBRATE_PCT and self.ci_high_pct < 0:
+            return "WIN"
+        return "PASS"
+
+
+def find_change_files(root: Path) -> list[Path]:
+    """Find every change/estimates.json under root (Criterion's per-bench output)."""
+    return sorted(root.rglob("change/estimates.json"))
+
+
+def parse_bench(change_file: Path, root: Path) -> BenchResult | None:
+    """Parse one change/estimates.json + sibling new/estimates.json + base/estimates.json.
+
+    Returns None if files are malformed (bench skipped, not failed).
+    """
+    bench_dir = change_file.parent.parent  # .../<bench>/<test>/
+    rel = bench_dir.relative_to(root)
+    name = str(rel)
+
+    try:
+        change = json.loads(change_file.read_text())
+        mean = change["mean"]
+        point = mean["point_estimate"]
+        ci_low = mean["confidence_interval"]["lower_bound"]
+        ci_high = mean["confidence_interval"]["upper_bound"]
+
+        new_path = bench_dir / "new" / "estimates.json"
+        new_ns = json.loads(new_path.read_text())["mean"]["point_estimate"]
+
+        base_path = bench_dir / "base" / "estimates.json"
+        old_ns = json.loads(base_path.read_text())["mean"]["point_estimate"]
+    except (KeyError, FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"warn: skipping {name}: {e}", file=sys.stderr)
+        return None
+
+    return BenchResult(name=name, point=point, ci_low=ci_low, ci_high=ci_high,
+                       new_ns=new_ns, old_ns=old_ns)
+
+
+def render_report(results: list[BenchResult], arch: str) -> str:
+    fails = [r for r in results if r.verdict() == "FAIL"]
+    warns = [r for r in results if r.verdict() == "WARN"]
+    wins = [r for r in results if r.verdict() == "WIN"]
+
+    lines = [f"### `{arch}` — perf regression report\n"]
+    if fails:
+        lines.append(f"**❌ {len(fails)} FAIL** (regression >{FAIL_PCT}% confirmed by 95% CI)")
+    if warns:
+        lines.append(f"**⚠ {len(warns)} WARN** (regression {WARN_PCT}-{FAIL_PCT}% confirmed)")
+    if wins:
+        lines.append(f"**🚀 {len(wins)} confirmed improvement**")
+    if not (fails or warns or wins):
+        lines.append(f"✅ All {len(results)} benches within noise band (±{WARN_PCT}%)")
+    lines.append("")
+
+    if fails or warns or wins:
+        lines.append("| Bench | Δ point | 95% CI | new ns | base ns | verdict |")
+        lines.append("|---|---:|---|---:|---:|---|")
+        for r in sorted(fails + warns + wins, key=lambda r: -r.ci_low_pct):
+            icon = {"FAIL": "❌", "WARN": "⚠", "WIN": "🚀"}[r.verdict()]
+            lines.append(
+                f"| `{r.name}` | {r.point_pct:+.2f}% | [{r.ci_low_pct:+.2f}%, {r.ci_high_pct:+.2f}%] "
+                f"| {r.new_ns:.1f} | {r.old_ns:.1f} | {icon} {r.verdict()} |"
+            )
+        lines.append("")
+
+    lines.append(
+        f"<details><summary>All {len(results)} measurements</summary>\n\n"
+        "| Bench | Δ point | CI-lower | CI-upper |\n|---|---:|---:|---:|"
+    )
+    for r in sorted(results, key=lambda r: r.name):
+        lines.append(
+            f"| `{r.name}` | {r.point_pct:+.2f}% | {r.ci_low_pct:+.2f}% | {r.ci_high_pct:+.2f}% |"
+        )
+    lines.append("\n</details>\n")
+    lines.append(
+        f"_Rule: CI-lower of change ≤{WARN_PCT}% passes silently; "
+        f"({WARN_PCT}%, {FAIL_PCT}%] warns; >{FAIL_PCT}% fails. Override via PR label `bench-allow-regression`._\n"
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("criterion_root", type=Path, help="Path to target/criterion (or per-bench root)")
+    ap.add_argument("arch", help="Arch label for the report header (e.g. aarch64-linux)")
+    ap.add_argument("--out", type=Path, help="Write markdown report to this path")
+    args = ap.parse_args()
+
+    if not args.criterion_root.exists():
+        print(f"error: {args.criterion_root} does not exist", file=sys.stderr)
+        return 2
+
+    change_files = find_change_files(args.criterion_root)
+    if not change_files:
+        print(f"warn: no change/estimates.json under {args.criterion_root}; baseline missing?",
+              file=sys.stderr)
+        # Treat missing baseline as pass — first run on a bench has no comparison.
+        if args.out:
+            args.out.write_text(f"### `{args.arch}` — no baseline to compare\n\n"
+                                f"No `change/estimates.json` found; this is expected on the "
+                                f"first run for a bench. Future runs will gate against this run.\n")
+        return 0
+
+    results = []
+    for cf in change_files:
+        r = parse_bench(cf, args.criterion_root)
+        if r is not None:
+            results.append(r)
+
+    if not results:
+        print("error: change files found but all failed to parse", file=sys.stderr)
+        return 2
+
+    report = render_report(results, args.arch)
+    print(report)
+    if args.out:
+        args.out.write_text(report)
+
+    fails = sum(1 for r in results if r.verdict() == "FAIL")
+    return 1 if fails > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf-bench-snapshot.py
+++ b/scripts/perf-bench-snapshot.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Convert Criterion's per-bench output into a single history snapshot JSON.
+
+Reads target/criterion/<bench>/<test>/new/estimates.json for every bench,
+emits a flat snapshot suitable for perf-baselines/history/.
+
+Usage:
+  perf-bench-snapshot.py <criterion_root> <arch> <commit_sha> [--out path]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("criterion_root", type=Path)
+    ap.add_argument("arch", help="e.g. aarch64-linux")
+    ap.add_argument("commit", help="git SHA")
+    ap.add_argument("--out", type=Path, help="output path (default: stdout)")
+    args = ap.parse_args()
+
+    if not args.criterion_root.exists():
+        print(f"error: {args.criterion_root} missing", file=sys.stderr)
+        return 1
+
+    benches: dict[str, dict] = {}
+    for est_file in sorted(args.criterion_root.rglob("new/estimates.json")):
+        bench_dir = est_file.parent.parent
+        rel = bench_dir.relative_to(args.criterion_root)
+        name = str(rel)
+        try:
+            est = json.loads(est_file.read_text())
+            mean = est["mean"]
+            ci = mean["confidence_interval"]
+            benches[name] = {
+                "ns": mean["point_estimate"],
+                "ns_ci_low": ci["lower_bound"],
+                "ns_ci_high": ci["upper_bound"],
+            }
+        except (KeyError, json.JSONDecodeError) as e:
+            print(f"warn: skipping {name}: {e}", file=sys.stderr)
+
+    snap = {
+        "commit": args.commit,
+        "date": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+        "arch": args.arch,
+        "benches": benches,
+    }
+    text = json.dumps(snap, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text)
+        print(f"wrote {args.out} ({len(benches)} benches)")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **ADR-058** introduces CPU performance regression tracking as a CI gate, using an orphan `perf-baselines` branch for baseline storage and trend history.
- **Two workflows**: `bench-update.yml` (push-to-main + weekly cron → updates baselines on both `x86_64-linux` and `aarch64-linux`) and `bench-regression.yml` (PR gate → compares against baselines, fails at >7% regression confirmed by 95% CI lower bound).
- **Phase 1 bench scope**: `elementwise_cpu_bench` (rms_norm, layer_norm, silu, gelu, add_bias_gelu, softmax, elementwise_mul) + existing `simd` bench from lattice-embed (dot product, normalize, int8 quantization).
- **No paid services** — Criterion JSON on an orphan git branch, Python scripts for gate/snapshot/README generation.

## Key decisions

| Decision | Choice |
|---|---|
| Baseline storage | Orphan `perf-baselines` branch (version-tracked, free, queryable via `git log`) |
| Runners | `ubuntu-latest` (AVX2) + `ubuntu-24.04-arm` (NEON) |
| Threshold | >7% CI-lower-bound = FAIL, 3-7% = WARN, ≤3% = pass |
| Override | PR label `bench-allow-regression` |
| Trend visibility | Auto-generated README with sparklines, headlines, per-bench drilldown |
| Advisory period | `continue-on-error: true` for first 7 days (Rollout step 3) |

## Files added/modified

- `docs/adr/ADR-058-cpu-perf-regression-ci.md` — full ADR (Draft)
- `crates/inference/benches/elementwise_cpu_bench.rs` — Criterion bench for 7 CPU ops
- `scripts/perf-bench-gate.py` — parses Criterion output, applies 7%/CI-lower rule
- `scripts/perf-bench-snapshot.py` — converts Criterion output to history JSON
- `scripts/perf-baselines-readme.py` — generates trend README with sparklines
- `.github/workflows/bench-update.yml` — baseline updater (push-to-main + weekly)
- `.github/workflows/bench-regression.yml` — PR regression gate
- `Makefile` — `make bench-ci` / `make bench-gate` targets

## Test plan

- [x] `elementwise_cpu_bench` smoke-tested locally (all 13 measurements pass)
- [x] `perf-bench-gate.py` tested against local Criterion output
- [x] `perf-baselines-readme.py` tested on synthetic 3-commit history (sparklines render correctly)
- [ ] First `bench-update.yml` run via `workflow_dispatch` after merge to seed `perf-baselines` branch
- [ ] Monitor advisory-mode flake rate for 7 days before enabling hard gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)