### PR TITLE
feat(inference): cross-turn KV prefix cache — skip re-prefill of shared conversation prefix (#462)

### DIFF
--- a/.khive/reports/crossturn_kv_462.md
+++ b/.khive/reports/crossturn_kv_462.md
@@ -1,8 +1,8 @@
 # Design: Cross-Turn KV Prefix Cache for Lattice #462
 
-Date: 2026-07-01  
-Role: architect, op 4, team `lattice_kv_462`  
-Status: proposed design; interfaces below are committed for implementation unless the critic rejects them.  
+Date: 2026-07-01
+Role: architect, op 4, team `lattice_kv_462`
+Status: shipped design (round-2 remediation, 2026-07-01). Interfaces below reflect the runtime shape as merged, not the original per-slot proposal (see "Round-2 remediation" note below).
 Inputs: `../analyst/design_brief.md`, direct code scan of `/Users/lion/projects/khive/lattice-kvcache-462`.
 
 Tooling note: `li team receive -t 2d5c82e54e73 --as architect` failed because `li` is not installed. Fallback `comm.inbox()` via khive returned count 0.
@@ -181,16 +181,32 @@ struct MetalCrossTurnPrefixEntry {
 
 #[derive(Debug, Default)]
 struct MetalCrossTurnPrefixCache {
-    entries: std::collections::HashMap<CrossTurnSlotId, MetalCrossTurnPrefixEntry>,
+    entry: Option<MetalCrossTurnPrefixEntry>,
 }
 
 impl MetalCrossTurnPrefixCache {
     fn get(&self, slot_id: CrossTurnSlotId) -> Option<&MetalCrossTurnPrefixEntry>;
     fn insert(&mut self, entry: MetalCrossTurnPrefixEntry);
+    fn take(&mut self, slot_id: CrossTurnSlotId) -> Option<MetalCrossTurnPrefixEntry>;
     fn remove(&mut self, slot_id: CrossTurnSlotId);
     fn clear(&mut self);
 }
 ```
+
+**Round-2 remediation (as shipped, differs from the design above):** the runtime
+shape is `entry: Option<MetalCrossTurnPrefixEntry>` — a single live entry per
+`MetalQwen35State`, **not** a `HashMap<CrossTurnSlotId, _>`. `get`/`take`/`remove`
+all filter by `slot_id` against that one entry (a different or absent slot is
+always a miss). `insert` unconditionally **replaces** whatever is currently
+retained, for any slot — saving a new entry for slot B silently evicts slot A's
+entry. This is a deliberate, bounded-by-construction design (never an unbounded
+per-slot map): at most one ~19.3 MiB GDN snapshot is ever alive, at the cost of
+zero retention across concurrent multi-slot traffic on the same `MetalQwen35State`
+(single-slot-at-a-time is the actual v1 contract; see "Round-2 remediation" note
+under "What The Cache Retains" below). The original per-slot `HashMap` sketch
+above was rejected in round-2 remediation because it was the source of the
+round-1/round-2 unsoundness findings (stale per-slot entries surviving live
+state mutation that the map had no way to observe).
 
 Extend `MetalQwen35State`:
 
@@ -278,7 +294,13 @@ impl MetalQwen35State {
 
 ## What The Cache Retains
 
-Per `CrossTurnSlotId`:
+**Round-2 remediation (as shipped):** at most ONE entry is retained per
+`MetalQwen35State`, not one per `CrossTurnSlotId`. The fields below describe
+that single retained entry when present; it is tagged with the `slot_id` it
+was saved for, and `get`/`take`/`remove` filter on that tag, but saving a new
+entry for a different slot unconditionally evicts whatever was retained
+before, regardless of slot. The "Per `CrossTurnSlotId`" framing in the
+original design (below) described the rejected multi-slot `HashMap` shape:
 
 - `token_ids: Vec<u32>`: exact rendered prompt tokens represented by state.
 - `represented_len: usize`: authoritative number of tokens in all reusable state.
@@ -289,6 +311,17 @@ Per `CrossTurnSlotId`:
 The v1 cache must not store every token-boundary GDN snapshot. One exact latest-boundary snapshot is enough for normal append-only chat and costs about 19.3 MiB for Qwen3.5-0.8B. Every-token GDN snapshots are rejected for v1 because they are about 19.3 MiB per boundary.
 
 ## Serve/Chat Hook
+
+**Round-2 remediation (status, 2026-07-01): DEFERRED, not implemented in this PR.**
+Everything in this section — the `Job.slot_id` extension, `request_slot_id`, the
+worker loop replacement, and the `chat_metal.rs` REPL/JSON-mode wiring — is design
+intent for a follow-up PR (D6), not a shipped component of #516. This PR ships only
+the correctness substrate: `MetalCrossTurnPrefixCache`,
+`generate_streaming_with_prefix_cache`, `chat_completion_streaming_with_prefix_cache`,
+and the round-2 raw-forward invalidation boundary. `lattice_serve.rs` and
+`chat_metal.rs` do not currently call any `*_with_prefix_cache` entry point, so
+neither the serve worker nor the chat REPL opt into cross-turn reuse yet — they
+continue to use `reset_state()`/`generate_streaming` exactly as before this PR.
 
 ### `lattice_serve.rs`
 
@@ -471,7 +504,7 @@ Why this is enough:
 
 ## GDN State Decision
 
-Chosen v1 option: persist one exact GDN snapshot at the latest represented boundary per cache slot.
+Chosen v1 option (as shipped): persist one exact GDN snapshot at the latest represented boundary, for at most one live entry across the whole `MetalQwen35State` (round-2 remediation — see "What The Cache Retains"; the original design below said "per cache slot" / "per slot", implying independent retention across slots, which the shipped single-entry shape does not provide).
 
 Alternatives considered:
 
@@ -479,7 +512,7 @@ Alternatives considered:
 |---|---:|---:|---|
 | Reuse attention KV only | No | Low | Rejected. GDN state would not match full re-prefill. |
 | Snapshot every token boundary | Yes | About 19.3 MiB per boundary for 0.8B | Rejected for v1 memory cost. |
-| One latest-boundary snapshot | Yes for append-only `L == represented_len` | About 19.3 MiB per slot | Chosen v1. |
+| One latest-boundary snapshot | Yes for append-only `L == represented_len` | About 19.3 MiB, at most one snapshot alive at a time (single live entry, round-2) | Chosen v1. |
 | Sparse checkpoints + replay | Yes if replay is token-identical | `N * 19.3 MiB` plus replay | v2, optional for edited-history speedup. |
 | Replay whole shared prefix | Correct if full model replay | O(shared prefix) | Fallback only; not the feature win. |
 
@@ -559,19 +592,20 @@ sequenceDiagram
 
 ## Coupling And Testability
 
-Components:
+Components (design-time list; **items 4 and 5 are DEFERRED follow-up work, not
+shipped in #516** — see "Serve/Chat Hook" above):
 
-1. `kv_cache::cross_turn` planner,
-2. `MetalCrossTurnPrefixCache`,
-3. `MetalQwen35State` cache-aware generate/chat methods,
-4. serve worker job protocol,
-5. chat_metal REPL integration.
+1. `kv_cache::cross_turn` planner — shipped.
+2. `MetalCrossTurnPrefixCache` — shipped (as a single-live-entry `Option`, round-2 remediation).
+3. `MetalQwen35State` cache-aware generate/chat methods — shipped.
+4. serve worker job protocol — deferred (D6 follow-up).
+5. chat_metal REPL integration — deferred (D6 follow-up).
 
 Direct dependencies after design:
 
 - planner has no dependency on Metal,
 - Metal cache depends on planner and GDN snapshot type,
-- serve/chat binaries depend only on public cache-aware methods and `CrossTurnSlotId`.
+- serve/chat binaries would depend only on public cache-aware methods and `CrossTurnSlotId` once D6 lands; today neither binary references them.
 
 Estimated coupling: `|Deps|=5`, `|C|=5`, `κ=5/(5*4)=0.25`, below the 0.3 target.
 
@@ -616,7 +650,7 @@ Alternatives:
 
 1. KV-only reuse: rejected because GDN recurrent state would diverge from full re-prefill.
 2. Every-token GDN snapshots: rejected because memory cost is too high for normal contexts.
-3. Latest-boundary GDN snapshot: accepted because append-only chat is the primary serve path and one snapshot per slot is feasible.
+3. Latest-boundary GDN snapshot: accepted because append-only chat is the primary serve path and one live snapshot (the single-entry shape shipped in round-2 remediation, not one per slot) is feasible.
 4. Sparse checkpoints: deferred as v2 because it expands memory policy and replay complexity.
 
 Evidence:

--- a/.khive/reports/crossturn_kv_462.md
+++ b/.khive/reports/crossturn_kv_462.md
@@ -1,0 +1,640 @@
+# Design: Cross-Turn KV Prefix Cache for Lattice #462
+
+Date: 2026-07-01  
+Role: architect, op 4, team `lattice_kv_462`  
+Status: proposed design; interfaces below are committed for implementation unless the critic rejects them.  
+Inputs: `../analyst/design_brief.md`, direct code scan of `/Users/lion/projects/khive/lattice-kvcache-462`.
+
+Tooling note: `li team receive -t 2d5c82e54e73 --as architect` failed because `li` is not installed. Fallback `comm.inbox()` via khive returned count 0.
+
+## Executive Decision
+
+Implement a worker-local cross-turn prefix cache for the Metal Qwen3.5 serve/chat path. The cache reuses only an exact token prefix that is already represented by all mutable model state:
+
+- rendered prompt token IDs,
+- live Metal full-attention KV buffers plus logical `seq_len`,
+- `InferenceSession.position`,
+- one exact `GdnSnapshot` at the same boundary.
+
+For v1, optimize append-only growing conversations where `L == cached.represented_len`. On mid-history divergence where `L < cached.represented_len`, fall back to full reset/full prefill unless the implementer also adds sparse GDN checkpoints and replay. Attention-KV-only reuse is forbidden for Qwen3.5 because 18 of 24 layers are GatedDeltaNet recurrent layers.
+
+Token-identity invariant:
+
+> For the same rendered conversation, tokenizer, model weights/config, adapter state, generation config, random seed, and stop handling, the cached path must produce exactly the same generated token IDs as the existing full-reset/full-refill path.
+
+This design preserves the invariant by requiring token-level prefix equality, restoring GDN state at the same boundary as the reused KV prefix, using absolute positions for suffix prefill, and falling back whenever any state boundary is unavailable or ambiguous.
+
+## Existing Architecture Anchors
+
+- `lattice_serve` owns one `!Send` `MetalQwen35State` on a dedicated worker thread and serializes `Job`s over `tokio::sync::mpsc` (`crates/inference/src/bin/lattice_serve.rs`).
+- Current serve reset: `metal.reset_state()` before every worker job at `lattice_serve.rs:232`.
+- Current chat/REPL reset: `chat_metal.rs:758` and `chat_metal.rs:824`.
+- `chat_completion_streaming` renders ChatML via `format_chat_template`, adds `<|im_end|>`, then calls `generate_streaming` (`metal_qwen35.rs:15082`-`15102`).
+- `generate_streaming` tokenizes into `prompt_ids`, then unconditionally calls `self.reset_state()` before full prefill (`metal_qwen35.rs:13707`-`13756`).
+- `forward_prefill_batched_chunk(token_ids, start_pos, all_positions)` already accepts absolute `start_pos` and writes KV/RoPE rows at that absolute position.
+- `forward_prefill_impl` is not directly reusable for suffix prefill because its public wrapper starts at zero and its single-token path calls `forward_step(token, 0)`.
+- Existing generic prefix cache patterns live under `crates/inference/src/kv_cache/prefix.rs` and are re-exported through `kv_cache/mod.rs`.
+- Existing GDN snapshot type is `crate::attention::gdn::GdnSnapshot = Vec<(Vec<f32>, Vec<f32>)>`.
+- Existing error variant `InferenceError::PrefixCache(String)` should be used for recoverable cache planning/restore failures.
+
+## Module Placement
+
+Follow existing crate boundaries:
+
+1. Add generic token-prefix planning in `crates/inference/src/kv_cache/cross_turn.rs`.
+   - This mirrors `kv_cache/prefix.rs`: small structs, deterministic planning, unit tests.
+   - It must not depend on `metal::*` buffers.
+   - Re-export from `crates/inference/src/kv_cache/mod.rs`.
+
+2. Add Metal-specific cache ownership inside `crates/inference/src/forward/metal_qwen35.rs`.
+   - `MetalQwen35State` already owns live `MetalKvCache`, GDN buffers, tokenizer-facing streaming, and private GDN snapshot/restore methods.
+   - The cross-turn entry stores logical KV ownership and one `GdnSnapshot`; actual K/V `Buffer`s remain in `self.session.kv_cache`.
+
+3. Update only serve/chat call sites for feature use.
+   - `lattice_serve.rs` should use the cache-aware chat method and remove its unconditional pre-job `reset_state()`.
+   - `chat_metal.rs` REPL can use the cache-aware method for the growing local `history`; JSON one-shot and stateless paths may keep full reset.
+
+Do not introduce a new service abstraction or shared database of cache state. The current worker is single-threaded around Metal, so worker-local state has lower coupling and clearer ownership.
+
+## Committed Rust Interfaces
+
+### Generic Planning Module
+
+File: `crates/inference/src/kv_cache/cross_turn.rs`
+
+```rust
+use crate::kv_cache::AdapterId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CrossTurnSlotId(pub u64);
+
+impl CrossTurnSlotId {
+    pub const DEFAULT: Self = Self(0);
+    pub const fn new(value: u64) -> Self;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CrossTurnPrefixMetadata {
+    pub model_fingerprint: u64,
+    pub tokenizer_fingerprint: u64,
+    pub adapter_id: AdapterId,
+    pub vocab_size: usize,
+    pub max_cache_len: usize,
+    pub kv_f16: bool,
+    pub rope_theta_bits: u64,
+    pub partial_rotary_factor_bits: Option<u32>,
+    pub layer_pattern_hash: u64,
+    pub chat_template_version: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KvPrefixHandle {
+    pub represented_len: usize,
+    pub num_full_attention_layers: usize,
+    pub kv_dim: usize,
+    pub max_cache_len: usize,
+    pub kv_f16: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossTurnPrefixEntry {
+    pub slot_id: CrossTurnSlotId,
+    pub metadata: CrossTurnPrefixMetadata,
+    pub token_ids: Vec<u32>,
+    pub represented_len: usize,
+    pub kv: KvPrefixHandle,
+    pub gdn_snapshot_len: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrefixReuseMode {
+    FullRefill,
+    ExactAppend,
+    ReplayFromCheckpoint { checkpoint_len: usize },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrefixRestorePlan {
+    pub mode: PrefixReuseMode,
+    pub shared_token_prefix_len: usize,
+    pub reusable_len: usize,
+    pub suffix_start: usize,
+    pub suffix_len: usize,
+    pub old_represented_len: usize,
+}
+
+pub fn longest_common_token_prefix(a: &[u32], b: &[u32]) -> usize;
+
+pub fn plan_prefix_reuse(
+    entry: Option<&CrossTurnPrefixEntry>,
+    metadata: &CrossTurnPrefixMetadata,
+    new_prompt_ids: &[u32],
+    sparse_checkpoint_lens: &[usize],
+) -> PrefixRestorePlan;
+```
+
+Rules for `plan_prefix_reuse`:
+
+- Return `FullRefill` when no entry exists, metadata differs, `new_prompt_ids` is empty, or `shared_token_prefix_len == 0`.
+- Return `ExactAppend` only when `shared_token_prefix_len == entry.represented_len` and `entry.gdn_snapshot_len == entry.represented_len`.
+- Return `ReplayFromCheckpoint { checkpoint_len }` only if `checkpoint_len <= shared_token_prefix_len` and an implementation actually owns an exact GDN checkpoint at `checkpoint_len`.
+- Otherwise return `FullRefill`.
+
+### Metal-Specific Runtime Types
+
+File: `crates/inference/src/forward/metal_qwen35.rs`, inside the existing `inner` module near `MetalKvCache` / `InferenceSession`.
+
+```rust
+use crate::attention::gdn::GdnSnapshot;
+use crate::error::InferenceError;
+use crate::kv_cache::{
+    CrossTurnPrefixEntry, CrossTurnPrefixMetadata, CrossTurnSlotId, KvPrefixHandle,
+    PrefixRestorePlan, PrefixReuseMode,
+};
+
+#[derive(Debug, Clone)]
+pub struct CrossTurnCacheStats {
+    pub slot_id: CrossTurnSlotId,
+    pub prompt_tokens: usize,
+    pub reused_tokens: usize,
+    pub prefetched_tokens: usize,
+    pub mode: PrefixReuseMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedGenerateOutput {
+    pub output: GenerateOutput,
+    pub cache: CrossTurnCacheStats,
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedChatCompletionOutput {
+    pub output: ChatCompletionOutput,
+    pub cache: CrossTurnCacheStats,
+}
+
+#[derive(Debug, Clone)]
+struct MetalCrossTurnPrefixEntry {
+    generic: CrossTurnPrefixEntry,
+    gdn_snapshot: GdnSnapshot,
+}
+
+#[derive(Debug, Default)]
+struct MetalCrossTurnPrefixCache {
+    entries: std::collections::HashMap<CrossTurnSlotId, MetalCrossTurnPrefixEntry>,
+}
+
+impl MetalCrossTurnPrefixCache {
+    fn get(&self, slot_id: CrossTurnSlotId) -> Option<&MetalCrossTurnPrefixEntry>;
+    fn insert(&mut self, entry: MetalCrossTurnPrefixEntry);
+    fn remove(&mut self, slot_id: CrossTurnSlotId);
+    fn clear(&mut self);
+}
+```
+
+Extend `MetalQwen35State`:
+
+```rust
+pub struct MetalQwen35State {
+    pub(crate) engine: MetalQwen35Engine,
+    pub(crate) session: InferenceSession,
+    pub(crate) lora: Option<MetalLoraAdapter>,
+    pub(crate) use_gdn_chunked: bool,
+    pub(crate) use_kv_f16: bool,
+    cross_turn_prefix_cache: MetalCrossTurnPrefixCache,
+}
+```
+
+Public cache-aware methods:
+
+```rust
+impl MetalQwen35State {
+    pub fn clear_cross_turn_prefix_cache(&mut self);
+
+    pub fn generate_streaming_with_prefix_cache<F>(
+        &mut self,
+        slot_id: CrossTurnSlotId,
+        prompt: &str,
+        tokenizer: &BpeTokenizer,
+        gen_cfg: &GenerateConfig,
+        on_token: F,
+    ) -> Result<CachedGenerateOutput, InferenceError>
+    where
+        F: FnMut(&str, u32) -> bool;
+
+    pub fn chat_completion_streaming_with_prefix_cache<F>(
+        &mut self,
+        slot_id: CrossTurnSlotId,
+        messages: &[ChatMessage],
+        tokenizer: &BpeTokenizer,
+        gen_cfg: &GenerateConfig,
+        on_token: F,
+    ) -> Result<CachedChatCompletionOutput, InferenceError>
+    where
+        F: FnMut(&str, u32) -> bool;
+}
+```
+
+Private helper signatures:
+
+```rust
+impl MetalQwen35State {
+    fn cross_turn_metadata(&self, tokenizer: &BpeTokenizer) -> CrossTurnPrefixMetadata;
+
+    fn plan_cross_turn_reuse(
+        &self,
+        slot_id: CrossTurnSlotId,
+        metadata: &CrossTurnPrefixMetadata,
+        prompt_ids: &[u32],
+    ) -> PrefixRestorePlan;
+
+    fn restore_cross_turn_prefix(
+        &mut self,
+        slot_id: CrossTurnSlotId,
+        plan: &PrefixRestorePlan,
+    ) -> Result<(), InferenceError>;
+
+    fn forward_prefill_from(
+        &mut self,
+        token_ids: &[u32],
+        start_pos: usize,
+        all_positions: bool,
+    ) -> Result<Vec<f32>, InferenceError>;
+
+    fn save_cross_turn_prefix(
+        &mut self,
+        slot_id: CrossTurnSlotId,
+        metadata: CrossTurnPrefixMetadata,
+        represented_token_ids: Vec<u32>,
+    ) -> Result<(), InferenceError>;
+
+    fn snapshot_gdn_states_checked(&self) -> Result<GdnSnapshot, InferenceError>;
+
+    fn restore_gdn_states_checked(&mut self, snapshot: &GdnSnapshot) -> Result<(), InferenceError>;
+}
+```
+
+`snapshot_gdn_states_checked` and `restore_gdn_states_checked` wrap the existing private snapshot/restore logic and convert shape mismatches to `InferenceError::PrefixCache` instead of relying on `debug_assert_eq!`.
+
+## What The Cache Retains
+
+Per `CrossTurnSlotId`:
+
+- `token_ids: Vec<u32>`: exact rendered prompt tokens represented by state.
+- `represented_len: usize`: authoritative number of tokens in all reusable state.
+- `kv: KvPrefixHandle`: logical handle to live `self.session.kv_cache` buffers, not a copy. The actual Metal `k_bufs` and `v_bufs` remain owned by the same `MetalQwen35State`.
+- `gdn_snapshot: GdnSnapshot`: exact recurrent `S` matrices and conv buffers after `represented_len` tokens.
+- `metadata: CrossTurnPrefixMetadata`: invalidates across model/tokenizer/adapter/RoPE/KV layout/template changes.
+
+The v1 cache must not store every token-boundary GDN snapshot. One exact latest-boundary snapshot is enough for normal append-only chat and costs about 19.3 MiB for Qwen3.5-0.8B. Every-token GDN snapshots are rejected for v1 because they are about 19.3 MiB per boundary.
+
+## Serve/Chat Hook
+
+### `lattice_serve.rs`
+
+Extend `Job`:
+
+```rust
+struct Job {
+    slot_id: CrossTurnSlotId,
+    messages: Vec<ChatMessage>,
+    cfg: GenerateConfig,
+    tx: mpsc::UnboundedSender<Ev>,
+}
+```
+
+Add request-derived slot selection:
+
+```rust
+fn request_slot_id(req: &ChatReq) -> CrossTurnSlotId;
+```
+
+Recommended v1 behavior:
+
+- If a request includes a client-supplied cache/session key, hash it into `CrossTurnSlotId`.
+- If no key exists, use `CrossTurnSlotId::DEFAULT` only when the server is configured for single-client local use; otherwise disable cross-turn caching for that request by using full reset. This avoids cross-client state bleed.
+
+Worker loop replacement:
+
+```rust
+while let Some(job) = job_rx.blocking_recv() {
+    let cb_tx = job.tx.clone();
+    let result = metal.chat_completion_streaming_with_prefix_cache(
+        job.slot_id,
+        &job.messages,
+        &tokenizer,
+        &job.cfg,
+        |delta, _id| cb_tx.send(Ev::Delta(delta.to_string())).is_ok(),
+    );
+
+    match result {
+        Ok(out) => {
+            let _ = job.tx.send(Ev::Done {
+                prompt_tokens: out.output.prompt_tokens,
+                completion_tokens: out.output.completion_tokens,
+            });
+        }
+        Err(err) => {
+            metal.reset_state();
+            metal.clear_cross_turn_prefix_cache();
+            let _ = job.tx.send(Ev::Error(err.to_string()));
+        }
+    }
+}
+```
+
+`Ev::Error(String)` is an added worker event so cache setup failures do not panic or silently hang the client.
+
+### `chat_metal.rs`
+
+- REPL mode: replace the per-turn `metal.reset_state()` with `chat_completion_streaming_with_prefix_cache(CrossTurnSlotId::DEFAULT, ...)`.
+- JSON serve mode: add the same slot-key rule as `lattice_serve` or keep full reset if no request-level session identity exists.
+- One-shot mode: no cache is needed; keep existing behavior.
+
+## Generation Algorithm
+
+1. Format/render prompt exactly as existing code does.
+   - Chat path still uses `format_chat_template(messages)`.
+   - `generate_streaming_with_prefix_cache` starts from the prompt string and tokenizer.
+
+2. Tokenize once:
+
+```rust
+let input = tokenizer.tokenize(prompt);
+let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
+```
+
+3. Preserve existing early exits before touching cache:
+   - empty prompt returns empty output,
+   - `max_new_tokens == 0` returns length stop,
+   - prompt longer than `max_context()` returns `StopReason::KvFull`.
+
+4. Build metadata and plan:
+
+```rust
+let metadata = self.cross_turn_metadata(tokenizer);
+let plan = self.plan_cross_turn_reuse(slot_id, &metadata, &prompt_ids);
+```
+
+5. Restore or reset:
+
+```rust
+match plan.mode {
+    PrefixReuseMode::ExactAppend => self.restore_cross_turn_prefix(slot_id, &plan)?,
+    PrefixReuseMode::ReplayFromCheckpoint { .. } => {
+        // v2 only; v1 should not return this mode unless implemented.
+        self.restore_cross_turn_prefix(slot_id, &plan)?;
+    }
+    PrefixReuseMode::FullRefill => self.reset_state(),
+}
+```
+
+6. Prefill suffix:
+
+```rust
+let suffix = &prompt_ids[plan.suffix_start..];
+let mut prefill_logits = if suffix.is_empty() {
+    // Correct only when restored state is at prompt end and there is a saved
+    // final prompt logit source. v1 should avoid this case by not caching a
+    // prompt end without logits, or fall back to full refill.
+    return Err(InferenceError::PrefixCache(
+        "cannot sample from a fully reused prompt without saved logits".into(),
+    ));
+} else {
+    self.forward_prefill_from(suffix, plan.suffix_start, false)?
+};
+```
+
+Append-only chat normally has a non-empty new suffix because each turn appends new user text and an open assistant marker.
+
+7. Run the existing sampling/decode loop unchanged except for error handling and final cache save.
+
+8. Cache save:
+
+After generation finishes or is interrupted, save only tokens actually represented in model state. Because the current loop samples the first prefill token before forwarding it into KV/GDN, the implementation must do one of these:
+
+- Conservative v1: cache only `prompt_ids` after suffix prefill and do not include generated assistant tokens in `represented_token_ids`. This still reuses the previous full rendered prompt on the next request when the client sends the assistant message text, but only up to the prior prompt boundary.
+- Better v1: after the loop, if the final emitted token has not been forwarded, run a silent `forward_step(last_pushed_id, self.session.kv_cache.seq_len)` before saving `prompt_ids + generated_ids`. This maximizes next-turn reuse but must not emit or resample anything.
+
+The implementation must choose one strategy and test `represented_len == session.kv_cache.seq_len == gdn_snapshot_len`. The preferred strategy is the silent final step because it lets the next turn reuse through the assistant output that the client will include in history.
+
+## Invalidation And Divergence Algorithm
+
+Definitions:
+
+```rust
+let shared = longest_common_token_prefix(&entry.token_ids, &new_prompt_ids);
+let reusable = shared.min(entry.represented_len);
+```
+
+Algorithm:
+
+1. If metadata differs: clear the slot and full refill.
+2. If `shared == 0`: full refill.
+3. If `shared == entry.represented_len` and `entry.gdn_snapshot_len == entry.represented_len`:
+   - restore GDN snapshot,
+   - set logical KV/session position to `shared`,
+   - prefill `new_prompt_ids[shared..]` at `start_pos = shared`.
+4. If `0 < shared < entry.represented_len`:
+   - full-attention KV rows after `shared` are invalid and may only be ignored by lowering logical length,
+   - GDN cannot be logically truncated,
+   - v1 full-refills unless sparse checkpoint replay is implemented.
+5. If `new_prompt_ids.len() < entry.represented_len`:
+   - treat as divergence/truncation; v1 full-refills.
+6. If `shared > self.max_context()` or suffix would exceed KV capacity:
+   - return clean `KvFull` output or `InferenceError::InvalidInput`, matching existing path semantics.
+
+KV invalidation uses `self.session.set_position(shared)`. Do not zero stale K/V rows; existing `MetalKvCache::reset` and `FlatKVCache::truncate_to` use logical invalidation. GDN invalidation must restore or replay; no truncation-only GDN path is correct.
+
+## Position And RoPE Handling
+
+Requirement:
+
+> The reused prefix and new suffix must use the same absolute positions as a full re-prefill of `new_prompt_ids`.
+
+Implementation rules:
+
+- Add `forward_prefill_from(token_ids, start_pos, all_positions) -> Result<Vec<f32>, InferenceError>`.
+- Validate every `token_id < vocab_size`; return `InferenceError::InvalidInput` on failure.
+- For `token_ids.is_empty()`, return an error unless the caller has a valid saved logits source.
+- For `token_ids.len() == 1`, call `forward_step(token_ids[0], start_pos)`, not `forward_step(..., 0)`.
+- For batched chunks, call `forward_prefill_batched_chunk(chunk, start_pos + offset, all_positions_for_chunk)`.
+- After restore and before suffix prefill, call `self.session.set_position(start_pos)`.
+- After suffix prefill, assert in debug and validate in release that `self.session.kv_cache.seq_len == start_pos + token_ids.len()`.
+
+Why this is enough:
+
+- Batched RoPE already accepts `base_pos` and indexes `cos/sin` using `base_pos + t`.
+- Batched K/V writes already use `base_pos + t`.
+- Prefill attention already receives `start_pos` and derives causal cache length from absolute position.
+- Decode already uses `pos = self.session.kv_cache.seq_len`.
+
+## GDN State Decision
+
+Chosen v1 option: persist one exact GDN snapshot at the latest represented boundary per cache slot.
+
+Alternatives considered:
+
+| Option | Correct | Cost | Decision |
+|---|---:|---:|---|
+| Reuse attention KV only | No | Low | Rejected. GDN state would not match full re-prefill. |
+| Snapshot every token boundary | Yes | About 19.3 MiB per boundary for 0.8B | Rejected for v1 memory cost. |
+| One latest-boundary snapshot | Yes for append-only `L == represented_len` | About 19.3 MiB per slot | Chosen v1. |
+| Sparse checkpoints + replay | Yes if replay is token-identical | `N * 19.3 MiB` plus replay | v2, optional for edited-history speedup. |
+| Replay whole shared prefix | Correct if full model replay | O(shared prefix) | Fallback only; not the feature win. |
+
+Correctness rationale:
+
+GDN layers mutate `S` matrices and conv buffers during both prefill and decode. These buffers are not indexed by token position and cannot be rewound by lowering `kv_cache.seq_len`. Therefore the cached path is state-equivalent to full re-prefill at boundary `L` only when it restores a snapshot taken exactly after processing tokens `[0, L)`, or when it replays from an earlier exact checkpoint to `L`. v1 only claims reuse when the exact latest snapshot is the needed boundary.
+
+## Error Handling Strategy
+
+- New cache-aware public methods return `Result<_, InferenceError>`.
+- Use `InferenceError::PrefixCache(String)` for cache metadata mismatch that should surface as an internal cache failure, malformed snapshot shape, missing saved GDN snapshot in a mode that requires it, and impossible restore plans.
+- Use `InferenceError::InvalidInput(String)` for raw invalid token IDs or caller-supplied cache/session key errors.
+- Preserve existing non-`Result` `generate_streaming` and `chat_completion_streaming` as full-reset compatibility wrappers.
+- Do not add `unwrap` or `expect` in lib code for cache paths. Internal invariants should use explicit `ok_or_else`, `checked_*`, and shape checks that return `InferenceError`.
+- Binaries may convert errors to response events or stderr, but must not panic the worker thread on cache failure. On cache error, clear the slot, reset state, and either retry full-refill once or return an error response.
+
+## Public API Compatibility
+
+Existing callers remain valid:
+
+```rust
+pub fn generate_streaming<F>(...) -> GenerateOutput;
+pub fn chat_completion_streaming<F>(...) -> ChatCompletionOutput;
+```
+
+New serve path opts into:
+
+```rust
+pub fn chat_completion_streaming_with_prefix_cache<F>(...) -> Result<CachedChatCompletionOutput, InferenceError>;
+```
+
+The compatibility methods must not silently use cross-turn cache. That keeps old one-shot and test behavior deterministic.
+
+## Diagrams
+
+Component view:
+
+```mermaid
+flowchart LR
+    Client[OpenAI client] --> Handler[axum chat handler]
+    Handler --> Job[Job: slot_id + messages + cfg]
+    Job --> Worker[Metal worker thread]
+    Worker --> State[MetalQwen35State]
+    State --> Planner[kv_cache::cross_turn planner]
+    State --> Prefix[MetalCrossTurnPrefixCache]
+    State --> KV[Live MetalKvCache buffers]
+    State --> GDN[GDN conv/S buffers]
+    Prefix --> Tokens[token_ids]
+    Prefix --> Snapshot[GdnSnapshot]
+    Prefix --> KVHandle[KvPrefixHandle]
+```
+
+Sequence view:
+
+```mermaid
+sequenceDiagram
+    participant W as Worker
+    participant M as MetalQwen35State
+    participant C as PrefixCache
+    participant G as GDN/KV State
+
+    W->>M: chat_completion_streaming_with_prefix_cache(slot, messages)
+    M->>M: format_chat_template + tokenize
+    M->>C: plan(slot, metadata, prompt_ids)
+    alt ExactAppend
+        M->>G: restore GDN snapshot
+        M->>G: set_position(L)
+        M->>M: forward_prefill_from(prompt_ids[L..], L)
+    else FullRefill
+        M->>G: reset_state()
+        M->>M: forward_prefill_from(prompt_ids, 0)
+    end
+    M->>M: sample/decode existing loop
+    M->>C: save represented token_ids + GDN snapshot + KV handle
+    M-->>W: CachedChatCompletionOutput + stats
+```
+
+## Coupling And Testability
+
+Components:
+
+1. `kv_cache::cross_turn` planner,
+2. `MetalCrossTurnPrefixCache`,
+3. `MetalQwen35State` cache-aware generate/chat methods,
+4. serve worker job protocol,
+5. chat_metal REPL integration.
+
+Direct dependencies after design:
+
+- planner has no dependency on Metal,
+- Metal cache depends on planner and GDN snapshot type,
+- serve/chat binaries depend only on public cache-aware methods and `CrossTurnSlotId`.
+
+Estimated coupling: `|Deps|=5`, `|C|=5`, `κ=5/(5*4)=0.25`, below the 0.3 target.
+
+Testability target `τ=0.86`: planner is pure unit-testable; Metal restore requires macOS/Metal integration tests but has existing tiny-fixture and 0.8B test patterns.
+
+## Required Tests
+
+Pure Rust unit tests in `kv_cache::cross_turn`:
+
+- `longest_common_token_prefix`: full hit, empty hit, first divergence, shorter old, shorter new.
+- metadata mismatch returns `FullRefill`.
+- exact append returns `ExactAppend`.
+- mid-history divergence without checkpoint returns `FullRefill`.
+- sparse checkpoint plan returns `ReplayFromCheckpoint` only when checkpoint length is valid.
+
+Metal unit/integration tests under existing `#[cfg(all(target_os = "macos", feature = "metal-gpu"))]` patterns:
+
+- `forward_prefill_from` with one token uses `start_pos`, not zero.
+- restore exact GDN snapshot plus suffix prefill matches full refill for generated token IDs.
+- 5-turn growing chat: cached path generated `token_ids` exactly equal full-reset path generated `token_ids` with fixed seed.
+- divergence edit in a middle message falls back to full refill and still matches full-reset output.
+- cache stats report baseline prompt tokens `N_t`, reused `L_t`, and prefetched `N_t - L_t`.
+- error path: malformed/missing GDN snapshot returns `InferenceError::PrefixCache` and does not panic.
+
+Measurement report requirement for `.khive/reports/crossturn_kv_462.md`:
+
+| Turn | Full-refill prefill tokens | Cached reused tokens | Cached prefetched tokens |
+|---:|---:|---:|---:|
+| 1 | `N1` | 0 | `N1` |
+| 2 | `N2` | `L2` | `N2 - L2` |
+| 3 | `N3` | `L3` | `N3 - L3` |
+| 4 | `N4` | `L4` | `N4 - L4` |
+| 5 | `N5` | `L5` | `N5 - L5` |
+
+The PR may claim prefill savings only for tokens actually skipped while preserving token identity.
+
+## ADR
+
+Decision: choose latest-boundary GDN snapshot + live KV logical reuse for v1.
+
+Alternatives:
+
+1. KV-only reuse: rejected because GDN recurrent state would diverge from full re-prefill.
+2. Every-token GDN snapshots: rejected because memory cost is too high for normal contexts.
+3. Latest-boundary GDN snapshot: accepted because append-only chat is the primary serve path and one snapshot per slot is feasible.
+4. Sparse checkpoints: deferred as v2 because it expands memory policy and replay complexity.
+
+Evidence:
+
+- Analyst brief identifies tokenization/reset insertion point and GDN snapshot cost.
+- Code scan confirms existing GDN snapshot/restore helpers and `set_position`.
+- Existing `forward_prefill_batched_chunk` already has the absolute-position surface needed for suffix prefill.
+
+Interpretation canon: Contra proferentem. The issue asks for divergent-prefix invalidation, but GDN makes arbitrary divergence reuse expensive. The minimal correct v1 is append-only O(new tokens) plus full-refill fallback for edited-history divergence.
+
+## Implementation Non-Goals
+
+- No shared cache across worker threads or processes.
+- No attention-KV-only shortcut for Qwen3.5.
+- No arbitrary edited-history O(new tokens) claim unless sparse GDN checkpoints are implemented and tested.
+- No public API that relies on text-prefix equality.
+- No panics or unwraps in new library cache code.
+
+## Domain Utility
+
+Domain utility: SKIPPED - `knowledge.suggest` returned no composeable domains; the upstream artifacts and direct code scan provided the necessary architecture evidence.

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -8302,7 +8302,22 @@ kernel void gdn_chunk_norm_silu_c32(
         /// GPU dispatch. The tokenizer-bounded generate path never triggers this; it
         /// can only be reached by a library consumer calling the raw entry point with
         /// an out-of-vocabulary id.
+        ///
+        /// # Cross-turn cache invalidation (#516 round-2 D7)
+        ///
+        /// This is a public raw-forward entry point that advances live KV/GDN
+        /// state outside the cache-aware generation family's ownership, so it
+        /// must clear any retained [`MetalCrossTurnPrefixCache`] entry before
+        /// mutating — otherwise a later `generate_streaming_with_prefix_cache`
+        /// call could restore a GDN snapshot for KV rows this call already
+        /// overwrote. Safe to call from inside the cache-aware decode loop
+        /// itself: by the time that loop reaches its own `forward_step` call,
+        /// `restore_cross_turn_prefix` has already `take()`-n (ExactAppend) or
+        /// `reset_state()` has already cleared (FullRefill) the slot's entry,
+        /// so this clear is a no-op there — the cache-aware path never has a
+        /// live entry saved while it is still generating.
         pub fn forward_step(&mut self, token_id: u32, position: usize) -> Vec<f32> {
+            self.cross_turn_prefix_cache.clear();
             self.forward_step_inner(token_id, position, false).logits
         }
 
@@ -8429,7 +8444,17 @@ kernel void gdn_chunk_norm_silu_c32(
         /// runs once at the entry point before any GPU work. The tokenizer-bounded
         /// generate path never triggers this; it can only be reached by a library
         /// consumer passing raw ids with an out-of-vocabulary value.
+        ///
+        /// # Cross-turn cache invalidation (#516 round-2 D7)
+        ///
+        /// Public raw-forward entry point — see [`Self::forward_step`]'s doc
+        /// comment for the invariant this enforces. `generate`/`generate_streaming`/
+        /// `generate_multimodal`/`compute_token_nlls` all call this after their own
+        /// `reset_state()`, which has already cleared the cache, so this clear is a
+        /// no-op on those paths; it only matters for a consumer calling this
+        /// entry point directly against a state with a live retained entry.
         pub fn forward_prefill(&mut self, token_ids: &[u32]) -> Vec<f32> {
+            self.cross_turn_prefix_cache.clear();
             self.forward_prefill_impl(token_ids, false)
         }
 
@@ -8444,7 +8469,13 @@ kernel void gdn_chunk_norm_silu_c32(
         /// # Panics
         ///
         /// Panics if any `token_ids[i] >= vocab_size`. See [`forward_prefill`] for details.
+        ///
+        /// # Cross-turn cache invalidation (#516 round-2 D7)
+        ///
+        /// Public raw-forward entry point — see [`Self::forward_step`]'s doc
+        /// comment for the invariant this enforces.
         pub fn forward_prefill_all_logits(&mut self, token_ids: &[u32]) -> Vec<f32> {
+            self.cross_turn_prefix_cache.clear();
             self.forward_prefill_impl(token_ids, true)
         }
 
@@ -15353,6 +15384,15 @@ kernel void gdn_chunk_norm_silu_c32(
         }
     }
 
+    // #516 round-2 D7: `MtpTargetVerifier` is a public trait and this impl's
+    // mutating methods (`rollback_cache_to`, `verify_tokens`) advance live
+    // KV/GDN state exactly like `forward_step`/`forward_prefill` — they are
+    // not currently wired into any live Metal generate loop (Metal MTP decode
+    // uses `mtp_greedy_round`, a self-contained mechanism; `mtp_verify_draft`
+    // is only exercised from benches today), but a consumer holding a
+    // `&mut MetalQwen35State` and `use`-ing this trait can call them directly,
+    // so they are part of the public raw-forward boundary and must clear the
+    // retained cross-turn entry before mutating, same as the inherent methods.
     impl crate::speculative::MtpTargetVerifier for MetalQwen35State {
         fn cache_position(&self) -> usize {
             self.session.kv_cache.seq_len
@@ -15362,6 +15402,7 @@ kernel void gdn_chunk_norm_silu_c32(
             &mut self,
             seq_len: usize,
         ) -> Result<(), crate::error::InferenceError> {
+            self.cross_turn_prefix_cache.clear();
             self.rollback_speculative_state_to(seq_len)
         }
 
@@ -15370,6 +15411,7 @@ kernel void gdn_chunk_norm_silu_c32(
             tokens: &[u32],
             start_pos: usize,
         ) -> Result<Vec<Vec<f32>>, crate::error::InferenceError> {
+            self.cross_turn_prefix_cache.clear();
             let out = self.verify_tokens_batched(tokens, start_pos)?;
             Ok(out.logits)
         }
@@ -22139,6 +22181,109 @@ kernel void decode_attention_reference(
             assert!(
                 state.cross_turn_prefix_cache.entry.is_none(),
                 "unload_lora_adapter must clear the retained cross-turn entry"
+            );
+        }
+
+        /// Round-2 D7 (codex blocker): a public raw-forward call
+        /// (`forward_step`) interleaved between two cache-aware calls on the
+        /// SAME slot must invalidate the retained entry, exactly like
+        /// `generate_streaming`'s `reset_state()` does for finding 2's
+        /// plain-path leg (D3, `cross_turn_cache_interleaved_plain_path_invalidates`
+        /// above) — `forward_step` mutates the same live KV/GDN buffers
+        /// without ever routing through `reset_state` or the cache's own
+        /// save path, so it is a second, independent way to leave a stale
+        /// entry pointing at overwritten state.
+        ///
+        /// Uses a strictly-longer continuation of the ORIGINAL conversation
+        /// (append one extra character) for the second call, same as D3's
+        /// test: an exact-equal retry would independently trip D5's
+        /// `FullRefill` guard (`cross_turn_cache_exact_equal_retry_full_refills`)
+        /// and mask whether D7's clear is actually doing anything.
+        ///
+        /// Mutation sensitivity: reverting D7 (removing
+        /// `self.cross_turn_prefix_cache.clear()` from `forward_step`) makes
+        /// this test fail — see the reverse-apply evidence recorded in the
+        /// PR body.
+        #[test]
+        fn cross_turn_cache_interleaved_raw_forward_invalidates() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let gen_cfg = cross_turn_test_gen_cfg(31, 2);
+
+            // Save a cross-turn entry via the cache-aware path (slot A's
+            // only slot, since `MetalCrossTurnPrefixCache` retains at most
+            // one live entry across the whole state — see D1).
+            let first = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("cache-aware first turn must succeed");
+            let mut conversation = "ab".to_string();
+            conversation.push_str(&first.output.text);
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_some(),
+                "precondition: the first cache-aware call must actually retain an entry"
+            );
+
+            // Interleave a raw public forward call on an unrelated token
+            // stream. This is the exact stale path codex named: `forward_step`
+            // advances `self.session.kv_cache` / GDN state directly, bypassing
+            // both `reset_state()` (D3's guard) and the cache-aware save path.
+            let _ = state.forward_step(0, 0);
+
+            // The raw call must have invalidated the retained entry outright
+            // (not just left it stale) — this is what D7 adds.
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_none(),
+                "forward_step must clear the retained cross-turn entry before mutating live state"
+            );
+
+            // Strict-append continuation of the ORIGINAL slot's conversation:
+            // if the entry had survived, this shape would still satisfy D5's
+            // `len > shared` guard and look like a valid ExactAppend, so the
+            // assertion below is genuinely exercising D7 and not being masked
+            // by D5.
+            let mut appended = conversation.clone();
+            appended.push('q');
+            let second = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    &appended,
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("cache-aware second turn must succeed");
+            assert_eq!(
+                second.cache.reused_tokens, 0,
+                "an interleaved raw forward_step call must force a full refill, not a stale restore"
+            );
+            assert_ne!(
+                second.cache.mode,
+                crate::kv_cache::PrefixReuseMode::ExactAppend,
+                "a raw-forward-invalidated entry must never be restored via ExactAppend"
+            );
+
+            let mut reference_state =
+                MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let reference_out =
+                reference_state.generate_streaming(&appended, &tokenizer, &gen_cfg, |_, _| true);
+            assert_eq!(
+                second.output.token_ids, reference_out.token_ids,
+                "after an interleaved raw forward_step call, output must still match full re-prefill"
             );
         }
     }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -4571,31 +4571,77 @@ kernel void gdn_chunk_norm_silu_c32(
         gdn_snapshot: crate::attention::gdn::GdnSnapshot,
     }
 
-    /// Worker-local map of cache slot to retained cross-turn prefix.
+    /// Worker-local, single-live-entry cross-turn prefix cache (#516 round-1
+    /// remediation, finding 1 + 5).
+    ///
+    /// Ownership invariant: at most ONE `MetalCrossTurnPrefixEntry` is ever
+    /// retained, bounded by design (never an unbounded per-slot map). The
+    /// entry is valid **iff** the live `self.session.kv_cache` rows and
+    /// `self.session.position` were left by exactly the generation call that
+    /// saved it. Any other mutation of live KV/GDN state — a different
+    /// slot's generation, the plain (non-cache-aware) generate path, a
+    /// `reset_state()` call, or a LoRA adapter load/unload — must invalidate
+    /// the entry before that mutation is allowed to proceed, because the
+    /// entry does not own private copies of the full-attention KV buffers
+    /// (see `MetalCrossTurnPrefixEntry` above): it can only ever describe
+    /// the ONE live buffer this process currently has. `get`/`take` both
+    /// enforce the slot match themselves so a caller can never accidentally
+    /// restore a different slot's entry.
     #[derive(Debug, Default)]
     struct MetalCrossTurnPrefixCache {
-        entries:
-            std::collections::HashMap<crate::kv_cache::CrossTurnSlotId, MetalCrossTurnPrefixEntry>,
+        entry: Option<MetalCrossTurnPrefixEntry>,
     }
 
     impl MetalCrossTurnPrefixCache {
+        /// Returns the retained entry only if it belongs to `slot_id`. A
+        /// different (or absent) slot is always a miss — never a partial or
+        /// stale match — so the planner falls back to `FullRefill`.
         fn get(
             &self,
             slot_id: crate::kv_cache::CrossTurnSlotId,
         ) -> Option<&MetalCrossTurnPrefixEntry> {
-            self.entries.get(&slot_id)
+            self.entry.as_ref().filter(|e| e.generic.slot_id == slot_id)
         }
 
+        /// Replace whatever is currently retained (if anything, for any
+        /// slot) with `entry`. At most one GDN snapshot is ever alive.
         fn insert(&mut self, entry: MetalCrossTurnPrefixEntry) {
-            self.entries.insert(entry.generic.slot_id, entry);
+            self.entry = Some(entry);
+        }
+
+        /// Remove and return the retained entry iff it belongs to
+        /// `slot_id`, leaving the cache empty either way it existed for
+        /// that slot. Used by `restore_cross_turn_prefix` so an
+        /// `ExactAppend` restore consumes its GDN snapshot instead of
+        /// cloning it, and so the cache is provably empty for the
+        /// remainder of the call until a fresh save succeeds.
+        fn take(
+            &mut self,
+            slot_id: crate::kv_cache::CrossTurnSlotId,
+        ) -> Option<MetalCrossTurnPrefixEntry> {
+            if self
+                .entry
+                .as_ref()
+                .is_some_and(|e| e.generic.slot_id == slot_id)
+            {
+                self.entry.take()
+            } else {
+                None
+            }
         }
 
         fn remove(&mut self, slot_id: crate::kv_cache::CrossTurnSlotId) {
-            self.entries.remove(&slot_id);
+            if self
+                .entry
+                .as_ref()
+                .is_some_and(|e| e.generic.slot_id == slot_id)
+            {
+                self.entry = None;
+            }
         }
 
         fn clear(&mut self) {
-            self.entries.clear();
+            self.entry = None;
         }
     }
 
@@ -6246,6 +6292,14 @@ kernel void gdn_chunk_norm_silu_c32(
                 intermediate,
                 max_rank,
             });
+            // #516 round-1 remediation D4: the cross-turn cache's adapter
+            // identity (`cross_turn_metadata`'s `adapter_id`) is a shape-based
+            // hash (max_rank/scale/projection count), not a content hash, so
+            // two different adapters with the same shape can collide on the
+            // same `AdapterId` (finding 3). The metadata hash is
+            // defense-in-depth; the unconditional clear here is the actual
+            // correctness mechanism.
+            self.cross_turn_prefix_cache.clear();
 
             Ok(())
         }
@@ -6253,6 +6307,10 @@ kernel void gdn_chunk_norm_silu_c32(
         /// Unload the currently loaded LoRA adapter, freeing GPU buffers.
         pub fn unload_lora_adapter(&mut self) {
             self.lora = None;
+            // #516 round-1 remediation D4: see the matching comment in
+            // `load_lora_adapter` — any adapter identity change must
+            // invalidate the retained cross-turn entry.
+            self.cross_turn_prefix_cache.clear();
         }
 
         /// Returns true if a LoRA adapter is currently loaded.
@@ -10398,6 +10456,15 @@ kernel void gdn_chunk_norm_silu_c32(
                 pool.active_base_seq_len = None;
             }
             self.session.last_pre_final_hidden = vec![0.0f32; self.engine.config.hidden_size];
+            // #516 round-1 remediation D3: every public path that resets live
+            // KV/GDN state (plain `generate_streaming`, chat, the serve
+            // worker, and the cache-aware path's own FullRefill/error legs)
+            // routes through here, so this is the single place that must
+            // invalidate any retained cross-turn entry. A retained entry
+            // describes exactly the state this call just vacated; leaving it
+            // alive would let a later cache-aware call restore GDN state for
+            // KV rows that no longer represent it (finding 2).
+            self.cross_turn_prefix_cache.clear();
         }
 
         /// Select the GDN prefill scan at runtime: `true` = chunked-parallel (default),
@@ -15472,19 +15539,22 @@ kernel void gdn_chunk_norm_silu_c32(
 
             match plan.mode {
                 PrefixReuseMode::ExactAppend => {
-                    let snapshot = self
-                        .cross_turn_prefix_cache
-                        .get(slot_id)
-                        .ok_or_else(|| {
-                            InferenceError::PrefixCache(
-                                "restore_cross_turn_prefix: ExactAppend plan but no cached entry \
-                                 for this slot"
-                                    .into(),
-                            )
-                        })?
-                        .gdn_snapshot
-                        .clone();
-                    self.restore_gdn_states_checked(&snapshot)?;
+                    // Take (not clone): from this point on the cache is
+                    // EMPTY for this slot until a fresh save succeeds at
+                    // the end of generation. Any early return between here
+                    // and that save (error `?`, caller-interrupt) leaves
+                    // the cache empty rather than retaining a stale entry
+                    // — fail-closed by construction (#516 round-1
+                    // remediation D2). This also removes a ~19MiB GDN
+                    // snapshot clone per restore.
+                    let entry = self.cross_turn_prefix_cache.take(slot_id).ok_or_else(|| {
+                        InferenceError::PrefixCache(
+                            "restore_cross_turn_prefix: ExactAppend plan but no cached entry \
+                             for this slot"
+                                .into(),
+                        )
+                    })?;
+                    self.restore_gdn_states_checked(&entry.gdn_snapshot)?;
                     self.session.set_position(plan.reusable_len);
                     Ok(())
                 }
@@ -21763,6 +21833,312 @@ kernel void decode_attention_reference(
                 second.cache.mode,
                 crate::kv_cache::PrefixReuseMode::FullRefill,
                 "a cleared cache slot must never be treated as a valid cached entry"
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // #516 round-1 remediation (codex REJECT) — regression coverage for
+        // findings 1/2/3/4. See
+        // .khive/codex_reviews/codex_review_pr516.md.
+        // -------------------------------------------------------------------
+
+        /// Finding 1 (slot isolation): a divergent-prompt call on a
+        /// different slot must evict the single retained entry (D1's
+        /// single-live-entry cache), so a later append to the ORIGINAL
+        /// slot's prefix cannot silently restore GDN state left by a
+        /// different slot's generation while attention reads whatever KV
+        /// rows the other slot's generation wrote.
+        #[test]
+        fn cross_turn_cache_slot_isolation_evicts_other_slot() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_a = crate::kv_cache::CrossTurnSlotId::new(1);
+            let slot_b = crate::kv_cache::CrossTurnSlotId::new(2);
+            let mut state = MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let gen_cfg = cross_turn_test_gen_cfg(11, 2);
+
+            // Save slot A.
+            let first = state
+                .generate_streaming_with_prefix_cache(slot_a, "ab", &tokenizer, &gen_cfg, |_, _| {
+                    true
+                })
+                .expect("slot A first turn must succeed");
+            let mut conv_a = "ab".to_string();
+            conv_a.push_str(&first.output.text);
+
+            // Divergent-prompt call on slot B: under D1, `insert` replaces
+            // whatever is retained regardless of slot, so this evicts A's
+            // entry and retains B's.
+            state
+                .generate_streaming_with_prefix_cache(
+                    slot_b,
+                    "xyz",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("slot B turn must succeed");
+
+            // Append-only continuation of A's prefix, issued on slot A
+            // AFTER B evicted the single retained entry: must NOT
+            // ExactAppend (there is no A entry left to restore from).
+            let second = state
+                .generate_streaming_with_prefix_cache(
+                    slot_a,
+                    &conv_a,
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("slot A second turn must succeed");
+            assert_eq!(
+                second.cache.reused_tokens, 0,
+                "slot A must not reuse GDN/KV state left by slot B's generation"
+            );
+            assert_ne!(
+                second.cache.mode,
+                crate::kv_cache::PrefixReuseMode::ExactAppend,
+                "a different-slot eviction must force a FullRefill, never ExactAppend"
+            );
+
+            let mut reference_state =
+                MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let reference_out =
+                reference_state.generate_streaming(&conv_a, &tokenizer, &gen_cfg, |_, _| true);
+            assert_eq!(
+                second.output.token_ids, reference_out.token_ids,
+                "after cross-slot eviction, output must still match full re-prefill"
+            );
+        }
+
+        /// Finding 2, plain-path leg (D3): interleaving a plain
+        /// `generate_streaming` call (which goes through `reset_state`)
+        /// between two cache-aware calls must invalidate the retained
+        /// entry — the plain path overwrites live KV/GDN state without
+        /// ever calling `save_cross_turn_prefix`.
+        ///
+        /// Mutation sensitivity: reverting D3 (removing
+        /// `self.cross_turn_prefix_cache.clear()` from `reset_state`) makes
+        /// this test fail, because the stale entry would still report
+        /// `ExactAppend` against state the plain path already overwrote.
+        #[test]
+        fn cross_turn_cache_interleaved_plain_path_invalidates() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let gen_cfg = cross_turn_test_gen_cfg(21, 2);
+
+            // Save a cross-turn entry.
+            let first = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("cache-aware first turn must succeed");
+            let mut conversation = "ab".to_string();
+            conversation.push_str(&first.output.text);
+
+            // Plain path: a different prompt, routed through `reset_state`,
+            // never touches the cross-turn cache's save path.
+            let _ = state.generate_streaming("zzzzzz", &tokenizer, &gen_cfg, |_, _| true);
+
+            // A genuine append (strictly longer than the cached entry) onto
+            // the ORIGINAL prefix through the cache-aware path again: if the
+            // stale entry survived, this satisfies D5's `len > shared` guard
+            // too (it is NOT an exact-equal retry), so it would still look
+            // like a valid ExactAppend continuation of `conversation` and
+            // this test would only be sensitive to D3, not accidentally
+            // masked by D5's separate guard.
+            let mut appended = conversation.clone();
+            appended.push('q');
+            let second = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    &appended,
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("cache-aware second turn must succeed");
+            assert_eq!(
+                second.cache.reused_tokens, 0,
+                "an interleaved plain generate_streaming call must invalidate the retained entry"
+            );
+
+            let mut reference_state =
+                MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let reference_out =
+                reference_state.generate_streaming(&appended, &tokenizer, &gen_cfg, |_, _| true);
+            assert_eq!(
+                second.output.token_ids, reference_out.token_ids,
+                "after an interleaved plain-path reset, output must still match full re-prefill"
+            );
+        }
+
+        /// Finding 4 (D5): retrying the exact same prompt through the
+        /// cache-aware path must not hit the empty-suffix invariant error
+        /// in `forward_prefill_from` — the planner must fall back to
+        /// `FullRefill` when the new prompt exactly equals the entry's
+        /// represented tokens.
+        ///
+        /// Mutation sensitivity: reverting D5 (dropping the
+        /// `new_prompt_ids.len() > shared` conjunct in
+        /// `plan_prefix_reuse`) makes this test fail: the planner would
+        /// again produce `ExactAppend` with `suffix_len == 0`, and
+        /// `generate_streaming_with_prefix_cache` would return
+        /// `Err(InferenceError::PrefixCache(..))` instead of `Ok`.
+        #[test]
+        fn cross_turn_cache_exact_equal_retry_full_refills() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let gen_cfg = cross_turn_test_gen_cfg(5, 2);
+
+            let first = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "abc",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("first call must succeed");
+
+            // The saved entry represents `prompt + generated tokens`, NOT
+            // just the original prompt (see the `represented_token_ids`
+            // construction in `generate_streaming_with_prefix_cache_inner`).
+            // To actually exercise the exact-equal boundary the second call
+            // must retry with THIS accumulated conversation — retrying with
+            // the bare "abc" prompt again would only exercise the ordinary
+            // mid-history-divergence FullRefill path (shared < represented_len),
+            // never reaching the `shared == represented_len` branch this test
+            // targets.
+            let mut conversation = "abc".to_string();
+            conversation.push_str(&first.output.text);
+
+            let second = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    &conversation,
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("exact-equal prompt retry must not error");
+            assert_eq!(
+                second.cache.reused_tokens, 0,
+                "an exact-equal prompt retry must plan FullRefill, not a zero-length ExactAppend"
+            );
+
+            let mut reference_state =
+                MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let reference_out =
+                reference_state
+                    .generate_streaming(&conversation, &tokenizer, &gen_cfg, |_, _| true);
+            assert_eq!(
+                second.output.token_ids, reference_out.token_ids,
+                "exact-equal prompt retry output must match full re-prefill"
+            );
+        }
+
+        /// Finding 3 (D4): LoRA adapter load/unload must invalidate the
+        /// retained cross-turn entry. The adapter-identity hash in
+        /// `CrossTurnPrefixMetadata` is shape-based (max_rank/scale/
+        /// projection count), not content-based, so two different adapters
+        /// with the same shape can collide on the same `AdapterId` — the
+        /// unconditional clear on load/unload is the actual correctness
+        /// mechanism, not the metadata hash. Asserted directly against the
+        /// cache struct (this `mod tests` is a child module of
+        /// `metal_qwen35`, so the private `entry` field is visible here).
+        #[test]
+        fn cross_turn_cache_lora_load_unload_invalidates() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let gen_cfg = cross_turn_test_gen_cfg(9, 2);
+
+            state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("save call must succeed");
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_some(),
+                "precondition: a save must actually retain an entry"
+            );
+
+            // `tiny_hybrid_fixture`'s only FullAttention layer is index 3
+            // (layers 0-2 are LinearAttention/GDN); `make_valid_layer`
+            // defaults to layer_idx 0, which is only valid against the
+            // single-FullAttention-layer fixture other LoRA tests use.
+            let mut lora_layer = make_valid_layer(512, 2);
+            lora_layer.layer_idx = 3;
+            state
+                .load_lora_adapter(vec![lora_layer], 1.0, None)
+                .expect("load_lora_adapter with a valid small fixture must succeed");
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_none(),
+                "load_lora_adapter must clear the retained cross-turn entry"
+            );
+
+            // Re-save under the loaded adapter, then unload and check
+            // invalidation again.
+            state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("save call under LoRA must succeed");
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_some(),
+                "precondition: a save under LoRA must actually retain an entry"
+            );
+
+            state.unload_lora_adapter();
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_none(),
+                "unload_lora_adapter must clear the retained cross-turn entry"
             );
         }
     }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -10501,7 +10501,15 @@ kernel void gdn_chunk_norm_silu_c32(
         /// Select the GDN prefill scan at runtime: `true` = chunked-parallel (default),
         /// `false` = serial per-token. Construction reads `LATTICE_GDN_CHUNKED`; this lets
         /// callers (benchmarks, A/B tests) flip the path on a live state without rebuilding.
+        ///
+        /// Flipping the mode invalidates any retained cross-turn cache entry: the two
+        /// scans are not bit-exact (measured logit drift up to ~2e-1 at chunk boundaries),
+        /// so a snapshot produced under one mode must not seed a prefix that the current
+        /// mode's full-refill reference would have prefilled differently.
         pub fn set_gdn_chunked(&mut self, enabled: bool) {
+            if self.use_gdn_chunked != enabled {
+                self.cross_turn_prefix_cache.clear();
+            }
             self.use_gdn_chunked = enabled;
         }
 
@@ -22284,6 +22292,84 @@ kernel void decode_attention_reference(
             assert_eq!(
                 second.output.token_ids, reference_out.token_ids,
                 "after an interleaved raw forward_step call, output must still match full re-prefill"
+            );
+        }
+
+        /// #516 round-3 remediation: `set_gdn_chunked` swaps the GDN prefill
+        /// algorithm, and the two scans are not bit-exact (measured logit
+        /// drift up to ~2e-1 at chunk boundaries). A cache entry saved under
+        /// one mode must not seed a restore whose full-refill reference would
+        /// use the other mode. Flipping the mode must evict the retained
+        /// entry; a no-op set must NOT (so benchmarks re-asserting the current
+        /// mode keep their cache).
+        #[test]
+        fn cross_turn_cache_invalidated_by_gdn_mode_flip() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let gen_cfg = cross_turn_test_gen_cfg(13, 2);
+
+            let first = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("cache-aware first turn must succeed");
+            let mut conversation = "ab".to_string();
+            conversation.push_str(&first.output.text);
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_some(),
+                "precondition: the first cache-aware call must actually retain an entry"
+            );
+
+            // Re-asserting the CURRENT mode is a no-op and must keep the entry.
+            let current_mode = state.use_gdn_chunked;
+            state.set_gdn_chunked(current_mode);
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_some(),
+                "setting the already-active GDN mode must not evict the cache entry"
+            );
+
+            // Flipping the mode must evict it outright.
+            state.set_gdn_chunked(!current_mode);
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_none(),
+                "flipping the GDN prefill mode must clear the retained cross-turn entry"
+            );
+
+            // Strict-append continuation: if the entry had survived the flip,
+            // this shape would satisfy the ExactAppend guards, so the
+            // assertions below genuinely exercise the mode-flip eviction.
+            let mut appended = conversation.clone();
+            appended.push('q');
+            let second = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    &appended,
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("cache-aware second turn must succeed");
+            assert_eq!(
+                second.cache.reused_tokens, 0,
+                "a GDN mode flip must force a full refill, not a cross-mode restore"
+            );
+            assert_ne!(
+                second.cache.mode,
+                crate::kv_cache::PrefixReuseMode::ExactAppend,
+                "an entry saved under the other GDN prefill mode must never be restored via ExactAppend"
             );
         }
     }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -21532,6 +21532,239 @@ kernel void decode_attention_reference(
             let result = quantize_row_q8_0(&vals);
             assert!(result.is_err(), "+inf in Q8_0 weight block must return Err");
         }
