### PR TITLE
ci(inference): cover f16 KV-cache Metal path (#252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,28 @@ jobs:
         env:
           LATTICE_METAL_TEST_ENFORCE: '1'
         run: cargo test -p lattice-inference --features f16,metal-gpu --lib q4 -- --nocapture
+      # Issue #252 (#238 follow-up): the f16 KV-cache Metal path (opt-in via
+      # LATTICE_KV_F16) had no automated test. GitHub's hosted macos-latest
+      # exposes a PARAVIRTUAL Metal GPU, not a real Apple7 device — a test
+      # gated on `supports_family(Apple7)` would silently skip-pass here. The
+      # f16 KV kernels (copy_buf_offset_f16, copy_kv_cache_batch_f16,
+      # decode_attention_f16, prefill_attention_batched_causal_f16) are not
+      # Apple7-gated, so this leg actually executes them and fails closed:
+      # LATTICE_METAL_TEST_ENFORCE=1 panics if no Metal device is present,
+      # and the grep below rejects a zero-test filter match as well as a run
+      # that never prints the runtime capability marker.
+      - name: inference - f16 KV-cache Metal path (macOS only)
+        if: runner.os == 'macOS'
+        env:
+          LATTICE_METAL_TEST_ENFORCE: '1'
+          LATTICE_KV_F16: '1'
+          LATTICE_METAL_PATH_PROOF: '1'
+        run: |
+          set -euo pipefail
+          log="${RUNNER_TEMP:-/tmp}/f16-kv-metal-test.log"
+          cargo test -p lattice-inference --features f16,metal-gpu --lib f16_kv_metal_path_executes_and_reports_capability -- --nocapture 2>&1 | tee "$log"
+          grep -Eq '^test result: ok\. 1 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
+          grep -Fq '[METAL_F16_KV_CAPABILITY] supported=true' "$log"
 
   # The benchmark harnesses live behind their own feature flags / target gates
   # and are never built by `cargo test`. A `Qwen35Config` field added to the

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -17790,6 +17790,99 @@ kernel void decode_attention_reference(
             }
         }
 
