### PR TITLE
perf(inference): chunked batched prefill for long prompts (1.78× TTFT)

### DIFF
--- a/crates/inference/src/bin/bench_decode_ab.rs
+++ b/crates/inference/src/bin/bench_decode_ab.rs
@@ -36,7 +36,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     use lattice_inference::forward::metal_qwen35::{ChatMessage, MetalQwen35State};
     use lattice_inference::model::qwen35::Qwen35Model;
     use lattice_inference::model::qwen35_config::{GenerateConfig, Qwen35Config};
-    use lattice_inference::tokenizer::BpeTokenizer;
+    use lattice_inference::tokenizer::{BpeTokenizer, Tokenizer};
 
     let home = std::env::var("HOME")?;
     let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
@@ -116,9 +116,31 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Same continuation prompt as the original bench, single user turn.
-    let prompt = "The quick brown fox jumps over the lazy dog. \
-                  Once upon a time in a land far away, there lived a";
-    let history = vec![ChatMessage::user(prompt)];
+    // Optionally pad to a target context length (BENCH_PROMPT_TOKENS) by
+    // repeating filler text, so we can measure decode at real context depth
+    // (agentic workload: long context + short response).
+    let base = "The quick brown fox jumps over the lazy dog. \
+                Once upon a time in a land far away, there lived a wise old owl \
+                who knew many secrets. Every morning the sun rose over the \
+                mountains and cast long shadows across the quiet valley. ";
+    let prompt: String = match std::env::var("BENCH_PROMPT_TOKENS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+    {
+        Some(target) if target > 0 => {
+            let mut p = String::new();
+            while tokenizer.tokenize(&p).real_length < target {
+                p.push_str(base);
+            }
+            p
+        }
+        _ => base.to_string(),
+    };
+    eprintln!(
+        "[bench] prompt_tokens={}",
+        tokenizer.tokenize(&prompt).real_length
+    );
+    let history = vec![ChatMessage::user(&prompt)];
 
     // One warmup (not recorded).
     metal.reset_state();

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6392,7 +6392,9 @@ kernel void moe_shared_gate_add(
         /// Uses batch GEMM (M=prompt_len) for projections instead of per-token GEMV,
         /// giving ~10-20x speedup on prefill for typical prompt lengths.
         ///
-        /// Falls back to sequential forward_step for prompts longer than max_prefill.
+        /// Prompts longer than max_prefill without active LoRA are processed in
+        /// max_prefill-sized batched chunks; LoRA-active prompts remain on the
+        /// per-token forward_step fallback.
         pub fn forward_prefill(&mut self, token_ids: &[u32]) -> Vec<f32> {
             self.forward_prefill_impl(token_ids, false)
         }
@@ -6419,18 +6421,14 @@ kernel void moe_shared_gate_add(
                 };
             }
             if n == 1 {
-                let logits = self.forward_step(token_ids[0], 0);
-                return logits;
+                return self.forward_step(token_ids[0], 0);
             }
