### PR TITLE
docs(embed): stabilize simd distance surface as khive ANN consumer contract (#433)

### DIFF
--- a/crates/embed/src/lib.rs
+++ b/crates/embed/src/lib.rs
@@ -6,9 +6,11 @@
 //! **Exception — stable khive ANN consumer contract:**
 //! `simd::{squared_euclidean_distance, euclidean_distance, dot_product, cosine_similarity}`
 //! are a stable consumer contract for khive's ANN indexes (`khive-hnsw`, `khive-vamana`;
-//! ADR-012): their `(&[f32], &[f32]) -> f32` signatures and documented degenerate-input /
-//! squared-L2 ordering behaviour are guaranteed across the 0.4.x line. The rest of `simd/`
-//! remains unstable.
+//! ADR-012): their `(&[f32], &[f32]) -> f32` signatures and documented degenerate-input
+//! behaviour are guaranteed across the 0.4.x line, as is the squared-L2 ordering invariant
+//! relative to this crate's Euclidean wrapper (both derive from the same accumulated squared
+//! distance; SIMD is not bit-identical to scalar and promises no exact ordering of near-ties).
+//! The rest of `simd/` remains unstable.
 //!
 //! The 21 `unsafe` blocks are gated SIMD intrinsic calls (AVX512/AVX2/NEON); the
 //! 1 `dead_code_allows` retains a superseded dot-product fallback for reference.

--- a/crates/embed/src/lib.rs
+++ b/crates/embed/src/lib.rs
@@ -2,6 +2,14 @@
 //!
 //! The SIMD dispatch layer (`simd/`) and model-loading API are actively evolving.
 //! Platform consumers should use this crate via `lattice-engine`, not directly.
+//!
+//! **Exception — stable khive ANN consumer contract:**
+//! `simd::{squared_euclidean_distance, euclidean_distance, dot_product, cosine_similarity}`
+//! are a stable consumer contract for khive's ANN indexes (`khive-hnsw`, `khive-vamana`;
+//! ADR-012): their `(&[f32], &[f32]) -> f32` signatures and documented degenerate-input /
+//! squared-L2 ordering behaviour are guaranteed across the 0.4.x line. The rest of `simd/`
+//! remains unstable.
+//!
 //! The 21 `unsafe` blocks are gated SIMD intrinsic calls (AVX512/AVX2/NEON); the
 //! 1 `dead_code_allows` retains a superseded dot-product fallback for reference.
 //! See `foundation/STABILITY.md` for the full policy.

--- a/crates/embed/src/simd/cosine.rs
+++ b/crates/embed/src/simd/cosine.rs
@@ -68,10 +68,18 @@ fn cosine_neon_kernel(a: &[f32], b: &[f32]) -> f32 {
     unsafe { cosine_similarity_neon_unrolled(a, b) }
 }
 
-/// **Unstable**: SIMD dispatch layer; use `lattice_embed::utils::cosine_similarity` for the stable wrapper.
+/// Cosine similarity over equal-length, non-empty `f32` slices.
 ///
 /// For pre-normalized vectors (embeddings typically are), use `dot_product`
 /// directly for better performance.
+///
+/// # Stability — khive ANN consumer contract
+///
+/// Part of the `simd::*` distance surface consumed directly by khive's ANN indexes
+/// (`khive-hnsw`, `khive-vamana`; ADR-012). The `(&[f32], &[f32]) -> f32` signature
+/// and the length-mismatch / empty-input behaviour (returns 0.0) are a **stable
+/// consumer contract** across the 0.4.x line. For the general-purpose ergonomic
+/// wrapper use `lattice_embed::utils::cosine_similarity`.
 #[inline]
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     if a.len() != b.len() || a.is_empty() {

--- a/crates/embed/src/simd/distance.rs
+++ b/crates/embed/src/simd/distance.rs
@@ -38,7 +38,16 @@ fn dispatch_squared(a: &[f32], b: &[f32]) -> f32 {
     squared_euclidean_distance_scalar(a, b)
 }
 
-/// **Unstable**: SIMD dispatch layer; use `lattice_embed::utils::euclidean_distance` for the stable wrapper.
+/// Euclidean (L2) distance over equal-length `f32` slices.
+///
+/// # Stability — khive ANN consumer contract
+///
+/// Part of the `simd::*` distance surface consumed directly by khive's ANN indexes
+/// (`khive-hnsw`, `khive-vamana`; ADR-012). The `(&[f32], &[f32]) -> f32` signature
+/// and length-mismatch behaviour (returns [`f32::MAX`]) are a **stable consumer
+/// contract** across the 0.4.x line. For the general-purpose ergonomic wrapper use
+/// `lattice_embed::utils::euclidean_distance`; prefer [`squared_euclidean_distance`]
+/// on hot paths where only ordering matters (it skips the final sqrt).
 #[inline]
 pub fn euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
     if a.len() != b.len() {
@@ -48,11 +57,21 @@ pub fn euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
     dispatch_squared(a, b).sqrt()
 }
 
-/// **Unstable**: squared Euclidean distance — skips the final sqrt.
+/// Squared Euclidean distance — skips the final sqrt.
 ///
 /// Ordering is preserved: `sq_dist(a,b) <= sq_dist(a,c) ↔ dist(a,b) <= dist(a,c)`.
-/// Use this for HNSW graph comparisons where only ordering matters; apply `.sqrt()`
+/// Use this for ANN graph comparisons where only ordering matters; apply `.sqrt()`
 /// at the output boundary when the true L2 distance is required.
+///
+/// # Stability — khive ANN consumer contract
+///
+/// This is the primary hot-path distance for khive's ANN indexes (`khive-hnsw`
+/// today, `khive-vamana` next; ADR-012). The `(&[f32], &[f32]) -> f32` signature,
+/// the length-mismatch behaviour (returns [`f32::MAX`]), and the squared-L2 ordering
+/// invariant above are a **stable consumer contract** across the 0.4.x line. SIMD
+/// results are not bit-identical to the scalar reference (FP non-associativity), but
+/// the ordering — the only property an ANN graph relies on — is guaranteed. For the
+/// general-purpose ergonomic wrapper use `lattice_embed::utils::euclidean_distance`.
 #[inline]
 pub fn squared_euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
     if a.len() != b.len() {

--- a/crates/embed/src/simd/distance.rs
+++ b/crates/embed/src/simd/distance.rs
@@ -68,10 +68,13 @@ pub fn euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
 /// This is the primary hot-path distance for khive's ANN indexes (`khive-hnsw`
 /// today, `khive-vamana` next; ADR-012). The `(&[f32], &[f32]) -> f32` signature,
 /// the length-mismatch behaviour (returns [`f32::MAX`]), and the squared-L2 ordering
-/// invariant above are a **stable consumer contract** across the 0.4.x line. SIMD
-/// results are not bit-identical to the scalar reference (FP non-associativity), but
-/// the ordering — the only property an ANN graph relies on — is guaranteed. For the
-/// general-purpose ergonomic wrapper use `lattice_embed::utils::euclidean_distance`.
+/// invariant above — vs this crate's [`euclidean_distance`], which derives from the
+/// same accumulated squared distance — are a **stable consumer contract** across the
+/// 0.4.x line. SIMD accumulates terms in a different order than the scalar reference,
+/// so results are not bit-identical and no exact scalar ordering of near-ties is
+/// promised; the documented squared-vs-Euclidean equivalence is the property an ANN
+/// graph relies on. For the general-purpose ergonomic wrapper use
+/// `lattice_embed::utils::euclidean_distance`.
 #[inline]
 pub fn squared_euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
     if a.len() != b.len() {

--- a/crates/embed/src/simd/dot_product.rs
+++ b/crates/embed/src/simd/dot_product.rs
@@ -160,10 +160,19 @@ fn dot_product_neon_kernel(a: &[f32], b: &[f32]) -> f32 {
     unsafe { dot_product_neon_unrolled(a, b) }
 }
 
-/// **Unstable**: SIMD dispatch layer; use `lattice_embed::utils::dot_product` for the stable wrapper.
+/// Dot product over equal-length `f32` slices.
 ///
-/// For normalized vectors, this equals cosine similarity.
+/// For normalized vectors, this equals cosine similarity (and `sq-L2 = 2*(1 - dot)`),
+/// so it backs cosine/inner-product ANN search on unit-norm vectors.
 /// Returns 0.0 if vectors have different lengths.
+///
+/// # Stability — khive ANN consumer contract
+///
+/// Part of the `simd::*` distance surface consumed directly by khive's ANN indexes
+/// (`khive-hnsw`, `khive-vamana`; ADR-012). The `(&[f32], &[f32]) -> f32` signature
+/// and length-mismatch behaviour (returns 0.0) are a **stable consumer contract**
+/// across the 0.4.x line. For the general-purpose ergonomic wrapper use
+/// `lattice_embed::utils::dot_product`.
 #[inline]
 pub fn dot_product(a: &[f32], b: &[f32]) -> f32 {
     // Runtime length check to prevent UB in release builds

--- a/crates/embed/src/simd/tests.rs
+++ b/crates/embed/src/simd/tests.rs
@@ -412,6 +412,9 @@ fn test_simd_distance_consumer_contract() {
     assert_eq!(euclidean_distance(&a4, &b3), f32::MAX);
     assert_eq!(dot_product(&a4, &b3), 0.0);
     assert_eq!(cosine_similarity(&a4, &b3), 0.0);
+
+    // cosine_similarity additionally documents empty-input → 0.0 (explicit guard).
+    assert_eq!(cosine_similarity(&[], &[]), 0.0);
 }
 
 #[test]

--- a/crates/embed/src/simd/tests.rs
+++ b/crates/embed/src/simd/tests.rs
@@ -343,6 +343,77 @@ fn test_avx512_euclidean_distance_dimensions() {
     }
 }
 
+/// Consumer contract for khive ANN indexes (`khive-hnsw`, `khive-vamana`; ADR-012).
+///
+/// Locks the guarantees the downstream indexes depend on so the surface cannot
+/// silently drift:
+/// 1. **Signature stability** — the four distance fns keep the
+///    `(&[f32], &[f32]) -> f32` shape (compile-time gate).
+/// 2. **Numerical stability** — `squared_euclidean_distance` tracks the scalar
+///    reference within FP tolerance across the queried dims (384 is the live
+///    embed dim).
+/// 3. **Ordering invariant** — squared-L2 sorts identically to true L2, the only
+///    property an ANN graph relies on.
+/// 4. **Degenerate-input behaviour** — the documented length-mismatch returns.
+#[test]
+fn test_simd_distance_consumer_contract() {
+    // The `(&[f32], &[f32]) -> f32` shape khive ANN indexes bind to.
+    type DistFn = fn(&[f32], &[f32]) -> f32;
+
+    // (1) Signature gate: fails to compile if any signature drifts.
+    let _contract: [DistFn; 4] = [
+        squared_euclidean_distance,
+        euclidean_distance,
+        dot_product,
+        cosine_similarity,
+    ];
+
+    // (2) squared_euclidean_distance == scalar reference, within FP tolerance.
+    for dim in AVX512_TEST_DIMS {
+        let a = generate_random_vector_seeded(dim, 911);
+        let b = generate_random_vector_seeded(dim, 1013);
+
+        let simd_result = squared_euclidean_distance(&a, &b);
+        let scalar_result = distance::squared_euclidean_distance_scalar(&a, &b);
+
+        assert_close(
+            simd_result,
+            scalar_result,
+            1e-3,
+            1e-4,
+            &format!("squared_euclidean_distance contract dim {dim}"),
+        );
+    }
+
+    // (3) Ordering invariant: sorting by squared-L2 matches sorting by true L2.
+    let query = generate_random_vector_seeded(384, 1);
+    let candidates: Vec<Vec<f32>> = (0..16)
+        .map(|i| generate_random_vector_seeded(384, 100 + i as u64))
+        .collect();
+    let order_by = |dist: DistFn| {
+        let mut idx: Vec<usize> = (0..candidates.len()).collect();
+        idx.sort_by(|&x, &y| {
+            dist(&query, &candidates[x])
+                .partial_cmp(&dist(&query, &candidates[y]))
+                .unwrap()
+        });
+        idx
+    };
+    assert_eq!(
+        order_by(squared_euclidean_distance),
+        order_by(euclidean_distance),
+        "squared_euclidean_distance must preserve true-L2 ordering (ANN invariant)"
+    );
+
+    // (4) Documented degenerate-input behaviour is part of the contract.
+    let a4 = [1.0_f32, 2.0, 3.0, 4.0];
+    let b3 = [1.0_f32, 2.0, 3.0];
+    assert_eq!(squared_euclidean_distance(&a4, &b3), f32::MAX);
+    assert_eq!(euclidean_distance(&a4, &b3), f32::MAX);
+    assert_eq!(dot_product(&a4, &b3), 0.0);
+    assert_eq!(cosine_similarity(&a4, &b3), 0.0);
+}
+
 #[test]
 fn test_avx512f_config_detection() {
     let config = SimdConfig::detect();


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes part of #433 — the **lattice-side deliverable** only. The khive-side `khive-vamana` wiring is cross-repo (owned by the khive maintainers, bench-gated) and intentionally out of scope.

## What & why

The four `lattice_embed::simd::*` distance fns that khive's ANN indexes call were tagged *"Unstable: SIMD dispatch layer"*. But they are now a **production consumer surface**: `khive-hnsw` already routes through them (`khive-hnsw/src/distance.rs:84`) and `khive-vamana` is next (ADR-012). No new kernel is needed — the primitives already exist. So the lattice-side action is to make the surface safe to depend on.

## Changes (docs + test only)

- **`simd/{distance,dot_product,cosine}.rs`** — rustdoc on `squared_euclidean_distance`, `euclidean_distance`, `dot_product`, `cosine_similarity` now declares a **stable consumer contract** for the 0.4.x line: the `(&[f32], &[f32]) -> f32` signature and the degenerate-input behaviour are guaranteed. For ordering, the precise guarantee is that `squared_euclidean_distance` sorts identically to this crate's `euclidean_distance` (both derive from the same accumulated squared distance, before `sqrt`) — the property an ANN graph relies on. SIMD accumulates in a different order than scalar, so results are *not* bit-identical and **no exact scalar ordering of near-ties is promised**.
- **`lib.rs`** — crate-level stability docs now carve out those four fns as the stable ANN consumer contract while the rest of `simd/` stays unstable (review round 1), with the same narrowed ordering wording (review round 2).
- **`simd/tests.rs`** — `test_simd_distance_consumer_contract` locks the surface against silent drift:
  1. compile-time signature gate (`[DistFn; 4]`),
  2. `squared_euclidean_distance` == scalar reference within FP tolerance across the queried dims (incl. 384, the live embed dim),
  3. the same-dispatch ordering invariant (squared-L2 sorts identically to this crate's `euclidean_distance`),
  4. the documented degenerate-length + cosine empty-input returns (`f32::MAX` / `0.0`).

## Verification

- `cargo test -p lattice-embed --lib` → **254 passed, 0 failed** (incl. the new contract test).
- `cargo clippy -p lattice-embed --all-targets -- -D warnings` → clean.
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p lattice-embed` → clean.
- **bench-compare: N/A** — the source diffs are rustdoc-only and the only code added is a `#[test]`; **no runtime code path changed**, so there is no perf surface to measure.

## Coordination note (release note)

Issue #433 also asks for a release-note line in `docs/releases/v0.4.1.md`. That file does **not** exist on `main` — it is created by the open PR **#432** (`chore/release-v0.4.1`). Adding it here would create an add/add conflict between the two PRs, so it is deliberately **not** in this PR. Suggested line to fold into #432 (or #432's successor — whether this lands in 0.4.1 vs 0.4.2 is a maintainer call):

> - **embed:** `simd::{squared_euclidean_distance, euclidean_distance, dot_product, cosine_similarity}` are now a documented stable consumer contract for khive's ANN indexes (khive-hnsw, khive-vamana; ADR-012) — `(&[f32], &[f32]) -> f32` signature + degenerate-input behaviour guaranteed across 0.4.x; `squared_euclidean_distance` sorts identically to this crate's `euclidean_distance` (no exact scalar ordering of near-ties promised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)