### PR TITLE
harden(inference): fail closed on q4 loader shape/original_len mismatch

### DIFF
--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -714,6 +714,23 @@ pub fn load_q4_file(path: &std::path::Path) -> Result<Q4Tensor, Box<dyn std::err
 
     f.read_exact(&mut b8)?;
     let original_len = u64::from_le_bytes(b8) as usize;
+
+    // Fail closed on a header whose shape disagrees with its element count.
+    // The quantize paths enforce `shape.product() == data.len()` via
+    // `assert_shape_matches_data_len`; the loader must reject the same
+    // inconsistency rather than return a tensor whose `shape` overstates the
+    // block payload (downstream matmuls would read stale, out-of-range data).
+    let shape_product = shape
+        .iter()
+        .try_fold(1_usize, |acc, &d| acc.checked_mul(d))
+        .ok_or("shape dims overflow usize")?;
+    if shape_product != original_len {
+        return Err(format!(
+            "shape product {shape_product} (shape={shape:?}) != original_len {original_len}"
+        )
+        .into());
+    }
+
     let n_blocks = original_len.div_ceil(32);
 
     let raw_len = checked_alloc_bytes(n_blocks, 20, file_len, "block payload")?;
@@ -1598,6 +1615,31 @@ mod tests {
         assert!(
             r.is_err(),
             "2^62 original_len must be rejected, not OOM-aborted"
+        );
+    }
+
+    #[test]
+    fn test_q4_rejects_shape_product_mismatch() {
+        // shape product (4*16=64) disagrees with original_len (32): the header
+        // claims twice as many elements as the block payload covers. The
+        // quantize paths reject this via assert_shape_matches_data_len; the
+        // loader must too, with a clean Err rather than a Q4Tensor whose shape
+        // overstates its data (downstream matmuls would read stale elements).
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"KHQ4");
+        buf.extend_from_slice(&2u32.to_le_bytes()); // version
+        buf.extend_from_slice(&2u32.to_le_bytes()); // ndim
+        buf.extend_from_slice(&4u64.to_le_bytes()); // shape[0]
+        buf.extend_from_slice(&16u64.to_le_bytes()); // shape[1] → product 64
+        buf.extend_from_slice(&32u64.to_le_bytes()); // original_len (≠ 64)
+        buf.extend_from_slice(&[0u8; 20]); // one valid-size block payload
+        let path = std::path::PathBuf::from("/tmp/test_q4_shape_mismatch.q4");
+        std::fs::write(&path, &buf).unwrap();
+        let r = load_q4_file(&path);
+        std::fs::remove_file(&path).ok();
+        assert!(
+            r.is_err(),
+            "shape product 64 != original_len 32 must be rejected"
         );
     }
 


### PR DESCRIPTION
## What

`load_q4_file` derived `n_blocks` from the header's `original_len` but never checked that the header's `shape` product agreed with `original_len`. A `.q4` file whose `shape` overstates its block payload loaded as a `Q4Tensor` whose `shape` claims more elements than the blocks cover — downstream matmuls would then read stale, out-of-range data with no error.

This adds a fail-closed check: `shape.product()` (computed via `checked_mul`, so a crafted huge shape can't itself overflow) must equal `original_len`, else a clean `Err` before any block is read.

## Why this is the right guard

The quantize/write paths already enforce `shape.product() == data.len()` via `assert_shape_matches_data_len` (panics on mismatch at the three quantize entry points). The loader was the one path that could *produce* an inconsistent `Q4Tensor` without tripping that invariant. This mirrors the same invariant on the read side, returning `Err` (no panic — the loader is fallible). Same hardening family as the existing `test_q4_rejects_huge_ndim` / `test_q4_rejects_huge_original_len` adversarial-header guards.

## Relation to #346

#346 item 2 (the `n_blocks * 20` alloc overflow) is **already guarded** in current code by `checked_alloc_bytes(n_blocks, 20, file_len, ...)` at `q4_weights.rs:736` (covered by `test_q4_rejects_huge_original_len`). This PR adds the **complementary** invariant #346 did not enumerate: shape ↔ `original_len` consistency. The other #346 items (partial-block scale P3, QuaRot embed symmetry P2 measure-first, doc bug P3) are out of scope here.

## Test

`test_q4_rejects_shape_product_mismatch` — crafts a header with shape `[4,16]` (product 64) but `original_len 32` plus one valid 20-byte block; asserts the load returns `Err`. Mutation-sensitive: without the new check the function reaches `n_blocks = 1`, reads the block, and returns `Ok` — the test fails when the fix is reverted.

## Gates

- `cargo clippy -p lattice-inference --lib -- -D warnings`: clean.
- All 39 `weights::q4_weights` tests pass; existing `test_save_load_round_trip` (real save→load) unaffected — valid files still load.
- **bench-compare not applicable**: the change is in the cold model-load path (`load_q4_file`), which no Criterion group exercises. No hot-path code and no numerics change, so the e2e-parity token-agreement gate is the relevant one and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
