### PR TITLE
docs(tune): document the inference-hook bridge for downstream consumers

### DIFF
--- a/crates/tune/README.md
+++ b/crates/tune/README.md
@@ -322,13 +322,15 @@ let finetuned = RegisteredModel::new("intent_classifier", "1.1.0")
 
 ## Feature Flags
 
-| Feature       | Default | Description                                |
-| ------------- | ------- | ------------------------------------------ |
-| `std`         | Yes     | Standard library support                   |
-| `serde`       | No      | Serialization (propagates to lattice-fann) |
-| `gpu`         | No      | GPU-accelerated training                   |
-| `gpu-tests`   | No      | GPU tests requiring hardware               |
-| `safetensors` | No      | Safe checkpoint serialization              |
+| Feature          | Default | Description                                                  |
+| ---------------- | ------- | ------------------------------------------------------------ |
+| `std`            | Yes     | Standard library support                                     |
+| `serde`          | No      | Serialization (propagates to lattice-fann)                   |
+| `gpu`            | No      | GPU-accelerated training                                     |
+| `gpu-tests`      | No      | GPU tests requiring hardware                                 |
+| `safetensors`    | No      | Safe checkpoint serialization                                |
+| `inference-hook` | No      | `impl LoraHook for LoraAdapter` (pulls in `lattice-inference`) |
+| `train-backward` | No      | Backward/gradient training surface (pulls in `lattice-inference`) |
 
 ```toml
 [dependencies]
@@ -336,6 +338,27 @@ lattice-tune = { version = "0.1" }                           # Default
 lattice-tune = { version = "0.1", features = ["serde"] }     # With serialization
 lattice-tune = { version = "0.1", features = ["gpu"] }       # GPU training
 lattice-tune = { version = "0.1", features = ["safetensors"] } # Safe checkpoints
+```
+
+### Injecting an adapter into `lattice-inference`
+
+Enable `inference-hook` to get `impl lattice_inference::lora_hook::LoraHook for
+LoraAdapter`, so a trained adapter can be handed to a running inference engine
+as a `Box<dyn LoraHook>`:
+
+```toml
+[dependencies]
+lattice-tune = { version = "0.3", features = ["inference-hook"] }
+lattice-inference = "0.3" # provides the LoraHook trait
+```
+
+```rust,ignore
+use lattice_tune::lora::LoraAdapter;
+use lattice_inference::lora_hook::LoraHook; // not re-exported at the crate root
+
+let adapter: LoraAdapter = /* LoraAdapter::load_peft_safetensors(...) */;
+let hook: Box<dyn LoraHook> = Box::new(adapter);
+// the engine calls hook.apply(layer_idx, module, x, output) on each projection
 ```
 
 ## Dependencies

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -102,6 +102,35 @@
 //! println!("Loaded: {}", loaded.full_name());
 //! ```
 //!
+//! # Consuming the `inference-hook` bridge
+//!
+//! To inject a trained [`LoraAdapter`] into a running
+//! `lattice-inference` forward pass, enable the `inference-hook` feature. It
+//! pulls in `lattice-inference` and provides `impl
+//! lattice_inference::lora_hook::LoraHook for LoraAdapter`, so an adapter can be
+//! handed to the engine as a `Box<dyn LoraHook>`:
+//!
+//! ```toml
+//! [dependencies]
+//! lattice-tune = { version = "0.3", features = ["inference-hook"] }
+//! lattice-inference = "0.3" # provides the LoraHook trait
+//! ```
+//!
+//! ```ignore
+//! use lattice_tune::lora::LoraAdapter;
+//! use lattice_inference::lora_hook::LoraHook;
+//!
+//! let adapter: LoraAdapter = /* load via LoraAdapter::load_peft_safetensors(...) */;
+//! let hook: Box<dyn LoraHook> = Box::new(adapter);
+//! // hand `hook` to the inference engine; on each projection it calls
+//! // hook.apply(layer_idx, module, x, output)
+//! ```
+//!
+//! The trait path is `lattice_inference::lora_hook::LoraHook` (it is not
+//! re-exported at the inference crate root). Without the `inference-hook`
+//! feature, `LoraAdapter` is a pure training type and carries no dependency on
+//! `lattice-inference`.
+//!
 //! # Design Principles
 //!
 //! 1. **Data-first**: Well-defined training example format with full traceability


### PR DESCRIPTION
## Problem (#63)

ADR-031 establishes `inference-hook` as the `LoraHook` bridge, but off-monorepo consumers had to reverse-engineer the `Cargo.toml` + import pattern from the `cfg(feature = "inference-hook")` attribute on the `impl` block.

## Fix (docs-only)

- **`crates/tune/src/lib.rs`** — new `# Consuming the inference-hook bridge` crate-doc section (shows on docs.rs).
- **`crates/tune/README.md`** — added `inference-hook` + `train-backward` rows to the Feature Flags table (both were missing) and a consumer snippet.

## TBV note — the issue's example was wrong

The issue suggested `use lattice_inference::LoraHook;`, but `LoraHook` is **not** re-exported at the inference crate root (`lib.rs` only has `pub mod lora_hook;`). The real consumer — tune's own `impl lattice_inference::lora_hook::LoraHook for LoraAdapter` at `lora/mod.rs:242` — uses the full path. The docs now match the path that actually compiles.

## Verification

- `cargo doc -p lattice-tune --no-deps` — my section adds **0 new warnings** (2 pre-existing `to_prompt` link warnings are unrelated and out of scope).
- Default doctests unaffected — the feature-gated examples are `ignore`/`rust,ignore` since `lattice-inference` is not a dependency under default features.

No code change.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)