### PR TITLE
perf(inference): fuse partial top-k + context-only repetition penalty in the full-logit sampler (#650)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -14851,28 +14851,25 @@ kernel void gdn_chunk_norm_silu_c32(
     }
 
     /// Full-logit sampling fallback (used when top_k == 0 or top_k > MAX_TOP_K).
-    /// Implements the same pipeline as sample_from_candidates but builds the
-    /// CandidateSet from raw logits.
+    ///
+    /// Delegates to `crate::sampling::sample_full_logits`, the shared engine
+    /// also used by the Qwen CPU decode loops
+    /// (`model/qwen35/sampling.rs::sample_token`). See that function's doc
+    /// comment for the three optimization levers applied here relative to the
+    /// old per-call `CandidateSet::from_full_logits` implementation: repetition
+    /// penalty over the unique-id set from `previous_ids` (not a per-candidate
+    /// `.contains()` scan over the full vocabulary), a streaming min-heap
+    /// partial top-k select feeding the top-p softmax draw (so softmax only
+    /// ever runs over the surviving k candidates), and thread-local scratch
+    /// buffers reused across decode steps instead of a fresh vocab-sized
+    /// `CandidateSet` per token.
     fn sample_token(
         logits: &[f32],
         cfg: &GenerateConfig,
         previous_ids: &[u32],
         rng_state: &mut u64,
     ) -> u32 {
-        use crate::sampling::CandidateSet;
-        let mut cs = CandidateSet::from_full_logits(logits);
-        cs.apply_repetition_penalty(previous_ids, cfg.repetition_penalty);
-        // A degenerate temperature (non-finite, <= 0, or finite-but-tiny so 1/t
-        // overflows) has no valid scaling; the t -> 0+ limit is argmax.
-        if crate::sampling::temperature_degenerate(cfg.temperature) {
-            return cs.argmax();
-        }
-        cs.apply_temperature(cfg.temperature);
-        cs.retain_top_k(cfg.top_k);
-        // #351: see sample_from_candidates — avoid the r == 1.0 worst-token bug
-        // by routing through the canonical [0, 1) helper (provably < 1.0).
-        let r = crate::sampling::uniform_f32_from_u64(xorshift64(rng_state));
-        cs.sample_top_p(cfg.top_p, r)
+        crate::sampling::sample_full_logits(logits, cfg, previous_ids, rng_state)
     }
 
     fn decode_tokens(tokenizer: &BpeTokenizer, ids: &[u32]) -> String {

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -2,7 +2,32 @@
 use crate::model::qwen35_config::GenerateConfig;
 
 /// Sample a token from logits using temperature, top-k, top-p, and repetition penalty.
+///
+/// Delegates to `crate::sampling::sample_full_logits`, the shared engine also
+/// used by the Metal CPU fallback (`forward/metal_qwen35.rs`'s private
+/// `sample_token`). See that function's doc comment for the three
+/// optimization levers (context-id-set repetition penalty, partial-select
+/// top-k with softmax over the surviving k only, thread-local buffer reuse
+/// across decode steps) applied here relative to the old per-call allocating
+/// implementation, preserved below as `sample_token_reference` for the
+/// mutation-sensitive parity tests.
 pub(crate) fn sample_token(
+    logits: &[f32],
+    cfg: &GenerateConfig,
+    previous_ids: &[u32],
+    rng_state: &mut u64,
+) -> u32 {
+    crate::sampling::sample_full_logits(logits, cfg, previous_ids, rng_state)
+}
+
+/// Reference oracle: the original allocating implementation of `sample_token`,
+/// kept byte-for-byte so a fixed-seed decode stream can be checked against it
+/// for regressions introduced by the `sample_full_logits` optimization. Not
+/// used on any production call path — test-only, so it (and the helpers below
+/// it now exclusively calls) do not trip `-D warnings` dead-code lints in a
+/// plain (non-test) `cargo check` / `cargo clippy` pass.
+#[cfg(test)]
+pub(crate) fn sample_token_reference(
     logits: &[f32],
     cfg: &GenerateConfig,
     previous_ids: &[u32],
@@ -75,6 +100,7 @@ pub(crate) fn sample_token(
     draw_from_distribution(&probs, rng_state)
 }
 
+#[cfg(test)]
 fn apply_repetition_penalty(adjusted: &mut [f32], previous_ids: &[u32], penalty: f32) {
     let vocab_size = adjusted.len();
     // previous_ids is the full token history and routinely repeats ids. Penalize each
@@ -106,6 +132,7 @@ fn apply_repetition_penalty(adjusted: &mut [f32], previous_ids: &[u32], penalty:
 /// form of the engine-wide first-in-set contract, so a fully-masked
 /// distribution yields the first in-vocabulary token deterministically and
 /// never panics.
+#[cfg(test)]
 fn greedy_token(adjusted: &[f32]) -> u32 {
     let mut best_idx = 0u32;
     let mut best_val = f32::NEG_INFINITY;
@@ -118,6 +145,7 @@ fn greedy_token(adjusted: &[f32]) -> u32 {
     best_idx
 }
 
+#[cfg(test)]
 fn build_softmax_probs(adjusted: &[f32], indices: &[usize]) -> Option<Vec<(usize, f32)>> {
     let max_logit = indices
         .iter()
@@ -146,6 +174,7 @@ fn build_softmax_probs(adjusted: &[f32], indices: &[usize]) -> Option<Vec<(usize
     Some(probs)
 }
 
+#[cfg(test)]
 fn apply_top_p(probs: &mut Vec<(usize, f32)>, top_p: f32) {
     let mut cumsum = 0.0f32;
     let mut cutoff = probs.len();
@@ -163,6 +192,7 @@ fn apply_top_p(probs: &mut Vec<(usize, f32)>, top_p: f32) {
     }
 }
 
+#[cfg(test)]
 fn draw_from_distribution(probs: &[(usize, f32)], rng_state: &mut u64) -> u32 {
     draw_index(probs, xorshift64(rng_state))
 }
@@ -180,6 +210,7 @@ fn draw_from_distribution(probs: &[(usize, f32)], rng_state: &mut u64) -> u32 {
 /// past c_{n-1} lies in that final interval, so the correct token is the LAST
 /// iterated one. This matches `CandidateSet::sample_top_p_with_scratch` (Path A),
 /// which also returns `candidates.last()` for the same reason.
+#[cfg(test)]
 fn draw_index(probs: &[(usize, f32)], r: f32) -> u32 {
     let mut cumsum = 0.0f32;
     for &(idx, p) in probs {
@@ -206,6 +237,7 @@ fn draw_index(probs: &[(usize, f32)], r: f32) -> u32 {
 /// token-identical streams for the same (logits, config, seed) — including inputs
 /// with exact logit ties at the top-k boundary, which the matched ascending
 /// token-id tie-break now resolves identically in both paths.
+#[cfg(test)]
 pub(crate) fn xorshift64(state: &mut u64) -> f32 {
     let x = crate::sampling::xorshift64_next(state);
     crate::sampling::uniform_f32_from_u64(x)
@@ -626,6 +658,114 @@ mod tests {
              the pre-softmax sort changes which token wins the contested rank or the \
              order of the two max-probability buckets, flipping dozens of the 200 \
              draws and failing this assertion."
+        );
+    }
+
+    /// Mutation-sensitive proof that the optimized `sample_token`
+    /// (`crate::sampling::sample_full_logits`: context-id-set repetition
+    /// penalty, partial-select top-k, thread-local scratch reuse) produces a
+    /// BYTE-IDENTICAL token stream to `sample_token_reference` (the original
+    /// full-clone / full-sort / fresh-HashSet implementation) under the
+    /// issue's default production config — temperature 0.7, top_p 0.9,
+    /// top_k 40, repetition_penalty 1.1 — over 256 decode steps with a
+    /// realistic, growing history that contains duplicate ids and an
+    /// out-of-vocabulary id (mirroring a stop-token id beyond the sampled
+    /// vocabulary). If either path's optimization changes the sampled
+    /// distribution, this test fails.
+    #[test]
+    fn optimized_sampler_matches_reference_default_issue_config() {
+        let vocab_size = 2048usize;
+        let logits: Vec<f32> = (0..vocab_size as u64)
+            .map(|i| {
+                let h = i
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                (h as f32 / u64::MAX as f32) * 20.0 - 10.0
+            })
+            .collect();
+
+        let cfg = GenerateConfig {
+            temperature: 0.7,
+            top_k: 40,
+            top_p: 0.9,
+            repetition_penalty: 1.1,
+            ..Default::default()
+        };
+        let seed = 0x5eed_f00d_1234_5678_u64;
+        let steps = 256usize;
+
+        // Seed history with a few prompt tokens, including a duplicate and an
+        // out-of-vocabulary id (both must be handled identically by both paths).
+        let seed_history: Vec<u32> = vec![3, 7, 3, vocab_size as u32 + 5];
+        let mut history_opt = seed_history.clone();
+        let mut history_ref = seed_history;
+        let mut rng_opt = seed;
+        let mut rng_ref = seed;
+
+        for step in 0..steps {
+            let token_opt = sample_token(&logits, &cfg, &history_opt, &mut rng_opt);
+            let token_ref = sample_token_reference(&logits, &cfg, &history_ref, &mut rng_ref);
+            assert_eq!(
+                token_opt, token_ref,
+                "optimized sample_token diverged from sample_token_reference at step {step}"
+            );
+            history_opt.push(token_opt);
+            history_ref.push(token_ref);
+        }
+    }
+
+    /// Mutation-sensitive proof that repetition penalty is applied BEFORE
+    /// top-k selection in the optimized path, not after. Constructs logits
+    /// where a previously-seen token sits inside the raw top-k window but
+    /// drops below the top-k boundary once its penalty is applied. If an
+    /// implementation applied top-k before the penalty, the seen token would
+    /// still occupy its raw-rank slot and the optimized stream would diverge
+    /// from the reference (which always penalizes first).
+    #[test]
+    fn optimized_sampler_penalty_before_topk_boundary() {
+        // top_k = 4. Raw ranks (descending): 0 (10.0), 1 (9.9), 2 (9.8), 3 (9.7),
+        // 4 (9.6), ... Token 3 is seen in history; with repetition_penalty=1.1 its
+        // penalized logit (9.7 / 1.1 ≈ 8.818) drops below token 4's unpenalized
+        // 9.6? No -- pick values so the drop crosses the boundary explicitly:
+        // token 3's raw logit is barely inside the top-4 window; after penalty it
+        // must fall below the raw rank-4 logit (token 4), swapping who survives.
+        let logits: Vec<f32> = vec![10.0, 9.9, 9.8, 9.7, 9.6, 1.0, 0.5, 0.1];
+        let cfg = GenerateConfig {
+            temperature: 1.0,
+            top_k: 4,
+            top_p: 1.0,
+            repetition_penalty: 1.1,
+            ..Default::default()
+        };
+        let previous_ids = [3u32];
+        let seed = 0xabad_1dea_dead_beefu64;
+        let n = 200usize;
+
+        let mut rng_opt = seed;
+        let tokens_opt: Vec<u32> = (0..n)
+            .map(|_| sample_token(&logits, &cfg, &previous_ids, &mut rng_opt))
+            .collect();
+
+        let mut rng_ref = seed;
+        let tokens_ref: Vec<u32> = (0..n)
+            .map(|_| sample_token_reference(&logits, &cfg, &previous_ids, &mut rng_ref))
+            .collect();
+
+        assert_eq!(
+            tokens_opt, tokens_ref,
+            "optimized sample_token must apply repetition penalty before top-k \
+             selection, exactly like sample_token_reference; a top-k-before-penalty \
+             regression would keep token 3 in the surviving set instead of token 4 \
+             and diverge this stream"
+        );
+
+        // Sanity: token 4 (not in `previous_ids`, unpenalized 9.6) must actually be
+        // reachable in the surviving set now that token 3's penalized logit
+        // (9.7 / 1.1 ≈ 8.818) drops below it -- otherwise this test is vacuous.
+        assert!(
+            tokens_opt.contains(&4),
+            "token 4 must be selectable once the penalty pushes token 3 below it \
+             in the top-k ranking (test would be vacuous otherwise)"
         );
     }
 }

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -342,6 +342,77 @@ mod tests {
         );
     }
 
+    /// Regression test for the codex-review round-1 blocker on PR #651:
+    /// `sample_full_logits` always routes through `select_top_k`, whose
+    /// scalar/NEON seed phases rewrite a NaN *scaled* logit to
+    /// `f32::NEG_INFINITY` so the min-heap root is never NaN. That
+    /// sanitization erases the NaN before
+    /// `CandidateSet::sample_top_p_with_scratch`'s own poisoned-sum guard
+    /// ever sees it, silently turning a fail-closed case into a normal
+    /// weighted draw. Proven counterexample (codex): `top_k=0`, logits
+    /// `[0.0, NaN, 0.0]`, seed `0x5eed_f00d_1234_5678` returned token 2
+    /// pre-fix; the fail-closed contract requires the finite argmax, token 0.
+    #[test]
+    fn test_full_logit_nan_fails_closed_topk_disabled() {
+        let logits = [0.0_f32, f32::NAN, 0.0];
+        let mut rng = 0x5eed_f00d_1234_5678_u64;
+        let token = sample_token(&logits, &cfg(1.0, 0), &[], &mut rng);
+        assert_eq!(
+            token, 0,
+            "top_k=0 (disabled): a NaN anywhere in the vocab must fail closed \
+             to argmax, not a weighted draw over the sanitized candidates"
+        );
+    }
+
+    /// Same counterexample as `test_full_logit_nan_fails_closed_topk_disabled`,
+    /// but with `top_k` larger than the vocab (`select_top_k` clamps `k` to
+    /// `logits.len()`, taking the identical full-vocab code path).
+    #[test]
+    fn test_full_logit_nan_fails_closed_topk_exceeds_vocab() {
+        let logits = [0.0_f32, f32::NAN, 0.0];
+        let mut rng = 0x5eed_f00d_1234_5678_u64;
+        let token = sample_token(&logits, &cfg(1.0, 100), &[], &mut rng);
+        assert_eq!(
+            token, 0,
+            "top_k > vocab: a NaN anywhere in the vocab must fail closed to argmax"
+        );
+    }
+
+    /// Same counterexample again with `top_k` strictly smaller than the
+    /// vocab, so `select_top_k` runs its genuine partial-selection path
+    /// (rather than the `k == 0`/`k >= len` full-vocab shortcut). The
+    /// fail-closed scan in `sample_full_logits` runs over the *full*
+    /// pre-top-k logits, so it must still catch this NaN and return the
+    /// global argmax even though top-k would otherwise discard the NaN slot
+    /// as the min-heap's worst (sanitized) candidate.
+    #[test]
+    fn test_full_logit_nan_fails_closed_topk_partial() {
+        let logits = [0.0_f32, f32::NAN, 0.0];
+        let mut rng = 0x5eed_f00d_1234_5678_u64;
+        let token = sample_token(&logits, &cfg(1.0, 2), &[], &mut rng);
+        assert_eq!(
+            token, 0,
+            "top_k < vocab: a NaN anywhere in the vocab must fail closed to \
+             argmax, not a partial-selection weighted draw"
+        );
+    }
+
+    /// All-`-inf` logits (a fully-masked distribution, e.g. every token
+    /// repetition-penalized to the floor) must fail closed to the first
+    /// token, matching `greedy_token`'s / `argmax_f32`'s documented
+    /// first-wins-on-a-degenerate-array contract (#280) rather than
+    /// panicking or producing a NaN-poisoned draw.
+    #[test]
+    fn test_full_logit_all_neg_inf_fails_closed_to_first_token() {
+        let logits = [f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY];
+        let mut rng = 7u64;
+        let token = sample_token(&logits, &cfg(1.0, 0), &[], &mut rng);
+        assert_eq!(
+            token, 0,
+            "all-(-inf) logits must fail closed to the first token"
+        );
+    }
+
     #[test]
     fn test_empty_logits_returns_zero_without_panic() {
         let logits: [f32; 0] = [];

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -537,6 +537,31 @@ pub(crate) fn sample_full_logits(
             1.0
         };
 
+        // Fail-closed guard: `select_top_k`'s scalar/NEON seed phases rewrite a
+        // NaN scaled logit to NEG_INFINITY so the min-heap root is never NaN
+        // (a NaN root would reject every finite candidate in the NEON prefilter).
+        // That sanitization is correct for the heap's internal ordering, but it
+        // erases the NaN *before* the softmax degeneracy guard in
+        // `CandidateSet::sample_top_p_with_scratch` ever sees it, silently
+        // turning a "poisoned distribution" case into "normal sampling over a
+        // masked candidate" — exactly the regression this scan closes.
+        //
+        // Mirror the old full-logit contract (`build_softmax_probs` returning
+        // `None` on a non-finite max or a NaN-poisoned sum, both of which fall
+        // back to argmax) with a single pass over the pre-scaled logits: any
+        // NaN anywhere forces degeneracy (a NaN can never become the max, so it
+        // would otherwise poison the softmax sum from a non-max position,
+        // #322-class); a non-finite max (every logit `-inf`, or a `+inf` logit)
+        // also forces degeneracy, matching `sample_top_p_with_scratch`'s
+        // non-finite-max short-circuit. Scaling by a positive finite `inv_temp`
+        // (guaranteed by the `temperature_degenerate` check above) preserves
+        // both NaN-ness and finiteness, so scanning before the fused top-k scale
+        // is equivalent to scanning after it.
+        let (has_nan, max_logit) = scan_nan_or_nonfinite_max(logit_scratch);
+        if has_nan || !max_logit.is_finite() {
+            return argmax_f32(logit_scratch);
+        }
+
         // Streaming min-heap top-k with fused temperature scaling — the softmax
         // draw below runs only over these k survivors, never the full vocabulary.
         select_top_k(logit_scratch, cfg.top_k, inv_temp, candidate_scratch);
@@ -736,6 +761,76 @@ pub(crate) fn record_logprob(
         logprob,
         top,
     });
+}
+
+/// Fail-closed pre-scan for `sample_full_logits`: detects whether `logits`
+/// contains any NaN and computes the NaN-ignoring ("numeric") max in a
+/// single pass, so the caller can fall back to `argmax_f32` before
+/// `select_top_k`'s scalar/NEON seed phases sanitize a NaN to `NEG_INFINITY`
+/// and hide it from the softmax degeneracy guard (codex PR #651 round 1).
+/// Runtime-dispatch NEON on aarch64 (same 4-wide-plus-scalar-tail structure
+/// as `argmax_f32_neon`) with a scalar fallback.
+fn scan_nan_or_nonfinite_max(logits: &[f32]) -> (bool, f32) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            // SAFETY: NEON is runtime-detected above; only loads aligned 4-f32 chunks.
+            return unsafe { scan_nan_or_nonfinite_max_neon(logits) };
+        }
+    }
+    scan_nan_or_nonfinite_max_scalar(logits)
+}
+
+fn scan_nan_or_nonfinite_max_scalar(logits: &[f32]) -> (bool, f32) {
+    let mut max_logit = f32::NEG_INFINITY;
+    let mut has_nan = false;
+    for &v in logits {
+        has_nan |= v.is_nan();
+        // `f32::max` is IEEE-754 `maxNum`: NaN never wins, matching the old
+        // full-logit reference's `.fold(f32::NEG_INFINITY, f32::max)`.
+        max_logit = max_logit.max(v);
+    }
+    (has_nan, max_logit)
+}
+
+/// NEON 4-wide NaN-detect + numeric-max scan.  `vmaxnmq_f32` accumulates the
+/// NaN-ignoring max per lane (IEEE-754 `maxNum`, matching `f32::max`).
+/// `vceqq_f32(v, v)` is all-ones where `v` is non-NaN (self-equal) and
+/// all-zero where `v` is NaN (a NaN self-comparison is always false), so
+/// OR-accumulating its bitwise complement across every chunk flags any NaN
+/// in the array.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn scan_nan_or_nonfinite_max_neon(logits: &[f32]) -> (bool, f32) {
+    use std::arch::aarch64::*;
+
+    let len = logits.len();
+    let mut i = 0usize;
+    let mut max_acc = vdupq_n_f32(f32::NEG_INFINITY);
+    let mut nan_acc = vdupq_n_u32(0);
+
+    while i + 4 <= len {
+        // SAFETY: loop condition guarantees four valid f32 values are in-bounds.
+        let v = vld1q_f32(logits.as_ptr().add(i));
+        max_acc = vmaxnmq_f32(max_acc, v);
+        let is_non_nan_lane = vceqq_f32(v, v);
+        nan_acc = vorrq_u32(nan_acc, vmvnq_u32(is_non_nan_lane));
+        i += 4;
+    }
+
+    // Horizontal reduction: numeric (NaN-ignoring) max across the 4 lanes,
+    // and OR-reduce the NaN-flag lanes to a single bool.
+    let mut max_logit = vmaxnmvq_f32(max_acc);
+    let mut has_nan = vmaxvq_u32(nan_acc) != 0;
+
+    // Scalar tail for the final 0-3 elements.
+    while i < len {
+        let v = *logits.get_unchecked(i);
+        has_nan |= v.is_nan();
+        max_logit = max_logit.max(v);
+        i += 1;
+    }
+    (has_nan, max_logit)
 }
 
 fn argmax_f32(logits: &[f32]) -> u32 {

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -3,7 +3,7 @@
 //! Supports temperature scaling, top-k filtering, top-p (nucleus) sampling,
 //! and repetition penalty.
 
-use crate::model::qwen35_config::{TokenLogprob, TopLogprob};
+use crate::model::qwen35_config::{GenerateConfig, TokenLogprob, TopLogprob};
 
 /// **Unstable**: sampling configuration for decoder-only generation; fields
 /// and defaults may change as the generation API evolves.
@@ -441,6 +441,114 @@ impl Sampler {
     pub fn reset(&mut self) {
         self.recent_tokens.clear();
     }
+}
+
+thread_local! {
+    /// Reused scratch for [`sample_full_logits`], the shared engine behind the
+    /// stateless `(logits, cfg, previous_ids, rng_state)` call sites that have
+    /// no owning struct to hold per-generation buffers: the Metal CPU fallback
+    /// (`forward/metal_qwen35.rs`'s private `sample_token`) and the Qwen CPU
+    /// decode loops (`model/qwen35/sampling.rs::sample_token`, shared by the
+    /// f16/q8/NEON/batch-prefill forward paths). Kept thread-local instead of
+    /// per-call so vocab-sized buffers are allocated once per thread and
+    /// reused across every decode step, not just within one generation.
+    static FULL_LOGIT_SCRATCH: std::cell::RefCell<FullLogitScratch> =
+        std::cell::RefCell::new(FullLogitScratch::new());
+}
+
+struct FullLogitScratch {
+    logit_scratch: Vec<f32>,
+    candidate_scratch: Vec<Candidate>,
+    prob_scratch: Vec<f32>,
+    penalty_seen: std::collections::HashSet<u32>,
+}
+
+impl FullLogitScratch {
+    fn new() -> Self {
+        Self {
+            logit_scratch: Vec::new(),
+            candidate_scratch: Vec::new(),
+            prob_scratch: Vec::new(),
+            penalty_seen: std::collections::HashSet::new(),
+        }
+    }
+}
+
+/// Shared full-logit sampling engine for callers that receive the full token
+/// history and RNG state as plain arguments each step (rather than owning a
+/// [`Sampler`]). Implements the same pipeline as `Sampler::sample`'s non-greedy
+/// path: apply repetition penalty once per unique previously-seen id, check
+/// the degenerate-temperature greedy short-circuit, then a single fused
+/// temperature-scale + partial top-k select feeding a top-p softmax draw.
+///
+/// This replaces, at each of its two call sites, a per-call
+/// `CandidateSet::from_full_logits` (materializes every vocabulary entry as a
+/// `Candidate` before any filtering) plus a per-candidate repetition-penalty
+/// scan (`previous_ids.contains(&c.token_id)`, O(vocab * history length)) with:
+/// - repetition penalty applied only at the indices named by the unique ids in
+///   `previous_ids` (a context-id set, O(unique history length));
+/// - `select_top_k`'s streaming min-heap partial selection, so the top-p
+///   softmax below only ever runs over the surviving `k` candidates, never the
+///   full vocabulary;
+/// - thread-local `logit_scratch` / `candidate_scratch` / `prob_scratch` /
+///   `penalty_seen` buffers reused across decode steps instead of a fresh
+///   vocab-sized allocation per token.
+pub(crate) fn sample_full_logits(
+    logits: &[f32],
+    cfg: &GenerateConfig,
+    previous_ids: &[u32],
+    rng_state: &mut u64,
+) -> u32 {
+    FULL_LOGIT_SCRATCH.with(|cell| {
+        let mut scratch = cell.borrow_mut();
+        let FullLogitScratch {
+            logit_scratch,
+            candidate_scratch,
+            prob_scratch,
+            penalty_seen,
+        } = &mut *scratch;
+
+        logit_scratch.clear();
+        logit_scratch.extend_from_slice(logits);
+
+        if cfg.repetition_penalty != 1.0 {
+            // Penalize each unique previously-seen id exactly once (HF
+            // gather-once semantics), matching `Sampler::apply_penalty_to_logit_scratch`.
+            penalty_seen.clear();
+            for &tok in previous_ids {
+                let idx = tok as usize;
+                if idx < logit_scratch.len() && penalty_seen.insert(tok) {
+                    logit_scratch[idx] =
+                        penalized_logit(logit_scratch[idx], cfg.repetition_penalty);
+                }
+            }
+        }
+
+        // A degenerate temperature (non-finite, <= 0, or finite-but-tiny so its
+        // reciprocal overflows) carries no valid scaling; the t -> 0+ limit is
+        // greedy argmax over the already-penalized logits.
+        if temperature_degenerate(cfg.temperature) {
+            return argmax_f32(logit_scratch);
+        }
+
+        let inv_temp = if cfg.temperature != 1.0 {
+            1.0 / cfg.temperature
+        } else {
+            1.0
+        };
+
+        // Streaming min-heap top-k with fused temperature scaling — the softmax
+        // draw below runs only over these k survivors, never the full vocabulary.
+        select_top_k(logit_scratch, cfg.top_k, inv_temp, candidate_scratch);
+
+        let mut cs = CandidateSet {
+            candidates: std::mem::take(candidate_scratch),
+        };
+        let r = uniform_f32_from_u64(xorshift64_next(rng_state));
+        let token = cs.sample_top_p_with_scratch(cfg.top_p, r, prob_scratch);
+        *candidate_scratch = cs.candidates; // restore scratch capacity
+        token
+    })
 }
 
 /// A generous upper bound on the magnitude of a transformer lm_head logit. Real
@@ -2118,5 +2226,193 @@ mod tests {
         assert_eq!(token_logprobs.len(), 2);
         assert_eq!(token_logprobs[1].token_id, 0);
         assert!(token_logprobs[1].top.is_empty());
+    }
+
+    // -------------------------------------------------------------------
+    // CPU-side microbench (issue #650): before/after `sample_full_logits`.
+    //
+    // `#[ignore]`d so normal `cargo test` runs stay fast; run explicitly with:
+    //   cargo test -p lattice-inference --lib --release -- --ignored --nocapture \
+    //     sampling::tests::microbench_sample_full_logits_default_issue_config
+    // -------------------------------------------------------------------
+
+    /// Literal copy of the pre-optimization `sample_token` algorithm (full
+    /// vocab clone, fresh per-call `HashSet`, full `Vec<usize>` index
+    /// allocation, allocating softmax-probs `Vec`) — the "before" arm of the
+    /// microbench. Mirrors what both `model/qwen35/sampling.rs::sample_token`
+    /// and the Metal CPU fallback did before this change; kept local to the
+    /// microbench so it has no effect on any production or library code path.
+    fn old_full_vocab_sample(
+        logits: &[f32],
+        temperature: f32,
+        top_k: usize,
+        top_p: f32,
+        repetition_penalty: f32,
+        previous_ids: &[u32],
+        rng_state: &mut u64,
+    ) -> u32 {
+        let vocab_size = logits.len();
+        let mut adjusted = logits.to_vec();
+
+        if repetition_penalty != 1.0 {
+            let mut seen = std::collections::HashSet::with_capacity(previous_ids.len());
+            for &id in previous_ids {
+                let idx = id as usize;
+                if idx < vocab_size && seen.insert(id) {
+                    adjusted[idx] = penalized_logit(adjusted[idx], repetition_penalty);
+                }
+            }
+        }
+
+        if temperature_degenerate(temperature) {
+            return argmax_f32(&adjusted);
+        }
+
+        if temperature != 1.0 {
+            let inv_temp = 1.0 / temperature;
+            for v in &mut adjusted {
+                *v *= inv_temp;
+            }
+        }
+
+        let mut indices: Vec<usize> = (0..vocab_size).collect();
+        if top_k > 0 && top_k < vocab_size {
+            indices.select_nth_unstable_by(top_k - 1, |&a, &b| {
+                adjusted[b]
+                    .partial_cmp(&adjusted[a])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.cmp(&b))
+            });
+            indices.truncate(top_k);
+        }
+        indices.sort_unstable_by(|&a, &b| {
+            adjusted[b]
+                .partial_cmp(&adjusted[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.cmp(&b))
+        });
+
+        let max_logit = indices
+            .iter()
+            .map(|&i| adjusted[i])
+            .fold(f32::NEG_INFINITY, f32::max);
+        if !max_logit.is_finite() {
+            return argmax_f32(&adjusted);
+        }
+        let mut probs: Vec<(usize, f32)> = indices
+            .iter()
+            .map(|&i| (i, (adjusted[i] - max_logit).exp()))
+            .collect();
+        let sum: f32 = probs.iter().map(|(_, p)| p).sum();
+        if !sum.is_finite() || sum <= 0.0 {
+            return argmax_f32(&adjusted);
+        }
+        for (_, p) in &mut probs {
+            *p /= sum;
+        }
+
+        if top_p < 1.0 {
+            let mut cumsum = 0.0f32;
+            let mut cutoff = probs.len();
+            for (i, (_, p)) in probs.iter().enumerate() {
+                cumsum += p;
+                if cumsum >= top_p {
+                    cutoff = i + 1;
+                    break;
+                }
+            }
+            probs.truncate(cutoff);
+            let new_sum: f32 = probs.iter().map(|(_, p)| p).sum();
+            for (_, p) in probs.iter_mut() {
+                *p /= new_sum;
+            }
+        }
+
+        let r = uniform_f32_from_u64(xorshift64_next(rng_state));
+        let mut cumsum = 0.0f32;
+        for &(idx, p) in &probs {
+            cumsum += p;
+            if r < cumsum {
+                return idx as u32;
+            }
+        }
+        probs.last().map(|&(idx, _)| idx as u32).unwrap_or(0)
+    }
+
+    #[test]
+    #[ignore = "perf microbench, not a correctness check; run explicitly with --ignored"]
+    fn microbench_sample_full_logits_default_issue_config() {
+        const VOCAB_SIZE: usize = 248_320; // Qwen3.5 real vocab (issue #650).
+        const ITERS: usize = 300;
+
+        let logits: Vec<f32> = (0..VOCAB_SIZE as u64)
+            .map(|i| {
+                let h = i
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                (h as f32 / u64::MAX as f32) * 20.0 - 10.0
+            })
+            .collect();
+        // A 64-token recent-history window, as a real decode loop would pass
+        // (previous_ids = prompt + generated-so-far), with duplicates.
+        let previous_ids: Vec<u32> = (0..64u32).map(|i| (i * 4099) % VOCAB_SIZE as u32).collect();
+
+        let cfg = SamplingConfig {
+            temperature: 0.7,
+            top_k: 40,
+            top_p: 0.9,
+            repetition_penalty: 1.1,
+        };
+        let gen_cfg = GenerateConfig {
+            temperature: cfg.temperature,
+            top_k: cfg.top_k,
+            top_p: cfg.top_p,
+            repetition_penalty: cfg.repetition_penalty,
+            ..Default::default()
+        };
+
+        let mut rng_before = 0xDEAD_BEEFu64;
+        let before_start = std::time::Instant::now();
+        for _ in 0..ITERS {
+            std::hint::black_box(old_full_vocab_sample(
+                &logits,
+                cfg.temperature,
+                cfg.top_k,
+                cfg.top_p,
+                cfg.repetition_penalty,
+                &previous_ids,
+                &mut rng_before,
+            ));
+        }
+        let before_elapsed = before_start.elapsed();
+
+        let mut rng_after = 0xDEAD_BEEFu64;
+        let after_start = std::time::Instant::now();
+        for _ in 0..ITERS {
+            std::hint::black_box(sample_full_logits(
+                &logits,
+                &gen_cfg,
+                &previous_ids,
+                &mut rng_after,
+            ));
+        }
+        let after_elapsed = after_start.elapsed();
+
+        let before_us_per_call = before_elapsed.as_secs_f64() * 1e6 / ITERS as f64;
+        let after_us_per_call = after_elapsed.as_secs_f64() * 1e6 / ITERS as f64;
+        eprintln!(
+            "microbench sample_full_logits @ vocab={VOCAB_SIZE}, iters={ITERS}, cfg=(temp=0.7,top_k=40,top_p=0.9,rep_penalty=1.1):\n\
+             before (old_full_vocab_sample): {before_elapsed:?} total, {before_us_per_call:.1} us/call, {:.1} tok/s\n\
+             after  (sample_full_logits):    {after_elapsed:?} total, {after_us_per_call:.1} us/call, {:.1} tok/s",
+            1e6 / before_us_per_call,
+            1e6 / after_us_per_call,
+        );
+
+        assert!(
+            after_elapsed < before_elapsed,
+            "optimized sample_full_logits ({after_elapsed:?}) must be faster than \
+             the old full-vocab-allocating algorithm ({before_elapsed:?}) at the \
+             issue's default config and vocab size"
+        );
     }
 }


### PR DESCRIPTION
Closes #650.

Sampled decode with the profiled default config (`temperature=0.7, top_p=0.9, top_k=40, repetition_penalty=1.1`) cost ~6.5 ms/token over the 248k-entry vocab — more than the 0.8B Q4 forward pass itself — because the live full-logit sampling path rebuilt a full-vocab `CandidateSet`, scanned every candidate for repetition-penalty history membership, and allocated fresh buffers on every decode step.

## What changed

New shared `crate::sampling::sample_full_logits` becomes the single engine behind both stateless full-logit call sites, which now delegate to it:

- `forward/metal_qwen35.rs::sample_token` (Metal CPU-fallback full-logit path)
- `model/qwen35/sampling.rs::sample_token` (CPU Qwen path — also the entry point used unmodified by every sibling decode loop: `cpu_f16.rs`, `cpu_q8.rs`, `neon_forward.rs`, `batch_prefill.rs`, and all four `generation.rs` decode loops)

Three levers:
1. **Partial-select top-k** via the existing streaming min-heap `select_top_k`; softmax/top-p run over the surviving k candidates, never the full 248k vocab. `top_k == 0` keeps full-distribution semantics (existing tests cover it).
2. **Repetition penalty over unique context ids only** — thread-local `HashSet` refilled per call, penalty applied by index; O(vocab × history) → O(unique history).
3. **Buffer reuse across decode steps** — thread-local scratch (logits copy, candidates, probs, penalty set) allocated once per thread.

## Performance

Dedicated CPU microbench on a synthetic 248,320-vocab logits vector with the issue's exact profiled config, same machine, same session:

| Path | Per sampling call |
|---|---:|
| before (full-vocab CandidateSet path) | 734.7 µs |
| after, round 1 (`sample_full_logits`, no NaN pre-scan) | 61.9 µs |
| after, round 2 (with fail-closed NaN/non-finite pre-scan) | 92.7 µs |

~7.9x per-call at the final head. Round 2 (internal review round-1 blocker fix) restored the repo's fail-closed sampling contract: a single-pass NEON-accelerated scan over the pre-scale logits falls back to greedy argmax on any NaN or non-finite max BEFORE `select_top_k` can sanitize NaN → `-inf` and hide the poisoned distribution. Contract correctness costs ~31µs/call; at the profiled ~6.5 ms/token total sampling cost this still recovers most of the sampled-vs-greedy throughput gap.

`make bench-compare` (default CPU groups): the default `elementwise_cpu_bench`/`simd` groups do not exercise the sampler; output attached in a comment for completeness.

## Semantics preserved

- Same seed → same sampled tokens on finite logits: 71/71 sampling tests and 1473/1473 crate tests pass; clippy `-D warnings` clean.
- Fail-closed regression tests added (the review counterexample `[0.0, NaN, 0.0]`, seed `0x5eed_f00d_1234_5678`) across `top_k=0`, `top_k > vocab`, `top_k < vocab`, plus all-`-inf`; mutation-verified — reverting the fix reproduces the exact reported bug value (`left: 2, right: 0`).
- Mutation check performed live: reordering penalty-after-top-k makes the two new distribution-equivalence tests fail; restoring makes them pass.
- GPU compact-candidate path (`sample_from_candidates`) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


