### PR TITLE
fix(embed): guard NEON hamming OOB (release UB) + quantized to_f32 bounds (#211)

### DIFF
--- a/crates/embed/src/simd/binary.rs
+++ b/crates/embed/src/simd/binary.rs
@@ -73,7 +73,14 @@ impl BinaryVector {
     /// **Unstable**: dequantize to float32; output semantics may change.
     ///
     /// Binary quantization is lossy: 1 -> +1.0, 0 -> -1.0.
+    ///
+    /// Returns an empty `Vec` if the packed buffer is shorter than `dims.div_ceil(8)`
+    /// bytes — i.e. the vector was constructed with mismatched fields.
     pub fn to_f32(&self) -> Vec<f32> {
+        let required_bytes = self.dims.div_ceil(8);
+        if self.data.len() < required_bytes {
+            return Vec::new();
+        }
         let mut result = Vec::with_capacity(self.dims);
         for i in 0..self.dims {
             let byte_idx = i / 8;
@@ -116,9 +123,17 @@ impl BinaryVector {
 /// **Unstable**: free function dispatches to NEON or scalar; may become private in a future cleanup.
 ///
 /// Uses popcount on XOR of the packed bytes.
+///
+/// Returns `u32::MAX` if dimensions differ or if either packed buffer is shorter than
+/// `dims.div_ceil(8)` bytes (malformed public-field construction).
 #[inline]
 pub fn hamming_distance_binary(a: &BinaryVector, b: &BinaryVector) -> u32 {
     if a.dims != b.dims {
+        return u32::MAX;
+    }
+
+    let required_bytes = a.dims.div_ceil(8);
+    if a.data.len() < required_bytes || b.data.len() < required_bytes {
         return u32::MAX;
     }
 
@@ -127,12 +142,13 @@ pub fn hamming_distance_binary(a: &BinaryVector, b: &BinaryVector) -> u32 {
     #[cfg(target_arch = "aarch64")]
     {
         if config.neon_enabled {
-            debug_assert_eq!(a.data.len(), b.data.len());
-            // SAFETY: NEON is available on aarch64. Matching dimensions require
-            // matching packed-byte lengths for vectors built by the constructor;
-            // the debug guard catches public-field invariant violations. The callee
-            // uses unaligned loads and chunk/remainder bounds within those slices.
-            return unsafe { hamming_distance_neon(&a.data, &b.data) };
+            // SAFETY: NEON is available on aarch64. Both slices have been verified above
+            // to contain at least `required_bytes` elements, which is the exact packed
+            // length for `dims` bits. The callee uses unaligned loads and chunk/remainder
+            // bounds strictly within those slices; no out-of-bounds read is possible.
+            return unsafe {
+                hamming_distance_neon(&a.data[..required_bytes], &b.data[..required_bytes])
+            };
         }
     }
 
@@ -141,7 +157,7 @@ pub fn hamming_distance_binary(a: &BinaryVector, b: &BinaryVector) -> u32 {
         let _ = config;
     }
 
-    hamming_distance_scalar(&a.data, &b.data)
+    hamming_distance_scalar(&a.data[..required_bytes], &b.data[..required_bytes])
 }
 
 /// Scalar Hamming distance using u64 chunks and count_ones().
@@ -400,5 +416,75 @@ mod tests {
             scalar_result, dispatch_result,
             "Scalar and dispatched Hamming should match"
         );
+    }
+
+    // --- Issue #211 regression tests -------------------------------------------------
+
+    #[test]
+    fn test_hamming_short_data_returns_max() {
+        // dims=128 requires 16 bytes; supply only 4 — must return u32::MAX, not OOB.
+        let a = BinaryVector {
+            dims: 128,
+            data: vec![0xFFu8; 4],
+            norm: 1.0,
+        };
+        let b = BinaryVector {
+            dims: 128,
+            data: vec![0x00u8; 4],
+            norm: 1.0,
+        };
+        assert_eq!(
+            hamming_distance_binary(&a, &b),
+            u32::MAX,
+            "Short data must yield u32::MAX, not an OOB read"
+        );
+    }
+
+    #[test]
+    fn test_hamming_one_side_short_returns_max() {
+        // a is correct length, b is too short.
+        let a = BinaryVector {
+            dims: 128,
+            data: vec![0xFFu8; 16],
+            norm: 1.0,
+        };
+        let b = BinaryVector {
+            dims: 128,
+            data: vec![0x00u8; 8],
+            norm: 1.0,
+        };
+        assert_eq!(hamming_distance_binary(&a, &b), u32::MAX);
+    }
+
+    #[test]
+    fn test_hamming_correct_data_still_works() {
+        // Verify the guard does not break the normal path.
+        let v = generate_vector(128, 42);
+        let bv = BinaryVector::from_f32(&v);
+        assert_eq!(bv.hamming_distance(&bv), 0);
+    }
+
+    #[test]
+    fn test_binary_to_f32_short_data_returns_empty() {
+        // dims=128 requires 16 bytes; supply only 4.
+        let bv = BinaryVector {
+            dims: 128,
+            data: vec![0xFFu8; 4],
+            norm: 1.0,
+        };
+        let result = bv.to_f32();
+        assert!(
+            result.is_empty(),
+            "to_f32 on malformed BinaryVector must return empty Vec"
+        );
+    }
+
+    #[test]
+    fn test_binary_to_f32_exact_length_works() {
+        // Exactly the right number of bytes — must succeed.
+        let v = generate_vector(128, 7);
+        let bv = BinaryVector::from_f32(&v);
+        let deq = bv.to_f32();
+        assert_eq!(deq.len(), 128);
     }
 }

--- a/crates/embed/src/simd/int4.rs
+++ b/crates/embed/src/simd/int4.rs
@@ -121,6 +121,9 @@ impl Int4Vector {
     ///
     /// Reverses the quantization: `v[i] = q[i] / scale - max_abs`
     ///
+    /// Returns an empty `Vec` if the packed buffer is shorter than `dims.div_ceil(2)`
+    /// bytes — i.e. the vector was constructed with mismatched fields.
+    ///
     /// # Precision
     ///
     /// INT4 unsigned symmetric quantization maps `[-max_abs, max_abs]` to `[0, 15]`
@@ -132,6 +135,11 @@ impl Int4Vector {
     /// `test_int4_dot_product_vs_f32` and `test_int4_roundtrip_accuracy`).
     /// Use `Int8` tier when higher fidelity is required.
     pub fn to_f32(&self) -> Vec<f32> {
+        let required_bytes = self.dims.div_ceil(2);
+        if self.data.len() < required_bytes {
+            return Vec::new();
+        }
+
         let scale = if self.params.scale.is_finite() && self.params.scale != 0.0 {
             self.params.scale
         } else {
@@ -570,6 +578,39 @@ mod tests {
         // but the key invariant is no panics and finite output.
         for &val in &deq {
             assert!(val.is_finite(), "Dequantized value should be finite");
+        }
+    }
+
+    // --- Issue #211 regression tests -------------------------------------------------
+
+    #[test]
+    fn test_int4_to_f32_short_data_returns_empty() {
+        // dims=128 requires 64 bytes; supply only 4.
+        let q = Int4Vector {
+            dims: 128,
+            data: vec![0xFFu8; 4],
+            params: Int4Params {
+                scale: 7.5,
+                max_abs: 1.0,
+            },
+            norm: 1.0,
+        };
+        let result = q.to_f32();
+        assert!(
+            result.is_empty(),
+            "to_f32 on malformed Int4Vector must return empty Vec"
+        );
+    }
+
+    #[test]
+    fn test_int4_to_f32_exact_length_works() {
+        // Exactly the right number of bytes — must succeed and not index OOB.
+        let v: Vec<f32> = (0..128).map(|i| (i as f32) / 64.0 - 1.0).collect();
+        let q = Int4Vector::from_f32(&v);
+        let deq = q.to_f32();
+        assert_eq!(deq.len(), 128);
+        for &val in &deq {
+            assert!(val.is_finite());
         }
     }
 }


### PR DESCRIPTION
## What

Fixes a **release-mode out-of-bounds read (UB)** plus two unguarded index paths in the quantized SIMD vector code.

Closes #211.

## The soundness bug (the real one)

`hamming_distance_binary` dispatched to `unsafe { hamming_distance_neon(&a.data, &b.data) }` guarded only by `debug_assert_eq!(a.data.len(), b.data.len())` — a **no-op in release**. `BinaryVector` has public fields, so a caller can construct `{ dims: 128, data: <4 bytes> }`: the `dims` equality check passes, and the NEON path then reads past the 4-byte buffer. The old SAFETY comment even admitted the guard "catches public-field invariant violations" only in debug.

Fix:
```rust
let required_bytes = a.dims.div_ceil(8);
if a.data.len() < required_bytes || b.data.len() < required_bytes {
    return u32::MAX;                       // same sentinel as the existing dims-mismatch path
}
// ... then dispatch on EXACT bounds, so the unsafe call is sound unconditionally:
hamming_distance_neon(&a.data[..required_bytes], &b.data[..required_bytes])
```
The slices are sub-bound to exactly `required_bytes`, turning the SAFETY contract from an unprovable "constructor invariant" into a post-verified bound that holds for any input.

## The two index guards

- `BinaryVector::to_f32` — `return Vec::new()` if `data.len() < dims.div_ceil(8)` (was unguarded indexing).
- `Int4Vector::to_f32` — same, `dims.div_ceil(2)`.

`to_f32` stays `-> Vec<f32>` (returns empty on malformed, documented) rather than `Result`, because switching to `Result` cascades through `tier.rs::StoredVector::to_f32` and `promote()` — beyond the 5-file scope. Vectors built via `from_f32` always satisfy the invariant, so no existing caller changes behaviour.

## Tests

7 new regression tests (short-data → `u32::MAX`, one-side-short, exact-length still correct, both `to_f32` short → empty / exact → ok). Suite: **245 unit + 33 edge + 19 precision + 20 doc tests pass**; clippy clean.

## Performance (ADR-058)

Pure guard: two integer comparisons + a slice re-bind before the existing NEON loop — no algorithmic change. `binary_cosine_distance/binary/384` measures 3.18 ns, with the guard below the noise floor. No before/after delta to report (not a perf change); the e2e-parity gate covers token agreement for the embed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
