### PR TITLE
docs(adr): refresh ADR-004/006/007 to current code (correctness traps)

### DIFF
--- a/docs/adr/ADR-004-kv-cache.md
+++ b/docs/adr/ADR-004-kv-cache.md
@@ -4,6 +4,25 @@
 **Date**: 2026-05-13\
 **Crate**: `lattice-inference`
 
+## Amendment (2026-06-24)
+
+Two facts in this ADR no longer match the implementation:
+
+1. **Storage format changed from f32 to f16.** `flat.rs` stores K and V as
+   `Vec<Vec<f16>>`. Writes convert f32 to f16 (`f16::from_f32`); reads dequantize
+   via `read_k_into`/`read_v_into`. This halves the memory footprint. For the
+   Qwen3-0.6B example (28 layers, 8 KV heads, 128 head_dim, 4096 max_seq_len) the
+   footprint is **~448 MB**, not ~896 MB as the original ADR stated. The `total_bytes()`
+   method on `FlatKVCacheConfig` reflects this; a test in `flat.rs` asserts
+   "expected ~448 MB."
+
+2. **`append_kv` and related mutators now return `Result<_, InferenceError>`.**
+   In PRs #290/#298 the previously panicking mutators were hardened to return
+   `Result<usize, InferenceError>` (for `append_kv`) and `Result<(), InferenceError>`
+   (for `advance`, `advance_by`, `prefill_layer`). The "allocation-free hot path"
+   property is preserved — the `Result` path adds only a bounds check, not an
+   allocation. Inline corrections are marked with `[CORRECTED]` below.
+
 ---
 
 ## Context
