### PR TITLE
docs(adr): align ADR set with shipped code + add ADR-065 feature-promotion gates

### DIFF
--- a/docs/adr/ADR-008-lora-injection.md
+++ b/docs/adr/ADR-008-lora-injection.md
@@ -79,7 +79,7 @@ Define `LoraHook` as a **`Send + Sync` trait in `lattice-inference`** with a `No
 
 - Zero overhead in production builds with `NoopLoraHook` (no branch, no call, no memory access).
 - `platform/tune` can implement `LoraHook` with any rank decomposition without modifying the kernel.
-- Multiple adapters can be composed by chaining hooks.
+- Multiple adapters can be composed outside the hook by pre-blending compatible LoRA layer data into one rank-sum adapter before loading the existing single-adapter path; the hook itself still represents one adapter application.
 - The string-based module API is forward-compatible with new architectures.
 
 **Negative**:

--- a/docs/adr/ADR-045-quarot-lora-composition.md
+++ b/docs/adr/ADR-045-quarot-lora-composition.md
@@ -216,8 +216,8 @@ When `quarot_seed` is `None` (unrotated Q4 base): skip rotation correction, uplo
 
 ### Risks
 
-1. **Adapter compatibility**: adapters trained on a different tokenizer / model revision won't match. Gate on config hash at load time.
-2. **Multi-adapter / MoLoRA**: this spec covers single-adapter injection. MoLoRA (mixture routing) is a v2 extension — the KG already has the W2-barycenter theory (`W2-Barycenter-Adapter-Blending`, `MoLoRA-W2-Covariance-Gap-Analysis`). The counter-rotation applies identically to each expert's A matrix.
+1. **Adapter compatibility**: adapters trained on a different tokenizer / model revision won't match. The governed manifest records `base_model_rev` and `tokenizer_rev`, and the loader fail-closes on status, bounded file size, SHA-256 mismatch, parse errors, rank/alpha/module/dimension validation; it does **not** yet compare base/tokenizer revisions or a config hash at load time.
+2. **Multi-adapter / MoLoRA**: a simple weighted decode-time mixture has shipped as a CPU pre-blend: `A_blend = vconcat(A_i)`, `B_blend = hconcat(w_i * B_i)`, then the existing single-adapter Metal path loads the rank-sum adapter. Learned/router mixture code is feature-gated behind `mixture`; W2-barycenter composition remains research background rather than the shipped blend path. The counter-rotation still applies to each expert's A matrix before/within composition.
 3. **Adapter rank explosion at Q4 precision**: the Q4 GEMV operates in reduced precision; the LoRA addition is f32/f16. This is actually *good* — the adapter delta is the high-precision correction on top of the quantized base. No precision loss on the personalization signal.
 4. **GDN layers**: Qwen3.5's GDN (Gated Delta Network) layers have `in_proj_qkv`, `in_proj_z`, `in_proj_a`, `in_proj_b`, `out_proj`. If users target these with LoRA (uncommon but possible), the same counter-rotation logic applies — the plan already covers them.
 
@@ -257,7 +257,7 @@ Steps 1-4 complete. Prefill falls back to sequential when adapter active (no bat
 - ADR-043: LoRA serving verification (existing LoRA correctness framework)
 - KG: `LoRA-Low-Rank-Adaptation` (e916fb8b), `LoraAdapter` (2d2ee731), `LoraHook` (7668f8d9)
 - KG: `QuaRot (Ashkboos 2024)` (86ec6a4f) — now `status: implemented`
-- KG: `W2-Barycenter-Adapter-Blending` (e6a40019) — MoLoRA v2 extension
+- KG: `W2-Barycenter-Adapter-Blending` (e6a40019) — research background; shipped decode mixture uses weighted rank-sum CPU pre-blend, not W2 barycenter transport
 - Hu et al. 2021, "LoRA: Low-Rank Adaptation of Large Language Models", arXiv:2106.09685
 - Ashkboos et al. 2024, "QuaRot: Outlier-Free 4-Bit Inference in Rotated LLMs", arXiv:2404.00456
 

--- a/docs/adr/ADR-046-structured-output.md
+++ b/docs/adr/ADR-046-structured-output.md
@@ -4,6 +4,10 @@
 **Date**: 2026-05-19
 **Crate**: lattice-inference
 
+## Implementation status as of 2026-06-30
+
+The grammar engine and JSON Schema compiler are implemented under `crates/inference/src/grammar/`. The compiler now has fail-closed compile-time caps for array cardinality, schema depth, object property count, trie depth, and precomputed grammar states. The current `lattice_serve` request shape does **not** expose OpenAI `response_format`; its generation config sets `grammar: None`, so serve-side structured output remains unshipped even though the grammar module exists.
+
 ## Context
 
 Agent and tool-call workflows require the model to emit syntactically valid output (JSON schema,

--- a/docs/adr/ADR-056-lora-tuning-pipeline.md
+++ b/docs/adr/ADR-056-lora-tuning-pipeline.md
@@ -723,13 +723,8 @@ changes require a new ADR.
 - Hu et al. 2021 — "LoRA: Low-Rank Adaptation of Large Language Models" — https://arxiv.org/abs/2106.09685
 - Dettmers et al. 2023 — "QLoRA: Efficient Finetuning of Quantized LLMs" — https://arxiv.org/abs/2305.14314
 
-## Implementation status (2026-06-24)
+## Implementation status as of 2026-06-30
 
-The `LoraTrainLoop` struct and the `train/lora/` directory proposed in this ADR were never
-created. Real backward-pass LoRA training shipped via a different code path:
-`crates/tune/src/bin/train_grad_full.rs` is the training binary, and backward pass primitives
-live under `crates/tune/src/` (lora/, train/ sub-directories). The
-`crates/inference/src/backward/` module (attention_gqa.rs, gradcheck.rs, ops.rs, tape.rs)
-holds the autograd tape. Anyone extending LoRA training should start from
-`crates/tune/src/bin/train_grad_full.rs` and `crates/tune/src/lora/online.rs`, not from
-the `LoraTrainLoop` / `train/lora/` paths described in this ADR's architecture section.
+The `LoraTrainLoop` struct and the `train/lora/` directory proposed in this ADR were never created. Real backward-pass LoRA training shipped via a different code path: `crates/tune/src/bin/train_grad_full.rs` is the full training binary, and backward-pass primitives live under `crates/tune/src/` plus the autograd tape in `crates/inference/src/backward/`. A bounded governed micro-trainer also shipped as `train_micro_lora` in `crates/tune/src/lora/train.rs`; it validates rank, step count, sequence length, layer bounds, token ids, and pair shapes before training.
+
+Anyone extending LoRA training should start from `crates/tune/src/bin/train_grad_full.rs`, `crates/tune/src/lora/train.rs`, and `crates/tune/src/lora/online.rs`, not from the `LoraTrainLoop` / `train/lora/` paths described in this ADR's architecture section. The ADR design remains a proposed full-pipeline shape; shipped code is partial and path-divergent.

--- a/docs/adr/ADR-060-pruning-toolbox.md
+++ b/docs/adr/ADR-060-pruning-toolbox.md
@@ -677,13 +677,8 @@ lattice_pruning.json        # method, sparsity stats
 - QuaRot (existing): `e754741e`
 - lattice-inference (existing): `6c0a97df`
 
-## Implementation status (2026-06-24)
+## Implementation status as of 2026-06-30
 
-Only the D2 ShortGPT block-influence scorer has shipped. `BlockInfluence` and
-`BlockInfluenceAccumulator` are implemented at `crates/inference/src/pruning.rs:62` and `121`.
-The `CalibrationObserver` trait (D1/P0), `Wanda` per-channel activation scorer, and `SliceGPT`
-PCA-rotation infrastructure are not present in source — `pruning.rs` module doc notes that
-`CalibrationObserver` and `ForwardCtx` hooks are "ADR-060 D1/P0 work (future PR)". Grep for
-`Wanda`, `SliceGPT`, and `CalibrationObserver` in `crates/` returns no type definitions. The
-`OrthogonalBasis` trait and `BasisKind` enum referenced in the ADR-044 Amendment are also not
-yet implemented (they are a design proposal).
+Partial shipment only. Shipped pieces are the D2-style block-influence scorer and layer-removal plumbing: `BlockInfluence`, `BlockInfluenceAccumulator`, `score_from_hidden_states`, Metal `LayerImportanceScore`, Metal `LayerPruningPlan`, `score_layer_importance`, and `Qwen35Config::apply_layer_mask`. These support scoring layer importance and applying a layer mask in memory.
+
+Still not shipped: D1 calibration observer / `ForwardCtx` hooks, the shared `LayerStats`/`CalibrationObserver` pipeline, D3 SliceGPT residual-width slicing, D4 Wanda/STADE per-channel scoring, D5 GQA head pruning, D6 SwiGLU FFN pruning, `PrunePlan` serialization, and the PPL-gated iterative pruning workflow. `CalibrationObserver` and `ForwardCtx` appear only as future-work comments; source searches for `Wanda`, `SliceGPT`, and `CalibrationObserver` find no implemented type definitions under `crates/`.

--- a/docs/adr/ADR-063-serving-architecture.md
+++ b/docs/adr/ADR-063-serving-architecture.md
@@ -4,12 +4,11 @@
 **Date**: 2026-05-27
 **Crate**: lattice-inference (new `serve` module + unified binary)
 
-## Implementation status (2026-06-24)
+## Implementation status as of 2026-06-30
 
-Phase 1 batch scheduling infrastructure is implemented. `crates/inference/src/batch/` exists with
-`config.rs`, `mod.rs`, `scheduler.rs`, `sequence.rs`, and `worker.rs`. Phase 2 (HTTP server,
-OpenAI/Anthropic API compatibility, GPU worker pool) has not been built. There is no `serve` binary
-or HTTP listener in the codebase as of this date.
+Partially shipped. The dedicated `lattice_serve` binary now exists as a Metal/f16 OpenAI-compatible HTTP daemon with `/v1/chat/completions`, `/v1/models`, and `/health` routes. It owns one resident Metal worker, loads the model once, and resets Metal/KV state for each job, so warm-serve keeps weights resident while requests remain stateless. Serve-side DoS hardening clamps `reasoning_budget` and `max_tokens` to `MODEL_MAX_CONTEXT` before constructing `GenerateConfig` and before generation allocates `generated_ids`; grammar compilation also has cardinality/depth/property/state caps in the grammar module.
+
+Still not shipped from this ADR: the full unified `lattice` CLI product surface, model acquisition/registry, Anthropic `/v1/messages`, continuous batching scheduler integration, GPU worker pool, `response_format` exposure in `lattice_serve`, embeddings route, auth, metrics, and prefix/radix cache product behavior.
 **Research**: RQ-5 (`workspaces/20260527/05.md`, 1583 lines)
 **Issues**: #91 (CLI), #92 (daemon), #93 (OpenAI API), #94 (Anthropic API)
 **Depends on**: ADR-048 (Continuous Batching), ADR-046 (XGrammar Structured Output), ADR-047 (Paged KV Cache)
@@ -34,7 +33,7 @@ Lattice has zero product surface. There are 9 standalone binaries in `crates/inf
 | `qwen35_debug`     | Debug diagnostic for Qwen3.5-2B forward pass           |
 | `qwen35_generate`  | Text generation demo                                   |
 
