### PR TITLE
fix(inference): remove duplicate futures dependency key (unbreak workspace build)

### DIFF
--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -37,7 +37,6 @@ clap = { workspace = true }
 axum = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
-futures = { workspace = true }
 ureq = { version = "2", features = ["tls"], optional = true }
 sha2 = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }


### PR DESCRIPTION
## Problem

`crates/inference/Cargo.toml` declared `futures = { workspace = true }` twice under `[dependencies]`. cargo rejects the manifest with `duplicate key 'futures'`, so **every workspace build fails at parse time** — `cargo build`, `cargo check`, `cargo metadata`, and all of CI on `main`.

## Root cause

Two independent additions of the same dependency landed without producing a textual merge conflict:

- #435 added `futures` for the `lattice_serve` HTTP daemon
- #332 added `futures` again for SSE streaming

The two insertions sat at different line positions, so git reported no conflict when the second was squash-merged onto a base that already carried the first. The result is a duplicate key in the dependency table.

## Fix

Remove the redundant second declaration. One workspace-versioned entry covers both call sites. One-line change (1 deletion).

## Verification

- `cargo metadata --no-deps` (inference manifest): parses ✓
- `cargo metadata --no-deps` (whole workspace): parses ✓ — confirms no other crate carries a same-table duplicate
- `cargo check -p lattice-inference`: clean ✓ (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
