### PR TITLE
chore(npm): scope embedding packages under @khive-ai + make publish-npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check clippy test fmt fmt-check build clean ci publish publish-dry lint-docs bench-ci bench-gate bench-compare bench-agentic bench-agentic-quick wasm-parity
+.PHONY: check clippy test fmt fmt-check build clean ci publish publish-dry publish-npm publish-npm-dry lint-docs bench-ci bench-gate bench-compare bench-agentic bench-agentic-quick wasm-parity
 
 check:
 	cargo check --workspace
@@ -33,6 +33,13 @@ publish-dry:
 
 publish:
 	./scripts/publish.sh
+
+# npm embedding packages (@khive-ai/lattice-embed + @khive-ai/lattice-embed-wasm).
+publish-npm-dry:
+	./scripts/publish-npm.sh --dry-run
+
+publish-npm:
+	./scripts/publish-npm.sh
 
 # ADR-058: run the same CPU benches CI does, save as new baseline.
 bench-ci:

--- a/npm/lattice-embed-native/README.md
+++ b/npm/lattice-embed-native/README.md
@@ -1,10 +1,10 @@
-# @lattice-embed/native
+# @khive-ai/lattice-embed
 
 Native (napi-rs) Node.js bindings for [`lattice-embed`](../../crates/embed):
 local BERT-family text embeddings (MiniLM, BGE, E5) loaded directly from a
 model directory on disk, with no WebAssembly overhead.
 
-This is the native counterpart to [`lattice-embed-wasm`](../lattice-embed-wasm),
+This is the native counterpart to [`@khive-ai/lattice-embed-wasm`](../lattice-embed-wasm),
 which loads model weights as in-memory byte buffers instead (no local
 filesystem access, portable to any JS runtime including browsers). Use this
 package when your Node process can read model files from disk directly and
@@ -25,13 +25,13 @@ or tested. Package manager support tested: npm and pnpm.
 ## Install
 
 ```sh
-npm install @lattice-embed/native
+npm install @khive-ai/lattice-embed
 ```
 
 ## Usage
 
 ```js
-const { loadModelSync } = require('@lattice-embed/native')
+const { loadModelSync } = require('@khive-ai/lattice-embed')
 
 const model = loadModelSync({ modelPath: '/path/to/all-minilm-l6-v2' })
 console.log(model.dimension) // 384
@@ -47,7 +47,7 @@ console.log(batch.rows, batch.dimensions) // 2 384
 console.log(batch.vector(0)) // Float32Array view into batch.data
 
 // Async variants (napi AsyncTask, run off the JS event loop thread):
-const { loadModel } = require('@lattice-embed/native')
+const { loadModel } = require('@khive-ai/lattice-embed')
 const asyncModel = await loadModel({ modelPath: '/path/to/bge-small-en-v1.5' })
 const asyncVec = await asyncModel.embed('quarterly financial report')
 ```

--- a/npm/lattice-embed-native/binding.js
+++ b/npm/lattice-embed-native/binding.js
@@ -5,7 +5,7 @@ const { join } = require('node:path')
 const { execFileSync } = require('node:child_process')
 
 const BINARY_NAME = 'lattice-embed-native'
-const PACKAGE_PREFIX = '@lattice-embed/native'
+const PACKAGE_PREFIX = '@khive-ai/lattice-embed'
 const loadErrors = []
 
 function requireCandidate(candidate) {

--- a/npm/lattice-embed-native/npm/darwin-arm64/package.json
+++ b/npm/lattice-embed-native/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@lattice-embed/native-darwin-arm64",
+  "name": "@khive-ai/lattice-embed-darwin-arm64",
   "version": "0.1.0",
-  "description": "Native binary for @lattice-embed/native on darwin-arm64.",
+  "description": "Native binary for @khive-ai/lattice-embed on darwin-arm64.",
   "license": "Apache-2.0",
   "main": "lattice-embed-native.darwin-arm64.node",
   "files": [
@@ -17,7 +17,6 @@
     "node": ">=18"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   }
 }

