### PR TITLE
ci(parity): add non-required Metal attention/KV parity leg with dispatch path-proof (#239)

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -225,8 +225,7 @@ jobs:
         run: cargo build --release --bin chat_metal -p lattice-inference --features "f16,metal-gpu"
 
       - name: Run Metal attention/KV parity check
-        run: |
-          python3 scripts/e2e_parity_check.py --backend metal | tee metal-parity-report.md
+        run: python3 scripts/e2e_parity_check.py --backend metal
         env:
           LATTICE_BIN: target/release/chat_metal
           LATTICE_METAL_PATH_PROOF: '1'

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -148,6 +148,105 @@ jobs:
           header: e2e-parity
           path: parity-report.md
 
+  # Non-required Metal attention/KV-cache parity leg (issue #239). e2e-parity
+  # only ever exercised the CPU (qwen35_generate) path above; this job exists
+  # to prove the Metal attention/KV dispatch helpers actually ran, not just
+  # that a Metal device was present.
+  #
+  # Gotcha (do not "fix" by adding an Apple7 family check): GitHub's
+  # macos-latest runner exposes a PARAVIRTUAL Metal device. Apple7-gated
+  # kernels silently no-op there, so a naive "did it run" check can go green
+  # without exercising anything. The audited attention/KV pipelines this job
+  # targets are NOT Apple7-gated (only the optional tiled-GEMM path is), so
+  # `runs-on: macos-latest` is expected to genuinely execute them — but the
+  # gate does not trust that assumption. scripts/e2e_parity_check.py
+  # --backend metal requires the runtime LATTICE_METAL_PATH_PROOF marker
+  # (dispatch-site counters emitted by chat_metal) and FAILS CLOSED — never
+  # skip-as-green — if the marker is missing or any required counter is zero.
+  # If a future CI run proves the hosted runner cannot execute the required
+  # kernels despite this, switch only `runs-on` to
+  # `[self-hosted, macOS, ARM64, metal]` and document why.
+  #
+  # Deliberately NOT added to parity-gate.needs below: this is an informational
+  # signal only. Making it required is a founder decision (repo branch
+  # protection), out of scope for this change.
+  metal-parity:
+    name: metal attention parity (informational)
+    needs: changes
+    if: needs.changes.outputs.engine == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: macos-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache Python packages
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/pip
+          key: e2e-pip-${{ runner.os }}-py311-v1
+
+      - name: Cache HF model weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
+          key: hf-qwen35-0.8b-v1
+
+      - name: Install Python deps
+        run: pip install "torch==2.12.1" "transformers==5.12.1" "tokenizers==0.22.2" "huggingface_hub==1.20.1"
+
+      - name: Download Qwen3.5-0.8B weights
+        run: |
+          python3 -c "
+          from huggingface_hub import snapshot_download
+          path = snapshot_download('Qwen/Qwen3.5-0.8B')
+          print(f'Model at: {path}')
+          "
+
+      - name: Setup lattice model dir
+        run: |
+          MODEL_CACHE=$(python3 -c "
+          from huggingface_hub import snapshot_download
+          print(snapshot_download('Qwen/Qwen3.5-0.8B'))
+          ")
+          mkdir -p ~/.lattice/models
+          ln -sf "$MODEL_CACHE" ~/.lattice/models/qwen3.5-0.8b
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: e2e-metal-parity
+
+      - name: Build lattice Metal binary
+        run: cargo build --release --bin chat_metal -p lattice-inference --features "f16,metal-gpu"
+
+      - name: Run Metal attention/KV parity check
+        run: |
+          python3 scripts/e2e_parity_check.py --backend metal | tee metal-parity-report.md
+        env:
+          LATTICE_BIN: target/release/chat_metal
+          LATTICE_METAL_PATH_PROOF: '1'
+          E2E_MAX_TOKENS: '4'
+          E2E_REPORT_PATH: metal-parity-report.md
+
+      - name: Ensure Metal report exists
+        if: always()
+        run: |
+          test -s metal-parity-report.md || {
+            printf '## Metal Attention/KV Parity Report\n\nNo report was produced. Check job logs.\n' > metal-parity-report.md
+          }
+
+      - name: Post Metal parity report
+        if: github.event_name == 'pull_request' && always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: e2e-metal-parity
+          path: metal-parity-report.md
+
   # Embedding-drift gate: re-embeds the 5 frozen BGE-small corpus texts and
   # asserts max per-vector (1 - cosine) < 1e-3 vs the committed baseline.
   #

--- a/crates/inference/src/bin/chat_metal.rs
+++ b/crates/inference/src/bin/chat_metal.rs
@@ -398,10 +398,21 @@ fn emit_json_generation(
     let mut ttft_ms: f64 = 0.0;
     let t1 = std::time::Instant::now();
 
+    // Path-proof probe (issue #239): opt-in so normal Lattice Studio runs pay no
+    // cost. When enabled, zero the dispatch-site counters before this generation
+    // so the marker below reflects only this call's Metal attention/KV dispatches.
+    let path_proof_enabled = matches!(
+        std::env::var("LATTICE_METAL_PATH_PROOF").as_deref(),
+        Ok("1") | Ok("true")
+    );
+    if path_proof_enabled {
+        metal.reset_path_proof_counters();
+    }
+
     // Capture the first write/flush failure so we can stop generation and return Err
     // rather than silently completing a run whose output was never received.
     let mut stream_err: Option<std::io::Error> = None;
-    let output = metal.generate_streaming(prompt, tokenizer, gen_cfg, |delta, _token_id| {
+    let output = metal.generate_streaming(prompt, tokenizer, gen_cfg, |delta, token_id| {
         if !first_token_emitted {
             ttft_ms = t1.elapsed().as_secs_f64() * 1000.0;
             first_token_emitted = true;
@@ -409,7 +420,7 @@ fn emit_json_generation(
         let token_json = json_escape(delta);
         let write_result = writeln!(
             stdout,
-            "@@lattice {{\"ev\":\"gen_token\",\"token\":{token_json},\"done\":false}}"
+            "@@lattice {{\"ev\":\"gen_token\",\"token\":{token_json},\"token_id\":{token_id},\"done\":false}}"
         )
         .and_then(|()| stdout.flush());
         if let Err(e) = write_result {
@@ -444,6 +455,24 @@ fn emit_json_generation(
         "[chat_metal] GPU Metal {model_format}{lora_tag}: {} prompt + {} gen in {}ms = {tok_s:.1} tok/s",
         output.prompt_tokens, output.generated_tokens, gen_ms
     );
+
+    // Emit the runtime path-proof marker (issue #239): CI gates on this to prove
+    // the required Metal attention/KV dispatches actually ran, rather than
+    // trusting a "Metal device present" check that a paravirtual CI runner would
+    // pass vacuously. See scripts/e2e_parity_check.py for the fail-closed parser.
+    if path_proof_enabled {
+        let s = metal.path_proof_snapshot();
+        eprintln!(
+            "[METAL_PATH_PROOF] prefill_kv_batch={} prefill_attn_batched={} decode_kv_copy={} decode_attn_direct={} decode_attn_split_partial={} decode_attn_split_reduce={} kv_f16={}",
+            s.prefill_kv_batch,
+            s.prefill_attn_batched,
+            s.decode_kv_copy,
+            s.decode_attn_direct,
+            s.decode_attn_split_partial,
+            s.decode_attn_split_reduce,
+            s.kv_f16,
+        );
+    }
 
     Ok(())
 }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -12817,9 +12817,11 @@ kernel void gdn_chunk_norm_silu_c32(
                     MTLSize::new(num_kv_heads as u64, 1, 1),
                     MTLSize::new(256, 1, 1),
                 );
-                self.path_proof
-                    .decode_attn_direct
-                    .fetch_add(1, Ordering::Relaxed);
+                if self.path_proof_enabled {
+                    self.path_proof
+                        .decode_attn_direct
+                        .fetch_add(1, Ordering::Relaxed);
+                }
             } else {
                 // Partitioned flash decode (H3): partial kernel + reduce kernel.
                 // Split KV cache into PARTITION_TOKENS-token chunks for better occupancy.
@@ -12837,9 +12839,11 @@ kernel void gdn_chunk_norm_silu_c32(
                     MTLSize::new(num_kv_heads as u64, num_partitions as u64, 1),
                     MTLSize::new(256, 1, 1),
                 );
-                self.path_proof
-                    .decode_attn_split_partial
-                    .fetch_add(1, Ordering::Relaxed);
+                if self.path_proof_enabled {
+                    self.path_proof
+                        .decode_attn_split_partial
+                        .fetch_add(1, Ordering::Relaxed);
+                }
 
                 // Reduce pass: one TG per KV head, combines all partitions.
                 // decode_attention_flash_reduce reads f32 attn_partials, not KV — no f16 variant.
@@ -12853,9 +12857,11 @@ kernel void gdn_chunk_norm_silu_c32(
                     MTLSize::new(num_kv_heads as u64, 1, 1),
                     MTLSize::new(256, 1, 1),
                 );
-                self.path_proof
-                    .decode_attn_split_reduce
-                    .fetch_add(1, Ordering::Relaxed);
+                if self.path_proof_enabled {
+                    self.path_proof
+                        .decode_attn_split_reduce
+                        .fetch_add(1, Ordering::Relaxed);
+                }
             }
         }
 
@@ -12996,9 +13002,11 @@ kernel void gdn_chunk_norm_silu_c32(
                 MTLSize::new(div_ceil(total as u64, wg) * wg, 1, 1),
                 MTLSize::new(wg, 1, 1),
             );
-            self.path_proof
-                .prefill_kv_batch
-                .fetch_add(1, Ordering::Relaxed);
+            if self.path_proof_enabled {
+                self.path_proof
+                    .prefill_kv_batch
+                    .fetch_add(1, Ordering::Relaxed);
+            }
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -13050,9 +13058,11 @@ kernel void gdn_chunk_norm_silu_c32(
                 MTLSize::new(num_kv_heads as u64, num_tokens as u64, 1),
                 MTLSize::new(256, 1, 1),
             );
-            self.path_proof
-                .prefill_attn_batched
-                .fetch_add(1, Ordering::Relaxed);
+            if self.path_proof_enabled {
+                self.path_proof
+                    .prefill_attn_batched
+                    .fetch_add(1, Ordering::Relaxed);
+            }
             Ok(())
         }
 
@@ -13311,9 +13321,11 @@ kernel void gdn_chunk_norm_silu_c32(
                 MTLSize::new(div_ceil(count as u64, wg) * wg, 1, 1),
                 MTLSize::new(wg, 1, 1),
             );
-            self.path_proof
-                .decode_kv_copy
-                .fetch_add(1, Ordering::Relaxed);
+            if self.path_proof_enabled {
+                self.path_proof
+                    .decode_kv_copy
+                    .fetch_add(1, Ordering::Relaxed);
+            }
         }
 
         #[allow(dead_code)] // element-wise add dispatch helper; used by full_attention_layer_step_by_idx

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -50,6 +50,7 @@ mod inner {
     use crate::tokenizer::common::Tokenizer;
     use crate::weights::q4_weights::quantize_row_q4_0;
     use metal::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     // ---------------------------------------------------------------------------
     // MSL Compute Shaders
@@ -4530,6 +4531,19 @@ kernel void gdn_chunk_norm_silu_c32(
         /// across threads or processes. Empty by default; only populated by
         /// the `*_with_prefix_cache` entry points.
         cross_turn_prefix_cache: MetalCrossTurnPrefixCache,
+        /// Per-instance flag: whether the path-proof counters below are live.
+        /// Read once from `LATTICE_METAL_PATH_PROOF` at construction time
+        /// (same pattern as `use_kv_f16`) so every dispatch-site `fetch_add`
+        /// is a no-op — not just relaxed-but-still-paid — on the default
+        /// (disabled) path. See `PathProofCounters` for what this gates.
+        pub(crate) path_proof_enabled: bool,
+        /// Runtime path-proof counters (issue #239): prove which Metal attention/KV
+        /// dispatch helpers actually ran, so CI can fail closed on a paravirtual
+        /// runner that reports a Metal device but silently skips required kernels.
+        /// Only recorded when `path_proof_enabled` is set (opt-in, zero cost
+        /// otherwise); read via `path_proof_snapshot` and zeroed via
+        /// `reset_path_proof_counters`.
+        pub(crate) path_proof: PathProofCounters,
     }
 
     // ---------------------------------------------------------------------------
@@ -4643,6 +4657,44 @@ kernel void gdn_chunk_norm_silu_c32(
         fn clear(&mut self) {
             self.entry = None;
         }
+    }
+
+    /// Dispatch-site counters for the Metal attention/KV-cache path-proof probe.
+    ///
+    /// `&self`-compatible (interior mutability) because the dispatch helpers that
+    /// increment these run inside `&self` methods sharing one command encoder.
+    #[derive(Default)]
+    pub struct PathProofCounters {
+        pub prefill_kv_batch: AtomicU64,
+        pub prefill_attn_batched: AtomicU64,
+        pub decode_kv_copy: AtomicU64,
+        pub decode_attn_direct: AtomicU64,
+        pub decode_attn_split_partial: AtomicU64,
+        pub decode_attn_split_reduce: AtomicU64,
+    }
+
+    impl PathProofCounters {
+        fn reset(&self) {
+            self.prefill_kv_batch.store(0, Ordering::Relaxed);
+            self.prefill_attn_batched.store(0, Ordering::Relaxed);
+            self.decode_kv_copy.store(0, Ordering::Relaxed);
+            self.decode_attn_direct.store(0, Ordering::Relaxed);
+            self.decode_attn_split_partial.store(0, Ordering::Relaxed);
+            self.decode_attn_split_reduce.store(0, Ordering::Relaxed);
+        }
+    }
+
+    /// Snapshot of [`PathProofCounters`] plus the KV-cache precision mode in effect,
+    /// suitable for formatting into the `[METAL_PATH_PROOF]` stderr marker.
+    #[derive(Debug, Clone, Copy, Default)]
+    pub struct PathProofSnapshot {
+        pub prefill_kv_batch: u64,
+        pub prefill_attn_batched: u64,
+        pub decode_kv_copy: u64,
+        pub decode_attn_direct: u64,
+        pub decode_attn_split_partial: u64,
+        pub decode_attn_split_reduce: u64,
+        pub kv_f16: bool,
     }
 
     // ---------------------------------------------------------------------------
@@ -5977,6 +6029,10 @@ kernel void gdn_chunk_norm_silu_c32(
                 std::env::var("LATTICE_KV_F16").as_deref(),
                 Ok("1") | Ok("true")
             );
+            let path_proof_enabled = matches!(
+                std::env::var("LATTICE_METAL_PATH_PROOF").as_deref(),
+                Ok("1") | Ok("true")
+            );
             // new_session reads LATTICE_KV_F16 identically, so session.kv_cache
             // and the use_kv_f16 field below agree by construction.
             let session = engine.new_session(max_cache_len)?;
@@ -5987,12 +6043,42 @@ kernel void gdn_chunk_norm_silu_c32(
                 use_gdn_chunked,
                 use_kv_f16,
                 cross_turn_prefix_cache: MetalCrossTurnPrefixCache::default(),
+                path_proof_enabled,
+                path_proof: PathProofCounters::default(),
             })
         }
 
         /// Returns `true` if MTP weights were loaded and the session has an active MTP state.
         pub fn has_mtp(&self) -> bool {
             self.session.mtp.is_some()
+        }
+
+        /// Zeroes the Metal attention/KV-cache path-proof counters (issue #239).
+        ///
+        /// Call before a one-shot `generate`/`generate_streaming` run so
+        /// [`Self::path_proof_snapshot`] afterward reflects only that run's dispatches.
+        pub fn reset_path_proof_counters(&self) {
+            self.path_proof.reset();
+        }
+
+        /// Snapshots the Metal attention/KV-cache path-proof counters (issue #239)
+        /// without resetting them, alongside the KV-cache precision mode in effect.
+        pub fn path_proof_snapshot(&self) -> PathProofSnapshot {
+            PathProofSnapshot {
+                prefill_kv_batch: self.path_proof.prefill_kv_batch.load(Ordering::Relaxed),
+                prefill_attn_batched: self.path_proof.prefill_attn_batched.load(Ordering::Relaxed),
+                decode_kv_copy: self.path_proof.decode_kv_copy.load(Ordering::Relaxed),
+                decode_attn_direct: self.path_proof.decode_attn_direct.load(Ordering::Relaxed),
+                decode_attn_split_partial: self
+                    .path_proof
+                    .decode_attn_split_partial
+                    .load(Ordering::Relaxed),
+                decode_attn_split_reduce: self
+                    .path_proof
+                    .decode_attn_split_reduce
+                    .load(Ordering::Relaxed),
+                kv_f16: self.use_kv_f16,
+            }
         }
 
         /// Resets GDN state-traffic counters to zero without changing the shape.
@@ -12731,6 +12817,9 @@ kernel void gdn_chunk_norm_silu_c32(
                     MTLSize::new(num_kv_heads as u64, 1, 1),
                     MTLSize::new(256, 1, 1),
                 );
+                self.path_proof
+                    .decode_attn_direct
+                    .fetch_add(1, Ordering::Relaxed);
             } else {
                 // Partitioned flash decode (H3): partial kernel + reduce kernel.
                 // Split KV cache into PARTITION_TOKENS-token chunks for better occupancy.
@@ -12748,6 +12837,9 @@ kernel void gdn_chunk_norm_silu_c32(
                     MTLSize::new(num_kv_heads as u64, num_partitions as u64, 1),
                     MTLSize::new(256, 1, 1),
                 );
+                self.path_proof
+                    .decode_attn_split_partial
+                    .fetch_add(1, Ordering::Relaxed);
 
                 // Reduce pass: one TG per KV head, combines all partitions.
                 // decode_attention_flash_reduce reads f32 attn_partials, not KV — no f16 variant.
@@ -12761,6 +12853,9 @@ kernel void gdn_chunk_norm_silu_c32(
                     MTLSize::new(num_kv_heads as u64, 1, 1),
                     MTLSize::new(256, 1, 1),
                 );
+                self.path_proof
+                    .decode_attn_split_reduce
+                    .fetch_add(1, Ordering::Relaxed);
             }
         }
 
@@ -12901,6 +12996,9 @@ kernel void gdn_chunk_norm_silu_c32(
                 MTLSize::new(div_ceil(total as u64, wg) * wg, 1, 1),
                 MTLSize::new(wg, 1, 1),
             );
+            self.path_proof
+                .prefill_kv_batch
+                .fetch_add(1, Ordering::Relaxed);
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -12952,6 +13050,9 @@ kernel void gdn_chunk_norm_silu_c32(
                 MTLSize::new(num_kv_heads as u64, num_tokens as u64, 1),
                 MTLSize::new(256, 1, 1),
             );
+            self.path_proof
+                .prefill_attn_batched
+                .fetch_add(1, Ordering::Relaxed);
             Ok(())
         }
 
@@ -13210,6 +13311,9 @@ kernel void gdn_chunk_norm_silu_c32(
                 MTLSize::new(div_ceil(count as u64, wg) * wg, 1, 1),
                 MTLSize::new(wg, 1, 1),
             );
+            self.path_proof
+                .decode_kv_copy
+                .fetch_add(1, Ordering::Relaxed);
         }
 
         #[allow(dead_code)] // element-wise add dispatch helper; used by full_attention_layer_step_by_idx
