### PR TITLE
harden(inference): reject non-divisible GQA heads in parse_qwen_config (load-time, not panic)

### DIFF
--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -1643,6 +1643,17 @@ fn parse_qwen_config(path: &Path) -> Result<QwenConfig, InferenceError> {
              num_key_value_heads ({num_key_value_heads}) must both be non-zero"
         )));
     }
+    // GQA grouping requires num_attention_heads divisible by num_key_value_heads.
+    // `GqaConfig::groups()` only `debug_assert`s this (stripped in release), and
+    // `apply_gqa_attention` hard-asserts it; a non-divisible caller-supplied
+    // config.json would otherwise panic deep in the forward pass. Reject it here
+    // at load time, mirroring `Qwen35Config::from_json_str`.
+    if num_attention_heads % num_key_value_heads != 0 {
+        return Err(InferenceError::InvalidInput(format!(
+            "config.json: num_attention_heads ({num_attention_heads}) must be \
+             divisible by num_key_value_heads ({num_key_value_heads})"
+        )));
+    }
     let hidden_size = get("hidden_size")?;
     // head_dim may be explicit in config, or inferred from hidden_size / num_heads.
     let head_dim =
@@ -1742,6 +1753,47 @@ mod tests {
         assert!(
             parse_qwen_config(&cfg_ok).is_ok(),
             "valid config must still parse"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn test_parse_config_non_divisible_gqa_heads_is_error_not_panic() {
+        let tmp = std::env::temp_dir().join("lattice_test_nondiv_gqa_heads");
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // num_attention_heads=16 not divisible by num_key_value_heads=6.
+        // `GqaConfig::groups()` only `debug_assert`s divisibility (stripped in
+        // release), so without this load-time guard a release build would reach
+        // the hard `assert_eq!` in `apply_gqa_attention` and panic deep in the
+        // forward pass. Must be rejected as InvalidInput at parse time.
+        let cfg_bad = tmp.join("non_divisible.json");
+        std::fs::write(
+            &cfg_bad,
+            r#"{"vocab_size":151669,"hidden_size":1024,"num_hidden_layers":1,"num_attention_heads":16,"num_key_value_heads":6,"head_dim":128,"intermediate_size":3072,"max_position_embeddings":32768}"#,
+        )
+        .unwrap();
+        let r = parse_qwen_config(&cfg_bad);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "non-divisible GQA heads must be InvalidInput, not panic; got {r:?}"
+        );
+        assert!(
+            r.unwrap_err().to_string().contains("divisible"),
+            "error message must name the divisibility violation"
+        );
+
+        // Sanity: an evenly-divisible config (16 % 8 == 0) still parses.
+        let cfg_ok = tmp.join("divisible.json");
+        std::fs::write(
+            &cfg_ok,
+            r#"{"vocab_size":151669,"hidden_size":1024,"num_hidden_layers":1,"num_attention_heads":16,"num_key_value_heads":8,"head_dim":128,"intermediate_size":3072,"max_position_embeddings":32768}"#,
+        )
+        .unwrap();
+        assert!(
+            parse_qwen_config(&cfg_ok).is_ok(),
+            "divisible config must still parse"
         );
 
         std::fs::remove_dir_all(&tmp).ok();


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

A caller-supplied Qwen `config.json` with `num_attention_heads` **not divisible** by `num_key_value_heads` passed `parse_qwen_config` (which only rejected zero head counts), then reached the hard `assert_eq!` in `apply_gqa_attention` (`crates/inference/src/attention/gqa.rs:102`) and **panicked deep in the forward pass**. `GqaConfig::groups()` only `debug_assert`s the invariant (stripped in release), so a release build would hit the panic rather than fail closed.

This adds the load-time divisibility guard in `parse_qwen_config`, returning `InvalidInput`, **mirroring the existing check** in `Qwen35Config::from_json_str` (`crates/inference/src/model/qwen35_config.rs:401`). FindExisting > Create.

## Provenance

Found via a discovery review sweep over `crates/inference/src/attention/gqa.rs` (1 P3 finding; the seeded softmax-fail-closed, GQA head-mapping, scale, causal-mask, and degenerate-input priors were all **refuted** for `gqa.rs` itself). The review also confirmed `gqa.rs` is **not** on the live Qwen3.5 decode/prefill path — Qwen3.5 uses separate attention implementations. So this gap is reachable through `QwenModel::from_directory` / CPU `forward_cpu_optimized` with a malformed caller-supplied model directory, **not** through any official Qwen3.5 model.

## Severity

P3 — malformed external config, non-official path. But it violates the no-panic rule for unsanitized library-facing input, and the fix is a one-line guard mirroring an existing one.

## Test

`test_parse_config_non_divisible_gqa_heads_is_error_not_panic` (sibling to the existing zero-heads test). **Mutation-sensitive**: with the guard neutered, the malformed config parses `Ok(...)` and the test fails (`got Ok(QwenConfig{ ... num_key_value_heads: 6 })`); restored → passes. Valid divisible config (16 % 8 == 0) still parses.

```text
cargo test -p lattice-inference --lib model::qwen::tests::test_parse_config
  3 passed; 0 failed
cargo clippy -p lattice-inference --lib -- -D warnings  → clean
```

No production behavior change for any valid model; this only converts a previously-panicking malformed-input path into a clean `InvalidInput`. e2e-parity unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
