### PR TITLE
docs: add fail-closed CI and test-triage guidance, fix publish order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,13 @@ PRs touching `crates/inference/src/` or `crates/embed/src/` trigger `e2e-parity.
 
 The `perf-baselines` branch is still updated by `bench-update.yml` on merge to main for trend tracking.
 
+### CI Authoring Rules (fail-closed)
+
+- Never pipe a gating command's output (`script | tee log`): the pipe's exit status masks the script's, and the gate silently passes on failure. Write reports to a file the step uploads (for example via an env-var path) and let the command's own exit code gate.
+- A gate must prove it exercised the real path. If the code under test can silently fall back (feature gate off, capability missing, GPU unavailable), assert on an explicit marker emitted by the exercised path and fail when it is absent. A skipped gate must read as red, not green.
+- Budget required-job timeouts for the runner pool's slow tail, not the median run. A deterministic timeout-cancel on a correct job is a false red that trains people to ignore the gate.
+- Informational (non-required) legs may be red. A red informational leg means "file the engine issue it found", not "block the merge" and not "delete the leg".
+
 ## Commands
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,9 +92,11 @@ fn similarity(query: &[f32], docs: &[Vec<f32>]) -> Vec<f32> {
 ## Crate Structure
 
 ```
-inference (~118K)  fann (7.7K)  transport (5.4K)   ← leaf, zero internal deps
-    |                |
-  embed (12K)    tune (20K)                       ← depend on leaves only
+fann (7.7K)   transport (5.4K)                    ← leaf, zero internal deps
+    |
+inference (~118K)                                 ← optional dep on fann (`mixture` feature)
+    |
+embed (12K)   tune (20K)                          ← embed uses inference; tune uses fann + inference
 ```
 
 ### lattice-inference — Transformer kernel
@@ -235,7 +237,7 @@ make ci              # full local CI (fmt + clippy + deno lint + test + build)
 make fmt             # cargo fmt + deno fmt on markdown
 make lint-docs       # deno doc lint only
 make publish-dry     # verify crates.io packaging
-make publish         # publish (leaf crates first, sleeps for indexing)
+make publish         # publish (dependency order, sleeps for indexing)
 
 # E2E parity (HF reference vs lattice)
 make e2e-parity                          # run locally (needs torch + transformers)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ PRs touching `crates/inference/src/` or `crates/embed/src/` trigger `e2e-parity.
 
 ## Crate Ownership
 
-Changes to `inference` affect `embed` and `tune`. Changes to `fann` affect `tune`. Changes to `transport`, `fann`, or `inference` alone are safe — they're leaf crates.
+Changes to `inference` affect `embed` and `tune`. Changes to `fann` affect `inference` (via the optional `mixture` feature) and `tune`. Only `fann` and `transport` are leaf crates; `transport` has no internal dependents (`embed` uses it in dev-tests only).
 
 ## Publishing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,22 @@ If the gap you're investigating exceeds these bounds, the cause is structural (a
 
 **Be skeptical of comments that paraphrase config fields.** A comment that says "X uses field=true" without explaining what the field actually controls in the reference implementation is a footgun. The lattice RoPE comment said "Qwen3.5 uses mrope_interleaved=true" — technically matched config, but `mrope_interleaved` controls multimodal M-RoPE section interleaving (video/image tokens), not 1-D text RoPE pairing. The bug existed for months because nobody verified the comment against HF's `rotate_half` or MLX's `nn.RoPE`.
 
