### PR TITLE
harden(inference): drop zero-length BPE special tokens to prevent tokenize() infinite loop

### DIFF
--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -216,6 +216,13 @@ impl BpeTokenizer {
         }
 
         let mut special_tokens = added_tokens;
+        // A zero-length special token would match at every position
+        // (`"".starts_with(_)` is always true), so match_special returns the
+        // same `pos` and tokenize() never advances — an infinite loop with
+        // unbounded output. A malformed tokenizer.json (an added_token whose
+        // "content" is empty) must not be able to wedge the engine: drop
+        // zero-length specials at construction.
+        special_tokens.retain(|name, _| !name.is_empty());
         for name in [
             "<|endoftext|>",
             "<|im_start|>",
@@ -1158,6 +1165,45 @@ mod tests {
         let tokenizer = synthetic_bpe();
         let ids = tokenizer.tokenize_to_ids("hello world");
         assert_eq!(ids, vec![11, 16]);
+    }
+
+    #[test]
+    fn test_empty_content_special_token_does_not_hang() {
+        // Regression: a malformed tokenizer.json with a zero-length added-token
+        // `content` injects "" into special_tokens. `"".starts_with(_)` is
+        // always true, so match_special returns the same `pos` and
+        // tokenize_to_ids_into never advances — an infinite loop with unbounded
+        // output on the first tokenize() call. The constructor must drop
+        // zero-length special tokens. Run in a worker thread so a re-introduced
+        // hang fails fast via timeout instead of stalling the test binary.
+        let mut vocab = HashMap::new();
+        for (s, i) in [("a", 0u32), ("b", 1), ("c", 2)] {
+            vocab.insert(s.to_string(), i);
+        }
+        let mut added = HashMap::new();
+        added.insert(String::new(), 0u32);
+        let tokenizer = BpeTokenizer::from_vocab_and_merges_with_config(
+            vocab,
+            Vec::new(),
+            added,
+            DEFAULT_BPE_CACHE_CAPACITY,
+            DEFAULT_BPE_MAX_SEQ_LEN,
+        )
+        .expect("construct tokenizer with empty special token");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(tokenizer.tokenize("abc").real_length);
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(len) => assert!(
+                len < 1000,
+                "empty special token produced runaway output ({len}); zero-length specials must be dropped"
+            ),
+            Err(_) => {
+                panic!("tokenize() hung on a zero-length special token (infinite-loop regression)")
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Problem

A malformed `tokenizer.json` whose `added_tokens` contains an entry with empty `content` (`{"id": N, "content": ""}`) injects `""` into the BPE special-token set. `match_special` does `tail.starts_with(token)`, and `"".starts_with(_)` is **always true**, so it returns `(pos + token.len(), id)` = `(pos, id)` — `pos` never advances. The `while pos < text.len()` loop in `tokenize_to_ids_into` then spins forever, pushing the same id, so the **very first `tokenize()` call hangs** with unbounded memory growth.

`tokenize()` is on the hot path of every inference request (`forward/metal_qwen35.rs` ×3, `bin/lattice.rs`), so a single bad `tokenizer.json` wedges the engine.

`special_tokens_sorted` sorts by length descending, placing `""` last — so it only fires at positions where no real special token matches, i.e. immediately on ordinary prompts like `"abc"`.

## Root cause (TBV-verified, all five legs)

1. `parse_added_tokens` (common.rs:740) accepts `content: ""` with no filter
2. → flows into `special_tokens = added_tokens` (bpe.rs:218)
3. → included in `special_tokens_sorted`, sorted last
4. → `match_special` returns `(pos + 0, id)` for the empty token
5. → `tokenize_to_ids_into` never advances `pos` → infinite loop + unbounded output

## Fix

Drop zero-length keys from `special_tokens` at construction in `from_vocab_and_merges_with_config` — the single choke point for every load path (`from_tokenizer_json`, `from_vocab_and_merges`, in-memory builders). A zero-length special token is semantically meaningless: it matches at every position.

```rust
special_tokens.retain(|name, _| !name.is_empty());
```

## Test

`test_empty_content_special_token_does_not_hang` runs `tokenize("abc")` on a worker thread with a 5s timeout, so a re-introduced hang fails fast (timeout panic) instead of stalling the test binary.

- **Red** (guard disabled): FAILED in 5.01s — `tokenize() hung on a zero-length special token (infinite-loop regression)`
- **Green** (guard in place): ok in 0.00s
- Full `tokenizer::bpe` suite: 9 passed; clippy clean

## Class

`#313`-class: revertable internal-robustness fix for a malformed model-config file (same class as #336 config divide-by-zero). No public-API signature change — `from_vocab_and_merges_with_config` is private.

## Bench

N/A — tokenizer construction guard, not a compute kernel. The `retain` runs once at load; no hot-path arithmetic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)