### PR TITLE
harden(inference): route tiny finite temperature to greedy argmax (#316)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -12857,7 +12857,9 @@ kernel void gdn_chunk_norm_silu_c32(
         if cfg.repetition_penalty != 1.0 {
             cs.apply_repetition_penalty(previous_ids, cfg.repetition_penalty);
         }
-        if cfg.temperature <= 0.0 {
+        // A degenerate temperature (non-finite, <= 0, or finite-but-tiny so 1/t
+        // overflows) has no valid scaling; the t -> 0+ limit is argmax.
+        if crate::sampling::temperature_degenerate(cfg.temperature) {
             return cs.argmax();
         }
         cs.apply_temperature(cfg.temperature);
@@ -12893,7 +12895,9 @@ kernel void gdn_chunk_norm_silu_c32(
         use crate::sampling::CandidateSet;
         let mut cs = CandidateSet::from_full_logits(logits);
         cs.apply_repetition_penalty(previous_ids, cfg.repetition_penalty);
-        if cfg.temperature <= 0.0 {
+        // A degenerate temperature (non-finite, <= 0, or finite-but-tiny so 1/t
+        // overflows) has no valid scaling; the t -> 0+ limit is argmax.
+        if crate::sampling::temperature_degenerate(cfg.temperature) {
             return cs.argmax();
         }
         cs.apply_temperature(cfg.temperature);

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -14,12 +14,12 @@ pub(crate) fn sample_token(
         apply_repetition_penalty(&mut adjusted, previous_ids, cfg.repetition_penalty);
     }
 
-    // A non-finite (NaN/±inf) or non-positive temperature carries no valid
-    // scaling: `1.0 / NaN` is NaN and `1.0 / inf` is 0, either of which corrupts
-    // the distribution (NaN logits, or all logits flattened to a uniform draw).
-    // Route them all to deterministic greedy argmax before any scaling, matching
-    // Sampler::sample and the documented "0.0 = greedy" contract.
-    if !cfg.temperature.is_finite() || cfg.temperature <= 0.0 {
+    // A degenerate temperature (non-finite, <= 0, or finite-but-tiny so its
+    // reciprocal overflows or scales a logit past f32::MAX) carries no valid
+    // scaling and is routed to deterministic greedy argmax before any scaling,
+    // matching Sampler::sample, the Metal paths, and the documented "0.0 = greedy"
+    // contract. See `crate::sampling::temperature_degenerate`.
+    if crate::sampling::temperature_degenerate(cfg.temperature) {
         return greedy_token(&adjusted);
     }
 
@@ -134,4 +134,55 @@ pub(crate) fn xorshift64(state: &mut u64) -> f32 {
     s ^= s << 17;
     *state = s;
     (s >> 11) as f32 / (1u64 << 53) as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(temperature: f32, top_k: usize) -> GenerateConfig {
+        GenerateConfig {
+            temperature,
+            top_k,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_sample_token_degenerate_temperature_falls_back_to_argmax() {
+        // A degenerate temperature (non-finite, <= 0, reciprocal-overflow, or residual
+        // post-multiply-overflow band) must route to greedy argmax rather than scaling
+        // every logit to inf and collapsing the softmax draw to token 0. The highest
+        // logit is index 1, so every degenerate temperature must return 1.
+        let logits = [10.0_f32, 11.0, 9.0];
+        for bad in [
+            f32::NAN,
+            f32::INFINITY,
+            -1.0,
+            0.0,
+            1e-45,
+            1e-39,
+            f32::MIN_POSITIVE,
+            1e-37,
+        ] {
+            let mut rng = 7u64;
+            let token = sample_token(&logits, &cfg(bad, 0), &[], &mut rng);
+            assert_eq!(
+                token, 1,
+                "degenerate temperature {bad} must fall back to argmax (token 1)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sample_token_valid_temperature_unchanged() {
+        // A normal temperature must still take the scaling + softmax draw path
+        // (byte-identical to before the degeneracy guard) and produce a valid token.
+        let logits = [10.0_f32, 11.0, 9.0];
+        let mut rng = 7u64;
+        let token = sample_token(&logits, &cfg(0.7, 0), &[], &mut rng);
+        assert!(token < 3, "valid temperature must return an in-range token");
+    }
 }

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -361,22 +361,39 @@ impl Sampler {
     }
 }
 
+/// A generous upper bound on the magnitude of a transformer lm_head logit. Real
+/// logits are O(10) (rarely past ~50); this 1e4 ceiling carries ~100-1000x of
+/// headroom. It defines the boundary below which a temperature is treated as
+/// greedy: if scaling a logit of this magnitude by `1.0 / t` would overflow f32,
+/// the temperature cannot produce a valid ordering for any realistic logit.
+const MAX_PLAUSIBLE_ABS_LOGIT: f32 = 1.0e4;
+
 /// True when `temperature` cannot produce a valid finite logit scaling, so sampling
 /// must fall back to greedy argmax (the `t -> 0+` limit, `softmax(logits / t) ->
-/// argmax(logits)`). Covers three cases:
+/// argmax(logits)`). Covers four cases:
 /// - non-finite temperature (NaN, ±inf): `1.0 / NaN` is NaN and `1.0 / inf` is 0, both
 ///   of which corrupt the scaled distribution;
 /// - `t <= 0`: no valid scaling;
-/// - finite but tiny positive `t`: `1.0 / t` overflows f32 to +inf for `t < ~2.94e-39`
-///   (since `f32::MAX ≈ 3.4e38`), so the scaling multiplies every logit by inf and
-///   loses their ordering, collapsing the distribution to the wrong token.
+/// - finite but tiny positive `t` where `1.0 / t` itself overflows f32 to +inf
+///   (`t < ~2.94e-39`, since `f32::MAX ≈ 3.4e38`): the scaling multiplies every logit
+///   by inf and loses their ordering;
+/// - finite `t` where `1.0 / t` stays finite but `logit * (1.0 / t)` overflows for a
+///   plausible logit (`t` roughly below `MAX_PLAUSIBLE_ABS_LOGIT / f32::MAX ≈ 2.94e-35`).
+///   The scaled logits saturate to +inf, the softmax's non-finite-max guard then
+///   returns an arbitrary candidate instead of the true argmax. Both overflow bands
+///   are well below any valid sampling temperature, and the `t -> 0+` limit is argmax
+///   for all of them, so routing them to greedy is exact, not a behavior change.
 ///
-/// Shared by every sampling entry point (CPU `Sampler::sample` and the Metal
-/// `sample_from_candidates` / `sample_token` paths) so the degeneracy check stays
-/// identical across backends.
+/// Shared by every sampling entry point (CPU `Sampler::sample`, the CPU
+/// `model/qwen35::sample_token`, and the Metal `sample_from_candidates` /
+/// `sample_token` paths) so the degeneracy check stays identical across backends.
 #[inline]
 pub(crate) fn temperature_degenerate(temperature: f32) -> bool {
-    !temperature.is_finite() || temperature <= 0.0 || !(1.0 / temperature).is_finite()
+    if !temperature.is_finite() || temperature <= 0.0 {
+        return true;
+    }
+    let inv_temp = 1.0 / temperature;
+    !inv_temp.is_finite() || inv_temp > f32::MAX / MAX_PLAUSIBLE_ABS_LOGIT
 }
 
 /// Apply repetition penalty to one logit. A penalty of 1.0, or any non-finite
@@ -752,7 +769,10 @@ mod tests {
 
     #[test]
     fn test_temperature_degenerate_predicate() {
-        // Degenerate: non-finite, non-positive, and finite-but-tiny (reciprocal overflows).
+        // Degenerate: non-finite, non-positive, finite-but-tiny where the reciprocal
+        // overflows (1e-45..1e-39), and the residual band where the reciprocal is finite
+        // but `logit * inv_temp` would overflow for a plausible logit (1e-38..1e-35,
+        // including f32::MIN_POSITIVE whose reciprocal 8.5e37 exceeds f32::MAX / 1e4).
         for bad in [
             f32::NAN,
             f32::INFINITY,
@@ -762,18 +782,46 @@ mod tests {
             1e-45,
             1e-40,
             1e-39,
+            f32::MIN_POSITIVE,
+            1e-37,
+            1e-35,
         ] {
             assert!(
                 temperature_degenerate(bad),
                 "temperature {bad} should be degenerate"
             );
         }
-        // Valid: normal temperatures whose reciprocal stays finite (incl. small-but-safe,
-        // e.g. f32::MIN_POSITIVE whose reciprocal 8.5e37 is below f32::MAX).
-        for ok in [1.0, 0.5, 2.0, 0.1, 1e-30, 1e-3, f32::MIN_POSITIVE] {
+        // Valid: normal temperatures, plus small-but-safe values whose reciprocal stays
+        // far enough below f32::MAX that scaling a plausible logit cannot overflow
+        // (1e-30 -> inv 1e30, well under the f32::MAX / 1e4 ≈ 3.4e34 threshold).
+        for ok in [1.0, 0.5, 2.0, 0.1, 1e-3, 1e-30] {
             assert!(
                 !temperature_degenerate(ok),
-                "temperature {ok} should be valid (reciprocal finite)"
+                "temperature {ok} should be valid (no scaling overflow)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_residual_band_temperature_falls_back_to_argmax() {
+        // The residual band: a finite, positive temperature whose reciprocal stays finite
+        // (so the pre-fix `!(1.0 / t).is_finite()` check missed it) yet is large enough
+        // that `logit * inv_temp` overflows for ordinary logits. Pre-fix this saturated
+        // every scaled logit to +inf and the softmax non-finite-max guard returned an
+        // arbitrary candidate. argmax (token 1) is the correct t -> 0+ limit.
+        let logits = vec![10.0, 11.0, 9.0];
+        for band in [f32::MIN_POSITIVE, 1e-37_f32, 1e-36] {
+            let config = SamplingConfig {
+                temperature: band,
+                top_k: 2,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+            };
+            let mut sampler = Sampler::new(config).with_seed(7);
+            assert_eq!(
+                sampler.sample(&logits),
+                1,
+                "residual-band temperature {band} must fall back to argmax, not collapse"
             );
         }
     }

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -274,15 +274,10 @@ impl Sampler {
         // (recent_tokens empty or raw argmax not recently generated) this avoids the
         // 993 KB extend_from_slice entirely.
         //
-        // A non-finite temperature (NaN, ±inf) is also routed here: it carries no
-        // valid scaling. `1.0 / NaN` is NaN, which poisons every scaled logit and
-        // collapses the fused top-k to token 0 (the lowest ID), and `1.0 / inf` is 0,
-        // which flattens all logits. Fall back to the same deterministic argmax as
-        // temperature <= 0.0 rather than sampling from a corrupted distribution.
-        if !self.config.temperature.is_finite()
-            || self.config.temperature <= 0.0
-            || self.config.top_k == 1
-        {
+        // A degenerate temperature (non-finite, <= 0, or finite-but-tiny so that its
+        // reciprocal overflows) carries no valid scaling and is routed here to the same
+        // deterministic argmax as the t -> 0+ limit. See `temperature_degenerate`.
+        if temperature_degenerate(self.config.temperature) || self.config.top_k == 1 {
             let raw_best = argmax_f32(logits);
             if self.config.repetition_penalty == 1.0 || !self.recent_tokens.contains(&raw_best) {
                 self.push_token(raw_best);
@@ -364,6 +359,24 @@ impl Sampler {
     pub fn reset(&mut self) {
         self.recent_tokens.clear();
     }
+}
+
+/// True when `temperature` cannot produce a valid finite logit scaling, so sampling
+/// must fall back to greedy argmax (the `t -> 0+` limit, `softmax(logits / t) ->
+/// argmax(logits)`). Covers three cases:
+/// - non-finite temperature (NaN, ±inf): `1.0 / NaN` is NaN and `1.0 / inf` is 0, both
+///   of which corrupt the scaled distribution;
+/// - `t <= 0`: no valid scaling;
+/// - finite but tiny positive `t`: `1.0 / t` overflows f32 to +inf for `t < ~2.94e-39`
+///   (since `f32::MAX ≈ 3.4e38`), so the scaling multiplies every logit by inf and
+///   loses their ordering, collapsing the distribution to the wrong token.
+///
+/// Shared by every sampling entry point (CPU `Sampler::sample` and the Metal
+/// `sample_from_candidates` / `sample_token` paths) so the degeneracy check stays
+/// identical across backends.
+#[inline]
+pub(crate) fn temperature_degenerate(temperature: f32) -> bool {
+    !temperature.is_finite() || temperature <= 0.0 || !(1.0 / temperature).is_finite()
 }
 
 /// Apply repetition penalty to one logit. A penalty of 1.0, or any non-finite
@@ -709,6 +722,58 @@ mod tests {
                 sampler.sample(&logits),
                 1,
                 "temperature {bad} must fall back to argmax, not collapse to token 0"
+            );
+        }
+    }
+
+    #[test]
+    fn test_tiny_temperature_falls_back_to_argmax() {
+        // A finite, positive, but tiny temperature whose reciprocal overflows f32 to
+        // +inf (t < ~2.94e-39). Pre-fix `inv_temp = 1.0 / t = inf` scaled every logit
+        // to +inf, destroying their ordering, and the fused top-k collapsed to token 0.
+        // The t -> 0+ limit of softmax(logits / t) is argmax, so the highest-logit
+        // token (1) must win. top_k=2 forces the non-greedy fused-top-k path.
+        let logits = vec![10.0, 11.0, 9.0];
+        for tiny in [1e-45_f32, 1e-40, 1e-39] {
+            let config = SamplingConfig {
+                temperature: tiny,
+                top_k: 2,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+            };
+            let mut sampler = Sampler::new(config).with_seed(7);
+            assert_eq!(
+                sampler.sample(&logits),
+                1,
+                "tiny temperature {tiny} must fall back to argmax, not collapse to token 0"
+            );
+        }
+    }
+
+    #[test]
+    fn test_temperature_degenerate_predicate() {
+        // Degenerate: non-finite, non-positive, and finite-but-tiny (reciprocal overflows).
+        for bad in [
+            f32::NAN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            0.0,
+            -1.0,
+            1e-45,
+            1e-40,
+            1e-39,
+        ] {
+            assert!(
+                temperature_degenerate(bad),
+                "temperature {bad} should be degenerate"
+            );
+        }
+        // Valid: normal temperatures whose reciprocal stays finite (incl. small-but-safe,
+        // e.g. f32::MIN_POSITIVE whose reciprocal 8.5e37 is below f32::MAX).
+        for ok in [1.0, 0.5, 2.0, 0.1, 1e-30, 1e-3, f32::MIN_POSITIVE] {
+            assert!(
+                !temperature_degenerate(ok),
+                "temperature {ok} should be valid (reciprocal finite)"
             );
         }
     }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Closes #316. A finite-but-tiny sampling temperature overflowed `inv_temp = 1.0 / temperature` to `+inf`, scaling every logit to `+inf`, destroying their ordering, and collapsing the draw to **token 0** instead of the correct `t -> 0+` limit, which is `argmax(logits)`.

The fix routes every degenerate temperature to deterministic greedy argmax through one shared predicate, `temperature_degenerate`, used by all sampling backends.

## What "degenerate" covers

`temperature_degenerate(t)` returns true (→ greedy) when:
1. `t` is non-finite (NaN, ±inf) — `1/NaN` is NaN, `1/inf` is 0, both corrupt the distribution;
2. `t <= 0` — no valid scaling (the documented `0.0 = greedy` contract);
3. `1.0 / t` itself overflows f32 to +inf (`t < ~2.94e-39`);
4. `1.0 / t` stays finite but `logit * (1/t)` would overflow for a plausible logit — `t` roughly below `MAX_PLAUSIBLE_ABS_LOGIT / f32::MAX ≈ 2.94e-35`, where `MAX_PLAUSIBLE_ABS_LOGIT = 1e4` (≈100–1000× real lm_head logit magnitude).

Cases 3 and 4 are both well below any valid sampling temperature, and the softmax limit is argmax across the whole degenerate range, so this is **exact — not a behavior change for any valid temperature**. Normal temperatures (0.1, 0.7, 1.0, 2.0) and small-but-safe ones (1e-3, 1e-30) stay on the byte-identical scaling path.

## Sites fixed (4 live sampling paths)

- `sampling.rs` — CPU `Sampler::sample`
- `model/qwen35/sampling.rs` — CPU `sample_token` (non-Metal generation loop)
- `forward/metal_qwen35.rs` — Metal `sample_from_candidates` and `sample_token`

## Verification

**RED→GREEN proven**: with the pre-fix predicate, `f32::MIN_POSITIVE` (1.18e-38) collapses to token 0; the fix routes it to argmax (token 1). New tests pin the reciprocal-overflow band, the residual post-multiply-overflow band, and the 4th-site routing. `cargo test -p lattice-inference` green (41 sampling-area tests), `clippy -D warnings` clean.

**Review rounds**:
- Round 1: flagged the 4th site (`model/qwen35::sample_token`, which had been missed) and the residual overflow band (cases 4 above). Both addressed in commit `a7f0d44e3`.
- Round 2: fixes confirmed — verified the overflow-band classification is mathematically correct (`|L * inv_temp| <= f32::MAX` for `|L| <= 1e4`), valid temperatures unchanged, 4th-site routing is repetition-penalty-aware, no new defect, and no remaining ungated `1/t` sampling site.

## bench-compare

`make bench-compare` (origin/main `e8b33f60c` vs HEAD `a7f0d44e3`):

```
significant (p < 0.05):     1 / 259 change blocks
non-significant (p > 0.05): 258 / 259
```

The single boundary-significant block is a **−1.1% improvement** on an unlabeled ~5µs micro-op, unrelated to sampling. No named regressions in the gate report. Expected: the degeneracy check runs once per sampled token and is not in any benched hot loop. This is a correctness fix; performance is flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
