### PR TITLE
fix(scripts): resolve named-baseline dirs in perf-bench-gate (#545)

### DIFF
--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -70,25 +70,38 @@ def find_baseline_estimates(bench_dir: Path, baseline_name: str) -> Path | None:
     after the baseline: the default (unnamed) rotation uses `base/`, while a
     named baseline (`--save-baseline <name>` / `--baseline <name>`, as used by
     bench-compare.sh's `compare-base` leg) writes under `<name>/` instead —
-    `base/` is never created in that flow. Prefer the default `base/` dir
-    (covers CI's default-rotation runs), then the caller-supplied/explicit
-    baseline name, then fall back to scanning for any other sibling directory
-    that holds an estimates.json and isn't `new`/`change` (the two dirs
-    Criterion always writes for the *current* run, never the baseline).
+    `base/` is never created in that flow. Prefer the caller-supplied baseline
+    name FIRST: Criterion computed change/ against that baseline, so a stale
+    `base/` left in a dirty local tree must not shadow it (codex review of
+    PR #548 reproduced exactly that wrong-baseline report). Then try the
+    default `base/` (covers CI's default-rotation runs). As a last resort,
+    accept a sibling directory holding an estimates.json that isn't
+    `new`/`change` — but only when it is unambiguous: Criterion supports
+    multiple named baselines side by side, and guessing among several would
+    silently gate against the wrong one.
     """
-    candidates = ["base", baseline_name]
+    candidates = [baseline_name, "base"]
     for candidate in candidates:
         p = bench_dir / candidate / "estimates.json"
         if p.exists():
             return p
 
-    for child in sorted(bench_dir.iterdir()):
-        if child.name in ("new", "change"):
-            continue
-        p = child / "estimates.json"
-        if child.is_dir() and p.exists():
-            return p
-
+    fallbacks = [
+        child for child in sorted(bench_dir.iterdir())
+        if child.is_dir()
+        and child.name not in ("new", "change")
+        and (child / "estimates.json").exists()
+    ]
+    if len(fallbacks) == 1:
+        print(f"note: {bench_dir.name}: using sole sibling baseline dir "
+              f"'{fallbacks[0].name}/' (neither '{baseline_name}/' nor 'base/' found)",
+              file=sys.stderr)
+        return fallbacks[0] / "estimates.json"
+    if len(fallbacks) > 1:
+        names = ", ".join(f.name for f in fallbacks)
+        print(f"warn: {bench_dir.name}: multiple candidate baseline dirs ({names}) "
+              f"and none match '{baseline_name}/' or 'base/' — refusing to guess",
+              file=sys.stderr)
     return None
 
 
@@ -195,6 +208,9 @@ def run_selftest() -> int:
     Regression coverage for #545: a default-rotation `base/` layout, a named-baseline
     `compare-base/` layout (what bench-compare.sh actually produces), and a `change/`
     dir with no resolvable baseline at all (must WARN by bench name, not silently skip).
+    Plus the codex findings on PR #548: when BOTH base/ and the named baseline exist,
+    the named baseline must win (dirty local tree with stale base/); when multiple
+    unrelated sibling baselines exist and none match, the gate must refuse to guess.
     """
     import contextlib
     import io
@@ -222,9 +238,25 @@ def run_selftest() -> int:
                      "confidence_interval": {"lower_bound": 0.05, "upper_bound": 0.15}}
         }))
 
+        # Codex finding 1: both base/ and compare-base/ present with different
+        # values — the named baseline must win over stale base/.
+        both_dir = root / "grp_d" / "bench_both"
+        _fabricate_bench(both_dir, "compare-base", base_ns=100.0)
+        (both_dir / "base").mkdir()
+        (both_dir / "base" / "estimates.json").write_text(
+            json.dumps({"mean": {"point_estimate": 1.0}}))  # stale decoy
+
+        # Codex finding 2: multiple unrelated sibling baselines, none matching
+        # the requested name — must skip loudly, not guess.
+        multi_dir = root / "grp_e" / "bench_multi"
+        _fabricate_bench(multi_dir, "old-run-1")
+        (multi_dir / "old-run-2").mkdir()
+        (multi_dir / "old-run-2" / "estimates.json").write_text(
+            json.dumps({"mean": {"point_estimate": 42.0}}))
+
         change_files = find_change_files(root)
