### PR TITLE
ci: faster queue (concurrency + docs-only skip) and stricter gates (typos, actionlint, semver-checks)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint config (docs: https://github.com/rhysd/actionlint/blob/main/docs/config.md).
+# actionlint has no way to know about self-hosted runner labels that only
+# exist in this repository's own runner fleet, so it flags them as unknown
+# by default; declaring them here is the documented fix.
+self-hosted-runner:
+  labels:
+    - m2max

--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -32,9 +32,13 @@ on:
 # Cancel a PR's own superseded runs so they stop occupying the shared macOS
 # runner pool (~5 concurrent, account-wide) while a newer push on the same PR
 # waits behind them. Never cancel a push to main or a manual dispatch: neither
-# has a "next run" to fall back on if killed mid-flight.
+# has a "next run" to fall back on if killed mid-flight. The event_name segment
+# keeps a push run and a workflow_dispatch run on the same ref out of each
+# other's queue: GitHub cancels a PENDING run whenever another run enters its
+# group, even with cancel-in-progress false, so two different trigger kinds
+# sharing one group could still replace each other while queued.
 concurrency:
-  group: app-binaries-${{ github.event.pull_request.number || github.ref }}
+  group: app-binaries-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -29,6 +29,14 @@ on:
       - '.github/workflows/app-binaries.yml'
   workflow_dispatch:
 
+# Cancel a PR's own superseded runs so they stop occupying the shared macOS
+# runner pool (~5 concurrent, account-wide) while a newer push on the same PR
+# waits behind them. Never cancel a push to main or a manual dispatch: neither
+# has a "next run" to fall back on if killed mid-flight.
+concurrency:
+  group: app-binaries-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,11 @@ name: CI
 # `unwrap-in-lib-lint` stay ungated and directly required: they are already
 # cheap ubuntu-only jobs, so gating them would save nothing.
 #
-# Rollout note: branch protection's required contexts currently list the
-# seven heavy job/matrix names directly. Swapping them for `ci-gate` is a
-# repo-settings change (Settings -> Branches -> main protection rule), done
-# once this workflow shape is merged and green.
+# Rollout note: branch protection's required contexts were swapped on
+# 2026-07-04 from the seven heavy job/matrix names to `ci-gate` (plus the
+# unchanged cargo-deny, parity-gate, app-binaries-gate, and q4 composed
+# golden). PRs branched from a pre-ci-gate main must update their branch
+# (strict up-to-date protection forces this anyway) to produce the context.
 on:
   push:
     branches: [main]
@@ -427,23 +428,16 @@ jobs:
           version: '1.7.12'
 
   # cargo-semver-checks against the latest published crates.io release for
-  # every internal path-dependency crate. Not yet a required context, per the
-  # continue-on-error note below, but visible on every PR so a breaking public
-  # API change is flagged before it ships unversioned, the way #634 was not.
+  # every internal path-dependency crate, so a breaking public API change is
+  # flagged before it ships unversioned, the way #634 was not. Gated through
+  # ci-gate below (it is docs-gated, so it cannot be a direct required
+  # context). The v0.5.0 publish reset the baseline: all five crates pass
+  # against the published 0.5.0, so this is a real gate, not informational.
   semver-checks:
     name: semver-checks
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    # Two of the five crates (lattice-inference, lattice-tune) already carry
-    # breaking public-API changes on main relative to the published 0.4.2
-    # baseline, accumulated before this gate existed and unrelated to any one
-    # PR; they will keep failing until the next version bump absorbs them.
-    # continue-on-error keeps the per-PR signal visible without holding every
-    # unrelated PR hostage to pre-existing debt this job did not create. Once
-    # a version bump brings the tree back to a clean baseline and this job
-    # proves green, it can be promoted to a required check.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -464,12 +458,12 @@ jobs:
   # safe required context: a matrix job skipped at job level never creates
   # its per-combination check runs at all, and a plain gated job that skips
   # reports success even if `changes` itself blew up. This job passes when
-  # there is nothing to check (docs-only) and mirrors the four heavy jobs'
+  # there is nothing to check (docs-only) and mirrors the five gated jobs'
   # results when there is, exactly like `parity-gate` in e2e-parity.yml and
   # `app-binaries-gate` in app-binaries.yml.
   ci-gate:
     name: ci-gate
-    needs: [changes, ci, feature-matrix, bench-compile, msrv]
+    needs: [changes, ci, feature-matrix, bench-compile, msrv, semver-checks]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -481,7 +475,8 @@ jobs:
           FEATURE_MATRIX_RESULT="${{ needs.feature-matrix.result }}"
           BENCH_COMPILE_RESULT="${{ needs.bench-compile.result }}"
           MSRV_RESULT="${{ needs.msrv.result }}"
-          echo "changes=$CHANGES_RESULT code=$CODE ci=$CI_RESULT feature-matrix=$FEATURE_MATRIX_RESULT bench-compile=$BENCH_COMPILE_RESULT msrv=$MSRV_RESULT"
+          SEMVER_RESULT="${{ needs.semver-checks.result }}"
+          echo "changes=$CHANGES_RESULT code=$CODE ci=$CI_RESULT feature-matrix=$FEATURE_MATRIX_RESULT bench-compile=$BENCH_COMPILE_RESULT msrv=$MSRV_RESULT semver-checks=$SEMVER_RESULT"
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::change-detection did not succeed, failing closed."
             exit 1
@@ -506,5 +501,9 @@ jobs:
             echo "::error::msrv did not succeed (result=$MSRV_RESULT)."
             exit 1
           fi
-          echo "Code changed; ci, feature-matrix, bench-compile, and msrv all PASSED."
+          if [ "$SEMVER_RESULT" != "success" ]; then
+            echo "::error::semver-checks did not succeed (result=$SEMVER_RESULT)."
+            exit 1
+          fi
+          echo "Code changed; ci, feature-matrix, bench-compile, msrv, and semver-checks all PASSED."
           exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,80 @@
 name: CI
 
-# NOTE: no `paths-ignore`. Every job here is (or can be) a *required* status
-# check, and a required check that never runs leaves a PR stuck on "Expected —
-# waiting for status to be reported" forever. So CI always runs on every PR to
-# main; the cargo cache keeps doc-only re-runs cheap (nothing recompiles).
+# NOTE: no `paths-ignore` on the triggers below. Every job here is (or can be)
+# a *required* status check, and a required check whose workflow never even
+# runs leaves a PR stuck on "Expected, waiting for status to be reported"
+# forever. So this workflow always triggers on every PR to main. Docs-only
+# PRs are instead handled per-job: `ci`, `feature-matrix`, `bench-compile`,
+# and `msrv` are gated on the `changes` job below and report `skipped` rather
+# than spending the account-wide macOS runner pool on a diff that cannot
+# affect compilation. A skipped required check still satisfies branch
+# protection, unlike a job whose workflow never ran at all. `cargo-deny`,
+# `rustdoc-lint`, and `unwrap-in-lib-lint` stay ungated: they are already
+# cheap ubuntu-only jobs, so gating them would save nothing.
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
+# Cancel a PR's own superseded runs so they stop occupying the shared
+# macOS runner pool (~5 concurrent, account-wide) while a newer push on the
+# same PR waits behind them. Never cancel a push to main: main has no "next
+# push" to fall back on if a run is killed mid-flight.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   LATTICE_REQUIRE_FIXTURES: "1"
 
 jobs:
+  # Decide whether anything outside the docs set changed. A PR that only
+  # touches markdown, ADRs, LICENSE, or .gitignore cannot affect compilation,
+  # so it does not need the macOS/ARM compile matrix below.
+  changes:
+    name: detect-code-changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
+            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+              || git diff --name-only "HEAD~1...HEAD")
+          else
+            CHANGED=$(git diff --name-only "HEAD~1...HEAD" 2>/dev/null || true)
+          fi
+          echo "Changed files:"
+          echo "$CHANGED"
+          # Docs set: **/*.md, docs/**, LICENSE*, .gitignore. Everything else
+          # counts as code, including workflow files, Cargo.*, Makefile*, and
+          # scripts/**. Conservative on purpose: when in doubt, run the matrix.
+          # Two single greps against here-strings, not a `grep | grep -q` pipe:
+          # a downstream `-q` can close its end of a pipe early and SIGPIPE the
+          # upstream producer, and under `pipefail` that reports as the
+          # pipeline's exit code instead of the match result (fail-open on a
+          # large diff).
+          NON_DOCS=$(grep -vE '(\.md$|^docs/|^LICENSE|^\.gitignore$)' <<<"$CHANGED" || true)
+          if grep -q . <<<"$NON_DOCS"; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "→ non-docs files changed: full matrix REQUIRED"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "→ docs-only change: full matrix skipped"
+          fi
+
   ci:
     name: CI
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -56,6 +114,8 @@ jobs:
   # spending runner time executing.
   feature-matrix:
     name: feature-matrix
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -211,6 +271,8 @@ jobs:
   # on x86 they are cfg'd out and the gate would be vacuous.
   bench-compile:
     name: bench-compile
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -237,6 +299,8 @@ jobs:
   # "compiles at MSRV", behavior is covered by the 1.94.1 jobs above.
   msrv:
     name: msrv (1.93, f16+metal-gpu)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -320,3 +384,58 @@ jobs:
       - name: clippy — unwrap/expect in library targets (informational)
         continue-on-error: true
         run: cargo clippy --workspace --lib -- -D clippy::unwrap_used -D clippy::expect_used