-            // Sequential fallback (LoRA or oversize) — only supports last-token mode.
-            // For all_positions mode under these conditions, caller must reduce window
-            // or quantize a Q4 dir without LoRA.
-            if self.lora.is_some() || n > self.session.max_prefill {
+            if self.lora.is_some() {
+                // Batched helper does not apply LoRA adapters; stay on sequential path.
                 if all_positions {
                     panic!(
-                        "forward_prefill_all_logits: n={n} exceeds max_prefill ({}) or LoRA active — \
-                         reduce window or run without LoRA",
-                        self.session.max_prefill
+                        "forward_prefill_all_logits: LoRA active — \
+                         batch/all-position prefill does not apply LoRA"
                     );
                 }
                 let mut last_logits = Vec::new();
@@ -6439,11 +6437,61 @@ kernel void moe_shared_gate_add(
                 }
                 return last_logits;
             }
-
             assert!(
                 n <= self.session.kv_cache.max_cache_len,
                 "prefill length {} exceeds max_cache_len {}",
                 n,
+                self.session.kv_cache.max_cache_len
+            );
+            let max_prefill = self.session.max_prefill;
+            if n <= max_prefill {
+                return self.forward_prefill_batched_chunk(token_ids, 0, all_positions);
+            }
+            // Chunked batched prefill: each chunk is one command buffer (preserving the
+            // n≤512 fast path within each chunk). GDN recurrent state threads across
+            // boundaries automatically — session GPU buffers are mutated in place and
+            // never reset between chunks within a single request.
+            if all_positions {
+                let mut all_logits = Vec::with_capacity(n * vocab);
+                let mut start_pos = 0usize;
+                for chunk in token_ids.chunks(max_prefill) {
+                    all_logits.extend(self.forward_prefill_batched_chunk(chunk, start_pos, true));
+                    start_pos += chunk.len();
+                }
+                all_logits
+            } else {
+                let mut last_logits = Vec::new();
+                let mut start_pos = 0usize;
+                for chunk in token_ids.chunks(max_prefill) {
+                    last_logits = self.forward_prefill_batched_chunk(chunk, start_pos, false);
+                    start_pos += chunk.len();
+                }
+                last_logits
+            }
+        }
+
+        /// Batched single-command-buffer prefill for a contiguous token slice starting
+        /// at absolute position `start_pos`.
+        ///
+        /// Writes full-attention K/V rows `start_pos..start_pos+n` and advances GDN
+        /// recurrent state in the session GPU buffers. Called by `forward_prefill_impl`
+        /// once per chunk; for `n ≤ max_prefill` it IS the entire prefill (one command
+        /// buffer, all 24 layers, final logits).
+        fn forward_prefill_batched_chunk(
+            &mut self,
+            token_ids: &[u32],
+            start_pos: usize,
+            all_positions: bool,
+        ) -> Vec<f32> {
+            let n = token_ids.len();
+            debug_assert!(
+                n <= self.session.max_prefill,
+                "forward_prefill_batched_chunk: n={n} exceeds max_prefill={}",
+                self.session.max_prefill
+            );
+            assert!(
+                start_pos + n <= self.session.kv_cache.max_cache_len,
+                "prefill chunk start_pos={start_pos} + n={n} exceeds max_cache_len {}",
                 self.session.kv_cache.max_cache_len
             );
             let cfg = self.engine.config.clone();
@@ -6842,6 +6890,8 @@ kernel void moe_shared_gate_add(
 
                     // Per-token: scatter, norm, RoPE, cache store, attention, gate
                     for t in 0..n {
+                        // abs_pos is the token's position in the full sequence across all chunks.
+                        let abs_pos = start_pos + t;
                         let q_off = (t * 2 * q_dim) as u64 * 4;
                         let qs_off = (t * q_dim) as u64 * 4;
                         let gz_off = (t * q_dim) as u64 * 4;
@@ -6901,7 +6951,7 @@ kernel void moe_shared_gate_add(
                         // RoPE table buffers cover max positions and per-token Q/K
                         // offsets are within activation buffers sized from the same config.
                         {
-                            let pos = t as u32;
+                            let pos = abs_pos as u32;
                             enc.set_compute_pipeline_state(&self.engine.pipelines.partial_rope);
                             enc.set_buffer(0, Some(&self.session.activations.q_separated), qs_off);
                             enc.set_buffer(1, Some(&self.engine.rope_cos), 0);
@@ -6927,9 +6977,10 @@ kernel void moe_shared_gate_add(
                             );
                         }
 
-                        // Store K, V to cache
+                        // Store K, V to cache; use absolute row so cross-chunk tokens
+                        // write to the correct KV cache rows rather than overwriting chunk 0.
                         {
-                            let dst_offset = (t * kv_dim) as u32;
+                            let dst_offset = (abs_pos * kv_dim) as u32;
                             enc.set_compute_pipeline_state(&self.engine.pipelines.copy_offset);
                             enc.set_buffer(0, Some(&self.session.activations.k), k_off);
                             enc.set_buffer(1, Some(&self.session.kv_cache.k_bufs[full_idx]), 0);
@@ -6950,9 +7001,10 @@ kernel void moe_shared_gate_add(
                             );
                         }
 
-                        // Causal attention: query Q[t] against cache[0..t+1]
+                        // Causal attention: Q[t] attends against cache[0..abs_pos+1],
+                        // covering all prior chunks when start_pos > 0.
                         {
-                            let cache_len = (t + 1) as u32;
+                            let cache_len = (abs_pos + 1) as u32;
                             enc.set_compute_pipeline_state(&self.engine.pipelines.decode_attention);
                             enc.set_buffer(0, Some(&self.session.activations.q_separated), qs_off);
                             enc.set_buffer(1, Some(&self.session.kv_cache.k_bufs[full_idx]), 0);
@@ -7221,7 +7273,7 @@ kernel void moe_shared_gate_add(
                 self.session.last_pre_final_hidden =
                     unsafe { read_buffer(&self.session.activations.pre_final_hidden, hidden) };
             }
-            self.session.kv_cache.seq_len = n;
+            self.session.set_position(start_pos + n);
 
             if let Some(pb) = ppl_buf {
                 // SAFETY: GPU completed, ppl_buf is StorageModeShared and sized n*vocab.
@@ -15594,6 +15646,228 @@ kernel void decode_attention_reference(
                     );
                 }
             }
+        }
+
+        // -----------------------------------------------------------------------
+        // Chunked batched prefill parity tests
+        // -----------------------------------------------------------------------
+
+        /// Build a token sequence of 650-700 tokens from varied prose paragraphs.
+        /// Uses the provided tokenizer; grows text by appending paragraphs until
+        /// the encoded length is ≥ 650, then truncates to ≤ 680.
+        fn long_real_text_tokens(tokenizer: &BpeTokenizer) -> Vec<u32> {
+            let paragraphs = [
+                "During a late engineering review, the team walked through the inference trace \
+                 one layer at a time. They checked where state changed, which buffers were reused, \
+                 and how a long request should preserve every earlier token.",
+                "The prompt continued with ordinary prose about debugging, benchmarks, release notes, \
+                 and careful handoffs. It used full sentences, punctuation, and varied vocabulary \
+                 so tokenization looked like real input rather than a repeated numeric pattern.",
+                "A second reviewer asked for evidence at the boundary between chunks. The answer \
+                 described rotary positions, cache rows, recurrent memory, and causal attention \
+                 in concrete terms before any optimization was accepted.",
+                "Verification across chunk boundaries requires that each token's absolute position \
+                 index matches the RoPE table row, the KV cache write offset, and the attention \
+                 causal mask — all three must use the same absolute coordinate, not a chunk-local one.",
+            ];
+            let mut text = String::new();
+            let mut ids = Vec::new();
+            for i in 0..256usize {
+                if !text.is_empty() {
+                    text.push_str("\n\n");
+                }
+                text.push_str(paragraphs[i % paragraphs.len()]);
+                let input = tokenizer.tokenize(&text);
+                ids = input.input_ids[..input.real_length].to_vec();
+                if ids.len() >= 650 {
+                    break;
+                }
+            }
+            if ids.len() > 680 {
+                ids.truncate(680);
+            }
+            ids
+        }
+
+        fn argmax_f32(xs: &[f32]) -> usize {
+            let mut best = 0usize;
+            let mut best_val = f32::NEG_INFINITY;
+            for (i, &x) in xs.iter().enumerate() {
+                if x > best_val {
+                    best_val = x;
+                    best = i;
+                }
+            }
+            best
+        }
+
+        #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+        #[test]
+        fn metal_qwen35_chunked_prefill_long_prompt_matches_step_loop() {
+            // Parity gate: chunked forward_prefill must agree with token-by-token
+            // forward_step on a prompt longer than max_prefill (≈512).
+            // Tests that RoPE offsets, KV cache rows, attention cache_len, and
+            // GDN recurrent state all thread correctly across chunk boundaries.
+            let model_dir =
+                std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
+                    .join(".lattice/models/qwen3.5-0.8b");
+            if !model_dir.join("model.safetensors").exists()
+                || !model_dir.join("config.json").exists()
+                || !model_dir.join("tokenizer.json").exists()
+            {
+                eprintln!(
+                    "skipping chunked prefill parity test: model files missing at {}",
+                    model_dir.display()
+                );
+                return;
+            }
+
+            let model = crate::model::qwen35::Qwen35Model::from_safetensors(&model_dir)
+                .expect("load qwen3.5-0.8b");
+            assert!(
+                model.config().num_active_linear_attention_layers() > 0,
+                "prompt must exercise at least one GDN layer"
+            );
+
+            let Some(device) = Device::system_default() else {
+                eprintln!("skipping chunked prefill parity test: no Metal device");
+                return;
+            };
+            let _ = device;
+
+            let mut state = MetalQwen35State::new(model.weights(), model.config(), 1024)
+                .expect("construct Metal qwen3.5-0.8b state");
+
+            let tokens = long_real_text_tokens(model.tokenizer());
+            assert!(
+                tokens.len() > state.session.max_prefill,
+                "prompt ({} tokens) must exceed max_prefill ({})",
+                tokens.len(),
+                state.session.max_prefill
+            );
+            assert!(
+                (600..=700).contains(&tokens.len()),
+                "prompt length {} out of expected 600-700 range",
+                tokens.len()
+            );
+
+            // Path A: token-by-token reference.
+            state.reset_state();
+            let mut step_logits = Vec::new();
+            for (pos, &tok) in tokens.iter().enumerate() {
+                step_logits = state.forward_step(tok, pos);
+            }
+
+            // Path B: chunked batched prefill.
+            state.reset_state();
+            let prefill_logits = state.forward_prefill(&tokens);
+
+            assert_eq!(step_logits.len(), model.config().vocab_size);
+            assert_eq!(prefill_logits.len(), model.config().vocab_size);
+
+            let max_abs_diff = step_logits
+                .iter()
+                .zip(prefill_logits.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0_f32, f32::max);
+
+            eprintln!(
+                "chunked prefill parity: max_abs_diff={max_abs_diff:.6}, \
+                 argmax_step={}, argmax_prefill={}, tokens={}",
+                argmax_f32(&step_logits),
+                argmax_f32(&prefill_logits),
+                tokens.len()
+            );
+
+            assert!(
+                max_abs_diff < 1e-2,
+                "chunked prefill logits diverged from step loop: max_abs_diff={max_abs_diff}"
+            );
+            assert_eq!(
+                argmax_f32(&step_logits),
+                argmax_f32(&prefill_logits),
+                "argmax mismatch between step loop and chunked prefill"
+            );
+            // Both paths must advance the session cursor to the full prompt length.
+            assert_eq!(state.session.kv_cache.seq_len, tokens.len());
+            assert_eq!(state.session.position, tokens.len());
+        }
+
+        #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+        #[test]
+        fn metal_qwen35_prefill_all_logits_long_prompt_no_longer_panics() {
+            // Regression gate: forward_prefill_all_logits must NOT panic when
+            // n > max_prefill and LoRA is inactive. Old code panicked; new code
+            // chunks the request and concatenates per-chunk all-position logits.
+            let model_dir =
+                std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
+                    .join(".lattice/models/qwen3.5-0.8b");
+            if !model_dir.join("model.safetensors").exists()
+                || !model_dir.join("config.json").exists()
+                || !model_dir.join("tokenizer.json").exists()
+            {
+                eprintln!(
+                    "skipping all-logits long-prompt test: model files missing at {}",
+                    model_dir.display()
+                );
+                return;
+            }
+
+            let Some(device) = Device::system_default() else {
+                eprintln!("skipping all-logits long-prompt test: no Metal device");
+                return;
+            };
+            let _ = device;
+
+            let model = crate::model::qwen35::Qwen35Model::from_safetensors(&model_dir)
+                .expect("load qwen3.5-0.8b");
+            let mut state = MetalQwen35State::new(model.weights(), model.config(), 1024)
+                .expect("construct Metal qwen3.5-0.8b state");
+
+            let tokens = long_real_text_tokens(model.tokenizer());
+            assert!(tokens.len() > state.session.max_prefill);
+
+            // Must not panic; returns n * vocab_size f32 values.
+            state.reset_state();
+            let flat = state.forward_prefill_all_logits(&tokens);
+            assert_eq!(
+                flat.len(),
+                tokens.len() * model.config().vocab_size,
+                "all-logits output length must be n * vocab_size"
+            );
+
+            // Final row of all-logits must agree with token-by-token final logits.
+            let vocab = model.config().vocab_size;
+            let final_row = &flat[(tokens.len() - 1) * vocab..tokens.len() * vocab];
+
+            state.reset_state();
+            let mut step_logits = Vec::new();
+            for (pos, &tok) in tokens.iter().enumerate() {
+                step_logits = state.forward_step(tok, pos);
+            }
+
+            let max_abs_diff = step_logits
+                .iter()
+                .zip(final_row.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0_f32, f32::max);
+
+            eprintln!(
+                "all-logits final-row parity: max_abs_diff={max_abs_diff:.6}, \
+                 argmax_step={}, argmax_all_logits_final={}",
+                argmax_f32(&step_logits),
+                argmax_f32(final_row)
+            );
+
+            assert!(
+                max_abs_diff < 1e-2,
+                "all-logits final row diverged from step loop: max_abs_diff={max_abs_diff}"
+            );
+            assert_eq!(
+                argmax_f32(&step_logits),
+                argmax_f32(final_row),
+                "argmax mismatch between step loop and all-logits final row"
+            );
         }
     }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -8185,6 +8185,7 @@ kernel void moe_shared_gate_add(
                 }
             }
             self.session.kv_cache.reset();
+            self.session.position = 0;
             if let Some(ref mut mtp) = self.session.mtp {
                 mtp.cache.reset();
             }
@@ -15789,6 +15790,100 @@ kernel void decode_attention_reference(
                 "argmax mismatch between step loop and chunked prefill"
             );
             // Both paths must advance the session cursor to the full prompt length.
+            assert_eq!(state.session.kv_cache.seq_len, tokens.len());
+            assert_eq!(state.session.position, tokens.len());
+        }
+
+        #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+        #[test]
+        fn metal_qwen35_chunked_prefill_length_1_final_chunk_matches_step_loop() {
+            // Degenerate-boundary gate: a prompt of exactly max_prefill + 1 tokens
+            // decomposes into chunks [max_prefill, 1]. The length-1 final chunk
+            // goes through forward_prefill_batched_chunk with n=1 (single-iteration
+            // per-token loops, m=1 GEMMs) — NOT the forward_step fast path. This
+            // path is unreachable by the 600-700 token parity test above.
+            let model_dir =
+                std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
+                    .join(".lattice/models/qwen3.5-0.8b");
+            if !model_dir.join("model.safetensors").exists()
+                || !model_dir.join("config.json").exists()
+                || !model_dir.join("tokenizer.json").exists()
+            {
+                eprintln!(
+                    "skipping length-1 final-chunk parity test: model files missing at {}",
+                    model_dir.display()
+                );
+                return;
+            }
+
+            let model = crate::model::qwen35::Qwen35Model::from_safetensors(&model_dir)
+                .expect("load qwen3.5-0.8b");
+            assert!(
+                model.config().num_active_linear_attention_layers() > 0,
+                "prompt must exercise at least one GDN layer"
+            );
+
+            let Some(device) = Device::system_default() else {
+                eprintln!("skipping length-1 final-chunk parity test: no Metal device");
+                return;
+            };
+            let _ = device;
+
+            let mut state = MetalQwen35State::new(model.weights(), model.config(), 1024)
+                .expect("construct Metal qwen3.5-0.8b state");
+
+            // Trim to exactly max_prefill + 1 so the final chunk has length 1.
+            let mut tokens = long_real_text_tokens(model.tokenizer());
+            let target = state.session.max_prefill + 1;
+            assert!(
+                tokens.len() >= target,
+                "helper produced {} tokens, need >= {target}",
+                tokens.len()
+            );
+            tokens.truncate(target);
+            assert_eq!(
+                tokens.len(),
+                state.session.max_prefill + 1,
+                "prompt must be exactly max_prefill + 1 for a length-1 final chunk"
+            );
+
+            // Path A: token-by-token reference.
+            state.reset_state();
+            let mut step_logits = Vec::new();
+            for (pos, &tok) in tokens.iter().enumerate() {
+                step_logits = state.forward_step(tok, pos);
+            }
+
+            // Path B: chunked batched prefill (final chunk length 1).
+            state.reset_state();
+            let prefill_logits = state.forward_prefill(&tokens);
+
+            assert_eq!(step_logits.len(), model.config().vocab_size);
+            assert_eq!(prefill_logits.len(), model.config().vocab_size);
+
+            let max_abs_diff = step_logits
+                .iter()
+                .zip(prefill_logits.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0_f32, f32::max);
+
+            eprintln!(
+                "length-1 final-chunk parity: max_abs_diff={max_abs_diff:.6}, \
+                 argmax_step={}, argmax_prefill={}, tokens={}",
+                argmax_f32(&step_logits),
+                argmax_f32(&prefill_logits),
+                tokens.len()
+            );
+
+            assert!(
+                max_abs_diff < 1e-2,
+                "length-1 final-chunk logits diverged from step loop: max_abs_diff={max_abs_diff}"
+            );
+            assert_eq!(
+                argmax_f32(&step_logits),
+                argmax_f32(&prefill_logits),
+                "argmax mismatch on length-1 final chunk"
+            );
             assert_eq!(state.session.kv_cache.seq_len, tokens.len());
             assert_eq!(state.session.position, tokens.len());
         }