@@ -15091,6 +15195,10 @@ kernel void gdn_chunk_norm_silu_c32(
                 std::env::var("LATTICE_KV_F16").as_deref(),
                 Ok("1") | Ok("true")
             );
+            let path_proof_enabled = matches!(
+                std::env::var("LATTICE_METAL_PATH_PROOF").as_deref(),
+                Ok("1") | Ok("true")
+            );
             let kv_cache = MetalKvCache::new(&device, num_full, kv_dim, max_cache_len, use_kv_f16);
 
             let dur_d = t_d.elapsed();
@@ -15252,6 +15360,8 @@ kernel void gdn_chunk_norm_silu_c32(
                 ),
                 use_kv_f16,
                 cross_turn_prefix_cache: MetalCrossTurnPrefixCache::default(),
+                path_proof_enabled,
+                path_proof: PathProofCounters::default(),
             })
         }
 
@@ -17581,6 +17691,8 @@ kernel void decode_attention_reference(
                 use_gdn_chunked: true,
                 use_kv_f16: false,
                 cross_turn_prefix_cache: MetalCrossTurnPrefixCache::default(),
+                path_proof_enabled: false,
+                path_proof: PathProofCounters::default(),
             }
         }
 
@@ -17780,6 +17892,8 @@ kernel void decode_attention_reference(
                 use_gdn_chunked: true,
                 use_kv_f16: false,
                 cross_turn_prefix_cache: MetalCrossTurnPrefixCache::default(),
+                path_proof_enabled: false,
+                path_proof: PathProofCounters::default(),
             };
             let _logits = state_a.forward_step(42, 0);
             let _logits = state_a.forward_step(7, 1);