+
+  # Cheap ubuntu spell-check. Comments, docs, and error-message strings have
+  # no compiler or test to catch a typo, so this is the only gate that reads
+  # prose at all. Ungated: the tool itself takes well under a minute.
+  typos:
+    name: typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.48.0
+
+  # Cheap ubuntu workflow lint. Catches malformed expressions, unknown
+  # contexts/inputs, and shellcheck-level issues inside `run:` steps before
+  # they only surface as a confusing failure on a live runner. Ungated for the
+  # same reason as `typos`: it is a fast, dependency-light static check.
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: raven-actions/actionlint@v2.2.0
+        with:
+          version: '1.7.12'
+
+  # cargo-semver-checks against the latest published crates.io release for
+  # every internal path-dependency crate. Not yet a required context, per the
+  # continue-on-error note below, but visible on every PR so a breaking public
+  # API change is flagged before it ships unversioned, the way #634 was not.
+  semver-checks:
+    name: semver-checks
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    # Two of the five crates (lattice-inference, lattice-tune) already carry
+    # breaking public-API changes on main relative to the published 0.4.2
+    # baseline, accumulated before this gate existed and unrelated to any one
+    # PR; they will keep failing until the next version bump absorbs them.
+    # continue-on-error keeps the per-PR signal visible without holding every
+    # unrelated PR hostage to pre-existing debt this job did not create. Once
+    # a version bump brings the tree back to a clean baseline and this job
+    # proves green, it can be promoted to a required check.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: semver-checks
+      # metal-gpu does not compile on Linux and must stay off; default-features
+      # keeps the check to each crate's own `[features] default = [...]` set
+      # rather than the action's heuristic all-features-ish default, which
+      # would otherwise try to turn on optional platform-gated features.
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: lattice-fann,lattice-transport,lattice-inference,lattice-embed,lattice-tune
+          feature-group: default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,27 @@ name: CI
 # a *required* status check, and a required check whose workflow never even
 # runs leaves a PR stuck on "Expected, waiting for status to be reported"
 # forever. So this workflow always triggers on every PR to main. Docs-only
