### PR TITLE
chore: gitignore .khive internal workspace directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Thumbs.db
 
 *__pycache__/
 uv.lock
+
+# Internal workspace artifacts (audits, notes, local tooling) — local-only
+.khive/


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Adds `.khive/` to `.gitignore` so local workspace artifacts (audit outputs, notes, local tooling) never land in the repository.

Note: two already-tracked files (`.khive/reports/crossturn_kv_462.md`, `.khive/reports/gdn_state_bandwidth_491.md`) remain tracked — gitignore does not untrack existing files. They can be removed in a follow-up if desired.