### PR TITLE
fix(inference): Q8 quantize returns UnsupportedModel on MoE instead of panic (#385)

### DIFF
--- a/crates/inference/examples/bench_suite.rs
+++ b/crates/inference/examples/bench_suite.rs
@@ -376,7 +376,7 @@ fn bench_llm_q8() -> Vec<Metric> {
     let rope = RopeTable::new(rope_dim, rope_max, cfg.rope_theta);
 
     let t_quant = Instant::now();
-    let q8_weights = quantize_from_model(&model);
+    let q8_weights = quantize_from_model(&model).expect("Q8 quantization failed");
     let quant_ms = t_quant.elapsed().as_millis() as f64;
 
     // Drop the f32 model to free memory

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -38,7 +38,12 @@ use crate::weights::q8_weights::{
 /// The embedding table and final norm remain f32 (embedding is tied to the LM head,
 /// norms are numerically sensitive). All large projection matrices are quantized
 /// per-row symmetric INT8.
-pub fn quantize_from_model(model: &Qwen35Model) -> Q8ModelWeights {
+///
+/// Returns `Err(InferenceError::UnsupportedModel)` for checkpoints that contain MoE
+/// layers, which Q8 quantization does not support.
+pub fn quantize_from_model(
+    model: &Qwen35Model,
+) -> Result<Q8ModelWeights, crate::error::InferenceError> {
     let cfg = model.config.clone();
     crate::weights::q8_weights::quantize_model_weights(&model.weights, &cfg)
 }

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -45,6 +45,9 @@ pub(crate) use weights::{
 };
 
 #[cfg(test)]
+pub(crate) use weights::{MoeLayerWeights, MoeRouter, RoutedExperts, SharedExpert};
+
+#[cfg(test)]
 pub use detokenize::bytes_to_unicode;
 #[cfg(test)]
 pub use generation::should_stop_token;

--- a/crates/inference/src/weights/q8_weights.rs
+++ b/crates/inference/src/weights/q8_weights.rs
@@ -19,6 +19,7 @@
 #![forbid(unsafe_code)]
 
 use crate::attention::gdn::GatedDeltaNetWeights;
+use crate::error::InferenceError;
 use crate::model::qwen35::{
     AttentionWeights, CommonLayerWeights, FeedForwardWeights, FullAttentionLayerWeights,
     ModelWeights,
@@ -283,7 +284,10 @@ pub struct Q8ModelWeights {
 /// The embedding table and final norm are cloned as-is (f32) since the embedding
 /// is tied to the LM head and norms are numerically sensitive. All large projection
 /// matrices are quantized per-row symmetric INT8.
-pub(crate) fn quantize_model_weights(weights: &ModelWeights, cfg: &Qwen35Config) -> Q8ModelWeights {
+pub(crate) fn quantize_model_weights(
+    weights: &ModelWeights,
+    cfg: &Qwen35Config,
+) -> Result<Q8ModelWeights, InferenceError> {
     let layers = weights
         .layers
         .iter()
@@ -296,16 +300,16 @@ pub(crate) fn quantize_model_weights(weights: &ModelWeights, cfg: &Qwen35Config)
                     Q8AttentionWeights::Full(quantize_full_attn_weights(full, cfg))
                 }
             };
-            let q8_common = quantize_common_weights(common);
-            (q8_attn, q8_common)
+            let q8_common = quantize_common_weights(common)?;
+            Ok((q8_attn, q8_common))
         })
-        .collect();
+        .collect::<Result<Vec<_>, InferenceError>>()?;
 
-    Q8ModelWeights {
+    Ok(Q8ModelWeights {
         embed_tokens: weights.embed_tokens.clone(),
         final_norm: weights.final_norm.clone(),
         layers,
-    }
+    })
 }
 
 /// **Unstable**: convert GatedDeltaNet weights to Q8; output type may change.
@@ -349,23 +353,27 @@ pub(crate) fn quantize_full_attn_weights(
 }
 
 /// Quantize the common per-layer MLP weights into their Q8 representation (dense only).
-pub(crate) fn quantize_common_weights(w: &CommonLayerWeights) -> Q8CommonLayerWeights {
+pub(crate) fn quantize_common_weights(
+    w: &CommonLayerWeights,
+) -> Result<Q8CommonLayerWeights, InferenceError> {
     let dense = match &w.ffn {
         FeedForwardWeights::Dense(d) => d,
         FeedForwardWeights::Moe(_) => {
-            panic!("Q8 quantization is dense-only; MoE layers are not supported");
+            return Err(InferenceError::UnsupportedModel(
+                "Q8 quantization is dense-only; MoE layers are not supported".to_string(),
+            ));
         }
     };
     let hidden = w.input_layernorm.len();
     let ((gate_rows, _), (up_rows, _), (down_rows, down_cols)) = infer_dense_shapes(dense, hidden);
 
-    Q8CommonLayerWeights {
+    Ok(Q8CommonLayerWeights {
         input_layernorm: w.input_layernorm.clone(),
         post_attention_layernorm: w.post_attention_layernorm.clone(),
         gate_proj: quantize_matrix(&dense.gate_proj, gate_rows, hidden),
         up_proj: quantize_matrix(&dense.up_proj, up_rows, hidden),
         down_proj: quantize_matrix(&dense.down_proj, down_rows, down_cols),
-    }
+    })
 }
 
 /// **Unstable**: compute Q8 vs f32 memory usage; return tuple shape may change.
@@ -744,5 +752,86 @@ mod tests {
         let last_row_scale = q.scales[rows - 1];
         assert!(first_row_scale > 0.0);
         assert!(last_row_scale > 0.0);
+    }
+
+    #[test]
+    fn test_quantize_common_weights_moe_returns_err_not_panic() {
+        use crate::error::InferenceError;
+        use crate::model::qwen35::{
+            CommonLayerWeights, FeedForwardWeights, MoeLayerWeights, MoeRouter, RoutedExperts,
+            SharedExpert,
+        };
+
+        let hidden = 4usize;
+        let num_experts = 2usize;
+        let num_experts_per_tok = 1usize;
+        let inter = 2usize;
+
+        let router = MoeRouter::new(
+            vec![0.0f32; num_experts * hidden],
+            num_experts,
+            num_experts_per_tok,
+            hidden,
+        )
+        .expect("valid router shape");
+
+        let experts = RoutedExperts::new(
+            vec![0.0f32; num_experts * 2 * inter * hidden],
+            vec![0.0f32; num_experts * hidden * inter],
+            num_experts,
+            hidden,
+            inter,
+        )
+        .expect("valid experts shape");
+
+        let shared_expert = SharedExpert::new(
+            vec![0.0f32; inter * hidden],
+            vec![0.0f32; inter * hidden],
+            vec![0.0f32; hidden * inter],
+            vec![0.0f32; hidden],
+            hidden,
+            inter,
+        )
+        .expect("valid shared expert shape");
+
+        let moe_common = CommonLayerWeights {
+            input_layernorm: vec![0.0f32; hidden],
+            post_attention_layernorm: vec![0.0f32; hidden],
+            ffn: FeedForwardWeights::Moe(MoeLayerWeights {
+                router,
+                experts,
+                shared_expert,
+            }),
+        };
+
+        let result = quantize_common_weights(&moe_common);
+        assert!(
+            matches!(result, Err(InferenceError::UnsupportedModel(_))),
+            "expected Err(UnsupportedModel), got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_quantize_common_weights_dense_returns_ok() {
+        use crate::model::qwen35::{CommonLayerWeights, DenseFfnWeights, FeedForwardWeights};
+
+        let hidden = 4usize;
+        let inter = 2usize;
+
+        let dense_common = CommonLayerWeights {
+            input_layernorm: vec![0.0f32; hidden],
+            post_attention_layernorm: vec![0.0f32; hidden],
+            ffn: FeedForwardWeights::Dense(DenseFfnWeights {
+                gate_proj: vec![0.0f32; inter * hidden],
+                up_proj: vec![0.0f32; inter * hidden],
+                down_proj: vec![0.0f32; hidden * inter],
+            }),
+        };
+
+        let result = quantize_common_weights(&dense_common);
+        assert!(
+            result.is_ok(),
+            "expected Ok for dense layer, got: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Closes #385. `cpu_q8::quantize_from_model` (a public, `**Unstable**`-marked library API) reached `quantize_common_weights`, which **panicked** on any `FeedForwardWeights::Moe(_)` layer — a no-panic-in-library-code rule violation that turned an unsupported model shape into process termination.

## Fix

Thread `Result<_, InferenceError>` up the (short) call chain:

- `quantize_common_weights` → `Result<Q8CommonLayerWeights, InferenceError>`; the MoE arm now returns `InferenceError::UnsupportedModel(...)` — the established error variant for unsupported model shapes — instead of panicking. (Q8 quantization is genuinely dense-only; unlike the f16 path, it has no MoE storage/forward support, so rejecting the whole layer is correct.)
- `quantize_model_weights` → `Result<Q8ModelWeights, InferenceError>`; the per-layer closure propagates with `?`, collected via `collect::<Result<Vec<_>, _>>()?`.
- `quantize_from_model` (public entry) → `Result<Q8ModelWeights, InferenceError>`; doc updated to document the `Err` case.
- Sole external caller `examples/bench_suite.rs` uses `.expect(...)` (permitted in example code).

Dense models (Qwen3.5-0.8b etc.) are unaffected — this was a latent crash for MoE checkpoints only, so it did not block the release; it removes the latent panic.

## Tests

- `test_quantize_common_weights_moe_returns_err_not_panic` — constructs a real `FeedForwardWeights::Moe` `CommonLayerWeights` (via the validated `MoeRouter`/`RoutedExperts`/`SharedExpert` constructors) and asserts `matches!(result, Err(InferenceError::UnsupportedModel(_)))`. Deliberately **not** `#[should_panic]`: it asserts `Err`, so reverting the fix back to `panic!` makes the test panic → FAIL. Mutation-verified this session: reverted → `FAILED` (panic at q8_weights.rs:362), restored → `ok`.
- `test_quantize_common_weights_dense_returns_ok` — guards the happy path.

## Verification

- `cargo build -p lattice-inference` + `--examples`: clean.
- `cargo check -p lattice-inference --features f16,metal-gpu --all-targets`: clean (no cfg-gated caller left on the old signature).
- `cargo test -p lattice-inference`: pass (incl. 2 new), 0 fail.
- `cargo clippy -p lattice-inference --all-targets -- -D warnings`: clean.
- No new `unwrap`/`expect`/`panic!` in library or binary code.

No `crates/inference/` runtime hot path touched (conversion-time only) — no bench-compare delta expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)