### PR TITLE
harden(inference): guard qwen35 sample_token against NaN/Inf/empty logits + invalid repetition penalty

### DIFF
--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -41,7 +41,9 @@ pub(crate) fn sample_token(
         indices.truncate(k);
     }
 
-    let mut probs = build_softmax_probs(&adjusted, &indices);
+    let Some(mut probs) = build_softmax_probs(&adjusted, &indices) else {
+        return greedy_token(&adjusted);
+    };
 
     probs.sort_unstable_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
 
@@ -63,11 +65,7 @@ fn apply_repetition_penalty(adjusted: &mut [f32], previous_ids: &[u32], penalty:
     for &id in previous_ids {
         let idx = id as usize;
         if idx < vocab_size && seen.insert(id) {
-            if adjusted[idx] > 0.0 {
-                adjusted[idx] /= penalty;
-            } else {
-                adjusted[idx] *= penalty;
-            }
+            adjusted[idx] = crate::sampling::penalized_logit(adjusted[idx], penalty);
         }
     }
 }
@@ -76,25 +74,42 @@ fn greedy_token(adjusted: &[f32]) -> u32 {
     adjusted
         .iter()
         .enumerate()
-        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .max_by(|(_, a), (_, b)| match (a.is_nan(), b.is_nan()) {
+            (true, true) => std::cmp::Ordering::Equal,
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            (false, false) => a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal),
+        })
         .map(|(i, _)| i as u32)
         .unwrap_or(0)
 }
 
