### PR TITLE
fix(inference): machine-wide GPU test lock via flock on /tmp/lion-metal-gpu-test.lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,12 @@ When a test fails intermittently or fails alongside unrelated work, run the disc
 
 This split a two-test failure report cleanly: one test failed deterministically at every prompt length under solo idle-GPU conditions (real chunk-boundary accumulation drift, its own issue), while the other passed solo in 65 seconds (a load flake, a different issue). Filing them as one regression would have sent the fix to the wrong place.
 
+### Machine-Wide GPU Test Lock
+
+All Metal-touching tests in this repo serialize through `gpu_test_lock()` (crates/inference/src/forward/metal_qwen35.rs), which holds two locks: an in-process mutex (thread serialization within one test binary) and an exclusive advisory flock on `/tmp/lion-metal-gpu-test.lock` (cross-process serialization, fleet-wide convention). Any harness on this machine that drives the GPU for measurements — other repos' test suites, bench runners, one-off scripts — should acquire the same flock before touching Metal. Concurrent GPU work corrupts both timing and numerics: contended confirmation batches inflated top-k logit margins ~3x and produced false failure reports (#628, #629).
+
+The lock blocks for up to 30 minutes, then panics with an `lsof /tmp/lion-metal-gpu-test.lock` hint rather than hanging silently. If a run appears stuck at test start, another process is holding the GPU; check who with `lsof` before killing anything.
+
 ### Regression Tests Must Be Mutation-Sensitive
 
 A regression test that passes with the fix reverted is decoration. Before claiming a test guards a fix: revert the fix (reverse-apply the diff — never `git checkout` over uncommitted work), `touch` the source file so cargo actually rebuilds, and watch the test fail. Then restore the fix and watch it pass.

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -22012,19 +22012,83 @@ kernel void decode_attention_reference(
             r
         }
 
