### PR TITLE
fix(inference): guard matmul_bt_q8 dimension products against usize overflow

### DIFF
--- a/crates/inference/src/weights/q8_weights.rs
+++ b/crates/inference/src/weights/q8_weights.rs
@@ -136,6 +136,14 @@ pub fn quantize_matrix(w: &[f32], rows: usize, cols: usize) -> Result<Q8Matrix, 
 /// The activation input remains f32, so the inner product is accumulated in f32 and the
 /// per-row scale is applied once per output element.
 pub fn matmul_bt_q8(a: &[f32], b_q: &Q8Matrix, c: &mut [f32], m: usize, k: usize, n: usize) {
+    // Guard the dimension products against usize overflow BEFORE any `m * k` /
+    // `n * k` / `m * n` is evaluated below: in release those multiplies wrap
+    // silently, so an overflowing shape could pass a length check and drive an
+    // out-of-bounds access. Mirrors the same guards in `matmul_bt`
+    // (forward/cpu/matmul.rs); `matmul_bt_q8` was missing them.
+    assert!(m.checked_mul(k).is_some(), "matmul shape overflow: m*k");
+    assert!(n.checked_mul(k).is_some(), "matmul shape overflow: n*k");
+    assert!(m.checked_mul(n).is_some(), "matmul shape overflow: m*n");
     assert_eq!(a.len(), m * k, "A length does not match m * k");
     assert_eq!(b_q.rows, n, "B_q rows do not match n");
     assert_eq!(b_q.cols, k, "B_q cols do not match k");
@@ -823,6 +831,50 @@ mod tests {
         assert!(approx_eq(c[1], expected1, 1e-6));
         assert!(approx_eq(c[0], -0.01, 1e-6));
         assert!(approx_eq(c[1], -3.82, 1e-6));
+    }
+
+    /// Tiny valid Q8Matrix for the overflow-guard tests: the guards fire before
+    /// `b_q` is inspected, so shape need only be self-consistent.
+    fn dummy_q8_1x1() -> Q8Matrix {
+        Q8Matrix {
+            data: vec![0i8],
+            scales: vec![0.0f32],
+            rows: 1,
+            cols: 1,
+        }
+    }
+
+    /// Overflow guard: `m * k` must be rejected before the length `assert_eq!`
+    /// wraps it. Mutation-sensitive — dropping the `m*k` guard makes this fall
+    /// through to the `A length does not match m * k` assert (m*k wraps in
+    /// release), changing the panic message and failing this `expected`.
+    #[test]
+    #[should_panic(expected = "matmul shape overflow: m*k")]
+    fn test_matmul_bt_q8_rejects_mk_overflow() {
+        let q = dummy_q8_1x1();
+        let mut c = vec![0.0f32; 1];
+        // m*k overflows; n*k and m*n do not.
+        matmul_bt_q8(&[], &q, &mut c, usize::MAX, 2, 1);
+    }
+
+    /// Overflow guard: `n * k` (m*k passes first).
+    #[test]
+    #[should_panic(expected = "matmul shape overflow: n*k")]
+    fn test_matmul_bt_q8_rejects_nk_overflow() {
+        let q = dummy_q8_1x1();
+        let mut c = vec![0.0f32; 1];
+        // m*k = 1*2 ok; n*k = MAX*2 overflows.
+        matmul_bt_q8(&[0.0, 0.0], &q, &mut c, 1, 2, usize::MAX);
+    }
+
+    /// Overflow guard: `m * n` (m*k and n*k pass first).
+    #[test]
+    #[should_panic(expected = "matmul shape overflow: m*n")]
+    fn test_matmul_bt_q8_rejects_mn_overflow() {
+        let q = dummy_q8_1x1();
+        let mut c = vec![0.0f32; 1];
+        // m*k = MAX*1 ok; n*k = 2*1 ok; m*n = MAX*2 overflows.
+        matmul_bt_q8(&[], &q, &mut c, usize::MAX, 1, 2);
     }
 
     #[test]

--- a/crates/inference/src/weights/q8_weights.rs
+++ b/crates/inference/src/weights/q8_weights.rs
@@ -165,6 +165,20 @@ pub fn matmul_bt_q8(a: &[f32], b_q: &Q8Matrix, c: &mut [f32], m: usize, k: usize
     #[cfg(target_os = "macos")]
     {
         const TILE_N: usize = 64;
+        // The tile scratch buffers are sized by `TILE_N * k` and `m * TILE_N`,
+        // which are NOT covered by the `m*k` / `n*k` / `m*n` guards above: when
+        // `n < TILE_N` (including `n == 0`) these products can overflow while the
+        // guarded ones do not, and a wrapped size would under-allocate the
+        // scratch and drive an OOB scatter below. Guard them on the same
+        // fail-closed contract.
+        assert!(
+            TILE_N.checked_mul(k).is_some(),
+            "matmul shape overflow: TILE_N*k"
+        );
+        assert!(
+            m.checked_mul(TILE_N).is_some(),
+            "matmul shape overflow: m*TILE_N"
+        );
         let mut b_f32 = vec![0.0f32; TILE_N * k];
         let mut c_tile = vec![0.0f32; m * TILE_N];
 
@@ -875,6 +889,42 @@ mod tests {
         let mut c = vec![0.0f32; 1];
         // m*k = MAX*1 ok; n*k = 2*1 ok; m*n = MAX*2 overflows.
         matmul_bt_q8(&[], &q, &mut c, usize::MAX, 1, 2);
+    }
+
+    /// Overflow guard for the macOS tile-scratch size `TILE_N * k`. With
+    /// `m=0, k=MAX, n=0` every earlier product (`m*k`, `n*k`, `m*n`) and every
+    /// length assert is zero/empty, so control reaches the tile block; `TILE_N*k`
+    /// then overflows. Mutation-sensitive: dropping this guard makes the
+    /// `vec![0.0f32; TILE_N * k]` allocation panic with "capacity overflow"
+    /// instead, failing this `expected`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[should_panic(expected = "matmul shape overflow: TILE_N*k")]
+    fn test_matmul_bt_q8_rejects_tile_nk_overflow() {
+        let q = Q8Matrix {
+            data: vec![],
+            scales: vec![],
+            rows: 0,
+            cols: usize::MAX,
+        };
+        matmul_bt_q8(&[], &q, &mut [], 0, usize::MAX, 0);
+    }
+
+    /// Overflow guard for the macOS tile-scratch size `m * TILE_N`. With
+    /// `m=MAX, k=0, n=0` the earlier products and length asserts are all
+    /// zero/empty, so control reaches the tile block; `m*TILE_N` then overflows.
+    /// Mutation-sensitive by the same "capacity overflow" message mismatch.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[should_panic(expected = "matmul shape overflow: m*TILE_N")]
+    fn test_matmul_bt_q8_rejects_m_tile_n_overflow() {
+        let q = Q8Matrix {
+            data: vec![],
+            scales: vec![],
+            rows: 0,
+            cols: 0,
+        };
+        matmul_bt_q8(&[], &q, &mut [], usize::MAX, 0, 0);
     }
 
     #[test]


### PR DESCRIPTION
## What

`matmul_bt_q8` (the Q8 activation×weight CPU path) evaluated `m*k`, `n*k` and
`m*n` directly inside its length assertions. In release those products wrap
silently on overflow, so a caller passing an overflowing shape could pass a
length check and then index out of bounds.

`matmul_bt` (`forward/cpu/matmul.rs`) already guards these products with
`checked_mul`. This mirrors the same three guards onto the Q8 path, which was
missing them.

## Changes

- Three `assert!(x.checked_mul(y).is_some(), ...)` guards ahead of the length
  asserts in `matmul_bt_q8`.
- Three `#[should_panic]` tests, one per product. They are mutation-sensitive:
  removing any single guard lets that product wrap, which changes the panic
  message and fails the corresponding test's `expected =`.

## Correctness / perf

- No behavior change on valid shapes.
- Guards run once per call before the `O(m*n*k)` loop — no measurable perf
  impact. `bench-compare` not applicable (hardening-only, no hot-path change).

## Test

`cargo test -p lattice-inference --lib weights::q8_weights::` → 18 passed
(incl. the 3 new guard tests). `cargo clippy -p lattice-inference --lib
-- -D warnings` clean.
