### PR TITLE
fix(inference): derive quantize_q4 output accounting from Q4_BLOCK_BYTES (#556)

### DIFF
--- a/crates/inference/src/bin/quantize_q4.rs
+++ b/crates/inference/src/bin/quantize_q4.rs
@@ -14,7 +14,7 @@
 //! Peak ≈ (tensor_elements × 6 bytes) — 178MB BF16 + 89MB Q4 for the largest shard tensor.
 
 use lattice_inference::weights::f32_weights::parse_index;
-use lattice_inference::weights::q4_weights::{quantize_bf16_to_q4, save_q4_file};
+use lattice_inference::weights::q4_weights::{Q4_BLOCK_BYTES, quantize_bf16_to_q4, save_q4_file};
 use memmap2::Mmap;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -483,7 +483,7 @@ fn main() {
 
                 let q4 = quantize_bf16_to_q4(&bf16_vals, shape)
                     .expect("Q4 quantization failed: source weights contain non-finite values");
-                let bytes_out = (q4.blocks.len() * 18) as u64;
+                let bytes_out = (q4.blocks.len() * Q4_BLOCK_BYTES) as u64;
                 total_bytes_out += bytes_out;
 
                 // Output file: <tensor_name_sanitized>.q4 (replace '.' and '/' with '_')

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -77,6 +77,12 @@ pub struct Q4Block {
 // Compile-time size assertion — must be exactly 20 bytes (2 + 2 + 16, no padding).
 const _: () = assert!(std::mem::size_of::<Q4Block>() == 20);
 
+/// Serialized size in bytes of one [`Q4Block`] (2 scale + 2 bias + 16 packed = 20).
+///
+/// Derive block-byte accounting from this constant rather than a magic literal so
+/// it can never drift from the struct layout asserted above.
+pub const Q4_BLOCK_BYTES: usize = std::mem::size_of::<Q4Block>();
+
 /// A Q4_0 quantized tensor.
 ///
 /// Stores blocks, shape metadata, and the count of valid original weights (the last


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #556.

## What

`quantize_q4.rs:486` computed the output-size summary statistic with a stale block size:

```rust
let bytes_out = (q4.blocks.len() * 18) as u64;
```

The Q4 block format is **20 bytes** per 32 weights (`f16 scale` + `f16 bias` + 16 bytes packed 4-bit), asserted at compile time in `q4_weights.rs` (`const _: () = assert!(size_of::<Q4Block>() == 20)`). The writer, the Metal decode kernel, and the loader all serialize/consume 20-byte blocks; only this one accounting literal still assumed the legacy 18-byte symmetric layout.

## Fix

- Introduce `pub const Q4_BLOCK_BYTES: usize = size_of::<Q4Block>()` in `q4_weights.rs`, next to the size assertion, mirroring the existing `Q8_0_BLOCK_BYTES` precedent in `neon.rs`.
- Use it at the accounting site instead of the literal. The value is now tied to the struct layout, so the two cannot drift.

## Scope / impact

Low severity: `total_bytes_out` is a reporting statistic printed by the CLI, not used to size any allocation or byte offset, so quantized output files were always correct. The reported total under-counted real output by ~10%; this corrects the report.

`* 18` at line 486 was the only bare block-size literal in the quantizer (grep-verified); `#526` previously fixed the stale *comments*, and this closes the one remaining *code* site.

## bench-compare

N/A. The change is a summary-statistic constant in the `quantize_q4` CLI binary (`crates/inference/src/bin/`) plus an inert `size_of`-derived `pub const`. It is not on any decode/prefill runtime path, no Criterion group covers it, and it cannot affect throughput (ADR-058 targets the inference/embed hot paths). Engine gates (`e2e-parity`, feature-matrix, CI) still run because the change lives under `crates/inference/src/`.

## Verification

- `cargo clippy -p lattice-inference --bin quantize_q4 -- -D warnings` clean.
- Const is compile-time equal to the asserted 20; the arithmetic (`blocks.len() * usize as u64`) is unchanged besides the value.
