### PR TITLE
fix(serve): cancel queued/running jobs on client disconnect (#552)

### DIFF
--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -91,12 +91,16 @@ mod imp {
     ///
     /// `cancel` reflects whether the client that submitted this job is still
     /// there. It starts `false` and flips to `true` the moment the matching
-    /// [`CancelOnDrop`] guard is dropped — i.e. the instant axum drops the
+    /// [`CancelOnDrop`] guard is dropped -- i.e. the instant axum drops the
     /// response future/stream, which is exactly what happens on client
     /// disconnect (browser tab closed, `curl` killed, request future
-    /// cancelled). The worker checks it (a) once at dequeue, before doing
-    /// any work, and (b) on every decode step, so an abandoned job is either
-    /// skipped entirely or stopped within one token of the client leaving.
+    /// cancelled). The worker checks it (a) once at dequeue, before doing any
+    /// work, and (b) independently of token emission, via
+    /// `chat_completion_streaming_with_cancel`'s `should_cancel` predicate --
+    /// before prefill, immediately after prefill returns, and at the top of
+    /// every decode iteration -- so an abandoned job is skipped entirely,
+    /// stopped before paying for prefill, or stopped within one decode step
+    /// of the client leaving.
     struct Job {
         messages: Vec<ChatMessage>,
         cfg: GenerateConfig,
@@ -251,9 +255,15 @@ mod imp {
             };
             let _ = ready.send(Ok(fmt));
 
-            run_worker_loop(job_rx, move |messages, cfg, on_token| {
+            run_worker_loop(job_rx, move |messages, cfg, on_token, should_cancel| {
                 metal.reset_state();
-                let out = metal.chat_completion_streaming(messages, &tokenizer, cfg, on_token);
+                let out = metal.chat_completion_streaming_with_cancel(
+                    messages,
+                    &tokenizer,
+                    cfg,
+                    on_token,
+                    should_cancel,
+                );
                 (out.prompt_tokens, out.completion_tokens)
             });
         });
@@ -266,15 +276,19 @@ mod imp {
     /// `generate` is injected so tests can swap in a fake, GPU-free generator
     /// while exercising the exact same queue/cancellation logic production
     /// uses. It must call `on_token` for each generated delta and stop as
-    /// soon as `on_token` returns `false`, returning
-    /// `(prompt_tokens, completion_tokens)` for whatever was actually
-    /// produced before stopping (early or at the cap).
+    /// soon as `on_token` returns `false`; it must also poll `should_cancel`
+    /// independently of `on_token` -- including during any phase that never
+    /// calls `on_token` at all (a prefill-like section, or a run of
+    /// empty-delta steps) -- and stop as soon as `should_cancel` returns
+    /// `true`. Either way, return `(prompt_tokens, completion_tokens)` for
+    /// whatever was actually produced before stopping (early or at the cap).
     fn run_worker_loop(
         mut job_rx: mpsc::UnboundedReceiver<Job>,
         mut generate: impl FnMut(
             &[ChatMessage],
             &GenerateConfig,
             &mut dyn FnMut(&str, u32) -> bool,
+            &mut dyn FnMut() -> bool,
         ) -> (usize, usize),
     ) {
         while let Some(job) = job_rx.blocking_recv() {
@@ -284,9 +298,9 @@ mod imp {
                 continue;
             }
             let cb_tx = job.tx.clone();
-            let cancel = job.cancel.clone();
+            let cancel_for_token = job.cancel.clone();
             let mut on_token = move |delta: &str, _id: u32| {
-                if *cancel.borrow() {
+                if *cancel_for_token.borrow() {
                     return false;
                 }
                 // `send` also fails once the client hangs up; kept as a
@@ -295,8 +309,14 @@ mod imp {
                 // its reply channel is gone.
                 cb_tx.send(Ev::Delta(delta.to_string())).is_ok()
             };
+            // Separate from `on_token`: this is what reaches the generator's
+            // prefill gap and its empty-delta decode iterations, neither of
+            // which ever calls `on_token` (see
+            // `MetalQwen35State::generate_streaming_with_cancel`).
+            let cancel_for_predicate = job.cancel.clone();
+            let mut should_cancel = move || *cancel_for_predicate.borrow();
             let (prompt_tokens, completion_tokens) =
-                generate(&job.messages, &job.cfg, &mut on_token);
+                generate(&job.messages, &job.cfg, &mut on_token, &mut should_cancel);
             let _ = job.tx.send(Ev::Done {
                 prompt_tokens,
                 completion_tokens,
@@ -773,16 +793,19 @@ mod imp {
     mod tests {
         use super::*;
         use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         use std::time::Duration;
 
-        /// A GPU-free stand-in for `MetalQwen35State::chat_completion_streaming`:
+        /// A GPU-free stand-in for `MetalQwen35State::chat_completion_streaming_with_cancel`:
         /// "generates" up to `cap` fake tokens, sleeping briefly between each so
         /// a cancelled job has many opportunities to be observed running past
         /// where it should have stopped. Counts how many times it was entered
         /// (`started`) and how many fake tokens actually ran (`ran_tokens`), so
         /// tests can assert a cancelled queued job's generator was never called
-        /// at all.
+        /// at all. Checks `should_cancel` at the top of each iteration in
+        /// addition to `on_token`'s own check, mirroring the production
+        /// contract; existing tests here only rely on the `on_token` path, so
+        /// this addition does not change their outcomes.
         #[allow(clippy::type_complexity)]
         fn fake_generate(
             cap: usize,
@@ -792,17 +815,62 @@ mod imp {
             &[ChatMessage],
             &GenerateConfig,
             &mut dyn FnMut(&str, u32) -> bool,
+            &mut dyn FnMut() -> bool,
         ) -> (usize, usize) {
-            move |_messages, _cfg, on_token| {
+            move |_messages, _cfg, on_token, should_cancel| {
                 started.fetch_add(1, Ordering::SeqCst);
                 let mut n = 0usize;
                 for i in 0..cap {
                     std::thread::sleep(Duration::from_millis(5));
+                    if should_cancel() {
+                        break;
+                    }
                     if !on_token("x", i as u32) {
                         break;
                     }
                     n += 1;
                     ran_tokens.fetch_add(1, Ordering::SeqCst);
+                }
+                (1, n)
+            }
+        }
+
+        /// A GPU-free fake with an explicit prefill-like phase *before* any
+        /// `on_token` call -- mirroring the real gap this fix closes:
+        /// production prefill has no callback point at all, so only
+        /// `should_cancel` (never `on_token`) can observe a disconnect that
+        /// happens during it. `entered_decode` flips only if the prefill-like
+        /// phase runs to completion uncancelled, so tests can assert it never
+        /// does.
+        #[allow(clippy::type_complexity)]
+        fn fake_generate_with_prefill_gap(
+            prefill_steps: usize,
+            decode_cap: usize,
+            entered_decode: Arc<AtomicBool>,
+        ) -> impl FnMut(
+            &[ChatMessage],
+            &GenerateConfig,
+            &mut dyn FnMut(&str, u32) -> bool,
+            &mut dyn FnMut() -> bool,
+        ) -> (usize, usize) {
+            move |_messages, _cfg, on_token, should_cancel| {
+                for _ in 0..prefill_steps {
+                    std::thread::sleep(Duration::from_millis(5));
+                    if should_cancel() {
+                        return (1, 0);
+                    }
+                }
+                entered_decode.store(true, Ordering::SeqCst);
+                let mut n = 0usize;
+                for i in 0..decode_cap {
+                    std::thread::sleep(Duration::from_millis(5));
+                    if should_cancel() {
+                        break;
+                    }
+                    if !on_token("x", i as u32) {
+                        break;
+                    }
+                    n += 1;
                 }
                 (1, n)
             }
@@ -974,6 +1042,64 @@ mod imp {
             );
 
             handle.join().expect("worker thread must not panic");
+        }
+
+        /// Codex review of PR #606: cancellation was only observed through the
+        /// `on_token` callback, so a generator phase that never calls it -- the
+        /// real prefill pass has no callback point at all -- could run
+        /// unbounded after the client already disconnected. This proves
+        /// `run_worker_loop` threads an independent `should_cancel` signal
+        /// through to `generate` and that a fake generator honoring only that
+        /// signal (never `on_token`) still gets stopped promptly, well short
+        /// of its prefill-like phase's natural end.
+        #[test]
+        fn running_job_cancelled_during_prefill_like_phase_never_calls_on_token() {
+            let (job_tx, job_rx) = mpsc::unbounded_channel::<Job>();
+            let entered_decode = Arc::new(AtomicBool::new(false));
+
+            let (job1, mut rx1, guard1) = make_job();
+            job_tx.send(job1).unwrap();
+            drop(job_tx);
+
+            // 400 * 5ms = up to 2s of "prefill" if never cancelled -- the test
+            // cancels at 20ms in, ~100x margin, so reaching Done quickly is
+            // only possible if should_cancel actually stopped it early.
+            let entered2 = entered_decode.clone();
+            let handle = std::thread::spawn(move || {
+                run_worker_loop(job_rx, fake_generate_with_prefill_gap(400, 50, entered2))
+            });
+
+            std::thread::sleep(Duration::from_millis(20));
+            drop(guard1);
+
+            match rx1.blocking_recv() {
+                Some(Ev::Delta(_)) => panic!(
+                    "on_token must never be called: cancellation happened while the \
+                     fake generator was still in its prefill-like phase, which does \
+                     not call on_token at all"
+                ),
+                Some(Ev::Done {
+                    completion_tokens, ..
+                }) => {
+                    assert_eq!(
+                        completion_tokens, 0,
+                        "job cancelled during the prefill-like phase must produce \
+                         zero tokens, got {completion_tokens}"
+                    );
+                }
+                None => panic!("job 1's reply channel closed before a Done event"),
+            }
+
+            handle.join().expect("worker thread must not panic");
+
+            assert!(
+                !entered_decode.load(Ordering::SeqCst),
+                "should_cancel alone (on_token is never called during this phase) \
+                 must stop the job before the decode phase is ever reached -- this \
+                 is the exact blind spot from the PR #606 review, where production \
+                 prefill has no on_token callback point and so could run to \
+                 completion after the client already disconnected"
+            );
         }
     }
 }

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -74,7 +74,7 @@ mod imp {
     use serde_json::{Value, json};
     use std::sync::Arc;
     use std::time::{Instant, SystemTime, UNIX_EPOCH};
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, watch};
 
     // ─── worker protocol ─────────────────────────────────────────────────────
 
@@ -88,10 +88,33 @@ mod imp {
     }
 
     /// A generation request handed to the single GPU worker thread.
+    ///
+    /// `cancel` reflects whether the client that submitted this job is still
+    /// there. It starts `false` and flips to `true` the moment the matching
+    /// [`CancelOnDrop`] guard is dropped — i.e. the instant axum drops the
+    /// response future/stream, which is exactly what happens on client
+    /// disconnect (browser tab closed, `curl` killed, request future
+    /// cancelled). The worker checks it (a) once at dequeue, before doing
+    /// any work, and (b) on every decode step, so an abandoned job is either
+    /// skipped entirely or stopped within one token of the client leaving.
     struct Job {
         messages: Vec<ChatMessage>,
         cfg: GenerateConfig,
         tx: mpsc::UnboundedSender<Ev>,
+        cancel: watch::Receiver<bool>,
+    }
+
+    /// Flips the paired `cancel` receiver to `true` when dropped. Held inside
+    /// the per-request SSE stream state (streaming) or the handler's local
+    /// scope (non-streaming) so it drops exactly when axum stops caring about
+    /// the response — on client disconnect, or harmlessly after the request
+    /// already finished normally (by then the worker has moved on anyway).
+    struct CancelOnDrop(watch::Sender<bool>);
+
+    impl Drop for CancelOnDrop {
+        fn drop(&mut self) {
+            let _ = self.0.send(true);
+        }
     }
 
     /// Server-side sampling defaults, overridable per-request.
@@ -216,7 +239,7 @@ mod imp {
         is_q4: bool,
         ready: std::sync::mpsc::Sender<Result<String, String>>,
     ) -> mpsc::UnboundedSender<Job> {
-        let (job_tx, mut job_rx) = mpsc::unbounded_channel::<Job>();
+        let (job_tx, job_rx) = mpsc::unbounded_channel::<Job>();
         std::thread::spawn(move || {
             let loaded = load_model(&model_dir, &tokenizer_path, is_q4);
             let (mut metal, tokenizer, fmt) = match loaded {
@@ -228,27 +251,57 @@ mod imp {
             };
             let _ = ready.send(Ok(fmt));
 
-            while let Some(job) = job_rx.blocking_recv() {
+            run_worker_loop(job_rx, move |messages, cfg, on_token| {
                 metal.reset_state();
-                let cb_tx = job.tx.clone();
-                let out = metal.chat_completion_streaming(
-                    &job.messages,
-                    &tokenizer,
-                    &job.cfg,
-                    |delta, _id| {
-                        // `send` fails once the client hangs up; returning false
-                        // stops generation early instead of burning GPU on a dead
-                        // connection.
-                        cb_tx.send(Ev::Delta(delta.to_string())).is_ok()
-                    },
-                );
-                let _ = job.tx.send(Ev::Done {
-                    prompt_tokens: out.prompt_tokens,
-                    completion_tokens: out.completion_tokens,
-                });
-            }
+                let out = metal.chat_completion_streaming(messages, &tokenizer, cfg, on_token);
+                (out.prompt_tokens, out.completion_tokens)
+            });
         });
         job_tx
+    }
+
+    /// Dequeue -> cancel-check -> generate -> reply, serialized on whatever
+    /// thread calls this (the dedicated Metal worker thread in production).
+    ///
+    /// `generate` is injected so tests can swap in a fake, GPU-free generator
+    /// while exercising the exact same queue/cancellation logic production
+    /// uses. It must call `on_token` for each generated delta and stop as
+    /// soon as `on_token` returns `false`, returning
+    /// `(prompt_tokens, completion_tokens)` for whatever was actually
+    /// produced before stopping (early or at the cap).
+    fn run_worker_loop(
+        mut job_rx: mpsc::UnboundedReceiver<Job>,
+        mut generate: impl FnMut(
+            &[ChatMessage],
+            &GenerateConfig,
+            &mut dyn FnMut(&str, u32) -> bool,
+        ) -> (usize, usize),
+    ) {
+        while let Some(job) = job_rx.blocking_recv() {
+            if *job.cancel.borrow() {
+                // The client was already gone before we ever got to this job:
+                // skip it entirely, no prefill, no decode, no reply.
+                continue;
+            }
+            let cb_tx = job.tx.clone();
+            let cancel = job.cancel.clone();
+            let mut on_token = move |delta: &str, _id: u32| {
+                if *cancel.borrow() {
+                    return false;
+                }
+                // `send` also fails once the client hangs up; kept as a
+                // second, independent check so a job whose cancellation
+                // notification is somehow delayed still stops the instant
+                // its reply channel is gone.
+                cb_tx.send(Ev::Delta(delta.to_string())).is_ok()
+            };
+            let (prompt_tokens, completion_tokens) =
+                generate(&job.messages, &job.cfg, &mut on_token);
+            let _ = job.tx.send(Ev::Done {
+                prompt_tokens,
+                completion_tokens,
+            });
+        }
     }
 
     fn load_model(
@@ -367,7 +420,16 @@ mod imp {
         let created = unix_secs();
 
         let (tx, mut rx) = mpsc::unbounded_channel::<Ev>();
-        if s.jobs.send(Job { messages, cfg, tx }).is_err() {
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        if s.jobs
+            .send(Job {
+                messages,
+                cfg,
+                tx,
+                cancel: cancel_rx,
+            })
+            .is_err()
+        {
             emit_serve_event(
                 "POST",
                 "/v1/chat/completions",
@@ -381,81 +443,90 @@ mod imp {
                 "inference worker unavailable",
             );
         }
+        // Dropped when nobody cares about the response anymore: at the end of
+        // this SSE stream (moved in below) or at the end of this function for
+        // the non-streaming branch. Either way that's the client disconnect
+        // signal the worker checks in `run_worker_loop`.
+        let cancel_guard = CancelOnDrop(cancel_tx);
 
         if streaming {
-            let stream = futures::stream::unfold((rx, Phase::Start), move |(mut rx, phase)| {
-                let id = id.clone();
-                let model = model_id.clone();
-                async move {
-                    match phase {
-                        Phase::Start => {
-                            let chunk = json!({
-                                "id": id, "object": "chat.completion.chunk",
-                                "created": created, "model": model,
-                                "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": null}],
-                            });
-                            Some((
-                                Ok::<Event, std::convert::Infallible>(
-                                    Event::default().data(chunk.to_string()),
-                                ),
-                                (rx, Phase::Body),
-                            ))
-                        }
-                        Phase::Body => match rx.recv().await {
-                            Some(Ev::Delta(d)) => {
+            let stream = futures::stream::unfold(
+                (rx, Phase::Start, cancel_guard),
+                move |(mut rx, phase, cancel_guard)| {
+                    let id = id.clone();
+                    let model = model_id.clone();
+                    async move {
+                        match phase {
+                            Phase::Start => {
                                 let chunk = json!({
                                     "id": id, "object": "chat.completion.chunk",
                                     "created": created, "model": model,
-                                    "choices": [{"index": 0, "delta": {"content": d}, "finish_reason": null}],
+                                    "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": null}],
                                 });
                                 Some((
-                                    Ok(Event::default().data(chunk.to_string())),
-                                    (rx, Phase::Body),
+                                    Ok::<Event, std::convert::Infallible>(
+                                        Event::default().data(chunk.to_string()),
+                                    ),
+                                    (rx, Phase::Body, cancel_guard),
                                 ))
                             }
-                            Some(Ev::Done {
-                                completion_tokens: ct,
-                                ..
-                            }) => {
-                                let chunk = json!({
-                                    "id": id, "object": "chat.completion.chunk",
-                                    "created": created, "model": model,
-                                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-                                });
-                                Some((
-                                    Ok(Event::default().data(chunk.to_string())),
-                                    (rx, Phase::Done(ct)),
-                                ))
+                            Phase::Body => match rx.recv().await {
+                                Some(Ev::Delta(d)) => {
+                                    let chunk = json!({
+                                        "id": id, "object": "chat.completion.chunk",
+                                        "created": created, "model": model,
+                                        "choices": [{"index": 0, "delta": {"content": d}, "finish_reason": null}],
+                                    });
+                                    Some((
+                                        Ok(Event::default().data(chunk.to_string())),
+                                        (rx, Phase::Body, cancel_guard),
+                                    ))
+                                }
+                                Some(Ev::Done {
+                                    completion_tokens: ct,
+                                    ..
+                                }) => {
+                                    let chunk = json!({
+                                        "id": id, "object": "chat.completion.chunk",
+                                        "created": created, "model": model,
+                                        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                                    });
+                                    Some((
+                                        Ok(Event::default().data(chunk.to_string())),
+                                        (rx, Phase::Done(ct), cancel_guard),
+                                    ))
+                                }
+                                None => {
+                                    let chunk = json!({
+                                        "id": id, "object": "chat.completion.chunk",
+                                        "created": created, "model": model,
+                                        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                                    });
+                                    Some((
+                                        Ok(Event::default().data(chunk.to_string())),
+                                        (rx, Phase::Done(0), cancel_guard),
+                                    ))
+                                }
+                            },
+                            Phase::Done(ct) => Some((
+                                Ok(Event::default().data("[DONE]")),
+                                (rx, Phase::End(ct), cancel_guard),
+                            )),
+                            Phase::End(ct) => {
+                                emit_serve_event(
+                                    "POST",
+                                    "/v1/chat/completions",
+                                    200,
+                                    Some(ct),
+                                    timer.elapsed().as_secs_f64() * 1000.0,
+                                    true,
+                                );
+                                None
                             }
-                            None => {
-                                let chunk = json!({
-                                    "id": id, "object": "chat.completion.chunk",
-                                    "created": created, "model": model,
-                                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-                                });
-                                Some((
-                                    Ok(Event::default().data(chunk.to_string())),
-                                    (rx, Phase::Done(0)),
-                                ))
-                            }
-                        },
-                        Phase::Done(ct) => {
-                            Some((Ok(Event::default().data("[DONE]")), (rx, Phase::End(ct))))
-                        }
-                        Phase::End(ct) => {
-                            emit_serve_event(
-                                "POST",
-                                "/v1/chat/completions",
-                                200,
-                                Some(ct),
-                                timer.elapsed().as_secs_f64() * 1000.0,
-                                true,
-                            );
-                            None
                         }
                     }
-                }
-            });
+                },
+            );
             Sse::new(stream)
                 .keep_alive(KeepAlive::default())
                 .into_response()
@@ -694,5 +765,215 @@ mod imp {
         })?;
 
         Ok(())
+    }
+
+    // ─── tests ───────────────────────────────────────────────────────────────
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        /// A GPU-free stand-in for `MetalQwen35State::chat_completion_streaming`:
+        /// "generates" up to `cap` fake tokens, sleeping briefly between each so
+        /// a cancelled job has many opportunities to be observed running past
+        /// where it should have stopped. Counts how many times it was entered
+        /// (`started`) and how many fake tokens actually ran (`ran_tokens`), so
+        /// tests can assert a cancelled queued job's generator was never called
+        /// at all.
+        #[allow(clippy::type_complexity)]
+        fn fake_generate(
+            cap: usize,
+            started: Arc<AtomicUsize>,
+            ran_tokens: Arc<AtomicUsize>,
+        ) -> impl FnMut(
+            &[ChatMessage],
+            &GenerateConfig,
+            &mut dyn FnMut(&str, u32) -> bool,
+        ) -> (usize, usize) {
+            move |_messages, _cfg, on_token| {
+                started.fetch_add(1, Ordering::SeqCst);
+                let mut n = 0usize;
+                for i in 0..cap {
+                    std::thread::sleep(Duration::from_millis(5));
+                    if !on_token("x", i as u32) {
+                        break;
+                    }
+                    n += 1;
+                    ran_tokens.fetch_add(1, Ordering::SeqCst);
+                }
+                (1, n)
+            }
+        }
+
+        /// Builds a `Job` plus the receiver its worker replies on and the guard
+        /// that cancels it when dropped (the same guard `chat_completions`
+        /// moves into the SSE stream / keeps local for non-streaming, standing
+        /// in here for "the client is still connected").
+        fn make_job() -> (Job, mpsc::UnboundedReceiver<Ev>, CancelOnDrop) {
+            let (tx, rx) = mpsc::unbounded_channel::<Ev>();
+            let (cancel_tx, cancel_rx) = watch::channel(false);
+            let job = Job {
+                messages: vec![ChatMessage::user("hi")],
+                cfg: GenerateConfig::default(),
+                tx,
+                cancel: cancel_rx,
+            };
+            (job, rx, CancelOnDrop(cancel_tx))
+        }
+
+        #[test]
+        fn queued_job_cancelled_before_dequeue_is_skipped_entirely() {
+            let (job_tx, job_rx) = mpsc::unbounded_channel::<Job>();
+            let started = Arc::new(AtomicUsize::new(0));
+            let ran_tokens = Arc::new(AtomicUsize::new(0));
+
+            // Job 1 occupies the worker (50 fake tokens, 5ms apart = ~250ms)
+            // long enough that job 2 is still sitting in the queue, untouched,
+            // when we cancel it a few lines down.
+            let (job1, rx1, _guard1) = make_job();
+            job_tx.send(job1).unwrap();
+
+            // Job 2: cancelled client-side (guard dropped) immediately, while
+            // it is still queued behind job 1.
+            let (job2, mut rx2, guard2) = make_job();
+            job_tx.send(job2).unwrap();
+            drop(guard2);
+
+            // Job 3: submitted after the cancelled one, to prove the worker
+            // moves on and keeps serving correctly afterward.
+            let (job3, rx3, _guard3) = make_job();
+            job_tx.send(job3).unwrap();
+            drop(job_tx);
+
+            let started2 = started.clone();
+            let ran2 = ran_tokens.clone();
+            let handle = std::thread::spawn(move || {
+                run_worker_loop(job_rx, fake_generate(50, started2, ran2))
+            });
+
+            let completion_tokens_of = |mut rx: mpsc::UnboundedReceiver<Ev>| -> Option<usize> {
+                let mut ct = None;
+                while let Some(ev) = rx.blocking_recv() {
+                    if let Ev::Done {
+                        completion_tokens, ..
+                    } = ev
+                    {
+                        ct = Some(completion_tokens);
+                    }
+                }
+                ct
+            };
+
+            assert_eq!(
+                completion_tokens_of(rx1),
+                Some(50),
+                "job 1 should run to completion undisturbed"
+            );
+
+            // Job 2 must produce NOTHING: no Delta, no Done -- the worker
+            // `continue`d past it without ever touching `generate`, so its
+            // `tx` is simply dropped with the rest of the `Job`.
+            assert!(
+                rx2.blocking_recv().is_none(),
+                "cancelled queued job must be skipped entirely: no events at all"
+            );
+
+            assert_eq!(
+                completion_tokens_of(rx3),
+                Some(50),
+                "worker must survive cancelling job 2 and serve job 3 normally afterward"
+            );
+
+            handle.join().expect("worker thread must not panic");
+
+            assert_eq!(
+                started.load(Ordering::SeqCst),
+                2,
+                "generate() must run exactly twice (job 1, job 3) -- never for cancelled job 2"
+            );
+            assert_eq!(
+                ran_tokens.load(Ordering::SeqCst),
+                100,
+                "50 real fake-tokens each for job 1 and job 3, zero for cancelled job 2"
+            );
+        }
+
+        #[test]
+        fn running_job_cancelled_midstream_stops_early_and_worker_survives() {
+            let (job_tx, job_rx) = mpsc::unbounded_channel::<Job>();
+            let started = Arc::new(AtomicUsize::new(0));
+            let ran_tokens = Arc::new(AtomicUsize::new(0));
+
+            // Job 1: a long fake generation (2000 tokens, 5ms apart) that we
+            // cancel partway through -- it must stop well short of the cap.
+            let (job1, mut rx1, guard1) = make_job();
+            job_tx.send(job1).unwrap();
+            // `Option` so it can be moved-out-and-dropped at most once from
+            // inside the loop below; the borrow checker cannot see that the
+            // `seen == 5` runtime condition only ever holds on one iteration,
+            // so a bare `drop(guard1)` there is rejected as a repeated move.
+            let mut guard1 = Some(guard1);
+
+            let (job2, mut rx2, _guard2) = make_job();
+            job_tx.send(job2).unwrap();
+            drop(job_tx);
+
+            let started2 = started.clone();
+            let ran2 = ran_tokens.clone();
+            let handle = std::thread::spawn(move || {
+                run_worker_loop(job_rx, fake_generate(2000, started2, ran2))
+            });
+
+            let mut seen = 0;
+            loop {
+                match rx1.blocking_recv() {
+                    Some(Ev::Delta(_)) => {
+                        seen += 1;
+                        if seen == 5 {
+                            // "Client disconnects" mid-stream.
+                            guard1.take();
+                        }
+                    }
+                    Some(Ev::Done {
+                        completion_tokens, ..
+                    }) => {
+                        assert!(
+                            completion_tokens < 2000,
+                            "job 1 must stop well short of its 2000-token cap after \
+                             cancellation, got {completion_tokens}"
+                        );
+                        assert!(
+                            completion_tokens < 100,
+                            "job 1 must stop within a handful of tokens of the client \
+                             disconnecting, not run on regardless; got {completion_tokens}"
+                        );
+                        break;
+                    }
+                    None => panic!("job 1's reply channel closed before a Done event"),
+                }
+            }
+
+            // Job 2 must still complete in full: the worker thread did not
+            // panic or wedge when job 1 was cancelled mid-generation.
+            let mut n2 = None;
+            while let Some(ev) = rx2.blocking_recv() {
+                if let Ev::Done {
+                    completion_tokens, ..
+                } = ev
+                {
+                    n2 = Some(completion_tokens);
+                }
+            }
+            assert_eq!(
+                n2,
+                Some(2000),
+                "worker must survive mid-stream cancellation and serve the next job to completion"
+            );
+
+            handle.join().expect("worker thread must not panic");
+        }
     }
 }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -14376,15 +14376,51 @@ kernel void gdn_chunk_norm_silu_c32(
         /// Streaming generation: calls `on_token` for each generated token.
         /// Returns total generated token count.
         /// The callback receives (token_text, token_id) and returns true to continue.
+        ///
+        /// Cancellable only through `on_token`'s return value. Callers that need to
+        /// observe cancellation independently of text emission -- so an
+        /// empty-delta decode iteration, or the uninterruptible prefill call
+        /// itself, can't silently swallow a disconnect -- should call
+        /// [`Self::generate_streaming_with_cancel`] instead.
         pub fn generate_streaming<F>(
             &mut self,
             prompt: &str,
             tokenizer: &BpeTokenizer,
             gen_cfg: &GenerateConfig,
-            mut on_token: F,
+            on_token: F,
         ) -> GenerateOutput
         where
             F: FnMut(&str, u32) -> bool,
+        {
+            self.generate_streaming_with_cancel(prompt, tokenizer, gen_cfg, on_token, || false)
+        }
+
+        /// Cancellation-aware sibling of [`Self::generate_streaming`].
+        ///
+        /// `should_cancel` is polled independently of `on_token`: before starting
+        /// the prefill pass, immediately after it returns, and at the top of every
+        /// decode iteration -- all before any further expensive GPU work runs for
+        /// that step. This closes two gaps `on_token`-only cancellation has:
+        /// prefill itself has no callback point at all (a long prompt can run to
+        /// completion after the client is already gone), and the decode loop only
+        /// calls `on_token` for non-empty text deltas, so a run of tokens that
+        /// decode to an incomplete UTF-8 tail (a multi-token codepoint mid-stream)
+        /// would otherwise skip the cancellation check for those iterations too.
+        /// SSE emission itself stays gated on non-empty deltas, unchanged.
+        ///
+        /// `generate_streaming` is the `should_cancel = || false` convenience form
+        /// and is otherwise identical; both share this one implementation.
+        pub fn generate_streaming_with_cancel<F, C>(
+            &mut self,
+            prompt: &str,
+            tokenizer: &BpeTokenizer,
+            gen_cfg: &GenerateConfig,
+            mut on_token: F,
+            mut should_cancel: C,
+        ) -> GenerateOutput
+        where
+            F: FnMut(&str, u32) -> bool,
+            C: FnMut() -> bool,
         {
             let cfg = self.engine.config.clone();
 
@@ -14508,8 +14544,45 @@ kernel void gdn_chunk_norm_silu_c32(
             };
             let mut thinking_closed = false;
 
+            // Checked independently of `on_token`: a client that disconnected
+            // between dequeue and here must not pay for the (potentially large,
+            // uninterruptible once started) prefill matmul below.
+            if should_cancel() {
+                if use_compact {
+                    self.session.compact_topk = 0;
+                    self.session.compact_route = GpuTopkRoute::CpuFallback;
+                }
+                return GenerateOutput {
+                    text: String::new(),
+                    token_ids: vec![],
+                    prompt_tokens: prompt_len,
+                    generated_tokens: 0,
+                    stopped: false, // caller interrupted the stream, not a stop condition
+                    stop_reason: Some(StopReason::Interrupt),
+                };
+            }
+
             // Batch prefill
             let mut prefill_logits = self.forward_prefill(&prompt_ids);
+
+            // The prefill call itself cannot be interrupted mid-flight (it is one
+            // GPU dispatch), so this is the earliest point a disconnect that
+            // happened *during* prefill can be observed -- before paying for any
+            // sampling or decode-loop work on its output.
+            if should_cancel() {
+                if use_compact {
+                    self.session.compact_topk = 0;
+                    self.session.compact_route = GpuTopkRoute::CpuFallback;
+                }
+                return GenerateOutput {
+                    text: String::new(),
+                    token_ids: vec![],
+                    prompt_tokens: prompt_len,
+                    generated_tokens: 0,
+                    stopped: false, // caller interrupted the stream, not a stop condition
+                    stop_reason: Some(StopReason::Interrupt),
+                };
+            }
 
             // Apply grammar masking to prefill logits before sampling.
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
@@ -14611,6 +14684,16 @@ kernel void gdn_chunk_norm_silu_c32(
             // cap = rb + max_new_tokens when budgeting; max_new_tokens otherwise (parity-safe).
             let cap = decode_cap(gen_cfg.reasoning_budget, gen_cfg.max_new_tokens);
             for _ in 1..cap {
+                // Checked before any per-step GPU work, independent of whether this
+                // iteration's delta ends up non-empty -- closes the gap where a run
+                // of tokens decoding to an incomplete UTF-8 tail (a multi-token
+                // codepoint mid-stream) would otherwise never reach the on_token
+                // check below and so never observe cancellation.
+                if should_cancel() {
+                    stopped_by_caller = true;
+                    stop_reason = StopReason::Interrupt;
+                    break;
+                }
                 if self.session.kv_cache.seq_len >= self.session.kv_cache.max_cache_len {
                     stop_reason = StopReason::KvFull;
                     break;
@@ -15827,6 +15910,10 @@ kernel void gdn_chunk_norm_silu_c32(
         /// **Unstable**: streaming chat completion; callback signature may change.
         ///
         /// Streaming chat completion with token-by-token callback.
+        ///
+        /// Cancellable only through `on_token`'s return value; see
+        /// [`Self::chat_completion_streaming_with_cancel`] for a variant that also
+        /// observes cancellation during prefill and on empty-delta decode steps.
         pub fn chat_completion_streaming<F>(
             &mut self,
             messages: &[ChatMessage],
@@ -15837,6 +15924,30 @@ kernel void gdn_chunk_norm_silu_c32(
         where
             F: FnMut(&str, u32) -> bool,
         {
+            self.chat_completion_streaming_with_cancel(
+                messages,
+                tokenizer,
+                gen_cfg,
+                on_token,
+                || false,
+            )
+        }
+
+        /// Cancellation-aware sibling of [`Self::chat_completion_streaming`]; see
+        /// [`Self::generate_streaming_with_cancel`] for exactly what `should_cancel`
+        /// observes that `on_token` alone cannot.
+        pub fn chat_completion_streaming_with_cancel<F, C>(
+            &mut self,
+            messages: &[ChatMessage],
+            tokenizer: &BpeTokenizer,
+            gen_cfg: &GenerateConfig,
+            on_token: F,
+            should_cancel: C,
+        ) -> ChatCompletionOutput
+        where
+            F: FnMut(&str, u32) -> bool,
+            C: FnMut() -> bool,
+        {
             let prompt = format_chat_template(messages);
             let mut cfg = gen_cfg.clone();
             if let Some(im_end_id) = tokenizer.special_token_id("<|im_end|>")
@@ -15844,7 +15955,13 @@ kernel void gdn_chunk_norm_silu_c32(
             {
                 cfg.stop_token_ids.push(im_end_id);
             }
-            let result = self.generate_streaming(&prompt, tokenizer, &cfg, on_token);
+            let result = self.generate_streaming_with_cancel(
+                &prompt,
+                tokenizer,
+                &cfg,
+                on_token,
+                should_cancel,
+            );
             let text = result.text.trim_end().to_string();
             ChatCompletionOutput {
                 message: ChatMessage::assistant(text),
@@ -22044,6 +22161,148 @@ kernel void decode_attention_reference(
                 out.stop_reason,
                 Some(StopReason::Interrupt),
                 "callback returning false must report Interrupt, got {:?}",
+                out.stop_reason
+            );
+        }
+
+        /// PR #606 review (Major finding): `on_token`-only cancellation cannot
+        /// observe a disconnect that happens before or during prefill, since
+        /// prefill has no callback point at all. `generate_streaming_with_cancel`
+        /// must check `should_cancel` before paying for prefill, so a client
+        /// that is already gone never even starts it and `on_token` is never
+        /// called.
+        #[test]
+        fn stop_reason_interrupt_when_cancelled_before_prefill_starts() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 8,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(1),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+            };
+
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+
+            let mut on_token_calls = 0u32;
+            let out = state.generate_streaming_with_cancel(
+                "a",
+                &tokenizer,
+                &gen_cfg,
+                |_delta, _id| {
+                    on_token_calls += 1;
+                    true
+                },
+                || true, // already cancelled before generation ever starts
+            );
+
+            assert_eq!(
+                on_token_calls, 0,
+                "should_cancel already true before prefill must return before \
+                 on_token is ever called, got {on_token_calls} calls"
+            );
+            assert_eq!(
+                out.generated_tokens, 0,
+                "cancelled-before-prefill must produce zero tokens"
+            );
+            assert!(!out.stopped, "cancellation is not an OpenAI stop condition");
+            assert_eq!(
+                out.stop_reason,
+                Some(StopReason::Interrupt),
+                "cancelled-before-prefill must report Interrupt, got {:?}",
+                out.stop_reason
+            );
+        }
+
+        /// PR #606 review (Major finding): the decode loop only called
+        /// `on_token` for non-empty deltas, so a client disconnect could be
+        /// missed for however many iterations produced an empty delta (an
+        /// incomplete UTF-8 tail mid-codepoint). This proves `should_cancel`
+        /// stops generation at the top of a decode iteration on its own, even
+        /// when `on_token` itself always answers "keep going" -- the decode
+        /// loop's own independent check, not the callback, is what halts it.
+        #[test]
+        fn stop_reason_interrupt_when_should_cancel_alone_stops_mid_decode() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 8,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(1),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+            };
+
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+
+            let mut on_token_calls = 0u32;
+            let mut should_cancel_calls = 0u32;
+            let out = state.generate_streaming_with_cancel(
+                "a",
+                &tokenizer,
+                &gen_cfg,
+                |_delta, _id| {
+                    on_token_calls += 1;
+                    true // on_token itself never asks to stop.
+                },
+                move || {
+                    should_cancel_calls += 1;
+                    // False for the before-prefill and after-prefill checks
+                    // (calls 1-2), letting exactly the prefill-sampled token
+                    // through; true starting at the decode loop's very first
+                    // check (call 3), before that iteration samples anything.
+                    should_cancel_calls > 2
+                },
+            );
+
+            assert_eq!(
+                on_token_calls, 1,
+                "exactly the prefill-sampled token should reach on_token before \
+                 should_cancel stops the decode loop on its first iteration, got \
+                 {on_token_calls} calls"
+            );
+            assert_eq!(
+                out.generated_tokens, 1,
+                "generation must stop after exactly 1 token (the prefill sample) \
+                 once should_cancel goes true at the top of the first decode \
+                 iteration, got {}",
+                out.generated_tokens
+            );
+            assert!(!out.stopped, "cancellation is not an OpenAI stop condition");
+            assert_eq!(
+                out.stop_reason,
+                Some(StopReason::Interrupt),
+                "should_cancel alone (on_token always returns true) must still \
+                 report Interrupt, got {:?}",
                 out.stop_reason
             );
         }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -22216,6 +22216,19 @@ kernel void decode_attention_reference(
                 "should_cancel already true before prefill must return before \
                  on_token is ever called, got {on_token_calls} calls"
             );
+            // `on_token_calls == 0` alone doesn't prove *which* checkpoint fired --
+            // the after-prefill check would produce the same on_token count if the
+            // before-prefill one were missing, since prefill's own output never
+            // reaches on_token either way (round-2 review finding). Prefill is the
+            // only thing that advances kv_cache.seq_len (metal_qwen35_chunked_prefill*
+            // tests assert seq_len == tokens.len() once it has run), so a still-zero
+            // seq_len is direct evidence prefill itself never started.
+            assert_eq!(
+                state.session.kv_cache.seq_len, 0,
+                "should_cancel already true before prefill must return before prefill \
+                 itself runs, but kv_cache.seq_len={} shows it advanced",
+                state.session.kv_cache.seq_len
+            );
             assert_eq!(
                 out.generated_tokens, 0,
                 "cancelled-before-prefill must produce zero tokens"


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

- `lattice_serve` serializes all generation through a single dedicated GPU worker thread fed by an unbounded job queue. Before this change, an abandoned client connection had no cancellation signal anywhere in that pipeline: a queued job would still be dequeued and run to completion, and a running job had no explicit early-stop path.
- Adds a `tokio::sync::watch::Receiver<bool>` field on `Job`, paired with a `CancelOnDrop` guard whose `Drop` flips it to `true`. The guard lives inside the SSE stream state (streaming) or as a handler local (non-streaming), so it fires exactly on client disconnect with no separate axum hook. The worker checks it at dequeue (skip cancelled queued jobs entirely — no prefill/decode) and inside the per-token callback (stop running jobs within one token).
- `tokio_util::sync::CancellationToken` is not in the dependency tree, so `watch::channel` was used instead — no new dependency added.
- Only `crates/inference/src/bin/lattice_serve.rs` changed.

Closes #552.

## Empirical evidence (measured before writing the fix)

Drove a locally running `qwen3.5-0.8b` (bf16) `lattice_serve` with a raw-socket HTTP/1.1 client for precise disconnect timing. A queued job with a ~3500-token prompt, abandoned while still sitting behind a running job, cost the worker ~8.2s before an unrelated 5-token probe could get an answer — a 23-35x inflation versus the 233-359ms baseline for the same-shaped probe elsewhere in the session. Abandoned *streaming* requests also produced no log line at all (telemetry only fired from the terminal SSE state), making the bug's cost invisible except as delay on the next real request.

## Test plan

- [x] Two new tests against an extracted, testable `run_worker_loop(job_rx, generate)` with a fake, GPU-free `generate` closure: `queued_job_cancelled_before_dequeue_is_skipped_entirely` and `running_job_cancelled_midstream_stops_early_and_worker_survives` — both assert the worker survives and serves subsequent jobs normally
- [x] Mutation-sensitivity demonstrated, not just claimed: both cancellation checks were temporarily neutralized, the file touched to force a rebuild, both tests failed with clear panics; neutralization reverted and both re-verified passing before committing
- [x] `cargo test -p lattice-inference --bin lattice_serve --features metal-gpu,f16` — 2 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo clippy -p lattice-inference --bin lattice_serve --features metal-gpu,f16 --tests -- -D warnings` — clean (this scoped, `--tests`-inclusive invocation was necessary since `metal-gpu` is non-default and plain workspace clippy never compiles this module; caught one real `clippy::type_complexity` hit on a test helper's return type, fixed with `#[allow(clippy::type_complexity)]`, matching an existing pattern used elsewhere in this codebase)
- [x] `cargo fmt --check` — clean
- [x] No `unwrap()`/`expect()` outside the test module

## Follow-up: broaden cancellation checkpoints beyond `on_token`

The dequeue-time and per-token checks above left two real gaps. `forward_prefill` is one uninterruptible GPU dispatch with no callback point inside it, so a client that disconnected right after dequeue still paid for the entire prefill (arbitrarily large for long prompts) before cancellation was ever observed. And `on_token` is only invoked when a decode step's text delta is non-empty; `IncrementalDetokenizer` intentionally withholds deltas that end mid a multi-token UTF-8 codepoint (CJK/emoji), so a run of such tokens skipped the cancellation check entirely for however many empty-delta steps occurred in a row.

Added `generate_streaming_with_cancel` / `chat_completion_streaming_with_cancel` in `metal_qwen35.rs`, cancellation-aware siblings that take a separate `should_cancel: FnMut() -> bool` closure checked at three points independent of `on_token`: before prefill starts, immediately after prefill returns (the earliest point a mid-prefill disconnect can be observed), and at the top of every decode iteration before any per-step GPU work. The existing `generate_streaming` / `chat_completion_streaming` keep their current signatures and behavior, now implemented as thin `|| false` delegations to the new methods, so none of their ~15 existing callers (`bin/lattice.rs`, `bin/chat_metal.rs`, `examples/bench_stability.rs`, and `metal_qwen35.rs`'s own test suite) need to change. `lattice_serve`'s `run_worker_loop` threads the job's existing cancellation watch channel into the new `should_cancel` parameter alongside the unchanged `on_token` wiring.

Both new checkpoints reuse `StopReason::Interrupt` (the existing caller-initiated-stop category) and the existing `stopped_by_caller` convention that skips the trailing detokenizer flush, and reset compact-route state on every exit path per the existing convention for early returns out of the decode loop.

New tests: two in `metal_qwen35.rs` (`stop_reason_interrupt_when_cancelled_before_prefill_starts`, `stop_reason_interrupt_when_should_cancel_alone_stops_mid_decode`) and one in `lattice_serve.rs` (`running_job_cancelled_during_prefill_like_phase_never_calls_on_token`). All three verified mutation-sensitive: reverting each new check individually makes its guarding test fail with the predicted call-count discrepancy (e.g. removing the decode-loop check alone: `left: 8, right: 1` where 8 is every unguarded decode iteration reaching `on_token` and 1 is the expected prefill-only token), restoring it passes again.

### bench-compare

`make bench-compare` (quick, `origin/main` `a00d7ebcd` vs `HEAD` `1b4b27bf1`):

- **lattice-inference** (`elementwise_cpu_bench`, the group this change actually falls under): all 7 benchmark groups (`rms_norm`, `layer_norm`, `silu_inplace`, `gelu`, `add_bias_gelu`, `softmax_attention`, `elementwise_mul`) show no regression — several report a mild improvement, consistent with ordinary cross-build noise rather than a causal effect, since none of these kernels are on the changed code path.
- **lattice-embed** (`simd` group, also run by default): the gate reports 11 FAIL / 7 WARN / 33 improvement, all of them `simd_*`/`int8_*` embed benchmarks — this PR makes zero changes to `lattice-embed`, so these reflect the two-worktree comparison's known noise/contention sensitivity, not a regression introduced here.

The actual changed code (three added `should_cancel()` closure calls: one before prefill, one after prefill, one per decode iteration) isn't covered by either default bench group — it's a boolean read on an already-hot path, orders of magnitude cheaper than the surrounding GPU dispatch it guards, so no dedicated benchmark was added for it.

## Follow-up: harden the before-prefill test's assertion

A re-review found that `stop_reason_interrupt_when_cancelled_before_prefill_starts` asserted `on_token_calls == 0`, but that alone doesn't prove *which* checkpoint fired — the after-prefill check would produce the identical `on_token` count if the before-prefill one were silently deleted, since prefill's own output never reaches `on_token` either way.

Added an assertion that `kv_cache.seq_len` stayed `0`. Prefill is the only thing that advances it (the existing `metal_qwen35_chunked_prefill*` tests assert `seq_len == tokens.len()` once prefill has run), so a still-zero `seq_len` is direct evidence prefill itself never started — something only the before-prefill checkpoint can guarantee. Mutation-verified: temporarily removing only the before-prefill check (leaving the after-prefill check intact) makes the new assertion fail with `left: 1, right: 0` (prefill ran and advanced the cursor by the 1-token test prompt); restoring it passes again.

This is a test-only change (one existing test function gains one assertion) — no production code path touched, so no bench-compare re-run.
