### PR TITLE
harden(inference): validate MtpConfig scalars + RoPE position bound in MtpVerifier

### DIFF
--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -519,18 +519,28 @@ impl<'a> MtpVerifier<'a> {
                 config.num_hidden_layers
             )));
         }
-        if embed_tokens.len() != config.vocab_size * config.hidden_size {
+        // Checked product so a pathological public config returns a typed error
+        // instead of overflow-panicking (debug) or wrapping (release) before the
+        // shape comparison. Matches the FlatKVCache checked-arithmetic precedent.
+        let embed_numel = config
+            .vocab_size
+            .checked_mul(config.hidden_size)
+            .ok_or_else(|| {
+                InferenceError::Inference(format!(
+                    "MtpConfig vocab_size ({}) * hidden_size ({}) overflows usize",
+                    config.vocab_size, config.hidden_size
+                ))
+            })?;
+        if embed_tokens.len() != embed_numel {
             return Err(InferenceError::Inference(format!(
-                "embed_tokens length {} != vocab_size * hidden_size = {}",
+                "embed_tokens length {} != vocab_size * hidden_size = {embed_numel}",
                 embed_tokens.len(),
-                config.vocab_size * config.hidden_size
             )));
         }
-        if lm_head_weight.len() != config.vocab_size * config.hidden_size {
+        if lm_head_weight.len() != embed_numel {
             return Err(InferenceError::Inference(format!(
-                "lm_head_weight length {} != vocab_size * hidden_size = {}",
+                "lm_head_weight length {} != vocab_size * hidden_size = {embed_numel}",
                 lm_head_weight.len(),
-                config.vocab_size * config.hidden_size
             )));
         }
         if config.draft_length > 8 {
@@ -589,6 +599,18 @@ impl<'a> MtpVerifier<'a> {
         }
 
         let rope_dim = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
+        // Reject zero-width RoPE: rope_dim < 2 gives half_dim == 0, so
+        // RopeTable::max_positions() == 0 and the forward_one position bound
+        // would reject every position. A no-RoPE MTP is unsupported (Qwen3.5
+        // always uses partial RoPE); fail closed rather than run without
+        // positional encoding.
+        if rope_dim < 2 {
+            return Err(InferenceError::UnsupportedModel(format!(
+                "MTP requires a non-zero RoPE width: head_dim ({}) * partial_rotary_factor ({}) \
+                 yields rope_dim {rope_dim}, need >= 2",
+                config.head_dim, config.partial_rotary_factor
+            )));
+        }
         // RopeTable built with head_dim=rope_dim so half_dim = rope_dim/2
         let rope = crate::rope::RopeTable::new(rope_dim, max_seq_len.max(1), config.rope_theta);
 
@@ -3763,9 +3785,12 @@ mod tests {
         let weights = tiny_mtp_weights(&cfg);
         let embed: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
         let lm_head: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
+        let Err(err) = MtpVerifier::new(cfg, &weights, &embed, &lm_head, 8) else {
+            panic!("partial_rotary_factor > 1 must be rejected");
+        };
         assert!(
-            MtpVerifier::new(cfg, &weights, &embed, &lm_head, 8).is_err(),
-            "partial_rotary_factor > 1 must be rejected"
+            format!("{err:?}").contains("partial_rotary_factor"),
+            "expected partial_rotary_factor rejection, got: {err:?}"
         );
     }
 
@@ -3779,9 +3804,54 @@ mod tests {
         let weights = tiny_mtp_weights(&cfg);
         let embed: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
         let lm_head: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
+        let Err(err) = MtpVerifier::new(cfg, &weights, &embed, &lm_head, 8) else {
+            panic!("num_key_value_heads == 0 must be rejected");
+        };
         assert!(
-            MtpVerifier::new(cfg, &weights, &embed, &lm_head, 8).is_err(),
-            "num_key_value_heads == 0 must be rejected"
+            format!("{err:?}").contains("num_key_value_heads"),
+            "expected num_key_value_heads rejection, got: {err:?}"
+        );
+    }
+
+    /// MtpVerifier::new rejects zero-width RoPE (partial_rotary_factor == 0.0,
+    /// which the [0,1] scalar check accepts) before constructing a degenerate
+    /// RopeTable whose max_positions() == 0 would reject every forward_one
+    /// position (codex #362 Major: position-bound exactness for zero-width RoPE).
+    #[test]
+    fn mtp_new_rejects_zero_partial_rotary_factor() {
+        let mut cfg = tiny_mtp_config();
+        cfg.partial_rotary_factor = 0.0;
+        let weights = tiny_mtp_weights(&cfg);
+        let embed: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
+        let lm_head: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
+        let Err(err) = MtpVerifier::new(cfg, &weights, &embed, &lm_head, 8) else {
+            panic!("zero-width RoPE (partial_rotary_factor == 0) must be rejected");
+        };
+        assert!(
+            format!("{err:?}").contains("RoPE width"),
+            "expected zero-width RoPE rejection, got: {err:?}"
+        );
+    }
+
+    /// MtpVerifier::new returns Err (not a debug overflow-panic / release wrap)
+    /// when vocab_size * hidden_size overflows usize. Weights/embeds are tiny;
+    /// the checked product fires before any tensor-shape comparison
+    /// (codex #362 Medium: unchecked dimension products).
+    #[test]
+    fn mtp_new_rejects_dimension_product_overflow() {
+        let base = tiny_mtp_config();
+        let weights = tiny_mtp_weights(&base);
+        let embed: Vec<f32> = vec![0.0; base.vocab_size * base.hidden_size];
+        let lm_head: Vec<f32> = vec![0.0; base.vocab_size * base.hidden_size];
+        let mut cfg = tiny_mtp_config();
+        cfg.hidden_size = usize::MAX / 2 + 1;
+        cfg.vocab_size = 2;
+        let Err(err) = MtpVerifier::new(cfg, &weights, &embed, &lm_head, 8) else {
+            panic!("overflowing vocab_size * hidden_size must return Err, not panic");
+        };
+        assert!(
+            format!("{err:?}").contains("overflows usize"),
+            "expected overflow rejection, got: {err:?}"
         );
     }
 

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -611,6 +611,40 @@ impl<'a> MtpVerifier<'a> {
                 config.head_dim, config.partial_rotary_factor
             )));
         }