-No unified CLI. No server. No HTTP handler. No API compatibility layer. A new user must `cargo run --release --bin chat_metal -- --model-dir /path/to/weights` to get a single chat response. There is no model acquisition, no model registry, no way to serve requests concurrently, and no way for external tools to talk to lattice over HTTP.
+At ADR authoring time there was no unified CLI, server, HTTP handler, or API compatibility layer. As of 2026-06-30, `lattice_serve` provides a Metal/f16 OpenAI-compatible HTTP daemon and `chat_metal --json --serve` provides warm resident-process request handling. The full unified CLI, model acquisition, model registry, Anthropic compatibility, concurrent scheduler integration, and broader product surface remain incomplete.
 
 ### Competitive landscape
 
@@ -50,7 +49,7 @@ Every competitor has `serve` as a first-class command:
 | **Candle**            | Rust           | Framework/library                                                                                        | CPU/CUDA/WASM       | Rust ML framework, safetensors, examples                                                                                       | More framework than polished LLM serving product                                                                                                                                                            |
 | **mistral.rs**        | Rust           | Strong: CLI run/serve, OpenAI API, quantization, Metal, multimodal, tool use, SDKs                       | Broad (CUDA+Metal)  | Nearest Rust competitor: zero-config HF loading, quantization breadth (GGUF/GPTQ/EXL2/HQQ), vision models, agent/tool features | Direct competitor; broader model+quant support. Lattice wedge: research-composable architecture (10 attn mechanisms, QuaRot, architecture search DSL), verified inference, Apple-Silicon-first optimization |
 | **Burn**              | Rust           | Framework (not LLM-serving product)                                                                      | CPU/CUDA/WASM/Metal | Type-safe Rust ML framework, auto-diff, training                                                                               | ML framework, not polished inference server; no LLM-specific serving features                                                                                                                               |
