### PR TITLE
fix(inference): speculative argmax first-wins to match greedy decode (#280)

### DIFF
--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -2117,6 +2117,17 @@ mod tests {
     }
 
     #[test]
+    fn argmax_skips_nan_and_never_panics() {
+        // NaN loses to finite values; among finite ties the first index wins.
+        // Matches sampling::argmax_f32_scalar and the engine greedy decode.
+        assert_eq!(argmax(&[f32::NAN, 1.0, 1.0]), 1);
+        assert_eq!(argmax(&[1.0, f32::NAN, 1.0]), 0);
+        // All-NaN and all-(-inf) fall back to index 0 — must never panic.
+        assert_eq!(argmax(&[f32::NAN, f32::NAN]), 0);
+        assert_eq!(argmax(&[f32::NEG_INFINITY, f32::NEG_INFINITY]), 0);
+    }
+
+    #[test]
     fn argmax_negative_values() {
         assert_eq!(argmax(&[-3.0, -1.0, -2.0]), 1);
     }

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -98,15 +98,22 @@ impl NgramSpeculator {
 ///
 /// Return the index of the maximum element in `logits`.
 ///
-/// When multiple elements share the maximum value, returns the last
-/// occurrence (Rust `max_by` semantics). Returns 0 on empty input.
+/// When multiple elements share the maximum value, returns the **first**
+/// occurrence. Speculative decoding must be token-identical to plain greedy, so
+/// this tie-break must match the engine greedy decode (`forward::metal_qwen35`),
+/// the `sampling` module, and `torch.argmax` — all of which are first-wins (#280).
+/// Non-finite (`NaN`) entries are skipped, matching `sampling::argmax_f32_scalar`.
+/// Returns 0 on empty input.
 pub fn argmax(logits: &[f32]) -> usize {
-    logits
-        .iter()
-        .enumerate()
-        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(i, _)| i)
-        .unwrap_or(0)
+    let mut best_idx = 0;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &v) in logits.iter().enumerate() {
+        if v > best_val {
+            best_val = v;
+            best_idx = i;
+        }
+    }
+    best_idx
 }
 
 // ---------------------------------------------------------------------------
@@ -2081,9 +2088,32 @@ mod tests {
     }
 
     #[test]
-    fn argmax_tie_last_wins() {
-        // Rust max_by returns the last element on tie.
-        assert_eq!(argmax(&[1.0, 1.0, 0.5]), 1);
+    fn argmax_tie_first_wins() {
+        // Greedy contract: speculation must be token-identical to plain greedy.
+        // The engine greedy decode (metal_qwen35), the sampling module, and
+        // torch.argmax all break ties toward the FIRST max index, so this helper
+        // must too (see #280).
+        assert_eq!(argmax(&[1.0, 1.0, 0.5]), 0);
+    }
+
+    #[test]
+    fn argmax_tie_matches_engine_first_wins() {
+        // Cross-check against the engine's first-wins loop on a tie-heavy vector:
+        // enabling speculation must not change the token on tied top logits.
+        let tie = [0.0_f32, 0.0, -1.0, 0.0];
+        let engine_first_wins = {
+            let mut best_id = 0usize;
+            let mut best_val = f32::NEG_INFINITY;
+            for (i, &v) in tie.iter().enumerate() {
+                if v > best_val {
+                    best_val = v;
+                    best_id = i;
+                }
+            }
+            best_id
+        };
+        assert_eq!(engine_first_wins, 0);
+        assert_eq!(argmax(&tie), engine_first_wins);
     }
 
     #[test]


### PR DESCRIPTION
Closes #280.

## Problem

`speculative::argmax` broke ties toward the **last** max index (`Rust max_by`), but every other greedy path breaks ties toward the **first**:
- engine greedy decode `forward::metal_qwen35.rs:7548-7553` (`if v > best_val`)
- `sampling::argmax_f32_scalar` (`sampling.rs:372`) and `argmax_f32_neon` (`:415`, explicit `lane_idx < best_idx`)
- `torch.argmax` (the HF reference the `e2e-parity` gate compares against)

Speculative decoding is documented as a **pure speedup — token-identical to plain greedy**. A tied top logit therefore made speculative output diverge from non-speculative greedy. Same class as #243/#258. The trigger correlates with activation: the n-gram speculator fires on repetitive context, which is exactly where top-logit ties (and quantization-induced logit collisions) are most likely.

Found by an adversarial audit of the speculative path, which has **zero CI coverage** (no workflow exercises speculation).

## Fix

`argmax` → a first-wins loop matching `sampling::argmax_f32_scalar`. NaN entries are now skipped consistently with the canonical paths (was: `partial_cmp().unwrap_or(Equal)`).

## Verification (TDD)

Tests written first, run against the **unfixed** code to prove they catch the bug:
```
argmax_tie_first_wins              left: 1  right: 0   FAILED
argmax_tie_matches_engine_first_wins  left: 3  right: 0   FAILED   (argmax returned 3 = last of three tied 0.0; engine returns 0)
```
After the fix:
```
test result: ok. 56 passed; 0 failed   (full speculative:: module)
cargo clippy -p lattice-inference --lib -- -D warnings   clean
```
`argmax_tie_matches_engine_first_wins` cross-checks against an inline copy of the engine's first-wins loop, so it guards the *contract* (agreement with greedy), not just a hardcoded index. `e2e-parity` triggers on this PR (touches `crates/inference/src`).

## Scope / follow-ups (not in this PR)

- Generation-level greedy-equivalence test for the speculative path in CI (would have caught both this and #243).
- Audit `mtp_verify_draft` error-path cache-rollback symmetry (review flagged: draft generation mutates caches before a possible `Err`; rollback only runs on the success path). Low severity.

## Note on merge

This is a behavior change (greedy output on tied logits). It is regression-gated and proven, but I am **not** auto-merging — flagging for human review since it changes tie-break semantics on the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
