### PR TITLE
fix(fann): validate deserialized Layer/Network through constructors

### DIFF
--- a/crates/fann/src/layer.rs
+++ b/crates/fann/src/layer.rs
@@ -285,6 +285,7 @@ unsafe fn simd_dot_product_avx512(a: &[f32], b: &[f32]) -> f32 {
 /// - biases: [num_outputs]
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "LayerData"))]
 pub struct Layer {
     /// Number of input neurons
     num_inputs: usize,
@@ -296,6 +297,36 @@ pub struct Layer {
     biases: Vec<f32>,
     /// Activation function
     activation: Activation,
+}
+
+/// Deserialization shadow for [`Layer`] that routes through [`Layer::with_weights`].
+///
+/// A corrupt or hand-crafted serialized layer whose `weights`/`biases` lengths
+/// disagree with its dimensions is rejected with a `FannError` instead of
+/// triggering an out-of-bounds panic during `forward`.
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+struct LayerData {
+    num_inputs: usize,
+    num_outputs: usize,
+    weights: Vec<f32>,
+    biases: Vec<f32>,
+    activation: Activation,
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<LayerData> for Layer {
+    type Error = FannError;
+
+    fn try_from(data: LayerData) -> Result<Self, Self::Error> {
+        Layer::with_weights(
+            data.num_inputs,
+            data.num_outputs,
+            data.weights,
+            data.biases,
+            data.activation,
+        )
+    }
 }
 
 impl Layer {

--- a/crates/fann/src/network/mod.rs
+++ b/crates/fann/src/network/mod.rs
@@ -86,6 +86,7 @@ fn forward_into_buffers(
 /// ```
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "NetworkData"))]
 pub struct Network {
     /// Network layers
     layers: Vec<Layer>,
@@ -93,6 +94,27 @@ pub struct Network {
     /// buffers[i] holds output of layer i (or input for i=0)
     #[cfg_attr(feature = "serde", serde(skip))]
     buffers: Vec<Vec<f32>>,
+}
+
+/// Deserialization shadow for [`Network`] that routes through [`Network::new`].
+///
+/// `buffers` is `#[serde(skip)]`, so a directly-deserialized `Network` would
+/// have empty buffers and panic on the first `forward`. Routing through `new`
+/// rebuilds the buffers from the layer dimensions and rejects empty or
+/// dimension-incompatible layer stacks with a `FannError`.
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+struct NetworkData {
+    layers: Vec<Layer>,
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<NetworkData> for Network {
+    type Error = FannError;
+
+    fn try_from(data: NetworkData) -> Result<Self, Self::Error> {
+        Network::new(data.layers)
+    }
 }
 
 impl Network {
@@ -412,5 +434,60 @@ mod tests {
         for (a, b) in output1.iter().zip(output2.iter()) {
             assert!((a - b).abs() < 1e-5);
         }
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_validation_tests {
+    use super::*;
+    use crate::activation::Activation;
+
+    fn sample_network() -> Network {
+        // 3 -> 4 (ReLU) -> 2 (Linear): first layer has 3*4 = 12 weights.
+        NetworkBuilder::new()
+            .input(3)
+            .hidden(4, Activation::ReLU)
+            .output(2, Activation::Linear)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn roundtrip_rebuilds_skipped_buffers_and_runs_forward() {
+        let net = sample_network();
+        let json = serde_json::to_string(&net).unwrap();
+        // `buffers` is #[serde(skip)] — a direct field-deserialize would leave it
+        // empty and panic in forward. The TryFrom path must rebuild it.
+        let mut restored: Network = serde_json::from_str(&json).unwrap();
+        let out = restored.forward(&[1.0, 2.0, 3.0]).unwrap();
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn empty_layer_stack_is_rejected() {
+        let result = serde_json::from_str::<Network>(r#"{"layers":[]}"#);
+        assert!(
+            result.is_err(),
+            "empty layer stack must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn layer_with_short_weights_is_rejected() {
+        // Serialize a valid network, then drop one weight from the first layer
+        // so weights.len() no longer equals num_inputs * num_outputs. Routing
+        // through Value avoids hard-coding the Activation serialization format.
+        let net = sample_network();
+        let json = serde_json::to_string(&net).unwrap();
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let weights = value["layers"][0]["weights"].as_array_mut().unwrap();
+        weights.pop();
+        let corrupted = serde_json::to_string(&value).unwrap();
+
+        let result = serde_json::from_str::<Network>(&corrupted);
+        assert!(
+            result.is_err(),
+            "layer with short weights must be rejected, got {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## What

Hardens `lattice-fann` against malformed deserialized `Layer`/`Network` values. Closes #221.

`Layer` and `Network` derive `Deserialize`, but the derived impl bypasses the validated constructors (`Layer::with_weights`, `Network::new`). A corrupt or hand-crafted serialized network could:

| Site | Defect | Now |
|------|--------|-----|
| `layer.rs` `Layer::forward` | indexes `weights[row_start + in_idx]` / `biases[out_idx]`; a deserialized layer with short `weights`/`biases` skips the `WeightCountMismatch`/`BiasCountMismatch` checks → OOB panic | `#[serde(try_from = "LayerData")]` routes through `Layer::with_weights` |
| `network/mod.rs` `Network::forward` / `num_inputs` / `num_outputs` | `buffers` is `#[serde(skip)]` → deserialized `Network` has empty buffers → index panic; empty `layers` → `layers[0]` panic | `#[serde(try_from = "NetworkData")]` routes through `Network::new` (rejects `EmptyNetwork`, rebuilds buffers) |

## Severity

**Medium / defense-in-depth.** Local trigger (corrupt checkpoint / malformed serialized network), reachable through `lattice-tune` (which enables `lattice-fann/serde` and loads checkpoints) — not a remote wire surface. The fix turns reachable panics into the existing `FannError` contract.

## Tests

`#[cfg(all(test, feature = "serde"))]` in `network/mod.rs`:
- `roundtrip_rebuilds_skipped_buffers_and_runs_forward` — valid network survives serialize→deserialize and the serde-skipped buffers are rebuilt (forward works)
- `empty_layer_stack_is_rejected` — `{"layers":[]}` → `Err`
- `layer_with_short_weights_is_rejected` — a valid network with one weight dropped → `Err`

Verified:
- `cargo build -p lattice-fann` (no serde — both feature configs compile)
- `cargo test -p lattice-fann --features serde` — all pass (3 new + existing)
- `cargo clippy -p lattice-fann --all-targets --features serde -- -D warnings` — clean

No new error types or API surface; happy-path round-trips are byte-identical.

## Perf

Not a perf PR — the guards are on cold deserialization paths only, no hot-loop change, so no `bench-compare` is warranted. The e2e-parity gate does not apply (no `inference`/`embed` source touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
