### PR TITLE
docs: align stale facts to re-measured source values (follow-up to #303)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Pure Rust inference engine. Apache-2.0. github.com/ohdearquant/lattice
 - Do not use `unwrap()` or `expect()` in library code. Tests and examples only.
 - Do not add upward dependencies (embed cannot depend on tune, inference cannot depend on embed).
 - Do not push directly to `main`. All changes go through feature branch → PR → review → merge.
-- Internal path dependencies must include a version for crates.io: `lattice-foo = { version = "0.1.0", path = "../foo" }`.
+- Internal path dependencies must include a version for crates.io: `lattice-foo = { version = "0.4.2", path = "../foo" }`.
 
 ```rust
 // === BAD — unwrap in library code ===
@@ -92,9 +92,9 @@ fn similarity(query: &[f32], docs: &[Vec<f32>]) -> Vec<f32> {
 ## Crate Structure
 
 ```
-inference (~112K)  fann (6.5K)  transport (5.4K)   ← leaf, zero internal deps
+inference (~118K)  fann (7.7K)  transport (5.4K)   ← leaf, zero internal deps
     |                |
-  embed (12K)    tune (15.6K)                     ← depend on leaves only
+  embed (12K)    tune (20K)                       ← depend on leaves only
 ```
 
 ### lattice-inference — Transformer kernel
@@ -243,7 +243,7 @@ make bench-gate                          # compare against perf-baselines branch
 
 ## ADRs
 
-63 ADRs in `docs/adr/INDEX.md`, globally numbered. Template: `docs/_templates/ADR_TEMPLATE.md`.
+64 ADRs in `docs/adr/INDEX.md`, globally numbered. Template: `docs/_templates/ADR_TEMPLATE.md`.
 
 Write when: new model, SIMD dispatch change, weight format change, new backend, public API change.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ provide for this model family:
 | Q4 + LoRA hot-swap (no reload) | yes | no | no |
 | Pure Rust, zero Python or framework | yes | no | no |
 
-PPL parity confirmed: Lattice 20.60, MLX 20.67 on wikitext-2 (2048 tokens). Reproduce:
+PPL benchmark (wikitext-2, from `docs/bench_results/perplexity.tsv`): Lattice q4 19.27, q4-QuaRot 19.95 (2048 tokens); MLX q8 15.82, q4 18.18 (2041 tokens). Reproduce:
 `./scripts/bench_context_scaling.sh`
 
 ---

--- a/crates/fann/README.md
+++ b/crates/fann/README.md
@@ -190,7 +190,7 @@ let output = network.forward_async(&input).await?;
 Requires the `parallel` feature to compile.
 
 ```rust
-// This example requires: lattice-fann = { version = "0.1", features = ["parallel"] }
+// This example requires: lattice-fann = { version = "0.4.2", features = ["parallel"] }
 use lattice_fann::{NetworkBuilder, Activation};
 
 let network = NetworkBuilder::new()
@@ -252,9 +252,9 @@ Format specification:
 
 ```toml
 [dependencies]
-lattice-fann = { version = "0.1" }                         # Default (std + simd)
-lattice-fann = { version = "0.1", features = ["parallel"] } # Parallel inference
-lattice-fann = { version = "0.1", features = ["gpu"] }      # GPU acceleration
+lattice-fann = { version = "0.4.2" }                         # Default (std + simd)
+lattice-fann = { version = "0.4.2", features = ["parallel"] } # Parallel inference
+lattice-fann = { version = "0.4.2", features = ["gpu"] }      # GPU acceleration
 ```
 
 ## Performance

--- a/crates/tune/README.md
+++ b/crates/tune/README.md
@@ -334,10 +334,10 @@ let finetuned = RegisteredModel::new("intent_classifier", "1.1.0")
 
 ```toml
 [dependencies]
-lattice-tune = { version = "0.1" }                           # Default
-lattice-tune = { version = "0.1", features = ["serde"] }     # With serialization
-lattice-tune = { version = "0.1", features = ["gpu"] }       # GPU training
-lattice-tune = { version = "0.1", features = ["safetensors"] } # Safe checkpoints
+lattice-tune = { version = "0.4.2" }                           # Default
+lattice-tune = { version = "0.4.2", features = ["serde"] }     # With serialization
+lattice-tune = { version = "0.4.2", features = ["gpu"] }       # GPU training
+lattice-tune = { version = "0.4.2", features = ["safetensors"] } # Safe checkpoints
 ```
 
 ### Injecting an adapter into `lattice-inference`
@@ -348,8 +348,8 @@ as a `Box<dyn LoraHook>`:
 
 ```toml
 [dependencies]
-lattice-tune = { version = "0.3", features = ["inference-hook"] }
-lattice-inference = "0.3" # provides the LoraHook trait
+lattice-tune = { version = "0.4.2", features = ["inference-hook"] }
+lattice-inference = "0.4.2" # provides the LoraHook trait
 ```
 
 ```rust,ignore
@@ -367,7 +367,7 @@ This crate depends on `lattice-fann` for neural network primitives.
 
 ```toml
 [dependencies]
-lattice-tune = { version = "0.1" }
+lattice-tune = { version = "0.4.2" }
 # lattice-fann is automatically included as a transitive dependency
 ```
 

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -112,8 +112,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! lattice-tune = { version = "0.3", features = ["inference-hook"] }
-//! lattice-inference = "0.3" # provides the LoraHook trait
+//! lattice-tune = { version = "0.4.2", features = ["inference-hook"] }
+//! lattice-inference = "0.4.2" # provides the LoraHook trait
 //! ```
 //!
 //! ```ignore


### PR DESCRIPTION
## What

Doc-alignment audit follow-up to **#303**. Corrects stale factual claims across top-level docs against the **current source**, with every changed value **independently re-measured** (TBV-at-issue — the issue's own "reality" numbers were not trusted blindly). Docs-only: Markdown + one doc-comment `toml` fence; **no source-logic changes**.

## Corrected claims (file → old → new, verified)

| File | Claim | Old | New (verified) | Source of truth |
|---|---|---|---|---|
| `AGENTS.md` | path-dep version example | `0.1.0` | `0.4.2` | `Cargo.toml [workspace.package] version` |
| `AGENTS.md` | inference LOC | `~112K` | `~118K` (118259) | `find crates/inference/src -name '*.rs' \| xargs wc -l` |
| `AGENTS.md` | fann LOC | `6.5K` | `7.7K` (7742) | `wc -l` on `crates/fann/src` |
| `AGENTS.md` | tune LOC | `15.6K` | `20K` (20238) | `wc -l` on `crates/tune/src` |
| `AGENTS.md` | embed LOC | `12K` | `12K` (12126, unchanged) | `wc -l` on `crates/embed/src` |
| `AGENTS.md` | ADR count | `63` | `64` | `find docs/adr -maxdepth 1 -name 'ADR-*.md' \| wc -l` |
| `README.md` | PPL claim | `parity confirmed: Lattice 20.60, MLX 20.67 (2048)` | `Lattice q4 19.27, q4-QuaRot 19.95 @2048; MLX q8 15.82, q4 18.18 @2041` | `docs/bench_results/perplexity.tsv` |
| `crates/fann/README.md` | feature-flag versions (×4) | `0.1` | `0.4.2` | workspace version |
| `crates/tune/README.md` | feature-flag / dep versions (×6) | `0.1` / `0.3` | `0.4.2` | workspace version |
| `crates/tune/src/lib.rs` | doc-comment `toml` versions (×2) | `0.3` | `0.4.2` | workspace version |

## Judgment calls (SAFE resolution)

1. **README PPL claim** — the unsubstantiated `20.60 / 20.67 "parity confirmed"` sentence has no committed artifact (those numbers appear in no committed TSV row). **Resolved** by replacing it with the **real committed rows** from `docs/bench_results/perplexity.tsv`, each labeled by model + quant (Lattice q4 19.27, q4-QuaRot 19.95 @2048 tokens; MLX q8 15.82, q4 18.18 @2041 tokens). No number invented.
2. **MSRV** — no new MSRV declared (that needs an out-of-scope compile check). The doc already carries the accurate statement *"CI pins Rust 1.94.1; no MSRV is declared"* (CI pin verified in `.github/workflows/`; `rust-version` absent from all `Cargo.toml`). **Left as-is** — no fabricated MSRV.

## `.gitignore`

The `review*.md` / `pr_review*.md` ignore rules are **already present in `main`** (`.gitignore:32-33`, landed by #306), so no `.gitignore` change is included here. The existing untracked review artifacts were **not** committed.

## Notes

- `crates/embed/README.md` was **not** modified — its public API (`NativeEmbeddingService` / `CachedEmbeddingService` / `EmbeddingService`) is already correct in `main`; no `LocalEmbeddingService` / `PooledEmbeddingService` / `fastembed` / `BGE` remain. It is not `include_str!`-included, so no doctest applies.
- Branch was fast-forwarded onto current `origin/main` before commit so the PR contains **only** the 5 doc files.

Refs #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)