+### Triage Flaky vs Deterministic Before Filing
+
+When a test fails intermittently or fails alongside unrelated work, run the discriminating experiment before writing the issue: ONE test, solo, `--test-threads=1`, idle GPU, exact main SHA. Concurrent GPU load corrupts both timing and numerics, so a "pre-existing failure on main" verified while other GPU work runs is not verified at all.
+
+This split a two-test failure report cleanly: one test failed deterministically at every prompt length under solo idle-GPU conditions (real chunk-boundary accumulation drift, its own issue), while the other passed solo in 65 seconds (a load flake, a different issue). Filing them as one regression would have sent the fix to the wrong place.
+
+### Regression Tests Must Be Mutation-Sensitive
+
+A regression test that passes with the fix reverted is decoration. Before claiming a test guards a fix: revert the fix (reverse-apply the diff — never `git checkout` over uncommitted work), `touch` the source file so cargo actually rebuilds, and watch the test fail. Then restore the fix and watch it pass.
+
+### Grep for Sibling Invocation Paths
+
+When a harness or guard fix lands in one invocation path, grep the same file for sibling paths that construct the same operation independently: a second subprocess command builder, a second workflow step calling the same script, a reimplementation of a guarded method. Any fix expressible as "add flag X to the call" has an unguarded copy-paste sibling until proven otherwise, and the fix's own description ("mirror the CPU path") is the grep query.
+
+This class recurred three times in one week before becoming a rule — most recently a greedy-decoding sampler flag added to the CPU parity harness path while the Metal-path command builder in the same file went without it, surfacing only on that leg's first live CI run.
+
 ### E2E Parity Gate
 
 PRs touching `crates/inference/src/` or `crates/embed/src/` trigger `e2e-parity.yml`. It runs HF transformers (reference) and lattice on the same macOS runner, comparing greedy generation output. The reference runs first to warm the machine.