+
+        // ---------------------------------------------------------------------
+        // Cross-turn KV prefix cache (#462): Metal integration tests.
+        //
+        // `single_char_vocab_tokenizer` gives a 32-token, merge-free vocab
+        // (one token per ASCII letter) so growing a conversation by string
+        // concatenation is guaranteed to grow the token sequence by an exact
+        // append — no re-tokenization boundary can shift earlier tokens,
+        // which keeps these tests focused on the cache logic itself rather
+        // than on tokenizer edge cases.
+        // ---------------------------------------------------------------------
+
+        fn cross_turn_test_gen_cfg(seed: u64, max_new_tokens: usize) -> GenerateConfig {
+            GenerateConfig {
+                max_new_tokens,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(seed),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+            }
+        }
+
+        /// The correctness gate for #462: a growing multi-turn conversation run
+        /// through `generate_streaming_with_prefix_cache` on one long-lived state
+        /// must produce byte-identical token IDs, turn by turn, to running each
+        /// turn's full accumulated prompt through plain `generate_streaming` on a
+        /// fresh state (i.e. the pre-#462 "re-prefill everything every turn"
+        /// behavior). If cross-turn KV/GDN reuse ever perturbs a single sampled
+        /// token, this test goes red.
+        #[test]
+        fn cross_turn_cache_multiturn_token_identity_matches_full_reprefill() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            // Keep EOS unreachable so every turn generates its full budget,
+            // guaranteeing the conversation keeps growing turn over turn.
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut cached_state =
+                MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+
+            let user_turns = ["a", "bc", "d", "ef", "g"];
+            let mut conversation = String::new();
+            let mut saw_exact_append = false;
+
+            for (turn_idx, user_text) in user_turns.iter().enumerate() {
+                conversation.push_str(user_text);
+                let gen_cfg = cross_turn_test_gen_cfg(42, 3);
+
+                let mut cached_delta_calls = 0u32;
+                let cached_out = cached_state
+                    .generate_streaming_with_prefix_cache(
+                        slot_id,
+                        &conversation,
+                        &tokenizer,
+                        &gen_cfg,
+                        |_delta, _id| {
+                            cached_delta_calls += 1;
+                            true
+                        },
+                    )
+                    .expect("cache-aware generation must not error on a valid conversation");
+
+                // Independent, from-scratch reference: a brand new state, full
+                // re-prefill of the entire accumulated conversation so far —
+                // exactly the behavior cross-turn reuse must reproduce.
+                let mut reference_state =
+                    MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+                let reference_gen_cfg = cross_turn_test_gen_cfg(42, 3);
+                let reference_out = reference_state.generate_streaming(
+                    &conversation,
+                    &tokenizer,
+                    &reference_gen_cfg,
+                    |_delta, _id| true,
+                );
+
+                assert_eq!(
+                    cached_out.output.token_ids, reference_out.token_ids,
+                    "turn {turn_idx}: cache-aware token IDs must match full re-prefill \
+                     exactly (conversation so far: {conversation:?})"
+                );
+                assert_eq!(
+                    cached_out.output.text, reference_out.text,
+                    "turn {turn_idx}: cache-aware decoded text must match full re-prefill"
+                );
+                assert_eq!(
+                    cached_out.output.stop_reason, reference_out.stop_reason,
+                    "turn {turn_idx}: stop reason must match full re-prefill"
+                );
+
+                if matches!(
+                    cached_out.cache.mode,
+                    crate::kv_cache::PrefixReuseMode::ExactAppend
+                ) {
+                    saw_exact_append = true;
+                    assert!(
+                        cached_out.cache.reused_tokens > 0,
+                        "turn {turn_idx}: ExactAppend must report a nonzero reused prefix"
+                    );
+                }
+
+                // Grow the conversation with the (validated-identical) reply so
+                // the next turn's prompt is a real append onto this one.
+                conversation.push_str(&cached_out.output.text);
+            }
+
+            assert!(
+                saw_exact_append,
+                "at least one later turn must actually exercise ExactAppend reuse — \
+                 otherwise this test only proves the FullRefill fallback path works"
+            );
+        }
+
+        /// Prefix-mismatch invalidation: when the new prompt does not share the
+        /// cached entry's history at all, the planner must fall back to
+        /// `FullRefill` (never attempt to graft an unrelated suffix onto stale
+        /// KV/GDN state), and the output must still be correct.
+        #[test]
+        fn cross_turn_cache_prefix_mismatch_falls_back_to_full_refill() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let gen_cfg = cross_turn_test_gen_cfg(7, 2);
+
+            let first = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "abc",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("first turn must succeed");
+            assert_eq!(
+                first.cache.mode,
+                crate::kv_cache::PrefixReuseMode::FullRefill,
+                "an empty cache must always plan FullRefill"
+            );
+
+            // Completely different conversation: zero shared token prefix
+            // with the cached entry from "abc".
+            let second = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "xyz",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("divergent-prefix turn must still succeed");
+            assert_eq!(
+                second.cache.mode,
+                crate::kv_cache::PrefixReuseMode::FullRefill,
+                "a prompt sharing no prefix with the cached entry must invalidate to FullRefill"
+            );
+
+            let mut reference_state =
+                MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let reference_out =
+                reference_state.generate_streaming("xyz", &tokenizer, &gen_cfg, |_, _| true);
+            assert_eq!(
+                second.output.token_ids, reference_out.token_ids,
+                "after a prefix-mismatch invalidation, output must still match full re-prefill"
+            );
+        }
+
+        /// `clear_cross_turn_prefix_cache` must force the next call to plan
+        /// `FullRefill` even when the new prompt would otherwise be a valid
+        /// `ExactAppend` continuation of the (now-cleared) entry.
+        #[test]
+        fn cross_turn_cache_clear_forces_full_refill_next_call() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let gen_cfg = cross_turn_test_gen_cfg(3, 2);
+
+            let first = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("first turn must succeed");
+            let mut conversation = "ab".to_string();
+            conversation.push_str(&first.output.text);
+
+            state.clear_cross_turn_prefix_cache();
+
+            let second = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    &conversation,
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                )
+                .expect("second turn after clear must succeed");
+            assert_eq!(
+                second.cache.mode,
+                crate::kv_cache::PrefixReuseMode::FullRefill,
+                "a cleared cache slot must never be treated as a valid cached entry"
+            );
+        }
     }
     // -----------------------------------------------------------------------
     // Blend correctness tests (inference-side LoraLayerData types)

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -4526,6 +4526,77 @@ kernel void gdn_chunk_norm_silu_c32(
         /// reads are a small fraction of decode bandwidth). Set `LATTICE_KV_F16=1`
         /// or `LATTICE_KV_F16=true` at construction time to enable.
         pub(crate) use_kv_f16: bool,
+        /// Cross-turn KV/GDN prefix cache (#462). Worker-local: never shared
+        /// across threads or processes. Empty by default; only populated by
+        /// the `*_with_prefix_cache` entry points.
+        cross_turn_prefix_cache: MetalCrossTurnPrefixCache,
+    }
+
+    // ---------------------------------------------------------------------------
+    // Cross-turn KV prefix cache (#462)
+    // ---------------------------------------------------------------------------
+
+    /// Per-call statistics for a cache-aware generate/chat call.
+    #[derive(Debug, Clone)]
+    pub struct CrossTurnCacheStats {
+        pub slot_id: crate::kv_cache::CrossTurnSlotId,
+        pub prompt_tokens: usize,
+        pub reused_tokens: usize,
+        pub prefetched_tokens: usize,
+        pub mode: crate::kv_cache::PrefixReuseMode,
+    }
+
+    /// [`GenerateOutput`] plus cross-turn cache stats for the call that produced it.
+    #[derive(Debug, Clone)]
+    pub struct CachedGenerateOutput {
+        pub output: GenerateOutput,
+        pub cache: CrossTurnCacheStats,
+    }
+
+    /// [`ChatCompletionOutput`] plus cross-turn cache stats for the call that produced it.
+    #[derive(Debug, Clone)]
+    pub struct CachedChatCompletionOutput {
+        pub output: ChatCompletionOutput,
+        pub cache: CrossTurnCacheStats,
+    }
+
+    /// One retained cross-turn entry: the generic (Metal-agnostic) planning
+    /// record plus the exact GDN recurrent-state snapshot taken at the same
+    /// token boundary. The live full-attention KV buffers are NOT copied here
+    /// — they stay in `self.session.kv_cache` and are only logically
+    /// truncated/advanced (see `restore_cross_turn_prefix`).
+    #[derive(Debug, Clone)]
+    struct MetalCrossTurnPrefixEntry {
+        generic: crate::kv_cache::CrossTurnPrefixEntry,
+        gdn_snapshot: crate::attention::gdn::GdnSnapshot,
+    }
+
+    /// Worker-local map of cache slot to retained cross-turn prefix.
+    #[derive(Debug, Default)]
+    struct MetalCrossTurnPrefixCache {
+        entries:
+            std::collections::HashMap<crate::kv_cache::CrossTurnSlotId, MetalCrossTurnPrefixEntry>,
+    }
+
+    impl MetalCrossTurnPrefixCache {
+        fn get(
+            &self,
+            slot_id: crate::kv_cache::CrossTurnSlotId,
+        ) -> Option<&MetalCrossTurnPrefixEntry> {
+            self.entries.get(&slot_id)
+        }
+
+        fn insert(&mut self, entry: MetalCrossTurnPrefixEntry) {
+            self.entries.insert(entry.generic.slot_id, entry);
+        }
+
+        fn remove(&mut self, slot_id: crate::kv_cache::CrossTurnSlotId) {
+            self.entries.remove(&slot_id);
+        }
+
+        fn clear(&mut self) {
+            self.entries.clear();
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -5869,6 +5940,7 @@ kernel void gdn_chunk_norm_silu_c32(
                 lora: None,
                 use_gdn_chunked,
                 use_kv_f16,
+                cross_turn_prefix_cache: MetalCrossTurnPrefixCache::default(),
             })
         }
 
