### PR TITLE
harden(inference): release-active soundness asserts on gdn_fused SIMD wrappers

### DIFF
--- a/crates/inference/src/attention/gdn_fused.rs
+++ b/crates/inference/src/attention/gdn_fused.rs
@@ -228,9 +228,14 @@ pub fn simd_matvec_transpose(
     key_dim: usize,
     value_dim: usize,
 ) {
-    debug_assert!(s.len() >= key_dim * value_dim);
-    debug_assert!(k.len() >= key_dim);
-    debug_assert!(kv_mem.len() >= value_dim);
+    // Release-active: these are the soundness preconditions for the unsafe SIMD
+    // kernels below (which load `key_dim`/`value_dim` lanes via raw pointers).
+    // `debug_assert!` is compiled out in release, so a malformed-slice call from
+    // this safe `pub fn` would reach an out-of-bounds SIMD load (UB). Promote to
+    // real checks so the contract violation panics deterministically instead.
+    assert!(s.len() >= key_dim * value_dim);
+    assert!(k.len() >= key_dim);
+    assert!(kv_mem.len() >= value_dim);
     #[cfg(target_arch = "x86_64")]
     {
         if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma")
@@ -267,9 +272,12 @@ pub fn simd_decay_and_rank1_update(
     key_dim: usize,
     value_dim: usize,
 ) {
-    debug_assert!(s.len() >= key_dim * value_dim);
-    debug_assert!(k.len() >= key_dim);
-    debug_assert!(delta.len() >= value_dim);
+    // Release-active: soundness preconditions for the unsafe SIMD kernels below.
+    // See `simd_matvec_transpose` for the rationale (debug_assert is removed in
+    // release, leaving the safe wrapper able to drive an OOB SIMD load).
+    assert!(s.len() >= key_dim * value_dim);
+    assert!(k.len() >= key_dim);
+    assert!(delta.len() >= value_dim);
     #[cfg(target_arch = "x86_64")]
     {
         if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma")
@@ -299,9 +307,12 @@ pub fn simd_decay_and_rank1_update(
 /// **Unstable**: SIMD-dispatched gated RMSNorm (AVX2/NEON/scalar fallback).
 #[inline]
 pub fn simd_gated_rms_norm(x: &[f32], z: &[f32], gamma: &[f32], out: &mut [f32], eps: f32) {
-    debug_assert_eq!(z.len(), x.len());
-    debug_assert_eq!(gamma.len(), x.len());
-    debug_assert!(out.len() >= x.len());
+    // Release-active: soundness preconditions for the unsafe SIMD kernels below.
+    // See `simd_matvec_transpose` for the rationale (debug_assert is removed in
+    // release, leaving the safe wrapper able to drive an OOB SIMD load).
+    assert_eq!(z.len(), x.len());
+    assert_eq!(gamma.len(), x.len());
+    assert!(out.len() >= x.len());
     #[cfg(target_arch = "x86_64")]
     {
         if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma")
@@ -1523,5 +1534,39 @@ mod tests {
             "fused decay gate must stay finite, got {g0}"
         );
         assert!(g0 < 1e-6, "expected g≈0 for huge decay rate, got {g0}");
+    }
+
+    // The safe public SIMD wrappers below dispatch to unsafe AVX2/NEON kernels
+    // that load `key_dim`/`value_dim`/`x.len()` lanes via raw pointers. A
+    // length-mismatched call must fail closed (panic) rather than read OOB. The
+    // guards are release-active `assert!`s, so these `#[should_panic]` tests hold
+    // in both debug and release builds.
+
+    #[test]
+    #[should_panic]
+    fn simd_matvec_transpose_rejects_short_k() {
+        let s = [0.0f32; 8];
+        let k = [0.0f32; 1]; // key_dim = 2 but only 1 element
+        let mut kv_mem = [0.0f32; 4];
+        simd_matvec_transpose(&s, &k, &mut kv_mem, 2, 4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn simd_decay_and_rank1_update_rejects_short_delta() {
+        let mut s = [0.0f32; 8];
+        let k = [0.0f32; 2];
+        let delta = [0.0f32; 1]; // value_dim = 4 but only 1 element
+        simd_decay_and_rank1_update(&mut s, &k, &delta, 0.5, 2, 4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn simd_gated_rms_norm_rejects_short_gamma() {
+        let x = [1.0f32; 8];
+        let z = [0.0f32; 8];
+        let gamma: [f32; 0] = []; // must equal x.len()
+        let mut out = [0.0f32; 8];
+        simd_gated_rms_norm(&x, &z, &gamma, &mut out, 1e-6);
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Problem

The safe public SIMD wrappers in `crates/inference/src/attention/gdn_fused.rs` —
`simd_matvec_transpose`, `simd_decay_and_rank1_update`, `simd_gated_rms_norm` —
guarded their unsafe AVX2/NEON dispatch with `debug_assert!` length checks only.

`debug_assert!` is compiled out in release builds. Because `pub mod attention`
(lib.rs:30) → `pub mod gdn_fused` re-exports these as `pub fn`s, a length-mismatched
call from outside the crate reaches an out-of-bounds SIMD load through raw pointers
(`_mm256_loadu_ps(ptr.add(i))` and the NEON equivalents) — undefined behavior in a
**safe** function.

### Concrete trigger (release, AVX2+FMA)

```rust
let x = [1.0f32; 8];
let z = [0.0f32; 8];
let gamma: [f32; 0] = [];          // must equal x.len()
let mut out = [0.0f32; 8];
simd_gated_rms_norm(&x, &z, &gamma, &mut out, 1e-6);
// debug: debug_assert catches it.
// release: reads 8 f32 from a zero-length slice via _mm256_loadu_ps(gamma.as_ptr()) → UB.
```

Found by an automated discovery pass over the attention module.

## Fix

Promote the length preconditions from `debug_assert!` to release-active
`assert!`/`assert_eq!` so a contract violation panics deterministically at the
soundness boundary instead of reading unrelated memory. This is the same hardening
class as #224 (SIMD shape-invariant guards), #250 (SIMD public-API contracts), and
#319 (release-active divisibility assert).

`simd_l2_normalize` is intentionally unchanged: it takes a single slice and is
self-consistent (no cross-slice length mismatch is possible).

## Tests

Three `#[should_panic]` regression tests, verified to fire in **both debug and
release** (the asserts are release-active by construction):

```
cargo test -p lattice-inference --lib attention::gdn_fused::         # 14 passed
cargo test --release -p lattice-inference --lib ...::tests::simd_    # 4 passed (panics fire in release)
cargo clippy -p lattice-inference -- -D warnings                     # clean
```

Behavior on correct inputs is unchanged (the asserts hold for all valid shapes;
the existing scalar/SIMD parity tests still pass).

## bench-compare

Not a perf change — the added checks are three integer comparisons per call,
outside the inner SIMD loop, on paths that already iterate `key_dim*value_dim`
floats. No measurable effect expected; this PR converts UB into a deterministic
panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)