### PR TITLE
perf(inference): pack varlen batches in BERT encode, skip padding compute (#677)

### DIFF
--- a/crates/inference/benches/e2e_bench.rs
+++ b/crates/inference/benches/e2e_bench.rs
@@ -120,5 +120,59 @@ fn e2e_encode_batch(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, e2e_encode, e2e_encode_batch);
+/// Padding-fraction comparison for the packed batched-encode path (#677): a
+/// high length-variance batch (5/30/100 real tokens) exercises the padding
+/// the packed layout removes, while a uniform batch (three copies of the
+/// same 100-token text) has no padding to remove and should land ~neutral.
+fn e2e_encode_batch_padding_variance(c: &mut Criterion) {
+    let Some(dir) = model_dir() else { return };
+
+    let model = BertModel::from_directory(&dir).expect("Failed to load model");
+    let _ = model.encode("warmup");
+
+    let short = "Hello world test";
+    let medium = "The quick brown fox jumps over the lazy dog. \
+        This sentence is designed to be roughly thirty tokens long for benchmarking.";
+    let long = "Artificial intelligence and machine learning have transformed the way we process \
+        information and make decisions. From natural language processing to computer vision, \
+        these technologies enable systems to understand, learn, and interact with the world \
+        in increasingly sophisticated ways. The development of transformer architectures has \
+        been particularly impactful, enabling models to capture long-range dependencies in \
+        sequential data with unprecedented effectiveness and efficiency.";
+
+    let mixed: Vec<&str> = vec![short, medium, long];
+    let uniform: Vec<&str> = vec![long, long, long];
+
+    let mut group = c.benchmark_group("e2e_encode_batch_padding_variance");
+    group.measurement_time(Duration::from_secs(15));
+    group.warm_up_time(Duration::from_secs(3));
+
+    group.bench_function("mixed_5_30_100", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                model
+                    .encode_batch(std::hint::black_box(mixed.as_slice()))
+                    .unwrap(),
+            )
+        });
+    });
+    group.bench_function("uniform_100", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                model
+                    .encode_batch(std::hint::black_box(uniform.as_slice()))
+                    .unwrap(),
+            )
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    e2e_encode,
+    e2e_encode_batch,
+    e2e_encode_batch_padding_variance
+);
 criterion_main!(benches);

--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -426,14 +426,23 @@ pub(crate) fn multi_head_attention_in_place(
     }
 }
 
-/// Fused batched multi-head attention for a padded `[batch, seq_len]` tensor.
+/// Fused batched multi-head attention for a packed (padding-free) `[total, hidden]`
+/// tensor (#677).
 ///
 /// This is the batch analogue of [`multi_head_attention_in_place`]: it fuses the
 /// position-wise Q/K/V and output projections into single `matmul_bt` calls over
-/// all `batch * seq_len` rows (bigger GEMMs, fewer BLAS/SIMD dispatches), while the
+/// every row of the packed batch (bigger GEMMs, fewer BLAS/SIMD dispatches), while the
 /// O(seq_len^2) score/softmax/context step -- which cannot be flattened across
-/// sequences without letting one sequence's tokens attend across a padding boundary
-/// into another sequence -- runs per-sequence, serially.
+/// sequences without letting one sequence's tokens attend into another sequence --
+/// runs per-sequence, serially.
+///
+/// `hidden_states` is the packed `[total, hidden_size]` tensor: sequence `b` occupies
+/// rows `cu_seqlens[b]..cu_seqlens[b+1]`, with no padding rows anywhere in between.
+/// `cu_seqlens` has `batch + 1` entries (`cu_seqlens[0] == 0`,
+/// `cu_seqlens[batch] == total`), the standard varlen cumulative-offset index. There
+/// is no `attention_mask` parameter: every packed row is a real token, so there is
+/// nothing to mask -- the structural `-inf` masking `multi_head_attention_in_place`
+/// needs for its padded single-sequence case does not apply here.
 ///
 /// This loop is deliberately **not** parallelized with rayon/std::thread, even
 /// though each sequence's slice is independent. On macOS, `matmul_bt` dispatches to