-        /// Serializes GPU-heavy model tests onto the single shared Metal device.
-        /// Concurrent GPU execution amplifies the pre-existing ADR-065 attention
-        /// race, which perturbs the *serial* GDN reference that the cross-algorithm
-        /// parity tests compare against — producing false-positive failures under
-        /// `cargo test`'s default multi-threading. The chunked scan itself is
-        /// deterministic (see `gdn_chunked_b_vs_b_self_consistency`); serializing
-        /// device access keeps the serial reference clean run-to-run.
-        fn gpu_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        /// Serializes GPU-heavy model tests onto the single shared Metal device —
+        /// across BOTH test threads in this process and any other process on the
+        /// machine.
+        ///
+        /// In-process half: concurrent GPU execution amplifies the pre-existing
+        /// ADR-065 attention race, which perturbs the *serial* GDN reference that
+        /// the cross-algorithm parity tests compare against — producing
+        /// false-positive failures under `cargo test`'s default multi-threading.
+        /// The chunked scan itself is deterministic (see
+        /// `gdn_chunked_b_vs_b_self_consistency`); serializing device access keeps
+        /// the serial reference clean run-to-run.
+        ///
+        /// Machine-level half (#628/#629 post-mortem): the in-process mutex cannot
+        /// stop `cargo test` runs launched from OTHER worktrees on the same
+        /// machine, and concurrent Metal load provably corrupts real-checkpoint
+        /// numerics (boundary-tie margins inflated ~3x during a confirmed
+        /// contention window). So the guard also holds an exclusive advisory
+        /// `flock` on a fixed machine-wide path, `/tmp/lion-metal-gpu-test.lock`,
+        /// making cross-process serialization automatic instead of a convention
+        /// agents must remember. Any harness touching the Metal GPU should
+        /// acquire the same path.
+        ///
+        /// Acquisition order is mutex-then-file, so at most one thread per
+        /// process ever contends the file lock. The file lock is polled with
+        /// `try_lock` so a wedged holder surfaces as a clear panic after a
+        /// generous timeout instead of a silent infinite hang.
+        struct GpuTestGuard {
+            _process: std::sync::MutexGuard<'static, ()>,
+            // Held for the guard's lifetime; dropping the File closes the fd,
+            // which releases the flock.
+            _machine: std::fs::File,
+        }
+
+        const GPU_MACHINE_LOCK_PATH: &str = "/tmp/lion-metal-gpu-test.lock";
+        const GPU_MACHINE_LOCK_TIMEOUT: std::time::Duration =
+            std::time::Duration::from_secs(30 * 60);
+
+        fn gpu_test_lock() -> GpuTestGuard {
             use std::sync::Mutex;
             static GPU_LOCK: Mutex<()> = Mutex::new(());
-            GPU_LOCK
+            let process = GPU_LOCK
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(GPU_MACHINE_LOCK_PATH)
+                .unwrap_or_else(|e| {
+                    panic!("gpu_test_lock: cannot open {GPU_MACHINE_LOCK_PATH}: {e}")
+                });
+            let deadline = std::time::Instant::now() + GPU_MACHINE_LOCK_TIMEOUT;
+            loop {
+                match file.try_lock() {
+                    Ok(()) => break,
+                    Err(std::fs::TryLockError::WouldBlock) => {
+                        if std::time::Instant::now() >= deadline {
+                            panic!(
+                                "gpu_test_lock: another process has held \
+                                 {GPU_MACHINE_LOCK_PATH} for over {}s — a Metal \
+                                 test run elsewhere on this machine is wedged or \
+                                 genuinely that long; inspect `lsof {GPU_MACHINE_LOCK_PATH}`",
+                                GPU_MACHINE_LOCK_TIMEOUT.as_secs()
+                            );
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(500));
+                    }
+                    Err(std::fs::TryLockError::Error(e)) => {
+                        panic!("gpu_test_lock: flock on {GPU_MACHINE_LOCK_PATH} failed: {e}")
+                    }
+                }
+            }
+            GpuTestGuard {
+                _process: process,
+                _machine: file,
+            }
         }
 
         fn minimal_bpe_tokenizer() -> crate::tokenizer::bpe::BpeTokenizer {


### PR DESCRIPTION
## Summary

Extends `gpu_test_lock()` in `crates/inference/src/forward/metal_qwen35.rs` to hold a second, machine-level lock: an exclusive advisory flock on the fixed path `/tmp/lion-metal-gpu-test.lock`, alongside the existing in-process mutex.

**Why**: the in-process mutex serializes threads inside one test binary, but nothing serialized GPU work *across processes*. Concurrent GPU load from sibling harnesses corrupted confirmation-batch numerics — top-k logit margins inflated ~3x under contention, producing false failure reports (post-mortems in #628 and #629). Maintainer ruling (2026-07-04): a machine-level advisory file lock at this fixed path, to be adopted by every Metal-touching harness on the machine.

## Design

- `gpu_test_lock()` now returns a `GpuTestGuard` holding both the `MutexGuard` and the flocked `File`; dropping the guard closes the fd, releasing the flock. Return-type change is transparent to all 25 call sites (bound as `let _guard`/`_gpu`/`_gpu_guard = gpu_test_lock();`; verified: no site names the type).
- Acquisition order is mutex-then-file, so at most one thread per process contends the file lock.
- `file.try_lock()` polled every 500 ms against a 30-minute deadline; on timeout it panics with an `lsof /tmp/lion-metal-gpu-test.lock` hint instead of hanging silently.
- Uses std `File::lock`/`try_lock`/`TryLockError` (stabilized Rust 1.89; repo MSRV 1.93) — zero new dependencies.
- Doc note added to CLAUDE.md ("Machine-Wide GPU Test Lock") recording the path convention for other harnesses.

## Testing

- `cargo check -p lattice-inference --tests --features f16,metal-gpu` clean
- `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- Test-harness-only change (the function is `#[cfg(test)]`-scoped harness code); no production code paths touched. bench-compare N/A — no inference kernel or hot-path change.

Live two-process contention verification (hold the flock from a second process, observe a Metal test block then proceed) is deferred until the machine is idle — the #611 bench-compare run is in flight and building a test binary now would corrupt it, which is exactly the failure mode this PR fixes.

Closes nothing; enables the #629 uncontended re-run and the corrupted confirmation-batch re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
