### PR TITLE
harden(inference): remove provably-dead stack snapshot in grammar PDA advance_byte (#322 F2)

### DIFF
--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -184,17 +184,15 @@ pub enum StepResult {
 /// If no alternative can accept `b`, try other alternatives for the current
 /// frame's rule via backtracking.
 pub fn advance_byte(state: &mut GrammarState, grammar: &CompiledGrammar, b: u8) -> StepResult {
-    // We snapshot the stack on entry; if all alternatives fail, restore it.
-    let snapshot = state.stack.clone();
-
+    // `try_advance_byte` operates on a clone of `state.stack` and only writes it
+    // back on success, so `state.stack` is already left untouched on rejection.
+    // No outer snapshot/restore is needed (would be one redundant clone per byte).
     if try_advance_byte(state, grammar, b) {
         state.partial_token_bytes.push(b);
         // Check for completion after consuming the byte.
         state.complete = is_accepting(state, grammar);
         StepResult::Accepted
     } else {
-        // Restore snapshot — byte was rejected.
-        state.stack = snapshot;
         StepResult::Rejected
     }
 }
@@ -679,6 +677,46 @@ mod tests {
         let mut state = GrammarState::initial();
         advance_byte(&mut state, &g, b'a');
         assert_eq!(advance_byte(&mut state, &g, b'x'), StepResult::Rejected);
+    }
+
+    #[test]
+    fn rejected_byte_leaves_state_intact_and_resumes() {
+        // A rejected byte must not corrupt the matcher: the consumed prefix
+        // stays committed and the correct continuation still completes. This
+        // locks the rollback-on-reject contract that `advance_byte` relies on
+        // (`try_advance_byte` clones the stack and only commits it on success,
+        // so no outer snapshot is needed).
+        //
+        // The grammar must be *nested* so the rejecting byte forces
+        // `try_advance_stack` to truncate a child frame before it fails:
+        //   root  ::= "a" child
+        //   child ::= "bc"
+        // Feeding `a`,`b` descends into `child` (frame pushed, one byte
+        // consumed). The wrong byte at child's second position truncates the
+        // child frame, then exhausts root's alternatives and returns false,
+        // mutating the working stack en route. Only the inner clone keeps
+        // `state.stack` intact so the correct `c` can still complete. A flat
+        // grammar (reject at the root frame returns false without mutating)
+        // never exercises this and would make the test vacuous.
+        let mut b = GrammarBuilder::new();
+        let root_id = b.reserve("root");
+        let child_id = b.reserve("child");
+        b.set_alts(
+            child_id,
+            vec![vec![Symbol::Terminal(b'b'), Symbol::Terminal(b'c')]],
+        );
+        b.set_alts(
+            root_id,
+            vec![vec![Symbol::Terminal(b'a'), Symbol::NonTerminal(child_id)]],
+        );
+        let g = b.build();
+
+        let mut state = GrammarState::initial();
+        assert_eq!(advance_byte(&mut state, &g, b'a'), StepResult::Accepted);
+        assert_eq!(advance_byte(&mut state, &g, b'b'), StepResult::Accepted);
+        assert_eq!(advance_byte(&mut state, &g, b'x'), StepResult::Rejected);
+        assert_eq!(advance_byte(&mut state, &g, b'c'), StepResult::Accepted);
+        assert!(state.complete);
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Closes **F2** of #322. `advance_byte` cloned `state.stack` into a snapshot on entry and restored it on the reject path. This is a **provable no-op**: `try_advance_byte` already operates on its own clone of `state.stack` (`let mut stack = state.stack.clone()`) and writes the result back (`state.stack = stack`) **only on success**, returning `false` without ever touching `state.stack` on rejection. `partial_token_bytes` / `complete` are likewise only mutated by `advance_byte` on the accept path. So the outer snapshot/restore could never observe a changed `state.stack` — it was one redundant `Vec<StackFrame>` clone per decoded byte on the constrained-decode hot path.

Behavior is **unchanged**. This is a dead-code removal, not a perf claim.

## What changed

- `advance_byte`: drop the entry `state.stack.clone()` and the reject-path `state.stack = snapshot` restore (3 lines), with a comment documenting why the inner clone makes them redundant.
- New test `rejected_byte_leaves_state_intact_and_resumes` locking the rollback-on-reject contract the removal now relies on solely in `try_advance_byte`.

## Test is mutation-verified (non-vacuous)

The guard uses a **nested** grammar (`root ::= "a" child`, `child ::= "bc"`) so the rejecting byte forces `try_advance_stack` to **truncate a child frame** before it fails — the path that actually mutates the working stack. Sequence: accept `a`, accept `b` (descends into `child`), reject `x` (truncates `child`, exhausts `root`, returns false), then accept `c` and complete.

- On correct code: **passes** (inner clone keeps `state.stack` intact, `c` completes).
- Mutating `try_advance_byte` to commit in place (`try_advance_stack(&mut state.stack, …)`): **fails** — `c` is wrongly `Rejected` (`left: Rejected, right: Accepted`), because the truncated child frame is lost.
- A *flat* grammar (reject at the root frame returns false without mutating) would make the test vacuous — verified and rejected during authoring.

## Validation

- `cargo test -p lattice-inference --lib grammar`: **74 passed** (73 + new guard).
- `cargo clippy -p lattice-inference --lib --tests -- -D warnings`: clean.

## bench-compare disposition

Verified that **zero benches** in `crates/inference/benches/` reference the grammar advance path (`advance_byte` / `grammar::pda` / `GrammarState` / `mask_logits`), so `make bench-compare`'s groups (attention / kv-cache / tokenizer / decode) cannot differentially exercise this change — any delta they report would be unrelated noise. The change removes a per-byte `Vec` allocation on a non-benched path and is structurally incapable of regressing any benched group (it deletes work, changes no control flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)