### PR TITLE
harden(inference): NEON softmax FMAXNM matches scalar maxNum on NaN rows

### DIFF
--- a/crates/inference/src/forward/cpu/softmax.rs
+++ b/crates/inference/src/forward/cpu/softmax.rs
@@ -121,19 +121,28 @@ unsafe fn softmax_attention_neon(x: &mut [f32], seq_len: usize, num_heads: usize
             let chunks = n / CHUNK;
 
             // --- Step 1: Find row max with 4x unrolling ---
+            // Use the maxNum intrinsics (FMAXNM: vmaxnmq/vmaxnmvq) rather than FMAX
+            // (vmaxq/vmaxvq). FMAX PROPAGATES a NaN operand; Rust `f32::max` in the
+            // scalar reference (and the scalar tail below) follows IEEE maxNum and
+            // DROPS a single NaN. With FMAX, a NaN anywhere in the row makes the whole
+            // reduced max NaN, every `neon_exp(x - NaN)` underflows to 0.0, the sum is
+            // 0.0, and the row is left all-zeros — diverging from the scalar path,
+            // which ignores the NaN and normalizes the finite logits. FMAXNM matches
+            // the scalar reference exactly and is byte-identical on all-finite rows
+            // (the only case that occurs in healthy inference), at no extra cost.
             let mut m0 = vdupq_n_f32(f32::NEG_INFINITY);
             let mut m1 = m0;
             let mut m2 = m0;
             let mut m3 = m0;
             for c in 0..chunks {
                 let base = c * CHUNK;
-                m0 = vmaxq_f32(m0, vld1q_f32(ptr.add(base) as *const f32));
-                m1 = vmaxq_f32(m1, vld1q_f32(ptr.add(base + 4) as *const f32));
-                m2 = vmaxq_f32(m2, vld1q_f32(ptr.add(base + 8) as *const f32));
-                m3 = vmaxq_f32(m3, vld1q_f32(ptr.add(base + 12) as *const f32));
+                m0 = vmaxnmq_f32(m0, vld1q_f32(ptr.add(base) as *const f32));
+                m1 = vmaxnmq_f32(m1, vld1q_f32(ptr.add(base + 4) as *const f32));
+                m2 = vmaxnmq_f32(m2, vld1q_f32(ptr.add(base + 8) as *const f32));
+                m3 = vmaxnmq_f32(m3, vld1q_f32(ptr.add(base + 12) as *const f32));
             }
-            let vmax = vmaxq_f32(vmaxq_f32(m0, m1), vmaxq_f32(m2, m3));
-            let mut max_val = vmaxvq_f32(vmax);
+            let vmax = vmaxnmq_f32(vmaxnmq_f32(m0, m1), vmaxnmq_f32(m2, m3));
+            let mut max_val = vmaxnmvq_f32(vmax);
             for i in (chunks * CHUNK)..n {
                 max_val = max_val.max(*ptr.add(i));
             }

--- a/crates/inference/src/forward/cpu/tests.rs
+++ b/crates/inference/src/forward/cpu/tests.rs
@@ -247,6 +247,45 @@ fn test_softmax_simd_matches_scalar() {
     }
 }
 
