### PR TITLE
chore(release): fix publish order for the fann→inference dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Changes to `inference` affect `embed` and `tune`. Changes to `fann` affect `tune
 
 ## Publishing
 
-Leaf crates publish first: inference → fann → transport → (wait 30s) → embed → (wait 30s) → tune. Use `make publish`. Internal path deps' `version =` field must match the current workspace version (bump them in lockstep when bumping `[workspace.package].version`).
+Publish order follows the internal dependency DAG (deps before dependents): fann, transport (leaves) → (wait 30s) → inference (depends on fann via the `mixture` feature) → (wait 30s) → embed, tune. Use `make publish`. Internal path deps' `version =` field must match the current workspace version (bump them in lockstep when bumping `[workspace.package].version`). When a feature adds a new internal dep (e.g. `mixture` made inference depend on fann), the publish order changes — re-derive it from `crates/*/Cargo.toml` path deps, do not assume the old order.
 
 **Shipped-bug recovery (bump-and-yank).** crates.io versions are immutable. When a published release has a correctness bug:
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -11,8 +11,16 @@ else
     FLAG=""
 fi
 
-echo "--- Leaf crates (no internal deps) ---"
-cargo publish -p lattice-inference $FLAG
+# Publish order follows the internal dependency DAG (deps before dependents):
+#   fann, transport   leaves, no internal deps
+#     -> inference     depends on fann (via the `mixture` feature)
+#       -> embed       depends on inference, transport
+#       -> tune        depends on fann, inference
+# Each tier waits for crates.io indexing before the next tier resolves it.
+# (--dry-run validates only the leaf tier: cargo cannot dry-run a crate whose
+#  internal deps are not yet live on the registry.)
+
+echo "--- Tier 1: leaf crates (no internal deps) ---"
 cargo publish -p lattice-fann $FLAG
 cargo publish -p lattice-transport $FLAG
 
@@ -21,14 +29,16 @@ if [ -z "$DRY_RUN" ]; then
     sleep 30
 fi
 
-echo "--- Dependent crates ---"
-cargo publish -p lattice-embed $FLAG
+echo "--- Tier 2: inference (depends on fann) ---"
+cargo publish -p lattice-inference $FLAG
 
 if [ -z "$DRY_RUN" ]; then
     echo "Waiting for crates.io indexing..."
     sleep 30
 fi
 
+echo "--- Tier 3: dependent crates (depend on inference) ---"
+cargo publish -p lattice-embed $FLAG
 cargo publish -p lattice-tune $FLAG
 
 echo "=== Done ==="


### PR DESCRIPTION
The `mixture` feature made `lattice-inference` depend on `lattice-fann` (optional path dep), inverting the publish DAG — fann must publish before inference. `scripts/publish.sh` still published inference first, so `make publish` failed at the first crate (cargo validates every version requirement against the registry, including optional ones).

Reorder to follow the DAG: **fann, transport → inference → embed, tune**, with indexing waits between tiers. Updates the CLAUDE.md publishing note + adds guidance to re-derive the order from crate manifests when a feature adds an internal dep.

Verified: both leaf crates dry-run clean at 0.4.1; the 0.4.1 crates.io publish (all 5 crates) already succeeded with this corrected order. Tooling/docs only — no published crate bytes change.