### PR TITLE
fix(inference): close three semantic gaps in generate_q8

### DIFF
--- a/crates/inference/examples/bench_suite.rs
+++ b/crates/inference/examples/bench_suite.rs
@@ -458,7 +458,7 @@ fn bench_llm_q8_neon() -> Vec<Metric> {
     let rope = RopeTable::new(rope_dim, rope_max, cfg.rope_theta);
 
     let t_quant = Instant::now();
-    let q8_model = quantize_model(model.weights(), &cfg);
+    let q8_model = quantize_model(model.weights(), &cfg).expect("quantize_model failed");
     let quant_ms = t_quant.elapsed().as_millis() as f64;
 
     drop(model);

--- a/crates/inference/src/bin/quantize_q4.rs
+++ b/crates/inference/src/bin/quantize_q4.rs
@@ -481,7 +481,8 @@ fn main() {
                     .map(|c| u16::from_le_bytes([c[0], c[1]]))
                     .collect();
 
-                let q4 = quantize_bf16_to_q4(&bf16_vals, shape);
+                let q4 = quantize_bf16_to_q4(&bf16_vals, shape)
+                    .expect("Q4 quantization failed: source weights contain non-finite values");
                 let bytes_out = (q4.blocks.len() * 18) as u64;
                 total_bytes_out += bytes_out;
 

--- a/crates/inference/src/forward/batch_prefill.rs
+++ b/crates/inference/src/forward/batch_prefill.rs
@@ -1752,6 +1752,54 @@ mod tests {
         }
     }
 
+    /// Build a 0-layer model where the greedy sequence is: token 1 → 2 → 3 (stop).
+    ///
+    /// embed_tokens uses standard basis vectors: embed[i][i] = 1.0 for i in 1..4 so
+    /// that each token lives in its own orthogonal direction. embed[0] and embed[4..]
+    /// are all zeros.
+    ///
+    /// lm_head is untied (ModelWeights::lm_head = Some(...)). It is a forward-shift
+    /// by one index in the basis:
+    ///   row 2 has col-1 = 1.0  → logit[2] wins from the embed[1] direction
+    ///   row 3 has col-2 = 1.0  → logit[3] wins from the embed[2] direction
+    ///
+    /// Greedy sequence from prompt "a" (→ token 1, eos_token_id=6):
+    ///   post-prefill: RMSNorm(embed[1]) = [0, 4, 0, …] → logit[2] = 4 wins → token 2
+    ///   decode step 1: RMSNorm(embed[2]) = [0, 0, 4, …] → logit[3] = 4 wins → stop(3)
+    fn rotation_model_fixture() -> Qwen35Model {
+        let cfg = make_test_config(16, 16, 7, 0);
+        let rope_dim = cfg.rope_dim();
+        let rope_max = cfg.max_position_embeddings.min(8192);
+        let rope = RopeTable::new(rope_dim, rope_max, cfg.rope_theta);
+        let hidden = cfg.hidden_size; // 16
+        let vocab = cfg.vocab_size; // 7
+
+        // Standard basis: each active token lives in its own orthogonal dimension.
+        let mut embed = vec![0.0f32; vocab * hidden];
+        embed[hidden + 1] = 1.0; // token 1 → e_1
+        embed[2 * hidden + 2] = 1.0; // token 2 → e_2
+        embed[3 * hidden + 3] = 1.0; // token 3 → e_3 (stop)
+
+        // Forward-shift lm_head: e_1 direction wins token 2; e_2 direction wins token 3.
+        // With RMSNorm(gamma=0), hidden = 4 * e_i for token i (inv_rms = 4.0 at hidden=16).
+        let mut lm_head = vec![0.0f32; vocab * hidden];
+        lm_head[2 * hidden + 1] = 1.0; // logit[2] = 4 * 1 = 4 from token 1
+        lm_head[3 * hidden + 2] = 1.0; // logit[3] = 4 * 1 = 4 from token 2
+
+        Qwen35Model {
+            config: cfg.clone(),
+            weights: ModelWeights {
+                embed_tokens: embed,
+                lm_head: Some(lm_head),
+                final_norm: vec![0.0f32; hidden],
+                layers: vec![],
+            },
+            tokenizer: dummy_tokenizer(),
+            rope,
+            lora: Box::new(crate::lora_hook::NoopLoraHook),
+        }
+    }
+
     /// `generate_with_batch_prefill` must stop on a token in `stop_token_ids`
     /// even when that token differs from `eos_token_id`.
     ///
@@ -1783,6 +1831,48 @@ mod tests {
             "generate_with_batch_prefill must stop immediately when the first \
              greedy token (0) is in stop_token_ids — got {} generated tokens instead",
             out.generated_tokens
+        );
+    }
+
+    /// `generate_with_batch_prefill` must also stop when the stop token first
+    /// appears in the **decode loop**, not only at the post-prefill check.
+    ///
+    /// Fixture: rotation_model_fixture(). Greedy sequence from prompt "a" (token 1):
+    ///   post-prefill  → token 2  (not stop=3)
+    ///   decode step 1 → token 3  (stop) → decode-loop fires
+    ///
+    /// Mutation proof: reverting ONLY the decode-loop `should_stop_token` check
+    /// (line 444 at time of writing) to `next_id == cfg.eos_token_id` leaves
+    /// token 3 uncaught (3 ≠ eos=6), the sequence continues, and generated_tokens
+    /// becomes ≥ 2 — failing the assertion below.
+    #[test]
+    fn test_generate_with_batch_prefill_honors_stop_token_ids_decode_loop() {
+        let model = rotation_model_fixture();
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 10,
+            stop_token_ids: vec![3], // stop on token 3 mid-decode-loop; eos_token_id=6≠3
+            temperature: 0.0,        // greedy: deterministic forward-shift sequence
+            ..Default::default()
+        };
+
+        // Prompt "a" → token 1.
+        // Post-prefill generates token 2 (not stop).
+        // Decode step 1 generates token 3 → decode-loop stop fires.
+        let out = model
+            .generate_with_batch_prefill("a", &gen_cfg)
+            .expect("generate_with_batch_prefill must succeed");
+
+        assert_eq!(
+            out.generated_tokens, 1,
+            "generate_with_batch_prefill must stop at decode-loop step 1 when token 3 \
+             is in stop_token_ids — got {} tokens; reverting only the decode-loop check \
+             lets token 3 through and produces ≥ 2 tokens",
+            out.generated_tokens
+        );
+        assert!(
+            out.stopped,
+            "generate_with_batch_prefill must set stopped=true when the decode-loop stop fires"
         );
     }
 

