### PR TITLE
fix: artifact-integrity hardening, #504 remaining slices (merged-Q4 cache, quantize_index.json, registry raw-load)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -14418,19 +14418,6 @@ kernel void gdn_chunk_norm_silu_c32(
             }
         }
 
-        /// Read the QuaRot rotation seed from `quantize_index.json` per ADR-051.
-        ///
-        /// Returns `None` when the file is absent, malformed, or lacks a `quarot_seed`
-        /// key — all three are valid "no rotation" states for backwards compatibility
-        /// with older artifacts. The caller falls back to the legacy `config.json`
-        /// field on `None`.
-        fn read_quarot_seed_from_index(q4_dir: &std::path::Path) -> Option<u64> {
-            let path = q4_dir.join("quantize_index.json");
-            let bytes = std::fs::read(&path).ok()?;
-            let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-            v.get("quarot_seed").and_then(serde_json::Value::as_u64)
-        }
-
         /// Create a new [`MetalQwen35State`] by loading pre-quantized Q4/F16 files directly
         /// from a directory, without going through the full f32 weight representation.
         ///
@@ -15224,8 +15211,10 @@ kernel void gdn_chunk_norm_silu_c32(
                 // ADR-051 contract: `quarot_seed` lives in `quantize_index.json`. Fall back
                 // to the legacy `config.json` field (`quarot_rotation_seed`) for
                 // backwards compatibility with artifacts produced before the contract was
-                // formalized.
-                let index_seed = Self::read_quarot_seed_from_index(q4_dir);
+                // formalized. #504 remaining slice 2: a *present but malformed* index is a
+                // hard error (fail-closed) — only a genuinely absent index falls back.
+                let index_seed = crate::quant::quarot::convert::read_quarot_seed_from_index(q4_dir)
+                    .map_err(|e| format!("from_q4_dir: {e}"))?;
                 let seed_opt = index_seed.or(cfg.quarot_rotation_seed);
                 match seed_opt {
                     Some(seed) => Some(
@@ -18075,49 +18064,12 @@ kernel void decode_attention_reference(
         // -------------------------------------------------------------------
         // from_q4_dir refuse-on-misconfig (round-1 codex findings on PR #32)
         // -------------------------------------------------------------------
-
-        #[test]
-        fn read_quarot_seed_from_index_finds_seed() {
-            // ADR-051 contract: `quantize_index.json` carries `quarot_seed`. The runtime
-            // loader's helper must extract it when present, return None when absent or the
-            // file is missing/malformed, and ignore everything else in the index.
-            let tmp = tempfile::tempdir().unwrap();
-
-            // Absent file → None.
-            assert_eq!(
-                MetalQwen35State::read_quarot_seed_from_index(tmp.path()),
-                None,
-                "missing quantize_index.json must yield None"
-            );
-
-            // File without `quarot_seed` → None.
-            std::fs::write(tmp.path().join("quantize_index.json"), r#"{"tensors":[]}"#).unwrap();
-            assert_eq!(
-                MetalQwen35State::read_quarot_seed_from_index(tmp.path()),
-                None,
-                "index without quarot_seed key must yield None"
-            );
-
-            // File with `quarot_seed` → Some(seed).
-            std::fs::write(
-                tmp.path().join("quantize_index.json"),
-                r#"{"quarot_seed":13258600446175248384,"tensors":[]}"#,
-            )
-            .unwrap();
-            assert_eq!(
-                MetalQwen35State::read_quarot_seed_from_index(tmp.path()),
-                Some(13_258_600_446_175_248_384_u64),
-                "index with quarot_seed key must round-trip the u64 exactly"
-            );
-
-            // Malformed JSON → None (silent fallback, never panics).
-            std::fs::write(tmp.path().join("quantize_index.json"), "not json").unwrap();
-            assert_eq!(
-                MetalQwen35State::read_quarot_seed_from_index(tmp.path()),
-                None,
-                "malformed index must yield None (never panic)"
-            );
-        }
+        //
+        // `read_quarot_seed_from_index` itself (the `quantize_index.json`
+        // reader) moved to `crate::quant::quarot::convert` (#504 remaining
+        // slice 2) — it is pure file-I/O with no Metal dependency, so its
+        // tests live there where they run under default (CPU-only) features
+        // instead of requiring `metal-gpu`.
 
         #[test]
         fn from_q4_dir_rejects_max_cache_len_above_max_position_embeddings() {

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -3516,103 +3516,6 @@ kernel void gdn_chunk_norm_silu_c32(
         Ok(Q4WeightBuf::from_mmap(buf, header.payload_offset, mmap))
     }
 
-    /// Merge two Q4 files into a single concatenated Q4 file and write it to `out_path`.
-    ///
-    /// Reads only the raw bytes (no deserialization) and prepends a new KHQ4 header
-    /// reflecting the merged shape.  Uses a temp-file + atomic rename so a crashed
-    /// mid-write never leaves a partial file at the final path.
-    ///
-    /// Returns `Err` if the model directory is read-only or I/O fails — callers
-    /// must fall back to the CPU concat path in that case.
-    #[cfg(feature = "metal-gpu")]
-    fn write_merged_qkvz(
-        qkv_path: &std::path::Path,
-        z_path: &std::path::Path,
-        out_path: &std::path::Path,
-    ) -> Result<(), String> {
-        use crate::weights::q4_weights::read_q4_header;
-        use std::io::{Read, Seek, SeekFrom, Write};
-
-        // Open and parse headers — then seek back to payload start for a direct byte copy.
-        let qkv_file = std::fs::File::open(qkv_path)
-            .map_err(|e| format!("open {}: {e}", qkv_path.display()))?;
-        let qkv_hdr =
-            read_q4_header(&qkv_file).map_err(|e| format!("header {}: {e}", qkv_path.display()))?;
-        let mut qkv_rdr = qkv_file;
-        qkv_rdr
-            .seek(SeekFrom::Start(qkv_hdr.payload_offset))
-            .map_err(|e| format!("seek {}: {e}", qkv_path.display()))?;
-        let qkv_payload_len = std::fs::metadata(qkv_path)
-            .map_err(|e| format!("metadata {}: {e}", qkv_path.display()))?
-            .len()
-            - qkv_hdr.payload_offset;
-        let mut qkv_payload = Vec::with_capacity(qkv_payload_len as usize);
-        qkv_rdr
-            .read_to_end(&mut qkv_payload)
-            .map_err(|e| format!("read {}: {e}", qkv_path.display()))?;
-
-        let z_file =
-            std::fs::File::open(z_path).map_err(|e| format!("open {}: {e}", z_path.display()))?;
-        let z_hdr =
-            read_q4_header(&z_file).map_err(|e| format!("header {}: {e}", z_path.display()))?;
-        let mut z_rdr = z_file;
-        z_rdr
-            .seek(SeekFrom::Start(z_hdr.payload_offset))
-            .map_err(|e| format!("seek {}: {e}", z_path.display()))?;
-        let z_payload_len = std::fs::metadata(z_path)
-            .map_err(|e| format!("metadata {}: {e}", z_path.display()))?
-            .len()
-            - z_hdr.payload_offset;
-        let mut z_payload = Vec::with_capacity(z_payload_len as usize);
-        z_rdr
-            .read_to_end(&mut z_payload)
-            .map_err(|e| format!("read {}: {e}", z_path.display()))?;
-
-        // Merged shape: rows = qkv_rows + z_rows, cols = hidden (shared)
-        let merged_rows = qkv_hdr.shape[0] + z_hdr.shape[0];
-        let cols = if qkv_hdr.shape.len() >= 2 {
-            qkv_hdr.shape[1]
-        } else {
-            1
-        };
-        let original_len = qkv_hdr.original_len + z_hdr.original_len;
-
-        // Write to a temp file then rename atomically so partial writes are never trusted.
-        let tmp = out_path.with_extension("q4.tmp");
-        let write_result = (|| -> Result<(), String> {
-            let mut f = std::io::BufWriter::new(
-                std::fs::File::create(&tmp)
-                    .map_err(|e| format!("create {}: {e}", tmp.display()))?,
-            );
-            // KHQ4 header: magic(4) + version(4) + ndim=2(4) + shape[0](8) + shape[1](8) + original_len(8)
-            f.write_all(b"KHQ4").map_err(|e| e.to_string())?;
-            // Version 2: asymmetric Q4 blocks (20 bytes each: scale + bias + 16 nibbles).
-            f.write_all(&2u32.to_le_bytes())
-                .map_err(|e| e.to_string())?;
-            f.write_all(&2u32.to_le_bytes())
-                .map_err(|e| e.to_string())?;
-            f.write_all(&(merged_rows as u64).to_le_bytes())
-                .map_err(|e| e.to_string())?;
-            f.write_all(&(cols as u64).to_le_bytes())
-                .map_err(|e| e.to_string())?;
-            f.write_all(&(original_len as u64).to_le_bytes())
-                .map_err(|e| e.to_string())?;
-            f.write_all(&qkv_payload).map_err(|e| e.to_string())?;
-            f.write_all(&z_payload).map_err(|e| e.to_string())?;
-            Ok(())
-        })();
-
-        if write_result.is_err() {
-            let _ = std::fs::remove_file(&tmp);
-            return write_result;
-        }
-
-        std::fs::rename(&tmp, out_path).map_err(|e| {
-            let _ = std::fs::remove_file(&tmp);
-            format!("rename: {e}")
-        })
-    }
-
     /// Weights for a GatedDeltaNet (linear attention) layer on GPU.
     pub(crate) struct MetalGdnLayerWeights {
         in_proj_qkv: Q4WeightBuf,  // [qkv_dim, hidden] — Q4/Q8
@@ -14866,14 +14769,23 @@ kernel void gdn_chunk_norm_silu_c32(
                             // Expected size: 36-byte header (ndim=2, payload_offset=36)
                             // + qkv payload + z payload.  All source weight files are 2D
                             // so payload_offset=36 for each.
-                            let expected_size = 36u64 + (qkv_size - 36) + (z_size - 36);
-                            let is_valid = std::fs::metadata(&merged_path)
-                                .ok()
-                                .map(|m| m.len() == expected_size)
-                                .unwrap_or(false);
+                            let expected_size =
+                                crate::weights::q4_weights::merged_qkvz_expected_size(qkv_size, z_size)
+                                    .map_err(|e| format!("layer {i} merge size: {e}"))?;
+                            // Content-integrity check (#504 remaining slice 1): size alone
+                            // cannot catch a same-size stale/corrupted merged artifact, so
+                            // this also verifies the merged file's payload hash against a
+                            // hash freshly derived from the *current* qkv/z source files —
+                            // fail closed to a rebuild on any mismatch or read error.
+                            let is_valid = crate::weights::q4_weights::merged_qkvz_cache_is_valid(
+                                &merged_path,
+                                expected_size,
+                                &qkv_p,
+                                &z_p,
+                            );
                             if !is_valid {
                                 let _ = std::fs::remove_file(&merged_path);
-                                if let Err(e) = write_merged_qkvz(&qkv_p, &z_p, &merged_path) {
+                                if let Err(e) = crate::weights::q4_weights::write_merged_qkvz(&qkv_p, &z_p, &merged_path) {
                                     eprintln!("[load] merge-on-first-load failed layer {i}: {e}; using CPU fallback");
                                     return Ok((i, None));
                                 }

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -133,6 +133,94 @@ struct QuantizeIndex {
     tensors: Vec<IndexEntry>,
 }
 
+/// Bounded size cap for `quantize_index.json` reads (#504 remaining slice 2).
+/// The index is a small per-tensor manifest (name/file/quantized/shape/numel
+/// per output tensor); even a multi-thousand-tensor checkpoint stays well
+/// under this cap. Bounding the read (stat-then-take, not a bare
+/// `fs::read`) prevents an unbounded allocation if the file is swapped for
+/// something huge between stat and read.
+#[cfg(any(test, feature = "metal-gpu"))]
+const MAX_QUANTIZE_INDEX_LEN: u64 = 16 * 1024 * 1024; // 16 MiB
+
+/// Read `quantize_index.json` under `dir`, bounded to
+/// [`MAX_QUANTIZE_INDEX_LEN`]. Returns `Ok(None)` only when the file is
+/// genuinely absent; any other failure (oversized, unreadable) is `Err`.
+///
+/// The only caller (`read_quarot_seed_from_index`, and in turn
+/// `MetalQwen35State::from_q4_dir`) is `metal-gpu`-gated; this is `#[cfg(any(test, ...))]`
+/// so the CPU-only test suite can exercise the real fail-closed logic
+/// without requiring a Metal GPU build (mirrors the slice-1 pattern in
+/// `weights/q4_weights.rs`).
+#[cfg(any(test, feature = "metal-gpu"))]
+fn read_quantize_index_bytes_bounded(path: &Path) -> Result<Option<Vec<u8>>, String> {
+    use std::io::Read;
+    let metadata = match fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(format!(
+                "{}: failed to stat quantize_index.json: {e}",
+                path.display()
+            ));
+        }
+    };
+    if metadata.len() > MAX_QUANTIZE_INDEX_LEN {
+        return Err(format!(
+            "{}: quantize_index.json too large: {} bytes exceeds cap of {MAX_QUANTIZE_INDEX_LEN} bytes",
+            path.display(),
+            metadata.len()
+        ));
+    }
+    let file = fs::File::open(path).map_err(|e| {
+        format!(
+            "{}: failed to open quantize_index.json: {e}",
+            path.display()
+        )
+    })?;
+    let mut buf = Vec::new();
+    file.take(MAX_QUANTIZE_INDEX_LEN.saturating_add(1))
+        .read_to_end(&mut buf)
+        .map_err(|e| {
+            format!(
+                "{}: failed to read quantize_index.json: {e}",
+                path.display()
+            )
+        })?;
+    if buf.len() as u64 > MAX_QUANTIZE_INDEX_LEN {
+        return Err(format!(
+            "{}: quantize_index.json too large: read exceeds cap of {MAX_QUANTIZE_INDEX_LEN} bytes",
+            path.display()
+        ));
+    }
+    Ok(Some(buf))
+}
+
+/// Read the QuaRot rotation seed from `quantize_index.json` per ADR-051.
+///
+/// Fail-closed contract (#504 remaining slice 2): a genuinely **absent**
+/// file is `Ok(None)` — pre-ADR-051 artifacts never had this file, and the
+/// caller falls back to the legacy `config.json` field
+/// (`quarot_rotation_seed`) for those. A **present** file that fails to
+/// read, exceeds the size cap, is not valid JSON, or does not match the
+/// `QuantizeIndex` schema is `Err`. Previously all three of "absent",
+/// "malformed", and "present without the key" collapsed to the same silent
+/// `None` — but a file that exists and doesn't parse is evidence of
+/// truncation/corruption/tampering, not a legitimate "no rotation"
+/// artifact, and silently falling back to the legacy seed (or no rotation
+/// at all) would apply the wrong rotation to a checkpoint that was
+/// actually QuaRot-rotated, silently corrupting inference output instead
+/// of refusing to load.
+#[cfg(any(test, feature = "metal-gpu"))]
+pub(crate) fn read_quarot_seed_from_index(q4_dir: &Path) -> Result<Option<u64>, String> {
+    let path = q4_dir.join("quantize_index.json");
+    let Some(bytes) = read_quantize_index_bytes_bounded(&path)? else {
+        return Ok(None);
+    };
+    let index: QuantizeIndex = serde_json::from_slice(&bytes)
+        .map_err(|e| format!("{}: malformed quantize_index.json: {e}", path.display()))?;
+    Ok(index.quarot_seed)
+}
+
 fn inject_quarot_seed(json: &str, seed: u64) -> Result<String, InferenceError> {
     let mut value: serde_json::Value = serde_json::from_str(json)
         .map_err(|e| InferenceError::Inference(format!("inject_quarot_seed: invalid JSON: {e}")))?;
@@ -2204,5 +2292,115 @@ mod tests {
             );
         }
         assert!(report.planned_quantized > 0);
+    }
+
+    // ------------------------------------------------------------------
+    // read_quarot_seed_from_index (#504 remaining slice 2: fail-closed
+    // integrity for `quantize_index.json`).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn read_quarot_seed_from_index_absent_file_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            read_quarot_seed_from_index(tmp.path()),
+            Ok(None),
+            "missing quantize_index.json must yield Ok(None), not an error"
+        );
+    }
+
+    #[test]
+    fn read_quarot_seed_from_index_without_key_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("quantize_index.json"), r#"{"tensors":[]}"#).unwrap();
+        assert_eq!(
+            read_quarot_seed_from_index(tmp.path()),
+            Ok(None),
+            "index without quarot_seed key must yield Ok(None)"
+        );
+    }
+
+    #[test]
+    fn read_quarot_seed_from_index_finds_seed() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("quantize_index.json"),
+            r#"{"quarot_seed":13258600446175248384,"tensors":[]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_quarot_seed_from_index(tmp.path()),
+            Ok(Some(13_258_600_446_175_248_384_u64)),
+            "index with quarot_seed key must round-trip the u64 exactly"
+        );
+    }
+
+    #[test]
+    fn read_quarot_seed_from_index_rejects_malformed_json() {
+        // #504 remaining slice 2: a *present* file that fails to parse must
+        // be a hard error, not a silent None — the pre-fix behavior treated
+        // corruption/truncation identically to "legitimately absent",
+        // which would silently apply the wrong (or no) QuaRot rotation to
+        // a checkpoint that actually needed one.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("quantize_index.json"), "not json").unwrap();
+        let err = read_quarot_seed_from_index(tmp.path())
+            .expect_err("malformed quantize_index.json must be rejected, not silently None");
+        assert!(
+            err.contains("malformed quantize_index.json"),
+            "error must name the malformed-index failure; got: {err}"
+        );
+    }
+
+    #[test]
+    fn read_quarot_seed_from_index_rejects_wrong_schema_shape() {
+        // `tensors` present but wrong type (string instead of an array) —
+        // valid JSON, but does not match the `QuantizeIndex` schema.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("quantize_index.json"),
+            r#"{"quarot_seed":42,"tensors":"not-an-array"}"#,
+        )
+        .unwrap();
+        assert!(
+            read_quarot_seed_from_index(tmp.path()).is_err(),
+            "schema-shape mismatch (tensors not an array) must be rejected"
+        );
+    }
+
+    #[test]
+    fn read_quarot_seed_from_index_rejects_truncated_file() {
+        // A file that exists but was cut off mid-write (e.g. a crash
+        // during `fs::write`) is invalid JSON and must fail closed.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("quantize_index.json"),
+            r#"{"quarot_seed":42,"tensors":[{"name":"foo","file":"foo.q4","quant"#,
+        )
+        .unwrap();
+        assert!(
+            read_quarot_seed_from_index(tmp.path()).is_err(),
+            "truncated quantize_index.json must be rejected"
+        );
+    }
+
+    #[test]
+    fn read_quarot_seed_from_index_rejects_oversized_file() {
+        // Bounded-read discipline (#504 remaining slice 1 pattern applied
+        // here): a file far larger than any real index should ever be
+        // must be rejected before it is fully read into memory.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("quantize_index.json");
+        // One byte over the cap; write sparsely via set_len to avoid
+        // actually allocating/writing 16 MiB+1 in the test.
+        let f = fs::File::create(&path).unwrap();
+        f.set_len(MAX_QUANTIZE_INDEX_LEN + 1).unwrap();
+        drop(f);
+        let err = read_quarot_seed_from_index(tmp.path())
+            .expect_err("oversized quantize_index.json must be rejected");
+        assert!(
+            err.contains("too large"),
+            "error must name the size-cap failure; got: {err}"
+        );
     }
 }

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -1095,7 +1095,14 @@ pub(crate) fn write_merged_qkvz(
     let qkv_payload_len = std::fs::metadata(qkv_path)
         .map_err(|e| format!("metadata {}: {e}", qkv_path.display()))?
         .len()
-        - qkv_hdr.payload_offset;
+        .checked_sub(qkv_hdr.payload_offset)
+        .ok_or_else(|| {
+            format!(
+                "{}: file truncated below header (shorter than payload_offset {})",
+                qkv_path.display(),
+                qkv_hdr.payload_offset
+            )
+        })?;
     let mut qkv_payload = Vec::with_capacity(qkv_payload_len as usize);
     qkv_rdr
         .read_to_end(&mut qkv_payload)
@@ -1111,7 +1118,14 @@ pub(crate) fn write_merged_qkvz(
     let z_payload_len = std::fs::metadata(z_path)
         .map_err(|e| format!("metadata {}: {e}", z_path.display()))?
         .len()
-        - z_hdr.payload_offset;
+        .checked_sub(z_hdr.payload_offset)
+        .ok_or_else(|| {
+            format!(
+                "{}: file truncated below header (shorter than payload_offset {})",
+                z_path.display(),
+                z_hdr.payload_offset
+            )
+        })?;
     let mut z_payload = Vec::with_capacity(z_payload_len as usize);
     z_rdr
         .read_to_end(&mut z_payload)

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -886,6 +886,282 @@ pub fn load_f16_tensor_file(
 }
 
 // ---------------------------------------------------------------------------
+// Merge-on-first-load `.q4` cache (`merged_qkvz_*.q4`) — content integrity
+// ---------------------------------------------------------------------------
+//
+// `forward::metal_qwen35`'s Metal loader merges each GatedDeltaNet layer's
+// `in_proj_qkv` and `in_proj_z` Q4 tensors into one `merged_qkvz_*.q4` file on
+// first load so later loads can zero-copy mmap it like any other Q4 weight.
+// The original cache-validity check compared only the merged file's *size*
+// against the current source files' sizes (`#504`, second slice): a
+// same-size stale or bit-rotted merged artifact would load silently. The
+// functions below add a fail-closed content hash on top of that size check,
+// mirroring `model::qwen`'s embedding-cache manifest guard (#504 first
+// slice): hash the *current* source payloads and the merged file's on-disk
+// payload, and only accept the cache when they match byte-for-byte via
+// SHA-256. Any read/parse error is treated as invalid (reject, don't warn)
+// so the caller always falls back to rebuilding the merge from trusted
+// sources rather than trusting a file it could not fully verify.
+
+/// Upper bound on a single `.q4` payload this module will read fully into
+/// memory for content-integrity hashing (merge-on-first-load source
+/// fingerprinting and merged-artifact verification). Generous relative to
+/// any single per-layer GatedDeltaNet `in_proj_qkv`/`in_proj_z` tensor, while
+/// still bounding the read so a corrupted or hostile file cannot drive an
+/// unbounded allocation.
+#[cfg(any(test, feature = "metal-gpu"))]
+pub(crate) const MAX_Q4_MERGE_PAYLOAD_LEN: u64 = 1 << 31; // 2 GiB
+
+/// Read and validate a `.q4` file's header via [`read_q4_header`], then read
+/// its payload (everything after the header) bounded by `max_len`.
+///
+/// The stat (via the header's file metadata) is only a fast-path; the read
+/// itself is bounded via `take(max_len + 1)`, so a file that grows or is
+/// swapped after the size check still cannot drive an allocation past the
+/// cap. Mirrors `model::qwen::read_embedding_cache_file_bounded`.
+///
+/// Only compiled for tests or the `metal-gpu` feature: its sole caller is
+/// the Metal merge-on-first-load `.q4` cache guard in
+/// `forward::metal_qwen35`, which itself only exists under `metal-gpu`.
+#[cfg(any(test, feature = "metal-gpu"))]
+pub(crate) fn read_q4_payload_bounded(
+    path: &std::path::Path,
+    max_len: u64,
+) -> Result<(Q4FileHeader, Vec<u8>), Box<dyn std::error::Error>> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let file = std::fs::File::open(path)?;
+    let header = read_q4_header(&file)?;
+    let file_len = file.metadata()?.len();
+    if file_len < header.payload_offset {
+        return Err(format!(
+            "{}: file truncated below header ({file_len} bytes < payload_offset {})",
+            path.display(),
+            header.payload_offset
+        )
+        .into());
+    }
+    let payload_len = file_len - header.payload_offset;
+    if payload_len > max_len {
+        return Err(format!(
+            "{}: payload too large: {payload_len} bytes exceeds cap of {max_len} bytes",
+            path.display()
+        )
+        .into());
+    }
+
+    let mut f = file;
+    f.seek(SeekFrom::Start(header.payload_offset))?;
+    let mut buf = Vec::new();
+    f.take(max_len.saturating_add(1)).read_to_end(&mut buf)?;
+    if buf.len() as u64 > max_len {
+        return Err(format!(
+            "{}: payload too large: read exceeds cap of {max_len} bytes",
+            path.display()
+        )
+        .into());
+    }
+    Ok((header, buf))
+}
+
+/// SHA-256 of `bytes`, formatted as lowercase hex. Mirrors
+/// `model::qwen::embedding_cache_sha256_hex` / `download::sha256_hex`.
+#[cfg(any(test, feature = "metal-gpu"))]
+pub(crate) fn q4_sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest.as_slice() {
+        use std::fmt::Write as _;
+        let _ = write!(&mut hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// Expected byte length of a `merged_qkvz_*.q4` file built from `qkv_file_len`
+/// and `z_file_len` (the on-disk lengths of the source `in_proj_qkv`/
+/// `in_proj_z` files): a 36-byte header (`ndim=2`, `payload_offset=36` — all
+/// source weight files are 2-D) plus both source payloads.
+///
+/// Returns `Err` instead of underflowing/panicking when a source file is
+/// smaller than its own 36-byte header (truncated/corrupt source), so a
+/// malformed source file fails closed here rather than wrapping to a bogus
+/// huge `u64` via unchecked subtraction.
+#[cfg(any(test, feature = "metal-gpu"))]
+pub(crate) fn merged_qkvz_expected_size(qkv_file_len: u64, z_file_len: u64) -> Result<u64, String> {
+    const HEADER_LEN: u64 = 36;
+    let qkv_payload_len = qkv_file_len.checked_sub(HEADER_LEN).ok_or_else(|| {
+        format!("qkv source file too small: {qkv_file_len} bytes < {HEADER_LEN}-byte header")
+    })?;
+    let z_payload_len = z_file_len.checked_sub(HEADER_LEN).ok_or_else(|| {
+        format!("z source file too small: {z_file_len} bytes < {HEADER_LEN}-byte header")
+    })?;
+    Ok(HEADER_LEN + qkv_payload_len + z_payload_len)
+}
+
+/// Content fingerprint (SHA-256 hex) of the *current* `qkv_path`/`z_path`
+/// source payloads, in write order (qkv then z) — i.e. exactly the bytes
+/// [`write_merged_qkvz`] would concatenate into a fresh merged file.
+///
+/// Reads both source payloads bounded by [`MAX_Q4_MERGE_PAYLOAD_LEN`].
+#[cfg(any(test, feature = "metal-gpu"))]
+pub(crate) fn merged_qkvz_source_fingerprint(
+    qkv_path: &std::path::Path,
+    z_path: &std::path::Path,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let (_qkv_hdr, mut qkv_payload) = read_q4_payload_bounded(qkv_path, MAX_Q4_MERGE_PAYLOAD_LEN)?;
+    let (_z_hdr, z_payload) = read_q4_payload_bounded(z_path, MAX_Q4_MERGE_PAYLOAD_LEN)?;
+    // Concatenate in write order (qkv then z) so this hashes exactly the
+    // bytes `write_merged_qkvz` would produce as the merged payload.
+    qkv_payload.extend_from_slice(&z_payload);
+    Ok(q4_sha256_hex(&qkv_payload))
+}
+
+/// Content fingerprint (SHA-256 hex) of an existing merged file's on-disk
+/// payload. Since [`write_merged_qkvz`] writes exactly `qkv_payload ||
+/// z_payload` after its header, a valid, uncorrupted merged file's
+/// fingerprint equals [`merged_qkvz_source_fingerprint`] computed from the
+/// same source files at write time.
+///
+/// Reads the merged payload bounded by [`MAX_Q4_MERGE_PAYLOAD_LEN`].
+#[cfg(any(test, feature = "metal-gpu"))]
+pub(crate) fn merged_qkvz_file_fingerprint(
+    merged_path: &std::path::Path,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let (_hdr, payload) = read_q4_payload_bounded(merged_path, MAX_Q4_MERGE_PAYLOAD_LEN)?;
+    Ok(q4_sha256_hex(&payload))
+}
+
+/// Fail-closed validity check for a `merged_qkvz_*.q4` cache entry.
+///
+/// Returns `true` only when `merged_path` exists, its size matches
+/// `expected_size`, and its content fingerprint matches a fingerprint
+/// freshly derived from the *current* `qkv_path`/`z_path` source files. Any
+/// I/O error, oversized payload, or malformed header on either side is
+/// treated as invalid — this never warns-and-continues on a mismatch, it
+/// always reports "rebuild from source" via `false`, so the caller
+/// re-derives the merge from trusted inputs instead of trusting a merged
+/// artifact it could not fully verify.
+#[cfg(any(test, feature = "metal-gpu"))]
+pub(crate) fn merged_qkvz_cache_is_valid(
+    merged_path: &std::path::Path,
+    expected_size: u64,
+    qkv_path: &std::path::Path,
+    z_path: &std::path::Path,
+) -> bool {
+    let Ok(metadata) = std::fs::metadata(merged_path) else {
+        return false;
+    };
+    if metadata.len() != expected_size {
+        return false;
+    }
+    let Ok(source_fp) = merged_qkvz_source_fingerprint(qkv_path, z_path) else {
+        return false;
+    };
+    let Ok(file_fp) = merged_qkvz_file_fingerprint(merged_path) else {
+        return false;
+    };
+    source_fp == file_fp
+}
+
+/// Merge two Q4 files into a single concatenated Q4 file and write it to
+/// `out_path`.
+///
+/// Reads only the raw bytes (no deserialization) and prepends a new KHQ4
+/// header reflecting the merged shape. Uses a temp-file + atomic rename so a
+/// crashed mid-write never leaves a partial file at the final path.
+///
+/// Returns `Err` if the model directory is read-only or I/O fails — callers
+/// must fall back to the CPU concat path in that case.
+#[cfg(any(test, feature = "metal-gpu"))]
+pub(crate) fn write_merged_qkvz(
+    qkv_path: &std::path::Path,
+    z_path: &std::path::Path,
+    out_path: &std::path::Path,
+) -> Result<(), String> {
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    // Open and parse headers — then seek back to payload start for a direct byte copy.
+    let qkv_file =
+        std::fs::File::open(qkv_path).map_err(|e| format!("open {}: {e}", qkv_path.display()))?;
+    let qkv_hdr =
+        read_q4_header(&qkv_file).map_err(|e| format!("header {}: {e}", qkv_path.display()))?;
+    let mut qkv_rdr = qkv_file;
+    qkv_rdr
+        .seek(SeekFrom::Start(qkv_hdr.payload_offset))
+        .map_err(|e| format!("seek {}: {e}", qkv_path.display()))?;
+    let qkv_payload_len = std::fs::metadata(qkv_path)
+        .map_err(|e| format!("metadata {}: {e}", qkv_path.display()))?
+        .len()
+        - qkv_hdr.payload_offset;
+    let mut qkv_payload = Vec::with_capacity(qkv_payload_len as usize);
+    qkv_rdr
+        .read_to_end(&mut qkv_payload)
+        .map_err(|e| format!("read {}: {e}", qkv_path.display()))?;
+
+    let z_file =
+        std::fs::File::open(z_path).map_err(|e| format!("open {}: {e}", z_path.display()))?;
+    let z_hdr = read_q4_header(&z_file).map_err(|e| format!("header {}: {e}", z_path.display()))?;
+    let mut z_rdr = z_file;
+    z_rdr
+        .seek(SeekFrom::Start(z_hdr.payload_offset))
+        .map_err(|e| format!("seek {}: {e}", z_path.display()))?;
+    let z_payload_len = std::fs::metadata(z_path)
+        .map_err(|e| format!("metadata {}: {e}", z_path.display()))?
+        .len()
+        - z_hdr.payload_offset;
+    let mut z_payload = Vec::with_capacity(z_payload_len as usize);
+    z_rdr
+        .read_to_end(&mut z_payload)
+        .map_err(|e| format!("read {}: {e}", z_path.display()))?;
+
+    // Merged shape: rows = qkv_rows + z_rows, cols = hidden (shared)
+    let merged_rows = qkv_hdr.shape[0] + z_hdr.shape[0];
+    let cols = if qkv_hdr.shape.len() >= 2 {
+        qkv_hdr.shape[1]
+    } else {
+        1
+    };
+    let original_len = qkv_hdr.original_len + z_hdr.original_len;
+
+    // Write to a temp file then rename atomically so partial writes are never trusted.
+    let tmp = out_path.with_extension("q4.tmp");
+    let write_result = (|| -> Result<(), String> {
+        let mut f = std::io::BufWriter::new(
+            std::fs::File::create(&tmp).map_err(|e| format!("create {}: {e}", tmp.display()))?,
+        );
+        // KHQ4 header: magic(4) + version(4) + ndim=2(4) + shape[0](8) + shape[1](8) + original_len(8)
+        f.write_all(b"KHQ4").map_err(|e| e.to_string())?;
+        // Version 2: asymmetric Q4 blocks (20 bytes each: scale + bias + 16 nibbles).
+        f.write_all(&2u32.to_le_bytes())
+            .map_err(|e| e.to_string())?;
+        f.write_all(&2u32.to_le_bytes())
+            .map_err(|e| e.to_string())?;
+        f.write_all(&(merged_rows as u64).to_le_bytes())
+            .map_err(|e| e.to_string())?;
+        f.write_all(&(cols as u64).to_le_bytes())
+            .map_err(|e| e.to_string())?;
+        f.write_all(&(original_len as u64).to_le_bytes())
+            .map_err(|e| e.to_string())?;
+        f.write_all(&qkv_payload).map_err(|e| e.to_string())?;
+        f.write_all(&z_payload).map_err(|e| e.to_string())?;
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return write_result;
+    }
+
+    std::fs::rename(&tmp, out_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("rename: {e}")
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -2119,5 +2395,256 @@ mod tests {
             result.is_err(),
             "+inf in weight block must be rejected with InvalidInput"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Merge-on-first-load `merged_qkvz_*.q4` cache — content-integrity guard
+    // (#504 remaining slice: "Merged-Q4 cache: compatibility check is
+    // size-only — no content integrity on the merged artifact.")
+    //
+    // Mutation sensitivity: `merged_qkvz_cache_is_valid`'s size check alone
+    // (the pre-fix behavior) would accept a same-size tampered/stale merged
+    // file. `test_merged_qkvz_cache_rejects_same_size_corrupted_payload` and
+    // `test_merged_qkvz_cache_rejects_same_size_stale_source` are the
+    // discriminating tests: reverting the fingerprint comparison back to a
+    // bare `metadata.len() == expected_size` check makes both pass
+    // incorrectly (`is_valid` would wrongly return `true`), so they fail
+    // under the reverted code. Verified manually per the task's mutation-test
+    // protocol — see the session report for the reverse-apply/touch/restore
+    // proof.
+    // -----------------------------------------------------------------------
+
+    /// Write a minimal valid 2-D `.q4` source file (`shape = [rows, cols]`,
+    /// `rows * cols` must be a multiple of 32) with content derived from
+    /// `seed` so distinct seeds produce distinct payload bytes.
+    fn write_test_q4_source(path: &std::path::Path, rows: usize, cols: usize, seed: f32) {
+        let n = rows * cols;
+        let f32_vals: Vec<f32> = (0..n).map(|i| (i as f32 + seed) % 7.0 - 3.0).collect();
+        let bf16_vals = to_bf16(&f32_vals);
+        let tensor = quantize_bf16_to_q4(&bf16_vals, &[rows, cols]).unwrap();
+        save_q4_file(path, &tensor).unwrap();
+    }
+
+    /// Build a fresh temp-dir-scoped triple of (qkv_path, z_path, merged_path)
+    /// for one test, so parallel `cargo test` runs never collide on the same
+    /// file. `qkv_seed`/`z_seed` control the source payload content.
+    fn merge_test_paths(
+        name: &str,
+    ) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!("lattice_test_merged_qkvz_{name}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        (dir.join("qkv.q4"), dir.join("z.q4"), dir.join("merged.q4"))
+    }
+
+    #[test]
+    fn test_merged_qkvz_expected_size_computes_correctly() {
+        // 36-byte header each; qkv payload = 100 bytes, z payload = 40 bytes.
+        let expected = merged_qkvz_expected_size(136, 76).unwrap();
+        assert_eq!(expected, 36 + 100 + 40);
+    }
+
+    #[test]
+    fn test_merged_qkvz_expected_size_rejects_truncated_source() {
+        // A source file shorter than its own 36-byte header must fail
+        // closed (`Err`), not underflow/panic via unchecked subtraction.
+        let err = merged_qkvz_expected_size(20, 136).unwrap_err();
+        assert!(
+            err.contains("too small"),
+            "expected a too-small error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_write_merged_qkvz_then_cache_is_valid() {
+        let (qkv_p, z_p, merged_p) = merge_test_paths("valid");
+        write_test_q4_source(&qkv_p, 4, 8, 1.0);
+        write_test_q4_source(&z_p, 4, 8, 5.0);
+
+        write_merged_qkvz(&qkv_p, &z_p, &merged_p).unwrap();
+
+        let qkv_len = std::fs::metadata(&qkv_p).unwrap().len();
+        let z_len = std::fs::metadata(&z_p).unwrap().len();
+        let expected_size = merged_qkvz_expected_size(qkv_len, z_len).unwrap();
+
+        assert!(
+            merged_qkvz_cache_is_valid(&merged_p, expected_size, &qkv_p, &z_p),
+            "freshly written merged cache must validate against its own sources"
+        );
+
+        std::fs::remove_dir_all(merged_p.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn test_merged_qkvz_cache_rejects_missing_file() {
+        let (qkv_p, z_p, merged_p) = merge_test_paths("missing");
+        write_test_q4_source(&qkv_p, 4, 8, 1.0);
+        write_test_q4_source(&z_p, 4, 8, 5.0);
+        let qkv_len = std::fs::metadata(&qkv_p).unwrap().len();
+        let z_len = std::fs::metadata(&z_p).unwrap().len();
+        let expected_size = merged_qkvz_expected_size(qkv_len, z_len).unwrap();
+
+        // merged_p was never written.
+        assert!(!merged_qkvz_cache_is_valid(
+            &merged_p,
+            expected_size,
+            &qkv_p,
+            &z_p
+        ));
+
+        std::fs::remove_dir_all(merged_p.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn test_merged_qkvz_cache_rejects_wrong_size() {
+        let (qkv_p, z_p, merged_p) = merge_test_paths("wrongsize");
+        write_test_q4_source(&qkv_p, 4, 8, 1.0);
+        write_test_q4_source(&z_p, 4, 8, 5.0);
+        write_merged_qkvz(&qkv_p, &z_p, &merged_p).unwrap();
+
+        // Append a stray byte, making the on-disk size disagree with
+        // `expected_size`.
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&merged_p)
+                .unwrap();
+            f.write_all(&[0xAA]).unwrap();
+        }
+
+        let qkv_len = std::fs::metadata(&qkv_p).unwrap().len();
+        let z_len = std::fs::metadata(&z_p).unwrap().len();
+        let expected_size = merged_qkvz_expected_size(qkv_len, z_len).unwrap();
+
+        assert!(!merged_qkvz_cache_is_valid(
+            &merged_p,
+            expected_size,
+            &qkv_p,
+            &z_p
+        ));
+
+        std::fs::remove_dir_all(merged_p.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn test_merged_qkvz_cache_rejects_truncated_file() {
+        let (qkv_p, z_p, merged_p) = merge_test_paths("truncated");
+        write_test_q4_source(&qkv_p, 4, 8, 1.0);
+        write_test_q4_source(&z_p, 4, 8, 5.0);
+        write_merged_qkvz(&qkv_p, &z_p, &merged_p).unwrap();
+
+        let full_len = std::fs::metadata(&merged_p).unwrap().len();
+        let bytes = std::fs::read(&merged_p).unwrap();
+        std::fs::write(&merged_p, &bytes[..bytes.len() - 10]).unwrap();
+
+        let qkv_len = std::fs::metadata(&qkv_p).unwrap().len();
+        let z_len = std::fs::metadata(&z_p).unwrap().len();
+        let expected_size = merged_qkvz_expected_size(qkv_len, z_len).unwrap();
+        assert_eq!(expected_size, full_len, "sanity: source sizes unchanged");
+
+        assert!(!merged_qkvz_cache_is_valid(
+            &merged_p,
+            expected_size,
+            &qkv_p,
+            &z_p
+        ));
+
+        std::fs::remove_dir_all(merged_p.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn test_merged_qkvz_cache_rejects_same_size_corrupted_payload() {
+        // Same-size bit flip inside the merged payload — the pre-fix
+        // size-only check would accept this file unchanged. This is the
+        // mutation-sensitive case for the content-integrity fix itself.
+        let (qkv_p, z_p, merged_p) = merge_test_paths("corrupted");
+        write_test_q4_source(&qkv_p, 4, 8, 1.0);
+        write_test_q4_source(&z_p, 4, 8, 5.0);
+        write_merged_qkvz(&qkv_p, &z_p, &merged_p).unwrap();
+
+        let qkv_len = std::fs::metadata(&qkv_p).unwrap().len();
+        let z_len = std::fs::metadata(&z_p).unwrap().len();
+        let expected_size = merged_qkvz_expected_size(qkv_len, z_len).unwrap();
+        let full_len = std::fs::metadata(&merged_p).unwrap().len();
+        assert_eq!(
+            full_len, expected_size,
+            "sanity: size unchanged by corruption"
+        );
+
+        // Flip one byte well inside the payload region (after the 36-byte
+        // header) without changing the file's length.
+        let mut bytes = std::fs::read(&merged_p).unwrap();
+        let flip_at = bytes.len() - 5;
+        bytes[flip_at] ^= 0xFF;
+        std::fs::write(&merged_p, &bytes).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&merged_p).unwrap().len(),
+            expected_size,
+            "sanity: byte flip must not change file size"
+        );
+
+        assert!(
+            !merged_qkvz_cache_is_valid(&merged_p, expected_size, &qkv_p, &z_p),
+            "a same-size, bit-flipped merged payload must fail the content-integrity check \
+             even though the size-only check would have accepted it"
+        );
+
+        std::fs::remove_dir_all(merged_p.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn test_merged_qkvz_cache_rejects_same_size_stale_source() {
+        // The z source file changes content (e.g. a re-quantize with
+        // different weights) but keeps the exact same byte length, so the
+        // merged filename (which encodes only sizes) and `expected_size`
+        // are both unchanged. The stale merged cache must still be
+        // rejected once content is checked.
+        let (qkv_p, z_p, merged_p) = merge_test_paths("stale");
+        write_test_q4_source(&qkv_p, 4, 8, 1.0);
+        write_test_q4_source(&z_p, 4, 8, 5.0);
+        write_merged_qkvz(&qkv_p, &z_p, &merged_p).unwrap();
+
+        let qkv_len = std::fs::metadata(&qkv_p).unwrap().len();
+        let z_len_before = std::fs::metadata(&z_p).unwrap().len();
+
+        // Re-write z with different content but the same shape (same size).
+        write_test_q4_source(&z_p, 4, 8, 99.0);
+        let z_len_after = std::fs::metadata(&z_p).unwrap().len();
+        assert_eq!(
+            z_len_before, z_len_after,
+            "sanity: same shape must produce the same file size"
+        );
+
+        let expected_size = merged_qkvz_expected_size(qkv_len, z_len_after).unwrap();
+        assert_eq!(
+            std::fs::metadata(&merged_p).unwrap().len(),
+            expected_size,
+            "sanity: merged file size still matches (source size unchanged)"
+        );
+
+        assert!(
+            !merged_qkvz_cache_is_valid(&merged_p, expected_size, &qkv_p, &z_p),
+            "a same-size stale source must invalidate the merged cache once content is checked"
+        );
+
+        std::fs::remove_dir_all(merged_p.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn test_merged_qkvz_source_fingerprint_matches_file_fingerprint_after_write() {
+        let (qkv_p, z_p, merged_p) = merge_test_paths("fingerprint");
+        write_test_q4_source(&qkv_p, 4, 8, 2.0);
+        write_test_q4_source(&z_p, 4, 8, 6.0);
+        write_merged_qkvz(&qkv_p, &z_p, &merged_p).unwrap();
+
+        let source_fp = merged_qkvz_source_fingerprint(&qkv_p, &z_p).unwrap();
+        let file_fp = merged_qkvz_file_fingerprint(&merged_p).unwrap();
+        assert_eq!(
+            source_fp, file_fp,
+            "a freshly written merged file's payload fingerprint must equal its sources' fingerprint"
+        );
+
+        std::fs::remove_dir_all(merged_p.parent().unwrap()).ok();
     }
 }

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -1081,54 +1081,15 @@ pub(crate) fn write_merged_qkvz(
     z_path: &std::path::Path,
     out_path: &std::path::Path,
 ) -> Result<(), String> {
-    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::io::Write;
 
-    // Open and parse headers — then seek back to payload start for a direct byte copy.
-    let qkv_file =
-        std::fs::File::open(qkv_path).map_err(|e| format!("open {}: {e}", qkv_path.display()))?;
-    let qkv_hdr =
-        read_q4_header(&qkv_file).map_err(|e| format!("header {}: {e}", qkv_path.display()))?;
-    let mut qkv_rdr = qkv_file;
-    qkv_rdr
-        .seek(SeekFrom::Start(qkv_hdr.payload_offset))
-        .map_err(|e| format!("seek {}: {e}", qkv_path.display()))?;
-    let qkv_payload_len = std::fs::metadata(qkv_path)
-        .map_err(|e| format!("metadata {}: {e}", qkv_path.display()))?
-        .len()
-        .checked_sub(qkv_hdr.payload_offset)
-        .ok_or_else(|| {
-            format!(
-                "{}: file truncated below header (shorter than payload_offset {})",
-                qkv_path.display(),
-                qkv_hdr.payload_offset
-            )
-        })?;
-    let mut qkv_payload = Vec::with_capacity(qkv_payload_len as usize);
-    qkv_rdr
-        .read_to_end(&mut qkv_payload)
+    // Bounded reads with the same cap as the validator: a stat-then-
+    // `read_to_end` here would let a source file that grows between the
+    // metadata check and the read drive an unbounded allocation during a
+    // cache rebuild.
+    let (qkv_hdr, qkv_payload) = read_q4_payload_bounded(qkv_path, MAX_Q4_MERGE_PAYLOAD_LEN)
         .map_err(|e| format!("read {}: {e}", qkv_path.display()))?;
-
-    let z_file =
-        std::fs::File::open(z_path).map_err(|e| format!("open {}: {e}", z_path.display()))?;
-    let z_hdr = read_q4_header(&z_file).map_err(|e| format!("header {}: {e}", z_path.display()))?;
-    let mut z_rdr = z_file;
-    z_rdr
-        .seek(SeekFrom::Start(z_hdr.payload_offset))
-        .map_err(|e| format!("seek {}: {e}", z_path.display()))?;
-    let z_payload_len = std::fs::metadata(z_path)
-        .map_err(|e| format!("metadata {}: {e}", z_path.display()))?
-        .len()
-        .checked_sub(z_hdr.payload_offset)
-        .ok_or_else(|| {
-            format!(
-                "{}: file truncated below header (shorter than payload_offset {})",
-                z_path.display(),
-                z_hdr.payload_offset
-            )
-        })?;
-    let mut z_payload = Vec::with_capacity(z_payload_len as usize);
-    z_rdr
-        .read_to_end(&mut z_payload)
+    let (z_hdr, z_payload) = read_q4_payload_bounded(z_path, MAX_Q4_MERGE_PAYLOAD_LEN)
         .map_err(|e| format!("read {}: {e}", z_path.display()))?;
 
     // Merged shape: rows = qkv_rows + z_rows, cols = hidden (shared)
@@ -2483,6 +2444,34 @@ mod tests {
         assert!(
             merged_qkvz_cache_is_valid(&merged_p, expected_size, &qkv_p, &z_p),
             "freshly written merged cache must validate against its own sources"
+        );
+
+        std::fs::remove_dir_all(merged_p.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn test_write_merged_qkvz_rejects_oversized_source_payload() {
+        // A source file whose payload exceeds MAX_Q4_MERGE_PAYLOAD_LEN must
+        // fail closed BEFORE any payload allocation — the rebuild path uses
+        // the same bounded reader as the validator. `set_len` produces a
+        // sparse file, so this asserts the cap without 2 GiB of disk I/O.
+        let (qkv_p, z_p, merged_p) = merge_test_paths("oversized_source");
+        write_test_q4_source(&qkv_p, 4, 8, 1.0);
+        write_test_q4_source(&z_p, 4, 8, 5.0);
+
+        let f = std::fs::File::options().write(true).open(&qkv_p).unwrap();
+        f.set_len(36 + MAX_Q4_MERGE_PAYLOAD_LEN + 1).unwrap();
+        drop(f);
+
+        let err = write_merged_qkvz(&qkv_p, &z_p, &merged_p)
+            .expect_err("oversized source payload must be rejected, not read to EOF");
+        assert!(
+            err.contains("payload too large"),
+            "expected a payload-cap error, got: {err}"
+        );
+        assert!(
+            !merged_p.exists(),
+            "no merged artifact may be produced from a rejected source"
         );
 
         std::fs::remove_dir_all(merged_p.parent().unwrap()).ok();

--- a/crates/tune/src/registry/storage/registry.rs
+++ b/crates/tune/src/registry/storage/registry.rs
@@ -302,23 +302,29 @@ impl ModelRegistry {
         names
     }
 
-    /// Load model weights
+    /// Load model weights, verifying the recorded checksum when one is on
+    /// record.
+    ///
+    /// #504 remaining slice 3: this used to be a pure raw load with **no**
+    /// checksum check at all — a caller reaching for the "obvious" method
+    /// name silently bypassed the verification `load_weights_verified`
+    /// performed, even though every model registered via [`Self::register`]
+    /// always carries a `weights_hash`. Fail-closed discipline now applies
+    /// here too: if `model.weights_hash` is `Some`, a mismatch is a hard
+    /// `TuneError::WeightIntegrityError`, not a silent pass-through. A
+    /// model with no recorded hash at all (e.g. [`Self::register_metadata`]
+    /// with weights added out-of-band, or a legacy pre-hash record) has
+    /// nothing to check against and loads unverified — that is the only
+    /// remaining "raw" case, and it is explicit (a `None` hash on the
+    /// record), never a silent skip of a hash that *is* present.
     pub fn load_weights(&self, model: &RegisteredModel) -> Result<Vec<u8>> {
         let path = model
             .weights_path
             .as_ref()
             .ok_or_else(|| TuneError::Storage("No weights path".to_string()))?;
 
-        self.storage.lock().load(path)
-    }
+        let weights = self.storage.lock().load(path)?;
 
-    /// Load model weights with checksum verification
-    ///
-    /// Returns `TuneError::WeightIntegrityError` if checksum doesn't match.
-    pub fn load_weights_verified(&self, model: &RegisteredModel) -> Result<Vec<u8>> {
-        let weights = self.load_weights(model)?;
-
-        // Verify checksum if available
         if let Some(ref expected_hash) = model.weights_hash {
             let actual_hash = sha256_hash(&weights);
             if &actual_hash != expected_hash {
@@ -330,6 +336,31 @@ impl ModelRegistry {
         }
 
         Ok(weights)
+    }
+
+    /// Load model weights, **requiring** a recorded checksum to verify
+    /// against.
+    ///
+    /// This is [`Self::load_weights`] (which already verifies whenever a
+    /// hash is on record) plus one additional guarantee for callers that
+    /// explicitly want verification: a model with **no** recorded
+    /// `weights_hash` is rejected rather than silently loaded unverified.
+    /// Use this entry point wherever the caller's contract requires "this
+    /// load is verified", and [`Self::load_weights`] only when an
+    /// unverified load of a hash-less (metadata-only-registered) model is
+    /// an accepted, understood case.
+    ///
+    /// Returns `TuneError::WeightIntegrityError` if the checksum doesn't
+    /// match, or `TuneError::Storage` if no checksum is on record at all.
+    pub fn load_weights_verified(&self, model: &RegisteredModel) -> Result<Vec<u8>> {
+        if model.weights_hash.is_none() {
+            return Err(TuneError::Storage(format!(
+                "load_weights_verified: model {} ({} v{}) has no recorded \
+                 weights_hash to verify against",
+                model.id, model.name, model.version
+            )));
+        }
+        self.load_weights(model)
     }
 
     /// Get number of registered models (lock-free snapshot)

--- a/crates/tune/src/registry/storage/registry.rs
+++ b/crates/tune/src/registry/storage/registry.rs
@@ -310,22 +310,49 @@ impl ModelRegistry {
     /// name silently bypassed the verification `load_weights_verified`
     /// performed, even though every model registered via [`Self::register`]
     /// always carries a `weights_hash`. Fail-closed discipline now applies
-    /// here too: if `model.weights_hash` is `Some`, a mismatch is a hard
-    /// `TuneError::WeightIntegrityError`, not a silent pass-through. A
-    /// model with no recorded hash at all (e.g. [`Self::register_metadata`]
-    /// with weights added out-of-band, or a legacy pre-hash record) has
-    /// nothing to check against and loads unverified — that is the only
-    /// remaining "raw" case, and it is explicit (a `None` hash on the
-    /// record), never a silent skip of a hash that *is* present.
+    /// here too: a hash mismatch is a hard
+    /// `TuneError::WeightIntegrityError`, not a silent pass-through.
+    ///
+    /// Verification is anchored to the **canonical registry record**
+    /// (resolved by `model.id` from the registry's own snapshot), never to
+    /// the caller-provided value: [`RegisteredModel`] is a plain DTO with
+    /// public `weights_path`/`weights_hash` fields, so a mutated clone
+    /// could otherwise redirect the load to a different path or "verify"
+    /// tampered bytes against a recomputed hash. A caller argument that
+    /// disagrees with the canonical record on either field is rejected
+    /// outright. A model whose *canonical* record has no hash at all
+    /// (e.g. [`Self::register_metadata`] with weights added out-of-band,
+    /// or a legacy pre-hash record) has nothing to check against and loads
+    /// unverified — that is the only remaining "raw" case, and it is
+    /// explicit (a `None` hash on the canonical record), never a silent
+    /// skip of a hash that *is* present.
     pub fn load_weights(&self, model: &RegisteredModel) -> Result<Vec<u8>> {
-        let path = model
+        let snap = self.models.load();
+        let canonical = snap
+            .get(&model.id)
+            .ok_or_else(|| TuneError::ModelNotFound {
+                name: model.name.clone(),
+                version: model.version.clone(),
+            })?;
+
+        if model.weights_path != canonical.weights_path
+            || model.weights_hash != canonical.weights_hash
+        {
+            return Err(TuneError::Storage(format!(
+                "load_weights: model {} argument disagrees with the canonical registry \
+                 record on weights_path/weights_hash; refusing to load from a mutated clone",
+                model.id
+            )));
+        }
+
+        let path = canonical
             .weights_path
             .as_ref()
             .ok_or_else(|| TuneError::Storage("No weights path".to_string()))?;
 
         let weights = self.storage.lock().load(path)?;
 
-        if let Some(ref expected_hash) = model.weights_hash {
+        if let Some(ref expected_hash) = canonical.weights_hash {
             let actual_hash = sha256_hash(&weights);
             if &actual_hash != expected_hash {
                 return Err(TuneError::WeightIntegrityError {
@@ -352,14 +379,27 @@ impl ModelRegistry {
     ///
     /// Returns `TuneError::WeightIntegrityError` if the checksum doesn't
     /// match, or `TuneError::Storage` if no checksum is on record at all.
+    ///
+    /// Like [`Self::load_weights`], the "is a hash on record" decision is
+    /// made against the canonical registry record, not the caller's clone
+    /// (whose public `weights_hash` field could have been set to `None` or
+    /// to a recomputed hash of tampered bytes).
     pub fn load_weights_verified(&self, model: &RegisteredModel) -> Result<Vec<u8>> {
-        if model.weights_hash.is_none() {
+        let snap = self.models.load();
+        let canonical = snap
+            .get(&model.id)
+            .ok_or_else(|| TuneError::ModelNotFound {
+                name: model.name.clone(),
+                version: model.version.clone(),
+            })?;
+        if canonical.weights_hash.is_none() {
             return Err(TuneError::Storage(format!(
                 "load_weights_verified: model {} ({} v{}) has no recorded \
                  weights_hash to verify against",
                 model.id, model.name, model.version
             )));
         }
+        drop(snap);
         self.load_weights(model)
     }
 

--- a/crates/tune/src/registry/storage/tests.rs
+++ b/crates/tune/src/registry/storage/tests.rs
@@ -172,6 +172,101 @@ fn test_load_weights_rejects_tampered_bytes_on_disk() {
 }
 
 #[test]
+fn test_load_weights_rejects_mutated_clone_hash() {
+    // `RegisteredModel` is a cloned DTO with public `weights_path`/
+    // `weights_hash` fields. If verification trusted the CALLER's value, a
+    // caller could tamper weights.bin on disk, set its clone's hash to
+    // sha256(tampered bytes), and have both entry points "verify" the
+    // tampered artifact. Verification must anchor to the canonical
+    // registry record and reject a disagreeing argument outright.
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = ModelRegistry::with_path(tmp.path()).unwrap();
+    let model = RegisteredModel::new("test", "1.0.0");
+    let weights = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+
+    let id = registry.register(model, &weights).unwrap();
+
+    // Tamper the on-disk artifact, then forge the clone's hash to match
+    // the tampered bytes.
+    let weights_path = tmp.path().join("test/1.0.0/weights.bin");
+    let mut tampered = weights.clone();
+    tampered[0] ^= 0xFF;
+    std::fs::write(&weights_path, &tampered).unwrap();
+
+    let mut forged = registry.get_by_id(&id).unwrap();
+    forged.weights_hash = Some(sha256_hash(&tampered));
+
+    let err = registry
+        .load_weights(&forged)
+        .expect_err("load_weights must not verify against a caller-forged hash");
+    assert!(
+        matches!(err, TuneError::Storage(_)),
+        "expected canonical-record disagreement rejection, got: {err:?}"
+    );
+    let err = registry
+        .load_weights_verified(&forged)
+        .expect_err("load_weights_verified must not verify against a caller-forged hash");
+    assert!(
+        matches!(err, TuneError::Storage(_)),
+        "expected canonical-record disagreement rejection, got: {err:?}"
+    );
+
+    // Blanking the clone's hash must not re-open the pre-#504 raw-load
+    // path either — the canonical record still carries a hash.
+    let mut hashless = registry.get_by_id(&id).unwrap();
+    hashless.weights_hash = None;
+    let err = registry
+        .load_weights(&hashless)
+        .expect_err("load_weights must not raw-load because a CLONE's hash was blanked");
+    assert!(
+        matches!(err, TuneError::Storage(_)),
+        "expected canonical-record disagreement rejection, got: {err:?}"
+    );
+    let err = registry
+        .load_weights_verified(&hashless)
+        .expect_err("load_weights_verified must not raw-load a hash-blanked clone");
+    assert!(
+        matches!(err, TuneError::Storage(_)),
+        "expected canonical-record disagreement rejection, got: {err:?}"
+    );
+
+    // The honest canonical record still rejects the tampered disk bytes
+    // via the checksum itself.
+    let canonical = registry.get_by_id(&id).unwrap();
+    let err = registry
+        .load_weights(&canonical)
+        .expect_err("canonical record must reject tampered disk bytes");
+    assert!(
+        matches!(err, TuneError::WeightIntegrityError { .. }),
+        "expected WeightIntegrityError, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_load_weights_rejects_unregistered_model() {
+    // A RegisteredModel value that was never registered (or was deleted)
+    // has no canonical record to verify against — it must not load at all.
+    let registry = ModelRegistry::in_memory();
+    let mut ghost = RegisteredModel::new("ghost", "1.0.0");
+    ghost.weights_path = Some("ghost/1.0.0/weights.bin".to_string());
+
+    let err = registry
+        .load_weights(&ghost)
+        .expect_err("load_weights must reject a model with no registry record");
+    assert!(
+        matches!(err, TuneError::ModelNotFound { .. }),
+        "expected ModelNotFound, got: {err:?}"
+    );
+    let err = registry
+        .load_weights_verified(&ghost)
+        .expect_err("load_weights_verified must reject a model with no registry record");
+    assert!(
+        matches!(err, TuneError::ModelNotFound { .. }),
+        "expected ModelNotFound, got: {err:?}"
+    );
+}
+
+#[test]
 fn test_load_weights_rejects_truncated_file_on_disk() {
     let tmp = tempfile::tempdir().unwrap();
     let registry = ModelRegistry::with_path(tmp.path()).unwrap();

--- a/crates/tune/src/registry/storage/tests.rs
+++ b/crates/tune/src/registry/storage/tests.rs
@@ -104,6 +104,122 @@ fn test_registry_delete() {
     assert!(registry.is_empty());
 }
 
+// ------------------------------------------------------------------
+// load_weights / load_weights_verified integrity (#504 remaining slice 3:
+// close the registry raw-load bypass — `load_weights` no longer silently
+// skips the checksum check when a hash is on record).
+// ------------------------------------------------------------------
+
+#[test]
+fn test_load_weights_verifies_when_hash_present() {
+    let registry = ModelRegistry::in_memory();
+    let model = RegisteredModel::new("test", "1.0.0");
+    let weights = vec![1u8, 2, 3, 4, 5];
+
+    let id = registry.register(model, &weights).unwrap();
+    let registered = registry.get_by_id(&id).unwrap();
+    assert!(
+        registered.weights_hash.is_some(),
+        "register() must always record a weights_hash"
+    );
+
+    // Untampered load succeeds via both entry points.
+    assert_eq!(registry.load_weights(&registered).unwrap(), weights);
+    assert_eq!(
+        registry.load_weights_verified(&registered).unwrap(),
+        weights
+    );
+}
+
+#[test]
+fn test_load_weights_rejects_tampered_bytes_on_disk() {
+    // #504 remaining slice 3: previously `load_weights` was a pure raw
+    // read with zero checksum check — a byte flipped on disk (or a
+    // truncated file, or a full swap) would load silently. It must now
+    // be rejected via the SAME entry point a naive caller reaches for,
+    // not only via `load_weights_verified`.
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = ModelRegistry::with_path(tmp.path()).unwrap();
+    let model = RegisteredModel::new("test", "1.0.0");
+    let weights = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+
+    let id = registry.register(model, &weights).unwrap();
+    let registered = registry.get_by_id(&id).unwrap();
+
+    // Tamper with the on-disk weights file directly (flip one byte,
+    // same length — the size-only-adjacent failure mode).
+    let weights_path = tmp.path().join("test/1.0.0/weights.bin");
+    let mut tampered = weights.clone();
+    tampered[3] ^= 0xFF;
+    std::fs::write(&weights_path, &tampered).unwrap();
+
+    let err = registry
+        .load_weights(&registered)
+        .expect_err("load_weights must reject tampered bytes, not silently load them");
+    assert!(
+        matches!(err, TuneError::WeightIntegrityError { .. }),
+        "expected WeightIntegrityError, got: {err:?}"
+    );
+
+    // load_weights_verified must reject the same tampered artifact too.
+    let err = registry
+        .load_weights_verified(&registered)
+        .expect_err("load_weights_verified must reject tampered bytes");
+    assert!(
+        matches!(err, TuneError::WeightIntegrityError { .. }),
+        "expected WeightIntegrityError, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_load_weights_rejects_truncated_file_on_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = ModelRegistry::with_path(tmp.path()).unwrap();
+    let model = RegisteredModel::new("test", "1.0.0");
+    let weights = vec![9u8; 64];
+
+    let id = registry.register(model, &weights).unwrap();
+    let registered = registry.get_by_id(&id).unwrap();
+
+    let weights_path = tmp.path().join("test/1.0.0/weights.bin");
+    std::fs::write(&weights_path, &weights[..32]).unwrap();
+
+    let err = registry
+        .load_weights(&registered)
+        .expect_err("load_weights must reject a truncated weights file");
+    assert!(
+        matches!(err, TuneError::WeightIntegrityError { .. }),
+        "expected WeightIntegrityError, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_load_weights_verified_rejects_missing_hash() {
+    // A model with weights on disk but no recorded hash at all (e.g.
+    // registered via `register_metadata` and given a weights_path
+    // out-of-band, or a legacy pre-hash record) has nothing to verify
+    // against. `load_weights` still loads it (there is no check to
+    // perform), but `load_weights_verified` — the entry point that
+    // promises verification — must refuse rather than silently return
+    // an unverified load.
+    let registry = ModelRegistry::in_memory();
+    let mut model = RegisteredModel::new("test", "1.0.0");
+    model.weights_path = Some("test/1.0.0/weights.bin".to_string());
+    model.weights_hash = None;
+    registry.register_metadata(model).unwrap();
+
+    let registered = registry.get("test", "1.0.0").unwrap();
+    assert!(registered.weights_hash.is_none());
+
+    let err = registry
+        .load_weights_verified(&registered)
+        .expect_err("load_weights_verified must refuse a model with no recorded hash");
+    assert!(
+        matches!(err, TuneError::Storage(_)),
+        "expected TuneError::Storage, got: {err:?}"
+    );
+}
+
 #[test]
 fn test_model_query() {
     let registry = ModelRegistry::in_memory();

--- a/crates/tune/src/registry/storage/tests.rs
+++ b/crates/tune/src/registry/storage/tests.rs
@@ -243,6 +243,42 @@ fn test_load_weights_rejects_mutated_clone_hash() {
 }
 
 #[test]
+fn test_load_weights_rejects_mutated_clone_path() {
+    // Path half of the canonical-record disagreement guard. The redirected
+    // file holds byte-identical content and the clone's hash is left
+    // canonical, so if the `weights_path` predicate were removed the load
+    // would wrongly SUCCEED (canonical path + canonical hash still line
+    // up) — the hash comparison cannot mask this test.
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = ModelRegistry::with_path(tmp.path()).unwrap();
+    let model = RegisteredModel::new("test", "1.0.0");
+    let weights = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+    let id = registry.register(model, &weights).unwrap();
+
+    let canonical_file = tmp.path().join("test/1.0.0/weights.bin");
+    let alt_rel = "test/1.0.0/weights_alt.bin";
+    std::fs::copy(&canonical_file, tmp.path().join(alt_rel)).unwrap();
+
+    let mut redirected = registry.get_by_id(&id).unwrap();
+    redirected.weights_path = Some(alt_rel.to_string());
+
+    let err = registry
+        .load_weights(&redirected)
+        .expect_err("load_weights must reject a clone with a redirected weights_path");
+    assert!(
+        matches!(err, TuneError::Storage(_)),
+        "expected canonical-record disagreement rejection, got: {err:?}"
+    );
+    let err = registry
+        .load_weights_verified(&redirected)
+        .expect_err("load_weights_verified must reject a clone with a redirected weights_path");
+    assert!(
+        matches!(err, TuneError::Storage(_)),
+        "expected canonical-record disagreement rejection, got: {err:?}"
+    );
+}
+
+#[test]
 fn test_load_weights_rejects_unregistered_model() {
     // A RegisteredModel value that was never registered (or was deleted)
     // has no canonical record to verify against — it must not load at all.


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #504.

Completes the three remaining slices identified during the slice-1 (#544) review. Same fail-closed discipline slice 1 established: bounded reads, content hashing, reject-don't-warn, no behavior change on valid artifacts.

## Slice 1 — merged-Q4 cache content integrity

`MetalQwen35State::from_q4_dir`'s merge-on-first-load cache (`merged_qkvz_*.q4`) was validated by file size only, so a same-size corrupted or stale artifact loaded silently. `merged_qkvz_cache_is_valid` (relocated to `weights/q4_weights.rs`, gated `#[cfg(any(test, feature = "metal-gpu"))]` so the CPU suite exercises the real logic) now also compares a SHA-256 fingerprint of the merged file's payload against a fingerprint freshly derived from the current qkv/z source files via bounded reads. `merged_qkvz_expected_size` and both `write_merged_qkvz` payload-length computations are hardened against truncation underflow (`checked_sub`, descriptive error).

## Slice 2 — `quantize_index.json` fail-closed integrity

Sole runtime consumer (`read_quarot_seed_from_index`, feeding QuaRot rotation reconstruction) previously collapsed absent/malformed/no-key into one silent `None`. A corrupted index for an actually-rotated checkpoint would silently apply the wrong rotation and corrupt every downstream logit. Now: genuinely absent → `Ok(None)` (unchanged legacy fallback); present but oversized (16 MiB cap, stat-then-take bounded read), unreadable, non-JSON, or schema-mismatched → hard `Err` propagated by `from_q4_dir`. Typed `serde_json::from_slice::<QuantizeIndex>` against the producer-side schema in `quant/quarot/convert.rs` gives shape validation for free.

## Slice 3 — registry raw-load checksum bypass

`ModelRegistry::load_weights` performed zero integrity checking while `load_weights_verified` sat next to it — a silent bypass, since `register()` always records `weights_hash`. `load_weights` now verifies whenever a hash is on record (`TuneError::WeightIntegrityError` on mismatch); `load_weights_verified` is strictly stronger and additionally rejects hash-less records. The only unverified load left is a record explicitly registered without a hash.

## Tests

19 new tests across the three surfaces, all constructing deliberately tampered artifacts (same-size corrupted payload, same-size stale source, malformed/truncated/oversized/wrong-schema JSON, flipped-byte and truncated weight files, missing hash). Mutation-sensitivity verified per slice: guards reverse-applied → tests fail; restored → pass.

```
cargo test -p lattice-inference --lib          1415 passed; 0 failed
cargo test -p lattice-tune --lib               178 passed; 0 failed
cargo clippy (default + f16,metal-gpu) -D warnings   clean
```

## bench-compare

Not run: no hot-path change. All three guards run once at artifact-load time (O(1) or one linear hash of a file already being read); the load paths' steady-state inference code is untouched. Slice-1 fingerprinting adds a one-time hash of the qkv/z source files on cache-hit validation at model load.