### PR TITLE
feat(tune): add online router-refit from preference feedback (update_router)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
         run: cargo test -p lattice-tune --features safetensors,inference-hook,serde --no-run
       - name: tune — train-backward (compile tests)
         run: cargo test -p lattice-tune --features train-backward --no-run
+      # The `mixture` feature gates the experimental online router-refit module
+      # (crates/tune/src/lora/router_update.rs) behind lattice-fann/online-router.
+      # It is off by default, so the required `ci` job never compiles or RUNS its
+      # fail-closed validation tests (empty-feedback, wrong context-dim, replay
+      # buffer bounds). Build AND run them here so the feature cannot rot silently.
+      - name: tune — mixture (online router-refit, build + run tests)
+        run: cargo test -p lattice-tune --features mixture --lib
       - name: inference — f16 + train-backward
         run: cargo build -p lattice-inference --features f16,train-backward
       # wgpu-gpu is excluded from default builds and was silently broken under

--- a/crates/fann/src/network/serialization.rs
+++ b/crates/fann/src/network/serialization.rs
@@ -3,7 +3,7 @@
 //! Provides binary serialization for efficient network storage and loading.
 
 use crate::activation::Activation;
-use crate::error::{FannError, FannResult};
+use crate::error::{FannError, FannResult, validate_allocation_size};
 use crate::layer::Layer;
 use crate::network::Network;
 
@@ -160,6 +160,21 @@ impl Network {
             return Err(FannError::EmptyNetwork);
         }
 
+        // Bounds-before-allocation: every layer header needs at minimum 9 bytes
+        // (num_inputs u32=4 + num_outputs u32=4 + activation u8=1). A hostile
+        // num_layers field cannot legitimately exceed what the remaining bytes
+        // can encode, so we bound it before reserving any capacity.
+        let remaining_for_layers = bytes.len().saturating_sub(pos);
+        let max_plausible_layers = remaining_for_layers / 9;
+        if num_layers > max_plausible_layers {
+            return Err(FannError::InvalidBuilder(format!(
+                "num_layers {num_layers} exceeds what the remaining {remaining_for_layers} \
+                 bytes can encode (max plausible with 9 bytes/layer: {max_plausible_layers})"
+            )));
+        }
+        // Secondary allocation-size guard for defence in depth.
+        validate_allocation_size(num_layers)?;
+
         let mut layers = Vec::with_capacity(num_layers);
 
         for layer_idx in 0..num_layers {
@@ -196,9 +211,20 @@ impl Network {
                 }
             };
 
-            // Read weights
-            let weight_count = num_inputs * num_outputs;
-            let weight_bytes = read_bytes(&mut pos, weight_count * 4)?;
+            // Read weights; use checked arithmetic so hostile dimension fields
+            // produce a clean Err rather than an allocation-abort.
+            let weight_count = num_inputs.checked_mul(num_outputs).ok_or_else(|| {
+                FannError::InvalidBuilder(format!(
+                    "layer {layer_idx}: num_inputs ({num_inputs}) * num_outputs \
+                     ({num_outputs}) overflows"
+                ))
+            })?;
+            let weight_byte_count = weight_count.checked_mul(4).ok_or_else(|| {
+                FannError::InvalidBuilder(format!(
+                    "layer {layer_idx}: weight byte count overflows ({weight_count} * 4)"
+                ))
+            })?;
+            let weight_bytes = read_bytes(&mut pos, weight_byte_count)?;
             let weights: Vec<f32> = weight_bytes
                 .chunks_exact(4)
                 .map(|chunk| {
@@ -225,6 +251,16 @@ impl Network {
 
             let layer = Layer::with_weights(num_inputs, num_outputs, weights, biases, activation)?;
             layers.push(layer);
+        }
+
+        // Reject trailing bytes — the binary format is exact; to_bytes produces
+        // no padding or footer. Extra bytes indicate a malformed or incorrect blob.
+        if pos != bytes.len() {
+            return Err(FannError::InvalidBuilder(format!(
+                "trailing bytes after parsing: consumed {pos} of {} bytes; \
+                 the format requires an exact-length blob",
+                bytes.len()
+            )));
         }
 
         Network::new(layers)
@@ -335,5 +371,74 @@ mod tests {
         for (orig, rest) in original_output.iter().zip(restored_output.iter()) {
             assert!((orig - rest).abs() < 1e-6);
         }
+    }
+
+    // ── FIX 2: bounds-before-allocation + trailing-bytes tests ──────────────
+
+    /// A header with num_layers = 0xFFFFFFFF and a short buffer must return
+    /// Err(FannError::InvalidBuilder) without attempting any large allocation.
+    ///
+    /// Mutation that defeats this test: remove the remaining-bytes bounds check
+    /// before Vec::with_capacity(num_layers).
+    #[test]
+    fn from_bytes_large_num_layers_short_buffer_returns_err() {
+        // Only 12 bytes: magic + version + num_layers=0xFFFFFFFF.
+        // remaining_for_layers = 0, max_plausible = 0 < 0xFFFFFFFF → Err.
+        let mut bytes = b"FANN".to_vec();
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes());
+        let result = Network::from_bytes(&bytes);
+        assert!(
+            matches!(result, Err(FannError::InvalidBuilder(_))),
+            "large num_layers with short buffer must return InvalidBuilder, got {result:?}"
+        );
+    }
+
+    /// A valid serialized blob with one extra trailing byte must return
+    /// Err(FannError::InvalidBuilder).
+    ///
+    /// Mutation that defeats this test: remove the trailing-bytes check after
+    /// the layer loop.
+    #[test]
+    fn from_bytes_trailing_bytes_returns_err() {
+        let net = NetworkBuilder::new()
+            .input(2)
+            .hidden(4, Activation::ReLU)
+            .output(2, Activation::Linear)
+            .build()
+            .unwrap();
+        let mut bytes = net.to_bytes();
+        bytes.push(0xAB); // one trailing byte
+        let result = Network::from_bytes(&bytes);
+        assert!(
+            matches!(result, Err(FannError::InvalidBuilder(_))),
+            "trailing byte must return InvalidBuilder, got {result:?}"
+        );
+    }
+
+    /// Layer dimensions where weight_count * 4 overflows usize must return
+    /// Err(FannError::InvalidBuilder) without allocating.
+    ///
+    /// On 64-bit targets, u32::MAX * u32::MAX ≈ 1.844e19 fits in usize, but
+    /// the result * 4 ≈ 7.4e19 > u64::MAX. With num_inputs=3_000_000_000 and
+    /// num_outputs=2_000_000_000: weight_count=6e18 (fits), weight_count*4=2.4e19
+    /// overflows → checked_mul(4) returns None → Err before any read_bytes call.
+    ///
+    /// Mutation that defeats this test: replace checked_mul(4) with weight_count * 4.
+    #[test]
+    fn from_bytes_weight_byte_count_overflow_returns_err() {
+        let mut bytes = b"FANN".to_vec();
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // version=1
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // num_layers=1
+        bytes.extend_from_slice(&3_000_000_000_u32.to_le_bytes()); // num_inputs
+        bytes.extend_from_slice(&2_000_000_000_u32.to_le_bytes()); // num_outputs
+        bytes.push(0); // activation=Linear
+        // 21 bytes total; the layer bounds check passes (remaining=9, max=1 layer).
+        // weight_count = 6e18 fits; weight_count*4 = 2.4e19 overflows u64 → Err.
+        let result = Network::from_bytes(&bytes);
+        assert!(
+            matches!(result, Err(FannError::InvalidBuilder(_))),
+            "weight byte count overflow must return InvalidBuilder, got {result:?}"
+        );
     }
 }

--- a/crates/fann/src/network/serialization.rs
+++ b/crates/fann/src/network/serialization.rs
@@ -3,7 +3,7 @@
 //! Provides binary serialization for efficient network storage and loading.
 
 use crate::activation::Activation;
-use crate::error::{FannError, FannResult, validate_allocation_size};
+use crate::error::{FannError, FannResult, validate_allocation_size, validate_layer_dimensions};
 use crate::layer::Layer;
 use crate::network::Network;
 
@@ -192,6 +192,14 @@ impl Network {
                 .try_into()
                 .map_err(|_| FannError::InvalidBuilder("Failed to read num_outputs".into()))?;
             let num_outputs = u32::from_le_bytes(num_outputs_bytes) as usize;
+
+            // Bounds-before-allocation: enforce the per-layer element cap on the
+            // hostile dimension fields BEFORE reading and collecting the weight and
+            // bias payloads. `Layer::with_weights` re-validates as defence in depth,
+            // but checking here keeps a large declared shape from driving a
+            // multi-hundred-MB `Vec<f32>` allocation before the cap is applied.
+            // num_inputs > 0 (enforced here) also bounds num_outputs for biases.
+            validate_layer_dimensions(num_inputs, num_outputs)?;
 
             // Read activation type
             let activation_type = read_bytes(&mut pos, 1)?[0];
@@ -426,17 +434,22 @@ mod tests {
         );
     }
 
