### PR TITLE
chore(release): v0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.4.1", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.4.2", path = "../inference", optional = true, features = ["f16"] }
 
 # Time
 chrono = { workspace = true }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -48,7 +48,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.4.1", path = "../fann", optional = true }
+lattice-fann = { version = "0.4.2", path = "../fann", optional = true }
 
 [[bin]]
 name = "lattice"

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -26,7 +26,7 @@ train-backward = ["dep:lattice-inference", "lattice-inference/train-backward", "
 sqlite = ["dep:rusqlite", "serde"]
 
 [dependencies]
-lattice-fann = { version = "0.4.1", path = "../fann" }
+lattice-fann = { version = "0.4.2", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -47,7 +47,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.4.1", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.4.2", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/docs/releases/v0.4.2.md
+++ b/docs/releases/v0.4.2.md
@@ -45,9 +45,12 @@ silently ignored. Decode behavior is otherwise unchanged.
 
 ## Versioning
 
-The workspace version and all internal path-dependency `version =` fields were bumped to `0.4.2`
-in lockstep (`lattice-inference`, `lattice-fann`, `lattice-transport`, `lattice-embed`,
-`lattice-tune`). No change to the `[workspace.package]` edition or MSRV.
+The workspace version was bumped to `0.4.2`, so all five published crates move to `0.4.2` in
+lockstep through `version.workspace = true`: `lattice-inference`, `lattice-fann`,
+`lattice-transport`, `lattice-embed`, and `lattice-tune`. The internal path-dependency
+`version =` constraints were bumped to match, on the two crates that appear as versioned internal
+dependencies (`lattice-inference` and `lattice-fann`). No change to the `[workspace.package]`
+edition or MSRV.
 
 ## Compatibility
 

--- a/docs/releases/v0.4.2.md
+++ b/docs/releases/v0.4.2.md
@@ -1,0 +1,58 @@
+# v0.4.2
+
+Patch release over v0.4.1. The headline is the rebuilt macOS Studio app and the serving surface
+behind it: a user-first Studio with Chat as the home screen, a standalone OpenAI-compatible HTTP
+server, and an engine-side reasoning-token budget that commits a reasoning model to an answer
+after a bounded amount of thinking. The new engine capability is additive and opt-in; with the
+budget unset, decode output is byte-identical to v0.4.1.
+
+## New (additive)
+
+**macOS Studio rebuilt user-first, plus `lattice_serve` and a reasoning-token budget** (#435).
+Three pieces ship together because the app drives the new engine and serve surfaces:
+
+- **Studio app.** The Studio macOS app is reorganized around the user's task rather than the
+  engine internals. Chat is the home screen, and a model sidebar drives Chat, Serve, Quantize,
+  Train, and Inspect. The Serve screen runs the new `lattice_serve` daemon and shows copyable
+  `curl` and Python client snippets for the running endpoint. `apps/macos` is not a published
+  crate and is not versioned with this bump.
+
+- **`lattice_serve` HTTP daemon.** A standalone, OpenAI-compatible HTTP server exposing
+  `POST /v1/chat/completions` (SSE streaming and non-streaming), `GET /v1/models`, and
+  `GET /health`, bound to `127.0.0.1`. Request size fields are clamped to the KV window before
+  allocation, so an oversized request fails cleanly instead of aborting the worker.
+
+- **Reasoning-token budget (engine).** `GenerateConfig` gains a `reasoning_budget:
+  Option<usize>`. When set, the engine injects the `</think>` token once the model has emitted
+  that many thinking tokens, committing a reasoning model to its answer instead of thinking
+  without bound. `None` (and `Some(0)`) disable the feature and leave decode byte-identical to
+  prior output. The budget is honored on both the CPU and Metal decode paths, streaming and
+  non-streaming, and composes with grammar-constrained decoding: a budget-forced `</think>` that
+  the active grammar forbids fails closed to a clean stop rather than a panic.
+
+## Diagnostics
+
+**Inference — fail-loud warning when `LATTICE_MTP` is set but MTP weights are missing** (#441).
+Enabling multi-token-prediction self-speculation via `LATTICE_MTP` when the loaded checkpoint
+carries no MTP weights previously fell back silently to ordinary decode. The loader now emits a
+warning naming the missing weights, so an ineffective `LATTICE_MTP` is visible instead of
+silently ignored. Decode behavior is otherwise unchanged.
+
+## Docs and chores
+
+- Stale per-crate LOC figures and `lattice-embed` version references in the docs were aligned
+  with the current tree (#458).
+
+## Versioning
+
+The workspace version and all internal path-dependency `version =` fields were bumped to `0.4.2`
+in lockstep (`lattice-inference`, `lattice-fann`, `lattice-transport`, `lattice-embed`,
+`lattice-tune`). No change to the `[workspace.package]` edition or MSRV.
+
+## Compatibility
+
+Drop-in over v0.4.1. The reasoning-token budget is opt-in through the new
+`GenerateConfig::reasoning_budget` field; with it unset, every decode path behaves exactly as in
+v0.4.1. `lattice_serve` and the Studio app are new surfaces and change nothing in the existing
+library APIs. No re-quantization or re-indexing is required, and `lattice-embed` forward output
+is unchanged, so existing vector indices remain valid. Existing v0.4.1 callers compile unchanged.


### PR DESCRIPTION
Workspace version bump `0.4.1` → `0.4.2` plus release notes. No source logic changes in this PR — version strings + release notes only.

## Contents (since v0.4.1)

- **Studio user-first redesign + reasoning-budget engine + `lattice_serve` HTTP daemon** (#435) — the macOS Studio app is reorganized around the user's task (Chat is home; a model sidebar drives Chat / Serve / Quantize / Train / Inspect). Adds a standalone OpenAI-compatible HTTP server (`POST /v1/chat/completions` SSE + non-stream, `GET /v1/models`, `GET /health`, bound to `127.0.0.1`) and an opt-in `GenerateConfig::reasoning_budget` that injects `</think>` once the model has emitted a bounded number of thinking tokens. With the budget unset (`None`/`Some(0)`), decode output is byte-identical to v0.4.1.
- **Fail-loud `LATTICE_MTP` warning** (#441) — warn when MTP self-speculation is requested via `LATTICE_MTP` but the loaded checkpoint carries no MTP weights, instead of silently falling back to ordinary decode.
- **Docs alignment** (#458) — stale per-crate LOC figures and `lattice-embed` version references brought in line with the tree.

## Bump

`[workspace.package].version` and all internal path-dependency `version =` fields bumped to `0.4.2` in lockstep (`lattice-inference`, `lattice-fann`, `lattice-transport`, `lattice-embed`, `lattice-tune`). Release notes: `docs/releases/v0.4.2.md`.

Validation: full CI (clippy, tests, e2e-parity) plus an installed-artifact walkthrough of `lattice_serve` and the macOS Studio app before tagging.