-# PRs are instead handled per-job: `ci`, `feature-matrix`, `bench-compile`,
-# and `msrv` are gated on the `changes` job below and report `skipped` rather
-# than spending the account-wide macOS runner pool on a diff that cannot
-# affect compilation. A skipped required check still satisfies branch
-# protection, unlike a job whose workflow never ran at all. `cargo-deny`,
-# `rustdoc-lint`, and `unwrap-in-lib-lint` stay ungated: they are already
+# PRs are instead handled by gating `ci`, `feature-matrix`, `bench-compile`,
+# and `msrv` on the `changes` job below.
+#
+# `ci` and `feature-matrix` are matrix jobs, so their required-check contexts
+# come from matrix expansion ("CI (macos-latest)", "feature-matrix
+# (ubuntu-latest)", etc). `jobs.<id>.if` is evaluated BEFORE the matrix
+# expands, so a docs-only skip at job level never even creates those
+# per-combination check runs; a required context that never gets created
+# stays "Expected, waiting for status" forever, the exact trap this
+# workflow's triggers are already written to avoid. So the matrix-expanded
+# names are NOT the required contexts here: `ci-gate` at the bottom of this
+# file is, mirroring `parity-gate` in e2e-parity.yml and `app-binaries-gate`
+# in app-binaries.yml. It always runs, always reports, and fails closed if
+# change-detection itself failed. `cargo-deny`, `rustdoc-lint`, and
+# `unwrap-in-lib-lint` stay ungated and directly required: they are already
 # cheap ubuntu-only jobs, so gating them would save nothing.