-    /// Layer dimensions where weight_count * 4 overflows usize must return
-    /// Err(FannError::InvalidBuilder) without allocating.
+    /// A header declaring a huge weight count (num_inputs * num_outputs far
+    /// above MAX_ALLOWED_ELEMENTS) must be rejected by the early per-layer size
+    /// cap with Err(FannError::ShapeTooLarge), before any byte-count arithmetic,
+    /// read, or allocation.
     ///
-    /// On 64-bit targets, u32::MAX * u32::MAX ≈ 1.844e19 fits in usize, but
-    /// the result * 4 ≈ 7.4e19 > u64::MAX. With num_inputs=3_000_000_000 and
-    /// num_outputs=2_000_000_000: weight_count=6e18 (fits), weight_count*4=2.4e19
-    /// overflows → checked_mul(4) returns None → Err before any read_bytes call.
+    /// With num_inputs=3_000_000_000 and num_outputs=2_000_000_000 the element
+    /// count is 6e18 — a valid usize, but ~6e10x the 100M cap. validate_layer_dimensions
+    /// (run right after the dimensions are read) rejects it via validate_allocation_size.
+    /// The downstream weight_count.checked_mul(4) guard remains as defence in depth
+    /// but is unreachable for these dimensions because the cap fires first.
     ///
-    /// Mutation that defeats this test: replace checked_mul(4) with weight_count * 4.
+    /// Mutation that defeats this test: remove the early validate_layer_dimensions
+    /// call — the parser then reaches weight_count.checked_mul(4), which overflows
+    /// (6e18 * 4 = 2.4e19 > usize::MAX) and returns InvalidBuilder instead.
     #[test]
