### PR TITLE
harden(bench): slopefit KV-cache sizing + governor killpg-EPERM fallback

### DIFF
--- a/crates/inference/src/bin/bench_decode_slopefit.rs
+++ b/crates/inference/src/bin/bench_decode_slopefit.rs
@@ -104,15 +104,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     grid.sort_unstable();
     grid.dedup();
 
-    // KV cache must hold the longest requested context plus the decode horizon.
-    // A too-small cache silently corrupts the deepest grid points: prefill fills
-    // the cache, decode immediately hits the cap, and the line reports tokens=1
-    // (a prefill cost masquerading as a decode rate, not a real per-token time).
-    // The previous hard-coded 4096 made every point at/above ctx=4096 — i.e. the
-    // entire SLOPEFIT_FULL {4096,8192,16384} tail this binary advertises — return
-    // tokens=1 instead of a measurement. Size from the grid so the tail is real.
     let max_ctx = grid.iter().copied().max().unwrap_or(512);
-    let cache_len = max_ctx + warmup_tokens.max(measure_tokens) + 16;
 
     // Detect Q4 dir (same heuristic as bench_decode_ab).
     let is_q4_dir = !dir.join("model.safetensors").exists()
@@ -137,9 +129,36 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         if is_q4_dir { "Q4" } else { "safetensors" }
     );
 
+    // Tokenizer first — the KV cache must hold the *padded* prompt, and the pad
+    // loop below overshoots `ctx` by up to one `base` block. Sizing from `max_ctx`
+    // alone leaves the deepest grid point short by that overshoot and silently
+    // truncates its decode (a milder echo of the tokens=1 corruption the previous
+    // hard-coded 4096 cache produced at every point >= 4096). Build the deepest
+    // prompt exactly as the measurement loop does and size from its real length.
+    let tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_dir.join("tokenizer.json"))?;
+
+    // Raw continuation prompt — no chat template — so the model sees a partial
+    // sentence and produces a continuation rather than a completed conversation.
+    // This avoids the early EOS that chat_completion triggers via im_end.
+    // The base text is intentionally left incomplete (no closing punctuation)
+    // so greedy continuation runs as a prose generation, not a Q&A exchange.
+    let base = "The quick brown fox jumps over the lazy dog and then continues \
+                running through the meadow past the old stone wall while the sun \
+                sets slowly over the distant mountains painting the sky in shades \
+                of orange and gold as the evening breeze stirs the tall grass and \
+                the river flows gently southward toward the ancient city where ";
+
+    let mut deepest_prompt = String::new();
+    while tokenizer.tokenize(&deepest_prompt).real_length < max_ctx {
+        deepest_prompt.push_str(base);
+    }
+    let deepest_prompt_tokens = tokenizer.tokenize(&deepest_prompt).real_length;
+    // Peak occupancy is prompt + the larger decode phase: warmup and measure each
+    // run after their own reset_state(), so the cache never holds both at once.
+    let cache_len = deepest_prompt_tokens + warmup_tokens.max(measure_tokens) + 16;
+
     // Load model — same dual ownership pattern as bench_decode_ab.
     let mut metal: MetalQwen35State;
-    let tokenizer: BpeTokenizer;
 
     if is_q4_dir {
         let cfg = if dir.join("config.json").exists() {
@@ -155,24 +174,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             cache_len,
         )
         .map_err(|e| format!("Metal Q4 init: {e}"))?;
-        tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_dir.join("tokenizer.json"))?;
     } else {
         let model = Qwen35Model::from_safetensors(dir).expect("load model");
         let cfg = model.config().clone();
         metal = MetalQwen35State::new(model.weights(), &cfg, cache_len).expect("init metal");
-        tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_dir.join("tokenizer.json"))?;
     }
-
-    // Raw continuation prompt — no chat template — so the model sees a partial
-    // sentence and produces a continuation rather than a completed conversation.
-    // This avoids the early EOS that chat_completion triggers via im_end.
-    // The base text is intentionally left incomplete (no closing punctuation)
-    // so greedy continuation runs as a prose generation, not a Q&A exchange.
-    let base = "The quick brown fox jumps over the lazy dog and then continues \
-                running through the meadow past the old stone wall while the sun \
-                sets slowly over the distant mountains painting the sky in shades \
-                of orange and gold as the evening breeze stirs the tall grass and \
-                the river flows gently southward toward the ancient city where ";
 
     // Greedy, stop_token_ids empty — EOS token (248044) still stops generation
     // via the hard-coded path in generate().  The prompt design above avoids