@@ -15073,6 +15145,7 @@ kernel void gdn_chunk_norm_silu_c32(
                     Ok("0") | Ok("false")
                 ),
                 use_kv_f16,
+                cross_turn_prefix_cache: MetalCrossTurnPrefixCache::default(),
             })
         }
 
@@ -15290,6 +15363,779 @@ kernel void gdn_chunk_norm_silu_c32(
                     self.session.gdn_states[i].restore_from(&(s_snap.clone(), conv_snap.clone()));
                 }
             }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-turn KV prefix cache: Metal-specific runtime (#462)
+    // -----------------------------------------------------------------------
+
+    impl MetalQwen35State {
+        /// Drop all retained cross-turn cache slots. Call this after any
+        /// error surfaces from a `*_with_prefix_cache` entry point (or from
+        /// the caller's own error handling) so a later turn cannot restore
+        /// from state that may no longer match the live KV/GDN buffers.
+        pub fn clear_cross_turn_prefix_cache(&mut self) {
+            self.cross_turn_prefix_cache.clear();
+        }
+
+        /// Everything that invalidates cross-turn reuse if it changes
+        /// between calls: model identity, tokenizer, adapter, RoPE/KV
+        /// layout, and chat template. Coarse-grained on purpose — a false
+        /// invalidation only costs a full re-prefill, never wrong output.
+        fn cross_turn_metadata(
+            &self,
+            tokenizer: &BpeTokenizer,
+        ) -> crate::kv_cache::CrossTurnPrefixMetadata {
+            use rustc_hash::FxHasher;
+            use std::hash::{Hash, Hasher};
+
+            let cfg = &self.engine.config;
+
+            let mut layer_hasher = FxHasher::default();
+            for lt in &cfg.layer_types {
+                (*lt as u8).hash(&mut layer_hasher);
+            }
+            let layer_pattern_hash = layer_hasher.finish();
+
+            let mut model_hasher = FxHasher::default();
+            cfg.hidden_size.hash(&mut model_hasher);
+            cfg.num_hidden_layers.hash(&mut model_hasher);
+            cfg.vocab_size.hash(&mut model_hasher);
+            cfg.rope_theta.to_bits().hash(&mut model_hasher);
+            cfg.mtp_num_hidden_layers.hash(&mut model_hasher);
+            layer_pattern_hash.hash(&mut model_hasher);
+            let model_fingerprint = model_hasher.finish();
+
+            let mut tok_hasher = FxHasher::default();
+            tokenizer.vocab_size().hash(&mut tok_hasher);
+            tokenizer
+                .special_token_id("<|im_end|>")
+                .hash(&mut tok_hasher);
+            tokenizer.special_token_id("</think>").hash(&mut tok_hasher);
+            let tokenizer_fingerprint = tok_hasher.finish();
+
+            let adapter_id = match &self.lora {
+                None => crate::kv_cache::AdapterId::BASE,
+                Some(adapter) => {
+                    let mut h = FxHasher::default();
+                    adapter.max_rank.hash(&mut h);
+                    adapter.scale.to_bits().hash(&mut h);
+                    adapter.projections.len().hash(&mut h);
+                    crate::kv_cache::AdapterId::new(h.finish())
+                }
+            };
+
+            crate::kv_cache::CrossTurnPrefixMetadata {
+                model_fingerprint,
+                tokenizer_fingerprint,
+                adapter_id,
+                vocab_size: cfg.vocab_size,
+                max_cache_len: self.session.kv_cache.max_cache_len,
+                kv_f16: self.use_kv_f16,
+                rope_theta_bits: cfg.rope_theta.to_bits(),
+                partial_rotary_factor_bits: Some(cfg.partial_rotary_factor.to_bits()),
+                layer_pattern_hash,
+                chat_template_version: 1,
+            }
+        }
+
+        /// Pure planning step: delegates to [`crate::kv_cache::plan_prefix_reuse`]
+        /// against whatever is currently cached for `slot_id`. v1 never owns
+        /// sparse GDN checkpoints, so it always plans with an empty checkpoint
+        /// set — `PrefixReuseMode::ReplayFromCheckpoint` is therefore never
+        /// produced by this call.
+        fn plan_cross_turn_reuse(
+            &self,
+            slot_id: crate::kv_cache::CrossTurnSlotId,
+            metadata: &crate::kv_cache::CrossTurnPrefixMetadata,
+            prompt_ids: &[u32],
+        ) -> crate::kv_cache::PrefixRestorePlan {
+            let entry = self
+                .cross_turn_prefix_cache
+                .get(slot_id)
+                .map(|e| &e.generic);
+            crate::kv_cache::plan_prefix_reuse(entry, metadata, prompt_ids, &[])
+        }
+
+        /// Restore live state to the plan's reusable boundary. Only
+        /// `ExactAppend` is implemented; `FullRefill` is handled by the
+        /// caller (`self.reset_state()`) per design.md step 5, and
+        /// `ReplayFromCheckpoint` fails closed since v1 owns no checkpoints.
+        fn restore_cross_turn_prefix(
+            &mut self,
+            slot_id: crate::kv_cache::CrossTurnSlotId,
+            plan: &crate::kv_cache::PrefixRestorePlan,
+        ) -> Result<(), crate::error::InferenceError> {
+            use crate::error::InferenceError;
+            use crate::kv_cache::PrefixReuseMode;
+
+            match plan.mode {
+                PrefixReuseMode::ExactAppend => {
+                    let snapshot = self
+                        .cross_turn_prefix_cache
+                        .get(slot_id)
+                        .ok_or_else(|| {
+                            InferenceError::PrefixCache(
+                                "restore_cross_turn_prefix: ExactAppend plan but no cached entry \
+                                 for this slot"
+                                    .into(),
+                            )
+                        })?
+                        .gdn_snapshot
+                        .clone();
+                    self.restore_gdn_states_checked(&snapshot)?;
+                    self.session.set_position(plan.reusable_len);
+                    Ok(())
+                }
+                PrefixReuseMode::ReplayFromCheckpoint { .. } => Err(InferenceError::PrefixCache(
+                    "restore_cross_turn_prefix: sparse GDN checkpoint replay is not implemented \
+                     in v1"
+                        .into(),
+                )),
+                PrefixReuseMode::FullRefill => {
+                    self.reset_state();
+                    Ok(())
+                }
+            }
+        }
+
+        /// Prefill `token_ids` starting at absolute position `start_pos`,
+        /// writing KV/RoPE rows and advancing GDN state from that position —
+        /// the suffix-prefill primitive the design requires. Unlike
+        /// `forward_prefill`/`forward_prefill_impl` (which always start at
+        /// position 0, including their `len == 1` fast path), every branch
+        /// here honors `start_pos`, so a single reused-prefix token forwards
+        /// at its true absolute position.
+        fn forward_prefill_from(
+            &mut self,
+            token_ids: &[u32],
+            start_pos: usize,
+            all_positions: bool,
+        ) -> Result<Vec<f32>, crate::error::InferenceError> {
+            use crate::error::InferenceError;
+
+            let vocab = self.engine.config.vocab_size;
+            for (t, &id) in token_ids.iter().enumerate() {
+                if (id as usize) >= vocab {
+                    return Err(InferenceError::InvalidInput(format!(
+                        "forward_prefill_from: token_ids[{t}]={id} out of range: vocab_size is {vocab}"
+                    )));
+                }
+            }
+            if token_ids.is_empty() {
+                return Err(InferenceError::PrefixCache(
+                    "forward_prefill_from: cannot prefill an empty suffix without a saved \
+                     logits source"
+                        .into(),
+                ));
+            }
+            if start_pos + token_ids.len() > self.session.kv_cache.max_cache_len {
+                return Err(InferenceError::InvalidInput(format!(
+                    "forward_prefill_from: start_pos {start_pos} + len {} exceeds max_cache_len {}",
+                    token_ids.len(),
+                    self.session.kv_cache.max_cache_len
+                )));
+            }
+            if token_ids.len() == 1 {
+                return Ok(self.forward_step(token_ids[0], start_pos));
+            }
+            if self.lora.is_some() {
+                if all_positions {
+                    return Err(InferenceError::PrefixCache(
+                        "forward_prefill_from: all-position output is not supported with an \
+                         active LoRA adapter"
+                            .into(),
+                    ));
+                }
+                let mut last_logits = Vec::new();
+                for (i, &id) in token_ids.iter().enumerate() {
+                    last_logits = self.forward_step(id, start_pos + i);
+                }
+                return Ok(last_logits);
+            }
+            let max_prefill = self.session.max_prefill;
+            if token_ids.len() <= max_prefill {
+                return Ok(self.forward_prefill_batched_chunk(token_ids, start_pos, all_positions));
+            }
+            if all_positions {
+                let mut all_logits = Vec::with_capacity(token_ids.len() * vocab);
+                let mut pos = start_pos;
+                for chunk in token_ids.chunks(max_prefill) {
+                    all_logits.extend(self.forward_prefill_batched_chunk(chunk, pos, true));
+                    pos += chunk.len();
+                }
+                Ok(all_logits)
+            } else {
+                let mut last_logits = Vec::new();
+                let mut pos = start_pos;
+                for chunk in token_ids.chunks(max_prefill) {
+                    last_logits = self.forward_prefill_batched_chunk(chunk, pos, false);
+                    pos += chunk.len();
+                }
+                Ok(last_logits)
+            }
+        }
+
+        /// Save `represented_token_ids` as the new cross-turn entry for
+        /// `slot_id`. Requires that live KV state already represents exactly
+        /// those tokens (`kv_cache.seq_len == represented_token_ids.len()`) —
+        /// callers must prefill/restore before saving, never after a partial
+        /// or speculative step.
+        fn save_cross_turn_prefix(
+            &mut self,
+            slot_id: crate::kv_cache::CrossTurnSlotId,
+            metadata: crate::kv_cache::CrossTurnPrefixMetadata,
+            represented_token_ids: Vec<u32>,
+        ) -> Result<(), crate::error::InferenceError> {
+            use crate::error::InferenceError;
+
+            let represented_len = represented_token_ids.len();
+            if represented_len != self.session.kv_cache.seq_len {
+                return Err(InferenceError::PrefixCache(format!(
+                    "save_cross_turn_prefix: represented_len {represented_len} != kv seq_len {}",
+                    self.session.kv_cache.seq_len
+                )));
+            }
+            let gdn_snapshot = self.snapshot_gdn_states_checked()?;
+            let kv = crate::kv_cache::KvPrefixHandle {
+                represented_len,
+                num_full_attention_layers: self.session.kv_cache.k_bufs.len(),
+                kv_dim: self.session.kv_cache.kv_dim,
+                max_cache_len: self.session.kv_cache.max_cache_len,
+                kv_f16: self.use_kv_f16,
+            };
+            let generic = crate::kv_cache::CrossTurnPrefixEntry {
+                slot_id,
+                metadata,
+                token_ids: represented_token_ids,
+                represented_len,
+                kv,
+                gdn_snapshot_len: represented_len,
+            };
+            self.cross_turn_prefix_cache
+                .insert(MetalCrossTurnPrefixEntry {
+                    generic,
+                    gdn_snapshot,
+                });
+            Ok(())
+        }
+
+        /// Best-effort cache save: a bookkeeping failure must not fail an
+        /// otherwise-successful generation. On failure the slot is cleared
+        /// rather than left holding a possibly-stale entry (fail-closed).
+        fn save_cross_turn_prefix_or_clear(
+            &mut self,
+            slot_id: crate::kv_cache::CrossTurnSlotId,
+            metadata: crate::kv_cache::CrossTurnPrefixMetadata,
+            represented_token_ids: Vec<u32>,
+        ) {
+            if self
+                .save_cross_turn_prefix(slot_id, metadata, represented_token_ids)
+                .is_err()
+            {
+                self.cross_turn_prefix_cache.remove(slot_id);
+            }
+        }
+
+        /// [`Self::snapshot_gdn_states`] has no failure mode today, but is
+        /// wrapped in `Result` so cache callers have one fallible surface to
+        /// widen behind if that ever changes.
+        fn snapshot_gdn_states_checked(
+            &self,
+        ) -> Result<crate::attention::gdn::GdnSnapshot, crate::error::InferenceError> {
+            use crate::speculative::MtpTargetVerifier;
+            Ok(self.snapshot_gdn_states())
+        }
+
+        /// Shape-checked wrapper around [`Self::restore_gdn_states`]. The
+        /// underlying restore only asserts shapes in debug builds
+        /// (`debug_assert_eq!`); this validates explicitly in all builds and
+        /// returns `InferenceError::PrefixCache` instead of restoring
+        /// mismatched buffers or panicking.
+        fn restore_gdn_states_checked(
+            &mut self,
+            snapshot: &crate::attention::gdn::GdnSnapshot,
+        ) -> Result<(), crate::error::InferenceError> {
+            use crate::error::InferenceError;
+            use crate::speculative::MtpTargetVerifier;
+
+            let num_layers = self.session.gdn_gpu_conv_bufs.len();
+            if snapshot.len() != num_layers {
+                return Err(InferenceError::PrefixCache(format!(
+                    "restore_gdn_states_checked: snapshot has {} layers, expected {num_layers}",
+                    snapshot.len()
+                )));
+            }
+            for (i, (s_snap, conv_snap)) in snapshot.iter().enumerate() {
+                let conv_buf = &self.session.gdn_gpu_conv_bufs[i];
+                let s_buf = &self.session.gdn_gpu_s_matrices[i];
+                let conv_floats = (conv_buf.length() / 4) as usize;
+                let s_floats = (s_buf.length() / 4) as usize;
+                if conv_snap.len() != conv_floats || s_snap.len() != s_floats {
+                    return Err(InferenceError::PrefixCache(format!(
+                        "restore_gdn_states_checked: layer {i} shape mismatch: conv {} != \
+                         {conv_floats} or s {} != {s_floats}",
+                        conv_snap.len(),
+                        s_snap.len()
+                    )));
+                }
+            }
+            self.restore_gdn_states(snapshot);
+            Ok(())
+        }
+
+        /// Cache-aware sibling of [`Self::generate_streaming`].
+        ///
+        /// Detects the longest shared token prefix between `slot_id`'s
+        /// cached entry and this prompt; when it is an exact, fully
+        /// represented append-only prefix (`PrefixReuseMode::ExactAppend`),
+        /// restores the GDN snapshot, sets the logical position, and
+        /// prefills only the divergent suffix via `forward_prefill_from`.
+        /// Otherwise falls back to `reset_state` + full prefill — byte-for-
+        /// byte the same path `generate_streaming` takes, so the decode loop
+        /// below is identical in both cases and produces the same generated
+        /// token IDs as the non-cached path for the same conversation
+        /// (token-identity invariant; see design.md).
+        ///
+        /// `generate_streaming` and `chat_completion_streaming` are left
+        /// untouched and never use this cache, so their behavior stays
+        /// deterministic and unaffected by any cache state.
+        pub fn generate_streaming_with_prefix_cache<F>(
+            &mut self,
+            slot_id: crate::kv_cache::CrossTurnSlotId,
+            prompt: &str,
+            tokenizer: &BpeTokenizer,
+            gen_cfg: &GenerateConfig,
+            on_token: F,
+        ) -> Result<CachedGenerateOutput, crate::error::InferenceError>
+        where
+            F: FnMut(&str, u32) -> bool,
+        {
+            match self.generate_streaming_with_prefix_cache_inner(
+                slot_id, prompt, tokenizer, gen_cfg, on_token,
+            ) {
+                Ok(out) => Ok(out),
+                Err(e) => {
+                    // Fail-closed: state and cache may disagree after a
+                    // restore/prefill/save error, so drop both rather than
+                    // risk a later turn reusing an inconsistent boundary.
+                    self.reset_state();
+                    self.cross_turn_prefix_cache.remove(slot_id);
+                    Err(e)
+                }
+            }
+        }
+
+        fn generate_streaming_with_prefix_cache_inner<F>(
+            &mut self,
+            slot_id: crate::kv_cache::CrossTurnSlotId,
+            prompt: &str,
+            tokenizer: &BpeTokenizer,
+            gen_cfg: &GenerateConfig,
+            mut on_token: F,
+        ) -> Result<CachedGenerateOutput, crate::error::InferenceError>
+        where
+            F: FnMut(&str, u32) -> bool,
+        {
+            use crate::kv_cache::PrefixReuseMode;
+
+            let cfg = self.engine.config.clone();
+
+            let mut rng_state = match gen_cfg.seed {
+                Some(s) => {
+                    if s == 0 {
+                        1
+                    } else {
+                        s
+                    }
+                }
+                None => {
+                    use std::time::SystemTime;
+                    let t = SystemTime::now()
+                        .duration_since(SystemTime::UNIX_EPOCH)
+                        .map(|d| d.as_nanos() as u64)
+                        .unwrap_or(0x12345678_9abcdef0);
+                    if t == 0 { 1 } else { t }
+                }
+            };
+
+            let input = tokenizer.tokenize(prompt);
+            let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
+            let prompt_len = prompt_ids.len();
+
+            // These three guards are byte-for-byte the same as
+            // `generate_streaming` and run before any state mutation, so an
+            // existing cache entry (if any) is left exactly as-is.
+            if prompt_len == 0 {
+                return Ok(CachedGenerateOutput {
+                    output: GenerateOutput {
+                        text: String::new(),
+                        token_ids: vec![],
+                        prompt_tokens: 0,
+                        generated_tokens: 0,
+                        stopped: false,
+                        stop_reason: None,
+                    },
+                    cache: CrossTurnCacheStats {
+                        slot_id,
+                        prompt_tokens: 0,
+                        reused_tokens: 0,
+                        prefetched_tokens: 0,
+                        mode: PrefixReuseMode::FullRefill,
+                    },
+                });
+            }
+            if gen_cfg.max_new_tokens == 0 {
+                return Ok(CachedGenerateOutput {
+                    output: GenerateOutput {
+                        text: String::new(),
+                        token_ids: vec![],
+                        prompt_tokens: prompt_len,
+                        generated_tokens: 0,
+                        stopped: false,
+                        stop_reason: Some(StopReason::Length),
+                    },
+                    cache: CrossTurnCacheStats {
+                        slot_id,
+                        prompt_tokens: prompt_len,
+                        reused_tokens: 0,
+                        prefetched_tokens: 0,
+                        mode: PrefixReuseMode::FullRefill,
+                    },
+                });
+            }
+            if prompt_len > self.max_context() {
+                return Ok(CachedGenerateOutput {
+                    output: GenerateOutput {
+                        text: String::new(),
+                        token_ids: vec![],
+                        prompt_tokens: prompt_len,
+                        generated_tokens: 0,
+                        stopped: true,
+                        stop_reason: Some(StopReason::KvFull),
+                    },
+                    cache: CrossTurnCacheStats {
+                        slot_id,
+                        prompt_tokens: prompt_len,
+                        reused_tokens: 0,
+                        prefetched_tokens: 0,
+                        mode: PrefixReuseMode::FullRefill,
+                    },
+                });
+            }
+
+            let metadata = self.cross_turn_metadata(tokenizer);
+            let plan = self.plan_cross_turn_reuse(slot_id, &metadata, &prompt_ids);
+
+            match plan.mode {
+                PrefixReuseMode::ExactAppend | PrefixReuseMode::ReplayFromCheckpoint { .. } => {
+                    self.restore_cross_turn_prefix(slot_id, &plan)?;
+                }
+                PrefixReuseMode::FullRefill => self.reset_state(),
+            }
+
+            let mut generated_ids: Vec<u32> = Vec::with_capacity(gen_cfg.max_new_tokens);
+            let mut all_ids = prompt_ids.clone();
+
+            let route = choose_gpu_topk_route(
+                gen_cfg.top_k,
+                std::env::var("LATTICE_COMPACT_TOPK").is_ok(),
+                std::env::var("LATTICE_COMPACT_TOPK_SELECT").is_ok(),
+            );
+            let use_compact = route != GpuTopkRoute::CpuFallback
+                && (gen_cfg.repetition_penalty == 1.0 || all_ids.is_empty())
+                && gen_cfg.grammar.is_none();
+            self.session.compact_route = if use_compact {
+                route
+            } else {
+                GpuTopkRoute::CpuFallback
+            };
+            if use_compact {
+                self.session.compact_topk = gen_cfg.top_k;
+            }
+
+            let mut grammar_state = gen_cfg.grammar.as_ref().map(|g| g.initial_state());
+
+            let think_close_id = if gen_cfg.reasoning_budget.is_some() {
+                tokenizer.special_token_id("</think>")
+            } else {
+                None
+            };
+            let mut thinking_closed = false;
+
+            // The one line that differs structurally from `generate_streaming`:
+            // prefill only the divergent suffix, at its true absolute position.
+            let suffix = &prompt_ids[plan.suffix_start..];
+            let mut prefill_logits = self.forward_prefill_from(suffix, plan.suffix_start, false)?;
+
+            if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                engine.mask_logits(gs, &mut prefill_logits);
+            }
+
+            let next_id = if use_compact {
+                sample_from_candidates(
+                    &self.session.compact_result,
+                    gen_cfg,
+                    &all_ids,
+                    &mut rng_state,
+                )
+            } else {
+                sample_token(&prefill_logits, gen_cfg, &all_ids, &mut rng_state)
+            };
+
+            let cache_stats = |mode, reused, prefetched| CrossTurnCacheStats {
+                slot_id,
+                prompt_tokens: prompt_len,
+                reused_tokens: reused,
+                prefetched_tokens: prefetched,
+                mode,
+            };
+
+            if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                if !engine.advance(gs, next_id) {
+                    let text = decode_tokens(tokenizer, &generated_ids);
+                    self.save_cross_turn_prefix_or_clear(
+                        slot_id,
+                        metadata.clone(),
+                        prompt_ids.clone(),
+                    );
+                    return Ok(CachedGenerateOutput {
+                        output: GenerateOutput {
+                            text,
+                            token_ids: generated_ids.clone(),
+                            prompt_tokens: prompt_len,
+                            generated_tokens: generated_ids.len(),
+                            stopped: false,
+                            stop_reason: Some(StopReason::Grammar),
+                        },
+                        cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
+                    });
+                }
+            }
+
+            let is_stop = |id: u32| -> bool {
+                id == cfg.eos_token_id || gen_cfg.stop_token_ids.contains(&id)
+            };
+
+            if is_stop(next_id) {
+                if use_compact {
+                    self.session.compact_topk = 0;
+                    self.session.compact_route = GpuTopkRoute::CpuFallback;
+                }
+                self.save_cross_turn_prefix_or_clear(slot_id, metadata.clone(), prompt_ids.clone());
+                return Ok(CachedGenerateOutput {
+                    output: GenerateOutput {
+                        text: String::new(),
+                        token_ids: vec![],
+                        prompt_tokens: prompt_len,
+                        generated_tokens: 0,
+                        stopped: true,
+                        stop_reason: Some(StopReason::Eos),
+                    },
+                    cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
+                });
+            }
+
+            if Some(next_id) == think_close_id {
+                thinking_closed = true;
+            }
+
+            let mut detok = IncrementalDetokenizer::new();
+            let mut reasoning_end_len: Option<usize> = None;
+            generated_ids.push(next_id);
+            all_ids.push(next_id);
+            if thinking_closed && reasoning_end_len.is_none() {
+                reasoning_end_len = Some(generated_ids.len());
+            }
+            let mut last_pushed_id = next_id;
+            let delta = detok.push(tokenizer, next_id);
+            if !delta.is_empty() && !on_token(&delta, next_id) {
+                if use_compact {
+                    self.session.compact_topk = 0;
+                    self.session.compact_route = GpuTopkRoute::CpuFallback;
+                }
+                // The caller cut the stream after exactly one forwarded
+                // token (the prefill sample) — state represents prompt +
+                // that one token already (forward happens on the *next*
+                // iteration in the loop below, which never runs here).
+                // Nothing further was forwarded, so do not save a cache
+                // entry claiming more than live state represents.
+                return Ok(CachedGenerateOutput {
+                    output: GenerateOutput {
+                        text: detok.text(),
+                        token_ids: generated_ids.clone(),
+                        prompt_tokens: prompt_len,
+                        generated_tokens: generated_ids.len(),
+                        stopped: false,
+                        stop_reason: Some(StopReason::Interrupt),
+                    },
+                    cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
+                });
+            }
+            let mut stopped = false;
+            let mut stopped_by_caller = false;
+            let mut stop_reason = StopReason::Length;
+
+            let cap = decode_cap(gen_cfg.reasoning_budget, gen_cfg.max_new_tokens);
+            for _ in 1..cap {
+                if self.session.kv_cache.seq_len >= self.session.kv_cache.max_cache_len {
+                    stop_reason = StopReason::KvFull;
+                    break;
+                }
+                let pos = self.session.kv_cache.seq_len;
+                let last_token = *all_ids
+                    .last()
+                    .expect("invariant: prompt or previous sample populated all_ids");
+                let mut step_logits = self.forward_step(last_token, pos);
+
+                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                    engine.mask_logits(gs, &mut step_logits);
+                }
+
+                let sampled_id = if use_compact {
+                    sample_from_candidates(
+                        &self.session.compact_result,
+                        gen_cfg,
+                        &all_ids,
+                        &mut rng_state,
+                    )
+                } else {
+                    sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
+                };
+
+                let next_id = force_close_think(
+                    gen_cfg.reasoning_budget,
+                    gen_cfg.enable_thinking,
+                    thinking_closed,
+                    generated_ids.len(),
+                    think_close_id,
+                )
+                .unwrap_or(sampled_id);
+
+                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                    if !engine.advance(gs, next_id) {
+                        stop_reason = StopReason::Grammar;
+                        break;
+                    }
+                }
+
+                if Some(next_id) == think_close_id {
+                    thinking_closed = true;
+                }
+
+                if is_stop(next_id) {
+                    stopped = true;
+                    stop_reason = StopReason::Eos;
+                    break;
+                }
+
+                generated_ids.push(next_id);
+                all_ids.push(next_id);
+                if thinking_closed && reasoning_end_len.is_none() {
+                    reasoning_end_len = Some(generated_ids.len());
+                }
+                last_pushed_id = next_id;
+                let delta = detok.push(tokenizer, next_id);
+                if !delta.is_empty() && !on_token(&delta, next_id) {
+                    stopped_by_caller = true;
+                    stop_reason = StopReason::Interrupt;
+                    break;
+                }
+                if self.session.kv_cache.seq_len >= self.session.kv_cache.max_cache_len {
+                    stop_reason = StopReason::KvFull;
+                    break;
+                }
+                if let Some(end) = reasoning_end_len {
+                    if generated_ids.len().saturating_sub(end) >= gen_cfg.max_new_tokens {
+                        break;
+                    }
+                }
+            }
+
+            if use_compact {
+                self.session.compact_topk = 0;
+                self.session.compact_route = GpuTopkRoute::CpuFallback;
+            }
+
+            // Every exit above leaves the last *pushed* generated token
+            // un-forwarded EXCEPT the `is_stop` break, where the stop token
+            // itself was never pushed and every element of `generated_ids`
+            // was already forwarded by the following iteration's
+            // `forward_step` call. Run one silent step so the next turn can
+            // reuse through the full assistant output (design.md step 8,
+            // "Better v1"). This must not sample or emit anything.
+            if !generated_ids.is_empty() && !stopped {
+                let seq_len = self.session.kv_cache.seq_len;
+                if seq_len < self.session.kv_cache.max_cache_len {
+                    let _ = self.forward_step(last_pushed_id, seq_len);
+                }
+                // else: KV is already full; the cache boundary stays one
+                // token short of `generated_ids` — still consistent, since
+                // KV/GDN and `represented_len` all agree at that boundary.
+            }
+
+            let represented_len = self.session.kv_cache.seq_len;
+            debug_assert!(represented_len >= prompt_len);
+            let generated_represented = represented_len - prompt_len;
+            let mut represented_token_ids = prompt_ids.clone();
+            represented_token_ids.extend_from_slice(&generated_ids[..generated_represented]);
+            self.save_cross_turn_prefix_or_clear(slot_id, metadata.clone(), represented_token_ids);
+
+            if !stopped_by_caller {
+                let tail = detok.finish();
+                if !tail.is_empty() {
+                    on_token(&tail, last_pushed_id);
+                }
+            }
+            let text = detok.text();
+            Ok(CachedGenerateOutput {
+                output: GenerateOutput {
+                    text,
+                    token_ids: generated_ids.clone(),
+                    prompt_tokens: prompt_len,
+                    generated_tokens: generated_ids.len(),
+                    stopped,
+                    stop_reason: Some(stop_reason),
+                },
+                cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
+            })
+        }
+
+        /// Cache-aware sibling of [`Self::chat_completion_streaming`]: same
+        /// ChatML formatting and `<|im_end|>` stop-token handling, routed
+        /// through [`Self::generate_streaming_with_prefix_cache`] instead of
+        /// `generate_streaming`.
+        pub fn chat_completion_streaming_with_prefix_cache<F>(
+            &mut self,
+            slot_id: crate::kv_cache::CrossTurnSlotId,
+            messages: &[ChatMessage],
+            tokenizer: &BpeTokenizer,
+            gen_cfg: &GenerateConfig,
+            on_token: F,
+        ) -> Result<CachedChatCompletionOutput, crate::error::InferenceError>
+        where
+            F: FnMut(&str, u32) -> bool,
+        {
+            let prompt = format_chat_template(messages);
+            let mut cfg = gen_cfg.clone();
+            if let Some(im_end_id) = tokenizer.special_token_id("<|im_end|>") {
+                if !cfg.stop_token_ids.contains(&im_end_id) {
+                    cfg.stop_token_ids.push(im_end_id);
+                }
+            }
+            let cached = self.generate_streaming_with_prefix_cache(
+                slot_id, &prompt, tokenizer, &cfg, on_token,
+            )?;
+            let text = cached.output.text.trim_end().to_string();
+            Ok(CachedChatCompletionOutput {
+                output: ChatCompletionOutput {
+                    message: ChatMessage::assistant(text),
+                    prompt_tokens: cached.output.prompt_tokens,
+                    completion_tokens: cached.output.generated_tokens,
+                },
+                cache: cached.cache,
+            })
         }
     }
 
