### PR TITLE
docs(readme): fix stale version pins + add a Get-a-model step to CLI quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ All three can be used on their own.
 
 ```toml
 [dependencies]
-lattice-embed = "0.4"
+lattice-embed = "0.5"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -165,13 +165,13 @@ Model weights are downloaded from HuggingFace on first use and cached at `~/.lat
 ### GPU acceleration (macOS)
 
 ```toml
-lattice-embed = { version = "0.4", features = ["metal-gpu"] }
+lattice-embed = { version = "0.5", features = ["metal-gpu"] }
 ```
 
 ### Cross-platform GPU
 
 ```toml
-lattice-embed = { version = "0.4", features = ["wgpu-gpu"] }
+lattice-embed = { version = "0.5", features = ["wgpu-gpu"] }
 ```
 
 ---
@@ -243,6 +243,25 @@ With Metal GPU (macOS only):
 
 ```bash
 cargo build --release -p lattice-inference --bin lattice --features metal-gpu,f16
+```
+
+### Get a model
+
+The embedding models above download automatically on first use. Generation
+checkpoints for `lattice chat` and `lattice serve` are not auto-fetched yet, so
+download one into the model cache before your first chat:
+
+```bash
+pip install -U "huggingface_hub[cli]"
+huggingface-cli download Qwen/Qwen3.5-0.8B --local-dir ~/.lattice/models/qwen3.5-0.8b
+```
+
+`huggingface_hub` is only the download transport — it is not a runtime
+dependency, and the engine itself runs no Python. Then point `--model` at that
+directory:
+
+```bash
+lattice chat --model ~/.lattice/models/qwen3.5-0.8b
 ```
 
 Beyond the unified `lattice` binary, several standalone tools live in

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -36,6 +36,7 @@ git status  # must be clean
 # 2. Version already bumped? Verify:
 grep '^version' Cargo.toml               # should show {VERSION}
 grep 'version = "' crates/*/Cargo.toml   # internal path deps match the workspace version
+grep -nE 'lattice-embed = ' README.md    # README Quick Start pins track the release major.minor — bump on a minor release
 
 # 3. Full CI
 make ci  # fmt + clippy + doc lint + test + release build


### PR DESCRIPTION
## What

Three funnel fixes to the top of the README, from a first-time-visitor read:

1. **Stale version pins.** The embeddings Quick Start and both GPU snippets pinned `lattice-embed = "0.4"`, but the published workspace is `0.5.0` and the crates.io badge on the same page shows current — the page disagreed with itself and a copy-paste installed a version behind. Bumped all three to `0.5`.

2. **Model-acquisition cliff.** Every CLI quick-start ends at `lattice chat --model ~/.lattice/models/qwen3.5-0.8b`, but the command that downloads a model to that path lived only in the Raspberry Pi subsection. A visitor on the primary macOS/Linux path ran chat, hit "no model at that path", and had no visible next step. Added a "Get a model" step to the CLI quick-start, before the first chat invocation.

3. **"No Python" clarity.** The new step notes that `huggingface_hub` is only the download transport, not a runtime dependency, so getting started doesn't read as contradicting the engine's no-Python positioning.

Plus a one-line release-checklist entry (`docs/RELEASE.md`) so the README pins track the tag on future minor releases.

## Scope

Docs only — no code, no hot path. `README.md` + `docs/RELEASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
