### PR TITLE
docs(inference): clarify (1+γ) RMSNorm in golden-logit test; resolve stale #31

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -13555,12 +13555,14 @@ kernel void decode_attention_reference(
             let logits = state.forward_step(42, 0);
             assert_eq!(logits.len(), cfg.vocab_size);
             let actual = &logits[..10];
-            // Math: token 42's embedding has a single non-zero element (=1.0). After
-            // input_layernorm (qwen35_rms_norm uses 1+gamma weights), the norm output
-            // is x * sqrt(hidden)/||x|| * (1 + gamma) = 1 * sqrt(512) * 2 = 45.2543.
-            // All attention and FFN weights are zero, so the residual stream stays at
-            // the input embedding. final_norm produces the same 45.2543 magnitude.
-            // Tied lm_head: logit[v] = embed[v, 0] * 45.2543 → -45.25, 0, 45.25 pattern.
+            // Math: token 42's embedding is one-hot: x[0]=1.0, x[1..]=0.0.
+            // All attention and FFN weights are zero → residual stream equals the
+            // raw embedding at every stage. final_norm then applies the shifted
+            // RMSNorm (qwen35_rms_norm convention: output = x * (1 + gamma) / rms(x)).
+            // With final_norm=[1.0] the scale is (1+1.0)=2; identity is gamma=0.
+            //   rms(x) = sqrt(1/512),  output[0] = 1.0 * (1+1.0) * sqrt(512) = 2*sqrt(512) ≈ 45.254.
+            // Tied lm_head col-0 pattern is [-1,0,1,-1,0,1,...], so logits ≈ ±45.25 / 0.
+            // (Issue #31: the original golden ±22.62 assumed plain-gamma; ±45.24 is correct.)
             let expected = [
                 -45.243256_f32,
                 0.0,


### PR DESCRIPTION
## Summary
Issue #31 reported `test_metal_qwen35_golden_logit_snapshot_forward_step_token_42_pos_0`
producing logits ≈ **2× the golden expected**. Investigation (full proof in show artifacts)
shows this was a **stale test golden, not a forward-path bug** — and it is **already fixed on
main**. This PR only corrects the explanatory comment and records the root cause to prevent
future confusion. `expected` values are unchanged.

## Root cause (verified against git history + source)
- The Metal kernel `rms_norm_qwen35` has used the **shifted `(1+γ)` RMSNorm** convention since
  the initial commit `d4b9839` — `x * rms * (1.0 + gamma[i])`. This is **intentional**: Qwen3.5
  shares Gemma3/Qwen3-Next zero-centered RMSNorm semantics (weights stored as ≈0 deviations;
  identity is `γ=0`). Documented in `model/qwen35/norm.rs:1-4` (OceanLi, `fff66b2`): "plain gamma
  produces garbage logits on this model."
- The fixture sets `final_norm=[1.0]` → `(1+1.0)=2×` is the **correct** scale → golden = `±45.24`.
- The original golden `±22.6216` assumed *plain*-gamma and was **wrong from `d4b9839`**.
- **Commit `0cc5c9e` (OceanLi, on main)** already corrected the golden `±22.62 → ±45.24` (as a
  side-fix during the RoPE stride-half work). The test **passes on main today.**
- PPL parity (Lattice 15.89 vs MLX 15.86 on Qwen3.5-0.8B) confirms `(1+γ)` is correct;
  reproducing `±22.62` would require plain-γ, which makes the model output garbage.

## What this PR changes
Comment-only (8 lines). The prior comment incorrectly attributed the `45.25` scale to
`input_layernorm`; it is produced by `final_norm`. The new comment derives it correctly and
records the `±22.62 → ±45.24` history.

## Verification
- Confirmed `0cc5c9e` is on `origin/main`; current golden = `±45.243256` (passing).
- Diff is comment-only; `expected` array unchanged.

Resolves #31 (already-fixed; this documents + closes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)