### PR TITLE
feat(inference): Q4 MTP weight loading (#630)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -14374,6 +14374,180 @@ kernel void gdn_chunk_norm_silu_c32(
         prompt
     }
 
+    /// Failure modes for resolving a single MTP tensor from disk (#636 round-1).
+    ///
+    /// `Missing` is the pre-existing graceful case: the caller (the MTP
+    /// projection-load closure in [`load_mtp_q4_weights`]) turns it into a
+    /// warn-and-fall-back-to-non-MTP-decode result via
+    /// [`mtp_missing_weights_warning`]. `Incompatible` is new and
+    /// deliberately NOT graceful: it means the on-disk artifact exists but
+    /// cannot be trusted (a stale `.q4` sibling in a QuaRot rotated-space
+    /// checkpoint, or a shape/transpose mismatch) — silently disabling MTP
+    /// would be safe, but silently *loading* it would produce garbage
+    /// drafts, so this propagates as a hard `from_q4_dir` load error
+    /// instead.
+    #[derive(Debug)]
+    enum MtpLoadErr {
+        Missing(std::path::PathBuf),
+        Incompatible(String),
+    }
+
+    impl From<std::path::PathBuf> for MtpLoadErr {
+        fn from(path: std::path::PathBuf) -> Self {
+            MtpLoadErr::Missing(path)
+        }
+    }
+
+    /// One MTP tensor's values as read from disk, before Metal buffer
+    /// creation — deliberately `Device`-free so flavor selection and shape
+    /// validation are unit-testable without a GPU (#636 round-1 medium #3).
+    #[derive(Debug)]
+    enum MtpTensorSource {
+        F16 {
+            values: Vec<f32>,
+            #[allow(dead_code)] // read via `shape()`, only exercised by `#[cfg(test)]` callers
+            shape: Vec<usize>,
+        },
+        Q4(crate::weights::q4_weights::Q4Tensor),
+    }
+
+    #[cfg(test)]
+    impl MtpTensorSource {
+        /// Test-only accessor for the resolved on-disk shape, used to assert
+        /// which flavor + shape a `resolve_mtp_projection` call picked
+        /// without needing a Metal `Device`.
+        fn shape(&self) -> &[usize] {
+            match self {
+                MtpTensorSource::F16 { shape, .. } => shape,
+                MtpTensorSource::Q4(tensor) => &tensor.shape,
+            }
+        }
+
+        fn is_q4(&self) -> bool {
+            matches!(self, MtpTensorSource::Q4(_))
+        }
+    }
+
+    /// Resolve one of the 8 MTP projection matrices from `q4_dir`, pure
+    /// CPU I/O only (no `Device`).
+    ///
+    /// `quantize_q4` applies the same `should_quantize` name-suffix rule to
+    /// MTP tensors as to the main model, so the 8 `*_proj*.weight` MTP
+    /// matrices are written as `.q4` on a plain (non-rotated) Q4 checkpoint.
+    /// `quantize_quarot` instead keeps every MTP tensor as unrotated `.f16`
+    /// (ADR-051 Phase 1: MTP counter-rotation needs unquantized weights),
+    /// and MUST NOT have a `.q4` sibling for any MTP tensor.
+    ///
+    /// `allow_q4` therefore encodes the checkpoint flavor, determined by
+    /// the caller BEFORE any projection is loaded (not sniffed per-file):
+    /// `true` for a plain Q4 checkpoint (no QuaRot rotation seed anywhere),
+    /// `false` for a QuaRot checkpoint. When `allow_q4` is `false` and a
+    /// `.q4` sibling exists anyway, that is an incompatible stale artifact
+    /// — `quantize_q4` was re-run into a QuaRot output directory (the
+    /// converter reuses a non-empty output dir rather than rejecting it),
+    /// producing rotated-space `.q4` weights that the runtime's
+    /// counter-rotation (keyed off the same directory's `quarot_seed`)
+    /// would silently apply on top of, corrupting every MTP draft without
+    /// any load failure to reveal it (#636 round-1 MAJOR). This is
+    /// rejected loudly instead of silently preferring `.f16`.
+    ///
+    /// Also validates the resolved tensor's on-disk shape against
+    /// `expected_shape`: a same-numel transposed file loads and generates
+    /// tokens but produces garbage MTP drafts (#636 round-1 medium #1), so
+    /// shape mismatches are rejected the same way as an incompatible
+    /// artifact rather than silently accepted.
+    fn resolve_mtp_projection(
+        q4_dir: &std::path::Path,
+        name: &str,
+        expected_shape: &[usize],
+        allow_q4: bool,
+    ) -> Result<MtpTensorSource, MtpLoadErr> {
+        use crate::weights::q4_weights::{load_f16_tensor_file, load_q4_file};
+
+        let q4_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "q4");
+        if q4_path.exists() {
+            if !allow_q4 {
+                return Err(MtpLoadErr::Incompatible(format!(
+                    "{}: incompatible stale MTP .q4 artifact found alongside a QuaRot \
+                     (rotated-space) checkpoint; QuaRot Phase 1 requires MTP projections \
+                     to remain unrotated .f16 — a .q4 sibling here means quantize_q4 was \
+                     re-run into a QuaRot output directory, and loading it would silently \
+                     apply counter-rotation on top of already-rotated-space weights, \
+                     corrupting every MTP draft without a load failure to reveal it. \
+                     Refusing to load — delete the stale .q4 file or regenerate the \
+                     checkpoint.",
+                    q4_path.display()
+                )));
+            }
+            let tensor =
+                load_q4_file(&q4_path).map_err(|_| MtpLoadErr::Missing(q4_path.clone()))?;
+            if tensor.shape != expected_shape {
+                return Err(MtpLoadErr::Incompatible(format!(
+                    "{}: MTP tensor '{name}' has shape {:?}, expected {expected_shape:?} — \
+                     refusing to load (a mismatched/transposed weight file loads and \
+                     generates tokens but silently produces garbage MTP drafts)",
+                    q4_path.display(),
+                    tensor.shape
+                )));
+            }
+            return Ok(MtpTensorSource::Q4(tensor));
+        }
+
+        let f16_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "f16");
+        if !f16_path.exists() {
+            return Err(MtpLoadErr::Missing(f16_path));
+        }
+        let (values, shape) =
+            load_f16_tensor_file(&f16_path).map_err(|_| MtpLoadErr::Missing(f16_path.clone()))?;
+        if shape != expected_shape {
+            return Err(MtpLoadErr::Incompatible(format!(
+                "{}: MTP tensor '{name}' has shape {shape:?}, expected {expected_shape:?} — \
+                 refusing to load (a mismatched/transposed weight file loads and generates \
+                 tokens but silently produces garbage MTP drafts)",
+                f16_path.display()
+            )));
+        }
+        Ok(MtpTensorSource::F16 { values, shape })
+    }
+
+    /// Resolve one of the 7 MTP norm tensors from `q4_dir`, pure CPU I/O
+    /// only (no `Device`). Norms are never quantized by `should_quantize`
+    /// in either quantizer, so they are always `.f16`-only regardless of
+    /// checkpoint flavor; a `.q4` sibling under a norm's name is treated
+    /// as an incompatible artifact rather than silently ignored (defense
+    /// in depth — should never occur on a checkpoint from either
+    /// quantizer). Also validates on-disk shape (#636 round-1 medium #1).
+    fn resolve_mtp_norm(
+        q4_dir: &std::path::Path,
+        name: &str,
+        expected_shape: &[usize],
+    ) -> Result<(Vec<f32>, Vec<usize>), MtpLoadErr> {
+        use crate::weights::q4_weights::load_f16_tensor_file;
+
+        let q4_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "q4");
+        if q4_path.exists() {
+            return Err(MtpLoadErr::Incompatible(format!(
+                "{}: unexpected MTP .q4 artifact for norm tensor '{name}' — norms are never \
+                 quantized by either quantizer; refusing to load an incompatible checkpoint",
+                q4_path.display()
+            )));
+        }
+        let f16_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "f16");
+        if !f16_path.exists() {
+            return Err(MtpLoadErr::Missing(f16_path));
+        }
+        let (values, shape) =
+            load_f16_tensor_file(&f16_path).map_err(|_| MtpLoadErr::Missing(f16_path.clone()))?;
+        if shape != expected_shape {
+            return Err(MtpLoadErr::Incompatible(format!(
+                "{}: MTP norm tensor '{name}' has shape {shape:?}, expected \
+                 {expected_shape:?} — refusing to load",
+                f16_path.display()
+            )));
+        }
+        Ok((values, shape))
+    }
+
     impl MetalQwen35State {
         /// **Unstable**: chat completion; stop token handling and output format may change.
         ///
@@ -14973,124 +15147,132 @@ kernel void gdn_chunk_norm_silu_c32(
         /// Returns no weights if the model has no MTP layers or if any weight file is
         /// missing; in the latter case the first missing file path is carried in the
         /// result so the caller can warn instead of silently falling back.
+        ///
+        /// `is_quarot` must reflect whether `q4_dir` is a QuaRot (rotated-space)
+        /// checkpoint — determined by the caller from `quarot_seed` presence
+        /// (`quantize_index.json` object manifest or the legacy `config.json`
+        /// field) BEFORE calling this function, so flavor detection never
+        /// depends on which files happen to exist per-tensor (#636 round-1
+        /// MAJOR). Returns `Err` (hard load failure, not a gracefully-disabled
+        /// warning) when an MTP tensor is present but untrustworthy: an
+        /// incompatible stale `.q4` sibling under `is_quarot`, or a
+        /// shape/transpose mismatch against the tensor's expected dimensions.
         fn load_mtp_q4_weights(
             q4_dir: &std::path::Path,
             cfg: &Qwen35Config,
             device: &Device,
-        ) -> MtpQ4LoadResult {
-            use crate::weights::q4_weights::{load_f16_tensor_file, load_q4_file};
-
+            is_quarot: bool,
+        ) -> Result<MtpQ4LoadResult, String> {
             if cfg.mtp_num_hidden_layers == 0 {
-                return MtpQ4LoadResult {
+                return Ok(MtpQ4LoadResult {
                     weights: None,
                     first_missing_file: None,
-                };
+                });
             }
 
-            let f16p = |name: &str| MetalQwen35State::q4_tensor_path(q4_dir, name, "f16");
+            let hidden = cfg.hidden_size;
+            let q_dim = cfg.full_q_dim();
+            let kv_dim = cfg.full_kv_dim();
+            let inter = cfg.intermediate_size;
+            let head_dim = cfg.head_dim;
+            // Projections may load .q4 only on a plain (non-QuaRot) checkpoint;
+            // QuaRot dirs must keep every MTP tensor unrotated .f16.
+            let allow_q4 = !is_quarot;
 
-            // Helper: load an f16 file as a f32 Metal buffer (for norm gammas / biases
-            // consumed by RMSNorm kernels that read f32 input).
-            let load_f16_buf_as_f32 =
-                |name: &str, label: &str| -> Result<Buffer, std::path::PathBuf> {
-                    let path = f16p(name);
-                    if !path.exists() {
-                        return Err(path);
-                    }
-                    let (vals, _) = load_f16_tensor_file(&path).map_err(|_| path.clone())?;
-                    Ok(make_buffer(device, &vals, label))
+            // Helper: resolve + widen an MTP norm to an f32 Metal buffer (for
+            // RMSNorm kernels that read f32 input).
+            let load_norm_as_f32 =
+                |name: &str, expected_shape: &[usize], label: &str| -> Result<Buffer, MtpLoadErr> {
+                    let (values, _) = resolve_mtp_norm(q4_dir, name, expected_shape)?;
+                    Ok(make_buffer(device, &values, label))
                 };
 
-            // Helper: load an f16 file as a Metal half-precision (f16) buffer for use
-            // by `dispatch_matmul_half` / `gemv_decode_m1`. ADR-051 Phase 1 mandates
-            // f16 storage for the 8 MTP projection matrices so the runtime applies
-            // counter-rotation on unquantized weights.
-            let load_f16_buf_as_half =
-                |name: &str, label: &str| -> Result<Buffer, std::path::PathBuf> {
-                    let path = f16p(name);
-                    if !path.exists() {
-                        return Err(path);
+            // Helper: resolve one of the 8 MTP projections and materialize it
+            // as an f16 Metal buffer for `dispatch_matmul_half` / `gemv_decode_m1`
+            // (ADR-051 Phase 1: both flavors store MTP projections unrotated).
+            let load_proj_as_half =
+                |name: &str, expected_shape: &[usize], label: &str| -> Result<Buffer, MtpLoadErr> {
+                    match resolve_mtp_projection(q4_dir, name, expected_shape, allow_q4)? {
+                        MtpTensorSource::Q4(tensor) => Ok(
+                            MetalQwen35State::make_buffer_f16_from_q4(device, &tensor, label),
+                        ),
+                        MtpTensorSource::F16 { values, .. } => {
+                            Ok(make_buffer_f16(device, &values, label))
+                        }
                     }
-                    let (vals, _) = load_f16_tensor_file(&path).map_err(|_| path.clone())?;
-                    Ok(make_buffer_f16(device, &vals, label))
                 };
 
-            // Helper: load one of the 8 MTP projection matrices as a Metal
-            // half-precision (f16) buffer, accepting either on-disk flavor.
-            //
-            // `quantize_q4` applies the same `should_quantize` name-suffix rule
-            // to MTP tensors as to the main model, so the 8 `*_proj*.weight`
-            // MTP matrices are written as `.q4` (dequantize-on-load here).
-            // `quantize_quarot` instead keeps every MTP tensor as unrotated
-            // `.f16` (ADR-051 Phase 1: MTP counter-rotation needs unquantized
-            // weights, so QuaRot checkpoints never emit MTP `.q4` files).
-            // Preferring `.q4` when present and falling back to `.f16` lets
-            // both checkpoint flavors load through the same path without
-            // needing to sniff which quantizer produced the directory.
-            let load_q4_or_f16_proj_as_half =
-                |name: &str, label: &str| -> Result<Buffer, std::path::PathBuf> {
-                    let q4_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "q4");
-                    if q4_path.exists() {
-                        let tensor = load_q4_file(&q4_path).map_err(|_| q4_path.clone())?;
-                        return Ok(MetalQwen35State::make_buffer_f16_from_q4(
-                            device, &tensor, label,
-                        ));
-                    }
-                    load_f16_buf_as_half(name, label)
-                };
-
-            let weights = (|| -> Result<MetalMtpWeights, std::path::PathBuf> {
+            let weights = (|| -> Result<MetalMtpWeights, MtpLoadErr> {
                 // --- Layer 0 weights (ADR-051: 8 projections as f16, 7 norms as f32) ---
-                let input_layernorm = load_f16_buf_as_f32(
+                let input_layernorm = load_norm_as_f32(
                     "mtp.layers.0.input_layernorm.weight",
+                    &[hidden],
                     "mtp.l0.input_layernorm",
                 )?;
-                let post_attention_layernorm = load_f16_buf_as_f32(
+                let post_attention_layernorm = load_norm_as_f32(
                     "mtp.layers.0.post_attention_layernorm.weight",
+                    &[hidden],
                     "mtp.l0.post_attn_layernorm",
                 )?;
-                let q_proj = load_q4_or_f16_proj_as_half(
+                let q_proj = load_proj_as_half(
                     "mtp.layers.0.self_attn.q_proj.weight",
+                    &[2 * q_dim, hidden],
                     "mtp.l0.q_proj",
                 )?;
-                let k_proj = load_q4_or_f16_proj_as_half(
+                let k_proj = load_proj_as_half(
                     "mtp.layers.0.self_attn.k_proj.weight",
+                    &[kv_dim, hidden],
                     "mtp.l0.k_proj",
                 )?;
-                let v_proj = load_q4_or_f16_proj_as_half(
+                let v_proj = load_proj_as_half(
                     "mtp.layers.0.self_attn.v_proj.weight",
+                    &[kv_dim, hidden],
                     "mtp.l0.v_proj",
                 )?;
-                let o_proj = load_q4_or_f16_proj_as_half(
+                let o_proj = load_proj_as_half(
                     "mtp.layers.0.self_attn.o_proj.weight",
+                    &[hidden, q_dim],
                     "mtp.l0.o_proj",
                 )?;
-                let q_norm =
-                    load_f16_buf_as_f32("mtp.layers.0.self_attn.q_norm.weight", "mtp.l0.q_norm")?;
-                let k_norm =
-                    load_f16_buf_as_f32("mtp.layers.0.self_attn.k_norm.weight", "mtp.l0.k_norm")?;
-                let gate_proj = load_q4_or_f16_proj_as_half(
+                let q_norm = load_norm_as_f32(
+                    "mtp.layers.0.self_attn.q_norm.weight",
+                    &[head_dim],
+                    "mtp.l0.q_norm",
+                )?;
+                let k_norm = load_norm_as_f32(
+                    "mtp.layers.0.self_attn.k_norm.weight",
+                    &[head_dim],
+                    "mtp.l0.k_norm",
+                )?;
+                let gate_proj = load_proj_as_half(
                     "mtp.layers.0.mlp.gate_proj.weight",
+                    &[inter, hidden],
                     "mtp.l0.gate_proj",
                 )?;
-                let up_proj = load_q4_or_f16_proj_as_half(
+                let up_proj = load_proj_as_half(
                     "mtp.layers.0.mlp.up_proj.weight",
+                    &[inter, hidden],
                     "mtp.l0.up_proj",
                 )?;
-                let down_proj = load_q4_or_f16_proj_as_half(
+                let down_proj = load_proj_as_half(
                     "mtp.layers.0.mlp.down_proj.weight",
+                    &[hidden, inter],
                     "mtp.l0.down_proj",
                 )?;
 
                 // --- Top-level MTP weights ---
-                let fc = load_q4_or_f16_proj_as_half("mtp.fc.weight", "mtp.fc")?;
-                let pre_fc_norm_embedding = load_f16_buf_as_f32(
+                let fc = load_proj_as_half("mtp.fc.weight", &[hidden, 2 * hidden], "mtp.fc")?;
+                let pre_fc_norm_embedding = load_norm_as_f32(
                     "mtp.pre_fc_norm_embedding.weight",
+                    &[hidden],
                     "mtp.pre_fc_norm_embedding",
                 )?;
-                let pre_fc_norm_hidden =
-                    load_f16_buf_as_f32("mtp.pre_fc_norm_hidden.weight", "mtp.pre_fc_norm_hidden")?;
-                let norm = load_f16_buf_as_f32("mtp.norm.weight", "mtp.norm")?;
+                let pre_fc_norm_hidden = load_norm_as_f32(
+                    "mtp.pre_fc_norm_hidden.weight",
+                    &[hidden],
+                    "mtp.pre_fc_norm_hidden",
+                )?;
+                let norm = load_norm_as_f32("mtp.norm.weight", &[hidden], "mtp.norm")?;
 
                 eprintln!("[mtp] Loaded MTP layer 0 weights from {}", q4_dir.display());
                 Ok(MetalMtpWeights {
@@ -15117,14 +15299,15 @@ kernel void gdn_chunk_norm_silu_c32(
             })();
 
             match weights {
-                Ok(weights) => MtpQ4LoadResult {
+                Ok(weights) => Ok(MtpQ4LoadResult {
                     weights: Some(weights),
                     first_missing_file: None,
-                },
-                Err(first_missing_file) => MtpQ4LoadResult {
+                }),
+                Err(MtpLoadErr::Missing(first_missing_file)) => Ok(MtpQ4LoadResult {
                     weights: None,
                     first_missing_file: Some(first_missing_file),
-                },
+                }),
+                Err(MtpLoadErr::Incompatible(message)) => Err(message),
             }
         }
 
@@ -15868,12 +16051,27 @@ kernel void gdn_chunk_norm_silu_c32(
             // tokenizer_path is accepted but not stored — tokenizer is loaded by the caller.
             let _ = tokenizer_path;
 
+            // Determine the QuaRot flavor BEFORE loading any MTP projection, so a
+            // stale MTP `.q4` sibling in a rotated-space checkpoint fails closed
+            // instead of silently loading rotated weights under counter-rotation
+            // (#636 round-1 MAJOR). ADR-051 contract: `quarot_seed` lives in
+            // `quantize_index.json`. Fall back to the legacy `config.json` field
+            // (`quarot_rotation_seed`) for backwards compatibility with artifacts
+            // produced before the contract was formalized. #504 remaining slice 2:
+            // a *present but malformed* index is a hard error (fail-closed) — only
+            // a genuinely absent index falls back.
+            let index_seed = crate::quant::quarot::convert::read_quarot_seed_from_index(q4_dir)
+                .map_err(|e| format!("from_q4_dir: {e}"))?;
+            let quarot_seed_opt = index_seed.or(cfg.quarot_rotation_seed);
+            let is_quarot = quarot_seed_opt.is_some();
+
             // Load MTP weights (cache+activations go into session, not engine).
             let mtp_requested = std::env::var_os("LATTICE_MTP").is_some();
             let MtpQ4LoadResult {
                 weights: mtp_weights_opt,
                 first_missing_file: mtp_missing_file,
-            } = Self::load_mtp_q4_weights(q4_dir, cfg, &device);
+            } = Self::load_mtp_q4_weights(q4_dir, cfg, &device, is_quarot)
+                .map_err(|e| format!("from_q4_dir: {e}"))?;
             if let Some(message) = super::mtp_missing_weights_warning(
                 mtp_requested,
                 mtp_weights_opt.is_some(),
@@ -15930,15 +16128,7 @@ kernel void gdn_chunk_norm_silu_c32(
             };
 
             let quarot_rotation = if mtp_weights_opt.is_some() {
-                // ADR-051 contract: `quarot_seed` lives in `quantize_index.json`. Fall back
-                // to the legacy `config.json` field (`quarot_rotation_seed`) for
-                // backwards compatibility with artifacts produced before the contract was
-                // formalized. #504 remaining slice 2: a *present but malformed* index is a
-                // hard error (fail-closed) — only a genuinely absent index falls back.
-                let index_seed = crate::quant::quarot::convert::read_quarot_seed_from_index(q4_dir)
-                    .map_err(|e| format!("from_q4_dir: {e}"))?;
-                let seed_opt = index_seed.or(cfg.quarot_rotation_seed);
-                match seed_opt {
+                match quarot_seed_opt {
                     Some(seed) => Some(
                         crate::quant::quarot::hadamard::RandomizedHadamard::new(seed, hidden)
                             .map_err(|e| {
@@ -19034,7 +19224,7 @@ kernel void decode_attention_reference(
         }
 
         // -------------------------------------------------------------------
-        // load_mtp_q4_weights: Q4-or-F16 MTP projection loading (#630)
+        // load_mtp_q4_weights: Q4-or-F16 MTP projection loading (#630, #636)
         // -------------------------------------------------------------------
         //
         // `quantize_q4` applies its `should_quantize` name-suffix rule to
@@ -19043,19 +19233,29 @@ kernel void decode_attention_reference(
         // `.q4`, while the 7 norm tensors are written as `.f16`.
         // `quantize_quarot` instead keeps ALL 15 MTP tensors as unrotated
         // `.f16` (ADR-051 Phase 1: MTP counter-rotation needs unquantized
-        // weights). `load_mtp_q4_weights` must accept both flavors.
+        // weights). `load_mtp_q4_weights` must accept both flavors, reject a
+        // stale `.q4` MTP sibling under a QuaRot (`is_quarot=true`) directory
+        // (round-1 MAJOR), and reject a transposed/mismatched tensor shape
+        // (round-1 medium #1). `resolve_mtp_projection`/`resolve_mtp_norm`
+        // are `Device`-free, so the flavor/shape logic itself is covered by
+        // CPU-only tests below that never skip on a Metal-less CI runner
+        // (round-1 medium #3); the `load_mtp_q4_weights` tests further down
+        // stay as `Device`-gated integration smoke on top of that.
 
-        /// Write a tiny `.f16` (KHF1) tensor file with `numel` copies of
-        /// `1.0`, mirroring the format `load_f16_tensor_file` reads
-        /// (crates/inference/src/weights/q4_weights.rs).
-        fn write_tiny_f16_fixture(dir: &std::path::Path, name: &str, numel: usize) {
+        /// Write a tiny `.f16` (KHF1) tensor file with the given `shape`,
+        /// filled with copies of `1.0`, mirroring the format
+        /// `load_f16_tensor_file` reads (crates/inference/src/weights/q4_weights.rs).
+        fn write_tiny_f16_fixture(dir: &std::path::Path, name: &str, shape: &[usize]) {
             use crate::weights::q4_weights::q4_f32_to_f16;
+            let numel: usize = shape.iter().product();
             let path = MetalQwen35State::q4_tensor_path(dir, name, "f16");
             let mut buf = Vec::new();
             buf.extend_from_slice(b"KHF1");
             buf.extend_from_slice(&1u32.to_le_bytes()); // version
-            buf.extend_from_slice(&1u32.to_le_bytes()); // ndim
-            buf.extend_from_slice(&(numel as u64).to_le_bytes()); // shape[0]
+            buf.extend_from_slice(&(shape.len() as u32).to_le_bytes()); // ndim
+            for &dim in shape {
+                buf.extend_from_slice(&(dim as u64).to_le_bytes());
+            }
             buf.extend_from_slice(&(numel as u64).to_le_bytes()); // numel
             for _ in 0..numel {
                 buf.extend_from_slice(&q4_f32_to_f16(1.0).to_le_bytes());
@@ -19063,38 +19263,212 @@ kernel void decode_attention_reference(
             std::fs::write(&path, buf).expect("write .f16 fixture");
         }
 
-        /// Write a tiny `.q4` tensor file with `numel` copies of `0.1`.
-        fn write_tiny_q4_fixture(dir: &std::path::Path, name: &str, numel: usize) {
+        /// Write a tiny `.q4` tensor file with the given `shape`, filled with
+        /// copies of `0.1`.
+        fn write_tiny_q4_fixture(dir: &std::path::Path, name: &str, shape: &[usize]) {
             use crate::weights::q4_weights::{quantize_f32_to_q4, save_q4_file};
+            let numel: usize = shape.iter().product();
             let data = vec![0.1f32; numel];
-            let tensor = quantize_f32_to_q4(&data, &[numel]).expect("quantize tiny tensor");
+            let tensor = quantize_f32_to_q4(&data, shape).expect("quantize tiny tensor");
             let path = MetalQwen35State::q4_tensor_path(dir, name, "q4");
             save_q4_file(&path, &tensor).expect("save .q4 fixture");
         }
 
-        /// The 8 MTP projection tensor names (q/k/v/o_proj, gate/up/down_proj, fc).
-        const MTP_PROJ_NAMES: [&str; 8] = [
-            "mtp.layers.0.self_attn.q_proj.weight",
-            "mtp.layers.0.self_attn.k_proj.weight",
-            "mtp.layers.0.self_attn.v_proj.weight",
-            "mtp.layers.0.self_attn.o_proj.weight",
-            "mtp.layers.0.mlp.gate_proj.weight",
-            "mtp.layers.0.mlp.up_proj.weight",
-            "mtp.layers.0.mlp.down_proj.weight",
-            "mtp.fc.weight",
-        ];
+        /// The 8 MTP projection tensor names paired with their expected
+        /// on-disk shape, derived from the real qwen3.5-0.8b-q4 checkpoint
+        /// (`~/.lattice/models/qwen3.5-0.8b-q4/mtp_*.q4` headers, verified by
+        /// hand during #636 round-1 remediation): on-disk shape is always
+        /// `[d_out, d_in]`, matching `expected_lora_shape`'s `(d_in, d_out)`
+        /// convention reversed.
+        fn mtp_proj_names_and_shapes(cfg: &Qwen35Config) -> [(&'static str, Vec<usize>); 8] {
+            let hidden = cfg.hidden_size;
+            let q_dim = cfg.full_q_dim();
+            let kv_dim = cfg.full_kv_dim();
+            let inter = cfg.intermediate_size;
+            [
+                (
+                    "mtp.layers.0.self_attn.q_proj.weight",
+                    vec![2 * q_dim, hidden],
+                ),
+                ("mtp.layers.0.self_attn.k_proj.weight", vec![kv_dim, hidden]),
+                ("mtp.layers.0.self_attn.v_proj.weight", vec![kv_dim, hidden]),
+                ("mtp.layers.0.self_attn.o_proj.weight", vec![hidden, q_dim]),
+                ("mtp.layers.0.mlp.gate_proj.weight", vec![inter, hidden]),
+                ("mtp.layers.0.mlp.up_proj.weight", vec![inter, hidden]),
+                ("mtp.layers.0.mlp.down_proj.weight", vec![hidden, inter]),
+                ("mtp.fc.weight", vec![hidden, 2 * hidden]),
+            ]
+        }
 
-        /// The 7 MTP norm tensor names — never quantized (`should_quantize`
-        /// excludes anything containing `norm.weight`).
-        const MTP_NORM_NAMES: [&str; 7] = [
-            "mtp.layers.0.input_layernorm.weight",
-            "mtp.layers.0.post_attention_layernorm.weight",
-            "mtp.layers.0.self_attn.q_norm.weight",
-            "mtp.layers.0.self_attn.k_norm.weight",
-            "mtp.norm.weight",
-            "mtp.pre_fc_norm_embedding.weight",
-            "mtp.pre_fc_norm_hidden.weight",
-        ];
+        /// The 7 MTP norm tensor names paired with their expected shape —
+        /// never quantized (`should_quantize` excludes anything containing
+        /// `norm.weight`). `q_norm`/`k_norm` are `[head_dim]`; the rest are
+        /// `[hidden]`.
+        fn mtp_norm_names_and_shapes(cfg: &Qwen35Config) -> [(&'static str, Vec<usize>); 7] {
+            let hidden = cfg.hidden_size;
+            let head_dim = cfg.head_dim;
+            [
+                ("mtp.layers.0.input_layernorm.weight", vec![hidden]),
+                ("mtp.layers.0.post_attention_layernorm.weight", vec![hidden]),
+                ("mtp.layers.0.self_attn.q_norm.weight", vec![head_dim]),
+                ("mtp.layers.0.self_attn.k_norm.weight", vec![head_dim]),
+                ("mtp.norm.weight", vec![hidden]),
+                ("mtp.pre_fc_norm_embedding.weight", vec![hidden]),
+                ("mtp.pre_fc_norm_hidden.weight", vec![hidden]),
+            ]
+        }
+
+        /// Write a complete, well-formed MTP tensor set to `dir`: the 8
+        /// projections in `proj_flavor` (`.q4` or `.f16`) and the 7 norms as
+        /// `.f16`.
+        fn write_full_mtp_fixture(dir: &std::path::Path, cfg: &Qwen35Config, proj_as_q4: bool) {
+            for (name, shape) in mtp_proj_names_and_shapes(cfg) {
+                if proj_as_q4 {
+                    write_tiny_q4_fixture(dir, name, &shape);
+                } else {
+                    write_tiny_f16_fixture(dir, name, &shape);
+                }
+            }
+            for (name, shape) in mtp_norm_names_and_shapes(cfg) {
+                write_tiny_f16_fixture(dir, name, &shape);
+            }
+        }
+
+        // --- CPU-only, Device-free coverage of the flavor/shape logic itself ---
+        // (round-1 medium #3: these never skip on a Metal-less CI runner.)
+
+        #[test]
+        fn resolve_mtp_projection_prefers_q4_when_allowed() {
+            let cfg = tiny_metal_qwen35_fixture().0;
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0]; // q_proj
+            write_tiny_q4_fixture(tmp.path(), name, shape);
+
+            let resolved =
+                resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
+                    .expect("plain Q4 dir must resolve the .q4 sibling");
+            assert!(
+                resolved.is_q4(),
+                "allow_q4=true with a .q4 file present must prefer the .q4 flavor"
+            );
+            assert_eq!(resolved.shape(), shape.as_slice());
+        }
+
+        #[test]
+        fn resolve_mtp_projection_falls_back_to_f16_when_q4_absent() {
+            let cfg = tiny_metal_qwen35_fixture().0;
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
+            write_tiny_f16_fixture(tmp.path(), name, shape);
+
+            let resolved =
+                resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
+                    .expect("QuaRot-shaped all-.f16 dir must resolve the .f16 sibling");
+            assert!(!resolved.is_q4(), "no .q4 file exists; must resolve .f16");
+        }
+
+        #[test]
+        fn resolve_mtp_projection_rejects_stale_q4_sibling_under_quarot() {
+            // Round-1 MAJOR: a QuaRot (rotated-space) checkpoint directory
+            // must never load an MTP `.q4` sibling even if one exists —
+            // that shape is reachable when `quantize_q4` is re-run into an
+            // existing QuaRot output dir (the converter reuses a non-empty
+            // output dir rather than rejecting it). Silently preferring
+            // `.q4` there would load rotated-space weights while
+            // counter-rotation (keyed off the same dir's `quarot_seed`)
+            // stays enabled, corrupting every MTP draft with no load
+            // failure to reveal it.
+            let cfg = tiny_metal_qwen35_fixture().0;
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
+            // Mixed/stale layout: BOTH a .q4 (leftover from a re-run
+            // quantize_q4) and the expected QuaRot .f16 exist side by side.
+            write_tiny_q4_fixture(tmp.path(), name, shape);
+            write_tiny_f16_fixture(tmp.path(), name, shape);
+
+            let err = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ false)
+                .expect_err(
+                    "allow_q4=false (QuaRot flavor) with a .q4 sibling present must fail closed",
+                );
+            let MtpLoadErr::Incompatible(message) = err else {
+                panic!("expected Incompatible, got {err:?}");
+            };
+            assert!(
+                message.contains("incompatible") && message.contains(".q4"),
+                "error must name the incompatible .q4 artifact; got: {message}"
+            );
+        }
+
+        #[test]
+        fn resolve_mtp_projection_rejects_transposed_q4_shape() {
+            // Round-1 medium #1: a same-numel transposed file must not
+            // silently load — it would generate tokens but produce garbage
+            // MTP drafts (0% accept class).
+            let cfg = tiny_metal_qwen35_fixture().0;
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0]; // q_proj: [2*q_dim, hidden]
+            let transposed: Vec<usize> = shape.iter().rev().copied().collect();
+            assert_ne!(
+                shape, &transposed,
+                "fixture cfg must have distinguishable q_proj dims for this test to be meaningful"
+            );
+            write_tiny_q4_fixture(tmp.path(), name, &transposed);
+
+            let err = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
+                .expect_err("a transposed same-numel .q4 tensor must be rejected, not accepted");
+            let MtpLoadErr::Incompatible(message) = err else {
+                panic!("expected Incompatible, got {err:?}");
+            };
+            assert!(
+                message.contains("shape"),
+                "error must name the shape mismatch; got: {message}"
+            );
+        }
+
+        #[test]
+        fn resolve_mtp_projection_rejects_transposed_f16_shape() {
+            let cfg = tiny_metal_qwen35_fixture().0;
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[6]; // down_proj: [hidden, inter]
+            let transposed: Vec<usize> = shape.iter().rev().copied().collect();
+            assert_ne!(
+                shape, &transposed,
+                "fixture cfg must have distinguishable down_proj dims for this test to be meaningful"
+            );
+            write_tiny_f16_fixture(tmp.path(), name, &transposed);
+
+            let err = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
+                .expect_err("a transposed same-numel .f16 tensor must be rejected, not accepted");
+            assert!(matches!(err, MtpLoadErr::Incompatible(_)));
+        }
+
+        #[test]
+        fn resolve_mtp_projection_reports_missing_when_neither_flavor_present() {
+            let cfg = tiny_metal_qwen35_fixture().0;
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
+
+            let err = resolve_mtp_projection(tmp.path(), name, shape, true)
+                .expect_err("neither flavor present must be Missing, not Ok");
+            assert!(matches!(err, MtpLoadErr::Missing(_)));
+        }
+
+        #[test]
+        fn resolve_mtp_norm_rejects_transposed_shape() {
+            let cfg = tiny_metal_qwen35_fixture().0;
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            // input_layernorm is [hidden]; use a 2-D reshape as the "wrong
+            // shape" stand-in since a 1-D vector has no transpose.
+            let name = "mtp.layers.0.input_layernorm.weight";
+            let hidden = cfg.hidden_size;
+            write_tiny_f16_fixture(tmp.path(), name, &[hidden, 1]);
+
+            let err = resolve_mtp_norm(tmp.path(), name, &[hidden])
+                .expect_err("a reshaped norm tensor must be rejected, not accepted");
+            assert!(matches!(err, MtpLoadErr::Incompatible(_)));
+        }
+
+        // --- Device-gated integration smoke on top of the CPU-only coverage above ---
 
         #[test]
         fn load_mtp_q4_weights_accepts_q4_projections_with_f16_norms() {
@@ -19104,31 +19478,27 @@ kernel void decode_attention_reference(
             // so it always reported the first projection as missing on
             // this exact directory layout (the real shape `quantize_q4`
             // ships) — reverting the fix must fail this assertion.
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
             let Some(device) = Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
                 return;
             };
             let (mut cfg, _weights) = tiny_metal_qwen35_fixture();
             cfg.mtp_num_hidden_layers = 1;
-            let hidden = cfg.hidden_size;
-            let intermediate = cfg.intermediate_size;
 
             let tmp = tempfile::tempdir().expect("tempdir create");
+            write_full_mtp_fixture(tmp.path(), &cfg, /* proj_as_q4 */ true);
 
-            for &name in &MTP_PROJ_NAMES {
-                let numel = if name.contains("gate_proj") || name.contains("up_proj") {
-                    intermediate * hidden
-                } else if name.contains("down_proj") {
-                    hidden * intermediate
-                } else {
-                    hidden * hidden
-                };
-                write_tiny_q4_fixture(tmp.path(), name, numel);
-            }
-            for &name in &MTP_NORM_NAMES {
-                write_tiny_f16_fixture(tmp.path(), name, hidden);
-            }
-
-            let result = MetalQwen35State::load_mtp_q4_weights(tmp.path(), &cfg, &device);
+            let result = MetalQwen35State::load_mtp_q4_weights(
+                tmp.path(),
+                &cfg,
+                &device,
+                /* is_quarot */ false,
+            )
+            .expect("well-formed plain-Q4 MTP directory must not hard-error");
 
             assert!(
                 result.weights.is_some(),
@@ -19146,23 +19516,27 @@ kernel void decode_attention_reference(
             // Phase 1). The Q4-preferring loader must fall back to `.f16`
             // when no `.q4` sibling exists, so this checkpoint flavor keeps
             // working exactly as before.
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
             let Some(device) = Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
                 return;
             };
             let (mut cfg, _weights) = tiny_metal_qwen35_fixture();
             cfg.mtp_num_hidden_layers = 1;
-            let hidden = cfg.hidden_size;
 
             let tmp = tempfile::tempdir().expect("tempdir create");
+            write_full_mtp_fixture(tmp.path(), &cfg, /* proj_as_q4 */ false);
 
-            for &name in &MTP_PROJ_NAMES {
-                write_tiny_f16_fixture(tmp.path(), name, hidden);
-            }
-            for &name in &MTP_NORM_NAMES {
-                write_tiny_f16_fixture(tmp.path(), name, hidden);
-            }
-
-            let result = MetalQwen35State::load_mtp_q4_weights(tmp.path(), &cfg, &device);
+            let result = MetalQwen35State::load_mtp_q4_weights(
+                tmp.path(),
+                &cfg,
+                &device,
+                /* is_quarot */ true,
+            )
+            .expect("well-formed all-.f16 QuaRot MTP directory must not hard-error");
 
             assert!(
                 result.weights.is_some(),
@@ -19178,7 +19552,12 @@ kernel void decode_attention_reference(
             // a `.f16` sibling, the loader must report it as missing (and
             // the caller falls back to the non-MTP decode path with a
             // warning) rather than silently loading garbage.
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
             let Some(device) = Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
                 return;
             };
             let (mut cfg, _weights) = tiny_metal_qwen35_fixture();
@@ -19187,7 +19566,8 @@ kernel void decode_attention_reference(
             let tmp = tempfile::tempdir().expect("tempdir create");
             // Deliberately write nothing — the directory is empty.
 
-            let result = MetalQwen35State::load_mtp_q4_weights(tmp.path(), &cfg, &device);
+            let result = MetalQwen35State::load_mtp_q4_weights(tmp.path(), &cfg, &device, false)
+                .expect("a genuinely-missing (not incompatible) artifact must not hard-error");
 
             assert!(
                 result.weights.is_none(),
@@ -19198,6 +19578,47 @@ kernel void decode_attention_reference(
                 result.first_missing_file.is_some(),
                 "load_mtp_q4_weights must report a first_missing_file when \
                  nothing is on disk"
+            );
+        }
+
+        #[test]
+        fn load_mtp_q4_weights_hard_errors_on_stale_q4_under_quarot() {
+            // Round-1 MAJOR integration coverage: a mixed/stale QuaRot
+            // directory (both .q4 and .f16 for a projection, is_quarot=true)
+            // must be a hard `Err`, not a gracefully-disabled `None` — this
+            // is the exact failure-open scenario codex flagged.
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(device) = Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let (mut cfg, _weights) = tiny_metal_qwen35_fixture();
+            cfg.mtp_num_hidden_layers = 1;
+
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            write_full_mtp_fixture(tmp.path(), &cfg, /* proj_as_q4 */ false);
+            // Stale leftover from a prior `quantize_q4` run into this dir.
+            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
+            write_tiny_q4_fixture(tmp.path(), name, shape);
+
+            let result = MetalQwen35State::load_mtp_q4_weights(
+                tmp.path(),
+                &cfg,
+                &device,
+                /* is_quarot */ true,
+            );
+            let Err(err) = result else {
+                panic!(
+                    "a stale MTP .q4 sibling under a QuaRot directory must hard-error, \
+                     not silently disable MTP or silently load the .q4"
+                )
+            };
+            assert!(
+                err.contains("incompatible") && err.contains(".q4"),
+                "error must name the incompatible .q4 artifact; got: {err}"
             );
         }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -26,13 +26,534 @@
 //! q/k/v/o_proj) and embed_tokens. Buffers kept as f32: norm weights, bias/log scalars,
 //! conv1d weights (small, read by CPU), RoPE tables, activation scratch buffers.
 
+// -----------------------------------------------------------------------------
+// MTP Q4/F16 tensor resolution (#630, #636) -- pure, `Device`-free, compiled
+// unconditionally in test builds (round-2 fix: these previously lived inside
+// `mod inner`, gated on `metal-gpu`, so `cargo test -p lattice-inference --lib
+// resolve_mtp` with no features reported "running 0 tests" -- the exact
+// skip-pass class round 1 flagged, just one layer up. `mod inner` re-imports
+// these via `use super::{...}` below.)
+// -----------------------------------------------------------------------------
+
+/// Build the sanitized MTP tensor file path (dots/slashes -> underscores),
+/// mirroring `MetalQwen35State::q4_tensor_path` -- duplicated here (rather than
+/// called through `MetalQwen35State`, which only exists under `metal-gpu`) so
+/// this module compiles and is unit-testable without the Metal feature at all
+/// (#636 round-2).
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+fn mtp_tensor_path(dir: &std::path::Path, tensor_name: &str, ext: &str) -> std::path::PathBuf {
+    let sanitized: String = tensor_name
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    dir.join(format!("{sanitized}.{ext}"))
+}
+
+/// Failure modes for resolving a single MTP tensor from disk (#636 round-1).
+///
+/// `Missing` is the pre-existing graceful case: the caller (the MTP
+/// projection-load closure in [`load_mtp_q4_weights`]) turns it into a
+/// warn-and-fall-back-to-non-MTP-decode result via
+/// [`mtp_missing_weights_warning`]. `Incompatible` is new and
+/// deliberately NOT graceful: it means the on-disk artifact exists but
+/// cannot be trusted (a stale `.q4` sibling in a QuaRot rotated-space
+/// checkpoint, or a shape/transpose mismatch) — silently disabling MTP
+/// would be safe, but silently *loading* it would produce garbage
+/// drafts, so this propagates as a hard `from_q4_dir` load error
+/// instead.
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+#[derive(Debug)]
+enum MtpLoadErr {
+    // The path is read by the real `metal-gpu` production caller
+    // (`load_mtp_q4_weights`) but only via `matches!` in the pure
+    // default-feature-only tests, so it looks unused in that specific
+    // build configuration.
+    Missing(#[allow(dead_code)] std::path::PathBuf),
+    Incompatible(String),
+}
+
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+impl From<std::path::PathBuf> for MtpLoadErr {
+    fn from(path: std::path::PathBuf) -> Self {
+        MtpLoadErr::Missing(path)
+    }
+}
+
+/// One MTP tensor's values as read from disk, before Metal buffer
+/// creation — deliberately `Device`-free so flavor selection and shape
+/// validation are unit-testable without a GPU (#636 round-1 medium #3).
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+#[derive(Debug)]
+enum MtpTensorSource {
+    F16 {
+        // Read by the real `metal-gpu` production caller
+        // (`load_mtp_q4_weights`'s `load_proj_as_half`); only the
+        // `#[cfg(test)]`-only `shape()`/`is_q4()` accessors read this in a
+        // default-feature (no metal-gpu) test-only build.
+        #[allow(dead_code)]
+        values: Vec<f32>,
+        #[allow(dead_code)] // read via `shape()`, only exercised by `#[cfg(test)]` callers
+        shape: Vec<usize>,
+    },
+    Q4(crate::weights::q4_weights::Q4Tensor),
+}
+
+#[cfg(test)]
+impl MtpTensorSource {
+    /// Test-only accessor for the resolved on-disk shape, used to assert
+    /// which flavor + shape a `resolve_mtp_projection` call picked
+    /// without needing a Metal `Device`.
+    fn shape(&self) -> &[usize] {
+        match self {
+            MtpTensorSource::F16 { shape, .. } => shape,
+            MtpTensorSource::Q4(tensor) => &tensor.shape,
+        }
+    }
+
+    fn is_q4(&self) -> bool {
+        matches!(self, MtpTensorSource::Q4(_))
+    }
+}
+
+/// Resolve one of the 8 MTP projection matrices from `q4_dir`, pure
+/// CPU I/O only (no `Device`).
+///
+/// `quantize_q4` applies the same `should_quantize` name-suffix rule to
+/// MTP tensors as to the main model, so the 8 `*_proj*.weight` MTP
+/// matrices are written as `.q4` on a plain (non-rotated) Q4 checkpoint.
+/// `quantize_quarot` instead keeps every MTP tensor as unrotated `.f16`
+/// (ADR-051 Phase 1: MTP counter-rotation needs unquantized weights),
+/// and MUST NOT have a `.q4` sibling for any MTP tensor.
+///
+/// `allow_q4` therefore encodes the checkpoint flavor, determined by
+/// the caller BEFORE any projection is loaded (not sniffed per-file):
+/// `true` for a plain Q4 checkpoint (no QuaRot rotation seed anywhere),
+/// `false` for a QuaRot checkpoint. When `allow_q4` is `false` and a
+/// `.q4` sibling exists anyway, that is an incompatible stale artifact
+/// — `quantize_q4` was re-run into a QuaRot output directory (the
+/// converter reuses a non-empty output dir rather than rejecting it),
+/// producing rotated-space `.q4` weights that the runtime's
+/// counter-rotation (keyed off the same directory's `quarot_seed`)
+/// would silently apply on top of, corrupting every MTP draft without
+/// any load failure to reveal it (#636 round-1 MAJOR). This is
+/// rejected loudly instead of silently preferring `.f16`.
+///
+/// Also validates the resolved tensor's on-disk shape against
+/// `expected_shape`: a same-numel transposed file loads and generates
+/// tokens but produces garbage MTP drafts (#636 round-1 medium #1), so
+/// shape mismatches are rejected the same way as an incompatible
+/// artifact rather than silently accepted.
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+fn resolve_mtp_projection(
+    q4_dir: &std::path::Path,
+    name: &str,
+    expected_shape: &[usize],
+    allow_q4: bool,
+) -> Result<MtpTensorSource, MtpLoadErr> {
+    use crate::weights::q4_weights::{load_f16_tensor_file, load_q4_file};
+
+    let q4_path = mtp_tensor_path(q4_dir, name, "q4");
+    if q4_path.exists() {
+        if !allow_q4 {
+            return Err(MtpLoadErr::Incompatible(format!(
+                "{}: incompatible stale MTP .q4 artifact found alongside a QuaRot \
+                 (rotated-space) checkpoint; QuaRot Phase 1 requires MTP projections \
+                 to remain unrotated .f16 — a .q4 sibling here means quantize_q4 was \
+                 re-run into a QuaRot output directory, and loading it would silently \
+                 apply counter-rotation on top of already-rotated-space weights, \
+                 corrupting every MTP draft without a load failure to reveal it. \
+                 Refusing to load — delete the stale .q4 file or regenerate the \
+                 checkpoint.",
+                q4_path.display()
+            )));
+        }
+        let tensor = load_q4_file(&q4_path).map_err(|_| MtpLoadErr::Missing(q4_path.clone()))?;
+        if tensor.shape != expected_shape {
+            return Err(MtpLoadErr::Incompatible(format!(
+                "{}: MTP tensor '{name}' has shape {:?}, expected {expected_shape:?} — \
+                 refusing to load (a mismatched/transposed weight file loads and \
+                 generates tokens but silently produces garbage MTP drafts)",
+                q4_path.display(),
+                tensor.shape
+            )));
+        }
+        return Ok(MtpTensorSource::Q4(tensor));
+    }
+
+    let f16_path = mtp_tensor_path(q4_dir, name, "f16");
+    if !f16_path.exists() {
+        return Err(MtpLoadErr::Missing(f16_path));
+    }
+    let (values, shape) =
+        load_f16_tensor_file(&f16_path).map_err(|_| MtpLoadErr::Missing(f16_path.clone()))?;
+    if shape != expected_shape {
+        return Err(MtpLoadErr::Incompatible(format!(
+            "{}: MTP tensor '{name}' has shape {shape:?}, expected {expected_shape:?} — \
+             refusing to load (a mismatched/transposed weight file loads and generates \
+             tokens but silently produces garbage MTP drafts)",
+            f16_path.display()
+        )));
+    }
+    Ok(MtpTensorSource::F16 { values, shape })
+}
+
+/// Resolve one of the 7 MTP norm tensors from `q4_dir`, pure CPU I/O
+/// only (no `Device`). Norms are never quantized by `should_quantize`
+/// in either quantizer, so they are always `.f16`-only regardless of
+/// checkpoint flavor; a `.q4` sibling under a norm's name is treated
+/// as an incompatible artifact rather than silently ignored (defense
+/// in depth — should never occur on a checkpoint from either
+/// quantizer). Also validates on-disk shape (#636 round-1 medium #1).
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+fn resolve_mtp_norm(
+    q4_dir: &std::path::Path,
+    name: &str,
+    expected_shape: &[usize],
+) -> Result<(Vec<f32>, Vec<usize>), MtpLoadErr> {
+    use crate::weights::q4_weights::load_f16_tensor_file;
+
+    let q4_path = mtp_tensor_path(q4_dir, name, "q4");
+    if q4_path.exists() {
+        return Err(MtpLoadErr::Incompatible(format!(
+            "{}: unexpected MTP .q4 artifact for norm tensor '{name}' — norms are never \
+             quantized by either quantizer; refusing to load an incompatible checkpoint",
+            q4_path.display()
+        )));
+    }
+    let f16_path = mtp_tensor_path(q4_dir, name, "f16");
+    if !f16_path.exists() {
+        return Err(MtpLoadErr::Missing(f16_path));
+    }
+    let (values, shape) =
+        load_f16_tensor_file(&f16_path).map_err(|_| MtpLoadErr::Missing(f16_path.clone()))?;
+    if shape != expected_shape {
+        return Err(MtpLoadErr::Incompatible(format!(
+            "{}: MTP norm tensor '{name}' has shape {shape:?}, expected \
+             {expected_shape:?} — refusing to load",
+            f16_path.display()
+        )));
+    }
+    Ok((values, shape))
+}
+
+#[cfg(test)]
+mod mtp_resolve_tests {
+    use super::*;
+    use crate::model::qwen35_config::{LayerType, Qwen35Config};
+
+    /// Minimal `Qwen35Config` for the pure `resolve_mtp_*` tests: no
+    /// `ModelWeights`/Metal `Device` construction at all (unlike
+    /// `tiny_metal_qwen35_fixture`, which lives inside `mod inner` and is
+    /// gated on the `metal-gpu` feature -- these tests must not depend on
+    /// it, or they'd silently disappear again on a Metal-less/no-feature
+    /// build, exactly the round-1/round-2 skip-pass class). Field values
+    /// mirror `tiny_metal_qwen35_fixture`'s config so the derived MTP
+    /// projection/norm shapes match the same real-checkpoint-verified
+    /// formulas.
+    fn tiny_mtp_test_config() -> Qwen35Config {
+        Qwen35Config {
+            hidden_size: 512,
+            num_hidden_layers: 1,
+            vocab_size: 64,
+            intermediate_size: 64,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: 2,
+            num_key_value_heads: 1,
+            head_dim: 256,
+            rope_theta: 10_000_000.0,
+            partial_rotary_factor: 0.25,
+            rope_parameters: None,
+            linear_num_key_heads: 1,
+            linear_num_value_heads: Some(1),
+            linear_key_head_dim: 16,
+            linear_value_head_dim: 16,
+            linear_conv_kernel_dim: 4,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            mtp_num_hidden_layers: 1,
+            mtp_use_dedicated_embeddings: false,
+            full_attention_interval: 1,
+            layer_types: vec![LayerType::FullAttention],
+            layer_mask: vec![true],
+            eos_token_id: 63,
+            max_position_embeddings: 128,
+            quarot_rotation_seed: None,
+        }
+    }
+
+    // MTP Q4/F16 tensor resolution (#630, #636): `quantize_q4` applies its
+    // `should_quantize` name-suffix rule to MTP tensor names exactly like the
+    // main model, so the 8 `*_proj*` matrices (q/k/v/o_proj, gate/up/down_proj,
+    // fc) are written as `.q4` while the 7 norm tensors are written as `.f16`.
+    // `quantize_quarot` instead keeps ALL 15 MTP tensors as unrotated `.f16`
+    // (ADR-051 Phase 1: MTP counter-rotation needs unquantized weights).
+    // `resolve_mtp_projection`/`resolve_mtp_norm` must accept both flavors,
+    // reject a stale `.q4` MTP sibling under a QuaRot (`is_quarot=true`)
+    // directory (round-1 MAJOR), and reject a transposed/mismatched tensor
+    // shape (round-1 medium #1). These tests live at the file top level,
+    // compiled unconditionally in any test build -- not gated on `metal-gpu`
+    // -- so this coverage never skip-passes on a Metal-less CI runner
+    // (round-1 medium #3, hardened further in round 2: see the module doc
+    // comment above `mtp_tensor_path` for why this code moved out of
+    // `mod inner` entirely).
+
+    /// Write a tiny `.f16` (KHF1) tensor file with the given `shape`,
+    /// filled with copies of `1.0`, mirroring the format
+    /// `load_f16_tensor_file` reads (crates/inference/src/weights/q4_weights.rs).
+    pub(crate) fn write_tiny_f16_fixture(dir: &std::path::Path, name: &str, shape: &[usize]) {
+        use crate::weights::q4_weights::q4_f32_to_f16;
+        let numel: usize = shape.iter().product();
+        let path = mtp_tensor_path(dir, name, "f16");
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"KHF1");
+        buf.extend_from_slice(&1u32.to_le_bytes()); // version
+        buf.extend_from_slice(&(shape.len() as u32).to_le_bytes()); // ndim
+        for &dim in shape {
+            buf.extend_from_slice(&(dim as u64).to_le_bytes());
+        }
+        buf.extend_from_slice(&(numel as u64).to_le_bytes()); // numel
+        for _ in 0..numel {
+            buf.extend_from_slice(&q4_f32_to_f16(1.0).to_le_bytes());
+        }
+        std::fs::write(&path, buf).expect("write .f16 fixture");
+    }
+
+    /// Write a tiny `.q4` tensor file with the given `shape`, filled with
+    /// copies of `0.1`.
+    pub(crate) fn write_tiny_q4_fixture(dir: &std::path::Path, name: &str, shape: &[usize]) {
+        use crate::weights::q4_weights::{quantize_f32_to_q4, save_q4_file};
+        let numel: usize = shape.iter().product();
+        let data = vec![0.1f32; numel];
+        let tensor = quantize_f32_to_q4(&data, shape).expect("quantize tiny tensor");
+        let path = mtp_tensor_path(dir, name, "q4");
+        save_q4_file(&path, &tensor).expect("save .q4 fixture");
+    }
+
+    /// The 8 MTP projection tensor names paired with their expected
+    /// on-disk shape, derived from the real qwen3.5-0.8b-q4 checkpoint
+    /// (`~/.lattice/models/qwen3.5-0.8b-q4/mtp_*.q4` headers, verified by
+    /// hand during #636 round-1 remediation): on-disk shape is always
+    /// `[d_out, d_in]`, matching `expected_lora_shape`'s `(d_in, d_out)`
+    /// convention reversed.
+    pub(crate) fn mtp_proj_names_and_shapes(cfg: &Qwen35Config) -> [(&'static str, Vec<usize>); 8] {
+        let hidden = cfg.hidden_size;
+        let q_dim = cfg.full_q_dim();
+        let kv_dim = cfg.full_kv_dim();
+        let inter = cfg.intermediate_size;
+        [
+            (
+                "mtp.layers.0.self_attn.q_proj.weight",
+                vec![2 * q_dim, hidden],
+            ),
+            ("mtp.layers.0.self_attn.k_proj.weight", vec![kv_dim, hidden]),
+            ("mtp.layers.0.self_attn.v_proj.weight", vec![kv_dim, hidden]),
+            ("mtp.layers.0.self_attn.o_proj.weight", vec![hidden, q_dim]),
+            ("mtp.layers.0.mlp.gate_proj.weight", vec![inter, hidden]),
+            ("mtp.layers.0.mlp.up_proj.weight", vec![inter, hidden]),
+            ("mtp.layers.0.mlp.down_proj.weight", vec![hidden, inter]),
+            ("mtp.fc.weight", vec![hidden, 2 * hidden]),
+        ]
+    }
+
+    /// The 7 MTP norm tensor names paired with their expected shape —
+    /// never quantized (`should_quantize` excludes anything containing
+    /// `norm.weight`). `q_norm`/`k_norm` are `[head_dim]`; the rest are
+    /// `[hidden]`.
+    // Only reachable via `write_full_mtp_fixture` (see its own
+    // `#[allow(dead_code)]` note above).
+    #[allow(dead_code)]
+    fn mtp_norm_names_and_shapes(cfg: &Qwen35Config) -> [(&'static str, Vec<usize>); 7] {
+        let hidden = cfg.hidden_size;
+        let head_dim = cfg.head_dim;
+        [
+            ("mtp.layers.0.input_layernorm.weight", vec![hidden]),
+            ("mtp.layers.0.post_attention_layernorm.weight", vec![hidden]),
+            ("mtp.layers.0.self_attn.q_norm.weight", vec![head_dim]),
+            ("mtp.layers.0.self_attn.k_norm.weight", vec![head_dim]),
+            ("mtp.norm.weight", vec![hidden]),
+            ("mtp.pre_fc_norm_embedding.weight", vec![hidden]),
+            ("mtp.pre_fc_norm_hidden.weight", vec![hidden]),
+        ]
+    }
+
+    /// Write a complete, well-formed MTP tensor set to `dir`: the 8
+    /// projections in `proj_flavor` (`.q4` or `.f16`) and the 7 norms as
+    /// `.f16`.
+    // Only consumed by the Device-gated integration tests in `mod
+    // inner::tests`, which don't exist in a default-feature (no
+    // metal-gpu) build -- looks dead in that configuration.
+    #[allow(dead_code)]
+    pub(crate) fn write_full_mtp_fixture(
+        dir: &std::path::Path,
+        cfg: &Qwen35Config,
+        proj_as_q4: bool,
+    ) {
+        for (name, shape) in mtp_proj_names_and_shapes(cfg) {
+            if proj_as_q4 {
+                write_tiny_q4_fixture(dir, name, &shape);
+            } else {
+                write_tiny_f16_fixture(dir, name, &shape);
+            }
+        }
+        for (name, shape) in mtp_norm_names_and_shapes(cfg) {
+            write_tiny_f16_fixture(dir, name, &shape);
+        }
+    }
+
+    // --- CPU-only, Device-free coverage of the flavor/shape logic itself ---
+    // (round-1 medium #3: these never skip on a Metal-less CI runner.)
+
+    #[test]
+    fn resolve_mtp_projection_prefers_q4_when_allowed() {
+        let cfg = tiny_mtp_test_config();
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0]; // q_proj
+        write_tiny_q4_fixture(tmp.path(), name, shape);
+
+        let resolved = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
+            .expect("plain Q4 dir must resolve the .q4 sibling");
+        assert!(
+            resolved.is_q4(),
+            "allow_q4=true with a .q4 file present must prefer the .q4 flavor"
+        );
+        assert_eq!(resolved.shape(), shape.as_slice());
+    }
+
+    #[test]
+    fn resolve_mtp_projection_falls_back_to_f16_when_q4_absent() {
+        let cfg = tiny_mtp_test_config();
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
+        write_tiny_f16_fixture(tmp.path(), name, shape);
+
+        let resolved = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
+            .expect("QuaRot-shaped all-.f16 dir must resolve the .f16 sibling");
+        assert!(!resolved.is_q4(), "no .q4 file exists; must resolve .f16");
+    }
+
+    #[test]
+    fn resolve_mtp_projection_rejects_stale_q4_sibling_under_quarot() {
+        // Round-1 MAJOR: a QuaRot (rotated-space) checkpoint directory
+        // must never load an MTP `.q4` sibling even if one exists —
+        // that shape is reachable when `quantize_q4` is re-run into an
+        // existing QuaRot output dir (the converter reuses a non-empty
+        // output dir rather than rejecting it). Silently preferring
+        // `.q4` there would load rotated-space weights while
+        // counter-rotation (keyed off the same dir's `quarot_seed`)
+        // stays enabled, corrupting every MTP draft with no load
+        // failure to reveal it.
+        let cfg = tiny_mtp_test_config();
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
+        // Mixed/stale layout: BOTH a .q4 (leftover from a re-run
+        // quantize_q4) and the expected QuaRot .f16 exist side by side.
+        write_tiny_q4_fixture(tmp.path(), name, shape);
+        write_tiny_f16_fixture(tmp.path(), name, shape);
+
+        let err = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ false).expect_err(
+            "allow_q4=false (QuaRot flavor) with a .q4 sibling present must fail closed",
+        );
+        let MtpLoadErr::Incompatible(message) = err else {
+            panic!("expected Incompatible, got {err:?}");
+        };
+        assert!(
+            message.contains("incompatible") && message.contains(".q4"),
+            "error must name the incompatible .q4 artifact; got: {message}"
+        );
+    }
+
+    #[test]
+    fn resolve_mtp_projection_rejects_transposed_q4_shape() {
+        // Round-1 medium #1: a same-numel transposed file must not
+        // silently load — it would generate tokens but produce garbage
+        // MTP drafts (0% accept class).
+        let cfg = tiny_mtp_test_config();
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0]; // q_proj: [2*q_dim, hidden]
+        let transposed: Vec<usize> = shape.iter().rev().copied().collect();
+        assert_ne!(
+            shape, &transposed,
+            "fixture cfg must have distinguishable q_proj dims for this test to be meaningful"
+        );
+        write_tiny_q4_fixture(tmp.path(), name, &transposed);
+
+        let err = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
+            .expect_err("a transposed same-numel .q4 tensor must be rejected, not accepted");
+        let MtpLoadErr::Incompatible(message) = err else {
+            panic!("expected Incompatible, got {err:?}");
+        };
+        assert!(
+            message.contains("shape"),
+            "error must name the shape mismatch; got: {message}"
+        );
+    }
+
+    #[test]
+    fn resolve_mtp_projection_rejects_transposed_f16_shape() {
+        let cfg = tiny_mtp_test_config();
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[6]; // down_proj: [hidden, inter]
+        let transposed: Vec<usize> = shape.iter().rev().copied().collect();
+        assert_ne!(
+            shape, &transposed,
+            "fixture cfg must have distinguishable down_proj dims for this test to be meaningful"
+        );
+        write_tiny_f16_fixture(tmp.path(), name, &transposed);
+
+        let err = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
+            .expect_err("a transposed same-numel .f16 tensor must be rejected, not accepted");
+        assert!(matches!(err, MtpLoadErr::Incompatible(_)));
+    }
+
+    #[test]
+    fn resolve_mtp_projection_reports_missing_when_neither_flavor_present() {
+        let cfg = tiny_mtp_test_config();
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
+
+        let err = resolve_mtp_projection(tmp.path(), name, shape, true)
+            .expect_err("neither flavor present must be Missing, not Ok");
+        assert!(matches!(err, MtpLoadErr::Missing(_)));
+    }
+
+    #[test]
+    fn resolve_mtp_norm_rejects_transposed_shape() {
+        let cfg = tiny_mtp_test_config();
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        // input_layernorm is [hidden]; use a 2-D reshape as the "wrong
+        // shape" stand-in since a 1-D vector has no transpose.
+        let name = "mtp.layers.0.input_layernorm.weight";
+        let hidden = cfg.hidden_size;
+        write_tiny_f16_fixture(tmp.path(), name, &[hidden, 1]);
+
+        let err = resolve_mtp_norm(tmp.path(), name, &[hidden])
+            .expect_err("a reshaped norm tensor must be rejected, not accepted");
+        assert!(matches!(err, MtpLoadErr::Incompatible(_)));
+    }
+}
+
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 mod inner {
     use super::GdnStateTrafficScope;
+    // MTP Q4/F16 flavor + shape resolution (#630, #636) now lives at the file
+    // top level (module-scope, above `mod inner`) so it compiles and is
+    // unit-testable without the `metal-gpu` feature at all (round-2 fix).
     #[cfg(feature = "gdn-state-counters")]
     use super::{
         GdnStateCopyKind, GdnStateTrafficCounters, GdnStateTrafficReport, GdnStateTrafficShape,
     };
+    use super::{MtpLoadErr, MtpTensorSource, resolve_mtp_norm, resolve_mtp_projection};
     use crate::attention::gdn::GatedDeltaNetState;
     use crate::attention::gdn_fused::GatedDeltaNetFusedScratch;
     #[cfg(debug_assertions)]
@@ -14374,180 +14895,6 @@ kernel void gdn_chunk_norm_silu_c32(
         prompt
     }
 
-    /// Failure modes for resolving a single MTP tensor from disk (#636 round-1).
-    ///
-    /// `Missing` is the pre-existing graceful case: the caller (the MTP
-    /// projection-load closure in [`load_mtp_q4_weights`]) turns it into a
-    /// warn-and-fall-back-to-non-MTP-decode result via
-    /// [`mtp_missing_weights_warning`]. `Incompatible` is new and
-    /// deliberately NOT graceful: it means the on-disk artifact exists but
-    /// cannot be trusted (a stale `.q4` sibling in a QuaRot rotated-space
-    /// checkpoint, or a shape/transpose mismatch) — silently disabling MTP
-    /// would be safe, but silently *loading* it would produce garbage
-    /// drafts, so this propagates as a hard `from_q4_dir` load error
-    /// instead.
-    #[derive(Debug)]
-    enum MtpLoadErr {
-        Missing(std::path::PathBuf),
-        Incompatible(String),
-    }
-
-    impl From<std::path::PathBuf> for MtpLoadErr {
-        fn from(path: std::path::PathBuf) -> Self {
-            MtpLoadErr::Missing(path)
-        }
-    }
-
-    /// One MTP tensor's values as read from disk, before Metal buffer
-    /// creation — deliberately `Device`-free so flavor selection and shape
-    /// validation are unit-testable without a GPU (#636 round-1 medium #3).
-    #[derive(Debug)]
-    enum MtpTensorSource {
-        F16 {
-            values: Vec<f32>,
-            #[allow(dead_code)] // read via `shape()`, only exercised by `#[cfg(test)]` callers
-            shape: Vec<usize>,
-        },
-        Q4(crate::weights::q4_weights::Q4Tensor),
-    }
-
-    #[cfg(test)]
-    impl MtpTensorSource {
-        /// Test-only accessor for the resolved on-disk shape, used to assert
-        /// which flavor + shape a `resolve_mtp_projection` call picked
-        /// without needing a Metal `Device`.
-        fn shape(&self) -> &[usize] {
-            match self {
-                MtpTensorSource::F16 { shape, .. } => shape,
-                MtpTensorSource::Q4(tensor) => &tensor.shape,
-            }
-        }
-
-        fn is_q4(&self) -> bool {
-            matches!(self, MtpTensorSource::Q4(_))
-        }
-    }
-
-    /// Resolve one of the 8 MTP projection matrices from `q4_dir`, pure
-    /// CPU I/O only (no `Device`).
-    ///
-    /// `quantize_q4` applies the same `should_quantize` name-suffix rule to
-    /// MTP tensors as to the main model, so the 8 `*_proj*.weight` MTP
-    /// matrices are written as `.q4` on a plain (non-rotated) Q4 checkpoint.
-    /// `quantize_quarot` instead keeps every MTP tensor as unrotated `.f16`
-    /// (ADR-051 Phase 1: MTP counter-rotation needs unquantized weights),
-    /// and MUST NOT have a `.q4` sibling for any MTP tensor.
-    ///
-    /// `allow_q4` therefore encodes the checkpoint flavor, determined by
-    /// the caller BEFORE any projection is loaded (not sniffed per-file):
-    /// `true` for a plain Q4 checkpoint (no QuaRot rotation seed anywhere),
-    /// `false` for a QuaRot checkpoint. When `allow_q4` is `false` and a
-    /// `.q4` sibling exists anyway, that is an incompatible stale artifact
-    /// — `quantize_q4` was re-run into a QuaRot output directory (the
-    /// converter reuses a non-empty output dir rather than rejecting it),
-    /// producing rotated-space `.q4` weights that the runtime's
-    /// counter-rotation (keyed off the same directory's `quarot_seed`)
-    /// would silently apply on top of, corrupting every MTP draft without
-    /// any load failure to reveal it (#636 round-1 MAJOR). This is
-    /// rejected loudly instead of silently preferring `.f16`.
-    ///
-    /// Also validates the resolved tensor's on-disk shape against
-    /// `expected_shape`: a same-numel transposed file loads and generates
-    /// tokens but produces garbage MTP drafts (#636 round-1 medium #1), so
-    /// shape mismatches are rejected the same way as an incompatible
-    /// artifact rather than silently accepted.
-    fn resolve_mtp_projection(
-        q4_dir: &std::path::Path,
-        name: &str,
-        expected_shape: &[usize],
-        allow_q4: bool,
-    ) -> Result<MtpTensorSource, MtpLoadErr> {
-        use crate::weights::q4_weights::{load_f16_tensor_file, load_q4_file};
-
-        let q4_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "q4");
-        if q4_path.exists() {
-            if !allow_q4 {
-                return Err(MtpLoadErr::Incompatible(format!(
-                    "{}: incompatible stale MTP .q4 artifact found alongside a QuaRot \
-                     (rotated-space) checkpoint; QuaRot Phase 1 requires MTP projections \
-                     to remain unrotated .f16 — a .q4 sibling here means quantize_q4 was \
-                     re-run into a QuaRot output directory, and loading it would silently \
-                     apply counter-rotation on top of already-rotated-space weights, \
-                     corrupting every MTP draft without a load failure to reveal it. \
-                     Refusing to load — delete the stale .q4 file or regenerate the \
-                     checkpoint.",
-                    q4_path.display()
-                )));
-            }
-            let tensor =
-                load_q4_file(&q4_path).map_err(|_| MtpLoadErr::Missing(q4_path.clone()))?;
-            if tensor.shape != expected_shape {
-                return Err(MtpLoadErr::Incompatible(format!(
-                    "{}: MTP tensor '{name}' has shape {:?}, expected {expected_shape:?} — \
-                     refusing to load (a mismatched/transposed weight file loads and \
-                     generates tokens but silently produces garbage MTP drafts)",
-                    q4_path.display(),
-                    tensor.shape
-                )));
-            }
-            return Ok(MtpTensorSource::Q4(tensor));
-        }
-
-        let f16_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "f16");
-        if !f16_path.exists() {
-            return Err(MtpLoadErr::Missing(f16_path));
-        }
-        let (values, shape) =
-            load_f16_tensor_file(&f16_path).map_err(|_| MtpLoadErr::Missing(f16_path.clone()))?;
-        if shape != expected_shape {
-            return Err(MtpLoadErr::Incompatible(format!(
-                "{}: MTP tensor '{name}' has shape {shape:?}, expected {expected_shape:?} — \
-                 refusing to load (a mismatched/transposed weight file loads and generates \
-                 tokens but silently produces garbage MTP drafts)",
-                f16_path.display()
-            )));
-        }
-        Ok(MtpTensorSource::F16 { values, shape })
-    }
-
-    /// Resolve one of the 7 MTP norm tensors from `q4_dir`, pure CPU I/O
-    /// only (no `Device`). Norms are never quantized by `should_quantize`
-    /// in either quantizer, so they are always `.f16`-only regardless of
-    /// checkpoint flavor; a `.q4` sibling under a norm's name is treated
-    /// as an incompatible artifact rather than silently ignored (defense
-    /// in depth — should never occur on a checkpoint from either
-    /// quantizer). Also validates on-disk shape (#636 round-1 medium #1).
-    fn resolve_mtp_norm(
-        q4_dir: &std::path::Path,
-        name: &str,
-        expected_shape: &[usize],
-    ) -> Result<(Vec<f32>, Vec<usize>), MtpLoadErr> {
-        use crate::weights::q4_weights::load_f16_tensor_file;
-
-        let q4_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "q4");
-        if q4_path.exists() {
-            return Err(MtpLoadErr::Incompatible(format!(
-                "{}: unexpected MTP .q4 artifact for norm tensor '{name}' — norms are never \
-                 quantized by either quantizer; refusing to load an incompatible checkpoint",
-                q4_path.display()
-            )));
-        }
-        let f16_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "f16");
-        if !f16_path.exists() {
-            return Err(MtpLoadErr::Missing(f16_path));
-        }
-        let (values, shape) =
-            load_f16_tensor_file(&f16_path).map_err(|_| MtpLoadErr::Missing(f16_path.clone()))?;
-        if shape != expected_shape {
-            return Err(MtpLoadErr::Incompatible(format!(
-                "{}: MTP norm tensor '{name}' has shape {shape:?}, expected \
-                 {expected_shape:?} — refusing to load",
-                f16_path.display()
-            )));
-        }
-        Ok((values, shape))
-    }
-
     impl MetalQwen35State {
         /// **Unstable**: chat completion; stop token handling and output format may change.
         ///
@@ -17279,6 +17626,14 @@ kernel void gdn_chunk_norm_silu_c32(
             LM_HEAD_TOPK_TIE_EPSILON, LM_HEAD_TOPK_TIE_EPSILON_Q4, TopkSetAgreement,
             topk_set_agreement_or_boundary_tie,
         };
+        // Fixture helpers for the MTP Q4/F16 loader tests below now live in
+        // the top-level `mtp_resolve_tests` module (round-2: moved out of
+        // `mod inner` so the pure resolver tests compile without
+        // `metal-gpu` -- these Device-gated integration tests still share
+        // the same fixture writers).
+        use super::super::mtp_resolve_tests::{
+            mtp_proj_names_and_shapes, write_full_mtp_fixture, write_tiny_q4_fixture,
+        };
         use super::*;
         use crate::model::qwen35::{
             CommonLayerWeights, DenseFfnWeights, FeedForwardWeights, FullAttentionLayerWeights,
@@ -19224,249 +19579,18 @@ kernel void decode_attention_reference(
         }
 
         // -------------------------------------------------------------------
-        // load_mtp_q4_weights: Q4-or-F16 MTP projection loading (#630, #636)
+        // load_mtp_q4_weights: Device-gated integration smoke (#630, #636)
         // -------------------------------------------------------------------
         //
-        // `quantize_q4` applies its `should_quantize` name-suffix rule to
-        // MTP tensor names exactly like the main model: the 8 `*_proj*`
-        // matrices (q/k/v/o_proj, gate/up/down_proj, fc) are written as
-        // `.q4`, while the 7 norm tensors are written as `.f16`.
-        // `quantize_quarot` instead keeps ALL 15 MTP tensors as unrotated
-        // `.f16` (ADR-051 Phase 1: MTP counter-rotation needs unquantized
-        // weights). `load_mtp_q4_weights` must accept both flavors, reject a
-        // stale `.q4` MTP sibling under a QuaRot (`is_quarot=true`) directory
-        // (round-1 MAJOR), and reject a transposed/mismatched tensor shape
-        // (round-1 medium #1). `resolve_mtp_projection`/`resolve_mtp_norm`
-        // are `Device`-free, so the flavor/shape logic itself is covered by
-        // CPU-only tests below that never skip on a Metal-less CI runner
-        // (round-1 medium #3); the `load_mtp_q4_weights` tests further down
-        // stay as `Device`-gated integration smoke on top of that.
-
-        /// Write a tiny `.f16` (KHF1) tensor file with the given `shape`,
-        /// filled with copies of `1.0`, mirroring the format
-        /// `load_f16_tensor_file` reads (crates/inference/src/weights/q4_weights.rs).
-        fn write_tiny_f16_fixture(dir: &std::path::Path, name: &str, shape: &[usize]) {
-            use crate::weights::q4_weights::q4_f32_to_f16;
-            let numel: usize = shape.iter().product();
-            let path = MetalQwen35State::q4_tensor_path(dir, name, "f16");
-            let mut buf = Vec::new();
-            buf.extend_from_slice(b"KHF1");
-            buf.extend_from_slice(&1u32.to_le_bytes()); // version
-            buf.extend_from_slice(&(shape.len() as u32).to_le_bytes()); // ndim
-            for &dim in shape {
-                buf.extend_from_slice(&(dim as u64).to_le_bytes());
-            }
-            buf.extend_from_slice(&(numel as u64).to_le_bytes()); // numel
-            for _ in 0..numel {
-                buf.extend_from_slice(&q4_f32_to_f16(1.0).to_le_bytes());
-            }
-            std::fs::write(&path, buf).expect("write .f16 fixture");
-        }
-
-        /// Write a tiny `.q4` tensor file with the given `shape`, filled with
-        /// copies of `0.1`.
-        fn write_tiny_q4_fixture(dir: &std::path::Path, name: &str, shape: &[usize]) {
-            use crate::weights::q4_weights::{quantize_f32_to_q4, save_q4_file};
-            let numel: usize = shape.iter().product();
-            let data = vec![0.1f32; numel];
-            let tensor = quantize_f32_to_q4(&data, shape).expect("quantize tiny tensor");
-            let path = MetalQwen35State::q4_tensor_path(dir, name, "q4");
-            save_q4_file(&path, &tensor).expect("save .q4 fixture");
-        }
-
-        /// The 8 MTP projection tensor names paired with their expected
-        /// on-disk shape, derived from the real qwen3.5-0.8b-q4 checkpoint
-        /// (`~/.lattice/models/qwen3.5-0.8b-q4/mtp_*.q4` headers, verified by
-        /// hand during #636 round-1 remediation): on-disk shape is always
-        /// `[d_out, d_in]`, matching `expected_lora_shape`'s `(d_in, d_out)`
-        /// convention reversed.
-        fn mtp_proj_names_and_shapes(cfg: &Qwen35Config) -> [(&'static str, Vec<usize>); 8] {
-            let hidden = cfg.hidden_size;
-            let q_dim = cfg.full_q_dim();
-            let kv_dim = cfg.full_kv_dim();
-            let inter = cfg.intermediate_size;
-            [
-                (
-                    "mtp.layers.0.self_attn.q_proj.weight",
-                    vec![2 * q_dim, hidden],
-                ),
-                ("mtp.layers.0.self_attn.k_proj.weight", vec![kv_dim, hidden]),
-                ("mtp.layers.0.self_attn.v_proj.weight", vec![kv_dim, hidden]),
-                ("mtp.layers.0.self_attn.o_proj.weight", vec![hidden, q_dim]),
-                ("mtp.layers.0.mlp.gate_proj.weight", vec![inter, hidden]),
-                ("mtp.layers.0.mlp.up_proj.weight", vec![inter, hidden]),
-                ("mtp.layers.0.mlp.down_proj.weight", vec![hidden, inter]),
-                ("mtp.fc.weight", vec![hidden, 2 * hidden]),
-            ]
-        }
-
-        /// The 7 MTP norm tensor names paired with their expected shape —
-        /// never quantized (`should_quantize` excludes anything containing
-        /// `norm.weight`). `q_norm`/`k_norm` are `[head_dim]`; the rest are
-        /// `[hidden]`.
-        fn mtp_norm_names_and_shapes(cfg: &Qwen35Config) -> [(&'static str, Vec<usize>); 7] {
-            let hidden = cfg.hidden_size;
-            let head_dim = cfg.head_dim;
-            [
-                ("mtp.layers.0.input_layernorm.weight", vec![hidden]),
-                ("mtp.layers.0.post_attention_layernorm.weight", vec![hidden]),
-                ("mtp.layers.0.self_attn.q_norm.weight", vec![head_dim]),
-                ("mtp.layers.0.self_attn.k_norm.weight", vec![head_dim]),
-                ("mtp.norm.weight", vec![hidden]),
-                ("mtp.pre_fc_norm_embedding.weight", vec![hidden]),
-                ("mtp.pre_fc_norm_hidden.weight", vec![hidden]),
-            ]
-        }
-
-        /// Write a complete, well-formed MTP tensor set to `dir`: the 8
-        /// projections in `proj_flavor` (`.q4` or `.f16`) and the 7 norms as
-        /// `.f16`.
-        fn write_full_mtp_fixture(dir: &std::path::Path, cfg: &Qwen35Config, proj_as_q4: bool) {
-            for (name, shape) in mtp_proj_names_and_shapes(cfg) {
-                if proj_as_q4 {
-                    write_tiny_q4_fixture(dir, name, &shape);
-                } else {
-                    write_tiny_f16_fixture(dir, name, &shape);
-                }
-            }
-            for (name, shape) in mtp_norm_names_and_shapes(cfg) {
-                write_tiny_f16_fixture(dir, name, &shape);
-            }
-        }
-
-        // --- CPU-only, Device-free coverage of the flavor/shape logic itself ---
-        // (round-1 medium #3: these never skip on a Metal-less CI runner.)
-
-        #[test]
-        fn resolve_mtp_projection_prefers_q4_when_allowed() {
-            let cfg = tiny_metal_qwen35_fixture().0;
-            let tmp = tempfile::tempdir().expect("tempdir create");
-            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0]; // q_proj
-            write_tiny_q4_fixture(tmp.path(), name, shape);
-
-            let resolved =
-                resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
-                    .expect("plain Q4 dir must resolve the .q4 sibling");
-            assert!(
-                resolved.is_q4(),
-                "allow_q4=true with a .q4 file present must prefer the .q4 flavor"
-            );
-            assert_eq!(resolved.shape(), shape.as_slice());
-        }
-
-        #[test]
-        fn resolve_mtp_projection_falls_back_to_f16_when_q4_absent() {
-            let cfg = tiny_metal_qwen35_fixture().0;
-            let tmp = tempfile::tempdir().expect("tempdir create");
-            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
-            write_tiny_f16_fixture(tmp.path(), name, shape);
-
-            let resolved =
-                resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
-                    .expect("QuaRot-shaped all-.f16 dir must resolve the .f16 sibling");
-            assert!(!resolved.is_q4(), "no .q4 file exists; must resolve .f16");
-        }
-
-        #[test]
-        fn resolve_mtp_projection_rejects_stale_q4_sibling_under_quarot() {
-            // Round-1 MAJOR: a QuaRot (rotated-space) checkpoint directory
-            // must never load an MTP `.q4` sibling even if one exists —
-            // that shape is reachable when `quantize_q4` is re-run into an
-            // existing QuaRot output dir (the converter reuses a non-empty
-            // output dir rather than rejecting it). Silently preferring
-            // `.q4` there would load rotated-space weights while
-            // counter-rotation (keyed off the same dir's `quarot_seed`)
-            // stays enabled, corrupting every MTP draft with no load
-            // failure to reveal it.
-            let cfg = tiny_metal_qwen35_fixture().0;
-            let tmp = tempfile::tempdir().expect("tempdir create");
-            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
-            // Mixed/stale layout: BOTH a .q4 (leftover from a re-run
-            // quantize_q4) and the expected QuaRot .f16 exist side by side.
-            write_tiny_q4_fixture(tmp.path(), name, shape);
-            write_tiny_f16_fixture(tmp.path(), name, shape);
-
-            let err = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ false)
-                .expect_err(
-                    "allow_q4=false (QuaRot flavor) with a .q4 sibling present must fail closed",
-                );
-            let MtpLoadErr::Incompatible(message) = err else {
-                panic!("expected Incompatible, got {err:?}");
-            };
-            assert!(
-                message.contains("incompatible") && message.contains(".q4"),
-                "error must name the incompatible .q4 artifact; got: {message}"
-            );
-        }
-
-        #[test]
-        fn resolve_mtp_projection_rejects_transposed_q4_shape() {
-            // Round-1 medium #1: a same-numel transposed file must not
-            // silently load — it would generate tokens but produce garbage
-            // MTP drafts (0% accept class).
-            let cfg = tiny_metal_qwen35_fixture().0;
-            let tmp = tempfile::tempdir().expect("tempdir create");
-            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0]; // q_proj: [2*q_dim, hidden]
-            let transposed: Vec<usize> = shape.iter().rev().copied().collect();
-            assert_ne!(
-                shape, &transposed,
-                "fixture cfg must have distinguishable q_proj dims for this test to be meaningful"
-            );
-            write_tiny_q4_fixture(tmp.path(), name, &transposed);
-
-            let err = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
-                .expect_err("a transposed same-numel .q4 tensor must be rejected, not accepted");
-            let MtpLoadErr::Incompatible(message) = err else {
-                panic!("expected Incompatible, got {err:?}");
-            };
-            assert!(
-                message.contains("shape"),
-                "error must name the shape mismatch; got: {message}"
-            );
-        }
-
-        #[test]
-        fn resolve_mtp_projection_rejects_transposed_f16_shape() {
-            let cfg = tiny_metal_qwen35_fixture().0;
-            let tmp = tempfile::tempdir().expect("tempdir create");
-            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[6]; // down_proj: [hidden, inter]
-            let transposed: Vec<usize> = shape.iter().rev().copied().collect();
-            assert_ne!(
-                shape, &transposed,
-                "fixture cfg must have distinguishable down_proj dims for this test to be meaningful"
-            );
-            write_tiny_f16_fixture(tmp.path(), name, &transposed);
-
-            let err = resolve_mtp_projection(tmp.path(), name, shape, /* allow_q4 */ true)
-                .expect_err("a transposed same-numel .f16 tensor must be rejected, not accepted");
-            assert!(matches!(err, MtpLoadErr::Incompatible(_)));
-        }
-
-        #[test]
-        fn resolve_mtp_projection_reports_missing_when_neither_flavor_present() {
-            let cfg = tiny_metal_qwen35_fixture().0;
-            let tmp = tempfile::tempdir().expect("tempdir create");
-            let (name, shape) = &mtp_proj_names_and_shapes(&cfg)[0];
-
-            let err = resolve_mtp_projection(tmp.path(), name, shape, true)
-                .expect_err("neither flavor present must be Missing, not Ok");
-            assert!(matches!(err, MtpLoadErr::Missing(_)));
-        }
-
-        #[test]
-        fn resolve_mtp_norm_rejects_transposed_shape() {
-            let cfg = tiny_metal_qwen35_fixture().0;
-            let tmp = tempfile::tempdir().expect("tempdir create");
-            // input_layernorm is [hidden]; use a 2-D reshape as the "wrong
-            // shape" stand-in since a 1-D vector has no transpose.
-            let name = "mtp.layers.0.input_layernorm.weight";
-            let hidden = cfg.hidden_size;
-            write_tiny_f16_fixture(tmp.path(), name, &[hidden, 1]);
-
-            let err = resolve_mtp_norm(tmp.path(), name, &[hidden])
-                .expect_err("a reshaped norm tensor must be rejected, not accepted");
-            assert!(matches!(err, MtpLoadErr::Incompatible(_)));
-        }
+        // Pure, `Device`-free coverage of the flavor/shape-resolution logic
+        // itself (`resolve_mtp_projection`/`resolve_mtp_norm`) lives at the
+        // file top level in `mod mtp_resolve_tests`, compiled unconditionally
+        // in any test build (not gated on the `metal-gpu` feature), so it
+        // never skip-passes on a Metal-less CI runner (#636 round-2 -- these
+        // tests used to live right here, inside this `metal-gpu`-gated
+        // `mod inner`, and `cargo test --lib resolve_mtp` with no features
+        // reported "running 0 tests"). The tests below instead exercise
+        // `load_mtp_q4_weights` end-to-end against a real Metal `Device`.
 
         // --- Device-gated integration smoke on top of the CPU-only coverage above ---
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -14978,7 +14978,7 @@ kernel void gdn_chunk_norm_silu_c32(
             cfg: &Qwen35Config,
             device: &Device,
         ) -> MtpQ4LoadResult {
-            use crate::weights::q4_weights::load_f16_tensor_file;
+            use crate::weights::q4_weights::{load_f16_tensor_file, load_q4_file};
 
             if cfg.mtp_num_hidden_layers == 0 {
                 return MtpQ4LoadResult {
@@ -14988,7 +14988,6 @@ kernel void gdn_chunk_norm_silu_c32(
             }
 
             let f16p = |name: &str| MetalQwen35State::q4_tensor_path(q4_dir, name, "f16");
-            // follow-up: #418's actual-load part is deferred; this loader still expects .f16 MTP files while the shipped Q4 checkpoint provides those weights as .q4.
 
             // Helper: load an f16 file as a f32 Metal buffer (for norm gammas / biases
             // consumed by RMSNorm kernels that read f32 input).
@@ -15016,6 +15015,30 @@ kernel void gdn_chunk_norm_silu_c32(
                     Ok(make_buffer_f16(device, &vals, label))
                 };
 
+            // Helper: load one of the 8 MTP projection matrices as a Metal
+            // half-precision (f16) buffer, accepting either on-disk flavor.
+            //
+            // `quantize_q4` applies the same `should_quantize` name-suffix rule
+            // to MTP tensors as to the main model, so the 8 `*_proj*.weight`
+            // MTP matrices are written as `.q4` (dequantize-on-load here).
+            // `quantize_quarot` instead keeps every MTP tensor as unrotated
+            // `.f16` (ADR-051 Phase 1: MTP counter-rotation needs unquantized
+            // weights, so QuaRot checkpoints never emit MTP `.q4` files).
+            // Preferring `.q4` when present and falling back to `.f16` lets
+            // both checkpoint flavors load through the same path without
+            // needing to sniff which quantizer produced the directory.
+            let load_q4_or_f16_proj_as_half =
+                |name: &str, label: &str| -> Result<Buffer, std::path::PathBuf> {
+                    let q4_path = MetalQwen35State::q4_tensor_path(q4_dir, name, "q4");
+                    if q4_path.exists() {
+                        let tensor = load_q4_file(&q4_path).map_err(|_| q4_path.clone())?;
+                        return Ok(MetalQwen35State::make_buffer_f16_from_q4(
+                            device, &tensor, label,
+                        ));
+                    }
+                    load_f16_buf_as_half(name, label)
+                };
+
             let weights = (|| -> Result<MetalMtpWeights, std::path::PathBuf> {
                 // --- Layer 0 weights (ADR-051: 8 projections as f16, 7 norms as f32) ---
                 let input_layernorm = load_f16_buf_as_f32(
@@ -15026,27 +15049,41 @@ kernel void gdn_chunk_norm_silu_c32(
                     "mtp.layers.0.post_attention_layernorm.weight",
                     "mtp.l0.post_attn_layernorm",
                 )?;
-                let q_proj =
-                    load_f16_buf_as_half("mtp.layers.0.self_attn.q_proj.weight", "mtp.l0.q_proj")?;
-                let k_proj =
-                    load_f16_buf_as_half("mtp.layers.0.self_attn.k_proj.weight", "mtp.l0.k_proj")?;
-                let v_proj =
-                    load_f16_buf_as_half("mtp.layers.0.self_attn.v_proj.weight", "mtp.l0.v_proj")?;
-                let o_proj =
-                    load_f16_buf_as_half("mtp.layers.0.self_attn.o_proj.weight", "mtp.l0.o_proj")?;
+                let q_proj = load_q4_or_f16_proj_as_half(
+                    "mtp.layers.0.self_attn.q_proj.weight",
+                    "mtp.l0.q_proj",
+                )?;
+                let k_proj = load_q4_or_f16_proj_as_half(
+                    "mtp.layers.0.self_attn.k_proj.weight",
+                    "mtp.l0.k_proj",
+                )?;
+                let v_proj = load_q4_or_f16_proj_as_half(
+                    "mtp.layers.0.self_attn.v_proj.weight",
+                    "mtp.l0.v_proj",
+                )?;
+                let o_proj = load_q4_or_f16_proj_as_half(
+                    "mtp.layers.0.self_attn.o_proj.weight",
+                    "mtp.l0.o_proj",
+                )?;
                 let q_norm =
                     load_f16_buf_as_f32("mtp.layers.0.self_attn.q_norm.weight", "mtp.l0.q_norm")?;
                 let k_norm =
                     load_f16_buf_as_f32("mtp.layers.0.self_attn.k_norm.weight", "mtp.l0.k_norm")?;
-                let gate_proj =
-                    load_f16_buf_as_half("mtp.layers.0.mlp.gate_proj.weight", "mtp.l0.gate_proj")?;
-                let up_proj =
-                    load_f16_buf_as_half("mtp.layers.0.mlp.up_proj.weight", "mtp.l0.up_proj")?;
-                let down_proj =
-                    load_f16_buf_as_half("mtp.layers.0.mlp.down_proj.weight", "mtp.l0.down_proj")?;
+                let gate_proj = load_q4_or_f16_proj_as_half(
+                    "mtp.layers.0.mlp.gate_proj.weight",
+                    "mtp.l0.gate_proj",
+                )?;
+                let up_proj = load_q4_or_f16_proj_as_half(
+                    "mtp.layers.0.mlp.up_proj.weight",
+                    "mtp.l0.up_proj",
+                )?;
+                let down_proj = load_q4_or_f16_proj_as_half(
+                    "mtp.layers.0.mlp.down_proj.weight",
+                    "mtp.l0.down_proj",
+                )?;
 
                 // --- Top-level MTP weights ---
-                let fc = load_f16_buf_as_half("mtp.fc.weight", "mtp.fc")?;
+                let fc = load_q4_or_f16_proj_as_half("mtp.fc.weight", "mtp.fc")?;
                 let pre_fc_norm_embedding = load_f16_buf_as_f32(
                     "mtp.pre_fc_norm_embedding.weight",
                     "mtp.pre_fc_norm_embedding",
@@ -18993,6 +19030,174 @@ kernel void decode_attention_reference(
                 result.is_ok(),
                 "mmap_q4_weight must accept a fully populated payload: {:?}",
                 result.err()
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // load_mtp_q4_weights: Q4-or-F16 MTP projection loading (#630)
+        // -------------------------------------------------------------------
+        //
+        // `quantize_q4` applies its `should_quantize` name-suffix rule to
+        // MTP tensor names exactly like the main model: the 8 `*_proj*`
+        // matrices (q/k/v/o_proj, gate/up/down_proj, fc) are written as
+        // `.q4`, while the 7 norm tensors are written as `.f16`.
+        // `quantize_quarot` instead keeps ALL 15 MTP tensors as unrotated
+        // `.f16` (ADR-051 Phase 1: MTP counter-rotation needs unquantized
+        // weights). `load_mtp_q4_weights` must accept both flavors.
+
+        /// Write a tiny `.f16` (KHF1) tensor file with `numel` copies of
+        /// `1.0`, mirroring the format `load_f16_tensor_file` reads
+        /// (crates/inference/src/weights/q4_weights.rs).
+        fn write_tiny_f16_fixture(dir: &std::path::Path, name: &str, numel: usize) {
+            use crate::weights::q4_weights::q4_f32_to_f16;
+            let path = MetalQwen35State::q4_tensor_path(dir, name, "f16");
+            let mut buf = Vec::new();
+            buf.extend_from_slice(b"KHF1");
+            buf.extend_from_slice(&1u32.to_le_bytes()); // version
+            buf.extend_from_slice(&1u32.to_le_bytes()); // ndim
+            buf.extend_from_slice(&(numel as u64).to_le_bytes()); // shape[0]
+            buf.extend_from_slice(&(numel as u64).to_le_bytes()); // numel
+            for _ in 0..numel {
+                buf.extend_from_slice(&q4_f32_to_f16(1.0).to_le_bytes());
+            }
+            std::fs::write(&path, buf).expect("write .f16 fixture");
+        }
+
+        /// Write a tiny `.q4` tensor file with `numel` copies of `0.1`.
+        fn write_tiny_q4_fixture(dir: &std::path::Path, name: &str, numel: usize) {
+            use crate::weights::q4_weights::{quantize_f32_to_q4, save_q4_file};
+            let data = vec![0.1f32; numel];
+            let tensor = quantize_f32_to_q4(&data, &[numel]).expect("quantize tiny tensor");
+            let path = MetalQwen35State::q4_tensor_path(dir, name, "q4");
+            save_q4_file(&path, &tensor).expect("save .q4 fixture");
+        }
+
+        /// The 8 MTP projection tensor names (q/k/v/o_proj, gate/up/down_proj, fc).
+        const MTP_PROJ_NAMES: [&str; 8] = [
+            "mtp.layers.0.self_attn.q_proj.weight",
+            "mtp.layers.0.self_attn.k_proj.weight",
+            "mtp.layers.0.self_attn.v_proj.weight",
+            "mtp.layers.0.self_attn.o_proj.weight",
+            "mtp.layers.0.mlp.gate_proj.weight",
+            "mtp.layers.0.mlp.up_proj.weight",
+            "mtp.layers.0.mlp.down_proj.weight",
+            "mtp.fc.weight",
+        ];
+
+        /// The 7 MTP norm tensor names — never quantized (`should_quantize`
+        /// excludes anything containing `norm.weight`).
+        const MTP_NORM_NAMES: [&str; 7] = [
+            "mtp.layers.0.input_layernorm.weight",
+            "mtp.layers.0.post_attention_layernorm.weight",
+            "mtp.layers.0.self_attn.q_norm.weight",
+            "mtp.layers.0.self_attn.k_norm.weight",
+            "mtp.norm.weight",
+            "mtp.pre_fc_norm_embedding.weight",
+            "mtp.pre_fc_norm_hidden.weight",
+        ];
+
+        #[test]
+        fn load_mtp_q4_weights_accepts_q4_projections_with_f16_norms() {
+            // Straight (non-QuaRot) Q4 checkpoint shape: 8 projections as
+            // `.q4`, 7 norms as `.f16`. Before the #630 fix,
+            // `load_mtp_q4_weights` only tried `.f16` for the projections,
+            // so it always reported the first projection as missing on
+            // this exact directory layout (the real shape `quantize_q4`
+            // ships) — reverting the fix must fail this assertion.
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let (mut cfg, _weights) = tiny_metal_qwen35_fixture();
+            cfg.mtp_num_hidden_layers = 1;
+            let hidden = cfg.hidden_size;
+            let intermediate = cfg.intermediate_size;
+
+            let tmp = tempfile::tempdir().expect("tempdir create");
+
+            for &name in &MTP_PROJ_NAMES {
+                let numel = if name.contains("gate_proj") || name.contains("up_proj") {
+                    intermediate * hidden
+                } else if name.contains("down_proj") {
+                    hidden * intermediate
+                } else {
+                    hidden * hidden
+                };
+                write_tiny_q4_fixture(tmp.path(), name, numel);
+            }
+            for &name in &MTP_NORM_NAMES {
+                write_tiny_f16_fixture(tmp.path(), name, hidden);
+            }
+
+            let result = MetalQwen35State::load_mtp_q4_weights(tmp.path(), &cfg, &device);
+
+            assert!(
+                result.weights.is_some(),
+                "load_mtp_q4_weights must load MTP weights when the 8 projections \
+                 are .q4 and the 7 norms are .f16 (the real quantize_q4 output \
+                 shape); first_missing_file={:?}",
+                result.first_missing_file
+            );
+        }
+
+        #[test]
+        fn load_mtp_q4_weights_still_accepts_all_f16_quarot_layout() {
+            // QuaRot checkpoints (`quantize_quarot`) keep every MTP tensor,
+            // including the 8 projections, as unrotated `.f16` (ADR-051
+            // Phase 1). The Q4-preferring loader must fall back to `.f16`
+            // when no `.q4` sibling exists, so this checkpoint flavor keeps
+            // working exactly as before.
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let (mut cfg, _weights) = tiny_metal_qwen35_fixture();
+            cfg.mtp_num_hidden_layers = 1;
+            let hidden = cfg.hidden_size;
+
+            let tmp = tempfile::tempdir().expect("tempdir create");
+
+            for &name in &MTP_PROJ_NAMES {
+                write_tiny_f16_fixture(tmp.path(), name, hidden);
+            }
+            for &name in &MTP_NORM_NAMES {
+                write_tiny_f16_fixture(tmp.path(), name, hidden);
+            }
+
+            let result = MetalQwen35State::load_mtp_q4_weights(tmp.path(), &cfg, &device);
+
+            assert!(
+                result.weights.is_some(),
+                "load_mtp_q4_weights must still accept the all-.f16 QuaRot \
+                 layout; first_missing_file={:?}",
+                result.first_missing_file
+            );
+        }
+
+        #[test]
+        fn load_mtp_q4_weights_reports_missing_file_when_neither_flavor_present() {
+            // Fail-closed contract: if a projection has neither a `.q4` nor
+            // a `.f16` sibling, the loader must report it as missing (and
+            // the caller falls back to the non-MTP decode path with a
+            // warning) rather than silently loading garbage.
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let (mut cfg, _weights) = tiny_metal_qwen35_fixture();
+            cfg.mtp_num_hidden_layers = 1;
+
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            // Deliberately write nothing — the directory is empty.
+
+            let result = MetalQwen35State::load_mtp_q4_weights(tmp.path(), &cfg, &device);
+
+            assert!(
+                result.weights.is_none(),
+                "load_mtp_q4_weights must not synthesize weights when both \
+                 .q4 and .f16 are absent"
+            );
+            assert!(
+                result.first_missing_file.is_some(),
+                "load_mtp_q4_weights must report a first_missing_file when \
+                 nothing is on disk"
             );
         }
 

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -216,7 +216,24 @@ pub(crate) fn read_quarot_seed_from_index(q4_dir: &Path) -> Result<Option<u64>, 
     let Some(bytes) = read_quantize_index_bytes_bounded(&path)? else {
         return Ok(None);
     };
-    let index: QuantizeIndex = serde_json::from_slice(&bytes)
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|e| format!("{}: malformed quantize_index.json: {e}", path.display()))?;
+    // `quantize_q4` (plain, non-rotated Q4 checkpoints — see
+    // `crates/inference/src/bin/quantize_q4.rs`) writes `quantize_index.json`
+    // as a bare top-level tensor array, not the `{quarot_seed, tensors}`
+    // object `quantize_quarot` produces. That shape genuinely carries no
+    // rotation seed; it is not malformed. Without this check, serde's
+    // derived `Deserialize` for `QuantizeIndex` accepts a top-level JSON
+    // array too (treating positional elements as struct fields in
+    // declaration order), so the array's first tensor entry (a JSON object)
+    // would be deserialized as the `quarot_seed: Option<u64>` field and fail
+    // with a confusing "invalid type: map, expected u64" — turning a
+    // perfectly valid plain-Q4 checkpoint into a hard load failure (#630
+    // end-to-end verification against the real qwen3.5-0.8b-q4 checkpoint).
+    if value.is_array() {
+        return Ok(None);
+    }
+    let index: QuantizeIndex = serde_json::from_value(value)
         .map_err(|e| format!("{}: malformed quantize_index.json: {e}", path.display()))?;
     Ok(index.quarot_seed)
 }
@@ -2317,6 +2334,27 @@ mod tests {
             read_quarot_seed_from_index(tmp.path()),
             Ok(None),
             "index without quarot_seed key must yield Ok(None)"
+        );
+    }
+
+    #[test]
+    fn read_quarot_seed_from_index_bare_array_is_none() {
+        // `quantize_q4` (plain, non-rotated Q4 checkpoints) writes
+        // `quantize_index.json` as a bare top-level tensor array, not the
+        // `{quarot_seed, tensors}` object `quantize_quarot` produces. This
+        // must be recognized as "no seed", not rejected as malformed —
+        // reverting the array-shape check makes serde misparse the first
+        // array element as the `quarot_seed: Option<u64>` field and error.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("quantize_index.json"),
+            r#"[{"name":"foo","file":"foo.q4","quantized":true,"shape":[2,2],"numel":4}]"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_quarot_seed_from_index(tmp.path()),
+            Ok(None),
+            "bare tensor-array quantize_index.json (plain quantize_q4 shape) must yield Ok(None)"
         );
     }
 


### PR DESCRIPTION
## Summary

- Implements the deferred half of #418/#441/#508: `load_mtp_q4_weights` (`crates/inference/src/forward/metal_qwen35.rs`) now actually loads MTP weights from a Q4 checkpoint instead of always warning-and-falling-back.
- `quantize_q4` applies the same `should_quantize` name-suffix rule to MTP tensor names as to the main model, so plain (non-QuaRot) Q4 checkpoints ship the 8 MTP projection matrices (`q/k/v/o_proj`, `gate/up/down_proj`, `fc`) as `.q4`, not `.f16`. The loader only ever tried `.f16` for those 8 tensors, so every real Q4 checkpoint's MTP head was reported "missing".
- `quantize_quarot` keeps all 15 MTP tensors as unrotated `.f16` (ADR-051 Phase 1: counter-rotation needs unquantized weights) — that flavor already worked through the existing f16 loader and is unaffected.
- Fixes a second, previously-dormant bug found during end-to-end verification: `read_quarot_seed_from_index` (`crates/inference/src/quant/quarot/convert.rs`) misparsed `quantize_q4`'s bare-array `quantize_index.json` as a malformed `QuantizeIndex` object the moment MTP loading started succeeding for plain Q4 checkpoints (this path was previously unreachable because MTP always failed first).

## Design

**Loader (`metal_qwen35.rs`)**: added `load_q4_or_f16_proj_as_half`, used only for the 8 MTP projection weights. It tries `<name>.q4` first (`load_q4_file` + `make_buffer_f16_from_q4`, the exact dequantize-on-load pattern the main model already uses for `in_proj_a`/`in_proj_b`), and falls back to the existing `load_f16_buf_as_half` when no `.q4` sibling exists. The 7 MTP norm tensors are untouched — `should_quantize` never quantizes anything containing `norm.weight`, so they are always `.f16` in both checkpoint flavors.

I deliberately did **not** invent a new format or touch `quantize_q4`'s output — verified first (read `quantize_q4.rs`'s `should_quantize`, both real checkpoints on disk under `~/.lattice/models/`) that `.q4` for the 8 MTP projections is exactly what the shipped quantizer already produces; the loader was the only piece out of sync.

**Index shape (`convert.rs`)**: `read_quarot_seed_from_index` now inspects the parsed JSON value before the typed deserialize. A top-level JSON array (the plain `quantize_q4` shape, no wrapper object) is `Ok(None)` — it genuinely carries no rotation seed, it's not malformed. Everything else goes through the existing typed `QuantizeIndex` deserialize, preserving the fail-closed behavior for genuinely corrupt/wrong-schema object-shaped indexes (existing tests for those cases are untouched and still pass).

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings` — clean
- `cargo check -p lattice-inference --tests` (default features, module correctly compiled out without `metal-gpu`) — clean
- 3 new mutation-sensitive unit tests for `load_mtp_q4_weights`:
  - `load_mtp_q4_weights_accepts_q4_projections_with_f16_norms` (the real `quantize_q4` shape)
  - `load_mtp_q4_weights_still_accepts_all_f16_quarot_layout` (the real `quantize_quarot` shape)
  - `load_mtp_q4_weights_reports_missing_file_when_neither_flavor_present` (fail-closed contract preserved)
  - Mutation-sensitivity verified by hand: reverse-applied the loader fix (made the new helper call straight through to the old f16-only closure), touched the file, reran — `load_mtp_q4_weights_accepts_q4_projections_with_f16_norms` failed exactly as expected; restored the fix and reran — all pass.
- 1 new unit test `read_quarot_seed_from_index_bare_array_is_none` for the index-shape fix.
- **Runtime end-to-end verification against both real local checkpoints** (`~/.lattice/models/qwen3.5-0.8b-q4` and `.../qwen3.5-0.8b-q4-quarot`): `LATTICE_MTP=1 ./target/debug/lattice chat --model <dir> --tokenizer-dir ~/.lattice/models/qwen3.5-0.8b` loads and generates on both, logging `[mtp] Loaded MTP layer 0 weights` with no fallback warning (previously: hard load failure on the plain-Q4 dir, from the index bug once MTP started "succeeding").

bench-compare: deferred — machine busy with other cargo/rustc processes during this session (weight loading is I/O + one-time dequantize, not a hot decode-loop op that `bench-compare`'s Criterion groups target, but I'll still run it if requested).

## Review round 1

Review of the initial commit found 1 major and 2 medium issues. All three are addressed in the follow-up commit `5781f1453`:

- **Flavor determined before file selection, not after.** The loader previously preferred a `.q4` sibling for any MTP projection unconditionally, with no awareness of whether the surrounding checkpoint was QuaRot. Because `quantize_q4` reuses a non-empty output directory rather than rejecting it, a QuaRot directory could end up with a stale `.q4` MTP projection left over from an earlier plain-Q4 run into the same path — and the loader would happily load it while QuaRot's counter-rotation stayed enabled, producing silently corrupted drafts with no load failure to surface it. `load_mtp_q4_weights` now takes an `is_quarot` flag (computed from the manifest/config `quarot_seed` before any MTP tensor is touched), and under QuaRot a `.q4` sibling is now a hard, named `Err` rather than a silent pick.
- **Every MTP tensor load now validates its on-disk shape** against the shape the checkpoint should have for that tensor (all 8 projections plus all 7 norms) before a Metal buffer is built. A same-numel transposed file — which would previously load without error and just generate garbage drafts — is now rejected.
- **The flavor/shape logic is now covered without a GPU.** `resolve_mtp_projection`/`resolve_mtp_norm` were factored out as pure, `Device`-free functions, with new CPU-only unit tests for plain-Q4 acceptance, all-F16 QuaRot acceptance, missing-file, the stale-`.q4`-under-QuaRot rejection, and transposed-shape rejection for both flavors. These run unconditionally in CI instead of skip-passing on a Metal-less runner. The pre-existing `Device`-gated tests remain as integration smoke and now honor `LATTICE_METAL_TEST_ENFORCE=1`.

Mutation-tested the major fix by hand: reverse-applied the `allow_q4` gate, touched the file, and confirmed `resolve_mtp_projection_rejects_stale_q4_sibling_under_quarot` and `load_mtp_q4_weights_hard_errors_on_stale_q4_under_quarot` both fail; restored the fix and confirmed both pass again.

Re-ran the full gate set (`fmt --check`, `clippy -D warnings` on `f16,metal-gpu` all-targets, the targeted `read_quarot_seed` tests, and the full MTP loader test module) and re-verified end-to-end against both real checkpoints (`~/.lattice/models/qwen3.5-0.8b-q4` and `qwen3.5-0.8b-q4-quarot`) with `LATTICE_MTP=1` — both still load MTP weights and generate normally, no regression from this round's changes.

## Review round 2

Re-review confirmed the major and both round-1 mediums fixed, but flagged one new medium: the seven new `resolve_mtp_*` CPU-only tests actually lived inside `mod inner`, which is itself gated on `#[cfg(all(target_os = "macos", feature = "metal-gpu"))]`. So `cargo test -p lattice-inference --lib resolve_mtp -- --test-threads=1` with no features reported "running 0 tests" — the round-1 coverage existed, but disappeared on any non-Metal CI leg, exactly the skip-pass class round 1 was meant to close, just one module level up.

Fixed in commit `b3a14f8b3` by moving the pure resolver itself out of `mod inner`: `resolve_mtp_projection`, `resolve_mtp_norm`, `MtpLoadErr`, and `MtpTensorSource` now live at the file's top level (outside the metal-gpu gate), compiled under `#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]` — the same pattern this file already uses elsewhere for exactly this problem. They no longer reach into `MetalQwen35State` for the path-sanitizing helper; a small standalone `mtp_tensor_path` function replaces that one call. `mod inner` now just imports the resolver via `use super::{...}`, with no behavior change. The seven pure tests and their fixture writers moved into a new top-level `mod mtp_resolve_tests`, using a lightweight config-only fixture instead of the Metal-gated one, so they have no `Device`/`ModelWeights` dependency at all. The four remaining `Device`-gated integration tests stayed in `mod inner::tests`, now importing the shared fixture helpers from `mtp_resolve_tests`.

Verified `cargo test -p lattice-inference --lib resolve_mtp -- --test-threads=1` with no features reports **7 passed** (was 0). Re-ran `clippy -D warnings` on `f16,metal-gpu` all-targets (clean) and all 67 targeted tests on real Metal hardware (pass). Re-ran the round-1 mutation test against the relocated code — unaffected. Re-verified end-to-end against both real checkpoints — no regression.

Closes #630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