--- a/crates/inference/src/forward/batch_prefill.rs
+++ b/crates/inference/src/forward/batch_prefill.rs
@@ -26,7 +26,7 @@ use crate::forward::cpu::{elementwise_mul, matmul_bt, silu_inplace};
 use crate::model::qwen35::{
     AttentionWeights, CommonLayerWeights, DenseFfnWeights, FeedForwardWeights, ForwardScratch,
     FullAttentionLayerWeights, KvCache, Qwen35Model, decode_tokens, qwen35_rms_norm, resize,
-    sample_token,
+    sample_token, should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::tokenizer::common::Tokenizer;
@@ -404,7 +404,7 @@ impl Qwen35Model {
         // Sample from the final prefill logits.
         let next_id = sample_token(&logits[..cfg.vocab_size], gen_cfg, &all_ids, &mut rng_state);
 
-        if next_id == cfg.eos_token_id {
+        if should_stop_token(cfg, gen_cfg, next_id) {
             return Ok(GenerateOutput {
                 text: String::new(),
                 token_ids: vec![],
@@ -441,7 +441,7 @@ impl Qwen35Model {
                 &mut rng_state,
             );
 
-            if next_id == cfg.eos_token_id {
+            if should_stop_token(cfg, gen_cfg, next_id) {
                 stopped = true;
                 break;
             }
@@ -1722,6 +1722,68 @@ mod tests {
         x ^= x << 17;
         *state = x;
         (x >> 32) as u32
+    }
+
+    /// Build a zero-layer Qwen35Model for generate_with_batch_prefill unit tests.
+    ///
+    /// All-zero embed_tokens → logits all 0 → greedy picks token 0.
+    /// eos_token_id=96 (vocab-1) so token 0 is NOT eos, making stop_token_ids=[0]
+    /// detectable as a distinct stop path.
+    fn zero_layer_batch_prefill_fixture() -> Qwen35Model {
+        let cfg = make_test_config(64, 128, 97, 0);
+        // make_test_config sets eos_token_id = vocab_size-1 = 96 ≠ 0 ✓
+
+        let rope_dim = cfg.rope_dim();
+        let rope_max = cfg.max_position_embeddings.min(8192);
+        let rope = RopeTable::new(rope_dim, rope_max, cfg.rope_theta);
+
+        Qwen35Model {
+            config: cfg.clone(),
+            weights: ModelWeights {
+                // All zeros → logits all 0 → greedy always picks token 0.
+                embed_tokens: vec![0.0f32; cfg.vocab_size * cfg.hidden_size],
+                lm_head: None,
+                final_norm: vec![0.0f32; cfg.hidden_size],
+                layers: vec![],
+            },
+            tokenizer: dummy_tokenizer(),
+            rope,
+            lora: Box::new(crate::lora_hook::NoopLoraHook),
+        }
+    }
+
+    /// `generate_with_batch_prefill` must stop on a token in `stop_token_ids`
+    /// even when that token differs from `eos_token_id`.
+    ///
+    /// Setup: all-zero weights → greedy sampling always picks token 0.
+    /// Config has eos_token_id=96 (not 0) and stop_token_ids=[0].
+    /// With the fix the first sampled token (0) hits the stop list and the
+    /// function returns 0 generated tokens.
+    ///
+    /// Mutation check: reverting `should_stop_token` back to
+    /// `next_id == cfg.eos_token_id` in either check causes `0 == 96` to be false,
+    /// so token 0 is pushed to output and `generated_tokens` becomes ≥ 1.
+    #[test]
+    fn test_generate_with_batch_prefill_honors_stop_token_ids() {
+        let model = zero_layer_batch_prefill_fixture();
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 4,
+            stop_token_ids: vec![0], // token 0 is the stop signal, NOT eos (96)
+            temperature: 0.0,        // greedy: all-zero logits always yield token 0
+            ..Default::default()
+        };
+
+        let out = model
+            .generate_with_batch_prefill("a", &gen_cfg)
+            .expect("generate_with_batch_prefill must succeed with valid stop_token_ids");
+
+        assert_eq!(
+            out.generated_tokens, 0,
+            "generate_with_batch_prefill must stop immediately when the first \
+             greedy token (0) is in stop_token_ids — got {} generated tokens instead",
+            out.generated_tokens
+        );
     }
 
     /// Minimal byte-level BPE tokenizer parsed from a string — no temp file, no

--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -15,6 +15,7 @@ use crate::attention::gdn_fused::{
 use crate::forward::cpu::{elementwise_mul, silu_inplace};
 use crate::model::qwen35::{
     ForwardScratch, KvCache, decode_tokens, qwen35_rms_norm, resize, sample_token,
+    should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::rope::RopeTable;
@@ -902,7 +903,7 @@ pub fn generate_f16(
         &mut rng_state,
     );
 
-    if next_id == cfg.eos_token_id {
+    if should_stop_token(cfg, gen_cfg, next_id) {
         return Ok(GenerateOutput {
             text: String::new(),
             token_ids: vec![],
@@ -942,7 +943,7 @@ pub fn generate_f16(
             &mut rng_state,
         );
 
-        if next_id == cfg.eos_token_id {
+        if should_stop_token(cfg, gen_cfg, next_id) {
             stopped = true;
             break;
         }
@@ -1412,4 +1413,108 @@ mod tests {
     // comparison; it hardens the bench-only public `generate_f16` path against a
     // manually constructed f16 weight set whose router declares more experts than
     // the routed-expert storage holds.
+
+    /// Build a zero-layer F16 model fixture for generate_f16 unit tests.
+    ///
+    /// All-zero u16 (= f16 zero) embeddings → logits all 0 → greedy picks token 0.
+    /// eos_token_id = 5 so that greedy token 0 is NOT eos, making stop_token_ids=[0]
+    /// detectable as a distinct stop path.
+    fn zero_layer_f16_fixture() -> (Qwen35Config, F16ModelWeights, RopeTable, BpeTokenizer) {
+        use std::collections::HashMap;
+
+        let hidden = 4usize;
+        let vocab = 8usize;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 0,
+            vocab_size: vocab,
+            intermediate_size: 4,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: 1,
+            num_key_value_heads: 1,
+            head_dim: 4,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5,
+            rope_parameters: None,
+            linear_num_key_heads: 1,
+            linear_num_value_heads: Some(1),
+            linear_key_head_dim: 4,
+            linear_value_head_dim: 4,
+            linear_conv_kernel_dim: 4,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![],
+            layer_mask: vec![],
+            // eos is 5 so that greedy token 0 is NOT eos — allows stop_token_ids=[0]
+            // to be a distinct, detectable stop signal.
+            eos_token_id: 5,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        // embed_tokens is [vocab * hidden] packed u16 (f16 zeros = 0u16).
+        // All zeros → logits all 0 → greedy always picks token 0.
+        let weights = F16ModelWeights {
+            embed_tokens: vec![0u16; vocab * hidden],
+            final_norm: vec![0.0f32; hidden],
+            layers: vec![],
+        };
+
+        // rope_dim = head_dim * partial_rotary_factor = 4 * 0.5 = 2.
+        let rope = RopeTable::new(2, 64, 10_000.0);
+
+        let mut vocab_map: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o", "w", "r", "d", "!"].iter().enumerate() {
+            vocab_map.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab_map, merges).unwrap();
+
+        (cfg, weights, rope, tokenizer)
+    }
+
+    /// `generate_f16` must stop on a token in `stop_token_ids` even when that
+    /// token differs from `eos_token_id`.
+    ///
+    /// Setup: all-zero f16 weights → greedy sampling always picks token 0.
+    /// Config has eos_token_id=5 (not 0) and stop_token_ids=[0].
+    /// With the fix the first sampled token (0) hits the stop list and the
+    /// function returns 0 generated tokens.
+    ///
+    /// Mutation check: reverting `should_stop_token` back to
+    /// `next_id == cfg.eos_token_id` in either check causes `0 == 5` to be false,
+    /// so token 0 is pushed to output and `generated_tokens` becomes ≥ 1.
+    #[test]
+    fn test_generate_f16_honors_stop_token_ids() {
+        let (cfg, weights, rope, tokenizer) = zero_layer_f16_fixture();
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 4,
+            stop_token_ids: vec![0], // token 0 is the stop signal, NOT eos (5)
+            temperature: 0.0,        // greedy: all-zero logits always yield token 0
+            ..Default::default()
+        };
+
+        let out = generate_f16(&weights, &cfg, &tokenizer, &rope, "h", &gen_cfg)
+            .expect("generate_f16 must succeed with valid stop_token_ids");
+
+        assert_eq!(
+            out.generated_tokens, 0,
+            "generate_f16 must stop immediately when the first greedy token (0) \
+             is in stop_token_ids — got {} generated tokens instead",
+            out.generated_tokens
+        );
+    }
 }

--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -1517,4 +1517,127 @@ mod tests {
             out.generated_tokens
         );
     }
+
+    /// `generate_f16` must also stop when the stop token first appears in the
+    /// **decode loop**, not only at the post-prefill check.
+    ///
+    /// Fixture: a "bouncing" 0-layer f16 model.
+    ///   embed[0] = [-1, 1, 0, 0]  (token 0, f16)
+    ///   embed[1] = [ 1, 1, 0, 0]  (token 1, f16)
+    ///   final_norm gamma = [-2, 0, 0, 0]
+    ///
+    /// The negative gamma at dim-0 flips the sign of that component after RMSNorm,
+    /// creating a "bounce" between tokens 0 and 1:
+    ///   from token 1: hidden = [-√2, +√2, 0, 0] → logit[0] = 2√2 wins → generates 0
+    ///   from token 0: hidden = [+√2, +√2, 0, 0] → logit[1] = 2√2 wins → generates 1
+    ///
+    /// Greedy sequence from prompt "e" (→ token 1, eos_token_id=5):
+    ///   post-prefill  → token 0  (not stop=1)
+    ///   decode step 1 → token 1  (stop) → decode-loop fires
+    ///
+    /// Mutation proof: reverting ONLY the decode-loop `should_stop_token` check
+    /// (line 946 at time of writing) to `next_id == cfg.eos_token_id` leaves
+    /// token 1 uncaught (1 ≠ eos=5), the sequence continues, and generated_tokens
+    /// becomes ≥ 2 — failing the assertion below.
+    #[test]
+    fn test_generate_f16_honors_stop_token_ids_decode_loop() {
+        use crate::weights::f16_weights::f32_to_f16_slice;
+        use std::collections::HashMap;
+
+        let hidden = 4usize;
+        let vocab = 8usize;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 0,
+            vocab_size: vocab,
+            intermediate_size: 4,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: 1,
+            num_key_value_heads: 1,
+            head_dim: 4,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5,
+            rope_parameters: None,
+            linear_num_key_heads: 1,
+            linear_num_value_heads: Some(1),
+            linear_key_head_dim: 4,
+            linear_value_head_dim: 4,
+            linear_conv_kernel_dim: 4,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![],
+            layer_mask: vec![],
+            // eos=5 so the stop at token 1 is detectable only via stop_token_ids.
+            eos_token_id: 5,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        // The negative gamma at dim-0 flips the sign of that component after
+        // RMSNorm, creating a deterministic "bounce" between tokens 0 and 1.
+        // from embed[1]=[1,1,0,0]: hidden→[-√2,+√2,0,0] → dot(embed[0]=[-1,1,..]) = 2√2 > 0
+        // from embed[0]=[-1,1,0,0]: hidden→[+√2,+√2,0,0] → dot(embed[1]=[1,1,..]) = 2√2 > 0
+        let embed_f32: Vec<f32> = {
+            let mut v = vec![0.0f32; vocab * hidden];
+            v[0] = -1.0; // token 0, dim 0
+            v[1] = 1.0; // token 0, dim 1
+            v[hidden] = 1.0; // token 1, dim 0
+            v[hidden + 1] = 1.0; // token 1, dim 1
+            v
+        };
+        let mut embed_f16 = vec![0u16; vocab * hidden];
+        f32_to_f16_slice(&embed_f32, &mut embed_f16);
+
+        let weights = F16ModelWeights {
+            embed_tokens: embed_f16,
+            final_norm: vec![-2.0f32, 0.0, 0.0, 0.0],
+            layers: vec![],
+        };
+
+        let rope = RopeTable::new(2, 64, 10_000.0);
+
+        let mut vocab_map: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o", "w", "r", "d", "!"].iter().enumerate() {
+            vocab_map.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab_map, merges).unwrap();
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 10,
+            stop_token_ids: vec![1], // stop on token 1 mid-decode-loop; eos_token_id=5≠1
+            temperature: 0.0,        // greedy: deterministic bouncing sequence
+            ..Default::default()
+        };
+
+        // Prompt "e" → token 1.
+        // Post-prefill generates token 0 (not stop=1).
+        // Decode step 1 generates token 1 → decode-loop stop fires.
+        let out = generate_f16(&weights, &cfg, &tokenizer, &rope, "e", &gen_cfg)
+            .expect("generate_f16 must succeed");
+
+        assert_eq!(
+            out.generated_tokens, 1,
+            "generate_f16 must stop at decode-loop step 1 when token 1 is in \
+             stop_token_ids — got {} tokens; reverting only the decode-loop check \
+             lets token 1 through and produces ≥ 2 tokens",
+            out.generated_tokens
+        );
+        assert!(
+            out.stopped,
+            "generate_f16 must set stopped=true when the decode-loop stop fires"
+        );
+    }
 }

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -760,9 +760,15 @@ pub fn generate_q8(
     // Autoregressive decode
     for _ in 1..gen_cfg.max_new_tokens {
         let pos = kv_cache.seq_len;
-        let last_token = *all_ids
-            .last()
-            .expect("invariant: prompt or previous sample populated all_ids");
+        // all_ids is seeded by the prompt before the loop, and the decode loop
+        // only continues when the previous sample pushed a new id, so the
+        // invariant `all_ids.is_empty() == false` should always hold here.
+        // Return an error rather than panicking so library callers can handle it.
+        let Some(&last_token) = all_ids.last() else {
+            return Err(crate::error::InferenceError::Inference(
+                "empty generation state".into(),
+            ));
+        };
 
         forward_step_q8(
             weights,

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -17,6 +17,7 @@ use crate::forward::cpu::{elementwise_mul, matmul_bt, silu_inplace};
 use crate::model::qwen35::Qwen35Model;
 use crate::model::qwen35::{
     ForwardScratch, KvCache, decode_tokens, qwen35_rms_norm, resize, sample_token,
+    should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::rope::RopeTable;
@@ -676,6 +677,19 @@ pub fn generate_q8(
         ));
     }
 
+    // max_new_tokens == 0 is a valid request: "score this prompt, return no tokens".
+    // Guard here so the decode loop (`for _ in 1..0`) never accidentally samples one
+    // token from the prefill logits before realising the budget is exhausted.
+    if gen_cfg.max_new_tokens == 0 {
+        return Ok(GenerateOutput {
+            text: String::new(),
+            token_ids: vec![],
+            prompt_tokens: prompt_len,
+            generated_tokens: 0,
+            stopped: false,
+        });
+    }
+
     // Context preflight. The RoPE cos/sin tables are indexed unchecked in
     // full_attention_step_q8 (`rope.cos_at(position * half + i)`), so a position
     // at or past the table capacity is an out-of-bounds slice access — a release
@@ -729,7 +743,7 @@ pub fn generate_q8(
         &mut rng_state,
     );
 
-    if next_id == cfg.eos_token_id {
+    if should_stop_token(cfg, gen_cfg, next_id) {
         return Ok(GenerateOutput {
             text: String::new(),
             token_ids: vec![],
@@ -769,7 +783,7 @@ pub fn generate_q8(
             &mut rng_state,
         );
 
-        if next_id == cfg.eos_token_id {
+        if should_stop_token(cfg, gen_cfg, next_id) {
             stopped = true;
             break;
         }
@@ -865,7 +879,7 @@ mod tests {
         }
 
         let zero_q8 = |rows: usize, cols: usize| -> crate::weights::q8_weights::Q8Matrix {
-            quantize_matrix(&vec![0.0f32; rows * cols], rows, cols)
+            quantize_matrix(&vec![0.0f32; rows * cols], rows, cols).unwrap()
         };
         // W_q = identity for first q_dim rows (Q part), zeros for next q_dim rows (gate part).
         // Row j selects input[j] exactly so scratch.q_buf is non-trivial and Q-loop mutation
@@ -875,8 +889,8 @@ mod tests {
             q_proj_f32[j * hidden + j] = 1.0;
         }
         let weights = Q8FullAttentionLayerWeights {
-            q_proj: quantize_matrix(&q_proj_f32, 2 * q_dim, hidden),
-            k_proj: quantize_matrix(&k_proj_f32, kv_dim, hidden),
+            q_proj: quantize_matrix(&q_proj_f32, 2 * q_dim, hidden).unwrap(),
+            k_proj: quantize_matrix(&k_proj_f32, kv_dim, hidden).unwrap(),
             v_proj: zero_q8(kv_dim, hidden),
             o_proj: zero_q8(hidden, q_dim),
             q_norm: vec![0.0f32; head_dim],
@@ -1131,15 +1145,15 @@ mod tests {
             k_proj_f32[j * hidden + j] = 1.0;
         }
         let zero_q8 = |rows: usize, cols: usize| -> crate::weights::q8_weights::Q8Matrix {
-            quantize_matrix(&vec![0.0f32; rows * cols], rows, cols)
+            quantize_matrix(&vec![0.0f32; rows * cols], rows, cols).unwrap()
         };
         let mut q_proj_f32 = vec![0.0f32; 2 * q_dim * hidden];
         for j in 0..q_dim {
             q_proj_f32[j * hidden + j] = 1.0;
         }
         let weights = Q8FullAttentionLayerWeights {
-            q_proj: quantize_matrix(&q_proj_f32, 2 * q_dim, hidden),
-            k_proj: quantize_matrix(&k_proj_f32, kv_dim, hidden),
+            q_proj: quantize_matrix(&q_proj_f32, 2 * q_dim, hidden).unwrap(),
+            k_proj: quantize_matrix(&k_proj_f32, kv_dim, hidden).unwrap(),
             v_proj: zero_q8(kv_dim, hidden),
             o_proj: zero_q8(hidden, q_dim),
             q_norm: vec![0.0f32; head_dim],
@@ -1249,6 +1263,141 @@ mod tests {
         assert!(
             output[..hidden].iter().all(|v| v.is_finite()),
             "GDN output must stay finite when the decay gate overflows"
+        );
+    }
+
+    /// Build a minimal Q8 config + weights with zero hidden layers so forward_step_q8
+    /// skips all attention and MLP blocks. The embedding lookup and final-norm steps
+    /// still execute, so embed_tokens and final_norm must have the right lengths.
+    fn zero_layer_q8_fixture() -> (Qwen35Config, Q8ModelWeights, RopeTable, BpeTokenizer) {
+        use std::collections::HashMap;
+
+        let hidden = 4usize;
+        let vocab = 8usize;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 0,
+            vocab_size: vocab,
+            intermediate_size: 4,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: 1,
+            num_key_value_heads: 1,
+            head_dim: 4,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5,
+            rope_parameters: None,
+            linear_num_key_heads: 1,
+            linear_num_value_heads: Some(1),
+            linear_key_head_dim: 4,
+            linear_value_head_dim: 4,
+            linear_conv_kernel_dim: 4,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![],
+            layer_mask: vec![],
+            // eos is 5 so that greedy token 0 is NOT eos — this lets tests for
+            // stop_token_ids use token 0 as a distinct stop signal.
+            eos_token_id: 5,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        // embed_tokens is [vocab, hidden] and also serves as the tied LM head.
+        // All zeros → logits are all zeros → greedy sampling always picks token 0.
+        let weights = Q8ModelWeights {
+            embed_tokens: vec![0.0f32; vocab * hidden],
+            final_norm: vec![0.0f32; hidden],
+            layers: vec![],
+        };
+
+        // rope_dim = head_dim * partial_rotary_factor = 4 * 0.5 = 2.
+        // No full-attention layers use the table, but max_positions must satisfy the
+        // context preflight (prompt_len + max_new_tokens <= max_positions).
+        let rope = RopeTable::new(2, 64, 10_000.0);
+
+        let mut vocab_map: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o", "w", "r", "d", "!"].iter().enumerate() {
+            vocab_map.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab_map, merges).unwrap();
+
+        (cfg, weights, rope, tokenizer)
+    }
+
+    /// `generate_q8` with `max_new_tokens == 0` must return zero generated tokens
+    /// without running a forward pass or sampling anything.
+    ///
+    /// Mutation check: removing the `max_new_tokens == 0` early return causes
+    /// the function to run prefill + sample one token from the logits, so
+    /// `generated_tokens` becomes 1 instead of 0 and the assertion fails.
+    #[test]
+    fn test_generate_q8_max_new_tokens_zero_returns_empty() {
+        let (cfg, weights, rope, tokenizer) = zero_layer_q8_fixture();
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            ..Default::default()
+        };
+
+        let out = generate_q8(&weights, &cfg, &tokenizer, &rope, "h", &gen_cfg)
+            .expect("max_new_tokens=0 must succeed, not error");
+
+        assert_eq!(
+            out.generated_tokens, 0,
+            "max_new_tokens=0 must produce zero generated tokens"
+        );
+        assert!(
+            out.token_ids.is_empty(),
+            "max_new_tokens=0 must produce an empty token list"
+        );
+        assert_eq!(out.prompt_tokens, 1, "prompt 'h' tokenizes to one token");
+    }
+
+    /// `generate_q8` must stop on a token in `stop_token_ids` even when that
+    /// token differs from `eos_token_id`.
+    ///
+    /// Setup: all-zero weights → greedy sampling always picks token 0.
+    /// Config has eos_token_id=5 (not 0) and stop_token_ids=[0].
+    /// With the fix the first sampled token (0) hits the stop list and the
+    /// function returns 0 generated tokens.
+    ///
+    /// Mutation check: reverting `should_stop_token` back to
+    /// `next_id == cfg.eos_token_id` causes `0 == 5` to be false, so token 0
+    /// is pushed to output and `generated_tokens` becomes ≥ 1.
+    #[test]
+    fn test_generate_q8_honors_stop_token_ids() {
+        let (cfg, weights, rope, tokenizer) = zero_layer_q8_fixture();
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 4,
+            stop_token_ids: vec![0], // token 0 is the stop signal, NOT eos (5)
+            temperature: 0.0,        // greedy: all-zero logits always yield token 0
+            ..Default::default()
+        };
+
+        let out = generate_q8(&weights, &cfg, &tokenizer, &rope, "h", &gen_cfg)
+            .expect("generate_q8 must succeed with valid stop_token_ids");
+
+        assert_eq!(
+            out.generated_tokens, 0,
+            "stop token 0 must halt generation before any token is emitted"
+        );
+        assert!(
+            out.stopped,
+            "stopped flag must be true when a stop token fires"
         );
     }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -4371,12 +4371,26 @@ kernel void gdn_chunk_norm_silu_c32(
     const Q4_0_BLOCK_SIZE: usize = 20;
 
     /// Quantize a row of f32 weights to Q8_0 blocks.
-    fn quantize_row_q8_0(src: &[f32]) -> Vec<u8> {
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if any element in `src` is non-finite (NaN or ±inf).
+    /// IEEE 754: `NaN > x` is always false, so a fold-max over NaN leaves
+    /// `amax` unchanged and the NaN is silently cast to 0 by the `clamp` below.
+    fn quantize_row_q8_0(src: &[f32]) -> Result<Vec<u8>, String> {
         assert_eq!(src.len() % QK8_0, 0);
         let nblocks = src.len() / QK8_0;
         let mut packed = Vec::with_capacity(nblocks * Q8_0_BLOCK_SIZE);
         for b in 0..nblocks {
             let block = &src[b * QK8_0..(b + 1) * QK8_0];
+            for &v in block {
+                if !v.is_finite() {
+                    return Err(format!(
+                        "Q8_0 weight block {b} contains a non-finite value ({v}); \
+                         source weights must be finite"
+                    ));
+                }
+            }
             let amax = block.iter().fold(0.0f32, |m, &v| m.max(v.abs()));
             let d = amax / 127.0;
             let id = if d != 0.0 { 1.0 / d } else { 0.0 };
@@ -4385,13 +4399,13 @@ kernel void gdn_chunk_norm_silu_c32(
                 packed.push((v * id).round().clamp(-127.0, 127.0) as i8 as u8);
             }
         }
-        packed
+        Ok(packed)
     }
 
     /// Create a Metal buffer with Q8_0 quantized weights from f32 data.
-    fn make_buffer_q8_0(device: &Device, data: &[f32], label: &str) -> Buffer {
+    fn make_buffer_q8_0(device: &Device, data: &[f32], label: &str) -> Result<Buffer, String> {
         assert_eq!(data.len() % QK8_0, 0);
-        let packed = quantize_row_q8_0(data);
+        let packed = quantize_row_q8_0(data)?;
         let byte_len = packed.len() as u64;
         let buf = device.new_buffer_with_data(
             packed.as_ptr() as *const _,
@@ -4399,17 +4413,17 @@ kernel void gdn_chunk_norm_silu_c32(
             MTLResourceOptions::StorageModeShared,
         );
         buf.set_label(label);
-        buf
+        Ok(buf)
     }
 
-    fn make_buffer_q4_0(device: &Device, data: &[f32], label: &str) -> Buffer {
+    fn make_buffer_q4_0(device: &Device, data: &[f32], label: &str) -> Result<Buffer, String> {
         assert_eq!(
             data.len() % QK4_0,
             0,
             "make_buffer_q4_0: data length {} not divisible by {QK4_0}",
             data.len()
         );
-        let packed = quantize_row_q4_0(data);
+        let packed = quantize_row_q4_0(data).map_err(|e| e.to_string())?;
         let byte_len = packed.len() as u64;
         let buf = device.new_buffer_with_data(
             packed.as_ptr() as *const _,
@@ -4417,7 +4431,7 @@ kernel void gdn_chunk_norm_silu_c32(
             MTLResourceOptions::StorageModeShared,
         );
         buf.set_label(label);
-        buf
+        Ok(buf)
     }
 
     fn make_zero_buffer(device: &Device, num_floats: usize, label: &str) -> Buffer {
@@ -5021,7 +5035,7 @@ kernel void gdn_chunk_norm_silu_c32(
                 QuantFormat::Q8_0 => Q8_0_BLOCK_SIZE,
                 QuantFormat::Q4_0 => Q4_0_BLOCK_SIZE,
             };
-            let pack_quant = |data: &[f32]| -> Vec<u8> {
+            let pack_quant = |data: &[f32]| -> Result<Vec<u8>, String> {
                 match quant_format {
                     QuantFormat::Q8_0 => {
                         assert_eq!(data.len() % QK8_0, 0);
@@ -5034,7 +5048,7 @@ kernel void gdn_chunk_norm_silu_c32(
                             "pack_quant: data length {} not divisible by {QK4_0}",
                             data.len()
                         );
-                        quantize_row_q4_0(data)
+                        quantize_row_q4_0(data).map_err(|e| e.to_string())
                     }
                 }
             };
@@ -5055,20 +5069,21 @@ kernel void gdn_chunk_norm_silu_c32(
                     buf.set_label(label);
                     buf
                 };
-            let make_buffer_quant = |device: &Device, data: &[f32], label: &str| -> Buffer {
-                match quant_format {
-                    QuantFormat::Q8_0 => make_buffer_q8_0(device, data, label),
-                    QuantFormat::Q4_0 => make_buffer_q4_0(device, data, label),
-                }
-            };
+            let make_buffer_quant =
+                |device: &Device, data: &[f32], label: &str| -> Result<Buffer, String> {
+                    match quant_format {
+                        QuantFormat::Q8_0 => make_buffer_q8_0(device, data, label),
+                        QuantFormat::Q4_0 => make_buffer_q4_0(device, data, label),
+                    }
+                };
 
             let mut layer_weights = Vec::with_capacity(cfg.num_hidden_layers);
             for (i, (attn_w, common_w)) in weights.layers.iter().enumerate() {
                 // Build the FFN weight variant for this layer (Dense or MoE).
                 let metal_ffn = match &common_w.ffn {
                     crate::model::qwen35::FeedForwardWeights::Dense(d) => {
-                        let gate_bytes = pack_quant(&d.gate_proj);
-                        let up_bytes = pack_quant(&d.up_proj);
+                        let gate_bytes = pack_quant(&d.gate_proj)?;
+                        let up_bytes = pack_quant(&d.up_proj)?;
                         debug_assert_eq!(
                             d.gate_proj.len(),
                             cfg.intermediate_size * cfg.hidden_size
@@ -5090,7 +5105,7 @@ kernel void gdn_chunk_norm_silu_c32(
                                 &device,
                                 &d.down_proj,
                                 &format!("L{i}.down.{quant_tag}"),
-                            )),
+                            )?),
                         }
                     }
                     crate::model::qwen35::FeedForwardWeights::Moe(m) => {
@@ -5211,12 +5226,12 @@ kernel void gdn_chunk_norm_silu_c32(
                                 &device,
                                 &gdn_w.in_proj_qkv,
                                 &format!("L{i}.gdn.qkv.{quant_tag}"),
-                            )),
+                            )?),
                             in_proj_z: Q4WeightBuf::from_buffer(make_buffer_quant(
                                 &device,
                                 &gdn_w.in_proj_z,
                                 &format!("L{i}.gdn.z.{quant_tag}"),
-                            )),
+                            )?),
                             in_proj_qkvz: {
                                 let mut combined = gdn_w.in_proj_qkv.clone();
                                 combined.extend_from_slice(&gdn_w.in_proj_z);
@@ -5224,7 +5239,7 @@ kernel void gdn_chunk_norm_silu_c32(
                                     &device,
                                     &combined,
                                     &format!("L{i}.gdn.qkvz.{quant_tag}"),
-                                ))
+                                )?)
                             },
                             // in_proj_b/a: keep f16 — CPU reads these for GDN recurrence
                             in_proj_b: make_buffer_f16(
@@ -5260,7 +5275,7 @@ kernel void gdn_chunk_norm_silu_c32(
                                 &device,
                                 &gdn_w.out_proj,
                                 &format!("L{i}.gdn.out.{quant_tag}"),
-                            )),
+                            )?),
                         })
                     }
                     AttentionWeights::Full(full_w) => {
@@ -5270,22 +5285,22 @@ kernel void gdn_chunk_norm_silu_c32(
                                 &device,
                                 &full_w.q_proj,
                                 &format!("L{i}.full.q.{quant_tag}"),
-                            )),
+                            )?),
                             k_proj: Q4WeightBuf::from_buffer(make_buffer_quant(
                                 &device,
                                 &full_w.k_proj,
                                 &format!("L{i}.full.k.{quant_tag}"),
-                            )),
+                            )?),
                             v_proj: Q4WeightBuf::from_buffer(make_buffer_quant(
                                 &device,
                                 &full_w.v_proj,
                                 &format!("L{i}.full.v.{quant_tag}"),
-                            )),
+                            )?),
                             o_proj: Q4WeightBuf::from_buffer(make_buffer_quant(
                                 &device,
                                 &full_w.o_proj,
                                 &format!("L{i}.full.o.{quant_tag}"),
-                            )),
+                            )?),
                             // Norm weights stay f32 (small, precision-sensitive)
                             q_norm: make_buffer(
                                 &device,
@@ -5312,7 +5327,7 @@ kernel void gdn_chunk_norm_silu_c32(
                 &device,
                 &weights.embed_tokens,
                 &format!("embed_tokens.{quant_tag}"),
-            ));
+            )?);
             // Final norm: f32 (small, precision-sensitive)
             let final_norm = make_buffer(&device, &weights.final_norm, "final_norm");
 
