### PR TITLE
feat(inference): LATTICE_OFFLINE env gate to block network model fetches

### DIFF
--- a/crates/inference/src/download.rs
+++ b/crates/inference/src/download.rs
@@ -6,6 +6,19 @@ use std::path::{Path, PathBuf};
 ///
 /// Ensure that the model files exist locally, downloading them if needed.
 pub fn ensure_model_files(model_name: &str, cache_dir: &Path) -> Result<PathBuf, InferenceError> {
+    // Offline gate: when LATTICE_OFFLINE is set, never touch the network — a cache miss
+    // fails fast instead of implicitly fetching from Hugging Face. Downstream consumers
+    // (khive CI, sandboxed builds) set this. Reading the env here keeps the public
+    // signature stable while `ensure_model_files_inner` stays env-free and unit-testable.
+    let offline = std::env::var_os("LATTICE_OFFLINE").is_some();
+    ensure_model_files_inner(model_name, cache_dir, offline)
+}
+
+fn ensure_model_files_inner(
+    model_name: &str,
+    cache_dir: &Path,
+    offline: bool,
+) -> Result<PathBuf, InferenceError> {
     let model_name = canonical_model_name(model_name)?;
     let model_dir = cache_dir.join(model_name);
     let safetensors_path = model_dir.join("model.safetensors");
@@ -17,6 +30,18 @@ pub fn ensure_model_files(model_name: &str, cache_dir: &Path) -> Result<PathBuf,
     if safetensors_path.exists() && has_tokenizer {
         tracing::debug!(path = %model_dir.display(), "model files already cached");
         return Ok(model_dir);
+    }
+
+    // Offline mode blocks the network entirely: a cache miss is a hard, clear error
+    // rather than a download attempt. Applies whether or not the `download` feature
+    // is compiled in.
+    if offline {
+        return Err(InferenceError::ModelNotFound(format!(
+            "model files not found at {} and LATTICE_OFFLINE is set (offline mode: no \
+             download attempted). Pre-fetch the model into the cache, or unset \
+             LATTICE_OFFLINE to allow downloading.",
+            model_dir.display()
+        )));
     }
 
     #[cfg(not(feature = "download"))]
@@ -253,4 +278,37 @@ fn sha256_hex(path: &Path) -> Result<String, InferenceError> {
         let _ = write!(&mut hex, "{byte:02x}");
     }
     Ok(hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Offline mode + cache miss must error immediately, never attempting a download.
+    #[test]
+    fn offline_cache_miss_errors_without_download() {
+        let tmp = std::env::temp_dir().join(format!("lattice_offline_miss_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let res = ensure_model_files_inner("all-minilm-l6-v2", &tmp, true);
+        assert!(
+            matches!(res, Err(InferenceError::ModelNotFound(_))),
+            "offline + cache miss must return ModelNotFound, got {res:?}"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Offline mode still serves a populated cache — it blocks the network, not cache reads.
+    #[test]
+    fn offline_cache_hit_succeeds() {
+        let tmp = std::env::temp_dir().join(format!("lattice_offline_hit_{}", std::process::id()));
+        let model_dir = tmp.join("all-minilm-l6-v2");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&model_dir).expect("create temp model dir");
+        std::fs::write(model_dir.join("model.safetensors"), b"stub")
+            .expect("write safetensors stub");
+        std::fs::write(model_dir.join("vocab.txt"), b"stub").expect("write vocab stub");
+        let res = ensure_model_files_inner("all-minilm-l6-v2", &tmp, true);
+        assert!(res.is_ok(), "offline + cache hit must succeed, got {res:?}");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }


### PR DESCRIPTION
## Summary

Add a `LATTICE_OFFLINE` environment gate so a model-file cache miss fails fast with a clear error instead of an implicit Hugging Face download.

`ensure_model_files` (the single network entrypoint, used by both inference and embed model loading) auto-downloads weights from Hugging Face on a cache miss when the `download` feature is on. Downstream consumers — khive CI, sandboxed / air-gapped builds — need a way to forbid the network so a missing model surfaces immediately instead of triggering an unexpected fetch (and the CI flakiness / firewall failures that come with it). This was requested by a downstream consumer (khive) after a CI lesson where the implicit fetch forced every consumer to add its own guard.

## Change

- `pub fn ensure_model_files` now reads `LATTICE_OFFLINE` once and delegates to an env-free `ensure_model_files_inner(model_name, cache_dir, offline)`. **Public signature unchanged** — no caller touched.
- When `offline` is set and the model is **not** cached, return `ModelNotFound` naming the directory, *before* any network branch, **regardless of the `download` feature**.
- **Cache hits are unaffected**: offline blocks the network, not cache reads. A populated cache still loads under `LATTICE_OFFLINE`.

```
model files not found at <path> and LATTICE_OFFLINE is set (offline mode: no
download attempted). Pre-fetch the model into the cache, or unset
LATTICE_OFFLINE to allow downloading.
```

## Tests

Two unit tests on the env-free inner fn (no global state, no network):
- `offline_cache_miss_errors_without_download` — offline + empty cache → `ModelNotFound`.
- `offline_cache_hit_succeeds` — offline + populated cache → `Ok` (network never consulted).

## Gates

- `cargo fmt` clean.
- `cargo clippy -p lattice-inference --all-targets -- -D warnings` (default features, includes `download`) → clean.
- `cargo clippy -p lattice-inference --features download --lib -- -D warnings` (forced rebuild) → clean.
- 2/2 new tests pass; 1 file changed, +58.

## bench-compare (per ADR-058 / repo policy)

`make bench-compare` — base `origin/main` (bb470e5e0) vs HEAD (58148dd9e):

- 259 micro-benchmark comparison rows (criterion HEAD-vs-BASE inline A/B). **253/259 report `p > 0.05` (no statistically significant change).**
- The 6 rows at `p = 0.05` are **all negative** (apparent speedups: −0.4%, −1.7%, −2.5%, −4.5%, −5.1%, and one −25.6% outlier on `elementwise_mul/4096`) — **zero regressions**. They sit on SIMD / elementwise / throughput compute groups that share no code path with `download.rs`; a load-path env read cannot speed up an elementwise kernel, so these are two-worktree separate-build noise (a documented harness false-positive source), not a code effect.
- The summary-table aggregator printed `error: change files found but all failed to parse` (missing base `estimates.json` paths — known two-worktree harness fragility); criterion's own inline A/B ran clean on both sides (BASE built + benched, then HEAD).

**Verdict: no regression.** `ensure_model_files` runs once at model construction and the offline gate is an env read plus an early return on a cache miss — it touches no decode, prefill, or embed-compute path, so no benchmarked group can be affected.

## Review

Held for review — not for auto-merge. Unblocks the downstream offline/cache-gate ask; consumers can set `LATTICE_OFFLINE=1` once a release ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
