### PR TITLE
fix(embed): tier-mismatch in prepared SIMD dispatch returns typed error instead of panicking (#210)

### DIFF
--- a/crates/embed/benches/simd.rs
+++ b/crates/embed/benches/simd.rs
@@ -610,7 +610,7 @@ fn bench_prepared_query(c: &mut Criterion) {
         bench.iter(|| {
             let results: Vec<f32> = stored_int8_data
                 .iter()
-                .map(|s| approximate_cosine_distance_prepared(black_box(&pre_q_int8), s))
+                .map(|s| approximate_cosine_distance_prepared(black_box(&pre_q_int8), s).unwrap())
                 .collect();
             black_box(results)
         });
@@ -633,7 +633,7 @@ fn bench_prepared_query(c: &mut Criterion) {
         bench.iter(|| {
             let results: Vec<f32> = stored_int4_data
                 .iter()
-                .map(|s| approximate_cosine_distance_prepared(black_box(&pre_q_int4), s))
+                .map(|s| approximate_cosine_distance_prepared(black_box(&pre_q_int4), s).unwrap())
                 .collect();
             black_box(results)
         });
@@ -656,7 +656,7 @@ fn bench_prepared_query(c: &mut Criterion) {
         bench.iter(|| {
             let results: Vec<f32> = stored_binary_data
                 .iter()
-                .map(|s| approximate_cosine_distance_prepared(black_box(&pre_q_binary), s))
+                .map(|s| approximate_cosine_distance_prepared(black_box(&pre_q_binary), s).unwrap())
                 .collect();
             black_box(results)
         });
@@ -738,10 +738,10 @@ fn bench_int8_prepared_dot_product(c: &mut Criterion) {
         let prepared = PreparedQuery::from_f32(&query_f32, QuantizationTier::Int8);
         group.bench_with_input(BenchmarkId::new("prepared", dim), &dim, |bench, _| {
             bench.iter(|| {
-                black_box(approximate_dot_product_prepared(
-                    black_box(&prepared),
-                    black_box(&stored_data),
-                ))
+                black_box(
+                    approximate_dot_product_prepared(black_box(&prepared), black_box(&stored_data))
+                        .unwrap(),
+                )
             });
         });
     }
@@ -853,7 +853,10 @@ fn bench_prepared_query_normalized_cosine(c: &mut Criterion) {
                 bench.iter(|| {
                     let results: Vec<f32> = stored_full
                         .iter()
-                        .map(|s| approximate_cosine_distance_prepared(black_box(&prepared_full), s))
+                        .map(|s| {
+                            approximate_cosine_distance_prepared(black_box(&prepared_full), s)
+                                .unwrap()
+                        })
                         .collect();
                     black_box(results)
                 });
@@ -898,6 +901,7 @@ fn bench_prepared_query_normalized_cosine(c: &mut Criterion) {
                                 s,
                                 NormalizationHint::Unit,
                             )
+                            .unwrap()
                         })
                         .collect();
                     black_box(results)
@@ -1144,10 +1148,13 @@ fn bench_prepared_batch_sizes(c: &mut Criterion) {
             &count,
             |bench, &n| {
                 bench.iter(|| {
-                    black_box(approximate_int8_batch_prepared(
-                        black_box(&pre_q_int8),
-                        black_box(&stored_int8[..n]),
-                    ))
+                    black_box(
+                        approximate_int8_batch_prepared(
+                            black_box(&pre_q_int8),
+                            black_box(&stored_int8[..n]),
+                        )
+                        .unwrap(),
+                    )
                 });
             },
         );
@@ -1171,10 +1178,13 @@ fn bench_prepared_batch_sizes(c: &mut Criterion) {
             &count,
             |bench, &n| {
                 bench.iter(|| {
-                    black_box(approximate_int4_batch_prepared(
-                        black_box(&pre_q_int4),
-                        black_box(&stored_int4[..n]),
-                    ))
+                    black_box(
+                        approximate_int4_batch_prepared(
+                            black_box(&pre_q_int4),
+                            black_box(&stored_int4[..n]),
+                        )
+                        .unwrap(),
+                    )
                 });
             },
         );

--- a/crates/embed/src/error.rs
+++ b/crates/embed/src/error.rs
@@ -67,6 +67,21 @@ pub enum EmbedError {
     /// Internal logic error (count mismatch, unexpected state).
     #[error("internal error: {0}")]
     Internal(String),
+
+    /// A quantization tier did not match the tier required by the operation.
+    ///
+    /// Raised by the `simd::tier` prepared-dispatch functions (e.g.
+    /// `approximate_cosine_distance_prepared`) when a `PreparedQuery`'s tier does not
+    /// match the stored data's tier, or a batch dispatch function's presumed tier.
+    #[error("tier mismatch in {op}: expected {expected:?}, got {actual:?}")]
+    TierMismatch {
+        /// Name of the operation where the mismatch was detected.
+        op: &'static str,
+        /// Tier the operation required.
+        expected: crate::simd::QuantizationTier,
+        /// Tier actually supplied.
+        actual: crate::simd::QuantizationTier,
+    },
 }
 
 /// **Stable**: result type alias for embedding operations.

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -293,31 +293,12 @@ pub fn prepare_query_with_norm(
 ///
 /// Returns a value in [0, 2] where 0 = identical, 2 = opposite.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the query tier does not match the stored-data tier.  Use
-/// [`try_approximate_cosine_distance_prepared`] when tiers are not statically
-/// guaranteed to match.
+/// Returns [`EmbedError::TierMismatch`] if the query tier does not match the
+/// stored-data tier.
 #[inline]
-pub fn approximate_cosine_distance_prepared(query: &PreparedQuery, stored: &QuantizedData) -> f32 {
-    match (query, stored) {
-        (PreparedQuery::Full(q), QuantizedData::Full(s)) => 1.0 - cosine_similarity(q, s),
-        (PreparedQuery::Int8(q), QuantizedData::Int8(s)) => {
-            1.0 - cosine_similarity_i8_trusted(s, q)
-        }
-        (PreparedQuery::Int4(q), QuantizedData::Int4(s)) => s.cosine_distance(q),
-        (PreparedQuery::Binary(q), QuantizedData::Binary(s)) => s.cosine_distance_approx(q),
-        _ => panic!("PreparedQuery tier must match QuantizedData tier"),
-    }
-}
-
-/// Non-panicking variant of [`approximate_cosine_distance_prepared`].
-///
-/// Returns `Err(EmbedError::Internal(...))` when the query tier does not match the
-/// stored-data tier instead of panicking.  Prefer this in contexts where the tiers
-/// may not be statically guaranteed to match.
-#[inline]
-pub fn try_approximate_cosine_distance_prepared(
+pub fn approximate_cosine_distance_prepared(
     query: &PreparedQuery,
     stored: &QuantizedData,
 ) -> Result<f32> {
@@ -328,33 +309,38 @@ pub fn try_approximate_cosine_distance_prepared(
         }
         (PreparedQuery::Int4(q), QuantizedData::Int4(s)) => Ok(s.cosine_distance(q)),
         (PreparedQuery::Binary(q), QuantizedData::Binary(s)) => Ok(s.cosine_distance_approx(q)),
-        _ => Err(EmbedError::Internal(
-            "PreparedQuery tier must match QuantizedData tier for cosine distance".into(),
-        )),
+        _ => Err(EmbedError::TierMismatch {
+            op: "approximate_cosine_distance_prepared",
+            expected: stored.tier(),
+            actual: query.tier(),
+        }),
     }
 }
 
-/// Non-panicking variant of [`approximate_dot_product_prepared`].
+/// Alias for [`approximate_cosine_distance_prepared`], retained for API compatibility.
 ///
-/// Returns `Err(EmbedError::Internal(...))` for binary inputs or a tier mismatch
-/// instead of panicking.
+/// As of the tier-mismatch hardening fix (issue #210), the non-`try_` variant no
+/// longer panics and returns the same `Result` as this function. Prefer the
+/// non-`try_` name in new code.
+#[inline]
+pub fn try_approximate_cosine_distance_prepared(
+    query: &PreparedQuery,
+    stored: &QuantizedData,
+) -> Result<f32> {
+    approximate_cosine_distance_prepared(query, stored)
+}
+
+/// Alias for [`approximate_dot_product_prepared`], retained for API compatibility.
+///
+/// As of the tier-mismatch hardening fix (issue #210), the non-`try_` variant no
+/// longer panics and returns the same `Result` as this function. Prefer the
+/// non-`try_` name in new code.
 #[inline]
 pub fn try_approximate_dot_product_prepared(
     query: &PreparedQuery,
     stored: &QuantizedData,
 ) -> Result<f32> {
-    match (query, stored) {
-        (PreparedQuery::Full(q), QuantizedData::Full(s)) => Ok(dot_product(q, s)),
-        (PreparedQuery::Int8(q), QuantizedData::Int8(s)) => Ok(dot_product_i8_trusted(q, s)),
-        (PreparedQuery::Int4(q), QuantizedData::Int4(s)) => Ok(s.dot_product(q)),
-        (PreparedQuery::Binary(_), QuantizedData::Binary(_)) => Err(EmbedError::Internal(
-            "Binary has no prepared dot product; use try_approximate_cosine_distance_prepared"
-                .into(),
-        )),
-        _ => Err(EmbedError::Internal(
-            "PreparedQuery tier must match QuantizedData tier for dot product".into(),
-        )),
-    }
+    approximate_dot_product_prepared(query, stored)
 }
 
 /// Cosine distance with unit-norm fast path.
@@ -370,58 +356,67 @@ pub fn try_approximate_dot_product_prepared(
 ///
 /// # Panics
 ///
-/// Panics (via [`approximate_cosine_distance_prepared`]) if the query tier does not
-/// match the stored-data tier. The unit-norm `Full` fast path returns directly and
-/// never reaches the delegate.
+/// # Errors
+///
+/// Returns [`EmbedError::TierMismatch`] (propagated from
+/// [`approximate_cosine_distance_prepared`]) if the query tier does not match the
+/// stored-data tier. The unit-norm `Full` fast path returns directly and never
+/// reaches the delegate.
 #[inline]
 pub fn approximate_cosine_distance_prepared_with_meta(
     meta: &PreparedQueryWithMeta,
     stored: &QuantizedData,
     stored_norm: NormalizationHint,
-) -> f32 {
+) -> Result<f32> {
     if meta.norm == NormalizationHint::Unit
         && stored_norm == NormalizationHint::Unit
         && let (PreparedQuery::Full(q), QuantizedData::Full(s)) = (&meta.query, stored)
     {
         let dot = dot_product(q, s);
-        return 1.0 - dot.clamp(-1.0, 1.0);
+        return Ok(1.0 - dot.clamp(-1.0, 1.0));
     }
     approximate_cosine_distance_prepared(&meta.query, stored)
 }
 
 /// **Unstable**: prepared dot product dispatch; query tier must match stored data tier.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the query tier does not match the stored-data tier, or if called
-/// with `Binary` data (binary has no meaningful dot product; use cosine distance
-/// instead).  Use [`try_approximate_dot_product_prepared`] for a non-panicking
-/// version.
+/// Returns [`EmbedError::TierMismatch`] if the query tier does not match the
+/// stored-data tier, or [`EmbedError::Internal`] if called with `Binary` data
+/// (binary has no meaningful dot product; use cosine distance instead).
 #[inline]
-pub fn approximate_dot_product_prepared(query: &PreparedQuery, stored: &QuantizedData) -> f32 {
+pub fn approximate_dot_product_prepared(
+    query: &PreparedQuery,
+    stored: &QuantizedData,
+) -> Result<f32> {
     match (query, stored) {
-        (PreparedQuery::Full(q), QuantizedData::Full(s)) => dot_product(q, s),
-        (PreparedQuery::Int8(q), QuantizedData::Int8(s)) => dot_product_i8_trusted(q, s),
-        (PreparedQuery::Int4(q), QuantizedData::Int4(s)) => s.dot_product(q),
-        (PreparedQuery::Binary(_), QuantizedData::Binary(_)) => {
-            panic!("Binary has no prepared dot product; use approximate_cosine_distance_prepared")
-        }
-        _ => panic!("PreparedQuery tier must match QuantizedData tier"),
+        (PreparedQuery::Full(q), QuantizedData::Full(s)) => Ok(dot_product(q, s)),
+        (PreparedQuery::Int8(q), QuantizedData::Int8(s)) => Ok(dot_product_i8_trusted(q, s)),
+        (PreparedQuery::Int4(q), QuantizedData::Int4(s)) => Ok(s.dot_product(q)),
+        (PreparedQuery::Binary(_), QuantizedData::Binary(_)) => Err(EmbedError::Internal(
+            "Binary has no prepared dot product; use approximate_cosine_distance_prepared".into(),
+        )),
+        _ => Err(EmbedError::TierMismatch {
+            op: "approximate_dot_product_prepared",
+            expected: stored.tier(),
+            actual: query.tier(),
+        }),
     }
 }
 
 /// Compute cosine distances from one prepared query to a slice of stored vectors.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics (via [`approximate_cosine_distance_prepared`]) if the query tier does not
-/// match any stored vector's tier. Use [`try_approximate_cosine_distance_prepared`]
-/// per item when tiers are not statically guaranteed to match.
+/// Returns [`EmbedError::TierMismatch`] (propagated from
+/// [`approximate_cosine_distance_prepared`]) if the query tier does not match any
+/// stored vector's tier.
 #[inline]
 pub fn batch_approximate_cosine_distance_prepared(
     query: &PreparedQuery,
     stored: &[QuantizedData],
-) -> Vec<f32> {
+) -> Result<Vec<f32>> {
     stored
         .iter()
         .map(|item| approximate_cosine_distance_prepared(query, item))
@@ -430,113 +425,137 @@ pub fn batch_approximate_cosine_distance_prepared(
 
 /// Like [`batch_approximate_cosine_distance_prepared`] but writes into a caller-supplied buffer.
 ///
-/// Clears and reuses the buffer to avoid allocations across repeated searches.
+/// Clears and reuses the buffer to avoid allocations across repeated searches. On error the
+/// buffer is left cleared (no partial results are written).
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics (via [`approximate_cosine_distance_prepared`]) if the query tier does not
-/// match any stored vector's tier.
+/// Returns [`EmbedError::TierMismatch`] (propagated from
+/// [`approximate_cosine_distance_prepared`]) if the query tier does not match any
+/// stored vector's tier.
 #[inline]
 pub fn batch_approximate_cosine_distance_prepared_into(
     query: &PreparedQuery,
     stored: &[QuantizedData],
     out: &mut Vec<f32>,
-) {
+) -> Result<()> {
     out.clear();
-    out.reserve(stored.len());
-    out.extend(
-        stored
-            .iter()
-            .map(|item| approximate_cosine_distance_prepared(query, item)),
-    );
+    let results: Vec<f32> = stored
+        .iter()
+        .map(|item| approximate_cosine_distance_prepared(query, item))
+        .collect::<Result<_>>()?;
+    out.extend(results);
+    Ok(())
 }
 
 /// Compute cosine distances from a prepared INT8 query to a slice of INT8 candidates.
 ///
 /// The query is quantized once outside this function; no per-iteration `from_f32` is called.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if `query` is not an `Int8` `PreparedQuery`.
+/// Returns [`EmbedError::TierMismatch`] if `query` is not an `Int8` `PreparedQuery`.
 #[inline]
 pub fn approximate_int8_batch_prepared(
     query: &PreparedQuery,
     candidates: &[QuantizedVector],
-) -> Vec<f32> {
+) -> Result<Vec<f32>> {
     let PreparedQuery::Int8(q) = query else {
-        panic!("PreparedQuery tier must be Int8");
+        return Err(EmbedError::TierMismatch {
+            op: "approximate_int8_batch_prepared",
+            expected: QuantizationTier::Int8,
+            actual: query.tier(),
+        });
     };
-    candidates
+    Ok(candidates
         .iter()
         .map(|candidate| 1.0 - cosine_similarity_i8_trusted(candidate, q))
-        .collect()
+        .collect())
 }
 
 /// Like [`approximate_int8_batch_prepared`] but writes into a caller-supplied buffer.
 ///
-/// # Panics
+/// On error the buffer is left cleared (no partial results are written).
 ///
-/// Panics if `query` is not an `Int8` `PreparedQuery`.
+/// # Errors
+///
+/// Returns [`EmbedError::TierMismatch`] if `query` is not an `Int8` `PreparedQuery`.
 #[inline]
 pub fn approximate_int8_batch_prepared_into(
     query: &PreparedQuery,
     candidates: &[QuantizedVector],
     out: &mut Vec<f32>,
-) {
-    let PreparedQuery::Int8(q) = query else {
-        panic!("PreparedQuery tier must be Int8");
-    };
+) -> Result<()> {
     out.clear();
+    let PreparedQuery::Int8(q) = query else {
+        return Err(EmbedError::TierMismatch {
+            op: "approximate_int8_batch_prepared_into",
+            expected: QuantizationTier::Int8,
+            actual: query.tier(),
+        });
+    };
     out.reserve(candidates.len());
     out.extend(
         candidates
             .iter()
             .map(|candidate| 1.0 - cosine_similarity_i8_trusted(candidate, q)),
     );
+    Ok(())
 }
 
 /// Compute cosine distances from a prepared INT4 query to a slice of INT4 candidates.
 ///
 /// The query is quantized once outside this function; no per-iteration `from_f32` is called.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if `query` is not an `Int4` `PreparedQuery`.
+/// Returns [`EmbedError::TierMismatch`] if `query` is not an `Int4` `PreparedQuery`.
 #[inline]
 pub fn approximate_int4_batch_prepared(
     query: &PreparedQuery,
     candidates: &[Int4Vector],
-) -> Vec<f32> {
+) -> Result<Vec<f32>> {
     let PreparedQuery::Int4(q) = query else {
-        panic!("PreparedQuery tier must be Int4");
+        return Err(EmbedError::TierMismatch {
+            op: "approximate_int4_batch_prepared",
+            expected: QuantizationTier::Int4,
+            actual: query.tier(),
+        });
     };
-    candidates
+    Ok(candidates
         .iter()
         .map(|candidate| candidate.cosine_distance(q))
-        .collect()
+        .collect())
 }
 
 /// Like [`approximate_int4_batch_prepared`] but writes into a caller-supplied buffer.
 ///
-/// # Panics
+/// On error the buffer is left cleared (no partial results are written).
 ///
-/// Panics if `query` is not an `Int4` `PreparedQuery`.
+/// # Errors
+///
+/// Returns [`EmbedError::TierMismatch`] if `query` is not an `Int4` `PreparedQuery`.
 #[inline]
 pub fn approximate_int4_batch_prepared_into(
     query: &PreparedQuery,
     candidates: &[Int4Vector],
     out: &mut Vec<f32>,
-) {
-    let PreparedQuery::Int4(q) = query else {
-        panic!("PreparedQuery tier must be Int4");
-    };
+) -> Result<()> {
     out.clear();
+    let PreparedQuery::Int4(q) = query else {
+        return Err(EmbedError::TierMismatch {
+            op: "approximate_int4_batch_prepared_into",
+            expected: QuantizationTier::Int4,
+            actual: query.tier(),
+        });
+    };
     out.reserve(candidates.len());
     out.extend(
         candidates
             .iter()
             .map(|candidate| candidate.cosine_distance(q)),
     );
+    Ok(())
 }
 
 /// **Unstable**: tiered distance dispatch; tier mix and formula may change.
@@ -754,9 +773,9 @@ mod tests {
             .map(QuantizedData::Int8)
             .collect();
 
-        let got = approximate_int8_batch_prepared(&prepared, &candidates);
+        let got = approximate_int8_batch_prepared(&prepared, &candidates).unwrap();
         for (i, item) in wrapped.iter().enumerate() {
-            let expected = approximate_cosine_distance_prepared(&prepared, item);
+            let expected = approximate_cosine_distance_prepared(&prepared, item).unwrap();
             assert!(
                 (got[i] - expected).abs() < 1e-6,
                 "int8 batch prepared mismatch at candidate {i}: got={}, expected={}",
@@ -779,9 +798,9 @@ mod tests {
             .map(QuantizedData::Int4)
             .collect();
 
-        let got = approximate_int4_batch_prepared(&prepared, &candidates);
+        let got = approximate_int4_batch_prepared(&prepared, &candidates).unwrap();
         for (i, item) in wrapped.iter().enumerate() {
-            let expected = approximate_cosine_distance_prepared(&prepared, item);
+            let expected = approximate_cosine_distance_prepared(&prepared, item).unwrap();
             assert!(
                 (got[i] - expected).abs() < 1e-5,
                 "int4 batch prepared mismatch at candidate {i}: got={}, expected={}",
@@ -804,8 +823,9 @@ mod tests {
             let q_cand = Int4Vector::from_f32(&candidate);
             let wrapped = QuantizedData::Int4(q_cand.clone());
 
-            let batch_result = approximate_int4_batch_prepared(&prepared, &[q_cand]);
-            let per_item_result = approximate_cosine_distance_prepared(&prepared, &wrapped);
+            let batch_result = approximate_int4_batch_prepared(&prepared, &[q_cand]).unwrap();
+            let per_item_result =
+                approximate_cosine_distance_prepared(&prepared, &wrapped).unwrap();
 
             assert!(
                 (batch_result[0] - per_item_result).abs() < 1e-5,
@@ -826,5 +846,164 @@ mod tests {
         for (a, b) in v.iter().zip(full_rt.iter()) {
             assert!((a - b).abs() < 1e-10, "Full tier should be lossless");
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Regression tests for issue #210: tier-mismatch in prepared SIMD
+    // dispatch must return a typed error, not panic.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_cosine_distance_prepared_tier_mismatch_returns_typed_error() {
+        let v = generate_vector(64, 1);
+        let query = PreparedQuery::from_f32(&v, QuantizationTier::Int8);
+        let stored = QuantizedData::from_f32(&v, QuantizationTier::Int4);
+
+        let err = approximate_cosine_distance_prepared(&query, &stored).unwrap_err();
+        match err {
+            EmbedError::TierMismatch {
+                op,
+                expected,
+                actual,
+            } => {
+                assert_eq!(op, "approximate_cosine_distance_prepared");
+                assert_eq!(expected, QuantizationTier::Int4);
+                assert_eq!(actual, QuantizationTier::Int8);
+            }
+            other => panic!("expected TierMismatch, got {other:?}"),
+        }
+
+        // try_ alias must agree.
+        assert!(try_approximate_cosine_distance_prepared(&query, &stored).is_err());
+    }
+
+    #[test]
+    fn test_dot_product_prepared_tier_mismatch_returns_typed_error() {
+        let v = generate_vector(64, 2);
+        let query = PreparedQuery::from_f32(&v, QuantizationTier::Full);
+        let stored = QuantizedData::from_f32(&v, QuantizationTier::Int8);
+
+        let err = approximate_dot_product_prepared(&query, &stored).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                EmbedError::TierMismatch {
+                    op: "approximate_dot_product_prepared",
+                    ..
+                }
+            ),
+            "unexpected error variant: {err:?}"
+        );
+
+        assert!(try_approximate_dot_product_prepared(&query, &stored).is_err());
+    }
+
+    #[test]
+    fn test_dot_product_prepared_binary_returns_typed_error_not_panic() {
+        let v = generate_vector(64, 3);
+        let query = PreparedQuery::from_f32(&v, QuantizationTier::Binary);
+        let stored = QuantizedData::from_f32(&v, QuantizationTier::Binary);
+
+        let err = approximate_dot_product_prepared(&query, &stored).unwrap_err();
+        assert!(
+            matches!(err, EmbedError::Internal(_)),
+            "unexpected error variant: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_cosine_distance_prepared_with_meta_tier_mismatch_returns_typed_error() {
+        let v = generate_vector(64, 4);
+        let meta =
+            PreparedQueryWithMeta::from_f32(&v, QuantizationTier::Full, NormalizationHint::Unknown);
+        let stored = QuantizedData::from_f32(&v, QuantizationTier::Int8);
+
+        let err = approximate_cosine_distance_prepared_with_meta(
+            &meta,
+            &stored,
+            NormalizationHint::Unknown,
+        )
+        .unwrap_err();
+        assert!(matches!(err, EmbedError::TierMismatch { .. }));
+    }
+
+    #[test]
+    fn test_batch_cosine_distance_prepared_tier_mismatch_returns_typed_error() {
+        let v = generate_vector(64, 5);
+        let query = PreparedQuery::from_f32(&v, QuantizationTier::Int8);
+        let stored = vec![
+            QuantizedData::from_f32(&v, QuantizationTier::Int8),
+            QuantizedData::from_f32(&v, QuantizationTier::Int4), // mismatched
+        ];
+
+        let err = batch_approximate_cosine_distance_prepared(&query, &stored).unwrap_err();
+        assert!(matches!(err, EmbedError::TierMismatch { .. }));
+
+        let mut out = vec![9.0, 9.0, 9.0]; // pre-populated, must be cleared even on error
+        let err =
+            batch_approximate_cosine_distance_prepared_into(&query, &stored, &mut out).unwrap_err();
+        assert!(matches!(err, EmbedError::TierMismatch { .. }));
+        assert!(
+            out.is_empty(),
+            "buffer must be cleared, not left with stale data"
+        );
+    }
+
+    #[test]
+    fn test_int8_batch_prepared_wrong_tier_returns_typed_error() {
+        let v = generate_vector(64, 6);
+        let query = PreparedQuery::from_f32(&v, QuantizationTier::Int4); // not Int8
+        let candidates = vec![QuantizedVector::from_f32(&v)];
+
+        let err = approximate_int8_batch_prepared(&query, &candidates).unwrap_err();
+        match err {
+            EmbedError::TierMismatch {
+                op,
+                expected,
+                actual,
+            } => {
+                assert_eq!(op, "approximate_int8_batch_prepared");
+                assert_eq!(expected, QuantizationTier::Int8);
+                assert_eq!(actual, QuantizationTier::Int4);
+            }
+            other => panic!("expected TierMismatch, got {other:?}"),
+        }
+
+        let mut out = vec![9.0];
+        let err = approximate_int8_batch_prepared_into(&query, &candidates, &mut out).unwrap_err();
+        assert!(matches!(err, EmbedError::TierMismatch { .. }));
+        assert!(
+            out.is_empty(),
+            "buffer must be cleared, not left with stale data"
+        );
+    }
+
+    #[test]
+    fn test_int4_batch_prepared_wrong_tier_returns_typed_error() {
+        let v = generate_vector(64, 7);
+        let query = PreparedQuery::from_f32(&v, QuantizationTier::Int8); // not Int4
+        let candidates = vec![Int4Vector::from_f32(&v)];
+
+        let err = approximate_int4_batch_prepared(&query, &candidates).unwrap_err();
+        match err {
+            EmbedError::TierMismatch {
+                op,
+                expected,
+                actual,
+            } => {
+                assert_eq!(op, "approximate_int4_batch_prepared");
+                assert_eq!(expected, QuantizationTier::Int4);
+                assert_eq!(actual, QuantizationTier::Int8);
+            }
+            other => panic!("expected TierMismatch, got {other:?}"),
+        }
+
+        let mut out = vec![9.0];
+        let err = approximate_int4_batch_prepared_into(&query, &candidates, &mut out).unwrap_err();
+        assert!(matches!(err, EmbedError::TierMismatch { .. }));
+        assert!(
+            out.is_empty(),
+            "buffer must be cleared, not left with stale data"
+        );
     }
 }

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -354,8 +354,6 @@ pub fn try_approximate_dot_product_prepared(
 /// that batch many lookups against a fixed stored set should pre-check once and
 /// use the cheaper overload directly.
 ///
-/// # Panics
-///
 /// # Errors
 ///
 /// Returns [`EmbedError::TierMismatch`] (propagated from
@@ -440,11 +438,16 @@ pub fn batch_approximate_cosine_distance_prepared_into(
     out: &mut Vec<f32>,
 ) -> Result<()> {
     out.clear();
-    let results: Vec<f32> = stored
-        .iter()
-        .map(|item| approximate_cosine_distance_prepared(query, item))
-        .collect::<Result<_>>()?;
-    out.extend(results);
+    out.reserve(stored.len());
+    for item in stored {
+        match approximate_cosine_distance_prepared(query, item) {
+            Ok(distance) => out.push(distance),
+            Err(e) => {
+                out.clear();
+                return Err(e);
+            }
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Closes #210. Converts every panicking path in `crates/embed/src/simd/tier.rs`'s
prepared-query SIMD dispatch layer into a typed `EmbedError` return, so a
mis-paired `(PreparedQuery, QuantizedData)` tier can no longer abort the
process.

## Site enumeration (grep-verified against current `main`, not the issue's
stale line numbers)

All in `crates/embed/src/simd/tier.rs`. The issue's count of 7 direct
`panic!`/`unreachable!` call sites matches what's on `main` today:

| # | Function | Before | After |
|---|----------|--------|-------|
| 1 | `approximate_cosine_distance_prepared` (was line 310) | `_ => panic!("PreparedQuery tier must match QuantizedData tier")` | `_ => Err(EmbedError::TierMismatch { op, expected: stored.tier(), actual: query.tier() })` |
| 2 | `approximate_dot_product_prepared` — Binary arm (was line 407) | `panic!("Binary has no prepared dot product; ...")` | `Err(EmbedError::Internal("Binary has no prepared dot product; ..."))` |
| 3 | `approximate_dot_product_prepared` — wildcard (was line 409) | `_ => panic!("PreparedQuery tier must match QuantizedData tier")` | `_ => Err(EmbedError::TierMismatch { .. })` |
| 4 | `approximate_int8_batch_prepared` (was line 467) | `let PreparedQuery::Int8(q) = query else { panic!(...) }` | `let PreparedQuery::Int8(q) = query else { return Err(EmbedError::TierMismatch { .. }) }` |
| 5 | `approximate_int8_batch_prepared_into` (was line 487) | same panic | same typed-error guard |
| 6 | `approximate_int4_batch_prepared` (was line 511) | `let PreparedQuery::Int4(q) = query else { panic!(...) }` | typed-error guard |
| 7 | `approximate_int4_batch_prepared_into` (was line 530) | same panic | same typed-error guard |

**Sibling-invocation-path rule applied**: grepped `crates/embed` for every
call site of these 7 functions plus the 2 batch-cosine wrapper functions.
Two knock-on callers directly transited a now-fallible function and needed
signature changes too (not separate panic sites, but they'd otherwise fail
to compile / silently swallow the new `Result`):

- `approximate_cosine_distance_prepared_with_meta` — falls back to
  `approximate_cosine_distance_prepared` on the non-unit-norm path.
- `batch_approximate_cosine_distance_prepared` /
  `batch_approximate_cosine_distance_prepared_into` — map the now-fallible
  cosine dispatch over a stored slice; converted to `Result<Vec<f32>>` /
  `Result<()>` via `.collect::<Result<_>>()`.

No other crate in the workspace (`inference`, `tune`, `fann`, `transport`)
calls any of these 9 functions — verified via
`grep -rn "approximate_.*_prepared\b" crates --include="*.rs" -l`, which
returns only `crates/embed/src/simd/tier.rs`, `crates/embed/src/simd/mod.rs`
(re-exports), and `crates/embed/benches/simd.rs`.

## Error-variant design

Added `EmbedError::TierMismatch { op: &'static str, expected: QuantizationTier,
actual: QuantizationTier }` to the `#[non_exhaustive]` `EmbedError` enum in
`crates/embed/src/error.rs`. This is an additive variant (non_exhaustive
already forces callers to have a wildcard arm), so it's not a breaking
change on its own.

The Binary-dot-product-unsupported arm keeps using
`EmbedError::Internal(String)` (an unsupported *operation*, not a tier
*mismatch* — same categorization the existing `try_*` siblings already
used).

`try_approximate_cosine_distance_prepared` and
`try_approximate_dot_product_prepared` (which already existed and already
returned `Result`, per the issue's own TBV note) are now thin aliases that
delegate to the base function — the base function *is* their old
implementation now, so keeping two names with duplicated match arms would
have been AEP-violating duplication. Both names remain public.

## Breaking-change note (workspace is 0.4.2, pre-1.0 → semver-minor allowed)

9 public function signatures change from infallible to `Result`-returning:
`approximate_cosine_distance_prepared`, `approximate_dot_product_prepared`,
`approximate_cosine_distance_prepared_with_meta`,
`batch_approximate_cosine_distance_prepared`,
`batch_approximate_cosine_distance_prepared_into`,
`approximate_int8_batch_prepared`, `approximate_int8_batch_prepared_into`,
`approximate_int4_batch_prepared`, `approximate_int4_batch_prepared_into`.
This is a source-breaking change for any external consumer of
`lattice-embed`'s prepared-dispatch API; given no in-workspace crate calls
these, the blast radius inside this monorepo is exactly the 2 files touched
here (tier.rs's own unit tests + benches/simd.rs). Recommend a minor version
bump on next release per the workspace's semver-minor-pre-1.0 convention.

The two `_into` variants now clear the output buffer before returning
`Err` (documented in their doc comments) rather than leaving it in
whatever partial state a fallible iterator might produce — no partial
writes on error.

## Mutation results

Reverted 2 representative guards (the cosine wildcard match arm, and the
`int8_batch_prepared` `let-else` tier guard), `touch`ed the file to force
a rebuild, and confirmed the corresponding new regression tests fail with
`called Result::unwrap_err() on an Ok value` — then restored the fix and
re-confirmed green. This establishes both new-test-shapes (match-arm
wildcard and `let-else` guard) are load-bearing, not decorative.

## Dependent accommodations

None outside `crates/embed` itself (no other workspace crate calls these
functions). Within `crates/embed`:

- `crates/embed/src/simd/tier.rs` unit tests (`test_int8_batch_prepared_matches_per_item_prepared`,
  `test_int4_batch_prepared_matches_per_item_prepared`,
  `test_int4_batch_prepared_api_dispatch_parity`) — added `.unwrap()` at
  each now-fallible call.
- `crates/embed/benches/simd.rs` — added `.unwrap()` at every call site
  (all benchmark inputs are tier-matched by construction, so this can
  never panic in practice; it only surfaces the new `Result` to satisfy
  the compiler).

7 new regression tests added (one per converted panic-site class + the
Binary-unsupported-operation arm), all in
`crates/embed/src/simd/tier.rs::tests`.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --features f16,metal-gpu -- -D warnings` — clean
- [x] `cargo test -p lattice-embed` — all pass (96 simd-module unit tests, 33+19+3 integration tests, 20 doctests)
- [x] `cargo check --workspace` — clean
- [x] Mutation-sensitivity verified on 2 representative guards (see above)
- [x] bench-compare deferred: centralized idle-machine batch pass planned (this PR touches only dispatch error handling, not the hot-path arithmetic; benches were updated mechanically with `.unwrap()` and not otherwise touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
