### PR TITLE
docs(macos): add user-facing install + first-chat guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ Lattice Studio is a native SwiftUI app for macOS 14+. It wraps the Rust engine i
 instrument-panel interface: live loss curves, before/after quantization comparisons,
 LoRA hot-swap in chat, and a model library manager.
 
+> New to the app? [`apps/macos/INSTALL.md`](apps/macos/INSTALL.md) is a step-by-step
+> install, get-a-model, and first-chat guide. The reference below covers building the
+> bundle and what each screen does.
+
 ### Build and package
 
 ```bash

--- a/apps/macos/INSTALL.md
+++ b/apps/macos/INSTALL.md
@@ -1,0 +1,149 @@
+# Installing Lattice Studio
+
+Lattice Studio is a native macOS app for running language models on your own Mac.
+It does chat, embeddings, quantization, and LoRA fine-tuning, all fully offline.
+The app bundles its own inference engine, so once it is installed there is nothing
+else to set up: no Python, no Rust, no command line.
+
+This guide is for people who want to install and use the app. If you want to build
+the distributable bundle for other people (signing, notarization, icons), see
+[`DISTRIBUTION.md`](DISTRIBUTION.md). For the engine, the command-line tools, and
+the HTTP server, see the [main README](../../README.md).
+
+---
+
+## Requirements
+
+- **macOS 14 (Sonoma) or later.**
+- **An Apple Silicon Mac (M1 or later) for chat.** The chat engine runs on the
+  Metal GPU, which is built for Apple Silicon. Intel Macs can run the app but fall
+  back to a slower CPU path that supports fewer model formats.
+- **Disk space for models.** A small chat model is about 1.5 GB; embedding models
+  range from 90 MB to 1.3 GB. Models are stored under `~/.lattice/models`.
+
+---
+
+## 1. Get the app
+
+The app is self-contained: the `.app` bundle carries the engine binaries inside it,
+so a Mac that installs the bundle needs no developer tools. Today there are two ways
+to get that bundle.
+
+### Build it from source (the path that works today)
+
+From a checkout of the repository, with Xcode (Swift 6.3+) and a Rust toolchain
+installed, run:
+
+```bash
+./apps/macos/scripts/package-app.sh
+```
+
+This compiles the Swift app and all engine binaries in release mode and assembles
+`apps/macos/dist/LatticeStudio.app`, along with a `.dmg` and a `.zip`. Any of these
+can be copied to another Mac and will run there without a toolchain.
+
+### Install a `.dmg` someone built
+
+If a developer hands you a `LatticeStudio.dmg` (or you built one with the command
+above), you do not need any developer tools to install it. Open the `.dmg` and go
+to step 2.
+
+> A signed, downloadable build hosted on the GitHub releases page is planned. Until
+> that lands, the two paths above are how you get the app. Hosting a public download
+> involves code-signing and notarization decisions that are still open.
+
+---
+
+## 2. Install and open it
+
+1. Drag **LatticeStudio** from the `.dmg` into your **Applications** folder.
+2. The app is signed with a free ad-hoc certificate, not a paid Apple Developer ID,
+   so the first launch needs one extra step. **Right-click** (or Control-click)
+   **LatticeStudio** in Applications, choose **Open**, then click **Open** in the
+   dialog. macOS remembers this, so every launch after the first is a normal
+   double-click.
+
+   The terminal equivalent of that one-time step is:
+
+   ```bash
+   xattr -dr com.apple.quarantine /Applications/LatticeStudio.app
+   ```
+
+---
+
+## 3. Get your first model
+
+The app opens on the **Models** screen. To add a model, open **Get Models**. There
+are three ways to add one.
+
+### Download an embedding model (one click)
+
+Embedding models power search and similarity. In the download section, pick one (for
+example `bge-small-en-v1.5`, about 130 MB) and click **Download**. The app fetches it,
+verifies its checksum, and shows it as installed.
+
+### Import a chat model from HuggingFace
+
+The generative chat models (the Qwen family) are added by importing a download from
+HuggingFace:
+
+1. In the import section, click **Copy HF URL** next to a model. Start with
+   **qwen3.5-0.8b**, the smallest and fastest.
+2. Download the model files. The app copied a URL like
+   `https://huggingface.co/Qwen/Qwen3.5-0.8B`; the repository id is the part after
+   `huggingface.co/`. Download it with HuggingFace's CLI:
+
+   ```bash
+   pip install -U "huggingface_hub[cli]"
+   huggingface-cli download Qwen/Qwen3.5-0.8B --local-dir qwen3.5-0.8b
+   ```
+
+   or clone it directly (needs `git-lfs`):
+
+   ```bash
+   git clone https://huggingface.co/Qwen/Qwen3.5-0.8B
+   ```
+
+   Use whichever repository the app gave you. The **Copy HF URL** button is the
+   source of truth.
+3. Back in the app, choose **Import from Disk**, then **Import Model**, and select the
+   folder you downloaded. A model folder must contain `config.json` and at least one
+   `.safetensors` file. The app copies it into `~/.lattice/models`.
+
+### Import any model already on disk
+
+If you already have a model folder (a 16-bit model, a Q4-quantized model, or an
+embedding model), use **Import from Disk** directly. The same `config.json` plus
+`.safetensors` rule applies.
+
+---
+
+## 4. Start chatting
+
+1. Open the **Chat** screen.
+2. Pick your model from the selector. Embedding models do not appear here because
+   they do not generate text. On Apple Silicon the GPU path runs both 16-bit and Q4
+   models; the CPU path runs 16-bit models only.
+3. Type a message and send it. The first message loads the model into memory. After
+   that the app keeps the model warm, so follow-up messages skip the reload. The
+   header shows the model and whether it is `warm` or `ready`.
+4. Use the reasoning toggle to turn the model's thinking trace on or off. With it on,
+   the thinking and the final answer are shown separately.
+
+Everything runs on your Mac. Nothing is sent to a server.
+
+---
+
+## Troubleshooting
+
+- **"LatticeStudio can't be opened because Apple cannot check it for malicious
+  software."** This is the ad-hoc-signing prompt from step 2. Right-click the app,
+  choose **Open**, then **Open** again. You only do this once.
+- **A model does not appear in the Chat selector.** Embedding models are excluded
+  from chat; import a generative (Qwen) model instead. On an Intel Mac, Q4 models are
+  also excluded, so import a 16-bit model.
+- **A model fails to import or load.** The folder must contain `config.json` and at
+  least one `.safetensors` file. The app shows the error verbatim, and it usually
+  names the missing file.
+- **Where are my models?** Under `~/.lattice/models`. Delete a folder there to remove
+  a model.