-    fn from_bytes_weight_byte_count_overflow_returns_err() {
+    fn from_bytes_huge_weight_dims_rejected_by_size_cap() {
         let mut bytes = b"FANN".to_vec();
         bytes.extend_from_slice(&1u32.to_le_bytes()); // version=1
         bytes.extend_from_slice(&1u32.to_le_bytes()); // num_layers=1
@@ -444,40 +457,61 @@ mod tests {
         bytes.extend_from_slice(&2_000_000_000_u32.to_le_bytes()); // num_outputs
         bytes.push(0); // activation=Linear
         // 21 bytes total; the layer bounds check passes (remaining=9, max=1 layer).
-        // weight_count = 6e18 fits; weight_count*4 = 2.4e19 overflows u64 → Err.
         let result = Network::from_bytes(&bytes);
         assert!(
-            matches!(result, Err(FannError::InvalidBuilder(_))),
-            "weight byte count overflow must return InvalidBuilder, got {result:?}"
+            matches!(result, Err(FannError::ShapeTooLarge { .. })),
+            "huge weight dims must hit the size cap before allocation, got {result:?}"
         );
     }
 
-    /// A header whose weight byte count is a valid usize *near* usize::MAX (so
-    /// checked_mul(4) returns Some, not None) must still return Err, not panic:
-    /// read_bytes must reject it without computing `*pos + n`.
+    /// A header with near-usize::MAX-product dimensions must be rejected cleanly
+    /// (Err, no panic) by the early per-layer size cap. This pins that
+    /// validate_layer_dimensions itself does not overflow/panic on extreme
+    /// dimensions: its internal checked_mul handles the 2^62-1 product, and
+    /// validate_allocation_size then rejects it with ShapeTooLarge.
     ///
-    /// num_inputs = 2^31-1, num_outputs = 2^31+1 → weight_count = 2^62-1
-    /// (checked_mul succeeds); weight_byte_count = 2^64-4 = usize::MAX-3
-    /// (checked_mul(4) succeeds). read_bytes(pos=21, usize::MAX-3) overflows
-    /// `*pos + n` in the unguarded form; the checked-available form returns Err.
-    /// Companion to from_bytes_weight_byte_count_overflow_returns_err, which
-    /// covers checked_mul(4) == None.
+    /// num_inputs = 2^31-1, num_outputs = 2^31+1 → product = 2^62-1 (a valid
+    /// usize, ~4.6e10x the 100M cap). The cap fires before the weight byte-count
+    /// arithmetic and before read_bytes is asked for the (usize::MAX-3) payload,
+    /// so the overflow-safe read_bytes guard remains as defence in depth here.
     ///
-    /// Mutation that defeats this test: revert read_bytes to `if *pos + n > bytes.len()`.
+    /// Mutation that defeats this test: remove the early validate_layer_dimensions
+    /// call — the parser then reaches read_bytes(pos=21, usize::MAX-3) and returns
+    /// a truncation InvalidBuilder instead of ShapeTooLarge.
     #[test]
-    fn from_bytes_read_bytes_pos_plus_n_overflow_returns_err() {
+    fn from_bytes_near_usize_max_dims_rejected_by_size_cap() {
         let mut bytes = b"FANN".to_vec();
         bytes.extend_from_slice(&1u32.to_le_bytes()); // version=1
         bytes.extend_from_slice(&1u32.to_le_bytes()); // num_layers=1
         bytes.extend_from_slice(&2_147_483_647_u32.to_le_bytes()); // num_inputs = 2^31-1
         bytes.extend_from_slice(&2_147_483_649_u32.to_le_bytes()); // num_outputs = 2^31+1
         bytes.push(0); // activation=Linear
-        // 21 bytes; weight_byte_count = usize::MAX-3 fits, so read_bytes is asked
-        // for usize::MAX-3 bytes at pos=21 — `*pos + n` would overflow unguarded.
         let result = Network::from_bytes(&bytes);
         assert!(
-            matches!(result, Err(FannError::InvalidBuilder(_))),
-            "near-usize::MAX weight byte count must return InvalidBuilder, got {result:?}"
+            matches!(result, Err(FannError::ShapeTooLarge { .. })),
+            "near-usize::MAX dims must hit the size cap before allocation, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn from_bytes_oversized_layer_dims_rejected_before_allocation() {
+        // A hostile header declaring more than MAX_ALLOWED_ELEMENTS weights must
+        // be rejected by the size cap BEFORE from_bytes reads or collects the
+        // weight payload. This buffer carries no weight bytes at all: if the cap
+        // were enforced only inside Layer::with_weights (after collection), the
+        // parser would first attempt the oversized weight read and return a
+        // truncation InvalidBuilder. Reverting the early validate_layer_dimensions
+        // call makes this case return InvalidBuilder instead of ShapeTooLarge.
+        let mut bytes = b"FANN".to_vec();
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // version=1
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // num_layers=1
+        bytes.extend_from_slice(&100_000_001_u32.to_le_bytes()); // num_inputs = MAX_ALLOWED_ELEMENTS + 1
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // num_outputs=1
+        bytes.push(0); // activation=Linear
+        let result = Network::from_bytes(&bytes);
+        assert!(
+            matches!(result, Err(FannError::ShapeTooLarge { .. })),
+            "oversized layer dims must hit the size cap before allocation, got {result:?}"
         );
     }
 }

--- a/crates/fann/src/network/serialization.rs
+++ b/crates/fann/src/network/serialization.rs
@@ -118,12 +118,16 @@ impl Network {
 
         // Helper to read bytes
         let read_bytes = |pos: &mut usize, n: usize| -> FannResult<&[u8]> {
-            if *pos + n > bytes.len() {
+            // Compute the remaining budget by subtraction, never `*pos + n`, so a
+            // hostile byte count near usize::MAX cannot overflow the bounds check
+            // itself. `*pos` is always <= bytes.len() (every read advances pos only
+            // after validating), so the subtraction is exact and `*pos + n` below
+            // is safe once `n <= available` is established.
+            let available = bytes.len().saturating_sub(*pos);
+            if n > available {
                 return Err(FannError::InvalidBuilder(format!(
-                    "Truncated data at offset {}: expected {} bytes, {} available",
+                    "Truncated data at offset {}: expected {n} bytes, {available} available",
                     *pos,
-                    n,
-                    bytes.len() - *pos
                 )));
             }
             let slice = &bytes[*pos..*pos + n];
@@ -236,8 +240,14 @@ impl Network {
                 })
                 .collect();
 
-            // Read biases
-            let bias_bytes = read_bytes(&mut pos, num_outputs * 4)?;
+            // Read biases; checked arithmetic for the same parser-boundary
+            // reason as the weight byte count above.
+            let bias_byte_count = num_outputs.checked_mul(4).ok_or_else(|| {
+                FannError::InvalidBuilder(format!(
+                    "layer {layer_idx}: bias byte count overflows ({num_outputs} * 4)"
+                ))
+            })?;
+            let bias_bytes = read_bytes(&mut pos, bias_byte_count)?;
             let biases: Vec<f32> = bias_bytes
                 .chunks_exact(4)
                 .map(|chunk| {
@@ -439,6 +449,35 @@ mod tests {
         assert!(
             matches!(result, Err(FannError::InvalidBuilder(_))),
             "weight byte count overflow must return InvalidBuilder, got {result:?}"
+        );
+    }
+
+    /// A header whose weight byte count is a valid usize *near* usize::MAX (so
+    /// checked_mul(4) returns Some, not None) must still return Err, not panic:
+    /// read_bytes must reject it without computing `*pos + n`.
+    ///
+    /// num_inputs = 2^31-1, num_outputs = 2^31+1 → weight_count = 2^62-1
+    /// (checked_mul succeeds); weight_byte_count = 2^64-4 = usize::MAX-3
+    /// (checked_mul(4) succeeds). read_bytes(pos=21, usize::MAX-3) overflows
+    /// `*pos + n` in the unguarded form; the checked-available form returns Err.
+    /// Companion to from_bytes_weight_byte_count_overflow_returns_err, which
+    /// covers checked_mul(4) == None.
+    ///
+    /// Mutation that defeats this test: revert read_bytes to `if *pos + n > bytes.len()`.
+    #[test]
+    fn from_bytes_read_bytes_pos_plus_n_overflow_returns_err() {
+        let mut bytes = b"FANN".to_vec();
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // version=1
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // num_layers=1
+        bytes.extend_from_slice(&2_147_483_647_u32.to_le_bytes()); // num_inputs = 2^31-1
+        bytes.extend_from_slice(&2_147_483_649_u32.to_le_bytes()); // num_outputs = 2^31+1
+        bytes.push(0); // activation=Linear
+        // 21 bytes; weight_byte_count = usize::MAX-3 fits, so read_bytes is asked
+        // for usize::MAX-3 bytes at pos=21 — `*pos + n` would overflow unguarded.
+        let result = Network::from_bytes(&bytes);
+        assert!(
+            matches!(result, Err(FannError::InvalidBuilder(_))),
+            "near-usize::MAX weight byte count must return InvalidBuilder, got {result:?}"
         );
     }
 }

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -24,6 +24,9 @@ inference-hook = ["dep:lattice-inference"]
 train-backward = ["dep:lattice-inference", "lattice-inference/train-backward", "lattice-inference/f16", "safetensors", "serde"]
 # SQLite-backed model registry storage
 sqlite = ["dep:rusqlite", "serde"]
+# Online adapter-selector refit from preference feedback (experimental, bench-gated).
+# Pulls in the lattice-fann training primitives (RLOO / EWC++) for gate updates.
+mixture = ["lattice-fann/online-router"]
 
 [dependencies]
 lattice-fann = { version = "0.4.2", path = "../fann" }

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -41,6 +41,8 @@ pub mod loader;
 pub mod manifest;
 pub mod online;
 pub mod optimizer;
+#[cfg(feature = "mixture")]
+pub mod router_update;
 #[cfg(feature = "safetensors")]
 mod safetensors;
 #[cfg(feature = "train-backward")]

--- a/crates/tune/src/lora/router_update.rs
+++ b/crates/tune/src/lora/router_update.rs
@@ -145,7 +145,8 @@ pub struct RouterUpdateConfig {
     /// Fraction of the replay buffer to include in each refit epoch.
     ///
     /// `0.0` disables replay; `1.0` includes all buffered events.
-    /// Clamped to `[0.0, 1.0]` at use time.
+    /// Must be finite and within `[0.0, 1.0]`; `update_router` rejects
+    /// values outside that range with `TuneError::Validation`.
     pub replay_mix_fraction: f32,
 }
 

--- a/crates/tune/src/lora/router_update.rs
+++ b/crates/tune/src/lora/router_update.rs
@@ -1,0 +1,829 @@
+//! Online adapter-selector refit from preference feedback signals.
+//!
+//! Consumes a batch of [`FeedbackEvent`]s, retunes the adapter-selection gate
+//! network with a single-sample policy-gradient update (RLOO / M=1), applies
+//! the EWC++ diagonal-Fisher null-space projection for anti-forgetting, and
+//! returns the updated gate as a self-contained FANN binary blob.
+//!
+//! This is the tune-side orchestration layer.  All gradient computation and
+//! Fisher accumulation live in the fann training primitives
+//! ([`RlooTrainer`], [`DiagonalFisher`]).  This module wires them with the
+//! replay buffer and persistence logic.
+//!
+//! # Polarity invariant
+//!
+//! The reward carried in each [`FeedbackEvent`] flows through a **single code
+//! path** to [`RlooTrainer::step`].  Positive reward raises the target
+//! adapter's routing probability; negative reward lowers it.  There is no
+//! separate branch for negative feedback — the sign is embedded in the
+//! gradient formula (`reward * (p - onehot(action))`).  See
+//! [`RlooTrainer::step`] for the derivation.
+//!
+//! # Feature gate
+//!
+//! This entire module is compiled only when the `mixture` feature is active.
+
+use std::collections::VecDeque;
+
+use lattice_fann::{
+    Network,
+    training::{RlooConfig, RlooTrainer},
+};
+
+use crate::error::{Result, TuneError};
+
+// Re-export so callers can import DiagonalFisher from this module without
+// a direct dependency on lattice-fann.
+pub use lattice_fann::training::DiagonalFisher;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Public types
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Polarity and strength of a preference signal from a completed request.
+///
+/// Explicit signals (thumbs / binary) carry full reward magnitude.
+/// Implicit signals (dwell time, follow-up rate) carry half magnitude.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum PreferenceSignal {
+    /// Explicit positive: the selected adapter produced a useful response.
+    Positive,
+    /// Explicit negative: the selected adapter was unhelpful or wrong.
+    Negative,
+    /// Implicit positive: weak evidence of a helpful response (e.g., long dwell).
+    ImplicitPositive,
+    /// Implicit negative: weak evidence of an unhelpful response (e.g., immediate
+    /// re-query).
+    ImplicitNegative,
+}
+
+impl PreferenceSignal {
+    /// Signed reward scalar forwarded to the policy-gradient step.
+    ///
+    /// Positive signals pull the target adapter's probability up; negative
+    /// signals push it down.  The fann RLOO trainer handles both polarities
+    /// through a single code path — do not special-case negative reward.
+    #[inline]
+    pub fn reward(&self) -> f32 {
+        match self {
+            Self::Positive => 1.0,
+            Self::ImplicitPositive => 0.5,
+            Self::ImplicitNegative => -0.5,
+            Self::Negative => -1.0,
+        }
+    }
+
+    /// Returns `true` for signals with positive reward (useful for replay
+    /// buffer filtering: only preferred adapters belong in replay storage).
+    #[inline]
+    pub fn is_positive(&self) -> bool {
+        matches!(self, Self::Positive | Self::ImplicitPositive)
+    }
+}
+
+/// A single recorded preference signal from a completed request.
+///
+/// Callers supply the pre-computed context vector that was passed to `route()`
+/// and the adapter index the feedback is about.  The `signal` field encodes
+/// polarity and strength; a single code path handles both positive and negative
+/// cases (see [`PreferenceSignal::reward`]).
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FeedbackEvent {
+    /// Embedding of the request context; must match the gate's input dimension.
+    ///
+    /// Dimension is determined at gate construction time; validated at entry
+    /// to [`update_router`] against `Network::num_inputs()`.
+    pub context_vector: Vec<f32>,
+    /// Index into the adapter pool that this feedback is about.
+    ///
+    /// For positive signals: the adapter that was correctly selected.
+    /// For negative signals: the adapter that was incorrectly selected and
+    /// should be pushed down.  Must be within `[0, gate.num_outputs())`.
+    pub preferred_adapter_idx: usize,
+    /// Opaque adapter identifier (mirrors `AdapterId = String` in the router).
+    ///
+    /// Stored for audit / tracing only; not used in gradient computation.
+    pub adapter_id: String,
+    /// Polarity and strength of the preference signal.
+    pub signal: PreferenceSignal,
+}
+
+/// Hyperparameters for one `update_router` refit call.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RouterUpdateConfig {
+    /// Learning rate applied inside [`RlooTrainer::step`].
+    pub learning_rate: f32,
+    /// Load-balancing auxiliary loss coefficient (prevents routing collapse).
+    /// Set to `0.0` to disable.
+    pub aux_loss_coeff: f32,
+    /// Router z-loss coefficient (discourages logit explosion).
+    /// Set to `0.0` to disable.
+    pub z_loss_coeff: f32,
+    /// Training epochs over the combined feedback + replay batch per call.
+    pub epochs: usize,
+    /// EWC++ Fisher regularisation strength.
+    ///
+    /// Reserved for the `penalty_gradient` variant of EWC regularisation.
+    /// The current implementation uses `DiagonalFisher::project_delta`
+    /// (null-space projection), which does not use this coefficient.
+    /// Set to `0.0` to communicate intent of no regularisation; values
+    /// above `0.0` will be used if the implementation switches to the
+    /// penalty-gradient path.
+    pub ewc_lambda: f32,
+    /// Fraction of the replay buffer to include in each refit epoch.
+    ///
+    /// `0.0` disables replay; `1.0` includes all buffered events.
+    /// Clamped to `[0.0, 1.0]` at use time.
+    pub replay_mix_fraction: f32,
+}
+
+impl Default for RouterUpdateConfig {
+    fn default() -> Self {
+        Self {
+            learning_rate: 1e-3,
+            aux_loss_coeff: 0.01,
+            z_loss_coeff: 0.001,
+            epochs: 5,
+            ewc_lambda: 0.1,
+            replay_mix_fraction: 0.5,
+        }
+    }
+}
+
+/// Result of one `update_router` call: the retrained gate ready to replace the
+/// prior one.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RouterDelta {
+    /// Serialised updated gate in FANN binary format.
+    ///
+    /// This is a complete network blob produced by `Network::to_bytes()`,
+    /// not a parameter diff.  Load with `Network::from_bytes()` or pass as
+    /// the `gate_bytes` argument to the next `update_router` call.
+    pub network_bytes: Vec<u8>,
+    /// Number of feedback events consumed in this refit.
+    pub events_consumed: usize,
+    /// Gate top-1 accuracy on the replay buffer after refit.
+    ///
+    /// Fraction of buffered entries where the gate's argmax equals the stored
+    /// preferred adapter index.  `None` when the replay buffer is empty.
+    pub replay_accuracy: Option<f32>,
+}
+
+/// Bounded FIFO experience-replay buffer of preference events.
+///
+/// Holds a history of `(context_vector, preferred_adapter_idx)` pairs —
+/// always positive-polarity, representing adapters that produced useful
+/// responses.  Capped at `max_size` entries; oldest events are evicted first.
+///
+/// # Replay polarity
+///
+/// Only events with a positive [`PreferenceSignal`] enter the buffer
+/// (see [`update_router`]).  During refit, buffered entries are replayed
+/// with reward `+1.0`.  Negative events carry no information about which
+/// adapter *should* be selected, so they are not stored.
+#[derive(Clone, Debug, Default)]
+pub struct ReplayBuffer {
+    inner: VecDeque<ReplayEntry>,
+    max_size: usize,
+}
+
+impl ReplayBuffer {
+    /// Create an empty replay buffer with the given capacity.
+    ///
+    /// `max_size` is the maximum number of entries retained; once full, the
+    /// oldest entry is evicted on each new push.  A `max_size` of `0` accepts
+    /// no entries.
+    pub fn new(max_size: usize) -> Self {
+        Self {
+            inner: VecDeque::new(),
+            max_size,
+        }
+    }
+
+    /// Current number of stored entries.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns `true` when the buffer holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Add a new entry, evicting the oldest if the buffer is at capacity.
+    ///
+    /// Entries pushed beyond `max_size` silently replace the front (oldest)
+    /// entry.  Pushing to a zero-capacity buffer is a no-op.
+    fn push(&mut self, entry: ReplayEntry) {
+        if self.max_size == 0 {
+            return;
+        }
+        if self.inner.len() >= self.max_size {
+            self.inner.pop_front();
+        }
+        self.inner.push_back(entry);
+    }
+
+    /// Iterate over all buffered entries in insertion order (oldest first).
+    fn entries(&self) -> impl Iterator<Item = &ReplayEntry> {
+        self.inner.iter()
+    }
+
+    /// Return up to `n` entries sampled uniformly across the buffer.
+    ///
+    /// Steps through the buffer at a uniform interval so the sample is drawn
+    /// from across the full history rather than only the oldest `n` events.
+    fn sample_n(&self, n: usize) -> Vec<&ReplayEntry> {
+        let len = self.inner.len();
+        if n == 0 || len == 0 {
+            return Vec::new();
+        }
+        let n = n.min(len);
+        // Step size: ceil(len / n) so we space out across the buffer.
+        let step = len.div_ceil(n).max(1);
+        self.inner.iter().step_by(step).take(n).collect()
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Private storage type
+// ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+struct ReplayEntry {
+    context_vector: Vec<f32>,
+    preferred_adapter_idx: usize,
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Core function
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Update the adapter selector gate from a batch of preference feedback events.
+///
+/// Loads `gate_bytes`, validates all events against the gate's dimensions,
+/// runs `config.epochs` passes of single-sample policy-gradient updates
+/// (RLOO / M=1) over the combined `events` + replay sample, applies the
+/// EWC++ diagonal-Fisher null-space projection after each step, serialises
+/// the updated gate, and returns a [`RouterDelta`].
+///
+/// The replay buffer and Fisher state are updated **in place**: after refit,
+/// new positive-signal events are appended to `replay` (oldest evicted if at
+/// capacity) and the Fisher anchor is set to the post-refit gate parameters.
+///
+/// # Polarity invariant
+///
+/// `events` may carry any [`PreferenceSignal`].  Positive signals raise the
+/// target adapter's probability; negative signals lower it.  Both polarities
+/// flow through the same `RlooTrainer::step` code path — the reward sign in
+/// `PreferenceSignal::reward()` determines the direction automatically.
+///
+/// # Arguments
+///
+/// * `gate_bytes` — Current gate serialised with `Network::to_bytes()`
+///   (from a previous `RouterDelta` or the initial construction).
+/// * `events` — Non-empty batch of preference signals.
+/// * `replay` — Mutable replay buffer; updated in place after refit.
+/// * `fisher` — Mutable diagonal Fisher state; auto-initialised to gate's
+///   parameter count on first use (empty `values`/`anchor`).  Returns
+///   [`TuneError::Validation`] if non-empty and size mismatches the gate.
+/// * `config` — Refit hyperparameters.
+///
+/// # Errors
+///
+/// * [`TuneError::Validation`] — empty event batch, context dimension
+///   mismatch, adapter index out of range, or Fisher size mismatch.
+/// * [`TuneError::Training`] — gate deserialisation failure, NaN/Inf in
+///   gate output, or Fisher accumulation failure.
+pub fn update_router(
+    gate_bytes: &[u8],
+    events: &[FeedbackEvent],
+    replay: &mut ReplayBuffer,
+    fisher: &mut DiagonalFisher,
+    config: &RouterUpdateConfig,
+) -> Result<RouterDelta> {
+    // ── 1. Guard: non-empty batch ─────────────────────────────────────────
+    if events.is_empty() {
+        return Err(TuneError::Validation(
+            "feedback events must not be empty; provide at least one event per refit call"
+                .to_owned(),
+        ));
+    }
+
+    // ── 2. Load gate from FANN binary ────────────────────────────────────
+    let mut gate = Network::from_bytes(gate_bytes)
+        .map_err(|e| TuneError::Training(format!("gate deserialisation failed: {e}")))?;
+
+    let num_inputs = gate.num_inputs();
+    let num_outputs = gate.num_outputs();
+    let total_params = gate.total_params();
+
+    // ── 3. Validate all events (fail-closed: reject the whole batch) ──────
+    for (idx, ev) in events.iter().enumerate() {
+        if ev.context_vector.len() != num_inputs {
+            return Err(TuneError::Validation(format!(
+                "event {idx}: context_vector length {} != gate input dimension {num_inputs}",
+                ev.context_vector.len()
+            )));
+        }
+        if ev.preferred_adapter_idx >= num_outputs {
+            return Err(TuneError::Validation(format!(
+                "event {idx}: preferred_adapter_idx {} >= gate output count {num_outputs}",
+                ev.preferred_adapter_idx
+            )));
+        }
+    }
+
+    // ── 4. Initialise or validate DiagonalFisher ──────────────────────────
+    // Auto-initialise when caller passes a default-constructed (empty) Fisher.
+    if fisher.values.is_empty() {
+        fisher.values = vec![0.0_f32; total_params];
+        fisher.anchor = vec![0.0_f32; total_params];
+        // `fisher.decay` remains as set by the caller.
+    } else if fisher.values.len() != total_params {
+        return Err(TuneError::Validation(format!(
+            "DiagonalFisher size {} does not match gate parameter count {total_params}",
+            fisher.values.len()
+        )));
+    }
+
+    // ── 5. Build RLOO trainer ─────────────────────────────────────────────
+    let rloo_config = RlooConfig {
+        learning_rate: config.learning_rate,
+        aux_loss_coeff: config.aux_loss_coeff,
+        z_loss_coeff: config.z_loss_coeff,
+    };
+    let mut trainer = RlooTrainer::new(rloo_config);
+
+    // ── 6. Sample replay entries before mutating the buffer ───────────────
+    let replay_count =
+        (replay.len() as f32 * config.replay_mix_fraction.clamp(0.0, 1.0)).ceil() as usize;
+    // Clone replay entries so the buffer is free to be updated below.
+    let replay_entries: Vec<ReplayEntry> = replay
+        .sample_n(replay_count)
+        .into_iter()
+        .map(|e| ReplayEntry {
+            context_vector: e.context_vector.clone(),
+            preferred_adapter_idx: e.preferred_adapter_idx,
+        })
+        .collect();
+
+    // ── 7. Training loop ──────────────────────────────────────────────────
+    for _ in 0..config.epochs {
+        // New events — reward carries the original signal polarity.
+        // Positive reward pulls the target adapter UP; negative pushes it DOWN.
+        // One code path handles both; DO NOT special-case negative reward.
+        for ev in events {
+            one_gradient_step(
+                &mut gate,
+                &mut trainer,
+                fisher,
+                &ev.context_vector,
+                ev.preferred_adapter_idx,
+                ev.signal.reward(),
+                config.learning_rate,
+            )?;
+        }
+
+        // Replay entries — always positive (only preferred adapters are stored).
+        for entry in &replay_entries {
+            one_gradient_step(
+                &mut gate,
+                &mut trainer,
+                fisher,
+                &entry.context_vector,
+                entry.preferred_adapter_idx,
+                1.0_f32,
+                config.learning_rate,
+            )?;
+        }
+    }
+
+    // ── 8. Fix Fisher anchor at post-refit parameters ─────────────────────
+    let post_params = collect_params(&gate);
+    fisher
+        .set_anchor(&post_params)
+        .map_err(|e| TuneError::Training(format!("fisher anchor update failed: {e}")))?;
+
+    // ── 9. Add positive new events to the replay buffer ───────────────────
+    for ev in events {
+        if ev.signal.is_positive() {
+            replay.push(ReplayEntry {
+                context_vector: ev.context_vector.clone(),
+                preferred_adapter_idx: ev.preferred_adapter_idx,
+            });
+        }
+    }
+
+    // ── 10. Compute accuracy on the updated replay buffer ─────────────────
+    let replay_accuracy = compute_replay_accuracy(&mut gate, replay);
+
+    // ── 11. Serialise updated gate ────────────────────────────────────────
+    let network_bytes = gate.to_bytes();
+
+    Ok(RouterDelta {
+        network_bytes,
+        events_consumed: events.len(),
+        replay_accuracy,
+    })
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Private helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Collect all gate parameters into a flat Vec (weights then biases per layer).
+///
+/// The layout mirrors `Network::total_params()`: for each layer in forward
+/// order, weights (row-major) then biases.  Used to snapshot parameters before
+/// a training step and to restore them after EWC projection.
+fn collect_params(gate: &Network) -> Vec<f32> {
+    let mut params = Vec::with_capacity(gate.total_params());
+    for layer in gate.layers() {
+        params.extend_from_slice(layer.weights());
+        params.extend_from_slice(layer.biases());
+    }
+    params
+}
+
+/// Restore all gate parameters from a flat slice (same layout as
+/// [`collect_params`]).
+///
+/// # Safety invariant
+///
+/// `params.len()` must equal `gate.total_params()`.  Callers ensure this by
+/// using `collect_params` on the same gate to produce `params`.
+fn set_params(gate: &mut Network, params: &[f32]) {
+    let mut offset = 0_usize;
+    for layer in gate.layers_mut() {
+        // Compute lengths from layer dimensions to avoid a double-borrow on `layer`.
+        let nw = layer.num_inputs() * layer.num_outputs();
+        let nb = layer.num_outputs();
+        layer
+            .weights_mut()
+            .copy_from_slice(&params[offset..offset + nw]);
+        offset += nw;
+        layer
+            .biases_mut()
+            .copy_from_slice(&params[offset..offset + nb]);
+        offset += nb;
+    }
+    debug_assert_eq!(
+        offset,
+        params.len(),
+        "param vector length mismatch in set_params"
+    );
+}
+
+/// Apply one policy-gradient step with EWC null-space projection.
+///
+/// Steps:
+/// 1. Snapshot `gate` parameters.
+/// 2. Run `trainer.step(gate, context, action_idx, reward)` to compute and
+///    apply the RLOO gradient (reward sign determines direction; one code
+///    path for ±reward).
+/// 3. Compute the raw parameter delta and approximate gradient.
+/// 4. Observe the gradient in the `DiagonalFisher` EMA.
+/// 5. Apply `fisher.project_delta` to damp updates on high-importance
+///    parameters (diagonal null-space projection).
+/// 6. Restore `gate` parameters to `before + projected_delta`.
+///
+/// # Polarity note
+///
+/// `reward > 0` → RLOO step raises `gate.forward(context)[action_idx]`.
+/// `reward < 0` → RLOO step lowers `gate.forward(context)[action_idx]`.
+/// The sign is carried through the gradient formula unchanged.
+fn one_gradient_step(
+    gate: &mut Network,
+    trainer: &mut RlooTrainer,
+    fisher: &mut DiagonalFisher,
+    context: &[f32],
+    action_idx: usize,
+    reward: f32,
+    lr: f32,
+) -> Result<()> {
+    let before = collect_params(gate);
+
+    // RLOO policy-gradient step: handles ±reward in one code path.
+    trainer
+        .step(gate, context, action_idx, reward)
+        .map_err(|e| TuneError::Training(format!("policy-gradient step failed: {e}")))?;
+
+    let after = collect_params(gate);
+
+    // Raw delta: after - before = -lr * gradient (SGD update rule).
+    // Approximate gradient = -(delta / lr).
+    let raw_delta: Vec<f32> = after
+        .iter()
+        .zip(before.iter())
+        .map(|(a, b)| a - b)
+        .collect();
+
+    // Update Fisher EMA with the approximate gradient.
+    // `observe_gradient` squares internally: F_i ← decay·F_i + (1−decay)·g_i².
+    let safe_lr = lr.abs().max(1e-10_f32);
+    let approx_grad: Vec<f32> = raw_delta.iter().map(|&d| -d / safe_lr).collect();
+    fisher
+        .observe_gradient(&approx_grad)
+        .map_err(|e| TuneError::Training(format!("Fisher gradient observation failed: {e}")))?;
+
+    // EWC null-space projection: damp updates proportional to Fisher importance.
+    // Parameters with high Fisher (important to prior tasks) are scaled toward
+    // zero; parameters with near-zero Fisher pass through unchanged.
+    let mut projected_delta = raw_delta;
+    fisher.project_delta(&mut projected_delta);
+
+    // Apply projected delta: new_params = before + projected_delta.
+    let projected: Vec<f32> = before
+        .iter()
+        .zip(projected_delta.iter())
+        .map(|(b, d)| b + d)
+        .collect();
+    set_params(gate, &projected);
+
+    Ok(())
+}
+
+/// Compute the gate's top-1 accuracy on the replay buffer.
+///
+/// For each buffered entry, the gate's `argmax` output is compared against
+/// `preferred_adapter_idx`.  Returns `None` when the buffer is empty.
+fn compute_replay_accuracy(gate: &mut Network, replay: &ReplayBuffer) -> Option<f32> {
+    if replay.is_empty() {
+        return None;
+    }
+    let total = replay.len();
+    let correct = replay
+        .entries()
+        .filter(|entry| {
+            gate.forward(&entry.context_vector)
+                .ok()
+                .and_then(|scores| {
+                    scores
+                        .iter()
+                        .enumerate()
+                        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+                        .map(|(i, _)| i)
+                })
+                .map(|top1| top1 == entry.preferred_adapter_idx)
+                .unwrap_or(false)
+        })
+        .count();
+    Some(correct as f32 / total as f32)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lattice_fann::{Activation, NetworkBuilder};
+
+    /// Deterministic gate: 4 inputs → 8 hidden (ReLU) → 3 outputs (Linear).
+    fn make_gate(num_inputs: usize, hidden: usize, num_outputs: usize) -> Network {
+        NetworkBuilder::new()
+            .input(num_inputs)
+            .hidden(hidden, Activation::ReLU)
+            .output(num_outputs, Activation::Linear)
+            .build_with_seed(42)
+            .unwrap()
+    }
+
+    /// Config with stronger learning rate so effects are clearly measurable
+    /// in unit tests without thousands of events.
+    fn test_config() -> RouterUpdateConfig {
+        RouterUpdateConfig {
+            learning_rate: 0.1,
+            ..RouterUpdateConfig::default()
+        }
+    }
+
+    /// Build a batch of identical feedback events pointing at one adapter.
+    fn make_events(
+        num: usize,
+        adapter_idx: usize,
+        signal: PreferenceSignal,
+        dim: usize,
+    ) -> Vec<FeedbackEvent> {
+        (0..num)
+            .map(|i| FeedbackEvent {
+                // Vary context slightly so aux loss sees non-trivial inputs.
+                context_vector: (0..dim).map(|j| (i + j) as f32 * 0.01 + 0.1).collect(),
+                preferred_adapter_idx: adapter_idx,
+                adapter_id: format!("adapter-{adapter_idx}"),
+                signal: signal.clone(),
+            })
+            .collect()
+    }
+
+    // ─── Validation / error-path tests ────────────────────────────────────
+
+    /// An empty event slice must immediately return Err(TuneError::Validation).
+    ///
+    /// Mutation that defeats this test: remove the `events.is_empty()` guard.
+    #[test]
+    fn update_router_empty_feedback_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher =
+            DiagonalFisher::new(0, 0.99).expect("dim=0, decay=0.99 are valid Fisher params"); // empty → auto-init
+        let config = test_config();
+
+        let result = update_router(&gate_bytes, &[], &mut replay, &mut fisher, &config);
+        assert!(result.is_err(), "empty event batch must return Err, got Ok");
+        match result {
+            Err(TuneError::Validation(_)) => {}
+            Err(other) => panic!("expected TuneError::Validation, got {other:?}"),
+            Ok(_) => panic!("expected Err, got Ok"),
+        }
+    }
+
+    /// An event with wrong context dimension must return Err(TuneError::Validation).
+    ///
+    /// Mutation that defeats this test: remove the context-length check in
+    /// the event-validation loop.
+    #[test]
+    fn update_router_wrong_context_dim_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher =
+            DiagonalFisher::new(0, 0.99).expect("dim=0, decay=0.99 are valid Fisher params");
+        let config = test_config();
+
+        // Gate expects 4 inputs; supply 7.
+        let events = vec![FeedbackEvent {
+            context_vector: vec![1.0; 7],
+            preferred_adapter_idx: 0,
+            adapter_id: "a".into(),
+            signal: PreferenceSignal::Positive,
+        }];
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "wrong context dim must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    // ─── Polarity / direction tests ───────────────────────────────────────
+
+    /// After update_router on a batch of positive events targeting adapter 2,
+    /// the gate's logit for adapter 2 must be strictly higher than before.
+    ///
+    /// Mutation that defeats this test: set `learning_rate` to `0.0` in the
+    /// RLOO gradient step so no update is applied.
+    #[test]
+    fn router_delta_score_shifts_toward_preferred() {
+        let mut gate_before = make_gate(4, 8, 3);
+        let ctx = vec![0.1_f32, 0.2, 0.3, 0.4];
+        let before_score = gate_before.forward(&ctx).unwrap()[2];
+
+        let gate_bytes = gate_before.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher =
+            DiagonalFisher::new(0, 0.99).expect("dim=0, decay=0.99 are valid Fisher params");
+        let config = test_config();
+
+        // 10 events all preferring adapter 2 with explicit positive signal.
+        let events = make_events(10, 2, PreferenceSignal::Positive, 4);
+        let delta = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config)
+            .expect("update_router must succeed on valid input");
+
+        let mut gate_after = Network::from_bytes(&delta.network_bytes)
+            .expect("RouterDelta::network_bytes must deserialise cleanly");
+        let after_score = gate_after.forward(&ctx).unwrap()[2];
+
+        assert!(
+            after_score > before_score,
+            "positive events targeting adapter 2 must raise its logit: \
+             before={before_score:.6}, after={after_score:.6}"
+        );
+    }
+
+    /// After update_router on a batch of negative events targeting adapter 1,
+    /// the gate's logit for adapter 1 must be strictly lower than before.
+    ///
+    /// This is the load-bearing polarity test.  Mutation that defeats it:
+    /// call `ev.signal.reward()` unconditionally as `+1.0` (ignore polarity),
+    /// which would push adapter 1 UP instead of DOWN.
+    #[test]
+    fn feedback_event_negative_signal_decreases_score() {
+        let mut gate_before = make_gate(4, 8, 3);
+        let ctx = vec![0.1_f32, 0.2, 0.3, 0.4];
+        let before_score = gate_before.forward(&ctx).unwrap()[1];
+
+        let gate_bytes = gate_before.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher =
+            DiagonalFisher::new(0, 0.99).expect("dim=0, decay=0.99 are valid Fisher params");
+        let config = test_config();
+
+        // 10 negative events targeting adapter 1: signal must push logit[1] DOWN.
+        let events = make_events(10, 1, PreferenceSignal::Negative, 4);
+        let delta = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config)
+            .expect("update_router must succeed on valid input");
+
+        let mut gate_after = Network::from_bytes(&delta.network_bytes)
+            .expect("RouterDelta::network_bytes must deserialise cleanly");
+        let after_score = gate_after.forward(&ctx).unwrap()[1];
+
+        assert!(
+            after_score < before_score,
+            "negative events targeting adapter 1 must lower its logit (polarity test): \
+             before={before_score:.6}, after={after_score:.6}"
+        );
+    }
+
+    // ─── RouterDelta serialisation round-trip ─────────────────────────────
+
+    /// The network bytes in RouterDelta must deserialise to a runnable gate
+    /// that produces the same output as the live gate immediately after refit.
+    ///
+    /// Mutation that defeats this test: return an empty Vec for
+    /// `RouterDelta::network_bytes` instead of calling `gate.to_bytes()`.
+    #[test]
+    fn router_delta_bytes_round_trip() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher =
+            DiagonalFisher::new(0, 0.99).expect("dim=0, decay=0.99 are valid Fisher params");
+        let config = test_config();
+
+        let events = make_events(5, 0, PreferenceSignal::Positive, 4);
+        let delta = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config).unwrap();
+
+        // Deserialise and run a forward pass to confirm the blob is complete.
+        let mut restored = Network::from_bytes(&delta.network_bytes)
+            .expect("RouterDelta::network_bytes must deserialise without error");
+        let ctx = vec![0.5_f32; 4];
+        let out = restored
+            .forward(&ctx)
+            .expect("restored gate must run forward pass");
+        assert_eq!(
+            out.len(),
+            3,
+            "restored gate output length must equal original num_outputs"
+        );
+    }
+
+    // ─── Replay buffer capacity tests ─────────────────────────────────────
+
+    /// Inserting more than `max_size` entries must cap the buffer at `max_size`.
+    ///
+    /// Mutation that defeats this test: remove the `pop_front()` eviction in
+    /// `ReplayBuffer::push()`.
+    #[test]
+    fn replay_buffer_bounded_at_max_size() {
+        let mut buf = ReplayBuffer::new(256);
+        for i in 0..600 {
+            buf.push(ReplayEntry {
+                context_vector: vec![i as f32],
+                preferred_adapter_idx: i % 4,
+            });
+        }
+        assert_eq!(
+            buf.len(),
+            256,
+            "buffer must be bounded at max_size=256 after 600 insertions"
+        );
+    }
+
+    /// After overflow the oldest entries must be evicted (FIFO discipline).
+    ///
+    /// After inserting events 0..600 into a 256-capacity buffer, events 0..343
+    /// have been evicted.  The front of the buffer holds event 344 (0-indexed),
+    /// which is the 345th inserted event.
+    ///
+    /// Mutation that defeats this test: push to the front instead of the back
+    /// (reversing insertion order) or skip `pop_front` (breaking eviction).
+    #[test]
+    fn replay_buffer_evicts_oldest() {
+        let mut buf = ReplayBuffer::new(256);
+        for i in 0..600 {
+            buf.push(ReplayEntry {
+                context_vector: vec![i as f32],
+                preferred_adapter_idx: 0,
+            });
+        }
+
+        // Front entry must be event 344 (first 344 events were evicted: 0..344 gone,
+        // 344 is the new front).
+        let front = buf
+            .inner
+            .front()
+            .expect("buffer must be non-empty after insertions");
+        assert!(
+            (front.context_vector[0] - 344.0).abs() < 1e-6,
+            "front entry should be the 345th inserted (index 344), got {}",
+            front.context_vector[0]
+        );
+    }
+}

--- a/crates/tune/src/lora/router_update.rs
+++ b/crates/tune/src/lora/router_update.rs
@@ -2,13 +2,22 @@
 //!
 //! Consumes a batch of [`FeedbackEvent`]s, retunes the adapter-selection gate
 //! network with a single-sample policy-gradient update (RLOO / M=1), applies
-//! the EWC++ diagonal-Fisher null-space projection for anti-forgetting, and
-//! returns the updated gate as a self-contained FANN binary blob.
+//! Fisher null-space damping for anti-forgetting (v1), and returns the updated
+//! gate as a self-contained FANN binary blob.
 //!
-//! This is the tune-side orchestration layer.  All gradient computation and
-//! Fisher accumulation live in the fann training primitives
-//! ([`RlooTrainer`], [`DiagonalFisher`]).  This module wires them with the
-//! replay buffer and persistence logic.
+//! # Anti-forgetting mechanism (v1)
+//!
+//! The shipped v1 mechanism is **Fisher null-space damping** via
+//! [`DiagonalFisher::project_delta`]: parameters with a high squared-gradient
+//! EMA (important to prior tasks) have their update scaled toward zero;
+//! parameters with near-zero importance pass through unchanged.  The anchor
+//! parameter vector is updated at the end of each refit call, but it is used
+//! only by the off-by-default penalty path — not by `project_delta`.
+//!
+//! The anchor-pullback penalty ([`DiagonalFisher::penalty_gradient`]) is a
+//! tested Phase-2 path wired to [`RouterUpdateConfig::ewc_lambda`].  It is
+//! **not** active in v1; `ewc_lambda` is validated and stored but not consumed
+//! by the current update loop.
 //!
 //! # Polarity invariant
 //!
@@ -267,9 +276,15 @@ struct ReplayEntry {
 ///
 /// Loads `gate_bytes`, validates all events against the gate's dimensions,
 /// runs `config.epochs` passes of single-sample policy-gradient updates
-/// (RLOO / M=1) over the combined `events` + replay sample, applies the
-/// EWC++ diagonal-Fisher null-space projection after each step, serialises
-/// the updated gate, and returns a [`RouterDelta`].
+/// (RLOO / M=1) over the combined `events` + replay sample, applies Fisher
+/// null-space damping after each step to protect parameters important to prior
+/// tasks, serialises the updated gate, and returns a [`RouterDelta`].
+///
+/// The v1 anti-forgetting mechanism is [`DiagonalFisher::project_delta`]:
+/// parameters with a high squared-gradient EMA are damped toward zero.  The
+/// anchor-pullback penalty (Phase-2) is wired to `config.ewc_lambda` but is
+/// **not** active in this version; the parameter is validated and stored for
+/// forward compatibility.
 ///
 /// The replay buffer and Fisher state are updated **in place**: after refit,
 /// new positive-signal events are appended to `replay` (oldest evicted if at
@@ -336,6 +351,62 @@ pub fn update_router(
                 ev.preferred_adapter_idx
             )));
         }