-        if len(change_files) != 3:
-            failures.append(f"expected 3 change/estimates.json, found {len(change_files)}")
+        if len(change_files) != 5:
+            failures.append(f"expected 5 change/estimates.json, found {len(change_files)}")
 
         stderr_buf = io.StringIO()
         results: dict[str, BenchResult] = {}
@@ -244,12 +276,25 @@ def run_selftest() -> int:
         if "grp_c/bench_orphan" not in stderr_text:
             failures.append("orphan bench did not emit a warning naming the bench")
 
+        both = results.get("grp_d/bench_both")
+        if both is None:
+            failures.append("both-dirs layout: bench not parsed")
+        elif both.old_ns != 100.0:
+            failures.append(f"both-dirs layout: expected named-baseline old_ns=100.0 "
+                            f"(compare-base/), got {both.old_ns} (stale base/ shadowed it)")
+
+        if "grp_e/bench_multi" in results:
+            failures.append("multi-sibling layout: gate guessed a baseline instead of refusing")
+        if "bench_multi" not in stderr_text or "refusing to guess" not in stderr_text:
+            failures.append("multi-sibling layout: no loud refusal warning emitted")
+
     for f in failures:
         print(f"FAIL: {f}", file=sys.stderr)
     if failures:
         print(f"SELFTEST: FAIL ({len(failures)} failure(s))")
         return 1
-    print("SELFTEST: PASS — base/ layout, compare-base/ layout, and orphan-change warn all correct")
+    print("SELFTEST: PASS — base/, compare-base/, orphan-warn, named-wins-over-stale-base, "
+          "and multi-sibling-refusal all correct")
     return 0
 
 

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -63,8 +63,37 @@ def find_change_files(root: Path) -> list[Path]:
     return sorted(root.rglob("change/estimates.json"))
 
 
