### PR TITLE
fix(inference): un-break main - test-module callers of Result-returning generate (#634 follow-up)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -23305,7 +23305,9 @@ kernel void decode_attention_reference(
                 logprobs: None,
             };
 
-            let out = state.generate("a", &tokenizer, &gen_cfg);
+            let out = state
+                .generate("a", &tokenizer, &gen_cfg)
+                .expect("generate (plain)");
             assert_excludes_stop_token_metal(&out, "MetalQwen35State::generate (plain)");
         }
 
@@ -23342,7 +23344,9 @@ kernel void decode_attention_reference(
                 logprobs: None,
             };
 
-            let out = state.generate("a", &tokenizer, &gen_cfg);
+            let out = state
+                .generate("a", &tokenizer, &gen_cfg)
+                .expect("generate (LATTICE_MTP)");
             assert_excludes_stop_token_metal(&out, "MetalQwen35State::generate (LATTICE_MTP)");
         }
 
@@ -23382,6 +23386,7 @@ kernel void decode_attention_reference(
                 );
                 state.generate("a", &tokenizer, &gen_cfg)
             });
+            let out = out.expect("generate (LATTICE_SELF_SPEC)");
             assert_excludes_stop_token_metal(
                 &out,
                 "MetalQwen35State::generate (LATTICE_SELF_SPEC)",
@@ -23416,10 +23421,12 @@ kernel void decode_attention_reference(
             };
 
             let mut deltas: Vec<String> = vec![];
-            let out = state.generate_streaming("a", &tokenizer, &gen_cfg, |delta, _id| {
-                deltas.push(delta.to_string());
-                true
-            });
+            let out = state
+                .generate_streaming("a", &tokenizer, &gen_cfg, |delta, _id| {
+                    deltas.push(delta.to_string());
+                    true
+                })
+                .expect("generate_streaming");
             assert_excludes_stop_token_metal(&out, "MetalQwen35State::generate_streaming");
             assert!(
                 deltas.is_empty(),
@@ -25572,12 +25579,9 @@ kernel void decode_attention_reference(
             let mut reference_state =
                 MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
             let reference_gen_cfg = cross_turn_test_gen_cfg(42, 3);
-            let reference_out = reference_state.generate_streaming(
-                &edited_prompt,
-                &tokenizer,
-                &reference_gen_cfg,
-                |_, _| true,
-            );
+            let reference_out = reference_state
+                .generate_streaming(&edited_prompt, &tokenizer, &reference_gen_cfg, |_, _| true)
+                .expect("reference re-prefill generate_streaming");
             assert_eq!(
                 edited.output.token_ids, reference_out.token_ids,
                 "replayed-from-checkpoint token IDs must match full re-prefill exactly"
@@ -25627,12 +25631,14 @@ kernel void decode_attention_reference(
             );
             let mut probe_reference_state =
                 MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
-            let probe_reference = probe_reference_state.generate_streaming(
-                &probe_prompt,
-                &tokenizer,
-                &cross_turn_test_gen_cfg(42, 3),
-                |_, _| true,
-            );
+            let probe_reference = probe_reference_state
+                .generate_streaming(
+                    &probe_prompt,
+                    &tokenizer,
+                    &cross_turn_test_gen_cfg(42, 3),
+                    |_, _| true,
+                )
+                .expect("probe reference generate_streaming");
             assert_eq!(
                 probe.output.token_ids, probe_reference.token_ids,
                 "probe token IDs must match full re-prefill exactly"
@@ -25657,12 +25663,14 @@ kernel void decode_attention_reference(
             );
             let mut followup_reference_state =
                 MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
-            let followup_reference = followup_reference_state.generate_streaming(
-                &followup_prompt,
-                &tokenizer,
-                &cross_turn_test_gen_cfg(42, 3),
-                |_, _| true,
-            );
+            let followup_reference = followup_reference_state
+                .generate_streaming(
+                    &followup_prompt,
+                    &tokenizer,
+                    &cross_turn_test_gen_cfg(42, 3),
+                    |_, _| true,
+                )
+                .expect("followup reference generate_streaming");
             assert_eq!(
                 followup.output.token_ids, followup_reference.token_ids,
                 "post-replay append token IDs must match full re-prefill exactly"


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Problem

Main is red since #634 merged (run 28714308803: msrv, feature-matrix macos, bench-compile all fail). #634 changed `generate`/`generate_streaming` to return `Result<GenerateOutput, InferenceError>` and updated binaries/examples/benches, but seven call sites in the metal_qwen35.rs `#[cfg(test)]` module were missed. They only compile under `--all-targets` with `f16,metal-gpu`, which the default local build skips (the known sibling-invocation-path class).

## Fix

Mechanical `.expect()` at each of the seven sites (four stop-token contract tests, three cross-turn re-prefill reference calls). No behavior change: these are test assertions where a generation error should panic the test.

## Verification

- `cargo check -p lattice-inference --features f16,metal-gpu --all-targets` green locally (was 9 errors)
- `cargo clippy -p lattice-inference --features f16,metal-gpu --all-targets -- -D warnings` green locally

## Semver flag for the next release

The #634 signature change on public API is breaking; the next crates.io publish must bump to 0.5.0, not 0.4.3.

Test-only change, no bench-compare applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

