### PR TITLE
ci(e2e-parity): pin HF reference deps to the known-green set (#236)

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -88,9 +88,15 @@ jobs:
           path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
           key: hf-qwen35-0.8b-v1
 
-      # Step 1: install reference framework (HF transformers + torch CPU)
+      # Step 1: install reference framework (HF transformers + torch CPU).
+      # Pinned to the known-green reference set — the exact versions that
+      # produced the current passing parity baseline (extracted from a green
+      # `e2e parity` run). An unpinned `pip install` lets a new transformers
+      # release silently change greedy-generation behavior and flip the parity
+      # verdict on borderline prompts (issue #236). To bump: change a pin, let
+      # this gate re-run, and re-baseline the committed goldens if it moves.
       - name: Install Python deps
-        run: pip install torch transformers tokenizers huggingface_hub
+        run: pip install "torch==2.12.1" "transformers==5.12.1" "tokenizers==0.22.2" "huggingface_hub==1.20.1"
 
       # Step 2: download model if not cached
       - name: Download Qwen3.5-0.8B weights


### PR DESCRIPTION
## Problem (#236)

The `e2e-parity` gate installs the HF reference framework unpinned:

```yaml
run: pip install torch transformers tokenizers huggingface_hub
```

A new upstream release of any of these can silently change greedy-generation
behavior and flip the parity verdict on borderline prompts — turning the gate
into a flaky, non-reproducible check whose verdict depends on whatever
versions PyPI served that day.

## Fix

Pin to the exact versions that produced the **current passing baseline**,
extracted from a green `e2e parity` run (run 28059027190, job 83068539238):

```yaml
run: pip install "torch==2.12.1" "transformers==5.12.1" "tokenizers==0.22.2" "huggingface_hub==1.20.1"
```

A 6-line comment above the install documents *why* it's pinned and the bump
procedure: change a pin, let the gate re-run, re-baseline the committed
goldens if greedy output moves.

## Scope / safety

- One file, `+8/-2`. CI-only — no engine, no `crates/` change, no bench impact.
- Versions are not guessed; they are the live resolution from a green run's
  `Successfully installed` line (tokenizers 0.22.2 was the final resolved
  version, not the 0.23.1 downgraded intermediate).
- Reproduces the existing green baseline exactly, so the gate stays green on
  merge and only future *unpinned drift* is prevented.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)