-| **lattice**           | Pure Rust      | **Currently missing**                                                                                    | Apple Silicon first | 10 attention mechanisms, QuaRot Q4, speculative decoding, embeddings, formal verification path                                 | Must add CLI/server/API immediately                                                                                                                                                                         |
+| **lattice**           | Pure Rust      | Dedicated Metal/f16 HTTP daemon shipped; unified CLI/product surface still incomplete                                            | Apple Silicon first | 10 attention mechanisms, QuaRot Q4, speculative decoding, embeddings, formal verification path                                 | Complete CLI/model registry/Anthropic/concurrency/product surface after the shipped OpenAI-compatible daemon                                                                                                  |
 
 ### Market validation for inference infrastructure
 
@@ -481,7 +480,7 @@ Responsibilities:
 
 3. **Model alias resolution**: `"model": "qwen3-0.6b-q4"` resolves through the model registry to the physical model path and metadata.
 
-4. **Response format dispatch**: `response_format: {"type": "json_object"}` activates the XGrammar engine (ADR-046) with a JSON grammar. `{"type": "json_schema", "json_schema": {...}}` converts the schema to a grammar. Unsupported features return `400 unsupported_schema_feature`.
+4. **Response format dispatch**: planned API behavior is that `response_format: {"type": "json_object"}` activates the XGrammar engine (ADR-046) with a JSON grammar, and `{"type": "json_schema", "json_schema": {...}}` converts the schema to a grammar. As of 2026-06-30, `lattice_serve` does not expose `response_format`; `build_cfg` sets `grammar: None`.
 
 ### D4: Inference scheduler
 
@@ -617,8 +616,8 @@ When `--spec ngram` or `--spec mtp` is set, the scheduler integrates with ADR-00
 | `stop`                                    | Implement. String or array of strings                                             |
 | `seed`                                    | Implement. Deterministic sampling when set                                        |
 | `response_format: {"type":"text"}`        | Default. Normal decoding                                                          |
-| `response_format: {"type":"json_object"}` | JSON grammar-constrained decoding (ADR-046)                                       |
-| `response_format: {"type":"json_schema"}` | Convert schema to grammar; `400` if unsupported features                          |
+| `response_format: {"type":"json_object"}` | Planned; grammar engine exists, but `lattice_serve` does not expose `response_format` as of 2026-06-30 |
+| `response_format: {"type":"json_schema"}` | Planned; JSON Schema compiler exists with fail-closed caps, but the serve request shape does not yet expose this field |
 | `tools`, `tool_choice`                    | Parse; v1 rejects with clear error unless model/template supports it              |
 | `logprobs`                                | Do not fake. Return `400 unsupported_feature`                                     |
 | `n > 1`                                   | Return `400` for v1                                                               |

