### PR TITLE
test(inference,transport): NaN/Inf-honest parity max-diff helpers

### DIFF
--- a/crates/embed/tests/embed_parity_vs_hf.rs
+++ b/crates/embed/tests/embed_parity_vs_hf.rs
@@ -127,11 +127,22 @@ fn cosine_sim(a: &[f32], b: &[f64]) -> f64 {
 }
 
 /// Element-wise max absolute difference between two f32 vectors.
+///
+/// NaN-honest: a `.fold(0.0, f64::max)` silently drops a NaN/Inf operand
+/// (IEEE maxNum keeps the non-NaN side), letting a catastrophically wrong
+/// output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
 fn max_abs_diff(a: &[f32], b: &[f64]) -> f64 {
-    a.iter()
-        .zip(b.iter())
-        .map(|(&x, &y)| (x as f64 - y).abs())
-        .fold(0.0_f64, f64::max)
+    let mut max = 0.0_f64;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        let d = (x as f64 - y).abs();
+        if !d.is_finite() {
+            return d;
+        }
+        if d > max {
+            max = d;
+        }
+    }
+    max
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/inference/src/attention/differential.rs
+++ b/crates/inference/src/attention/differential.rs
@@ -501,13 +501,23 @@ mod tests {
         out
     }
 
+    // NaN-honest max|a-b|: a `.fold(0.0, f32::max)` silently drops a NaN/Inf
+    // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+    // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
     #[allow(dead_code)]
     fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
         assert_eq!(a.len(), b.len());
-        a.iter()
-            .zip(b.iter())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0_f32, f32::max)
+        let mut max = 0.0_f32;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = (x - y).abs();
+            if !d.is_finite() {
+                return d;
+            }
+            if d > max {
+                max = d;
+            }
+        }
+        max
     }
 
     fn make_cfg(

--- a/crates/inference/src/attention/flash.rs
+++ b/crates/inference/src/attention/flash.rs
@@ -920,11 +920,21 @@ mod tests {
         mask
     }
 
+    // NaN-honest max|a-b|: a `.fold(0.0, f32::max)` silently drops a NaN/Inf
+    // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+    // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
     fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
-        a.iter()
-            .zip(b.iter())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0f32, f32::max)
+        let mut max = 0.0f32;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = (x - y).abs();
+            if !d.is_finite() {
+                return d;
+            }
+            if d > max {
+                max = d;
+            }
+        }
+        max
     }
 
     fn reference_attention_head(

--- a/crates/inference/src/attention/gated.rs
+++ b/crates/inference/src/attention/gated.rs
@@ -335,12 +335,22 @@ mod tests {
         out
     }
 
+    // NaN-honest max|a-b|: a `.fold(0.0, f32::max)` silently drops a NaN/Inf
+    // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+    // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
     fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
         assert_eq!(a.len(), b.len());
-        a.iter()
-            .zip(b.iter())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0f32, f32::max)
+        let mut max = 0.0f32;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = (x - y).abs();
+            if !d.is_finite() {
+                return d;
+            }
+            if d > max {
+                max = d;
+            }
+        }
+        max
     }
 
     // ---------------------------------------------------------------

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -18469,11 +18469,21 @@ mod inner {
             y
         }
 
+        // NaN-honest max|a-b|: a `.fold(0.0, f32::max)` silently drops a NaN/Inf
+        // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+        // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
         fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
-            a.iter()
-                .zip(b.iter())
-                .map(|(x, y)| (x - y).abs())
-                .fold(0.0f32, f32::max)
+            let mut max = 0.0f32;
+            for (x, y) in a.iter().zip(b.iter()) {
+                let d = (x - y).abs();
+                if !d.is_finite() {
+                    return d;
+                }
+                if d > max {
+                    max = d;
+                }
+            }
+            max
         }
 
         /// Hermetic numeric differential: naive vs tiled vs CPU reference, two shapes.

