### PR TITLE
fix: rebuild stale bench binary (#524) + fix stale Q4 gemv decode comments (#526)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -948,9 +948,9 @@ kernel void copy_buf_offset_f16(
     dst[dst_offset + gid] = half(src[gid]);
 }
 
-// ===== Q4_0 GEMV Decode: 4-bit x float32 with simd_sum reduction =====
-// Q4_0 block: [f16 scale (2B)][16 bytes packed 4-bit] = 18 bytes per 32 weights.
-// Packed as unsigned offset: real_value = (nibble - 8) * scale.
+// ===== Q4 GEMV Decode: asymmetric 4-bit x float32 with simd_sum reduction =====
+// Q4 block: [f16 scale (2B)][f16 bias/min (2B)][16 bytes packed 4-bit] = 20 bytes per 32 weights.
+// Packed nibbles are unsigned sequential pairs: real_value = nibble * scale + bias.
 // NR=2 output rows per threadgroup, 4 simdgroups of 32 = 128 threads.
 // Dispatch: threadgroups=(ceil(N/2), 1, 1), threads=(32, 4, 1)
 kernel void gemv_q4_decode(
@@ -12274,7 +12274,7 @@ kernel void gdn_chunk_norm_silu_c32(
             &self,
             enc: &ComputeCommandEncoderRef,
             x: &Buffer,       // activation [1,K] float
-            qw: &Q4WeightBuf, // Q4_0 packed weights [N, K/32 * 18]; payload at qw.payload_offset
+            qw: &Q4WeightBuf, // Q4 packed weights [N, (K/32) * 20]; payload at qw.payload_offset
             y: &Buffer,       // output [1,N] float
             _m: u32,
             n: u32,
@@ -14232,7 +14232,7 @@ kernel void gdn_chunk_norm_silu_c32(
         /// Create a Metal buffer from pre-quantized Q4 block bytes (raw `[u8]`).
         ///
         /// The bytes are the serialized `Q4Block` array as written by `save_q4_file`
-        /// (after the file header), i.e. `n_blocks × 18` raw bytes.
+        /// (after the file header), i.e. `n_blocks × 20` raw bytes.
         fn make_buffer_from_q4_raw(device: &Device, raw: &[u8], label: &str) -> Buffer {
             let buf = device.new_buffer_with_data(
                 raw.as_ptr() as *const _,

--- a/scripts/bench_decode_slopefit.sh
+++ b/scripts/bench_decode_slopefit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # ADR-064: decode slope/intercept fit harness driver.
 #
-# Builds bench_decode_slopefit (if needed), runs it, pipes stdout through the
+# Builds bench_decode_slopefit, runs it, pipes stdout through the
 # Python post-processor, and emits the final ADR-064 JSON.
 #
 # Usage:
@@ -31,13 +31,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Build if stale.
-if [[ ! -x "$BIN" ]]; then
-    >&2 echo "[slopefit] building bench_decode_slopefit (release)..."
-    cargo build --release -p lattice-inference --bin bench_decode_slopefit \
-        --features "f16,metal-gpu" 2>&1 | grep -v "^$" >&2 \
-        || { echo '{"error":"build failed"}'; exit 1; }
-fi
+# Build before benchmarking; cargo incremental prevents stale release binaries.
+>&2 echo "[slopefit] building bench_decode_slopefit (release)..."
+cargo build --release -p lattice-inference --bin bench_decode_slopefit \
+    --features "f16,metal-gpu" 2>&1 | grep -v "^$" >&2 \
+    || { echo '{"error":"build failed"}'; exit 1; }
 
 >&2 echo "[slopefit] running measurement binary..."
 if [[ -n "$OUT" ]]; then


### PR DESCRIPTION
_PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Resolves two small, independent issues in one branch. One commit per issue, comment-only where required, all gates green.

References #524 and #526 — intentionally **not** auto-closed; left open for human review.

## Per-issue status

| Issue | Root cause (file:line) | Fix applied | Test result | Status |
|---|---|---|---|---|
| #524 | `scripts/bench_decode_slopefit.sh` — build guarded by `[[ ! -x "$BIN" ]]`, so an existing-but-stale binary was never rebuilt (silently benched old code) | Removed the conditional; `cargo build --release … --bin bench_decode_slopefit` now runs unconditionally every invocation. Structurally cannot run a stale binary — no heuristic to get wrong; cargo's incremental tracking keeps it fast when nothing changed. | `cargo check --workspace` ✅ · `cargo clippy --workspace -- -D warnings` ✅ · `bash -n` ✅ · live stale-rebuild demo ✅ | **RESOLVED** |
| #526 | `crates/inference/src/forward/metal_qwen35.rs` (kernel header ~L948, `qw` param comment, `make_buffer_from_q4_raw` doc) — comments claimed a legacy 18-byte symmetric `Q4_0` block with `(nibble - 8) * scale` dequant | Rewrote the 3 stale comment groups to match the actual, already-correct 20-byte asymmetric layout (`scale` + `bias` + 16 nibbles, `w = nibble * scale + bias`), verified against the `Q4Block` struct (compile-asserted 20 bytes) and the kernel body. Comment-only; zero code lines changed. Crate-wide sweep found no remaining sibling stale claims. | `cargo check --workspace` ✅ · `cargo clippy --workspace -- -D warnings` ✅ · `cargo fmt --check` ✅ · no behavior change (no new tests needed) | **RESOLVED** |

## #524 — stale-binary rebuild demonstration

Reproduced the exact bug class: build once, modify a source file the binary depends on, rerun the script's build command, and confirm cargo recompiles/relinks instead of silently reusing the stale-but-executable binary (which the old `[[ ! -x "$BIN" ]]` check would have done).

**1 — baseline build**
```
$ cargo build --release -p lattice-inference --bin bench_decode_slopefit --features "f16,metal-gpu"
   Compiling lattice-inference v0.4.2 (…/crates/inference)
    Finished `release` profile [optimized] target(s) in 37.10s
EXIT: 0
```
Binary mtime after baseline: `1783007031`.

**2 — touch a source file the binary depends on**
```
$ touch crates/inference/src/bin/bench_decode_slopefit.rs
```

**3 — rerun the build command now present unconditionally in the script**
```
$ cargo build --release -p lattice-inference --bin bench_decode_slopefit --features "f16,metal-gpu"
   Compiling lattice-inference v0.4.2 (…/crates/inference)
    Finished `release` profile [optimized] target(s) in 0.96s
EXIT: 0
```
Binary mtime after rebuild: `1783007043` — **changed**. `Compiling lattice-inference` (not just `Finished`) proves the crate was recompiled and relinked rather than reused. Under the old conditional, the binary was still executable so no rebuild would have occurred and the bench would have measured stale code.

## Gate summary

```
cargo check --workspace                    → EXIT 0
cargo clippy --workspace -- -D warnings    → EXIT 0
cargo fmt --check                          → EXIT 0
bash -n scripts/bench_decode_slopefit.sh   → EXIT 0
```

## Notes

- Two commits, one per issue: `fix(bench): actually rebuild stale binary in bench_decode_slopefit.sh (#524)` and `docs(inference): fix stale Q4 gemv decode block-format comments (#526)`.
- A separate latent accounting bug exists at `crates/inference/src/bin/quantize_q4.rs:486` (`q4.blocks.len() * 18` should be `* 20`) — this is executable code, out of #526's comment-only scope, and is intentionally left untouched here. Recommend a follow-up issue.