@@ -195,7 +201,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         "[slopefit] grid={grid:?} warmup={warmup_tokens} measure={measure_tokens} repeats={repeats}"
     );
     eprintln!(
-        "[slopefit] kv_cache_len={cache_len} (max_ctx={max_ctx} + decode_horizon {})",
+        "[slopefit] kv_cache_len={cache_len} \
+         (deepest_prompt={deepest_prompt_tokens} for max_ctx={max_ctx} + decode_horizon {})",
         warmup_tokens.max(measure_tokens)
     );
 

--- a/crates/inference/src/bin/bench_decode_slopefit.rs
+++ b/crates/inference/src/bin/bench_decode_slopefit.rs
@@ -104,6 +104,16 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     grid.sort_unstable();
     grid.dedup();
 
+    // KV cache must hold the longest requested context plus the decode horizon.
+    // A too-small cache silently corrupts the deepest grid points: prefill fills
+    // the cache, decode immediately hits the cap, and the line reports tokens=1
+    // (a prefill cost masquerading as a decode rate, not a real per-token time).
+    // The previous hard-coded 4096 made every point at/above ctx=4096 — i.e. the
+    // entire SLOPEFIT_FULL {4096,8192,16384} tail this binary advertises — return
+    // tokens=1 instead of a measurement. Size from the grid so the tail is real.
+    let max_ctx = grid.iter().copied().max().unwrap_or(512);
+    let cache_len = max_ctx + warmup_tokens.max(measure_tokens) + 16;
+
     // Detect Q4 dir (same heuristic as bench_decode_ab).
     let is_q4_dir = !dir.join("model.safetensors").exists()
         && std::fs::read_dir(dir)
@@ -138,14 +148,18 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             Qwen35Config::qwen35_0_8b()
         };
-        metal =
-            MetalQwen35State::from_q4_dir(dir, &tokenizer_dir.join("tokenizer.json"), &cfg, 4096)
-                .map_err(|e| format!("Metal Q4 init: {e}"))?;
+        metal = MetalQwen35State::from_q4_dir(
+            dir,
+            &tokenizer_dir.join("tokenizer.json"),
+            &cfg,
+            cache_len,
+        )
+        .map_err(|e| format!("Metal Q4 init: {e}"))?;
         tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_dir.join("tokenizer.json"))?;
     } else {
         let model = Qwen35Model::from_safetensors(dir).expect("load model");
         let cfg = model.config().clone();
-        metal = MetalQwen35State::new(model.weights(), &cfg, 4096).expect("init metal");
+        metal = MetalQwen35State::new(model.weights(), &cfg, cache_len).expect("init metal");
         tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_dir.join("tokenizer.json"))?;
     }
 
@@ -179,6 +193,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!(
         "[slopefit] grid={grid:?} warmup={warmup_tokens} measure={measure_tokens} repeats={repeats}"
+    );
+    eprintln!(
+        "[slopefit] kv_cache_len={cache_len} (max_ctx={max_ctx} + decode_horizon {})",
+        warmup_tokens.max(measure_tokens)
     );
 
     for &ctx in &grid {

--- a/scripts/perf_governor.py
+++ b/scripts/perf_governor.py
@@ -308,7 +308,10 @@ class PerfGovernor:
 
         _group_signal(signal.SIGTERM)
         try:
-            proc.wait(timeout=2.0)
+            # Short grace, not a generous one: this is a bounded-window / thermal
+            # safety kill, and a GPU bench mid-command-buffer won't service SIGTERM
+            # promptly, so dwelling here only adds load at the cap. Escalate fast.
+            proc.wait(timeout=0.3)
             return  # SIGTERM was enough
         except subprocess.TimeoutExpired:
             pass
@@ -392,10 +395,12 @@ class PerfGovernor:
                             f"{self.max_thermal_cooldowns} cooldown cycles — hard abort"
                         )
                         abort_msgs.append(msg)
-                        # SIGCONT first so SIGTERM is receivable, then SIGKILL
+                        # SIGCONT first so SIGTERM is receivable, then SIGKILL.
+                        # Swallow EPERM too — _kill_pg's direct fallback carries
+                        # the kill even if this group signal is denied.
                         try:
                             os.killpg(os.getpgid(proc.pid), signal.SIGCONT)
-                        except ProcessLookupError:
+                        except (ProcessLookupError, PermissionError):
                             pass
                         self._kill_pg(proc, msg)
                         return
@@ -410,6 +415,14 @@ class PerfGovernor:
                                 "waiting for thermal to clear"
                             )
                         except ProcessLookupError:
