### PR TITLE
fix(inference): bound IncrementalDetokenizer retention to the decode-boundary tail window (#324)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -14154,20 +14154,26 @@ kernel void gdn_chunk_norm_silu_c32(
                 reasoning_end_len = Some(generated_ids.len());
             }
             let mut last_pushed_id = next_id;
+            // `text` is the caller-owned full output — the detokenizer itself only
+            // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
+            let mut text = String::new();
             let delta = detok.push(tokenizer, next_id);
-            if !delta.is_empty() && !on_token(&delta, next_id) {
-                if use_compact {
-                    self.session.compact_topk = 0;
-                    self.session.compact_route = GpuTopkRoute::CpuFallback;
+            if !delta.is_empty() {
+                text.push_str(&delta);
+                if !on_token(&delta, next_id) {
+                    if use_compact {
+                        self.session.compact_topk = 0;
+                        self.session.compact_route = GpuTopkRoute::CpuFallback;
+                    }
+                    return GenerateOutput {
+                        text,
+                        token_ids: generated_ids.clone(),
+                        prompt_tokens: prompt_len,
+                        generated_tokens: generated_ids.len(),
+                        stopped: false, // caller interrupted the stream, not a stop condition
+                        stop_reason: Some(StopReason::Interrupt),
+                    };
                 }
-                return GenerateOutput {
-                    text: detok.text(),
-                    token_ids: generated_ids.clone(),
-                    prompt_tokens: prompt_len,
-                    generated_tokens: generated_ids.len(),
-                    stopped: false, // caller interrupted the stream, not a stop condition
-                    stop_reason: Some(StopReason::Interrupt),
-                };
             }
             let mut stopped = false;
             let mut stopped_by_caller = false;
@@ -14280,10 +14286,10 @@ kernel void gdn_chunk_norm_silu_c32(
                     // above. A late cancel here (return value intentionally unused)
                     // does not change why generation stopped, so treating it as
                     // Interrupt would misattribute the stop cause to this flush.
+                    text.push_str(&tail);
                     on_token(&tail, last_pushed_id);
                 }
             }
-            let text = detok.text();
             GenerateOutput {
                 text,
                 token_ids: generated_ids.clone(),
@@ -16191,29 +16197,35 @@ kernel void gdn_chunk_norm_silu_c32(
                 reasoning_end_len = Some(generated_ids.len());
             }
             let mut last_pushed_id = next_id;
+            // `text` is the caller-owned full output — the detokenizer itself only
+            // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
+            let mut text = String::new();
             let delta = detok.push(tokenizer, next_id);
-            if !delta.is_empty() && !on_token(&delta, next_id) {
-                if use_compact {
-                    self.session.compact_topk = 0;
-                    self.session.compact_route = GpuTopkRoute::CpuFallback;
+            if !delta.is_empty() {
+                text.push_str(&delta);
+                if !on_token(&delta, next_id) {
+                    if use_compact {
+                        self.session.compact_topk = 0;
+                        self.session.compact_route = GpuTopkRoute::CpuFallback;
+                    }
+                    // The caller cut the stream after exactly one forwarded
+                    // token (the prefill sample) — state represents prompt +
+                    // that one token already (forward happens on the *next*
+                    // iteration in the loop below, which never runs here).
+                    // Nothing further was forwarded, so do not save a cache
+                    // entry claiming more than live state represents.
+                    return Ok(CachedGenerateOutput {
+                        output: GenerateOutput {
+                            text,
+                            token_ids: generated_ids.clone(),
+                            prompt_tokens: prompt_len,
+                            generated_tokens: generated_ids.len(),
+                            stopped: false,
+                            stop_reason: Some(StopReason::Interrupt),
+                        },
+                        cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
+                    });
                 }
-                // The caller cut the stream after exactly one forwarded
-                // token (the prefill sample) — state represents prompt +
-                // that one token already (forward happens on the *next*
-                // iteration in the loop below, which never runs here).
-                // Nothing further was forwarded, so do not save a cache
-                // entry claiming more than live state represents.
-                return Ok(CachedGenerateOutput {
-                    output: GenerateOutput {
-                        text: detok.text(),
-                        token_ids: generated_ids.clone(),
-                        prompt_tokens: prompt_len,
-                        generated_tokens: generated_ids.len(),
-                        stopped: false,
-                        stop_reason: Some(StopReason::Interrupt),
-                    },
-                    cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
-                });
             }
             let mut stopped = false;
             let mut stopped_by_caller = false;
@@ -16279,10 +16291,13 @@ kernel void gdn_chunk_norm_silu_c32(
                 }
                 last_pushed_id = next_id;
                 let delta = detok.push(tokenizer, next_id);
-                if !delta.is_empty() && !on_token(&delta, next_id) {
-                    stopped_by_caller = true;
-                    stop_reason = StopReason::Interrupt;
-                    break;
+                if !delta.is_empty() {
+                    text.push_str(&delta);
+                    if !on_token(&delta, next_id) {
+                        stopped_by_caller = true;
+                        stop_reason = StopReason::Interrupt;
+                        break;
+                    }
                 }
                 if self.session.kv_cache.seq_len >= self.session.kv_cache.max_cache_len {
                     stop_reason = StopReason::KvFull;
@@ -16327,10 +16342,10 @@ kernel void gdn_chunk_norm_silu_c32(
             if !stopped_by_caller {
                 let tail = detok.finish();
                 if !tail.is_empty() {
+                    text.push_str(&tail);
                     on_token(&tail, last_pushed_id);
                 }
             }
-            let text = detok.text();
             Ok(CachedGenerateOutput {
                 output: GenerateOutput {
                     text,

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -14252,10 +14252,13 @@ kernel void gdn_chunk_norm_silu_c32(
                 }
                 last_pushed_id = next_id;
                 let delta = detok.push(tokenizer, next_id);
-                if !delta.is_empty() && !on_token(&delta, next_id) {
-                    stopped_by_caller = true;
-                    stop_reason = StopReason::Interrupt;
-                    break;
+                if !delta.is_empty() {
+                    text.push_str(&delta);
+                    if !on_token(&delta, next_id) {
+                        stopped_by_caller = true;
+                        stop_reason = StopReason::Interrupt;
+                        break;
+                    }
                 }
                 if self.session.kv_cache.seq_len >= self.session.kv_cache.max_cache_len {
                     stop_reason = StopReason::KvFull;
@@ -20547,6 +20550,68 @@ kernel void decode_attention_reference(
                 out.generated_tokens, 0,
                 "max_new_tokens == 0 must produce no tokens, got {}",
                 out.generated_tokens
+            );
+        }
+
+        /// Regression (review finding on the streaming-retention PR): the non-prefix
+        /// `generate_streaming` decode loop must append every non-empty delta to the
+        /// returned `GenerateOutput.text`, not just hand it to `on_token`. A prior
+        /// version of the loop body called `on_token(&delta, next_id)` without first
+        /// doing `text.push_str(&delta)`, so `out.text` silently dropped every decode
+        /// token's contribution (only the prefill token and the final incomplete-UTF-8
+        /// tail were ever appended). `single_char_vocab_tokenizer` guarantees every
+        /// token decodes to exactly one non-empty-delta character (no UTF-8 boundary
+        /// holdback), so this test exercises the loop body on every one of its
+        /// iterations rather than being satisfied by the prefill token alone.
+        #[test]
+        fn streaming_text_accumulates_every_loop_delta_not_only_prefill() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 5,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(1),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+            };
+
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            // Push eos_token_id out of the model's reachable output range so greedy
+            // sampling cannot end the stream after the prefill token — this test
+            // needs several decode-loop iterations (not just the prefill push) to
+            // exercise the bug.
+            cfg.eos_token_id = u32::MAX;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+
+            let mut accumulated = String::new();
+            let out = state.generate_streaming("a", &tokenizer, &gen_cfg, |delta, _id| {
+                accumulated.push_str(delta);
+                true
+            });
+
+            assert!(
+                out.generated_tokens >= 3,
+                "test needs at least 3 generated tokens to exercise the decode loop, got {}",
+                out.generated_tokens
+            );
+            assert_eq!(
+                out.text, accumulated,
+                "GenerateOutput.text must equal the concatenation of every on_token \
+                 delta (plus the finish() tail, already included in `accumulated` via \
+                 the callback) — a mismatch means the non-prefix decode loop dropped \
+                 deltas instead of appending them to the caller-owned `text` accumulator"
             );
         }
 

--- a/crates/inference/src/model/qwen35/detokenize.rs
+++ b/crates/inference/src/model/qwen35/detokenize.rs
@@ -314,6 +314,44 @@ mod tests {
         assert!(detok.retained_byte_capacity() <= DETOK_RETAINED_BYTE_CAPACITY);
     }
 
+    /// Companion regression for issue #324 (review finding on the retention-bound
+    /// PR): the test above only ever pushes 1-byte ASCII tokens, so `pending`'s
+    /// `Vec` never grows past its initial `with_capacity(DETOK_RETAINED_BYTE_CAPACITY)`
+    /// allocation — deleting the `compact_pending_capacity()` call (or its call
+    /// site) would still pass it, since there is never anything to compact.
+    /// This test feeds a *single* token whose decoded bytes (12, all valid
+    /// ASCII) exceed `DETOK_RETAINED_BYTE_CAPACITY` (8) in one `push`, forcing
+    /// `pending`'s allocation to grow past the bound before `flush_complete`
+    /// drains it back to empty — then asserts the retained *capacity* still
+    /// compacts back down to the bound afterward, actually exercising
+    /// `compact_pending_capacity`'s shrink path.
+    #[test]
+    fn incremental_detokenizer_retention_compacts_after_oversized_single_push() {
+        let byte_encoder = bytes_to_unicode();
+        // One BPE token whose decoded bytes are 12 copies of 'a' — longer than
+        // DETOK_RETAINED_BYTE_CAPACITY (8), all valid UTF-8, so every byte
+        // flushes in the same `push` call that appended it.
+        let oversized_token: String =
+            std::iter::repeat_n(byte_encoder[b'a' as usize], 12).collect();
+        let mut vocab = HashMap::new();
+        vocab.insert(oversized_token, 0u32);
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, Vec::new())
+            .expect("synthetic BPE tokenizer builds");
+
+        let mut detok = IncrementalDetokenizer::new();
+        let delta = detok.push(&tokenizer, 0);
+
+        assert_eq!(delta, "a".repeat(12));
+        assert_eq!(detok.retained_byte_len(), 0);
+        assert!(
+            detok.retained_byte_capacity() <= DETOK_RETAINED_BYTE_CAPACITY,
+            "a single push whose decoded bytes (12) exceed DETOK_RETAINED_BYTE_CAPACITY \
+             (8) must still leave the retained allocation compacted back down, got \
+             capacity {}",
+            detok.retained_byte_capacity()
+        );
+    }
+
     /// UTF-8-boundary property: a CJK/emoji/combining-mark/ZWJ-sequence token
     /// stream, fed one BPE-token-sized byte chunk at a time (deliberately
     /// splitting multibyte scalars and a multi-codepoint grapheme cluster across

--- a/crates/inference/src/model/qwen35/detokenize.rs
+++ b/crates/inference/src/model/qwen35/detokenize.rs
@@ -42,29 +42,40 @@ pub(crate) fn decode_tokens(tokenizer: &BpeTokenizer, ids: &[u32]) -> String {
     String::from_utf8_lossy(&bytes).to_string()
 }
 
+/// Upper bound on the raw bytes an [`IncrementalDetokenizer`] retains between
+/// `push` calls. A UTF-8 scalar is at most 4 bytes, so a handful of bytes is
+/// always enough to hold the longest possible incomplete trailing codepoint;
+/// this bound exists purely to cap allocator churn, not to limit correctness.
+const DETOK_RETAINED_BYTE_CAPACITY: usize = 8;
+
 /// Incremental, UTF-8-boundary-safe detokenizer for streaming generation.
 ///
 /// Byte-level BPE frequently splits a single multibyte codepoint (CJK, emoji,
 /// accented Latin) across two or more tokens. Decoding the running token list
 /// with `from_utf8_lossy` after every token would substitute `U+FFFD` for the
 /// incomplete trailing bytes and stream that replacement char to the caller,
-/// who cannot retract it. This type instead buffers raw bytes and emits only
-/// the longest *complete* UTF-8 prefix after each token, holding incomplete
-/// trailing bytes until a later token completes the codepoint. The concatenation
-/// of every `push` delta plus the final `finish` equals `decode_tokens` over the
-/// same ids.
+/// who cannot retract it. This type instead buffers only the undecided tail —
+/// the bytes of a UTF-8 scalar still being assembled across token boundaries —
+/// and emits every complete UTF-8 prefix as soon as it is known, so retained
+/// state stays bounded regardless of how long the generation runs (issue
+/// #324). The full generated text is *not* retained here: callers that need
+/// the whole-generation string (e.g. `GenerateOutput.text`) accumulate the
+/// `push`/`finish` deltas themselves. The concatenation of every `push` delta
+/// plus the final `finish` equals `decode_tokens` over the same ids.
 pub(crate) struct IncrementalDetokenizer {
     byte_decoder: HashMap<char, u8>,
-    bytes: Vec<u8>,
-    flushed: usize,
+    /// Bytes appended since the last `push`, not yet proven to be either a
+    /// complete UTF-8 prefix (already emitted) or an unrepairable invalid
+    /// sequence (already replaced). Only an in-progress incomplete codepoint
+    /// tail should ever accumulate here between calls.
+    pending: Vec<u8>,
 }
 
 impl IncrementalDetokenizer {
     pub(crate) fn new() -> Self {
         Self {
             byte_decoder: build_byte_decoder(),
-            bytes: Vec::new(),
-            flushed: 0,
+            pending: Vec::with_capacity(DETOK_RETAINED_BYTE_CAPACITY),
         }
     }
 
@@ -72,38 +83,39 @@ impl IncrementalDetokenizer {
     /// empty when the token only contributed continuation bytes of a codepoint
     /// still being assembled).
     pub(crate) fn push(&mut self, tokenizer: &BpeTokenizer, id: u32) -> String {
-        append_token_bytes(tokenizer, id, &self.byte_decoder, &mut self.bytes);
+        append_token_bytes(tokenizer, id, &self.byte_decoder, &mut self.pending);
         self.flush_complete()
     }
 
     fn flush_complete(&mut self) -> String {
         let mut out = String::new();
+        let mut consumed = 0usize;
+
         loop {
-            match std::str::from_utf8(&self.bytes[self.flushed..]) {
+            match std::str::from_utf8(&self.pending[consumed..]) {
                 // Entire remaining buffer is valid UTF-8: emit it all.
                 Ok(s) => {
                     out.push_str(s);
-                    self.flushed = self.bytes.len();
-                    return out;
+                    consumed = self.pending.len();
+                    break;
                 }
                 Err(e) => {
                     let valid = e.valid_up_to();
                     if valid > 0 {
-                        // [flushed .. flushed + valid] is guaranteed valid by
+                        // [consumed .. consumed + valid] is guaranteed valid by
                         // valid_up_to, so from_utf8_lossy substitutes nothing.
+                        let end = consumed + valid;
                         out.push_str(
-                            String::from_utf8_lossy(
-                                &self.bytes[self.flushed..self.flushed + valid],
-                            )
-                            .as_ref(),
+                            String::from_utf8_lossy(&self.pending[consumed..end]).as_ref(),
                         );
-                        self.flushed += valid;
+                        consumed = end;
                     }
                     match e.error_len() {
                         // None: the error is an incomplete trailing codepoint,
                         // not a malformed one. A later token may complete it, so
-                        // keep the tail buffered and emit no replacement char.
-                        None => return out,
+                        // fail closed: keep every remaining byte buffered and
+                        // emit no replacement char.
+                        None => break,
                         // Some(len): a genuinely invalid sequence of `len` bytes
                         // that no future token can repair. Emit one U+FFFD (matching
                         // from_utf8_lossy's maximal-subpart substitution), skip past
@@ -111,30 +123,55 @@ impl IncrementalDetokenizer {
                         // the bad byte until finish().
                         Some(len) => {
                             out.push('\u{FFFD}');
-                            self.flushed += len;
+                            consumed += len;
                         }
                     }
                 }
             }
         }
+
+        if consumed > 0 {
+            self.pending.drain(..consumed);
+        }
+        self.compact_pending_capacity();
+        out
     }
 
     /// Flush any trailing incomplete bytes lossily. Call once after the final
     /// token so the concatenated stream matches `decode_tokens` exactly even when
     /// a generation is truncated mid-codepoint.
     pub(crate) fn finish(&mut self) -> String {
-        if self.flushed < self.bytes.len() {
-            let tail = String::from_utf8_lossy(&self.bytes[self.flushed..]).into_owned();
-            self.flushed = self.bytes.len();
-            tail
-        } else {
-            String::new()
+        if self.pending.is_empty() {
+            return String::new();
+        }
+        let tail = String::from_utf8_lossy(&self.pending).into_owned();
+        self.pending.clear();
+        self.compact_pending_capacity();
+        tail
+    }
+
+    /// Shrink `pending`'s allocation back to the small retained bound once its
+    /// length has fallen back under it, so a rare long invalid-byte run does not
+    /// permanently inflate this detokenizer's footprint for the rest of the
+    /// generation (see issue #324).
+    fn compact_pending_capacity(&mut self) {
+        if self.pending.capacity() > DETOK_RETAINED_BYTE_CAPACITY
+            && self.pending.len() <= DETOK_RETAINED_BYTE_CAPACITY
+        {
+            let mut compact = Vec::with_capacity(DETOK_RETAINED_BYTE_CAPACITY);
+            compact.extend_from_slice(&self.pending);
+            self.pending = compact;
         }
     }
 
-    /// The full decoded text so far (equivalent to `decode_tokens` over every fed id).
-    pub(crate) fn text(&self) -> String {
-        String::from_utf8_lossy(&self.bytes).to_string()
+    #[cfg(test)]
+    fn retained_byte_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    #[cfg(test)]
+    fn retained_byte_capacity(&self) -> usize {
+        self.pending.capacity()
     }
 }
 
@@ -166,6 +203,8 @@ pub fn bytes_to_unicode() -> Vec<char> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tokenizer::bpe::BpeTokenizer;
+    use std::collections::HashMap;
 
     #[test]
     fn incremental_flush_reconstructs_split_codepoints() {
@@ -175,12 +214,12 @@ mod tests {
         let mut d = IncrementalDetokenizer::new();
         let mut out = String::new();
         for c in chunks {
-            d.bytes.extend_from_slice(c);
+            d.pending.extend_from_slice(c);
             out.push_str(&d.flush_complete());
         }
         out.push_str(&d.finish());
         assert_eq!(out, "好😀ok");
-        assert_eq!(out, d.text());
+        assert_eq!(d.retained_byte_len(), 0);
     }
 
     #[test]
@@ -189,11 +228,11 @@ mod tests {
         // flushes the incomplete tail lossily, matching decode_tokens' behavior.
         let mut d = IncrementalDetokenizer::new();
         let mut out = String::new();
-        d.bytes.extend_from_slice(&[b'h', b'i', 0xE5, 0xA5]);
+        d.pending.extend_from_slice(&[b'h', b'i', 0xE5, 0xA5]);
         out.push_str(&d.flush_complete());
         out.push_str(&d.finish());
         assert_eq!(out, String::from_utf8_lossy(&[b'h', b'i', 0xE5, 0xA5]));
-        assert_eq!(out, d.text());
+        assert_eq!(d.retained_byte_len(), 0);
     }
 
     #[test]
@@ -202,10 +241,10 @@ mod tests {
         // can complete. flush_complete must emit U+FFFD for it immediately and
         // keep going, not buffer it until finish() (which would stall the stream).
         let mut d = IncrementalDetokenizer::new();
-        d.bytes.extend_from_slice(&[0x80]);
+        d.pending.extend_from_slice(&[0x80]);
         let first = d.flush_complete();
         assert_eq!(first, "\u{FFFD}", "invalid byte must flush immediately");
-        d.bytes.extend_from_slice(b"A");
+        d.pending.extend_from_slice(b"A");
         let second = d.flush_complete();
         assert_eq!(second, "A", "valid byte after invalid one must flush");
         // Concatenated stream equals from_utf8_lossy over the whole byte buffer.
@@ -213,6 +252,7 @@ mod tests {
             format!("{first}{second}"),
             String::from_utf8_lossy(&[0x80, b'A'])
         );
+        assert_eq!(d.retained_byte_len(), 0);
     }
 
     #[test]
@@ -221,10 +261,10 @@ mod tests {
         // valid runs verbatim — byte-for-byte equal to from_utf8_lossy.
         let raw = [b'h', b'i', 0xFF, b'y', b'o'];
         let mut d = IncrementalDetokenizer::new();
-        d.bytes.extend_from_slice(&raw);
+        d.pending.extend_from_slice(&raw);
         let out = d.flush_complete();
         assert_eq!(out, String::from_utf8_lossy(&raw));
-        assert_eq!(out, d.text());
+        assert_eq!(d.retained_byte_len(), 0);
     }
 
     #[test]
@@ -233,10 +273,113 @@ mod tests {
         let mut d = IncrementalDetokenizer::new();
         let mut out = String::new();
         for c in [b"He".as_slice(), b"llo", b"!"] {
-            d.bytes.extend_from_slice(c);
+            d.pending.extend_from_slice(c);
             out.push_str(&d.flush_complete());
         }
         out.push_str(&d.finish());
         assert_eq!(out, "Hello!");
+        assert_eq!(d.retained_byte_len(), 0);
+    }
+
+    /// Regression for issue #324: retained state must stay bounded by a fixed
+    /// capacity no matter how many tokens are streamed. Before the fix,
+    /// `IncrementalDetokenizer` retained the whole generation's decoded bytes
+    /// (`bytes` + `flushed` cursor), so this loop would grow retained capacity
+    /// linearly with the token count. If the bound is removed (e.g. reverting to
+    /// unconditional whole-buffer retention, or dropping the drain/compaction
+    /// step), `retained_byte_capacity()` grows past `DETOK_RETAINED_BYTE_CAPACITY`
+    /// and this test fails.
+    #[test]
+    fn incremental_detokenizer_retention_bounded_for_long_ascii_stream() {
+        let byte_encoder = bytes_to_unicode();
+        let mut vocab = HashMap::new();
+        vocab.insert(byte_encoder[b'a' as usize].to_string(), 0u32);
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, Vec::new())
+            .expect("synthetic BPE tokenizer builds");
+
+        let mut detok = IncrementalDetokenizer::new();
+        let mut out = String::new();
+        for _ in 0..8_192 {
+            out.push_str(&detok.push(&tokenizer, 0));
+            assert_eq!(detok.retained_byte_len(), 0);
+            assert!(
+                detok.retained_byte_capacity() <= DETOK_RETAINED_BYTE_CAPACITY,
+                "capacity must remain bounded, got {}",
+                detok.retained_byte_capacity()
+            );
+        }
+        out.push_str(&detok.finish());
+        assert_eq!(out.len(), 8_192);
+        assert_eq!(detok.retained_byte_len(), 0);
+        assert!(detok.retained_byte_capacity() <= DETOK_RETAINED_BYTE_CAPACITY);
+    }
+
+    /// UTF-8-boundary property: a CJK/emoji/combining-mark/ZWJ-sequence token
+    /// stream, fed one BPE-token-sized byte chunk at a time (deliberately
+    /// splitting multibyte scalars and a multi-codepoint grapheme cluster across
+    /// token boundaries), must decode byte-identical to `decode_tokens`, the
+    /// accumulate-everything reference path. Retained bytes must never exceed 3
+    /// (the longest possible incomplete UTF-8 tail) while streaming. If an
+    /// over-eager drop clears `pending` on an incomplete tail (`error_len() ==
+    /// None`) instead of retaining it, or emits U+FFFD for a merely-incomplete
+    /// sequence, the streamed output diverges from the reference and this test
+    /// fails.
+    #[test]
+    fn incremental_detokenizer_utf8_parity_matches_full_decode_for_split_stream() {
+        let chunks: &[&[u8]] = &[
+            b"H",
+            &[0xE5],
+            &[0xA5, 0xBD],
+            b" ",
+            &[0xF0, 0x9F],
+            &[0x98],
+            &[0x80],
+            b" ",
+            b"e",
+            &[0xCC],
+            &[0x81],
+            b" ",
+            &[0xF0, 0x9F, 0x91],
+            &[0xA9, 0xE2],
+            &[0x80, 0x8D],
+            &[0xF0, 0x9F, 0x92],
+            &[0xBB],
+        ];
+
+        let byte_encoder = bytes_to_unicode();
+        let mut vocab = HashMap::new();
+        let mut ids = Vec::with_capacity(chunks.len());
+        let mut next_id = 0u32;
+        for chunk in chunks {
+            let token_str: String = chunk.iter().map(|&b| byte_encoder[b as usize]).collect();
+            // Interning: an already-seen chunk string reuses its existing id
+            // instead of colliding as a duplicate vocab key.
+            let id = *vocab.entry(token_str).or_insert_with(|| {
+                let id = next_id;
+                next_id += 1;
+                id
+            });
+            ids.push(id);
+        }
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, Vec::new())
+            .expect("synthetic BPE tokenizer builds");
+
+        let reference = decode_tokens(&tokenizer, &ids);
+        assert_eq!(
+            reference,
+            "H\u{597D} \u{1F600} e\u{301} \u{1F469}\u{200D}\u{1F4BB}"
+        );
+
+        let mut detok = IncrementalDetokenizer::new();
+        let mut streamed = String::new();
+        for &id in &ids {
+            streamed.push_str(&detok.push(&tokenizer, id));
+            assert!(detok.retained_byte_len() <= 3);
+        }
+        streamed.push_str(&detok.finish());
+
+        assert_eq!(streamed, reference);
+        assert_eq!(detok.retained_byte_len(), 0);
+        assert!(detok.retained_byte_capacity() <= DETOK_RETAINED_BYTE_CAPACITY);
     }
 }

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -386,8 +386,12 @@ impl Qwen35Model {
         if gen_cfg.stop_strings.is_empty() {
             // Fast path: no string-level stops. Behaviour byte-for-byte identical
             // to before this feature was added; the e2e-parity CI gate pins this.
+            // `text` is the caller-owned full output — the detokenizer itself only
+            // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
+            let mut text = String::new();
             let delta = detok.push(&self.tokenizer, next_id);
             if !delta.is_empty() {
+                text.push_str(&delta);
                 on_token(&delta);
             }
 
@@ -473,6 +477,7 @@ impl Qwen35Model {
 
                 let delta = detok.push(&self.tokenizer, next_id);
                 if !delta.is_empty() {
+                    text.push_str(&delta);
                     on_token(&delta);
                 }
 
@@ -488,11 +493,12 @@ impl Qwen35Model {
             // so the streamed deltas concatenate to exactly the returned text.
             let tail = detok.finish();
             if !tail.is_empty() {
+                text.push_str(&tail);
                 on_token(&tail);
             }
 
             Ok(GenerateOutput {
-                text: detok.text(),
+                text,
                 token_ids: generated_ids.clone(),
                 prompt_tokens: prompt_len,
                 generated_tokens: generated_ids.len(),


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

`IncrementalDetokenizer` previously retained **every decoded byte for the entire lifetime of a generation** (a growing `bytes: Vec<u8>` plus a `flushed` cursor) so that `text()` could reconstruct the whole output on demand. For long generations this grows memory **linearly with token count**, even though the only state a streaming detokenizer needs is the small tail around the current UTF-8 decode boundary.

This PR bounds that retention to a tiny tail window:

- The struct now holds a single `pending: Vec<u8>` containing only the **undecided UTF-8 boundary bytes** (the incomplete trailing scalar, at most 3 bytes between pushes).
- After every `push`/`finish`, consumed bytes are `drain`ed and the buffer capacity is compacted back down to `DETOK_RETAINED_BYTE_CAPACITY` (8 bytes). A `Vec` does not shrink capacity on `drain`/`clear` alone, so the explicit compaction is what actually caps the allocation.
- Whole-generation text now accumulates in the generation call sites that already own `GenerateOutput.text` (the CPU no-stop streaming path and both Metal streaming paths). String-stop paths already accumulated their own full text and are unchanged.
- `text()` is removed (not stubbed); it has no remaining callers.

### Fail-closed boundary rule (preserved exactly)

Byte-level BPE can split a single codepoint across tokens, so flushing only complete UTF-8 per token is a hard invariant. The boundary logic is unchanged in behavior:

- `Ok(s)` → emit all, consume all.
- `Err` with `valid_up_to() > 0` → emit only the proven-valid prefix, advance by exactly that many bytes.
- `error_len() == None` (incomplete trailing codepoint) → **retain every remaining byte, emit nothing** — a later token may complete it. This is the fail-closed branch: when in doubt at a boundary, retain.
- `error_len() == Some(len)` → emit one `U+FFFD` and advance by `len` (only Rust-classified unrepairable bytes are ever dropped — never bytes that could still complete a codepoint).
- `finish()` is the sole lossy flush, at generation end.

## Tests

- **Bounded-memory regression** (`incremental_detokenizer_retention_bounded_for_long_ascii_stream`): asserts retained capacity stays `<= 8` across an 8,192-token stream — bound is independent of generation length.
- **UTF-8-boundary parity** (`incremental_detokenizer_utf8_parity_matches_full_decode_for_split_stream`): a CJK / emoji / combining-mark / ZWJ token stream streams **byte-identical** to the accumulate-everything `decode_tokens` reference.
- Both tests are mutation-verified as load-bearing: removing the retention bound makes the memory test fail; an over-eager drop of the incomplete tail makes the parity test fail.
- Full workspace suite green; `clippy --workspace -D warnings` and `fmt --check` clean.

## Bench comparison (CPU-only A/B)

`make bench-compare` (`origin/main` → `HEAD`, quick mode). The diff touches only decode bookkeeping (`Vec<u8>`/`String`) in the `lattice-inference` crate, so `elementwise_cpu_bench` is the nearest CPU group with production relevance (there is no detokenizer-specific Criterion bench in the repo). Base = `origin/main`, Head = this branch.

### `elementwise_cpu_bench` (lattice-inference) — before/after

| Benchmark | Base (median) | Head (median) | Change (CI) | p-value | Verdict |
|---|---|---|---|---|---|
| rms_norm/896 | 130.83 ns | 135.06 ns | +2.81% .. +4.95% | 0.08 | noise |
| rms_norm/4096 | 558.69 ns | 565.97 ns | +1.10% .. +2.11% | 0.08 | noise |
| layer_norm/896 | 206.74 ns | 204.02 ns | −1.67% .. −0.02% | 0.15 | noise |
| layer_norm/4096 | 899.04 ns | 892.94 ns | −1.15% .. +0.08% | 0.27 | noise |
| silu_inplace/896 | 451.18 ns | 455.61 ns | −0.76% .. +1.42% | 0.77 | noise |
| silu_inplace/4096 | 2.0544 µs | 2.0516 µs | −0.55% .. −0.03% | 0.10 | noise |
| gelu/896 | 369.22 ns | 366.72 ns | −1.13% .. −0.56% | 0.05 | noise (tiny improvement) |
| gelu/4096 | 1.6716 µs | 1.6799 µs | −0.70% .. +0.80% | 0.89 | noise |
| add_bias_gelu/896 | 386.91 ns | 390.68 ns | +0.24% .. +2.16% | 0.15 | noise |
| add_bias_gelu/4096 | 1.7661 µs | 1.7784 µs | −0.45% .. +2.22% | 0.53 | noise |
| softmax_attention/128 | 3.5945 µs | 3.6582 µs | +1.48% .. +2.94% | 0.10 | noise |
| softmax_attention/512 | 62.496 µs | 63.684 µs | +1.43% .. +2.67% | 0.08 | noise |
| elementwise_mul/4096 | 279.18 ns | 280.67 ns | +0.21% .. +0.70% | 0.12 | noise |

All 13 benchmarks are statistically indistinguishable from base (every p-value ≥ 0.05). Expected: none of these kernels are on the detokenizer code path; the change is token-to-text bookkeeping only. No measurable regression. No Metal/GPU benches were run (this change is CPU-only by nature).

## Reviewer note (behavior change on caller-interrupt only)

On a **caller interrupt** (which returns/breaks without calling `finish()`), the aggregate `GenerateOutput.text` no longer appends a trailing `U+FFFD` for a half-received codepoint present at the interrupt boundary — that partial byte is simply omitted. The streamed `on_token` deltas are byte-identical in both versions, and **all non-interrupt paths** (stop / kv-full / max-tokens / natural-end) call `finish()` and remain byte-identical to the previous behavior. This is an intentional consequence of moving accumulation to the callers, and is arguably more correct (a partial output shouldn't carry a bogus replacement char for a codepoint the caller chose to interrupt mid-way). Flagged here purely for transparency.

Closes #324
