### PR TITLE
docs: align stale LOC/version/parity facts and fix embed README API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ Thumbs.db
 *.bin
 *.onnx
 *.gguf
+
+# Codex/review scratch artifacts (repo-root only)
+/review*.md
+/pr_review*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,9 +92,9 @@ fn similarity(query: &[f32], docs: &[Vec<f32>]) -> Vec<f32> {
 ## Crate Structure
 
 ```
-inference (57K)  fann (7.5K)  transport (5.3K)   ← leaf, zero internal deps
-    |               |
-  embed (14K)    tune (13K)                       ← depend on leaves only
+inference (104K)  fann (6.5K)  transport (5.4K)   ← leaf, zero internal deps
+    |                |
+  embed (12K)    tune (15.6K)                     ← depend on leaves only
 ```
 
 ### lattice-inference — Transformer kernel
@@ -182,7 +182,7 @@ E5 models need `"query: "` / `"passage: "` prefixes. Qwen3 needs instruction pre
 
 ## Rust Conventions
 
-**Toolchain**: Edition 2024, MSRV 1.85.0, resolver 2. CI pinned to rustc 1.94.1.
+**Toolchain**: Edition 2024, no MSRV declared; CI pins Rust 1.94.1, resolver 2.
 
 **Lints**: Zero clippy warnings. All crates inherit `[lints] workspace = true`. Correctness lints are `deny`. `unsafe_op_in_unsafe_fn = "allow"` for SIMD. `inference` allows `too_many_arguments` and `needless_range_loop` crate-wide. AVX-512 code gets `#[allow(clippy::incompatible_msrv)]`.
 
@@ -217,7 +217,7 @@ GitHub Actions on every push/PR to `main`: fmt → clippy → test → build. Ru
 
 ### E2E Parity Gate
 
-PRs touching `crates/inference/src/` or `crates/embed/src/` trigger `e2e-parity.yml`. It runs HF transformers (reference) then lattice on the same macOS runner and compares greedy generation output. First 3 tokens must match (GDN recurrence diverges naturally after that). Speed is reported but not gated.
+PRs touching `crates/inference/src/` or `crates/embed/src/` trigger `e2e-parity.yml`. It runs HF transformers (reference) then lattice on the same macOS runner and compares greedy generation output. First 3 greedy tokens must match HF (2 for the long-prefill prompt; GDN recurrence diverges naturally after that). Speed is reported but not gated.
 
 The `perf-baselines` branch is still updated by `bench-update.yml` on merge to main for trend tracking.
 
@@ -243,7 +243,7 @@ make bench-gate                          # compare against perf-baselines branch
 
 ## ADRs
 
-58 ADRs in `docs/adr/INDEX.md`, globally numbered. Template: `docs/_templates/ADR_TEMPLATE.md`.
+63 ADRs in `docs/adr/INDEX.md`, globally numbered. Template: `docs/_templates/ADR_TEMPLATE.md`.
 
 Write when: new model, SIMD dispatch change, weight format change, new backend, public API change.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ import numpy as np, mlx.core as mx, mlx.nn as nn
 This process closed a 0.77 PPL gap on Qwen3.5-0.8B that had been misdiagnosed as "f32-vs-bf16 precision drift" for days. The actual bug was a RoPE pairing convention mismatch — interleaved `(2i, 2i+1)` vs stride-half `(i, half+i)`. Verified in 5 seconds: stride-half max-diff `8e-6`, interleaved `67.5`. PPL dropped from 16.62 → 15.89 (MLX gold 15.86).
 
 **Quantitative bounds reject hypotheses cheaply.** Before chasing "FP precision drift" or other plausible-sounding causes, check the literature for typical magnitude:
+
 - f16 vs f32 PPL delta: `~0.00x` (llama.cpp community)
 - bf16 vs f32 PPL delta: `<0.05` (arxiv:2510.26788)
 - Q4 quantization PPL delta: `0.1-0.3` (llama.cpp #406)
@@ -58,7 +59,7 @@ If the gap you're investigating exceeds these bounds, the cause is structural (a
 
 PRs touching `crates/inference/src/` or `crates/embed/src/` trigger `e2e-parity.yml`. It runs HF transformers (reference) and lattice on the same macOS runner, comparing greedy generation output. The reference runs first to warm the machine.
 
-- **Token parity**: first 5 greedy tokens must match HF exactly
+- **Token parity**: first 3 greedy tokens must match HF exactly (2 for the long-prefill prompt)
 - **Speed**: reported informationally, not gated
 - **Baseline tracking**: `bench-update.yml` still collects Criterion micro-benchmarks on merge to main (trend data, not a gate)
 
@@ -102,7 +103,7 @@ Changes to `inference` affect `embed` and `tune`. Changes to `fann` affect `tune
 
 ## Publishing
 
-Leaf crates publish first: inference → fann → transport → (wait 30s) → embed → (wait 30s) → tune. Use `make publish`. Internal path deps' `version = ` field must match the current workspace version (bump them in lockstep when bumping `[workspace.package].version`).
+Leaf crates publish first: inference → fann → transport → (wait 30s) → embed → (wait 30s) → tune. Use `make publish`. Internal path deps' `version =` field must match the current workspace version (bump them in lockstep when bumping `[workspace.package].version`).
 
 **Shipped-bug recovery (bump-and-yank).** crates.io versions are immutable. When a published release has a correctness bug:
 

--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ and can be used standalone.
 
 ## Crates
 
-| Crate                                    | Description                                                                                                                                                                    | LOC    |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
-| [`lattice-embed`](crates/embed/)         | Embedding service — `EmbeddingService` trait, `NativeEmbeddingService`, `CachedEmbeddingService`, SIMD cosine/dot/euclidean, backfill, migration                               | ~14 k  |
-| [`lattice-inference`](crates/inference/) | Transformer kernel — safetensors loading, BERT/BGE/Qwen3 forward pass, WordPiece/SentencePiece/BPE tokenizers, Metal/WGPU backends, LoRA hooks, KV cache, speculative decoding | ~69 k  |
-| [`lattice-fann`](crates/fann/)           | Fast neural network primitives — `NetworkBuilder`, pre-allocated layers, zero-alloc forward pass, backprop trainer, FANN binary format                                         | ~7.5 k |
-| [`lattice-tune`](crates/tune/)           | Training infrastructure — knowledge distillation pipeline, dataset management, LoRA adapter management, model registry with semver lineage                                     | ~13 k  |
-| [`lattice-transport`](crates/transport/) | Optimal transport math — Sinkhorn-Knopp (balanced + unbalanced), Wasserstein barycenters, embedding drift detection, log-domain throughout                                     | ~5.3 k |
+| Crate                                    | Description                                                                                                                                                                    | LOC     |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| [`lattice-embed`](crates/embed/)         | Embedding service — `EmbeddingService` trait, `NativeEmbeddingService`, `CachedEmbeddingService`, SIMD cosine/dot/euclidean, backfill, migration                               | ~12 k   |
+| [`lattice-inference`](crates/inference/) | Transformer kernel — safetensors loading, BERT/BGE/Qwen3 forward pass, WordPiece/SentencePiece/BPE tokenizers, Metal/WGPU backends, LoRA hooks, KV cache, speculative decoding | ~104 k  |
+| [`lattice-fann`](crates/fann/)           | Fast neural network primitives — `NetworkBuilder`, pre-allocated layers, zero-alloc forward pass, backprop trainer, FANN binary format                                         | ~6.5 k  |
+| [`lattice-tune`](crates/tune/)           | Training infrastructure — knowledge distillation pipeline, dataset management, LoRA adapter management, model registry with semver lineage                                     | ~15.6 k |
+| [`lattice-transport`](crates/transport/) | Optimal transport math — Sinkhorn-Knopp (balanced + unbalanced), Wasserstein barycenters, embedding drift detection, log-domain throughout                                     | ~5.4 k  |
 
 ---
 
@@ -199,10 +199,10 @@ let config = ModelConfig::try_new(EmbeddingModel::Qwen3Embedding4B, Some(512))?;
 
 ```toml
 # GPU acceleration on macOS
-lattice-embed = { version = "0.1", features = ["metal-gpu"] }
+lattice-embed = { version = "0.3", features = ["metal-gpu"] }
 
 # Cross-platform GPU
-lattice-embed = { version = "0.1", features = ["wgpu-gpu"] }
+lattice-embed = { version = "0.3", features = ["wgpu-gpu"] }
 ```
 
 ---
@@ -287,10 +287,10 @@ prompt, so prompt prefill, model load, and per-call overhead cancel and every en
 the _same_ way (greedy, median of 5 runs).
 
 | Context | Lattice (Q8, f16 head) | Ollama (Q8_0) | MLX (Q8 g64, AMX) | Lattice vs Ollama |
-| ------- | ---------------------- | ------------- | ------------------ | ----------------- |
-| 64 tok  | **187**                | 93            | 265                | **2.0×**          |
-| 128 tok | **171**                | 92            | 263                | **1.9×**          |
-| 256 tok | **146**                | 88            | 260                | **1.6×**          |
+| ------- | ---------------------- | ------------- | ----------------- | ----------------- |
+| 64 tok  | **187**                | 93            | 265               | **2.0×**          |
+| 128 tok | **171**                | 92            | 263               | **1.9×**          |
+| 256 tok | **146**                | 88            | 260               | **1.6×**          |
 
 MLX uses Apple's private MPS/AMX matrix engines — a different category than public-Metal-compute
 engines (Lattice, Ollama). **MLX decodes faster than Lattice.** Lattice's value is portability

--- a/crates/embed/README.md
+++ b/crates/embed/README.md
@@ -5,7 +5,7 @@ similarity matching.
 
 ## Features
 
-- **Local Embeddings**: Generate embeddings locally using BGE models via fastembed
+- **Native Embeddings**: Generate embeddings locally using pure Rust inference (no ONNX, no Python)
 - **SIMD Acceleration**: AVX2/AVX-512/NEON optimized vector operations (7x speedup)
 - **LRU Cache**: Blake3-based caching to avoid recomputation
 - **Async API**: Full async/await support with tokio
@@ -22,15 +22,15 @@ All models have a 512 token input limit.
 
 ## Services
 
-### LocalEmbeddingService
+### NativeEmbeddingService
 
 Single-model service with lazy initialization. Inference is serialized (one call at a
-time).
+time). Concurrency is handled internally.
 
 ```rust
-use lattice_embed::{EmbeddingService, EmbeddingModel, LocalEmbeddingService};
+use lattice_embed::{EmbeddingService, EmbeddingModel, NativeEmbeddingService};
 
-let service = LocalEmbeddingService::new();
+let service = NativeEmbeddingService::default();
 let embedding = service.embed_one("Hello, world!", EmbeddingModel::default()).await?;
 assert_eq!(embedding.len(), 384);
 ```
@@ -40,25 +40,14 @@ assert_eq!(embedding.len(), 384);
 Wraps any `EmbeddingService` with LRU caching. Identical texts return cached embeddings.
 
 ```rust
-use lattice_embed::{CachedEmbeddingService, LocalEmbeddingService, EmbeddingService};
+use lattice_embed::{CachedEmbeddingService, NativeEmbeddingService, EmbeddingService};
 use std::sync::Arc;
 
-let inner = Arc::new(LocalEmbeddingService::new());
+let inner = Arc::new(NativeEmbeddingService::new());
 let cached = CachedEmbeddingService::new(inner, 1000); // 1000 entry cache
 
 let emb1 = cached.embed_one("Hello", EmbeddingModel::default()).await?;
 let emb2 = cached.embed_one("Hello", EmbeddingModel::default()).await?; // cache hit
-```
-
-### PooledEmbeddingService
-
-Maintains N model instances for parallel inference. Memory scales linearly (~100-300MB
-per instance).
-
-```rust
-use lattice_embed::{PooledEmbeddingService, EmbeddingService};
-
-let service = PooledEmbeddingService::new(4); // 4 concurrent inference slots
 ```
 
 ## SIMD Vector Operations
@@ -129,14 +118,14 @@ println!("Hit rate: {:.1}%", stats.hit_rate() * 100.0);
 
 ## Feature Flags
 
-| Feature | Default | Description                          |
-| ------- | ------- | ------------------------------------ |
-| `local` | Yes     | Enable local embedding via fastembed |
+| Feature  | Default | Description                                    |
+| -------- | ------- | ---------------------------------------------- |
+| `native` | Yes     | Enable local embedding via pure Rust inference |
 
 ```toml
 [dependencies]
-lattice-embed = { version = "0.1", default-features = false }  # SIMD only
-lattice-embed = { version = "0.1" }  # Full (local + SIMD)
+lattice-embed = { version = "0.3", default-features = false }  # SIMD only
+lattice-embed = { version = "0.3" }  # Full (native + SIMD)
 ```
 
 ## Batch Processing


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Resolves part of #303 (mechanical, verifiable fixes only; PPL parity claim and MSRV declaration in Cargo.toml intentionally deferred — see notes below).

### What was wrong and what is now correct

**LOC counts** (all measured via `find crates/$c/src -name '*.rs' | xargs wc -l`):

| Crate | Old | New (measured) |
|---|---|---|
| `lattice-inference` | ~69 k | ~104 k (103,775) |
| `lattice-embed` | ~14 k | ~12 k (11,929) |
| `lattice-fann` | ~7.5 k | ~6.5 k (6,477) |
| `lattice-tune` | ~13 k | ~15.6 k (15,600) |
| `lattice-transport` | ~5.3 k | ~5.4 k (5,381) |

**Version in feature-flag examples** (`README.md` lines 202-205): `"0.1"` → `"0.3"` (matches `[workspace.package].version`).

**MSRV** (`AGENTS.md` line 185): `"MSRV 1.85.0"` → `"no MSRV declared; CI pins Rust 1.94.1"`. Verified: no `rust-version` field in any `Cargo.toml`. The 1.85.0 claim was unsubstantiated. Adding `rust-version` to Cargo.toml is deferred — it requires a compile verification pass.

**ADR count** (`AGENTS.md` line 246): `58 ADRs` → `63 ADRs`. Verified: `docs/adr/` contains 63 ADR files + `INDEX.md`.

**E2E parity token window** (`AGENTS.md` line 220, `CLAUDE.md` line 61):
- `AGENTS.md` said "First 3 tokens must match" (correct for short prompts but incomplete).
- `CLAUDE.md` said "first 5 greedy tokens must match HF exactly" (wrong count entirely).
- Fixed both to: "first 3 greedy tokens must match HF (2 for the long-prefill prompt)."
- Verified against `scripts/e2e_parity_check.py` `PROMPTS` list: 3 short prompts use `match_window=3`; the `~816-token` long-prefill prompt uses `match_window=2`.

**`crates/embed/README.md`** (published crate README — biggest factual gap):
- `LocalEmbeddingService` → `NativeEmbeddingService` (the actual exported type; `pub use service::NativeEmbeddingService` in `lib.rs` line 94).
- Removed `PooledEmbeddingService` — does not exist anywhere in the codebase.
- Removed fastembed / "BGE models via fastembed" claims — engine is pure native Rust; `Cargo.toml` has no `fastembed` dependency; the `[features]` section uses `native = ["dep:lattice-inference"]`.
- Fixed feature flag name: `local` → `native` (the real default feature).
- Updated `CachedEmbeddingService::new` example to use `Arc<NativeEmbeddingService>` (matching the real generic signature `fn new(inner: Arc<S>, cache_capacity: usize)`).
- Fixed version `"0.1"` → `"0.3"` in `[dependencies]` examples.

**`.gitignore`**: Added `/review*.md` and `/pr_review*.md` (repo-root anchored) to suppress review scratch artifacts. Verified no tracked files match these patterns (`git ls-files | grep -E '^review.*\.md'` returns empty).

### Intentionally deferred (per #303 scope)

- **PPL parity claim** (`README.md` lines 306-307: "20.60 vs 20.67"): needs a maintainer decision on replacement text or removal. Left exactly as-is.
- **MSRV `rust-version` field in Cargo.toml**: adding it is a compile-check operation, not a docs edit. Flagged in the AGENTS.md correction so future contributors know the current state.

## Test plan

- [x] `git diff --name-only` shows only `.gitignore`, `AGENTS.md`, `CLAUDE.md`, `README.md`, `crates/embed/README.md` — zero `.rs` files.
- [x] Pre-commit hook passed: `cargo check` (lattice-inference + lattice-embed) + `deno fmt --check` on all `.md` files — all green.
- [x] All LOC numbers re-measured in this session via canonical command.
- [x] `scripts/e2e_parity_check.py` `PROMPTS` list read directly to confirm `match_window` values.
- [x] `crates/embed/src/lib.rs` `pub use` re-exports read directly to confirm type names.
- [x] `crates/embed/Cargo.toml` `[features]` read directly to confirm no `fastembed`, correct feature name is `native`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)