### PR TITLE
dist(cli): real install channel — cargo install packaging + release binaries workflow (#633)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,99 @@
+name: release-binaries
+# Prebuilt `lattice` CLI binaries attached to GitHub releases (#633).
+#
+# Triggers only on a *published* GitHub release (never on tag push, so a
+# `git tag && git push` alone does not fire a build — a release must be
+# explicitly published via `gh release create` / the UI, matching the
+# existing bump-and-yank release flow in CLAUDE.md).
+#
+# Runners are chosen to build each target NATIVELY (no cross-compilation
+# toolchain): `macos-latest` is arm64 (aarch64-apple-darwin), `ubuntu-latest`
+# is x86_64 (x86_64-unknown-linux-gnu), `ubuntu-24.04-arm` is aarch64
+# (aarch64-unknown-linux-gnu) — the same three-runner shape `bench-update.yml`
+# already uses for CPU benches. Metal is macOS-only, so only the darwin leg
+# builds with `metal-gpu`; both Linux legs build CPU-only (`f16` alone) so the
+# CLI still installs and runs (NEON dispatch, no GPU) on Linux — see the
+# Raspberry Pi / ARM Linux README section this mirrors.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build+upload against (e.g. v0.4.2). Required for manual runs.'
+        required: true
+
+permissions:
+  contents: write # required for `gh release upload`
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+
+jobs:
+  build:
+    name: build (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+            features: f16,metal-gpu
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            features: f16
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            features: f16
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - name: Pin the real toolchain bin on PATH
+        # See ci.yml: some macos-latest images ship a rustup-init shim as
+        # ~/.cargo/bin/cargo rather than the rustup proxy.
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-binaries-${{ matrix.target }}
+
+      - name: Build lattice CLI (release)
+        run: cargo build --release -p lattice-inference --bin lattice --features ${{ matrix.features }}
+
+      - name: Package tarball + sha256
+        id: package
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          STAGE="lattice-${VERSION}-${TARGET}"
+          mkdir -p "$STAGE"
+          cp target/release/lattice "$STAGE/"
+          strip "$STAGE/lattice" || echo "::warning::strip failed or unavailable, shipping unstripped binary"
+          cp README.md LICENSE "$STAGE/" 2>/dev/null || true
+          ARCHIVE="${STAGE}.tar.gz"
+          tar -czf "$ARCHIVE" "$STAGE"
+          shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+          echo "sha256_file=${ARCHIVE}.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" \
+            "${{ steps.package.outputs.archive }}" \
+            "${{ steps.package.outputs.sha256_file }}" \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/README.md
+++ b/README.md
@@ -176,7 +176,49 @@ lattice-embed = { version = "0.4", features = ["wgpu-gpu"] }
 
 ## Quick Start: CLI
 
-Build from source (requires Rust 1.93+ and, for Metal, macOS 14+):
+### Install
+
+Three ways to get `lattice`, in order of convenience:
+
+**1. `cargo install` (from [crates.io](https://crates.io/crates/lattice-inference)):**
+
+```bash
+# CPU build (Linux/macOS). f16 is required to load the BF16/F16 safetensors
+# that HuggingFace checkpoints ship in.
+cargo install lattice-inference --bin lattice --features f16
+
+# With Metal GPU (macOS only)
+cargo install lattice-inference --bin lattice --features f16,metal-gpu
+```
+
+This installs `lattice` to `~/.cargo/bin/lattice`. Requires Rust 1.93+
+(`rustup update` if `cargo install` complains about the `rust-version`).
+
+**2. Prebuilt release binaries:**
+
+Every [GitHub release](https://github.com/ohdearquant/lattice/releases) ships
+`lattice-<version>-<target>.tar.gz` for `aarch64-apple-darwin` (macOS,
+Metal-enabled), `x86_64-unknown-linux-gnu`, and `aarch64-unknown-linux-gnu`
+(both CPU-only), plus a matching `.sha256` file.
+
+```bash
+VERSION=0.4.2   # match the release you want
+TARGET=aarch64-apple-darwin   # or x86_64-unknown-linux-gnu / aarch64-unknown-linux-gnu
+
+curl -LO "https://github.com/ohdearquant/lattice/releases/download/v${VERSION}/lattice-${VERSION}-${TARGET}.tar.gz"
+curl -LO "https://github.com/ohdearquant/lattice/releases/download/v${VERSION}/lattice-${VERSION}-${TARGET}.tar.gz.sha256"
+
+# Verify before extracting
+shasum -a 256 -c "lattice-${VERSION}-${TARGET}.tar.gz.sha256"
+
+tar -xzf "lattice-${VERSION}-${TARGET}.tar.gz"
+./lattice-${VERSION}-${TARGET}/lattice chat --model ~/.lattice/models/qwen3.5-0.8b
+```
+
+No Homebrew tap yet — tracked as a follow-up once release binaries have shipped
+for a few versions ([#633](https://github.com/ohdearquant/lattice/issues/633)).
+
+**3. Build from source** (requires Rust 1.93+ and, for Metal, macOS 14+):
 
 ```bash
 git clone https://github.com/ohdearquant/lattice

--- a/README.md
+++ b/README.md
@@ -196,13 +196,15 @@ This installs `lattice` to `~/.cargo/bin/lattice`. Requires Rust 1.93+
 
 **2. Prebuilt release binaries:**
 
-Every [GitHub release](https://github.com/ohdearquant/lattice/releases) ships
+[GitHub releases](https://github.com/ohdearquant/lattice/releases) ship
 `lattice-<version>-<target>.tar.gz` for `aarch64-apple-darwin` (macOS,
 Metal-enabled), `x86_64-unknown-linux-gnu`, and `aarch64-unknown-linux-gnu`
-(both CPU-only), plus a matching `.sha256` file.
+(both CPU-only), plus a matching `.sha256` file. Check the release's Assets
+list first: releases published before this workflow landed have no prebuilt
+binaries (use `cargo install` for those versions).
 
 ```bash
-VERSION=0.4.2   # match the release you want
+VERSION=0.4.2   # match a release that has binary assets attached
 TARGET=aarch64-apple-darwin   # or x86_64-unknown-linux-gnu / aarch64-unknown-linux-gnu
 
 curl -LO "https://github.com/ohdearquant/lattice/releases/download/v${VERSION}/lattice-${VERSION}-${TARGET}.tar.gz"

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ list first: releases published before this workflow landed have no prebuilt
 binaries (use `cargo install` for those versions).
 
 ```bash
-VERSION=0.4.2   # match a release that has binary assets attached
+VERSION=<version>   # replace with a release whose Assets list includes lattice-* tarballs
 TARGET=aarch64-apple-darwin   # or x86_64-unknown-linux-gnu / aarch64-unknown-linux-gnu
 
 curl -LO "https://github.com/ohdearquant/lattice/releases/download/v${VERSION}/lattice-${VERSION}-${TARGET}.tar.gz"


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Closes #633 (follow-up from the #568 closed-issue reconciliation audit — the DMG/build-path work shipped but the CLI itself had no install channel other than clone-and-build).

- **`cargo install` channel — already works, verified live.** `cargo install lattice-inference --bin lattice --features f16` (and `--features f16,metal-gpu` for Metal) installs and runs from crates.io today at v0.4.2. No packaging changes were needed: the `lattice` bin target in `crates/inference/Cargo.toml` has no `required-features` gap, and the binary's own `metal_gpu_required_message` already fails closed with a clear rebuild hint when a Q4 model needs Metal and the binary was built without it. This PR documents the channel; it does not change the crate.
- **Release binaries — new workflow.** `.github/workflows/release-binaries.yml` triggers on `release: published` (plus a manual `workflow_dispatch` with a `tag` input for re-running against an existing release). Builds the CLI natively on three runners (no cross-compilation toolchain, mirroring `bench-update.yml`'s matrix shape):
  - `macos-latest` → `aarch64-apple-darwin`, `--features f16,metal-gpu`
  - `ubuntu-latest` → `x86_64-unknown-linux-gnu`, `--features f16`
  - `ubuntu-24.04-arm` → `aarch64-unknown-linux-gnu`, `--features f16`

  Each leg strips the binary, packages `lattice-<version>-<target>.tar.gz` (README + LICENSE bundled), writes a `.sha256`, and uploads both to the release via `gh release upload --clobber`.
- **README** — restructured the "Quick Start: CLI" section into three explicit install channels (cargo install, release-binary download + sha256 verification, build from source), leaving the existing Raspberry Pi/ARM Linux tips in place underneath rather than clobbering them.
- **Homebrew tap** — intentionally deferred. The issue itself scopes it as optional/"after release binaries exist"; there are no tagged release binaries yet for a tap formula to point at. Filing as an explicit follow-up once a release has actually gone through this workflow.

## What was verified this session

| Channel | Verified how | Result |
|---|---|---|
| `cargo install lattice-inference --bin lattice --features f16` | Ran live against crates.io into a throwaway `CARGO_HOME`, not `--path` | Installed cleanly, `lattice --help` runs, `Finished release ... Installed package lattice-inference v0.4.2` |
| `cargo install --path crates/inference --bin lattice --features f16 --locked` | Local worktree install into a throwaway `CARGO_HOME` | Same result — confirms the in-tree Cargo.toml matches what's published |
| `cargo build --release -p lattice-inference --bin lattice --features f16` | Local build | Clean |
| `cargo fmt --all -- --check` | Local | Clean, no diff |
| `cargo clippy --workspace --all-targets --features f16,metal-gpu -- -D warnings` | Local | Clean |
| release-binaries.yml YAML | `python3 -c "import yaml; yaml.safe_load(...)"` (no `actionlint` available in this sandbox) | Parses; manually reviewed against `bench-update.yml`/`app-binaries.yml` conventions (toolchain pin, rust-cache, runner choices) |
| The workflow's actual release-triggered run | **Not verifiable without publishing a real GitHub release** — deferred to the next tagged release. First real run should be watched via `gh run list` right after the next `gh release create` | Deferred |
| `metal-gpu` build on Linux runners | N/A by design — Linux legs build CPU-only (`f16` only), matching the existing Raspberry Pi/ARM Linux README guidance | N/A |

## Deviations from the issue's literal scope

- Homebrew tap not implemented (issue marks it optional, gated on release binaries existing).
- No x86_64-apple-darwin binary — issue says "aarch64-apple-darwin at minimum"; `macos-latest` GitHub runners are arm64-native, and I did not want to add a cross-compilation leg (x86_64 darwin cross-build from an arm64 runner) without a demonstrated need. Easy follow-up if requested.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features f16,metal-gpu -- -D warnings`
- [x] `cargo build --release -p lattice-inference --bin lattice --features f16`
- [x] `cargo install` (both `--path` and live crates.io) into throwaway `CARGO_HOME`s
- [ ] First real `release: published` run of `release-binaries.yml` on the next tagged release (cannot be exercised pre-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