+#
+# Rollout note: branch protection's required contexts currently list the
+# seven heavy job/matrix names directly. Swapping them for `ci-gate` is a
+# repo-settings change (Settings -> Branches -> main protection rule), done
+# once this workflow shape is merged and green.
 on:
   push:
     branches: [main]
@@ -20,9 +34,13 @@ on:
 # Cancel a PR's own superseded runs so they stop occupying the shared
 # macOS runner pool (~5 concurrent, account-wide) while a newer push on the
 # same PR waits behind them. Never cancel a push to main: main has no "next
-# push" to fall back on if a run is killed mid-flight.
+# push" to fall back on if a run is killed mid-flight. The event_name segment
+# keeps a push run and a workflow_dispatch run on the same ref out of each
+# other's queue: GitHub cancels a PENDING run whenever another run enters its
+# group, even with cancel-in-progress false, so two different trigger kinds
+# sharing one group could still replace each other while queued.
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -439,3 +457,54 @@ jobs:
         with:
           package: lattice-fann,lattice-transport,lattice-inference,lattice-embed,lattice-tune
           feature-group: default-features
+
+  # REQUIRED status check (see the rollout note at the top of this file).
+  # Always runs, always reports. `ci`, `feature-matrix`, `bench-compile`, and
+  # `msrv` are matrix and/or docs-gated, so none of them is individually a
+  # safe required context: a matrix job skipped at job level never creates
+  # its per-combination check runs at all, and a plain gated job that skips
+  # reports success even if `changes` itself blew up. This job passes when
+  # there is nothing to check (docs-only) and mirrors the four heavy jobs'
+  # results when there is, exactly like `parity-gate` in e2e-parity.yml and
+  # `app-binaries-gate` in app-binaries.yml.
+  ci-gate:
+    name: ci-gate
+    needs: [changes, ci, feature-matrix, bench-compile, msrv]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve gate
+        run: |
+          CHANGES_RESULT="${{ needs.changes.result }}"
+          CODE="${{ needs.changes.outputs.code }}"
+          CI_RESULT="${{ needs.ci.result }}"
+          FEATURE_MATRIX_RESULT="${{ needs.feature-matrix.result }}"
+          BENCH_COMPILE_RESULT="${{ needs.bench-compile.result }}"
+          MSRV_RESULT="${{ needs.msrv.result }}"
+          echo "changes=$CHANGES_RESULT code=$CODE ci=$CI_RESULT feature-matrix=$FEATURE_MATRIX_RESULT bench-compile=$BENCH_COMPILE_RESULT msrv=$MSRV_RESULT"
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::change-detection did not succeed, failing closed."
+            exit 1
+          fi
+          if [ "$CODE" != "true" ]; then
+            echo "Docs-only change, heavy compile jobs not required. PASS."
+            exit 0
+          fi
+          if [ "$CI_RESULT" != "success" ]; then
+            echo "::error::ci did not succeed (result=$CI_RESULT)."
+            exit 1
+          fi
+          if [ "$FEATURE_MATRIX_RESULT" != "success" ]; then
+            echo "::error::feature-matrix did not succeed (result=$FEATURE_MATRIX_RESULT)."
+            exit 1
+          fi
+          if [ "$BENCH_COMPILE_RESULT" != "success" ]; then
+            echo "::error::bench-compile did not succeed (result=$BENCH_COMPILE_RESULT)."
+            exit 1
+          fi
+          if [ "$MSRV_RESULT" != "success" ]; then
+            echo "::error::msrv did not succeed (result=$MSRV_RESULT)."
+            exit 1
+          fi
+          echo "Code changed; ci, feature-matrix, bench-compile, and msrv all PASSED."
+          exit 0

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -27,8 +27,12 @@ on:
 # runner pool (~5 concurrent, account-wide) while a newer push on the same PR
 # waits behind them. Never cancel a push to main, a schedule, or a manual
 # dispatch: none of those has a "next run" to fall back on if killed mid-flight.