--- a/npm/lattice-embed-native/package.json
+++ b/npm/lattice-embed-native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lattice-embed/native",
+  "name": "@khive-ai/lattice-embed",
   "version": "0.1.0",
   "description": "Native (napi-rs) Node.js bindings for lattice-embed: local BERT-family text embeddings (MiniLM, BGE) loaded directly from disk, no WASM overhead.",
   "license": "Apache-2.0",
@@ -49,13 +49,13 @@
     ]
   },
   "optionalDependencies": {
-    "@lattice-embed/native-darwin-arm64": "0.1.0",
-    "@lattice-embed/native-darwin-x64": "0.1.0",
-    "@lattice-embed/native-linux-x64-gnu": "0.1.0",
-    "@lattice-embed/native-linux-x64-musl": "0.1.0",
-    "@lattice-embed/native-linux-arm64-gnu": "0.1.0",
-    "@lattice-embed/native-linux-arm64-musl": "0.1.0",
-    "@lattice-embed/native-win32-x64-msvc": "0.1.0"
+    "@khive-ai/lattice-embed-darwin-arm64": "0.1.0",
+    "@khive-ai/lattice-embed-darwin-x64": "0.1.0",
+    "@khive-ai/lattice-embed-linux-x64-gnu": "0.1.0",
+    "@khive-ai/lattice-embed-linux-x64-musl": "0.1.0",
+    "@khive-ai/lattice-embed-linux-arm64-gnu": "0.1.0",
+    "@khive-ai/lattice-embed-linux-arm64-musl": "0.1.0",
+    "@khive-ai/lattice-embed-win32-x64-msvc": "0.1.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.2",
@@ -63,7 +63,6 @@
     "typescript": "^5.8.0"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   }
 }

--- a/npm/lattice-embed-native/scripts/assert-packlist.mjs
+++ b/npm/lattice-embed-native/scripts/assert-packlist.mjs
@@ -1,7 +1,7 @@
 // Pack-list guard: asserts the main package tarball (`npm pack --dry-run
 // --json`, piped in on stdin) contains the JS-facing surface but none of
 // the Rust build inputs or the platform-specific `.node` binary -- those
-// ship only in the per-platform `@lattice-embed/native-<target>` packages
+// ship only in the per-platform `@khive-ai/lattice-embed-<target>` packages
 // (npm/<target>/package.json), never in this package. Run via `npm run
 // packlist` (see package.json).
 import assert from 'node:assert/strict'

--- a/npm/lattice-embed-wasm/README.md
+++ b/npm/lattice-embed-wasm/README.md
@@ -1,4 +1,4 @@
-# lattice-embed-wasm
+# @khive-ai/lattice-embed-wasm
 
 Text embeddings from a pure-Rust BERT-family encoder, compiled to
 WebAssembly, wrapped in a small Node adapter that resolves a model name to