--- a/docs/bench_results/agentic_1k_compare.json
+++ b/docs/bench_results/agentic_1k_compare.json
@@ -1,0 +1,32 @@
+[
+  {
+    "engine": "lattice",
+    "context": 1009,
+    "response": 100,
+    "ttft_ms": 10206.6,
+    "decode_ms": 1513.4,
+    "total_ms": 11720.0,
+    "prefill_tok_s": 99,
+    "decode_tok_s": 66
+  },
+  {
+    "engine": "ollama",
+    "context": 1450,
+    "response": 100,
+    "ttft_ms": 479.9,
+    "decode_ms": 1194.1,
+    "total_ms": 1674.0,
+    "prefill_tok_s": 3022,
+    "decode_tok_s": 84
+  },
+  {
+    "engine": "mlx",
+    "context": 1000,
+    "response": 100,
+    "ttft_ms": 383.5,
+    "decode_ms": 405.8,
+    "total_ms": 789.3,
+    "prefill_tok_s": 2608.0,
+    "decode_tok_s": 246.0
+  }
+]

--- a/scripts/bench_compare_1k.py
+++ b/scripts/bench_compare_1k.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Agentic-workload speed comparison at 1000-token context / 100-token response.
+
+Lattice  — real Metal e2e path via bench_decode_ab (prompt padded to ~1000 tok).
+Ollama   — /api/generate with the same workload, timings from the API.
+MLX      — measured separately by bench_agentic_workload.py (loaded from JSON).
+
+Methodology (identical across engines):
+  TTFT   = prefill latency (generate 1 token)
+  Total  = prefill + 100-token decode
+  Decode = Total - TTFT  ->  decode_tok_s = 100 / (decode_ms/1000)
+"""
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from statistics import median
+
+import requests
+
+REPO = Path(__file__).parent.parent
+BIN = REPO / "target" / "release" / "bench_decode_ab"
+MODEL_DIR = Path.home() / ".lattice" / "models" / "qwen3.5-0.8b"
+CTX = 1000
+RESP = 100
+RUNS = 5
+
+BASE = (
+    "The quick brown fox jumps over the lazy dog. "
+    "Once upon a time in a land far away, there lived a wise old owl "
+    "who knew many secrets. Every morning the sun rose over the "
+    "mountains and cast long shadows across the quiet valley. "
+)
+
+
+def lattice_total_ms(n_tokens):
+    env = os.environ.copy()
+    env.update(
+        BENCH_N=str(n_tokens),
+        BENCH_RUNS=str(RUNS),
+        BENCH_PROMPT_TOKENS=str(CTX),
+        LATTICE_MODEL_DIR=str(MODEL_DIR),
+    )
+    out = subprocess.run(
+        [str(BIN)], env=env, capture_output=True, text=True, timeout=300
+    )
+    times = []
+    actual_prompt = None
+    for line in (out.stdout + out.stderr).splitlines():
+        if "prompt_tokens=" in line:
+            actual_prompt = int(line.split("prompt_tokens=")[1].split()[0])
+        if line.startswith("RESULT"):
+            for p in line.split():
+                if p.startswith("total_ms="):
+                    times.append(float(p.split("=")[1]))
+    if not times:
+        raise RuntimeError(f"no lattice results:\n{out.stdout}\n{out.stderr}")
+    return median(times), actual_prompt
+
+
+def bench_lattice():
+    print("\n─── Lattice (Q8 safetensors, pure-Rust Metal) ───")
+    ttft, pt = lattice_total_ms(1)
+    total, _ = lattice_total_ms(RESP)
+    decode_ms = total - ttft
+    return mk("lattice", pt, ttft, total, decode_ms)
+
+
+def make_prompt(n_tokens_approx):
+    # ~0.75 words/token heuristic; ollama will report the true prompt count.
+    reps = max(1, n_tokens_approx * 4 // (len(BASE.split()) * 3))
+    return BASE * reps
+
+
+def bench_ollama(model="qwen3.5:0.8b"):
+    print("\n─── Ollama (Q4_K_M, llama.cpp Metal) ───")
+    url = "http://localhost:11434/api/generate"
+    prompt = make_prompt(CTX)
+    # warmup
+    requests.post(url, json={"model": model, "prompt": "hi", "stream": False,
+                             "options": {"num_predict": 4}}, timeout=120)
+    ttfts, totals, pcount = [], [], None
+    for _ in range(RUNS):
+        r = requests.post(url, json={
+            "model": model, "prompt": prompt, "stream": False,
+            "options": {"num_predict": RESP, "temperature": 0, "seed": 42},
+        }, timeout=300).json()
+        prompt_eval = r.get("prompt_eval_duration", 0) / 1e6  # ns -> ms
+        eval_dur = r.get("eval_duration", 0) / 1e6
+        load = r.get("load_duration", 0) / 1e6
+        ttfts.append(load + prompt_eval)
+        totals.append(load + prompt_eval + eval_dur)
+        pcount = r.get("prompt_eval_count", pcount)
+    ttft, total = median(ttfts), median(totals)
+    return mk("ollama", pcount, ttft, total, total - ttft)
+
+
+def mk(engine, ctx, ttft, total, decode_ms):
+    decode_tok_s = RESP / (decode_ms / 1000) if decode_ms > 0 else 0
+    prefill_tok_s = ctx / (ttft / 1000) if ttft > 0 else 0
+    row = {
+        "engine": engine, "context": ctx, "response": RESP,
+        "ttft_ms": round(ttft, 1), "decode_ms": round(decode_ms, 1),
+        "total_ms": round(total, 1),
+        "prefill_tok_s": round(prefill_tok_s), "decode_tok_s": round(decode_tok_s),
+    }
+    print(f"    context: {ctx} tok | TTFT {ttft:.0f}ms ({prefill_tok_s:.0f} tok/s) "
+          f"| decode {decode_ms:.0f}ms ({decode_tok_s:.0f} tok/s) | total {total:.0f}ms")
+    return row
+
+
+def main():
+    rows = [bench_lattice(), bench_ollama()]
+
+    # Pull MLX @ ctx≈1000 from the prior measurement.
+    mlx_json = REPO / "docs" / "bench_results" / "agentic_workload.json"
+    if mlx_json.exists():
+        for r in json.loads(mlx_json.read_text()):
+            if r["engine"] == "mlx" and abs(r["context"] - CTX) <= 50:
+                rows.append(r)
+                break
+
+    print("\n═══ Agentic Workload: 1000-token context, 100-token response ═══\n")
+    h = f"{'Engine':<10}{'Ctx':>6}{'TTFT(ms)':>10}{'Decode(ms)':>12}{'Total(ms)':>11}{'Prefill t/s':>13}{'Decode t/s':>12}"
+    print(h)
+    print("-" * len(h))
+    for r in rows:
+        print(f"{r['engine']:<10}{r['context']:>6}{r['ttft_ms']:>10.0f}"
+              f"{r['decode_ms']:>12.0f}{r['total_ms']:>11.0f}"
+              f"{r['prefill_tok_s']:>13.0f}{r['decode_tok_s']:>12.0f}")
+
+    out = REPO / "docs" / "bench_results" / "agentic_1k_compare.json"
+    out.write_text(json.dumps(rows, indent=2))
+    print(f"\nRaw: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2e_parity_check.py
+++ b/scripts/e2e_parity_check.py
@@ -22,19 +22,147 @@ import sys
 import time
 
 
-PROMPTS = [
-    "The capital of France is",
-    "In the year 2024, artificial intelligence",
-    "def fibonacci(n):\n    if n <= 1:\n        return n\n    return",
+# Each entry is (prompt, match_window).
+#
+# match_window: minimum number of leading generated tokens that must agree
+# between HF and lattice. Kept small because Qwen3.5 is a hybrid GQA+GDN
+# model and GDN recurrent state accumulation amplifies tiny f32 rounding
+# differences between implementations, so greedy output naturally diverges
+# after a few tokens. 3 tokens validates the forward pass (prefill + first
+# decode steps) for short prompts. For the long-prefill case the first
+# generated token is the critical signal (see comment on LONG_PROMPT below).
+PROMPTS: list[tuple[str, int]] = [
+    ("The capital of France is", 3),
+    ("In the year 2024, artificial intelligence", 3),
+    ("def fibonacci(n):\n    if n <= 1:\n        return n\n    return", 3),
+    # LONG_PROMPT: ~816 tokens (measured with Qwen/Qwen3.5-0.8B tokenizer).
+    # Must exceed max_prefill=512 so forward_prefill_impl takes the sequential
+    # per-token forward_step loop (the n > self.session.max_prefill branch in
+    # metal_qwen35.rs:forward_prefill_impl). This exercises the oversize /
+    # chunked-prefill path that upcoming PRs #188 and #189 modify.
+    # match_window=2: the first two generated tokens are a direct function of
+    # the full 816-step prefill final-position logits. GDN recurrent state
+    # drifts during decode (same reason short prompts use 3 not 15), but the
+    # first generated token after a correct long prefill must be identical
+    # between HF and lattice. Two tokens gives a margin over a single-token
+    # coincidence while remaining tolerant of subsequent decode drift.
+    (
+        "def merge_sort(arr):\n"
+        '    """\n'
+        "    Merge sort implementation.\n"
+        "    Time complexity: O(n log n)\n"
+        "    Space complexity: O(n)\n"
+        '    """\n'
+        "    if len(arr) <= 1:\n"
+        "        return arr\n"
+        "    mid = len(arr) // 2\n"
+        "    left = merge_sort(arr[:mid])\n"
+        "    right = merge_sort(arr[mid:])\n"
+        "    return merge(left, right)\n"
+        "\n"
+        "def merge(left, right):\n"
+        "    result = []\n"
+        "    i = j = 0\n"
+        "    while i < len(left) and j < len(right):\n"
+        "        if left[i] <= right[j]:\n"
+        "            result.append(left[i])\n"
+        "            i += 1\n"
+        "        else:\n"
+        "            result.append(right[j])\n"
+        "            j += 1\n"
+        "    result.extend(left[i:])\n"
+        "    result.extend(right[j:])\n"
+        "    return result\n"
+        "\n"
+        "def quick_sort(arr, low=0, high=None):\n"
+        '    """\n'
+        "    Quick sort implementation using Lomuto partition scheme.\n"
+        "    Average time complexity: O(n log n)\n"
+        "    Worst case: O(n^2) when already sorted.\n"
+        '    """\n'
+        "    if high is None:\n"
+        "        high = len(arr) - 1\n"
+        "    if low < high:\n"
+        "        pivot_idx = partition(arr, low, high)\n"
+        "        quick_sort(arr, low, pivot_idx - 1)\n"
+        "        quick_sort(arr, pivot_idx + 1, high)\n"
+        "    return arr\n"
+        "\n"
+        "def partition(arr, low, high):\n"
+        "    pivot = arr[high]\n"
+        "    i = low - 1\n"
+        "    for j in range(low, high):\n"
+        "        if arr[j] <= pivot:\n"
+        "            i += 1\n"
+        "            arr[i], arr[j] = arr[j], arr[i]\n"
+        "    arr[i + 1], arr[high] = arr[high], arr[i + 1]\n"
+        "    return i + 1\n"
+        "\n"
+        "def binary_search(arr, target):\n"
+        '    """Binary search in sorted array. Returns index or -1."""\n'
+        "    left, right = 0, len(arr) - 1\n"
+        "    while left <= right:\n"
+        "        mid = (left + right) // 2\n"
+        "        if arr[mid] == target:\n"
+        "            return mid\n"
+        "        elif arr[mid] < target:\n"
+        "            left = mid + 1\n"
+        "        else:\n"
+        "            right = mid - 1\n"
+        "    return -1\n"
+        "\n"
+        "class Stack:\n"
+        '    """LIFO stack backed by a Python list."""\n'
+        "    def __init__(self):\n"
+        "        self._data = []\n"
+        "\n"
+        "    def push(self, item):\n"
+        "        self._data.append(item)\n"
+        "\n"
+        "    def pop(self):\n"
+        "        if self.is_empty():\n"
+        '            raise IndexError("pop from empty stack")\n'
+        "        return self._data.pop()\n"
+        "\n"
+        "    def peek(self):\n"
+        "        if self.is_empty():\n"
+        '            raise IndexError("peek at empty stack")\n'
+        "        return self._data[-1]\n"
+        "\n"
+        "    def is_empty(self):\n"
+        "        return len(self._data) == 0\n"
+        "\n"
+        "    def size(self):\n"
+        "        return len(self._data)\n"
+        "\n"
+        "\n"
+        "class Queue:\n"
+        '    """FIFO queue using two stacks for amortized O(1) enqueue and dequeue."""\n'
+        "    def __init__(self):\n"
+        "        self._inbox = Stack()\n"
+        "        self._outbox = Stack()\n"
+        "\n"
+        "    def enqueue(self, item):\n"
+        "        self._inbox.push(item)\n"
+        "\n"
+        "    def dequeue(self):\n"
+        "        if self._outbox.is_empty():\n"
+        "            while not self._inbox.is_empty():\n"
+        "                self._outbox.push(self._inbox.pop())\n"
+        "        if self._outbox.is_empty():\n"
+        '            raise IndexError("dequeue from empty queue")\n'
+        "        return self._outbox.pop()\n"
+        "\n"
+        "    def is_empty(self):\n"
+        "        return self._inbox.is_empty() and self._outbox.is_empty()\n"
+        "\n"
+        "# All algorithms above are correct Python. The next function is:\n"
+        "def",
+        2,
+    ),
 ]
 
 MAX_TOKENS = int(os.environ.get("E2E_MAX_TOKENS", "15"))