+        // Reward values are derived from PreferenceSignal::reward(), which always
+        // returns a finite f32; only the caller-supplied context vector needs this
+        // non-finite guard.
+        if ev.context_vector.iter().any(|&v| !v.is_finite()) {
+            return Err(TuneError::Validation(format!(
+                "event {idx}: context_vector contains a non-finite value (NaN or Inf)"
+            )));
+        }
+    }
+
+    // ── 3.5. Validate config hyperparameters ─────────────────────────────
+    if !config.learning_rate.is_finite() || config.learning_rate <= 0.0 {
+        return Err(TuneError::Validation(format!(
+            "learning_rate must be finite and > 0, got {}",
+            config.learning_rate
+        )));
+    }
+    if !config.aux_loss_coeff.is_finite() || config.aux_loss_coeff < 0.0 {
+        return Err(TuneError::Validation(format!(
+            "aux_loss_coeff must be finite and >= 0, got {}",
+            config.aux_loss_coeff
+        )));
+    }
+    if !config.z_loss_coeff.is_finite() || config.z_loss_coeff < 0.0 {
+        return Err(TuneError::Validation(format!(
+            "z_loss_coeff must be finite and >= 0, got {}",
+            config.z_loss_coeff
+        )));
+    }
+    if !config.ewc_lambda.is_finite() || config.ewc_lambda < 0.0 {
+        return Err(TuneError::Validation(format!(
+            "ewc_lambda must be finite and >= 0, got {}",
+            config.ewc_lambda
+        )));
+    }
+    if !config.replay_mix_fraction.is_finite()
+        || config.replay_mix_fraction < 0.0
+        || config.replay_mix_fraction > 1.0
+    {
+        return Err(TuneError::Validation(format!(
+            "replay_mix_fraction must be finite and in [0.0, 1.0], got {}",
+            config.replay_mix_fraction
+        )));
+    }
+    if config.epochs == 0 {
+        return Err(TuneError::Validation(
+            "epochs must be > 0; a refit with zero training epochs has no effect".to_owned(),
+        ));
+    }
+    // Fisher decay must be in the open interval (0, 1) on both the empty
+    // auto-init path and the non-empty reuse path. Mirror DiagonalFisher::new.
+    if !fisher.decay.is_finite() || fisher.decay <= 0.0 || fisher.decay >= 1.0 {
+        return Err(TuneError::Validation(format!(
+            "DiagonalFisher decay must be finite and in the open interval (0, 1), got {}",
+            fisher.decay
+        )));
     }
 
     // ── 4. Initialise or validate DiagonalFisher ──────────────────────────