@@ -14678,6 +14693,30 @@ kernel void gdn_chunk_norm_silu_c32(
             );
         }
 
+        // Mutation proof: reverting the is_finite() guard makes this test pass NaN
+        // through undetected (NaN.abs() is NaN, m.max(NaN) == m, so amax stays 0.0,
+        // scale stays 0.0, and NaN * 0.0 = NaN → clamp → 0 silently). With the guard
+        // the function returns Err before any NaN reaches the scale computation.
+        #[test]
+        fn quantize_row_q8_0_rejects_nan() {
+            let mut row = vec![0.0f32; 32];
+            row[7] = f32::NAN;
+            assert!(
+                quantize_row_q8_0(&row).is_err(),
+                "quantize_row_q8_0 must return Err when a block element is NaN"
+            );
+        }
+
+        #[test]
+        fn quantize_row_q8_0_rejects_inf() {
+            let mut row = vec![0.5f32; 32];
+            row[0] = f32::INFINITY;
+            assert!(
+                quantize_row_q8_0(&row).is_err(),
+                "quantize_row_q8_0 must return Err when a block element is +Inf"
+            );
+        }
+
         /// Sweep all 65 536 u16 bit patterns and assert that `convert_f16_row` (NEON
         /// on aarch64, scalar on other targets) produces bit-identical output to the
         /// scalar `f16_to_f32` reference for every pattern.
