### PR TITLE
perf(inference): reuse ForwardScratch buffers in Q8 CPU decode (#416)

### DIFF
--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -1555,4 +1555,241 @@ mod tests {
              got {result:?}"
         );
     }
+
+    /// Builds a tiny but non-degenerate 2-layer Q8 model (1 linear + 1 full-attention
+    /// layer, matching the `Q8NeonModel` fixture in `neon_forward.rs`) with deterministic
+    /// non-zero weights via an LCG, so `forward_step_q8` exercises every alloc site
+    /// touched by the `ForwardScratch` buffer-reuse change: the full-attention input
+    /// copy into `input_tmp`, the `q_and_gate` projection write, `split_q_and_gate`'s
+    /// deinterleave into `gate_z`, and the FFN input copy into `input_tmp`.
+    fn make_nonzero_q8_cpu_test_model() -> (Qwen35Config, Q8ModelWeights, RopeTable) {
+        use crate::model::qwen35_config::LayerType;
+        use crate::weights::q8_weights::quantize_matrix;
+
+        let hidden: usize = 64;
+        let vocab: usize = 128;
+        let inter: usize = 128;
+        let num_attn_heads: usize = 2;
+        let num_kv_heads: usize = 1;
+        let head_dim: usize = 32;
+        let q_dim = num_attn_heads * head_dim; // 64
+        let kv_dim = num_kv_heads * head_dim; // 32
+        let lin_key_heads: usize = 2;
+        let lin_val_heads: usize = 2;
+        let lin_key_dim: usize = 32;
+        let lin_val_dim: usize = 32;
+        let lin_qkv_dim = lin_key_heads * lin_key_dim * 2 + lin_val_heads * lin_val_dim; // 192
+        let lin_output_dim = lin_val_heads * lin_val_dim; // 64
+        let kernel_size: usize = 4;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 2,
+            vocab_size: vocab,
+            intermediate_size: inter,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: num_attn_heads,
+            num_key_value_heads: num_kv_heads,
+            head_dim,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5,
+            rope_parameters: None,
+            linear_num_key_heads: lin_key_heads,
+            linear_num_value_heads: Some(lin_val_heads),
+            linear_key_head_dim: lin_key_dim,
+            linear_value_head_dim: lin_val_dim,
+            linear_conv_kernel_dim: kernel_size,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![LayerType::LinearAttention, LayerType::FullAttention],
+            layer_mask: vec![true; 2],
+            eos_token_id: 127,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        let rope_dim = (head_dim as f32 * cfg.partial_rotary_factor) as usize; // 16
+        let rope = RopeTable::new(rope_dim, cfg.max_position_embeddings, cfg.rope_theta);
+
+        // Deterministic weight generator: LCG producing small non-zero floats.
+        let mut seed: u64 = 0xdead_beef_cafe_babe;
+        let mut next_weight = |n: usize, k: usize| -> crate::weights::q8_weights::Q8Matrix {
+            let floats: Vec<f32> = (0..n * k)
+                .map(|_| {
+                    seed = seed
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    ((seed >> 33) as f32 / u32::MAX as f32) * 0.04 - 0.02
+                })
+                .collect();
+            // LCG output is bounded -- always finite, quantization cannot fail.
+            quantize_matrix(&floats, n, k).unwrap()
+        };
+
+        let gdn_w = Q8GatedDeltaNetWeights {
+            in_proj_qkv: next_weight(lin_qkv_dim, hidden),
+            in_proj_z: next_weight(lin_output_dim, hidden),
+            in_proj_b: next_weight(lin_key_heads, hidden),
+            in_proj_a: next_weight(lin_key_heads, hidden),
+            a_log: vec![0.0f32; lin_key_heads],
+            dt_bias: vec![0.0f32; lin_key_heads],
+            conv1d_weight: vec![0.01f32; lin_qkv_dim * kernel_size],
+            conv_dim: lin_qkv_dim,
+            kernel_size,
+            norm_weight: vec![0.0f32; lin_val_dim],
+            out_proj: next_weight(hidden, lin_output_dim),
+        };
+
+        let full_w = Q8FullAttentionLayerWeights {
+            q_proj: next_weight(2 * q_dim, hidden),
+            k_proj: next_weight(kv_dim, hidden),
+            v_proj: next_weight(kv_dim, hidden),
+            o_proj: next_weight(hidden, q_dim),
+            q_norm: vec![0.0f32; head_dim],
+            k_norm: vec![0.0f32; head_dim],
+        };
+
+        let make_common = |seed: &mut u64| -> Q8CommonLayerWeights {
+            let mut nw = |n: usize, k: usize| -> crate::weights::q8_weights::Q8Matrix {
+                let floats: Vec<f32> = (0..n * k)
+                    .map(|_| {
+                        *seed = seed
+                            .wrapping_mul(6_364_136_223_846_793_005)
+                            .wrapping_add(1_442_695_040_888_963_407);
+                        ((*seed >> 33) as f32 / u32::MAX as f32) * 0.04 - 0.02
+                    })
+                    .collect();
+                quantize_matrix(&floats, n, k).unwrap()
+            };
+            Q8CommonLayerWeights {
+                input_layernorm: vec![0.0f32; hidden],
+                post_attention_layernorm: vec![0.0f32; hidden],
+                gate_proj: nw(inter, hidden),
+                up_proj: nw(inter, hidden),
+                down_proj: nw(hidden, inter),
+            }
+        };
+
+        let layers = vec![
+            (Q8AttentionWeights::Linear(gdn_w), make_common(&mut seed)),
+            (Q8AttentionWeights::Full(full_w), make_common(&mut seed)),
+        ];
+
+        let embed_tokens: Vec<f32> = (0..vocab * hidden)
+            .map(|_| {
+                seed = seed
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                ((seed >> 33) as f32 / u32::MAX as f32) * 0.04 - 0.02
+            })
+            .collect();
+
+        let weights = Q8ModelWeights {
+            embed_tokens,
+            final_norm: vec![0.0f32; hidden],
+            layers,
+        };
+
+        (cfg, weights, rope)
+    }
+
+    /// End-to-end regression guard for the `ForwardScratch` buffer-reuse change in
+    /// `full_attention_step_q8` and `ffn_step_q8` (#416): decodes two real Q8 steps
+    /// (position 0, then position 1 -- first-token vs subsequent-token) and checks
+    /// that reusing the four touched scratch buffers (`input_tmp`, `q_and_gate`,
+    /// `gate_z` via `split_q_and_gate`, and `input_tmp` again for the FFN) across
+    /// calls never leaks stale data into the result.
+    ///
+    /// Design: run the same two-step decode twice, once starting from a pristine
+    /// `ForwardScratch` and once starting from a `ForwardScratch` already "dirtied"
+    /// by a prior unrelated decode (`gdn_states`/`kv_cache` are fresh each time, so
+    /// only the scratch buffers carry over). Every alloc site this change touches
+    /// writes into a scratch buffer that previously came from a freshly allocated,
+    /// often implicitly-zeroed `Vec`; a buffer-reuse bug that under- or
+    /// mis-writes a reused region would surface as `dirty != pristine` here even
+    /// though both runs use identical model weights and identical input tokens.
+    #[test]
+    fn test_forward_step_q8_decode_survives_dirty_scratch_reuse() {
+        let (cfg, weights, rope) = make_nonzero_q8_cpu_test_model();
+        let num_linear = cfg.num_linear_attention_layers();
+        let num_full = cfg.num_full_attention_layers();
+
+        let decode_two_steps = |scratch: &mut ForwardScratch| -> Vec<f32> {
+            let mut gdn_states: Vec<GatedDeltaNetState> = (0..num_linear)
+                .map(|_| GatedDeltaNetState::new(&cfg))
+                .collect();
+            let mut kv_cache = KvCache::new(num_full);
+
+            // First token: exercises `ensure_capacity`'s first-call resize path.
+            forward_step_q8(
+                &weights,
+                &cfg,
+                &rope,
+                7,
+                0,
+                &mut gdn_states,
+                &mut kv_cache,
+                scratch,
+            );
+            kv_cache.seq_len += 1;
+            // Second token: subsequent-token decode reusing the same scratch buffers.
+            forward_step_q8(
+                &weights,
+                &cfg,
+                &rope,
+                11,
+                1,
+                &mut gdn_states,
+                &mut kv_cache,
+                scratch,
+            );
+
+            scratch.logits[..16].to_vec()
+        };
+
+        let mut pristine_scratch = ForwardScratch::new();
+        let pristine = decode_two_steps(&mut pristine_scratch);
+
+        let mut dirtied_scratch = ForwardScratch::new();
+        let _ = decode_two_steps(&mut dirtied_scratch); // warm up: dirty every scratch buffer
+        let dirty = decode_two_steps(&mut dirtied_scratch); // decode again, same scratch object
+
+        assert_eq!(
+            pristine, dirty,
+            "decoding through a previously-used ForwardScratch must produce identical logits \
+             to a pristine scratch -- a buffer-reuse bug in the Q8 decode alloc sites (#416) \
+             would leak stale data here"
+        );
+
+        assert!(
+            pristine.iter().any(|&v| v.abs() > 1e-9),
+            "all 16 logits are zero -- check weight generation"
+        );
+        for (i, &v) in pristine.iter().enumerate() {
+            assert!(v.is_finite(), "logit[{i}] is not finite: {v}");
+        }
+
+        // Golden bit-identical values captured from this deterministic fixture.
+        // Regenerate by temporarily printing `pristine` if the fixture or the
+        // production Q8 decode math intentionally changes.
+        let expected: [f32; 16] = [
+            0.6030709, 0.6551996, 0.60194814, 0.64469767, 0.69641805, 0.5887781, 0.62342393,
+            0.6259914, 0.65434885, 0.74827236, 0.69311845, 0.7374152, 0.6237912, 0.65976304,
+            0.6478549, 0.68329644,
+        ];
+        for (i, (&actual, &exp)) in pristine.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (actual - exp).abs() <= 1e-6,
+                "logit[{i}] mismatch: actual={actual:.8}, expected={exp:.8}"
+            );
+        }
+    }
 }

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -263,8 +263,18 @@ fn full_attention_step_q8(
     rope: &RopeTable,
     hidden: usize,
 ) {
-    // Read input from attn_out (where caller placed it)
-    let input: Vec<f32> = scratch.attn_out[..hidden].to_vec();
+    // Read input from attn_out (where caller placed it). Scoped destructure so
+    // the `attn_out` read and `input_tmp` write borrow disjoint fields instead
+    // of aliasing through `scratch` — avoids a fresh-Vec clone (#416).
+    {
+        let ForwardScratch {
+            attn_out,
+            input_tmp,
+            ..
+        } = scratch;
+        let src = &attn_out[..hidden];
+        input_tmp[..hidden].copy_from_slice(src);
+    }
     let q_dim = cfg.full_q_dim();
     let kv_dim = cfg.full_kv_dim();
     let head_dim = cfg.head_dim;
@@ -275,40 +285,50 @@ fn full_attention_step_q8(
     // Q projection produces [Q, gate] interleaved per head:
     // view(num_heads, head_dim*2) -> chunk(2) -> Q[num_heads, head_dim], gate[num_heads, head_dim]
     let q_proj_dim = 2 * q_dim;
-    let mut q_and_gate = vec![0.0f32; q_proj_dim];
-    matmul_bt_q8(
-        &input,
-        &weights.q_proj,
-        &mut q_and_gate,
-        1,
-        hidden,
-        q_proj_dim,
-    );
-    // Scatter per-head: each head has [Q_h, gate_h] of size head_dim*2
-    let mut gate_z = vec![0.0f32; q_dim];
-    for h in 0..num_q_heads {
-        let src = h * head_dim * 2;
-        let dst = h * head_dim;
-        scratch.q_buf[dst..dst + head_dim].copy_from_slice(&q_and_gate[src..src + head_dim]);
-        gate_z[dst..dst + head_dim]
-            .copy_from_slice(&q_and_gate[src + head_dim..src + head_dim * 2]);
+    {
+        let ForwardScratch {
+            input_tmp,
+            q_and_gate,
+            ..
+        } = scratch;
+        matmul_bt_q8(
+            &input_tmp[..hidden],
+            &weights.q_proj,
+            &mut q_and_gate[..q_proj_dim],
+            1,
+            hidden,
+            q_proj_dim,
+        );
     }
-    matmul_bt_q8(
-        &input,
-        &weights.k_proj,
-        &mut scratch.k_buf[..kv_dim],
-        1,
-        hidden,
-        kv_dim,
-    );
-    matmul_bt_q8(
-        &input,
-        &weights.v_proj,
-        &mut scratch.v_buf[..kv_dim],
-        1,
-        hidden,
-        kv_dim,
-    );
+    // Scatter per-head: each head has [Q_h, gate_h] of size head_dim*2. The
+    // block above ends before this call so `split_q_and_gate` can take `&mut self`.
+    scratch.split_q_and_gate(num_q_heads, head_dim);
+    {
+        let ForwardScratch {
+            input_tmp, k_buf, ..
+        } = scratch;
+        matmul_bt_q8(
+            &input_tmp[..hidden],
+            &weights.k_proj,
+            &mut k_buf[..kv_dim],
+            1,
+            hidden,
+            kv_dim,
+        );
+    }
+    {
+        let ForwardScratch {
+            input_tmp, v_buf, ..
+        } = scratch;
+        matmul_bt_q8(
+            &input_tmp[..hidden],
+            &weights.v_proj,
+            &mut v_buf[..kv_dim],
+            1,
+            hidden,
+            kv_dim,
+        );
+    }
 
     // Per-head QK-norm (Qwen3.5 RMSNorm: 1 + gamma, f32 norms)
     for h in 0..num_q_heads {
@@ -427,9 +447,14 @@ fn full_attention_step_q8(
     }
 
     // Output gating: attn_output *= sigmoid(gate)
-    for (ctx, &gz) in scratch.context[..q_dim].iter_mut().zip(&gate_z[..q_dim]) {
-        let sig = 1.0 / (1.0 + (-gz).exp());
-        *ctx *= sig;
+    {
+        let ForwardScratch {
+            context, gate_z, ..
+        } = scratch;
+        for (ctx, &gz) in context[..q_dim].iter_mut().zip(&gate_z[..q_dim]) {
+            let sig = 1.0 / (1.0 + (-gz).exp());
+            *ctx *= sig;
+        }
     }
 
     // Output projection: context [1, q_dim] @ o_proj^T [hidden, q_dim] (Q8 weights)
@@ -460,26 +485,46 @@ fn ffn_step_q8(
 ) {
     let inter = cfg.intermediate_size;
 
-    // Read input from ffn_out (where caller placed it)
-    let input: Vec<f32> = scratch.ffn_out[..hidden].to_vec();
+    // Read input from ffn_out (where caller placed it). Scoped destructure so
+    // the `ffn_out` read and `input_tmp` write borrow disjoint fields instead
+    // of aliasing through `scratch` — avoids a fresh-Vec clone (#416).
+    {
+        let ForwardScratch {
+            ffn_out, input_tmp, ..
+        } = scratch;
+        let src = &ffn_out[..hidden];
+        input_tmp[..hidden].copy_from_slice(src);
+    }
 
     // gate = gate_proj(input), up = up_proj(input) (Q8 weights)
-    matmul_bt_q8(
-        &input,
-        &common.gate_proj,
-        &mut scratch.gate_buf[..inter],
-        1,
-        hidden,
-        inter,
-    );
-    matmul_bt_q8(
-        &input,
-        &common.up_proj,
-        &mut scratch.up_buf[..inter],
-        1,
-        hidden,
-        inter,
-    );
+    {
+        let ForwardScratch {
+            input_tmp,
+            gate_buf,
+            ..
+        } = scratch;
+        matmul_bt_q8(
+            &input_tmp[..hidden],
+            &common.gate_proj,
+            &mut gate_buf[..inter],
+            1,
+            hidden,
+            inter,
+        );
+    }
+    {
+        let ForwardScratch {
+            input_tmp, up_buf, ..
+        } = scratch;
+        matmul_bt_q8(
+            &input_tmp[..hidden],
+            &common.up_proj,
+            &mut up_buf[..inter],
+            1,
+            hidden,
+            inter,
+        );
+    }
 
     // SwiGLU: silu(gate) * up
     silu_inplace(&mut scratch.gate_buf[..inter]);


### PR DESCRIPTION
## What

Reuse the persistent `ForwardScratch` buffers in the Q8 CPU decode hot path instead of allocating fresh `Vec`s each step. Removes four transient heap allocation sites per decoder layer step:

- `full_attention_step_q8`: attention-input clone, `q_and_gate` projection, `gate_z` deinterleave (full-attention layers only)
- `ffn_step_q8`: FFN input clone (every decoder layer)

## Measurement (ADR-058)

No throughput speedup is claimed. Direct machine timing for a CPU Q8 `forward_step_q8` decode bench is not possible in this repo today: the `inference_perf` bench is disabled (`bench = false`) and the active `elementwise_cpu_bench` does not execute the removed allocation sites.

- `elementwise_cpu_bench` A/B (`origin/main` vs HEAD): **all groups non-significant at p ≤ 0.05** — no regression, no measurable gain from these kernels.
- Analytic allocation delta on Qwen3.5-0.8B decode stack (18 linear + 6 full-attention layers): **42 fewer transient heap allocations per generated token** (18 from full-attention sites × 6 layers + 24 FFN-input clones × 24 layers). Example: a 128-token generation drops 5,376 transient allocations.

The value here is allocator-pressure reduction on the decode hot path, verified analytically and by an allocation-site audit, not a wall-clock win.

## Test

Adds `test_forward_step_q8_decode_survives_dirty_scratch_reuse` — a mutation-sensitive regression test on a tiny deterministic 2-layer Q8 model that exercises every reused scratch buffer (full-attention input copy, `q_and_gate`, `split_q_and_gate` deinterleave, FFN input copy). Reverting the reuse change leaves the assertions intact; corrupting the reuse (stale scratch) makes it fail.

`cargo clippy --workspace -- -D warnings` clean; `forward::cpu_q8` module tests green (10 passed).

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
