### PR TITLE
fix(inference): keep broad string branch reachable in anyOf shared-prefix trie

### DIFF
--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -31,7 +31,7 @@
 
 use crate::grammar::pda::{Alt, CompiledGrammar, GrammarBuilder, Symbol};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 /// Maximum array cardinality (`minItems` / `maxItems`) the compiler will
 /// materialize.
@@ -244,80 +244,77 @@ impl<'a> CompileCtx<'a> {
             .or_else(|| schema.get("oneOf"))
             .and_then(Value::as_array)
         {
-            let mut all_alts: Vec<Alt> = Vec::new();
+            // The no-rewind PDA commits to an alternative once it consumes a
+            // byte (the #353/#380 consumed-guard), so every branch that can
+            // begin with `"` competes for the single opening quote: once one of
+            // them consumes it, the siblings become unreachable. Every JSON
+            // string shares that opening `"`, so listing string-valued branches
+            // separately strands all but the first (issue #310 — the
+            // over-rejection regression fixed here). Collapse the whole
+            // string-valued class into ONE branch with a single `"` entry:
+            //
+            //   * any broad string (`{"type":"string"}`; also `pattern` /
+            //     `minLength`, which this compiler does not enforce and so
+            //     widens to any string) makes the class the `json_string` rule.
+            //     It subsumes every string literal, so a valid string is never
+            //     rejected and the literals need no separate branch.
+            //   * otherwise the string literals (`const` / all-string `enum`)
+            //     become a single trie so each diverges inside the quoted region
+            //     instead of competing at the shared opening quote.
+            //
+            // Non-string branches (numbers, booleans, null, objects, arrays)
+            // never begin with `"`, so they follow the string entry in their
+            // original relative order and stay reachable: a non-`"` input
+            // diverges from the string entry at sym_pos == 0 and the PDA falls
+            // through. A non-string sibling that could ITSELF begin with `"` (a
+            // `$ref`, nested `anyOf`, untyped or mixed-type schema) is left among
+            // them; the string entry shadows its quoted inputs, which
+            // `json_string` / the literal trie already decide correctly. The
+            // residual narrowing for such a sibling matches the pre-existing
+            // numeric-enum limitation below and never over-accepts.
+            let mut broad_string = false;
+            let mut literals: Vec<String> = Vec::new();
+            let mut other_subs: Vec<&Value> = Vec::new();
             for sub in any_of {
-                let sub_alts = self.compile_schema(sub, _path)?;
-                all_alts.extend(sub_alts);
+                match string_class_of(sub) {
+                    Some(StrClass::Broad) => broad_string = true,
+                    Some(StrClass::Literals(values)) => literals.extend(values),
+                    None => other_subs.push(sub),
+                }
             }
 
-            // A fully-quoted string-literal alternative is one whose every
-            // symbol is a Terminal, opening and closing with `"` (e.g. a string
-            // `const`). Two or more such alternatives may share a byte prefix
-            // and be over-rejected by the no-rewind PDA, so we factor them into
-            // a trie where every branch diverges at sym_pos == 0.
-            //
-            // The trie alternative begins with `"`, and is only safe to hoist
-            // ahead of the others when NONE of them can also begin with `"`:
-            // the no-rewind PDA cannot fall through to a later sibling once the
-            // trie consumes the opening quote. A broad `{"type":"string"}`
-            // branch compiles to `[NonTerminal(json_string)]`, whose FIRST set
-            // contains `"`, so in its presence we keep the original flat order
-            // (the broad branch already subsumes the string consts).
-            //
-            // Scope: quoted string literals only.  Non-string literal alts
-            // (numbers, booleans, null) have distinct first bytes and are left
-            // flat.  Numeric enums with a shared prefix (e.g. `const 1` /
-            // `const 10`) are an unquoted narrower residual that requires the
-            // delimiter from the surrounding grammar context to disambiguate and
-            // cannot be fixed locally by a trie.
-            let is_string_lit = |alt: &Alt| {
-                alt.len() >= 2
-                    && matches!(alt.first(), Some(Symbol::Terminal(b'"')))
-                    && matches!(alt.last(), Some(Symbol::Terminal(b'"')))
-                    && alt.iter().all(|sym| matches!(sym, Symbol::Terminal(_)))
-            };
-            let lit_count = all_alts.iter().filter(|alt| is_string_lit(alt)).count();
-            let mut memo: HashMap<usize, bool> = HashMap::new();
-            let mut on_stack: HashSet<usize> = HashSet::new();
-            let other_can_start_with_quote =
-                all_alts
-                    .iter()
-                    .filter(|alt| !is_string_lit(alt))
-                    .any(|alt| {
-                        alt.first().is_some_and(|first| {
-                            first_byte_can_be_quote(&self.builder, first, &mut memo, &mut on_stack)
-                        })
-                    });
-
-            if lit_count >= 2 && !other_can_start_with_quote {
-                let (string_lit_alts, other_alts): (Vec<Alt>, Vec<Alt>) =
-                    all_alts.into_iter().partition(|alt| is_string_lit(alt));
-                // Full quoted JSON strings are inherently prefix-free once their
-                // closing `"` is included — no extra terminator needed here.
-                let seqs: Vec<Vec<u8>> = string_lit_alts
-                    .into_iter()
-                    .map(|alt| {
-                        alt.into_iter()
-                            .filter_map(|sym| {
-                                if let Symbol::Terminal(b) = sym {
-                                    Some(b)
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect()
-                    })
-                    .collect();
+            let mut merged: Vec<Alt> = Vec::new();
+            if broad_string {
+                match self.builder.rule_id("json_string") {
+                    Some(id) => merged.push(vec![Symbol::NonTerminal(id)]),
+                    None => merged.push(vec![Symbol::Terminal(b'"'), Symbol::Terminal(b'"')]),
+                }
+            } else if !literals.is_empty() {
+                // Distinct JSON strings are prefix-free once the closing `"` is
+                // part of each leaf, so every literal diverges within the trie.
+                literals.sort();
+                literals.dedup();
+                let mut seqs: Vec<Vec<u8>> = Vec::with_capacity(literals.len());
+                for s in &literals {
+                    let json_repr = serde_json::to_string(s).map_err(|e| {
+                        SchemaError(format!("cannot JSON-encode string value: {e}"))
+                    })?;
+                    // json_repr is e.g. `"a\"b"` — strip the surrounding `"`.
+                    let inner = &json_repr[1..json_repr.len() - 1];
+                    let mut seq: Vec<u8> = inner.bytes().collect();
+                    seq.push(b'"');
+                    seqs.push(seq);
+                }
                 let trie_root_id = self.compile_trie_literals(&seqs)?;
-                let mut combined = vec![vec![Symbol::NonTerminal(trie_root_id)]];
-                combined.extend(other_alts);
-                return Ok(combined);
+                merged.push(vec![
+                    Symbol::Terminal(b'"'),
+                    Symbol::NonTerminal(trie_root_id),
+                ]);
             }
-
-            // Not trie-eligible (fewer than two shared string literals, or a
-            // sibling can also begin with `"`): keep the alternatives in their
-            // original schema order so a broad string branch stays reachable.
-            return Ok(all_alts);
+            for sub in other_subs {
+                merged.extend(self.compile_schema(sub, _path)?);
+            }
+            return Ok(merged);
         }
 
         // Dispatch on `type`
@@ -1477,55 +1474,6 @@ fn build_trie_node(
 /// the surrounding context resolves them.  Until then, `enum [1, 10]` remains
 /// a narrower known limitation: `10` is over-rejected by the no-rewind PDA
 /// (the same safe direction as before).
-/// Whether any value matched by `sym` can begin with a `"` byte (its FIRST set
-/// contains the opening quote of a JSON string).
-///
-/// Used by the `anyOf`/`oneOf` handler to decide whether a shared-prefix
-/// string-literal trie can be safely hoisted ahead of the other alternatives.
-/// The no-rewind PDA commits to an alternative once it consumes a byte, so a
-/// trie placed before a sibling that also begins with `"` (e.g. a broad
-/// `{"type":"string"}` branch, which compiles to `[NonTerminal(json_string)]`)
-/// would make that sibling unreachable. When this returns true for any such
-/// sibling, the caller keeps the alternatives flat in their original order.
-///
-/// Sound in the safe direction: an unknown rule or a reference cycle yields
-/// `true` (suppress the trie), which can only cost the optimization, never
-/// reintroduce over-rejection. Memoized per rule id for linear time over the
-/// rule graph (the compiler is reachable from untrusted schemas).
-fn first_byte_can_be_quote(
-    builder: &GrammarBuilder,
-    sym: &Symbol,
-    memo: &mut HashMap<usize, bool>,
-    on_stack: &mut HashSet<usize>,
-) -> bool {
-    match sym {
-        Symbol::Terminal(b) => *b == b'"',
-        // `AnyByte` (GBNF `.`) matches any byte, `"` included.
-        Symbol::AnyByte => true,
-        Symbol::NonTerminal(id) => {
-            if let Some(&cached) = memo.get(id) {
-                return cached;
-            }
-            if !on_stack.insert(*id) {
-                // Active cycle: assume reachable (conservative) without caching,
-                // since the exact value is still being computed up the stack.
-                return true;
-            }
-            let result = match builder.rule_alts(*id) {
-                Some(alts) => alts.iter().any(|alt| {
-                    alt.first().is_some_and(|first| {
-                        first_byte_can_be_quote(builder, first, memo, on_stack)
-                    })
-                }),
-                None => true,
-            };
-            on_stack.remove(id);
-            memo.insert(*id, result);
-            result
-        }
-    }
-}
-
 fn compile_enum(values: &[Value]) -> Result<Vec<Alt>, SchemaError> {
     // All-string enums are handled upstream via compile_string_type, which
     // trie-compiles the alternatives to avoid PDA ambiguity.  This path is
@@ -1542,6 +1490,50 @@ fn compile_enum(values: &[Value]) -> Result<Vec<Alt>, SchemaError> {
 /// Compile a `const` schema (a single fixed JSON value).
 fn compile_const(v: &Value) -> Result<Vec<Alt>, SchemaError> {
     Ok(vec![json_value_to_alt(v)?])
+}
+
+/// How an `anyOf`/`oneOf` sub-schema matches strings, for collapsing the
+/// string-valued ambiguity class into a single `"` entry (see the `anyOf`
+/// handler). A sub-schema that is not a string-valued class — a number,
+/// boolean, null, object, array, or a schema whose string matching cannot be
+/// reduced to a broad string or a fixed literal set (mixed `enum`, `$ref`,
+/// nested `anyOf`, untyped) — classifies as `None`.
+enum StrClass {
+    /// Any JSON string (`{"type":"string"}`). `pattern` / `minLength` are not
+    /// enforced by this compiler, so such a schema widens to any string — the
+    /// same `json_string` rule `compile_string_type` emits for it standalone.
+    Broad,
+    /// A fixed set of string values (a string `const` or an all-string `enum`).
+    Literals(Vec<String>),
+}
+
+/// Classify a raw `anyOf`/`oneOf` sub-schema for string-class merging.
+fn string_class_of(sub: &Value) -> Option<StrClass> {
+    let obj = sub.as_object()?;
+    if let Some(Value::String(s)) = obj.get("const") {
+        return Some(StrClass::Literals(vec![s.clone()]));
+    }
+    let ty = obj.get("type").and_then(Value::as_str);
+    if let Some(arr) = obj.get("enum").and_then(Value::as_array) {
+        // An all-string `enum` is a literal set only when the (optional) `type`
+        // does not contradict it. A mixed enum may match non-string values too,
+        // so it stays unclassified and the caller keeps it as an "other" branch.
+        if (ty == Some("string") || ty.is_none())
+            && !arr.is_empty()
+            && arr.iter().all(Value::is_string)
+        {
+            let values = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            return Some(StrClass::Literals(values));
+        }
+        return None;
+    }
+    if ty == Some("string") {
+        return Some(StrClass::Broad);
+    }
+    None
 }
 
 /// Convert a concrete JSON value to a grammar alternative (sequence of terminal bytes).
@@ -1821,11 +1813,12 @@ mod tests {
 
     /// Regression: a broad `{"type":"string"}` branch alongside shared-prefix
     /// string consts must stay reachable. The broad branch compiles to
-    /// `[NonTerminal(json_string)]`, whose FIRST set contains `"`; hoisting a
-    /// const trie ahead of it made the no-rewind PDA consume the opening quote
-    /// and then fail to fall through, wrongly rejecting an arbitrary string such
-    /// as `"zzz"`. Mutation guard: removing the FIRST-set guard reintroduces the
-    /// over-rejection and fails this test.
+    /// `[NonTerminal(json_string)]`, whose FIRST set contains `"`; #471's
+    /// unconditional const-trie hoist made the no-rewind PDA consume the opening
+    /// quote and then fail to fall through, wrongly rejecting an arbitrary string
+    /// such as `"zzz"`. A present broad string collapses the whole string class
+    /// to `json_string`, which subsumes the consts. Mutation guard: reverting to
+    /// the unconditional hoist reintroduces the over-rejection and fails here.
     #[test]
     fn anyof_broad_string_with_shared_prefix_consts() {
         let g = compile_ok(r#"{"anyOf":[{"type":"string"},{"const":"abc"},{"const":"abd"}]}"#);
@@ -1840,9 +1833,9 @@ mod tests {
 
     /// A non-string sibling that cannot begin with `"` (here `integer`) does not
     /// block the shared-prefix trie: `"abc"`/`"abd"` are disambiguated by the
-    /// trie and the integer branch remains reachable. Mutation guard against
-    /// over-correcting the FIRST-set guard to disable the trie whenever any
-    /// non-literal sibling is present — the flat fallback over-rejects `"abd"`.
+    /// combined trie and the integer branch stays reachable (a non-`"` input
+    /// diverges from the trie at sym_pos == 0). Mutation guard: emitting the
+    /// branches flat instead of one trie over-rejects `"abd"`.
     #[test]
     fn anyof_shared_prefix_consts_with_integer() {
         let g = compile_ok(r#"{"anyOf":[{"const":"abc"},{"const":"abd"},{"type":"integer"}]}"#);
@@ -1855,6 +1848,78 @@ mod tests {
             accepts(&g, b"123"),
             "the integer branch must remain reachable"
         );
+        assert!(
+            rejects(&g, b"\"abe\""),
+            "a non-member string must be rejected"
+        );
+    }
+
+    /// Broad string LAST (issue #310 / PR #472): the broad `{"type":"string"}`
+    /// is listed AFTER the shared-prefix consts, so schema order cannot be
+    /// relied on to keep it reachable. Classifying the whole string class up
+    /// front and collapsing it to `json_string` makes position irrelevant — an
+    /// arbitrary string that diverges from the consts (`"abe"`) is still
+    /// accepted. Mutation guard: an order-sensitive fix (hoisting the const trie
+    /// whenever the broad branch is not first) over-rejects `"abe"` here.
+    #[test]
+    fn anyof_broad_string_after_consts() {
+        let g = compile_ok(r#"{"anyOf":[{"const":"abc"},{"const":"abd"},{"type":"string"}]}"#);
+        assert!(
+            accepts(&g, b"\"abe\""),
+            "broad string (listed last) must accept a string that diverges from the consts"
+        );
+        assert!(accepts(&g, b"\"zzz\""), "arbitrary string must be accepted");
+        assert!(accepts(&g, b"\"abc\""), "\"abc\" must be accepted");
+        assert!(accepts(&g, b"\"abd\""), "\"abd\" must be accepted");
+        assert!(rejects(&g, b"123"), "a non-string must still be rejected");
+    }
+
+    /// A narrower string sibling — a string `enum` rather than a broad string —
+    /// alongside shared-prefix consts (issue #310 / PR #472). With no broad
+    /// branch present, every string literal (the two consts and the two enum
+    /// members) is unioned into ONE trie, so all four diverge inside the quoted
+    /// region and stay reachable. Mutation guard: keeping the branches flat (or
+    /// hoisting only the consts) over-rejects `"abd"`; widening the class to
+    /// `json_string` would over-accept `"abg"`.
+    #[test]
+    fn anyof_narrower_string_enum_sibling() {
+        let g = compile_ok(
+            r#"{"anyOf":[{"const":"abc"},{"const":"abd"},{"type":"string","enum":["abe","abf"]}]}"#,
+        );
+        assert!(accepts(&g, b"\"abc\""), "const \"abc\" must be accepted");
+        assert!(
+            accepts(&g, b"\"abd\""),
+            "const \"abd\" must be accepted via the combined trie"
+        );
+        assert!(
+            accepts(&g, b"\"abe\""),
+            "enum member \"abe\" must be accepted"
+        );
+        assert!(
+            accepts(&g, b"\"abf\""),
+            "enum member \"abf\" must be accepted"
+        );
+        assert!(
+            rejects(&g, b"\"abg\""),
+            "a string in no branch must be rejected (no over-accept)"
+        );
+    }
+
+    /// A non-string `enum` sibling (`[1, 2]`) must classify as a non-string
+    /// branch, not fold into the string literal trie (issue #310 / PR #472).
+    /// The consts form the trie; the numeric enum stays reachable because it
+    /// cannot begin with `"`. Mutation guard: misclassifying the numeric enum as
+    /// a string literal set drops the `1`/`2` branch; keeping the branches flat
+    /// over-rejects `"abd"`.
+    #[test]
+    fn anyof_numeric_enum_sibling() {
+        let g = compile_ok(r#"{"anyOf":[{"const":"abc"},{"const":"abd"},{"enum":[1,2]}]}"#);
+        assert!(
+            accepts(&g, b"\"abd\""),
+            "\"abd\" must be accepted via the trie"
+        );
+        assert!(accepts(&g, b"1"), "numeric enum member 1 must be reachable");
+        assert!(accepts(&g, b"2"), "numeric enum member 2 must be reachable");
         assert!(
             rejects(&g, b"\"abe\""),
             "a non-member string must be rejected"

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -210,6 +210,88 @@ impl<'a> CompileCtx<'a> {
         result
     }
 
+    /// Lower an `anyOf` / `oneOf` to a list of alternatives.
+    ///
+    /// The no-rewind PDA commits to an alternative once it consumes a byte (the
+    /// #353/#380 consumed-guard), so every branch that can begin with `"`
+    /// competes for the single opening quote: once one of them consumes it, the
+    /// siblings become unreachable. Every JSON string shares that opening `"`,
+    /// so listing string-valued branches separately strands all but the first
+    /// (issue #310 — the over-rejection regression fixed here). Collapse the
+    /// whole string-valued class into ONE branch with a single `"` entry:
+    ///
+    ///   * any broad string (`{"type":"string"}`; also `pattern` / `minLength`,
+    ///     which this compiler does not enforce and so widens to any string)
+    ///     makes the class the `json_string` rule. It subsumes every string
+    ///     literal, so a valid string is never rejected and the literals need no
+    ///     separate branch.
+    ///   * otherwise the string literals (`const` / all-string `enum`) become a
+    ///     single trie so each diverges inside the quoted region instead of
+    ///     competing at the shared opening quote.
+    ///
+    /// Non-string branches (numbers, booleans, null, objects, arrays) never
+    /// begin with `"`, so they follow the string entry in their original
+    /// relative order and stay reachable: a non-`"` input diverges from the
+    /// string entry at sym_pos == 0 and the PDA falls through. A non-string
+    /// sibling that could ITSELF begin with `"` (a `$ref`, nested `anyOf`,
+    /// untyped or mixed-type schema) is left among them; the string entry
+    /// shadows its quoted inputs, which `json_string` / the literal trie already
+    /// decide correctly. The residual narrowing for such a sibling matches the
+    /// pre-existing numeric-enum limitation and never over-accepts.
+    ///
+    /// Kept `#[inline(never)]` and out of `compile_schema_inner` so these locals
+    /// do not enlarge that function's per-recursion stack frame (see the call
+    /// site: a deep `$ref` chain must hit the depth guard, not the native stack).
+    #[inline(never)]
+    fn compile_any_of(
+        &mut self,
+        any_of: &'a [Value],
+        path: &[&str],
+    ) -> Result<Vec<Alt>, SchemaError> {
+        let mut broad_string = false;
+        let mut literals: Vec<String> = Vec::new();
+        let mut other_subs: Vec<&'a Value> = Vec::new();
+        for sub in any_of {
+            match string_class_of(sub) {
+                Some(StrClass::Broad) => broad_string = true,
+                Some(StrClass::Literals(values)) => literals.extend(values),
+                None => other_subs.push(sub),
+            }
+        }
+
+        let mut merged: Vec<Alt> = Vec::new();
+        if broad_string {
+            match self.builder.rule_id("json_string") {
+                Some(id) => merged.push(vec![Symbol::NonTerminal(id)]),
+                None => merged.push(vec![Symbol::Terminal(b'"'), Symbol::Terminal(b'"')]),
+            }
+        } else if !literals.is_empty() {
+            // Distinct JSON strings are prefix-free once the closing `"` is part
+            // of each leaf, so every literal diverges within the trie.
+            literals.sort();
+            literals.dedup();
+            let mut seqs: Vec<Vec<u8>> = Vec::with_capacity(literals.len());
+            for s in &literals {
+                let json_repr = serde_json::to_string(s)
+                    .map_err(|e| SchemaError(format!("cannot JSON-encode string value: {e}")))?;
+                // json_repr is e.g. `"a\"b"` — strip the surrounding `"`.
+                let inner = &json_repr[1..json_repr.len() - 1];
+                let mut seq: Vec<u8> = inner.bytes().collect();
+                seq.push(b'"');
+                seqs.push(seq);
+            }
+            let trie_root_id = self.compile_trie_literals(&seqs)?;
+            merged.push(vec![
+                Symbol::Terminal(b'"'),
+                Symbol::NonTerminal(trie_root_id),
+            ]);
+        }
+        for sub in other_subs {
+            merged.extend(self.compile_schema(sub, path)?);
+        }
+        Ok(merged)
+    }
+
     fn compile_schema_inner(
         &mut self,
         schema: &'a Value,
@@ -238,83 +320,19 @@ impl<'a> CompileCtx<'a> {
             return compile_const(v);
         }
 
-        // Handle `anyOf` / `oneOf`
+        // Handle `anyOf` / `oneOf`. The body lives in a separate, non-inlined
+        // method (see `compile_any_of`) so its locals do not enlarge this
+        // function's stack frame: a deep `$ref` chain re-enters
+        // `compile_schema_inner` at every link, and the depth guard (#343) must
+        // reject at MAX_SCHEMA_DEPTH before the native stack overflows. Folding
+        // the anyOf locals in here regressed that headroom (a 2000-link chain
+        // overflowed instead of returning the depth error).
         if let Some(any_of) = schema
             .get("anyOf")
             .or_else(|| schema.get("oneOf"))
             .and_then(Value::as_array)
         {
-            // The no-rewind PDA commits to an alternative once it consumes a
-            // byte (the #353/#380 consumed-guard), so every branch that can
-            // begin with `"` competes for the single opening quote: once one of
-            // them consumes it, the siblings become unreachable. Every JSON
-            // string shares that opening `"`, so listing string-valued branches
-            // separately strands all but the first (issue #310 — the
-            // over-rejection regression fixed here). Collapse the whole
-            // string-valued class into ONE branch with a single `"` entry:
-            //
-            //   * any broad string (`{"type":"string"}`; also `pattern` /
-            //     `minLength`, which this compiler does not enforce and so
-            //     widens to any string) makes the class the `json_string` rule.
-            //     It subsumes every string literal, so a valid string is never
-            //     rejected and the literals need no separate branch.
-            //   * otherwise the string literals (`const` / all-string `enum`)
-            //     become a single trie so each diverges inside the quoted region
-            //     instead of competing at the shared opening quote.
-            //
-            // Non-string branches (numbers, booleans, null, objects, arrays)
-            // never begin with `"`, so they follow the string entry in their
-            // original relative order and stay reachable: a non-`"` input
-            // diverges from the string entry at sym_pos == 0 and the PDA falls
-            // through. A non-string sibling that could ITSELF begin with `"` (a
-            // `$ref`, nested `anyOf`, untyped or mixed-type schema) is left among
-            // them; the string entry shadows its quoted inputs, which
-            // `json_string` / the literal trie already decide correctly. The
-            // residual narrowing for such a sibling matches the pre-existing
-            // numeric-enum limitation below and never over-accepts.
-            let mut broad_string = false;
-            let mut literals: Vec<String> = Vec::new();
-            let mut other_subs: Vec<&Value> = Vec::new();
-            for sub in any_of {
-                match string_class_of(sub) {
-                    Some(StrClass::Broad) => broad_string = true,
-                    Some(StrClass::Literals(values)) => literals.extend(values),
-                    None => other_subs.push(sub),
-                }
-            }
-
-            let mut merged: Vec<Alt> = Vec::new();
-            if broad_string {
-                match self.builder.rule_id("json_string") {
-                    Some(id) => merged.push(vec![Symbol::NonTerminal(id)]),
-                    None => merged.push(vec![Symbol::Terminal(b'"'), Symbol::Terminal(b'"')]),
-                }
-            } else if !literals.is_empty() {
-                // Distinct JSON strings are prefix-free once the closing `"` is
-                // part of each leaf, so every literal diverges within the trie.
-                literals.sort();
-                literals.dedup();
-                let mut seqs: Vec<Vec<u8>> = Vec::with_capacity(literals.len());
-                for s in &literals {
-                    let json_repr = serde_json::to_string(s).map_err(|e| {
-                        SchemaError(format!("cannot JSON-encode string value: {e}"))
-                    })?;
-                    // json_repr is e.g. `"a\"b"` — strip the surrounding `"`.
-                    let inner = &json_repr[1..json_repr.len() - 1];
-                    let mut seq: Vec<u8> = inner.bytes().collect();
-                    seq.push(b'"');
-                    seqs.push(seq);
-                }
-                let trie_root_id = self.compile_trie_literals(&seqs)?;
-                merged.push(vec![
-                    Symbol::Terminal(b'"'),
-                    Symbol::NonTerminal(trie_root_id),
-                ]);
-            }
-            for sub in other_subs {
-                merged.extend(self.compile_schema(sub, _path)?);
-            }
-            return Ok(merged);
+            return self.compile_any_of(any_of, _path);
         }
 
         // Dispatch on `type`

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -31,7 +31,7 @@
 
 use crate::grammar::pda::{Alt, CompiledGrammar, GrammarBuilder, Symbol};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Maximum array cardinality (`minItems` / `maxItems`) the compiler will
 /// materialize.
@@ -250,27 +250,48 @@ impl<'a> CompileCtx<'a> {
                 all_alts.extend(sub_alts);
             }
 
-            // Partition: separate fully-quoted string-literal alternatives
-            // (every symbol is Terminal, first byte is `"`, last byte is `"`)
-            // from all other alternatives.  Two or more such alternatives may
-            // share a byte prefix and be over-rejected by the no-rewind PDA.
-            // Build a trie over them so every branch diverges at sym_pos == 0.
+            // A fully-quoted string-literal alternative is one whose every
+            // symbol is a Terminal, opening and closing with `"` (e.g. a string
+            // `const`). Two or more such alternatives may share a byte prefix
+            // and be over-rejected by the no-rewind PDA, so we factor them into
+            // a trie where every branch diverges at sym_pos == 0.
+            //
+            // The trie alternative begins with `"`, and is only safe to hoist
+            // ahead of the others when NONE of them can also begin with `"`:
+            // the no-rewind PDA cannot fall through to a later sibling once the
+            // trie consumes the opening quote. A broad `{"type":"string"}`
+            // branch compiles to `[NonTerminal(json_string)]`, whose FIRST set
+            // contains `"`, so in its presence we keep the original flat order
+            // (the broad branch already subsumes the string consts).
             //
             // Scope: quoted string literals only.  Non-string literal alts
-            // (numbers, booleans, null) have distinct first bytes in practice
-            // and are left flat.  Numeric enums with a shared prefix (e.g.
-            // `const 1` / `const 10`) are an unquoted narrower residual that
-            // requires the delimiter from the surrounding grammar context to
-            // disambiguate and cannot be fixed locally by a trie.
-            let (string_lit_alts, other_alts): (Vec<Alt>, Vec<Alt>) =
-                all_alts.into_iter().partition(|alt| {
-                    alt.len() >= 2
-                        && matches!(alt.first(), Some(Symbol::Terminal(b'"')))
-                        && matches!(alt.last(), Some(Symbol::Terminal(b'"')))
-                        && alt.iter().all(|sym| matches!(sym, Symbol::Terminal(_)))
-                });
+            // (numbers, booleans, null) have distinct first bytes and are left
+            // flat.  Numeric enums with a shared prefix (e.g. `const 1` /
+            // `const 10`) are an unquoted narrower residual that requires the
+            // delimiter from the surrounding grammar context to disambiguate and
+            // cannot be fixed locally by a trie.
+            let is_string_lit = |alt: &Alt| {
+                alt.len() >= 2
+                    && matches!(alt.first(), Some(Symbol::Terminal(b'"')))
+                    && matches!(alt.last(), Some(Symbol::Terminal(b'"')))
+                    && alt.iter().all(|sym| matches!(sym, Symbol::Terminal(_)))
+            };
+            let lit_count = all_alts.iter().filter(|alt| is_string_lit(alt)).count();
+            let mut memo: HashMap<usize, bool> = HashMap::new();
+            let mut on_stack: HashSet<usize> = HashSet::new();
+            let other_can_start_with_quote =
+                all_alts
+                    .iter()
+                    .filter(|alt| !is_string_lit(alt))
+                    .any(|alt| {
+                        alt.first().is_some_and(|first| {
+                            first_byte_can_be_quote(&self.builder, first, &mut memo, &mut on_stack)
+                        })
+                    });
 
-            if string_lit_alts.len() >= 2 {
+            if lit_count >= 2 && !other_can_start_with_quote {
+                let (string_lit_alts, other_alts): (Vec<Alt>, Vec<Alt>) =
+                    all_alts.into_iter().partition(|alt| is_string_lit(alt));
                 // Full quoted JSON strings are inherently prefix-free once their
                 // closing `"` is included — no extra terminator needed here.
                 let seqs: Vec<Vec<u8>> = string_lit_alts
@@ -293,10 +314,10 @@ impl<'a> CompileCtx<'a> {
                 return Ok(combined);
             }
 
-            // Fewer than 2 string-literal alts: flatten as before (no trie needed).
-            let mut combined = string_lit_alts;
-            combined.extend(other_alts);
-            return Ok(combined);
+            // Not trie-eligible (fewer than two shared string literals, or a
+            // sibling can also begin with `"`): keep the alternatives in their
+            // original schema order so a broad string branch stays reachable.
+            return Ok(all_alts);
         }
 
         // Dispatch on `type`
@@ -1456,6 +1477,55 @@ fn build_trie_node(
 /// the surrounding context resolves them.  Until then, `enum [1, 10]` remains
 /// a narrower known limitation: `10` is over-rejected by the no-rewind PDA
 /// (the same safe direction as before).
+/// Whether any value matched by `sym` can begin with a `"` byte (its FIRST set
+/// contains the opening quote of a JSON string).
+///
+/// Used by the `anyOf`/`oneOf` handler to decide whether a shared-prefix
+/// string-literal trie can be safely hoisted ahead of the other alternatives.
+/// The no-rewind PDA commits to an alternative once it consumes a byte, so a
+/// trie placed before a sibling that also begins with `"` (e.g. a broad
+/// `{"type":"string"}` branch, which compiles to `[NonTerminal(json_string)]`)
+/// would make that sibling unreachable. When this returns true for any such
+/// sibling, the caller keeps the alternatives flat in their original order.
+///
+/// Sound in the safe direction: an unknown rule or a reference cycle yields
+/// `true` (suppress the trie), which can only cost the optimization, never
+/// reintroduce over-rejection. Memoized per rule id for linear time over the
+/// rule graph (the compiler is reachable from untrusted schemas).
+fn first_byte_can_be_quote(
+    builder: &GrammarBuilder,
+    sym: &Symbol,
+    memo: &mut HashMap<usize, bool>,
+    on_stack: &mut HashSet<usize>,
+) -> bool {
+    match sym {
+        Symbol::Terminal(b) => *b == b'"',
+        // `AnyByte` (GBNF `.`) matches any byte, `"` included.
+        Symbol::AnyByte => true,
+        Symbol::NonTerminal(id) => {
+            if let Some(&cached) = memo.get(id) {
+                return cached;
+            }
+            if !on_stack.insert(*id) {
+                // Active cycle: assume reachable (conservative) without caching,
+                // since the exact value is still being computed up the stack.
+                return true;
+            }
+            let result = match builder.rule_alts(*id) {
+                Some(alts) => alts.iter().any(|alt| {
+                    alt.first().is_some_and(|first| {
+                        first_byte_can_be_quote(builder, first, memo, on_stack)
+                    })
+                }),
+                None => true,
+            };
+            on_stack.remove(id);
+            memo.insert(*id, result);
+            result
+        }
+    }
+}
+
 fn compile_enum(values: &[Value]) -> Result<Vec<Alt>, SchemaError> {
     // All-string enums are handled upstream via compile_string_type, which
     // trie-compiles the alternatives to avoid PDA ambiguity.  This path is
@@ -1747,6 +1817,48 @@ mod tests {
         assert!(rejects(&g, b"\"abe\""), "\"abe\" must be rejected");
         assert!(rejects(&g, b"\"ab\""), "\"ab\" must be rejected");
         assert!(rejects(&g, b"\"abcd\""), "\"abcd\" must be rejected");
+    }
+
+    /// Regression: a broad `{"type":"string"}` branch alongside shared-prefix
+    /// string consts must stay reachable. The broad branch compiles to
+    /// `[NonTerminal(json_string)]`, whose FIRST set contains `"`; hoisting a
+    /// const trie ahead of it made the no-rewind PDA consume the opening quote
+    /// and then fail to fall through, wrongly rejecting an arbitrary string such
+    /// as `"zzz"`. Mutation guard: removing the FIRST-set guard reintroduces the
+    /// over-rejection and fails this test.
+    #[test]
+    fn anyof_broad_string_with_shared_prefix_consts() {
+        let g = compile_ok(r#"{"anyOf":[{"type":"string"},{"const":"abc"},{"const":"abd"}]}"#);
+        assert!(
+            accepts(&g, b"\"zzz\""),
+            "broad string branch must accept an arbitrary string"
+        );
+        assert!(accepts(&g, b"\"abc\""), "\"abc\" must be accepted");
+        assert!(accepts(&g, b"\"abd\""), "\"abd\" must be accepted");
+        assert!(rejects(&g, b"123"), "a non-string must still be rejected");
+    }
+
+    /// A non-string sibling that cannot begin with `"` (here `integer`) does not
+    /// block the shared-prefix trie: `"abc"`/`"abd"` are disambiguated by the
+    /// trie and the integer branch remains reachable. Mutation guard against
+    /// over-correcting the FIRST-set guard to disable the trie whenever any
+    /// non-literal sibling is present — the flat fallback over-rejects `"abd"`.
+    #[test]
+    fn anyof_shared_prefix_consts_with_integer() {
+        let g = compile_ok(r#"{"anyOf":[{"const":"abc"},{"const":"abd"},{"type":"integer"}]}"#);
+        assert!(accepts(&g, b"\"abc\""), "\"abc\" must be accepted");
+        assert!(
+            accepts(&g, b"\"abd\""),
+            "\"abd\" must be accepted via the trie"
+        );
+        assert!(
+            accepts(&g, b"123"),
+            "the integer branch must remain reachable"
+        );
+        assert!(
+            rejects(&g, b"\"abe\""),
+            "a non-member string must be rejected"
+        );
     }
 
     /// Three-way shared prefix ["foo","food","foot"]: all three accepted.

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -1072,7 +1072,18 @@ impl<'a> CompileCtx<'a> {
     /// Compile `"type": "string"` potentially with an `enum` constraint.
     fn compile_string_type(&mut self, schema: &Value) -> Result<Vec<Alt>, SchemaError> {
         if let Some(values) = schema.get("enum").and_then(Value::as_array) {
-            let str_values: Vec<&str> = values.iter().filter_map(|v| v.as_str()).collect();
+            let mut str_values: Vec<&str> = values.iter().filter_map(|v| v.as_str()).collect();
+            // A sibling `const` is a single-value enum, so the string language is
+            // the intersection `{const} ∩ enum`. Narrow to the const when it is a
+            // string; a non-string const is unsatisfiable under `type:"string"`,
+            // emptying the set. (`compile_schema_inner` dispatches `enum` before
+            // `const`, so without this the const would be silently ignored.)
+            if let Some(c) = schema.get("const") {
+                match c.as_str() {
+                    Some(cs) => str_values.retain(|s| *s == cs),
+                    None => str_values.clear(),
+                }
+            }
             if !str_values.is_empty() {
                 // Factor the common `'"'` prefix and `'"'` suffix into a
                 // wrapper so that string enum alternatives are disambiguated
@@ -1117,8 +1128,13 @@ impl<'a> CompileCtx<'a> {
                     Symbol::NonTerminal(trie_root_id),
                 ]]);
             }
+            // No surviving string member — a non-string `enum`, or a `const`
+            // that conflicts with every member — so the language is empty. Emit
+            // no alternative; falling through to `json_string` below would
+            // over-accept arbitrary strings (issue #472).
+            return Ok(Vec::new());
         }
-        // Default: any JSON string via built-in rule.
+        // Default: any JSON string via built-in rule (no `enum` constraint).
         if let Some(id) = self.builder.rule_id("json_string") {
             Ok(vec![vec![Symbol::NonTerminal(id)]])
         } else {
@@ -1519,67 +1535,101 @@ fn compile_const(v: &Value) -> Result<Vec<Alt>, SchemaError> {
 
 /// How an `anyOf`/`oneOf` sub-schema matches strings, for collapsing the
 /// string-valued ambiguity class into a single `"` entry (see the `anyOf`
-/// handler). A sub-schema that is not a string-valued class — a number,
-/// boolean, null, object, array, or a schema whose string matching cannot be
-/// reduced to a broad string or a fixed literal set (an UNTYPED mixed `enum`,
-/// a `$ref`, a nested `anyOf`, an untyped `{}`, or a `{"type":["string",...]}`
-/// union) — classifies as `None`. A `{"type":"string","enum":[...]}` whose enum
-/// mixes string and non-string members IS reducible: `type:"string"` kills the
-/// non-string members, leaving the string members as the exact literal set.
+/// handler). `type`, `const`, and `enum` are conjunctive assertions, so a
+/// sub-schema's string language is the INTERSECTION of the constraints it
+/// states. A schema that may also accept a non-string value, or whose string
+/// language is not reducible to a broad string or a fixed literal set (a `$ref`,
+/// a nested `anyOf`, an untyped `{}`, a `{"type":["string",...]}` union, or an
+/// untyped mixed `enum`) classifies as `None` and stays an "other" branch.
 enum StrClass {
-    /// Any JSON string (`{"type":"string"}`). `pattern` / `minLength` are not
-    /// enforced by this compiler, so such a schema widens to any string — the
-    /// same `json_string` rule `compile_string_type` emits for it standalone.
+    /// Any JSON string (`{"type":"string"}` with no value constraint).
+    /// `pattern` / `minLength` are not enforced by this compiler, so such a
+    /// schema widens to any string — the same `json_string` rule
+    /// `compile_string_type` emits for it standalone.
     Broad,
-    /// A fixed set of string values (a string `const` or an all-string `enum`).
+    /// A fixed set of string values (a string `const`, an all-string `enum`, or
+    /// a `{"type":"string","enum":[...]}` intersected down to its string
+    /// members). An EMPTY set is a dead branch — `const`/`enum` conflict, or a
+    /// `type:"string"` enum with no string member — whose language is empty, so
+    /// it contributes nothing to the union (it must NOT widen to any string).
     Literals(Vec<String>),
 }
 
 /// Classify a raw `anyOf`/`oneOf` sub-schema for string-class merging.
+///
+/// `type`, `const`, and `enum` are conjunctive assertions, so the branch's
+/// string language is their INTERSECTION — this models that intersection rather
+/// than taking the first keyword seen. A branch that may accept a non-string
+/// value, or whose string language is not reducible to a broad string or a
+/// fixed literal set, returns `None` and stays an "other". A dead branch (empty
+/// intersection, e.g. `const`/`enum` conflict or a `type:"string"` enum with no
+/// string member) returns `Literals(vec![])` so it contributes nothing — it
+/// must NOT fall through to `None`, which would let the standalone path widen it
+/// to any string.
 fn string_class_of(sub: &Value) -> Option<StrClass> {
     let obj = sub.as_object()?;
-    if let Some(Value::String(s)) = obj.get("const") {
-        return Some(StrClass::Literals(vec![s.clone()]));
-    }
-    let ty = obj.get("type").and_then(Value::as_str);
-    if let Some(arr) = obj.get("enum").and_then(Value::as_array) {
-        if arr.is_empty() {
-            return None;
-        }
-        if ty == Some("string") {
-            // `type:"string"` makes every non-string enum member unsatisfiable
-            // (instance must satisfy the type AND equal an enum member), so the
-            // branch's language is exactly the enum's string members. Fold them;
-            // the dead non-string members are dropped without changing the
-            // language. With no string member the branch accepts nothing — leave
-            // it as an "other" so the standalone path emits that empty language
-            // rather than this fold emitting an empty trie.
-            let values: Vec<String> = arr
-                .iter()
-                .filter_map(|v| v.as_str().map(str::to_string))
-                .collect();
-            if values.is_empty() {
-                return None;
+    // `type` gate: only an absent type or exactly `"string"` keeps the branch a
+    // pure string class. A scalar non-string type, or a `type` array (for which
+    // `as_str()` is `None` on a non-string `Value`), means the branch may accept
+    // a non-string value, so it cannot fold into the string entry.
+    let type_is_string = match obj.get("type") {
+        None => false,
+        Some(Value::String(s)) if s == "string" => true,
+        _ => return None,
+    };
+    let const_val = obj.get("const");
+    let enum_arr = obj.get("enum").and_then(Value::as_array);
+    match (const_val, enum_arr) {
+        (Some(c), enum_opt) => {
+            // `const` is a single-value enum. The language is the intersection of
+            // {const}, the `enum` (when present), and the type.
+            let Some(cs) = c.as_str() else {
+                // Non-string const: with `type:"string"` nothing satisfies both
+                // (dead branch); with no type the branch accepts that non-string
+                // value, which this string fold cannot represent.
+                return if type_is_string {
+                    Some(StrClass::Literals(Vec::new()))
+                } else {
+                    None
+                };
+            };
+            // String const: fold it only if a present `enum` also contains it; a
+            // conflicting `enum` makes the intersection empty (dead branch).
+            match enum_opt {
+                Some(arr) if !arr.iter().any(|v| v == c) => Some(StrClass::Literals(Vec::new())),
+                _ => Some(StrClass::Literals(vec![cs.to_string()])),
             }
-            return Some(StrClass::Literals(values));
         }
-        if ty.is_none() && arr.iter().all(Value::is_string) {
-            // No `type` constraint: a non-string member is itself a satisfiable
-            // value the branch accepts, so only an all-string enum is a pure
-            // literal set. A mixed untyped enum keeps its non-string members and
-            // stays an "other" branch (folding would drop those acceptances).
-            let values = arr
-                .iter()
-                .filter_map(|v| v.as_str().map(str::to_string))
-                .collect();
-            return Some(StrClass::Literals(values));
+        (None, Some(arr)) => {
+            if type_is_string {
+                // `type:"string"` kills every non-string member; the language is
+                // exactly the string members (possibly empty = dead branch).
+                Some(StrClass::Literals(
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect(),
+                ))
+            } else if !arr.is_empty() && arr.iter().all(Value::is_string) {
+                // Untyped all-string enum: a pure literal set.
+                Some(StrClass::Literals(
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect(),
+                ))
+            } else {
+                // Untyped mixed or empty enum: non-string members stay reachable
+                // as an "other" branch (folding would drop those acceptances).
+                None
+            }
         }
-        return None;
+        (None, None) => {
+            if type_is_string {
+                Some(StrClass::Broad)
+            } else {
+                None
+            }
+        }
     }
-    if ty == Some("string") {
-        return Some(StrClass::Broad);
-    }
-    None
 }
 
 /// Convert a concrete JSON value to a grammar alternative (sequence of terminal bytes).
@@ -1998,6 +2048,126 @@ mod tests {
         assert!(
             rejects(&g, b"1"),
             "the integer enum member is unsatisfiable under type:string"
+        );
+    }
+
+    /// A `{"type":"string","enum":[1,2]}` branch is unsatisfiable: an instance
+    /// must be a string AND equal a numeric enum member, so it accepts no string.
+    /// `string_class_of` must classify it as the empty literal set (a dead
+    /// branch), NOT `None` — `None` routes it through `compile_string_type`'s
+    /// `json_string` fallback and over-accepts arbitrary strings (issue #472
+    /// codex round-4 blocker 2). Mutation guard: returning `None` accepts "zzz".
+    #[test]
+    fn anyof_typed_enum_no_string_members_rejected() {
+        let g = compile_ok(r#"{"anyOf":[{"type":"integer"},{"type":"string","enum":[1,2]}]}"#);
+        assert!(accepts(&g, b"7"), "the integer branch must stay reachable");
+        assert!(
+            rejects(&g, b"\"zzz\""),
+            "the unsatisfiable type:string + numeric-enum branch must not widen to any-string"
+        );
+    }
+
+    /// `const` and `enum` are conjunctive, so `{"type":"string","const":"x","enum":["y"]}`
+    /// accepts no value (nothing equals both "x" and "y"). `string_class_of` must
+    /// fold the const only when a present enum contains it, classifying this
+    /// conflicting branch as the empty literal set (issue #472 codex round-4
+    /// blocker 1). Mutation guard: folding the const before checking the enum
+    /// accepts "x"; folding the enum before checking the const accepts "y".
+    #[test]
+    fn anyof_const_conflicting_enum_rejected() {
+        let g = compile_ok(
+            r#"{"anyOf":[{"type":"integer"},{"type":"string","const":"x","enum":["y"]}]}"#,
+        );
+        assert!(accepts(&g, b"7"), "the integer branch must stay reachable");
+        assert!(
+            rejects(&g, b"\"x\""),
+            "const \"x\" conflicts with enum [\"y\"] — empty intersection, reject"
+        );
+        assert!(
+            rejects(&g, b"\"y\""),
+            "enum member \"y\" conflicts with const \"x\" — empty intersection, reject"
+        );
+    }
+
+    /// `{"type":"string","const":"x","enum":["x","y"]}`: the const narrows the
+    /// enum to the intersection {"x"}, so only "x" is accepted, NOT "y" (issue
+    /// #472 codex round-4). Mutation guard: ignoring the const and folding the
+    /// whole enum accepts "y".
+    #[test]
+    fn anyof_const_compatible_enum_folds_to_const() {
+        let g = compile_ok(
+            r#"{"anyOf":[{"type":"integer"},{"type":"string","const":"x","enum":["x","y"]}]}"#,
+        );
+        assert!(accepts(&g, b"7"), "the integer branch must stay reachable");
+        assert!(
+            accepts(&g, b"\"x\""),
+            "const \"x\" is in the enum — accepted"
+        );
+        assert!(
+            rejects(&g, b"\"y\""),
+            "\"y\" is in the enum but excluded by const \"x\" — reject"
+        );
+    }
+
+    /// Standalone `{"type":"string","enum":[1,2]}` is unsatisfiable;
+    /// `compile_string_type` must emit the empty language, not the `json_string`
+    /// fallback (issue #472 blocker 2, standalone path). Mutation guard: the
+    /// `json_string` fallback accepts "zzz".
+    #[test]
+    fn standalone_typed_enum_no_string_members_rejects_all() {
+        let g = compile_ok(r#"{"type":"string","enum":[1,2]}"#);
+        assert!(
+            rejects(&g, b"\"zzz\""),
+            "no string satisfies type:string + enum [1,2]"
+        );
+        assert!(rejects(&g, b"1"), "the numeric member is not a string");
+    }
+
+    /// Standalone const/enum intersection through `compile_string_type`, which
+    /// `compile_schema_inner` reaches via the `enum` dispatch — without the
+    /// intersection a sibling `const` would be silently ignored (issue #472
+    /// blocker 1, standalone path). Mutation guard: dropping the const-narrowing
+    /// accepts "y" in both cases.
+    #[test]
+    fn standalone_string_const_enum_intersection() {
+        let conflict = compile_ok(r#"{"type":"string","const":"x","enum":["y"]}"#);
+        assert!(
+            rejects(&conflict, b"\"x\""),
+            "const conflicts with enum — reject \"x\""
+        );
+        assert!(
+            rejects(&conflict, b"\"y\""),
+            "const conflicts with enum — reject \"y\""
+        );
+        let compatible = compile_ok(r#"{"type":"string","const":"x","enum":["x","y"]}"#);
+        assert!(
+            accepts(&compatible, b"\"x\""),
+            "const \"x\" is in the enum — accept"
+        );
+        assert!(
+            rejects(&compatible, b"\"y\""),
+            "\"y\" excluded by const \"x\" — reject"
+        );
+    }
+
+    /// Edge cases for typed string enums: an empty `enum` is the empty language
+    /// (reject all), and a duplicate member folds to a single trie path without
+    /// error (issue #472 codex round-4 next-round focus).
+    #[test]
+    fn typed_string_enum_empty_and_duplicate_members() {
+        let empty = compile_ok(r#"{"type":"string","enum":[]}"#);
+        assert!(rejects(&empty, b"\"zzz\""), "empty enum accepts nothing");
+        let dups = compile_ok(r#"{"type":"string","enum":["dup","dup"]}"#);
+        assert!(
+            accepts(&dups, b"\"dup\""),
+            "a duplicated member still accepts once"
+        );
+        assert!(rejects(&dups, b"\"other\""), "no over-accept from dedup");
+        let in_anyof = compile_ok(r#"{"anyOf":[{"type":"integer"},{"type":"string","enum":[]}]}"#);
+        assert!(accepts(&in_anyof, b"7"), "integer branch reachable");
+        assert!(
+            rejects(&in_anyof, b"\"zzz\""),
+            "empty typed enum contributes no string"
         );
     }
 

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -232,12 +232,19 @@ impl<'a> CompileCtx<'a> {
     /// Non-string branches (numbers, booleans, null, objects, arrays) never
     /// begin with `"`, so they follow the string entry in their original
     /// relative order and stay reachable: a non-`"` input diverges from the
-    /// string entry at sym_pos == 0 and the PDA falls through. A non-string
-    /// sibling that could ITSELF begin with `"` (a `$ref`, nested `anyOf`,
-    /// untyped or mixed-type schema) is left among them; the string entry
-    /// shadows its quoted inputs, which `json_string` / the literal trie already
-    /// decide correctly. The residual narrowing for such a sibling matches the
-    /// pre-existing numeric-enum limitation and never over-accepts.
+    /// string entry at sym_pos == 0 and the PDA falls through.
+    ///
+    /// LIMITATION (pre-existing; `origin/main` rejects the same inputs): a
+    /// sibling whose language includes strings but is NOT folded into the string
+    /// entry — a `$ref` to a string rule, a nested `anyOf`, an untyped `{}`, a
+    /// `{"type":["string",...]}` union, or an untyped mixed `enum` — has its
+    /// quoted inputs shadowed by the hoisted entry once the entry consumes the
+    /// opening `"`, so those strings are over-rejected (issue #473).
+    /// `string_class_of` folds every shape it can prove reduces to a fixed string
+    /// set (`const`, all-string `enum`, and `{"type":"string","enum":[...]}`
+    /// whose `type` makes the non-string members dead), leaving only siblings
+    /// that genuinely need parallel-stack matching. The merge can only narrow
+    /// such a sibling, never widen it — it never over-accepts.
     ///
     /// Kept `#[inline(never)]` and out of `compile_schema_inner` so these locals
     /// do not enlarge that function's per-recursion stack frame (see the call
@@ -1514,8 +1521,11 @@ fn compile_const(v: &Value) -> Result<Vec<Alt>, SchemaError> {
 /// string-valued ambiguity class into a single `"` entry (see the `anyOf`
 /// handler). A sub-schema that is not a string-valued class — a number,
 /// boolean, null, object, array, or a schema whose string matching cannot be
-/// reduced to a broad string or a fixed literal set (mixed `enum`, `$ref`,
-/// nested `anyOf`, untyped) — classifies as `None`.
+/// reduced to a broad string or a fixed literal set (an UNTYPED mixed `enum`,
+/// a `$ref`, a nested `anyOf`, an untyped `{}`, or a `{"type":["string",...]}`
+/// union) — classifies as `None`. A `{"type":"string","enum":[...]}` whose enum
+/// mixes string and non-string members IS reducible: `type:"string"` kills the
+/// non-string members, leaving the string members as the exact literal set.
 enum StrClass {
     /// Any JSON string (`{"type":"string"}`). `pattern` / `minLength` are not
     /// enforced by this compiler, so such a schema widens to any string — the
@@ -1533,13 +1543,31 @@ fn string_class_of(sub: &Value) -> Option<StrClass> {
     }
     let ty = obj.get("type").and_then(Value::as_str);
     if let Some(arr) = obj.get("enum").and_then(Value::as_array) {
-        // An all-string `enum` is a literal set only when the (optional) `type`
-        // does not contradict it. A mixed enum may match non-string values too,
-        // so it stays unclassified and the caller keeps it as an "other" branch.
-        if (ty == Some("string") || ty.is_none())
-            && !arr.is_empty()
-            && arr.iter().all(Value::is_string)
-        {
+        if arr.is_empty() {
+            return None;
+        }
+        if ty == Some("string") {
+            // `type:"string"` makes every non-string enum member unsatisfiable
+            // (instance must satisfy the type AND equal an enum member), so the
+            // branch's language is exactly the enum's string members. Fold them;
+            // the dead non-string members are dropped without changing the
+            // language. With no string member the branch accepts nothing — leave
+            // it as an "other" so the standalone path emits that empty language
+            // rather than this fold emitting an empty trie.
+            let values: Vec<String> = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            if values.is_empty() {
+                return None;
+            }
+            return Some(StrClass::Literals(values));
+        }
+        if ty.is_none() && arr.iter().all(Value::is_string) {
+            // No `type` constraint: a non-string member is itself a satisfiable
+            // value the branch accepts, so only an all-string enum is a pure
+            // literal set. A mixed untyped enum keeps its non-string members and
+            // stays an "other" branch (folding would drop those acceptances).
             let values = arr
                 .iter()
                 .filter_map(|v| v.as_str().map(str::to_string))
@@ -1941,6 +1969,83 @@ mod tests {
         assert!(
             rejects(&g, b"\"abe\""),
             "a non-member string must be rejected"
+        );
+    }
+
+    /// A typed mixed `enum` sibling `{"type":"string","enum":["abe",1]}`: the
+    /// `type:"string"` makes the integer member unsatisfiable, so the branch's
+    /// language is exactly {"abe"} and `string_class_of` folds it into the
+    /// literal trie (issue #310 / PR #472, codex round-3 offered fix). The trie
+    /// then accepts both the const "abc" and the folded "abe". Mutation guard:
+    /// dropping the typed-mixed fold (classifying the enum as an "other") strands
+    /// "abe" behind the const trie and over-rejects it.
+    #[test]
+    fn anyof_typed_mixed_enum_folded() {
+        let g = compile_ok(r#"{"anyOf":[{"const":"abc"},{"type":"string","enum":["abe",1]}]}"#);
+        assert!(accepts(&g, b"\"abc\""), "const \"abc\" must be accepted");
+        assert!(
+            accepts(&g, b"\"abe\""),
+            "the type:string enum's string member \"abe\" must be folded and accepted"
+        );
+        assert!(
+            rejects(&g, b"\"abd\""),
+            "a string in no branch must be rejected (no over-accept)"
+        );
+        assert!(
+            rejects(&g, b"\"zzz\""),
+            "the dead integer member must not widen the branch to any-string"
+        );
+        assert!(
+            rejects(&g, b"1"),
+            "the integer enum member is unsatisfiable under type:string"
+        );
+    }
+
+    /// DOCUMENTED LIMITATION (issue #473): a `$ref` to a broad-string rule listed
+    /// beside string consts has its quoted inputs shadowed by the hoisted const
+    /// trie — the no-rewind PDA commits to the trie once it consumes the opening
+    /// `"`. "zzz" is valid via `#/$defs/S` but rejected. This matches
+    /// `origin/main` exactly (verified by reverting the compiler and re-probing)
+    /// and is NOT a regression; the fix needs parallel-stack matching (#473).
+    /// This test pins the current behavior so a future engine change flips it
+    /// intentionally rather than silently.
+    #[test]
+    fn anyof_ref_to_broad_string_shadowed_known_limitation() {
+        let g = compile_ok(
+            r##"{"$defs":{"S":{"type":"string"}},"anyOf":[{"const":"abc"},{"const":"abd"},{"$ref":"#/$defs/S"}]}"##,
+        );
+        assert!(accepts(&g, b"\"abc\""), "const \"abc\" still accepted");
+        assert!(accepts(&g, b"\"abd\""), "const \"abd\" still accepted");
+        assert!(
+            rejects(&g, b"\"zzz\""),
+            "KNOWN LIMITATION #473: $ref->string sibling shadowed by the const trie"
+        );
+    }
+
+    /// DOCUMENTED LIMITATION (issue #473): a nested `anyOf` containing a broad
+    /// string classifies as an "other" sibling (string_class_of does not recurse
+    /// into nested anyOf), so its quoted inputs are shadowed by the hoisted const
+    /// trie. Matches `origin/main`; pins current behavior pending #473.
+    #[test]
+    fn anyof_nested_anyof_string_shadowed_known_limitation() {
+        let g = compile_ok(r#"{"anyOf":[{"const":"abc"},{"anyOf":[{"type":"string"}]}]}"#);
+        assert!(accepts(&g, b"\"abc\""), "const \"abc\" still accepted");
+        assert!(
+            rejects(&g, b"\"zzz\""),
+            "KNOWN LIMITATION #473: nested-anyOf string shadowed by the const trie"
+        );
+    }
+
+    /// DOCUMENTED LIMITATION (issue #473): an untyped `{}` sibling accepts any
+    /// JSON value, but its string inputs are shadowed by the hoisted const trie.
+    /// Matches `origin/main`; pins current behavior pending #473.
+    #[test]
+    fn anyof_untyped_sibling_shadowed_known_limitation() {
+        let g = compile_ok(r#"{"anyOf":[{"const":"abc"},{}]}"#);
+        assert!(accepts(&g, b"\"abc\""), "const \"abc\" still accepted");
+        assert!(
+            rejects(&g, b"\"zzz\""),
+            "KNOWN LIMITATION #473: untyped empty-schema string inputs shadowed by the const trie"
         );
     }
 

--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -612,6 +612,16 @@ impl GrammarBuilder {
         self.name_to_id.get(name).copied()
     }
 
+    /// Read-only view of a reserved rule's alternatives.
+    ///
+    /// Used by the JSON-schema compiler's `anyOf`/`oneOf` FIRST-set guard to
+    /// decide whether a shared-prefix string-literal trie can be hoisted ahead
+    /// of the other alternatives. Pure introspection: it neither mutates the
+    /// builder nor participates in PDA simulation.
+    pub fn rule_alts(&self, id: usize) -> Option<&[Alt]> {
+        self.rules.get(id).map(|rule| rule.alts.as_slice())
+    }
+
     /// Consume the builder and produce a `CompiledGrammar`.
     ///
     /// Panics if the root rule (index 0, name "root") has no alternatives.

--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -612,16 +612,6 @@ impl GrammarBuilder {
         self.name_to_id.get(name).copied()
     }
 
-    /// Read-only view of a reserved rule's alternatives.
-    ///
-    /// Used by the JSON-schema compiler's `anyOf`/`oneOf` FIRST-set guard to
-    /// decide whether a shared-prefix string-literal trie can be hoisted ahead
-    /// of the other alternatives. Pure introspection: it neither mutates the
-    /// builder nor participates in PDA simulation.
-    pub fn rule_alts(&self, id: usize) -> Option<&[Alt]> {
-        self.rules.get(id).map(|rule| rule.alts.as_slice())
-    }
-
     /// Consume the builder and produce a `CompiledGrammar`.
     ///
     /// Panics if the root rule (index 0, name "root") has no alternatives.


### PR DESCRIPTION
## What

PR #471 closed the `abc`/`abd` shared-prefix over-rejection in `anyOf`/`oneOf` by trie-compiling the string-literal alternatives and **hoisting that trie ahead of the other alternatives**. Because the no-rewind PDA commits to an alternative the moment it consumes a byte (the #353/#380 consumed-guard), and **every JSON string shares the opening `"`**, that hoist stranded any *other* string-valued branch competing for the same opening quote. Over-rejections result:

- a broad `{"type":"string"}` sibling (compiles to `json_string`) — `"zzz"` wrongly rejected;
- a narrower `{"type":"string","enum":[...]}` sibling — its members wrongly rejected;
- and the bug is **order-sensitive**: a broad string listed *after* the consts is shadowed by the hoisted const trie just the same.

## Fix

Collapse the **string-valued ambiguity class** into ONE branch with a single `"` entry, classified from the raw sub-schemas (no rule-graph walk):

- if **any** broad string is present, the class becomes the `json_string` rule — it subsumes every string literal, so a valid string is never rejected;
- otherwise all string literals (`const` / all-string `enum`, **and** a typed mixed `enum` — see below) union into **one trie**, so each diverges *inside* the quoted region instead of competing at the shared opening quote.

Non-string branches (numbers, booleans, null, objects, arrays — none of which begin with `"`) follow the string entry in their original relative order and stay reachable: a non-`"` input diverges from the string entry at `sym_pos == 0` and the PDA falls through. **Order no longer matters** because the string class is the only `"`-starter the PDA reaches.

### Typed mixed-enum fold (added in review round 3)

`{"type":"string","enum":["abe",1]}` is a quote-capable sibling, but its language is **exactly** `{"abe"}`: `type:"string"` makes the integer member unsatisfiable (an instance must satisfy the type *and* equal an enum member). `string_class_of` now folds the surviving string members into the literal trie instead of stranding the branch as an "other". This is lossless — it can only make the union more precise, never wider.

### Honest limitation (issue #473)

A sibling whose language **includes** strings but does **not** reduce to a fixed literal set — a `$ref` to a string rule, a nested `anyOf`, an untyped `{}`, a `{"type":["string","number"]}` union, or an **untyped** mixed `enum` — is left among the "others" and its quoted inputs are **shadowed** by the hoisted string entry, so those strings are **over-rejected**.

This is **not a regression**: `origin/main` rejects the same inputs (verified by reverting the compiler to `origin/main` and re-probing — identical output). It is a pre-existing limitation that #471/#472 narrowed but did not close. The merge never **over-accepts** for these shapes (an unfolded sibling can only be too narrow). Closing it needs either deeper recursive folding (`$ref`/nested-`anyOf`, tractable) or parallel-stack / NFA matching (untyped/mixed-type, an engine change) — both tracked in **#473**. The doc-comments now state this plainly instead of claiming these inputs are "decided correctly".

### No PDA change

The fix is entirely in the compile-time JSON-schema lowering. **`pda.rs` is byte-identical to `main`** (`git diff --quiet origin/main -- crates/inference/src/grammar/pda.rs`), so the #353/#380 over-acceptance fixes are untouched.

## Before / after (verified empirically vs `origin/main`)

| `anyOf` schema | input | `main` (post-#471) | this PR |
|---|---|---|---|
| `[{type:string}, const abc, const abd]` (broad first) | `"zzz"` | **reject** 🐛 | accept ✅ |
| `[const abc, const abd, {type:string}]` (broad last) | `"abe"` | **reject** 🐛 | accept ✅ |
| `[const abc, const abd, {type:string,enum:[abe,abf]}]` | `"abf"` | **reject** 🐛 | accept ✅ |
| `[const abc, {type:string,enum:[abe,1]}]` (typed mixed) | `"abe"` | **reject** 🐛 | accept ✅ |
| `[const abc, {type:string,enum:[abe,1]}]` | `1` | reject | reject (type kills it) |
| `[const abc, const abd, {$ref→string}]` | `"zzz"` | reject | reject — **known limit #473** |
| `[const abc, {}]` (untyped) | `"zzz"` | reject | reject — **known limit #473** |
| `[const abc, const abd, {enum:[1,2]}]` | `"abd"` / `1` | accept | accept |
| `[const abc, const abd]` | `"abd"` | accept | accept |

Over-rejections fixed where the string set is foldable; pre-existing limitations documented + pinned; no over-acceptance anywhere.

## Tests

`grammar::json_schema` anyOf coverage (11 tests, all **mutation-sensitive** where they assert the fix):

- broad-string first / broad-string last (order-sensitivity), narrower string-`enum` sibling, numeric-`enum` sibling reachable, object sibling reachable, shared-prefix consts — from #471/#472;
- **`anyof_typed_mixed_enum_folded`** (round 3) — the typed mixed-enum fold; verified mutation-sensitive (reverting the fold in-place fails the `"abe"` assertion);
- **`anyof_ref_to_broad_string_shadowed_known_limitation`**, **`anyof_nested_anyof_string_shadowed_known_limitation`**, **`anyof_untyped_sibling_shadowed_known_limitation`** (round 3) — pin the documented #473 limitation: each asserts the current over-rejecting behavior that matches `origin/main`, so a future engine change flips them intentionally.

`cargo test grammar::` — **108 passed, 0 failed** (incl. `deep_ref_chain_rejected`, the depth-guard test). `cargo clippy --workspace -- -D warnings` clean. `cargo fmt --check` clean.

## Perf

Grammar **compile-time** change only — the compiled grammar is built once at engine construction, never in the token loop; no decode / forward / elementwise / embed path is touched. The Criterion suite has **no grammar / JSON-schema / PDA benchmark**, so there is no measured surface this PR could regress. `make bench-compare` accordingly has nothing to report.

Refs #310, #471, #473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
