### PR TITLE
fix(inference): reject zero head counts in parse_qwen_config (#294)

### DIFF
--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -1632,6 +1632,17 @@ fn parse_qwen_config(path: &Path) -> Result<QwenConfig, InferenceError> {
         .unwrap_or(1e-6);
 
     let num_attention_heads = get("num_attention_heads")?;
+    let num_key_value_heads = get("num_key_value_heads")?;
+    // Both head counts are used as divisors (head_dim inference below,
+    // QwenConfig::num_groups, GQA grouping). A zero from a caller-supplied
+    // config.json would otherwise be an integer divide-by-zero panic, so reject
+    // it as InvalidInput here rather than crashing deep in the forward pass.
+    if num_attention_heads == 0 || num_key_value_heads == 0 {
+        return Err(InferenceError::InvalidInput(format!(
+            "config.json: num_attention_heads ({num_attention_heads}) and \
+             num_key_value_heads ({num_key_value_heads}) must both be non-zero"
+        )));
+    }
     let hidden_size = get("hidden_size")?;
     // head_dim may be explicit in config, or inferred from hidden_size / num_heads.
     let head_dim =
@@ -1642,7 +1653,7 @@ fn parse_qwen_config(path: &Path) -> Result<QwenConfig, InferenceError> {
         hidden_size,
         num_hidden_layers: get("num_hidden_layers")?,
         num_attention_heads,
-        num_key_value_heads: get("num_key_value_heads")?,
+        num_key_value_heads,
         head_dim,
         intermediate_size: get("intermediate_size")?,
         max_position_embeddings: get("max_position_embeddings")?,
@@ -1686,6 +1697,54 @@ mod tests {
         assert_eq!(cfg.q_dim(), 2048); // 16 * 128
         assert_eq!(cfg.kv_dim(), 1024); // 8 * 128
         assert_eq!(cfg.num_groups(), 2); // 16 / 8
+    }
+
+    #[test]
+    fn test_parse_config_zero_heads_is_error_not_panic() {
+        let tmp = std::env::temp_dir().join("lattice_test_zero_heads");
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // num_attention_heads=0 WITH head_dim present: proves the eager
+        // `unwrap_or(hidden_size / num_attention_heads)` divide-by-zero is
+        // guarded even on the head_dim-explicit path.
+        let cfg_zero_attn = tmp.join("zero_attn_heads.json");
+        std::fs::write(
+            &cfg_zero_attn,
+            r#"{"vocab_size":151669,"hidden_size":1024,"num_hidden_layers":1,"num_attention_heads":0,"num_key_value_heads":8,"head_dim":128,"intermediate_size":3072,"max_position_embeddings":32768}"#,
+        )
+        .unwrap();
+        let r = parse_qwen_config(&cfg_zero_attn);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "num_attention_heads=0 must be InvalidInput, not panic; got {r:?}"
+        );
+
+        // num_key_value_heads=0: sibling divisor (num_groups / GQA grouping).
+        let cfg_zero_kv = tmp.join("zero_kv_heads.json");
+        std::fs::write(
+            &cfg_zero_kv,
+            r#"{"vocab_size":151669,"hidden_size":1024,"num_hidden_layers":1,"num_attention_heads":16,"num_key_value_heads":0,"head_dim":128,"intermediate_size":3072,"max_position_embeddings":32768}"#,
+        )
+        .unwrap();
+        let r = parse_qwen_config(&cfg_zero_kv);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "num_key_value_heads=0 must be InvalidInput, not panic; got {r:?}"
+        );
+
+        // Sanity: a valid config still parses.
+        let cfg_ok = tmp.join("valid.json");
+        std::fs::write(
+            &cfg_ok,
+            r#"{"vocab_size":151669,"hidden_size":1024,"num_hidden_layers":1,"num_attention_heads":16,"num_key_value_heads":8,"head_dim":128,"intermediate_size":3072,"max_position_embeddings":32768}"#,
+        )
+        .unwrap();
+        assert!(
+            parse_qwen_config(&cfg_ok).is_ok(),
+            "valid config must still parse"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #294.

## What

`parse_qwen_config` read `num_attention_heads` from a caller-supplied `config.json` and immediately used it as a divisor:

```rust
let head_dim = extract_json_usize(&text, "head_dim").unwrap_or(hidden_size / num_attention_heads);
```

`unwrap_or` evaluates its argument **eagerly**, so `num_attention_heads == 0` is an integer divide-by-zero panic — even when `head_dim` is present in the config and the inferred value is never used. `num_key_value_heads` is the same bug class one field away: `QwenConfig::num_groups` (`num_attention_heads / num_key_value_heads`) and the GQA grouping divide by it on every forward pass, so a zero there panics after a successful parse.

This PR validates both head counts are non-zero at parse time and returns `InferenceError::InvalidInput` (the variant documented for "caller-supplied input was invalid"), matching lattice's no-panic-on-caller-input rule for library code.

## Why

Found by an automated discovery audit of the inference public API surface, verified at source. `QwenModel::from_directory(path)` reads a caller-supplied `config.json` before weight loading, so an edited/untrusted/corrupt config is a reachable public path into the panic.

## Tests

- `test_parse_config_zero_heads_is_error_not_panic` — asserts `Err(InvalidInput)` (not panic) for `num_attention_heads=0` (with `head_dim` present, proving the eager-eval path is guarded), for `num_key_value_heads=0`, and that a valid config still parses.
- `cargo clippy -p lattice-inference --features f16,metal-gpu -- -D warnings` clean.

## Perf

`parse_qwen_config` runs **once per model load**, off every prefill/decode hot loop — no benchmark exercises it and the guard cannot affect inference throughput. `make bench-compare` (origin/main `8e5d415ac` vs HEAD `49e95bc05`, quick, M1) was run for the measure-first rule. It produced **no parseable A/B table**: the only criterion groups present were stale embed/SIMD baselines (e.g. `simd_query_batch_dot_product`, `tier_prepared_batch_sizes`) with no `base/estimates.json`, so the comparator reported `change files found but all failed to parse`. This is the expected outcome — the changed code (config JSON parsing at load time) is in no benchmarked path, so there is nothing on the hot path to measure.

The relevant correctness gate is `e2e-parity` (greedy token agreement vs HF), which this PR must pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
