### PR TITLE
fix(inference): drop nightly-only NEON f16 intrinsics so stable toolchains build (#568)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,30 @@ jobs:
       - name: embed benches
         run: cargo bench -p lattice-embed --no-run
 
+  # MSRV gate (#568). Every other job pins 1.94.1, so an API that stabilized in
+  # 1.94 compiles green across all of CI while breaking every user on an older
+  # stable — exactly how the nightly-gated NEON f16 intrinsics (stabilized in
+  # 1.94, rust-lang/rust#136306) shipped and broke a stable-1.93 user's build.
+  # This job compiles the workspace at the declared rust-version instead.
+  # macos-latest because it is aarch64 Apple Silicon: the NEON and Metal
+  # surfaces only compile there. --all-targets because one of the three #568
+  # intrinsic copies lived in a bench target. check (not test): the gate is
+  # "compiles at MSRV", behavior is covered by the 1.94.1 jobs above.
+  msrv:
+    name: msrv (1.93, f16+metal-gpu)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93.1
+      - name: Pin the real toolchain bin on PATH
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv
+          cache-on-failure: true
+      - name: workspace — check at MSRV (f16,metal-gpu, all targets)
+        run: cargo check --workspace --features f16,metal-gpu --all-targets
+
   # Supply-chain gate. licenses/bans/sources are deterministic and REQUIRED:
   # a green main cannot turn red without a manifest/lockfile change. Advisories
   # run separately as informational (continue-on-error) because fresh RUSTSEC

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,15 @@ members = [
 [workspace.package]
 version = "0.4.2"
 edition = "2024"
+# MSRV, verified end-to-end (workspace + deps) on 1.93.1 and guarded by the msrv CI
+# job (aarch64 macOS, f16,metal-gpu, --all-targets) so a newer-toolchain-only API
+# cannot silently ship again (#568: nightly-gated NEON f16 intrinsics compiled on
+# CI's pinned 1.94.1 but broke users on 1.93). Locked deps already require >=1.88,
+# so 1.85 (the edition2024 floor in .clippy.toml) is not attainable. .clippy.toml
+# intentionally stays at 1.85: it only sets the style-lint floor, and raising it to
+# 1.93 activates manual_is_multiple_of across ~70 pre-existing sites (tracked as a
+# follow-up).
+rust-version = "1.93"
 authors = ["Ocean <ocean@lionagi.ai>"]
 license = "Apache-2.0"
 repository = "https://github.com/ohdearquant/lattice"

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lattice-embed"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/fann/Cargo.toml
+++ b/crates/fann/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lattice-fann"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lattice-inference"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/inference/benches/f16_convert_bench.rs
+++ b/crates/inference/benches/f16_convert_bench.rs
@@ -3,8 +3,10 @@
 //!
 //! Measures at N=1024 (the Qwen3.5-0.8B hidden size):
 //! - `scalar`: hand-written IEEE-754 bit-manipulation loop (~10 ops/element)
-//! - `neon`: `vcvt_f32_f16` NEON intrinsic (4 lanes/instruction) on aarch64;
-//!   falls back to scalar on other targets
+//!
+//! A NEON fast path (`vcvt_f32_f16`, 4 lanes/instruction) was removed in #568: it
+//! required the nightly-only `stdarch_neon_f16` feature and broke stable-toolchain
+//! builds. `convert_f16_row` in `metal_qwen35.rs` is scalar-only for the same reason.
 //!
 //! Run: `cargo bench -p lattice-inference --bench f16_convert_bench`
 //!
@@ -53,41 +55,6 @@ unsafe fn convert_f16_row_scalar(src: *const u16, dst: *mut f32, n: usize) {
 }
 
 // --------------------------------------------------------------------------
-// NEON fast path (aarch64 only; falls through to scalar on other targets)
-// --------------------------------------------------------------------------
-
-/// Convert n f16 values (as u16 bits) at `src` into f32 values at `dst`.
-///
-/// On aarch64 uses `vcvt_f32_f16` (4 lanes per instruction); scalar elsewhere.
-///
-/// # Safety
-/// `src` must point to at least `n` initialized u16 values; `dst` to at least `n` writable f32.
-unsafe fn convert_f16_row_neon(src: *const u16, dst: *mut f32, n: usize) {
-    #[cfg(target_arch = "aarch64")]
-    {
-        use std::arch::aarch64::*;
-        // SAFETY: caller guarantees src has n u16 values and dst has n f32 values.
-        // NEON is always present on aarch64; we process 4 lanes per iter, scalar tail.
-        let mut i = 0usize;
-        while i + 4 <= n {
-            let v_u16 = vld1_u16(src.add(i));
-            let v_f16 = vreinterpret_f16_u16(v_u16);
-            let v_f32 = vcvt_f32_f16(v_f16);
-            vst1q_f32(dst.add(i), v_f32);
-            i += 4;
-        }
-        while i < n {
-            *dst.add(i) = f16_to_f32_scalar(*src.add(i));
-            i += 1;
-        }
-    }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        convert_f16_row_scalar(src, dst, n);
-    }
-}
-
-// --------------------------------------------------------------------------
 // Bench harness
 // --------------------------------------------------------------------------
 
@@ -117,15 +84,6 @@ fn bench_f16_convert(c: &mut Criterion) {
             // SAFETY: src and dst are N-element buffers; loop is inbounds.
             unsafe {
                 convert_f16_row_scalar(black_box(src.as_ptr()), black_box(dst.as_mut_ptr()), N);
-            }
-        })
-    });
-
-    group.bench_with_input(BenchmarkId::new("neon", N), &N, |b, &_n| {
-        b.iter(|| {
-            // SAFETY: same as above.
-            unsafe {
-                convert_f16_row_neon(black_box(src.as_ptr()), black_box(dst.as_mut_ptr()), N);
             }
         })
     });

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -5151,37 +5151,19 @@ kernel void gdn_chunk_norm_silu_c32(
     /// Convert a contiguous slice of IEEE-754 half-precision values (stored as u16 bits)
     /// to f32, writing into a pre-allocated destination buffer.
     ///
-    /// On aarch64 the inner loop uses `vcvt_f32_f16` (4 lanes per instruction) with a
-    /// scalar remainder tail. On other targets the scalar `f16_to_f32` is used throughout.
+    /// Scalar `f16_to_f32` throughout. A 4-lane NEON fast path (`vcvt_f32_f16`) was
+    /// tried on aarch64 but requires the nightly-only `stdarch_neon_f16` feature
+    /// (rust-lang/rust#136306) and broke stable-toolchain builds (#568) — this runs
+    /// off the GPU decode hot path (one row per token embedding lookup / readback),
+    /// so the scalar cost is not worth the unstable dependency.
     ///
     /// # Safety
     /// - `src` must point to at least `n` contiguous, initialized u16 values.
     /// - `dst` must point to at least `n` contiguous, writable f32 values.
     /// - `n` may be zero (no-op).
     unsafe fn convert_f16_row(src: *const u16, dst: *mut f32, n: usize) {
-        #[cfg(target_arch = "aarch64")]
-        {
-            use std::arch::aarch64::*;
-            // SAFETY: src has n u16 values; dst has n f32 values; we process 4 per iteration
-            // then handle the remainder scalarly. NEON is always present on aarch64.
-            let mut i = 0usize;
-            while i + 4 <= n {
-                let v_u16 = vld1_u16(src.add(i));
-                let v_f16 = vreinterpret_f16_u16(v_u16);
-                let v_f32 = vcvt_f32_f16(v_f16);
-                vst1q_f32(dst.add(i), v_f32);
-                i += 4;
-            }
-            while i < n {
-                *dst.add(i) = f16_to_f32(*src.add(i));
-                i += 1;
-            }
-        }
-        #[cfg(not(target_arch = "aarch64"))]
-        {
-            for i in 0..n {
-                *dst.add(i) = f16_to_f32(*src.add(i));
-            }
+        for i in 0..n {
+            *dst.add(i) = f16_to_f32(*src.add(i));
         }
     }
 
@@ -17001,9 +16983,10 @@ kernel void gdn_chunk_norm_silu_c32(
             );
         }
 
-        /// Sweep all 65 536 u16 bit patterns and assert that `convert_f16_row` (NEON
-        /// on aarch64, scalar on other targets) produces bit-identical output to the
-        /// scalar `f16_to_f32` reference for every pattern.
+        /// Sweep all 65 536 u16 bit patterns and assert that `convert_f16_row` produces
+        /// bit-identical output to the scalar `f16_to_f32` reference for every pattern
+        /// (regression guard: `convert_f16_row` is itself scalar-only post-#568, so this
+        /// mainly pins the loop's correctness against the reference implementation).
         ///
         /// NaN comparison policy: both outputs are NaN ⇒ pass (any NaN payload is
         /// acceptable; the bit pattern of a NaN is not architecturally meaningful).

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lattice-transport"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lattice-tune"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #568

## Root cause

`convert_f16_row` in `metal_qwen35.rs` used `vreinterpret_f16_u16` + `vcvt_f32_f16` on aarch64. Those intrinsics were nightly-only behind `stdarch_neon_f16` until they **stabilized in Rust 1.94** (rust-lang/rust#136306). Every CI job pins rustc 1.94.1, so CI stayed green while every user on stable ≤1.93 hit `E0658` on the documented build path:

```
cargo build --release -p lattice-inference --bin eval_perplexity --features f16,metal-gpu
```

Reproduced exactly on rustc 1.93.1 before the fix (E0658 at the two intrinsic call sites).

Thanks to @bencium for the report and the precise diagnosis — the issue identified both the failing feature gate and the fix shape.

## Fix (commit 1)

- Collapse `convert_f16_row` to the scalar `f16_to_f32` loop. The scalar conversion was already the NEON remainder-tail reference, so the change is bit-identical by construction; the existing 65536-pattern sweep test pins this.
- Remove the dead `convert_f16_row_neon` sibling in `f16_convert_bench.rs` and its bench arm (it can't compile on stable either). No gate config references the removed bench ID.
- This helper is off the GPU decode hot path (one row per token embedding lookup / readback), so the scalar cost is not a perf concern. A future stable-SIMD or `core::arch::asm` (`fcvtl`) fast path stays on the table if profiling ever shows this row conversion mattering.

## Systemic guard (commit 2)

A generic "stable" CI job would **not** have caught this — 1.94 is stable now. The gap is CI-toolchain vs MSRV skew, so:

- Declare `rust-version = "1.93"` in `[workspace.package]`, inherited by all five crates. Verified end-to-end on 1.93.1 including the locked dependency tree (locked deps already require up to rustc 1.88, so an older floor is not attainable).
- Add an `msrv` CI job: `cargo check --workspace --features f16,metal-gpu --all-targets` on `macos-latest` at 1.93.1. Apple Silicon because the NEON/Metal surfaces only compile there; `--all-targets` because one of the intrinsic copies lived in a bench target.
- `.clippy.toml` deliberately stays at `msrv = 1.85`: it only sets the style-lint floor, and raising it activates `manual_is_multiple_of` across ~70 pre-existing sites (tracked as a follow-up). Documented in `Cargo.toml`.

## Verification

| Check | Result |
|---|---|
| Exact failing command from #568 on rustc 1.93.1 | builds clean after fix (fails with E0658 before) |
| `cargo check --workspace --features f16,metal-gpu --all-targets` on 1.93.1 | clean |
| f16 sweep test (`convert_f16_row` 65536-pattern bit-identity) | pass |
| `cargo clippy --all-targets --features f16,metal-gpu -- -D warnings` (CI's exact clippy gate) | clean |
| `scripts/package-app.sh` (full user-facing packaging path) | success — 10 binaries, codesign verified, Lattice.app 23M / .dmg 9.6M / .zip 8.7M |
| GPU-flake differential (branch vs main @ same base, same machine load) | not diff-related — same tests fail on **main** with the same shape but different nondeterministic details (greedy 3/10000 vs 1/10000 at different positions; top-k boundary-tie at different steps; one test flipped pass/fail in the opposite direction). The sweep test proves the conversion change is bit-identical for all 65536 f16 inputs, so the diff cannot alter numerics. |

## Bench note

The touched helper runs once per token for embedding-row conversion and readback, off the Metal decode hot path. The removed bench arm existed only to compare the (now-removed) NEON variant against scalar; the scalar arm remains registered. No decode/prefill throughput path changed, so `bench-compare` on the Criterion GPU groups is not applicable to this diff.