-fn build_softmax_probs(adjusted: &[f32], indices: &[usize]) -> Vec<(usize, f32)> {
+fn build_softmax_probs(adjusted: &[f32], indices: &[usize]) -> Option<Vec<(usize, f32)>> {
     let max_logit = indices
         .iter()
         .map(|&i| adjusted[i])
         .fold(f32::NEG_INFINITY, f32::max);
+    // A non-finite max (+INF token, or an empty/all-NaN/-INF index set whose
+    // fold stays NEG_INFINITY) makes every `(logit - max).exp()` NaN; the
+    // weighted draw then never selects a token and falls through to a wrong
+    // one. Signal "degenerate" so the caller returns the argmax instead.
+    if !max_logit.is_finite() {
+        return None;
+    }
     let mut probs: Vec<(usize, f32)> = indices
         .iter()
         .map(|&i| (i, (adjusted[i] - max_logit).exp()))
         .collect();
     let sum: f32 = probs.iter().map(|(_, p)| p).sum();
+    // A finite max does not guarantee a finite sum: a NaN logit in a non-max
+    // position (NaN never becomes `max_logit`) poisons the sum. Same fallback.
+    if !sum.is_finite() || sum <= 0.0 {
+        return None;
+    }
     for (_, p) in &mut probs {
         *p /= sum;
     }
-    probs
+    Some(probs)
 }
 
 fn apply_top_p(probs: &mut Vec<(usize, f32)>, top_p: f32) {
@@ -184,5 +199,64 @@ mod tests {
         let mut rng = 7u64;
         let token = sample_token(&logits, &cfg(0.7, 0), &[], &mut rng);
         assert!(token < 3, "valid temperature must return an in-range token");
+    }
+
+    #[test]
+    fn test_inf_logit_routes_to_argmax_not_nan_draw() {
+        // +INF logit with the full sampling path (non-degenerate temp, top_k=0)
+        // must return the +INF token (index 2), not an arbitrary NaN-softmax draw.
+        let logits = [0.0_f32, 1.0, f32::INFINITY];
+        let mut rng = 42u64;
+        let token = sample_token(&logits, &cfg(1.0, 0), &[], &mut rng);
+        assert_eq!(
+            token, 2,
+            "infinite-logit token must win via argmax fallback"
+        );
+    }
+
+    #[test]
+    fn test_nan_in_nonmax_position_routes_to_argmax() {
+        // Finite max but a NaN in a non-max slot poisons the softmax sum; the
+        // guard must fall back to the finite argmax (index 0), not the NaN slot.
+        let logits = [5.0_f32, f32::NAN, 1.0];
+        let mut rng = 7u64;
+        let token = sample_token(&logits, &cfg(1.0, 0), &[], &mut rng);
+        assert_eq!(
+            token, 0,
+            "finite argmax must win when a non-max logit is NaN"
+        );
+    }
+
+    #[test]
+    fn test_empty_logits_returns_zero_without_panic() {
+        let logits: [f32; 0] = [];
+        let mut rng = 1u64;
+        let token = sample_token(&logits, &cfg(1.0, 0), &[], &mut rng);
+        assert_eq!(token, 0, "empty logits must return 0, never panic");
+    }
+
+    #[test]
+    fn test_invalid_repetition_penalty_is_noop_not_signflip() {
+        // A negative penalty must NOT flip the sign of a seen positive logit.
+        // With penalty treated as no-op, the raw argmax (index 0) wins.
+        let logits = [5.0_f32, 1.0, 0.5];
+        let mut cfg_rp = cfg(0.0, 0); // temp 0 -> greedy, isolates the penalty effect
+        cfg_rp.repetition_penalty = -1.0;
+        let mut rng = 7u64;
+        let token = sample_token(&logits, &cfg_rp, &[0], &mut rng);
+        assert_eq!(
+            token, 0,
+            "invalid penalty must be a no-op, argmax stays index 0"
+        );
+    }
+
+    #[test]
+    fn test_nan_repetition_penalty_is_noop() {
+        let logits = [5.0_f32, 1.0, 0.5];
+        let mut cfg_rp = cfg(0.0, 0);
+        cfg_rp.repetition_penalty = f32::NAN;
+        let mut rng = 7u64;
+        let token = sample_token(&logits, &cfg_rp, &[0], &mut rng);
+        assert_eq!(token, 0, "NaN penalty must be a no-op");
     }
 }

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -410,7 +410,7 @@ pub(crate) fn temperature_degenerate(temperature: f32) -> bool {
 /// or non-positive value, is treated as "no penalty" so an invalid config can
 /// never flip a logit's sign or produce an infinity.
 #[inline(always)]
-fn penalized_logit(logit: f32, penalty: f32) -> f32 {
+pub(crate) fn penalized_logit(logit: f32, penalty: f32) -> f32 {
     if penalty == 1.0 || !penalty.is_finite() || penalty <= 0.0 {
         return logit;
     }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Brings the **production** per-token sampler `qwen35::sampling::sample_token` (called from every Metal/CPU/NEON decode loop) to parity with the defensive guards its sibling `crate::sampling::Sampler` already has. Found via an automated discovery sweep over `sampling.rs`; verification confirmed all three are genuine divergences (not the dead/shared path initially assumed).

All three triggers produced wrong output or a panic on anomalous logits:

| # | Trigger | Old behavior | Sibling guard mirrored |
|---|---------|--------------|------------------------|
| F1 | `+INF` logit, or NaN in a non-max position | softmax all-NaN → weighted draw never matches → falls through to `probs[0]` (wrong token) | `sampling.rs:153` (`!max_logit.is_finite()`) + `:166` (`!sum.is_finite() \|\| sum <= 0.0`) |
| F2 | `repetition_penalty` ≤ 0 / NaN / inf | inline `/= penalty` / `*= penalty` flips the logit's sign | `sampling.rs:414` `penalized_logit` no-ops invalid penalties |
| F3 | empty logits (vocab 0) | `probs[0]` panics (index OOB) | `sampling.rs:140` empty guard (`return 0`) |

## Fix

- `build_softmax_probs` now returns `Option`, yielding `None` on non-finite max **or** non-finite/≤0 sum; `sample_token` falls back to `greedy_token` (argmax). One guard covers **F1 and F3** — empty index set folds to `NEG_INFINITY` → `None` → `greedy_token(&[])` → `0`, matching the sibling.
- `apply_repetition_penalty` reuses the canonical `crate::sampling::penalized_logit` (made `pub(crate)`) instead of the unguarded inline branch (**F2**).
- `greedy_token`'s comparator demotes NaN so it can never win `max_by` (which returns the last `Equal` element) — required for the `None` fallback to be correct, and it also hardens the pre-existing degenerate-temperature path.

**Happy path is byte-identical** (finite, non-empty logits, valid `penalty>0`): the guards only branch on already-anomalous inputs.

## Tests

5 red/green regression tests added (each fails before the corresponding guard, passes after): Inf-logit→argmax, NaN-non-max→argmax, empty→0-no-panic, negative-penalty→no-op, NaN-penalty→no-op. `cargo test -p lattice-inference --lib model::qwen35::sampling` → 7 passed. Sibling `sampling::tests` → 43 passed. `cargo clippy --lib --features metal-gpu -D warnings` clean.

## Bench

N/A — non-kernel change adding 3 `f32` comparisons per token (`is_finite` on already-computed max/sum) on a path dominated by the full-vocab softmax `exp`; token selection is byte-identical on the happy path. e2e-parity (greedy token agreement vs HF) is the binding gate and runs on this PR. Same class as merged #317 / #327 sampling guards (bench flat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
