### PR TITLE
fix(embed): bench uses data() accessor after field privatization

### DIFF
--- a/crates/embed/benches/simd.rs
+++ b/crates/embed/benches/simd.rs
@@ -390,7 +390,7 @@ fn bench_memory_usage(c: &mut Criterion) {
         let v_q = QuantizedVector::from_f32(&v);
 
         let f32_bytes = v.len() * std::mem::size_of::<f32>();
-        let i8_bytes = v_q.data.len() * std::mem::size_of::<i8>() + 16; // + overhead
+        let i8_bytes = v_q.len() * std::mem::size_of::<i8>() + 16; // + overhead
 
         println!(
             "dim={}: float32={}B, int8={}B, ratio={:.1}x",
@@ -692,8 +692,8 @@ fn bench_dot_product_i8_raw(c: &mut Criterion) {
             |bench, _| {
                 bench.iter(|| {
                     black_box(simd::dot_product_i8_raw(
-                        black_box(&a_q.data),
-                        black_box(&b_q.data),
+                        black_box(a_q.data()),
+                        black_box(b_q.data()),
                     ))
                 });
             },


### PR DESCRIPTION
Hotfix for main CI red status. The `crates/embed/benches/simd.rs` file references `q_v.data` and `a_q.data` directly — these stopped compiling when PR #79 made `QuantizedVector.data` private. Local clippy didn't catch this because the default clippy scope omits benches; CI surfaced it post-merge.

The pre-commit hook fix to use `--all-targets` (which would have caught this locally) is tracked in #87.

## Test plan
- [x] `cargo bench -p lattice-embed --bench simd --no-run` builds clean locally