### PR TITLE
harden(inference): bound grammar PDA depth + array cardinality (#343)

### DIFF
--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -366,6 +366,77 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    /// Regression (issue #343): a left-recursive GBNF grammar (`root ::= root`)
+    /// must not hang. Before the PDA depth cap, `enumerate_grammar_states` grew
+    /// the PDA stack without bound inside a single `simulate_token` call. The
+    /// depth cap turns it into a bounded dead grammar; construction returns.
+    #[test]
+    fn cyclic_gbnf_does_not_hang() {
+        let vocab = tiny_vocab();
+        let spec = GrammarSpec::Gbnf("root ::= root\n".to_string());
+        let result = GrammarEngine::new(&spec, vocab);
+        // Bounded construction (Ok with a dead grammar) is the contract — the
+        // point is that it terminates rather than hanging or OOMing.
+        assert!(result.is_ok(), "cyclic GBNF should construct, not hang");
+    }
+
+    /// Regression (issue #343): a JSON-Schema `$ref` cycle compiles to a cyclic
+    /// grammar and previously hung at construction via the same PDA mechanism.
+    #[test]
+    fn cyclic_ref_schema_does_not_hang() {
+        let vocab = tiny_vocab();
+        let spec = GrammarSpec::JsonSchema(serde_json::json!({
+            "$ref": "#/$defs/Node",
+            "$defs": { "Node": { "$ref": "#/$defs/Node" } }
+        }));
+        let result = GrammarEngine::new(&spec, vocab);
+        assert!(
+            result.is_ok(),
+            "cyclic $ref schema should construct, not hang"
+        );
+    }
+
+    /// Regression (issue #343): an array schema with an absurd `maxItems`
+    /// (near `u64::MAX`) previously overflowed the stack in `build_bounded_tail`.
+    /// It must now be rejected with a typed error at the parse boundary.
+    #[test]
+    fn array_maxitems_overflow_rejected() {
+        let vocab = tiny_vocab();
+        let spec = GrammarSpec::JsonSchema(serde_json::json!({
+            "type": "array",
+            "items": { "type": "boolean" },
+            "maxItems": 18446744073709551615u64
+        }));
+        let err = match GrammarEngine::new(&spec, vocab) {
+            Ok(_) => panic!("absurd maxItems must be rejected, not overflow the stack"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("maxItems"),
+            "error should name the offending field: {err}"
+        );
+    }
+
+    /// Regression (issue #343): the `minItems` sibling — a near-`u64::MAX`
+    /// `minItems` drives the required-item loop ~1.8e19 times. Reject it too.
+    #[test]
+    fn array_minitems_overflow_rejected() {
+        let vocab = tiny_vocab();
+        let spec = GrammarSpec::JsonSchema(serde_json::json!({
+            "type": "array",
+            "items": { "type": "boolean" },
+            "minItems": 18446744073709551615u64
+        }));
+        let err = match GrammarEngine::new(&spec, vocab) {
+            Ok(_) => panic!("absurd minItems must be rejected, not hang"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("minItems"),
+            "error should name the offending field: {err}"
+        );
+    }
+
     #[test]
     fn mask_logits_blocks_disallowed() {
         // Boolean grammar: only "true" or "false" tokens allowed.

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -437,6 +437,70 @@ mod tests {
         );
     }
 
+    /// Regression (issue #343, codex finding B): a long *acyclic* `$defs`
+    /// reference chain (`N0→N1→…→Nk`, each a distinct unseen ref) recurses
+    /// `compile_schema` once per link. Without the depth cap this overflowed the
+    /// stack at compile time, independent of the PDA cycle fix. A 2000-link
+    /// chain (well past MAX_SCHEMA_DEPTH=512) must reject cleanly.
+    #[test]
+    fn deep_ref_chain_rejected() {
+        let n = 2000usize;
+        let mut defs = serde_json::Map::new();
+        for i in 0..n {
+            let target = if i + 1 < n {
+                serde_json::json!({ "$ref": format!("#/$defs/N{}", i + 1) })
+            } else {
+                serde_json::json!({ "type": "boolean" })
+            };
+            defs.insert(format!("N{i}"), target);
+        }
+        let schema = serde_json::json!({ "$ref": "#/$defs/N0", "$defs": defs });
+        let spec = GrammarSpec::JsonSchema(schema);
+        let err = match GrammarEngine::new(&spec, tiny_vocab()) {
+            Ok(_) => panic!("deep $ref chain must be rejected, not overflow the stack"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("depth"), "error should mention depth: {err}");
+    }
+
+    /// A short acyclic `$ref` chain (well under the cap) must still compile.
+    #[test]
+    fn shallow_ref_chain_accepted() {
+        let n = 64usize;
+        let mut defs = serde_json::Map::new();
+        for i in 0..n {
+            let target = if i + 1 < n {
+                serde_json::json!({ "$ref": format!("#/$defs/N{}", i + 1) })
+            } else {
+                serde_json::json!({ "type": "boolean" })
+            };
+            defs.insert(format!("N{i}"), target);
+        }
+        let schema = serde_json::json!({ "$ref": "#/$defs/N0", "$defs": defs });
+        let result = GrammarEngine::new(&GrammarSpec::JsonSchema(schema), tiny_vocab());
+        assert!(result.is_ok(), "a 64-link $ref chain should compile");
+    }
+
+    /// Boundary (issue #343, codex finding D): `maxItems` one past the cap is
+    /// rejected; a small in-range `maxItems` still compiles.
+    #[test]
+    fn array_maxitems_boundary() {
+        let over = GrammarSpec::JsonSchema(serde_json::json!({
+            "type": "array", "items": { "type": "boolean" }, "maxItems": 4097
+        }));
+        assert!(
+            GrammarEngine::new(&over, tiny_vocab()).is_err(),
+            "maxItems just past the cap must be rejected"
+        );
+        let ok = GrammarSpec::JsonSchema(serde_json::json!({
+            "type": "array", "items": { "type": "boolean" }, "maxItems": 8
+        }));
+        assert!(
+            GrammarEngine::new(&ok, tiny_vocab()).is_ok(),
+            "a small in-range maxItems must still compile"
+        );
+    }
+
     #[test]
     fn mask_logits_blocks_disallowed() {
         // Boolean grammar: only "true" or "false" tokens allowed.

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -46,6 +46,18 @@ use std::collections::HashMap;
 /// at the parse boundary with a typed error.
 const MAX_ARRAY_CARDINALITY: usize = 4096;
 
+/// Maximum schema recursion depth the compiler will descend.
+///
+/// `compile_schema` is the single recursion hub: `$ref` targets, object
+/// properties, array items, and `anyOf`/`oneOf` branches all recurse back into
+/// it. A parseable schema with a long `$defs` reference chain
+/// (`A→B→C→…`, each a distinct unseen ref) or deeply nested objects therefore
+/// recurses once per link with no natural bound — a compile-time stack overflow
+/// reachable from untrusted schema input (issue #343, codex finding B). Cap the
+/// depth: `serde_json` itself rejects JSON nested beyond 128, and no legitimate
+/// schema chains references or nests anywhere near 512 levels.
+const MAX_SCHEMA_DEPTH: usize = 512;
+
 /// Error returned by the JSON Schema compiler.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SchemaError(pub String);
@@ -114,6 +126,9 @@ struct CompileCtx<'a> {
     /// (issue #310 finding #2: each array node gets a unique suffix to prevent
     /// rule sharing across distinct array schemas in the same document).
     array_counter: usize,
+    /// Current `compile_schema` recursion depth (issue #343: bound compile-time
+    /// recursion through `$ref` chains and deep nesting).
+    depth: usize,
 }
 
 impl<'a> CompileCtx<'a> {
@@ -139,11 +154,33 @@ impl<'a> CompileCtx<'a> {
             builder,
             enum_counter: 0,
             array_counter: 0,
+            depth: 0,
         })
     }
 
     /// Compile `schema` into a list of alternatives.
+    ///
+    /// Thin recursion-depth wrapper around [`Self::compile_schema_inner`]: every
+    /// recursive descent (refs, properties, items, `anyOf`) re-enters here, so a
+    /// single depth cap bounds all compile-time recursion (issue #343).
     fn compile_schema(
+        &mut self,
+        schema: &'a Value,
+        path: &[&str],
+    ) -> Result<Vec<Alt>, SchemaError> {
+        self.depth += 1;
+        if self.depth > MAX_SCHEMA_DEPTH {
+            self.depth -= 1;
+            return Err(SchemaError(format!(
+                "schema nesting / $ref chain exceeds the supported depth ({MAX_SCHEMA_DEPTH})"
+            )));
+        }
+        let result = self.compile_schema_inner(schema, path);
+        self.depth -= 1;
+        result
+    }
+
+    fn compile_schema_inner(
         &mut self,
         schema: &'a Value,
         _path: &[&str],

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -33,6 +33,19 @@ use crate::grammar::pda::{Alt, CompiledGrammar, GrammarBuilder, Symbol};
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// Maximum array cardinality (`minItems` / `maxItems`) the compiler will
+/// materialize.
+///
+/// `build_cardinality_array_alt` emits one grammar rule (or symbol) per
+/// required/optional item, and `build_bounded_tail` recurses once per unit of
+/// `maxItems - minItems` slack. A parseable schema with `maxItems` or
+/// `minItems` near `u64::MAX` (e.g. `18446744073709551615`) therefore overflows
+/// the stack or exhausts memory at compile time — reachable from untrusted
+/// schema input at `GrammarEngine::new` (issue #343). Constrained decoding has
+/// no real use for arrays anywhere near this many items; reject beyond the cap
+/// at the parse boundary with a typed error.
+const MAX_ARRAY_CARDINALITY: usize = 4096;
+
 /// Error returned by the JSON Schema compiler.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SchemaError(pub String);
@@ -344,6 +357,24 @@ impl<'a> CompileCtx<'a> {
             .get("maxItems")
             .and_then(Value::as_u64)
             .map(|v| v as usize);
+
+        // issue #343: cap cardinality before materializing per-item rules.
+        // `build_bounded_tail` recurses once per unit of slack and the required-
+        // item loop emits one symbol group per `minItems`, so an absurd
+        // `minItems`/`maxItems` (e.g. u64::MAX) overflows the stack / exhausts
+        // memory at compile time. Reject at the parse boundary.
+        if min_items > MAX_ARRAY_CARDINALITY {
+            return Err(SchemaError(format!(
+                "array schema minItems ({min_items}) exceeds the supported limit ({MAX_ARRAY_CARDINALITY})"
+            )));
+        }
+        if let Some(max) = max_items {
+            if max > MAX_ARRAY_CARDINALITY {
+                return Err(SchemaError(format!(
+                    "array schema maxItems ({max}) exceeds the supported limit ({MAX_ARRAY_CARDINALITY})"
+                )));
+            }
+        }
 
         // issue #310 finding #2: validate cardinality constraints up front.
         if let Some(max) = max_items {

--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -62,6 +62,19 @@ pub enum Symbol {
     NonTerminal(usize),
 }
 
+/// Maximum PDA stack depth before an advance is rejected.
+///
+/// A left-recursive or cyclic grammar (`root ::= root`, or a JSON-Schema `$ref`
+/// cycle) makes `try_advance_stack` push non-terminal frames without ever
+/// consuming a byte, growing the stack without bound — a hang reachable from
+/// untrusted grammar input at `GrammarEngine::new` (issue #343). Capping the
+/// depth turns that into a bounded rejection (the grammar becomes a dead
+/// grammar that accepts nothing) instead of an OOM. The bound is far above any
+/// real nesting: `serde_json` itself caps recursion at 128, and each JSON level
+/// expands to only a handful of PDA frames, so 8192 frames is unreachable by a
+/// well-formed grammar on well-formed output.
+pub(crate) const MAX_PDA_DEPTH: usize = 8192;
+
 /// A compiled grammar rule: a name and a set of alternatives.
 #[derive(Debug, Clone)]
 pub struct Rule {
@@ -207,6 +220,11 @@ fn try_advance_stack(stack: &mut Vec<StackFrame>, grammar: &CompiledGrammar, b: 
     loop {
         if stack.is_empty() {
             // Stack empty and we still have a byte to consume → reject.
+            return false;
+        }
+        if stack.len() > MAX_PDA_DEPTH {
+            // Cyclic / left-recursive grammar pushing frames without progress
+            // (issue #343). Reject rather than grow the stack unbounded.
             return false;
         }
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #343.

## Problem

Three untrusted-grammar inputs hang or crash `GrammarEngine::new` (the structured-output
request boundary, `engine.rs:152`). Confirmed empirically via a throwaway repro
(`timeout 20` → HANG / HANG / SIGABRT):

| Input | Mechanism | Pre-fix |
|-------|-----------|---------|
| GBNF `root ::= root` | `try_advance_stack` pushes PDA frames without consuming a byte | HANG (OOM) |
| JSON-Schema `$ref` cycle | `compile_ref` terminates but emits a cyclic grammar → same PDA cycle | HANG |
| `maxItems: 18446744073709551615` | `build_bounded_tail` recurses per slack unit | CRASH (stack overflow) |
| `minItems: 18446744073709551615` (sibling) | `1..min` required-item loop | HANG/OOM |

`enumerate_grammar_states` runs over every vocab token **at construction**, so the explosion
happens before any masking; the existing `MAX_GRAMMAR_STATES` breadth cap can't fire because a
single `simulate_token` never returns.

## Fix (contained, revertable)

- **`pda.rs`** — `MAX_PDA_DEPTH = 8192`: `try_advance_stack` rejects the byte when the PDA stack
  exceeds it. A cyclic/left-recursive grammar becomes a bounded *dead grammar* (accepts nothing)
  instead of hanging. 8192 frames is far above any real nesting — `serde_json` itself caps
  recursion at 128, and each JSON level expands to only a handful of PDA frames.
- **`json_schema.rs:compile_array`** — `MAX_ARRAY_CARDINALITY = 4096`: reject `minItems`/`maxItems`
  beyond the cap with a typed `SchemaError` at the parse boundary (matching the #310/#342 pattern).
  Bounds both `build_bounded_tail` recursion depth and the required-item loop.

Proper compile-time cyclic-grammar detection (a clear "cyclic grammar rejected" error rather than a
silent dead grammar) is a reasonable follow-up; this PR removes the DoS now.

## Tests

4 new regression tests in `engine.rs` (cyclic GBNF, cyclic `$ref`, `maxItems`, `minItems`), each
**red/green proved**: with the guard temporarily stripped, the cyclic tests hang (`timeout` rc 124)
and the `maxItems` test aborts (`SIGABRT`); with the guard, all pass. 67 grammar tests green,
clippy clean.

## Bench

N/A — load-time construction guards; the hot path (`mask_logits`/`advance`) is unchanged. A single
`stack.len()` comparison is added to the per-byte advance loop (negligible, only relevant on
pathological input). `e2e-parity.yml` gates greedy-token correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
