### PR TITLE
perf(inference): enable tiled simdgroup Q4 GEMM on Apple7+ (1.62× prefill)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -4749,7 +4749,10 @@ kernel void gdn_chunk_norm_silu_c32(
             };
 
             let make_optional_gemm_q4_tiled = || -> Option<ComputePipelineState> {
-                if !device.supports_family(MTLGPUFamily::Apple9) {
+                // simdgroup_float8x8 matrix ops are available since Apple7 (M1).
+                // The compile/pipeline `.ok()?` chain below falls back to the
+                // naive gemm_q4 on any device where the V3.0 source fails.
+                if !device.supports_family(MTLGPUFamily::Apple7) {
                     return None;
                 }
                 let tiled_opts = CompileOptions::new();
@@ -13105,7 +13108,10 @@ kernel void gdn_chunk_norm_silu_c32(
             };
 
             let make_optional_gemm_q4_tiled = || -> Option<ComputePipelineState> {
-                if !device.supports_family(MTLGPUFamily::Apple9) {
+                // simdgroup_float8x8 matrix ops are available since Apple7 (M1).
+                // The compile/pipeline `.ok()?` chain below falls back to the
+                // naive gemm_q4 on any device where the V3.0 source fails.
+                if !device.supports_family(MTLGPUFamily::Apple7) {
                     return None;
                 }
                 let tiled_opts = CompileOptions::new();
@@ -16111,6 +16117,31 @@ kernel void decode_attention_reference(
             // Unload
             state.unload_lora_adapter();
             assert!(!state.has_lora_adapter());
+        }
+
+        #[test]
+        fn gemm_q4_tiled_enabled_on_apple7_plus() {
+            // Regression guard for the M>1 prefill GEMM. The simdgroup-matrix
+            // tiled Q4 kernel (`gemm_q4_tiled`) must be enabled on every Apple7+
+            // GPU (M1 and up). It was previously gated behind Apple9, silently
+            // disabling it on M1/M2 and falling back to the ~1.6x-slower naive
+            // `gemm_q4`. A silent MSL compile failure would re-trigger the same
+            // fallback. Both regress prefill throughput with no visible error,
+            // so assert the real gate path keeps the tiled pipeline live.
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            if !device.supports_family(MTLGPUFamily::Apple7) {
+                return;
+            }
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let state =
+                MetalQwen35State::new(&weights, &cfg, 4).expect("tiny MetalQwen35State fixture");
+            assert!(
+                state.engine.pipelines.gemm_q4_tiled.is_some(),
+                "gemm_q4_tiled must be enabled on Apple7+ (got None — gate regressed \
+                 or MSL_Q4_TILED_SOURCE failed to compile)"
+            );
         }
 
         // ── malformed-load validation tests ──────────────────────────────────


### PR DESCRIPTION
## What

The M>1 prefill GEMM — `gemm_q4_tiled`, a `simdgroup_float8x8`-tiled kernel (BM64/BN32/BK32, inline Q4 dequant) — was gated behind **Apple9 (M3+)**, silently disabling it on **every M1/M2** and falling back to the naive `gemm_q4` (no simdgroup matrix ops). `simdgroup_float8x8` has been available since **Apple7 (M1)**; the existing `.ok()?` compile/pipeline chain already falls back safely on any device where the Metal-3.0 source fails to compile, so the conservative Apple9 floor only cost throughput.

This lowers the gate to **Apple7** at both engine-init sites (`new()` and `from_q4_dir()`).

## Why it matters

This is the prefill lever. Phase attribution established prefill is **GEMM-bound** (~80% of prefill is pure GEMM — `out_mlp` ~50%, projections ~31%). With the tiled kernel disabled on M1/M2, that GEMM ran at ~17% of M2 Max f16 peak. Enabling it recovers a large fraction of that.

## Measured A/B (measure-first, ADR-058)

Apple **M2 Max** (reports Apple8, *not* Apple9 — so tiled was OFF on `main`), Q4 `qwen3.5-0.8b`, 512-token prefill via `bench_q4_prefill`, 3 runs each, idle GPU:

| Config | Prefill @512 | Throughput | std |
|---|---|---|---|
| naive (Apple9 gate = `main`) | 585.7 ms | 874 tok/s | 0.1 ms |
| tiled (Apple7 gate = this PR) | 361.4 ms | **1415 tok/s** | 0.1 ms |
| **speedup** | | **1.62×** | |

## Correctness (differential test)

`forward_prefill_all_logits`, 400 tokens, **tiled vs naive logits** on the same build:

- `max_abs_diff = 7.25e-5` (logit range ±33 → ~2e-6 relative)
- **greedy argmax agreement = 100.00% (400/400)**
- Q4 PPL (wiki.test.raw, 1211 windows): **17.034**, unchanged within FP reduction-order noise

The difference is pure FP reduction order. Greedy tokens are identical, so `e2e-parity` (lattice greedy vs HF) is preserved — and it now exercises the tiled path on the Apple-Silicon CI runner for the first time. Full `metal_qwen35` test module: 77/77 pass (incl. golden logit snapshot).

## Regression guard

Adds a GPU-gated test (`gemm_q4_tiled_enabled_on_apple7_plus`) asserting the **real gate path** keeps the tiled pipeline live on Apple7+. Catches both an accidental gate revert (fails on an M1/M2 runner) and a silent `MSL_Q4_TILED_SOURCE` compile failure — both of which would silently fall back to the slow kernel with no visible error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)