### PR TITLE
harden(inference): guard compute_decay_gate against exp(a_log) NaN (#314)

### DIFF
--- a/crates/inference/src/attention/gdn.rs
+++ b/crates/inference/src/attention/gdn.rs
@@ -410,7 +410,13 @@ pub fn l2_normalize_vec(x: &mut [f32]) {
 /// Compute decay gate: g = exp(-exp(a_log) * softplus(alpha + dt_bias))
 #[inline]
 fn compute_decay_gate(a_log: f32, alpha: f32, dt_bias: f32) -> f32 {
-    let a = a_log.exp();
+    // `a_log.exp()` overflows f32 to +inf for a_log > ~88. Paired with a very negative
+    // `alpha + dt_bias` (softplus hard-returns 0.0), the product is `inf * 0.0` = NaN and
+    // `exp(NaN)` = NaN — which then propagates through the recurrent state S and poisons
+    // every subsequent token. Clamp the decay rate to finite so the product stays finite:
+    // `huge * 0 = 0` → g = 1 (the dt≈0 "no decay" limit), `huge * positive` → -inf → g = 0
+    // (full decay). No effect for valid checkpoints, where a_log stays O(1).
+    let a = a_log.exp().min(f32::MAX);
     let sp = softplus(alpha + dt_bias);
     (-a * sp).exp()
 }
@@ -588,6 +594,30 @@ mod tests {
                 "decay gate should be in (0, 1], got {g} for a_log={a_log}, alpha={alpha}, dt_bias={dt_bias}"
             );
         }
+    }
+
+    #[test]
+    fn test_decay_gate_finite_on_exp_overflow() {
+        // a_log large enough that exp(a_log) overflows f32 to +inf, paired with a very
+        // negative (alpha + dt_bias) where softplus hard-returns 0.0. Pre-guard this was
+        // `inf * 0.0` = NaN → `exp(NaN)` = NaN, which then poisons the entire recurrent
+        // state S and every subsequent token.
+        let g = compute_decay_gate(100.0, -200.0, 0.0);
+        assert!(
+            g.is_finite() && (0.0..=1.0).contains(&g),
+            "decay gate must stay finite in [0,1] under exp overflow, got {g}"
+        );
+        // softplus(very_negative) ≈ 0 ⇒ dt ≈ 0 ⇒ no time step ⇒ no decay ⇒ g = 1.
+        assert!((g - 1.0).abs() < 1e-6, "expected g≈1 for dt≈0, got {g}");
+
+        // The full-decay limit also stays finite: overflowing a_log with a positive dt
+        // drives the exponent to -inf, so g → 0 (not NaN).
+        let g0 = compute_decay_gate(100.0, 5.0, 0.0);
+        assert!(
+            g0.is_finite() && g0 >= 0.0,
+            "decay gate must stay finite, got {g0}"
+        );
+        assert!(g0 < 1e-6, "expected g≈0 for huge decay rate, got {g0}");
     }
 
     #[test]

--- a/crates/inference/src/attention/gdn_fused.rs
+++ b/crates/inference/src/attention/gdn_fused.rs
@@ -135,7 +135,10 @@ fn scalar_gated_rms_norm(x: &[f32], z: &[f32], gamma: &[f32], out: &mut [f32], e
 
 #[inline]
 fn compute_decay_gate(a_log: f32, alpha: f32, dt_bias: f32) -> f32 {
-    let a = a_log.exp();
+    // Clamp the decay rate to finite: `a_log.exp()` overflows to +inf for a_log > ~88, and
+    // `inf * softplus(very_negative)=0.0` is NaN that poisons the recurrent state. Mirrors
+    // the scalar `gdn::compute_decay_gate` guard (kept in lockstep for scalar/fused parity).
+    let a = a_log.exp().min(f32::MAX);
     let sp = softplus(alpha + dt_bias);
     (-a * sp).exp()
 }
@@ -1499,5 +1502,26 @@ mod tests {
             let energy: f32 = head_slice.iter().map(|x| x * x).sum();
             assert!(energy > 0.0, "head {h} output is zero in symmetric config");
         }
+    }
+
+    #[test]
+    fn test_fused_decay_gate_finite_on_exp_overflow() {
+        // Mirror of gdn::test_decay_gate_finite_on_exp_overflow for the fused path's
+        // own compute_decay_gate. `a_log.exp()` overflows f32 to +inf for a_log > ~88;
+        // paired with softplus(very_negative) = 0.0 the product was `inf * 0.0` = NaN,
+        // which poisons the recurrent state and every subsequent token.
+        let g = compute_decay_gate(100.0, -200.0, 0.0);
+        assert!(
+            g.is_finite() && (0.0..=1.0).contains(&g),
+            "fused decay gate must stay finite in [0,1] under exp overflow, got {g}"
+        );
+        assert!((g - 1.0).abs() < 1e-6, "expected g≈1 for dt≈0, got {g}");
+
+        let g0 = compute_decay_gate(100.0, 5.0, 0.0);
+        assert!(
+            g0.is_finite() && g0 >= 0.0,
+            "fused decay gate must stay finite, got {g0}"
+        );
+        assert!(g0 < 1e-6, "expected g≈0 for huge decay rate, got {g0}");
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #314.

## Problem

`compute_decay_gate` (GatedDeltaNet decay gate `g = exp(-exp(a_log) * softplus(alpha + dt_bias))`) can emit `NaN`, which then poisons the entire recurrent state `S` and every subsequent token.

```rust
let a = a_log.exp();                  // a_log > ~88 → f32 overflow → +inf
let sp = softplus(alpha + dt_bias);   // alpha+dt_bias < -20 → softplus hard-returns 0.0
(-a * sp).exp()                       // inf * 0.0 = NaN → exp(NaN) = NaN
```

`compute_decay_gate(100.0, -200.0, 0.0)` returns `NaN` pre-fix (verified by the red test).

## Fix

Clamp the decay rate to finite: `let a = a_log.exp().min(f32::MAX);`. Then:
- `huge * 0 = 0` → `g = 1` (the `dt≈0` "no decay" limit)
- `huge * positive` → `-inf` → `g = 0` (full decay)

Byte-identical for every valid checkpoint (`a_log` stays `O(1)`). Applied to both the scalar reference (`gdn.rs`) and the production fused path (`gdn_fused.rs`), kept in lockstep for scalar/fused parity.

## Severity

Latent / hardening. Not reachable from any shipped Qwen3.5 weights (they keep `a_log` at `O(1)`), but the failure mode is catastrophic if hit and the guard is free. Fits the `#224`–`#226` sampler/shape hardening cadence. Found via a discovery pass over `crates/inference/src/attention/`.

## Tests

`test_decay_gate_finite_on_exp_overflow` (gdn.rs) and `test_fused_decay_gate_finite_on_exp_overflow` (gdn_fused.rs). Red→green proven: reverting the `.min(f32::MAX)` makes both fail with `got NaN`; with the guard both assert `g.is_finite()`, `g ∈ [0,1]`, `g≈1` for `dt≈0`, and `g≈0` for huge decay rate.

```
test attention::gdn::tests::test_decay_gate_finite_on_exp_overflow ... ok
test attention::gdn_fused::tests::test_fused_decay_gate_finite_on_exp_overflow ... ok
test result: ok. 30 passed; 0 failed
```

`cargo clippy --workspace -- -D warnings` clean.

## bench-compare

This is a correctness/hardening fix on a path that is byte-identical for all valid inputs (the only behavioral change is on overflowing `a_log`, never present in real weights), so no perf delta is expected. bench-compare output appended below once the run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
