### PR TITLE
fix(inference): treat non-finite temperature as greedy in sampling (#295)

### DIFF
--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -14,15 +14,20 @@ pub(crate) fn sample_token(
         apply_repetition_penalty(&mut adjusted, previous_ids, cfg.repetition_penalty);
     }
 
-    if cfg.temperature > 0.0 && cfg.temperature != 1.0 {
+    // A non-finite (NaN/±inf) or non-positive temperature carries no valid
+    // scaling: `1.0 / NaN` is NaN and `1.0 / inf` is 0, either of which corrupts
+    // the distribution (NaN logits, or all logits flattened to a uniform draw).
+    // Route them all to deterministic greedy argmax before any scaling, matching
+    // Sampler::sample and the documented "0.0 = greedy" contract.
+    if !cfg.temperature.is_finite() || cfg.temperature <= 0.0 {
+        return greedy_token(&adjusted);
+    }
+
+    if cfg.temperature != 1.0 {
         let inv_temp = 1.0 / cfg.temperature;
         for v in &mut adjusted {
             *v *= inv_temp;
         }
-    }
-
-    if cfg.temperature <= 0.0 {
-        return greedy_token(&adjusted);
     }
 
     let mut indices: Vec<usize> = (0..vocab_size).collect();

--- a/crates/inference/src/model/qwen35/tests.rs
+++ b/crates/inference/src/model/qwen35/tests.rs
@@ -63,6 +63,30 @@ fn test_sample_repetition_penalty() {
 }
 
 #[test]
+fn test_sample_nonfinite_temperature_is_greedy() {
+    // The live Qwen3.5 decode sampler must treat a non-finite temperature as
+    // greedy (deterministic argmax = token 1), not sample from an unscaled
+    // distribution (NaN) or a flattened uniform one (+inf → inv_temp 0). top_k=2
+    // forces the categorical path that would otherwise mis-sample.
+    let logits = vec![0.0, 100.0, 99.0];
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let cfg = crate::model::qwen35_config::GenerateConfig {
+            temperature: bad,
+            top_k: 2,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            ..Default::default()
+        };
+        let mut rng = 7u64;
+        let token = sample_token(&logits, &cfg, &[], &mut rng);
+        assert_eq!(
+            token, 1,
+            "temperature {bad} must fall back to greedy argmax, not corrupt sampling"
+        );
+    }
+}
+
+#[test]
 fn test_decode_tokens_roundtrip() {
     // Test the byte_encoder/decoder roundtrip
     let encoder = bytes_to_unicode();

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -103,9 +103,11 @@ impl CandidateSet {
         best_id
     }
 
-    /// Scale logits by `1 / temperature`.  No-op when temperature == 1.0.
+    /// Scale logits by `1 / temperature`.  No-op when temperature is 1.0,
+    /// non-positive, or non-finite (NaN/±inf) — none of those carry a valid
+    /// scaling, and `1.0 / NaN` would poison every logit with NaN.
     pub fn apply_temperature(&mut self, temperature: f32) {
-        if temperature <= 0.0 || temperature == 1.0 {
+        if !temperature.is_finite() || temperature <= 0.0 || temperature == 1.0 {
             return;
         }
         let inv = 1.0 / temperature;
@@ -271,7 +273,16 @@ impl Sampler {
         // whenever the raw argmax token is not in recent_tokens. In the common case
         // (recent_tokens empty or raw argmax not recently generated) this avoids the
         // 993 KB extend_from_slice entirely.
-        if self.config.temperature <= 0.0 || self.config.top_k == 1 {
+        //
+        // A non-finite temperature (NaN, ±inf) is also routed here: it carries no
+        // valid scaling. `1.0 / NaN` is NaN, which poisons every scaled logit and
+        // collapses the fused top-k to token 0 (the lowest ID), and `1.0 / inf` is 0,
+        // which flattens all logits. Fall back to the same deterministic argmax as
+        // temperature <= 0.0 rather than sampling from a corrupted distribution.
+        if !self.config.temperature.is_finite()
+            || self.config.temperature <= 0.0
+            || self.config.top_k == 1
+        {
             let raw_best = argmax_f32(logits);
             if self.config.repetition_penalty == 1.0 || !self.recent_tokens.contains(&raw_best) {
                 self.push_token(raw_best);
@@ -665,6 +676,52 @@ mod tests {
         let mut sampler = Sampler::new(config);
         let logits = vec![1.0, 5.0, 2.0];
         assert_eq!(sampler.sample(&logits), 1);
+    }
+
+    #[test]
+    fn test_nonfinite_temperature_falls_back_to_argmax() {
+        // top_k=2 forces the non-greedy fused-top-k path pre-fix, where a NaN/inf
+        // temperature produced `inv_temp = NaN`/`0`, scaling every logit to NaN/0
+        // and collapsing the result to token 0. The guard must instead return the
+        // true argmax (token 1) for any non-finite temperature.
+        let logits = vec![0.0, 100.0, 99.0];
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let config = SamplingConfig {
+                temperature: bad,
+                top_k: 2,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+            };
+            let mut sampler = Sampler::new(config).with_seed(7);
+            assert_eq!(
+                sampler.sample(&logits),
+                1,
+                "temperature {bad} must fall back to argmax, not collapse to token 0"
+            );
+        }
+    }
+
+    #[test]
+    fn test_apply_temperature_nonfinite_is_noop() {
+        // A non-finite (or non-positive) temperature must leave logits untouched —
+        // `1.0 / NaN` would poison the whole candidate set, `1.0 / inf` would zero it.
+        for bad in [
+            f32::NAN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            0.0_f32,
+            -2.0_f32,
+        ] {
+            let mut cs = CandidateSet::from_full_logits(&[1.0, 5.0, 3.0]);
+            cs.apply_temperature(bad);
+            let logits: Vec<f32> = cs.candidates.iter().map(|c| c.logit).collect();
+            assert_eq!(
+                logits,
+                vec![1.0, 5.0, 3.0],
+                "temperature {bad} must be a no-op, leaving logits finite and unscaled"
+            );
+            assert_eq!(cs.argmax(), 1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #295.

## What

A non-finite (`NaN`/`±inf`) `SamplingConfig::temperature` silently corrupted sampling output instead of falling back to a defined behavior. Two paths were affected:

1. **`Sampler::sample` (fused CPU path)** — the greedy fast path guard was `temperature <= 0.0 || top_k == 1`. `NaN <= 0.0` and `+inf <= 0.0` are both `false`, so a non-finite temperature with `top_k != 1` fell through to the non-greedy fused top-k path, where:
   ```rust
   let inv_temp = if temperature != 1.0 { 1.0 / temperature } else { 1.0 };
   ```
   `NaN != 1.0` is `true` → `inv_temp = 1.0 / NaN = NaN`. Every `logit * NaN = NaN`; `select_top_k`'s crash-guard then replaces all NaN seeds with `NEG_INFINITY`, so `sample_top_p` returns `candidates[0]` = **token 0** (the lowest ID), not the true argmax. (`+inf` → `inv_temp = 0` → all logits flattened to 0.)

2. **`CandidateSet::apply_temperature` (Metal GPU compact path, `metal_qwen35.rs:12804/12840`)** — its guard checked `temperature <= 0.0 || temperature == 1.0` but not `NaN`, so `1.0 / NaN = NaN` poisoned every candidate logit.

3. **`model::qwen35::sampling::sample_token` (the live Qwen3.5 decode sampler — used by every CPU/NEON/Metal generation path)** — found during review of this PR. It scaled by `1.0 / temperature` and only fell back to greedy on `temperature <= 0.0`. `NaN` skipped scaling *and* the greedy guard → sampled from the unscaled distribution; `+inf` → `inv_temp = 0` → all logits flattened to a uniform draw. Fixed by reordering so the greedy guard runs first and covers non-finite as well as non-positive temperatures.

## Fix

Route any non-finite temperature to each path's **existing** degenerate-temperature branch (`is_finite()` is `false` for `NaN`/`±inf`):

- `Sampler::sample` → deterministic greedy argmax (same branch as `temperature <= 0.0`).
- `CandidateSet::apply_temperature` → no-op / unscaled (same branch as `<= 0.0` / `== 1.0`).

This is internally consistent with how each path already treats `temperature <= 0.0`, follows the HF/llama.cpp convention that a non-positive/degenerate temperature means greedy, and adds no per-logit work (one scalar `is_finite()` branch per `sample()` call). `select_top_k` is private and reached only from the now-guarded `Sampler::sample`, so no non-finite `inv_temp` can reach it.

## Why

Found by an automated discovery audit, verified at source. Reachable from the public `Sampler` / `CandidateSet` API with a misconfigured/pathological temperature. Produces wrong output (not a crash), which is harder to detect than a panic.

## Tests

- `test_nonfinite_temperature_falls_back_to_argmax` — `NaN`/`+inf`/`-inf` with `top_k=2` (the path that previously collapsed to token 0) must return the true argmax (token 1). Fails against base, which still routes these to the NaN-poisoned fused path.
- `test_apply_temperature_nonfinite_is_noop` — `NaN`/`±inf`/`0.0`/`-2.0` leave logits finite and unchanged on the `CandidateSet` primitive.
- `test_sample_nonfinite_temperature_is_greedy` (qwen35 path) — `NaN`/`+inf`/`-inf` with `top_k=2` fall back to argmax (token 1) in the live decode sampler.
- Full sampling group: `cargo test -p lattice-inference --lib sampling` → 33 passed; qwen35 sample tests → 3 passed.
- `cargo clippy -p lattice-inference --features f16,metal-gpu -- -D warnings` clean (covers all `sample_token` callers incl. Metal).

## Perf

The change adds a single scalar `is_finite()` branch per `sample()` call (once per generated token, **not** per-logit) and widens an already-existing fast-path condition — no new hot-loop work. `make bench-compare` (origin/main `297e6e5d0` vs HEAD `6b32b9415`, quick, M1) was run per the measure-first rule. As with the prior config-parsing PR, it produced **no parseable A/B table**: the only criterion groups with data were stale embed/SIMD baselines (`simd_*`, `tier_prepared_*`, `softmax_attention`) lacking `base/estimates.json`, so the comparator reported `change files found but all failed to parse`. This is expected — the sampling branch is in no microbenchmark's path, so there is nothing on a measured hot loop to compare.

The relevant correctness gate is `e2e-parity` (greedy token agreement vs HF), which this PR must pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
