### PR TITLE
refactor(inference): unify CPU sampling RNG onto one canonical primitive

### DIFF
--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -134,21 +134,27 @@ fn draw_from_distribution(probs: &[(usize, f32)], rng_state: &mut u64) -> u32 {
     let mut cumsum = 0.0f32;
     for &(idx, p) in probs {
         cumsum += p;
-        if r <= cumsum {
+        // Canonical strict-less-than boundary: r is in [0, 1) and cumsum grows
+        // toward 1.0, so `r < cumsum` is the textbook-correct inverse-CDF draw.
+        // `r <= cumsum` could double-count the boundary probability and — before
+        // the 53-bit fix — could be reached with r == 1.0 (rounding artifact),
+        // mishandling that edge case.
+        if r < cumsum {
             return idx as u32;
         }
     }
     probs[0].0 as u32
 }
 
-/// Xorshift64 PRNG. Returns a value in [0, 1).
+/// Canonical uniform f32 in [0, 1) via the shared xorshift64 primitive.
+///
+/// Delegates to `crate::sampling::xorshift64_next` (shifts 13/7/17, full period
+/// over nonzero state) and `crate::sampling::uniform_f32_from_u64` (top-24-bit
+/// conversion, provably strictly < 1.0). Both CPU sampling paths now share these
+/// primitives, producing identical seeded token streams from the same seed.
 pub(crate) fn xorshift64(state: &mut u64) -> f32 {
-    let mut s = *state;
-    s ^= s << 13;
-    s ^= s >> 7;
-    s ^= s << 17;
-    *state = s;
-    (s >> 11) as f32 / (1u64 << 53) as f32
+    let x = crate::sampling::xorshift64_next(state);
+    crate::sampling::uniform_f32_from_u64(x)
 }
 
 #[cfg(test)]
@@ -258,5 +264,81 @@ mod tests {
         let mut rng = 7u64;
         let token = sample_token(&logits, &cfg_rp, &[0], &mut rng);
         assert_eq!(token, 0, "NaN penalty must be a no-op");
+    }
+
+    #[test]
+    fn canonical_rng_streams_match_across_sampling_paths() {
+        // Both CPU sampling paths must produce the same seeded float stream once
+        // they share xorshift64_next + uniform_f32_from_u64.
+        // Note: crate::model::qwen35::sampling is private, so this test lives here
+        // where both xorshift64 (local) and the canonical primitives are reachable.
+        let seed = 0x1234_5678_9abc_def0u64;
+        let n = 32usize;
+
+        // Path 1: this module's xorshift64 (now delegates to the canonical primitives).
+        let mut state_q = seed;
+        let q35: Vec<f32> = (0..n).map(|_| xorshift64(&mut state_q)).collect();
+
+        // Path 2: direct use of xorshift64_next + uniform_f32_from_u64 from crate::sampling.
+        let mut state_c = seed;
+        let canonical: Vec<f32> = (0..n)
+            .map(|_| {
+                let x = crate::sampling::xorshift64_next(&mut state_c);
+                crate::sampling::uniform_f32_from_u64(x)
+            })
+            .collect();
+
+        assert_eq!(
+            q35, canonical,
+            "xorshift64 and canonical primitives must produce identical streams"
+        );
+    }
+
+    #[test]
+    fn draw_from_distribution_uses_strict_less_than() {
+        // Verify the draw boundary is `r < cumsum`, not `r <= cumsum`.
+        //
+        // Two-token distribution: prob 0.6 for token 0, prob 0.4 for token 1.
+        // We use two hardcoded seeds with known xorshift64 outputs:
+        //   seed 0x1234_5678_9abc_def0 -> r ≈ 0.9941  (> 0.6): must select token 1
+        //   seed 0xdead_beef_cafe_1234 -> r ≈ 0.1557  (< 0.6): must select token 0
+        //
+        // These were verified against the canonical xorshift64_next + uniform_f32_from_u64
+        // implementation at the time this test was written.
+        let probs: Vec<(usize, f32)> = vec![(0, 0.6), (1, 0.4)];
+
+        // Verify the expected r values hold (catches any future primitive change).
+        let seed_high = 0x1234_5678_9abc_def0u64;
+        let mut s = seed_high;
+        let r_high = xorshift64(&mut s);
+        assert!(
+            r_high > 0.6 && r_high < 1.0,
+            "seed {seed_high:#018x} must produce r > 0.6, got {r_high}"
+        );
+
+        let seed_low = 0xdead_beef_cafe_1234u64;
+        let mut s = seed_low;
+        let r_low = xorshift64(&mut s);
+        assert!(
+            r_low < 0.6,
+            "seed {seed_low:#018x} must produce r < 0.6, got {r_low}"
+        );
+
+        // With r > 0.6: cumsum after token 0 is 0.6, which is NOT > r, so strict `r < cumsum`
+        // is false → skip token 0.  Cumsum after token 1 is 1.0 > r → select token 1.
+        // Under the old `r <= cumsum` boundary this would also select token 1 here, but
+        // the canonical `<` is what the spec requires and what this test locks in.
+        let mut rng_high = seed_high;
+        let token_high = draw_from_distribution(&probs, &mut rng_high);
+        assert_eq!(
+            token_high, 1,
+            "r={r_high} > 0.6 must skip the first token (cumsum=0.6) and select token 1"
+        );
+
+        // With r < 0.6: cumsum after token 0 is 0.6 > r → strict `r < cumsum` is true
+        // → select token 0 immediately.
+        let mut rng_low = seed_low;
+        let token_low = draw_from_distribution(&probs, &mut rng_low);
+        assert_eq!(token_low, 0, "r={r_low} < 0.6 must select token 0");
     }
 }

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -154,8 +154,11 @@ fn draw_index(probs: &[(usize, f32)], r: f32) -> u32 {
 ///
 /// Delegates to `crate::sampling::xorshift64_next` (shifts 13/7/17, full period
 /// over nonzero state) and `crate::sampling::uniform_f32_from_u64` (top-24-bit
-/// conversion, provably strictly < 1.0). Both CPU sampling paths now share these
-/// primitives, producing identical seeded token streams from the same seed.
+/// conversion, provably strictly < 1.0). Both CPU sampling paths now share this
+/// canonical RNG primitive, so a fixed seed yields the same uniform draw stream.
+/// This does NOT guarantee identical token streams: the two paths still diverge
+/// below the RNG layer (top-k tie-break and the candidate-exhaustion fallback
+/// pick in opposite directions), so equal draws can still select different tokens.
 pub(crate) fn xorshift64(state: &mut u64) -> f32 {
     let x = crate::sampling::xorshift64_next(state);
     crate::sampling::uniform_f32_from_u64(x)

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -130,15 +130,19 @@ fn apply_top_p(probs: &mut Vec<(usize, f32)>, top_p: f32) {
 }
 
 fn draw_from_distribution(probs: &[(usize, f32)], rng_state: &mut u64) -> u32 {
-    let r = xorshift64(rng_state);
+    draw_index(probs, xorshift64(rng_state))
+}
+
+/// Inverse-CDF draw: return the first token whose cumulative probability exceeds
+/// `r`. The boundary is strict `r < cumsum`: the canonical uniform draw gives
+/// `r` in `[0, 1)`, so `r < cumsum` is the textbook-correct inverse-CDF and never
+/// double-counts a bucket boundary (`r <= cumsum` would, and is also unsafe for an
+/// `r` that reached exactly 1.0). Falls back to the first (highest-probability)
+/// token only if float error leaves the final cumsum just under `r`.
+fn draw_index(probs: &[(usize, f32)], r: f32) -> u32 {
     let mut cumsum = 0.0f32;
     for &(idx, p) in probs {
         cumsum += p;
-        // Canonical strict-less-than boundary: r is in [0, 1) and cumsum grows
-        // toward 1.0, so `r < cumsum` is the textbook-correct inverse-CDF draw.
-        // `r <= cumsum` could double-count the boundary probability and — before
-        // the 53-bit fix — could be reached with r == 1.0 (rounding artifact),
-        // mishandling that edge case.
         if r < cumsum {
             return idx as u32;
         }
@@ -295,30 +299,34 @@ mod tests {
     }
 
     #[test]
-    fn draw_from_distribution_uses_strict_less_than() {
+    fn draw_index_uses_strict_less_than_at_exact_boundary() {
         // Lock the draw boundary as `r < cumsum`, NOT `r <= cumsum`. The two
-        // operators only differ when `r` exactly equals a partial cumsum, so we
-        // construct precisely that case: make the first token's probability equal
-        // the drawn `r`. Then cumsum-after-token-0 == r exactly, and
-        //   `r < cumsum`  -> `r < r`  == false -> skip token 0, select token 1
-        //   `r <= cumsum` -> `r <= r` == true  -> select token 0
-        // so a regression back to `<=` flips this assertion and fails the test.
-        let seed = 0x1234_5678_9abc_def0u64;
-
-        // Draw r the same way draw_from_distribution will (advance a copy).
-        let mut probe = seed;
-        let r = xorshift64(&mut probe);
-        assert!((0.0..1.0).contains(&r), "r must be in [0, 1), got {r}");
-
-        // First token's prob == r exactly; cumsum after it is `0.0 + r == r` (exact in f32).
-        let probs: Vec<(usize, f32)> = vec![(0, r), (1, 1.0 - r)];
-
-        let mut rng = seed;
-        let token = draw_from_distribution(&probs, &mut rng);
+        // operators differ ONLY when `r` exactly equals a partial cumsum. Use
+        // values that are exact in f32 (0.5) so there is no rounding ambiguity and
+        // no dependence on the RNG reproducing a bit-identical float: r == 0.5,
+        // first token prob == 0.5, so cumsum after token 0 is `0.0 + 0.5 == 0.5`.
+        //   `r < cumsum`  -> `0.5 < 0.5`  == false -> skip token 0, select token 1
+        //   `r <= cumsum` -> `0.5 <= 0.5` == true  -> select token 0
+        // A regression back to `<=` flips this and fails the test.
+        let probs: Vec<(usize, f32)> = vec![(0, 0.5), (1, 0.5)];
         assert_eq!(
-            token, 1,
-            "with cumsum==r at the boundary, strict `r < cumsum` must skip token 0 \
-             and select token 1 (a `r <= cumsum` regression would select token 0)"
+            draw_index(&probs, 0.5),
+            1,
+            "at the exact boundary (cumsum == r), strict `r < cumsum` must skip \
+             token 0 and select token 1 (a `r <= cumsum` regression selects token 0)"
+        );
+
+        // Sanity: r below the first bucket selects token 0; r at/above the last
+        // bucket's cumsum (only reachable via float error) falls back to token 0.
+        assert_eq!(
+            draw_index(&probs, 0.25),
+            0,
+            "r below first cumsum picks token 0"
+        );
+        assert_eq!(
+            draw_index(&probs, 0.75),
+            1,
+            "r between the two bucket boundaries picks token 1"
         );
     }
 }

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -296,49 +296,29 @@ mod tests {
 
     #[test]
     fn draw_from_distribution_uses_strict_less_than() {
-        // Verify the draw boundary is `r < cumsum`, not `r <= cumsum`.
-        //
-        // Two-token distribution: prob 0.6 for token 0, prob 0.4 for token 1.
-        // We use two hardcoded seeds with known xorshift64 outputs:
-        //   seed 0x1234_5678_9abc_def0 -> r ≈ 0.9941  (> 0.6): must select token 1
-        //   seed 0xdead_beef_cafe_1234 -> r ≈ 0.1557  (< 0.6): must select token 0
-        //
-        // These were verified against the canonical xorshift64_next + uniform_f32_from_u64
-        // implementation at the time this test was written.
-        let probs: Vec<(usize, f32)> = vec![(0, 0.6), (1, 0.4)];
+        // Lock the draw boundary as `r < cumsum`, NOT `r <= cumsum`. The two
+        // operators only differ when `r` exactly equals a partial cumsum, so we
+        // construct precisely that case: make the first token's probability equal
+        // the drawn `r`. Then cumsum-after-token-0 == r exactly, and
+        //   `r < cumsum`  -> `r < r`  == false -> skip token 0, select token 1
+        //   `r <= cumsum` -> `r <= r` == true  -> select token 0
+        // so a regression back to `<=` flips this assertion and fails the test.
+        let seed = 0x1234_5678_9abc_def0u64;
 
-        // Verify the expected r values hold (catches any future primitive change).
-        let seed_high = 0x1234_5678_9abc_def0u64;
-        let mut s = seed_high;
-        let r_high = xorshift64(&mut s);
-        assert!(
-            r_high > 0.6 && r_high < 1.0,
-            "seed {seed_high:#018x} must produce r > 0.6, got {r_high}"
-        );
+        // Draw r the same way draw_from_distribution will (advance a copy).
+        let mut probe = seed;
+        let r = xorshift64(&mut probe);
+        assert!((0.0..1.0).contains(&r), "r must be in [0, 1), got {r}");
 
-        let seed_low = 0xdead_beef_cafe_1234u64;
-        let mut s = seed_low;
-        let r_low = xorshift64(&mut s);
-        assert!(
-            r_low < 0.6,
-            "seed {seed_low:#018x} must produce r < 0.6, got {r_low}"
-        );
+        // First token's prob == r exactly; cumsum after it is `0.0 + r == r` (exact in f32).
+        let probs: Vec<(usize, f32)> = vec![(0, r), (1, 1.0 - r)];
 
-        // With r > 0.6: cumsum after token 0 is 0.6, which is NOT > r, so strict `r < cumsum`
-        // is false → skip token 0.  Cumsum after token 1 is 1.0 > r → select token 1.
-        // Under the old `r <= cumsum` boundary this would also select token 1 here, but
-        // the canonical `<` is what the spec requires and what this test locks in.
-        let mut rng_high = seed_high;
-        let token_high = draw_from_distribution(&probs, &mut rng_high);
+        let mut rng = seed;
+        let token = draw_from_distribution(&probs, &mut rng);
         assert_eq!(
-            token_high, 1,
-            "r={r_high} > 0.6 must skip the first token (cumsum=0.6) and select token 1"
+            token, 1,
+            "with cumsum==r at the boundary, strict `r < cumsum` must skip token 0 \
+             and select token 1 (a `r <= cumsum` regression would select token 0)"
         );
-
-        // With r < 0.6: cumsum after token 0 is 0.6 > r → strict `r < cumsum` is true
-        // → select token 0 immediately.
-        let mut rng_low = seed_low;
-        let token_low = draw_from_distribution(&probs, &mut rng_low);
-        assert_eq!(token_low, 0, "r={r_low} < 0.6 must select token 0");
     }
 }

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -202,6 +202,25 @@ impl CandidateSet {
     }
 }
 
+/// Canonical xorshift64 state advance shared by every CPU sampling path.
+/// Shifts 13/7/17 give a full period over nonzero state.
+pub(crate) fn xorshift64_next(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    x
+}
+
+/// Canonical uniform f32 in [0, 1) from a 64-bit random word. Uses the top 24
+/// bits (the f32 mantissa width) so the result is a uniform over representable
+/// f32 values in [0, 1) and is provably strictly < 1.0 — unlike a 53-bit
+/// integer cast to f32, which rounds up to exactly 1.0 at the top of the range.
+pub(crate) fn uniform_f32_from_u64(x: u64) -> f32 {
+    (x >> 40) as f32 / (1u64 << 24) as f32
+}
+
 /// Xorshift64 PRNG for sampling (no external dependency).
 struct Rng {
     state: u64,
@@ -215,17 +234,12 @@ impl Rng {
     }
 
     fn next_u64(&mut self) -> u64 {
-        let mut x = self.state;
-        x ^= x << 13;
-        x ^= x >> 7;
-        x ^= x << 17;
-        self.state = x;
-        x
+        xorshift64_next(&mut self.state)
     }
 
     /// Returns a uniform f32 in [0, 1).
     fn next_f32(&mut self) -> f32 {
-        (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32
+        uniform_f32_from_u64(self.next_u64())
     }
 }
 
@@ -1439,5 +1453,29 @@ mod tests {
             1,
             "duplicate history id must be penalized once, not per occurrence"
         );
+    }
+
+    // ── canonical RNG primitive tests ────────────────────────────────────────
+
+    #[test]
+    fn uniform_f32_from_u64_is_always_in_unit_interval() {
+        // The canonical 24-bit conversion must be in [0, 1) for all u64 values —
+        // in particular u64::MAX must NOT round up to exactly 1.0 (the latent bug
+        // in the 53-bit `(s >> 11) as f32 / 2^53` path).
+        for x in [
+            0u64,
+            1,
+            u64::MAX,
+            0xFFFF_FFFF_FFFF_FFFF,
+            1u64 << 40,
+            (1u64 << 40) - 1,
+            0x8000_0000_0000_0000,
+        ] {
+            let f = uniform_f32_from_u64(x);
+            assert!(
+                (0.0..1.0).contains(&f),
+                "uniform_f32_from_u64({x:#018x}) = {f} is not in [0, 1)"
+            );
+        }
     }
 }

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,19 @@
+## Highlights
+
+**CPU sampling RNG consolidation (seeded-stream break).** The two CPU sampling paths — the generic `Sampler` (`crate::sampling`) and the Qwen3.5 `sample_token` path (`crate::model::qwen35::sampling`) — previously carried *independent* implementations of the xorshift64 PRNG and its `u64 → f32` conversion. The conversions diverged (24-bit `(x >> 40) / 2^24`, provably `< 1.0`, vs 53-bit `(x >> 11) / 2^53`, which rounds to exactly `1.0` at `u64::MAX`) and the inverse-CDF comparison diverged (`r < cumsum` vs `r <= cumsum`). This release unifies both paths onto a single canonical primitive.
+
+## Breaking changes
+
+- **Seeded token stream changes for the Qwen3.5 stochastic path.** The Qwen3.5 path now draws uniforms via the shared `xorshift64_next` + 24-bit `uniform_f32_from_u64` primitive (previously 53-bit), and its inverse-CDF draw now uses strict `r < cumsum` (previously `r <= cumsum`). A fixed `--seed` with `--temperature > 0` therefore produces a **different** (but equally valid) token sequence than v0.2.x. Greedy decoding (`temperature == 0` / argmax) is **unaffected** and byte-identical — the e2e-parity gate stays green.
+  - **Who is affected:** anyone pinning exact stochastic outputs to a seed (golden-output tests, reproducibility harnesses) across the v0.2.x → v0.3.0 boundary. Re-baseline seeded expectations against v0.3.0.
+  - **Why:** the old 53-bit conversion could emit exactly `1.0`, which falls through `r < cumsum` to the worst candidate — a real (if rare) reproducibility/correctness hazard. The unified 24-bit primitive is provably `< 1.0`.
+- The generic `Sampler` path is **byte-identical** to v0.2.x — its `next_u64`/`next_f32` were factored into the shared free functions without changing the bit math.
+
+## Scope / non-goals
+
+- The shared primitive guarantees both CPU paths consume the **same uniform draw stream** from a fixed seed. It does **not** guarantee identical *token* streams: the paths still diverge below the RNG layer (top-k tie-break — `Sampler` heap breaks ties toward the lower token id, `sample_token` does not; and the candidate-exhaustion fallback picks in opposite directions — lowest-prob vs highest-prob). Unifying those selection semantics is out of scope here.
+- The Metal host inline sampler (`forward/metal_qwen35.rs`) carries a **third** `u64 → f32` conversion (`raw / u64::MAX`, which can equal `1.0`). It is unchanged in this release and tracked as [#351](https://github.com/ohdearquant/lattice/issues/351) (Metal GPU-capture session, Ocean-gated).
+
+## Diff stats
+
+3 files (`crates/inference/src/sampling.rs`, `crates/inference/src/model/qwen35/sampling.rs`, this note). RNG primitive extracted to `pub(crate)` free functions; both paths delegate. Added unit tests: unit-interval invariant across edge `u64` values, cross-path RNG-stream equality, and strict-less-than boundary behaviour at an exact `cumsum == r` tie.


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Unify the two divergent CPU sampling RNG primitives onto one canonical implementation. `crate::sampling::Sampler` (used by `generate.rs`) and `model::qwen35::sample_token` (used by neon_forward / cpu_f16 / cpu_q8 / generation.rs / batch_prefill / metal orchestration) previously used **different** u64→f32 conversions and **different** multinomial draw boundaries, so the same seed produced different token streams — a reproducibility/parity bug.

- Extract `xorshift64_next` (shifts 13/7/17) + `uniform_f32_from_u64` (top-24-bit, provably `< 1.0`) into `crate::sampling` as the single source of truth.
- Route both paths through them; align the qwen35 draw to the canonical `r < cumsum`.
- Extract `draw_index(probs, r)` so the inverse-CDF boundary is unit-testable without RNG round-tripping.

## Why the 53-bit path was wrong

The old qwen35 conversion `(s >> 11) as f32 / (1u64 << 53) as f32` casts a 53-bit integer to f32 (24-bit mantissa); at the top of the range it **rounds to exactly 1.0** (verified: `u64::MAX` → `1.0`). Combined with `r <= cumsum` this mishandles the boundary. The canonical top-24-bit form is provably `< 1.0`.

## ⚠️ Behavior change (read before merge)

This **changes the seeded stochastic token stream** of the qwen35 production CPU + metal-orchestration decode paths (temperature > 0 with a fixed seed). `Sampler` (Path 1) output is **byte-identical** — its formula was already the canonical one, so only the qwen35 path moves onto it. **Greedy / temperature-0 / degenerate-temperature decoding is unaffected** (routes to argmax, RNG-independent), so the e2e-parity gate (greedy-only) stays green.

**Release-note action for the maintainer:** for a published crate, note in the next release that seeded stochastic sampling output differs from prior versions (anyone who pinned a seed for reproducibility will see different — and now more-correct — draws). Greedy output is unchanged.

## Scope

- A **third** divergent RNG exists in the Metal host sampler (`metal_qwen35.rs:12905`, `r = raw as f64 / u64::MAX as f64` — can equal exactly 1.0). It is **deliberately not touched** here (Metal is GPU-capture, held pending maintainer review) and is filed as #351 to route it through the same shared primitives when Metal work is unblocked.

## Tests

- `uniform_f32_from_u64_is_always_in_unit_interval` — 7 edge u64 (incl `u64::MAX`) all strictly `< 1.0`.
- `canonical_rng_streams_match_across_sampling_paths` — same seed → byte-identical 32-float streams across both paths.
- `draw_index_uses_strict_less_than_at_exact_boundary` — exact-in-f32 `r == 0.5`, prob `0.5`; verified **red** under `r <= cumsum`, **green** under `r < cumsum`.

`cargo test -p lattice-inference --lib` → **1054 passed, 0 failed**. `cargo clippy -p lattice-inference --all-targets -- -D warnings` clean.

Reviewed by an independent critic agent; review flagged 2 major issues, both fixes applied (Metal-comment scoping → #351; boundary-test de-flake → `draw_index` seam). **Build for review — not for self-merge** (touches the e2e-adjacent decode path; awaiting maintainer review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
