### PR TITLE
quality(quant): honest perplexity.tsv + hardened harness + Q4 PPL regression gate (#616)

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -605,11 +605,15 @@ jobs:
 
       # Regenerate the ephemeral unrotated Q4 artifact (NOT committed) from the
       # real weights. Deterministic: quantize_q4 has no random seed.
+      # quantize_q4 writes .q4/.f16/quantize_index.json but NOT config.json, and
+      # eval_perplexity's load_cfg_for_q4 reads config.json from the Q4 dir — so
+      # copy it in (the tokenizer is supplied separately via --tokenizer-dir).
       - name: Generate ephemeral Q4 artifact
         run: |
           target/release/quantize_q4 \
             --model-dir ~/.lattice/models/qwen3.5-0.8b \
             --output-dir "$RUNNER_TEMP/qwen3.5-0.8b-q4"
+          cp ~/.lattice/models/qwen3.5-0.8b/config.json "$RUNNER_TEMP/qwen3.5-0.8b-q4/config.json"
 
       - name: Run Q4 PPL regression gate
         env:

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -75,7 +75,7 @@ jobs:
           # still triggers wasm-parity. Without them, engine stays false and the
           # required parity-gate could pass green without the wasm path ever
           # running, a fail-open on the gate itself.
-          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/e2e_parity_check\.py$|^\.github/workflows/e2e-parity\.yml$|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$|^scripts/ppl_gate_check\.py$|^crates/inference/tests/fixtures/ppl_gate_v1/|^crates/inference/src/bin/eval_perplexity\.rs$|^crates/inference/src/bin/quantize_q4\.rs$' <<<"$CHANGED" >/dev/null; then
+          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/e2e_parity_check\.py$|^\.github/workflows/e2e-parity\.yml$|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$|^scripts/ppl_gate_check\.py$|^crates/inference/tests/fixtures/ppl_gate_v1/|^crates/inference/src/bin/eval_perplexity\.rs$|^crates/inference/src/bin/quantize_q4\.rs$|^docs/bench_results/wiki\.test\.raw$' <<<"$CHANGED" >/dev/null; then
             echo "engine=true" >> "$GITHUB_OUTPUT"
             echo "→ engine surface changed: parity REQUIRED"
           else
@@ -501,6 +501,27 @@ jobs:
             --features "f16,metal-gpu" \
             -- --nocapture
 
+  # Fail-closed control-flow self-test for the Q4 PPL gate script (issue #616).
+  # Cheap, deterministic, GPU-free (sandbox tree + stub eval_perplexity), so —
+  # unlike q4-ppl-quality, whose PPL golden bootstraps on the runner — this has
+  # no bootstrap and is wired into parity-gate.needs as a REQUIRED guard from day
+  # one. It locks the gate's fail-closed contract (RECORD-on-null, ENFORCE
+  # pass/fail, hard-fail on every provisioning/parse error, env-record cannot
+  # mask an armed golden, non-finite golden rejected) against future regressions.
+  ppl-gate-selftest:
+    name: ppl-gate selftest
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run ppl-gate control-flow self-test
+        run: bash scripts/ppl_gate_check_selftest.sh
+
   # Q4 perplexity regression gate (issue #616). Measures the UNROTATED Metal Q4
   # tier (the actually-shipping quantization) over a fixed WikiText-2 slice and
   # compares against a frozen golden PPL.
@@ -619,7 +640,7 @@ jobs:
   # its golden is armed (see that job's comment).
   parity-gate:
     name: parity-gate
-    needs: [changes, parity, embed-drift, wasm-parity, q4-composed]
+    needs: [changes, parity, embed-drift, wasm-parity, q4-composed, ppl-gate-selftest]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -631,7 +652,8 @@ jobs:
           DRIFT_RESULT="${{ needs.embed-drift.result }}"
           WASM_RESULT="${{ needs.wasm-parity.result }}"
           Q4_RESULT="${{ needs.q4-composed.result }}"
-          echo "changes=$CHANGES_RESULT engine=$ENGINE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT q4-composed=$Q4_RESULT"
+          PPL_SELFTEST_RESULT="${{ needs.ppl-gate-selftest.result }}"
+          echo "changes=$CHANGES_RESULT engine=$ENGINE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT q4-composed=$Q4_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT"
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::change-detection did not succeed — failing closed."
             exit 1
@@ -656,5 +678,9 @@ jobs:
             echo "::error::Engine changed and q4-composed golden did not succeed (result=$Q4_RESULT)."
             exit 1
           fi
-          echo "Engine changed; parity, embed-drift, wasm-parity, and q4-composed all PASSED."
+          if [ "$PPL_SELFTEST_RESULT" != "success" ]; then
+            echo "::error::Engine changed and ppl-gate self-test did not succeed (result=$PPL_SELFTEST_RESULT)."
+            exit 1
+          fi
+          echo "Engine changed; parity, embed-drift, wasm-parity, q4-composed, and ppl-gate-selftest all PASSED."
           exit 0

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -537,18 +537,17 @@ jobs:
   # Why an absolute golden captured on THIS runner (paravirtual Metal): the Q4
   # forward path is numerically correct on the hosted runner (proven by q4-composed)
   # but absolute PPL differs from real Apple-GPU, so the golden must be captured
-  # here. Bootstrap: golden.json ships `ppl: null`, so the first run executes in
-  # RECORD mode (scripts/ppl_gate_check.py) — it PRINTS + PR-comments the measured
-  # paravirtual PPL and does NOT fail. A maintainer commits that value into
-  # crates/inference/tests/fixtures/ppl_gate_v1/golden.json, after which the gate
+  # here. The golden was captured via a null-sentinel RECORD bootstrap (run
+  # 28841919096) and is now ARMED (golden.json `ppl` = 16.589111). The gate
   # enforces fail-closed (|measured - golden| > tolerance). Corpus-slice size and
   # tolerance rationale are documented in golden.json.
   #
-  # Deliberately NOT in parity-gate.needs below yet: while the golden is null the
-  # gate is fail-OPEN (record mode), so wiring it into the required gate now would
-  # add a fail-open leg. Once the golden is armed, add `q4-ppl-quality` to
-  # parity-gate.needs AND to the repo's required status checks (same maintainer
-  # step as embed-drift / wasm-parity / q4-composed).
+  # ARMED + REQUIRED: this job is wired into parity-gate.needs (the required
+  # status check). To keep the required leg from being silently de-armed, the run
+  # step below sets LATTICE_PPL_GATE_REQUIRE_ARMED=1 — if a future change reverts
+  # `ppl` to null, the gate fails CLOSED here instead of re-entering the fail-open
+  # RECORD mode. Deliberate re-capture (per golden.json `_regenerate`) runs the
+  # binary/script WITHOUT that flag.
   q4-ppl-quality:
     name: q4 ppl regression gate
     needs: changes
@@ -620,6 +619,9 @@ jobs:
           LATTICE_PPL_Q4_DIR: ${{ runner.temp }}/qwen3.5-0.8b-q4
           LATTICE_PPL_TOKENIZER_DIR: ~/.lattice/models/qwen3.5-0.8b
           PPL_GATE_REPORT: ppl-gate-report.md
+          # Required gate: refuse to pass green if the golden is ever de-armed
+          # (ppl reverted to null). RECORD-mode re-capture runs without this flag.
+          LATTICE_PPL_GATE_REQUIRE_ARMED: "1"
         run: python3 scripts/ppl_gate_check.py
 
       - name: Ensure report exists

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -638,13 +638,14 @@ jobs:
 
   # REQUIRED status check. Always runs, always reports. Passes when the engine
   # did not change (nothing to verify); mirrors the parity, embed-drift,
-  # wasm-parity, and q4-composed verdicts when it did. Fails closed if
-  # change-detection itself errored. metal-parity is deliberately excluded
-  # (informational — see its comment above). q4-ppl-quality is excluded until
-  # its golden is armed (see that job's comment).
+  # wasm-parity, q4-composed, ppl-gate-selftest, and q4-ppl-quality verdicts when
+  # it did. Fails closed if change-detection itself errored. metal-parity is
+  # deliberately excluded (informational — see its comment above). q4-ppl-quality
+  # is now armed (golden captured on run 28841919096) and gates the shipping Q4
+  # tier for regressions.
   parity-gate:
     name: parity-gate
-    needs: [changes, parity, embed-drift, wasm-parity, q4-composed, ppl-gate-selftest]
+    needs: [changes, parity, embed-drift, wasm-parity, q4-composed, ppl-gate-selftest, q4-ppl-quality]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -657,7 +658,8 @@ jobs:
           WASM_RESULT="${{ needs.wasm-parity.result }}"
           Q4_RESULT="${{ needs.q4-composed.result }}"
           PPL_SELFTEST_RESULT="${{ needs.ppl-gate-selftest.result }}"
-          echo "changes=$CHANGES_RESULT engine=$ENGINE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT q4-composed=$Q4_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT"
+          Q4PPL_RESULT="${{ needs.q4-ppl-quality.result }}"
+          echo "changes=$CHANGES_RESULT engine=$ENGINE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT q4-composed=$Q4_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT q4-ppl-quality=$Q4PPL_RESULT"
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::change-detection did not succeed — failing closed."
             exit 1
@@ -686,5 +688,9 @@ jobs:
             echo "::error::Engine changed and ppl-gate self-test did not succeed (result=$PPL_SELFTEST_RESULT)."
             exit 1
           fi
-          echo "Engine changed; parity, embed-drift, wasm-parity, q4-composed, and ppl-gate-selftest all PASSED."
+          if [ "$Q4PPL_RESULT" != "success" ]; then
+            echo "::error::Engine changed and q4-ppl-quality regression gate did not succeed (result=$Q4PPL_RESULT)."
+            exit 1
+          fi
+          echo "Engine changed; parity, embed-drift, wasm-parity, q4-composed, ppl-gate-selftest, and q4-ppl-quality all PASSED."
           exit 0

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -75,7 +75,7 @@ jobs:
           # still triggers wasm-parity. Without them, engine stays false and the
           # required parity-gate could pass green without the wasm path ever
           # running, a fail-open on the gate itself.
-          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/e2e_parity_check\.py$|^\.github/workflows/e2e-parity\.yml$|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$' <<<"$CHANGED" >/dev/null; then
+          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/e2e_parity_check\.py$|^\.github/workflows/e2e-parity\.yml$|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$|^scripts/ppl_gate_check\.py$|^crates/inference/tests/fixtures/ppl_gate_v1/|^crates/inference/src/bin/eval_perplexity\.rs$|^crates/inference/src/bin/quantize_q4\.rs$' <<<"$CHANGED" >/dev/null; then
             echo "engine=true" >> "$GITHUB_OUTPUT"
             echo "→ engine surface changed: parity REQUIRED"
           else
@@ -501,11 +501,122 @@ jobs:
             --features "f16,metal-gpu" \
             -- --nocapture
 
+  # Q4 perplexity regression gate (issue #616). Measures the UNROTATED Metal Q4
+  # tier (the actually-shipping quantization) over a fixed WikiText-2 slice and
+  # compares against a frozen golden PPL.
+  #
+  # Why unrotated Q4 and not the QuaRot delta: the original ADR-044 gate asserted
+  # `quarot - unrotated < 0.5`. On the current forward path offline QuaRot v0 is
+  # net-NEGATIVE (+1.9 PPL worse than unrotated asymmetric Q4) by design — Hadamard
+  # forces symmetric Q4 (worse fidelity floor) and offline v0 has no online R3/R4
+  # rotation to recover it. A "quarot must win" gate would red main on a known,
+  # accepted limitation. So #616 repoints the gate to catch a REGRESSION in the
+  # shipping tier. See ADR-044 "Conclusion superseded (2026-07-06)" + issue #703.
+  #
+  # Why an absolute golden captured on THIS runner (paravirtual Metal): the Q4
+  # forward path is numerically correct on the hosted runner (proven by q4-composed)
+  # but absolute PPL differs from real Apple-GPU, so the golden must be captured
+  # here. Bootstrap: golden.json ships `ppl: null`, so the first run executes in
+  # RECORD mode (scripts/ppl_gate_check.py) — it PRINTS + PR-comments the measured
+  # paravirtual PPL and does NOT fail. A maintainer commits that value into
+  # crates/inference/tests/fixtures/ppl_gate_v1/golden.json, after which the gate
+  # enforces fail-closed (|measured - golden| > tolerance). Corpus-slice size and
+  # tolerance rationale are documented in golden.json.
+  #
+  # Deliberately NOT in parity-gate.needs below yet: while the golden is null the
+  # gate is fail-OPEN (record mode), so wiring it into the required gate now would
+  # add a fail-open leg. Once the golden is armed, add `q4-ppl-quality` to
+  # parity-gate.needs AND to the repo's required status checks (same maintainer
+  # step as embed-drift / wasm-parity / q4-composed).
+  q4-ppl-quality:
+    name: q4 ppl regression gate
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache Python packages
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/pip
+          key: q4-composed-pip-${{ runner.os }}-py311-v1
+
+      - name: Cache HF model weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
+          key: hf-qwen35-0.8b-v1
+
+      - name: Install Python deps
+        run: pip install "huggingface_hub==1.20.1"
+
+      - name: Download Qwen3.5-0.8B weights
+        run: |
+          python3 -c "
+          from huggingface_hub import snapshot_download
+          print(f'Model at: {snapshot_download(\"Qwen/Qwen3.5-0.8B\")}')
+          "
+
+      - name: Setup lattice model dir
+        run: |
+          MODEL_CACHE=$(python3 -c "
+          from huggingface_hub import snapshot_download
+          print(snapshot_download('Qwen/Qwen3.5-0.8B'))
+          ")
+          mkdir -p ~/.lattice/models
+          ln -sf "$MODEL_CACHE" ~/.lattice/models/qwen3.5-0.8b
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: q4-ppl-quality
+
+      - name: Build eval_perplexity + quantize_q4
+        run: |
+          cargo build --release -p lattice-inference \
+            --bin eval_perplexity --bin quantize_q4 --features "f16,metal-gpu"
+
+      # Regenerate the ephemeral unrotated Q4 artifact (NOT committed) from the
+      # real weights. Deterministic: quantize_q4 has no random seed.
+      - name: Generate ephemeral Q4 artifact
+        run: |
+          target/release/quantize_q4 \
+            --model-dir ~/.lattice/models/qwen3.5-0.8b \
+            --output-dir "$RUNNER_TEMP/qwen3.5-0.8b-q4"
+
+      - name: Run Q4 PPL regression gate
+        env:
+          LATTICE_PPL_Q4_DIR: ${{ runner.temp }}/qwen3.5-0.8b-q4
+          LATTICE_PPL_TOKENIZER_DIR: ~/.lattice/models/qwen3.5-0.8b
+          PPL_GATE_REPORT: ppl-gate-report.md
+        run: python3 scripts/ppl_gate_check.py
+
+      - name: Ensure report exists
+        if: always()
+        run: |
+          test -s ppl-gate-report.md || {
+            printf '## Q4 perplexity regression gate (#616)\n\nNo report produced. Check job logs.\n' > ppl-gate-report.md
+          }
+
+      - name: Post PPL gate report
+        if: github.event_name == 'pull_request' && always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: q4-ppl-gate
+          path: ppl-gate-report.md
+
   # REQUIRED status check. Always runs, always reports. Passes when the engine
   # did not change (nothing to verify); mirrors the parity, embed-drift,
   # wasm-parity, and q4-composed verdicts when it did. Fails closed if
   # change-detection itself errored. metal-parity is deliberately excluded
-  # (informational — see its comment above).
+  # (informational — see its comment above). q4-ppl-quality is excluded until
+  # its golden is armed (see that job's comment).
   parity-gate:
     name: parity-gate
     needs: [changes, parity, embed-drift, wasm-parity, q4-composed]

--- a/crates/inference/tests/fixtures/ppl_gate_v1/golden.json
+++ b/crates/inference/tests/fixtures/ppl_gate_v1/golden.json
@@ -9,8 +9,9 @@
   "stride": 256,
   "max_tokens": 2048,
 
-  "ppl": null,
+  "ppl": 16.589111,
   "tolerance": 0.05,
+  "_captured_from": "GitHub Actions run 28841919096 (RECORD mode, macos-latest paravirtual Metal, head 66d45fcf5), 2026-07-07. https://github.com/ohdearquant/lattice/actions/runs/28841919096 . Notable: this paravirtual value matches a real-GPU M2 Max measurement (16.589166) to 5.5e-5 for THIS Q4 eval path — see kg note. Runner-capture stays the default for new paths regardless.",
 
   "_capture": "The `ppl` value MUST be captured on the CI runner (GitHub macos-latest, PARAVIRTUAL Metal), NOT on a real Apple GPU. The Q4 forward path is numerically correct on paravirtual (proven by the q4-composed token-ID gate) but absolute PPL differs from real-GPU, so a real-GPU number would false-fail here. Bootstrap: the first CI run executes in RECORD mode (ppl==null) and prints the paravirtual PPL as a PR comment; commit that value here, then arm the gate (add q4-ppl-quality to parity-gate.needs + repo required checks).",
 

--- a/crates/inference/tests/fixtures/ppl_gate_v1/golden.json
+++ b/crates/inference/tests/fixtures/ppl_gate_v1/golden.json
@@ -1,0 +1,22 @@
+{
+  "_purpose": "Frozen Q4 perplexity golden for the #616 regression gate. Consumed by scripts/ppl_gate_check.py, run by the q4-ppl-quality job in .github/workflows/e2e-parity.yml.",
+  "_gate": "Fails closed if |measured - ppl| > tolerance, where `measured` is unrotated Metal Q4 PPL over the corpus slice below. Catches a regression in the SHIPPING quantization tier. NOT the QuaRot delta gate (offline QuaRot v0 is net-negative by design; see ADR-044 conclusion-superseded amendment + #703).",
+
+  "model": "Qwen3.5-0.8B",
+  "tier": "q4-unrotated",
+  "corpus": "docs/bench_results/wiki.test.raw",
+  "window": 512,
+  "stride": 256,
+  "max_tokens": 2048,
+
+  "ppl": null,
+  "tolerance": 0.05,
+
+  "_capture": "The `ppl` value MUST be captured on the CI runner (GitHub macos-latest, PARAVIRTUAL Metal), NOT on a real Apple GPU. The Q4 forward path is numerically correct on paravirtual (proven by the q4-composed token-ID gate) but absolute PPL differs from real-GPU, so a real-GPU number would false-fail here. Bootstrap: the first CI run executes in RECORD mode (ppl==null) and prints the paravirtual PPL as a PR comment; commit that value here, then arm the gate (add q4-ppl-quality to parity-gate.needs + repo required checks).",
+
+  "_corpus_slice_sensitivity": "max_tokens=2048 scores ~2047 tokens across ~7 windows of 512 (stride 256), ~20s on the runner — chosen as the wall-time knee. PPL on this fixed slice reads ABOVE the full-corpus canonical because shorter context accumulation biases per-token NLL upward: real-GPU measured 16.59 on this 2048-token slice vs 15.73 on the full 310K-token corpus (~+0.86). That bias is CONSTANT for a fixed slice+window schedule, so it does not affect a regression gate comparing against a golden captured on the identical slice. Enlarging the slice lowers absolute PPL and tightens run-to-run variance, at ~linear wall-cost. The slice bias is a property of the corpus+schedule (roughly env-independent); the absolute golden itself is env-specific (paravirtual) and comes from CI.",
+
+  "_tolerance_rationale": "0.05 is conservative: >> expected run-to-run Metal reduction-ordering variance (PPL is deterministic over a fixed corpus+schedule in exact arithmetic; GPU float-reduction reorder wobble is ~1e-3), and << the smallest meaningful quantization regression (llama.cpp community: Q4 PPL deltas start ~0.1). Confirm the observed variance on the first few CI runs and tighten if the runner proves tighter than 0.05.",
+
+  "_regenerate": "Deliberate + reviewable, never auto-done by CI. Re-run the q4-ppl-quality job (or eval_perplexity --q4-dir <ephemeral> --tokenizer-dir <model> --corpus-file docs/bench_results/wiki.test.raw --window 512 --stride 256 --max-tokens 2048 --json) on the target runner, read the measured PPL, update `ppl`, and note the commit SHA it was captured on in the PR."
+}

--- a/docs/bench_results/perplexity.tsv
+++ b/docs/bench_results/perplexity.tsv
@@ -1,6 +1,19 @@
-lattice	q4	19.266338	2048
-lattice	q4-quarot	19.950512	2048
-  q8: PPL = 15.8218 (2041 tokens)
-  q4: PPL = 18.1839 (2041 tokens)
+# perplexity.tsv — Q4 quantization quality, lattice tiers vs MLX cross-check
+# Regenerated 2026-07-07T03:22Z from ae1f91cfc (real GPU). Qwen3.5-0.8B, WikiText-2 raw test,
+#   window=512 stride=256 max_tokens=2048, QuaRot seed=0xC0FFEE.
+#   PPL is deterministic over a fixed corpus + window schedule (one run is canonical).
+# ADR-044 reconciliation: ADR-044 step-4 recorded QuaRot Q4 as -1.61 PPL BETTER than
+#   unrotated Q4 (full corpus). That was measured on a PRE-RoPE-fix forward path (May 2026).
+#   A code-bisection on identical corpus/slice/seed shows the delta sign is set by code
+#   version, not corpus: ADR-044-era binary = -0.81 (QuaRot better), current binary = +1.90
+#   (QuaRot worse). Forward-path fixes improved the unrotated baseline ~4.5 PPL but QuaRot
+#   only ~1.8 — QuaRot was compensating for baseline bugs since fixed. Offline QuaRot v0 is
+#   net-negative by design (Hadamard forces symmetric Q4, worse fidelity floor); the missing
+#   mechanism is online R3/R4 (issue #703). See also #616. Columns: engine<TAB>tier<TAB>ppl<TAB>tokens
+lattice	q4	16.589166	2048
+lattice	q4-quarot	19.007144	2048
+# informational: quarot-unrotated delta = +2.4180 at max_tokens=2048 (offline v0 net-negative, #703)
+# mlx rows carried from prior reference run (mlx-lm has a transformers-version incompat in this venv,
+#   out of scope for #616; re-run scripts/bench_quality.sh once mlx-lm is fixed to refresh these).
 mlx	q8	15.8218	2041
 mlx	q4	18.1839	2041

--- a/scripts/bench_quality.sh
+++ b/scripts/bench_quality.sh
@@ -19,18 +19,36 @@ set -uo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 EVAL_BIN="$REPO/target/release/eval_perplexity"
-Q4_DIR="$HOME/.lattice/models/qwen3.5-0.8b-q4"
-QUAROT_DIR="$HOME/.lattice/models/qwen3.5-0.8b-q4-quarot"
-TOK_DIR="$HOME/.lattice/models/qwen3.5-0.8b"
+Q4_DIR="${Q4_DIR:-$HOME/.lattice/models/qwen3.5-0.8b-q4}"
+QUAROT_DIR="${QUAROT_DIR:-$HOME/.lattice/models/qwen3.5-0.8b-q4-quarot}"
+TOK_DIR="${TOK_DIR:-$HOME/.lattice/models/qwen3.5-0.8b}"
 OUT="$REPO/docs/bench_results"
 CORPUS="$OUT/wiki.test.raw"
 DATA="$OUT/perplexity.tsv"
 MAX_TOKENS="${MAX_TOKENS:-2048}"   # ~20s on Metal Q4 (107 tok/s scoring rate)
 WINDOW="${WINDOW:-512}"            # Buffer is window*vocab*4 = ~508MB at vocab=248K
 STRIDE="${STRIDE:-256}"            # 2x stride overlap → adequate context coverage
+SEED="${SEED:-0xC0FFEE}"           # QuaRot rotation seed (artifacts not interchangeable across seeds)
+SKIP_MLX="${SKIP_MLX:-0}"          # set 1 to skip the MLX cross-check (no mlx-lm / offline)
 
 mkdir -p "$OUT"
 : > "$DATA"
+SHA="$(git -C "$REPO" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+STAMP="$(date -u +%Y-%m-%dT%H:%MZ)"
+{
+  echo "# perplexity.tsv — Q4 quantization quality, lattice tiers vs MLX cross-check"
+  echo "# Regenerated $STAMP from $SHA (real GPU). Qwen3.5-0.8B, WikiText-2 raw test,"
+  echo "#   window=$WINDOW stride=$STRIDE max_tokens=$MAX_TOKENS, QuaRot seed=$SEED."
+  echo "#   PPL is deterministic over a fixed corpus + window schedule (one run is canonical)."
+  echo "# ADR-044 reconciliation: ADR-044 step-4 recorded QuaRot Q4 as -1.61 PPL BETTER than"
+  echo "#   unrotated Q4 (full corpus). That was measured on a PRE-RoPE-fix forward path (May 2026)."
+  echo "#   A code-bisection on identical corpus/slice/seed shows the delta sign is set by code"
+  echo "#   version, not corpus: ADR-044-era binary = -0.81 (QuaRot better), current binary = +1.90"
+  echo "#   (QuaRot worse). Forward-path fixes improved the unrotated baseline ~4.5 PPL but QuaRot"
+  echo "#   only ~1.8 — QuaRot was compensating for baseline bugs since fixed. Offline QuaRot v0 is"
+  echo "#   net-negative by design (Hadamard forces symmetric Q4, worse fidelity floor); the missing"
+  echo "#   mechanism is online R3/R4 (issue #703). See also #616. Columns: engine<TAB>tier<TAB>ppl<TAB>tokens"
+} >> "$DATA"
 echo "=== Perplexity bench | Qwen3.5-0.8B | WikiText-2 test | window=$WINDOW stride=$STRIDE max_tokens=$MAX_TOKENS ==="
 
 # ---- Corpus check ----
@@ -54,6 +72,7 @@ if [[ -d "$Q4_DIR" ]] && [[ -x "$EVAL_BIN" ]]; then
     --max-tokens "$MAX_TOKENS" 2>&1)
   PPL=$(echo "$OUT_TXT" | extract_ppl | head -1)
   echo "  PPL: ${PPL:-PARSE_FAILED}"
+  Q4PPL="$PPL"
   [[ -n "$PPL" ]] && printf "lattice\tq4\t%s\t%s\n" "$PPL" "$MAX_TOKENS" >> "$DATA"
 else
   echo "  lattice/q4: SKIP (no $Q4_DIR; quantize via target/release/quantize_q4 to enable)"
@@ -67,14 +86,28 @@ if [[ -d "$QUAROT_DIR" ]] && [[ -x "$EVAL_BIN" ]]; then
     --max-tokens "$MAX_TOKENS" 2>&1)
   PPL=$(echo "$OUT_TXT" | extract_ppl | head -1)
   echo "  PPL: ${PPL:-PARSE_FAILED}"
