### PR TITLE
feat(tune): stream generate_lora output via generate_streaming

### DIFF
--- a/crates/tune/src/bin/generate_lora.rs
+++ b/crates/tune/src/bin/generate_lora.rs
@@ -7,7 +7,9 @@
 //!     --lora adapter.safetensors \
 //!     --prompt "Write a Rust function that checks if a number is prime" \
 //!     --max-tokens 64
+//!     [--json]   Emit @@lattice gen_token events for the Lattice Studio app.
 
+use std::io::Write;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -16,6 +18,34 @@ fn parse_arg(args: &[String], flag: &str) -> Option<String> {
         .position(|a| a == flag)
         .and_then(|i| args.get(i + 1))
         .cloned()
+}
+
+fn parse_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|a| a == flag)
+}
+
+/// Escape a string as a JSON string literal (including surrounding double quotes).
+/// Does NOT depend on serde_json — this is a self-contained, correct escaper.
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                // Other ASCII control characters: \u00XX
+                let code = c as u32;
+                out.push_str(&format!("\\u{code:04x}"));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 fn default_model_cache() -> PathBuf {
@@ -41,7 +71,14 @@ fn main() {
 
     let temperature: Option<f32> = parse_arg(&args, "--temperature").and_then(|s| s.parse().ok());
 
+    let top_k: Option<usize> = parse_arg(&args, "--top-k").and_then(|s| s.parse().ok());
+    let top_p: Option<f32> = parse_arg(&args, "--top-p").and_then(|s| s.parse().ok());
+    let repetition_penalty: Option<f32> =
+        parse_arg(&args, "--repetition-penalty").and_then(|s| s.parse().ok());
+
     let lora_path: Option<PathBuf> = parse_arg(&args, "--lora").map(PathBuf::from);
+
+    let emit_json = parse_flag(&args, "--json");
 
     let model_dir = if let Some(dir) = parse_arg(&args, "--model-dir") {
         PathBuf::from(dir)
@@ -107,39 +144,97 @@ fn main() {
     if let Some(t) = temperature {
         gen_cfg.temperature = t;
     }
+    if let Some(k) = top_k {
+        gen_cfg.top_k = k;
+    }
+    if let Some(p) = top_p {
+        gen_cfg.top_p = p;
+    }
+    if let Some(r) = repetition_penalty {
+        gen_cfg.repetition_penalty = r;
+    }
 
     println!("\nPrompt: {prompt}");
     println!(
-        "Config: temp={}, top_k={}, seed={:?}, max_tokens={}",
-        gen_cfg.temperature, gen_cfg.top_k, gen_cfg.seed, max_tokens
+        "Config: temp={}, top_k={}, top_p={}, rep_penalty={}, seed={:?}, max_tokens={}",
+        gen_cfg.temperature,
+        gen_cfg.top_k,
+        gen_cfg.top_p,
+        gen_cfg.repetition_penalty,
+        gen_cfg.seed,
+        max_tokens
     );
     println!("Generating...\n");
 
-    // Generate
     let t1 = Instant::now();
-    match model.generate(&prompt, &gen_cfg) {
-        Ok(output) => {
-            let gen_ms = t1.elapsed().as_millis();
-            let tok_s = if gen_ms > 0 {
-                output.generated_tokens as f64 / (gen_ms as f64 / 1000.0)
-            } else {
-                0.0
-            };
 
-            println!("--- Output ---");
-            println!("{}", output.text);
-            println!("--- Stats ---");
-            println!(
-                "Tokens: {} prompt + {} generated in {}ms ({:.1} tok/s)",
-                output.prompt_tokens, output.generated_tokens, gen_ms, tok_s
-            );
-            if lora_path.is_some() {
-                println!("LoRA: ACTIVE");
+    if emit_json {
+        // Streaming JSON mode: emit @@lattice gen_token events live.
+        let mut stdout = std::io::stdout();
+        let mut first_token_emitted = false;
+        let mut ttft_ms: f64 = 0.0;
+
+        let result = model.generate_streaming(&prompt, &gen_cfg, |delta| {
+            if !first_token_emitted {
+                ttft_ms = t1.elapsed().as_secs_f64() * 1000.0;
+                first_token_emitted = true;
+            }
+            let token_json = json_escape(delta);
+            writeln!(
+                stdout,
+                "@@lattice {{\"ev\":\"gen_token\",\"token\":{token_json},\"done\":false}}"
+            )
+            .ok();
+            stdout.flush().ok();
+        });
+
+        match result {
+            Ok(output) => {
+                let gen_ms = t1.elapsed().as_millis();
+                let tok_s = if gen_ms > 0 {
+                    output.generated_tokens as f64 / (gen_ms as f64 / 1000.0)
+                } else {
+                    0.0
+                };
+                // Final done event with stats.
+                writeln!(
+                    stdout,
+                    "@@lattice {{\"ev\":\"gen_token\",\"token\":\"\",\"done\":true,\"tok_s\":{tok_s:.1},\"ttft_ms\":{ttft_ms:.1}}}"
+                )
+                .ok();
+                stdout.flush().ok();
+            }
+            Err(e) => {
+                eprintln!("Generation failed: {e}");
+                std::process::exit(1);
             }
         }
-        Err(e) => {
-            eprintln!("Generation failed: {e}");
-            std::process::exit(1);
+    } else {
+        // Non-JSON mode: original atomic output block, unchanged.
+        match model.generate(&prompt, &gen_cfg) {
+            Ok(output) => {
+                let gen_ms = t1.elapsed().as_millis();
+                let tok_s = if gen_ms > 0 {
+                    output.generated_tokens as f64 / (gen_ms as f64 / 1000.0)
+                } else {
+                    0.0
+                };
+
+                println!("--- Output ---");
+                println!("{}", output.text);
+                println!("--- Stats ---");
+                println!(
+                    "Tokens: {} prompt + {} generated in {}ms ({:.1} tok/s)",
+                    output.prompt_tokens, output.generated_tokens, gen_ms, tok_s
+                );
+                if lora_path.is_some() {
+                    println!("LoRA: ACTIVE");
+                }
+            }
+            Err(e) => {
+                eprintln!("Generation failed: {e}");
+                std::process::exit(1);
+            }
         }
     }
 }


### PR DESCRIPTION
## What
Stream tokens from `generate_lora` via `generate_streaming`, with sampler controls.

## Why
`generate_lora` (the LoRA-adapter generation binary) previously buffered the full output. It now uses the streaming entry point from PR-1 so adapter-driven generation streams token-by-token like `chat_metal`.

## Files
- `crates/tune/src/bin/generate_lora.rs` (+119/-24)

## Verification
`cargo build --release -p lattice-tune --bin generate_lora --features safetensors,inference-hook` clean. This binary's compile break (E0599: `generate_streaming` not in scope) was one of the two regressions that motivated the PR-G gate. Built green in the integrated-tree gate.

## Base
Stacked on `pr/eng-1-streaming-detok` (depends on `generate_streaming`). Review/merge PR-1 first.

## Series
Part of the PR #193 engine-slice (finest split). All engine code lands on main; the macOS app surfaces a subset (Models + Chat) for v0.0.1.
