### PR TITLE
chore(release): prepare v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.4.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.4.1", path = "../inference", optional = true, features = ["f16"] }
 
 # Time
 chrono = { workspace = true }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -47,7 +47,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.4.0", path = "../fann", optional = true }
+lattice-fann = { version = "0.4.1", path = "../fann", optional = true }
 
 [[bin]]
 name = "lattice"

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -26,7 +26,7 @@ train-backward = ["dep:lattice-inference", "lattice-inference/train-backward", "
 sqlite = ["dep:rusqlite", "serde"]
 
 [dependencies]
-lattice-fann = { version = "0.4.0", path = "../fann" }
+lattice-fann = { version = "0.4.1", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -47,7 +47,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.4.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.4.1", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -1,44 +1,33 @@
 # v0.4.1
 
-Patch release over v0.4.0. No breaking changes: every public API keeps the shape it had in
-v0.4.0, so this is a drop-in upgrade. The release is two correctness fixes, two fail-closed
-hardening changes, and two additive features (plus a macOS Studio UX change that is not a
-published crate).
-
-## Fixes
-
-**Inference — GatedDeltaNet decay indexed per value head** (#427). The GDN decode path indexed
-the decay-gate parameters per *key* head instead of per *value* head. On models where the value
-and key head counts differ (Qwen3.6-27B), this read the wrong decay row and the recurrent state
-diverged, producing coherent-early / garbage-late decode collapse. Decay parameters are now
-indexed per value head, matching the reference layout. Models with symmetric head counts (e.g.
-Qwen3.5-0.8B) were unaffected and produce identical output.
-
-**Inference — detokenizer renders non-special added tokens** (#430). `id_to_token` was built
-only from the base vocabulary, so added control tokens above the base maximum (for Qwen3.5/3.6,
-the `<think>` / `</think>` reasoning markers and their siblings, ids 248044–248069) resolved to
-`None` and decoded to an empty string. Reasoning-model output therefore silently dropped its
-think-tags. The detokenizer now carries an `added_render` map for the non-`special` subset of
-added tokens, with a fallback in `token_for_id`, so these tokens detokenize to their literal
-text. The model's forward pass and sampler were already correct; this was a detokenization-only
-bug.
-
-## Hardening (fail-closed)
-
-**Inference — GDN decay-gate clamped finite across all forward paths** (#426). `exp(a_log)` in
-the GDN decay gate is now clamped with `min(exp(a_log), f32::MAX)` on every forward copy (CPU
-f16, Metal decode, NEON, fused, and batched prefill), matching the existing CPU reference. A
-non-finite decay would poison the recurrent state via `inf * 0 = NaN`. The clamp is a no-op for
-valid checkpoints; it only prevents NaN propagation on malformed or out-of-range inputs.
-
-**Inference — Q4 loader fails closed on metadata mismatch** (#415). The Q4 weight loader now
-rejects a tensor whose declared shape or `original_len` disagrees with the dequantized buffer,
-instead of proceeding with a mis-sized tensor.
+Patch release over v0.4.0. The headline is an adaptive LoRA serving stack: a weighted adapter
+mixture at decode time, a governed adapter manifest with a fail-closed loader, and an online
+router that refits from preference feedback. Alongside it, grammar-constrained decoding is now
+wired into the CPU generate paths, plus a batch of correctness fixes and fail-closed hardening
+across the inference engine. Every new capability is additive and feature-gated; existing v0.4.0
+call sites compile and behave unchanged.
 
 ## New (additive)
 
+**Inference — weighted LoRA adapter mixture at decode** (#443). Several LoRA adapters can be
+blended into a single effective adapter at decode time, weighted per adapter, with no Metal
+kernel change: rank is a runtime parameter, so the existing kernels stay rank-agnostic. The
+blend is computed on CPU by concatenating the A factors and weight-scaling the B factors, which
+is exact. Routing is gated behind the `mixture` feature.
+
+**Tune — governed LoRA manifest with a fail-closed loader** (#444). A schema-versioned manifest
+describes a set of adapters, each with a status (approved / quarantined / revoked), a SHA-256
+content hash, and the base-model and tokenizer revisions it was trained against. The loader runs
+an ordered set of fail-closed checks (status, content hash, base/tokenizer match, path
+confinement, layer bounds) and refuses to load anything that does not validate. Adds a micro-LoRA
+trainer entry point.
+
+**Fann — online router refit** (#448). The adapter router can refit from preference feedback
+using a single-sample policy-gradient update with an EWC++ regularizer to bound forgetting,
+together with a convergence benchmark.
+
 **Tune — `--save` persists a trained LoRA as PEFT safetensors** (#431). The exact-gradient LoRA
-trainer can now write its trained factors to a standard PEFT `.safetensors` adapter. The adapter
+trainer can write its trained factors to a standard PEFT `.safetensors` adapter. The adapter
 loads unchanged into both the CPU (`generate_lora`) and GPU Metal (`chat_metal --lora`)
 inference paths and steers generation exactly as trained.
 
@@ -53,13 +42,73 @@ streaming view and the completed-turn view agree on the think/answer boundary, i
 thinking-on truncated-stream case. `apps/macos` is not a published crate and is not versioned
 with this bump.
 
-## Diff scope
+## Grammar-constrained decoding
 
-7 commits since v0.4.0 (#415, #425, #426, #427, #428, #430, #431). No change to the
-`[workspace.package]` edition or MSRV. Internal path-dependency `version =` fields were bumped to
-`0.4.1` in lockstep with the workspace version.
+**Inference — grammar masking wired into the Qwen3.5 CPU generate paths** (#397). The existing
+`GenerateConfig::grammar` engine (present since v0.4.0, previously honored only on the Metal
+path) is now applied on the CPU `generate` and `generate_streaming` paths as well: logits are
+masked before sampling on every step and the grammar state advances on the emitted token, so the
+CPU and Metal paths agree on grammar-constrained output.
+
+**Inference — grammar masking fails closed** (#413 and related). An empty or all-blocking grammar
+mask now returns a clean `InvalidInput` error instead of sampling from an all-`-inf`
+distribution, and `CandidateSet::argmax` returns the first in-set token id on an all-masked set
+rather than an out-of-set id. The Q4/Q8 weight-quantizer class gained a non-finite scale guard in
+the same pass.
+
+## Fixes
+
+**Inference — GatedDeltaNet decay indexed per value head** (#427). The GDN decode path indexed
+the decay-gate parameters per *key* head instead of per *value* head. On models where the value
+and key head counts differ (Qwen3.6-27B), this read the wrong decay row and the recurrent state
+diverged, producing coherent-early / garbage-late decode collapse. Decay parameters are now
+indexed per value head, matching the reference layout. Models with symmetric head counts (e.g.
+Qwen3.5-0.8B) were unaffected and produce identical output.
+
+**Inference — detokenizer renders non-special added tokens** (#430). `id_to_token` was built only
+from the base vocabulary, so added control tokens above the base maximum (for Qwen3.5/3.6, the
+`<think>` / `</think>` reasoning markers and their siblings, ids 248044–248069) resolved to
+`None` and decoded to an empty string. Reasoning-model output therefore silently dropped its
+think-tags. The detokenizer now carries an `added_render` map for the non-`special` subset of
+added tokens, with a fallback in `token_for_id`, so these tokens detokenize to their literal
+text. The model's forward pass and sampler were already correct; this was a detokenization-only
+bug.
+
+**Inference — decode attention dispatched with the KV head count** (#459). The Metal decode
+attention dispatch used the query head count where it needed the key/value head count.
+
+## Hardening (fail-closed)
+
+**Inference — GDN decay-gate clamped finite across all forward paths** (#426). `exp(a_log)` in
+the GDN decay gate is now clamped with `min(exp(a_log), f32::MAX)` on every forward copy (CPU
+f16, Metal decode, NEON, fused, and batched prefill), matching the existing CPU reference. A
+non-finite decay would poison the recurrent state via `inf * 0 = NaN`. The clamp is a no-op for
+valid checkpoints; it only prevents NaN propagation on malformed or out-of-range inputs.
+
+**Inference — Q4 loader fails closed on metadata mismatch** (#415). The Q4 weight loader rejects a
+tensor whose declared shape or `original_len` disagrees with the dequantized buffer, instead of
+proceeding with a mis-sized tensor.
+
+**Inference — FlatKVCache public-API defense-in-depth** (#449). The public KV-cache API validates
+its inputs and fails closed on out-of-range access instead of indexing unchecked.
+
+## Docs and chores
+
+- Decode-throughput numbers in the README are clarified as decode-only slope estimates, with a
+  new section on why throughput falls as context grows (#463).
+- The embed SIMD distance surface is documented as a stable ANN consumer contract (#434).
+- The default training-data directory was renamed to `data/lora-train` (#447).
+
+## Versioning
+
+The workspace version and all internal path-dependency `version =` fields were bumped to `0.4.1`
+in lockstep (`lattice-inference`, `lattice-fann`, `lattice-transport`, `lattice-embed`,
+`lattice-tune`). No change to the `[workspace.package]` edition or MSRV.
 
 ## Compatibility
 
-No re-indexing or re-quantization is required. Existing v0.4.0 callers compile unchanged.
-`lattice-embed` forward output is unchanged from v0.4.0; existing vector indices remain valid.
+Drop-in over v0.4.0. The new LoRA serving capabilities are additive and feature-gated; grammar
+masking reuses the existing `GenerateConfig::grammar` field; the fixes and hardening change
+behavior only on the malformed or previously-incorrect inputs they address. No re-quantization or
+re-indexing is required, and `lattice-embed` forward output is unchanged from v0.4.0, so existing
+vector indices remain valid. Existing v0.4.0 callers compile unchanged.

--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -1,0 +1,65 @@
+# v0.4.1
+
+Patch release over v0.4.0. No breaking changes: every public API keeps the shape it had in
+v0.4.0, so this is a drop-in upgrade. The release is two correctness fixes, two fail-closed
+hardening changes, and two additive features (plus a macOS Studio UX change that is not a
+published crate).
+
+## Fixes
+
+**Inference — GatedDeltaNet decay indexed per value head** (#427). The GDN decode path indexed
+the decay-gate parameters per *key* head instead of per *value* head. On models where the value
+and key head counts differ (Qwen3.6-27B), this read the wrong decay row and the recurrent state
+diverged, producing coherent-early / garbage-late decode collapse. Decay parameters are now
+indexed per value head, matching the reference layout. Models with symmetric head counts (e.g.
+Qwen3.5-0.8B) were unaffected and produce identical output.
+
+**Inference — detokenizer renders non-special added tokens** (#430). `id_to_token` was built
+only from the base vocabulary, so added control tokens above the base maximum (for Qwen3.5/3.6,
+the `<think>` / `</think>` reasoning markers and their siblings, ids 248044–248069) resolved to
+`None` and decoded to an empty string. Reasoning-model output therefore silently dropped its
+think-tags. The detokenizer now carries an `added_render` map for the non-`special` subset of
+added tokens, with a fallback in `token_for_id`, so these tokens detokenize to their literal
+text. The model's forward pass and sampler were already correct; this was a detokenization-only
+bug.
+
+## Hardening (fail-closed)
+
+**Inference — GDN decay-gate clamped finite across all forward paths** (#426). `exp(a_log)` in
+the GDN decay gate is now clamped with `min(exp(a_log), f32::MAX)` on every forward copy (CPU
+f16, Metal decode, NEON, fused, and batched prefill), matching the existing CPU reference. A
+non-finite decay would poison the recurrent state via `inf * 0 = NaN`. The clamp is a no-op for
+valid checkpoints; it only prevents NaN propagation on malformed or out-of-range inputs.
+
+**Inference — Q4 loader fails closed on metadata mismatch** (#415). The Q4 weight loader now
+rejects a tensor whose declared shape or `original_len` disagrees with the dequantized buffer,
+instead of proceeding with a mis-sized tensor.
+
+## New (additive)
+
+**Tune — `--save` persists a trained LoRA as PEFT safetensors** (#431). The exact-gradient LoRA
+trainer can now write its trained factors to a standard PEFT `.safetensors` adapter. The adapter
+loads unchanged into both the CPU (`generate_lora`) and GPU Metal (`chat_metal --lora`)
+inference paths and steers generation exactly as trained.
+
+**Inference / macOS — persistent warm serve process** (#425). Chat generation can run against a
+persistent serve process that keeps the model resident between turns, removing per-turn reload
+latency.
+
+**macOS Studio — reasoning on/off toggle with split views** (#428). The Studio chat screen adds
+a reasoning (thinking) on/off toggle and renders the reasoning trace and the final answer in
+separate views. The finalization logic was extracted into a pure, unit-tested helper so the live
+streaming view and the completed-turn view agree on the think/answer boundary, including the
+thinking-on truncated-stream case. `apps/macos` is not a published crate and is not versioned
+with this bump.
+
+## Diff scope
+
+7 commits since v0.4.0 (#415, #425, #426, #427, #428, #430, #431). No change to the
+`[workspace.package]` edition or MSRV. Internal path-dependency `version =` fields were bumped to
+`0.4.1` in lockstep with the workspace version.
+
+## Compatibility
+
+No re-indexing or re-quantization is required. Existing v0.4.0 callers compile unchanged.
+`lattice-embed` forward output is unchanged from v0.4.0; existing vector indices remain valid.


### PR DESCRIPTION
## What

Release-prep for **v0.4.1**, a patch over v0.4.0. No code changes in this PR — version bump + release note only. The seven commits this release ships already landed on `main` after the v0.4.0 tag was cut.

## Version bump (lockstep)

`[workspace.package].version` 0.4.0 → 0.4.1, plus the three internal path-dependency `version =` fields bumped in lockstep (the publishing rule):

- `Cargo.toml` `[workspace.package]`
- `crates/embed/Cargo.toml` → `lattice-inference`
- `crates/tune/Cargo.toml` → `lattice-fann`, `lattice-inference`

`cargo metadata` resolves cleanly; all five crates show `0.4.1` in the (gitignored) lockfile.

## Release note

`docs/releases/v0.4.1.md` added, accurate to the 7 commits since the v0.4.0 tag:

**Fixes**
- #427 — GDN decay indexed per *value* head (fixes Qwen3.6-27B decode collapse on asymmetric head counts; symmetric models unaffected)
- #430 — detokenizer renders non-special added tokens (fixes `</think>` / reasoning markers decoding to empty; forward + sampler were already correct, detok-only bug)

**Hardening (fail-closed)**
- #426 — GDN decay-gate `exp(a_log)` clamped finite across all forward paths (CPU/Metal/NEON/fused/prefill parity; no-op for valid checkpoints)
- #415 — Q4 loader fails closed on shape / `original_len` mismatch

**New (additive)**
- #431 — tune `--save` persists trained LoRA as PEFT safetensors (loads into both CPU `generate_lora` and GPU Metal `chat_metal --lora`)
- #425 — persistent warm serve process (no per-turn model reload)
- #428 — macOS Studio reasoning on/off toggle + split thinking/answer views (`apps/macos`, not a published crate)

## Compatibility

No breaking changes. Drop-in over 0.4.0: every public API keeps its v0.4.0 shape, no re-indexing or re-quantization required, `lattice-embed` output unchanged.

## Validation

- `cargo metadata` — version graph resolves, all crates 0.4.1.
- `cargo clippy --workspace -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
