### PR TITLE
docs: consolidated models, attention variants & features reference (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,20 @@ Model weights are downloaded from HuggingFace on first use and cached at `~/.lat
 
 ## Features
 
-| Feature                       | Description                                                                                  |
-| ----------------------------- | -------------------------------------------------------------------------------------------- |
-| Pure Rust compute             | Hand-written SIMD kernels (AVX2/NEON). No C++, no ONNX, no CUDA.                             |
-| Two transformer architectures | BERT/BGE encoder-only (mean pooling) and Qwen3 decoder-only (causal GQA, last-token pooling) |
-| 9 supported models            | BGE, mE5, MiniLM, Qwen3-Embedding families — see table below                                 |
-| Metal GPU backend             | Native Apple Silicon acceleration via Metal MSL shaders. WGPU fallback for cross-platform.   |
-| Three pure Rust tokenizers    | WordPiece, SentencePiece, BPE — no Hugging Face tokenizers C extension                       |
-| Safetensors native            | Memory-mapped weight loading from HuggingFace `.safetensors` format                          |
-| MRL support                   | Matryoshka truncation for Qwen3 models (configurable output dimension >= 32)                 |
-| LRU embedding cache           | `CachedEmbeddingService` with sharded in-memory cache and hit/miss stats                     |
-| LoRA adapter injection        | Inject trained LoRA adapters into inference models at runtime                                |
-| Knowledge distillation        | Train small models from Claude/GPT/Gemini teacher soft labels                                |
-| Optimal transport             | Sinkhorn-Knopp solver (log-domain, epsilon-scaling) for embedding drift detection            |
-| Tiny fast networks            | `lattice-fann`: sub-5ms classifiers with pre-allocated buffers, zero-alloc forward pass      |
+| Feature                    | Description                                                                                                                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pure Rust compute          | Hand-written SIMD kernels (AVX2/NEON). No C++, no ONNX, no CUDA.                                                                                                                |
+| Multiple model families    | BERT/BGE encoder (CLS pooling), E5/MiniLM encoder (mean pooling), Qwen3 decoder embedding, Qwen3.5/3.6 generation, CrossEncoder reranker — see [docs/models.md](docs/models.md) |
+| 9 local embedding models   | BGE, mE5, MiniLM, Qwen3-Embedding families — full support matrix: [docs/models.md](docs/models.md)                                                                              |
+| Metal GPU backend          | Native Apple Silicon acceleration via Metal MSL shaders. WGPU fallback for cross-platform.                                                                                      |
+| Three pure Rust tokenizers | WordPiece, SentencePiece, BPE — no Hugging Face tokenizers C extension                                                                                                          |
+| Safetensors native         | Memory-mapped weight loading from HuggingFace `.safetensors` format                                                                                                             |
+| MRL support                | Matryoshka truncation for Qwen3 models (configurable output dimension >= 32)                                                                                                    |
+| LRU embedding cache        | `CachedEmbeddingService` with sharded in-memory cache and hit/miss stats                                                                                                        |
+| LoRA adapter injection     | Inference hook, `Qwen35Model::set_lora`, `lattice-tune` PEFT safetensors, Metal single-adapter path — see [docs/models.md §3](docs/models.md#3-inference-features)              |
+| Knowledge distillation     | Train small models from Claude/GPT/Gemini teacher soft labels                                                                                                                   |
+| Optimal transport          | Sinkhorn-Knopp solver (log-domain, epsilon-scaling) for embedding drift detection                                                                                               |
+| Tiny fast networks         | `lattice-fann`: sub-5ms classifiers with pre-allocated buffers, zero-alloc forward pass                                                                                         |
 
 ---
 
@@ -127,25 +127,26 @@ and can be used standalone.
 
 ## Supported Models
 
-All local models load from HuggingFace safetensors format.
+For the full support matrix — all embedding and generation models, attention variants, inference
+features, and tokenizer details — see **[docs/models.md](docs/models.md)**.
 
-| Model                               | Variant                                                     | Architecture       | Dimensions | Max Tokens | Tokenizer     |
-| ----------------------------------- | ----------------------------------------------------------- | ------------------ | ---------- | ---------- | ------------- |
-| `BgeSmallEnV15`                     | BAAI/bge-small-en-v1.5                                      | BERT encoder       | 384        | 512        | WordPiece     |
-| `BgeBaseEnV15`                      | BAAI/bge-base-en-v1.5                                       | BERT encoder       | 768        | 512        | WordPiece     |
-| `BgeLargeEnV15`                     | BAAI/bge-large-en-v1.5                                      | BERT encoder       | 1024       | 512        | WordPiece     |
-| `MultilingualE5Small`               | intfloat/multilingual-e5-small                              | BERT encoder       | 384        | 512        | SentencePiece |
-| `MultilingualE5Base`                | intfloat/multilingual-e5-base                               | BERT encoder       | 768        | 512        | SentencePiece |
-| `AllMiniLmL6V2`                     | sentence-transformers/all-MiniLM-L6-v2                      | BERT encoder       | 384        | 256        | WordPiece     |
-| `ParaphraseMultilingualMiniLmL12V2` | sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 | BERT encoder       | 384        | 128        | WordPiece     |
-| `Qwen3Embedding0_6B`                | Qwen/Qwen3-Embedding-0.6B                                   | Decoder (GQA+RoPE) | 1024       | 8192       | BPE           |
-| `Qwen3Embedding4B`                  | Qwen/Qwen3-Embedding-4B                                     | Decoder (GQA+RoPE) | 2560*      | 8192       | BPE           |
+Quick reference for the local embedding models available through `EmbeddingModel`:
 
-*Qwen3-Embedding-4B supports MRL truncation to any dimension >= 32.
+| Variant                             | HuggingFace ID                                                | Dims  | Max tokens | Auto-download  |
+| ----------------------------------- | ------------------------------------------------------------- | :---: | :--------: | :------------: |
+| `BgeSmallEnV15`                     | `BAAI/bge-small-en-v1.5`                                      |  384  |    512     |       ✓        |
+| `BgeBaseEnV15`                      | `BAAI/bge-base-en-v1.5`                                       |  768  |    512     |       ✓        |
+| `BgeLargeEnV15`                     | `BAAI/bge-large-en-v1.5`                                      | 1024  |    512     |       ✓        |
+| `MultilingualE5Small`               | `intfloat/multilingual-e5-small`                              |  384  |    512     |       ✓        |
+| `MultilingualE5Base`                | `intfloat/multilingual-e5-base`                               |  768  |    512     |       ✓        |
+| `AllMiniLmL6V2`                     | `sentence-transformers/all-MiniLM-L6-v2`                      |  384  |    256     |       ✓        |
+| `ParaphraseMultilingualMiniLmL12V2` | `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` |  384  |    128     |       ✓        |
+| `Qwen3Embedding0_6B`                | `Qwen/Qwen3-Embedding-0.6B`                                   | 1024  |    8192    | local dir only |
+| `Qwen3Embedding4B`                  | `Qwen/Qwen3-Embedding-4B`                                     | 2560† |    8192    | local dir only |
 
-E5 models expect asymmetric `"query: "` / `"passage: "` prefixes for retrieval. Qwen3 models
-expect an instruction prefix. The `EmbeddingModel` enum exposes `query_instruction()` and
-`document_instruction()` so callers can apply these correctly.
+†Both Qwen3 embedding variants support MRL truncation to any dimension ≥ 32.
+BGE v1.5 uses CLS pooling; E5 and MiniLM use mean pooling.
+E5 `document_instruction()` returns `"passage: "` — `embed_passage()` applies it automatically.
 
 ---
 
@@ -283,30 +284,30 @@ vectors enough to warrant re-indexing.
 
 Fair end-to-end measurement — **slope method**: `tok/s = (N₂−N₁) / (T(N₂)−T(N₁))` for a fixed
 prompt, so prompt prefill, model load, and per-call overhead cancel and every engine is measured
-the *same* way (greedy, median of 5 runs, N₁=32, N₂=256).
+the _same_ way (greedy, median of 5 runs, N₁=32, N₂=256).
 
-| Engine | Quant | decode tok/s | Notes |
-|--------|-------|--------------|-------|
-| MLX | Q8 (g64) | **247** | Apple's Metal-native framework — fastest |
-| **Lattice** | f16 | **157** | Pure Rust + Metal; ~1.9× Ollama |
-| Ollama | Q8_0 | **84** | llama.cpp Metal backend |
+| Engine      | Quant    | decode tok/s | Notes                                    |
+| ----------- | -------- | ------------ | ---------------------------------------- |
+| MLX         | Q8 (g64) | **247**      | Apple's Metal-native framework — fastest |
+| **Lattice** | f16      | **157**      | Pure Rust + Metal; ~1.9× Ollama          |
+| Ollama      | Q8_0     | **84**       | llama.cpp Metal backend                  |
 
 Cross-check: Ollama's slope (84) matches its own `eval_duration` rate (87), confirming the
 methodology is sound.
 
 **Honest caveats.** Lattice's Qwen3.5 decode path is **f16** (`MetalQwen35State::new`); MLX is Q8
 and Ollama is Q8_0, so this is not quant-matched. There is **no end-to-end Q8 path** for Qwen3.5
-in Lattice — the earlier "Q8 139" number was an f16 `forward_step` *micro-benchmark* mislabeled
+in Lattice — the earlier "Q8 139" number was an f16 `forward_step` _micro-benchmark_ mislabeled
 "Q8" (the bench's `load_q8_state` builds the same f16 state as the f16 path). 157 tok/s (f16,
 true e2e) is Lattice's actual decode rate for this model; the only other real e2e path is **Q4**
 (`from_q4_dir`). **MLX decodes faster than Lattice.** Lattice's value is portability plus
 capabilities no other engine has on this model:
 
-| Lattice-only capability | MLX | Ollama |
-|---|---|---|
-| QuaRot 4-bit (rotated quant) | ✗ | ✗ |
-| Q4 + LoRA r8 hot-swap (no reload) | ✗ | ✗ |
-| Pure Rust, zero Python / framework | ✗ | ✗ |
+| Lattice-only capability            | MLX | Ollama |
+| ---------------------------------- | --- | ------ |
+| QuaRot 4-bit (rotated quant)       | ✗   | ✗      |
+| Q4 + LoRA r8 hot-swap (no reload)  | ✗   | ✗      |
+| Pure Rust, zero Python / framework | ✗   | ✗      |
 
 A previous version of this table claimed "+8% vs MLX"; that was a measurement artifact (a
 criterion `forward_step` micro-bench compared against MLX end-to-end with prefill counted in the

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,126 +1,173 @@
-# Models
+# Supported Models, Attention Variants & Features
 
-## Supported Models
+Authoritative reference for what Lattice supports **today** in the current codebase.
+Every entry is verified against source code. Status labels:
 
-| Variant                             | HuggingFace ID                                                | Architecture  | Dimensions | Max Tokens | Languages    | Use Case                        |
-| ----------------------------------- | ------------------------------------------------------------- | ------------- | ---------- | ---------- | ------------ | ------------------------------- |
-| `BgeSmallEnV15`                     | `BAAI/bge-small-en-v1.5`                                      | BERT encoder  | 384        | 512        | English      | Default — fast, small footprint |
-| `BgeBaseEnV15`                      | `BAAI/bge-base-en-v1.5`                                       | BERT encoder  | 768        | 512        | English      | Balanced quality/speed          |
-| `BgeLargeEnV15`                     | `BAAI/bge-large-en-v1.5`                                      | BERT encoder  | 1024       | 512        | English      | Highest quality English         |
-| `MultilingualE5Small`               | `intfloat/multilingual-e5-small`                              | BERT encoder  | 384        | 512        | 100+         | Multilingual, fast              |
-| `MultilingualE5Base`                | `intfloat/multilingual-e5-base`                               | BERT encoder  | 768        | 512        | 100+         | Multilingual, balanced          |
-| `AllMiniLmL6V2`                     | `sentence-transformers/all-MiniLM-L6-v2`                      | BERT encoder  | 384        | 256        | English      | Sentence similarity             |
-| `ParaphraseMultilingualMiniLmL12V2` | `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` | BERT encoder  | 384        | 128        | 50+          | Paraphrase detection            |
-| `Qwen3Embedding0_6B`                | `Qwen/Qwen3-Embedding-0.6B`                                   | Decoder (GQA) | 1024       | 8192       | Multilingual | Long context, MRL-capable       |
-| `Qwen3Embedding4B`                  | `Qwen/Qwen3-Embedding-4B`                                     | Decoder (GQA) | 2560       | 8192       | Multilingual | Highest quality, MRL-capable    |
-| `TextEmbedding3Small`               | `text-embedding-3-small` (OpenAI)                             | Remote API    | 1536       | 8191       | Multilingual | Remote fallback                 |
+- **shipped** — callable path exists now for the stated scope.
+- **partial** — callable path exists, but an important integration or model family is limited.
+- **experimental** — code exists but is unstable, gated, or not a general serving API.
+- **scaffold-only** — type/config placeholder exists; no usable runtime path.
+- **not shipped** — absent in the current branch.
+- **P1 metadata only** — PR #132 metadata enum; not a production dispatch layer.
 
-`TextEmbedding3Small` is the only remote model; all others run locally via `lattice-inference`.
+---
 
-## Model Architecture Details
+## 1. Supported Models
 
-### BERT/BGE Family (Encoder-Only)
+Lattice has local embedding loaders for seven BERT-family embedding variants, local-directory
+Qwen3 embedding loaders, a local Qwen3.5/Qwen3.6 generation loader, a local BERT-style
+cross-encoder loader, a remote embedding enum placeholder, and a BitNet config scaffold.
 
-Config sourced from `lattice_inference::BertConfig`:
+Automatic HuggingFace download is available **only for the seven BERT-family embedding variants**.
+Qwen3 embedding and Qwen3.5/Qwen3.6 generation paths require local files.
 
-| Variant   | Hidden size | Layers | Attention heads | Intermediate | Parameters |
-| --------- | ----------- | ------ | --------------- | ------------ | ---------- |
-| BGE-small | 384         | 12     | 12              | 1536         | ~33M       |
-| BGE-base  | 768         | 12     | 12              | 3072         | ~110M      |
-| BGE-large | 1024        | 24     | 16              | 4096         | ~335M      |
+### Embedding models (`EmbeddingModel`)
 
-- Tokenizer: WordPiece (BGE, all-MiniLM); SentencePiece/BPE (mE5)
-- Vocab: 30,522 tokens
-- Pooling: mean pooling over non-padding tokens, followed by L2 normalization
-- Layer norm eps: 1e-12
+| Variant                             | HuggingFace ID                                                | Dims  | Max tokens |  Pooling   |    Download    |    Status     |
+| ----------------------------------- | ------------------------------------------------------------- | :---: | :--------: | :--------: | :------------: | :-----------: |
+| `BgeSmallEnV15`                     | `BAAI/bge-small-en-v1.5`                                      |  384  |    512     |    CLS     |       ✓        |    shipped    |
+| `BgeBaseEnV15`                      | `BAAI/bge-base-en-v1.5`                                       |  768  |    512     |    CLS     |       ✓        |    shipped    |
+| `BgeLargeEnV15`                     | `BAAI/bge-large-en-v1.5`                                      | 1024  |    512     |    CLS     |       ✓        |    shipped    |
+| `MultilingualE5Small`               | `intfloat/multilingual-e5-small`                              |  384  |    512     |    mean    |       ✓        |    shipped    |
+| `MultilingualE5Base`                | `intfloat/multilingual-e5-base`                               |  768  |    512     |    mean    |       ✓        |    shipped    |
+| `AllMiniLmL6V2`                     | `sentence-transformers/all-MiniLM-L6-v2`                      |  384  |    256     |    mean    |       ✓        |    shipped    |
+| `ParaphraseMultilingualMiniLmL12V2` | `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` |  384  |    128     |    mean    |       ✓        |    shipped    |
+| `Qwen3Embedding0_6B`                | `Qwen/Qwen3-Embedding-0.6B`                                   | 1024  |   8192†    | last-token | local dir only |    partial    |
+| `Qwen3Embedding4B`                  | `Qwen/Qwen3-Embedding-4B`                                     | 2560‡ |   8192†    | last-token | local dir only |    partial    |
+| `TextEmbedding3Small`               | `text-embedding-3-small` (OpenAI)                             | 1536  |    8191    |     —      |       —        | scaffold-only |
 
-### Qwen3-Embedding (Decoder-Only)
+†Model config advertises 32 768 max positions; `EmbeddingModel::max_input_tokens()` caps service
+usage at 8 192.
 
-Architecture: causal attention with GQA (Grouped-Query Attention), RoPE positional encoding,
-RMSNorm, SwiGLU FFN activation, last-token pooling.
+‡`Qwen3Embedding4B` and `Qwen3Embedding0_6B` both support MRL (Matryoshka Representation
+Learning): the output dimension can be truncated to any value ≥ 32 via
+`ModelConfig::try_new(model, Some(dim))`.
 
-Key difference from BERT: decoder models produce the embedding from the last non-padding token
-rather than mean-pooling the full sequence. They handle long context (8192 tokens) natively
-because of RoPE but have higher memory and compute requirements.
+**Notes on BGE pooling**: BGE v1.5 models use **CLS** pooling; E5 and MiniLM variants use
+**mean** pooling. They do not all use mean pooling.
 
-MRL (Matryoshka Representation Learning) is supported: the 4B model's 2560-dimensional output
-can be truncated to any dimension ≥ 32 with `ModelConfig::try_new(model, Some(dim))`. This
-allows trading off retrieval quality for storage and compute cost.
+**`TextEmbedding3Small`**: `is_remote()` returns `true` and the native service rejects it.
+No remote service implementation exists. Do not treat it as a working fallback.
 
-## How Models Are Loaded
+**E5 prefixes**: `query_instruction()` returns `"query: "` and `document_instruction()` returns
+`"passage: "` for both E5 variants. `embed_passage()` applies the prefix automatically — callers
+do not need to add it manually.
 
-All local models are loaded from safetensors files via memory-mapped I/O:
+### Other loader surfaces
 
-```
-~/.lattice/models/<model-name>/model.safetensors   ← mmap'd (zero-copy)
-~/.lattice/models/<model-name>/vocab.txt            ← WordPiece models
-~/.lattice/models/<model-name>/tokenizer.json       ← SentencePiece/BPE models
-```
+| Surface                                                                 |                    Status                     | Notes                                                                                                                                                                                                                                                                        |
+| ----------------------------------------------------------------------- | :-------------------------------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BERT/BGE local loader (`BertModel::from_directory` / `from_pretrained`) |                    shipped                    | Loads `model.safetensors` + auto-detected tokenizer. `from_pretrained` downloads only cataloged BERT-family IDs. Sharded BERT safetensors are **not** supported.                                                                                                             |
+| Cross-encoder reranker (`CrossEncoderModel::from_directory`)            |                    shipped                    | BERT-style sequence-classification for query-document scoring. Requires pair tokenization and `type_vocab_size >= 2`.                                                                                                                                                        |
+| Qwen3 embedding local loader (`QwenModel::from_directory`)              | shipped for local files, partial for download | Loads single-file or sharded Qwen3 embedding checkpoints. Sharded loading is handled by `ShardedSafetensors::open_index` when `model.safetensors.index.json` is present — no `backfill` feature required. `from_pretrained` exists but the download catalog has no Qwen IDs. |
+| Qwen3.5/Qwen3.6 generation loader (`Qwen35Model::from_safetensors`)     |                    partial                    | Loads local single-file or sharded Qwen3.5/Qwen3.6 generation checkpoints. MTP fields are config/runtime-gated (experimental).                                                                                                                                               |
+| `Qwen35Config::qwen35_2b` preset                                        |                    shipped                    | 24 layers, 2 048 hidden, dense FFN, tied embeddings, 262 144 max positions.                                                                                                                                                                                                  |
+| `Qwen35Config::qwen35_0_8b` preset                                      |                    partial                    | 24 layers, 1 024 hidden, dense FFN, 1 MTP layer. Base decode wired; MTP experimental.                                                                                                                                                                                        |
+| `Qwen35Config::qwen36_35b_a3b` preset                                   |                    partial                    | 40 layers, MoE 256 experts top-8 plus shared expert. Config/weight loader supported; not a polished serving path.                                                                                                                                                            |
+| `Qwen35Config::qwen36_27b` preset                                       |                    partial                    | 64 layers, 5 120 hidden, dense FFN. Local loader/config support; not a served product surface.                                                                                                                                                                               |
+| BitNet b1.58 2B4T (`BitNetConfig::bitnet_2b4t`)                         |                 scaffold-only                 | Config preset exists; no `BitNetModel` loader is re-exported from `model/mod.rs`.                                                                                                                                                                                            |
 
-The `SafetensorsFile` type in `lattice-inference` wraps the mmap and provides typed tensor
-views (`Tensor1D`, `Tensor2D`). Weights are never copied to a separate heap buffer unless the
-`backfill` feature is enabled for sharded Qwen checkpoints.
+### Model loading and cache
 
-Weight formats available (controlled by `lattice-inference` feature flags):
+```text
+# BERT-family (auto-download available)
+~/.lattice/models/<model-name>/model.safetensors
+~/.lattice/models/<model-name>/vocab.txt            (WordPiece models)
+~/.lattice/models/<model-name>/tokenizer.json       (BPE/SentencePiece models)
 
-- `f32` — default, highest precision
-- `f16` — half precision, enabled by the `f16` feature
-- `Q8` — 8-bit quantization
-- `Q4` — 4-bit quantization
+# Qwen3 embedding (local directory required)
+LATTICE_QWEN_MODEL_DIR or ~/.lattice/models/qwen3-embedding-<variant>/
 
-## Download Mechanism
-
-The `download` feature in `lattice-inference` (enabled by default in `lattice-embed`) fetches
-model files from HuggingFace on first use:
-
-```
-https://huggingface.co/{hf_model_id}/resolve/main/model.safetensors
-https://huggingface.co/{hf_model_id}/resolve/main/vocab.txt       (BGE/MiniLM)
-https://huggingface.co/{hf_model_id}/resolve/main/tokenizer.json  (E5/Qwen3)
-```
-
-The download is skipped when both `model.safetensors` and the tokenizer file are already
-present in the cache directory. The SHA-2 hash of downloaded files is verified.
-
-Disable auto-download:
-
-```toml
-lattice-inference = { git = "...", default-features = false, features = ["std"] }
+# Qwen3.5/Qwen3.6 generation (local directory required)
+<path>/model.safetensors  (single-file or sharded)
+<path>/tokenizer.json     (BPE, required)
 ```
 
-With download disabled, `InferenceError::ModelNotFound` is returned if weights are absent.
+Environment variables:
 
-## Cache Directory
+- `LATTICE_MODEL_CACHE` — overrides the BERT-family download cache directory (default
+  `~/.lattice/models`).
+- `LATTICE_QWEN_MODEL_DIR` — overrides the Qwen3 embedding local directory.
 
-Default cache: `~/.lattice/models/`. This is exposed as:
+Public loader functions are `from_pretrained()` (download-backed, BERT-family only) and
+`from_directory()` (local path). The old names `BertModel::load` / `QwenModel::load` are **not**
+the current public API.
 
-```rust
-// lattice-inference
-pub const DEFAULT_CACHE_DIR: &str = "~/.lattice/models";
-```
+### Weight formats
 
-Override by setting the `LATTICE_CACHE_DIR` environment variable or passing a custom path
-to `BertModel::load` / `QwenModel::load`.
+`f32` safetensors are the primary and universal path. f16, Q8, Q4, and QuaRot Q4 code exists
+but support is path-specific, not universal across all models:
 
-## Adding a New Model
+- **f16** — half-precision helpers; not a shipped f16 KV-cache path (see §3).
+- **Q8** — dense-only; panics on MoE configs.
+- **Q4** — available via the `quantize_q4` binary for supported paths.
+- **QuaRot Q4** — offline converter (`quantize_quarot` binary) + Metal direct-load path. Converter
+  refuses non-power-of-two hidden dims and MoE configs.
 
-To add support for a new embedding model:
+---
 
-1. **If BERT-family (encoder-only)**: Add a `BertConfig` factory method in
-   `crates/inference/src/model/bert.rs` with the correct `hidden_size`, `num_hidden_layers`,
-   `num_attention_heads`, `intermediate_size`, and `max_position_embeddings`. Wire the HuggingFace
-   ID into the `canonical_model_name` mapping in `crates/inference/src/download.rs`.
+## 2. Attention Variants
 
-2. **If decoder-only**: Add a `QwenConfig` in `crates/inference/src/model/qwen.rs` with
-   the correct GQA head counts, RoPE theta, and SwiGLU expansion ratio. Verify that the
-   `last_token_pool` path handles the model's attention mask convention.
+The current `docs/supported-models-features` branch exports attention modules but does **not**
+contain the `AttentionKind` enum. The 10-row table below is taken from PR #132's hardened
+ADR-059 Phase-1 metadata enum on branch `show/seed-impl/attention-dispatch`.
 
-3. **Add a variant to `EmbeddingModel`** in `crates/embed/src/model.rs`. Implement the match
-   arms for `dimensions()`, `max_input_tokens()`, `query_instruction()`, `model_id()`, and
-   `is_local()`. Add `FromStr` patterns.
+**`AttentionKind` is P1 metadata only.** The enum does not implement `AttentionOp`, allocate
+state or scratch buffers, or call kernels. Production callers via a dispatch layer are future
+P2+ work. The "production caller" column describes whether the _backing implementation_ (kernel,
+forward pass) is used today outside the enum.
 
-4. **Wire into `NativeEmbeddingService`** in `crates/embed/src/service/native.rs` — the
-   `LoadedModel` enum dispatches on the model variant to choose the BERT or Qwen path.
+The enum is exhaustive: PR #132 tests assert exactly 10 variants.
 
-5. Add a test asserting the expected embedding dimensions and a round-trip `FromStr`/`Display`
-   check.
+| Variant               | `is_causal` | `supports_kv_cache` | Production caller (backing impl)                                                                                                      |
+| --------------------- | :---------: | :-----------------: | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `Mha`                 |    false    |        false        | Backing MHA is production-used by BERT and CrossEncoder. `AttentionKind`: P1 metadata only.                                           |
+| `Gqa(gqa::GqaConfig)` |    true     |        true         | Backing cache-backed GQA is production-used by Qwen generation/decode paths. `AttentionKind`: P1 metadata only.                       |
+| `Flash`               |    false    |        false        | Backing tiled CPU Flash code exists; no verified production caller. `AttentionKind`: P1 metadata only.                                |
+| `FlashCausal`         |    true     |        false        | Backing causal Flash module exists; no verified production caller. `AttentionKind`: P1 metadata only.                                 |
+| `Gdn`                 |    true     |        false        | Backing recurrent GDN step exists; production Qwen3.5 uses the fused variant instead. `AttentionKind`: P1 metadata only.              |
+| `GdnFused`            |    true     |        false        | Backing fused GDN has a production caller in the Qwen3.5 forward path for linear-attention layers. `AttentionKind`: P1 metadata only. |
+| `GatedGqa`            |    true     |        true         | Backing behavior is production-used by Qwen3.5 full-attention layers (K/V append + sigmoid gate). `AttentionKind`: P1 metadata only.  |
+| `Differential`        |    true     |        false        | Backing standalone kernel exists; no verified production caller. `AttentionKind`: P1 metadata only.                                   |
+| `NativeSparse`        |    true     |        false        | Backing standalone NSA kernel exists; no verified production caller. `AttentionKind`: P1 metadata only.                               |
+| `Decode`              |    true     |        true         | Backing decode path has a Metal production caller. `AttentionKind`: P1 metadata only.                                                 |
+
+**Recurrent vs KV-cache**: GDN and GdnFused use recurrent state (`GatedDeltaNetState`), not a
+KV cache — hence `supports_kv_cache = false`.
+
+---
+
+## 3. Inference Features
+
+| Feature                     |           Status           | Notes                                                                                                                                                                                                                                                  |
+| --------------------------- | :------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| f16 KV cache                |      **not shipped**       | Current flat, paged, and Qwen3.5 ad hoc KV caches store `f32` and accept `&[f32]` append/read buffers. The `f16` feature flag covers weight helpers only.                                                                                              |
+| LoRA inference hook         |      partial/shipped       | CPU inference hook for projection deltas; `Qwen35Model::set_lora` exposed. `lattice-tune` loads PEFT safetensors behind `inference-hook`. Metal single-active-adapter runtime path exists. Multi-adapter continuous-batching grouping is not complete. |
+| LoRA + QuaRot composition   |      partial/shipped       | Rotation-aware LoRA transformation exists; Metal loader applies it when `quarot_seed` is supplied. Unknown targets fail closed. Scope limited to supported projection targets.                                                                         |
+| QuaRot INT4                 |      partial/shipped       | QuaRot module family, offline converter (`quantize_quarot` binary), and Metal direct Q4/F16 directory loader exist. Converter refuses non-power-of-two hidden dims and MoE configs.                                                                    |
+| Speculative decoding        |        experimental        | N-gram speculative decoding wrapper (model-agnostic); MTP verifier structs/metrics exist; Metal MTP/self-spec paths are greedy-only and disabled with grammar or compact sampling. Not a stable serving API.                                           |
+| Continuous batching         |   partial — library only   | `batch` module exports Phase-1 scheduler/worker structures with chunked prefill and FIFO policy. HTTP/gRPC serving integration is **not** in scope for the current branch (ADR-048 excludes it; ADR-063 defers serving to v0.4+).                      |
+| Serving / CLI               |      partial/proposed      | Standalone binaries exist (`chat_metal`, `qwen35_generate`, `quantize_q4`, `quantize_quarot`). There is **no** unified `lattice` binary, no HTTP server, no API compatibility layer. ADR-063 is a proposed target state, not current behavior.         |
+| Grammar / structured output | partial/shipped (unstable) | Grammar-constrained decoding supports a JSON Schema subset and GBNF escape hatch, compiled into `GrammarEngine`, masks logits, and is wired into the Metal generation loop. Grammar disables compact top-k and speculative paths.                      |
+| Metrics / profiling         |      partial/proposed      | Current observability is profiling structs, `encode_profiled()`, and env-gated Metal step profiling. ADR-061 `MetricsMode`/`ForwardCtx`/`MetricSink`/SQLite/JSONL infrastructure is proposed/design-only.                                              |
+
+---
+
+## 4. Tokenizers
+
+Lattice has three dependency-free tokenizer implementations behind a common `Tokenizer` trait
+and an auto-loader. The loader probes files in this order: `tokenizer.json` → BPE vocab/merges →
+`vocab.txt` → `tokenizer.model`. Unsupported `tokenizer.json` model types return an error.
+
+`Tokenizer` trait methods: `tokenize`, `tokenize_batch`, `vocab_size`, `max_seq_len`,
+pair-tokenization checks, and `decode`.
+
+| Tokenizer     | Status  | Notes                                                                                                                                                                                                                                |
+| ------------- | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| BPE           | shipped | Byte-level GPT/Qwen-style BPE. Supports `tokenizer.json`, `vocab.json` + `merges.txt`, and `vocab.txt` + `merges.txt`. Qwen3.5/Qwen3.6 generation **requires** BPE `tokenizer.json`. Qwen3 embedding also typically resolves to BPE. |
+| SentencePiece | shipped | Unigram model. Supports HF `tokenizer.json` types `Unigram` / `SentencePieceUnigram` and native `tokenizer.model`. Available to BERT-family loaders through `load_tokenizer` when the model directory provides compatible files.     |
+| WordPiece     | shipped | Supports `tokenizer.json` model type `WordPiece` and `vocab.txt`. Implements BERT-style pair tokenization. BGE/MiniLM download paths use `vocab.txt`. CrossEncoder requires pair tokenization.                                       |
+
+**Tokenizer assignment is auto-detected, not hard-coded per model.** Calling E5 "SentencePiece"
+or BGE/BERT "WordPiece/BPE" as fixed assignments is incorrect — the loader auto-detects the
+format from the files present in the model directory.


### PR DESCRIPTION
## Summary

Resolves #16. Rewrites `docs/models.md` into the single authoritative reference for what Lattice supports, verified against source code. README repointed (4 link sites, stale table replaced).

### Four sections, all code-accurate:
1. **Supported models** — 9 `EmbeddingModel` variants + Qwen3.5/3.6 generation + CrossEncoder + BitNet scaffold (marked scaffold-only)
2. **Attention variants** — all 10 `AttentionKind` from PR #132's hardened enum with exact `is_causal`/`supports_kv_cache`; correctly framed as P1 metadata only
3. **Inference features** — f16 KV cache (not shipped), LoRA (partial), QuaRot (partial), speculative decoding (experimental), continuous batching (library-only), serving/CLI (proposed), grammar (partial-unstable), metrics (proposed)
4. **Tokenizers** — BPE / SentencePiece / WordPiece with auto-detection

### 22 stale claims corrected (highlights):
- BGE pooling: mean → **CLS** pooling
- `TextEmbedding3Small`: supported → **scaffold-only**
- Qwen auto-download: claimed → **local directory required**
- Cache env var: `LATTICE_CACHE_DIR` → `LATTICE_MODEL_CACHE`
- f16 KV cache: implied shipped → **not shipped** (f32 storage)
- Unified serving/CLI: implied → **not shipped** (ADR-063 is proposed)
- `AttentionKind`: implied live dispatch → **P1 metadata, no kernel wiring**

### Critic verdict
APPROVE (0.95) — 8+ file:line spot-checks, attention table verified verbatim against PR #132 source branch, 0 CRIT/MAJ/MIN findings.

## Test plan
- [ ] `docs/models.md` sections match current code (docs-only, no code changes)
- [ ] README links resolve to `docs/models.md`
- [ ] No aspirational claims survive (all status labels honest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)