### PR TITLE
harden(inference): reject malformed tokenizer.json vocab ids at load

### DIFF
--- a/crates/inference/src/tokenizer/common.rs
+++ b/crates/inference/src/tokenizer/common.rs
@@ -695,7 +695,13 @@ pub(crate) fn json_object_to_vocab(
         let id = id_value.as_u64().ok_or_else(|| {
             InferenceError::Tokenizer(format!("invalid non-integer token id for {token:?}"))
         })?;
-        vocab.insert(token.clone(), id as u32);
+        // Token ids are stored as u32 everywhere downstream. A JSON value past u32::MAX
+        // would silently wrap under `as u32` (e.g. 2^32 -> 0) and alias an unrelated
+        // token; reject it instead of corrupting the vocabulary.
+        let id = u32::try_from(id).map_err(|_| {
+            InferenceError::Tokenizer(format!("token id {id} for {token:?} exceeds u32 range"))
+        })?;
+        vocab.insert(token.clone(), id);
     }
     Ok(vocab)
 }
@@ -713,6 +719,18 @@ pub(crate) fn vocab_txt_to_map(vocab_text: &str) -> HashMap<String, u32> {
 /// Convert a token->id vocabulary map into an ID-indexed token table.
 pub(crate) fn invert_vocab(vocab: &HashMap<String, u32>) -> Result<Vec<String>, InferenceError> {
     let max_id = vocab.values().copied().max().unwrap_or(0) as usize;
+    // `id_to_token` is a dense table sized to the largest id. Real tokenizer vocabs are
+    // dense (ids 0..len), so gaps are small and tolerated. A malformed tokenizer.json with
+    // a single sparse huge id (e.g. 4_294_967_295) would otherwise force a ~100 GB
+    // allocation here and abort the process at load. Cap the table at 16x the entry count:
+    // generous headroom for any real gap, a hard ceiling on the malformed-input blast radius.
+    let max_slots = vocab.len().saturating_mul(16);
+    if max_id >= max_slots {
+        return Err(InferenceError::Tokenizer(format!(
+            "vocabulary id {max_id} out of range for {} entries (sparse or malformed)",
+            vocab.len()
+        )));
+    }
     let mut id_to_token = vec![String::new(); max_id + 1];
     for (token, &id) in vocab {
         let slot = &mut id_to_token[id as usize];
@@ -740,10 +758,16 @@ pub(crate) fn parse_added_tokens(root: &JsonValue) -> HashMap<String, u32> {
         let Some(content) = object.get("content").and_then(JsonValue::as_str) else {
             continue;
         };
-        let Some(id) = object.get("id").and_then(JsonValue::as_u64) else {
+        // Skip an id past u32::MAX rather than wrap it under `as u32` into a colliding
+        // id (parse_added_tokens is lenient by contract and already skips malformed entries).
+        let Some(id) = object
+            .get("id")
+            .and_then(JsonValue::as_u64)
+            .and_then(|v| u32::try_from(v).ok())
+        else {
             continue;
         };
-        tokens.insert(content.to_string(), id as u32);
+        tokens.insert(content.to_string(), id);
     }
 
     tokens
@@ -830,7 +854,8 @@ fn find_template_processing(pp: &JsonValue) -> Option<&JsonValue> {
 
 fn resolve_template_token_id(special_tokens: Option<&JsonValue>, name: &str) -> Option<u32> {
     let ids = special_tokens?.get(name)?.get("ids")?.as_array()?;
-    ids.first()?.as_u64().map(|v| v as u32)
+    // An id past u32::MAX is treated as absent rather than wrapped into a wrong id.
+    ids.first()?.as_u64().and_then(|v| u32::try_from(v).ok())
 }
 
 /// **Unstable**: internal LRU cache used by tokenizer implementations;
@@ -1010,6 +1035,52 @@ mod tests {
         let inverse = invert_vocab(&vocab).unwrap();
         assert_eq!(inverse[0], "[PAD]");
         assert_eq!(inverse[3], "hello");
+    }
+
+    #[test]
+    fn test_vocab_id_overflowing_u32_rejected() {
+        // A token id past u32::MAX would wrap under `as u32` (2^32 -> 0) and alias another
+        // token. json_object_to_vocab must reject it at parse time, not corrupt the vocab.
+        let json = parse_json(r#"{"[PAD]": 4294967296}"#).unwrap();
+        assert!(
+            json_object_to_vocab(&json).is_err(),
+            "a vocab id past u32::MAX must be rejected, not wrapped"
+        );
+    }
+
+    #[test]
+    fn test_invert_vocab_rejects_disproportionate_sparse_id() {
+        // A vocabulary whose largest id vastly exceeds its entry count would force a giant
+        // dense-table allocation (a single id of 4_294_967_295 -> ~100 GB) and abort the
+        // process at load. invert_vocab caps the table at 16x the entry count and rejects.
+        // Here: 1 entry, id 50 -> 51 slots, well past the 16x cap.
+        let mut vocab = HashMap::new();
+        vocab.insert("a".to_string(), 50u32);
+        assert!(
+            invert_vocab(&vocab).is_err(),
+            "a single sparse id far past the entry count must be rejected"
+        );
+        // A normal gapped vocab (within the cap) still inverts fine — no regression.
+        let mut dense = HashMap::new();
+        dense.insert("a".to_string(), 0u32);
+        dense.insert("b".to_string(), 3u32);
+        assert!(invert_vocab(&dense).is_ok());
+    }
+
+    #[test]
+    fn test_added_token_id_overflowing_u32_skipped() {
+        // parse_added_tokens is lenient: an id past u32::MAX is skipped, not wrapped into a
+        // colliding id. A well-formed sibling entry is still parsed.
+        let root = parse_json(
+            r#"{"added_tokens":[{"content":"<bad>","id":4294967296},{"content":"<ok>","id":7}]}"#,
+        )
+        .unwrap();
+        let tokens = parse_added_tokens(&root);
+        assert_eq!(tokens.get("<ok>"), Some(&7));
+        assert!(
+            !tokens.contains_key("<bad>"),
+            "an added-token id past u32::MAX must be skipped, not wrapped to a colliding id"
+        );
     }
 
     #[test]

--- a/crates/inference/src/tokenizer/common.rs
+++ b/crates/inference/src/tokenizer/common.rs
@@ -711,7 +711,13 @@ pub(crate) fn vocab_txt_to_map(vocab_text: &str) -> HashMap<String, u32> {
     let mut vocab = HashMap::new();
     for (idx, line) in vocab_text.lines().enumerate() {
         let token = line.trim_end_matches('\r').to_string();
-        vocab.insert(token, idx as u32);
+        // The line index is the token id. Stop rather than wrap if it would exceed u32
+        // range (a vocab.txt past 2^32 lines is malformed); enumerate is monotonic, so no
+        // later line could fit either.
+        let Ok(id) = u32::try_from(idx) else {
+            break;
+        };
+        vocab.insert(token, id);
     }
     vocab
 }
@@ -1049,6 +1055,15 @@ mod tests {
     }
 
     #[test]
+    fn test_vocab_id_at_u32_max_accepted() {
+        // u32::MAX itself is in range and must be accepted (not rejected) — locks the
+        // try_from boundary against an off-by-one that would reject the largest valid id.
+        let json = parse_json(r#"{"x": 4294967295}"#).unwrap();
+        let vocab = json_object_to_vocab(&json).expect("u32::MAX is a valid id");
+        assert_eq!(vocab.get("x"), Some(&u32::MAX));
+    }
+
+    #[test]
     fn test_invert_vocab_rejects_disproportionate_sparse_id() {
         // A vocabulary whose largest id vastly exceeds its entry count would force a giant
         // dense-table allocation (a single id of 4_294_967_295 -> ~100 GB) and abort the
@@ -1065,6 +1080,21 @@ mod tests {
         dense.insert("a".to_string(), 0u32);
         dense.insert("b".to_string(), 3u32);
         assert!(invert_vocab(&dense).is_ok());
+    }
+
+    #[test]
+    fn test_invert_vocab_cap_boundary() {
+        // The cap is `max_id >= len*16`. For a single entry (len 1, cap 16): id 15 -> 16
+        // slots is the largest accepted table; id 16 trips the cap. Locks the off-by-one.
+        let mut at_limit = HashMap::new();
+        at_limit.insert("a".to_string(), 15u32);
+        assert!(invert_vocab(&at_limit).is_ok(), "max_id == len*16 - 1 fits");
+        let mut over_limit = HashMap::new();
+        over_limit.insert("a".to_string(), 16u32);
+        assert!(
+            invert_vocab(&over_limit).is_err(),
+            "max_id == len*16 must trip the cap"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Three robustness gaps in the shared tokenizer parse layer (`crates/inference/src/tokenizer/common.rs`), all reachable from `load_tokenizer` on a malformed-but-parseable `tokenizer.json`. Surfaced by a discovery pass; each verified against source before fixing.

### 1. `u64` vocab id silently wrapped to `u32` (silent token aliasing)
`json_object_to_vocab` cast a file-supplied `u64` id straight to `u32`. An id past `u32::MAX` (e.g. `4294967296` → `0`) wrapped to a small in-range id and aliased an unrelated token with no error. Now rejected via `u32::try_from`. The same overflow guard is applied to the two sibling cast sites flagged in review:
- `parse_added_tokens` (lenient-by-contract) — skips an oversized id rather than wrapping it.
- `resolve_template_token_id` (TemplateProcessing) — treats an oversized id as absent.

### 2. `invert_vocab` unbounded dense-table allocation (load-time DoS)
`invert_vocab` sized `id_to_token` to `max_id + 1` with no bound. `invert_vocab` is only ever called on the dense base `model.vocab` (BPE, WordPiece), so for a real tokenizer `max_id ≈ len`. A malformed `model.vocab` with a single sparse huge id (e.g. `4_294_967_295`) forced a ~100 GB allocation and **aborted the process at load**. The table is now capped at **16× the entry count** — generous headroom for the gap-tolerant vocabs the existing `test_invert_vocab` exercises (ids `0` and `3` at len 2), a hard ceiling on the malformed-input blast radius.

## Reachability
`load_tokenizer` (common.rs L202) is the production dispatch that builds WordPiece/BPE/SentencePiece tokenizers from `tokenizer.json`. The vocab map, added-tokens, and template-processing ids all run through these parse functions at load on file-controlled input.

## Testing
- `test_vocab_id_overflowing_u32_rejected` — `{"[PAD]": 4294967296}` → `Err`.
- `test_invert_vocab_rejects_disproportionate_sparse_id` — single entry, id 50 → `Err`; a normal gapped vocab still inverts (`is_ok`).
- `test_added_token_id_overflowing_u32_skipped` — oversized id skipped, well-formed sibling parsed.
- **Red/green proof**: with both Result-path guards removed, the two tests fail (wrap accepted / sparse id allocates without error); restored, all 9 `common::tests` pass. The disproportionate test uses id 50 (51 slots) so no actual giant allocation runs.
- `cargo clippy -p lattice-inference` clean.

## Bench
N/A — construction-time guards that run once at model load; no hot-path or kernel change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)