+# The event_name segment keeps a scheduled run and a main-push run from
+# sharing one queue: GitHub cancels a PENDING run whenever another run enters
+# its group, even with cancel-in-progress false, so a schedule/push/dispatch
+# trio sharing github.ref could replace each other while queued.
 concurrency:
-  group: e2e-parity-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-parity-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -23,6 +23,14 @@ on:
     - cron: '0 6 * * 1'  # weekly Monday 06:00 UTC
   workflow_dispatch:
 
+# Cancel a PR's own superseded runs so they stop occupying the shared macOS
+# runner pool (~5 concurrent, account-wide) while a newer push on the same PR
+# waits behind them. Never cancel a push to main, a schedule, or a manual
+# dispatch: none of those has a "next run" to fall back on if killed mid-flight.
+concurrency:
+  group: e2e-parity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,44 @@
+# Spell-check config for `typos` (crate-ci/typos). Kept minimal: only what the
+# tool actually flags in this repo, not a preemptive kitchen-sink list.
+
+[files]
+# Binary/data fixtures and large corpora are not prose; scanning them as text
+# produces thousands of false positives from arbitrary subword byte sequences
+# and floating-point dumps. Excluded even though `.gitignore` already covers
+# `target/` and `.khive/`, so the exclusion is explicit rather than incidental.
+extend-exclude = [
+    "crates/inference/tests/fixtures/tokenizers/**",
+    "crates/inference/benchmarks/golden_logits/**",
+    "crates/embed/tests/fixtures/**",
+    "docs/bench_results/**",
+    "target/**",
+    ".khive/**",
+]
+
+[default.extend-words]
+# Domain vocabulary and established abbreviations, not misspellings:
+ot = "ot"       # optimal transport (crates/transport, ADR-035/036/038/039/055)
+wht = "wht"     # Walsh-Hadamard Transform (QuaRot rotation)
+nax = "nax"     # MLX's own `_nax` GEMM dispatch suffix, quoted in docs/mlx_kernel_study.md
+tpe = "tpe"     # Tree-structured Parzen Estimator (hyperparameter search)
+comput = "comput" # bibliographic abbreviation, "SIAM J. Sci. Comput."
+oll = "oll"     # ollama shell/plot variable abbreviation in bench scripts
+yhat = "yhat"   # statistics notation (predicted value)
+unparseable = "unparseable" # accepted alternate spelling (cf. Java ParseException)
+
+# Short local-variable and struct-field abbreviations the checker treats as
+# misspelled English words:
+ba = "ba"       # a/b-comparison suffix (ws_ba, div_ba, d_ba)
+alog = "alog"   # GDN a_log gate weight (w_alog)
+paln = "paln"   # post_attention_layernorm abbreviation
+clen = "clen"   # cache/context-length loop variable in decode benchmarks
+lits = "lits"   # `Vec<String>` of literals in the JSON-schema grammar compiler
+mis = "mis"     # the "mis-" prefix (mis-sample, mis-sized, mis-hoisted, mis-writes)
+pn = "pn"       # Metal shader-source string literal variable name
+
+# Deliberate test/bench literals, not real words:
+abd = "abd"     # JSON-schema grammar const-string test fixtures ("abc"/"abd"/"abe")
+fo = "fo"       # truncated-string grammar rejection test ("fo"/"foo"/"food")
+hel = "hel"     # tokenizer BPE merge-algorithm test fixture ("hel" + "l" -> "hell")
+transfor = "transfor" # progressive-substring bench label building up to "transform"
+artic = "artic"       # progressive-substring bench label building up to "artificial"

