### PR TITLE
docs(embed): document i8 [-127,127] precondition on dot_product_i8_raw (#326)

### DIFF
--- a/crates/embed/src/service/mod.rs
+++ b/crates/embed/src/service/mod.rs
@@ -93,7 +93,8 @@ pub trait EmbeddingService: Send + Sync {
     ///
     /// Returns a vector of embeddings, one for each input text, in the same order.
     /// Applies no role-specific prompt prefix (equivalent to `Generic` role).
-    /// Use [`embed_query`] / [`embed_passage`] for asymmetric retrieval models.
+    /// Use [`EmbeddingService::embed_query`] / [`EmbeddingService::embed_passage`]
+    /// for asymmetric retrieval models.
     async fn embed(&self, texts: &[String], model: EmbeddingModel) -> Result<Vec<Vec<f32>>>;
 
     /// **Stable**: generate an embedding for a single text.

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -176,8 +176,10 @@ impl QuantizedVector {
 /// # Invariant
 ///
 /// Both vectors must satisfy the `[-127, 127]` range invariant. The value `-128`
-/// causes silent corruption in AVX2 (`_mm256_sign_epi8` saturation) and AVX-512
-/// VNNI (`_mm512_dpbusd_epi32` after `vpabsb`). The `data` field is private, so
+/// causes silent corruption on the AVX2 and AVX-512-VNNI paths, which apply an
+/// operand's sign by negating a byte (`_mm256_sign_epi8` / a `0 - b` emulation):
+/// negating `-128` wraps back to `-128` in two's complement instead of `+128`,
+/// so the kernel accumulates the wrong sign. The `data` field is private, so
 /// only `from_f32` (which clamps) can populate it — `debug_assert!` is sufficient.
 #[inline]
 pub fn dot_product_i8(a: &QuantizedVector, b: &QuantizedVector) -> f32 {
@@ -644,8 +646,10 @@ fn dot_product_i8_scalar_kernel(a: &[i8], b: &[i8]) -> f32 {
 /// # Invariant
 ///
 /// Both slices must satisfy the `[-127, 127]` range invariant. The value `-128`
-/// causes silent corruption in AVX2 (`_mm256_sign_epi8` saturation) and AVX-512
-/// VNNI (`_mm512_dpbusd_epi32` after `vpabsb`). The invariant is enforced with a
+/// causes silent corruption on the AVX2 and AVX-512-VNNI paths, which apply an
+/// operand's sign by negating a byte (`_mm256_sign_epi8` / a `0 - b` emulation):
+/// negating `-128` wraps back to `-128` in two's complement instead of `+128`,
+/// so the kernel accumulates the wrong sign. The invariant is enforced with a
 /// **`debug_assert!`** (debug builds only); callers MUST guarantee it. The
 /// `QuantizedVector::from_f32` constructor satisfies it by clamping to `[-127, 127]`.
 /// Promoting this to a release `assert!` would add an O(n) scan to a documented hot
@@ -670,12 +674,14 @@ fn dot_product_i8_dispatch(a: &[i8], b: &[i8]) -> f32 {
 /// # Invariant (caller-guaranteed)
 ///
 /// Every element of `a` and `b` must lie in `[-127, 127]`, i.e. the value
-/// `-128` (`i8::MIN`) must not appear. `-128` causes silent corruption in the
-/// AVX2 (`_mm256_sign_epi8` saturation) and AVX-512 VNNI (`_mm512_dpbusd_epi32`
-/// after `vpabsb`) kernels — the dispatch returns a wrong distance with no
-/// panic. The precondition is checked only by `debug_assert!`, which is
-/// compiled out in release builds, so a release caller gets no diagnostic.
-/// `-128` is memory-safe (no UB), only numerically out-of-contract.
+/// `-128` (`i8::MIN`) must not appear. The AVX2 and AVX-512-VNNI kernels apply
+/// an operand's sign by negating a byte (`_mm256_sign_epi8` / a `0 - b`
+/// emulation); negating `-128` wraps back to `-128` in two's complement instead
+/// of `+128`, so the kernel silently accumulates the wrong sign and the dispatch
+/// returns a wrong distance with no panic. The precondition is checked only by
+/// `debug_assert!`, which is compiled out in release builds, so a release caller
+/// gets no diagnostic. `-128` is memory-safe (no UB), only numerically
+/// out-of-contract.
 ///
 /// Vectors produced by [`QuantizedVector::from_f32`] satisfy this automatically
 /// (it clamps to `[-127, 127]`). Callers feeding slices from an external or

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -666,6 +666,22 @@ fn dot_product_i8_dispatch(a: &[i8], b: &[i8]) -> f32 {
 ///
 /// The key difference is zero allocation overhead: no `Vec<i8>`, no
 /// `QuantizedVector`, no `QuantizationParams`. Just raw slices in, f32 out.
+///
+/// # Invariant (caller-guaranteed)
+///
+/// Every element of `a` and `b` must lie in `[-127, 127]`, i.e. the value
+/// `-128` (`i8::MIN`) must not appear. `-128` causes silent corruption in the
+/// AVX2 (`_mm256_sign_epi8` saturation) and AVX-512 VNNI (`_mm512_dpbusd_epi32`
+/// after `vpabsb`) kernels — the dispatch returns a wrong distance with no
+/// panic. The precondition is checked only by `debug_assert!`, which is
+/// compiled out in release builds, so a release caller gets no diagnostic.
+/// `-128` is memory-safe (no UB), only numerically out-of-contract.
+///
+/// Vectors produced by [`QuantizedVector::from_f32`] satisfy this automatically
+/// (it clamps to `[-127, 127]`). Callers feeding slices from an external or
+/// differently-configured quantizer must clamp `i8::MIN` up to `-127` first.
+/// The invariant is a `debug_assert!` rather than a release `assert!` on
+/// purpose: a release-time scan would add O(n) work to this documented hot path.
 #[inline]
 pub fn dot_product_i8_raw(a: &[i8], b: &[i8]) -> f32 {
     if a.len() != b.len() {


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Resolves #326.

## What

`dot_product_i8_raw` (and the `_raw` int8 kernels) require every `i8` input in `[-127, 127]` — the value `-128`/`i8::MIN` silently corrupts the AVX2 / AVX-512-VNNI paths. The precondition is `debug_assert!`-only (compiled out in release), so a release caller feeding `-128` from an external quantizer gets wrong distances with no panic.

The public rustdoc on `dot_product_i8_raw` did not state this — it lived only in the private `dot_product_i8_dispatch` helper, invisible on the public symbol and its `simd/mod.rs` re-export. This PR adds an explicit `# Invariant (caller-guaranteed)` section: the `-128` hazard, that it is memory-safe but numerically out-of-contract, how `QuantizedVector::from_f32` satisfies it (clamps), and why the check is intentionally `debug_assert!` not a release `assert!` (O(n) scan on a hot path).

Per #326 this is **documentation-only** — there is no in-tree misuse (the default quantizer clamps at `quantized.rs:130`; only benches call `_raw`), and validating inputs at runtime would defeat the unchecked-kernel's purpose.

## Drive-by (same crate, same concern)

`cargo doc -p lattice-embed -D warnings` was already failing on `main` due to two broken intra-doc links at `service/mod.rs:96` (`[embed_query]`/`[embed_passage]` — bare names that don't resolve). Fixed to the qualified `EmbeddingService::` form, matching the working reference at line 40. Embed now doc-lints clean.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc -p lattice-embed --no-deps` → clean (was failing on main).
- `cargo clippy -p lattice-embed --all-targets -D warnings` → clean.
- Pre-commit deno doc lint → passed.

No behavior change (docs only). `make bench-compare` N/A — no code path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)