### PR TITLE
feat(tune): batch LoRA training loop with Adam/AdamW optimizer

### DIFF
--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -56,6 +56,11 @@ required-features = ["safetensors", "inference-hook"]
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "train_bench"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/tune/benches/train_bench.rs
+++ b/crates/tune/benches/train_bench.rs
@@ -1,0 +1,178 @@
+//! Benchmark for the batch LoRA training loop.
+//!
+//! Measures [`train_lora`] throughput as a function of sample count (batch_size
+//! parameter is informational; the loop is sequential).
+//!
+//! Groups:
+//!   lora/train_loop    — num_epochs=5, batch_size ∈ {10, 50, 100}, SGD
+//!   lora/optimizer_cmp — SGD vs Adam vs AdamW at 50 samples, 5 epochs
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer};
+use lattice_tune::train::OptimizerConfig;
+use lattice_tune::{LoraTrainConfig, TrainSample, train_lora};
+use std::collections::HashMap;
+
+const D_IN: usize = 64;
+const D_OUT: usize = 64;
+const RANK: usize = 4;
+const NUM_EPOCHS: usize = 5;
+
+/// Build a deterministic pseudo-random f32 from two indices (no external rand crate).
+fn pseudo_f32(seed: u64, idx: u64) -> f32 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    (seed, idx).hash(&mut h);
+    // Map to (-0.5, 0.5) so the initial weights are centred.
+    h.finish() as f32 / u64::MAX as f32 - 0.5
+}
+
+fn make_adapter() -> LoraAdapter {
+    let config = LoraConfig {
+        rank: RANK,
+        alpha: RANK as f32, // scale = 1.0
+        target_modules: vec!["q_proj".into()],
+    };
+    let mut layers = HashMap::new();
+    layers.insert(
+        (0usize, "q_proj".to_string()),
+        LoraLayer {
+            // A: (rank, d_in)
+            a: (0..(RANK * D_IN))
+                .map(|i| pseudo_f32(1, i as u64) * 0.01)
+                .collect(),
+            // B: (d_out, rank)
+            b: (0..(D_OUT * RANK))
+                .map(|i| pseudo_f32(2, i as u64) * 0.01)
+                .collect(),
+            d_in: D_IN,
+            d_out: D_OUT,
+            rank: RANK,
+        },
+    );
+    LoraAdapter::new(config, layers)
+}
+
+fn make_samples(n: usize) -> Vec<TrainSample> {
+    (0..n)
+        .map(|i| TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: (0..D_IN)
+                .map(|j| pseudo_f32(3 + i as u64, j as u64))
+                .collect(),
+            target_delta: (0..D_OUT)
+                .map(|j| pseudo_f32(1000 + i as u64, j as u64) * 0.1)
+                .collect(),
+        })
+        .collect()
+}
+
+fn bench_train_loop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lora/train_loop");
+
+    for &n_samples in &[10usize, 50, 100] {
+        let samples = make_samples(n_samples);
+
+        group.bench_with_input(
+            BenchmarkId::new("num_samples", n_samples),
+            &n_samples,
+            |b, _| {
+                b.iter(|| {
+                    // Re-create adapter each iteration so weights start fresh.
+                    let mut adapter = make_adapter();
+                    let config = LoraTrainConfig {
+                        learning_rate: 0.01,
+                        num_epochs: NUM_EPOCHS,
+                        batch_size: n_samples,
+                        optimizer: None,
+                        lr_schedule: None,
+                        grad_clip_norm: None,
+                    };
+                    train_lora(
+                        black_box(&mut adapter),
+                        black_box(&samples),
+                        black_box(&config),
+                    )
+                    .expect("train_lora must not fail in bench")
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_optimizer_cmp(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lora/optimizer_cmp");
+    let samples = make_samples(50);
+
+    // SGD
+    group.bench_function("sgd", |b| {
+        b.iter(|| {
+            let mut adapter = make_adapter();
+            let config = LoraTrainConfig {
+                learning_rate: 0.01,
+                num_epochs: NUM_EPOCHS,
+                batch_size: 50,
+                optimizer: None,
+                lr_schedule: None,
+                grad_clip_norm: None,
+            };
+            train_lora(
+                black_box(&mut adapter),
+                black_box(&samples),
+                black_box(&config),
+            )
+            .expect("train_lora must not fail in bench")
+        });
+    });
+
+    // Adam
+    group.bench_function("adam", |b| {
+        b.iter(|| {
+            let mut adapter = make_adapter();
+            let config = LoraTrainConfig {
+                learning_rate: 0.01,
+                num_epochs: NUM_EPOCHS,
+                batch_size: 50,
+                optimizer: Some(OptimizerConfig::adam(0.01)),
+                lr_schedule: None,
+                grad_clip_norm: None,
+            };
+            train_lora(
+                black_box(&mut adapter),
+                black_box(&samples),
+                black_box(&config),
+            )
+            .expect("train_lora must not fail in bench")
+        });
+    });
+
+    // AdamW
+    group.bench_function("adamw", |b| {
+        b.iter(|| {
+            let mut adapter = make_adapter();
+            let config = LoraTrainConfig {
+                learning_rate: 0.01,
+                num_epochs: NUM_EPOCHS,
+                batch_size: 50,
+                optimizer: Some(OptimizerConfig::adamw(0.01, 0.01)),
+                lr_schedule: None,
+                grad_clip_norm: None,
+            };
+            train_lora(
+                black_box(&mut adapter),
+                black_box(&samples),
+                black_box(&config),
+            )
+            .expect("train_lora must not fail in bench")
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_train_loop, bench_optimizer_cmp);
+criterion_main!(benches);

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -149,7 +149,9 @@ pub use train::{
 pub use train::{GpuTrainer, GpuTrainerBuilder};
 
 // LoRA re-exports
-pub use lora::{LoraAdapter, LoraConfig, LoraLayer};
+pub use lora::{
+    LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+};
 
 // Registry re-exports
 pub use registry::{
@@ -168,7 +170,9 @@ pub mod prelude {
         LabelingResult, TeacherConfig, TeacherProvider,
     };
     pub use crate::error::{Result, TuneError};
-    pub use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    pub use crate::lora::{
+        LoraAdapter, LoraConfig, LoraLayer, LoraTrainConfig, TrainResult, TrainSample, train_lora,
+    };
     pub use crate::registry::{
         LiveModel, ModelMetadata, ModelRegistry, ModelStatus, RegisteredModel, RollbackController,
         RollbackRecord, ShadowComparison, ShadowConfig, ShadowSession, ShadowState, StorageBackend,

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -35,13 +35,17 @@
 
 mod apply;
 pub mod online;
+pub mod optimizer;
 #[cfg(feature = "safetensors")]
 mod safetensors;
+pub mod train;
 
 pub use apply::apply_lora;
 pub use online::{AdaptStepResult, adapt_step};
+pub use optimizer::{AdamState, LoraGradients, compute_lora_gradients};
 #[cfg(feature = "safetensors")]
 pub use safetensors::{load_peft_safetensors, save_peft_safetensors};
+pub use train::{LoraTrainConfig, TrainResult, TrainSample, train_lora};
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/tune/src/lora/optimizer.rs
+++ b/crates/tune/src/lora/optimizer.rs
@@ -1,0 +1,466 @@
+//! Adam and AdamW optimizers for LoRA weight updates.
+//!
+//! Provides [`AdamState`] for stateful Adam/AdamW updates and
+//! [`compute_lora_gradients`] which mirrors the forward/backward pass of
+//! [`adapt_step`](super::online::adapt_step) without applying the update.
+
+use std::collections::HashMap;
+
+use super::LoraAdapter;
+use crate::error::TuneError;
+
+/// Stateful Adam / AdamW optimizer.
+///
+/// Tracks per-parameter first and second moment estimates keyed by an
+/// arbitrary string (typically `"{layer_idx}_{module}_{param}"` where
+/// `param` is `"a"` or `"b"`).  All keys share a single global step counter
+/// `t` which is incremented on every call to [`step`](AdamState::step).
+pub struct AdamState {
+    /// First moment estimates (exponential moving average of gradients).
+    m: HashMap<String, Vec<f32>>,
+    /// Second moment estimates (exponential moving average of squared gradients).
+    v: HashMap<String, Vec<f32>>,
+    /// Global step counter (1-based: starts at 0, incremented before each bias correction).
+    pub t: usize,
+}
+
+impl AdamState {
+    /// Create a fresh optimizer state with zero moments and step counter.
+    pub fn new() -> Self {
+        Self {
+            m: HashMap::new(),
+            v: HashMap::new(),
+            t: 0,
+        }
+    }
+
+    /// Perform one Adam (or AdamW) update step on `params` in place.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Unique string key identifying this parameter tensor.
+    /// * `params` - Parameter slice to update in place.
+    /// * `grads` - Gradient slice (same length as `params`).
+    /// * `lr` - Learning rate for this step (may be scheduled externally).
+    /// * `beta1` - First moment decay (typical: 0.9).
+    /// * `beta2` - Second moment decay (typical: 0.999).
+    /// * `eps` - Numerical stability constant (typical: 1e-8).
+    /// * `weight_decay` - L2 / decoupled weight decay coefficient.
+    /// * `decoupled` - If `true`, apply AdamW-style decoupled weight decay
+    ///   (`θ -= lr * λ * θ`) before the Adam gradient step.  If `false`,
+    ///   weight_decay is unused (standard Adam).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `params.len() != grads.len()`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn step(
+        &mut self,
+        key: &str,
+        params: &mut [f32],
+        grads: &[f32],
+        lr: f32,
+        beta1: f32,
+        beta2: f32,
+        eps: f32,
+        weight_decay: f32,
+        decoupled: bool,
+    ) {
+        assert_eq!(
+            params.len(),
+            grads.len(),
+            "params and grads must have the same length"
+        );
+        let n = params.len();
+
+        // Lazily initialise moment vectors to zero.
+        let m = self
+            .m
+            .entry(key.to_string())
+            .or_insert_with(|| vec![0.0f32; n]);
+        let v = self
+            .v
+            .entry(key.to_string())
+            .or_insert_with(|| vec![0.0f32; n]);
+
+        // Increment step counter once per call (shared across all keys so that
+        // bias-correction is epoch-consistent regardless of key ordering).
+        self.t += 1;
+
+        // Bias-correction denominators.
+        let bc1 = 1.0 - beta1.powi(self.t as i32);
+        let bc2 = 1.0 - beta2.powi(self.t as i32);
+
+        for i in 0..n {
+            let g = grads[i];
+
+            // Update biased first moment: m = β₁·m + (1-β₁)·g
+            m[i] = beta1 * m[i] + (1.0 - beta1) * g;
+            // Update biased second moment: v = β₂·v + (1-β₂)·g²
+            v[i] = beta2 * v[i] + (1.0 - beta2) * g * g;
+
+            // Bias-corrected estimates.
+            let m_hat = m[i] / bc1;
+            let v_hat = v[i] / bc2;
+
+            // AdamW: decoupled weight decay applied before the gradient step.
+            if decoupled && weight_decay != 0.0 {
+                params[i] -= lr * weight_decay * params[i];
+            }
+
+            // θ -= lr · m̂ / (√v̂ + ε)
+            params[i] -= lr * m_hat / (v_hat.sqrt() + eps);
+        }
+    }
+}
+
+impl Default for AdamState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Gradient computation ────────────────────────────────────────────────────
+
+/// Gradients of the LoRA MSE loss with respect to a single layer's A and B matrices.
+#[derive(Debug)]
+pub struct LoraGradients {
+    /// Gradient with respect to B, row-major `(d_out, rank)`.
+    pub grad_b: Vec<f32>,
+    /// Gradient with respect to A, row-major `(rank, d_in)`.
+    pub grad_a: Vec<f32>,
+    /// MSE loss `||scale·B·A·input - target||²` (sum, not mean).
+    pub loss: f32,
+}
+
+/// Compute LoRA gradients without applying an update.
+///
+/// Mirrors the forward / backward arithmetic in [`adapt_step`](super::online::adapt_step)
+/// exactly, returning raw gradients instead of performing an SGD step.
+///
+/// # Forward pass
+///
+/// ```text
+/// intermediate = A @ input          (rank,)
+/// delta        = scale * B @ intermediate  (d_out,)
+/// error        = delta - target_delta
+/// loss         = ||error||²
+/// ```
+///
+/// # Backward pass
+///
+/// ```text
+/// dL/dB[i,r] = 2 · scale · error[i] · intermediate[r]
+/// dL/dA[r,j] = 2 · scale · (Bᵀ·error)[r] · input[j]
+/// ```
+///
+/// # Errors
+///
+/// * [`TuneError::Training`]          – layer `(layer_idx, module)` not found.
+/// * [`TuneError::DimensionMismatch`] – `input` or `target_delta` wrong length.
+pub fn compute_lora_gradients(
+    adapter: &LoraAdapter,
+    layer_idx: usize,
+    module: &str,
+    input: &[f32],
+    target_delta: &[f32],
+) -> Result<LoraGradients, TuneError> {
+    let scale = adapter.config.scale();
+
+    let lora = adapter
+        .layers
+        .get(&(layer_idx, module.to_string()))
+        .ok_or_else(|| TuneError::Training(format!("no LoRA layer for ({layer_idx}, {module})")))?;
+
+    let rank = lora.rank;
+    let d_in = lora.d_in;
+    let d_out = lora.d_out;
+
+    if input.len() != d_in {
+        return Err(TuneError::DimensionMismatch {
+            expected: d_in,
+            actual: input.len(),
+        });
+    }
+    if target_delta.len() != d_out {
+        return Err(TuneError::DimensionMismatch {
+            expected: d_out,
+            actual: target_delta.len(),
+        });
+    }
+
+    // Forward: intermediate = A @ input  (rank,)
+    let mut intermediate = vec![0.0f32; rank];
+    for r in 0..rank {
+        let row = &lora.a[r * d_in..(r + 1) * d_in];
+        intermediate[r] = row.iter().zip(input.iter()).map(|(a, x)| a * x).sum();
+    }
+
+    // Forward: delta = scale * B @ intermediate  (d_out,)
+    let mut delta = vec![0.0f32; d_out];
+    for i in 0..d_out {
+        let row = &lora.b[i * rank..(i + 1) * rank];
+        let acc: f32 = row
+            .iter()
+            .zip(intermediate.iter())
+            .map(|(b, h)| b * h)
+            .sum();
+        delta[i] = scale * acc;
+    }
+
+    // Residual and loss (sum of squared errors, matching adapt_step).
+    let error: Vec<f32> = delta
+        .iter()
+        .zip(target_delta.iter())
+        .map(|(d, t)| d - t)
+        .collect();
+    let loss: f32 = error.iter().map(|e| e * e).sum();
+
+    // dL/dB[i*rank + r] = 2 * scale * error[i] * intermediate[r]
+    let mut grad_b = vec![0.0f32; d_out * rank];
+    for i in 0..d_out {
+        for r in 0..rank {
+            grad_b[i * rank + r] = 2.0 * scale * error[i] * intermediate[r];
+        }
+    }
+
+    // bt_error[r] = Σ_i B[i*rank + r] * error[i]
+    let mut bt_error = vec![0.0f32; rank];
+    for r in 0..rank {
+        bt_error[r] = (0..d_out).map(|i| lora.b[i * rank + r] * error[i]).sum();
+    }
+
+    // dL/dA[r*d_in + j] = 2 * scale * bt_error[r] * input[j]
+    let mut grad_a = vec![0.0f32; rank * d_in];
+    for r in 0..rank {
+        for j in 0..d_in {
+            grad_a[r * d_in + j] = 2.0 * scale * bt_error[r] * input[j];
+        }
+    }
+
+    Ok(LoraGradients {
+        grad_b,
+        grad_a,
+        loss,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lora::train::{LoraTrainConfig, TrainSample, train_lora};
+    use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    use crate::train::OptimizerConfig;
+    use std::collections::HashMap;
+
+    /// rank=2, d_in=3, d_out=2, scale=1.0 (alpha=2.0, rank=2)
+    fn make_small_adapter() -> LoraAdapter {
+        let config = LoraConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["q_proj".into()],
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![
+                    1.0, 0.5, 0.0, // row 0
+                    0.0, 0.5, 1.0, // row 1
+                ],
+                b: vec![
+                    1.0, 0.0, // row 0
+                    0.0, 1.0, // row 1
+                ],
+                d_in: 3,
+                d_out: 2,
+                rank: 2,
+            },
+        );
+        LoraAdapter::new(config, layers)
+    }
+
+    fn make_samples(n: usize) -> Vec<TrainSample> {
+        (0..n)
+            .map(|i| {
+                let fi = i as f32;
+                TrainSample {
+                    layer_idx: 0,
+                    module: "q_proj".to_string(),
+                    input: vec![fi * 0.1 + 0.1, fi * 0.2 + 0.2, fi * 0.3 + 0.3],
+                    target_delta: vec![fi * 0.05, fi * 0.05 + 0.1],
+                }
+            })
+            .collect()
+    }
+
+    // ─── gradient computation tests ────────────────────────────────────────
+
+    #[test]
+    fn test_gradient_computation() {
+        let adapter = make_small_adapter();
+        let input = vec![1.0f32, 2.0, 3.0];
+        let target_delta = vec![5.0f32, 5.0];
+
+        let grads = compute_lora_gradients(&adapter, 0, "q_proj", &input, &target_delta)
+            .expect("compute_lora_gradients must succeed");
+
+        // grad_b shape: d_out * rank = 2 * 2 = 4
+        assert_eq!(
+            grads.grad_b.len(),
+            4,
+            "grad_b must have d_out*rank elements"
+        );
+        // grad_a shape: rank * d_in = 2 * 3 = 6
+        assert_eq!(grads.grad_a.len(), 6, "grad_a must have rank*d_in elements");
+        // Loss must be positive because delta != target.
+        assert!(grads.loss > 0.0, "loss must be positive");
+        // At least one gradient element must be non-zero.
+        assert!(
+            grads.grad_b.iter().any(|&g| g.abs() > 1e-9)
+                || grads.grad_a.iter().any(|&g| g.abs() > 1e-9),
+            "gradients must be non-zero"
+        );
+    }
+
+    #[test]
+    fn test_gradient_computation_missing_layer() {
+        let adapter = make_small_adapter();
+        let err = compute_lora_gradients(&adapter, 99, "missing", &[1.0, 2.0], &[1.0])
+            .expect_err("missing layer must return Err");
+        assert!(
+            matches!(err, TuneError::Training(_)),
+            "expected Training variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_gradient_computation_dimension_mismatch() {
+        let adapter = make_small_adapter();
+        // input too short (d_in=3, passing 2)
+        let err = compute_lora_gradients(&adapter, 0, "q_proj", &[1.0, 2.0], &[1.0, 1.0])
+            .expect_err("wrong input length must return Err");
+        assert!(
+            matches!(err, TuneError::DimensionMismatch { .. }),
+            "expected DimensionMismatch, got {err:?}"
+        );
+    }
+
+    // ─── Adam state tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_adam_step_updates_params() {
+        let mut state = AdamState::new();
+        let mut params = vec![1.0f32, 2.0, 3.0];
+        let grads = vec![0.1f32, 0.2, 0.3];
+        let original = params.clone();
+
+        state.step(
+            "test",
+            &mut params,
+            &grads,
+            0.01,
+            0.9,
+            0.999,
+            1e-8,
+            0.0,
+            false,
+        );
+
+        for (p, o) in params.iter().zip(original.iter()) {
+            assert_ne!(p, o, "params must change after Adam step");
+        }
+        assert_eq!(state.t, 1, "step counter must be 1 after first step");
+    }
+
+    #[test]
+    fn test_adamw_weight_decay() {
+        // Train two adapters on the same task — one with weight_decay, one without.
+        // The weight-decayed adapter should have smaller weight magnitude.
+        let samples = make_samples(5);
+
+        // --- with weight decay ---
+        let mut adapter_wd = make_small_adapter();
+        let config_wd = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 20,
+            batch_size: 5,
+            optimizer: Some(OptimizerConfig::adamw(0.01, 0.1)),
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+        train_lora(&mut adapter_wd, &samples, &config_wd).expect("AdamW train must succeed");
+
+        // --- without weight decay ---
+        let mut adapter_no_wd = make_small_adapter();
+        let config_no_wd = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 20,
+            batch_size: 5,
+            optimizer: Some(OptimizerConfig::adam(0.01)),
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+        train_lora(&mut adapter_no_wd, &samples, &config_no_wd).expect("Adam train must succeed");
+
+        let key = (0usize, "q_proj".to_string());
+        let norm_wd: f32 = adapter_wd.layers[&key]
+            .a
+            .iter()
+            .chain(adapter_wd.layers[&key].b.iter())
+            .map(|x| x * x)
+            .sum::<f32>()
+            .sqrt();
+        let norm_no_wd: f32 = adapter_no_wd.layers[&key]
+            .a
+            .iter()
+            .chain(adapter_no_wd.layers[&key].b.iter())
+            .map(|x| x * x)
+            .sum::<f32>()
+            .sqrt();
+
+        assert!(
+            norm_wd < norm_no_wd,
+            "AdamW weight decay must produce smaller weight norms: wd={norm_wd:.6} vs no_wd={norm_no_wd:.6}"
+        );
+    }
+
+    #[test]
+    fn test_adam_converges_faster() {
+        // Same task, same number of epochs — Adam should reach lower final loss than SGD.
+        let samples = make_samples(5);
+
+        // SGD
+        let mut adapter_sgd = make_small_adapter();
+        let config_sgd = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 10,
+            batch_size: 5,
+            optimizer: None, // backward-compat SGD path
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+        let result_sgd =
+            train_lora(&mut adapter_sgd, &samples, &config_sgd).expect("SGD train must succeed");
+
+        // Adam
+        let mut adapter_adam = make_small_adapter();
+        let config_adam = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 10,
+            batch_size: 5,
+            optimizer: Some(OptimizerConfig::adam(0.01)),
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+        let result_adam =
+            train_lora(&mut adapter_adam, &samples, &config_adam).expect("Adam train must succeed");
+
+        assert!(
+            result_adam.final_loss < result_sgd.final_loss,
+            "Adam must converge faster than SGD on this task: adam={:.6} sgd={:.6}",
+            result_adam.final_loss,
+            result_sgd.final_loss,
+        );
+    }
+}

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -1,0 +1,447 @@
+//! Batch LoRA training loop (ADR-057, perf-opt-train-loop).
+//!
+//! Provides [`train_lora`] which iterates over a slice of [`TrainSample`]s for
+//! multiple epochs, calling [`adapt_step`] for each sample and accumulating per-epoch
+//! MSE loss statistics.
+//!
+//! When [`LoraTrainConfig::optimizer`] is `Some(Adam | AdamW)`, the loop uses
+//! [`AdamState`](super::optimizer::AdamState) to apply adaptive gradient updates
+//! instead of plain SGD.  When `optimizer` is `None`, the loop falls back to the
+//! original [`adapt_step`] SGD path for full backward compatibility.
+
+use super::{
+    LoraAdapter,
+    online::adapt_step,
+    optimizer::{AdamState, compute_lora_gradients},
+};
+use crate::error::TuneError;
+use crate::train::{LRSchedule, Optimizer, OptimizerConfig};
+
+/// Configuration for a batch LoRA training run.
+#[derive(Debug, Clone)]
+pub struct LoraTrainConfig {
+    /// SGD step size applied inside each [`adapt_step`] call (also used as
+    /// the base learning rate when an Adam optimizer is active).
+    pub learning_rate: f32,
+    /// Number of full passes over the sample set.
+    pub num_epochs: usize,
+    /// Batch size (informational; does not affect the current sequential loop).
+    pub batch_size: usize,
+    /// Optional optimizer configuration.  When `None` the loop uses the
+    /// backward-compatible SGD path ([`adapt_step`]).  When `Some`, an
+    /// Adam or AdamW update is performed using the parameters from the
+    /// [`OptimizerConfig`] (the `learning_rate` field in the config is used
+    /// as the base LR, overriding this struct's `learning_rate` field).
+    pub optimizer: Option<OptimizerConfig>,
+    /// Optional learning-rate schedule.  Only used when `optimizer` is
+    /// `Some`; ignored in the SGD path.
+    pub lr_schedule: Option<LRSchedule>,
+    /// Optional gradient clipping by global L2 norm.  Applied to each
+    /// sample's gradients before the optimizer step when `optimizer` is `Some`.
+    pub grad_clip_norm: Option<f32>,
+}
+
+/// A single training sample: one (input, target_delta) pair for one LoRA layer.
+#[derive(Debug, Clone)]
+pub struct TrainSample {
+    /// Transformer layer index (0-based).
+    pub layer_idx: usize,
+    /// Module name, e.g. `"q_proj"`.
+    pub module: String,
+    /// Input activation vector; length must equal the layer's `d_in`.
+    pub input: Vec<f32>,
+    /// Target LoRA output correction; length must equal the layer's `d_out`.
+    pub target_delta: Vec<f32>,
+}
+
+/// Summary statistics from a completed [`train_lora`] run.
+#[derive(Debug, Clone)]
+pub struct TrainResult {
+    /// Average MSE loss recorded in the final epoch.
+    pub final_loss: f32,
+    /// Average MSE loss per epoch (length == `num_epochs`).
+    pub epoch_losses: Vec<f32>,
+    /// Total number of [`adapt_step`] calls executed (`num_epochs * samples.len()`).
+    pub total_steps: usize,
+}
+
+/// Run a multi-epoch batch LoRA training loop.
+///
+/// Iterates over all `samples` in order for each epoch (no shuffling, ensuring
+/// deterministic behaviour).  The update rule is selected by
+/// [`LoraTrainConfig::optimizer`]:
+///
+/// * `None` — backward-compatible SGD via [`adapt_step`].
+/// * `Some(Adam)` — Adam adaptive gradient update.
+/// * `Some(AdamW)` — AdamW (Adam + decoupled weight decay).
+///
+/// # Arguments
+///
+/// * `adapter` – Mutable LoRA adapter whose weights are updated in place.
+/// * `samples` – Slice of training samples; must be non-empty.
+/// * `config`  – Hyper-parameters for the training run.
+///
+/// # Errors
+///
+/// * [`TuneError::Training`]          – `samples` is empty.
+/// * [`TuneError::InvalidConfig`]     – `batch_size == 0` or `num_epochs == 0`.
+/// * [`TuneError::Training`]          – A sample references a `(layer_idx, module)` pair
+///   that is not present in the adapter.
+/// * [`TuneError::DimensionMismatch`] – A sample's `input` or `target_delta` has the
+///   wrong length for its LoRA layer.
+pub fn train_lora(
+    adapter: &mut LoraAdapter,
+    samples: &[TrainSample],
+    config: &LoraTrainConfig,
+) -> Result<TrainResult, TuneError> {
+    if samples.is_empty() {
+        return Err(TuneError::Training(
+            "no training samples provided".to_string(),
+        ));
+    }
+    if config.batch_size == 0 {
+        return Err(TuneError::InvalidConfig(
+            "batch_size must be > 0".to_string(),
+        ));
+    }
+    if config.num_epochs == 0 {
+        return Err(TuneError::InvalidConfig(
+            "num_epochs must be > 0".to_string(),
+        ));
+    }
+
+    match &config.optimizer {
+        None => train_lora_sgd(adapter, samples, config),
+        Some(opt_cfg) => {
+            use crate::train::Optimizer;
+            match &opt_cfg.optimizer {
+                Optimizer::Adam | Optimizer::AdamW => {
+                    train_lora_adam(adapter, samples, config, opt_cfg)
+                }
+                unsupported => Err(TuneError::InvalidConfig(format!(
+                    "optimizer variant '{unsupported}' is not supported by train_lora; \
+                     use Adam or AdamW, or set optimizer to None for SGD"
+                ))),
+            }
+        }
+    }
+}
+
+/// SGD path — delegates to `adapt_step` for backward compatibility.
+fn train_lora_sgd(
+    adapter: &mut LoraAdapter,
+    samples: &[TrainSample],
+    config: &LoraTrainConfig,
+) -> Result<TrainResult, TuneError> {
+    let mut epoch_losses = Vec::with_capacity(config.num_epochs);
+
+    for _ in 0..config.num_epochs {
+        let mut epoch_loss_sum = 0.0f32;
+        for sample in samples {
+            let step_result = adapt_step(
+                adapter,
+                sample.layer_idx,
+                &sample.module,
+                &sample.input,
+                &sample.target_delta,
+                config.learning_rate,
+            )?;
+            epoch_loss_sum += step_result.loss;
+        }
+        epoch_losses.push(epoch_loss_sum / samples.len() as f32);
+    }
+
+    let final_loss = *epoch_losses.last().expect("num_epochs > 0");
+    Ok(TrainResult {
+        final_loss,
+        epoch_losses,
+        total_steps: config.num_epochs * samples.len(),
+    })
+}
+
+/// Adam / AdamW path.
+fn train_lora_adam(
+    adapter: &mut LoraAdapter,
+    samples: &[TrainSample],
+    config: &LoraTrainConfig,
+    opt_cfg: &OptimizerConfig,
+) -> Result<TrainResult, TuneError> {
+    let decoupled = matches!(opt_cfg.optimizer, Optimizer::AdamW);
+    let base_lr = opt_cfg.learning_rate;
+
+    let mut adam = AdamState::new();
+    let mut epoch_losses = Vec::with_capacity(config.num_epochs);
+    let mut global_step: usize = 0;
+
+    for epoch in 0..config.num_epochs {
+        let mut epoch_loss_sum = 0.0f32;
+
+        for sample in samples {
+            // Effective LR from optional schedule.
+            let lr = if let Some(sched) = &config.lr_schedule {
+                sched.get_lr(base_lr, global_step, epoch)
+            } else {
+                base_lr
+            };
+
+            // Compute gradients without touching weights.
+            let mut grads = compute_lora_gradients(
+                adapter,
+                sample.layer_idx,
+                &sample.module,
+                &sample.input,
+                &sample.target_delta,
+            )?;
+
+            epoch_loss_sum += grads.loss;
+
+            // Optional gradient clipping by global L2 norm.
+            if let Some(max_norm) = config.grad_clip_norm {
+                let sq_sum: f32 = grads
+                    .grad_b
+                    .iter()
+                    .chain(grads.grad_a.iter())
+                    .map(|g| g * g)
+                    .sum();
+                let norm = sq_sum.sqrt();
+                if norm > max_norm {
+                    let scale = max_norm / (norm + 1e-8);
+                    for g in grads.grad_b.iter_mut().chain(grads.grad_a.iter_mut()) {
+                        *g *= scale;
+                    }
+                }
+            }
+
+            // Apply Adam update to B and A parameters for this layer.
+            let key = &(sample.layer_idx, sample.module.clone());
+            let lora = adapter.layers.get_mut(key).ok_or_else(|| {
+                TuneError::Training(format!(
+                    "no LoRA layer for ({}, {})",
+                    sample.layer_idx, sample.module
+                ))
+            })?;
+
+            let key_b = format!("{}_{}_b", sample.layer_idx, sample.module);
+            let key_a = format!("{}_{}_a", sample.layer_idx, sample.module);
+
+            adam.step(
+                &key_b,
+                &mut lora.b,
+                &grads.grad_b,
+                lr,
+                opt_cfg.beta1,
+                opt_cfg.beta2,
+                opt_cfg.epsilon,
+                opt_cfg.weight_decay,
+                decoupled,
+            );
+            // Decrement step counter so A and B share the same effective step t.
+            adam.t -= 1;
+            adam.step(
+                &key_a,
+                &mut lora.a,
+                &grads.grad_a,
+                lr,
+                opt_cfg.beta1,
+                opt_cfg.beta2,
+                opt_cfg.epsilon,
+                opt_cfg.weight_decay,
+                decoupled,
+            );
+
+            global_step += 1;
+        }
+
+        epoch_losses.push(epoch_loss_sum / samples.len() as f32);
+    }
+
+    let final_loss = *epoch_losses.last().expect("num_epochs > 0");
+    Ok(TrainResult {
+        final_loss,
+        epoch_losses,
+        total_steps: config.num_epochs * samples.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+    use std::collections::HashMap;
+
+    /// rank=2, d_in=3, d_out=2, scale=1.0 (alpha=2.0, rank=2)
+    fn make_small_adapter() -> LoraAdapter {
+        let config = LoraConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["q_proj".into()],
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![
+                    1.0, 0.5, 0.0, // row 0
+                    0.0, 0.5, 1.0, // row 1
+                ],
+                b: vec![
+                    1.0, 0.0, // row 0
+                    0.0, 1.0, // row 1
+                ],
+                d_in: 3,
+                d_out: 2,
+                rank: 2,
+            },
+        );
+        LoraAdapter::new(config, layers)
+    }
+
+    /// Build a synthetic sample whose target_delta is the initial LoRA output for the given
+    /// input, slightly perturbed — this gives a reachable regression target without
+    /// requiring a warm-up forward pass from the caller.
+    fn make_samples(n: usize) -> Vec<TrainSample> {
+        // Use varied inputs so samples span different directions in weight-space.
+        (0..n)
+            .map(|i| {
+                let fi = i as f32;
+                TrainSample {
+                    layer_idx: 0,
+                    module: "q_proj".to_string(),
+                    // d_in = 3
+                    input: vec![fi * 0.1 + 0.1, fi * 0.2 + 0.2, fi * 0.3 + 0.3],
+                    // d_out = 2  — target is something the network can learn toward
+                    target_delta: vec![fi * 0.05, fi * 0.05 + 0.1],
+                }
+            })
+            .collect()
+    }
+
+    fn sgd_config(learning_rate: f32, num_epochs: usize) -> LoraTrainConfig {
+        LoraTrainConfig {
+            learning_rate,
+            num_epochs,
+            batch_size: 5,
+            optimizer: None,
+            lr_schedule: None,
+            grad_clip_norm: None,
+        }
+    }
+
+    #[test]
+    fn test_train_convergence() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = sgd_config(0.01, 10);
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.epoch_losses.len(), 10);
+        assert_eq!(result.total_steps, 50);
+        assert!(
+            result.epoch_losses.last().unwrap() < result.epoch_losses.first().unwrap(),
+            "loss must decrease over 10 epochs: first={:.6}, last={:.6}",
+            result.epoch_losses.first().unwrap(),
+            result.epoch_losses.last().unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_train_empty_batch() {
+        let mut adapter = make_small_adapter();
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 5,
+            batch_size: 1,
+            optimizer: None,
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+
+        let err =
+            train_lora(&mut adapter, &[], &config).expect_err("empty samples must return Err");
+        assert!(
+            matches!(err, TuneError::Training(_)),
+            "expected Training variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_dimension_mismatch() {
+        let mut adapter = make_small_adapter();
+        // d_in for layer (0, "q_proj") is 3, but we pass a 2-element input.
+        let bad_samples = vec![TrainSample {
+            layer_idx: 0,
+            module: "q_proj".to_string(),
+            input: vec![1.0, 2.0], // wrong length (d_in=3)
+            target_delta: vec![1.0, 1.0],
+        }];
+        let config = LoraTrainConfig {
+            learning_rate: 0.01,
+            num_epochs: 1,
+            batch_size: 1,
+            optimizer: None,
+            lr_schedule: None,
+            grad_clip_norm: None,
+        };
+
+        let err = train_lora(&mut adapter, &bad_samples, &config)
+            .expect_err("dimension mismatch must return Err");
+        assert!(
+            matches!(err, TuneError::DimensionMismatch { .. }),
+            "expected DimensionMismatch variant, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_train_metrics() {
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(5);
+
+        let config = sgd_config(0.01, 3);
+
+        let result = train_lora(&mut adapter, &samples, &config).expect("train_lora must succeed");
+
+        assert_eq!(result.total_steps, 15, "3 epochs × 5 samples = 15 steps");
+        assert_eq!(result.epoch_losses.len(), 3, "one loss entry per epoch");
+    }
+
+    #[test]
+    fn test_unsupported_optimizer_returns_invalid_config() {
+        use crate::train::{Optimizer, OptimizerConfig};
+
+        let mut adapter = make_small_adapter();
+        let samples = make_samples(2);
+
+        for variant in [
+            OptimizerConfig {
+                optimizer: Optimizer::SGD,
+                ..OptimizerConfig::default()
+            },
+            OptimizerConfig {
+                optimizer: Optimizer::SGDMomentum,
+                ..OptimizerConfig::default()
+            },
+            OptimizerConfig {
+                optimizer: Optimizer::RMSprop,
+                ..OptimizerConfig::default()
+            },
+        ] {
+            let name = variant.optimizer.to_string();
+            let config = LoraTrainConfig {
+                learning_rate: 0.01,
+                num_epochs: 1,
+                batch_size: 1,
+                optimizer: Some(variant),
+                lr_schedule: None,
+                grad_clip_norm: None,
+            };
+            let err = train_lora(&mut adapter, &samples, &config)
+                .expect_err("unsupported optimizer must return Err");
+            assert!(
+                matches!(err, TuneError::InvalidConfig(_)),
+                "expected InvalidConfig for optimizer '{name}', got {err:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `train_lora` API for batch LoRA training with configurable optimizer, learning rate, epochs, gradient clipping
- Adam and AdamW optimizer implementations with bias correction
- InvalidConfig error for unsupported optimizer variants

**Scope**: `crates/tune/` only — independent of inference and embed changes.

## Test plan

- [x] Compiles clean (`cargo clippy -p lattice-tune -- -D warnings`)
- [ ] CI validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)