### PR TITLE
fix(inference): consolidate CPU token-sampling so Sampler and sample_token agree

### DIFF
--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -55,15 +55,17 @@ pub(crate) fn sample_token(
             .then_with(|| a.cmp(&b))
     });
 
+    // `indices` is already in (descending adjusted-logit, ascending token-id)
+    // order from the pre-sort above. softmax is monotonic in the logit, so the
+    // probabilities build_softmax_probs returns inherit exactly that order
+    // (descending probability, ties broken by ascending token-id) without any
+    // further sorting. Re-sorting here would double the sort cost — and for the
+    // supported `top_k == 0` (no top-k filtering) that means sorting the full
+    // vocabulary twice per decode step. apply_top_p and draw_index both rely only
+    // on this descending order, which the pre-sort already guarantees.
     let Some(mut probs) = build_softmax_probs(&adjusted, &indices) else {
         return greedy_token(&adjusted);
     };
-
-    probs.sort_unstable_by(|(ia, a), (ib, b)| {
-        b.partial_cmp(a)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| ia.cmp(ib))
-    });
 
     if cfg.top_p < 1.0 {
         apply_top_p(&mut probs, cfg.top_p);
@@ -302,8 +304,18 @@ mod tests {
         assert_eq!(token, 0, "NaN penalty must be a no-op");
     }
 
-    /// Parity proof: `Sampler::sample` (Path A) and `sample_token` (Path B)
-    /// must produce IDENTICAL token sequences for the same logits, config, and seed.
+    /// Realistic-input parity regression guard: `Sampler::sample` (Path A) and
+    /// `sample_token` (Path B) must produce IDENTICAL token sequences for the same
+    /// logits, config, and seed on a typical no-tie logit vector.
+    ///
+    /// This guards against future drift but does NOT by itself isolate the three
+    /// consolidation alignments — its input has no exact ties (so the tie-break
+    /// never engages) and never forces the CDF fallback (it fires only on rare
+    /// float-rounding events). The mutation-sensitive per-fix proofs live in
+    /// `draw_index_fallback_returns_last_bucket_not_first` (fallback) and
+    /// `cross_path_parity_with_logit_ties` (tie-break + summation order). What this
+    /// test does prove: with the pre-sort in place, the two paths' softmax sums are
+    /// bit-identical, so they agree on a full 200-draw realistic stream.
     ///
     /// Seed alignment: `Sampler::with_seed(S)` calls `Rng::new(S)` which sets
     /// `state = S` (for S ≠ 0). `sample_token` takes `rng_state: &mut u64`; when
@@ -410,8 +422,9 @@ mod tests {
              token 0 and select token 1 (a `r <= cumsum` regression selects token 0)"
         );
 
-        // Sanity: r below the first bucket selects token 0; r at/above the last
-        // bucket's cumsum (only reachable via float error) falls back to token 0.
+        // Sanity: r below the first bucket selects token 0; r between the two
+        // bucket boundaries selects token 1 (these probs sum to exactly 1.0, so
+        // the fallback branch is never reached here — see the dedicated test below).
         assert_eq!(
             draw_index(&probs, 0.25),
             0,
@@ -424,52 +437,71 @@ mod tests {
         );
     }
 
-    /// Parity proof with exact logit ties: both sampling paths must produce
-    /// IDENTICAL token sequences even when the logit set contains exact f32 ties.
+    #[test]
+    fn draw_index_fallback_returns_last_bucket_not_first() {
+        // Directly force the float-error fallback branch: probs that sum to LESS
+        // than r so `r < cumsum` never fires and the loop runs to completion. The
+        // correct fallback is the LAST bucket — on a descending-prob, sum≈1.0 CDF
+        // the final bucket owns [c_{n-2}, 1.0), so an r that floats past the last
+        // threshold belongs to the LAST token. This matches Path A's
+        // `CandidateSet::sample_top_p_with_scratch`, which returns `candidates.last()`.
+        //
+        // This test is the mutation-sensitive proof of the fallback alignment:
+        // reverting `draw_index` to the old `probs[probs.len()-1]` → `probs[0]`
+        // returns idx 7 and fails this assertion. The full-stream parity tests do
+        // NOT exercise this branch (it fires only on ~1e-7 float-rounding events),
+        // which is exactly why this direct unit test exists.
+        let probs: Vec<(usize, f32)> = vec![(7, 0.3), (8, 0.3), (9, 0.3)]; // sum 0.9 < r
+        assert_eq!(
+            draw_index(&probs, 0.95),
+            9,
+            "when cumsum never reaches r (float error), the draw belongs to the \
+             LAST bucket (idx 9); the old `probs[0]` behaviour returns idx 7"
+        );
+    }
+
+    /// Mutation-sensitive tie-break parity proof: both sampling paths must produce
+    /// IDENTICAL token sequences when the logit set contains exact f32 ties, AND
+    /// this test must FAIL if Path B breaks ties towards the higher token-id.
     ///
-    /// Two tie scenarios are exercised simultaneously:
+    /// The earlier version of this test was vacuous (codex round-1 finding): it put
+    /// the ties at low-probability positions (logit 25 of 64) and used top_p=0.95,
+    /// so the nucleus truncated the tied tokens before they could affect a draw —
+    /// a reversed tie-break still passed. The fix is to give the tied tokens real
+    /// probability mass and disable nucleus truncation so the tie-break is observable:
     ///
-    /// 1. **Within-top-40 tie** (indices 5 and 6 share logit 59.0):
-    ///    Both are selected by top-k. Correct sort order places index 5 before
-    ///    index 6 (ascending token-id tie-break). A reversed tie-break reorders
-    ///    the softmax iteration → different accumulated sums → different cumsum
-    ///    thresholds → different tokens drawn.
+    /// - **top_p = 1.0** — no truncation; every kept token participates in draws.
+    /// - **Tie at the maximum** (indices 0 & 1 both = 10.0): they carry ~0.38 of the
+    ///   mass EACH. A reversed sort-order tie-break swaps which of the two owns the
+    ///   first CDF bucket [0, 0.38), so ~77 of 200 draws flip.
+    /// - **Tie at the top-k=3 boundary** (indices 2 & 3 both = 9.5): rank 3 is
+    ///   contested. The correct selection tie-break retains index 2 (lower id, prob
+    ///   ~0.23); a reversed one retains index 3 instead → a different ~0.23-mass token
+    ///   appears in ~46 of 200 draws.
     ///
-    /// 2. **Boundary tie** (indices 39 and 40 share logit 25.0):
-    ///    Exactly 39 tokens rank above this pair, so rank 40 is contested.
-    ///    Correct tie-break retains index 39 (lower id) and evicts index 40.
-    ///    A reversed tie-break swaps them → different token pool → divergent
-    ///    sequences.
-    ///
-    /// This test will FAIL if either path breaks ties towards the higher
-    /// token-id, because the resulting candidate sets and/or sort orders diverge.
+    /// Both ties carry enough probability that a reversed tie-break in EITHER the
+    /// `select_nth_unstable_by` selection OR the pre-softmax sort diverges the stream
+    /// well within 200 draws. Empirically verified mutation-sensitive: reverting
+    /// either Path-B tie-break comparator to descending token-id fails this assertion.
     #[test]
     fn cross_path_parity_with_logit_ties() {
         use crate::model::qwen35_config::GenerateConfig;
         use crate::sampling::{Sampler, SamplingConfig};
 
-        // Base logits: index i gets value (64 − i) so the natural sorted order
-        // is strictly descending, all distinct.
-        let mut logits: Vec<f32> = (0..64).map(|i| 64.0_f32 - i as f32).collect();
+        // 8 tokens. Two ties, both at HIGH-probability positions:
+        //   idx 0 & 1 tie at the maximum (10.0)        -> sort-order tie-break
+        //   idx 2 & 3 tie at the top_k=3 boundary (9.5) -> selection tie-break
+        // Remaining tokens descend so the rest of the order is unambiguous.
+        let logits: Vec<f32> = vec![10.0, 10.0, 9.5, 9.5, 9.0, 8.0, 7.0, 6.0];
 
-        // Tie 1 (within top-40): indices 5 and 6 both receive logit 59.0.
-        // Index 5 originally had 59.0; set index 6 to match.
-        // Both survive top-k selection. Correct sort: 5 before 6.
-        logits[6] = logits[5]; // 59.0
-
-        // Tie 2 (boundary): indices 39 and 40 both receive logit 25.0.
-        // Index 39 originally had 25.0; set index 40 to match.
-        // The 39 tokens above this pair fill ranks 1–39, leaving rank 40
-        // contested. Correct tie-break: index 39 wins; index 40 is evicted.
-        logits[40] = logits[39]; // 25.0
-
-        let temperature = 0.8f32;
-        let top_k = 40usize;
-        let top_p = 0.95f32;
+        let temperature = 1.0f32;
+        let top_k = 3usize; // rank 3 contested between idx 2 and idx 3
+        let top_p = 1.0f32; // NO nucleus truncation — tied tokens stay in play
         let seed = 0xdead_beef_cafe_babe_u64;
         let n = 200usize;
 
-        // Path A: Sampler (CandidateSet::sample_top_p_with_scratch)
+        // Path A: Sampler (CandidateSet::sample_top_p_with_scratch). Keeps {0,1,2}
+        // (idx 2 wins the rank-3 tie by lower id), ordered [0,1,2] (lower id first).
         let config_a = SamplingConfig {
             temperature,
             top_k,
@@ -479,7 +511,9 @@ mod tests {
         let mut sampler = Sampler::new(config_a).with_seed(seed);
         let tokens_a: Vec<u32> = (0..n).map(|_| sampler.sample(&logits)).collect();
 
-        // Path B: sample_token (this module's pipeline)
+        // Path B: sample_token (this module's pipeline). With matching tie-breaks it
+        // also keeps {0,1,2} ordered [0,1,2]; a reversed tie-break keeps {0,1,3}
+        // and/or orders the max tie [1,0], diverging the stream.
         let config_b = GenerateConfig {
             temperature,
             top_k,
@@ -495,10 +529,11 @@ mod tests {
         assert_eq!(
             tokens_a, tokens_b,
             "Sampler::sample and sample_token must produce identical token streams \
-             even when logits contain exact f32 ties — within top-k (indices 5 & 6) \
-             and at the k=40 boundary (indices 39 & 40). A backwards tie-break \
-             diverges the candidate set or softmax iteration order, which changes \
-             the probability distribution and fails this assertion."
+             with high-probability ties at the max (idx 0 & 1) and the top_k=3 \
+             boundary (idx 2 & 3). A backwards tie-break in either the selection or \
+             the pre-softmax sort changes which token wins the contested rank or the \
+             order of the two max-probability buckets, flipping dozens of the 200 \
+             draws and failing this assertion."
         );
     }
 }

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -37,15 +37,33 @@ pub(crate) fn sample_token(
             adjusted[b]
                 .partial_cmp(&adjusted[a])
                 .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.cmp(&b))
         });
         indices.truncate(k);
     }
+
+    // Sort indices by descending adjusted logit + ascending token-id so that
+    // build_softmax_probs iterates in the same order as
+    // CandidateSet::sample_top_p_with_scratch (which sorts candidates first).
+    // Identical iteration order guarantees bit-identical softmax sums and
+    // therefore bit-identical probabilities — required for the cross-path
+    // parity test and for exact numerical alignment at the draw boundary.
+    indices.sort_unstable_by(|&a, &b| {
+        adjusted[b]
+            .partial_cmp(&adjusted[a])
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.cmp(&b))
+    });
 
     let Some(mut probs) = build_softmax_probs(&adjusted, &indices) else {
         return greedy_token(&adjusted);
     };
 
