### PR TITLE
fix(inference): Qwen3.5 greedy sampling first-wins tie-break (#280 contract)

### DIFF
--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -90,18 +90,25 @@ fn apply_repetition_penalty(adjusted: &mut [f32], previous_ids: &[u32], penalty:
     }
 }
 
+/// Greedy argmax with **first-wins** tie-break.
+///
+/// `Iterator::max_by` keeps the *last* element on `Ordering::Equal`, so tied
+/// maximum logits (e.g. `[0.0, 1.0, 1.0]`) returned the higher token-id — the
+/// opposite of the engine-wide greedy contract. `speculative::argmax`,
+/// `sampling::argmax_f32_scalar`, the Metal greedy path, and `torch.argmax` all
+/// return the *first* occurrence (#280). This mirrors them exactly: strict `>`
+/// from `NEG_INFINITY` skips `NaN` (a `NaN` comparison is always false) and
+/// returns 0 on empty / all-`NaN` input.
 fn greedy_token(adjusted: &[f32]) -> u32 {
-    adjusted
-        .iter()
-        .enumerate()
-        .max_by(|(_, a), (_, b)| match (a.is_nan(), b.is_nan()) {
-            (true, true) => std::cmp::Ordering::Equal,
-            (true, false) => std::cmp::Ordering::Less,
-            (false, true) => std::cmp::Ordering::Greater,
-            (false, false) => a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal),
-        })
-        .map(|(i, _)| i as u32)
-        .unwrap_or(0)
+    let mut best_idx = 0u32;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &v) in adjusted.iter().enumerate() {
+        if v > best_val {
+            best_val = v;
+            best_idx = i as u32;
+        }
+    }
+    best_idx
 }
 
 fn build_softmax_probs(adjusted: &[f32], indices: &[usize]) -> Option<Vec<(usize, f32)>> {
@@ -235,6 +242,29 @@ mod tests {
                 "degenerate temperature {bad} must fall back to argmax (token 1)"
             );
         }
+    }
+
+    #[test]
+    fn test_greedy_tie_break_is_first_wins() {
+        // Tied maximum logits must return the FIRST occurrence, matching
+        // speculative::argmax, sampling::argmax_f32_scalar, the Metal greedy
+        // path, and torch.argmax (#280). The prior `max_by` returned the LAST
+        // tied index (token 2 here) — a silent greedy-parity divergence on ties.
+        let logits = [0.0_f32, 1.0, 1.0];
+        assert_eq!(greedy_token(&logits), 1, "first-wins on tied max");
+
+        // Same contract through the public degenerate-temperature entry point.
+        let mut rng = 3u64;
+        let token = sample_token(&logits, &cfg(0.0, 0), &[], &mut rng);
+        assert_eq!(token, 1, "temperature=0 greedy must be first-wins on ties");
+
+        // NaN is skipped; the first finite max wins.
+        let with_nan = [f32::NAN, 2.0_f32, 2.0];
+        assert_eq!(
+            greedy_token(&with_nan),
+            1,
+            "NaN skipped, first finite max wins"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Problem

Qwen3.5 CPU greedy decode silently diverged from every sibling greedy path on tied logits.

The degenerate-temperature path (`temperature == 0`) returns `greedy_token(&adjusted)`, which used `Iterator::max_by`. On `Ordering::Equal`, `max_by` keeps the **last** element, so tied maximum logits such as `[0.0, 1.0, 1.0]` returned the higher token-id (token 2) instead of the first (token 1).

This breaks the engine-wide **first-wins** greedy contract (#280):
- `speculative::argmax` — documents + implements first-wins (strict `>`)
- `sampling::argmax_f32_scalar` — strict `>`
- Metal greedy path — first-wins
- `torch.argmax` — first occurrence

So the same prompt could pick a different token on a tie in Qwen3.5 CPU greedy mode than in speculative decode, the Metal path, or the reference.

## Fix

Rewrite `greedy_token` as an explicit first-wins loop: `(best_idx, best_val) = (0, -inf)`, update only on strict `v > best_val`. Strict `>` from `NEG_INFINITY` also skips `NaN` (NaN comparisons are always false), preserving the prior NaN-skip behavior. Returns 0 on empty / all-`NaN` input.

## Test

Mutation-sensitive regression test `test_greedy_tie_break_is_first_wins`:
- `greedy_token([0.0, 1.0, 1.0]) == 1` (first-wins on tie)
- `sample_token([0.0, 1.0, 1.0], temp=0) == 1` (same contract through the public entry)
- `greedy_token([NaN, 2.0, 2.0]) == 1` (NaN skipped, first finite max wins)

Verified the test **fails** when `greedy_token` is reverted to the `max_by` (last-wins) implementation, and passes with the fix.

## Why CI was blind

`e2e-parity.yml` is greedy-token-only on BF16, and real fp32 logit ties almost never occur in practice, so the existing parity gate could not catch this. Found via a static discovery review pass over `sampling.rs` / `speculative.rs` / `model/qwen35/sampling.rs` (0 P0, this was 1 of 3 P1s).

## Bench

No perf-sensitive path touched (the loop is equivalent work to `max_by`); CPU greedy tie-break only. `make bench-compare` not run — this is a correctness fix in a non-hot branch with no algorithmic change to throughput-relevant code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
