### PR TITLE
perf(inference): per-layer decode GPU profiler (LATTICE_PROFILE_GPU) for #241

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -7106,6 +7106,8 @@ kernel void gdn_chunk_norm_silu_c32(
 
             // --- Per-phase timing (enabled by env LATTICE_PROFILE=1) ---
             let profiling = std::env::var_os("LATTICE_PROFILE").is_some();
+            // Per-layer command buffers: isolate each layer's GPU wall for #241 attribution.
+            let profiling_gpu = std::env::var_os("LATTICE_PROFILE_GPU").is_some();
 
             if std::env::var_os("LATTICE_GDN_CPU").is_some() {
                 #[cfg(not(debug_assertions))]
@@ -7149,56 +7151,145 @@ kernel void gdn_chunk_norm_silu_c32(
             // Raw pointer breaks the borrow chain: cmd is ref-counted by Metal
             // and outlives the queue borrow. The encode_* methods need &mut self
             // (for session state) but don't touch engine.queue.
-            let cmd = unsafe {
-                &*(self.engine.queue.new_command_buffer() as *const metal::CommandBufferRef)
-            };
-            let enc = cmd.new_compute_command_encoder();
+            let topk_which = if !profiling_gpu {
+                let cmd = unsafe {
+                    &*(self.engine.queue.new_command_buffer() as *const metal::CommandBufferRef)
+                };
+                let enc = cmd.new_compute_command_encoder();
 
-            for layer_i in 0..cfg.num_hidden_layers {
-                if !cfg.is_layer_active(layer_i) {
-                    continue;
-                }
-                let compact_idx = active_layer_idx;
-                active_layer_idx += 1;
-                let is_linear = matches!(
-                    &self.engine.layer_weights[compact_idx].0,
-                    MetalLayerAttnWeights::Linear(_)
-                );
-                if is_linear {
-                    gdn_gpu_dispatches += self.encode_gdn_layer(
-                        enc,
-                        compact_idx,
-                        linear_idx,
-                        position,
-                        layer_i,
-                        &cfg,
-                        &mut prof,
-                        profiling,
+                for layer_i in 0..cfg.num_hidden_layers {
+                    if !cfg.is_layer_active(layer_i) {
+                        continue;
+                    }
+                    let compact_idx = active_layer_idx;
+                    active_layer_idx += 1;
+                    let is_linear = matches!(
+                        &self.engine.layer_weights[compact_idx].0,
+                        MetalLayerAttnWeights::Linear(_)
                     );
-                    linear_idx += 1;
+                    if is_linear {
+                        gdn_gpu_dispatches += self.encode_gdn_layer(
+                            enc,
+                            compact_idx,
+                            linear_idx,
+                            position,
+                            layer_i,
+                            &cfg,
+                            &mut prof,
+                            profiling,
+                        );
+                        linear_idx += 1;
+                    } else {
+                        self.encode_gqa_layer(
+                            enc,
+                            compact_idx,
+                            full_idx,
+                            position,
+                            kv_dim,
+                            layer_i,
+                            &cfg,
+                            &mut prof,
+                            profiling,
+                        );
+                        full_idx += 1;
+                    }
+                } // end layer loop
+
+                let topk = self.encode_final_head(enc, &cfg, capture_hidden, &mut prof, profiling);
+
+                // Single submit for entire forward pass + optional top-k.
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+
+                topk
+            } else {
+                // Per-layer command buffers: isolate each layer's GPU wall for #241 attribution.
+                let mut layer_walls: Vec<(usize, bool, u128)> = Vec::new();
+
+                for layer_i in 0..cfg.num_hidden_layers {
+                    if !cfg.is_layer_active(layer_i) {
+                        continue;
+                    }
+                    let compact_idx = active_layer_idx;
+                    active_layer_idx += 1;
+                    let is_linear = matches!(
+                        &self.engine.layer_weights[compact_idx].0,
+                        MetalLayerAttnWeights::Linear(_)
+                    );
+                    let cmd_i = unsafe {
+                        &*(self.engine.queue.new_command_buffer() as *const metal::CommandBufferRef)
+                    };
+                    let enc_i = cmd_i.new_compute_command_encoder();
+                    if is_linear {
+                        gdn_gpu_dispatches += self.encode_gdn_layer(
+                            enc_i,
+                            compact_idx,
+                            linear_idx,
+                            position,
+                            layer_i,
+                            &cfg,
+                            &mut prof,
+                            profiling,
+                        );
+                        linear_idx += 1;
+                    } else {
+                        self.encode_gqa_layer(
+                            enc_i,
+                            compact_idx,
+                            full_idx,
+                            position,
+                            kv_dim,
+                            layer_i,
+                            &cfg,
+                            &mut prof,
+                            profiling,
+                        );
+                        full_idx += 1;
+                    }
+                    enc_i.end_encoding();
+                    let t = std::time::Instant::now();
+                    cmd_i.commit();
+                    cmd_i.wait_until_completed();
+                    let wall = t.elapsed().as_micros();
+                    layer_walls.push((layer_i, is_linear, wall));
+                } // end per-layer loop
+
+                let cmd_head = unsafe {
+                    &*(self.engine.queue.new_command_buffer() as *const metal::CommandBufferRef)
+                };
+                let enc_head = cmd_head.new_compute_command_encoder();
+                let topk =
+                    self.encode_final_head(enc_head, &cfg, capture_hidden, &mut prof, profiling);
+                enc_head.end_encoding();
+                let t_head = std::time::Instant::now();
+                cmd_head.commit();
+                cmd_head.wait_until_completed();
+                let head_wall = t_head.elapsed().as_micros();
+
+                let n_gdn = layer_walls.iter().filter(|e| e.1).count();
+                let n_gqa = layer_walls.iter().filter(|e| !e.1).count();
+                let gdn_sum: u128 = layer_walls.iter().filter(|e| e.1).map(|e| e.2).sum();
+                let gqa_sum: u128 = layer_walls.iter().filter(|e| !e.1).map(|e| e.2).sum();
+                let sum_all = gdn_sum + gqa_sum + head_wall;
+                let gdn_mean = if n_gdn > 0 {
+                    gdn_sum / n_gdn as u128
                 } else {
-                    self.encode_gqa_layer(
-                        enc,
-                        compact_idx,
-                        full_idx,
-                        position,
-                        kv_dim,
-                        layer_i,
-                        &cfg,
-                        &mut prof,
-                        profiling,
-                    );
-                    full_idx += 1;
-                }
-            } // end layer loop
+                    0
+                };
+                let gqa_mean = if n_gqa > 0 {
+                    gqa_sum / n_gqa as u128
+                } else {
+                    0
+                };
+                eprintln!(
+                    "[GPU-PROFILE] step {position}: total_us={sum_all} \
+                     gdn_sum_us={gdn_sum} gqa_sum_us={gqa_sum} final_head_us={head_wall} \
+                     n_gdn={n_gdn} n_gqa={n_gqa} gdn_mean_us={gdn_mean} gqa_mean_us={gqa_mean}"
+                );
 
-            let topk_which =
-                self.encode_final_head(enc, &cfg, capture_hidden, &mut prof, profiling);
-
-            // Single submit for entire forward pass + optional top-k.
-            enc.end_encoding();
-            cmd.commit();
-            cmd.wait_until_completed();
+                topk
+            };
 
             // Diagnostic: dump post-final-norm hidden state magnitudes for
             // divergence analysis vs MLX. Set LATTICE_HIDDEN_DUMP=path to enable.

--- a/docs/bench_results/decode_kernel_profile.md
+++ b/docs/bench_results/decode_kernel_profile.md
@@ -1,0 +1,61 @@
+# Decode-step per-kernel GPU profile (#241)
+
+Model: qwen3.5-0.8b (18 GDN linear-attention layers + 6 GQA full-attention layers).
+Harness: `bench_decode_ab` warm decode, `LATTICE_PROFILE` (CPU-encode vs GPU) and
+`LATTICE_PROFILE_GPU` (per-layer isolated GPU wall, added for #241). Apple Silicon, f16+metal-gpu.
+Measured 2026-06-23. All numbers are warm steady-state (steps ~96-119).
+
+## Gating result — decode is 99% GPU-bound
+
+`LATTICE_PROFILE` decomposes the step into CPU-encode time per phase vs `other_us`
+(the commit→`wait_until_completed` wall = GPU compute, since all 24 layers are one
+command buffer with a single wait):
+
+| | total/token | CPU-encode (embed+proj+gdn+gqa+mlp+final) | other_us (GPU) |
+|---|---|---|---|
+| f16 | ~6290 µs (159 tok/s) | ~37 µs (0.5%) | ~6250 µs (99.5%) |
+| Q4  | ~4230 µs (236 tok/s) | ~37 µs (0.9%) | ~4190 µs (99.1%) |
+
+**The lever is GPU kernel time, not CPU dispatch overhead.** (Consistent with the
+prior prefill finding that GDN dispatch amortization is ~0%.) Q4 is +49% over f16
+at single-token decode here.
+
+## Per-layer GPU attribution (`LATTICE_PROFILE_GPU`)
+
+Each layer is run in its own command buffer with a host-wall around commit+wait, so
+every per-layer number carries ~1 barrier (~180 µs, derived from isolated-sum
+~11.6 ms vs fused ~6.9 ms over 25 flushes). Relative attribution is robust; absolute
+per-layer values are barrier-inflated.
+
+| Phase | f16 µs/layer | Q4 µs/layer | Q4 effect | f16 share | Q4 share |
+|---|---|---|---|---|---|
+| GDN layer (×18) | 375 | 319 | −15% | 58% | ~63% |
+| GQA layer (×6)  | 542 | 489 | −10% | 28% | ~32% |
+| lm_head (×1)    | 1561 | 524 | **−3.0×** | 13% | ~5% |
+
+## Findings (refines the prior decode-bandwidth note)
+
+1. **No single kernel dominates.** f16: GDN-block ~50%, GQA-block ~31%, lm_head ~20%
+   (after barrier correction). It is a distributed cost.
+2. **Per-layer, a GQA layer is ~1.85× heavier than a GDN layer** (true ~362 vs ~195 µs).
+   GDN dominates the step only by 3× layer count, NOT by per-layer cost. The naive
+   "GDN scan is the expensive kernel" framing is wrong at the per-layer level.
+3. **lm_head is pure weight-bandwidth** — Q4 collapses it 3× (1561→524 µs). In the
+   shipping Q4 default it is already handled (~5%), a non-lever. In f16 it is the single
+   largest kernel (~20%) and a clean Q4/Q8-lm_head lever if f16 decode matters.
+4. **GDN and GQA layers are NOT weight-GEMV-bound** — Q4 only shaves 10-15%, vs the 3×
+   it gives lm_head. So within those layers the dominant cost is quantization-immune:
+   the GDN recurrence scan + conv1d (state ops), and GQA `decode_attention` over the KV
+   cache (+ softmax). Their projection GEMVs are a minority of the layer.
+
+## Conclusion — highest-value Q4-decode lever
+
+For the shipping **Q4 path (236 tok/s)** the breakdown is ~GDN 53% / GQA 40% / head 7%.
+The GDN recurrence path (18 layers, ~53%, quantization-immune) is the top target →
+**#174 (GDN single-pass decode kernel)**. GQA `decode_attention` (~40%) is the second.
+
+Open follow-up (gated first step of the attack task): a *direct* within-GDN-layer GPU
+split (recurrence-scan vs conv1d vs in/out-projection) to quantify how much of the GDN
+layer is the scan specifically. The Q4-immunity evidence above is strong but indirect;
+this requires refactoring `encode_gdn_layer` to flush mid-function (it currently receives
+only `&enc`, not the queue).


### PR DESCRIPTION
## What

Adds env-gated per-layer GPU-time attribution to the Metal decode step (`LATTICE_PROFILE_GPU=1`), and the resulting profile as a durable artifact. Closes the measurement half of #241.

When `LATTICE_PROFILE_GPU` is **unset**, the decode path is byte-identical to today: one command buffer for all 24 layers, single `wait_until_completed`. When **set**, each layer runs in its own command buffer with a host wall around commit+wait, emitting a `[GPU-PROFILE]` line (`gdn_sum_us`/`gqa_sum_us`/`final_head_us` + per-type means). The default branch is unchanged — the diff just wraps it in `if !profiling_gpu { <original> } else { <per-layer> }`.

## Profile findings (qwen3.5-0.8b — `docs/bench_results/decode_kernel_profile.md`)

- **Decode is 99% GPU-bound** (CPU-encode ~0.5%) — the lever is kernel time, not dispatch overhead.
- f16 step: **GDN-block ~50%, GQA-block ~31%, lm_head ~20%**. Per-layer a GQA layer is **1.85× heavier** than a GDN layer — GDN dominates by 3× layer count, not per-layer cost.
- **Q4 differential**: lm_head collapses **3×** under Q4 (pure weight-bandwidth, already handled in the Q4 default), while GDN/GQA layers shrink only 10-15% → they are **quantization-immune** (recurrence-scan + attention, not weight-GEMV).
- **Top Q4-decode lever = the GDN recurrence path (~53%)** → #174 (GDN single-pass decode kernel). Direct within-GDN kernel split is the gated next step.

## Safety / testing

- No hot-path behavior change when the flag is off; the e2e-parity gate validates greedy-token agreement is unchanged.
- `cargo build --release --features f16,metal-gpu` clean; `cargo clippy -p lattice-inference --features f16,metal-gpu -- -D warnings` clean.
- Tooling + measurement only — no bench-compare A/B needed (the default decode path is untouched).

Refs #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)