### PR TITLE
fix(inference): inject SentencePiece BOS/EOS from tokenizer.json post_processor

### DIFF
--- a/crates/inference/src/tokenizer/common.rs
+++ b/crates/inference/src/tokenizer/common.rs
@@ -1021,4 +1021,54 @@ mod tests {
         push_eos_preserving_limit(&mut ids, 99, 0);
         assert!(ids.is_empty());
     }
+
+    #[test]
+    fn test_parse_post_processor_template_special_ids() {
+        // Synthetic TemplateProcessing where the template uses [CLS]/[SEP]
+        // (e.g. BERT-style) but the model also happens to have <s>/</s> in vocab.
+        // The IDs in special_tokens are the authoritative source for prefix/suffix.
+        let raw = r#"{
+            "post_processor": {
+                "type": "TemplateProcessing",
+                "single": [
+                    {"SpecialToken": {"id": "[CLS]", "type_id": 0}},
+                    {"Sequence": {"id": "A", "type_id": 0}},
+                    {"SpecialToken": {"id": "[SEP]", "type_id": 0}}
+                ],
+                "special_tokens": {
+                    "[CLS]": {"id": "[CLS]", "ids": [101], "tokens": ["[CLS]"]},
+                    "[SEP]": {"id": "[SEP]", "ids": [102], "tokens": ["[SEP]"]}
+                }
+            }
+        }"#;
+        let root = parse_json(raw).unwrap();
+        let pp = parse_post_processor_flags(&root);
+        assert!(pp.add_bos, "template starts with SpecialToken → add_bos");
+        assert!(pp.add_eos, "template ends with SpecialToken → add_eos");
+        assert_eq!(pp.bos_id, Some(101), "[CLS] id authoritative");
+        assert_eq!(pp.eos_id, Some(102), "[SEP] id authoritative");
+    }
+
+    #[test]
+    fn test_parse_post_processor_xlm_roberta_style() {
+        // XLM-RoBERTa-style: <s>/</s> in template AND in special_tokens.
+        let raw = r#"{
+            "post_processor": {
+                "type": "TemplateProcessing",
+                "single": [
+                    {"SpecialToken": {"id": "<s>", "type_id": 0}},
+                    {"Sequence": {"id": "A", "type_id": 0}},
+                    {"SpecialToken": {"id": "</s>", "type_id": 0}}
+                ],
+                "special_tokens": {
+                    "<s>": {"id": "<s>", "ids": [0], "tokens": ["<s>"]},
+                    "</s>": {"id": "</s>", "ids": [2], "tokens": ["</s>"]}
+                }
+            }
+        }"#;
+        let root = parse_json(raw).unwrap();
+        let pp = parse_post_processor_flags(&root);
+        assert_eq!(pp.bos_id, Some(0));
+        assert_eq!(pp.eos_id, Some(2));
+    }
 }

--- a/crates/inference/src/tokenizer/common.rs
+++ b/crates/inference/src/tokenizer/common.rs
@@ -753,6 +753,86 @@ pub(crate) fn known_special_id(vocab: &HashMap<String, u32>, names: &[&str]) -> 
     names.iter().find_map(|name| vocab.get(*name).copied())
 }
 
+pub(crate) struct PostProcessorFlags {
+    pub add_bos: bool,
+    pub add_eos: bool,
+    pub bos_id: Option<u32>,
+    pub eos_id: Option<u32>,
+}
+
+pub(crate) fn parse_post_processor_flags(root: &JsonValue) -> PostProcessorFlags {
+    let default = PostProcessorFlags {
+        add_bos: false,
+        add_eos: false,
+        bos_id: None,
+        eos_id: None,
+    };
+
+    let Some(pp) = root.get("post_processor") else {
+        return default;
+    };
+
+    let Some(template) = find_template_processing(pp) else {
+        return default;
+    };
+
+    let Some(single) = template.get("single").and_then(JsonValue::as_array) else {
+        return default;
+    };
+
+    let special_tokens = template.get("special_tokens");
+    let mut add_bos = false;
+    let mut add_eos = false;
+    let mut bos_id = None;
+    let mut eos_id = None;
+    let mut seen_sequence = false;
+
+    for item in single {
+        if let Some(st) = item.get("SpecialToken") {
+            let token_name = st.get("id").and_then(JsonValue::as_str);
+            if !seen_sequence {
+                add_bos = true;
+                if let Some(name) = token_name {
+                    bos_id = resolve_template_token_id(special_tokens, name);
+                }
+            } else {
+                add_eos = true;
+                if let Some(name) = token_name {
+                    eos_id = resolve_template_token_id(special_tokens, name);
+                }
+            }
+        } else if item.get("Sequence").is_some() {
+            seen_sequence = true;
+        }
+    }
+
+    PostProcessorFlags {
+        add_bos,
+        add_eos,
+        bos_id,
+        eos_id,
+    }
+}
+
+fn find_template_processing(pp: &JsonValue) -> Option<&JsonValue> {
+    let pp_type = pp.get("type")?.as_str()?;
+    match pp_type {
+        "TemplateProcessing" => Some(pp),
+        "Sequence" => {
+            let processors = pp.get("processors")?.as_array()?;
+            processors
+                .iter()
+                .find(|p| p.get("type").and_then(JsonValue::as_str) == Some("TemplateProcessing"))
+        }
+        _ => None,
+    }
+}
+
+fn resolve_template_token_id(special_tokens: Option<&JsonValue>, name: &str) -> Option<u32> {
+    let ids = special_tokens?.get(name)?.get("ids")?.as_array()?;
+    ids.first()?.as_u64().map(|v| v as u32)
+}
+
 /// **Unstable**: internal LRU cache used by tokenizer implementations;
 /// not part of the public embedding API.
 ///

