### PR TITLE
fix(inference): reject odd/zero rope_dim at config parse time

### DIFF
--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -438,13 +438,17 @@ impl Qwen35Config {
         // inside the documented "first rope_dim dimensions" range untouched — wrong output
         // with no error signal.  rope_dim == 0 makes RopeTable::max_positions() return 0,
         // which causes every non-empty-sequence call to the capacity-guarded APIs to fail
-        // instead of the intended no-op.  Reject both fail-closed; no-RoPE variants that
-        // need rope_dim==0 require an explicit dispatch path (Refs #401).
+        // instead of the intended no-op.  rope_dim > head_dim indexes head_vec[half + i] past
+        // the head_dim-length slice: the partial_rotary_factor <= 1.0 check above bounds this
+        // in real arithmetic, but rope_dim() casts head_dim through f32, so a head_dim above
+        // f32's exact-integer range (2^24) can round UP and derive rope_dim > head_dim even at
+        // factor 1.0.  Reject all three fail-closed; no-RoPE variants that need rope_dim==0
+        // require an explicit dispatch path (Refs #401).
         let rope_dim = cfg.rope_dim();
-        if rope_dim < 2 || rope_dim % 2 != 0 {
+        if rope_dim < 2 || rope_dim % 2 != 0 || rope_dim > cfg.head_dim {
             return Err(InferenceError::Inference(format!(
-                "invalid Qwen config.json: derived rope_dim ({rope_dim}) must be even and \
-                 >= 2 (head_dim={hd}, partial_rotary_factor={prf})",
+                "invalid Qwen config.json: derived rope_dim ({rope_dim}) must be even, >= 2, \
+                 and <= head_dim ({hd}) (partial_rotary_factor={prf})",
                 hd = cfg.head_dim,
                 prf = cfg.partial_rotary_factor,
             )));
@@ -1218,6 +1222,23 @@ mod tests {
         let json = r#"{"text_config": {"partial_rotary_factor": 0.0}}"#;
         let err = Qwen35Config::from_config_json_str(json)
             .expect_err("zero rope_dim must yield an InferenceError, not capacity-zero surprise")
+            .to_string();
+        assert!(err.contains("rope_dim"), "wrong guard fired: {err}");
+    }
+
+    #[test]
+    fn test_rope_dim_exceeds_head_dim_via_f32_rounding_errors() {
+        // Mutation contract: removing the `rope_dim > cfg.head_dim` guard must make this
+        // test FAIL (the call returns Ok instead of Err).
+        //
+        // partial_rotary_factor=1.0 keeps rope_dim <= head_dim in real arithmetic, but
+        // rope_dim() casts head_dim through f32: head_dim=16_777_219 (2^24 + 3) rounds UP to
+        // 16_777_220, so rope_dim=16_777_220 > head_dim. That value is even and >= 2, so it
+        // slips the lower-bound/parity guard and would index head_vec[rope_dim/2 + i] one past
+        // the head_dim-length slice in apply_partial_rope. Fail closed at parse time.
+        let json = r#"{"text_config": {"head_dim": 16777219, "partial_rotary_factor": 1.0}}"#;
+        let err = Qwen35Config::from_config_json_str(json)
+            .expect_err("rope_dim > head_dim (f32 rounding) must yield an InferenceError, not OOB")
             .to_string();
         assert!(err.contains("rope_dim"), "wrong guard fired: {err}");
     }

--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -432,6 +432,23 @@ impl Qwen35Config {
                 cfg.partial_rotary_factor
             )));
         }
+        // rope_dim = (head_dim * partial_rotary_factor) as usize.  apply_partial_rope pairs
+        // dimensions as (i, half+i) for i in 0..half, where half = rope_dim / 2.  An odd
+        // rope_dim silently truncates: only 2*(rope_dim/2) dims are rotated, leaving one dim
+        // inside the documented "first rope_dim dimensions" range untouched — wrong output
+        // with no error signal.  rope_dim == 0 makes RopeTable::max_positions() return 0,
+        // which causes every non-empty-sequence call to the capacity-guarded APIs to fail
+        // instead of the intended no-op.  Reject both fail-closed; no-RoPE variants that
+        // need rope_dim==0 require an explicit dispatch path (Refs #401).
+        let rope_dim = cfg.rope_dim();
+        if rope_dim < 2 || rope_dim % 2 != 0 {
+            return Err(InferenceError::Inference(format!(
+                "invalid Qwen config.json: derived rope_dim ({rope_dim}) must be even and \
+                 >= 2 (head_dim={hd}, partial_rotary_factor={prf})",
+                hd = cfg.head_dim,
+                prf = cfg.partial_rotary_factor,
+            )));
+        }
         // The GatedDeltaNet fused path divides by these head counts: `value_heads / key_heads`
         // (gdn_fused.rs ratio) and `h / ratio` per value head. A parseable config with
         // `linear_num_key_heads == 0`, `linear_num_value_heads == 0`, or value-heads not a
