### PR TITLE
chore(docs): neutralize internal references in docs and comments

### DIFF
--- a/.github/workflows/adr064-gpu-decode-nightly.yml
+++ b/.github/workflows/adr064-gpu-decode-nightly.yml
@@ -1,6 +1,6 @@
 name: ADR-064 GPU decode perf nightly (informational)
 #
-# DORMANT — this workflow is committed but INERT until a founder provisions a
+# DORMANT — this workflow is committed but INERT until a maintainer provisions a
 # self-hosted runner labeled [self-hosted, m2max]. No such runner exists as of
 # this commit. GitHub Actions never schedules a job onto a label set with zero
 # registered runners, so `schedule` events for this workflow will simply not
@@ -15,7 +15,7 @@ name: ADR-064 GPU decode perf nightly (informational)
 # able to execute code on a self-hosted runner (arbitrary-code-on-our-hardware
 # risk). Intentionally NOT in any branch-protection required-status set: this
 # gate is proposed-only per docs/adr/ADR-067-gpu-decode-perf-regression-gates.md
-# and must not become merge-blocking without explicit founder sign-off.
+# and must not become merge-blocking without explicit maintainer sign-off.
 
 on:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       # `GrammarEngine` blocks every vocab entry. The exact "3 passed; 0
       # failed" grep guards against a silently zero-matching filter, the same
       # failure mode the Q4 and f16-KV steps above already guard against.
-      # #611 round-1 codex review (major): without LATTICE_METAL_TEST_ENFORCE,
+      # #611 (major): without LATTICE_METAL_TEST_ENFORCE,
       # each test early-returns (asserted as "passed" by cargo) when
       # `Device::system_default()` is absent, so a runner without a Metal
       # device would silently green this gate without ever exercising the
@@ -244,7 +244,7 @@ jobs:
           log="${RUNNER_TEMP:-/tmp}/metal-grammar-failclosed-test.log"
           cargo test -p lattice-inference --features f16,metal-gpu --lib fails_closed_on_all_blocking_grammar -- --nocapture 2>&1 | tee "$log"
           grep -Eq '^test result: ok\. 3 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
-      # #611 round-1 codex review (medium): the three tests above only reach
+      # #611 (medium): the three tests above only reach
       # the post-prefill masking site (their fixture blocks every vocab entry
       # from step 0), so removing a DECODE-LOOP `has_finite_logit` guard left
       # them green. These three companion tests use a grammar that allows

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -180,7 +180,7 @@ jobs:
   # `[self-hosted, macOS, ARM64, metal]` and document why.
   #
   # Deliberately NOT added to parity-gate.needs below: this is an informational
-  # signal only. Making it required is a founder decision (repo branch
+  # signal only. Making it required is a maintainer decision (repo branch
   # protection), out of scope for this change.
   metal-parity:
     name: metal attention parity (informational)
@@ -279,7 +279,7 @@ jobs:
   #
   # NOTE: once this job has gone green on CI once, add "embed-drift" to the
   # repository's required status checks (Settings → Branches → main protection
-  # rule).  That governance step is done by the founder; it is intentionally
+  # rule).  That governance step is done by the maintainers; it is intentionally
   # not automated here.
   embed-drift:
     name: embed drift gate
@@ -340,7 +340,7 @@ jobs:
   # change that must carry rationale + mutation evidence.
   #
   # NOTE: once this job has gone green on CI once, add "q4-composed" to the
-  # repository's required status checks alongside embed-drift. That founder
+  # repository's required status checks alongside embed-drift. That
   # governance step is intentionally not automated here.
   q4-composed:
     name: q4 composed golden

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ Thumbs.db
 *.onnx
 *.gguf
 
-# Codex/review scratch artifacts (repo-root only)
+# Review scratch artifacts (repo-root only)
 /review*.md
 /pr_review*.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ This split a two-test failure report cleanly: one test failed deterministically 
 
 ### Machine-Wide GPU Test Lock
 
-All Metal-touching tests in this repo serialize through `gpu_test_lock()` (crates/inference/src/forward/metal_qwen35.rs), which holds two locks: an in-process mutex (thread serialization within one test binary) and an exclusive advisory flock on `/tmp/lion-metal-gpu-test.lock` (cross-process serialization, fleet-wide convention). Any harness on this machine that drives the GPU for measurements — other repos' test suites, bench runners, one-off scripts — should acquire the same flock before touching Metal. Concurrent GPU work corrupts both timing and numerics: contended confirmation batches inflated top-k logit margins ~3x and produced false failure reports (#628, #629).
+All Metal-touching tests in this repo serialize through `gpu_test_lock()` (crates/inference/src/forward/metal_qwen35.rs), which holds two locks: an in-process mutex (thread serialization within one test binary) and an exclusive advisory flock on `/tmp/lion-metal-gpu-test.lock` (cross-process serialization, machine-wide convention). Any harness on this machine that drives the GPU for measurements — other repos' test suites, bench runners, one-off scripts — should acquire the same flock before touching Metal. Concurrent GPU work corrupts both timing and numerics: contended confirmation batches inflated top-k logit margins ~3x and produced false failure reports (#628, #629).
 
 The lock blocks for up to 30 minutes, then panics with an `lsof /tmp/lion-metal-gpu-test.lock` hint rather than hanging silently. If a run appears stuck at test start, another process is holding the GPU; check who with `lsof` before killing anything.
 
@@ -101,7 +101,7 @@ PRs touching `crates/inference/src/` or `crates/embed/src/` trigger `e2e-parity.
 - Feature branches + PRs for all changes. Never push directly to main.
 - Conventional commits with crate scope: `feat(inference): add Qwen3.5 MoE support`.
 
-### Merge Gate (Ocean directive 2026-07-04)
+### Merge Gate
 
 A PR merges only when its branch is **up to date with main** AND **green at its actual head**.
 Branch protection enforces this (`required_status_checks.strict = true`), added after #634

--- a/apps/macos/DESIGN.md
+++ b/apps/macos/DESIGN.md
@@ -1,6 +1,6 @@
 # Lattice Studio — Design Decision
 
-> **Status:** Decision doc for Ocean. Two refined finalists, head-to-head, with a recommendation and a build sequence.
+> **Status:** Decision doc. Two refined finalists, head-to-head, with a recommendation and a build sequence.
 > **Target:** macOS 26, SwiftUI, `swift build`. Toolchain verified: Apple Swift 6.3.2 / `arm64-apple-macosx26.0`.
 > **Backend:** the `lattice` pure-Rust engine, driven via CLI subprocesses (line-delimited JSON event stream).
 > **Brand law (governs both directions):** *measure first, the number is the truth.* Bold is spent on the **numbers**, not on chrome. Adaptive light + dark from day one.
@@ -37,7 +37,7 @@ Both directions adopt three shared laws, grafted from the design exploration:
 
 lattice owns hand-written Metal/AVX2/NEON kernels with zero framework — no Python, no ONNX, no CUDA, no runtime. The app should look like the **instrument panel of that engine**, not a wrapper around it. So every numeric quantity (loss, grad-norm, tok/s, PPL, MB, rank, lr) is a first-class citizen in tabular monospace that never reflows as digits change, on hairline-ruled opaque panels with almost no chrome — the way a DAW or a Bloomberg terminal trades whitespace for live truth.
 
-One accent (signal teal) is spent only on **movement** — the loss trace, the active token stream, the now-cursor — so the eye always lands on the thing that is actually changing. It honors Ocean's editorial/high-contrast lean by making **bold typography the hero** (a 56pt loss numeral, luminous data on ink) instead of illustration, and it beats a generic dashboard because it commits fully to the instrument metaphor: readouts, sweeps, gates — the literal visual translation of measure-first DNA.
+One accent (signal teal) is spent only on **movement** — the loss trace, the active token stream, the now-cursor — so the eye always lands on the thing that is actually changing. It follows an editorial/high-contrast design direction by making **bold typography the hero** (a 56pt loss numeral, luminous data on ink) instead of illustration, and it beats a generic dashboard because it commits fully to the instrument metaphor: readouts, sweeps, gates — the literal visual translation of measure-first DNA.
 
 The README is explicit that MLX is faster; lattice's edge is **capabilities + honesty**. So we sell the moat, not raw speed: QuaRot 4-bit, Q4+LoRA hot-swap with no reload, pure-Rust portability.
 
@@ -181,7 +181,7 @@ MAIN SHELL — 02 TRAIN (dark) ---------------------------------------
 
 lattice is an instrument, not an app. An oscilloscope doesn't decorate the waveform; it gets out of the way so the engineer trusts the trace. Console is near-monochrome so the one thing that earns color and movement — a live loss ticking down, a PPL delta, a parity PASS — is unmissable and pre-attentive. Everything is reachable from a single command bar (⌘K), because a tool that worships "measure first" should never make you hunt through menus for the measurement.
 
-It earns Ocean's editorial/bold lean by spending all of that boldness on the **numerals themselves**, not on chrome — the visual analog of pure-Rust with no Python, no ONNX, no runtime bloat. Same "numbers never touch glass" law; glass lives only on the navigation layer.
+It follows the editorial/bold design direction by spending all of that boldness on the **numerals themselves**, not on chrome — the visual analog of pure-Rust with no Python, no ONNX, no runtime bloat. Same "numbers never touch glass" law; glass lives only on the navigation layer.
 
 ## Visual Identity
 
@@ -313,7 +313,7 @@ CHAT split-compare — hot-swap fader (base vs +adapter)
 | **Feature surfacing** | 9 — dedicated comparator/quant-table screens, denser readouts | 8 — slightly thinner; config lists + right-rail metrics | Instrument |
 | **Feasibility** | 9 — all native APIs; density redraw is the only watch-item | 10 — least surface area, glass on nav only | Console |
 | **Distinctiveness** | 8 — instrument/Bloomberg metaphor is on-brand but not category-novel | 7 — risks "another dark dev tool" without an exceptional type pass | Instrument |
-| **Density posture** | High by default (with a comfortable toggle) | Lean by default (Cmd-K hides forms) | depends on Ocean |
+| **Density posture** | High by default (with a comfortable toggle) | Lean by default (Cmd-K hides forms) | open design choice |
 
 **When each wins.** Instrument wins when the user lives *inside* a run — watching loss, scrubbing the curve, reading six wells at once — and wants the screen to be a panel of live truth. It is the richer demo and the more defensible brand statement. Console wins on pure speed and minimal build risk: a power user who configures by keystroke and never wants to see a form, on the cheapest path to ship. Console's distinctiveness is its only soft spot — near-monochrome reads generic unless the hero numerals are genuinely authored.
 
@@ -329,9 +329,9 @@ Why:
 1. **Brand fit is the tiebreaker and Instrument wins it 10 vs 9.** lattice's identity is literally "the number is the truth," and Instrument is the most complete translation of that into UI — readout wells, the oscilloscope strip chart with scrub-to-freeze, GATE PILL verdicts. It sells the *moat* (QuaRot ContrastPair, hot-swap fader) rather than raw speed, exactly as the README demands.
 2. **The feasibility gap is small and closeable.** Instrument is a 9 to Console's 10. Its only real risk is 60fps redraw of the live curve under a fast step/token stream — mitigated by buffering points and throttling chart commits to ~20Hz, the same technique both directions already specify. Everything else maps to native APIs (`.monospacedDigit`, `.contentTransition(.numericText())`, Swift Charts `LineMark`+`RuleMark`+`chartOverlay`, `NavigationSplitView`). Verified buildable on the installed Swift 6.3.2 / macOS 26 toolchain.
 3. **Grafting closes the only thing Console wins on.** Adding the ⌘K spine to Instrument gives power users the keyboard-first launch path without sacrificing the dense readout panels. The comfortable-row toggle (32px) handles the density-too-cold risk Instrument self-flags. We get Console's speed *and* Instrument's brand depth.
-4. **Honors Ocean's editorial/bold lean correctly.** Both reject the literal display-serif reading (a streaming loss in a 96pt serif visibly jitters — it contradicts "the truth does not shimmer"). Instrument spends all its boldness on a 56pt tabular-mono hero numeral: editorial confidence without the jitter risk.
+4. **Honors the editorial/bold design lean correctly.** Both reject the literal display-serif reading (a streaming loss in a 96pt serif visibly jitters — it contradicts "the truth does not shimmer"). Instrument spends all its boldness on a 56pt tabular-mono hero numeral: editorial confidence without the jitter risk.
 
-The override on Ocean's "editorial/bold" lean is deliberate and stated: editorial is a *typographic posture*, not a literal magazine. We deliver it as **monospace-numeral boldness**, which is both more on-brand for an instrument and lower-risk to build. If Ocean specifically wants the magazine-cover feel, that is the genuine fork below.
+The override on the "editorial/bold" lean is deliberate and stated: editorial is a *typographic posture*, not a literal magazine. We deliver it as **monospace-numeral boldness**, which is both more on-brand for an instrument and lower-risk to build. If the magazine-cover feel is specifically wanted, that is the genuine fork below.
 
 ---
 

--- a/apps/macos/DISTRIBUTION.md
+++ b/apps/macos/DISTRIBUTION.md
@@ -57,7 +57,7 @@ This is a one-time step. The app will open normally on subsequent launches.
 
 ## Upgrading to Developer ID signing (for App Store or notarized distribution)
 
-When Ocean has a $99/year Apple Developer Program membership, replace the
+When a $99/year Apple Developer Program membership is available, replace the
 ad-hoc step in `package-app.sh` with a full Developer ID workflow:
 
 ```bash