@@ -449,17 +458,240 @@ pub(crate) fn multi_head_attention_in_place(
 /// fresh A/B on that specific backend shows a win -- do not assume this decision
 /// carries over to a different dispatch path without re-measuring.
 ///
-/// `hidden_states`/`attention_mask` are the flattened `[batch * seq_len, ...]`
-/// tensors (row `b * seq_len + i` is token `i` of sequence `b`). `output` receives
-/// the same output-projection result that `multi_head_attention_in_place` writes
-/// into `buffers.temp` (bias-added, LoRA-applied); callers add the residual and run
-/// `layer_norm` themselves, exactly as the single-sequence path does.
-///
-/// All existing masking/softmax fail-closed guards from `multi_head_attention_in_place`
-/// (structural `-inf` masking, `softmax_attention`'s all-masked-row zero guard) are
-/// preserved verbatim per sequence -- see that function's comments for the rationale.
+/// `output` receives the same output-projection result that
+/// `multi_head_attention_in_place` writes into `buffers.temp` (bias-added,
+/// LoRA-applied); callers add the residual and run `layer_norm` themselves, exactly
+/// as the single-sequence path does.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn multi_head_attention_batched(
+    hidden_states: &[f32],
+    layer_weights: &TransformerLayerWeights<'_>,
+    fused_qkv_weight: &[f32],
+    fused_qkv_bias: &[f32],
+    cu_seqlens: &[usize],
+    hidden_size: usize,
+    num_heads: usize,
+    head_dim: usize,
+    q: &mut [f32],
+    k: &mut [f32],
+    v: &mut [f32],
+    qkv: &mut [f32],
+    concat: &mut [f32],
+    output: &mut [f32],
+    lora: &dyn LoraHook,
+    layer_idx: usize,
+) {
+    assert!(
+        cu_seqlens.len() >= 2,
+        "standard: cu_seqlens must have at least 2 entries (batch + 1)"
+    );
+    assert_eq!(cu_seqlens[0], 0, "standard: cu_seqlens must start at 0");
+    let batch = cu_seqlens.len() - 1;
+    let total = cu_seqlens[batch];
+    assert!(num_heads > 0, "standard: num_heads must be non-zero");
+    assert!(head_dim > 0, "standard: head_dim must be non-zero");
+    assert_eq!(
+        hidden_size,
+        num_heads * head_dim,
+        "standard: hidden_size must equal num_heads * head_dim"
+    );
+    assert!(
+        total.checked_mul(hidden_size).is_some(),
+        "standard: total * hidden_size overflow"
+    );
+    let used_hidden = total * hidden_size;
+    assert_eq!(
+        hidden_states.len(),
+        used_hidden,
+        "standard: hidden_states length must equal total * hidden_size"
+    );
+    assert!(q.len() >= used_hidden, "standard: q scratch too small");
+    assert!(k.len() >= used_hidden, "standard: k scratch too small");
+    assert!(v.len() >= used_hidden, "standard: v scratch too small");
+    assert!(
+        concat.len() >= used_hidden,
+        "standard: concat scratch too small"
+    );
+    assert!(
+        output.len() >= used_hidden,
+        "standard: output scratch too small"
+    );
+    assert!(
+        qkv.len() >= used_hidden * 3,
+        "standard: qkv scratch too small"
+    );
+
+    // Fused Q/K/V projection (#674): one matmul_bt call across every row in
+    // the packed batch against the layer's [3*hidden, hidden] fused weight,
+    // instead of three separate [hidden, hidden] projections. The interleaved
+    // [total, 3*hidden] result is split into plain contiguous q/k/v buffers in
+    // one pass, preserving LoraHook::apply's [total, hidden_size]-per-tensor
+    // contract exactly (that trait lives outside this crate's optimizable
+    // surface). This step is row-independent: it does not need `cu_seqlens`
+    // at all, only the total row count.
+    {
+        let qkv = &mut qkv[..used_hidden * 3];
+        matmul_bt(
+            hidden_states,
+            fused_qkv_weight,
+            qkv,
+            total,
+            hidden_size,
+            3 * hidden_size,
+        );
+        add_bias(qkv, fused_qkv_bias, 3 * hidden_size);
+
+        for r in 0..total {
+            let src = r * 3 * hidden_size;
+            q[r * hidden_size..(r + 1) * hidden_size].copy_from_slice(&qkv[src..src + hidden_size]);
+            k[r * hidden_size..(r + 1) * hidden_size]
+                .copy_from_slice(&qkv[src + hidden_size..src + 2 * hidden_size]);
+            v[r * hidden_size..(r + 1) * hidden_size]
+                .copy_from_slice(&qkv[src + 2 * hidden_size..src + 3 * hidden_size]);
+        }
+    }
+    lora.apply(layer_idx, "query", hidden_states, &mut q[..used_hidden]);
+    lora.apply(layer_idx, "key", hidden_states, &mut k[..used_hidden]);
+    lora.apply(layer_idx, "value", hidden_states, &mut v[..used_hidden]);
+
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let q = &q[..used_hidden];
+    let k = &k[..used_hidden];
+    let v = &v[..used_hidden];
+    let concat = &mut concat[..used_hidden];
+
+    // Per-sequence score/softmax/context. This loop runs serially, one sequence
+    // at a time; each `cu_seqlens[b]..cu_seqlens[b+1]` region of `concat` is
+    // written by exactly one iteration, over disjoint slices of the shared
+    // read-only `q`/`k`/`v` buffers. Every row in a sequence's region is real
+    // (packing removed padding entirely), so there is no mask to apply here.
+    for b in 0..batch {
+        let start = cu_seqlens[b];
+        let end = cu_seqlens[b + 1];
+        assert!(
+            end >= start,
+            "standard: cu_seqlens must be non-decreasing (segment {b})"
+        );
+        let seq_len = end - start;
+        if seq_len == 0 {
+            continue;
+        }
+        // Per-sequence quadratic-in-seq_len scratch (scores is
+        // [num_heads, seq_len, seq_len]): reuse the single-sequence overflow
+        // guard, since this is exactly that shape check applied per segment.
+        assert_standard_no_overflow(seq_len, hidden_size, num_heads, head_dim);
+
+        let row_start = start * hidden_size;
+        let concat_b = &mut concat[row_start..row_start + seq_len * hidden_size];
+
+        let mut q_head = vec![0.0f32; seq_len * head_dim];
+        let mut k_head = vec![0.0f32; seq_len * head_dim];
+        let mut v_all_t = vec![0.0f32; hidden_size * seq_len];
+        let mut scores_head = vec![0.0f32; seq_len * seq_len];
+        let mut scores = vec![0.0f32; num_heads * seq_len * seq_len];
+        let mut context_head = vec![0.0f32; seq_len * head_dim];
+
+        // Q*K^T via SIMD matmul_bt, one head at a time (mirrors
+        // multi_head_attention_in_place's single-sequence loop exactly).
+        for h in 0..num_heads {
+            let head_offset = h * head_dim;
+
+            for i in 0..seq_len {
+                let src_start = row_start + i * hidden_size + head_offset;
+                let dst_start = i * head_dim;
+                q_head[dst_start..dst_start + head_dim]
+                    .copy_from_slice(&q[src_start..src_start + head_dim]);
+            }
+            for i in 0..seq_len {
+                let src_start = row_start + i * hidden_size + head_offset;
+                let dst_start = i * head_dim;
+                k_head[dst_start..dst_start + head_dim]
+                    .copy_from_slice(&k[src_start..src_start + head_dim]);
+            }
+
+            matmul_bt(
+                &q_head[..seq_len * head_dim],
+                &k_head[..seq_len * head_dim],
+                &mut scores_head[..seq_len * seq_len],
+                seq_len,
+                head_dim,
+                seq_len,
+            );
+
+            let scores_offset = h * seq_len * seq_len;
+            for (idx, &score) in scores_head.iter().enumerate() {
+                scores[scores_offset + idx] = score * scale;
+            }
+        }
+
+        // No masking: every row in this sequence's packed region is real, so
+        // softmax runs over the raw scaled scores directly (still through the
+        // same fail-closed `softmax_attention` kernel as every other path).
+        softmax_attention(&mut scores, seq_len, num_heads);
+
+        // Transpose V once for this sequence (#673 acceptable-minimum):
+        // one [hidden_size, seq_len] transpose instead of `num_heads`
+        // separate [head_dim, seq_len] transposes; identical element
+        // count moved, one loop instead of `num_heads` smaller loops.
+        for i in 0..seq_len {
+            let v_row_start = row_start + i * hidden_size;
+            for d in 0..hidden_size {
+                v_all_t[d * seq_len + i] = v[v_row_start + d];
+            }
+        }
+
+        // scores*V context aggregation, writing directly into this
+        // sequence's `concat_b` region (#673): removes the intermediate
+        // `context` buffer and its extra full-hidden-size copy pass.
+        for h in 0..num_heads {
+            let head_offset = h * head_dim;
+
+            let scores_offset = h * seq_len * seq_len;
+            let scores_head = &scores[scores_offset..scores_offset + seq_len * seq_len];
+            let v_head_t = &v_all_t[head_offset * seq_len..(head_offset + head_dim) * seq_len];
+            matmul_bt(
+                scores_head,
+                v_head_t,
+                &mut context_head[..seq_len * head_dim],
+                seq_len,
+                seq_len,
+                head_dim,
+            );
+
+            for i in 0..seq_len {
+                let dst = i * hidden_size + head_offset;
+                concat_b[dst..dst + head_dim]
+                    .copy_from_slice(&context_head[i * head_dim..(i + 1) * head_dim]);
+            }
+        }
+    }
+
+    // Fused output projection: one matmul_bt call across every row in the batch.
+    let concat = &concat[..used_hidden];
+    let output = &mut output[..used_hidden];
+    matmul_bt(
+        concat,
+        layer_weights.attn_output_weight.data,
+        output,
+        total,
+        hidden_size,
+        hidden_size,
+    );
+    add_bias(output, layer_weights.attn_output_bias.data, hidden_size);
+    lora.apply(layer_idx, "attn_output", concat, output);
+}
+
+/// Pre-#677 padded batched attention, preserved as a test-only reference.
+///
+/// This is the padded `[batch, seq_len]` implementation `multi_head_attention_batched`
+/// used before the packed/varlen rewrite: every sequence occupies a uniform
+/// `seq_len`-row slot with masked padding rows, instead of a `cu_seqlens`-indexed
+/// packed region. It exists solely so the parity test can compare the new packed
+/// production path against an independently-computed ground truth without
+/// reimplementing the old kernel inline in the test module.
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn multi_head_attention_batched_padded_reference(
     hidden_states: &[f32],
     layer_weights: &TransformerLayerWeights<'_>,
     fused_qkv_weight: &[f32],
@@ -516,13 +748,6 @@ pub(crate) fn multi_head_attention_batched(
         "standard: qkv scratch too small"
     );
 
-    // Fused Q/K/V projection (#674): one matmul_bt call across every row in
-    // the batch against the layer's [3*hidden, hidden] fused weight, instead
-    // of three separate [hidden, hidden] projections. The interleaved
-    // [rows, 3*hidden] result is split into plain contiguous q/k/v buffers in
-    // one pass, preserving LoraHook::apply's [rows, hidden_size]-per-tensor
-    // contract exactly (that trait lives outside this crate's optimizable
-    // surface).
     {
         let qkv = &mut qkv[..used_hidden * 3];
         matmul_bt(
@@ -554,10 +779,6 @@ pub(crate) fn multi_head_attention_batched(
     let v = &v[..used_hidden];
     let concat = &mut concat[..used_hidden];
 
-    // Per-sequence score/softmax/context. This loop runs serially, one sequence
-    // at a time; each chunk of `concat` (one sequence's [seq_len, hidden_size]
-    // region) is written by exactly one iteration, over disjoint slices of the
-    // shared read-only `q`/`k`/`v`/`attention_mask` buffers.
     concat
         .chunks_mut(seq_len * hidden_size)
         .enumerate()
@@ -573,8 +794,6 @@ pub(crate) fn multi_head_attention_batched(
             let mut scores = vec![0.0f32; num_heads * seq_len * seq_len];
             let mut context_head = vec![0.0f32; seq_len * head_dim];
 
-            // Q*K^T via SIMD matmul_bt, one head at a time (mirrors
-            // multi_head_attention_in_place's single-sequence loop exactly).
             for h in 0..num_heads {
                 let head_offset = h * head_dim;
 
@@ -606,8 +825,6 @@ pub(crate) fn multi_head_attention_batched(
                 }
             }
 
-            // Structural -inf masking + fail-closed softmax -- identical to
-            // multi_head_attention_in_place; see its comment for the #361 rationale.
             for h in 0..num_heads {
                 for i in 0..seq_len {
                     let row_off = (h * seq_len + i) * seq_len;
@@ -621,10 +838,6 @@ pub(crate) fn multi_head_attention_batched(
             }
             softmax_attention(&mut scores, seq_len, num_heads);
 
-            // Transpose V once for this sequence (#673 acceptable-minimum):
-            // one [hidden_size, seq_len] transpose instead of `num_heads`
-            // separate [head_dim, seq_len] transposes; identical element
-            // count moved, one loop instead of `num_heads` smaller loops.
             for i in 0..seq_len {
                 let v_row_start = row_start + i * hidden_size;
                 for d in 0..hidden_size {
@@ -632,9 +845,6 @@ pub(crate) fn multi_head_attention_batched(
                 }
             }
 
-            // scores*V context aggregation, writing directly into this
-            // sequence's `concat_b` region (#673): removes the intermediate
-            // `context` buffer and its extra full-hidden-size copy pass.
             for h in 0..num_heads {
                 let head_offset = h * head_dim;
 
@@ -658,7 +868,6 @@ pub(crate) fn multi_head_attention_batched(
             }
         });
 
-    // Fused output projection: one matmul_bt call across every row in the batch.
     let concat = &concat[..used_hidden];
     let output = &mut output[..used_hidden];
     matmul_bt(
@@ -1114,23 +1323,21 @@ mod tests {
         assert_standard_no_overflow(1usize << 32, 2, 2, 1);
     }
 
-    /// Weights-free parity check between `multi_head_attention_batched` and the
-    /// single-sequence `multi_head_attention` path, run over synthetic (no model
-    /// file) inputs so it exercises in default CI.
+    /// Weights-free parity check between the packed `multi_head_attention_batched`
+    /// (#677) and the single-sequence `multi_head_attention` path, run over
+    /// synthetic (no model file) inputs so it exercises in default CI.
     ///
-    /// Builds two sequences of different real length (2 tokens and 3 tokens)
-    /// padded to a common `seq_len` of 3. The padded slot in the shorter sequence
-    /// carries a huge-magnitude value and is masked out (`mask=0`); if masking or
-    /// the per-sequence row stride (`seq_offset`/`row_start`) were wrong, that
-    /// value would leak into the real tokens' output or the wrong sequence's
-    /// slice would be compared, and the parity check below would fail.
+    /// Builds two sequences of different real length (2 tokens and 3 tokens),
+    /// concatenated with no padding: `cu_seqlens = [0, 2, 5]`. If the
+    /// per-sequence offset/length derived from `cu_seqlens` were wrong -- an
+    /// off-by-one in `start`/`end`, or a swapped segment -- either the wrong
+    /// slice of `q`/`k`/`v` would be attended over, or the wrong sequence's
+    /// output would be compared below, and the parity check would fail.
     ///
-    /// Mutation-checked by hand while writing this test: (1) forcing the mask
-    /// passed into `multi_head_attention_batched` to all-ones (so the padded,
-    /// huge-magnitude slot is treated as a valid key) made this test fail; (2)
-    /// corrupting `row_start`'s stride (multiplying by an extra `+1` offset in
-    /// the per-sequence loop) also made it fail; both were reverted and the test
-    /// re-confirmed passing before landing.
+    /// Mutation-checked by hand while writing this test: shifting sequence 1's
+    /// `cu_seqlens` entry by `+1` (so its window silently absorbs one of
+    /// sequence 0's rows) made this test fail; the corruption was reverted and
+    /// the test re-confirmed passing before landing.
     ///
     /// Q, K, and V use DISTINCT scaled-identity weights and distinct per-dim
     /// biases (not the shared identity block this test used before #678
@@ -1145,12 +1352,10 @@ mod tests {
     /// hidden block flips the corresponding scratch buffer against a
     /// differently-scaled/biased reference and fails the assertion below.
     #[test]
-    fn batched_attention_matches_single_sequence_per_row_with_padding() {
+    fn batched_attention_matches_single_sequence_per_row_packed() {
         let hidden_size = 8;
         let num_heads = 2;
         let head_dim = 4;
-        let seq_len = 3; // common padded length
-        let batch = 2;
         let intermediate_size = hidden_size;
 
         let identity_8x8: Vec<f32> = {
@@ -1263,26 +1468,23 @@ mod tests {
 
         // Sequence 0: 2 real tokens, deterministic small values.
         let seq0_real: Vec<f32> = (0..2 * hidden_size).map(|i| 1.0 + i as f32 * 0.1).collect();
-        // Padded slot for sequence 0: huge magnitude, must never leak once masked.
-        let seq0_pad: Vec<f32> = vec![1.0e6; hidden_size];
 
-        // Sequence 1: 3 real tokens (fills seq_len exactly, no padding needed),
-        // deterministic small values distinct from sequence 0.
+        // Sequence 1: 3 real tokens, deterministic small values distinct from
+        // sequence 0.
         let seq1_real: Vec<f32> = (0..3 * hidden_size)
             .map(|i| 100.0 + i as f32 * 0.1)
             .collect();
 
-        // Flattened batched input: [seq0 tok0, seq0 tok1, seq0 pad, seq1 tok0, seq1 tok1, seq1 tok2]
-        let mut hidden_states_batched = Vec::with_capacity(batch * seq_len * hidden_size);
-        hidden_states_batched.extend_from_slice(&seq0_real);
-        hidden_states_batched.extend_from_slice(&seq0_pad);
-        hidden_states_batched.extend_from_slice(&seq1_real);
-        assert_eq!(hidden_states_batched.len(), batch * seq_len * hidden_size);
+        // Packed input: [seq0 tok0, seq0 tok1, seq1 tok0, seq1 tok1, seq1 tok2],
+        // no padding rows anywhere. cu_seqlens marks sequence 0 as rows [0, 2)
+        // and sequence 1 as rows [2, 5).
+        let mut hidden_states_packed = Vec::with_capacity(5 * hidden_size);
+        hidden_states_packed.extend_from_slice(&seq0_real);
+        hidden_states_packed.extend_from_slice(&seq1_real);
+        let cu_seqlens = vec![0usize, 2, 5];
+        let total = *cu_seqlens.last().unwrap();
 
-        let attention_mask_batched: Vec<u32> = vec![1, 1, 0, 1, 1, 1];
-
-        let rows = batch * seq_len;
-        let used_hidden = rows * hidden_size;
+        let used_hidden = total * hidden_size;
         let mut q = vec![0.0f32; used_hidden];
         let mut k = vec![0.0f32; used_hidden];
         let mut v = vec![0.0f32; used_hidden];
@@ -1291,13 +1493,11 @@ mod tests {
         let mut output = vec![0.0f32; used_hidden];
 
         multi_head_attention_batched(
-            &hidden_states_batched,
+            &hidden_states_packed,
             &layer,
             &fused_qkv_weight,
             &fused_qkv_bias,
-            &attention_mask_batched,
-            batch,
-            seq_len,
+            &cu_seqlens,
             hidden_size,
             num_heads,
             head_dim,
@@ -1329,10 +1529,10 @@ mod tests {
         // bias differ.
         let mut expected_q = vec![0.0f32; used_hidden];
         matmul_bt(
-            &hidden_states_batched,
+            &hidden_states_packed,
             &query_w,
             &mut expected_q,
-            rows,
+            total,
             hidden_size,
             hidden_size,
         );
@@ -1346,10 +1546,10 @@ mod tests {
 
         let mut expected_k = vec![0.0f32; used_hidden];
         matmul_bt(
-            &hidden_states_batched,
+            &hidden_states_packed,
             &key_w,
             &mut expected_k,
-            rows,
+            total,
             hidden_size,
             hidden_size,
         );
@@ -1363,10 +1563,10 @@ mod tests {
 
         let mut expected_v = vec![0.0f32; used_hidden];
         matmul_bt(
-            &hidden_states_batched,
+            &hidden_states_packed,
             &value_w,
             &mut expected_v,
-            rows,
+            total,
             hidden_size,
             hidden_size,
         );
@@ -1417,7 +1617,7 @@ mod tests {
             &NoopLoraHook,
             0,
         );
-        let seq1_row_start = seq_len * hidden_size;
+        let seq1_row_start = 2 * hidden_size; // cu_seqlens[1] * hidden_size
         let got1 = &output[seq1_row_start..seq1_row_start + 3 * hidden_size];
         for (i, (&g, &e)) in got1.iter().zip(expected1.iter()).enumerate() {
             assert!(

--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -1334,14 +1334,13 @@ mod tests {
     /// slice of `q`/`k`/`v` would be attended over, or the wrong sequence's
     /// output would be compared below, and the parity check would fail.
     ///
-    /// Mutation-checked by hand while writing this test: shifting sequence 1's
-    /// `cu_seqlens` entry by `+1` (so its window silently absorbs one of
-    /// sequence 0's rows) made this test fail; the corruption was reverted and
-    /// the test re-confirmed passing before landing.
+    /// This check is mutation-sensitive: shifting sequence 1's `cu_seqlens`
+    /// entry by `+1` (so its window silently absorbs one of sequence 0's rows)
+    /// makes the parity assertion fail.
     ///
     /// Q, K, and V use DISTINCT scaled-identity weights and distinct per-dim
-    /// biases (not the shared identity block this test used before #678
-    /// review): with Q == K == V, a swapped or shifted QKV split offset keeps
+    /// biases (not a shared identity block): with Q == K == V, a swapped or
+    /// shifted QKV split offset keeps
     /// the fused split self-consistent with the reference path, since both
     /// sides read the same values regardless of which third of `qkv` each
     /// buffer actually came from. With distinct Q/K/V this test additionally

--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -349,14 +349,16 @@ impl BertModel {
 
     /// **Stable**: batch-encode entry point; consumed by `lattice-embed`.
     ///
-    /// Runs a single fused batched forward pass over all texts: the position-wise
+    /// Runs a single fused batched forward pass over all texts, using a packed
+    /// (padding-free) row layout (#677): every sequence contributes only its real
+    /// tokens, concatenated back to back, tracked by a `cu_seqlens` cumulative-offset
+    /// index instead of a shared `batch * seq_len` padded stride. The position-wise
     /// stages (embedding lookup, Q/K/V projection, FFN, output projection) are each
-    /// one `matmul_bt`/`layer_norm` call over every `batch * seq_len` row, instead of
-    /// `batch` separate single-sequence forward passes. Only the O(seq_len^2)
-    /// attention score/context step loops per sequence (see
-    /// [`crate::attention::multi_head_attention_batched`]) are run serially, one
-    /// sequence at a time, over disjoint output slices. The implementation detail
-    /// may change without API breakage.
+    /// one `matmul_bt`/`layer_norm` call over every real row -- no wasted rows for
+    /// padding. Only the O(seq_len^2) attention score/context step loops per
+    /// sequence (see [`crate::attention::multi_head_attention_batched`]) are run
+    /// serially, one sequence at a time, over disjoint output slices. The
+    /// implementation detail may change without API breakage.
     pub fn encode_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, InferenceError> {
         if texts.is_empty() {
             return Ok(Vec::new());
@@ -367,52 +369,61 @@ impl BertModel {
             return Ok(vec![self.encode(texts[0])?]);
         }
 
+        self.encode_batch_packed(texts)
+    }
+
+    /// Packed batched-encode pipeline (#677): always runs the fused batched
+    /// forward pass over `texts`, regardless of count.
+    ///
+    /// Split out from [`Self::encode_batch`] so the parity test can exercise this
+    /// path directly at batch size 1 too -- `encode_batch` itself shortcuts a
+    /// single text to [`Self::encode`], which never touches [`Self::forward_batch`].
+    fn encode_batch_packed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, InferenceError> {
         let tokenized = self.tokenizer.tokenize_batch(texts);
         let batch = tokenized.len();
         let hidden_size = self.config.hidden_size;
 
-        // `Tokenizer::tokenize_batch`'s documented contract is "pad to batch-local
-        // max," but that padding is produced by each tokenizer implementation
-        // independently (WordPiece/BPE/SentencePiece). Re-pad defensively here to
-        // one shared `seq_len` rather than trusting every implementation to agree,
-        // so a future tokenizer that pads inconsistently fails safe (extra zero
-        // rows, masked out) instead of producing a misaligned flat batch tensor.
-        let seq_len = tokenized
-            .iter()
-            .map(|input| input.input_ids.len())
-            .max()
-            .unwrap_or(2)
-            .max(1);
-
-        let rows = batch * seq_len;
-        let mut input_ids = Vec::with_capacity(rows);
-        let mut attention_mask = Vec::with_capacity(rows);
-        let mut token_type_ids = Vec::with_capacity(rows);
+        // Packed layout: concatenate each sequence's REAL tokens only (no padding),
+        // tracked via `cu_seqlens` (cumulative offsets; `cu_seqlens[b]..cu_seqlens[b
+        // + 1]` is sequence b's row range). `TokenizedInput::real_length` already
+        // records each sequence's true length independently of how the tokenizer
+        // padded it for its own batch-local `input_ids`/`token_type_ids`, so packing
+        // is a matter of slicing off the real prefix, not re-deriving it. The
+        // `max_position_embeddings` clamp mirrors `forward_with_hook`'s single-item
+        // truncation of an over-long sequence, applied per sequence rather than
+        // uniformly across the whole batch.
+        let mut cu_seqlens = Vec::with_capacity(batch + 1);
+        cu_seqlens.push(0usize);
+        let mut input_ids = Vec::new();
+        let mut token_type_ids = Vec::new();
         for input in &tokenized {
-            let real = input.input_ids.len();
-            input_ids.extend_from_slice(&input.input_ids);
-            input_ids.extend(std::iter::repeat_n(0u32, seq_len - real));
-            attention_mask.extend_from_slice(&input.attention_mask);
-            attention_mask.extend(std::iter::repeat_n(0u32, seq_len - real));
-            token_type_ids.extend_from_slice(&input.token_type_ids);
-            token_type_ids.extend(std::iter::repeat_n(0u32, seq_len - real));
+            let real = input.real_length.min(self.config.max_position_embeddings);
+            input_ids.extend_from_slice(&input.input_ids[..real]);
+            token_type_ids.extend_from_slice(&input.token_type_ids[..real]);
+            let end = cu_seqlens.last().copied().unwrap_or(0) + real;
+            cu_seqlens.push(end);
         }
 
-        let hidden = self.forward_batch(
-            &input_ids,
-            &attention_mask,
-            &token_type_ids,
-            batch,
-            seq_len,
-            &NoopLoraHook,
-        );
+        let hidden = self.forward_batch(&input_ids, &token_type_ids, &cu_seqlens, &NoopLoraHook);
+
+        // Every packed row is real, so pooling needs an all-ones mask rather than
+        // the padding-aware mask the old padded path built. One shared buffer sized
+        // to the batch's longest real sequence, sliced per item below, instead of
+        // allocating a fresh mask per sequence.
+        let max_real_len = (0..batch)
+            .map(|b| cu_seqlens[b + 1] - cu_seqlens[b])
+            .max()
+            .unwrap_or(0);
+        let ones_mask = vec![1u32; max_real_len];
 
         let mut outputs = Vec::with_capacity(batch);
         for b in 0..batch {
-            let off = b * seq_len * hidden_size;
-            let hidden_b = &hidden[off..off + seq_len * hidden_size];
-            let mask_b = &attention_mask[b * seq_len..(b + 1) * seq_len];
-            let mut pooled = self.pool(hidden_b, mask_b, seq_len);
+            let start = cu_seqlens[b];
+            let end = cu_seqlens[b + 1];
+            let real_len = end - start;
+            let hidden_b = &hidden[start * hidden_size..end * hidden_size];
+            let mask_b = &ones_mask[..real_len];
+            let mut pooled = self.pool(hidden_b, mask_b, real_len);
             l2_normalize(&mut pooled);
             outputs.push(pooled);
         }
@@ -654,15 +665,15 @@ impl BertModel {
         hidden
     }
 
-    /// Fused batched forward pass over `[batch, seq_len]` flattened, padded input.
+    /// Fused batched forward pass over a packed (padding-free) row layout (#677).
     ///
-    /// `input_ids`/`attention_mask`/`token_type_ids` are flat `batch * seq_len`
-    /// arrays (row `b * seq_len + i` is token `i` of sequence `b`); every sequence
-    /// must already be padded to the same `seq_len` (right-padded, so position 0 is
-    /// always the real leading token -- required by `cls_pool`). Returns a flat
-    /// `[batch * seq_len, hidden_size]` hidden-state tensor; callers slice out each
-    /// sequence's `[seq_len, hidden_size]` region and pool it individually with that
-    /// sequence's own mask.
+    /// `input_ids`/`token_type_ids` are the concatenation of every sequence's REAL
+    /// tokens, with no padding rows anywhere; `cu_seqlens` (length `batch + 1`,
+    /// `cu_seqlens[0] == 0`) gives the cumulative row offsets, so sequence `b`
+    /// occupies rows `cu_seqlens[b]..cu_seqlens[b + 1]`. Returns a flat
+    /// `[total, hidden_size]` hidden-state tensor (`total == cu_seqlens[batch]`);
+    /// callers slice out each sequence's `cu_seqlens[b]..cu_seqlens[b + 1]` region
+    /// and pool it individually.
     ///
     /// This is a new function, not a modification of [`Self::forward`]/
     /// [`Self::forward_with_hook`] -- `encode()` and `forward_tokenized` (used by
@@ -671,10 +682,8 @@ impl BertModel {
     fn forward_batch(
         &self,
         input_ids: &[u32],
-        attention_mask: &[u32],
         token_type_ids: &[u32],
-        batch: usize,
-        padded_seq_len: usize,
+        cu_seqlens: &[usize],
         lora: &dyn LoraHook,
     ) -> Vec<f32> {
         let hidden_size = self.config.hidden_size;
@@ -682,38 +691,33 @@ impl BertModel {
         let num_heads = self.config.num_attention_heads;
         let head_dim = self.config.head_dim();
 
-        debug_assert_eq!(input_ids.len(), batch * padded_seq_len);
-        debug_assert_eq!(attention_mask.len(), batch * padded_seq_len);
-        debug_assert_eq!(token_type_ids.len(), batch * padded_seq_len);
+        debug_assert!(!cu_seqlens.is_empty());
+        debug_assert_eq!(cu_seqlens[0], 0);
+        let batch = cu_seqlens.len() - 1;
+        let total = cu_seqlens[batch];
 
-        // Clamp exactly as the single-sequence path does (forward_with_hook), so a
-        // batch item longer than the model's position table degrades the same way
-        // encode()/encode_batch always have: excess trailing tokens are silently
-        // dropped from the forward pass (their embedding lookup and attention
-        // participation), not just truncated at the caller boundary. `padded_seq_len`
-        // remains the stride into the flat `input_ids`/`attention_mask` arrays;
-        // `seq_len` (post-clamp) is the number of positions actually computed.
-        let seq_len = padded_seq_len.min(self.config.max_position_embeddings);
-        let rows = batch * seq_len;
+        debug_assert_eq!(input_ids.len(), total);
+        debug_assert_eq!(token_type_ids.len(), total);
 
-        let used_hidden = rows * hidden_size;
-        let used_intermediate = rows * intermediate_size;
+        let used_hidden = total * hidden_size;
+        let used_intermediate = total * intermediate_size;
 
         let mut hidden = vec![0.0f32; used_hidden];
 
         // Embedding lookup: position id resets to `i` (the in-sequence index) for
-        // every sequence `b` -- the one correctness-critical detail of flattening a
-        // batch across this loop. Getting this wrong (using the flat row index
-        // instead) would give every sequence after the first wrong position
-        // embeddings.
+        // every sequence `b`, derived from `cu_seqlens` rather than a uniform
+        // stride -- the one correctness-critical detail carried over from the
+        // pre-#677 padded path's flattening. Callers (`encode_batch_packed`) are
+        // responsible for capping each sequence's real length at
+        // `max_position_embeddings` before building `cu_seqlens`/`input_ids`, the
+        // same truncation `forward_with_hook` applies per single sequence; this
+        // function trusts `cu_seqlens` to already reflect that.
         for b in 0..batch {
-            let src_offset = b * padded_seq_len;
-            let dst_offset = b * seq_len;
-            for i in 0..seq_len {
-                let src_row = src_offset + i;
-                let dst_row = dst_offset + i;
-                let tok_id = input_ids[src_row] as usize;
-                let typ_id = token_type_ids[src_row] as usize;
+            let start = cu_seqlens[b];
+            let end = cu_seqlens[b + 1];
+            for (i, row) in (start..end).enumerate() {
+                let tok_id = input_ids[row] as usize;
+                let typ_id = token_type_ids[row] as usize;
                 let pos_id = i;
 
                 debug_assert!(tok_id < self.weights.word_embeddings.rows);
@@ -726,7 +730,7 @@ impl BertModel {
                     [pos_id * hidden_size..(pos_id + 1) * hidden_size];
                 let typ_row = &self.weights.token_type_embeddings.data
                     [typ_id * hidden_size..(typ_id + 1) * hidden_size];
-                let out_row = &mut hidden[dst_row * hidden_size..(dst_row + 1) * hidden_size];
+                let out_row = &mut hidden[row * hidden_size..(row + 1) * hidden_size];
 
                 for d in 0..hidden_size {
                     out_row[d] = tok_row[d] + pos_row[d] + typ_row[d];
@@ -744,11 +748,218 @@ impl BertModel {
             self.config.layer_norm_eps,
         );
 
-        // `attention_mask` is strided by `padded_seq_len`; the attention kernel
-        // below expects a `[batch * seq_len]` array strided by the (possibly
-        // clamped) `seq_len`. These are almost always equal (clamping only fires
-        // for a batch item longer than the model's position table), so avoid the
-        // copy on the common path.
+        let mut q = vec![0.0f32; used_hidden];
+        let mut k = vec![0.0f32; used_hidden];
+        let mut v = vec![0.0f32; used_hidden];
+        let mut qkv = vec![0.0f32; used_hidden * 3];
+        let mut concat = vec![0.0f32; used_hidden];
+        let mut attn_out = vec![0.0f32; used_hidden];
+        let mut ffn_intermediate = vec![0.0f32; used_intermediate];
+        let mut temp = vec![0.0f32; used_hidden];
+
+        for layer_idx in 0..self.config.num_hidden_layers {
+            let layer = &self.weights.layers[layer_idx];
+            let fused = &self.fused_qkv[layer_idx];
+
+            multi_head_attention_batched(
+                &hidden,
+                layer,
+                &fused.weight,
+                &fused.bias,
+                cu_seqlens,
+                hidden_size,
+                num_heads,
+                head_dim,
+                &mut q,
+                &mut k,
+                &mut v,
+                &mut qkv,
+                &mut concat,
+                &mut attn_out,
+                lora,
+                layer_idx,
+            );
+
+            residual_add_layer_norm(
+                &mut hidden,
+                &attn_out,
+                layer.attn_layer_norm_weight.data,
+                layer.attn_layer_norm_bias.data,
+                hidden_size,
+                self.config.layer_norm_eps,
+            );
+
+            matmul_bt(
+                &hidden,
+                layer.ffn_intermediate_weight.data,
+                &mut ffn_intermediate,
+                total,
+                hidden_size,
+                intermediate_size,
+            );
+            // #675: route through the shared `apply_ffn_intermediate_lora_and_activation`
+            // helper so this batched path and `forward_with_hook` cannot drift.
+            // `encode_batch` only ever supplies `NoopLoraHook`, so the adapter
+            // add-in is a no-op here and this stays a direct swap for the old
+            // add_bias + gelu pair.
+            apply_ffn_intermediate_lora_and_activation(
+                lora,
+                layer_idx,
+                &hidden,
+                &mut ffn_intermediate,
+                layer.ffn_intermediate_bias.data,
+                intermediate_size,
+            );
+
+            matmul_bt(
+                &ffn_intermediate,
+                layer.ffn_output_weight.data,
+                &mut temp,
+                total,
+                intermediate_size,
+                hidden_size,
+            );
+            add_bias(&mut temp, layer.ffn_output_bias.data, hidden_size);
+            lora.apply(layer_idx, "ffn_output", &ffn_intermediate, &mut temp);
+            residual_add_layer_norm(
+                &mut hidden,
+                &temp,
+                layer.ffn_layer_norm_weight.data,
+                layer.ffn_layer_norm_bias.data,
+                hidden_size,
+                self.config.layer_norm_eps,
+            );
+        }
+
+        hidden
+    }
+
+    /// Pre-#677 padded batched-encode pipeline, preserved as a test-only reference.
+    ///
+    /// Rebuilds the `batch * seq_len` padded tensor `encode_batch` used to build
+    /// before the packed/varlen rewrite, and runs it through
+    /// [`forward_batch_padded_reference`](Self::forward_batch_padded_reference).
+    /// Exists solely so the parity test has an independently-computed ground truth
+    /// that does not share code with the packed production path.
+    #[cfg(test)]
+    fn encode_batch_padded_reference(&self, texts: &[&str]) -> Vec<Vec<f32>> {
+        let tokenized = self.tokenizer.tokenize_batch(texts);
+        let batch = tokenized.len();
+        let hidden_size = self.config.hidden_size;
+
+        let seq_len = tokenized
+            .iter()
+            .map(|input| input.input_ids.len())
+            .max()
+            .unwrap_or(2)
+            .max(1);
+
+        let rows = batch * seq_len;
+        let mut input_ids = Vec::with_capacity(rows);
+        let mut attention_mask = Vec::with_capacity(rows);
+        let mut token_type_ids = Vec::with_capacity(rows);
+        for input in &tokenized {
+            let real = input.input_ids.len();
+            input_ids.extend_from_slice(&input.input_ids);
+            input_ids.extend(std::iter::repeat_n(0u32, seq_len - real));
+            attention_mask.extend_from_slice(&input.attention_mask);
+            attention_mask.extend(std::iter::repeat_n(0u32, seq_len - real));
+            token_type_ids.extend_from_slice(&input.token_type_ids);
+            token_type_ids.extend(std::iter::repeat_n(0u32, seq_len - real));
+        }
+
+        let hidden = self.forward_batch_padded_reference(
+            &input_ids,
+            &attention_mask,
+            &token_type_ids,
+            batch,
+            seq_len,
+            &NoopLoraHook,
+        );
+
+        let mut outputs = Vec::with_capacity(batch);
+        for b in 0..batch {
+            let off = b * seq_len * hidden_size;
+            let hidden_b = &hidden[off..off + seq_len * hidden_size];
+            let mask_b = &attention_mask[b * seq_len..(b + 1) * seq_len];
+            let mut pooled = self.pool(hidden_b, mask_b, seq_len);
+            l2_normalize(&mut pooled);
+            outputs.push(pooled);
+        }
+
+        outputs
+    }
+
+    /// Pre-#677 padded batched forward pass, preserved as a test-only reference.
+    ///
+    /// This is [`Self::forward_batch`] as it existed before the packed/varlen
+    /// rewrite: `input_ids`/`attention_mask`/`token_type_ids` are flat
+    /// `batch * seq_len` arrays (row `b * seq_len + i` is token `i` of sequence
+    /// `b`), every sequence padded to the same `seq_len`. It exists solely to give
+    /// the parity test an independent ground truth for the packed production path,
+    /// computed through a genuinely different (not just relabeled) code path.
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    fn forward_batch_padded_reference(
+        &self,
+        input_ids: &[u32],
+        attention_mask: &[u32],
+        token_type_ids: &[u32],
+        batch: usize,
+        padded_seq_len: usize,
+        lora: &dyn LoraHook,
+    ) -> Vec<f32> {
+        use crate::attention::multi_head_attention_batched_padded_reference;
+
+        let hidden_size = self.config.hidden_size;
+        let intermediate_size = self.config.intermediate_size;
+        let num_heads = self.config.num_attention_heads;
+        let head_dim = self.config.head_dim();
+
+        debug_assert_eq!(input_ids.len(), batch * padded_seq_len);
+        debug_assert_eq!(attention_mask.len(), batch * padded_seq_len);
+        debug_assert_eq!(token_type_ids.len(), batch * padded_seq_len);
+
+        let seq_len = padded_seq_len.min(self.config.max_position_embeddings);
+        let rows = batch * seq_len;
+
+        let used_hidden = rows * hidden_size;
+        let used_intermediate = rows * intermediate_size;
+
+        let mut hidden = vec![0.0f32; used_hidden];
+
+        for b in 0..batch {
+            let src_offset = b * padded_seq_len;
+            let dst_offset = b * seq_len;
+            for i in 0..seq_len {
+                let src_row = src_offset + i;
+                let dst_row = dst_offset + i;
+                let tok_id = input_ids[src_row] as usize;
+                let typ_id = token_type_ids[src_row] as usize;
+                let pos_id = i;
+
+                let tok_row = &self.weights.word_embeddings.data
+                    [tok_id * hidden_size..(tok_id + 1) * hidden_size];
+                let pos_row = &self.weights.position_embeddings.data
+                    [pos_id * hidden_size..(pos_id + 1) * hidden_size];
+                let typ_row = &self.weights.token_type_embeddings.data
+                    [typ_id * hidden_size..(typ_id + 1) * hidden_size];
+                let out_row = &mut hidden[dst_row * hidden_size..(dst_row + 1) * hidden_size];
+
+                for d in 0..hidden_size {
+                    out_row[d] = tok_row[d] + pos_row[d] + typ_row[d];
+                }
+            }
+        }
+
+        layer_norm(
+            &mut hidden,
+            self.weights.embedding_layer_norm_weight.data,
+            self.weights.embedding_layer_norm_bias.data,
+            hidden_size,
+            self.config.layer_norm_eps,
+        );
+
         let attention_mask_clamped: Vec<u32>;
         let attention_mask: &[u32] = if seq_len == padded_seq_len {
             attention_mask
@@ -775,7 +986,7 @@ impl BertModel {
             let layer = &self.weights.layers[layer_idx];
             let fused = &self.fused_qkv[layer_idx];
 
-            multi_head_attention_batched(
+            multi_head_attention_batched_padded_reference(
                 &hidden,
                 layer,
                 &fused.weight,
@@ -813,11 +1024,6 @@ impl BertModel {
                 hidden_size,
                 intermediate_size,
             );
-            // #675: route through the shared `apply_ffn_intermediate_lora_and_activation`
-            // helper so this batched path and `forward_with_hook` cannot drift.
-            // `encode_batch` only ever supplies `NoopLoraHook`, so the adapter
-            // add-in is a no-op here and this stays a direct swap for the old
-            // add_bias + gelu pair.
             apply_ffn_intermediate_lora_and_activation(
                 lora,
                 layer_idx,
@@ -1174,6 +1380,124 @@ mod tests {
                 max_abs_diff <= 1e-4,
                 "boundary text[{i}]: max-abs-diff {max_abs_diff} > 1e-4"
             );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Packed vs padded batched-encode parity (#677, mutation-sensitive)
+    //
+    // Guards the packed/varlen batched-encode rewrite: `encode_batch_packed`'s
+    // packed `cu_seqlens`-indexed forward pass must match `encode_batch_padded_reference`'s
+    // independently computed pre-#677 padded forward pass (preserved verbatim as a
+    // `#[cfg(test)]`-only reference; see `forward_batch_padded_reference` and
+    // `crate::attention::multi_head_attention_batched_padded_reference`).
+    //
+    // Both sides call `encode_batch_packed`/`encode_batch_padded_reference`
+    // directly, bypassing the public `encode_batch`'s single-item shortcut
+    // (which calls `encode()` and never touches either batched kernel), so a
+    // batch of size 1 genuinely exercises the packed kernel's degenerate
+    // one-segment `cu_seqlens = [0, total]` case instead of trivially matching
+    // by construction.
+    //
+    // Parametrized over four shapes; the max-variance shape ([1, 2, 128]-ish
+    // real tokens) is the one most likely to expose an off-by-one in the
+    // per-sequence `cu_seqlens[b]`/`cu_seqlens[b + 1]` window that
+    // `multi_head_attention_batched` indexes with -- a wrong offset there
+    // shows up as a large divergence on the longest sequence, not a rounding
+    // difference, since it would pull in (or drop) real rows from a
+    // neighboring sequence's attention window.
+    //
+    // NOT literal bit-for-bit equality. Measured directly on this model: any
+    // sequence that is the batch's longest (so the padded reference never
+    // actually padded it) comes back exactly bit-identical (`max_abs_diff ==
+    // 0.0`), but a sequence that WAS padded in the reference lands within
+    // ~2e-7 absolute of the packed output, not `0`. Isolated with a standalone
+    // harness varying only attention's total row count (real rows identical,
+    // extra masked padding rows appended): `multi_head_attention`'s output for
+    // the same real rows shifts by 1 ULP once the masked-out row count
+    // changes, even though `exp(-inf) == 0` zeroes every padding contribution
+    // algebraically. Apple's Accelerate `cblas_sgemm` (the `matmul_bt`
+    // backend on this platform) and the SIMD softmax reduction are not
+    // proven shape-invariant at the bit level for a fixed set of real
+    // rows plus a varying number of masked rows; only the row COUNT changes,
+    // but that changes GEMM tiling/blocking and reduction order, which
+    // reassociates the sum. This is the same class of accepted f32
+    // reassociation already documented elsewhere in this crate (e.g. the
+    // LoRA adapter reorder in `forward_with_hook`), just measured here to a
+    // much tighter bound than that convention's cosine/max-abs-diff check
+    // because this parity claim is far stronger (identical kernel, only the
+    // row count and per-sequence real length differ). `TOLERANCE` below is
+    // ~45x the largest diff measured across all four shapes on this model,
+    // and still 10x tighter than the crate's existing batched-vs-solo parity
+    // tolerance (1e-4) -- a genuine `cu_seqlens` indexing bug pulls in a
+    // neighboring sequence's rows and blows through it by several orders of
+    // magnitude, not a rounding-scale amount; that class stays caught.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    #[ignore]
+    fn encode_batch_packed_matches_padded() {
+        let Ok(model_dir) = std::env::var("LATTICE_INFERENCE_MODEL_DIR") else {
+            return;
+        };
+        let model = BertModel::from_directory(Path::new(&model_dir)).unwrap();
+
+        let short = "hi";
+        let medium = "the quick brown fox jumps over the lazy dog";
+        let long_text = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod \
+            tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam quis \
+            nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis \
+            aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat \
+            nulla pariatur excepteur sint occaecat cupidatat non proident sunt in culpa qui \
+            officia deserunt mollit anim id est laborum";
+        let uniform_64 = "word ".repeat(64);
+        let one_word = "a";
+        let two_words = "hi there";
+        let long_128 = "word ".repeat(128);
+
+        let shapes: Vec<(&str, Vec<&str>)> = vec![
+            ("single_row", vec![medium]),
+            (
+                "uniform_three_same_length",
+                vec![
+                    uniform_64.as_str(),
+                    uniform_64.as_str(),
+                    uniform_64.as_str(),
+                ],
+            ),
+            (
+                "max_variance_1_2_128",
+                vec![one_word, two_words, long_128.as_str()],
+            ),
+            ("mixed_5_30_100", vec![short, medium, long_text]),
+        ];
+
+        // ~45x the largest max-abs-diff measured across all four shapes on this
+        // model (2.2e-7), and 10x tighter than the crate's existing batched-vs-solo
+        // parity tolerance (1e-4, see `test_encode_batch_matches_per_item_encode_mixed_lengths`).
+        const TOLERANCE: f32 = 1e-5;
+
+        for (name, texts) in shapes {
+            let packed = model.encode_batch_packed(&texts).unwrap();
+            let padded = model.encode_batch_padded_reference(&texts);
+
+            assert_eq!(packed.len(), padded.len(), "{name}: output count mismatch");
+            for (i, (p, q)) in packed.iter().zip(padded.iter()).enumerate() {
+                assert_eq!(
+                    p.len(),
+                    q.len(),
+                    "{name}: text[{i}] embedding length mismatch"
+                );
+                let max_abs_diff = p
+                    .iter()
+                    .zip(q.iter())
+                    .map(|(a, b)| (a - b).abs())
+                    .fold(0.0f32, f32::max);
+                assert!(
+                    max_abs_diff <= TOLERANCE,
+                    "{name}: text[{i}] packed vs padded max_abs_diff {max_abs_diff} exceeds {TOLERANCE}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`encode_batch` padded every sequence to the batch-local max length and ran all
position-wise matmuls (embedding, fused QKV, FFN) over `batch * seq_len` rows. On
mixed-length batches those padding rows are pure waste: attention masks them out
and pooling ignores them. A `[5, 100]`-token batch computed 200 rows for 105 real
tokens.

This switches the batched path to a **packed / varlen layout**: each sequence's
real tokens are concatenated, and a `cu_seqlens` cumulative-offset index marks
segment boundaries. Position-wise matmuls run over the packed row count;
per-sequence attention indexes each segment by `cu_seqlens[b]..cu_seqlens[b+1]`
instead of a uniform stride, with no padding rows to mask. **The public
`encode_batch` signature is unchanged.**

## Correctness

Real-token outputs are numerically equivalent to the padded path, but **not
bit-identical**, and that is expected and understood:

- The **longest sequence** in each batch (never padded in the old path) comes back
  **bit-identical** (`max_abs_diff == 0.0`).
- **Shorter sequences** land within **~2e-7 absolute**. The old path ran an extra
  masked softmax over padding columns; even though `exp(-inf)` zeroes those columns
  algebraically, the extra masked rows change GEMM tiling and softmax reduction
  order, which reassociates the f32 sums. The packed path skips that spurious work,
  so it is the **cleaner** computation, not a drift from truth.

This is the same accepted-f32-reassociation class already documented elsewhere in
this crate (e.g. the LoRA adapter reorder in `forward_with_hook`).

Gates:
- New `encode_batch_packed_matches_padded` asserts packed vs a verbatim-preserved
  pre-change padded reference within **1e-5** (~45x the largest measured diff,
  10x tighter than the crate's existing batched-vs-solo tolerance) across
  **single-row, uniform, max-variance, and mixed** shapes.
- Existing `test_encode_batch_matches_per_item_encode_mixed_lengths` (batched vs
  per-item encode, the transitive HF-parity gate) still passes at 1e-4.
- Attention indexing has a mutation-checked unit test (shifting a `cu_seqlens`
  entry by +1 fails it).
- All model-gated tests pass on `bge-small-en-v1.5`; full `lattice-inference` lib
  suite green; `clippy --workspace --all-targets -D warnings` clean.

## Performance (`make bench-compare` equivalent: same-worktree source-swap A/B)

The public `encode_batch` signature is unchanged, so the padded baseline was
measured by swapping only the two source files back to `main` in a single binary
and re-running the same bench. `bge-small-en-v1.5`, packed vs padded:

| batch | shape | change | notes |
|-------|-------|--------|-------|
| `mixed_5_30_100` | high length-variance | **−44.2%** (CI [−44.7%, −43.7%], p<0.05) | matches the ~45% real-token fraction; robust |
| `uniform_100` | 3× same length | **no change beyond noise** | see below |

`uniform_100` first reported a "+23% regression", but a **same-binary re-run**
(packed vs identical packed code) then showed **−16.9%** — a ~20% swing on
identical code. The uniform bench is simply noisy (wider CIs, fewer samples per
window); mechanistically a uniform batch has no padding, so packed and padded do
identical work. There is **no real regression** on uniform batches; the win is
concentrated exactly where padding exists.

## Scope

Internal batched-encode layout only. No public API change, no numerics change
beyond the accepted ~2e-7 reassociation, no new dependencies.
