### PR TITLE
fix(inference): Q4 Metal decode dispatch geometry + asymmetric-bias f16 materialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,17 @@ jobs:
       - name: embed — metal-gpu clippy (macOS only)
         if: runner.os == 'macOS'
         run: cargo clippy -p lattice-embed --features metal-gpu -- -D warnings
+      # The metal-gpu surface was BUILT and linted above but never RUN, so Metal
+      # correctness tests (e.g. the Q4 decode dispatch-geometry regression #384)
+      # were local-only — a green CI here verified compilation, not behavior.
+      # Run the Q4 Metal correctness tests on the Apple-silicon runner.
+      # LATTICE_METAL_TEST_ENFORCE=1 makes the dispatch regression fail closed if
+      # the runner ever loses its Apple7 GPU, rather than skip-passing silently.
+      - name: inference — metal-gpu Q4 tests (macOS only)
+        if: runner.os == 'macOS'
+        env:
+          LATTICE_METAL_TEST_ENFORCE: '1'
+        run: cargo test -p lattice-inference --features f16,metal-gpu --lib q4 -- --nocapture
 
   # The benchmark harnesses live behind their own feature flags / target gates
   # and are never built by `cargo test`. A `Qwen35Config` field added to the

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -17049,6 +17049,12 @@ kernel void decode_attention_reference(
             // silently skips here would make this regression gate verify nothing —
             // the same silent-skip class as the embed parity gate (#383). The
             // dedicated macOS test step sets LATTICE_METAL_TEST_ENFORCE=1.
+            //
+            // Note: NO Apple7 family gate. `gemv_q4_decode` uses only `simd_sum` +
+            // threadgroup memory, not the Apple7-gated `simdgroup_matrix` MMA path,
+            // so it runs on GitHub's paravirtual macOS GPU (which reports a Metal
+            // device but NOT Apple7). The tiled-GEMM tests below DO need Apple7 and
+            // skip on CI; this decode-geometry test genuinely runs there.
             let enforce = std::env::var("LATTICE_METAL_TEST_ENFORCE").is_ok();
             let Some(device) = Device::system_default() else {
                 assert!(
@@ -17057,14 +17063,6 @@ kernel void decode_attention_reference(
                 );
                 return;
             };
-            if !device.supports_family(MTLGPUFamily::Apple7) {
-                assert!(
-                    !enforce,
-                    "LATTICE_METAL_TEST_ENFORCE=1 but Metal device lacks Apple7 — \
-                     Q4 decode dispatch regression cannot be exercised"
-                );
-                return;
-            }
             let (cfg, weights) = tiny_metal_qwen35_fixture();
             let state =
                 MetalQwen35State::new(&weights, &cfg, 4).expect("tiny MetalQwen35State fixture");

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -17045,10 +17045,24 @@ kernel void decode_attention_reference(
         /// dequant reference. Reverting the fix to `div_ceil(4)` fails this test.
         #[test]
         fn dispatch_matmul_q4_writes_all_rows() {
+            // Fail closed under enforce: a CI runner that provisions a Metal GPU but
+            // silently skips here would make this regression gate verify nothing —
+            // the same silent-skip class as the embed parity gate (#383). The
+            // dedicated macOS test step sets LATTICE_METAL_TEST_ENFORCE=1.
+            let enforce = std::env::var("LATTICE_METAL_TEST_ENFORCE").is_ok();
             let Some(device) = Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
                 return;
             };
             if !device.supports_family(MTLGPUFamily::Apple7) {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but Metal device lacks Apple7 — \
+                     Q4 decode dispatch regression cannot be exercised"
+                );
                 return;
             }
             let (cfg, weights) = tiny_metal_qwen35_fixture();

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -11519,7 +11519,7 @@ kernel void gdn_chunk_norm_silu_c32(
             enc.set_bytes(3, 4, &n as *const u32 as *const _);
             enc.set_bytes(4, 4, &k as *const u32 as *const _);
             enc.dispatch_thread_groups(
-                MTLSize::new(n.div_ceil(4) as u64, 1, 1), // NR=4
+                MTLSize::new(n.div_ceil(2) as u64, 1, 1), // gemv_q4_decode writes NR=2 rows/threadgroup
                 MTLSize::new(32, 4, 1),
             );
         }
@@ -13343,10 +13343,11 @@ kernel void gdn_chunk_norm_silu_c32(
             let mut f16_data: Vec<u16> = Vec::with_capacity(tensor.original_len);
             for block in &tensor.blocks {
                 let scale = q4_f16_to_f32(block.scale);
+                let bias = q4_f16_to_f32(block.bias);
                 for b in 0..16 {
                     let byte_val = block.packed[b];
-                    let w0 = ((byte_val & 0x0f) as f32 - 8.0) * scale;
-                    let w1 = ((byte_val >> 4) as f32 - 8.0) * scale;
+                    let w0 = (byte_val & 0x0f) as f32 * scale + bias;
+                    let w1 = (byte_val >> 4) as f32 * scale + bias;
                     f16_data.push(q4_f32_to_f16(w0));
                     f16_data.push(q4_f32_to_f16(w1));
                 }
@@ -17027,6 +17028,86 @@ kernel void decode_attention_reference(
                     "[shape B] tiled_vs_naive={tiled_vs_naive:.4e} exceeds 0.012"
                 );
             }
+        }
+
+        /// Regression for the Q4 decode dispatch-geometry bug (codex 2026-06-26).
+        ///
+        /// `gemv_q4_decode` writes NR=2 output rows per threadgroup, so
+        /// `dispatch_matmul_q4` MUST launch `ceil(N/2)` groups. The prior `ceil(N/4)`
+        /// left the upper ~half of the rows unwritten — on the Q4 decode/logits path
+        /// (`final_logits` → `dispatch_matmul` for `QuantFormat::Q4_0`, N = vocab_size)
+        /// this silently corrupted every token after the first prefill token, because
+        /// the upper half of the vocabulary logits were never produced.
+        ///
+        /// N=6 is the minimal shape that exposes it: `ceil(6/4)=2` groups write only
+        /// rows 0..4 (rows 4,5 dropped); `ceil(6/2)=3` groups write all 6. Pre-fill Y
+        /// with a sentinel and assert every row is overwritten and matches the CPU
+        /// dequant reference. Reverting the fix to `div_ceil(4)` fails this test.
+        #[test]
+        fn dispatch_matmul_q4_writes_all_rows() {
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            if !device.supports_family(MTLGPUFamily::Apple7) {
+                return;
+            }
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let state =
+                MetalQwen35State::new(&weights, &cfg, 4).expect("tiny MetalQwen35State fixture");
+
+            let (n, k) = (6usize, 64usize);
+            let (qw_raw, w_deq) = make_q4_weight_ref(&device, 0x0FF0_1234_u64, n, k);
+            let qw = Q4WeightBuf::from_buffer(qw_raw);
+
+            let mut xrng = 0x1234_5678_u64;
+            let x: Vec<f32> = (0..k)
+                .map(|_| {
+                    xrng = xrng
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
+                    ((xrng >> 11) as u32 as f32 / u32::MAX as f32) * 2.0 - 1.0
+                })
+                .collect();
+            let x_buf = device.new_buffer_with_data(
+                x.as_ptr() as *const _,
+                (x.len() * 4) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+
+            // Pre-fill the output with a sentinel far outside the achievable result
+            // range (|y| < K = 64 here); any row left untouched keeps it.
+            const SENTINEL: f32 = -123_456.0;
+            let y_init = vec![SENTINEL; n];
+            let y_buf = device.new_buffer_with_data(
+                y_init.as_ptr() as *const _,
+                (n * 4) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+
+            let cmd = state.engine.queue.new_command_buffer();
+            let enc = cmd.new_compute_command_encoder();
+            state.dispatch_matmul_q4(enc, &x_buf, &qw, &y_buf, 1, n as u32, k as u32);
+            enc.end_encoding();
+            cmd.commit();
+            cmd.wait_until_completed();
+
+            // SAFETY: StorageModeShared, GPU work completed, size matches allocation.
+            let y: &[f32] =
+                unsafe { std::slice::from_raw_parts(y_buf.contents() as *const f32, n) };
+            let y_ref = cpu_matmul_ref(&x, &w_deq, 1, n, k);
+
+            for (row, &val) in y.iter().enumerate() {
+                assert!(
+                    val.to_bits() != SENTINEL.to_bits(),
+                    "row {row} of {n} never written — dispatch grid under-covers \
+                     gemv_q4_decode (NR=2 rows/group). This is the codex P0 decode-geometry bug."
+                );
+            }
+            let diff = max_abs_diff(y, &y_ref);
+            assert!(
+                diff < 1e-3,
+                "dispatch_matmul_q4 result diverges from CPU dequant ref: max_abs_diff={diff:.4e}"
+            );
         }
 
         // ── Q8 GEMM numeric differential gate ────────────────────────────────

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -57,7 +57,9 @@
 /// ```text
 /// byte[b] = (q[2b+1] << 4) | q[2b]
 /// ```
-/// where `q[i] = clamp(round(weight[i] / scale) + 8, 0, 15)`.
+/// where `q[i] = clamp(round((weight[i] - bias) / scale), 0, 15)` for the default
+/// asymmetric format (`bias` = per-block minimum). The legacy symmetric variant
+/// fixes `bias = -8 * scale`, giving `q[i] = clamp(round(weight[i] / scale) + 8, 0, 15)`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Q4Block {


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Two Q4 correctness bugs on the Metal decode path, both surfaced by a discovery review pass over quantization and verified this session. **Both are P0** and should land before the v0.4.0 cut.

### P0-A — dispatch geometry under-covers output rows

`dispatch_matmul_q4` launched `n.div_ceil(4)` threadgroups, but the bound `gemv_q4_decode` kernel writes **NR=2** rows per threadgroup. The upper ~half of the output rows were never written.

On the Q4 decode/logits path (`final_logits` → `dispatch_matmul` for `QuantFormat::Q4_0`, N = vocab_size) this silently corrupted **every token after the first prefill token** — the upper half of the vocabulary logits were stale/uninitialized.

- Only **m=1 decode** hit it. m>1 prefill/PPL uses the tiled `dispatch_gemm_q4` path (whose m==1 branch already uses `div_ceil(2)`), which is why **Q4 PPL looked healthy (18.08)** while interactive Q4 generation produced garbage after token one. This is also why e2e-parity (BF16, greedy-token-only) never caught it.

**Runtime verification** (`chat_metal`, greedy, temp 0):

| prompt | before fix | after fix |
|---|---|---|
| `The capital of France is` | ` Paris` → garbage | ` Paris.` then coherent repeat (60 tok/s) |
| `Once upon a time` | ` of staw staw staw…` | ` of the year, the world is in full bloom…` |
| `Python is a programming language that` | ` was ialis ialis…` | ` was developed by … used for creating applications…` |

Fix: `n.div_ceil(4)` → `n.div_ceil(2)` (one line), matching the already-correct `dispatch_gemm_q4` m==1 branch.

### P0-B — asymmetric bias ignored in f16 materialization

`make_buffer_f16_from_q4` decoded every nibble as `(nibble - 8) * scale` (the old **symmetric** formula), ignoring `block.bias`. The current Q4 block format is **asymmetric** — `weight = nibble * scale + bias` per the `Q4Block` doc-comment and the canonical `dequantize_row_q4_0`.

This helper materializes f16 buffers for `embed_tokens` and GDN `in_proj` on the `from_q4_dir` path, so the same Q4 artifact was decoded inconsistently vs the GPU GEMV kernel (which already reads bias correctly). Fixed to `nibble * scale + bias`.

## Regression test

`dispatch_matmul_q4_writes_all_rows` (N=6, sentinel-prefilled output) exercises the **wrapper directly** and is mutation-sensitive — reverting to `div_ceil(4)` fails with `row 4 of 6 never written`. Verified both directions this session (pass on fix, fail on revert).

P0-B's helper is a nested fn returning a Metal `Buffer`; it is verified against the documented spec (`Q4Block` comment + `dequantize_row_q4_0`). A direct unit test would require extracting the dequant loop — noted as possible follow-up, not done here to keep the change minimal.

## Gates

- `cargo clippy -p lattice-inference --features "f16 metal-gpu" --lib` clean.
- New regression test passes; mutation-revert fails as expected.
- e2e-parity (BF16) is **blind to Q4** by construction — it gates that this change doesn't regress the BF16 path, not the Q4 fix itself. The Q4 proof is the runtime decode table + the new test.
- Not a perf PR: `div_ceil(2)` doubles Q4-decode GEMV threadgroups vs the broken baseline, but the baseline computed wrong logits, so an A/B throughput delta is not meaningful. Post-fix decode is ~60 tok/s on M1.

## Scope

Metal/GPU correctness — not eligible for automatic merge; requires review and a maintainer merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
