### PR TITLE
feat(inference): wire cross-turn prefix cache into lattice serve Metal worker (#462)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ over the entire KV cache:
 - The linear-attention (gated-delta) layers are constant-time in context and do not contribute to the
   slope.
 
-In an interactive chat this compounds with prompt prefill. The serve path currently re-prefills the
-whole conversation on every turn ([#462](https://github.com/ohdearquant/lattice/issues/462)), a
-separate and larger cost than the decode slope, and the main reason a long chat feels progressively
-slower.
+In an interactive chat this compounds with prompt prefill, a separate and larger cost than the
+decode slope and historically the main reason a long chat felt progressively slower. Both serve
+binaries now reuse the previous turn's shared token prefix instead of re-prefilling the whole
+conversation from scratch on every turn ([#462](https://github.com/ohdearquant/lattice/issues/462),
+see [`docs/cross-turn-cache.md`](docs/cross-turn-cache.md)); a request whose history is not a safe
+append onto the retained state still falls back to a full re-prefill.
 
 MLX uses Apple's private MPS/AMX matrix engines. Lattice uses the public Metal compute API,
 the same tier as Ollama. MLX decodes faster than Lattice at raw throughput. Lattice's edge is

--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -2388,13 +2388,34 @@ mod serve {
 
                 while let Some(job) = job_rx.blocking_recv() {
                     let mut on_token = job.on_token;
-                    let output = state.generate_streaming(
+                    // Cache-aware call (#462): reuses the previous turn's
+                    // shared token prefix instead of a full re-prefill on
+                    // every request. This worker thread owns one
+                    // `MetalQwen35State` for the whole process lifetime (one
+                    // thread = one session), so `CrossTurnSlotId::DEFAULT` is
+                    // the only slot that exists; the planner re-verifies the
+                    // retained prefix against this request's prompt on every
+                    // call and falls back to `PrefixReuseMode::FullRefill`
+                    // whenever they diverge, so correctness never depends on
+                    // distinguishing clients. Mirrors the wiring already
+                    // shipped in `lattice_serve.rs`.
+                    let cached = state.generate_streaming_with_prefix_cache(
+                        lattice_inference::kv_cache::CrossTurnSlotId::DEFAULT,
                         &job.prompt,
                         &tokenizer,
                         &job.gen_cfg,
                         |delta, _token_id| on_token(delta),
                     );
-                    let _ = job.reply.send(output);
+                    if let Ok(c) = &cached {
+                        eprintln!(
+                            "[lattice serve] cross-turn cache: mode={:?} reused={} prefetched={} prompt={}",
+                            c.cache.mode,
+                            c.cache.reused_tokens,
+                            c.cache.prefetched_tokens,
+                            c.cache.prompt_tokens,
+                        );
+                    }
+                    let _ = job.reply.send(cached.map(|c| c.output));
                 }
             });
 

--- a/docs/cross-turn-cache.md
+++ b/docs/cross-turn-cache.md
@@ -30,19 +30,16 @@ or a second client's unrelated prompt interleaved onto the same slot) still fall
 document. Cache stats (`slot`, `prompt_tokens`, `reused_tokens`, `mode`) are logged to stderr per
 request; there is no response-surface (HTTP header/JSON field/SSE event) telemetry yet.
 
-**`lattice serve` (the OpenAI-compatible HTTP server in `lattice.rs`) does not call the
-cache-aware methods yet.** It still calls the plain, non-cache-aware `generate_streaming` on every
-request:
-
-- `lattice serve` → `POST /v1/chat/completions` re-prefills the entire `messages` array from
-  scratch on every request, every time, regardless of how much of the conversation is unchanged
-  from the previous request. This is not an oversight this document is pointing out for the first
-  time — the project's own README says so directly: "The serve path currently re-prefills the
-  whole conversation on every turn ([#462](https://github.com/ohdearquant/lattice/issues/462)), a
-  separate and larger cost than the decode slope, and the main reason a long chat feels
-  progressively slower."
-
-That gap is tracked as `lattice serve`-specific follow-up work under issue #462.
+**`lattice serve` (the OpenAI-compatible HTTP server in `lattice.rs`) now calls the cache-aware
+methods too**, on the same single sticky `CrossTurnSlotId::DEFAULT` slot as `lattice_serve`: its
+Metal worker thread calls `generate_streaming_with_prefix_cache` instead of the plain,
+non-cache-aware `generate_streaming` on every request. `POST /v1/chat/completions` no longer
+re-prefills the entire prompt from scratch when a turn is a safe append onto the previous one —
+the same `FullRefill` fallback applies for a new conversation, edited history, or an interleaved
+second client on the same slot. Cache stats (`mode`, `reused_tokens`, `prefetched_tokens`,
+`prompt_tokens`) are logged to stderr per request, matching `lattice_serve`'s telemetry. This path
+has no client-disconnect cancellation today (unlike `lattice_serve`'s
+`_and_cancel` variant), so it uses the plain `generate_streaming_with_prefix_cache` wrapper.
 
 See [`docs/serve-http-api.md`](serve-http-api.md) for the full `lattice serve` HTTP API — this
 document is only about the library-level cache, not the HTTP surface.
@@ -54,13 +51,10 @@ earlier ones' retained state, forcing a full re-prefill rather than corrupting a
 cache itself safe for concurrent multi-session residency (a bounded multi-entry store with proven
 KV/GDN ownership) is called out explicitly as follow-up work, not something already done.
 
-So: if you're calling `lattice_serve`'s HTTP API from one active conversation at a time, this cache
-now helps you; if several conversations interleave through it, expect honest fallback to full
-re-prefill for whichever conversation was not most recently active. If you're calling `lattice
-serve`'s HTTP API or using `chat_metal`/the underlying `MetalQwen35State` API directly, the
-cache-aware behavior described in the rest of this document applies (`chat_metal` and
-`MetalQwen35State` callers), and the rest of this document covers exactly what "safely extends"
-means and where the sharp edges are.
+So: if you're calling `lattice_serve`'s or `lattice serve`'s HTTP API from one active conversation
+at a time, this cache now helps you; if several conversations interleave through either, expect
+honest fallback to full re-prefill for whichever conversation was not most recently active. The
+rest of this document covers exactly what "safely extends" means and where the sharp edges are.
 
 ## The library API
 
@@ -243,9 +237,9 @@ did not get its own independent storage alongside it. If your process genuinely 
 multiple concurrent conversations through one `MetalQwen35State`, only the most recently generated
 one benefits from caching at any given moment; the others pay full re-prefill every time they get
 a turn. This is the multi-session thrash a single shared worker sees when several simultaneous
-chats share one sticky slot, as `lattice_serve` now does: correct (a losing conversation just gets
-an honest full re-prefill) but not the multi-session residency a bounded multi-entry cache would
-give.
+chats share one sticky slot, as `lattice_serve` and `lattice serve` both now do: correct (a losing
+conversation just gets an honest full re-prefill) but not the multi-session residency a bounded
+multi-entry cache would give.
 
 PR #516 originally considered an unbounded per-slot map, but the underlying full-attention KV
 buffer is one mutable live buffer shared by the whole process. A stale map entry could restore GDN
@@ -320,12 +314,9 @@ the fallback path alone, and a dedicated Criterion bench,
 
 ## Summary
 
-- The cache is reachable today through direct `MetalQwen35State` calls, `chat_metal`, and
-  `lattice_serve` (sticky `CrossTurnSlotId::DEFAULT` slot, honest full-refill fallback on any
-  mismatch). `lattice serve` (the OpenAI-compatible HTTP server in `lattice.rs`) does not call the
-  cache-aware methods yet — every request through it still re-prefills its entire conversation
-  history from scratch, a known and already-documented gap (README, issue #462) tracked as
-  follow-up work, not something this document is newly discovering.
+- The cache is reachable today through direct `MetalQwen35State` calls, `chat_metal`,
+  `lattice_serve`, and `lattice serve` (the OpenAI-compatible HTTP server in `lattice.rs`) — all on
+  a sticky `CrossTurnSlotId::DEFAULT` slot, with honest full-refill fallback on any mismatch.
 - Use `CrossTurnSlotId::DEFAULT` for a single local conversation; only one entry is ever retained
   process-wide, so multiplexing several conversations through distinct slot IDs on one
   `MetalQwen35State` does not give each of them independent caching — the most recent one wins and


### PR DESCRIPTION
## Summary

Wires the cross-turn KV prefix cache into `lattice serve`'s Metal worker
(`crates/inference/src/bin/lattice.rs`, `MetalHandle::spawn`'s job loop). This
was the last unwired serve surface for #462 — the standalone `lattice_serve`
binary was already wired in #662.

The worker's single call site now calls `generate_streaming_with_prefix_cache`
with `CrossTurnSlotId::DEFAULT` instead of the plain, non-cache-aware
`generate_streaming` on every request:

```rust
let cached = state.generate_streaming_with_prefix_cache(
    lattice_inference::kv_cache::CrossTurnSlotId::DEFAULT,
    &job.prompt,
    &tokenizer,
    &job.gen_cfg,
    |delta, _token_id| on_token(delta),
);
if let Ok(c) = &cached {
    eprintln!(
        "[lattice serve] cross-turn cache: mode={:?} reused={} prefetched={} prompt={}",
        c.cache.mode, c.cache.reused_tokens, c.cache.prefetched_tokens, c.cache.prompt_tokens,
    );
}
let _ = job.reply.send(cached.map(|c| c.output));
```

This worker thread owns one `MetalQwen35State` for the whole process
lifetime (one thread = one session), so the sticky `DEFAULT` slot is the only
slot that exists; the planner re-verifies the retained prefix against every
request's prompt and falls back to `PrefixReuseMode::FullRefill` whenever it
diverges (new conversation, edited history, or an unrelated request
interleaved on the same slot), so correctness never depends on distinguishing
clients — a losing turn just forfeits the reuse speedup, it can never corrupt
output.

`MetalJob.reply`'s contract is unchanged (`Result<GenerateOutput, _>`); cache
stats go to stderr only, matching `lattice_serve`'s existing telemetry. This
path has no client-disconnect cancellation today (unlike `lattice_serve`'s
`_and_cancel` variant), so it uses the plain `generate_streaming_with_prefix_cache`
wrapper rather than forcing a misleading `|| false` through the cancel-aware
entry point. Adding cancellation plumbing to this worker is separate,
out-of-scope work.

Also updates `docs/cross-turn-cache.md` and `README.md`, both of which still
described `lattice serve`'s HTTP path as unconditionally re-prefilling the
whole conversation on every turn.

## Why this matters

Turn-N prefill for an unchanged conversation prefix drops from O(total
conversation length) to O(new tokens) instead of re-running the full
GQA+GDN prefill from scratch on every request — the entire point of #462.
A full `make bench-compare` won't observe this (it doesn't exercise a
multi-turn HTTP conversation), and the dedicated Criterion bench added
alongside the `lattice_serve` wiring (#662) already measures the underlying
engine call this wiring routes through: cache-aware turn cost stays roughly
flat as prior-turn count grows, versus a full re-prefill's cost growing with
total conversation length.

## Test coverage — and a gap worth flagging

I did not add a new regression test at this call site. Two reasons:

1. **No CPU-testable seam exists for `MetalHandle`.** Unlike
   `lattice_serve.rs`'s worker (which factors the job-processing loop into a
   standalone `run_worker_loop` taking an injected `generate` closure for
   GPU-free cancellation tests), `lattice.rs`'s `MetalHandle::spawn` loads the
   real Q4 model and runs the job loop inline on one dedicated thread, with
   no injectable seam. Even `lattice_serve.rs`'s own injected-closure signature
   returns only `(prompt_tokens, completion_tokens)`, discarding cache stats
   entirely — so it couldn't assert a reuse plan either.
2. **Precedent**: the immediately-preceding, already-merged sibling PR (#662,
   wiring the identical call into `lattice_serve.rs`) added zero new
   call-site-level test for this reason, relying entirely on the engine-level
   reuse-plan tests already in `crates/inference/src/forward/metal_qwen35.rs`
   (which exhaustively cover `generate_streaming_with_prefix_cache` /
   `_and_cancel` — the exact same function this wiring calls, unchanged) plus
   `e2e-parity.yml`'s token-parity gate for correctness of the overall path.

Building a device-gated integration test through `MetalHandle` itself would
need a real Q4 checkpoint directory (`MetalHandle::spawn` only takes
`from_q4_dir`, not a raw-weights constructor), which isn't available as a
fast fixture; a test that instead drives `MetalQwen35State` directly with a
duplicated tiny fixture would just re-test engine logic already covered
elsewhere, not the wiring itself. I'm flagging this explicitly per Π_TBV
rather than silently skipping it — happy to add a device-gated test if a
reviewer wants one despite the precedent.

## Verification

- `cargo clippy -p lattice-inference --features metal-gpu -- -D warnings` — clean
- `cargo clippy -p lattice-inference --bin lattice -- -D warnings` (default features) — clean
- `cargo test -p lattice-inference --bin lattice` — 123 passed, 0 failed (non-GPU suite; unaffected by this change since it's behind `#[cfg(feature = "metal-gpu")]`)
- `cargo test -p lattice-inference --bin lattice --features metal-gpu --no-run` — compiles clean
- Did **not** run any Metal device tests locally (GPU contended by other work); left device-test execution to CI's feature-matrix / `e2e-parity.yml`.

Cross-refs: #462, #662, #552 (deferred cancellation plumbing), #661 (deferred renderer unification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)