### PR TITLE
docs: forward-pass walkthrough and inference module rustdoc (#304)

### DIFF
--- a/crates/inference/src/attention/flash.rs
+++ b/crates/inference/src/attention/flash.rs
@@ -1,3 +1,4 @@
+//! Tiled attention configuration and scratch-buffer support for tiled attention kernels.
 use crate::attention::AttentionBuffers;
 use crate::forward::cpu::{add_bias, matmul_bt};
 use crate::weights::TransformerLayerWeights;

--- a/crates/inference/src/attention/mod.rs
+++ b/crates/inference/src/attention/mod.rs
@@ -1,3 +1,4 @@
+//! Attention module index for `decode`, `differential`, `flash`, `flash_causal`, `gated`, `gdn`, `gdn_backward`, `gdn_fused`, `gqa`, `native_sparse`, and `standard`; re-exports the standard attention helpers.
 pub mod decode;
 pub mod differential;
 pub mod flash;

--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -1,3 +1,4 @@
+//! Standard attention buffers, multi-head attention, and in-place attention helpers.
 use crate::forward::cpu::{add_bias, matmul_bt, softmax_attention};
 use crate::lora_hook::LoraHook;
 use crate::weights::TransformerLayerWeights;

--- a/crates/inference/src/backward/attention_gqa.rs
+++ b/crates/inference/src/backward/attention_gqa.rs
@@ -1,3 +1,4 @@
+//! Materialized GQA attention backward data and helpers, including `AttnCache`, `AttnGrads`, `gqa_backward`, and `gqa_forward_with_cache`.
 // Materialised causal GQA self-attention backward pass.
 // Used for gradchecking and for the backward tape through layer-23.
 //

--- a/crates/inference/src/backward/gradcheck.rs
+++ b/crates/inference/src/backward/gradcheck.rs
@@ -1,3 +1,4 @@
+//! Tiny-model gradient-checking utilities, including tiny weights, tiny forward/loss helpers, and `gradcheck_lora`.
 // End-to-end gradcheck harness: tiny all-GQA 2-layer fixture,
 // hidden=64, 4 Q-heads, 1 KV-head, head_dim=16, no GDN layers.
 // Validates that the entire backward chain produces analytic grads

--- a/crates/inference/src/backward/mod.rs
+++ b/crates/inference/src/backward/mod.rs
@@ -1,3 +1,4 @@
+//! Backward-pass module index for `attention_gqa`, `gradcheck`, `ops`, and `tape`.
 pub mod attention_gqa;
 pub mod gradcheck;
 pub mod ops;

--- a/crates/inference/src/backward/ops.rs
+++ b/crates/inference/src/backward/ops.rs
@@ -1,3 +1,4 @@
+//! Backward primitives for cross entropy, linear VJP, LoRA VJP, RMSNorm backward, RoPE backward, and SwiGLU backward.
 // Backward pass primitives for CPU f32 training.
 // Each function computes a VJP (vector-Jacobian product) given the upstream
 // gradient and cached activations from the forward pass.

--- a/crates/inference/src/backward/tape.rs
+++ b/crates/inference/src/backward/tape.rs
@@ -1,3 +1,4 @@
+//! Forward-cache structs and helper forwards for RMSNorm and SwiGLU.
 // Forward pass that caches all activations needed for the backward pass.
 // The scope for this milestone: only layer-23 (the last GQA layer) is trained.
 // Layers 0..23 are a frozen prefix — we run them forward and save the residual

--- a/crates/inference/src/bin/ppl_metal.rs
+++ b/crates/inference/src/bin/ppl_metal.rs
@@ -1,3 +1,4 @@
+//! Metal Qwen3.5 perplexity binary entry point.
 use lattice_inference::forward::metal_qwen35::MetalQwen35State;
 use lattice_inference::model::qwen35::{PerplexityConfig, Qwen35Model};
 use lattice_inference::tokenizer::{BpeTokenizer, Tokenizer};

--- a/crates/inference/src/download.rs
+++ b/crates/inference/src/download.rs
@@ -1,3 +1,4 @@
+//! Model-file ensure/download flow, canonical model names, checksum verification, and download helper.
 use crate::error::InferenceError;
 use std::path::{Path, PathBuf};
 

--- a/crates/inference/src/error.rs
+++ b/crates/inference/src/error.rs
@@ -1,3 +1,4 @@
+//! Inference error type, display/error implementations, and I/O error conversion.
 use std::fmt::{Display, Formatter};
 
 /// **Stable**: primary error type consumed by `lattice-embed`; adding new variants

--- a/crates/inference/src/forward/cpu/activation.rs
+++ b/crates/inference/src/forward/cpu/activation.rs
@@ -1,3 +1,4 @@
+//! CPU activation and bias helpers, including tanh, GELU, add-bias, and fused add-bias-GELU paths.
 // ===================================================================
 // Fast tanh approximation — Pade (7,6) rational, max error < 4e-5
 // ===================================================================

--- a/crates/inference/src/forward/cpu/arch_kernels.rs
+++ b/crates/inference/src/forward/cpu/arch_kernels.rs
@@ -1,3 +1,4 @@
+//! Unsafe architecture-specific matmul kernels for AVX2, AVX512, NEON, plus horizontal-sum support.
 // ---------------------------------------------------------------------------
 // AVX2+FMA matmul_bt — 4 accumulators × 8 lanes = 32 elements/iter
 // ---------------------------------------------------------------------------

--- a/crates/inference/src/forward/cpu/blas.rs
+++ b/crates/inference/src/forward/cpu/blas.rs
@@ -1,3 +1,4 @@
+//! Accelerate-backed and fallback SGEMM helpers for transposed-B and non-transposed matrix multiplies.
 // ===================================================================
 // Apple Accelerate framework BLAS binding (macOS only)
 // ===================================================================

--- a/crates/inference/src/forward/cpu/elementwise.rs
+++ b/crates/inference/src/forward/cpu/elementwise.rs
@@ -1,3 +1,4 @@
+//! CPU elementwise kernels for RMSNorm, SiLU, elementwise multiply, and scalar variants.
 // ===================================================================
 // Elementwise operations — RMS norm, SiLU, element-wise mul — with SIMD fast paths
 // ===================================================================

--- a/crates/inference/src/forward/cpu/matmul.rs
+++ b/crates/inference/src/forward/cpu/matmul.rs
@@ -1,3 +1,4 @@
+//! General matmul helpers, preallocated matmul, transposed-B matmul, scalar fallbacks, and m=1 specialization.
 #[cfg(not(target_os = "macos"))]
 use super::simd::simd_config;
 

--- a/crates/inference/src/forward/cpu/mod.rs
+++ b/crates/inference/src/forward/cpu/mod.rs
@@ -1,3 +1,4 @@
+//! CPU forward-kernel module index.
 mod activation;
 mod arch_kernels;
 mod blas;

--- a/crates/inference/src/forward/cpu/norm.rs
+++ b/crates/inference/src/forward/cpu/norm.rs
@@ -1,3 +1,4 @@
+//! Layer-norm dispatch and scalar layer-norm implementation.
 // ===================================================================
 // Layer normalization (in-place) — with SIMD fast path
 // ===================================================================

--- a/crates/inference/src/forward/cpu/simd.rs
+++ b/crates/inference/src/forward/cpu/simd.rs
@@ -1,3 +1,4 @@
+//! Runtime SIMD configuration and accessor.
 use std::sync::OnceLock;
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/inference/src/forward/cpu/softmax.rs
+++ b/crates/inference/src/forward/cpu/softmax.rs
@@ -1,3 +1,4 @@
+//! Softmax attention helpers and fast exponential approximation.
 // ===================================================================
 // Softmax over attention scores — with SIMD fast path
 // ===================================================================

--- a/crates/inference/src/forward/cpu/tests.rs
+++ b/crates/inference/src/forward/cpu/tests.rs
@@ -1,3 +1,4 @@
+//! CPU kernel unit tests for matmul, tiled matmul, layer norm, `fast_tanh`, and GELU.
 use super::*;
 use approx::assert_relative_eq;
 

--- a/crates/inference/src/forward/cpu/tiled.rs
+++ b/crates/inference/src/forward/cpu/tiled.rs
@@ -1,3 +1,4 @@
+//! Tile constants and tiled transposed-B matmul helpers.
 // ===================================================================
 // Cache-blocked (tiled) matrix multiplication: C = A @ B^T
 // ===================================================================

--- a/crates/inference/src/forward/cpu/tiled_avx2.rs
+++ b/crates/inference/src/forward/cpu/tiled_avx2.rs
@@ -1,3 +1,4 @@
+//! Unsafe AVX2 tiled transposed-B matmul implementation.
 // ---------------------------------------------------------------------------
 // AVX2+FMA tiled matmul_bt — cache-blocked with 4×8 AVX2 microkernel
 // ---------------------------------------------------------------------------

--- a/crates/inference/src/forward/cpu/tiled_neon.rs
+++ b/crates/inference/src/forward/cpu/tiled_neon.rs
@@ -1,3 +1,4 @@
+//! Unsafe NEON tiled transposed-B matmul implementation.
 // ---------------------------------------------------------------------------
 // NEON tiled matmul_bt — cache-blocked with 4×8 NEON microkernel
 // ---------------------------------------------------------------------------

--- a/crates/inference/src/forward/gpu/inner.rs
+++ b/crates/inference/src/forward/gpu/inner.rs
@@ -1,3 +1,4 @@
+//! Inner WGPU forward module index and API-type re-exports.
 mod api;
 mod bind_groups;
 mod buffers;

--- a/crates/inference/src/forward/gpu/inner/api.rs
+++ b/crates/inference/src/forward/gpu/inner/api.rs
@@ -1,3 +1,4 @@
+//! GPU result/error types and Qwen3 GPU configuration and weight structs.
 use std::fmt;
 
 /// **Unstable**: GPU forward result type; error type may gain new variants.

--- a/crates/inference/src/forward/gpu/inner/bind_groups.rs
+++ b/crates/inference/src/forward/gpu/inner/bind_groups.rs
@@ -1,3 +1,4 @@
+//! WGPU bind-group structs and constructors for layer and global bindings.
 use std::num::NonZeroU64;
 
 use super::api::{Qwen3Config, Result};

--- a/crates/inference/src/forward/gpu/inner/buffers.rs
+++ b/crates/inference/src/forward/gpu/inner/buffers.rs
@@ -1,3 +1,4 @@
+//! GPU weight and activation buffer structs plus upload and activation-buffer creation helpers.
 use std::sync::{Arc, atomic::Ordering};
 
 use wgpu::util::DeviceExt;

--- a/crates/inference/src/forward/gpu/inner/dims.rs
+++ b/crates/inference/src/forward/gpu/inner/dims.rs
@@ -1,3 +1,4 @@
+//! GPU forward dimensions, configuration validation, and runtime feasibility validation.
 use super::api::checked_mul;
 use super::api::{GpuForwardError, GpuRuntimeConfig, Qwen3Config, Result};
 use super::params::ELEM_WG;

--- a/crates/inference/src/forward/gpu/inner/dispatch.rs
+++ b/crates/inference/src/forward/gpu/inner/dispatch.rs
@@ -1,3 +1,4 @@
+//! WGPU dispatch helpers for matmul, RMSNorm, copy, add, SiLU, multiply, RoPE, attention scores, softmax, and context.
 use super::api::Result;
 use super::dims::ForwardDims;
 use super::params::{

--- a/crates/inference/src/forward/gpu/inner/params.rs
+++ b/crates/inference/src/forward/gpu/inner/params.rs
@@ -1,3 +1,4 @@
+//! GPU shader/workgroup constants and parameter-slot constants.
 use std::sync::atomic::AtomicU64;
 
 use bytemuck::{Pod, Zeroable};

--- a/crates/inference/src/forward/gpu/inner/pipelines.rs
+++ b/crates/inference/src/forward/gpu/inner/pipelines.rs
@@ -1,3 +1,4 @@
+//! WGPU bind-group-layout and compute-pipeline creation helpers.
 use std::{borrow::Cow, num::NonZeroU64};
 
 use super::params::PARAM_SLOT_BYTES;

--- a/crates/inference/src/forward/gpu/inner/shaders.rs
+++ b/crates/inference/src/forward/gpu/inner/shaders.rs
@@ -1,3 +1,4 @@
+//! WGSL shader source constants for matmul, RMSNorm, copy, add, and related GPU kernels.
 pub(super) const MATMUL_BT_SHADER: &str = r#"
 @group(0) @binding(0) var<storage, read> A: array<f32>;
 @group(0) @binding(1) var<storage, read> B: array<f32>;

--- a/crates/inference/src/forward/gpu/inner/state.rs
+++ b/crates/inference/src/forward/gpu/inner/state.rs
@@ -1,3 +1,4 @@
+//! GPU model state, forward entry, and embedding helper.
 use std::sync::{Arc, Mutex, atomic::Ordering, mpsc};
 
 use super::api::checked_mul;

--- a/crates/inference/src/forward/gpu/inner/tests.rs
+++ b/crates/inference/src/forward/gpu/inner/tests.rs
@@ -1,3 +1,4 @@
+//! GPU-vs-CPU tiny-model tests and CPU reference helpers.
 use super::*;
 
 #[test]

--- a/crates/inference/src/forward/gpu/inner/util.rs
+++ b/crates/inference/src/forward/gpu/inner/util.rs
@@ -1,3 +1,4 @@
+//! GPU utility helpers for RoPE table building, byte counts, `usize` to `u32` conversion, and ceiling division.
 use super::api::checked_mul;
 use super::api::{GpuForwardError, Result};
 

--- a/crates/inference/src/forward/mod.rs
+++ b/crates/inference/src/forward/mod.rs
@@ -1,3 +1,4 @@
+//! Forward-kernel module index for batch prefill, BitNet, CPU, f16 CPU, q8 CPU, GPU, Metal, and NEON paths.
 pub mod batch_prefill;
 pub mod bitnet_kernel;
 pub mod cpu;

--- a/crates/inference/src/model/mod.rs
+++ b/crates/inference/src/model/mod.rs
@@ -1,3 +1,4 @@
+//! Model module index for BERT, BitNet config, cross-encoder, Qwen, Qwen3.5, and Qwen3.5 config, with BERT/CrossEncoder/Qwen/Qwen3.5 type re-exports.
 pub mod bert;
 pub mod bitnet_config;
 pub mod cross_encoder;

--- a/crates/inference/src/model/qwen35/cache.rs
+++ b/crates/inference/src/model/qwen35/cache.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 KV cache, forward scratch, and scratch resize helper.
 use crate::attention::gdn_fused::GatedDeltaNetFusedScratch;
 use crate::model::qwen35_config::Qwen35Config;
 

--- a/crates/inference/src/model/qwen35/debug.rs
+++ b/crates/inference/src/model/qwen35/debug.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 debug methods and debug statistics.
 use super::cache::{ForwardScratch, KvCache};
 use super::model::Qwen35Model;
 use super::norm::qwen35_rms_norm;

--- a/crates/inference/src/model/qwen35/detokenize.rs
+++ b/crates/inference/src/model/qwen35/detokenize.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 byte-decoder construction, token-byte appending, token decoding, incremental detokenization, and byte-to-Unicode mapping.
 use crate::tokenizer::bpe::BpeTokenizer;
 use std::collections::HashMap;
 

--- a/crates/inference/src/model/qwen35/forward.rs
+++ b/crates/inference/src/model/qwen35/forward.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 forward implementation, including `forward_step`, attention dispatch, full attention, and dense FFN paths.
 use super::cache::{ForwardScratch, KvCache};
 use super::model::Qwen35Model;
 use super::moe::moe_ffn_step;

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 generation, streaming generation, prefill/decode loops, stop-streamer utilities, and stop-token helpers.
 use super::cache::{ForwardScratch, KvCache};
 use super::detokenize::{IncrementalDetokenizer, decode_tokens};
 use super::model::Qwen35Model;

--- a/crates/inference/src/model/qwen35/loading.rs
+++ b/crates/inference/src/model/qwen35/loading.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 tensor-name requirements, validation, owned tensor loaders, layer-specific weight loaders, and `load_weights`.
 use super::weights::{
     AttentionWeights, CommonLayerWeights, DenseFfnWeights, FeedForwardWeights,
     FullAttentionLayerWeights, ModelWeights, MoeLayerWeights, MoeRouter, RoutedExperts,

--- a/crates/inference/src/model/qwen35/model.rs
+++ b/crates/inference/src/model/qwen35/model.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 model type, safetensors loader, accessors, LoRA setter, train-backward weight accessors, and layer weight statistics.
 use super::loading::{load_weights, validate_required_tensor_names};
 use super::weights::{AttentionWeights, FeedForwardWeights, ModelWeights};
 use crate::error::InferenceError;

--- a/crates/inference/src/model/qwen35/moe.rs
+++ b/crates/inference/src/model/qwen35/moe.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 MoE FFN step, router probabilities, top-k selection, selected-weight renormalization, routed expert accumulation, and shared expert application.
 use super::cache::ForwardScratch;
 use super::weights::MoeLayerWeights;
 use crate::forward::cpu::{elementwise_mul, matmul_bt, silu_inplace};

--- a/crates/inference/src/model/qwen35/norm.rs
+++ b/crates/inference/src/model/qwen35/norm.rs
@@ -1,3 +1,4 @@
+//! Shifted RMSNorm implementation used by the Qwen3.5 forward path.
 /// Qwen3.5 uses a shifted RMSNorm: `x * rsqrt(mean(x²) + eps) * (1 + gamma)`.
 /// Empirically verified by PPL — plain `gamma` (the standard convention used
 /// by Qwen3/Llama and MLX `nn.RMSNorm`) produces nonsense logits on this

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 token sampling, repetition penalty, greedy fallback, softmax probability build, top-p filtering, distribution draw, and RNG helper.
 use crate::model::qwen35_config::GenerateConfig;
 
 /// Sample a token from logits using temperature, top-k, top-p, and repetition penalty.

--- a/crates/inference/src/model/qwen35/tests.rs
+++ b/crates/inference/src/model/qwen35/tests.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 unit tests for partial RoPE, sampling, repetition penalty, detokenization, scratch temporaries, required tensor names, stop tokens, and MoE router construction.
 use super::moe::moe_ffn_step;
 use super::weights::{MoeLayerWeights, MoeRouter, RoutedExperts, SharedExpert};
 use super::*;

--- a/crates/inference/src/model/qwen35/weights.rs
+++ b/crates/inference/src/model/qwen35/weights.rs
@@ -1,3 +1,4 @@
+//! Qwen3.5 full-attention, common, dense, attention, model, and MoE weight structs plus `ModelWeights::logits_weight`.
 use crate::attention::gdn::GatedDeltaNetWeights;
 use crate::error::InferenceError;
 

--- a/crates/inference/src/pool.rs
+++ b/crates/inference/src/pool.rs
@@ -1,3 +1,4 @@
+//! BERT pooling enum and mean, last-token, CLS, and L2 pooling helpers.
 use crate::forward::cpu::simd_config;
 
 /// **Stable** (provisional): pooling strategy for BERT-family encoder models.

--- a/crates/inference/src/tokenizer/mod.rs
+++ b/crates/inference/src/tokenizer/mod.rs
@@ -1,3 +1,4 @@
+//! Tokenizer module index and re-exports for WordPiece, BPE, common tokenizer types/loaders, and SentencePiece.
 pub mod bpe;
 pub mod common;
 pub mod sentencepiece;

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -1,3 +1,4 @@
+//! Safetensors metadata and f32 weight structs, including tensor, transformer-layer, BERT, cross-encoder, safetensors-file, and Qwen layer weights.
 use crate::error::InferenceError;
 use memmap2::Mmap;
 use serde_json::Value;

--- a/crates/inference/src/weights/mod.rs
+++ b/crates/inference/src/weights/mod.rs
@@ -1,3 +1,4 @@
+//! Weight module index for f16, f32, q4, and q8 weights, with f32 weight re-exports.
 pub mod f16_weights;
 pub mod f32_weights;
 pub mod q4_weights;

--- a/docs/forward-pass.md
+++ b/docs/forward-pass.md
@@ -55,7 +55,8 @@ pre-attention RMSNorm.
 ### 8. Pre-attention norm — `crate::model::qwen35::norm::qwen35_rms_norm`
 
 `qwen35_rms_norm` is a shifted RMSNorm: it computes
-`inv_rms * (1.0 + gamma)` per element, where `gamma` is the learned weight.
+`x * inv_rms * (1.0 + gamma)` per element, where `x` is the input activation
+and `gamma` is the learned weight.
 
 ### 9. Attention dispatch — `crate::model::qwen35::Qwen35Model::run_attention_layer`
 
@@ -85,8 +86,11 @@ For full-attention layers:
 
 ### 12. Q/K/V projection — `crate::model::qwen35::Qwen35Model::project_qkv`
 
-`project_qkv` runs three independent matmuls to produce Q, K, V and applies
-per-head Q/K RMSNorm to each resulting head vector.
+`project_qkv` runs three matmuls. Because `attn_output_gate` is enabled, the
+Q projection weight is `[2*q_dim, hidden]`: it produces both `Q` and the output
+gate `Z` in a single matmul, which `split_q_and_gate` deinterleaves. The other
+two matmuls produce K and V. Per-head Q/K RMSNorm is applied to each resulting
+head vector; `gate_Z` is applied later as the sigmoid output gate.
 
 ### 13. Attention context — `crate::model::qwen35::Qwen35Model::compute_attention_context`
 
@@ -151,9 +155,10 @@ It applies, in order:
 
 1. Repetition penalty on the logit of recently generated tokens.
 2. Greedy fallback when temperature is zero or degenerate.
-3. Top-k filtering (retains the k highest logits).
-4. Softmax followed by top-p (nucleus) filtering.
-5. Draws a token from the resulting distribution.
+3. Temperature scaling of the logits (skipped when temperature is 1.0).
+4. Top-k filtering (retains the k highest logits).
+5. Softmax followed by top-p (nucleus) filtering.
+6. Draws a token from the resulting distribution.
 
 The drawn token id is appended to the generated sequence and becomes the
 input to the next `forward_step` call.

--- a/docs/forward-pass.md
+++ b/docs/forward-pass.md
@@ -1,0 +1,168 @@
+# Qwen3.5 Forward-Pass Walkthrough
+
+This document traces a token through the Qwen3.5 inference forward pass,
+referencing the real module and function names from `crates/inference/src/`.
+The path described here is the **Qwen3.5 path** (`crate::model::qwen35`).
+The older `crate::generate::generate` / `crate::sampling::Sampler::sample`
+path is a separate code path and is not described here.
+
+---
+
+## Step-by-step trace
+
+### 1. Generation entry — `crate::model::qwen35::Qwen35Model::generate`
+
+The caller invokes `Qwen35Model::generate` with a prompt string and a
+`GenerateConfig`. The method tokenizes the prompt and copies the resulting
+token ids into a local buffer.
+
+### 2. RNG initialization — `crate::model::qwen35::generation::initial_rng_state`
+
+`initial_rng_state` initializes a seeded or clock-derived RNG state. This
+state is threaded through all subsequent sampling calls.
+
+### 3. State allocation — `crate::model::qwen35::Qwen35Model::generate`
+
+`generate` allocates three per-session data structures:
+
+- `GatedDeltaNetState` — recurrent state for GDN (linear-attention) layers.
+- `KvCache` — key/value cache for full-attention layers.
+- `ForwardScratch` — reusable activation buffers (hidden, q, k, v, …).
+
+### 4. Prefill loop — `crate::model::qwen35::generation::prefill_tokens`
+
+`prefill_tokens` iterates over each prompt token and calls
+`model.forward_step(token_id, pos, …)` for each position, populating the
+KV cache and GDN state.
+
+### 5. Single-token forward entry — `crate::model::qwen35::Qwen35Model::forward_step`
+
+`forward_step` is the core per-token entry point used for both prefill and
+decode. It grows scratch buffer capacity if the current token position
+requires it.
+
+### 6. Embedding lookup — `crate::model::qwen35::Qwen35Model::forward_step`
+
+The embedding lookup is inline: the row for `token_id` is copied from
+`self.weights.embed_tokens` directly into `scratch.hidden`.
+
+### 7. Layer loop entry — `crate::model::qwen35::Qwen35Model::forward_step`
+
+`forward_step` loops over all hidden layers. For each layer it saves the
+current `scratch.hidden` as the residual stream and applies the
+pre-attention RMSNorm.
+
+### 8. Pre-attention norm — `crate::model::qwen35::norm::qwen35_rms_norm`
+
+`qwen35_rms_norm` is a shifted RMSNorm: it computes
+`inv_rms * (1.0 + gamma)` per element, where `gamma` is the learned weight.
+
+### 9. Attention dispatch — `crate::model::qwen35::Qwen35Model::run_attention_layer`
+
+`run_attention_layer` dispatches on the layer's attention type:
+
+- `AttentionWeights::Linear` → GDN branch (step 10).
+- `AttentionWeights::Full` → full-attention branch (step 11).
+
+### 10. GDN branch — `crate::attention::gdn_fused::gated_delta_net_step_fused`
+
+For linear-attention layers, `gated_delta_net_step_fused`:
+
+1. Projects Q, K, V, Z, beta, and alpha from the normed hidden state.
+2. Runs fused conv1d + SiLU on the input features.
+3. Updates the recurrent `GatedDeltaNetState`.
+4. Output-projects the result back to the residual dimension.
+
+### 11. Full-attention branch — `crate::model::qwen35::Qwen35Model::full_attention_step_from_attn_out`
+
+For full-attention layers:
+
+1. Projects Q, K, V (step 12).
+2. Applies Rotary Position Embeddings (RoPE) to Q and K.
+3. Appends the new K/V to the `KvCache`.
+4. Computes the attention context (step 13).
+5. Gates and output-projects the context.
+
+### 12. Q/K/V projection — `crate::model::qwen35::Qwen35Model::project_qkv`
+
+`project_qkv` runs three independent matmuls to produce Q, K, V and applies
+per-head Q/K RMSNorm to each resulting head vector.
+
+### 13. Attention context — `crate::model::qwen35::Qwen35Model::compute_attention_context`
+
+`compute_attention_context` computes scaled dot-product attention scores over
+the cached K vectors, applies causal softmax, and accumulates the weighted V
+vectors into `scratch.context`.
+
+### 14. Attention residual and post-attention norm — `crate::model::qwen35::Qwen35Model::forward_step`
+
+Back in `forward_step`, the attention output is added back to the residual
+stream and `qwen35_rms_norm` is applied again (post-attention norm).
+
+### 15. FFN dispatch — `crate::model::qwen35::Qwen35Model::run_ffn_layer`
+
+`run_ffn_layer` dispatches on the layer's FFN type:
+
+- Dense FFN → `dense_ffn_step_from_ffn_out` (step 16).
+- MoE FFN → `moe_ffn_step` (step 17).
+
+### 16. Dense MLP — `crate::model::qwen35::Qwen35Model::dense_ffn_step_from_ffn_out`
+
+The dense path:
+
+1. Runs gate and up matmuls on the normed hidden state.
+2. Applies SiLU to the gate output and elementwise-multiplies with the up output.
+3. Down-projects the result to the residual dimension.
+
+### 17. MoE FFN — `crate::model::qwen35::moe::moe_ffn_step`
+
+The Mixture-of-Experts path:
+
+1. Computes router probabilities from the normed hidden state.
+2. Selects and renormalizes the top-k expert scores.
+3. Accumulates each selected routed expert's contribution.
+4. Adds the shared expert's output.
+
+### 18. MLP residual — `crate::model::qwen35::Qwen35Model::forward_step`
+
+The FFN output is added back to the residual stream.
+
+### 19. Final RMSNorm — `crate::model::qwen35::Qwen35Model::forward_step`
+
+After the last layer, `forward_step` applies a final `qwen35_rms_norm` using
+`self.weights.final_norm`.
+
+### 20. LM head weight selection — `crate::model::qwen35::weights::ModelWeights::logits_weight`
+
+`logits_weight` selects the vocabulary projection weights: the explicit
+`lm_head` weight tensor if present, otherwise the tied `embed_tokens` tensor.
+
+### 21. Logit computation — `crate::forward::cpu::matmul_bt`
+
+`matmul_bt` (transposed-B matmul) multiplies the final hidden state against
+the vocabulary weight matrix, producing a logit vector of size `vocab_size`.
+
+### 22–23. Sampling — `crate::model::qwen35::sampling::sample_token`
+
+`sample_token` is the Qwen3.5 sampling entry point, called after each
+prefill step and in the decode loop.
+
+It applies, in order:
+
+1. Repetition penalty on the logit of recently generated tokens.
+2. Greedy fallback when temperature is zero or degenerate.
+3. Top-k filtering (retains the k highest logits).
+4. Softmax followed by top-p (nucleus) filtering.
+5. Draws a token from the resulting distribution.
+
+The drawn token id is appended to the generated sequence and becomes the
+input to the next `forward_step` call.
+
+---
+
+## Scope note
+
+This walkthrough covers the Qwen3.5 code path only. The codebase also
+contains an older generation path (`crate::generate::generate`) with its own
+sampler (`crate::sampling::Sampler::sample`); that path is not described here
+and must not be conflated with the Qwen3.5 path above.


### PR DESCRIPTION
## What

Docs-only pass for issue #304. **Zero** executable-code, signature, type, test, or bench changes — the only `.rs` edits are module-level `//!` rustdoc headers (54 files, exactly one `+//!` line each, verified via `git diff -- '*.rs' | grep '^+' | grep -v '^+//!'` → empty).

**New narrative doc**
- `docs/forward-pass.md` — Qwen3.5 forward-pass walkthrough (embedding → layers (GDN/full attention, MLP/MoE) → final norm → lm_head → sampling).

**Module-level `//!` rustdoc added** to `crates/inference/src/`:
- `attention/`: `flash.rs`, `mod.rs`, `standard.rs`
- `backward/`: `attention_gqa.rs`, `gradcheck.rs`, `mod.rs`, `ops.rs`, `tape.rs`
- `bin/ppl_metal.rs`, `download.rs`, `error.rs`, `pool.rs`
- `forward/mod.rs`
- `forward/cpu/`: `activation.rs`, `arch_kernels.rs`, `blas.rs`, `elementwise.rs`, `matmul.rs`, `mod.rs`, `norm.rs`, `simd.rs`, `softmax.rs`, `tests.rs`, `tiled.rs`, `tiled_avx2.rs`, `tiled_neon.rs`
- `forward/gpu/inner.rs` and `forward/gpu/inner/`: `api.rs`, `bind_groups.rs`, `buffers.rs`, `dims.rs`, `dispatch.rs`, `params.rs`, `pipelines.rs`, `shaders.rs`, `state.rs`, `tests.rs`, `util.rs`
- `model/mod.rs`
- `model/qwen35/`: `cache.rs`, `debug.rs`, `detokenize.rs`, `forward.rs`, `generation.rs`, `loading.rs`, `model.rs`, `moe.rs`, `norm.rs`, `sampling.rs`, `tests.rs`, `weights.rs`
- `tokenizer/mod.rs`
- `weights/`: `f32_weights.rs`, `mod.rs`

**Not created** (FindExisting): no crate READMEs (`ls crates/*/README.md` → all five workspace members `embed`, `fann`, `inference`, `transport`, `tune` already have one); no `RELEASE.md` (existing `docs/releases/` covers through v0.4.2 and `docs/_templates/RELEASE.md` exists). The stale issue text still lists inference/transport READMEs as missing — superseded by the current-branch inventory.

## Verification (anti-#303)

Every load-bearing claim was checked against the **actual current worktree source**, not training data or the (stale) issue text:

- **Crate version `0.4.2`** — read from workspace `Cargo.toml` (`version = "0.4.2"`); each member inherits via `version.workspace = true`. No version string was invented or bumped.
- **Crate README inventory** — verified by `ls crates/*/README.md`; all five present → no README written (avoids the #303 duplication/staleness failure).
- **Feature flags** — cross-checked against each `Cargo.toml` (`inference`: `default/std/f16/metal-gpu/wgpu-gpu/bench-internals/bench-ort/backfill/download/train-backward/mixture`; `embed`: `default/native/metal-gpu/avx512/local`).
- **Forward-pass walkthrough — every step names a real `module::fn` confirmed in source** (`grep` over `crates/inference/src/`):
  - `Qwen35Model::generate` — `model/qwen35/generation.rs:16`
  - `initial_rng_state`, `prefill_tokens` — `model/qwen35/generation.rs`
  - `Qwen35Model::forward_step`, `run_attention_layer`, `full_attention_step_from_attn_out`, `project_qkv`, `compute_attention_context`, `run_ffn_layer`, `dense_ffn_step_from_ffn_out` — `model/qwen35/forward.rs`
  - `qwen35_rms_norm` — `model/qwen35/norm.rs`
  - `gated_delta_net_step_fused` — `attention/gdn_fused.rs`
  - `moe_ffn_step` — `model/qwen35/moe.rs`
  - `ModelWeights::logits_weight` (ties to `embed_tokens` when `lm_head` absent) — `model/qwen35/weights.rs:52-54`
  - `forward::cpu::matmul_bt` — `forward/cpu/matmul.rs:66` (`pub fn`)
  - `sample_token` — `model/qwen35/sampling.rs`
  - Supporting facts verified: `enum AttentionWeights { Linear, Full }` (`weights.rs:38-41`), `embed_tokens`/`final_norm` weight fields. The legacy Qwen path (`crate::generate::generate`, `Sampler::sample`) is explicitly fenced off as **not** the path described.
- **`//!` headers** — each header's content matches its module's actual contents; sampled (`sampling.rs`, `forward/cpu/mod.rs`, `norm.rs`) confirmed. No fabricated APIs, LOC counts, or perplexity numbers anywhere — the #303 failure mode is not repeated.

## Perf

Docs only. No code changed, so `make bench-compare` has nothing to report.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | PASS (exit 0) |
| `cargo doc --workspace --no-deps` | PASS (exit 0) — pre-existing repo-wide broken-link warnings only; **zero introduced** by this branch (every added `//!` uses backtick code-spans, never `[Item]` link syntax) |
| `cargo clippy --workspace -- -D warnings` | PASS (exit 0) |
| `cargo build --workspace` | PASS (exit 0) |

Refs #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
