### PR TITLE
fix(inference): clamp speculative decode to max_new_tokens budget (#242)

### DIFF
--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -1927,8 +1927,12 @@ where
             // Verify the draft tokens
             let (accepted, logits_vec) = verify_draft(&draft, pos, &mut forward_fn);
 
-            // Accept verified tokens
-            for &t in &draft[..accepted] {
+            // Accept verified tokens, but never past the caller's budget: a
+            // multi-token draft can exceed `max_new_tokens` in a single step,
+            // so clamp the commit to the remaining budget (#242).
+            let remaining = max_new_tokens - generated.len();
+            let commit = accepted.min(remaining);
+            for &t in &draft[..commit] {
                 if t == eos_token {
                     return generated;
                 }
@@ -1939,7 +1943,8 @@ where
 
             // If we rejected some draft tokens, the last set of logits
             // gives us the model's actual prediction for the next token.
-            if accepted < draft.len() {
+            // Skip it once the budget is full so the fallback cannot overrun.
+            if accepted < draft.len() && generated.len() < max_new_tokens {
                 let rejection_logits =
                     &logits_vec[accepted.min(logits_vec.len().saturating_sub(1))];
                 let next_token = argmax(rejection_logits) as u32;
@@ -2516,6 +2521,42 @@ mod tests {
             4,
         );
         assert_eq!(result.len(), 10);
+    }
+
+    #[test]
+    fn generate_does_not_overrun_budget_on_multi_token_draft() {
+        // Regression for #242: the speculative branch committed every accepted
+        // draft token (plus a rejection-fallback token) without re-checking the
+        // budget, so a multi-token draft could return more than `max_new_tokens`.
+        //
+        // The suffix [7,8,9] recurs at pos 0, so `speculate(&prompt)` drafts
+        // prompt[3..7] = [0,7,8,9] on the very first step. The forward_fn below
+        // makes the target agree with all four (accepted == 4), so a budget of 1
+        // would have returned 4 tokens before the fix.
+        let prompt = vec![7u32, 8, 9, 0, 7, 8, 9];
+        let eos = 999u32;
+        for max_new in 1..=3 {
+            let out = generate_with_speculation(
+                &prompt,
+                max_new,
+                eos,
+                |tok: u32, _pos: usize| match tok {
+                    0 => logits_with_argmax(1000, 7),
+                    7 => logits_with_argmax(1000, 8),
+                    8 => logits_with_argmax(1000, 9),
+                    _ => logits_with_argmax(1000, 5),
+                },
+                5,
+                4,
+            );
+            assert!(
+                out.len() <= max_new,
+                "budget {max_new} overrun: produced {} tokens {:?}",
+                out.len(),
+                out
+            );
+            assert_eq!(out.len(), max_new, "should fill the budget exactly");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #242: `generate_with_speculation` could return **more than `max_new_tokens`** tokens.

The decode loop only checks the budget at the top (`while generated.len() < max_new_tokens`). Inside the speculative branch it committed **every** accepted draft token, plus a rejection-fallback token, without re-checking the budget. So when the n-gram speculator drafts several tokens that all verify in one step, the function overruns: a 4-token draft with `max_new_tokens = 1` returned 4 tokens.

This breaks the API contract — a caller asking for N tokens can get more, overrunning their buffer / context budget.

## Fix

In the speculative branch only (the non-speculative single-token path is untouched):

```rust
let remaining = max_new_tokens - generated.len();   // > 0: top-of-loop guard holds, nothing pushed since
let commit = accepted.min(remaining);
for &t in &draft[..commit] { ... }                  // was &draft[..accepted]

if accepted < draft.len() && generated.len() < max_new_tokens {   // added budget gate
    /* rejection fallback */
}
```

Loop invariant is now `generated.len() <= max_new_tokens` on every return path. When `accepted <= remaining` (the common, no-overrun case) the committed tokens and fallback are byte-identical to before — only the overrun edge is clamped.

**No underflow:** `remaining = max_new_tokens - generated.len()` is computed right after the loop guard `generated.len() < max_new_tokens`; only `speculate()` and `verify_draft()` run in between and neither pushes to `generated`, so `remaining >= 1` always.

## Regression test (TDD)

`generate_does_not_overrun_budget_on_multi_token_draft`: a prompt whose suffix `[7,8,9]` recurs earlier, so `speculate` drafts `[0,7,8,9]` on the first step; a `forward_fn` makes the target accept all four (`accepted == 4`). Asserts `out.len() == max_new` for `max_new in 1..=3`.

- **Red** (pre-fix): `budget 1 overrun: produced 4 tokens [0, 7, 8, 9]`
- **Green** (post-fix): passes for all three budgets.

## Verification

- `cargo test -p lattice-inference --lib`: **933 passed, 0 failed** (53/53 speculative).
- `cargo clippy -p lattice-inference --lib -- -D warnings`: clean.
- Adversarial review (underflow / invariant / no-regression / test-quality): **approved**. Confirmed `remaining` cannot underflow (subtraction sits under the `generated.len() < max_new_tokens` guard, nothing pushes in between), `generated.len() <= max_new_tokens` holds on every return/break path, the no-overrun path is byte-identical to before, and the regression test correctly exercises the speculative branch and fails pre-fix.
- **Perf:** no measurable delta — and none is possible to measure. The touched function `generate_with_speculation` is an opt-in n-gram-speculation wrapper that is not on the standard decode hot path and is **not exercised by any Criterion bench group** (verified: the only bench hits for "speculat" are an unrelated comment in `attention_dispatch_bench` and a self-contained *mock* MTP loop in `inference_perf` that uses a local trait, not this function). `make bench-compare` (origin/main `e39c540b1` vs HEAD `c4752c0f6`) produced no usable A/B table — the two-worktree harness failed to parse change files (a known flakiness), which is moot here since the changed code has zero bench coverage. The inference CPU bench (`elementwise_cpu_bench`) builds and runs clean on HEAD. The diff adds only two integer comparisons inside a branch the standard decode path never enters, so a hot-path regression is structurally impossible.

## Scope

One file (`crates/inference/src/speculative.rs`, +44/-3): the budget clamp + the regression test. Does not touch #243 (separate known issue: `verify_draft` commits `draft[0]` unverified → lossy decode), which needs an algorithmic change to the verification loop and is filed separately.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
