### PR TITLE
fix(inference): repetition penalty seeds full prompt history (#387)

### DIFF
--- a/crates/inference/src/batch/worker.rs
+++ b/crates/inference/src/batch/worker.rs
@@ -263,16 +263,17 @@ impl BatchWorker {
         }
 
         let id = self.seq_manager.next_id();
+        let mut sampler = Sampler::new(request.sampling.clone());
+        sampler.seed_history(&request.prompt_ids);
         let seq = Sequence::new(
             id,
             request.prompt_ids,
-            request.sampling.clone(),
+            request.sampling,
             request.lora_adapter,
             request.max_new_tokens,
         );
         let page_size = self.kv_pool_page_size();
         self.seq_manager.add(seq, page_size);
-        let sampler = Sampler::new(request.sampling);
         self.samplers.insert(id, sampler);
         self.scheduler.enqueue(id);
         Some(id)
@@ -648,6 +649,45 @@ mod tests {
             max_new_tokens: 10, // 60 + 10 = 70 > 64
         };
         assert!(worker.submit(req).is_none());
+    }
+
+    /// Regression guard for #387 batch path: `submit` must seed the sampler's
+    /// repetition-penalty history with the prompt tokens so the FIRST sampled
+    /// token already penalizes any token that appeared in the prompt.
+    ///
+    /// Mutation-sensitive: removing `sampler.seed_history(&request.prompt_ids)`
+    /// from `submit()` leaves `recent_tokens` empty at the first sample call.
+    /// The greedy fast-path shortcut then fires (`penalty > 1.0 &&
+    /// !recent_tokens.contains(&raw_best)` is true for empty history), returning
+    /// the un-penalized argmax (token 3) instead of the penalized winner (token 4).
+    #[test]
+    fn submit_seeds_prompt_history_for_repetition_penalty() {
+        let mut worker = test_worker();
+        worker.submit(InferenceRequest {
+            prompt_ids: vec![3], // token 3 is in the prompt; must be penalized
+            sampling: SamplingConfig {
+                temperature: 0.0, // greedy fast path
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 2.0,
+            },
+            lora_adapter: None,
+            max_new_tokens: 1,
+        });
+
+        // logits: token 3 raw-wins (9.0 > 5.5) but loses after penalty (4.5 < 5.5).
+        let mut logits = vec![0.0f32; 8];
+        logits[3] = 9.0; // prompt token — raw winner, must be penalized
+        logits[4] = 5.5; // penalty-adjusted winner
+
+        let out = worker.step(|_input, _pool| logits.clone());
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].token_id, 4,
+            "prompt token 3 must be penalized (9.0/2.0=4.5 < 5.5) so token 4 wins; \
+             without seed_history in submit(), token 3 is not penalized and wins raw \
+             (mutation: remove seed_history call from submit())"
+        );
     }
 
     // --- BatchWorker step: sequence lifecycle ---

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -324,8 +324,10 @@ pub fn generate(
     // Decode calls use seq_len=1, which is always within this capacity.
     scratch.ensure_capacity(cfg, prompt_len.max(1), effective_cap);
 
-    // 3. Initialize sampler
+    // 3. Initialize sampler and seed prompt history so prompt tokens are included
+    // in repetition-penalty scoring from the very first generated token.
     let mut sampler = Sampler::new(config.sampling.clone());
+    sampler.seed_history(&prompt_ids[..prompt_len]);
 
     // 4. Initialise grammar state if grammar-constrained decoding is requested.
     let mut grammar_state = config.grammar.as_ref().map(|g| g.initial_state());

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -1650,13 +1650,17 @@ mod tests {
             repetition_penalty: 2.0,
         };
         let mut sampler = Sampler::new(config).with_seed(1);
-        // Build a 65-token history: token 1 is the oldest entry (position 0).
-        // Filler tokens use ids >= 2 so they do not compete with tokens 0 or 1.
-        let mut history: Vec<u32> = vec![1];
-        history.extend(2u32..66); // 64 filler tokens → total history length = 65
-        sampler.seed_history(&history);
+        // Build a 65-token history THROUGH push_token, the path the removed 64-cap
+        // actually lived on. token 1 is the oldest entry (pushed first). Filler tokens
+        // use ids >= 2 so they do not compete with tokens 0 or 1.
+        sampler.push_token(1);
+        for t in 2u32..66 {
+            sampler.push_token(t); // 64 filler tokens → total history length = 65
+        }
         // Without cap: token 1 penalty applies → 10.0/2.0 = 5.0 < 6.0 → token 0 wins.
-        // With old 64-cap: token 1 was evicted from the window → 10.0 wins, token 1 wins.
+        // With old 64-cap restored in push_token: token 1 was evicted from the window →
+        // raw_best (token 1) is no longer in history so the greedy shortcut returns it
+        // un-penalized → token 1 wins.
         let token = sampler.sample(&[6.0, 10.0]);
         assert_eq!(
             token, 0,

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -262,10 +262,11 @@ impl Rng {
 pub struct Sampler {
     config: SamplingConfig,
     rng: Rng,
-    /// Recently generated token IDs (for repetition penalty).
+    /// Token IDs seen since the last `reset`: prompt tokens (from `seed_history`)
+    /// followed by all generated tokens.  Full history is retained for repetition penalty.
     recent_tokens: Vec<u32>,
-    /// Max tokens to track for repetition penalty.
-    max_recent: usize,
+    /// Reused dedup set for penalty application; cleared at the start of each use.
+    penalty_seen: std::collections::HashSet<u32>,
     /// Reused candidate buffer; avoids 1.9 MB alloc per call at vocab=248,320.
     candidate_scratch: Vec<Candidate>,
     /// Reused probability buffer for top-p softmax.
@@ -289,7 +290,7 @@ impl Sampler {
             config,
             rng: Rng::new(seed),
             recent_tokens: Vec::new(),
-            max_recent: 64,
+            penalty_seen: std::collections::HashSet::new(),
             candidate_scratch: Vec::new(),
             prob_scratch: Vec::new(),
             logit_scratch: Vec::new(),
@@ -300,6 +301,15 @@ impl Sampler {
     pub fn with_seed(mut self, seed: u64) -> Self {
         self.rng = Rng::new(seed);
         self
+    }
+
+    /// **Unstable**: seed the repetition-penalty history with prompt tokens.
+    ///
+    /// Call once after construction and before the first `sample` call so
+    /// prompt tokens are penalized from the very first generated token,
+    /// matching the Qwen3.5 full-history contract.
+    pub fn seed_history(&mut self, prompt_ids: &[u32]) {
+        self.recent_tokens.extend_from_slice(prompt_ids);
     }
 
     /// **Unstable**: sample a token ID; sampling strategy details may change.
@@ -341,18 +351,8 @@ impl Sampler {
             // raw argmax would change once the penalty is applied — clone + re-scan.
             self.logit_scratch.clear();
             self.logit_scratch.extend_from_slice(logits);
-            for (pos, &tok) in self.recent_tokens.iter().enumerate() {
-                // Penalize each id once (recent_tokens may repeat). recent_tokens is
-                // capped at max_recent (64), so this O(n²) scan stays well under the
-                // full-vocab argmax cost and avoids a per-call allocation.
-                if self.recent_tokens[..pos].contains(&tok) {
-                    continue;
-                }
-                let idx = tok as usize;
-                if idx < self.logit_scratch.len() {
-                    self.logit_scratch[idx] = penalized_logit(self.logit_scratch[idx], penalty);
-                }
-            }
+            // Penalize each unique id exactly once (HF gather-once semantics).
+            self.apply_penalty_to_logit_scratch(penalty);
             let token = argmax_f32(&self.logit_scratch);
             self.push_token(token);
             return token;
@@ -361,21 +361,11 @@ impl Sampler {
         // Non-greedy path: clone logits for in-place penalty + fused top-k.
         self.logit_scratch.clear();
         self.logit_scratch.extend_from_slice(logits);
-        let adj = &mut self.logit_scratch;
 
         if self.config.repetition_penalty != 1.0 {
-            for (pos, &tok) in self.recent_tokens.iter().enumerate() {
-                // Penalize each id once (recent_tokens may repeat); applying it per
-                // occurrence compounds to penalty^N. Capped at max_recent (64), so the
-                // O(n²) dedup scan is negligible against the fused top-k over the vocab.
-                if self.recent_tokens[..pos].contains(&tok) {
-                    continue;
-                }
-                let idx = tok as usize;
-                if idx < adj.len() {
-                    adj[idx] = penalized_logit(adj[idx], self.config.repetition_penalty);
-                }
-            }
+            let penalty = self.config.repetition_penalty;
+            // Penalize each unique id exactly once (HF gather-once semantics).
+            self.apply_penalty_to_logit_scratch(penalty);
         }
 
         let inv_temp = if self.config.temperature != 1.0 {
@@ -387,7 +377,7 @@ impl Sampler {
         // Streaming min-heap top-k with fused temperature scaling.
         // ~95% of vocab elements are skipped by the NEON threshold gate.
         select_top_k(
-            adj,
+            &self.logit_scratch,
             self.config.top_k,
             inv_temp,
             &mut self.candidate_scratch,
@@ -404,8 +394,18 @@ impl Sampler {
 
     fn push_token(&mut self, token: u32) {
         self.recent_tokens.push(token);
-        if self.recent_tokens.len() > self.max_recent {
-            self.recent_tokens.remove(0);
+    }
+
+    /// Apply `penalty` in-place to `logit_scratch` for every unique token id in
+    /// `recent_tokens`, penalizing each id exactly once (HF gather-once semantics).
+    /// `penalty_seen` is cleared first so capacity is retained across calls.
+    fn apply_penalty_to_logit_scratch(&mut self, penalty: f32) {
+        self.penalty_seen.clear();
+        for &tok in &self.recent_tokens {
+            let idx = tok as usize;
+            if idx < self.logit_scratch.len() && self.penalty_seen.insert(tok) {
+                self.logit_scratch[idx] = penalized_logit(self.logit_scratch[idx], penalty);
+            }
         }
     }
 
@@ -1605,5 +1605,91 @@ mod tests {
                 "uniform_f32_from_u64({x:#018x}) = {f} is not in [0, 1)"
             );
         }
+    }
+
+    // ── #387 repetition-penalty history contract tests ───────────────────────
+
+    /// First-token prompt penalty: seeded prompt tokens must be penalized on the
+    /// very first `sample` call.
+    ///
+    /// Mutation-sensitive: reverting `seed_history` (or not calling it in
+    /// `generate.rs`) leaves `recent_tokens` empty, so token 1 is NOT penalized
+    /// and wins with logit 10.0, failing this assertion.
+    #[test]
+    fn test_seed_history_penalizes_prompt_token_on_first_sample() {
+        let config = SamplingConfig {
+            temperature: 0.0, // greedy
+            top_k: 1,
+            top_p: 1.0,
+            repetition_penalty: 2.0,
+        };
+        let mut sampler = Sampler::new(config).with_seed(1);
+        // Seed token 1 as a prompt token.
+        sampler.seed_history(&[1u32]);
+        // logits: token 1 = 10.0 wins raw, but 10.0/2.0 = 5.0 < token 0's 6.0 after penalty.
+        let token = sampler.sample(&[6.0, 10.0]);
+        assert_eq!(
+            token, 0,
+            "token 1 was seeded in history; penalty 2.0 reduces its adjusted logit \
+             below token 0; without seed_history, token 1 wins (mutation: omit seed_history)"
+        );
+    }
+
+    /// Beyond-64-token history: a token at position 0 in a 65-entry history must
+    /// still be penalized after the old 64-entry cap is removed.
+    ///
+    /// Mutation-sensitive: re-introducing the `max_recent` truncation evicts token 1
+    /// from the window, leaving it unpenalized, so token 1 wins with logit 10.0
+    /// instead of token 0 with logit 6.0.
+    #[test]
+    fn test_uncapped_history_penalizes_tokens_beyond_64() {
+        let config = SamplingConfig {
+            temperature: 0.0, // greedy
+            top_k: 1,
+            top_p: 1.0,
+            repetition_penalty: 2.0,
+        };
+        let mut sampler = Sampler::new(config).with_seed(1);
+        // Build a 65-token history: token 1 is the oldest entry (position 0).
+        // Filler tokens use ids >= 2 so they do not compete with tokens 0 or 1.
+        let mut history: Vec<u32> = vec![1];
+        history.extend(2u32..66); // 64 filler tokens → total history length = 65
+        sampler.seed_history(&history);
+        // Without cap: token 1 penalty applies → 10.0/2.0 = 5.0 < 6.0 → token 0 wins.
+        // With old 64-cap: token 1 was evicted from the window → 10.0 wins, token 1 wins.
+        let token = sampler.sample(&[6.0, 10.0]);
+        assert_eq!(
+            token, 0,
+            "token 1 at position 0 in a 65-entry history must still be penalized; \
+             the old 64-cap silently dropped it (mutation: restore max_recent truncation)"
+        );
+    }
+
+    /// Penalize-once / no compounding: a token repeated many times in history is
+    /// penalized exactly once, not penalty^N times.
+    ///
+    /// Mutation-sensitive: reverting the HashSet dedup to per-occurrence penalty
+    /// compounds to penalty^4 = 16.0, reducing the adjusted logit from 5.0 to 0.625,
+    /// so token 0 wins instead of token 1.
+    #[test]
+    fn test_penalty_applied_exactly_once_for_repeated_history_token() {
+        let config = SamplingConfig {
+            temperature: 0.0, // greedy
+            top_k: 1,
+            top_p: 1.0,
+            repetition_penalty: 2.0,
+        };
+        let mut sampler = Sampler::new(config).with_seed(1);
+        // Token 1 repeated 4 times in history.
+        sampler.seed_history(&[1, 1, 1, 1]);
+        // Once penalized: 10.0/2.0 = 5.0 > 4.9 → token 1 wins (correct).
+        // Per-occurrence (penalty^4): 10.0/16.0 = 0.625 < 4.9 → token 0 wins (wrong).
+        let token = sampler.sample(&[4.9, 10.0]);
+        assert_eq!(
+            token, 1,
+            "token 1 repeated 4× must be penalized once (5.0 > 4.9, token 1 wins); \
+             per-occurrence compounding yields 0.625 and wrongly selects token 0 \
+             (mutation: replace HashSet dedup with per-occurrence penalty)"
+        );
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Closes #387. The repetition penalty in the generic `Sampler` only saw tokens it had
itself emitted via `push_token`, and only the most recent 64 of them (a hard cap). The
prompt was never penalized, and on sequences longer than 64 decoded tokens the early
history silently fell out of the penalty window. This diverges from the in-repo reference
sampler (`model/qwen35/sampling.rs::apply_repetition_penalty`) and from HF, both of which
penalize over the **full** token history (prompt + generated), deduped once.

### What changed

- **`sampling.rs`**: added `seed_history(&mut self, prompt_ids: &[u32])` so the prompt is
  in scope for the penalty before the first sample. Replaced the 64-token truncation with
  full uncapped history. Penalty application now dedups via a reused `HashSet<u32>`
  (`penalty_seen`) so each distinct token is penalized exactly once (HF gather-once
  semantics — per-occurrence would compound to `penalty^N`). O(n) over history, applied in
  both the greedy and non-greedy paths via a shared helper.
- **`generate.rs`** and **`batch/worker.rs`**: seed the sampler with the prompt ids before
  the first sample, on both generate paths, for cross-path consistency. In `worker.rs` the
  seed is taken before `prompt_ids` is moved into the `Sequence`.

### Correctness gating (why this is safe for the decode hot path)

- The penalty loop only runs when `repetition_penalty != 1.0`. The default decode path with
  no penalty is structurally untouched.
- `seed_history` is a one-time `Vec::extend` at the prefill stage, outside the decode loop.

### Tests (mutation-verified)

- `test_seed_history_penalizes_prompt_token_on_first_sample`
- `test_uncapped_history_penalizes_tokens_beyond_64`
- `test_penalty_applied_exactly_once_for_repeated_history_token`
- `submit_seeds_prompt_history_for_repetition_penalty` (batch worker path; reverting the
  `seed_history` call makes the greedy shortcut emit the un-penalized token → test fails)

## bench-compare

`crates/inference/` is touched, so bench-compare is required. The `sampling_pipeline`
group does **not differentially exercise this change**: no bench in the suite calls
`push_token` or `seed_history`, so `recent_tokens` stays empty across all iterations, the
penalty loop iterates zero tokens, and the HashSet-dedup-vs-64-cap difference cannot
manifest. Clean idle-machine HEAD numbers (full, not `--quick`):

| group | HEAD |
|---|---|
| `greedy_k1` | 73.9 µs |
| `default_k50_topp0.9` | 66.6 µs |
| `wide_k256_topp0.9` | 166.7 µs |
| `repeated_scratch_reuse/k50_topp0.9` | 73.3 µs |

These are in line with main. The penalty path's full-history cost (the only behavioral
change) is the intended cost of matching the reference contract and is bounded O(unique
tokens) per call behind the `repetition_penalty != 1.0` gate. No measurable regression on
any benched path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