+  QRPPL="$PPL"
   [[ -n "$PPL" ]] && printf "lattice\tq4-quarot\t%s\t%s\n" "$PPL" "$MAX_TOKENS" >> "$DATA"
 else
   echo "  lattice/q4-quarot: SKIP (no $QUAROT_DIR)"
 fi
 
+# ---- QuaRot delta (INFORMATIONAL, not a gate — offline v0 is net-negative, see header/#703) ----
+if [[ -n "${Q4PPL:-}" ]] && [[ -n "${QRPPL:-}" ]]; then
+  DELTA=$(awk -v q="$Q4PPL" -v r="$QRPPL" 'BEGIN{printf "%+.4f", r-q}')
+  echo "  QuaRot delta (quarot-unrotated): $DELTA  [informational; positive = QuaRot worse]"
+  echo "# informational: quarot-unrotated delta = $DELTA at max_tokens=$MAX_TOKENS (offline v0 net-negative, #703)" >> "$DATA"
+fi
+
 # ---- MLX Q8 + Q4 (cross-check) ----
+if [[ "$SKIP_MLX" == "1" ]]; then
+  echo "─── MLX cross-check: SKIP (SKIP_MLX=1) ───"
+else
 echo "─── MLX (Q8 + Q4 cross-check) ───"
