### PR TITLE
feat(inference): env-gated per-kernel GPU time attribution for decode step (#241)

### DIFF
--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -137,6 +137,10 @@ required-features = ["f16", "metal-gpu"]
 name = "bench_concurrent"
 required-features = ["f16", "metal-gpu"]
 
+[[example]]
+name = "decode_profile"
+required-features = ["f16", "metal-gpu"]
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 approx = "0.5"

--- a/crates/inference/examples/decode_profile.rs
+++ b/crates/inference/examples/decode_profile.rs
@@ -1,0 +1,145 @@
+/// Per-kernel GPU time attribution for a single Metal decode step on Qwen3.5-0.8B.
+///
+/// Sets `LATTICE_DECODE_PROFILE=1` and runs `n_steps` decode steps. For each step
+/// the library prints a `[DECODE_PROFILE]` table to stderr with true GPU execution
+/// time (commit+wait) per kernel group: gdn_layer, gqa_layer, lm_head.
+///
+/// Model format is auto-detected from the directory: `.q4` files → Q4 weights,
+/// `model.safetensors` → f16 weights.
+///
+/// Usage (f16):
+///   LATTICE_MODEL_DIR=/Users/lion/.lattice/models/qwen3.5-0.8b \
+///   cargo run --release --example decode_profile -p lattice-inference --features "f16,metal-gpu"
+///
+/// Usage (Q4):
+///   LATTICE_MODEL_DIR=/Users/lion/.lattice/models/qwen3.5-0.8b-q4 \
+///   cargo run --release --example decode_profile -p lattice-inference --features "f16,metal-gpu"
+fn main() {
+    #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+    {
+        eprintln!("decode_profile requires macOS + metal-gpu feature.");
+        std::process::exit(1);
+    }
+
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    run();
+}
+
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+fn run() {
+    use lattice_inference::forward::metal_qwen35::MetalQwen35State;
+    use lattice_inference::model::qwen35::Qwen35Model;
+    use lattice_inference::model::qwen35_config::Qwen35Config;
+    use std::time::Instant;
+
+    // Activate per-group GPU timing in forward_step_inner_impl.
+    // SAFETY: single-threaded example binary; no races.
+    unsafe { std::env::set_var("LATTICE_DECODE_PROFILE", "1") };
+
+    let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
+        .expect("set LATTICE_MODEL_DIR to the model directory (f16 or Q4)");
+    let dir = std::path::Path::new(&model_dir_str);
+
+    let is_q4 = dir
+        .read_dir()
+        .map(|mut entries| {
+            entries.any(|e| {
+                e.map(|e| e.path().extension().map(|x| x == "q4").unwrap_or(false))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false);
+
+    eprintln!(
+        "[decode_profile] Loading {} model from {} ...",
+        if is_q4 { "Q4" } else { "f16" },
+        dir.display()
+    );
+
+    let t_load = Instant::now();
+    let mut state: MetalQwen35State = if is_q4 {
+        let cfg = if dir.join("config.json").exists() {
+            Qwen35Config::from_config_json(&dir.join("config.json")).expect("parse config.json")
+        } else {
+            Qwen35Config::qwen35_0_8b()
+        };
+        let tokenizer_path = dir.join("tokenizer.json");
+        MetalQwen35State::from_q4_dir(dir, &tokenizer_path, &cfg, 512)
+            .expect("from_q4_dir failed — MSL compile or weight load error")
+    } else {
+        let model = Qwen35Model::from_safetensors(dir).expect("from_safetensors failed");
+        MetalQwen35State::new(model.weights(), model.config(), 512)
+            .expect("MetalQwen35State::new failed")
+    };
+    eprintln!(
+        "[decode_profile] Model loaded in {:.1}s",
+        t_load.elapsed().as_secs_f64()
+    );
+
+    // Prefill with a ~256-token prompt using cycling IDs 100..356.
+    let prefill_len = 256usize;
+    let prompt_ids: Vec<u32> = (0u32..prefill_len as u32)
+        .map(|i| 100 + (i % 256))
+        .collect();
+
+    eprintln!("[decode_profile] Warmup prefill ({prefill_len} tokens)...");
+    state.reset_state();
+    let prefill_logits = state.forward_prefill(&prompt_ids);
+    let first_argmax = argmax_f32(&prefill_logits);
+    eprintln!("[decode_profile] Prefill complete. greedy first token = {first_argmax}");
+
+    // Warmup decode: 3 steps (not timed, LATTICE_DECODE_PROFILE already set).
+    for i in 0..3usize {
+        let _ = state.forward_step(200 + i as u32, prefill_len + i);
+    }
+
+    let n_steps = 10usize;
+    eprintln!();
+    eprintln!("[decode_profile] Running {n_steps} profiled decode steps.");
+    eprintln!("[decode_profile] Attribution tables follow (one per step):");
+    eprintln!();
+
+    let mut step_wall_us: Vec<u128> = Vec::with_capacity(n_steps);
+
+    for i in 0..n_steps {
+        let pos = prefill_len + 3 + i;
+        let t = Instant::now();
+        let logits = state.forward_step(200 + i as u32, pos);
+        let wall_us = t.elapsed().as_micros();
+        step_wall_us.push(wall_us);
+        // Suppress "value unused" without touching logits contents.
+        let _ = logits.len();
+        eprintln!();
+    }
+
+    let total_wall_us: u128 = step_wall_us.iter().sum();
+    let mean_wall_us = total_wall_us as f64 / n_steps as f64;
+    let min_wall_us = *step_wall_us.iter().min().unwrap_or(&0) as f64;
+    let max_wall_us = *step_wall_us.iter().max().unwrap_or(&0) as f64;
+
+    eprintln!("[decode_profile] === Wall-time summary ({n_steps} steps) ===");
+    eprintln!(
+        "  mean: {mean_wall_us:.0} µs  ({:.1} tok/s under profiling)",
+        1_000_000.0 / mean_wall_us
+    );
+    eprintln!("  min:  {min_wall_us:.0} µs");
+    eprintln!("  max:  {max_wall_us:.0} µs");
+    eprintln!();
+    eprintln!("  NOTE: throughput above is lower than fused-path throughput because");
+    eprintln!("  LATTICE_DECODE_PROFILE serializes GPU pipelining via per-group commit/wait.");
+    eprintln!("  Refer to the [DECODE_PROFILE] tables above for per-group breakdown.");
+    eprintln!();
+    eprintln!("[decode_profile] OFF-path sanity: greedy first token from prefill = {first_argmax}");
+    eprintln!(
+        "  (re-run without LATTICE_DECODE_PROFILE to confirm the same argmax via the fused path)"
+    );
+}
+
+fn argmax_f32(logits: &[f32]) -> usize {
+    logits
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(i, _)| i)
+        .unwrap_or(0)
+}

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -5398,6 +5398,10 @@ kernel void gdn_chunk_norm_silu_c32(
         gpu_gdn_us: u128,
         gpu_gqa_us: u128,
         gpu_lm_head_us: u128,
+        // 4-category de-confounded fields: separates shared MLP from layer-specific mixer/attn.
+        gpu_gdn_mixer_us: u128,
+        gpu_gqa_attn_us: u128,
+        gpu_mlp_us: u128,
     }
 
     impl MetalQwen35State {
@@ -7182,6 +7186,7 @@ kernel void gdn_chunk_norm_silu_c32(
                     };
                     let layer_enc = layer_cmd.new_compute_command_encoder();
                     if is_linear {
+                        // Mixer-only (no MLP): measures pure GDN recurrence cost.
                         gdn_gpu_dispatches += self.encode_gdn_layer(
                             layer_enc,
                             compact_idx,
@@ -7191,14 +7196,35 @@ kernel void gdn_chunk_norm_silu_c32(
                             &cfg,
                             &mut prof,
                             profiling,
+                            false,
                         );
                         linear_idx += 1;
                         layer_enc.end_encoding();
-                        let t_gpu = std::time::Instant::now();
+                        let t_mixer = std::time::Instant::now();
                         layer_cmd.commit();
                         layer_cmd.wait_until_completed();
-                        prof.gpu_gdn_us += t_gpu.elapsed().as_micros();
+                        prof.gpu_gdn_mixer_us += t_mixer.elapsed().as_micros();
+                        // MLP-only command buffer for this GDN layer.
+                        let mlp_cmd = unsafe {
+                            &*(self.engine.queue.new_command_buffer()
+                                as *const metal::CommandBufferRef)
+                        };
+                        let mlp_enc = mlp_cmd.new_compute_command_encoder();
+                        self.encode_mlp_block(
+                            mlp_enc,
+                            compact_idx,
+                            layer_i,
+                            &cfg,
+                            &mut prof,
+                            false,
+                        );
+                        mlp_enc.end_encoding();
+                        let t_mlp = std::time::Instant::now();
+                        mlp_cmd.commit();
+                        mlp_cmd.wait_until_completed();
+                        prof.gpu_mlp_us += t_mlp.elapsed().as_micros();
                     } else {
+                        // Attn-only (no MLP): measures pure GQA attention cost.
                         self.encode_gqa_layer(
                             layer_enc,
                             compact_idx,
@@ -7209,14 +7235,37 @@ kernel void gdn_chunk_norm_silu_c32(
                             &cfg,
                             &mut prof,
                             profiling,
+                            false,
                         );
                         full_idx += 1;
                         layer_enc.end_encoding();
-                        let t_gpu = std::time::Instant::now();
+                        let t_attn = std::time::Instant::now();
                         layer_cmd.commit();
                         layer_cmd.wait_until_completed();
-                        prof.gpu_gqa_us += t_gpu.elapsed().as_micros();
+                        prof.gpu_gqa_attn_us += t_attn.elapsed().as_micros();
+                        // MLP-only command buffer for this GQA layer.
+                        let mlp_cmd = unsafe {
+                            &*(self.engine.queue.new_command_buffer()
+                                as *const metal::CommandBufferRef)
+                        };
+                        let mlp_enc = mlp_cmd.new_compute_command_encoder();
+                        self.encode_mlp_block(
+                            mlp_enc,
+                            compact_idx,
+                            layer_i,
+                            &cfg,
+                            &mut prof,
+                            false,
+                        );
+                        mlp_enc.end_encoding();
+                        let t_mlp = std::time::Instant::now();
+                        mlp_cmd.commit();
+                        mlp_cmd.wait_until_completed();
+                        prof.gpu_mlp_us += t_mlp.elapsed().as_micros();
                     }
+                    // Keep legacy aggregates for backward compat with existing tooling.
+                    prof.gpu_gdn_us = prof.gpu_gdn_mixer_us;
+                    prof.gpu_gqa_us = prof.gpu_gqa_attn_us;
                 }
 
                 let head_cmd = unsafe {
@@ -7231,7 +7280,10 @@ kernel void gdn_chunk_norm_silu_c32(
                 head_cmd.wait_until_completed();
                 prof.gpu_lm_head_us += t_gpu.elapsed().as_micros();
 
-                let total_gpu_us = prof.gpu_gdn_us + prof.gpu_gqa_us + prof.gpu_lm_head_us;
+                let total_gpu_us = prof.gpu_gdn_mixer_us
+                    + prof.gpu_gqa_attn_us
+                    + prof.gpu_mlp_us
+                    + prof.gpu_lm_head_us;
                 let pct = |v: u128| -> f64 {
                     if total_gpu_us == 0 {
                         0.0
@@ -7241,23 +7293,27 @@ kernel void gdn_chunk_norm_silu_c32(
                 };
                 eprintln!("[DECODE_PROFILE] step {position}: total_gpu_us={total_gpu_us}");
                 eprintln!(
-                    "  gdn_layer:   {:>8} µs  ({:5.1}%)  [18 GDN layers: norm+in_proj+conv1d+recurrence+out_proj+mlp]",
-                    prof.gpu_gdn_us,
-                    pct(prof.gpu_gdn_us)
+                    "  gdn_mixer:   {:>8} µs  ({:5.1}%)  [18 GDN layers: norm+in_proj+conv1d+recurrence+out_proj (no MLP)]",
+                    prof.gpu_gdn_mixer_us,
+                    pct(prof.gpu_gdn_mixer_us)
                 );
                 eprintln!(
-                    "  gqa_layer:   {:>8} µs  ({:5.1}%)  [6 GQA layers: norm+qkv_proj+attention+o_proj+mlp]",
-                    prof.gpu_gqa_us,
-                    pct(prof.gpu_gqa_us)
+                    "  gqa_attn:    {:>8} µs  ({:5.1}%)  [6 GQA layers: norm+qkv_proj+attention+o_proj (no MLP)]",
+                    prof.gpu_gqa_attn_us,
+                    pct(prof.gpu_gqa_attn_us)
+                );
+                eprintln!(
+                    "  mlp:         {:>8} µs  ({:5.1}%)  [all 24 layers: post_attn_norm+gate_up_proj+silu_mul+down_proj]",
+                    prof.gpu_mlp_us,
+                    pct(prof.gpu_mlp_us)
                 );
                 eprintln!(
                     "  lm_head:     {:>8} µs  ({:5.1}%)  [final norm + lm_head GEMV]",
                     prof.gpu_lm_head_us,
                     pct(prof.gpu_lm_head_us)
                 );
-                eprintln!("  unaccounted: {:>8} µs  ({:5.1}%)", 0u128, 0.0f64);
                 eprintln!(
-                    "  NOTE: GPU time under serialized per-group command buffers; absolute throughput is lower than the fused path because per-group commit/wait disables cross-kernel GPU pipelining."
+                    "  NOTE: GPU time under serialized per-group command buffers (2 cmd bufs/layer + 1 for lm_head). Absolute throughput is lower than the fused path."
                 );
 
                 debug_assert_eq!(
@@ -7350,6 +7406,7 @@ kernel void gdn_chunk_norm_silu_c32(
                         &cfg,
                         &mut prof,
                         profiling,
+                        true,
                     );
                     linear_idx += 1;
                 } else {
@@ -7363,6 +7420,7 @@ kernel void gdn_chunk_norm_silu_c32(
                         &cfg,
                         &mut prof,
                         profiling,
+                        true,
                     );
                     full_idx += 1;
                 }
@@ -7552,6 +7610,7 @@ kernel void gdn_chunk_norm_silu_c32(
                         &cfg,
                         &mut prof,
                         false,
+                        true,
                     );
                     linear_idx += 1;
                 }
@@ -9996,6 +10055,123 @@ kernel void gdn_chunk_norm_silu_c32(
         // Layer-encoding helpers (called from forward_step_inner)
         // ===================================================================
 
+        /// Encode the MLP tail shared by every layer (both GDN and GQA).
+        ///
+        /// Dispatches: fused residual-add-norm → gate_up_proj GEMV → LoRA(gate/up) →
+        /// silu_mul → down_proj GEMV → LoRA(down) → residual-add-copy.
+        ///
+        /// Pure extraction from `encode_gdn_layer` / `encode_gqa_layer`; the fused
+        /// path is byte-for-byte identical to inlining.
+        ///
+        /// # Preconditions
+        /// - `self.session.activations.residual` holds the post-attention residual.
+        /// - `self.session.activations.attn_out` holds the attention output.
+        /// - `self.session.activations.hidden` is scratch space.
+        ///
+        /// # Postconditions
+        /// - `self.session.activations.residual` and `.hidden` hold the post-FFN state.
+        fn encode_mlp_block(
+            &mut self,
+            enc: &ComputeCommandEncoderRef,
+            compact_idx: usize,
+            layer_idx: usize,
+            cfg: &Qwen35Config,
+            prof: &mut StepProfile,
+            profiling: bool,
+        ) {
+            let hidden = cfg.hidden_size;
+            let inter = cfg.intermediate_size;
+            let (_, common_w) = &self.engine.layer_weights[compact_idx];
+            let mlp_t0 = profiling.then(std::time::Instant::now);
+            self.dispatch_fused_residual_add_norm(
+                enc,
+                &self.session.activations.residual,
+                &self.session.activations.attn_out,
+                &self.session.activations.residual,
+                &self.session.activations.hidden,
+                &common_w.post_attention_layernorm,
+                hidden as u32,
+                cfg.rms_norm_eps,
+            );
+            // SAFETY: FFN weight buffers are live for the command buffer lifetime.
+            match &common_w.ffn {
+                MetalFfnWeights::Dense {
+                    gate_up_proj,
+                    down_proj,
+                } => {
+                    let w_gate_up = gate_up_proj as *const Q4WeightBuf;
+                    let w_down = down_proj as *const Q4WeightBuf;
+                    unsafe {
+                        self.dispatch_matmul(
+                            enc,
+                            &self.session.activations.hidden,
+                            &*w_gate_up,
+                            &self.session.activations.gate,
+                            1,
+                            (2 * inter) as u32,
+                            hidden as u32,
+                        );
+                    }
+                    self.dispatch_lora_if_active(
+                        enc,
+                        &self.session.activations.hidden,
+                        0,
+                        &self.session.activations.gate,
+                        0,
+                        layer_idx,
+                        "gate_proj",
+                    );
+                    self.dispatch_lora_if_active(
+                        enc,
+                        &self.session.activations.hidden,
+                        0,
+                        &self.session.activations.gate,
+                        (inter * std::mem::size_of::<f32>()) as u64,
+                        layer_idx,
+                        "up_proj",
+                    );
+                    self.dispatch_silu_mul_fused(enc, &self.session.activations.gate, inter as u32);
+                    unsafe {
+                        self.dispatch_matmul(
+                            enc,
+                            &self.session.activations.gate,
+                            &*w_down,
+                            &self.session.activations.ffn_out,
+                            1,
+                            hidden as u32,
+                            inter as u32,
+                        );
+                    }
+                    self.dispatch_lora_if_active(
+                        enc,
+                        &self.session.activations.gate,
+                        0,
+                        &self.session.activations.ffn_out,
+                        0,
+                        layer_idx,
+                        "down_proj",
+                    );
+                }
+                MetalFfnWeights::Moe(moe_bufs) => {
+                    let moe_ptr = moe_bufs.as_ref() as *const MoeMetalBuffers;
+                    // SAFETY: moe_bufs is owned by layer_weights which is live.
+                    unsafe {
+                        self.encode_moe_ffn(enc, &*moe_ptr, cfg);
+                    }
+                }
+            }
+            self.dispatch_add_and_copy(
+                enc,
+                &self.session.activations.ffn_out,
+                &self.session.activations.residual,
+                &self.session.activations.hidden,
+                hidden as u32,
+            );
+            if let Some(t0) = mlp_t0 {
+                prof.mlp_us += t0.elapsed().as_micros();
+            }
+        }
+
         /// Encode all Metal commands for a single GDN (linear-attention) layer.
         ///
         /// All commands are appended to the already-open encoder `enc`; no new
@@ -10011,9 +10187,9 @@ kernel void gdn_chunk_norm_silu_c32(
             cfg: &Qwen35Config,
             prof: &mut StepProfile,
             profiling: bool,
+            with_mlp: bool,
         ) -> usize {
             let hidden = cfg.hidden_size;
-            let inter = cfg.intermediate_size;
             let (
                 w_in_proj_qkvz,
                 w_in_proj_b,
@@ -10284,100 +10460,8 @@ kernel void gdn_chunk_norm_silu_c32(
                 "out_proj",
             );
 
-            // MLP: fused residual+add+norm replaces 4 dispatches with 1
-            // residual = residual + attn_out; hidden = norm(residual)
-            let mlp_t0 = profiling.then(std::time::Instant::now);
-            self.dispatch_fused_residual_add_norm(
-                enc,
-                &self.session.activations.residual,
-                &self.session.activations.attn_out,
-                &self.session.activations.residual,
-                &self.session.activations.hidden,
-                &common_w.post_attention_layernorm,
-                hidden as u32,
-                cfg.rms_norm_eps,
-            );
-            // Dispatch FFN (Dense SwiGLU or MoE).
-            // SAFETY: FFN weight buffers are live for the command buffer lifetime.
-            match &common_w.ffn {
-                MetalFfnWeights::Dense {
-                    gate_up_proj,
-                    down_proj,
-                } => {
-                    let w_gate_up = gate_up_proj as *const Q4WeightBuf;
-                    let w_down = down_proj as *const Q4WeightBuf;
-                    // Single fused GEMV: hidden × gate_up_proj[2*inter, hidden] → gate[0..2*inter]
-                    unsafe {
-                        self.dispatch_matmul(
-                            enc,
-                            &self.session.activations.hidden,
-                            &*w_gate_up,
-                            &self.session.activations.gate,
-                            1,
-                            (2 * inter) as u32,
-                            hidden as u32,
-                        );
-                    }
-                    // LoRA: gate half at offset 0, up half at offset inter*sizeof(f32)
-                    self.dispatch_lora_if_active(
-                        enc,
-                        &self.session.activations.hidden,
-                        0,
-                        &self.session.activations.gate,
-                        0,
-                        layer_idx,
-                        "gate_proj",
-                    );
-                    self.dispatch_lora_if_active(
-                        enc,
-                        &self.session.activations.hidden,
-                        0,
-                        &self.session.activations.gate,
-                        (inter * std::mem::size_of::<f32>()) as u64,
-                        layer_idx,
-                        "up_proj",
-                    );
-                    // silu_mul_fused: gate[0..inter] = silu(gate[0..inter]) * gate[inter..2*inter]
-                    self.dispatch_silu_mul_fused(enc, &self.session.activations.gate, inter as u32);
-                    unsafe {
-                        self.dispatch_matmul(
-                            enc,
-                            &self.session.activations.gate,
-                            &*w_down,
-                            &self.session.activations.ffn_out,
-                            1,
-                            hidden as u32,
-                            inter as u32,
-                        );
-                    }
-                    self.dispatch_lora_if_active(
-                        enc,
-                        &self.session.activations.gate,
-                        0,
-                        &self.session.activations.ffn_out,
-                        0,
-                        layer_idx,
-                        "down_proj",
-                    );
-                }
-                MetalFfnWeights::Moe(moe_bufs) => {
-                    let moe_ptr = moe_bufs.as_ref() as *const MoeMetalBuffers;
-                    // SAFETY: moe_bufs is owned by layer_weights which is live.
-                    unsafe {
-                        self.encode_moe_ffn(enc, &*moe_ptr, cfg);
-                    }
-                }
-            }
-            // End of layer: residual += ffn_out, hidden = residual (fused)
-            self.dispatch_add_and_copy(
-                enc,
-                &self.session.activations.ffn_out,
-                &self.session.activations.residual,
-                &self.session.activations.hidden,
-                hidden as u32,
-            );
-            if let Some(t0) = mlp_t0 {
-                prof.mlp_us += t0.elapsed().as_micros();
+            if with_mlp {
+                self.encode_mlp_block(enc, compact_idx, layer_idx, cfg, prof, profiling);
             }
 
             1 // one GDN GPU dispatch per layer
@@ -10399,9 +10483,9 @@ kernel void gdn_chunk_norm_silu_c32(
             cfg: &Qwen35Config,
             prof: &mut StepProfile,
             profiling: bool,
+            with_mlp: bool,
         ) {
             let hidden = cfg.hidden_size;
-            let inter = cfg.intermediate_size;
             // GQA: SINGLE command buffer — pre-norm + projections + KV copy + attention + MLP
             let (w_q_proj, w_k_proj, w_v_proj, w_o_proj, w_q_norm, w_k_norm) = {
                 let MetalLayerAttnWeights::Full(full_w) = &self.engine.layer_weights[compact_idx].0
@@ -10614,99 +10698,8 @@ kernel void gdn_chunk_norm_silu_c32(
                 prof.projection_us += t0.elapsed().as_micros();
             }
 
-            // MLP: fused residual+add+norm replaces 4 dispatches with 1
-            let gqa_mlp_t0 = profiling.then(std::time::Instant::now);
-            self.dispatch_fused_residual_add_norm(
-                enc,
-                &self.session.activations.residual,
-                &self.session.activations.attn_out,
-                &self.session.activations.residual,
-                &self.session.activations.hidden,
-                &common_w.post_attention_layernorm,
-                hidden as u32,
-                cfg.rms_norm_eps,
-            );
-            // Dispatch FFN (Dense SwiGLU or MoE).
-            // SAFETY: FFN weight buffers are live for the command buffer lifetime.
-            match &common_w.ffn {
-                MetalFfnWeights::Dense {
-                    gate_up_proj,
-                    down_proj,
-                } => {
-                    let w_gate_up = gate_up_proj as *const Q4WeightBuf;
-                    let w_down = down_proj as *const Q4WeightBuf;
-                    // Single fused GEMV: hidden × gate_up_proj[2*inter, hidden] → gate[0..2*inter]
-                    unsafe {
-                        self.dispatch_matmul(
-                            enc,
-                            &self.session.activations.hidden,
-                            &*w_gate_up,
-                            &self.session.activations.gate,
-                            1,
-                            (2 * inter) as u32,
-                            hidden as u32,
-                        );
-                    }
-                    // LoRA: gate half at offset 0, up half at offset inter*sizeof(f32)
-                    self.dispatch_lora_if_active(
-                        enc,
-                        &self.session.activations.hidden,
-                        0,
-                        &self.session.activations.gate,
-                        0,
-                        layer_idx,
-                        "gate_proj",
-                    );
-                    self.dispatch_lora_if_active(
-                        enc,
-                        &self.session.activations.hidden,
-                        0,
-                        &self.session.activations.gate,
-                        (inter * std::mem::size_of::<f32>()) as u64,
-                        layer_idx,
-                        "up_proj",
-                    );
-                    // silu_mul_fused: gate[0..inter] = silu(gate[0..inter]) * gate[inter..2*inter]
-                    self.dispatch_silu_mul_fused(enc, &self.session.activations.gate, inter as u32);
-                    unsafe {
-                        self.dispatch_matmul(
-                            enc,
-                            &self.session.activations.gate,
-                            &*w_down,
-                            &self.session.activations.ffn_out,
-                            1,
-                            hidden as u32,
-                            inter as u32,
-                        );
-                    }
-                    self.dispatch_lora_if_active(
-                        enc,
-                        &self.session.activations.gate,
-                        0,
-                        &self.session.activations.ffn_out,
-                        0,
-                        layer_idx,
-                        "down_proj",
-                    );
-                }
-                MetalFfnWeights::Moe(moe_bufs) => {
-                    let moe_ptr = moe_bufs.as_ref() as *const MoeMetalBuffers;
-                    // SAFETY: moe_bufs is owned by layer_weights which is live.
-                    unsafe {
-                        self.encode_moe_ffn(enc, &*moe_ptr, cfg);
-                    }
-                }
-            }
-            // End of layer: residual += ffn_out, hidden = residual (fused)
-            self.dispatch_add_and_copy(
-                enc,
-                &self.session.activations.ffn_out,
-                &self.session.activations.residual,
-                &self.session.activations.hidden,
-                hidden as u32,
-            );
-            if let Some(t0) = gqa_mlp_t0 {
-                prof.mlp_us += t0.elapsed().as_micros();
+            if with_mlp {
+                self.encode_mlp_block(enc, compact_idx, layer_idx, cfg, prof, profiling);
             }
         }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -5392,6 +5392,12 @@ kernel void gdn_chunk_norm_silu_c32(
         gqa_attention_us: u128,
         mlp_us: u128,
         final_us: u128,
+        // GPU-time fields populated by LATTICE_DECODE_PROFILE per-group command-buffer split.
+        // True GPU execution time measured as Instant::now() around commit()+wait_until_completed()
+        // for serialized per-group command buffers. Zero when LATTICE_DECODE_PROFILE is not set.
+        gpu_gdn_us: u128,
+        gpu_gqa_us: u128,
+        gpu_lm_head_us: u128,
     }
 
     impl MetalQwen35State {
@@ -7112,6 +7118,7 @@ kernel void gdn_chunk_norm_silu_c32(
 
             // --- Per-phase timing (enabled by env LATTICE_PROFILE=1) ---
             let profiling = std::env::var_os("LATTICE_PROFILE").is_some();
+            let decode_profiling = std::env::var_os("LATTICE_DECODE_PROFILE").is_some();
 
             if std::env::var_os("LATTICE_GDN_CPU").is_some() {
                 #[cfg(not(debug_assertions))]
@@ -7151,6 +7158,169 @@ kernel void gdn_chunk_norm_silu_c32(
 
             let kv_dim = cfg.full_kv_dim();
 
+            if decode_profiling {
+                // Per-group command-buffer split path (LATTICE_DECODE_PROFILE=1).
+                // Each layer gets its own command buffer committed and waited before the next.
+                // GPU time = Instant::now() wraps commit()+wait_until_completed() per layer.
+                // This serializes cross-kernel GPU pipelining; absolute throughput is lower
+                // than the fused path.
+                for layer_i in 0..cfg.num_hidden_layers {
+                    if !cfg.is_layer_active(layer_i) {
+                        continue;
+                    }
+                    let compact_idx = active_layer_idx;
+                    active_layer_idx += 1;
+                    let is_linear = matches!(
+                        &self.engine.layer_weights[compact_idx].0,
+                        MetalLayerAttnWeights::Linear(_)
+                    );
+                    // SAFETY: same raw-pointer idiom as the fused path below.
+                    // cmd is ref-counted by Metal and outlives the queue borrow.
+                    // encode_* methods need &mut self but don't touch engine.queue.
+                    let layer_cmd = unsafe {
+                        &*(self.engine.queue.new_command_buffer() as *const metal::CommandBufferRef)
+                    };
+                    let layer_enc = layer_cmd.new_compute_command_encoder();
+                    if is_linear {
+                        gdn_gpu_dispatches += self.encode_gdn_layer(
+                            layer_enc,
+                            compact_idx,
+                            linear_idx,
+                            position,
+                            layer_i,
+                            &cfg,
+                            &mut prof,
+                            profiling,
+                        );
+                        linear_idx += 1;
+                        layer_enc.end_encoding();
+                        let t_gpu = std::time::Instant::now();
+                        layer_cmd.commit();
+                        layer_cmd.wait_until_completed();
+                        prof.gpu_gdn_us += t_gpu.elapsed().as_micros();
+                    } else {
+                        self.encode_gqa_layer(
+                            layer_enc,
+                            compact_idx,
+                            full_idx,
+                            position,
+                            kv_dim,
+                            layer_i,
+                            &cfg,
+                            &mut prof,
+                            profiling,
+                        );
+                        full_idx += 1;
+                        layer_enc.end_encoding();
+                        let t_gpu = std::time::Instant::now();
+                        layer_cmd.commit();
+                        layer_cmd.wait_until_completed();
+                        prof.gpu_gqa_us += t_gpu.elapsed().as_micros();
+                    }
+                }
+
+                let head_cmd = unsafe {
+                    &*(self.engine.queue.new_command_buffer() as *const metal::CommandBufferRef)
+                };
+                let head_enc = head_cmd.new_compute_command_encoder();
+                let topk_which_inner =
+                    self.encode_final_head(head_enc, &cfg, capture_hidden, &mut prof, profiling);
+                head_enc.end_encoding();
+                let t_gpu = std::time::Instant::now();
+                head_cmd.commit();
+                head_cmd.wait_until_completed();
+                prof.gpu_lm_head_us += t_gpu.elapsed().as_micros();
+
+                let total_gpu_us = prof.gpu_gdn_us + prof.gpu_gqa_us + prof.gpu_lm_head_us;
+                let pct = |v: u128| -> f64 {
+                    if total_gpu_us == 0 {
+                        0.0
+                    } else {
+                        v as f64 / total_gpu_us as f64 * 100.0
+                    }
+                };
+                eprintln!("[DECODE_PROFILE] step {position}: total_gpu_us={total_gpu_us}");
+                eprintln!(
+                    "  gdn_layer:   {:>8} µs  ({:5.1}%)  [18 GDN layers: norm+in_proj+conv1d+recurrence+out_proj+mlp]",
+                    prof.gpu_gdn_us,
+                    pct(prof.gpu_gdn_us)
+                );
+                eprintln!(
+                    "  gqa_layer:   {:>8} µs  ({:5.1}%)  [6 GQA layers: norm+qkv_proj+attention+o_proj+mlp]",
+                    prof.gpu_gqa_us,
+                    pct(prof.gpu_gqa_us)
+                );
+                eprintln!(
+                    "  lm_head:     {:>8} µs  ({:5.1}%)  [final norm + lm_head GEMV]",
+                    prof.gpu_lm_head_us,
+                    pct(prof.gpu_lm_head_us)
+                );
+                eprintln!("  unaccounted: {:>8} µs  ({:5.1}%)", 0u128, 0.0f64);
+                eprintln!(
+                    "  NOTE: GPU time under serialized per-group command buffers; absolute throughput is lower than the fused path because per-group commit/wait disables cross-kernel GPU pipelining."
+                );
+
+                debug_assert_eq!(
+                    gdn_gpu_dispatches, expected_gdn_dispatches,
+                    "GDN GPU recurrence dispatch count mismatch"
+                );
+
+                if profiling {
+                    let total_us = step_start.elapsed().as_micros();
+                    let accounted_us = prof.embedding_us
+                        + prof.projection_us
+                        + prof.gdn_recurrence_us
+                        + prof.gqa_attention_us
+                        + prof.mlp_us
+                        + prof.final_us;
+                    let other_us = total_us.saturating_sub(accounted_us);
+                    eprintln!(
+                        "[PROFILE] step {position}: total_us={total_us} \
+                         embedding_us={} projection_us={} gdn_recurrence_us={} \
+                         gqa_attention_us={} mlp_us={} final_us={} other_us={} \
+                         gdn_gpu_dispatches={} expected_gdn_dispatches={} gdn_cpu_dispatches={}",
+                        prof.embedding_us,
+                        prof.projection_us,
+                        prof.gdn_recurrence_us,
+                        prof.gqa_attention_us,
+                        prof.mlp_us,
+                        prof.final_us,
+                        other_us,
+                        gdn_gpu_dispatches,
+                        expected_gdn_dispatches,
+                        gdn_cpu_dispatches,
+                    );
+                }
+
+                // SAFETY: GPU completed (wait_until_completed called above for head_cmd).
+                let pre_final_hidden = if capture_hidden || self.session.mtp.is_some() {
+                    let h =
+                        unsafe { read_buffer(&self.session.activations.pre_final_hidden, hidden) };
+                    self.session.last_pre_final_hidden = h.clone();
+                    h
+                } else {
+                    Vec::new()
+                };
+
+                let logits = if skip_logits_readback {
+                    vec![]
+                } else if let Some(which) = topk_which_inner {
+                    let k = self.session.compact_topk;
+                    let candidates = unsafe { self.read_topk_candidates(which, k) };
+                    self.session.compact_result = candidates;
+                    vec![]
+                } else {
+                    unsafe { read_buffer(&self.session.activations.logits, cfg.vocab_size) }
+                };
+                self.session.kv_cache.seq_len += 1;
+
+                return MetalStepOutput {
+                    logits,
+                    pre_final_hidden,
+                };
+            }
+
+            // Fused single-command-buffer path (default, zero-cost when LATTICE_DECODE_PROFILE is off).
             // Single command buffer for ALL 24 layers — no intermediate waits.
             // Raw pointer breaks the borrow chain: cmd is ref-counted by Metal
             // and outlives the queue borrow. The encode_* methods need &mut self


### PR DESCRIPTION
## #241 — env-gated per-kernel GPU-time attribution for the decode step

Closes #241. Adds an `LATTICE_DECODE_PROFILE`-gated profiler that attributes single-token decode GPU time to its constituent kernels, so decode optimization targets the kernel that **actually** dominates rather than a layer-count artifact.

### What it does
- **Off by default, byte-for-byte identical fused path.** The profiling branch is a complete early-return guarded by `std::env::var_os("LATTICE_DECODE_PROFILE")`. With the env var unset, the decode path is unchanged (the only edit to the fused path is the additive `with_mlp=true` call-through). The greedy-token e2e-parity gate is the binding correctness check.
- **4-category de-confounded attribution.** Commit 2 extracts the shared SwiGLU MLP tail (`post_attn_norm + gate_up GEMV + LoRA + silu_mul + down GEMV + LoRA + residual-add`) out of both `encode_gdn_layer` and `encode_gqa_layer` into a pure `encode_mlp_block`. In the profiling branch the mixer/attn runs in one command buffer (`with_mlp=false`) and the MLP in a second, so the table separates:
  - `gdn_mixer` (18 layers: norm+in_proj+conv1d+recurrence+out_proj)
  - `gqa_attn` (6 layers: norm+qkv+attention+o_proj)
  - `mlp` (all 24 layers, shared)
  - `lm_head` (final norm + vocab GEMV)
- New example `crates/inference/examples/decode_profile.rs` (256-token prefill + 10 timed decode steps).

### Measurement (this session, M-series, qwen3.5-0.8b; 10 timed steps, steady-state)

| Category | f16 µs/step | f16 % | Q4 µs/step | Q4 % | layers | f16 µs/layer | Q4 µs/layer |
|---|---:|---:|---:|---:|---:|---:|---:|
| gdn_mixer | 6052 | 31.7% | 5091 | 33.3% | 18 | 336 | 283 |
| gqa_attn  | 4713 | 24.7% | 4366 | 28.6% | 6  | **786** | **728** |
| mlp (shared) | 6764 | 35.4% | 5369 | 35.1% | 24 | 282 | 224 |
| lm_head   | 1575 | 8.2% | 460 | 3.0% | 1 | 1575 | 460 |
| **total** | **19104** | | **15285** | | | | |

(Q4 step-256 cold-start outlier — 80.7% gdn_mixer — excluded; steady-state used.)

### Finding: phase-1 "GDN dominates (~50%)" was a double artifact — overturned
The earlier per-layer-type attribution bundled the shared MLP into both layer totals **and** was inflated by the 18-vs-6 layer count. De-confounded:

1. **No single dominant kernel.** Decode GPU splits ~3 ways: MLP ~35%, GDN mixer ~32%, GQA attn ~25–29%, lm_head 3–8%.
2. **Per-layer, GQA attention is the most expensive primitive** (~786µs f16 / 728µs Q4) — **2.3–2.6× the GDN mixer** (336/283µs). GDN's aggregate size is purely its 18-layer count; per layer it is the *cheapest* mixer.
3. **Largest aggregate category is the shared SwiGLU MLP** (~35%) — the same gate_up/down GEMVs the prefill GEMM line already targets, not the recurrence.
4. **Bandwidth signal:** Q4 cuts total decode GPU ~20% (19.1k→15.3k µs); lm_head drops 3.4× (1575→460µs). Consistent with decode being partially weight-bandwidth-bound (#241/#241-decode-finding) — the GEMV-heavy ops (lm_head, MLP) are bandwidth-bound.

**Implication for decode optimization:** there is no recurrence-specific silver bullet. A targeted GDN-scan rewrite addresses only ~32% and it is already the cheapest per-layer mixer. Decode wins come broadly from GEMV/MLP bandwidth across all 24 layers (dtype/kernel — the prefill lever generalized), and secondarily from GQA per-layer cost.

### Methodology caveat (stated in the table footer too)
Per-group `commit + wait_until_completed` serializes GPU pipelining, so absolute throughput under profiling is lower than the fused path (50.6 tok/s f16 / 63.7 tok/s Q4 under profiling). The **percentages and per-layer ranking** are the meaningful output — attribution under serialized execution. The headline effects (GQA 2.3–2.6× GDN per-layer; MLP ~35%) are large enough to be robust to serialization overhead.

### Verification
- **Adversarial review: approved** — A) fused-path MLP extraction byte-equivalent to prior inline blocks; B) all call sites updated, only profiling passes `with_mlp=false` with an immediate second MLP command buffer; C) `LATTICE_DECODE_PROFILE` early-return, non-profiling path unchanged; D) per-MLP command buffers use the existing raw-pointer borrow-breaking idiom, committed+waited before the borrow ends; E) legacy aggregates + 4-bucket total accounting consistent; F) no hot-path allocation/clone, clippy-risk clear.
- **Fused path byte-identity:** independently diff-confirmed (the `with_mlp=true` call-through appends the identical ordered dispatch sequence to the same encoder). No perf delta is possible on the fused path by construction; `make bench-compare` is therefore not the binding gate — **e2e-parity** (greedy token agreement vs HF) is.
- **edition note:** `unsafe { std::env::set_var(...) }` in the example is required (workspace is edition 2024, where `set_var` is `unsafe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