+        // Checked derived-dimension products. MtpScratch::new and FlatKVCache
+        // allocate from these, and num_attention_heads/head_dim can be oversized
+        // in a public config even with tiny weights (only weights.layers.len()
+        // is checked above), so a pathological config could overflow-panic
+        // (debug) or wrap (release) before construction. Validate the products
+        // here — the private MtpScratch::new and the cache config are only
+        // reached through this constructor, so upstream checking is sufficient.
+        let checked_dim = |a: usize, b: usize, what: &str| -> Result<usize, InferenceError> {
+            a.checked_mul(b).ok_or_else(|| {
+                InferenceError::Inference(format!(
+                    "MtpConfig dimension product {what} ({a} * {b}) overflows usize"
+                ))
+            })
+        };
+        let q_dim = checked_dim(
+            config.num_attention_heads,
+            config.head_dim,
+            "num_attention_heads * head_dim",
+        )?;
+        let kv_dim = checked_dim(
+            config.num_key_value_heads,
+            config.head_dim,
+            "num_key_value_heads * head_dim",
+        )?;
+        checked_dim(2, config.hidden_size, "2 * hidden_size")?;
+        checked_dim(2, q_dim, "2 * q_dim")?;
+        checked_dim(2, config.moe_intermediate_size, "2 * moe_intermediate_size")?;
+        checked_dim(
+            config.num_attention_heads,
+            max_seq_len,
+            "num_attention_heads * max_seq_len",
+        )?;
+        checked_dim(kv_dim, max_seq_len, "kv_dim * max_seq_len")?;
+
         // RopeTable built with head_dim=rope_dim so half_dim = rope_dim/2
         let rope = crate::rope::RopeTable::new(rope_dim, max_seq_len.max(1), config.rope_theta);
 
@@ -3852,6 +3886,29 @@ mod tests {
         assert!(
             format!("{err:?}").contains("overflows usize"),
             "expected overflow rejection, got: {err:?}"
+        );
+    }
+
+    /// MtpVerifier::new returns Err (not a panic) when num_attention_heads *
+    /// head_dim overflows. Reachable with TINY weights — only weights.layers.len()
+    /// is checked before MtpScratch/cache construction, so an oversized
+    /// num_attention_heads passes the scalar/divisibility checks (kv_heads=1)
+    /// yet overflows q_dim (codex #362 round-2 Medium: derived-dimension products).
+    #[test]
+    fn mtp_new_rejects_head_dim_product_overflow() {
+        let base = tiny_mtp_config();
+        let weights = tiny_mtp_weights(&base);
+        let embed: Vec<f32> = vec![0.0; base.vocab_size * base.hidden_size];
+        let lm_head: Vec<f32> = vec![0.0; base.vocab_size * base.hidden_size];
+        let mut cfg = tiny_mtp_config();
+        cfg.num_key_value_heads = 1;
+        cfg.num_attention_heads = usize::MAX / 4 + 1; // * head_dim (4) overflows
+        let Err(err) = MtpVerifier::new(cfg, &weights, &embed, &lm_head, 8) else {
+            panic!("overflowing num_attention_heads * head_dim must return Err, not panic");
+        };
+        assert!(
+            format!("{err:?}").contains("overflows usize"),
+            "expected dimension-product overflow rejection, got: {err:?}"
         );
     }
 

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -544,6 +544,50 @@ impl<'a> MtpVerifier<'a> {
             ));
         }
 