--- a/crates/inference/src/tokenizer/sentencepiece.rs
+++ b/crates/inference/src/tokenizer/sentencepiece.rs
@@ -251,8 +251,12 @@ impl SentencePieceTokenizer {
         let model = ParsedSentencePieceModel {
             pieces,
             unk_id,
-            bos_id: bos_id.or(pp.bos_id),
-            eos_id: eos_id.or(pp.eos_id),
+            // TemplateProcessing IDs are authoritative when present — the template
+            // declares its own special tokens (which may be e.g. [CLS]/[SEP] even when
+            // <s>/</s> also exist in vocab). Only fall back to vocab-name guesses
+            // when the template did not supply explicit IDs.
+            bos_id: pp.bos_id.or(bos_id),
+            eos_id: pp.eos_id.or(eos_id),
             pad_id,
             add_bos: pp.add_bos,
             add_eos: pp.add_eos,

--- a/crates/inference/src/tokenizer/sentencepiece.rs
+++ b/crates/inference/src/tokenizer/sentencepiece.rs
@@ -7,7 +7,7 @@
 use crate::error::InferenceError;
 use crate::tokenizer::common::{
     JsonValue, ThreadSafeLruCache, TokenizedInput, Tokenizer, json_path, known_special_id, pad_ids,
-    parse_json, push_eos_preserving_limit,
+    parse_json, parse_post_processor_flags, push_eos_preserving_limit,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -140,6 +140,8 @@ struct ParsedSentencePieceModel {
     bos_id: Option<u32>,
     eos_id: Option<u32>,
     pad_id: Option<u32>,
+    add_bos: bool,
+    add_eos: bool,
     dummy_prefix: bool,
     remove_extra_whitespaces: bool,
     escape_whitespaces: bool,
@@ -153,6 +155,8 @@ impl Default for ParsedSentencePieceModel {
             bos_id: None,
             eos_id: None,
             pad_id: None,
+            add_bos: false,
+            add_eos: false,
             dummy_prefix: true,
             remove_extra_whitespaces: true,
             escape_whitespaces: true,
@@ -243,12 +247,15 @@ impl SentencePieceTokenizer {
         let eos_id = known_special_id(&vocab_map, &["<eos>", "</s>"]);
         let pad_id = known_special_id(&vocab_map, &["<pad>"]);
 
+        let pp = parse_post_processor_flags(&root);
         let model = ParsedSentencePieceModel {
             pieces,
             unk_id,
-            bos_id,
-            eos_id,
+            bos_id: bos_id.or(pp.bos_id),
+            eos_id: eos_id.or(pp.eos_id),
             pad_id,
+            add_bos: pp.add_bos,
+            add_eos: pp.add_eos,
             dummy_prefix: true,
             remove_extra_whitespaces: true,
             escape_whitespaces: true,
@@ -306,8 +313,8 @@ impl SentencePieceTokenizer {
             pad_id,
             bos_id: model.bos_id,
             eos_id: model.eos_id,
-            add_bos: false,
-            add_eos: false,
+            add_bos: model.add_bos,
+            add_eos: model.add_eos,
             max_seq_len,
             dummy_prefix: model.dummy_prefix,
             remove_extra_whitespaces: model.remove_extra_whitespaces,
@@ -334,6 +341,8 @@ impl SentencePieceTokenizer {
                 bos_id: None,
                 eos_id: None,
                 pad_id: Some(unk_id),
+                add_bos: false,
+                add_eos: false,
                 dummy_prefix: true,
                 remove_extra_whitespaces: true,
                 escape_whitespaces: true,


### PR DESCRIPTION
## Layer
L1 — tokenizer fix (PR2 of 11 in `embed-perf-quality` show)

## What
Parses `tokenizer.json` `post_processor` field of type `TemplateProcessing` for SentencePiece tokenizers (E5 family). Extracts `single` template, detects `<s>`/`</s>` IDs, injects them at the SP encode boundary AFTER subword tokenization and BEFORE returning `TokenizedInput`.

## Why
Audit gap: pre-fix lattice produced 0/9 PASS on E5 SentencePiece cases. HF reference always wraps SP outputs in BOS/EOS via the template processor.

## Result
- E5 audit cases: 0/9 → 9/9 PASS
- No new dependencies

## Stack
Base: #105 (PR1 audit baseline)
Umbrella: #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)