### PR TITLE
harden(inference): apply_gqa_attention release-active divisibility assert (#318)

### DIFF
--- a/crates/inference/src/attention/gqa.rs
+++ b/crates/inference/src/attention/gqa.rs
@@ -93,6 +93,17 @@ pub fn apply_gqa_attention(
     cfg: GqaConfig,
     scratch: &mut GqaScratch,
 ) {
+    // Hard divisibility guard, matching `decode_attention_scores` and the flash
+    // paths. `GqaConfig::groups()` only `debug_assert`s this invariant, which is
+    // stripped in release; a non-divisible config would then truncate `groups`,
+    // skip the high query heads, and leave them stale in `attn_out` (never zeroed)
+    // while the unsafe strided-BLAS path below assumes a validated head layout.
+    assert!(cfg.num_kv_heads > 0, "num_kv_heads must be > 0");
+    assert_eq!(
+        cfg.num_heads % cfg.num_kv_heads,
+        0,
+        "num_heads must be divisible by num_kv_heads"
+    );
     let groups = cfg.groups();
     let q_dim = cfg.q_dim();
     let kv_dim = cfg.kv_dim();
@@ -536,5 +547,29 @@ mod tests {
         }
 
         bit_eq(&fused, &ref_scores);
+    }
+
+    #[test]
+    #[should_panic(expected = "num_heads must be divisible by num_kv_heads")]
+    fn non_divisible_head_config_panics() {
+        // A non-divisible head topology (num_heads % num_kv_heads != 0) must fail
+        // fast at the kernel entry rather than silently process only the first
+        // `num_kv_heads * floor(groups)` query heads and leave the remainder stale.
+        // The hard assert fires in release too (unlike the prior `debug_assert` in
+        // `groups()`), matching `decode_attention_scores`. RED before the entry
+        // guard: `groups()`'s debug_assert panics with the default message, which
+        // does not contain this expected substring.
+        let cfg = GqaConfig {
+            num_heads: 3,
+            num_kv_heads: 2,
+            head_dim: 4,
+        };
+        let seq_len = 4usize;
+        let q = vec![0.0f32; seq_len * cfg.q_dim()];
+        let k = vec![0.0f32; seq_len * cfg.kv_dim()];
+        let v = vec![0.0f32; seq_len * cfg.kv_dim()];
+        let mut out = vec![0.0f32; seq_len * cfg.q_dim()];
+        let mut scratch = GqaScratch::default();
+        apply_gqa_attention(&q, &k, &v, &mut out, seq_len, cfg, &mut scratch);
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #318.

## Problem

`apply_gqa_attention` (`crates/inference/src/attention/gqa.rs`) guarded the GQA head-divisibility invariant (`num_heads % num_kv_heads == 0`) only via `debug_assert_eq!` in `GqaConfig::groups()`. The workspace `Cargo.toml` has no `[profile.release] debug-assertions = true`, so that assertion is **stripped in release builds**.

In release, a non-divisible config makes `groups = num_heads / num_kv_heads` truncate; the kernel loops `for kv_h in 0..num_kv_heads` writing only `num_kv_heads * groups` query heads, and `attn_out` is **never zeroed** — so the high query heads are left silently stale instead of failing fast. The function also has an `unsafe` strided-BLAS path (gqa.rs:134/137) whose SAFETY comment assumes a validated head layout, which in release was unenforced.

Every sibling attention path already asserts this **exact** invariant with a hard `assert_eq!` that fires in release:
- `attention/decode.rs:29-33` (`decode_attention_scores`, same `GqaConfig`, same unsafe SIMD)
- `attention/decode.rs:84`, `attention/flash.rs:98`, `attention/flash.rs:623`, `attention/flash_causal.rs:134`, `attention/differential.rs:72`

`apply_gqa_attention` was the only GQA kernel entry using `debug_assert` for it.

## Fix

Promote the guard to a hard `assert!`/`assert_eq!` at the `apply_gqa_attention` entry, verbatim-matching `decode_attention_scores`. Placed before any `cfg.groups()` use so it fires first.

Real shipped Qwen configs are always divisible (16/8, 8/2), so the assertion never fires for real models — **zero blast radius** for valid configs and no decode-hot-loop impact (decode uses `decode_attention*`, which already asserts; `apply_gqa_attention` is the prefill path, called once per layer).

## RED → GREEN

`non_divisible_head_config_panics` calls `apply_gqa_attention` with `num_heads=3, num_kv_heads=2` and asserts `#[should_panic(expected = "num_heads must be divisible by num_kv_heads")]`.

- **RED** (entry guard neutralized): `groups()`'s `debug_assert` panics with the *default* message `assertion left == right failed / left: 1 / right: 0` — does **not** contain the expected substring → test FAILS (`panic did not contain expected string`). Reproduced this session.
- **GREEN** (entry guard in place): the custom-message hard assert fires → matches → test PASSES.

This proves the behavior change from "default-message, debug-only panic" to "custom-message, release-active panic."

## Validation

- `cargo test -p lattice-inference --lib attention::gqa` → 6 passed, 0 failed
- `cargo clippy -p lattice-inference --lib` → clean
- **review (high effort): approved** — all 5 verification points pass; adversarial residual check confirms no release-time upstream divisibility check exists on the prefill path, so this is the genuine release-activation point (not dead defensive code).

## bench-compare (origin/main vs HEAD)

`make bench-compare` — **no regression**. 259 change blocks; 16 flagged `p = 0.05 < 0.05`, **all improvements** (negative %, e.g. `-8.3%`, `-5.4%`), **zero regressions**. A single entry assert that runs once per prefill layer-call cannot speed up 16 unrelated micro-benchmarks; the uniform-direction, all-at-exactly-`p=0.05` pattern is the known two-worktree machine-state artifact (ADR-058 / documented false-positive signature), not a code effect. The added check is outside every benched hot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
