### PR TITLE
docs(adr): reconcile stale Status fields and aspirational claims (#301, #302)

### DIFF
--- a/docs/adr/ADR-001-pure-rust-transformer-engine.md
+++ b/docs/adr/ADR-001-pure-rust-transformer-engine.md
@@ -13,7 +13,7 @@ Python, no external runtime.
 
 ## Decision
 
-### Pure Rust, 57.5K LOC
+### Pure Rust, ~104K LOC [CORRECTED: was 57.5K at initial commit; `find crates/inference/src -name '*.rs' | xargs wc -l` as of 2026-06-24 yields ~103,775 lines]
 
 The engine implements the full transformer forward pass:
 

--- a/docs/adr/ADR-014-embedding-service.md
+++ b/docs/adr/ADR-014-embedding-service.md
@@ -60,6 +60,16 @@ divergence between current and reference embedding distributions. Used for:
 Not yet wired into production — the algorithms are proven and tested,
 awaiting integration into the embedding pipeline.
 
+## Implementation status (2026-06-24)
+
+The `EmbeddingService` trait, `NativeEmbeddingService`, and `CachedEmbeddingService` are
+implemented at `crates/embed/src/service/` (native.rs, cached.rs). The transport/drift submodule
+shown in §Decision as `embed/src/service/transport/` was not placed there. Optimal transport
+and drift detection shipped as a standalone crate: `crates/transport/src/` (sinkhorn.rs,
+divergence.rs, barycenter.rs, online_drift.rs, etc.). The embedding crate (`crates/embed/`) does
+not import `crates/transport/`; wiring drift detection into the embedding pipeline remains
+a future step.
+
 ## Consequences
 
 - `ml/embed` is the only crate that imports `ml/inference`.

--- a/docs/adr/ADR-028-teacher-providers.md
+++ b/docs/adr/ADR-028-teacher-providers.md
@@ -135,6 +135,15 @@ pub trait Teacher {
 provider set. If provider count exceeds 6-8, this alternative should be revisited. The
 `Custom(String)` variant provides escape hatch for unforeseen providers.
 
+## Implementation status (2026-06-24)
+
+`TeacherConfig`, `TeacherProvider`, and `EndpointSecurity` are implemented at
+`crates/tune/src/distill/teacher/config.rs` and `security.rs`. However, actual HTTP API calls
+to teacher providers are placeholders. `crates/tune/src/distill/pipeline/distill.rs:12` states:
+"This is a placeholder implementation. The actual API calls would need to be implemented with a
+proper HTTP client like `reqwest`." No `reqwest` or HTTP client dependency is wired. The
+`DistillationPipeline::label_single` and `label_batch` methods do not make real network calls.
+
 ## References
 
 - TeacherConfig: `crates/tune/src/distill/teacher.rs`

--- a/docs/adr/ADR-030-knowledge-distillation.md
+++ b/docs/adr/ADR-030-knowledge-distillation.md
@@ -91,6 +91,15 @@ The method pairs them by index (returns `TuneError::DimensionMismatch` on length
 - `to_training_examples` uses index-aligned slices (results, context_embeddings, message_embeddings). If the caller filters results before passing them, the index alignment breaks. The `DimensionMismatch` error catches length mismatches but not index-misalignment bugs where lengths happen to match after filtering.
 - `MAX_PROMPT_LENGTH = 50_000` is conservative for most teacher APIs but may need adjustment for context-heavy conversations with many messages.
 
+## Implementation status (2026-06-24)
+
+The data contract (`LabelingResult`, `TrainingExample`, `DistillationStats`) and the
+`DistillationPipeline` struct are fully defined and tested. Actual HTTP teacher calls remain
+placeholder: `crates/tune/src/distill/pipeline/distill.rs:65` comments "This is a placeholder
+— actual implementation would call the teacher API." No `reqwest` HTTP requests are made; the
+`label_single` and `label_batch` methods do not hit any external endpoint. The pipeline struct
+and config presets are ready for wiring once a real HTTP client is added.
+
 ## References
 
 - `crates/tune/src/distill/pipeline/distill.rs` — `DistillationPipeline`, `label_single`, `label_batch`, `to_training_examples`

--- a/docs/adr/ADR-031-lora-adapter-management.md
+++ b/docs/adr/ADR-031-lora-adapter-management.md
@@ -20,7 +20,7 @@ Three-layer design: `LoraConfig` (global config), `LoraLayer` (per-projection we
 
 #### LoraConfig and Scaling
 
-`LoraConfig` holds `rank: usize`, `alpha: f32`, and `target_modules: Vec<String>`. The effective scaling factor is `alpha / rank`. When loading from PEFT safetensors, `alpha` defaults to `rank` (so `scale = 1.0`), matching PEFT's default behavior. Callers can override `alpha` post-load for explicit scaling.
+`LoraConfig` holds `rank: usize`, `alpha: f32`, and `target_modules: Vec<String>`. The effective scaling factor is `alpha / rank`. [CORRECTED: as of commit a91a7c05] When loading from PEFT safetensors, `alpha` is now read from the safetensors header metadata (`crates/tune/src/lora/safetensors.rs:403`). If the header contains no `alpha` key (e.g. raw PEFT exports), the loader falls back to `alpha = rank` so `scale = 1.0`, matching PEFT's default behavior. Callers can still override `alpha` post-load for explicit scaling.
 
 `LoraConfig::scale()` guards against `rank == 0` by returning `0.0` rather than dividing by zero.
 

--- a/docs/adr/ADR-033-jit-adaptation.md
+++ b/docs/adr/ADR-033-jit-adaptation.md
@@ -27,7 +27,7 @@ JIT here means "triggered at inference time" — not LLVM JIT or kernel JIT. The
 | `LastNLayers(n)` (default: 2) | Last N layers trainable, earlier frozen                           | Standard adaptation with stability                          |
 | `HeadOnly`                    | Only the classification head (last layer)                         | Fastest, minimum parameter update                           |
 | `GradualUnfreeze`             | All layers, LR scales linearly from `frozen_lr_multiplier` to 1.0 | When earlier layers also need adaptation                    |
-| `LowRank { rank }`            | All base weights frozen; low-rank delta matrices                  | LoRA-style adaptation (in-memory, not saved as safetensors) |
+| `LowRank { rank }`            | All base weights frozen; low-rank delta matrices (not yet implemented — see §Consequences/Negative) | LoRA-style adaptation (in-memory, not saved as safetensors) |
 | `Full`                        | All parameters                                                    | Maximum adaptation, slowest                                 |
 
 `freeze::get_frozen_layers(strategy, total_layers) -> Vec<bool>` returns a per-layer freeze mask. `freeze::get_lr_multipliers(strategy, total_layers, frozen_mult) -> Vec<f32>` returns per-layer learning rate scale factors. For `GradualUnfreeze`, multipliers are linearly interpolated from `frozen_lr_multiplier` at layer 0 to `1.0` at the last layer.

--- a/docs/adr/ADR-045-quarot-lora-composition.md
+++ b/docs/adr/ADR-045-quarot-lora-composition.md
@@ -20,7 +20,7 @@ The next step is **LoRA adapter injection on top of the QuaRot Q4 base**. This c
 | `LoraConfig` (rank, alpha, targets) | `crates/tune/src/lora/mod.rs` | Active |
 | CPU forward LoRA injection | `crates/inference/src/model/qwen35/model.rs:17` | Active — `Qwen35Model.lora` field, called per projection |
 | Metal Q4 forward path | `crates/inference/src/forward/metal_qwen35.rs` | Active — LoRA dispatch after each projection (PR #37) |
-| QuaRot seed in artifact | `config.json` in quantize_quarot output | **NOT YET PERSISTED** — caller must supply seed explicitly (see §Prerequisites) |
+| QuaRot seed in artifact | `config.json` in quantize_quarot output | Shipped — `inject_quarot_seed` at `crates/inference/src/quant/quarot/convert.rs:136` writes the seed into the output `config.json` under both `text_config` and top-level keys |
 | `RandomizedHadamard` reconstruction | `crates/inference/src/quant/quarot/` | Active — deterministic from seed |
 
 ### Gaps (remaining)
@@ -230,7 +230,7 @@ When `quarot_seed` is `None` (unrotated Q4 base): skip rotation correction, uplo
 | 3 | `MetalQwen35State::load_lora_adapter` API: orchestrates rotation + buffer upload + Rust dispatch wrapper | **Done** (PR #36) |
 | 4 | Forward path integration: dispatch LoRA kernel after each adapted Q4 GEMV | **Done** (PR #37) |
 | 5 | End-to-end validation: PPL with adapter vs CPU reference path | Pending |
-| 6 | `bin/chat_metal` adapter flag: `--lora-dir <PATH>` for interactive use | Pending |
+| 6 | `bin/chat_metal` adapter flag: `--lora-dir <PATH>` for interactive use | Done — `--lora` flag implemented at `crates/inference/src/bin/chat_metal.rs:405` |
 
 Steps 1-4 complete. Prefill falls back to sequential when adapter active (no batch LoRA kernel).
 `in_proj_b`/`in_proj_a` rejected at load time (consumed inside fused kernels).

--- a/docs/adr/ADR-047-paged-kv-cache.md
+++ b/docs/adr/ADR-047-paged-kv-cache.md
@@ -3,7 +3,9 @@
 **Status**: Accepted (KV element format superseded by ADR-062 for f16/int8/int4)
 **Date**: 2026-05-19
 **Crate**: `lattice-inference`
-**Amendment (2026-05-27)**: ADR-062 replaces `Arc<[f32]>` page storage with format-parameterized `KvFormat` (f16/int8/int4). The page adapter namespacing, LRU ownership, restore/promote semantics, and 256-token multi-sequence page design remain unchanged. `PrefixPageCache` `prefix_page_size` (default 64 tokens, `prefix.rs:111`) is the authoritative prefix matching granularity.
+**Amendment (2026-05-27)**: ADR-062 proposes replacing `Arc<[f32]>` page storage with format-parameterized `KvFormat` (f16/int8/int4). The page adapter namespacing, LRU ownership, restore/promote semantics, and 256-token multi-sequence page design remain unchanged. `PrefixPageCache` `prefix_page_size` (default 64 tokens, `prefix.rs:111`) is the authoritative prefix matching granularity.
+
+**Implementation note (2026-06-24)**: The KvFormat amendment is a forward plan. As of this date, `crates/inference/src/kv_cache/prefix.rs:60` still stores `Arc<[f32]>` pages. ADR-062 itself was not built (see ADR-062 §Implementation status).
 
 ---
 

--- a/docs/adr/ADR-055-online-drift-detection.md
+++ b/docs/adr/ADR-055-online-drift-detection.md
@@ -231,3 +231,13 @@ receives `Vec<f32>` values. Enforcement: `crates/transport/Cargo.toml` must neve
 - Genevay, Peyré, Cuturi, "Learning Generative Models with Sinkhorn Divergences", AISTATS 2018
 - Feydy et al., "Interpolating between Optimal Transport and MMD using Sinkhorn Divergences",
   AISTATS 2019 — positive semi-definiteness proof used to justify divergence thresholding
+
+## Implementation status (2026-06-24)
+
+`OnlineDriftDetector` is fully implemented at `crates/transport/src/online_drift.rs:109` and
+re-exported from `crates/transport/src/lib.rs:119`. The `DriftSampler` bridge trait described
+in §"Layer 1: `lattice-inference`" was not built. Searching `crates/inference/src/` for
+`DriftSampler` returns no results. The inference forward pass has no `Arc<dyn DriftSampler>`
+hook. The end-to-end drift sampling path (inference → transport → reaction) described in this
+ADR's architecture exists only in `lattice-transport`; the inference-side callback boundary
+and application-level wiring remain unimplemented.

--- a/docs/adr/ADR-056-lora-tuning-pipeline.md
+++ b/docs/adr/ADR-056-lora-tuning-pipeline.md
@@ -722,3 +722,14 @@ changes require a new ADR.
 - ADR-054 — Rotation-Aware LoRA Training (RoLoRA; depends on this ADR)
 - Hu et al. 2021 — "LoRA: Low-Rank Adaptation of Large Language Models" — https://arxiv.org/abs/2106.09685
 - Dettmers et al. 2023 — "QLoRA: Efficient Finetuning of Quantized LLMs" — https://arxiv.org/abs/2305.14314
+
+## Implementation status (2026-06-24)
+
+The `LoraTrainLoop` struct and the `train/lora/` directory proposed in this ADR were never
+created. Real backward-pass LoRA training shipped via a different code path:
+`crates/tune/src/bin/train_grad_full.rs` is the training binary, and backward pass primitives
+live under `crates/tune/src/` (lora/, train/ sub-directories). The
+`crates/inference/src/backward/` module (attention_gqa.rs, gradcheck.rs, ops.rs, tape.rs)
+holds the autograd tape. Anyone extending LoRA training should start from
+`crates/tune/src/bin/train_grad_full.rs` and `crates/tune/src/lora/online.rs`, not from
+the `LoraTrainLoop` / `train/lora/` paths described in this ADR's architecture section.

--- a/docs/adr/ADR-057-lora-consumer-api.md
+++ b/docs/adr/ADR-057-lora-consumer-api.md
@@ -1,8 +1,16 @@
 # ADR-057: LoRA Full-Lifecycle Consumer API
 
-**Status**: Draft
+**Status**: Accepted
 **Date**: 2026-05-23
 **Crate**: lattice-tune, lattice-inference
+
+## Status update (2026-06-24)
+
+All five lifecycle gaps described in §Context were closed. `save_peft_safetensors` is
+public at `crates/tune/src/lora/safetensors.rs:439`. `adapt_step` (online gradient step)
+ships at `crates/tune/src/lora/online.rs:38`. The BERT hook, consumer docs, and
+inference-hook feature gate shipped across D1–D5 (see KG entity `LoraConsumerAPI`).
+Status promoted from Draft to Accepted.
 
 ## Context
 

--- a/docs/adr/ADR-058-cpu-perf-regression-ci.md
+++ b/docs/adr/ADR-058-cpu-perf-regression-ci.md
@@ -1,8 +1,17 @@
 # ADR-058: CPU Performance Regression Tracking in CI
 
-**Status**: Draft
+**Status**: Superseded
 **Date**: 2026-05-24
 **Crate**: workspace (CI infrastructure, touches lattice-inference + lattice-embed bench surfaces)
+
+## Status update (2026-06-24)
+
+The proposed `bench-regression.yml` workflow was never created (confirmed: `ls .github/workflows/`
+shows `app-binaries.yml`, `bench-update.yml`, `ci.yml`, `e2e-parity.yml` — no
+`bench-regression.yml`). The actual regression gate shipped as `.github/workflows/e2e-parity.yml`
+(PR #192), which runs HF transformers vs lattice on the same macOS runner and requires first-3-token
+greedy parity. Criterion micro-benchmarks are collected as trend data by `bench-update.yml` but are
+not a merge gate. This ADR's CPU-bench-as-gate design was superseded by the e2e-parity approach.
 
 ## Context
 

--- a/docs/adr/ADR-060-pruning-toolbox.md
+++ b/docs/adr/ADR-060-pruning-toolbox.md
@@ -676,3 +676,14 @@ lattice_pruning.json        # method, sparsity stats
 - Lottery Ticket Hypothesis: `6b08bfba`
 - QuaRot (existing): `e754741e`
 - lattice-inference (existing): `6c0a97df`
+
+## Implementation status (2026-06-24)
+
+Only the D2 ShortGPT block-influence scorer has shipped. `BlockInfluence` and
+`BlockInfluenceAccumulator` are implemented at `crates/inference/src/pruning.rs:62` and `121`.
+The `CalibrationObserver` trait (D1/P0), `Wanda` per-channel activation scorer, and `SliceGPT`
+PCA-rotation infrastructure are not present in source — `pruning.rs` module doc notes that
+`CalibrationObserver` and `ForwardCtx` hooks are "ADR-060 D1/P0 work (future PR)". Grep for
+`Wanda`, `SliceGPT`, and `CalibrationObserver` in `crates/` returns no type definitions. The
+`OrthogonalBasis` trait and `BasisKind` enum referenced in the ADR-044 Amendment are also not
+yet implemented (they are a design proposal).

--- a/docs/adr/ADR-061-inference-metrics-infrastructure.md
+++ b/docs/adr/ADR-061-inference-metrics-infrastructure.md
@@ -7,6 +7,18 @@
 **Depends on**: ADR-059 (ModelSpec, ForwardCtx, LayerMetrics schema — **ADR-061 is the authoritative source for LayerMetrics**)
 **Consumed by**: ADR-060 (Structured Pruning uses CheapOnline metrics as scoring substrate)
 
+## Implementation status (2026-06-24)
+
+Phase 1 is partially shipped. `LayerMetrics` and `ForwardMetrics` exist at
+`crates/inference/src/metrics.rs:30` and `56` respectively. `MetricsMode` (Off / CheapOnline /
+AttentionProfile / HeavyDiagnostics) and `OnlineSoftmaxEntropy` accumulator are implemented in the
+same file. `BlockInfluence` and `BlockInfluenceAccumulator` ship at `crates/inference/src/pruning.rs:62`
+and `121`. `AttentionEntropy` as a standalone type was never created; attention entropy is stored as a
+field (`entropy: Option<Vec<f32>>`) on `LayerMetrics`. The `MetricSink` trait, SQLite recorder, JSONL
+event writer, and the experiment runner CLI (Phases 2–5) are not yet built. The `CalibrationObserver`
+trait and `ForwardCtx` hooks are described in the `pruning.rs` module doc as "ADR-060 D1/P0 work
+(future PR)" and are not present in source as of this date.
+
 ## Context
 
 Lattice's current observability surface is PPL (strided sliding-window, ADR-044 step 4) and wall-clock throughput (bench scripts via `scripts/bench-compare.sh`). This is sufficient for "config A has PPL X, config B has PPL Y" but insufficient for _architectural insight_: which layers are doing useful work, which heads are redundant, where the memory bandwidth bottleneck is, and whether a given layer is a candidate for replacement, removal, or compression.

--- a/docs/adr/ADR-062-metal-fa2-prefill.md
+++ b/docs/adr/ADR-062-metal-fa2-prefill.md
@@ -1,11 +1,22 @@
 # ADR-062: Metal FlashAttention-2 Prefill + KV Cache Quantization Chain
 
-**Status**: Proposed
+**Status**: Proposed (partially superseded — see implementation status below)
 **Date**: 2026-05-27
 **Crate**: lattice-inference (Metal shaders, KV cache). Phase 0 proposes extracting shaders into a `crates/lattice-metal/` directory tree. **This introduces a new workspace member** — see Crate Layout below for dependency direction, feature gating, and publish-order consequences. If the team prefers keeping shaders inside `crates/inference/`, the same file structure applies under `crates/inference/src/metal/` without a new crate.
 **Research**: RQ-4 (`workspaces/20260527/04.md`)
 **Issues**: #126 (Metal FA2 prefill), #85 (MLX kernel study), #86 (shader extraction)
 **KG entities**: `Metal FA2 Prefill` (0dfbc841), `Metal Fused Attention` (48ee18b2), `FlashAttention-2` (63602a7f), `Chunked Prefill` (018193b3)
+
+## Implementation status (2026-06-24)
+
+The prefill bottleneck described in §Context was solved by a different mechanism than the FA2
+Metal shader proposed here. The shipped solution is chunked batched prefill:
+`forward_prefill_batched_chunk` at `crates/inference/src/forward/metal_qwen35.rs:7878` (PR #228,
+1.78× TTFT improvement). Tiled Q4 GEMM landing on Apple7+ (PRs #265/#270/#283) further reduced
+prefill time. The full Metal FA2 kernel (new shader extraction into `crates/lattice-metal/`) and
+KV-cache quantization chain described in this ADR were not built; `prefix.rs:60` still stores
+`Arc<[f32]>` pages. The ADR remains as the historical design proposal; its KV-quant chain is an
+open future direction.
 
 ---
 

--- a/docs/adr/ADR-063-serving-architecture.md
+++ b/docs/adr/ADR-063-serving-architecture.md
@@ -3,6 +3,13 @@
 **Status**: Proposed
 **Date**: 2026-05-27
 **Crate**: lattice-inference (new `serve` module + unified binary)
+
+## Implementation status (2026-06-24)
+
+Phase 1 batch scheduling infrastructure is implemented. `crates/inference/src/batch/` exists with
+`config.rs`, `mod.rs`, `scheduler.rs`, `sequence.rs`, and `worker.rs`. Phase 2 (HTTP server,
+OpenAI/Anthropic API compatibility, GPU worker pool) has not been built. There is no `serve` binary
+or HTTP listener in the codebase as of this date.
 **Research**: RQ-5 (`workspaces/20260527/05.md`, 1583 lines)
 **Issues**: #91 (CLI), #92 (daemon), #93 (OpenAI API), #94 (Anthropic API)
 **Depends on**: ADR-048 (Continuous Batching), ADR-046 (XGrammar Structured Output), ADR-047 (Paged KV Cache)


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Resolves the second wave of the 2026-06-24 doc/ADR alignment audit: ADRs whose **Status** field or architecture claims no longer match the code. Docs-only — 16 ADR files, zero `.rs`. Each edit was source-verified against the live code (file:line cited in every note); claims that didn't hold were rejected, not papered over.

Closes #301. Closes #302.

## #301 — Status hygiene (shipped/superseded ADRs mislabeled)

| ADR | Was | Now | Evidence |
|-----|-----|-----|----------|
| ADR-057 lora-consumer-api | Draft | **Accepted** | `save_peft_safetensors` @ `tune/src/lora/safetensors.rs:439`, `adapt_step` @ `online.rs:38` |
| ADR-058 cpu-perf-regression-ci | Draft | **Superseded** | `bench-regression.yml` never created; real gate is `e2e-parity.yml` (#192) |
| ADR-061 inference-metrics | Proposed | Proposed + impl-status | `LayerMetrics` @ `metrics.rs:30`, `BlockInfluence` @ `pruning.rs:62` shipped; `AttentionEntropy`-type / `MetricSink` / runner CLI not built |
| ADR-062 metal-fa2-prefill | Proposed | Proposed (partially superseded) | prefill solved by `forward_prefill_batched_chunk` @ `metal_qwen35.rs:7878` (#228) + tiled GEMM (#265/#270/#283); FA2 shader + KV-quant chain not built |
| ADR-063 serving-architecture | Proposed | Proposed + impl-status | Phase 1 `inference/src/batch/` shipped; Phase 2 HTTP/GPU worker not |
| ADR-031 lora-adapter-management | "alpha defaults to rank" | corrected | alpha now read from safetensors header @ `safetensors.rs:403`, falls back to rank if absent |
| ADR-045 quarot-lora-composition | seed "NOT YET PERSISTED", step 6 pending | both done | `inject_quarot_seed` @ `convert.rs:136`; `--lora` @ `chat_metal.rs:405` |
| ADR-047 paged-kv-cache | amendment claims f16/int8/int4 pages | reconciled | `prefix.rs:60` still `Arc<[f32]>`; amendment is a forward plan |
| ADR-001 pure-rust-engine | "57.5K LOC" | "~104K LOC" | `find crates/inference/src -name '*.rs' \| xargs wc -l` = 103,775 |

## #302 — "Accepted" ADRs describing unbuilt architecture (added honest Implementation-status sections)

| ADR | Claimed | Reality |
|-----|---------|---------|
| ADR-056 lora-tuning-pipeline | `train/lora/LoraTrainLoop` | never created; real path is `tune/src/bin/train_grad_full.rs` + `inference/src/backward/` |
| ADR-033 jit-adaptation | `LowRank` trains A/B matrices | only freezes base weights; training infra lives in `inference/backward/` |
| ADR-055 online-drift-detection | end-to-end drift sampling | `OnlineDriftDetector` @ `transport/src/online_drift.rs:109` exists; `DriftSampler` inference bridge absent |
| ADR-028 / ADR-030 distillation | multi-provider HTTP teacher | structs exist; HTTP calls are placeholders (`distill.rs:12-13,65` — no `reqwest` wired) |
| ADR-060 pruning-toolbox | full toolbox (Wanda, SliceGPT, CalibrationObserver) | only ShortGPT `BlockInfluence` @ `pruning.rs:62` shipped |
| ADR-014 embedding-service | transport at `embed/src/service/transport/` | real path `crates/transport/src/`; embed does not import transport |

## TBV notes

- The implementer caught two **protective omissions**, both confirmed: (a) ADR-044's "NOT YET PERSISTED" prerequisite text is actually in ADR-045, not 044 — edited 045, left 044 untouched rather than edit on non-existent text; (b) the audit's "ADR-061 has no metrics types" premise was partly wrong — `LayerMetrics`/`BlockInfluence` do exist, so the note distinguishes what shipped from what didn't instead of claiming full non-implementation.
- Orchestrator fixed two structural placements post-review (ADR-061/062 section ordering) so no metadata or `## Context` heading was orphaned.

Convention follows ADR-047's amendment style and PR #307: preserve the historical decision record, mark factual corrections inline with `[CORRECTED]` or in a dated `## Implementation status` / `## Status update` section. e2e-parity correctly skips (no engine source changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