@@ -14,13 +14,13 @@ same whether the weights are already on disk or need to be fetched first.
 ## Install
 
 ```
-npm install lattice-embed-wasm
+npm install @khive-ai/lattice-embed-wasm
 ```
 
 ## Usage
 
 ```js
-import { embed, embedText, Embedder } from 'lattice-embed-wasm';
+import { embed, embedText, Embedder } from '@khive-ai/lattice-embed-wasm';
 
 // Primary form: pick a model explicitly.
 const vec = await embed('a sentence to embed', 'minilm');
@@ -118,7 +118,7 @@ variables it defines on its own side:
 
 - one that names which npm package to load as the wasm-embedding provider
   (so it can be swapped without a code change), pointing at
-  `lattice-embed-wasm`;
+  `@khive-ai/lattice-embed-wasm`;
 - one that selects which model name to pass into `embed(text, model)`.
 
 Neither variable is read by this package itself; the model name is always

--- a/npm/lattice-embed-wasm/package.json
+++ b/npm/lattice-embed-wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lattice-embed-wasm",
+  "name": "@khive-ai/lattice-embed-wasm",
   "version": "0.1.0",
   "description": "Pure-Rust BERT-family text embeddings compiled to WebAssembly, with a small Node adapter for model resolution, caching, and pooling.",
   "type": "module",
@@ -43,5 +43,8 @@
     "vector-search",
     "rust"
   ],
-  "dependencies": {}
+  "dependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -8,24 +8,35 @@ set -e
 # Mirrors scripts/publish.sh (crates.io) in style: --dry-run support, ordered
 # tiers, fail-closed on a missing artifact.
 #
+# Immutability: npm name@version tuples cannot be republished. A real publish
+# that fails partway therefore leaves an unrepublishable partial release, so
+# this script dry-runs the WHOLE release first and only starts real publishes
+# once every package packs and every gate (native prepublishOnly test) passes.
+# A mid-flight network failure during the real pass still requires a manual
+# version bump — npm has no atomic multi-package publish — but every
+# deterministic failure is caught before the first upload.
+#
 # Provenance: each package's publishConfig sets access=public. Sigstore
-# provenance requires a supported CI with OIDC (e.g. GitHub Actions), so it is
-# NOT baked into publishConfig (that would hard-fail a local publish). This
-# script adds --provenance only when running under CI; a local/manual publish
-# runs without it.
+# provenance requires an OIDC-capable publish environment (e.g. GitHub Actions
+# with `id-token: write`), which a generic `$CI` does not guarantee, so it is
+# gated behind an explicit NPM_PROVENANCE=1 opt-in rather than baked into
+# publishConfig (which would hard-fail a local publish).
 
-DRY_RUN=${1:-""}
-
-if [ "$DRY_RUN" = "--dry-run" ]; then
-    echo "=== Dry Run: npm packages ==="
-    FLAG="--dry-run"
-else
-    echo "=== Publishing to npm ==="
-    FLAG=""
-fi
+case "${1:-}" in
+    "")
+        MODE="publish"
+        ;;
+    --dry-run)
+        MODE="dry-run"
+        ;;
+    *)
+        echo "usage: $0 [--dry-run]" >&2
+        exit 2
+        ;;
+esac
 
 PROV=""
-if [ -n "$CI" ]; then
+if [ "${NPM_PROVENANCE:-}" = "1" ]; then
     PROV="--provenance"
 fi
 
@@ -33,54 +44,67 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd)
 WASM_DIR="$ROOT/npm/lattice-embed-wasm"
 NATIVE_DIR="$ROOT/npm/lattice-embed-native"
 
-# ---- @khive-ai/lattice-embed-wasm: portable, single artifact, all platforms.
-# `prepack` rebuilds wasm/lattice_embed_bg.wasm from source before packing.
-echo "--- @khive-ai/lattice-embed-wasm (portable wasm) ---"
-( cd "$WASM_DIR" && npm publish $FLAG $PROV )
-
-# ---- @khive-ai/lattice-embed: napi per-platform binaries.
-# Gather any locally built .node into npm/<platform>/, then publish every
-# platform subpackage that has a binary BEFORE the main package (which lists
-# them in optionalDependencies). npm skips optional deps that were never
-# published; at runtime the binding reports FL_EMBED_UNSUPPORTED_PLATFORM on a
-# platform whose binary was not shipped, and the portable wasm package covers
-# those platforms. Cross-platform binaries come from the napi build matrix in
-# CI; a local run ships only the current platform.
-echo "--- @khive-ai/lattice-embed native binaries ---"
+# Gather any locally built .node into npm/<platform>/ so the platform
+# subpackages have their binary. Cross-platform binaries come from the napi
+# build matrix in CI; a local run only produces the current platform.
 ( cd "$NATIVE_DIR" && npm run artifacts >/dev/null 2>&1 || true )
 
-PUBLISHED_PLATFORMS=""
-MISSING_PLATFORMS=""
+# Discover the platform subpackages that actually carry a binary.
+PLATFORM_DIRS=""
 for pkgdir in "$NATIVE_DIR"/npm/*/; do
     [ -d "$pkgdir" ] || continue
-    platform=$(basename "$pkgdir")
     if ls "$pkgdir"*.node >/dev/null 2>&1; then
-        echo "  publishing @khive-ai/lattice-embed-$platform"
-        ( cd "$pkgdir" && npm publish $FLAG $PROV )
-        PUBLISHED_PLATFORMS="$PUBLISHED_PLATFORMS $platform"
-    else
-        MISSING_PLATFORMS="$MISSING_PLATFORMS $platform"
+        PLATFORM_DIRS="$PLATFORM_DIRS $pkgdir"
     fi
 done
 
-if [ -z "$PUBLISHED_PLATFORMS" ]; then
+if [ -z "$PLATFORM_DIRS" ]; then
     echo "ERROR: no native platform binary found under $NATIVE_DIR/npm/*/." >&2
     echo "Build the current platform first: (cd $NATIVE_DIR && npm run build)." >&2
     echo "Cross-platform binaries are produced by the napi build matrix in CI." >&2
     exit 1
 fi
 
-if [ -n "$MISSING_PLATFORMS" ]; then
-    echo "NOTE: no native binary shipped for:$MISSING_PLATFORMS"
-    echo "      users there get FL_EMBED_UNSUPPORTED_PLATFORM; @khive-ai/lattice-embed-wasm covers them."
+# ---- Preflight: dry-run the ENTIRE release before any real publish. This
+# packs wasm (prepack rebuild), every present platform subpackage, and the
+# native main package (its prepublishOnly runs `napi artifacts && npm test`).
+# Any failure here aborts before a single package is published.
+echo "=== Preflight (dry-run: pack + gate the full release) ==="
+( cd "$WASM_DIR" && npm publish --dry-run )
+for pkgdir in $PLATFORM_DIRS; do
+    ( cd "$pkgdir" && npm publish --dry-run )
+done
+( cd "$NATIVE_DIR" && npm publish --dry-run )
+echo "Preflight OK."
+
+if [ "$MODE" = "dry-run" ]; then
+    echo "=== Dry run complete: nothing published ==="
+    exit 0
 fi
 
-if [ -z "$DRY_RUN" ]; then
-    echo "Waiting for npm indexing before the main package resolves its optional deps..."
-    sleep 30
-fi
+# ---- Real publish: platform subpackages BEFORE the main package that lists
+# them in optionalDependencies, then the portable wasm package.
+echo "=== Publishing to npm ==="
+for pkgdir in $PLATFORM_DIRS; do
+    platform=$(basename "$pkgdir")
+    echo "--- @khive-ai/lattice-embed-$platform ---"
+    ( cd "$pkgdir" && npm publish $PROV )
+done
+
+echo "Waiting for npm indexing before the main package resolves its optional deps..."
+sleep 30
 
 echo "--- @khive-ai/lattice-embed (native main) ---"
-( cd "$NATIVE_DIR" && npm publish $FLAG $PROV )
+( cd "$NATIVE_DIR" && npm publish $PROV )
+
+echo "--- @khive-ai/lattice-embed-wasm (portable wasm) ---"
+( cd "$WASM_DIR" && npm publish $PROV )
+
+echo
+echo "NOTE: on a platform whose native binary was not published, npm resolves"
+echo "      that optional dependency as absent and require('@khive-ai/lattice-embed')"
+echo "      throws FL_EMBED_NATIVE_LOAD_FAILED (the native package does NOT fall"
+echo "      back to wasm on its own). Consumers wanting portable coverage install"
+echo "      @khive-ai/lattice-embed-wasm, which runs everywhere."
 
 echo "=== Done ==="

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -e
+
+# Publish the two npm embedding packages under the @khive-ai scope:
+#   @khive-ai/lattice-embed-wasm   portable pure-wasm channel (all platforms)
+#   @khive-ai/lattice-embed        native napi channel + per-platform binaries
+#
+# Mirrors scripts/publish.sh (crates.io) in style: --dry-run support, ordered
+# tiers, fail-closed on a missing artifact.
+#
+# Provenance: each package's publishConfig sets access=public. Sigstore
+# provenance requires a supported CI with OIDC (e.g. GitHub Actions), so it is
+# NOT baked into publishConfig (that would hard-fail a local publish). This
+# script adds --provenance only when running under CI; a local/manual publish
+# runs without it.
+
+DRY_RUN=${1:-""}
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+    echo "=== Dry Run: npm packages ==="
+    FLAG="--dry-run"
+else
+    echo "=== Publishing to npm ==="
+    FLAG=""
+fi
+
+PROV=""
+if [ -n "$CI" ]; then
+    PROV="--provenance"
+fi
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+WASM_DIR="$ROOT/npm/lattice-embed-wasm"
+NATIVE_DIR="$ROOT/npm/lattice-embed-native"
+
+# ---- @khive-ai/lattice-embed-wasm: portable, single artifact, all platforms.
+# `prepack` rebuilds wasm/lattice_embed_bg.wasm from source before packing.
+echo "--- @khive-ai/lattice-embed-wasm (portable wasm) ---"
+( cd "$WASM_DIR" && npm publish $FLAG $PROV )
+
+# ---- @khive-ai/lattice-embed: napi per-platform binaries.
+# Gather any locally built .node into npm/<platform>/, then publish every
+# platform subpackage that has a binary BEFORE the main package (which lists
+# them in optionalDependencies). npm skips optional deps that were never
+# published; at runtime the binding reports FL_EMBED_UNSUPPORTED_PLATFORM on a
+# platform whose binary was not shipped, and the portable wasm package covers
+# those platforms. Cross-platform binaries come from the napi build matrix in
+# CI; a local run ships only the current platform.
+echo "--- @khive-ai/lattice-embed native binaries ---"
+( cd "$NATIVE_DIR" && npm run artifacts >/dev/null 2>&1 || true )
+
+PUBLISHED_PLATFORMS=""
+MISSING_PLATFORMS=""
+for pkgdir in "$NATIVE_DIR"/npm/*/; do
+    [ -d "$pkgdir" ] || continue
+    platform=$(basename "$pkgdir")
+    if ls "$pkgdir"*.node >/dev/null 2>&1; then
+        echo "  publishing @khive-ai/lattice-embed-$platform"
+        ( cd "$pkgdir" && npm publish $FLAG $PROV )
+        PUBLISHED_PLATFORMS="$PUBLISHED_PLATFORMS $platform"
+    else
+        MISSING_PLATFORMS="$MISSING_PLATFORMS $platform"
+    fi
+done
+
+if [ -z "$PUBLISHED_PLATFORMS" ]; then
+    echo "ERROR: no native platform binary found under $NATIVE_DIR/npm/*/." >&2
+    echo "Build the current platform first: (cd $NATIVE_DIR && npm run build)." >&2
+    echo "Cross-platform binaries are produced by the napi build matrix in CI." >&2
+    exit 1
+fi
+
+if [ -n "$MISSING_PLATFORMS" ]; then
+    echo "NOTE: no native binary shipped for:$MISSING_PLATFORMS"
+    echo "      users there get FL_EMBED_UNSUPPORTED_PLATFORM; @khive-ai/lattice-embed-wasm covers them."
+fi
+
+if [ -z "$DRY_RUN" ]; then
+    echo "Waiting for npm indexing before the main package resolves its optional deps..."
+    sleep 30
+fi
+
+echo "--- @khive-ai/lattice-embed (native main) ---"
+( cd "$NATIVE_DIR" && npm publish $FLAG $PROV )
+
+echo "=== Done ==="


### PR DESCRIPTION
## What

Reparents both npm embedding channels to the `@khive-ai` scope (Ocean's decision) and adds a `make publish-npm` target mirroring `make publish` for crates.io.

| package | role | was |
|---|---|---|
| `@khive-ai/lattice-embed` | native napi channel (default, fast) | `@lattice-embed/native` |
| `@khive-ai/lattice-embed-<platform>` | per-platform prebuilt binaries | `@lattice-embed/native-<platform>` |
| `@khive-ai/lattice-embed-wasm` | portable pure-wasm channel (the ruflo Tier -1 embedder) | `lattice-embed-wasm` |

Naming follows the esbuild convention (`esbuild` native + `esbuild-wasm` portable) and matches the repo's own `khive` + `@khive-ai/kernel-<platform>` layout.

## napi rename correctness

A napi-rs scope rename must keep **three** identifiers in sync or native loading silently breaks on every platform:
1. `package.json` `name`
2. `binding.js` `PACKAGE_PREFIX` (builds the `${PREFIX}-${platform}` optional-dep require path)
3. the `optionalDependencies` keys (+ each platform subpackage's `name`)

The internal `binaryName` / `.node` filename stems are left unchanged (users never see them; renaming cascades needlessly).

## `make publish-npm`

`scripts/publish-npm.sh` (POSIX sh, mirrors `scripts/publish.sh`):
- **Preflights the entire release** with a `--dry-run` pass (pack wasm + every present platform subpackage + native main `prepublishOnly` test) **before any real publish** — npm `name@version` tuples are immutable, so a deterministic failure must never leave an unrepublishable partial release.
- publishes platform subpackages **before** the native main package (which lists them in `optionalDependencies`), then the portable wasm package.
- `--dry-run` capable (`make publish-npm-dry`); unknown args fail closed (exit 2).
- fails closed when no platform binary is present.
- **provenance** is gated behind an explicit `NPM_PROVENANCE=1` opt-in (Sigstore provenance needs an OIDC-capable runner; generic `$CI` is too broad and would hard-fail a token-only job). It is not baked into `publishConfig`, so a local publish is not blocked.

## Platform coverage (honest)

A local run ships only the current platform's `.node`. On a platform whose binary was **not** published, npm resolves that optional dependency as absent and `require('@khive-ai/lattice-embed')` throws `FL_EMBED_NATIVE_LOAD_FAILED` — the native package does **not** auto-fall-back to wasm. Consumers wanting portable coverage install `@khive-ai/lattice-embed-wasm`, which runs everywhere. Full cross-platform native coverage comes from a napi build matrix in CI (follow-on).

## Verification (dry-run)

- `@khive-ai/lattice-embed-wasm`: packs 9 files incl. `wasm/lattice_embed_bg.wasm` (352 KB), `public` access
- `@khive-ai/lattice-embed` main: packs 6 files, **no `.node`** (packlist guard holds), `public` access
- native package tests: 30/30 pass; unknown-arg guard exits 2; full preflight publishes nothing
- both channels smoke-tested against local weights: 384-dim vectors, native ≈ wasm components (same model, same math)

## Codex review

APPROVE-WITH-FIXES → all four findings applied (preflight-before-publish, `NPM_PROVENANCE=1` gate, arg fail-closed, corrected error-code/fallback docs). Re-review pending.

## Not in this PR (publish-step, follow-on)

- Upload the model weights as GitHub release assets and set `WEIGHTS_RELEASE_TAG` in `registry.mjs` (local weight sha256 already match the pinned registry hashes byte-for-byte).
- `npm publish` under `@khive-ai` (account 2FA).
- napi cross-platform build matrix in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)