### PR TITLE
fix(inference): guard usize overflow in generate() max_seq computation

### DIFF
--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -203,15 +203,59 @@ fn check_kv_cache_capacity(
 ///
 /// A caller passing `max_new_tokens` near `usize::MAX` would otherwise wrap the
 /// addition (release builds elide the overflow check), yielding a tiny `max_seq`,
-/// an undersized cache, and a bare panic inside `prefill_layer`'s capacity
-/// assertion. Returning `InvalidInput` turns that latent panic into a clean,
-/// caller-visible error.
+/// an undersized cache, and a bare panic on the first prefill write into the
+/// (now too small) cache buffer. Returning `InvalidInput` turns that latent panic
+/// into a clean, caller-visible error.
+///
+/// This guards only the addition; [`check_alloc_capacity`] guards the subsequent
+/// multiplication into per-buffer byte counts.
 fn compute_max_seq(prompt_len: usize, max_new_tokens: usize) -> Result<usize, InferenceError> {
     prompt_len.checked_add(max_new_tokens).ok_or_else(|| {
         InferenceError::InvalidInput(format!(
             "prompt_len ({prompt_len}) + max_new_tokens ({max_new_tokens}) overflows usize"
         ))
     })
+}
+
+/// Validate that the KV cache and per-token scratch sized to `effective_cap` will
+/// not overflow `usize` when their element counts are computed.
+///
+/// [`compute_max_seq`] guards the `prompt_len + max_new_tokens` *addition*, but a
+/// huge-yet-non-overflowing result (e.g. `max_new_tokens = usize::MAX / 1024`)
+/// still wraps the downstream `max_seq_len * dim` *multiplications* in cache
+/// sizing ([`FlatKVCacheConfig::layer_capacity`]) and scratch sizing
+/// (`ForwardScratch::ensure_capacity`), yielding undersized buffers and a panic on
+/// the first write. Every length-scaled allocation is linear in `effective_cap`,
+/// so summing their per-position element coefficients and checking the single
+/// product `effective_cap * Σcoeff` bounds them all at once: each individual
+/// product is `≤` the sum, so if the sum is overflow-safe every term is too.
+///
+/// The remaining scratch buffers scale with `prompt_len` (real tokenized input,
+/// not caller-controlled to pathological sizes), so they are not guarded here.
+fn check_alloc_capacity(
+    cfg: &QwenConfig,
+    num_layers: usize,
+    effective_cap: usize,
+) -> Result<(), InferenceError> {
+    let kv_dim = cfg.kv_dim();
+    // Per-position element coefficients that scale with the cache length:
+    //   KV cache (K+V across all layers): 2 * num_layers * kv_dim
+    //   dequant scratch (cached_k_f32 + cached_v_f32): 2 * kv_dim
+    //   attention scores: num_attention_heads
+    let coeff = (|| -> Option<usize> {
+        let cache = 2usize.checked_mul(num_layers)?.checked_mul(kv_dim)?;
+        let dequant = 2usize.checked_mul(kv_dim)?;
+        cache
+            .checked_add(dequant)?
+            .checked_add(cfg.num_attention_heads)
+    })()
+    .ok_or_else(|| InferenceError::InvalidInput("model dimensions overflow usize".into()))?;
+    effective_cap.checked_mul(coeff).ok_or_else(|| {
+        InferenceError::InvalidInput(format!(
+            "KV cache + scratch for max_seq ({effective_cap}) overflows usize"
+        ))
+    })?;
+    Ok(())
 }
 
 /// **Unstable**: text generation entry point for Qwen3 models; the full
@@ -267,6 +311,7 @@ pub fn generate(
         .map(|c| c.max(1).min(max_seq))
         .unwrap_or(max_seq);
     check_kv_cache_capacity(config.kv_cache_capacity, effective_cap, prompt_len)?;
+    check_alloc_capacity(cfg, cfg.num_hidden_layers, effective_cap)?;
     let cache_cfg = FlatKVCacheConfig::for_qwen3(
         cfg.num_hidden_layers,
         cfg.num_key_value_heads,
@@ -1039,6 +1084,28 @@ mod tests {
         let err = compute_max_seq(10, usize::MAX).unwrap_err();
         assert!(matches!(err, InferenceError::InvalidInput(_)));
         let err = compute_max_seq(usize::MAX, 1).unwrap_err();
+        assert!(matches!(err, InferenceError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_check_alloc_capacity_normal() {
+        let cfg = QwenConfig::qwen3_embedding_0_6b();
+        // A realistic context length must pass.
+        assert!(check_alloc_capacity(&cfg, cfg.num_hidden_layers, 4096).is_ok());
+        assert!(check_alloc_capacity(&cfg, cfg.num_hidden_layers, 262_144).is_ok());
+        assert!(check_alloc_capacity(&cfg, cfg.num_hidden_layers, 0).is_ok());
+    }
+
+    #[test]
+    fn test_check_alloc_capacity_multiplication_overflow_is_error() {
+        // The codex review of PR #291 found that guarding only compute_max_seq's
+        // addition leaves the downstream `max_seq_len * kv_dim` multiplication
+        // unchecked: a huge-yet-non-overflowing effective_cap (here usize::MAX/1024,
+        // matching the reviewer's kv_dim=8*128 counterexample) wraps the cache/scratch
+        // element count and panics on the first write. The guard must reject it.
+        let cfg = QwenConfig::qwen3_embedding_0_6b();
+        let effective_cap = usize::MAX / 1024;
+        let err = check_alloc_capacity(&cfg, cfg.num_hidden_layers, effective_cap).unwrap_err();
         assert!(matches!(err, InferenceError::InvalidInput(_)));
     }
 

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -198,6 +198,22 @@ fn check_kv_cache_capacity(
     Ok(())
 }
 
+/// Compute the maximum sequence length (prompt + generated) used to size the KV
+/// cache, guarding against `usize` overflow on a pathological `max_new_tokens`.
+///
+/// A caller passing `max_new_tokens` near `usize::MAX` would otherwise wrap the
+/// addition (release builds elide the overflow check), yielding a tiny `max_seq`,
+/// an undersized cache, and a bare panic inside `prefill_layer`'s capacity
+/// assertion. Returning `InvalidInput` turns that latent panic into a clean,
+/// caller-visible error.
+fn compute_max_seq(prompt_len: usize, max_new_tokens: usize) -> Result<usize, InferenceError> {
+    prompt_len.checked_add(max_new_tokens).ok_or_else(|| {
+        InferenceError::InvalidInput(format!(
+            "prompt_len ({prompt_len}) + max_new_tokens ({max_new_tokens}) overflows usize"
+        ))
+    })
+}
+
 /// **Unstable**: text generation entry point for Qwen3 models; the full
 /// generation loop (prefill, decode, sampling) is under active design.
 ///
@@ -243,7 +259,7 @@ pub fn generate(
     }
 
     // 2. Initialize KV cache and scratch (allocate once per request)
-    let max_seq = prompt_len + config.max_new_tokens;
+    let max_seq = compute_max_seq(prompt_len, config.max_new_tokens)?;
     // Effective cache capacity: honour the caller's opt-in cap (issue #12).
     // Clamped to [1, max_seq] so over-large caps and zero are both safe.
     let effective_cap = config
@@ -1005,6 +1021,25 @@ mod tests {
         };
         assert_eq!(output.generated_tokens, 3);
         assert!(!output.stopped_by_eos);
+    }
+
+    #[test]
+    fn test_compute_max_seq_normal() {
+        assert_eq!(compute_max_seq(10, 100).unwrap(), 110);
+        assert_eq!(compute_max_seq(0, 0).unwrap(), 0);
+        // Largest sum that still fits exactly.
+        assert_eq!(compute_max_seq(1, usize::MAX - 1).unwrap(), usize::MAX);
+    }
+
+    #[test]
+    fn test_compute_max_seq_overflow_is_error_not_panic() {
+        // A pathological max_new_tokens near usize::MAX must surface a clean
+        // InvalidInput error rather than wrapping the addition and panicking
+        // later inside prefill_layer's capacity assertion (codex finding #2).
+        let err = compute_max_seq(10, usize::MAX).unwrap_err();
+        assert!(matches!(err, InferenceError::InvalidInput(_)));
+        let err = compute_max_seq(usize::MAX, 1).unwrap_err();
+        assert!(matches!(err, InferenceError::InvalidInput(_)));
     }
 
     #[test]

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -347,8 +347,13 @@ pub fn generate(
         engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
     }
 
-    // 6. Sample first token from the last position's logits
-    let mut generated_ids: Vec<u32> = Vec::with_capacity(config.max_new_tokens);
+    // 6. Sample first token from the last position's logits.
+    // Cap the preallocation hint at effective_cap (the real generation ceiling —
+    // decode stops once the cache is full), not the raw max_new_tokens: a caller
+    // with a small kv_cache_capacity and a huge max_new_tokens would otherwise
+    // panic in Vec::with_capacity (capacity * 4 bytes > isize::MAX). effective_cap
+    // is already validated allocation-safe by check_alloc_capacity above.
+    let mut generated_ids: Vec<u32> = Vec::with_capacity(config.max_new_tokens.min(effective_cap));
     let first_token = sampler.sample(&scratch.logits[..cfg.vocab_size]);
     generated_ids.push(first_token);
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Guards three `usize` overflow / over-allocation hazards in `generate()`'s KV-cache / scratch sizing on a pathological caller-controlled `max_new_tokens`. All convert a latent process abort into a clean `InferenceError::InvalidInput` (or a bounded allocation).

1. **Addition** (`compute_max_seq`): `max_new_tokens` near `usize::MAX` wrapped `prompt_len + max_new_tokens` (release builds elide the overflow check), yielding a tiny `max_seq` and an undersized cache. Extracted into a testable `checked_add` helper.

2. **Multiplication** (`check_alloc_capacity`): surfaced by review round 1. A huge-yet-non-overflowing `max_seq` (e.g. `max_new_tokens = usize::MAX / kv_dim`) still wraps the downstream `max_seq_len * dim` products in `FlatKVCacheConfig::layer_capacity` and `ForwardScratch::ensure_capacity`, yielding undersized buffers and a panic on the first write. Every length-scaled allocation is linear in `effective_cap`, so the guard sums their per-position element coefficients (cache `2·num_layers·kv_dim` + dequant scratch `2·kv_dim` + scores `num_attention_heads`) and checks the single product `effective_cap × Σcoeff` — each individual term is `≤` the sum, so one checked multiply bounds them all. Rejects before any allocation.

3. **Preallocation cap** (`generated_ids`): surfaced by review round 2. With a small `kv_cache_capacity`, the multiplication guard passes on the small `effective_cap`, but `Vec::with_capacity(config.max_new_tokens)` still received the raw huge value and panics (`capacity * 4 bytes > isize::MAX`). Capped the hint at `effective_cap` — the real generation ceiling, since decode stops on `cache.is_full()`, and `effective_cap` is already proven allocation-safe by guard 2. Byte-identical behavior whenever `max_new_tokens ≤ effective_cap`.

## Why

Found by a panic-safety audit of the generation path. Lattice's rule is no panic on caller-controlled input in library code; this turns a latent process abort into a clean error. The input is pathological, but the fix is trivial and correct.

## Tests

- `test_compute_max_seq_normal` / `test_compute_max_seq_overflow_is_error_not_panic` — addition boundary + `Err(InvalidInput)` on overflow, no panic.
- `test_check_alloc_capacity_normal` — realistic context lengths (4096, 262144, 0) on `qwen3_embedding_0_6b` pass.
- `test_check_alloc_capacity_multiplication_overflow_is_error` — the reviewer's exact counterexample (`effective_cap = usize::MAX / 1024`, `kv_dim = 8·128`) returns `Err(InvalidInput)`, no panic.
- Full lib suite: 983 pass (979 baseline + 4 new). `cargo clippy -p lattice-inference --features f16,metal-gpu -- -D warnings` clean.

## Perf

The guard runs once per `generate()` call, off the prefill/decode hot loop, so zero hot-path impact.

Criterion A/B on `elementwise_cpu_bench` (origin/main `89a4a51c4` vs HEAD, same session, M1):

```
rms_norm/896          No change          (p = 0.77)
rms_norm/4096         No change          (p = 0.18)
layer_norm/896        "improved" -42%    (p = 0.00)  ← noise: CI [-55%, -25%]
layer_norm/4096       "improved" -38%    (p = 0.03)  ← noise: CI [-57%, -10%]
silu_inplace/896      "improved" -36%    (p = 0.00)  ← noise: CI [-50%, -16%]
silu_inplace/4096     "improved" -66%    (p = 0.00)  ← noise: CI [-74%, -54%]
gelu/896              No change          (p = 0.08)
gelu/4096             No change          (p = 0.19)
add_bias_gelu/896     No change          (p = 0.14)
add_bias_gelu/4096    No change          (p = 0.08)
softmax_attention/128 No change          (p = 0.29)
softmax_attention/512 "improved" -25%    (p = 0.00)  ← noise: CI [-36%, -12%]
elementwise_mul/4096  No change          (p = 0.16)
```

The change runs once per `generate()` call and modifies no code path these benchmarks
exercise, so any real delta would be zero. The flagged "improvements" carry wide CIs and
are the known two-worktree machine-state variance documented across prior lattice perf PRs
(the BASE half of the A/B ran on a colder machine). No regression on any group.

## Related

Sibling of #290 (the deeper `FlatKVCache` assert→`Result` hardening this overflow was the only reachable path into). #290 is the broader follow-up; this PR closes the one reachable panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
