### PR TITLE
ci: guard metal-gpu workspace build against #537 regression class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,15 @@ jobs:
       - name: embed — metal-gpu (macOS only)
         if: runner.os == 'macOS'
         run: cargo build -p lattice-embed --features metal-gpu
-      # The package-specific metal-gpu builds above only compile lattice-inference
-      # and lattice-embed. A workspace-level `--features metal-gpu` combination can
-      # still fail to compile (e.g. #537: a constructor left with a stale field set
-      # after a struct grew new fields) without either package leg catching it.
-      # Compile-only workspace check so that class of regression cannot hide again.
+      # The two metal-gpu legs above build the lattice-inference and lattice-embed
+      # libraries (the embed leg pulls in lattice-inference/metal-gpu transitively),
+      # so a stale-field constructor in either library is already caught there. What
+      # they do NOT compile is the rest of the workspace's metal-gpu surface: the
+      # other default-member crates and the metal-gpu-gated binaries. A #537-class
+      # drift (a constructor left with a stale field set after a struct grew fields)
+      # in that surface compiles clean on both library legs, and the default-feature
+      # `ci` job cannot see the metal-gpu surface at all. Compile-only workspace
+      # check closes that gap.
       - name: workspace — metal-gpu check (macOS only)
         if: runner.os == 'macOS'
         run: cargo check --workspace --features metal-gpu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,14 @@ jobs:
       - name: embed — metal-gpu (macOS only)
         if: runner.os == 'macOS'
         run: cargo build -p lattice-embed --features metal-gpu
+      # The package-specific metal-gpu builds above only compile lattice-inference
+      # and lattice-embed. A workspace-level `--features metal-gpu` combination can
+      # still fail to compile (e.g. #537: a constructor left with a stale field set
+      # after a struct grew new fields) without either package leg catching it.
+      # Compile-only workspace check so that class of regression cannot hide again.
+      - name: workspace — metal-gpu check (macOS only)
+        if: runner.os == 'macOS'
+        run: cargo check --workspace --features metal-gpu
       # The required `ci` job runs `cargo clippy --workspace` with DEFAULT
       # features only, so the entire metal-gpu surface — including the ~18K-line
       # metal_qwen35.rs — was never linted, and 34 clippy errors accumulated


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Refs #537.

## What was reproduced

I could **not** reproduce #537 on `origin/main`. The issue reports that
`from_w3_mlp_dir` is missing struct fields under `--features metal-gpu`, but:

- `from_w3_mlp_dir` does not exist anywhere in the tree (`grep -rn` → no match).
  It lives only on an unmerged draft branch, not on `main`.
- `cargo check --workspace --features metal-gpu` compiles clean on this branch.

Because the metal-gpu workspace already compiles, the compiler itself
guarantees every struct initializer is field-complete (a missing-field error
is a hard `E0063`), so there is no struct-field build break to patch on `main`.
**This PR contains no Rust source change** — it is a preventive CI guard, not a
struct-field fix.

## What this changes

One step added to the existing `feature-matrix` job in
`.github/workflows/ci.yml`:

```yaml
- name: workspace — metal-gpu check (macOS only)
  if: runner.os == 'macOS'
  run: cargo check --workspace --features metal-gpu
```

## What the CI leg covers

The two existing metal-gpu legs build the `lattice-inference` and
`lattice-embed` **libraries** per package (`-p lattice-inference`,
`-p lattice-embed`; the embed leg pulls in `lattice-inference/metal-gpu`
transitively), so a stale-field constructor in either library is already
caught there. What they do **not** compile is the rest of the workspace's
metal-gpu surface: the other default-member crates and the metal-gpu-gated
binaries. A #537-class drift (a constructor left with a stale field set
after a struct grows new fields) in that surface compiles clean on both
library legs, and the default-feature `ci` job cannot see the metal-gpu
surface at all.

This adds the cheapest honest guard: a compile-only
`cargo check --workspace --features metal-gpu`, macOS-gated like the sibling
Metal steps (Metal kernels only exist on macOS), running on every PR to `main`.
`check` rather than `build`/`test` keeps it fast while still catching the whole
missing-field / feature-unification regression class on the surface the
package-scoped legs don't reach.

## Notes

- Does not close #537 — left open for maintainer review of the disposition
  (non-reproducible on `main`; preventive guard added).
- Verified: `cargo check --workspace --features metal-gpu` passes; `cargo fmt`
  clean; pre-commit checks pass.