@@ -16614,6 +17460,7 @@ kernel void decode_attention_reference(
                 lora: None,
                 use_gdn_chunked: true,
                 use_kv_f16: false,
+                cross_turn_prefix_cache: MetalCrossTurnPrefixCache::default(),
             }
         }
 
@@ -16812,6 +17659,7 @@ kernel void decode_attention_reference(
                 lora: None,
                 use_gdn_chunked: true,
                 use_kv_f16: false,
+                cross_turn_prefix_cache: MetalCrossTurnPrefixCache::default(),
             };
             let _logits = state_a.forward_step(42, 0);
             let _logits = state_a.forward_step(7, 1);

--- a/crates/inference/src/kv_cache/cross_turn.rs
+++ b/crates/inference/src/kv_cache/cross_turn.rs
@@ -1,0 +1,342 @@
+//! Cross-turn KV prefix cache planning (#462).
+//!
+//! Pure token-level planning for reusing a previous turn's KV/GDN state
+//! across chat turns. This module owns no GPU buffers and no live model
+//! state — it only decides, from token IDs and metadata, whether a cached
+//! prefix can be reused and where the new suffix begins. The Metal-specific
+//! runtime (live KV buffers, GDN snapshots) lives in
+//! `crate::forward::metal_qwen35`.
+//!
+//! See design.md step 4 (ADR: latest-boundary GDN snapshot + live KV logical
+//! reuse for v1). Reuse is only ever claimed for an exact token prefix that
+//! is already fully represented by retained state; any divergence falls
+//! back to `PrefixReuseMode::FullRefill`.
+
+use crate::kv_cache::AdapterId;
+
+/// Identifies one cross-turn cache slot. Distinct slots never share state,
+/// so distinct conversations (or clients) using distinct slot IDs cannot
+/// read one another's KV/GDN state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CrossTurnSlotId(pub u64);
+
+impl CrossTurnSlotId {
+    /// The single-client / local-use default slot.
+    pub const DEFAULT: Self = Self(0);
+
+    /// Build a slot ID from a caller-supplied value (e.g. a hashed session key).
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Everything that must match between the cached entry and the current
+/// request for reuse to be considered. Any field mismatch invalidates the
+/// entry — the cached KV/GDN state is not state-equivalent to a re-prefill
+/// under a different model, tokenizer, adapter, RoPE, or KV layout.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CrossTurnPrefixMetadata {
+    pub model_fingerprint: u64,
+    pub tokenizer_fingerprint: u64,
+    pub adapter_id: AdapterId,
+    pub vocab_size: usize,
+    pub max_cache_len: usize,
+    pub kv_f16: bool,
+    pub rope_theta_bits: u64,
+    pub partial_rotary_factor_bits: Option<u32>,
+    pub layer_pattern_hash: u64,
+    pub chat_template_version: u32,
+}
+
+/// Logical handle to the live full-attention KV buffers backing a cached
+/// prefix. Does not own the buffers — the Metal state keeps them in place
+/// and only truncates/advances the logical `seq_len`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KvPrefixHandle {
+    pub represented_len: usize,
+    pub num_full_attention_layers: usize,
+    pub kv_dim: usize,
+    pub max_cache_len: usize,
+    pub kv_f16: bool,
+}
+
+/// One retained cross-turn prefix: the exact tokens, and the length to
+/// which model state (KV + GDN) is known to represent them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrossTurnPrefixEntry {
+    pub slot_id: CrossTurnSlotId,
+    pub metadata: CrossTurnPrefixMetadata,
+    pub token_ids: Vec<u32>,
+    pub represented_len: usize,
+    pub kv: KvPrefixHandle,
+    pub gdn_snapshot_len: usize,
+}
+
+/// How the next turn should build on (or discard) the cached entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrefixReuseMode {
+    /// No usable overlap: reset state and prefill the whole prompt.
+    FullRefill,
+    /// The cached entry is an exact prefix of the new prompt and its GDN
+    /// snapshot is taken at that same boundary — reuse it verbatim.
+    ExactAppend,
+    /// Reuse only up to an earlier exact GDN checkpoint, then replay/prefill
+    /// forward. v2: no v1 caller currently supplies checkpoints, so this
+    /// variant is never produced by the current Metal integration.
+    ReplayFromCheckpoint { checkpoint_len: usize },
+}
+
+/// The result of planning: what to restore, and where the new suffix starts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrefixRestorePlan {
+    pub mode: PrefixReuseMode,
+    pub shared_token_prefix_len: usize,
+    pub reusable_len: usize,
+    pub suffix_start: usize,
+    pub suffix_len: usize,
+    pub old_represented_len: usize,
+}
+
+/// Length of the longest common prefix of two token ID slices.
+pub fn longest_common_token_prefix(a: &[u32], b: &[u32]) -> usize {
+    a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+}
+
+/// Decide how (or whether) to reuse `entry` for `new_prompt_ids`.
+///
+/// See the module-level rules: reuse is only claimed for an exact prefix
+/// match against fully represented state (`ExactAppend`), or against an
+/// exact earlier GDN checkpoint boundary present in `sparse_checkpoint_lens`
+/// (`ReplayFromCheckpoint`). Everything else falls back to `FullRefill` —
+/// decline-beats-fabricate for the token-identity invariant.
+pub fn plan_prefix_reuse(
+    entry: Option<&CrossTurnPrefixEntry>,
+    metadata: &CrossTurnPrefixMetadata,
+    new_prompt_ids: &[u32],
+    sparse_checkpoint_lens: &[usize],
+) -> PrefixRestorePlan {
+    let full_refill = |shared: usize, old_represented_len: usize| PrefixRestorePlan {
+        mode: PrefixReuseMode::FullRefill,
+        shared_token_prefix_len: shared,
+        reusable_len: 0,
+        suffix_start: 0,
+        suffix_len: new_prompt_ids.len(),
+        old_represented_len,
+    };
+
+    let Some(entry) = entry else {
+        return full_refill(0, 0);
+    };
+
+    if &entry.metadata != metadata || new_prompt_ids.is_empty() {
+        return full_refill(0, entry.represented_len);
+    }
+
+    let shared = longest_common_token_prefix(&entry.token_ids, new_prompt_ids);
+    if shared == 0 {
+        return full_refill(0, entry.represented_len);
+    }
+
+    if shared == entry.represented_len && entry.gdn_snapshot_len == entry.represented_len {
+        return PrefixRestorePlan {
+            mode: PrefixReuseMode::ExactAppend,
+            shared_token_prefix_len: shared,
+            reusable_len: shared,
+            suffix_start: shared,
+            suffix_len: new_prompt_ids.len() - shared,
+            old_represented_len: entry.represented_len,
+        };
+    }
+
+    // Mid-history reuse: only valid at an exact, already-owned checkpoint
+    // boundary at or below the shared prefix length.
+    if let Some(&checkpoint_len) = sparse_checkpoint_lens
+        .iter()
+        .filter(|&&len| len > 0 && len <= shared)
+        .max()
+    {
+        return PrefixRestorePlan {
+            mode: PrefixReuseMode::ReplayFromCheckpoint { checkpoint_len },
+            shared_token_prefix_len: shared,
+            reusable_len: checkpoint_len,
+            suffix_start: checkpoint_len,
+            suffix_len: new_prompt_ids.len() - checkpoint_len,
+            old_represented_len: entry.represented_len,
+        };
+    }
+
+    full_refill(shared, entry.represented_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata() -> CrossTurnPrefixMetadata {
+        CrossTurnPrefixMetadata {
+            model_fingerprint: 1,
+            tokenizer_fingerprint: 2,
+            adapter_id: AdapterId::BASE,
+            vocab_size: 1000,
+            max_cache_len: 4096,
+            kv_f16: false,
+            rope_theta_bits: 0,
+            partial_rotary_factor_bits: None,
+            layer_pattern_hash: 42,
+            chat_template_version: 1,
+        }
+    }
+
+    fn entry(
+        token_ids: Vec<u32>,
+        represented_len: usize,
+        gdn_snapshot_len: usize,
+    ) -> CrossTurnPrefixEntry {
+        CrossTurnPrefixEntry {
+            slot_id: CrossTurnSlotId::DEFAULT,
+            metadata: metadata(),
+            token_ids,
+            represented_len,
+            kv: KvPrefixHandle {
+                represented_len,
+                num_full_attention_layers: 6,
+                kv_dim: 512,
+                max_cache_len: 4096,
+                kv_f16: false,
+            },
+            gdn_snapshot_len,
+        }
+    }
+
+    #[test]
+    fn longest_common_prefix_full_hit() {
+        assert_eq!(longest_common_token_prefix(&[1, 2, 3], &[1, 2, 3]), 3);
+    }
+
+    #[test]
+    fn longest_common_prefix_empty_hit() {
+        assert_eq!(longest_common_token_prefix(&[], &[1, 2, 3]), 0);
+        assert_eq!(longest_common_token_prefix(&[1, 2, 3], &[]), 0);
+        assert_eq!(longest_common_token_prefix(&[9], &[1, 2, 3]), 0);
+    }
+
+    #[test]
+    fn longest_common_prefix_first_divergence() {
+        assert_eq!(longest_common_token_prefix(&[1, 2, 3], &[1, 2, 9]), 2);
+        assert_eq!(longest_common_token_prefix(&[1, 9, 3], &[1, 2, 3]), 1);
+    }
+
+    #[test]
+    fn longest_common_prefix_shorter_old() {
+        assert_eq!(longest_common_token_prefix(&[1, 2], &[1, 2, 3, 4]), 2);
+    }
+
+    #[test]
+    fn longest_common_prefix_shorter_new() {
+        assert_eq!(longest_common_token_prefix(&[1, 2, 3, 4], &[1, 2]), 2);
+    }
+
+    #[test]
+    fn plan_no_entry_is_full_refill() {
+        let plan = plan_prefix_reuse(None, &metadata(), &[1, 2, 3], &[]);
+        assert_eq!(plan.mode, PrefixReuseMode::FullRefill);
+        assert_eq!(plan.suffix_start, 0);
+        assert_eq!(plan.suffix_len, 3);
+    }
+
+    #[test]
+    fn plan_metadata_mismatch_is_full_refill() {
+        let e = entry(vec![1, 2, 3], 3, 3);
+        let mut other = metadata();
+        other.model_fingerprint = 999;
+        let plan = plan_prefix_reuse(Some(&e), &other, &[1, 2, 3, 4], &[]);
+        assert_eq!(plan.mode, PrefixReuseMode::FullRefill);
+        assert_eq!(plan.reusable_len, 0);
+    }
+
+    #[test]
+    fn plan_empty_new_prompt_is_full_refill() {
+        let e = entry(vec![1, 2, 3], 3, 3);
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[], &[]);
+        assert_eq!(plan.mode, PrefixReuseMode::FullRefill);
+    }
+
+    #[test]
+    fn plan_zero_shared_prefix_is_full_refill() {
+        let e = entry(vec![1, 2, 3], 3, 3);
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[9, 8, 7], &[]);
+        assert_eq!(plan.mode, PrefixReuseMode::FullRefill);
+        assert_eq!(plan.shared_token_prefix_len, 0);
+    }
+
+    #[test]
+    fn plan_exact_append() {
+        let e = entry(vec![1, 2, 3], 3, 3);
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[1, 2, 3, 4, 5], &[]);
+        assert_eq!(plan.mode, PrefixReuseMode::ExactAppend);
+        assert_eq!(plan.shared_token_prefix_len, 3);
+        assert_eq!(plan.reusable_len, 3);
+        assert_eq!(plan.suffix_start, 3);
+        assert_eq!(plan.suffix_len, 2);
+        assert_eq!(plan.old_represented_len, 3);
+    }
+
+    #[test]
+    fn plan_exact_append_requires_gdn_snapshot_at_boundary() {
+        // GDN snapshot lags represented_len -> not a safe ExactAppend even
+        // though the token prefix matches exactly.
+        let e = entry(vec![1, 2, 3], 3, 2);
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[1, 2, 3, 4], &[]);
+        assert_eq!(plan.mode, PrefixReuseMode::FullRefill);
+    }
+
+    #[test]
+    fn plan_mid_history_divergence_without_checkpoint_is_full_refill() {
+        // Shared prefix (2) is shorter than represented_len (3): edited history.
+        let e = entry(vec![1, 2, 3], 3, 3);
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[1, 2, 9, 9], &[]);
+        assert_eq!(plan.mode, PrefixReuseMode::FullRefill);
+        assert_eq!(plan.shared_token_prefix_len, 2);
+        assert_eq!(plan.old_represented_len, 3);
+    }
+
+    #[test]
+    fn plan_mid_history_divergence_shorter_new_prompt_is_full_refill() {
+        let e = entry(vec![1, 2, 3, 4, 5], 5, 5);
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[1, 2, 3], &[]);
+        assert_eq!(plan.mode, PrefixReuseMode::FullRefill);
+        assert_eq!(plan.shared_token_prefix_len, 3);
+    }
+
+    #[test]
+    fn plan_sparse_checkpoint_replay_only_when_valid() {
+        let e = entry(vec![1, 2, 3, 4, 5], 5, 5);
+        // Divergence after token 3; a checkpoint at 3 exists -> replay from 3.
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[1, 2, 3, 9, 9], &[3]);
+        assert_eq!(
+            plan.mode,
+            PrefixReuseMode::ReplayFromCheckpoint { checkpoint_len: 3 }
+        );
+        assert_eq!(plan.reusable_len, 3);
+        assert_eq!(plan.suffix_start, 3);
+        assert_eq!(plan.suffix_len, 2);
+    }
+
+    #[test]
+    fn plan_sparse_checkpoint_beyond_shared_prefix_is_ignored() {
+        let e = entry(vec![1, 2, 3, 4, 5], 5, 5);
+        // Checkpoint at 4 is past the shared prefix (3) -> cannot be used.
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[1, 2, 3, 9, 9], &[4]);
+        assert_eq!(plan.mode, PrefixReuseMode::FullRefill);
+    }
+
+    #[test]
+    fn plan_picks_the_deepest_valid_checkpoint() {
+        let e = entry(vec![1, 2, 3, 4, 5], 5, 5);
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[1, 2, 3, 9, 9], &[1, 3]);
+        assert_eq!(
+            plan.mode,
+            PrefixReuseMode::ReplayFromCheckpoint { checkpoint_len: 3 }
+        );
+    }
+}

