### PR TITLE
fix(inference): recover SentencePiece byte-fallback typing from tokenizer.json (#255)

### DIFF
--- a/crates/inference/src/tokenizer/sentencepiece.rs
+++ b/crates/inference/src/tokenizer/sentencepiece.rs
@@ -210,6 +210,16 @@ impl SentencePieceTokenizer {
                 InferenceError::Tokenizer("tokenizer.json missing model.vocab".into())
             })?;
 
+        // SentencePiece serializes a model-level `byte_fallback` flag in
+        // tokenizer.json. Shape-inference of `<0xNN>` pieces is the recovery
+        // signal when the flag is true or absent (HF byte-fallback models set
+        // it true; some recovery paths omit it). Only an explicit `false`
+        // suppresses inference — so a model that genuinely declares no byte
+        // fallback keeps a literal `<0xNN>` text token as Normal (#255 review).
+        let byte_fallback_enabled = json_path(&root, &["model", "byte_fallback"])
+            .and_then(JsonValue::as_bool)
+            != Some(false);
+
         let mut pieces = Vec::with_capacity(vocab_entries.len());
         for entry in vocab_entries {
             let values = entry.as_array().ok_or_else(|| {
@@ -232,7 +242,7 @@ impl SentencePieceTokenizer {
             // inserted into the trie as literal text — leaving byte_fallback_ids
             // empty and breaking OOV byte fallback in viterbi_encode. Recover the
             // Byte type from the `<0xNN>` shape, mirroring the .model loader (#255).
-            let kind = if parse_byte_piece(piece).is_some() {
+            let kind = if byte_fallback_enabled && parse_byte_piece(piece).is_some() {
                 SentencePieceType::Byte
             } else {
                 SentencePieceType::Normal
@@ -941,6 +951,16 @@ mod tests {
         assert_eq!(tok.inner.byte_fallback_ids[0xE2], Some(3));
         // Normal pieces are unaffected by the inference.
         assert_eq!(tok.tokenize_to_ids("hello"), vec![1]);
+    }
+
+    #[test]
+    fn test_json_loader_respects_explicit_byte_fallback_false() {
+        // When the model explicitly declares no byte fallback, a literal
+        // `<0xNN>`-shaped piece must stay Normal (trie-resolvable), not be
+        // misrouted to byte_fallback_ids by shape inference (#255 review edge).
+        let json = r#"{"model":{"type":"Unigram","unk_id":0,"byte_fallback":false,"vocab":[["<unk>",0.0],["<0x41>",-5.0]]}}"#;
+        let tok = SentencePieceTokenizer::from_tokenizer_json_str(json).unwrap();
+        assert_eq!(tok.inner.byte_fallback_ids[0x41], None);
     }
 
     // HF Metaspace semantics: trailing whitespace in input must not produce a

--- a/crates/inference/src/tokenizer/sentencepiece.rs
+++ b/crates/inference/src/tokenizer/sentencepiece.rs
@@ -227,10 +227,20 @@ impl SentencePieceTokenizer {
                 .as_f64()
                 .ok_or_else(|| InferenceError::Tokenizer("invalid SentencePiece score".into()))?
                 as f32;
+            // tokenizer.json does not carry SentencePiece piece-type tags, so a
+            // `<0xNN>` byte-fallback piece would otherwise be loaded as Normal and
+            // inserted into the trie as literal text — leaving byte_fallback_ids
+            // empty and breaking OOV byte fallback in viterbi_encode. Recover the
+            // Byte type from the `<0xNN>` shape, mirroring the .model loader (#255).
+            let kind = if parse_byte_piece(piece).is_some() {
+                SentencePieceType::Byte
+            } else {
+                SentencePieceType::Normal
+            };
             pieces.push(SentencePieceEntry {
                 piece: piece.to_string(),
                 score,
-                kind: SentencePieceType::Normal,
+                kind,
             });
         }
 
@@ -914,6 +924,23 @@ mod tests {
     fn test_parse_byte_piece() {
         assert_eq!(parse_byte_piece("<0x41>"), Some(0x41));
         assert_eq!(parse_byte_piece("not-a-byte"), None);
+    }
+
+    #[test]
+    fn test_json_loader_routes_byte_pieces_to_fallback() {
+        // A SentencePiece Unigram model loaded from tokenizer.json must recover
+        // byte-fallback typing for `<0xNN>` pieces, matching the `.model`
+        // protobuf loader.  Regression test for #255: typing was hard-coded to
+        // Normal, so byte pieces landed in the trie as literal text and
+        // byte_fallback_ids stayed empty — breaking OOV byte fallback in
+        // viterbi_encode.
+        let json = r#"{"model":{"type":"Unigram","unk_id":0,"vocab":[["<unk>",0.0],["▁hello",-1.0],["<0x41>",-5.0],["<0xE2>",-5.0]]}}"#;
+        let tok = SentencePieceTokenizer::from_tokenizer_json_str(json).unwrap();
+        // `<0xNN>` pieces route to byte_fallback_ids (not the trie).
+        assert_eq!(tok.inner.byte_fallback_ids[0x41], Some(2));
+        assert_eq!(tok.inner.byte_fallback_ids[0xE2], Some(3));
+        // Normal pieces are unaffected by the inference.
+        assert_eq!(tok.tokenize_to_ids("hello"), vec![1]);
     }
 
     // HF Metaspace semantics: trailing whitespace in input must not produce a


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #255.

## Problem

`from_tokenizer_json_str` (the tokenizer.json Unigram loader) hard-coded every piece to `SentencePieceType::Normal`. tokenizer.json carries no SentencePiece piece-type tag, so `<0xNN>` byte-fallback pieces were inserted into the trie as literal text and never routed into `byte_fallback_ids`. Result: OOV byte fallback in `viterbi_encode` silently failed for any SP model loaded from `.json` — OOV chars fell through to `<unk>` instead of decomposing into byte tokens. The `.model` protobuf loader was unaffected (it reads the piece-type enum, `6 => Byte`).

## Fix

Infer the `Byte` type from the `<0xNN>` shape via the existing `parse_byte_piece` helper, mirroring `from_parsed_model`'s kind-routing. Only mistyped byte pieces change behavior; `Normal` pieces are untouched (single localized site, +28/-1).

## Gate (red/green)

`test_json_loader_routes_byte_pieces_to_fallback`:
- asserts `byte_fallback_ids[0x41]`/`[0xE2]` are populated after a `.json` load (was `None` pre-fix → `Some(id)` post-fix)
- asserts a `Normal` piece still tokenizes to its id unchanged (guards against over-typing)

Verified RED pre-fix (`left: None, right: Some(2)`), GREEN post-fix. Full tokenizer suite 35/35, `clippy --tests -D warnings` clean, fmt clean.

## bench-compare

N/A — load-time typing inference + encode routing, not an inference/embed hot-path change; not covered by any Criterion group. e2e-parity does not exercise SentencePiece byte fallback, so the synthetic internal-state red/green test is the regression gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)