--- a/docs/adr/ADR-065-feature-promotion-gates.md
+++ b/docs/adr/ADR-065-feature-promotion-gates.md
@@ -1,0 +1,211 @@
+# ADR-065: Feature Promotion Gates — Merge Measured Primitives, Not Research Ideas
+
+**Status**: Proposed
+**Date**: 2026-06-30
+**Scope**: lattice workspace — all feature branches, research issues, and experiment PRs
+**Depends on**: ADR-064 (CI Gate Taxonomy and Promotion Policy)
+
+---
+
+## Context
+
+Lattice ships a research-composable inference kernel. The cost of this composability is an ever-growing backlog of ideas that are technically plausible but not yet measured: learnable test-time state updates, latent GDN reasoning, state interpolation, adaptive compute routing, and more. Without a shared gate taxonomy, the bar for "ready to merge" is implicit and inconsistent — some PRs land at the research-note stage, others stall indefinitely because the bar is unclear.
+
+ADR-064 classifies *existing* CI gates. This ADR defines the *decision rule* for any new feature or research idea from inception to default-on: a five-level gate ladder where each level has an explicit measurable threshold and a standard issue template that every research question must answer before merge.
+
+The core tension is: features are cheap to add and expensive to maintain. Every default-on feature is a permanent regression surface, a forever-tested configuration, and a mental model that every future developer must carry. The gate ladder is designed to make that cost explicit before it is paid.
+
+---
+
+## Decision
+
+### Principle
+
+**Lattice merges measured primitives, not research ideas.**
+
+A research idea may be correct. It may even be elegant. It does not merge until it has produced a measurement that could falsify it, passed a kill threshold that would have killed it if it were wrong, and lived behind a flag long enough to accumulate evidence. The gate ladder encodes this as five levels; every feature must pass its entry gate before merge.
+
+---
+
+### The Five-Gate Ladder
+
+#### G0 — Research Note
+
+A research note is a markdown issue, a Jupyter/Pluto notebook, or a script under `experiments/`. It does **not** touch any file in `crates/` or `.github/`. Its only merge bar is that it is readable and cites the evidence it is based on.
+
+G0 artifacts: GitHub issue, `experiments/<topic>/`, literature reference.
+
+#### G1 — Measurement Primitive
+
+A measurement primitive adds visibility *without changing model output*. It is telemetry, a bench harness, a state dump, or a JSONL trace, always behind a Cargo feature flag or a runtime `LATTICE_*` env var.
+
+Merge bar for G1:
+- Adds no observable change to generated token sequences when the flag is off.
+- `< 2%` decode-throughput overhead when the flag is on; `0%` when off (confirmed by `bench_decode_ab` on the primary target workload).
+- Stable JSONL schema that captures at minimum: `model`, `tokenizer`, `quant`, `commit`, `hardware`, `prompt_hash`, and the metric being observed.
+- No change to any existing public API surface.
+
+G1 artifacts: Cargo feature or env-gated telemetry path, bench JSONL trace, schema doc.
+
+#### G2 — Experiment Branch
+
+An experiment branch implements the feature idea behind a named feature gate. It does not change any default behavior.
+
+Merge bar for G2:
+- Exactly one target benchmark (the primary metric this feature is supposed to improve).
+- Exactly one baseline measurement on the same hardware and model checkpoint (committed as `experiments/<name>/baseline.jsonl`).
+- Exactly one kill threshold: a value of the primary metric at or below which the branch is abandoned (committed as `experiments/<name>/kill_threshold.md`).
+- Machine-readable metrics output (JSONL conforming to the G1 schema).
+- Reproducible from a single command: `cargo bench --features <flag> -- <bench_name>` or equivalent.
+
+G2 artifacts: feature-gated implementation, `experiments/<name>/baseline.jsonl`, `experiments/<name>/kill_threshold.md`, CI bench integration.
+
+#### G3 — Default-Off Feature
+
+A default-off feature has beaten its baseline on the primary metric, survived its kill threshold, and produced no regression on secondary metrics. It ships with the feature gate off in `Cargo.toml` defaults and in all CI configurations unless explicitly activated.
+
+Merge bar for G3 (all thresholds must be met simultaneously):
+
+| Metric class | Threshold |
+|---|---|
+| Speed | ≥ 15% wall-clock improvement on the primary decode or prefill benchmark |
+| Memory | ≥ 20% peak memory reduction (if memory is the primary claim) |
+| Quality | Statistically significant improvement at matched token counts (p < 0.05, Welch t-test or bootstrap CI) |
+| Safety | Lower false-negative rate at matched false-positive rate on the safety eval suite |
+| Telemetry overhead | < 2% decode throughput impact when on; exactly 0% when off |
+| Training overhead | No hot-path cost increase unless < 5% additional decode overhead |
+
+A G3 feature may relax any threshold that is not its primary claim (e.g., a speed feature need not show memory improvement), but it must not *worsen* any metric beyond measurement noise (< 1 σ of the baseline distribution).
+
+G3 artifacts: feature-gated implementation, full benchmark results against G2 baseline, CI integration with feature enabled, updated `docs/adr/` entry or new ADR.
+
+#### G4 — Default-On
+
+Default-on is rare and reserved for primitives that cannot be wrong by construction. Acceptable G4 categories:
+
+- **Pure telemetry-off paths**: a code path that is only reached when a telemetry feature is explicitly disabled; removing it cannot change model behavior.
+- **Deterministic artifacts**: changes that produce bit-identical output under all inputs (e.g., a correctness fix, a deterministic hash, a canonical serialization format).
+- **Exact snapshot/restore**: checkpoint/restore logic that is verified to round-trip by property test.
+- **Safe scheduling or cache management**: changes to KV page allocation or scheduler bookkeeping that preserve all existing invariants and are covered by the existing property-test suite.
+- **No-quality-loss kernels**: a kernel replacement verified to be numerically identical to the replaced kernel by the existing forward-equivalence test suite.
+
+G4 merge bar: the category must be justified in the PR description by reference to one of the five categories above, and the relevant test must pass in CI.
+
+---
+
+### The Eight-Question Issue Template
+
+Every GitHub issue that proposes a new feature or research direction must answer all eight questions before any code is written. Unanswered questions are not acceptable; `N/A` requires justification.
+
+```markdown
+## Feature Proposal Checklist
+
+1. **User-visible outcome**: What user-observable behavior improves if this works?
+   <!-- e.g., "Time-to-first-token for long-context requests drops by ≥ 15%" -->
+
+2. **Prior art**: What existing implementation, paper, or ADR already covers this?
+   <!-- If none, explain why this is genuinely novel. -->
+
+3. **Cheapest falsifying experiment**: What is the smallest experiment that would
+   prove this idea wrong?
+   <!-- e.g., "Run bench_decode_ab with flag on vs off on a 2k-token prompt" -->
+
+4. **Promote threshold**: At what measured value does this become a G3 candidate?
+   <!-- Must be a concrete number, e.g., "> 15% wall-clock on bench_decode_ab" -->
+
+5. **Kill threshold**: At what measured value is this idea abandoned?
+   <!-- Must be a concrete number, e.g., "< 5% improvement after 3 experiment PRs" -->
+
+6. **Code location before proof**: Where does the implementation live while it is
+   still at G0/G1/G2?
+   <!-- e.g., "experiments/mtp-adaptive-draft/ or behind feature = 'exp-adaptive'" -->
+
+7. **Default-on guard**: What flag or Cargo feature prevents this from becoming
+   default-on before it reaches G4?
+   <!-- e.g., "LATTICE_ADAPTIVE_DRAFT=1 env var; default false" -->
+
+8. **Gate level**: What gate level (G0–G4) does this PR target?
+   <!-- G0 = research note only; G1 = telemetry; G2 = experiment; G3 = default-off; G4 = default-on -->
+```
+
+---
+
+### The Adaptive-Feature Gating-Vector Pattern
+
+Any feature whose job is to "decide how hard to think" or "how much to trust this token" should be built as a gating vector that maps cheap per-token signals to a calibrated error probability and then to an action. This is the standard shape for adaptive compute features in lattice; new features in this space should follow it rather than inventing ad hoc routing logic.
+
+#### Cheap per-token signals (inputs)
+
+| Signal | Source | Cost |
+|---|---|---|
+| Token entropy | softmax of top-k logits | one pass over logits |
+| Top-k logit mass | sum of top-k softmax | same pass |
+| Logit margin (top1 − top2) | already computed for sampling | free |
+| Sequence average log-prob | running sum, O(1) update | O(1) per token |
+| MTP accept rate | `MtpVerifier` output | G1 telemetry flag |
+| MTP head disagreement | KL between draft and target distributions | G1 telemetry flag |
+| GDN state-delta cosine | cosine similarity of consecutive `GatedDeltaNetState` snapshots | G1 telemetry flag |
+| State-norm growth | L2 norm of delta between snapshots | G1 telemetry flag |
+| Gate entropy | entropy of GDN gating vector | G1 telemetry flag |
+| Context length | token position / KV fill fraction | free |
+| Domain flags | per-request metadata (e.g., code, math, safety-sensitive) | O(1) |
+
+#### Calibrated error probability (intermediate)
+
+The signals above are mapped to a single scalar `p_err ∈ [0, 1]` representing the estimated probability that the current token or segment is in the tail of the model's competence distribution. Calibration is required: raw confidence scores are systematically over- or under-confident.
+
+**Isotonic regression / UCCI-style margin calibration** is the recommended prior art. Isotonic regression fits a monotone mapping from the raw score (e.g., logit margin) to empirical error rate on a held-out calibration corpus without assuming a parametric form. Conformal / UCCI-style margin calibration extends this to sequence-level coverage guarantees. Isotonic regression is available directly as a scikit-learn primitive (`sklearn.isotonic`); the conformal variants are standard, separately-published methods. Both families have been validated on LLM confidence calibration tasks. Any G2 or G3 gating-vector feature must include a calibration curve on the primary eval corpus as part of its benchmark output.
+
+#### Action set (outputs)
+
+| Action | Trigger condition | Cost |
+|---|---|---|
+| `allow-direct` | `p_err < θ_low` | baseline decode |
+| `short-think` | `θ_low ≤ p_err < θ_mid` | reasoning budget × short multiplier |
+| `long-think` | `θ_mid ≤ p_err < θ_high` | reasoning budget × long multiplier |
+| `multi-sample` | `p_err ≥ θ_high` and budget allows | N independent samples, majority vote |
+| `escalate-larger-local-model` | `p_err ≥ θ_high` and larger model available | switch to resident larger model |
+| `quarantine-or-defer` | safety flag set or `p_err = 1.0` | return structured error |
+
+Thresholds `θ_low`, `θ_mid`, `θ_high` are calibrated per domain and per model checkpoint. They are not compile-time constants; they are loaded from a config file at model startup and are themselves G1-gated until calibrated on production data.
+
+---
+
+### Closing Note: Research Roadmap and High-Risk Hypotheses
+
+The open research-roadmap epics — adaptive compute routing, MTP acceptance-rate-driven early exit, GDN state-guided speculative drafting, and domain-aware threshold tuning — are the first consumers of this ADR. Each of those epics should open with the eight-question template and proceed through the gate ladder in order.
+
+Three hypotheses carry elevated risk because they require state telemetry that does not yet exist:
+
+- **Learnable test-time state updates**: updating model parameters or adapter weights at inference time based on the current sequence. Risk: silent distribution shift, unbounded memory, and safety-surface expansion.
+- **Latent GDN reasoning**: using the GDN state vector as an implicit chain-of-thought medium without an explicit reasoning trace. Risk: unobservable intermediate state makes safety evaluation impossible.
+- **State interpolation**: interpolating between two GDN state vectors to blend two conversation contexts. Risk: emergent behavior at the interpolation boundary has no principled bound.
+
+All three **stay at G0 or G1** until the G1 state-telemetry primitive (GDN state-delta cosine, state-norm growth, gate entropy) exists in production and has accumulated sufficient calibration data to make the kill thresholds in the eight-question template meaningful. Merging any of these hypotheses before state telemetry exists would mean shipping a G3 feature with an untestable kill threshold — a direct violation of this ADR's principle.
+
+---
+
+## Consequences
+
+**Positive**:
+- Any contributor opening a new research issue knows exactly what questions to answer and what gate to target.
+- The kill threshold is committed before the feature is built, removing retrospective ambiguity about when to abandon a direction.
+- G1 measurement primitives accumulate calibration data that makes all future gating-vector features cheaper to evaluate.
+
+**Negative**:
+- The gate ladder adds friction for genuinely obvious improvements that would have passed G3 trivially. Mitigation: G3 merge bar can be satisfied in a single PR if the experiment results are included.
+- Calibration curves require a held-out corpus, which must be maintained as the model checkpoint evolves.
+
+---
+
+## References
+
+- ADR-064: CI Gate Taxonomy and Promotion Policy
+- ADR-006: Speculative Decoding (`MtpVerifier`, GDN rollback — G1 telemetry consumers)
+- ADR-052: GDN State Management (`GatedDeltaNetState::snapshot`/`restore_from` — state telemetry substrate)
+- ADR-061: Inference Metrics Infrastructure — the G1 substrate for metric capture
+- Isotonic regression calibration: Zadrozny & Elkan 2002, "Transforming classifier scores into accurate multiclass probability estimates"
+- Conformal calibration (comparison method, distinct from isotonic regression): Angelopoulos & Bates 2023, "Conformal Risk Control", arxiv:2208.02814
+- `crates/inference/src/attention/gdn.rs` — `GatedDeltaNetState::snapshot`/`restore_from`
+- `crates/inference/src/speculative.rs` — `MtpVerifier`, accept-rate tracking
+- `crates/inference/src/metrics.rs` — `LayerMetrics`, `ForwardMetrics`

