### PR TITLE
docs: inference + transport READMEs and forward-pass walkthrough (#304)

### DIFF
--- a/crates/inference/README.md
+++ b/crates/inference/README.md
@@ -1,0 +1,99 @@
+# lattice-inference — Contributor Map
+
+**Stability tier: Experimental.** This crate has high churn, 153 `unsafe` blocks, and 22
+`dead_code_allows`. It is NOT intended for direct use by platform or feature crates.
+Consumers should go through `lattice-embed`. The unsafe blocks are documented in
+`foundation/STABILITY.md §Tech Debt`. Tracking issue: #1306.
+See `foundation/STABILITY.md` for the full stability policy.
+
+If you are trying to generate embeddings in an application, start with `lattice-embed`, not
+this crate. The README you are reading is a contributor's map for people opening PRs on the
+inference engine itself.
+
+---
+
+## Module Map
+
+### Grouped modules
+
+These modules contain submodules (directories with their own `mod.rs`).
+
+| Module | Responsibility |
+|--------|---------------|
+| `attention` | Attention kernel variants: standard MHA, GQA, flash (CPU tiled), flash-causal (decoder prefill), GDN (gated decay network), GDN-fused, native sparse, and differential. Exposes `AttentionTag` for typed dispatch. |
+| `forward` | Compute backends: scalar CPU, NEON (AArch64), Metal (macOS MSL), WGPU, Q8/f16 CPU kernels, tiled GEMM (`metal_gemm`, `gpu_gemm`), batched prefill, and BitNet kernel. Exports `matmul_bt`, `rms_norm`, `silu_inplace`, `elementwise_mul` from the CPU submodule. |
+| `model` | Model configs and loaders: `BertModel`/`BertConfig`, `QwenModel`/`QwenConfig`, `Qwen35Model`, `CrossEncoderModel`, `BitNet` config. Each submodule owns its safetensors load path and forward-pass dispatch. |
+| `tokenizer` | Tokenizer implementations: `WordPieceTokenizer` (BERT), `BpeTokenizer` (Qwen3/GPT-2 byte-level), `SentencePieceTokenizer`. Shared `Tokenizer` trait and `load_tokenizer` auto-detect helper live in `tokenizer/common.rs`. |
+| `vision` | Qwen3-VL vision encoder (ADR-049): ViT forward pass, patch preprocessing, MLP merger, `MultimodalInput` type. CPU-only; Metal GPU path is deferred. |
+| `weights` | Weight storage formats (`Tensor2D`), safetensors memory-mapped loading, f32/f16/Q8/Q4 weight structs, sharded-checkpoint support. |
+
+### Standalone modules
+
+| Module | Responsibility |
+|--------|---------------|
+| `batch` | Continuous batching engine (ADR-048): `BatchWorker`, `FifoScheduler`, `Sequence`, `SequenceManager`, chunked prefill interleaved with decode steps. |
+| `download` | Model file cache and conditional download (`ensure_model_files`). Disabled unless the `download` feature is enabled. |
+| `error` | `InferenceError` — the crate's single error type, re-exported at the crate root. Stable; adding variants is backward-compatible. |
+| `generate` | Text generation loop for Qwen3: `generate()` entry point, `GenerateConfig`, `GenerateOutput`, `forward_with_cache` inner loop, `compute_attention` GQA kernel. |
+| `grammar` | Grammar-constrained decoding (ADR-046): `GrammarEngine` compiles a JSON Schema or GBNF spec to a byte-level PDA, then masks logits via `mask_logits` and advances state via `advance` each decode step. |
+| `kv_cache` | Two KV cache implementations: `FlatKVCache` (contiguous pre-allocated, single request) and `PagedKVCache` (256-token pages, LRU eviction, multi-model serving). Includes `PrefixPageCache` for prefix reuse. |
+| `lora_hook` | `LoraHook` trait: defines the `apply(layer_idx, module, x, output)` contract that the forward pass calls after each linear projection. `NoopLoraHook` is the zero-overhead default. |
+| `metrics` | Inference metrics (ADR-061): `MetricsMode` enum and `LayerMetrics` schema. Zero overhead when `MetricsMode::Off`. |
+| `pool` | Pooling strategies for producing a single embedding vector: `BertPooling` (Mean or CLS), `mean_pool`, `cls_pool`, `last_token_pool` (Qwen3), `l2_normalize`. |
+| `pruning` | ShortGPT block-influence scorer (ADR-060 D2 seed): `BlockInfluenceAccumulator` and `BlockInfluence`. Standalone math; the calibration pipeline hooks are future work. |
+| `quant` | Quantization pre-transforms: `quarot` (Walsh-Hadamard rotation primitives, ADR-044). Not yet wired into the Q4 weight path. |
+| `rope` | Rotary position embeddings: `RopeTable` precomputes sin/cos tables and applies them in-place to Q and K slices before attention. |
+| `sampling` | Token sampling for generation: `Sampler`, `SamplingConfig` (temperature, top-k, top-p, repetition penalty). |
+| `speculative` | N-gram prompt-lookup speculative decoding: `NgramSpeculator::speculate` + `verify_draft` (low-level) and `generate_with_speculation` (high-level wrapper). |
+
+### Feature-gated modules
+
+| Module | Feature flag | Responsibility |
+|--------|-------------|----------------|
+| `backward` | `train-backward` | Reverse-mode autodiff for LoRA training: `tape`, `ops`, `attention_gqa`, `gradcheck`. Submodule of `lattice-tune`'s training loop. |
+
+---
+
+## Supported Architectures
+
+| Architecture | Submodule | Notes |
+|---|---|---|
+| BERT / BGE (encoder-only) | `model/bert.rs` | Bidirectional attention, WordPiece tokenizer, mean or CLS pooling. Covers BGE-small/base/large, E5-small/base, all-MiniLM, paraphrase-multilingual-MiniLM. |
+| Qwen3 / Qwen3.5 (decoder-only) | `model/qwen.rs`, `model/qwen35/` | Causal GQA, RoPE, RMSNorm, SwiGLU FFN, BPE tokenizer, last-token pooling. Covers Qwen3-Embedding-0.6B and 4B. |
+| BitNet | `model/bitnet_config.rs` | 1.58-bit quantized weight architecture. |
+| Qwen3-VL (vision) | `vision/` | ViT patch encoder + MLP merger for multimodal input; CPU-only (ADR-049 v0 scope). |
+| Cross-encoder | `model/cross_encoder.rs` | BERT-style reranker with a classification head on top of the CLS token. |
+
+---
+
+## Where to Start for Common PR Types
+
+**New model architecture.** Add a submodule under `model/` following the pattern in
+`model/qwen.rs` (config struct, weights struct, `load` function, `encode`/`forward` method).
+Wire the new architecture into `lattice-embed`'s `EmbeddingModel` enum when ready.
+
+**Attention kernel change.** Work in `attention/` and `forward/`. A new kernel goes in its
+own file under `attention/` (e.g. `attention/flash_causal.rs`), registers a variant on
+`AttentionTag`, and dispatches from the relevant `forward/` backend. See
+`docs/architecture.md` for the full forward-pass walkthrough before touching this path.
+
+**Sampling or generation.** `sampling.rs` owns the `Sampler` and `SamplingConfig` structs.
+The generate loop in `generate.rs` is where sampling is called; grammar-constrained paths
+also live there.
+
+**LoRA adapter injection.** The `LoraHook` trait in `lora_hook.rs` is the injection point.
+The training-side implementation lives in `crates/tune`. Backward-pass gradients are behind
+the `train-backward` feature in `backward/`.
+
+**Quantization.** Q4 and Q8 weight structs are in `weights/q4_weights.rs` and
+`weights/q8_weights.rs`. Pre-transform math (QuaRot) is in the `quant/quarot/` module
+(`hadamard.rs`, `convert.rs`, `pipeline.rs`). Wiring QuaRot into the Q4 load path is tracked
+in ADR-044.
+
+---
+
+## Cross-References
+
+- `docs/architecture.md` — crate dependency graph, design philosophy, and forward-pass pipeline.
+- `AGENTS.md` — contribution policy, SIMD verification rules, agent attribution requirements.
+- `docs/adr/INDEX.md` — full list of architecture decision records by crate.

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -1,0 +1,121 @@
+# lattice-transport
+
+**Stability tier: Unstable.** The Sinkhorn API is functional but consumed by only one crate.
+API shape may change as Brain Phase 7 Objective synthesis adopts it. The crate will be promoted
+to Stable after a second consumer lands. See `foundation/STABILITY.md` for the full policy.
+
+---
+
+## What This Crate Is
+
+`lattice-transport` implements entropy-regularized optimal transport (Sinkhorn-Knopp algorithm)
+in log-domain for numerical stability. Its primary use case is quantifying how much embedding
+geometry shifts between model versions — for example, when `lattice-embed` swaps from
+BGE-small to mE5-small and needs to detect distribution drift across stored embeddings.
+
+The crate was extracted from `foundation/score` in Wave4 so that Brain Phase 7 Objective
+synthesis can consume optimal-transport primitives independently of the scoring infrastructure.
+
+---
+
+## Boundary Constraints
+
+**f32-only.** All tensor inputs and computation use `f32`. No f16, bf16, or integer paths exist.
+
+**No inference dependency.** `lattice-transport` has zero intra-workspace dependencies. Its
+`Cargo.toml` lists only `rayon` and `serde` as runtime dependencies. It does not depend on
+`lattice-inference`, `lattice-embed`, or any other lattice crate. This isolation is intentional:
+the crate provides pure math primitives that any consumer can take without pulling in the full
+transformer stack.
+
+**No BLAS/LAPACK.** All arithmetic is pure Rust. Log-domain operations prevent numerical
+underflow without external linear algebra libraries.
+
+**Pre-allocated workspaces.** `SinkhornWorkspace` avoids heap allocation during the inner
+iteration loop. Callers create a workspace once and reuse it across calls.
+
+---
+
+## Module Map
+
+| Module | Responsibility |
+|--------|---------------|
+| `sinkhorn` | Core balanced Sinkhorn solver. `SinkhornSolver`, `SinkhornConfig`, `SinkhornWorkspace`, `SinkhornResult`. Also `uniform_weights`, `normalize_weights`. |
+| `sinkhorn_log` | Log-domain solver with epsilon-scaling schedule. `LogDomainSinkhornSolver`, `LogDomainSinkhornConfig`, `EpsilonScalingSchedule`. More numerically stable for small epsilon. |
+| `unbalanced` | KL-relaxed marginal variant. `UnbalancedSinkhornSolver`, `UnbalancedConfig`, `UnbalancedResult`. Useful when source/target marginals are imprecise. |
+| `cost` | Cost matrix abstraction. `CostMatrix` trait, `DenseCostMatrix`, `PairwiseCostMatrix`, `SquaredEuclidean`, `CosineDistance`. |
+| `divergence` | Debiased Sinkhorn divergence. `SinkhornDivergence`, `sinkhorn_divergence`, `point_set_sinkhorn_divergence`. Removes the self-transport bias from raw OT cost. |
+| `transport_plan` | Sparse transport plan extraction. `SparseTransportPlan`, `extract_sparse_plan`, `log_gamma`. |
+| `barycenter` | Wasserstein barycenter computation. `FixedSupportBarycenter`, `FreeSupportBarycenter`, `BarycenterConfig`. |
+| `drift` | High-level embedding drift API. `detect_drift_records`, `detect_drift_memories`, `DriftReport`, `DriftSummary`, `DriftMetricKind`, `PerEntryDisplacement`. |
+| `online_drift` | Streaming (sliding-window) drift detection. `OnlineDriftDetector`, `OnlineDriftConfig`, `OnlineDriftSignal`. Calls `point_set_sinkhorn_divergence` every `check_interval` observations. |
+| `logsumexp` | Stable log-sum-exp arithmetic used throughout the solvers. Internal numeric foundation. |
+| `math` | Internal numeric helpers (private). |
+
+---
+
+## Public Types (re-exported at crate root)
+
+**Sinkhorn solver:**
+`SinkhornSolver`, `SinkhornConfig`, `SinkhornWorkspace`, `SinkhornResult`,
+`BatchSolveResult`, `MarginalPair`, `ProgressObserver`, `ProgressState`,
+`SinkhornError`, `normalize_weights`, `uniform_weights`
+
+**Cost abstractions:**
+`CostMatrix`, `DenseCostMatrix`, `PairwiseCostMatrix`, `ClosureCostMatrix`,
+`ContiguousPoints`, `SquaredEuclidean`, `CosineDistance`, `PointMetric`, `PointSet`, `CostError`
+
+**Log-domain solver:**
+`LogDomainSinkhornSolver`, `LogDomainSinkhornConfig`, `LogDomainSinkhornResult`,
+`EpsilonScalingSchedule`, `EpsilonStageSummary`
+
+**Transport plan:**
+`SparseTransportPlan`, `SparseTransportEntry`, `extract_sparse_plan`, `log_gamma`
+
+**Divergence:**
+`SinkhornDivergence`, `sinkhorn_divergence`, `point_set_sinkhorn_divergence`
+
+**Unbalanced:**
+`UnbalancedSinkhornSolver`, `UnbalancedConfig`, `UnbalancedResult`
+
+**Barycenter:**
+`FixedSupportBarycenter`, `FreeSupportBarycenter`, `BarycenterConfig`, `BarycenterProblem`,
+`FixedSupportBarycenterWorkspace`, `FreeSupportConfig`, `OwnedPointMeasure`,
+`fixed_support_barycenter`, `free_support_barycenter`
+
+**Drift:**
+`detect_drift_records`, `detect_drift_memories`, `DriftReport`, `DriftSummary`,
+`DriftConfig`, `DriftMetricKind`, `DriftSolverMode`, `DriftWeighting`,
+`EmbeddingRecord`, `MemoryLike`, `PerEntryDisplacement`
+
+**Online drift:**
+`OnlineDriftDetector`, `OnlineDriftConfig`, `OnlineDriftSignal`
+
+---
+
+## Inference-Side Bridge (Not Yet Built)
+
+`OnlineDriftDetector` lives in this crate. Per ADR-055, the inference-side `DriftSampler`
+bridge that would feed live KV-cache statistics into the detector is not yet built. The two
+pieces exist at opposite ends of the dependency graph: `lattice-transport` is a leaf crate
+with no inference dependency, while the bridge would need to observe `lattice-inference`
+internals. The integration point is tracked in ADR-055.
+
+---
+
+## Quick Example
+
+```rust
+use lattice_transport::{
+    SinkhornSolver, SinkhornConfig, SinkhornWorkspace,
+    DenseCostMatrix, uniform_weights,
+};
+
+let cost = DenseCostMatrix::new(2, 2, vec![0.0, 1.0, 1.0, 0.0]);
+let source = uniform_weights(2);
+let target = uniform_weights(2);
+let solver = SinkhornSolver::default();
+let mut workspace = SinkhornWorkspace::new(2, 2);
+let result = solver.solve(&cost, &source, &target, &mut workspace).unwrap();
+assert!(result.converged);
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,3 +145,159 @@ lattice-tune             ← training pipeline (depends on fann + inference)
 | Build a training loop with distillation  | `lattice-tune`                 |
 | Measure embedding distribution drift     | `lattice-transport`            |
 | Write a new model architecture or kernel | `lattice-inference` (internal) |
+
+## Forward Pass Pipeline
+
+This section traces the decoder (Qwen3) generate path end to end. All references are to
+`crates/inference/src/` unless a full path is given. The encoder (BERT/BGE) path is
+structurally similar but uses bidirectional attention and skips the KV cache and decode loop.
+
+### 1. Model Load
+
+`QwenModel::load` (`model/qwen.rs`) opens the model directory and calls
+`SafetensorsFile::open` (`weights/f32_weights.rs`) to memory-map `model.safetensors`. Tensors
+are accessed as zero-copy `Tensor2D<'a>` slices backed by the mmap. Sharded checkpoints go
+through `ShardedQwenBacking`, which owns heap-allocated copies of each shard. The model also
+constructs a `RopeTable` (`rope.rs`) at load time by precomputing sin/cos tables up to
+`max_position_embeddings`.
+
+### 2. Entry Point
+
+```
+generate(model, prompt, config)   // generate.rs:276
+```
+
+`generate` is the single public entry point for text generation. It accepts a `&QwenModel`, a
+prompt string, and a `GenerateConfig` (`generate.rs:27`), then orchestrates the five steps
+below. `GenerateConfig` carries `max_new_tokens`, `SamplingConfig`, an optional EOS token ID,
+an optional `GrammarEngine`, and an optional `kv_cache_capacity` cap.
+
+### 3. Tokenize
+
+```
+tokenizer.tokenize(prompt)   // tokenizer/common.rs:37
+```
+
+`QwenModel::tokenizer()` returns a `Box<dyn Tokenizer>`. For Qwen3 this is a `BpeTokenizer`
+(`tokenizer/bpe.rs`) doing GPT-2-style byte-level BPE encoding. `tokenize` returns a
+`TokenizedInput` with `input_ids` (a `Vec<u32>`) and `real_length` (number of non-padding
+tokens). The generate loop uses `tokenized.real_length` as `prompt_len`.
+
+### 4. Allocate KV Cache and Scratch
+
+`generate.rs` allocates a `FlatKVCache` (`kv_cache/flat.rs`) sized to
+`prompt_len + max_new_tokens` (or the caller's `kv_cache_capacity` cap). The cache stores K
+and V tensors in f16 (2 bytes per element) across all layers in two contiguous per-layer
+buffers, totalling `2 * num_layers * capacity * kv_dim * 2` bytes.
+
+A `ForwardScratch` struct (`generate.rs:103`) holds pre-allocated f32 buffers for all
+intermediate activations: `hidden`, `residual`, `qkv_buf`, `q_buf`, `k_buf`, `v_buf`,
+`attn_out`, `gate_up_buf`, `gate_buf`, `up_buf`, `ffn_out`, `scores`, `logits`, and two
+dequantization buffers (`cached_k_f32`, `cached_v_f32`). `ensure_capacity` grows these
+buffers on the first call (prefill size) and never shrinks them, so decode steps reuse the
+same allocation.
+
+### 5. Prefill
+
+```
+forward_with_cache(model, &prompt_ids[..prompt_len], &mut cache, 0, &mut scratch, max_seq)
+```
+
+`forward_with_cache` (`generate.rs:451`) runs the full prompt through the transformer in a
+single pass (`start_pos = 0`, `seq_len = prompt_len`). Inside:
+
+1. **Embedding lookup** (`generate.rs:475`). Each token ID indexes into
+   `weights.embed_tokens.data` (the `[vocab_size, hidden_size]` embedding matrix) and copies
+   one row into `scratch.hidden`.
+
+2. **Transformer layers** (`generate.rs:494`). For each of `num_hidden_layers` layers:
+
+   a. **Pre-attention RMS norm** (`forward/cpu.rs: rms_norm`). Normalizes
+   `scratch.hidden` in place using the layer's `input_layernorm_weight`.
+
+   b. **Fused QKV projection** (`matmul_bt`). A single `[seq_len, hidden_size] ×
+      [qkv_dim, hidden_size]^T` matmul produces `[seq_len, qkv_dim]` in `scratch.qkv_buf`.
+   The output is then scattered into separate `scratch.q_buf`, `scratch.k_buf`,
+   `scratch.v_buf` slices.
+
+   c. **Per-head QK RMS norm**. Each Q head and each KV head is independently RMS-normed
+   using `lw.q_norm_weight` and `lw.k_norm_weight`.
+
+   d. **RoPE** (`rope.rs: RopeTable::apply`). `RopeTable::apply` rotates each Q and K head
+   in place using the precomputed sin/cos table at position `start_pos + token_index`.
+
+   e. **KV cache write** (`generate.rs:563`). K and V are converted f32→f16 and appended to
+   `cache.k_buffer_mut(layer_idx)` and `cache.v_buffer_mut(layer_idx)`.
+
+   f. **Attention** (`generate.rs:620, compute_attention`). The cached K and V buffers are
+   dequantized f16→f32 into `scratch.cached_k_f32` / `scratch.cached_v_f32`. Then
+   `compute_attention` (`generate.rs:875`) runs GQA with causal masking: Q @ K^T scaled
+   by `1/sqrt(head_dim)`, softmax, weighted sum of V. During prefill (`q_seq_len > 1`)
+   the generic path applies a causal mask (`ki > start_pos + qi → NEG_INFINITY`). During
+   decode (`q_seq_len == 1`) a faster path loads each KV row once and dots it against all
+   Q heads in its GQA group, then uses an online safe-softmax (running `(m, l)`
+   accumulation) before accumulating V via NEON on AArch64 for `head_dim = 128`.
+
+   g. **Output projection** (`matmul_bt`). `[seq_len, q_dim] × [hidden_size, q_dim]^T →
+      [seq_len, hidden_size]` writes the attention output back to `scratch.hidden`.
+
+   h. **Residual add**. `scratch.hidden[i] += scratch.residual[i]` for each element.
+
+   i. **Post-attention RMS norm** using `lw.post_attention_layernorm_weight`.
+
+   j. **SwiGLU FFN**. A fused gate+up projection (`[seq_len, hidden] × [2*inter, hidden]^T`)
+   fills `scratch.gate_up_buf`. Gate and up halves are scattered, then `silu_inplace` is
+   applied to the gate half, followed by `elementwise_mul(gate, up)` to produce the
+   activated hidden state. The down projection (`[seq_len, inter] × [hidden_size, inter]^T`)
+   writes the FFN output. A second residual add completes the layer.
+
+3. **KV cache advance** (`cache.advance_by(seq_len)`, `generate.rs:702`). Increments the
+   logical sequence length by the number of tokens just processed.
+
+4. **Final RMS norm** (`generate.rs:706`). Applied to the last token's hidden state only
+   (`hidden[last_start..]`).
+
+5. **Logits projection** (`generate.rs:716`). Qwen3 ties `lm_head` with `embed_tokens`:
+   `logits = hidden_last @ embed_tokens^T`. This is a single `matmul_bt` call producing a
+   `[1, vocab_size]` vector written into `scratch.logits`.
+
+### 6. Sample First Token
+
+```
+sampler.sample(&scratch.logits[..cfg.vocab_size])   // sampling.rs
+```
+
+`Sampler::sample` applies temperature scaling, top-k filtering, top-p nucleus filtering, and
+repetition penalty, then draws a token ID. If a `GrammarEngine` is active, `mask_logits` is
+called on `scratch.logits` before sampling and `advance` is called after (`grammar/mod.rs`).
+
+### 7. Decode Loop
+
+```
+for step in 0..max_new_tokens.saturating_sub(1) {
+    forward_with_cache(model, &[last_token], &mut cache, pos-1, &mut scratch, max_seq)?;
+    token = sampler.sample(&scratch.logits[..vocab_size]);
+    generated_ids.push(token);
+}
+```
+
+Each decode step calls `forward_with_cache` with a single-token input. The KV cache grows by
+one position per step. The loop stops on EOS, when the cache is full (optional
+`kv_cache_capacity` cap), or when `max_new_tokens` is exhausted.
+
+### 8. Detokenize
+
+```
+tokenizer.decode(&generated_ids)   // tokenizer/common.rs:44
+```
+
+`BpeTokenizer::decode` converts generated token IDs back to a UTF-8 string using GPT-2
+byte-level decoding. If `GenerateConfig::include_prompt` is set, the prompt string is
+prepended to the result.
+
+### Setting a Breakpoint
+
+To inspect the forward pass at runtime, set a breakpoint on `forward_with_cache`
+(`generate.rs:451`). The prefill call has `seq_len = prompt_len`; each decode call has
+`seq_len = 1`. The logits for the sampled token are always in `scratch.logits[0..vocab_size]`
+after the function returns.


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes the top onboarding-coverage gaps from the 2026-06-24 doc audit (#304). Docs-only — two new READMEs and one appended section, zero `.rs`. Every module name, type, function, and file path was verified against the live source before writing (the audit that spawned this found a published README referencing types that don't exist — the discipline here is the opposite).

## What's added

- **`crates/inference/README.md`** (new) — a **contributor's map** for the ~104K-LOC core crate, not a user guide. Leads with the real stability policy from `lib.rs` (Experimental, 153 unsafe blocks, "consumers go through `lattice-embed`"), then a module-by-module table (all 20 modules + the feature-gated `backward`), the supported architectures (BERT/BGE, Qwen3/3.5, BitNet, Qwen3-VL, cross-encoder), and a "where to start for common PR types" section. A new inference PR now opens into a map instead of a wall.
- **`crates/transport/README.md`** (new) — what the crate is (entropy-regularized OT / Sinkhorn, embedding-drift detection), its boundary constraints (f32-only, **zero intra-workspace dependencies** — verified `Cargo.toml` lists only `rayon`+`serde`), the full module map, public types, a compiling Quick Example, and an honest "inference-side `DriftSampler` bridge not yet built" note (consistent with ADR-055, just merged).
- **`docs/architecture.md`** — appended a `## Forward Pass Pipeline` section tracing the real Qwen3 generate path end to end (model load → tokenize → KV-cache/scratch alloc → prefill layer loop → logits → sample → decode loop) with `generate.rs` line anchors a contributor can set breakpoints from.

## TBV (orchestrator, against source)

- Forward-pass line anchors independently re-verified: `generate()` @276, `forward_with_cache` @451, `compute_attention` @875, `advance_by` @702, `decode` @424 — all match.
- Transport Quick Example confirmed compilable: `SinkhornSolver::default()` @sinkhorn.rs:54, `SinkhornWorkspace::new(rows,cols)` @82, `solve<C>` @386, `DenseCostMatrix::new(rows,cols,data)` @cost.rs:280, `uniform_weights` @857, `SinkhornResult.converged` @266.
- Transport dependency-boundary claim confirmed: `Cargo.toml` has only `rayon`+`serde`, no `lattice-*`.
- All inference-README file-path references exist (`attention/flash_causal.rs`, `weights/q4_weights.rs`, `weights/q8_weights.rs`, `model/cross_encoder.rs`, `model/bitnet_config.rs`, `tokenizer/common.rs`, …).
- **Caught and fixed one broken path**: the draft pointed QuaRot math at `quant/quarot.rs`, which does not exist — it's the `quant/quarot/` directory. Corrected before pushing (this was the exact failure mode the audit flagged).
- Protective omissions preserved: `foundation/STABILITY.md` is referenced in `lib.rs` itself but doesn't exist in this standalone repo, so it's kept as a text reference, not a clickable link.

No engine source changed, so e2e-parity correctly skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
