### PR TITLE
ci(embed): release-cadence parity gate for production embedding models

### DIFF
--- a/.github/workflows/embed-parity-release.yml
+++ b/.github/workflows/embed-parity-release.yml
@@ -1,0 +1,100 @@
+name: embed-parity-release
+# Release-cadence embedding parity gate. NOT a per-PR / per-commit check — the
+# per-PR coverage is the BGE-small `embed-drift` job in e2e-parity.yml. This one
+# runs the heavier full HF-reference parity suite across the production embedding
+# models (the ones khive actually serves: all-minilm-l6-v2 and
+# paraphrase-multilingual-minilm-l12-v2) plus bge-small and multilingual-e5-small,
+# on the release branch / tag, where the cost of provisioning every model's
+# weights is justified.
+#
+# Why release-cadence and not per-PR: provisioning four model checkpoints (~600 MB
+# total) on every PR is wasteful, and the forward path that produces these vectors
+# is stable (only #232 NEON normalize + #214 f16 conversion touched it since
+# v0.3.0). Drift is caught per-PR for BGE; this gate is the broader release
+# backstop so a production-model geometry regression cannot ship un-noticed.
+#
+# Anti-silent-skip: the parity tests skip when weights are absent. This workflow
+# sets LATTICE_PARITY_GATE_ENFORCE=1 so a missing checkpoint (provisioning
+# regression) FAILS the job instead of passing a gate that verified nothing.
+# (qwen3-embedding-0.6b is #[ignore]'d for lattice#103 and is intentionally not
+# covered here.)
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - 'release-prep/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+
+jobs:
+  embed-parity:
+    name: embed parity (production models)
+    # arm64 to exercise the NEON normalize path production lattice runs on.
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: embed-parity-release
+
+      # Weights are immutable, so the cache keys never need to change unless a
+      # model revision is bumped (then bump the matching key suffix).
+      - name: Cache bge-small-en-v1.5 weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.lattice/models/bge-small-en-v1.5
+          key: bge-small-en-v1.5-v1
+
+      - name: Cache multilingual-e5-small weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.lattice/models/multilingual-e5-small
+          key: multilingual-e5-small-v1
+
+      - name: Cache all-minilm-l6-v2 weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.lattice/models/all-minilm-l6-v2
+          key: all-minilm-l6-v2-v1
+
+      - name: Cache paraphrase-multilingual-minilm-l12-v2 weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.lattice/models/paraphrase-multilingual-minilm-l12-v2
+          key: paraphrase-multilingual-minilm-l12-v2-v1
+
+      # Download any model not restored from cache. --download-only is idempotent:
+      # a cache hit leaves the weights in place and this just re-verifies them.
+      - name: Provision model weights
+        run: |
+          set -euo pipefail
+          for model in \
+            bge-small-en-v1.5 \
+            multilingual-e5-small \
+            all-minilm-l6-v2 \
+            paraphrase-multilingual-minilm-l12-v2; do
+            echo "::group::provision $model"
+            cargo run --release -p lattice-embed --bin embed -- --model "$model" --download-only
+            echo "::endgroup::"
+          done
+
+      - name: Run embedding parity gate
+        # LATTICE_PARITY_GATE_ENFORCE=1 makes a missing checkpoint fail-closed
+        # instead of silently skipping (see record_vector_weight_skip).
+        env:
+          LATTICE_PARITY_GATE_ENFORCE: '1'
+        run: |
+          cargo test --release -p lattice-embed --test embed_parity_vs_hf \
+            -- --nocapture

--- a/crates/embed/tests/embed_parity_vs_hf.rs
+++ b/crates/embed/tests/embed_parity_vs_hf.rs
@@ -89,7 +89,25 @@ fn load_fixture(filename: &str) -> Vec<Golden> {
     serde_json::from_str(&data).unwrap_or_else(|e| panic!("bad JSON in {filename}: {e}"))
 }
 
+/// Handle the no-weights case: skip locally, but FAIL CLOSED in CI.
+///
+/// Locally and in the workspace-wide `cargo test` job the weights are usually
+/// absent, so each parity test calls this and `return`s — a clean skip. The
+/// dedicated release-cadence gate (`.github/workflows/embed-parity-release.yml`)
+/// provisions the weights AND sets `LATTICE_PARITY_GATE_ENFORCE=1`; there a
+/// missing model means provisioning failed and a silent skip would be pure
+/// theater (a green gate that verified nothing). Under the enforce flag this
+/// panics instead of returning, so the gate fails loudly. Mirrors the
+/// `LATTICE_DRIFT_GATE_ENFORCE` guard in `embed_drift_baseline.rs`.
 fn record_vector_weight_skip(test_name: &str, model_dir: &std::path::Path) {
+    if std::env::var("LATTICE_PARITY_GATE_ENFORCE").is_ok() {
+        panic!(
+            "parity gate weights missing despite LATTICE_PARITY_GATE_ENFORCE=1 — \
+             provisioning failed for {test_name} (expected weights at {}). A silent \
+             skip here would make the release parity gate verify nothing.",
+            model_dir.display()
+        );
+    }
     eprintln!(
         "LATTICE_VECTOR_PARITY_SKIPPED test={test_name} reason=missing_weights path={}",
         model_dir.display()


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Why

Production khive serves **all-minilm-l6-v2** and **paraphrase-multilingual-minilm-l12-v2** embeddings (default `EmbeddingModel::AllMiniLmL6V2`). The only per-PR embedding coverage today is the **BGE-small** drift gate in `e2e-parity.yml`. The HF-parity tests for the production MiniLMs (and multilingual-e5-small) exist in `embed_parity_vs_hf.rs` but **silently skip when weights are absent** — and CI runners lack the weights, so those models have had **zero CI coverage**.

## What

- **`embed-parity-release.yml`** — a release-cadence gate (triggers on tag push `v*`, `release-prep/**` branches, and `workflow_dispatch`; **not** per-PR/per-commit). Provisions the four model checkpoints (cached by model dir, ~600 MB total) and runs the full `embed_parity_vs_hf` suite on the arm64 NEON path production uses.
- **Anti-silent-skip guard** — `record_vector_weight_skip` now fail-closes under `LATTICE_PARITY_GATE_ENFORCE=1` (mirrors the existing `LATTICE_DRIFT_GATE_ENFORCE` guard in `embed_drift_baseline.rs`). A missing checkpoint **fails** the job instead of passing a gate that verified nothing.

`qwen3-embedding-0.6b` is `#[ignore]`'d (lattice#103) and intentionally not covered.

## Verification (both directions, locally)

| Condition | Result |
|---|---|
| Weights present + enforce | **4 pass** — min_cosine 0.99987 (minilm 0.99990, paraphrase 0.99988, e5 0.99994, bge 0.99987) |
| Weights missing + enforce | **4 fail loudly** — `panic: parity gate weights missing despite LATTICE_PARITY_GATE_ENFORCE=1` |

The fail-closed direction is the point: it proves the gate cannot go green by skipping everything.

## Scope

CI infra + a test-harness guard. No published-crate source changes, so this does not affect v0.4.0 crate contents — it is a fast-follow backstop, not a release blocker. Default `cargo test` (no enforce env) still cleanly skips when weights are absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)