@@ -16824,7 +16863,7 @@ kernel void decode_attention_reference(
             let mut packed_bytes = Vec::with_capacity(n * (k / 32) * 20);
             let mut deq_weights = Vec::with_capacity(n * k);
             for row in weights_f32.chunks_exact(k) {
-                let row_packed = quantize_row_q4_0(row);
+                let row_packed = quantize_row_q4_0(row).unwrap();
                 deq_weights.extend_from_slice(&dequantize_row_q4_0(&row_packed, k));
                 packed_bytes.extend_from_slice(&row_packed);
             }
@@ -17220,7 +17259,7 @@ kernel void decode_attention_reference(
             let mut packed_bytes = Vec::with_capacity(n * (k / 32) * 34);
             let mut deq_weights = Vec::with_capacity(n * k);
             for row in weights_f32.chunks_exact(k) {
-                let row_packed = quantize_row_q8_0(row);
+                let row_packed = quantize_row_q8_0(row).unwrap();
                 // Dequantize for CPU reference: each 34-byte block has f16 scale + 32 i8 values.
                 for block in row_packed.chunks_exact(34) {
                     let scale_bits = (block[0] as u16) | ((block[1] as u16) << 8);
@@ -17533,7 +17572,7 @@ kernel void decode_attention_reference(
             let mut packed_bytes = Vec::with_capacity(n * (k / 32) * 20);
             let mut w_deq = Vec::with_capacity(n * k);
             for row in w_f32.chunks_exact(k) {
-                let row_packed = quantize_row_q4_0(row);
+                let row_packed = quantize_row_q4_0(row).unwrap();
                 w_deq.extend_from_slice(&dequantize_row_q4_0(&row_packed, k));
                 packed_bytes.extend_from_slice(&row_packed);
             }
@@ -17612,7 +17651,7 @@ kernel void decode_attention_reference(
             let mut nz_packed = Vec::with_capacity(n * (k / 32) * 20);
             let mut nz_deq = Vec::with_capacity(n * k);
             for row in w_nz.chunks_exact(k) {
-                let row_packed = quantize_row_q4_0(row);
+                let row_packed = quantize_row_q4_0(row).unwrap();
                 nz_deq.extend_from_slice(&dequantize_row_q4_0(&row_packed, k));
                 nz_packed.extend_from_slice(&row_packed);
             }
@@ -19662,6 +19701,37 @@ kernel void decode_attention_reference(
                 "RACE-LOCALIZATION: chunked-vs-serial state max_abs_diff = {:.6}",
                 max_diff(&chunked_a, &serial_a)
             );
+        }
+
+        // -------------------------------------------------------------------
+        // Q8_0 non-finite input guard — mutation-sensitive (Finding 1, PR #452)
+        //
+        // IEEE 754: `NaN > x` is always false, so a fold-max over a block
+        // containing NaN leaves `amax` unchanged, and the NaN element is
+        // silently cast to 0 by the `clamp`, producing a plausible-looking
+        // packed buffer with a wrong entry and no error.
+        //
+        // Mutation sensitivity: removing the `if !v.is_finite()` guard in
+        // `quantize_row_q8_0` converts both Err returns to Ok, making
+        // `result.is_err()` false and failing both assertions.
+        // -------------------------------------------------------------------
+
+        #[test]
+        fn test_quantize_row_q8_0_rejects_nan() {
+            // A block with one NaN must return Err, not silently encode it as 0.
+            let mut vals = vec![1.0f32; 32];
+            vals[5] = f32::NAN;
+            let result = quantize_row_q8_0(&vals);
+            assert!(result.is_err(), "NaN in Q8_0 weight block must return Err");
+        }
+
+        #[test]
+        fn test_quantize_row_q8_0_rejects_inf() {
+            // A block with +inf must return Err; is_finite() rejects NaN, +inf, and -inf.
+            let mut vals = vec![1.0f32; 32];
+            vals[15] = f32::INFINITY;
+            let result = quantize_row_q8_0(&vals);
+            assert!(result.is_err(), "+inf in Q8_0 weight block must return Err");
         }
     }
 }

--- a/crates/inference/src/forward/neon.rs
+++ b/crates/inference/src/forward/neon.rs
@@ -8,6 +8,8 @@
 //! WITHOUT converting to f32 first. This avoids the CPU format conversion trap
 //! that made dequant-then-BLAS slower than native f32.
 
+use crate::error::InferenceError;
+
 /// Q8_0 block: 4-byte f32 scale + 32 int8 weights = 36 bytes.
 const QK8_0: usize = 32;
 const Q8_0_BLOCK_BYTES: usize = 4 + QK8_0;
@@ -306,7 +308,15 @@ pub fn matmul_q8_neon_into(
 /// Pack f32 weight matrix `[N, K]` into Q8_0 format.
 ///
 /// Returns packed bytes where each row is `K/32` blocks of `[f32_scale, 32×i8]`.
-pub fn pack_weights_q8(weights: &[f32], n: usize, k: usize) -> Vec<u8> {
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any element in `weights` is non-finite.
+/// IEEE-754 `NaN > x` is always false; a NaN would silently leave `max_abs` unchanged,
+/// producing a wrong (finite) scale while quantizing the corrupt element to a clamped
+/// i8 — wrong-but-quiet. Rejecting here makes the error point at the source weights
+/// rather than a downstream matmul producing garbage output.
+pub fn pack_weights_q8(weights: &[f32], n: usize, k: usize) -> Result<Vec<u8>, InferenceError> {
     assert_eq!(weights.len(), n * k);
     assert_eq!(k % QK8_0, 0);
     let blocks_per_row = k / QK8_0;
@@ -319,6 +329,14 @@ pub fn pack_weights_q8(weights: &[f32], n: usize, k: usize) -> Vec<u8> {
 
         for b in 0..blocks_per_row {
             let block_data = &row_data[b * QK8_0..(b + 1) * QK8_0];
+            for (i, &v) in block_data.iter().enumerate() {
+                if !v.is_finite() {
+                    return Err(InferenceError::InvalidInput(format!(
+                        "Q8_0 NEON weight block {b} in row {row} offset {i} contains a \
+                         non-finite value ({v}); source weights must be finite"
+                    )));
+                }
+            }
             let max_abs = block_data
                 .iter()
                 .copied()
@@ -334,7 +352,7 @@ pub fn pack_weights_q8(weights: &[f32], n: usize, k: usize) -> Vec<u8> {
         }
     }
 
-    packed
+    Ok(packed)
 }
 
 #[cfg(test)]
@@ -365,7 +383,7 @@ mod tests {
         let n = 4;
         let k = 64;
         let w: Vec<f32> = (0..n * k).map(|i| ((i % 17) as f32 - 8.0) * 0.1).collect();
-        let packed = pack_weights_q8(&w, n, k);
+        let packed = pack_weights_q8(&w, n, k).unwrap();
         assert_eq!(packed.len(), n * (k / QK8_0) * Q8_0_BLOCK_BYTES);
     }
 
@@ -390,7 +408,7 @@ mod tests {
 
         // Q8 scalar
         let (x_q, x_scale) = quantize_vec_q8(&x);
-        let packed = pack_weights_q8(&w, n, k);
+        let packed = pack_weights_q8(&w, n, k).unwrap();
         let mut q8_out = vec![0.0f32; n];
         matvec_q8_scalar(&x_q, x_scale, &packed, n, k, &mut q8_out);
 
@@ -417,7 +435,7 @@ mod tests {
             .collect();
 
         let (x_q, x_scale) = quantize_vec_q8(&x);
-        let packed = pack_weights_q8(&w, n, k);
+        let packed = pack_weights_q8(&w, n, k).unwrap();
 
         let mut scalar_out = vec![0.0f32; n];
         matvec_q8_scalar(&x_q, x_scale, &packed, n, k, &mut scalar_out);
@@ -444,7 +462,7 @@ mod tests {
         let w: Vec<f32> = (0..n * k)
             .map(|i| if i % 2 == 0 { 0.5 } else { -0.5 })
             .collect();
-        let packed = pack_weights_q8(&w, n, k);
+        let packed = pack_weights_q8(&w, n, k).unwrap();
         let out = matmul_q8_neon(&x, &packed, n, k);
         assert_eq!(out.len(), n);
         // Each row alternates 0.5/-0.5, dot with all-1s = 0.0
@@ -461,7 +479,7 @@ mod tests {
         let w: Vec<f32> = (0..n * k)
             .map(|i| ((i % 37) as f32 - 18.0) * 0.01)
             .collect();
-        let packed = pack_weights_q8(&w, n, k);
+        let packed = pack_weights_q8(&w, n, k).unwrap();
         let out = matmul_q8_neon(&x, &packed, n, k);
         assert_eq!(out.len(), n);
         // Smoke test: no NaN/Inf
@@ -478,7 +496,7 @@ mod tests {
         let w: Vec<f32> = (0..n * k)
             .map(|i| ((i * 13 + 7) % 23) as f32 * 0.04 - 0.46)
             .collect();
-        let packed = pack_weights_q8(&w, n, k);
+        let packed = pack_weights_q8(&w, n, k).unwrap();
 
         let expected = matmul_q8_neon(&x, &packed, n, k);
 
@@ -489,6 +507,39 @@ mod tests {
         assert_eq!(
             expected, out,
             "matmul_q8_neon_into must produce bitwise-identical output to matmul_q8_neon"
+        );
+    }
+
+    /// Mutation check: removing the `!v.is_finite()` guard in `pack_weights_q8`
+    /// makes this test pass NaN weights silently (NaN never updates `max_abs` via `>`,
+    /// so the scale stays finite and the corrupt element is clamped to an arbitrary
+    /// i8 value without error). The test must FAIL when the guard is removed.
+    #[test]
+    fn pack_weights_q8_rejects_nan() {
+        let n = 1;
+        let k = 32;
+        let mut w = vec![0.5f32; n * k];
+        w[15] = f32::NAN;
+        assert!(
+            pack_weights_q8(&w, n, k).is_err(),
+            "pack_weights_q8 must return Err when a block element is NaN"
+        );
+    }
+
+    /// Mutation check: removing the `!v.is_finite()` guard in `pack_weights_q8`
+    /// makes this test pass +Inf weights silently (`f32::INFINITY > max_abs` is true,
+    /// so max_abs becomes +Inf and scale becomes +Inf / 127 = +Inf, propagating
+    /// infinity into every quantized row without a typed error). The test must FAIL
+    /// when the guard is removed.
+    #[test]
+    fn pack_weights_q8_rejects_inf() {
+        let n = 1;
+        let k = 32;
+        let mut w = vec![0.5f32; n * k];
+        w[0] = f32::INFINITY;
+        assert!(
+            pack_weights_q8(&w, n, k).is_err(),
+            "pack_weights_q8 must return Err when a block element is +Inf"
         );
     }
 }

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -23,7 +23,7 @@ use crate::forward::neon::{matmul_q8_neon_into, pack_weights_q8};
 use crate::model::qwen35::{
     AttentionWeights, CommonLayerWeights, FeedForwardWeights, ForwardScratch,
     FullAttentionLayerWeights, KvCache, ModelWeights, decode_tokens, qwen35_rms_norm, resize,
-    sample_token,
+    sample_token, should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::rope::RopeTable;
@@ -944,7 +944,7 @@ pub fn generate_q8_neon(
         &mut rng_state,
     );
 
-    if next_id == cfg.eos_token_id {
+    if should_stop_token(cfg, gen_cfg, next_id) {
         return Ok(GenerateOutput {
             text: String::new(),
             token_ids: vec![],
@@ -984,7 +984,7 @@ pub fn generate_q8_neon(
             &mut rng_state,
         );
 
-        if next_id == cfg.eos_token_id {
+        if should_stop_token(cfg, gen_cfg, next_id) {
             stopped = true;
             break;
         }
@@ -2418,6 +2418,98 @@ mod tests {
         assert!(
             msg.contains("context window"),
             "error should mention context window, got: {msg}"
+        );
+    }
+
+    /// `generate_q8_neon` must stop on a token in `stop_token_ids` even when
+    /// that token differs from `eos_token_id`.
+    ///
+    /// Setup: hidden=64 (must be multiple of 32 for Q8_0), vocab=64, all-zero
+    /// weights → logits all 0 → greedy always picks token 0.
+    /// Config has eos_token_id=5 (not 0) and stop_token_ids=[0].
+    ///
+    /// Mutation check: reverting `should_stop_token` back to
+    /// `next_id == cfg.eos_token_id` in either check causes `0 == 5` to be false,
+    /// so token 0 is pushed to output and `generated_tokens` becomes ≥ 1.
+    #[test]
+    fn test_generate_q8_neon_honors_stop_token_ids() {
+        use std::collections::HashMap;
+
+        // Q8_0 requires hidden % 32 == 0; use 64.
+        let hidden = 64usize;
+        let vocab = 64usize;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 0,
+            vocab_size: vocab,
+            intermediate_size: 64,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: 1,
+            num_key_value_heads: 1,
+            head_dim: 64,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5,
+            rope_parameters: None,
+            linear_num_key_heads: 1,
+            linear_num_value_heads: Some(1),
+            linear_key_head_dim: 64,
+            linear_value_head_dim: 64,
+            linear_conv_kernel_dim: 64,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![],
+            layer_mask: vec![],
+            // eos is 5 so token 0 is NOT eos — stop_token_ids=[0] is the
+            // distinct stop path we are testing.
+            eos_token_id: 5,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        // All-zero packed weights: scale=0, all i8=0 → logits all 0 → greedy picks 0.
+        let model = Q8NeonModel {
+            embed_tokens: vec![0.0f32; vocab * hidden],
+            final_norm: vec![0.0f32; hidden],
+            lm_head_packed: zero_packed(vocab, hidden),
+            lm_head_rows: vocab,
+            lm_head_cols: hidden,
+            layers: vec![],
+        };
+
+        // rope_dim = head_dim * partial_rotary_factor = 64 * 0.5 = 32 (multiple of 32 ✓)
+        let rope = RopeTable::new(32, 64, 10_000.0);
+
+        let mut vocab_map: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab_map.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![("h".to_string(), "e".to_string())];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab_map, merges).unwrap();
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 4,
+            stop_token_ids: vec![0], // token 0 is the stop signal, NOT eos (5)
+            temperature: 0.0,        // greedy: all-zero logits always yield token 0
+            ..Default::default()
+        };
+
+        let out = generate_q8_neon(&model, &cfg, &tokenizer, &rope, "h", &gen_cfg)
+            .expect("generate_q8_neon must succeed with valid stop_token_ids");
+
+        assert_eq!(
+            out.generated_tokens, 0,
+            "generate_q8_neon must stop immediately when the first greedy token (0) \
+             is in stop_token_ids — got {} generated tokens instead",
+            out.generated_tokens
         );
     }
 }

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -2512,4 +2512,127 @@ mod tests {
             out.generated_tokens
         );
     }
+
+    /// `generate_q8_neon` must also stop when the stop token first appears in the
+    /// **decode loop**, not only at the post-prefill check.
+    ///
+    /// Fixture: a "bouncing" 0-layer Q8 model.
+    ///   embed[0] = [-1, 1, 0, ..., 0]  (64 dims, first two non-zero)
+    ///   embed[1] = [ 1, 1, 0, ..., 0]
+    ///   lm_head_packed = pack_weights_q8 of the same matrix (mimics tied weights)
+    ///   final_norm gamma = [-2, 0, ..., 0]
+    ///
+    /// The negative gamma at dim-0 flips that component after RMSNorm, creating a
+    /// deterministic bounce between tokens 0 and 1 (Q8 rounding preserves ordering):
+    ///   from token 1: hidden ∝ [-c, +c, 0, …] → Q8 dot → logit[0] > logit[1]
+    ///   from token 0: hidden ∝ [+c, +c, 0, …] → Q8 dot → logit[1] > logit[0]
+    ///
+    /// Greedy sequence from prompt "e" (→ token 1, eos_token_id=5):
+    ///   post-prefill  → token 0  (not stop=1)
+    ///   decode step 1 → token 1  (stop) → decode-loop fires
+    ///
+    /// Mutation proof: reverting ONLY the decode-loop `should_stop_token` check
+    /// (line 987 at time of writing) to `next_id == cfg.eos_token_id` leaves
+    /// token 1 uncaught (1 ≠ eos=5), the sequence continues, and generated_tokens
+    /// becomes ≥ 2 — failing the assertion below.
+    #[test]
+    fn test_generate_q8_neon_honors_stop_token_ids_decode_loop() {
+        use std::collections::HashMap;
+
+        // Q8_0 requires hidden % 32 == 0; use 64 (same as the post-prefill test).
+        let hidden = 64usize;
+        let vocab = 64usize;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 0,
+            vocab_size: vocab,
+            intermediate_size: 64,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: 1,
+            num_key_value_heads: 1,
+            head_dim: 64,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5,
+            rope_parameters: None,
+            linear_num_key_heads: 1,
+            linear_num_value_heads: Some(1),
+            linear_key_head_dim: 64,
+            linear_value_head_dim: 64,
+            linear_conv_kernel_dim: 64,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![],
+            layer_mask: vec![],
+            // eos=5 so the stop at token 1 is detectable only via stop_token_ids.
+            eos_token_id: 5,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        // The negative gamma at dim-0 creates a "bounce" each decode step.
+        // from embed[1]=[1,1,0,…]: hidden∝[-c,+c,0,…] → Q8 matmul → logit[0] > 0 wins
+        // from embed[0]=[-1,1,0,…]: hidden∝[+c,+c,0,…] → Q8 matmul → logit[1] > 0 wins
+        let mut embed_f32 = vec![0.0f32; vocab * hidden];
+        embed_f32[0] = -1.0; // token 0, dim 0
+        embed_f32[1] = 1.0; // token 0, dim 1
+        embed_f32[hidden] = 1.0; // token 1, dim 0
+        embed_f32[hidden + 1] = 1.0; // token 1, dim 1
+
+        let lm_head_packed = pack_weights_q8(&embed_f32, vocab, hidden);
+
+        let mut final_norm = vec![0.0f32; hidden];
+        final_norm[0] = -2.0; // flip dim-0 sign after RMSNorm to drive the bounce
+
+        let model = Q8NeonModel {
+            embed_tokens: embed_f32,
+            final_norm,
+            lm_head_packed,
+            lm_head_rows: vocab,
+            lm_head_cols: hidden,
+            layers: vec![],
+        };
+
+        let rope = RopeTable::new(32, 64, 10_000.0);
+
+        let mut vocab_map: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab_map.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![("h".to_string(), "e".to_string())];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab_map, merges).unwrap();
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 10,
+            stop_token_ids: vec![1], // stop on token 1 mid-decode-loop; eos_token_id=5≠1
+            temperature: 0.0,        // greedy: deterministic bouncing sequence
+            ..Default::default()
+        };
+
+        // Prompt "e" → token 1.
+        // Post-prefill generates token 0 (not stop=1).
+        // Decode step 1 generates token 1 → decode-loop stop fires.
+        let out = generate_q8_neon(&model, &cfg, &tokenizer, &rope, "e", &gen_cfg)
+            .expect("generate_q8_neon must succeed");
+
+        assert_eq!(
+            out.generated_tokens, 1,
+            "generate_q8_neon must stop at decode-loop step 1 when token 1 is in \
+             stop_token_ids — got {} tokens; reverting only the decode-loop check \
+             lets token 1 through and produces ≥ 2 tokens",
+            out.generated_tokens
+        );
+        assert!(
+            out.stopped,
+            "generate_q8_neon must set stopped=true when the decode-loop stop fires"
+        );
+    }
 }

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -18,6 +18,7 @@ use crate::attention::gdn::{
     GatedDeltaNetState, GatedDeltaNetWeights, gated_rms_norm, l2_normalize_vec, sigmoid, softplus,
 };
 use crate::attention::gdn_fused::GatedDeltaNetFusedScratch;
+use crate::error::InferenceError;
 use crate::forward::cpu::{elementwise_mul, silu_inplace};
 use crate::forward::neon::{matmul_q8_neon_into, pack_weights_q8};
 use crate::model::qwen35::{
@@ -162,25 +163,29 @@ pub struct Q8NeonModel {
 // -----------------------------------------------------------------------
 
 /// Convert GDN weights to Q8_0 NEON packed format.
-fn pack_gdn_weights(w: &GatedDeltaNetWeights) -> Q8NeonGdnWeights {
-    Q8NeonGdnWeights {
-        in_proj_qkv_packed: pack_weights_q8(&w.in_proj_qkv, w.in_proj_qkv_rows, w.in_proj_qkv_cols),
+fn pack_gdn_weights(w: &GatedDeltaNetWeights) -> Result<Q8NeonGdnWeights, InferenceError> {
+    Ok(Q8NeonGdnWeights {
+        in_proj_qkv_packed: pack_weights_q8(
+            &w.in_proj_qkv,
+            w.in_proj_qkv_rows,
+            w.in_proj_qkv_cols,
+        )?,
         in_proj_qkv_rows: w.in_proj_qkv_rows,
         in_proj_qkv_cols: w.in_proj_qkv_cols,
 
-        in_proj_z_packed: pack_weights_q8(&w.in_proj_z, w.in_proj_z_rows, w.in_proj_z_cols),
+        in_proj_z_packed: pack_weights_q8(&w.in_proj_z, w.in_proj_z_rows, w.in_proj_z_cols)?,
         in_proj_z_rows: w.in_proj_z_rows,
         in_proj_z_cols: w.in_proj_z_cols,
 
-        in_proj_b_packed: pack_weights_q8(&w.in_proj_b, w.in_proj_b_rows, w.in_proj_b_cols),
+        in_proj_b_packed: pack_weights_q8(&w.in_proj_b, w.in_proj_b_rows, w.in_proj_b_cols)?,
         in_proj_b_rows: w.in_proj_b_rows,
         in_proj_b_cols: w.in_proj_b_cols,
 
-        in_proj_a_packed: pack_weights_q8(&w.in_proj_a, w.in_proj_a_rows, w.in_proj_a_cols),
+        in_proj_a_packed: pack_weights_q8(&w.in_proj_a, w.in_proj_a_rows, w.in_proj_a_cols)?,
         in_proj_a_rows: w.in_proj_a_rows,
         in_proj_a_cols: w.in_proj_a_cols,
 
-        out_proj_packed: pack_weights_q8(&w.out_proj, w.out_proj_rows, w.out_proj_cols),
+        out_proj_packed: pack_weights_q8(&w.out_proj, w.out_proj_rows, w.out_proj_cols)?,
         out_proj_rows: w.out_proj_rows,
         out_proj_cols: w.out_proj_cols,
 
@@ -190,69 +195,74 @@ fn pack_gdn_weights(w: &GatedDeltaNetWeights) -> Q8NeonGdnWeights {
         conv_dim: w.conv_dim,
         kernel_size: w.kernel_size,
         norm_weight: w.norm_weight.clone(),
-    }
+    })
 }
 
 /// Convert full-attention weights to Q8_0 NEON packed format.
 fn pack_full_attn_weights(
     w: &FullAttentionLayerWeights,
     cfg: &Qwen35Config,
-) -> Q8NeonFullAttnWeights {
+) -> Result<Q8NeonFullAttnWeights, InferenceError> {
     let hidden = cfg.hidden_size;
     let q_dim = cfg.full_q_dim();
     let kv_dim = cfg.full_kv_dim();
     let q_proj_rows = 2 * q_dim; // Q + gate interleaved
 
-    Q8NeonFullAttnWeights {
-        q_proj_packed: pack_weights_q8(&w.q_proj, q_proj_rows, hidden),
+    Ok(Q8NeonFullAttnWeights {
+        q_proj_packed: pack_weights_q8(&w.q_proj, q_proj_rows, hidden)?,
         q_proj_rows,
         q_proj_cols: hidden,
 
-        k_proj_packed: pack_weights_q8(&w.k_proj, kv_dim, hidden),
+        k_proj_packed: pack_weights_q8(&w.k_proj, kv_dim, hidden)?,
         k_proj_rows: kv_dim,
         k_proj_cols: hidden,
 
-        v_proj_packed: pack_weights_q8(&w.v_proj, kv_dim, hidden),
+        v_proj_packed: pack_weights_q8(&w.v_proj, kv_dim, hidden)?,
         v_proj_rows: kv_dim,
         v_proj_cols: hidden,
 
-        o_proj_packed: pack_weights_q8(&w.o_proj, hidden, q_dim),
+        o_proj_packed: pack_weights_q8(&w.o_proj, hidden, q_dim)?,
         o_proj_rows: hidden,
         o_proj_cols: q_dim,
 
         q_norm: w.q_norm.clone(),
         k_norm: w.k_norm.clone(),
-    }
+    })
 }
 
 /// Convert common layer weights (MLP) to Q8_0 NEON packed format.
-fn pack_common_weights(w: &CommonLayerWeights, cfg: &Qwen35Config) -> Q8NeonCommonWeights {
+fn pack_common_weights(
+    w: &CommonLayerWeights,
+    cfg: &Qwen35Config,
+) -> Result<Q8NeonCommonWeights, InferenceError> {
     let hidden = cfg.hidden_size;
     let inter = cfg.intermediate_size;
 
     let (gate_proj, up_proj, down_proj) = match &w.ffn {
         FeedForwardWeights::Dense(dense) => (&dense.gate_proj, &dense.up_proj, &dense.down_proj),
         FeedForwardWeights::Moe(_) => {
-            panic!("Q8 NEON packing is dense-only; MoE configs are not supported");
+            return Err(InferenceError::InvalidInput(
+                "Q8 NEON packing is dense-only; MoE layer configs are not supported".into(),
+            ));
         }
     };
 
-    Q8NeonCommonWeights {
+    Ok(Q8NeonCommonWeights {
         input_layernorm: w.input_layernorm.clone(),
         post_attention_layernorm: w.post_attention_layernorm.clone(),
 
-        gate_proj_packed: pack_weights_q8(gate_proj, inter, hidden),
+        gate_proj_packed: pack_weights_q8(gate_proj, inter, hidden)?,
         gate_proj_rows: inter,
         gate_proj_cols: hidden,
 
-        up_proj_packed: pack_weights_q8(up_proj, inter, hidden),
+        up_proj_packed: pack_weights_q8(up_proj, inter, hidden)?,
         up_proj_rows: inter,
         up_proj_cols: hidden,
 
-        down_proj_packed: pack_weights_q8(down_proj, hidden, inter),
+        down_proj_packed: pack_weights_q8(down_proj, hidden, inter)?,
         down_proj_rows: hidden,
         down_proj_cols: inter,
-    }
+    })
 }
 
 /// **Unstable**: quantize model weights to Q8_0 NEON format; packing strategy may change.
@@ -265,7 +275,15 @@ fn pack_common_weights(w: &CommonLayerWeights, cfg: &Qwen35Config) -> Q8NeonComm
 ///
 /// The lm_head (logits projection) is packed separately from the embedding table:
 /// embed_tokens stays f32 for lookup, lm_head gets Q8_0 for the final matmul.
-pub fn quantize_model(weights: &ModelWeights, cfg: &Qwen35Config) -> Q8NeonModel {
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any weight element is non-finite,
+/// or if the model contains MoE layers (Q8 NEON packing is dense-only).
+pub fn quantize_model(
+    weights: &ModelWeights,
+    cfg: &Qwen35Config,
+) -> Result<Q8NeonModel, InferenceError> {
     let hidden = cfg.hidden_size;
     let vocab = cfg.vocab_size;
 
@@ -275,28 +293,28 @@ pub fn quantize_model(weights: &ModelWeights, cfg: &Qwen35Config) -> Q8NeonModel
         .map(|(attn, common)| {
             let q8_attn = match attn {
                 AttentionWeights::Linear(gdn_w) => {
-                    Q8NeonAttentionWeights::Linear(pack_gdn_weights(gdn_w))
+                    Q8NeonAttentionWeights::Linear(pack_gdn_weights(gdn_w)?)
                 }
                 AttentionWeights::Full(full_w) => {
-                    Q8NeonAttentionWeights::Full(pack_full_attn_weights(full_w, cfg))
+                    Q8NeonAttentionWeights::Full(pack_full_attn_weights(full_w, cfg)?)
                 }
             };
-            let q8_common = pack_common_weights(common, cfg);
-            (q8_attn, q8_common)
+            let q8_common = pack_common_weights(common, cfg)?;
+            Ok((q8_attn, q8_common))
         })
-        .collect();
+        .collect::<Result<Vec<_>, InferenceError>>()?;
 
     // Pack the actual output projection; for Qwen3.6 this is untied lm_head.weight.
-    let lm_head_packed = pack_weights_q8(weights.logits_weight(), vocab, hidden);
+    let lm_head_packed = pack_weights_q8(weights.logits_weight(), vocab, hidden)?;
 
-    Q8NeonModel {
+    Ok(Q8NeonModel {
         embed_tokens: weights.embed_tokens.clone(),
         final_norm: weights.final_norm.clone(),
         lm_head_packed,
         lm_head_rows: vocab,
         lm_head_cols: hidden,
         layers,
-    }
+    })
 }
 
 // -----------------------------------------------------------------------
@@ -1040,7 +1058,8 @@ pub mod bench_support {
 
     fn gen_weights_q8(n: usize, k: usize, rng: &mut u64) -> Vec<u8> {
         let floats: Vec<f32> = (0..n * k).map(|_| xorshift64(rng)).collect();
-        pack_weights_q8(&floats, n, k)
+        // Fixture weights are generated from a bounded LCG — always finite.
+        pack_weights_q8(&floats, n, k).unwrap()
     }
 
     impl Q8ForwardBenchFixture {
@@ -1182,7 +1201,8 @@ pub mod bench_support {
                     s as f32 / 0x10000_u64 as f32 * 0.04 - 0.02
                 })
                 .collect();
-            let lm_head_packed = pack_weights_q8(&embed_tokens, vocab, hidden);
+            // Fixture embed is bounded LCG output — always finite.
+            let lm_head_packed = pack_weights_q8(&embed_tokens, vocab, hidden).unwrap();
 
             let model = Q8NeonModel {
                 embed_tokens,
@@ -1301,7 +1321,8 @@ pub mod bench_support {
                     s as f32 / 0x10000_u64 as f32 * 0.04 - 0.02
                 })
                 .collect();
-            let lm_head_packed = pack_weights_q8(&embed_tokens, vocab, hidden);
+            // Fixture embed is bounded LCG output — always finite.
+            let lm_head_packed = pack_weights_q8(&embed_tokens, vocab, hidden).unwrap();
 
             let model = Q8NeonModel {
                 embed_tokens,
@@ -1394,7 +1415,7 @@ mod tests {
 
     /// Helper: create a zero Q8_0 packed weight buffer for [n, k].
     fn zero_packed(n: usize, k: usize) -> Vec<u8> {
-        pack_weights_q8(&vec![0.0f32; n * k], n, k)
+        pack_weights_q8(&vec![0.0f32; n * k], n, k).unwrap()
     }
 
     #[test]
@@ -1471,7 +1492,7 @@ mod tests {
             ],
         };
 
-        let q8 = quantize_model(&weights, &cfg);
+        let q8 = quantize_model(&weights, &cfg).unwrap();
 
         // Check lm_head packed size
         assert_eq!(q8.lm_head_packed.len(), q8_packed_size(vocab, hidden));
@@ -1793,7 +1814,7 @@ mod tests {
             for j in 0..kv_dim {
                 mat[j * hidden + j] = 1.0;
             }
-            pack_weights_q8(&mat, kv_dim, hidden)
+            pack_weights_q8(&mat, kv_dim, hidden).unwrap()
         };
 
         // W_q = identity for first q_dim rows (Q part), zeros for next q_dim rows (gate part).
@@ -1804,7 +1825,7 @@ mod tests {
             for j in 0..q_dim {
                 mat[j * hidden + j] = 1.0;
             }
-            pack_weights_q8(&mat, 2 * q_dim, hidden)
+            pack_weights_q8(&mat, 2 * q_dim, hidden).unwrap()
         };
 
         let weights = Q8NeonFullAttnWeights {
@@ -1989,7 +2010,8 @@ mod tests {
                     ((seed >> 33) as f32 / u32::MAX as f32) * 0.04 - 0.02
                 })
                 .collect();
-            pack_weights_q8(&floats, n, k)
+            // LCG output is bounded — always finite.
+            pack_weights_q8(&floats, n, k).unwrap()
         };
 
         let gdn_w = Q8NeonGdnWeights {
@@ -2043,7 +2065,8 @@ mod tests {
                         ((*seed >> 33) as f32 / u32::MAX as f32) * 0.04 - 0.02
                     })
                     .collect();
-                pack_weights_q8(&floats, n, k)
+                // LCG output is bounded — always finite.
+                pack_weights_q8(&floats, n, k).unwrap()
             };
             Q8NeonCommonWeights {
                 input_layernorm: vec![0.0f32; hidden],
@@ -2070,7 +2093,8 @@ mod tests {
                 s as f32 / 0x10000_u64 as f32 * 0.04 - 0.02
             })
             .collect();
-        let lm_head_packed = pack_weights_q8(&embed_tokens, vocab, hidden);
+        // Fixture embed is bounded hash output — always finite.
+        let lm_head_packed = pack_weights_q8(&embed_tokens, vocab, hidden).unwrap();
 
         let model = Q8NeonModel {
             embed_tokens,
@@ -2246,7 +2270,8 @@ mod tests {
             for j in 0..rows.min(hidden) {
                 mat[j * hidden + j] = 1.0;
             }
-            pack_weights_q8(&mat, rows, hidden)
+            // Identity matrices contain only 0.0 and 1.0 — always finite.
+            pack_weights_q8(&mat, rows, hidden).unwrap()
         };
         let weights = Q8NeonFullAttnWeights {
             q_proj_packed: identity(2 * q_dim),
@@ -2587,7 +2612,8 @@ mod tests {
         embed_f32[hidden] = 1.0; // token 1, dim 0
         embed_f32[hidden + 1] = 1.0; // token 1, dim 1
 
-        let lm_head_packed = pack_weights_q8(&embed_f32, vocab, hidden);
+        // Embed values are ±1.0 or 0.0 — all finite.
+        let lm_head_packed = pack_weights_q8(&embed_f32, vocab, hidden).unwrap();
 
         let mut final_norm = vec![0.0f32; hidden];
         final_norm[0] = -2.0; // flip dim-0 sign after RMSNorm to drive the bounce

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -661,7 +661,15 @@ pub(crate) fn earliest_stop_match(haystack: &str, stops: &[String]) -> Option<us
 }
 
 /// Returns true when `token_id` is EOS or is in the `stop_token_ids` list.
-pub fn should_stop_token(cfg: &Qwen35Config, gen_cfg: &GenerateConfig, token_id: u32) -> bool {
+///
+/// `pub(crate)` — all callers (Q8, F16, NEON, batch-prefill generate paths) live
+/// within this crate. Keeping the function crate-private avoids leaking a
+/// low-level sampling helper as part of the public API.
+pub(crate) fn should_stop_token(
+    cfg: &Qwen35Config,
+    gen_cfg: &GenerateConfig,
+    token_id: u32,
+) -> bool {
     token_id == cfg.eos_token_id || gen_cfg.stop_token_ids.contains(&token_id)
 }
 

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -49,7 +49,7 @@ pub(crate) use weights::{MoeLayerWeights, MoeRouter, RoutedExperts, SharedExpert
 
 #[cfg(test)]
 pub use detokenize::bytes_to_unicode;
-#[cfg(test)]
+// Needed by the Q8 generate path (cpu_q8.rs) as well as by tests.
 pub use generation::should_stop_token;
 
 /// Exposed for consumers that need to drive a per-layer coverage check

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -49,8 +49,9 @@ pub(crate) use weights::{MoeLayerWeights, MoeRouter, RoutedExperts, SharedExpert
 
 #[cfg(test)]
 pub use detokenize::bytes_to_unicode;
-// Needed by the Q8 generate path (cpu_q8.rs) as well as by tests.
-pub use generation::should_stop_token;
+// Needed by all generate paths (cpu_q8, cpu_f16, neon_forward, batch_prefill)
+// and by tests. `pub(crate)` keeps it out of the public API surface.
+pub(crate) use generation::should_stop_token;
 
 /// Exposed for consumers that need to drive a per-layer coverage check
 /// over a Qwen3.5 checkpoint without going through the model loader —

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -438,7 +438,7 @@ pub fn convert_quarot_qwen35(
             let n_blocks = entry.data.len().div_ceil(32) as u64;
             total_bytes_out += header_bytes + n_blocks.saturating_mul(20);
             if !opts.dry_run {
-                let q4 = quantize_f64_to_q4(&entry.data, &entry.shape);
+                let q4 = quantize_f64_to_q4(&entry.data, &entry.shape)?;
                 let file_name = format!("{sanitized}.q4");
                 let out_path = output_dir.join(&file_name);
                 save_q4_file(&out_path, &q4).map_err(|e| {

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -48,6 +48,8 @@
 // the two transmute-equivalent slice casts in stream_quantize_shard and save/load.
 #![allow(clippy::cast_possible_truncation)]
 
+use crate::error::InferenceError;
+
 /// One Q4_0 quantization block: 32 weights packed as 4-bit unsigned integers.
 ///
 /// `scale` is stored as a raw IEEE-754 f16 bit pattern in a `u16` — the `half` crate
@@ -227,12 +229,17 @@ fn bf16_to_f32(v: u16) -> f32 {
 // Core block quantization
 // ---------------------------------------------------------------------------
 
-/// Quantize exactly 32 f32 values into one [`Q4Block`].
+/// Quantize exactly 32 f32 values into one [`Q4Block`] using asymmetric mode.
 ///
-/// Uses scale = `abs_max / 7.0` (if `abs_max == 0` uses `1.0`).
 /// Nibble layout: sequential pairs — `byte[b] = (q[2b+1] << 4) | q[2b]`.
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any value in `vals` is non-finite.
+/// IEEE-754 `NaN > x` is always false, so a NaN would silently leave the
+/// min/max accumulators unchanged and produce wrong-but-no-error quantization.
 #[inline]
-fn quantize_block(vals: &[f32; 32]) -> Q4Block {
+fn quantize_block(vals: &[f32; 32]) -> Result<Q4Block, InferenceError> {
     quantize_block_with_mode(vals, false)
 }
 
@@ -241,8 +248,27 @@ fn quantize_block(vals: &[f32; 32]) -> Q4Block {
 /// with non-zero distributional center. Both modes share the same on-disk
 /// format: `dequant = nibble * scale + bias`. Symmetric mode sets
 /// `bias = -8 * scale` so that nibble=8 maps to exactly 0.
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any element of `vals` is
+/// non-finite. IEEE-754 `NaN > x` is always false; a NaN silently leaves
+/// `abs_max`, `min_val`, or `max_val` unchanged, yielding wrong-but-no-error
+/// quantization. Rejecting here means the error points at the source weight
+/// rather than a downstream matmul.
 #[inline]
-pub(crate) fn quantize_block_with_mode(vals: &[f32; 32], symmetric: bool) -> Q4Block {
+pub(crate) fn quantize_block_with_mode(
+    vals: &[f32; 32],
+    symmetric: bool,
+) -> Result<Q4Block, InferenceError> {
+    for (i, &v) in vals.iter().enumerate() {
+        if !v.is_finite() {
+            return Err(InferenceError::InvalidInput(format!(
+                "Q4 weight block element {i} contains a non-finite value ({v}); \
+                 source weights must be finite"
+            )));
+        }
+    }
     if symmetric {
         let abs_max = vals.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
         let scale = if abs_max == 0.0 {
@@ -258,11 +284,11 @@ pub(crate) fn quantize_block_with_mode(vals: &[f32; 32], symmetric: bool) -> Q4B
             let q1 = ((vals[2 * b + 1] * inv_scale).round() + 8.0).clamp(0.0, 15.0) as u8;
             packed[b] = (q1 << 4) | (q0 & 0x0f);
         }
-        Q4Block {
+        Ok(Q4Block {
             scale: q4_f32_to_f16(scale),
             bias: q4_f32_to_f16(bias),
             packed,
-        }
+        })
     } else {
         let min_val = vals.iter().copied().fold(f32::INFINITY, f32::min);
         let max_val = vals.iter().copied().fold(f32::NEG_INFINITY, f32::max);
@@ -275,11 +301,11 @@ pub(crate) fn quantize_block_with_mode(vals: &[f32; 32], symmetric: bool) -> Q4B
             let q1 = (((vals[2 * b + 1] - min_val) * inv_scale).round()).clamp(0.0, 15.0) as u8;
             packed[b] = (q1 << 4) | (q0 & 0x0f);
         }
-        Q4Block {
+        Ok(Q4Block {
             scale: q4_f32_to_f16(scale),
             bias: q4_f32_to_f16(min_val),
             packed,
-        }
+        })
     }
 }
 
@@ -293,13 +319,17 @@ pub(crate) fn quantize_block_with_mode(vals: &[f32; 32], symmetric: bool) -> Q4B
 /// if `src.len()` is not a multiple of 32.
 ///
 /// Returns raw bytes containing tightly-packed [`Q4Block`]s (20 bytes each).
-pub fn quantize_row_q4_0(src: &[f32]) -> Vec<u8> {
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any value in `src` is non-finite.
+pub fn quantize_row_q4_0(src: &[f32]) -> Result<Vec<u8>, InferenceError> {
     let n_blocks = src.len().div_ceil(32);
     let mut out = Vec::with_capacity(n_blocks * 20);
     for chunk in src.chunks(32) {
         let mut vals = [0.0f32; 32];
         vals[..chunk.len()].copy_from_slice(chunk);
-        let block = quantize_block(&vals);
+        let block = quantize_block(&vals)?;
         // SAFETY: Q4Block is #[repr(C)] with size 20; its alignment is 2 (the
         // alignment of the leading `scale: u16` per the Rust Reference's repr(C)
         // rule). Casting to `&[u8; 20]` is valid because the target element type
@@ -308,7 +338,7 @@ pub fn quantize_row_q4_0(src: &[f32]) -> Vec<u8> {
         let bytes: &[u8; 20] = unsafe { &*std::ptr::from_ref(&block).cast() };
         out.extend_from_slice(bytes);
     }
-    out
+    Ok(out)
 }
 
 /// Dequantize Q4_0 blocks (raw bytes) back to f32 values.
@@ -340,7 +370,15 @@ pub fn dequantize_row_q4_0(data: &[u8], n_weights: usize) -> Vec<f32> {
 ///
 /// `src` has shape `[rows, cols]`. Each row is quantized independently into
 /// `cols.div_ceil(32)` blocks. Returns raw bytes (20 bytes per block).
-pub fn quantize_tensor_q4_0(src: &[f32], rows: usize, cols: usize) -> Vec<u8> {
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any value in `src` is non-finite.
+pub fn quantize_tensor_q4_0(
+    src: &[f32],
+    rows: usize,
+    cols: usize,
+) -> Result<Vec<u8>, InferenceError> {
     assert_eq!(
         src.len(),
         rows * cols,
@@ -350,9 +388,9 @@ pub fn quantize_tensor_q4_0(src: &[f32], rows: usize, cols: usize) -> Vec<u8> {
     let mut out = Vec::with_capacity(rows * blocks_per_row * 20);
     for row_idx in 0..rows {
         let row = &src[row_idx * cols..(row_idx + 1) * cols];
-        out.extend_from_slice(&quantize_row_q4_0(row));
+        out.extend_from_slice(&quantize_row_q4_0(row)?);
     }
-    out
+    Ok(out)
 }
 
 // ---------------------------------------------------------------------------
@@ -387,7 +425,12 @@ fn assert_shape_matches_data_len(shape: &[usize], data_len: usize) {
 /// Quantize a BF16 tensor (raw `u16` slice) into a [`Q4Tensor`].
 ///
 /// Panics if `shape.iter().product()` does not equal `data.len()`.
-pub fn quantize_bf16_to_q4(data: &[u16], shape: &[usize]) -> Q4Tensor {
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any BF16 value decodes to a
+/// non-finite f32 (NaN or ±inf).
+pub fn quantize_bf16_to_q4(data: &[u16], shape: &[usize]) -> Result<Q4Tensor, InferenceError> {
     assert_shape_matches_data_len(shape, data.len());
     let original_len = data.len();
     let n_blocks = original_len.div_ceil(32);
@@ -398,14 +441,14 @@ pub fn quantize_bf16_to_q4(data: &[u16], shape: &[usize]) -> Q4Tensor {
         for (i, &v) in chunk.iter().enumerate() {
             vals[i] = bf16_to_f32(v);
         }
-        blocks.push(quantize_block(&vals));
+        blocks.push(quantize_block(&vals)?);
     }
 
-    Q4Tensor {
+    Ok(Q4Tensor {
         blocks,
         shape: shape.to_vec(),
         original_len,
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -426,7 +469,11 @@ pub fn quantize_bf16_to_q4(data: &[u16], shape: &[usize]) -> Q4Tensor {
 /// avoids that truncation.
 ///
 /// Panics if `shape.iter().product()` does not equal `data.len()`.
-pub fn quantize_f32_to_q4(data: &[f32], shape: &[usize]) -> Q4Tensor {
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any value in `data` is non-finite.
+pub fn quantize_f32_to_q4(data: &[f32], shape: &[usize]) -> Result<Q4Tensor, InferenceError> {
     assert_shape_matches_data_len(shape, data.len());
     let original_len = data.len();
     let n_blocks = original_len.div_ceil(32);
@@ -435,14 +482,14 @@ pub fn quantize_f32_to_q4(data: &[f32], shape: &[usize]) -> Q4Tensor {
     for chunk in data.chunks(32) {
         let mut vals = [0.0f32; 32];
         vals[..chunk.len()].copy_from_slice(chunk);
-        blocks.push(quantize_block(&vals));
+        blocks.push(quantize_block(&vals)?);
     }
 
-    Q4Tensor {
+    Ok(Q4Tensor {
         blocks,
         shape: shape.to_vec(),
         original_len,
-    }
+    })
 }
 
 /// Quantize an `f64` tensor into a [`Q4Tensor`] via f32 downcast.
@@ -467,7 +514,12 @@ pub fn quantize_f32_to_q4(data: &[f32], shape: &[usize]) -> Q4Tensor {
 /// boundaries.
 ///
 /// Panics if `shape.iter().product()` does not equal `data.len()`.
-pub fn quantize_f64_to_q4(data: &[f64], shape: &[usize]) -> Q4Tensor {
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any f64 value is non-finite (NaN
+/// or ±inf), or if the f32 downcast produces a non-finite value.
+pub fn quantize_f64_to_q4(data: &[f64], shape: &[usize]) -> Result<Q4Tensor, InferenceError> {
     quantize_f64_to_q4_mode(data, shape, true) // symmetric — QuaRot-rotated weights are zero-mean
 }
 
@@ -478,7 +530,15 @@ pub fn quantize_f64_to_q4(data: &[f64], shape: &[usize]) -> Q4Tensor {
 /// is approximately zero anyway, producing a 0.067·abs_max error on the zero
 /// representation). Use `false` for raw weights with non-zero distributional
 /// center.
-pub fn quantize_f64_to_q4_mode(data: &[f64], shape: &[usize], symmetric: bool) -> Q4Tensor {
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if any value in `data` is non-finite.
+pub fn quantize_f64_to_q4_mode(
+    data: &[f64],
+    shape: &[usize],
+    symmetric: bool,
+) -> Result<Q4Tensor, InferenceError> {
     assert_shape_matches_data_len(shape, data.len());
     let original_len = data.len();
     let n_blocks = original_len.div_ceil(32);
@@ -489,14 +549,14 @@ pub fn quantize_f64_to_q4_mode(data: &[f64], shape: &[usize], symmetric: bool) -
         for (i, &v) in chunk.iter().enumerate() {
             vals[i] = v as f32;
         }
-        blocks.push(quantize_block_with_mode(&vals, symmetric));
+        blocks.push(quantize_block_with_mode(&vals, symmetric)?);
     }
 
-    Q4Tensor {
+    Ok(Q4Tensor {
         blocks,
         shape: shape.to_vec(),
         original_len,
-    }
+    })
 }
 
 /// Dequantize all blocks of a [`Q4Tensor`] back to f32.
@@ -542,7 +602,7 @@ pub fn stream_quantize_shard(
             let v = u16::from_ne_bytes([pair[0], pair[1]]);
             vals[j] = bf16_to_f32(v);
         }
-        blocks.push(quantize_block(&vals));
+        blocks.push(quantize_block(&vals).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?);
     }
 
     Ok(blocks)
@@ -852,7 +912,7 @@ mod tests {
     // -----------------------------------------------------------------------
     #[test]
     fn test_quantize_dequantize_zeros() {
-        let data = quantize_row_q4_0(&vec![0.0f32; 64]);
+        let data = quantize_row_q4_0(&vec![0.0f32; 64]).unwrap();
         let out = dequantize_row_q4_0(&data, 64);
         assert_eq!(out.len(), 64);
         for v in &out {
@@ -866,7 +926,7 @@ mod tests {
     #[test]
     fn test_quantize_dequantize_small_values() {
         let src: Vec<f32> = (0..32).map(|i| i as f32 * 7.0 / 31.0).collect();
-        let data = quantize_row_q4_0(&src);
+        let data = quantize_row_q4_0(&src).unwrap();
         let out = dequantize_row_q4_0(&data, 32);
         let max_err = src
             .iter()
@@ -885,7 +945,7 @@ mod tests {
     #[test]
     fn test_quantize_dequantize_symmetric() {
         let src: Vec<f32> = (0..32).map(|i| (i as f32 - 15.5) / 15.5 * 7.0).collect();
-        let data = quantize_row_q4_0(&src);
+        let data = quantize_row_q4_0(&src).unwrap();
         let out = dequantize_row_q4_0(&data, 32);
         let max_err = src
             .iter()
@@ -907,7 +967,7 @@ mod tests {
         let mut src = vec![0.0f32; 32];
         src[0] = 7.0;
         src[1] = -7.0;
-        let data = quantize_row_q4_0(&src);
+        let data = quantize_row_q4_0(&src).unwrap();
         // Asymmetric: min=-7, max=7, scale = 14/15 ≈ 0.933
         // q[0] = round((7.0 - (-7.0)) / scale) = round(15) = 15 → low nibble
         // q[1] = round((-7.0 - (-7.0)) / scale) = round(0)  = 0  → high nibble
@@ -934,7 +994,7 @@ mod tests {
     fn test_quantize_single_block() {
         // Use values in [-7, 7] so scale = 7/7 = 1.0 and max quantization error = 0.5.
         let src: Vec<f32> = (0..32).map(|i| (i as f32 / 31.0) * 14.0 - 7.0).collect();
-        let data = quantize_row_q4_0(&src);
+        let data = quantize_row_q4_0(&src).unwrap();
         assert_eq!(data.len(), 20, "single block must be 20 bytes");
         let out = dequantize_row_q4_0(&data, 32);
         assert_eq!(out.len(), 32);
@@ -957,7 +1017,7 @@ mod tests {
     #[test]
     fn test_quantize_multiple_blocks() {
         let src: Vec<f32> = (0..128).map(|i| (i as f32 - 64.0) / 10.0).collect();
-        let data = quantize_row_q4_0(&src);
+        let data = quantize_row_q4_0(&src).unwrap();
         assert_eq!(data.len(), 4 * 20, "4 blocks must be 80 bytes");
         let out = dequantize_row_q4_0(&data, 128);
         assert_eq!(out.len(), 128);
@@ -1050,7 +1110,7 @@ mod tests {
         let mut src = vec![0.0f32; 32];
         src[0] = 0.0;
         src[1] = 7.0;
-        let data = quantize_row_q4_0(&src);
+        let data = quantize_row_q4_0(&src).unwrap();
         let byte0 = data[4];
         assert_eq!(
             byte0, 0xF0,
@@ -1083,7 +1143,7 @@ mod tests {
         let src: Vec<f32> = (0..rows * cols)
             .map(|i| (i as f32 - 128.0) / 20.0)
             .collect();
-        let data = quantize_tensor_q4_0(&src, rows, cols);
+        let data = quantize_tensor_q4_0(&src, rows, cols).unwrap();
         let blocks_per_row = cols.div_ceil(32); // 2 blocks per row of 64 cols
         assert_eq!(
             data.len(),
@@ -1131,7 +1191,7 @@ mod tests {
     #[test]
     fn test_quantize_dequantize_round_trip_zeros_bf16() {
         let data = vec![0u16; 64];
-        let tensor = quantize_bf16_to_q4(&data, &[64]);
+        let tensor = quantize_bf16_to_q4(&data, &[64]).unwrap();
         let out = dequantize_q4_to_f32(&tensor);
         assert_eq!(out.len(), 64);
         for v in &out {
@@ -1143,7 +1203,7 @@ mod tests {
     fn test_quantize_dequantize_round_trip_positive_bf16() {
         let f32_vals: Vec<f32> = (0..32).map(|i| i as f32 * 7.0 / 31.0).collect();
         let bf16_vals = to_bf16(&f32_vals);
-        let tensor = quantize_bf16_to_q4(&bf16_vals, &[32]);
+        let tensor = quantize_bf16_to_q4(&bf16_vals, &[32]).unwrap();
         let out = dequantize_q4_to_f32(&tensor);
         // Compare against bf16-rounded originals (bf16 conversion is lossy at input).
         // Threshold 0.51 accounts for f16 scale rounding on top of the 0.5 quantization step.
@@ -1163,7 +1223,7 @@ mod tests {
         f32_vals[0] = 0.0;
         f32_vals[1] = 7.0;
         let bf16_vals = to_bf16(&f32_vals);
-        let tensor = quantize_bf16_to_q4(&bf16_vals, &[32]);
+        let tensor = quantize_bf16_to_q4(&bf16_vals, &[32]).unwrap();
         assert_eq!(tensor.blocks.len(), 1);
         assert_eq!(
             tensor.blocks[0].packed[0], 0xF0,
@@ -1177,7 +1237,7 @@ mod tests {
         let mut f32_vals = [0.0f32; 32];
         f32_vals[0] = 100.0;
         let bf16_vals = to_bf16(&f32_vals);
-        let tensor = quantize_bf16_to_q4(&bf16_vals, &[32]);
+        let tensor = quantize_bf16_to_q4(&bf16_vals, &[32]).unwrap();
         let low_nibble = tensor.blocks[0].packed[0] & 0x0f;
         assert_eq!(low_nibble, 15, "weight[0]=100 should clamp to nibble 15");
     }
@@ -1195,7 +1255,7 @@ mod tests {
             f32_vals.push(-((i % 7) as f32 + 1.0));
         } // range [-7, -1]
         let bf16_vals = to_bf16(&f32_vals);
-        let tensor = quantize_bf16_to_q4(&bf16_vals, &[64]);
+        let tensor = quantize_bf16_to_q4(&bf16_vals, &[64]).unwrap();
         assert_eq!(tensor.blocks.len(), 2);
         let out = dequantize_q4_to_f32(&tensor);
         // All block-0 values are positive [1..7], scale≈1. Dequant ≥ (1-0.5)*1 = 0.5 > 0.
@@ -1212,7 +1272,7 @@ mod tests {
     fn test_save_load_round_trip() {
         let f32_vals: Vec<f32> = (0..64).map(|i| (i as f32 - 32.0) / 4.0).collect();
         let bf16_vals = to_bf16(&f32_vals);
-        let original = quantize_bf16_to_q4(&bf16_vals, &[8, 8]);
+        let original = quantize_bf16_to_q4(&bf16_vals, &[8, 8]).unwrap();
         let path = std::path::PathBuf::from("/tmp/test_q4_round_trip.q4");
         save_q4_file(&path, &original).unwrap();
         let loaded = load_q4_file(&path).unwrap();
@@ -1230,7 +1290,7 @@ mod tests {
     fn test_stream_quantize_shard_matches_batch() {
         let f32_vals: Vec<f32> = (0..96).map(|i| i as f32 / 10.0).collect();
         let bf16_vals = to_bf16(&f32_vals);
-        let batch_tensor = quantize_bf16_to_q4(&bf16_vals, &[96]);
+        let batch_tensor = quantize_bf16_to_q4(&bf16_vals, &[96]).unwrap();
         // Convert bf16 u16s to raw bytes (native endian, matching stream_quantize_shard)
         let bf16_bytes: Vec<u8> = bf16_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
         let stream_blocks = stream_quantize_shard(&bf16_bytes).unwrap();
@@ -1245,7 +1305,7 @@ mod tests {
     fn test_shape_preservation() {
         let shape = vec![4usize, 8, 4]; // 128 elements
         let data = vec![0u16; 128];
-        let tensor = quantize_bf16_to_q4(&data, &shape);
+        let tensor = quantize_bf16_to_q4(&data, &shape).unwrap();
         assert_eq!(tensor.shape, shape);
         assert_eq!(tensor.original_len, 128);
         assert_eq!(tensor.blocks.len(), 4); // 128 / 32 = 4
@@ -1272,7 +1332,7 @@ mod tests {
             let v = ((state >> 32) as f32 / u32::MAX as f32) * 14.0 - 7.0;
             f32_vals.push(v);
         }
-        let data = quantize_row_q4_0(&f32_vals);
+        let data = quantize_row_q4_0(&f32_vals).unwrap();
         let out = dequantize_row_q4_0(&data, 1024);
         assert_eq!(out.len(), 1024);
         let mae = f32_vals
@@ -1316,7 +1376,7 @@ mod tests {
     #[test]
     fn quantize_f32_to_q4_shape_and_length() {
         let src = synthetic_f32_uniform(96, 17);
-        let q = quantize_f32_to_q4(&src, &[3, 32]);
+        let q = quantize_f32_to_q4(&src, &[3, 32]).unwrap();
         assert_eq!(q.shape, vec![3, 32]);
         assert_eq!(q.original_len, 96);
         assert_eq!(q.blocks.len(), 3, "96 elems = 3 full Q4 blocks");
@@ -1325,7 +1385,7 @@ mod tests {
     #[test]
     fn quantize_f32_to_q4_pads_partial_block() {
         let src = synthetic_f32_uniform(40, 19);
-        let q = quantize_f32_to_q4(&src, &[40]);
+        let q = quantize_f32_to_q4(&src, &[40]).unwrap();
         assert_eq!(q.original_len, 40);
         assert_eq!(q.blocks.len(), 2, "40 elems = 1 full + 1 partial Q4 block");
     }
@@ -1342,8 +1402,8 @@ mod tests {
             .map(f64::from)
             .collect();
         let src_f32: Vec<f32> = src_f64.iter().map(|&v| v as f32).collect();
-        let q_f64 = quantize_f64_to_q4_mode(&src_f64, &[256], false);
-        let q_f32 = quantize_f32_to_q4(&src_f32, &[256]);
+        let q_f64 = quantize_f64_to_q4_mode(&src_f64, &[256], false).unwrap();
+        let q_f32 = quantize_f32_to_q4(&src_f32, &[256]).unwrap();
         assert_eq!(q_f64.shape, q_f32.shape);
         assert_eq!(q_f64.original_len, q_f32.original_len);
         assert_eq!(
@@ -1372,8 +1432,8 @@ mod tests {
             .collect();
         let f32_from_bf16: Vec<f32> = bf16_bits.iter().map(|&b| bf16_to_f32(b)).collect();
 
-        let q_bf16 = quantize_bf16_to_q4(&bf16_bits, &[256]);
-        let q_f32 = quantize_f32_to_q4(&f32_from_bf16, &[256]);
+        let q_bf16 = quantize_bf16_to_q4(&bf16_bits, &[256]).unwrap();
+        let q_f32 = quantize_f32_to_q4(&f32_from_bf16, &[256]).unwrap();
         assert_eq!(q_bf16.blocks.len(), q_f32.blocks.len());
         for (i, (a, b)) in q_bf16.blocks.iter().zip(q_f32.blocks.iter()).enumerate() {
             assert_eq!(a.scale, b.scale, "block {i} scale should match");
@@ -1396,8 +1456,8 @@ mod tests {
         let src = synthetic_f32_uniform(2048, 31);
         let bf16_bits: Vec<u16> = src.iter().map(|&v| f32_to_bf16_bits(v)).collect();
 
-        let q_bf16 = quantize_bf16_to_q4(&bf16_bits, &[2048]);
-        let q_f32 = quantize_f32_to_q4(&src, &[2048]);
+        let q_bf16 = quantize_bf16_to_q4(&bf16_bits, &[2048]).unwrap();
+        let q_f32 = quantize_f32_to_q4(&src, &[2048]).unwrap();
         let deq_bf16 = dequantize_q4_to_f32(&q_bf16);
         let deq_f32 = dequantize_q4_to_f32(&q_f32);
 
@@ -1475,8 +1535,8 @@ mod tests {
         // produce the same per-block byte layout as `quantize_row_q4_0`
         // (which the existing kernels are already validated against).
         let src = synthetic_f32_uniform(128, 37);
-        let q = quantize_f32_to_q4(&src, &[128]);
-        let row_bytes = quantize_row_q4_0(&src);
+        let q = quantize_f32_to_q4(&src, &[128]).unwrap();
+        let row_bytes = quantize_row_q4_0(&src).unwrap();
         assert_eq!(row_bytes.len(), q.blocks.len() * 20);
         // SAFETY: Q4Block is #[repr(C)] size 20 (scale + bias + 16 nibbles),
         // alignment 2; byte-cast is valid because target element type is u8.
@@ -1501,7 +1561,7 @@ mod tests {
     fn dequantize_row_q4_0_misaligned_does_not_panic() {
         // Build a valid 1-block (20-byte) buffer by quantizing 32 known values.
         let src: Vec<f32> = (0..32).map(|i| (i as f32 / 31.0) * 14.0 - 7.0).collect();
-        let mut buf = quantize_row_q4_0(&src); // exactly 20 bytes
+        let mut buf = quantize_row_q4_0(&src).unwrap(); // exactly 20 bytes
         assert_eq!(buf.len(), 20);
         // Append 5 garbage bytes — total 25, which is NOT a multiple of 20.
         buf.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF, 0xFF]);
@@ -1544,7 +1604,7 @@ mod tests {
     #[test]
     fn dequantize_row_q4_0_exact_blocks_unchanged() {
         let src: Vec<f32> = (0..64).map(|i| (i as f32 - 32.0) / 10.0).collect();
-        let data = quantize_row_q4_0(&src);
+        let data = quantize_row_q4_0(&src).unwrap();
         assert_eq!(data.len(), 40, "2-block input must be 40 bytes");
         let out = dequantize_row_q4_0(&data, 64);
         assert_eq!(out.len(), 64);
@@ -1676,6 +1736,48 @@ mod tests {
         assert!(
             r.is_err(),
             "u32::MAX ndim in .f16 must be rejected, not OOM-aborted"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Non-finite input guard — mutation-sensitive tests (Finding 1, PR #452)
+    //
+    // IEEE-754: `NaN > x` and `NaN < x` are always false, so a plain
+    // `f32::max` / `f32::min` fold over a block that contains NaN silently
+    // ignores the NaN element and computes scale from the finite elements
+    // only. The NaN then quantizes to nibble 0 via a saturating cast, so
+    // no panic occurs and the caller receives a plausible-looking Q4Block
+    // with a silently wrong entry. The guard at the top of
+    // `quantize_block_with_mode` must catch this before the fold.
+    //
+    // Mutation sensitivity: removing the `if !v.is_finite()` guard converts
+    // both `Err` returns below to `Ok`, turning `result.is_err()` → false
+    // and failing the assertion.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_quantize_block_rejects_nan_input() {
+        // Block with one NaN among otherwise-valid weights must return Err.
+        let mut vals = vec![1.0f32; 32];
+        vals[7] = f32::NAN;
+        let result = quantize_row_q4_0(&vals);
+        assert!(
+            result.is_err(),
+            "NaN in weight block must be rejected with InvalidInput"
+        );
+    }
+
+    #[test]
+    fn test_quantize_block_rejects_inf_input() {
+        // Block with one +inf element must return Err; the guard covers both
+        // +inf and -inf via `is_finite()` (which returns false for any
+        // non-finite value, including NaN, +inf, and -inf).
+        let mut vals = vec![1.0f32; 32];
+        vals[15] = f32::INFINITY;
+        let result = quantize_row_q4_0(&vals);
+        assert!(
+            result.is_err(),
+            "+inf in weight block must be rejected with InvalidInput"
         );
     }
 }

--- a/crates/inference/src/weights/q8_weights.rs
+++ b/crates/inference/src/weights/q8_weights.rs
@@ -50,12 +50,19 @@ pub struct Q8Matrix {
 /// - `scale[i] = max(abs(row)) / 127.0`
 /// - if the row is all zeros, `scale[i] = 1.0`
 /// - `q[i, j] = clamp(round(w[i, j] / scale[i]), -128, 127)`
-pub fn quantize_matrix(w: &[f32], rows: usize, cols: usize) -> Q8Matrix {
-    assert_eq!(
-        w.len(),
-        rows * cols,
-        "matrix length does not match rows * cols"
-    );
+///
+/// Returns `Err(InvalidInput)` if any source row contains `NaN` or `±inf`.
+/// A non-finite source value produces a non-finite scale (`inf / 127 = inf`),
+/// which then turns every matmul output for that output channel into `NaN`
+/// (`0 * inf`). Rejecting here attributes the error to the bad source weight
+/// rather than to a downstream numerical guard.
+pub fn quantize_matrix(w: &[f32], rows: usize, cols: usize) -> Result<Q8Matrix, InferenceError> {
+    if w.len() != rows * cols {
+        return Err(InferenceError::InvalidInput(format!(
+            "matrix length {} does not match rows({rows}) * cols({cols})",
+            w.len()
+        )));
+    }
 
     let mut data = Vec::with_capacity(w.len());
     let mut scales = Vec::with_capacity(rows);
@@ -74,6 +81,16 @@ pub fn quantize_matrix(w: &[f32], rows: usize, cols: usize) -> Q8Matrix {
         }
 
         let scale = if max_abs == 0.0 { 1.0 } else { max_abs / 127.0 };
+
+        // A NaN or ±inf in the source row yields a non-finite scale.
+        // Reject here so downstream matmuls never receive a non-finite scale.
+        if !scale.is_finite() {
+            return Err(InferenceError::InvalidInput(format!(
+                "Q8 weight row {row_idx} has non-finite scale ({scale}); \
+                 source row contains NaN or ±inf"
+            )));
+        }
+
         scales.push(scale);
 
         for &v in row {
@@ -82,12 +99,12 @@ pub fn quantize_matrix(w: &[f32], rows: usize, cols: usize) -> Q8Matrix {
         }
     }
 
-    Q8Matrix {
+    Ok(Q8Matrix {
         data,
         scales,
         rows,
         cols,
-    }
+    })
 }
 
 /// **Unstable**: quantized matmul_bt kernel; tile size and dispatch strategy may change.
@@ -297,7 +314,7 @@ pub(crate) fn quantize_model_weights(
                     Q8AttentionWeights::Linear(quantize_gdn_weights(gdn)?)
                 }
                 AttentionWeights::Full(full) => {
-                    Q8AttentionWeights::Full(quantize_full_attn_weights(full, cfg))
+                    Q8AttentionWeights::Full(quantize_full_attn_weights(full, cfg)?)
                 }
             };
             let q8_common = quantize_common_weights(common)?;
@@ -361,18 +378,24 @@ pub fn quantize_gdn_weights(
         )));
     }
 
+    let in_proj_qkv = quantize_matrix(&w.in_proj_qkv, w.in_proj_qkv_rows, w.in_proj_qkv_cols)?;
+    let in_proj_z = quantize_matrix(&w.in_proj_z, w.in_proj_z_rows, w.in_proj_z_cols)?;
+    let in_proj_b = quantize_matrix(&w.in_proj_b, w.in_proj_b_rows, w.in_proj_b_cols)?;
+    let in_proj_a = quantize_matrix(&w.in_proj_a, w.in_proj_a_rows, w.in_proj_a_cols)?;
+    let out_proj = quantize_matrix(&w.out_proj, w.out_proj_rows, w.out_proj_cols)?;
+
     Ok(Q8GatedDeltaNetWeights {
-        in_proj_qkv: quantize_matrix(&w.in_proj_qkv, w.in_proj_qkv_rows, w.in_proj_qkv_cols),
-        in_proj_z: quantize_matrix(&w.in_proj_z, w.in_proj_z_rows, w.in_proj_z_cols),
-        in_proj_b: quantize_matrix(&w.in_proj_b, w.in_proj_b_rows, w.in_proj_b_cols),
-        in_proj_a: quantize_matrix(&w.in_proj_a, w.in_proj_a_rows, w.in_proj_a_cols),
+        in_proj_qkv,
+        in_proj_z,
+        in_proj_b,
+        in_proj_a,
         a_log: w.a_log.clone(),
         dt_bias: w.dt_bias.clone(),
         conv1d_weight: w.conv1d_weight.clone(),
         conv_dim: w.conv_dim,
         kernel_size: w.kernel_size,
         norm_weight: w.norm_weight.clone(),
-        out_proj: quantize_matrix(&w.out_proj, w.out_proj_rows, w.out_proj_cols),
+        out_proj,
     })
 }
 
@@ -380,21 +403,28 @@ pub fn quantize_gdn_weights(
 ///
 /// The original full-attention weight struct does not carry explicit row/column metadata,
 /// so the matrix shapes are inferred from the config's attention topology.
+///
+/// Returns `Err(InvalidInput)` if any weight matrix contains `NaN` or `±inf` values.
 pub(crate) fn quantize_full_attn_weights(
     w: &FullAttentionLayerWeights,
     cfg: &Qwen35Config,
-) -> Q8FullAttentionLayerWeights {
+) -> Result<Q8FullAttentionLayerWeights, InferenceError> {
     let ((q_rows, hidden), (kv_rows, _), (_, _), (o_rows, o_cols)) =
         infer_full_attention_shapes(w, cfg);
 
-    Q8FullAttentionLayerWeights {
-        q_proj: quantize_matrix(&w.q_proj, q_rows, hidden),
-        k_proj: quantize_matrix(&w.k_proj, kv_rows, hidden),
-        v_proj: quantize_matrix(&w.v_proj, kv_rows, hidden),
-        o_proj: quantize_matrix(&w.o_proj, o_rows, o_cols),
+    let q_proj = quantize_matrix(&w.q_proj, q_rows, hidden)?;
+    let k_proj = quantize_matrix(&w.k_proj, kv_rows, hidden)?;
+    let v_proj = quantize_matrix(&w.v_proj, kv_rows, hidden)?;
+    let o_proj = quantize_matrix(&w.o_proj, o_rows, o_cols)?;
+
+    Ok(Q8FullAttentionLayerWeights {
+        q_proj,
+        k_proj,
+        v_proj,
+        o_proj,
         q_norm: w.q_norm.clone(),
         k_norm: w.k_norm.clone(),
-    }
+    })
 }
 
 /// Quantize the common per-layer MLP weights into their Q8 representation (dense only).
@@ -412,12 +442,16 @@ pub(crate) fn quantize_common_weights(
     let hidden = w.input_layernorm.len();
     let ((gate_rows, _), (up_rows, _), (down_rows, down_cols)) = infer_dense_shapes(dense, hidden);
 
+    let gate_proj = quantize_matrix(&dense.gate_proj, gate_rows, hidden)?;
+    let up_proj = quantize_matrix(&dense.up_proj, up_rows, hidden)?;
+    let down_proj = quantize_matrix(&dense.down_proj, down_rows, down_cols)?;
+
     Ok(Q8CommonLayerWeights {
         input_layernorm: w.input_layernorm.clone(),
         post_attention_layernorm: w.post_attention_layernorm.clone(),
-        gate_proj: quantize_matrix(&dense.gate_proj, gate_rows, hidden),
-        up_proj: quantize_matrix(&dense.up_proj, up_rows, hidden),
-        down_proj: quantize_matrix(&dense.down_proj, down_rows, down_cols),
+        gate_proj,
+        up_proj,
+        down_proj,
     })
 }
 
@@ -602,7 +636,7 @@ mod tests {
             0.0, 0.0, 0.0, 1.0, // row 3
         ];
 
-        let q = quantize_matrix(&w, rows, cols);
+        let q = quantize_matrix(&w, rows, cols).unwrap();
         let dq = dequantize_matrix(&q);
 
         assert_eq!(q.rows, rows);
@@ -683,7 +717,7 @@ mod tests {
             w.push(uniform_signed(&mut seed) * 0.03);
         }
 
-        let q = quantize_matrix(&w, rows, cols);
+        let q = quantize_matrix(&w, rows, cols).unwrap();
         let dq = dequantize_matrix(&q);
 
         let mut max_abs_err = 0.0f32;
@@ -724,7 +758,7 @@ mod tests {
             }
         }
 
-        let b_q = quantize_matrix(&b, n, k);
+        let b_q = quantize_matrix(&b, n, k).unwrap();
 
         let mut c_f32 = vec![0.0f32; m * n];
         let mut c_q8 = vec![0.0f32; m * n];
@@ -762,7 +796,7 @@ mod tests {
             -2.54, 0.0, 1.28, // row 1, scale = 0.02, q = [-127, 0, 64]
         ];
 
-        let q = quantize_matrix(&b, 2, 3);
+        let q = quantize_matrix(&b, 2, 3).unwrap();
         assert!(approx_eq(q.scales[0], 0.01, 1e-8));
         assert!(approx_eq(q.scales[1], 0.02, 1e-8));
         assert_eq!(&q.data[0..3], &[127i8, -64i8, 0i8]);
@@ -786,7 +820,7 @@ mod tests {
             0.0, 0.0, 0.0, 0.0, // zero row
             0.5, -0.5, 0.25, -0.25,
         ];
-        let q = quantize_matrix(&b, 2, 4);
+        let q = quantize_matrix(&b, 2, 4).unwrap();
 
         assert!(approx_eq(q.scales[0], 1.0, 1e-8));
         assert_eq!(&q.data[0..4], &[0i8, 0i8, 0i8, 0i8]);
@@ -805,7 +839,7 @@ mod tests {
             1.27, -0.63, 0.0, // max abs = 1.27 -> scale = 0.01
             -2.54, 2.0, 0.0, // max abs = 2.54 -> scale = 0.02
         ];
-        let q = quantize_matrix(&w, 2, 3);
+        let q = quantize_matrix(&w, 2, 3).unwrap();
 
         assert!(approx_eq(q.scales[0], 0.01, 1e-8));
         assert!(approx_eq(q.scales[1], 0.02, 1e-8));
@@ -838,7 +872,7 @@ mod tests {
             }
         }
 
-        let q = quantize_matrix(&w, rows, cols);
+        let q = quantize_matrix(&w, rows, cols).unwrap();
 
         assert_eq!(q.rows, rows);
         assert_eq!(q.cols, cols);
@@ -908,6 +942,61 @@ mod tests {
             matches!(result, Err(InferenceError::UnsupportedModel(_))),
             "expected Err(UnsupportedModel), got: {result:?}"
         );
+    }
+
+    /// `quantize_matrix` must reject a weight matrix whose source row contains
+    /// `+inf` or `NaN`. Such a row produces `scale = inf / 127 = inf`, which then
+    /// poisons every matmul output for that channel via `0 * inf = NaN`.
+    ///
+    /// Mutation check: removing the `!scale.is_finite()` guard in `quantize_matrix`
+    /// causes this call to return `Ok` instead of `Err`, failing `expect_err`.
+    #[test]
+    fn test_quantize_matrix_rejects_nonfinite_source_row() {
+        // Row 0 is finite; row 1 contains +inf → scale for row 1 = inf / 127 = inf.
+        let w = vec![
+            1.0,
+            2.0,
+            3.0, // row 0: finite, scale ≈ 3/127
+            1.0,
+            f32::INFINITY,
+            0.0, // row 1: +inf → scale = inf
+        ];
+        match quantize_matrix(&w, 2, 3) {
+            Err(InferenceError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("non-finite"),
+                    "error must describe the non-finite scale; got: {msg}"
+                );
+                assert!(
+                    msg.contains("1"),
+                    "error must identify the offending row index; got: {msg}"
+                );
+            }
+            Err(e) => panic!("expected InvalidInput for non-finite scale, got: {e}"),
+            Ok(_) => panic!("expected Err for non-finite source row, got Ok"),
+        }
+    }
+
+    /// `quantize_gdn_weights` propagates the non-finite-scale error from
+    /// `quantize_matrix`. A single `+inf` value in `in_proj_qkv` is enough.
+    ///
+    /// Mutation check: removing the `!scale.is_finite()` guard in `quantize_matrix`
+    /// causes this to return `Ok`, failing `expect_err`.
+    #[test]
+    fn test_quantize_gdn_weights_rejects_nonfinite_scale() {
+        let mut w = valid_gdn_weights(3, 8);
+        // row 0 of in_proj_qkv gets max_abs = +inf → scale = +inf / 127 = +inf
+        w.in_proj_qkv[0] = f32::INFINITY;
+        match quantize_gdn_weights(&w) {
+            Err(InferenceError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("non-finite"),
+                    "error must describe the non-finite scale; got: {msg}"
+                );
+            }
+            Err(e) => panic!("expected InvalidInput for non-finite scale, got: {e}"),
+            Ok(_) => panic!("expected Err for non-finite source weight, got Ok"),
+        }
     }
 
     #[test]

--- a/crates/inference/src/weights/q8_weights.rs
+++ b/crates/inference/src/weights/q8_weights.rs
@@ -74,6 +74,17 @@ pub fn quantize_matrix(w: &[f32], rows: usize, cols: usize) -> Result<Q8Matrix, 
 
         let mut max_abs = 0.0f32;
         for &v in row {
+            // IEEE 754: `NaN > x` is FALSE for any x, so a NaN value would
+            // silently leave max_abs unchanged. The scale then stays finite,
+            // and the NaN element is quantized to 0 via Rust's saturating
+            // f32-as-i8 cast — wrong data, no error. Reject the row here so
+            // the error points at the source weight, not a downstream matmul.
+            if !v.is_finite() {
+                return Err(InferenceError::InvalidInput(format!(
+                    "Q8 weight row {row_idx} contains a non-finite value ({v}); \
+                     source weights must be finite"
+                )));
+            }
             let abs_v = v.abs();
             if abs_v > max_abs {
                 max_abs = abs_v;
@@ -82,8 +93,8 @@ pub fn quantize_matrix(w: &[f32], rows: usize, cols: usize) -> Result<Q8Matrix, 
 
         let scale = if max_abs == 0.0 { 1.0 } else { max_abs / 127.0 };
 
-        // A NaN or ±inf in the source row yields a non-finite scale.
-        // Reject here so downstream matmuls never receive a non-finite scale.
+        // Defensive guard: the loop above already rejects NaN/±inf inputs,
+        // so a non-finite scale here would indicate an internal logic error.
         if !scale.is_finite() {
             return Err(InferenceError::InvalidInput(format!(
                 "Q8 weight row {row_idx} has non-finite scale ({scale}); \
@@ -974,6 +985,45 @@ mod tests {
             }
             Err(e) => panic!("expected InvalidInput for non-finite scale, got: {e}"),
             Ok(_) => panic!("expected Err for non-finite source row, got Ok"),
+        }
+    }
+
+    /// `quantize_matrix` must reject a weight matrix that contains `NaN`.
+    ///
+    /// Unlike `±inf`, NaN does NOT propagate through the `> max_abs` comparison
+    /// in IEEE 754 — `NaN > max_abs` evaluates to `false` — so a NaN value
+    /// never updates `max_abs`.  The scale then stays finite and the NaN element
+    /// is silently quantized to 0 via Rust's saturating `f32 as i8` cast.
+    ///
+    /// Mutation check: removing the `!v.is_finite()` loop guard inside
+    /// `quantize_matrix` makes this test return `Ok` (NaN quietly becomes 0)
+    /// instead of `Err`, failing the `expect_err`-style match.
+    #[test]
+    fn test_quantize_matrix_rejects_nan_input() {
+        // Row 0 is finite; row 1 contains NaN in lane 1.
+        // Without the loop guard the NaN never updates max_abs, the scale is
+        // finite, and the result is Ok (NaN → 0).  With the guard it is Err.
+        let w = vec![
+            1.0,
+            2.0,
+            3.0, // row 0: finite
+            1.0,
+            f32::NAN,
+            0.0, // row 1: NaN lane
+        ];
+        match quantize_matrix(&w, 2, 3) {
+            Err(InferenceError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("non-finite"),
+                    "error must describe the non-finite value; got: {msg}"
+                );
+                assert!(
+                    msg.contains("1"),
+                    "error must identify the offending row index; got: {msg}"
+                );
+            }
+            Err(e) => panic!("expected InvalidInput for NaN input, got: {e}"),
+            Ok(_) => panic!("expected Err for NaN input, got Ok"),
         }
     }
 


### PR DESCRIPTION
## Summary

Hardens the Q8/Q4 quantization and `generate_q8` path. Closes three `generate_q8` semantic gaps, extends the non-finite-input guard across the full load-time weight-quantizer class, and adds decode-loop stop-token coverage to the sibling generate paths.

### Part 1 — `generate_q8` semantic gaps

**Gap 1 — `max_new_tokens == 0` emits one token instead of zero.** `generate_q8` ran prefill and sampled one token even when `max_new_tokens == 0` (the decode loop `for _ in 1..0` skips, but the prefill sample ran unconditionally first). Added the same early-return `Qwen35Model::generate` already has, after the empty-prompt check and before context preflight.

**Gap 2 — `stop_token_ids` ignored.** Both EOS checks used `next_id == cfg.eos_token_id`, silently ignoring `gen_cfg.stop_token_ids`. Replaced both sites with `should_stop_token(cfg, gen_cfg, next_id)` (checks `eos_token_id` and `stop_token_ids`), mirroring the non-Q8 path. Promoted the `should_stop_token` re-export from `#[cfg(test)]`-only to unconditional so the production Q8 path can use it.

**Gap 3 — non-finite Q8 scale accepted at quantize time.** `quantize_matrix` computed `scale = max_abs / 127.0` with no guard. A `NaN`/`±inf` source value yields `scale = inf`, turning every matmul output for that channel into `NaN` (`0 * inf`). Added a pre-fold `!v.is_finite()` rejection returning `Err(InvalidInput)`, changed `quantize_matrix` to `Result`, and propagated `?` through `quantize_gdn_weights`, `quantize_full_attn_weights`, `quantize_common_weights`, `quantize_model_weights`.

### Part 2 — non-finite guard across the full weight-quantizer class

Gap 3's guard is one of four load-time weight quantizers. Swept the class so a `NaN`/`±inf` source weight fails closed at quantize time in **all** of them, each rejecting before the abs-max / min-max scale fold:

- `weights/q4_weights.rs` — `quantize_block_with_mode`, cascading `Result` through every public entry point (`quantize_block`, `quantize_row_q4_0`, `quantize_tensor_q4_0`, `quantize_bf16_to_q4`, `quantize_f32_to_q4`, `quantize_f64_to_q4`, `quantize_f64_to_q4_mode`, `stream_quantize_shard`).
- `weights/q8_weights.rs` — `quantize_matrix` (Gap 3).
- `forward/neon.rs` — `pack_weights_q8` (NEON Q8 weight packer), cascading `Result` through `pack_gdn_weights` / `pack_full_attn_weights` / `pack_common_weights` / `quantize_model` in `neon_forward.rs`.
- `forward/metal_qwen35.rs` — `quantize_row_q8_0` (per-block check), propagated through `make_buffer_q8_0` / `make_buffer_q4_0` and their call sites in `new()`.

**Deliberately out of scope** (different classes, flagged as potential follow-ups): `forward/neon.rs::quantize_vec_q8` is a runtime *activation* quantizer (decode hot path; guarding it is a per-token scan with a perf cost), and `forward/bitnet_kernel.rs` is the separate BitNet 1.58-bit architecture, not the Qwen Q8/Q4 path this issue covers.

### Part 3 — decode-loop stop-token coverage

Added mutation-sensitive tests asserting the **decode-loop** `should_stop_token` site (not the post-prefill early-return) honors `stop_token_ids`, in `batch_prefill.rs`, `cpu_f16.rs`, and `neon_forward.rs`. Each forces the stop token on the second generated token via a deterministic greedy construction, guaranteeing at least one decode iteration past prefill.

## Test plan

- `cargo fmt -p lattice-inference --check` — clean
- `cargo clippy -p lattice-inference --all-targets -- -D warnings` — clean
- `cargo clippy -p lattice-inference --all-targets --features metal-gpu -- -D warnings` — clean
- `cargo test -p lattice-inference` — passes (lib, bin, integration, doctests)
- Mutation-sensitive regression tests (revert-fails / restore-passes via Edit-revert, not `git checkout`):
  - Gap 1: `test_generate_q8_max_new_tokens_zero_returns_empty`
  - Gap 2: `test_generate_q8_honors_stop_token_ids`
  - Gap 3 + class: `test_quantize_matrix_rejects_nonfinite_source_row`, `test_quantize_gdn_weights_rejects_nonfinite_scale`, `pack_weights_q8_rejects_nan`, `pack_weights_q8_rejects_inf`
  - Part 3: decode-loop stop-token tests in `batch_prefill.rs` / `cpu_f16.rs` / `neon_forward.rs`

## Bench

bench-compare: no change expected. Every guard rejects only non-finite quantizer input; the default quantization and decode path is byte-identical (the `is_finite` check is one comparison per element on the one-time load-time quantization, not the decode hot path).

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)