+                            return  # child already gone — nothing to throttle
+                        except PermissionError:
+                            # SIGSTOP denied on a still-live, thermally-hot process.
+                            # Abandoning the poller would also drop BOUNDED watch and
+                            # leave it running hot, so escalate to a hard abort.
+                            msg = "THERMAL: SIGSTOP denied (EPERM) — hard abort"
+                            abort_msgs.append(msg)
+                            self._kill_pg(proc, msg)
                             return
                 else:
                     # Thermal cleared — resume if paused
@@ -422,6 +435,10 @@ class PerfGovernor:
                             _log(f"THERMAL: cleared; sent SIGCONT to pgid={pgid}")
                         except ProcessLookupError:
                             return
+                        except PermissionError:
+                            # Resume denied; the next poll re-evaluates thermal and
+                            # will hard-abort if pressure persists. Don't crash here.
+                            pass
 
         poller = threading.Thread(target=_poller, daemon=True)
         poller.start()

--- a/scripts/perf_governor.py
+++ b/scripts/perf_governor.py
@@ -279,21 +279,54 @@ class PerfGovernor:
 
     # ------------------------------------------------------------------
     def _kill_pg(self, proc: subprocess.Popen, reason: str) -> None:
-        """Send SIGTERM then SIGKILL to the process group. Logs the reason."""
+        """Terminate the child (SIGTERM then SIGKILL), confirm it is dead.
+
+        The child is spawned with ``start_new_session=True`` so its pgid equals
+        its pid; the group signal reaches the whole subtree. But ``killpg`` can
+        raise ``PermissionError`` (EPERM) on macOS — e.g. when the group leader
+        has exited but the group still holds a zombie, or a GPU-helper member
+        runs under a security context the sender cannot signal. A bare
+        ``except ProcessLookupError`` lets that EPERM escape and crash the poller
+        thread, leaving the SIGKILL undelivered. Since this governor IS the
+        bounded-window safety guarantee, the kill path must never depend on the
+        group signal landing: on ANY failure, fall back to a direct ``proc.kill``
+        (the child is one we definitely own) and reap to CONFIRM death.
+        """
         _log(f"KILL [{reason}]: pid={proc.pid}")
-        try:
-            pgid = os.getpgid(proc.pid)
+
+        def _group_signal(sig: int) -> None:
+            # Best-effort group signal. ProcessLookupError = already gone (fine).
+            # PermissionError = EPERM on the group; swallow and let the direct
+            # proc.kill() fallback below carry the guarantee.
             try:
-                os.killpg(pgid, signal.SIGTERM)
-            except ProcessLookupError:
-                return
-            time.sleep(0.25)
-            try:
-                os.killpg(pgid, signal.SIGKILL)
-            except ProcessLookupError:
+                os.killpg(os.getpgid(proc.pid), sig)
+            except (ProcessLookupError, PermissionError):
                 pass
+
+        if proc.poll() is not None:
+            return  # already dead — nothing to do
+
+        _group_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=2.0)
+            return  # SIGTERM was enough
+        except subprocess.TimeoutExpired:
+            pass
+
+        _group_signal(signal.SIGKILL)
+        # Direct kill of the child we own — independent of the group signal,
+        # so an EPERM on killpg cannot leave the process running.
+        try:
+            proc.kill()
         except ProcessLookupError:
             pass
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            _log(
+                f"KILL [{reason}]: pid={proc.pid} STILL ALIVE after SIGKILL — "
+                "manual intervention required"
+            )
 
     # ------------------------------------------------------------------
     def run_guarded(self, label: str, argv: List[str]) -> int:
@@ -585,6 +618,56 @@ def _cmd_selftest(gov: PerfGovernor) -> int:
             print(f"  GovernorAbort raised as expected: {e.reason}")
 
     demo("(c) BOUNDED cap kills long process", demo_c)