--- a/docs/adr/ADR-ALIGNMENT-AUDIT.md
+++ b/docs/adr/ADR-ALIGNMENT-AUDIT.md
@@ -4,7 +4,7 @@
 **Date**: 2026-06-30
 **Scope**: `docs/adr/` (65 numbered ADRs + `INDEX.md`)
 
-Source ref: `origin/main` at `4772d5b` via `/Users/lion/khive-work/worktrees/docs-adr-alignment`.
+Source ref: `origin/main` at `4772d5b`.
 
 Inventory basis: `../explorer/adr-inventory.md` listed 65 markdown files under `docs/adr/` on `origin/main`: 64 numbered ADRs plus `INDEX.md`. This change adds ADR-065 (the companion methodology ADR), bringing committed HEAD to 65 numbered ADRs plus `INDEX.md`. Statuses below are classified from source evidence or concrete source gaps, not ADR prose alone. If an ADR makes no current code-checkable claim beyond an implemented path, it is marked `current` with the relevant source path.
 

--- a/docs/adr/ADR-ALIGNMENT-AUDIT.md
+++ b/docs/adr/ADR-ALIGNMENT-AUDIT.md
@@ -1,0 +1,92 @@
+# ADR-ALIGNMENT-AUDIT: ADR Set Classification as of 2026-06-30
+
+**Status**: Informational
+**Date**: 2026-06-30
+**Scope**: `docs/adr/` (65 numbered ADRs + `INDEX.md`)
+
+Source ref: `origin/main` at `4772d5b` via `/Users/lion/khive-work/worktrees/docs-adr-alignment`.
+
+Inventory basis: `../explorer/adr-inventory.md` listed 65 markdown files under `docs/adr/` on `origin/main`: 64 numbered ADRs plus `INDEX.md`. This change adds ADR-065 (the companion methodology ADR), bringing committed HEAD to 65 numbered ADRs plus `INDEX.md`. Statuses below are classified from source evidence or concrete source gaps, not ADR prose alone. If an ADR makes no current code-checkable claim beyond an implemented path, it is marked `current` with the relevant source path.
+
+## Classification Table
+
+| ADR | Title | Status | One-line Evidence |
+|-----|-------|--------|-------------------|
+| 001 | Pure Rust Transformer Engine | current | Core pure-Rust inference crate exists under `crates/inference/src/lib.rs`, with CPU/Metal backends and HuggingFace/safetensors loaders under `crates/inference/src/{forward,weights,model}`. |
+| 002 | SIMD Dispatch Strategy | current | Runtime CPU SIMD dispatch exists in `crates/inference/src/forward/cpu/simd.rs`; NEON fallback/source exists in `crates/inference/src/forward/neon.rs`. |
+| 003 | SafeTensors Weight Loading | current | SafeTensors loaders and storage formats exist in `crates/inference/src/weights/f32_weights.rs` and `crates/inference/src/weights/f16_weights.rs`. |
+| 004 | KV Cache Design | current | `FlatKVCache` and `PagedKVCache` are exported from `crates/inference/src/kv_cache/mod.rs:13`; f16 flat-cache behavior is implemented in `crates/inference/src/kv_cache/flat.rs`. |
+| 005 | Tokenizer Architecture | current | `Tokenizer` implementations remain in `crates/inference/src/tokenizer/`; added-token rendering shipped via `crates/inference/src/tokenizer/bpe.rs:49` and `common.rs:791`. |
+| 006 | Speculative Decoding | current | `NgramSpeculator`, `MtpVerifier`, KV rollback, and GDN snapshot restore are implemented in `crates/inference/src/speculative.rs:488`, `1273`, and `1347`. |
+| 007 | Rotary Positional Encoding (RoPE) | current | RoPE split-half convention is exercised by MTP and Qwen paths; source evidence includes `crates/inference/src/speculative.rs` plus Metal MTP gates at `crates/inference/src/forward/metal_qwen35.rs:9667`. |
+| 008 | LoRA Injection via Trait Hook | stale | The base hook exists in `crates/inference/src/lora_hook.rs`, but the multi-adapter statement is stale: shipped decode mixture uses CPU pre-blend in `crates/inference/src/forward/metal_qwen35.rs:4301`, not hook chaining. |
+| 009 | Model Architectures (BERT and Qwen3) | current | BERT, Qwen, and Qwen3.5 modules are present under `crates/inference/src/model/{bert.rs,qwen.rs,qwen35/}`. |
+| 010 | Attention Mechanisms | superseded | Primitive attention modules exist, but the taxonomy is now owned by `AttentionKind` in `crates/inference/src/attention/mod.rs:57` per ADR-059. |
+| 011 | Sampling Strategies | current | Sampling implementation is present in `crates/inference/src/sampling.rs` and Qwen3.5 sampling integration in `crates/inference/src/model/qwen35/sampling.rs`. |
+| 012 | Runtime SIMD Detection Strategy | current | `lattice-embed` SIMD modules exist under `crates/embed/src/simd/`, including `dot_product.rs`, `cosine.rs`, and tiered quantized paths. |
+| 013 | lattice-embed as SIMD Foundation Layer | current | `crates/embed/src/lib.rs` re-exports SIMD and embedding primitives; vector kernels are centralized under `crates/embed/src/simd/`. |
+| 014 | Embedding Service | current | `EmbeddingService` and `NativeEmbeddingService` are present in `crates/embed/src/service/mod.rs` and `native.rs:63`. |
+| 015 | Sharded LRU Embedding Cache | current | `EmbeddingCache` and cached service wrapper exist in `crates/embed/src/cache.rs:137` and `crates/embed/src/service/cached.rs:42`. |
+| 016 | Embedding Model Variants | current | `EmbeddingModel`, model configs, and provenance live in `crates/embed/src/model.rs` and are re-exported from `crates/embed/src/lib.rs`. |
+| 017 | NativeEmbeddingService Orchestration | current | `NativeEmbeddingService` owns model selection and generation in `crates/embed/src/service/native.rs:63` and implements `EmbeddingService` at `native.rs:310`. |
+| 018 | Quantized Vector Tiers | current | `QuantizedVector`, `QuantizedData`, and tiered approximate search exist in `crates/embed/src/simd/quantized.rs:75` and `tier.rs:103`. |
+| 019 | Backfill and Migration Pipeline | current | `BackfillCoordinator`, migration controller, and routing types exist in `crates/embed/src/backfill/coordinator.rs:77` and `migration/`. |
+| 020 | Neural Network Primitives | current | `Network` and layer primitives are present in `crates/fann/src/network/mod.rs:90` and `crates/fann/src/layer.rs`. |
+| 021 | Zero-Allocation Inference | current | `lattice-fann` exposes network inference with reusable state in `crates/fann/src/network/`; no contradictory source gap was found in the current fann surface. |
+| 022 | Gradient Guard Strategy | current | `GradientGuardStrategy` exists and is wired into backprop at `crates/fann/src/training/gradient.rs:57` and `backprop.rs:313`. |
+| 023 | Activation Functions | current | Activation primitives are implemented in `crates/fann/src/activation.rs` and re-exported through `crates/fann/src/lib.rs`. |
+| 024 | Network Builder Pattern | current | `NetworkBuilder` exists in `crates/fann/src/network/builder.rs:29`. |
+| 025 | GPU Backend | current | WGPU GPU backend modules exist under `crates/fann/src/gpu/` and are feature-gated from `crates/fann/src/lib.rs`. |
+| 026 | Training Loop | current | Backprop training types and `TrainingConfig` are implemented under `crates/fann/src/training/`, including `backprop.rs` and `mod.rs`. |
+| 027 | Fine-Tuning Pipeline | current | `lattice-tune` exports distill, train, data, registry, and LoRA modules from `crates/tune/src/lib.rs:137`. |
+| 028 | Multi-Provider Teacher Strategy | current | `TeacherProvider` covers Claude/OpenAI/Gemini/Local/Custom at `crates/tune/src/distill/teacher/mod.rs:16`. |
+| 029 | Model Registry with Lineage | current | `ModelRegistry`, `RegisteredModel`, and storage backends exist in `crates/tune/src/registry/storage/registry.rs:23` and `registry/mod.rs`. |
+| 030 | Knowledge Distillation Pipeline | current | `DistillationPipeline`, `DistillationConfig`, and teacher config are implemented in `crates/tune/src/distill/pipeline/` and `teacher/`. |
+| 031 | LoRA Adapter Management | current | `LoraAdapter`, PEFT/MLX safetensors load/save, loader guards, and manifest modules exist under `crates/tune/src/lora/`. |
+| 032 | Training Callbacks | current | `TrainingCallback`, `LoggingCallback`, and callback wiring exist in `crates/tune/src/train/loop/callbacks.rs:8` and `loop/mod.rs:32`. |
+| 033 | JIT Adaptation | current | `JitAdapter` and strategies are present in `crates/tune/src/train/jit.rs:195`, with known training placeholder behavior documented by ADR-056 status. |
+| 034 | Dataset Pipeline | current | `Dataset`, `DatasetConfig`, stats, split, and batching live in `crates/tune/src/data/dataset.rs:13` and `164`. |
+| 035 | Sinkhorn-Knopp Balanced OT Solver | current | `SinkhornSolver`, `SinkhornConfig`, and `SinkhornWorkspace` exist in `crates/transport/src/sinkhorn.rs:33`, `70`, and `370`. |
+| 036 | Log-Domain Numerical Stability | current | Log-domain solver and stable helpers are present in `crates/transport/src/sinkhorn_log.rs` and `logsumexp.rs`. |
+| 037 | Cost Matrix Abstractions | current | `CostMatrix`, `DenseCostMatrix`, and pairwise/closure costs exist in `crates/transport/src/cost.rs:255` and `268`. |
+| 038 | Wasserstein Barycenters | current | Fixed/free support barycenter code is implemented in `crates/transport/src/barycenter.rs:23`, `89`, and `283`. |
+| 039 | Sinkhorn Divergence | current | Debiased `SinkhornDivergence` and point-set helpers exist in `crates/transport/src/divergence.rs:34` and `84`. |
+| 040 | Gated Attention (G1 SDPA-Output Gating) | current | Gated attention source exists in `crates/inference/src/attention/gated.rs`; taxonomy integration is in `attention/mod.rs:57`. |
+| 041 | Differential Attention | current | Differential attention implementation exists in `crates/inference/src/attention/differential.rs`. |
+| 042 | Native Sparse Attention | current | Native sparse attention implementation exists in `crates/inference/src/attention/native_sparse.rs`. |
+| 043 | LoRA Serving Verification and Qwen3.5-0.8B Support | current | Qwen/Metal LoRA loading and verification paths exist in `crates/inference/src/forward/metal_qwen35.rs` plus `crates/tune/src/lora/safetensors.rs`. |
+| 044 | QuaRot Hadamard-Rotated 4-bit Quantization | current | QuaRot converter, rotation, plan, and forward-equivalence code exist under `crates/inference/src/quant/quarot/`. |
+| 045 | QuaRot + LoRA Composition at Inference Time | stale | Single-adapter QuaRot+LoRA shipped, but mixture and compatibility prose drifted: CPU pre-blend exists at `metal_qwen35.rs:4301`; manifest rev fields are stored at `manifest.rs:49` and `51` but not load-compared. |
+| 046 | XGrammar Structured Output Engine | partially-implemented | Grammar engine and caps exist in `crates/inference/src/grammar/`, but `lattice_serve` sets `grammar: None` and does not expose `response_format` in `crates/inference/src/bin/lattice_serve.rs:117` and `202`. |
+| 047 | Paged KV Cache with Prefix Reuse | superseded | Paged KV exists in `crates/inference/src/kv_cache/paged.rs:374`, but KV element-format ownership moved to f16/int8/int4 work in ADR-062 and `flat.rs` f16 paths. |
+| 048 | Continuous Batching with Disaggregated Prefill/Decode | superseded | Batch modules exist in `crates/inference/src/batch/`, but GPU-worker/product serving ownership moved to ADR-063 and `crates/inference/src/bin/lattice_serve.rs`. |
+| 049 | Vision Encoder Integration (Qwen-VL Path) | aspirational | No vision encoder module or Qwen-VL runtime path was found under `crates/inference/src/`; current source tree has text/Qwen/embedding model paths only. |
+| 050 | Rejection Sampling for Speculative Decoding | current | Speculative verifier, MTP target trait, rollback, and acceptance code exist in `crates/inference/src/speculative.rs:1273` and following. |
+| 051 | QuaRot-MTP Rotation Reconciliation | current | MTP partial RoPE and QuaRot/MTP reconciliation paths are exercised through `crates/inference/src/speculative.rs` and `crates/inference/src/quant/quarot/lora.rs`. |
+| 052 | GDN State Management for Speculative Rollback | current | `GatedDeltaNetState::snapshot`/`restore_from` exist in `crates/inference/src/attention/gdn.rs:102` and `109`, and MTP restore is wired in `speculative.rs:1347`. |
+| 053 | MoE Metal Dispatch with Expert Coalescing | current | MoE and Metal dispatch evidence exists in `crates/inference/src/model/qwen35/moe.rs` and `crates/inference/src/forward/metal_qwen35.rs`. |
+| 054 | Rotation-Aware LoRA Training (RoLoRA Integration) | aspirational | Serving-side QuaRot LoRA exists in `crates/inference/src/quant/quarot/lora.rs`, but no RoLoRA training module was found under `crates/tune/src`. |
+| 055 | Online Distribution Drift Detection via Sinkhorn Divergence | partially-implemented | `OnlineDriftDetector` is implemented and exported at `crates/transport/src/online_drift.rs:109` and `transport/src/lib.rs:119`; no inference `DriftSampler` bridge exists. |
+| 056 | LoRA Tuning Pipeline | partially-implemented | Full `train/lora/` pipeline was not created, but bounded LoRA training shipped via `crates/tune/src/lora/train.rs:209` and `train_grad_full.rs`. |
+| 057 | LoRA Full-Lifecycle Consumer API | current | Lifecycle gaps are closed by `save_peft_safetensors`, `adapt_step`, BERT hook, and docs in `crates/tune/src/lora/` and `crates/inference/src/model/cross_encoder.rs`. |
+| 058 | CPU Performance Regression Tracking in CI | superseded | ADR status is superseded and current CI gate taxonomy lives in ADR-064 plus `.github/workflows/ci.yml`. |
+| 059 | Composable Layer Architecture | partially-implemented | `AttentionKind` is implemented in `crates/inference/src/attention/mod.rs:57`; broader composable layer architecture remains proposed. |
+| 060 | Pruning Toolbox | partially-implemented | D2 block influence and masks shipped (`crates/inference/src/pruning.rs:62`, `qwen35_config.rs:619`, `metal_qwen35.rs:5082`); D1/D3/D4/D5 remain absent. |
+| 061 | Inference Metrics & Experiment Runner Infrastructure | partially-implemented | `LayerMetrics` and `ForwardMetrics` exist in `crates/inference/src/metrics.rs:30` and `58`; `MetricSink`/runner pieces remain proposed. |
+| 062 | Metal FA2 Prefill + KV Cache Quantization Chain | partially-implemented | f16 `FlatKVCache` behavior exists in `crates/inference/src/kv_cache/flat.rs`, but FA2 prefill and int8/int4 KV chain remain proposed. |
+| 063 | Serving Architecture --- CLI, HTTP Server, API Compatibility | stale | ADR says no server/HTTP listener, but `lattice_serve` exists with OpenAI-compatible routes and warm stateless reset at `crates/inference/src/bin/lattice_serve.rs:1`, `231`, and `677`. |
+| 064 | CI Gate Taxonomy and Promotion Policy | current | `rustdoc-lint` and `unwrap-in-lib-lint` informational jobs are present in `.github/workflows/ci.yml:180` and `208`; the methodology ADR it anticipated was added as ADR-065 in this change. |
+| 065 | Feature Promotion Gates --- Merge Measured Primitives, Not Research Ideas | current | Companion methodology ADR added in this change; encodes the G0--G4 promotion-gate ladder, the 8-question issue template, and the adaptive gating-vector pattern (`docs/adr/ADR-065-feature-promotion-gates.md`). |
+| INDEX | Architecture Decision Records | current | Index lists the tracked ADR set in `docs/adr/INDEX.md`; inventory count matches `git ls-tree origin/main docs/adr` at 64 numbered ADRs plus `INDEX.md`. |
+
+## Summary
+
+| Status | Count |
+|--------|------:|
+| current | 50 |
+| stale | 3 |
+| superseded | 4 |
+| partially-implemented | 7 |
+| aspirational | 2 |
+
+ADRs requiring implementer action (stale fact corrections and partial-status notes) are detailed in the accompanying update manifest. ADRs marked `partially-implemented` but already accurately status-noted are not necessarily all manifest entries; only those with drifted prose or no existing status note appear in the manifest.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -90,12 +90,20 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | ---------------------------------------- | ----------------------------------------- |
 | [058](ADR-058-cpu-perf-regression-ci.md) | CPU Performance Regression Tracking in CI |
 
