### PR TITLE
fix(embed): add BGE query instruction for asymmetric retrieval

### DIFF
--- a/crates/embed/CONFIG.md
+++ b/crates/embed/CONFIG.md
@@ -80,7 +80,7 @@ Runtime configuration pairing a model with an optional MRL truncation dimension.
 | `max_input_tokens()`     | `usize`        | Token limit for chunking/truncation — `model.rs:200`                     |
 | `supports_output_dim()`  | `bool`         | Only Qwen3 variants — `model.rs:263`                                     |
 | `query_instruction()`    | `Option<&str>` | Query prefix for asymmetric retrieval; BGE/E5/Qwen3 `Some`, MiniLM `None` — `model.rs:227`                       |
-| `document_instruction()` | `Option<&str>` | Currently `None` for all — `model.rs:242`                                |
+| `document_instruction()` | `Option<&str>` | E5 `"passage: "`; `None` for others — `model.rs:242`                                |
 | `model_id()`             | `&str`         | HuggingFace ID — `model.rs:248`                                          |
 | `key_version()`          | `&str`         | `"v3"` for Qwen3/OpenAI, `"v1.5"` for BGE/E5 — `model.rs:272`            |
 
@@ -279,7 +279,7 @@ let config = ModelConfig::new(EmbeddingModel::TextEmbedding3Small);
 
 ## Model Query Instructions (Asymmetric Retrieval)
 