+// A NaN in an attention-score row must not make the NEON fast path diverge from the
+// scalar reference. seq_len must be >= CHUNK (16) so the row actually enters the NEON
+// vector max loop; a shorter row falls to the scalar tail and matches trivially. With
+// FMAX (the pre-fix reduction) the NaN propagates -> max = NaN -> every exp underflows
+// to 0 -> the row is all zeros. With FMAXNM (maxNum) the NaN is dropped, matching the
+// scalar path which normalizes the finite logits and gives the NaN lane zero weight.
+// aarch64-only: the AVX2 path uses a different (position-dependent) NaN reduction and
+// its maxNum/NaN-delta parity is a deliberate, separately-tracked follow-up.
+#[cfg(target_arch = "aarch64")]
+#[test]
+fn test_softmax_neon_nan_row_matches_scalar() {
+    let num_heads = 1;
+    let seq_len = 16;
+    let n = num_heads * seq_len * seq_len;
+    let mut x_simd = vec![0.0f32; n];
+    for (i, v) in x_simd.iter_mut().enumerate() {
+        *v = (i % seq_len) as f32;
+    }
+    // Poison the first lane of row 0 with NaN (the lane FMAX would propagate from).
+    x_simd[0] = f32::NAN;
+    let mut x_scalar = x_simd.clone();
+
+    softmax_attention(&mut x_simd, seq_len, num_heads);
+    softmax_attention_scalar(&mut x_scalar, seq_len, num_heads);
+
+    // The NaN lane gets zero weight in both paths (fast_exp(NaN) -> 0.0).
+    assert_eq!(x_simd[0], 0.0, "NEON NaN lane must be 0.0, not propagated");
+    assert_eq!(x_scalar[0], 0.0);
+
+    // Row 0 must be a real distribution (sums to 1), NOT the pre-fix all-zeros.
+    let row0_sum: f32 = x_simd[0..seq_len].iter().sum();
+    assert_relative_eq!(row0_sum, 1.0, epsilon = 1e-3);
+
+    // NEON and scalar agree element-wise across every lane of the NaN row.
+    for i in 0..seq_len {
+        assert_relative_eq!(x_simd[i], x_scalar[i], epsilon = 1e-3);
+    }
+}
+
 #[test]
 fn test_fast_exp_accuracy() {
     // Verify fast_exp matches std exp within acceptable tolerance for softmax.


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

The attention-score softmax (`forward/cpu/softmax.rs`, used by the BERT-style bidirectional MHA / embedding path) has three implementations: scalar reference, NEON, AVX2. The NEON fast path reduced the per-row max with **FMAX** (`vmaxq_f32`/`vmaxvq_f32`), which **propagates** a NaN operand. The scalar reference (and the NEON scalar tail) use Rust `f32::max` = IEEE **maxNum**, which **drops** a single NaN.

For a row of length ≥ `CHUNK` (16) carrying a NaN, the two paths diverged:

| path | row max | result |
|------|---------|--------|
| scalar | largest finite logit | valid distribution, NaN lane gets 0 weight |
| NEON (pre-fix) | `NaN` | `neon_exp(x - NaN)` → 0.0 every lane → sum 0 → row **all-zeros** |

## Fix

Swap the NEON max-reduction to **FMAXNM** (`vmaxnmq_f32`/`vmaxnmvq_f32` = maxNum) so NEON matches the scalar reference exactly. Byte-identical on all-finite rows (the only case in healthy inference), same instruction latency, no added branch.

Adds an `#[cfg(target_arch = "aarch64")]` regression test asserting NEON↔scalar parity on a `seq_len=16` row with a NaN. `seq_len ≥ CHUNK` is required to engage the SIMD max path — a shorter row falls to the scalar tail and would match trivially (vacuous).

## Scope / severity

DIVERGENT-BUT-NON-OCCURRING in healthy inference: finite Q/K scores never reach this path as NaN unless upstream weights/activations/caller scores are already corrupt. This is a backend-parity hardening fix (scalar↔SIMD contract), revertable, no public-API-signature change.

## Deferred (separately tracked)

- **AVX2 maxNum**: `_mm256_max_ps` MAXPS NaN handling is position-dependent; needs a deliberate mask-NaN-to-`-inf`-before-reduce emulation, not a mnemonic swap. Untestable on arm64 CI. Left as a follow-up.
- **`+inf` / fail-closed policy**: scalar `inf - inf → NaN` is a separate non-finite policy question (decode.rs fails closed; softmax does not). Out of scope here.
- **Release-active shape guard** on `softmax_attention`: the `debug_assert_eq!` shape contract is debug-only, but the overflow path is safe-panic (slice range check fires before any unsafe `ptr.add`), not UB. Diagnostic-only; deferred.

## Test

```
cargo test -p lattice-inference softmax   # 21 passed (incl. test_softmax_neon_nan_row_matches_scalar)
cargo clippy -p lattice-inference -- -D warnings   # clean
```

No bench-compare: this is an O(1) instruction-substitution on the same NEON reduction (FMAX→FMAXNM, identical latency), not a perf change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)