-## architecture / research (ADR-059 through ADR-063) — Proposed
+## architecture / research (ADR-059 through ADR-065) — Proposed
 
-| ADR                                                | Title                                        | Status   | Depends on   |
-| -------------------------------------------------- | -------------------------------------------- | -------- | ------------ |
-| [059](ADR-059-composable-layer-architecture.md)    | Composable Layer Architecture                | Proposed | ADR-010      |
-| [060](ADR-060-pruning-toolbox.md)                  | Pruning Toolbox                              | Proposed | ADR-044, 059 |
-| [061](ADR-061-inference-metrics-infrastructure.md) | Inference Metrics & Experiment Runner        | Proposed | ADR-059      |
-| [062](ADR-062-metal-fa2-prefill.md)                | Metal FA2 Prefill + KV Cache Quantization    | Proposed | ADR-047      |
-| [063](ADR-063-serving-architecture.md)             | Serving Architecture — CLI, HTTP, API Compat | Proposed | ADR-048, 046 |
+| ADR                                                | Title                                                         | Status       | Depends on   |
+| -------------------------------------------------- | ------------------------------------------------------------- | ------------ | ------------ |
+| [059](ADR-059-composable-layer-architecture.md)    | Composable Layer Architecture                                 | Proposed     | ADR-010      |
+| [060](ADR-060-pruning-toolbox.md)                  | Pruning Toolbox                                               | Proposed     | ADR-044, 059 |
+| [061](ADR-061-inference-metrics-infrastructure.md) | Inference Metrics & Experiment Runner                         | Proposed     | ADR-059      |
+| [062](ADR-062-metal-fa2-prefill.md)                | Metal FA2 Prefill + KV Cache Quantization                     | Proposed     | ADR-047      |
+| [063](ADR-063-serving-architecture.md)             | Serving Architecture — CLI, HTTP, API Compat                  | Proposed     | ADR-048, 046 |
+| [064](ADR-064-ci-gate-taxonomy.md)                 | CI Gate Taxonomy and Promotion Policy                         | Proposed     | ADR-058      |
+| [065](ADR-065-feature-promotion-gates.md)          | Feature promotion gates: merge measured primitives, not ideas | Proposed     | ADR-064      |
+
+## informational
+
+| ADR                                         | Title                             | Status       |
+| ------------------------------------------- | --------------------------------- | ------------ |
+| [AUDIT](ADR-ALIGNMENT-AUDIT.md)             | ADR Alignment Audit (2026-06-30)  | Informational |


