### PR TITLE
harden(inference): drop zero-length WordPiece added tokens to prevent tokenize() infinite loop

### DIFF
--- a/crates/inference/src/tokenizer/wordpiece.rs
+++ b/crates/inference/src/tokenizer/wordpiece.rs
@@ -378,8 +378,21 @@ impl WordPieceTokenizer {
         let mut continuation_builder = PlainTrieBuilder::new();
         for (token, &id) in &vocab {
             if let Some(stripped) = token.strip_prefix("##") {
+                // A "##"-only vocab entry strips to "" — see the empty-subword note below.
+                if stripped.is_empty() {
+                    continue;
+                }
                 continuation_builder.insert(stripped, id as i32);
             } else {
+                // An empty subword sets the trie *root* value, so longest_match_chars
+                // returns a zero-length match (idx == start) at every position and
+                // wordpiece_tokenize_word_into's `start = end` never advances — a
+                // non-advancing-match hang, the same class the added-token retain
+                // above guards. A raw "" vocab key here (and a "##"-only key above)
+                // both yield an empty subword; an empty subword is never a real token.
+                if token.is_empty() {
+                    continue;
+                }
                 whole_builder.insert(token, id as i32);
             }
         }
@@ -559,12 +572,19 @@ impl WordPieceTokenizer {
                 &self.inner.continuation_trie
             };
 
-            if let Some((id, end)) = trie.longest_match_chars(&chars, start) {
-                out.push(id);
-                start = end;
-            } else {
-                out.push(self.inner.unk_id);
-                start += 1;
+            match trie.longest_match_chars(&chars, start) {
+                // `end > start` guards against a zero-length match wedging the loop:
+                // an empty subword in the trie (dropped at construction, guarded here
+                // too) yields a root match at idx == start, and `start = end` would
+                // never advance. Treat any non-advancing match as no match.
+                Some((id, end)) if end > start => {
+                    out.push(id);
+                    start = end;
+                }
+                _ => {
+                    out.push(self.inner.unk_id);
+                    start += 1;
+                }
             }
         }
     }
@@ -1136,6 +1156,55 @@ mod tests {
             ),
             Err(_) => {
                 panic!("tokenize() hung on a zero-length added token (infinite-loop regression)")
+            }
+        }
+    }
+
+    #[test]
+    fn test_empty_content_vocab_token_does_not_hang() {
+        // Regression (companion to the added-token guard): a malformed
+        // tokenizer.json `model.vocab` can carry an empty key (`{"": id}`) or a
+        // "##"-only key (which strip_prefix("##") reduces to ""). Either inserts
+        // the empty string into a trie, which sets the trie *root* value;
+        // longest_match_chars then returns a zero-length match (idx == start) at
+        // every position and wordpiece_tokenize_word_into's `start = end` never
+        // advances — an infinite loop with unbounded output. Construction must drop
+        // empty subwords and the loop must reject non-advancing matches. Run on a
+        // worker thread with a 5s timeout so a re-introduced hang fails fast.
+        let mut vocab = HashMap::new();
+        for (s, i) in [
+            ("[PAD]", 0u32),
+            ("[UNK]", 1),
+            ("[CLS]", 2),
+            ("[SEP]", 3),
+            ("[MASK]", 4),
+            ("a", 5),
+            ("b", 6),
+            ("c", 7),
+            ("", 8),   // raw empty vocab key
+            ("##", 9), // "##"-only key strips to ""
+        ] {
+            vocab.insert(s.to_string(), i);
+        }
+        let tokenizer = WordPieceTokenizer::from_vocab_map_with_added(
+            vocab,
+            HashMap::new(),
+            DEFAULT_WORDPIECE_CACHE_CAPACITY,
+            DEFAULT_MAX_SEQ_LEN,
+        )
+        .expect("construct wordpiece tokenizer with empty vocab token");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(tokenizer.tokenize("abc").real_length);
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(len) => assert!(
+                len < 1000,
+                "empty vocab token produced runaway output ({len}); empty subwords must be dropped"
+            ),
+            Err(_) => {
+                panic!("tokenize() hung on a zero-length vocab token (infinite-loop regression)")
             }
         }
     }

