### PR TITLE
docs: align stale facts — inference LOC, dep versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ fn similarity(query: &[f32], docs: &[Vec<f32>]) -> Vec<f32> {
 ## Crate Structure
 
 ```
-inference (104K)  fann (6.5K)  transport (5.4K)   ← leaf, zero internal deps
+inference (~112K)  fann (6.5K)  transport (5.4K)   ← leaf, zero internal deps
     |                |
   embed (12K)    tune (15.6K)                     ← depend on leaves only
 ```

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ and can be used standalone.
 
 ```toml
 [dependencies]
-lattice-embed = "0.3"
+lattice-embed = "0.4"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/crates/embed/README.md
+++ b/crates/embed/README.md
@@ -124,8 +124,8 @@ println!("Hit rate: {:.1}%", stats.hit_rate() * 100.0);
 
 ```toml
 [dependencies]
-lattice-embed = { version = "0.3", default-features = false }  # SIMD only
-lattice-embed = { version = "0.3" }  # Full (native + SIMD)
+lattice-embed = { version = "0.4", default-features = false }  # SIMD only
+lattice-embed = { version = "0.4" }  # Full (native + SIMD)
 ```
 
 ## Batch Processing


### PR DESCRIPTION
## Summary

Mechanical doc fixes only — no code, no behavior change. All values measured from the live tree.

## Fix table

| File | Before | After | Measured by |
|------|--------|-------|-------------|
| `AGENTS.md:95` — inference crate size | `104K` | `~112K` | `find crates/inference/src -name '*.rs' \| xargs wc -l` → 111,887 |
| `README.md:100` — embed Quick Start dep | `"0.3"` | `"0.4"` | `[workspace.package].version = "0.4.0"` |
| `crates/embed/README.md:127` — feature-flag example | `version = "0.3"` | `version = "0.4"` | same workspace version |
| `crates/embed/README.md:128` — feature-flag example | `version = "0.3"` | `version = "0.4"` | same workspace version |

Items verified already correct on `main` (no change needed):
- **embed README API types** — `NativeEmbeddingService` and `CachedEmbeddingService` already present; no stale `LocalEmbeddingService`/`PooledEmbeddingService`/`fastembed` symbols. Confirmed against `crates/embed/src/lib.rs` (`pub use service::{CachedEmbeddingService, NativeEmbeddingService}`, `#[cfg(feature = "native")]`).
- **ADR count** — `AGENTS.md:246` already says 63 (`ls docs/adr/ | grep -v INDEX | wc -l` = 63).
- **Parity-gate wording** — `AGENTS.md:220` already says "First 3 greedy tokens must match HF (2 for the long-prefill prompt)" which matches `scripts/e2e_parity_check.py` exactly.
- **MSRV** — `AGENTS.md:185` already says "no MSRV declared; CI pins Rust 1.94.1" (correct).
- **`.gitignore` review artifacts** — `/review*.md` and `/pr_review*.md` rules already present.

## Deferred — needs maintainer decision

Two items from #303 require a judgment call and were left untouched:

1. **`README.md:76` PPL claim** (`"PPL parity confirmed: Lattice 20.60, MLX 20.67 on wikitext-2 (2048 tokens)"`) — `docs/bench_results/perplexity.tsv` shows different numbers (lattice-q4 19.27, mlx-q4 18.18). Options: delete the sentence, replace with the tsv figures, or re-run `eval_perplexity` and commit a fresh artifact. Not touched here because inventing or deleting a factual claim without a backing measurement is not a mechanical fix.

2. **MSRV** — already corrected to "no MSRV declared" in a prior commit; nothing to do here.

## Verification

- `cargo fmt --check` — clean (no Rust files touched)
- `cargo check --workspace` and doc lint ran via pre-commit hook — passed
- embed README symbols grep-verified against `crates/embed/src/lib.rs` before writing

Refs #303