### PR TITLE
fix(inference): short-circuit max_new_tokens==0 in batch_prefill/cpu_f16/neon + multimodal paths (#612)

### DIFF
--- a/crates/inference/src/forward/batch_prefill.rs
+++ b/crates/inference/src/forward/batch_prefill.rs
@@ -374,6 +374,20 @@ impl Qwen35Model {
             return Err(InferenceError::Inference("empty prompt".into()));
         }
 
+        // max_new_tokens == 0 means "generate nothing": return before sampling so
+        // we never emit a token the caller did not ask for. Mirrors the guard in
+        // Qwen35Model::generate (crates/inference/src/model/qwen35/generation.rs).
+        if gen_cfg.max_new_tokens == 0 {
+            return Ok(GenerateOutput {
+                text: String::new(),
+                token_ids: vec![],
+                prompt_tokens: prompt_len,
+                generated_tokens: 0,
+                stopped: false,
+                stop_reason: Some(StopReason::Length),
+            });
+        }
+
         // Grammar-constrained decoding is not wired into the batch-prefill path; reject
         // grammar configs before any sampling to avoid silently producing unconstrained
         // output when a caller sets gen_cfg.grammar (#397/#398).
@@ -1993,6 +2007,43 @@ mod tests {
             matches!(result, Err(InferenceError::InvalidInput(_))),
             "generate_with_batch_prefill must fail closed with InvalidInput when grammar is \
              set (#397/#398); got {result:?}"
+        );
+    }
+
+    /// `generate_with_batch_prefill` with `max_new_tokens == 0` must return zero
+    /// generated tokens without running prefill or sampling anything (#612, 3rd
+    /// recurrence of the #226/#456 bug class).
+    ///
+    /// Mutation sensitivity: removing the `max_new_tokens == 0` early return
+    /// causes the function to run `prefill_prompt` and sample one token from the
+    /// final logits, so `generated_tokens` becomes 1 instead of 0 and the
+    /// assertion below fails.
+    #[test]
+    fn generate_with_batch_prefill_max_new_tokens_zero_returns_empty() {
+        let cfg = tiny_test_config();
+        let model = build_random_model(cfg, 0x1234_5678_abcd_ef01);
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            ..Default::default()
+        };
+
+        let out = model
+            .generate_with_batch_prefill("a b c", &gen_cfg)
+            .expect("max_new_tokens=0 must succeed, not error");
+
+        assert_eq!(
+            out.generated_tokens, 0,
+            "max_new_tokens=0 must produce zero generated tokens"
+        );
+        assert!(
+            out.token_ids.is_empty(),
+            "max_new_tokens=0 must produce an empty token list"
+        );
+        assert_eq!(
+            out.stop_reason,
+            Some(StopReason::Length),
+            "max_new_tokens=0 must report stop_reason=Length"
         );
     }
 }

--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -866,6 +866,20 @@ pub fn generate_f16(
         ));
     }
 
+    // max_new_tokens == 0 means "generate nothing": return before sampling so
+    // we never emit a token the caller did not ask for. Mirrors the guard in
+    // Qwen35Model::generate (crates/inference/src/model/qwen35/generation.rs).
+    if gen_cfg.max_new_tokens == 0 {
+        return Ok(GenerateOutput {
+            text: String::new(),
+            token_ids: vec![],
+            prompt_tokens: prompt_len,
+            generated_tokens: 0,
+            stopped: false,
+            stop_reason: Some(StopReason::Length),
+        });
+    }
+
     // Reject grammar configs before allocating any state. Grammar masking
     // (`mask_logits` + `advance`) is not wired into this generate loop; without
     // the guard the grammar field would be silently ignored, producing