-uv run --quiet --with mlx-lm python3 - "$TOK_DIR" "$CORPUS" "$WINDOW" "$STRIDE" "$MAX_TOKENS" <<'PY' >> "$DATA" 2>&1 | tee /tmp/mlx_ppl.log
+# Capture stdout to a temp; only clean "mlx<TAB>..." rows are appended to $DATA so a
+# broken mlx-lm (import/tokenizer errors) can never pollute the data file. stderr → log.
+MLX_TMP="$(mktemp)"
+uv run --quiet --with mlx-lm python3 - "$TOK_DIR" "$CORPUS" "$WINDOW" "$STRIDE" "$MAX_TOKENS" > "$MLX_TMP" 2>/tmp/mlx_ppl.log <<'PY'
 import sys, math
 mdir, corpus, window, stride, max_tokens = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5])
 import mlx.core as mx
@@ -115,13 +148,16 @@ def ppl_at_bits(bits, label):
 ppl_at_bits(8, "q8")
 ppl_at_bits(4, "q4")
 PY
+grep -E '^mlx	' "$MLX_TMP" >> "$DATA" || echo "  MLX cross-check produced no rows (see /tmp/mlx_ppl.log)"
+rm -f "$MLX_TMP"
+fi
 
 echo ""
 echo "═══ Perplexity Summary ═══"
 if [[ -s "$DATA" ]]; then
   printf "  %-10s %-10s %10s %10s\n" "engine" "tier" "PPL ↓" "tokens"
   printf "  %s\n" "----------------------------------------"
