### PR TITLE
fix(bench): fix #545 gate baseline parse mismatch + add per-group bench overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@ cargo bench -p lattice-embed --bench simd -- "int8_raw|normalize"   # multiple g
 cargo bench -p lattice-inference --bench elementwise_cpu_bench      # inference CPU ops
 ```
 
+For the A/B workflow, pass the same Criterion filter through `make bench-compare`:
+
+```bash
+make bench-compare BENCH_GROUPS_INFERENCE="rms_norm|gelu"
+make bench-compare BENCH_GROUPS_EMBED="simd_dot_product|int8_raw"
+```
+
+Leaving these variables unset keeps the default `elementwise_cpu_bench` and `simd` bench targets.
+
 Quick mode (`--quick`) is sufficient for direction + magnitude. Full mode only when you need tight CIs for a PR description or ADR evidence.
 
 ### Differential Test First (Cross-Framework Bugs)

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,12 @@ bench-decode-slopefit:
 	./scripts/bench_decode_slopefit.sh
 
 # A/B benchmark across git refs. Uses worktree for base, leaves working tree untouched.
-# Usage: make bench-compare                     (origin/main vs HEAD)
-#        make bench-compare BASE=main HEAD=pr/x (explicit refs)
+# Usage: make bench-compare                                           (origin/main vs HEAD)
+#        make bench-compare BASE=main HEAD=pr/x                       (explicit refs)
+#        make bench-compare BENCH_GROUPS_INFERENCE='rms_norm|gelu'    (Criterion filter)
+#        make bench-compare BENCH_GROUPS_EMBED='simd_dot_product'     (Criterion filter)
 bench-compare:
-	./scripts/bench-compare.sh $(or $(BASE),origin/main) $(or $(HEAD),HEAD)
+	BENCH_GROUPS_INFERENCE="$(BENCH_GROUPS_INFERENCE)" BENCH_GROUPS_EMBED="$(BENCH_GROUPS_EMBED)" ./scripts/bench-compare.sh $(or $(BASE),origin/main) $(or $(HEAD),HEAD)
 
 # Agentic-workload benchmark: lattice vs ollama vs MLX at 1000/2000/4000-token context.
 # Prereqs: bench_decode_ab binary built, ollama serve running, mlx_lm available.

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ bench-decode-slopefit:
 #        make bench-compare BENCH_GROUPS_INFERENCE='rms_norm|gelu'    (Criterion filter)
 #        make bench-compare BENCH_GROUPS_EMBED='simd_dot_product'     (Criterion filter)
 bench-compare:
-	BENCH_GROUPS_INFERENCE="$(BENCH_GROUPS_INFERENCE)" BENCH_GROUPS_EMBED="$(BENCH_GROUPS_EMBED)" ./scripts/bench-compare.sh $(or $(BASE),origin/main) $(or $(HEAD),HEAD)
+	BENCH_GROUPS_INFERENCE="$(value BENCH_GROUPS_INFERENCE)" BENCH_GROUPS_EMBED="$(value BENCH_GROUPS_EMBED)" ./scripts/bench-compare.sh $(or $(BASE),origin/main) $(or $(HEAD),HEAD)
 
 # Agentic-workload benchmark: lattice vs ollama vs MLX at 1000/2000/4000-token context.
 # Prereqs: bench_decode_ab binary built, ollama serve running, mlx_lm available.

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -8,6 +8,12 @@
 #   scripts/bench-compare.sh HEAD~3                  # HEAD~3 vs HEAD
 #
 # Defaults to --quick (~2 min). Use --full (~15 min) for tight confidence intervals.
+# Optional Criterion filters:
+#   BENCH_GROUPS_INFERENCE="rms_norm|gelu" scripts/bench-compare.sh
+#   BENCH_GROUPS_EMBED="simd_dot_product|int8_raw" scripts/bench-compare.sh
+# Unset filters run all groups in the default bench targets:
+#   lattice-inference: elementwise_cpu_bench
+#   lattice-embed: simd
 # Uses a git worktree for the base ref so your working tree stays untouched.
 set -euo pipefail
 
@@ -44,6 +50,8 @@ trap cleanup EXIT
 # --- Bench list (same as ADR-058 Phase 1) ---
 BENCHES_INFERENCE="elementwise_cpu_bench"
 BENCHES_EMBED="simd"
+BENCH_GROUPS_INFERENCE="${BENCH_GROUPS_INFERENCE:-}"
+BENCH_GROUPS_EMBED="${BENCH_GROUPS_EMBED:-}"
 
 # --- Build + bench base ---
 echo ""
@@ -52,11 +60,11 @@ echo "--- Building + benching BASE ($BASE_SHA) ---"
   cd "$WT"
   # Only bench what exists — some benches may not exist on older refs
   if cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" --no-run 2>/dev/null; then
-    cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" -- --save-baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:" || true
+    cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --save-baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:" || true
   else
     echo "  (elementwise_cpu_bench not present on $BASE_SHA — skipping)"
   fi
-  cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- --save-baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:" || true
+  cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --save-baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:" || true
 )
 
 # --- Copy base criterion data to HEAD's target ---
@@ -89,18 +97,18 @@ fi
 (
   cd "$HEAD_DIR"
   if cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" --no-run 2>/dev/null; then
-    cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" -- --baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:|change:" || true
+    cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:|change:" || true
   else
     echo "  (elementwise_cpu_bench not present on $HEAD_SHA — skipping)"
   fi
-  cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- --baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:|change:" || true
+  cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:|change:" || true
 )
 
 # --- Report ---
 echo ""
 echo "=== Full gate report ==="
 if [ -d "$HEAD_DIR/target/criterion" ]; then
-  python3 "$REPO/scripts/perf-bench-gate.py" "$HEAD_DIR/target/criterion" "local-compare" 2>&1 || true
+  python3 "$REPO/scripts/perf-bench-gate.py" "$HEAD_DIR/target/criterion" "local-compare" --baseline-name compare-base 2>&1 || true
 fi
 
 echo ""


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #545.

## Summary

Two focused changes to make `make bench-compare` produce trustworthy, diff-relevant evidence. Shell/Makefile/docs only — no Rust source touched (`cargo check --workspace` passes).

### 1. Fix #545 — gate parsed zero benchmarks (baseline contract mismatch)

`scripts/bench-compare.sh` saves a **named** Criterion baseline (`--save-baseline compare-base`), but `scripts/perf-bench-gate.py` used to look only under the default `base/` directory layout, so the gate parsed **zero** comparisons and emitted an empty "failed to parse" report.

The chosen contract keeps the **named-baseline** convention (`compare-base`) — it is the convention the A/B script already uses, and a named baseline is self-documenting and won't collide with an ad-hoc `cargo bench --save-baseline base` a developer may have lying around. The gate resolver (named-first, `base/` fallback) already landed on `main`; this branch makes the producer side explicit by passing `--baseline-name compare-base` at the `bench-compare.sh` call site, so the producer/consumer contract is pinned at the call site instead of relying silently on the gate's default (which could drift).

### 2. Add optional per-group Criterion filters (`BENCH_GROUPS_INFERENCE` / `BENCH_GROUPS_EMBED`)

New optional env-or-make-var overrides let a PR bench only the Criterion groups its diff actually touches, instead of the full suites every time:

```bash
make bench-compare BENCH_GROUPS_INFERENCE="rms_norm|gelu"
make bench-compare BENCH_GROUPS_EMBED="simd_dot_product|int8_raw"
```

**Defaults are unchanged.** When both are unset (or empty) the `${VAR:+"$VAR"}` expansion emits no filter argument, so the four `cargo bench` invocations are byte-identical to today's — the full `elementwise_cpu_bench` (inference) and `simd` (embed) targets. The `--bench` targets never move; the variables only narrow Criterion's own filter within those targets. Documented in the script header, the Makefile usage block, and CLAUDE.md's bench section.

## Files

- `scripts/bench-compare.sh` — explicit `--baseline-name compare-base`; `BENCH_GROUPS_*` filter threading + header docs.
- `Makefile` — `bench-compare` passes `BENCH_GROUPS_*` through; usage examples.
- `CLAUDE.md` — override documented under the "bench by group" section.

3 files, 27 insertions, 8 deletions.

## Empirical evidence — gate now parses >0 comparisons

Ran `make bench-compare` in quick mode on this branch to completion (exit 0): build + quick-bench BASE `origin/main` (`85ef8eaf4`) then HEAD (`9bed231d0`), then the gate report. The gate parsed **259 benchmark comparisons** (`45 FAIL / 19 WARN / 111 confirmed improvement / 84 within-noise`) and rendered a full report — the #545 empty-report / "failed to parse" failure mode does not reproduce (`grep -c "failed to parse"` → 0).

> ⚠️ **The FAIL/WARN deltas below are measurement noise, not real regressions.** This diff changes only shell, Makefile, and Markdown — zero Rust changed between the two benched refs, so any true delta should be ~0%. The run executed on a workstation under concurrent CPU load, which produces the large swings you see. This output is pasted **only to prove the gate now parses and reports non-zero comparisons** (the object of #545), not as performance data.

<details><summary>Verbatim <code>make bench-compare</code> gate report (259 comparisons parsed)</summary>

```
=== bench-compare: origin/main (85ef8eaf4) vs HEAD (9bed231d0) ===

