### PR TITLE
fix(inference): render non-special added tokens in detokenizer (qwen3.6 think-tag bug)

### DIFF
--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -8,7 +8,8 @@ use crate::error::InferenceError;
 use crate::tokenizer::common::{
     JsonValue, ThreadSafeLruCache, TokenizedInput, Tokenizer, invert_vocab, json_object_to_vocab,
     json_path, known_special_id, pad_ids, parse_added_tokens, parse_json,
-    parse_post_processor_flags, push_eos_preserving_limit, vocab_txt_to_map,
+    parse_post_processor_flags, parse_rendered_added_tokens, push_eos_preserving_limit,
+    vocab_txt_to_map,
 };
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
@@ -40,6 +41,12 @@ struct BpeInner {
     byte_encoder: Vec<char>,
     special_tokens: HashMap<String, u32>,
     special_tokens_sorted: Vec<String>,
+    /// Decode-side map for added tokens with `special=false` (`<think>`/`</think>`,
+    /// `<tool_call>`, FIM markers). These ids are absent from the base BPE `vocab`,
+    /// so `token_for_id` falls back to this map to render them as literal text
+    /// instead of silently dropping them. `special=true` markers are deliberately
+    /// excluded so they stay swallowed (matching `skip_special_tokens=True`).
+    added_render: HashMap<u32, String>,
     pad_id: u32,
     unk_id: Option<u32>,
     bos_id: Option<u32>,
@@ -152,11 +159,13 @@ impl BpeTokenizer {
         })?;
         let merges = parse_merges_json(merges_value)?;
         let added = parse_added_tokens(&root);
+        let rendered_added = parse_rendered_added_tokens(&root);
 
         let mut tokenizer = Self::from_vocab_and_merges_with_config(
             vocab,
             merges,
             added,
+            rendered_added,
             DEFAULT_BPE_CACHE_CAPACITY,
             DEFAULT_BPE_MAX_SEQ_LEN,
         )?;
@@ -191,6 +200,7 @@ impl BpeTokenizer {
             vocab,
             merges,
             HashMap::new(),
+            HashMap::new(),
             DEFAULT_BPE_CACHE_CAPACITY,
             DEFAULT_BPE_MAX_SEQ_LEN,
         )
