### PR TITLE
fix(inference): make ShardedQwenBacking drop order explicit via ManuallyDrop (#14)

### DIFF
--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -470,8 +470,8 @@ impl QwenModel {
                 }
             };
 
-            // SAFETY: The backing store (_storage / safetensors) outlives weights
-            // because it is dropped after weights (RFC 1857 struct field drop order).
+            // SAFETY: The safetensors backing is stored in `_storage`; `QwenModel::drop`
+            // explicitly drops `weights` before `_storage`, independent of field order.
             let weights: QwenWeights<'static> = unsafe { std::mem::transmute(weights_tmp) };
 
             let rope_max = config
@@ -529,10 +529,9 @@ impl QwenModel {
                 }
             };
 
-            // SAFETY: `weights_tmp` already has 'static lifetime from
-            // `load_qwen_weights_owned` — the slices point into `backing` which
-            // is a heap-allocated Box.  We store `backing` in `_storage` and
-            // declare `weights` before `_storage` so drop order is correct.
+            // SAFETY: `weights_tmp` contains slices into `backing`. `backing` is moved
+            // into `_storage`, and `QwenModel::drop` explicitly drops `weights` before
+            // `_storage`, independent of field declaration order.
             let weights: QwenWeights<'static> = weights_tmp;
 
             let rope_max = config

--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -13,6 +13,7 @@ use crate::rope::RopeTable;
 use crate::tokenizer::common::{Tokenizer, load_tokenizer};
 use crate::weights::{QwenWeights, SafetensorsFile, ShardedQwenBacking, ShardedSafetensors};
 use std::collections::HashMap;
+use std::mem::ManuallyDrop;
 use std::path::Path;
 use std::sync::Mutex;
 use std::time::Instant;
@@ -20,9 +21,9 @@ use std::time::Instant;
 /// Backing storage for Qwen model weights — either a single mmap'd file or
 /// an owned heap allocation for sharded checkpoints.
 ///
-/// Drop order within `QwenModel` guarantees that `weights` is dropped before
-/// this enum (RFC 1857 struct field ordering), keeping all tensor slice
-/// references valid for the model's lifetime.
+/// `QwenModel` wraps both `weights` and `_storage` in `ManuallyDrop` and
+/// implements `Drop` to drop `weights` before `_storage`, keeping tensor
+/// slice references valid regardless of field declaration order.
 ///
 /// The inner fields are kept solely for their `Drop` effect (RAII backing store).
 #[allow(dead_code)]
