### PR TITLE
harden(inference): standard MHA entry overflow/layout guard + add_bias release asserts

### DIFF
--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -80,7 +80,6 @@ pub fn multi_head_attention(
     buffers.temp[..seq_len * hidden_size].to_vec()
 }
 
-/// Internal in-place attention kernel.
 /// Release-active precondition guard for the bidirectional MHA shape products.
 ///
 /// `multi_head_attention_in_place` previously checked the entry shapes only with
@@ -130,6 +129,7 @@ fn assert_standard_no_overflow(
     );
 }
 
+/// Internal in-place attention kernel.
 pub(crate) fn multi_head_attention_in_place(
     hidden_states: &[f32],
     layer_weights: &TransformerLayerWeights<'_>,

--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -81,6 +81,55 @@ pub fn multi_head_attention(
 }
 
 /// Internal in-place attention kernel.
+/// Release-active precondition guard for the bidirectional MHA shape products.
+///
+/// `multi_head_attention_in_place` previously checked the entry shapes only with
+/// `debug_assert!`, so a release build silently accepted a malformed shape. Two
+/// hazards follow from that: (1) `hidden_size != num_heads * head_dim` produces a
+/// stale concat layout (the per-head copy loops write only `num_heads * head_dim`
+/// lanes of each `hidden_size`-wide row, leaving the rest stale before the output
+/// projection consumes them); (2) the local products `seq_len * hidden_size`,
+/// `num_heads * seq_len * seq_len`, and `num_heads * seq_len * head_dim` are not
+/// dominated by the `matmul_bt` boundary guards and could wrap a 64-bit `usize`
+/// for an absurd shape, yielding an undersized scratch slice. This asserts the
+/// head-layout invariant and that every product is computed before it wraps.
+#[inline]
+fn assert_standard_no_overflow(
+    seq_len: usize,
+    hidden_size: usize,
+    num_heads: usize,
+    head_dim: usize,
+) {
+    assert!(num_heads > 0, "standard: num_heads must be non-zero");
+    assert!(head_dim > 0, "standard: head_dim must be non-zero");
+    assert!(
+        num_heads.checked_mul(head_dim).is_some(),
+        "standard shape overflow: num_heads * head_dim"
+    );
+    assert_eq!(
+        hidden_size,
+        num_heads * head_dim,
+        "standard: hidden_size must equal num_heads * head_dim"
+    );
+    assert!(
+        seq_len.checked_mul(hidden_size).is_some(),
+        "standard shape overflow: seq_len * hidden_size"
+    );
+    assert!(
+        num_heads.checked_mul(seq_len).is_some(),
+        "standard shape overflow: num_heads * seq_len"
+    );
+    let nh_sl = num_heads * seq_len;
+    assert!(
+        nh_sl.checked_mul(seq_len).is_some(),
+        "standard shape overflow: num_heads * seq_len * seq_len"
+    );
+    assert!(
+        nh_sl.checked_mul(head_dim).is_some(),
+        "standard shape overflow: num_heads * seq_len * head_dim"
+    );
+}
+
 pub(crate) fn multi_head_attention_in_place(
     hidden_states: &[f32],
     layer_weights: &TransformerLayerWeights<'_>,
@@ -93,9 +142,17 @@ pub(crate) fn multi_head_attention_in_place(
     lora: &dyn LoraHook,
     layer_idx: usize,
 ) {
-    debug_assert_eq!(hidden_states.len(), seq_len * hidden_size);
-    debug_assert_eq!(attention_mask.len(), seq_len);
-    debug_assert_eq!(hidden_size, num_heads * head_dim);
+    assert_standard_no_overflow(seq_len, hidden_size, num_heads, head_dim);
+    assert_eq!(
+        hidden_states.len(),
+        seq_len * hidden_size,
+        "standard: hidden_states length must equal seq_len * hidden_size"
+    );
+    assert_eq!(
+        attention_mask.len(),
+        seq_len,
+        "standard: attention_mask length must equal seq_len"
+    );
 
     let used_hidden = seq_len * hidden_size;
     let used_scores = num_heads * seq_len * seq_len;
@@ -567,5 +624,28 @@ mod tests {
         for &v in result_all.iter().chain(result_masked.iter()) {
             assert!(v.is_finite());
         }
+    }
+
+    #[test]
+    fn standard_no_overflow_accepts_valid_shape() {
+        // hidden_size == num_heads * head_dim, no product wraps.
+        assert_standard_no_overflow(8, 64, 8, 8);
+    }
+
+    #[test]
+    #[should_panic(expected = "hidden_size must equal num_heads * head_dim")]
+    fn standard_no_overflow_rejects_layout_mismatch() {
+        // hidden_size=4 but num_heads * head_dim = 2: the concat layout would
+        // leave lanes 2..4 of every row stale before the output projection.
+        assert_standard_no_overflow(1, 4, 1, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "num_heads * seq_len * seq_len")]
+    fn standard_no_overflow_rejects_wrapping_product() {
+        // seq_len=2^32, num_heads=2, head_dim=1, hidden_size=2: every earlier
+        // product fits, but num_heads * seq_len * seq_len = 2^65 wraps a 64-bit
+        // usize to a small value that would feed an undersized scores slice.
+        assert_standard_no_overflow(1usize << 32, 2, 2, 1);
     }
 }

--- a/crates/inference/src/forward/cpu/activation.rs
+++ b/crates/inference/src/forward/cpu/activation.rs
@@ -255,8 +255,12 @@ unsafe fn gelu_avx2(x: &mut [f32]) {
 ///
 /// Add bias to each row of a matrix (in-place).
 pub fn add_bias(x: &mut [f32], bias: &[f32], dim: usize) {
-    debug_assert_eq!(bias.len(), dim);
-    debug_assert_eq!(x.len() % dim, 0);
+    assert_eq!(bias.len(), dim, "add_bias: bias length must equal dim");
+    assert_eq!(
+        x.len() % dim,
+        0,
+        "add_bias: x length must be a multiple of dim"
+    );
 
     for row in x.chunks_exact_mut(dim) {
         for (val, &b) in row.iter_mut().zip(bias.iter()) {
@@ -495,5 +499,33 @@ mod guard_tests {
         let mut x = vec![0.0; 8];
         let bias = vec![0.0; 3];
         add_bias_gelu(&mut x, &bias, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "bias length must equal dim")]
+    fn add_bias_rejects_short_bias() {
+        // A short bias previously truncated silently (chunks_exact + zip),
+        // leaving the trailing lanes unbiased. Fail closed in release now.
+        let mut x = vec![0.0; 8];
+        let bias = vec![0.0; 3];
+        add_bias(&mut x, &bias, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "multiple of dim")]
+    fn add_bias_rejects_ragged_x() {
+        // x.len() not a multiple of dim previously dropped the remainder row.
+        let mut x = vec![0.0; 7];
+        let bias = vec![0.0; 4];
+        add_bias(&mut x, &bias, 4);
+    }
+
+    #[test]
+    fn add_bias_accepts_valid_lengths() {
+        let dim = 4;
+        let bias = vec![0.1, -0.2, 0.3, -0.4];
+        let mut x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]; // 2 rows × dim
+        add_bias(&mut x, &bias, dim);
+        assert_eq!(x, vec![1.1, 1.8, 3.3, 3.6, 5.1, 5.8, 7.3, 7.6]);
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

A discovery review of `attention/standard.rs` (the bidirectional BERT-style MHA kernel) found two release-only precondition gaps — the same #313-class as the already-merged `gqa.rs` (#364), `decode.rs` (#365), `flash_causal.rs` (#366), `flash.rs` (#367), and the matmul boundary (#369). This closes them in `standard.rs` and the shared `add_bias` primitive.

### 1. `standard.rs` entry: debug-only shape/overflow checks → release-active
- The entry used `debug_assert!` for the head-layout invariant and computed `seq_len*hidden_size`, `num_heads*seq_len*seq_len`, and `num_heads*seq_len*head_dim` as **unchecked** `usize` products.
- A release build silently accepted `hidden_size != num_heads*head_dim`: the per-head copy loops then write only `num_heads*head_dim` lanes of each `hidden_size`-wide concat row, leaving the trailing lanes **stale** before the output projection consumes them (a silent wrong-output path — no OOB).
- The products are not dominated by the `matmul_bt` boundary guards and could wrap a 64-bit `usize` for an absurd shape, feeding an undersized scratch slice.
- Fix: `assert_standard_no_overflow(seq_len, hidden_size, num_heads, head_dim)` (`num_heads>0`, `head_dim>0`, `checked_mul` on every product, `assert_eq!(hidden_size, num_heads*head_dim)`) + release-active entry length asserts. Mirrors `assert_flash_no_overflow`.

### 2. `add_bias`: debug-only length checks → release-active (`assert_eq!`)
- `add_bias` used `debug_assert!` while its sibling `add_bias_gelu` already fail-closes in release. A short bias **truncated silently** (`chunks_exact_mut` + `zip`), leaving trailing lanes unbiased; a ragged `x` dropped the remainder row.
- Promoted both checks to release `assert_eq!`, matching `add_bias_gelu`.
- **Blast-radius audit:** all 18 `add_bias` call sites (standard×4, flash×8, bert×2, benches×3, test×1) pass loader-validated lengths (`f32_weights.rs:503`) at the matching `dim`. No valid caller is affected; the asserts only catch malformed directly-constructed weights.

This is a correctness/safety hardening, not a perf change: the new asserts are O(1) per call (entry-level), not per-element.

## Tests
- 3 new `standard.rs` guard tests: accepts valid shape, rejects layout mismatch, rejects wrapping `num_heads*seq_len*seq_len`.
- 3 new `add_bias` guard tests: rejects short bias, rejects ragged `x`, accepts valid lengths (value-checked).
- Full `lattice-inference` lib suite: **1090 passed, 0 failed**. `cargo clippy --workspace -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