--- a/apps/macos/Sources/LatticeStudio/Bridge/LatticeBridge.swift
+++ b/apps/macos/Sources/LatticeStudio/Bridge/LatticeBridge.swift
@@ -504,7 +504,7 @@ enum LatticeBridge {
     /// MODELS table, but those adapters carry no model association, so the per-model
     /// picker stayed empty. This bridges that gap.
     ///
-    /// Compatibility policy (Ocean, 2026-06-21 — "compatible-only"):
+    /// Compatibility policy (2026-06-21 — "compatible-only"):
     ///   - An adapter that declares a base model (MLX `model` field, e.g.
     ///     "Qwen/Qwen3.5-0.8B") attaches ONLY to the local model whose name equals the
     ///     normalized base (org prefix stripped + lowercased → "qwen3.5-0.8b"). This

--- a/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
+++ b/apps/macos/Sources/LatticeStudio/Screens/ChatScreen.swift
@@ -21,7 +21,7 @@ import SwiftUI
 // Completion detection:
 //   Each run carries an onComplete hook (set in send()/retryTurn()) that
 //   AppStore.finish() fires when the subprocess exits — independent of ChatScreen being
-//   mounted, so a turn still resolves if Ocean navigates away mid-generation.
+//   mounted, so a turn still resolves if the user navigates away mid-generation.
 
 // MARK: - Typing indicator dots
 
@@ -1426,7 +1426,7 @@ struct ChatScreen: View {
         // CPU path: keep using the one-shot generate_lora subprocess (unchanged).
         let run = useGPU ? store.runChatGPU(cfg) : store.runGenerate(cfg)
 
-        // Resolve via the run's own completion hook so the turn lands even if Ocean navigates
+        // Resolve via the run's own completion hook so the turn lands even if the user navigates
         // away from Chat before generation finishes (the .onChange handlers only fire while
         // ChatScreen is mounted). It also fires if another screen's launch() supersedes this
         // run — finish() runs onComplete with a failed status, so the turn shows a real reason

--- a/apps/macos/Sources/LatticeStudio/Store/DomainModels.swift
+++ b/apps/macos/Sources/LatticeStudio/Store/DomainModels.swift
@@ -211,7 +211,7 @@ struct ChatTurn: Identifiable {
     var responseTokens: Int? = nil
     var totalMs: Double? = nil
     /// Error message from the run log — set when the turn finishes with an empty response.
-    /// Shown instead of "(no output)" so Ocean knows WHY the engine produced nothing.
+    /// Shown instead of "(no output)" so the user knows WHY the engine produced nothing.
     var errorMessage: String? = nil
     /// The GenConfig used to produce this turn — stored so Retry can re-launch the identical run.
     var retryConfig: ChatGenConfig? = nil

--- a/apps/macos/Tests/LatticeStudioTests/ChatFinalizationTests.swift
+++ b/apps/macos/Tests/LatticeStudioTests/ChatFinalizationTests.swift
@@ -8,7 +8,7 @@ final class ChatFinalizationTests: XCTestCase {
     /// Thinking-on prefills "<think>\n" into the PROMPT, so a truncated reasoning stream is
     /// tagless in genText. It must be treated as unfinished reasoning, NOT the answer — an empty
     /// response is the signal that renderChatML skips this turn from history (history gates on a
-    /// non-empty responseText). This is the exact regression codex flagged on PR #428 round-2.
+    /// non-empty responseText). This is the exact regression fixed in PR #428.
     func testThinkingOnTruncatedTaglessReasoningIsNotAnswer() {
         let (thinking, response) = ChatFinalization.finalize(
             "partial reasoning", prefilledOpenThink: true)

--- a/apps/macos/docs/INSTRUMENT_SCOPE.md
+++ b/apps/macos/docs/INSTRUMENT_SCOPE.md
@@ -9,7 +9,7 @@
 
 Lattice Instrument is a zero-dependency macOS 14 SwiftUI application (Swift 6.0 tools,
 Package.swift line 7) that wraps the Rust `lattice-tune` and `lattice-inference` engine
-binaries as subprocess instruments. Its purpose is to let Ocean run LoRA fine-tuning,
+binaries as subprocess instruments. Its purpose is to let the user run LoRA fine-tuning,
 model quantization, chat testing, and training-data inspection without leaving a macOS
 window — while the Rust binaries remain the single source of correctness.
 

--- a/crates/inference/examples/bench_quality.rs
+++ b/crates/inference/examples/bench_quality.rs
@@ -6,7 +6,7 @@
 /// Pruned-8  mask: GDN layers 12,16,20,24,28,32,36,40 removed (every 4th GDN in middle).
 /// Pruned-12 mask: GDN layers 8,12,16,20,24,28,32,36,40,44,48,52 removed (evenly spread).
 ///
-/// Gate (from critic spec): mean_cos >= 0.95 AND min_cos >= 0.85.
+/// Quality gate: mean_cos >= 0.95 AND min_cos >= 0.85.
 ///
 /// Usage:
 ///   LATTICE_MODEL_DIR=~/.lattice/models/qwen3.6-27b-q4 \
@@ -83,7 +83,7 @@ fn run() {
         .collect();
 
     // Pruning masks — GDN layers only, type-balanced is not needed since both configs
-    // are pure-GDN and the critic requested these specific indices
+    // are pure-GDN and the pruning benchmark uses these specific indices
     let pruned_8_layers: Vec<usize> = vec![12, 16, 20, 24, 28, 32, 36, 40];
     let pruned_12_layers: Vec<usize> = vec![8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52];
 

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -1940,7 +1940,7 @@ mod imp {
             handle.join().expect("worker thread must not panic");
         }
 
-        /// Codex review of PR #606: cancellation was only observed through the
+        /// PR #606: cancellation was only observed through the
         /// `on_token` callback, so a generator phase that never calls it -- the
         /// real prefill pass has no callback point at all -- could run
         /// unbounded after the client already disconnected. This proves

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -10407,7 +10407,7 @@ kernel void gdn_chunk_norm_silu_c32(
                         generated_ids.extend_from_slice(&tokens[..emit_len]);
                         // Stop-token contract (#613): `tokens` holds only the committed
                         // (non-stop) tokens for this round — the stop token itself is
-                        // never in it. Codex round-1 (#632): `emit_len == tokens.len()`
+                        // never in it. #632: `emit_len == tokens.len()`
                         // alone is not sufficient — if the committed payload exactly
                         // fills `remaining`, the excluded stop token would have landed
                         // one position *beyond* `max_new_tokens`, so plain greedy would
@@ -19945,7 +19945,7 @@ kernel void decode_attention_reference(
             // Round-1 MAJOR integration coverage: a mixed/stale QuaRot
             // directory (both .q4 and .f16 for a projection, is_quarot=true)
             // must be a hard `Err`, not a gracefully-disabled `None` — this
-            // is the exact failure-open scenario codex flagged.
+            // is the exact failure-open scenario this guard closes.
             let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
             let Some(device) = Device::system_default() else {
                 assert!(
@@ -19982,7 +19982,7 @@ kernel void decode_attention_reference(
         }
 
         // -------------------------------------------------------------------
-        // from_q4_dir refuse-on-misconfig (round-1 codex findings on PR #32)
+        // from_q4_dir refuse-on-misconfig (PR #32)
         // -------------------------------------------------------------------
         //
         // `read_quarot_seed_from_index` itself (the `quantize_index.json`
@@ -19993,7 +19993,7 @@ kernel void decode_attention_reference(
 
         #[test]
         fn from_q4_dir_rejects_max_cache_len_above_max_position_embeddings() {
-            // Round-1 codex Major: `from_q4_dir` was missing the
+            // `from_q4_dir` was missing the
             // `max_cache_len <= cfg.max_position_embeddings` guard that
             // `new_session` enforces. Without it, `--max-cache-len 999999
             // --window 999999` would slip past the strided-PPL aggregator
@@ -20041,7 +20041,7 @@ kernel void decode_attention_reference(
 
         #[test]
         fn from_q4_dir_rejects_tied_config_with_lm_head_artifact() {
-            // Round-2 codex Blocker: the round-1 fix only caught the
+            // The prior fix only caught the
             // `tie_word_embeddings=false` + missing `lm_head.q4` half of
             // the artifact contract. The opposite mismatch —
             // `tie_word_embeddings=true` but a `lm_head_weight.q4`
@@ -20084,7 +20084,7 @@ kernel void decode_attention_reference(
 
         #[test]
         fn from_q4_dir_rejects_untied_config_without_lm_head_artifact() {
-            // Round-1 codex Blocker: the loader silently fell back to
+            // The loader silently fell back to
             // `embed_tokens` when `tie_word_embeddings=false` and
             // `lm_head.q4` was missing. That is exactly the contamination
             // ADR-044 step 3c forbids — a QuaRot artifact missing its
@@ -20699,7 +20699,7 @@ kernel void decode_attention_reference(
             }
         }
 
-        /// Regression for the Q4 decode dispatch-geometry bug (codex 2026-06-26).
+        /// Regression for the Q4 decode dispatch-geometry bug (2026-06-26).
         ///
         /// `gemv_q4_decode` writes NR=2 output rows per threadgroup, so
         /// `dispatch_matmul_q4` MUST launch `ceil(N/2)` groups. The prior `ceil(N/4)`
@@ -20781,7 +20781,7 @@ kernel void decode_attention_reference(
                 assert!(
                     val.to_bits() != SENTINEL.to_bits(),
                     "row {row} of {n} never written — dispatch grid under-covers \
-                     gemv_q4_decode (NR=2 rows/group). This is the codex P0 decode-geometry bug."
+                     gemv_q4_decode (NR=2 rows/group). This is the P0 decode-geometry bug."
                 );
             }
             let diff = max_abs_diff(y, &y_ref);
@@ -21232,7 +21232,7 @@ kernel void decode_attention_reference(
                  half-tile staging may be saturating or accumulating in f16"
             );
 
-            // ── Isolated near-zero block (codex #272 review) ────────────────
+            // ── Isolated near-zero block (#272) ────────────────
             // The mixed-block assertion above is dominated by the near-unit block, so it
             // cannot isolate the near-zero claim. Zero the near-unit block and keep only the
             // near-zero one, so the output magnitude IS the near-zero block's contribution.
@@ -23471,7 +23471,7 @@ kernel void decode_attention_reference(
 
         #[test]
         fn metal_generate_multimodal_excludes_stop_token() {
-            // Codex round 1 (#632) flagged `generate_multimodal` as a public
+            // #632: `generate_multimodal` is a public
             // entry point with its own sampling loop, missing from both the
             // `stop_token_contract` manifest and this test module's #613
             // sweep. It already implements the EXCLUDE contract (checks
@@ -24753,7 +24753,7 @@ kernel void decode_attention_reference(
             assert_eq!(p.num_chunks, 2); // ceil(33/32) = 2
         }
 
-        /// Regression for the chunked log-decay NaN edge (codex review of PR #235).
+        /// Regression for the chunked log-decay NaN edge (PR #235).
         ///
         /// `gdn_chunk_materialize_c32` stores each token's log-decay `-a*sp` and
         /// `gdn_chunk_solve_c32` forms decay ratios as `exp(cumsum[j] - cumsum[k])`.
@@ -25885,9 +25885,8 @@ kernel void decode_attention_reference(
         }
 
         // -------------------------------------------------------------------
-        // #516 round-1 remediation (codex REJECT) — regression coverage for
-        // findings 1/2/3/4. See
-        // .khive/codex_reviews/codex_review_pr516.md.
+        // #516 remediation — regression coverage for
+        // findings 1/2/3/4.
         // -------------------------------------------------------------------
 
         /// Finding 1 (slot isolation): a divergent-prompt call on a
@@ -26192,7 +26191,7 @@ kernel void decode_attention_reference(
             );
         }
 
-        /// Round-2 D7 (codex blocker): a public raw-forward call
+        /// D7: a public raw-forward call
         /// (`forward_step`) interleaved between two cache-aware calls on the
         /// SAME slot must invalidate the retained entry, exactly like
         /// `generate_streaming`'s `reset_state()` does for finding 2's
@@ -26247,7 +26246,7 @@ kernel void decode_attention_reference(
             );
 
             // Interleave a raw public forward call on an unrelated token
-            // stream. This is the exact stale path codex named: `forward_step`
+            // stream. This is the exact stale path: `forward_step`
             // advances `self.session.kv_cache` / GDN state directly, bypassing
             // both `reset_state()` (D3's guard) and the cache-aware save path.
             let _ = state.forward_step(0, 0);
@@ -26397,8 +26396,8 @@ kernel void decode_attention_reference(
         // of the three functions (`generate`, `generate_streaming_with_cancel`,
         // `generate_streaming_with_prefix_cache_inner`) — is reachable only
         // from step 2 onward and needs a grammar that allows exactly one
-        // token and then blocks everything. #611 round-1 codex review (medium
-        // finding) flagged that gap: it is covered separately by the
+        // token and then blocks everything. #611 (medium
+        // finding): that gap is covered separately by the
         // "DECODE-LOOP integration tests" block below this one, which builds
         // exactly that allow-then-block fixture.
         //
@@ -26608,7 +26607,7 @@ kernel void decode_attention_reference(
         }
 
         // -----------------------------------------------------------------------
-        // Grammar fail-closed DECODE-LOOP integration tests (#611 round-1 codex
+        // Grammar fail-closed DECODE-LOOP integration tests (#611
         // finding, medium)
         //
         // The three tests above only reach the post-prefill masking site: their
@@ -28793,7 +28792,7 @@ mod mtp_greedy_round_tests {
     }
 
     // -----------------------------------------------------------------------
-    // CAP-EDGE REGRESSION (codex finding #1 on PR #287):
+    // CAP-EDGE REGRESSION (PR #287):
     // A round can emit up to 2 non-stop tokens (case B, #613). When
     // max_new_tokens lands mid-emission, the call site must clip so MTP
     // never exceeds the cap — plain greedy `generate()` stops at the cap
@@ -29002,7 +29001,7 @@ mod mtp_greedy_round_tests {
     // *meaning* of "every token in tokens was emitted" shifts, since `tokens`
     // is shorter now (see the budget=2 test below for the concrete effect).
     //
-    // Codex round-1 (#632): `emit_len == tokens.len()` alone under-counts one
+    // #632: `emit_len == tokens.len()` alone under-counts one
     // more boundary — when the committed payload exactly *fills* `remaining`
     // (`remaining == tokens.len()`), the excluded stop token itself would sit
     // one position beyond `max_new_tokens`. Plain greedy never reaches that
@@ -29077,7 +29076,7 @@ mod mtp_greedy_round_tests {
                     // FIX 1: stopped only when every committed token was actually
                     // emitted (not clipped) — tokens never includes the stop itself
                     // — AND at least one more slot remained beyond the committed
-                    // payload for that excluded stop token (codex round-1, #632):
+                    // payload for that excluded stop token (#632):
                     // an exact-fill payload (remaining == tokens.len()) means the
                     // stop token itself sits beyond the budget, so plain greedy
                     // would report Length there, not Eos.
@@ -29117,8 +29116,8 @@ mod mtp_greedy_round_tests {
         // payload exactly fills the budget, so the excluded bonus stop token
         // would have landed one position beyond `max_new_tokens`.
         //
-        // Codex round-1 (#632) flagged the prior expectation here
-        // (`stopped=true`) as wrong: plain greedy's decode loop caps at
+        // #632: the prior expectation here
+        // (`stopped=true`) was wrong: plain greedy's decode loop caps at
         // exactly `max_new_tokens` steps and never samples that extra
         // position, so it would report `Length`, not `Eos`, in this exact
         // scenario. `stopped=false` is the correct value — the emitted
@@ -29142,7 +29141,7 @@ mod mtp_greedy_round_tests {
         // argmax at pos+1 agrees) → EmitAndStop([pending]) = [10] (draft
         // excluded, #613). Budget=1: remaining=1 == tokens.len()=1 (exact
         // fill) → the excluded stop token would sit one position beyond the
-        // budget → stopped=false (codex round-1, #632 boundary case).
+        // budget → stopped=false (#632 boundary case).
         let logit_rows = vec![make_logit(10, 5), make_logit(EOS, 5)];
         let draft_seq = vec![EOS];
         let (tokens, stopped) = simulate_mtp_with_stopped(&logit_rows, &draft_seq, 1);
@@ -29174,7 +29173,7 @@ mod mtp_greedy_round_tests {
         // disagrees with the proposed draft), and the target's replacement
         // (bonus_token) is itself the stop → EmitAndStop([pending]) = [10]
         // (replacement excluded, #613). Budget=1: remaining=1 ==
-        // tokens.len()=1 (exact fill) → stopped=false (codex round-1, #632).
+        // tokens.len()=1 (exact fill) → stopped=false (#632).
         let logit_rows = vec![make_logit(10, 5), make_logit(EOS, 5)];
         // draft_seq deliberately does not match argmax(logit_rows[1])=EOS,
         // forcing rejection; the target's replacement (EOS) becomes bonus_token.

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -111,7 +111,7 @@ pub struct GenerateOutput {
 
 // ---------------------------------------------------------------------------
 // ForwardScratch: pre-allocated activation and logits buffers, reused across
-// all tokens in a request. Eliminates 204 allocations/token (Round 0 baseline).
+// all tokens in a request. Eliminates 204 allocations/token vs. the unoptimized baseline.
 // ---------------------------------------------------------------------------
 
 struct ForwardScratch {
@@ -1305,7 +1305,7 @@ mod tests {
     fn test_compute_max_seq_overflow_is_error_not_panic() {
         // A pathological max_new_tokens near usize::MAX must surface a clean
         // InvalidInput error rather than wrapping the addition and panicking
-        // later inside prefill_layer's capacity assertion (codex finding #2).
+        // later inside prefill_layer's capacity assertion (finding #2).
         let err = compute_max_seq(10, usize::MAX).unwrap_err();
         assert!(matches!(err, InferenceError::InvalidInput(_)));
         let err = compute_max_seq(usize::MAX, 1).unwrap_err();
@@ -1472,7 +1472,7 @@ mod tests {
 
     #[test]
     fn test_check_alloc_capacity_multiplication_overflow_is_error() {
-        // The codex review of PR #291 found that guarding only compute_max_seq's
+        // PR #291 found that guarding only compute_max_seq's
         // addition leaves the downstream `max_seq_len * kv_dim` multiplication
         // unchecked: a huge-yet-non-overflowing effective_cap (here usize::MAX/1024,
         // matching the reviewer's kv_dim=8*128 counterexample) wraps the cache/scratch

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -438,7 +438,7 @@ mod tests {
         );
     }
 
-    /// Regression (issue #343, codex finding B): a long *acyclic* `$defs`
+    /// Regression (issue #343, finding B): a long *acyclic* `$defs`
     /// reference chain (`N0→N1→…→Nk`, each a distinct unseen ref) recurses
     /// `compile_schema` once per link. Without the depth cap this overflowed the
     /// stack at compile time, independent of the PDA cycle fix. A 2000-link
@@ -482,7 +482,7 @@ mod tests {
         assert!(result.is_ok(), "a 64-link $ref chain should compile");
     }
 
-    /// Boundary (issue #343, codex finding D): `maxItems` one past the cap is
+    /// Boundary (issue #343, finding D): `maxItems` one past the cap is
     /// rejected; a small in-range `maxItems` still compiles.
     #[test]
     fn array_maxitems_boundary() {

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -53,7 +53,7 @@ const MAX_ARRAY_CARDINALITY: usize = 4096;
 /// it. A parseable schema with a long `$defs` reference chain
 /// (`A→B→C→…`, each a distinct unseen ref) or deeply nested objects therefore
 /// recurses once per link with no natural bound — a compile-time stack overflow
-/// reachable from untrusted schema input (issue #343, codex finding B). Cap the
+/// reachable from untrusted schema input (issue #343, finding B). Cap the
 /// depth: `serde_json` itself rejects JSON nested beyond 128, and no legitimate
 /// schema chains references or nests anywhere near 512 levels.
 const MAX_SCHEMA_DEPTH: usize = 512;
@@ -600,8 +600,8 @@ impl<'a> CompileCtx<'a> {
     /// would re-materialize the (sibling-dropped) non-string target and
     /// over-accept it. The string-forcing check spans the WHOLE chain, not just
     /// the outer `sub`, so an intermediate `$defs` node such as
-    /// `{"$ref":<integer def>,"type":"string"}` is caught (issue #473, codex
-    /// review). This lookup never touches `self.depth` and never registers a
+    /// `{"$ref":<integer def>,"type":"string"}` is caught (issue #473). This
+    /// lookup never touches `self.depth` and never registers a
     /// rule; `compile_ref` / `compile_schema` remain the authoritative recursion
     /// guard (issue #343) for the `other_subs` path.
     fn ref_string_contribution(&self, sub: &'a Value) -> Result<RefStr, SchemaError> {
@@ -1118,7 +1118,7 @@ impl<'a> CompileCtx<'a> {
             id
         };
 
-        // issue #310 #2 (codex review): honor cardinality even with no `items` schema.
+        // issue #310 #2: honor cardinality even with no `items` schema.
         if min_items > 0 || max_items.is_some() {
             let n = self.array_counter;
             self.array_counter += 1;
@@ -2758,7 +2758,7 @@ mod tests {
     /// A typed mixed `enum` sibling `{"type":"string","enum":["abe",1]}`: the
     /// `type:"string"` makes the integer member unsatisfiable, so the branch's
     /// language is exactly {"abe"} and `string_class_of` folds it into the
-    /// literal trie (issue #310 / PR #472, codex round-3 offered fix). The trie
+    /// literal trie (issue #310 / PR #472). The trie
     /// then accepts both the const "abc" and the folded "abe". Mutation guard:
     /// dropping the typed-mixed fold (classifying the enum as an "other") strands
     /// "abe" behind the const trie and over-rejects it.
@@ -2788,8 +2788,8 @@ mod tests {
     /// must be a string AND equal a numeric enum member, so it accepts no string.
     /// `string_class_of` must classify it as the empty literal set (a dead
     /// branch), NOT `None` — `None` routes it through `compile_string_type`'s
-    /// `json_string` fallback and over-accepts arbitrary strings (issue #472
-    /// codex round-4 blocker 2). Mutation guard: returning `None` accepts "zzz".
+    /// `json_string` fallback and over-accepts arbitrary strings (issue #472,
+    /// finding 2). Mutation guard: returning `None` accepts "zzz".
     #[test]
     fn anyof_typed_enum_no_string_members_rejected() {
         let g = compile_ok(r#"{"anyOf":[{"type":"integer"},{"type":"string","enum":[1,2]}]}"#);
@@ -2803,8 +2803,8 @@ mod tests {
     /// `const` and `enum` are conjunctive, so `{"type":"string","const":"x","enum":["y"]}`
     /// accepts no value (nothing equals both "x" and "y"). `string_class_of` must
     /// fold the const only when a present enum contains it, classifying this
-    /// conflicting branch as the empty literal set (issue #472 codex round-4
-    /// blocker 1). Mutation guard: folding the const before checking the enum
+    /// conflicting branch as the empty literal set (issue #472,
+    /// finding 1). Mutation guard: folding the const before checking the enum
     /// accepts "x"; folding the enum before checking the const accepts "y".
     #[test]
     fn anyof_const_conflicting_enum_rejected() {
@@ -2824,7 +2824,7 @@ mod tests {
 
     /// `{"type":"string","const":"x","enum":["x","y"]}`: the const narrows the
     /// enum to the intersection {"x"}, so only "x" is accepted, NOT "y" (issue
-    /// #472 codex round-4). Mutation guard: ignoring the const and folding the
+    /// #472). Mutation guard: ignoring the const and folding the
     /// whole enum accepts "y".
     #[test]
     fn anyof_const_compatible_enum_folds_to_const() {
@@ -2885,7 +2885,7 @@ mod tests {
 
     /// Edge cases for typed string enums: an empty `enum` is the empty language
     /// (reject all), and a duplicate member folds to a single trie path without
-    /// error (issue #472 codex round-4 next-round focus).
+    /// error (issue #472).
     #[test]
     fn typed_string_enum_empty_and_duplicate_members() {
         let empty = compile_ok(r#"{"type":"string","enum":[]}"#);
@@ -3048,7 +3048,7 @@ mod tests {
         );
     }
 
-    /// FIXED (issue #473, codex REJECT): the string-forcing keyword sits on an
+    /// FIXED (issue #473): the string-forcing keyword sits on an
     /// INTERMEDIATE `$defs` node, not the outer `anyOf` sub. `S` is
     /// `{$ref: N-integer, type/const/enum-string}`, so `S`'s language is the
     /// empty conjunction (integer ∧ string); the outer branch `{$ref: S}` is a
@@ -3108,7 +3108,7 @@ mod tests {
         );
     }
 
-    /// FIXED (issue #473, codex round-2 REJECT): draft-2020-12 §6.1.1 lets `type`
+    /// FIXED (issue #473): draft-2020-12 §6.1.1 lets `type`
     /// be an ARRAY of type names. A string-ONLY type array (`["string"]`, or any
     /// non-empty all-`"string"` array) is string-forcing, exactly like the scalar
     /// `type:"string"`. On a `$ref`->integer terminal — DIRECT sibling or an
@@ -4514,8 +4514,8 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Issue #474 (round-4 follow-up) — anyOf branch-count cap and byte
-    // budgets that were checked late (or not at all) before this round.
+    // Issue #474 (follow-up) — anyOf branch-count cap and byte
+    // budgets that were checked late (or not at all) previously.
     // -----------------------------------------------------------------------
 
     /// anyOf/oneOf branch-count cap (issue #474, finding 2): a schema whose
@@ -4655,13 +4655,13 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Issue #474 (round-6 follow-up) — single-oversized-literal byte cap.
-    // Rounds 1-5 capped cardinality (many literals); this closes the
+    // Issue #474 (follow-up) — single-oversized-literal byte cap.
+    // The earlier fixes capped cardinality (many literals); this closes the
     // distinct sub-class where ONE literal's own byte length exceeds
     // MAX_STRING_LITERAL_BYTES before any prior guard sees it.
     // -----------------------------------------------------------------------
 
-    /// Top-level const byte cap (issue #474, round 6): a top-level `const`
+    /// Top-level const byte cap (issue #474): a top-level `const`
     /// whose byte length exceeds MAX_STRING_LITERAL_BYTES is rejected by the
     /// `guard_literal_bytes` check in `json_value_to_alt`, which has no other
     /// byte guard upstream of it.
@@ -4683,7 +4683,7 @@ mod tests {
         );
     }
 
-    /// Object property key byte cap (issue #474, round 6): an object property
+    /// Object property key byte cap (issue #474): an object property
     /// whose KEY (not value) exceeds MAX_STRING_LITERAL_BYTES is rejected by
     /// the `guard_literal_bytes` checks in `compile_object` (raw key) and
     /// `json_string_literal` (JSON-encoded key), before the key reaches the
@@ -4708,15 +4708,15 @@ mod tests {
         );
     }
 
-    /// anyOf const single-byte cap (issue #474, round 6): an `anyOf` branch
+    /// anyOf const single-byte cap (issue #474): an `anyOf` branch
     /// with a single oversized `const` is rejected by the `guard_literal_bytes`
     /// check in `string_class_of`'s const arm.
     ///
-    /// Backstopped: the round-5 incremental byte-budget guard inside
+    /// Backstopped: the earlier incremental byte-budget guard inside
     /// `compile_any_of`'s classification loop (Fix 4) also catches this input,
-    /// so this test stays green even if the round-6 guard alone is reverted.
-    /// It is defense-in-depth for the transient ~1x copy at the exact line
-    /// codex named, not independently mutation-sensitive — see
+    /// so this test stays green even if this guard alone is reverted.
+    /// It is defense-in-depth for the transient ~1x copy at the exact line,
+    /// not independently mutation-sensitive — see
     /// `object_key_byte_capped` / `const_literal_byte_capped` for the
     /// mutation-pinned guards.
     #[test]
@@ -4732,11 +4732,11 @@ mod tests {
         );
     }
 
-    /// anyOf enum member single-byte cap (issue #474, round 6): an `anyOf`
+    /// anyOf enum member single-byte cap (issue #474): an `anyOf`
     /// branch with a single oversized `enum` member is rejected by the
     /// `guard_literal_bytes` checks in `string_class_of`'s enum arms.
     ///
-    /// Backstopped: same as `anyof_const_single_byte_capped` — the round-5
+    /// Backstopped: same as `anyof_const_single_byte_capped` — the earlier
     /// incremental byte-budget guard in `compile_any_of` also catches this
     /// input, so this test is defense-in-depth, not independently
     /// mutation-sensitive.
@@ -4815,7 +4815,7 @@ mod tests {
         );
     }
 
-    /// `$defs` name CUMULATIVE byte cap (issue #474, round 8): the schema-wide
+    /// `$defs` name CUMULATIVE byte cap (issue #474): the schema-wide
     /// entry guard is per-string, so many definition names each UNDER the
     /// per-string cap can still sum past it while `CompileCtx::new` clones every
     /// key into the `defs` map (and `$defs` has no cardinality cap). The
@@ -4849,7 +4849,7 @@ mod tests {
         );
     }
 
-    /// Object property key CUMULATIVE byte cap (issue #474, round 8): the
+    /// Object property key CUMULATIVE byte cap (issue #474): the
     /// per-key `guard_literal_bytes` cap and `MAX_OBJECT_PROPERTIES` count cap
     /// each bound one dimension, but their product (many near-cap keys) still
     /// drives the per-byte `json_string_literal` Symbol expansion and the

--- a/crates/inference/src/metrics.rs
+++ b/crates/inference/src/metrics.rs
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn test_entropy_f32_max_uniform() {
-        // Codex finding: uniform f32::MAX logits must produce ln(N), not 0.
+        // Regression guard: uniform f32::MAX logits must produce ln(N), not 0.
         let mut acc = OnlineSoftmaxEntropy::new();
         acc.update(f32::MAX);
         acc.update(f32::MAX);

--- a/crates/inference/src/model/qwen35/eval.rs
+++ b/crates/inference/src/model/qwen35/eval.rs
@@ -923,7 +923,7 @@ mod tests {
 
     #[test]
     fn compute_perplexity_rejects_stride_equal_window() {
-        // Round-1 codex finding: stride == window silently dropped every
+        // Finding: stride == window silently dropped every
         // window-boundary token (the first token of each disjoint window has
         // no predecessor inside its own window). The harness now errors
         // before that can happen.
@@ -948,7 +948,7 @@ mod tests {
 
     #[test]
     fn compute_perplexity_rejects_window_above_rope_capacity() {
-        // Round-1 codex finding: the public Result-returning API was able
+        // Finding: the public Result-returning API was able
         // to panic by indexing the precomputed RoPE table past its end.
         // The harness now validates window <= max_context up-front. After
         // the step-4b refactor the message comes from the shared aggregator
@@ -979,7 +979,7 @@ mod tests {
 
     #[test]
     fn compute_perplexity_accepts_long_window_on_short_corpus() {
-        // Round-2 codex finding: the long-window guard was rejecting safe
+        // Finding: the long-window guard was rejecting safe
         // short-corpus invocations. The effective slice length is
         // `min(window, tokens.len())`, so an oversized window with a small
         // corpus must succeed — the per-window clip keeps every slice

--- a/crates/inference/src/model/qwen35/sampling.rs
+++ b/crates/inference/src/model/qwen35/sampling.rs
@@ -342,14 +342,14 @@ mod tests {
         );
     }
 
-    /// Regression test for the codex-review round-1 blocker on PR #651:
+    /// Regression test for a blocker found on PR #651:
     /// `sample_full_logits` always routes through `select_top_k`, whose
     /// scalar/NEON seed phases rewrite a NaN *scaled* logit to
     /// `f32::NEG_INFINITY` so the min-heap root is never NaN. That
     /// sanitization erases the NaN before
     /// `CandidateSet::sample_top_p_with_scratch`'s own poisoned-sum guard
     /// ever sees it, silently turning a fail-closed case into a normal
-    /// weighted draw. Proven counterexample (codex): `top_k=0`, logits
+    /// weighted draw. Proven counterexample: `top_k=0`, logits
     /// `[0.0, NaN, 0.0]`, seed `0x5eed_f00d_1234_5678` returned token 2
     /// pre-fix; the fail-closed contract requires the finite argmax, token 0.
     #[test]
@@ -659,7 +659,7 @@ mod tests {
     /// IDENTICAL token sequences when the logit set contains exact f32 ties, AND
     /// this test must FAIL if Path B breaks ties towards the higher token-id.
     ///
-    /// The earlier version of this test was vacuous (codex round-1 finding): it put
+    /// The earlier version of this test was vacuous (finding): it put
     /// the ties at low-probability positions (logit 25 of 64) and used top_p=0.95,
     /// so the nucleus truncated the tied tokens before they could affect a draw —
     /// a reversed tie-break still passed. The fix is to give the tied tokens real

--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -816,7 +816,7 @@ pub struct TokenLogprob {
 /// `stop_token_contract` test module for the cross-path regression sweep).
 /// `generated_tokens` always equals `token_ids.len()`.
 ///
-/// **`stop_strings` behave differently (codex round 1, #632).** A
+/// **`stop_strings` behave differently (#632).** A
 /// `stop_strings` match truncates `text` to the point where the match begins,
 /// but the token(s) whose decoded text completed the match are **not**
 /// removed from `token_ids`/`generated_tokens` — the implementation cannot
@@ -1256,7 +1256,7 @@ mod tests {
     #[test]
     fn test_zero_linear_num_key_heads_errors() {
         // gdn_fused divides `value_heads / linear_num_key_heads`; a parseable 0 is a hard
-        // integer divide-by-zero panic deep in the GatedDeltaNet recurrence (codex #342 finding).
+        // integer divide-by-zero panic deep in the GatedDeltaNet recurrence (#342).
         let json = r#"{"text_config": {"linear_num_key_heads": 0}}"#;
         let err = Qwen35Config::from_config_json_str(json)
             .expect_err("linear_num_key_heads: 0 must yield an InferenceError, not divide-by-zero")

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -1352,7 +1352,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Dry-run / real-write byte-count parity (codex finding fix gate)
+    // Dry-run / real-write byte-count parity
     // ------------------------------------------------------------------
 
     /// Correctness gate: dry_run=true and dry_run=false on the same model
@@ -1510,8 +1510,8 @@ mod tests {
     }
 
     /// Smoke check on `q4_f32_to_f16` (used by `write_f16_file`).
-    /// Includes an f16-subnormal regression: codex round-1 flagged that
-    /// the old local helper flushed every value below f16's smallest
+    /// Includes an f16-subnormal regression, since fixed: the old local
+    /// helper flushed every value below f16's smallest
     /// normal to zero, silently corrupting small-magnitude weights in
     /// kept tensors (e.g., `A_log`, `dt_bias`, GDN `linear_attn.norm`).
     #[test]
@@ -1528,8 +1528,7 @@ mod tests {
         let h = q4_f32_to_f16(1e-7_f32);
         assert_ne!(
             h, 0,
-            "1e-7 (an f16 subnormal range value) must not flush to zero \
-             — that was the codex round-1 Medium"
+            "1e-7 (an f16 subnormal range value) must not flush to zero"
         );
         // f32 subnormals (well below f16's subnormal range) DO round to zero
         // because there's no f16 representation for them.
@@ -1546,7 +1545,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Path-layout refuses (codex round-1 Majors 1 + 2)
+    // Path-layout refuses (review findings, Majors 1 + 2)
     // ------------------------------------------------------------------
 
     /// Major 1: when input and output paths resolve to the same canonical

--- a/crates/inference/src/quant/quarot/forward_equivalence.rs
+++ b/crates/inference/src/quant/quarot/forward_equivalence.rs
@@ -1425,7 +1425,7 @@ mod tests {
     /// Per-tensor coverage helper: run the full pipeline correctly, then
     /// scale `victim_name` by `factor` in the rotated working set and
     /// assert the gate refuses. Covers the chain-probe-skipped planned
-    /// tensors that codex flagged in round 1.
+    /// tensors that were flagged in review.
     fn assert_corrupting_planned_tensor_refuses(victim_name: &str, factor: f64, seed: u64) {
         let cfg = tied_tiny_test_cfg();
         let original = build_working_set(&cfg, seed);
@@ -1481,7 +1481,7 @@ mod tests {
     /// Per-tensor coverage: corrupting `k_proj` is invisible to the chain
     /// probe (probe shortcuts through `q_proj` → `o_proj`) but must be
     /// caught by the per-tensor algebraic check. This regression case is
-    /// the specific gap codex flagged in PR #28 round-1 review.
+    /// the specific gap flagged in the PR #28 review.
     #[test]
     fn per_tensor_check_catches_corrupted_k_proj() {
         assert_corrupting_planned_tensor_refuses(
@@ -1576,7 +1576,7 @@ mod tests {
         );
     }
 
-    /// Matrix-equivalence vs single-vector: codex round 2 demonstrated
+    /// Matrix-equivalence vs single-vector: further review demonstrated
     /// that the single-probe-vector implementation would miss a row
     /// perturbation orthogonal to the probe direction. The current
     /// matrix-equivalence implementation compares every stored element,

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -767,7 +767,7 @@ pub(crate) fn record_logprob(
 /// contains any NaN and computes the NaN-ignoring ("numeric") max in a
 /// single pass, so the caller can fall back to `argmax_f32` before
 /// `select_top_k`'s scalar/NEON seed phases sanitize a NaN to `NEG_INFINITY`
-/// and hide it from the softmax degeneracy guard (codex PR #651 round 1).
+/// and hide it from the softmax degeneracy guard (PR #651).
 /// Runtime-dispatch NEON on aarch64 (same 4-wide-plus-scalar-tail structure
 /// as `argmax_f32_neon`) with a scalar fallback.
 fn scan_nan_or_nonfinite_max(logits: &[f32]) -> (bool, f32) {
@@ -1359,8 +1359,8 @@ mod tests {
 
     /// A repetition penalty in (0, 1) BOOSTS recent tokens. The greedy fast path
     /// must not shortcut to the raw argmax when a boosted recent token would
-    /// overtake it, even though the raw argmax itself is not recent (codex
-    /// sampling discovery: the fast-path invariant only holds for penalty >= 1.0).
+    /// overtake it, even though the raw argmax itself is not recent (the
+    /// fast-path invariant only holds for penalty >= 1.0).
     #[test]
     fn test_greedy_sub_one_penalty_boosts_recent_token() {
         let config = SamplingConfig {

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -1873,7 +1873,7 @@ fn sample_adjusted(p: &[f32], q: &[f32], r: f32) -> usize {
 ///
 /// `target_logits[n - 1]` is reserved for the bonus token sampled after full
 /// acceptance. Using `target_logits[i]` to verify `draft_tokens[i]` is the
-/// off-by-one that codex round 1 flagged (Leviathan Algorithm 1 evaluates
+/// off-by-one flagged in review (Leviathan Algorithm 1 evaluates
 /// `p_i(x_i)`, not `p_{i+1}(x_i)`).
 ///
 /// For each position `i`:
@@ -4449,7 +4449,7 @@ mod tests {
     /// MtpVerifier::new rejects zero-width RoPE (partial_rotary_factor == 0.0,
     /// which the [0,1] scalar check accepts) before constructing a degenerate
     /// RopeTable whose max_positions() == 0 would reject every forward_one
-    /// position (codex #362 Major: position-bound exactness for zero-width RoPE).
+    /// position (#362 Major: position-bound exactness for zero-width RoPE).
     #[test]
     fn mtp_new_rejects_zero_partial_rotary_factor() {
         let mut cfg = tiny_mtp_config();
@@ -4469,7 +4469,7 @@ mod tests {
     /// MtpVerifier::new returns Err (not a debug overflow-panic / release wrap)
     /// when vocab_size * hidden_size overflows usize. Weights/embeds are tiny;
     /// the checked product fires before any tensor-shape comparison
-    /// (codex #362 Medium: unchecked dimension products).
+    /// (#362 Medium: unchecked dimension products).
     #[test]
     fn mtp_new_rejects_dimension_product_overflow() {
         let base = tiny_mtp_config();
@@ -4492,7 +4492,7 @@ mod tests {
     /// head_dim overflows. Reachable with TINY weights — only weights.layers.len()
     /// is checked before MtpScratch/cache construction, so an oversized
     /// num_attention_heads passes the scalar/divisibility checks (kv_heads=1)
-    /// yet overflows q_dim (codex #362 round-2 Medium: derived-dimension products).
+    /// yet overflows q_dim (#362 Medium: derived-dimension products).
     #[test]
     fn mtp_new_rejects_head_dim_product_overflow() {
         let base = tiny_mtp_config();

--- a/crates/inference/src/stop_token_contract.rs
+++ b/crates/inference/src/stop_token_contract.rs
@@ -43,7 +43,7 @@
 //!
 //! Entry 12 (`generate_multimodal`) has its own independent sampling loop —
 //! it does not call `generate`/`generate_streaming` internally — and was
-//! missing from this manifest until codex round 1 on PR #632 flagged it as
+//! missing from this manifest until the PR #632 review flagged it as
 //! an unguarded sibling-invocation path (#613's own warning pattern). Its
 //! loop already used the EXCLUDE contract (checks `is_stop` before pushing
 //! at every termination point: first-token sample, KV-full break, and the

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -901,7 +901,7 @@ fn has_regex_split(pt: &JsonValue) -> bool {
 }
 
 /// Fail closed on explicit `tokenizer.json` `pre_tokenizer` metadata this
-/// parser cannot honestly model (#330 codex round-2 finding 1).
+/// parser cannot honestly model (#330 finding 1).
 ///
 /// `from_vocab_and_merges_with_config` always defaults to `Gpt4Regex`
 /// pre-tokenization, and `detect_gpt4_regex_pretokenizer` above only ever
@@ -928,8 +928,8 @@ fn has_regex_split(pt: &JsonValue) -> bool {
 ///   the trailing `ByteLevel(use_regex:false)` is just "don't split again".
 ///   Any other/unsupported sibling (e.g. `Metaspace`, `Whitespace`) rejects
 ///   the whole sequence even when another child is a regex `Split` — a
-///   `Split` does not honestly dominate later pre-tokenizers (codex round-3,
-///   #330 residual finding).
+///   `Split` does not honestly dominate later pre-tokenizers (#330 residual
+///   finding).
 /// - Bare top-level `ByteLevel` with `use_regex` absent or `true` -> accept
 ///   (HF's default `use_regex=true` is exactly what `Gpt4Regex`
 ///   approximates; this is the common gpt2/roberta Hub shape).
@@ -973,7 +973,7 @@ fn is_regex_split_node(pt: &JsonValue) -> bool {
 /// Deliberately does NOT use `has_regex_split`'s `any()`-over-descendants
 /// shortcut here: a regex `Split` earlier in a `Sequence` does not make an
 /// unrelated, unsupported sibling (e.g. `Metaspace`) honest to run through
-/// `Gpt4Regex` (codex round-3, #330 residual finding).
+/// `Gpt4Regex` (#330 residual finding).
 fn is_supported_bpe_pretokenizer(pt: &JsonValue) -> bool {
     if is_regex_split_node(pt) {
         return true;
@@ -1265,8 +1265,8 @@ mod tests {
     }
 
     /// Vocab/merges for the cross-space-merge discriminator used by the
-    /// `validate_bpe_pretokenizer` fail-closed tests below (codex round-2,
-    /// #330 finding 1). Byte-level maps a literal space to `Ġ` (U+0120), so
+    /// `validate_bpe_pretokenizer` fail-closed tests below (#330 finding 1).
+    /// Byte-level maps a literal space to `Ġ` (U+0120), so
     /// `"a b"` byte-encodes to `"aĠb"`. Base single-byte tokens (`a`, `Ġ`,
     /// `b`) plus staged merges `Ġ`+`b` -> `Ġb` -> (with `a`) `aĠb` let a
     /// SINGLE merged id (2) only be reachable if "a" and " b" land in the
@@ -1274,7 +1274,7 @@ mod tests {
     /// always splits on word boundaries, so "a" and " b" land in different
     /// pieces and the cross-space merge can never fire, giving `[0, 1]`
     /// (the "a" and "Ġb" ids from separate pieces) instead. This is a
-    /// direct id-level proxy for the silent-wrong-ids failure mode codex's
+    /// direct id-level proxy for the silent-wrong-ids failure mode a
     /// review flagged for explicit `use_regex:false` metadata that fell
     /// through to the `Gpt4Regex` default unchecked.
     fn cross_space_merge_json(pre_tokenizer: &str) -> String {
@@ -1292,7 +1292,7 @@ mod tests {
 
     #[test]
     fn test_bytelevel_use_regex_false_rejected_without_supporting_split() {
-        // codex round-2 (#330 finding 1, major/fail-open): a tokenizer.json
+        // #330 finding 1 (major/fail-open): a tokenizer.json
         // that explicitly declares `ByteLevel(use_regex:false)` with no
         // preceding regex `Split` must be REJECTED, not silently tokenized
         // with the `Gpt4Regex` default. HF's ByteLevel `use_regex=false`
@@ -1311,7 +1311,7 @@ mod tests {
 
     #[test]
     fn test_unknown_pretokenizer_type_rejected() {
-        // codex round-2 (#330 finding 1): an unrecognized pre_tokenizer type
+        // #330 finding 1: an unrecognized pre_tokenizer type
         // (Metaspace, Whitespace, BertPreTokenizer, ...) on a BPE model must
         // also fail closed rather than silently defaulting to `Gpt4Regex`.
         let json = cross_space_merge_json(r#"{"type": "Metaspace", "replacement": "_"}"#);
@@ -1325,7 +1325,7 @@ mod tests {
 
     #[test]
     fn test_bare_bytelevel_use_regex_true_or_absent_accepted() {
-        // codex round-2 (#330 finding 1): bare `ByteLevel` with `use_regex`
+        // #330 finding 1: bare `ByteLevel` with `use_regex`
         // absent or `true` is the common gpt2/roberta Hub shape and must
         // keep working exactly as the #330 fix intended — HF's own default
         // for `use_regex` is `true`, which is what `Gpt4Regex` approximates.
@@ -1344,7 +1344,7 @@ mod tests {
 
     #[test]
     fn test_sequence_split_then_bytelevel_use_regex_false_accepted() {
-        // codex round-2 (#330 finding 1): the real Qwen/Qwen3-Embedding
+        // #330 finding 1: the real Qwen/Qwen3-Embedding
         // shape is `Sequence[Split{pattern.Regex}, ByteLevel{use_regex:false}]`
         // — a regex Split establishes the correct segmentation, and the
         // trailing `ByteLevel(use_regex:false)` just means "don't split
@@ -1366,7 +1366,7 @@ mod tests {
 
     #[test]
     fn test_sequence_split_then_metaspace_rejected() {
-        // codex round-3 (#330 residual finding): before this fix,
+        // #330 residual finding: before this fix,
         // `is_supported_bpe_pretokenizer` returned `true` as soon as
         // `has_regex_split` found ANY descendant regex `Split`, so
         // `Sequence[Split{pattern.Regex}, Metaspace]` was wrongly accepted
@@ -1396,7 +1396,7 @@ mod tests {
     #[test]
     fn test_sequence_split_then_whitespace_rejected() {
         // Same class as `test_sequence_split_then_metaspace_rejected` above,
-        // with `Whitespace` (also named explicitly in codex round-2's
+        // with `Whitespace` (also named explicitly in the #330 finding 1
         // reject list) as the unsupported sibling instead of `Metaspace`.
         let pre_tokenizer = r#"{
             "type": "Sequence",

--- a/crates/inference/tests/grammar_json_schema_regression.rs
+++ b/crates/inference/tests/grammar_json_schema_regression.rs
@@ -65,7 +65,7 @@ fn enum_helper_names_do_not_collide() {
     );
 }
 
-// Finding #4 ($defs sub-case, raised by codex review): a generated
+// Finding #4 ($defs sub-case, raised in review): a generated
 // `str_enum_N` helper rule must not overwrite a user `$defs` rule that
 // happens to share the same name. Here `a` references a def literally named
 // `str_enum_0` (an integer), and `b`'s enum helper would otherwise reserve
@@ -92,7 +92,7 @@ fn enum_helper_does_not_clobber_user_defs_rule() {
     );
 }
 
-// Finding #4 (reverse $defs sub-case, raised by codex re-review): when an enum
+// Finding #4 (reverse $defs sub-case, raised in re-review): when an enum
 // property compiles BEFORE a `$ref` to a def of a colliding name, the `$ref`
 // must resolve to the DEF, not alias to the enum helper. Here `a` (enum, first)
 // would claim `str_enum_0`; `b` then references a def named `str_enum_0` that is

--- a/crates/inference/tests/grammar_tbv_probe.rs
+++ b/crates/inference/tests/grammar_tbv_probe.rs
@@ -5,7 +5,7 @@
 //!   f2 (array cardinality minItems/maxItems)   — FIXED in this session
 //!   f3 (prefixItems tuple arrays)              — FIXED in this session
 //!   f4 (string enum rule-name collision)       — previously fixed upstream
-//!   f5 (single-stack PDA common-prefix)        — Ocean-gated architectural, marked #[ignore]
+//!   f5 (single-stack PDA common-prefix)        — needs architectural redesign, marked #[ignore]
 //!   f6 (leading-zero integer rejection)        — previously fixed upstream
 //!   f7 (enum/const string escaping)            — FIXED in this session
 
@@ -25,7 +25,7 @@ fn full_accept(g: &CompiledGrammar, s: &[u8]) -> bool {
 }
 
 #[test]
-#[ignore = "issue #310 finding #5 (single-stack PDA cannot backtrack common prefixes) — Ocean-gated architectural redesign"]
+#[ignore = "issue #310 finding #5 (single-stack PDA cannot backtrack common prefixes) — needs architectural redesign"]
 fn f5_common_prefix_raw() {
     let mut b = GrammarBuilder::new();
     b.add_rule(
@@ -43,7 +43,7 @@ fn f5_common_prefix_raw() {
 }
 
 #[test]
-#[ignore = "issue #310 finding #5 (single-stack PDA cannot backtrack common prefixes) — Ocean-gated architectural redesign"]
+#[ignore = "issue #310 finding #5 (single-stack PDA cannot backtrack common prefixes) — needs architectural redesign"]
 fn f5_common_prefix_enum() {
     let g = compile_json_schema(&serde_json::json!({"type":"string","enum":["apple","apricot"]}))
         .unwrap();
@@ -182,7 +182,7 @@ fn f2_multi_array_no_collision() {
 
 #[test]
 fn f2_no_items_cardinality() {
-    // codex #1: cardinality must be enforced even without an `items` schema.
+    // Finding #1: cardinality must be enforced even without an `items` schema.
     let g0 = compile_json_schema(&serde_json::json!({"type":"array","maxItems":0})).unwrap();
     assert!(
         full_accept(&g0, b"[]"),
@@ -207,7 +207,7 @@ fn f2_no_items_cardinality() {
 
 #[test]
 fn f3_prefix_items_maxitems() {
-    // critic F1 / codex #2: prefixItems + items must honor maxItems.
+    // Finding #2: prefixItems + items must honor maxItems.
     let g = compile_json_schema(&serde_json::json!(
         {"type":"array","prefixItems":[{"type":"integer"}],"items":{"type":"integer"},"maxItems":2}
     ))
@@ -234,7 +234,7 @@ fn f3_prefix_maxitems_lt_prefixlen_error() {
 
 #[test]
 fn f3_empty_prefix_items_applies_items() {
-    // codex #3: empty prefixItems == no prefixItems; `items` must apply.
+    // Finding #3: empty prefixItems == no prefixItems; `items` must apply.
     let g = compile_json_schema(&serde_json::json!(
         {"type":"array","prefixItems":[],"items":{"type":"integer"}}
     ))

--- a/docs/adr/ADR-042-native-sparse-attention.md
+++ b/docs/adr/ADR-042-native-sparse-attention.md
@@ -91,10 +91,10 @@ Public surface:
 
 | Alternative | Pros | Cons | Why Not |
 |---|---|---|---|
-| Mean-pooling compression (`fla-org` variant) | Parameter-free; no φ weights to supply | Explicitly *not* the paper; discards the learnable MLP φ | Ocean chose the faithful paper algorithm |
-| Selection-branch-only ("ship the seed") | Smallest; isolates the novel kernel piece | Not the full mechanism; defers the gated three-branch merge | Ocean chose the full faithful implementation |
-| Defer NSA entirely | Avoids building on a nonexistent checkpoint | Leaves the bench-oriented attention series at 2/3 | Ocean chose to build it |
-| Follow `lucidrains` exactly | One coherent reference to transcribe | Diverges from the paper (logits-as-scores, mean aggregation, mem-KV, left-pad) | Ocean asked for paper-faithful |
+| Mean-pooling compression (`fla-org` variant) | Parameter-free; no φ weights to supply | Explicitly *not* the paper; discards the learnable MLP φ | The faithful paper algorithm was chosen over the parameter-free variant |
+| Selection-branch-only ("ship the seed") | Smallest; isolates the novel kernel piece | Not the full mechanism; defers the gated three-branch merge | The full faithful implementation was chosen over the seed-only variant |
+| Defer NSA entirely | Avoids building on a nonexistent checkpoint | Leaves the bench-oriented attention series at 2/3 | Chosen: build the full mechanism rather than deferring it |
+| Follow `lucidrains` exactly | One coherent reference to transcribe | Diverges from the paper (logits-as-scores, mean aggregation, mem-KV, left-pad) | Paper-faithful implementation was the requirement |
 | Single Q/K/V set, RoPE'd by caller (ADR-010 convention) | Matches the other modules' signature | Paper §3.3.3 mandates independent K/V per branch, and compression needs non-RoPE Q/K | Faithfulness requires 8 activation buffers: `q`, `q_rope`, `k_cmp`, `k_slc`, `k_win`, `v_cmp`, `v_slc`, `v_win` |
 
 ---

--- a/docs/adr/ADR-045-quarot-lora-composition.md
+++ b/docs/adr/ADR-045-quarot-lora-composition.md
@@ -2,7 +2,6 @@
 
 **Status**: Accepted
 **Date**: 2026-05-16
-**Author**: Ocean (HaiyangLi)
 **Depends on**: ADR-044 (QuaRot rotated quantization, v0 shipped in v0.2.0)
 
 ## Context

--- a/docs/adr/ADR-058-cpu-perf-regression-ci.md
+++ b/docs/adr/ADR-058-cpu-perf-regression-ci.md
@@ -21,7 +21,7 @@ The decode hot path on Apple Silicon depends on tight CPU SIMD kernels (NEON ele
 2. Restoring the `-128` validation scan on the public `dot_product_i8` entry point cost a measurable percentage of int8 throughput before being moved behind a `_dispatch` indirection.
 3. Tightening the polynomial `exp` upper clamp from 88.72 → 88.0 — no measurable impact, but easy to imagine a similar change costing 5% of softmax throughput.
 
-The end-to-end decode bench (`scripts/bench_apples_to_apples.sh`) catches macro regressions but is too noisy to attribute them: on a busy M2 Max with 5–10 concurrent `li play` processes, lattice decode throughput swings by 25% (issue #77). We cannot use noisy end-to-end numbers as a merge gate.
+The end-to-end decode bench (`scripts/bench_apples_to_apples.sh`) catches macro regressions but is too noisy to attribute them: on a busy M2 Max with 5–10 concurrent GPU-bench processes, lattice decode throughput swings by 25% (issue #77). We cannot use noisy end-to-end numbers as a merge gate.
 
 The GPU path cannot run on GitHub Actions runners (no Metal). But the CPU paths can — and they account for elementwise activations, normalization, the int8 embed path, decode attention reductions, and the entire CPU fallback for systems without GPU acceleration.
 
@@ -33,7 +33,7 @@ The GPU path cannot run on GitHub Actions runners (no Metal). But the CPU paths 
 - **Free GitHub-hosted runners only.** No self-hosted M-series runner for now (separate decision).
 - **GH Actions noise.** Shared runners exhibit run-to-run variance; threshold must be loose enough to not flake, tight enough to catch real regressions.
 - **Cross-architecture coverage.** Both NEON (aarch64 Linux via `ubuntu-24.04-arm`) and AVX2 (x86_64 Linux via `ubuntu-latest`) must be gated separately — a regression in only one path is still a regression.
-- **Trend visibility.** Ocean wants "very granular" tracking — not just "did this PR regress" but "how has performance evolved over time."
+- **Trend visibility.** The design requires "very granular" tracking — not just "did this PR regress" but "how has performance evolved over time."
 
 ## Decision
 
@@ -220,7 +220,7 @@ Just use `cargo bench --baseline previous` and rely on Criterion's built-in `reg
 
 ### A2: Bencher.dev or Codspeed (paid hosted services)
 
-Rejected by Ocean directive: "we can do it ourselves, no need to pay for these kinds of stuff."
+Rejected: building in-house avoids external cost and dependency.
 
 ### A3: Self-hosted Apple Silicon runner
 

--- a/docs/adr/ADR-064-ci-gate-taxonomy.md
+++ b/docs/adr/ADR-064-ci-gate-taxonomy.md
@@ -20,7 +20,7 @@ Implemented additive changes in this run:
 3. `unwrap-in-lib-lint` observation job added to `.github/workflows/ci.yml` with
    `continue-on-error: true` at the job level. Not added to any required-status set.
 
-All new merge-blocking gates listed below remain proposed until founder sign-off. No proposed gate
+All new merge-blocking gates listed below remain proposed until maintainer sign-off. No proposed gate
 in this ADR should be treated as accepted branch-protection policy. The two observation jobs above
 are explicitly non-blocking and will show existing debt on first run.
 
@@ -70,7 +70,7 @@ The project is a pure-Rust inference engine. CI design must not add new dependen
 must not weaken or remove any existing gate. Additive observation gates can be introduced separately
 only when they are non-required or explicitly allowed to fail during their observation period.
 
-Any change that would make a new gate merge-blocking is not decided here. It requires founder
+Any change that would make a new gate merge-blocking is not decided here. It requires maintainer
 sign-off because it changes branch-protection policy, migration expectations, and merge risk.
 
 ### Verified absence ledger
@@ -164,10 +164,10 @@ The MSRV check candidate was evaluated and skipped for this run. No workspace cr
 - Pick an arbitrary older toolchain version that has no policy backing and could produce persistent
   noise if the codebase uses syntax unavailable on that version.
 
-Without a founder-approved minimum Rust version, a non-trivial MSRV job cannot be made cleanly
+Without a maintainer-approved minimum Rust version, a non-trivial MSRV job cannot be made cleanly
 non-blocking in spirit — it would be guessing at a policy rather than measuring against one. The
 absence of `rust-version` remains a verified gap (rank 2 in the verified absence ledger). It is
-recorded below as a founder-gated proposal where the required policy decision can be made explicitly.
+recorded below as an open proposal pending an explicit policy decision.
 
 ### D5: Remaining non-blocking additive candidates (not yet implemented)
 
@@ -175,12 +175,12 @@ recorded below as a founder-gated proposal where the required policy decision ca
 |---|---|---|---|
 | `publish-dry-run` | packaging | New non-required job invoking existing `scripts/publish.sh --dry-run`, path-filtered to Cargo and crate/package surfaces, allowed to fail initially. | Requires review of the publish script's environment expectations before CI wiring; deferred to a separate change. |
 
-### D6: Founder-gated proposals are not accepted changes
+### D6: Deferred proposals are not accepted changes
 
 The following proposals would create or promote a merge-blocking gate. They are explicitly proposed
-for founder sign-off and are not decided by this ADR.
+for maintainer sign-off and are not decided by this ADR.
 
-| proposal | protected property | founder decision needed |
+| proposal | protected property | maintainer decision needed |
 |---|---|---|
 | Make `unwrap-in-lib-lint` required, or encode unwrap and expect denial in workspace lint policy. | correctness | Blocks merges on existing or future panic-safety violations; requires agreement on tolerated exceptions and migration path. |
 | Define official MSRV, add `rust-version`, and make an MSRV compile check required. | build-hygiene | Establishes a compatibility contract that can constrain dependency and language-feature choices. |
@@ -197,7 +197,7 @@ A CI check may become merge-blocking only when all of the following are true:
 2. The trigger and path-filter behavior are explicit.
 3. The failure mode is documented.
 4. Existing failures are either fixed or covered by an accepted migration plan.
-5. Branch-protection impact is approved by the founder.
+5. Branch-protection impact is approved by the maintainers.
 
 This keeps new gates additive while preventing surprise merge blockage.
 
@@ -266,7 +266,7 @@ If accepted separately, add non-required jobs for rustdoc linting, unwrap/expect
 publish dry-run visibility, or MSRV telemetry. These jobs must not be added to branch protection in
 the same change.
 
-### Phase 3: Founder sign-off
+### Phase 3: Maintainer sign-off
 
 For any proposed merge-blocking gate, decide the exact protected property, failure mode, migration
 plan, and branch-protection context.

--- a/docs/adr/ADR-066-output-correctness-gate-architecture.md
+++ b/docs/adr/ADR-066-output-correctness-gate-architecture.md
@@ -1,6 +1,6 @@
 # ADR-066: Output-Correctness Gate Architecture
 
-- Status: Accepted (founder resolved F-1 through F-4 on 2026-07-01; dispositions recorded in D6)
+- Status: Accepted (F-1 through F-4 resolved on 2026-07-01; dispositions recorded in D6)
 - Date: 2026-07-01
 - Depends on: ADR-064 (CI gate taxonomy), ADR-065 (feature promotion gates), ADR-063 (serving architecture)
 - Supersedes: nothing (fills the gap ADR-064's verified-absence ledger and D6 table point at)
@@ -11,7 +11,7 @@ ADR-064 classified every *existing* gate and established the promotion policy (D
 governs *new feature admission*. Neither answers the question this ADR answers: **what output
 invariants must the engine hold, and which gate layer enforces each one?**
 
-Ground truth as of 2026-07-01 (full inventory: `.khive/workspaces/20260701/f1-gates/gate_inventory.md`):
+Ground truth as of 2026-07-01:
 
 - Branch protection is ruleset `16354934`: exactly 8 required status contexts (`CI` ×3,
   `feature-matrix` ×2, `bench-compile`, `cargo-deny`, `parity-gate`), **zero required PR
@@ -23,8 +23,7 @@ Ground truth as of 2026-07-01 (full inventory: `.khive/workspaces/20260701/f1-ga
   `bench-update.yml` (no `pull_request` trigger at all), `embed-parity-release.yml`
   (release-cadence only).
 
-Ten shipped-and-fixed bug classes were mapped against this gate set
-(`.khive/workspaces/20260701/f1-gates/gap_corpus.md`). Every one of them merged clean through
+Ten shipped-and-fixed bug classes were mapped against this gate set. Every one of them merged clean through
 the gates above. They do not miss randomly — they cluster into five structural blind spots of
 the current architecture:
 
@@ -83,7 +82,7 @@ contract test (this is enforceable in review by grepping the catalog):
    convention (stride-half max-diff ~1e-6 vs interleaved ~67 — rejects in seconds).
 9. **Recurrent-state indexing**: decay/gate parameters index by the reference architecture's
    cardinality (per-value-head for asymmetric GDN); verified against HF indexing, not
-   self-consistency. (Full closure founder-gated on an asymmetric checkpoint — #262.)
+   self-consistency. (Full closure blocked on an asymmetric checkpoint — #262.)
 10. **Fail-closed context bounds**: forward paths return errors, never assert-panic, when
     `prompt_len > max_context()`.
 
@@ -95,7 +94,7 @@ contract test (this is enforceable in review by grepping the catalog):
 2. **The aggregator pattern is canonical.** Any path-filtered required check must follow
    `parity-gate`'s always-report aggregator design (e2e-parity.yml:205-238). `app-binaries.yml`
    currently violates this: it runs on nearly every engine PR, can show red, and blocks nothing.
-   It gets an aggregator job; making that aggregator *required* is founder-gated (D6).
+   It gets an aggregator job; making that aggregator *required* is deferred pending sign-off (D6).
 3. **Compare rendered text, not only token IDs.** `e2e_parity_check.py`'s `compare()` gains a
    decoded-text equality check alongside `hf_ids`/`lat_ids`. This single change makes the
    existing required gate structurally able to see bug classes #430 and (with a CJK prompt
@@ -132,16 +131,16 @@ contract test (this is enforceable in review by grepping the catalog):
 | Serve DoS (#435) | 7, 10 | L4/L1 | Partial — clamps shipped; no CI abuse-path test |
 | Metal under-dispatch (#384) | 6 | L1 | Partial — fixed site tested; no canary-test convention for new kernels |
 | Paravirtual false-green | D3.1 | signal | No — one opt-in env var on one test |
-| GDN decay indexing (#262/#427) | 9 | L3 | No — needs long-horizon gate + asymmetric checkpoint (founder-gated) |
+| GDN decay indexing (#262/#427) | 9 | L3 | No — needs long-horizon gate + asymmetric checkpoint (deferred) |
 | Streaming UTF-8 (#196) | 5 | L1 + D3.3 | Partial — unit tests yes; no CJK prompt in the required gate |
 
 Open issues #239 (Metal parity leg), #320 (rotated+Q4 composed golden), #252 (kv_f16 parity
 run), #167 (self-hosted perf/quality gates), #153 (per-kernel micro-bench gate) are all
 instances of this ADR's L2/L3 layers and inherit its design rather than each re-deciding shape.
 
-### D6. Rollout — founder-gated vs immediately actionable
+### D6. Rollout — deferred vs immediately actionable
 
-**Founder-gated** (each changes merge-blocking behavior or spends money; per ADR-064 D7 rule 5):
+**Deferred** (each changes merge-blocking behavior or spends money; per ADR-064 D7 rule 5):
 
 | # | Proposal | Cost/impact |
 |---|---|---|
@@ -150,7 +149,7 @@ instances of this ADR's L2/L3 layers and inherit its design rather than each re-
 | F-3 | Self-hosted M2 Max runner for L3 nightly (PPL tiers, long-generation, #167 perf gates) | Hardware + maintenance; the only path to non-paravirtual Metal signal |
 | F-4 | Any change to review requirements or bypass actors (`required_approving_review_count: 0`, RepositoryRole bypass) | Governance; out of automated hands entirely |
 
-**Founder dispositions (2026-07-01, approved as recommended):**
+**Dispositions (2026-07-01, approved as recommended):**
 
 - F-1: **Approved.** `app-binaries` aggregator becomes a required context once the
   non-required job (item 5 below) exists and is green.
@@ -159,11 +158,11 @@ instances of this ADR's L2/L3 layers and inherit its design rather than each re-
   (review checkpoint 2026-07-15).
 - F-3: **Approved, schedule-only.** The self-hosted runner workflow runs on `schedule` against
   `main` only, never on pull requests (public-repo fork-PR code execution risk). The workflow
-  ships dormant; runner registration waits on founder-designated hardware.
+  ships dormant; runner registration waits on designated hardware.
 - F-4: **Keep as is.** Zero required approvals and RepositoryRole bypass remain while the repo
   is effectively solo; revisit when outside contributors arrive.
 
-**Immediately actionable without founder sign-off** (no required-context changes, no spend):
+**Immediately actionable without further sign-off** (no required-context changes, no spend):
 
 1. `e2e_parity_check.py`: add rendered-text comparison to `compare()` + 1 CJK/emoji prompt (D3.3).
 2. Regenerate `docs/bench_results/perplexity.tsv` on current main; commit the command (D3.4).
@@ -188,7 +187,6 @@ instances of this ADR's L2/L3 layers and inherit its design rather than each re-
 
 ## Verification
 
-- Inventory and corpus artifacts with file:line citations:
-  `.khive/workspaces/20260701/f1-gates/{gate_inventory,gap_corpus}.md` (recon 2026-07-01,
-  primary sources only — live ruleset JSON, workflow files, `git log`, `gh issue view`).
+- Inventory and corpus recon (2026-07-01) built from primary sources only — live ruleset
+  JSON, workflow files, `git log`, `gh issue view`.
 - Every "fixed in" claim in D5 maps to a merge commit verified in git history during recon.

--- a/docs/adr/ADR-067-gpu-decode-perf-regression-gates.md
+++ b/docs/adr/ADR-067-gpu-decode-perf-regression-gates.md
@@ -25,7 +25,7 @@ PPL, greedy/top-k agreement, contention/KV-layout), and fails only on a confirme
 the CI lower bound, following the ADR-058 method.
 
 The self-hosted M2 Max runner referenced by issue #167 **does not exist yet** — provisioning it is
-a pending founder decision, tracked separately from this ADR. That means the nightly workflow
+a pending maintainer decision, tracked separately from this ADR. That means the nightly workflow
 described below is buildable and correct today, but cannot execute until the runner is
 provisioned. Scoping this ADR to "everything buildable now" keeps the harness, gate script, and
 workflow definition ready to go live the moment the runner lands, without inventing speculative
@@ -89,9 +89,9 @@ fabricated pass. The gate script treats any row depending on a null field as `IN
 ### What is explicitly NOT decided here
 
 - **The runner does not exist.** This ADR proposes the workflow shape; it does not request or
-  imply approval to provision `[self-hosted, m2max]`. That is a separate founder decision.
+  imply approval to provision `[self-hosted, m2max]`. That is a separate maintainer decision.
 - **No gate in this table is merge-blocking.** The nightly workflow is intentionally excluded from
-  any required-status-check set. Promoting any row to merge-blocking requires a separate founder
+  any required-status-check set. Promoting any row to merge-blocking requires a separate
   sign-off, per the ADR-064 taxonomy's promotion policy (ADR-064 §"gated vs. informational").
 - **Baseline publishing.** This workflow reads from the `perf-baselines` branch but does not push
   to it; wiring an automatic baseline-update step is left for a later change once the runner is
@@ -118,7 +118,7 @@ implemented, everything that does remains dormant and clearly marked as such.
    never silently passes and never masks a real `FAIL` elsewhere.
 3. This ADR document.
 
-**DORMANT — pending founder sign-off on the self-hosted runner:**
+**DORMANT — pending sign-off on the self-hosted runner:**
 
 1. `.github/workflows/adr064-gpu-decode-nightly.yml` — schedule-only, non-required, no PR trigger,
    targets `runs-on: [self-hosted, m2max]`. Committed now so it activates the moment the runner is
@@ -127,7 +127,7 @@ implemented, everything that does remains dormant and clearly marked as such.
    contention loss, KV-layout assertion) into `scripts/bench_decode_slopefit.py` — out of scope
    for this change; the gate script already handles their absence honestly via `INCOMPLETE`.
 3. Promoting any row in the gate table to a required, merge-blocking status check — explicitly not
-   done here; requires founder sign-off per the ADR-064 taxonomy's promotion policy.
+   done here; requires sign-off per the ADR-064 taxonomy's promotion policy.
 
 No existing gate (in this ADR or elsewhere in `.github/workflows`) was weakened, removed, or made
 merge-blocking by this change. Everything above is additive.

--- a/docs/cli-tools.md
+++ b/docs/cli-tools.md
@@ -8,7 +8,7 @@ one is for, what it needs on disk, and a verified command sequence with real out
 Every command below was actually run against a local `qwen3.5-0.8b` checkpoint (and its Q4
 variants) in this repository: the flags, the failure messages, and the output shapes are copied
 from that terminal, not reconstructed from memory. Metal-GPU-touching runs went through the
-fleet-wide `/tmp/lion-metal-gpu-test.lock` advisory flock (see `CLAUDE.md`) so they never
+machine-wide `/tmp/lion-metal-gpu-test.lock` advisory flock (see `CLAUDE.md`) so they never
 overlapped another process's GPU work.
 
 **A note on the numbers below.** Every `tok/s`, latency, timing, and perplexity figure in this

--- a/docs/cross-turn-cache.md
+++ b/docs/cross-turn-cache.md
@@ -243,8 +243,8 @@ a turn. This is exactly the multi-session risk PR #619's description cites as th
 `lattice serve`/`lattice_serve` weren't wired up yet — a single shared worker with this cache
 behind a server handling several simultaneous chats would thrash.
 
-This single-entry design traces back to a real bug caught in review: PR #516's round-1 codex
-review rejected an earlier version that used an unbounded per-slot `HashMap`, because the
+This single-entry design traces back to a real bug caught in review: PR #516's review
+rejected an earlier version that used an unbounded per-slot `HashMap`, because the
 underlying full-attention KV buffer is one mutable live buffer shared by the whole process — a
 stale map entry could restore GDN state from one conversation while attention silently read KV
 rows another generation had since overwritten. The fix (documented as remediation items D1-D6)

--- a/docs/mlx_kernel_study.md
+++ b/docs/mlx_kernel_study.md
@@ -3,10 +3,10 @@
 **Issue**: #85\
 **Branch**: docs/mlx-kernel-study\
 **MLX source pinned to**: [`ml-explore/mlx@2e6632e5b84aa42d1bebecb0207092e223ff4d58`](https://github.com/ml-explore/mlx/tree/2e6632e5b84aa42d1bebecb0207092e223ff4d58) (2026-05-29)\
-**Lattice source**: `crates/inference/src/forward/` — all file:line citations are from `../e1/current_state.md`\
+**Lattice source**: `crates/inference/src/forward/` — all file:line citations verified against the lattice source\
 **External sources**: FlashAttention-2 arXiv:2307.08691 (2023-07-17, C:0.85), Apple MSL Spec (2025-10-23, C:0.95), Apple developer docs (2026-05-30, C:0.9)\
 **Source authority**: C:0.95 = MLX source or current Apple docs | C:0.85 = FA2 paper | Inference explicitly labeled with confidence scores\
-**Produced from**: `r1/landscape.md`, `r1/web_findings.md`, `r2/khive_grounding.md`, `e1/current_state.md`, `a1/analysis.md`, `a1/recommendations.md`
+**Produced from**: a primary-source audit of MLX (upstream source and Apple documentation) and the lattice Metal forward path
 
 ---
 
@@ -82,13 +82,13 @@ Fact (C:0.95): Apple documents that residency sets reduce CPU overhead versus pe
 
 ## 2. Why MLX Resists Concurrent-Load Degradation (#77): Sourced Hypothesis
 
-**Scope note**: The `~2.8%` concurrent-load degradation figure and the `25%` lattice figure are flow-provided benchmark context. `r1/landscape.md` explicitly reports that the MLX 2.8% figure was not found in MLX source or Apple docs. The mechanism below is a sourced hypothesis, not a proven causal explanation.
+**Scope note**: The `~2.8%` concurrent-load degradation figure and the `25%` lattice figure are flow-provided benchmark context. The primary-source audit reports that the MLX 2.8% figure was not found in MLX source or Apple docs. The mechanism below is a sourced hypothesis, not a proven causal explanation.
 
-**Critical correction** (from critic review, confirmed against `e1/current_state.md`): Lattice Qwen3.5 decode **already** uses a single command buffer for all active layers with no intermediate waits. This is documented at `crates/inference/src/forward/metal_qwen35.rs:5971` ("Single command buffer for ALL 24 layers - no intermediate waits"), with one encoder at `:5978`, one submit at `:6021`, and one commit/wait at `:6023`. The same single-submit pattern holds for prefill (`metal_qwen35.rs:6311`, `:6312`, `:7091`) and batch verification (`metal_qwen35.rs:4792`, `:5407`). The #77 gap is **not** explained by per-layer command buffer submission; that architecture is already in place.
+**Critical correction** (confirmed against the lattice source): Lattice Qwen3.5 decode **already** uses a single command buffer for all active layers with no intermediate waits. This is documented at `crates/inference/src/forward/metal_qwen35.rs:5971` ("Single command buffer for ALL 24 layers - no intermediate waits"), with one encoder at `:5978`, one submit at `:6021`, and one commit/wait at `:6023`. The same single-submit pattern holds for prefill (`metal_qwen35.rs:6311`, `:6312`, `:7091`) and batch verification (`metal_qwen35.rs:4792`, `:5407`). The #77 gap is **not** explained by per-layer command buffer submission; that architecture is already in place.
 
 ### 2.1 Queue-Level Residency Sets (Inference, C:0.8)
 
-MLX inserts its heap/buffers into a residency set, calls `requestResidency()`, and attaches the set to the command queue [`resident.cpp#L8-L38`](https://github.com/ml-explore/mlx/blob/2e6632e5b84aa42d1bebecb0207092e223ff4d58/mlx/backend/metal/resident.cpp#L8-L38), [`allocator.cpp#L34-L66`](https://github.com/ml-explore/mlx/blob/2e6632e5b84aa42d1bebecb0207092e223ff4d58/mlx/backend/metal/allocator.cpp#L34-L66), [`device.cpp#L263-L279`](https://github.com/ml-explore/mlx/blob/2e6632e5b84aa42d1bebecb0207092e223ff4d58/mlx/backend/metal/device.cpp#L263-L279). Apple states residency sets mitigate per-encoder CPU overhead, queue attachment is more efficient than per-command-buffer attachment, and `requestResidency()` can reduce commit-to-GPU-start delay [Apple Residency Sets](https://developer.apple.com/documentation/metal/simplifying-gpu-resource-management-with-residency-sets). Under concurrent GPU load, this commit-to-start delay reduction is a plausible differentiator. `e1/current_state.md` does not identify a comparable residency-set mechanism in lattice.
+MLX inserts its heap/buffers into a residency set, calls `requestResidency()`, and attaches the set to the command queue [`resident.cpp#L8-L38`](https://github.com/ml-explore/mlx/blob/2e6632e5b84aa42d1bebecb0207092e223ff4d58/mlx/backend/metal/resident.cpp#L8-L38), [`allocator.cpp#L34-L66`](https://github.com/ml-explore/mlx/blob/2e6632e5b84aa42d1bebecb0207092e223ff4d58/mlx/backend/metal/allocator.cpp#L34-L66), [`device.cpp#L263-L279`](https://github.com/ml-explore/mlx/blob/2e6632e5b84aa42d1bebecb0207092e223ff4d58/mlx/backend/metal/device.cpp#L263-L279). Apple states residency sets mitigate per-encoder CPU overhead, queue attachment is more efficient than per-command-buffer attachment, and `requestResidency()` can reduce commit-to-GPU-start delay [Apple Residency Sets](https://developer.apple.com/documentation/metal/simplifying-gpu-resource-management-with-residency-sets). Under concurrent GPU load, this commit-to-start delay reduction is a plausible differentiator. No comparable residency-set mechanism was identified in lattice.
 
 This inference exceeds direct source evidence that queue-level residency explains the 25% vs 2.8% gap. **A concurrent-load benchmark gate with Metal System Trace counters is required before attributing the gap to this mechanism.**
 
@@ -110,7 +110,7 @@ A concurrent-load benchmark with Metal System Trace counters — commit-to-start
 
 ---
 
-## 3. Gap Analysis: Lattice vs MLX (file:line from `e1/current_state.md`)
+## 3. Gap Analysis: Lattice vs MLX
 
 ### G1. Attention / Flash (Issues #13, #126)
 
@@ -166,7 +166,7 @@ A concurrent-load benchmark with Metal System Trace counters — commit-to-start
 
 ## 4. Prioritized Roadmap
 
-Source: `a1/recommendations.md`. Impact/effort are analyst scores (1-5). Higher ratio ranks first.
+Impact/effort are estimated scores (1-5). Higher ratio ranks first.
 
 | Rank | Technique / action                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Issue          | Expected impact | Effort | Risk     | Impact/effort | Source traceability                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | ---: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- | --------------: | -----: | -------- | ------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -189,7 +189,7 @@ Source: `a1/recommendations.md`. Impact/effort are analyst scores (1-5). Higher 
 
 ---
 
-## 5. KG Entities — Create/Link Plan (from `r2/khive_grounding.md`)
+## 5. KG Entities — Create/Link Plan
 
 No MLX-specific technique entities were found in the KG during the r2 grounding pass. The following are new. Existing targets from r2:
 
@@ -220,4 +220,4 @@ No MLX-specific technique entities were found in the KG during the r2 grounding 
 - Not found (C:0.95): The `~2.8%` MLX concurrent-load degradation number was not found in MLX source or Apple docs by `r1`. Treat as flow-provided benchmark context until benchmark provenance is attached.
 - Not found (C:0.9): Apple public docs do not expose detailed scheduler policy, residency eviction policy, or GPU occupancy counters. Metal System Trace is required to validate the #77 hypothesis.
 - Recency risk (C:0.85): FlashAttention-2 is older than two years as of 2026-05-30 but remains the primary paper for the cited mechanisms.
-- Removed (critic review): The following claims were present in the prior draft and have been removed — none were found in r1's primary-source sweep: 'sdpa.metal' path name, 'metal.cpp command graph' claim, SGMMA 'single clock cycle', 'MTLCommandQueue priority hints'.
+- Removed after review: The following claims were present in the prior draft and have been removed — none were found in the primary-source sweep: 'sdpa.metal' path name, 'metal.cpp command graph' claim, SGMMA 'single clock cycle', 'MTLCommandQueue priority hints'.

--- a/docs/releases/v0.2.3.md
+++ b/docs/releases/v0.2.3.md
@@ -59,7 +59,6 @@
 - **Reproducible bench scripts**: `bench-compare.sh` (origin/main vs HEAD A/B), `bench_apples_to_apples.sh`, `bench_apples_precise.sh`, `bench_q4_apples.sh`, `bench_quality.sh`
 - **Logit comparison harness**: `scripts/compare_logits.py` — windowed PPL evaluation, per-position argmax agreement vs MLX
 - **WikiText-2 fixture committed** (`docs/bench_results/wiki.test.raw`) for reproducible PPL bench
-- **Codex review automation**: `scripts/codex_review_pr76*.sh` — adversarial review rounds with self-verification
 
 ## Fixes
 

--- a/docs/releases/v0.2.5.md
+++ b/docs/releases/v0.2.5.md
@@ -49,7 +49,7 @@ No regression in untouched SIMD/forward kernels. The show touched only tokenizer
 
 - [#102](https://github.com/ohdearquant/lattice/issues/102) — SIMD throughput (quantization amortization, simsimd_comparison bench restore, NEON normalize target)
 - [#103](https://github.com/ohdearquant/lattice/issues/103) — Qwen3-Embedding forward-pass divergence (0.948 cosine on whitespace input, 0.989 on tokens-match input)
-- [#116](https://github.com/ohdearquant/lattice/issues/116) — Codex-review follow-ups from the show stack (edge cases the parity gate doesn't cover: AddedToken structured-field enforcement, Qwen `\s+(?!\S)` whitespace regex, WordPiece NFD combining-mark stripping, SentencePiece literal-`▁` distinction)
+- [#116](https://github.com/ohdearquant/lattice/issues/116) — Review follow-ups (edge cases the parity gate doesn't cover: AddedToken structured-field enforcement, Qwen `\s+(?!\S)` whitespace regex, WordPiece NFD combining-mark stripping, SentencePiece literal-`▁` distinction)
 
 ## Diff Stats
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -12,7 +12,7 @@
 ## Scope / non-goals
 
 - The shared primitive guarantees both CPU paths consume the **same uniform draw stream** from a fixed seed. It does **not** guarantee identical *token* streams: the paths still diverge below the RNG layer (top-k tie-break — `Sampler` heap breaks ties toward the lower token id, `sample_token` does not; and the candidate-exhaustion fallback picks in opposite directions — lowest-prob vs highest-prob). Unifying those selection semantics is out of scope here.
-- The Metal host inline sampler (`forward/metal_qwen35.rs`) carries a **third** `u64 → f32` conversion (`raw / u64::MAX`, which can equal `1.0`). It is unchanged in this release and tracked as [#351](https://github.com/ohdearquant/lattice/issues/351) (Metal GPU-capture session, Ocean-gated).
+- The Metal host inline sampler (`forward/metal_qwen35.rs`) carries a **third** `u64 → f32` conversion (`raw / u64::MAX`, which can equal `1.0`). It is unchanged in this release and tracked as [#351](https://github.com/ohdearquant/lattice/issues/351) (requires a Metal GPU-capture session; deferred).
 
 ## Diff stats
 

--- a/scripts/bench_q4_apples.sh
+++ b/scripts/bench_q4_apples.sh
@@ -2,7 +2,7 @@
 # Quant-MATCHED apples-to-apple decode benchmark — slope (marginal) method, Q4.
 #
 # Companion to bench_apples_to_apples.sh (which does f16 Lattice vs Q8 MLX/Ollama).
-# This one is the honest quant-matched comparison Ocean asked for:
+# This one is the honest quant-matched comparison:
 #
 #   Lattice Q4 (plain per-row, ~/.lattice/models/qwen3.5-0.8b-q4)
 #   vs MLX Q4  (nn.quantize bits=4 group_size=64, same source weights)

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -72,7 +72,7 @@ def find_baseline_estimates(bench_dir: Path, baseline_name: str) -> Path | None:
     bench-compare.sh's `compare-base` leg) writes under `<name>/` instead —
     `base/` is never created in that flow. Prefer the caller-supplied baseline
     name FIRST: Criterion computed change/ against that baseline, so a stale
-    `base/` left in a dirty local tree must not shadow it (codex review of
+    `base/` left in a dirty local tree must not shadow it (review of
     PR #548 reproduced exactly that wrong-baseline report). Then try the
     default `base/` (covers CI's default-rotation runs). As a last resort,
     accept a sibling directory holding an estimates.json that isn't
@@ -208,7 +208,7 @@ def run_selftest() -> int:
     Regression coverage for #545: a default-rotation `base/` layout, a named-baseline
     `compare-base/` layout (what bench-compare.sh actually produces), and a `change/`
     dir with no resolvable baseline at all (must WARN by bench name, not silently skip).
-    Plus the codex findings on PR #548: when BOTH base/ and the named baseline exist,
+    Plus the findings on PR #548: when BOTH base/ and the named baseline exist,
     the named baseline must win (dirty local tree with stale base/); when multiple
     unrelated sibling baselines exist and none match, the gate must refuse to guess.
     """
@@ -238,7 +238,7 @@ def run_selftest() -> int:
                      "confidence_interval": {"lower_bound": 0.05, "upper_bound": 0.15}}
         }))
 
-        # Codex finding 1: both base/ and compare-base/ present with different
+        # Finding 1: both base/ and compare-base/ present with different
         # values — the named baseline must win over stale base/.
         both_dir = root / "grp_d" / "bench_both"
         _fabricate_bench(both_dir, "compare-base", base_ns=100.0)
@@ -246,7 +246,7 @@ def run_selftest() -> int:
         (both_dir / "base" / "estimates.json").write_text(
             json.dumps({"mean": {"point_estimate": 1.0}}))  # stale decoy
 
-        # Codex finding 2: multiple unrelated sibling baselines, none matching
+        # Finding 2: multiple unrelated sibling baselines, none matching
         # the requested name — must skip loudly, not guess.
         multi_dir = root / "grp_e" / "bench_multi"
         _fabricate_bench(multi_dir, "old-run-1")

--- a/scripts/perf_governor.README.md
+++ b/scripts/perf_governor.README.md
@@ -1,6 +1,6 @@
 # perf_governor — macOS Bench Resource Guardrail
 
-Hard gate that runs before (and during) any perf measurement on Ocean's Mac.
+Hard gate that runs before (and during) any perf measurement on this machine.
 Pure stdlib, no pip deps. macOS-only. No sudo required.
 
 The module lives at `scripts/perf_governor.py` (tracked, CI-reachable, survives a
@@ -28,7 +28,7 @@ python3 scripts/perf_governor.py --status
 # Gate check only (exit 0 = clear, exit 2 = blocked)
 python3 scripts/perf_governor.py --preflight
 
-# Demonstrate every guard tripping without a real bench (Leo's sanity demo)
+# Demonstrate every guard tripping without a real bench (sanity demo)
 python3 scripts/perf_governor.py --selftest
 
 # Full gate: preflight → run → cooldown (replace 'cargo bench ...' with your cmd)

--- a/scripts/perf_governor.py
+++ b/scripts/perf_governor.py
@@ -41,7 +41,7 @@ _THIS_FILE = Path(__file__).resolve()
 _SCRIPTS_DIR = _THIS_FILE.parent       # scripts/ (tracked)
 _REPO_ROOT = _SCRIPTS_DIR.parent       # one level up: repo root
 
-# Kill-switch sentinel. DECOUPLED from this module's own location (Leo f5aa3305):
+# Kill-switch sentinel. DECOUPLED from this module's own location (see commit f5aa3305):
 # the emergency-stop path must stay at a stable, repo-rooted location even if
 # this script moves. Resolution precedence (applied in PerfGovernor.__init__):
 #   --sentinel arg  >  $PERF_GOVERNOR_SENTINEL env  >  this default.
@@ -90,7 +90,7 @@ def _read_thermal() -> dict:
         # DELIBERATE fail-OPEN: a pmset read error assumes nominal so a flaky
         # thermal probe never blocks a run. Safe because BOUNDED + AFK-ONLY +
         # KILL-SWITCH still bound every run (AC and AFK readers fail CLOSED).
-        # Verified + accepted by Leo (f5aa3305).
+        # Verified in commit f5aa3305.
         _log(f"WARNING: pmset -g therm failed ({exc}); assuming nominal")
         return {"speed_limit": 100, "nominal": True}
 
@@ -770,7 +770,7 @@ def _cmd_selftest(gov: PerfGovernor) -> int:
         g_afk = PerfGovernor(afk_only=True, afk_threshold_s=300)
         g_afk._thermal_reader = lambda: {"speed_limit": 100, "nominal": True}
         g_afk._ac_reader = lambda: True
-        g_afk._idle_reader = lambda: 10.0  # fake: Ocean is typing
+        g_afk._idle_reader = lambda: 10.0  # fake: user is actively typing
         try:
             g_afk.preflight()
             raise AssertionError("preflight should have raised on AFK-ONLY")


### PR DESCRIPTION
## Summary

Sweeps tracked documentation, ADRs, workflow comments, and Rust/Swift code
comments for internal-operations references that don't belong in a public
repo: person-specific prose, provenance wording, and local-only paths. All technical content
(issue/PR numbers, ADR references, rationale, file:line citations, product
behavior) is preserved; only the internal-process framing is rewritten or
dropped.

No behavior changes: this is docs, comments, and workflow-comment edits
only. No test logic, no `#[ignore]` gating behavior, no runtime code paths
changed.

## Judgment calls

A few hits were deliberately left as-is because changing them would either
alter behavior (out of scope for a docs-only PR) or remove a legitimate,
pre-existing public convention:

- `Cargo.toml`'s `authors` field — left as standard package metadata.
- `README.md`'s "Built by [Ocean (HaiyangLi)]" attribution line — left as a
  pre-existing public attribution, not an internal-ops reference.
- `AGENTS.md`'s AI-agent-attribution policy section — this is the repo's own
  public contribution policy describing how AI-authored PR/issue content
  must be labeled; it legitimately names agent tools (Claude, Codex) as part
  of that policy, so it was left verbatim.
- `scripts/bench_apples_precise.sh`'s GPU-contention-detection `ps aux | grep`
  string — this is functional runtime behavior (detects concurrent GPU load
  before benchmarking), so changing the matched process name is out of scope
  for a cleanup limited to docs, comments, workflow comments, and test ignore-reason text.
- Various `lambda:`/`lambda ` occurrences across the codebase are either
  Rust/Python closure syntax or the `ewc_lambda` machine-learning
  hyperparameter name (EWC regularization strength) — not internal actor
  references.
- "advisory"/"advisories" throughout CI docs and `deny.toml` refer to
  `cargo-deny`'s standard security-advisory terminology and generic
  non-blocking CI signal status.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p lattice-inference --lib` — 1474 passed, 0 failed, 8 ignored
- [x] `make lint-docs` — passed (18 files checked)

