### PR TITLE
feat(inference): GDN prefill serial-vs-chunked isolation bench harness (#175 instrument)

### DIFF
--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -92,6 +92,11 @@ path = "src/bin/bench_decode_ab.rs"
 required-features = ["f16", "metal-gpu"]
 
 [[bin]]
+name = "bench_gdn_prefill_ab"
+path = "src/bin/bench_gdn_prefill_ab.rs"
+required-features = ["f16", "metal-gpu", "bench-internals"]
+
+[[bin]]
 name = "bench_lora_mixture"
 path = "src/bin/bench_lora_mixture.rs"
 required-features = ["f16", "metal-gpu"]

--- a/crates/inference/src/bin/bench_gdn_prefill_ab.rs
+++ b/crates/inference/src/bin/bench_gdn_prefill_ab.rs
@@ -1,0 +1,814 @@
+//! GDN-recurrence-isolating prefill A/B bench harness (issue #175, Phase B).
+//!
+//! Measures GDN recurrence dispatch time ONLY (conv1d + per-token recurrence on the
+//! serial path; the `gdn_chunk_*` C32 dispatch family on the chunked path) for the
+//! 0.8B Qwen3.5 model, isolated from the surrounding O(n^2) full-attention layers and
+//! from the GDN layers' own non-recurrence GEMMs (QKV/Z projections, out_proj, MLP).
+//! This is the INSTRUMENT for the ADR-064 #175 acceptance gate (recurrence speedup vs
+//! sequential scan >=5x@4K, >=10x@16K) — see the bench methodology notes in the PR /
+//! bench docs for the full spec this implements. Every number this bin prints is
+//! PROVISIONAL until a maintainer re-verifies the harness fresh on an idle machine.
+//!
+//! Isolation method: dedicated command-buffer CPU wall-clock timing (spec's preferred
+//! method 1). `MetalQwen35State::forward_prefill_chunk_gdn_isolated` (metal_qwen35.rs,
+//! `bench-internals`-gated) is a structural copy of the production
+//! `forward_prefill_batched_chunk` with command-buffer boundaries inserted immediately
+//! before/after each GDN layer's recurrence dispatch — same kernels, same dispatch
+//! args, same buffers, only the encoder/command-buffer split points differ. See that
+//! method's doc comment for the full argument that this cannot alter GDN numerics.
+//!
+//! Scope guard: 0.8B path ONLY. Does not touch or measure the 27B path.
+//!
+//! Env:
+//!   LATTICE_MODEL_DIR   model dir (default ~/.lattice/models/qwen3.5-0.8b)
+//!   BENCH_LENGTHS       comma-separated token counts (default "1024,4096,16384")
+//!   BENCH_WARMUP        warmup prefills per (length, path), discarded (default 2)
+//!   BENCH_REPEATS       timed repeats per (length, path) (default 5)
+//!
+//! Output: one TSV row per (length, path) to stdout, plus a serial/chunked speedup
+//! summary and any self-validation FLAGS to stderr and stdout.
+//!
+//! Calibration: in addition to the isolated (per-layer-split) sweep above, this
+//! bin also runs a production-path calibration sweep per length —
+//! `bench_support::forward_prefill_production_chunk`, the real unmodified
+//! `forward_prefill_batched_chunk` dispatch (single command buffer, no per-layer
+//! splits). This exists because the isolated method's own command-buffer splits
+//! add CPU<->GPU sync overhead that biases its serial/chunked ratio, so it cannot
+//! be checked against a tight historical prior directly. The production sweep's
+//! serial_total/chunked_total ratio is the TIGHT anchor check instead (see
+//! `FLAG[production_total_anchor]` below); the isolated sweep's own ratio check
+//! is a wide sanity bound only (`FLAG[reality_anchor]`), not a calibration.
+
+#[cfg(not(all(
+    target_os = "macos",
+    feature = "metal-gpu",
+    feature = "bench-internals"
+)))]
+fn main() {
+    eprintln!("Requires macOS + metal-gpu + bench-internals features.");
+    std::process::exit(1);
+}
+
+#[cfg(all(
+    target_os = "macos",
+    feature = "metal-gpu",
+    feature = "bench-internals"
+))]
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("bench_gdn_prefill_ab failed: {e}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(all(
+    target_os = "macos",
+    feature = "metal-gpu",
+    feature = "bench-internals"
+))]
+mod gpu_flock {
+    //! Mirrors `metal_qwen35::gpu_test_lock()` (same path, same timeout, same
+    //! panic-with-lsof hint) — that function is private to the lib crate (it lives
+    //! in a `#[cfg(test)]`-adjacent module), so a `src/bin` binary cannot call it
+    //! directly (bin targets are separate crates for privacy purposes; they only see
+    //! the lib's `pub` surface). This is a deliberate, minimal duplication of the
+    //! fleet-wide GPU serialization convention (the repo CLAUDE.md "Machine-Wide
+    //! GPU Test Lock"), not a divergent one: same lock file, same semantics.
+    const GPU_MACHINE_LOCK_PATH: &str = "/tmp/lion-metal-gpu-test.lock";
+    const GPU_MACHINE_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+    /// Acquires the exclusive flock and leaks it for the process lifetime
+    /// (this bin is a short-lived, single-shot measurement run — there is no other
+    /// Metal work in this process to serialize against once acquired).
+    pub fn acquire_for_process() {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(GPU_MACHINE_LOCK_PATH)
+            .unwrap_or_else(|e| panic!("gpu flock: cannot open {GPU_MACHINE_LOCK_PATH}: {e}"));
+        let deadline = std::time::Instant::now() + GPU_MACHINE_LOCK_TIMEOUT;
+        loop {
+            match file.try_lock() {
+                Ok(()) => break,
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    if std::time::Instant::now() >= deadline {
+                        panic!(
+                            "gpu flock: another process has held {GPU_MACHINE_LOCK_PATH} for \
+                             over {}s — a Metal run elsewhere on this machine is wedged or \
+                             genuinely that long; inspect `lsof {GPU_MACHINE_LOCK_PATH}`",
+                            GPU_MACHINE_LOCK_TIMEOUT.as_secs()
+                        );
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                }
+                Err(std::fs::TryLockError::Error(e)) => {
+                    panic!("gpu flock: flock on {GPU_MACHINE_LOCK_PATH} failed: {e}")
+                }
+            }
+        }
+        // Leak: hold for the rest of the process. `file` intentionally never drops.
+        std::mem::forget(file);
+    }
+}
+
+#[cfg(all(
+    target_os = "macos",
+    feature = "metal-gpu",
+    feature = "bench-internals"
+))]
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    use lattice_inference::forward::metal_qwen35::MetalQwen35State;
+    use lattice_inference::forward::metal_qwen35::bench_support::{self, GdnIsolatedChunkTiming};
+    use lattice_inference::model::qwen35::Qwen35Model;
+    use lattice_inference::tokenizer::{BpeTokenizer, Tokenizer};
+
+    // --- INVALIDATION GUARD: debug builds produce meaningless Metal timing. This is
+    // a compile-time check (not a runtime assert!) precisely because
+    // `debug_assertions` is a compile-time constant — clippy correctly flags
+    // `assert!(!cfg!(debug_assertions))` as a pointless constant assertion, and
+    // failing to even build in debug mode is a strictly better guard anyway. ---
+    #[cfg(debug_assertions)]
+    compile_error!(
+        "bench_gdn_prefill_ab: MUST build --release (debug Metal timing is meaningless — see \
+         the bench methodology notes in the PR for 'What INVALIDATES a run')"
+    );
+
+    // --- INVALIDATION GUARD: hold the fleet-wide Metal GPU flock BEFORE any Metal
+    // work (model load below doesn't touch Metal, but MetalQwen35State::new does). ---
+    eprintln!("[bench] acquiring /tmp/lion-metal-gpu-test.lock ...");
+    let flock_acquired_at = std::time::Instant::now();
+    gpu_flock::acquire_for_process();
+    eprintln!(
+        "[bench] flock held ({:.1}s wait)",
+        flock_acquired_at.elapsed().as_secs_f64()
+    );
+    let flock_held = true; // unreachable past acquire_for_process() otherwise (it panics)
+
+    let home = std::env::var("HOME")?;
+    let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
+        .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.5-0.8b"));
+    let dir = std::path::Path::new(&model_dir_str);
+
+    let lengths: Vec<usize> = std::env::var("BENCH_LENGTHS")
+        .unwrap_or_else(|_| "1024,4096,16384".to_string())
+        .split(',')
+        .map(|s| {
+            s.trim()
+                .parse()
+                .expect("BENCH_LENGTHS: comma-separated integers")
+        })
+        .collect();
+    let warmup: usize = std::env::var("BENCH_WARMUP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2);
+    let repeats: usize = std::env::var("BENCH_REPEATS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5);
+    assert!(
+        warmup >= 2,
+        "bench methodology requires >=2 warmup prefills"
+    );
+    assert!(repeats >= 5, "bench methodology requires >=5 timed repeats");
+    // --interleaved: toggle the two arms (chunked/serial) per repeat rather than
+    // running all repeats of one arm before the other, so thermal/clock drift over
+    // the run lands symmetrically on both arms instead of biasing whichever arm
+    // runs second. Off by default to keep today's acquisition order unchanged.
+    let interleaved: bool = std::env::args().any(|a| a == "--interleaved");
+    if interleaved {
+        eprintln!("[bench] mode=interleaved (per-prefill arm toggling)");
+    }
+
+    // --- SCOPE GUARD: 0.8B path only. ---
+    if !model_dir_str.contains("0.8b") && !model_dir_str.contains("0_8b") {
+        eprintln!(
+            "[bench] WARNING: LATTICE_MODEL_DIR={model_dir_str} does not look like the 0.8B \
+             checkpoint. This harness is 0.8B-ONLY per its scope guard (the 27B path is \
+             founder-gated) — refusing to proceed unless the shape check below also happens \
+             to match 0.8B's GDN dims."
+        );
+    }
+
+    eprintln!("[bench] loading {model_dir_str}");
+    let model = Qwen35Model::from_safetensors(dir).map_err(|e| format!("load model: {e}"))?;
+    let cfg = model.config().clone();
+    let max_len_needed = *lengths.iter().max().expect("BENCH_LENGTHS non-empty");
+    // A little headroom above the longest sweep length.
+    let max_cache_len = max_len_needed + 512;
+    let mut state = MetalQwen35State::new(model.weights(), &cfg, max_cache_len)
+        .map_err(|e| format!("Metal init: {e}"))?;
+    let tokenizer_dir_str =
+        std::env::var("LATTICE_TOKENIZER_DIR").unwrap_or_else(|_| model_dir_str.clone());
+    let tokenizer = BpeTokenizer::from_tokenizer_json(
+        &std::path::Path::new(&tokenizer_dir_str).join("tokenizer.json"),
+    )?;
+
+    let mp = bench_support::max_prefill(&state);
+    eprintln!("[bench] max_prefill (session chunk cap) = {mp}");
+
+    // --- Fixed prompt, deterministically repeated + truncated to EXACT token counts. ---
+    // Real prose (not a numeric filler pattern) so tokenization exercises normal BPE
+    // merge behavior, matching the pattern already used by this file's own
+    // `long_real_text_tokens` test helper (metal_qwen35.rs) for the same reason.
+    let paragraphs = [
+        "During a late engineering review, the team walked through the inference trace \
+         one layer at a time. They checked where state changed, which buffers were reused, \
+         and how a long request should preserve every earlier token.",
+        "The prompt continued with ordinary prose about debugging, benchmarks, release \
+         notes, and careful handoffs. It used full sentences, punctuation, and varied \
+         vocabulary so tokenization looked like real input rather than a repeated numeric \
+         pattern.",
+        "A second reviewer asked for evidence at the boundary between chunks. The answer \
+         described rotary positions, cache rows, recurrent memory, and causal attention \
+         in concrete terms before any optimization was accepted.",
+        "Verification across chunk boundaries requires that each token's absolute \
+         position index matches the RoPE table row, the KV cache write offset, and the \
+         attention causal mask, all three using the same absolute coordinate, never a \
+         chunk-local one.",
+    ];
+    // Tokenize per-paragraph and accumulate ids, NOT the whole accumulated text each
+    // iteration: re-tokenizing the growing string is O(iterations x text_len) — at
+    // max_len_needed=16384 that burned >38 min of CPU before the first measurement
+    // and blew the run timeout (TBV finding 2026-07-07; the 33-min "silent" smoke run
+    // was the same defect, not GPU contention). Per-paragraph token boundaries differ
+    // slightly from whole-text tokenization at the join points, which is irrelevant
+    // here: the prompt is a deterministic fixed input held identical across both
+    // measured paths.
+    let base_tokens: Vec<u32> = {
+        let mut ids: Vec<u32> = Vec::with_capacity(max_len_needed + 1024);
+        let mut i = 0usize;
+        while ids.len() < max_len_needed && i <= max_len_needed {
+            let text = if i == 0 {
+                paragraphs[0].to_string()
+            } else {
+                format!("\n\n{}", paragraphs[i % paragraphs.len()])
+            };
+            i += 1;
+            let input = tokenizer.tokenize(&text);
+            ids.extend_from_slice(&input.input_ids[..input.real_length]);
+            // i > max_len_needed guard: real prose alone did not reach the target
+            // length quickly enough (pathological BPE ratio) — fall back to padding below.
+        }
+        ids
+    };
+    let tokens_for = |n: usize| -> Vec<u32> {
+        if n <= base_tokens.len() {
+            base_tokens[..n].to_vec()
+        } else {
+            // Pad with token id 1, matching the existing boundary-sweep test's filler
+            // convention (metal_qwen35.rs
+            // gdn_chunked_prefill_vs_serial_prefill_logit_parity).
+            let mut v = base_tokens.clone();
+            v.resize(n, 1u32);
+            v
+        }
+    };
+
+    // Run `n` tokens through the isolated-timing chunk loop once; returns accumulated
+    // GDN/non-GDN timing across all `max_prefill`-sized chunks. Caller must have
+    // already called `state.set_gdn_chunked(..)` and `state.reset_state()`.
+    let run_once = |state: &mut MetalQwen35State, tokens: &[u32]| -> GdnIsolatedChunkTiming {
+        let mut total = GdnIsolatedChunkTiming::default();
+        let mut start = 0usize;
+        for chunk in tokens.chunks(mp) {
+            let t = bench_support::forward_prefill_gdn_isolated_chunk(state, chunk, start);
+            total.accumulate(&t);
+            start += chunk.len();
+        }
+        total
+    };
+
+    #[derive(Clone, Copy)]
+    struct Stats {
+        median: f64,
+        min: f64,
+        max: f64,
+        iqr_pct_of_median: f64,
+        suspect: bool,
+    }
+    fn stats(mut xs: Vec<f64>) -> Stats {
+        xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let n = xs.len();
+        let percentile = |p: f64| -> f64 {
+            if n == 1 {
+                return xs[0];
+            }
+            let idx = p * (n as f64 - 1.0);
+            let lo = idx.floor() as usize;
+            let hi = idx.ceil() as usize;
+            if lo == hi {
+                xs[lo]
+            } else {
+                xs[lo] + (xs[hi] - xs[lo]) * (idx - lo as f64)
+            }
+        };
+        let median = percentile(0.5);
+        let q1 = percentile(0.25);
+        let q3 = percentile(0.75);
+        let iqr = q3 - q1;
+        let iqr_pct_of_median = if median > 0.0 {
+            iqr / median * 100.0
+        } else {
+            0.0
+        };
+        Stats {
+            median,
+            min: xs[0],
+            max: xs[n - 1],
+            iqr_pct_of_median,
+            suspect: iqr_pct_of_median > 15.0,
+        }
+    }
+
+    /// Production-total anchor bands, versioned to a measured baseline.
+    ///
+    /// Baseline: 2026-07-08 idle-machine run at f8c302f9e (serial_prod_total /
+    /// chunked_prod_total, unmodified production dispatch, warmup>=2 repeats>=5):
+    /// 2.415x @1024, 2.072x @4096, 1.476x @16384. Bands are baseline -20%/+20%.
+    /// Anchors go stale as unrelated optimizations land: when this flag fires on an
+    /// otherwise-clean idle run, re-measure the baseline at current HEAD and update
+    /// these constants (with the new SHA) rather than widening the band.
+    fn prod_anchor_band(length: usize) -> Option<(f64, f64)> {
+        match length {
+            1024 => Some((1.93, 2.90)),
+            4096 => Some((1.66, 2.49)),
+            16384 => Some((1.18, 1.77)),
+            _ => None,
+        }
+    }
+
+    struct RowResult {
+        length: usize,
+        path: &'static str,
+        gdn: Stats,
+        total: Stats,
+        non_gdn: Stats,
+    }
+    let mut rows: Vec<RowResult> = Vec::new();
+
+    // Run `n` tokens through the UNMODIFIED production dispatch path once (single
+    // command buffer per max_prefill-sized chunk, no per-layer splits) and return
+    // total CPU wall-clock time in ms. Caller must have already called
+    // `state.set_gdn_chunked(..)` and `state.reset_state()`. Unlike `run_once`
+    // above, no internal command-buffer-boundary timing is needed: production
+    // dispatch already commits + waits synchronously per chunk, so a plain
+    // `Instant` wrapped around the whole chunking loop is the real measurement.
+    let run_once_production = |state: &mut MetalQwen35State, tokens: &[u32]| -> f64 {
+        let start = std::time::Instant::now();
+        let mut pos = 0usize;
+        for chunk in tokens.chunks(mp) {
+            bench_support::forward_prefill_production_chunk(state, chunk, pos);
+            pos += chunk.len();
+        }
+        start.elapsed().as_secs_f64() * 1000.0
+    };
+
+    struct ProdRowResult {
+        length: usize,
+        path: &'static str,
+        total: Stats,
+    }
+    let mut prod_rows: Vec<ProdRowResult> = Vec::new();
+
+    // Prompt-identity guard: every arm and sweep claiming to measure the same input
+    // must receive a byte-identical token stream — ASSERTED via hash, not assumed
+    // (both sweeps call tokens_for independently; this pins them to each other, and
+    // the printed hash makes cross-run prompt identity checkable from logs).
+    fn fnv1a_tokens(tokens: &[u32]) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for &t in tokens {
+            for b in t.to_le_bytes() {
+                h ^= b as u64;
+                h = h.wrapping_mul(0x100000001b3);
+            }
+        }
+        h
+    }
+    let mut prompt_hashes: std::collections::HashMap<usize, u64> = std::collections::HashMap::new();
+
+    // --- Production-path calibration sweep (runs BEFORE the isolated sweep). ---
+    for &length in &lengths {
+        let tokens = tokens_for(length);
+        assert_eq!(tokens.len(), length, "tokens_for produced wrong length");
+        let h = fnv1a_tokens(&tokens);
+        prompt_hashes.insert(length, h);
+        eprintln!("[bench] len={length:6} prompt_fnv1a={h:016x}");
+
+        let prod_arms: [(bool, &'static str); 2] = [(true, "chunked_prod"), (false, "serial_prod")];
+        if interleaved {
+            // Warm each arm once, in arm order, before the interleaved timed loop
+            // below — warmup order does not matter, only the timed samples need to
+            // toggle arms so thermal/clock drift lands symmetrically on both.
+            for &(chunked, _) in &prod_arms {
+                state.set_gdn_chunked(chunked);
+                for _ in 0..warmup {
+                    state.reset_state();
+                    let _ = run_once_production(&mut state, &tokens);
+                }
+            }
+            let mut total_samples: [Vec<f64>; 2] =
+                [Vec::with_capacity(repeats), Vec::with_capacity(repeats)];
+            for _ in 0..repeats {
+                for (i, &(chunked, _)) in prod_arms.iter().enumerate() {
+                    state.set_gdn_chunked(chunked);
+                    state.reset_state();
+                    total_samples[i].push(run_once_production(&mut state, &tokens));
+                }
+            }
+            for (i, &(_, path_name)) in prod_arms.iter().enumerate() {
+                let total = stats(std::mem::take(&mut total_samples[i]));
+                eprintln!(
+                    "[bench] len={length:6} path={path_name:12} total_ms median={:.2} \
+                     [{:.2},{:.2}] IQR%={:.1}{}  (production calibration, unmodified dispatch)",
+                    total.median,
+                    total.min,
+                    total.max,
+                    total.iqr_pct_of_median,
+                    if total.suspect { " SUSPECT" } else { "" },
+                );
+                prod_rows.push(ProdRowResult {
+                    length,
+                    path: path_name,
+                    total,
+                });
+            }
+        } else {
+            for (chunked, path_name) in prod_arms {
+                state.set_gdn_chunked(chunked);
+
+                for _ in 0..warmup {
+                    state.reset_state();
+                    let _ = run_once_production(&mut state, &tokens);
+                }
+
+                let mut total_samples = Vec::with_capacity(repeats);
+                for _ in 0..repeats {
+                    state.reset_state();
+                    total_samples.push(run_once_production(&mut state, &tokens));
+                }
+                let total = stats(total_samples);
+                eprintln!(
+                    "[bench] len={length:6} path={path_name:12} total_ms median={:.2} \
+                     [{:.2},{:.2}] IQR%={:.1}{}  (production calibration, unmodified dispatch)",
+                    total.median,
+                    total.min,
+                    total.max,
+                    total.iqr_pct_of_median,
+                    if total.suspect { " SUSPECT" } else { "" },
+                );
+                prod_rows.push(ProdRowResult {
+                    length,
+                    path: path_name,
+                    total,
+                });
+            }
+        }
+    }
+
+    for &length in &lengths {
+        let tokens = tokens_for(length);
+        assert_eq!(tokens.len(), length, "tokens_for produced wrong length");
+        let h = fnv1a_tokens(&tokens);
+        assert_eq!(
+            Some(&h),
+            prompt_hashes.get(&length),
+            "prompt-identity violation at len={length}: isolated-sweep tokens hash \
+             {h:016x} != production-sweep hash — arms are not measuring the same input"
+        );
+
+        let isolated_arms: [(bool, &'static str); 2] = [(true, "chunked"), (false, "serial")];
+        if interleaved {
+            // Warm each arm once, in arm order, before the interleaved timed loop
+            // below — warmup order does not matter, only the timed samples need to
+            // toggle arms so thermal/clock drift lands symmetrically on both.
+            for &(chunked, _) in &isolated_arms {
+                state.set_gdn_chunked(chunked);
+                for _ in 0..warmup {
+                    state.reset_state();
+                    let _ = run_once(&mut state, &tokens);
+                }
+            }
+            let mut gdn_samples: [Vec<f64>; 2] =
+                [Vec::with_capacity(repeats), Vec::with_capacity(repeats)];
+            let mut total_samples: [Vec<f64>; 2] =
+                [Vec::with_capacity(repeats), Vec::with_capacity(repeats)];
+            let mut non_gdn_samples: [Vec<f64>; 2] =
+                [Vec::with_capacity(repeats), Vec::with_capacity(repeats)];
+            for _ in 0..repeats {
+                for (i, &(chunked, _)) in isolated_arms.iter().enumerate() {
+                    state.set_gdn_chunked(chunked);
+                    state.reset_state();
+                    let t = run_once(&mut state, &tokens);
+                    gdn_samples[i].push(t.gdn_ms);
+                    total_samples[i].push(t.total_ms());
+                    non_gdn_samples[i].push(t.non_gdn_ms);
+                }
+            }
+            for (i, &(_, path_name)) in isolated_arms.iter().enumerate() {
+                let gdn = stats(std::mem::take(&mut gdn_samples[i]));
+                let total = stats(std::mem::take(&mut total_samples[i]));
+                let non_gdn = stats(std::mem::take(&mut non_gdn_samples[i]));
+                eprintln!(
+                    "[bench] len={length:6} path={path_name:8} gdn_ms median={:.2} \
+                     [{:.2},{:.2}] IQR%={:.1}{}  total_ms median={:.2}  non_gdn_ms median={:.2}",
+                    gdn.median,
+                    gdn.min,
+                    gdn.max,
+                    gdn.iqr_pct_of_median,
+                    if gdn.suspect { " SUSPECT" } else { "" },
+                    total.median,
+                    non_gdn.median,
+                );
+                rows.push(RowResult {
+                    length,
+                    path: path_name,
+                    gdn,
+                    total,
+                    non_gdn,
+                });
+            }
+        } else {
+            for (chunked, path_name) in isolated_arms {
+                state.set_gdn_chunked(chunked);
+
+                for _ in 0..warmup {
+                    state.reset_state();
+                    let _ = run_once(&mut state, &tokens);
+                }
+
+                let mut gdn_samples = Vec::with_capacity(repeats);
+                let mut total_samples = Vec::with_capacity(repeats);
+                let mut non_gdn_samples = Vec::with_capacity(repeats);
+                for _ in 0..repeats {
+                    state.reset_state();
+                    let t = run_once(&mut state, &tokens);
+                    gdn_samples.push(t.gdn_ms);
+                    total_samples.push(t.total_ms());
+                    non_gdn_samples.push(t.non_gdn_ms);
+                }
+
+                let gdn = stats(gdn_samples);
+                let total = stats(total_samples);
+                let non_gdn = stats(non_gdn_samples);
+                eprintln!(
+                    "[bench] len={length:6} path={path_name:8} gdn_ms median={:.2} \
+                     [{:.2},{:.2}] IQR%={:.1}{}  total_ms median={:.2}  non_gdn_ms median={:.2}",
+                    gdn.median,
+                    gdn.min,
+                    gdn.max,
+                    gdn.iqr_pct_of_median,
+                    if gdn.suspect { " SUSPECT" } else { "" },
+                    total.median,
+                    non_gdn.median,
+                );
+                rows.push(RowResult {
+                    length,
+                    path: path_name,
+                    gdn,
+                    total,
+                    non_gdn,
+                });
+            }
+        }
+    }
+
+    // --- Self-validation + TSV emission, per length. ---
+    println!(
+        "length\tpath\tgdn_ms_median\tgdn_ms_min\tgdn_ms_max\ttotal_ms_median\t\
+         non_gdn_ms_median\tn_repeats\tflock_held\tvalidation_flags"
+    );
+    if interleaved {
+        println!("# mode=interleaved");
+    }
+
+    let mut any_flags = false;
+    for &length in &lengths {
+        let serial = rows
+            .iter()
+            .find(|r| r.length == length && r.path == "serial")
+            .expect("serial row present");
+        let chunked = rows
+            .iter()
+            .find(|r| r.length == length && r.path == "chunked")
+            .expect("chunked row present");
+        let prod_serial = prod_rows
+            .iter()
+            .find(|r| r.length == length && r.path == "serial_prod")
+            .expect("serial_prod row present");
+        let prod_chunked = prod_rows
+            .iter()
+            .find(|r| r.length == length && r.path == "chunked_prod")
+            .expect("chunked_prod row present");
+
+        // Production-calibration TSV rows: same column shape as the isolated rows
+        // so the file stays parseable, gdn_ms_*/non_gdn_ms_median columns are N/A
+        // for these paths (0.000, not "-" — those columns are numeric everywhere
+        // else in this file) since production dispatch has no isolated GDN segment.
+        for r in [prod_serial, prod_chunked] {
+            let mut flags: Vec<&str> = Vec::new();
+            if r.total.suspect {
+                flags.push("SUSPECT_TOTAL_IQR");
+            }
+            let flags_str = if flags.is_empty() {
+                "-".to_string()
+            } else {
+                any_flags = true;
+                flags.join(",")
+            };
+            println!(
+                "{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{}\t{}\t{}",
+                r.length,
+                r.path,
+                0.000,
+                0.000,
+                0.000,
+                r.total.median,
+                0.000,
+                repeats,
+                flock_held,
+                flags_str,
+            );
+        }
+
+        for r in [serial, chunked] {
+            let mut flags: Vec<&str> = Vec::new();
+            if r.gdn.suspect {
+                flags.push("SUSPECT_GDN_IQR");
+            }
+            if r.total.suspect {
+                flags.push("SUSPECT_TOTAL_IQR");
+            }
+            let flags_str = if flags.is_empty() {
+                "-".to_string()
+            } else {
+                any_flags = true;
+                flags.join(",")
+            };
+            println!(
+                "{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{}\t{}\t{}",
+                r.length,
+                r.path,
+                r.gdn.median,
+                r.gdn.min,
+                r.gdn.max,
+                r.total.median,
+                r.non_gdn.median,
+                repeats,
+                flock_held,
+                flags_str,
+            );
+        }
+
+        // Self-validation check 1: non-GDN consistency.
+        let non_gdn_diff_pct = if serial.non_gdn.median > 0.0 {
+            (serial.non_gdn.median - chunked.non_gdn.median).abs() / serial.non_gdn.median * 100.0
+        } else {
+            0.0
+        };
+        let non_gdn_flag = non_gdn_diff_pct > 15.0;
+
+        // Self-validation check 2: cross-check (serial_total - chunked_total) ≈
+        // (serial_GDN - chunked_GDN).
+        let total_diff = serial.total.median - chunked.total.median;
+        let gdn_diff = serial.gdn.median - chunked.gdn.median;
+        let cross_check_diff_pct = if gdn_diff.abs() > 1e-9 {
+            (total_diff - gdn_diff).abs() / gdn_diff.abs() * 100.0
+        } else {
+            0.0
+        };
+        let cross_check_flag = cross_check_diff_pct > 20.0;
+
+        // Self-validation check 3: isolated-ratio sanity bound. This is NOT a
+        // calibration against any historical prior — no isolated-recurrence-only
+        // prior exists by construction (the isolated method's own command-buffer
+        // splits add CPU<->GPU sync overhead unique to this harness, so nothing
+        // measured outside it is comparable). The tight calibration against a
+        // prior interleaved A/B measurement (2026-06) lives in the production-total
+        // check below instead. This check only rejects results that cannot be a
+        // real recurrence speedup
+        // under any honest accounting: a reversal (chunked slower than serial,
+        // ratio < 1.0) or an implausibly large ratio (>20x) for the same kernels
+        // running the same recurrence work.
+        let ratio = if chunked.gdn.median > 0.0 {
+            serial.gdn.median / chunked.gdn.median
+        } else {
+            f64::NAN
+        };
+        let anchor_flag = !(1.0..=20.0).contains(&ratio) || ratio.is_nan();
+
+        println!(
+            "# len={length}: serial_GDN/chunked_GDN speedup = {:.3}x  \
+             [serial {:.2},{:.2},{:.2}] / [chunked {:.2},{:.2},{:.2}] (median,min,max ms)",
+            ratio,
+            serial.gdn.min,
+            serial.gdn.median,
+            serial.gdn.max,
+            chunked.gdn.min,
+            chunked.gdn.median,
+            chunked.gdn.max,
+        );
+
+        // Self-validation check 4: production-total anchor. Unlike the isolated
+        // sweep, the production sweep uses the UNMODIFIED dispatch path (single
+        // command buffer per chunk), so it is the correct place to check against a
+        // measured baseline. The baseline is versioned per-length via
+        // `prod_anchor_band` rather than a single fixed band, because a single
+        // band drifts stale as unrelated optimizations land elsewhere in the
+        // dispatch path (a June-4-era 1.35-1.75x band false-fired after a month of
+        // non-GDN changes moved the true ratio outside it). Lengths without a
+        // calibrated band skip the tight check and print an informational line
+        // instead of firing FLAG[production_total_anchor].
+        let prod_ratio = if prod_chunked.total.median > 0.0 {
+            prod_serial.total.median / prod_chunked.total.median
+        } else {
+            f64::NAN
+        };
+        let band = prod_anchor_band(length);
+        let prod_anchor_flag = match band {
+            Some((lo, hi)) => !(lo..=hi).contains(&prod_ratio) || prod_ratio.is_nan(),
+            None => false,
+        };
+        if band.is_none() {
+            println!(
+                "# len={length}: no production-anchor band calibrated for this length \
+                 (bands: 1024/4096/16384); tight anchor skipped"
+            );
+        }
+
+        println!(
+            "# len={length}: serial_prod_total/chunked_prod_total speedup = {:.3}x  \
+             [serial_prod {:.2},{:.2},{:.2}] / [chunked_prod {:.2},{:.2},{:.2}] \
+             (median,min,max ms; unmodified production dispatch)",
+            prod_ratio,
+            prod_serial.total.min,
+            prod_serial.total.median,
+            prod_serial.total.max,
+            prod_chunked.total.min,
+            prod_chunked.total.median,
+            prod_chunked.total.max,
+        );
+
+        let mut length_flags: Vec<String> = Vec::new();
+        if non_gdn_flag {
+            length_flags.push(format!(
+                "FLAG[non_gdn_consistency]: non-GDN work differs {non_gdn_diff_pct:.1}% between \
+                 serial/chunked at len={length} (serial={:.2}ms chunked={:.2}ms) — GDN isolation \
+                 may be leaking non-recurrence work into the timed segment.",
+                serial.non_gdn.median, chunked.non_gdn.median
+            ));
+        }
+        if cross_check_flag {
+            length_flags.push(format!(
+                "FLAG[cross_check]: (serial_total-chunked_total)={total_diff:.2}ms vs \
+                 (serial_GDN-chunked_GDN)={gdn_diff:.2}ms differ by {cross_check_diff_pct:.1}% \
+                 at len={length}."
+            ));
+        }
+        if anchor_flag {
+            length_flags.push(format!(
+                "FLAG[reality_anchor]: serial_GDN/chunked_GDN={ratio:.3}x at len={length} is \
+                 outside the wide isolated-sweep sanity bound 1.0-20.0x (no reversal, no \
+                 implausible blowup) — the harness's isolation is suspect, do NOT trust this \
+                 length's numbers. This is a sanity bound only, not a calibration; see \
+                 FLAG[production_total_anchor] for the tight anchor check."
+            ));
+        }
+        if prod_anchor_flag {
+            let (lo, hi) = band.expect("prod_anchor_flag only set when band is Some");
+            length_flags.push(format!(
+                "FLAG[production_total_anchor]: serial_prod_total/chunked_prod_total=\
+                 {prod_ratio:.3}x at len={length} is outside the expected {lo:.2}-{hi:.2}x band \
+                 (baseline 2026-07-08 @ f8c302f9e) — measured under the unmodified production \
+                 dispatch path (single command buffer per chunk, same regime the baseline was \
+                 measured under). Do NOT trust this length's speedup claim."
+            ));
+        }
+        if length_flags.is_empty() {
+            println!("# len={length}: self-validation flags: none (clean)");
+        } else {
+            any_flags = true;
+            for f in &length_flags {
+                println!("# len={length}: {f}");
+                eprintln!("{f}");
+            }
+        }
+    }
+
+    if any_flags {
+        eprintln!(
+            "[bench] *** ONE OR MORE SELF-VALIDATION FLAGS FIRED — see FLAG lines above. \
+             This run's numbers are NOT trustworthy as-is. ***"
+        );
+    } else {
+        eprintln!("[bench] self-validation: all flags clean on this run.");
+    }
+    eprintln!(
+        "[bench] REMINDER: all numbers from this harness are PROVISIONAL until a \
+         maintainer re-verifies the harness fresh on an idle machine (see the bench \
+         methodology notes in the PR)."
+    );
+
+    Ok(())
+}

--- a/crates/inference/src/bin/bench_gdn_prefill_ab.rs
+++ b/crates/inference/src/bin/bench_gdn_prefill_ab.rs
@@ -181,13 +181,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("[bench] mode=interleaved (per-prefill arm toggling)");
     }
 
-    // --- SCOPE GUARD: 0.8B path only. ---
+    // --- SCOPE GUARD: 0.8B path only (name check is advisory; the hard check is
+    // the config-shape assert after Metal init below). ---
     if !model_dir_str.contains("0.8b") && !model_dir_str.contains("0_8b") {
         eprintln!(
             "[bench] WARNING: LATTICE_MODEL_DIR={model_dir_str} does not look like the 0.8B \
-             checkpoint. This harness is 0.8B-ONLY per its scope guard (the 27B path is \
-             founder-gated) — refusing to proceed unless the shape check below also happens \
-             to match 0.8B's GDN dims."
+             checkpoint. This harness only measures configs supporting the chunked GDN \
+             prefill path; the shape check below hard-fails otherwise."
         );
     }
 
@@ -204,6 +204,18 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let tokenizer = BpeTokenizer::from_tokenizer_json(
         &std::path::Path::new(&tokenizer_dir_str).join("tokenizer.json"),
     )?;
+
+    // HARD scope check: the chunked arm must actually be the chunked path. Without
+    // this, an unsupported config would fall back to the serial recurrence while the
+    // harness labels the arm "chunked" — the isolated forward also asserts this, but
+    // failing here is earlier and names the cause.
+    if !bench_support::gdn_chunked_prefill_supported(&state) {
+        return Err(format!(
+            "model at {model_dir_str} does not support the chunked GDN prefill path — \
+             this harness would mislabel a serial measurement as 'chunked'; refusing to run"
+        )
+        .into());
+    }
 
     let mp = bench_support::max_prefill(&state);
     eprintln!("[bench] max_prefill (session chunk cap) = {mp}");
@@ -253,6 +265,19 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         ids
     };
+    // Validate every token id against the model vocab BEFORE any forward call: the
+    // bench-support entry points bypass the public path's token-id validation, and
+    // the embedding copy is an unsafe read indexed by token id. A mismatched
+    // LATTICE_TOKENIZER_DIR must fail loudly here, not corrupt the first warmup.
+    // (`tokens_for`'s padding id 1 is trivially in-vocab.)
+    let vocab = bench_support::vocab_size(&state);
+    if let Some((i, id)) = bench_support::first_out_of_vocab(&base_tokens, vocab) {
+        return Err(format!(
+            "token id {id} at base_tokens[{i}] is >= vocab_size {vocab} — tokenizer/model \
+             mismatch (check LATTICE_TOKENIZER_DIR vs LATTICE_MODEL_DIR)"
+        )
+        .into());
+    }
     let tokens_for = |n: usize| -> Vec<u32> {
         if n <= base_tokens.len() {
             base_tokens[..n].to_vec()
@@ -670,15 +695,26 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         let non_gdn_flag = non_gdn_diff_pct > 15.0;
 
         // Self-validation check 2: cross-check (serial_total - chunked_total) ≈
-        // (serial_GDN - chunked_GDN).
+        // (serial_GDN - chunked_GDN). A near-zero GDN delta does NOT make the check
+        // pass: if the isolated measurement breaks in a way that zeroes both arms'
+        // GDN time while the totals still differ, that is exactly a broken
+        // instrument, so the undefined-ratio case flags unless the total delta is
+        // also negligible (1ms absolute). Non-finite inputs always flag.
         let total_diff = serial.total.median - chunked.total.median;
         let gdn_diff = serial.gdn.median - chunked.gdn.median;
-        let cross_check_diff_pct = if gdn_diff.abs() > 1e-9 {
-            (total_diff - gdn_diff).abs() / gdn_diff.abs() * 100.0
-        } else {
+        let cross_check_undefined = gdn_diff.abs() <= 1e-9;
+        let cross_check_diff_pct = if cross_check_undefined {
             0.0
+        } else {
+            (total_diff - gdn_diff).abs() / gdn_diff.abs() * 100.0
         };
-        let cross_check_flag = cross_check_diff_pct > 20.0;
+        let cross_check_flag = if !total_diff.is_finite() || !gdn_diff.is_finite() {
+            true
+        } else if cross_check_undefined {
+            total_diff.abs() > 1.0
+        } else {
+            cross_check_diff_pct > 20.0
+        };
 
         // Self-validation check 3: isolated-ratio sanity bound. This is NOT a
         // calibration against any historical prior — no isolated-recurrence-only
@@ -760,11 +796,20 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             ));
         }
         if cross_check_flag {
-            length_flags.push(format!(
-                "FLAG[cross_check]: (serial_total-chunked_total)={total_diff:.2}ms vs \
-                 (serial_GDN-chunked_GDN)={gdn_diff:.2}ms differ by {cross_check_diff_pct:.1}% \
-                 at len={length}."
-            ));
+            if cross_check_undefined {
+                length_flags.push(format!(
+                    "FLAG[cross_check]: undefined cross-check ratio at len={length} — \
+                     (serial_GDN-chunked_GDN)={gdn_diff:.4}ms is ~zero (or non-finite) while \
+                     (serial_total-chunked_total)={total_diff:.2}ms is not: the isolated GDN \
+                     measurement is not accounting for the arms' total-time difference."
+                ));
+            } else {
+                length_flags.push(format!(
+                    "FLAG[cross_check]: (serial_total-chunked_total)={total_diff:.2}ms vs \
+                     (serial_GDN-chunked_GDN)={gdn_diff:.2}ms differ by \
+                     {cross_check_diff_pct:.1}% at len={length}."
+                ));
+            }
         }
         if anchor_flag {
             length_flags.push(format!(

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -7065,6 +7065,16 @@ mod inner {
 
             let chunked_requested = self.use_gdn_chunked;
             let chunked_supported = Self::supports_gdn_chunked_prefill(&cfg);
+            // Bench-internals path: fail LOUD instead of falling back. The
+            // production path degrades gracefully to the serial recurrence, but a
+            // bench that did the same would measure the serial path while the
+            // harness labels the arm "chunked" — a silent instrument corruption.
+            assert!(
+                !chunked_requested || chunked_supported,
+                "GDN chunked prefill requested (set_gdn_chunked(true)) but this config \
+                 does not support the chunked path — refusing to silently measure the \
+                 serial recurrence under a 'chunked' label"
+            );
             let chunked_enabled = chunked_requested && chunked_supported;
 
             let mut timing = bench_support::GdnIsolatedChunkTiming::default();
@@ -26582,7 +26592,72 @@ mod inner {
             token_ids: &[u32],
             start_pos: usize,
         ) -> GdnIsolatedChunkTiming {
+            assert_token_ids_in_vocab(state, token_ids);
             state.forward_prefill_chunk_gdn_isolated(token_ids, start_pos)
+        }
+
+        /// The model's vocab size, exposed so harness bins can validate token ids
+        /// BEFORE the first forward call: the entry points in this module bypass
+        /// the public `forward_prefill_impl` path and its token-id validation, and
+        /// the embedding copy is an unsafe read indexed by token id.
+        pub fn vocab_size(state: &MetalQwen35State) -> usize {
+            state.engine.config.vocab_size
+        }
+
+        /// First out-of-vocab token id, if any: `Some((index, id))` where
+        /// `id as usize >= vocab`. Pure scan, factored out for testability.
+        pub fn first_out_of_vocab(token_ids: &[u32], vocab: usize) -> Option<(usize, u32)> {
+            token_ids
+                .iter()
+                .enumerate()
+                .find(|&(_, &id)| id as usize >= vocab)
+                .map(|(i, &id)| (i, id))
+        }
+
+        /// Both bench entry points bypass the public path's token-id validation,
+        /// so they re-validate here: the first forward would otherwise read
+        /// outside `embed_tokens` in the unsafe embedding copy instead of failing
+        /// loudly before measurement.
+        fn assert_token_ids_in_vocab(state: &MetalQwen35State, token_ids: &[u32]) {
+            let vocab = state.engine.config.vocab_size;
+            if let Some((i, id)) = first_out_of_vocab(token_ids, vocab) {
+                panic!(
+                    "token id {id} at index {i} is out of vocab range ({vocab}) — refusing \
+                     to run the unsafe embedding copy on unvalidated ids (tokenizer/model \
+                     mismatch?)"
+                );
+            }
+        }
+
+        /// True iff this state's config supports the chunked GDN prefill path.
+        /// Harness bins must hard-fail when this is false rather than proceed: a
+        /// state with `set_gdn_chunked(true)` but no support would otherwise run
+        /// the serial recurrence while the harness labels the arm "chunked".
+        pub fn gdn_chunked_prefill_supported(state: &MetalQwen35State) -> bool {
+            MetalQwen35State::supports_gdn_chunked_prefill(&state.engine.config)
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::first_out_of_vocab;
+
+            #[test]
+            fn first_out_of_vocab_accepts_in_range() {
+                assert_eq!(first_out_of_vocab(&[0, 1, 99], 100), None);
+                assert_eq!(first_out_of_vocab(&[], 100), None);
+            }
+
+            #[test]
+            fn first_out_of_vocab_finds_first_offender() {
+                // Two offenders; the FIRST (index 1) must be reported.
+                assert_eq!(first_out_of_vocab(&[5, 200, 300], 100), Some((1, 200)));
+            }
+
+            #[test]
+            fn first_out_of_vocab_rejects_id_equal_to_vocab() {
+                // vocab_size itself is out of range (valid ids are 0..vocab_size).
+                assert_eq!(first_out_of_vocab(&[100], 100), Some((0, 100)));
+            }
         }
 
         /// The session's `max_prefill` (single-command-buffer chunk cap; 512 for all
@@ -26621,6 +26696,7 @@ mod inner {
             token_ids: &[u32],
             start_pos: usize,
         ) {
+            assert_token_ids_in_vocab(state, token_ids);
             let _ = state.forward_prefill_batched_chunk(token_ids, start_pos, true, false);
         }
     }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6969,6 +6969,718 @@ mod inner {
             }
         }
 
+        /// GDN-recurrence-isolating variant of [`Self::forward_prefill_batched_chunk`],
+        /// built for the #175 bench harness (`bin/bench_gdn_prefill_ab.rs`).
+        ///
+        /// Structurally identical to `forward_prefill_batched_chunk`: same op sequence,
+        /// same buffers, same dispatch calls, same per-layer branch (GDN vs full
+        /// attention). The ONLY difference is *where command-buffer boundaries fall*:
+        /// immediately before and after each GDN layer's recurrence dispatch (either
+        /// `dispatch_gdn_chunked_prefill_layer`'s C32 family, or the serial
+        /// conv1d+recurrence per-token loop) the current encoder is ended and its
+        /// command buffer committed + `wait_until_completed`, a fresh command buffer
+        /// is opened for the GDN dispatch alone, then another fresh one for the rest of
+        /// the layer. This isolates the GDN segment's CPU wall-clock time from the
+        /// surrounding GEMMs/norms so the two scans' recurrence cost can be compared
+        /// without the O(n^2) attention layers (or the GDN layers' own non-recurrence
+        /// GEMMs) swamping the signal.
+        ///
+        /// No GDN kernel, dispatch argument, threadgroup geometry, or buffer differs
+        /// from the production path — only the encoder/command-buffer boundaries
+        /// change. This cannot introduce a new GDN-state race: within one encoder,
+        /// Metal already serializes same-buffer read/write hazards between
+        /// consecutive dispatches (the production path's correctness already depends
+        /// on this), and an explicit `commit` + `wait_until_completed` between two
+        /// *separate* command buffers on the same StorageModeShared buffers is a
+        /// strictly stronger ordering guarantee than that. Splitting into more,
+        /// smaller command buffers can only add synchronization stalls, never change
+        /// what a kernel reads or writes.
+        ///
+        /// Always skips the terminal RMSNorm/lm_head/top-k tail (mirrors
+        /// `forward_prefill_batched_chunk`'s `emit_logits = false` path) — logits are
+        /// never needed for a dispatch-timing measurement, skipping the tail removes a
+        /// large amount of code unrelated to GDN isolation, and the tail's cost is
+        /// identical between the serial and chunked paths regardless (it depends on
+        /// neither), so omitting it does not bias the serial-vs-chunked comparison.
+        ///
+        /// Handles exactly one `max_prefill`-sized chunk starting at `start_pos`
+        /// (`n = token_ids.len() <= self.session.max_prefill`, asserted below); the
+        /// caller drives the `max_prefill`-sized chunking loop for prompts longer than
+        /// `max_prefill`, exactly as `forward_prefill_impl` does for the production
+        /// path, threading GDN recurrent state across chunk boundaries via the
+        /// session's GPU buffers (unchanged by this method).
+        ///
+        /// Gated on `bench-internals` (like `bench_support` itself, which owns this
+        /// method's return type) — this is bench-only isolation plumbing, not part of
+        /// the production dispatch path, so it stays out of the default `metal-gpu`
+        /// build the way `bench_support`'s other helpers do.
+        #[cfg(feature = "bench-internals")]
+        fn forward_prefill_chunk_gdn_isolated(
+            &mut self,
+            token_ids: &[u32],
+            start_pos: usize,
+        ) -> bench_support::GdnIsolatedChunkTiming {
+            let n = token_ids.len();
+            assert!(
+                n <= self.session.max_prefill,
+                "forward_prefill_chunk_gdn_isolated: n={n} exceeds max_prefill={}",
+                self.session.max_prefill
+            );
+            assert!(
+                start_pos + n <= self.session.kv_cache.max_cache_len,
+                "prefill chunk start_pos={start_pos} + n={n} exceeds max_cache_len {}",
+                self.session.kv_cache.max_cache_len
+            );
+            let cfg = self.engine.config.clone();
+            let m = n as u32;
+            let hidden = cfg.hidden_size;
+            let inter = cfg.intermediate_size;
+            let kv_dim = cfg.full_kv_dim();
+            let q_dim = cfg.full_q_dim();
+            let num_q_heads = cfg.num_attention_heads;
+            let num_kv_heads = cfg.num_key_value_heads;
+            let head_dim = cfg.head_dim;
+            let half_rope_dim = (cfg.rope_dim() / 2) as u32;
+
+            // Batch embedding: f16 -> f32 for all N tokens. Identical to
+            // forward_prefill_batched_chunk; embedding is CPU-side memcpy work, held
+            // fixed across serial/chunked and excluded from both timing buckets below
+            // (it happens before the first command buffer opens).
+            //
+            // SAFETY: embed_tokens is StorageModeShared f16, no GPU in flight; token
+            // ids are validated by the harness bin before this is ever called.
+            unsafe {
+                let src_base = self.engine.embed_tokens.contents() as *const u16;
+                let dst_base = self.session.activations.hidden.contents() as *mut f32;
+                for (t, &id) in token_ids.iter().enumerate() {
+                    let src = src_base.add(id as usize * hidden);
+                    let dst = dst_base.add(t * hidden);
+                    convert_f16_row(src, dst, hidden);
+                }
+            }
+
+            let mut active_layer_idx = 0usize;
+            let mut linear_idx = 0usize;
+            let mut full_idx = 0usize;
+
+            let chunked_requested = self.use_gdn_chunked;
+            let chunked_supported = Self::supports_gdn_chunked_prefill(&cfg);
+            let chunked_enabled = chunked_requested && chunked_supported;
+
+            let mut timing = bench_support::GdnIsolatedChunkTiming::default();
+
+            let mut cmd = self.engine.queue.new_command_buffer();
+            let mut enc = cmd.new_compute_command_encoder();
+            let mut seg_start = std::time::Instant::now();
+
+            for layer_i in 0..cfg.num_hidden_layers {
+                if !cfg.is_layer_active(layer_i) {
+                    continue;
+                }
+                let compact_idx = active_layer_idx;
+                active_layer_idx += 1;
+                let is_linear = matches!(
+                    &self.engine.layer_weights[compact_idx].0,
+                    MetalLayerAttnWeights::Linear(_)
+                );
+
+                // Extract weight pointers (avoids borrow conflict with &mut self) --
+                // identical pattern to forward_prefill_batched_chunk.
+                let (_, common_w) = &self.engine.layer_weights[compact_idx];
+                let w_in_norm = &common_w.input_layernorm as *const Buffer;
+                let w_post_norm = &common_w.post_attention_layernorm as *const Buffer;
+                let (w_gate_up, w_down, gate_byte_size) = match &common_w.ffn {
+                    MetalFfnWeights::Dense {
+                        gate_up_proj,
+                        down_proj,
+                    } => {
+                        let byte_size: u64 = match self.engine.quant_format {
+                            QuantFormat::Q8_0 => {
+                                (inter * (hidden / QK8_0) * Q8_0_BLOCK_SIZE) as u64
+                            }
+                            QuantFormat::Q4_0 => {
+                                (inter * (hidden / QK4_0) * Q4_0_BLOCK_SIZE) as u64
+                            }
+                        };
+                        (
+                            gate_up_proj as *const Q4WeightBuf,
+                            down_proj as *const Q4WeightBuf,
+                            byte_size,
+                        )
+                    }
+                    MetalFfnWeights::Moe(_) => {
+                        panic!(
+                            "forward_prefill_chunk_gdn_isolated: MoE layers are not \
+                             supported in batch prefill (M>1); the #175 harness is \
+                             0.8B-only (dense), this branch is unreachable there."
+                        );
+                    }
+                };
+
+                if is_linear {
+                    // ========= GDN layer: batch projections + isolated recurrence =========
+                    let (w_qkv, w_z, w_b, w_a, w_alog, w_dtb, w_conv, w_norm, w_out) = {
+                        let MetalLayerAttnWeights::Linear(gdn_w) =
+                            &self.engine.layer_weights[compact_idx].0
+                        else {
+                            unreachable!()
+                        };
+                        (
+                            &gdn_w.in_proj_qkv as *const Q4WeightBuf,
+                            &gdn_w.in_proj_z as *const Q4WeightBuf,
+                            &gdn_w.in_proj_b as *const Buffer,
+                            &gdn_w.in_proj_a as *const Buffer,
+                            &gdn_w.a_log as *const Buffer,
+                            &gdn_w.dt_bias as *const Buffer,
+                            &gdn_w.conv1d_weight as *const Buffer,
+                            &gdn_w.norm_weight as *const Buffer,
+                            &gdn_w.out_proj as *const Q4WeightBuf,
+                        )
+                    };
+                    let qkv_d = cfg.linear_qkv_dim();
+                    let out_d = cfg.linear_output_dim();
+                    let num_h = cfg.linear_num_key_heads;
+                    let key_d = cfg.linear_key_head_dim;
+                    let val_d = cfg.linear_value_head_dim;
+                    let ks = cfg.linear_conv_kernel_dim as u32;
+
+                    // Batch: fused copy hidden -> residual + norm hidden in-place.
+                    unsafe {
+                        self.dispatch_copy_and_rms_norm_batch(
+                            enc,
+                            &self.session.activations.hidden,
+                            &self.session.activations.residual,
+                            &*w_in_norm,
+                            hidden as u32,
+                            m,
+                            cfg.rms_norm_eps,
+                        );
+                    }
+
+                    // Batch: QKV + Z projections (GEMM) -- non-GDN, stays in this segment.
+                    unsafe {
+                        self.dispatch_gemm(
+                            enc,
+                            &self.session.activations.hidden,
+                            0,
+                            &*w_qkv,
+                            &self.session.activations.gdn_qkv,
+                            0,
+                            m,
+                            qkv_d as u32,
+                            hidden as u32,
+                        );
+                        self.dispatch_gemm(
+                            enc,
+                            &self.session.activations.hidden,
+                            0,
+                            &*w_z,
+                            &self.session.activations.gdn_z,
+                            0,
+                            m,
+                            out_d as u32,
+                            hidden as u32,
+                        );
+                    }
+
+                    // ---- GDN isolation boundary: close the pre-GDN (non-GDN) segment ----
+                    enc.end_encoding();
+                    cmd.commit();
+                    cmd.wait_until_completed();
+                    timing.non_gdn_ms += seg_start.elapsed().as_secs_f64() * 1000.0;
+
+                    let gdn_cmd = self.engine.queue.new_command_buffer();
+                    let gdn_enc = gdn_cmd.new_compute_command_encoder();
+                    let gdn_start = std::time::Instant::now();
+
+                    // GDN recurrence: chunked-parallel path or serial per-token --
+                    // dispatch calls/args are byte-identical to
+                    // forward_prefill_batched_chunk, only the target encoder differs.
+                    let chunk_params = if chunked_enabled {
+                        Self::make_gdn_chunk_params(&cfg, n)
+                    } else {
+                        None
+                    };
+                    if let Some(params) = chunk_params {
+                        let weights = unsafe {
+                            GdnChunkedWeights {
+                                conv1d_weight: &*w_conv,
+                                in_proj_b: &*w_b,
+                                in_proj_a: &*w_a,
+                                a_log: &*w_alog,
+                                dt_bias: &*w_dtb,
+                                norm_weight: &*w_norm,
+                            }
+                        };
+                        self.dispatch_gdn_chunked_prefill_layer(
+                            gdn_enc, linear_idx, weights, params,
+                        );
+                    } else {
+                        for t in 0..n {
+                            let qkv_off = (t * qkv_d) as u64 * 4;
+                            let z_off = (t * out_d) as u64 * 4;
+                            let h_off = (t * hidden) as u64 * 4;
+
+                            unsafe {
+                                gdn_enc
+                                    .set_compute_pipeline_state(&self.engine.pipelines.conv1d_silu);
+                                gdn_enc.set_buffer(
+                                    0,
+                                    Some(&self.session.gdn_gpu_conv_bufs[linear_idx]),
+                                    0,
+                                );
+                                gdn_enc.set_buffer(
+                                    1,
+                                    Some(&self.session.activations.gdn_qkv),
+                                    qkv_off,
+                                );
+                                gdn_enc.set_buffer(2, Some(&*w_conv), 0);
+                                gdn_enc.set_buffer(3, Some(&self.session.gdn_gpu_conv_out), 0);
+                                let qd = qkv_d as u32;
+                                gdn_enc.set_bytes(4, 4, &qd as *const u32 as *const _);
+                                gdn_enc.set_bytes(5, 4, &ks as *const u32 as *const _);
+                                let wg = 256u64;
+                                gdn_enc.dispatch_threads(
+                                    MTLSize::new(div_ceil(qkv_d as u64, wg) * wg, 1, 1),
+                                    MTLSize::new(wg, 1, 1),
+                                );
+                            }
+
+                            unsafe {
+                                #[repr(C)]
+                                struct GdnRecurParams {
+                                    key_dim: u32,
+                                    value_dim: u32,
+                                    num_key_heads: u32,
+                                    num_value_heads: u32,
+                                    hidden_size: u32,
+                                    q_total: u32,
+                                    v_offset: u32,
+                                    scale: f32,
+                                    eps: f32,
+                                }
+                                let num_vh = cfg.linear_num_value_heads();
+                                let q_total = (num_h * key_d) as u32;
+                                let params = GdnRecurParams {
+                                    key_dim: key_d as u32,
+                                    value_dim: val_d as u32,
+                                    num_key_heads: num_h as u32,
+                                    num_value_heads: num_vh as u32,
+                                    hidden_size: hidden as u32,
+                                    q_total,
+                                    v_offset: q_total * 2,
+                                    scale: 1.0 / (key_d as f32).sqrt(),
+                                    eps: cfg.rms_norm_eps,
+                                };
+                                gdn_enc.set_compute_pipeline_state(
+                                    &self.engine.pipelines.gdn_recurrence,
+                                );
+                                gdn_enc.set_buffer(
+                                    0,
+                                    Some(&self.session.gdn_gpu_s_matrices[linear_idx]),
+                                    0,
+                                );
+                                gdn_enc.set_buffer(1, Some(&self.session.gdn_gpu_conv_out), 0);
+                                gdn_enc.set_buffer(2, Some(&self.session.activations.gdn_z), z_off);
+                                gdn_enc.set_buffer(
+                                    3,
+                                    Some(&self.session.activations.hidden),
+                                    h_off,
+                                );
+                                gdn_enc.set_buffer(4, Some(&*w_b), 0);
+                                gdn_enc.set_buffer(5, Some(&*w_a), 0);
+                                gdn_enc.set_buffer(6, Some(&*w_alog), 0);
+                                gdn_enc.set_buffer(7, Some(&*w_dtb), 0);
+                                gdn_enc.set_buffer(8, Some(&*w_norm), 0);
+                                gdn_enc.set_buffer(9, Some(&self.session.activations.gdn_z), z_off);
+                                gdn_enc.set_bytes(
+                                    10,
+                                    std::mem::size_of::<GdnRecurParams>() as u64,
+                                    &params as *const GdnRecurParams as *const _,
+                                );
+                                gdn_enc.dispatch_thread_groups(
+                                    MTLSize::new(num_vh as u64, 1, 1),
+                                    MTLSize::new(32, 4, 1),
+                                );
+                            }
+                        }
+                    }
+
+                    gdn_enc.end_encoding();
+                    gdn_cmd.commit();
+                    gdn_cmd.wait_until_completed();
+                    timing.gdn_ms += gdn_start.elapsed().as_secs_f64() * 1000.0;
+                    timing.num_gdn_layers += 1;
+
+                    // ---- reopen a fresh segment for the rest of this layer + subsequent layers ----
+                    cmd = self.engine.queue.new_command_buffer();
+                    enc = cmd.new_compute_command_encoder();
+                    seg_start = std::time::Instant::now();
+
+                    // Batch: out_proj -- non-GDN, in the fresh post-GDN segment.
+                    unsafe {
+                        self.dispatch_gemm(
+                            enc,
+                            &self.session.activations.gdn_z,
+                            0,
+                            &*w_out,
+                            &self.session.activations.attn_out,
+                            0,
+                            m,
+                            hidden as u32,
+                            out_d as u32,
+                        );
+                    }
+
+                    // Batch: fused residual-add + norm for MLP.
+                    unsafe {
+                        self.dispatch_fused_residual_add_norm_batch(
+                            enc,
+                            &self.session.activations.residual,
+                            &self.session.activations.attn_out,
+                            &self.session.activations.residual,
+                            &self.session.activations.hidden,
+                            &*w_post_norm,
+                            hidden as u32,
+                            m,
+                            cfg.rms_norm_eps,
+                        );
+                    }
+
+                    // Batch: MLP (gate + up + silu_mul + down)
+                    unsafe {
+                        self.dispatch_gemm_at(
+                            enc,
+                            &self.session.activations.hidden,
+                            0,
+                            &*w_gate_up,
+                            0,
+                            &self.session.activations.gate,
+                            0,
+                            m,
+                            inter as u32,
+                            hidden as u32,
+                        );
+                        self.dispatch_gemm_at(
+                            enc,
+                            &self.session.activations.hidden,
+                            0,
+                            &*w_gate_up,
+                            gate_byte_size,
+                            &self.session.activations.up,
+                            0,
+                            m,
+                            inter as u32,
+                            hidden as u32,
+                        );
+                    }
+                    self.dispatch_silu_mul(enc, m * inter as u32);
+                    unsafe {
+                        self.dispatch_gemm(
+                            enc,
+                            &self.session.activations.gate,
+                            0,
+                            &*w_down,
+                            &self.session.activations.ffn_out,
+                            0,
+                            m,
+                            hidden as u32,
+                            inter as u32,
+                        );
+                    }
+
+                    // Batch: fused end-of-layer residual add + copy.
+                    self.dispatch_add_and_copy(
+                        enc,
+                        &self.session.activations.ffn_out,
+                        &self.session.activations.residual,
+                        &self.session.activations.hidden,
+                        m * hidden as u32,
+                    );
+
+                    linear_idx += 1;
+                } else {
+                    // ========= Full attention layer: byte-identical to
+                    // forward_prefill_batched_chunk's else-branch. No GDN work here,
+                    // so it just dispatches into whichever segment is currently open
+                    // (never split). =========
+                    let (w_q, w_k, w_v, w_o, w_qn, w_kn) = {
+                        let MetalLayerAttnWeights::Full(full_w) =
+                            &self.engine.layer_weights[compact_idx].0
+                        else {
+                            unreachable!()
+                        };
+                        (
+                            &full_w.q_proj as *const Q4WeightBuf,
+                            &full_w.k_proj as *const Q4WeightBuf,
+                            &full_w.v_proj as *const Q4WeightBuf,
+                            &full_w.o_proj as *const Q4WeightBuf,
+                            &full_w.q_norm as *const Buffer,
+                            &full_w.k_norm as *const Buffer,
+                        )
+                    };
+                    let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+                    unsafe {
+                        self.dispatch_copy_and_rms_norm_batch(
+                            enc,
+                            &self.session.activations.hidden,
+                            &self.session.activations.residual,
+                            &*w_in_norm,
+                            hidden as u32,
+                            m,
+                            cfg.rms_norm_eps,
+                        );
+                    }
+
+                    unsafe {
+                        self.dispatch_gemm(
+                            enc,
+                            &self.session.activations.hidden,
+                            0,
+                            &*w_q,
+                            &self.session.activations.q,
+                            0,
+                            m,
+                            (2 * q_dim) as u32,
+                            hidden as u32,
+                        );
+                        self.dispatch_gemm(
+                            enc,
+                            &self.session.activations.hidden,
+                            0,
+                            &*w_k,
+                            &self.session.activations.k,
+                            0,
+                            m,
+                            kv_dim as u32,
+                            hidden as u32,
+                        );
+                        self.dispatch_gemm(
+                            enc,
+                            &self.session.activations.hidden,
+                            0,
+                            &*w_v,
+                            &self.session.activations.v,
+                            0,
+                            m,
+                            kv_dim as u32,
+                            hidden as u32,
+                        );
+                    }
+
+                    {
+                        let base_pos = start_pos as u32;
+                        let num_tok = m;
+                        let nqh = num_q_heads as u32;
+                        let nkh = num_kv_heads as u32;
+                        let hd = head_dim as u32;
+                        let kvd = kv_dim as u32;
+                        let (qn_ref, kn_ref): (&Buffer, &Buffer) = unsafe { (&*w_qn, &*w_kn) };
+
+                        self.dispatch_scatter_q_gate_batch(enc, num_tok, nqh, hd);
+                        self.dispatch_per_head_rms_norm_batch(
+                            enc,
+                            &self.session.activations.q_separated,
+                            qn_ref,
+                            num_tok,
+                            nqh,
+                            hd,
+                            cfg.rms_norm_eps,
+                        );
+                        self.dispatch_per_head_rms_norm_batch(
+                            enc,
+                            &self.session.activations.k,
+                            kn_ref,
+                            num_tok,
+                            nkh,
+                            hd,
+                            cfg.rms_norm_eps,
+                        );
+                        self.dispatch_partial_rope_batch(
+                            enc,
+                            &self.session.activations.q_separated,
+                            num_tok,
+                            nqh,
+                            hd,
+                            half_rope_dim,
+                            base_pos,
+                        );
+                        self.dispatch_partial_rope_batch(
+                            enc,
+                            &self.session.activations.k,
+                            num_tok,
+                            nkh,
+                            hd,
+                            half_rope_dim,
+                            base_pos,
+                        );
+                        self.dispatch_copy_kv_cache_batch(
+                            enc,
+                            &self.session.activations.k,
+                            &self.session.activations.v,
+                            &self.session.kv_cache.k_bufs[full_idx],
+                            &self.session.kv_cache.v_bufs[full_idx],
+                            num_tok,
+                            kvd,
+                            base_pos,
+                        );
+                    }
+
+                    if self
+                        .dispatch_prefill_attention_batched(
+                            enc,
+                            &self.session.kv_cache.k_bufs[full_idx],
+                            &self.session.kv_cache.v_bufs[full_idx],
+                            start_pos as u32,
+                            m,
+                            head_dim as u32,
+                            num_q_heads as u32,
+                            num_kv_heads as u32,
+                            q_dim as u32,
+                            kv_dim as u32,
+                            scale,
+                        )
+                        .is_err()
+                    {
+                        for t in 0..n {
+                            let abs_pos = start_pos + t;
+                            let qs_off = (t * q_dim) as u64 * 4;
+                            let ao_off = (t * q_dim) as u64 * 4;
+                            let cache_len = (abs_pos + 1) as u32;
+                            let hd = head_dim as u32;
+                            let nqh = num_q_heads as u32;
+                            let nkh = num_kv_heads as u32;
+                            let qd = q_dim as u32;
+                            let kvd = kv_dim as u32;
+                            {
+                                if self.use_kv_f16 {
+                                    enc.set_compute_pipeline_state(
+                                        &self.engine.pipelines.decode_attention_f16,
+                                    );
+                                } else {
+                                    enc.set_compute_pipeline_state(
+                                        &self.engine.pipelines.decode_attention,
+                                    );
+                                }
+                                enc.set_buffer(
+                                    0,
+                                    Some(&self.session.activations.q_separated),
+                                    qs_off,
+                                );
+                                enc.set_buffer(1, Some(&self.session.kv_cache.k_bufs[full_idx]), 0);
+                                enc.set_buffer(2, Some(&self.session.kv_cache.v_bufs[full_idx]), 0);
+                                enc.set_buffer(3, Some(&self.session.activations.attn_out), ao_off);
+                                enc.set_bytes(4, 4, &cache_len as *const u32 as *const _);
+                                enc.set_bytes(5, 4, &hd as *const u32 as *const _);
+                                enc.set_bytes(6, 4, &nqh as *const u32 as *const _);
+                                enc.set_bytes(7, 4, &nkh as *const u32 as *const _);
+                                enc.set_bytes(8, 4, &qd as *const u32 as *const _);
+                                enc.set_bytes(9, 4, &kvd as *const u32 as *const _);
+                                enc.set_bytes(10, 4, &scale as *const f32 as *const _);
+                                enc.dispatch_thread_groups(
+                                    MTLSize::new(nkh as u64, 1, 1),
+                                    MTLSize::new(256, 1, 1),
+                                );
+                            }
+                        }
+                    }
+
+                    self.dispatch_sigmoid_gate(enc, m * q_dim as u32);
+
+                    unsafe {
+                        self.dispatch_gemm(
+                            enc,
+                            &self.session.activations.attn_out,
+                            0,
+                            &*w_o,
+                            &self.session.activations.ffn_out,
+                            0,
+                            m,
+                            hidden as u32,
+                            q_dim as u32,
+                        );
+                    }
+
+                    unsafe {
+                        self.dispatch_fused_residual_add_norm_batch(
+                            enc,
+                            &self.session.activations.residual,
+                            &self.session.activations.ffn_out,
+                            &self.session.activations.residual,
+                            &self.session.activations.hidden,
+                            &*w_post_norm,
+                            hidden as u32,
+                            m,
+                            cfg.rms_norm_eps,
+                        );
+                    }
+
+                    unsafe {
+                        self.dispatch_gemm_at(
+                            enc,
+                            &self.session.activations.hidden,
+                            0,
+                            &*w_gate_up,
+                            0,
+                            &self.session.activations.gate,
+                            0,
+                            m,
+                            inter as u32,
+                            hidden as u32,
+                        );
+                        self.dispatch_gemm_at(
+                            enc,
+                            &self.session.activations.hidden,
+                            0,
+                            &*w_gate_up,
+                            gate_byte_size,
+                            &self.session.activations.up,
+                            0,
+                            m,
+                            inter as u32,
+                            hidden as u32,
+                        );
+                    }
+                    self.dispatch_silu_mul(enc, m * inter as u32);
+                    unsafe {
+                        self.dispatch_gemm(
+                            enc,
+                            &self.session.activations.gate,
+                            0,
+                            &*w_down,
+                            &self.session.activations.ffn_out,
+                            0,
+                            m,
+                            hidden as u32,
+                            inter as u32,
+                        );
+                    }
+
+                    self.dispatch_add_and_copy(
+                        enc,
+                        &self.session.activations.ffn_out,
+                        &self.session.activations.residual,
+                        &self.session.activations.hidden,
+                        m * hidden as u32,
+                    );
+
+                    full_idx += 1;
+                }
+            }
+
+            // Close the trailing non-GDN segment (mirrors the emit_logits=false early
+            // return in forward_prefill_batched_chunk: still commit + advance the
+            // session cursor, just never compute logits).
+            enc.end_encoding();
+            cmd.commit();
+            cmd.wait_until_completed();
+            timing.non_gdn_ms += seg_start.elapsed().as_secs_f64() * 1000.0;
+
+            self.session.set_position(start_pos + n);
+            timing
+        }
+
         /// MTP greedy decode loop (LATTICE_MTP=1, greedy only).
         ///
         /// Each round: draft one extra token via MTP, verify 2 tokens with the target
@@ -25817,6 +26529,99 @@ mod inner {
                 };
                 LmHeadBenchOutput { marker }
             }
+        }
+
+        /// Per-chunk GDN/non-GDN wall-clock dispatch time, in milliseconds, for the
+        /// #175 harness (`bin/bench_gdn_prefill_ab.rs`). `gdn_ms` covers only the
+        /// isolated recurrence dispatch (chunked C32 family or serial
+        /// conv1d+recurrence); `non_gdn_ms` covers everything else in the same
+        /// `max_prefill`-sized chunk (embedding excluded — see
+        /// [`forward_prefill_gdn_isolated_chunk`]'s doc comment).
+        #[derive(Clone, Copy, Debug, Default)]
+        pub struct GdnIsolatedChunkTiming {
+            pub gdn_ms: f64,
+            pub non_gdn_ms: f64,
+            pub num_gdn_layers: usize,
+        }
+
+        impl GdnIsolatedChunkTiming {
+            pub fn total_ms(&self) -> f64 {
+                self.gdn_ms + self.non_gdn_ms
+            }
+
+            pub fn accumulate(&mut self, other: &GdnIsolatedChunkTiming) {
+                self.gdn_ms += other.gdn_ms;
+                self.non_gdn_ms += other.non_gdn_ms;
+                self.num_gdn_layers += other.num_gdn_layers;
+            }
+        }
+
+        /// #175 harness entry point. Runs ONE `max_prefill`-sized prefill chunk
+        /// (`token_ids.len() <= max_prefill(state)`) with GDN recurrence dispatch
+        /// isolated into its own command buffer(s) (see
+        /// `MetalQwen35State::forward_prefill_chunk_gdn_isolated`'s doc comment for
+        /// exactly what changed vs the production dispatch path — nothing GDN-kernel
+        /// -related). Returns wall-clock GDN vs non-GDN dispatch time for this chunk.
+        ///
+        /// For prompts longer than `max_prefill`, the caller must drive the chunking
+        /// loop itself (mirrors `forward_prefill_impl`'s production chunking):
+        ///
+        /// ```ignore
+        /// state.set_gdn_chunked(chunked);
+        /// state.reset_state();
+        /// let mut total = GdnIsolatedChunkTiming::default();
+        /// let mp = max_prefill(&state);
+        /// let mut start = 0usize;
+        /// for chunk in token_ids.chunks(mp) {
+        ///     total.accumulate(&forward_prefill_gdn_isolated_chunk(&mut state, chunk, start));
+        ///     start += chunk.len();
+        /// }
+        /// ```
+        pub fn forward_prefill_gdn_isolated_chunk(
+            state: &mut MetalQwen35State,
+            token_ids: &[u32],
+            start_pos: usize,
+        ) -> GdnIsolatedChunkTiming {
+            state.forward_prefill_chunk_gdn_isolated(token_ids, start_pos)
+        }
+
+        /// The session's `max_prefill` (single-command-buffer chunk cap; 512 for all
+        /// current configs, `max_cache_len.min(512)`) — the caller-side chunking loop
+        /// for [`forward_prefill_gdn_isolated_chunk`] must split prompts on this
+        /// boundary exactly as the production `forward_prefill_impl` does.
+        pub fn max_prefill(state: &MetalQwen35State) -> usize {
+            state.session.max_prefill
+        }
+
+        /// Production-path calibration entry point for the #175 harness. Runs ONE
+        /// `max_prefill`-sized prefill chunk through the real, unmodified
+        /// [`MetalQwen35State::forward_prefill_batched_chunk`] dispatch — single
+        /// command buffer, no per-layer command-buffer splits — the same path
+        /// `forward_prefill_impl` uses in production. This exists so the isolated
+        /// harness's per-layer-split measurement can be anchored against an
+        /// unmodified-dispatch total, rather than against a stale prior number: the
+        /// isolated method's own command-buffer splits add CPU<->GPU sync overhead
+        /// that a total-vs-total comparison must not include.
+        ///
+        /// `all_positions=true` (writes full-attention K/V rows and advances GDN
+        /// state for every token in `token_ids`, matching
+        /// `forward_prefill_chunk_gdn_isolated`'s contract) and `emit_logits=false`
+        /// (skips the terminal RMSNorm/lm_head/top-k tail, again matching the
+        /// isolated path, so the two measurements cover comparable work — see
+        /// `forward_prefill_chunk_gdn_isolated`'s doc comment for why omitting the
+        /// tail does not bias a serial-vs-chunked ratio).
+        ///
+        /// Returns nothing: unlike the isolated path, production dispatch is a
+        /// single command buffer per chunk (one commit + `wait_until_completed`
+        /// already inside `forward_prefill_batched_chunk`), so the caller times the
+        /// call from outside with a plain CPU `Instant` — no internal
+        /// instrumentation is needed or added.
+        pub fn forward_prefill_production_chunk(
+            state: &mut MetalQwen35State,
+            token_ids: &[u32],
+            start_pos: usize,
+        ) {
+            let _ = state.forward_prefill_batched_chunk(token_ids, start_pos, true, false);
         }
     }
 }