### PR DESCRIPTION
## Summary

The `docs/adr/` ADR set had drifted behind shipped code after a heavy release cycle. This PR audits every ADR against shipped `main`, corrects stale facts in place, and adds one new methodology ADR. **Docs only — no code logic changed, no ADRs renumbered, no design rationale rewritten.**

## Part 1 — ADR staleness audit

`docs/adr/ADR-ALIGNMENT-AUDIT.md` classifies every ADR file (one row per file) from source evidence — not ADR prose — with the shipped code path or concrete gap as one-line evidence.

| Status | Count |
|--------|------:|
| current | 50 |
| stale | 3 |
| superseded | 4 |
| partially-implemented | 7 |
| aspirational | 2 |

(65 numbered ADRs + `INDEX.md`.)

**Corrected / status-noted in place (rationale untouched):**

- **ADR-008** (LoRA injection), **ADR-045** (QuaRot-LoRA composition), **ADR-046** (structured output), **ADR-056** (LoRA tuning pipeline) — stale numeric/factual claims corrected against shipped source (s1 reasoning-budget control #435, LoRA adapter mixture #443, governed LoRA manifest #444, online router refit #448/#453).
- **ADR-060** (pruning toolbox) — `partially-implemented`: added an "Implementation status as of 2026-06-30" note. Only D2 (BlockInfluence scorer + masks) shipped (`crates/inference/src/pruning.rs:62`); D1/D3/D4/D5 marked not-yet-implemented. Design rationale preserved.
- **ADR-063** (serving architecture) — `stale`: ADR claimed no HTTP listener, but `lattice_serve` ships OpenAI-compatible routes + warm stateless reset (`crates/inference/src/bin/lattice_serve.rs`).

## Part 2 — new methodology ADR (ADR-065)

`docs/adr/ADR-065-feature-promotion-gates.md` — **"Feature Promotion Gates: Merge Measured Primitives, Not Research Ideas."** Encodes:

- **The 5-gate ladder** — G0 research-note → G1 measurement-primitive (visibility without output change, <2% on / 0% off, stable JSONL schema) → G2 experiment-branch (one benchmark, one baseline, one kill threshold, reproducible from one command) → G3 default-off feature (beats baseline with no quality/safety/latency regression; speed ≥15%, memory ≥20%, quality stat-sig at matched tokens) → G4 default-on (rare; telemetry-off / deterministic / exact snapshot-restore only).
- **The 8-question issue template** every research/feature issue must answer (user-visible outcome, prior art, cheapest falsifying experiment, promote/kill thresholds, code location, the anti-default-on flag, gate level).
- **The adaptive-feature gating-vector pattern** — cheap per-token signals (token entropy, logit margin, seq avg logprob, MTP accept-rate / head-disagreement, GDN state-delta, gate entropy, context length, domain flags) → calibrated `p_err` → action set {allow-direct, short-think, long-think, multi-sample, escalate-larger-local-model, quarantine-or-defer}, with isotonic / conformal margin calibration named as prior art.
- Closing note: the open research-roadmap epics are the first consumers; high-risk hypotheses (learnable test-time state updates, latent GDN reasoning, state interpolation) stay at G0/G1 until state telemetry exists.

## Verification

- `cargo fmt --all -- --check` — exit 0
- `./scripts/lint-docs.sh` — Doc Lint Passed (10 files)
- Commit is docs-only: 9 files, all `docs/adr/`, no deletes/renames, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