--- a/crates/inference/src/quant/quarot/lora.rs
+++ b/crates/inference/src/quant/quarot/lora.rs
@@ -235,11 +235,21 @@ mod tests {
             .collect()
     }
 
+    // NaN-honest max|a-b|: a `.fold(0.0, f32::max)` silently drops a NaN/Inf
+    // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+    // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
     fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
-        a.iter()
-            .zip(b.iter())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0_f32, f32::max)
+        let mut max = 0.0_f32;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = (x - y).abs();
+            if !d.is_finite() {
+                return d;
+            }
+            if d > max {
+                max = d;
+            }
+        }
+        max
     }
 
     // --- Input-side tests (A counter-rotation) ---

--- a/crates/inference/src/quant/quarot/pipeline.rs
+++ b/crates/inference/src/quant/quarot/pipeline.rs
@@ -279,11 +279,21 @@ mod tests {
         y
     }
 
+    // NaN-honest max|a-b|: a `.fold(0.0, f64::max)` silently drops a NaN/Inf
+    // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+    // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
     fn max_abs_diff_f64(a: &[f64], b: &[f64]) -> f64 {
-        a.iter()
-            .zip(b.iter())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0_f64, f64::max)
+        let mut max = 0.0_f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = (x - y).abs();
+            if !d.is_finite() {
+                return d;
+            }
+            if d > max {
+                max = d;
+            }
+        }
+        max
     }
 
     #[test]

--- a/crates/inference/src/quant/quarot/rmsnorm_fusion.rs
+++ b/crates/inference/src/quant/quarot/rmsnorm_fusion.rs
@@ -212,11 +212,21 @@ mod tests {
         y
     }
 
+    // NaN-honest max|a-b|: a `.fold(0.0, f64::max)` silently drops a NaN/Inf
+    // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+    // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
     fn max_abs_diff_f64(a: &[f64], b: &[f64]) -> f64 {
-        a.iter()
-            .zip(b.iter())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0_f64, f64::max)
+        let mut max = 0.0_f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = (x - y).abs();
+            if !d.is_finite() {
+                return d;
+            }
+            if d > max {
+                max = d;
+            }
+        }
+        max
     }
 
     #[test]

--- a/crates/inference/src/quant/quarot/rotation.rs
+++ b/crates/inference/src/quant/quarot/rotation.rs
@@ -209,11 +209,21 @@ mod tests {
         y
     }
 
+    // NaN-honest max|a-b|: a `.fold(0.0, f32::max)` silently drops a NaN/Inf
+    // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+    // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
     fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
-        a.iter()
-            .zip(b.iter())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0_f32, f32::max)
+        let mut max = 0.0_f32;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = (x - y).abs();
+            if !d.is_finite() {
+                return d;
+            }
+            if d > max {
+                max = d;
+            }
+        }
+        max
     }
 
     fn synthetic_weight(rows: usize, cols: usize, seed: u64) -> Vec<f32> {
@@ -360,11 +370,21 @@ mod tests {
         y
     }
 
+    // NaN-honest max|a-b|: a `.fold(0.0, f64::max)` silently drops a NaN/Inf
+    // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+    // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
     fn max_abs_diff_f64(a: &[f64], b: &[f64]) -> f64 {
-        a.iter()
-            .zip(b.iter())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0_f64, f64::max)
+        let mut max = 0.0_f64;
+        for (x, y) in a.iter().zip(b.iter()) {
+            let d = (x - y).abs();
+            if !d.is_finite() {
+                return d;
+            }
+            if d > max {
+                max = d;
+            }
+        }
+        max
     }
 
     #[test]

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -1905,11 +1905,21 @@ mod tests {
                 .collect()
         }
 
