### PR TITLE
fix(inference): harden KV-cache preconditions (page_size=0 div-by-zero, release-build assert parity) (#244)

### DIFF
--- a/crates/inference/src/kv_cache/flat.rs
+++ b/crates/inference/src/kv_cache/flat.rs
@@ -232,9 +232,13 @@ impl FlatKVCache {
     ///
     /// `buf` must have length >= `seq_len * kv_dim`. Converts f16→f32.
     pub fn read_k_into(&self, layer: usize, buf: &mut [f32]) {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         let end = self.seq_len * self.config.kv_dim();
-        debug_assert!(buf.len() >= end);
+        assert!(
+            buf.len() >= end,
+            "output buffer too small: need {end}, got {}",
+            buf.len()
+        );
         for (i, &h) in self.k[layer][..end].iter().enumerate() {
             buf[i] = h.to_f32();
         }
@@ -244,9 +248,13 @@ impl FlatKVCache {
     ///
     /// `buf` must have length >= `seq_len * kv_dim`. Converts f16→f32.
     pub fn read_v_into(&self, layer: usize, buf: &mut [f32]) {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         let end = self.seq_len * self.config.kv_dim();
-        debug_assert!(buf.len() >= end);
+        assert!(
+            buf.len() >= end,
+            "output buffer too small: need {end}, got {}",
+            buf.len()
+        );
         for (i, &h) in self.v[layer][..end].iter().enumerate() {
             buf[i] = h.to_f32();
         }
@@ -257,7 +265,7 @@ impl FlatKVCache {
     /// Use `read_k_into` for f32 dequantized access.
     #[inline]
     pub fn get_k_f16(&self, layer: usize) -> &[f16] {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         let end = self.seq_len * self.config.kv_dim();
         &self.k[layer][..end]
     }
@@ -267,7 +275,7 @@ impl FlatKVCache {
     /// Use `read_v_into` for f32 dequantized access.
     #[inline]
     pub fn get_v_f16(&self, layer: usize) -> &[f16] {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         let end = self.seq_len * self.config.kv_dim();
         &self.v[layer][..end]
     }
@@ -277,7 +285,7 @@ impl FlatKVCache {
     /// Allocates a Vec; prefer `read_k_into` when a pre-allocated buffer is available.
     #[inline]
     pub fn get_k(&self, layer: usize) -> Vec<f32> {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         let end = self.seq_len * self.config.kv_dim();
         self.k[layer][..end].iter().map(|h| h.to_f32()).collect()
     }
@@ -287,7 +295,7 @@ impl FlatKVCache {
     /// Allocates a Vec; prefer `read_v_into` when a pre-allocated buffer is available.
     #[inline]
     pub fn get_v(&self, layer: usize) -> Vec<f32> {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         let end = self.seq_len * self.config.kv_dim();
         self.v[layer][..end].iter().map(|h| h.to_f32()).collect()
     }
@@ -295,7 +303,7 @@ impl FlatKVCache {
     /// **Unstable**: mutable K slice for in-place f16 operations (e.g. RoPE applied in f16).
     #[inline]
     pub fn get_k_mut(&mut self, layer: usize) -> &mut [f16] {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         let end = self.seq_len * self.config.kv_dim();
         &mut self.k[layer][..end]
     }
@@ -303,7 +311,7 @@ impl FlatKVCache {
     /// **Unstable**: mutable V slice for in-place f16 operations.
     #[inline]
     pub fn get_v_mut(&mut self, layer: usize) -> &mut [f16] {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         let end = self.seq_len * self.config.kv_dim();
         &mut self.v[layer][..end]
     }
@@ -311,28 +319,28 @@ impl FlatKVCache {
     /// **Unstable**: full K buffer including unwritten positions (f16); used by prefill.
     #[inline]
     pub fn k_buffer_mut(&mut self, layer: usize) -> &mut [f16] {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         &mut self.k[layer]
     }
 
     /// **Unstable**: immutable full K buffer (f16).
     #[inline]
     pub fn k_buffer(&self, layer: usize) -> &[f16] {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         &self.k[layer]
     }
 
     /// **Unstable**: full V buffer including unwritten positions (f16).
     #[inline]
     pub fn v_buffer_mut(&mut self, layer: usize) -> &mut [f16] {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         &mut self.v[layer]
     }
 
     /// **Unstable**: immutable full V buffer (f16).
     #[inline]
     pub fn v_buffer(&self, layer: usize) -> &[f16] {
-        debug_assert!(layer < self.config.num_layers);
+        assert!(layer < self.config.num_layers, "layer index out of bounds");
         &self.v[layer]
     }
 
@@ -662,6 +670,38 @@ mod tests {
                 "read_k_into[{i}]: expected {orig}, got {got}"
             );
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "layer index out of bounds")]
+    fn read_k_into_out_of_range_layer_panics_clearly() {
+        // Regression for #244: read accessors guarded `layer` with `debug_assert!`,
+        // which compiled out in release and degraded to a bare `index out of bounds`
+        // panic. Now a runtime `assert!` gives the same descriptive message in both
+        // profiles, matching the write path (`append_kv` / `prefill_layer`).
+        let config = make_config(2, 8);
+        let kv_dim = config.kv_dim();
+        let cache = FlatKVCache::new(config);
+        let mut buf = vec![0.0f32; kv_dim];
+        cache.read_k_into(2, &mut buf); // valid layers are 0..2
+    }
+
+    #[test]
+    #[should_panic(expected = "output buffer too small")]
+    fn read_k_into_undersized_buffer_panics_clearly() {
+        // Regression for #244: the `buf.len() >= end` precondition was a
+        // `debug_assert!` and so unchecked in release. It is now a runtime
+        // `assert!` with a descriptive message.
+        let config = make_config(1, 8);
+        let kv_dim = config.kv_dim();
+        let mut cache = FlatKVCache::new(config);
+        let k = vec![1.0f32; kv_dim];
+        let v = vec![0.0f32; kv_dim];
+        cache.append_kv(0, &k, &v);
+        cache.advance();
+
+        let mut too_small = vec![0.0f32; kv_dim - 1];
+        cache.read_k_into(0, &mut too_small);
     }
 
     #[test]

--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -169,7 +169,15 @@ pub struct PageTable {
 
 impl PageTable {
     /// **Unstable**: create an empty page table.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `page_size == 0`: it is the divisor in [`PageTable::resolve`],
+    /// so a zero would otherwise surface as a cryptic divide-by-zero. This is
+    /// the authoritative guard for every `PageTable` (the `PagedKVCache`
+    /// constructors and `SequenceManager::add` both route through here).
     pub fn new(page_size: usize) -> Self {
+        assert!(page_size > 0, "PageTable page_size must be non-zero");
         Self {
             entries: Vec::new(),
             seq_len: 0,
@@ -1132,6 +1140,15 @@ mod tests {
         let mut config = make_config(4);
         config.page_size = 0;
         let _ = PagedKVCache::new(config);
+    }
+
+    #[test]
+    #[should_panic(expected = "page_size must be non-zero")]
+    fn page_table_zero_page_size_panics() {
+        // Regression for #244: `PageTable::new` is the authoritative chokepoint
+        // (`SequenceManager::add` reaches it directly, bypassing the
+        // `PagedKVCache` config guard), so the guard must live here too.
+        let _ = PageTable::new(0);
     }
 
     #[test]

--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -278,10 +278,21 @@ impl PagedKVCache {
     /// Passing `None` preserves existing behavior. Passing `Some(cache)` enables
     /// `restore_prefix` and `promote_to_prefix` without changing the hot append
     /// and gather paths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `config.page_size == 0`. `page_size` is the divisor in the
+    /// logical-page math (`PageTable::resolve`), so a zero would otherwise
+    /// surface later as a cryptic divide-by-zero in the hot path. This mirrors
+    /// the prefix path, which already rejects a zero `prefix_page_size`.
     pub fn with_prefix_cache(
         config: PagedKVCacheConfig,
         prefix_cache: Option<Arc<Mutex<PrefixPageCache>>>,
     ) -> Self {
+        assert!(
+            config.page_size > 0,
+            "PagedKVCacheConfig.page_size must be non-zero"
+        );
         let fpp = config.floats_per_page();
         let pool = PagePool::new(config.max_pages, fpp);
         let table = PageTable::new(config.page_size);
@@ -1110,6 +1121,17 @@ mod tests {
         for layer in 0..2 {
             cache.append_kv_layer(layer, &k, &v);
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "page_size must be non-zero")]
+    fn paged_zero_page_size_panics_at_construction() {
+        // Regression for #244: page_size == 0 is the divisor in PageTable::resolve,
+        // so it must be rejected at construction with a clear message instead of
+        // surfacing later as a cryptic divide-by-zero in the hot path.
+        let mut config = make_config(4);
+        config.page_size = 0;
+        let _ = PagedKVCache::new(config);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #244: two KV-cache precondition gaps on the `Unstable` `pub` API of `lattice-inference` (a published crate), both reachable from caller-controlled input.

### 1. `page_size == 0` → deferred divide-by-zero (paged.rs)

`PageTable::resolve` does `token_pos / self.page_size` and `% self.page_size`, but `page_size` was never validated at construction — a zero surfaced later as a cryptic divide-by-zero in the hot path.

Two `pub` paths build a `PageTable`:
- `PagedKVCache::new` → `with_prefix_cache`
- `SequenceManager::add(seq, page_size)` (batch/sequence.rs) — builds `PageTable::new(page_size)` **directly**, bypassing any config guard.

Fix: the authoritative `assert!(page_size > 0)` lives in **`PageTable::new`** — the single chokepoint both paths route through, and the type whose `resolve` does the division. `with_prefix_cache` keeps a config-framed guard as defense-in-depth (fires first for the `PagedKVCache` path). Mirrors the prefix path, which already rejects a zero `prefix_page_size`. All construction-time → zero hot-path cost.

### 2. Read accessors used `debug_assert!` → bare index panic in release (flat.rs)

`read_k_into`, `read_v_into`, `get_k_f16`, `get_v_f16`, `get_k`, `get_v`, and the `*_mut` / `*_buffer` variants guarded `layer < num_layers` (and `read_*_into` guarded `buf.len() >= end`) with `debug_assert!`, which compiles out in release and degrades to a bare `index out of bounds` panic. The sibling **write** path (`append_kv`, `prefill_layer`) and `advance_by` / `truncate_to` already runtime-`assert!` the identical conditions — so the read path was internally inconsistent.

Fix: promote those `debug_assert!` to runtime `assert!` with descriptive messages.

**This is diagnostics + internal-consistency only, not a UB fix:** `self.k[layer]` is already bounds-checked by Rust, and `end = seq_len * kv_dim()` is bounded by `max_seq_len` (enforced by `advance_by`/`prefill`), so there was never out-of-bounds access or silent corruption — just a worse panic message in release.

## Perf (ADR-058)

The read accessors are on the decode hot path, so finding 2 was measured. `kv_cache_f16/read_k_into` A/B, clean `origin/main` baseline vs HEAD:

```
kv_cache_f16/read_k_into/f16_to_f32_256_tokens
  time:   [80.60 µs 80.89 µs 81.22 µs]
  change: [-0.07% +0.28% +0.60%] (p = 0.11 > 0.05)
  No change in performance detected.
```

The added `assert!` is a redundant, perfectly-predicted branch dwarfed by the f16→f32 dequant loop. Finding 1 is construction-time and has no hot-path surface.

## Tests

Four regression tests, each fails pre-fix (construction did not panic / wrong panic message) and passes post-fix:
- `paged_zero_page_size_panics_at_construction` (PagedKVCache path)
- `page_table_zero_page_size_panics` (PageTable chokepoint, covers SequenceManager::add)
- `read_k_into_out_of_range_layer_panics_clearly`
- `read_k_into_undersized_buffer_panics_clearly`

`cargo test -p lattice-inference --lib`: **936 passed, 0 failed**. `cargo clippy --workspace -- -D warnings`: clean.

Adversarial review: approved with fixes. The single blocker was that `page_size==0` was still reachable via `SequenceManager::add` → `PageTable::new(0)`, bypassing the config guard — **this is exactly the path closed by the second commit** (`PageTable::new` chokepoint guard + `page_table_zero_page_size_panics` test), which the review observed in progress but assessed outside its committed scope. The review independently confirmed: finding 2 introduces no UB (`self.k[layer]` already bounds-checked, `end` bounded by `max_seq_len`), no behavior change for valid inputs, no caller relies on the old release-lenient behavior, and the regression tests are correct. (The review noted the flat-read tests only directly exercise `read_k_into`; the promoted `assert!` is byte-identical across all read accessors and the review deemed `read_k_into` "representative," so per-accessor test duplication is omitted as test-bloat.)

## Scope

`crates/inference/src/kv_cache/paged.rs` + `flat.rs` (file-disjoint from the other open lattice PRs). No behavior change for valid inputs — only invalid inputs now fail fast with a clear message instead of a cryptic one (or, for `page_size==0`, instead of a deferred divide-by-zero).

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
