### PR TITLE
feat(macos): reasoning on/off toggle + separate thinking/response views in chat

### DIFF
--- a/apps/macos/Sources/LatticeStudio/Screens/ChatFinalization.swift
+++ b/apps/macos/Sources/LatticeStudio/Screens/ChatFinalization.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Pure split/finalization of a chat generation stream around the `<think>…</think>`
+/// reasoning boundary. Extracted from `ChatScreen` so it can be unit-tested without a View.
+///
+/// Two surfaces share this logic and MUST agree, otherwise reasoning shown live in the
+/// thinking area can land in the answer bubble at the end (or vice versa):
+/// - the live `.onChange` streaming router (runs on every token delta), and
+/// - `resolveTurn` finalization (runs once generation completes).
+enum ChatFinalization {
+
+    /// Split a cumulative generation string into (thinking, response) on the
+    /// `<think>…</think>` boundary. Tag-only — it knows nothing about how the prompt was built.
+    /// - `</think>` present: text before it (minus a leading `<think>`) is thinking; text after is response.
+    /// - only `<think>` present: everything after it is thinking; response is empty.
+    /// - neither tag present: all of it is the response; thinking is empty.
+    /// Always parses the FULL cumulative string, so a tag split across token deltas resolves on the next delta.
+    static func split(_ raw: String) -> (thinking: String, response: String) {
+        let openTag = "<think>"
+        let closeTag = "</think>"
+        if let closeRange = raw.range(of: closeTag) {
+            var thinking = String(raw[raw.startIndex..<closeRange.lowerBound])
+            if let openRange = thinking.range(of: openTag) {
+                thinking = String(thinking[openRange.upperBound...])
+            }
+            let response = String(raw[closeRange.upperBound...])
+            return (thinking.trimmingCharacters(in: .whitespacesAndNewlines),
+                    response.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        if let openRange = raw.range(of: openTag) {
+            let thinking = String(raw[openRange.upperBound...])
+            return (thinking.trimmingCharacters(in: .whitespacesAndNewlines), "")
+        }
+        return ("", raw.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Finalize a generation into (thinking, response), honoring whether the request
+    /// PREFILLED an open `<think>` block into the prompt (the enable_thinking=true path in
+    /// renderChatML). When thinking was prefilled the model's stream carries NO opening tag —
+    /// it begins mid-reasoning and only emits `</think>` before the answer. So a stream with no
+    /// `</think>` boundary is UNFINISHED REASONING, not the answer, and must not become the
+    /// response: history gates on a non-empty responseText, so an unfinished turn stored as the
+    /// answer would re-inject raw reasoning into the next prompt.
+    ///
+    /// - `</think>` present: standard split (thinking before, answer after; answer may be empty).
+    /// - in-stream `<think>` but no `</think>`: open block never closed → all reasoning.
+    /// - no tags but `prefilledOpenThink`: tagless stream is reasoning, response empty.
+    /// - no tags and not prefilled (thinking off): the raw stream is the answer.
+    static func finalize(_ raw: String, prefilledOpenThink: Bool) -> (thinking: String, response: String) {
+        let parsed = split(raw)
+        if raw.contains("</think>") {
+            return parsed
+        }
+        if raw.contains("<think>") {
+            return (parsed.thinking, "")
+        }
+        if prefilledOpenThink {
+            return (raw.trimmingCharacters(in: .whitespacesAndNewlines), "")
+        }
+        return ("", raw.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+}

--- a/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
+++ b/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
@@ -59,6 +59,8 @@ struct ChatScreen: View {
 
     // Composer text is ephemeral — clearing on navigation is acceptable
     @State private var composerText: String = ""
+    // Which turns have their reasoning disclosure open (auto-open while streaming).
+    @State private var expandedThinking: Set<UUID> = []
 
     // MARK: Store-backed derived helpers
 
@@ -140,7 +142,9 @@ struct ChatScreen: View {
             guard let turnID = store.chatAwaitingTurnID,
                   let idx = store.chatTurns.firstIndex(where: { $0.id == turnID })
             else { return }
-            store.chatTurns[idx].responseText = newText ?? ""
+            let parsed = splitThinking(newText ?? "")
+            store.chatTurns[idx].thinkingText = parsed.thinking
+            store.chatTurns[idx].responseText = parsed.response
         }
     }
 
@@ -365,6 +369,17 @@ struct ChatScreen: View {
                         ),
                         placeholder: "random"
                     )
+
+                    // Reasoning — when off, inject a closed <think></think> so the model skips
+                    // its reasoning trace and answers directly.
+                    ParamRowPicker(
+                        label: "Reasoning",
+                        options: ["On", "Off"],
+                        selection: Binding(
+                            get: { store.chatEnableThinking ? "On" : "Off" },
+                            set: { store.chatEnableThinking = ($0 == "On") }
+                        )
+                    )
                 }
                 .instrumentPanel()
                 .padding(.horizontal, Theme.Space.lg)
@@ -468,6 +483,32 @@ struct ChatScreen: View {
             // Assistant bubble — left-aligned, surfaceRaised fill
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
+                    // Reasoning disclosure — visible whenever the turn produced a thinking trace.
+                    // Auto-expands while streaming (running + no final answer yet), collapsible after.
+                    if !turn.thinkingText.isEmpty {
+                        let isExpanded = Binding<Bool>(
+                            get: { expandedThinking.contains(turn.id) || (turn.status == .running && turn.responseText.isEmpty) },
+                            set: { now in
+                                if now { expandedThinking.insert(turn.id) } else { expandedThinking.remove(turn.id) }
+                            }
+                        )
+                        DisclosureGroup(isExpanded: isExpanded) {
+                            Text(turn.thinkingText)
+                                .font(Theme.Fonts.caption)
+                                .foregroundStyle(Theme.Palette.textSecondary)
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.top, 4)
+                        } label: {
+                            Label("Reasoning", systemImage: "brain")
+                                .font(Theme.Fonts.caption)
+                                .foregroundStyle(Theme.Palette.textTertiary)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(assistantBubbleBackground)
+                    }
+
                     if turn.status == .running && turn.responseText.isEmpty {
                         // Typing indicator: distinguish "loading model" from "generating"
                         HStack(spacing: Theme.Space.xs) {
@@ -755,7 +796,7 @@ struct ChatScreen: View {
     }
 
     /// Build ChatML from completed turns (single-mode history as context).
-    private func renderChatML(newUserText: String) -> String {
+    private func renderChatML(newUserText: String, enableThinking: Bool) -> String {
         var buf = ""
         for turn in store.chatTurns {
             guard turn.status == .done, !turn.responseText.isEmpty else { continue }
@@ -763,8 +804,38 @@ struct ChatScreen: View {
             buf += "<|im_start|>assistant\n\(turn.responseText)<|im_end|>\n"
         }
         buf += "<|im_start|>user\n\(newUserText)<|im_end|>\n"
-        buf += "<|im_start|>assistant\n"
+        if enableThinking {
+            buf += "<|im_start|>assistant\n"
+        } else {
+            // Closed empty think block = the official template's enable_thinking=false path;
+            // the model emits the answer directly with no reasoning.
+            buf += "<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        }
         return buf
+    }
+
+    /// Split a cumulative generation string into (thinking, response) on the <think>…</think> boundary.
+    /// - If `</think>` is present: text before it (minus a leading `<think>`) is thinking; text after is response.
+    /// - If only `<think>` is present (still reasoning): everything after it is thinking; response is empty.
+    /// - If neither tag is present: all of it is the response; thinking is empty.
+    /// Always parses the FULL cumulative string, so a tag split across token deltas resolves on the next delta.
+    private func splitThinking(_ raw: String) -> (thinking: String, response: String) {
+        let openTag = "<think>"
+        let closeTag = "</think>"
+        if let closeRange = raw.range(of: closeTag) {
+            var thinking = String(raw[raw.startIndex..<closeRange.lowerBound])
+            if let openRange = thinking.range(of: openTag) {
+                thinking = String(thinking[openRange.upperBound...])
+            }
+            let response = String(raw[closeRange.upperBound...])
+            return (thinking.trimmingCharacters(in: .whitespacesAndNewlines),
+                    response.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        if let openRange = raw.range(of: openTag) {
+            let thinking = String(raw[openRange.upperBound...])
+            return (thinking.trimmingCharacters(in: .whitespacesAndNewlines), "")
+        }
+        return ("", raw.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
     // MARK: Single-mode send
@@ -779,7 +850,7 @@ struct ChatScreen: View {
         let topK = Int(store.chatTopKText) ?? 50
         let topP = Double(store.chatTopPText) ?? 0.9
         let repetitionPenalty = Double(store.chatRepPenaltyText) ?? 1.1
-        let chatMLPrompt = renderChatML(newUserText: rawUserText)
+        let chatMLPrompt = renderChatML(newUserText: rawUserText, enableThinking: store.chatEnableThinking)
         let useGPU = store.chatUseGPU
 
         // For Q4 models on the GPU path: the tokenizer lives in the bf16 sibling directory.
@@ -919,9 +990,15 @@ struct ChatScreen: View {
         store.chatUserStoppedTurnID = nil
 
         let responseText: String
+        let thinkingText: String
         if !run.genText.isEmpty {
-            responseText = run.genText.trimmingCharacters(in: .whitespacesAndNewlines)
+            let parsed = splitThinking(run.genText)
+            thinkingText = parsed.thinking
+            responseText = parsed.response.isEmpty
+                ? run.genText.trimmingCharacters(in: .whitespacesAndNewlines)  // no </think> closed yet → show raw
+                : parsed.response
         } else {
+            thinkingText = ""
             let cleaned = run.log
                 .filter { !$0.hasPrefix("$ ") }
                 .joined(separator: "\n")
@@ -935,6 +1012,7 @@ struct ChatScreen: View {
         }
 
         store.chatTurns[idx].responseText = responseText
+        store.chatTurns[idx].thinkingText = thinkingText
 
         if wasUserStopped {
             store.chatTurns[idx].status = .done

--- a/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
+++ b/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
@@ -142,7 +142,11 @@ struct ChatScreen: View {
             guard let turnID = store.chatAwaitingTurnID,
                   let idx = store.chatTurns.firstIndex(where: { $0.id == turnID })
             else { return }
-            let parsed = splitThinking(newText ?? "")
+            // Same prefill-aware split as finalization: while reasoning (thinking-on, no
+            // </think> yet) the stream stays in the thinking area instead of flashing in the
+            // answer bubble and then vanishing when resolveTurn corrects it.
+            let parsed = ChatFinalization.finalize(newText ?? "",
+                                                   prefilledOpenThink: store.chatTurns[idx].prefilledOpenThink)
             store.chatTurns[idx].thinkingText = parsed.thinking
             store.chatTurns[idx].responseText = parsed.response
         }
@@ -818,29 +822,7 @@ struct ChatScreen: View {
         return buf
     }
 
-    /// Split a cumulative generation string into (thinking, response) on the <think>…</think> boundary.
-    /// - If `</think>` is present: text before it (minus a leading `<think>`) is thinking; text after is response.
-    /// - If only `<think>` is present (still reasoning): everything after it is thinking; response is empty.
-    /// - If neither tag is present: all of it is the response; thinking is empty.
-    /// Always parses the FULL cumulative string, so a tag split across token deltas resolves on the next delta.
-    private func splitThinking(_ raw: String) -> (thinking: String, response: String) {
-        let openTag = "<think>"
-        let closeTag = "</think>"
-        if let closeRange = raw.range(of: closeTag) {
-            var thinking = String(raw[raw.startIndex..<closeRange.lowerBound])
-            if let openRange = thinking.range(of: openTag) {
-                thinking = String(thinking[openRange.upperBound...])
-            }
-            let response = String(raw[closeRange.upperBound...])
-            return (thinking.trimmingCharacters(in: .whitespacesAndNewlines),
-                    response.trimmingCharacters(in: .whitespacesAndNewlines))
-        }
-        if let openRange = raw.range(of: openTag) {
-            let thinking = String(raw[openRange.upperBound...])
-            return (thinking.trimmingCharacters(in: .whitespacesAndNewlines), "")
-        }
-        return ("", raw.trimmingCharacters(in: .whitespacesAndNewlines))
-    }
+    // Reasoning split/finalization lives in ChatFinalization (pure, unit-tested).
 
     // MARK: Single-mode send
 
@@ -902,6 +884,10 @@ struct ChatScreen: View {
         var turn = ChatTurn(prompt: rawUserText)
         turn.retryConfig = retryCfg
         turn.inferenceLabel = inferenceLabel
+        // Thinking-on prefills an open <think> into the prompt (renderChatML), so a truncated
+        // reasoning stream is tagless. Snapshot the mode so finalization treats such a stream
+        // as unfinished reasoning rather than the answer (prevents history poisoning).
+        turn.prefilledOpenThink = store.chatEnableThinking
         let turnID = turn.id
         store.chatTurns.append(turn)
         store.chatAwaitingTurnID = turnID
@@ -996,23 +982,14 @@ struct ChatScreen: View {
         let responseText: String
         let thinkingText: String
         if !run.genText.isEmpty {
-            let parsed = splitThinking(run.genText)
+            // Prefill-aware finalization. When thinking was prefilled (open <think> in the
+            // prompt) and the stream has no </think>, the whole stream is unfinished reasoning,
+            // not the answer — keep it as thinkingText and leave responseText empty so the turn
+            // is skipped from history (renderChatML gates history on non-empty responseText).
+            let parsed = ChatFinalization.finalize(run.genText,
+                                                   prefilledOpenThink: store.chatTurns[idx].prefilledOpenThink)
             thinkingText = parsed.thinking
-            if !parsed.response.isEmpty {
-                responseText = parsed.response
-            } else if parsed.thinking.isEmpty {
-                // No <think> tags at all → the raw stream is the answer.
-                responseText = run.genText.trimmingCharacters(in: .whitespacesAndNewlines)
-            } else {
-                // Thinking present but no final answer: generation ended before
-                // </think> (max tokens / stop / model quirk), or produced empty
-                // post-think output. Do NOT fall back to raw genText — that leaves
-                // a raw "<think>…" in the response bubble and, worse, re-injects it
-                // as assistant history on the next turn (history uses responseText,
-                // gated on non-empty). Keep the parsed reasoning; leave the response
-                // empty so the unfinished turn is skipped from history.
-                responseText = ""
-            }
+            responseText = parsed.response
         } else {
             thinkingText = ""
             let cleaned = run.log

--- a/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
+++ b/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
@@ -805,7 +805,11 @@ struct ChatScreen: View {
         }
         buf += "<|im_start|>user\n\(newUserText)<|im_end|>\n"
         if enableThinking {
-            buf += "<|im_start|>assistant\n"
+            // Open think block = the official template's enable_thinking=true path
+            // (chat_template.jinja:152). A thinking checkpoint continues inside the block
+            // and closes with </think> before the answer; renderChatML's split keys on that
+            // boundary. A non-thinking checkpoint ignores the prefix and answers directly.
+            buf += "<|im_start|>assistant\n<think>\n"
         } else {
             // Closed empty think block = the official template's enable_thinking=false path;
             // the model emits the answer directly with no reasoning.

--- a/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
+++ b/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
@@ -998,9 +998,21 @@ struct ChatScreen: View {
         if !run.genText.isEmpty {
             let parsed = splitThinking(run.genText)
             thinkingText = parsed.thinking
-            responseText = parsed.response.isEmpty
-                ? run.genText.trimmingCharacters(in: .whitespacesAndNewlines)  // no </think> closed yet → show raw
-                : parsed.response
+            if !parsed.response.isEmpty {
+                responseText = parsed.response
+            } else if parsed.thinking.isEmpty {
+                // No <think> tags at all → the raw stream is the answer.
+                responseText = run.genText.trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                // Thinking present but no final answer: generation ended before
+                // </think> (max tokens / stop / model quirk), or produced empty
+                // post-think output. Do NOT fall back to raw genText — that leaves
+                // a raw "<think>…" in the response bubble and, worse, re-injects it
+                // as assistant history on the next turn (history uses responseText,
+                // gated on non-empty). Keep the parsed reasoning; leave the response
+                // empty so the unfinished turn is skipped from history.
+                responseText = ""
+            }
         } else {
             thinkingText = ""
             let cleaned = run.log

--- a/apps/macos/Sources/LatticeStudio/Store/AppStore.swift
+++ b/apps/macos/Sources/LatticeStudio/Store/AppStore.swift
@@ -57,6 +57,7 @@ final class AppStore {
     var chatTopKText: String = "50"
     var chatTopPText: String = "0.9"
     var chatRepPenaltyText: String = "1.1"
+    var chatEnableThinking: Bool = true
     // In-flight tracking — must be store-owned so a generation that finishes while
     // the user is on another screen still lands in chatTurns.
     var chatAwaitingTurnID: UUID? = nil

--- a/apps/macos/Sources/LatticeStudio/Store/DomainModels.swift
+++ b/apps/macos/Sources/LatticeStudio/Store/DomainModels.swift
@@ -193,6 +193,13 @@ struct ChatTurn: Identifiable {
     /// Honest hardware label, snapshotted at send time: "GPU Metal bf16", "CPU bf16", etc.
     /// Never updated after the run starts — what launched is what ran.
     var inferenceLabel: String? = nil
+    /// Whether this turn's prompt PREFILLED an open `<think>` block (the enable_thinking=true
+    /// path in renderChatML). When true the model's stream carries no opening tag — it begins
+    /// mid-reasoning and only emits `</think>` before the answer — so a completed stream with
+    /// no `</think>` boundary is unfinished reasoning, not the answer. Finalization keeps it as
+    /// thinkingText and leaves responseText empty so the unfinished turn is skipped from history.
+    /// Snapshotted at send time (Retry mutates the turn in place and keeps this flag).
+    var prefilledOpenThink: Bool = false
 }
 
 /// The generation parameters needed to retry a failed/empty turn.

--- a/apps/macos/Sources/LatticeStudio/Store/DomainModels.swift
+++ b/apps/macos/Sources/LatticeStudio/Store/DomainModels.swift
@@ -180,6 +180,9 @@ struct ChatTurn: Identifiable {
     let id = UUID()
     let prompt: String
     var responseText: String = ""
+    /// Reasoning trace parsed from the <think>…</think> block in the stream.
+    /// Empty when the turn has no reasoning (thinking disabled, or model emitted none).
+    var thinkingText: String = ""
     var status: TurnStatus = .running
     var tokensPerSecond: Double? = nil
     /// Error message from the run log — set when the turn finishes with an empty response.

--- a/apps/macos/Tests/LatticeStudioTests/ChatFinalizationTests.swift
+++ b/apps/macos/Tests/LatticeStudioTests/ChatFinalizationTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import LatticeStudio
+
+final class ChatFinalizationTests: XCTestCase {
+
+    // MARK: - finalize: prefill-aware (the history-poisoning fix)
+
+    /// Thinking-on prefills "<think>\n" into the PROMPT, so a truncated reasoning stream is
+    /// tagless in genText. It must be treated as unfinished reasoning, NOT the answer — an empty
+    /// response is the signal that renderChatML skips this turn from history (history gates on a
+    /// non-empty responseText). This is the exact regression codex flagged on PR #428 round-2.
+    func testThinkingOnTruncatedTaglessReasoningIsNotAnswer() {
+        let (thinking, response) = ChatFinalization.finalize(
+            "partial reasoning", prefilledOpenThink: true)
+        XCTAssertEqual(thinking, "partial reasoning")
+        XCTAssertEqual(response, "", "tagless reasoning must not become the answer (history poisoning)")
+    }
+
+    /// Thinking-on, complete stream: model emits reasoning then closes with </think> before the
+    /// answer. No leading <think> in genText (it was prefilled into the prompt), so the splitter
+    /// keys on </think> alone.
+    func testThinkingOnCompleteSplitsOnCloseTag() {
+        let (thinking, response) = ChatFinalization.finalize(
+            "reasoning here</think>the answer", prefilledOpenThink: true)
+        XCTAssertEqual(thinking, "reasoning here")
+        XCTAssertEqual(response, "the answer")
+    }
+
+    /// Thinking-on, closed reasoning but no answer text after </think> (max tokens / stop right
+    /// at the boundary). Reasoning is kept; response empty so the turn is skipped from history.
+    func testThinkingOnClosedButEmptyAnswer() {
+        let (thinking, response) = ChatFinalization.finalize(
+            "reasoning here</think>", prefilledOpenThink: true)
+        XCTAssertEqual(thinking, "reasoning here")
+        XCTAssertEqual(response, "")
+    }
+
+    /// Thinking-off: prompt prefills a CLOSED empty block, model answers directly with no tags.
+    /// The raw stream IS the answer (prefilledOpenThink is false on this path).
+    func testThinkingOffTaglessIsAnswer() {
+        let (thinking, response) = ChatFinalization.finalize(
+            "the direct answer", prefilledOpenThink: false)
+        XCTAssertEqual(thinking, "")
+        XCTAssertEqual(response, "the direct answer")
+    }
+
+    /// In-stream open <think> that never closes (model re-emitted the tag and was truncated):
+    /// everything after the open tag is reasoning, response empty — regardless of prefill flag.
+    func testInStreamOpenTagNeverClosedIsReasoning() {
+        let (thinking, response) = ChatFinalization.finalize(
+            "<think>\nstill reasoning", prefilledOpenThink: false)
+        XCTAssertEqual(thinking, "still reasoning")
+        XCTAssertEqual(response, "")
+    }
+
+    // MARK: - split: pure tag splitter
+
+    func testSplitClosedBlock() {
+        let (thinking, response) = ChatFinalization.split("<think>reasons</think>answer")
+        XCTAssertEqual(thinking, "reasons")
+        XCTAssertEqual(response, "answer")
+    }
+
+    func testSplitNoTags() {
+        let (thinking, response) = ChatFinalization.split("just text")
+        XCTAssertEqual(thinking, "")
+        XCTAssertEqual(response, "just text")
+    }
+}


### PR DESCRIPTION
## Summary

Qwen3.6 emits its chain-of-thought wrapped in literal `<think>…</think>` tags directly into the `gen_token` stream. Previously the whole stream (reasoning + final answer) landed in one chat bubble, and there was no way to turn reasoning off. This adds a reasoning toggle and separates the two views.

Verified mechanism first (no engine change needed): `chat_metal`'s `generate_streaming` tokenizes `--prompt` **raw**, and `GenerateConfig.enable_thinking` is set but never read by the generator. So thinking control is entirely app-side — prompt construction + stream parsing.

## Changes (app-only, `apps/macos/`)

- **`ChatTurn.thinkingText`** — new field holding the reasoning trace parsed out of the stream.
- **`splitThinking`** — splits the cumulative generation string at `</think>` into `(thinking, response)`. Handles closed-tag, open-tag-only (still streaming), and no-tag cases; re-parses the full cumulative string each delta so a tag split across tokens resolves naturally.
- **Reasoning On/Off** — a `ParamRowPicker` in the chat inspector. Off injects a closed `<|im_start|>assistant\n<think>\n\n</think>\n\n` prefix (the official chat template's `enable_thinking=false` path) so the model answers directly with no reasoning. On = plain assistant prefix; the model emits its own `<think>`.
- **Separate views** — a collapsible "Reasoning" disclosure (auto-expands while it streams, collapsible after) renders above the final-answer bubble whenever a turn produced reasoning.
- **History correctness** — ChatML history uses `responseText` (answer only), so prior-turn reasoning is correctly dropped from context.

## Gate

`cd apps/macos && swift build` → `Build complete!` No engine code touched; `crates/` unchanged.