### PR TITLE
docs: clarify decode-only slope metric and context falloff

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,37 @@ library from a single window.
 
 ## Benchmarks
 
-Measured on Apple M2 Max, Qwen3.5-0.8B, slope method (token throughput excluding prompt prefill
-and model load). Greedy decoding, median of 5 runs.
+Measured on Apple M2 Max, Qwen3.5-0.8B. Greedy decoding, median of 5 runs.
+
+These are **decode-only** rates: steady-state token generation speed with prompt prefill and
+one-time model load excluded. Per-token decode latency is fit as `t = intercept + slope * ctx`
+across several context lengths (the "slope method") and reported as `1000 / t` at each. `Context`
+is the number of tokens already in the KV cache when the measured token is decoded. The wall-clock
+speed you observe in an interactive chat is lower than these numbers, because it also includes
+prefill of the whole prompt (see "Why throughput falls with context" below).
 
 | Context | Lattice (Q8, f16 head) | Ollama (Q8_0) | MLX (Q8 g64, AMX) | Lattice vs Ollama |
 |---------|------------------------|---------------|-------------------|-------------------|
 | 64 tok  | **187 tok/s**          | 93            | 265               | 2.0x              |
 | 128 tok | **171 tok/s**          | 92            | 263               | 1.9x              |
 | 256 tok | **146 tok/s**          | 88            | 260               | 1.6x              |
+
+### Why throughput falls with context
+
+Decode slows as context grows (187 → 171 → 146 tok/s above) because every generated token attends
+over the entire KV cache:
+
+- The grouped-query attention (GQA) layers do work proportional to context length on each token: the
+  full key/value cache is streamed through memory every step. Decode is memory-bandwidth bound, so
+  per-token latency rises linearly with context (`t ≈ intercept + slope * ctx`) and throughput is its
+  reciprocal.
+- The linear-attention (gated-delta) layers are constant-time in context and do not contribute to the
+  slope.
+
+In an interactive chat this compounds with prompt prefill. The serve path currently re-prefills the
+whole conversation on every turn ([#462](https://github.com/ohdearquant/lattice/issues/462)), a
+separate and larger cost than the decode slope, and the main reason a long chat feels progressively
+slower.
 
 MLX uses Apple's private MPS/AMX matrix engines. Lattice uses the public Metal compute API,
 the same tier as Ollama. MLX decodes faster than Lattice at raw throughput. Lattice's edge is

--- a/scripts/bench_decode_slopefit.py
+++ b/scripts/bench_decode_slopefit.py
@@ -199,6 +199,11 @@ result = {
     "dispatches_per_token": None,
     "command_buffers_per_token": None,
     # Diagnostics (not in ADR spec — informational only).
+    "_metric": (
+        "decode-only tok/s (steady-state generation; prompt prefill and model "
+        "load EXCLUDED). per_tok_ms = intercept + slope*ctx; tok_s = 1000/per_tok_ms. "
+        "Wall-clock chat throughput is lower because it includes prefill."
+    ),
     "_n_ctx_points": len(ctx_vals),
     "_n_raw_repeats": len(all_pairs),
     "_n_boot_samples": len(boot_slopes),


### PR DESCRIPTION
The Benchmarks numbers (187/171/146 tok/s) are **decode-only** slope-method rates with prompt prefill and model load excluded. That was not stated clearly, so they read as inconsistent with the lower wall-clock throughput an interactive chat shows (which includes prefill). This PR makes the metric unambiguous and explains the context dependence.

## README
- Benchmarks intro now states the numbers are decode-only, defines the "slope method" (`t = intercept + slope·ctx`, report `1000/t`), and defines the `Context` column (tokens already in the KV cache).
- New **"Why throughput falls with context"** section: GQA layers do O(ctx) work per token streaming the whole KV cache (memory-bandwidth bound → linear per-token latency); GDN layers are O(1). Notes that interactive chat compounds this with full-conversation prefill each turn and links #462.

## slopefit script
- `bench_decode_slopefit.py` now emits a `_metric` field in its JSON labeling the output as decode-only (prefill excluded), so the number can't be misread as wall-clock.

Docs + one comment-string only. No code paths touched.