+        // Guard structural scalars: zero values cause divide-by-zero or OOB on
+        // first forward_one; partial_rotary_factor outside [0,1] produces a
+        // rope_dim > head_dim which overreads the per-head slice in
+        // mtp_apply_partial_rope.
+        if config.hidden_size == 0 {
+            return Err(InferenceError::Inference(
+                "MtpConfig hidden_size must be > 0".into(),
+            ));
+        }
+        if config.vocab_size == 0 {
+            return Err(InferenceError::Inference(
+                "MtpConfig vocab_size must be > 0".into(),
+            ));
+        }
+        if config.head_dim == 0 {
+            return Err(InferenceError::Inference(
+                "MtpConfig head_dim must be > 0".into(),
+            ));
+        }
+        if config.num_attention_heads == 0 {
+            return Err(InferenceError::Inference(
+                "MtpConfig num_attention_heads must be > 0".into(),
+            ));
+        }
+        if config.num_key_value_heads == 0 {
+            return Err(InferenceError::Inference(
+                "MtpConfig num_key_value_heads must be > 0".into(),
+            ));
+        }
+        if config.num_attention_heads % config.num_key_value_heads != 0 {
+            return Err(InferenceError::Inference(format!(
+                "MtpConfig num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
+                config.num_attention_heads, config.num_key_value_heads
+            )));
+        }
+        if !config.partial_rotary_factor.is_finite()
+            || !(0.0..=1.0).contains(&config.partial_rotary_factor)
+        {
+            return Err(InferenceError::Inference(format!(
+                "MtpConfig partial_rotary_factor {} is not in [0.0, 1.0]",
+                config.partial_rotary_factor
+            )));
+        }
+
         let rope_dim = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
         // RopeTable built with head_dim=rope_dim so half_dim = rope_dim/2
         let rope = crate::rope::RopeTable::new(rope_dim, max_seq_len.max(1), config.rope_theta);
@@ -606,6 +650,18 @@ impl<'a> MtpVerifier<'a> {
             return Err(InferenceError::InvalidInput(format!(
                 "MTP KV cache is full ({} tokens); call rollback_cache_to or reset_cache before forward_one",
                 self.cache.seq_len()
+            )));
+        }
+
+        // Guard RoPE table bounds: `position` is an independent parameter and
+        // can exceed `max_seq_len` even when the cache is not full.
+        // mtp_apply_partial_rope indexes at `position * half_dim + i`; if
+        // position >= rope.max_positions() that index is past the end of the
+        // precomputed table and panics.  Fail closed instead.
+        if position >= self.rope.max_positions() {
+            return Err(InferenceError::InvalidInput(format!(
+                "MTP forward_one position {position} out of range for RoPE table of {} positions",
+                self.rope.max_positions()
             )));
         }
 
@@ -3655,6 +3711,78 @@ mod tests {
             }
             Err(other) => panic!("expected InvalidInput for full cache, got {other:?}"),
         }