@@ -344,11 +415,36 @@ pub fn update_router(
         fisher.values = vec![0.0_f32; total_params];
         fisher.anchor = vec![0.0_f32; total_params];
         // `fisher.decay` remains as set by the caller.
-    } else if fisher.values.len() != total_params {
-        return Err(TuneError::Validation(format!(
-            "DiagonalFisher size {} does not match gate parameter count {total_params}",
-            fisher.values.len()
-        )));
+    } else {
+        // Non-empty Fisher: validate dimensions and numeric integrity before
+        // any mutation so we fail closed before touching the training state.
+        if fisher.values.len() != total_params {
+            return Err(TuneError::Validation(format!(
+                "DiagonalFisher size {} does not match gate parameter count {total_params}",
+                fisher.values.len()
+            )));
+        }
+        // Fisher diagonal entries are squared-gradient EMAs — they must be
+        // finite and non-negative by construction.
+        if fisher.values.iter().any(|&v| !v.is_finite() || v < 0.0) {
+            return Err(TuneError::Validation(
+                "DiagonalFisher values must all be finite and >= 0 \
+                 (Fisher diagonal entries are squared-gradient EMAs)"
+                    .to_owned(),
+            ));
+        }
+        if fisher.anchor.len() != total_params {
+            return Err(TuneError::Validation(format!(
+                "DiagonalFisher anchor length {} does not match gate parameter count \
+                 {total_params}",
+                fisher.anchor.len()
+            )));
+        }
+        if fisher.anchor.iter().any(|&v| !v.is_finite()) {
+            return Err(TuneError::Validation(
+                "DiagonalFisher anchor contains a non-finite value".to_owned(),
+            ));
+        }
     }
 
     // ── 5. Build RLOO trainer ─────────────────────────────────────────────
