### PR TITLE
chore(release): v0.5.0 - version bump + release notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 # MSRV, verified end-to-end (workspace + deps) on 1.93.1 and guarded by the msrv CI
 # job (aarch64 macOS, f16,metal-gpu, --all-targets) so a newer-toolchain-only API

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.4.2", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.5.0", path = "../inference", optional = true, features = ["f16"] }
 
 # Time
 chrono = { workspace = true }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -52,7 +52,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.4.2", path = "../fann", optional = true }
+lattice-fann = { version = "0.5.0", path = "../fann", optional = true }
 
 [[bin]]
 name = "lattice"

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -30,7 +30,7 @@ sqlite = ["dep:rusqlite", "serde"]
 mixture = ["lattice-fann/online-router"]
 
 [dependencies]
-lattice-fann = { version = "0.4.2", path = "../fann" }
+lattice-fann = { version = "0.5.0", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -51,7 +51,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.4.2", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.5.0", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,6 +1,6 @@
 # lattice v0.5.0
 
-91 commits since v0.4.2. Minor-version bump because this release changes a public API
+97 commits since v0.4.2. Minor-version bump because this release changes a public API
 (see Breaking changes); under 0.x semantics, 0.5.0 is the compatibility boundary.
 
 ## Breaking changes
@@ -24,6 +24,11 @@
   stop token from `token_ids`/`text` and reports `stop_reason` consistently.
 - **Q4 MTP weight loading** (#630, #636): native Q4 checkpoints now load MTP weights,
   extending the LATTICE_MTP speculative path to quantized models.
+- **Cross-turn KV prefix reuse in `chat_metal`** (#462, #619): interactive REPL and
+  `--json` chat turns that extend the previous conversation reuse cached KV/GDN state
+  and only prefill the new suffix, instead of re-prefilling the whole history every
+  turn. Edited histories, adapter swaps, or any fingerprint mismatch fall back to a
+  full re-prefill automatically.
 - **Sparse GDN checkpoint replay for the cross-turn cache** (#590, #635) plus a
   codified GDN chunked-prefill drift bound (#534, #563).
 - **Native Q4 checkpoints in `lattice chat` / `lattice serve`** (#581), turning the

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,56 @@
+# lattice v0.5.0
+
+91 commits since v0.4.2. Minor-version bump because this release changes a public API
+(see Breaking changes); under 0.x semantics, 0.5.0 is the compatibility boundary.
+
+## Breaking changes
+
+- `MetalQwen35State::generate`, `generate_streaming`, and the related Metal generation
+  entry points now return `Result<GenerateOutput, InferenceError>` instead of
+  `GenerateOutput` (#634). This is the fail-closed grammar-mask fix: a grammar state
+  that masks every token now surfaces `InferenceError::InvalidInput` instead of
+  silently feeding an all-`-inf` logit row to the sampler. Callers add `?` or match on
+  the error.
+- The HTTP serving stack (axum/tokio/futures) is now behind a default-on `serve`
+  feature (#644). `cargo install lattice-inference` and existing
+  `--features f16,metal-gpu` profiles are unchanged; library consumers building with
+  `default-features = false` no longer pull an HTTP server into their tree.
+
+## Highlights
+
+- **Fail-closed Metal grammar masking** (#611, #634): all Metal generation paths guard
+  `mask_logits` the way the CPU paths always have.
+- **Unified stop-token contract** (#613, #632): every `generate()` path excludes the
+  stop token from `token_ids`/`text` and reports `stop_reason` consistently.
+- **Q4 MTP weight loading** (#630, #636): native Q4 checkpoints now load MTP weights,
+  extending the LATTICE_MTP speculative path to quantized models.
+- **Sparse GDN checkpoint replay for the cross-turn cache** (#590, #635) plus a
+  codified GDN chunked-prefill drift bound (#534, #563).
+- **Native Q4 checkpoints in `lattice chat` / `lattice serve`** (#581), turning the
+  27B model into a practical chat/serve surface on Apple Silicon.
+- **OpenAI-compatible logprobs/top_logprobs** on chat completions (#585, #620) and an
+  ADR-068 grammar wire contract (#607).
+- **`lattice doctor` preflight** (#586, #605) and QuaRot `quantize_index.json`
+  object-form acceptance (#627).
+- **Real install channel** (#633, #638): cargo-install packaging plus a
+  release-binaries workflow.
+- **Two-stage lm_head block top-k Stage-1 fused kernel** (#171, #559).
+- **Machine-wide Metal test serialization** via `/tmp/lion-metal-gpu-test.lock`
+  flock (#631), plus typed errors for embed SIMD tier mismatch (#210, #639).
+- Stable-toolchain ARM builds: nightly-only NEON f16 intrinsics removed (#568, #570).
+
+## Fixes
+
+- Truncated Q4 mmap payloads rejected before Metal dispatch (#540, #557).
+- `max_new_tokens == 0` short-circuits across batch_prefill/cpu_f16/neon/multimodal
+  paths (#612, #621).
+- Serve cancels queued/running jobs on client disconnect (#552, #606).
+- Bench gate baseline parse mismatch (#545, #561); quantize_q4 output accounting
+  derived from `Q4_BLOCK_BYTES` (#569).
+- Test-module callers updated for the `Result` generation API (#645).
+
+## Docs
+
+- ROADMAP.md (#567), CLI/serve capability matrix (#589, #642), verified CLI
+  walkthroughs (#602, #640), Q4/QuaRot + cross-turn cache + serve API cookbooks
+  (#625), Raspberry Pi / ARM install tips (#576).


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Workspace 0.4.2 -> 0.5.0, internal path-dep versions in lockstep, docs/releases/v0.5.0.md (91 commits since v0.4.2).

## Why 0.5.0, not 0.4.3

#634 changed the Metal generation entry points to return `Result<GenerateOutput, InferenceError>` — a breaking public API change. Under 0.x semantics the minor version is the compatibility boundary, so patch-bumping would break `^0.4` users on `cargo update`.

## Merge gating

Holds in draft until: #645 (main un-break) and #644 (serve feature split, part of this release's content) are both MERGED and main is green end-to-end. Tag + `make publish` follow the merged state per the publish protocol (fann, transport -> inference -> embed, tune).

Version/docs-only change: bench-compare waiver (no code paths touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
