### PR TITLE
fix(inference): greedy MTP path must use deterministic argmax verifier (#237)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -8778,15 +8778,17 @@ kernel void gdn_chunk_norm_silu_c32(
                 // `greedy=true`: argmax-only acceptance that is deterministic and
                 // token-for-token equivalent to plain greedy `generate()`. Passing
                 // `greedy=false` here drove a clock-seeded RNG, making greedy MTP output
-                // non-deterministic and not argmax-equivalent (#237). In greedy mode
-                // `draft_logits` is unused, so pass `&[]` per the function contract.
+                // non-deterministic and not argmax-equivalent (#237). In greedy mode the
+                // verifier never reads `draft_logits` (it may even be `&[]` per the
+                // contract), but we still hand it the draft's own logits: the value is
+                // ignored on the greedy path and this keeps `draft.logits` a live read.
                 //   draft_tokens          = [draft.token_id]
-                //   draft_logits          = &[]                   (unused in greedy mode)
+                //   draft_logits          = [draft.logits]        (ignored in greedy mode)
                 //   initial_target_logits = verify_out.logits[0]  (predicts draft position)
                 //   target_logits         = [verify_out.logits[1]] (bonus on full accept)
                 let Ok(rs) = crate::speculative::rejection_sample_draft(
                     &[draft.token_id],
-                    &[],
+                    std::slice::from_ref(&draft.logits),
                     &verify_out.logits[0],
                     std::slice::from_ref(&verify_out.logits[1]),
                     true,

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -8773,17 +8773,23 @@ kernel void gdn_chunk_norm_silu_c32(
 
                 // Route the accept/reject decision through `rejection_sample_draft` so
                 // the live MTP loop and the trait-level `mtp_verify_draft` share the
-                // same verifier implementation (ADR-050). For probabilistic 1-draft MTP:
+                // same verifier implementation (ADR-050). This is the GREEDY MTP loop
+                // (entered only when top_k<=1 && temperature<=0.0), so verification uses
+                // `greedy=true`: argmax-only acceptance that is deterministic and
+                // token-for-token equivalent to plain greedy `generate()`. Passing
+                // `greedy=false` here drove a clock-seeded RNG, making greedy MTP output
+                // non-deterministic and not argmax-equivalent (#237). In greedy mode
+                // `draft_logits` is unused, so pass `&[]` per the function contract.
                 //   draft_tokens          = [draft.token_id]
-                //   draft_logits          = [draft.logits]   (q(·) for draft position)
+                //   draft_logits          = &[]                   (unused in greedy mode)
                 //   initial_target_logits = verify_out.logits[0]  (predicts draft position)
                 //   target_logits         = [verify_out.logits[1]] (bonus on full accept)
                 let Ok(rs) = crate::speculative::rejection_sample_draft(
                     &[draft.token_id],
-                    std::slice::from_ref(&draft.logits),
+                    &[],
                     &verify_out.logits[0],
                     std::slice::from_ref(&verify_out.logits[1]),
-                    false,
+                    true,
                     None,
                 ) else {
                     // Fallback: accept pending, advance normally.

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -3395,6 +3395,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn rejection_greedy_one_draft_mtp_contract_empty_draft_logits() {
+        // Locks the contract the greedy MTP loop (metal_qwen35::generate_greedy_mtp,
+        // #237) depends on: a single draft token verified with `greedy=true` and an
+        // EMPTY `draft_logits` slice (unused in greedy mode). The downstream loop reads
+        //   accept → bonus = argmax(target_logits[0])  (verify_out.logits[1])
+        //   reject → bonus = argmax(initial_target)     (verify_out.logits[0])
+        // A regression that flips this call back to probabilistic (greedy=false,
+        // clock-seeded) would break determinism and these argmax bonus identities.
+        // `seed=None` with `greedy=true` must stay deterministic (no RNG is built).
+        const VOCAB: usize = 16;
+        let initial_target = peaked_logits(VOCAB, 4, 6.0); // target's pick at draft pos = 4
+        let target_logits = vec![peaked_logits(VOCAB, 11, 6.0)]; // full-accept bonus = 11
+
+        // Accept: draft token == initial_target argmax (4) → accept, bonus = 11.
+        let accept =
+            rejection_sample_draft(&[4u32], &[], &initial_target, &target_logits, true, None)
+                .unwrap();
+        assert_eq!(
+            accept.accepted_count, 1,
+            "draft == initial argmax → accepted"
+        );
+        assert!(!accept.had_rejection);
+        assert_eq!(
+            accept.bonus_token,
+            Some(11),
+            "full-accept bonus is argmax(target_logits[0])"
+        );
+
+        // Reject: draft token (7) != initial_target argmax (4) → reject, bonus = 4.
+        let reject =
+            rejection_sample_draft(&[7u32], &[], &initial_target, &target_logits, true, None)
+                .unwrap();
+        assert_eq!(
+            reject.accepted_count, 0,
+            "draft != initial argmax → rejected"
+        );
+        assert!(reject.had_rejection);
+        assert_eq!(
+            reject.bonus_token,
+            Some(4),
+            "rejection bonus is the target's own pick = argmax(initial_target)"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // MtpVerifier f16 KV cache rollback regression (Defect 4 fix, Option A).
     //


### PR DESCRIPTION
## Summary

Addresses **#237 (concern #1 of 3)**: the greedy MTP decode loop used the probabilistic, clock-seeded rejection sampler, making a deterministic greedy path produce non-deterministic output. Concerns #2 (draft-stop short-circuit) and #3 (EOS-drop in test-only helper) are **left open** — they need a differential test to confirm and are out of scope here.

`generate_greedy_mtp` (`crates/inference/src/forward/metal_qwen35.rs`) is entered **only** under greedy config (`top_k<=1 && temperature<=0.0`), yet it called `rejection_sample_draft(..., greedy=false, seed=None)`. With `greedy=false` + `seed=None`, the sampler takes its probabilistic branch with a clock-seeded RNG (`SpecRng::from_clock()`), so acceptance/bonus were non-deterministic and not argmax-equivalent to plain greedy `generate()`.

## Fix

One call site: flip `greedy=false` → `greedy=true`. The downstream accept/reject code at the call site already documents and expects exactly the argmax semantics greedy mode produces:
- accept → `bonus = argmax(verify_out.logits[1])`
- reject → `bonus = argmax(verify_out.logits[0])`

`draft_logits` is **unread** on the greedy path (validation is gated by `!greedy`), so its value is irrelevant to correctness. We pass `std::slice::from_ref(&draft.logits)` (the draft's own logits) rather than `&[]`: an earlier `&[]` revision removed the only non-test reader of `MetalMtpForwardOutput.logits`, which tripped `field 'logits' is never read` (dead_code) under the `--features f16,metal-gpu` clippy gate (`ci.yml`, macOS only — not caught by a plain `clippy --workspace`). Handing the verifier the draft's logits keeps the field a live read with zero behavior change.

The sibling call site `mtp_verify_draft` (`speculative.rs:1284`) intentionally keeps `greedy=false` — it is the general probabilistic verifier per ADR-050, not a greedy-only path. Left unchanged (verified).

## Why this is safe / dormant

`qwen3.5-0.8b` ships **no MTP weights**, so `generate_greedy_mtp` is unreachable by default and the **e2e-parity gate is unaffected**. This is a latent correctness fix on an opt-in path (`LATTICE_MTP`).

## Regression setup

- New unit test `rejection_greedy_one_draft_mtp_contract_empty_draft_logits` (speculative.rs) locks the exact n=1 MTP greedy contract the fixed call site depends on: empty `draft_logits`, accept→`argmax(target_logits[0])`, reject→`argmax(initial_target)`. None of the existing greedy tests used n=1 or an empty `draft_logits` slice, so this is non-redundant. (The test deliberately exercises the `&[]` contract to prove the function ignores `draft_logits` in greedy mode — independent of what the call site passes.)
- Existing greedy-mode tests (`rejection_greedy_mode_accepts_matching_argmax`, `rejection_greedy_all_match`, `rejection_greedy_mode_regression_matches_existing_argmax_behavior`) continue to lock the multi-draft greedy semantics.
- The Metal call-site wiring itself cannot be exercised headlessly (dormant Metal path, no MTP weights), so it is gated by code review; this is noted honestly rather than papered over with a test that cannot run.

## Validation

- `cargo test -p lattice-inference --lib speculative::` → 60 passed
- `cargo clippy -p lattice-inference --features f16,metal-gpu -- -D warnings` → clean (the metal-gpu gate that the `&[]` revision regressed)
- `cargo clippy --workspace -- -D warnings` + fmt + doc-lint → clean
- Review (high effort): approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