@@ -824,6 +920,388 @@ mod tests {
             (front.context_vector[0] - 344.0).abs() < 1e-6,
             "front entry should be the 345th inserted (index 344), got {}",
             front.context_vector[0]
+        );
+    }
+
+    // ─── FIX 1: input-validation tests ────────────────────────────────────
+
+    /// NaN learning_rate must return Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `!config.learning_rate.is_finite()` branch.
+    #[test]
+    fn update_router_nan_learning_rate_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = RouterUpdateConfig {
+            learning_rate: f32::NAN,
+            ..test_config()
+        };
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "NaN learning_rate must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// Zero learning_rate must return Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `config.learning_rate <= 0.0` branch.
+    #[test]
+    fn update_router_zero_learning_rate_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = RouterUpdateConfig {
+            learning_rate: 0.0,
+            ..test_config()
+        };
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "zero learning_rate must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// Negative learning_rate must return Err(TuneError::Validation).
+    ///
+    /// Mutation: invert or remove the `config.learning_rate <= 0.0` check.
+    #[test]
+    fn update_router_negative_learning_rate_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = RouterUpdateConfig {
+            learning_rate: -0.1,
+            ..test_config()
+        };
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "negative learning_rate must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// NaN aux_loss_coeff must return Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `!config.aux_loss_coeff.is_finite()` branch.
+    #[test]
+    fn update_router_nan_aux_loss_coeff_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = RouterUpdateConfig {
+            aux_loss_coeff: f32::NAN,
+            ..test_config()
+        };
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "NaN aux_loss_coeff must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// Negative z_loss_coeff must return Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `config.z_loss_coeff < 0.0` branch.
+    #[test]
+    fn update_router_negative_z_loss_coeff_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = RouterUpdateConfig {
+            z_loss_coeff: -0.001,
+            ..test_config()
+        };
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "negative z_loss_coeff must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// Negative ewc_lambda must return Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `config.ewc_lambda < 0.0` branch.
+    #[test]
+    fn update_router_negative_ewc_lambda_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = RouterUpdateConfig {
+            ewc_lambda: -0.1,
+            ..test_config()
+        };
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "negative ewc_lambda must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// Infinite ewc_lambda must return Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `!config.ewc_lambda.is_finite()` branch.
+    #[test]
+    fn update_router_infinite_ewc_lambda_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = RouterUpdateConfig {
+            ewc_lambda: f32::INFINITY,
+            ..test_config()
+        };
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "infinite ewc_lambda must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// replay_mix_fraction > 1.0 must return Err(TuneError::Validation).
+    ///
+    /// Prior to this fix the value was silently clamped; the guard makes a bad
+    /// value loud instead.
+    ///
+    /// Mutation: remove the `config.replay_mix_fraction > 1.0` branch.
+    #[test]
+    fn update_router_replay_mix_fraction_out_of_range_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = RouterUpdateConfig {
+            replay_mix_fraction: 1.5,
+            ..test_config()
+        };
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "replay_mix_fraction > 1.0 must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// A NaN value inside an event's context_vector must return Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `ev.context_vector.iter().any(!is_finite)` check.
+    #[test]
+    fn update_router_nan_context_value_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = test_config();
+        let events = vec![FeedbackEvent {
+            context_vector: vec![1.0, f32::NAN, 0.5, 0.0],
+            preferred_adapter_idx: 0,
+            adapter_id: "a".into(),
+            signal: PreferenceSignal::Positive,
+        }];
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "NaN in context_vector must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// epochs == 0 must return Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `config.epochs == 0` check.
+    #[test]
+    fn update_router_zero_epochs_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+        let config = RouterUpdateConfig {
+            epochs: 0,
+            ..test_config()
+        };
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "epochs=0 must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// A non-empty DiagonalFisher with a NaN value must return Err(TuneError::Validation).
+    ///
+    /// Uses a struct literal to bypass DiagonalFisher::new() validation so the
+    /// invalid state reaches update_router's own guard.
+    ///
+    /// Mutation: remove the `!v.is_finite()` branch in the Fisher values check.
+    #[test]
+    fn update_router_fisher_nan_value_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let total_params = gate.total_params();
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut values = vec![0.0_f32; total_params];
+        values[0] = f32::NAN;
+        let mut fisher = DiagonalFisher {
+            values,
+            anchor: vec![0.0; total_params],
+            decay: 0.99,
+        };
+        let config = test_config();
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "Fisher NaN value must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// A non-empty DiagonalFisher with a negative value must return Err(TuneError::Validation).
+    ///
+    /// Fisher diagonal entries are squared-gradient EMAs and must be >= 0.
+    ///
+    /// Mutation: remove the `v < 0.0` branch in the Fisher values check.
+    #[test]
+    fn update_router_fisher_negative_value_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let total_params = gate.total_params();
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut values = vec![0.0_f32; total_params];
+        values[1] = -0.5;
+        let mut fisher = DiagonalFisher {
+            values,
+            anchor: vec![0.0; total_params],
+            decay: 0.99,
+        };
+        let config = test_config();
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "negative Fisher value must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// Fisher decay = 1.0, set via struct literal to bypass DiagonalFisher::new(),
+    /// must return Err(TuneError::Validation) even when values is empty.
+    ///
+    /// Mutation: remove the Fisher decay guard in update_router.
+    #[test]
+    fn update_router_fisher_decay_one_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher {
+            values: vec![],
+            anchor: vec![],
+            decay: 1.0,
+        };
+        let config = test_config();
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "Fisher decay=1.0 must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// A non-empty DiagonalFisher with anchor length != total_params must return
+    /// Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `fisher.anchor.len() != total_params` check.
+    #[test]
+    fn update_router_fisher_anchor_len_mismatch_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let total_params = gate.total_params();
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut fisher = DiagonalFisher {
+            values: vec![0.0; total_params],
+            anchor: vec![0.0; total_params + 3], // wrong length
+            decay: 0.99,
+        };
+        let config = test_config();
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "Fisher anchor length mismatch must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    /// A non-empty DiagonalFisher with a non-finite anchor entry must return
+    /// Err(TuneError::Validation).
+    ///
+    /// Mutation: remove the `fisher.anchor.iter().any(!is_finite)` check.
+    #[test]
+    fn update_router_fisher_nonfinite_anchor_returns_err() {
+        let gate = make_gate(4, 8, 3);
+        let total_params = gate.total_params();
+        let gate_bytes = gate.to_bytes();
+        let mut replay = ReplayBuffer::new(256);
+        let mut anchor = vec![0.0_f32; total_params];
+        anchor[2] = f32::INFINITY;
+        let mut fisher = DiagonalFisher {
+            values: vec![0.0; total_params],
+            anchor,
+            decay: 0.99,
+        };
+        let config = test_config();
+        let events = make_events(1, 0, PreferenceSignal::Positive, 4);
+        let result = update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config);
+        assert!(
+            matches!(result, Err(TuneError::Validation(_))),
+            "non-finite Fisher anchor must return TuneError::Validation, got {result:?}"
+        );
+    }
+
+    // ─── ewc_lambda Phase-2 boundary test ─────────────────────────────────
+
+    /// Two runs identical in every respect except ewc_lambda must produce
+    /// byte-identical RouterDelta::network_bytes.
+    ///
+    /// This pins the Phase-2 boundary: v1 uses project_delta (Fisher
+    /// null-space damping), which does not read ewc_lambda.  The test fails
+    /// the moment someone wires ewc_lambda into the update path without
+    /// revisiting the design.
+    ///
+    /// Mutation: multiply the projected delta by `config.ewc_lambda` inside
+    /// one_gradient_step — the two outputs will diverge.
+    #[test]
+    fn ewc_lambda_is_inert_in_projection_path() {
+        let gate_bytes = make_gate(4, 8, 3).to_bytes();
+        let events = make_events(3, 1, PreferenceSignal::Positive, 4);
+
+        let run = |ewc_lambda: f32| -> Vec<u8> {
+            let mut replay = ReplayBuffer::new(256);
+            let mut fisher = DiagonalFisher::new(0, 0.99).unwrap();
+            let config = RouterUpdateConfig {
+                ewc_lambda,
+                ..test_config()
+            };
+            update_router(&gate_bytes, &events, &mut replay, &mut fisher, &config)
+                .expect("update_router must succeed on valid input")
+                .network_bytes
+        };
+
+        let bytes_zero = run(0.0);
+        let bytes_half = run(0.5);
+        assert_eq!(
+            bytes_zero, bytes_half,
+            "ewc_lambda must not affect network_bytes in the v1 projection path"
         );
     }
 }


