### PR TITLE
fix(inference): RoPE stride-half pairing in all 3 alt-forward decode variants (#392)

### DIFF
--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -1071,8 +1071,16 @@ mod tests {
             k_proj_f32[j * hidden + j] = 1.0;
         }
 
+        // W_q = identity for first q_dim rows (Q part), zeros for next q_dim rows (gate part).
+        // Row j selects input[j] exactly so scratch.q_buf is non-trivial and Q-loop mutation
+        // changes the assertion result.
+        let mut q_proj_f32 = vec![0.0f32; 2 * q_dim * hidden];
+        for j in 0..q_dim {
+            q_proj_f32[j * hidden + j] = 1.0;
+        }
+
         let weights = F16FullAttentionLayerWeights {
-            q_proj: to_f16(&vec![0.0f32; 2 * q_dim * hidden]),
+            q_proj: to_f16(&q_proj_f32),
             k_proj: to_f16(&k_proj_f32),
             v_proj: to_f16(&vec![0.0f32; kv_dim * hidden]),
             o_proj: to_f16(&vec![0.0f32; hidden * q_dim]),
@@ -1102,6 +1110,8 @@ mod tests {
         // Reference: reproduce the same matmul + QK-norm + stride-half RoPE.
         // Using the same production matmul and norm keeps f16 rounding error identical on
         // both sides, so the only source of divergence under mutation is the RoPE pairing.
+
+        // --- K reference ---
         let mut k_ref = vec![0.0f32; kv_dim];
         matmul_bt_f16(&input, &weights.k_proj, &mut k_ref, 1, hidden, kv_dim);
         qwen35_rms_norm(&mut k_ref, &weights.k_norm, head_dim, cfg.rms_norm_eps);
@@ -1118,15 +1128,51 @@ mod tests {
         }
 
         let k_cached = &kv_cache.k[0][..kv_dim];
-        let max_diff = k_cached
+        let max_k_diff = k_cached
             .iter()
             .zip(k_ref.iter())
             .map(|(a, b)| (a - b).abs())
             .fold(0.0f32, f32::max);
 
         assert!(
-            max_diff < 1e-4,
-            "cpu F16 stride-half RoPE diverges from reference: max_diff = {max_diff:.6}. \
+            max_k_diff < 1e-4,
+            "cpu F16 K-loop stride-half RoPE diverges from reference: max_k_diff = {max_k_diff:.6}. \
+             With interleaved pairing the diff is O(0.1-1). Bug: #392."
+        );
+
+        // --- Q reference (guards the Q loop mutation) ---
+        // The production scatter copies q_and_gate[0..q_dim] → scratch.q_buf[0..q_dim]
+        // for head 0 (num_q_heads=1).
+        let mut q_and_gate_ref = vec![0.0f32; 2 * q_dim];
+        matmul_bt_f16(
+            &input,
+            &weights.q_proj,
+            &mut q_and_gate_ref,
+            1,
+            hidden,
+            2 * q_dim,
+        );
+        let mut q_ref = q_and_gate_ref[..q_dim].to_vec();
+        qwen35_rms_norm(&mut q_ref, &weights.q_norm, head_dim, cfg.rms_norm_eps);
+
+        for i in 0..half {
+            let cos_val = rope.cos_at(base + i);
+            let sin_val = rope.sin_at(base + i);
+            let x0 = q_ref[i];
+            let x1 = q_ref[half + i];
+            q_ref[i] = x0 * cos_val - x1 * sin_val;
+            q_ref[half + i] = x0 * sin_val + x1 * cos_val;
+        }
+
+        let max_q_diff = scratch.q_buf[..q_dim]
+            .iter()
+            .zip(q_ref.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_q_diff < 1e-4,
+            "cpu F16 Q-loop stride-half RoPE diverges from reference: max_q_diff = {max_q_diff:.6}. \
              With interleaved pairing the diff is O(0.1-1). Bug: #392."
         );
     }

--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -300,7 +300,7 @@ fn full_attention_step_f16(
         );
     }
 
-    // Partial RoPE: only first rope_dim dimensions of each head (interleaved pairing)
+    // Partial RoPE: stride-half pairing (i, half+i) — matches apply_partial_rope / HF rotate_half
     let half = rope_dim / 2;
     for h in 0..num_q_heads {
         let start = h * head_dim;
@@ -308,10 +308,10 @@ fn full_attention_step_f16(
         for i in 0..half {
             let cos_val = rope.cos_at(base + i);
             let sin_val = rope.sin_at(base + i);
-            let x0 = scratch.q_buf[start + 2 * i];
-            let x1 = scratch.q_buf[start + 2 * i + 1];
-            scratch.q_buf[start + 2 * i] = x0 * cos_val - x1 * sin_val;
-            scratch.q_buf[start + 2 * i + 1] = x0 * sin_val + x1 * cos_val;
+            let x0 = scratch.q_buf[start + i];
+            let x1 = scratch.q_buf[start + half + i];
+            scratch.q_buf[start + i] = x0 * cos_val - x1 * sin_val;
+            scratch.q_buf[start + half + i] = x0 * sin_val + x1 * cos_val;
         }
     }
     for h in 0..num_kv_heads {
@@ -320,10 +320,10 @@ fn full_attention_step_f16(
         for i in 0..half {
             let cos_val = rope.cos_at(base + i);
             let sin_val = rope.sin_at(base + i);
-            let x0 = scratch.k_buf[start + 2 * i];
-            let x1 = scratch.k_buf[start + 2 * i + 1];
-            scratch.k_buf[start + 2 * i] = x0 * cos_val - x1 * sin_val;
-            scratch.k_buf[start + 2 * i + 1] = x0 * sin_val + x1 * cos_val;
+            let x0 = scratch.k_buf[start + i];
+            let x1 = scratch.k_buf[start + half + i];
+            scratch.k_buf[start + i] = x0 * cos_val - x1 * sin_val;
+            scratch.k_buf[start + half + i] = x0 * sin_val + x1 * cos_val;
         }
     }
 
@@ -995,6 +995,139 @@ mod tests {
         assert_eq!(
             cfg.num_full_attention_layers() + cfg.num_linear_attention_layers(),
             cfg.num_hidden_layers
+        );
+    }
+
+    /// Regression test for #392: cpu F16 RoPE must use stride-half pairing (i, half+i), not
+    /// interleaved (2i, 2i+1).
+    ///
+    /// Design: call `full_attention_step_f16` with an identity K-projection so k_buf equals
+    /// the input exactly (1.0 in f16 is exact, no rounding error on the diagonal).
+    /// Independently reproduce the same matmul + QK-norm + stride-half RoPE in the test body
+    /// and compare against the post-call KV-cache. The two paths agree to <1e-4 when the
+    /// production loops are correct; reverting either loop to 2*i interleaved produces
+    /// max_diff ~0.9 (observed during mutation verification).
+    #[test]
+    fn test_full_attn_step_f16_rope_stride_half_parity() {
+        use crate::model::qwen35_config::LayerType;
+        use crate::weights::f16_weights::f32_to_f16_slice;
+
+        let head_dim: usize = 32;
+        let num_q_heads: usize = 1;
+        let num_kv_heads: usize = 1;
+        let hidden: usize = 64;
+        let q_dim = num_q_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+        let position: usize = 3;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 2,
+            vocab_size: 128,
+            intermediate_size: 128,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: num_q_heads,
+            num_key_value_heads: num_kv_heads,
+            head_dim,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5, // rope_dim = 16, half = 8
+            rope_parameters: None,
+            linear_num_key_heads: 2,
+            linear_num_value_heads: Some(2),
+            linear_key_head_dim: 32,
+            linear_value_head_dim: 32,
+            linear_conv_kernel_dim: 4,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![LayerType::LinearAttention, LayerType::FullAttention],
+            layer_mask: vec![true; 2],
+            eos_token_id: 127,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        let rope_dim = cfg.rope_dim(); // = 16
+        let half = rope_dim / 2; // = 8
+        let rope = RopeTable::new(rope_dim, 512, cfg.rope_theta);
+
+        // Helper: convert f32 slice to packed f16 Vec<u16>.
+        let to_f16 = |src: &[f32]| -> Vec<u16> {
+            let mut dst = vec![0u16; src.len()];
+            f32_to_f16_slice(src, &mut dst);
+            dst
+        };
+
+        // W_k = identity [kv_dim, hidden]: row j selects input[j] exactly (1.0 in f16 is exact).
+        let mut k_proj_f32 = vec![0.0f32; kv_dim * hidden];
+        for j in 0..kv_dim {
+            k_proj_f32[j * hidden + j] = 1.0;
+        }
+
+        let weights = F16FullAttentionLayerWeights {
+            q_proj: to_f16(&vec![0.0f32; 2 * q_dim * hidden]),
+            k_proj: to_f16(&k_proj_f32),
+            v_proj: to_f16(&vec![0.0f32; kv_dim * hidden]),
+            o_proj: to_f16(&vec![0.0f32; hidden * q_dim]),
+            q_norm: vec![0.0f32; head_dim],
+            k_norm: vec![0.0f32; head_dim],
+        };
+
+        // Distinct non-trivial input values (positions 0..64 scaled to small floats).
+        let input: Vec<f32> = (0..hidden).map(|i| (i as f32 + 1.0) * 0.07).collect();
+
+        let mut scratch = ForwardScratch::new();
+        scratch.ensure_capacity(&cfg, 2);
+        scratch.attn_out[..hidden].copy_from_slice(&input);
+
+        let mut kv_cache = KvCache::new(1);
+        full_attention_step_f16(
+            &weights,
+            0,
+            position,
+            &mut kv_cache,
+            &mut scratch,
+            &cfg,
+            &rope,
+            hidden,
+        );
+
+        // Reference: reproduce the same matmul + QK-norm + stride-half RoPE.
+        // Using the same production matmul and norm keeps f16 rounding error identical on
+        // both sides, so the only source of divergence under mutation is the RoPE pairing.
+        let mut k_ref = vec![0.0f32; kv_dim];
+        matmul_bt_f16(&input, &weights.k_proj, &mut k_ref, 1, hidden, kv_dim);
+        qwen35_rms_norm(&mut k_ref, &weights.k_norm, head_dim, cfg.rms_norm_eps);
+
+        // Stride-half reference (correct pairing).
+        let base = position * half;
+        for i in 0..half {
+            let cos_val = rope.cos_at(base + i);
+            let sin_val = rope.sin_at(base + i);
+            let x0 = k_ref[i];
+            let x1 = k_ref[half + i];
+            k_ref[i] = x0 * cos_val - x1 * sin_val;
+            k_ref[half + i] = x0 * sin_val + x1 * cos_val;
+        }
+
+        let k_cached = &kv_cache.k[0][..kv_dim];
+        let max_diff = k_cached
+            .iter()
+            .zip(k_ref.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_diff < 1e-4,
+            "cpu F16 stride-half RoPE diverges from reference: max_diff = {max_diff:.6}. \
+             With interleaved pairing the diff is O(0.1-1). Bug: #392."
         );
     }
 

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -836,8 +836,15 @@ mod tests {
         let zero_q8 = |rows: usize, cols: usize| -> crate::weights::q8_weights::Q8Matrix {
             quantize_matrix(&vec![0.0f32; rows * cols], rows, cols)
         };
+        // W_q = identity for first q_dim rows (Q part), zeros for next q_dim rows (gate part).
+        // Row j selects input[j] exactly so scratch.q_buf is non-trivial and Q-loop mutation
+        // changes the assertion result.
+        let mut q_proj_f32 = vec![0.0f32; 2 * q_dim * hidden];
+        for j in 0..q_dim {
+            q_proj_f32[j * hidden + j] = 1.0;
+        }
         let weights = Q8FullAttentionLayerWeights {
-            q_proj: zero_q8(2 * q_dim, hidden),
+            q_proj: quantize_matrix(&q_proj_f32, 2 * q_dim, hidden),
             k_proj: quantize_matrix(&k_proj_f32, kv_dim, hidden),
             v_proj: zero_q8(kv_dim, hidden),
             o_proj: zero_q8(hidden, q_dim),
@@ -868,6 +875,8 @@ mod tests {
         // Using the same production matmul and norm functions keeps the reference
         // in step with quantization, so the only source of divergence under mutation
         // is the RoPE pairing itself.
+
+        // --- K reference ---
         let mut k_ref = vec![0.0f32; kv_dim];
         matmul_bt_q8(&input, &weights.k_proj, &mut k_ref, 1, hidden, kv_dim);
         qwen35_rms_norm(&mut k_ref, &weights.k_norm, head_dim, cfg.rms_norm_eps);
@@ -884,15 +893,51 @@ mod tests {
         }
 
         let k_cached = &kv_cache.k[0][..kv_dim];
-        let max_diff = k_cached
+        let max_k_diff = k_cached
             .iter()
             .zip(k_ref.iter())
             .map(|(a, b)| (a - b).abs())
             .fold(0.0f32, f32::max);
 
         assert!(
-            max_diff < 1e-4,
-            "cpu Q8 stride-half RoPE diverges from reference: max_diff = {max_diff:.6}. \
+            max_k_diff < 1e-4,
+            "cpu Q8 K-loop stride-half RoPE diverges from reference: max_k_diff = {max_k_diff:.6}. \
+             With interleaved pairing the diff is O(0.1-1). Bug: #392."
+        );
+
+        // --- Q reference (guards the Q loop mutation) ---
+        // The production scatter copies q_and_gate[0..q_dim] → scratch.q_buf[0..q_dim]
+        // for head 0 (num_q_heads=1).
+        let mut q_and_gate_ref = vec![0.0f32; 2 * q_dim];
+        matmul_bt_q8(
+            &input,
+            &weights.q_proj,
+            &mut q_and_gate_ref,
+            1,
+            hidden,
+            2 * q_dim,
+        );
+        let mut q_ref = q_and_gate_ref[..q_dim].to_vec();
+        qwen35_rms_norm(&mut q_ref, &weights.q_norm, head_dim, cfg.rms_norm_eps);
+
+        for i in 0..half {
+            let cos_val = rope.cos_at(base + i);
+            let sin_val = rope.sin_at(base + i);
+            let x0 = q_ref[i];
+            let x1 = q_ref[half + i];
+            q_ref[i] = x0 * cos_val - x1 * sin_val;
+            q_ref[half + i] = x0 * sin_val + x1 * cos_val;
+        }
+
+        let max_q_diff = scratch.q_buf[..q_dim]
+            .iter()
+            .zip(q_ref.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_q_diff < 1e-4,
+            "cpu Q8 Q-loop stride-half RoPE diverges from reference: max_q_diff = {max_q_diff:.6}. \
              With interleaved pairing the diff is O(0.1-1). Bug: #392."
         );
     }

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -320,7 +320,7 @@ fn full_attention_step_q8(
         );
     }
 
-    // Partial RoPE: only first rope_dim dimensions of each head (interleaved pairing)
+    // Partial RoPE: stride-half pairing (i, half+i) — matches apply_partial_rope / HF rotate_half
     let half = rope_dim / 2;
     for h in 0..num_q_heads {
         let start = h * head_dim;
@@ -328,10 +328,10 @@ fn full_attention_step_q8(
         for i in 0..half {
             let cos_val = rope.cos_at(base + i);
             let sin_val = rope.sin_at(base + i);
-            let x0 = scratch.q_buf[start + 2 * i];
-            let x1 = scratch.q_buf[start + 2 * i + 1];
-            scratch.q_buf[start + 2 * i] = x0 * cos_val - x1 * sin_val;
-            scratch.q_buf[start + 2 * i + 1] = x0 * sin_val + x1 * cos_val;
+            let x0 = scratch.q_buf[start + i];
+            let x1 = scratch.q_buf[start + half + i];
+            scratch.q_buf[start + i] = x0 * cos_val - x1 * sin_val;
+            scratch.q_buf[start + half + i] = x0 * sin_val + x1 * cos_val;
         }
     }
     for h in 0..num_kv_heads {
@@ -340,10 +340,10 @@ fn full_attention_step_q8(
         for i in 0..half {
             let cos_val = rope.cos_at(base + i);
             let sin_val = rope.sin_at(base + i);
-            let x0 = scratch.k_buf[start + 2 * i];
-            let x1 = scratch.k_buf[start + 2 * i + 1];
-            scratch.k_buf[start + 2 * i] = x0 * cos_val - x1 * sin_val;
-            scratch.k_buf[start + 2 * i + 1] = x0 * sin_val + x1 * cos_val;
+            let x0 = scratch.k_buf[start + i];
+            let x1 = scratch.k_buf[start + half + i];
+            scratch.k_buf[start + i] = x0 * cos_val - x1 * sin_val;
+            scratch.k_buf[start + half + i] = x0 * sin_val + x1 * cos_val;
         }
     }
 
@@ -766,6 +766,136 @@ pub fn generate_q8(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for #392: cpu Q8 RoPE must use stride-half pairing (i, half+i), not
+    /// interleaved (2i, 2i+1).
+    ///
+    /// Design: call `full_attention_step_q8` with an identity K-projection so k_buf equals
+    /// the quantized input (no quantization error in W_k).  Independently reproduce the same
+    /// matmul + QK-norm + stride-half RoPE in the test body and compare against the post-call
+    /// KV-cache.  The two RoPE paths agree to <1e-4 when the production loops are correct;
+    /// reverting either loop to 2*i interleaved produces max_diff ~0.9 (observed during
+    /// mutation verification).
+    #[test]
+    fn test_full_attn_step_q8_rope_stride_half_parity() {
+        use crate::model::qwen35_config::LayerType;
+        use crate::weights::q8_weights::quantize_matrix;
+
+        let head_dim: usize = 32;
+        let num_q_heads: usize = 1;
+        let num_kv_heads: usize = 1;
+        let hidden: usize = 64;
+        let q_dim = num_q_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+        let position: usize = 3;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 2,
+            vocab_size: 128,
+            intermediate_size: 128,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: num_q_heads,
+            num_key_value_heads: num_kv_heads,
+            head_dim,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5, // rope_dim = 16, half = 8
+            rope_parameters: None,
+            linear_num_key_heads: 2,
+            linear_num_value_heads: Some(2),
+            linear_key_head_dim: 32,
+            linear_value_head_dim: 32,
+            linear_conv_kernel_dim: 4,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![LayerType::LinearAttention, LayerType::FullAttention],
+            layer_mask: vec![true; 2],
+            eos_token_id: 127,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        let rope_dim = cfg.rope_dim(); // = 16
+        let half = rope_dim / 2; // = 8
+        let rope = RopeTable::new(rope_dim, 512, cfg.rope_theta);
+
+        // W_k = identity [kv_dim, hidden]: row j selects input[j] exactly (127/127 = 1.0).
+        let mut k_proj_f32 = vec![0.0f32; kv_dim * hidden];
+        for j in 0..kv_dim {
+            k_proj_f32[j * hidden + j] = 1.0;
+        }
+
+        let zero_q8 = |rows: usize, cols: usize| -> crate::weights::q8_weights::Q8Matrix {
+            quantize_matrix(&vec![0.0f32; rows * cols], rows, cols)
+        };
+        let weights = Q8FullAttentionLayerWeights {
+            q_proj: zero_q8(2 * q_dim, hidden),
+            k_proj: quantize_matrix(&k_proj_f32, kv_dim, hidden),
+            v_proj: zero_q8(kv_dim, hidden),
+            o_proj: zero_q8(hidden, q_dim),
+            q_norm: vec![0.0f32; head_dim],
+            k_norm: vec![0.0f32; head_dim],
+        };
+
+        // Distinct non-trivial input values (positions 0..64 scaled to small floats).
+        let input: Vec<f32> = (0..hidden).map(|i| (i as f32 + 1.0) * 0.07).collect();
+
+        let mut scratch = ForwardScratch::new();
+        scratch.ensure_capacity(&cfg, 2);
+        scratch.attn_out[..hidden].copy_from_slice(&input);
+
+        let mut kv_cache = KvCache::new(1);
+        full_attention_step_q8(
+            &weights,
+            0,
+            position,
+            &mut kv_cache,
+            &mut scratch,
+            &cfg,
+            &rope,
+            hidden,
+        );
+
+        // Reference: reproduce the same matmul + QK-norm + stride-half RoPE.
+        // Using the same production matmul and norm functions keeps the reference
+        // in step with quantization, so the only source of divergence under mutation
+        // is the RoPE pairing itself.
+        let mut k_ref = vec![0.0f32; kv_dim];
+        matmul_bt_q8(&input, &weights.k_proj, &mut k_ref, 1, hidden, kv_dim);
+        qwen35_rms_norm(&mut k_ref, &weights.k_norm, head_dim, cfg.rms_norm_eps);
+
+        // Stride-half reference (correct pairing).
+        let base = position * half;
+        for i in 0..half {
+            let cos_val = rope.cos_at(base + i);
+            let sin_val = rope.sin_at(base + i);
+            let x0 = k_ref[i];
+            let x1 = k_ref[half + i];
+            k_ref[i] = x0 * cos_val - x1 * sin_val;
+            k_ref[half + i] = x0 * sin_val + x1 * cos_val;
+        }
+
+        let k_cached = &kv_cache.k[0][..kv_dim];
+        let max_diff = k_cached
+            .iter()
+            .zip(k_ref.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_diff < 1e-4,
+            "cpu Q8 stride-half RoPE diverges from reference: max_diff = {max_diff:.6}. \
+             With interleaved pairing the diff is O(0.1-1). Bug: #392."
+        );
+    }
 
     #[test]
     #[allow(clippy::type_complexity)]

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -564,7 +564,7 @@ fn full_attention_step_q8_neon(
         );
     }
 
-    // Partial RoPE: interleaved pairing, first rope_dim dimensions
+    // Partial RoPE: stride-half pairing (i, half+i) — matches apply_partial_rope / HF rotate_half
     let half = rope_dim / 2;
     for h in 0..num_q_heads {
         let start = h * head_dim;
@@ -572,10 +572,10 @@ fn full_attention_step_q8_neon(
         for i in 0..half {
             let cos_val = rope.cos_at(base + i);
             let sin_val = rope.sin_at(base + i);
-            let x0 = scratch.q_buf[start + 2 * i];
-            let x1 = scratch.q_buf[start + 2 * i + 1];
-            scratch.q_buf[start + 2 * i] = x0 * cos_val - x1 * sin_val;
-            scratch.q_buf[start + 2 * i + 1] = x0 * sin_val + x1 * cos_val;
+            let x0 = scratch.q_buf[start + i];
+            let x1 = scratch.q_buf[start + half + i];
+            scratch.q_buf[start + i] = x0 * cos_val - x1 * sin_val;
+            scratch.q_buf[start + half + i] = x0 * sin_val + x1 * cos_val;
         }
     }
     for h in 0..num_kv_heads {
@@ -584,10 +584,10 @@ fn full_attention_step_q8_neon(
         for i in 0..half {
             let cos_val = rope.cos_at(base + i);
             let sin_val = rope.sin_at(base + i);
-            let x0 = scratch.k_buf[start + 2 * i];
-            let x1 = scratch.k_buf[start + 2 * i + 1];
-            scratch.k_buf[start + 2 * i] = x0 * cos_val - x1 * sin_val;
-            scratch.k_buf[start + 2 * i + 1] = x0 * sin_val + x1 * cos_val;
+            let x0 = scratch.k_buf[start + i];
+            let x1 = scratch.k_buf[start + half + i];
+            scratch.k_buf[start + i] = x0 * cos_val - x1 * sin_val;
+            scratch.k_buf[start + half + i] = x0 * sin_val + x1 * cos_val;
         }
     }
 
@@ -1707,6 +1707,143 @@ mod tests {
         }
     }
 
+    /// Regression test for #392: NEON Q8 RoPE must use stride-half pairing (i, half+i), not
+    /// interleaved (2i, 2i+1).
+    ///
+    /// Mirror of `test_full_attn_step_q8_rope_stride_half_parity` in cpu_q8.rs, using the
+    /// NEON packed weight format and `full_attention_step_q8_neon`.  The identity K-projection
+    /// propagates quantised input into k_buf with no W_k quantisation error.  A stride-half
+    /// reference reproduces the expected k_cache; max_diff < 1e-4 with the fix, ~0.9 with the
+    /// interleaved bug (verified by mutation testing).
+    #[test]
+    fn test_full_attn_step_q8_neon_rope_stride_half_parity() {
+        let head_dim: usize = 32;
+        let num_q_heads: usize = 1;
+        let num_kv_heads: usize = 1;
+        let hidden: usize = 64;
+        let q_dim = num_q_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+        let position: usize = 3;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 2,
+            vocab_size: 128,
+            intermediate_size: 128,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: num_q_heads,
+            num_key_value_heads: num_kv_heads,
+            head_dim,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5, // rope_dim = 16, half = 8
+            rope_parameters: None,
+            linear_num_key_heads: 2,
+            linear_num_value_heads: Some(2),
+            linear_key_head_dim: 32,
+            linear_value_head_dim: 32,
+            linear_conv_kernel_dim: 4,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![LayerType::LinearAttention, LayerType::FullAttention],
+            layer_mask: vec![true; 2],
+            eos_token_id: 127,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        let rope_dim = cfg.rope_dim(); // = 16
+        let half = rope_dim / 2; // = 8
+        let rope = RopeTable::new(rope_dim, 512, cfg.rope_theta);
+
+        // W_k packed identity [kv_dim=32, hidden=64]: row j = e_j → k_buf[j] = x[j].
+        // Q8_0 block packs scale=1/127 and one i8=127; dequant gives exact 1.0 × x[j].
+        let identity_packed = {
+            let mut mat = vec![0.0f32; kv_dim * hidden];
+            for j in 0..kv_dim {
+                mat[j * hidden + j] = 1.0;
+            }
+            pack_weights_q8(&mat, kv_dim, hidden)
+        };
+
+        let weights = Q8NeonFullAttnWeights {
+            q_proj_packed: zero_packed(2 * q_dim, hidden),
+            q_proj_rows: 2 * q_dim,
+            q_proj_cols: hidden,
+            k_proj_packed: identity_packed,
+            k_proj_rows: kv_dim,
+            k_proj_cols: hidden,
+            v_proj_packed: zero_packed(kv_dim, hidden),
+            v_proj_rows: kv_dim,
+            v_proj_cols: hidden,
+            o_proj_packed: zero_packed(hidden, q_dim),
+            o_proj_rows: hidden,
+            o_proj_cols: q_dim,
+            q_norm: vec![0.0f32; head_dim],
+            k_norm: vec![0.0f32; head_dim],
+        };
+
+        let input: Vec<f32> = (0..hidden).map(|i| (i as f32 + 1.0) * 0.07).collect();
+
+        let mut scratch = ForwardScratch::new();
+        scratch.ensure_capacity(&cfg, 2);
+        scratch.attn_out[..hidden].copy_from_slice(&input);
+
+        let mut kv_cache = KvCache::new(1);
+        full_attention_step_q8_neon(
+            &weights,
+            0,
+            position,
+            &mut kv_cache,
+            &mut scratch,
+            &cfg,
+            &rope,
+            hidden,
+        );
+
+        // Reference: same matmul + QK-norm + stride-half RoPE as the production path.
+        let mut k_ref = vec![0.0f32; kv_dim];
+        matmul_q8_neon_into(
+            &input,
+            &weights.k_proj_packed,
+            kv_dim,
+            hidden,
+            &mut k_ref,
+            &mut scratch.x_q_scratch,
+        );
+        qwen35_rms_norm(&mut k_ref, &weights.k_norm, head_dim, cfg.rms_norm_eps);
+
+        let base = position * half;
+        for i in 0..half {
+            let cos_val = rope.cos_at(base + i);
+            let sin_val = rope.sin_at(base + i);
+            let x0 = k_ref[i];
+            let x1 = k_ref[half + i];
+            k_ref[i] = x0 * cos_val - x1 * sin_val;
+            k_ref[half + i] = x0 * sin_val + x1 * cos_val;
+        }
+
+        let k_cached = &kv_cache.k[0][..kv_dim];
+        let max_diff = k_cached
+            .iter()
+            .zip(k_ref.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_diff < 1e-4,
+            "NEON Q8 stride-half RoPE diverges from reference: max_diff = {max_diff:.6}. \
+             With interleaved pairing the diff is O(0.1-1). Bug: #392."
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Nonzero parity test: captures current allocating NEON logits as baseline.
     // After GDN/full-attention buffer migration (i2), re-run and verify the
@@ -1936,22 +2073,22 @@ mod tests {
         // To recapture: add `eprintln!("{:?}", &logits_a[..16]);` before this block, run test,
         // then update the array below.
         let expected: [f32; 16] = [
-            -0.03680095,
-            0.04277617,
-            0.002856411,
-            0.0072362088,
-            -0.07445018,
-            0.001189895,
-            0.07319608,
-            0.027846893,
-            -0.02805086,
-            -0.10936779,
-            0.041943453,
-            0.08327203,
-            0.007971644,
-            -0.079894274,
-            0.01471648,
-            0.028457977,
+            -0.036519982,
+            0.04271806,
+            0.0027702842,
+            0.007089529,
+            -0.074217916,
+            0.001136966,
+            0.07316325,
+            0.027880985,
+            -0.027898913,
+            -0.10935478,
+            0.04180234,
+            0.08315472,
+            0.008195344,
+            -0.07999688,
+            0.014749594,
+            0.028362377,
         ];
         for (i, (&actual, &exp)) in logits_a.iter().zip(expected.iter()).enumerate() {
             assert!(

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -1773,8 +1773,19 @@ mod tests {
             pack_weights_q8(&mat, kv_dim, hidden)
         };
 
+        // W_q = identity for first q_dim rows (Q part), zeros for next q_dim rows (gate part).
+        // Row j selects input[j] exactly so scratch.q_buf is non-trivial and Q-loop mutation
+        // changes the assertion result.
+        let q_identity_packed = {
+            let mut mat = vec![0.0f32; 2 * q_dim * hidden];
+            for j in 0..q_dim {
+                mat[j * hidden + j] = 1.0;
+            }
+            pack_weights_q8(&mat, 2 * q_dim, hidden)
+        };
+
         let weights = Q8NeonFullAttnWeights {
-            q_proj_packed: zero_packed(2 * q_dim, hidden),
+            q_proj_packed: q_identity_packed,
             q_proj_rows: 2 * q_dim,
             q_proj_cols: hidden,
             k_proj_packed: identity_packed,
@@ -1809,6 +1820,8 @@ mod tests {
         );
 
         // Reference: same matmul + QK-norm + stride-half RoPE as the production path.
+
+        // --- K reference ---
         let mut k_ref = vec![0.0f32; kv_dim];
         matmul_q8_neon_into(
             &input,
@@ -1831,15 +1844,52 @@ mod tests {
         }
 
         let k_cached = &kv_cache.k[0][..kv_dim];
-        let max_diff = k_cached
+        let max_k_diff = k_cached
             .iter()
             .zip(k_ref.iter())
             .map(|(a, b)| (a - b).abs())
             .fold(0.0f32, f32::max);
 
         assert!(
-            max_diff < 1e-4,
-            "NEON Q8 stride-half RoPE diverges from reference: max_diff = {max_diff:.6}. \
+            max_k_diff < 1e-4,
+            "NEON Q8 K-loop stride-half RoPE diverges from reference: max_k_diff = {max_k_diff:.6}. \
+             With interleaved pairing the diff is O(0.1-1). Bug: #392."
+        );
+
+        // --- Q reference (guards the Q loop mutation) ---
+        // The production scatter copies q_and_gate[0..q_dim] → scratch.q_buf[0..q_dim]
+        // for head 0 (num_q_heads=1).
+        let q_proj_dim = 2 * q_dim;
+        let mut q_and_gate_ref = vec![0.0f32; q_proj_dim];
+        matmul_q8_neon_into(
+            &input,
+            &weights.q_proj_packed,
+            q_proj_dim,
+            hidden,
+            &mut q_and_gate_ref,
+            &mut scratch.x_q_scratch,
+        );
+        let mut q_ref = q_and_gate_ref[..q_dim].to_vec();
+        qwen35_rms_norm(&mut q_ref, &weights.q_norm, head_dim, cfg.rms_norm_eps);
+
+        for i in 0..half {
+            let cos_val = rope.cos_at(base + i);
+            let sin_val = rope.sin_at(base + i);
+            let x0 = q_ref[i];
+            let x1 = q_ref[half + i];
+            q_ref[i] = x0 * cos_val - x1 * sin_val;
+            q_ref[half + i] = x0 * sin_val + x1 * cos_val;
+        }
+
+        let max_q_diff = scratch.q_buf[..q_dim]
+            .iter()
+            .zip(q_ref.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_q_diff < 1e-4,
+            "NEON Q8 Q-loop stride-half RoPE diverges from reference: max_q_diff = {max_q_diff:.6}. \
              With interleaved pairing the diff is O(0.1-1). Bug: #392."
         );
     }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

The v0.2.3 Qwen3.5 RoPE pairing fix (interleaved `(2i, 2i+1)` → stride-half `(i, half+i)`, matching canonical `apply_partial_rope` / HF `rotate_half` / MLX `traditional=False`) was applied only to the shared helper. It survived as **interleaved** in all three hand-inlined alt-forward decode variants, which re-implement the decode step instead of calling the helper:

- `crates/inference/src/forward/cpu_q8.rs` — `full_attention_step_q8` (Q + K loops)
- `crates/inference/src/forward/neon_forward.rs` — `full_attention_step_q8_neon` (Q + K loops)
- `crates/inference/src/forward/cpu_f16.rs` — `full_attention_step_f16` (Q + K loops)

## Impact (P1, not user-facing P0)

`generate_q8` / `generate_q8_neon` / `generate_f16` are **public API but bench-only** (`examples/bench_suite.rs` + benches). The shipped CLI decode path (`Qwen35Model::generate` → `forward_step` → `apply_partial_rope`) and the prefill path (`batch_prefill.rs` → `apply_partial_rope`) were always correct. e2e-parity is blind to this (BF16 greedy via the canonical path only). Any quality/throughput number measured through the Q8/f16 bench forwards before this fix used wrong logits on full-attention layers.

## Fix

Each variant's Q and K RoPE loops changed to stride-half. One mutation-sensitive regression test per variant:

- identity K-projection so the KV-cache K equals an independent inline stride-half reference
- asserts `max_diff < 1e-4`
- mutation-verified: reverting either loop to interleaved → `max_diff ≈ 0.9237` (well above threshold)

## Verification

- 40 f16 / 18 Q8 lib tests pass; clippy clean (`-D warnings`)
- Each parity test fails when its fix is reverted (genuine mutation sensitivity)

Filed as #392. Held pending maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
