### PR TITLE
feat(fann): online router refit (single-sample policy gradient + EWC++) with convergence bench

### DIFF
--- a/crates/fann/Cargo.toml
+++ b/crates/fann/Cargo.toml
@@ -11,6 +11,9 @@ description = "Fast neural network primitives for Lattice - tiny models, fast in
 default = ["std", "simd"]
 std = []
 simd = []
+# Policy-gradient router trainer and EWC forgetting guard — off by default.
+# Enable with --features online-router to access RlooTrainer and DiagonalFisher.
+online-router = []
 parallel = ["dep:rayon"]
 serde = ["dep:serde", "dep:serde_json"]
 # GPU acceleration via wgpu (Metal on macOS, Vulkan on Linux, DX12 on Windows)
@@ -41,6 +44,7 @@ name = "fann_xor"
 [[bench]]
 name = "router_online"
 harness = false
+required-features = ["online-router"]
 
 [dev-dependencies]
 approx = "0.5"

--- a/crates/fann/Cargo.toml
+++ b/crates/fann/Cargo.toml
@@ -38,6 +38,10 @@ futures = { version = "0.3", optional = true }
 [[example]]
 name = "fann_xor"
 
+[[bench]]
+name = "router_online"
+harness = false
+
 [dev-dependencies]
 approx = "0.5"
 proptest.workspace = true