@@ -1743,6 +1757,62 @@ mod tests {
             matches!(result, Err(InferenceError::InvalidInput(_))),
             "generate_f16 must fail closed with InvalidInput when grammar is set (#397/#398); \
              got {result:?}"
+        );
+    }
+
+    /// `generate_f16` with `max_new_tokens == 0` must return zero generated tokens
+    /// without running prefill or sampling anything (#612, 3rd recurrence of the
+    /// #226/#456 bug class).
+    ///
+    /// The guard fires before any weight dereference or state allocation, so
+    /// empty weight vecs are sufficient — mirrors the grammar-guard test above.
+    ///
+    /// Mutation sensitivity: removing the `max_new_tokens == 0` early return
+    /// causes the function to run prefill (against empty weight vecs, which
+    /// would panic) and sample one token, so `generated_tokens` becomes 1
+    /// instead of 0 and the assertion below fails.
+    #[test]
+    fn generate_f16_max_new_tokens_zero_returns_empty() {
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let weights = F16ModelWeights {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            layers: vec![],
+        };
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            ..Default::default()
+        };
+
+        let out = generate_f16(&weights, &cfg, &tokenizer, &rope, "hello", &gen_cfg)
+            .expect("max_new_tokens=0 must succeed, not error");
+
+        assert_eq!(
+            out.generated_tokens, 0,
+            "max_new_tokens=0 must produce zero generated tokens"
+        );
+        assert!(
+            out.token_ids.is_empty(),
+            "max_new_tokens=0 must produce an empty token list"
+        );
+        assert_eq!(
+            out.stop_reason,
+            Some(StopReason::Length),
+            "max_new_tokens=0 must report stop_reason=Length"
         );
     }
 }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -21594,6 +21594,78 @@ kernel void decode_attention_reference(
             );
         }
 
+        /// `generate_multimodal` with `max_new_tokens == 0` must return zero
+        /// generated tokens without running prefill or sampling (#612 sibling-
+        /// invocation-path audit found this 4th guard site; #621 review round 1
+        /// flagged it as missing mutation-sensitive coverage).
+        ///
+        /// Unlike the CPU-side zero-budget tests (which use empty weight vecs
+        /// to make mutation trivially observable via a panic), Metal GPU state
+        /// needs real buffers, so this loads the real Qwen3.5-0.8B checkpoint.
+        /// Mutation sensitivity: if the `max_new_tokens == 0` guard were
+        /// removed, execution would fall through to `reset_state` plus real
+        /// prefill/sampling against the loaded weights and produce at least
+        /// one generated token, failing the `generated_tokens == 0` assertion
+        /// below.
+        #[test]
+        fn generate_multimodal_max_new_tokens_zero_returns_empty() {
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+            let Some(model) = load_real_qwen35_0_8b_or_skip() else {
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            let mut state = MetalQwen35State::new(model.weights(), model.config(), 128)
+                .expect("real-checkpoint state");
+
+            let visual_tokens = 4usize;
+            let d_model = model.config().hidden_size;
+            let text_tokens = vec![1u32, 2, 3];
+            let input = crate::vision::MultimodalInput {
+                patch_embeddings: vec![0.0f32; visual_tokens * d_model],
+                raw_patches: 16,
+                visual_tokens,
+                d_model,
+                text_tokens: text_tokens.clone(),
+            };
+
+            let tokenizer = minimal_bpe_tokenizer();
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 0,
+                ..Default::default()
+            };
+
+            let out = state
+                .generate_multimodal(input, &tokenizer, &gen_cfg)
+                .expect("max_new_tokens=0 must succeed, not error");
+
+            assert!(
+                out.token_ids.is_empty(),
+                "max_new_tokens=0 must produce no token IDs, got {:?}",
+                out.token_ids
+            );
+            assert_eq!(
+                out.generated_tokens, 0,
+                "max_new_tokens=0 must produce zero generated tokens"
+            );
+            assert_eq!(
+                out.prompt_tokens,
+                visual_tokens + text_tokens.len(),
+                "prompt_tokens must equal visual_tokens + text_tokens.len()"
+            );
+            assert!(
+                !out.stopped,
+                "max_new_tokens=0 exit is budget exhaustion, not a stop condition"
+            );
+            assert_eq!(
+                out.stop_reason,
+                Some(StopReason::Length),
+                "max_new_tokens=0 must report StopReason::Length"
+            );
+        }
+
         /// Acceptance test #2 (task order item 7 / design_spec.md Test Plan
         /// §5): top-k SET agreement 100% for K in {8,16,40,64} vs. the
         /// full-logit CPU oracle, on real checkpoint positions (the

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -10577,6 +10577,20 @@ kernel void gdn_chunk_norm_silu_c32(
                 });
             }
 