### PR DESCRIPTION
## What

A user-facing install guide for the macOS app: `apps/macos/INSTALL.md`, linked from the README's Lattice Studio section.

## Why

`apps/macos/DISTRIBUTION.md` is maintainer-facing (build / sign / notarize) and the README's macOS section is reference-style. Neither walks a new user from a fresh Mac to a first chat, and neither documents **how to get a generative model** — the import-from-HuggingFace flow that an inference app is useless without.

## Contents

- **Requirements** (macOS 14+, Apple Silicon for chat, disk for models).
- **Get the app**: build from source (the path that works today), or install a `.dmg` someone built (self-contained, no toolchain needed on the target Mac).
- **Install** + the one-time Gatekeeper step (ad-hoc signed → right-click Open, or `xattr -dr`).
- **Get a model**, three ways: one-click embedding download (checksum-verified), import a Qwen chat model from HuggingFace (Copy HF URL → download → Import from Disk), or import any folder already on disk.
- **First chat**: model selector, warm/ready residency, reasoning toggle.
- **Troubleshooting**.

## Flagged decision (not resolved here)

The guide's primary install path is **build-from-source**, because there is no hosted downloadable artifact yet:
- #390 (auto-attach `.dmg`/`.zip` to GitHub releases) is still open.
- A public download needs **code-signing + notarization** (the app is ad-hoc signed today, so Gatekeeper warns).

The guide ships with build-from-source as today's path and keeps the `.dmg`-attach + signing as an open decision, to be made if/when it actually blocks distribution. The doc is written so that swapping in a hosted, signed download later is a small edit (the install steps already cover the `.dmg` case).

## Accuracy notes

- Describes the **shipped (main)** single-mode Chat UX (transcript + composer, model selector, `warm`/`ready` residency, reasoning toggle), not the README's older "side-by-side base vs adapter" wording (that drift is tracked separately in #458).
- GPU path runs bf16 + Q4, CPU path runs bf16 only; reflected in the model-selection and troubleshooting guidance.

Docs-only (2 files, +153). No code paths touched, so no `e2e-parity` trigger. `deno` doc-lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)