### PR TITLE
harden(inference): flash.rs release-active overflow guards for tiled shape + scratch products

### DIFF
--- a/crates/inference/src/attention/flash.rs
+++ b/crates/inference/src/attention/flash.rs
@@ -188,6 +188,8 @@ impl TiledAttentionBuffers {
         let d = config.head_dim.max(1);
         let seq = max_seq_len.max(1);
 
+        assert_tiled_scratch_no_overflow(br, bc, d, seq);
+
         resize_zeroed(&mut self.q_tile, br * d);
         resize_zeroed(&mut self.k_tile, bc * d);
         resize_zeroed(&mut self.v_tile, bc * d);
@@ -230,6 +232,75 @@ fn resize_zeroed(buffer: &mut Vec<f32>, len: usize) {
     if buffer.len() < len {
         buffer.resize(len, 0.0);
     }
+}
+
+/// Reject tile/sequence shape products that wrap `usize` before scratch allocation.
+///
+/// `TiledAttentionConfig::{tile_size_q, tile_size_kv, head_dim}` are public, caller-controlled
+/// fields, so an arbitrary tile size can wrap a scratch-length product (`tile_q * tile_kv`,
+/// `tile_kv * head_dim`, ...) to a small value. `resize_zeroed` would then allocate an undersized
+/// buffer that the core kernel later slices as if the unwrapped tile were present, panicking from
+/// an internal bound instead of rejecting the impossible config. This is the non-causal sibling of
+/// the `flash_causal.rs` tile-scratch overflow guard (#366). Release-active: the wrap is invisible
+/// to a debug-only check.
+#[inline]
+fn assert_tiled_scratch_no_overflow(br: usize, bc: usize, head_dim: usize, seq: usize) {
+    assert!(
+        br.checked_mul(bc).is_some(),
+        "tiled scratch overflow: tile_q * tile_kv"
+    );
+    assert!(
+        br.checked_mul(head_dim).is_some(),
+        "tiled scratch overflow: tile_q * head_dim"
+    );
+    assert!(
+        bc.checked_mul(head_dim).is_some(),
+        "tiled scratch overflow: tile_kv * head_dim"
+    );
+    assert!(
+        seq.checked_mul(head_dim).is_some(),
+        "tiled scratch overflow: max_seq_len * head_dim"
+    );
+}
+
+/// Reject multi-head projection shape products that wrap `usize` before the release length asserts.
+///
+/// The release-active `assert_eq!(hidden_size, num_q_heads * head_dim)` and the derived
+/// `seq_len * q_proj_dim` / `seq_len * kv_proj_dim` slice lengths in
+/// `tiled_multi_head_attention_in_place` are computed with plain `*`. A wrapping
+/// `num_q_heads * head_dim` makes the `hidden_size` assert *accept* an impossible head layout, then
+/// per-head extraction (`head_index * head_dim`, `src[start..start + head_dim]`) indexes a buffer
+/// sized for the wrapped (tiny) shape and reads out of bounds. Mirrors
+/// `flash_causal.rs::assert_flash_no_overflow` (#366). Caller guarantees `num_kv_heads != 0` and
+/// `num_q_heads % num_kv_heads == 0` (asserted at the call site).
+#[inline]
+fn assert_flash_tiled_no_overflow(
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    seq_len: usize,
+    hidden_size: usize,
+) {
+    assert!(
+        num_q_heads.checked_mul(head_dim).is_some(),
+        "tiled shape overflow: num_q_heads * head_dim"
+    );
+    assert!(
+        num_kv_heads.checked_mul(head_dim).is_some(),
+        "tiled shape overflow: num_kv_heads * head_dim"
+    );
+    assert!(
+        seq_len.checked_mul(hidden_size).is_some(),
+        "tiled shape overflow: seq_len * hidden_size"
+    );
+    assert!(
+        seq_len.checked_mul(num_q_heads * head_dim).is_some(),
+        "tiled shape overflow: seq_len * q_proj_dim"
+    );
+    assert!(
+        seq_len.checked_mul(num_kv_heads * head_dim).is_some(),
+        "tiled shape overflow: seq_len * kv_proj_dim"
+    );
 }
 
 #[inline]
@@ -617,6 +688,8 @@ pub(crate) fn tiled_multi_head_attention_in_place(
         "config.num_kv_heads must match"
     );
     assert_eq!(config.head_dim, head_dim, "config.head_dim must match");
+    assert_ne!(num_kv_heads, 0, "num_kv_heads must be > 0");
+    assert_flash_tiled_no_overflow(num_q_heads, num_kv_heads, head_dim, seq_len, hidden_size);
     assert_eq!(hidden_states.len(), seq_len * hidden_size);
     assert_eq!(attention_mask.len(), seq_len);
     assert_eq!(hidden_size, num_q_heads * head_dim);
@@ -1411,5 +1484,33 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "tiled scratch overflow")]
+    fn tile_config_scratch_overflow_is_rejected() {
+        // Public `TiledAttentionConfig` fields let a caller pick a tile size that wraps
+        // `tile_kv * head_dim` to 0; the guard must reject it before `ensure_capacity` allocates
+        // an undersized scratch buffer. External head shapes are valid.
+        let config = TiledAttentionConfig {
+            tile_size_q: 2,
+            tile_size_kv: 1usize << 63,
+            num_q_heads: 1,
+            num_kv_heads: 1,
+            head_dim: 2,
+        };
+        let _buffers = TiledAttentionBuffers::new(2, &config);
+    }
+
+    #[test]
+    #[should_panic(expected = "tiled shape overflow")]
+    fn entry_shape_overflow_is_rejected_not_silently_accepted() {
+        // `num_q_heads * head_dim` wraps to a small value; without the guard the
+        // `hidden_size == num_q_heads * head_dim` release assert would accept an impossible head
+        // layout and per-head extraction would index out of bounds. Exercised directly because the
+        // only call site (`tiled_multi_head_attention_in_place`) needs a fully-populated
+        // 16-tensor `TransformerLayerWeights`; the guard placement before the products is verified
+        // by inspection/review.
+        assert_flash_tiled_no_overflow((1usize << 63) + 1, 1, 2, 2, 2);
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Non-causal sibling of the flash_causal.rs overflow hardening (#366). A warm-start discovery review sweep (seeded with the confirmed attention-kernel overflow bug-class) found the **same unchecked-usize-shape-product class** in the CPU tiled FlashAttention kernel `crates/inference/src/attention/flash.rs`. Two release-active asserts could accept impossible buffers because their products wrap on 64-bit before the check:

### Major — entry shape products (`tiled_multi_head_attention_in_place`)
`num_q_heads * head_dim`, `seq_len * hidden_size`, `seq_len * q_proj_dim`, `seq_len * kv_proj_dim` are computed with plain `*` before/inside the release `assert_eq!`s. A wrapping `num_q_heads * head_dim` makes `assert_eq!(hidden_size, num_q_heads * head_dim)` *accept* an impossible head layout; per-head extraction then computes `head_index * head_dim` and slices `src[start..start + head_dim]` out of bounds (trigger: `num_q_heads = (1<<63)+1, num_kv_heads = 1, head_dim = 2, seq_len = 2` → `q_all[4..6]` on a 4-element buffer). Guarded by `assert_flash_tiled_no_overflow` placed before the products.

### Medium — tile-scratch products (`TiledAttentionBuffers::ensure_capacity`)
`tile_q * tile_kv`, `tile_kv * head_dim`, `max_seq_len * head_dim` are sized from the **public, caller-controlled** `TiledAttentionConfig` fields. A wrapping tile size (e.g. `tile_kv = 1<<63` → `tile_kv * head_dim` wraps to 0) allocates undersized scratch, then the kernel slices it as if the full tile were present and panics from an internal bound. Guarded by `assert_tiled_scratch_no_overflow` at the single choke point (`ensure_capacity`, reached by both `new()` and the public per-head/multi-head entries).

Both guards are release-active precondition `assert!`s on a safe public API gating downstream unchecked indexing — matching the `decode.rs` (#365) / `flash_causal.rs` (#366) precedent (a wrapping product is invisible to the existing debug-only checks).

## Bug-class TBV (verified + rejected)
- **Class 1 overflow:** VULNERABLE → fixed here (both findings).
- **Class 2 NEON-softmax NaN asymmetry:** CLEAN / N-A — flash.rs's online softmax is **scalar** (no `vmaxq_f32`/`vmaxvq_f32` reduction); a NaN/+inf score already fail-closes via `denom > 0.0` → `fill(0.0)`. TBV true-negative.
- **Class 3 safe-pub→unsafe-SIMD:** the per-tile `matmul_bt` calls are release-bounds-checked slices (clean). Review flagged a *separate* surface — the **projection** matmuls pass `TransformerLayerWeights.data` after debug-only shape checks (non-macOS SIMD only). That is a cross-kernel weight-validation pattern (spans standard/gated/differential too), tracked as a follow-up issue, **out of scope** for this tight overflow PR.
- **Finite `MASK_VALUE` (-10000) sentinel:** pre-existing, design-gated, already tracked as #361 — not touched (changing flash.rs alone breaks parity with the materialized path).

## Testing
- Two `should_panic` regression tests: `tile_config_scratch_overflow_is_rejected` (realistic public `TiledAttentionBuffers::new` path), `entry_shape_overflow_is_rejected_not_silently_accepted` (direct guard call — the only call site needs a 16-tensor `TransformerLayerWeights`; placement verified by review).
- 7 existing flash parity tests (materialized-MHA / GQA / MQA / per-head) green → **happy path byte-identical** (only `is_some()` checks added).
- Full `lattice-inference` lib suite: **1081 passed, 0 failed, 7 ignored**. `cargo clippy -p lattice-inference --lib -- -D warnings` clean. Pre-commit (fmt + clippy + doc-lint) green.

Not a perf change → no bench-compare required. e2e-parity will run (inference/src touched); happy path is identical so token agreement is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