+            // max_new_tokens == 0 means "generate nothing": return before prefill/sampling
+            // so we never emit a token the caller did not ask for. Mirrors the
+            // guard in generate() above (#612 sibling-path audit).
+            if gen_cfg.max_new_tokens == 0 {
+                return Ok(GenerateOutput {
+                    text: String::new(),
+                    token_ids: vec![],
+                    prompt_tokens: total_len,
+                    generated_tokens: 0,
+                    stopped: false,
+                    stop_reason: Some(StopReason::Length),
+                });
+            }
+
             if total_len > self.session.kv_cache.max_cache_len {
                 return Err(InferenceError::InvalidInput(format!(
                     "generate_multimodal: total sequence length ({}) exceeds KV cache capacity ({}); \

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -907,6 +907,20 @@ pub fn generate_q8_neon(
         ));
     }
 
+    // max_new_tokens == 0 means "generate nothing": return before sampling so
+    // we never emit a token the caller did not ask for. Mirrors the guard in
+    // Qwen35Model::generate (crates/inference/src/model/qwen35/generation.rs).
+    if gen_cfg.max_new_tokens == 0 {
+        return Ok(GenerateOutput {
+            text: String::new(),
+            token_ids: vec![],
+            prompt_tokens: prompt_len,
+            generated_tokens: 0,
+            stopped: false,
+            stop_reason: Some(StopReason::Length),
+        });
+    }
+
     // Reject grammar configs before allocating any state. Grammar masking
     // (`mask_logits` + `advance`) is not wired into this generate loop; without
     // the guard the grammar field would be silently ignored, producing
@@ -2726,6 +2740,62 @@ mod tests {
             matches!(result, Err(InferenceError::InvalidInput(_))),
             "generate_q8_neon must fail closed with InvalidInput when grammar is set \
              (#397/#398); got {result:?}"
+        );
+    }
+
+    /// `generate_q8_neon` with `max_new_tokens == 0` must return zero generated
+    /// tokens without running prefill or sampling anything (#612, 3rd recurrence
+    /// of the #226/#456 bug class).
+    ///
+    /// The guard fires before any weight dereference or state allocation, so
+    /// empty weight vecs are sufficient — mirrors the grammar-guard test above.
+    ///
+    /// Mutation sensitivity: removing the `max_new_tokens == 0` early return
+    /// causes the function to run prefill (against empty weight vecs, which
+    /// would panic) and sample one token, so `generated_tokens` becomes 1
+    /// instead of 0 and the assertion below fails.
+    #[test]
+    fn generate_q8_neon_max_new_tokens_zero_returns_empty() {
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![("h".to_string(), "e".to_string())];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let model = Q8NeonModel {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            lm_head_packed: vec![],
+            lm_head_rows: 0,
+            lm_head_cols: 0,
+            layers: vec![],
+        };
+
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            ..Default::default()
+        };
+
+        let out = generate_q8_neon(&model, &cfg, &tokenizer, &rope, "hello", &gen_cfg)
+            .expect("max_new_tokens=0 must succeed, not error");
+
+        assert_eq!(
+            out.generated_tokens, 0,
+            "max_new_tokens=0 must produce zero generated tokens"
+        );
+        assert!(
+            out.token_ids.is_empty(),
+            "max_new_tokens=0 must produce an empty token list"
+        );
+        assert_eq!(
+            out.stop_reason,
+            Some(StopReason::Length),
+            "max_new_tokens=0 must report stop_reason=Length"
         );
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Closes #612.

`max_new_tokens == 0` is short-circuited in the generic path (`generate.rs`), the
Qwen3.5 CPU path (`generation.rs`), Q8 (`cpu_q8.rs`), and the Metal variants — but
three sibling CPU decode-loop entry points proceeded straight into prefill+sample
with a zero budget. This is the 3rd recurrence of the same bug class (#226, #456).

Adds the identical guard already used elsewhere (return before prefill/sampling
with an empty `GenerateOutput`, `stop_reason: Some(StopReason::Length)`) to:

- `crates/inference/src/forward/cpu_f16.rs::generate_f16`
- `crates/inference/src/forward/batch_prefill.rs::generate_with_batch_prefill`
- `crates/inference/src/forward/neon_forward.rs::generate_q8_neon`

Per the issue's second acceptance item, every other `GenerateOutput`-producing
entry point in the crate was audited for the same gap (see table below). One more
genuine gap was found — `generate_multimodal` (Metal) only short-circuited on
`total_len == 0`, not on `max_new_tokens == 0` — and got the same guard.

### Sibling-site audit

| Site | Guarded? | Notes |
|---|---|---|
| `generate.rs::generate` (generic path) | Yes (pre-existing) | Guard at top, before prefill |
| `model/qwen35/generation.rs::Qwen35Model::generate` | Yes (pre-existing) | Guard at top |
| `model/qwen35/generation.rs::Qwen35Model::generate_streaming` | Yes (pre-existing) | Guard at top |
| `forward/cpu_q8.rs::generate_q8` | Yes (pre-existing) | Guard at top |
| `forward/cpu_f16.rs::generate_f16` | **Fixed this PR** | Was unguarded |
| `forward/batch_prefill.rs::generate_with_batch_prefill` | **Fixed this PR** | Was unguarded |
| `forward/neon_forward.rs::generate_q8_neon` | **Fixed this PR** | Was unguarded |
| `forward/metal_qwen35.rs::generate` | Yes (pre-existing, #456) | Guard at top |
| `forward/metal_qwen35.rs::generate_with_lora_mixture` | Yes (delegates) | Calls guarded `self.generate()` |
| `forward/metal_qwen35.rs::generate_multimodal` | **Fixed this PR** | Only guarded `total_len == 0`, not `max_new_tokens == 0` |
| `forward/metal_qwen35.rs::generate_streaming` | Yes (delegates) | Calls guarded `generate_streaming_with_cancel` |
| `forward/metal_qwen35.rs::generate_streaming_with_cancel` | Yes (pre-existing, #456) | Guard at top |
| `forward/metal_qwen35.rs::generate_streaming_with_prefix_cache` | Yes (delegates) | Calls guarded `_inner` |
| `forward/metal_qwen35.rs::generate_streaming_with_prefix_cache_inner` | Yes (pre-existing, #456) | Guard at top |
| `forward/metal_qwen35.rs::generate_greedy_mtp` / `generate_greedy_self_spec` (private) | Yes (transitively) | Only reachable through `generate()`, after its guard |
| Non-metal-gpu stub `generate` (feature-gated fallback) | N/A | Always returns empty regardless of input |

No sites were left deliberately unguarded.

## Test plan

Added one mutation-sensitive regression test per fixed CPU path, asserting
`generated_tokens == 0`, `token_ids.is_empty()`, and
`stop_reason == Some(StopReason::Length)` for a `max_new_tokens: 0` request:

- `forward::cpu_f16::tests::generate_f16_max_new_tokens_zero_returns_empty`
- `forward::batch_prefill::tests::generate_with_batch_prefill_max_new_tokens_zero_returns_empty`
- `forward::neon_forward::tests::generate_q8_neon_max_new_tokens_zero_returns_empty`

Each test was verified mutation-sensitive locally: reverting its guard and
re-running caused the test to fail (two panic on the now-unguarded empty-weights
prefill, one fails the `generated_tokens == 0` assertion directly), then the guard
was restored and the test re-confirmed passing.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p lattice-inference --features f16` — 1428 passed, 0 failed, 7 ignored (plus all other test binaries green)
- [x] `cargo check -p lattice-inference --features f16,metal-gpu` (compile-only; GPU execution not exercised, machine's GPU was in use by another run)

### bench-compare

Waiver: this change is a per-call early-return placed before prefill/decode begins; it adds one branch per generate call (not per token) and touches no kernel, no per-token loop body, and no bench-covered code path. No A/B run taken.