+        /// Issue #252 (#238 follow-up): runtime capability probe for the f16
+        /// KV-cache Metal path. GitHub's hosted `macos-latest` runner exposes a
+        /// PARAVIRTUAL Metal GPU (not a real Apple7 device), so this test must
+        /// NOT gate on `supports_family(Apple7)` — it gates on whether the f16
+        /// KV kernels actually construct and execute, and fails loudly
+        /// (LATTICE_METAL_TEST_ENFORCE=1) instead of skip-passing when a Metal
+        /// device is absent.
+        #[test]
+        fn f16_kv_metal_path_executes_and_reports_capability() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = Device::system_default() else {
+                eprintln!("[METAL_F16_KV_CAPABILITY] supported=false reason=no_metal_device");
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+
+            assert!(
+                matches!(
+                    std::env::var("LATTICE_KV_F16").as_deref(),
+                    Ok("1") | Ok("true")
+                ),
+                "f16 KV Metal probe must run with LATTICE_KV_F16=1"
+            );
+            assert!(
+                matches!(
+                    std::env::var("LATTICE_METAL_PATH_PROOF").as_deref(),
+                    Ok("1") | Ok("true")
+                ),
+                "f16 KV Metal probe must run with LATTICE_METAL_PATH_PROOF=1"
+            );
+
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let mut state = match MetalQwen35State::new(&weights, &cfg, 16) {
+                Ok(state) => state,
+                Err(err) => {
+                    eprintln!(
+                        "[METAL_F16_KV_CAPABILITY] supported=false reason=construct_failed error={err}"
+                    );
+                    panic!("f16 KV Metal capability probe failed during state construction: {err}");
+                }
+            };
+
+            assert!(state.use_kv_f16, "state did not enable f16 KV cache");
+            assert!(state.session.kv_cache.kv_f16, "KV cache layout is not f16");
+            assert!(state.path_proof_enabled, "path-proof counters are disabled");
+
+            let expected_kv_bytes = 16 * cfg.full_kv_dim() * 2;
+            assert_eq!(
+                state.session.kv_cache.k_bufs[0].length() as usize,
+                expected_kv_bytes,
+                "K cache buffer must use f16 element size"
+            );
+
+            state.reset_path_proof_counters();
+            let _ = state.forward_prefill(&[1, 2, 3]);
+            let decode_pos = state.session.kv_cache.seq_len;
+            let _ = state.forward_step(4, decode_pos);
+
+            let proof = state.path_proof_snapshot();
+            eprintln!(
+                "[METAL_F16_KV_CAPABILITY] supported=true kv_f16={} prefill_kv_batch={} prefill_attn_batched={} decode_kv_copy={} decode_attn_direct={} decode_attn_split_partial={} decode_attn_split_reduce={}",
+                proof.kv_f16,
+                proof.prefill_kv_batch,
+                proof.prefill_attn_batched,
+                proof.decode_kv_copy,
+                proof.decode_attn_direct,
+                proof.decode_attn_split_partial,
+                proof.decode_attn_split_reduce,
+            );
+
+            assert!(proof.kv_f16, "path proof did not report kv_f16=true");
+            assert!(
+                proof.prefill_kv_batch > 0,
+                "f16 batch KV write did not execute"
+            );
+            assert!(
+                proof.prefill_attn_batched > 0,
+                "f16 batched prefill attention did not execute"
+            );
+            assert!(
+                proof.decode_kv_copy > 0,
+                "f16 decode KV copy did not execute"
+            );
+            assert!(
+                proof.decode_attn_direct > 0
+                    || (proof.decode_attn_split_partial > 0 && proof.decode_attn_split_reduce > 0),
+                "f16 decode attention did not execute"
+            );
+        }
+
         #[test]
         fn test_metal_qwen35_engine_session_isolation() {
             let Some(_) = Device::system_default() else {


### PR DESCRIPTION
_PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

This PR adds hosted macOS CI coverage for issue #252 by executing a dedicated `lattice-inference` Rust test under `LATTICE_KV_F16=1`, `LATTICE_METAL_PATH_PROOF=1`, and `LATTICE_METAL_TEST_ENFORCE=1`. The test constructs the tiny Metal Qwen3.5 fixture, requires f16 KV cache allocation, runs batch prefill plus one decode step, and fails unless runtime path-proof counters show f16 KV batch write, f16 batched prefill attention, f16 decode KV copy, and f16 decode attention executed. The workflow also asserts Cargo reported exactly one matching test, so a zero-test filter pass is rejected.

This covers execution of the non-Apple7-gated f16 KV-cache Metal path on GitHub's hosted `macos-latest` paravirtual Metal device. It does not cover Apple7-gated Q4/Q8 tiled GEMM kernels, long-context split f16 decode attention, performance, or self-hosted Apple silicon behavior. If hosted paravirtual Metal cannot execute these kernels, execution coverage requires a self-hosted Apple silicon runner; a hosted compile-only leg would be labeled compile-only and would not be represented as execution coverage.

**Why capability, not GPU family:** GitHub's hosted `macos-latest` runners expose a paravirtual Metal GPU, not a real Apple7 device. A test gated on `supports_family(Apple7)` would silently skip-pass there — coverage that reads as real but isn't. The f16 KV kernels involved (`copy_buf_offset_f16`, `copy_kv_cache_batch_f16`, `decode_attention_f16`, `prefill_attention_batched_causal_f16`) are built from generic MSL source and are not Apple7-gated, so this leg gates on actual runtime capability (does the pipeline construct and execute) rather than a hardware family flag.

**Fail-closed behavior:**
- No Metal device present + `LATTICE_METAL_TEST_ENFORCE=1` → the probe panics rather than skipping.
- f16 pipeline construction/execution failure → explicit panic.
- The workflow step greps the test log for the literal `1 passed` test-count line, so a filter that matches zero tests fails the step instead of reading as green.

Follow-up to #238.

Locally verified on real Apple-silicon Metal (`cargo test -p lattice-inference --features f16,metal-gpu --lib f16_kv_metal_path_executes_and_reports_capability -- --nocapture`): the probe reports `supported=true` with nonzero dispatch counters for KV batch write, batched prefill attention, decode KV copy, and decode attention. Execution on GitHub's actual hosted paravirtual runner is unproven until the first CI run on this PR — that residual risk is intentionally disclosed here rather than hidden, and the leg is designed to fail loudly (not skip) if hosted execution turns out not to be possible.
