### PR TITLE
fix(transport): guard deserialized values against OOB/overflow/alloc panics

### DIFF
--- a/crates/transport/src/cost.rs
+++ b/crates/transport/src/cost.rs
@@ -272,19 +272,23 @@ pub struct DenseCostMatrix {
 }
 
 impl DenseCostMatrix {
-    /// Create from pre-computed data. Panics in debug mode if dimensions mismatch.
+    /// Create from pre-computed data.
+    ///
+    /// Panics if `rows × cols` overflows `usize` or does not equal `data.len()`.
     ///
     /// **Stable** (provisional): constructor matches struct stability.
     pub fn new(rows: usize, cols: usize, data: Vec<f32>) -> Self {
         // FP-030: validate shape in release builds too — a caller-provided
         // dimension mismatch corrupts every subsequent cost() lookup.
+        // checked_mul guards rows × cols against silently wrapping in release,
+        // which could otherwise let a corrupt (rows, cols) pass the length check.
+        let Some(expected) = rows.checked_mul(cols) else {
+            panic!("DenseCostMatrix: dimensions {rows}×{cols} overflow usize");
+        };
         assert_eq!(
-            rows * cols,
+            expected,
             data.len(),
-            "DenseCostMatrix: expected {} elements ({}×{}), got {}",
-            rows * cols,
-            rows,
-            cols,
+            "DenseCostMatrix: expected {expected} elements ({rows}×{cols}), got {}",
             data.len()
         );
         Self { rows, cols, data }

--- a/crates/transport/src/online_drift.rs
+++ b/crates/transport/src/online_drift.rs
@@ -17,12 +17,20 @@ use crate::{
 /// Minimum `window_size` enforced by `OnlineDriftConfig::normalized`.
 pub const MIN_ONLINE_DRIFT_WINDOW_SIZE: usize = 128;
 
+/// Maximum `window_size` enforced by `OnlineDriftConfig::normalized`.
+///
+/// Each drift check builds three `W×W` Sinkhorn workspaces, so memory scales as
+/// O(W²). This cap bounds one detector's workspace footprint to roughly
+/// 3 × 4096² × 4 bytes ≈ 192 MB, preventing a deserialized config with an
+/// oversized window from exhausting memory.
+pub const MAX_ONLINE_DRIFT_WINDOW_SIZE: usize = 4096;
+
 /// Configuration for streaming Sinkhorn drift detection.
 ///
 /// **Stable** (provisional): aggregate config for the online drift API; new fields would be additive with `Default`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OnlineDriftConfig {
-    /// Sliding window size W. Values below 128 are raised to 128 (O(W²) cost per check).
+    /// Sliding window size W. Clamped to `[128, 4096]` by `normalized` (O(W²) cost per check).
     pub window_size: usize,
     /// Compute divergence every N observed samples once both windows are full.
     pub check_interval: usize,
@@ -46,7 +54,9 @@ impl Default for OnlineDriftConfig {
 
 impl OnlineDriftConfig {
     fn normalized(mut self) -> Self {
-        self.window_size = self.window_size.max(MIN_ONLINE_DRIFT_WINDOW_SIZE);
+        self.window_size = self
+            .window_size
+            .clamp(MIN_ONLINE_DRIFT_WINDOW_SIZE, MAX_ONLINE_DRIFT_WINDOW_SIZE);
         self.check_interval = self.check_interval.max(1);
         self
     }
@@ -237,6 +247,30 @@ impl OnlineDriftDetector {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn window_size_above_max_is_clamped() {
+        let config = OnlineDriftConfig {
+            window_size: usize::MAX,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.normalized().window_size,
+            MAX_ONLINE_DRIFT_WINDOW_SIZE
+        );
+    }
+
+    #[test]
+    fn window_size_below_min_is_raised() {
+        let config = OnlineDriftConfig {
+            window_size: 1,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.normalized().window_size,
+            MIN_ONLINE_DRIFT_WINDOW_SIZE
+        );
+    }
 
     // Deterministic linear congruential generator so tests don't need `rand`.
     struct Lcg {

--- a/crates/transport/src/sinkhorn.rs
+++ b/crates/transport/src/sinkhorn.rs
@@ -347,6 +347,14 @@ impl SinkhornResult {
     where
         C: CostMatrix + ?Sized,
     {
+        if row >= self.log_u.len() || col >= self.log_v.len() {
+            return Err(SinkhornError::DimensionMismatch {
+                expected_rows: self.log_u.len(),
+                got_rows: row,
+                expected_cols: self.log_v.len(),
+                got_cols: col,
+            });
+        }
         let value = cost.cost(row, col);
         if !value.is_finite() {
             return Err(SinkhornError::NonFiniteCost { row, col, value });

--- a/crates/transport/src/transport_plan.rs
+++ b/crates/transport/src/transport_plan.rs
@@ -72,6 +72,15 @@ pub fn extract_sparse_plan<C>(
 where
     C: CostMatrix + ?Sized,
 {
+    if result.log_u.len() != cost.rows() || result.log_v.len() != cost.cols() {
+        return Err(SinkhornError::DimensionMismatch {
+            expected_rows: cost.rows(),
+            got_rows: result.log_u.len(),
+            expected_cols: cost.cols(),
+            got_cols: result.log_v.len(),
+        });
+    }
+
     let log_threshold = if threshold <= 0.0 {
         f32::NEG_INFINITY
     } else {

--- a/crates/transport/tests/input_validation.rs
+++ b/crates/transport/tests/input_validation.rs
@@ -1,0 +1,67 @@
+//! Regression tests for input-validation hardening.
+//!
+//! `SinkhornResult` and `DenseCostMatrix` expose public fields and derive
+//! `Deserialize`, so a caller can construct values whose dual-variable lengths
+//! or dimensions do not match. These tests pin that such values produce an
+//! error (or a clear panic for the constructor contract) instead of an
+//! out-of-bounds read.
+
+use lattice_transport::cost::DenseCostMatrix;
+use lattice_transport::sinkhorn::{SinkhornError, SinkhornResult};
+use lattice_transport::transport_plan::extract_sparse_plan;
+
+fn result_with_duals(rows: usize, cols: usize) -> SinkhornResult {
+    SinkhornResult {
+        epsilon: 0.1,
+        iterations: 0,
+        converged: true,
+        last_error: 0.0,
+        transport_cost: 0.0,
+        regularized_cost: 0.0,
+        entropy: 0.0,
+        transported_mass: 0.0,
+        row_residual_l1: 0.0,
+        col_residual_l1: 0.0,
+        log_u: vec![0.0; rows],
+        log_v: vec![0.0; cols],
+    }
+}
+
+#[test]
+fn extract_sparse_plan_rejects_mismatched_result_and_cost() {
+    // Dual variables sized for a 2×3 problem ...
+    let result = result_with_duals(2, 3);
+    // ... but the cost matrix claims 4×4: indexing log_u[row] in the loop would
+    // read past its length without the up-front guard.
+    let cost = DenseCostMatrix::new(4, 4, vec![1.0; 16]);
+    let err = extract_sparse_plan(&result, &cost, 0.0).unwrap_err();
+    assert!(
+        matches!(err, SinkhornError::DimensionMismatch { .. }),
+        "expected DimensionMismatch, got {err:?}"
+    );
+}
+
+#[test]
+fn log_gamma_rejects_out_of_range_indices() {
+    let result = result_with_duals(2, 3);
+    let cost = DenseCostMatrix::new(2, 3, vec![1.0; 6]);
+
+    // row 5 is out of range for log_u (len 2).
+    let err = result.log_gamma(&cost, 5, 0).unwrap_err();
+    assert!(matches!(err, SinkhornError::DimensionMismatch { .. }));
+
+    // col 9 is out of range for log_v (len 3).
+    let err = result.log_gamma(&cost, 0, 9).unwrap_err();
+    assert!(matches!(err, SinkhornError::DimensionMismatch { .. }));
+
+    // in-range indices still succeed.
+    assert!(result.log_gamma(&cost, 1, 2).is_ok());
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn dense_cost_matrix_rejects_dimension_overflow() {
+    // rows × cols overflows usize; the constructor must panic clearly rather
+    // than let the wrapped product pass the element-count check.
+    let _ = DenseCostMatrix::new(usize::MAX, 2, Vec::new());
+}


### PR DESCRIPTION
## What

Hardens `lattice-transport` (optimal-transport math: Sinkhorn solver, cost matrices, drift detection) against inconsistent externally-constructed / deserialized values. Closes #219.

Four guards, all reusing existing patterns (no new error types or API surface):

| Site | Defect | Guard |
|------|--------|-------|
| `transport_plan.rs` `extract_sparse_plan` | indexes `result.log_u[row]`/`log_v[col]` over `cost.rows()`/`cols()` — mismatched duals OOB-panic | up-front `DimensionMismatch` when length ≠ dims |
| `sinkhorn.rs` `SinkhornResult::log_gamma` | unchecked `log_u[row]`/`log_v[col]` with caller indices (sibling of the above) | bounds `DimensionMismatch` |
| `cost.rs` `DenseCostMatrix::new` | `rows * cols` wraps silently in release — a corrupt shape can pass the length check | `checked_mul` + clear panic on overflow |
| `online_drift.rs` `OnlineDriftConfig` | `window_size` only raised to a min, no max → three O(W²) workspaces can exhaust memory | `clamp` to `[128, 4096]` (~192 MB workspace cap) |

## Severity

**Low / defense-in-depth.** `lattice-transport` is internal optimal-transport math — not wire-facing, and no other workspace crate currently depends on it. These are panic/overflow/alloc safety guards, not a remote-DoS surface. (Found via a hardening sweep that was mis-primed as "untrusted wire input"; the code patterns are real, the reachability is internal API-misuse.)

## Tests

- `tests/input_validation.rs` (new): mismatched result/cost → `DimensionMismatch`; out-of-range `log_gamma` → `DimensionMismatch` (+ in-range still `Ok`); overflow dims → clear panic.
- `online_drift.rs`: `window_size` above max is clamped; below min is raised.
- `cargo test -p lattice-transport`: 29 unit + 3 integration + 1 doctest pass.
- `cargo clippy -p lattice-transport --all-targets -- -D warnings`: clean.

Happy paths are byte-identical; no behavior change for well-formed inputs.

## Perf

Not a perf PR — guards are O(1) length checks on cold construction/extraction paths, no hot-loop change, so no `bench-compare` is warranted. The e2e-parity gate does not apply (no `inference`/`embed` source touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
