### PR TITLE
fix(embed): correct double-EOS and trailing-ws tokenization for Qwen3 forward parity (#103)

### DIFF
--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -683,10 +683,14 @@ impl QwenModel {
         let mut ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
 
         let eos = self.inference_config.eos_token_id;
-        if ids.len() < max_len {
-            ids.push(eos);
-        } else {
-            if let Some(last) = ids.last_mut() {
+        // Only append EOS if the tokenizer has not already done so. Qwen3's
+        // tokenizer.json post_processor (TemplateProcessing) appends <|endoftext|>
+        // automatically; a second append would pool from a spurious extra EOS
+        // token instead of the real last-content token, causing embedding divergence.
+        if ids.last() != Some(&eos) {
+            if ids.len() < max_len {
+                ids.push(eos);
+            } else if let Some(last) = ids.last_mut() {
                 *last = eos;
             }
         }

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -1071,7 +1071,12 @@ fn try_newline_run(chars: &[char], pos: usize) -> Option<usize> {
     if i > nl_start { Some(i) } else { None }
 }
 
-/// `\s+(?!\S)` — whitespace not followed by non-whitespace (i.e. trailing)
+/// `\s+(?!\S)` — whitespace not followed by non-whitespace.
+///
+/// Implements greedy-with-backtracking semantics: match as many whitespace chars
+/// as possible such that the char immediately after is NOT `\S` (non-whitespace).
+/// When a whitespace run precedes a non-whitespace char, the longest valid match
+/// is the run minus the last char (whose lookahead sees the following whitespace).
 fn try_trailing_ws(chars: &[char], pos: usize) -> Option<usize> {
     if !chars.get(pos).is_some_and(|c| c.is_whitespace()) {
         return None;
@@ -1080,7 +1085,16 @@ fn try_trailing_ws(chars: &[char], pos: usize) -> Option<usize> {
     while i < chars.len() && chars[i].is_whitespace() {
         i += 1;
     }
-    if i == chars.len() { Some(i) } else { None }
+    if i == chars.len() {
+        Some(i)
+    } else if i > pos + 1 {
+        // Whitespace run of ≥2 before a non-whitespace: backtrack one position.
+        // The resulting match ends at i-1, whose lookahead char (at i-1) is whitespace.
+        Some(i - 1)
+    } else {
+        // Single space before non-whitespace: (?!\S) fails even after backtracking.
+        None
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes #103. Two co-located tokenization bugs caused Qwen3-Embedding-0.6B's cosine divergence from HF golden vectors (worst: 0.9477 on whitespace input, 0.9886 on "fox").

### Root cause 1: Double-EOS in `tokenize_for_embedding` (`qwen.rs`)
The Qwen3 `tokenizer.json` has a `TemplateProcessing` post_processor that automatically appends `<|endoftext|>` (token 151643). `tokenize_for_embedding` then appended it **again**, so last-token pooling extracted embeddings from a spurious extra EOS position instead of the real last-content token.

**Fix:** Guard with `if ids.last() != Some(&eos)`.

### Root cause 2: `try_trailing_ws` missing backtracking (`bpe.rs`)
The GPT-4/tiktoken regex `\s+(?!\S)` uses greedy-with-backtracking. For N≥2 spaces before a word, the match is N−1 spaces (backtrack 1). The lattice implementation only matched at end-of-string, producing wrong pre-tokenization chunks and wrong BPE token IDs for inputs with interior whitespace runs.

**Fix:** Add the backtrack-1 branch for runs of ≥2 whitespace before non-whitespace.

### Differential evidence (per CLAUDE.md methodology)

| Hypothesis | Max-diff before | Max-diff after | Status |
|---|---|---|---|
| Double-EOS | fox 0.0141, ws 0.0347 | fox 0.0021, ws 0.0292 | **DECISIVE #1** (partial) |
| try_trailing_ws backtracking | ws cos=0.961 remaining | ws 0.0018 → cos 0.9999 | **DECISIVE #2** |
| Bidirectional attention mask | tested: all inputs cos 0.03–0.31 | — | REFUTED |
| RoPE pairing | stride-half already in place (v0.2.3) | — | Correct already |

### After fix — all 5 inputs cos ≥ 0.9998

| Input | Before | After |
|---|---|---|
| fox | 0.9886 | **0.9999** |
| "Pure Rust..." | 0.9973 | **0.9998** |
| "Café résumé..." | 0.9954 | **0.9999** |
| "   leading whitespace..." | 0.9477 | **0.9999** |
| "短い日本語..." | 0.9899 | **0.9999** |

All 4 other models (BGE, E5, MiniLM, paraphrase) remain ≥ 0.9998. Clippy/fmt clean.

## Test plan
- [ ] `LATTICE_NO_GPU=1 cargo test -p lattice-embed --test embed_parity_vs_hf -- qwen` — all 5 inputs cos ≥ 0.995
- [ ] Other 4 model parity tests still pass ≥ 0.9998
- [ ] `cargo test -p lattice-inference -- tokenizer` — 32/32 pass
- [ ] `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)