+    }
+
+    /// forward_one returns Err (not a panic) when `position` equals max_seq_len even
+    /// though the KV cache is not yet full.  This guards the RoPE table OOB path in
+    /// mtp_apply_partial_rope (independent `position` param, distinct from the #290
+    /// is_full guard).
+    #[test]
+    fn mtp_verifier_forward_one_out_of_range_position_returns_err() {
+        let cfg = tiny_mtp_config();
+        let weights = tiny_mtp_weights(&cfg);
+
+        let embed: Vec<f32> = (0..cfg.vocab_size * cfg.hidden_size)
+            .map(|i| ((i as f32 + 1.0) * 0.01).sin())
+            .collect();
+        let lm_head: Vec<f32> = (0..cfg.vocab_size * cfg.hidden_size)
+            .map(|i| ((i as f32 + 2.0) * 0.01).cos())
+            .collect();
+
+        let h = cfg.hidden_size;
+        let max_seq = 4usize;
+        let prev_hidden: Vec<f32> = (0..h).map(|i| 0.1 * (i as f32 + 1.0)).collect();
+
+        // Cache starts empty (seq_len == 0); pass position == max_seq so the
+        // cache is not full but the position is past the RoPE table.
+        let mut v = MtpVerifier::new(cfg, &weights, &embed, &lm_head, max_seq).unwrap();
+        assert_eq!(v.cache.seq_len(), 0, "cache must start empty");
+        assert!(!v.cache.is_full(), "cache must not be full yet");
+
+        match v.forward_one(1, max_seq, &prev_hidden) {
+            Ok(_) => panic!(
+                "forward_one with out-of-range position must return Err, not panic or succeed"
+            ),
+            Err(crate::InferenceError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("position"),
+                    "error message should mention position, got: {msg}"
+                );
+            }
+            Err(other) => panic!("expected InvalidInput for out-of-range position, got {other:?}"),
+        }
+    }
+
+    /// MtpVerifier::new rejects a config whose partial_rotary_factor is outside [0,1].
+    /// Factor 2.0 would produce rope_dim = 2 * head_dim, making mtp_apply_partial_rope
+    /// index head_vec[head_dim] on a head_dim-length slice (Bug 2 / scalar validation).
+    #[test]
+    fn mtp_new_rejects_partial_rotary_factor_above_one() {
+        let mut cfg = tiny_mtp_config();
+        cfg.partial_rotary_factor = 2.0;
+        let weights = tiny_mtp_weights(&cfg);
+        let embed: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
+        let lm_head: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
+        assert!(
+            MtpVerifier::new(cfg, &weights, &embed, &lm_head, 8).is_err(),
+            "partial_rotary_factor > 1 must be rejected"
+        );
+    }
+
+    /// MtpVerifier::new rejects a config with num_key_value_heads == 0.
+    /// Zero kv heads causes divide-by-zero at `groups = num_q_heads / num_kv_heads`
+    /// on the first forward_one (Bug 2 / scalar validation).
+    #[test]
+    fn mtp_new_rejects_zero_kv_heads() {
+        let mut cfg = tiny_mtp_config();
+        cfg.num_key_value_heads = 0;
+        let weights = tiny_mtp_weights(&cfg);
+        let embed: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
+        let lm_head: Vec<f32> = vec![0.0; cfg.vocab_size * cfg.hidden_size];
+        assert!(
+            MtpVerifier::new(cfg, &weights, &embed, &lm_head, 8).is_err(),
+            "num_key_value_heads == 0 must be rejected"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Problem

`pub mod speculative` (lib.rs:51) exposes `MtpConfig`, `MtpVerifier::new`, and
`MtpVerifier::forward_one` as public API. Two library-panic gaps were reachable
through them on config/model-influenced input (library code must return `Err`,
not panic).

### Bug 1 — `forward_one` panics on out-of-range RoPE `position`

The `#290` guard only checks `is_full()` (cache `seq_len == max_seq_len`). But
`position` is an **independent** parameter. With a non-full cache and
`position >= rope.max_positions()`, `mtp_apply_partial_rope` indexes the RoPE
table at `position * half + i` out of bounds → panic.

### Bug 2 — `MtpVerifier::new` accepts malformed `MtpConfig` scalars

`new` validated layer/embed/lm_head shapes but not the structural scalars:

- `partial_rotary_factor` outside `[0,1]` → `rope_dim = head_dim * factor > head_dim`
  → `mtp_apply_partial_rope` reads `head_vec[head_dim]` off a `head_dim`-length slice.
- `num_key_value_heads == 0` → divide-by-zero at `num_q_heads / num_kv_heads`.
- zero `hidden_size`/`vocab_size`/`head_dim`/`num_attention_heads`, or non-divisible
  head counts → downstream OOB / malformed GQA grouping.

A bad config constructed `Ok` and panicked on first `forward_one`.

Found by a discovery review pass over `speculative.rs`.

## Fix

1. `forward_one`: add `position < self.rope.max_positions()` check returning
   `Err(InvalidInput)`, right after the existing `is_full()` guard.
2. `MtpVerifier::new`: add a scalar-validation block (nonzero dims, divisible head
   counts, finite `partial_rotary_factor ∈ [0,1]`) returning typed `Err` before any
   panic-prone math — matching the `#296`/`#342` Qwen35Config guard pattern.

Same fail-closed hardening class as `#290`/`#350`. Behavior is unchanged for valid
configs and inputs (existing 61 tests still green).

## Tests

3 new regression tests (out-of-range position, `partial_rotary_factor > 1`,
`num_key_value_heads == 0`):

```
cargo test -p lattice-inference --lib speculative::tests   # 64 passed (was 61)
cargo clippy -p lattice-inference --lib -- -D warnings      # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