--- a/crates/fann/benches/router_online.rs
+++ b/crates/fann/benches/router_online.rs
@@ -1,0 +1,634 @@
+//! # Router Online-Learning Convergence Bench
+//!
+//! 4-algorithm × 3-regime head-to-head comparison for the selector-gate
+//! policy-gradient trainer.  Plain `fn main()` binary (`harness = false`).
+//! Prints per-regime convergence tables and a summary matrix.
+//!
+//! ## Algorithms
+//!
+//! - **A — oracle ceiling**: trainer receives the true-best adapter index as
+//!   target each round (upper bound on achievable accuracy).
+//! - **B — M=1 reward-on-served**: on-policy categorical sample; `+1` if
+//!   served adapter matches true best, `−1` otherwise.
+//! - **C — phase-2 positive-only**: on-policy sample via `rloo_step`; only
+//!   confirmed-positive events are consumed (negative events are dropped).
+//! - **D — hybrid**: routes positive events through the multi-sample update,
+//!   negative events through the single-sample update (no events dropped).
+//!
+//! ## Regimes
+//!
+//! - **dense**: every round produces a feedback event (800 rounds).
+//! - **noisy**: every round, 20 % of events are corrupted (800 rounds).
+//! - **sparse**: 15 % feedback probability, 1 600 rounds.
+//!
+//! ## DEFERRED — not in this file
+//!
+//! - **Bench 3 — adapter routing latency** (`bench_router_latency.rs`):
+//!   depends on the adapter-blend API (LoRA mixture path) which lives on a
+//!   different branch.  Deferred until that branch lands on main.
+//!
+//! - **Bench 4 — EWC++ Fisher stability under distribution shift**: requires
+//!   composing `DiagonalFisher` penalty gradients between gradient-compute and
+//!   weight-apply — a seam that `RlooTrainer::step` does not currently expose
+//!   (it applies weights internally and returns only the scalar loss).
+//!   Deferred pending a public `GradientDelta` return value from `step`.
+
+use lattice_fann::training::{RlooConfig, RlooTrainer};
+use lattice_fann::{Activation, Network, NetworkBuilder};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+// ---------------------------------------------------------------------------
+// Task constants
+// ---------------------------------------------------------------------------
+
+/// Number of adapters (selector output dimension).
+const K: usize = 4;
+/// Context dimension (selector input dimension).
+const D: usize = 16;
+/// Held-out evaluation set size — generated ONCE, never trained on.
+const N_EVAL: usize = 200;
+/// Gaussian noise scale for class-conditioned context generation.
+const NOISE: f32 = 0.5;
+
+// Checkpoint schedules.
+const DENSE_NOISY_CPS: &[usize] = &[0, 100, 400, 800];
+const SPARSE_CPS: &[usize] = &[0, 200, 800, 1600];
+
+// ---------------------------------------------------------------------------
+// Seeds — all printed at runtime
+// ---------------------------------------------------------------------------
+
+/// Seed for the K ground-truth unit weight vectors.
+const WEIGHT_SEED: u64 = 42;
+/// Seed for selector-gate initialisation (shared across all arms).
+const GATE_SEED: u64 = 7;
+/// Seed for eval-set class draws.
+const EVAL_CLASS_SEED: u64 = 200;
+/// Seed for eval-set Gaussian noise draws.
+const EVAL_NOISE_SEED: u64 = 201;
+/// Seed for training class draws (per arm, reseeded).
+const TRAIN_CLASS_SEED: u64 = 100;
+/// Seed for training Gaussian context noise (per arm, reseeded).
+const CTX_NOISE_SEED: u64 = 101;
+/// Seed for categorical action sampling — B and C only (per arm, reseeded).
+const ACTION_SEED: u64 = 400;
+/// Seed for reward/label noise draws — noisy regime only (per arm, reseeded).
+const REWARD_NOISE_SEED: u64 = 500;
+/// Seed for sparse feedback gate draws — sparse regime only (per arm, reseeded).
+const SPARSE_SEED: u64 = 600;
+/// Seed for `RlooTrainer`'s internal RNG (Phase-2 Gumbel path).
+const TRAINER_SEED: u64 = 300;
+
+// ---------------------------------------------------------------------------
+// Algorithm / regime tags
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Algorithm {
+    OracleCeiling,
+    M1RewardOnServed,
+    Phase2PositiveOnly,
+    /// Routes positive events through the multi-sample update, negative events
+    /// through the single-sample update.
+    Hybrid,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Regime {
+    Dense,
+    Noisy,
+    Sparse,
+}
+
+// ---------------------------------------------------------------------------
+// Data structures
+// ---------------------------------------------------------------------------
+
+struct CheckpointRow {
+    t: usize,
+    accuracy: f32,
+    entropy_bits: f32,
+}
+
+struct ArmResult {
+    rows: Vec<CheckpointRow>,
+    effective_updates: usize,
+    /// Positive-only events that were discarded (Phase-2 only; 0 for A and B).
+    dropped: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no unwrap / panic)
+// ---------------------------------------------------------------------------
+
+/// Dot product of two equal-length slices.
+fn dot(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum()
+}
+
+/// Numerically stable softmax (local copy — private in rloo.rs).
+fn softmax(logits: &[f32]) -> Vec<f32> {
+    if logits.is_empty() {
+        return Vec::new();
+    }
+    let max_val = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let exps: Vec<f32> = logits.iter().map(|&s| (s - max_val).exp()).collect();
+    let sum: f32 = exps.iter().sum();
+    if sum == 0.0 {
+        vec![1.0 / logits.len() as f32; logits.len()]
+    } else {
+        exps.iter().map(|&e| e / sum).collect()
+    }
+}
+
+/// Index of the largest value; returns 0 on empty slice.
+fn argmax(values: &[f32]) -> usize {
+    values
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(i, _)| i)
+        .unwrap_or(0)
+}
+
+/// Inverse-CDF categorical sample; falls back to last index on edge cases.
+fn sample_categorical(probs: &[f32], rng: &mut SmallRng) -> usize {
+    let u: f32 = rng.gen_range(0.0_f32..1.0_f32);
+    let mut cumsum = 0.0_f32;
+    for (i, &p) in probs.iter().enumerate() {
+        cumsum += p;
+        if u <= cumsum {
+            return i;
+        }
+    }
+    probs.len().saturating_sub(1)
+}
+
+/// Ground-truth adapter index: `argmax_k dot(ctx, weights[k])`.
+fn true_best(ctx: &[f32], weights: &[Vec<f32>]) -> usize {
+    (0..weights.len())
+        .max_by(|&a, &b| {
+            dot(ctx, &weights[a])
+                .partial_cmp(&dot(ctx, &weights[b]))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .unwrap_or(0)
+}
+
+/// Box-Muller transform: one standard-normal variate from two uniform draws.
+fn gaussian_f32(rng: &mut SmallRng) -> f32 {
+    let u1: f32 = rng.r#gen::<f32>().clamp(1e-38_f32, 1.0 - f32::EPSILON);
+    let u2: f32 = rng.r#gen::<f32>();
+    (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos()
+}
+
+/// Class-conditioned context: `w[class] + NOISE * g`, `g ~ N(0, I_D)`.
+///
+/// With unit weight vectors and NOISE=0.5, `argmax_k dot(ctx, w_k)` reliably
+/// recovers `class` — the task is crisply learnable.
+fn gen_context(class: usize, weights: &[Vec<f32>], noise_rng: &mut SmallRng) -> Vec<f32> {
+    weights[class]
+        .iter()
+        .map(|&w| w + NOISE * gaussian_f32(noise_rng))
+        .collect()
+}
+
+/// Greedy evaluation on the held-out set.
+///
+/// Returns `(accuracy, entropy_bits)`:
+/// - **accuracy**: fraction where `argmax(logits) == true_best`.
+/// - **entropy_bits**: Shannon entropy H = −Σ f_k log₂(f_k) of the empirical
+///   adapter-selection distribution across `N_EVAL` contexts.
+fn eval_metrics(
+    gate: &mut Network,
+    eval_contexts: &[Vec<f32>],
+    eval_true_best: &[usize],
+) -> Result<(f32, f32), Box<dyn std::error::Error>> {
+    let mut correct = 0_usize;
+    let mut counts = vec![0_usize; K];
+
+    for (ctx, &best) in eval_contexts.iter().zip(eval_true_best.iter()) {
+        let logits = gate.forward(ctx.as_slice())?.to_vec();
+        let selected = argmax(&logits);
+        if selected == best {
+            correct += 1;
+        }
+        counts[selected] += 1;
+    }
+
+    let accuracy = correct as f32 / N_EVAL as f32;
+    let n = N_EVAL as f32;
+    let mut entropy = 0.0_f32;
+    for &c in &counts {
+        if c > 0 {
+            let p = c as f32 / n;
+            entropy -= p * p.log2();
+        }
+    }
+    Ok((accuracy, entropy))
+}
+
+// ---------------------------------------------------------------------------
+// Training arm
+// ---------------------------------------------------------------------------
+
+/// Run one `(algorithm, regime)` arm end-to-end.
+///
+/// Every arm receives freshly reseeded independent RNG streams so the
+/// sparse/noise masks are reproducible and comparable across algorithms within
+/// the same regime.
+#[allow(clippy::too_many_arguments)]
+fn run_arm(
+    weights: &[Vec<f32>],
+    eval_contexts: &[Vec<f32>],
+    eval_true_best: &[usize],
+    algo: Algorithm,
+    regime: Regime,
+    config: RlooConfig,
+    rounds: usize,
+    checkpoints: &[usize],
+) -> Result<ArmResult, Box<dyn std::error::Error>> {
+    let mut gate = NetworkBuilder::new()
+        .input(D)
+        .hidden(16, Activation::ReLU)
+        .output(K, Activation::Linear)
+        .build_with_seed(GATE_SEED)?;
+
+    let mut trainer = RlooTrainer::with_seed(config, TRAINER_SEED);
+
+    // Per-arm independent streams reseeded from constants.
+    let mut class_rng = SmallRng::seed_from_u64(TRAIN_CLASS_SEED);
+    let mut ctx_noise_rng = SmallRng::seed_from_u64(CTX_NOISE_SEED);
+    let mut action_rng = SmallRng::seed_from_u64(ACTION_SEED);
+    let mut reward_noise_rng = SmallRng::seed_from_u64(REWARD_NOISE_SEED);
+    let mut sparse_rng = SmallRng::seed_from_u64(SPARSE_SEED);
+
+    let mut effective_updates = 0_usize;
+    let mut dropped = 0_usize;
+    let mut rows: Vec<CheckpointRow> = Vec::new();
+
+    // T=0: evaluate before any training (sanity / leakage check).
+    if checkpoints.contains(&0) {
+        let (accuracy, entropy_bits) = eval_metrics(&mut gate, eval_contexts, eval_true_best)?;
+        rows.push(CheckpointRow {
+            t: 0,
+            accuracy,
+            entropy_bits,
+        });
+    }
+
+    for round in 1..=rounds {
+        // Step 1: draw class, build class-conditioned context.
+        let c = class_rng.gen_range(0..K);
+        let ctx = gen_context(c, weights, &mut ctx_noise_rng);
+        let best = true_best(&ctx, weights);
+
+        // Step 2: feedback gate (sparse draws happen every round in sparse regime).
+        let give_feedback = if regime == Regime::Sparse {
+            sparse_rng.r#gen::<f32>() < 0.15
+        } else {
+            true
+        };
+
+        // Step 3: algorithm branch.
+        //
+        // RNG draw order within each algorithm is kept consistent so that
+        // the sparse/noise masks align across A/B/C within the same regime.
+        // action_rng is NOT drawn for A (oracle has no exploration step).
+        match algo {
+            Algorithm::OracleCeiling => {
+                if give_feedback {
+                    let mut target = best;
+                    if regime == Regime::Noisy && reward_noise_rng.r#gen::<f32>() < 0.20 {
+                        // Corrupt: pick a uniformly-random index != best.
+                        let mut wrong = reward_noise_rng.gen_range(0..(K - 1));
+                        if wrong >= best {
+                            wrong += 1;
+                        }
+                        target = wrong;
+                    }
+                    trainer.step(&mut gate, ctx.as_slice(), target, 1.0)?;
+                    effective_updates += 1;
+                }
+            }
+
+            Algorithm::M1RewardOnServed => {
+                // On-policy sample (always — not gated by give_feedback).
+                let logits = gate.forward(ctx.as_slice())?.to_vec();
+                let served = sample_categorical(&softmax(&logits), &mut action_rng);
+                if give_feedback {
+                    let mut reward = if served == best { 1.0_f32 } else { -1.0_f32 };
+                    if regime == Regime::Noisy && reward_noise_rng.r#gen::<f32>() < 0.20 {
+                        reward = -reward;
+                    }
+                    trainer.step(&mut gate, ctx.as_slice(), served, reward)?;
+                    effective_updates += 1;
+                }
+            }
+
+            Algorithm::Phase2PositiveOnly => {
+                // On-policy sample (always — not gated by give_feedback).
+                let logits = gate.forward(ctx.as_slice())?.to_vec();
+                let served = sample_categorical(&softmax(&logits), &mut action_rng);
+                if give_feedback {
+                    let mut positive = served == best;
+                    if regime == Regime::Noisy && reward_noise_rng.r#gen::<f32>() < 0.20 {
+                        positive = !positive;
+                    }
+                    if positive {
+                        // k=1 (top-1 subset), M=6 Gumbel samples with LOO baseline.
+                        trainer.rloo_step(&mut gate, ctx.as_slice(), served, 1, 6)?;
+                        effective_updates += 1;
+                    } else {
+                        // No negative-event interface in Phase-2 — drop.
+                        dropped += 1;
+                    }
+                }
+            }
+
+            Algorithm::Hybrid => {
+                // On-policy sample (always — not gated by give_feedback).
+                let logits = gate.forward(ctx.as_slice())?.to_vec();
+                let served = sample_categorical(&softmax(&logits), &mut action_rng);
+                if give_feedback {
+                    let mut positive = served == best;
+                    if regime == Regime::Noisy && reward_noise_rng.r#gen::<f32>() < 0.20 {
+                        positive = !positive;
+                    }
+                    if positive {
+                        // Multi-sample update: k=1 top-1 subset, M=6 Gumbel samples.
+                        trainer.rloo_step(&mut gate, ctx.as_slice(), served, 1, 6)?;
+                    } else {
+                        // Single-sample update with negative reward.
+                        trainer.step(&mut gate, ctx.as_slice(), served, -1.0)?;
+                    }
+                    effective_updates += 1;
+                }
+            }
+        }
+
+        // Step 4: checkpoint eval (greedy argmax on held-out set).
+        if checkpoints.contains(&round) {
+            let (accuracy, entropy_bits) = eval_metrics(&mut gate, eval_contexts, eval_true_best)?;
+            rows.push(CheckpointRow {
+                t: round,
+                accuracy,
+                entropy_bits,
+            });
+        }
+    }
+
+    Ok(ArmResult {
+        rows,
+        effective_updates,
+        dropped,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Output helpers
+// ---------------------------------------------------------------------------
+
+fn print_arm_table(title: &str, result: &ArmResult) {
+    println!(
+        "\n--- {title}  (eff_updates={}) ---",
+        result.effective_updates
+    );
+    println!("{:>6} | {:>10} | {:>14}", "T", "accuracy", "entropy (bits)");
+    println!("{}", "-".repeat(38));
+    for row in &result.rows {
+        println!(
+            "{:>6} | {:>10.4} | {:>14.4}",
+            row.t, row.accuracy, row.entropy_bits
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== Router Online-Learning 4×3 Head-to-Head Bench ===");
+    println!(
+        "seeds  weight:{WEIGHT_SEED}  gate:{GATE_SEED}  \
+         eval_class:{EVAL_CLASS_SEED}  eval_noise:{EVAL_NOISE_SEED}  \
+         train_class:{TRAIN_CLASS_SEED}  ctx_noise:{CTX_NOISE_SEED}  \
+         action:{ACTION_SEED}  reward_noise:{REWARD_NOISE_SEED}  \
+         sparse:{SPARSE_SEED}  trainer:{TRAINER_SEED}"
+    );
+    println!(
+        "K={K}  D={D}  N_eval={N_EVAL}  ctx_noise={NOISE}  \
+         lr=0.05  aux_loss_coeff=0.01  z_loss_coeff=0.001"
+    );
+
+    // -------------------------------------------------------------------------
+    // Ground-truth unit weight vectors (K × D).
+    // Each drawn from Uniform(−1,1) then L2-normalised → near-orthogonal in R^16.
+    // Routing rule: true_best(ctx) = argmax_k dot(ctx, w[k]).
+    // -------------------------------------------------------------------------
+    let mut weight_rng = SmallRng::seed_from_u64(WEIGHT_SEED);
+    let weights: Vec<Vec<f32>> = (0..K)
+        .map(|_| {
+            let raw: Vec<f32> = (0..D)
+                .map(|_| weight_rng.gen_range(-1.0_f32..1.0_f32))
+                .collect();
+            let norm = raw.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-9_f32);
+            raw.iter().map(|x| x / norm).collect()
+        })
+        .collect();
+
+    // -------------------------------------------------------------------------
+    // Held-out eval set: N_EVAL class-conditioned contexts.
+    // Seeds (200, 201) are disjoint from training seeds (100, 101).
+    // -------------------------------------------------------------------------
+    let mut eval_class_rng = SmallRng::seed_from_u64(EVAL_CLASS_SEED);
+    let mut eval_noise_rng = SmallRng::seed_from_u64(EVAL_NOISE_SEED);
+    let eval_contexts: Vec<Vec<f32>> = (0..N_EVAL)
+        .map(|_| {
+            let c = eval_class_rng.gen_range(0..K);
+            gen_context(c, &weights, &mut eval_noise_rng)
+        })
+        .collect();
+    let eval_true_best: Vec<usize> = eval_contexts
+        .iter()
+        .map(|c| true_best(c, &weights))
+        .collect();
+
+    let config = RlooConfig {
+        learning_rate: 0.05,
+        aux_loss_coeff: 0.01,
+        z_loss_coeff: 0.001,
+    };
+
+    let algos = [
+        Algorithm::OracleCeiling,
+        Algorithm::M1RewardOnServed,
+        Algorithm::Phase2PositiveOnly,
+        Algorithm::Hybrid,
+    ];
+    let algo_names = [
+        "A oracle-ceiling",
+        "B m1-reward-on-served",
+        "C phase2-positive-only",
+        "D hybrid",
+    ];
+
+    // (regime, label, rounds, checkpoints)
+    let regime_configs: &[(Regime, &str, usize, &[usize])] = &[
+        (Regime::Dense, "dense", 800, DENSE_NOISY_CPS),
+        (Regime::Noisy, "noisy", 800, DENSE_NOISY_CPS),
+        (Regime::Sparse, "sparse", 1600, SPARSE_CPS),
+    ];
+
+    // Run all 12 cells: [regime][algo].
+    let mut all_results: Vec<Vec<ArmResult>> = Vec::new();
+
+    for &(regime, regime_name, rounds, checkpoints) in regime_configs {
+        println!("\n========== REGIME: {regime_name} ==========");
+        let mut regime_results: Vec<ArmResult> = Vec::new();
+
+        for (ai, &algo) in algos.iter().enumerate() {
+            let result = run_arm(
+                &weights,
+                &eval_contexts,
+                &eval_true_best,
+                algo,
+                regime,
+                config.clone(),
+                rounds,
+                checkpoints,
+            )?;
+
+            let title = if algo == Algorithm::Phase2PositiveOnly {
+                format!("{} (dropped={})", algo_names[ai], result.dropped)
+            } else {
+                algo_names[ai].to_string()
+            };
+            print_arm_table(&title, &result);
+            regime_results.push(result);
+        }
+
+        all_results.push(regime_results);
+    }
+
+    // -------------------------------------------------------------------------
+    // Summary
+    // -------------------------------------------------------------------------
+    println!("\n========== SUMMARY MATRIX ==========");
+
+    // T=0 sanity from dense/A (all arms share the same initialisation).
+    let t0_opt = all_results
+        .first()
+        .and_then(|r| r.first())
+        .and_then(|a| a.rows.first());
+
+    if let Some(t0) = t0_opt {
+        println!(
+            "\nT=0 SANITY: accuracy={:.4}  (expected ≈ {:.4} = 1/K)  \
+             entropy={:.4} bits  (expected ≈ {:.4} = log2(K))",
+            t0.accuracy,
+            1.0_f32 / K as f32,
+            t0.entropy_bits,
+            (K as f32).log2()
+        );
+        if t0.accuracy > 0.40 {
+            println!(
+                "  *** LEAKAGE WARNING: T=0 accuracy {:.4} >> chance (0.25). \
+                 Verify eval seeds ({EVAL_CLASS_SEED},{EVAL_NOISE_SEED}) != \
+                 train seeds ({TRAIN_CLASS_SEED},{CTX_NOISE_SEED}). ***",
+                t0.accuracy
+            );
+        } else {
+            println!("  (T=0 looks clean — no leakage detected)");
+        }
+    }
+
+    println!();
+    println!(
+        "{:<8} | {:>12} | {:>12} | {:>12} | {:>12} | {:>8} | {:>8} | {:>8} | {:>8}",
+        "regime",
+        "A_final_acc",
+        "B_final_acc",
+        "C_final_acc",
+        "D_final_acc",
+        "A_ent",
+        "B_ent",
+        "C_ent",
+        "D_ent"
+    );
+    println!("{}", "-".repeat(112));
+
+    let regime_labels = ["dense", "noisy", "sparse"];
+    for (ri, regime_results) in all_results.iter().enumerate() {
+        let final_acc: Vec<f32> = regime_results
+            .iter()
+            .map(|r| r.rows.last().map(|row| row.accuracy).unwrap_or(0.0))
+            .collect();
+        let final_ent: Vec<f32> = regime_results
+            .iter()
+            .map(|r| r.rows.last().map(|row| row.entropy_bits).unwrap_or(0.0))
+            .collect();
+
+        println!(
+            "{:<8} | {:>12.4} | {:>12.4} | {:>12.4} | {:>12.4} | {:>8.4} | {:>8.4} | {:>8.4} | {:>8.4}",
+            regime_labels[ri],
+            final_acc.first().copied().unwrap_or(0.0),
+            final_acc.get(1).copied().unwrap_or(0.0),
+            final_acc.get(2).copied().unwrap_or(0.0),
+            final_acc.get(3).copied().unwrap_or(0.0),
+            final_ent.first().copied().unwrap_or(0.0),
+            final_ent.get(1).copied().unwrap_or(0.0),
+            final_ent.get(2).copied().unwrap_or(0.0),
+            final_ent.get(3).copied().unwrap_or(0.0),
+        );
+    }
+
+    // Per-regime headline.
+    println!();
+    for (ri, regime_results) in all_results.iter().enumerate() {
+        let a_acc = regime_results
+            .first()
+            .and_then(|r| r.rows.last())
+            .map(|row| row.accuracy)
+            .unwrap_or(0.0);
+        let b_acc = regime_results
+            .get(1)
+            .and_then(|r| r.rows.last())
+            .map(|row| row.accuracy)
+            .unwrap_or(0.0);
+        let c_acc = regime_results
+            .get(2)
+            .and_then(|r| r.rows.last())
+            .map(|row| row.accuracy)
+            .unwrap_or(0.0);
+        let d_acc = regime_results
+            .get(3)
+            .and_then(|r| r.rows.last())
+            .map(|row| row.accuracy)
+            .unwrap_or(0.0);
+
+        let b_pct_of_a = if a_acc > 0.0 {
+            b_acc / a_acc * 100.0
+        } else {
+            0.0
+        };
+        let c_vs_b_pts = (c_acc - b_acc) * 100.0;
+        let c_label = if c_vs_b_pts >= 0.0 { "beats" } else { "trails" };
+        let d_vs_b_pts = (d_acc - b_acc) * 100.0;
+        let d_label = if d_vs_b_pts >= 0.0 { "beats" } else { "trails" };
+
+        println!(
+            "{}: B reaches {:.1}% of A accuracy; C {} B by {:.1} pts; D {} B by {:.1} pts",
+            regime_labels[ri],
+            b_pct_of_a,
+            c_label,
+            c_vs_b_pts.abs(),
+            d_label,
+            d_vs_b_pts.abs()
+        );
+    }
+
+    Ok(())
+}

--- a/crates/fann/src/training/ewc.rs
+++ b/crates/fann/src/training/ewc.rs
@@ -9,7 +9,7 @@
 //! neural networks", PNAS 2017; Chaudhry et al., "Efficient Lifelong Learning
 //! with A-GEM", ICLR 2019 (EWC++ online variant).
 
-use crate::error::{FannError, FannResult};
+use crate::error::{FannError, FannResult, validate_allocation_size};
 
 /// Diagonal Fisher information matrix for Elastic Weight Consolidation (EWC++).
 ///
@@ -44,14 +44,34 @@ impl DiagonalFisher {
     /// Fisher estimate, then [`set_anchor`] once at the task boundary before
     /// starting the next task.
     ///
+    /// # Errors
+    ///
+    /// Returns [`FannError::InvalidDistributionParams`] if `decay` is non-finite
+    /// or outside the supported open interval `(0, 1)`.  Outside this interval the
+    /// EMA update `F ← decay·F + (1−decay)·g²` either stalls (`decay ≥ 1`, making
+    /// `1−decay ≤ 0` which reverses the penalty sign) or degenerates (`decay = 0`,
+    /// pure replacement with no memory).
+    ///
+    /// Returns [`FannError::ShapeTooLarge`] if `num_params` exceeds the
+    /// allocation safety limit.
+    ///
     /// [`observe_gradient`]: DiagonalFisher::observe_gradient
     /// [`set_anchor`]: DiagonalFisher::set_anchor
-    pub fn new(num_params: usize, decay: f32) -> Self {
-        Self {
+    pub fn new(num_params: usize, decay: f32) -> FannResult<Self> {
+        // Reject decay outside (0, 1) and non-finite values before any allocation.
+        // decay ≥ 1 makes (1−decay) ≤ 0, which reverses accumulated importance;
+        // decay = 0 collapses to pure-replacement with no EMA memory.
+        if !decay.is_finite() || decay <= 0.0 || decay >= 1.0 {
+            return Err(FannError::InvalidDistributionParams(format!(
+                "EWC decay must be finite and in the open interval (0, 1), got {decay}"
+            )));
+        }
+        validate_allocation_size(num_params)?;
+        Ok(Self {
             values: vec![0.0; num_params],
             anchor: vec![0.0; num_params],
             decay,
-        }
+        })
     }
 
     /// Update the diagonal Fisher estimate with one gradient observation.
@@ -168,12 +188,14 @@ impl DiagonalFisher {
 mod tests {
     use super::*;
 
+    use crate::error::MAX_ALLOWED_ELEMENTS;
+
     /// A degenerate Fisher (all-zero values) must leave delta unchanged.
     ///
     /// Verifies the early-return path in project_delta — no projection, no panic.
     #[test]
     fn ewc_degenerate_fisher_is_identity() {
-        let fisher = DiagonalFisher::new(4, 0.9);
+        let fisher = DiagonalFisher::new(4, 0.9).unwrap();
         let mut delta = vec![1.0_f32, -2.0, 3.0, -4.0];
         let original = delta.clone();
         // values are all zero → f_max < 1e-8 → early return.
@@ -187,21 +209,20 @@ mod tests {
     /// High-Fisher entry blocks its parameter's update; zero-Fisher entry passes.
     #[test]
     fn ewc_high_fisher_blocks() {
-        let mut fisher = DiagonalFisher::new(2, 0.0);
-        // decay=0 → observe_gradient fully replaces values with g².
+        let mut fisher = DiagonalFisher::new(2, 0.9).unwrap();
+        // decay=0.9 → F[0] = 0.9*0 + 0.1*100² = 1000; F[1] = 0.
         fisher.observe_gradient(&[100.0, 0.0]).unwrap();
-        // values == [10000.0, 0.0]; f_max == 10000.0.
 
         let mut delta = vec![1.0_f32, 1.0];
         fisher.project_delta(&mut delta);
 
-        // values[0] == f_max → scale = (1 - 1.0).max(0) = 0 → blocked.
+        // F[0] == f_max → scale = (1 - 1000/1000).max(0) = 0 → blocked.
         assert!(
             delta[0].abs() < 1e-6,
             "high-Fisher entry should be blocked, got {}",
             delta[0]
         );
-        // values[1] == 0 → scale = (1 - 0.0).max(0) = 1 → passes through.
+        // F[1] == 0 → scale = (1 - 0/1000).max(0) = 1 → passes through.
         assert!(
             (delta[1] - 1.0).abs() < 1e-6,
             "zero-Fisher entry should pass through, got {}",
@@ -209,11 +230,16 @@ mod tests {
         );
     }
 
-    /// With anchor=0, params=[2], Fisher=1, lambda=1 → out accumulates +2.
+    /// With anchor=0, params=[2], Fisher≈1, lambda=1 → out accumulates ≈+2.
+    ///
+    /// Uses decay=f32::EPSILON so (1−decay)≈1 and one unit-gradient observation
+    /// gives F[0]≈1.0; the penalty gradient is thus ≈ lambda·F[0]·(θ−θ*)=2.
+    /// This regression test pins the direction: positive gradient means the
+    /// update (w -= lr·g) pulls θ back toward the anchor, not away from it.
     #[test]
     fn ewc_penalty_gradient_pulls_to_anchor() {
-        let mut fisher = DiagonalFisher::new(1, 0.0);
-        // decay=0 → values[0] = g² = 1.0 after one unit-gradient observation.
+        let mut fisher = DiagonalFisher::new(1, f32::EPSILON).unwrap();
+        // decay≈0 → values[0] ≈ g² = 1.0 after one unit-gradient observation.
         fisher.observe_gradient(&[1.0]).unwrap();
         // anchor remains at zero (default).
 
@@ -221,20 +247,24 @@ mod tests {
         let mut out = vec![0.0_f32];
         fisher.penalty_gradient(&params, 1.0, &mut out).unwrap();
 
-        // Gradient = lambda * F[0] * (theta[0] - anchor[0]) = 1 * 1 * (2 - 0) = +2.
-        // Positive: this term is subtracted in gradient descent, pulling theta
-        // back toward the anchor and resisting forgetting.
+        // Gradient = lambda · F[0] · (theta[0] − anchor[0]) ≈ 1 · 1 · (2 − 0) = +2.
+        // Positive: subtracted in gradient descent → θ moves toward anchor.
         assert!(
-            (out[0] - 2.0).abs() < 1e-6,
-            "expected penalty gradient +2.0, got {}",
+            (out[0] - 2.0).abs() < 1e-5,
+            "expected penalty gradient ≈+2.0 (toward anchor), got {}",
             out[0]
+        );
+        // Direction check: penalty gradient must be strictly positive when θ > anchor.
+        assert!(
+            out[0] > 0.0,
+            "penalty gradient must be positive when theta > anchor (toward anchor)"
         );
     }
 
     /// Two EMA steps with decay=0.9 and unit gradient must match the closed-form.
     #[test]
     fn ewc_fisher_ema_accumulates() {
-        let mut fisher = DiagonalFisher::new(1, 0.9);
+        let mut fisher = DiagonalFisher::new(1, 0.9).unwrap();
 
         // Step 1: F = 0.9 * 0 + 0.1 * 1² = 0.1
         fisher.observe_gradient(&[1.0]).unwrap();
@@ -256,16 +286,92 @@ mod tests {
     /// observe_gradient with a wrong-length slice must return Err, not panic.
     #[test]
     fn ewc_length_mismatch_errors() {
-        let mut fisher = DiagonalFisher::new(4, 0.9);
+        let mut fisher = DiagonalFisher::new(4, 0.9).unwrap();
         let result = fisher.observe_gradient(&[1.0, 2.0]); // 2 != 4
         assert!(result.is_err(), "expected Err on length mismatch, got Ok");
+    }
+
+    // ---- BLOCKER 2 guard tests (allocation bounds) --------------------------
+
+    /// Constructing with num_params > MAX_ALLOWED_ELEMENTS must return Err, not panic.
+    ///
+    /// Mutation that breaks this: removing the `validate_allocation_size` call.
+    #[test]
+    fn diagonal_fisher_new_too_large_returns_err() {
+        let result = DiagonalFisher::new(MAX_ALLOWED_ELEMENTS + 1, 0.9);
+        assert!(
+            matches!(result, Err(FannError::ShapeTooLarge { .. })),
+            "expected ShapeTooLarge error for num_params > MAX, got {result:?}"
+        );
+    }
+
+    // ---- MAJOR 1 guard tests (decay validation) ----------------------------
+
+    /// decay = 0.0 must be rejected (lower bound of the open interval).
+    ///
+    /// Mutation that breaks this: removing or inverting the `decay <= 0.0` check.
+    #[test]
+    fn diagonal_fisher_new_decay_zero_returns_err() {
+        let result = DiagonalFisher::new(4, 0.0);
+        assert!(
+            matches!(result, Err(FannError::InvalidDistributionParams(_))),
+            "expected InvalidDistributionParams for decay=0.0, got {result:?}"
+        );
+    }
+
+    /// decay = 1.0 must be rejected (upper bound of the open interval).
+    ///
+    /// Mutation that breaks this: removing or inverting the `decay >= 1.0` check.
+    #[test]
+    fn diagonal_fisher_new_decay_one_returns_err() {
+        let result = DiagonalFisher::new(4, 1.0);
+        assert!(
+            matches!(result, Err(FannError::InvalidDistributionParams(_))),
+            "expected InvalidDistributionParams for decay=1.0, got {result:?}"
+        );
+    }
+
+    /// decay = -0.5 must be rejected (below zero).
+    ///
+    /// Mutation that breaks this: removing the `decay <= 0.0` check.
+    #[test]
+    fn diagonal_fisher_new_decay_negative_returns_err() {
+        let result = DiagonalFisher::new(4, -0.5);
+        assert!(
+            matches!(result, Err(FannError::InvalidDistributionParams(_))),
+            "expected InvalidDistributionParams for decay=-0.5, got {result:?}"
+        );
+    }
+
+    /// decay = NaN must be rejected.
+    ///
+    /// Mutation that breaks this: removing the `is_finite()` check.
+    #[test]
+    fn diagonal_fisher_new_decay_nan_returns_err() {
+        let result = DiagonalFisher::new(4, f32::NAN);
+        assert!(
+            matches!(result, Err(FannError::InvalidDistributionParams(_))),
+            "expected InvalidDistributionParams for decay=NaN, got {result:?}"
+        );
+    }
+
+    /// decay = +Inf must be rejected.
+    ///
+    /// Mutation that breaks this: removing the `is_finite()` check.
+    #[test]
+    fn diagonal_fisher_new_decay_inf_returns_err() {
+        let result = DiagonalFisher::new(4, f32::INFINITY);
+        assert!(
+            matches!(result, Err(FannError::InvalidDistributionParams(_))),
+            "expected InvalidDistributionParams for decay=+Inf, got {result:?}"
+        );
     }
 
     /// Serialise then deserialise must produce a structurally equal value.
     #[cfg(feature = "serde")]
     #[test]
     fn ewc_fisher_roundtrips() {
-        let mut fisher = DiagonalFisher::new(3, 0.9);
+        let mut fisher = DiagonalFisher::new(3, 0.9).unwrap();
         fisher.observe_gradient(&[1.0, 2.0, 3.0]).unwrap();
         fisher.set_anchor(&[0.1, 0.2, 0.3]).unwrap();
 

--- a/crates/fann/src/training/ewc.rs
+++ b/crates/fann/src/training/ewc.rs
@@ -1,0 +1,282 @@
+//! Elastic Weight Consolidation (EWC++) diagonal-Fisher forgetting guard.
+//!
+//! Prevents catastrophic forgetting during online or continual learning by
+//! penalising updates to parameters that were important for prior tasks.
+//! "Importance" is measured via an exponential moving average of squared
+//! gradients — a diagonal approximation to the Fisher information matrix.
+//!
+//! Reference: Kirkpatrick et al., "Overcoming catastrophic forgetting in
+//! neural networks", PNAS 2017; Chaudhry et al., "Efficient Lifelong Learning
+//! with A-GEM", ICLR 2019 (EWC++ online variant).
+
+use crate::error::{FannError, FannResult};
+
+/// Diagonal Fisher information matrix for Elastic Weight Consolidation (EWC++).
+///
+/// Tracks per-parameter importance via an exponential moving average (EMA) of
+/// squared gradients. Accumulate importance with [`observe_gradient`], fix the
+/// reference point at a task boundary with [`set_anchor`], then either call
+/// [`penalty_gradient`] to inject the EWC regularisation term into the backward
+/// pass, or [`project_delta`] to null-space-damp a raw parameter update.
+///
+/// All operations on flat `&[f32]` slices — no network type dependency.
+///
+/// [`observe_gradient`]: DiagonalFisher::observe_gradient
+/// [`set_anchor`]: DiagonalFisher::set_anchor
+/// [`penalty_gradient`]: DiagonalFisher::penalty_gradient
+/// [`project_delta`]: DiagonalFisher::project_delta
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DiagonalFisher {
+    /// Diagonal Fisher estimate: EMA of squared gradients, one entry per parameter.
+    pub values: Vec<f32>,
+    /// Anchor (reference) parameter vector captured at the end of a prior task.
+    pub anchor: Vec<f32>,
+    /// EMA decay factor ∈ (0, 1). Higher values give slower decay and longer memory.
+    pub decay: f32,
+}
+
+impl DiagonalFisher {
+    /// Create a new zeroed Fisher estimate for `num_params` parameters.
+    ///
+    /// Both `values` (Fisher diagonal) and `anchor` (reference parameters)
+    /// are initialised to zero. Call [`observe_gradient`] to warm up the
+    /// Fisher estimate, then [`set_anchor`] once at the task boundary before
+    /// starting the next task.
+    ///
+    /// [`observe_gradient`]: DiagonalFisher::observe_gradient
+    /// [`set_anchor`]: DiagonalFisher::set_anchor
+    pub fn new(num_params: usize, decay: f32) -> Self {
+        Self {
+            values: vec![0.0; num_params],
+            anchor: vec![0.0; num_params],
+            decay,
+        }
+    }
+
+    /// Update the diagonal Fisher estimate with one gradient observation.
+    ///
+    /// Applies the EWC++ online rule:
+    ///
+    /// ```text
+    /// F_i ← decay · F_i  +  (1 − decay) · g_i²
+    /// ```
+    ///
+    /// Call this after every backward pass on the prior-task distribution to
+    /// maintain a running importance estimate. Returns an error if `grad.len()`
+    /// does not equal the number of parameters this guard was created for.
+    pub fn observe_gradient(&mut self, grad: &[f32]) -> FannResult<()> {
+        if grad.len() != self.values.len() {
+            return Err(FannError::InputSizeMismatch {
+                expected: self.values.len(),
+                actual: grad.len(),
+            });
+        }
+        let one_minus_decay = 1.0 - self.decay;
+        for (f, &g) in self.values.iter_mut().zip(grad.iter()) {
+            // EMA of g² accumulates squared-gradient importance over time.
+            *f = self.decay * *f + one_minus_decay * g * g;
+        }
+        Ok(())
+    }
+
+    /// Fix the anchor (reference) parameter vector at a task boundary.
+    ///
+    /// The EWC penalty measures deviation from these anchor parameters, so
+    /// call this once after the prior task finishes training. Returns an
+    /// error if `params.len()` does not match the guard's parameter count.
+    pub fn set_anchor(&mut self, params: &[f32]) -> FannResult<()> {
+        if params.len() != self.anchor.len() {
+            return Err(FannError::InputSizeMismatch {
+                expected: self.anchor.len(),
+                actual: params.len(),
+            });
+        }
+        self.anchor.copy_from_slice(params);
+        Ok(())
+    }
+
+    /// Accumulate the EWC penalty gradient into `out`.
+    ///
+    /// The EWC regularisation loss is `(λ/2) Σ F_i (θ_i − θ*_i)²`.
+    /// Its gradient with respect to θ_i is `λ · F_i · (θ_i − θ*_i)`,
+    /// which is *added* into `out` — the caller subtracts the combined
+    /// gradient in the descent step.
+    ///
+    /// Returns an error if `params` or `out` have a different length than
+    /// the Fisher diagonal.
+    pub fn penalty_gradient(&self, params: &[f32], lambda: f32, out: &mut [f32]) -> FannResult<()> {
+        let n = self.values.len();
+        if params.len() != n {
+            return Err(FannError::InputSizeMismatch {
+                expected: n,
+                actual: params.len(),
+            });
+        }
+        if out.len() != n {
+            return Err(FannError::InputSizeMismatch {
+                expected: n,
+                actual: out.len(),
+            });
+        }
+        // self.anchor.len() == n by construction (set_anchor length-checks any update).
+        for (((v, anchor), p), out_elem) in self
+            .values
+            .iter()
+            .zip(self.anchor.iter())
+            .zip(params.iter())
+            .zip(out.iter_mut())
+        {
+            // Gradient of (λ/2)·F_i·(θ_i − θ*_i)² is λ·F_i·(θ_i − θ*_i).
+            *out_elem += lambda * v * (p - anchor);
+        }
+        Ok(())
+    }
+
+    /// Damp a raw parameter update `delta` toward the Fisher null-space.
+    ///
+    /// Diagonal approximation: parameters with high Fisher importance (large
+    /// squared-gradient EMA = important to prior tasks) have their update
+    /// magnitude scaled toward zero; parameters with near-zero Fisher pass
+    /// through unchanged.  Full SVD null-space projection is deferred; this
+    /// O(n) diagonal approximation is appropriate for online continual learning.
+    ///
+    /// Processes `min(delta.len(), self.values.len())` entries so the guard
+    /// can be used on parameter sub-slices without error.
+    ///
+    /// Degenerate-Fisher guard: if `f_max < 1e-8` (no importance signal has
+    /// accumulated yet) the function returns immediately — no projection, no
+    /// division, no panic.
+    pub fn project_delta(&self, delta: &mut [f32]) {
+        let f_max = self.values.iter().copied().fold(0.0_f32, f32::max);
+
+        // No importance signal has been observed yet — treat as identity.
+        if f_max < 1e-8 {
+            return;
+        }
+
+        // High-Fisher parameters are important to past tasks; damping their
+        // update toward zero reduces forgetting.  Low-Fisher parameters
+        // (values[i]/f_max ≈ 0) are free to change and pass through at scale ≈ 1.
+        for (d, &v) in delta.iter_mut().zip(self.values.iter()) {
+            *d *= (1.0 - v / f_max).max(0.0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A degenerate Fisher (all-zero values) must leave delta unchanged.
+    ///
+    /// Verifies the early-return path in project_delta — no projection, no panic.
+    #[test]
+    fn ewc_degenerate_fisher_is_identity() {
+        let fisher = DiagonalFisher::new(4, 0.9);
+        let mut delta = vec![1.0_f32, -2.0, 3.0, -4.0];
+        let original = delta.clone();
+        // values are all zero → f_max < 1e-8 → early return.
+        fisher.project_delta(&mut delta);
+        assert_eq!(
+            delta, original,
+            "degenerate Fisher must be identity on project_delta"
+        );
+    }
+
+    /// High-Fisher entry blocks its parameter's update; zero-Fisher entry passes.
+    #[test]
+    fn ewc_high_fisher_blocks() {
+        let mut fisher = DiagonalFisher::new(2, 0.0);
+        // decay=0 → observe_gradient fully replaces values with g².
+        fisher.observe_gradient(&[100.0, 0.0]).unwrap();
+        // values == [10000.0, 0.0]; f_max == 10000.0.
+
+        let mut delta = vec![1.0_f32, 1.0];
+        fisher.project_delta(&mut delta);
+
+        // values[0] == f_max → scale = (1 - 1.0).max(0) = 0 → blocked.
+        assert!(
+            delta[0].abs() < 1e-6,
+            "high-Fisher entry should be blocked, got {}",
+            delta[0]
+        );
+        // values[1] == 0 → scale = (1 - 0.0).max(0) = 1 → passes through.
+        assert!(
+            (delta[1] - 1.0).abs() < 1e-6,
+            "zero-Fisher entry should pass through, got {}",
+            delta[1]
+        );
+    }
+
+    /// With anchor=0, params=[2], Fisher=1, lambda=1 → out accumulates +2.
+    #[test]
+    fn ewc_penalty_gradient_pulls_to_anchor() {
+        let mut fisher = DiagonalFisher::new(1, 0.0);
+        // decay=0 → values[0] = g² = 1.0 after one unit-gradient observation.
+        fisher.observe_gradient(&[1.0]).unwrap();
+        // anchor remains at zero (default).
+
+        let params = vec![2.0_f32];
+        let mut out = vec![0.0_f32];
+        fisher.penalty_gradient(&params, 1.0, &mut out).unwrap();
+
+        // Gradient = lambda * F[0] * (theta[0] - anchor[0]) = 1 * 1 * (2 - 0) = +2.
+        // Positive: this term is subtracted in gradient descent, pulling theta
+        // back toward the anchor and resisting forgetting.
+        assert!(
+            (out[0] - 2.0).abs() < 1e-6,
+            "expected penalty gradient +2.0, got {}",
+            out[0]
+        );
+    }
+
+    /// Two EMA steps with decay=0.9 and unit gradient must match the closed-form.
+    #[test]
+    fn ewc_fisher_ema_accumulates() {
+        let mut fisher = DiagonalFisher::new(1, 0.9);
+
+        // Step 1: F = 0.9 * 0 + 0.1 * 1² = 0.1
+        fisher.observe_gradient(&[1.0]).unwrap();
+        assert!(
+            (fisher.values[0] - 0.1).abs() < 1e-6,
+            "after step 1 expected 0.1, got {}",
+            fisher.values[0]
+        );
+
+        // Step 2: F = 0.9 * 0.1 + 0.1 * 1² = 0.09 + 0.10 = 0.19
+        fisher.observe_gradient(&[1.0]).unwrap();
+        assert!(
+            (fisher.values[0] - 0.19).abs() < 1e-6,
+            "after step 2 expected 0.19, got {}",
+            fisher.values[0]
+        );
+    }
+
+    /// observe_gradient with a wrong-length slice must return Err, not panic.
+    #[test]
+    fn ewc_length_mismatch_errors() {
+        let mut fisher = DiagonalFisher::new(4, 0.9);
+        let result = fisher.observe_gradient(&[1.0, 2.0]); // 2 != 4
+        assert!(result.is_err(), "expected Err on length mismatch, got Ok");
+    }
+
+    /// Serialise then deserialise must produce a structurally equal value.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn ewc_fisher_roundtrips() {
+        let mut fisher = DiagonalFisher::new(3, 0.9);
+        fisher.observe_gradient(&[1.0, 2.0, 3.0]).unwrap();
+        fisher.set_anchor(&[0.1, 0.2, 0.3]).unwrap();
+
+        let json = serde_json::to_string(&fisher).unwrap();
+        let recovered: DiagonalFisher = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(fisher.values, recovered.values);
+        assert_eq!(fisher.anchor, recovered.anchor);
+        assert!(
+            (fisher.decay - recovered.decay).abs() < 1e-9,
+            "decay mismatch after roundtrip"
+        );
+    }
+}

--- a/crates/fann/src/training/ewc.rs
+++ b/crates/fann/src/training/ewc.rs
@@ -291,7 +291,7 @@ mod tests {
         assert!(result.is_err(), "expected Err on length mismatch, got Ok");
     }
 
-    // ---- BLOCKER 2 guard tests (allocation bounds) --------------------------
+    // ---- Allocation-bound guard tests ---------------------------------------
 
     /// Constructing with num_params > MAX_ALLOWED_ELEMENTS must return Err, not panic.
     ///
@@ -305,7 +305,7 @@ mod tests {
         );
     }
 
-    // ---- MAJOR 1 guard tests (decay validation) ----------------------------
+    // ---- Decay-validation guard tests ---------------------------------------
 
     /// decay = 0.0 must be rejected (lower bound of the open interval).
     ///

--- a/crates/fann/src/training/mod.rs
+++ b/crates/fann/src/training/mod.rs
@@ -4,13 +4,17 @@
 //! and optimization strategies.
 
 mod backprop;
+#[cfg(feature = "online-router")]
 pub mod ewc;
 mod gradient;
+#[cfg(feature = "online-router")]
 pub mod rloo;
 
 pub use backprop::BackpropTrainer;
+#[cfg(feature = "online-router")]
 pub use ewc::DiagonalFisher;
 pub use gradient::GradientGuardStrategy;
+#[cfg(feature = "online-router")]
 pub use rloo::{RlooConfig, RlooTrainer};
 
 use crate::error::FannResult;
@@ -147,6 +151,23 @@ pub trait Trainer {
         targets: &[Vec<f32>],
         config: &TrainingConfig,
     ) -> FannResult<TrainingResult>;
+}
+
+// Structural reachability test: when online-router is enabled the public types
+// must be importable through the training module path.  Without the feature the
+// entire ewc/rloo sub-modules are absent, so the check is compile-time only.
+#[cfg(all(test, feature = "online-router"))]
+mod online_router_reachability {
+    use super::{DiagonalFisher, RlooConfig, RlooTrainer};
+
+    #[test]
+    fn online_router_types_are_reachable() {
+        // Merely naming the types proves the feature gate exposes them.
+        let _: Option<DiagonalFisher> = None;
+        let _config = RlooConfig::default();
+        // RlooTrainer::new is non-Copy but constructible — just confirm the path resolves.
+        let _trainer = RlooTrainer::new(RlooConfig::default());
+    }
 }
 
 #[cfg(test)]

--- a/crates/fann/src/training/mod.rs
+++ b/crates/fann/src/training/mod.rs
@@ -4,10 +4,14 @@
 //! and optimization strategies.
 
 mod backprop;
+pub mod ewc;
 mod gradient;
+pub mod rloo;
 
 pub use backprop::BackpropTrainer;
+pub use ewc::DiagonalFisher;
 pub use gradient::GradientGuardStrategy;
+pub use rloo::{RlooConfig, RlooTrainer};
 
 use crate::error::FannResult;
 use crate::network::Network;

--- a/crates/fann/src/training/rloo.rs
+++ b/crates/fann/src/training/rloo.rs
@@ -1,0 +1,616 @@
+//! REINFORCE with Leave-One-Out baseline (RLOO) policy-gradient trainer.
+//!
+//! Trains a selector gate network to prefer adapters that produce positive
+//! reward signals. The gate network must use `Activation::Linear` on its
+//! output layer (raw logits); softmax is applied inside this module.
+//!
+//! EWC forgetting-guard integration is intentionally absent here — compose
+//! [`crate::training::ewc::DiagonalFisher`] at the call site to pin prior-task
+//! parameters independently of the policy-gradient update.
+
+use crate::activation::Activation;
+use crate::error::{FannError, FannResult};
+use crate::network::Network;
+
+use rand::Rng;
+use rand::SeedableRng;
+
+/// Hyperparameters for one policy-gradient refit step.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RlooConfig {
+    /// Step size applied per policy-gradient update.
+    pub learning_rate: f32,
+    /// Coefficient for the load-balance auxiliary loss (prevents routing collapse).
+    pub aux_loss_coeff: f32,
+    /// Coefficient for the router z-loss (discourages logit explosion).
+    pub z_loss_coeff: f32,
+}
+
+impl Default for RlooConfig {
+    fn default() -> Self {
+        Self {
+            learning_rate: 1e-3,
+            aux_loss_coeff: 0.01,
+            z_loss_coeff: 0.001,
+        }
+    }
+}
+
+/// Single-sample policy-gradient trainer for a selector gate.
+///
+/// The gate is a `Network` whose output layer activation is `Linear` (it
+/// returns raw logits; softmax is applied here in the loss, not in the
+/// network).
+///
+/// EWC forgetting-guard integration is intentionally outside this struct —
+/// compose `DiagonalFisher` at the call site to apply penalty gradients on
+/// top of the policy-gradient delta independently.
+pub struct RlooTrainer {
+    config: RlooConfig,
+    /// RNG used for Gumbel-max sampling in the Phase-2 multi-sample path.
+    rng: rand::rngs::SmallRng,
+}
+
+impl RlooTrainer {
+    /// Create a new trainer, seeding the RNG from system entropy.
+    pub fn new(config: RlooConfig) -> Self {
+        Self {
+            config,
+            rng: rand::rngs::SmallRng::from_entropy(),
+        }
+    }
+
+    /// Create a new trainer with a fixed RNG seed for deterministic behaviour.
+    ///
+    /// Prefer this constructor in tests to guarantee reproducible results.
+    pub fn with_seed(config: RlooConfig, seed: u64) -> Self {
+        Self {
+            config,
+            rng: rand::rngs::SmallRng::seed_from_u64(seed),
+        }
+    }
+
+    /// Phase-1 single-sample REINFORCE step (M=1), the active path.
+    ///
+    /// `action_idx` is the adapter index the reward is about:
+    ///   - positive reward  → `action_idx` = the preferred adapter
+    ///   - negative reward  → `action_idx` = the selected adapter (push it down)
+    ///
+    /// `reward` carries polarity AND strength: `+1.0` / `−1.0` explicit,
+    /// `+0.5` / `−0.5` implicit. There is exactly one code path for ±reward —
+    /// the sign is embedded in the gradient formula; no special-casing for
+    /// negative reward.
+    ///
+    /// Returns the scalar policy loss `−reward · log p[action_idx]` for logging.
+    pub fn step(
+        &mut self,
+        gate: &mut Network,
+        context: &[f32],
+        action_idx: usize,
+        reward: f32,
+    ) -> FannResult<f32> {
+        let num_inputs = gate.num_inputs();
+        let num_outputs = gate.num_outputs();
+        let num_layers = gate.num_layers();
+
+        if context.len() != num_inputs {
+            return Err(FannError::InputSizeMismatch {
+                expected: num_inputs,
+                actual: context.len(),
+            });
+        }
+
+        if action_idx >= num_outputs {
+            return Err(FannError::InputSizeMismatch {
+                expected: num_outputs,
+                actual: action_idx.saturating_add(1),
+            });
+        }
+
+        // Gate output layer must be Linear (raw logits, softmax applied here).
+        {
+            let layers = gate.layers();
+            if !matches!(layers[num_layers - 1].activation(), Activation::Linear) {
+                return Err(FannError::TrainingError(
+                    "rloo gate output layer must be Linear (logits)".into(),
+                ));
+            }
+        }
+
+        // Forward pass (populates activation buffers).
+        let logits: Vec<f32> = gate.forward(context)?.to_vec();
+
+        let probs = softmax(&logits);
+        let lse = log_sum_exp(&logits);
+
+        let k = num_outputs;
+        let sum_p_sq: f32 = probs.iter().map(|&p| p * p).sum();
+        // Scalar used in the load-balance gradient (computed once).
+        let c = sum_p_sq - 1.0 / k as f32;
+
+        // Output-layer error vector g (length K).
+        //
+        // Because the output activation is Linear (derivative = 1), g is the
+        // pre-activation error directly — no additional derivative multiply.
+        //
+        // g[j] = reward * (p[j] − onehot(action)[j])          (1) policy term
+        //      + aux_coeff * (2/K) * p[j] * (p[j] − 1/K − c) (2) load-balance
+        //      + z_coeff   * 2 * LSE * p[j]                   (3) z-loss
+        //
+        // For reward > 0 the policy term is the CE gradient pulling q(action) UP.
+        // For reward < 0 the sign flips and pushes q(action) DOWN.
+        // One code path handles both — DO NOT special-case negative reward.
+        let output_deltas: Vec<f32> = probs
+            .iter()
+            .enumerate()
+            .map(|(j, &pj)| {
+                let onehot_j = if j == action_idx { 1.0_f32 } else { 0.0_f32 };
+                let policy = reward * (pj - onehot_j);
+                let aux =
+                    self.config.aux_loss_coeff * (2.0 / k as f32) * pj * (pj - 1.0 / k as f32 - c);
+                let zloss = self.config.z_loss_coeff * 2.0 * lse * pj;
+                policy + aux + zloss
+            })
+            .collect();
+
+        self.backprop_and_apply(gate, context, &output_deltas, num_layers)?;
+
+        // Scalar policy loss for caller logging.
+        let loss = -reward * probs[action_idx].max(1e-9).ln();
+        Ok(loss)
+    }
+
+    /// Phase-2 full RLOO multi-sample step (M > 1).
+    ///
+    /// Draws `m_samples` k-subsets via Gumbel-max sampling and uses a
+    /// leave-one-out baseline to reduce gradient variance. Returns the mean
+    /// reward across samples.
+    ///
+    /// This is not the default path — activate via the bench harness when
+    /// comparing against Phase-1.
+    pub fn rloo_step(
+        &mut self,
+        gate: &mut Network,
+        context: &[f32],
+        preferred_idx: usize,
+        k: usize,
+        m_samples: usize,
+    ) -> FannResult<f32> {
+        let num_inputs = gate.num_inputs();
+        let num_outputs = gate.num_outputs();
+        let num_layers = gate.num_layers();
+
+        if context.len() != num_inputs {
+            return Err(FannError::InputSizeMismatch {
+                expected: num_inputs,
+                actual: context.len(),
+            });
+        }
+
+        if preferred_idx >= num_outputs {
+            return Err(FannError::InputSizeMismatch {
+                expected: num_outputs,
+                actual: preferred_idx.saturating_add(1),
+            });
+        }
+
+        if k < 1 || k > num_outputs {
+            return Err(FannError::TrainingError(format!(
+                "rloo_step: k={k} out of range [1, {num_outputs}]"
+            )));
+        }
+
+        if m_samples < 1 {
+            return Err(FannError::TrainingError(
+                "rloo_step: m_samples must be >= 1".into(),
+            ));
+        }
+
+        {
+            let layers = gate.layers();
+            if !matches!(layers[num_layers - 1].activation(), Activation::Linear) {
+                return Err(FannError::TrainingError(
+                    "rloo gate output layer must be Linear (logits)".into(),
+                ));
+            }
+        }
+
+        let logits: Vec<f32> = gate.forward(context)?.to_vec();
+        let probs = softmax(&logits);
+        let lse = log_sum_exp(&logits);
+
+        // Gumbel-max sampling: draw m_samples k-subsets.
+        let mut rewards: Vec<f32> = Vec::with_capacity(m_samples);
+        let mut subsets: Vec<Vec<usize>> = Vec::with_capacity(m_samples);
+
+        for _ in 0..m_samples {
+            // Perturb each logit with independent Gumbel(0,1) noise:
+            //   g_i = s_i + (−ln(−ln(u_i))),  u_i ~ Uniform(0,1) open interval.
+            let mut perturbed: Vec<(f32, usize)> = logits
+                .iter()
+                .enumerate()
+                .map(|(i, &s)| {
+                    let u: f32 = {
+                        let raw: f32 = self.rng.r#gen::<f32>();
+                        // Clamp to open (0,1) to avoid ln(0).
+                        raw.clamp(1e-38_f32, 1.0 - f32::EPSILON)
+                    };
+                    let gumbel_noise = -(-u.ln()).ln();
+                    (s + gumbel_noise, i)
+                })
+                .collect();
+
+            // Select top-k by perturbed logit (descending).
+            perturbed.sort_unstable_by(|a, b| {
+                b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
+            });
+            let subset: Vec<usize> = perturbed.iter().take(k).map(|&(_, i)| i).collect();
+
+            let r = if subset.contains(&preferred_idx) {
+                1.0_f32
+            } else {
+                -1.0_f32
+            };
+            rewards.push(r);
+            subsets.push(subset);
+        }
+
+        // Build output-layer gradient with leave-one-out baseline.
+        let reward_sum: f32 = rewards.iter().sum();
+        let ko = num_outputs;
+        let sum_p_sq: f32 = probs.iter().map(|&p| p * p).sum();
+        let c = sum_p_sq - 1.0 / ko as f32;
+
+        let mut output_deltas = vec![0.0_f32; ko];
+
+        for (r_m, subset_m) in rewards.iter().zip(subsets.iter()) {
+            // Leave-one-out baseline: (ΣR − R_m) / (M − 1); 0 if M == 1.
+            let baseline = if m_samples > 1 {
+                (reward_sum - r_m) / (m_samples - 1) as f32
+            } else {
+                0.0
+            };
+            let advantage = r_m - baseline;
+
+            // g[j] += -(1/M) * advantage * (count(j ∈ subset) − k · p[j])
+            for j in 0..ko {
+                let in_subset: f32 = subset_m
+                    .iter()
+                    .map(|&i| if i == j { 1.0_f32 } else { 0.0_f32 })
+                    .sum();
+                output_deltas[j] +=
+                    -(1.0 / m_samples as f32) * advantage * (in_subset - probs[j] * k as f32);
+            }
+        }
+
+        // Aux and z-loss terms (identical to step).
+        for (j, &pj) in probs.iter().enumerate() {
+            let aux =
+                self.config.aux_loss_coeff * (2.0 / ko as f32) * pj * (pj - 1.0 / ko as f32 - c);
+            let zloss = self.config.z_loss_coeff * 2.0 * lse * pj;
+            output_deltas[j] += aux + zloss;
+        }
+
+        self.backprop_and_apply(gate, context, &output_deltas, num_layers)?;
+
+        Ok(reward_sum / m_samples as f32)
+    }
+
+    /// Backpropagate the output-layer delta through hidden layers and apply
+    /// a plain SGD update (no momentum, no weight decay).
+    ///
+    /// Mirrors `backprop.rs::compute_gradients` lines 94–152 (hidden-layer
+    /// backprop) and `apply_gradients` lines 170–191 (simplified, batch_size=1).
+    fn backprop_and_apply(
+        &self,
+        gate: &mut Network,
+        input: &[f32],
+        output_deltas: &[f32],
+        num_layers: usize,
+    ) -> FannResult<()> {
+        // --- Phase 1: compute all layer deltas and accumulate gradients ---
+        // Both gate.layers() and gate.activations() are &self borrows and may
+        // coexist simultaneously; they are released before the mutable apply phase.
+        let (weight_grads, bias_grads) = {
+            // Start with the output-layer delta (from caller).
+            let mut deltas: Vec<Vec<f32>> = Vec::with_capacity(num_layers);
+            deltas.push(output_deltas.to_vec());
+
+            // Mirror backprop.rs:94-121: propagate deltas backward through hidden layers.
+            let layers = gate.layers(); // shared borrow: released at end of this block
+            for layer_idx in (0..num_layers - 1).rev() {
+                let layer_activation = layers[layer_idx].activation();
+                let layer_num_outputs = layers[layer_idx].num_outputs();
+                let next_num_inputs = layers[layer_idx + 1].num_inputs();
+                let next_num_outputs = layers[layer_idx + 1].num_outputs();
+                let next_weights = layers[layer_idx + 1].weights();
+
+                let prev_deltas = deltas.last().ok_or_else(|| {
+                    FannError::TrainingError("empty deltas during backpropagation".to_string())
+                })?;
+
+                // gate.activations() is also a &self borrow — OK alongside layers.
+                let layer_activations = gate.activations(layer_idx).ok_or_else(|| {
+                    FannError::TrainingError(format!("missing activations for layer {layer_idx}"))
+                })?;
+
+                let mut layer_deltas = vec![0.0_f32; layer_num_outputs];
+                for i in 0..layer_num_outputs {
+                    let mut sum = 0.0_f32;
+                    for j in 0..next_num_outputs {
+                        // Weight layout: row-major, row j, column i.
+                        let weight = next_weights[j * next_num_inputs + i];
+                        sum += weight * prev_deltas[j];
+                    }
+                    let deriv = layer_activation.derivative(layer_activations[i]);
+                    layer_deltas[i] = sum * deriv;
+                }
+
+                deltas.push(layer_deltas);
+            }
+            // Mirror backprop.rs:123-124: reverse to forward layer order.
+            deltas.reverse();
+
+            // Allocate gradient buffers (mirror backprop.rs:126-152).
+            let mut weight_grads: Vec<Vec<f32>> = layers
+                .iter()
+                .map(|l| vec![0.0_f32; l.weights().len()])
+                .collect();
+            let mut bias_grads: Vec<Vec<f32>> = layers
+                .iter()
+                .map(|l| vec![0.0_f32; l.biases().len()])
+                .collect();
+
+            for (layer_idx, delta) in deltas.iter().enumerate() {
+                let num_i = layers[layer_idx].num_inputs();
+                let num_o = layers[layer_idx].num_outputs();
+
+                let layer_input: &[f32] = if layer_idx == 0 {
+                    input
+                } else {
+                    gate.activations(layer_idx - 1).ok_or_else(|| {
+                        FannError::TrainingError(format!(
+                            "missing activations for layer {}",
+                            layer_idx - 1
+                        ))
+                    })?
+                };
+
+                // dW[i,j] = delta[i] * input[j]
+                for (i, &d) in delta.iter().enumerate().take(num_o) {
+                    for (j, &inp) in layer_input.iter().enumerate().take(num_i) {
+                        weight_grads[layer_idx][i * num_i + j] += d * inp;
+                    }
+                }
+
+                // dB[i] = delta[i]
+                for (i, &d) in delta.iter().enumerate().take(num_o) {
+                    bias_grads[layer_idx][i] += d;
+                }
+            }
+
+            (weight_grads, bias_grads)
+            // `layers` (shared borrow) drops here — gate is free for mutation.
+        };
+
+        // --- Phase 2: apply plain SGD (mirror backprop.rs:170-191, no momentum) ---
+        let lr = self.config.learning_rate;
+        for layer_idx in 0..num_layers {
+            let Some(layer) = gate.layer_mut(layer_idx) else {
+                continue;
+            };
+
+            let weights = layer.weights_mut();
+            for (w, &g) in weights.iter_mut().zip(weight_grads[layer_idx].iter()) {
+                *w -= lr * g;
+            }
+
+            let biases = layer.biases_mut();
+            for (b, &g) in biases.iter_mut().zip(bias_grads[layer_idx].iter()) {
+                *b -= lr * g;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Load-balance auxiliary loss: `(1/K) Σ_i (p_i − 1/K)²`.
+///
+/// Penalises routing collapse where one adapter receives most probability mass.
+/// `probs` should be the softmax of the gate logits.
+pub fn load_balance_aux_loss(probs: &[f32]) -> f32 {
+    if probs.is_empty() {
+        return 0.0;
+    }
+    let k = probs.len() as f32;
+    let uniform = 1.0 / k;
+    probs
+        .iter()
+        .map(|&p| (p - uniform) * (p - uniform))
+        .sum::<f32>()
+        / k
+}
+
+/// Router z-loss: `(log Σ_i exp(s_i))²`.
+///
+/// Discourages logit explosion by penalising large log-sum-exp values.
+/// `logits` should be the raw gate output (pre-softmax).
+pub fn router_z_loss(logits: &[f32]) -> f32 {
+    let lse = log_sum_exp(logits);
+    lse * lse
+}
+
+// --- Private helpers ---
+
+/// Numerically stable softmax: subtract max before exp to prevent overflow.
+fn softmax(logits: &[f32]) -> Vec<f32> {
+    if logits.is_empty() {
+        return Vec::new();
+    }
+    let max_val = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let exps: Vec<f32> = logits.iter().map(|&s| (s - max_val).exp()).collect();
+    let sum: f32 = exps.iter().sum();
+    if sum == 0.0 {
+        // Degenerate case: return uniform distribution.
+        vec![1.0 / logits.len() as f32; logits.len()]
+    } else {
+        exps.iter().map(|&e| e / sum).collect()
+    }
+}
+
+/// Numerically stable log-sum-exp: `max(s) + log Σ_i exp(s_i − max(s))`.
+fn log_sum_exp(logits: &[f32]) -> f32 {
+    if logits.is_empty() {
+        return 0.0;
+    }
+    let max_val = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let sum: f32 = logits.iter().map(|&s| (s - max_val).exp()).sum();
+    max_val + sum.ln()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::activation::Activation;
+    use crate::network::NetworkBuilder;
+
+    /// Build a deterministic 4-input → 8-hidden(ReLU) → 4-output(Linear) gate.
+    fn test_gate() -> Network {
+        NetworkBuilder::new()
+            .input(4)
+            .hidden(8, Activation::ReLU)
+            .output(4, Activation::Linear)
+            .build_with_seed(1)
+            .unwrap()
+    }
+
+    const CTX: [f32; 4] = [0.1, -0.2, 0.3, 0.4];
+
+    /// A positive reward on action 2 must increase the logit for action 2.
+    ///
+    /// Mutation that fails this test: setting learning_rate to 0 or zeroing
+    /// the policy gradient term in `step`.
+    #[test]
+    fn rloo_positive_reward_increases_action_score() {
+        let mut gate = test_gate();
+        let mut trainer = RlooTrainer::with_seed(RlooConfig::default(), 1);
+
+        let before = gate.forward(&CTX).unwrap()[2];
+        trainer.step(&mut gate, &CTX, 2, 1.0).unwrap();
+        let after = gate.forward(&CTX).unwrap()[2];
+
+        assert!(
+            after > before,
+            "positive reward must increase action score: before={before}, after={after}"
+        );
+    }
+
+    /// A negative reward on action 1 must DECREASE the logit for action 1.
+    ///
+    /// This is the critical polarity test. Mutation that fails: dropping the
+    /// `reward *` factor (treating −1.0 as +1.0) or routing negative reward
+    /// through a cross-entropy call toward a different preferred index.
+    #[test]
+    fn rloo_negative_reward_decreases_action_score() {
+        let mut gate = test_gate();
+        let mut trainer = RlooTrainer::with_seed(RlooConfig::default(), 1);
+
+        let before = gate.forward(&CTX).unwrap()[1];
+        trainer.step(&mut gate, &CTX, 1, -1.0).unwrap();
+        let after = gate.forward(&CTX).unwrap()[1];
+
+        assert!(
+            after < before,
+            "negative reward must decrease action score (polarity test): before={before}, after={after}"
+        );
+    }
+
+    /// Load-balance loss must be nonzero for a peaked distribution and near
+    /// zero for a uniform distribution.
+    ///
+    /// Mutation that fails: returning 0.0 unconditionally.
+    #[test]
+    fn load_balance_aux_loss_nonzero_on_skewed() {
+        let skewed_logits = [10.0_f32, -10.0, -10.0, -10.0];
+        let probs = softmax(&skewed_logits);
+        let loss = load_balance_aux_loss(&probs);
+        assert!(
+            loss > 1e-6,
+            "load-balance loss must be nonzero on skewed distribution, got {loss}"
+        );
+
+        let uniform = [0.25_f32; 4];
+        let uniform_loss = load_balance_aux_loss(&uniform);
+        assert!(
+            uniform_loss < 1e-6,
+            "load-balance loss must be near zero for uniform distribution, got {uniform_loss}"
+        );
+    }
+
+    /// Router z-loss must be strictly larger for large logits than for zero logits.
+    ///
+    /// Mutation that fails: returning 0.0 unconditionally.
+    #[test]
+    fn router_z_loss_nonzero_on_large_logits() {
+        let large = [100.0_f32; 4];
+        let small = [0.0_f32; 4];
+        let z_large = router_z_loss(&large);
+        let z_small = router_z_loss(&small);
+        assert!(
+            z_large > z_small,
+            "z-loss must be larger for large logits: z_large={z_large}, z_small={z_small}"
+        );
+        assert!(
+            z_large > 1e-6,
+            "z-loss must be nonzero for large logits, got {z_large}"
+        );
+    }
+
+    /// Wrong context dimension must return Err, not panic.
+    #[test]
+    fn rloo_wrong_context_dim_errors() {
+        let mut gate = test_gate();
+        let mut trainer = RlooTrainer::with_seed(RlooConfig::default(), 1);
+        let wrong_ctx = [1.0_f32; 5]; // gate expects 4
+        let result = trainer.step(&mut gate, &wrong_ctx, 0, 1.0);
+        assert!(
+            result.is_err(),
+            "wrong context dimension must return Err, not panic"
+        );
+    }
+
+    /// Explicit reward (+1.0) must move the action logit more than implicit (+0.5).
+    ///
+    /// Mutation that fails: computing the gradient without the `reward *` scale
+    /// factor, or treating all rewards as +1.0.
+    #[test]
+    fn rloo_implicit_weaker_than_explicit() {
+        let gate_base = test_gate();
+
+        let mut gate_explicit = gate_base.clone();
+        let mut gate_implicit = gate_base;
+
+        let mut trainer_e = RlooTrainer::with_seed(RlooConfig::default(), 1);
+        let mut trainer_i = RlooTrainer::with_seed(RlooConfig::default(), 1);
+
+        let before_e = gate_explicit.forward(&CTX).unwrap()[2];
+        let before_i = gate_implicit.forward(&CTX).unwrap()[2];
+
+        trainer_e.step(&mut gate_explicit, &CTX, 2, 1.0).unwrap();
+        trainer_i.step(&mut gate_implicit, &CTX, 2, 0.5).unwrap();
+
+        let after_e = gate_explicit.forward(&CTX).unwrap()[2];
+        let after_i = gate_implicit.forward(&CTX).unwrap()[2];
+
+        let delta_e = (after_e - before_e).abs();
+        let delta_i = (after_i - before_i).abs();
+
+        assert!(
+            delta_e > delta_i,
+            "explicit reward (+1.0) must move action score more than implicit (+0.5): \
+             delta_e={delta_e}, delta_i={delta_i}"
+        );
+    }
+}

--- a/crates/fann/src/training/rloo.rs
+++ b/crates/fann/src/training/rloo.rs
@@ -217,8 +217,17 @@ impl RlooTrainer {
         }
 
         // Reject caller-supplied sizes that would cause Vec::with_capacity to OOM.
-        // m_samples drives two allocations of that length below.
+        // m_samples sizes the rewards/subsets outer vecs directly; the retained
+        // subsets additionally hold m_samples * k indices in aggregate. k alone is
+        // range-checked, but the product can still overflow usize or exceed the
+        // allocation cap, so bound the product before any allocation runs.
         validate_allocation_size(m_samples)?;
+        let subset_storage = m_samples.checked_mul(k).ok_or_else(|| {
+            FannError::TrainingError(format!(
+                "rloo_step: m_samples ({m_samples}) * k ({k}) overflows usize"
+            ))
+        })?;
+        validate_allocation_size(subset_storage)?;
 
         {
             let layers = gate.layers();
@@ -628,7 +637,7 @@ mod tests {
         );
     }
 
-    // ---- BLOCKER 2 guard test (allocation bounds) ---------------------------
+    // ---- Allocation-bound guard tests ---------------------------------------
 
     /// rloo_step with m_samples > MAX_ALLOWED_ELEMENTS must return Err, not panic.
     ///
@@ -641,6 +650,25 @@ mod tests {
         assert!(
             matches!(result, Err(FannError::ShapeTooLarge { .. })),
             "expected ShapeTooLarge error for m_samples > MAX, got {result:?}"
+        );
+    }
+
+    /// A per-call m_samples that is itself within bounds must still be rejected
+    /// when m_samples * k (the aggregate retained-subset storage) exceeds the cap.
+    /// Here m_samples = 30M passes the standalone m_samples guard (< 100M) but
+    /// 30M * 4 = 120M exceeds it, so only the product guard can produce the error.
+    ///
+    /// Mutation that breaks this: removing the `validate_allocation_size(subset_storage)?`
+    /// product check (the standalone m_samples guard alone admits this input).
+    #[test]
+    fn rloo_step_m_samples_times_k_product_too_large_returns_err() {
+        let mut gate = test_gate();
+        let mut trainer = RlooTrainer::with_seed(RlooConfig::default(), 1);
+        let k = gate.num_outputs(); // 4
+        let result = trainer.rloo_step(&mut gate, &CTX, 0, k, 30_000_000);
+        assert!(
+            matches!(result, Err(FannError::ShapeTooLarge { .. })),
+            "expected ShapeTooLarge error for m_samples*k > MAX, got {result:?}"
         );
     }
 }

--- a/crates/fann/src/training/rloo.rs
+++ b/crates/fann/src/training/rloo.rs
@@ -169,6 +169,15 @@ impl RlooTrainer {
     ///
     /// This is not the default path — activate via the bench harness when
     /// comparing against Phase-1.
+    ///
+    /// Invariant for any future activation: this path consumes only
+    /// preferred-known (positive) events, so it MUST be paired with the M=1
+    /// [`Self::step`] negative path; never run it positive-only. The
+    /// convergence bench's positive-only arm collapsed to chance (policy
+    /// entropy toward zero, mass on a single output) because dropping
+    /// negative feedback removes the signal that pushes a wrongly-selected
+    /// output down. Carrying both polarities is a correctness requirement,
+    /// not a tuning choice.
     pub fn rloo_step(
         &mut self,
         gate: &mut Network,

--- a/crates/fann/src/training/rloo.rs
+++ b/crates/fann/src/training/rloo.rs
@@ -9,7 +9,7 @@
 //! parameters independently of the policy-gradient update.
 
 use crate::activation::Activation;
-use crate::error::{FannError, FannResult};
+use crate::error::{FannError, FannResult, validate_allocation_size};
 use crate::network::Network;
 
 use rand::Rng;
@@ -215,6 +215,10 @@ impl RlooTrainer {
                 "rloo_step: m_samples must be >= 1".into(),
             ));
         }
+
+        // Reject caller-supplied sizes that would cause Vec::with_capacity to OOM.
+        // m_samples drives two allocations of that length below.
+        validate_allocation_size(m_samples)?;
 
         {
             let layers = gate.layers();
@@ -483,6 +487,7 @@ fn log_sum_exp(logits: &[f32]) -> f32 {
 mod tests {
     use super::*;
     use crate::activation::Activation;
+    use crate::error::MAX_ALLOWED_ELEMENTS;
     use crate::network::NetworkBuilder;
 
     /// Build a deterministic 4-input → 8-hidden(ReLU) → 4-output(Linear) gate.
@@ -620,6 +625,22 @@ mod tests {
             delta_e > delta_i,
             "explicit reward (+1.0) must move action score more than implicit (+0.5): \
              delta_e={delta_e}, delta_i={delta_i}"
+        );
+    }
+
+    // ---- BLOCKER 2 guard test (allocation bounds) ---------------------------
+
+    /// rloo_step with m_samples > MAX_ALLOWED_ELEMENTS must return Err, not panic.
+    ///
+    /// Mutation that breaks this: removing the `validate_allocation_size(m_samples)?` call.
+    #[test]
+    fn rloo_step_m_samples_too_large_returns_err() {
+        let mut gate = test_gate();
+        let mut trainer = RlooTrainer::with_seed(RlooConfig::default(), 1);
+        let result = trainer.rloo_step(&mut gate, &CTX, 0, 1, MAX_ALLOWED_ELEMENTS + 1);
+        assert!(
+            matches!(result, Err(FannError::ShapeTooLarge { .. })),
+            "expected ShapeTooLarge error for m_samples > MAX, got {result:?}"
         );
     }
 }


### PR DESCRIPTION
Part of #440 — the fann-side foundation for online adapter-router refinement from served-action + scalar-reward feedback. This is a contextual-bandit setting: one action is served per context and one reward is observed.

## rloo module

- M=1 single-sample policy gradient with **one** update path for both positive and negative feedback:
  `g[j] = reward * (p[j] - onehot(action)[j])`.
  Reward sign alone sets the direction — `reward > 0` raises the served action's probability, `reward < 0` lowers it. Negative feedback is **not** reduced to cross-entropy toward a "preferred" action (a punished selection has no trustworthy preferred); the sign-flipped update is a correctness requirement, documented in the `rloo_step` rustdoc.
- Load-balancing aux loss (coeff 0.01) + router z-loss (coeff 0.001) as collapse guards.
- Optional multi-sample variant (Gumbel-max sampling + leave-one-out baseline) behind config, disabled by default.

## ewc module

- Diagonal-Fisher Elastic Weight Consolidation for anti-forgetting across successive online refits: `observe_gradient`, `set_anchor`, `penalty_gradient`, `project_delta`. serde-gated.

## convergence bench (`router_online`, `harness = false`)

Four-arm head-to-head across **dense / noisy (20% label-flip) / sparse (15% feedback)** reward regimes, reporting final routing accuracy and policy entropy:

- `OracleCeiling` — supervised upper bound
- `RewardOnServed` — the M=1 candidate (carries both polarities)
- `PositiveOnly` — drops negative feedback
- `Hybrid`

Result (K=4, D=16, 200-eval): `RewardOnServed` reaches 71–91% of the oracle ceiling across regimes; `PositiveOnly` collapses to chance (policy entropy → ~0, mass on a single adapter) — empirical evidence that negative feedback must be carried. The bench validates learning **dynamics** and polarity necessity (the mechanism is K/D-agnostic); real-scale quantitative convergence is a separate follow-up.

Feature-gated and disabled by default; enabling is a follow-up decision.

Gate: `cargo clippy -p lattice-fann --all-targets -- -D warnings` clean, `cargo fmt --check` clean, workspace pre-commit + doc-lint passed.
