### PR TITLE
harden(inference): context preflight in generate/generate_streaming (RoPE bounds)

### DIFF
--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -39,6 +39,22 @@ impl Qwen35Model {
             });
         }
 
+        // Context preflight: prefill + decode drive RoPE positions up to
+        // prompt_len + max_new_tokens, and apply_partial_rope indexes the
+        // precomputed cos/sin table unchecked. Past max_context() that is an
+        // out-of-bounds slice access — a release panic, not a clean error.
+        // Mirror the HTTP server's contract (bin/lattice.rs) so direct and HTTP
+        // generation agree on when a request is too long. Same guard in
+        // generate_streaming.
+        let max_context = self.max_context();
+        if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
+            return Err(InferenceError::Inference(format!(
+                "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
+                 model context window ({max_context})",
+                gen_cfg.max_new_tokens
+            )));
+        }
+
         let num_linear = cfg.num_linear_attention_layers();
         let num_full = cfg.num_full_attention_layers();
         let mut gdn_states: Vec<GatedDeltaNetState> = (0..num_linear)
@@ -182,6 +198,18 @@ impl Qwen35Model {
                 generated_tokens: 0,
                 stopped: false,
             });
+        }
+
+        // Context preflight: see generate() for rationale — apply_partial_rope
+        // indexes the RoPE table unchecked, so a request past max_context() would
+        // panic in the decode loop. Mirror the HTTP server's contract.
+        let max_context = self.max_context();
+        if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
+            return Err(InferenceError::Inference(format!(
+                "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
+                 model context window ({max_context})",
+                gen_cfg.max_new_tokens
+            )));
         }
 
         let num_linear = cfg.num_linear_attention_layers();

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -39,13 +39,20 @@ impl Qwen35Model {
             });
         }
 