+        // NaN-honest max|a-b|: a `.fold(0.0, f64::max)` silently drops a NaN/Inf
+        // operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+        // wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
         fn max_diff(a: &[f64], b: &[f64]) -> f64 {
-            a.iter()
-                .zip(b)
-                .map(|(x, y)| (x - y).abs())
-                .fold(0.0_f64, f64::max)
+            let mut max = 0.0_f64;
+            for (x, y) in a.iter().zip(b) {
+                let d = (x - y).abs();
+                if !d.is_finite() {
+                    return d;
+                }
+                if d > max {
+                    max = d;
+                }
+            }
+            max
         }
 
         // Independent symmetric Q4 dequant reference: re-implements

--- a/crates/inference/tests/differential_attention_test.rs
+++ b/crates/inference/tests/differential_attention_test.rs
@@ -45,12 +45,22 @@ fn det_data(len: usize, seed: u64) -> Vec<f32> {
     out
 }
 
+// NaN-honest max|a-b|: a `.fold(0.0, f32::max)` silently drops a NaN/Inf
+// operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+// wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
 fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
     assert_eq!(a.len(), b.len(), "length mismatch in max_abs_diff");
-    a.iter()
-        .zip(b.iter())
-        .map(|(x, y)| (x - y).abs())
-        .fold(0.0_f32, f32::max)
+    let mut max = 0.0_f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        let d = (x - y).abs();
+        if !d.is_finite() {
+            return d;
+        }
+        if d > max {
+            max = d;
+        }
+    }
+    max
 }
 
 // ===================================================================

--- a/crates/inference/tests/gated_attention_test.rs
+++ b/crates/inference/tests/gated_attention_test.rs
@@ -81,12 +81,22 @@ fn ref_apply_sigmoid_gate(context: &[f32], gate: &[f32]) -> Vec<f32> {
         .collect()
 }
 
+// NaN-honest max|a-b|: a `.fold(0.0, f32::max)` silently drops a NaN/Inf
+// operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+// wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
 fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
     assert_eq!(a.len(), b.len(), "length mismatch in max_abs_diff");
-    a.iter()
-        .zip(b.iter())
-        .map(|(x, y)| (x - y).abs())
-        .fold(0.0f32, f32::max)
+    let mut max = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        let d = (x - y).abs();
+        if !d.is_finite() {
+            return d;
+        }
+        if d > max {
+            max = d;
+        }
+    }
+    max
 }
 
 // ===================================================================

--- a/crates/inference/tests/native_sparse_attention_test.rs
+++ b/crates/inference/tests/native_sparse_attention_test.rs
@@ -76,12 +76,22 @@ fn det_data(len: usize, seed: u64) -> Vec<f32> {
     out
 }
 
+// NaN-honest max|a-b|: a `.fold(0.0, f32::max)` silently drops a NaN/Inf
+// operand (IEEE maxNum keeps the non-NaN side), letting a catastrophically
+// wrong output read as 0.0 and slip past a `<= tol` gate. Surface it instead.
 fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
     assert_eq!(a.len(), b.len(), "length mismatch in max_abs_diff");
-    a.iter()
-        .zip(b.iter())
-        .map(|(x, y)| (x - y).abs())
-        .fold(0.0_f32, f32::max)
+    let mut max = 0.0_f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        let d = (x - y).abs();
+        if !d.is_finite() {
+            return d;
+        }
+        if d > max {
+            max = d;
+        }
+    }
+    max
 }
 
 // ===================================================================