--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ PPL benchmark (wikitext-2, from `docs/bench_results/perplexity.tsv`): Lattice q4
 | [`lattice-tune`](crates/tune/)           | Training: knowledge distillation pipeline, dataset management, LoRA adapter management, model registry                                                                | [![](https://img.shields.io/crates/v/lattice-tune.svg)](https://crates.io/crates/lattice-tune)           |
 | [`lattice-transport`](crates/transport/) | Optimal transport: Sinkhorn-Knopp (balanced + unbalanced), Wasserstein barycenters, embedding drift detection                                                         | [![](https://img.shields.io/crates/v/lattice-transport.svg)](https://crates.io/crates/lattice-transport) |
 
-The three leaf crates (`inference`, `fann`, `transport`) have zero intra-workspace dependencies
-and can be used standalone.
+Two leaf crates (`fann`, `transport`) have zero intra-workspace dependencies. `inference` is
+standalone by default and pulls in `fann` only when the optional `mixture` feature is enabled.
+All three can be used on their own.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,24 +30,24 @@ library from a single window.
 
 ## Capabilities
 
-| | |
-|---|---|
-| Pure Rust compute | Hand-written SIMD kernels (AVX2/NEON). No C++, no ONNX, no CUDA. |
-| Metal GPU backend | Native Apple Silicon acceleration via Metal MSL shaders. WGPU fallback for cross-platform. |
-| Generation models | Qwen3.5-0.8B / 2B, Qwen3.6-35B-A3B (MoE), Qwen3.6-27B. Hybrid GatedDeltaNet + GQA architecture. |
-| Embedding models | 9 models: BGE, E5, MiniLM, Qwen3-Embedding families. Auto-download for 7 BERT-family variants. |
-| Three tokenizers | WordPiece, SentencePiece, BPE. No Hugging Face tokenizers C extension. |
-| Quantization | Q8, Q4, and QuaRot (rotation-based 4-bit). No other engine runs Q4 + LoRA hot-swap on Qwen3.5. |
-| LoRA | Inference hook, hot-swap with no reload, PEFT safetensors format, training via `lattice-tune`. |
-| HTTP API | OpenAI-compatible `/v1/chat/completions` via `lattice serve`. |
-| Safetensors native | Memory-mapped weight loading. Single-file and sharded checkpoints. |
-| KV cache | Incremental decoding with key-value caching. |
-| Speculative decoding | Draft-model acceleration on the CPU path. |
-| Grammar decoding | Constrained output via a pushdown automaton. OpenAI string-level stop sequences. |
-| MRL support | Matryoshka truncation for Qwen3-Embedding models (output dimension >= 32). |
-| LRU cache | `CachedEmbeddingService` with sharded in-memory cache and hit/miss stats. |
-| Knowledge distillation | Train small models from Claude/GPT/Gemini teacher soft labels via `lattice-tune`. |
-| Optimal transport | Sinkhorn-Knopp solver for embedding drift detection via `lattice-transport`. |
+|                        |                                                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------------------------- |
+| Pure Rust compute      | Hand-written SIMD kernels (AVX2/NEON). No C++, no ONNX, no CUDA.                                |
+| Metal GPU backend      | Native Apple Silicon acceleration via Metal MSL shaders. WGPU fallback for cross-platform.      |
+| Generation models      | Qwen3.5-0.8B / 2B, Qwen3.6-35B-A3B (MoE), Qwen3.6-27B. Hybrid GatedDeltaNet + GQA architecture. |
+| Embedding models       | 9 models: BGE, E5, MiniLM, Qwen3-Embedding families. Auto-download for 7 BERT-family variants.  |
+| Three tokenizers       | WordPiece, SentencePiece, BPE. No Hugging Face tokenizers C extension.                          |
+| Quantization           | Q8, Q4, and QuaRot (rotation-based 4-bit). No other engine runs Q4 + LoRA hot-swap on Qwen3.5.  |
+| LoRA                   | Inference hook, hot-swap with no reload, PEFT safetensors format, training via `lattice-tune`.  |
+| HTTP API               | OpenAI-compatible `/v1/chat/completions` via `lattice serve`.                                   |
+| Safetensors native     | Memory-mapped weight loading. Single-file and sharded checkpoints.                              |
+| KV cache               | Incremental decoding with key-value caching.                                                    |
+| Speculative decoding   | Draft-model acceleration on the CPU path.                                                       |
+| Grammar decoding       | Constrained output via a pushdown automaton. OpenAI string-level stop sequences.                |
+| MRL support            | Matryoshka truncation for Qwen3-Embedding models (output dimension >= 32).                      |
+| LRU cache              | `CachedEmbeddingService` with sharded in-memory cache and hit/miss stats.                       |
+| Knowledge distillation | Train small models from Claude/GPT/Gemini teacher soft labels via `lattice-tune`.               |
+| Optimal transport      | Sinkhorn-Knopp solver for embedding drift detection via `lattice-transport`.                    |
 
 ---
 
@@ -63,7 +63,7 @@ speed you observe in an interactive chat is lower than these numbers, because it
 prefill of the whole prompt (see "Why throughput falls with context" below).
 
 | Context | Lattice (Q8, f16 head) | Ollama (Q8_0) | MLX (Q8 g64, AMX) | Lattice vs Ollama |
-|---------|------------------------|---------------|-------------------|-------------------|
+| ------- | ---------------------- | ------------- | ----------------- | ----------------- |
 | 64 tok  | **187 tok/s**          | 93            | 265               | 2.0x              |
 | 128 tok | **171 tok/s**          | 92            | 263               | 1.9x              |
 | 256 tok | **146 tok/s**          | 88            | 260               | 1.6x              |
@@ -90,11 +90,11 @@ the same tier as Ollama. MLX decodes faster than Lattice at raw throughput. Latt
 portability (pure Rust, zero Python, zero framework) plus capabilities neither Ollama nor MLX
 provide for this model family:
 
-| Capability | Lattice | MLX | Ollama |
-|---|---|---|---|
-| QuaRot 4-bit (rotation-based quant) | yes | no | no |
-| Q4 + LoRA hot-swap (no reload) | yes | no | no |
-| Pure Rust, zero Python or framework | yes | no | no |
+| Capability                          | Lattice | MLX | Ollama |
+| ----------------------------------- | ------- | --- | ------ |
+| QuaRot 4-bit (rotation-based quant) | yes     | no  | no     |
+| Q4 + LoRA hot-swap (no reload)      | yes     | no  | no     |
+| Pure Rust, zero Python or framework | yes     | no  | no     |
 
 PPL benchmark (wikitext-2, from `docs/bench_results/perplexity.tsv`): Lattice q4 19.27, q4-QuaRot 19.95 (2048 tokens); MLX q8 15.82, q4 18.18 (2041 tokens). Reproduce:
 `./scripts/bench_context_scaling.sh`
@@ -103,13 +103,13 @@ PPL benchmark (wikitext-2, from `docs/bench_results/perplexity.tsv`): Lattice q4
 
 ## Crates
 
-| Crate | Description | crates.io |
-|-------|-------------|-----------|
-| [`lattice-embed`](crates/embed/) | Embedding service: `EmbeddingService` trait, `NativeEmbeddingService`, `CachedEmbeddingService`, SIMD cosine/dot/euclidean, backfill | [![](https://img.shields.io/crates/v/lattice-embed.svg)](https://crates.io/crates/lattice-embed) |
+| Crate                                    | Description                                                                                                                                                           | crates.io                                                                                                |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [`lattice-embed`](crates/embed/)         | Embedding service: `EmbeddingService` trait, `NativeEmbeddingService`, `CachedEmbeddingService`, SIMD cosine/dot/euclidean, backfill                                  | [![](https://img.shields.io/crates/v/lattice-embed.svg)](https://crates.io/crates/lattice-embed)         |
 | [`lattice-inference`](crates/inference/) | Transformer kernel: safetensors loading, BERT/BGE/Qwen3 forward pass, three tokenizers, Metal/WGPU backends, LoRA hooks, KV cache, speculative decoding, quantization | [![](https://img.shields.io/crates/v/lattice-inference.svg)](https://crates.io/crates/lattice-inference) |
-| [`lattice-fann`](crates/fann/) | Fast neural network primitives: `NetworkBuilder`, pre-allocated layers, zero-alloc forward pass, backprop trainer | [![](https://img.shields.io/crates/v/lattice-fann.svg)](https://crates.io/crates/lattice-fann) |
-| [`lattice-tune`](crates/tune/) | Training: knowledge distillation pipeline, dataset management, LoRA adapter management, model registry | [![](https://img.shields.io/crates/v/lattice-tune.svg)](https://crates.io/crates/lattice-tune) |
-| [`lattice-transport`](crates/transport/) | Optimal transport: Sinkhorn-Knopp (balanced + unbalanced), Wasserstein barycenters, embedding drift detection | [![](https://img.shields.io/crates/v/lattice-transport.svg)](https://crates.io/crates/lattice-transport) |
+| [`lattice-fann`](crates/fann/)           | Fast neural network primitives: `NetworkBuilder`, pre-allocated layers, zero-alloc forward pass, backprop trainer                                                     | [![](https://img.shields.io/crates/v/lattice-fann.svg)](https://crates.io/crates/lattice-fann)           |
+| [`lattice-tune`](crates/tune/)           | Training: knowledge distillation pipeline, dataset management, LoRA adapter management, model registry                                                                | [![](https://img.shields.io/crates/v/lattice-tune.svg)](https://crates.io/crates/lattice-tune)           |
+| [`lattice-transport`](crates/transport/) | Optimal transport: Sinkhorn-Knopp (balanced + unbalanced), Wasserstein barycenters, embedding drift detection                                                         | [![](https://img.shields.io/crates/v/lattice-transport.svg)](https://crates.io/crates/lattice-transport) |
 
 The three leaf crates (`inference`, `fann`, `transport`) have zero intra-workspace dependencies
 and can be used standalone.
@@ -287,17 +287,17 @@ The command bar (cmd-K) runs everything from a single keyboard shortcut:
 
 ### Embedding models
 
-| Variant | HuggingFace ID | Dims | Max tokens | Auto-download |
-|---------|---------------|------|-----------|---------------|
-| `BgeSmallEnV15` | `BAAI/bge-small-en-v1.5` | 384 | 512 | yes |
-| `BgeBaseEnV15` | `BAAI/bge-base-en-v1.5` | 768 | 512 | yes |
-| `BgeLargeEnV15` | `BAAI/bge-large-en-v1.5` | 1024 | 512 | yes |
-| `MultilingualE5Small` | `intfloat/multilingual-e5-small` | 384 | 512 | yes |
-| `MultilingualE5Base` | `intfloat/multilingual-e5-base` | 768 | 512 | yes |
-| `AllMiniLmL6V2` | `sentence-transformers/all-MiniLM-L6-v2` | 384 | 256 | yes |
-| `ParaphraseMultilingualMiniLmL12V2` | `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` | 384 | 128 | yes |
-| `Qwen3Embedding0_6B` | `Qwen/Qwen3-Embedding-0.6B` | 1024 | 8192 | local dir only |
-| `Qwen3Embedding4B` | `Qwen/Qwen3-Embedding-4B` | 2560* | 8192 | local dir only |
+| Variant                             | HuggingFace ID                                                | Dims  | Max tokens | Auto-download  |
+| ----------------------------------- | ------------------------------------------------------------- | ----- | ---------- | -------------- |
+| `BgeSmallEnV15`                     | `BAAI/bge-small-en-v1.5`                                      | 384   | 512        | yes            |
+| `BgeBaseEnV15`                      | `BAAI/bge-base-en-v1.5`                                       | 768   | 512        | yes            |
+| `BgeLargeEnV15`                     | `BAAI/bge-large-en-v1.5`                                      | 1024  | 512        | yes            |
+| `MultilingualE5Small`               | `intfloat/multilingual-e5-small`                              | 384   | 512        | yes            |
+| `MultilingualE5Base`                | `intfloat/multilingual-e5-base`                               | 768   | 512        | yes            |
+| `AllMiniLmL6V2`                     | `sentence-transformers/all-MiniLM-L6-v2`                      | 384   | 256        | yes            |
+| `ParaphraseMultilingualMiniLmL12V2` | `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` | 384   | 128        | yes            |
+| `Qwen3Embedding0_6B`                | `Qwen/Qwen3-Embedding-0.6B`                                   | 1024  | 8192       | local dir only |
+| `Qwen3Embedding4B`                  | `Qwen/Qwen3-Embedding-4B`                                     | 2560* | 8192       | local dir only |
 
 *Qwen3-Embedding-4B and 0.6B support MRL truncation to any dimension >= 32.
 BGE v1.5 uses CLS pooling. E5 and MiniLM use mean pooling.
@@ -305,12 +305,12 @@ E5 `embed_passage()` applies the `"passage: "` prefix automatically.
 
 ### Generation models (local files required)
 
-| Config preset | Description |
-|---------------|-------------|
-| `Qwen35Config::qwen35_0_8b` | 24 layers, 1024 hidden, 1 MTP layer. Base decode shipped; MTP experimental. |
-| `Qwen35Config::qwen35_2b` | 24 layers, 2048 hidden, dense FFN, tied embeddings. |
-| `Qwen35Config::qwen36_35b_a3b` | 40 layers, MoE 256 experts top-8. Config and weight loader supported. |
-| `Qwen35Config::qwen36_27b` | 64 layers, 5120 hidden, dense FFN. |
+| Config preset                  | Description                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------- |
+| `Qwen35Config::qwen35_0_8b`    | 24 layers, 1024 hidden, 1 MTP layer. Base decode shipped; MTP experimental. |
+| `Qwen35Config::qwen35_2b`      | 24 layers, 2048 hidden, dense FFN, tied embeddings.                         |
+| `Qwen35Config::qwen36_35b_a3b` | 40 layers, MoE 256 experts top-8. Config and weight loader supported.       |
+| `Qwen35Config::qwen36_27b`     | 64 layers, 5120 hidden, dense FFN.                                          |
 
 The Qwen3.5 architecture uses a hybrid of 18 GatedDeltaNet layers and 6 GQA attention layers.
 Lattice is the only open-source engine that correctly runs this hybrid recurrence at Q4 on Apple Silicon.
@@ -364,10 +364,10 @@ let sims = utils::batch_cosine_similarity(&pairs);
 
 Measured performance on normalized vectors (internal benchmarks, subject to hardware):
 
-| Operation | Scalar | SIMD |
-|-----------|--------|------|
-| cosine similarity (384-dim) | ~650 ns | ~90 ns |
-| cosine similarity (768-dim) | ~1300 ns | ~180 ns |
+| Operation                    | Scalar   | SIMD    |
+| ---------------------------- | -------- | ------- |
+| cosine similarity (384-dim)  | ~650 ns  | ~90 ns  |
+| cosine similarity (768-dim)  | ~1300 ns | ~180 ns |
 | cosine similarity (1024-dim) | ~1700 ns | ~240 ns |
 
 ---
@@ -376,21 +376,21 @@ Measured performance on normalized vectors (internal benchmarks, subject to hard
 
 ### lattice-embed
 
-| Feature | Default | Description |
-|---------|---------|-------------|
-| `native` | yes | Pure Rust inference via `lattice-inference` |
-| `metal-gpu` | no | Metal GPU acceleration (macOS) |
-| `avx512` | no | AVX-512 SIMD kernels (requires nightly) |
+| Feature     | Default | Description                                 |
+| ----------- | ------- | ------------------------------------------- |
+| `native`    | yes     | Pure Rust inference via `lattice-inference` |
+| `metal-gpu` | no      | Metal GPU acceleration (macOS)              |
+| `avx512`    | no      | AVX-512 SIMD kernels (requires nightly)     |
 
 ### lattice-inference
 
-| Feature | Default | Description |
-|---------|---------|-------------|
-| `f16` | no | Half-precision weights |
-| `metal-gpu` | no | Metal compute backend |
-| `wgpu-gpu` | no | WGPU cross-platform GPU backend |
-| `download` | yes | HuggingFace weight download with checksum verification |
-| `backfill` | no | Re-embedding coordinator (requires `rusqlite`) |
+| Feature     | Default | Description                                            |
+| ----------- | ------- | ------------------------------------------------------ |
+| `f16`       | no      | Half-precision weights                                 |
+| `metal-gpu` | no      | Metal compute backend                                  |
+| `wgpu-gpu`  | no      | WGPU cross-platform GPU backend                        |
+| `download`  | yes     | HuggingFace weight download with checksum verification |
+| `backfill`  | no      | Re-embedding coordinator (requires `rusqlite`)         |
 
 ---
 
@@ -453,8 +453,9 @@ on your target hardware for representative numbers.
 
 ## Publishing
 
-Leaf crates publish first: `inference` then `fann` then `transport` (wait 30s) then `embed`
-(wait 30s) then `tune`.
+Publish order follows the internal dependency DAG (dependencies before dependents): `fann` and
+`transport` (leaves), wait 30s, then `inference` (depends on `fann`), wait 30s, then `embed`
+and `tune`.
 
 ```bash
 make publish


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Docs-only. Promotes three process rules that earned their place through repeated incidents into the agent guidance docs, adds fail-closed CI authoring rules, and fixes one factual error in the README.

### CLAUDE.md — three new Development Process subsections

- **Triage Flaky vs Deterministic Before Filing**: the discriminating experiment is one test, solo, `--test-threads=1`, idle GPU, exact main SHA. Recently split a two-test failure report into one real deterministic divergence (#534) and one load flake (#533) — filing them together would have misdirected the fix.
- **Regression Tests Must Be Mutation-Sensitive**: revert the fix, `touch` the source so cargo rebuilds, watch the test fail, restore, watch it pass.
- **Grep for Sibling Invocation Paths**: a harness/guard fix landing in one invocation path leaves copy-paste siblings unguarded (third recurrence this week: `run_lattice` got the greedy-decoding `--repetition-penalty 1.0` fix in #528 while `run_lattice_metal` in the same file went without it until #529).

### AGENTS.md — CI Authoring Rules (fail-closed)

No exit-masking pipes on gating commands (#521 class), path-proof markers so silent fallbacks read as red (#529's approach), slow-tail timeout budgeting (#528's timeout lesson), and the informational-leg doctrine (red informational leg = file the engine issue, e.g. #535; not block, not delete).

### README

- Fix stale publish order: `inference` is no longer a leaf crate — it depends on `fann` via the `mixture` feature, so the correct DAG order is `fann`/`transport` → `inference` → `embed`/`tune` (matches CLAUDE.md and `make publish`).
- Normalize to `deno fmt` output (repo formatter; the reflow accounts for most of the README diff).

## Bench

Not applicable — no changes under `crates/`. bench-compare not run (docs only).

## Verification

- Pre-commit hook passed: fmt, clippy, deno doc lint (12 files).
- Diff swept for internal-tooling references: none.