### PR TITLE
test(inference): parameterize bench_q4_prefill seq_len for context-scaling characterization

### DIFF
--- a/crates/inference/examples/bench_q4_prefill.rs
+++ b/crates/inference/examples/bench_q4_prefill.rs
@@ -43,9 +43,14 @@ fn run() {
         .expect("from_q4_dir failed — MSL compile or weight load error");
     eprintln!("[bench] Model loaded in {:.1}s", t0.elapsed().as_secs_f64());
 
-    // 512 synthetic token IDs cycling through mid-vocabulary (stable, repeatable)
-    let prompt_ids: Vec<u32> = (0u32..512).map(|i| 100 + (i % 1000)).collect();
-    let seq_len = prompt_ids.len();
+    // Synthetic token IDs cycling through mid-vocabulary (stable, repeatable).
+    // Sequence length is configurable via LATTICE_SEQ_LEN (default 512) to
+    // characterize the prefill throughput curve across context lengths.
+    let seq_len: usize = std::env::var("LATTICE_SEQ_LEN")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(512);
+    let prompt_ids: Vec<u32> = (0u32..seq_len as u32).map(|i| 100 + (i % 1000)).collect();
 
     let n_warmup = 1usize;
     let n_measure = 3usize;


### PR DESCRIPTION
## What

Parameterizes `bench_q4_prefill` sequence length via `LATTICE_SEQ_LEN` (default 512, behavior unchanged when unset), so the prefill throughput curve can be characterized across context lengths. The project mandates multi-context reporting — single-context numbers mislead.

## Why

After #265 (tiled simdgroup Q4 GEMM, 1.62× prefill), I needed to see how the win holds across context lengths to decide the next prefill lever. The curve is the evidence.

## Measured curve (post-#265, M2 Max Q4 qwen3.5-0.8b, idle GPU, std <1.5ms)

| ctx | tok/s | ms |
|-----|-------|-----|
| 128 | 1097 | 116.7 |
| 512 | **1415** (peak) | 361.7 |
| 1024 | 1333 | 768.3 |
| 2048 | 1191 | 1719.9 |

Peak at 512; gentle -16% decline by 2048 as quadratic attention cost grows; the 128 dip is the fixed-overhead floor. Conclusion: the GEMM fix captured the bulk of the typical-context prefill opportunity; further prefill gains live at long context (attention/flash-attn), not the GEMM kernel or the linear GDN scan.

## Scope

Example/harness only — no library or kernel changes, no e2e-parity impact. CI build covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)