-  awk -F'\t' '{printf "  %-10s %-10s %10s %10s\n", $1, $2, $3, $4}' "$DATA"
+  awk -F'\t' '/^#/{next} NF>=4{printf "  %-10s %-10s %10s %10s\n", $1, $2, $3, $4}' "$DATA"
 else
   echo "  (no measurements completed)"
 fi

--- a/scripts/ppl_gate_check.py
+++ b/scripts/ppl_gate_check.py
@@ -28,12 +28,13 @@ so it catches regressions while the env-specific offset is baked into the golden
 
 Modes
 -----
-  RECORD  (LATTICE_PPL_GATE_RECORD=1, or golden `ppl` is null): measure and print
-          the PPL, DO NOT fail on value. Used to bootstrap the golden — the first
-          CI run on the runner prints the paravirtual PPL, a maintainer commits it
-          into golden.json, and the gate goes live. Loud banner marks this as an
-          UNARMED (fail-open) state.
-  ENFORCE (default when golden `ppl` is numeric): fail-closed if
+  RECORD  (entered iff golden `ppl` is null): measure and print the PPL, DO NOT
+          fail on value. Used to bootstrap the golden — the first CI run on the
+          runner prints the paravirtual PPL, a maintainer commits it into
+          golden.json, and the gate goes live. Loud banner marks this UNARMED
+          (fail-open) state. LATTICE_PPL_GATE_RECORD=1 is ignored once the golden
+          is numeric — an env flag can never suppress enforcement.
+  ENFORCE (whenever golden `ppl` is numeric): fail-closed if
           |measured - golden| > tolerance.
 
 Fail-closed contract: any provisioning/execution failure (binary missing, no PPL
@@ -42,6 +43,7 @@ a skip-as-green — a broken run must not masquerade as a passing gate.
 """
 
 import json
+import math
 import os
 import subprocess
 import sys
@@ -67,12 +69,20 @@ def main() -> None:
     if not eval_bin.exists():
         fail(f"eval_perplexity not built at {eval_bin}")
 
-    q4_dir = os.environ.get("LATTICE_PPL_Q4_DIR")
-    tok_dir = os.environ.get("LATTICE_PPL_TOKENIZER_DIR")
-    if not q4_dir or not Path(q4_dir).is_dir():
-        fail(f"LATTICE_PPL_Q4_DIR unset or not a directory: {q4_dir!r}")
-    if not tok_dir or not Path(tok_dir).is_dir():
-        fail(f"LATTICE_PPL_TOKENIZER_DIR unset or not a directory: {tok_dir!r}")
+    def resolve_dir(var: str) -> str:
+        # GitHub Actions `env:` values are NOT shell-expanded, so a `~` or
+        # `$HOME` reaches us literally. Expand both here so the caller can use
+        # either form; a still-unresolved path fails closed below.
+        raw = os.environ.get(var)
+        if not raw:
+            fail(f"{var} unset")
+        resolved = os.path.expanduser(os.path.expandvars(raw))
+        if not Path(resolved).is_dir():
+            fail(f"{var} is not a directory: {raw!r} (resolved: {resolved!r})")
+        return resolved
+
+    q4_dir = resolve_dir("LATTICE_PPL_Q4_DIR")
+    tok_dir = resolve_dir("LATTICE_PPL_TOKENIZER_DIR")
 
     corpus = REPO / spec["corpus"]
     if not corpus.exists():
@@ -115,9 +125,24 @@ def main() -> None:
         sys.stderr.write(proc.stdout)
         fail("no @@lattice perplexity event parsed from eval_perplexity output")
 
-    golden_ppl = spec.get("ppl")
+    # Validate golden numerics: a non-finite tolerance (e.g. "1e999" -> inf) or
+    # golden ppl would make enforcement a fail-open no-op. Reject, fail closed.
     tol = float(spec["tolerance"])
-    record = os.environ.get("LATTICE_PPL_GATE_RECORD") == "1" or golden_ppl is None
+    if not (math.isfinite(tol) and tol > 0):
+        fail(f"golden tolerance must be a finite positive number, got {spec['tolerance']!r}")
+    golden_ppl = spec.get("ppl")
+    if golden_ppl is not None:
+        golden_ppl = float(golden_ppl)
+        if not (math.isfinite(golden_ppl) and golden_ppl > 0):
+            fail(f"golden ppl must be null or a finite positive number, got {spec.get('ppl')!r}")
+
+    # RECORD mode (measure-only, no value enforcement) is entered ONLY when the
+    # golden is unarmed (ppl is null). A numeric golden ALWAYS enforces — an env
+    # flag cannot suppress enforcement, otherwise a regression could be forced to
+    # exit 0. The env flag only makes the *unarmed* state explicit locally.
+    record = golden_ppl is None
+    if os.environ.get("LATTICE_PPL_GATE_RECORD") == "1" and not record:
+        print("::warning::LATTICE_PPL_GATE_RECORD ignored: golden is armed (numeric); enforcing.")
 
     report = REPO / os.environ.get("PPL_GATE_REPORT", "ppl-gate-report.md")
     lines = [

--- a/scripts/ppl_gate_check.py
+++ b/scripts/ppl_gate_check.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Q4 perplexity regression gate (issue #616).
+
+Runs `eval_perplexity` on the *unrotated* Metal Q4 tier (the actually-shipping
+quantization) over a fixed corpus slice and compares the result against a golden
+PPL frozen in `crates/inference/tests/fixtures/ppl_gate_v1/golden.json`.
+
+Why a frozen-golden regression gate and not the QuaRot delta gate
+-----------------------------------------------------------------
+The original ADR-044 dual-Q4 gate asserted `quarot - unrotated < 0.5`. On the
+current forward path offline QuaRot v0 is a *net-negative* (+1.9 PPL worse than
+unrotated asymmetric Q4) by design — Hadamard rotation forces symmetric Q4,
+which has a worse fidelity floor, and offline v0 has no online R3/R4 rotation to
+recover it (see ADR-044 "Conclusion superseded (2026-07-06)" and issue #703).
+A `quarot must win` gate would therefore red main on a known, accepted
+limitation. So #616 repoints the gate onto the shipping tier: catch a
+*regression* in unrotated Q4 PPL against a known-good baseline.
+
+Why an absolute golden captured on the CI runner (not a relative delta)
+-----------------------------------------------------------------------
+GitHub's `macos-latest` exposes a PARAVIRTUAL Metal device. The Q4 forward path
+is numerically correct there (proven by the `q4-composed` token-ID gate), but
+absolute PPL differs from a real Apple-GPU. A CPU-BF16-vs-Metal-Q4 relative gate
+would NOT cancel that quirk (the two numbers come from different compute paths,
+only one of which is paravirtual). The honest, env-robust design is an absolute
+golden *captured on the same paravirtual runner*: run-to-run it is reproducible,
+so it catches regressions while the env-specific offset is baked into the golden.
+
+Modes
+-----
+  RECORD  (LATTICE_PPL_GATE_RECORD=1, or golden `ppl` is null): measure and print
+          the PPL, DO NOT fail on value. Used to bootstrap the golden — the first
+          CI run on the runner prints the paravirtual PPL, a maintainer commits it
+          into golden.json, and the gate goes live. Loud banner marks this as an
+          UNARMED (fail-open) state.
+  ENFORCE (default when golden `ppl` is numeric): fail-closed if
+          |measured - golden| > tolerance.
+
+Fail-closed contract: any provisioning/execution failure (binary missing, no PPL
+line parsed, corpus missing, golden missing while enforcing) is a hard FAIL, never
+a skip-as-green — a broken run must not masquerade as a passing gate.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+REPO = Path(__file__).resolve().parents[1]
+GOLDEN = REPO / "crates/inference/tests/fixtures/ppl_gate_v1/golden.json"
+
+
+def fail(msg: str) -> NoReturn:
+    print(f"::error::[ppl-gate] {msg}", file=sys.stderr)
+    print(f"\nFAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    if not GOLDEN.exists():
+        fail(f"golden not found: {GOLDEN}")
+    spec = json.loads(GOLDEN.read_text())
+
+    eval_bin = REPO / "target/release/eval_perplexity"
+    if not eval_bin.exists():
+        fail(f"eval_perplexity not built at {eval_bin}")
+
+    q4_dir = os.environ.get("LATTICE_PPL_Q4_DIR")
+    tok_dir = os.environ.get("LATTICE_PPL_TOKENIZER_DIR")
+    if not q4_dir or not Path(q4_dir).is_dir():
+        fail(f"LATTICE_PPL_Q4_DIR unset or not a directory: {q4_dir!r}")
+    if not tok_dir or not Path(tok_dir).is_dir():
+        fail(f"LATTICE_PPL_TOKENIZER_DIR unset or not a directory: {tok_dir!r}")
+
+    corpus = REPO / spec["corpus"]
+    if not corpus.exists():
+        fail(f"corpus not found: {corpus}")
+
+    cmd = [
+        str(eval_bin),
+        "--q4-dir",
+        q4_dir,
+        "--tokenizer-dir",
+        tok_dir,
+        "--corpus-file",
+        str(corpus),
+        "--window",
+        str(spec["window"]),
+        "--stride",
+        str(spec["stride"]),
+        "--max-tokens",
+        str(spec["max_tokens"]),
+        "--json",
+        "--label",
+        "q4",
+    ]
+    print(f"[ppl-gate] running: {' '.join(cmd)}", flush=True)
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    sys.stderr.write(proc.stderr)
+    if proc.returncode != 0:
+        fail(f"eval_perplexity exited {proc.returncode}")
+
+    # Parse the machine-readable event line: @@lattice {"ev":"perplexity",...}
+    measured = None
+    tokens = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("@@lattice "):
+            obj = json.loads(line[len("@@lattice ") :])
+            if obj.get("ev") == "perplexity" and obj.get("label") == "q4":
+                measured = float(obj["ppl"])
+                tokens = int(obj["tokens"])
+    if measured is None:
+        sys.stderr.write(proc.stdout)
+        fail("no @@lattice perplexity event parsed from eval_perplexity output")
+
+    golden_ppl = spec.get("ppl")
+    tol = float(spec["tolerance"])
+    record = os.environ.get("LATTICE_PPL_GATE_RECORD") == "1" or golden_ppl is None
+
+    report = REPO / os.environ.get("PPL_GATE_REPORT", "ppl-gate-report.md")
+    lines = [
+        "## Q4 perplexity regression gate (#616)",
+        "",
+        "- tier: unrotated Metal Q4 (shipping)",
+        f"- corpus: `{spec['corpus']}`, first {spec['max_tokens']} tokens",
+        f"- window/stride: {spec['window']}/{spec['stride']}",
+        f"- tokens scored: {tokens}",
+        f"- **measured PPL: {measured:.6f}**",
+    ]
+
+    if record:
+        lines += [
+            f"- golden PPL: {'null (UNARMED)' if golden_ppl is None else f'{golden_ppl:.6f}'}",
+            "",
+            "> **GATE UNARMED (fail-open).** This run is in RECORD mode. To arm the",
+            "> gate: commit the measured PPL above into",
+            "> `crates/inference/tests/fixtures/ppl_gate_v1/golden.json` (`ppl` field),",
+            "> then add `q4-ppl-quality` to `parity-gate.needs` and to the repository's",
+            "> required status checks. Until then this gate reports but does not block.",
+        ]
+        report.write_text("\n".join(lines) + "\n")
+        print("\n".join(lines))
+        print(f"\n[ppl-gate] RECORD mode — measured PPL {measured:.6f} (gate not enforced)")
+        return
+
+    delta = abs(measured - float(golden_ppl))
+    passed = delta <= tol
+    lines += [
+        f"- golden PPL: {float(golden_ppl):.6f}",
+        f"- tolerance: {tol:.6f}",
+        f"- |measured - golden|: {delta:.6f}",
+        f"- verdict: **{'PASS' if passed else 'FAIL'}**",
+    ]
+    report.write_text("\n".join(lines) + "\n")
+    print("\n".join(lines))
+    if not passed:
+        fail(
+            f"Q4 PPL regressed: measured {measured:.6f} vs golden {float(golden_ppl):.6f} "
+            f"(|Δ|={delta:.6f} > tol={tol:.6f})"
+        )
+    print(
+        f"\n[ppl-gate] PASS — Q4 PPL {measured:.6f} within {tol:.6f} "
+        f"of golden {float(golden_ppl):.6f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ppl_gate_check.py
+++ b/scripts/ppl_gate_check.py
@@ -144,6 +144,19 @@ def main() -> None:
     if os.environ.get("LATTICE_PPL_GATE_RECORD") == "1" and not record:
         print("::warning::LATTICE_PPL_GATE_RECORD ignored: golden is armed (numeric); enforcing.")
 
+    # When this gate is wired as a REQUIRED status check, an unarmed golden must
+    # NOT pass green: reverting `ppl` to null would otherwise silently de-arm the
+    # gate while branch protection still sees a success. The required CI job sets
+    # LATTICE_PPL_GATE_REQUIRE_ARMED=1 so a null/missing golden fails closed here.
+    # RECORD mode stays available for the deliberate re-capture bootstrap (run
+    # without this flag), and the sandbox self-test still exercises the null path.
+    if record and os.environ.get("LATTICE_PPL_GATE_REQUIRE_ARMED") == "1":
+        fail(
+            "golden ppl is null/missing but LATTICE_PPL_GATE_REQUIRE_ARMED=1: this "
+            "is a required gate and must be armed. Commit a numeric `ppl` into the "
+            "golden fixture, or run without the flag to re-capture in RECORD mode."
+        )
+
     report = REPO / os.environ.get("PPL_GATE_REPORT", "ppl-gate-report.md")
     lines = [
         "## Q4 perplexity regression gate (#616)",

--- a/scripts/ppl_gate_check_selftest.sh
+++ b/scripts/ppl_gate_check_selftest.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ppl_gate_check.py control flow (issue #616).
+#
+# The gate is a fail-closed CI guard; this proves each branch's exit code in an
+# isolated sandbox (a fake REPO tree + a stub eval_perplexity), touching neither
+# the real repo nor the GPU. Run locally or in the cheap CI lane:
+#   bash scripts/ppl_gate_check_selftest.sh
+#
+# Guards, in order: RECORD-on-null, ENFORCE pass, ENFORCE fail, and every
+# fail-closed path (binary error even in RECORD, missing corpus/dir, unparsed
+# output, env-record cannot mask an armed golden, non-finite golden/tolerance).
+set -uo pipefail
+
+SRC="$(cd "$(dirname "$0")/.." && pwd)/scripts/ppl_gate_check.py"
+SB="$(mktemp -d)/repo"
+mkdir -p "$SB/scripts" "$SB/target/release" \
+         "$SB/crates/inference/tests/fixtures/ppl_gate_v1" \
+         "$SB/docs/bench_results" "$SB/q4dir" "$SB/tokdir"
+cp "$SRC" "$SB/scripts/ppl_gate_check.py"
+echo "some corpus text" > "$SB/docs/bench_results/wiki.test.raw"
+touch "$SB/q4dir/config.json" "$SB/tokdir/tokenizer.json"
+
+golden() {  # $1 = ppl (number or the literal null), $2 = tolerance (default 0.05)
+  cat > "$SB/crates/inference/tests/fixtures/ppl_gate_v1/golden.json" <<EOF
+{ "model":"m","tier":"q4","corpus":"docs/bench_results/wiki.test.raw",
+  "window":512,"stride":256,"max_tokens":2048,"ppl":$1,"tolerance":${2:-0.05} }
+EOF
+}
+
+stub() {  # $1 = emitted ppl, $2 = exit code
+  cat > "$SB/target/release/eval_perplexity" <<EOF
+#!/usr/bin/env bash
+echo '@@lattice {"ev":"perplexity","label":"q4","ppl":$1,"nll":2.8,"tokens":2047,"windows":7,"ms":100}'
+exit $2
+EOF
+  chmod +x "$SB/target/release/eval_perplexity"
+}
+
+run() {  # extra env as "KEY=VAL" args; captures combined output to $OUT, returns rc
+  OUT="$(cd "$SB" && env LATTICE_PPL_Q4_DIR="$SB/q4dir" \
+        LATTICE_PPL_TOKENIZER_DIR="$SB/tokdir" \
+        PPL_GATE_REPORT="$SB/report.md" "$@" \
+        python3 scripts/ppl_gate_check.py 2>&1)"
+  return $?
+}
+
+pass=0; fail=0
+check() {  # $1=desc $2=expected_exit $3=actual_exit $4=must_contain
+  if [ "$2" = "$3" ] && grep -qF "$4" <<<"$OUT"; then
+    echo "  PASS: $1 (exit $3)"; pass=$((pass+1))
+  else
+    echo "  FAIL: $1 — expected exit $2 got $3; wanted substring: $4"
+    echo "        output: $(tr '\n' '|' <<<"$OUT" | tail -c 300)"
+    fail=$((fail+1))
+  fi
+}
+
+echo "=== ppl_gate_check.py control-flow self-test ==="
+
+golden null;   stub 16.60 0; run;                          check "RECORD/null golden -> exit0 UNARMED"        0 $? "GATE UNARMED"
+golden 16.60;  stub 16.61 0; run;                          check "ENFORCE within tol -> exit0 PASS"           0 $? "verdict: **PASS**"
+golden 16.60;  stub 17.00 0; run;                          check "ENFORCE out of tol -> exit1 FAIL"           1 $? "Q4 PPL regressed"
+golden null;   stub 16.60 3; run;                          check "ERROR binary rc=3 in RECORD -> exit1"       1 $? "eval_perplexity exited 3"
+golden 16.60;  stub 16.61 0; run LATTICE_PPL_GATE_RECORD=1; check "env-record cannot mask armed golden (pass)" 0 $? "verdict: **PASS**"
+golden 16.60;  stub 17.00 0; run LATTICE_PPL_GATE_RECORD=1; check "env-record cannot mask armed regression"    1 $? "Q4 PPL regressed"
+golden 16.60 1e999; stub 17.00 0; run;                     check "non-finite tolerance rejected -> exit1"     1 $? "finite positive"
+golden -1 0.05; stub 16.60 0; run;                         check "non-positive golden ppl rejected -> exit1"  1 $? "finite positive"
+
+# provisioning / parse failures must all fail closed
+golden 16.60; stub 16.61 0; rm -f "$SB/docs/bench_results/wiki.test.raw"; run
+check "corpus missing -> exit1" 1 $? "corpus not found"
+echo "some corpus text" > "$SB/docs/bench_results/wiki.test.raw"
+
+golden 16.60; stub 16.61 0
+OUT="$(cd "$SB" && env LATTICE_PPL_Q4_DIR="$SB/nonexistent" \
+      LATTICE_PPL_TOKENIZER_DIR="$SB/tokdir" PPL_GATE_REPORT="$SB/report.md" \
+      python3 scripts/ppl_gate_check.py 2>&1)"
+check "q4 dir missing -> exit1" 1 $? "not a directory"
+
+# path resolution: $VAR / ~ in the env value must be expanded, not taken literally
+golden null; stub 16.60 0
+OUT="$(cd "$SB" && env LATTICE_PPL_Q4_DIR="$SB/q4dir" REALTOK="$SB/tokdir" \
+      LATTICE_PPL_TOKENIZER_DIR='${REALTOK}' PPL_GATE_REPORT="$SB/report.md" \
+      python3 scripts/ppl_gate_check.py 2>&1)"
+check "env-var in path is expanded (not literal) -> exit0" 0 $? "measured PPL"
+
+golden 16.60; stub 16.61 0
+printf '#!/usr/bin/env bash\necho "no structured event"\nexit 0\n' > "$SB/target/release/eval_perplexity"
+chmod +x "$SB/target/release/eval_perplexity"; run
+check "no event line -> exit1" 1 $? "no @@lattice perplexity event"
+
+echo ""
+echo "=== $pass passed, $fail failed ==="
+rm -rf "$(dirname "$SB")"
+[ "$fail" = 0 ]

--- a/scripts/ppl_gate_check_selftest.sh
+++ b/scripts/ppl_gate_check_selftest.sh
@@ -8,7 +8,8 @@
 #
 # Guards, in order: RECORD-on-null, ENFORCE pass, ENFORCE fail, and every
 # fail-closed path (binary error even in RECORD, missing corpus/dir, unparsed
-# output, env-record cannot mask an armed golden, non-finite golden/tolerance).
+# output, env-record cannot mask an armed golden, require-armed rejects a null
+# golden on the required leg, non-finite golden/tolerance).
 set -uo pipefail
 
 SRC="$(cd "$(dirname "$0")/.." && pwd)/scripts/ppl_gate_check.py"
@@ -63,6 +64,8 @@ golden 16.60;  stub 17.00 0; run;                          check "ENFORCE out of
 golden null;   stub 16.60 3; run;                          check "ERROR binary rc=3 in RECORD -> exit1"       1 $? "eval_perplexity exited 3"
 golden 16.60;  stub 16.61 0; run LATTICE_PPL_GATE_RECORD=1; check "env-record cannot mask armed golden (pass)" 0 $? "verdict: **PASS**"
 golden 16.60;  stub 17.00 0; run LATTICE_PPL_GATE_RECORD=1; check "env-record cannot mask armed regression"    1 $? "Q4 PPL regressed"
+golden null;   stub 16.60 0; run LATTICE_PPL_GATE_REQUIRE_ARMED=1; check "require-armed + null golden -> exit1" 1 $? "required gate and must be armed"
+golden 16.60;  stub 16.61 0; run LATTICE_PPL_GATE_REQUIRE_ARMED=1; check "require-armed + armed golden enforces" 0 $? "verdict: **PASS**"
 golden 16.60 1e999; stub 17.00 0; run;                     check "non-finite tolerance rejected -> exit1"     1 $? "finite positive"
 golden -1 0.05; stub 16.60 0; run;                         check "non-positive golden ppl rejected -> exit1"  1 $? "finite positive"
 


### PR DESCRIPTION
Closes #616. Regenerates the stale `perplexity.tsv`, hardens the bench harness, and wires the Q4 perplexity gate into CI.

## Context — the premise changed mid-task

#616 asked to (a) regenerate the stale `perplexity.tsv` that contradicted ADR-044, and (b) wire the QuaRot delta gate into CI. A controlled code-bisection established *why* the tsv contradicted ADR-044: ADR-044's "QuaRot beats Q4 by 1.61 PPL" was a **pre-RoPE-fix artifact**. On current code QuaRot is **+1.90 PPL worse** than unrotated asymmetric Q4 (same corpus/slice/seed; only the code version flips the sign). Full write-up in the ADR-044 amendment (#704) and #703.

Consequence: a fail-closed `quarot − unrotated < 0.5` gate would red main on a **known-accepted** limitation. So the gate is repointed: **gate the unrotated asymmetric Q4 path** (the actually-shipping tier) against a frozen golden, catching a *regression* in the shipping quantization. The QuaRot delta stays **informational** in the tsv, carrying the offline-v0-net-negative note.

## Part 1 — honest data + hardened harness

**`perplexity.tsv` regenerated honest** (real GPU, M2 Max; Qwen3.5-0.8B, WikiText-2 raw test, window 512 / stride 256, seed `0xC0FFEE`):

| engine | tier | PPL | tokens |
|--------|------|-----|--------|
| lattice | q4 | 16.589166 | 2048 |
| lattice | q4-quarot | 19.007144 | 2048 |
| mlx | q8 | 15.8218 | 2041 |
| mlx | q4 | 18.1839 | 2041 |

Prior committed numbers (q4 19.27 / quarot 19.95) were stale. The file now carries a `#` provenance header + the ADR-044 reconciliation. Full-corpus canonical: unrotated 15.73 / QuaRot 17.63 / delta +1.90.

**`bench_quality.sh` hardened:** env-overridable `Q4_DIR`/`QUAROT_DIR`/`TOK_DIR`/`SEED`; emits provenance header + reconciliation; computes the quarot−unrotated delta as **informational** (not a gate); `SKIP_MLX` guard; and a **bug fix** — a failing `mlx-lm` previously dumped its Python traceback straight into `perplexity.tsv` via `>> $DATA 2>&1`; now only clean `mlx\t…` rows are appended.

## Part 2 — CI gate (`q4-ppl-quality`)

A new job in `e2e-parity.yml` runs `eval_perplexity` on the unrotated Metal Q4 tier over a fixed 2048-token WikiText-2 slice and compares against a frozen golden, fail-closed past tolerance. Modeled on the `q4-composed` gate (ephemeral artifact from real weights, `LATTICE_*_ENFORCE`-style fail-closed contract, engine-change detection, not auto-added to required checks).

**Paravirtual-golden bootstrap.** GitHub's `macos-latest` is paravirtual Metal — the Q4 forward path is numerically correct there (proven by `q4-composed`) but absolute PPL differs from real GPU, so the golden must be captured *on the runner*. `golden.json` ships `ppl: null`; the first CI run self-bootstraps in **RECORD mode** — it prints and PR-comments the measured paravirtual PPL and does **not** fail (loud UNARMED banner). A maintainer commits that value into `golden.json`, then arms the gate (adds `q4-ppl-quality` to `parity-gate.needs` + repo required checks). Until armed it reports but does not block — no fail-open leg in the required gate.

**Corpus-slice sensitivity** (documented in `golden.json`): the 2048-token slice reads ~0.9 PPL above the full-corpus canonical (16.59 vs 15.73) because shorter context accumulation biases per-token NLL upward. That bias is **constant** for a fixed slice+schedule, so it does not affect a regression gate comparing against a golden captured on the identical slice. 2048 tokens ≈ 20s scoring — the wall-time knee. Tolerance 0.05 is >> expected Metal reduction-reorder wobble (~1e-3) and << the smallest meaningful quant regression (~0.1, llama.cpp floor).

## Review + hardening

Adversarial review returned **APPROVE-WITH-FIXES**; all 4 findings applied in the follow-up commit:

1. **Path expansion** — GitHub Actions `env:` doesn't expand `~`/`$HOME`; the script now `expanduser`+`expandvars` both dir inputs (else the tokenizer-dir check would fail before the first run could record a PPL).
2. **Change-detection** — added `docs/bench_results/wiki.test.raw` to the engine-change grep (it's a gate input via the golden; a corpus-only edit must not skip the gate).
3. **Record escape hatch** — RECORD mode is now entered iff the golden is null; `LATTICE_PPL_GATE_RECORD=1` can no longer suppress enforcement on an armed golden (a regression can't be forced to exit 0).
4. **Non-finite golden** — a tolerance of `1e999` (→ inf) or non-finite/non-positive golden ppl is rejected (would otherwise make enforcement a fail-open no-op).

Added `scripts/ppl_gate_check_selftest.sh` — a deterministic, GPU-free control-flow self-test (sandbox tree + stub `eval_perplexity`) proving all 12 branches including every fail-closed path. It has no bootstrap, so it's wired as the `ppl-gate-selftest` ubuntu job and into `parity-gate.needs` as a **required** guard from day one (the PPL-value golden arms later on the runner).

## Status

- [x] `perplexity.tsv` regenerated honest + `bench_quality.sh` hardened
- [x] `q4-ppl-quality` CI job + fail-closed `ppl_gate_check.py` + `golden.json`
- [x] review fixes applied + `ppl-gate-selftest` required guard (12/12 self-test cases green)
- [ ] **Arm the golden**: read the RECORD-mode PPL from this PR's first CI run, commit it into `golden.json`, add `q4-ppl-quality` to `parity-gate.needs` + required checks
- mlx cross-check rows carried from the prior reference run (mlx-lm transformers-version incompat in this venv; out of scope for #616)

Refs #616, #703, #704, #622.
