### PR TITLE
fix(serve): fail-closed roles and content parts, OpenAI content-parts arrays, config-derived max context (#641, #649 API, #551)

### DIFF
--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -3107,6 +3107,15 @@ mod serve {
             MessageContent::Parts(parts) => {
                 let mut out = String::new();
                 for part in parts {
+                    if part.kind == "image_url" {
+                        // #649: no vision tower exists yet — fail closed with
+                        // the same message lattice_serve uses, rather than
+                        // this server's generic "not supported" text.
+                        return Err(ApiError::BadRequest {
+                            message: "image input requires a vision-capable model".to_string(),
+                            code: "unsupported_feature",
+                        });
+                    }
                     if part.kind != "text" {
                         return Err(ApiError::BadRequest {
                             message: format!(
@@ -4485,13 +4494,32 @@ mod serve {
                 text: None,
             }]);
             let err = message_text(&content).unwrap_err();
-            assert!(matches!(
-                err,
-                ApiError::BadRequest {
-                    code: "unsupported_feature",
-                    ..
+            match err {
+                ApiError::BadRequest { message, code } => {
+                    assert_eq!(code, "unsupported_feature");
+                    assert_eq!(message, "image input requires a vision-capable model");
                 }
-            ));
+                other => panic!("expected BadRequest, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn message_text_parts_rejects_unknown_part_type() {
+            let content = MessageContent::Parts(vec![ContentPart {
+                kind: "file".to_string(),
+                text: None,
+            }]);
+            let err = message_text(&content).unwrap_err();
+            match err {
+                ApiError::BadRequest { message, code } => {
+                    assert_eq!(code, "unsupported_feature");
+                    assert_eq!(
+                        message,
+                        "content part type 'file' is not supported; only 'text' parts are accepted"
+                    );
+                }
+                other => panic!("expected BadRequest, got {other:?}"),
+            }
         }
 
         // -----------------------------------------------------------------------

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -56,6 +56,7 @@ fn main() {
 mod imp {
     use axum::{
         Json, Router,
+        body::{Body, to_bytes},
         extract::State,
         http::StatusCode,
         response::{
@@ -146,9 +147,49 @@ mod imp {
         jobs: mpsc::UnboundedSender<Job>,
         model_id: Arc<str>,
         defaults: Defaults,
+        /// Runtime context window derived from the loaded model (#551): the
+        /// exact KV cache length `load_model` allocated, never a hard-coded
+        /// constant. See `model_context_from_config` and `build_cfg`.
+        model_max_context: usize,
     }
 
     // ─── OpenAI request shapes ───────────────────────────────────────────────
+
+    /// Request body cap applied before any JSON parsing (serve DoS-hardening
+    /// rule: every size field clamps before allocation).
+    const REQUEST_BODY_LIMIT_BYTES: usize = 1_048_576;
+    /// Maximum number of content parts accepted per message (#649). Enforced
+    /// by `validate_content_part_limits` before the typed `ChatReq` is parsed.
+    const MAX_CONTENT_PARTS_PER_MESSAGE: usize = 64;
+    /// Maximum byte length of a single content string / part payload (#649).
+    const MAX_CONTENT_PART_BYTES: usize = 65_536;
+    /// #551 fallback when the loaded model's config has no derivable context.
+    const FALLBACK_MODEL_MAX_CONTEXT: usize = 4096;
+
+    /// #649: image input is accepted in the OpenAI wire shape but this server
+    /// has no vision tower, so it must fail closed with a clear message
+    /// rather than silently dropping the part or coercing it to text.
+    const IMAGE_REQUIRES_VISION_MESSAGE: &str = "image input requires a vision-capable model";
+
+    /// A request-validation failure that must surface as HTTP 400 (#641,
+    /// #649). Fail-closed: unknown roles and unsupported content parts are
+    /// never coerced or dropped, they always produce one of these.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum RequestError {
+        BadRequest(String),
+    }
+
+    impl RequestError {
+        fn bad_request(message: impl Into<String>) -> Self {
+            Self::BadRequest(message.into())
+        }
+
+        fn message(&self) -> &str {
+            match self {
+                Self::BadRequest(message) => message,
+            }
+        }
+    }
 
     #[derive(Deserialize)]
     struct ChatReq {
@@ -178,55 +219,530 @@ mod imp {
     #[derive(Deserialize)]
     struct InMsg {
         role: String,
+        content: MessageContent,
+    }
+
+    /// Fail-closed chat role (#641): only these three roles are accepted.
+    /// Anything else — `tool`, `developer`, a typo, an empty string — is
+    /// rejected with HTTP 400 rather than silently coerced to `user`.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum MessageRole {
+        System,
+        User,
+        Assistant,
+    }
+
+    impl MessageRole {
+        fn parse(raw: &str) -> Result<Self, RequestError> {
+            match raw {
+                "system" => Ok(Self::System),
+                "user" => Ok(Self::User),
+                "assistant" => Ok(Self::Assistant),
+                other => Err(RequestError::bad_request(format!(
+                    "unsupported role '{other}'; must be 'system', 'user', or 'assistant'"
+                ))),
+            }
+        }
+    }
+
+    /// OpenAI message content: either a plain string or an array of typed
+    /// parts (`[{"type":"text","text":"..."}]`). Both forms deserialize
+    /// successfully here; rejection of unsupported part types happens in
+    /// `content_text` so the exact offending part is available for the error
+    /// message.
+    #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+    #[serde(untagged)]
+    enum MessageContent {
+        Text(String),
+        Parts(Vec<Part>),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum Part {
+        Text { text: String },
+        ImageUrl { image_url: ImageUrl },
+        /// Any part `type` other than `text`/`image_url` (#641/#649): kept
+        /// instead of dropped so it can be rejected with its real type name.
+        Unsupported { kind: String },
+    }
+
+    #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+    struct ImageUrl {
+        url: String,
         #[serde(default)]
-        content: Value,
+        detail: Option<String>,
     }
 
-    /// OpenAI message content is either a string or an array of typed parts
-    /// (`[{"type":"text","text":"..."}]`). Flatten both to plain text.
-    fn content_text(v: &Value) -> String {
-        match v {
-            Value::String(s) => s.clone(),
-            Value::Array(parts) => parts
-                .iter()
-                .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
-                .collect::<Vec<_>>()
-                .join(""),
-            Value::Null => String::new(),
-            other => other.to_string(),
+    #[derive(Deserialize)]
+    struct RawPart {
+        #[serde(rename = "type")]
+        kind: Option<String>,
+        #[serde(default)]
+        text: Option<String>,
+        #[serde(default)]
+        image_url: Option<ImageUrl>,
+    }
+
+    impl<'de> Deserialize<'de> for Part {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let raw = RawPart::deserialize(deserializer)?;
+            match raw.kind.as_deref() {
+                Some("text") => {
+                    let text = raw.text.ok_or_else(|| {
+                        serde::de::Error::custom("text content part must include string field 'text'")
+                    })?;
+                    Ok(Self::Text { text })
+                }
+                Some("image_url") => {
+                    let image_url = raw.image_url.ok_or_else(|| {
+                        serde::de::Error::custom(
+                            "image_url content part must include object field 'image_url'",
+                        )
+                    })?;
+                    Ok(Self::ImageUrl { image_url })
+                }
+                Some(kind) => Ok(Self::Unsupported {
+                    kind: kind.to_string(),
+                }),
+                None => Ok(Self::Unsupported {
+                    kind: "<missing>".to_string(),
+                }),
+            }
         }
     }
 
-    fn to_chat_message(m: &InMsg) -> ChatMessage {
-        let content = content_text(&m.content);
-        match m.role.as_str() {
-            "system" => ChatMessage::system(content),
-            "assistant" => ChatMessage::assistant(content),
-            _ => ChatMessage::user(content),
+    fn part_too_large_message(message_index: usize, part_index: usize) -> String {
+        format!("messages[{message_index}].content[{part_index}] exceeds {MAX_CONTENT_PART_BYTES} bytes")
+    }
+
+    fn too_many_parts_message(message_index: usize) -> String {
+        format!(
+            "messages[{message_index}].content has too many parts; maximum is {MAX_CONTENT_PARTS_PER_MESSAGE}"
+        )
+    }
+
+    /// Borrowed serde preflight over the raw request body: walks only
+    /// `messages[*].content` and checks part counts / payload byte lengths
+    /// *before* the typed `ChatReq` is deserialized, so an oversized or
+    /// part-flooded body is rejected before its strings/arrays are ever
+    /// allocated (serve DoS-hardening rule: clamp before alloc). Any other
+    /// shape mismatch is left for the authoritative typed parse below —
+    /// this function only ever raises the two size/count errors above.
+    fn validate_content_part_limits(body: &[u8]) -> Result<(), RequestError> {
+        use serde::de::{DeserializeSeed, Error as DeError, IgnoredAny, MapAccess, SeqAccess, Visitor};
+        use std::cell::RefCell;
+        use std::fmt;
+
+        let violation: RefCell<Option<RequestError>> = RefCell::new(None);
+
+        struct StringLenSeed<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+            message_index: usize,
+            part_index: usize,
+        }
+        impl<'de, 'v> DeserializeSeed<'de> for StringLenSeed<'v> {
+            type Value = ();
+            fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct V<'v> {
+                    violation: &'v RefCell<Option<RequestError>>,
+                    message_index: usize,
+                    part_index: usize,
+                }
+                impl<'de, 'v> Visitor<'de> for V<'v> {
+                    type Value = ();
+                    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        f.write_str("a string")
+                    }
+                    fn visit_str<E: DeError>(self, v: &str) -> Result<(), E> {
+                        if v.len() > MAX_CONTENT_PART_BYTES {
+                            *self.violation.borrow_mut() = Some(RequestError::bad_request(
+                                part_too_large_message(self.message_index, self.part_index),
+                            ));
+                        }
+                        Ok(())
+                    }
+                    fn visit_string<E: DeError>(self, v: String) -> Result<(), E> {
+                        self.visit_str(&v)
+                    }
+                    fn visit_unit<E: DeError>(self) -> Result<(), E> {
+                        Ok(())
+                    }
+                }
+                deserializer.deserialize_any(V {
+                    violation: self.violation,
+                    message_index: self.message_index,
+                    part_index: self.part_index,
+                })
+            }
+        }
+
+        struct ImageUrlLenSeed<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+            message_index: usize,
+            part_index: usize,
+        }
+        impl<'de, 'v> DeserializeSeed<'de> for ImageUrlLenSeed<'v> {
+            type Value = ();
+            fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct V<'v> {
+                    violation: &'v RefCell<Option<RequestError>>,
+                    message_index: usize,
+                    part_index: usize,
+                }
+                impl<'de, 'v> Visitor<'de> for V<'v> {
+                    type Value = ();
+                    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        f.write_str("an image_url object")
+                    }
+                    fn visit_map<A>(self, mut map: A) -> Result<(), A::Error>
+                    where
+                        A: MapAccess<'de>,
+                    {
+                        while let Some(key) = map.next_key::<&str>()? {
+                            if key == "url" {
+                                map.next_value_seed(StringLenSeed {
+                                    violation: self.violation,
+                                    message_index: self.message_index,
+                                    part_index: self.part_index,
+                                })?;
+                            } else {
+                                map.next_value::<IgnoredAny>()?;
+                            }
+                        }
+                        Ok(())
+                    }
+                    fn visit_unit<E: DeError>(self) -> Result<(), E> {
+                        Ok(())
+                    }
+                }
+                deserializer.deserialize_any(V {
+                    violation: self.violation,
+                    message_index: self.message_index,
+                    part_index: self.part_index,
+                })
+            }
+        }
+
+        struct PartSeed<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+            message_index: usize,
+            part_index: usize,
+        }
+        impl<'de, 'v> DeserializeSeed<'de> for PartSeed<'v> {
+            type Value = ();
+            fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct V<'v> {
+                    violation: &'v RefCell<Option<RequestError>>,
+                    message_index: usize,
+                    part_index: usize,
+                }
+                impl<'de, 'v> Visitor<'de> for V<'v> {
+                    type Value = ();
+                    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        f.write_str("a content part object")
+                    }
+                    fn visit_map<A>(self, mut map: A) -> Result<(), A::Error>
+                    where
+                        A: MapAccess<'de>,
+                    {
+                        while let Some(key) = map.next_key::<&str>()? {
+                            match key {
+                                "text" => {
+                                    map.next_value_seed(StringLenSeed {
+                                        violation: self.violation,
+                                        message_index: self.message_index,
+                                        part_index: self.part_index,
+                                    })?;
+                                }
+                                "image_url" => {
+                                    map.next_value_seed(ImageUrlLenSeed {
+                                        violation: self.violation,
+                                        message_index: self.message_index,
+                                        part_index: self.part_index,
+                                    })?;
+                                }
+                                _ => {
+                                    map.next_value::<IgnoredAny>()?;
+                                }
+                            }
+                        }
+                        Ok(())
+                    }
+                }
+                deserializer.deserialize_any(V {
+                    violation: self.violation,
+                    message_index: self.message_index,
+                    part_index: self.part_index,
+                })
+            }
+        }
+
+        struct ContentVisitor<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+            message_index: usize,
+        }
+        impl<'de, 'v> Visitor<'de> for ContentVisitor<'v> {
+            type Value = ();
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a string or array of content parts")
+            }
+            fn visit_str<E: DeError>(self, v: &str) -> Result<(), E> {
+                if v.len() > MAX_CONTENT_PART_BYTES {
+                    *self.violation.borrow_mut() = Some(RequestError::bad_request(
+                        part_too_large_message(self.message_index, 0),
+                    ));
+                }
+                Ok(())
+            }
+            fn visit_string<E: DeError>(self, v: String) -> Result<(), E> {
+                self.visit_str(&v)
+            }
+            fn visit_seq<A>(self, mut seq: A) -> Result<(), A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut part_index = 0usize;
+                loop {
+                    if part_index >= MAX_CONTENT_PARTS_PER_MESSAGE {
+                        let msg = too_many_parts_message(self.message_index);
+                        *self.violation.borrow_mut() = Some(RequestError::bad_request(msg.clone()));
+                        return Err(A::Error::custom(msg));
+                    }
+                    let seed = PartSeed {
+                        violation: self.violation,
+                        message_index: self.message_index,
+                        part_index,
+                    };
+                    match seq.next_element_seed(seed)? {
+                        Some(()) => part_index += 1,
+                        None => break,
+                    }
+                }
+                Ok(())
+            }
+        }
+
+        struct MessageVisitor<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+            message_index: usize,
+        }
+        impl<'de, 'v> Visitor<'de> for MessageVisitor<'v> {
+            type Value = ();
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a message object")
+            }
+            fn visit_map<A>(self, mut map: A) -> Result<(), A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                while let Some(key) = map.next_key::<&str>()? {
+                    if key == "content" {
+                        map.next_value_seed(ContentSeed {
+                            violation: self.violation,
+                            message_index: self.message_index,
+                        })?;
+                    } else {
+                        map.next_value::<IgnoredAny>()?;
+                    }
+                }
+                Ok(())
+            }
+        }
+
+        struct ContentSeed<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+            message_index: usize,
+        }
+        impl<'de, 'v> DeserializeSeed<'de> for ContentSeed<'v> {
+            type Value = ();
+            fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(ContentVisitor {
+                    violation: self.violation,
+                    message_index: self.message_index,
+                })
+            }
+        }
+
+        struct MessageSeed<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+            message_index: usize,
+        }
+        impl<'de, 'v> DeserializeSeed<'de> for MessageSeed<'v> {
+            type Value = ();
+            fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_map(MessageVisitor {
+                    violation: self.violation,
+                    message_index: self.message_index,
+                })
+            }
+        }
+
+        struct MessagesVisitor<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+        }
+        impl<'de, 'v> Visitor<'de> for MessagesVisitor<'v> {
+            type Value = ();
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("an array of messages")
+            }
+            fn visit_seq<A>(self, mut seq: A) -> Result<(), A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut message_index = 0usize;
+                while seq
+                    .next_element_seed(MessageSeed {
+                        violation: self.violation,
+                        message_index,
+                    })?
+                    .is_some()
+                {
+                    message_index += 1;
+                }
+                Ok(())
+            }
+        }
+
+        struct TopVisitor<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+        }
+        impl<'de, 'v> Visitor<'de> for TopVisitor<'v> {
+            type Value = ();
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a chat completion request object")
+            }
+            fn visit_map<A>(self, mut map: A) -> Result<(), A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                while let Some(key) = map.next_key::<&str>()? {
+                    if key == "messages" {
+                        map.next_value_seed(MessagesSeed {
+                            violation: self.violation,
+                        })?;
+                    } else {
+                        map.next_value::<IgnoredAny>()?;
+                    }
+                }
+                Ok(())
+            }
+        }
+
+        struct MessagesSeed<'v> {
+            violation: &'v RefCell<Option<RequestError>>,
+        }
+        impl<'de, 'v> DeserializeSeed<'de> for MessagesSeed<'v> {
+            type Value = ();
+            fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_seq(MessagesVisitor {
+                    violation: self.violation,
+                })
+            }
+        }
+
+        let mut de = serde_json::Deserializer::from_slice(body);
+        // Any error other than a captured violation is left for the typed
+        // `ChatReq` parse below to report authoritatively.
+        let _ = de.deserialize_any(TopVisitor {
+            violation: &violation,
+        });
+        match violation.into_inner() {
+            Some(err) => Err(err),
+            None => Ok(()),
         }
     }
 