### PR DESCRIPTION
## What

New `bench-internals` binary `bench_gdn_prefill_ab`: an isolation bench harness measuring the GDN recurrence cost of the serial (per-token) vs chunked (C32) prefill paths, feeding the renegotiated #175 acceptance gates (see the gate comment on #175).

Two sweeps per length:
- **Isolated sweep** — a bench-only forward variant (`forward_prefill_chunk_gdn_isolated`) splits the command buffer around each GDN layer's recurrence dispatches so their GPU time is measured directly. The added sync compresses the measured ratio toward 1.0, so isolated ratios are floors.
- **Production calibration sweep** — the unmodified production dispatch path, checked against per-length anchor bands versioned to a measured baseline (2026-07-08 @ f8c302f9e). Anchors that fire on a clean idle run mean "re-measure the baseline at current HEAD", not "widen the band".

Self-validation built in: non-GDN consistency across arms, total-vs-GDN cross-check, wide isolated sanity bound (1.0–20.0x), the production anchor above, and a prompt-identity FNV-1a hash guard proving both sweeps tokenized the same input.

`--interleaved` toggles the two arms per prefill instead of running them as sequential blocks, so thermal/clock drift lands symmetrically on both arms. This mode is mandatory for #175 gate adjudication (sequential arms at 16K showed ~17% non-GDN inflation in the second arm; interleaved at 1024 shows 0.9% arm asymmetry).