-    probs.sort_unstable_by(|(_, a), (_, b)| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    probs.sort_unstable_by(|(ia, a), (ib, b)| {
+        b.partial_cmp(a)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| ia.cmp(ib))
+    });
 
     if cfg.top_p < 1.0 {
         apply_top_p(&mut probs, cfg.top_p);
@@ -137,8 +155,15 @@ fn draw_from_distribution(probs: &[(usize, f32)], rng_state: &mut u64) -> u32 {
 /// `r`. The boundary is strict `r < cumsum`: the canonical uniform draw gives
 /// `r` in `[0, 1)`, so `r < cumsum` is the textbook-correct inverse-CDF and never
 /// double-counts a bucket boundary (`r <= cumsum` would, and is also unsafe for an
-/// `r` that reached exactly 1.0). Falls back to the first (highest-probability)
-/// token only if float error leaves the final cumsum just under `r`.
+/// `r` that reached exactly 1.0).
+///
+/// Falls back to the LAST element when float-summation error leaves the final
+/// cumsum just under `r`. Probs are sorted descending and renormalised to
+/// sum≈1.0, so cumulative thresholds are c_0<c_1<...<c_{n-1}≈1.0. The last
+/// bucket owns the half-open interval `[c_{n-2}, 1.0)`. A draw `r` that floats
+/// past c_{n-1} lies in that final interval, so the correct token is the LAST
+/// iterated one. This matches `CandidateSet::sample_top_p_with_scratch` (Path A),
+/// which also returns `candidates.last()` for the same reason.
 fn draw_index(probs: &[(usize, f32)], r: f32) -> u32 {
     let mut cumsum = 0.0f32;
     for &(idx, p) in probs {
@@ -147,18 +172,22 @@ fn draw_index(probs: &[(usize, f32)], r: f32) -> u32 {
             return idx as u32;
         }
     }
-    probs[0].0 as u32
+    // Callers guarantee non-empty: build_softmax_probs returns None for empty
+    // indices, so draw_index is only reached when probs has at least one element.
+    probs[probs.len() - 1].0 as u32
 }
 
 /// Canonical uniform f32 in [0, 1) via the shared xorshift64 primitive.
 ///
 /// Delegates to `crate::sampling::xorshift64_next` (shifts 13/7/17, full period
 /// over nonzero state) and `crate::sampling::uniform_f32_from_u64` (top-24-bit
-/// conversion, provably strictly < 1.0). Both CPU sampling paths now share this
-/// canonical RNG primitive, so a fixed seed yields the same uniform draw stream.
-/// This does NOT guarantee identical token streams: the two paths still diverge
-/// below the RNG layer (top-k tie-break and the candidate-exhaustion fallback
-/// pick in opposite directions), so equal draws can still select different tokens.
+/// conversion, provably strictly < 1.0). Both CPU sampling paths share this
+/// primitive so a fixed seed yields the same uniform draw stream. After the
+/// fallback unification (`draw_index` now returns the LAST element, matching
+/// `CandidateSet::sample_top_p_with_scratch`) and the tie-break alignment (top-k
+/// selection, the probability sort, and the softmax summation order all now match
+/// Path A), a fixed seed produces token-identical streams for inputs without exact
+/// logit ties at the top-k boundary (a rare event for realistic model outputs).
 pub(crate) fn xorshift64(state: &mut u64) -> f32 {
     let x = crate::sampling::xorshift64_next(state);
     crate::sampling::uniform_f32_from_u64(x)
@@ -273,6 +302,68 @@ mod tests {
         assert_eq!(token, 0, "NaN penalty must be a no-op");
     }
 
+    /// Parity proof: `Sampler::sample` (Path A) and `sample_token` (Path B)
+    /// must produce IDENTICAL token sequences for the same logits, config, and seed.
+    ///
+    /// Seed alignment: `Sampler::with_seed(S)` calls `Rng::new(S)` which sets
+    /// `state = S` (for S ≠ 0). `sample_token` takes `rng_state: &mut u64`; when
+    /// initialised to `S`, the first `xorshift64(&mut rng_state)` call advances
+    /// the same way as `Rng::next_f32()` in Path A. Both paths consume exactly one
+    /// RNG step per token draw, so the draw streams are permanently aligned.
+    #[test]
+    fn cross_path_parity_sampler_vs_sample_token() {
+        use crate::model::qwen35_config::GenerateConfig;
+        use crate::sampling::{Sampler, SamplingConfig};
+
+        // 64-entry logit vector; hash-derived values in [-10, 10] with no exact
+        // ties (all 64 u64 hash values differ in the top 24 bits of f32 with
+        // overwhelming probability — expected collisions < 0.001).
+        let logits: Vec<f32> = (0..64u64)
+            .map(|i| {
+                let h = i
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                (h as f32 / u64::MAX as f32) * 20.0 - 10.0
+            })
+            .collect();
+
+        let temperature = 0.8f32;
+        let top_k = 40usize;
+        let top_p = 0.95f32;
+        let seed = 0xdead_beef_cafe_babe_u64;
+        let n = 200usize;
+
+        // Path A: Sampler — internal Rng seeded to `seed` via `with_seed`.
+        let config_a = SamplingConfig {
+            temperature,
+            top_k,
+            top_p,
+            repetition_penalty: 1.0,
+        };
+        let mut sampler = Sampler::new(config_a).with_seed(seed);
+        let tokens_a: Vec<u32> = (0..n).map(|_| sampler.sample(&logits)).collect();
+
+        // Path B: sample_token — rng_state initialised to the same seed; the first
+        // xorshift64_next call advances identically to Rng::next_u64 in Path A.
+        let config_b = GenerateConfig {
+            temperature,
+            top_k,
+            top_p,
+            repetition_penalty: 1.0,
+            ..Default::default()
+        };
+        let mut rng_state = seed;
+        let tokens_b: Vec<u32> = (0..n)
+            .map(|_| sample_token(&logits, &config_b, &[], &mut rng_state))
+            .collect();
+
+        assert_eq!(
+            tokens_a, tokens_b,
+            "Sampler::sample and sample_token must produce identical token streams \
+             for the same logits, config, and seed (consolidation parity proof)"
+        );
+    }
+
     #[test]
     fn canonical_rng_streams_match_across_sampling_paths() {
         // Both CPU sampling paths must produce the same seeded float stream once
@@ -330,6 +421,84 @@ mod tests {
             draw_index(&probs, 0.75),
             1,
             "r between the two bucket boundaries picks token 1"
+        );
+    }
+
+    /// Parity proof with exact logit ties: both sampling paths must produce
+    /// IDENTICAL token sequences even when the logit set contains exact f32 ties.
+    ///
+    /// Two tie scenarios are exercised simultaneously:
+    ///
+    /// 1. **Within-top-40 tie** (indices 5 and 6 share logit 59.0):
+    ///    Both are selected by top-k. Correct sort order places index 5 before
+    ///    index 6 (ascending token-id tie-break). A reversed tie-break reorders
+    ///    the softmax iteration → different accumulated sums → different cumsum
+    ///    thresholds → different tokens drawn.
+    ///
+    /// 2. **Boundary tie** (indices 39 and 40 share logit 25.0):
+    ///    Exactly 39 tokens rank above this pair, so rank 40 is contested.
+    ///    Correct tie-break retains index 39 (lower id) and evicts index 40.
+    ///    A reversed tie-break swaps them → different token pool → divergent
+    ///    sequences.
+    ///
+    /// This test will FAIL if either path breaks ties towards the higher
+    /// token-id, because the resulting candidate sets and/or sort orders diverge.
+    #[test]
+    fn cross_path_parity_with_logit_ties() {
+        use crate::model::qwen35_config::GenerateConfig;
+        use crate::sampling::{Sampler, SamplingConfig};
+
+        // Base logits: index i gets value (64 − i) so the natural sorted order
+        // is strictly descending, all distinct.
+        let mut logits: Vec<f32> = (0..64).map(|i| 64.0_f32 - i as f32).collect();
+
+        // Tie 1 (within top-40): indices 5 and 6 both receive logit 59.0.
+        // Index 5 originally had 59.0; set index 6 to match.
+        // Both survive top-k selection. Correct sort: 5 before 6.
+        logits[6] = logits[5]; // 59.0
+
+        // Tie 2 (boundary): indices 39 and 40 both receive logit 25.0.
+        // Index 39 originally had 25.0; set index 40 to match.
+        // The 39 tokens above this pair fill ranks 1–39, leaving rank 40
+        // contested. Correct tie-break: index 39 wins; index 40 is evicted.
+        logits[40] = logits[39]; // 25.0
+
+        let temperature = 0.8f32;
+        let top_k = 40usize;
+        let top_p = 0.95f32;
+        let seed = 0xdead_beef_cafe_babe_u64;
+        let n = 200usize;
+
+        // Path A: Sampler (CandidateSet::sample_top_p_with_scratch)
+        let config_a = SamplingConfig {
+            temperature,
+            top_k,
+            top_p,
+            repetition_penalty: 1.0,
+        };
+        let mut sampler = Sampler::new(config_a).with_seed(seed);
+        let tokens_a: Vec<u32> = (0..n).map(|_| sampler.sample(&logits)).collect();
+
+        // Path B: sample_token (this module's pipeline)
+        let config_b = GenerateConfig {
+            temperature,
+            top_k,
+            top_p,
+            repetition_penalty: 1.0,
+            ..Default::default()
+        };
+        let mut rng_state = seed;
+        let tokens_b: Vec<u32> = (0..n)
+            .map(|_| sample_token(&logits, &config_b, &[], &mut rng_state))
+            .collect();
+
+        assert_eq!(
+            tokens_a, tokens_b,
+            "Sampler::sample and sample_token must produce identical token streams \
+             even when logits contain exact f32 ties — within top-k (indices 5 & 6) \
+             and at the k=40 boundary (indices 39 & 40). A backwards tie-break \
+             diverges the candidate set or softmax iteration order, which changes \
+             the probability distribution and fails this assertion."
         );
     }
 }

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -186,10 +186,12 @@ fn draw_index(probs: &[(usize, f32)], r: f32) -> u32 {
 /// conversion, provably strictly < 1.0). Both CPU sampling paths share this
 /// primitive so a fixed seed yields the same uniform draw stream. After the
 /// fallback unification (`draw_index` now returns the LAST element, matching
-/// `CandidateSet::sample_top_p_with_scratch`) and the tie-break alignment (top-k
-/// selection, the probability sort, and the softmax summation order all now match
-/// Path A), a fixed seed produces token-identical streams for inputs without exact
-/// logit ties at the top-k boundary (a rare event for realistic model outputs).
+/// `CandidateSet::sample_top_p_with_scratch`) and the tie-break alignment (the
+/// top-k selection and the single pre-softmax index sort fix both the tie order
+/// and the softmax summation order to match Path A), a fixed seed produces
+/// token-identical streams for the same (logits, config, seed) — including inputs
+/// with exact logit ties at the top-k boundary, which the matched ascending
+/// token-id tie-break now resolves identically in both paths.
 pub(crate) fn xorshift64(state: &mut u64) -> f32 {
     let x = crate::sampling::xorshift64_next(state);
     crate::sampling::uniform_f32_from_u64(x)


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Two CPU token-sampling paths were supposed to agree but diverged on edge cases:

- **Path A** `Sampler::sample` (`crates/inference/src/sampling.rs`) — the canonical/reference path (`CandidateSet`, k-element min-heap select, candidate-order sort, inverse-CDF draw, `candidates.last()` fallback).
- **Path B** `sample_token`/`draw_index` (`crates/inference/src/model/qwen35/sampling.rs`) — the **live** path used by every CPU forward impl (cpu_f16, cpu_q8, neon_forward, batch_prefill, metal_qwen35).

The RNG primitive was already shared. This PR closes the three residual divergences so Path B produces **token-identical** output to Path A for the same `(logits, temperature, top_k, top_p, seed)`:

1. **Fallback direction** — `draw_index`'s float-error fallback now returns the LAST CDF bucket (`probs[len-1]`), not `probs[0]`. The last bucket owns `[c_{n-2}, 1.0)`, so a draw `r` that floats past the final cumsum belongs to the last token — matching Path A's `candidates.last()`.
2. **Tie-break direction** — top-k selection and the pre-softmax sort both break exact-logit ties by ascending token-id, matching Path A's `heap_less` / `order_candidates` (lower token-id wins).
3. **Summation order** — a single pre-softmax index sort makes Path B iterate the softmax in the same order as Path A, so the sums are bit-identical (float summation is non-associative).

## Scope / risk

This changes the **live qwen35 stochastic decode output** only for rare edge cases (exact logit ties / ~1e-7 float-error fallback events), as a deterministic canonicalization toward the canonical Path A. **Greedy/argmax is unaffected** — `temperature_degenerate(...)` routes to `greedy_token` before `draw_index`, so the greedy e2e-parity CI gate does not change. Because the live *stochastic* path is not covered by that gate, this is submitted for review rather than self-merged.

## Review history (2 rounds)

- **Round 1: fixes required.** Implementation logic sound, but the regression tests were vacuous — review reverted the alignments in a disposable worktree and the tests still passed. Three findings: (1) no-tie parity test never forced the fallback branch; (2) tie test placed ties at low-probability positions under `top_p=0.95` so the nucleus truncated them before they affected a draw (a reversed tie-break still passed); (3) the pre-sort made a later `probs.sort` redundant — and for `top_k==0` it sorted the full vocab twice per step.
- **Fixes** (`fe3b8c1de`): direct `draw_index` fallback unit test (probs sum < r → must return LAST); rebuilt tie test with `top_p=1.0` and high-probability ties (idx 0&1 at the max → sort-order tie-break; idx 2&3 at the `top_k=3` boundary → selection tie-break); removed the redundant `probs.sort_unstable_by` (softmax monotonicity already leaves probs in desc-prob/asc-id order). Doc nit fixed in `54b395e78`.
- **Round 2: no blocking issues.** Review independently re-ran every mutation in disposable worktrees: reverting the fallback fails the fallback test; reversing both tie-breaks fails the tie test; reversing **only** selection fails; reversing **only** the pre-sort fails; the removed sort is correct for Path A parity; greedy routing still bypasses `draw_index`.

## Tests

`cargo test -p lattice-inference --lib sampling` → 55 pass; clippy clean. Mutation-sensitivity verified locally and independently confirmed on clean recompiles during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
