### PR TITLE
docs(grammar): reconcile module doc against actual issue state

### DIFF
--- a/crates/inference/src/grammar/mod.rs
+++ b/crates/inference/src/grammar/mod.rs
@@ -48,25 +48,21 @@
 //! Grammar-constrained generation is **BETA**. It is opt-in via
 //! `GenerateConfig::grammar` and disabled by default.
 //!
-//! Known issues tracked at the time of this release:
-//!
-//! - **Object schemas mixing required and optional properties may reject valid
-//!   JSON** ([#355]). A JSON object that satisfies a schema with both
-//!   `required` and non-required properties can be incorrectly refused by the
-//!   PDA state machine during generation. Workaround: use schemas with either
-//!   all-required or all-optional properties, or inline the optional fields as
-//!   `anyOf: [{...}, {}]`.
-//!
-//! - **The PDA backtracker does not rewind consumed bytes** ([#353]). Once the
-//!   PDA advances past a byte, it cannot backtrack. This means some shared-prefix
-//!   `anyOf`/`oneOf` grammars over-accept or over-reject tokens at branch points
-//!   where the correct parse requires lookahead beyond a committed prefix.
-//!
-//! Both issues are pre-existing (present since v0.3.0) and tracked. Follow
-//! [#353] and [#355] on GitHub for fixes.
+//! The mixed-required/optional JSON-Schema rejection and the no-rewind-backtracker
+//! over-accept/over-reject class this BETA originally shipped with are fixed
+//! ([#355], [#353] — closed via [#380], [#468], [#471], [#472]). Correctness work in
+//! this area is ongoing: residual and newer findings in the JSON-Schema compiler and
+//! the PDA/engine runtime are tracked live at [#310] and [#322] respectively — check
+//! those issues for current status rather than assuming this comment stays up to date.
 //!
 //! [#353]: https://github.com/ohdearquant/lattice/issues/353
 //! [#355]: https://github.com/ohdearquant/lattice/issues/355
+//! [#380]: https://github.com/ohdearquant/lattice/pull/380
+//! [#468]: https://github.com/ohdearquant/lattice/pull/468
+//! [#471]: https://github.com/ohdearquant/lattice/pull/471
+//! [#472]: https://github.com/ohdearquant/lattice/pull/472
+//! [#310]: https://github.com/ohdearquant/lattice/issues/310
+//! [#322]: https://github.com/ohdearquant/lattice/issues/322
 
 pub mod engine;
 pub mod gbnf;


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

- `crates/inference/src/grammar/mod.rs`'s "Stability and known limitations" doc comment described two specific defects (mixed required/optional JSON-Schema property rejection; PDA backtracker no-rewind over-accept/over-reject) as current known issues, citing #355 and #353. Both issues are actually **closed** -- fixed via #380, #468, #471, #472. Restating already-fixed bugs as live limitations is misleading, not just a stale link.
- Replaces that section with a pointer to the actual live open trackers for this area, #310 (JSON-Schema compiler) and #322 (PDA/engine runtime), without asserting what specifically remains open in either -- both issues carry their own current per-finding status.
- Doc-comment only; no behavior change. Found while writing ADR-068 (#607), which needed to cite these trackers accurately and caught the discrepancy.

## Test plan

- [x] `cargo doc -p lattice-inference --no-deps` -- no new warnings (pre-existing unrelated warnings in `speculative.rs` and `generation.rs` only)
- [x] `cargo clippy -p lattice-inference --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean


## bench-compare waiver

This PR touches a path under `crates/inference/`, but the entire diff is inside a `//!` module doc comment (verified via `git show <sha> -- crates/inference/src/grammar/mod.rs`: every changed line starts with `//!`, none is a compiled code block or doctest -- the file's one fenced example is `rust,ignore` and untouched). No compiled code, no doctest, no behavior changes. `make bench-compare` cannot show a difference because there is no code difference for it to measure. Waiving per the repo's own exception clause rather than running a benchmark that would necessarily report noise-only deltas.
