### PR TITLE
fix(inference): resolve clippy 1.96 lints and pin toolchain to 1.94.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,14 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: macos-latest
+    # RUSTUP_TOOLCHAIN pins every rustup-mediated invocation in this job to 1.93.1.
+    # Without it, rustup's checked-in rust-toolchain.toml (1.94.1, repo dev/CI pin)
+    # outranks the action's `rustup default 1.93.1`, so `rustup which cargo` and
+    # `cargo check` below would silently resolve to 1.94.1 and this gate would stop
+    # proving anything about the declared MSRV (see rust-toolchain.toml precedence:
+    # https://rust-lang.github.io/rustup/overrides.html).
+    env:
+      RUSTUP_TOOLCHAIN: "1.93.1"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.93.1
@@ -352,6 +360,8 @@ jobs:
         with:
           shared-key: msrv
           cache-on-failure: true
+      - name: assert selected compiler is 1.93.1
+        run: rustc --version | grep -F 1.93.1
       - name: workspace — check at MSRV (f16,metal-gpu, all targets)
         run: cargo check --workspace --features f16,metal-gpu --all-targets
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,9 @@ E5 models need `"query: "` / `"passage: "` prefixes. Qwen3 needs instruction pre
 
 ## Rust Conventions
 
-**Toolchain**: Edition 2024, no MSRV declared; CI pins Rust 1.94.1, resolver 2.
+**Toolchain**: Edition 2024, resolver 2. MSRV is 1.93 (`Cargo.toml` `rust-version`, CI-gated
+at 1.93.1 in the `msrv` job). Repository development/CI toolchain is pinned to 1.94.1 via
+`rust-toolchain.toml`.
 
 **Lints**: Zero clippy warnings. All crates inherit `[lints] workspace = true`. Correctness lints are `deny`. `unsafe_op_in_unsafe_fn = "allow"` for SIMD. `inference` allows `too_many_arguments` and `needless_range_loop` crate-wide. AVX-512 code gets `#[allow(clippy::incompatible_msrv)]`.
 