@@ -39,9 +58,10 @@ pub struct FlatKVCacheConfig {
 `FlatKVCache`:
 
 ```rust
+// [CORRECTED: storage is f16, not f32 — see Amendment above]
 pub struct FlatKVCache {
-    k: Vec<Vec<f32>>,   // [num_layers][max_seq_len * kv_dim]
-    v: Vec<Vec<f32>>,   // [num_layers][max_seq_len * kv_dim]
+    k: Vec<Vec<f16>>,   // [num_layers][max_seq_len * kv_dim]  (f16 elements)
+    v: Vec<Vec<f16>>,   // [num_layers][max_seq_len * kv_dim]  (f16 elements)
     seq_len: usize,
 }
 ```
@@ -49,12 +69,13 @@ pub struct FlatKVCache {
 Memory footprint for Qwen3-0.6B (28 layers, 8 KV heads, 128 head_dim, 4096 max_seq_len):
 
 ```
-28 × 8 × 128 × 4096 × 2 (K+V) × 4 bytes = 896 MB
+[CORRECTED] 28 × 8 × 128 × 4096 × 2 (K+V) × 2 bytes (f16) ≈ 448 MB
+(was: 28 × 8 × 128 × 4096 × 2 (K+V) × 4 bytes (f32) = 896 MB)
 ```
 
 `FlatKVCache` key methods:
 
-- `append_kv()` — O(1) append, advances `seq_len`
+- `append_kv()` — O(1) append; [CORRECTED: returns `Result<usize, InferenceError>` (#298), not `()` — see Amendment]
 - `truncate_to(n)` — sets `seq_len = n`, no deallocation
 - `reset()` — zeros data + `seq_len = 0`
 - `reset_fast()` — `seq_len = 0` only (no zero fill; caller owns validity)
@@ -72,7 +93,12 @@ Provide **two complementary KV cache implementations**: `FlatKVCache` for single
 
 ## Key Design Choices
 
-1. **Pre-allocation in FlatKVCache**: All memory is allocated at construction time. `append_kv()` is a bounds check + slice write — no allocation on the hot path. For embedding workloads where `forward()` is called thousands of times per second, this eliminates GC pressure entirely.
+1. **Pre-allocation in FlatKVCache**: All memory is allocated at construction time.
+   `append_kv()` is a bounds check + slice write — no allocation on the hot path.
+   [CORRECTED: `append_kv` returns `Result<usize, InferenceError>` (#298); the
+   bounds check now produces an `Err` instead of panicking. The allocation-free
+   property is preserved.] For embedding workloads where `forward()` is called
+   thousands of times per second, this eliminates GC pressure entirely.
 2. **Contiguous layout per layer**: Each layer's K tensor is a single `Vec<f32>` of size `max_seq_len * kv_dim`. The layout `[max_seq_len, kv_dim]` means that reading a full key sequence for attention is a single contiguous memory region — cache-friendly for the GEMM in attention scoring.
 3. **`reset_fast()` vs `reset()`**: The fast reset sets only `seq_len = 0` without zeroing. The caller is responsible for not reading stale data. This is correct because every position up to `seq_len` is written before being read. Saves ~7 ms for a 4096-token cache on M3.
 4. **256-token page granularity in PagedKVCache**: Balances internal fragmentation (larger pages = more waste for short sequences) against management overhead (smaller pages = more entries in the page table and LRU structure). 256 tokens at 128 head_dim × 8 heads × 2 sides × 4 bytes = 2 MB per page — fits one huge page on Linux.
@@ -103,12 +129,18 @@ Provide **two complementary KV cache implementations**: `FlatKVCache` for single
 
 **Negative**:
 
-- `FlatKVCache` reserves full memory for `max_seq_len` at construction regardless of actual sequence length. For Qwen3-0.6B with 4096 max tokens, this is 896 MB — always, even for a 10-token sequence.
+- `FlatKVCache` reserves full memory for `max_seq_len` at construction regardless of
+  actual sequence length. [CORRECTED: for Qwen3-0.6B with 4096 max tokens, this is
+  **~448 MB** (f16 storage, 2 bytes/element) — always, even for a 10-token sequence.
+  The original ADR stated 896 MB (f32). The f16 change halved the footprint.]
 - Two cache types mean two code paths to maintain and test.
 
 **Risks**:
 
-- The 896 MB flat cache footprint makes `QwenModel` unsuitable for memory-constrained deployments. Consumers must pass a smaller `max_seq_len` if they need to fit within a tighter budget.
+- [CORRECTED: the flat cache footprint for Qwen3-0.6B at 4096 tokens is ~448 MB (f16),
+  not 896 MB (f32). The guidance stands: consumers must pass a smaller `max_seq_len`
+  for memory-constrained deployments, but the budget is now approximately half what
+  the original ADR implied.]
 - `reset_fast()` is safe only if the caller guarantees it writes all positions before reading them. A bug that reads a stale position will produce wrong attention — no memory safety violation, but wrong outputs with no error signal.
 
 ---

--- a/docs/adr/ADR-006-speculative-decoding.md
+++ b/docs/adr/ADR-006-speculative-decoding.md
@@ -4,6 +4,14 @@
 **Date**: 2026-05-13\
 **Crate**: `lattice-inference`
 
+## Amendment (2026-06-24)
+
+The Risks section originally stated that `mtp_apply_partial_rope()` uses
+**interleaved pairs `(2i, 2i+1)`**. This was incorrect as of the v0.2.3
+RoPE-convention fix. The function now uses **split-half `(i, half+i)`**, matching
+the main-model convention. See ADR-007 Amendment for full context. The inline
+correction is marked with `[CORRECTED]` in the Risks section below.
+
 ---
 
 ## Context
@@ -93,7 +101,11 @@ Implement **two-tier speculative decoding**: `NgramSpeculator` (zero training, p
 
 **Risks**:
 
-- The MTP layer's partial RoPE implementation (`mtp_apply_partial_rope()`) uses interleaved pairs `(2i, 2i+1)` — distinct from the target model's split-half RoPE. A bug that applies the wrong RoPE pattern to MTP will produce quietly wrong draft tokens with high rejection rates, not a crash.
+- [CORRECTED: `mtp_apply_partial_rope()` now uses split-half `(i, half+i)`, matching
+  the target model's convention — not interleaved `(2i, 2i+1)` as the original ADR
+  stated. The residual risk is unchanged in character: applying the wrong pairing
+  convention to MTP produces quietly wrong draft tokens with high rejection rates, not
+  a crash. As of v0.2.3, the correct convention is split-half.]
 
 ---
 

--- a/docs/adr/ADR-007-rope-positional-encoding.md
+++ b/docs/adr/ADR-007-rope-positional-encoding.md
@@ -4,6 +4,25 @@
 **Date**: 2026-05-13\
 **Crate**: `lattice-inference`
 
+## Amendment (2026-06-24)
+
+The original ADR (Decision point 6 and the Consequences section) documented that
+`MtpVerifier` uses **interleaved pairs `(2i, 2i+1)`** for partial RoPE. This was
+**incorrect as of the v0.2.3 RoPE-convention fix**. The MTP partial RoPE path
+(`speculative.rs:mtp_apply_partial_rope`) now uses **split-half `(i, half+i)`**,
+matching the main-model convention. The code comment on that function reads:
+"Stride-half partial RoPE: rotate pairs (i, half+i) for i in 0..rope_dim/2 —
+matches HF rotate_half / MLX traditional=False."
+
+**Do not reintroduce interleaved pairing to `mtp_apply_partial_rope`.** The v0.2.3
+bug was the interleaved `(2i, 2i+1)` variant; the fix is split-half `(i, half+i)`.
+Cross-reference: the "Differential Test First" section of `CLAUDE.md` in this repo
+documents the v0.2.3 RoPE-convention fix and the diagnostic method used to identify
+the pairing mismatch.
+
+The original Decision and Context text is preserved below as a historical record.
+Inline corrections to the false statements are marked with `[CORRECTED]`.
+
 ---
 
 ## Context
@@ -46,7 +65,10 @@ Tests in `src/rope.rs` verify:
 - Norm preservation (rotation is an isometry)
 - Precision to 1e-6 vs f64 reference up to position 262,143
 
-The MtpVerifier in `src/speculative.rs` uses a separate partial RoPE application (`mtp_apply_partial_rope()`) that applies rotation only to the first `rope_dim` dimensions (25% of `head_dim`) using interleaved pairs `(2i, 2i+1)`.
+The MtpVerifier in `src/speculative.rs` uses a separate partial RoPE application
+(`mtp_apply_partial_rope()`) that applies rotation only to the first `rope_dim`
+dimensions (25% of `head_dim`). [CORRECTED: uses split-half pairs `(i, half+i)`,
+not interleaved `(2i, 2i+1)` — see Amendment above.]
 
 ---
 
@@ -63,7 +85,12 @@ Precompute RoPE frequency tables at model initialization in **f64 precision, sto
 3. **Precomputed table**: The table for Qwen3-0.6B is `32,768 × 64 (half_dim)` f32 entries × 2 (cos+sin) × 4 bytes = 16 MB. This is modest and avoids computing `cos(pos * freq[i])` in the hot path (transcendentals are expensive: ~20–80 cycles vs ~1 cycle for a table lookup).
 4. **θ=1,000,000 for Qwen3**: YaRN and similar extended-context RoPE variants use higher theta values to reduce the rotation speed of high-frequency dimensions, extending the effective context window beyond the training length. Qwen3 is trained with θ=1,000,000 and `max_position_embeddings=32,768`.
 5. **Immutable after construction**: `RopeTable` is constructed once and shared as `&RopeTable`. No locking. The apply method takes `&mut [f32]` (the head buffer) and `&self`, making parallelism straightforward.
-6. **MtpVerifier uses interleaved pairs for partial RoPE**: This is an exception to the split-half convention, dictated by the MTP architecture spec. It applies to only 25% of dimensions (`rope_dim = partial_rotary_factor * head_dim`). The interleaved and split-half conventions produce different outputs; mixing them would produce wrong attention.
+6. **MtpVerifier partial RoPE uses split-half `(i, half+i)`** [CORRECTED: the
+   original ADR stated "interleaved pairs `(2i, 2i+1)` — an exception to the
+   split-half convention." This was wrong. After the v0.2.3 fix, `mtp_apply_partial_rope`
+   uses split-half `(i, half+i)`, identical in pairing style to the main-model
+   `RopeTable::apply`. It applies to only 25% of dimensions (`rope_dim = partial_rotary_factor * head_dim`).
+   There is no longer a pairing-convention exception for the MTP path.]
 
 ---
 
@@ -92,18 +119,25 @@ Precompute RoPE frequency tables at model initialization in **f64 precision, sto
 **Negative**:
 
 - 16 MB table per model in steady state. For a system running five concurrent models, this is 80 MB of RoPE tables alone.
-- Two RoPE conventions in the codebase (split-half for main path, interleaved for MTP partial RoPE) require careful documentation to avoid future bugs.
+- [CORRECTED: as of v0.2.3, there is only one pairing convention in the codebase:
+  split-half `(i, half+i)` for both the main-model path and the MTP partial RoPE path.
+  The original concern about two conflicting conventions no longer applies.]
 
 **Risks**:
 
 - If a future model uses a non-standard theta schedule (e.g., NTK-aware interpolation with frequency-dependent theta), the current `RopeTable::new()` API accepts only a single scalar theta. The API must be extended.
-- The MTP interleaved partial RoPE is distinct from the main split-half RoPE. A refactor that "unifies" the RoPE code without checking the MTP path could silently break speculative decoding.
+- [CORRECTED: MTP partial RoPE is now split-half, not interleaved. The residual risk
+  is the inverse: a future refactor that "unifies" MTP with the main RoPE path could
+  accidentally reintroduce the interleaved bug. The function `mtp_apply_partial_rope`
+  is intentionally separate to apply RoPE to only `rope_dim` (25%) of dimensions;
+  do not merge it with `RopeTable::apply` without verifying the partial-dimension
+  contract is preserved.]
 
 ---
 
 ## References
 
 - `src/rope.rs` — `RopeTable`, `new()`, `apply()`, test suite
-- `src/speculative.rs` — `mtp_apply_partial_rope()`, interleaved-pair convention, `partial_rotary_factor=0.25`
+- `src/speculative.rs` — `mtp_apply_partial_rope()`, split-half convention `(i, half+i)`, `partial_rotary_factor=0.25` [CORRECTED from "interleaved-pair convention"]
 - Su et al. 2021 — "RoFormer: Enhanced Transformer with Rotary Position Embedding" — https://arxiv.org/abs/2104.09864
 - Qwen3 technical report — theta=1,000,000, max_position_embeddings=32,768


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

**Highest priority — RoPE correctness trap (ADR-006 and ADR-007):** Both ADRs
previously stated that `mtp_apply_partial_rope()` uses interleaved pairs `(2i, 2i+1)`
"by design" and called it "an exception to the split-half convention." That sentence
was a correctness trap: a contributor reading it would have a written rationale to
reintroduce the v0.2.3 bug. The current code (verified: `speculative.rs:mtp_apply_partial_rope`
lines 1129-1137) uses split-half `(i, half+i)`, matching the main-model convention.
Both ADRs now say so explicitly, with a warning not to reintroduce interleaved pairing.

**ADR-004 — KV cache f16 storage and Result-returning mutators:** The ADR described
`FlatKVCache` with `Vec<Vec<f32>>` storage and an infallible `append_kv() -> ()`.
The implementation (verified: `flat.rs` lines 10-13, 76-78, 142-180) stores f16, and
`append_kv` returns `Result<usize, InferenceError>` (#290/#298). Three mentions of
896 MB corrected to ~448 MB (f16 = 2 bytes, not f32 = 4 bytes). The allocation-free
hot-path property is preserved.

## Changes

- `docs/adr/ADR-007-rope-positional-encoding.md` — Amendment header; corrected Context
  paragraph, Decision point 6, Consequences negative point, Risks section, and
  References entry (all claimed interleaved; all now say split-half).
- `docs/adr/ADR-006-speculative-decoding.md` — Amendment header; corrected Risks section
  interleaved claim.
- `docs/adr/ADR-004-kv-cache.md` — Amendment header; corrected struct layout (f16),
  footprint formula (448 MB), `append_kv` signature, Key Design Choice 1, and two
  further 896 MB mentions in Consequences/Risks.

Original Decision/Context text is preserved as historical record. False sentences are
corrected in-place with `[CORRECTED]` markers so a reader scanning the body is not
misled.

## Validation

- `git diff --stat` shows exactly 3 `.md` files, zero `.rs` files.
- `deno fmt --check` passes on all three files (also confirmed by pre-commit hook).
- Code verified before writing: `speculative.rs:mtp_apply_partial_rope` confirmed
  split-half; `flat.rs` confirmed f16 storage, `Result`-returning mutators, and
  ~448 MB test assertion.

Resolves #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)