### PR TITLE
ci: always-reporting app-binaries-gate (ADR-066 F-1 rollout, step 1)

### DIFF
--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -1,8 +1,9 @@
 name: app-binaries
 # Regression gate: build every binary the macOS Studio app ships, each with its
 # required-features. `cargo build --workspace` skips required-features bins, so
-# this is the only CI that compiles chat_metal / eval_perplexity / train_grad_full
-# / generate_lora / embed with the features the app actually builds them with.
+# this is the only CI that compiles chat_metal / eval_perplexity / lattice_serve
+# / train_grad_full / generate_lora / embed with the features the app actually
+# builds them with.
 # See scripts/build-app-bins.sh for the rationale and the two regressions that
 # motivated it.
 #
@@ -21,6 +22,11 @@ on:
     branches: [main]
     paths:
       - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'scripts/build-app-bins.sh'
+      - 'apps/macos/scripts/package-app.sh'
+      - '.github/workflows/app-binaries.yml'
   workflow_dispatch:
 
 permissions:
@@ -54,7 +60,10 @@ jobs:
           fi
           echo "Changed files:"
           echo "$CHANGED"
-          if echo "$CHANGED" | grep -qE '^crates/|^Cargo\.(toml|lock)$|^scripts/build-app-bins\.sh$|^\.github/workflows/app-binaries\.yml$'; then
+          # here-string, not `echo | grep -q`: -q exits at first match, echo gets
+          # SIGPIPE, and under pipefail the pipeline reports 141 → the else branch
+          # would silently skip the build on large diffs (fail-open).
+          if grep -E '^crates/|^Cargo\.(toml|lock)$|^scripts/build-app-bins\.sh$|^apps/macos/scripts/package-app\.sh$|^\.github/workflows/app-binaries\.yml$' <<<"$CHANGED" >/dev/null; then
             echo "bins=true" >> "$GITHUB_OUTPUT"
             echo "→ app-binary surface changed: build REQUIRED"
           else

--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -5,14 +5,18 @@ name: app-binaries
 # / generate_lora / embed with the features the app actually builds them with.
 # See scripts/build-app-bins.sh for the rationale and the two regressions that
 # motivated it.
+#
+# Required-check shape (ADR-066 F-1): the workflow ALWAYS triggers on PRs (no
+# `paths:` filter on the PR event), but the expensive macOS build job only runs
+# when app-binary-relevant files change. The cheap always-running
+# `app-binaries-gate` job is the status context to mark required — it passes
+# when there is nothing to build and mirrors the build result when there is.
+# This avoids the trap where a path-filtered required check never reports on
+# docs-only PRs and wedges them on "Expected — waiting for status".
 
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'crates/**'
-      - 'scripts/build-app-bins.sh'
-      - '.github/workflows/app-binaries.yml'
   push:
     branches: [main]
     paths:
@@ -27,8 +31,41 @@ env:
   CARGO_INCREMENTAL: '0'
 
 jobs:
+  # Decide whether the app-binary surface changed. Output drives both the
+  # expensive build job and the required gate below.
+  changes:
+    name: detect-app-bin-changes
+    runs-on: ubuntu-latest
+    outputs:
+      bins: ${{ steps.filter.outputs.bins }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
+            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+              || git diff --name-only "HEAD~1...HEAD")
+          else
+            CHANGED=$(git diff --name-only "HEAD~1...HEAD" 2>/dev/null || true)
+          fi
+          echo "Changed files:"
+          echo "$CHANGED"
+          if echo "$CHANGED" | grep -qE '^crates/|^Cargo\.(toml|lock)$|^scripts/build-app-bins\.sh$|^\.github/workflows/app-binaries\.yml$'; then
+            echo "bins=true" >> "$GITHUB_OUTPUT"
+            echo "→ app-binary surface changed: build REQUIRED"
+          else
+            echo "bins=false" >> "$GITHUB_OUTPUT"
+            echo "→ no app-binary change: build skipped, gate passes"
+          fi
+
   build-app-bins:
     name: build app-shipped binaries