@@ -200,10 +210,18 @@ impl BpeTokenizer {
         vocab: HashMap<String, u32>,
         merges: Vec<(String, String)>,
         added_tokens: HashMap<String, u32>,
+        rendered_added: HashMap<String, u32>,
         cache_capacity: usize,
         max_seq_len: usize,
     ) -> Result<Self, InferenceError> {
         let id_to_token = invert_vocab(&vocab)?;
+        // Invert the renderable added-token set to id -> content for decode-side
+        // lookup. Built once at construction; consulted by `token_for_id` only
+        // when the base table misses (added-token ids exceed the base vocab range).
+        let added_render: HashMap<u32, String> = rendered_added
+            .into_iter()
+            .map(|(content, id)| (id, content))
+            .collect();
         let mut merge_ranks: HashMap<String, HashMap<String, usize>> = HashMap::new();
         for (rank, (left, right)) in merges.into_iter().enumerate() {
             // First occurrence defines the rank: merges are listed in priority
@@ -256,6 +274,7 @@ impl BpeTokenizer {
             byte_encoder: bytes_to_unicode(),
             special_tokens,
             special_tokens_sorted,
+            added_render,
             pad_id,
             unk_id,
             bos_id,
@@ -281,6 +300,7 @@ impl BpeTokenizer {
             byte_encoder: self.inner.byte_encoder.clone(),
             special_tokens: self.inner.special_tokens.clone(),
             special_tokens_sorted: self.inner.special_tokens_sorted.clone(),
+            added_render: self.inner.added_render.clone(),
             pad_id: self.inner.pad_id,
             unk_id: self.inner.unk_id,
             bos_id: self.inner.bos_id,
@@ -306,6 +326,7 @@ impl BpeTokenizer {
             byte_encoder: self.inner.byte_encoder.clone(),
             special_tokens: self.inner.special_tokens.clone(),
             special_tokens_sorted: self.inner.special_tokens_sorted.clone(),
+            added_render: self.inner.added_render.clone(),
             pad_id: self.inner.pad_id,
             unk_id,
             bos_id: self.inner.bos_id,
@@ -335,6 +356,7 @@ impl BpeTokenizer {
             byte_encoder: self.inner.byte_encoder.clone(),
             special_tokens: self.inner.special_tokens.clone(),
             special_tokens_sorted: self.inner.special_tokens_sorted.clone(),
+            added_render: self.inner.added_render.clone(),
             pad_id: self.inner.pad_id,
             unk_id: self.inner.unk_id,
             bos_id: self.inner.bos_id,
@@ -358,6 +380,7 @@ impl BpeTokenizer {
             byte_encoder: self.inner.byte_encoder.clone(),
             special_tokens: self.inner.special_tokens.clone(),
             special_tokens_sorted: self.inner.special_tokens_sorted.clone(),
+            added_render: self.inner.added_render.clone(),
             pad_id: self.inner.pad_id,
             unk_id: self.inner.unk_id,
             bos_id: self.inner.bos_id,
@@ -381,6 +404,7 @@ impl BpeTokenizer {
             byte_encoder: self.inner.byte_encoder.clone(),
             special_tokens: self.inner.special_tokens.clone(),
             special_tokens_sorted: self.inner.special_tokens_sorted.clone(),
+            added_render: self.inner.added_render.clone(),
             pad_id: self.inner.pad_id,
             unk_id: self.inner.unk_id,
             bos_id: self.inner.bos_id,
@@ -410,7 +434,15 @@ impl BpeTokenizer {
     ///
     /// Reverse lookup for debugging.
     pub fn token_for_id(&self, id: u32) -> Option<&str> {
-        self.inner.id_to_token.get(id as usize).map(String::as_str)
+        // Base vocab first; added tokens with `special=false` (think/tool/FIM
+        // markers) live beyond the base range, so fall back to `added_render` to
+        // render them as text instead of dropping them. `special=true` markers
+        // are absent from both maps and stay swallowed.
+        self.inner
+            .id_to_token
+            .get(id as usize)
+            .map(String::as_str)
+            .or_else(|| self.inner.added_render.get(&id).map(String::as_str))
     }
 
     /// **Unstable**: look up special token ID by name; set of known special tokens may change.
@@ -1186,6 +1218,7 @@ mod tests {
             vocab,
             Vec::new(),
             added,
+            HashMap::new(),
             DEFAULT_BPE_CACHE_CAPACITY,
             DEFAULT_BPE_MAX_SEQ_LEN,
         )
@@ -1241,6 +1274,100 @@ mod tests {
         // prior generate.rs detokenize block discarded the text entirely.
         assert_eq!(tokenizer.decode(&ids), Some("hello world".to_string()));
         assert_eq!(tokenizer.decode(&[]), Some(String::new()));
+    }
+
+    #[test]
+    fn test_decode_renders_nonspecial_added_tokens() {
+        // Regression (qwen3.6-27b think-tag bug): added tokens with special=false
+        // (`</think>`, `<tool_call>`, FIM markers) live BEYOND the base vocab range,
+        // so before the fix `token_for_id` returned None and they decoded to the
+        // empty string — silently swallowed from the output stream even though the
+        // model sampled them correctly. They must now render as their literal text.
+        // special=true markers (im_end-style) must STILL be swallowed.
+        let mut vocab = HashMap::new();
+        for (s, i) in [("a", 0u32), ("b", 1), ("c", 2)] {
+            vocab.insert(s.to_string(), i);
+        }
+        // rendered_added = the special=false subset (content -> id), ids past base max.
+        let mut rendered = HashMap::new();
+        rendered.insert("</think>".to_string(), 100u32);
+        rendered.insert("<think>".to_string(), 101u32);
+        rendered.insert("<tool_call>".to_string(), 102u32);
+
+        let tokenizer = BpeTokenizer::from_vocab_and_merges_with_config(
+            vocab,
+            Vec::new(),
+            HashMap::new(),
+            rendered,
+            DEFAULT_BPE_CACHE_CAPACITY,
+            DEFAULT_BPE_MAX_SEQ_LEN,
+        )
+        .expect("construct tokenizer with rendered added tokens");
+
+        // special=false added tokens render verbatim (byte-level decode is identity
+        // for printable ASCII).
+        assert_eq!(tokenizer.decode(&[101]), Some("<think>".to_string()));
+        assert_eq!(tokenizer.decode(&[100]), Some("</think>".to_string()));
+        assert_eq!(tokenizer.decode(&[102]), Some("<tool_call>".to_string()));
+        // Mixed with base content tokens, in stream order.
+        assert_eq!(
+            tokenizer.decode(&[0, 1, 100, 2]),
+            Some("ab</think>c".to_string())
+        );
+        // An id present in neither base vocab nor the rendered set (e.g. a
+        // special=true marker) stays swallowed — token_for_id returns None.
+        assert_eq!(tokenizer.decode(&[200]), Some(String::new()));
+
+        // The incremental streaming detokenizer must agree byte-for-byte.
+        use crate::model::qwen35::detokenize::IncrementalDetokenizer;
+        let mut detok = IncrementalDetokenizer::new();
+        let mut out = String::new();
+        for id in [0u32, 100, 1] {
+            out.push_str(&detok.push(&tokenizer, id));
+        }
+        out.push_str(&detok.finish());
+        assert_eq!(out, "a</think>b");
+    }
+
+    #[test]
+    fn test_from_tokenizer_json_renders_real_qwen_think_tags() {
+        // End-to-end regression gate for the qwen3.6 think-tag detok bug, driving
+        // the REAL public loader (`from_tokenizer_json_str`) with the EXACT added-token
+        // ids and special flags from the shipped qwen tokenizer.json (verified identical
+        // on both qwen3.5-0.8b and qwen3.6-27b): `<think>`=248068, `</think>`=248069 are
+        // special=false and live FAR above the base vocab max (248043). This exercises
+        // the full wiring parse_rendered_added_tokens → added_render → token_for_id →
+        // decode; a token-level parity gate (e2e-parity compares token IDS) is BLIND to
+        // this class because the ids matched while the rendered text dropped the tag.
+        let json = r#"{
+            "model": {
+                "type": "BPE",
+                "vocab": {"a": 0, "b": 1},
+                "merges": []
+            },
+            "added_tokens": [
+                {"id": 248045, "content": "<|im_start|>", "special": true},
+                {"id": 248046, "content": "<|im_end|>", "special": true},
+                {"id": 248058, "content": "<tool_call>", "special": false},
+                {"id": 248068, "content": "<think>", "special": false},
+                {"id": 248069, "content": "</think>", "special": false}
+            ]
+        }"#;
+        let tokenizer =
+            BpeTokenizer::from_tokenizer_json_str(json).expect("load tokenizer.json fixture");
+
+        // special=false think/tool tags render verbatim (the bug: these were swallowed).
+        assert_eq!(tokenizer.decode(&[248069]), Some("</think>".to_string()));
+        assert_eq!(tokenizer.decode(&[248068]), Some("<think>".to_string()));
+        assert_eq!(tokenizer.decode(&[248058]), Some("<tool_call>".to_string()));
+        // special=true chat-control markers stay swallowed (HF skip_special_tokens=True).
+        assert_eq!(tokenizer.decode(&[248046]), Some(String::new()));
+        assert_eq!(tokenizer.decode(&[248045]), Some(String::new()));
+        // A close tag mid-stream between base content tokens renders in order.
+        assert_eq!(
+            tokenizer.decode(&[0, 248069, 1]),
+            Some("a</think>b".to_string())
+        );
     }
 
     #[test]

--- a/crates/inference/src/tokenizer/common.rs
+++ b/crates/inference/src/tokenizer/common.rs
@@ -779,6 +779,49 @@ pub(crate) fn parse_added_tokens(root: &JsonValue) -> HashMap<String, u32> {
     tokens
 }
 
+/// Parse the subset of `added_tokens` that should be **rendered as literal text**
+/// when decoding, i.e. those whose `"special"` flag is `false` (or absent).
+///
+/// HF's `decode(skip_special_tokens=True)` — the chat default — skips only the
+/// `special=true` set (control/chat/vision markers like `<|im_end|>`), while
+/// `special=false` added tokens (`<think>`/`</think>`, `<tool_call>`, FIM markers)
+/// are emitted verbatim. The base BPE vocab does not contain any added-token ids,
+/// so without this map their decode falls through to nothing and they are silently
+/// swallowed from the output stream. Returns `content -> id`.
+pub(crate) fn parse_rendered_added_tokens(root: &JsonValue) -> HashMap<String, u32> {
+    let mut tokens = HashMap::new();
+    let Some(array) = root.get("added_tokens").and_then(JsonValue::as_array) else {
+        return tokens;
+    };
+
+    for item in array {
+        let Some(object) = item.as_object() else {
+            continue;
+        };
+        // Absent "special" defaults to false (matches HF AddedToken), so render it.
+        if object
+            .get("special")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let Some(content) = object.get("content").and_then(JsonValue::as_str) else {
+            continue;
+        };
+        let Some(id) = object
+            .get("id")
+            .and_then(JsonValue::as_u64)
+            .and_then(|v| u32::try_from(v).ok())
+        else {
+            continue;
+        };
+        tokens.insert(content.to_string(), id);
+    }
+
+    tokens
+}
+
 pub(crate) fn known_special_id(vocab: &HashMap<String, u32>, names: &[&str]) -> Option<u32> {
     names.iter().find_map(|name| vocab.get(*name).copied())
 }
@@ -1010,6 +1053,31 @@ mod tests {
             Some(1)
         );
         assert_eq!(parse_added_tokens(&json).get("<bos>").copied(), Some(42));
+    }
+
+    #[test]
+    fn test_parse_rendered_added_tokens_filters_special() {
+        let json = parse_json(
+            r#"{
+                "added_tokens": [
+                    {"id": 1, "content": "<|im_start|>", "special": true},
+                    {"id": 2, "content": "</think>", "special": false},
+                    {"id": 3, "content": "<think>"},
+                    {"id": 4, "content": "<tool_call>", "special": false}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let rendered = parse_rendered_added_tokens(&json);
+        // special=true is excluded (HF skip_special_tokens=True swallows it).
+        assert_eq!(rendered.get("<|im_start|>"), None);
+        // special=false renders verbatim.
+        assert_eq!(rendered.get("</think>").copied(), Some(2));
+        // absent special field defaults to false → renders.
+        assert_eq!(rendered.get("<think>").copied(), Some(3));
+        assert_eq!(rendered.get("<tool_call>").copied(), Some(4));
+        assert_eq!(rendered.len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
Scope-clean replacement for #429 (which was accidentally stacked on the `feat/chat-thinking-mode` branch and carried 3 unrelated macOS files — review flagged the scope mismatch; the tokenizer fix itself had review issues addressed, with a mutation test confirming the gates are real). This branch is cut from `origin/main` and contains **only** the two tokenizer files.

## The bug

`qwen3.6-27b-q4` / `qwen3.5-0.8b` (identical tokenizer shape) appeared to never emit `<think>`/`</think>`. Disproven hypotheses (empirically, this session): not a non-thinking checkpoint, not logit suppression — a `bench_logit_dump` showed the forward ranks `</think>` (id 248069) as **argmax** (logit 21.497) and the sampler picks it.

**Real cause = detokenizer.** `id_to_token` is built from `model.vocab` only (base max id 248043), so the 26 `added_tokens` (248044-248069) were absent. `token_for_id(248069)` returned `None` → the close tag contributed zero bytes → `</think>` silently swallowed; the visible `\n\n` was the next token.

## The fix (HF-faithful)

HF `decode(skip_special_tokens=True)` skips only `special=true` added tokens; `special=false` ones (`<think>`, `</think>`, `<tool_call>`, FIM markers) render verbatim. `parse_rendered_added_tokens` parses the `special != true` subset; BPE stores an `added_render` (id→content) map threaded through the constructor + 5 builders; `token_for_id` falls back to it. **Isolated** from `id_to_token`/`vocab_size()`/`vocab_bytes()`/grammar — review verified no leak into sizing, grammar masks, or encoding.

## Regression gate (text-level, model-free, Metal-free)

e2e-parity compares **token IDs** and is structurally blind to this class — the ids matched while the rendered text dropped the tag. New gates assert **text rendering** in the normal CPU `cargo test` job:
- `test_from_tokenizer_json_renders_real_qwen_think_tags` — drives the real loader `from_tokenizer_json_str` with the **exact shipped qwen added-token ids/flags**; `</think>`/`<think>`/`<tool_call>` render, `<|im_end|>`/`<|im_start|>` stay swallowed. (Mutation-tested: removing only the `token_for_id` fallback makes this fail with `Some("")`.)
- `test_parse_rendered_added_tokens_filters_special`, `test_decode_renders_nonspecial_added_tokens` (parser + decode/streaming).

## E2E verification

Forcing prompt, greedy, q4 27B on Metal — first generated token is now `</think>`, then `\n\n`, then `Hello! ...`. Before: stream began at `\n\n` (tag swallowed).

## bench-compare

Not meaningful: change is confined to the detok path (one `HashMap` fallback in `token_for_id`, once per generated token), off every Criterion group and the forward/embed hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)