### PR TITLE
fix(inference): guard out-of-vocab token_id at forward entry points (#269)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -7293,6 +7293,13 @@ kernel void gdn_chunk_norm_silu_c32(
         /// **Unstable**: single-token forward step; kernel dispatch strategy evolving.
         ///
         /// Run a single token through the full model. Returns logits [vocab_size].
+        ///
+        /// # Panics
+        ///
+        /// Panics if `token_id >= vocab_size`. The check is O(1) and runs before any
+        /// GPU dispatch. The tokenizer-bounded generate path never triggers this; it
+        /// can only be reached by a library consumer calling the raw entry point with
+        /// an out-of-vocabulary id.
         pub fn forward_step(&mut self, token_id: u32, position: usize) -> Vec<f32> {
             self.forward_step_inner(token_id, position, false).logits
         }
@@ -7404,6 +7411,13 @@ kernel void gdn_chunk_norm_silu_c32(
         /// Prompts longer than max_prefill without active LoRA are processed in
         /// max_prefill-sized batched chunks; LoRA-active prompts remain on the
         /// per-token forward_step fallback.
+        ///
+        /// # Panics
+        ///
+        /// Panics if any `token_ids[i] >= vocab_size`. The check is O(seq_len) and
+        /// runs once at the entry point before any GPU work. The tokenizer-bounded
+        /// generate path never triggers this; it can only be reached by a library
+        /// consumer passing raw ids with an out-of-vocabulary value.
         pub fn forward_prefill(&mut self, token_ids: &[u32]) -> Vec<f32> {
             self.forward_prefill_impl(token_ids, false)
         }
@@ -7415,6 +7429,10 @@ kernel void gdn_chunk_norm_silu_c32(
         /// Used by perplexity evaluation. Allocates a per-call buffer of size
         /// `n * vocab_size * 4` bytes — for `vocab_size=248K` and `n=128` that's
         /// ~127MB. Callers should cap `n` accordingly (typical PPL window: 128).
+        ///
+        /// # Panics
+        ///
+        /// Panics if any `token_ids[i] >= vocab_size`. See [`forward_prefill`] for details.
         pub fn forward_prefill_all_logits(&mut self, token_ids: &[u32]) -> Vec<f32> {
             self.forward_prefill_impl(token_ids, true)
         }
@@ -7422,6 +7440,15 @@ kernel void gdn_chunk_norm_silu_c32(
         fn forward_prefill_impl(&mut self, token_ids: &[u32], all_positions: bool) -> Vec<f32> {
             let n = token_ids.len();
             let vocab = self.engine.config.vocab_size;
+            // Validate all ids once at the entry point (O(seq_len)) before any GPU work.
+            // Do NOT duplicate this inside the hot embedding loop; the inner chunk code
+            // relies on this pre-scan and omits the per-token guard.
+            for (t, &id) in token_ids.iter().enumerate() {
+                assert!(
+                    (id as usize) < vocab,
+                    "forward_prefill: token_ids[{t}]={id} out of range: vocab_size is {vocab}",
+                );
+            }
             if n == 0 {
                 return if all_positions {
                     vec![]
@@ -7516,16 +7543,11 @@ kernel void gdn_chunk_norm_silu_c32(
 
             // Batch embedding: f16 → f32 for all N tokens
             // SAFETY: embed_tokens is StorageModeShared f16, no GPU in flight;
-            // each id is validated < vocab_size before computing the offset.
+            // all ids validated < vocab_size at the forward_prefill_impl entry point.
             unsafe {
                 let src_base = self.engine.embed_tokens.contents() as *const u16;
                 let dst_base = self.session.activations.hidden.contents() as *mut f32;
                 for (t, &id) in token_ids.iter().enumerate() {
-                    assert!(
-                        (id as usize) < cfg.vocab_size,
-                        "forward_prefill: token_ids[{t}]={id} >= vocab_size {}",
-                        cfg.vocab_size
-                    );
                     let src = src_base.add(id as usize * hidden);
                     let dst = dst_base.add(t * hidden);
                     // SAFETY: embed_tokens row has hidden u16 values; dst row has hidden f32 values.

--- a/crates/inference/src/model/qwen35/forward.rs
+++ b/crates/inference/src/model/qwen35/forward.rs
@@ -13,6 +13,12 @@ use crate::forward::cpu::{elementwise_mul, matmul_bt, silu_inplace};
 
 impl Qwen35Model {
     /// Single-token forward pass. Writes logits into scratch.logits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `token_id >= vocab_size`. The tokenizer-bounded generate path
+    /// never triggers this; it can only be reached by a library consumer calling
+    /// the raw entry point with an out-of-vocabulary id.
     pub(crate) fn forward_step(
         &self,
         token_id: u32,
@@ -23,6 +29,12 @@ impl Qwen35Model {
     ) {
         let cfg = &self.config;
         let hidden = cfg.hidden_size;
+
+        assert!(
+            (token_id as usize) < cfg.vocab_size,
+            "token_id {token_id} out of range: vocab_size is {}",
+            cfg.vocab_size,
+        );
 
         scratch.ensure_capacity(cfg, kv_cache.seq_len + 1);
 

--- a/crates/inference/src/model/qwen35/tests.rs
+++ b/crates/inference/src/model/qwen35/tests.rs
@@ -685,6 +685,71 @@ mod lora_serving {
         );
     }
 
+    // ---------------------------------------------------------------------------
+    // Out-of-vocabulary token_id guard tests (issue #269)
+    // ---------------------------------------------------------------------------
+
+    /// CPU path: a token_id exactly at vocab_size (one past the last valid id)
+    /// must panic with a message that names the offending id and the vocab size.
+    /// "vocab_size is" is our contract — the cryptic slice panic says nothing like that.
+    #[test]
+    #[should_panic(expected = "vocab_size is")]
+    fn cpu_forward_step_rejects_token_at_vocab_size() {
+        let cfg = test_config();
+        let model = build_model(cfg.clone(), 0x1234);
+        let (mut gdn, mut kv, mut scratch) = fresh_state(&cfg);
+        // vocab_size is 97; id 97 is one past the end.
+        model.forward_step(cfg.vocab_size as u32, 0, &mut gdn, &mut kv, &mut scratch);
+    }
+
+    /// CPU path: u32::MAX must also panic with the same clear message.
+    #[test]
+    #[should_panic(expected = "vocab_size is")]
+    fn cpu_forward_step_rejects_max_u32() {
+        let cfg = test_config();
+        let model = build_model(cfg.clone(), 0x1234);
+        let (mut gdn, mut kv, mut scratch) = fresh_state(&cfg);
+        model.forward_step(u32::MAX, 0, &mut gdn, &mut kv, &mut scratch);
+    }
+
+    /// CPU path: the last valid id (vocab_size − 1) must NOT panic.
+    #[test]
+    fn cpu_forward_step_accepts_last_valid_token() {
+        let cfg = test_config();
+        let model = build_model(cfg.clone(), 0x1234);
+        let (mut gdn, mut kv, mut scratch) = fresh_state(&cfg);
+        // token 96 = vocab_size − 1 = eos_token_id. Must not panic.
+        model.forward_step(
+            cfg.vocab_size as u32 - 1,
+            0,
+            &mut gdn,
+            &mut kv,
+            &mut scratch,
+        );
+        // Logits buffer was written — at least some are finite.
+        assert!(
+            scratch.logits[..cfg.vocab_size]
+                .iter()
+                .all(|v| v.is_finite()),
+            "logits must be finite for a valid token"
+        );
+    }
+
+    /// CPU path: token 0 (always valid) produces finite logits.
+    #[test]
+    fn cpu_forward_step_accepts_token_zero() {
+        let cfg = test_config();
+        let model = build_model(cfg.clone(), 0x5678);
+        let (mut gdn, mut kv, mut scratch) = fresh_state(&cfg);
+        model.forward_step(0, 0, &mut gdn, &mut kv, &mut scratch);
+        assert!(
+            scratch.logits[..cfg.vocab_size]
+                .iter()
+                .all(|v| v.is_finite()),
+            "logits must be finite for token 0"
+        );
+    }
+
     #[test]
     fn generate_max_new_tokens_zero_returns_empty() {
         // Contract: max_new_tokens == 0 means "generate nothing". The non-streaming


### PR DESCRIPTION
## Summary

- **CPU `Qwen35Model::forward_step`**: adds an explicit `assert!` with message `"token_id {id} out of range: vocab_size is {v}"` at the top of the function, before the embedding index is computed. Previously emitted a cryptic `"range end index N out of range for slice of length M"` panic.
- **Metal `MetalQwen35State::forward_step`**: the check already existed in `forward_step_inner_impl` (O(1), before any GPU dispatch). Added `# Panics` doc-comment to the public entry point to document the contract.
- **Metal `MetalQwen35State::forward_prefill`** (and `forward_prefill_all_logits`): added an O(seq_len) pre-scan in `forward_prefill_impl` (the shared impl both public functions delegate to) before any GPU work. Removed the previous per-token `assert!` that lived inside the hot embedding loop in `forward_prefill_batched_chunk` (redundant after the entry-point guard; violated the no-per-token-hot-loop-check invariant).

## Return-type decisions

| Entry point | Returns | Decision |
|---|---|---|
| `Qwen35Model::forward_step` | `()` | documented `assert!` panic — cannot add `Result` without a breaking `pub(crate)` signature change |
| `MetalQwen35State::forward_step` | `Vec<f32>` | documented panic (guard was already present in `forward_step_inner_impl`; added `# Panics` doc) |
| `MetalQwen35State::forward_prefill` | `Vec<f32>` | documented panic — same rationale; O(seq_len) guard added at entry point |

All three match the deliberate documented-panic posture established in issue #227.

## Robustness only — no perf change

The guards run at entry (O(1) for the single-token path, O(seq_len) for prefill) and are not on the per-token hot path. The tokenizer-bounded generate path never reaches them; they are only reachable by a library consumer passing raw ids directly. No algorithm change; no behaviour change for valid inputs; bench-compare not required per CLAUDE.md ("robustness-only").

## Test plan

- [x] TDD red phase verified: old tests for `cpu_forward_step_rejects_token_at_vocab_size` and `cpu_forward_step_rejects_max_u32` failed before the fix (panic message `"range end index ... out of range for slice"` did not contain `"vocab_size is"`)
- [x] TDD green phase: all 4 new tests pass after the fix
- [x] 3 pre-existing `lora_serving` tests still pass (no regression)
- [x] `cargo clippy -p lattice-inference --features f16 -- -D warnings`: clean
- [x] `cargo build -p lattice-inference --features f16`: clean (non-Metal build)
- [x] Pre-commit hook (fmt + clippy + doc lint + build): passed

```
running 7 tests
test model::qwen35::tests::lora_serving::generate_max_new_tokens_zero_returns_empty ... ok
test model::qwen35::tests::lora_serving::cpu_forward_step_rejects_max_u32 - should panic ... ok
test model::qwen35::tests::lora_serving::cpu_forward_step_rejects_token_at_vocab_size - should panic ... ok
test model::qwen35::tests::lora_serving::cpu_forward_step_accepts_token_zero ... ok
test model::qwen35::tests::lora_serving::cpu_forward_step_accepts_last_valid_token ... ok
test model::qwen35::tests::lora_serving::lora_hook_invoked_at_every_adapted_projection ... ok
test model::qwen35::tests::lora_serving::lora_adapter_changes_logits_deterministically ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 945 filtered out; finished in 0.01s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)