### PR TITLE
harden(inference): guard config parse against full_attention_interval=0 divide-by-zero panic

### DIFF
--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -365,6 +365,17 @@ impl Qwen35Config {
             }
         }
         if cfg.layer_types.len() != cfg.num_hidden_layers {
+            // compute_layer_types uses `(i + 1) % interval`; a zero interval (from an
+            // explicit `"full_attention_interval": 0`, or the container `#[serde(default)]`
+            // fallback when a preset's interval is zero) would panic with a remainder
+            // divide-by-zero. Malformed input must surface as a typed error, not a panic.
+            if cfg.full_attention_interval == 0 {
+                return Err(InferenceError::Inference(
+                    "invalid Qwen config.json: full_attention_interval must be > 0 when \
+                     layer_types is absent or its length differs from num_hidden_layers"
+                        .to_string(),
+                ));
+            }
             cfg.layer_types =
                 compute_layer_types(cfg.num_hidden_layers, cfg.full_attention_interval);
         }
@@ -926,6 +937,29 @@ mod tests {
         assert!(
             cfg.layer_mask.iter().all(|&v| v),
             "normalized mask must be all-true"
+        );
+    }
+
+    #[test]
+    fn test_zero_full_attention_interval_errors_not_panics() {
+        // A config.json with full_attention_interval: 0 must return a clean
+        // InferenceError, never panic. layer_types is omitted, so the container
+        // #[serde(default)] fills it from the preset (whose length differs from
+        // num_hidden_layers: 4), forcing the recompute branch that calls
+        // compute_layer_types(4, 0) -> (i + 1) % 0 -> divide-by-zero panic
+        // without the guard.
+        let json = r#"{
+            "text_config": {
+                "hidden_size": 2048,
+                "num_hidden_layers": 4,
+                "full_attention_interval": 0,
+                "eos_token_id": 1
+            }
+        }"#;
+        let result = Qwen35Config::from_config_json_str(json);
+        assert!(
+            result.is_err(),
+            "full_attention_interval: 0 must yield an InferenceError, not panic"
         );
     }
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Problem

`Qwen35Config::from_config_json_str` recomputes `layer_types` when its length differs from `num_hidden_layers`, calling `compute_layer_types(num_hidden_layers, full_attention_interval)`. That function does `(i + 1) % full_attention_interval` — a **zero interval panics** with `attempt to calculate the remainder with a divisor of zero` instead of returning a typed error.

**Reachability is real, not theoretical.** The struct carries a container-level `#[serde(default)]`, so an absent `layer_types` defaults to the preset vector (35B preset, length ≫ a small model's layer count). Any config whose `num_hidden_layers` differs from the preset's forces the recompute branch. An explicit `"full_attention_interval": 0` in such a config then panics the whole engine on a parseable-but-malformed `config.json` — violating the no-panic-on-malformed-input invariant (same class as #319 GQA-assert, #327 SP-byte-fallback).

## Fix

Guard the recompute branch: a zero interval returns `InferenceError::Inference(...)` instead of panicking. ~10 lines, single untrusted entry point.

- Happy paths unchanged: valid non-zero interval recomputes as before; a length-matched `layer_types` skips the branch entirely (byte-identical).
- The infallible presets all pass hardcoded non-zero intervals (`4`) and are unaffected; `compute_layer_types`'s contract (caller passes interval > 0) is preserved, validated at the one boundary where untrusted input flows in.

## Test (red/green)

`test_zero_full_attention_interval_errors_not_panics` parses a config with `full_attention_interval: 0` and an omitted `layer_types` (defaults to a mismatched-length preset, forcing the recompute branch).

- **Red** (guard removed): `panicked at qwen35_config.rs:633: attempt to calculate the remainder with a divisor of zero`.
- **Green** (guard present): parse returns `Err`, test asserts `is_err()`.

All 26 `qwen35_config` tests pass; `cargo clippy -p lattice-inference --lib -- -D warnings` clean.

## Bench

N/A — config-parse-only change, no kernel or hot-path code touched. No measurable performance surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)