### PR TITLE
fix(embed): runnable download command for the Qwen3-Embedding fetch path (#691, #692, #693)

### DIFF
--- a/crates/embed/src/service/native.rs
+++ b/crates/embed/src/service/native.rs
@@ -306,9 +306,9 @@ fn qwen_model_dir(model_type: EmbeddingModel) -> Result<std::path::PathBuf> {
         Ok(dir)
     } else {
         Err(EmbedError::ModelInitialization(format!(
-            "Qwen3 model not found at {}. Download from {}",
-            dir.display(),
-            model_type.model_id()
+            "Qwen3 model not found at {dir}. Download it with:\n  huggingface-cli download {repo} --local-dir {dir}",
+            dir = dir.display(),
+            repo = model_type.model_id()
         )))
     }
 }

--- a/crates/inference/examples/bench_embedding.rs
+++ b/crates/inference/examples/bench_embedding.rs
@@ -1,7 +1,7 @@
 //! Benchmark: Pure Rust inference vs ONNX Runtime for Qwen3-Embedding-0.6B.
 //!
 //! Usage:
-//!   cargo run --release --features "f16,bench-ort" --bin bench_embedding
+//!   cargo run --release -p lattice-inference --example bench_embedding --features "f16,bench-ort"
 
 use std::time::Instant;
 

--- a/crates/inference/examples/bench_gpu.rs
+++ b/crates/inference/examples/bench_gpu.rs
@@ -31,7 +31,9 @@ fn run_bench() {
 
     if !dir.join("model.safetensors").exists() {
         eprintln!("Model not found at {model_dir}");
-        eprintln!("Run: cargo run --release --features 'f16,download' --bin bench_embedding");
+        eprintln!(
+            "Download: huggingface-cli download Qwen/Qwen3-Embedding-0.6B --local-dir {model_dir}"
+        );
         std::process::exit(1);
     }
 

--- a/crates/inference/examples/bench_gpu.rs
+++ b/crates/inference/examples/bench_gpu.rs
@@ -1,7 +1,7 @@
 //! Benchmark: GPU forward pass for Qwen3-Embedding-0.6B vs CPU.
 //!
 //! Usage:
-//!   cargo run --release --features "f16,wgpu-gpu" --bin bench_gpu -p lattice-inference
+//!   cargo run --release -p lattice-inference --example bench_gpu --features "f16,wgpu-gpu"
 
 use std::path::Path;
 use std::time::Instant;

--- a/crates/inference/examples/bench_metal.rs
+++ b/crates/inference/examples/bench_metal.rs
@@ -1,7 +1,7 @@
 //! Benchmark: Direct Metal forward pass for Qwen3-Embedding-0.6B vs CPU.
 //!
 //! Usage:
-//!   cargo run --release --features "f16,metal-gpu" --bin bench_metal -p lattice-inference
+//!   cargo run --release -p lattice-inference --example bench_metal --features "f16,metal-gpu"
 
 use std::path::Path;
 use std::time::Instant;

--- a/crates/inference/examples/bench_metal.rs
+++ b/crates/inference/examples/bench_metal.rs
@@ -29,7 +29,9 @@ fn run_bench() {
 
     if !dir.join("model.safetensors").exists() {
         eprintln!("Model not found at {model_dir}");
-        eprintln!("Run: cargo run --release --features 'f16,download' --bin bench_embedding");
+        eprintln!(
+            "Download: huggingface-cli download Qwen/Qwen3-Embedding-0.6B --local-dir {model_dir}"
+        );
         std::process::exit(1);
     }
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -57,13 +57,13 @@ These require model weights to be already cached:
 
 ```sh
 # Full embedding pipeline: tokenize → forward → pool → normalize
-cargo run -p lattice-inference --example bench_embedding --release
+cargo run -p lattice-inference --example bench_embedding --release --features f16
 
 # Metal GPU path on Apple Silicon
-cargo run -p lattice-inference --example bench_metal --release --features metal-gpu
+cargo run -p lattice-inference --example bench_metal --release --features f16,metal-gpu
 
 # Concurrent embedding throughput
-cargo run -p lattice-inference --example bench_concurrent --release
+cargo run -p lattice-inference --example bench_concurrent --release --features f16,metal-gpu
 ```
 
 ## What the Benchmarks Cover


### PR DESCRIPTION
## Summary

Qwen3-Embedding models do not auto-download (only BERT-family variants do), so users meet a "fetch it yourself" path. Its guidance was wrong or incomplete in three places, all hit in a single real user walkthrough (mondweep/vibe-cast `learnings.md`). This corrects all three to the copy-pasteable `huggingface-cli download <repo> --local-dir <dir>` pattern already used by `bench_profile.rs:20` and the README Qwen3.5 install steps.

## Changes

- **#693 — `crates/embed/src/service/native.rs`**: the not-found error named the HuggingFace repo id but handed no runnable command. Now prints `Download it with:\n  huggingface-cli download <repo> --local-dir <dir>`.
- **#691 — `crates/inference/examples/bench_metal.rs` + `bench_gpu.rs`**: both pointed at `--bin bench_embedding`, which does not resolve (`bench_embedding` is an `[[example]]`, not a `[[bin]]`) and would not download anything even run correctly. Replaced with the same runnable `huggingface-cli` command against the expected model dir.
- **#692 — `docs/benchmarks.md`**: example invocations omitted required cargo features. Corrected to match `crates/inference/Cargo.toml` `required-features`: `bench_embedding` → `f16`; `bench_metal` → `f16,metal-gpu`; `bench_concurrent` → `f16,metal-gpu`.

## Verification (local, heavy-lane serialized)

- `cargo fmt --check` clean
- `cargo check -p lattice-embed` (the `native.rs` lib change) compiles
- `cargo check --example bench_metal --features f16,metal-gpu` compiles
- `cargo check --example bench_gpu --features f16,wgpu-gpu` compiles (note: `bench_gpu` is `wgpu-gpu`-gated, not `metal-gpu`)
- Pre-commit hook (workspace check + doc lint + capability-matrix) passed

Docs/message-only change; no runtime behavior altered beyond error/hint text. Closes #691, #692, #693.