-Several models prepend an instruction to queries (but not passages) for asymmetric retrieval. The `query_instruction()` method (`model.rs:227`) returns the prefix. For Qwen3-Embedding it is:
+Several models prepend an instruction to queries for asymmetric retrieval. The `query_instruction()` method (`model.rs:227`) returns the prefix. For Qwen3-Embedding it is:
 
 ```
 "Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: "
@@ -287,4 +287,4 @@ Several models prepend an instruction to queries (but not passages) for asymmetr
 
 This is applied automatically by `NativeEmbeddingService`. BGE-v1.5 and E5 models also return a query-side prefix for asymmetric retrieval; MiniLM returns `None` (genuinely symmetric — trained with contrastive objectives on raw text).
 
-`document_instruction()` returns `None` for all models — documents are embedded as-is.
+`document_instruction()` (`model.rs:242`) returns a passage-side prefix only for E5 (`"passage: "`); it is `None` for all other models (BGE, MiniLM, Qwen3, OpenAI), which embed documents as-is.

--- a/crates/embed/CONFIG.md
+++ b/crates/embed/CONFIG.md
@@ -79,7 +79,7 @@ Runtime configuration pairing a model with an optional MRL truncation dimension.
 | `is_remote()`            | `bool`         | Only `TextEmbedding3Small` — `model.rs:186`                              |
 | `max_input_tokens()`     | `usize`        | Token limit for chunking/truncation — `model.rs:200`                     |
 | `supports_output_dim()`  | `bool`         | Only Qwen3 variants — `model.rs:263`                                     |
-| `query_instruction()`    | `Option<&str>` | Qwen3 requires instruction prefix — `model.rs:227`                       |
+| `query_instruction()`    | `Option<&str>` | Query prefix for asymmetric retrieval; BGE/E5/Qwen3 `Some`, MiniLM `None` — `model.rs:227`                       |
 | `document_instruction()` | `Option<&str>` | Currently `None` for all — `model.rs:242`                                |
 | `model_id()`             | `&str`         | HuggingFace ID — `model.rs:248`                                          |
 | `key_version()`          | `&str`         | `"v3"` for Qwen3/OpenAI, `"v1.5"` for BGE/E5 — `model.rs:272`            |
@@ -277,14 +277,14 @@ let config = ModelConfig::new(EmbeddingModel::TextEmbedding3Small);
 
 ---
 
-## Decoder-Only Model Query Instructions
+## Model Query Instructions (Asymmetric Retrieval)
 
-Qwen3 models require instruction-prefixed queries for asymmetric retrieval. The `query_instruction()` method (`model.rs:227`) returns the prefix:
+Several models prepend an instruction to queries (but not passages) for asymmetric retrieval. The `query_instruction()` method (`model.rs:227`) returns the prefix. For Qwen3-Embedding it is:
 
 ```
 "Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: "
 ```
 
-This is applied automatically by `NativeEmbeddingService`. BERT/BGE/E5 models return `None` (no prefix needed — trained with contrastive objectives on raw text).
+This is applied automatically by `NativeEmbeddingService`. BGE-v1.5 and E5 models also return a query-side prefix for asymmetric retrieval; MiniLM returns `None` (genuinely symmetric — trained with contrastive objectives on raw text).
 
 `document_instruction()` returns `None` for all models — documents are embedded as-is.

--- a/crates/embed/src/model.rs
+++ b/crates/embed/src/model.rs
@@ -240,8 +240,13 @@ impl EmbeddingModel {
     /// - **Qwen3-Embedding** models: require an instruction prompt to align the
     ///   decoder embedding space for retrieval tasks.
     ///
-    /// - **BGE / MiniLM** models: trained with contrastive objectives on raw text;
-    ///   no prefix needed.
+    /// - **BGE** models (`BgeSmallEnV15`, `BgeBaseEnV15`, `BgeLargeEnV15`): also
+    ///   asymmetric-retrieval — queries need the BGE-v1.5 retrieval instruction
+    ///   prefix, passages do not (see `document_instruction()`, which stays
+    ///   `None` for BGE). Omitting the prefix degrades retrieval quality.
+    ///
+    /// - **MiniLM** models: trained with contrastive objectives on raw text;
+    ///   genuinely symmetric, no prefix needed on either side.
     ///
     /// Returns `Some(prefix)` if the query text should be wrapped as
     /// `"{prefix}{query}"` before embedding. Returns `None` for models that
@@ -257,6 +262,14 @@ impl EmbeddingModel {
             EmbeddingModel::Qwen3Embedding0_6B | EmbeddingModel::Qwen3Embedding4B => Some(
                 "Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: ",
             ),
+            EmbeddingModel::BgeSmallEnV15
+            | EmbeddingModel::BgeBaseEnV15
+            | EmbeddingModel::BgeLargeEnV15 => {
+                // BGE-v1.5 asymmetric retrieval: queries get the documented
+                // retrieval instruction, passages stay raw text (see
+                // document_instruction()).
+                Some("Represent this sentence for searching relevant passages: ")
+            }
             _ => None,
         }
     }

--- a/crates/embed/src/service/mod.rs
+++ b/crates/embed/src/service/mod.rs
@@ -110,9 +110,9 @@ pub trait EmbeddingService: Send + Sync {
 
     /// **Stable**: embed query texts with model-specific query prompt prefix applied.
     ///
-    /// For models that use asymmetric prompts (E5, Qwen3-Embedding), this prepends the
+    /// For models that use asymmetric prompts (BGE, E5, Qwen3-Embedding), this prepends the
     /// `query_instruction()` prefix before calling the model forward.  For models with
-    /// no query prefix (BGE, MiniLM), this is equivalent to `embed()`.
+    /// no query prefix (MiniLM), this is equivalent to `embed()`.
     ///
     /// Cache keys produced by this method are distinct from those produced by
     /// `embed_passage()` and `embed()` even when the raw text is identical.

--- a/crates/embed/src/service/tests.rs
+++ b/crates/embed/src/service/tests.rs
@@ -235,6 +235,33 @@ fn test_e5_document_instruction() {
     );
 }
 
+/// BGE-v1.5 query_instruction returns the documented retrieval instruction
+/// (asymmetric retrieval — queries get the prefix, passages do not). Guards
+/// against a future over-correction that adds the prefix to the passage side.
+#[test]
+fn test_bge_query_instruction() {
+    assert_eq!(
+        EmbeddingModel::BgeSmallEnV15.query_instruction(),
+        Some("Represent this sentence for searching relevant passages: "),
+        "BGE small must return the retrieval query instruction"
+    );
+    assert_eq!(
+        EmbeddingModel::BgeBaseEnV15.query_instruction(),
+        Some("Represent this sentence for searching relevant passages: "),
+        "BGE base must return the retrieval query instruction"
+    );
+    assert_eq!(
+        EmbeddingModel::BgeLargeEnV15.query_instruction(),
+        Some("Represent this sentence for searching relevant passages: "),
+        "BGE large must return the retrieval query instruction"
+    );
+    assert_eq!(
+        EmbeddingModel::BgeSmallEnV15.document_instruction(),
+        None,
+        "BGE passages must stay unprefixed"
+    );
+}
+
 /// BGE and MiniLM models must NOT have document_instruction (they use raw text).
 #[test]
 fn test_bge_minilm_no_document_instruction() {


### PR DESCRIPTION
## Problem

BGE-v1.5 models (`bge-small/base/large-en-v1.5`) are asymmetric-retrieval models: a search query is meant to carry an instruction prefix while a passage is embedded as raw text. `EmbeddingModel::query_instruction()` already applies the correct prefix for E5 and Qwen3-Embedding, but the three BGE variants fell through to `None`, so BGE queries were embedded with no instruction. That silently degrades retrieval quality for anyone using a BGE model for search.

## Fix

Add the documented BGE-v1.5 retrieval instruction (`"Represent this sentence for searching relevant passages: "`) for `BgeSmallEnV15`, `BgeBaseEnV15`, and `BgeLargeEnV15` in `query_instruction()`. `document_instruction()` is unchanged and stays `None` for BGE, since passages take no prefix. The doc comment is updated to separate BGE (asymmetric, query-only prefix) from MiniLM (genuinely symmetric).

Scope: this closes the crate-level `EmbeddingService` gap. Threading the query-vs-passage distinction through the napi and wasm bindings is a separate follow-up.

## Tests

- New `test_bge_query_instruction` asserts the prefix for all three BGE variants and guards that BGE `document_instruction()` stays `None`.
- Verified mutation-sensitive: the test fails when the fix is reverted and passes when restored.
- `cargo test -p lattice-embed` green, `cargo clippy -p lattice-embed -- -D warnings` clean.

## Perf

Static string added to a lookup match. No hot-path or per-token impact; bench-compare not applicable.