--- a/_typos.toml
+++ b/_typos.toml
@@ -5,14 +5,13 @@
 # Binary/data fixtures and large corpora are not prose; scanning them as text
 # produces thousands of false positives from arbitrary subword byte sequences
 # and floating-point dumps. Excluded even though `.gitignore` already covers
-# `target/` and `.khive/`, so the exclusion is explicit rather than incidental.
+# `target/`, so the exclusion is explicit rather than incidental.
 extend-exclude = [
     "crates/inference/tests/fixtures/tokenizers/**",
     "crates/inference/benchmarks/golden_logits/**",
     "crates/embed/tests/fixtures/**",
     "docs/bench_results/**",
     "target/**",
-    ".khive/**",
 ]
 
 [default.extend-words]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Why

The account-wide GitHub macOS runner concurrency cap is shared across every
job, and up to 9 macOS jobs can fire per push event across `ci.yml`,
`e2e-parity.yml`, and `app-binaries.yml`. None of the three workflows had a
`concurrency` group, so superseded runs on a PR (an older push, or a run
against a since-force-pushed SHA) keep occupying runners instead of being
cancelled: one incident had two stale-SHA runs sitting on runners for over
20 minutes ahead of a live set. Separately, docs-only PRs ran the full
macOS/ARM compile matrix in `ci.yml` for no reason, and there was no gate
that would have caught a breaking public API change: the recent
Result-wrapping of `generate` / `generate_streaming*` / `chat_completion*`
shipped with nothing flagging it as a semver break.

## What

**A. Concurrency groups** in `ci.yml`, `e2e-parity.yml`, and
`app-binaries.yml`: `group: <workflow>-${{ github.event.pull_request.number
|| github.ref }}`, `cancel-in-progress` true only for the `pull_request`
event (never for a push to `main`, which has no "next run" to fall back on
if killed mid-flight).

