### PR TITLE
test(gate): cover ADR-064 absolute-delta sub-predicate + fix boundary semantics (#525)

### DIFF
--- a/scripts/adr064-gpu-decode-gate.py
+++ b/scripts/adr064-gpu-decode-gate.py
@@ -129,8 +129,8 @@ def eval_ttft_dispatch_row(current: dict[str, Any], baseline: dict[str, Any]) ->
     if disp_lb > 0.05:
         reasons.append(f"decode/dispatches_per_token lb={disp_lb:.4f} > 0.05")
     disp_abs = disp_c["ci95_low"] - disp_b["ci95_high"]
-    if disp_abs > 10:
-        reasons.append(f"decode/dispatches_per_token abs_delta={disp_abs:.4f} > 10")
+    if disp_abs >= 10:
+        reasons.append(f"decode/dispatches_per_token abs_delta={disp_abs:.4f} >= 10")
 
     cmdbuf_c = entries_c["decode/command_buffers_per_token"]
     if cmdbuf_c["ci95_low"] > 2:

--- a/tests/test_adr064_gpu_decode_gate.py
+++ b/tests/test_adr064_gpu_decode_gate.py
@@ -131,14 +131,81 @@ class TtftDispatchRowRegressionTest(unittest.TestCase):
             if name != "ttft_dispatch":
                 self.assertEqual(r.verdict, "PASS", f"{name}: {r.reasons}")
 
-    def test_dispatches_absolute_delta_trips_row(self):
-        baseline = _doc(_base_benches())
+    def test_dispatches_absolute_delta_below_threshold_passes_row(self):
+        baseline_benches = _base_benches()
+        baseline_benches["decode/dispatches_per_token"] = _bench(
+            250.0, 249.0, 250.0, False, "count"
+        )
+        baseline = _doc(baseline_benches)
         current_benches = _base_benches()
-        # Relative lb stays small but absolute +10 dispatch/token breach fires.
-        current_benches["decode/dispatches_per_token"] = _bench(30.5, 30.5, 30.6, False, "count")
+        # disp_abs=9.9, disp_lb=3.96% -- both comfortably under threshold.
+        current_benches["decode/dispatches_per_token"] = _bench(259.9, 259.9, 260.0, False, "count")
         current = _doc(current_benches)
         results = {r.name: r for r in gate.evaluate(current, baseline)}
-        self.assertEqual(results["ttft_dispatch"].verdict, "FAIL")
+        self.assertEqual(
+            results["ttft_dispatch"].verdict,
+            "PASS",
+            f"dispatch abs below-threshold: expected PASS below +10, got "
+            f"{results['ttft_dispatch'].verdict}: {results['ttft_dispatch'].reasons}",
+        )
+
+    def test_dispatches_absolute_delta_above_threshold_trips_abs_only(self):
+        baseline_benches = _base_benches()
+        baseline_benches["decode/dispatches_per_token"] = _bench(
+            250.0, 249.0, 250.0, False, "count"
+        )
+        baseline = _doc(baseline_benches)
+        current_benches = _base_benches()
+        # disp_abs=10.1, disp_lb=4.04% -- only the absolute sub-predicate fires.
+        current_benches["decode/dispatches_per_token"] = _bench(260.1, 260.1, 260.2, False, "count")
+        current = _doc(current_benches)
+        results = {r.name: r for r in gate.evaluate(current, baseline)}
+        row = results["ttft_dispatch"]
+        self.assertEqual(
+            row.verdict,
+            "FAIL",
+            f"dispatch abs above-threshold: expected abs_delta-only FAIL above +10, "
+            f"got {row.verdict}: {row.reasons}",
+        )
+        self.assertTrue(
+            any("abs_delta" in reason for reason in row.reasons),
+            f"dispatch abs above-threshold: expected abs_delta-only FAIL above +10, "
+            f"got {row.verdict}: {row.reasons}",
+        )
+        self.assertFalse(
+            any("lb=" in reason for reason in row.reasons),
+            f"dispatch abs above-threshold: expected abs_delta-only FAIL above +10, "
+            f"got {row.verdict}: {row.reasons}",
+        )
+
+    def test_dispatches_absolute_delta_boundary_trips_fail_closed(self):
+        baseline_benches = _base_benches()
+        baseline_benches["decode/dispatches_per_token"] = _bench(
+            250.0, 249.0, 250.0, False, "count"
+        )
+        baseline = _doc(baseline_benches)
+        current_benches = _base_benches()
+        # disp_abs=10.0 exactly at the +10 boundary, disp_lb=4.00% -- fail-closed ruling.
+        current_benches["decode/dispatches_per_token"] = _bench(260.0, 260.0, 260.1, False, "count")
+        current = _doc(current_benches)
+        results = {r.name: r for r in gate.evaluate(current, baseline)}
+        row = results["ttft_dispatch"]
+        self.assertEqual(
+            row.verdict,
+            "FAIL",
+            f"dispatch abs boundary: expected fail-closed exact +10 FAIL, "
+            f"got {row.verdict}: {row.reasons}",
+        )
+        self.assertTrue(
+            any("abs_delta=10.0000 >= 10" in reason for reason in row.reasons),
+            f"dispatch abs boundary: expected fail-closed exact +10 FAIL, "
+            f"got {row.verdict}: {row.reasons}",
+        )
+        self.assertFalse(
+            any("lb=" in reason for reason in row.reasons),
+            f"dispatch abs boundary: expected fail-closed exact +10 FAIL, "
+            f"got {row.verdict}: {row.reasons}",
+        )
 
     def test_command_buffers_ceiling_trips_row(self):
         baseline = _doc(_base_benches())


### PR DESCRIPTION
_PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Spec ruling for #525: ADR-064 does not define exact at-threshold semantics for the absolute dispatch/token predicate. ADR-064 says, "enforcing thresholds requires threshold, variance, hardware, and retry policy decisions," and requires that a gate's "failure mode is documented"; the renumbered gate table in ADR-067 lists dispatch/token as "regression `> 5%` OR absolute `+10`" but does not state whether exact `+10` passes. Because that boundary is ambiguous, this PR applies the fail-closed rule: an absolute dispatch delta exactly at `+10.0000` trips the gate, so the implementation uses `>= 10`.

## Per-issue status

| issue# | root cause file:line | fix applied | test result | status |
|---|---|---|---|---|
| #525 | `scripts/adr064-gpu-decode-gate.py:132` — absolute-delta sub-predicate used strict `>` at the spec boundary and had no dedicated selftest coverage (the only existing trip fixture was masked by the relative `lb` predicate) | Changed `if disp_abs > 10:` → `>= 10` (and matching reason string) for fail-closed boundary semantics; added 3 mutation-sensitive fixtures in `tests/test_adr064_gpu_decode_gate.py` (below=pass, above=abs-only trip, exactly-at=fail-closed trip) reusing the existing `_bench`/`_base_benches`/`_doc` named-base pattern, each holding `disp_lb < 5%` so only the absolute branch can fire | `20 passed`; mutation-sensitivity verified (reverting `>=`→`>`, deleting the sub-predicate, or flipping the comparator each fails exactly the predicted fixtures, byte-identical restore) | RESOLVED |
