### PR TITLE
harden(inference): clamp GDN decay-gate exp(a_log) to finite across all forward paths (fail-closed, NaN-poison parity w/ CPU)

### DIFF
--- a/crates/inference/src/forward/batch_prefill.rs
+++ b/crates/inference/src/forward/batch_prefill.rs
@@ -1087,7 +1087,9 @@ fn apply_causal_conv1d_prefill(
 /// Local copy of the private GatedDeltaNet decay gate computation.
 #[inline]
 fn compute_decay_gate_prefill(a_log: f32, alpha: f32, dt_bias: f32) -> f32 {
-    let a = a_log.exp();
+    // Clamp exp(a_log) to finite (mirror gdn.rs compute_decay_gate): a_log>~88 -> +inf,
+    // inf*0 (softplus underflow) = NaN poisons the recurrent state.
+    let a = a_log.exp().min(f32::MAX);
     let sp = softplus_prefill(alpha + dt_bias);
     (-a * sp).exp()
 }

--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -141,8 +141,9 @@ pub fn gated_delta_net_step_fused_f16(
         simd_l2_normalize(&mut scratch.q_head[..key_dim]);
         simd_l2_normalize(&mut scratch.k_head[..key_dim]);
 
-        // Decay gate (f32 weights: a_log, dt_bias)
-        let a = weights.a_log[h].exp();
+        // Decay gate (f32 weights: a_log, dt_bias). Clamp exp(a_log) to finite
+        // (mirror gdn.rs compute_decay_gate): a_log>~88 -> +inf, inf*0 = NaN poisons state.
+        let a = weights.a_log[h].exp().min(f32::MAX);
         let sp = softplus(scratch.alpha_proj[h] + weights.dt_bias[h]);
         let g = (-a * sp).exp();
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1130,7 +1130,7 @@ kernel void gdn_recurrence_fused(
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     // Decay gate
-    float a = exp(a_log[k_head]);
+    float a = min(exp(a_log[k_head]), FLT_MAX);  // clamp +inf (parity w/ CPU gdn.rs): inf*0 = NaN poisons GDN state
     float sp = log(1.0f + exp(alpha_val + dt_bias[k_head]));
     float g = exp(-a * sp);
 
@@ -1264,7 +1264,7 @@ kernel void gdn_recurrence_fused_q36(
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     // Decay gate
-    float a = exp(a_log[k_head]);
+    float a = min(exp(a_log[k_head]), FLT_MAX);  // clamp +inf (parity w/ CPU gdn.rs): inf*0 = NaN poisons GDN state
     float sp = log(1.0f + exp(alpha_val + dt_bias[k_head]));
     float g = exp(-a * sp);
 
@@ -1377,7 +1377,7 @@ kernel void gdn_precompute_keys(
     float ks_inv      = (sg_buf[0] > 1e-12f) ? rsqrt(sg_buf[0]) : 0.0f;
     float k_norm_val  = k_val * ks_inv;
 
-    float a  = exp(a_log[k_head]);
+    float a  = min(exp(a_log[k_head]), FLT_MAX);  // clamp +inf (parity w/ CPU gdn.rs): inf*0 = NaN poisons GDN state
     float sp = log(1.0f + exp(alpha_val + dt_bias[k_head]));
     float g  = exp(-a * sp);
 
@@ -9919,7 +9919,7 @@ kernel void gdn_chunk_norm_silu_c32(
                 simd_l2_normalize(&mut q_head);
                 simd_l2_normalize(&mut k_head);
 
-                let a = a_log[kh].exp();
+                let a = a_log[kh].exp().min(f32::MAX); // finite clamp (see gdn.rs compute_decay_gate): inf*0 = NaN poisons state
                 let sp = softplus(alpha_proj[kh] + dt_bias[kh]);
                 let g = (-a * sp).exp();
 
@@ -10100,7 +10100,7 @@ kernel void gdn_chunk_norm_silu_c32(
                 simd_l2_normalize(&mut q_head);
                 simd_l2_normalize(&mut k_head);
 
-                let a = a_log_v[kh].exp();
+                let a = a_log_v[kh].exp().min(f32::MAX); // finite clamp (see gdn.rs compute_decay_gate): inf*0 = NaN poisons state
                 let sp = softplus(alpha_proj[kh] + dt_bias_v[kh]);
                 let g = (-a * sp).exp();
 
@@ -18099,7 +18099,11 @@ kernel void decode_attention_reference(
             let vocab = 32usize;
             let num_kh = 1usize;
             let kd = 16usize;
-            let vd = 16usize;
+            // vd * num_kh = GDN out_dim = the contraction dim K of the out_proj Q8
+            // GEMM, which the GEMV/GEMM kernel requires to be a multiple of 32 (real
+            // configs use vd=128). 16 made the GDN-only GPU tests crash on real Apple
+            // hardware (and silently skip in paravirtual CI where no Metal device exists).
+            let vd = 32usize;
             let qkv_dim = num_kh * kd * 2 + num_kh * vd; // Q+K+V
             let out_dim = num_kh * vd;
             let ks = 4usize;
@@ -18242,6 +18246,46 @@ kernel void decode_attention_reference(
             assert!(
                 logits.iter().all(|v| v.is_finite()),
                 "all GDN-only logits must be finite"
+            );
+        }
+
+        /// Mutation-sensitive guard for the GDN decode decay-gate clamp.
+        ///
+        /// When `a_log > ~88`, the kernel's `exp(a_log)` overflows to `+inf`; when
+        /// `alpha + dt_bias` drives softplus to exactly `0.0`, the *unclamped*
+        /// product is `inf * 0 = NaN`, which poisons the recurrent state and every
+        /// subsequent logit (coherent-early / garbage-late on long generations).
+        /// The fix mirrors the CPU `compute_decay_gate` clamp (`exp(a_log).min(MAX)`).
+        /// This test FAILS (non-finite logits) if the decode clamp is reverted and
+        /// PASSES once it is present.
+        #[test]
+        fn forward_step_gdn_only_decay_gate_clamps_overflow() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _guard = gpu_test_lock();
+            let (cfg, mut weights) = tiny_hybrid_fixture();
+
+            // Drive every GDN head into the overflow corner: a_log huge (exp -> +inf)
+            // and dt_bias very negative (softplus -> 0). Unclamped: inf * 0 = NaN.
+            for (attn, _) in weights.layers.iter_mut() {
+                if let AttentionWeights::Linear(gdn) = attn {
+                    for a in gdn.a_log.iter_mut() {
+                        *a = 100.0;
+                    }
+                    for b in gdn.dt_bias.iter_mut() {
+                        *b = -200.0;
+                    }
+                }
+            }
+
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let logits = state.forward_step_gdn_only(1, 0);
+
+            assert!(
+                logits.iter().all(|v| v.is_finite()),
+                "GDN decode decay-gate must clamp exp(a_log) to finite; got non-finite \
+                 logits (inf * 0 = NaN poison) — the decode clamp was reverted"
             );
         }
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Fail-closed hardening for the GatedDeltaNet decay gate. Every GDN forward path computes `a = exp(a_log)` for the decay gate `g = exp(-a * softplus(alpha + dt_bias))`. The CPU reference (`attention/gdn.rs::compute_decay_gate`) clamps this with `min(exp(a_log), f32::MAX)`; the Metal decode kernels and two other forward copies did **not**. In the overflow corner (`a_log > ~88` so `exp = +inf`, and `alpha + dt_bias` small enough that softplus underflows to exactly `0.0`), the product is `inf * 0 = NaN`, which flows into the rank-1 state update and **poisons the recurrent state permanently**. This PR mirrors the CPU clamp into every remaining GDN path.

This is the same family as #412 / #414 (Q8 / NEON forward hardening): a **no-op for valid checkpoints** (where `exp(a_log)` stays finite), firing only in the pathological corner.

## ⚠️ Scope correction — this does NOT fix the qwen3.6-27B garbage-late symptom

An earlier draft of this PR framed the clamp as the fix for the observed Qwen3.6-27B "coherent-early / garbage-late" decode degeneration. **A direct inspection of the 27B Q4 checkpoint disproves that.** Reading all 48 GDN `A_log` tensors: `a_log ∈ [-5.5625, +4.9375]` across every layer and head, `max exp(a_log) = 139` (finite). No head comes near the `a_log > 88.72` overflow corner, so this clamp is a **no-op for that checkpoint** and cannot be its cure. The clamp is still correct hardening (protects against malformed/adversarial checkpoints and any future training run that drifts `a_log` high), so the PR stands on those grounds alone.

The real root cause of the 27B symptom is tracked separately: a per-**key**-head vs HF per-**value**-head decay-granularity mismatch in the asymmetric GDN path (HF Qwen3-Next defines `A_log`/`dt_bias`/`alpha`/`beta` per value-head `[48]`; lattice indexes decay by key-head `a_log[h/ratio]` and ignores `a_log[16..48]`). That sits in the #262 asymmetric-head cluster (pending an asymmetric-checkpoint design decision) and is **not** part of this PR.

## Changes

`exp(a_log)` becomes `min(exp(a_log), FLT_MAX)` (MSL) / `.exp().min(f32::MAX)` (Rust) at every GDN decay-gate site:

- `gdn_recurrence_fused` (MSL, generic/0.8B decode)
- `gdn_recurrence_fused_q36` (MSL, 27B-specialized decode)
- `gdn_precompute_keys` (MSL, 27B sharded decode)
- 2 host-side Rust GDN loops (asymmetric-safe orchestrated path)
- `cpu_f16.rs` decode loop
- `batch_prefill.rs::compute_decay_gate_prefill`

The chunked-prefill MSL path already floors via `GDN_LOG_ALPHA_FLOOR` and is untouched.

**Test-harness repair (pre-existing bug, found while validating):** `tiny_hybrid_fixture` used `vd=16`, making the GDN `out_proj` Q8-GEMM contraction dim `K=16`, which trips the kernel's `K % 32 == 0` guard. The three `forward_step_gdn_only_*` GPU tests therefore **crashed on real Apple hardware** and **silently skipped in paravirtual CI** (no Metal `system_default` device). Bumped `vd` to a realistic `32` (production configs use 128). Those tests now actually run.

**New mutation-sensitive test:** `forward_step_gdn_only_decay_gate_clamps_overflow` drives `a_log=100, dt_bias=-200` and asserts finite logits. Verified it **FAILS with NaN logits when the clamp is reverted** and **PASSES with the fix**.

## Validation

- `cargo test -p lattice-inference --features metal-gpu` — all GDN/fixture tests green on M2 Max (Apple8).
- Mutation check: revert clamp at the generic kernel, new test fails with the exact `inf*0=NaN` assertion; restore, passes. (Independently reproduced during review.)
- `cargo clippy -p lattice-inference --all-targets -- -D warnings` clean (default + `--features metal-gpu`). `cargo fmt --check` clean.

## bench-compare

The change is one `min()` per decay-gate evaluation in kernels that already run; on valid checkpoints the clamp never fires, so the expected delta is **zero**. The GPU A/B (`make bench-compare`) is deferred under an active machine heat constraint and will be attached pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