+    needs: changes
+    if: needs.changes.outputs.bins == 'true'
     runs-on: macos-latest
     timeout-minutes: 45
     steps:
@@ -39,3 +76,33 @@ jobs:
           shared-key: app-binaries
       - name: Build all app-shipped binaries (required-features included)
         run: ./scripts/build-app-bins.sh
+
+  # The status context to mark required once it has reported reliably on a few
+  # PRs (ADR-066 F-1 phased rollout). Fails closed on change-detection failure,
+  # passes when nothing relevant changed, otherwise mirrors the build result.
+  app-binaries-gate:
+    name: app-binaries-gate
+    needs: [changes, build-app-bins]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve gate
+        run: |
+          CHANGES_RESULT="${{ needs.changes.result }}"
+          BINS="${{ needs.changes.outputs.bins }}"
+          BUILD_RESULT="${{ needs.build-app-bins.result }}"
+          echo "changes=$CHANGES_RESULT bins=$BINS build=$BUILD_RESULT"
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::change-detection did not succeed — failing closed."
+            exit 1
+          fi
+          if [ "$BINS" != "true" ]; then
+            echo "No app-binary change — build not required. PASS."
+            exit 0
+          fi
+          if [ "$BUILD_RESULT" != "success" ]; then
+            echo "::error::App-binary surface changed and build did not succeed (result=$BUILD_RESULT)."
+            exit 1
+          fi
+          echo "App-binary surface changed; build PASSED."
+          exit 0

--- a/scripts/build-app-bins.sh
+++ b/scripts/build-app-bins.sh
@@ -42,6 +42,7 @@ build_bin -p lattice-tune      --bin train_grad_full --features train-backward
 build_bin -p lattice-tune      --bin generate_lora   --features safetensors,inference-hook
 build_bin -p lattice-inference --bin eval_perplexity --features f16,metal-gpu
 build_bin -p lattice-inference --bin chat_metal      --features f16,metal-gpu
+build_bin -p lattice-inference --bin lattice_serve   --features f16,metal-gpu
 
 # lattice-embed — `native` is a default feature, so no explicit --features.
 build_bin -p lattice-embed     --bin embed


### PR DESCRIPTION
> _PR authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Restructures `app-binaries.yml` into the same required-check shape as `e2e-parity.yml`: the workflow now triggers on every PR, a cheap `detect-app-bin-changes` job decides whether the expensive macOS build is needed, and a new always-reporting `app-binaries-gate` job is the status context intended to become required.

## Why

ADR-066 F-1 approved making the app-binaries build a required check. The raw `build app-shipped binaries` job cannot be marked required as-is: it is path-filtered, so docs-only PRs would never receive the status and would wedge on "Expected — waiting for status to be reported". The gate job passes when no app-binary-relevant file changed, mirrors the build result when one did, and fails closed if change detection itself fails.

## Review round 1 remediation (d78dc6b58)

Adversarial review before required-check promotion found three fail-opens, all fixed in this PR:

1. **Fail-safe change detection**: the detector's `echo "$CHANGED" | grep -qE` under `pipefail` could hit SIGPIPE (status 141) on large diffs and silently skip the build. Replaced with a here-string read; stress-verified at 5,000 and 200,000 trailing changed files.
2. **`lattice_serve` coverage**: `scripts/build-app-bins.sh` now also builds `lattice_serve --features f16,metal-gpu`, matching the full set `apps/macos/scripts/package-app.sh` ships. Live CI on this PR logs the build.
3. **Detection coverage**: `apps/macos/scripts/package-app.sh` (source of truth for the shipped binary set) added to the detection regex, and the push paths filter now covers the build script, Cargo files, and the workflow itself.

## Rollout

1. **This PR**: gate lands non-required and starts reporting on every PR.
2. **Step 2 (separate)**: after the gate has reported reliably, flip the branch ruleset to require `app-binaries-gate` (and drop any requirement on the raw build job name).

The workflow file itself changes in this PR, so the build job runs here and exercises the full path, including the `lattice_serve` build.