--- a/crates/inference/src/tokenizer/wordpiece.rs
+++ b/crates/inference/src/tokenizer/wordpiece.rs
@@ -344,10 +344,18 @@ impl WordPieceTokenizer {
 
     fn from_vocab_map_with_added(
         vocab: HashMap<String, u32>,
-        added_tokens: HashMap<String, u32>,
+        mut added_tokens: HashMap<String, u32>,
         cache_capacity: usize,
         max_seq_len: usize,
     ) -> Result<Self, InferenceError> {
+        // A zero-length added token would match at every position
+        // (`"".starts_with(_)` is always true), so match_added_token returns the
+        // same `pos` and tokenize_to_ids_into never advances — an infinite loop
+        // with unbounded output. A malformed tokenizer.json (an added_token whose
+        // "content" is empty) must not be able to wedge the engine: drop
+        // zero-length added tokens at construction (mirrors the BPE guard).
+        added_tokens.retain(|name, _| !name.is_empty());
+
         let id_to_token = invert_vocab(&vocab)?;
 
         let cls_id = *vocab
@@ -1082,6 +1090,54 @@ mod tests {
         let trie = builder.build();
         let chars: Vec<char> = "embedding".chars().collect();
         assert_eq!(trie.longest_match_chars(&chars, 0), Some((3, 9)));
+    }
+
+    #[test]
+    fn test_empty_content_added_token_does_not_hang() {
+        // Regression (mirrors the BPE guard): a malformed tokenizer.json with a
+        // zero-length added-token `content` injects "" into added_tokens.
+        // `"".starts_with(_)` is always true, so match_added_token returns the
+        // same `pos` and tokenize_to_ids_into never advances — an infinite loop
+        // with unbounded output on the first tokenize() call. The constructor
+        // must drop zero-length added tokens. Run on a worker thread with a 5s
+        // timeout so a re-introduced hang fails fast instead of stalling the
+        // test binary.
+        let mut vocab = HashMap::new();
+        for (s, i) in [
+            ("[PAD]", 0u32),
+            ("[UNK]", 1),
+            ("[CLS]", 2),
+            ("[SEP]", 3),
+            ("[MASK]", 4),
+            ("a", 5),
+            ("b", 6),
+            ("c", 7),
+        ] {
+            vocab.insert(s.to_string(), i);
+        }
+        let mut added = HashMap::new();
+        added.insert(String::new(), 1u32);
+        let tokenizer = WordPieceTokenizer::from_vocab_map_with_added(
+            vocab,
+            added,
+            DEFAULT_WORDPIECE_CACHE_CAPACITY,
+            DEFAULT_MAX_SEQ_LEN,
+        )
+        .expect("construct wordpiece tokenizer with empty added token");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(tokenizer.tokenize("abc").real_length);
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(len) => assert!(
+                len < 1000,
+                "empty added token produced runaway output ({len}); zero-length tokens must be dropped"
+            ),
+            Err(_) => {
+                panic!("tokenize() hung on a zero-length added token (infinite-loop regression)")
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Problem (companion to #338)

WordPiece has the **same empty-added-token hazard** as BPE. `match_added_token` (wordpiece.rs:527) does `tail.starts_with(token)`, and `"".starts_with(_)` is **always true**, so an empty added token returns `(pos + token.len(), id)` = `(pos, id)` — `pos` never advances. The outer `while pos < text.len()` loop in `tokenize_to_ids_into` (476-488) then spins forever, pushing the same id → the first `tokenize()` call hangs with unbounded memory growth.

WordPiece is **production-wired** via `bert.rs` (embedding / reranking models). A malformed `tokenizer.json` with an `added_tokens` entry whose `content` is empty (accepted by `parse_added_tokens`, common.rs:740) is enough to trigger it.

## Fix

Drop zero-length keys from `added_tokens` at construction in `from_vocab_map_with_added` — the single choke point for every wordpiece load path. Mirrors the BPE guard in #338.

```rust
added_tokens.retain(|name, _| !name.is_empty());
```

## Test

`test_empty_content_added_token_does_not_hang` runs `tokenize("abc")` on a worker thread with a 5s timeout, so a re-introduced hang fails fast (timeout panic) instead of stalling the test binary.

- **Red** (guard disabled): FAILED in 5.01s — `tokenize() hung on a zero-length added token (infinite-loop regression)`
- **Green** (guard in place): ok in 0.00s
- Full `tokenizer::wordpiece` suite: 14 passed; clippy clean

## Class

`#313`-class: revertable internal-robustness fix for a malformed model-config file (same class/root cause as #338). No public-API signature change — `from_vocab_map_with_added` is private.

## Bench

N/A — tokenizer construction guard, not a compute kernel. The `retain` runs once at load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)