`crates/inference` changes are additive and bench-gated: a `bench_support` module and the isolated forward variant behind the `bench-internals` feature; a one-line production-path wrapper. No production dispatch path is modified.

## Validation

Interleaved run, 1024 tokens, warmup 2 / repeats 5, GPU flock held, idle machine:

```
[bench] mode=interleaved (per-prefill arm toggling)
[bench] len=  1024 prompt_fnv1a=d822301c03d57c57
[bench] len=  1024 path=chunked_prod total_ms median=503.81 [499.84,507.75] IQR%=0.4
[bench] len=  1024 path=serial_prod  total_ms median=1213.93 [1208.16,1218.54] IQR%=0.4
[bench] len=  1024 path=chunked  gdn_ms median=156.45 [155.35,158.20] IQR%=0.8  total_ms median=519.05  non_gdn_ms median=362.60
[bench] len=  1024 path=serial   gdn_ms median=901.38 [879.43,909.36] IQR%=0.5  total_ms median=1266.68  non_gdn_ms median=365.91
# len=1024: serial_GDN/chunked_GDN speedup = 5.761x
# len=1024: serial_prod_total/chunked_prod_total speedup = 2.410x   (anchor band 1.93-2.90: PASS)
# len=1024: self-validation flags: none (clean)
```