-def parse_bench(change_file: Path, root: Path) -> BenchResult | None:
-    """Parse one change/estimates.json + sibling new/estimates.json + base/estimates.json.
+def find_baseline_estimates(bench_dir: Path, baseline_name: str) -> Path | None:
+    """Locate the baseline estimates.json for a bench directory.
+
+    Criterion writes the pre-run comparison snapshot under a directory named
+    after the baseline: the default (unnamed) rotation uses `base/`, while a
+    named baseline (`--save-baseline <name>` / `--baseline <name>`, as used by
+    bench-compare.sh's `compare-base` leg) writes under `<name>/` instead —
+    `base/` is never created in that flow. Prefer the default `base/` dir
+    (covers CI's default-rotation runs), then the caller-supplied/explicit
+    baseline name, then fall back to scanning for any other sibling directory
+    that holds an estimates.json and isn't `new`/`change` (the two dirs
+    Criterion always writes for the *current* run, never the baseline).
+    """
+    candidates = ["base", baseline_name]
+    for candidate in candidates:
+        p = bench_dir / candidate / "estimates.json"
+        if p.exists():
+            return p
+
+    for child in sorted(bench_dir.iterdir()):
+        if child.name in ("new", "change"):
+            continue
+        p = child / "estimates.json"
+        if child.is_dir() and p.exists():
+            return p
+
+    return None
+
+
+def parse_bench(change_file: Path, root: Path, baseline_name: str) -> BenchResult | None:
+    """Parse one change/estimates.json + sibling new/estimates.json + baseline estimates.json.
 
     Returns None if files are malformed (bench skipped, not failed).
     """
@@ -82,7 +111,12 @@ def parse_bench(change_file: Path, root: Path) -> BenchResult | None:
         new_path = bench_dir / "new" / "estimates.json"
         new_ns = json.loads(new_path.read_text())["mean"]["point_estimate"]
 
-        base_path = bench_dir / "base" / "estimates.json"
+        base_path = find_baseline_estimates(bench_dir, baseline_name)
+        if base_path is None:
+            print(f"warn: {name}: change/estimates.json present but no resolvable "
+                  f"baseline dir (tried base/, {baseline_name}/, and other siblings) "
+                  f"— skipping", file=sys.stderr)
+            return None
         old_ns = json.loads(base_path.read_text())["mean"]["point_estimate"]
     except (KeyError, FileNotFoundError, json.JSONDecodeError) as e:
         print(f"warn: skipping {name}: {e}", file=sys.stderr)
@@ -135,12 +169,109 @@ def render_report(results: list[BenchResult], arch: str) -> str:
     return "\n".join(lines)
 
 
+def _fabricate_bench(bench_dir: Path, baseline_dirname: str,
+                     point: float = 0.10, ci_low: float = 0.05, ci_high: float = 0.15,
+                     new_ns: float = 100.0, base_ns: float = 90.0) -> None:
+    """Write a fake Criterion bench dir (new/, <baseline_dirname>/, change/) for --selftest."""
+    bench_dir.mkdir(parents=True, exist_ok=True)
+    (bench_dir / "new").mkdir(exist_ok=True)
+    (bench_dir / "new" / "estimates.json").write_text(
+        json.dumps({"mean": {"point_estimate": new_ns}}))
+    (bench_dir / baseline_dirname).mkdir(exist_ok=True)
+    (bench_dir / baseline_dirname / "estimates.json").write_text(
+        json.dumps({"mean": {"point_estimate": base_ns}}))
+    (bench_dir / "change").mkdir(exist_ok=True)
+    (bench_dir / "change" / "estimates.json").write_text(json.dumps({
+        "mean": {
+            "point_estimate": point,
+            "confidence_interval": {"lower_bound": ci_low, "upper_bound": ci_high},
+        }
+    }))
+
+
+def run_selftest() -> int:
+    """Fabricate both baseline layouts + an orphan case; assert the parser handles each.
+
+    Regression coverage for #545: a default-rotation `base/` layout, a named-baseline
+    `compare-base/` layout (what bench-compare.sh actually produces), and a `change/`
+    dir with no resolvable baseline at all (must WARN by bench name, not silently skip).
+    """
+    import contextlib
+    import io
+    import tempfile
+
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+
+        default_dir = root / "grp_a" / "bench_default"
+        _fabricate_bench(default_dir, "base")
+
+        named_dir = root / "grp_b" / "bench_named"
+        _fabricate_bench(named_dir, "compare-base")
+
+        orphan_dir = root / "grp_c" / "bench_orphan"
+        orphan_dir.mkdir(parents=True)
+        (orphan_dir / "new").mkdir()
+        (orphan_dir / "new" / "estimates.json").write_text(
+            json.dumps({"mean": {"point_estimate": 100.0}}))
+        (orphan_dir / "change").mkdir()
+        (orphan_dir / "change" / "estimates.json").write_text(json.dumps({
+            "mean": {"point_estimate": 0.1,
+                     "confidence_interval": {"lower_bound": 0.05, "upper_bound": 0.15}}
+        }))
+
+        change_files = find_change_files(root)
+        if len(change_files) != 3:
+            failures.append(f"expected 3 change/estimates.json, found {len(change_files)}")
+
+        stderr_buf = io.StringIO()
+        results: dict[str, BenchResult] = {}
+        with contextlib.redirect_stderr(stderr_buf):
+            for cf in change_files:
+                r = parse_bench(cf, root, baseline_name="compare-base")
+                if r is not None:
+                    results[r.name] = r
+        stderr_text = stderr_buf.getvalue()
+
+        if "grp_a/bench_default" not in results:
+            failures.append("default base/ layout: bench not parsed")
+        if "grp_b/bench_named" not in results:
+            failures.append("named compare-base/ layout: bench not parsed")
+        if "grp_c/bench_orphan" in results:
+            failures.append("orphan bench (no resolvable baseline) was parsed instead of skipped")
+        if "grp_c/bench_orphan" not in stderr_text:
+            failures.append("orphan bench did not emit a warning naming the bench")
+
+    for f in failures:
+        print(f"FAIL: {f}", file=sys.stderr)
+    if failures:
+        print(f"SELFTEST: FAIL ({len(failures)} failure(s))")
+        return 1
+    print("SELFTEST: PASS — base/ layout, compare-base/ layout, and orphan-change warn all correct")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("criterion_root", type=Path, help="Path to target/criterion (or per-bench root)")
-    ap.add_argument("arch", help="Arch label for the report header (e.g. aarch64-linux)")
+    ap.add_argument("criterion_root", type=Path, nargs="?",
+                    help="Path to target/criterion (or per-bench root)")
+    ap.add_argument("arch", nargs="?",
+                    help="Arch label for the report header (e.g. aarch64-linux)")
     ap.add_argument("--out", type=Path, help="Write markdown report to this path")
+    ap.add_argument("--baseline-name", default="compare-base",
+                    help="Named-baseline dir to look for when base/ is absent "
+                         "(default: compare-base, matching bench-compare.sh)")
+    ap.add_argument("--selftest", action="store_true",
+                    help="Run the fixture self-test (no criterion_root/arch needed) and exit")
     args = ap.parse_args()
+
+    if args.selftest:
+        return run_selftest()
+
+    if args.criterion_root is None or args.arch is None:
+        ap.error("criterion_root and arch are required unless --selftest is passed")
 
     if not args.criterion_root.exists():
         print(f"error: {args.criterion_root} does not exist", file=sys.stderr)
@@ -159,7 +290,7 @@ def main() -> int:
 
     results = []
     for cf in change_files:
-        r = parse_bench(cf, args.criterion_root)
+        r = parse_bench(cf, args.criterion_root, args.baseline_name)
         if r is not None:
             results.append(r)
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Fixes #545.

## Bug

`scripts/perf-bench-gate.py` hardcoded `base/estimates.json` as the baseline path, but `scripts/bench-compare.sh` runs Criterion with `--save-baseline compare-base` / `--baseline compare-base`. With a named baseline, Criterion writes the snapshot under `compare-base/` and never creates `base/` — verified empirically by running the exact two-leg flow against the `simd_dot_product` group and inspecting `target/criterion/**`: each bench dir holds `{compare-base, new, change}`, no `base/`. The gate therefore parsed **zero benches** on every local bench-compare run since it landed (raw `change:` lines were the only usable evidence).

## Fix

- `find_baseline_estimates()`: try `base/` (default rotation, keeps CI-style runs working), then the named baseline dir (`--baseline-name`, default `compare-base` to match bench-compare.sh), then any sibling dir holding an `estimates.json` other than `new/`/`change/`.
- A `change/estimates.json` with no resolvable baseline now **warns with the bench name** instead of silently skipping — silent truncation is what let this bug go unnoticed.
- `--selftest`: fabricates all three layouts (`base/`, `compare-base/`, orphan `change/`) in a temp dir and asserts parse/parse/warn respectively, following the `perf_governor.py --selftest` convention.

## Evidence

- Pre-fix against a real two-leg bench tree: `error: change files found but all failed to parse` (8 skip warnings, exit 2).
- Post-fix, same tree: 8/8 benches parsed with real ns values in both columns.
- `--selftest`: `SELFTEST: PASS — base/ layout, compare-base/ layout, and orphan-change warn all correct`.

## Notes

- Scripts-only change; no crate code touched, so no `make bench-compare` A/B applies (the two FAIL rows in the verification run are `--quick`-mode noise on a busy machine, not a gated claim).
- Two pre-existing `ruff` E501 violations in this file exist identically on `main`; left untouched to avoid scope creep.