### PR TITLE
fix(embed): harden SIMD public-API contracts (#249)

### DIFF
--- a/crates/embed/src/simd/binary.rs
+++ b/crates/embed/src/simd/binary.rs
@@ -147,7 +147,7 @@ pub fn hamming_distance_binary(a: &BinaryVector, b: &BinaryVector) -> u32 {
             // length for `dims` bits. The callee uses unaligned loads and chunk/remainder
             // bounds strictly within those slices; no out-of-bounds read is possible.
             return unsafe {
-                hamming_distance_neon(&a.data[..required_bytes], &b.data[..required_bytes])
+                hamming_distance_neon(&a.data[..required_bytes], &b.data[..required_bytes], a.dims)
             };
         }
     }
@@ -157,15 +157,24 @@ pub fn hamming_distance_binary(a: &BinaryVector, b: &BinaryVector) -> u32 {
         let _ = config;
     }
 
-    hamming_distance_scalar(&a.data[..required_bytes], &b.data[..required_bytes])
+    hamming_distance_scalar(&a.data[..required_bytes], &b.data[..required_bytes], a.dims)
 }
 
 /// Scalar Hamming distance using u64 chunks and count_ones().
-fn hamming_distance_scalar(a: &[u8], b: &[u8]) -> u32 {
+///
+/// `dims` is the true dimension count; the slice `a`/`b` has length `dims.div_ceil(8)`.
+/// When `dims % 8 != 0` the final byte contains `8 - (dims % 8)` padding bits that must
+/// not be counted. Bit 7 (MSB) holds the first dimension of each byte (see
+/// `from_f32_with_threshold`), so the `r = dims % 8` valid bits are the top `r` bits:
+/// mask = `0xFF << (8 - r)`.
+fn hamming_distance_scalar(a: &[u8], b: &[u8], dims: usize) -> u32 {
     let mut total: u32 = 0;
 
+    // Number of fully-populated 8-byte chunks (all bits valid).
+    let full_bytes = dims / 8; // bytes where every bit is a real dimension
+    let chunks = full_bytes / 8;
+
     // Process 8 bytes at a time as u64
-    let chunks = a.len() / 8;
     for c in 0..chunks {
         let offset = c * 8;
         let a_u64 = u64::from_ne_bytes([
@@ -191,10 +200,18 @@ fn hamming_distance_scalar(a: &[u8], b: &[u8]) -> u32 {
         total += (a_u64 ^ b_u64).count_ones();
     }
 
-    // Handle remaining bytes
+    // Handle the remaining full bytes (between the last u64 chunk and the partial byte)
     let remainder_start = chunks * 8;
-    for i in remainder_start..a.len() {
+    for i in remainder_start..full_bytes {
         total += (a[i] ^ b[i]).count_ones();
+    }
+
+    // Handle the single partial byte (if dims is not a multiple of 8).
+    // The `r` valid bits occupy the top `r` bits of the byte (MSB = dim 0 within byte).
+    let r = dims % 8;
+    if r != 0 {
+        let mask = 0xFFu8 << (8 - r); // top `r` bits set, bottom `(8-r)` clear
+        total += ((a[full_bytes] ^ b[full_bytes]) & mask).count_ones();
     }
 
     total
@@ -205,13 +222,17 @@ fn hamming_distance_scalar(a: &[u8], b: &[u8]) -> u32 {
 /// `vcnt` counts set bits in each byte of a NEON register.
 /// We XOR the two vectors, apply vcnt, then horizontally sum.
 ///
+/// `dims` is the true dimension count. When `dims % 8 != 0`, the final byte holds
+/// padding bits in its low bits; only the top `dims % 8` bits (MSB = first dim) are
+/// counted, matching the scalar path's masking logic.
+///
 /// # Safety
 ///
 /// Caller must ensure running on aarch64 (NEON is mandatory).
-/// `a` and `b` must have equal length.
+/// `a` and `b` must have equal length == `dims.div_ceil(8)`.
 #[cfg(target_arch = "aarch64")]
 #[inline]
-unsafe fn hamming_distance_neon(a: &[u8], b: &[u8]) -> u32 {
+unsafe fn hamming_distance_neon(a: &[u8], b: &[u8], dims: usize) -> u32 {
     // SA-163/164: verify equal-length backing slices before the SIMD loop.
     debug_assert_eq!(
         a.len(),
@@ -220,9 +241,11 @@ unsafe fn hamming_distance_neon(a: &[u8], b: &[u8]) -> u32 {
         a.len(),
         b.len()
     );
-    let len = a.len();
+
+    // Only full bytes (where every bit is a real dimension) go through the SIMD loop.
+    let full_bytes = dims / 8;
     const SIMD_WIDTH: usize = 16;
-    let chunks = len / SIMD_WIDTH;
+    let chunks = full_bytes / SIMD_WIDTH;
 
     // Accumulate popcount bytes into u16 to avoid overflow
     // (max 8 bits per byte, 16 bytes per register = 128 per chunk, fits u8 for ~1 chunk)
@@ -250,10 +273,18 @@ unsafe fn hamming_distance_neon(a: &[u8], b: &[u8]) -> u32 {
     let total = vgetq_lane_u64(sum_u64, 0) + vgetq_lane_u64(sum_u64, 1);
     let mut result = total as u32;
 
-    // Handle remainder
+    // Handle remaining full bytes (between last SIMD chunk and the partial byte)
     let remainder_start = chunks * SIMD_WIDTH;
-    for i in remainder_start..len {
+    for i in remainder_start..full_bytes {
         result += (a[i] ^ b[i]).count_ones();
+    }
+
+    // Handle the single partial byte (if dims is not a multiple of 8).
+    // Top `r` bits are real dimensions; bottom `(8 - r)` bits are padding.
+    let r = dims % 8;
+    if r != 0 {
+        let mask = 0xFFu8 << (8 - r); // top `r` bits set, bottom `(8-r)` clear
+        result += ((a[full_bytes] ^ b[full_bytes]) & mask).count_ones();
     }
 
     result
@@ -409,7 +440,7 @@ mod tests {
         let ba = BinaryVector::from_f32(&a);
         let bb = BinaryVector::from_f32(&b);
 
-        let scalar_result = hamming_distance_scalar(&ba.data, &bb.data);
+        let scalar_result = hamming_distance_scalar(&ba.data, &bb.data, ba.dims);
         let dispatch_result = ba.hamming_distance(&bb);
 
         assert_eq!(
@@ -486,5 +517,73 @@ mod tests {
         let bv = BinaryVector::from_f32(&v);
         let deq = bv.to_f32();
         assert_eq!(deq.len(), 128);
+    }
+
+    // --- Issue #249 regression: padding-bit masking in Hamming distance -------------
+
+    /// Vectors with 12 dimensions use 2 bytes, with 4 padding bits in byte 1 (the low
+    /// nibble). Two vectors that agree on all 12 real dimensions but differ in their
+    /// padding bits must report Hamming distance 0, not 4.
+    ///
+    /// Before the fix, XOR-popcount over the raw final byte counted those 4 spurious
+    /// differing padding bits. After the fix, the mask `0xFF << (8 - 4) = 0xF0` zeroes
+    /// the low nibble before counting, giving the correct answer.
+    #[test]
+    fn test_hamming_ignores_padding_bits() {
+        // 12 dims → 2 bytes; the last 4 bits of byte 1 are padding.
+        // Build via pub fields so we can inject arbitrary padding.
+        let clean = BinaryVector {
+            dims: 12,
+            // byte 1: top nibble = 4 valid dims, low nibble = 0 (zero padding)
+            data: vec![0b10101010u8, 0b11110000u8],
+            norm: 1.0,
+        };
+        let dirty = BinaryVector {
+            dims: 12,
+            // same valid bits in top nibble of byte 1, non-zero garbage in low-nibble padding
+            data: vec![0b10101010u8, 0b11111111u8],
+            norm: 1.0,
+        };
+
+        // Both vectors agree on all 12 real dimensions; Hamming distance must be 0.
+        assert_eq!(
+            hamming_distance_scalar(&clean.data, &dirty.data, 12),
+            0,
+            "scalar: padding bits must not be counted"
+        );
+        assert_eq!(
+            clean.hamming_distance(&dirty),
+            0,
+            "dispatch: padding bits must not be counted"
+        );
+
+        // Cosine distance approximation must also be 0.0 for identical valid bits.
+        assert_eq!(
+            clean.cosine_distance_approx(&dirty),
+            0.0,
+            "cosine_distance_approx: padding bits must not be counted"
+        );
+    }
+
+    /// Verifies that the partial-byte mask counts real differing bits correctly.
+    ///
+    /// byte 0: 0b10101010 ^ 0b01010101 = 0b11111111 → 8 differing bits.
+    /// byte 1 (masked with 0xF0): (0b11110000 ^ 0b00000000) & 0xF0 = 0b11110000 → 4 bits.
+    /// Total: 12, which equals `dims` (every real dimension differs).
+    #[test]
+    fn test_hamming_partial_byte_count() {
+        let a = BinaryVector {
+            dims: 12,
+            data: vec![0b10101010u8, 0b11110000u8],
+            norm: 1.0,
+        };
+        let b = BinaryVector {
+            dims: 12,
+            data: vec![0b01010101u8, 0b00000000u8],
+            norm: 1.0,
+        };
+
+        assert_eq!(hamming_distance_scalar(&a.data, &b.data, 12), 12);
+        assert_eq!(a.hamming_distance(&b), 12);
     }
 }

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -644,8 +644,12 @@ fn dot_product_i8_scalar_kernel(a: &[i8], b: &[i8]) -> f32 {
 /// # Invariant
 ///
 /// Both slices must satisfy the `[-127, 127]` range invariant. The value `-128`
-/// causes silent corruption in AVX2 and AVX-512 VNNI SIMD paths. This function
-/// enforces the invariant with a release-mode `assert!` at the public boundary.
+/// causes silent corruption in AVX2 (`_mm256_sign_epi8` saturation) and AVX-512
+/// VNNI (`_mm512_dpbusd_epi32` after `vpabsb`). The invariant is enforced with a
+/// **`debug_assert!`** (debug builds only); callers MUST guarantee it. The
+/// `QuantizedVector::from_f32` constructor satisfies it by clamping to `[-127, 127]`.
+/// Promoting this to a release `assert!` would add an O(n) scan to a documented hot
+/// path and is intentionally avoided.
 ///
 /// # Performance
 ///

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -544,7 +544,19 @@ pub fn approximate_int4_batch_prepared_into(
 /// The query is always f32; the stored data may be at any tier.
 ///
 /// Returns a value in [0, 2] where 0 = identical, 2 = opposite.
+///
+/// # Precondition
+///
+/// `query_f32.len()` must equal the stored vector's dimensionality. Violating
+/// this is a caller bug; correct HNSW usage never triggers it.
 pub fn approximate_cosine_distance(query_f32: &[f32], stored: &QuantizedData) -> f32 {
+    debug_assert_eq!(
+        query_f32.len(),
+        stored.dims(),
+        "approximate_cosine_distance: query length {} != stored dims {}",
+        query_f32.len(),
+        stored.dims(),
+    );
     match stored {
         QuantizedData::Full(v) => {
             // Exact cosine distance


### PR DESCRIPTION
## Summary

Fixes #249. An adversarial sweep of the `lattice-embed` SIMD numerical kernels found **no correctness bug on the normal internal data flow** (every kernel is correct for `from_f32`-produced inputs). The three issues are **public-API contract / misuse-hardening** gaps at the boundary where a caller supplies data the internal constructors would never produce. This PR closes all three, file-disjoint to `crates/embed/src/simd/`.

## Finding 1 — `binary.rs`: trailing padding bits counted when `dims % 8 != 0` (the real fix)

`BinaryVector` packs `dims` bits into `dims.div_ceil(8)` bytes; a non-multiple-of-8 `dims` leaves padding bits in the final byte. `hamming_distance_scalar`/`hamming_distance_neon` popcounted **all** packed bytes, so two vectors that agree on every real dimension but differ in their padding bits over-counted the distance. `from_f32` zeroes padding (so the production pipeline is unaffected), but the over-count is reachable via direct `pub`-field construction or deserialization of external data whose padding isn't zeroed.

**Fix:** both kernels now take `dims`, run the SIMD/u64 loop over `full_bytes = dims / 8` only, and mask the single partial byte before popcount:

```rust
let r = dims % 8;
if r != 0 {
    let mask = 0xFFu8 << (8 - r); // top r bits valid (MSB = first dim per byte), bottom 8-r are padding
    total += ((a[full_bytes] ^ b[full_bytes]) & mask).count_ones();
}
```

The mask is MSB-first to match `from_f32_with_threshold` (`bit_idx = 7 - (i % 8)`). OOB-safe: `hamming_distance_binary` slices both operands to `required_bytes = dims.div_ceil(8)`, so `a[full_bytes]` is in-bounds exactly when `r != 0` and is never touched when `r == 0`. For `dims % 8 == 0` the new bounds are byte-identical to the old `a.len()`-based loop.

Two regression tests added: `test_hamming_ignores_padding_bits` (dims=12, clean vs dirty padding → Hamming 0) and `test_hamming_partial_byte_count` (all 12 real bits differ → 12).

## Finding 2 — `tier.rs`: dimension mismatch escaped the documented `[0, 2]` range

`approximate_cosine_distance` documents a `[0, 2]` return. On the Binary tier, a `query_f32.len() != stored.dims()` mismatch routed through Hamming (which returns `u32::MAX` on length mismatch) → `~2.0 * u32::MAX / dims`, an unbounded value that corrupts HNSW ranking. A length mismatch is a precondition violation (the index is fixed-dim), so the proportionate fix is a cheap `O(1)` `# Precondition` `debug_assert_eq!(query_f32.len(), stored.dims())` — not a release-path guard.

## Finding 3 — `quantized.rs`: doc claimed a release `assert!` it does not have (doc-vs-code)

`dot_product_i8_raw`'s doc said it *"enforces the invariant with a release-mode `assert!`"*. The code uses `debug_assert!` (compiles out in release). The function is `pub` and takes arbitrary `&[i8]`; on x86 a `-128` byte silently corrupts the dot via the AVX2 `_mm256_sign_epi8` / AVX-512 VNNI `_mm512_dpbusd_epi32`-after-`vpabsb` fast paths. **Doc-only fix:** the doc now accurately describes the `debug_assert!`, the `[-127, 127]` caller contract (which `from_f32` satisfies by clamping), and why a release O(n) scan is intentionally avoided (it would be an ADR-058 regression on the documented HNSW hot path for a precondition realistic callers already meet).

## Why no debug→release promotion (unlike #246)

#246 promoted O(1) shape checks debug→release (cheap). Findings 1 and 3 here guard an **O(n) scan on a hot path**; a release scan would be an ADR-058 regression. The proportionate fixes are: correctness for Finding 1 (mask is O(1) per call, on the partial byte only), and contract documentation + an O(1) precondition for Findings 2/3.

## Verification (this session, local Apple Silicon)

```
cargo test -p lattice-embed ......................... 247 + 4 + 15 + 33 + 19 + 3 + 20 passed, 0 failed
cargo clippy -p lattice-embed --all-targets -D warnings  clean
cargo fmt -p lattice-embed --check ................... clean
```

## Perf (ADR-058) — bench A/B on the `binary_cosine_distance` group

`binary` sub-bench (routes through the fixed `cosine_distance_approx → hamming_distance` path), `--quick`, fix vs clean main baseline:

| dim  | base      | fix       | change             |
|------|-----------|-----------|--------------------|
| 384  | 2.93 ns   | 2.84 ns   | No change (p=0.09) |
| 768  | 4.28 ns   | 4.05 ns   | No change (p=0.07) |
| 1024 | 5.26 ns   | 4.97 ns   | No change (p=0.07) |
| 1536 | 7.25 ns   | 6.97 ns   | -3.4% (p=0.05, noise-level) |

All bench dims are multiples of 8, so they exercise the unchanged `dims % 8 == 0` codepath (byte-identical to `main`) — the table confirms no regression. The new partial-byte mask runs only when `dims % 8 != 0` and is a few scalar ops on a single byte; it is correctness-only and cannot meaningfully regress the kernel. Behavior-preserving for all `from_f32` inputs, so `e2e-parity` stays green.

## Scope

`crates/embed/src/simd/{binary,quantized,tier}.rs` only — file-disjoint from the other open lattice PRs (#238 KV, #245/#246 speculative/KV preconditions, #248 metal-gpu clippy gate).

Closes #249

## Adversarial review

A high-effort adversarial review, scoped to the uncommitted diff: **approved** — "no blocking defects found." It independently verified the mask matches MSB-first packing (`bit_idx = 7 - (i % 8)`), OOB safety (`a[full_bytes]` in-range iff `r != 0`), byte-identical `dims % 8 == 0` coverage, scalar/NEON parity, that the two new tests exercise the mask path with correct arithmetic (dims=12 → 0xF0), and that the doc updates match the actual `debug_assert!` code and cite intrinsics (`_mm256_sign_epi8`, `_mm512_dpbusd_epi32`) that exist in the kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
