### PR TITLE
harden(inference): guard PagedKVCache and BatchWorker against usize overflow (#460)

### DIFF
--- a/crates/inference/benches/inference_perf.rs
+++ b/crates/inference/benches/inference_perf.rs
@@ -280,7 +280,8 @@ fn paged_config(seq_capacity: usize, num_layers: usize) -> PagedKVCacheConfig {
 fn prefilled_cache_1layer(seq_len: usize) -> PagedKVCache {
     let k_tok = rand_f32_vec(KV_DIM, 0xBBBB_0001);
     let v_tok = rand_f32_vec(KV_DIM, 0xBBBB_0002);
-    let mut cache = PagedKVCache::new(paged_config(seq_len, 1));
+    let mut cache = PagedKVCache::try_new(paged_config(seq_len, 1))
+        .expect("valid paged bench config must succeed");
     for _ in 0..seq_len {
         cache.append_kv_layer(0, &k_tok, &v_tok);
         cache.advance();

--- a/crates/inference/src/batch/mod.rs
+++ b/crates/inference/src/batch/mod.rs
@@ -25,7 +25,7 @@
 //! use lattice_inference::batch::worker::PagedKVCacheConfigExt;
 //!
 //! let kv_config = PagedKVCacheConfig { /* ... */ };
-//! let mut worker = BatchWorker::new(
+//! let mut worker = BatchWorker::try_new(
 //!     BatchConfig::default(),
 //!     kv_config,
 //!     s_floats_per_slot,

--- a/crates/inference/src/batch/worker.rs
+++ b/crates/inference/src/batch/worker.rs
@@ -79,6 +79,56 @@ impl GdnStatePool {
         }
     }
 
+    /// Fallible constructor — returns `InvalidInput` on overflow rather than
+    /// panicking or silently allocating a wrong-sized pool.
+    pub fn try_new(
+        capacity: usize,
+        s_floats_per_slot: usize,
+        conv_floats_per_slot: usize,
+    ) -> Result<Self, InferenceError> {
+        // Guard each per-slot allocation and the free_slots Vec independently;
+        // they are separate allocations and each must not exceed isize::MAX bytes.
+        let s_bytes = s_floats_per_slot
+            .checked_mul(std::mem::size_of::<f32>())
+            .ok_or_else(|| {
+                InferenceError::InvalidInput(format!(
+                    "s_floats_per_slot ({s_floats_per_slot}) * size_of::<f32>() overflows usize"
+                ))
+            })?;
+        // Rust Vec panics when the byte allocation exceeds `isize::MAX`.
+        if s_bytes > isize::MAX as usize {
+            return Err(InferenceError::InvalidInput(format!(
+                "s_floats_per_slot byte size ({s_bytes}) exceeds isize::MAX — allocation would panic"
+            )));
+        }
+        let conv_bytes = conv_floats_per_slot
+            .checked_mul(std::mem::size_of::<f32>())
+            .ok_or_else(|| {
+                InferenceError::InvalidInput(format!(
+                    "conv_floats_per_slot ({conv_floats_per_slot}) * size_of::<f32>() overflows usize"
+                ))
+            })?;
+        if conv_bytes > isize::MAX as usize {
+            return Err(InferenceError::InvalidInput(format!(
+                "conv_floats_per_slot byte size ({conv_bytes}) exceeds isize::MAX — allocation would panic"
+            )));
+        }
+        // `free_slots` is a `VecDeque<usize>` of length `capacity`.
+        let slots_bytes = capacity
+            .checked_mul(std::mem::size_of::<usize>())
+            .ok_or_else(|| {
+                InferenceError::InvalidInput(format!(
+                    "capacity ({capacity}) * size_of::<usize>() overflows usize"
+                ))
+            })?;
+        if slots_bytes > isize::MAX as usize {
+            return Err(InferenceError::InvalidInput(format!(
+                "capacity ({capacity}) slot-index allocation ({slots_bytes} bytes) exceeds isize::MAX"
+            )));
+        }
+        Ok(Self::new(capacity, s_floats_per_slot, conv_floats_per_slot))
+    }
+
     /// Allocate a slot for a sequence. Returns `None` when the pool is full.
     pub fn alloc(&mut self, seq_id: SeqId) -> Option<usize> {
         let slot = self.free_slots.pop_front()?;
@@ -258,11 +308,11 @@ impl BatchWorker {
     ) -> Result<Self, InferenceError> {
         let floats_per_page = kv_pool_config.try_floats_per_page_pub()?;
         let kv_pool = PagePool::try_new(kv_pool_config.max_pages, floats_per_page)?;
-        let gdn_pool = GdnStatePool::new(
+        let gdn_pool = GdnStatePool::try_new(
             config.max_batch_size,
             s_floats_per_slot,
             conv_floats_per_slot,
-        );
+        )?;
         let scheduler = FifoScheduler::new(config.clone());
         Ok(Self {
             config,
@@ -909,6 +959,21 @@ mod tests {
         assert!(
             matches!(r, Err(InferenceError::InvalidInput(_))),
             "expected InvalidInput on worker PagePool capacity overflow"
+        );
+    }
+
+    // --- GdnStatePool isize::MAX boundary test (Fix 2) ---
+
+    #[test]
+    fn gdn_state_pool_try_new_isize_max_byte_bound_returns_invalid_input() {
+        // s_floats_per_slot such that s_floats * 4 > isize::MAX; element count
+        // itself fits usize. The GdnStatePool::try_new guard must catch this
+        // before any Vec is allocated; without it vec![0.0f32; s_floats] panics.
+        let s_floats = (isize::MAX as usize / std::mem::size_of::<f32>()) + 1;
+        let r = GdnStatePool::try_new(1, s_floats, 1);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput when s_floats byte size exceeds isize::MAX, got {r:?}"
         );
     }
 }

--- a/crates/inference/src/batch/worker.rs
+++ b/crates/inference/src/batch/worker.rs
@@ -113,17 +113,22 @@ impl GdnStatePool {
                 "conv_floats_per_slot byte size ({conv_bytes}) exceeds isize::MAX — allocation would panic"
             )));
         }
-        // `free_slots` is a `VecDeque<usize>` of length `capacity`.
-        let slots_bytes = capacity
-            .checked_mul(std::mem::size_of::<usize>())
+        // Guard all three capacity-length allocations: s_matrices (Vec<Vec<f32>>),
+        // conv_buffers (Vec<Vec<f32>>), and free_slots (VecDeque<usize>).
+        // size_of::<Vec<f32>>() == 24 bytes on 64-bit, which is larger than
+        // size_of::<usize>() == 8 bytes, so a single check against the Vec<f32>
+        // element width subsumes the usize free_slots bound and both outer
+        // Vec<Vec<f32>> bounds.
+        let outer_bytes = capacity
+            .checked_mul(std::mem::size_of::<Vec<f32>>())
             .ok_or_else(|| {
                 InferenceError::InvalidInput(format!(
-                    "capacity ({capacity}) * size_of::<usize>() overflows usize"
+                    "capacity ({capacity}) * size_of::<Vec<f32>>() overflows usize"
                 ))
             })?;
-        if slots_bytes > isize::MAX as usize {
+        if outer_bytes > isize::MAX as usize {
             return Err(InferenceError::InvalidInput(format!(
-                "capacity ({capacity}) slot-index allocation ({slots_bytes} bytes) exceeds isize::MAX"
+                "capacity ({capacity}) outer-vector allocation ({outer_bytes} bytes) exceeds isize::MAX"
             )));
         }
         Ok(Self::new(capacity, s_floats_per_slot, conv_floats_per_slot))
@@ -974,6 +979,20 @@ mod tests {
         assert!(
             matches!(r, Err(InferenceError::InvalidInput(_))),
             "expected InvalidInput when s_floats byte size exceeds isize::MAX, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn gdn_state_pool_try_new_outer_vec_capacity_bound_returns_invalid_input() {
+        // capacity * size_of::<Vec<f32>>() exceeds isize::MAX while capacity *
+        // size_of::<usize>() (the old guard width) does NOT; per-slot float
+        // counts are 0 so the s/conv guards pass. Without the outer-vector guard
+        // `new`'s collect::<Vec<Vec<f32>>>() panics with capacity overflow.
+        let capacity = (isize::MAX as usize / std::mem::size_of::<Vec<f32>>()) + 1;
+        let r = GdnStatePool::try_new(capacity, 0, 0);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput when outer-vector byte size exceeds isize::MAX, got {r:?}"
         );
     }
 }

--- a/crates/inference/src/batch/worker.rs
+++ b/crates/inference/src/batch/worker.rs
@@ -24,6 +24,7 @@ use crate::batch::scheduler::{FifoScheduler, Scheduler};
 use crate::batch::sequence::{
     AdapterKey, FinishReason, SeqId, Sequence, SequenceManager, SequenceState,
 };
+use crate::error::InferenceError;
 use crate::kv_cache::{PagePool, PagedKVCacheConfig};
 use crate::sampling::{Sampler, SamplingConfig};
 
@@ -244,6 +245,35 @@ impl BatchWorker {
             eos_token_id,
             output_buffer: VecDeque::new(),
         }
+    }
+
+    /// Fallible constructor — returns `InvalidInput` on overflow rather than
+    /// panicking or silently allocating a wrong-sized pool.
+    pub fn try_new(
+        config: BatchConfig,
+        kv_pool_config: PagedKVCacheConfig,
+        s_floats_per_slot: usize,
+        conv_floats_per_slot: usize,
+        eos_token_id: Option<u32>,
+    ) -> Result<Self, InferenceError> {
+        let floats_per_page = kv_pool_config.try_floats_per_page_pub()?;
+        let kv_pool = PagePool::try_new(kv_pool_config.max_pages, floats_per_page)?;
+        let gdn_pool = GdnStatePool::new(
+            config.max_batch_size,
+            s_floats_per_slot,
+            conv_floats_per_slot,
+        );
+        let scheduler = FifoScheduler::new(config.clone());
+        Ok(Self {
+            config,
+            seq_manager: SequenceManager::new(),
+            gdn_pool,
+            kv_pool,
+            scheduler,
+            samplers: HashMap::new(),
+            eos_token_id,
+            output_buffer: VecDeque::new(),
+        })
     }
 
     /// Submit a new inference request.
@@ -521,11 +551,16 @@ impl BatchWorker {
 /// trait provides the equivalent calculation for the worker.
 pub trait PagedKVCacheConfigExt {
     fn floats_per_page_pub(&self) -> usize;
+    fn try_floats_per_page_pub(&self) -> Result<usize, InferenceError>;
 }
 
 impl PagedKVCacheConfigExt for crate::kv_cache::PagedKVCacheConfig {
     fn floats_per_page_pub(&self) -> usize {
         self.num_layers * 2 * self.page_size * self.kv_dim()
+    }
+
+    fn try_floats_per_page_pub(&self) -> Result<usize, InferenceError> {
+        self.try_floats_per_page()
     }
 }
 
@@ -554,13 +589,14 @@ mod tests {
             chunk_size: 8,
             prefill_reserve_pages: 2,
         };
-        BatchWorker::new(
+        BatchWorker::try_new(
             config,
             test_kv_config(),
             16,      // s_floats_per_slot (tiny for tests)
             8,       // conv_floats_per_slot
             Some(2), // eos = token 2
         )
+        .expect("valid test worker config must succeed")
     }
 
     fn dummy_logits(winner: u32, vocab: usize) -> Vec<f32> {
@@ -760,7 +796,7 @@ mod tests {
 
     #[test]
     fn step_chunked_prefill_multiple_chunks() {
-        let mut worker = BatchWorker::new(
+        let mut worker = BatchWorker::try_new(
             BatchConfig {
                 max_batch_size: 4,
                 max_seq_len: 128,
@@ -771,7 +807,8 @@ mod tests {
             16,
             8,
             Some(99), // eos = 99
-        );
+        )
+        .expect("valid chunked-prefill worker config must succeed");
         // Prompt of 7 tokens requires ceil(7/3) = 3 prefill steps.
         worker.submit(InferenceRequest {
             prompt_ids: vec![1, 2, 3, 4, 5, 6, 7],
@@ -825,5 +862,53 @@ mod tests {
         let cfg = test_kv_config(); // page=4, layers=2, kv_heads=2, head_dim=4
         // kv_dim = 2*4 = 8; floats = 2 * 2 * 4 * 8 = 128
         assert_eq!(cfg.floats_per_page_pub(), 128);
+    }
+
+    // --- Overflow hardening tests (#460) ---
+
+    #[test]
+    fn batch_worker_try_new_overflow_floats_per_page_returns_invalid_input() {
+        let config = BatchConfig {
+            max_batch_size: 1,
+            max_seq_len: 8,
+            chunk_size: 1,
+            prefill_reserve_pages: 0,
+        };
+        let kv_pool_config = PagedKVCacheConfig {
+            page_size: 8,
+            max_pages: 1,
+            num_layers: usize::MAX / 16 + 2,
+            num_kv_heads: 1,
+            head_dim: 1,
+            eviction: EvictionPolicy::None,
+        };
+        let r = BatchWorker::try_new(config, kv_pool_config, 1, 1, None);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput on worker KV page overflow"
+        );
+    }
+
+    #[test]
+    fn batch_worker_try_new_overflow_page_pool_capacity_returns_invalid_input() {
+        let config = BatchConfig {
+            max_batch_size: 1,
+            max_seq_len: 8,
+            chunk_size: 1,
+            prefill_reserve_pages: 0,
+        };
+        let kv_pool_config = PagedKVCacheConfig {
+            page_size: 1,
+            max_pages: usize::MAX,
+            num_layers: 1,
+            num_kv_heads: 1,
+            head_dim: 1,
+            eviction: EvictionPolicy::None,
+        };
+        let r = BatchWorker::try_new(config, kv_pool_config, 1, 1, None);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput on worker PagePool capacity overflow"
+        );
     }
 }

--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -179,12 +179,19 @@ impl PagePool {
         // that fits usize can still overflow the byte layout. Guard it here so
         // the fallible path fails closed instead of panicking ("capacity
         // overflow") inside `vec!`.
-        len.checked_mul(std::mem::size_of::<f32>()).ok_or_else(|| {
+        let byte_len = len.checked_mul(std::mem::size_of::<f32>()).ok_or_else(|| {
             InferenceError::InvalidInput(format!(
                 "page pool byte size ({len} * {}) overflows usize",
                 std::mem::size_of::<f32>()
             ))
         })?;
+        // Rust Vec panics when the byte allocation exceeds `isize::MAX`; a usize
+        // product that fits can still cross this tighter bound.
+        if byte_len > isize::MAX as usize {
+            return Err(InferenceError::InvalidInput(format!(
+                "page pool byte size ({byte_len}) exceeds isize::MAX — allocation would panic"
+            )));
+        }
         let data = vec![0.0f32; len];
         let free_list: Vec<usize> = (0..max_pages).rev().collect();
         Ok(Self {
@@ -382,6 +389,47 @@ impl PagedKVCache {
         let fpp = config.try_floats_per_page()?;
         let _total_bytes = config.try_total_bytes()?;
         let pool = PagePool::try_new(config.max_pages, fpp)?;
+
+        // When a prefix cache is present, validate that its page geometry cannot
+        // produce a panicking allocation on the hot promote/restore path.
+        if let Some(ref cache_arc) = prefix_cache {
+            let guard = cache_arc
+                .lock()
+                .map_err(|_| InferenceError::PrefixCache("prefix cache lock poisoned".into()))?;
+            let pc = guard.config();
+            let kv_dim = config
+                .num_kv_heads
+                .checked_mul(config.head_dim)
+                .ok_or_else(|| {
+                    InferenceError::InvalidInput(format!(
+                        "num_kv_heads ({}) * head_dim ({}) overflows usize",
+                        config.num_kv_heads, config.head_dim
+                    ))
+                })?;
+            let floats = config
+                .num_layers
+                .checked_mul(2)
+                .and_then(|n| n.checked_mul(pc.prefix_page_size))
+                .and_then(|n| n.checked_mul(kv_dim))
+                .ok_or_else(|| {
+                    InferenceError::InvalidInput(format!(
+                        "prefix page float count (num_layers={} * 2 * prefix_page_size={} * kv_dim={kv_dim}) overflows usize",
+                        config.num_layers, pc.prefix_page_size
+                    ))
+                })?;
+            // Catch the isize::MAX bound that Rust Vec enforces at allocation.
+            let prefix_page_bytes = floats
+                .checked_mul(std::mem::size_of::<f32>())
+                .filter(|&b| b <= isize::MAX as usize)
+                .ok_or_else(|| {
+                    InferenceError::InvalidInput(format!(
+                        "prefix page byte size ({floats} * {}) exceeds isize::MAX",
+                        std::mem::size_of::<f32>()
+                    ))
+                })?;
+            let _ = prefix_page_bytes;
+        }
+
         let table = PageTable::new(config.page_size);
         Ok(Self {
             pool,
@@ -575,7 +623,30 @@ impl PagedKVCache {
         let prefix_len = self.seq_len();
         let prefix_page_count = PrefixEntry::pages_for_tokens(prefix_len, prefix_page_size);
         let kv_dim = self.config.kv_dim();
-        let floats_per_prefix_page = self.config.num_layers * 2 * prefix_page_size * kv_dim;
+        let floats_per_prefix_page = self
+            .config
+            .num_layers
+            .checked_mul(2)
+            .and_then(|n| n.checked_mul(prefix_page_size))
+            .and_then(|n| n.checked_mul(kv_dim))
+            .ok_or_else(|| {
+                InferenceError::InvalidInput(format!(
+                    "prefix page float count (num_layers={} * 2 * prefix_page_size={prefix_page_size} * kv_dim={kv_dim}) overflows usize",
+                    self.config.num_layers
+                ))
+            })?;
+        // Guard the byte size; a usize-valid count can still exceed isize::MAX
+        // and panic inside `vec!`.
+        let prefix_page_bytes = floats_per_prefix_page
+            .checked_mul(std::mem::size_of::<f32>())
+            .filter(|&b| b <= isize::MAX as usize)
+            .ok_or_else(|| {
+                InferenceError::InvalidInput(format!(
+                    "prefix page byte size ({floats_per_prefix_page} * {}) exceeds isize::MAX",
+                    std::mem::size_of::<f32>()
+                ))
+            })?;
+        let _ = prefix_page_bytes; // size validated; the vec! uses float count below
         let mut pages = Vec::with_capacity(prefix_page_count);
 
         for prefix_page_idx in 0..prefix_page_count {
@@ -1378,5 +1449,51 @@ mod tests {
         let cache = PagedKVCache::try_new(config).expect("valid config must succeed");
         assert_eq!(cache.seq_len(), 0);
         assert_eq!(cache.free_pages(), 2);
+    }
+
+    // --- isize::MAX boundary tests (Fix 1 / Fix 3) ---
+
+    #[test]
+    fn page_pool_try_new_isize_max_byte_bound_returns_invalid_input() {
+        // Element count fits usize (1 * (isize::MAX/4 + 1)), but the byte size
+        // (floats * 4) exceeds isize::MAX. The guard added in Fix 1 must catch
+        // this; without it the vec! macro panics with "capacity overflow".
+        let floats_per_page = (isize::MAX as usize / std::mem::size_of::<f32>()) + 1;
+        let r = PagePool::try_new(1, floats_per_page);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput when byte size exceeds isize::MAX, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn try_with_prefix_cache_oversized_prefix_geometry_returns_invalid_input() {
+        // Construct a prefix cache whose prefix_page_size produces a per-page
+        // float count such that floats * 4 > isize::MAX. The Fix 3 construction
+        // guard must catch this before any allocation is attempted.
+        let kv_dim = 1usize; // num_kv_heads=1, head_dim=1 → kv_dim=1
+        // num_layers=1, 2, prefix_page_size=X, kv_dim=1 → floats = 2*X
+        // We want 2*X > isize::MAX/4, so X > isize::MAX/8.
+        let bad_prefix_page_size = (isize::MAX as usize / (2 * std::mem::size_of::<f32>())) + 1;
+        let prefix_cache = Arc::new(Mutex::new(PrefixPageCache::new(PrefixPageCacheConfig {
+            capacity: 1,
+            prefix_page_size: bad_prefix_page_size,
+            num_layers: 1,
+            num_kv_heads: 1,
+            head_dim: kv_dim,
+        })));
+        let config = PagedKVCacheConfig {
+            page_size: 4,
+            max_pages: 1,
+            num_layers: 1,
+            num_kv_heads: 1,
+            head_dim: kv_dim,
+            eviction: EvictionPolicy::None,
+        };
+        let r = PagedKVCache::try_with_prefix_cache(config, Some(prefix_cache));
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput on oversized prefix geometry, got {r:?}"
+        );
     }
 }

--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -49,10 +49,33 @@ impl PagedKVCacheConfig {
         self.num_kv_heads * self.head_dim
     }
 
+    pub(crate) fn try_kv_dim(&self) -> Result<usize, InferenceError> {
+        self.num_kv_heads.checked_mul(self.head_dim).ok_or_else(|| {
+            InferenceError::InvalidInput(format!(
+                "num_kv_heads ({}) * head_dim ({}) overflows usize",
+                self.num_kv_heads, self.head_dim
+            ))
+        })
+    }
+
     /// Floats per page: stores K and V for all layers across page_size tokens.
     #[inline]
     fn floats_per_page(&self) -> usize {
         self.num_layers * 2 * self.page_size * self.kv_dim()
+    }
+
+    pub(crate) fn try_floats_per_page(&self) -> Result<usize, InferenceError> {
+        let kv_dim = self.try_kv_dim()?;
+        self.num_layers
+            .checked_mul(2)
+            .and_then(|n| n.checked_mul(self.page_size))
+            .and_then(|n| n.checked_mul(kv_dim))
+            .ok_or_else(|| {
+                InferenceError::InvalidInput(format!(
+                    "num_layers ({}) * 2 * page_size ({}) * kv_dim ({kv_dim}) overflows usize",
+                    self.num_layers, self.page_size
+                ))
+            })
     }
 
     /// **Unstable**: memory footprint of a single page.
@@ -60,14 +83,45 @@ impl PagedKVCacheConfig {
         self.floats_per_page() * std::mem::size_of::<f32>()
     }
 
+    pub fn try_bytes_per_page(&self) -> Result<usize, InferenceError> {
+        let floats_per_page = self.try_floats_per_page()?;
+        floats_per_page
+            .checked_mul(std::mem::size_of::<f32>())
+            .ok_or_else(|| {
+                InferenceError::InvalidInput(format!(
+                    "floats_per_page ({floats_per_page}) * size_of::<f32>() ({}) overflows usize",
+                    std::mem::size_of::<f32>()
+                ))
+            })
+    }
+
     /// **Unstable**: total memory budget across all pages.
     pub fn total_bytes(&self) -> usize {
         self.max_pages * self.bytes_per_page()
     }
 
+    pub fn try_total_bytes(&self) -> Result<usize, InferenceError> {
+        let bytes_per_page = self.try_bytes_per_page()?;
+        self.max_pages.checked_mul(bytes_per_page).ok_or_else(|| {
+            InferenceError::InvalidInput(format!(
+                "max_pages ({}) * bytes_per_page ({bytes_per_page}) overflows usize",
+                self.max_pages
+            ))
+        })
+    }
+
     /// **Unstable**: maximum token capacity.
     pub fn max_tokens(&self) -> usize {
         self.max_pages * self.page_size
+    }
+
+    pub fn try_max_tokens(&self) -> Result<usize, InferenceError> {
+        self.max_pages.checked_mul(self.page_size).ok_or_else(|| {
+            InferenceError::InvalidInput(format!(
+                "max_pages ({}) * page_size ({}) overflows usize",
+                self.max_pages, self.page_size
+            ))
+        })
     }
 }
 
@@ -111,6 +165,24 @@ impl PagePool {
             max_pages,
             floats_per_page,
         }
+    }
+
+    /// **Unstable**: create a pre-allocated page pool, returning an error on
+    /// overflow rather than panicking or producing a silently-wrong capacity.
+    pub fn try_new(max_pages: usize, floats_per_page: usize) -> Result<Self, InferenceError> {
+        let len = max_pages.checked_mul(floats_per_page).ok_or_else(|| {
+            InferenceError::InvalidInput(format!(
+                "max_pages ({max_pages}) * floats_per_page ({floats_per_page}) overflows usize"
+            ))
+        })?;
+        let data = vec![0.0f32; len];
+        let free_list: Vec<usize> = (0..max_pages).rev().collect();
+        Ok(Self {
+            data,
+            free_list,
+            max_pages,
+            floats_per_page,
+        })
     }
 
     /// **Unstable**: allocate a page index; returns `None` when exhausted.
@@ -279,6 +351,35 @@ impl PagedKVCache {
     /// **Unstable**: create a new paged KV cache without prefix sharing.
     pub fn new(config: PagedKVCacheConfig) -> Self {
         Self::with_prefix_cache(config, None)
+    }
+
+    /// **Unstable**: fallible constructor — returns `InvalidInput` on overflow
+    /// instead of panicking or silently allocating a wrong-sized pool.
+    pub fn try_new(config: PagedKVCacheConfig) -> Result<Self, InferenceError> {
+        Self::try_with_prefix_cache(config, None)
+    }
+
+    /// **Unstable**: fallible constructor with optional prefix sharing.
+    pub fn try_with_prefix_cache(
+        config: PagedKVCacheConfig,
+        prefix_cache: Option<Arc<Mutex<PrefixPageCache>>>,
+    ) -> Result<Self, InferenceError> {
+        if config.page_size == 0 {
+            return Err(InferenceError::InvalidInput(
+                "PagedKVCacheConfig.page_size must be non-zero".into(),
+            ));
+        }
+        let fpp = config.try_floats_per_page()?;
+        let _total_bytes = config.try_total_bytes()?;
+        let pool = PagePool::try_new(config.max_pages, fpp)?;
+        let table = PageTable::new(config.page_size);
+        Ok(Self {
+            pool,
+            table,
+            config,
+            prefix_cache,
+            lru_order: VecDeque::new(),
+        })
     }
 
     /// **Unstable**: create a new paged KV cache with optional prefix sharing.
@@ -1184,5 +1285,75 @@ mod tests {
         assert_eq!(table.resolve(4), (5, 0));
         // Token 5 -> page 5, offset 1
         assert_eq!(table.resolve(5), (5, 1));
+    }
+
+    // --- Overflow hardening tests (#460) ---
+
+    #[test]
+    fn paged_try_new_overflow_kv_dim_returns_invalid_input() {
+        let config = PagedKVCacheConfig {
+            page_size: 1,
+            max_pages: 1,
+            num_layers: 1,
+            num_kv_heads: usize::MAX,
+            head_dim: 2,
+            eviction: EvictionPolicy::None,
+        };
+        let r = PagedKVCache::try_new(config);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput on kv_dim overflow, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn paged_try_new_overflow_floats_per_page_returns_invalid_input() {
+        let config = PagedKVCacheConfig {
+            page_size: 8,
+            max_pages: 1,
+            num_layers: usize::MAX / 16 + 2,
+            num_kv_heads: 1,
+            head_dim: 1,
+            eviction: EvictionPolicy::None,
+        };
+        let r = PagedKVCache::try_new(config);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput on floats_per_page overflow, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn paged_try_new_overflow_total_bytes_returns_invalid_input() {
+        let config = PagedKVCacheConfig {
+            page_size: 1,
+            max_pages: usize::MAX / 8 + 2,
+            num_layers: 1,
+            num_kv_heads: 1,
+            head_dim: 1,
+            eviction: EvictionPolicy::None,
+        };
+        let r = PagedKVCache::try_new(config);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput on total_bytes overflow, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn page_pool_try_new_overflow_capacity_returns_invalid_input() {
+        let r = PagePool::try_new(usize::MAX, 2);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput on page-pool capacity overflow, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn paged_try_new_valid_config_succeeds() {
+        let config = make_config(2);
+        let cache = PagedKVCache::try_new(config).expect("valid config must succeed");
+        assert_eq!(cache.seq_len(), 0);
+        assert_eq!(cache.free_pages(), 2);
     }
 }

--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -388,10 +388,12 @@ impl PagedKVCache {
         }
         let fpp = config.try_floats_per_page()?;
         let _total_bytes = config.try_total_bytes()?;
-        let pool = PagePool::try_new(config.max_pages, fpp)?;
 
         // When a prefix cache is present, validate that its page geometry cannot
-        // produce a panicking allocation on the hot promote/restore path.
+        // produce a panicking allocation on the hot promote/restore path. Run
+        // this before any allocation (including the PagePool below) so an
+        // oversized prefix config is rejected before the constructor commits
+        // to any allocation at all.
         if let Some(ref cache_arc) = prefix_cache {
             let guard = cache_arc
                 .lock()
@@ -430,6 +432,7 @@ impl PagedKVCache {
             let _ = prefix_page_bytes;
         }
 
+        let pool = PagePool::try_new(config.max_pages, fpp)?;
         let table = PageTable::new(config.page_size);
         Ok(Self {
             pool,

--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -175,6 +175,16 @@ impl PagePool {
                 "max_pages ({max_pages}) * floats_per_page ({floats_per_page}) overflows usize"
             ))
         })?;
+        // `vec![0.0f32; len]` allocates `len * size_of::<f32>()` bytes; a length
+        // that fits usize can still overflow the byte layout. Guard it here so
+        // the fallible path fails closed instead of panicking ("capacity
+        // overflow") inside `vec!`.
+        len.checked_mul(std::mem::size_of::<f32>()).ok_or_else(|| {
+            InferenceError::InvalidInput(format!(
+                "page pool byte size ({len} * {}) overflows usize",
+                std::mem::size_of::<f32>()
+            ))
+        })?;
         let data = vec![0.0f32; len];
         let free_list: Vec<usize> = (0..max_pages).rev().collect();
         Ok(Self {
@@ -1346,6 +1356,19 @@ mod tests {
         assert!(
             matches!(r, Err(InferenceError::InvalidInput(_))),
             "expected InvalidInput on page-pool capacity overflow, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn page_pool_try_new_overflow_bytes_returns_invalid_input() {
+        // Element count (1 * usize::MAX/2) fits usize, but the f32 byte layout
+        // (len * 4) overflows. The fallible constructor must fail closed rather
+        // than panic with "capacity overflow" inside `vec!`. This is the gap
+        // `BatchWorker::try_new` inherits via `PagePool::try_new`.
+        let r = PagePool::try_new(1, usize::MAX / 2);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput on page-pool byte overflow, got {r:?}"
         );
     }
 

--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -192,6 +192,24 @@ impl PagePool {
                 "page pool byte size ({byte_len}) exceeds isize::MAX — allocation would panic"
             )));
         }
+        // `free_list` is a sibling allocation drawn from the same `max_pages`
+        // cardinality as `data`, but sized in `usize` elements (8 bytes each)
+        // rather than floats. When `floats_per_page` is 0, `len`/`byte_len`
+        // above are 0 and pass trivially even for a huge `max_pages`, so this
+        // allocation needs its own byte-layout guard to fail closed instead of
+        // panicking ("capacity overflow") inside `.collect()`.
+        let free_list_bytes = max_pages
+            .checked_mul(std::mem::size_of::<usize>())
+            .ok_or_else(|| {
+                InferenceError::InvalidInput(format!(
+                    "max_pages ({max_pages}) * size_of::<usize>() overflows usize"
+                ))
+            })?;
+        if free_list_bytes > isize::MAX as usize {
+            return Err(InferenceError::InvalidInput(format!(
+                "free-list allocation ({free_list_bytes} bytes) exceeds isize::MAX — allocation would panic"
+            )));
+        }
         let data = vec![0.0f32; len];
         let free_list: Vec<usize> = (0..max_pages).rev().collect();
         Ok(Self {
@@ -1466,6 +1484,22 @@ mod tests {
         assert!(
             matches!(r, Err(InferenceError::InvalidInput(_))),
             "expected InvalidInput when byte size exceeds isize::MAX, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn page_pool_try_new_free_list_capacity_bound_returns_invalid_input() {
+        // `floats_per_page = 0` makes `len = max_pages * 0 = 0`, so the `data`
+        // guard above (byte_len = 0) passes trivially regardless of how huge
+        // `max_pages` is. This test pins the *sibling* `free_list` guard,
+        // which must independently catch a `max_pages` whose `usize`-element
+        // (8 bytes each) byte layout exceeds `isize::MAX` even when the
+        // `data` allocation is empty.
+        let max_pages = (isize::MAX as usize / std::mem::size_of::<usize>()) + 1;
+        let r = PagePool::try_new(max_pages, 0);
+        assert!(
+            matches!(r, Err(InferenceError::InvalidInput(_))),
+            "expected InvalidInput when free_list byte size exceeds isize::MAX, got {r:?}"
         );
     }
 


### PR DESCRIPTION
## What

`PagedKVCacheConfig`, `PagePool`, `PagedKVCache`, and `BatchWorker` all derived allocation sizes from unchecked `usize` multiplication of config/request-derived fields (`num_layers`, `num_kv_heads`, `head_dim`, `page_size`, `max_pages`). On the batch/serve path these values come from external request dimensions, so an oversized product could silently wrap to a tiny capacity or abort via `Vec::with_capacity` before any typed error — the same overflow class fixed for `FlatKVCache` in #407.

Affected sites (verified against current source):
- `paged.rs` `floats_per_page` / `total_bytes` raw multiplies
- `PagePool::new(max_pages * floats_per_page)` — allocation before any check
- `batch/worker.rs` — duplicated raw product `num_layers * 2 * page_size * kv_dim` in `floats_per_page_pub`

## Fix

Mirrors `FlatKVCache::try_new` (#407) exactly: every dimension product uses `checked_mul`; the first overflow returns `InferenceError::InvalidInput` before any allocation.

New checked constructors and helpers:
- `PagedKVCacheConfig`: `try_kv_dim`, `try_floats_per_page`, `try_bytes_per_page`, `try_total_bytes`, `try_max_tokens`
- `PagePool::try_new` — checks `max_pages * floats_per_page` before `vec![]`
- `PagedKVCache::try_new` / `try_with_prefix_cache` — validates all geometry, then calls `PagePool::try_new`
- `BatchWorker::try_new` — calls `try_floats_per_page_pub()?` then `PagePool::try_new()?`
- `PagedKVCacheConfigExt::try_floats_per_page_pub` — checked variant of the extension trait; eliminates the duplicated raw product in the worker

All four production callers (bench, test helpers, doc usage sketch) routed through the checked constructors. No `unwrap()`/`expect()` added to library code.

## Tests

Seven mutation-sensitive CPU-only unit tests added (no GPU, no model weights):

**`kv_cache/paged.rs`** (5 tests):
- `paged_try_new_overflow_kv_dim_returns_invalid_input` — `num_kv_heads=usize::MAX, head_dim=2`
- `paged_try_new_overflow_floats_per_page_returns_invalid_input` — `num_layers=usize::MAX/16+2`
- `paged_try_new_overflow_total_bytes_returns_invalid_input` — `max_pages=usize::MAX/8+2`
- `page_pool_try_new_overflow_capacity_returns_invalid_input` — `PagePool::try_new(usize::MAX, 2)`
- `paged_try_new_valid_config_succeeds` — happy path

**`batch/worker.rs`** (2 tests):
- `batch_worker_try_new_overflow_floats_per_page_returns_invalid_input` — covers worker-side duplicate product site
- `batch_worker_try_new_overflow_page_pool_capacity_returns_invalid_input` — covers `BatchWorker→PagePool` path

Mutation sensitivity verified manually: reverting each `checked_mul` guard to raw `*` causes the corresponding test to fail (panic on overflow in debug mode).

## Perf

Cold constructor-path guards only; no decode/forward/elementwise/embed path touched. The Criterion suite has no benchmark on cache construction, so `make bench-compare` has nothing to report.

---

Refs #460, #407, #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)