--- a/crates/inference/src/kv_cache/cross_turn.rs
+++ b/crates/inference/src/kv_cache/cross_turn.rs
@@ -109,6 +109,13 @@ pub fn longest_common_token_prefix(a: &[u32], b: &[u32]) -> usize {
 /// exact earlier GDN checkpoint boundary present in `sparse_checkpoint_lens`
 /// (`ReplayFromCheckpoint`). Everything else falls back to `FullRefill` —
 /// decline-beats-fabricate for the token-identity invariant.
+///
+/// `ExactAppend` additionally requires a non-empty suffix
+/// (`new_prompt_ids.len() > shared`, #516 round-1 remediation D5): an
+/// exact-equal retry of the represented prompt has no divergent suffix to
+/// prefill, and the Metal integration's `forward_prefill_from` treats an
+/// empty suffix as an internal invariant violation, not a valid no-op. That
+/// case falls back to `FullRefill` here rather than surfacing as an error.
 pub fn plan_prefix_reuse(
     entry: Option<&CrossTurnPrefixEntry>,
     metadata: &CrossTurnPrefixMetadata,
@@ -137,7 +144,10 @@ pub fn plan_prefix_reuse(
         return full_refill(0, entry.represented_len);
     }
 
-    if shared == entry.represented_len && entry.gdn_snapshot_len == entry.represented_len {
+    if shared == entry.represented_len
+        && entry.gdn_snapshot_len == entry.represented_len
+        && new_prompt_ids.len() > shared
+    {
         return PrefixRestorePlan {
             mode: PrefixReuseMode::ExactAppend,
             shared_token_prefix_len: shared,
@@ -279,6 +289,26 @@ mod tests {
         assert_eq!(plan.suffix_start, 3);
         assert_eq!(plan.suffix_len, 2);
         assert_eq!(plan.old_represented_len, 3);
+    }
+
+    // #516 round-1 remediation D5 (finding 4): an exact-equal prompt retry
+    // has shared == represented_len but a zero-length suffix. Before D5 this
+    // produced `ExactAppend` with `suffix_len == 0`, which the Metal
+    // integration's `forward_prefill_from` rejects as an empty-suffix error
+    // instead of treating as a valid (degenerate) reuse. The planner must
+    // fall back to `FullRefill` instead.
+    //
+    // Mutation sensitivity: dropping the `new_prompt_ids.len() > shared`
+    // conjunct (reverting to the pre-D5 condition) makes this test fail,
+    // because the plan would again be `ExactAppend` with `suffix_len == 0`.
+    #[test]
+    fn plan_exact_equal_prompt_is_full_refill() {
+        let e = entry(vec![1, 2, 3], 3, 3);
+        let plan = plan_prefix_reuse(Some(&e), &metadata(), &[1, 2, 3], &[]);
+        assert_eq!(plan.mode, PrefixReuseMode::FullRefill);
+        assert_eq!(plan.shared_token_prefix_len, 3);
+        assert_eq!(plan.old_represented_len, 3);
+        assert_eq!(plan.suffix_len, 3);
     }
 
     #[test]

--- a/crates/inference/src/kv_cache/mod.rs
+++ b/crates/inference/src/kv_cache/mod.rs
@@ -6,10 +6,15 @@
 //! - `PagedKVCache`: Page-based cache with on-demand 256-token page allocation,
 //!   LRU eviction, and memory budgeting for multi-model serving.
 
+pub(crate) mod cross_turn;
 pub(crate) mod flat;
 pub(crate) mod paged;
 pub(crate) mod prefix;
 
+pub use cross_turn::{
+    CrossTurnPrefixEntry, CrossTurnPrefixMetadata, CrossTurnSlotId, KvPrefixHandle,
+    PrefixRestorePlan, PrefixReuseMode, longest_common_token_prefix, plan_prefix_reuse,
+};
 pub use flat::{FlatKVCache, FlatKVCacheConfig};
 pub use paged::{EvictionPolicy, PagePool, PageTable, PagedKVCache, PagedKVCacheConfig};
 pub use prefix::{


### PR DESCRIPTION
## WIP preservation — cross-turn KV prefix cache

An autonomous implementation pass (#462) produced a substantial
implementation but did **not** reach its own correctness gate before completing.
Preserving as a **draft** review surface so the work isn't lost across a session
switch. **Do not merge** — this is unverified.

### What was built
- `crates/inference/src/kv_cache/cross_turn.rs` (342 LOC): token-level prefix-reuse
  planner. Owns no GPU buffers; decides reuse-vs-`FullRefill` from token IDs +
  metadata; latest-boundary GDN snapshot + live KV logical reuse for v1; any
  divergence falls back to `PrefixReuseMode::FullRefill`.
- `crates/inference/src/forward/metal_qwen35.rs` (+848): Metal runtime hooks for
  the KV logical reuse + GDN snapshot path.
- `crates/inference/src/kv_cache/mod.rs` (+5): module wiring.
- An architect design record covering the implementation approach.

### What is NOT done (the gate)
- **Token-identity correctness test** — cross-turn output must be byte-identical to
  a full re-prefill, *through the GDN recurrent state* (18/24 layers). This is the
  explicitly-hard part and is **unverified**. No test was written.
- **Build / clippy** — committed unbuilt to preserve the work; compile status
  unchecked.
- **Measured prefill savings** on a real multi-turn conversation.

### The open design question
GDN recurrent-state cross-turn continuity: the v1 design chose a
"latest-boundary GDN snapshot + live KV logical reuse" — its correctness through
the GDN layers is the crux and is unproven. This generalizes to design item **F5**
(stateful-serving / GDN cross-turn continuity ADR) in the lattice design queue.

Preserved so the work survives a model switch.
The correctness gate + build verification are the required next steps before this
leaves draft.

## Round-1 remediation (review round 1: issues found)

Round-1 review found issues: the token-prefix planner was conservative but
the Metal integration violated the core state contract (a per-slot `HashMap` cache
retained entries while the underlying full-attention KV buffer is a single mutable
live buffer, so a stale entry could restore GDN state from one conversation while
attention read KV rows left by a different generation). Six findings total, fixed
per a fixed design (D1-D6) — still **draft**, still not merged/ready.

| Finding | Fix (design decision) | Test |
|---|---|---|
| 1 — cross-slot K/V bleed (Blocker) | **D1**: `MetalCrossTurnPrefixCache` retains at most one entry (`Option<MetalCrossTurnPrefixEntry>`, not an unbounded `HashMap`); `get`/`take`/`remove` all enforce the slot match, so a different slot is always a miss | `cross_turn_cache_slot_isolation_evicts_other_slot` (T4) |
| 2 — stale entries survive `reset_state`/interrupt (Blocker) | **D2 + D3**: `restore_cross_turn_prefix`'s `ExactAppend` arm now `take()`s (not clones) the entry, so the cache is empty from the start of a restore until a fresh save succeeds — fail-closed on any early return; `reset_state()` (the single choke point for plain `generate_streaming`, chat, serve worker, and the cache-aware path's own FullRefill/error legs) now clears the cache too | `cross_turn_cache_interleaved_plain_path_invalidates` (T5, mutation-sensitivity verified) |
| 3 — LoRA identity is shape- not content-based (Major) | **D4**: `load_lora_adapter`/`unload_lora_adapter` unconditionally clear `cross_turn_prefix_cache`; the metadata's shape-based hash remains defense-in-depth, the clear is the actual correctness mechanism | `cross_turn_cache_lora_load_unload_invalidates` (T7) |
| 4 — exact-equal retry hits an empty-suffix error (Major) | **D5**: planner requires `new_prompt_ids.len() > shared` for `ExactAppend`; exact-equal prompts now fall through to `FullRefill` instead of surfacing `InferenceError::PrefixCache` | `plan_exact_equal_prompt_is_full_refill` (planner unit test) + `cross_turn_cache_exact_equal_retry_full_refills` (T6, mutation-sensitivity verified) |
| 5 — unbounded slot growth / memory DoS (Major) | Structurally fixed by **D1** — at most one ~19MiB GDN snapshot is ever retained, bounded by design, not by an LRU cap | Covered by T4 (only one entry ever alive) |
| 6 — `lattice_serve.rs`/`chat_metal.rs` never opt into the cache (Major) | **D6 — explicitly out of scope for this remediation.** Deliberate follow-up PR once findings 1-5 are confirmed correct; wiring the serve/REPL entry points before that would ship the cross-slot and staleness bugs directly into the server path | Not addressed here |

**Mutation-sensitivity evidence** (T5/D3, T6/D5): both fixes were verified by
reverse-applying the target hunk via `Edit` on the uncommitted diff (never
`git checkout` on work in progress), `touch`-ing the file to defeat cargo's mtime
cache, rerunning the specific test, confirming it failed for the predicted reason,
then re-applying the fix and confirming it passed again.
- T5 (D3 reverted): `reused_tokens` mismatch (`left=4, right=0`) — the stale entry
  reported a spurious `ExactAppend` restore.
- T6 (D5 reverted): the exact predicted error,
  `PrefixCache("forward_prefill_from: cannot prefill an empty suffix without a
  saved logits source")`.

Two test-design bugs were found and fixed *during* this process (both tests
initially passed for the wrong reason — an unrelated guard from a different design
decision was masking the one under test): T5's second call originally reused a
same-length retry, which independently satisfied D5's separate suffix guard
regardless of D3; T6's second call originally reused the bare prompt text, but a
saved entry represents `prompt + generated tokens`, so the exact-equal boundary was
never actually reached. Both were corrected before mutation-sensitivity was
re-verified.

### Gates (all run in this worktree, real Metal hardware)
- `cargo fmt --check` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo clippy --workspace --features metal-gpu -- -D warnings` — clean
- `cargo test -p lattice-inference --features metal-gpu cross_turn` — 24 passed, 0 failed
- `cargo test -p lattice-inference kv_cache` — 102 passed, 0 failed

Still **draft**; still requires findings 1-5 fixes reviewed and finding 6 (serve
wiring) done as a follow-up before this can leave draft.


## Round-2 remediation (review round 2)

Round-2 review found issues: 1 blocker (D7) + 1 medium (D8). Round-1's D1-D5 were
independently re-verified sound by the round-2 reviewer and were **not** touched
in this round.

### D7 (Blocker) — public raw-forward APIs could still mutate live KV/GDN state without invalidating the cache

**The gap:** `forward_step`, `forward_prefill`, and `forward_prefill_all_logits`
are public entry points that advance `self.session.kv_cache` / GDN state directly.
They don't route through `reset_state()` (D3's guard) or the cache-aware save path,
so a caller could: save an entry via `generate_streaming_with_prefix_cache(slot, ...)`
→ call `forward_step`/`forward_prefill` on an unrelated token stream → continue the
original slot with a strict append → get a spurious `ExactAppend` that restores a
GDN snapshot against KV rows the raw call already overwrote. Same bug class as
round-1 finding 2, through a different public mutation path.

**Fix — full boundary enumeration.** Every `pub fn` on `MetalQwen35State` (and the
public `MtpTargetVerifier` trait impl for it) was read and classified into exactly
one of: **(a) cache-ownership participant** — already clears/owns the cache
correctly; **(b) mutates outside ownership** — needed a new `clear()`; **(c)
read-only / non-mutating / unrelated struct** — no change needed.

| Method | Mutates live KV/GDN? | Classification | Disposition |
|---|---|---|---|
| `forward_step` | Yes (`forward_step_inner`, advances `kv_cache.seq_len`) | (b) | **Fixed**: added `cross_turn_prefix_cache.clear()` at the top |
| `forward_prefill` | Yes (`forward_prefill_impl`) | (b) | **Fixed**: same |
| `forward_prefill_all_logits` | Yes (`forward_prefill_impl`) | (b) | **Fixed**: same |
| `MtpTargetVerifier::rollback_cache_to` (trait impl) | Yes (`rollback_speculative_state_to`: sets `kv_cache.seq_len`, restores GDN slot) | (b) | **Fixed**: added clear(). Public trait; not wired into any live Metal generate loop today (Metal MTP decode uses the self-contained `mtp_greedy_round`, not `mtp_verify_draft`/this trait — only benches exercise it), but reachable by any consumer holding `&mut MetalQwen35State` + the trait in scope, so it is real public surface |
| `MtpTargetVerifier::verify_tokens` (trait impl) | Yes (`verify_tokens_batched`: `forward_step_inner` + GDN checkpointing per token) | (b) | **Fixed**: added clear(), same rationale |
| `generate` | Yes | (a) | Calls `self.reset_state()` at the top before any prefill/forward work — already clears |
| `generate_multimodal` | Yes | (a) | Same — calls `reset_state()` before prefill |
| `generate_streaming` | Yes | (a) | Same — calls `reset_state()` before prefill |
| `generate_streaming_with_prefix_cache` / `_inner` | Yes | (a) | The cache-aware family itself: `restore_cross_turn_prefix`'s `ExactAppend` arm `take()`s the entry before any mutation, `FullRefill` arm calls `reset_state()`; saves via `save_cross_turn_prefix_or_clear` only at the very end |
| `chat_completion` | Yes (via `generate`) | (a) | Delegates to `generate`, covered transitively |
| `chat_completion_streaming` | Yes (via `generate_streaming`) | (a) | Delegates to `generate_streaming`, covered transitively |
| `chat_completion_streaming_with_prefix_cache` | Yes (via cache-aware family) | (a) | Delegates to `generate_streaming_with_prefix_cache`, covered transitively |
| `compute_token_nlls` | Yes | (a) | Calls `self.reset_state()` before `forward_prefill_all_logits` — verified explicitly per the task instructions rather than assumed |
| `score_layer_importance` | Yes (via private `forward_prefill_layer_traces_last_token`) | (a) | That private helper calls `reset_state()` inside its own per-layer loop AND once more at the end before returning — verified explicitly, not assumed; every exit path leaves the cache cleared |
| `reset_state` | Yes | (a — the choke point) | Already the D3 remediation: clears `cross_turn_prefix_cache` unconditionally; this is what makes (a) above transitively correct |
| `load_lora_adapter` / `unload_lora_adapter` / `generate_with_lora_mixture` | Yes | (a) | D4 remediation: load/unload unconditionally clear; the mixture path routes through both |
| `clear_cross_turn_prefix_cache` | N/A (clears the cache itself) | (a) | Cache-ownership API |
| `new` / `from_q4_dir` / `new_session` | No (fresh state / fresh session) | (c) | Construction, not mutation of an existing live cache |
| `has_mtp`, `has_lora_adapter`, `max_context`, `set_gdn_chunked`, `reset_gdn_state_traffic`, `gdn_state_traffic_report`, `take_gdn_state_traffic_report` | No | (c) | Read-only or feature-counter bookkeeping, no KV/GDN/position mutation |
| `compute_perplexity` | No direct mutation | (c) | Thin wrapper driving `compute_token_nlls` (already (a)) as its per-window kernel |
| `system`/`user`/`assistant` (`ChatMessage`), `format_chat_template`, `blend_lora_layer_data`, `mtp_missing_weights_warning`, `mtp_greedy_round` | No | (c) | Free functions / other-struct builders; `mtp_greedy_round` takes no `&mut MetalQwen35State` (pure decision function), called only from inside `generate`'s own decode loop which is already (a)-covered |

**Self-invalidation check (required by the task, not skipped):** before adding
`clear()` to the three public methods, verified the cache-aware decode loop's own
internal `forward_step` calls (inside `generate_streaming_with_prefix_cache_inner`)
never run against a live entry — `restore_cross_turn_prefix`'s `ExactAppend` arm
uses `take()` (not clone), so the slot is already empty by the time decode starts;
the `FullRefill` arm calls `reset_state()`, which clears the whole cache first. So
the new `clear()` calls inside `forward_step`/`forward_prefill*` are a no-op on the
cache-aware path's own re-entrant calls — no self-invalidation, no reordering
needed.

**Test (T8):** `cross_turn_cache_interleaved_raw_forward_invalidates` — saves an
entry via `generate_streaming_with_prefix_cache` on slot A, calls raw
`forward_step(0, 0)` on an unrelated token, then continues the ORIGINAL slot with a
strictly-longer append (never an exact-equal retry, so D5's separate guard can't be
what's doing the work) and asserts `reused_tokens == 0`, `mode != ExactAppend`, and
output token-identity against a fresh full re-prefill.

**Mutation-sensitivity evidence:** reverse-applied *only* the `forward_step` clear
via `Edit` (never `git checkout` on the uncommitted fix), `touch`-ed the file to
defeat cargo's mtime cache, reran T8:

```
thread '...cross_turn_cache_interleaved_raw_forward_invalidates' panicked at
crates/inference/src/forward/metal_qwen35.rs:22248:13:
forward_step must clear the retained cross-turn entry before mutating live state
test result: FAILED. 0 passed; 1 failed
```

Restored the fix, touched again, reran to green:

```
test forward::metal_qwen35::inner::tests::cross_turn_cache_interleaved_raw_forward_invalidates ... ok
test result: ok. 1 passed; 0 failed
```

### D8 (Medium) — design report drift

The design report still documented the rejected
`HashMap<CrossTurnSlotId, MetalCrossTurnPrefixEntry>` multi-slot design at the
struct-sketch level, said retained state was "Per `CrossTurnSlotId`" and "per cache
slot" / "per slot" in the GDN-decision rationale, and listed serve/chat REPL wiring
as implemented design components even though D6 is deliberately deferred.

**Fix:**
- Replaced the `HashMap` struct sketch with the actual shipped shape
  (`entry: Option<MetalCrossTurnPrefixEntry>`, slot-filtered `get`/`take`/`remove`,
  unconditional `insert` replacement) and added a "Round-2 remediation" note
  explaining the divergence from the original per-slot proposal.
- Corrected the "Per `CrossTurnSlotId`" retention section and the "one snapshot per
  slot" GDN-decision rationale to describe the single-live-entry contract.
- Marked the "Serve/Chat Hook" section and its "Components" list explicitly
  **DEFERRED (D6 follow-up)** — verified via `grep -rln "with_prefix_cache"` across
  `crates/` and `apps/` that neither `lattice_serve.rs` nor `chat_metal.rs`
  reference any `*_with_prefix_cache` entry point today, so the claim is accurate,
  not just relabeled.
- Fixed the trailing whitespace on report lines 3-5 that `git diff --check` flagged.

### Gates (all run in this worktree, real Metal hardware, post-D7/D8 commits)

- `cargo test -p lattice-inference --features metal-gpu cross_turn` — **25 passed**, 0 failed (24 round-1 + T8)
- `cargo test -p lattice-inference kv_cache` — **102 passed**, 0 failed
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo clippy --workspace --features metal-gpu -- -D warnings` — clean
- `cargo fmt --check` — clean
- `git diff --check origin/main...HEAD` — clean (post-commit; the report's trailing whitespace is fixed)

Commits: `800a811b0` (D7 fix + T8), `78bbe7fee` (D8 report drift fix).

Still **draft**; D6 (serve/chat wiring) remains explicitly out of scope for this PR.