-# Qwen3.5 is a hybrid GQA+GDN model. GDN recurrent state accumulation
-# amplifies tiny f32 rounding differences between implementations, so
-# greedy output diverges after a few tokens. 3 tokens is sufficient to
-# validate the forward pass (prefill + first decode steps) while
-# allowing natural implementation variance.
-MATCH_WINDOW = 3
 
 HF_MODEL_ID = os.environ.get("HF_MODEL_ID", "Qwen/Qwen3.5-0.8B")
 LATTICE_BIN = os.environ.get(
@@ -140,7 +268,7 @@ def run_lattice(prompt: str, max_tokens: int) -> dict:
     }
 
 
-def compare(prompt: str, hf: dict, lattice: dict) -> dict:
+def compare(prompt: str, hf: dict, lattice: dict, match_window: int) -> dict:
     """Compare HF vs lattice outputs. Returns verdict dict."""
     hf_ids = hf["generated_ids"][:MAX_TOKENS]
     lat_ids = lattice["generated_ids"][:MAX_TOKENS]
@@ -152,12 +280,13 @@ def compare(prompt: str, hf: dict, lattice: dict) -> dict:
             first_mismatch = i
             break
 
-    window_match = first_mismatch >= MATCH_WINDOW
+    window_match = first_mismatch >= match_window
     total_agree = sum(1 for a, b in zip(hf_ids, lat_ids) if a == b)
     agree_rate = total_agree / min_len if min_len > 0 else 0
 
     return {
         "prompt": prompt[:60],
+        "match_window": match_window,
         "first_mismatch": first_mismatch if first_mismatch < min_len else None,
         "window_match": window_match,
         "agree_rate": agree_rate,
@@ -175,18 +304,18 @@ def render_report(results: list[dict]) -> str:
     lines = ["## E2E Parity Report", ""]
     fails = [r for r in results if not r["pass"]]
     if fails:
-        lines.append(f"**FAIL**: {len(fails)}/{len(results)} prompts diverged within first {MATCH_WINDOW} tokens")
+        lines.append(f"**FAIL**: {len(fails)}/{len(results)} prompts diverged within their match windows")
     else:
-        lines.append(f"**PASS**: all {len(results)} prompts match within first {MATCH_WINDOW} tokens")
+        lines.append(f"**PASS**: all {len(results)} prompts match within their respective match windows")
     lines.append("")
 
-    lines.append("| Prompt | Agreement | First Diff | HF tok/s | Lattice tok/s | Verdict |")
-    lines.append("|--------|-----------|------------|----------|---------------|---------|")
+    lines.append("| Prompt | Window | Agreement | First Diff | HF tok/s | Lattice tok/s | Verdict |")
+    lines.append("|--------|--------|-----------|------------|----------|---------------|---------|")
     for r in results:
         diff = f"pos {r['first_mismatch']}" if r["first_mismatch"] is not None else "none"
         icon = "PASS" if r["pass"] else "FAIL"
         lines.append(
-            f"| `{r['prompt']}` | {r['total_agree']}/{r['total_compared']} "
+            f"| `{r['prompt']}` | {r['match_window']} | {r['total_agree']}/{r['total_compared']} "
             f"| {diff} | {r['hf_tok_s']:.1f} | {r['lat_tok_s']:.1f} | {icon} |"
         )
 
@@ -216,9 +345,9 @@ def main() -> int:
         return 2
 
     results = []
-    for prompt in PROMPTS:
+    for prompt, match_window in PROMPTS:
         print(f"\n{'='*60}", file=sys.stderr)
-        print(f"Prompt: {prompt[:60]}", file=sys.stderr)
+        print(f"Prompt: {prompt[:60]}  (match_window={match_window})", file=sys.stderr)
 
         print("[hf] running reference...", file=sys.stderr)
         hf_out = run_hf_reference(prompt, MAX_TOKENS)
@@ -230,7 +359,7 @@ def main() -> int:
             print("FAIL: lattice binary failed", file=sys.stderr)
             return 1
 
-        verdict = compare(prompt, hf_out, lat_out)
+        verdict = compare(prompt, hf_out, lat_out, match_window)
         results.append(verdict)
 
         status = "PASS" if verdict["pass"] else "FAIL"


### PR DESCRIPTION
## Summary

Replaces the per-token sequential prefill fallback (taken for prompts longer than `max_prefill ≈ 512`) with **chunked batched prefill** on Metal. A 1000-token prompt previously cost ~1000 individual GPU dispatches via `forward_step`; it now runs as batched chunks, cutting time-to-first-token by **1.78×** with **bit-for-bit identical** greedy output.

This is a single clean PR superseding the stale stack #187 (bench harness) + #188 (chunked prefill). It bundles the engine change **with its bench + regression setup**.

## Measured (this session, real before/after at ~1000-ctx, same harness)

`BENCH_N=1` (≈ TTFT), `BENCH_PROMPT_TOKENS=1000`, `BENCH_RUNS=5`, median:

| | TTFT @ 1009-ctx | Correctness |
|---|---:|---|
| main (`431b40dd2`) | 9,696 ms | oracle |
| **this PR** | **5,460 ms (1.78×)** | **bit-for-bit identical greedy output** |

Decode throughput unchanged (this only touches the prefill path).

## Correctness — bit-for-bit vs the sequential oracle

Two in-repo parity tests (`cargo test`, gated on the local qwen3.5-0.8b model) compare chunked/batched prefill against the token-by-token `forward_step` oracle:

- `metal_qwen35_chunked_prefill_long_prompt_matches_step_loop` (679 tokens, spans the 512 boundary): `max_abs_diff = 0.000000`, argmax match
- `metal_qwen35_chunked_prefill_length_1_final_chunk_matches_step_loop` (513 tokens → chunks `[512, 1]`, exercises the degenerate length-1 final chunk): `max_abs_diff = 0.000000`, argmax match

The chunking is a pure command-buffer-batching reorganization with absolute-position (`abs_pos`) threading through RoPE / KV-write offset / attention causal mask — no algorithmic change to attention or GDN. GDN conv + recurrence state and the KV cache carry across chunk boundaries via persistent session buffers.

## Review

Adversarial review of the diff: no merge-blockers. Verified chunk-boundary edges (n=512/513/partial-final), `abs_pos` threading, GDN+KV continuity, the RoPE block, buffer sizing, and u32 offset bounds (peaks ~134M ≪ 4.29B u32 max). The two recommended fixes are included:

- **MINOR-1**: `reset_state` now zeroes `session.position` alongside `kv_cache.reset()` (latent-bug prevention for the concurrent API the field exists for).
- **MINOR-3**: the 513-token length-1-final-chunk parity test above (a path the 600-700 token test never reaches).

## Bench + regression setup (ships in this PR)

- **Bench**: `bench_decode_ab` (with `BENCH_PROMPT_TOKENS` to pad to real context depth) + `scripts/bench_compare_1k.py` + a sample baseline (`docs/bench_results/agentic_1k_compare.json`) — the TTFT A/B is reproducible on any machine.
- **Regression (unit)**: the two parity tests above run under `cargo test --features "f16 metal-gpu"`.
- **Regression (e2e gate)**: `scripts/e2e_parity_check.py` gains an ~816-token oversize prompt (with a per-prompt match window). Because this PR touches `crates/inference/src/**`, `e2e-parity.yml`'s macOS job runs and the new oversize case **exercises the >512 chunked path against HF on this very PR** — the regression gate that protects this code is proven here, not deferred.

## ADR-058

Per-PR before/after numbers included above (TTFT A/B is the relevant measurement for a prefill change; `bench_decode_ab` is the agentic-workload harness). No decode-path Criterion groups are touched.

## Honest ceiling

1.78× is the first compounding step; TTFT is still ~14× behind MLX (~384 ms). Batched causal attention (#189) and chunked-parallel GDN (#190) are the follow-ups, each gated + measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