--- a/crates/transport/src/logsumexp.rs
+++ b/crates/transport/src/logsumexp.rs
@@ -158,10 +158,19 @@ pub fn normalize_log_weights(log_weights: &mut [f32]) -> f32 {
 /// Maximum absolute difference between two same-length slices.
 ///
 /// **Unstable**: barycenter convergence helper; may be inlined.
+///
+/// Fails closed on a non-finite difference: a NaN or Inf `delta` compares
+/// `false` against every running max under plain `>`, so a naive
+/// accumulate-the-max loop silently reports the non-finite input as `0.0`.
+/// This returns the first non-finite `delta` immediately instead, so a
+/// catastrophically wrong input can never read back as a clean small value.
 pub fn max_abs_diff(lhs: &[f32], rhs: &[f32]) -> f32 {
     let mut max_delta = 0.0;
     for (&left, &right) in lhs.iter().zip(rhs.iter()) {
         let delta = abs(left - right);
+        if !delta.is_finite() {
+            return delta;
+        }
         if delta > max_delta {
             max_delta = delta;
         }
@@ -257,4 +266,34 @@ pub fn kl_term(x: f32, y: f32, floor: f32) -> f32 {
     let x_clamped = x.max(floor);
     let y_clamped = y.max(floor);
     x_clamped * (safe_ln(x_clamped, floor) - safe_ln(y_clamped, floor)) - x_clamped + y_clamped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mutation-sensitivity proof: a plain accumulate-the-max loop with no
+    /// finiteness check silently reports `0.0` for a NaN or Inf difference, so
+    /// a catastrophically wrong input would read as a clean small value and
+    /// pass a tolerance gate. This asserts the fixed helper surfaces the
+    /// non-finite value instead; if this ever fails, the gate is decoration
+    /// again.
+    #[test]
+    fn max_abs_diff_is_nan_and_inf_honest() {
+        let clean = [1.0f32, 2.0, 3.0];
+
+        let nan_side = [1.0f32, f32::NAN, 3.0];
+        let d = max_abs_diff(&clean, &nan_side);
+        assert!(
+            !d.is_finite(),
+            "max_abs_diff silently dropped a NaN operand (got {d}); the gate is blind"
+        );
+
+        let inf_side = [1.0f32, f32::INFINITY, 3.0];
+        let di = max_abs_diff(&clean, &inf_side);
+        assert!(
+            !di.is_finite(),
+            "max_abs_diff silently dropped an Inf operand (got {di}); the gate is blind"
+        );
+    }
 }


### PR DESCRIPTION
## What

Makes 15 parity-test max-diff helpers across `inference`, `transport`, and `embed` NaN/Inf-honest. Each folded `max|a-b|` with `f32::max`/`f64::max` (or a plain `>` accumulate loop). IEEE `maxNum` returns the non-NaN operand, so a NaN/Inf output silently read as a clean small value and could pass a `<= tol` gate — a gate-integrity bug: a parity gate that maxNums past NaN can report green on a catastrophically wrong kernel output.

Each helper now returns the first non-finite difference immediately, failing closed on it. **Behavior-preserving for all finite inputs** (same max as before).

This is the fleet-wide follow-up to #716, which fixed the same class in the GDN chunkwise oracle's gate (where a strong-decay revert produced 20480 NaN that the max-fold reported as 0.0).

## Scope

Helpers fixed (14 files): `metal_qwen35.rs` (test module), `quarot/{lora,rotation,rmsnorm_fusion,pipeline}.rs` (incl. both f32 and f64 variants in `rotation.rs`), `attention/{flash,gated,differential}.rs`, `weights/q4_weights.rs`, `transport/logsumexp.rs`, and 4 test files (`native_sparse_attention_test`, `differential_attention_test`, `gated_attention_test`, `embed_parity_vs_hf`).

**Deliberately untouched:** the `.fold(f32::NEG_INFINITY, f32::max)` softmax/logit stability maxes — those legitimately want `maxNum` semantics for numerical-stability max-subtraction.

## Public API note

`lattice-transport::logsumexp::max_abs_diff` (pub fn) changes its NaN/Inf behavior: previously returned `0.0` on a non-finite delta, now returns the non-finite delta. Non-breaking for all finite inputs.

## Tests

Adds a mutation-sensitivity test on the transport public helper (NaN and Inf operands must surface non-finite, not fold to `0.0`).

## bench-compare

N/A — no production perf surface. Changes are test-module/debug parity helpers plus one convergence-debug `pub fn` gaining a single `is_finite` branch per element (not a hot path). Behavior-preserving for finite inputs.