Full three-length campaign (sequential mode, same instrument): 5.80x @1024, 5.21x @4096, 4.70x @16384 isolated recurrence — the basis for the #175 gate re-baseline.

`cargo clippy --release -D warnings` clean; `cargo fmt --check` clean. Debug builds are rejected with `compile_error!` (timing in debug is meaningless).

## bench-compare — no perf impact (instrument-artifact deltas, proven by a null A/B)

`make bench-compare` reports large CPU-microbench "regressions" for this PR, but they are harness artifacts, not real. Two independent lines of evidence:

**1. Structural: the benched binaries are byte-identical between base and head.** Every source addition here is behind `#[cfg(feature = "bench-internals")]` (metal_qwen35.rs), plus one new `[[bin]]` with `required-features`. The Cargo.toml diff is a single inert bin entry — no dependency, feature-definition, profile, or default-feature change. The criterion benches (`elementwise_cpu_bench`, embed `simd`) build **without** `bench-internals`, so they compile from identical effective source on both sides. Identical machine code cannot regress.

**2. Empirical null A/B.** Running `bench-compare origin/main origin/main` — **the same commit against itself, zero source difference** — produced **56 FAIL / 12 WARN, worst +378%**. That is *more* fake regressions than this PR's run (35 FAIL). The mechanism: `bench-compare` builds and benches BASE first, then HEAD second, so the second half runs on a machine thermally saturated by the first half and throttles uniformly. The one-sided inflation and the co-reported "improvements" (42–72 depending on run) are the signature of that bias.

Verdict: **no perf change is attributable to this PR**; its deltas are below the instrument's own commit-vs-itself noise floor. (Filed separately: `bench-compare`'s base-then-head ordering produces false regressions under thermal load — it needs interleaving or a cooldown to be usable as a gate on this machine.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