@@ -23154,7 +23268,8 @@ mod gdn_state_traffic_tests {
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub use inner::{
     ChatCompletionOutput, ChatMessage, ChatRole, LayerImportanceScore, LayerPruningPlan,
-    LoraLayerData, MetalQwen35State, blend_lora_layer_data, format_chat_template,
+    LoraLayerData, MetalQwen35State, PathProofSnapshot, blend_lora_layer_data,
+    format_chat_template,
 };
 
 // Stub for non-macOS or non-metal builds.

--- a/scripts/e2e_parity_check.py
+++ b/scripts/e2e_parity_check.py
@@ -383,6 +383,13 @@ def run_lattice_metal(prompt: str, max_tokens: int) -> dict:
         "--prompt", prompt,
         "--max-tokens", str(max_tokens),
         "--temperature", "0.0",
+        # chat_metal's serving default is repetition_penalty 1.1, but the HF
+        # reference applies none — the same greedy-decision mismatch documented
+        # on the CPU path above (run_lattice). Force 1.0 so both sides run the
+        # same greedy rule and any remaining divergence is genuinely the
+        # engine's (e.g. the long-prefill Metal divergence, which reproduces
+        # with this flag set and with either GDN prefill mode).
+        "--repetition-penalty", "1.0",
         "--json",
     ]
 

