### PR TITLE
docs(examples): add Q4/QuaRot, cross-turn cache, and serve API cookbooks

### DIFF
--- a/docs/cross-turn-cache.md
+++ b/docs/cross-turn-cache.md
@@ -134,15 +134,23 @@ pub struct CachedGenerateOutput {
 
 This is your "did it actually reuse anything" signal — check `cache.mode` and
 `cache.reused_tokens` rather than assuming caching happened just because you called the
-`_with_prefix_cache` method. `chat_metal` (once PR #619 lands) prints exactly this to stderr after
-every turn:
+`_with_prefix_cache` method. `chat_metal` (once PR #619 lands — still an open draft as of this
+writing, so treat the lines below as a representative example, not a verbatim quote; exact wording
+may change before it merges) prints a line like this to stderr after every turn. The `--json` path
+(`--json --prompt` / `--json --serve`) and the interactive REPL use two different shapes:
 
 ```
-[chat_metal] GPU Metal q4-quarot: 812 prompt + 40 gen in 620ms = 64.5 tok/s | cache: ExactAppend reused 780/812
+# --json mode
+[chat_metal] GPU Metal q4: 812 prompt + 40 gen in 620ms = 64.5 tok/s | cache: ExactAppend reused 780/812
+
+# interactive REPL
+[812 prompt + 40 gen in 620.0ms = 64.5 tok/s | GPU Metal q4 | cache: ExactAppend reused 780/812]
 ```
 
-`reused_tokens` out of `prompt_tokens` tells you how much of this turn's prompt didn't need to be
-re-prefilled; `mode` tells you which of the three `PrefixReuseMode` variants applied.
+`model_format` here is `"bf16"` or `"q4"` — there is no separate `"q4-quarot"` label; a
+QuaRot-converted checkpoint loads and reports as plain `"q4"`. `reused_tokens` out of
+`prompt_tokens` tells you how much of this turn's prompt didn't need to be re-prefilled; `mode`
+tells you which of the three `PrefixReuseMode` variants applied.
 
 ### `PrefixReuseMode`: what actually happened
 

--- a/docs/cross-turn-cache.md
+++ b/docs/cross-turn-cache.md
@@ -1,0 +1,329 @@
+# Cross-Turn KV Prefix Cache
+
+A multi-turn chat conversation re-sends its entire history as the prompt on every turn (the
+client is stateless; the server/library is not expected to remember anything between calls).
+Without a cache, that means re-prefilling every prior message from scratch on every single turn
+— cost that grows with conversation length and, for Qwen3.5's hybrid GQA+GDN architecture, also
+means recomputing 18 of 24 layers' recurrent GDN state from the beginning every time.
+
+The cross-turn prefix cache (issue #462) lets a new turn that safely extends the previous one
+reuse that retained KV/GDN state and prefill only the new suffix, instead of re-prefilling the
+whole conversation. This document covers the actual Rust API, what currently calls it, and — just
+as important — what does **not** call it yet, since that gap is easy to assume away incorrectly.
+
+## Where this cache lives, and where it doesn't (read this first)
+
+The underlying cache (`crate::kv_cache::cross_turn` plus the Metal runtime hooks in
+`MetalQwen35State`) shipped in PR #516 (merged). At that point, **nothing in the codebase called
+it** — it was infrastructure with zero consumers. PR #619 is the first to wire a real caller, and
+it wires exactly one: **`chat_metal`** (`crates/inference/src/bin/chat_metal.rs`), both its
+`--json` one-shot/`--serve` path and its interactive REPL.
+
+As of this writing, PR #619 is still open in draft. The behavior described in this document under
+"Using it from `chat_metal`" reflects that PR's diff, not code on `main` yet — check its status
+(`gh pr view 619`) before relying on it, and treat this document as provisional on that PR's
+content until it merges.
+
+**Neither `lattice serve` (the OpenAI-compatible HTTP server in `lattice.rs`) nor `lattice_serve`
+(the separate HTTP daemon built for the macOS Studio app) call the cache-aware methods, and PR
+#619 does not add them.** Both still call the plain, non-cache-aware `generate_streaming`, or
+(for `lattice_serve`) unconditionally `reset_state()` before every request. Concretely:
+
+- `lattice serve` → `POST /v1/chat/completions` re-prefills the entire `messages` array from
+  scratch on every request, every time, regardless of how much of the conversation is unchanged
+  from the previous request. This is not an oversight this document is pointing out for the first
+  time — the project's own README says so directly: "The serve path currently re-prefills the
+  whole conversation on every turn ([#462](https://github.com/ohdearquant/lattice/issues/462)), a
+  separate and larger cost than the decode slope, and the main reason a long chat feels
+  progressively slower."
+- `lattice_serve` (the macOS Studio daemon) is the same: no cache-aware calls anywhere in that
+  binary as of this writing.
+
+See [`docs/serve-http-api.md`](serve-http-api.md) for the full `lattice serve` HTTP API — this
+document is only about the library-level cache, not the HTTP surface.
+
+PR #619's own description explains why it deliberately stopped short of wiring the HTTP servers:
+the current cache is a **single-entry** store (see below) — safe for one interactive process
+talking to one conversation at a time, but wiring it into a multi-session server as-is would let
+one client's request evict another client's retained state, silently forcing that other client
+back to a full re-prefill. Making it safe for concurrent multi-session serving is called out
+explicitly as follow-up work, not something already done.
+
+So: if you're calling the HTTP API, this cache does not currently help you, full stop. If you're
+using `chat_metal` directly (or the underlying `MetalQwen35State` API in your own Rust code), it
+does, and the rest of this document covers exactly what "safely extends" means and where the
+sharp edges are.
+
+## The library API
+
+Everything here lives on `MetalQwen35State` (`lattice_inference::forward::metal_qwen35`) and in
+`lattice_inference::kv_cache`.
+
+### Identifying a conversation: `CrossTurnSlotId`
+
+```rust
+use lattice_inference::kv_cache::CrossTurnSlotId;
+
+let slot = CrossTurnSlotId::DEFAULT;        // the single-client / local-use slot (value 0)
+let slot = CrossTurnSlotId::new(0xABCD_1234); // e.g. a hashed session key, for your own multiplexing
+```
+
+`CrossTurnSlotId` is a thin `u64` wrapper. Distinct slot IDs are guaranteed never to read each
+other's retained state — but see "One entry, not one entry per slot" below before assuming two
+slots can be used concurrently with both benefiting from caching at once.
+
+### The two cache-aware entry points
+
+These are siblings of the existing (non-cached) generation methods, not a flag on them — the
+plain methods are untouched and never consult the cache:
+
+```rust
+pub fn generate_streaming_with_prefix_cache<F>(
+    &mut self,
+    slot_id: CrossTurnSlotId,
+    prompt: &str,
+    tokenizer: &BpeTokenizer,
+    gen_cfg: &GenerateConfig,
+    on_token: F,
+) -> Result<CachedGenerateOutput, InferenceError>
+where
+    F: FnMut(&str, u32) -> bool;
+
+pub fn chat_completion_streaming_with_prefix_cache<F>(
+    &mut self,
+    slot_id: CrossTurnSlotId,
+    messages: &[ChatMessage],
+    tokenizer: &BpeTokenizer,
+    gen_cfg: &GenerateConfig,
+    on_token: F,
+) -> Result<CachedChatCompletionOutput, InferenceError>
+where
+    F: FnMut(&str, u32) -> bool;
+```
+
+`chat_completion_streaming_with_prefix_cache` is the one you want for an actual multi-turn
+conversation: pass your full growing `Vec<ChatMessage>` history each turn (same as the
+non-cached `chat_completion_streaming`) — it formats the ChatML prompt internally and appends the
+`<|im_end|>` stop token, then calls the prefix-cache-aware generation path underneath.
+
+You no longer need to call `reset_state()` yourself before each turn. The old pattern —
+`metal.reset_state(); metal.chat_completion_streaming(&history, ...)` — becomes just
+`metal.chat_completion_streaming_with_prefix_cache(slot_id, &history, ...)`. A first request, a
+divergent/edited history, an adapter change, or any other case where reuse isn't safe falls back
+to a full internal reset-and-reprefill on its own — you don't need to detect that yourself.
+
+### Reading what happened: `CachedGenerateOutput` / `CachedChatCompletionOutput`
+
+Both cache-aware calls return the normal output type plus cache statistics for that call:
+
+```rust
+pub struct CrossTurnCacheStats {
+    pub slot_id: CrossTurnSlotId,
+    pub prompt_tokens: usize,
+    pub reused_tokens: usize,
+    pub prefetched_tokens: usize,
+    pub mode: PrefixReuseMode,
+}
+
+pub struct CachedGenerateOutput {
+    pub output: GenerateOutput,       // identical to the non-cached return type
+    pub cache: CrossTurnCacheStats,
+}
+// CachedChatCompletionOutput is the same shape with `output: ChatCompletionOutput`.
+```
+
+This is your "did it actually reuse anything" signal — check `cache.mode` and
+`cache.reused_tokens` rather than assuming caching happened just because you called the
+`_with_prefix_cache` method. `chat_metal` (once PR #619 lands) prints exactly this to stderr after
+every turn:
+
+```
+[chat_metal] GPU Metal q4-quarot: 812 prompt + 40 gen in 620ms = 64.5 tok/s | cache: ExactAppend reused 780/812
+```
+
+`reused_tokens` out of `prompt_tokens` tells you how much of this turn's prompt didn't need to be
+re-prefilled; `mode` tells you which of the three `PrefixReuseMode` variants applied.
+
+### `PrefixReuseMode`: what actually happened
+
+```rust
+pub enum PrefixReuseMode {
+    /// No usable overlap: reset state and prefill the whole prompt.
+    FullRefill,
+    /// The cached entry is an exact prefix of the new prompt and its GDN
+    /// snapshot is taken at that same boundary — reuse it verbatim.
+    ExactAppend,
+    /// Reuse only up to an earlier exact GDN checkpoint, then replay/prefill
+    /// forward. v2: no v1 caller currently supplies checkpoints, so this
+    /// variant is never produced by the current Metal integration.
+    ReplayFromCheckpoint { checkpoint_len: usize },
+}
+```
+
+In practice, with today's callers, you will only ever see `FullRefill` or `ExactAppend`.
+`ReplayFromCheckpoint` exists in the type for a planned sparse-checkpoint extension but nothing in
+the current Metal integration produces it — don't design around it yet.
+
+## What makes a turn "safely extend" the previous one
+
+The planner (`plan_prefix_reuse` in `kv_cache::cross_turn`) only ever claims `ExactAppend` when
+**all** of the following hold:
+
+1. The new prompt's tokens are an exact superset of the retained entry's tokens, sharing the
+   entire retained prefix (an exact token-ID match, not a fuzzy/semantic one).
+2. That shared prefix covers the entry's _entire_ represented length (partial mid-history reuse
+   without an explicit checkpoint isn't attempted).
+3. The new prompt actually has a nonempty suffix beyond that shared prefix — an exact repeat of
+   the previous prompt with nothing new falls back to `FullRefill` rather than treating a
+   zero-length suffix as a (disallowed) no-op prefill.
+4. A `CrossTurnPrefixMetadata` fingerprint matches exactly between the retained entry and the
+   current request:
+
+```rust
+pub struct CrossTurnPrefixMetadata {
+    pub model_fingerprint: u64,
+    pub tokenizer_fingerprint: u64,
+    pub adapter_id: AdapterId,
+    pub vocab_size: usize,
+    pub max_cache_len: usize,
+    pub kv_f16: bool,
+    pub rope_theta_bits: u64,
+    pub partial_rotary_factor_bits: Option<u32>,
+    pub layer_pattern_hash: u64,
+    pub chat_template_version: u32,
+}
+```
+
+Any mismatch — a different loaded model, a different tokenizer, a LoRA adapter swapped in or out,
+a different KV dtype, RoPE configuration, layer pattern, or chat template version — invalidates
+the entry and forces `FullRefill`. This is deliberately conservative: the module's own doc comment
+puts it as "any divergence falls back to `PrefixReuseMode::FullRefill`" — decline-beats-fabricate
+for token-identity correctness. You do not get a wrong-but-fast answer; you get a slow-but-correct
+one.
+
+Practical implications for structuring a conversation to actually benefit:
+
+- **Only append to history; don't edit or delete earlier turns.** Editing an earlier user message
+  or regenerating an earlier assistant turn changes the token sequence at a position before the
+  end, so the longest-common-prefix against the retained entry stops at the edit point (or
+  becomes 0 if the edit is near the start) — every turn after an edit pays a full re-prefill until
+  the next unedited extension.
+- **Don't interleave unrelated conversations through the same slot.** See the next section — a
+  second conversation on the same slot doesn't get its own separate cache entry, it evicts the
+  first one's.
+- **A LoRA adapter swap invalidates the cache** (it's part of the fingerprint) — expect a full
+  re-prefill on the turn immediately after swapping adapters.
+
+## One entry, not one entry per slot
+
+This is the sharpest edge in the current design, and it's easy to misread from "distinct slots
+never share state" alone. The Metal-side cache (`MetalCrossTurnPrefixCache`) retains **at most one
+entry, for one slot, at a time** — it is not an unbounded per-slot map:
+
+> Worker-local, single-live-entry cross-turn prefix cache (#516 round-1 remediation, finding 1 +
+> 5). Ownership invariant: at most ONE `MetalCrossTurnPrefixEntry` is ever retained, bounded by
+> design (never an unbounded per-slot map).
+
+`get`/`take` both check the slot ID on the one entry that exists, so a lookup for a _different_
+slot than the one currently retained is always a clean miss (never a stale or wrong-slot hit) —
+that's the isolation guarantee. But it also means: if you generate on slot A, then slot B, then
+slot A again, that third call is a full refill — slot B's generation evicted slot A's entry, it
+did not get its own independent storage alongside it. If your process genuinely interleaves
+multiple concurrent conversations through one `MetalQwen35State`, only the most recently generated
+one benefits from caching at any given moment; the others pay full re-prefill every time they get
+a turn. This is exactly the multi-session risk PR #619's description cites as the reason
+`lattice serve`/`lattice_serve` weren't wired up yet — a single shared worker with this cache
+behind a server handling several simultaneous chats would thrash.
+
+This single-entry design traces back to a real bug caught in review: PR #516's round-1 codex
+review rejected an earlier version that used an unbounded per-slot `HashMap`, because the
+underlying full-attention KV buffer is one mutable live buffer shared by the whole process — a
+stale map entry could restore GDN state from one conversation while attention silently read KV
+rows another generation had since overwritten. The fix (documented as remediation items D1-D6)
+was to cap retention at one entry and make any other mutation of live state — a different slot's
+generation, the plain non-cache-aware generate path, an explicit `reset_state()`, or a LoRA
+load/unload — invalidate the entry before that mutation proceeds.
+
+## Failure handling
+
+If a cache-aware call fails partway through (a restore or prefill error), the engine does not
+leave the cache or live model state in a possibly-inconsistent condition for the next call to
+trip over:
+
+```rust
+match self.generate_streaming_with_prefix_cache_inner(slot_id, prompt, tokenizer, gen_cfg, on_token) {
+    Ok(out) => Ok(out),
+    Err(e) => {
+        // Fail-closed: state and cache may disagree after a
+        // restore/prefill/save error, so drop both rather than
+        // risk a later turn reusing an inconsistent boundary.
+        self.reset_state();
+        self.cross_turn_prefix_cache.remove(slot_id);
+        Err(e)
+    }
+}
+```
+
+Both the live model state and the retained cache entry for that slot are cleared before the error
+is returned to you. The next call on that slot — even a retry of the same conversation — starts
+from a clean `FullRefill`, not from a half-restored state. `chat_metal`'s own error handling relies
+on exactly this: on a generation failure it just surfaces an error event (or, in the REPL, drops
+the unanswered turn) and continues, because it knows the engine already put itself back into a
+consistent state.
+
+## Using it from `chat_metal` (once PR #619 merges)
+
+`chat_metal`'s interactive REPL builds a growing `Vec<ChatMessage>` history and, per PR #619's
+diff, now calls the cache-aware entry point instead of resetting state on every turn:
+
+```rust
+let cache_result = metal.chat_completion_streaming_with_prefix_cache(
+    CrossTurnSlotId::DEFAULT,
+    &history,
+    &tokenizer,
+    &gen_cfg,
+    |delta, _| {
+        print!("{delta}");
+        std::io::stdout().flush().ok();
+        response_text.push_str(delta);
+        true
+    },
+);
+```
+
+The old unconditional `metal.reset_state()` call that used to precede every turn is removed
+entirely — the cache-aware call now owns that decision. The one-shot `--json --prompt` and
+`--json --serve` paths (used by the macOS Studio app to drive `chat_metal` as a subprocess) get
+the same treatment via `emit_json_generation`, using `metal.generate_streaming_with_prefix_cache`
+with the same `CrossTurnSlotId::DEFAULT` slot, since that binary only ever handles one
+conversation per process. Both call sites drop the `output` field out of the returned
+`Cached*Output` for the actual generated text/token count, and log the `cache` field's
+`mode`/`reused_tokens`/`prompt_tokens` alongside the existing tok/s line so you can see the cache
+behavior on every turn without instrumenting anything yourself.
+
+The PR also adds a Metal integration test,
+`cross_turn_cache_chat_completion_matches_full_reprefill`, that drives a growing multi-turn
+history through this wrapper and asserts token-identity against an independent from-scratch full
+re-prefill, plus a nonzero reused-token count on at least one turn — so the test cannot pass via
+the fallback path alone, and a dedicated Criterion bench,
+`cross_turn_prefix_cache_bench`, to measure the reuse path directly.
+
+## Summary
+
+- The cache exists and works today only through direct `MetalQwen35State` calls and (once #619
+  merges) `chat_metal`. It is not reachable from `lattice serve` or `lattice_serve` — every HTTP
+  request re-prefills its entire conversation history from scratch, a known and already-documented
+  gap (README, issue #462), not something this document is newly discovering.
+- Use `CrossTurnSlotId::DEFAULT` for a single local conversation; only one entry is ever retained
+  process-wide, so multiplexing several conversations through distinct slot IDs on one
+  `MetalQwen35State` does not give each of them independent caching — the most recent one wins and
+  evicts the rest.
+- Reuse requires an exact token-prefix match plus an exact match on a ten-field fingerprint
+  (model, tokenizer, adapter, vocab, cache length, KV dtype, RoPE config, layer pattern, chat
+  template version). Any mismatch, or any edit to earlier conversation turns, forces a full
+  re-prefill rather than a wrong answer.
+- Check `cache.mode` and `cache.reused_tokens` on the returned `Cached*Output` (or the
+  `chat_metal` stderr log line) to confirm reuse actually happened — don't assume it did just
+  because you called the `_with_prefix_cache` method.
+- On any internal failure, both live model state and the cache entry are cleared before the error
+  propagates — the next call starts clean.

--- a/docs/q4-quantization.md
+++ b/docs/q4-quantization.md
@@ -194,10 +194,23 @@ writes nothing** — `ConversionReport` is never returned, `main` prints `ERROR:
 There is no partial/corrupt output state to clean up.
 
 Note the different tensor counts (188 quantized + 148 kept = 336) versus plain `quantize_q4`'s
-271 + 217 = 488 on the same source directory: the QuaRot pipeline in this codebase operates on the
-core Qwen3.5 text transformer and does not carry the vision tower or MTP head through the rotation
-the way `quantize_q4`'s generic tensor-by-tensor pass does. If your workflow needs the QuaRot path
-specifically for text generation (chat/serve), this is expected; it is not a partial-conversion bug.
+271 + 217 = 488 on the same source directory. The two exclusions behind that gap are different
+kinds of things, and it's worth being precise about which is which
+(`crates/inference/src/quant/quarot/convert.rs`):
+
+- **Vision tower — excluded, never read.** Qwen3.5-0.8B's checkpoint on disk is multimodal (it
+  ships a `vision_config`); QuaRot's converter never reads or rewrites those tensors on either the
+  input or output side. They simply aren't part of this pipeline.
+- **MTP tensors — copied, not rotated or quantized.** When the config has `mtp_num_hidden_layers >
+  0` (true for Qwen3.5-0.8B, which ships 1 MTP layer), `write_mtp_weights_quarot` copies each MTP
+  tensor into the output directory as an unrotated, unquantized `.f16` file. They're part of the
+  336-tensor output — counted in the 148 "kept (F16)" — not silently dropped. Rotating and
+  quantizing MTP tensors is deferred to a later phase (see the ADR-051 note in `convert.rs`); today
+  they ride along as plain f16 copies.
+
+If your workflow needs the QuaRot path specifically for text generation (chat/serve), this is
+expected — the language-model tensors are the ones rotated and quantized, and MTP still loads and
+runs (as f16), it's just not yet part of the rotation; it is not a partial-conversion bug.
 
 ## Step 3: verify with perplexity, not just "it loaded"
 
@@ -313,21 +326,8 @@ codebase is Metal-only).
 `lattice doctor --model <dir> --tokenizer-dir <dir>` is a preflight check: it reports the detected
 format, weight memory footprint, KV-cache cost per token, and whether the checkpoint's tensors and
 your system's memory are actually sufficient to load it, without spending the time to load and run
-the model. Run it before `chat`/`serve` on any new Q4 output:
-
-```
-$ ./target/release/lattice doctor --model ~/.lattice/models/qwen3.5-0.8b-q4-quarot --tokenizer-dir ~/.lattice/models/qwen3.5-0.8b
-Model directory : /Users/lion/.lattice/models/qwen3.5-0.8b-q4-quarot
-Format          : Q4
-Placement       : Metal GPU
-Quantization    : Q4_0 (lattice native, v2 asymmetric)
-Tensors found   : 488
-Weight memory   : 1.07 GiB (1151517051 bytes)
-...
-Tokenizer       : /Users/lion/.lattice/models/qwen3.5-0.8b/tokenizer.json (found)
-
-Result: OK -- weights + KV cache fit; ready to load
-```
+the model. Run it before `chat`/`serve` on any new Q4 output — **but see the `quantize_quarot`
+limitation immediately below before pointing it at a QuaRot output directory.**
 
 exits 0 with `Result: OK` when the checkpoint is loadable and fits comfortably; exits 1 with
 `Result: NOT READY` and a specific reason otherwise. **If `doctor` reports dozens or hundreds of
@@ -338,6 +338,19 @@ corrupted or incomplete conversion — `doctor` inherits the same Qwen3.6-27B co
 `lattice serve`/`lattice chat`, so a missing config makes it expect a 27B-shaped tensor set against
 your smaller checkpoint's actual tensors. Copy `config.json` in and re-run `doctor` before assuming
 the conversion itself is broken.
+
+**Current limitation: `doctor` only understands `quantize_q4`'s bare-array manifest.**
+`lattice doctor` deserializes `quantize_index.json` as a plain JSON array of tensor entries
+(`Vec<Q4IndexEntry>` in `crates/inference/src/bin/lattice.rs`) — the shape `quantize_q4` writes.
+`quantize_quarot` writes a different, object-shaped manifest instead (`{"quarot_seed": ...,
+"tensors": [...]}`, see `crates/inference/src/quant/quarot/convert.rs`) so it can carry the
+rotation seed alongside the tensor list. Pointing `doctor` at a `quantize_quarot` output directory
+today does not produce a `Result: OK` or `Result: NOT READY` verdict at all — it fails at the
+manifest-parsing step with a JSON type-mismatch error (`invalid type: map, expected a sequence`),
+before any of the memory/tensor checks run. This is tracked as
+[issue #626](https://github.com/ohdearquant/lattice/issues/626); until it's resolved, treat
+`doctor` as `quantize_q4`-only, and verify a `quantize_quarot` checkpoint via `chat`/`serve`
+directly or `eval_perplexity --quarot-q4-dir` (Step 3 above) instead of `doctor`.
 
 ## Summary checklist
 

--- a/docs/q4-quantization.md
+++ b/docs/q4-quantization.md
@@ -1,0 +1,352 @@
+# Q4 and QuaRot Quantization Workflow
+
+This document walks through the full path from an unquantized Qwen3.5 checkpoint to a
+running, verified 4-bit model: `quantize_q4` (plain Q4_0), `quantize_quarot` (Hadamard-rotated
+Q4_0, ADR-044), loading the result, and the perplexity-based check that tells you whether the
+conversion actually preserved model quality. Every command below was run against
+`~/.lattice/models/qwen3.5-0.8b` in this repository to confirm the exact flags and output shape.
+
+For the underlying design (why rotation helps 4-bit quantization, the forward-equivalence
+gate, the acceptance threshold), see
+[`docs/adr/ADR-044-quarot-rotated-quantization.md`](adr/ADR-044-quarot-rotated-quantization.md).
+This document is the practical companion: what to type and what the output means.
+
+## Two converters, two purposes
+
+| Tool                  | Input                    | Output                                     | Rotation | Use when                                                 |
+| --------------------- | ------------------------ | ------------------------------------------ | -------- | -------------------------------------------------------- |
+| `bin/quantize_q4`     | BF16/F16/F32 safetensors | Q4_0 `.q4`/`.f16` + index                  | no       | Fast, simple 4-bit conversion                            |
+| `bin/quantize_quarot` | BF16/F16/F32 safetensors | Hadamard-rotated Q4_0 `.q4`/`.f16` + index | yes      | Lower quantization error at the same bit width (ADR-044) |
+
+Both write one file per tensor (`<sanitized_name>.q4` for quantized tensors, `<sanitized_name>.f16`
+for tensors kept at higher precision) plus a `quantize_index.json` that records, per tensor, its
+output file, whether it was quantized, its original shape, and element count. This directory
+layout is what `MetalQwen35State::from_q4_dir` (the Metal loader used by `lattice serve`,
+`lattice chat`, `chat_metal`, and `eval_perplexity --q4-dir`) expects.
+
+## Step 1: plain Q4_0 with `quantize_q4`
+
+```bash
+cargo build --release -p lattice-inference --bin quantize_q4
+./target/release/quantize_q4 \
+  --model-dir ~/.lattice/models/qwen3.5-0.8b \
+  --output-dir ~/.lattice/models/qwen3.5-0.8b-q4
+```
+
+`quantize_q4` has no `--help` — passing an unrecognized flag, or omitting a required one, prints
+usage to stderr and exits 1:
+
+```
+$ ./target/release/quantize_q4
+--model-dir is required
+Usage: quantize_q4 --model-dir <DIR> --output-dir <DIR> [--dry-run]
+
+  --model-dir   directory containing model.safetensors[.index.json]
+  --output-dir  directory to write .q4 and index files
+  --dry-run     read tensors but skip writing output
+```
+
+`--model-dir` and `--output-dir` are both required; `--dry-run` reads and quantizes every tensor
+in memory (so you see the same per-tensor log and summary) but skips every disk write, which is
+useful as a smoke test before committing to a large conversion. There is no `--seed` — plain Q4_0
+quantization is a deterministic per-block min/max scale-and-round, so there is nothing to seed.
+
+A real run against the 0.8B checkpoint (which also carries a vision tower and an MTP head, hence
+488 tensors rather than just the text-transformer's share):
+
+```
+=== quantize_q4: SafeTensors → Q4_0 ===
+Model dir:  /Users/lion/.lattice/models/qwen3.5-0.8b
+Output dir: /Users/lion/.lattice/models/qwen3.5-0.8b-q4
+Tensors:    488
+
+  [1/488] F16   model.language_model.embed_tokens.weight  shape=[151936, 1024]  296.8MB  dtype=BF16  0.128s
+  [2/488] Q4_0  model.language_model.layers.0.self_attn.q_proj.weight  shape=[4096, 1024]  8.0MB→2.5MB  0.02s
+  ...
+  [488/488] F16   mtp.pre_fc_norm_hidden.weight  shape=[1024]  0.0MB  dtype=BF16  0.000s
+Index written: /Users/lion/.lattice/models/qwen3.5-0.8b-q4/quantize_index.json
+
+=== Summary ===
+Tensors processed: 488
+  Quantized (Q4_0): 271
+  Kept (F16):       217
+Input size:   1.63 GB
+Output size:  0.51 GB
+Ratio:        3.20x  (31.3%)
+Total time:   6.2s
+```
+
+271 of 488 tensors are quantized; the other 217 (norms, biases, GDN's `A_log`/`dt_bias`/conv1d
+weights, and the embedding table in this run) are kept at their original width and written as
+`.f16`. The `should_quantize` rule in `quantize_q4.rs` targets the large projection/MLP/embedding
+matrices and explicitly excludes norms, biases, and Mamba/GDN-specific scalars — quantizing those
+would save almost no memory and would hurt accuracy disproportionately.
+
+### The gotcha: `quantize_q4`'s output has no `config.json`
+
+This is the single most important thing in this document. **`quantize_q4` never writes a
+`config.json`** — its output directory holds only `.q4`/`.f16` tensor files and
+`quantize_index.json`. This differs from `quantize_quarot` (below), whose output directory
+_does_ include one. Every consumer of a Q4 directory that isn't `quantize_q4` itself assumes
+`config.json` might be present, but they disagree on what happens when it's not:
+
+- `lattice serve --model <q4-dir>` and `lattice chat --model <q4-dir>` (in `lattice.rs`)
+  call a helper (`load_q4_config`) that **falls back to a hardcoded Qwen3.6-27B default config**
+  when `config.json` is missing, printing only a one-line warning to stderr:
+  `Warning: <dir> has no config.json; falling back to the Qwen3.6-27B default config.` For any
+  checkpoint that isn't actually the 27B model — including the 0.8B checkpoint used throughout
+  this document — this silently loads the wrong architecture (wrong layer count, hidden size,
+  attention/GDN layer pattern). It does not fail; it fails _wrong_, and only a warning line
+  distinguishes that from a normal load.
+- `eval_perplexity --q4-dir <dir>` (see Step 3) hard-errors instead:
+  `ERROR: Q4 dir <dir> is missing config.json` and exits 1. No silent fallback.
+- `lattice doctor --model <q4-dir>` (see "Verify before you load", below) also ends up using the
+  same Qwen3.6-27B fallback internally, which causes it to expect ~500 additional tensors that a
+  smaller checkpoint doesn't have. It **does** fail closed (exit 1, `Result: NOT READY`), but the
+  reported reason — "531 required tensor(s) missing" — points at the symptom, not the cause.
+
+**The fix is the same in all three cases: copy `config.json` from the source model directory into
+the `quantize_q4` output directory before loading it with anything else.**
+
+```bash
+cp ~/.lattice/models/qwen3.5-0.8b/config.json ~/.lattice/models/qwen3.5-0.8b-q4/config.json
+```
+
+`quantize_quarot` (Step 2) does not have this problem — it writes its own `config.json`
+automatically as part of its output.
+
+## Step 2: QuaRot-rotated Q4_0 with `quantize_quarot`
+
+QuaRot (Ashkboos et al., NeurIPS 2024) applies a Hadamard rotation to the residual stream before
+quantizing, spreading outlier magnitude across channels so that per-block min/max quantization has
+less dynamic range to cover. `quantize_quarot` implements ADR-044 step 3c: rotate, quantize, then
+verify the rotation didn't change the model's forward output beyond a tight numerical tolerance
+before writing anything.
+
+Unlike `quantize_q4`, this tool has real `--help`:
+
+```
+$ ./target/release/quantize_quarot --help
+usage: quantize_quarot --model-dir <PATH> --output-dir <PATH> --seed <U64> [OPTIONS]
+
+QuaRot Q4_0 converter for Qwen3.5 (ADR-044 step 3c).
+
+required:
+  --model-dir <PATH>         Input directory with config.json + safetensors.
+  --output-dir <PATH>        Output directory (created if absent).
+  --seed <U64>               Hadamard rotation seed (decimal or 0x... hex).
+
+options:
+  --tolerance <F64>          Forward-equivalence tolerance. Default 1e-5.
+  --num-probe-tokens <USIZE> Chain-probe sample size. Default 4.
+  --dry-run                  Run pipeline + gate; skip disk writes.
+  -h, --help                 Print this help and exit.
+
+The converter refuses to write any output if the forward-equivalence
+gate fails (delta > tolerance) — this protects against silently shipping
+a model whose logits diverged during conversion.
+```
+
+`--seed` is required and has no default: converted artifacts from different seeds are not
+interchangeable (the rotation matrix is seed-derived), so the project's convention is to record
+the seed used, not rely on an implicit default. It accepts decimal or `0x`-prefixed hex, with
+optional `_` separators exactly like a Rust integer literal (`0xCAFE_BABE_DEAD_BEEF`).
+
+```bash
+cargo build --release -p lattice-inference --bin quantize_quarot
+./target/release/quantize_quarot \
+  --model-dir ~/.lattice/models/qwen3.5-0.8b \
+  --output-dir ~/.lattice/models/qwen3.5-0.8b-q4-quarot \
+  --seed 0xC0FFEE
+```
+
+Real output from that command:
+
+```
+=== quantize_quarot: QuaRot Q4_0 converter ===
+Model dir:   /Users/lion/.lattice/models/qwen3.5-0.8b
+Output dir:  /Users/lion/.lattice/models/qwen3.5-0.8b-q4-quarot
+Seed:        0x0000000000c0ffee
+Tolerance:   0.00001
+Probe toks:  4
+Mode:        WRITE
+
+=== Summary ===
+Tied input:        true
+Quantized (Q4_0):  188
+Kept (F16):        148
+Input bytes:       1.44 GB
+Output bytes:      0.62 GB
+Compression:       2.30x (43.4%)
+Forward-equiv:     max_abs=7.017e-14, mean_abs=1.050e-14 (tol=1e-5, probes=[17156, 85503, 9161, 94570])
+Wall time:         77.6s
+```
+
+`Tied input: true` means this checkpoint ties its embedding and `lm_head` weights (one tensor,
+two roles) — the converter detected and preserved that. The `Forward-equiv` line is the
+correctness gate: it runs the _unrotated_ and _rotated_ model forward on `--num-probe-tokens`
+sample token chains and reports the max/mean absolute logit difference. Here `max_abs=7e-14`
+against a `tol=1e-5` tolerance is nine orders of magnitude inside the bound — the rotation is
+mathematically exact up to floating-point noise, as it should be (a Hadamard rotation is
+orthogonal; it changes representation, not the function computed). **If this gate fails, the tool
+writes nothing** — `ConversionReport` is never returned, `main` prints `ERROR: ...` and returns
+`ExitCode::FAILURE` (exit 1), and the output directory is left without a completed conversion.
+There is no partial/corrupt output state to clean up.
+
+Note the different tensor counts (188 quantized + 148 kept = 336) versus plain `quantize_q4`'s
+271 + 217 = 488 on the same source directory: the QuaRot pipeline in this codebase operates on the
+core Qwen3.5 text transformer and does not carry the vision tower or MTP head through the rotation
+the way `quantize_q4`'s generic tensor-by-tensor pass does. If your workflow needs the QuaRot path
+specifically for text generation (chat/serve), this is expected; it is not a partial-conversion bug.
+
+## Step 3: verify with perplexity, not just "it loaded"
+
+A checkpoint that loads and generates _something_ is not evidence the quantization preserved
+quality — Q4_0 and especially a botched rotation can produce fluent-looking but degraded text.
+`eval_perplexity` (ADR-044 step 4) is the actual acceptance check: it scores a held-out text
+corpus and reports perplexity (PPL), and in its dual-Q4 mode it computes the PPL delta between an
+unrotated and a rotated checkpoint against a threshold.
+
+```
+$ ./target/release/eval_perplexity --help
+```
+
+(flags summarized from the binary's own doc comment, `crates/inference/src/bin/eval_perplexity.rs`)
+
+| Flag                                    | Meaning                                                                                                                     |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `--model-dir <PATH>`                    | CPU baseline mode: safetensors checkpoint via `Qwen35Model::from_safetensors`.                                              |
+| `--q4-dir <PATH>`                       | Metal Q4 mode: a `quantize_q4` output directory.                                                                            |
+| `--quarot-q4-dir <PATH>`                | Metal Q4 mode: a `quantize_quarot` output directory.                                                                        |
+| `--q4-dir` + `--quarot-q4-dir` together | Dual-Q4 mode: runs both, prints both reports, then the delta and the ADR-044 acceptance verdict.                            |
+| `--tokenizer-dir <PATH>`                | Required for Metal modes — Q4 directories don't ship `tokenizer.json`, so point this at the original safetensors directory. |
+| `--corpus-file <PATH>`                  | UTF-8 text file, tokenized end-to-end.                                                                                      |
+| `--window` / `--stride`                 | Context window / stride in tokens. Default 512 / 256.                                                                       |
+| `--max-tokens`                          | Cap on tokens scored, for a fast smoke run. Default: no cap (scores the whole corpus).                                      |
+| `--delta-threshold`                     | Dual-Q4 mode only. Default `0.5`.                                                                                           |
+
+Exit code is 0 when PPL is computed and (in dual-Q4 mode) the delta is below the threshold; 1 on
+any error, or on a dual-Q4 delta at or above the threshold (acceptance fail).
+
+The repository ships a small held-out corpus at `docs/bench_results/wiki.test.raw` for exactly
+this purpose. A real dual-Q4 run against the two checkpoints produced above (remember: `--q4-dir`
+needs `config.json` copied in per the gotcha above; `--quarot-q4-dir` already has its own):
+
+```bash
+./target/release/eval_perplexity \
+  --q4-dir ~/.lattice/models/qwen3.5-0.8b-q4 \
+  --quarot-q4-dir ~/.lattice/models/qwen3.5-0.8b-q4-quarot \
+  --tokenizer-dir ~/.lattice/models/qwen3.5-0.8b \
+  --corpus-file docs/bench_results/wiki.test.raw \
+  --max-tokens 4096
+```
+
+```
+=== Perplexity Report (unrotated Q4) ===
+PPL:                18.349821
+Tokens scored:      4095
+Windows:            15
+
+=== Perplexity Report (QuaRot Q4) ===
+PPL:                20.608386
+Tokens scored:      4095
+Windows:            15
+
+=== Acceptance Gate (ADR-044 step 4) ===
+Unrotated Q4 PPL: 18.349821
+QuaRot Q4 PPL:    20.608386
+PPL delta:        +2.258565  (quarot - unrotated)
+Threshold:        < 0.500000
+Verdict:          FAIL (delta >= threshold)
+```
+
+Read this result carefully before concluding anything is broken: **15 windows is far too small a
+sample to make an accept/reject call.** `--max-tokens 4096` is useful for confirming the whole
+pipeline runs end to end (both checkpoints load, both score, the gate logic itself works), not for
+a real quality verdict — treat a FAIL at this scale as "rerun on more data," not "the conversion is
+bad." The project's own published reference numbers, at a still-modest but larger 2048-token
+window count (`docs/bench_results/perplexity.tsv`, cited in the README), show the same pattern:
+`lattice q4 19.266338` vs `lattice q4-quarot 19.950512` — a delta of +0.68, which is _also_ over
+the nominal 0.5 threshold. In other words, a nonzero, threshold-exceeding delta at reduced token
+counts is a known characteristic of this measurement at small scale, not something unique to a
+fresh from-scratch conversion. Reproduce the project's own reference numbers with
+`./scripts/bench_context_scaling.sh`, or omit `--max-tokens` entirely (scores the full corpus,
+310,034 tokens for `wiki.test.raw` — expect this to take considerably longer than the smoke-test
+run above) before treating either a PASS or a FAIL as a real acceptance decision.
+
+`eval_perplexity` also emits a machine-readable line per report on stdout, independent of the
+human-readable summary on stderr:
+
+```
+@@lattice {"ev":"perplexity","label":"unrotated Q4","ppl":18.349821,"nll":2.90962,"tokens":4095,"windows":15,"ms":14090}
+```
+
+## Step 4: load and run the quantized checkpoint
+
+Once you have a Q4 directory with `config.json` present (native for `quantize_quarot`, copied
+manually for `quantize_q4`), it loads through the same CLI entry points as any other checkpoint —
+`lattice` auto-detects the format from the directory contents (presence of any `*.q4` file selects
+the Q4/Metal path; `model.safetensors`/`.index.json` selects the CPU/safetensors path):
+
+```bash
+# Interactive, one-shot-per-line REPL (no cross-turn conversation history)
+./target/release/lattice chat \
+  --model ~/.lattice/models/qwen3.5-0.8b-q4-quarot \
+  --tokenizer-dir ~/.lattice/models/qwen3.5-0.8b
+
+# OpenAI-compatible HTTP server — see docs/serve-http-api.md for the full API
+./target/release/lattice serve \
+  --model ~/.lattice/models/qwen3.5-0.8b-q4-quarot \
+  --tokenizer-dir ~/.lattice/models/qwen3.5-0.8b \
+  --port 8080
+```
+
+`--tokenizer-dir` is required for a Q4 directory in both cases (Q4 output never includes
+`tokenizer.json`) and should point at the original safetensors directory. Both commands require
+the `metal-gpu` feature at build time (`cargo build --release -p lattice-inference --bin lattice
+--features metal-gpu,f16`); without it, a Q4 model directory is rejected with a clear
+"requires the metal-gpu feature" error rather than attempting a CPU fallback (Q4 inference in this
+codebase is Metal-only).
+
+### Verify before you load: `lattice doctor`
+
+`lattice doctor --model <dir> --tokenizer-dir <dir>` is a preflight check: it reports the detected
+format, weight memory footprint, KV-cache cost per token, and whether the checkpoint's tensors and
+your system's memory are actually sufficient to load it, without spending the time to load and run
+the model. Run it before `chat`/`serve` on any new Q4 output:
+
+```
+$ ./target/release/lattice doctor --model ~/.lattice/models/qwen3.5-0.8b-q4-quarot --tokenizer-dir ~/.lattice/models/qwen3.5-0.8b
+Model directory : /Users/lion/.lattice/models/qwen3.5-0.8b-q4-quarot
+Format          : Q4
+Placement       : Metal GPU
+Quantization    : Q4_0 (lattice native, v2 asymmetric)
+Tensors found   : 488
+Weight memory   : 1.07 GiB (1151517051 bytes)
+...
+Tokenizer       : /Users/lion/.lattice/models/qwen3.5-0.8b/tokenizer.json (found)
+
+Result: OK -- weights + KV cache fit; ready to load
+```
+
+exits 0 with `Result: OK` when the checkpoint is loadable and fits comfortably; exits 1 with
+`Result: NOT READY` and a specific reason otherwise. **If `doctor` reports dozens or hundreds of
+"missing required tensors" with layer indices well beyond what you'd expect for your model size**
+(for example, layers in the 20s-40s for what you know is a small checkpoint), the near-certain
+real cause is a missing `config.json` in that directory (see the gotcha in Step 1) rather than a
+corrupted or incomplete conversion — `doctor` inherits the same Qwen3.6-27B config fallback as
+`lattice serve`/`lattice chat`, so a missing config makes it expect a 27B-shaped tensor set against
+your smaller checkpoint's actual tensors. Copy `config.json` in and re-run `doctor` before assuming
+the conversion itself is broken.
+
+## Summary checklist
+
+1. `quantize_q4 --model-dir SRC --output-dir Q4_DIR` — fast, no rotation, no `config.json` written.
+2. `quantize_quarot --model-dir SRC --output-dir QUAROT_DIR --seed 0x...` — rotated, includes its
+   own `config.json`, refuses to write output if its internal forward-equivalence check fails.
+3. Copy `config.json` from `SRC` into `Q4_DIR` (not needed for `QUAROT_DIR`).
+4. `lattice doctor --model <dir> --tokenizer-dir SRC` before loading anything for real.
+5. `eval_perplexity --q4-dir Q4_DIR --quarot-q4-dir QUAROT_DIR --tokenizer-dir SRC --corpus-file <corpus>`
+   (full corpus, no `--max-tokens`) as the actual quality gate — exit code 0 plus a delta below
+   the threshold is the real "it worked" signal, not just successful loading.
+6. `lattice chat` / `lattice serve --model <dir> --tokenizer-dir SRC` to actually use the result.

--- a/docs/serve-http-api.md
+++ b/docs/serve-http-api.md
@@ -85,6 +85,32 @@ Shut down with Ctrl-C — it's a graceful shutdown, not an immediate kill:
 (confirmed live: the process exits cleanly after printing this, rather than dropping in-flight
 connections.)
 
+## Auth, rate limiting, and concurrency
+
+None of this is implemented today — worth stating explicitly, since issue #601 asks for it:
+
+- **No authentication.** There is no API-key check, bearer-token check, or any other
+  `Authorization` handling anywhere in the router — it's exactly the two routes plus the
+  body-size layer shown above. Anyone who can reach the listening address can call it.
+- **No rate limiting, no per-request admission control.** There is no request-count or
+  concurrency-limiting middleware in front of the handlers. The only thing that rejects a request
+  before it reaches model code is the 1 MiB body-size cap already shown above.
+- **CPU backend: not serialized by the server, but not free either.** Each CPU request's
+  `generate` call runs as blocking work on a Tokio blocking-pool task
+  (`tokio::task::spawn_blocking`, `crates/inference/src/bin/lattice.rs`), so multiple CPU requests
+  can execute concurrently up to Tokio's blocking-pool size — this is not a hard concurrency-1
+  limit, but concurrent CPU requests still contend for the same CPU cores and memory.
+- **Metal/Q4 backend: effectively concurrency-1.** All Metal generation is funneled through one
+  dedicated worker thread (an `mpsc` channel into a single OS thread holding the `!Send` Metal
+  state, `crates/inference/src/bin/lattice.rs`) — a deliberate design choice matching how one local
+  GPU device actually works, not an oversight. Two concurrent requests against a Q4-backed
+  `lattice serve` run back-to-back, not in parallel; the later request's connection simply stays
+  open until its turn in the channel comes up.
+
+None of this makes `lattice serve` unsafe to run locally or behind your own reverse proxy that adds
+auth and rate limiting — it just means `lattice serve` itself provides neither, so don't expose it
+directly to an untrusted network.
+
 ## `GET /health`
 
 ```

--- a/docs/serve-http-api.md
+++ b/docs/serve-http-api.md
@@ -1,0 +1,382 @@
+# `lattice serve` HTTP API
+
+The README shows one bare `curl` example against `/v1/chat/completions`. This document covers
+the rest of the surface: exact request/response shapes, streaming, error responses, validation
+order, and behavior that is easy to get wrong if you only read the happy path. Everything below
+was verified against `crates/inference/src/bin/lattice.rs`'s `mod serve` (the `lattice serve`
+subcommand's implementation) and confirmed live against a running server built from this
+repository.
+
+## A naming note before anything else
+
+This codebase has **two** separately built HTTP servers with confusingly similar names:
+
+- **`lattice serve`** — a subcommand of the unified `lattice` CLI binary
+  (`crates/inference/src/bin/lattice.rs`). This is the general-purpose, OpenAI-compatible server
+  the README documents (Quick Start and "### HTTP API" sections), with an active development
+  history (unified-CLI ADR-063, SSE streaming, stop sequences, native Q4 checkpoint support,
+  `lattice doctor` preflight). **This document is about `lattice serve`.**
+- **`lattice_serve`** — a separate, standalone binary
+  (`crates/inference/src/bin/lattice_serve.rs`), purpose-built as the internal HTTP daemon the
+  macOS Lattice Studio app spawns and talks to (introduced in PR #435). It has its own, narrower
+  route set (`GET /`, `GET /health`, `GET /v1/models`, `POST /v1/chat/completions`) and its own
+  disconnect-cancellation behavior (PR #552/#606) that `lattice serve` does not have (see
+  "Streaming" below). It is not what the README's HTTP API section documents, and it is out of
+  scope for this document.
+
+If you arrived here from an issue or note that points at `lattice_serve.rs` specifically: the
+README's actual HTTP API example — the thing that issue was asking to be expanded — targets
+`lattice serve` (the CLI subcommand), not the standalone `lattice_serve` binary. This document
+covers the one the README documents.
+
+## Starting the server
+
+```bash
+# CPU (safetensors checkpoint)
+cargo build --release -p lattice-inference --bin lattice --features f16
+./target/release/lattice serve --model ~/.lattice/models/qwen3.5-0.8b --port 8080
+
+# Metal GPU (native Q4 checkpoint) — see docs/q4-quantization.md for producing one
+cargo build --release -p lattice-inference --bin lattice --features metal-gpu,f16
+./target/release/lattice serve \
+  --model ~/.lattice/models/qwen3.5-0.8b-q4-quarot \
+  --tokenizer-dir ~/.lattice/models/qwen3.5-0.8b \
+  --port 8080
+```
+
+The model directory's contents pick the backend automatically: a `model.safetensors` file (or
+`.index.json` for a sharded checkpoint) selects the CPU path; the presence of any `*.q4` file
+selects the Metal path (requires the `metal-gpu` feature at build time — without it, a Q4
+directory is rejected with a clear error rather than silently falling back to CPU). `--model-id`
+lets you set the identifier clients must send back in `"model"`; if omitted, it's derived from the
+model directory's basename (`qwen3.5-0.8b`, `qwen3.5-0.8b-q4-quarot`, etc.).
+
+Startup output:
+
+```
+Loading model from /Users/lion/.lattice/models/qwen3.5-0.8b...
+Model loaded. Serving as 'qwen3.5-0.8b'.
+Listening on 127.0.0.1:8080  (model: qwen3.5-0.8b, max_tokens default: 64)
+  POST /v1/chat/completions
+  GET  /health
+```
+
+That printed route list is exhaustive — this is the complete router:
+
+```rust
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/v1/chat/completions", post(chat_completions))
+        .layer(DefaultBodyLimit::max(1_048_576)) // 1 MiB request body cap
+        .with_state(state)
+}
+```
+
+There is no `/v1/models`, `/v1/completions`, or any admin/metrics endpoint. If you need a model
+listing endpoint, that's `lattice_serve` (the other binary), not this one.
+
+Shut down with Ctrl-C — it's a graceful shutdown, not an immediate kill:
+
+```
+^CShutdown signal received, draining connections...
+```
+
+(confirmed live: the process exits cleanly after printing this, rather than dropping in-flight
+connections.)
+
+## `GET /health`
+
+```
+$ curl -s http://127.0.0.1:8080/health
+{"status":"ok"}
+```
+
+Always 200 once the server is listening; there's no dependency check behind it (it doesn't verify
+the model is still loadable/usable, just that the process is up and routing requests).
+
+## `POST /v1/chat/completions` — non-streaming
+
+```bash
+curl http://127.0.0.1:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3.5-0.8b",
+    "messages": [{"role": "user", "content": "Say hello in exactly 3 words."}],
+    "max_tokens": 32,
+    "temperature": 0.0
+  }'
+```
+
+Real response (captured against a running server in this repo):
+
+```json
+{
+  "id": "chatcmpl-1783130141-0",
+  "object": "chat.completion",
+  "created": 1783130141,
+  "model": "qwen3.5-0.8b",
+  "choices": [
+    {
+      "index": 0,
+      "message": { "role": "assistant", "content": "<think>\n\n</think>\n\nHello!" },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": { "prompt_tokens": 16, "completion_tokens": 6, "total_tokens": 22 }
+}
+```
+
+Notes on real fields you'll see:
+
+- `id` is `chatcmpl-{unix_seconds}-{request_counter}` — the counter is a per-process
+  `AtomicU64` that makes IDs unique across concurrent requests within the same second, not a
+  globally unique/opaque token.
+- `content` can include Qwen3.5's `<think>...</think>` reasoning block as a literal prefix in the
+  message text — this server does not separate reasoning from the final answer into different
+  response fields (no OpenAI-style `reasoning_content`); it's all one `content` string, exactly as
+  the model emitted it. An empty `<think>\n\n</think>` before the real answer, as above, is normal
+  for a simple prompt.
+- `finish_reason` is `"stop"` when generation ended via EOS/stop-token/stop-string, `"length"` when
+  the `max_tokens` budget was exhausted first. There is no `"content_filter"` or `"tool_calls"`
+  value — those OpenAI finish reasons don't apply here.
+
+### Request fields
+
+```rust
+pub struct ChatCompletionRequest {
+    pub model: String,                              // required, must match the served model_id
+    pub messages: Vec<Message>,
+    pub max_tokens: Option<usize>,
+    pub max_completion_tokens: Option<usize>,        // alias; must agree with max_tokens if both set
+    pub temperature: Option<f32>,                    // default 0.7, range [0.0, 2.0]
+    pub top_p: Option<f32>,                          // default 0.9, range (0.0, 1.0]
+    pub stream: Option<bool>,
+    pub stop: Option<Value>,                         // string, or array of 1-4 non-empty strings
+    pub seed: Option<u64>,
+    pub response_format: Option<ResponseFormat>,     // only {"type": "text"} accepted
+    pub tools: Option<Value>,                        // rejected if present
+    pub tool_choice: Option<Value>,                  // rejected if present
+    pub logprobs: Option<bool>,                      // rejected if true (see "logprobs" below)
+    pub n: Option<usize>,                            // rejected if > 1
+}
+```
+
+`message.content` accepts either a plain string or an OpenAI-style content-parts array, but only
+`{"type": "text", "text": "..."}` parts — an image/audio/file part is rejected with 400, not
+silently dropped. `messages[].role` must be `"system"`, `"user"`, or `"assistant"`; `"tool"` and
+`"developer"` are explicitly named and rejected (`"role 'tool' is not supported by this server"`);
+anything else gets a generic `"unsupported role '...'"` message.
+
+The struct's own doc comment on the `stream` field currently reads "SSE streaming — not yet
+supported; rejected with 400" — **this is stale and wrong**. Streaming is fully implemented (see
+below); the comment simply wasn't updated when it was added. Trust the behavior below (confirmed
+both by the passing test `reject_unsupported_stream_true_ok` and by a live request), not that
+comment.
+
+### Validation order
+
+Requests are validated in a fixed sequence; the first failure wins. Useful to know so you can
+predict which error you'll get when more than one thing is wrong with a request:
+
+1. JSON body parses and is under the 1 MiB limit.
+2. `reject_unsupported`: `tools`/`tool_choice` present, `logprobs: true`, `n > 1`,
+   `response_format.type != "text"`.
+3. `model` matches the server's loaded model ID.
+4. `messages` is non-empty.
+5. The **last** message has role `"user"` (a Qwen ChatML constraint — the conversation must end on
+   a user turn for the model to have something to respond to).
+6. `max_tokens`/`max_completion_tokens`, `temperature`, `top_p` are all in range.
+7. Every message renders into ChatML (role + content-part checks).
+8. The rendered prompt's token count plus `max_tokens` fits the model's context window.
+9. `stop` parses into valid stop strings.
+
+### Rejected requests — exact error shapes
+
+Every error response uses this envelope, live-verified for all three status codes:
+
+```json
+{ "error": { "message": "...", "type": "invalid_request_error", "code": "...", "param": null } }
+```
+
+`type` is `"invalid_request_error"` for both 400 and 413 responses, `"server_error"` for 500.
+`param` is always `null` today — no field ever populates it. Some real examples:
+
+```
+$ curl -s -w '\n%{http_code}\n' http://127.0.0.1:8080/v1/chat/completions \
+    -d '{"model":"qwen3.5-0.8b","messages":[{"role":"user","content":"hi"}],"logprobs":true}'
+{"error":{"message":"logprobs is not supported by this server","type":"invalid_request_error","code":"unsupported_feature","param":null}}
+400
+```
+
+```
+$ curl -s -w '\n%{http_code}\n' http://127.0.0.1:8080/v1/chat/completions \
+    -d '{"model":"qwen3.5-0.8b","messages":[{"role":"user","content":"hi"}],"n":2}'
+{"error":{"message":"n > 1 is not supported","type":"invalid_request_error","code":"unsupported_feature","param":null}}
+400
+```
+
+Malformed JSON (here, a syntax error — a missing `}`):
+
+```
+$ curl -s -w '\n%{http_code}\n' http://127.0.0.1:8080/v1/chat/completions \
+    -d '{"model": "qwen3.5-0.8b", "messages": [ { "role": "user", "content": "hi" ] }'
+{"error":{"message":"invalid JSON request body","type":"invalid_request_error","code":"invalid_request_body","param":null}}
+400
+```
+
+The underlying parser error is logged server-side only
+(`eprintln!("invalid request body: {}", ...)`) — it is deliberately never forwarded to the client.
+For the malformed request above, the server's stderr shows:
+
+```
+invalid request body: Failed to parse the request body as JSON: messages[0].?: expected `,` or `}` at line 1 column 75
+```
+
+Note the literal backticks around `,` and `}` — that's serde_json's own error-message formatting,
+not markdown. If you're debugging a malformed-request issue, check the server's stderr, not the
+response body; the client only ever sees the generic `"invalid JSON request body"` message above.
+
+A request body over 1 MiB gets HTTP 413, not 400:
+
+```
+$ curl -s -w '\n%{http_code}\n' http://127.0.0.1:8080/v1/chat/completions \
+    --data-binary @big_payload.json
+{"error":{"message":"request body exceeds 1 MiB limit","type":"invalid_request_error","code":"request_body_too_large","param":null}}
+413
+```
+
+### `logprobs` — rejected today, in review for support
+
+As of this writing, `"logprobs": true` is unconditionally rejected
+(`"logprobs is not supported by this server"`, code `unsupported_feature`) — confirmed both by
+source and by a live request above. **PR #620** (issue #585, still open/draft as of this writing)
+adds real OpenAI-compatible `logprobs`/`top_logprobs` support to this exact endpoint's
+non-streaming path, with `top_logprobs` range-checked to `0..=20` and required to pair with
+`logprobs: true`. Two things worth knowing if you're reading this close to when that PR lands:
+
+- Per that PR's own description, `stream: true` combined with `logprobs: true` will still be
+  rejected with 400 even after it merges — streaming logprobs is explicitly out of scope for that
+  change.
+- That PR's own description also notes that the cross-turn prefix-cache generation path (see
+  [`docs/cross-turn-cache.md`](cross-turn-cache.md)) doesn't populate logprobs and isn't reachable
+  from this HTTP server anyway — not a regression from that change, just a documented gap.
+
+If you're reading this after #620 has merged, verify the current behavior against
+`reject_unsupported` in `lattice.rs` directly rather than trusting this paragraph — it will be
+stale at that point.
+
+## `POST /v1/chat/completions` — streaming (SSE)
+
+Set `"stream": true`. The response is `text/event-stream`, one JSON object per `data:` line,
+matching OpenAI's chunk sequence exactly: a role chunk first, then one chunk per text delta, then
+a finish chunk with an empty `delta: {}`, then the literal `data: [DONE]`.
+
+```bash
+curl -N http://127.0.0.1:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen3.5-0.8b","messages":[{"role":"user","content":"Count to 3."}],"max_tokens":24,"temperature":0.0,"stream":true}'
+```
+
+Real captured output (trimmed):
+
+```
+data: {"id":"chatcmpl-1783130154-1","object":"chat.completion.chunk","created":1783130154,"model":"qwen3.5-0.8b","choices":[{"index":0,"delta":{"role":"assistant"}}]}
+
+data: {"id":"chatcmpl-1783130154-1","object":"chat.completion.chunk","created":1783130154,"model":"qwen3.5-0.8b","choices":[{"index":0,"delta":{"content":"<think>"}}]}
+
+data: {"id":"chatcmpl-1783130154-1","object":"chat.completion.chunk","created":1783130154,"model":"qwen3.5-0.8b","choices":[{"index":0,"delta":{"content":"Here"}}]}
+
+... (one chunk per token) ...
+
+data: {"id":"chatcmpl-1783130154-1","object":"chat.completion.chunk","created":1783130154,"model":"qwen3.5-0.8b","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+```
+
+`ChunkDelta`'s `role`/`content` fields are both `#[serde(skip_serializing_if = "Option::is_none")]`
+— that's why the finish chunk's `delta` serializes as the literal empty object `{}` rather than
+`{"role":null,"content":null}`. The connection also gets axum's default SSE keep-alive (a comment
+ping if 15 seconds pass with no event), so a slow prefill before the first token won't look like a
+dead connection to an intermediate proxy.
+
+Two caveats worth knowing before you build on this:
+
+- **No disconnect-cancellation.** If the client disconnects mid-stream, generation keeps running
+  to the `max_tokens` cap on the server — the dropped send errors are silently ignored, but nothing
+  stops the underlying generation early. This is called out directly in the handler's own comment:
+  "per-token backpressure / disconnect-cancellation is a future refinement." The separate
+  `lattice_serve` daemon binary _does_ have this (a `CancelOnDrop`/`watch::channel` mechanism added
+  in PR #552/#606) — `lattice serve` does not, as of this writing.
+- **An internal generation failure mid-stream is invisible in the stream shape.** If the
+  generation task errors out partway through (an engine panic path, an invariant violation), the
+  server emits a normal-looking finish chunk (`finish_reason: "stop"`) followed by `[DONE]` —
+  exactly what a successful completion looks like. The only trace of the failure is a server-side
+  `eprintln!` (`"generation error (streaming): ..."` or `"generation invariant violation: ..."`).
+  A client cannot distinguish "finished normally" from "failed partway through" from the SSE
+  stream alone.
+
+## Context window and token-budget limits
+
+`lattice serve` enforces a **hardcoded `max_tokens_cap` of 4096** — this is not a CLI flag; it's a
+literal in `main()`'s `Command::Serve` handling. A request asking for more is rejected:
+
+```
+{"error":{"message":"max_tokens 8000 exceeds server limit 4096","type":"invalid_request_error","code":"max_tokens_exceeds_limit","param":null}}
+```
+
+Separately, for the Metal/Q4 backend specifically, the usable context window is capped at
+`MetalChatBackend::MAX_CACHE_LEN` (4096 tokens) regardless of the loaded model's actual
+`max_position_embeddings` (Qwen3.5-0.8B's config reports 262144) — `lattice doctor` will show you
+this cap directly (see [`docs/q4-quantization.md`](q4-quantization.md)). If your rendered prompt's
+token count plus `max_tokens` exceeds the effective context window, you get:
+
+```
+{"error":{"message":"prompt (X tokens) plus max_tokens (Y) exceeds model context window (Z)","type":"invalid_request_error","code":"context_length_exceeded","param":null}}
+```
+
+The CPU (safetensors) backend doesn't have this particular cap — its `max_context()` comes from
+the model's own config — but the 4096 `max_tokens_cap` still applies to both backends equally.
+
+## A realistic multi-turn example
+
+The server is stateless per request — there is no session/conversation ID, and (as covered in
+[`docs/cross-turn-cache.md`](cross-turn-cache.md)) no cross-turn KV cache reuse either. Every
+request must carry the full conversation history in `messages`, and every request re-prefills that
+entire history from scratch:
+
+```bash
+curl http://127.0.0.1:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3.5-0.8b",
+    "messages": [
+      {"role": "system", "content": "You are a terse assistant. Answer in one sentence."},
+      {"role": "user", "content": "What is the capital of France?"},
+      {"role": "assistant", "content": "<think>\n\n</think>\n\nThe capital of France is Paris."},
+      {"role": "user", "content": "And its population?"}
+    ],
+    "max_tokens": 64,
+    "temperature": 0.0
+  }'
+```
+
+Feeding a prior assistant turn's `<think>...</think>` block back in as history is fine — the
+server doesn't strip or special-case it; it's rendered into ChatML like any other assistant
+message content. There is no requirement to strip reasoning blocks between turns.
+
+## Summary
+
+- `lattice serve` (not the separate `lattice_serve` binary) is the OpenAI-compatible server this
+  document covers: `GET /health`, `POST /v1/chat/completions`, nothing else.
+- Non-streaming and streaming (SSE) both work today; the request struct's doc comment claiming
+  streaming is unsupported is stale — verify against `reject_unsupported` and its tests, not that
+  comment.
+- Every error is the OpenAI error envelope shape (`error.message`/`type`/`code`/`param`), with
+  `code` distinguishing specific failure reasons; malformed-JSON parser detail and internal
+  generation failures are logged server-side only, never returned to the client.
+- `logprobs` is rejected today; PR #620 (in review) adds it non-streaming-only.
+- `max_tokens` is hard-capped at 4096 server-wide; the Metal/Q4 backend additionally caps total
+  context at 4096 regardless of the model's own configured maximum.
+- No cross-turn caching, no disconnect-cancellation on the streaming path, and a mid-stream
+  internal failure is indistinguishable from a normal finish in the SSE shape itself.


### PR DESCRIPTION
## Summary

Three new flat-file cookbooks under `docs/`, matching the repo's existing convention
(`docs/examples.md`, `docs/inference-usage.md`, `docs/getting-started.md`) rather than
introducing a `docs/examples/` or `docs/cookbook/` subdirectory.

- **`docs/q4-quantization.md`** (Closes #596) — end-to-end Q4/QuaRot workflow: `quantize_q4`
  vs `quantize_quarot`, the `quantize_index.json` shape, loading/running the resulting
  checkpoint, and `eval_perplexity` as the "did it actually work" verification step (not just
  "it loaded and generated text"). Every command and every number in this file was run live
  against a real Qwen3.5-0.8B checkpoint in this worktree this session — nothing is
  from-memory or assumed.

  The central finding: **`quantize_q4` never writes a `config.json`** into its output
  directory (unlike `quantize_quarot`, which does), and the three consumers of a Q4 directory
  disagree on what happens when it's missing — `lattice serve`/`chat` silently falls back to a
  hardcoded Qwen3.6-27B config with only a one-line warning (wrong architecture, loads
  "successfully"), `eval_perplexity --q4-dir` hard-errors cleanly, and `lattice doctor` hits the
  same silent fallback and then fails with a confusing "531 required tensors missing" message
  that doesn't name the real cause. All three behaviors were reproduced live and are documented
  with the fix (copy `config.json` from the source directory).

- **`docs/cross-turn-cache.md`** (Closes #597) — the cross-turn KV prefix cache library API
  (`CrossTurnSlotId`, `generate_streaming_with_prefix_cache`,
  `chat_completion_streaming_with_prefix_cache`, `PrefixReuseMode`, the single-entry cache
  design and its fail-closed error handling), and how PR #619 wires it into `chat_metal`.

- **`docs/serve-http-api.md`** (Closes #601) — the `lattice serve` HTTP API beyond a bare curl
  one-liner: full request/response shapes, the exact OpenAI-style error envelope and every
  distinct rejected-request case (unsupported features, malformed JSON, oversized payload,
  context-length-exceeded), the real SSE chunk sequence for streaming (captured live, including
  literal `<think>` reasoning-token deltas), the hardcoded `max_tokens_cap` of 4096, and
  graceful Ctrl-C shutdown (also confirmed live).

  Clarifies a naming ambiguity: issue #601's acceptance criteria point at
  `crates/inference/src/bin/lattice_serve.rs`, but that's a separate, narrower binary built for
  the macOS Studio app daemon. The README's own "Quick Start" and "HTTP API" sections document
  `lattice serve` (the CLI subcommand in `lattice.rs`), which is what this cookbook covers.

## Flags for review — behavior from still-open upstream PRs

- **`docs/cross-turn-cache.md`** documents PR #619's diff (`chat_metal` wiring), which is
  **still open in draft** as of this writing. The doc says so explicitly up front and points at
  `gh pr view 619` for current status. Please re-check this file's "Using it from `chat_metal`"
  section once #619 merges or changes.
- **`docs/serve-http-api.md`** documents current `logprobs` behavior (unconditionally rejected)
  and separately notes PR #620 (**still open in draft**), which adds real `logprobs`/
  `top_logprobs` support to the same endpoint's non-streaming path. Please re-check the
  "`logprobs`" section once #620 merges.
- A discovered-but-unrelated-to-either-PR issue, flagged inline in `docs/serve-http-api.md`:
  the `ChatCompletionRequest.stream` field's doc comment currently says "SSE streaming — not
  yet supported; rejected with 400," which is stale/wrong — streaming works today, confirmed
  live. Documented as a known inconsistency, not fixed in this PR (out of scope — this PR is
  docs-only).

## Verification

All CLI usage, flags, output shapes, and error responses were verified live against binaries
built from this worktree this session (not from training-data memory or assumption):
`quantize_q4`, `quantize_quarot`, `eval_perplexity` (including a real dual-Q4 acceptance-gate
run), `lattice doctor` (both a healthy run and the config.json-missing failure mode), and a
live `lattice serve` process exercised with `curl` for health, non-streaming and streaming
chat completions, and four distinct rejected-request cases plus a graceful-shutdown test.

No code changes — docs only, no build/test gate applies beyond the repo's existing
`scripts/lint-docs.sh` (passed via the pre-commit hook).

## Test plan

- [x] `deno fmt --check` on all three new files (via the repo's `scripts/lint-docs.sh`,
      enforced by `.githooks/pre-commit`)
- [x] Every command shown as runnable was actually run against a real checkpoint in this
      worktree this session
- [x] Internal cross-links between the three cookbooks resolve to real files/anchors
- [ ] Re-check `docs/cross-turn-cache.md` once PR #619 finalizes
- [ ] Re-check the `logprobs` section of `docs/serve-http-api.md` once PR #620 finalizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)