+
+    # (c2) killpg EPERM: when the process-group signal is denied (the real macOS
+    # failure observed on a GPU bench at the bounded cap), the child must STILL
+    # die via the direct proc.kill() fallback. Regression lock — reverting
+    # _kill_pg to a bare `except ProcessLookupError` lets the EPERM escape, the
+    # SIGKILL never lands, and `sleep 999` survives this assertion.
+    def demo_c2() -> None:
+        g = PerfGovernor(max_window_s=2, cooldown_s=0, afk_only=False,
+                         poll_interval_s=0.4)
+        g._thermal_reader = lambda: {"speed_limit": 100, "nominal": True}
+        g._ac_reader = lambda: True
+        g._idle_reader = lambda: 999.0
+
+        captured: dict = {}
+        real_popen = subprocess.Popen
+        orig_killpg = os.killpg
+
+        def capturing_popen(*a, **k):
+            p = real_popen(*a, **k)
+            captured["proc"] = p
+            return p
+
+        def eperm_killpg(_pgid, _sig):
+            # Simulate the denied group signal. proc.kill() uses os.kill on the
+            # single owned child, not killpg, so the fallback remains effective.
+            raise PermissionError(1, "Operation not permitted")
+
+        subprocess.Popen = capturing_popen  # type: ignore[assignment]
+        os.killpg = eperm_killpg  # type: ignore[assignment]
+        try:
+            try:
+                g.run_guarded("demo_c2", ["sleep", "999"])
+                raise AssertionError("expected GovernorAbort under killpg-EPERM")
+            except GovernorAbort as e:
+                print(f"  GovernorAbort raised under killpg-EPERM: {e.reason}")
+        finally:
+            subprocess.Popen = real_popen  # type: ignore[assignment]
+            os.killpg = orig_killpg  # type: ignore[assignment]
+
+        proc = captured["proc"]
+        for _ in range(30):
+            if proc.poll() is not None:
+                break
+            time.sleep(0.1)
+        assert proc.poll() is not None, (
+            "child survived killpg-EPERM — direct proc.kill() fallback failed"
+        )
+        print(f"  child pid={proc.pid} killed via direct fallback (rc={proc.returncode})")
+
+    demo("(c2) killpg-EPERM falls back to direct child kill", demo_c2)
 
     # (d) KILL-SWITCH: create sentinel → preflight aborts → remove → passes
     def demo_d() -> None:


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Two perf-harness correctness fixes found while running the ADR-064 decode slopefit over a long-context grid. Both are internal harness/tooling (a benchmark binary and the macOS perf-safety guardrail script) — no library, kernel, or public-API code is touched.

## 1. `bench_decode_slopefit.rs` — KV cache silently truncated deep grid points

The binary advertises a `SLOPEFIT_FULL` tail of `{4096, 8192, 16384}` but hard-coded a **4096-token** KV cache. Every grid point at or above 4096 silently truncated: prefill filled the cache, decode immediately hit the cap, and the line reported `tokens=1` — a prefill cost masquerading as a decode rate, not a real per-token time.

Fix: size the cache from the **actual deepest padded prompt** (the pad loop overshoots `ctx` by up to one filler block, so sizing from `max_ctx` alone — the first cut, caught in review — still left the deepest point short). `cache_len = deepest_padded_prompt_tokens + max(warmup, measure) + 16`.

Verified empirically under the governor: `ctx=4096` went `tokens=1 → tokens=128`; `kv_cache_len=4240 (deepest_prompt=4096 + decode_horizon 128)`. The newly-measurable 4096 decode rate (24.1 tok/s) landed within 5% of the linear extrapolation — the decode-latency model is **linear in context through 4096, R² = 0.988 over a 64× span** (`ms/tok = 9.08 + 0.00793·ctx`, crossover ~1145 ctx).

## 2. `perf_governor.py` — kill path crashed on `killpg` EPERM

At the bounded-window cap on a real GPU bench, the group `SIGKILL` raised `PermissionError` (EPERM, macOS). The handler caught only `ProcessLookupError`, so the EPERM escaped and **crashed the poller thread**, leaving the SIGKILL undelivered (the child died only because the earlier SIGTERM happened to land). This governor *is* the perf-safety guarantee, so its kill path must not depend on the group signal landing.

Fix: catch EPERM on every group signal and fall back to a **direct `proc.kill()`** on the owned child, then reap to confirm death. The thermal SIGCONT/SIGSTOP paths are hardened the same way (a denied SIGSTOP escalates to a hard abort rather than abandoning the poller). SIGTERM grace cut 2.0s → 0.3s so a safety kill doesn't dwell while a Metal command buffer ignores SIGTERM.

New selftest case `(c2)` injects an EPERM-raising `killpg` and asserts the child still dies via the direct fallback — regression lock. All 7 guards green.

## Testing
- `cargo clippy -p lattice-inference --bin bench_decode_slopefit --features f16,metal-gpu -- -D warnings` clean
- `python3 scripts/perf_governor.py --selftest` — all 7 guards trip as designed (incl. c2)
- Empirical: ctx=4096 decode confirmed `tokens=128` post-fix, under the AFK/AC/thermal governor

## Why no `make bench-compare`
The CLAUDE.md rule targets engine perf changes. This diff touches only a **benchmark-harness binary** (cache-allocation sizing) and a **Python guardrail script** — zero library/kernel code paths, so there is no engine throughput for bench-compare to measure. The relevant gate is e2e-parity (correctness), which runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)