### `local-compare` — perf regression report

**❌ 45 FAIL** (regression >7.0% confirmed by 95% CI)
**⚠ 19 WARN** (regression 3.0-7.0% confirmed)
**🚀 111 confirmed improvement**

| Bench | Δ point | 95% CI | new ns | base ns | verdict |
|---|---:|---|---:|---:|---|
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_64c` | +776.72% | [+763.01%, +790.74%] | 36014.1 | 4107.8 | ❌ FAIL |
| `tier_prepared_batch_sizes/int4_batch_prepared/100` | +696.74% | [+680.35%, +713.12%] | 18442.3 | 2314.7 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_64c` | +683.71% | [+658.90%, +708.87%] | 33622.0 | 4290.1 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_16c` | +628.43% | [+616.92%, +640.29%] | 6970.9 | 957.0 | ❌ FAIL |
| `tier_prepared_batch_sizes/int8_batch_prepared/100` | +624.81% | [+582.93%, +666.83%] | 7287.9 | 1005.5 | ❌ FAIL |
| `tier_prepared_batch_sizes/int4_query_per_call/100` | +587.11% | [+567.96%, +606.57%] | 1039018.1 | 151215.0 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_16c` | +468.17% | [+392.25%, +544.47%] | 5471.6 | 963.0 | ❌ FAIL |
| `tier_prepared_batch_sizes/int8_query_per_call/1000` | +371.72% | [+357.45%, +386.08%] | 5263310.9 | 1115779.0 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/384d_64c` | +363.06% | [+324.67%, +401.76%] | 8152.6 | 1760.6 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/768d_16c` | +245.53% | [+236.03%, +255.09%] | 2970.9 | 859.8 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/768d_4c` | +205.17% | [+196.70%, +213.70%] | 400.4 | 131.2 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_4c` | +191.32% | [+184.07%, +198.92%] | 750.9 | 257.8 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_256c` | +218.58% | [+176.63%, +260.95%] | 51328.6 | 16111.9 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/384d_16c` | +171.32% | [+168.13%, +174.59%] | 732.6 | 270.0 | ❌ FAIL |
| `tier_prepared_batch_sizes/int8_batch_prepared/10` | +158.52% | [+154.50%, +162.56%] | 303.2 | 117.3 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/384d_16c` | +140.36% | [+138.60%, +142.14%] | 1074.5 | 447.0 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_1000c` | +139.18% | [+136.39%, +141.97%] | 149184.3 | 62374.2 | ❌ FAIL |
| `tier_prepared_batch_sizes/int8_query_per_call/100` | +274.04% | [+129.29%, +419.71%] | 416120.3 | 111250.0 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_256c` | +163.41% | [+128.55%, +198.84%] | 42199.4 | 16020.7 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_1000c` | +136.67% | [+109.46%, +164.08%] | 201926.3 | 85319.7 | ❌ FAIL |
| `tier_prepared_batch_sizes/int4_query_per_call/1000` | +106.68% | [+104.31%, +109.06%] | 3106202.9 | 1502888.7 | ❌ FAIL |
| `int8_prepared_dot_product/prepared/1024` | +105.34% | [+100.19%, +110.50%] | 50.0 | 24.4 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/384d_64c` | +135.77% | [+94.20%, +177.93%] | 2410.2 | 1022.2 | ❌ FAIL |
| `tier_prepared_batch_sizes/int4_batch_prepared/10` | +91.00% | [+74.82%, +107.58%] | 482.3 | 252.5 | ❌ FAIL |
| `tier_prepared_batch_sizes/int4_batch_prepared/1000` | +76.96% | [+71.27%, +82.74%] | 40690.6 | 22993.6 | ❌ FAIL |
| `tier_prepared_batch_sizes/int8_batch_prepared/1000` | +63.86% | [+63.17%, +64.56%] | 17820.9 | 10875.4 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/768d_4c` | +35.87% | [+34.05%, +37.69%] | 305.7 | 225.0 | ❌ FAIL |
| `simd_normalized_cosine_fast_path/cosine_full/384` | +30.21% | [+29.23%, +31.21%] | 50.2 | 38.5 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/384d_256c` | +30.14% | [+28.20%, +32.11%] | 8637.5 | 6636.8 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_1000c` | +27.25% | [+25.58%, +28.95%] | 77709.1 | 61066.3 | ❌ FAIL |
| `int8_prepared_dot_product/per_call/768` | +26.43% | [+24.46%, +28.41%] | 2898.6 | 2292.6 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c` | +27.00% | [+23.50%, +30.53%] | 6645.4 | 5232.4 | ❌ FAIL |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_256c` | +22.75% | [+20.09%, +25.46%] | 25699.7 | 20936.8 | ❌ FAIL |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/768` | +39.36% | [+17.11%, +61.63%] | 89868.3 | 64486.5 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_4c` | +21.92% | [+16.78%, +27.06%] | 401.1 | 328.9 | ❌ FAIL |
| `simd_normalized_cosine_fast_path/dot_product/384` | +17.24% | [+16.48%, +18.00%] | 32.5 | 27.8 | ❌ FAIL |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_4c` | +14.63% | [+14.52%, +14.73%] | 373.5 | 325.9 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_1000c` | +17.50% | [+13.79%, +21.30%] | 94260.9 | 80219.6 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_4c` | +14.11% | [+13.27%, +14.95%] | 380.5 | 333.5 | ❌ FAIL |
| `tier_prepared_batch_sizes/int4_query_per_call/10` | +14.11% | [+12.94%, +15.29%] | 17246.1 | 15113.4 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/768d_16c` | +15.99% | [+11.65%, +20.36%] | 569.4 | 490.9 | ❌ FAIL |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_4c` | +14.54% | [+11.31%, +17.77%] | 335.2 | 292.7 | ❌ FAIL |
| `tier_prepared_batch_sizes/int8_query_per_call/10` | +12.25% | [+10.55%, +13.95%] | 12557.8 | 11187.8 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/384d_256c` | +13.99% | [+9.35%, +18.82%] | 9893.0 | 8679.1 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_16c` | +10.80% | [+8.13%, +13.52%] | 1461.6 | 1319.2 | ❌ FAIL |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_64c` | +6.92% | [+6.75%, +7.09%] | 5512.1 | 5155.4 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/simd_batch/768d_1000c` | +8.61% | [+6.67%, +10.59%] | 65723.0 | 60513.2 | ⚠ WARN |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/1024` | +44.93% | [+6.30%, +83.98%] | 120971.0 | 83468.5 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c` | +6.15% | [+6.01%, +6.29%] | 5274.0 | 4968.5 | ⚠ WARN |
| `binary_cosine_distance/float32_simd/384` | +6.84% | [+5.49%, +8.20%] | 40.6 | 38.0 | ⚠ WARN |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_16c` | +8.43% | [+5.11%, +11.78%] | 1382.0 | 1274.6 | ⚠ WARN |
| `simd_query_batch_dot_product/pair_loop/768d_256c` | +6.28% | [+4.95%, +7.61%] | 16839.5 | 15844.7 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/simd_batch/768d_64c` | +5.63% | [+4.72%, +6.54%] | 4186.0 | 3962.9 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_64c` | +5.17% | [+4.65%, +5.69%] | 4211.4 | 4004.5 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_1000c` | +4.98% | [+4.59%, +5.37%] | 64946.3 | 61867.7 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_64c` | +5.31% | [+4.50%, +6.12%] | 5445.4 | 5170.8 | ⚠ WARN |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_4c` | +9.54% | [+4.49%, +14.86%] | 154.8 | 141.3 | ⚠ WARN |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_64c` | +4.86% | [+4.40%, +5.32%] | 2061.0 | 1965.4 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_64c` | +4.65% | [+4.11%, +5.19%] | 4122.8 | 3939.5 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_4c` | +4.24% | [+4.03%, +4.46%] | 335.8 | 322.1 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_16c` | +4.82% | [+3.95%, +5.71%] | 1204.0 | 1148.6 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_1000c` | +4.93% | [+3.55%, +6.34%] | 63017.2 | 60057.4 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/simd_batch/768d_256c` | +4.90% | [+3.49%, +6.32%] | 16393.7 | 15627.5 | ⚠ WARN |
| `int8_prepared_dot_product/per_call/129` | +5.49% | [+3.25%, +7.76%] | 372.0 | 352.6 | ⚠ WARN |
| `int8_batch_cosine/float32_simd/100` | -3.35% | [-3.62%, -3.07%] | 4761.7 | 4926.6 | 🚀 WIN |
| `tier_prepared_query/int4_query_per_call_1000` | -3.05% | [-4.24%, -1.86%] | 1544379.6 | 1592956.7 | 🚀 WIN |
| `simd_query_batch_dot_product/simd_batch/128d_64c` | -3.89% | [-4.40%, -3.36%] | 363.9 | 378.6 | 🚀 WIN |
| `int8_quantization/quantize/1024` | -4.08% | [-4.72%, -3.45%] | 3104.9 | 3237.1 | 🚀 WIN |
| `simd_batch_dot_product/simd_batch/100` | -4.37% | [-4.79%, -3.96%] | 4193.0 | 4384.7 | 🚀 WIN |
| `simd_batch_dot_product/scalar_loop/100` | -4.02% | [-4.79%, -3.24%] | 23026.0 | 23991.0 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_1000c` | -3.68% | [-4.89%, -2.44%] | 31512.5 | 32715.3 | 🚀 WIN |
| `int4_cosine_distance/float32_simd/384` | -3.37% | [-5.21%, -1.47%] | 39.4 | 40.7 | 🚀 WIN |
| `simd_squared_euclidean_fast_path/euclidean_full/768` | -5.00% | [-5.46%, -4.53%] | 59.4 | 62.5 | 🚀 WIN |
| `int4_cosine_distance/float32_simd/1536` | -4.40% | [-5.48%, -3.32%] | 135.0 | 141.2 | 🚀 WIN |
| `int8_vs_float32_cosine/float32_simd/1536` | -4.69% | [-5.61%, -3.75%] | 130.5 | 137.0 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8/127` | -3.90% | [-5.67%, -2.10%] | 6.8 | 7.1 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/simd_batch/384d_16c` | -5.29% | [-5.87%, -4.69%] | 500.1 | 528.0 | 🚀 WIN |
| `int8_vs_float32_cosine/float32_simd/768` | -5.27% | [-5.92%, -4.61%] | 69.1 | 73.0 | 🚀 WIN |
| `int8_prepared_dot_product/prepared/128` | -4.58% | [-5.93%, -3.22%] | 5.2 | 5.4 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_256c` | -4.81% | [-6.32%, -3.26%] | 8373.4 | 8796.9 | 🚀 WIN |
| `tier_prepared_query/binary_query_per_call_1000` | -3.53% | [-6.40%, -0.49%] | 891121.1 | 923740.6 | 🚀 WIN |
| `int8_quantization/quantize/384` | -4.66% | [-6.59%, -2.66%] | 1150.8 | 1207.1 | 🚀 WIN |
| `int8_batch_cosine/int8_loop/100` | -4.16% | [-6.66%, -1.54%] | 1072.9 | 1119.5 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/384` | -5.79% | [-7.07%, -4.49%] | 10.4 | 11.1 | 🚀 WIN |
| `memory_size/search_1000_int8` | -5.78% | [-7.11%, -4.44%] | 10559.7 | 11207.5 | 🚀 WIN |
| `simd_squared_euclidean_fast_path/euclidean_full/384` | -5.78% | [-7.31%, -4.20%] | 30.2 | 32.1 | 🚀 WIN |
| `int4_cosine_distance/int4/1024` | -7.05% | [-7.31%, -6.79%] | 61.4 | 66.1 | 🚀 WIN |
| `simd_squared_euclidean_fast_path/euclidean_full/1024` | -6.38% | [-7.82%, -4.90%] | 79.4 | 84.8 | 🚀 WIN |
| `int8_quantization/quantize/1536` | -5.84% | [-7.82%, -3.81%] | 4636.4 | 4924.2 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_16c` | -6.73% | [-7.89%, -5.55%] | 511.1 | 548.0 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/1536` | -7.54% | [-7.91%, -7.17%] | 36.2 | 39.1 | 🚀 WIN |
| `binary_cosine_distance/binary/384` | -7.26% | [-8.12%, -6.38%] | 2.8 | 3.0 | 🚀 WIN |
| `int8_batch_cosine/int8_loop/1000` | -8.51% | [-8.69%, -8.32%] | 12458.8 | 13617.0 | 🚀 WIN |
| `int8_quantization/quantize/768` | -5.77% | [-8.96%, -2.48%] | 2367.5 | 2512.5 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8/129` | -7.19% | [-10.12%, -4.17%] | 5.3 | 5.7 | 🚀 WIN |
| `simd_throughput_384/cosine_similarity` | -8.72% | [-10.40%, -7.00%] | 39.1 | 42.9 | 🚀 WIN |
| `int8_batch_cosine/int8_loop/10` | -7.98% | [-10.50%, -5.34%] | 114.9 | 124.9 | 🚀 WIN |
| `memory_size/search_1000_float32` | -9.50% | [-10.70%, -8.29%] | 32785.8 | 36227.1 | 🚀 WIN |
| `int8_batch_cosine/float32_simd/10` | -10.15% | [-11.14%, -9.15%] | 328.9 | 366.1 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/768` | -10.01% | [-11.29%, -8.72%] | 18.5 | 20.5 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/simd_batch/768d_16c` | -11.25% | [-13.36%, -9.04%] | 962.7 | 1084.7 | 🚀 WIN |
| `binary_cosine_distance/float32_simd/1536` | -12.53% | [-13.47%, -11.58%] | 130.1 | 148.7 | 🚀 WIN |
| `simd_dot_product/scalar/1536` | -13.39% | [-14.02%, -12.76%] | 1292.5 | 1492.4 | 🚀 WIN |
| `simd_batch_dot_product/scalar_loop/10` | -13.93% | [-14.72%, -13.12%] | 2340.5 | 2719.2 | 🚀 WIN |
| `simd_query_batch_dot_product/simd_batch/128d_4c` | -14.39% | [-14.74%, -14.05%] | 35.1 | 41.0 | 🚀 WIN |
| `simd_dot_product/simd/1536` | -13.68% | [-14.79%, -12.57%] | 121.1 | 140.3 | 🚀 WIN |
| `simd_dot_product/scalar/384` | -14.59% | [-15.22%, -13.96%] | 237.8 | 278.5 | 🚀 WIN |
| `simd_batch_cosine/scalar_loop/100` | -16.45% | [-16.82%, -16.09%] | 69518.9 | 83209.9 | 🚀 WIN |
| `simd_dot_product/simd/768` | -15.08% | [-17.17%, -12.89%] | 56.6 | 66.6 | 🚀 WIN |
| `simd_dot_product/scalar/1024` | -16.11% | [-17.29%, -14.91%] | 811.2 | 967.0 | 🚀 WIN |
| `simd_dot_product/simd/1024` | -16.15% | [-17.33%, -14.96%] | 76.9 | 91.7 | 🚀 WIN |
| `simd_euclidean_distance/simd/1536` | -15.09% | [-17.52%, -12.52%] | 121.2 | 142.7 | 🚀 WIN |
| `int8_batch_cosine/float32_simd/1000` | -16.15% | [-17.57%, -14.68%] | 42310.4 | 50457.2 | 🚀 WIN |
| `simd_cosine_similarity/scalar/1536` | -18.01% | [-18.39%, -17.63%] | 3872.0 | 4722.6 | 🚀 WIN |
| `simd_throughput_384/normalize` | -17.17% | [-19.44%, -14.80%] | 104.0 | 125.6 | 🚀 WIN |
| `simd_batch_cosine/scalar_loop/10` | -17.42% | [-19.52%, -15.29%] | 7337.4 | 8885.4 | 🚀 WIN |
| `simd_throughput_384/euclidean_distance` | -18.15% | [-19.65%, -16.59%] | 29.9 | 36.5 | 🚀 WIN |
| `rms_norm/4096` | -17.14% | [-19.93%, -14.29%] | 582.2 | 702.6 | 🚀 WIN |
| `simd_normalize/scalar/768` | -17.45% | [-19.94%, -14.84%] | 740.9 | 897.5 | 🚀 WIN |
| `binary_cosine_distance/binary/1024` | -17.91% | [-20.13%, -15.58%] | 5.1 | 6.2 | 🚀 WIN |
| `rms_norm/896` | -19.72% | [-20.66%, -18.76%] | 133.9 | 166.8 | 🚀 WIN |
| `simd_dot_product/simd/384` | -19.66% | [-20.75%, -18.55%] | 28.1 | 35.0 | 🚀 WIN |
| `layer_norm/896` | -19.66% | [-21.49%, -17.74%] | 211.6 | 263.4 | 🚀 WIN |
| `simd_throughput_384/dot_product` | -21.09% | [-22.81%, -19.35%] | 28.0 | 35.5 | 🚀 WIN |
| `simd_cosine_similarity/simd/1536` | -20.50% | [-23.51%, -17.33%] | 130.7 | 164.3 | 🚀 WIN |
| `simd_batch_cosine/simd_batch/100` | -21.48% | [-23.59%, -19.25%] | 4205.3 | 5355.4 | 🚀 WIN |
| `simd_normalize/scalar/384` | -23.59% | [-23.91%, -23.28%] | 388.4 | 508.3 | 🚀 WIN |
| `simd_batch_cosine/simd_batch/10` | -23.47% | [-24.10%, -22.83%] | 325.2 | 425.0 | 🚀 WIN |
| `simd_normalize/simd/384` | -22.66% | [-24.75%, -20.45%] | 75.9 | 98.1 | 🚀 WIN |
| `simd_batch_cosine/scalar_loop/1000` | -25.17% | [-25.78%, -24.56%] | 696607.1 | 930932.0 | 🚀 WIN |
| `silu_inplace/4096` | -27.15% | [-27.48%, -26.82%] | 2097.3 | 2879.1 | 🚀 WIN |
| `elementwise_mul/4096` | -26.96% | [-28.23%, -25.66%] | 282.7 | 387.0 | 🚀 WIN |
| `simd_dot_product/scalar/768` | -30.21% | [-32.10%, -28.22%] | 580.4 | 831.6 | 🚀 WIN |
| `simd_batch_dot_product/simd_batch/10` | -26.44% | [-32.26%, -19.60%] | 245.8 | 334.2 | 🚀 WIN |
| `silu_inplace/896` | -30.78% | [-32.97%, -28.50%] | 461.5 | 666.8 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/1024` | -28.47% | [-34.80%, -21.01%] | 27.3 | 38.1 | 🚀 WIN |
| `int8_vs_float32_cosine/float32_simd/384` | -34.04% | [-34.95%, -33.11%] | 39.5 | 60.0 | 🚀 WIN |
| `simd_cosine_similarity/simd/1024` | -34.85% | [-34.97%, -34.73%] | 89.6 | 137.6 | 🚀 WIN |
| `simd_cosine_similarity/scalar/384` | -34.18% | [-35.57%, -32.73%] | 703.1 | 1068.3 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_16c` | -27.84% | [-36.19%, -17.03%] | 971.5 | 1346.3 | 🚀 WIN |
| `simd_cosine_similarity/scalar/768` | -38.94% | [-39.38%, -38.49%] | 1754.6 | 2873.3 | 🚀 WIN |
| `layer_norm/4096` | -34.11% | [-39.38%, -27.94%] | 900.4 | 1366.5 | 🚀 WIN |
| `softmax_attention/128` | -38.94% | [-39.54%, -38.33%] | 3665.1 | 6002.1 | 🚀 WIN |
| `int4_cosine_distance/float32_simd/1024` | -40.41% | [-43.13%, -37.55%] | 90.8 | 152.3 | 🚀 WIN |
| `simd_euclidean_distance/simd/1024` | -40.91% | [-46.14%, -34.67%] | 80.3 | 135.9 | 🚀 WIN |
| `simd_query_batch_dot_product/pair_loop/128d_4c` | -45.03% | [-46.24%, -43.79%] | 52.6 | 95.6 | 🚀 WIN |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/1024` | -49.69% | [-49.85%, -49.53%] | 78305.5 | 155644.7 | 🚀 WIN |
| `simd_cosine_similarity/scalar/1024` | -46.38% | [-50.53%, -41.56%] | 2485.0 | 4634.7 | 🚀 WIN |
| `simd_normalize/simd/1536` | -51.05% | [-52.55%, -49.47%] | 253.0 | 516.8 | 🚀 WIN |
| `add_bias_gelu/4096` | -57.62% | [-57.72%, -57.51%] | 1784.8 | 4210.9 | 🚀 WIN |
| `simd_euclidean_distance/scalar/1024` | -57.49% | [-58.03%, -56.94%] | 833.4 | 1960.3 | 🚀 WIN |
| `simd_euclidean_distance/scalar/384` | -58.02% | [-58.51%, -57.52%] | 248.8 | 592.7 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_4c` | -57.86% | [-58.60%, -57.09%] | 225.0 | 533.8 | 🚀 WIN |
| `simd_normalize/scalar/1024` | -59.37% | [-60.04%, -58.69%] | 979.1 | 2409.7 | 🚀 WIN |
| `simd_euclidean_distance/simd/768` | -56.54% | [-60.57%, -51.64%] | 59.3 | 136.4 | 🚀 WIN |
| `add_bias_gelu/896` | -59.75% | [-61.71%, -57.59%] | 394.7 | 980.7 | 🚀 WIN |
| `simd_normalize/simd/768` | -49.66% | [-64.44%, -15.61%] | 134.6 | 267.4 | 🚀 WIN |
| `softmax_attention/512` | -64.40% | [-65.06%, -63.71%] | 63812.2 | 179225.5 | 🚀 WIN |
| `simd_batch_cosine/simd_batch/1000` | -64.49% | [-65.22%, -63.74%] | 38405.1 | 108151.0 | 🚀 WIN |
| `gelu/896` | -64.46% | [-65.64%, -63.20%] | 373.9 | 1052.0 | 🚀 WIN |
| `simd_normalize/scalar/1536` | -65.41% | [-66.41%, -64.40%] | 1520.0 | 4394.7 | 🚀 WIN |
| `binary_cosine_distance/float32_simd/1024` | -61.48% | [-66.75%, -54.36%] | 88.7 | 230.2 | 🚀 WIN |
| `simd_euclidean_distance/scalar/1536` | -63.61% | [-70.88%, -51.48%] | 1346.5 | 3699.9 | 🚀 WIN |
| `binary_cosine_distance/binary/1536` | -68.07% | [-73.94%, -58.95%] | 7.1 | 22.3 | 🚀 WIN |
| `binary_cosine_distance/binary/768` | -73.07% | [-73.95%, -72.14%] | 4.1 | 15.3 | 🚀 WIN |
| `binary_cosine_distance/float32_simd/768` | -77.62% | [-78.57%, -76.59%] | 69.9 | 312.4 | 🚀 WIN |
| `simd_cosine_similarity/simd/768` | -72.14% | [-78.78%, -60.35%] | 70.9 | 254.3 | 🚀 WIN |
| `simd_normalize/simd/1024` | -80.06% | [-80.25%, -79.86%] | 179.0 | 897.6 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/simd_batch/768d_4c` | -75.17% | [-81.19%, -63.52%] | 250.7 | 1009.7 | 🚀 WIN |
| `simd_euclidean_distance/scalar/768` | -82.57% | [-82.83%, -82.31%] | 595.4 | 3416.7 | 🚀 WIN |
| `gelu/4096` | -78.71% | [-83.91%, -68.71%] | 1704.5 | 8008.1 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_4c` | -81.90% | [-86.38%, -73.68%] | 143.4 | 791.9 | 🚀 WIN |
| `simd_euclidean_distance/simd/384` | -84.09% | [-86.79%, -80.03%] | 30.5 | 191.9 | 🚀 WIN |
| `simd_cosine_similarity/simd/384` | -86.84% | [-87.10%, -86.57%] | 38.8 | 295.1 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_16c` | -88.02% | [-88.36%, -87.66%] | 870.7 | 7269.1 | 🚀 WIN |

_Rule: CI-lower of change ≤3.0% passes silently; (3.0%, 7.0%] warns; >7.0% fails. Override via PR label `bench-allow-regression`._


Done. Base=origin/main (85ef8eaf4), Head=HEAD (9bed231d0)
```

</details>

_Full 1499-line run (including the raw per-benchmark Criterion timing stream and the complete 259-row measurement appendix) captured at `tester/gate_output.txt`; the ranked report above is the gate's own parsed output._
