### PR TITLE
fix(fann): harden training contracts (SkipBatch metric, hidden-softmax, doc)

### DIFF
--- a/crates/fann/src/activation.rs
+++ b/crates/fann/src/activation.rs
@@ -318,7 +318,12 @@ impl Activation {
     /// and need `f'(x)`. For efficiency, many activation derivatives can be
     /// computed from the output `y` directly.
     ///
-    /// Note: For Softmax, use `derivative_batch` with the full Jacobian.
+    /// For Softmax, both this method and `derivative_batch` return only the
+    /// **diagonal** of the Jacobian: `s_i * (1 − s_i)`.  The full Jacobian
+    /// (`J[i,j] = s_i * (δ_ij − s_j)`) is required for mathematically correct
+    /// Softmax gradients; it is implemented for the output layer in
+    /// `backprop.rs::compute_gradients`.  Hidden-layer Softmax uses only the
+    /// diagonal approximation (tracked as FP-095).
     #[inline]
     pub fn derivative(&self, output: f32) -> f32 {
         match self {

--- a/crates/fann/src/network/builder.rs
+++ b/crates/fann/src/network/builder.rs
@@ -31,6 +31,28 @@ pub struct NetworkBuilder {
     layers: Vec<(usize, Activation)>,
 }
 
+/// Reject Softmax on any hidden (non-final) layer.
+///
+/// Softmax normalises over the simplex — meaningful only at the output.
+/// On hidden layers the gradient degrades to the diagonal approximation
+/// `s_i*(1-s_i)`, producing silently wrong gradients (tracked as FP-095).
+fn validate_no_hidden_softmax(layers: &[(usize, Activation)]) -> FannResult<()> {
+    if layers.len() < 2 {
+        return Ok(());
+    }
+    let last_hidden = layers.len() - 1;
+    for (_, activation) in &layers[..last_hidden] {
+        if activation.is_softmax() {
+            return Err(FannError::InvalidBuilder(
+                "Softmax is only valid as the output-layer activation; \
+                 hidden layers must use a pointwise activation"
+                    .into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl NetworkBuilder {
     /// Create a new network builder
     pub fn new() -> Self {
@@ -70,6 +92,7 @@ impl NetworkBuilder {
     /// - Input size was not specified
     /// - No layers were added
     /// - Any layer has size 0
+    /// - Softmax is used on a hidden (non-output) layer
     pub fn build(self) -> FannResult<Network> {
         let input_size = self
             .input_size
@@ -82,6 +105,8 @@ impl NetworkBuilder {
         if input_size == 0 {
             return Err(FannError::InvalidBuilder("Input size cannot be 0".into()));
         }
+
+        validate_no_hidden_softmax(&self.layers)?;
 
         let mut layers = Vec::with_capacity(self.layers.len());
         let mut prev_size = input_size;
@@ -139,6 +164,8 @@ impl NetworkBuilder {
         if input_size == 0 {
             return Err(FannError::InvalidBuilder("Input size cannot be 0".into()));
         }
+
+        validate_no_hidden_softmax(&self.layers)?;
 
         let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
         let mut layers = Vec::with_capacity(self.layers.len());
@@ -260,5 +287,54 @@ mod tests {
         let layer1 = network1.layer(0).unwrap();
         let layer2 = network2.layer(0).unwrap();
         assert_ne!(layer1.weights(), layer2.weights());
+    }
+
+    #[test]
+    fn test_builder_rejects_hidden_softmax() {
+        // Softmax on a hidden layer should be rejected.
+        let result = NetworkBuilder::new()
+            .input(2)
+            .hidden(4, Activation::Softmax)
+            .output(1, Activation::Linear)
+            .build();
+        assert!(
+            matches!(result, Err(FannError::InvalidBuilder(_))),
+            "expected InvalidBuilder, got {result:?}"
+        );
+
+        // build_with_seed must enforce the same rule.
+        let result = NetworkBuilder::new()
+            .input(2)
+            .hidden(4, Activation::Softmax)
+            .output(1, Activation::Linear)
+            .build_with_seed(0);
+        assert!(
+            matches!(result, Err(FannError::InvalidBuilder(_))),
+            "expected InvalidBuilder from build_with_seed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_builder_output_softmax_is_allowed() {
+        // Softmax on the output layer must continue to work.
+        let result = NetworkBuilder::new()
+            .input(4)
+            .hidden(8, Activation::ReLU)
+            .output(3, Activation::Softmax)
+            .build();
+        assert!(
+            result.is_ok(),
+            "output Softmax should be allowed, got {result:?}"
+        );
+
+        let result = NetworkBuilder::new()
+            .input(4)
+            .hidden(8, Activation::ReLU)
+            .output(3, Activation::Softmax)
+            .build_with_seed(7);
+        assert!(
+            result.is_ok(),
+            "output Softmax with seed should be allowed, got {result:?}"
+        );
     }
 }

--- a/crates/fann/src/training/backprop.rs
+++ b/crates/fann/src/training/backprop.rs
@@ -292,7 +292,9 @@ impl Trainer for BackpropTrainer {
                     grads.fill(0.0);
                 }
 
-                // Accumulate gradients over batch
+                // Accumulate gradients over batch; keep batch error separate so
+                // SkipBatch can discard it without inflating epoch_error.
+                let mut batch_error = 0.0_f32;
                 for &idx in &indices[batch_start..batch_end] {
                     let error = self.compute_gradients(
                         network,
@@ -301,7 +303,7 @@ impl Trainer for BackpropTrainer {
                         &mut weight_grads,
                         &mut bias_grads,
                     )?;
-                    epoch_error += error;
+                    batch_error += error;
                 }
 
                 // Check for NaN/Inf gradients before applying
@@ -314,7 +316,8 @@ impl Trainer for BackpropTrainer {
                             )));
                         }
                         GradientGuardStrategy::Sanitize => {
-                            // Replace NaN/Inf with zeros and continue
+                            // Replace NaN/Inf with zeros and continue; batch is
+                            // still applied (sanitized) so we commit its error.
                             for grads in weight_grads.iter_mut() {
                                 sanitize_gradients(grads);
                             }
@@ -328,7 +331,8 @@ impl Trainer for BackpropTrainer {
                             );
                         }
                         GradientGuardStrategy::SkipBatch => {
-                            // Skip this batch entirely
+                            // Discard both gradients AND error for this batch so
+                            // epoch_error stays proportional to batch_count.
                             tracing::warn!(
                                 "Epoch {}: skipping batch due to NaN/Inf gradients ({})",
                                 epoch,
@@ -348,7 +352,16 @@ impl Trainer for BackpropTrainer {
                     actual_batch_size,
                 );
 
+                // Commit error and sample count only for non-skipped batches.
+                epoch_error += batch_error;
                 batch_count += actual_batch_size;
+            }
+
+            // Every batch was skipped — error metric is undefined; fail loudly.
+            if batch_count == 0 {
+                return Err(FannError::NumericInstability(
+                    "all batches skipped due to NaN/Inf gradients".into(),
+                ));
             }
 
             // Average error
@@ -365,10 +378,12 @@ impl Trainer for BackpropTrainer {
                 });
             }
 
-            // Check for NaN (numeric instability)
-            if avg_error.is_nan() {
+            // Catch both NaN and +Inf (the latter arises when every batch skips
+            // but batch_count is somehow non-zero due to partial skips and a
+            // very large accumulated error).
+            if avg_error.is_nan() || avg_error.is_infinite() {
                 return Err(FannError::NumericInstability(
-                    "NaN error during training".into(),
+                    "non-finite error during training".into(),
                 ));
             }
         }
@@ -476,6 +491,46 @@ mod tests {
 
         let result = trainer.train(&mut network, &inputs, &targets, &config);
         assert!(matches!(result, Err(FannError::TrainingError(_))));
+    }
+
+    #[test]
+    fn test_skip_batch_all_skipped_returns_error() {
+        // Targets containing NaN propagate into gradients (diff = output - NaN = NaN),
+        // triggering the gradient guard on every batch.  With SkipBatch the whole
+        // epoch completes with batch_count == 0, which must be an Err not an Ok
+        // with a non-finite final_error.
+        let mut network = NetworkBuilder::new()
+            .input(2)
+            .hidden(2, Activation::Tanh)
+            .output(1, Activation::Linear)
+            .build_with_seed(1)
+            .unwrap();
+
+        let inputs = vec![vec![1.0_f32, 0.0], vec![0.0, 1.0]];
+        // NaN targets guarantee NaN in every gradient computation.
+        let targets = vec![vec![f32::NAN], vec![f32::NAN]];
+
+        let mut trainer = BackpropTrainer::new();
+        let config = TrainingConfig::new()
+            .learning_rate(0.1)
+            .momentum(0.0)
+            .max_epochs(1)
+            .batch_size(2)
+            .shuffle(false)
+            .gradient_guard(GradientGuardStrategy::SkipBatch);
+
+        let result = trainer.train(&mut network, &inputs, &targets, &config);
+        assert!(
+            matches!(result, Err(FannError::NumericInstability(_))),
+            "expected NumericInstability, got {result:?}"
+        );
+        // Confirm the error text is informative (not just any instability error).
+        if let Err(FannError::NumericInstability(msg)) = result {
+            assert!(
+                msg.contains("all batches skipped"),
+                "unexpected message: {msg}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

An adversarial sweep (high effort) of the `lattice-fann` numerical path (activation, layer, backprop, gradient, network, builder, serialization, error) surfaced two real defects plus one misleading doc. This PR fixes all three, file-disjoint to `crates/fann/src/`. Each was TBV'd against the source before acting — the sweep initially rated the hidden-softmax issue CRITICAL, but the common output-layer softmax path is already correct (full Jacobian in `backprop::compute_gradients`), so the real exposure is the narrower hidden-layer case, fixed here by rejecting it at build time.

## Finding 1 — `backprop.rs`: SkipBatch skews the epoch metric and can divide by zero (the real fix)

`BackpropTrainer::train` added each sample's error into `epoch_error` **before** the NaN/Inf gradient-guard check. On `GradientGuardStrategy::SkipBatch`, the batch `continue`s past `batch_count += actual_batch_size` — but its error was already counted. Two defects:

- **Partial skips** inflate `avg_error = epoch_error / batch_count` (numerator counts skipped batches the denominator doesn't).
- **All batches skip** → `batch_count == 0` → `avg_error = epoch_error / 0 = +inf`, and the post-epoch guard only checked `is_nan()`, so `+inf` silently entered `error_history` and training "succeeded" with a non-finite final error.

**Fix:** per-sample error accumulates into a local `batch_error`; `epoch_error += batch_error` is committed alongside `batch_count += actual_batch_size` only for non-skipped batches (the `SkipBatch` `continue` now discards both; the `Sanitize` path still falls through and commits, since a sanitized batch *was* applied). An all-skipped epoch returns `Err(FannError::NumericInstability("all batches skipped due to NaN/Inf gradients"))`, and the guard now catches `is_nan() || is_infinite()`.

## Finding 2 — `builder.rs`: hidden-layer Softmax produces silently wrong gradients

Softmax normalizes over the simplex — meaningful only as the **output** activation. As a hidden activation, backprop uses `Activation::derivative()`, which returns only the diagonal `s_i*(1−s_i)` of the Softmax Jacobian; the off-diagonal coupling `J[i,j] = s_i*(δ_ij − s_j)` is dropped, so gradients are silently wrong (FP-095). The output-layer path is unaffected (it computes the full Jacobian inline in `compute_gradients`).

**Fix:** `validate_no_hidden_softmax` rejects `Activation::Softmax` on any non-final layer (`FannError::InvalidBuilder`) in both `build()` and `build_with_seed()`. Output-layer Softmax remains allowed. Verified safe: no existing usage (README/proptests/builder tests) uses hidden Softmax.

## Finding 3 — `activation.rs`: misleading derivative doc (doc-only)

`derivative()`'s doc said *"For Softmax, use `derivative_batch` with the full Jacobian."* False — `derivative_batch` also returns only the diagonal. Corrected to state that both return the diagonal, the full Jacobian is required and lives in `backprop::compute_gradients` for the output layer, and hidden-layer Softmax uses the diagonal approximation (FP-095). The existing `TODO(FP-095)` is preserved.

## Regression tests (the safety net)

- `test_skip_batch_all_skipped_returns_error` — NaN targets + `SkipBatch` → asserts `Err(NumericInstability)` containing "all batches skipped", **not** an `Ok` with a non-finite `final_error`. Fails on pre-fix code (which returned `Ok`).
- `test_builder_rejects_hidden_softmax` — hidden Softmax → `Err(InvalidBuilder)` via both build paths.
- `test_builder_output_softmax_is_allowed` — output Softmax still builds (both paths), guarding against over-rejection.

## Verification (this session, local Apple Silicon)

```
cargo test -p lattice-fann --lib ............ 74 passed; 0 failed
cargo test -p lattice-fann (incl doctests) .. all green
cargo clippy -p lattice-fann --all-targets -D warnings .. clean
cargo fmt -p lattice-fann --check ........... clean
cargo build -p lattice-tune ................. builds (fann is a tune dep)
```

## ADR-058 note (no bench-compare)

`lattice-fann` is the CPU feed-forward trainer used by `lattice-tune` for LoRA; it is **not** in the inference/embed decode hot path that ADR-058 gates with `bench-compare`. The changes are a local error accumulator (no extra work on the hot loop — error was already summed, just into a different variable), an O(1) build-time validation, and a doc edit. The three regression tests are the correctness safety net. The PR triggers `ci.yml` (fmt/clippy/test/build, base=main); it does not touch `inference/`/`embed/` so `e2e-parity.yml` does not apply.

## Scope

`crates/fann/src/{activation,network/builder,training/backprop}.rs` only — file-disjoint from every open lattice PR (#250 embed-simd, #248 metal-gpu clippy, #246/#245 inference KV/spec, #238 f16 KV, #234 bench harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
