### PR TITLE
fix(inference): dispatch decode_attention with num_kv_heads not num_q_heads

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6628,8 +6628,12 @@ kernel void gdn_chunk_norm_silu_c32(
                         enc.set_bytes(8, 4, &qd as *const u32 as *const _);
                         enc.set_bytes(9, 4, &kvd as *const u32 as *const _);
                         enc.set_bytes(10, 4, &scale as *const f32 as *const _);
+                        // Grid axis = num_kv_heads: the kernel maps gid → kvh and handles
+                        // each GQA group of Q heads internally per threadgroup. Dispatching
+                        // nqh wastes (nqh - nkh) threadgroups that the kernel's early-return
+                        // guard discards; output is bit-identical but scheduling is nkh-sized.
                         enc.dispatch_thread_groups(
-                            MTLSize::new(nqh as u64, 1, 1),
+                            MTLSize::new(nkh as u64, 1, 1),
                             MTLSize::new(256, 1, 1),
                         );
 
@@ -8470,8 +8474,10 @@ kernel void gdn_chunk_norm_silu_c32(
                                 enc.set_bytes(8, 4, &qd as *const u32 as *const _);
                                 enc.set_bytes(9, 4, &kvd as *const u32 as *const _);
                                 enc.set_bytes(10, 4, &scale as *const f32 as *const _);
+                                // Grid axis = num_kv_heads: see fallback site above for
+                                // the invariant. Same kernel, same geometry requirement.
                                 enc.dispatch_thread_groups(
-                                    MTLSize::new(nqh as u64, 1, 1),
+                                    MTLSize::new(nkh as u64, 1, 1),
                                     MTLSize::new(256, 1, 1),
                                 );
                             }


### PR DESCRIPTION
## Summary

Two fallback dispatch sites for `decode_attention` / `decode_attention_f16` were launching `num_q_heads` (nqh) threadgroups where the kernel's grid axis is `num_kv_heads` (nkh).

## Geometry invariant

The `DEFINE_DECODE_ATTENTION` kernel maps grid axis 0 to the **KV-head index** (`kvh = gid`). Each threadgroup processes one KV head and its full GQA group of Q heads internally:

```metal
// Grid: [num_kv_heads, 1, 1].  Threads: [256, 1, 1]
const uint kvh = gid;
if (kvh >= num_kv_heads) return;       // guard for over-dispatched threadgroups
const uint group_size = num_q_heads / num_kv_heads;
```

The kernel guards out-of-range threadgroups with an early `return`, so **output was always correct** — the over-dispatch is a scheduling waste, not a correctness bug.

## Impact

For Qwen3.5-0.8B (16 Q-heads, 2 KV-heads): 14 of 16 threadgroups at each fallback invocation were no-ops — an 8× over-dispatch. The waste scales with the GQA ratio.

## Change

| Site | File / approx line | Before | After |
|------|--------------------|--------|-------|
| Single-token decode fallback | `metal_qwen35.rs` ~L6632 | `MTLSize::new(nqh as u64, 1, 1)` | `MTLSize::new(nkh as u64, 1, 1)` |
| Per-token prefill fallback   | `metal_qwen35.rs` ~L8474 | `MTLSize::new(nqh as u64, 1, 1)` | `MTLSize::new(nkh as u64, 1, 1)` |

Both sites now match the canonical dispatch at L7108 (`MTLSize::new(num_kv_heads as u64, 1, 1)`). A WHY comment at each site documents the grid-axis invariant.

Output is **bit-identical** — only GPU scheduling overhead changes.

## Verification

- `cargo clippy -p lattice-inference --all-targets --features metal-gpu -- -D warnings` — passes clean
- e2e-parity CI (greedy BF16 token agreement vs HF transformers) is the live Metal correctness gate — must clear before merge
- These are fallback paths (active when `dispatch_prefill_attention_batched` fails shape validation), not the flash-decode hot path; adversarial review recommended given live Metal decode scope

## Bench-compare (origin/main `bb470e5e0` vs `1a5c3748d`, `--quick`)

`scripts/bench-compare.sh origin/main fix/issue-391-metal-dispatch-geometry` over the `elementwise_cpu_bench` (inference) and `simd` (embed) groups. **No statistically significant change — every group is p > 0.05.** Representative named groups:

| Group | Δ median | p |
|-------|----------|---|
| rms_norm/896 | +1.38% | 0.13 |
| rms_norm/4096 | +0.94% | 0.13 |
| layer_norm/4096 | +0.02% | 0.90 |
| silu_inplace/4096 | +1.45% | 0.23 |
| gelu/4096 | −0.63% | 0.53 |
| add_bias_gelu/4096 | +1.03% | 0.08 |
| softmax_attention/512 | −0.46% | 0.10 |
| elementwise_mul/4096 | +1.20% | 0.11 |
| simd_normalize/simd/384 | +16.2% | 0.08 |
| simd_normalize/simd/768 | +12.2% | 0.08 |

The large `simd_normalize` deltas are **measurement artifacts, not a regression**, for two independent reasons:

1. **Two-worktree contention.** The HEAD leg benched second, concurrently with other active `cargo` builds on this machine (a code-review run plus a sibling fix agent), inflating HEAD timings. Every group is p > 0.05, including the +12–16% ones (p = 0.08).
2. **The changed code is not in the bench suite.** This PR changes only Metal `decode_attention` dispatch geometry (`num_kv_heads` vs `num_q_heads` threadgroup count). `elementwise_cpu_bench` and `simd` are pure CPU/SIMD routines that never touch the Metal decode path, and the output is bit-identical (the kernel early-returns over-dispatched threadgroups). The real correctness gate for this change is **e2e-parity** token-identity, not these micro-benches.

A clean quiescent rerun (no concurrent builds) is available on request for tighter CIs; it would not change the conclusion, since the changed path is structurally outside these groups.

Closes #391
