### PR TITLE
ci: make observation jobs conclude green (step-level continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,13 +170,14 @@ jobs:
           command: check advisories
 
   # Observation job: rustdoc build and intra-doc link lint.
-  # NON-BLOCKING — continue-on-error: true. Do NOT add to required-status checks.
-  # Surfaces doc-build failures and broken intra-doc links (a verified absent gap)
-  # without wedging merges during the initial observation period.
+  # NON-BLOCKING. The lint STEP carries continue-on-error: true, so the job
+  # concludes success and the commit status stays green while the lint still runs
+  # and surfaces findings in the step log. A job-level continue-on-error does NOT
+  # neutralize a job's check-run conclusion, so it cannot keep the commit status
+  # green (this is why every commit went red). Do NOT add to required-status checks.
   rustdoc-lint:
     name: rustdoc-lint (informational)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.94.1
@@ -187,6 +188,7 @@ jobs:
           shared-key: rustdoc-lint
           cache-on-failure: true
       - name: cargo doc — broken-intra-doc-links and doc warnings (informational)
+        continue-on-error: true
         env:
           RUSTDOCFLAGS: >-
             -D warnings
@@ -195,13 +197,15 @@ jobs:
         run: cargo doc --workspace --no-deps
 
   # Observation job: unwrap/expect usage in workspace library targets.
-  # NON-BLOCKING — continue-on-error: true. Do NOT add to required-status checks.
-  # Surfaces panic-safety debt in library code (a verified absent gap) without
-  # changing merge behavior. Expected to show existing debt on first run.
+  # NON-BLOCKING. The lint STEP carries continue-on-error: true, so the job
+  # concludes success and the commit status stays green while the lint still
+  # surfaces panic-safety debt in the step log. A job-level continue-on-error does
+  # NOT neutralize a job's check-run conclusion, so it cannot keep the commit
+  # status green. Do NOT add to required-status checks. Expected to show existing
+  # debt in the logs.
   unwrap-in-lib-lint:
     name: unwrap-in-lib-lint (informational)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.94.1
@@ -214,4 +218,5 @@ jobs:
           shared-key: unwrap-in-lib-lint
           cache-on-failure: true
       - name: clippy — unwrap/expect in library targets (informational)
+        continue-on-error: true
         run: cargo clippy --workspace --lib -- -D clippy::unwrap_used -D clippy::expect_used


### PR DESCRIPTION
## What

`main` has shown a red commit status for many commits. The cause is the two
ADR-064 observation jobs, not any real failure:

- `rustdoc-lint (informational)`
- `unwrap-in-lib-lint (informational)`

Both run a deliberately-strict lint that currently finds existing debt, so the
lint command exits non-zero on every run. Each job carried `continue-on-error: true`
at the **job** level. That field only prevents the overall *workflow run* from
being marked failed; it does **not** change the job's own check-run conclusion,
which stays `failure`. GitHub renders that as a red ✗ on the commit. Every
gating check (CI matrix, feature-matrix, parity-gate, embed drift, cargo-deny,
app-binaries, bench-compile) is green — only these two non-required observation
checks were red.

## Fix

Move `continue-on-error: true` from the job level to the **lint step** in each
job:

- A step with `continue-on-error: true` that fails does not fail its job, so the
  job concludes `success` and the commit status is green.
- The lint still runs and its output (broken intra-doc links, `unwrap`/`expect`
  in library targets) is still visible in the step log, preserving the
  observation purpose ADR-064 D3 describes ("visible in the workflow UI but
  cannot block a merge").
- Comments are updated to record *why* job-level `continue-on-error` cannot keep
  the status green, so this is not reverted later.

Neither job is in any required-status set (ADR-064 explicitly keeps them
non-required), so this is purely a status-signal correction with no change to
merge gating.

## Verification

- `ruby -ryaml` parses the edited `ci.yml` cleanly.
- Diff is surgical: `continue-on-error` relocated on both jobs plus comment
  rewording; no other job, gate, or step touched.

## Perf

CI-config only. No engine, benchmark, or library code changed, so
`make bench-compare` has nothing to report.

Refs #417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
