### PR TITLE
harden(inference): release-active guards for shape invariants gating unsafe SIMD

### DIFF
--- a/crates/inference/src/forward/cpu/activation.rs
+++ b/crates/inference/src/forward/cpu/activation.rs
@@ -275,8 +275,16 @@ pub fn add_bias(x: &mut [f32], bias: &[f32], dim: usize) {
 /// in a single pass, saving one full traversal of the data compared to calling
 /// `add_bias` then `gelu` separately.
 pub fn add_bias_gelu(x: &mut [f32], bias: &[f32], dim: usize) {
-    debug_assert_eq!(bias.len(), dim);
-    debug_assert_eq!(x.len() % dim, 0);
+    assert_eq!(
+        bias.len(),
+        dim,
+        "add_bias_gelu: bias length must equal dim before the SIMD kernels index it"
+    );
+    assert_eq!(
+        x.len() % dim,
+        0,
+        "add_bias_gelu: x length must be a multiple of dim"
+    );
 
     let config = simd_config();
 
@@ -463,5 +471,29 @@ unsafe fn add_bias_gelu_avx2(x: &mut [f32], bias: &[f32], dim: usize) {
             let inner = 0.797_884_6 * (v + 0.044_715 * x3);
             *ptr.add(i) = 0.5 * v * (1.0 + fast_tanh(inner));
         }
+    }
+}
+
+#[cfg(test)]
+mod guard_tests {
+    use super::*;
+
+    #[test]
+    fn add_bias_gelu_accepts_valid_lengths() {
+        let dim = 4;
+        let bias = vec![0.1, -0.2, 0.3, -0.4];
+        let mut x = vec![1.0, -1.0, 2.0, -2.0, 0.5, -0.5, 0.0, 1.5]; // 2 rows × dim
+        add_bias_gelu(&mut x, &bias, dim);
+        assert_eq!(x.len(), 8);
+        assert!(x.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    #[should_panic(expected = "bias length must equal dim")]
+    fn add_bias_gelu_rejects_short_bias() {
+        // dim=4 needs bias.len()==4; a short bias would OOB the unsafe SIMD kernel.
+        let mut x = vec![0.0; 8];
+        let bias = vec![0.0; 3];
+        add_bias_gelu(&mut x, &bias, 4);
     }
 }

--- a/crates/inference/src/forward/cpu/norm.rs
+++ b/crates/inference/src/forward/cpu/norm.rs
@@ -10,9 +10,21 @@ use super::simd::simd_config;
 ///
 /// Layer normalization (in-place).
 pub fn layer_norm(x: &mut [f32], gamma: &[f32], beta: &[f32], hidden: usize, eps: f32) {
-    debug_assert_eq!(gamma.len(), hidden);
-    debug_assert_eq!(beta.len(), hidden);
-    debug_assert_eq!(x.len() % hidden, 0);
+    assert_eq!(
+        gamma.len(),
+        hidden,
+        "layer_norm: gamma length must equal hidden before the SIMD kernels index it"
+    );
+    assert_eq!(
+        beta.len(),
+        hidden,
+        "layer_norm: beta length must equal hidden before the SIMD kernels index it"
+    );
+    assert_eq!(
+        x.len() % hidden,
+        0,
+        "layer_norm: x length must be a multiple of hidden"
+    );
 
     let config = simd_config();
 
@@ -243,5 +255,31 @@ unsafe fn layer_norm_avx2(x: &mut [f32], gamma: &[f32], beta: &[f32], hidden: us
         for i in (chunks * 32)..hidden {
             *out_ptr.add(i) = (*out_ptr.add(i) - mean) * inv_std * *g_ptr.add(i) + *b_ptr.add(i);
         }
+    }
+}
+
+#[cfg(test)]
+mod guard_tests {
+    use super::*;
+
+    #[test]
+    fn layer_norm_accepts_valid_lengths() {
+        let hidden = 4;
+        let gamma = vec![1.0; hidden];
+        let beta = vec![0.0; hidden];
+        let mut x = vec![1.0, 2.0, 3.0, 4.0, -1.0, -2.0, -3.0, -4.0]; // 2 rows
+        layer_norm(&mut x, &gamma, &beta, hidden, 1e-5);
+        assert_eq!(x.len(), 8);
+        assert!(x.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    #[should_panic(expected = "gamma length must equal hidden")]
+    fn layer_norm_rejects_short_gamma() {
+        // hidden=4 needs gamma.len()==4; a short gamma would OOB the unsafe SIMD kernel.
+        let mut x = vec![0.0; 8];
+        let gamma = vec![1.0; 3];
+        let beta = vec![0.0; 4];
+        layer_norm(&mut x, &gamma, &beta, 4, 1e-5);
     }
 }

--- a/crates/inference/src/pool.rs
+++ b/crates/inference/src/pool.rs
@@ -329,8 +329,20 @@ pub fn last_token_pool(
     seq_len: usize,
     hidden_size: usize,
 ) -> Vec<f32> {
-    debug_assert_eq!(hidden_states.len(), seq_len * hidden_size);
-    debug_assert_eq!(attention_mask.len(), seq_len);
+    assert!(seq_len > 0, "seq_len must be non-zero for last_token_pool");
+    let expected_hidden = seq_len
+        .checked_mul(hidden_size)
+        .expect("invariant: seq_len * hidden_size must fit usize");
+    assert_eq!(
+        hidden_states.len(),
+        expected_hidden,
+        "hidden_states length must match seq_len * hidden_size"
+    );
+    assert_eq!(
+        attention_mask.len(),
+        seq_len,
+        "attention_mask length must match seq_len"
+    );
 
     // Find the last non-padding position.
     let last_pos = (0..seq_len)
@@ -735,5 +747,18 @@ mod tests {
             out.push(unit * 0.04 - 0.02);
         }
         out
+    }
+
+    #[test]
+    #[should_panic(expected = "hidden_states length must match seq_len * hidden_size")]
+    fn last_token_pool_rejects_short_hidden_states() {
+        // seq_len=2, hidden_size=4 needs 8 elements; pass 4.
+        let _ = last_token_pool(&[0.0; 4], &[1, 1], 2, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "seq_len must be non-zero")]
+    fn last_token_pool_rejects_zero_seq_len() {
+        let _ = last_token_pool(&[], &[], 0, 4);
     }
 }

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -1892,6 +1892,13 @@ pub fn generate_with_speculation<F>(
 where
     F: FnMut(u32, usize) -> Vec<f32>,
 {
+    // An empty prompt cannot seed the n-gram speculator or the decode history,
+    // so there is nothing to generate from. Return early instead of panicking on
+    // `all_tokens.last()` in the first decode step.
+    if prompt_tokens.is_empty() {
+        return Vec::new();
+    }
+
     let speculator = NgramSpeculator::new(prompt_tokens.to_vec(), max_ngram, max_draft);
     let mut generated: Vec<u32> = Vec::new();
     let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
@@ -3186,5 +3193,13 @@ mod tests {
                  stale f16 dequant scratch is contaminating attention output"
             );
         }
+    }
+
+    #[test]
+    fn generate_with_speculation_empty_prompt_returns_empty() {
+        // Empty prompt cannot seed speculation; must return empty, not panic on
+        // `all_tokens.last()` in the first decode step.
+        let out = generate_with_speculation(&[], 8, 999, |_tok, _pos| vec![0.0; 4], 3, 4);
+        assert!(out.is_empty());
     }
 }


### PR DESCRIPTION
## What

Promotes four `inference` forward-path shape/length invariants from `debug_assert!` (no-op in release) to release-active checks, so malformed inputs fail closed with a clear message instead of an out-of-bounds read in the `unsafe` SIMD kernels (or a cryptic index panic). Closes #213 and #223.

| Site | Defect | Now |
|------|--------|-----|
| `pool.rs` `last_token_pool` | `debug_assert_eq!` on lengths → release OOB on `hidden_states[last*hs..]`; `seq_len==0` slices an empty buffer | `assert!(seq_len>0)` + `checked_mul` + length `assert_eq!` (mirrors the existing, un-flagged `cls_pool`) |
| `forward/cpu/activation.rs` `add_bias_gelu` | `debug_assert_eq!(bias.len(), dim)` → `add_bias_gelu_neon`/`_avx2` read `b_ptr.add(i)` past a short `bias` (release UB) | `assert_eq!(bias.len(), dim)` before dispatch |
| `forward/cpu/norm.rs` `layer_norm` | `debug_assert_eq!` on `gamma`/`beta` → `layer_norm_neon`/`_avx2` read `g_ptr`/`b_ptr` past short slices (release UB) | `assert_eq!` on `gamma`/`beta`/`x` before dispatch |
| `speculative.rs` `generate_with_speculation` | empty `prompt_tokens` panics on `all_tokens.last().expect(...)` in the first decode step | early-return empty `Vec` (nothing to generate from) |

## TBV note (one finding was a false positive)

#213's third site — `rejection_sample_draft` indexing `target_logits[i-1]` / `.last()` — is **already guarded**: the function validates `target_logits.len() == n` (and early-returns on `n == 0`) at entry, so those indices are provably in-bounds. Left untouched.

## Severity

**Medium–high / defense-in-depth.** The activation/norm gaps are release-mode OOB reads (UB) reachable from a caller with an undersized parameter slice; current in-tree model callers pass correctly-sized slices, so this hardens the public API surface against future/direct callers. The pooling/speculative sites convert cryptic panics into clear, intentional failures.

## Tests

7 new guard tests (custom-message `#[should_panic]` so the assert is distinguished from the old `debug_assert` even in a debug-mode test build):
- `last_token_pool_rejects_short_hidden_states`, `last_token_pool_rejects_zero_seq_len`
- `add_bias_gelu_accepts_valid_lengths`, `add_bias_gelu_rejects_short_bias`
- `layer_norm_accepts_valid_lengths`, `layer_norm_rejects_short_gamma`
- `generate_with_speculation_empty_prompt_returns_empty`

Verified:
- `cargo test -p lattice-inference --lib` — **921 passed, 0 failed** (914 existing + 7 new); pre-existing `add_bias_gelu` parity tests still green (asserts don't false-trip valid inputs)
- `cargo clippy -p lattice-inference --all-targets -- -D warnings` — clean

## Perf

Not a perf PR — the guards are O(1) length comparisons at function entry (once per call, negligible vs the per-element kernel work), happy-path byte-identical. No `bench-compare` warranted. The e2e-parity gate applies (touches `inference/src`) and validates greedy token parity; these changes do not alter any valid-input output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
