### PR TITLE
test(inference): regression coverage for PagedKVCache Lru overflow (#292)

### DIFF
--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -1387,6 +1387,48 @@ mod tests {
     }
 
     #[test]
+    fn paged_lru_overflow_leaves_live_pages_unchanged() {
+        let mut config = make_config(2); // 2 pages * page_size 4 = 8 max_tokens.
+        config.eviction = EvictionPolicy::Lru;
+        let kv_dim = config.kv_dim();
+        let max_tokens = config.max_tokens();
+        let mut cache = PagedKVCache::new(config);
+
+        for step in 0..max_tokens {
+            for layer in 0..2 {
+                let k = vec![step as f32; kv_dim];
+                let v = vec![1000.0 + step as f32; kv_dim];
+                cache.append_kv_layer(layer, &k, &v);
+            }
+            cache.advance();
+        }
+
+        let overflow = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            for layer in 0..2 {
+                let k = vec![999.0; kv_dim];
+                let v = vec![1999.0; kv_dim];
+                cache.append_kv_layer(layer, &k, &v);
+            }
+        }));
+        assert!(overflow.is_err(), "LRU overflow should fail closed");
+
+        assert_eq!(cache.seq_len(), max_tokens);
+        assert_eq!(cache.num_pages(), 2);
+
+        let mut k_buf = vec![0.0f32; max_tokens * kv_dim];
+        let mut v_buf = vec![0.0f32; max_tokens * kv_dim];
+        cache.gather_k(0, &mut k_buf);
+        cache.gather_v(0, &mut v_buf);
+
+        for step in 0..max_tokens {
+            for i in 0..kv_dim {
+                assert_eq!(k_buf[step * kv_dim + i], step as f32);
+                assert_eq!(v_buf[step * kv_dim + i], 1000.0 + step as f32);
+            }
+        }
+    }
+
+    #[test]
     #[should_panic(expected = "page_size must be non-zero")]
     fn paged_zero_page_size_panics_at_construction() {
         // Regression for #244: page_size == 0 is the divisor in PageTable::resolve,


### PR DESCRIPTION
_PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Adds regression coverage for the `PagedKVCache` LRU-eviction failure described in #292.

While preparing the fix, I confirmed that the underlying library bug is **already fixed** in `main` (commit `50c3612a9`, "fail closed on PagedKVCache Lru overflow past max_tokens (#337)"). Rather than fabricate a redundant code change, this PR is **test-only**: it locks in the fixed behavior with a mutation-sensitive regression test so the #292 scenario cannot silently regress.

## What was broken (#292)

`PagedKVCache::append_kv_layer` computes `needed_pages` **once** before the page-allocation loop:

```rust
let needed_pages = (pos / page_size) + 1;
while self.table.num_pages() < needed_pages {
    let phys = self.alloc_page(); // may evict_lru when the pool is exhausted
    self.table.push_page(phys);
}
```

Under `EvictionPolicy::Lru`, once a sequence grows past `max_tokens` (so `needed_pages > max_pages`) and the page pool is exhausted, each loop iteration evicts one page and re-pushes one — **net-zero on `num_pages()`**. The loop therefore cannot converge: it drains `lru_order` (evicting pages that are still live), and then either

- **panics** with `"LRU order empty but pool exhausted"`, or
- **silently corrupts** state — `pop_front_page` clamps `seq_len` mid-loop, shifting the logical page table under live data.

Because `EvictionPolicy::Lru` is public API with no in-tree constructor, this only affected external consumers.

## The fix (already landed, #337)

`append_kv_layer` now **fails closed** before the loop, for `EvictionPolicy::Lru` only:

```rust
if self.config.eviction == EvictionPolicy::Lru {
    assert!(
        needed_pages <= self.config.max_pages,
        "PagedKVCache::append_kv_layer: position {pos} needs {needed_pages} pages but \
         max_pages is {}; EvictionPolicy::Lru does not yet support sequences beyond \
         max_tokens ({}) (see issue #337)",
        self.config.max_pages,
        self.config.max_tokens(),
    );
}
```

This rejects the non-convergent case up front with a clear, actionable message, so the runaway loop is never entered. `alloc_page` (which calls `evict_lru`) is only reachable from this guarded loop, so the guard covers the sole public eviction path. The `EvictionPolicy::None` path is untouched. (Sliding a window past capacity remains unimplemented and is tracked separately in #337.)

## This PR: regression coverage

Adds `paged_lru_overflow_leaves_live_pages_unchanged`, which fills the cache to capacity under `EvictionPolicy::Lru`, then attempts an overflowing append and asserts:

1. the overflow **fails closed** (panics, caught via `catch_unwind`);
2. `seq_len()` and `num_pages()` are **unchanged**; and
3. every previously stored live page is **byte-for-byte intact** (`gather_k`/`gather_v`) — proving no page-table shift or data corruption.

This complements the existing repro test `paged_lru_eviction_fails_closed_beyond_max_tokens`.

## Mutation evidence

Reverse-applying the #337 guard (removing only the library `assert!` block and its doc note, leaving both tests untouched) and re-running:

```
thread '...paged_lru_eviction_fails_closed_beyond_max_tokens' panicked at paged.rs:909:
LRU order empty but pool exhausted
  -> should_panic(expected = "does not yet support sequences beyond max_tokens") does NOT match -> FAIL

thread '...paged_lru_overflow_leaves_live_pages_unchanged' panicked at paged.rs:909:
LRU order empty but pool exhausted
  -> then corruption assertion fires: seq_len left: 4, right: 8 -> FAIL

test result: FAILED. 0 passed; 2 failed
```

Both tests fail without the guard — the new test surfaces the exact `seq_len` corruption from #292 — and both pass with it. Mutation-sensitivity confirmed.

## Gates run (CPU-only)

- `cargo test -p lattice-inference --lib` → **1356 passed, 0 failed, 7 ignored**
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean

## Notes

- Test-only change; no library code, no API, no signatures modified.
- Does not close #292 — left open for maintainer review.
