### PR TITLE
fix(inference): clamp apply_temperature reciprocal to prevent tiny-temp overflow (#322 F3)

### DIFF
--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -107,17 +107,28 @@ impl CandidateSet {
     /// non-positive, or non-finite (NaN/±inf) — none of those carry a valid
     /// scaling, and `1.0 / NaN` would poison every logit with NaN.
     ///
-    /// A finite-but-tiny temperature has a reciprocal that overflows `f32`. Left
-    /// unclamped it would collapse every logit to `+inf`, destroying their order, and
-    /// downstream sampling would then return token 0 instead of the argmax — even though
-    /// the `t -> 0+` limit must stay greedy. The multiplier is clamped to the same bound
-    /// `temperature_degenerate` uses, so for any logit within `MAX_PLAUSIBLE_ABS_LOGIT` the
-    /// scaled value stays finite and the argmax is preserved (softmax -> one-hot on argmax).
+    /// A finite-but-tiny temperature has a reciprocal that overflows `f32`, so it carries
+    /// no valid finite scaling: the `t -> 0+` limit is hard-greedy. Scaling such a
+    /// temperature (even with a clamped multiplier) leaves close logits near 50/50, so
+    /// `sample_top_p` could still return a non-argmax token. Instead collapse the set to a
+    /// one-hot on the argmax — the same hard-argmax route the main `Sampler` takes for a
+    /// degenerate temperature (see `temperature_degenerate`).
     pub fn apply_temperature(&mut self, temperature: f32) {
         if !temperature.is_finite() || temperature <= 0.0 || temperature == 1.0 {
             return;
         }
-        let inv = (1.0 / temperature).min(f32::MAX / MAX_PLAUSIBLE_ABS_LOGIT);
+        if temperature_degenerate(temperature) {
+            let best = self.argmax();
+            for c in &mut self.candidates {
+                c.logit = if c.token_id == best {
+                    0.0
+                } else {
+                    f32::NEG_INFINITY
+                };
+            }
+            return;
+        }
+        let inv = 1.0 / temperature;
         for c in &mut self.candidates {
             c.logit *= inv;
         }
@@ -932,6 +943,22 @@ mod tests {
             cs.sample_top_p(1.0, 0.0),
             1,
             "tiny positive temperature must resolve to the argmax (greedy), not token 0"
+        );
+    }
+
+    #[test]
+    fn apply_temperature_tiny_temp_is_hard_greedy_for_close_logits() {
+        // Even an arbitrarily small logit gap must resolve to hard argmax under a
+        // degenerate temperature (the t -> 0+ limit), matching the main Sampler's
+        // `temperature_degenerate` route. A finite multiplier (clamped or not) would
+        // leave these two near 50/50, so `sample_top_p(1.0, 0.75)` could draw token 0;
+        // the one-hot collapse makes the argmax (token 1) the only reachable draw.
+        let mut cs = CandidateSet::from_full_logits(&[0.0, f32::from_bits(1)]);
+        cs.apply_temperature(1e-45);
+        assert_eq!(
+            cs.sample_top_p(1.0, 0.75),
+            1,
+            "degenerate temperature must be hard-greedy even for adjacent logits"
         );
     }
 

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -933,9 +933,10 @@ mod tests {
     #[test]
     fn apply_temperature_tiny_positive_temp_stays_greedy() {
         // A finite-but-tiny temperature has a reciprocal that overflows f32. The
-        // t -> 0+ limit must stay greedy (argmax). Without the clamp, `1.0 / 1e-45 ==
-        // +inf` collapses both logits to +inf; the sort then tie-breaks on ascending
-        // token_id and `sample_top_p` returns token 0 instead of the argmax (token 1).
+        // t -> 0+ limit must stay greedy (argmax). Without the degenerate-branch
+        // collapse, `1.0 / 1e-45 == +inf` scales both logits to +inf; the sort then
+        // tie-breaks on ascending token_id and `sample_top_p` returns token 0 instead
+        // of the argmax (token 1).
         let mut cs = CandidateSet::from_full_logits(&[10.0, 11.0]);
         cs.apply_temperature(1e-45);
         // top_p = 1.0 (no nucleus truncation) + r = 0.0 => pure argmax selection.

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -106,11 +106,18 @@ impl CandidateSet {
     /// Scale logits by `1 / temperature`.  No-op when temperature is 1.0,
     /// non-positive, or non-finite (NaN/±inf) — none of those carry a valid
     /// scaling, and `1.0 / NaN` would poison every logit with NaN.
+    ///
+    /// A finite-but-tiny temperature has a reciprocal that overflows `f32`. Left
+    /// unclamped it would collapse every logit to `+inf`, destroying their order, and
+    /// downstream sampling would then return token 0 instead of the argmax — even though
+    /// the `t -> 0+` limit must stay greedy. The multiplier is clamped to the same bound
+    /// `temperature_degenerate` uses, so for any logit within `MAX_PLAUSIBLE_ABS_LOGIT` the
+    /// scaled value stays finite and the argmax is preserved (softmax -> one-hot on argmax).
     pub fn apply_temperature(&mut self, temperature: f32) {
         if !temperature.is_finite() || temperature <= 0.0 || temperature == 1.0 {
             return;
         }
-        let inv = 1.0 / temperature;
+        let inv = (1.0 / temperature).min(f32::MAX / MAX_PLAUSIBLE_ABS_LOGIT);
         for c in &mut self.candidates {
             c.logit *= inv;
         }
@@ -910,6 +917,22 @@ mod tests {
             );
             assert_eq!(cs.argmax(), 1);
         }
+    }
+
+    #[test]
+    fn apply_temperature_tiny_positive_temp_stays_greedy() {
+        // A finite-but-tiny temperature has a reciprocal that overflows f32. The
+        // t -> 0+ limit must stay greedy (argmax). Without the clamp, `1.0 / 1e-45 ==
+        // +inf` collapses both logits to +inf; the sort then tie-breaks on ascending
+        // token_id and `sample_top_p` returns token 0 instead of the argmax (token 1).
+        let mut cs = CandidateSet::from_full_logits(&[10.0, 11.0]);
+        cs.apply_temperature(1e-45);
+        // top_p = 1.0 (no nucleus truncation) + r = 0.0 => pure argmax selection.
+        assert_eq!(
+            cs.sample_top_p(1.0, 0.0),
+            1,
+            "tiny positive temperature must resolve to the argmax (greedy), not token 0"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

`CandidateSet::apply_temperature` computed `1.0 / temperature` directly. A finite-but-tiny positive temperature (e.g. `1e-45`) produced an `+inf` multiplier that collapsed every logit to `+inf`, destroyed their ordering, and made downstream `sample_top_p` return **token 0 instead of the argmax** — even though the `t -> 0+` limit must stay greedy.

The main `Sampler` already routes degenerate temperatures to a **hard argmax** via `temperature_degenerate`, but this **public** helper did not, so direct callers of `CandidateSet` silently got the wrong token. This is a recurrence of the #316/#317 tiny-temperature class on the public API surface.

Found via a fresh discovery review pass over the CPU sampling pipeline (#322 F3); F1 (#397) and F2 (#398) from the same pass are filed separately as grammar items pending a design decision.

## Fix

When `temperature_degenerate(temperature)` is true (finite-but-tiny positive temp whose reciprocal overflows), collapse the candidate set to a **one-hot on the argmax**: set the argmax candidate's logit to `0.0` and all others to `f32::NEG_INFINITY`, then return. Any downstream `sample_top_p` then returns the argmax deterministically — matching the hard-argmax route the main `Sampler` takes for the same predicate.

Normal temperatures still scale by `1 / temperature`; non-finite, non-positive, and `1.0` temperatures stay no-ops (unchanged contract).

(Round 1 used a finite clamp on the multiplier; review correctly found that only *approximates* greedy — for very close logits the clamped softmax stays near 50/50 and could still draw a non-argmax token. Replaced with the one-hot collapse.)

## Tests (both mutation-verified)

- `apply_temperature_tiny_positive_temp_stays_greedy`: `[10.0, 11.0]`, `apply_temperature(1e-45)`, `sample_top_p(1.0, 0.0) == 1`.
- `apply_temperature_tiny_temp_is_hard_greedy_for_close_logits`: `[0.0, f32::from_bits(1)]`, `apply_temperature(1e-45)`, `sample_top_p(1.0, 0.75) == 1`.

Each guards a distinct degradation: reverting to raw scaling fails the overflow test (`left 0, right 1`); replacing the fix with the finite clamp fails the close-logit test (`left 0, right 1`). The hard-argmax fix passes both. 58 `sampling::` tests pass; `cargo clippy -p lattice-inference -- -D warnings` clean.

## bench-compare

Structural disposition: the degenerate branch only fires for finite-but-tiny temperatures (reciprocal overflow) and replaces the scaling loop with an argmax scan + one-hot write of the same length; for normal temperatures the path is byte-for-byte the prior `1 / temperature` scaling. No bench exercises this sampling helper and the decode hot path is untouched (precedent accepted for #387, #396).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