-        // Context preflight: prefill + decode drive RoPE positions up to
-        // prompt_len + max_new_tokens, and apply_partial_rope indexes the
-        // precomputed cos/sin table unchecked. Past max_context() that is an
-        // out-of-bounds slice access — a release panic, not a clean error.
-        // Mirror the HTTP server's contract (bin/lattice.rs) so direct and HTTP
-        // generation agree on when a request is too long. Same guard in
-        // generate_streaming.
+        // Context preflight. apply_partial_rope indexes the precomputed cos/sin
+        // table unchecked, so a position at or past max_context() is an
+        // out-of-bounds slice access — a release panic, not a clean error. The
+        // exact highest position the CPU loop reaches is prompt_len +
+        // max_new_tokens - 2 (prefill 0..prompt_len-1; the first token reuses
+        // prefill logits with no new RoPE lookup; decode runs `1..max_new_tokens`
+        // from position prompt_len), so the precise RoPE-safe bound is
+        // prompt_len + max_new_tokens - 1 <= max_context. We deliberately adopt
+        // the stricter total-token policy prompt_len + max_new_tokens <=
+        // max_context instead: it is the OpenAI-style "prompt plus requested
+        // completion fits the window" contract and matches the HTTP server
+        // (bin/lattice.rs) verbatim, so direct and HTTP generation agree on when
+        // a request is too long. Strictly safe (it can only reject one extra
+        // edge request, never admit a panic). Same guard in generate_streaming.
         let max_context = self.max_context();
         if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
             return Err(InferenceError::Inference(format!(
@@ -200,9 +207,10 @@ impl Qwen35Model {
             });
         }
 
-        // Context preflight: see generate() for rationale — apply_partial_rope
-        // indexes the RoPE table unchecked, so a request past max_context() would
-        // panic in the decode loop. Mirror the HTTP server's contract.
+        // Context preflight: see generate() for the full rationale and the exact
+        // vs. adopted-bound discussion. apply_partial_rope indexes the RoPE table
+        // unchecked, so a request past max_context() would panic in the decode
+        // loop; this mirrors the HTTP server's total-token contract verbatim.
         let max_context = self.max_context();
         if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
             return Err(InferenceError::Inference(format!(

--- a/crates/inference/src/model/qwen35/tests.rs
+++ b/crates/inference/src/model/qwen35/tests.rs
@@ -815,4 +815,58 @@ mod lora_serving {
         assert!(out.token_ids.is_empty(), "token_ids must be empty");
         assert!(out.prompt_tokens > 0, "prompt must still be counted");
     }
+
+    #[test]
+    fn generate_rejects_request_exceeding_context_window() {
+        // A direct generate() call whose prompt + max_new_tokens exceeds the
+        // RoPE table capacity must return a clean error, NOT panic in the
+        // decode loop by indexing the cos/sin table past its end. The HTTP
+        // server preflights this (bin/lattice.rs); the public library method
+        // must agree. Mutation-sensitive: the preflight is the only path to
+        // Err for a non-empty prompt with a large max_new_tokens — without it
+        // this input either panics (index OOB) or returns Ok, both of which
+        // fail expect_err.
+        let cfg = test_config();
+        let model = build_model(cfg, 0xBEEF_CAFE);
+        let max_context = model.max_context();
+        let gen_cfg = crate::model::qwen35_config::GenerateConfig {
+            max_new_tokens: max_context + 16,
+            ..Default::default()
+        };
+        let err = model
+            .generate("abc", &gen_cfg)
+            .expect_err("request beyond context window must error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("context window") && msg.contains(&format!("{max_context}")),
+            "error must name the context window and the bound; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn generate_streaming_rejects_request_exceeding_context_window() {
+        // Same preflight contract as generate(); the streaming variant shares
+        // the guard. on_token must never fire because the error returns before
+        // any forward pass.
+        let cfg = test_config();
+        let model = build_model(cfg, 0xBEEF_CAFD);
+        let max_context = model.max_context();
+        let gen_cfg = crate::model::qwen35_config::GenerateConfig {
+            max_new_tokens: max_context + 16,
+            ..Default::default()
+        };
+        let mut emitted = 0usize;
+        let err = model
+            .generate_streaming("abc", &gen_cfg, |_| emitted += 1)
+            .expect_err("request beyond context window must error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("context window") && msg.contains(&format!("{max_context}")),
+            "error must name the context window and the bound; got: {msg}"
+        );
+        assert_eq!(
+            emitted, 0,
+            "no tokens may stream when the request is rejected"
+        );
+    }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

The public `Qwen35Model::generate` and `generate_streaming` validated only empty-prompt and `max_new_tokens == 0`. They did **not** bound the request against `max_context()`. The decode loop drives RoPE `position` into `apply_partial_rope`, which indexes the precomputed cos/sin table with `cos_at(base + i)` / `sin_at(base + i)` — **unchecked** slice access (`self.cos[idx]`, `rope.rs:58/64`). Past `max_context()` that is an out-of-bounds index: a **release panic**, not a clean error.

The HTTP server wrapper (`bin/lattice.rs:667`) and the eval helpers already preflight this. So a request the server cleanly rejects with a 400 would **crash the process** when made through the direct library API. This PR closes that inconsistency.

## Change

Add a release-active preflight to both entry points before any allocation or forward pass:

```rust
let max_context = self.max_context();
if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
    return Err(InferenceError::Inference(format!(
        "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
         model context window ({max_context})",
        gen_cfg.max_new_tokens
    )));
}
```

Inlined at both `generate` and `generate_streaming`, with cross-referencing comments.

## Bound: intentional total-token policy (review round 1)

Review (fixes required) correctly noted the exact highest RoPE position the CPU loop reaches is `prompt_len + max_new_tokens - 2` (prefill `0..prompt_len-1`; the first generated token reuses prefill logits with **no** new RoPE lookup; decode runs `1..max_new_tokens` from position `prompt_len`). So the *precise* RoPE-safe bound is `prompt_len + max_new_tokens - 1 <= max_context`.

The guard deliberately keeps the **stricter** `prompt_len + max_new_tokens <= max_context`. That is the OpenAI-style "prompt plus requested completion fits the window" contract, and it matches the HTTP server (`bin/lattice.rs`) **verbatim** so direct and HTTP generation agree on when a request is too long. The bound is **strictly safe** — review confirmed it can only reject one extra edge request, never admit a panic. The round-2 commit corrects the guard comment to document this choice (it previously overstated the positions reached). No behavior change.

## Discovery / scope

Found by a discovery review pass over the live Qwen3.5 CPU decode RoPE path. The companion **P2** (config accepts zero/odd derived `rope_dim`) is filed as **#401**. The review's "Adjacent Entry Points" finding (other public / feature-gated paths reaching RoPE without a preflight: `forward_prompt_debug`, `generate_with_batch_prefill`, `rope_cos_sin_tables`) is filed as **#403**, out of scope here.

## Test

`generate_rejects_request_exceeding_context_window` and `generate_streaming_rejects_request_exceeding_context_window` drive a request past the synthetic model's RoPE capacity and assert a clean error (+ the streaming test asserts `on_token` never fires). **Mutation-verified**: the preflight is the only `Err` path for a non-empty prompt with large `max_new_tokens`, so neutralizing both guards makes both tests fail.

## bench-compare

Not run — adds a single `saturating_add` comparison once per `generate()` call, before any forward pass; no hot-loop or per-token arithmetic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
