### PR TITLE
harden(inference): release-active shape guards in deinterleave_q_gate (#322)

### DIFF
--- a/crates/inference/src/attention/gated.rs
+++ b/crates/inference/src/attention/gated.rs
@@ -24,8 +24,9 @@ use crate::forward::cpu::simd_config;
 ///
 /// # Panics
 ///
-/// Panics (debug-only) if `q_and_gate.len() != 2 * num_heads * head_dim`,
-/// `q_buf.len() != num_heads * head_dim`, or `gate_buf.len() != num_heads * head_dim`.
+/// Panics if `num_heads * head_dim` or `2 * q_dim` overflows `usize`, or if
+/// `q_and_gate.len() != 2 * num_heads * head_dim`, `q_buf.len() != num_heads * head_dim`,
+/// or `gate_buf.len() != num_heads * head_dim`.
 #[inline]
 pub fn deinterleave_q_gate(
     q_and_gate: &[f32],
@@ -34,10 +35,36 @@ pub fn deinterleave_q_gate(
     num_heads: usize,
     head_dim: usize,
 ) {
+    assert!(
+        num_heads.checked_mul(head_dim).is_some(),
+        "deinterleave_q_gate shape overflow: num_heads * head_dim"
+    );
     let q_dim = num_heads * head_dim;
-    debug_assert_eq!(q_and_gate.len(), 2 * q_dim);
-    debug_assert_eq!(q_buf.len(), q_dim);
-    debug_assert_eq!(gate_buf.len(), q_dim);
+    assert!(
+        q_dim.checked_mul(2).is_some(),
+        "deinterleave_q_gate shape overflow: 2 * q_dim"
+    );
+    assert_eq!(
+        q_and_gate.len(),
+        2 * q_dim,
+        "deinterleave_q_gate: q_and_gate.len()={} != 2 * num_heads * head_dim={}",
+        q_and_gate.len(),
+        2 * q_dim
+    );
+    assert_eq!(
+        q_buf.len(),
+        q_dim,
+        "deinterleave_q_gate: q_buf.len()={} != num_heads * head_dim={}",
+        q_buf.len(),
+        q_dim
+    );
+    assert_eq!(
+        gate_buf.len(),
+        q_dim,
+        "deinterleave_q_gate: gate_buf.len()={} != num_heads * head_dim={}",
+        gate_buf.len(),
+        q_dim
+    );
 
     for h in 0..num_heads {
         let src = h * head_dim * 2;
@@ -363,6 +390,23 @@ mod tests {
         deinterleave_q_gate(&packed, &mut q_buf, &mut gate_buf, num_heads, head_dim);
         assert_eq!(q_buf, [1.0, 2.0, 5.0, 6.0]);
         assert_eq!(gate_buf, [3.0, 4.0, 7.0, 8.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "q_and_gate.len()")]
+    fn test_deinterleave_rejects_overlong_packed_input() {
+        // A too-LONG packed buffer does not index-panic in the copy loop (the
+        // source has enough elements), so without the release-active length
+        // assert it would silently process only the first 2*q_dim and succeed.
+        // The guard must reject it. Mutation-sensitive: removing the assert_eq!
+        // makes this test fail (no panic on the silent partial result).
+        let num_heads = 2usize;
+        let head_dim = 2usize;
+        let q_dim = num_heads * head_dim;
+        let overlong = vec![0.0f32; 2 * q_dim + 2];
+        let mut q_buf = vec![0.0f32; q_dim];
+        let mut gate_buf = vec![0.0f32; q_dim];
+        deinterleave_q_gate(&overlong, &mut q_buf, &mut gate_buf, num_heads, head_dim);
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

`deinterleave_q_gate` (the public Qwen3.5 Q+gate split helper) guarded its shape contract with `debug_assert_eq!`, which is a **no-op in release builds**. A malformed caller would hit either:
- an opaque slice-index panic (too-short `q_and_gate`), or
- **silent truncation** — a too-long `q_and_gate` is processed only up to the first `2*q_dim` elements with no error at all.

Every other attention helper closed this class in the #360–#374 hardening sweep (`standard.rs:104-112` is the precedent idiom). `gated.rs` was the one file the sweep missed. This was surfaced by a fresh discovery review pass over `crates/inference/src/attention/gated.rs` (one P2, no P0/P1; gating arithmetic verified correct vs HF Qwen3-Next).

## Change

- Convert the three `debug_assert_eq!` → release-active `assert_eq!`.
- Add `checked_mul` overflow guards on `num_heads * head_dim` and `2 * q_dim`, matching the `standard.rs` idiom.
- Signature unchanged (no `Result<>` conversion — the codebase precedent is release-active `assert!`, not a fallible API; that would be a larger change requiring a design decision).
- Update the `# Panics` doc to drop "debug-only".

The two `apply_sigmoid_gate*` helpers in this file already use release-active `assert_eq!` and are unchanged.

## Liveness / scope

`gated.rs` **is** a live Qwen3.5 full-attention decode dependency (`apply_sigmoid_gate` at `forward.rs:242`, `deinterleave_q_gate` via `cache.rs:164`). The live path allocates correctly-sized scratch first, so this is **not** a live-model correctness bug — it hardens the public API boundary against malformed external callers, completing the gap the sweep left.

## Test

`test_deinterleave_rejects_overlong_packed_input` uses an over-long packed buffer — the case that **silently succeeds** without the guard (too-short would index-panic either way, so it can't prove the guard). Mutation-verified: neutralizing the length assert makes the test FAIL ("test did not panic as expected").

## bench-compare

Not run. This adds only branch-predictable assertion checks on a non-hot setup path — scratch shape is validated once per forward, not per token; no hot-loop arithmetic changed. Per the "honest structural-disposition" precedent (#387/#396) when no bench exercises the changed path.

## Verification

- `cargo test -p lattice-inference --lib attention::gated` → 8 passed
- `cargo test -p lattice-inference --test gated_attention_test` → 6 passed
- `cargo clippy -p lattice-inference --lib -- -D warnings` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
