### PR TITLE
chore(tune): rename default training-data dir to data/lora-train

### DIFF
--- a/crates/tune/src/bin/train_grad.rs
+++ b/crates/tune/src/bin/train_grad.rs
@@ -284,7 +284,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(default_model_dir);
     let data_dir = parse_arg(&args, "--data-dir")
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("data/claude-logs-lora"));
+        .unwrap_or_else(|| PathBuf::from("data/lora-train"));
     let steps: usize = parse_arg(&args, "--steps")
         .and_then(|s| s.parse().ok())
         .unwrap_or(150);

--- a/crates/tune/src/bin/train_grad_full.rs
+++ b/crates/tune/src/bin/train_grad_full.rs
@@ -66,7 +66,7 @@ fn usage() {
 
 Options:
   --model-dir   <PATH>   Model directory (default: $HOME/.lattice/models/qwen3.5-0.8b)
-  --data-dir    <PATH>   Dataset directory with train.jsonl + valid.jsonl (default: data/claude-logs-lora)
+  --data-dir    <PATH>   Dataset directory with train.jsonl + valid.jsonl (default: data/lora-train)
   --first-layer <N>      First materialised (trained) layer (default: 19)
   --steps       <N>      Adam steps (default: 25)
   --lr          <F>      Learning rate (default: 1e-3)
@@ -699,7 +699,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(default_model_dir);
     let data_dir = parse_arg(&args, "--data-dir")
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("data/claude-logs-lora"));
+        .unwrap_or_else(|| PathBuf::from("data/lora-train"));
     let first_layer: usize = parse_arg(&args, "--first-layer")
         .and_then(|s| s.parse().ok())
         .unwrap_or(19);

--- a/crates/tune/src/bin/train_grad_layer23.rs
+++ b/crates/tune/src/bin/train_grad_layer23.rs
@@ -56,7 +56,7 @@ fn usage() {
 
 Options:
   --model-dir  <PATH>   Model directory (default: $HOME/.lattice/models/qwen3.5-0.8b)
-  --data-dir   <PATH>   Dataset directory with train.jsonl (default: data/claude-logs-lora)
+  --data-dir   <PATH>   Dataset directory with train.jsonl (default: data/lora-train)
   --steps      <N>      Adam steps (default: 25)
   --lr         <F>      Learning rate (default: 1e-3)
   --rank       <N>      LoRA rank (default: 8)
@@ -412,7 +412,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(default_model_dir);
     let data_dir = parse_arg(&args, "--data-dir")
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("data/claude-logs-lora"));
+        .unwrap_or_else(|| PathBuf::from("data/lora-train"));
     let steps: usize = parse_arg(&args, "--steps")
         .and_then(|s| s.parse().ok())
         .unwrap_or(25);


### PR DESCRIPTION
## Summary

- Renames the hardcoded default `--data-dir` path in all three `train_grad*` binaries from `data/claude-logs-lora` to `data/lora-train`.
- Covers both the runtime default (`PathBuf::from(...)`) and the `--help` string in each binary.
- No logic changed; callers who pass `--data-dir` explicitly are unaffected.

Files changed (5 occurrences across 3 files):
- `crates/tune/src/bin/train_grad.rs` (1 occurrence)
- `crates/tune/src/bin/train_grad_full.rs` (2 occurrences: help text + default)
- `crates/tune/src/bin/train_grad_layer23.rs` (2 occurrences: help text + default)

## Test plan

- [x] `cargo build -p lattice-tune` — green
- [x] `cargo clippy -p lattice-tune --all-targets -- -D warnings` — green
- [x] `cargo fmt -p lattice-tune --check` — green
- [x] pre-commit hook (full workspace check + doc lint) — green
- [x] No remaining `claude-logs-lora` occurrences in tracked files

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)