### PR TITLE
feat(tune): validate LoRA adapter dims vs model config before set_lora (#8)

### DIFF
--- a/crates/tune/src/bin/generate_lora.rs
+++ b/crates/tune/src/bin/generate_lora.rs
@@ -51,7 +51,7 @@ fn main() {
     };
 
     // Load base model
-    println!("Loading model from {:?}...", model_dir);
+    println!("Loading model from {model_dir:?}...");
     let t0 = Instant::now();
 
     let mut model =
@@ -67,7 +67,7 @@ fn main() {
 
     // Load LoRA adapter
     if let Some(ref lora) = lora_path {
-        println!("Loading LoRA adapter from {:?}...", lora);
+        println!("Loading LoRA adapter from {lora:?}...");
         let t_lora = Instant::now();
 
         match lattice_tune::lora::LoraAdapter::from_safetensors(lora) {
@@ -79,6 +79,10 @@ fn main() {
                     adapter.config.scale(),
                     adapter.num_parameters()
                 );
+                if let Err(e) = adapter.validate_against(model.config()) {
+                    eprintln!("LoRA adapter incompatible with loaded model: {e}");
+                    std::process::exit(1);
+                }
                 model.set_lora(Box::new(adapter));
                 println!(
                     "  LoRA active (loaded in {}ms)",
@@ -95,9 +99,11 @@ fn main() {
     }
 
     // Configure generation
-    let mut gen_cfg = lattice_inference::model::qwen35_config::GenerateConfig::default();
-    gen_cfg.max_new_tokens = max_tokens;
-    gen_cfg.seed = seed;
+    let mut gen_cfg = lattice_inference::model::qwen35_config::GenerateConfig {
+        max_new_tokens: max_tokens,
+        seed,
+        ..lattice_inference::model::qwen35_config::GenerateConfig::default()
+    };
     if let Some(t) = temperature {
         gen_cfg.temperature = t;
     }

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -181,6 +181,61 @@ impl LoraAdapter {
     }
 }
 
+#[cfg(feature = "inference-hook")]
+impl LoraAdapter {
+    /// Validate adapter dimensions against a Qwen3.5 model configuration.
+    ///
+    /// Checks every `(layer_idx, module)` pair in the adapter:
+    /// - `layer_idx` is within `config.num_hidden_layers`
+    /// - `d_in` / `d_out` match the projection dimensions the model expects
+    ///
+    /// Returns `Err(TuneError::Validation(...))` on the first mismatch found.
+    /// Call this after loading and before
+    /// [`set_lora`](lattice_inference::model::qwen35::Qwen35Model::set_lora)
+    /// to surface dim errors before generation starts.
+    pub fn validate_against(
+        &self,
+        config: &lattice_inference::model::qwen35_config::Qwen35Config,
+    ) -> crate::error::Result<()> {
+        for ((layer_idx, module), layer) in &self.layers {
+            if *layer_idx >= config.num_hidden_layers {
+                return Err(crate::error::TuneError::Validation(format!(
+                    "LoRA layer index {layer_idx} >= model num_hidden_layers {} (module: {module})",
+                    config.num_hidden_layers
+                )));
+            }
+
+            let is_full = config.is_full_attention(*layer_idx);
+            let (expected_d_in, expected_d_out) = match (module.as_str(), is_full) {
+                ("q_proj", true) => (config.hidden_size, 2 * config.full_q_dim()),
+                ("k_proj", true) => (config.hidden_size, config.full_kv_dim()),
+                ("v_proj", true) => (config.hidden_size, config.full_kv_dim()),
+                ("o_proj", true) => (config.full_q_dim(), config.hidden_size),
+                ("in_proj_qkv", false) => (config.hidden_size, config.linear_qkv_dim()),
+                ("in_proj_z", false) => (config.hidden_size, config.linear_output_dim()),
+                ("out_proj", false) => (config.linear_output_dim(), config.hidden_size),
+                ("gate_proj", _) => (config.hidden_size, config.intermediate_size),
+                ("up_proj", _) => (config.hidden_size, config.intermediate_size),
+                ("down_proj", _) => (config.intermediate_size, config.hidden_size),
+                (m, _) => {
+                    return Err(crate::error::TuneError::Validation(format!(
+                        "LoRA module '{m}' (layer {layer_idx}) is not a recognised Qwen3.5 projection"
+                    )));
+                }
+            };
+
+            if layer.d_in != expected_d_in || layer.d_out != expected_d_out {
+                return Err(crate::error::TuneError::Validation(format!(
+                    "LoRA adapter dims mismatch for layer {layer_idx} module '{module}': \
+                     adapter has (d_in={}, d_out={}) but model expects (d_in={expected_d_in}, d_out={expected_d_out})",
+                    layer.d_in, layer.d_out
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
 // Implement LoraHook from lattice-inference so LoraAdapter can be injected
 // into the inference forward pass.
 #[cfg(feature = "inference-hook")]
@@ -351,5 +406,81 @@ mod tests {
         let adapter = LoraAdapter::new(config, HashMap::new());
         let unknown = adapter.validate_modules(&["q_proj"]);
         assert!(unknown.is_empty());
+    }
+
+    #[cfg(feature = "inference-hook")]
+    mod validate_against_tests {
+        use super::*;
+        use lattice_inference::model::qwen35_config::Qwen35Config;
+
+        fn make_adapter_for_layer(
+            layer_idx: usize,
+            module: &str,
+            d_in: usize,
+            d_out: usize,
+        ) -> LoraAdapter {
+            let rank = 4;
+            let mut layers = HashMap::new();
+            layers.insert(
+                (layer_idx, module.to_string()),
+                LoraLayer {
+                    a: vec![0.0; rank * d_in],
+                    b: vec![0.0; d_out * rank],
+                    d_in,
+                    d_out,
+                    rank,
+                },
+            );
+            LoraAdapter::new(
+                LoraConfig {
+                    rank,
+                    alpha: rank as f32,
+                    target_modules: vec![module.to_string()],
+                },
+                layers,
+            )
+        }
+
+        #[test]
+        fn test_validate_against_layer_out_of_bounds() {
+            let cfg = Qwen35Config::qwen35_0_8b();
+            // layer 999 does not exist
+            let adapter = make_adapter_for_layer(999, "q_proj", 1024, 4096);
+            assert!(adapter.validate_against(&cfg).is_err());
+        }
+
+        #[test]
+        fn test_validate_against_dim_mismatch() {
+            let cfg = Qwen35Config::qwen35_0_8b();
+            // 0.8b: hidden=1024, full_q_dim=8*256=2048 → q_proj expects (1024, 4096)
+            // Supply 2b dims (hidden=2048, full_q_dim=4096 → d_out=8192) — wrong for 0.8b.
+            // Layer 3 is full-attention in the 24-layer 0.8b config.
+            let adapter = make_adapter_for_layer(3, "q_proj", 2048, 8192);
+            assert!(adapter.validate_against(&cfg).is_err());
+        }
+
+        #[test]
+        fn test_validate_against_correct_dims_passes() {
+            let cfg = Qwen35Config::qwen35_0_8b();
+            // Layer 3 is full-attention; q_proj: d_in=hidden=1024, d_out=2*full_q_dim=4096.
+            let adapter = make_adapter_for_layer(3, "q_proj", 1024, 4096);
+            assert!(adapter.validate_against(&cfg).is_ok());
+        }
+
+        #[test]
+        fn test_validate_against_mlp_correct() {
+            let cfg = Qwen35Config::qwen35_0_8b();
+            // gate_proj on any layer: d_in=hidden=1024, d_out=intermediate=3584.
+            let adapter = make_adapter_for_layer(0, "gate_proj", 1024, 3584);
+            assert!(adapter.validate_against(&cfg).is_ok());
+        }
+
+        #[test]
+        fn test_validate_against_unknown_module_errors() {
+            let cfg = Qwen35Config::qwen35_0_8b();
+            let adapter = make_adapter_for_layer(3, "xq_proj_typo", 1024, 4096);
+            let err = adapter.validate_against(&cfg).unwrap_err();
+            assert!(err.to_string().contains("not a recognised"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
Adds `LoraAdapter::validate_against(&Qwen35Config)` (`crates/tune/src/lora/mod.rs:194`) — checks
layer-index bounds and `(d_in, d_out)` per module against the model's config-derived projection
dims **before** `set_lora`, returning a typed error on mismatch. Wired into the load→apply path in
`generate_lora.rs:82` (between `from_safetensors` and `set_lora`). 5 new tests.

Closes #8.

## LoRA-API backlog dispositions (verify-first; Π_AEP)
This play verified the full LoRA-API cluster against current code. Only #8 needed new code; the
rest were already implemented (recommend closing at review with the evidence below):

| Issue | Disposition | Evidence |
|------|------------|----------|
| **#8** | **IMPLEMENTED here** | `validate_against` + 5 tests (this PR) |
| #61 `adapt_step` | already done | `lora/online.rs:38` + 4 tests (PR #65) |
| #62 typed ModuleName enum | DECIDED: keep `String` keys + `validate_modules` | ADR-057 D4 records the decision; `mod.rs:175` + tests (PR #65) |
| #63 downstream Cargo.toml doc | already done | ADR-031:96-121 + `tune/Cargo.toml:20` |
| #60 SafeTensors save | save-side done | `safetensors.rs:413` writes rank/alpha/target_modules + round-trip test (PR #65). **Residual follow-up:** load-side `alpha != rank` readback (load defaults `alpha = rank`) — the known ADR-057 alpha-metadata follow-up; not in this batch. |

## Verification
- `cargo test -p lattice-tune --features "safetensors,inference-hook" lora` → 45/45 pass.
- `cargo clippy --workspace -- -D warnings` clean; critic CRIT 0 / MAJ 0 — APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)