-    /// KV-cache length the worker allocates (see `load_model`). A request's
-    /// `max_tokens` is clamped to this so an absurd value cannot drive
-    /// `Vec::with_capacity(max_new_tokens)` in the Metal decode path to a
-    /// capacity-overflow abort (which would kill the GPU worker thread, a
-    /// persistent DoS). The prompt+completion-exceeds-window case is handled
-    /// fail-closed inside the Metal generate path.
-    const MODEL_MAX_CONTEXT: usize = 4096;
+    /// Clamp-then-parse entry point (#649 DoS hardening): validates part
+    /// counts/sizes against the raw bytes first, then deserializes the typed
+    /// request. Never allocates the request's strings/arrays before the
+    /// clamp has run.
+    fn parse_chat_req(body: &[u8]) -> Result<ChatReq, RequestError> {
+        validate_content_part_limits(body)?;
+        serde_json::from_slice::<ChatReq>(body)
+            .map_err(|_| RequestError::bad_request("invalid JSON request body"))
+    }
 
-    fn build_cfg(req: &ChatReq, d: &Defaults) -> GenerateConfig {
+    /// Flatten message content to plain text (#641, #649). Fails closed:
+    /// an `image_url` part returns the vision-model message, any other
+    /// unsupported part type names itself in the error rather than being
+    /// silently dropped.
+    fn content_text(content: &MessageContent) -> Result<String, RequestError> {
+        match content {
+            MessageContent::Text(text) => Ok(text.clone()),
+            MessageContent::Parts(parts) => {
+                let mut out = String::new();
+                for part in parts {
+                    match part {
+                        Part::Text { text } => out.push_str(text),
+                        Part::ImageUrl { .. } => {
+                            return Err(RequestError::bad_request(IMAGE_REQUIRES_VISION_MESSAGE));
+                        }
+                        Part::Unsupported { kind } => {
+                            return Err(RequestError::bad_request(format!(
+                                "unsupported content part type '{kind}'; only 'text' parts are accepted"
+                            )));
+                        }
+                    }
+                }
+                Ok(out)
+            }
+        }
+    }
+
+    fn to_chat_message(m: &InMsg) -> Result<ChatMessage, RequestError> {
+        let role = MessageRole::parse(&m.role)?;
+        let content = content_text(&m.content)?;
+        Ok(match role {
+            MessageRole::System => ChatMessage::system(content),
+            MessageRole::User => ChatMessage::user(content),
+            MessageRole::Assistant => ChatMessage::assistant(content),
+        })
+    }
+
+    /// Derive the model's usable context window from its config (#551):
+    /// `max_position_embeddings` when a real `config.json` was loaded,
+    /// otherwise (or when the field is non-positive) the documented
+    /// fallback. Never a hard-coded constant divorced from the loaded model.
+    fn model_context_from_config(cfg: Option<&Qwen35Config>) -> usize {
+        cfg.map(|cfg| cfg.max_position_embeddings)
+            .filter(|&n| n > 0)
+            .unwrap_or(FALLBACK_MODEL_MAX_CONTEXT)
+    }
+
+    fn build_cfg(req: &ChatReq, d: &Defaults, model_max_context: usize) -> GenerateConfig {
         // Clamp like `max_tokens`: a budget past the KV window is meaningless and
         // would let a future `with_capacity(decode_cap(..))` abort on overflow.
         let reasoning_budget = req
             .reasoning_budget
             .filter(|&n| n > 0)
             .or(d.reasoning_budget)
-            .map(|n| n.min(MODEL_MAX_CONTEXT));
+            .map(|n| n.min(model_max_context));
         GenerateConfig {
             max_new_tokens: req
                 .max_tokens
                 .unwrap_or(d.max_tokens)
-                .min(MODEL_MAX_CONTEXT),
+                .min(model_max_context),
             temperature: req.temperature.unwrap_or(d.temperature),
             top_k: req.top_k.unwrap_or(d.top_k),
             top_p: req.top_p.unwrap_or(d.top_p),
@@ -250,23 +766,39 @@ mod imp {
     /// Spawn the dedicated thread that owns the `!Send` Metal state. Loads the
     /// model, signals readiness (or a load error) over `ready`, then serves jobs
     /// serially until all `Job` senders drop.
+    /// Worker readiness payload (#551): carries the actual KV context the
+    /// worker allocated so `run()` can store it in `AppState` instead of a
+    /// hard-coded constant.
+    struct WorkerReady {
+        format: String,
+        model_max_context: usize,
+    }
+
     fn spawn_worker(
         model_dir: std::path::PathBuf,
         tokenizer_path: std::path::PathBuf,
         is_q4: bool,
-        ready: std::sync::mpsc::Sender<Result<String, String>>,
+        ready: std::sync::mpsc::Sender<Result<WorkerReady, String>>,
     ) -> mpsc::UnboundedSender<Job> {
         let (job_tx, job_rx) = mpsc::unbounded_channel::<Job>();
         std::thread::spawn(move || {
             let loaded = load_model(&model_dir, &tokenizer_path, is_q4);
-            let (mut metal, tokenizer, fmt) = match loaded {
+            let LoadedModel {
+                mut metal,
+                tokenizer,
+                format,
+                model_max_context,
+            } = match loaded {
                 Ok(t) => t,
                 Err(e) => {
                     let _ = ready.send(Err(e));
                     return;
                 }
             };
-            let _ = ready.send(Ok(fmt));
+            let _ = ready.send(Ok(WorkerReady {
+                format,
+                model_max_context,
+            }));
 
             run_worker_loop(job_rx, move |messages, cfg, on_token, should_cancel| {
                 metal.reset_state();
@@ -348,32 +880,65 @@ mod imp {
         }
     }
 
+    /// Everything the worker thread needs after a successful model load,
+    /// including the actual KV context (#551) so request clamping never
+    /// drifts from what was actually allocated.
+    struct LoadedModel {
+        metal: MetalQwen35State,
+        tokenizer: BpeTokenizer,
+        format: String,
+        model_max_context: usize,
+    }
+
     fn load_model(
         model_dir: &std::path::Path,
         tokenizer_path: &std::path::Path,
         is_q4: bool,
-    ) -> Result<(MetalQwen35State, BpeTokenizer, String), String> {
+    ) -> Result<LoadedModel, String> {
         let tokenizer = BpeTokenizer::from_tokenizer_json(tokenizer_path)
             .map_err(|e| format!("tokenizer load failed ({}): {e}", tokenizer_path.display()))?;
 
         if is_q4 {
-            let cfg = if model_dir.join("config.json").exists() {
+            let has_config_json = model_dir.join("config.json").exists();
+            let cfg = if has_config_json {
                 Qwen35Config::from_config_json(&model_dir.join("config.json"))
                     .map_err(|e| format!("config.json parse failed: {e}"))?
             } else {
                 Qwen35Config::qwen36_27b()
             };
-            let metal =
-                MetalQwen35State::from_q4_dir(model_dir, tokenizer_path, &cfg, MODEL_MAX_CONTEXT)
-                    .map_err(|e| format!("Q4 model load failed: {e}"))?;
-            Ok((metal, tokenizer, "q4".to_string()))
+            let requested_context = if has_config_json {
+                model_context_from_config(Some(&cfg))
+            } else {
+                model_context_from_config(None)
+            };
+            let metal = MetalQwen35State::from_q4_dir(
+                model_dir,
+                tokenizer_path,
+                &cfg,
+                requested_context,
+            )
+            .map_err(|e| format!("Q4 model load failed: {e}"))?;
+            let model_max_context = metal.max_context();
+            Ok(LoadedModel {
+                metal,
+                tokenizer,
+                format: "q4".to_string(),
+                model_max_context,
+            })
         } else {
             let model = Qwen35Model::from_safetensors(model_dir)
                 .map_err(|e| format!("safetensors load failed: {e}"))?;
             let cfg = model.config().clone();
-            let metal = MetalQwen35State::new(model.weights(), &cfg, MODEL_MAX_CONTEXT)
+            let requested_context = model_context_from_config(Some(&cfg));
+            let metal = MetalQwen35State::new(model.weights(), &cfg, requested_context)
                 .map_err(|e| format!("Metal init failed: {e}"))?;
-            Ok((metal, tokenizer, "bf16".to_string()))
+            let model_max_context = metal.max_context();
+            Ok(LoadedModel {
+                metal,
+                tokenizer,
+                format: "bf16".to_string(),
+                model_max_context,
+            })
         }
     }
 
@@ -442,8 +1007,39 @@ mod imp {
         End(usize),  // holds completion_tokens; emits telemetry then stream ends
     }
 
-    async fn chat_completions(State(s): State<AppState>, Json(req): Json<ChatReq>) -> Response {
+    async fn chat_completions(State(s): State<AppState>, body: Body) -> Response {
         let timer = Instant::now();
+        let body = match to_bytes(body, REQUEST_BODY_LIMIT_BYTES).await {
+            Ok(body) => body,
+            Err(_) => {
+                emit_serve_event(
+                    "POST",
+                    "/v1/chat/completions",
+                    400,
+                    None,
+                    timer.elapsed().as_secs_f64() * 1000.0,
+                    false,
+                );
+                return err_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!("request body exceeds {REQUEST_BODY_LIMIT_BYTES} bytes"),
+                );
+            }
+        };
+        let req = match parse_chat_req(&body) {
+            Ok(req) => req,
+            Err(err) => {
+                emit_serve_event(
+                    "POST",
+                    "/v1/chat/completions",
+                    400,
+                    None,
+                    timer.elapsed().as_secs_f64() * 1000.0,
+                    false,
+                );
+                return err_response(StatusCode::BAD_REQUEST, err.message());
+            }
+        };
         if req.messages.is_empty() {
             emit_serve_event(
                 "POST",
@@ -456,8 +1052,21 @@ mod imp {
             return err_response(StatusCode::BAD_REQUEST, "`messages` must not be empty");
         }
 
-        let messages: Vec<ChatMessage> = req.messages.iter().map(to_chat_message).collect();
-        let cfg = build_cfg(&req, &s.defaults);
+        let messages: Vec<ChatMessage> = match req.messages.iter().map(to_chat_message).collect() {
+            Ok(messages) => messages,
+            Err(err) => {
+                emit_serve_event(
+                    "POST",
+                    "/v1/chat/completions",
+                    400,
+                    None,
+                    timer.elapsed().as_secs_f64() * 1000.0,
+                    false,
+                );
+                return err_response(StatusCode::BAD_REQUEST, err.message());
+            }
+        };
+        let cfg = build_cfg(&req, &s.defaults, s.model_max_context);
         let model_id = req.model.clone().unwrap_or_else(|| s.model_id.to_string());
         let streaming = req.stream.unwrap_or(false);
         let id = format!("chatcmpl-{}", unix_nanos());
@@ -805,8 +1414,11 @@ mod imp {
         );
         let (ready_tx, ready_rx) = std::sync::mpsc::channel();
         let jobs = spawn_worker(model_dir.clone(), tokenizer_path, is_q4, ready_tx);
-        let fmt = match ready_rx.recv() {
-            Ok(Ok(fmt)) => fmt,
+        let WorkerReady {
+            format: fmt,
+            model_max_context,
+        } = match ready_rx.recv() {
+            Ok(Ok(ready)) => ready,
             Ok(Err(e)) => return Err(e.into()),
             Err(_) => return Err("worker thread exited during model load".into()),
         };
@@ -816,12 +1428,15 @@ mod imp {
             .and_then(|n| n.to_str())
             .unwrap_or("lattice")
             .into();
-        eprintln!("[lattice_serve] model '{model_id}' ({fmt}) ready");
+        eprintln!(
+            "[lattice_serve] model '{model_id}' ({fmt}) ready (context={model_max_context})"
+        );
 
         let state = AppState {
             jobs,
             model_id,
             defaults,
+            model_max_context,
         };
 
         let rt = tokio::runtime::Builder::new_multi_thread()
@@ -1266,6 +1881,137 @@ mod imp {
             handle
                 .join()
                 .expect("worker thread must not panic on a generation error");
+        }
+
+        // ── #641 / #649 request parsing and clamp tests ──────────────────
+
+        #[test]
+        fn message_content_plain_string_to_chat_message() {
+            let msg = InMsg {
+                role: "user".to_string(),
+                content: MessageContent::Text("hi".to_string()),
+            };
+            let chat_message = to_chat_message(&msg).expect("plain string content must parse");
+            assert_eq!(
+                chat_message.role,
+                lattice_inference::forward::metal_qwen35::ChatRole::User
+            );
+            assert_eq!(chat_message.content, "hi");
+        }
+
+        #[test]
+        fn message_content_parts_concatenate_in_order() {
+            let content = MessageContent::Parts(vec![
+                Part::Text {
+                    text: "a".to_string(),
+                },
+                Part::Text {
+                    text: "b".to_string(),
+                },
+            ]);
+            assert_eq!(content_text(&content).unwrap(), "ab");
+        }
+
+        #[test]
+        fn message_content_image_url_rejected() {
+            let content = MessageContent::Parts(vec![Part::ImageUrl {
+                image_url: ImageUrl {
+                    url: "https://example.com/cat.png".to_string(),
+                    detail: None,
+                },
+            }]);
+            let err = content_text(&content).unwrap_err();
+            assert_eq!(err.message(), IMAGE_REQUIRES_VISION_MESSAGE);
+        }
+
+        #[test]
+        fn message_content_unknown_part_rejected() {
+            let content = MessageContent::Parts(vec![Part::Unsupported {
+                kind: "file".to_string(),
+            }]);
+            let err = content_text(&content).unwrap_err();
+            assert_eq!(
+                err.message(),
+                "unsupported content part type 'file'; only 'text' parts are accepted"
+            );
+        }
+
+        #[test]
+        fn message_role_unknown_rejected() {
+            let err = MessageRole::parse("developer").unwrap_err();
+            assert_eq!(
+                err.message(),
+                "unsupported role 'developer'; must be 'system', 'user', or 'assistant'"
+            );
+        }
+
+        #[test]
+        fn parse_chat_req_rejects_too_many_parts_before_typed_parse() {
+            let parts: Vec<String> = (0..65)
+                .map(|i| format!(r#"{{"type":"text","text":"p{i}"}}"#))
+                .collect();
+            let body = format!(
+                r#"{{"messages":[{{"role":"user","content":[{}]}}]}}"#,
+                parts.join(",")
+            );
+            let err = parse_chat_req(body.as_bytes()).unwrap_err();
+            assert_eq!(
+                err.message(),
+                "messages[0].content has too many parts; maximum is 64"
+            );
+        }
+
+        #[test]
+        fn parse_chat_req_rejects_oversized_text_part_before_typed_parse() {
+            let big_text = "x".repeat(MAX_CONTENT_PART_BYTES + 1);
+            let body = format!(
+                r#"{{"messages":[{{"role":"user","content":[{{"type":"text","text":"{big_text}"}}]}}]}}"#,
+            );
+            let err = parse_chat_req(body.as_bytes()).unwrap_err();
+            assert_eq!(
+                err.message(),
+                "messages[0].content[0] exceeds 65536 bytes"
+            );
+        }
+
+        #[test]
+        fn build_cfg_clamps_to_runtime_context() {
+            let defaults = Defaults {
+                max_tokens: 100,
+                temperature: 0.7,
+                top_k: 50,
+                top_p: 0.9,
+                repetition_penalty: 1.1,
+                reasoning_budget: Some(50),
+            };
+            let req = ChatReq {
+                model: None,
+                messages: vec![],
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                max_tokens: None,
+                seed: None,
+                stream: None,
+                repetition_penalty: None,
+                reasoning_budget: Some(50),
+            };
+            let cfg = build_cfg(&req, &defaults, 8);
+            assert!(cfg.max_new_tokens <= 8);
+            let reasoning_budget = cfg.reasoning_budget.unwrap_or(0);
+            assert!(reasoning_budget + cfg.max_new_tokens + 1 <= 8);
+        }
+
+        #[test]
+        fn model_context_uses_config_max_position_embeddings() {
+            let mut cfg = Qwen35Config::qwen35_2b();
+            cfg.max_position_embeddings = 12345;
+            assert_eq!(model_context_from_config(Some(&cfg)), 12345);
+        }
+
+        #[test]
+        fn model_context_falls_back_to_4096_when_absent() {
+            assert_eq!(model_context_from_config(None), FALLBACK_MODEL_MAX_CONTEXT);
         }
     }
 }

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -65,11 +65,14 @@ mod imp {
         },
         routing::{get, post},
     };
-    use lattice_inference::forward::metal_qwen35::{ChatMessage, MetalQwen35State};
+    use lattice_inference::forward::metal_qwen35::{
+        ChatMessage, MetalQwen35State, format_chat_template,
+    };
     use lattice_inference::model::qwen35::Qwen35Model;
     use lattice_inference::model::qwen35_config::{
         GenerateConfig, QWEN_CHAT_IM_END_TOKEN_ID, Qwen35Config,
     };
+    use lattice_inference::tokenizer::Tokenizer as _;
     use lattice_inference::tokenizer::bpe::BpeTokenizer;
     use serde::Deserialize;
     use serde_json::{Value, json};
@@ -93,6 +96,14 @@ mod imp {
         /// non-streaming handlers below decide separately how much (if any)
         /// of it is safe to surface to the HTTP client.
         Failed {
+            message: String,
+        },
+        /// The request itself cannot fit the model's KV window (#656: prompt
+        /// length was unknown to `build_cfg`, so this is only checked once
+        /// the worker tokenizes the prompt). Client-caused, so it maps to
+        /// HTTP 400 rather than the 500 `Failed` uses -- distinct from a
+        /// generation-time failure, never a server-side problem.
+        Rejected {
             message: String,
         },
     }
@@ -214,6 +225,76 @@ mod imp {
         repetition_penalty: Option<f32>,
         #[serde(default)]
         reasoning_budget: Option<usize>,
+        // #656: known-but-unsupported OpenAI fields, modeled explicitly (not
+        // left to serde's default silent-drop of unknown fields) so
+        // `reject_unsupported` can name the exact offending field and
+        // return HTTP 400 rather than quietly running a tool-calling/
+        // JSON-mode/multi-completion request as a plain text completion.
+        #[serde(default)]
+        max_completion_tokens: Option<usize>,
+        #[serde(default)]
+        tools: Option<Value>,
+        #[serde(default)]
+        tool_choice: Option<Value>,
+        #[serde(default)]
+        response_format: Option<ResponseFormat>,
+        #[serde(default)]
+        n: Option<usize>,
+        #[serde(default)]
+        logprobs: Option<bool>,
+        #[serde(default)]
+        top_logprobs: Option<usize>,
+        #[serde(default)]
+        stop: Option<Value>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct ResponseFormat {
+        r#type: String,
+    }
+
+    /// #656: reject known-but-unsupported OpenAI request fields with HTTP
+    /// 400 instead of silently ignoring them -- the same fail-closed
+    /// philosophy `MessageRole::parse`/`content_text` already apply to
+    /// roles and content parts. Mirrors `lattice.rs`'s `reject_unsupported`,
+    /// scoped to this minimal server's narrower surface: unlike
+    /// `lattice.rs`, this server has no `logprobs`/`stop` implementation at
+    /// all, so both are rejected outright rather than conditionally.
+    fn reject_unsupported(req: &ChatReq) -> Result<(), RequestError> {
+        if req.tools.is_some() || req.tool_choice.is_some() {
+            return Err(RequestError::bad_request(
+                "tools and tool_choice are not supported by this server",
+            ));
+        }
+        if req.n.unwrap_or(1) > 1 {
+            return Err(RequestError::bad_request("n > 1 is not supported"));
+        }
+        if let Some(fmt) = &req.response_format
+            && fmt.r#type != "text"
+        {
+            return Err(RequestError::bad_request(format!(
+                "response_format.type '{}' is not supported; use 'text'",
+                fmt.r#type
+            )));
+        }
+        if req.logprobs.unwrap_or(false) || req.top_logprobs.is_some() {
+            return Err(RequestError::bad_request(
+                "logprobs/top_logprobs are not supported by this server",
+            ));
+        }
+        if req.stop.is_some() {
+            return Err(RequestError::bad_request(
+                "stop is not supported by this server",
+            ));
+        }
+        if let (Some(a), Some(b)) = (req.max_tokens, req.max_completion_tokens)
+            && a != b
+        {
+            return Err(RequestError::bad_request(format!(
+                "max_tokens ({a}) and max_completion_tokens ({b}) differ; supply only one"
+            )));
+        }
+        Ok(())
     }
 
     #[derive(Debug, Deserialize)]
@@ -528,18 +609,25 @@ mod imp {
             {
                 let mut part_index = 0usize;
                 loop {
-                    if part_index >= MAX_CONTENT_PARTS_PER_MESSAGE {
-                        let msg = too_many_parts_message(self.message_index);
-                        *self.violation.borrow_mut() = Some(RequestError::bad_request(msg.clone()));
-                        return Err(A::Error::custom(msg));
-                    }
                     let seed = PartSeed {
                         violation: self.violation,
                         message_index: self.message_index,
                         part_index,
                     };
                     match seq.next_element_seed(seed)? {
-                        Some(()) => part_index += 1,
+                        Some(()) => {
+                            part_index += 1;
+                            // #656: reject only once MORE than the documented
+                            // maximum has actually been consumed, so an array
+                            // of exactly `MAX_CONTENT_PARTS_PER_MESSAGE` parts
+                            // is accepted and only the (MAX+1)-th is rejected.
+                            if part_index > MAX_CONTENT_PARTS_PER_MESSAGE {
+                                let msg = too_many_parts_message(self.message_index);
+                                *self.violation.borrow_mut() =
+                                    Some(RequestError::bad_request(msg.clone()));
+                                return Err(A::Error::custom(msg));
+                            }
+                        }
                         None => break,
                     }
                 }
@@ -751,6 +839,11 @@ mod imp {
         // window even when `reasoning_budget` is absent/zero.
         let max_new_tokens = req
             .max_tokens
+            // #656: `max_completion_tokens` is the current OpenAI field name;
+            // `reject_unsupported` already rejected the two being present
+            // and disagreeing, so whichever is set here is the caller's
+            // single, unambiguous intent.
+            .or(req.max_completion_tokens)
             .unwrap_or(d.max_tokens)
             .min(model_max_context.saturating_sub(1));
         // The worst-case decode cap is `reasoning_budget + max_new_tokens + 1`
@@ -778,11 +871,50 @@ mod imp {
             grammar: None,
             stop_strings: vec![],
             reasoning_budget,
-            // ChatReq has no logprobs/top_logprobs fields (#585) — this minimal
-            // server does not expose them, same as the rest of the OpenAI
-            // surface it does not implement (tools, response_format, etc.).
+            // ChatReq models `logprobs`/`top_logprobs` (#656) only so
+            // `reject_unsupported` can fail closed with HTTP 400 -- this
+            // minimal server has no logprobs implementation at all, so a
+            // `logprobs: true` request never reaches here (see below).
             logprobs: None,
         }
+    }
+
+    /// Prefix marker used only by the KV-window pre-check in `spawn_worker`'s
+    /// `generate` closure: distinguishes a client-caused window-overflow
+    /// rejection (HTTP 400, `Ev::Rejected`) from a genuine generation
+    /// failure (HTTP 500, `Ev::Failed`) without changing `run_worker_loop`'s
+    /// generic `Result<(usize, usize), String>` contract, which every other
+    /// caller and test fake still uses unchanged.
+    const PROMPT_EXCEEDS_WINDOW_PREFIX: &str = "prompt-exceeds-window: ";
+
+    /// #656: `build_cfg` only clamps `max_new_tokens`/`reasoning_budget`
+    /// against `model_max_context` *in isolation* -- it has no visibility
+    /// into `prompt_len` (unknown until the worker tokenizes the prompt).
+    /// The invariant that must actually hold is the full-window one:
+    /// `prompt_len + max_new_tokens + reasoning_budget + 1 <= model_max_context`.
+    /// Called by the worker right after tokenizing, before generation
+    /// starts, so a request that would overrun the KV cache is rejected up
+    /// front instead of silently hitting `StopReason::KvFull` mid-generation
+    /// while the response still claims `finish_reason: "stop"`.
+    fn check_prompt_fits_window(
+        model_max_context: usize,
+        prompt_len: usize,
+        cfg: &GenerateConfig,
+    ) -> Result<(), String> {
+        let decode_cap = cfg
+            .max_new_tokens
+            .saturating_add(cfg.reasoning_budget.unwrap_or(0));
+        let required = prompt_len.saturating_add(decode_cap).saturating_add(1);
+        if required > model_max_context {
+            let available = model_max_context.saturating_sub(prompt_len);
+            return Err(format!(
+                "prompt has {prompt_len} tokens, leaving {available} of the \
+                 {model_max_context}-token context window for generation, but this \
+                 request needs {decode_cap} generated tokens plus 1 (total {required}); \
+                 reduce max_tokens/reasoning_budget or shorten the prompt"
+            ));
+        }
+        Ok(())
     }
 
     // ─── GPU worker thread ───────────────────────────────────────────────────
@@ -825,6 +957,16 @@ mod imp {
             }));
 
             run_worker_loop(job_rx, move |messages, cfg, on_token, should_cancel| {
+                // #656: verify the FULL window invariant (prompt included)
+                // before doing any GPU work -- `cfg` alone was already
+                // clamped by `build_cfg`, but only against the window in
+                // isolation, not against this specific prompt's length.
+                let prompt_len = tokenizer
+                    .tokenize(&format_chat_template(messages))
+                    .real_length;
+                if let Err(msg) = check_prompt_fits_window(model_max_context, prompt_len, cfg) {
+                    return Err(format!("{PROMPT_EXCEEDS_WINDOW_PREFIX}{msg}"));
+                }
                 metal.reset_state();
                 metal
                     .chat_completion_streaming_with_cancel(
@@ -897,8 +1039,15 @@ mod imp {
                     });
                 }
                 Err(message) => {
-                    eprintln!("generation error: {message}");
-                    let _ = job.tx.send(Ev::Failed { message });
+                    if let Some(client_message) = message.strip_prefix(PROMPT_EXCEEDS_WINDOW_PREFIX)
+                    {
+                        let _ = job.tx.send(Ev::Rejected {
+                            message: client_message.to_string(),
+                        });
+                    } else {
+                        eprintln!("generation error: {message}");
+                        let _ = job.tx.send(Ev::Failed { message });
+                    }
                 }
             }
         }
@@ -1057,6 +1206,17 @@ mod imp {
                 return err_response(StatusCode::BAD_REQUEST, err.message());
             }
         };
+        if let Err(err) = reject_unsupported(&req) {
+            emit_serve_event(
+                "POST",
+                "/v1/chat/completions",
+                400,
+                None,
+                timer.elapsed().as_secs_f64() * 1000.0,
+                false,
+            );
+            return err_response(StatusCode::BAD_REQUEST, err.message());
+        }
         if req.messages.is_empty() {
             emit_serve_event(
                 "POST",
@@ -1187,6 +1347,26 @@ mod imp {
                                         (rx, Phase::Done(0), cancel_guard),
                                     ))
                                 }
+                                Some(Ev::Rejected { message }) => {
+                                    // #656: the request cannot fit the model's KV
+                                    // window (prompt + requested generation). The
+                                    // status code is already committed to 200 SSE,
+                                    // so this cannot become the 400 the
+                                    // non-streaming path returns; report it as
+                                    // `finish_reason: "length"` instead of "stop"
+                                    // so a client can at least tell no content was
+                                    // actually generated for this reason.
+                                    eprintln!("request rejected (streaming): {message}");
+                                    let chunk = json!({
+                                        "id": id, "object": "chat.completion.chunk",
+                                        "created": created, "model": model,
+                                        "choices": [{"index": 0, "delta": {}, "finish_reason": "length"}],
+                                    });
+                                    Some((
+                                        Ok(Event::default().data(chunk.to_string())),
+                                        (rx, Phase::Done(0), cancel_guard),
+                                    ))
+                                }
                                 None => {
                                     let chunk = json!({
                                         "id": id, "object": "chat.completion.chunk",
@@ -1252,6 +1432,23 @@ mod imp {
                             false,
                         );
                         return err_response(StatusCode::INTERNAL_SERVER_ERROR, "inference failed");
+                    }
+                    Ev::Rejected { message } => {
+                        // #656: client-caused request-contract violation (the
+                        // prompt plus requested generation does not fit the
+                        // model's KV window), caught before any generation
+                        // ran -- unlike `Ev::Failed`, the response has not
+                        // been committed yet, so this surfaces as a real 400
+                        // with the specific reason, not a generic 500.
+                        emit_serve_event(
+                            "POST",
+                            "/v1/chat/completions",
+                            400,
+                            None,
+                            timer.elapsed().as_secs_f64() * 1000.0,
+                            false,
+                        );
+                        return err_response(StatusCode::BAD_REQUEST, &message);
                     }
                 }
             }
@@ -1716,6 +1913,9 @@ mod imp {
                     Some(Ev::Failed { message }) => {
                         panic!("fake_generate never fails; unexpected Ev::Failed: {message}")
                     }
+                    Some(Ev::Rejected { message }) => {
+                        panic!("fake_generate never rejects; unexpected Ev::Rejected: {message}")
+                    }
                     None => panic!("job 1's reply channel closed before a Done event"),
                 }
             }
@@ -1785,6 +1985,9 @@ mod imp {
                 }
                 Some(Ev::Failed { message }) => panic!(
                     "fake_generate_with_prefill_gap never fails; unexpected Ev::Failed: {message}"
+                ),
+                Some(Ev::Rejected { message }) => panic!(
+                    "fake_generate_with_prefill_gap never rejects; unexpected Ev::Rejected: {message}"
                 ),
                 None => panic!("job 1's reply channel closed before a Done event"),
             }
@@ -1873,6 +2076,9 @@ mod imp {
                 ),
                 Some(Ev::Delta(_)) => {
                     panic!("a generator that fails on its first call must never emit a Delta first")
+                }
+                Some(Ev::Rejected { message }) => {
+                    panic!("this fake generator never rejects; unexpected Ev::Rejected: {message}")
                 }
                 None => panic!("job 1's reply channel closed with no event at all"),
             }
@@ -1976,6 +2182,23 @@ mod imp {
             );
         }
 
+        /// #656 boundary fix: exactly `MAX_CONTENT_PARTS_PER_MESSAGE` (64)
+        /// parts is the documented maximum and MUST be accepted — only
+        /// MAX+1 (covered above) is rejected.
+        #[test]
+        fn parse_chat_req_accepts_max_parts_boundary() {
+            assert_eq!(MAX_CONTENT_PARTS_PER_MESSAGE, 64);
+            let parts: Vec<String> = (0..MAX_CONTENT_PARTS_PER_MESSAGE)
+                .map(|i| format!(r#"{{"type":"text","text":"p{i}"}}"#))
+                .collect();
+            let body = format!(
+                r#"{{"messages":[{{"role":"user","content":[{}]}}]}}"#,
+                parts.join(",")
+            );
+            let req = parse_chat_req(body.as_bytes()).expect("exactly 64 parts must be accepted");
+            assert_eq!(req.messages.len(), 1);
+        }
+
         #[test]
         fn parse_chat_req_rejects_oversized_text_part_before_typed_parse() {
             let big_text = "x".repeat(MAX_CONTENT_PART_BYTES + 1);
@@ -2007,11 +2230,153 @@ mod imp {
                 stream: None,
                 repetition_penalty: None,
                 reasoning_budget: Some(50),
+                max_completion_tokens: None,
+                tools: None,
+                tool_choice: None,
+                response_format: None,
+                n: None,
+                logprobs: None,
+                top_logprobs: None,
+                stop: None,
             };
             let cfg = build_cfg(&req, &defaults, 8);
             assert!(cfg.max_new_tokens <= 8);
             let reasoning_budget = cfg.reasoning_budget.unwrap_or(0);
             assert!(reasoning_budget + cfg.max_new_tokens < 8);
+        }
+
+        // ── #656: prompt-aware KV-window invariant ────────────────────────
+        //
+        // `build_cfg` alone only clamps `max_new_tokens`/`reasoning_budget`
+        // against the window in isolation; `check_prompt_fits_window` is the
+        // second half that accounts for `prompt_len`, which is only known
+        // once the worker tokenizes the prompt (see `spawn_worker`).
+
+        #[test]
+        fn check_prompt_fits_window_rejects_when_prompt_plus_decode_overflows() {
+            // model_max_context=8, prompt_len=2, max_tokens=7, reasoning_budget=None:
+            // build_cfg clamps max_new_tokens to min(7, 8-1)=7 in isolation, but
+            // 2 (prompt) + 7 (decode) + 1 (delimiter) = 10 > 8 -- must reject.
+            let defaults = Defaults {
+                max_tokens: 7,
+                temperature: 0.7,
+                top_k: 50,
+                top_p: 0.9,
+                repetition_penalty: 1.1,
+                reasoning_budget: None,
+            };
+            let req = ChatReq {
+                model: None,
+                messages: vec![],
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                max_tokens: Some(7),
+                seed: None,
+                stream: None,
+                repetition_penalty: None,
+                reasoning_budget: None,
+                max_completion_tokens: None,
+                tools: None,
+                tool_choice: None,
+                response_format: None,
+                n: None,
+                logprobs: None,
+                top_logprobs: None,
+                stop: None,
+            };
+            let cfg = build_cfg(&req, &defaults, 8);
+            let err = check_prompt_fits_window(8, 2, &cfg).unwrap_err();
+            assert!(
+                err.contains("2 tokens") && err.contains("8-token"),
+                "error must name the actual prompt length and window: {err}"
+            );
+        }
+
+        #[test]
+        fn check_prompt_fits_window_accepts_exact_boundary_no_needless_truncation() {
+            // model_max_context=8, prompt_len=1, max_tokens=6, reasoning_budget=1:
+            // build_cfg clamps max_new_tokens to min(6, 7)=6, reasoning_room=8-6-1=1,
+            // reasoning_budget=min(1,1)=1. 1 (prompt) + 6 (max_new_tokens) +
+            // 1 (reasoning_budget) + 1 (delimiter) = 9 > 8 -- the "+1 delimiter"
+            // edge case from the review: still overflows by exactly one slot,
+            // so it must ALSO reject, proving the check catches the boundary
+            // exactly rather than off-by-one under-rejecting.
+            let defaults = Defaults {
+                max_tokens: 6,
+                temperature: 0.7,
+                top_k: 50,
+                top_p: 0.9,
+                repetition_penalty: 1.1,
+                reasoning_budget: None,
+            };
+            let req = ChatReq {
+                model: None,
+                messages: vec![],
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                max_tokens: Some(6),
+                seed: None,
+                stream: None,
+                repetition_penalty: None,
+                reasoning_budget: Some(1),
+                max_completion_tokens: None,
+                tools: None,
+                tool_choice: None,
+                response_format: None,
+                n: None,
+                logprobs: None,
+                top_logprobs: None,
+                stop: None,
+            };
+            let cfg = build_cfg(&req, &defaults, 8);
+            assert!(check_prompt_fits_window(8, 1, &cfg).is_err());
+
+            // Same request, but the window has one more slot of room (9):
+            // 1 + 6 + 1 + 1 = 9 <= 9 -- must be ACCEPTED, and `max_new_tokens`
+            // must be the full requested 6, not needlessly truncated.
+            let cfg2 = build_cfg(&req, &defaults, 9);
+            assert_eq!(cfg2.max_new_tokens, 6, "must not needlessly truncate");
+            assert!(check_prompt_fits_window(9, 1, &cfg2).is_ok());
+        }
+
+        #[test]
+        fn check_prompt_fits_window_accepts_ordinary_prompt_unclamped() {
+            // A near-window but comfortably-fitting prompt must generate its
+            // full requested budget -- no needless truncation in the common case.
+            let defaults = Defaults {
+                max_tokens: 50,
+                temperature: 0.7,
+                top_k: 50,
+                top_p: 0.9,
+                repetition_penalty: 1.1,
+                reasoning_budget: None,
+            };
+            let req = ChatReq {
+                model: None,
+                messages: vec![],
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                max_tokens: Some(50),
+                seed: None,
+                stream: None,
+                repetition_penalty: None,
+                reasoning_budget: None,
+                max_completion_tokens: None,
+                tools: None,
+                tool_choice: None,
+                response_format: None,
+                n: None,
+                logprobs: None,
+                top_logprobs: None,
+                stop: None,
+            };
+            let cfg = build_cfg(&req, &defaults, 4096);
+            assert_eq!(cfg.max_new_tokens, 50);
+            // prompt_len=100: 100 + 50 + 0 + 1 = 151 <= 4096.
+            assert!(check_prompt_fits_window(4096, 100, &cfg).is_ok());
         }
 
         #[test]
@@ -2101,6 +2466,146 @@ mod imp {
             let (status, message) = error_message_of(response).await;
             assert_eq!(status, StatusCode::BAD_REQUEST);
             assert_eq!(message, "messages[0].content[0] exceeds 65536 bytes");
+        }
+
+        // ── #656: known-but-unsupported OpenAI field rejection ────────────
+        //
+        // Same fail-closed contract as the three tests above: these fields
+        // are parsed (not silently dropped by serde's unknown-field
+        // default), so a client asking for tool calls / JSON mode / N
+        // completions / stop sequences gets an explicit 400 naming the
+        // unsupported field instead of a plain-text completion that quietly
+        // ignored the request's actual contract.
+
+        #[tokio::test]
+        async fn chat_completions_tools_400() {
+            let body = Body::from(
+                r#"{"messages":[{"role":"user","content":"hi"}],
+                    "tools":[{"type":"function","function":{"name":"f"}}]}"#
+                    .to_string(),
+            );
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(
+                message,
+                "tools and tool_choice are not supported by this server"
+            );
+        }
+
+        #[tokio::test]
+        async fn chat_completions_tool_choice_400() {
+            let body = Body::from(
+                r#"{"messages":[{"role":"user","content":"hi"}],"tool_choice":"auto"}"#.to_string(),
+            );
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(
+                message,
+                "tools and tool_choice are not supported by this server"
+            );
+        }
+
+        #[tokio::test]
+        async fn chat_completions_json_response_format_400() {
+            let body = Body::from(
+                r#"{"messages":[{"role":"user","content":"hi"}],
+                    "response_format":{"type":"json_object"}}"#
+                    .to_string(),
+            );
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(
+                message,
+                "response_format.type 'json_object' is not supported; use 'text'"
+            );
+        }
+
+        #[tokio::test]
+        async fn chat_completions_n_greater_than_one_400() {
+            let body =
+                Body::from(r#"{"messages":[{"role":"user","content":"hi"}],"n":2}"#.to_string());
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(message, "n > 1 is not supported");
+        }
+
+        #[tokio::test]
+        async fn chat_completions_logprobs_400() {
+            let body = Body::from(
+                r#"{"messages":[{"role":"user","content":"hi"}],"logprobs":true}"#.to_string(),
+            );
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(
+                message,
+                "logprobs/top_logprobs are not supported by this server"
+            );
+        }
+
+        #[tokio::test]
+        async fn chat_completions_stop_400() {
+            let body = Body::from(
+                r#"{"messages":[{"role":"user","content":"hi"}],"stop":"\n"}"#.to_string(),
+            );
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(message, "stop is not supported by this server");
+        }
+
+        #[tokio::test]
+        async fn chat_completions_conflicting_max_tokens_400() {
+            let body = Body::from(
+                r#"{"messages":[{"role":"user","content":"hi"}],
+                    "max_tokens":10,"max_completion_tokens":20}"#
+                    .to_string(),
+            );
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(
+                message,
+                "max_tokens (10) and max_completion_tokens (20) differ; supply only one"
+            );
+        }
+
+        #[test]
+        fn build_cfg_aliases_max_completion_tokens_when_max_tokens_absent() {
+            let defaults = Defaults {
+                max_tokens: 100,
+                temperature: 0.7,
+                top_k: 50,
+                top_p: 0.9,
+                repetition_penalty: 1.1,
+                reasoning_budget: None,
+            };
+            let req = ChatReq {
+                model: None,
+                messages: vec![],
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                max_tokens: None,
+                seed: None,
+                stream: None,
+                repetition_penalty: None,
+                reasoning_budget: None,
+                max_completion_tokens: Some(42),
+                tools: None,
+                tool_choice: None,
+                response_format: None,
+                n: None,
+                logprobs: None,
+                top_logprobs: None,
+                stop: None,
+            };
+            let cfg = build_cfg(&req, &defaults, 4096);
+            assert_eq!(cfg.max_new_tokens, 42);
         }
     }
 }

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -191,7 +191,7 @@ mod imp {
         }
     }
 
-    #[derive(Deserialize)]
+    #[derive(Debug, Deserialize)]
     struct ChatReq {
         #[serde(default)]
         model: Option<String>,
@@ -216,7 +216,7 @@ mod imp {
         reasoning_budget: Option<usize>,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Debug, Deserialize)]
     struct InMsg {
         role: String,
         content: MessageContent,
@@ -259,11 +259,17 @@ mod imp {
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum Part {
-        Text { text: String },
-        ImageUrl { image_url: ImageUrl },
+        Text {
+            text: String,
+        },
+        ImageUrl {
+            image_url: ImageUrl,
+        },
         /// Any part `type` other than `text`/`image_url` (#641/#649): kept
         /// instead of dropped so it can be rejected with its real type name.
-        Unsupported { kind: String },
+        Unsupported {
+            kind: String,
+        },
     }
 
     #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -292,7 +298,9 @@ mod imp {
             match raw.kind.as_deref() {
                 Some("text") => {
                     let text = raw.text.ok_or_else(|| {
-                        serde::de::Error::custom("text content part must include string field 'text'")
+                        serde::de::Error::custom(
+                            "text content part must include string field 'text'",
+                        )
                     })?;
                     Ok(Self::Text { text })
                 }
@@ -315,7 +323,9 @@ mod imp {
     }
 
     fn part_too_large_message(message_index: usize, part_index: usize) -> String {
-        format!("messages[{message_index}].content[{part_index}] exceeds {MAX_CONTENT_PART_BYTES} bytes")
+        format!(
+            "messages[{message_index}].content[{part_index}] exceeds {MAX_CONTENT_PART_BYTES} bytes"
+        )
     }
 
     fn too_many_parts_message(message_index: usize) -> String {
@@ -332,7 +342,10 @@ mod imp {
     /// shape mismatch is left for the authoritative typed parse below —
     /// this function only ever raises the two size/count errors above.
     fn validate_content_part_limits(body: &[u8]) -> Result<(), RequestError> {
-        use serde::de::{DeserializeSeed, Error as DeError, IgnoredAny, MapAccess, SeqAccess, Visitor};
+        use serde::Deserializer as _;
+        use serde::de::{
+            DeserializeSeed, Error as DeError, IgnoredAny, MapAccess, SeqAccess, Visitor,
+        };
         use std::cell::RefCell;
         use std::fmt;
 
@@ -733,16 +746,27 @@ mod imp {
     fn build_cfg(req: &ChatReq, d: &Defaults, model_max_context: usize) -> GenerateConfig {
         // Clamp like `max_tokens`: a budget past the KV window is meaningless and
         // would let a future `with_capacity(decode_cap(..))` abort on overflow.
+        // Reserve one slot of headroom so the worst-case decode cap below
+        // (`reasoning_budget + max_new_tokens + 1`) never exceeds the KV
+        // window even when `reasoning_budget` is absent/zero.
+        let max_new_tokens = req
+            .max_tokens
+            .unwrap_or(d.max_tokens)
+            .min(model_max_context.saturating_sub(1));
+        // The worst-case decode cap is `reasoning_budget + max_new_tokens + 1`
+        // (#551): keep it at or below the KV window the worker actually
+        // allocated, not just below `model_max_context` in isolation.
+        let reasoning_room = model_max_context
+            .saturating_sub(max_new_tokens)
+            .saturating_sub(1);
         let reasoning_budget = req
             .reasoning_budget
             .filter(|&n| n > 0)
             .or(d.reasoning_budget)
-            .map(|n| n.min(model_max_context));
+            .map(|n| n.min(reasoning_room))
+            .filter(|&n| n > 0);
         GenerateConfig {
-            max_new_tokens: req
-                .max_tokens
-                .unwrap_or(d.max_tokens)
-                .min(model_max_context),
+            max_new_tokens,
             temperature: req.temperature.unwrap_or(d.temperature),
             top_k: req.top_k.unwrap_or(d.top_k),
             top_p: req.top_p.unwrap_or(d.top_p),
@@ -911,13 +935,9 @@ mod imp {
             } else {
                 model_context_from_config(None)
             };
-            let metal = MetalQwen35State::from_q4_dir(
-                model_dir,
-                tokenizer_path,
-                &cfg,
-                requested_context,
-            )
-            .map_err(|e| format!("Q4 model load failed: {e}"))?;
+            let metal =
+                MetalQwen35State::from_q4_dir(model_dir, tokenizer_path, &cfg, requested_context)
+                    .map_err(|e| format!("Q4 model load failed: {e}"))?;
             let model_max_context = metal.max_context();
             Ok(LoadedModel {
                 metal,
@@ -1009,22 +1029,19 @@ mod imp {
 
     async fn chat_completions(State(s): State<AppState>, body: Body) -> Response {
         let timer = Instant::now();
-        let body = match to_bytes(body, REQUEST_BODY_LIMIT_BYTES).await {
-            Ok(body) => body,
-            Err(_) => {
-                emit_serve_event(
-                    "POST",
-                    "/v1/chat/completions",
-                    400,
-                    None,
-                    timer.elapsed().as_secs_f64() * 1000.0,
-                    false,
-                );
-                return err_response(
-                    StatusCode::BAD_REQUEST,
-                    &format!("request body exceeds {REQUEST_BODY_LIMIT_BYTES} bytes"),
-                );
-            }
+        let Ok(body) = to_bytes(body, REQUEST_BODY_LIMIT_BYTES).await else {
+            emit_serve_event(
+                "POST",
+                "/v1/chat/completions",
+                400,
+                None,
+                timer.elapsed().as_secs_f64() * 1000.0,
+                false,
+            );
+            return err_response(
+                StatusCode::BAD_REQUEST,
+                &format!("request body exceeds {REQUEST_BODY_LIMIT_BYTES} bytes"),
+            );
         };
         let req = match parse_chat_req(&body) {
             Ok(req) => req,
@@ -1428,9 +1445,7 @@ mod imp {
             .and_then(|n| n.to_str())
             .unwrap_or("lattice")
             .into();
-        eprintln!(
-            "[lattice_serve] model '{model_id}' ({fmt}) ready (context={model_max_context})"
-        );
+        eprintln!("[lattice_serve] model '{model_id}' ({fmt}) ready (context={model_max_context})");
 
         let state = AppState {
             jobs,
@@ -1968,10 +1983,7 @@ mod imp {
                 r#"{{"messages":[{{"role":"user","content":[{{"type":"text","text":"{big_text}"}}]}}]}}"#,
             );
             let err = parse_chat_req(body.as_bytes()).unwrap_err();
-            assert_eq!(
-                err.message(),
-                "messages[0].content[0] exceeds 65536 bytes"
-            );
+            assert_eq!(err.message(), "messages[0].content[0] exceeds 65536 bytes");
         }
 
         #[test]
@@ -1999,7 +2011,7 @@ mod imp {
             let cfg = build_cfg(&req, &defaults, 8);
             assert!(cfg.max_new_tokens <= 8);
             let reasoning_budget = cfg.reasoning_budget.unwrap_or(0);
-            assert!(reasoning_budget + cfg.max_new_tokens + 1 <= 8);
+            assert!(reasoning_budget + cfg.max_new_tokens < 8);
         }
 
         #[test]
@@ -2012,6 +2024,83 @@ mod imp {
         #[test]
         fn model_context_falls_back_to_4096_when_absent() {
             assert_eq!(model_context_from_config(None), FALLBACK_MODEL_MAX_CONTEXT);
+        }
+
+        // ── HTTP-level 400 tests ──────────────────────────────────────────
+        //
+        // All three failure modes below (`#641` unknown role, `#649` image
+        // part, `#649` oversized part) return from `chat_completions` before
+        // a `Job` is ever sent to `s.jobs`, so a fake unbounded sender with no
+        // running worker is a faithful stand-in: no GPU, no model load.
+
+        fn test_app_state() -> AppState {
+            let (jobs, _rx) = mpsc::unbounded_channel::<Job>();
+            AppState {
+                jobs,
+                model_id: Arc::from("test-model"),
+                defaults: Defaults {
+                    max_tokens: 100,
+                    temperature: 0.7,
+                    top_k: 50,
+                    top_p: 0.9,
+                    repetition_penalty: 1.1,
+                    reasoning_budget: None,
+                },
+                model_max_context: 4096,
+            }
+        }
+
+        async fn error_message_of(response: Response) -> (StatusCode, String) {
+            let status = response.status();
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("response body must be readable");
+            let value: serde_json::Value =
+                serde_json::from_slice(&body).expect("error response must be valid JSON");
+            let message = value["error"]["message"]
+                .as_str()
+                .expect("error response must carry error.message")
+                .to_string();
+            (status, message)
+        }
+
+        #[tokio::test]
+        async fn chat_completions_unknown_role_400() {
+            let body =
+                Body::from(r#"{"messages":[{"role":"developer","content":"hi"}]}"#.to_string());
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(
+                message,
+                "unsupported role 'developer'; must be 'system', 'user', or 'assistant'"
+            );
+        }
+
+        #[tokio::test]
+        async fn chat_completions_image_url_400() {
+            let body = Body::from(
+                r#"{"messages":[{"role":"user","content":[
+                    {"type":"image_url","image_url":{"url":"https://example.com/cat.png"}}
+                ]}]}"#
+                    .to_string(),
+            );
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(message, IMAGE_REQUIRES_VISION_MESSAGE);
+        }
+
+        #[tokio::test]
+        async fn chat_completions_oversized_part_400() {
+            let big_text = "x".repeat(MAX_CONTENT_PART_BYTES + 1);
+            let body = Body::from(format!(
+                r#"{{"messages":[{{"role":"user","content":[{{"type":"text","text":"{big_text}"}}]}}]}}"#,
+            ));
+            let response = chat_completions(State(test_app_state()), body).await;
+            let (status, message) = error_message_of(response).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(message, "messages[0].content[0] exceeds 65536 bytes");
         }
     }
 }

--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -115,11 +115,21 @@ pub struct Qwen35Config {
 
     // --- Generation ---
     pub eos_token_id: u32,
+    /// Model's native context window. Missing from a `config.json` is
+    /// representable (defaults to 4096) so callers deriving the serve
+    /// context clamp (#551) can distinguish "no real value present" from a
+    /// present-but-small value rather than silently inheriting an unrelated
+    /// preset's context length.
+    #[serde(default = "default_max_position_embeddings")]
     pub max_position_embeddings: usize,
 }
 
 fn default_tie_word_embeddings() -> bool {
     true
+}
+
+fn default_max_position_embeddings() -> usize {
+    4096
 }
 
 // Nested rope_parameters in HF config.json (many models nest rope_theta and
@@ -1431,6 +1441,38 @@ mod tests {
             "Qwen3.5 mtp_num_hidden_layers must default to 0"
         );
         assert!(!cfg.mtp_use_dedicated_embeddings);
+    }
+
+    #[test]
+    fn qwen35_config_missing_max_position_embeddings_defaults_4096() {
+        // #551: a config.json without max_position_embeddings must not
+        // silently inherit the container-level Default's (qwen36_35b_a3b)
+        // 262_144 context — it must resolve to the documented 4096 fallback.
+        let json = r#"{
+            "text_config": {
+                "hidden_size": 2048,
+                "num_hidden_layers": 24,
+                "vocab_size": 248320,
+                "num_attention_heads": 8,
+                "num_key_value_heads": 2,
+                "head_dim": 256,
+                "rms_norm_eps": 0.000001,
+                "intermediate_size": 6144,
+                "linear_num_key_heads": 16,
+                "linear_num_value_heads": 16,
+                "linear_key_head_dim": 128,
+                "linear_value_head_dim": 128,
+                "linear_conv_kernel_dim": 4,
+                "full_attention_interval": 4,
+                "eos_token_id": 248044,
+                "rope_theta": 10000000.0,
+                "partial_rotary_factor": 0.25
+            }
+        }"#;
+
+        let cfg = Qwen35Config::from_config_json_str(json)
+            .expect("config without max_position_embeddings still parses");
+        assert_eq!(cfg.max_position_embeddings, 4096);
     }
 
     #[test]


### PR DESCRIPTION
Closes #641, closes #551, delivers the API half of #649.

`lattice_serve` correctness bundle — three fail-open behaviors on the public HTTP surface become fail-closed, and the context limit stops lying:

## #641 — no more silent coercion
- Unknown chat roles returned as HTTP 400 with a clear message (previously silently coerced to `user`).
- Unsupported content part types return 400 (previously silently dropped).

## #649 (API half) — OpenAI content-parts
- `messages[].content` accepts both a plain string and the array-of-parts form; `text` parts concatenate in order.
- `image_url` parts fail closed with 400 ("image input requires a vision-capable model") — never silently dropped. The engine vision path (#564/#424) is untouched; this is the API contract only.
- Part counts and per-part byte sizes clamp BEFORE any parsing/allocation, per the serve DoS-hardening rule (every size field clamps before alloc).

## #551 — config-derived max context
- `MODEL_MAX_CONTEXT` now derives from the loaded model's `config.json` (`max_position_embeddings`) with a 4096 fallback, and request clamping is consistent with actual KV sizing.
- Bonus invariant fix found during the work: the `max_new_tokens` clamp in `build_cfg` left no headroom for `reasoning_budget + 1`, which could push decode one token past the actual KV cache.

## Evidence
- `lattice_serve` tests 17/17 (including 3 new HTTP-level tests driving the real `chat_completions` handler: unknown role → 400, image_url → 400, oversized part → 400), sibling `lattice.rs` serve tests 69/69.
- `cargo clippy --workspace -- -D warnings` and `--features f16,metal-gpu --all-targets` both clean.
- Known gap documented (not scope-crept): the `lattice serve` sibling module in `lattice.rs` relies on its pre-existing 1MB `DefaultBodyLimit` rather than the new per-part preflight clamps; tracked in the report and a good candidate for the executable capability matrix (#654).

No inference-kernel changes; `make bench-compare` not applicable beyond CI's e2e-parity gate (serve binary only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
