### PR TITLE
perf(inference): fused batched BERT encode (ADR-070)

### DIFF
--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -343,6 +343,259 @@ pub(crate) fn multi_head_attention_in_place(
     }
 }
 
+/// Fused batched multi-head attention for a padded `[batch, seq_len]` tensor.
+///
+/// This is the batch analogue of [`multi_head_attention_in_place`]: it fuses the
+/// position-wise Q/K/V and output projections into single `matmul_bt` calls over
+/// all `batch * seq_len` rows (bigger GEMMs, fewer BLAS/SIMD dispatches), while the
+/// O(seq_len^2) score/softmax/context step -- which cannot be flattened across
+/// sequences without letting one sequence's tokens attend across a padding boundary
+/// into another sequence -- runs per-sequence, serially.
+///
+/// This loop is deliberately **not** parallelized with rayon/std::thread, even
+/// though each sequence's slice is independent. On macOS, `matmul_bt` dispatches to
+/// Apple Accelerate (`forward/cpu/blas.rs`), which already runs GEMM across its own
+/// multi-threaded AMX worker pool -- including at small M. Wrapping this per-sequence
+/// loop in an outer parallel iterator nests a second thread pool on top of that one:
+/// measured A/B on this crate's own bench harness, batch=64, all-MiniLM-L6-v2, showed
+/// the rayon-parallel version at ~870-900 texts/s versus ~1225-1370 texts/s serial --
+/// oversubscription made it slower, not faster, confirming the fused GEMM calls
+/// (bigger M) are the actual lever, not manual threading on top of them. Only the
+/// non-Accelerate fallback kernels (non-macOS, or the hand-rolled SIMD path) and
+/// non-GEMM position-wise ops would be candidates for added threading, and only if a
+/// fresh A/B on that specific backend shows a win -- do not assume this decision
+/// carries over to a different dispatch path without re-measuring.
+///
+/// `hidden_states`/`attention_mask` are the flattened `[batch * seq_len, ...]`
+/// tensors (row `b * seq_len + i` is token `i` of sequence `b`). `output` receives
+/// the same output-projection result that `multi_head_attention_in_place` writes
+/// into `buffers.temp` (bias-added, LoRA-applied); callers add the residual and run
+/// `layer_norm` themselves, exactly as the single-sequence path does.
+///
+/// All existing masking/softmax fail-closed guards from `multi_head_attention_in_place`
+/// (structural `-inf` masking, `softmax_attention`'s all-masked-row zero guard) are
+/// preserved verbatim per sequence -- see that function's comments for the rationale.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn multi_head_attention_batched(
+    hidden_states: &[f32],
+    layer_weights: &TransformerLayerWeights<'_>,
+    attention_mask: &[u32],
+    batch: usize,
+    seq_len: usize,
+    hidden_size: usize,
+    num_heads: usize,
+    head_dim: usize,
+    q: &mut [f32],
+    k: &mut [f32],
+    v: &mut [f32],
+    concat: &mut [f32],
+    output: &mut [f32],
+    lora: &dyn LoraHook,
+    layer_idx: usize,
+) {
+    assert_standard_no_overflow(seq_len, hidden_size, num_heads, head_dim);
+    assert!(
+        batch.checked_mul(seq_len).is_some(),
+        "standard: batch * seq_len overflow"
+    );
+    let rows = batch * seq_len;
+    assert!(
+        rows.checked_mul(hidden_size).is_some(),
+        "standard: rows * hidden_size overflow"
+    );
+    let used_hidden = rows * hidden_size;
+    assert_eq!(
+        hidden_states.len(),
+        used_hidden,
+        "standard: hidden_states length must equal batch * seq_len * hidden_size"
+    );
+    assert_eq!(
+        attention_mask.len(),
+        rows,
+        "standard: attention_mask length must equal batch * seq_len"
+    );
+    assert!(q.len() >= used_hidden, "standard: q scratch too small");
+    assert!(k.len() >= used_hidden, "standard: k scratch too small");
+    assert!(v.len() >= used_hidden, "standard: v scratch too small");
+    assert!(
+        concat.len() >= used_hidden,
+        "standard: concat scratch too small"
+    );
+    assert!(
+        output.len() >= used_hidden,
+        "standard: output scratch too small"
+    );
+
+    // Fused Q/K/V projection: one matmul_bt call per projection across every
+    // row in the batch, instead of `batch` separate single-sequence calls.
+    {
+        let q = &mut q[..used_hidden];
+        matmul_bt(
+            hidden_states,
+            layer_weights.query_weight.data,
+            q,
+            rows,
+            hidden_size,
+            hidden_size,
+        );
+        add_bias(q, layer_weights.query_bias.data, hidden_size);
+        lora.apply(layer_idx, "query", hidden_states, q);
+    }
+    {
+        let k = &mut k[..used_hidden];
+        matmul_bt(
+            hidden_states,
+            layer_weights.key_weight.data,
+            k,
+            rows,
+            hidden_size,
+            hidden_size,
+        );
+        add_bias(k, layer_weights.key_bias.data, hidden_size);
+        lora.apply(layer_idx, "key", hidden_states, k);
+    }
+    {
+        let v = &mut v[..used_hidden];
+        matmul_bt(
+            hidden_states,
+            layer_weights.value_weight.data,
+            v,
+            rows,
+            hidden_size,
+            hidden_size,
+        );
+        add_bias(v, layer_weights.value_bias.data, hidden_size);
+        lora.apply(layer_idx, "value", hidden_states, v);
+    }
+
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let q = &q[..used_hidden];
+    let k = &k[..used_hidden];
+    let v = &v[..used_hidden];
+    let concat = &mut concat[..used_hidden];
+
+    // Per-sequence score/softmax/context. Each chunk of `concat` (one sequence's
+    // [seq_len, hidden_size] region) is written by exactly one task, so this is a
+    // safe disjoint-mutation parallel loop; the shared `q`/`k`/`v`/`attention_mask`
+    // are read-only from every task's perspective.
+    concat
+        .chunks_mut(seq_len * hidden_size)
+        .enumerate()
+        .for_each(|(b, concat_b)| {
+            let seq_offset = b * seq_len;
+            let row_start = seq_offset * hidden_size;
+            let mask_b = &attention_mask[seq_offset..seq_offset + seq_len];
+
+            let mut q_head = vec![0.0f32; seq_len * head_dim];
+            let mut k_head = vec![0.0f32; seq_len * head_dim];
+            let mut v_head_t = vec![0.0f32; head_dim * seq_len];
+            let mut scores_head = vec![0.0f32; seq_len * seq_len];
+            let mut scores = vec![0.0f32; num_heads * seq_len * seq_len];
+            let mut context_head = vec![0.0f32; seq_len * head_dim];
+            let mut context = vec![0.0f32; num_heads * seq_len * head_dim];
+
+            // Q*K^T via SIMD matmul_bt, one head at a time (mirrors
+            // multi_head_attention_in_place's single-sequence loop exactly).
+            for h in 0..num_heads {
+                let head_offset = h * head_dim;
+
+                for i in 0..seq_len {
+                    let src_start = row_start + i * hidden_size + head_offset;
+                    let dst_start = i * head_dim;
+                    q_head[dst_start..dst_start + head_dim]
+                        .copy_from_slice(&q[src_start..src_start + head_dim]);
+                }
+                for i in 0..seq_len {
+                    let src_start = row_start + i * hidden_size + head_offset;
+                    let dst_start = i * head_dim;
+                    k_head[dst_start..dst_start + head_dim]
+                        .copy_from_slice(&k[src_start..src_start + head_dim]);
+                }
+
+                matmul_bt(
+                    &q_head[..seq_len * head_dim],
+                    &k_head[..seq_len * head_dim],
+                    &mut scores_head[..seq_len * seq_len],
+                    seq_len,
+                    head_dim,
+                    seq_len,
+                );
+
+                let scores_offset = h * seq_len * seq_len;
+                for (idx, &score) in scores_head.iter().enumerate() {
+                    scores[scores_offset + idx] = score * scale;
+                }
+            }
+
+            // Structural -inf masking + fail-closed softmax -- identical to
+            // multi_head_attention_in_place; see its comment for the #361 rationale.
+            for h in 0..num_heads {
+                for i in 0..seq_len {
+                    let row_off = (h * seq_len + i) * seq_len;
+                    let row = &mut scores[row_off..row_off + seq_len];
+                    for j in 0..seq_len {
+                        if mask_b[j] == 0 {
+                            row[j] = f32::NEG_INFINITY;
+                        }
+                    }
+                }
+            }
+            softmax_attention(&mut scores, seq_len, num_heads);
+
+            // scores*V context aggregation, one head at a time.
+            for h in 0..num_heads {
+                let head_offset = h * head_dim;
+
+                for i in 0..seq_len {
+                    let v_row_start = row_start + i * hidden_size + head_offset;
+                    for d in 0..head_dim {
+                        v_head_t[d * seq_len + i] = v[v_row_start + d];
+                    }
+                }
+
+                let scores_offset = h * seq_len * seq_len;
+                let scores_head = &scores[scores_offset..scores_offset + seq_len * seq_len];
+                matmul_bt(
+                    scores_head,
+                    &v_head_t[..head_dim * seq_len],
+                    &mut context_head[..seq_len * head_dim],
+                    seq_len,
+                    seq_len,
+                    head_dim,
+                );
+
+                let ctx_offset = h * seq_len * head_dim;
+                context[ctx_offset..ctx_offset + seq_len * head_dim]
+                    .copy_from_slice(&context_head[..seq_len * head_dim]);
+            }
+
+            // Concat heads back into this sequence's [seq_len, hidden_size] region.
+            for i in 0..seq_len {
+                for h in 0..num_heads {
+                    let head_offset = h * head_dim;
+                    for d in 0..head_dim {
+                        concat_b[i * hidden_size + head_offset + d] =
+                            context[(h * seq_len + i) * head_dim + d];
+                    }
+                }
+            }
+        });
+
+    // Fused output projection: one matmul_bt call across every row in the batch.
+    let concat = &concat[..used_hidden];
+    let output = &mut output[..used_hidden];
+    matmul_bt(
+        concat,
+        layer_weights.attn_output_weight.data,
+        output,
+        rows,
+        hidden_size,
+        hidden_size,
+    );
+    add_bias(output, layer_weights.attn_output_bias.data, hidden_size);
+    lora.apply(layer_idx, "attn_output", concat, output);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -474,10 +474,10 @@ pub(crate) fn multi_head_attention_batched(
     let v = &v[..used_hidden];
     let concat = &mut concat[..used_hidden];
 
-    // Per-sequence score/softmax/context. Each chunk of `concat` (one sequence's
-    // [seq_len, hidden_size] region) is written by exactly one task, so this is a
-    // safe disjoint-mutation parallel loop; the shared `q`/`k`/`v`/`attention_mask`
-    // are read-only from every task's perspective.
+    // Per-sequence score/softmax/context. This loop runs serially, one sequence
+    // at a time; each chunk of `concat` (one sequence's [seq_len, hidden_size]
+    // region) is written by exactly one iteration, over disjoint slices of the
+    // shared read-only `q`/`k`/`v`/`attention_mask` buffers.
     concat
         .chunks_mut(seq_len * hidden_size)
         .enumerate()
@@ -1035,5 +1035,213 @@ mod tests {
         // product fits, but num_heads * seq_len * seq_len = 2^65 wraps a 64-bit
         // usize to a small value that would feed an undersized scores slice.
         assert_standard_no_overflow(1usize << 32, 2, 2, 1);
+    }
+
+    /// Weights-free parity check between `multi_head_attention_batched` and the
+    /// single-sequence `multi_head_attention` path, run over synthetic (no model
+    /// file) inputs so it exercises in default CI.
+    ///
+    /// Builds two sequences of different real length (2 tokens and 3 tokens)
+    /// padded to a common `seq_len` of 3. The padded slot in the shorter sequence
+    /// carries a huge-magnitude value and is masked out (`mask=0`); if masking or
+    /// the per-sequence row stride (`seq_offset`/`row_start`) were wrong, that
+    /// value would leak into the real tokens' output or the wrong sequence's
+    /// slice would be compared, and the parity check below would fail.
+    ///
+    /// Mutation-checked by hand while writing this test: (1) forcing the mask
+    /// passed into `multi_head_attention_batched` to all-ones (so the padded,
+    /// huge-magnitude slot is treated as a valid key) made this test fail; (2)
+    /// corrupting `row_start`'s stride (multiplying by an extra `+1` offset in
+    /// the per-sequence loop) also made it fail; both were reverted and the test
+    /// re-confirmed passing before landing.
+    #[test]
+    fn batched_attention_matches_single_sequence_per_row_with_padding() {
+        let hidden_size = 8;
+        let num_heads = 2;
+        let head_dim = 4;
+        let seq_len = 3; // common padded length
+        let batch = 2;
+        let intermediate_size = hidden_size;
+
+        let identity_8x8: Vec<f32> = {
+            let mut m = vec![0.0f32; hidden_size * hidden_size];
+            for i in 0..hidden_size {
+                m[i * hidden_size + i] = 1.0;
+            }
+            m
+        };
+        let zero_bias_8: Vec<f32> = vec![0.0; hidden_size];
+        let ones_8: Vec<f32> = vec![1.0; hidden_size];
+
+        let layer = TransformerLayerWeights {
+            query_weight: Tensor2D {
+                data: &identity_8x8,
+                rows: hidden_size,
+                cols: hidden_size,
+            },
+            query_bias: Tensor1D {
+                data: &zero_bias_8,
+                len: hidden_size,
+            },
+            key_weight: Tensor2D {
+                data: &identity_8x8,
+                rows: hidden_size,
+                cols: hidden_size,
+            },
+            key_bias: Tensor1D {
+                data: &zero_bias_8,
+                len: hidden_size,
+            },
+            value_weight: Tensor2D {
+                data: &identity_8x8,
+                rows: hidden_size,
+                cols: hidden_size,
+            },
+            value_bias: Tensor1D {
+                data: &zero_bias_8,
+                len: hidden_size,
+            },
+            attn_output_weight: Tensor2D {
+                data: &identity_8x8,
+                rows: hidden_size,
+                cols: hidden_size,
+            },
+            attn_output_bias: Tensor1D {
+                data: &zero_bias_8,
+                len: hidden_size,
+            },
+            attn_layer_norm_weight: Tensor1D {
+                data: &ones_8,
+                len: hidden_size,
+            },
+            attn_layer_norm_bias: Tensor1D {
+                data: &zero_bias_8,
+                len: hidden_size,
+            },
+            ffn_intermediate_weight: Tensor2D {
+                data: &identity_8x8,
+                rows: intermediate_size,
+                cols: hidden_size,
+            },
+            ffn_intermediate_bias: Tensor1D {
+                data: &zero_bias_8,
+                len: intermediate_size,
+            },
+            ffn_output_weight: Tensor2D {
+                data: &identity_8x8,
+                rows: intermediate_size,
+                cols: hidden_size,
+            },
+            ffn_output_bias: Tensor1D {
+                data: &zero_bias_8,
+                len: hidden_size,
+            },
+            ffn_layer_norm_weight: Tensor1D {
+                data: &ones_8,
+                len: hidden_size,
+            },
+            ffn_layer_norm_bias: Tensor1D {
+                data: &zero_bias_8,
+                len: hidden_size,
+            },
+        };
+
+        // Sequence 0: 2 real tokens, deterministic small values.
+        let seq0_real: Vec<f32> = (0..2 * hidden_size).map(|i| 1.0 + i as f32 * 0.1).collect();
+        // Padded slot for sequence 0: huge magnitude, must never leak once masked.
+        let seq0_pad: Vec<f32> = vec![1.0e6; hidden_size];
+
+        // Sequence 1: 3 real tokens (fills seq_len exactly, no padding needed),
+        // deterministic small values distinct from sequence 0.
+        let seq1_real: Vec<f32> = (0..3 * hidden_size)
+            .map(|i| 100.0 + i as f32 * 0.1)
+            .collect();
+
+        // Flattened batched input: [seq0 tok0, seq0 tok1, seq0 pad, seq1 tok0, seq1 tok1, seq1 tok2]
+        let mut hidden_states_batched = Vec::with_capacity(batch * seq_len * hidden_size);
+        hidden_states_batched.extend_from_slice(&seq0_real);
+        hidden_states_batched.extend_from_slice(&seq0_pad);
+        hidden_states_batched.extend_from_slice(&seq1_real);
+        assert_eq!(hidden_states_batched.len(), batch * seq_len * hidden_size);
+
+        let attention_mask_batched: Vec<u32> = vec![1, 1, 0, 1, 1, 1];
+
+        let rows = batch * seq_len;
+        let used_hidden = rows * hidden_size;
+        let mut q = vec![0.0f32; used_hidden];
+        let mut k = vec![0.0f32; used_hidden];
+        let mut v = vec![0.0f32; used_hidden];
+        let mut concat = vec![0.0f32; used_hidden];
+        let mut output = vec![0.0f32; used_hidden];
+
+        multi_head_attention_batched(
+            &hidden_states_batched,
+            &layer,
+            &attention_mask_batched,
+            batch,
+            seq_len,
+            hidden_size,
+            num_heads,
+            head_dim,
+            &mut q,
+            &mut k,
+            &mut v,
+            &mut concat,
+            &mut output,
+            &NoopLoraHook,
+            0,
+        );
+
+        for v in output.iter() {
+            assert!(v.is_finite(), "batched output must be finite: {output:?}");
+        }
+
+        // Sequence 0: compare the first 2 (real) rows of the batched output
+        // against an independent single-sequence call on the 2 unpadded tokens.
+        let mut buf0 = AttentionBuffers::new(2, hidden_size, num_heads, intermediate_size);
+        let expected0 = multi_head_attention(
+            &seq0_real,
+            &layer,
+            &[1u32, 1],
+            2,
+            hidden_size,
+            num_heads,
+            head_dim,
+            &mut buf0,
+            &NoopLoraHook,
+            0,
+        );
+        let seq0_row_start = 0;
+        let got0 = &output[seq0_row_start..seq0_row_start + 2 * hidden_size];
+        for (i, (&g, &e)) in got0.iter().zip(expected0.iter()).enumerate() {
+            assert!(
+                (g - e).abs() <= 1e-6,
+                "seq0 row element {i} mismatch: batched={g} single={e}"
+            );
+        }
+
+        // Sequence 1: compare all 3 (real) rows of the batched output against an
+        // independent single-sequence call on the same 3 tokens.
+        let mut buf1 = AttentionBuffers::new(3, hidden_size, num_heads, intermediate_size);
+        let expected1 = multi_head_attention(
+            &seq1_real,
+            &layer,
+            &[1u32, 1, 1],
+            3,
+            hidden_size,
+            num_heads,
+            head_dim,
+            &mut buf1,
+            &NoopLoraHook,
+            0,
+        );
+        let seq1_row_start = seq_len * hidden_size;
+        let got1 = &output[seq1_row_start..seq1_row_start + 3 * hidden_size];
+        for (i, (&g, &e)) in got1.iter().zip(expected1.iter()).enumerate() {
+            assert!(
+                (g - e).abs() <= 1e-6,
+                "seq1 row element {i} mismatch: batched={g} single={e}"
+            );
+        }
     }
 }

--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -4,7 +4,9 @@
 //! boxed `dyn Tokenizer`, allowing WordPiece, BPE, and SentencePiece tokenizers
 //! to share a single inference path.
 
-use crate::attention::{AttentionBuffers, multi_head_attention_in_place};
+use crate::attention::{
+    AttentionBuffers, multi_head_attention_batched, multi_head_attention_in_place,
+};
 use crate::download::ensure_model_files;
 use crate::error::InferenceError;
 use crate::forward::cpu::{add_bias, gelu, layer_norm, matmul_bt};
@@ -233,36 +235,71 @@ impl BertModel {
     }
 
     /// **Stable**: batch-encode entry point; consumed by `lattice-embed`.
-    /// The sequential implementation detail may change without API breakage.
+    ///
+    /// Runs a single fused batched forward pass over all texts: the position-wise
+    /// stages (embedding lookup, Q/K/V projection, FFN, output projection) are each
+    /// one `matmul_bt`/`layer_norm` call over every `batch * seq_len` row, instead of
+    /// `batch` separate single-sequence forward passes. Only the O(seq_len^2)
+    /// attention score/context step loops per sequence (see
+    /// [`crate::attention::multi_head_attention_batched`]), and that loop runs in
+    /// parallel across sequences. The implementation detail may change without API
+    /// breakage.
     pub fn encode_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, InferenceError> {
         if texts.is_empty() {
             return Ok(Vec::new());
         }
+        if texts.len() == 1 {
+            // Single item: the batched path's flatten/scratch-allocation overhead
+            // buys nothing over the plain single-sequence path.
+            return Ok(vec![self.encode(texts[0])?]);
+        }
 
         let tokenized = self.tokenizer.tokenize_batch(texts);
-        let max_seq_len = tokenized
+        let batch = tokenized.len();
+        let hidden_size = self.config.hidden_size;
+
+        // `Tokenizer::tokenize_batch`'s documented contract is "pad to batch-local
+        // max," but that padding is produced by each tokenizer implementation
+        // independently (WordPiece/BPE/SentencePiece). Re-pad defensively here to
+        // one shared `seq_len` rather than trusting every implementation to agree,
+        // so a future tokenizer that pads inconsistently fails safe (extra zero
+        // rows, masked out) instead of producing a misaligned flat batch tensor.
+        let seq_len = tokenized
             .iter()
-            .map(|input| input.real_length)
+            .map(|input| input.input_ids.len())
             .max()
-            .unwrap_or(2);
-        let mut buffers = AttentionBuffers::new(
-            max_seq_len,
-            self.config.hidden_size,
-            self.config.num_attention_heads,
-            self.config.intermediate_size,
+            .unwrap_or(2)
+            .max(1);
+
+        let rows = batch * seq_len;
+        let mut input_ids = Vec::with_capacity(rows);
+        let mut attention_mask = Vec::with_capacity(rows);
+        let mut token_type_ids = Vec::with_capacity(rows);
+        for input in &tokenized {
+            let real = input.input_ids.len();
+            input_ids.extend_from_slice(&input.input_ids);
+            input_ids.extend(std::iter::repeat_n(0u32, seq_len - real));
+            attention_mask.extend_from_slice(&input.attention_mask);
+            attention_mask.extend(std::iter::repeat_n(0u32, seq_len - real));
+            token_type_ids.extend_from_slice(&input.token_type_ids);
+            token_type_ids.extend(std::iter::repeat_n(0u32, seq_len - real));
+        }
+
+        let hidden = self.forward_batch(
+            &input_ids,
+            &attention_mask,
+            &token_type_ids,
+            batch,
+            seq_len,
+            &NoopLoraHook,
         );
 
-        let mut outputs = Vec::with_capacity(tokenized.len());
-        for input in &tokenized {
-            let seq_len = input.real_length;
-            let hidden_states = self.forward(
-                &input.input_ids[..seq_len],
-                &input.attention_mask[..seq_len],
-                &input.token_type_ids[..seq_len],
-                seq_len,
-                &mut buffers,
-            );
-            let mut pooled = self.pool(&hidden_states, &input.attention_mask[..seq_len], seq_len);
+        let mut outputs = Vec::with_capacity(batch);
+        for b in 0..batch {
+            let off = b * seq_len * hidden_size;
+            let hidden_b = &hidden[off..off + seq_len * hidden_size];
+            let mask_b = &attention_mask[b * seq_len..(b + 1) * seq_len];
+            let mut pooled = self.pool(hidden_b, mask_b, seq_len);
             l2_normalize(&mut pooled);
             outputs.push(pooled);
         }
@@ -463,6 +500,202 @@ impl BertModel {
 
         hidden
     }
+
+    /// Fused batched forward pass over `[batch, seq_len]` flattened, padded input.
+    ///
+    /// `input_ids`/`attention_mask`/`token_type_ids` are flat `batch * seq_len`
+    /// arrays (row `b * seq_len + i` is token `i` of sequence `b`); every sequence
+    /// must already be padded to the same `seq_len` (right-padded, so position 0 is
+    /// always the real leading token -- required by `cls_pool`). Returns a flat
+    /// `[batch * seq_len, hidden_size]` hidden-state tensor; callers slice out each
+    /// sequence's `[seq_len, hidden_size]` region and pool it individually with that
+    /// sequence's own mask.
+    ///
+    /// This is a new function, not a modification of [`Self::forward`]/
+    /// [`Self::forward_with_hook`] -- `encode()` and `forward_tokenized` (used by
+    /// `CrossEncoderModel`) are untouched and keep their existing single-sequence
+    /// behavior and performance.
+    fn forward_batch(
+        &self,
+        input_ids: &[u32],
+        attention_mask: &[u32],
+        token_type_ids: &[u32],
+        batch: usize,
+        padded_seq_len: usize,
+        lora: &dyn LoraHook,
+    ) -> Vec<f32> {
+        let hidden_size = self.config.hidden_size;
+        let intermediate_size = self.config.intermediate_size;
+        let num_heads = self.config.num_attention_heads;
+        let head_dim = self.config.head_dim();
+
+        debug_assert_eq!(input_ids.len(), batch * padded_seq_len);
+        debug_assert_eq!(attention_mask.len(), batch * padded_seq_len);
+        debug_assert_eq!(token_type_ids.len(), batch * padded_seq_len);
+
+        // Clamp exactly as the single-sequence path does (forward_with_hook), so a
+        // batch item longer than the model's position table degrades the same way
+        // encode()/encode_batch always have: excess trailing tokens are silently
+        // dropped from the forward pass (their embedding lookup and attention
+        // participation), not just truncated at the caller boundary. `padded_seq_len`
+        // remains the stride into the flat `input_ids`/`attention_mask` arrays;
+        // `seq_len` (post-clamp) is the number of positions actually computed.
+        let seq_len = padded_seq_len.min(self.config.max_position_embeddings);
+        let rows = batch * seq_len;
+
+        let used_hidden = rows * hidden_size;
+        let used_intermediate = rows * intermediate_size;
+
+        let mut hidden = vec![0.0f32; used_hidden];
+
+        // Embedding lookup: position id resets to `i` (the in-sequence index) for
+        // every sequence `b` -- the one correctness-critical detail of flattening a
+        // batch across this loop. Getting this wrong (using the flat row index
+        // instead) would give every sequence after the first wrong position
+        // embeddings.
+        for b in 0..batch {
+            let src_offset = b * padded_seq_len;
+            let dst_offset = b * seq_len;
+            for i in 0..seq_len {
+                let src_row = src_offset + i;
+                let dst_row = dst_offset + i;
+                let tok_id = input_ids[src_row] as usize;
+                let typ_id = token_type_ids[src_row] as usize;
+                let pos_id = i;
+
+                debug_assert!(tok_id < self.weights.word_embeddings.rows);
+                debug_assert!(typ_id < self.weights.token_type_embeddings.rows);
+                debug_assert!(pos_id < self.weights.position_embeddings.rows);
+
+                let tok_row = &self.weights.word_embeddings.data
+                    [tok_id * hidden_size..(tok_id + 1) * hidden_size];
+                let pos_row = &self.weights.position_embeddings.data
+                    [pos_id * hidden_size..(pos_id + 1) * hidden_size];
+                let typ_row = &self.weights.token_type_embeddings.data
+                    [typ_id * hidden_size..(typ_id + 1) * hidden_size];
+                let out_row = &mut hidden[dst_row * hidden_size..(dst_row + 1) * hidden_size];
+
+                for d in 0..hidden_size {
+                    out_row[d] = tok_row[d] + pos_row[d] + typ_row[d];
+                }
+            }
+        }
+
+        // Embedding LayerNorm: one call over every row in the batch -- unchanged,
+        // row-count-generic kernel (crate::forward::cpu::layer_norm).
+        layer_norm(
+            &mut hidden,
+            self.weights.embedding_layer_norm_weight.data,
+            self.weights.embedding_layer_norm_bias.data,
+            hidden_size,
+            self.config.layer_norm_eps,
+        );
+
+        // `attention_mask` is strided by `padded_seq_len`; the attention kernel
+        // below expects a `[batch * seq_len]` array strided by the (possibly
+        // clamped) `seq_len`. These are almost always equal (clamping only fires
+        // for a batch item longer than the model's position table), so avoid the
+        // copy on the common path.
+        let attention_mask_clamped: Vec<u32>;
+        let attention_mask: &[u32] = if seq_len == padded_seq_len {
+            attention_mask
+        } else {
+            attention_mask_clamped = (0..batch)
+                .flat_map(|b| {
+                    let off = b * padded_seq_len;
+                    attention_mask[off..off + seq_len].iter().copied()
+                })
+                .collect();
+            &attention_mask_clamped
+        };
+
+        let mut q = vec![0.0f32; used_hidden];
+        let mut k = vec![0.0f32; used_hidden];
+        let mut v = vec![0.0f32; used_hidden];
+        let mut concat = vec![0.0f32; used_hidden];
+        let mut attn_out = vec![0.0f32; used_hidden];
+        let mut ffn_intermediate = vec![0.0f32; used_intermediate];
+        let mut temp = vec![0.0f32; used_hidden];
+
+        for layer_idx in 0..self.config.num_hidden_layers {
+            let layer = &self.weights.layers[layer_idx];
+
+            multi_head_attention_batched(
+                &hidden,
+                layer,
+                attention_mask,
+                batch,
+                seq_len,
+                hidden_size,
+                num_heads,
+                head_dim,
+                &mut q,
+                &mut k,
+                &mut v,
+                &mut concat,
+                &mut attn_out,
+                lora,
+                layer_idx,
+            );
+
+            for i in 0..used_hidden {
+                temp[i] = attn_out[i] + hidden[i];
+            }
+            layer_norm(
+                &mut temp,
+                layer.attn_layer_norm_weight.data,
+                layer.attn_layer_norm_bias.data,
+                hidden_size,
+                self.config.layer_norm_eps,
+            );
+            hidden.copy_from_slice(&temp);
+
+            matmul_bt(
+                &hidden,
+                layer.ffn_intermediate_weight.data,
+                &mut ffn_intermediate,
+                rows,
+                hidden_size,
+                intermediate_size,
+            );
+            add_bias(
+                &mut ffn_intermediate,
+                layer.ffn_intermediate_bias.data,
+                intermediate_size,
+            );
+            lora.apply(
+                layer_idx,
+                "ffn_intermediate",
+                &hidden,
+                &mut ffn_intermediate,
+            );
+            gelu(&mut ffn_intermediate);
+
+            matmul_bt(
+                &ffn_intermediate,
+                layer.ffn_output_weight.data,
+                &mut temp,
+                rows,
+                intermediate_size,
+                hidden_size,
+            );
+            add_bias(&mut temp, layer.ffn_output_bias.data, hidden_size);
+            lora.apply(layer_idx, "ffn_output", &ffn_intermediate, &mut temp);
+            for i in 0..used_hidden {
+                temp[i] += hidden[i];
+            }
+            layer_norm(
+                &mut temp,
+                layer.ffn_layer_norm_weight.data,
+                layer.ffn_layer_norm_bias.data,
+                hidden_size,
+                self.config.layer_norm_eps,
+            );
+            hidden.copy_from_slice(&temp);
+        }
+
+        hidden
+    }
 }
 
 fn parse_config_json_if_present(path: &Path) -> Result<Option<BertConfig>, InferenceError> {
@@ -604,6 +837,115 @@ mod tests {
         assert_eq!(embedding.len(), model.dimensions());
         let norm = (embedding.iter().map(|x| x * x).sum::<f32>()).sqrt();
         assert_relative_eq!(norm, 1.0, epsilon = 1e-4);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fused batched forward parity (mutation-sensitive)
+    //
+    // Guards the `encode_batch` rewrite: the fused batched forward path
+    // (`forward_batch` + `multi_head_attention_batched`) must produce the same
+    // per-text embeddings as looping `encode()` one text at a time. This catches
+    // the two correctness traps a naive batch-flattening introduces: cross-sequence
+    // attention leakage through the padding mask, and position-id drift for any
+    // sequence after the first (see forward_batch's embedding-lookup comment).
+    //
+    // Reverting `encode_batch` to loop per-item (or breaking the position-id /
+    // mask plumbing in `forward_batch`/`multi_head_attention_batched`) must make
+    // these tests fail, not just the CI bench numbers regress.
+    // -------------------------------------------------------------------------
+
+    fn cosine(a: &[f32], b: &[f32]) -> f32 {
+        let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+        let na = (a.iter().map(|x| x * x).sum::<f32>()).sqrt();
+        let nb = (b.iter().map(|x| x * x).sum::<f32>()).sqrt();
+        if na == 0.0 || nb == 0.0 {
+            return 0.0;
+        }
+        dot / (na * nb)
+    }
+
+    #[test]
+    #[ignore]
+    fn test_encode_batch_matches_per_item_encode_mixed_lengths() {
+        let Ok(model_dir) = std::env::var("LATTICE_INFERENCE_MODEL_DIR") else {
+            return;
+        };
+        let model = BertModel::from_directory(Path::new(&model_dir)).unwrap();
+
+        // Mixed lengths (short to long) force real padding across the batch.
+        let short = "hi";
+        let medium = "the quick brown fox jumps over the lazy dog";
+        let long_text = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod \
+            tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam quis \
+            nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis \
+            aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat \
+            nulla pariatur excepteur sint occaecat cupidatat non proident sunt in culpa qui \
+            officia deserunt mollit anim id est laborum";
+        let texts: Vec<&str> = vec![
+            short,
+            medium,
+            long_text,
+            "another sentence",
+            short,
+            medium,
+            "one more",
+            long_text,
+        ];
+
+        let batched = model.encode_batch(&texts).unwrap();
+        assert_eq!(batched.len(), texts.len());
+
+        for (i, text) in texts.iter().enumerate() {
+            let solo = model.encode(text).unwrap();
+            let cos = cosine(&batched[i], &solo);
+            let max_abs_diff = batched[i]
+                .iter()
+                .zip(solo.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0f32, f32::max);
+            assert!(
+                cos >= 0.99999,
+                "text[{i}] ({text:?}...): batched vs solo cosine {cos} < 0.99999"
+            );
+            assert!(
+                max_abs_diff <= 1e-4,
+                "text[{i}] ({text:?}...): max-abs-diff {max_abs_diff} > 1e-4"
+            );
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_encode_batch_boundary_max_and_min_length() {
+        let Ok(model_dir) = std::env::var("LATTICE_INFERENCE_MODEL_DIR") else {
+            return;
+        };
+        let model = BertModel::from_directory(Path::new(&model_dir)).unwrap();
+
+        // One sequence at exactly the model's max position length, one at length 1
+        // (single real token beyond [CLS]/[SEP] framing) -- the widest padding gap
+        // this path can produce.
+        let max_len_text = "word ".repeat(model.config().max_position_embeddings);
+        let one_token_text = "a";
+        let texts: Vec<&str> = vec![&max_len_text, one_token_text];
+
+        let batched = model.encode_batch(&texts).unwrap();
+        assert_eq!(batched.len(), 2);
+
+        for (i, text) in texts.iter().enumerate() {
+            let solo = model.encode(text).unwrap();
+            let cos = cosine(&batched[i], &solo);
+            let max_abs_diff = batched[i]
+                .iter()
+                .zip(solo.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0f32, f32::max);
+            assert!(cos >= 0.99999, "boundary text[{i}]: cosine {cos} < 0.99999");
+            assert!(
+                max_abs_diff <= 1e-4,
+                "boundary text[{i}]: max-abs-diff {max_abs_diff} > 1e-4"
+            );
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -241,9 +241,9 @@ impl BertModel {
     /// one `matmul_bt`/`layer_norm` call over every `batch * seq_len` row, instead of
     /// `batch` separate single-sequence forward passes. Only the O(seq_len^2)
     /// attention score/context step loops per sequence (see
-    /// [`crate::attention::multi_head_attention_batched`]), and that loop runs in
-    /// parallel across sequences. The implementation detail may change without API
-    /// breakage.
+    /// [`crate::attention::multi_head_attention_batched`]) are run serially, one
+    /// sequence at a time, over disjoint output slices. The implementation detail
+    /// may change without API breakage.
     pub fn encode_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, InferenceError> {
         if texts.is_empty() {
             return Ok(Vec::new());


### PR DESCRIPTION
## Summary
Implements the fused batched encode path from ADR-070 (#671). `encode_batch` becomes one fused forward across the padded batch: position-wise GEMMs (embedding, QKV, FFN, output projection) run as single big-M calls across `batch*padded_seq_len` rows; the O(seq^2) attention step loops per sequence with additive padding masking. Mean pooling divides by mask-sum length; CLS reads position 0; softmax fail-closed guards preserved unweakened. Single-item calls short-circuit to the untouched `encode()`.

An initial rayon-over-sequences variant benched slower than serial (the BLAS backend already threads its GEMMs even at small M) and was removed. No new threading, no new dependencies.

## bench-compare (same machine, back-to-back, under background load; indicative, relative signal)
| | single p50 | bs=8 | bs=32 | bs=64 |
|---|---|---|---|---|
| baseline (origin/main) | ~1.87 ms | ~440-520 texts/s | ~458-507 | ~446-486 |
| fused | ~1.85 ms | ~1240-1305 | ~1520-1590 | ~1552-1571 |
| ratio | ~1.0x | ~2.4-3.0x | ~3.0-3.5x | ~3.2-3.5x |

ADR-070's A/B bar (bs 8/32/64 materially above baseline, single-text not regressed) is met. The idle-machine ONNX-parity comparison runs before any external hot-path claim.

## Tests
- New mutation-sensitive parity tests: mixed-length batch (2-200+ tokens) vs per-item encode, cosine >= 0.99999, max-abs-diff <= 1e-4; boundary case (max-len + 1-token). Verified against real all-MiniLM weights (env-gated, `--ignored`).
- HF parity suite green; clippy `-D warnings` clean; fmt clean. No Metal path touched.

Merge is gated on ADR-070 (#671) acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)