### PR TITLE
fix(embed): bound skip accounting in migration controller + backfill sizing

### DIFF
--- a/crates/embed/src/backfill/coordinator.rs
+++ b/crates/embed/src/backfill/coordinator.rs
@@ -338,14 +338,19 @@ impl BackfillCoordinator {
     /// Compute the next batch size to process.
     ///
     /// Returns `0` if the migration is not in `InProgress` state.
-    /// Otherwise returns the smaller of the configured batch size
-    /// and the remaining items.
+    /// Otherwise returns the smaller of the configured batch size and the
+    /// effective remaining items (total minus processed minus skipped).
+    /// This keeps the batch estimate coherent with `record_progress`, which
+    /// also uses `effective_total = total − skipped` as its completion
+    /// threshold.
     pub fn next_batch_size(&self) -> usize {
         match self.controller.state() {
             MigrationState::InProgress {
-                processed, total, ..
+                processed,
+                total,
+                skipped,
             } => {
-                let remaining = total.saturating_sub(*processed);
+                let remaining = total.saturating_sub(*processed).saturating_sub(*skipped);
                 remaining.min(self.config.batch_size)
             }
             _ => 0,

--- a/crates/embed/src/backfill/tests.rs
+++ b/crates/embed/src/backfill/tests.rs
@@ -3,7 +3,7 @@
 use crate::backfill::{
     BackfillConfig, BackfillCoordinator, EmbeddingRoute, EmbeddingRoutingConfig, RoutingPhase,
 };
-use crate::migration::{MigrationPlan, MigrationState};
+use crate::migration::{MigrationPlan, MigrationState, SkipReason};
 use crate::model::EmbeddingModel;
 
 fn test_plan() -> MigrationPlan {
@@ -551,4 +551,44 @@ fn test_routing_config_lifecycle_full() {
     assert_eq!(routing.query_model, EmbeddingModel::BgeBaseEnV15);
     assert_eq!(routing.write_models.len(), 2);
     assert!(routing.migration_id.is_some());
+}
+
+#[test]
+fn test_next_batch_size_accounts_for_skipped() {
+    let plan = MigrationPlan {
+        id: "batch-skipped".to_string(),
+        source_model: EmbeddingModel::BgeSmallEnV15,
+        target_model: EmbeddingModel::BgeBaseEnV15,
+        total_embeddings: 10,
+        batch_size: 100, // larger than total so batch_size is not the limit
+        created_at: "2026-01-27T00:00:00Z".to_string(),
+    };
+    let config = BackfillConfig {
+        batch_size: 50,
+        ..BackfillConfig::default()
+    };
+    let mut coord = BackfillCoordinator::new(plan, config);
+    coord.start().unwrap();
+
+    // Skip 3 items; processed = 0.
+    for _ in 0..3 {
+        coord
+            .controller
+            .record_skip(SkipReason::ContentDeleted)
+            .unwrap();
+    }
+
+    // Effective remaining = 10 - 0 - 3 = 7; batch_size = 50 -> 7.
+    assert_eq!(coord.next_batch_size(), 7);
+
+    // Process the remaining 7 effective items; migration should complete.
+    coord.record_batch(7).unwrap();
+    assert!(
+        coord.state().is_terminal(),
+        "expected Completed, got {:?}",
+        coord.state()
+    );
+
+    // After completion, next_batch_size must be 0.
+    assert_eq!(coord.next_batch_size(), 0);
 }

--- a/crates/embed/src/migration/controller.rs
+++ b/crates/embed/src/migration/controller.rs
@@ -139,6 +139,17 @@ impl MigrationController {
                 total,
                 skipped,
             } => {
+                // Guard: processed + skipped must not reach total before this skip is
+                // counted. Equality means the budget is already exhausted (duplicate or
+                // retried skip); allow only while strictly less than total.
+                if *processed + *skipped >= *total {
+                    return Err(MigrationError::InvalidTransition {
+                        from: format!("{:?}", self.state),
+                        to: format!(
+                            "InProgress (skip rejected: processed + skipped would exceed total ({total}))",
+                        ),
+                    });
+                }
                 self.skip_reasons.push(reason);
                 self.state = MigrationState::InProgress {
                     processed: *processed,

--- a/crates/embed/src/migration/tests.rs
+++ b/crates/embed/src/migration/tests.rs
@@ -527,3 +527,55 @@ fn test_lifecycle_with_skips() {
     assert!(ctrl.state().is_terminal());
     assert_eq!(ctrl.state().skipped(), 2);
 }
+
+#[test]
+fn test_record_skip_rejects_exceeding_total() {
+    let plan = MigrationPlan {
+        id: "skip-cap".to_string(),
+        source_model: EmbeddingModel::BgeSmallEnV15,
+        target_model: EmbeddingModel::BgeBaseEnV15,
+        total_embeddings: 2,
+        batch_size: 10,
+        created_at: "2026-01-27T00:00:00Z".to_string(),
+    };
+    let mut ctrl = MigrationController::new(plan);
+    ctrl.start().unwrap();
+
+    // First two skips exhaust the budget (processed=0, so 0+0<2, 0+1<2).
+    assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_ok());
+    assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_ok());
+    assert_eq!(ctrl.state().skipped(), 2);
+
+    // Third skip must be rejected (0+2 >= 2); skipped count must not change.
+    assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_err());
+    assert_eq!(ctrl.state().skipped(), 2);
+}
+
+#[test]
+fn test_all_skipped_still_completes() {
+    let plan = MigrationPlan {
+        id: "all-skipped-complete".to_string(),
+        source_model: EmbeddingModel::BgeSmallEnV15,
+        target_model: EmbeddingModel::BgeBaseEnV15,
+        total_embeddings: 2,
+        batch_size: 10,
+        created_at: "2026-01-27T00:00:00Z".to_string(),
+    };
+    let mut ctrl = MigrationController::new(plan);
+    ctrl.start().unwrap();
+
+    // Skipping all items is legitimate: effective_total becomes 0.
+    assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_ok());
+    assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_ok());
+
+    // record_progress(0) should complete because effective_total == 0.
+    ctrl.record_progress(0).unwrap();
+
+    assert!(
+        ctrl.state().is_terminal(),
+        "expected Completed, got {:?}",
+        ctrl.state()
+    );
+    assert_eq!(ctrl.state().skipped(), 2);
+    assert_eq!(ctrl.state().processed(), 0);
+}


### PR DESCRIPTION
## Problem (issue #253)

An adversarial correctness sweep of the non-SIMD `lattice-embed` path surfaced two coherence gaps in the dimension-change migration's **skip accounting**. Both are about the relationship between `processed`, `skipped`, and `total`.

### 1. Unbounded `record_skip` → premature `Completed` (data loss)

`MigrationController::record_skip` incremented `skipped` with no upper bound. A retry or duplicate skip could push `skipped` past `total`. Once that happens, `record_progress` computes `effective_total = total.saturating_sub(skipped)` which saturates to `0`, so the migration transitions to `Completed` while little or no work was actually embedded — silent data loss for skipped-but-never-recomputed entries.

**Fix:** reject the skip with `MigrationError::InvalidTransition` (reused — carries a diagnostic message, PI_AEP) once `processed + skipped` would reach `total`. The guard runs *before* the increment, so a rejected skip leaves state unchanged.

### 2. `next_batch_size` ignored `skipped` → over-estimates remaining work

`BackfillCoordinator::next_batch_size` computed `remaining = total - processed`. With skips present this over-counts the remaining work and can keep proposing batches after the effective work is exhausted. Now `remaining = total - processed - skipped`, coherent with the controller's `effective_total`.

### Not a bug (verified, left alone)

The legitimately-all-skipped path — `skipped == total` because every item is already up to date — still completes correctly. The original sweep flagged this as HIGH; on TBV it is correct behavior, so only the *unbounded* invariant is the gap. Severity downgraded accordingly.

## Tests

- `test_record_skip_rejects_exceeding_total` — skip at the boundary is rejected, count unchanged
- `test_all_skipped_still_completes` — the legitimate all-skipped completion path preserved
- `test_next_batch_size_accounts_for_skipped` — `next_batch_size` honors `skipped` (10 total, 3 skipped → 7) then reaches 0 at terminal

## Verification (run locally)

- `cargo test -p lattice-embed` — 248 pass, 0 fail
- `cargo clippy -p lattice-embed --all-targets -- -D warnings` — clean
- `cargo fmt -p lattice-embed --check` — clean

No inference/embed-forward hot-path changes (migration/backfill state machine only), so no bench-compare required under ADR-058; `e2e-parity.yml` `paths:` filter does not match these files.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)