### PR TITLE
feat(tune): --save flag to persist trained LoRA as PEFT safetensors

### DIFF
--- a/crates/tune/src/bin/train_grad_layer23.rs
+++ b/crates/tune/src/bin/train_grad_layer23.rs
@@ -64,7 +64,7 @@ Options:
   --seq-len    <N>      Max tokens per sample (default: 64)
   --max-train  <N>      Training samples cap (default: 3)
   --log-every  <N>      Print NLL every N steps (default: 5)
-  --save       <PATH>   Save trained adapter as PEFT safetensors (needs --features safetensors)
+  --save       <PATH>   Save trained adapter as PEFT safetensors (requires --features train-backward)
   -h, --help            Print this help"
     );
 }
@@ -736,7 +736,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(not(feature = "safetensors"))]
         {
             let _ = save_path;
-            return Err("--save requires building with --features safetensors".into());
+            return Err("--save requires building with --features train-backward".into());
         }
     }
 

--- a/crates/tune/src/bin/train_grad_layer23.rs
+++ b/crates/tune/src/bin/train_grad_layer23.rs
@@ -64,6 +64,7 @@ Options:
   --seq-len    <N>      Max tokens per sample (default: 64)
   --max-train  <N>      Training samples cap (default: 3)
   --log-every  <N>      Print NLL every N steps (default: 5)
+  --save       <PATH>   Save trained adapter as PEFT safetensors (needs --features safetensors)
   -h, --help            Print this help"
     );
 }
@@ -433,6 +434,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let log_every: usize = parse_arg(&args, "--log-every")
         .and_then(|s| s.parse().ok())
         .unwrap_or(5);
+    let save_path = parse_arg(&args, "--save");
 
     println!("=== exact-gradient LoRA trainer (layer {LAYER}, gated GQA) ===");
     println!("model-dir:  {}", model_dir.display());
@@ -689,5 +691,54 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         final_nll - base_nll,
         tstep.elapsed().as_secs_f64()
     );
+
+    // Persist the trained low-rank factors as a PEFT-format adapter. The trainer
+    // stores B as row-major [d_out, rank] and A as [rank, d_in] (see ops::lora_vjp),
+    // which is exactly LoraLayer's convention -- no transpose. q_proj is gated, so
+    // its d_out spans the full 2*q_dim output (Q rows + gate rows).
+    if let Some(save_path) = save_path.as_deref() {
+        #[cfg(feature = "safetensors")]
+        {
+            use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer};
+            use std::collections::HashMap;
+            let mut layers = HashMap::new();
+            layers.insert(
+                (LAYER, "q_proj".to_string()),
+                LoraLayer {
+                    a: lora_a_q.clone(),
+                    b: lora_b_q.clone(),
+                    d_in: dims.hidden,
+                    d_out: 2 * q_dim,
+                    rank,
+                },
+            );
+            layers.insert(
+                (LAYER, "v_proj".to_string()),
+                LoraLayer {
+                    a: lora_a_v.clone(),
+                    b: lora_b_v.clone(),
+                    d_in: dims.hidden,
+                    d_out: kv_dim,
+                    rank,
+                },
+            );
+            let config = LoraConfig {
+                rank,
+                alpha,
+                target_modules: vec!["q_proj".to_string(), "v_proj".to_string()],
+            };
+            let adapter = LoraAdapter::new(config, layers);
+            adapter
+                .save_safetensors(std::path::Path::new(save_path))
+                .map_err(|e| format!("save adapter: {e}"))?;
+            println!("saved adapter (layer {LAYER}, q_proj+v_proj, rank {rank}) → {save_path}");
+        }
+        #[cfg(not(feature = "safetensors"))]
+        {
+            let _ = save_path;
+            return Err("--save requires building with --features safetensors".into());
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## What

Adds a `--save <path>` flag to `train_grad_layer23` that serializes the trained
LoRA factors as a PEFT-format safetensors file via the tune crate's existing
`LoraAdapter::save_safetensors`. The trainer previously ran NLL down purely
in-memory, so a trained adapter could never be loaded back for inference. This
closes the **train → save → load → infer** loop in pure Rust/Metal.

## Layout correctness

Verified against `ops::lora_vjp` (the gradient kernel the trainer already uses):

| factor | trainer storage | LoraLayer convention | transpose? |
|--------|-----------------|----------------------|------------|
| A (q/v) | row-major `[rank, d_in]` | `[rank, d_in]` | none |
| B (q/v) | row-major `[d_out, rank]` | `[d_out, rank]` | none |

`q_proj` is **gated** (Qwen3.5/3.6), so its `d_out` spans the full `2*q_dim`
output (Q rows + gate rows); `v_proj` `d_out = kv_dim`; both `lora_A d_in = hidden`.
The save block is gated on the `safetensors` feature, already pulled in
transitively by `train-backward` (this binary's required feature).

## Empirical end-to-end validation

Trained on a single overfit example, saved, then loaded via `chat_metal --lora`
on the **Metal** path (a fully separate code path from the CPU trainer):

```
TBV gate:  model NLL 5.39393 == chain NLL 5.39393  (diff 9.5e-7)
training:  base NLL 5.3939 → final NLL 0.0001  (120 Adam steps)

greedy generation, same prompt:
  baseline (no LoRA):  "\n\n<think>\nHere's a thinking process that leads to
                        the suggested wave features..."
  with adapter:        "Real feature — let me read how waves is structured
                        before I add anything."  ← exact trained target, verbatim
```

The verbatim reproduction across the train/save/load/infer boundary (CPU
exact-gradient trainer → PEFT safetensors → Metal inference loader) confirms
all four tensor layouts are correct. Any transpose or mis-size would yield
garbage or no change. (The single-example overfit then loops because no EOS was
learned — expected, this is a layout-correctness demo, not a general fine-tune.)

## Scope

- One file, `crates/tune/src/bin/train_grad_layer23.rs`, +51 lines, additive.
- No change to `inference`/`embed` src → no bench-compare / e2e-parity impact.
- clippy `-D warnings` clean (train-backward feature); fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)