### PR TITLE
fix(inference): fail-loud when LATTICE_MTP set but MTP weight file missing (#418 part 1)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -13431,6 +13431,13 @@ kernel void gdn_chunk_norm_silu_c32(
                 return None;
             }
 
+            // Fail-loud (#418): a speculation feature must never silently disable itself.
+            // When the operator explicitly requests MTP via the env var but a weight file
+            // is missing (the shipped Q4 checkpoint stores the 8 MTP projections as `.q4`
+            // while this loader reads `.f16`), warn and name the file instead of returning
+            // `None` into a silent no-op that decodes at the plain baseline.
+            let want_mtp = std::env::var_os("LATTICE_MTP").is_some();
+
             let f16p = |name: &str| MetalQwen35State::q4_tensor_path(q4_dir, name, "f16");
 
             // Helper: load an f16 file as a f32 Metal buffer (for norm gammas / biases
@@ -13438,6 +13445,14 @@ kernel void gdn_chunk_norm_silu_c32(
             let load_f16_buf_as_f32 = |name: &str, label: &str| -> Option<Buffer> {
                 let path = f16p(name);
                 if !path.exists() {
+                    if want_mtp {
+                        eprintln!(
+                            "[mtp] WARNING: LATTICE_MTP is set but MTP weight file is \
+                             missing: {} — MTP speculation DISABLED, decoding at the plain \
+                             baseline (see issue #418).",
+                            path.display()
+                        );
+                    }
                     return None;
                 }
                 let (vals, _) = load_f16_tensor_file(&path).ok()?;
@@ -13451,6 +13466,14 @@ kernel void gdn_chunk_norm_silu_c32(
             let load_f16_buf_as_half = |name: &str, label: &str| -> Option<Buffer> {
                 let path = f16p(name);
                 if !path.exists() {
+                    if want_mtp {
+                        eprintln!(
+                            "[mtp] WARNING: LATTICE_MTP is set but MTP weight file is \
+                             missing: {} — MTP speculation DISABLED, decoding at the plain \
+                             baseline (see issue #418).",
+                            path.display()
+                        );
+                    }
                     return None;
                 }
                 let (vals, _) = load_f16_tensor_file(&path).ok()?;


### PR DESCRIPTION
## Summary

Part 1 of #418: make MTP self-speculation **fail loud** instead of silently disabling itself.

`LATTICE_MTP=1` is currently a silent no-op on the shipped Q4 checkpoint. `load_mtp_q4_weights` loads the 8 MTP projections via `load_f16_*` helpers that read `.f16` files, but on the Q4 checkpoint those projections ship as `.q4`. The first missing `.f16` short-circuits the loader to `None`, MTP is disabled, and decoding silently falls back to the plain baseline with **no signal to the operator** that the feature they requested is off.

This is the same fail-closed/fail-loud bug class as the serve-DoS, softmax-fail-closed, and finite-mask-sentinel hardening: a feature that disables itself on a missing precondition must say so.

## Change

A single warn in each of the two MTP loader closures (`load_f16_buf_as_f32`, `load_f16_buf_as_half`), in the existing `!path.exists()` branch that already returned `None`:

- Gated on `want_mtp = std::env::var_os("LATTICE_MTP").is_some()` so **default loads stay silent** (no spam when MTP was never requested).
- Names the first missing file, so the operator sees exactly which weight is absent.
- Structurally zero-cost: it lives in a model-construction error branch, runs at most once at load, and touches no decode or prefill path.

```
[mtp] WARNING: LATTICE_MTP is set but MTP weight file is missing: <path>
      — MTP speculation DISABLED, decoding at the plain baseline (see issue #418).
```

## Scope

This is **part 1 (fail-loud only)**. Part 2 — actually loading the `.q4` MTP projections so MTP works on the Q4 checkpoint — is a separate, larger fix tracked in #418.

## Gates

- `cargo fmt` clean.
- `cargo clippy -p lattice-inference --features f16,metal-gpu --all-targets -- -D warnings` → clean (RC=0). The warn lives on the `metal-gpu` path.
- 1 file changed, +23 (additive; no logic change to the existing `None` return).

## bench-compare (per ADR-058 / repo policy)

`make bench-compare` — base `origin/main` (bb470e5e0) vs HEAD (7fc286282):

- 259 micro-benchmark comparison rows. **253/259 report `p > 0.05` (no statistically significant change).**
- The remaining 6 sit at the `p ≈ 0.05` boundary and are **all negative** (apparent 1.9–7.4% speedups; **zero regressions**), spread across CPU/SIMD groups (`rms_norm`, `simd_*`, elementwise) that share no code path with the MTP loader. 6/259 is *below* the ~13 false positives expected by chance at α=0.05, and a load-path `eprintln!` cannot speed up a SIMD micro-bench — so these are two-worktree separate-build noise (a documented harness false-positive source), not a code effect.
- The summary-table aggregator printed `error: ... failed to parse` (missing base `estimates.json` paths — known two-worktree harness fragility); the underlying Criterion A/B itself ran clean on both sides.

**Verdict: no regression.** Consistent with a structurally zero-cost change (load-path warn, no decode/prefill path touched).

## Review

Held for review — not for auto-merge. Closes the fail-loud half of #418; part 2 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
