### PR TITLE
fix(inference): standard attention masks with -inf, not a finite sentinel (#361)

### DIFF
--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -255,7 +255,13 @@ pub(crate) fn multi_head_attention_in_place(
                 let row = &mut scores[(h * seq_len + i) * seq_len..(h * seq_len + i + 1) * seq_len];
                 for j in 0..seq_len {
                     if attention_mask[j] == 0 {
-                        row[j] = -10_000.0;
+                        // Mask structurally with -inf, not a finite sentinel. A finite
+                        // sentinel can be *exceeded* by a valid logit that sits below it,
+                        // which would make the masked key the softmax row max and hand it
+                        // dominant probability (the #361 leakage mode, fixed in flash.rs;
+                        // standard.rs is the live materialized CPU path). softmax_attention
+                        // zeros an all-masked row via its max-finiteness guard.
+                        row[j] = f32::NEG_INFINITY;
                     }
                 }
             }
@@ -624,6 +630,134 @@ mod tests {
         for &v in result_all.iter().chain(result_masked.iter()) {
             assert!(v.is_finite());
         }
+    }
+
+    #[test]
+    fn masked_token_value_does_not_leak_when_valid_score_below_sentinel() {
+        // #361 live-path (standard.rs) regression. A masked key is excluded with -inf,
+        // not a finite sentinel. Construct a row whose only VALID score sits below where
+        // the old -10_000 sentinel lived: with the finite sentinel the masked key becomes
+        // the softmax row max and its (large) value leaks into the output; with -inf the
+        // valid key dominates and the masked value is suppressed. Reverting line 258 to
+        // `-10_000.0` makes this fail (row-0 output jumps to the masked token's value).
+        let seq_len = 2;
+        let num_heads = 1;
+        let head_dim = 2;
+        let hidden_size = num_heads * head_dim; // 2
+
+        // Token 0 carries a small value; token 1 (which we mask) carries a large value so
+        // any leak is unmistakable.
+        let hidden_states = vec![1.0, 0.0, 500.0, 500.0];
+
+        // Distinct Q/K projections drive score[0][0] = Q_0·K_0·scale below -10_000:
+        // Q_0 = [200,0], K_0 = [-100,0] -> -20000 * (1/sqrt(2)) ≈ -14142.
+        let query_w: Vec<f32> = vec![200.0, 0.0, 0.0, 0.0];
+        let key_w: Vec<f32> = vec![-100.0, 0.0, 0.0, 0.0];
+        let identity_2x2: Vec<f32> = vec![1.0, 0.0, 0.0, 1.0];
+        let zero_bias_2: Vec<f32> = vec![0.0; 2];
+        let ones_2: Vec<f32> = vec![1.0; 2];
+        let intermediate_size = hidden_size;
+
+        let layer = TransformerLayerWeights {
+            query_weight: Tensor2D {
+                data: &query_w,
+                rows: hidden_size,
+                cols: hidden_size,
+            },
+            query_bias: Tensor1D {
+                data: &zero_bias_2,
+                len: hidden_size,
+            },
+            key_weight: Tensor2D {
+                data: &key_w,
+                rows: hidden_size,
+                cols: hidden_size,
+            },
+            key_bias: Tensor1D {
+                data: &zero_bias_2,
+                len: hidden_size,
+            },
+            value_weight: Tensor2D {
+                data: &identity_2x2,
+                rows: hidden_size,
+                cols: hidden_size,
+            },
+            value_bias: Tensor1D {
+                data: &zero_bias_2,
+                len: hidden_size,
+            },
+            attn_output_weight: Tensor2D {
+                data: &identity_2x2,
+                rows: hidden_size,
+                cols: hidden_size,
+            },
+            attn_output_bias: Tensor1D {
+                data: &zero_bias_2,
+                len: hidden_size,
+            },
+            attn_layer_norm_weight: Tensor1D {
+                data: &ones_2,
+                len: hidden_size,
+            },
+            attn_layer_norm_bias: Tensor1D {
+                data: &zero_bias_2,
+                len: hidden_size,
+            },
+            ffn_intermediate_weight: Tensor2D {
+                data: &identity_2x2,
+                rows: intermediate_size,
+                cols: hidden_size,
+            },
+            ffn_intermediate_bias: Tensor1D {
+                data: &zero_bias_2,
+                len: intermediate_size,
+            },
+            ffn_output_weight: Tensor2D {
+                data: &identity_2x2,
+                rows: hidden_size,
+                cols: intermediate_size,
+            },
+            ffn_output_bias: Tensor1D {
+                data: &zero_bias_2,
+                len: hidden_size,
+            },
+            ffn_layer_norm_weight: Tensor1D {
+                data: &ones_2,
+                len: hidden_size,
+            },
+            ffn_layer_norm_bias: Tensor1D {
+                data: &zero_bias_2,
+                len: hidden_size,
+            },
+        };
+
+        // Mask token 1 (the large-value token) for every query row.
+        let mask = vec![1u32, 0];
+        let mut buf = AttentionBuffers::new(seq_len, hidden_size, num_heads, intermediate_size);
+        let out = multi_head_attention(
+            &hidden_states,
+            &layer,
+            &mask,
+            seq_len,
+            hidden_size,
+            num_heads,
+            head_dim,
+            &mut buf,
+            &NoopLoraHook,
+            0,
+        );
+
+        assert!(
+            out.iter().all(|v| v.is_finite()),
+            "output must be finite: {out:?}"
+        );
+        // Row 0 must reflect the VALID token's value (V_0 = [1,0]), not the masked
+        // token's value (V_1 = [500,500]).
+        assert!(
+            out[0].abs() < 50.0 && out[1].abs() < 50.0,
+            "masked token value leaked into row 0 output: {:?} (expected ~[1,0])",
+            &out[0..2]
+        );
     }
 
     #[test]

--- a/crates/inference/src/forward/cpu/softmax.rs
+++ b/crates/inference/src/forward/cpu/softmax.rs
@@ -45,6 +45,16 @@ pub fn softmax_attention_scalar(x: &mut [f32], seq_len: usize, num_heads: usize)
             let start = (h * seq_len + s) * seq_len;
             let row = &mut x[start..start + seq_len];
             let max_val = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            if !max_val.is_finite() {
+                // Every score in this row is masked (-inf): there is no valid key to
+                // attend to. Emit a zero distribution instead of computing
+                // `fast_exp(-inf - -inf) = fast_exp(NaN)`, whose value is path-dependent
+                // (0.0 on scalar/NEON, but a tiny nonzero on AVX2 where MAXPS returns
+                // the finite operand on a NaN input) and would otherwise diverge across
+                // SIMD backends. Zeroing keeps every backend fail-closed and identical.
+                row.fill(0.0);
+                continue;
+            }
             let mut sum = 0.0f32;
             for val in row.iter_mut() {
                 *val = fast_exp(*val - max_val);
@@ -147,6 +157,13 @@ unsafe fn softmax_attention_neon(x: &mut [f32], seq_len: usize, num_heads: usize
                 max_val = max_val.max(*ptr.add(i));
             }
 
+            // All-masked row (max stayed -inf): zero it and skip, matching the scalar
+            // reference. Avoids `neon_exp(-inf - -inf)` and keeps every backend identical.
+            if !max_val.is_finite() {
+                row.fill(0.0);
+                continue;
+            }
+
             // --- Step 2: Subtract max + fast exp + accumulate sum ---
             let vmax_val = vdupq_n_f32(max_val);
             let mut s0 = vdupq_n_f32(0.0);
@@ -242,6 +259,15 @@ unsafe fn softmax_attention_avx2(x: &mut [f32], seq_len: usize, num_heads: usize
             let mut max_val = _mm_cvtss_f32(max32);
             for i in (chunks * 8)..n {
                 max_val = max_val.max(*ptr.add(i));
+            }
+
+            // All-masked row (max stayed -inf): zero it and skip, matching the scalar
+            // reference. Without this, the SIMD lanes compute `fast_exp_avx2(-inf - -inf)`
+            // where MAXPS returns the finite clamp on a NaN input, yielding a tiny nonzero
+            // weight and a uniform row — diverging from scalar/NEON which produce zeros.
+            if !max_val.is_finite() {
+                row.fill(0.0);
+                continue;
             }
 
             // --- Step 2: Subtract max + fast exp + accumulate sum (all SIMD) ---

--- a/crates/inference/src/forward/cpu/tests.rs
+++ b/crates/inference/src/forward/cpu/tests.rs
@@ -331,6 +331,47 @@ fn test_softmax_all_masked_row_is_zero_across_backends() {
     assert_relative_eq!(row1_sum, 1.0, epsilon = 1e-3);
 }
 
+// Contract for a row with at least one finite valid score and a -inf-masked key
+// (the common #361 case, distinct from the all-masked row above). The masked
+// weight is NOT mathematically exact zero: `softmax_attention` routes through
+// `fast_exp`, which clamps its input to the [-87, 88] floor, so `fast_exp(-inf)`
+// is `fast_exp(-87)` ~= 1.746e-38, not 0.0. This is deliberate and byte-identical
+// to the prior `-10_000.0` sentinel for valid-keys-present rows (both clamp to the
+// same floor), which is why e2e-parity greedy generation is unaffected. The
+// guarantee #361 needs is weaker than exact zero: the masked weight is negligible
+// and never the row max / never dominant. Asserting the clamped magnitude (rather
+// than 0.0) locks that contract so a future `-inf`->0.0 special-case can't silently
+// change parity/perf behaviour without updating this expectation.
+#[test]
+fn test_softmax_finite_valid_row_masked_weight_is_clamped_nonzero_not_dominant() {
+    let num_heads = 1;
+    let seq_len = 2;
+    // Row 0: valid key 0 scores 0.0, masked key 1 is -inf.
+    let mut x = vec![0.0f32, f32::NEG_INFINITY, 0.0, 0.0];
+    softmax_attention(&mut x, seq_len, num_heads);
+
+    let valid = x[0];
+    let masked = x[1];
+    assert!(
+        valid.is_finite() && masked.is_finite(),
+        "row must be finite"
+    );
+    // The masked weight is a tiny clamped nonzero, not exact zero.
+    assert!(
+        masked > 0.0,
+        "fast_exp clamp makes the masked weight strictly > 0"
+    );
+    assert!(
+        masked < 1e-30,
+        "masked weight {masked} must be negligible (clamped fast_exp(-87) ~= 1.7e-38)"
+    );
+    // The valid key carries essentially all the probability mass: never dominated.
+    assert!(
+        valid > 1.0 - 1e-6,
+        "valid key weight {valid} must dominate (~1.0)"
+    );
+}
+
 #[test]
 fn test_fast_exp_accuracy() {
     // Verify fast_exp matches std exp within acceptable tolerance for softmax.

--- a/crates/inference/src/forward/cpu/tests.rs
+++ b/crates/inference/src/forward/cpu/tests.rs
@@ -286,6 +286,51 @@ fn test_softmax_neon_nan_row_matches_scalar() {
     }
 }
 
+// An all-masked attention row (every score -inf, the structural mask used by
+// standard.rs after #361) must collapse to a zero distribution identically on every
+// backend. Without the max-finiteness guard the row max stays -inf, `exp(-inf - -inf)`
+// is NaN, and the backends disagree: scalar/NEON map it to 0.0 but AVX2's MAXPS returns
+// the finite clamp on a NaN input, yielding a tiny nonzero weight and a uniform row.
+// seq_len=16 forces the SIMD vector loops (CHUNK=16 / 8-lane AVX2) rather than the
+// scalar tail. The guard makes SIMD and the scalar reference byte-identical here.
+#[test]
+fn test_softmax_all_masked_row_is_zero_across_backends() {
+    let num_heads = 1;
+    let seq_len = 16;
+    let n = num_heads * seq_len * seq_len;
+    // Row 0 entirely masked; rows 1.. carry a normal finite distribution so the test
+    // also confirms the guard does not perturb neighbouring rows.
+    let mut x_simd = vec![0.0f32; n];
+    for (i, v) in x_simd.iter_mut().enumerate() {
+        *v = if i < seq_len {
+            f32::NEG_INFINITY
+        } else {
+            (i % seq_len) as f32
+        };
+    }
+    let mut x_scalar = x_simd.clone();
+
+    softmax_attention(&mut x_simd, seq_len, num_heads);
+    softmax_attention_scalar(&mut x_scalar, seq_len, num_heads);
+
+    for i in 0..seq_len {
+        assert!(
+            x_simd[i].is_finite(),
+            "all-masked SIMD lane {i} = {} must be finite",
+            x_simd[i]
+        );
+        assert_eq!(
+            x_simd[i], 0.0,
+            "all-masked SIMD lane {i} = {} must be exactly 0.0 (not uniform)",
+            x_simd[i]
+        );
+        assert_eq!(x_scalar[i], 0.0, "all-masked scalar lane {i} must be 0.0");
+    }
+    // A neighbouring finite row is untouched and still normalizes to 1.0.
+    let row1_sum: f32 = x_simd[seq_len..2 * seq_len].iter().sum();
+    assert_relative_eq!(row1_sum, 1.0, epsilon = 1e-3);
+}
+
 #[test]
 fn test_fast_exp_accuracy() {
     // Verify fast_exp matches std exp within acceptable tolerance for softmax.


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

`standard.rs` is the **live materialized CPU attention path** and shared the exact #361 finite-mask-sentinel bug fixed for the latent flash kernel in #373. It masked padded keys with `-10_000.0`, folded into the softmax row max. A valid logit below the sentinel makes the masked key the row max → it receives dominant softmax probability and leaks its value.

Unlike flash.rs (bench-only/latent), this path is reachable: Q/K project directly from `hidden_states` with **separate** `query_weight`/`key_weight` and no pre-norm bounding the scores, so distinct W_q/W_k can drive a valid score below the sentinel.

## Fix

- `standard.rs:258`: mask with `f32::NEG_INFINITY` so the masked key can never be the softmax row max. `softmax_attention` routes through `fast_exp`, which clamps `-inf` to the `-87` floor, so the masked weight is `fast_exp(-87)` ≈ 1.7e-38 — negligible and never dominant, not mathematically exact zero (byte-identical to the prior sentinel for valid-keys-present rows). Review round 1 flagged the earlier "exactly zero" wording; commit e991e3d adds `test_softmax_finite_valid_row_masked_weight_is_clamped_nonzero_not_dominant` to lock this clamped contract.
- `softmax_attention` (scalar / NEON / AVX2): add a max-finiteness guard. An all-masked row (`max_val` stays `-inf`, so `exp(-inf - -inf) = NaN`) is zeroed and skipped.

The guard also closes a **cross-backend divergence** the `-inf` flip would otherwise expose: scalar/NEON map `fast_exp(NaN)` to `0.0`, but AVX2's `MAXPS` returns the finite clamp on a NaN input → a tiny nonzero weight and a uniform row. With the guard, all three backends are byte-identical on an all-masked row.

**Byte-identical for all normal inference** — valid logits are O(10), the guard never fires, and `-inf` vs `-10_000` produce the same masked weight (both clamp to `fast_exp(-87)`). e2e-parity greedy generation is unaffected.

## Tests

- `masked_token_value_does_not_leak_when_valid_score_below_sentinel` — integration regression, **mutation-sensitive**: reverting line 258 to `-10_000.0` makes row-0 output jump from `~[1,0]` (valid token) to `[500,500]` (masked token's leaked value). Verified this session.
- `test_softmax_all_masked_row_is_zero_across_backends` — SIMD/scalar parity that an all-masked row collapses to exactly `0.0`, not a uniform distribution.

## Verification

- `cargo test -p lattice-inference --lib attention::` — 171 passed
- `cargo test -p lattice-inference --lib forward::cpu` — 45 passed
- `cargo clippy -p lattice-inference --lib -- -D warnings` — clean
- Mutation-sensitivity empirically confirmed (revert → `[500,500]` leak).

Correctness-only, no perf path touched (one never-taken `is_finite` branch per row). Closes the live-path sibling of #361 / #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
