### PR TITLE
fix(inference): fail closed on PagedKVCache Lru overflow past max_tokens (#337)

### DIFF
--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -780,6 +780,17 @@ impl PagedKVCache {
     /// **Unstable**: append a single token's K and V for a specific layer.
     ///
     /// Automatically allocates new pages as needed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `layer`/slice-length preconditions are violated, or if
+    /// `EvictionPolicy::Lru` would need to grow the page table past
+    /// `max_pages` (i.e. the sequence has exceeded `max_tokens()`). Sliding
+    /// the window past capacity is not yet supported (see issue #337):
+    /// evicting the oldest page and re-pushing it is net-zero on
+    /// `num_pages()`, so without this guard the growth loop below would
+    /// never converge and would instead drain `lru_order` and panic on an
+    /// unrelated internal invariant a few iterations later.
     pub fn append_kv_layer(&mut self, layer: usize, k_token: &[f32], v_token: &[f32]) {
         let kv_dim = self.config.kv_dim();
         assert_eq!(k_token.len(), kv_dim);
@@ -791,6 +802,16 @@ impl PagedKVCache {
 
         // Check if we need a new page.
         let needed_pages = (pos / page_size) + 1;
+        if self.config.eviction == EvictionPolicy::Lru {
+            assert!(
+                needed_pages <= self.config.max_pages,
+                "PagedKVCache::append_kv_layer: position {pos} needs {needed_pages} pages but \
+                 max_pages is {}; EvictionPolicy::Lru does not yet support sequences beyond \
+                 max_tokens ({}) (see issue #337)",
+                self.config.max_pages,
+                self.config.max_tokens(),
+            );
+        }
         while self.table.num_pages() < needed_pages {
             let phys = self.alloc_page();
             self.table.push_page(phys);
@@ -1329,6 +1350,37 @@ mod tests {
         }
 
         // 5th token needs a new page -> should panic.
+        for layer in 0..2 {
+            cache.append_kv_layer(layer, &k, &v);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "does not yet support sequences beyond max_tokens")]
+    fn paged_lru_eviction_fails_closed_beyond_max_tokens() {
+        // Regression for #337: the growth loop evicted a page and re-pushed
+        // it (net-zero num_pages), without re-touching it in lru_order, so
+        // appending past max_tokens (max_pages * page_size) silently drained
+        // lru_order and panicked on an unrelated internal invariant ("LRU
+        // order empty but pool exhausted") a few tokens later instead of
+        // failing closed on the actual precondition.
+        let mut config = make_config(2); // 2 pages * page_size 4 = 8 max_tokens.
+        config.eviction = EvictionPolicy::Lru;
+        let kv_dim = config.kv_dim();
+        let mut cache = PagedKVCache::new(config);
+
+        let k = vec![1.0; kv_dim];
+        let v = vec![2.0; kv_dim];
+
+        // Fill exactly max_tokens (8) tokens across the 2 pages.
+        for _ in 0..8 {
+            for layer in 0..2 {
+                cache.append_kv_layer(layer, &k, &v);
+            }
+            cache.advance();
+        }
+
+        // 9th token exceeds max_tokens; Lru cannot yet slide the window.
         for layer in 0..2 {
             cache.append_kv_layer(layer, &k, &v);
         }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Fixes #337. `PagedKVCache::append_kv_layer`'s growth loop, under `EvictionPolicy::Lru`, evicted the oldest page and immediately re-pushed the *same physical page index* back onto the table (`crates/inference/src/kv_cache/paged.rs:794-797`, was line 794 pre-fix). That's net-zero on `table.num_pages()`. Once a sequence needed more logical pages than `max_pages` could ever provide (i.e. `seq_len > max_tokens`), the loop could never converge: each iteration drained one entry from `lru_order` (the re-pushed page is never re-added to `lru_order` — `touch_page` only runs once, after the loop, on the final resolved page for this call). Once `lru_order` emptied, `evict_lru()`'s `.expect("LRU order empty but pool exhausted")` (`paged.rs:909` pre-fix, now `paged.rs:920`) panicked with a message describing an unrelated internal invariant rather than the actual precondition ("this sequence exceeded max_tokens and Lru can't slide past it yet").

Confirmed the premise on current `main` (481d39049) by hand-tracing the exact repro from the issue (`max_pages=2, page_size=4`, append+advance 8 tokens, then a 9th) — panics at `paged.rs:909` with the exact message quoted in the issue, before this fix.

## Root cause

- `crates/inference/src/kv_cache/paged.rs:783` (`append_kv_layer`, pre-fix) — unbounded growth loop assumes `alloc_page()` + `push_page()` always nets `+1` page; under `Lru` it nets `0` once the pool is fully allocated.
- `crates/inference/src/kv_cache/paged.rs:902` (`evict_lru`) — the re-pushed page is never re-touched in `lru_order`, so `lru_order` monotonically drains over `max_pages` growth iterations regardless of how many pages are actually needed.

## Fix

Added an explicit bound check right before the growth loop: when `EvictionPolicy::Lru` and `needed_pages > max_pages`, panic immediately with a message naming the real precondition (sequence exceeds `max_tokens`, which `Lru` does not yet support sliding past). This is **not** the sliding-window feature (the issue's option 2 — adding a base-offset to `PageTable` so eviction rebases addressing correctly). The issue explicitly flags that as "the real feature... a deliberate change, not an autonomous patch, since it touches the cache's addressing contract," so it's out of scope here. This PR implements option 3 (fail closed with a clear, documented precondition) in the style this file already uses for `EvictionPolicy::None` exhaustion (an existing, accepted panic-based fail-fast convention in `PagedKVCache` specifically).

`EvictionPolicy::Lru` is not wired into any production path today — `crates/inference/src/batch/worker.rs` uses `EvictionPolicy::None` exclusively (confirmed via grep across the workspace) — so this closes the landmine without touching any reachable serving code, and the existing `paged_no_eviction_panics_on_exhaustion` test (`None` policy) is untouched/still passes with its original message.

Related: issue #292 (LRU stale `needed_pages` panic) looks like the same root cause under a different symptom description. Not touched here — out of scope for #337, flagging for whoever picks it up next.

## Regression test

`paged_lru_eviction_fails_closed_beyond_max_tokens` (`crates/inference/src/kv_cache/paged.rs`) reproduces the issue's exact repro shape (`max_pages=2, page_size=4`, 8 tokens then a 9th) and asserts on the *new* panic message via `#[should_panic(expected = "does not yet support sequences beyond max_tokens")]`.

**Mutation-sensitivity proof**: reverse-applied just the guard hunk (kept doc comment + test), reran the test — it panics but with the *original* message ("LRU order empty but pool exhausted"), which does not contain the expected substring, so the test FAILS without the fix. Re-applied the fix, reran — passes. (Used `touch` after the revert per the cargo-mtime gotcha; never used `git checkout` on the uncommitted file.) Cross-family review independently read-confirmed the two panic message strings are disjoint, so the `should_panic(expected=...)` substring pins the fix structurally.

## Gate results (this session, worktree `../lattice-lru-337`)

- `cargo fmt --check` — pass (no diff)
- `cargo clippy --workspace -- -D warnings` — pass (0 warnings)
- `cargo clippy --workspace --features metal-gpu -- -D warnings` — pass (0 warnings)
- `cargo test -p lattice-inference --lib kv_cache::paged` — 24 passed, 0 failed
- `cargo test -p lattice-inference kv_cache` (full module, all targets) — 86 passed, 0 failed
- `cargo check --features metal-gpu` — pass (build succeeds; no metal-gated code touched — `paged.rs` has no `cfg(feature = "metal-gpu")` blocks)
- pre-commit hook (clippy + deno doc lint) — pass

## bench-compare: maintainer waiver (documented)

A `make bench-compare` A/B was attempted at the maintainer gate; the harness base leg failed to produce Criterion baselines (`base/estimates.json` missing for every group → no table; known two-worktree harness fragility). Rather than rerun a 15-30 min suite, the waiver rests on reachability evidence, all grep-verified this session:

- `append_kv_layer` has **no callers outside `crates/inference/src/kv_cache/`** — it is not on any live forward, decode, or serve path. The batch worker consumes only `PagedKVCacheConfig` (config plumbing), not this function.
- The new guard executes **only inside the `EvictionPolicy::Lru` arm**, and every in-tree config uses `EvictionPolicy::None` (`batch/worker.rs:636,938,961`, `benches/inference_perf.rs:276`).
- No active Criterion group exercises `PagedKVCache` (the only bench referencing it, `inference_perf`, is shelved) — there is no measurable group for this code, and no production path executes it.

Net effect on any benchmarked or served path: zero instructions changed.

## Caveats

- This closes the panic/landmine, not the feature. `EvictionPolicy::Lru` still cannot correctly serve `seq_len > max_tokens` — it now fails closed with a clear message instead of corrupting internal state and panicking on the wrong invariant. The real sliding-window fix (base-offset addressing) remains open, per the issue's own recommendation, as a deliberate follow-up.
- Issue #292 likely shares this root cause; not touched in this PR (scope discipline per #337 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