**B. Docs-only skip for `ci.yml`**: a new `changes` job (ubuntu, git-diff
based, same style as `e2e-parity.yml`'s existing change-detection job)
outputs `code=true` when anything outside `**/*.md`, `docs/**`, `LICENSE*`,
`.gitignore` changed. Everything else, including `.github/workflows/**`,
`Cargo.*`, `Makefile*`, and `scripts/**`, counts as code by design (when in
doubt, run the matrix). The `ci`, `feature-matrix`, `bench-compile`, and
`msrv` jobs are gated on `needs: changes` + `if: needs.changes.outputs.code
== 'true'`; a docs-only PR now reports these as `skipped` instead of
spending the shared macOS pool. `cargo-deny`, `rustdoc-lint`, and
`unwrap-in-lib-lint` are left ungated since they are already cheap
ubuntu-only jobs. Job display names are unchanged (see below).

**C. Two new cheap ubuntu jobs in `ci.yml`**:
- `typos` (`crate-ci/typos@v1.48.0`): spell-checks comments, docs, and
  string literals. Found zero genuine typos in the current tree; 215 raw
  findings were all domain vocabulary, established abbreviations, or
  deliberate test-fixture literals, now allow-listed in `_typos.toml`
  (with an inline comment on every entry explaining why it isn't a typo).
- `actionlint` (`raven-actions/actionlint@v2.2.0`, pinned to actionlint
  `1.7.12`): lints workflow YAML for malformed expressions and
  shellcheck-level issues in `run:` steps. Running it repo-wide surfaced
  one pre-existing finding in an untouched workflow
  (`adr064-gpu-decode-nightly.yml`): an unrecognized self-hosted runner
  label (`m2max`). Rather than edit that file (out of scope for this PR)
  or leave the brand-new `actionlint` job permanently red for a reason
  unrelated to this change, this PR adds `.github/actionlint.yaml`
  declaring the label, which is the documented fix for this exact false
  positive. Flagging this explicitly since it is a small addition beyond
  the literal ask.

**D. `semver-checks` job in `ci.yml`**: gated on the same `changes` output,
runs `obi1kenobi/cargo-semver-checks-action@v2` against the published
crates.io baseline for `lattice-fann,lattice-transport,lattice-inference,lattice-embed,lattice-tune`,
default features only (`feature-group: default-features`, so `metal-gpu`
is never enabled on the Linux runner). As of round 3 this is a REAL gate:
the v0.5.0 publish (2026-07-04) reset the baseline and all five crates
pass `cargo semver-checks` against the published 0.5.0, so
`continue-on-error` was removed and the job is aggregated into `ci-gate`
(it is docs-gated, so it cannot be a direct required context).

## Required-check contexts (rollout DONE 2026-07-04)

Branch protection was updated on 2026-07-04: the seven docs-gated heavy
contexts (`CI (ubuntu-latest)`, `CI (macos-latest)`, `CI (ubuntu-24.04-arm)`,
`feature-matrix (ubuntu-latest)`, `feature-matrix (macos-latest)`,
`bench-compile`, `msrv (1.93, f16+metal-gpu)`) were replaced by the
always-reporting `ci-gate` aggregator, resolving the round-2 blocker
(docs-only PRs can no longer wedge on never-created matrix contexts).
Current required contexts: `ci-gate`, `cargo-deny`, `parity-gate`,
`app-binaries-gate`, `q4 composed golden` (`strict: true` unchanged).
`ci-gate` aggregates `ci`, `feature-matrix`, `bench-compile`, `msrv`, and
`semver-checks`, fails closed if change detection itself fails, and passes
on docs-only PRs. PRs branched from a pre-ci-gate `main` must update their
branch to produce the context; the strict up-to-date rule forces that
anyway. `typos` and `actionlint` remain new, non-required contexts.

## Validation performed

- YAML syntax checked for all three edited workflows via `python3 -c
  "import yaml; yaml.safe_load(open(...))"` (pyyaml via `uv run --with
  pyyaml`).
- `actionlint` run locally against the whole repo: clean (exit 0) after
  adding `.github/actionlint.yaml`.
- `typos` run locally against the whole repo: clean (exit 0) after adding
  `_typos.toml`.
- `cargo semver-checks check-release` run locally for all five crates:
  at review time (round 1) two crates failed against the then-published
  `0.4.2` baseline; after the v0.5.0 publish on 2026-07-04 the same
  command passes for all five crates against `0.5.0`, which is why the
  job is now a real gate (aggregated via `ci-gate`) with no
  `continue-on-error`.
- `git diff --stat` confirms a tight diff: only the three workflow files
  plus the two new config files, no Rust source or `Cargo.toml` touched.
- Diffed job `name:` fields against `origin/main` for all three files to
  confirm required-check contexts are preserved.

**Live validation**: multiple GitHub Actions runs have exercised these
workflows on this PR across rounds 1-3, including the ci-gate aggregator
and the new typos/actionlint/semver-checks jobs at the current head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



