### PR TITLE
fix(inference): metal sampler r==1.0 worst-token bug (#351)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -12865,7 +12865,11 @@ kernel void gdn_chunk_norm_silu_c32(
         cs.apply_temperature(cfg.temperature);
 
         let raw = xorshift64(rng_state);
-        let r = (raw as f64 / u64::MAX as f64) as f32;
+        // #351: `(raw as f64 / u64::MAX as f64) as f32` rounds up to exactly 1.0
+        // when raw == u64::MAX, and sample_top_p with r == 1.0 can select the
+        // worst-probability token. Route through the canonical [0, 1) helper
+        // (provably < 1.0), matching the CPU sampling path.
+        let r = crate::sampling::uniform_f32_from_u64(raw);
         cs.sample_top_p(cfg.top_p, r)
     }
 
@@ -12902,7 +12906,9 @@ kernel void gdn_chunk_norm_silu_c32(
         }
         cs.apply_temperature(cfg.temperature);
         cs.retain_top_k(cfg.top_k);
-        let r = (xorshift64(rng_state) as f64 / u64::MAX as f64) as f32;
+        // #351: see sample_from_candidates — avoid the r == 1.0 worst-token bug
+        // by routing through the canonical [0, 1) helper (provably < 1.0).
+        let r = crate::sampling::uniform_f32_from_u64(xorshift64(rng_state));
         cs.sample_top_p(cfg.top_p, r)
     }
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Closes #351. Both Metal sampling sites in `metal_qwen35.rs` drew the uniform random value as `(raw as f64 / u64::MAX as f64) as f32`. When `raw == u64::MAX` this rounds to **exactly 1.0**, and `sample_top_p(top_p, 1.0)` walks the entire nucleus CDF and can land on the worst-probability token in the set. A latent "worst-token" sampling bug on temperature>0 / top-p paths.

Both sites now route through the canonical `uniform_f32_from_u64` helper (`sampling.rs`), whose 24-bit conversion is provably in `[0, 1)` and is the exact primitive the CPU sampling path uses. This also makes the Metal and CPU samplers bit-consistent in their RNG→unit-interval mapping.

## Changes

- `sample_from_candidates`: `let r = crate::sampling::uniform_f32_from_u64(raw);`
- `sample_token`: `let r = crate::sampling::uniform_f32_from_u64(xorshift64(rng_state));`

8 lines, reuses an existing primitive (Π_AEP — no new code path).

## Testing

- Covered by the existing boundary test `uniform_f32_from_u64_is_always_in_unit_interval`, which asserts `u64::MAX` maps below 1.0. The fix is delegation to that already-guarded primitive, so no new test is added.
- `cargo build --release -p lattice-inference --features metal-gpu` — green
- `cargo clippy --release -p lattice-inference --features metal-gpu -- -D warnings` — clean

Note: `e2e-parity.yml` exercises **greedy** generation only, so it will not hit this temperature>0 / top-p path. The boundary test is the regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)