### PR TITLE
release: v0.2.3 — ship RoPE fix to crates.io (yank 0.2.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.2.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.2.3", path = "../inference", optional = true, features = ["f16"] }
 
 # Time
 chrono = { workspace = true }

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -25,7 +25,7 @@ inference-hook = ["dep:lattice-inference"]
 sqlite = ["dep:rusqlite", "serde"]
 
 [dependencies]
-lattice-fann = { version = "0.2.0", path = "../fann" }
+lattice-fann = { version = "0.2.3", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -46,7 +46,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook (optional — for LoRA adapter injection)
-lattice-inference = { version = "0.2.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.2.3", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/docs/releases/v0.2.3.md
+++ b/docs/releases/v0.2.3.md
@@ -89,11 +89,15 @@
 
 ## Crates Published
 
-- `lattice-inference` 0.2.2
-- `lattice-embed` 0.2.2
-- `lattice-fann` 0.2.2
-- `lattice-tune` 0.2.2
-- `lattice-transport` 0.2.2
+- `lattice-inference` 0.2.3
+- `lattice-embed` 0.2.3
+- `lattice-fann` 0.2.3
+- `lattice-tune` 0.2.3
+- `lattice-transport` 0.2.3
+
+## Note on v0.2.2
+
+v0.2.2 was published to crates.io on 2026-05-20 and yanked on 2026-05-25 — it shipped the broken interleaved RoPE pairing fixed in #96. v0.2.3 is the first release that includes the RoPE fix. Use 0.2.3 or later. The GitHub tag v0.2.2 remains for history but no crates.io install from it.
 
 ## Diff Stats
 


### PR DESCRIPTION
## Summary

crates.io v0.2.2 was published 2026-05-20, **before** the RoPE pairing fix landed (PR #96, merged today). Cannot republish 0.2.2 (immutable on crates.io), so bumping to 0.2.3 to ship the fix. v0.2.2 will be yanked on crates.io post-publish.

## Changes

- Workspace version 0.2.2 → 0.2.3
- Internal path-dep minimum versions bumped to 0.2.3 (`embed`, `tune`)
- `docs/releases/v0.2.2.md` → `v0.2.3.md` with yank notice

## Post-merge

```sh
git checkout main && git pull
git tag -a v0.2.3 -m "v0.2.3"
git push origin v0.2.3
gh release create v0.2.3 --title "v0.2.3 — MLX-parity quality" --notes-file docs/releases/v0.2.3.md
make publish
# Then yank broken 0.2.2:
for c in lattice-inference lattice-fann lattice-transport lattice-embed lattice-tune; do
  cargo yank --version 0.2.2 -p "$c"
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)