### PR DESCRIPTION
## Summary

Implements `update_router` — the tune-side capstone of the adaptive micro-LoRA adapter-router system (issue #440). Builds on the already-merged fann online-update primitives (#448) and governed-manifest loader (#444); the net-new code here is the tune-side `update_router` plus fail-closed hardening of the FANN deserializer it depends on.

## What `update_router` does

Consumes a batch of `FeedbackEvent`s, refits the FANN adapter-selector gate via single-sample policy-gradient (RLOO / M=1), applies EWC++ diagonal-Fisher null-space projection for anti-forgetting, and returns a `RouterDelta` with the serialised gate ready to replace the prior one.

## fann primitives wired

- `RlooTrainer::step(gate, context, action_idx, reward)` — one SGD step; RLOO gradient + load-balancing aux-loss + z-loss
- `DiagonalFisher::observe_gradient` — EMA of squared gradients after each step
- `DiagonalFisher::project_delta` — damps updates to high-Fisher (important) parameters toward zero

## Anti-forgetting mechanism (v1)

v1 anti-forgetting is **Fisher null-space damping** via `project_delta`: updates to high-Fisher (previously-important) gate parameters are damped toward zero. The anchor-pullback penalty (`penalty_gradient`, wired to `ewc_lambda`) is a deliberate **off-by-default Phase-2** path — `ewc_lambda` is validated but inert in the v1 update loop. A boundary test (`ewc_lambda_is_inert_in_projection_path`) pins this: `RouterDelta::network_bytes` is byte-identical for `ewc_lambda` `0.0` vs `0.5`.

## Polarity invariant

Both positive and negative signals flow through a **single code path** via `PreferenceSignal::reward()` as the signed scalar. Positive reward raises the target adapter's routing logit; negative reward lowers it. No special-casing of negative reward. `reward()` is a closed enum-to-constant mapping, so the reward value is always finite by construction.

## Where it plugs into the PR1 router

`RouterDelta::network_bytes` is a complete FANN binary blob (`Network::to_bytes()`). Callers deserialise with `Network::from_bytes()` and pass to `AdapterRouter::new(gate)` in `crates/inference/src/mixture.rs`.

## Fail-closed input hardening

`update_router` consumes untrusted config scalars, Fisher state, and context vectors, and the deserialiser it feeds reads an untrusted byte blob. Both are now validated before any mutation or allocation:

- **`update_router`**: per-event context-vector finiteness; config-scalar validation (learning rate finite & > 0; aux/z/EWC coefficients finite & ≥ 0; `replay_mix_fraction` finite & in `[0.0, 1.0]` — rejected, not silently clamped; epochs > 0); Fisher decay finite & in `(0, 1)` on both the auto-init and reuse paths; on the reuse path, Fisher values finite & ≥ 0, anchor length == total params, anchor finiteness. All of this runs before Fisher mutation, trainer construction, and replay-buffer allocation.
- **`Network::from_bytes`**: `num_layers` bounded by `remaining_bytes / 9` (each layer header is ≥ 9 bytes) before `Vec::with_capacity`; each layer's dimensions are validated against the element cap (`validate_layer_dimensions`) immediately after they are read, before the weight/bias payloads are read or collected, so an oversized header cannot drive a large allocation before the cap rejects it; shape and byte-count arithmetic uses `checked_mul`; the `read_bytes` helper computes its bounds budget by subtraction (`bytes.len().saturating_sub(*pos)`) so the bounds check itself cannot overflow on a near-`usize::MAX` byte count; trailing bytes are rejected. Malformed input returns a clean `Err` (`ShapeTooLarge` / `InvalidBuilder`) instead of an allocation-abort or panic.

## Feature gate

`mixture = ["lattice-fann/online-router"]` in `crates/tune/Cargo.toml` (experimental, disabled by default, bench-gated per #440). It enables fann's pure-Rust `online-router` feature (no platform deps), so the gated build runs on all CI OSes. `feature-matrix` in `ci.yml` builds and tests this combination.

## Files changed

| File | Change |
|------|--------|
| `crates/tune/src/lora/router_update.rs` | New — 1307 LOC including 23 mutation-sensitive tests |
| `crates/fann/src/network/serialization.rs` | Fail-closed deserializer hardening: bounded allocation, per-layer element cap, checked/overflow-safe arithmetic (10 hostile-input regression tests) |
| `crates/tune/Cargo.toml` | +`mixture = ["lattice-fann/online-router"]` feature |
| `crates/tune/src/lora/mod.rs` | +`#[cfg(feature = "mixture")] pub mod router_update;` |
| `.github/workflows/ci.yml` | feature-matrix runs `cargo test -p lattice-tune --features mixture --lib` |

## Test plan

```
cargo test  -p lattice-fann --lib                                       -> 78 passed
cargo test  -p lattice-tune --features mixture --lib                    -> 197 passed
cargo clippy -p lattice-fann --all-targets -- -D warnings               -> clean
cargo clippy -p lattice-tune --features mixture --all-targets -- -D warnings -> clean
```

Load-bearing invariants are mutation-tested, including:

| Test | Guards |
|------|--------|
| `feedback_event_negative_signal_decreases_score` | Negative signal lowers the target logit — mutation `reward = 1.0` makes it rise, test FAILS |
| `ewc_lambda_is_inert_in_projection_path` | `RouterDelta` byte-identical for `ewc_lambda` 0.0 vs 0.5 — pins the Phase-2 knob inert |
| `update_router_replay_mix_fraction_out_of_range_returns_err` | Out-of-range `replay_mix_fraction` → `TuneError::Validation` (reject, not clamp) |
| `from_bytes_oversized_layer_dims_rejected_before_allocation` | Oversized dimension header → `ShapeTooLarge` from the element cap before any weight read/allocation |
| `router_delta_score_shifts_toward_preferred` | Positive signal raises the preferred adapter's logit |
| `router_delta_bytes_round_trip` | `RouterDelta::network_bytes` deserialises cleanly |

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)
