### PR TITLE
chore(release): v0.5.1 — version bump + release notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 # MSRV, verified end-to-end (workspace + deps) on 1.93.1 and guarded by the msrv CI
 # job (aarch64 macOS, f16,metal-gpu, --all-targets) so a newer-toolchain-only API

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -55,14 +55,14 @@ tracing = "0.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["sync", "rt"] }
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.5.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.5.1", path = "../inference", optional = true, features = ["f16"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.0", default-features = false, features = ["sync", "rt"] }
 # Same crate, trimmed to the CPU compute path: `std` + `f16`, without
 # `download` (ureq) or `serve` (axum/tokio-net/mio), none of which compile to
 # wasm32-unknown-unknown.
-lattice-inference = { version = "0.5.0", path = "../inference", optional = true, default-features = false, features = [
+lattice-inference = { version = "0.5.1", path = "../inference", optional = true, default-features = false, features = [
     "std",
     "f16",
 ] }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -60,7 +60,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.5.0", path = "../fann", optional = true }
+lattice-fann = { version = "0.5.1", path = "../fann", optional = true }
 
 [[bin]]
 name = "lattice"

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -30,7 +30,7 @@ sqlite = ["dep:rusqlite", "serde"]
 mixture = ["lattice-fann/online-router"]
 
 [dependencies]
-lattice-fann = { version = "0.5.0", path = "../fann" }
+lattice-fann = { version = "0.5.1", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -51,7 +51,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.5.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.5.1", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/docs/releases/v0.5.1.md
+++ b/docs/releases/v0.5.1.md
@@ -1,0 +1,54 @@
+# lattice v0.5.1
+
+22 commits since v0.5.0. Patch bump: this release is additive only — no public API
+changes (enforced by the `semver-checks` CI gate added in #648). The breaking vision
+encoder work (ADR-069) is parked off `main` and will land in a future minor; only its
+ADR document is on `main` here.
+
+## Highlights
+
+- **npm distribution channel for the embedding engine.** The CPU embedding engine now
+  ships to npm under the `@khive-ai` scope, in two forms:
+  - `@khive-ai/lattice-embed-wasm` — portable WASM adapter, runs anywhere (#687), built
+    on a wasm32 build of the embedding engine with in-memory model loading (#681).
+  - `@khive-ai/lattice-embed` — native napi-rs binding for maximum throughput (#689).
+    **Platform coverage for this initial release is `darwin-arm64` only** — the package
+    declares the full 7-platform `optionalDependencies` matrix, but only the
+    macOS/Apple-Silicon binary is published. On any other platform `binding.js` throws
+    `FL_EMBED_NATIVE_LOAD_FAILED` (there is no automatic WASM fallback); use
+    `@khive-ai/lattice-embed-wasm` there. Broadening the prebuilt matrix is tracked as a
+    follow-on issue.
+  - `make publish-npm` / `make publish-npm-dry` drive the publish, with a full dry-run
+    preflight of every package before any real publish (#694).
+- **BGE asymmetric-retrieval correctness** (#690): the embedding engine applies the BGE
+  query instruction prefix on the query side (`embed_query`) and not on the passage side
+  (`embed_passage`), so BGE/E5 retrieval scores are computed correctly.
+- **CPU embedding throughput** (ADR-070): fused batched BERT encode (#672) plus fused
+  BERT QKV projection with reduced attention copy traffic (#678), gated for ONNX parity
+  (#671).
+- **Cross-turn KV prefix cache wired into `lattice serve`** (#462): the Metal serve
+  worker (#662, #666) and unified Metal prompt rendering (#667) reuse cached KV/GDN
+  state across turns, matching the `chat_metal` behavior shipped in 0.5.0.
+- **Serve robustness**: fail-closed roles and content parts, OpenAI content-parts
+  arrays, config-derived max context (#656); Metal generation loops honor `stop_strings`
+  (#657); executable endpoint capability-matrix test (#665).
+- **Sampler and prefill perf**: public prefill delegates to the batched path with a
+  serial fallback (#680); stop-string scanning bounded to a rolling suffix window
+  (#679); fused partial top-k + context-only repetition penalty in the full-logit
+  sampler (#651).
+
+## Fixes
+
+- Centralized Q4/QuaRot manifest parsing and validation (#655, #664).
+
+## Docs
+
+- ADR-069 (vision encoder recalibration for Qwen3.5-0.8B, #669) and ADR-070 (CPU
+  embedding fused batched encode + ONNX parity gate, #671).
+- Cross-turn cache status refresh (#660); `lattice doctor` manifest guidance (#659).
+- Neutralized internal references in docs and comments (#658).
+
+## CI
+
+- Faster queue (concurrency + docs-only skip) and stricter gates: typos, actionlint, and
+  `semver-checks` (#648).


### PR DESCRIPTION
## Release-prep: v0.5.1 (additive patch over v0.5.0)

Bumps workspace + internal path-dep versions `0.5.0 → 0.5.1` and adds `docs/releases/v0.5.1.md`. 22 commits since the v0.5.0 tag, **all additive — no public API break** (the `semver-checks` gate from #648 enforces this on CI). The breaking vision-encoder work (ADR-069) stays parked off `main`; only its ADR doc is on `main`.

### What ships in 0.5.1
- **`@khive-ai` npm embedding channel**: `@khive-ai/lattice-embed-wasm` (portable WASM, #687/#681) + `@khive-ai/lattice-embed` (native napi-rs, #689) + `make publish-npm` with full dry-run preflight (#694). **The native package is `darwin-arm64`-only for this initial (v0.1.0) release** — the 7-platform `optionalDependencies` matrix is declared but only the macOS/Apple-Silicon binary is published; other platforms throw `FL_EMBED_NATIVE_LOAD_FAILED` (no auto-WASM-fallback) and should use the `-wasm` package. Broadening the prebuilt matrix is filed as a follow-on issue.
- **BGE asymmetric-retrieval query prefix** (#690).
- **ADR-070 CPU embedding perf**: fused batched BERT encode (#672) + fused QKV projection (#678).
- **Cross-turn KV prefix cache wired into `lattice serve`** (#462, #662/#666/#667).
- **Serve hardening**: fail-closed roles/content-parts + config-derived max context (#656); `stop_strings` honored on Metal (#657).
- **Sampler/prefill perf**: batched-path prefill delegation (#680), rolling-suffix stop-string scan (#679), fused top-k + repetition penalty (#651).

### Verification
- Pre-commit hook compiled the full workspace clean at 0.5.1; doc-lint passed.
- CI (build + test + `semver-checks` + e2e-parity) is the release gate.

### Release mechanics (after merge, Ocean-held)
- Tag `v0.5.1` → `make publish` (crates.io, publish DAG: fann, transport → inference → embed, tune).
- npm `@khive-ai` publish via `make publish-npm` (2FA OTP, weights upload + `WEIGHTS_RELEASE_TAG`).

Routing to Leo's gate before the ready/publish flip.