--- a/scripts/e2e_parity_check.py
+++ b/scripts/e2e_parity_check.py
@@ -6,14 +6,31 @@ generation output (token IDs) and reports speed.
 
 Exit codes: 0 = pass, 1 = parity failure, 2 = setup error.
 
+Args:
+  --backend {cpu,metal}  which lattice binary/path to exercise (default: cpu).
+                          "cpu" runs qwen35_generate and parses its legacy text
+                          output. "metal" runs `chat_metal --json` and requires
+                          the LATTICE_METAL_PATH_PROOF runtime capability marker
+                          to prove the Metal attention/KV-cache dispatch helpers
+                          actually ran; a missing/invalid/zero-count marker is a
+                          gate FAILURE (never a skip), so a paravirtual runner
+                          that silently no-ops the required kernels goes red
+                          instead of green (issue #239).
+
 Env vars:
-  LATTICE_BIN       path to lattice qwen35_generate binary (default: target/release/qwen35_generate)
-  LATTICE_MODEL_DIR path to model weights (default: ~/.lattice/models/qwen3.5-0.8b)
-  HF_MODEL_ID       HuggingFace model ID (default: Qwen/Qwen3.5-0.8B)
-  E2E_MAX_TOKENS    tokens to generate per prompt (default: 15)
-  E2E_REPORT_PATH   write markdown report here (optional)
+  LATTICE_BIN             path to the lattice binary under test (default:
+                           target/release/qwen35_generate for --backend cpu,
+                           target/release/chat_metal for --backend metal)
+  LATTICE_MODEL_DIR       path to model weights (default: ~/.lattice/models/qwen3.5-0.8b)
+  HF_MODEL_ID             HuggingFace model ID (default: Qwen/Qwen3.5-0.8B)
+  E2E_MAX_TOKENS          tokens to generate per prompt (default: 15)
+  E2E_REPORT_PATH         write markdown report here (optional)
+  LATTICE_METAL_PATH_PROOF  set to "1" so chat_metal emits the
+                           `[METAL_PATH_PROOF]` stderr marker this script
+                           requires in --backend metal mode
 """
 
+import argparse
 import json
 import os
 import re
@@ -171,9 +188,16 @@ PROMPTS: list[tuple[str, int]] = [
 MAX_TOKENS = int(os.environ.get("E2E_MAX_TOKENS", "15"))
 
 HF_MODEL_ID = os.environ.get("HF_MODEL_ID", "Qwen/Qwen3.5-0.8B")
+
+# LATTICE_BIN default depends on --backend (chat_metal for metal, qwen35_generate
+# for cpu), but argparse only runs inside main(). An explicit LATTICE_BIN env var
+# always wins; module import time sets a provisional cpu-shaped default so any
+# code that reads LATTICE_BIN before main() runs still gets a sane path, and
+# main() overwrites it with the backend-correct default once args are parsed.
 LATTICE_BIN = os.environ.get(
     "LATTICE_BIN", "target/release/qwen35_generate"
 )
+_LATTICE_BIN_EXPLICIT = "LATTICE_BIN" in os.environ
 MODEL_DIR = os.environ.get(
     "LATTICE_MODEL_DIR",
     os.path.expanduser("~/.lattice/models/qwen3.5-0.8b"),
@@ -287,6 +311,159 @@ def run_lattice(prompt: str, max_tokens: int) -> dict:
     }
 
 
+# Required (non-zero) path-proof counters, matching the dispatch-site instrumentation
+# in crates/inference/src/forward/metal_qwen35.rs. decode attention takes either the
+# direct kernel (short caches) or the split partial+reduce pair (long caches) — never
+# both — so that pair is an OR, everything else is a hard AND.
+_PATH_PROOF_RE = re.compile(
+    r"\[METAL_PATH_PROOF\]\s+"
+    r"prefill_kv_batch=(\d+)\s+"
+    r"prefill_attn_batched=(\d+)\s+"
+    r"decode_kv_copy=(\d+)\s+"
+    r"decode_attn_direct=(\d+)\s+"
+    r"decode_attn_split_partial=(\d+)\s+"
+    r"decode_attn_split_reduce=(\d+)\s+"
+    r"kv_f16=(true|false)"
+)
+
+
+def parse_path_proof_marker(stderr_text: str) -> dict | None:
+    """Extract the last `[METAL_PATH_PROOF]` marker from chat_metal's stderr.
+
+    Returns None if the marker is absent or malformed — callers must treat that
+    as a gate FAILURE, not a skip, per the paravirtual-runner gotcha in issue #239.
+    """
+    match = None
+    for line in stderr_text.splitlines():
+        m = _PATH_PROOF_RE.search(line)
+        if m:
+            match = m  # keep the last one, in case of retries/logging noise
+    if match is None:
+        return None
+    return {
+        "prefill_kv_batch": int(match.group(1)),
+        "prefill_attn_batched": int(match.group(2)),
+        "decode_kv_copy": int(match.group(3)),
+        "decode_attn_direct": int(match.group(4)),
+        "decode_attn_split_partial": int(match.group(5)),
+        "decode_attn_split_reduce": int(match.group(6)),
+        "kv_f16": match.group(7) == "true",
+    }
+
+
+def path_proof_covers_required_path(counters: dict) -> bool:
+    """Fail-closed check: did the required Metal attention/KV dispatches run?"""
+    if counters["prefill_kv_batch"] <= 0:
+        return False
+    if counters["prefill_attn_batched"] <= 0:
+        return False
+    if counters["decode_kv_copy"] <= 0:
+        return False
+    direct_ok = counters["decode_attn_direct"] > 0
+    split_ok = (
+        counters["decode_attn_split_partial"] > 0
+        and counters["decode_attn_split_reduce"] > 0
+    )
+    return direct_ok or split_ok
+
+
+def run_lattice_metal(prompt: str, max_tokens: int) -> dict:
+    """Run `chat_metal --json` and parse its `@@lattice` event stream.
+
+    Fails closed (returns None) if the run errors, the event stream is
+    malformed, or the `[METAL_PATH_PROOF]` marker is missing or does not cover
+    the required attention/KV-cache dispatch path — this is the mechanism that
+    makes the gate red on a paravirtual CI runner that reports a Metal device
+    but silently no-ops the required kernels (issue #239), instead of a vacuous
+    green pass.
+    """
+    cmd = [
+        LATTICE_BIN,
+        "--model-dir", MODEL_DIR,
+        "--prompt", prompt,
+        "--max-tokens", str(max_tokens),
+        "--temperature", "0.0",
+        "--json",
+    ]
+
+    t0 = time.time()
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=300
+        )
+    except subprocess.TimeoutExpired:
+        print("[lattice-metal] FAILED (timeout)", file=sys.stderr)
+        return None
+    elapsed = time.time() - t0
+
+    if result.returncode != 0:
+        print(f"[lattice-metal] FAILED (exit {result.returncode})", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        return None
+
+    gen_ids: list[int] = []
+    text_parts: list[str] = []
+    tok_per_sec = 0.0
+    saw_done = False
+
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("@@lattice "):
+            continue
+        payload = line[len("@@lattice "):]
+        try:
+            ev = json.loads(payload)
+        except json.JSONDecodeError as e:
+            print(f"[lattice-metal] malformed @@lattice event: {e}", file=sys.stderr)
+            print(line, file=sys.stderr)
+            return None
+        if ev.get("ev") != "gen_token":
+            continue
+        if ev.get("done"):
+            saw_done = True
+            tok_per_sec = float(ev.get("tok_s", 0.0))
+            continue
+        token_id = ev.get("token_id")
+        if not isinstance(token_id, int):
+            print(
+                f"[lattice-metal] gen_token event missing integer token_id: {ev}",
+                file=sys.stderr,
+            )
+            return None
+        gen_ids.append(token_id)
+        text_parts.append(ev.get("token", ""))
+
+    if not saw_done:
+        print("[lattice-metal] no done:true event observed in output", file=sys.stderr)
+        return None
+
+    path_proof = parse_path_proof_marker(result.stderr)
+    if path_proof is None:
+        print(
+            "[lattice-metal] LATTICE_METAL_PATH_PROOF marker missing or malformed "
+            "— failing closed (never skip-as-green)",
+            file=sys.stderr,
+        )
+        print(result.stderr, file=sys.stderr)
+        return None
+    if not path_proof_covers_required_path(path_proof):
+        print(
+            f"[lattice-metal] path-proof counters do not cover the required Metal "
+            f"attention/KV-cache dispatch path: {path_proof}",
+            file=sys.stderr,
+        )
+        return None
+
+    print(f"[lattice-metal] path-proof OK: {path_proof}", file=sys.stderr)
+
+    return {
+        "generated_ids": gen_ids,
+        "text": "".join(text_parts),
+        "elapsed_s": elapsed,
+        "tok_per_sec": tok_per_sec,
+    }
+
+
 def compare(prompt: str, hf: dict, lattice: dict, match_window: int) -> dict:
     """Compare HF vs lattice outputs. Returns verdict dict."""
     hf_ids = hf["generated_ids"][:MAX_TOKENS]
@@ -349,6 +526,28 @@ def render_report(results: list[dict]) -> str:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backend",
+        choices=["cpu", "metal"],
+        default="cpu",
+        help=(
+            "cpu (default): qwen35_generate, legacy text parsing. "
+            "metal: chat_metal --json, fail-closed on the LATTICE_METAL_PATH_PROOF "
+            "capability marker (issue #239)."
+        ),
+    )
+    args = parser.parse_args()
+    backend = args.backend
+
+    global LATTICE_BIN
+    if not _LATTICE_BIN_EXPLICIT:
+        LATTICE_BIN = (
+            "target/release/chat_metal"
+            if backend == "metal"
+            else "target/release/qwen35_generate"
+        )
+
     if not os.path.isfile(LATTICE_BIN):
         print(f"error: lattice binary not found at {LATTICE_BIN}", file=sys.stderr)
         return 2
@@ -371,8 +570,12 @@ def main() -> int:
         print("[hf] running reference...", file=sys.stderr)
         hf_out = run_hf_reference(prompt, MAX_TOKENS)
 
-        print("[lattice] running under test...", file=sys.stderr)
-        lat_out = run_lattice(prompt, MAX_TOKENS)
+        print(f"[lattice-{backend}] running under test...", file=sys.stderr)
+        lat_out = (
+            run_lattice_metal(prompt, MAX_TOKENS)
+            if backend == "metal"
+            else run_lattice(prompt, MAX_TOKENS)
+        )
 
         if lat_out is None:
             print("FAIL: lattice binary failed", file=sys.stderr)


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What this does

Adds a new **non-required, informational** `metal-parity` job to `.github/workflows/e2e-parity.yml`, alongside the existing required CPU `parity` job. It builds `chat_metal` with `--features f16,metal-gpu` and runs the same HF-transformers-vs-lattice greedy-token comparison used by the CPU gate, but through the Metal attention/KV-cache dispatch path instead of the CPU path.

The core problem this closes: today's e2e parity only ever builds `qwen35_generate` (CPU path), so `MetalQwen35State`, `decode_attention`, `prefill_attention_batched_causal`, and the Metal KV-cache are entirely invisible to CI — a paravirtual `macos-latest` runner could report a Metal device while a broken or silently no-op'd kernel goes completely unnoticed.

Fail-closed design (no skip-as-green possible):
- `scripts/e2e_parity_check.py` gains `--backend {cpu,metal}`. `--backend metal` runs `chat_metal --json` and requires a `[METAL_PATH_PROOF]` stderr marker (dispatch-site `AtomicU64` counters, opt-in via `LATTICE_METAL_PATH_PROOF=1`, zero cost otherwise) proving the prefill KV-batch write, prefill batched attention, decode KV-copy, and one of the two decode-attention paths (direct or split-partial+reduce) actually dispatched.
- A missing/malformed marker, or any required counter at zero, is treated as a **gate failure**, never a skip. This is what protects against a paravirtual runner that reports Metal capability but no-ops the kernels.
- `parity-gate.needs` is unchanged (`[changes, parity, embed-drift]`) — `metal-parity` is not referenced anywhere in the required aggregator, so it cannot block merges regardless of outcome. No `continue-on-error` is used anywhere; a real failure is red, not muted.
- `crates/inference/src/forward/metal_qwen35.rs` adds the six dispatch counters (`prefill_kv_batch`, `prefill_attn_batched`, `decode_kv_copy`, `decode_attn_direct`, `decode_attn_split_partial`, `decode_attn_split_reduce`) at the true dispatch call sites, `Ordering::Relaxed` `AtomicU64`s on `MetalQwen35State`, reset/snapshot per generation.
- `crates/inference/src/bin/chat_metal.rs` reports the counters via a `[METAL_PATH_PROOF]` stderr line, gated entirely behind `LATTICE_METAL_PATH_PROOF` so normal (Lattice Studio) runs pay zero per-token cost.

Two small script fixes included:
- `LATTICE_BIN`'s default now derives from `--backend` (`chat_metal` for metal, `qwen35_generate` for cpu) instead of always defaulting to the CPU binary; an explicit `LATTICE_BIN` env var still always wins. Previously a local `--backend metal` run without exporting `LATTICE_BIN` would silently invoke the wrong binary.
- `run_lattice_metal`'s subprocess call now catches `subprocess.TimeoutExpired` and reports a clean `[lattice-metal] FAILED (timeout)` instead of an uncaught traceback (still fails closed either way).

## Mutation evidence (full `--backend metal` runs, pinned `torch==2.12.1`/`transformers==5.12.1`)

Command used for all three runs:

```bash
LATTICE_BIN=target/release/chat_metal LATTICE_METAL_PATH_PROOF=1 E2E_MAX_TOKENS=4 \
  python3 scripts/e2e_parity_check.py --backend metal
```

**Note on a pre-existing, independently-tracked gap:** one of the four e2e-parity prompts (the ~816-token `merge_sort` long-prefill prompt added in #228) fails on unmodified `main` today, unrelated to this PR — confirmed by running the existing CPU `--backend cpu` path on the same commit before any mutation, which shows the identical `FAIL: 1/4` with the identical divergence (`merge_sort(arr):` -> `main():`). This is tracked as issue #520 (open since 2026-07-01; 20+ prior `main` CI runs have shown the same 1/4 failure since 2026-06-24). This PR's diff does not touch the chunked-prefill logic responsible, so the Metal leg simply inherits the same pre-existing gap the required CPU `parity` job already has. The mutation-proof signal below is the *differential* (1/4 -> 4/4 on mutation, reverting back to 1/4), not the raw exit code, since a bare `exit=0` is unreachable until #520 is fixed separately.

**Run 1 — clean (unmutated `acc[qi] / dn`):**
```
[lattice-metal] path-proof OK: {'prefill_kv_batch': 6, 'prefill_attn_batched': 6, 'decode_kv_copy': 36, 'decode_attn_direct': 18, 'decode_attn_split_partial': 0, 'decode_attn_split_reduce': 0, 'kv_f16': False}
[PASS] agree=3/4 ...   # "The capital of France is"
[PASS] agree=4/4 ...   # "In the year 2024, artificial intelligence"
[PASS] agree=4/4 ...   # "def fibonacci(n): ..."
[lattice-metal] path-proof OK: {'prefill_kv_batch': 12, 'prefill_attn_batched': 12, 'decode_kv_copy': 36, 'decode_attn_direct': 0, 'decode_attn_split_partial': 18, 'decode_attn_split_reduce': 18, 'kv_f16': False}
[FAIL] agree=0/4 ...   # "def merge_sort(arr): ..." (pre-existing #520, split-decode path)

FAIL: 1/4 prompts failed parity gate
```
`echo $?` -> **`exit=1`** (verified locally with `set -o pipefail`). **Correction (post-review):** the parenthetical originally here claimed "CI's default bash already runs with `-o pipefail`" — that is wrong. GitHub Actions' unspecified `run:` shell is `bash -e {0}`, which does **not** set `pipefail`; only an explicit `shell: bash` step adds `-o pipefail`. The CI step this evidence was gathered for has since been fixed to not pipe through `tee` at all (see "Remediation" below), so the job's exit code is the script's own, with no shell-default assumption required.

**Run 2 — mutated (`crates/inference/src/forward/metal_qwen35.rs:2666`, `acc[qi] / dn` -> `acc[qi] * dn`):**
```
[lattice-metal] path-proof OK: {'prefill_kv_batch': 6, 'prefill_attn_batched': 6, 'decode_kv_copy': 36, 'decode_attn_direct': 18, 'decode_attn_split_partial': 0, 'decode_attn_split_reduce': 0, 'kv_f16': False}
[FAIL] agree=0/4 ...   # HF: " Paris.\nThe" / Lattice: " the only one that"
[FAIL] agree=0/4 ...   # HF: " (AI) has" / Lattice: " 1.0"
[FAIL] agree=0/4 ...   # HF: " fibonacci(n-1" / Lattice: "rietn = "
[lattice-metal] path-proof OK: {'prefill_kv_batch': 12, 'prefill_attn_batched': 12, 'decode_kv_copy': 36, 'decode_attn_direct': 0, 'decode_attn_split_partial': 18, 'decode_attn_split_reduce': 18, 'kv_f16': False}
[FAIL] agree=0/4 ...   # HF: " merge_sort(arr):" / Lattice: " undo the world with"

FAIL: 4/4 prompts failed parity gate
```
`echo $?` -> **`exit=1`**. Path-proof counters are identical in shape to the clean run (same nonzero values, same direct-vs-split decode selection per prompt) — proving the mutation caused a **numeric divergence, not a dispatch skip**. All three previously-clean prompts now fail alongside the pre-existing long-prompt failure.

**Run 3 — reverted (`acc[qi] * dn` -> `acc[qi] / dn`, via `Edit` reverse-apply, never `git checkout`):**
```
[lattice-metal] path-proof OK: {'prefill_kv_batch': 6, 'prefill_attn_batched': 6, 'decode_kv_copy': 36, 'decode_attn_direct': 18, 'decode_attn_split_partial': 0, 'decode_attn_split_reduce': 0, 'kv_f16': False}
[PASS] agree=3/4 ...   # "The capital of France is"
[PASS] agree=4/4 ...   # "In the year 2024, artificial intelligence"
[PASS] agree=4/4 ...   # "def fibonacci(n): ..."
[lattice-metal] path-proof OK: {'prefill_kv_batch': 12, 'prefill_attn_batched': 12, 'decode_kv_copy': 36, 'decode_attn_direct': 0, 'decode_attn_split_partial': 18, 'decode_attn_split_reduce': 18, 'kv_f16': False}
[FAIL] agree=0/4 ...   # "def merge_sort(arr): ..." (pre-existing #520, unchanged)

FAIL: 1/4 prompts failed parity gate
```
`echo $?` -> **`exit=1`**, bit-identical to Run 1's per-prompt agreement pattern — confirms revert restored exact clean state, and the pre-existing #520 failure is deterministic, not flaky. A follow-up re-check after the `LATTICE_BIN` default fix (run without setting `LATTICE_BIN` explicitly, to exercise the new backend-derived default) reproduced the identical 3-PASS/1-known-FAIL pattern, confirming the script fix is orthogonal to the comparison logic.

| Run | Mutation state | Exit | Prompts failing | Path-proof counters |
|---|---|---|---|---|
| 1 (clean) | unmutated | 1 | 1/4 (pre-existing #520 only) | nonzero, required path covered |
| 2 (mutated) | `* dn` | 1 | 4/4 (all, incl. 3 previously-clean) | nonzero, required path covered (dispatch ran; numbers wrong) |
| 3 (reverted) | unmutated (restored) | 1 | 1/4 (pre-existing #520 only, bit-identical to run 1) | nonzero, required path covered |

## Honest limits

- **`runs-on: macos-latest` is a deliberate paravirtual-runner assumption.** The audited attention/KV dispatch paths are not Apple-family-gated (only the optional tiled-GEMM path is), so the hosted paravirtual Metal device is expected to exercise them for real. If a future CI run proves the hosted runner silently no-ops these kernels, the fallback is `runs-on: [self-hosted, macOS, ARM64, metal]` — this requires runner administration and reduces reproducibility for outside contributors, so it is not the first choice.
- KV-cache precision: this leg uses the default `kv_f16=false` KV cache, covering the Metal KV-cache path with the fewest numeric-parity variables. A stronger follow-up (`LATTICE_KV_F16=1`) would cover f16 KV kernels too but has a higher chance of first-N token drift and should be a separate informational leg pending maintainer approval.
- The long-prefill prompt's pre-existing failure (issue #520) is out of scope for this PR and will continue to show as `FAIL: 1/4` on the new Metal leg until #520 is independently fixed — this is expected and matches the required CPU `parity` job's current (also-failing) state on the same prompt.
- The make-required promotion decision for `metal-parity` remains open and pending a maintainer decision; this PR only adds the informational leg.

## Remediation (rebase + review fixes)

Rebased onto current `main` (picked up #516 cross-turn KV cache and #527/#528's `e2e-parity.yml` rewrite) and addressed three review findings:

- **Blocker — tee-pipe fail-open.** The `metal-parity` step ran `python3 scripts/e2e_parity_check.py --backend metal | tee metal-parity-report.md` under GitHub Actions' default `run:` shell (`bash -e {0}`, no `pipefail`), so a checker failure could be masked by `tee`'s own zero exit. Fixed to match the now-canonical pattern used by the required `parity` job on `main`: no pipe, `E2E_REPORT_PATH: metal-parity-report.md` as a step env var, and the script writes its own report. Also corrected the wrong "GitHub Actions default shell has pipefail" claim in the mutation-evidence note above.
- **Major — unconditional hot-path atomics.** The six dispatch-site counters (`prefill_kv_batch`, `prefill_attn_batched`, `decode_kv_copy`, `decode_attn_direct`, `decode_attn_split_partial`, `decode_attn_split_reduce`) were incrementing on every decode/prefill dispatch regardless of `LATTICE_METAL_PATH_PROOF`, contradicting the "zero cost when unset" claim — only the reset/snapshot/stderr-emission in `chat_metal.rs` was gated, not the counting itself. Added a `path_proof_enabled: bool` field on `MetalQwen35State` (read once from `LATTICE_METAL_PATH_PROOF` at construction time, same pattern as the existing `use_kv_f16` flag) and gated every `fetch_add` call site behind it. Disabled-mode cost is now genuinely zero (no atomic op at all, not just a cheap one); enabled-mode cost is unmeasured in this session — no percentage is claimed.
- **Minor — PR description attribution line** corrected from "PR authored by..." to "PR description authored by...".

`cargo fmt --check` and `cargo clippy --workspace --features "f16,metal-gpu" -- -D warnings` pass clean post-rebase. YAML re-validated with `python3 -c "import yaml; yaml.safe_load(...)"` (OK).

`cargo test -p lattice-inference --features "f16,metal-gpu"`: 1459 passed, **2 failed**, 9 ignored. Both failures (`forward::metal_qwen35::inner::tests::gdn_chunked_prefill_vs_serial_prefill_logit_parity`, `forward::metal_qwen35::inner::tests::metal_qwen35_prefill_all_logits_long_prompt_no_longer_panics`) are **pre-existing on `main`, not introduced by this PR** — confirmed by running the identical two tests in an isolated worktree checked out at the pre-rebase `main` tip (`711abe7af`, i.e. after #516/#527/#528, before this branch's rebase): both fail there too, with the same GDN-chunked-prefill-vs-serial and all-logits-vs-step-loop divergence signature (magnitudes vary run-to-run, consistent with known float nondeterminism in the GDN chunked-prefill path; argmax still agrees in the second test). This PR's diff to `metal_qwen35.rs` is scoped entirely to wrapping the six `fetch_add` counter calls in `if self.path_proof_enabled { }` — it does not touch GDN chunked-prefill or all-logits computation, so it cannot be the cause. These two failures track back to PR #516's own commit message, which states the token-identity/GDN work was "INCOMPLETE / UNVERIFIED." Not fixed here — out of scope for a CI-instrumentation PR — but flagged so the pre-existing gap is visible rather than silently inherited.

`make bench-compare` was not run for this PR: its default groups (`elementwise_cpu_bench` for inference, `simd` for embed) are CPU-only Criterion benches that do not exercise the `#[cfg(all(target_os = "macos", feature = "metal-gpu"))]` code path this PR's Major fix touches, so a bench-compare run would not actually measure the change. The Major-fix change (gating 6 `fetch_add` calls behind a bool check) is a well-understood zero-cost-when-disabled pattern already used elsewhere in this file (`use_kv_f16`); no throughput number is claimed for enabled-mode cost since it was not benchmarked this session.

Refs #239


---

### First live run of the metal leg (ed621e9a5 update)

The informational metal job's first CI run (@45c1f6f46) returned **FAIL 1/4** — and the failure is genuine signal, not noise:

- 3/4 prompts matched HF exactly on the Metal backend, with the path-proof marker confirming the real prefill/decode Metal kernels ran (no vacuous pass).
- The ~816-token long-prefill `merge_sort` prompt diverged at position 0 (HF/CPU: `merge_sort(arr):`, Metal: `main():`). Differential triage on a real M-series GPU excluded both harness suspects: it reproduces with `--repetition-penalty 1.0` forced AND with `LATTICE_GDN_CHUNKED=0` (serial GDN prefill). That makes it a real Metal long-prefill engine divergence, now tracked as **#535** (revives #228's original question, which CI could never exercise before this job existed).
- One real harness gap WAS found and fixed in ed621e9a5: `run_lattice_metal` omitted the `--repetition-penalty 1.0` that the CPU path forces (chat_metal's serving default is 1.1). Fixed so the metal leg's verdict reflects only engine divergence. This does not fix #535 — verified empirically.

A red informational leg with a filed engine issue is this job working as designed (per the phased-legs decision: legs are non-required signal until the promotion review). The required `parity-gate` is green and byte-identical to `main`.
