### PR TITLE
fix(inference): apply repetition penalty once per unique id, not per occurrence (#312)

### DIFF
--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -54,9 +54,15 @@ pub(crate) fn sample_token(
 
 fn apply_repetition_penalty(adjusted: &mut [f32], previous_ids: &[u32], penalty: f32) {
     let vocab_size = adjusted.len();
+    // previous_ids is the full token history and routinely repeats ids. Penalize each
+    // id exactly once (HF gather-once semantics; matches the Metal CandidateSet path).
+    // Applying per occurrence would compound to penalty^N and over-suppress common
+    // tokens as the sequence grows. O(n) dedup via a set — negligible beside the
+    // full-vocab `adjusted` clone the caller already pays each step.
+    let mut seen = std::collections::HashSet::with_capacity(previous_ids.len());
     for &id in previous_ids {
         let idx = id as usize;
-        if idx < vocab_size {
+        if idx < vocab_size && seen.insert(id) {
             if adjusted[idx] > 0.0 {
                 adjusted[idx] /= penalty;
             } else {

--- a/crates/inference/src/model/qwen35/tests.rs
+++ b/crates/inference/src/model/qwen35/tests.rs
@@ -63,6 +63,28 @@ fn test_sample_repetition_penalty() {
 }
 
 #[test]
+fn test_repetition_penalty_applied_once_per_repeated_id() {
+    // `previous_ids` is the full token history (prompt + generated), so it routinely
+    // contains the same id multiple times. The penalty must apply ONCE per id —
+    // matching HF and the Metal `CandidateSet` path — not once per occurrence
+    // (which compounds to penalty^N and over-suppresses as the sequence grows).
+    let logits = vec![0.0, 10.0, 3.0];
+    let cfg = crate::model::qwen35_config::GenerateConfig {
+        temperature: 0.0,
+        repetition_penalty: 2.0,
+        ..Default::default()
+    };
+    let mut rng = 1u64;
+    // Token 1 appears TWICE in the history. Penalized once: 10/2 = 5 (beats token 2's 3).
+    // Per-occurrence bug: 10/2/2 = 2.5 (token 2 wrongly wins).
+    let token = sample_token(&logits, &cfg, &[1, 1], &mut rng);
+    assert_eq!(
+        token, 1,
+        "repeated history id must be penalized once (10/2=5), not per occurrence (2.5)"
+    );
+}
+
+#[test]
 fn test_sample_nonfinite_temperature_is_greedy() {
     // The live Qwen3.5 decode sampler must treat a non-finite temperature as
     // greedy (deterministic argmax = token 1), not sample from an unscaled

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -292,7 +292,13 @@ impl Sampler {
             self.logit_scratch.clear();
             self.logit_scratch.extend_from_slice(logits);
             let penalty = self.config.repetition_penalty;
-            for &tok in &self.recent_tokens {
+            for (pos, &tok) in self.recent_tokens.iter().enumerate() {
+                // Penalize each id once (recent_tokens may repeat). recent_tokens is
+                // capped at max_recent (64), so this O(n²) scan stays well under the
+                // full-vocab argmax cost and avoids a per-call allocation.
+                if self.recent_tokens[..pos].contains(&tok) {
+                    continue;
+                }
                 let idx = tok as usize;
                 if idx < self.logit_scratch.len() {
                     self.logit_scratch[idx] = penalized_logit(self.logit_scratch[idx], penalty);
@@ -309,7 +315,13 @@ impl Sampler {
         let adj = &mut self.logit_scratch;
 
         if self.config.repetition_penalty != 1.0 {
-            for &tok in &self.recent_tokens {
+            for (pos, &tok) in self.recent_tokens.iter().enumerate() {
+                // Penalize each id once (recent_tokens may repeat); applying it per
+                // occurrence compounds to penalty^N. Capped at max_recent (64), so the
+                // O(n²) dedup scan is negligible against the fused top-k over the vocab.
+                if self.recent_tokens[..pos].contains(&tok) {
+                    continue;
+                }
                 let idx = tok as usize;
                 if idx < adj.len() {
                     adj[idx] = penalized_logit(adj[idx], self.config.repetition_penalty);
@@ -1192,6 +1204,33 @@ mod tests {
         assert!(
             (penalized_logit(-2.0, 2.0) - -4.0).abs() < 1e-6,
             "-2.0*2.0 == -4.0"
+        );
+    }
+
+    #[test]
+    fn test_repetition_penalty_applied_once_per_token() {
+        // `recent_tokens` accumulates duplicates (`push_token` never dedups), so a
+        // token repeated within the window must be penalized exactly ONCE — matching
+        // HF's gather-once semantics and the Metal `CandidateSet` path. Applying the
+        // penalty per occurrence compounds it (penalty^N) and silently over-suppresses
+        // common tokens as a sequence grows.
+        let mut s = Sampler::new(SamplingConfig {
+            temperature: 0.0,
+            top_k: 1,
+            top_p: 1.0,
+            repetition_penalty: 2.0,
+        })
+        .with_seed(1);
+        // Step 1: token 1 is the clear argmax; recent_tokens -> [1].
+        assert_eq!(s.sample(&[0.0, 10.0, 0.0]), 1);
+        // Step 2: token 1 penalized once (10/2 = 5) still wins; recent_tokens -> [1, 1].
+        assert_eq!(s.sample(&[0.0, 10.0, 0.0]), 1);
+        // Step 3: token 1 penalized ONCE (10/2 = 5) must beat token 2 (logit 3).
+        // The per-occurrence bug penalizes twice (10/2/2 = 2.5) and wrongly picks token 2.
+        assert_eq!(
+            s.sample(&[0.0, 10.0, 3.0]),
+            1,
+            "duplicate history id must be penalized once, not per occurrence"
         );
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Fixes #312.

## Problem

Repetition penalty was applied **per occurrence** of a token id in the history instead of **once per unique id**, in the two CPU rep-penalty paths. Because the history routinely repeats ids, a token appearing `N` times was penalized `penalty^N`, compounding unboundedly with sequence length. HF (`RepetitionPenaltyLogitsProcessor`, gather-once/scatter) and the engine's own Metal path (`CandidateSet::apply_repetition_penalty`, via `contains`) apply the penalty exactly once per id.

| Path | Before | After |
|------|--------|-------|
| Metal `CandidateSet` (`sampling.rs:82`) | once per unique id ✓ | unchanged |
| CPU `Sampler::sample` (greedy + non-greedy) | **per occurrence** ✗ | once per unique id ✓ |
| CPU `qwen35::sample_token` (`model/qwen35/sampling.rs`) | **per occurrence** ✗ | once per unique id ✓ |

`Sampler::sample` is live for `generate.rs` / `batch/worker.rs`; `qwen35::sample_token` is live for `cpu_q8` / `cpu_f16` / `neon_forward` / `batch_prefill` / `generation.rs`. With the default `repetition_penalty = 1.1`, a common token appearing 30× in a 500-token generation was suppressed ~17× instead of 1.1×, growing with length.

## Fix

- **Sampler** (history capped at `max_recent = 64`): allocation-free `recent_tokens[..pos].contains` dedup. O(n²) bounded at 64², negligible against the full-vocab fused top-k scan.
- **qwen35** (unbounded history): `HashSet` dedup. O(n), dominated by the full-vocab `adjusted` clone the function already pays each decode step.

## Tests (red/green)

Two regression tests, one per path. Both **fail on the prior behavior** (penalty applied twice → pick token 2) and **pass after the fix** (applied once → pick token 1):

```
penalty=2.0, logits=[0,10,3], history=[1,1]
  per-occurrence (bug):  10/2/2 = 2.5  -> token 2  (WRONG)
  per-unique  (correct):  10/2   = 5.0  -> token 1
```

Verified: both fail on `main` (`left: 2, right: 1`), pass on this branch. Full `sampling::` (31) and `qwen35::tests` (21) suites green; `cargo clippy -p lattice-inference --all-targets -D warnings` clean.

## bench-compare (sampler_allocation, origin/main vs HEAD)

| group | origin/main | HEAD | delta |
|---|---|---|---|
| `default_topk50_topp0.9` | 43.97 µs | 44.02 µs | +0.1% (noise) |
| `greedy_argmax_baseline` | 45.27 µs | 45.24 µs | −0.06% (noise) |

No change: the dedup path is only entered when a token repeats in history, which the empty-history allocation benches don't exercise. Added cost is bounded as described above.

Not caught by `e2e-parity.yml` (greedy runs with `repetition_penalty = 1.0`, which early-returns before these loops). Adversarial review: approved (correctness, consistency across all three paths, per-path perf choice, test discrimination, no e2e-parity/borrow regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