--- a/crates/inference/src/attention/native_sparse.rs
+++ b/crates/inference/src/attention/native_sparse.rs
@@ -461,11 +461,7 @@ pub fn apply_native_sparse_attention(
 
     // model_dim: infer from x_buf length. seq_len=0 is handled below after the early return.
     // For seq_len>0 the division is safe because seq_len>=1.
-    let model_dim = if seq_len > 0 {
-        x_buf.len() / seq_len
-    } else {
-        0
-    };
+    let model_dim = x_buf.len().checked_div(seq_len).unwrap_or(0);
     assert_eq!(
         x_buf.len(),
         seq_len * model_dim,

--- a/crates/inference/src/rope.rs
+++ b/crates/inference/src/rope.rs
@@ -38,11 +38,7 @@ impl RopeTable {
     /// Callers that index `apply` / `cos_at` / `sin_at` beyond this will panic.
     #[inline]
     pub fn max_positions(&self) -> usize {
-        if self.half_dim == 0 {
-            0
-        } else {
-            self.cos.len() / self.half_dim
-        }
+        self.cos.len().checked_div(self.half_dim).unwrap_or(0)
     }
 
     /// **Unstable**: row stride in the cos/sin tables — equals `head_dim / 2`.

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -3078,9 +3078,8 @@ mod tests {
             l
         };
         let mut ref_tokens = prompt.clone();
-        let mut ref_pos = prompt.len();
         let mut greedy_out = Vec::with_capacity(max_new);
-        for _ in 0..max_new {
+        for ref_pos in (prompt.len()..).take(max_new) {
             let logits = greedy_fwd(*ref_tokens.last().unwrap(), ref_pos);
             let t = argmax(&logits) as u32;
             if t == eos {
@@ -3088,7 +3087,6 @@ mod tests {
             }
             greedy_out.push(t);
             ref_tokens.push(t);
-            ref_pos += 1;
         }
 
         // Speculative path — identical forward logic, independent closure.
@@ -3138,9 +3136,8 @@ mod tests {
             l
         };
         let mut ref_tokens = prompt.clone();
-        let mut ref_pos = prompt.len();
         let mut greedy_out = Vec::with_capacity(max_new);
-        for _ in 0..max_new {
+        for ref_pos in (prompt.len()..).take(max_new) {
             let logits = greedy_fwd(*ref_tokens.last().unwrap(), ref_pos);
             let t = argmax(&logits) as u32;
             if t == eos {
@@ -3148,7 +3145,6 @@ mod tests {
             }
             greedy_out.push(t);
             ref_tokens.push(t);
-            ref_pos += 1;
         }
 
         let spec_out = generate_with_speculation(&prompt, max_new, eos, tied_fwd, 5, 4);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.94.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Fixes #779 — a local-toolchain-vs-CI skew: CI pins `dtolnay/rust-toolchain@1.94.1`, but a
local checkout on stable 1.96 fails `cargo clippy --workspace -- -D warnings` (and therefore
the pre-commit hook) on four specific lints in unmodified source that #779 named. All four
fixes are mechanical, behavior-preserving refactors — no semantic change.

- `clippy::manual_checked_ops` in `crates/inference/src/attention/native_sparse.rs`: replaced
  the manual `if seq_len > 0 { x_buf.len() / seq_len } else { 0 }` guard with
  `x_buf.len().checked_div(seq_len).unwrap_or(0)`.
- `clippy::manual_checked_ops` in `crates/inference/src/rope.rs` (`max_positions`): same
  pattern, replaced the `half_dim == 0` guard + division with `checked_div`/`unwrap_or(0)`.
- `clippy::explicit_counter_loop` (×2) in `crates/inference/src/speculative.rs` test helpers:
  replaced `for _ in 0..max_new { ... ref_pos += 1; }` (with a separately-tracked `ref_pos`
  counter) with `for ref_pos in (prompt.len()..).take(max_new) { ... }`, per clippy's own
  suggested rewrite. `ref_pos` was otherwise only used as a loop counter in these closures.

Also adds `rust-toolchain.toml` at the repo root, pinning `channel = "1.94.1"` (matching the
CI toolchain) plus `rustfmt`/`clippy` components. This is the root fix for the underlying
class of bug: without a pin, `rustup`'s "latest stable" default silently drifts ahead of
whatever CI is pinned to, and a contributor's local clippy starts failing on lints that don't
exist yet in the CI-pinned toolchain — inviting `--no-verify` habits on the pre-commit hook.

**Round-1 review follow-ups (this update):**

- The `rust-toolchain.toml` pin outranks `dtolnay/rust-toolchain@1.93.1`'s `rustup default`
  inside the `msrv` CI job, since rustup selects a checked-in toolchain file ahead of the
  default toolchain. Both `rustup which cargo` and `cargo check` in that job were silently
  resolving to 1.94.1, so the required MSRV check no longer proved the 1.93 contract it
  exists to gate (the exact #568 failure class). Fixed: `RUSTUP_TOOLCHAIN: "1.93.1"` set at
  the `msrv` job level, plus an explicit `rustc --version | grep -F 1.93.1` assertion step
  before the check. No other CI job touched.
- `AGENTS.md`'s toolchain line said "no MSRV declared," which is stale — `Cargo.toml` already
  declares `rust-version = "1.93"` and CI already gates it. Updated to distinguish the 1.93
  MSRV floor from the 1.94.1 repository development/CI toolchain this PR pins. ADR-064 (a
  historical decision record) is left untouched.
- Narrowed the "four lints" framing below — see Validation.
- Bench-compare re-run twice with the toolchain forced identically for both refs; both
  result sets and the run-to-run variance finding are in the evidence section below.

## Validation

- `cargo clippy --workspace -- -D warnings` — clean, using the pinned 1.94.1 toolchain.
- `RUSTUP_TOOLCHAIN=1.93.1 cargo check --workspace --features f16,metal-gpu --all-targets` —
  passed (MSRV check, forced to the actual 1.93.1 compiler, mirroring the fixed CI job).
- `cargo test -p lattice-inference --lib` — 1536 passed, 0 failed, 18 ignored (includes
  targeted re-runs of the `speculative`, `native_sparse`, and `rope` test modules).
- `cargo +1.96.0 clippy -p lattice-inference --lib -- -D warnings` — passed, confirming the
  four sites #779 named are clean under 1.96.
- **Scope note**: a raw `cargo +1.96.0 clippy --workspace -- -D warnings` still reports four
  additional, unrelated 1.96 warnings on the current base that this PR does not touch:
  `clippy::manual_checked_ops` in `crates/inference/src/bin/lattice.rs:397`, and
  `clippy::useless_conversion` in `crates/inference/src/bin/eval_perplexity.rs:631` and
  `crates/embed/src/service/cached.rs:172` / `:210`. This PR fixes exactly the four sites
  #779 identified; the branch is not claimed to be workspace-wide 1.96-clean.

<details>
<summary>make bench-compare evidence (same-toolchain reruns; original confounded run retained for provenance)</summary>

**Same-toolchain A/B** (`RUSTUP_TOOLCHAIN=1.94.1 make bench-compare`, quick mode, 1.94.1
forced for both refs — verified effective on `origin/main`, which has no toolchain file):
two independent runs on identical refs (`aa4aec6e8...dfe9c2d38^` code-identical benches):

- Run A (review round 1): 19 FAIL / 39 WARN / 6 improvement
- Run B (this branch, post-fix): 4 FAIL / 16 WARN / 53 improvement

Every FAIL/WARN in both runs is confined to `lattice-embed` SIMD/cosine/euclidean groups
(plus one transient inference-group `gelu/4096` +7.57% WARN in run B only), all disjoint
from the code paths touched here. The two runs *flip direction* on dozens of embed
entries (many run-A regressions re-measure as run-B improvements) on identical code and
identical compiler — which is direct evidence these flags are machine-load measurement
noise in quick-mode CIs, not real regressions: a genuine regression is stable in sign
across runs. Apart from the one-run-only `gelu/4096` warning (absent in run A; the GELU
path is untouched by this diff), every flagged entry in both runs is in `lattice-embed`.

Original (compiler-confounded) run, retained for provenance only: 31 FAIL / 55 WARN /
8 improvement, likewise embed-only — superseded by the same-toolchain runs above.

</details>

Closes #779