@@ -1168,6 +1185,41 @@ mod tests {
             Qwen35Config::from_config_json_str(json).is_ok(),
             "partial_rotary_factor == 1.0 (full rotary) must be accepted"
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // rope_dim invariant tests (issue #401)
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_odd_rope_dim_errors_not_panics() {
+        // Mutation contract: removing the `rope_dim < 2 || rope_dim % 2 != 0` guard must
+        // make this test FAIL (the call returns Ok instead of Err).
+        //
+        // head_dim=10, partial_rotary_factor=0.3 → rope_dim = (10 * 0.3) as usize = 3 (odd).
+        // apply_partial_rope uses half = rope_dim / 2 = 1, rotating only pair (0,1) and
+        // leaving dim 2 (inside the declared rotate range) silently unrotated — wrong output.
+        let json = r#"{"text_config": {"head_dim": 10, "partial_rotary_factor": 0.3}}"#;
+        let err = Qwen35Config::from_config_json_str(json)
+            .expect_err("odd rope_dim must yield an InferenceError, not silent wrong output")
+            .to_string();
+        assert!(err.contains("rope_dim"), "wrong guard fired: {err}");
+    }
+
+    #[test]
+    fn test_zero_rope_dim_errors_not_panics() {
+        // Mutation contract: removing the `rope_dim < 2 || rope_dim % 2 != 0` guard must
+        // make this test FAIL (the call returns Ok instead of Err).
+        //
+        // partial_rotary_factor=0.0 → rope_dim = 0.  RopeTable::new(0, ..) gives
+        // max_positions()=0, so every non-empty-sequence call to the capacity-guarded APIs
+        // rejects the input rather than applying a no-op — contrary to caller expectations.
+        // Reject fail-closed until a dedicated no-RoPE dispatch path exists (Refs #401).
+        let json = r#"{"text_config": {"partial_rotary_factor": 0.0}}"#;
+        let err = Qwen35Config::from_config_json_str(json)
+            .expect_err("zero rope_dim must yield an InferenceError, not capacity-zero surprise")
+            .to_string();
+        assert!(err.contains("rope_dim"), "wrong guard fired: {err}");
     }
 
     #[test]

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -701,7 +701,9 @@ mod tests {
         cfg.layer_mask = vec![true; cfg.num_hidden_layers];
         cfg.tie_word_embeddings = tied;
         cfg.rms_norm_eps = 1e-6;
-        cfg.partial_rotary_factor = 0.25;
+        // head_dim (4) * partial_rotary_factor must derive an even rope_dim >= 2
+        // (Qwen35Config parse guard, #401); 4 * 0.5 = 2.
+        cfg.partial_rotary_factor = 0.5;
         cfg.rope_theta = 1_000_000.0;
         cfg.max_position_embeddings = 1024;
         cfg.eos_token_id = 3;


### PR DESCRIPTION
## Summary

- `Qwen35Config::from_config_json_str` validated `partial_rotary_factor` ∈ [0.0, 1.0] but never checked the **derived** `rope_dim = (head_dim * partial_rotary_factor) as usize`, admitting two classes of silent misbehaviour.
- **Odd `rope_dim`**: `apply_partial_rope` computes `half = rope_dim / 2` via integer truncation, so only `2*(rope_dim/2)` dims are rotated — one dim inside the declared rotate range is silently left unrotated (wrong output, no error).
- **Zero `rope_dim`**: `RopeTable::new(0, ..)` sets `max_positions() = 0`, causing every non-empty-sequence call to the capacity-guarded APIs to be rejected rather than being a no-op.

Fix: after the existing `head_dim` and `partial_rotary_factor` guards pass, compute `rope_dim` and return a typed `InferenceError` when it is `< 2` or odd. This is the fail-closed interim for the zero case pending an explicit no-RoPE dispatch path (Refs #401). All shipped Qwen3.5/3.6 configs use `rope_dim = 64` (even) and are unaffected.

## What changed

- `/crates/inference/src/model/qwen35_config.rs`: one new guard block in `from_config_json_str` (after the `partial_rotary_factor` check, before the GDN head-count checks).
- Two new mutation-sensitive tests: `test_odd_rope_dim_errors_not_panics` and `test_zero_rope_dim_errors_not_panics`.

## Test plan

- [x] `cargo clippy -p lattice-inference --all-targets -- -D warnings` clean
- [x] `cargo test -p lattice-inference -- qwen35_config` — 38 tests pass (including both new tests)
- [x] Mutation verification: removing the guard causes both new tests to FAIL; restoring causes both to PASS
- [ ] E2E parity gate (CI) — no forward-path code changed; gate is informational for this PR

No benchmark comparison: this change is in config parsing only. No forward-pass, decode, or prefill code was modified.

Refs #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)