@@ -392,11 +393,24 @@ pub struct QwenModel {
     /// Optional Metal GPU forward pass. When available, transformer layers run on GPU
     /// while embedding lookup and pooling stay on CPU.
     metal: Option<Mutex<MetalForwardPass>>,
-    // INVARIANT: `weights` MUST be declared before `_storage`.
-    // RFC 1857 guarantees struct fields are dropped in declaration order, so
-    // `weights` (which holds slices into `_storage`) is dropped first.
-    weights: QwenWeights<'static>,
-    _storage: SafetensorsStorage,
+    // Both fields are `ManuallyDrop` so that `Drop for QwenModel` can enforce
+    // explicit drop order: `weights` before `_storage`. This is independent of
+    // field declaration order — a reorder cannot cause use-after-free.
+    weights: ManuallyDrop<QwenWeights<'static>>,
+    _storage: ManuallyDrop<SafetensorsStorage>,
+}
+
+impl Drop for QwenModel {
+    fn drop(&mut self) {
+        // SAFETY: `weights` holds slice references into the data owned by `_storage`.
+        // We drop `weights` first to release those references, then drop `_storage`.
+        // Using `ManuallyDrop` here makes this ordering explicit and independent of
+        // field declaration order — a future field reorder cannot cause use-after-free.
+        unsafe {
+            ManuallyDrop::drop(&mut self.weights);
+            ManuallyDrop::drop(&mut self._storage);
+        }
+    }
 }
 
 impl QwenModel {
@@ -474,8 +488,8 @@ impl QwenModel {
                 buffers: Mutex::new(ForwardBuffers::new()),
                 cache: Mutex::new(HashMap::with_capacity(1024)),
                 metal,
-                weights,
-                _storage: SafetensorsStorage::Single(safetensors),
+                weights: ManuallyDrop::new(weights),
+                _storage: ManuallyDrop::new(SafetensorsStorage::Single(safetensors)),
             })
         } else if index_path.exists() {
             // --- Sharded path ---
@@ -535,8 +549,8 @@ impl QwenModel {
                 buffers: Mutex::new(ForwardBuffers::new()),
                 cache: Mutex::new(HashMap::with_capacity(1024)),
                 metal,
-                weights,
-                _storage: SafetensorsStorage::Sharded(backing),
+                weights: ManuallyDrop::new(weights),
+                _storage: ManuallyDrop::new(SafetensorsStorage::Sharded(backing)),
             })
         } else {
             Err(InferenceError::ModelNotFound(format!(

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -1170,17 +1170,18 @@ impl ShardedSafetensors {
         });
 
         // --- Build QwenWeights borrowing from the backing ---
-        // SAFETY: The backing is heap-allocated in a Box and will be stored alongside
-        // the QwenWeights<'static> in SafetensorsStorage::Sharded inside QwenModel.
-        // Field drop order (RFC 1857) guarantees backing outlives weights: `weights`
-        // is declared before `_safetensors` in QwenModel, so `_safetensors` (which
-        // owns the backing) is dropped last.
+        // SAFETY: The backing is heap-allocated in a Box; its address is stable.
+        // `QwenModel` wraps both `weights` and `_storage` in `ManuallyDrop` and
+        // implements `Drop` to drop `weights` before `_storage`, ensuring the
+        // slice references in `weights` are released before `backing` is freed.
+        // This invariant is independent of field declaration order in `QwenModel`.
         let weights: QwenWeights<'static> = {
             #[allow(clippy::explicit_auto_deref)]
             let b: &ShardedQwenBacking = &*backing;
-            // SAFETY: We extend the lifetime of references into `b` to 'static.
-            // This is safe because `backing` lives in a Box that is co-located
-            // with the QwenWeights inside QwenModel and is dropped after it.
+            // SAFETY: We extend the borrow of `b` to 'static. This is sound because
+            // `backing` outlives any use of these references: `QwenModel` drops
+            // `weights` before `_storage` via an explicit `Drop` impl that uses
+            // `ManuallyDrop`, independent of field declaration order.
             let b: &'static ShardedQwenBacking = unsafe { &*(b as *const ShardedQwenBacking) };
 
             let embed_tokens = Tensor2D {

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -987,9 +987,9 @@ impl ShardedSafetensors {
     /// Load all Qwen3 weights from a sharded checkpoint into an owned backing store.
     ///
     /// Returns `(backing, weights)` where `weights` borrows from `backing`.
-    /// The caller MUST store `backing` in a `Box` and ensure `weights` does not
-    /// outlive it.  In `QwenModel` the `SafetensorsStorage::Sharded` variant
-    /// owns the `Box<ShardedQwenBacking>` and is dropped after `weights`.
+    /// The caller MUST keep `backing` alive until after `weights` is dropped.
+    /// `QwenModel` enforces this with `ManuallyDrop` fields and an explicit
+    /// `Drop` impl that drops `weights` before `_storage`.
     pub fn load_qwen_weights_owned(
         &mut self,
         num_layers: usize,


### PR DESCRIPTION
## Summary
Removes the fragile soundness invariant where `QwenModel`'s `QwenWeights<'static>` (zero-copy
slices into the mmap/heap backing) were valid **only** because of struct field declaration order
(RFC 1857 drop order). A future field reorder would have silently caused use-after-free.

## Fix
Wrap both fields in `ManuallyDrop` and implement `Drop for QwenModel` to drop them in an explicit,
declaration-order-independent sequence:
```rust
weights:  ManuallyDrop<QwenWeights<'static>>,
_storage: ManuallyDrop<SafetensorsStorage>,

impl Drop for QwenModel {
    fn drop(&mut self) {
        unsafe {
            ManuallyDrop::drop(&mut self.weights);   // release borrowed slices first
            ManuallyDrop::drop(&mut self._storage);  // then free the backing
        }
    }
}
```
`ManuallyDrop` excludes both fields from compiler auto-drop, so declaration order no longer governs
their destruction — the order is hard-coded in `Drop::drop`. A reorder **cannot** reintroduce the
UAF. Stale RFC-1857 SAFETY comments updated to describe the new mechanism.

## Properties
- **Hazard removed by the type system**, not by a comment/assertion.
- **No new UB**; panic-safe in the leak-not-UAF sense (if `weights` drop panics, `_storage` leaks).
- **Zero-copy preserved** (no extra weight-data copy); public `QwenWeights` API unchanged.

## Verification
- `cargo check` / `cargo clippy -D warnings` / weight+model-load tests — green (critic re-ran).
- Adversarial critic: CRIT 0 / MAJ 0 — APPROVE.

Closes #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)