### PR TITLE
fix(inference): shared fail-closed softmax row finalizer (ADR-080 C1)

### DIFF
--- a/crates/inference/src/attention/decode.rs
+++ b/crates/inference/src/attention/decode.rs
@@ -209,14 +209,23 @@ fn softmax_decode_scores(
             l = l * alpha + (s - m_new).exp();
             m = m_new;
         }
-        if l > 0.0 {
-            let inv_l = 1.0 / l;
-            for s in row.iter_mut() {
-                *s = (*s - m).exp() * inv_l;
-            }
-        } else {
-            row.fill(0.0);
+        // ADR-080 C1: route the fail-closed final decision through the
+        // shared row-finalizer (#780). Behavior-preserving: the online
+        // (Welford-style) running normalizer `l` here is arithmetically
+        // independent of this split — `l` and `m` are already fully
+        // resolved from the read-only pass above. Splitting the fused
+        // `exp(*s - m) * inv_l` into a separate exp pass then
+        // `finalize_row`'s multiply-by-`inv` is the same floating-point
+        // operations in the same order (no added/removed rounding step).
+        // The added `l.is_finite()` guard (vs. the prior bare `l > 0.0`)
+        // does not change reachable behavior: in every non-finite-score
+        // scenario reachable here, `l` becomes NaN (not a finite-but-huge
+        // or `+inf` value) before this point, so `l > 0.0` and
+        // `l.is_finite() && l > 0.0` already agree on every reachable input.
+        for s in row.iter_mut() {
+            *s = (*s - m).exp();
         }
+        crate::attention::softmax_row::finalize_row(row, l);
     }
 }
 
@@ -813,6 +822,38 @@ mod tests {
             out.iter().all(|&x| x == 0.0),
             "expected fail-closed zero row, got {out:?}"
         );
+    }
+
+    /// ADR-080 C1: `softmax_decode_scores` (the scalar/portable path, called
+    /// directly here rather than through `decode_attention` which always
+    /// dispatches to NEON on aarch64) must fail closed on a lone NaN score,
+    /// not leave it corrupting the row. A second, unpoisoned head in the
+    /// same batched buffer must stay unaffected.
+    #[test]
+    fn test_decode_softmax_scalar_nan_score_fails_closed() {
+        let kv_seq_len = 4;
+        let num_heads = 2;
+        let score_stride = kv_seq_len;
+        let mut scores = vec![0.0f32; num_heads * score_stride];
+        // head 0: poisoned with a NaN score.
+        scores[0..kv_seq_len].copy_from_slice(&[1.0, f32::NAN, 0.5, -0.2]);
+        // head 1: well-formed, must be unaffected.
+        scores[score_stride..score_stride + kv_seq_len].copy_from_slice(&[0.1, 0.2, 0.3, 0.05]);
+
+        softmax_decode_scores(&mut scores, num_heads, kv_seq_len, score_stride);
+
+        let head0 = &scores[0..kv_seq_len];
+        assert!(
+            head0.iter().all(|&v| v == 0.0),
+            "NaN-poisoned head must zero out: {head0:?}"
+        );
+        let head1 = &scores[score_stride..score_stride + kv_seq_len];
+        assert!(
+            head1.iter().all(|v| v.is_finite()),
+            "sibling head must be unaffected: {head1:?}"
+        );
+        let sum: f32 = head1.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-4, "head1 must sum to ~1: {head1:?}");
     }
 
     /// A `NaN` score in the scalar tail (`kv_seq_len % 16 != 0`) must fail closed

--- a/crates/inference/src/attention/differential.rs
+++ b/crates/inference/src/attention/differential.rs
@@ -391,25 +391,25 @@ pub fn apply_differential_attention(
                     }
                 }
 
-                // Softmax (numerically stable, two-pass)
+                // Softmax (numerically stable, two-pass). ADR-080 C1: route the
+                // fail-closed final decision through the shared row-finalizer
+                // instead of the bare `sum > 0.0` check, which had no `else`
+                // branch and left a NaN/+inf-poisoned row un-zeroed (#780).
                 for qi in 0..seq_len {
                     let row = &mut score_slice[qi * seq_len..(qi + 1) * seq_len];
                     let valid = qi + 1;
-                    let max_val = row[..valid]
-                        .iter()
-                        .copied()
-                        .fold(f32::NEG_INFINITY, f32::max);
+                    let (max_val, any_nan) =
+                        crate::attention::softmax_row::row_max_and_any_nan(&row[..valid]);
+                    if crate::attention::softmax_row::row_fails_closed_pre_exp(max_val, any_nan) {
+                        row.fill(0.0);
+                        continue;
+                    }
                     let mut sum = 0.0_f32;
                     for v in &mut row[..valid] {
                         *v = (*v - max_val).exp();
                         sum += *v;
                     }
-                    if sum > 0.0 {
-                        let inv = 1.0 / sum;
-                        for v in &mut row[..valid] {
-                            *v *= inv;
-                        }
-                    }
+                    crate::attention::softmax_row::finalize_row(&mut row[..valid], sum);
                     row[valid..].fill(0.0);
                 }
             }
@@ -644,6 +644,49 @@ mod tests {
             out.len(),
             seq_len * cfg.num_heads * 2 * cfg.head_dim,
             "output length must be seq_len * num_heads * 2 * head_dim"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // ADR-080 C1: NaN score must fail closed (zero the poisoned row), not
+    // propagate. RED before the fix: the softmax loop's `if sum > 0.0` had no
+    // `else` branch, so a NaN-poisoned row was left holding NaN/Inf exponentials
+    // instead of being zeroed (#780).
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_diff_attn_nan_score_fails_closed() {
+        let head_dim = 2_usize;
+        let cfg = make_cfg(1, 1, head_dim, 0);
+        let seq_len = 3_usize;
+
+        // Poison q at position 1 so the QK dot product for query row 1 is NaN.
+        let mut q = det_data(seq_len * cfg.q_dim(), 11);
+        q[cfg.q_dim()] = f32::NAN;
+        let k = det_data(seq_len * cfg.k_dim(), 12);
+        let v = det_data(seq_len * cfg.v_dim(), 13);
+
+        let params = zero_lambda_params(head_dim);
+        let subln_w = vec![1.0f32; 2 * head_dim];
+        let mut out = vec![0.0f32; seq_len * cfg.out_dim()];
+        let mut scratch = DiffAttnScratch::default();
+
+        apply_differential_attention(
+            &q,
+            &k,
+            &v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+
+        assert!(
+            out.iter().all(|x| x.is_finite()),
+            "differential attention output must stay finite even with a NaN score, got {out:?}"
         );
     }
 

--- a/crates/inference/src/attention/differential.rs
+++ b/crates/inference/src/attention/differential.rs
@@ -659,16 +659,29 @@ mod tests {
         let head_dim = 2_usize;
         let cfg = make_cfg(1, 1, head_dim, 0);
         let seq_len = 3_usize;
+        let q_dim = cfg.q_dim();
+        let out_dim = cfg.out_dim();
 
-        // Poison q at position 1 so the QK dot product for query row 1 is NaN.
-        let mut q = det_data(seq_len * cfg.q_dim(), 11);
-        q[cfg.q_dim()] = f32::NAN;
+        // Differential attention packs TWO Q sub-vectors per head (Q1 -> scores1,
+        // Q2 -> scores2; see the `(q_h0, k_h0, scores1), (q_h1, k_h1, scores2)`
+        // pair loop above). Poisoning only ONE sub-vector's dim (as the original
+        // regression test did) only fails ONE of the two differential softmaxes
+        // closed, so `context = attn1 - lambda*attn2` is `0 - lambda*attn2`, not
+        // exactly zero -- `is_finite()` passed on that output for the wrong
+        // reason (a still-finite nonzero value), not because the row was zeroed.
+        // Poison the WHOLE token-1 Q row (both sub-vectors) so BOTH softmaxes
+        // fail closed and the differential context is `0 - lambda*0 == 0`
+        // exactly, letting this test pin "zero in full" instead of "finite".
+        let mut q = det_data(seq_len * q_dim, 11);
+        for d in 0..q_dim {
+            q[q_dim + d] = f32::NAN;
+        }
         let k = det_data(seq_len * cfg.k_dim(), 12);
         let v = det_data(seq_len * cfg.v_dim(), 13);
 
         let params = zero_lambda_params(head_dim);
         let subln_w = vec![1.0f32; 2 * head_dim];
-        let mut out = vec![0.0f32; seq_len * cfg.out_dim()];
+        let mut out = vec![0.0f32; seq_len * out_dim];
         let mut scratch = DiffAttnScratch::default();
 
         apply_differential_attention(
@@ -684,9 +697,87 @@ mod tests {
             &mut scratch,
         );
 
+        let poisoned_row = &out[out_dim..2 * out_dim];
         assert!(
-            out.iter().all(|x| x.is_finite()),
-            "differential attention output must stay finite even with a NaN score, got {out:?}"
+            poisoned_row.iter().all(|&x| x == 0.0),
+            "differential attention's poisoned query row must be exactly \
+             all-zero (fail-closed), not merely finite; got {poisoned_row:?}"
+        );
+
+        // Sibling rows (query 0 and query 2) share no poisoned Q/K/V and must
+        // stay finite and non-degenerate (a real normalized result, not
+        // incidentally zero).
+        for t in [0usize, 2usize] {
+            let row = &out[t * out_dim..(t + 1) * out_dim];
+            assert!(
+                row.iter().all(|x| x.is_finite()),
+                "query {t}'s row must stay finite, got {row:?}"
+            );
+            assert!(
+                row.iter().any(|&x| x != 0.0),
+                "query {t}'s row must be a real (non-degenerate) result, got {row:?}"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // test_diff_attn_partial_nan_row_fails_closed_in_full
+    // ---------------------------------------------------------------
+
+    /// #785 round-1 medium 2 (codex): poisoning a WHOLE Q row (as
+    /// `test_diff_attn_nan_score_fails_closed` does) makes every lane of that
+    /// row NaN together, so it can't distinguish "zero the whole row" from a
+    /// buggy "zero only the NaN lane(s), normalize the rest" mutation -- both
+    /// produce the same all-zero result there. This test poisons a single K
+    /// TIME STEP instead (both packed K halves at position 0), which causal
+    /// masking puts in every later query's row but leaves the *other* lanes of
+    /// that row (k1, k2, ...) untouched: query 1's row is `[NaN, finite]`, a
+    /// genuinely mixed row. A one-lane-only-zero mutation would zero just lane
+    /// 0 and renormalize lane 1 to a nonzero weight, producing a nonzero
+    /// combined context; the real fail-closed contract must zero the WHOLE
+    /// row so the combined context is exactly zero.
+    #[test]
+    fn test_diff_attn_partial_nan_row_fails_closed_in_full() {
+        let head_dim = 2_usize;
+        let cfg = make_cfg(1, 1, head_dim, 0);
+        let seq_len = 2_usize;
+        let out_dim = cfg.out_dim();
+
+        let q = det_data(seq_len * cfg.q_dim(), 21);
+        // Poison K time-step 0 across BOTH packed K halves (k_h0 -> scores1,
+        // k_h1 -> scores2) so both differential softmax paths see the same
+        // partial-NaN pattern for every query that includes position 0.
+        let mut k = det_data(seq_len * cfg.k_dim(), 22);
+        for d in 0..cfg.k_dim() {
+            k[d] = f32::NAN;
+        }
+        let v = det_data(seq_len * cfg.v_dim(), 23);
+
+        let params = zero_lambda_params(head_dim);
+        let subln_w = vec![1.0f32; 2 * head_dim];
+        let mut out = vec![0.0f32; seq_len * out_dim];
+        let mut scratch = DiffAttnScratch::default();
+
+        apply_differential_attention(
+            &q,
+            &k,
+            &v,
+            &params,
+            &subln_w,
+            1e-6,
+            &mut out,
+            seq_len,
+            &cfg,
+            &mut scratch,
+        );
+
+        // Query 1's row is `[k0=NaN, k1=finite]` in both scores1 and scores2 --
+        // exactly the mixed-lane case a per-lane-only fix would mishandle.
+        let mixed_row = &out[out_dim..2 * out_dim];
+        assert!(
+            mixed_row.iter().all(|&x| x == 0.0),
+            "a row with any NaN lane must fail closed in FULL (all lanes zero), \
+             not just the poisoned lane(s); got {mixed_row:?}"
         );
     }
 

--- a/crates/inference/src/attention/flash_causal.rs
+++ b/crates/inference/src/attention/flash_causal.rs
@@ -169,6 +169,10 @@ pub fn flash_attention_causal_with_config(
     let mut scratch = FlashAttentionScratch::new(br, bc, head_dim);
     let mut group_m = vec![f32::NEG_INFINITY; groups * seq_len];
     let mut group_l = vec![0.0f32; groups * seq_len];
+    // ADR-080 C1 (#780): per-row fail-closed flag, threaded across K-blocks
+    // like `group_m`/`group_l`, set once any processed block observes a
+    // genuine NaN/`+inf` score for that row.
+    let mut group_bad = vec![false; groups * seq_len];
 
     let num_q_blocks = ceil_div(seq_len, br);
     let num_k_blocks = ceil_div(seq_len, bc);
@@ -176,6 +180,7 @@ pub fn flash_attention_causal_with_config(
     for kv_h in 0..num_kv_heads {
         group_m.fill(f32::NEG_INFINITY);
         group_l.fill(0.0);
+        group_bad.fill(false);
 
         let q_head_base = kv_h * groups;
         for g in 0..groups {
@@ -209,6 +214,7 @@ pub fn flash_attention_causal_with_config(
                 let q_h = q_head_base + g;
                 let m_head = &mut group_m[g * seq_len..(g + 1) * seq_len];
                 let l_head = &mut group_l[g * seq_len..(g + 1) * seq_len];
+                let bad_head = &mut group_bad[g * seq_len..(g + 1) * seq_len];
 
                 for q_block_idx in 0..num_q_blocks {
                     let q_start = q_block_idx * br;
@@ -243,6 +249,7 @@ pub fn flash_attention_causal_with_config(
                         &mut scratch,
                         &mut m_head[q_start..q_start + br_cur],
                         &mut l_head[q_start..q_start + br_cur],
+                        &mut bad_head[q_start..q_start + br_cur],
                         q_start,
                         k_start,
                         br_cur,
@@ -272,6 +279,7 @@ pub fn flash_attention_causal_with_config(
                 q_head_base + g,
                 seq_len,
                 &group_l[g * seq_len..(g + 1) * seq_len],
+                &group_bad[g * seq_len..(g + 1) * seq_len],
             );
         }
     }
@@ -417,11 +425,29 @@ fn normalize_head_output(
     head_idx: usize,
     seq_len: usize,
     l: &[f32],
+    bad: &[bool],
 ) {
     let head_off = head_idx * head_dim;
     for row in 0..seq_len {
-        let inv_l = if l[row] > 0.0 { 1.0 / l[row] } else { 0.0 };
         let off = row * q_dim + head_off;
+        // ADR-080 C1: a row flagged `bad` (NaN/`+inf` score seen in any
+        // processed K-block, #780) fails closed to an exact-zero row
+        // regardless of what `l[row]` (or the accumulated unnormalized
+        // output) holds, matching the shared fail-closed contract rather
+        // than trusting a possibly-corrupted running denominator. This is
+        // an explicit `= 0.0` assignment, not a `*= 0.0` multiply: the
+        // accumulator can itself hold NaN by this point (e.g. if the same
+        // poisoned key's V row is also non-finite), and `NaN * 0.0` is
+        // still `NaN` under IEEE 754.
+        if bad[row] {
+            attn_out[off..off + head_dim].fill(0.0);
+            continue;
+        }
+        let inv_l = if l[row].is_finite() && l[row] > 0.0 {
+            1.0 / l[row]
+        } else {
+            0.0
+        };
         for d in 0..head_dim {
             attn_out[off + d] *= inv_l;
         }
@@ -432,6 +458,7 @@ fn flash_update_block(
     scratch: &mut FlashAttentionScratch,
     m_rows: &mut [f32],
     l_rows: &mut [f32],
+    bad_rows: &mut [bool],
     q_start: usize,
     k_start: usize,
     br_cur: usize,
@@ -457,10 +484,21 @@ fn flash_update_block(
         let row_p = &mut p[row * bc_cur..(row + 1) * bc_cur];
 
         let mut block_row_max = f32::NEG_INFINITY;
+        // ADR-080 C1 (#780): a genuine NaN or `+inf` score anywhere in this
+        // row's VISIBLE (non-causally-masked) columns must fail-close the
+        // whole row, not just that lane. `-inf` from the causal mask itself
+        // is legitimate and must not trip this. Tracked independently of
+        // `block_row_max`'s fold because `if *score > block_row_max` is
+        // `false` for a NaN operand (IEEE 754), silently dropping it from
+        // the max the same way `f32::max` does.
+        let mut block_has_poison = false;
 
         if block_is_strictly_lower {
             for score in row_scores.iter_mut() {
                 *score *= scale;
+                if score.is_nan() || *score == f32::INFINITY {
+                    block_has_poison = true;
+                }
                 if *score > block_row_max {
                     block_row_max = *score;
                 }
@@ -473,12 +511,20 @@ fn flash_update_block(
                     *score = f32::NEG_INFINITY;
                 } else {
                     *score *= scale;
+                    if score.is_nan() || *score == f32::INFINITY {
+                        block_has_poison = true;
+                    }
                     if *score > block_row_max {
                         block_row_max = *score;
                     }
                 }
             }
         }
+
+        if block_has_poison {
+            bad_rows[row] = true;
+        }
+        let row_is_bad = bad_rows[row];
 
         let m_old = m_rows[row];
         let m_new = if m_old > block_row_max {
@@ -488,15 +534,21 @@ fn flash_update_block(
         };
         scratch.row_m_new[row] = m_new;
 
-        let alpha = if m_old.is_finite() && m_new.is_finite() {
+        let alpha = if !row_is_bad && m_old.is_finite() && m_new.is_finite() {
             (m_old - m_new).exp()
         } else {
+            // Once a row is condemned, discard whatever partial output it
+            // accumulated from earlier (clean) blocks too: the final
+            // `normalize_head_output` forces this row to exact zero, but
+            // `alpha = 0.0` here keeps the intermediate accumulator from
+            // carrying forward stale non-finite state across further
+            // blocks for no purpose.
             0.0
         };
         scratch.row_alpha[row] = alpha;
 
         let mut row_sum = 0.0f32;
-        if m_new.is_finite() {
+        if !row_is_bad && m_new.is_finite() {
             for col in 0..bc_cur {
                 let score = row_scores[col];
                 let value = if score.is_finite() {
@@ -559,37 +611,45 @@ fn standard_attention_causal(
             let q_off = qi * q_dim + q_head_off;
             let q_row = &q_buf[q_off..q_off + head_dim];
 
-            let mut max_score = f32::NEG_INFINITY;
             for ki in 0..seq_len {
-                let score = if ki > qi {
+                scores[ki] = if ki > qi {
                     f32::NEG_INFINITY
                 } else {
                     let k_off = ki * kv_dim + kv_head_off;
                     let k_row = &k_buf[k_off..k_off + head_dim];
                     scale * dot(q_row, k_row)
                 };
-                scores[ki] = score;
-                if score > max_score {
-                    max_score = score;
-                }
-            }
-
-            let mut denom = 0.0f32;
-            for ki in 0..seq_len {
-                let p = if scores[ki].is_finite() {
-                    (scores[ki] - max_score).exp()
-                } else {
-                    0.0
-                };
-                probs[ki] = p;
-                denom += p;
             }
 
             let out_off = qi * q_dim + q_head_off;
             let out_row = &mut attn_out[out_off..out_off + head_dim];
             out_row.fill(0.0);
 
-            if denom > 0.0 {
+            // ADR-080 C1: route the fail-closed final decision through the
+            // shared row-finalizer contract (#780). RED before the fix: a
+            // lone NaN score among the visible (ki <= qi) range was silently
+            // dropped to a zero-weight lane via `scores[ki].is_finite()`
+            // while the row's OTHER valid lanes still normalized around a
+            // `max_score` fold that had already silently ignored the NaN
+            // operand (`if score > max_score` is false for NaN) — a
+            // partially-normalized row, which the fail-closed contract
+            // forbids. `ki > qi` positions are always exactly `-inf`
+            // (never NaN), so `row_max_and_any_nan` cannot false-positive
+            // on legitimate causal masking.
+            let row = &mut scores[..seq_len];
+            let (max_score, any_nan) = crate::attention::softmax_row::row_max_and_any_nan(row);
+            if crate::attention::softmax_row::row_fails_closed_pre_exp(max_score, any_nan) {
+                continue;
+            }
+
+            let mut denom = 0.0f32;
+            for ki in 0..=qi {
+                let p = (row[ki] - max_score).exp();
+                probs[ki] = p;
+                denom += p;
+            }
+
+            if denom.is_finite() && denom > 0.0 {
                 let inv = 1.0 / denom;
                 for ki in 0..=qi {
                     let weight = probs[ki] * inv;
@@ -910,5 +970,112 @@ mod tests {
                 fallback_below: 0,
             },
         );
+    }
+
+    /// ADR-080 C1 (#780): `standard_attention_causal` (the short-sequence
+    /// fallback path, used here via `head_dim=4 > seq_len=3`). A NaN key
+    /// score at position 1 must fail-close every row that causally attends
+    /// to it (query 2), while query 0 (attends only to itself, never sees
+    /// position 1) stays unaffected.
+    #[test]
+    fn standard_path_nan_key_fails_closed_for_dependent_rows_only() {
+        let seq_len = 3;
+        let num_heads = 1;
+        let num_kv_heads = 1;
+        let head_dim = 4; // seq_len(3) < fallback_below(head_dim=4) -> standard path
+        let q_buf = [1.0f32, 0.0, 0.0, 0.0].repeat(seq_len);
+        let mut k_buf = vec![0.0f32; seq_len * head_dim];
+        k_buf[0] = 1.0; // K0
+        k_buf[head_dim] = f32::NAN; // K1: poison
+        k_buf[2 * head_dim] = 0.5; // K2
+        let mut v_buf = vec![0.0f32; seq_len * head_dim];
+        v_buf[0] = 10.0; // V0
+        v_buf[head_dim] = 20.0; // V1
+        v_buf[2 * head_dim] = 30.0; // V2
+        let mut out = vec![1.0f32; seq_len * head_dim]; // pre-fill nonzero to prove overwrite
+
+        flash_attention_causal(
+            &q_buf,
+            &k_buf,
+            &v_buf,
+            &mut out,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            seq_len,
+        );
+
+        let pos0 = &out[0..head_dim];
+        assert!(
+            (pos0[0] - 10.0).abs() < 1e-4 && pos0[1..].iter().all(|&v| v == 0.0),
+            "query 0 (self-attends only) must be unaffected: {pos0:?}"
+        );
+        let pos2 = &out[2 * head_dim..3 * head_dim];
+        assert!(
+            pos2.iter().all(|&v| v == 0.0),
+            "query 2 (causally attends to the NaN-poisoned position 1) must \
+             fail closed to exact zero: {pos2:?}"
+        );
+    }
+
+    /// ADR-080 C1 (#780): the tiled Flash Attention path threads a per-row
+    /// `bad` flag across K-blocks (`flash_update_block`'s `bad_rows` /
+    /// `normalize_head_output`'s `bad`) so a NaN key discovered in one block
+    /// fails closed every row that causally depends on it, even in a LATER
+    /// block. `br=2, bc=2` forces `seq_len=4` into 2 K-blocks and 2 Q-blocks
+    /// with `fallback_below=0` (never use the short-sequence fallback), so
+    /// this specifically exercises `flash_update_block`/`normalize_head_output`,
+    /// not `standard_attention_causal`. Poison sits in K-block 0 (position 1);
+    /// query 0 (block 0, self-attends only) must stay clean, while queries
+    /// 1, 2, and 3 (which all causally see position 1, queries 2/3 via a
+    /// LATER Q-block re-processing the FIRST K-block) must all fail closed.
+    #[test]
+    fn tiled_path_nan_key_fails_closed_across_blocks() {
+        let seq_len = 4;
+        let num_heads = 1;
+        let num_kv_heads = 1;
+        let head_dim = 4;
+        let q_buf = [1.0f32, 0.0, 0.0, 0.0].repeat(seq_len);
+        let mut k_buf = vec![0.0f32; seq_len * head_dim];
+        k_buf[0] = 1.0; // K0
+        k_buf[head_dim] = f32::NAN; // K1: poison
+        k_buf[2 * head_dim] = 0.5; // K2
+        k_buf[3 * head_dim] = 0.3; // K3
+        let mut v_buf = vec![0.0f32; seq_len * head_dim];
+        v_buf[0] = 10.0; // V0
+        v_buf[head_dim] = 20.0; // V1
+        v_buf[2 * head_dim] = 30.0; // V2
+        v_buf[3 * head_dim] = 40.0; // V3
+        let mut out = vec![1.0f32; seq_len * head_dim];
+
+        flash_attention_causal_with_config(
+            &q_buf,
+            &k_buf,
+            &v_buf,
+            &mut out,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            seq_len,
+            FlashAttentionConfig {
+                br: 2,
+                bc: 2,
+                fallback_below: 0,
+            },
+        );
+
+        let pos0 = &out[0..head_dim];
+        assert!(
+            (pos0[0] - 10.0).abs() < 1e-4 && pos0[1..].iter().all(|&v| v == 0.0),
+            "query 0 (self-attends only) must be unaffected: {pos0:?}"
+        );
+        for qi in 1..seq_len {
+            let row = &out[qi * head_dim..(qi + 1) * head_dim];
+            assert!(
+                row.iter().all(|&v| v == 0.0),
+                "query {qi} (causally attends to the NaN-poisoned position 1) \
+                 must fail closed to exact zero: {row:?}"
+            );
+        }
     }
 }

--- a/crates/inference/src/attention/gqa.rs
+++ b/crates/inference/src/attention/gqa.rs
@@ -337,9 +337,18 @@ fn apply_scaled_causal_softmax_fused(
             *v *= scale;
         }
 
-        let mut max_val = f32::NEG_INFINITY;
-        for &v in &row[..valid] {
-            max_val = max_val.max(v);
+        // ADR-080 C1: route the fail-closed final decision through the
+        // shared row-finalizer contract (#780). Behavior-preserving: this
+        // implementation used real `.exp()` (not an approximation), so a
+        // lone NaN score already propagated into `sum` and tripped the old
+        // `sum > 0.0 && sum.is_finite()` else-branch; the explicit
+        // `any_nan` pre-scan here just short-circuits that same outcome
+        // before spending the `exp()` calls, matching `decode.rs`/
+        // `flash-causal`'s degenerate-row fallback.
+        let (max_val, any_nan) = crate::attention::softmax_row::row_max_and_any_nan(&row[..valid]);
+        if crate::attention::softmax_row::row_fails_closed_pre_exp(max_val, any_nan) {
+            row.fill(0.0);
+            continue;
         }
 
         let mut sum = 0.0f32;
@@ -348,20 +357,7 @@ fn apply_scaled_causal_softmax_fused(
             sum += *v;
         }
 
-        if sum > 0.0 && sum.is_finite() {
-            let inv = 1.0 / sum;
-            for v in &mut row[..valid] {
-                *v *= inv;
-            }
-        } else {
-            // Degenerate row: every valid score was masked or non-finite, so `max_val`
-            // is non-finite and `exp` produced NaN/Inf (e.g. all -inf, or any +inf).
-            // Emit a zero-probability row instead of propagating NaN into the context,
-            // matching `decode.rs` (`row.fill(0.0)` when the normalizer is not positive)
-            // and the flash-causal non-finite handling.
-            row[..valid].fill(0.0);
-        }
-
+        crate::attention::softmax_row::finalize_row(&mut row[..valid], sum);
         row[valid..].fill(0.0);
     }
 }
@@ -645,6 +641,28 @@ mod tests {
         assert!(
             scores.iter().all(|&v| v == 0.0),
             "degenerate row must be zero"
+        );
+    }
+
+    /// ADR-080 C1: a lone NaN score anywhere in the visible range must zero
+    /// the whole row via the shared `row_fails_closed_pre_exp` pre-scan, not
+    /// just leave the NaN lane corrupted. Row 1 (qi=1, valid=2) is poisoned;
+    /// row 0 (qi=0, valid=1, its own well-formed score) is unaffected.
+    #[test]
+    fn fused_softmax_nan_lane_zeros_whole_row() {
+        let seq_len = 2usize;
+        let batch_rows = 2usize; // one query group of seq_len rows
+        let mut scores = vec![1.0f32, 0.0, f32::NAN, 2.0];
+        apply_scaled_causal_softmax_fused(&mut scores, batch_rows, seq_len, 1.0);
+        assert!(
+            scores[seq_len..].iter().all(|&v| v == 0.0),
+            "NaN-poisoned row must zero out: {:?}",
+            &scores[seq_len..]
+        );
+        assert!(
+            scores[..seq_len].iter().all(|v| v.is_finite()),
+            "sibling row must be unaffected: {:?}",
+            &scores[..seq_len]
         );
     }
 }

--- a/crates/inference/src/attention/mod.rs
+++ b/crates/inference/src/attention/mod.rs
@@ -10,6 +10,7 @@ pub mod gdn_backward;
 pub mod gdn_fused;
 pub mod gqa;
 pub mod native_sparse;
+pub mod softmax_row;
 pub mod standard;
 
 // Re-export from standard for backward compat

--- a/crates/inference/src/attention/native_sparse.rs
+++ b/crates/inference/src/attention/native_sparse.rs
@@ -1037,23 +1037,29 @@ fn aggregate_selection_importance(p_cmp: &[f32], sj: usize, cps: usize, ipc: usi
 }
 
 /// Numerically stable in-place softmax.
+///
+/// ADR-080 C1: routes the fail-closed decision through the shared row
+/// finalizer. Previously `if sum > 0.0` had no `else` branch, so a NaN/+inf
+/// score left `x` holding raw NaN/Inf exponentials instead of a zeroed row
+/// (#780) — this is the single softmax helper shared by all three
+/// `apply_native_sparse_attention` branches (compression, selection, sliding
+/// window), so the fix applies to all of them at once.
 #[inline]
 fn softmax_inplace(x: &mut [f32]) {
     if x.is_empty() {
         return;
     }
-    let max_val = x.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let (max_val, any_nan) = crate::attention::softmax_row::row_max_and_any_nan(x);
+    if crate::attention::softmax_row::row_fails_closed_pre_exp(max_val, any_nan) {
+        x.fill(0.0);
+        return;
+    }
     let mut sum = 0.0f32;
     for v in x.iter_mut() {
         *v = (*v - max_val).exp();
         sum += *v;
     }
-    if sum > 0.0 {
-        let inv = 1.0 / sum;
-        for v in x.iter_mut() {
-            *v *= inv;
-        }
-    }
+    crate::attention::softmax_row::finalize_row(x, sum);
 }
 
 #[inline]
@@ -1799,6 +1805,30 @@ mod tests {
         // softmax is monotone: larger input → larger output
         assert!(x[0] > x[2], "softmax({}) > softmax({})", orig[0], orig[2]);
         assert!(x[2] > x[1], "softmax({}) > softmax({})", orig[2], orig[1]);
+    }
+
+    // ADR-080 C1: a NaN score must zero the WHOLE row, not leave NaN/Inf in
+    // place. RED before the fix: `if sum > 0.0` had no `else`, so `x` was left
+    // holding the raw (NaN-poisoned) unnormalized exponentials (#780).
+    #[test]
+    fn test_softmax_inplace_nan_fails_closed() {
+        let mut x = vec![1.0f32, f32::NAN, 2.0, 0.5];
+        softmax_inplace(&mut x);
+        assert!(x.iter().all(|&v| v == 0.0), "expected all-zero row: {x:?}");
+    }
+
+    #[test]
+    fn test_softmax_inplace_pos_inf_fails_closed() {
+        let mut x = vec![1.0f32, f32::INFINITY, 2.0];
+        softmax_inplace(&mut x);
+        assert!(x.iter().all(|&v| v == 0.0), "expected all-zero row: {x:?}");
+    }
+
+    #[test]
+    fn test_softmax_inplace_all_neg_inf_fails_closed() {
+        let mut x = vec![f32::NEG_INFINITY; 3];
+        softmax_inplace(&mut x);
+        assert!(x.iter().all(|&v| v == 0.0), "expected all-zero row: {x:?}");
     }
 
     // ---------------------------------------------------------------

--- a/crates/inference/src/attention/softmax_row.rs
+++ b/crates/inference/src/attention/softmax_row.rs
@@ -1,0 +1,159 @@
+//! ADR-080 cluster C1: shared fail-closed softmax row-finalizer contract.
+//!
+//! Canonical semantics, established in [`crate::attention::gqa::apply_gqa_attention`]'s
+//! fused softmax and [`crate::attention::decode::decode_attention`]'s online softmax:
+//! a softmax row is zeroed **in full** when any input score is NaN, the row max is
+//! `+inf`, or the accumulated denominator is non-positive or non-finite (fail-closed).
+//! No site may silently drop a single lane, clamp a masked `-inf` sentinel into
+//! finite probability mass, or emit a partially-normalized row.
+//!
+//! These helpers implement the shared *decision* logic only. Each call site keeps
+//! its own backend-appropriate exp implementation (real [`f32::exp`], the
+//! Schraudolph `fast_exp` bit-trick approximation, or a NEON/AVX2 vectorized
+//! variant) per ADR-080's "no numeric behavior changes beyond the documented
+//! fail-closed fixes" -- this module does not choose or perform exp for callers.
+//! All functions here are allocation-free and `#[inline]`.
+
+/// Scan `row` for its max value and whether any element is NaN.
+///
+/// A plain `f32::max`-based fold silently *drops* a lone NaN operand (IEEE
+/// `maxNum` semantics: `f32::max(x, NaN) == x`), so a row containing exactly one
+/// NaN score would otherwise report a finite max and let that NaN escape
+/// detection entirely (it can then survive as a single bad lane instead of
+/// failing the whole row closed). This scans explicitly so callers can fail
+/// closed on NaN regardless of where it falls relative to the true max.
+#[inline]
+pub fn row_max_and_any_nan(row: &[f32]) -> (f32, bool) {
+    let mut max_val = f32::NEG_INFINITY;
+    let mut any_nan = false;
+    for &v in row {
+        if v.is_nan() {
+            any_nan = true;
+        } else {
+            max_val = max_val.max(v);
+        }
+    }
+    (max_val, any_nan)
+}
+
+/// True iff the row must fail closed based on the pre-exp scan alone: any NaN
+/// present, or the row max is not finite (`+inf`, or `-inf` for a fully-masked
+/// row with no valid key). Both cases zero the whole row per the canonical
+/// contract, without needing to compute a single exp.
+#[inline]
+pub fn row_fails_closed_pre_exp(max_val: f32, any_nan: bool) -> bool {
+    any_nan || !max_val.is_finite()
+}
+
+/// Exact-zero guard for a structurally-masked (`-inf`) lane.
+///
+/// Fast/approximate exp implementations (the Schraudolph `fast_exp` bit-trick
+/// used across this crate) clamp their input to a finite floor for range
+/// safety; without this guard a `-inf` mask sentinel round-trips through
+/// `fast_exp(-inf - max)` into a small but nonzero weight instead of exact
+/// `0.0` (#740). Callers combine this with their own exp:
+/// `if is_masked_neg_inf(v) { 0.0 } else { fast_exp(v - max) }`.
+#[inline]
+pub fn is_masked_neg_inf(v: f32) -> bool {
+    v == f32::NEG_INFINITY
+}
+
+/// Normalize `row` in place by `sum` if the row is well-formed (finite,
+/// strictly positive denominator); otherwise zero the entire row. This is the
+/// shared final decision every canonical site already applies
+/// (`sum > 0.0 && sum.is_finite()`), extracted so every consolidated call site
+/// shares one fail-closed implementation instead of reimplementing the branch.
+#[inline]
+pub fn finalize_row(row: &mut [f32], sum: f32) {
+    if sum.is_finite() && sum > 0.0 {
+        let inv = 1.0 / sum;
+        for v in row.iter_mut() {
+            *v *= inv;
+        }
+    } else {
+        row.fill(0.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_max_and_any_nan_ignores_nan_in_max_but_flags_it() {
+        let row = [1.0f32, f32::NAN, 3.0, 2.0];
+        let (max_val, any_nan) = row_max_and_any_nan(&row);
+        assert_eq!(max_val, 3.0);
+        assert!(any_nan);
+    }
+
+    #[test]
+    fn row_max_and_any_nan_all_neg_inf() {
+        let row = [f32::NEG_INFINITY; 4];
+        let (max_val, any_nan) = row_max_and_any_nan(&row);
+        assert_eq!(max_val, f32::NEG_INFINITY);
+        assert!(!any_nan);
+    }
+
+    #[test]
+    fn row_fails_closed_pre_exp_nan() {
+        assert!(row_fails_closed_pre_exp(3.0, true));
+    }
+
+    #[test]
+    fn row_fails_closed_pre_exp_pos_inf_max() {
+        assert!(row_fails_closed_pre_exp(f32::INFINITY, false));
+    }
+
+    #[test]
+    fn row_fails_closed_pre_exp_neg_inf_max() {
+        assert!(row_fails_closed_pre_exp(f32::NEG_INFINITY, false));
+    }
+
+    #[test]
+    fn row_fails_closed_pre_exp_finite_ok() {
+        assert!(!row_fails_closed_pre_exp(5.0, false));
+    }
+
+    #[test]
+    fn is_masked_neg_inf_exact() {
+        assert!(is_masked_neg_inf(f32::NEG_INFINITY));
+        assert!(!is_masked_neg_inf(-1.0e30));
+        assert!(!is_masked_neg_inf(f32::NAN));
+    }
+
+    #[test]
+    fn finalize_row_normalizes_well_formed_sum() {
+        let mut row = [1.0f32, 1.0, 2.0];
+        finalize_row(&mut row, 4.0);
+        assert_eq!(row, [0.25, 0.25, 0.5]);
+    }
+
+    #[test]
+    fn finalize_row_zeros_on_nan_sum() {
+        let mut row = [1.0f32, f32::NAN, 2.0];
+        finalize_row(&mut row, f32::NAN);
+        assert_eq!(row, [0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn finalize_row_zeros_on_zero_sum() {
+        let mut row = [0.0f32, 0.0, 0.0];
+        finalize_row(&mut row, 0.0);
+        assert_eq!(row, [0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn finalize_row_zeros_on_negative_sum() {
+        let mut row = [1.0f32, 2.0];
+        finalize_row(&mut row, -1.0);
+        assert_eq!(row, [0.0, 0.0]);
+    }
+
+    #[test]
+    fn finalize_row_zeros_on_infinite_sum() {
+        let mut row = [1.0f32, 2.0];
+        finalize_row(&mut row, f32::INFINITY);
+        assert_eq!(row, [0.0, 0.0]);
+    }
+}

--- a/crates/inference/src/backward/attention_gqa.rs
+++ b/crates/inference/src/backward/attention_gqa.rs
@@ -520,27 +520,29 @@ pub fn gqa_forward_with_cache(
             let kv_off = kvh * head_dim;
             let q = &q_after_rope[t][q_off..q_off + head_dim];
 
-            let mut max_score = f32::NEG_INFINITY;
             let prob_start = qh * (t + 1);
             for s in 0..=t {
                 let k = &k_after_rope[s * kv_dim + kv_off..s * kv_dim + kv_off + head_dim];
                 let dot: f32 = q.iter().zip(k.iter()).map(|(qi, ki)| qi * ki).sum();
-                let score = dot * scale;
-                probs_all[prob_start + s] = score;
-                if score > max_score {
-                    max_score = score;
-                }
+                probs_all[prob_start + s] = dot * scale;
             }
 
-            let mut sum_exp = 0.0f32;
-            for s in 0..=t {
-                let e = (probs_all[prob_start + s] - max_score).exp();
-                probs_all[prob_start + s] = e;
-                sum_exp += e;
-            }
-            let inv = 1.0 / sum_exp;
-            for s in 0..=t {
-                probs_all[prob_start + s] *= inv;
+            // ADR-080 C1 (#785 round-1 major 1): this forward-recompute builds
+            // `softmax_probs` for the backward tape, not a vocabulary softmax and
+            // not the `gqa.rs` test oracle -- a NaN/`+inf` score must zero the
+            // whole probability row (and its context row), not poison the
+            // gradient path via a bare `1.0 / sum_exp`.
+            let row = &mut probs_all[prob_start..prob_start + t + 1];
+            let (max_score, any_nan) = crate::attention::softmax_row::row_max_and_any_nan(row);
+            if crate::attention::softmax_row::row_fails_closed_pre_exp(max_score, any_nan) {
+                row.fill(0.0);
+            } else {
+                let mut sum_exp = 0.0f32;
+                for v in row.iter_mut() {
+                    *v = (*v - max_score).exp();
+                    sum_exp += *v;
+                }
+                crate::attention::softmax_row::finalize_row(row, sum_exp);
             }
 
             let ctx_off = t * q_dim + qh * head_dim;
@@ -818,5 +820,119 @@ mod tests {
         assert!(err_av < 1e-2, "GQA grad_A_v rel_err {err_av:.2e} >= 1e-2");
         assert!(err_bq < 1e-2, "GQA grad_B_q rel_err {err_bq:.2e} >= 1e-2");
         assert!(err_bv < 1e-2, "GQA grad_B_v rel_err {err_bv:.2e} >= 1e-2");
+    }
+
+    /// ADR-080 C1 (#785 round-1 major 1): `gqa_forward_with_cache`'s
+    /// forward-recompute causal attention (used to build `softmax_probs` and
+    /// `context` for the backward tape) is a production attention row, not the
+    /// `gqa.rs` test oracle and not a vocabulary softmax. Poisoning ONE Q
+    /// component for one query head (via a NaN weight, not a NaN input row --
+    /// so V is never touched and the "poisoned weight times poisoned V"
+    /// confound documented elsewhere in this cluster cannot mask the result)
+    /// must zero that head's entire stored probability row and context row at
+    /// every time step, while the sibling query head's rows stay finite and
+    /// normalized.
+    #[test]
+    fn gqa_forward_with_cache_nan_q_score_fails_closed_sibling_head_stays_finite() {
+        let seq_len = 3;
+        let hidden = 8;
+        let num_q_heads = 2;
+        let num_kv_heads = 1;
+        let head_dim = 4;
+        let rope_dim = 2;
+        let eps_norm = 1e-6f32;
+
+        let q_dim = num_q_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+        let half = rope_dim / 2;
+
+        let mut rng = 0xC0FF_EE00_u64;
+        let mut w_q = rand_vec(&mut rng, 2 * q_dim * hidden, 0.1);
+        let w_k = rand_vec(&mut rng, kv_dim * hidden, 0.1);
+        let w_v = rand_vec(&mut rng, kv_dim * hidden, 0.1);
+        let w_o = rand_vec(&mut rng, hidden * q_dim, 0.1);
+        let q_norm_w = vec![1.0f32; head_dim];
+        let k_norm_w = vec![1.0f32; head_dim];
+        let x = rand_vec(&mut rng, seq_len * hidden, 0.2);
+
+        // Poison query head 0's first raw Q output dim (`deinterleave_q_gate`
+        // maps head `h`'s Q half to raw indices `[h*head_dim*2, h*head_dim*2 +
+        // head_dim)`; head 0 starts at raw index 0). This is a WEIGHT mutation,
+        // not an input mutation: it never touches `w_k` or `w_v`, so K and V
+        // stay finite for every position -- only every time step's own head-0
+        // Q vector becomes NaN (further smeared by q_norm's shared `inv_rms`
+        // and RoPE's rotation, but always confined to head 0).
+        w_q[0] = f32::NAN;
+
+        let cos_table: Vec<f32> = (0..seq_len * half)
+            .map(|i| {
+                let pos = i / half;
+                let dim = i % half;
+                let theta = (pos as f32) / (10000f32.powf(2.0 * dim as f32 / rope_dim as f32));
+                theta.cos()
+            })
+            .collect();
+        let sin_table: Vec<f32> = (0..seq_len * half)
+            .map(|i| {
+                let pos = i / half;
+                let dim = i % half;
+                let theta = (pos as f32) / (10000f32.powf(2.0 * dim as f32 / rope_dim as f32));
+                theta.sin()
+            })
+            .collect();
+
+        let (_out, cache) = gqa_forward_with_cache(
+            &x,
+            &w_q,
+            &w_k,
+            &w_v,
+            &w_o,
+            &q_norm_w,
+            &k_norm_w,
+            None,
+            None,
+            None,
+            None,
+            0,
+            0.0,
+            seq_len,
+            hidden,
+            num_q_heads,
+            num_kv_heads,
+            head_dim,
+            rope_dim,
+            &cos_table,
+            &sin_table,
+            eps_norm,
+        );
+
+        for t in 0..seq_len {
+            let row_len = t + 1;
+            let poisoned_probs = &cache.softmax_probs[t][0..row_len];
+            let clean_probs = &cache.softmax_probs[t][row_len..2 * row_len];
+            assert!(
+                poisoned_probs.iter().all(|&p| p == 0.0),
+                "t={t}: query head 0 (NaN Q) probability row must be exactly \
+                 all-zero, got {poisoned_probs:?}"
+            );
+            assert!(
+                clean_probs.iter().all(|p| p.is_finite()),
+                "t={t}: sibling query head 1 probability row must stay finite, \
+                 got {clean_probs:?}"
+            );
+
+            let ctx_poisoned = &cache.context[t * q_dim..t * q_dim + head_dim];
+            let ctx_clean = &cache.context[t * q_dim + head_dim..t * q_dim + 2 * head_dim];
+            assert!(
+                ctx_poisoned.iter().all(|&v| v == 0.0),
+                "t={t}: query head 0's context row must be exactly all-zero, \
+                 got {ctx_poisoned:?}"
+            );
+            assert!(
+                ctx_clean.iter().all(|v| v.is_finite()),
+                "t={t}: sibling query head 1's context row must stay finite, \
+                 got {ctx_clean:?}"
+            );
+        }
     }
 }

--- a/crates/inference/src/forward/batch_prefill.rs
+++ b/crates/inference/src/forward/batch_prefill.rs
@@ -1074,6 +1074,12 @@ fn causal_tiled_attention_head(
             acc[..head_dim].fill(0.0);
             let mut running_max = f32::NEG_INFINITY;
             let mut running_sum = 0.0f32;
+            // ADR-080 C1 (#780): tracked independently of the `local_max`/
+            // `running_max` folds because `if score > local_max` is `false`
+            // for a NaN operand (IEEE 754), silently dropping it from the
+            // max the same way `f32::max` does. This is the online-softmax
+            // single-row analogue of `flash_causal.rs`'s `block_has_poison`.
+            let mut row_poisoned = false;
 
             let max_kv_pos = q_row + 1;
             for kv_start in (0..max_kv_pos).step_by(tile_kv) {
@@ -1088,6 +1094,9 @@ fn causal_tiled_attention_head(
                         dot += q_vec[d] * k[k_off + d];
                     }
                     let score = dot * scale;
+                    if score.is_nan() || score == f32::INFINITY {
+                        row_poisoned = true;
+                    }
                     tile_scores[local_idx] = score;
                     if score > local_max {
                         local_max = score;
@@ -1121,9 +1130,23 @@ fn causal_tiled_attention_head(
             }
 
             let out_off = q_row * out_stride + q_head_offset;
-            let inv_sum = 1.0 / running_sum.max(f32::MIN_POSITIVE);
-            for d in 0..head_dim {
-                output[out_off + d] = acc[d] * inv_sum;
+            // ADR-080 C1 (#780): RED before the fix, `running_sum.max(f32::MIN_POSITIVE)`
+            // silently replaced a NaN `running_sum` with a tiny-but-positive
+            // finite value instead of failing closed, so `1.0 / running_sum`
+            // became an enormous (~8.5e37) finite number and the output row
+            // exploded into huge finite garbage rather than zero. Structurally
+            // distinct from `attention::softmax_row::finalize_row` (this
+            // online algorithm writes into a separate `acc` accumulator, not
+            // an in-place score row), so this is an inline contract-conformant
+            // fix rather than a call to the shared helper: fail closed on a
+            // poisoned row OR a non-positive/non-finite denominator.
+            if row_poisoned || !running_sum.is_finite() || running_sum <= 0.0 {
+                output[out_off..out_off + head_dim].fill(0.0);
+            } else {
+                let inv_sum = 1.0 / running_sum;
+                for d in 0..head_dim {
+                    output[out_off + d] = acc[d] * inv_sum;
+                }
             }
         }
     }
@@ -2086,6 +2109,71 @@ mod tests {
             out.stop_reason,
             Some(StopReason::Length),
             "max_new_tokens=0 must report stop_reason=Length"
+        );
+    }
+
+    /// ADR-080 C1 (#780): RED before the fix, `running_sum.max(f32::MIN_POSITIVE)`
+    /// silently replaced a NaN running denominator with a tiny positive
+    /// finite value, turning `1.0 / running_sum` into an enormous
+    /// (~8.5e37) finite number and exploding the output row into huge
+    /// finite garbage instead of failing closed to zero. Query row 0
+    /// (self-attends only, K0 finite) must stay clean and non-degenerate;
+    /// query row 2 (causally attends to the NaN-poisoned K1) must fail
+    /// closed to an exact-zero row.
+    #[test]
+    fn causal_tiled_attention_head_nan_key_fails_closed() {
+        let head_dim = 4;
+        let seq_len = 3;
+        let q_stride = head_dim;
+        let kv_stride = head_dim;
+        let out_stride = head_dim;
+
+        // Q rows all [1,0,0,0] so score(qi, ki) reduces to scale * K[ki][0].
+        let q = [1.0f32, 0.0, 0.0, 0.0].repeat(seq_len);
+        let mut k = vec![0.0f32; seq_len * head_dim];
+        k[0] = 1.0; // K0: finite
+        k[head_dim] = f32::NAN; // K1: poison
+        k[2 * head_dim] = 0.5; // K2: finite
+        let mut v = vec![0.0f32; seq_len * head_dim];
+        v[0] = 10.0; // V0
+        v[head_dim] = 20.0; // V1
+        v[2 * head_dim] = 30.0; // V2
+
+        let mut output = vec![1.0f32; seq_len * out_stride]; // nonzero: prove overwrite
+        let config = TiledAttentionConfig::new(1, 1, head_dim);
+        let mut buffers = TiledAttentionBuffers::default();
+        let mut acc = vec![0.0f32; head_dim];
+        let mut tile_scores = vec![0.0f32; config.tile_size_kv.max(1).max(seq_len)];
+
+        causal_tiled_attention_head(
+            &q,
+            &k,
+            &v,
+            &mut output,
+            seq_len,
+            q_stride,
+            kv_stride,
+            out_stride,
+            0,
+            0,
+            head_dim,
+            1.0,
+            &config,
+            &mut buffers,
+            &mut acc,
+            &mut tile_scores,
+        );
+
+        let row0 = &output[0..head_dim];
+        assert!(
+            (row0[0] - 10.0).abs() < 1e-4 && row0[1..].iter().all(|&v| v == 0.0),
+            "query 0 (self-attends only) must be unaffected: {row0:?}"
+        );
+        let row2 = &output[2 * out_stride..2 * out_stride + head_dim];
+        assert!(
+            row2.iter().all(|&v| v == 0.0),
+            "query 2 (causally attends to the NaN-poisoned position 1) must \
+             fail closed to exact zero, got {row2:?}"
         );
     }
 }

--- a/crates/inference/src/forward/cpu/softmax.rs
+++ b/crates/inference/src/forward/cpu/softmax.rs
@@ -41,32 +41,37 @@ pub fn softmax_attention(x: &mut [f32], seq_len: usize, num_heads: usize) {
 }
 
 pub fn softmax_attention_scalar(x: &mut [f32], seq_len: usize, num_heads: usize) {
+    use crate::attention::softmax_row::{
+        finalize_row, is_masked_neg_inf, row_fails_closed_pre_exp, row_max_and_any_nan,
+    };
+
     for h in 0..num_heads {
         for s in 0..seq_len {
             let start = (h * seq_len + s) * seq_len;
             let row = &mut x[start..start + seq_len];
-            let max_val = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-            if !max_val.is_finite() {
-                // Every score in this row is masked (-inf): there is no valid key to
-                // attend to. Emit a zero distribution instead of computing
-                // `fast_exp(-inf - -inf) = fast_exp(NaN)`, whose value is path-dependent
-                // (0.0 on scalar/NEON, but a tiny nonzero on AVX2 where MAXPS returns
-                // the finite operand on a NaN input) and would otherwise diverge across
-                // SIMD backends. Zeroing keeps every backend fail-closed and identical.
+            let (max_val, any_nan) = row_max_and_any_nan(row);
+            if row_fails_closed_pre_exp(max_val, any_nan) {
+                // Either every score in this row is masked (-inf, no valid key to
+                // attend to) or a NaN score is present (ADR-080 C1 / #740: a NaN
+                // score used to survive as a single bad lane instead of failing
+                // the whole row closed). Zero the whole row before computing any
+                // exp — this keeps every backend fail-closed and identical.
                 row.fill(0.0);
                 continue;
             }
             let mut sum = 0.0f32;
             for val in row.iter_mut() {
-                *val = fast_exp(*val - max_val);
+                // `fast_exp` clamps its input to a finite floor, so a masked
+                // `-inf` lane would otherwise round-trip into a small nonzero
+                // weight (#740) instead of exact zero. Guard it explicitly.
+                *val = if is_masked_neg_inf(*val) {
+                    0.0
+                } else {
+                    fast_exp(*val - max_val)
+                };
                 sum += *val;
             }
-            if sum > 0.0 {
-                let inv_sum = 1.0 / sum;
-                for val in row.iter_mut() {
-                    *val *= inv_sum;
-                }
-            }
+            finalize_row(row, sum);
         }
     }
 }
@@ -131,7 +136,7 @@ unsafe fn softmax_attention_neon(x: &mut [f32], seq_len: usize, num_heads: usize
             let n = row.len();
             let chunks = n / CHUNK;
 
-            // --- Step 1: Find row max with 4x unrolling ---
+            // --- Step 1: Find row max with 4x unrolling, plus an explicit NaN scan ---
             // Use the maxNum intrinsics (FMAXNM: vmaxnmq/vmaxnmvq) rather than FMAX
             // (vmaxq/vmaxvq). FMAX PROPAGATES a NaN operand; Rust `f32::max` in the
             // scalar reference (and the scalar tail below) follows IEEE maxNum and
@@ -141,51 +146,94 @@ unsafe fn softmax_attention_neon(x: &mut [f32], seq_len: usize, num_heads: usize
             // which ignores the NaN and normalizes the finite logits. FMAXNM matches
             // the scalar reference exactly and is byte-identical on all-finite rows
             // (the only case that occurs in healthy inference), at no extra cost.
+            //
+            // FMAXNM dropping NaN from the *max* means a NaN score would otherwise
+            // survive undetected as a single bad lane (ADR-080 C1 / #740) instead of
+            // failing the whole row closed. `vceqq_f32(v, v)` is all-ones for every
+            // non-NaN lane (NaN never equals itself), so ANDing that mask across all
+            // chunks and reducing with `vminvq_u32` gives an explicit any-NaN flag at
+            // negligible extra cost (one more vector op per chunk, no extra load).
             let mut m0 = vdupq_n_f32(f32::NEG_INFINITY);
             let mut m1 = m0;
             let mut m2 = m0;
             let mut m3 = m0;
+            let mut nm0 = vdupq_n_u32(u32::MAX);
+            let mut nm1 = nm0;
+            let mut nm2 = nm0;
+            let mut nm3 = nm0;
             for c in 0..chunks {
                 let base = c * CHUNK;
-                m0 = vmaxnmq_f32(m0, vld1q_f32(ptr.add(base) as *const f32));
-                m1 = vmaxnmq_f32(m1, vld1q_f32(ptr.add(base + 4) as *const f32));
-                m2 = vmaxnmq_f32(m2, vld1q_f32(ptr.add(base + 8) as *const f32));
-                m3 = vmaxnmq_f32(m3, vld1q_f32(ptr.add(base + 12) as *const f32));
+                let v0 = vld1q_f32(ptr.add(base) as *const f32);
+                let v1 = vld1q_f32(ptr.add(base + 4) as *const f32);
+                let v2 = vld1q_f32(ptr.add(base + 8) as *const f32);
+                let v3 = vld1q_f32(ptr.add(base + 12) as *const f32);
+                m0 = vmaxnmq_f32(m0, v0);
+                m1 = vmaxnmq_f32(m1, v1);
+                m2 = vmaxnmq_f32(m2, v2);
+                m3 = vmaxnmq_f32(m3, v3);
+                nm0 = vandq_u32(nm0, vceqq_f32(v0, v0));
+                nm1 = vandq_u32(nm1, vceqq_f32(v1, v1));
+                nm2 = vandq_u32(nm2, vceqq_f32(v2, v2));
+                nm3 = vandq_u32(nm3, vceqq_f32(v3, v3));
             }
             let vmax = vmaxnmq_f32(vmaxnmq_f32(m0, m1), vmaxnmq_f32(m2, m3));
             let mut max_val = vmaxnmvq_f32(vmax);
+            let nan_free_mask = vandq_u32(vandq_u32(nm0, nm1), vandq_u32(nm2, nm3));
+            let mut any_nan = vminvq_u32(nan_free_mask) == 0;
             for i in (chunks * CHUNK)..n {
-                max_val = max_val.max(*ptr.add(i));
+                let v = *ptr.add(i);
+                if v.is_nan() {
+                    any_nan = true;
+                } else {
+                    max_val = max_val.max(v);
+                }
             }
 
-            // All-masked row (max stayed -inf): zero it and skip, matching the scalar
-            // reference. Avoids `neon_exp(-inf - -inf)` and keeps every backend identical.
-            if !max_val.is_finite() {
+            // All-masked row (max stayed -inf), a `+inf` max, or any NaN score: zero
+            // it and skip, matching the scalar reference (ADR-080 C1 contract).
+            if any_nan || !max_val.is_finite() {
                 row.fill(0.0);
                 continue;
             }
 
             // --- Step 2: Subtract max + fast exp + accumulate sum ---
+            // A structurally-masked `-inf` lane must produce exact `0.0`, not the
+            // small nonzero value `neon_exp`'s finite-floor clamp would otherwise
+            // produce (#740); `vceqq_f32(v, neg_inf)` + `vbslq_f32` blends that lane
+            // to exact zero without a scalar fallback.
             let vmax_val = vdupq_n_f32(max_val);
+            let neg_inf = vdupq_n_f32(f32::NEG_INFINITY);
+            let zero = vdupq_n_f32(0.0);
             let mut s0 = vdupq_n_f32(0.0);
             let mut s1 = s0;
             let mut s2 = s0;
             let mut s3 = s0;
             for c in 0..chunks {
                 let base = c * CHUNK;
-                let e0 = neon_exp_f32(vsubq_f32(vld1q_f32(ptr.add(base) as *const f32), vmax_val));
-                let e1 = neon_exp_f32(vsubq_f32(
-                    vld1q_f32(ptr.add(base + 4) as *const f32),
-                    vmax_val,
-                ));
-                let e2 = neon_exp_f32(vsubq_f32(
-                    vld1q_f32(ptr.add(base + 8) as *const f32),
-                    vmax_val,
-                ));
-                let e3 = neon_exp_f32(vsubq_f32(
-                    vld1q_f32(ptr.add(base + 12) as *const f32),
-                    vmax_val,
-                ));
+                let raw0 = vld1q_f32(ptr.add(base) as *const f32);
+                let raw1 = vld1q_f32(ptr.add(base + 4) as *const f32);
+                let raw2 = vld1q_f32(ptr.add(base + 8) as *const f32);
+                let raw3 = vld1q_f32(ptr.add(base + 12) as *const f32);
+                let e0 = vbslq_f32(
+                    vceqq_f32(raw0, neg_inf),
+                    zero,
+                    neon_exp_f32(vsubq_f32(raw0, vmax_val)),
+                );
+                let e1 = vbslq_f32(
+                    vceqq_f32(raw1, neg_inf),
+                    zero,
+                    neon_exp_f32(vsubq_f32(raw1, vmax_val)),
+                );
+                let e2 = vbslq_f32(
+                    vceqq_f32(raw2, neg_inf),
+                    zero,
+                    neon_exp_f32(vsubq_f32(raw2, vmax_val)),
+                );
+                let e3 = vbslq_f32(
+                    vceqq_f32(raw3, neg_inf),
+                    zero,
+                    neon_exp_f32(vsubq_f32(raw3, vmax_val)),
+                );
                 vst1q_f32(ptr.add(base), e0);
                 vst1q_f32(ptr.add(base + 4), e1);
                 vst1q_f32(ptr.add(base + 8), e2);
@@ -197,13 +245,18 @@ unsafe fn softmax_attention_neon(x: &mut [f32], seq_len: usize, num_heads: usize
             }
             let mut sum = vaddvq_f32(vaddq_f32(vaddq_f32(s0, s1), vaddq_f32(s2, s3)));
             for i in (chunks * CHUNK)..n {
-                let e = fast_exp(*ptr.add(i) - max_val);
+                let raw = *ptr.add(i);
+                let e = if raw == f32::NEG_INFINITY {
+                    0.0
+                } else {
+                    fast_exp(raw - max_val)
+                };
                 *ptr.add(i) = e;
                 sum += e;
             }
 
             // --- Step 3: Divide by sum with 4x unrolling ---
-            if sum > 0.0 {
+            if sum.is_finite() && sum > 0.0 {
                 let vinv = vdupq_n_f32(1.0 / sum);
                 for c in 0..chunks {
                     let base = c * CHUNK;
@@ -245,11 +298,20 @@ unsafe fn softmax_attention_avx2(x: &mut [f32], seq_len: usize, num_heads: usize
             let n = row.len();
             let chunks = n / 8;
 
-            // --- Step 1: Find row max using SIMD ---
+            // --- Step 1: Find row max using SIMD, plus an explicit NaN scan ---
+            // `_mm256_max_ps` (MAXPS) drops a lone NaN operand like `f32::max`, so a
+            // NaN score would otherwise survive undetected as a single bad lane
+            // (ADR-080 C1 / #740) instead of failing the whole row closed.
+            // `_mm256_cmp_ps(v, v, _CMP_EQ_OQ)` is all-ones for every non-NaN lane
+            // (ordered-equal comparisons are false for NaN), so ANDing that mask
+            // across chunks gives an explicit any-NaN flag.
             let mut vmax = _mm256_set1_ps(f32::NEG_INFINITY);
+            let mut nan_free = _mm256_set1_ps(f32::from_bits(u32::MAX));
             for c in 0..chunks {
                 // SAFETY: c * 8 + 7 < chunks * 8 <= n, within row bounds.
-                vmax = _mm256_max_ps(vmax, _mm256_loadu_ps(ptr.add(c * 8) as *const f32));
+                let v = _mm256_loadu_ps(ptr.add(c * 8) as *const f32);
+                vmax = _mm256_max_ps(vmax, v);
+                nan_free = _mm256_and_ps(nan_free, _mm256_cmp_ps(v, v, _CMP_EQ_OQ));
             }
             // Horizontal max reduction
             let hi128 = _mm256_extractf128_ps(vmax, 1);
@@ -258,38 +320,61 @@ unsafe fn softmax_attention_avx2(x: &mut [f32], seq_len: usize, num_heads: usize
             let max64 = _mm_max_ps(max128, _mm_movehl_ps(max128, max128));
             let max32 = _mm_max_ps(max64, _mm_movehdup_ps(max64));
             let mut max_val = _mm_cvtss_f32(max32);
+            // Horizontal AND reduction of the NaN-free mask (as integers).
+            let nan_free_i = _mm256_castps_si256(nan_free);
+            let hi128_i = _mm256_extractf128_si256(nan_free_i, 1);
+            let lo128_i = _mm256_castsi256_si128(nan_free_i);
+            let and128 = _mm_and_si128(lo128_i, hi128_i);
+            let and64 = _mm_and_si128(and128, _mm_srli_si128(and128, 8));
+            let and32 = _mm_and_si128(and64, _mm_srli_si128(and64, 4));
+            let mut any_nan = (_mm_cvtsi128_si32(and32) as u32) != u32::MAX;
             for i in (chunks * 8)..n {
-                max_val = max_val.max(*ptr.add(i));
+                let v = *ptr.add(i);
+                if v.is_nan() {
+                    any_nan = true;
+                } else {
+                    max_val = max_val.max(v);
+                }
             }
 
-            // All-masked row (max stayed -inf): zero it and skip, matching the scalar
-            // reference. Without this, the SIMD lanes compute `fast_exp_avx2(-inf - -inf)`
-            // where MAXPS returns the finite clamp on a NaN input, yielding a tiny nonzero
-            // weight and a uniform row — diverging from scalar/NEON which produce zeros.
-            if !max_val.is_finite() {
+            // All-masked row (max stayed -inf), a `+inf` max, or any NaN score: zero
+            // it and skip, matching the scalar reference (ADR-080 C1 contract).
+            if any_nan || !max_val.is_finite() {
                 row.fill(0.0);
                 continue;
             }
 
             // --- Step 2: Subtract max + fast exp + accumulate sum (all SIMD) ---
+            // A structurally-masked `-inf` lane must produce exact `0.0`, not the
+            // small nonzero value `fast_exp_avx2`'s finite-floor clamp would
+            // otherwise produce (#740); blend that lane to exact zero via the
+            // NaN-free-style ordered-equal compare against `-inf`.
             let vmax_val = _mm256_set1_ps(max_val);
+            let neg_inf = _mm256_set1_ps(f32::NEG_INFINITY);
             let mut vsum = _mm256_setzero_ps();
             for c in 0..chunks {
                 let off = c * 8;
-                let v = _mm256_sub_ps(_mm256_loadu_ps(ptr.add(off) as *const f32), vmax_val);
-                let e = fast_exp_avx2(v);
+                let raw = _mm256_loadu_ps(ptr.add(off) as *const f32);
+                let is_masked = _mm256_cmp_ps(raw, neg_inf, _CMP_EQ_OQ);
+                let e_full = fast_exp_avx2(_mm256_sub_ps(raw, vmax_val));
+                let e = _mm256_andnot_ps(is_masked, e_full);
                 _mm256_storeu_ps(ptr.add(off), e);
                 vsum = _mm256_add_ps(vsum, e);
             }
             let mut sum = hsum_m256(vsum);
             for i in (chunks * 8)..n {
-                let e = fast_exp(*ptr.add(i) - max_val);
+                let raw = *ptr.add(i);
+                let e = if raw == f32::NEG_INFINITY {
+                    0.0
+                } else {
+                    fast_exp(raw - max_val)
+                };
                 *ptr.add(i) = e;
                 sum += e;
             }
 
             // --- Step 3: Divide by sum using SIMD ---
-            if sum > 0.0 {
+            if sum.is_finite() && sum > 0.0 {
                 let inv_sum = 1.0 / sum;
                 let vinv = _mm256_set1_ps(inv_sum);
                 for c in 0..chunks {
@@ -300,6 +385,285 @@ unsafe fn softmax_attention_avx2(x: &mut [f32], seq_len: usize, num_heads: usize
                 for i in (chunks * 8)..n {
                     *ptr.add(i) *= inv_sum;
                 }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `[seq_len, seq_len]` single-head score matrix where query row 0
+    /// holds `row` (padded/truncated to `seq_len`) and every other query row
+    /// holds benign, well-formed finite scores. Returns `(matrix, seq_len)`.
+    fn single_row_matrix(row: &[f32]) -> (Vec<f32>, usize) {
+        let seq_len = row.len();
+        let mut x = vec![0.0f32; seq_len * seq_len];
+        x[..seq_len].copy_from_slice(row);
+        for qi in 1..seq_len {
+            for ki in 0..seq_len {
+                x[qi * seq_len + ki] = 0.1 * (qi as f32 + 1.0) + 0.01 * (ki as f32);
+            }
+        }
+        (x, seq_len)
+    }
+
+    /// A single NaN score anywhere in the row must zero the WHOLE row, not just
+    /// that lane (#740). RED before the fix: the row max fold silently dropped
+    /// the NaN operand, so only the NaN's own output lane stayed corrupted while
+    /// the rest of the row normalized around the (correct) finite max.
+    #[test]
+    fn scalar_nan_lane_zeros_whole_row() {
+        let (mut x, seq_len) = single_row_matrix(&[1.0, f32::NAN, 2.0, 0.5]);
+        softmax_attention_scalar(&mut x, seq_len, 1);
+        assert!(
+            x[..seq_len].iter().all(|&v| v == 0.0),
+            "expected all-zero row: {:?}",
+            &x[..seq_len]
+        );
+    }
+
+    /// A `+inf` score must zero the whole row (fail-closed on non-finite max).
+    #[test]
+    fn scalar_pos_inf_zeros_whole_row() {
+        let (mut x, seq_len) = single_row_matrix(&[1.0, f32::INFINITY, 2.0]);
+        softmax_attention_scalar(&mut x, seq_len, 1);
+        assert!(
+            x[..seq_len].iter().all(|&v| v == 0.0),
+            "expected all-zero row: {:?}",
+            &x[..seq_len]
+        );
+    }
+
+    /// An all-masked (`-inf`) row must zero out rather than compute `fast_exp(NaN)`.
+    #[test]
+    fn scalar_all_neg_inf_zeros_row() {
+        let (mut x, seq_len) = single_row_matrix(&[f32::NEG_INFINITY; 4]);
+        softmax_attention_scalar(&mut x, seq_len, 1);
+        assert!(
+            x[..seq_len].iter().all(|&v| v == 0.0),
+            "expected all-zero row: {:?}",
+            &x[..seq_len]
+        );
+    }
+
+    /// A masked (`-inf`) lane mixed with valid scores must produce EXACT `0.0`,
+    /// not the small nonzero value `fast_exp`'s finite-floor clamp would
+    /// otherwise leak (#740). RED before the fix: `fast_exp(-inf - max)` clamped
+    /// to `fast_exp(-87.0)`, a tiny but nonzero weight.
+    #[test]
+    fn scalar_masked_lane_is_exact_zero() {
+        let (mut x, seq_len) = single_row_matrix(&[1.0, f32::NEG_INFINITY, 0.5]);
+        softmax_attention_scalar(&mut x, seq_len, 1);
+        assert_eq!(x[1], 0.0, "masked lane must be exact zero, got {}", x[1]);
+        assert!(x[..seq_len].iter().all(|v| v.is_finite()));
+        let sum: f32 = x[..seq_len].iter().sum();
+        assert!(
+            (sum - 1.0).abs() < 1e-4,
+            "row must still sum to ~1: {:?}",
+            &x[..seq_len]
+        );
+    }
+
+    /// Multiple heads/rows in one call: only the poisoned row zeros, sibling
+    /// rows in the same batched buffer stay well-formed.
+    #[test]
+    fn scalar_only_poisoned_row_zeros() {
+        let seq_len = 2;
+        let num_heads = 1;
+        // head 0, row 0 (query 0): NaN present. head 0, row 1 (query 1): clean.
+        let mut x = vec![f32::NAN, 1.0, 0.3, 0.7];
+        softmax_attention_scalar(&mut x, seq_len, num_heads);
+        assert!(x[0..2].iter().all(|&v| v == 0.0), "row 0 must zero: {x:?}");
+        assert!(x[2..4].iter().all(|v| v.is_finite() && *v > 0.0));
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    mod neon {
+        use super::*;
+
+        fn run_neon(x: &mut [f32], seq_len: usize, num_heads: usize) {
+            // SAFETY: NEON is always available on aarch64.
+            unsafe {
+                softmax_attention_neon(x, seq_len, num_heads);
+            }
+        }
+
+        /// NEON must match the scalar reference: a single NaN lane zeros the
+        /// whole row. Uses a 17-wide row (one 16-wide vectorized chunk + a
+        /// scalar tail) so both the chunked path and the tail path run.
+        #[test]
+        fn neon_nan_in_chunk_zeros_whole_row() {
+            let mut row = vec![0.5f32; 17];
+            row[5] = f32::NAN; // inside the 16-wide vectorized chunk
+            let (mut x, seq_len) = single_row_matrix(&row);
+            run_neon(&mut x, seq_len, 1);
+            assert!(
+                x[..seq_len].iter().all(|&v| v == 0.0),
+                "expected all-zero row: {:?}",
+                &x[..seq_len]
+            );
+        }
+
+        /// NaN in the scalar tail (not caught by the vectorized chunk NaN scan)
+        /// must also zero the whole row.
+        #[test]
+        fn neon_nan_in_tail_zeros_whole_row() {
+            let mut row = vec![0.5f32; 17];
+            row[16] = f32::NAN; // scalar tail lane
+            let (mut x, seq_len) = single_row_matrix(&row);
+            run_neon(&mut x, seq_len, 1);
+            assert!(
+                x[..seq_len].iter().all(|&v| v == 0.0),
+                "expected all-zero row: {:?}",
+                &x[..seq_len]
+            );
+        }
+
+        /// A `+inf` score zeros the whole row.
+        #[test]
+        fn neon_pos_inf_zeros_whole_row() {
+            let mut row = vec![0.5f32; 17];
+            row[3] = f32::INFINITY;
+            let (mut x, seq_len) = single_row_matrix(&row);
+            run_neon(&mut x, seq_len, 1);
+            assert!(
+                x[..seq_len].iter().all(|&v| v == 0.0),
+                "expected all-zero row: {:?}",
+                &x[..seq_len]
+            );
+        }
+
+        /// An all-masked (`-inf`) row zeros out.
+        #[test]
+        fn neon_all_neg_inf_zeros_row() {
+            let row = vec![f32::NEG_INFINITY; 17];
+            let (mut x, seq_len) = single_row_matrix(&row);
+            run_neon(&mut x, seq_len, 1);
+            assert!(
+                x[..seq_len].iter().all(|&v| v == 0.0),
+                "expected all-zero row: {:?}",
+                &x[..seq_len]
+            );
+        }
+
+        /// A masked (`-inf`) lane inside the vectorized chunk must be exact
+        /// zero, not `neon_exp`'s finite-floor-clamp leakage (#740).
+        #[test]
+        fn neon_masked_lane_in_chunk_is_exact_zero() {
+            let mut row = vec![0.5f32; 17];
+            row[2] = f32::NEG_INFINITY;
+            let (mut x, seq_len) = single_row_matrix(&row);
+            run_neon(&mut x, seq_len, 1);
+            assert_eq!(x[2], 0.0, "masked lane must be exact zero, got {}", x[2]);
+            assert!(x[..seq_len].iter().all(|v| v.is_finite()));
+            let sum: f32 = x[..seq_len].iter().sum();
+            assert!(
+                (sum - 1.0).abs() < 1e-3,
+                "row must still sum to ~1: {:?}",
+                &x[..seq_len]
+            );
+        }
+
+        /// NEON must agree with the scalar reference on well-formed (all
+        /// finite) rows, matching the scalar/NEON parity the file's own
+        /// comments already document.
+        #[test]
+        fn neon_matches_scalar_on_finite_row() {
+            let row: Vec<f32> = (0..20).map(|i| (i as f32 * 0.37).sin()).collect();
+            let (mut x_scalar, seq_len) = single_row_matrix(&row);
+            let mut x_neon = x_scalar.clone();
+            softmax_attention_scalar(&mut x_scalar, seq_len, 1);
+            run_neon(&mut x_neon, seq_len, 1);
+            for (a, b) in x_scalar[..seq_len].iter().zip(x_neon[..seq_len].iter()) {
+                assert!((a - b).abs() < 1e-4, "scalar={a} neon={b}");
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    mod avx2 {
+        use super::*;
+
+        fn run_avx2(x: &mut [f32], seq_len: usize, num_heads: usize) -> bool {
+            if !simd_config().avx2_enabled {
+                return false;
+            }
+            // SAFETY: gated on the runtime AVX2 feature check above.
+            unsafe {
+                softmax_attention_avx2(x, seq_len, num_heads);
+            }
+            true
+        }
+
+        #[test]
+        fn avx2_nan_in_chunk_zeros_whole_row() {
+            let mut row = vec![0.5f32; 9]; // one 8-wide chunk + a scalar tail
+            row[3] = f32::NAN;
+            let (mut x, seq_len) = single_row_matrix(&row);
+            if !run_avx2(&mut x, seq_len, 1) {
+                return;
+            }
+            assert!(
+                x[..seq_len].iter().all(|&v| v == 0.0),
+                "expected all-zero row: {:?}",
+                &x[..seq_len]
+            );
+        }
+
+        #[test]
+        fn avx2_nan_in_tail_zeros_whole_row() {
+            let mut row = vec![0.5f32; 9];
+            row[8] = f32::NAN;
+            let (mut x, seq_len) = single_row_matrix(&row);
+            if !run_avx2(&mut x, seq_len, 1) {
+                return;
+            }
+            assert!(
+                x[..seq_len].iter().all(|&v| v == 0.0),
+                "expected all-zero row: {:?}",
+                &x[..seq_len]
+            );
+        }
+
+        #[test]
+        fn avx2_pos_inf_zeros_whole_row() {
+            let mut row = vec![0.5f32; 9];
+            row[0] = f32::INFINITY;
+            let (mut x, seq_len) = single_row_matrix(&row);
+            if !run_avx2(&mut x, seq_len, 1) {
+                return;
+            }
+            assert!(
+                x[..seq_len].iter().all(|&v| v == 0.0),
+                "expected all-zero row: {:?}",
+                &x[..seq_len]
+            );
+        }
+
+        #[test]
+        fn avx2_masked_lane_is_exact_zero() {
+            let mut row = vec![0.5f32; 9];
+            row[4] = f32::NEG_INFINITY;
+            let (mut x, seq_len) = single_row_matrix(&row);
+            if !run_avx2(&mut x, seq_len, 1) {
+                return;
+            }
+            assert_eq!(x[4], 0.0, "masked lane must be exact zero, got {}", x[4]);
+        }
+
+        #[test]
+        fn avx2_matches_scalar_on_finite_row() {
+            let row: Vec<f32> = (0..20).map(|i| (i as f32 * 0.37).sin()).collect();
+            let (mut x_scalar, seq_len) = single_row_matrix(&row);
+            let mut x_avx2 = x_scalar.clone();
+            softmax_attention_scalar(&mut x_scalar, seq_len, 1);
+            if !run_avx2(&mut x_avx2, seq_len, 1) {
+                return;
+            }
+            for (a, b) in x_scalar[..seq_len].iter().zip(x_avx2[..seq_len].iter()) {
+                assert!((a - b).abs() < 1e-4, "scalar={a} avx2={b}");
             }
         }
     }

--- a/crates/inference/src/forward/cpu/softmax.rs
+++ b/crates/inference/src/forward/cpu/softmax.rs
@@ -136,62 +136,53 @@ unsafe fn softmax_attention_neon(x: &mut [f32], seq_len: usize, num_heads: usize
             let n = row.len();
             let chunks = n / CHUNK;
 
-            // --- Step 1: Find row max with 4x unrolling, plus an explicit NaN scan ---
-            // Use the maxNum intrinsics (FMAXNM: vmaxnmq/vmaxnmvq) rather than FMAX
-            // (vmaxq/vmaxvq). FMAX PROPAGATES a NaN operand; Rust `f32::max` in the
-            // scalar reference (and the scalar tail below) follows IEEE maxNum and
-            // DROPS a single NaN. With FMAX, a NaN anywhere in the row makes the whole
-            // reduced max NaN, every `neon_exp(x - NaN)` underflows to 0.0, the sum is
-            // 0.0, and the row is left all-zeros — diverging from the scalar path,
-            // which ignores the NaN and normalizes the finite logits. FMAXNM matches
-            // the scalar reference exactly and is byte-identical on all-finite rows
-            // (the only case that occurs in healthy inference), at no extra cost.
-            //
-            // FMAXNM dropping NaN from the *max* means a NaN score would otherwise
-            // survive undetected as a single bad lane (ADR-080 C1 / #740) instead of
-            // failing the whole row closed. `vceqq_f32(v, v)` is all-ones for every
-            // non-NaN lane (NaN never equals itself), so ANDing that mask across all
-            // chunks and reducing with `vminvq_u32` gives an explicit any-NaN flag at
-            // negligible extra cost (one more vector op per chunk, no extra load).
+            // --- Step 1: Find row max with 4x unrolling ---
+            // ADR-080 C1 (#785 round-1 perf): use the plain FMAX intrinsics
+            // (vmaxq/vmaxvq), which PROPAGATE a NaN operand, instead of the
+            // maxNum FMAXNM intrinsics (vmaxnmq/vmaxnmvq) paired with an
+            // explicit `vceqq`/`vandq` NaN-tracking mask. The C1 contract
+            // requires a NaN score to fail the WHOLE row closed (not survive
+            // as a single bad lane, #740) — the same outcome FMAX gives for
+            // free via `!max_val.is_finite()` below, mirroring the scalar
+            // reference (`row_max_and_any_nan`/`row_fails_closed_pre_exp`) and
+            // `attention/decode.rs`'s `softmax_decode_neon`. The prior
+            // FMAXNM-drops-NaN + explicit-track approach was redundant work
+            // once the scalar path itself started failing closed on NaN;
+            // there is no longer a "normalize around the NaN" case to
+            // preserve. `-inf` masked lanes still flow through `max`
+            // correctly (they are not NaN and always lose to a real value).
             let mut m0 = vdupq_n_f32(f32::NEG_INFINITY);
             let mut m1 = m0;
             let mut m2 = m0;
             let mut m3 = m0;
-            let mut nm0 = vdupq_n_u32(u32::MAX);
-            let mut nm1 = nm0;
-            let mut nm2 = nm0;
-            let mut nm3 = nm0;
             for c in 0..chunks {
                 let base = c * CHUNK;
-                let v0 = vld1q_f32(ptr.add(base) as *const f32);
-                let v1 = vld1q_f32(ptr.add(base + 4) as *const f32);
-                let v2 = vld1q_f32(ptr.add(base + 8) as *const f32);
-                let v3 = vld1q_f32(ptr.add(base + 12) as *const f32);
-                m0 = vmaxnmq_f32(m0, v0);
-                m1 = vmaxnmq_f32(m1, v1);
-                m2 = vmaxnmq_f32(m2, v2);
-                m3 = vmaxnmq_f32(m3, v3);
-                nm0 = vandq_u32(nm0, vceqq_f32(v0, v0));
-                nm1 = vandq_u32(nm1, vceqq_f32(v1, v1));
-                nm2 = vandq_u32(nm2, vceqq_f32(v2, v2));
-                nm3 = vandq_u32(nm3, vceqq_f32(v3, v3));
+                m0 = vmaxq_f32(m0, vld1q_f32(ptr.add(base) as *const f32));
+                m1 = vmaxq_f32(m1, vld1q_f32(ptr.add(base + 4) as *const f32));
+                m2 = vmaxq_f32(m2, vld1q_f32(ptr.add(base + 8) as *const f32));
+                m3 = vmaxq_f32(m3, vld1q_f32(ptr.add(base + 12) as *const f32));
             }
-            let vmax = vmaxnmq_f32(vmaxnmq_f32(m0, m1), vmaxnmq_f32(m2, m3));
-            let mut max_val = vmaxnmvq_f32(vmax);
-            let nan_free_mask = vandq_u32(vandq_u32(nm0, nm1), vandq_u32(nm2, nm3));
-            let mut any_nan = vminvq_u32(nan_free_mask) == 0;
+            let vmax = vmaxq_f32(vmaxq_f32(m0, m1), vmaxq_f32(m2, m3));
+            let mut max_val = vmaxvq_f32(vmax);
             for i in (chunks * CHUNK)..n {
                 let v = *ptr.add(i);
-                if v.is_nan() {
-                    any_nan = true;
-                } else {
-                    max_val = max_val.max(v);
+                // `f32::max` returns the finite operand when the other is
+                // NaN, which would drop a tail NaN AND erase an already-NaN
+                // chunk max behind a later finite tail lane. Force NaN to
+                // propagate across the chunk/tail boundary explicitly,
+                // exactly like `softmax_decode_neon`.
+                if max_val.is_nan() || v.is_nan() {
+                    max_val = f32::NAN;
+                    break;
                 }
+                max_val = max_val.max(v);
             }
 
-            // All-masked row (max stayed -inf), a `+inf` max, or any NaN score: zero
-            // it and skip, matching the scalar reference (ADR-080 C1 contract).
-            if any_nan || !max_val.is_finite() {
+            // All-masked row (max stayed -inf), a `+inf` max, or any NaN score
+            // (NaN propagated through FMAX above, so `is_finite()` alone now
+            // catches it): zero it and skip, matching the scalar reference
+            // (ADR-080 C1 contract).
+            if !max_val.is_finite() {
                 row.fill(0.0);
                 continue;
             }

--- a/crates/inference/src/forward/cpu/tests.rs
+++ b/crates/inference/src/forward/cpu/tests.rs
@@ -248,14 +248,16 @@ fn test_softmax_simd_matches_scalar() {
     }
 }
 
-// A NaN in an attention-score row must not make the NEON fast path diverge from the
-// scalar reference. seq_len must be >= CHUNK (16) so the row actually enters the NEON
-// vector max loop; a shorter row falls to the scalar tail and matches trivially. With
-// FMAX (the pre-fix reduction) the NaN propagates -> max = NaN -> every exp underflows
-// to 0 -> the row is all zeros. With FMAXNM (maxNum) the NaN is dropped, matching the
-// scalar path which normalizes the finite logits and gives the NaN lane zero weight.
-// aarch64-only: the AVX2 path uses a different (position-dependent) NaN reduction and
-// its maxNum/NaN-delta parity is a deliberate, separately-tracked follow-up.
+// ADR-080 C1 (#780): a NaN anywhere in an attention-score row must fail-close
+// the WHOLE row, not just leave that lane at zero weight while the rest of
+// the row silently renormalizes around the other (finite) scores. This test
+// previously locked the pre-C1 behavior (NaN lane -> 0.0, row still sums to
+// 1.0), which is exactly the "silently drop a single lane" pattern #740/C1
+// forbids; it now asserts the fail-closed contract instead. seq_len must be
+// >= CHUNK (16) so the row actually enters the NEON vector max/NaN-scan loop;
+// a shorter row falls to the scalar tail and matches trivially.
+// aarch64-only: the AVX2 path uses a separate SIMD implementation with its
+// own dedicated NaN-lane tests in `forward/cpu/softmax.rs`.
 #[cfg(target_arch = "aarch64")]
 #[test]
 fn test_softmax_neon_nan_row_matches_scalar() {
@@ -266,25 +268,28 @@ fn test_softmax_neon_nan_row_matches_scalar() {
     for (i, v) in x_simd.iter_mut().enumerate() {
         *v = (i % seq_len) as f32;
     }
-    // Poison the first lane of row 0 with NaN (the lane FMAX would propagate from).
+    // Poison the first lane of row 0 with NaN.
     x_simd[0] = f32::NAN;
     let mut x_scalar = x_simd.clone();
 
     softmax_attention(&mut x_simd, seq_len, num_heads);
     softmax_attention_scalar(&mut x_scalar, seq_len, num_heads);
 
-    // The NaN lane gets zero weight in both paths (fast_exp(NaN) -> 0.0).
-    assert_eq!(x_simd[0], 0.0, "NEON NaN lane must be 0.0, not propagated");
-    assert_eq!(x_scalar[0], 0.0);
-
-    // Row 0 must be a real distribution (sums to 1), NOT the pre-fix all-zeros.
-    let row0_sum: f32 = x_simd[0..seq_len].iter().sum();
-    assert_relative_eq!(row0_sum, 1.0, epsilon = 1e-3);
-
-    // NEON and scalar agree element-wise across every lane of the NaN row.
+    // ADR-080 C1: the NaN poisons the WHOLE row, not just its own lane.
     for i in 0..seq_len {
-        assert_relative_eq!(x_simd[i], x_scalar[i], epsilon = 1e-3);
+        assert_eq!(
+            x_simd[i], 0.0,
+            "NEON row must fail-close to all-zero: lane {i}"
+        );
+        assert_eq!(
+            x_scalar[i], 0.0,
+            "scalar row must fail-close to all-zero: lane {i}"
+        );
     }
+
+    // A sibling (non-poisoned) row is unaffected and still normalizes to 1.0.
+    let row1_sum: f32 = x_simd[seq_len..2 * seq_len].iter().sum();
+    assert_relative_eq!(row1_sum, 1.0, epsilon = 1e-3);
 }
 
 // An all-masked attention row (every score -inf, the structural mask used by
@@ -332,19 +337,15 @@ fn test_softmax_all_masked_row_is_zero_across_backends() {
     assert_relative_eq!(row1_sum, 1.0, epsilon = 1e-3);
 }
 
-// Contract for a row with at least one finite valid score and a -inf-masked key
-// (the common #361 case, distinct from the all-masked row above). The masked
-// weight is NOT mathematically exact zero: `softmax_attention` routes through
-// `fast_exp`, which clamps its input to the [-87, 88] floor, so `fast_exp(-inf)`
-// is `fast_exp(-87)` ~= 1.746e-38, not 0.0. This is deliberate and byte-identical
-// to the prior `-10_000.0` sentinel for valid-keys-present rows (both clamp to the
-// same floor), which is why e2e-parity greedy generation is unaffected. The
-// guarantee #361 needs is weaker than exact zero: the masked weight is negligible
-// and never the row max / never dominant. Asserting the clamped magnitude (rather
-// than 0.0) locks that contract so a future `-inf`->0.0 special-case can't silently
-// change parity/perf behaviour without updating this expectation.
+// ADR-080 C1 (#740): a row with at least one finite valid score and a
+// -inf-masked key (the common #361 case, distinct from the all-masked row
+// above) must give the masked key EXACT zero weight, not a tiny nonzero
+// `fast_exp` clamp floor. This test previously locked the pre-#740 behavior
+// (masked weight ~= fast_exp(-87) ~= 1.7e-38, deliberately nonzero); C1's
+// exact-zero-masking fix (`is_masked_neg_inf`) closed that leak, so this now
+// asserts the masked lane is precisely `0.0`.
 #[test]
-fn test_softmax_finite_valid_row_masked_weight_is_clamped_nonzero_not_dominant() {
+fn test_softmax_finite_valid_row_masked_weight_is_exact_zero() {
     let num_heads = 1;
     let seq_len = 2;
     // Row 0: valid key 0 scores 0.0, masked key 1 is -inf.
@@ -357,19 +358,11 @@ fn test_softmax_finite_valid_row_masked_weight_is_clamped_nonzero_not_dominant()
         valid.is_finite() && masked.is_finite(),
         "row must be finite"
     );
-    // The masked weight is a tiny clamped nonzero, not exact zero.
+    assert_eq!(masked, 0.0, "masked lane must be exact zero, got {masked}");
+    // The valid key carries all the probability mass.
     assert!(
-        masked > 0.0,
-        "fast_exp clamp makes the masked weight strictly > 0"
-    );
-    assert!(
-        masked < 1e-30,
-        "masked weight {masked} must be negligible (clamped fast_exp(-87) ~= 1.7e-38)"
-    );
-    // The valid key carries essentially all the probability mass: never dominated.
-    assert!(
-        valid > 1.0 - 1e-6,
-        "valid key weight {valid} must dominate (~1.0)"
+        (valid - 1.0).abs() < 1e-6,
+        "valid key weight {valid} must be ~1.0"
     );
 }
 

--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -350,7 +350,6 @@ fn full_attention_step_f16(
 
         // Compute scores against all cached K vectors
         let scores_start = qh * cur_seq_len;
-        let mut max_score = f32::NEG_INFINITY;
 
         for t in 0..cur_seq_len {
             let k_off = t * kv_dim + kvh * head_dim;
@@ -358,23 +357,26 @@ fn full_attention_step_f16(
             for d in 0..head_dim {
                 dot += q[d] * k_cache[k_off + d];
             }
-            let s = dot * scale;
-            scratch.scores[scores_start + t] = s;
-            if s > max_score {
-                max_score = s;
-            }
+            scratch.scores[scores_start + t] = dot * scale;
         }
 
-        // Softmax
-        let mut sum_exp = 0.0f32;
-        for t in 0..cur_seq_len {
-            let e = (scratch.scores[scores_start + t] - max_score).exp();
-            scratch.scores[scores_start + t] = e;
-            sum_exp += e;
-        }
-        let inv_sum = 1.0 / sum_exp;
-        for t in 0..cur_seq_len {
-            scratch.scores[scores_start + t] *= inv_sum;
+        // ADR-080 C1: route the fail-closed final decision through the
+        // shared row-finalizer contract (#780). RED before the fix: the
+        // bare `1.0 / sum_exp` had no guard, so a NaN/`+inf` cached score
+        // propagated NaN into the context output instead of failing the
+        // row closed. Mirrors the byte-identical duplicate in
+        // `model::qwen35::forward::compute_attention_context`.
+        let row = &mut scratch.scores[scores_start..scores_start + cur_seq_len];
+        let (max_score, any_nan) = crate::attention::softmax_row::row_max_and_any_nan(row);
+        if crate::attention::softmax_row::row_fails_closed_pre_exp(max_score, any_nan) {
+            row.fill(0.0);
+        } else {
+            let mut sum_exp = 0.0f32;
+            for v in row.iter_mut() {
+                *v = (*v - max_score).exp();
+                sum_exp += *v;
+            }
+            crate::attention::softmax_row::finalize_row(row, sum_exp);
         }
 
         // Weighted sum of V
@@ -1242,6 +1244,125 @@ mod tests {
             max_q_diff < 1e-4,
             "cpu F16 Q-loop stride-half RoPE diverges from reference: max_q_diff = {max_q_diff:.6}. \
              With interleaved pairing the diff is O(0.1-1). Bug: #392."
+        );
+    }
+
+    /// ADR-080 C1 (#780): `full_attention_step_f16`'s decode-attention row
+    /// finalizer must fail closed on a NaN score, not propagate the bare
+    /// `1.0 / sum_exp` into the context output. A prior cached position is
+    /// poisoned (NaN K); the current position's own K/V stay finite. RED
+    /// before the fix: the poisoned row's NaN leaked into every context lane.
+    #[test]
+    fn test_full_attn_step_f16_nan_cached_score_fails_closed() {
+        use crate::model::qwen35_config::LayerType;
+        use crate::weights::f16_weights::f32_to_f16_slice;
+
+        let head_dim: usize = 32;
+        let num_q_heads: usize = 1;
+        let num_kv_heads: usize = 1;
+        let hidden: usize = 64;
+        let q_dim = num_q_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+        let position: usize = 1;
+
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 2,
+            vocab_size: 128,
+            intermediate_size: 128,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: num_q_heads,
+            num_key_value_heads: num_kv_heads,
+            head_dim,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5,
+            rope_parameters: None,
+            linear_num_key_heads: 2,
+            linear_num_value_heads: Some(2),
+            linear_key_head_dim: 32,
+            linear_value_head_dim: 32,
+            linear_conv_kernel_dim: 4,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![LayerType::LinearAttention, LayerType::FullAttention],
+            layer_mask: vec![true; 2],
+            eos_token_id: 127,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+        };
+
+        let rope = RopeTable::new(cfg.rope_dim(), 512, cfg.rope_theta);
+
+        let to_f16 = |src: &[f32]| -> Vec<u16> {
+            let mut dst = vec![0u16; src.len()];
+            f32_to_f16_slice(src, &mut dst);
+            dst
+        };
+
+        // W_k = identity, W_q = identity for the Q half (gate half zero), W_v
+        // = identity too (so the CURRENT token's V is a distinct, finite,
+        // predictable vector rather than zero -- confirms the fail-closed
+        // path isn't trivially passing because every V is zero anyway).
+        let mut k_proj_f32 = vec![0.0f32; kv_dim * hidden];
+        for j in 0..kv_dim {
+            k_proj_f32[j * hidden + j] = 1.0;
+        }
+        let mut v_proj_f32 = vec![0.0f32; kv_dim * hidden];
+        for j in 0..kv_dim {
+            v_proj_f32[j * hidden + j] = 1.0;
+        }
+        let mut q_proj_f32 = vec![0.0f32; 2 * q_dim * hidden];
+        for j in 0..q_dim {
+            q_proj_f32[j * hidden + j] = 1.0;
+        }
+
+        let weights = F16FullAttentionLayerWeights {
+            q_proj: to_f16(&q_proj_f32),
+            k_proj: to_f16(&k_proj_f32),
+            v_proj: to_f16(&v_proj_f32),
+            o_proj: to_f16(&vec![0.0f32; hidden * q_dim]),
+            q_norm: vec![0.0f32; head_dim],
+            k_norm: vec![0.0f32; head_dim],
+        };
+
+        let input: Vec<f32> = (0..hidden).map(|i| (i as f32 + 1.0) * 0.07).collect();
+
+        let mut scratch = ForwardScratch::new();
+        scratch.ensure_capacity(&cfg, 2);
+        scratch.attn_out[..hidden].copy_from_slice(&input);
+
+        // Pre-load one poisoned cached position (position 0): NaN K, finite V.
+        let mut kv_cache = KvCache::new(1);
+        let mut poisoned_k = vec![0.0f32; kv_dim];
+        poisoned_k[0] = f32::NAN;
+        let finite_v = vec![5.0f32; kv_dim];
+        kv_cache.append_kv(0, &poisoned_k, &finite_v);
+        kv_cache.seq_len = 1;
+
+        full_attention_step_f16(
+            &weights,
+            0,
+            position,
+            &mut kv_cache,
+            &mut scratch,
+            &cfg,
+            &rope,
+            hidden,
+        );
+
+        assert!(
+            scratch.context[..head_dim].iter().all(|&v| v == 0.0),
+            "expected exact-zero context for a NaN-poisoned cached score, \
+             got {:?}",
+            &scratch.context[..head_dim]
         );
     }
 

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -416,23 +416,21 @@ fn full_attention_step_q8(
 
         // Softmax. Fail closed on a non-finite score row: a NaN Q/K activation
         // (e.g. from an infinite Q8 scale via `0.0 * inf`) makes `sum_exp` NaN, and
-        // `NaN > 0.0` is false, so without the else-branch the unnormalized NaN
-        // weights would flow into the V accumulation and poison the logits. Mirrors
+        // real (unclamped) `.exp()` already reaches the shared row-finalizer's
+        // full-row-zero outcome via that NaN-into-`sum_exp` propagation. Mirrors
         // generate.rs::compute_attention (#409) and cpu_f16 moe_ffn_step_f16 (#411).
+        // ADR-080 C1 (#785 round-1 medium 1): routed through `finalize_row` for
+        // consolidation -- behavior-preserving, no output change.
         let mut sum_exp = 0.0f32;
         for t in 0..cur_seq_len {
             let e = (scratch.scores[scores_start + t] - max_score).exp();
             scratch.scores[scores_start + t] = e;
             sum_exp += e;
         }
-        if sum_exp > 0.0 {
-            let inv_sum = 1.0 / sum_exp;
-            for t in 0..cur_seq_len {
-                scratch.scores[scores_start + t] *= inv_sum;
-            }
-        } else {
-            scratch.scores[scores_start..scores_start + cur_seq_len].fill(0.0);
-        }
+        crate::attention::softmax_row::finalize_row(
+            &mut scratch.scores[scores_start..scores_start + cur_seq_len],
+            sum_exp,
+        );
 
         // Weighted sum of V
         let ctx_off = qh * head_dim;
@@ -1267,6 +1265,44 @@ mod tests {
             scratch.context[..q_dim].iter().all(|v| v.is_finite()),
             "Q8 attention must fail closed (zero context), not propagate NaN"
         );
+    }
+
+    /// ADR-080 C1 (#785 round-1 medium 1) clean-row parity check: after
+    /// routing this site's finalizer through the shared `finalize_row` helper,
+    /// a well-formed (non-poisoned) single-position row must still normalize
+    /// to exactly `1.0` (softmax of one score is always `1.0`), not be
+    /// incidentally swept into the fail-closed zero branch.
+    #[test]
+    fn test_full_attn_step_q8_clean_row_still_normalizes() {
+        let (cfg, rope, weights, hidden) = tiny_full_attn_fixture();
+        let num_heads = cfg.num_attention_heads;
+
+        let input: Vec<f32> = (0..hidden).map(|i| (i as f32 + 1.0) * 0.07).collect();
+        let mut scratch = ForwardScratch::new();
+        scratch.ensure_capacity(&cfg, 2);
+        scratch.attn_out[..hidden].copy_from_slice(&input);
+        let mut kv_cache = KvCache::new(1);
+
+        full_attention_step_q8(
+            &weights,
+            0,
+            3,
+            &mut kv_cache,
+            &mut scratch,
+            &cfg,
+            &rope,
+            hidden,
+        );
+
+        // cur_seq_len == 1 (fresh cache): each head's single-position row must
+        // normalize to exactly 1.0, proving `finalize_row`'s normalize branch
+        // fired rather than its fail-closed zero branch.
+        for h in 0..num_heads {
+            assert_eq!(
+                scratch.scores[h], 1.0,
+                "head {h}: clean single-position row must normalize to 1.0"
+            );
+        }
     }
 
     /// A decay-gate overflow (`a_log.exp() == +inf`) combined with a softplus

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -657,17 +657,16 @@ fn full_attention_step_q8_neon(
             sum_exp += e;
         }
         // Fail closed: a non-finite score (NaN/+inf from a corrupt Q/K
-        // activation) poisons sum_exp; `NaN > 0.0` is false, so the else
-        // branch zeros the row instead of scaling by a NaN inv_sum. Mirrors
-        // the Q8 CPU and f32 siblings (forward::cpu_q8, generate::compute_attention).
-        if sum_exp > 0.0 {
-            let inv_sum = 1.0 / sum_exp;
-            for t in 0..cur_seq_len {
-                scratch.scores[scores_start + t] *= inv_sum;
-            }
-        } else {
-            scratch.scores[scores_start..scores_start + cur_seq_len].fill(0.0);
-        }
+        // activation) poisons sum_exp; real (unclamped) `.exp()` already
+        // reaches the shared row-finalizer's full-row-zero outcome via that
+        // NaN-into-`sum_exp` propagation. Mirrors the Q8 CPU and f32 siblings
+        // (forward::cpu_q8, generate::compute_attention). ADR-080 C1 (#785
+        // round-1 medium 1): routed through `finalize_row` for consolidation
+        // -- behavior-preserving, no output change.
+        crate::attention::softmax_row::finalize_row(
+            &mut scratch.scores[scores_start..scores_start + cur_seq_len],
+            sum_exp,
+        );
 
         // Weighted sum of V
         let ctx_off = qh * head_dim;
@@ -2338,6 +2337,19 @@ mod tests {
             &cfg,
             &rope,
             hidden,
+        );
+
+        // ADR-080 C1 (#785 round-1 medium 1) clean-row parity check: before any
+        // poisoning, this well-formed single-position row (identity q/k/v
+        // projections, non-zero input) must normalize through `finalize_row`,
+        // not be incidentally swept into the fail-closed zero branch.
+        assert_eq!(
+            scratch.scores[0], 1.0,
+            "clean single-position row must normalize to 1.0 before poisoning"
+        );
+        assert!(
+            scratch.context[..q_dim].iter().any(|&v| v != 0.0),
+            "clean row's context must be a real (non-degenerate) result"
         );
 
         // Corrupt the prior cached K (position 0) and advance to position 1 so

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -1111,14 +1111,14 @@ fn compute_attention(
                 l = l * alpha + (s - m_new).exp();
                 m = m_new;
             }
-            if l > 0.0 {
-                let inv_l = 1.0 / l;
-                for s in scores.iter_mut() {
-                    *s = (*s - m).exp() * inv_l;
-                }
-            } else {
-                scores.fill(0.0);
+            // ADR-080 C1 (#785 round-1 medium 1): route the final decision
+            // through the shared row-finalizer. Behavior-preserving -- `l`
+            // reaches the same `<= 0.0`/non-finite outcomes as the manual
+            // `if l > 0.0 { .. } else { scores.fill(0.0) }` this replaces.
+            for s in scores.iter_mut() {
+                *s = (*s - m).exp();
             }
+            crate::attention::softmax_row::finalize_row(scores, l);
         }
 
         // Phase 3: V accumulation — per-head, NEON-accelerated on aarch64 for head_dim=128.
@@ -1167,27 +1167,18 @@ fn compute_attention(
                 }
             }
 
-            // Softmax
+            // Softmax. ADR-080 C1 (#785 round-1 medium 1): route the final
+            // decision through the shared row-finalizer -- behavior-preserving,
+            // real (unclamped) `.exp()` already reaches the same full-row-zero
+            // outcome via NaN-into-`sum` propagation that the manual
+            // `if sum > 0.0 { .. } else { scores.fill(0.0) }` this replaces did.
             let max_score = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
             let mut sum = 0.0f32;
             for s in scores.iter_mut() {
                 *s = (*s - max_score).exp();
                 sum += *s;
             }
-            if sum > 0.0 {
-                let inv = 1.0 / sum;
-                for s in scores.iter_mut() {
-                    *s *= inv;
-                }
-            } else {
-                // Fail closed, mirroring the q_seq_len==1 online fast path (l > 0.0
-                // guard above). A non-finite score (e.g. a NaN Q/K activation) makes
-                // `sum` NaN; `NaN > 0.0` is false, so without this branch the
-                // unnormalized NaN weights would flow into the V accumulation and
-                // poison the attention output. Zeroing the row drops this query's
-                // contribution instead of propagating garbage into the logits.
-                scores.fill(0.0);
-            }
+            crate::attention::softmax_row::finalize_row(scores, sum);
 
             // Weighted sum of V
             let out_off = qi * (num_heads * head_dim) + h * head_dim;
@@ -1557,10 +1548,14 @@ mod tests {
             output[0]
         );
         assert_eq!(output[0], 0.0, "failed-closed row must be zeroed");
-        // Query 1 has a finite score and must still produce a finite result.
+        // ADR-080 C1 (#785 round-1 medium 1) clean-row parity check: query 1's
+        // clean row must still normalize through `finalize_row` to the exact
+        // weighted average, not merely stay finite. Both keys score equally
+        // (q[1] == 0.0 dotted with either k), so softmax is a uniform 0.5/0.5
+        // and output[1] == 0.5*7.0 + 0.5*11.0 == 9.0.
         assert!(
-            output[1].is_finite(),
-            "finite query must be unaffected, got {}",
+            (output[1] - 9.0).abs() < 1e-5,
+            "clean sibling query must normalize to the exact weighted average, got {}",
             output[1]
         );
     }

--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -637,6 +637,37 @@ impl Drop for QwenModel {
     }
 }
 
+/// ADR-080 cluster C1: apply the causal mask then the fail-closed softmax
+/// normalization to a single `[seq_len]` attention-score row in place, where
+/// `qi` is this row's query position and `scale` is the pre-softmax score
+/// scale (`1 / sqrt(head_dim)`).
+///
+/// This is the shared body of what used to be two byte-identical inline
+/// softmax duplicates in `forward_all_layers` and `forward_profiled` (#780);
+/// extracting it here both routes the fail-closed decision through the
+/// shared `attention::softmax_row` contract and removes the duplication
+/// between the two call sites in this file.
+fn causal_softmax_row(row: &mut [f32], qi: usize, scale: f32) {
+    for (ki, v) in row.iter_mut().enumerate() {
+        if ki > qi {
+            *v = f32::NEG_INFINITY;
+        } else {
+            *v *= scale;
+        }
+    }
+    let (max_val, any_nan) = crate::attention::softmax_row::row_max_and_any_nan(row);
+    if crate::attention::softmax_row::row_fails_closed_pre_exp(max_val, any_nan) {
+        row.fill(0.0);
+        return;
+    }
+    let mut sum = 0.0f32;
+    for v in row.iter_mut() {
+        *v = (*v - max_val).exp();
+        sum += *v;
+    }
+    crate::attention::softmax_row::finalize_row(row, sum);
+}
+
 impl QwenModel {
     /// **Unstable**: load Qwen3 model from a local directory; path convention may change.
     pub fn from_directory(dir: &Path) -> Result<Self, InferenceError> {
@@ -1126,27 +1157,14 @@ impl QwenModel {
                     head_dim,
                     seq_len,
                 );
+                // ADR-080 C1: shared `causal_softmax_row` helper (defined above
+                // `impl QwenModel`) replaces the bare `sum > 0.0` check (which
+                // had no `else` and left a NaN/+inf-poisoned row un-zeroed,
+                // #780) and deduplicates what used to be two byte-identical
+                // secondary-prefill softmax copies in this file.
                 for qi in 0..seq_len {
                     let row = &mut scores_head[qi * seq_len..(qi + 1) * seq_len];
-                    for ki in 0..seq_len {
-                        if ki > qi {
-                            row[ki] = f32::NEG_INFINITY;
-                        } else {
-                            row[ki] *= scale;
-                        }
-                    }
-                    let max_val = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-                    let mut sum = 0.0f32;
-                    for v in row.iter_mut() {
-                        *v = (*v - max_val).exp();
-                        sum += *v;
-                    }
-                    if sum > 0.0 {
-                        let inv = 1.0 / sum;
-                        for v in row.iter_mut() {
-                            *v *= inv;
-                        }
-                    }
+                    causal_softmax_row(row, qi, scale);
                 }
                 for i in 0..seq_len {
                     let v_off = i * kv_dim + kv_h * head_dim;
@@ -1449,27 +1467,14 @@ impl QwenModel {
                 );
 
                 // Scale + causal mask + softmax.
+                // ADR-080 C1: shared `causal_softmax_row` helper (defined above
+                // `impl QwenModel`) replaces the bare `sum > 0.0` check (which
+                // had no `else` and left a NaN/+inf-poisoned row un-zeroed,
+                // #780) and deduplicates what used to be two byte-identical
+                // secondary-prefill softmax copies in this file.
                 for qi in 0..seq_len {
                     let row = &mut scores_head[qi * seq_len..(qi + 1) * seq_len];
-                    for ki in 0..seq_len {
-                        if ki > qi {
-                            row[ki] = f32::NEG_INFINITY;
-                        } else {
-                            row[ki] *= scale;
-                        }
-                    }
-                    let max_val = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-                    let mut sum = 0.0f32;
-                    for v in row.iter_mut() {
-                        *v = (*v - max_val).exp();
-                        sum += *v;
-                    }
-                    if sum > 0.0 {
-                        let inv = 1.0 / sum;
-                        for v in row.iter_mut() {
-                            *v *= inv;
-                        }
-                    }
+                    causal_softmax_row(row, qi, scale);
                 }
 
                 // Transpose V_head for matmul_bt trick: V_T[head_dim, seq_len]
@@ -3456,5 +3461,94 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // ---------------------------------------------------------------
+    // ADR-080 C1: `causal_softmax_row` (shared by the `forward_all_layers` /
+    // `forward_profiled` secondary-prefill duplicates, #780) must fail
+    // closed on a NaN score, a `+inf` max, or a fully-masked row, not
+    // propagate garbage.
+    //
+    // Note on scope: an earlier version of this test built a full
+    // `QwenModel` fixture and poisoned a token's *embedding* to check that
+    // the NaN didn't leak into sibling positions' hidden states end to end.
+    // That test was infeasible and was removed: poisoning a token's
+    // embedding poisons Q, K, *and* V for that position (all three are
+    // linear projections of the same hidden row), and `0.0 * NaN == NaN` in
+    // IEEE 754 — so even a *correctly* fail-closed softmax weight of exactly
+    // `0.0` for the poisoned position still yields NaN once multiplied
+    // against that position's NaN V-vector in the context matmul
+    // (`scores @ V`). That is a property of plain matmul shared by the
+    // canonical `gqa.rs`/`decode.rs` implementations too (neither guards
+    // exact-zero-weight multiplication against a NaN operand); it is a
+    // separate, out-of-scope concern from the softmax row-finalizer contract
+    // this cluster fixes. `gqa.rs`'s own existing NaN tests
+    // (`fused_softmax_all_neg_inf_row_is_zero_not_nan`,
+    // `fused_softmax_pos_inf_row_is_zero_not_nan`) test at the same level as
+    // here: the softmax row function directly, not through a full
+    // model forward pass.
+    // ---------------------------------------------------------------
+
+    /// A NaN score anywhere in the visible (non-causally-masked) range must
+    /// zero the whole row. RED before the fix: `if sum > 0.0` with no `else`
+    /// left a NaN-poisoned row's NaN/garbage exponentials un-zeroed.
+    #[test]
+    fn causal_softmax_row_nan_score_fails_closed() {
+        let mut row = vec![1.0f32, f32::NAN, 2.0];
+        causal_softmax_row(&mut row, 2, 1.0);
+        assert!(
+            row.iter().all(|&v| v == 0.0),
+            "expected all-zero row: {row:?}"
+        );
+    }
+
+    /// A `+inf` score must zero the whole row (fail-closed on non-finite max).
+    #[test]
+    fn causal_softmax_row_pos_inf_score_fails_closed() {
+        let mut row = vec![1.0f32, f32::INFINITY, 2.0];
+        causal_softmax_row(&mut row, 2, 1.0);
+        assert!(
+            row.iter().all(|&v| v == 0.0),
+            "expected all-zero row: {row:?}"
+        );
+    }
+
+    /// The causal mask sets every `ki > qi` lane to `-inf` before the
+    /// fail-closed decision; a query that only sees itself (`qi == 0`) must
+    /// still normalize correctly (this is not a poisoned-row case).
+    #[test]
+    fn causal_softmax_row_masks_future_positions() {
+        let mut row = vec![1.0f32, 2.0, 3.0];
+        causal_softmax_row(&mut row, 0, 1.0);
+        assert_eq!(
+            row,
+            vec![1.0, 0.0, 0.0],
+            "query 0 must attend only to itself: {row:?}"
+        );
+    }
+
+    /// A row that is fully masked to `-inf` (degenerate `qi` with no visible
+    /// keys) must zero out rather than compute `exp(NaN)` from a `-inf - -inf`
+    /// subtraction.
+    #[test]
+    fn causal_softmax_row_all_masked_zeros_row() {
+        let mut row = vec![f32::NEG_INFINITY; 3];
+        causal_softmax_row(&mut row, 0, 1.0);
+        assert!(
+            row.iter().all(|&v| v == 0.0),
+            "expected all-zero row: {row:?}"
+        );
+    }
+
+    /// A well-formed row still normalizes to a valid probability
+    /// distribution over the visible (non-masked) positions (guards against
+    /// the fixture trivially zeroing everything regardless of the fix).
+    #[test]
+    fn causal_softmax_row_normal_row_sums_to_one() {
+        let mut row = vec![1.0f32, 2.0, 3.0, 4.0];
+        causal_softmax_row(&mut row, 3, 1.0);
+        assert!(row.iter().all(|v| v.is_finite() && *v >= 0.0));
+        let sum: f32 = row.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-5, "expected sum ~1.0, got {sum}");
     }
 }

--- a/crates/inference/src/model/qwen35/forward.rs
+++ b/crates/inference/src/model/qwen35/forward.rs
@@ -375,7 +375,6 @@ impl Qwen35Model {
             let q = &scratch.q_buf[q_off..q_off + head_dim];
 
             let scores_start = qh * cur_seq_len;
-            let mut max_score = f32::NEG_INFINITY;
 
             for t in 0..cur_seq_len {
                 let k_off = t * kv_dim + kvh * head_dim;
@@ -383,23 +382,12 @@ impl Qwen35Model {
                 for d in 0..head_dim {
                     dot += q[d] * k_cache[k_off + d];
                 }
-                let s = dot * scale;
-                scratch.scores[scores_start + t] = s;
-                if s > max_score {
-                    max_score = s;
-                }
+                scratch.scores[scores_start + t] = dot * scale;
             }
 
-            let mut sum_exp = 0.0f32;
-            for t in 0..cur_seq_len {
-                let e = (scratch.scores[scores_start + t] - max_score).exp();
-                scratch.scores[scores_start + t] = e;
-                sum_exp += e;
-            }
-            let inv_sum = 1.0 / sum_exp;
-            for t in 0..cur_seq_len {
-                scratch.scores[scores_start + t] *= inv_sum;
-            }
+            decode_context_softmax_row(
+                &mut scratch.scores[scores_start..scores_start + cur_seq_len],
+            );
 
             let ctx_off = qh * head_dim;
             for d in 0..head_dim {
@@ -502,5 +490,61 @@ impl Qwen35Model {
             down_input,
             &mut scratch.ffn_out[..hidden],
         );
+    }
+}
+
+/// ADR-080 cluster C1: fail-closed softmax normalize for one decode-step
+/// attention-score row (`compute_attention_context`'s per-head row over the
+/// KV cache, #780). No causal masking here — decode attends to every cached
+/// position for the current token, so unlike the prefill row-finalizers this
+/// is a plain full-row two-pass softmax with no masked tail.
+fn decode_context_softmax_row(row: &mut [f32]) {
+    let (max_score, any_nan) = crate::attention::softmax_row::row_max_and_any_nan(row);
+    if crate::attention::softmax_row::row_fails_closed_pre_exp(max_score, any_nan) {
+        row.fill(0.0);
+        return;
+    }
+    let mut sum_exp = 0.0f32;
+    for v in row.iter_mut() {
+        *v = (*v - max_score).exp();
+        sum_exp += *v;
+    }
+    crate::attention::softmax_row::finalize_row(row, sum_exp);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RED before the fix: the bare `1.0 / sum_exp` had no guard, so a
+    /// NaN-poisoned cached score propagated NaN into every lane instead of
+    /// failing the row closed.
+    #[test]
+    fn decode_context_softmax_row_nan_score_fails_closed() {
+        let mut row = vec![1.0f32, f32::NAN, 0.5];
+        decode_context_softmax_row(&mut row);
+        assert!(
+            row.iter().all(|&v| v == 0.0),
+            "expected all-zero row: {row:?}"
+        );
+    }
+
+    #[test]
+    fn decode_context_softmax_row_pos_inf_score_fails_closed() {
+        let mut row = vec![1.0f32, f32::INFINITY, 0.5];
+        decode_context_softmax_row(&mut row);
+        assert!(
+            row.iter().all(|&v| v == 0.0),
+            "expected all-zero row: {row:?}"
+        );
+    }
+
+    #[test]
+    fn decode_context_softmax_row_normal_row_sums_to_one() {
+        let mut row = vec![1.0f32, 2.0, 3.0, 0.5];
+        decode_context_softmax_row(&mut row);
+        assert!(row.iter().all(|v| v.is_finite() && *v >= 0.0));
+        let sum: f32 = row.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-5, "expected sum ~1.0, got {sum}");
     }
 }

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -934,30 +934,30 @@ impl<'a> MtpVerifier<'a> {
 
             // Compute scores
             let scores_start = qh * cur_seq_len;
-            let mut max_score = f32::NEG_INFINITY;
             for t in 0..cur_seq_len {
                 let k_off = t * kv_dim + kvh * head_dim;
                 let mut dot = 0.0f32;
                 for d in 0..head_dim {
                     dot += self.scratch.q[q_off + d] * k_all[k_off + d];
                 }
-                let s = dot * scale;
-                self.scratch.scores[scores_start + t] = s;
-                if s > max_score {
-                    max_score = s;
-                }
+                self.scratch.scores[scores_start + t] = dot * scale;
             }
 
-            // Softmax
-            let mut sum_exp = 0.0f32;
-            for t in 0..cur_seq_len {
-                let e = (self.scratch.scores[scores_start + t] - max_score).exp();
-                self.scratch.scores[scores_start + t] = e;
-                sum_exp += e;
-            }
-            let inv_sum = 1.0 / sum_exp;
-            for t in 0..cur_seq_len {
-                self.scratch.scores[scores_start + t] *= inv_sum;
+            // ADR-080 C1: fail-closed softmax row contract (#785 round-1 blocker 1).
+            // This is MtpVerifier's own GQA attention over its KV cache, not a
+            // vocabulary/logit softmax -- a NaN/`+inf` cached score must zero the
+            // whole row, not silently poison every weight via `1.0 / sum_exp`.
+            let row = &mut self.scratch.scores[scores_start..scores_start + cur_seq_len];
+            let (max_score, any_nan) = crate::attention::softmax_row::row_max_and_any_nan(row);
+            if crate::attention::softmax_row::row_fails_closed_pre_exp(max_score, any_nan) {
+                row.fill(0.0);
+            } else {
+                let mut sum_exp = 0.0f32;
+                for v in row.iter_mut() {
+                    *v = (*v - max_score).exp();
+                    sum_exp += *v;
+                }
+                crate::attention::softmax_row::finalize_row(row, sum_exp);
             }
 
             // Weighted sum of V
@@ -4513,5 +4513,73 @@ mod tests {
         // `all_tokens.last()` in the first decode step.
         let out = generate_with_speculation(&[], 8, 999, |_tok, _pos| vec![0.0; 4], 3, 4);
         assert!(out.is_empty());
+    }
+
+    /// ADR-080 C1 (#785 round-1 blocker 1): `MtpVerifier::forward_one`'s own GQA
+    /// attention over its KV cache is a production attention row, not a
+    /// vocabulary/logit softmax (the PR body's original classification was wrong).
+    /// A NaN cached K row must zero the whole attention-context row for every
+    /// query head that attends through that KV head, while a sibling query head
+    /// attending through an unpoisoned KV head stays finite/normalized.
+    ///
+    /// Uses `num_key_value_heads == num_attention_heads == 2` (MHA, `groups == 1`)
+    /// so each query head has its own independent KV head slice: poisoning KV
+    /// head 0 cannot leak into query head 1's row through GQA sharing.
+    #[test]
+    fn mtp_forward_one_nan_cached_k_row_fails_closed_sibling_head_stays_finite() {
+        let mut cfg = tiny_mtp_config();
+        cfg.num_key_value_heads = 2; // MHA: qh 0 -> kvh 0, qh 1 -> kvh 1, independent caches
+        let weights = tiny_mtp_weights(&cfg);
+        let h = cfg.hidden_size;
+        let head_dim = cfg.head_dim;
+        let max_seq = 8usize;
+
+        let embed: Vec<f32> = (0..cfg.vocab_size * h)
+            .map(|i| ((i as f32 + 1.0) * 0.01).sin())
+            .collect();
+        let lm_head: Vec<f32> = (0..cfg.vocab_size * h)
+            .map(|i| ((i as f32 + 2.0) * 0.01).cos())
+            .collect();
+        let prev_hidden: Vec<f32> = (0..h).map(|i| 0.1 * (i as f32 + 1.0)).collect();
+
+        let mut verifier = MtpVerifier::new(cfg, &weights, &embed, &lm_head, max_seq).unwrap();
+
+        // Step 0: append a real (unpoisoned) K/V pair at cache position 0.
+        verifier.forward_one(1, 0, &prev_hidden).unwrap();
+        assert_eq!(verifier.cache.seq_len(), 1);
+
+        // Directly poison KV head 0's cached K vector at position 0 -- a NaN
+        // score that must be caught by `row_max_and_any_nan`, not silently
+        // dropped by the old `if s > max_score` fold.
+        {
+            let k_buf = verifier.cache.k_buffer_mut(0);
+            // Position 0, KV head 0 occupies the first `head_dim` lanes of the
+            // per-position `kv_dim`-wide slice.
+            k_buf[0] = half::f16::NAN;
+        }
+
+        // Step 1: a second forward_one attends over cache positions {0, 1}.
+        // qh=0 (kvh=0) sees the poisoned position-0 score; qh=1 (kvh=1) does not.
+        verifier.forward_one(2, 1, &prev_hidden).unwrap();
+
+        let ctx = &verifier.scratch.context;
+        let poisoned_head = &ctx[0..head_dim];
+        let clean_head = &ctx[head_dim..2 * head_dim];
+
+        assert!(
+            poisoned_head.iter().all(|&v| v == 0.0),
+            "query head attending through the poisoned KV head must be exactly \
+             all-zero (fail-closed), got {poisoned_head:?}"
+        );
+        assert!(
+            clean_head.iter().all(|v| v.is_finite()),
+            "sibling query head attending through an unpoisoned KV head must \
+             stay finite, got {clean_head:?}"
+        );
+        assert!(
+            clean_head.iter().any(|&v| v != 0.0),
+            "sibling query head's context must be a real (non-degenerate) \
+             normalized result, not incidentally all-zero, got {clean_head:?}"
+        );
     }
 }

--- a/crates/inference/src/vision/vit.rs
+++ b/crates/inference/src/vision/vit.rs
@@ -160,12 +160,23 @@ fn swiglu(gate: &[f32], up: &[f32]) -> Vec<f32> {
 }
 
 /// Softmax over a slice of logits (in-place).
+///
+/// ADR-080 C1: routes the fail-closed row contract through the shared
+/// row-finalizer (#741). Previously this had NO guard at all — a NaN or
+/// `+inf` logit propagated NaN through the unconditional division into every
+/// element of the row and onward through the rest of the ViT forward pass.
 fn softmax_inplace(x: &mut [f32]) {
-    let max = x.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-    let sum: f32 = x.iter().map(|v| (v - max).exp()).sum();
-    for v in x.iter_mut() {
-        *v = ((*v - max).exp()) / sum;
+    let (max, any_nan) = crate::attention::softmax_row::row_max_and_any_nan(x);
+    if crate::attention::softmax_row::row_fails_closed_pre_exp(max, any_nan) {
+        x.fill(0.0);
+        return;
     }
+    let mut sum = 0.0f32;
+    for v in x.iter_mut() {
+        *v = (*v - max).exp();
+        sum += *v;
+    }
+    crate::attention::softmax_row::finalize_row(x, sum);
 }
 
 // ---------------------------------------------------------------------------
@@ -617,6 +628,40 @@ mod tests {
         for &v in &out {
             assert!(v.is_finite(), "ViT output contained non-finite: {v}");
         }
+    }
+
+    // ADR-080 C1 / #741: `softmax_inplace` previously had NO fail-closed guard
+    // at all — a NaN or `+inf` logit divided every element by a NaN/Inf `sum`,
+    // propagating NaN through the whole row instead of zeroing it. RED before
+    // the fix: these assertions failed with a NaN-populated row.
+    #[test]
+    fn softmax_inplace_nan_fails_closed() {
+        let mut x = vec![1.0f32, f32::NAN, 2.0, 0.5];
+        softmax_inplace(&mut x);
+        assert!(x.iter().all(|&v| v == 0.0), "expected all-zero row: {x:?}");
+    }
+
+    #[test]
+    fn softmax_inplace_pos_inf_fails_closed() {
+        let mut x = vec![1.0f32, f32::INFINITY, 2.0];
+        softmax_inplace(&mut x);
+        assert!(x.iter().all(|&v| v == 0.0), "expected all-zero row: {x:?}");
+    }
+
+    #[test]
+    fn softmax_inplace_all_neg_inf_fails_closed() {
+        let mut x = vec![f32::NEG_INFINITY; 4];
+        softmax_inplace(&mut x);
+        assert!(x.iter().all(|&v| v == 0.0), "expected all-zero row: {x:?}");
+    }
+
+    #[test]
+    fn softmax_inplace_normal_row_still_normalizes() {
+        let mut x = vec![1.0f32, 2.0, 3.0];
+        softmax_inplace(&mut x);
+        let sum: f32 = x.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "row must sum to ~1: {x:?}");
+        assert!(x.iter().all(|v| v.is_finite() && *v >= 0.0));
     }
 
     #[test]


### PR DESCRIPTION
## Contract (ADR-080 C1)

A softmax row whose inputs contain NaN, whose max is `+inf`, or whose denominator is
non-positive/non-finite is **zeroed in full** (fail closed). No site may silently drop a
single lane, clamp, or emit a partially-normalized row.

This PR extracts the shared row-finalizer as an allocation-free `#[inline]` helper
(`crates/inference/src/attention/softmax_row.rs`: `row_max_and_any_nan`,
`row_fails_closed_pre_exp`, `is_masked_neg_inf`, `finalize_row`) and routes every
in-scope CPU production attention-row softmax site through it (GPU/shader kernels: see
the deferred-follow-up section below), or through an inline
contract-conformant fix where the helper's `&mut [f32]` shape doesn't fit the site's
control flow.

Part of #780.

## Site-by-site

| Site | Treatment | Notes |
|---|---|---|
| `attention/gqa.rs::apply_scaled_causal_softmax_fused` | Routed (refactor-only) | Real unclamped `.exp()` already fails closed via NaN-into-sum; swap is behavior-preserving — verified via existing bitexact/reference-parity tests, unchanged |
| `attention/decode.rs::softmax_decode_scores` | Routed (refactor-only) | Online/Welford max+`l`, exp pass now separated from `finalize_row(row, l)` |
| `attention/decode.rs::softmax_decode_neon` | Inline fix (structural) | Raw-pointer SIMD chunk loop, can't take a `&mut [f32]` helper without breaking vectorization; reimplements the same NaN-scan/`+inf`/non-positive-sum contract inline |
| `forward/cpu/softmax.rs::softmax_attention_scalar/neon/avx2` | Routed + fixed (#740) | Fixed: NaN-lane silently dropped by `fold(NEG_INFINITY, max)`; exact-zero for masked `-inf` lanes (previously round-tripped through `fast_exp`'s clamp into a tiny nonzero weight) |
| `model/qwen.rs` (2 inline duplicates in `forward_all_layers` + `forward_profiled`) | Deduplicated + routed (#739) | Extracted `causal_softmax_row` free fn, both call sites now call it — removes the independent formula copy |
| `model/qwen35/forward.rs::compute_attention_context` | Routed (fixed) | Extracted `decode_context_softmax_row`; bare `1.0 / sum_exp` had no guard |
| `forward/cpu_f16.rs::full_attention_step_f16` | Inline fix (fixed) | Same bug pattern as qwen35/forward.rs; can't reuse `decode_context_softmax_row` (private to that module) so the guard is inlined with a comment pointing at the sibling |
| `vision/vit.rs` (softmax_inplace) | Routed + fixed (#741) | Previously no fail-closed guard at all |
| `attention/differential.rs` | Routed | Standalone normalizer; `MASK_VALUE = -10_000.0` sentinel left unchanged (separate bug class, #373) |
| `attention/native_sparse.rs::softmax_inplace` (3 call sites) | Routed | |
| `attention/flash_causal.rs::standard_attention_causal` | Routed + fixed | Short-seq fallback; computes the full masked row first, then applies the shared decision helpers |
| `attention/flash_causal.rs` tiled Flash Attention path (`flash_update_block` + `normalize_head_output`) | Inline fix (fixed) | Online-softmax running-max/`l`/`alpha` can't route through a single-row helper; added a `bad_rows`/`group_bad` flag persisted across K-blocks so a NaN/`+inf` score anywhere in a row forces that row to zero at every subsequent block and at final normalization |
| `forward/batch_prefill.rs::causal_tiled_attention_head` | Inline fix (fixed) | `running_sum.max(f32::MIN_POSITIVE)` silently converted a NaN denominator into a ~8.5e37 reciprocal instead of failing closed; replaced with an explicit `row_poisoned \|\| !is_finite \|\| <= 0.0` zero-fill branch |
| `speculative.rs::MtpVerifier::forward_one` | Routed + fixed (round-1 blocker 1) | **Correction**: round 1 of this PR wrongly folded this into the "vocabulary/logit softmax" exemption list below. It is an attention-row softmax (MTP verify-step GQA scores), was fail-open (`let inv_sum = 1.0 / sum_exp;`, no guard), and is now routed through `row_max_and_any_nan`/`row_fails_closed_pre_exp`/`finalize_row`. Mutation-verified. |
| `backward/attention_gqa.rs::gqa_forward_with_cache` (train-backward feature) | Routed + fixed (round-1 major 1) | **Correction**: round 1 flagged this as "discovered, out of scope" reasoning the no-masking loop range made it lower risk. Codex correctly rejected that — it's still a bare `inv = 1.0 / sum_exp` with no guard, same contract violation. Now routed through the shared helper. Mutation-verified. |
| `generate.rs::compute_attention` (online decode fast path + generic prefill/multi-token path) | Routed (refactor-only, round-1 medium 1) | Both standalone finalizers already reached the same fail-closed outcome as `finalize_row` (online: `if l > 0.0 {...} else fill(0.0)`; generic: real unclamped `.exp()`/NaN-into-sum); routed for consolidation, not a behavior fix. Clean-row parity assertions added to the existing NaN tests. |
| `forward/cpu_q8.rs::full_attention_step_q8` | Routed (refactor-only, round-1 medium 1) | Already fail-closed (real unclamped `.exp()`); routed through `finalize_row` for consolidation. New clean-row parity test added. |
| `forward/neon_forward.rs::full_attention_step_q8_neon` | Routed (refactor-only, round-1 medium 1) | Same as `cpu_q8.rs`; routed for consolidation. Existing NaN test strengthened with a clean-row parity check. |

### GPU/shader kernel conformance — deferred follow-up (tracked by ADR-080 / #780 until its issue is filed)

Live WGPU/Metal kernel conformance with the C1 contract (`forward/gpu/inner/shaders.rs::attention_softmax`'s
`1.0 / max(sum, 1e-20)` floor-clamp, and any GDN/Metal-side softmax) is **not claimed exempt**. It is
**out of scope for this PR** and remains a tracked ADR-080/#780 obligation: a follow-up issue is
filed once a GPU behavioral repro exists (timeboxed; if the repro resists, the data-flow analysis
escalates rather than being dropped), and the shader fix lands there. This PR touches CPU code only.

### Sibling grep — exempt sites (different contract, not attention-row softmax)

Grepped the workspace for `fold(NEG_INFINITY, max)` / `1.0 / sum` / `inv_sum` / floor-clamp
patterns after routing. Remaining sites are **vocabulary/logit softmax for sampling or
perplexity**, not attention scores — no masking, different failure surface, out of C1's scope:
`sampling.rs`, `metrics.rs` (PPL), `backward/gradcheck.rs`,
`backward/ops.rs` (gradient softmax), `kv_cache/flat.rs`, `model/qwen35/eval.rs::log_sum_exp`,
`model/qwen35/moe.rs` (MoE router, already fail-closed with its own tests). `q4_weights.rs` is a
quantization scale-finding max, unrelated to softmax. **`generate.rs` and `speculative.rs` are
removed from this list** (round 1 wrongly exempted them; both carry real attention-row softmax
sites now routed/fixed above — see the site table).

The one permitted standalone copy per the issue text ("the scalar formula oracle in parity
tests is the only permitted standalone copy"): `attention/gqa.rs`'s `#[cfg(test)]`
`reference_attention_per_head`, a naive bit-exact oracle used only to assert the production
fused kernel matches it.

## Mutation-sensitive tests (all verified: revert fix → red, restore → green)

- `attention/softmax_row.rs` — 3 tests on `finalize_row` (NaN sum, negative sum, zero sum)
- `forward/cpu/softmax.rs` — 3 tests (`scalar_masked_lane_is_exact_zero`,
  `scalar_nan_lane_zeros_whole_row`, `scalar_only_poisoned_row_zeros`)
- `model/qwen.rs` — 3 of 5 `causal_softmax_row_*` tests (reverted to the true pre-fix code via
  `git diff main`: bare `if sum > 0.0 {...}` with no `else` branch)
- `attention/flash_causal.rs` — `tiled_path_nan_key_fails_closed_across_blocks` (required
  reverting **both** the `flash_update_block` row-gating AND `normalize_head_output`'s bad-check
  simultaneously; either alone is redundant/self-sufficient — genuine belt-and-suspenders)
- `forward/batch_prefill.rs` — `causal_tiled_attention_head_nan_key_fails_closed` (reverted to
  `running_sum.max(f32::MIN_POSITIVE)`, confirmed the row explodes to `[NaN, NaN, NaN, NaN]`)

### Round 2 (codex round-1 review response) — additional mutation-verified fixes

- `speculative.rs::mtp_forward_one_nan_cached_k_row_fails_closed_sibling_head_stays_finite` —
  poisons one KV cache K-row lane (MHA config, `num_key_value_heads=2`, groups=1) so only one
  query head is affected; asserts that head's context is exactly `0.0` and the sibling head's
  context stays finite/non-degenerate. Reverted to the true pre-fix `forward_one` (bare
  `max_score`/`inv_sum`, no guard): confirmed RED (`got [NaN, NaN, NaN, NaN]`). Restored: GREEN.
- `backward/attention_gqa.rs::gqa_forward_with_cache_nan_q_score_fails_closed_sibling_head_stays_finite`
  (train-backward feature) — poisons `w_q[0]` (a Q-projection weight, not an input row, so K/V
  stay untouched) with `num_q_heads=2, num_kv_heads=1`; asserts head 0's `softmax_probs`/`context`
  are exactly `0.0` at every `t`, head 1's stay finite. Reverted to the true pre-fix code (bare
  `max`/`inv = 1.0/sum_exp`): confirmed RED (`got [NaN]` at `t=0`). Restored: GREEN.
- `generate.rs::test_compute_attention_prefill_nan_score_fails_closed` — strengthened the
  sibling-query assertion from `is_finite()` to an exact value (`(output[1] - 9.0).abs() < 1e-5`),
  proving the clean row went through `finalize_row`'s real normalization, not just "didn't NaN."
- `forward/cpu_q8.rs::test_full_attn_step_q8_clean_row_still_normalizes` (new) and
  `forward/neon_forward.rs::test_full_attn_step_q8_neon_nan_score_fails_closed` (strengthened) —
  clean-row parity checks around the newly-routed `finalize_row` call sites.
- `attention/differential.rs::test_diff_attn_nan_score_fails_closed` — **codex flagged this as
  too weak**: the original poisoned only one of the two differential softmax paths (`q_h0`), so
  `is_finite()` passed on a still-nonzero `0 - lambda_full*attn2` value, not because the row was
  actually zeroed. Rewrote to poison the WHOLE token's Q row (both `q_h0`/`q_h1` sub-vectors) so
  both differential softmaxes fail closed simultaneously, and strengthened the assertion to
  exact-zero on the full poisoned output row (sibling rows checked finite + non-degenerate).
  Mutation-verified two ways, both required by codex:
  - **Whole-row-fill revert**: reverted to the pre-C1 fail-open code (bare `max`/`inv_sum`, no
    `else`) — confirmed RED (`got [NaN, NaN, NaN, NaN]`).
  - **One-lane-only-zero mutation**: replaced the fail-closed branch with a variant that zeros
    only the NaN lane(s) and renormalizes the rest (the exact partial-row bug class C1 forbids).
    The strengthened test correctly went RED (`got [1.15, -1.01, -0.17, -0.44]`, not all-zero).
    Added a **second, dedicated test**,
    `test_diff_attn_partial_nan_row_fails_closed_in_full`, because the whole-row-poisoned test
    above can't discriminate this mutation (every lane is already NaN together there, so
    "zero-the-NaN-lanes" and "zero-the-whole-row" coincide). The new test poisons a single K
    TIME STEP (not a whole Q row) across both packed K halves, which causal masking places in
    every later query's row while leaving that row's *other* lanes finite (`[NaN, finite]`) —
    a genuinely mixed row. Confirmed this new test alone catches the one-lane mutation (RED)
    while the original NaN test stays green under the same mutation; both green after restore.

Full CPU test suite (`cargo test -p lattice-inference --lib`): **1584 passed, 0 failed, 18
ignored** (default features); **1601 passed, 0 failed, 18 ignored** (`--features train-backward`,
covers `backward/attention_gqa.rs`).
`cargo clippy --workspace --tests -- -D warnings`: clean (both feature sets).

## bench-compare

### Round 1 (quick mode, `origin/main` 41cda99f1 vs HEAD d4a606f40) — superseded, see Round 2

**2 FAIL, 6 WARN, 21 improvements.** The two FAILs were both `softmax_attention` (the
`forward/cpu/softmax.rs` NEON path benchmarked directly):

| Bench | Δ point | 95% CI | verdict |
|---|---:|---|---|
| `softmax_attention/128` | +22.45% | [+20.75%, +24.15%] | ❌ FAIL |
| `softmax_attention/512` | +20.87% | [+20.45%, +21.28%] | ❌ FAIL |

At the time, this was attributed to the extra per-lane `vceqq_f32`/`vandq_u32` NaN-tracking ops
being "structurally necessary." **Codex correctly challenged that in round 1**: the tracking was
redundant, not necessary — see Round 2 below.

### Round 2 — NEON FMAX simplification (codex round-1 perf ask)

`forward/cpu/softmax.rs`'s NEON path used `vmaxnmq_f32`/`vmaxnmvq_f32` (FMAXNM, drops a NaN
operand) paired with an explicit `vceqq_f32`/`vandq_u32` NaN-tracking mask, reasoning (at the
time) that this was needed to detect a NaN the max-reduction itself would silently swallow. But
the *scalar* reference (`row_max_and_any_nan`/`row_fails_closed_pre_exp`) and
`attention/decode.rs::softmax_decode_neon` already solve this more cheaply: use the
NaN-*propagating* `vmaxq_f32`/`vmaxvq_f32` (FMAX) instead, and the existing
`if !max_val.is_finite() { row.fill(0.0); }` check catches the NaN for free — no separate
tracking mask needed. Replaced the tracking-mask approach with FMAX, mirroring `decode.rs`
exactly (including its chunk/tail NaN-propagation-across-boundary handling). The per-lane `-inf`
masked-lane blend (`vbslq_f32` against `neg_inf`) is unchanged — that's a different, genuinely
contract-required piece (exact-zero for masked lanes, not a NaN-detection mechanism).

AVX2 was NOT changed: x86 has no NaN-propagating alternative to `MAXPS` (unlike ARM's
FMAX/FMAXNM pair), so the AVX2 path's explicit `_mm256_cmp_ps`/`_mm256_and_ps` NaN-tracking is
not redundant — it's the only way to detect a NaN there. All 66 `softmax`-namespaced unit tests
pass unchanged after the NEON change (`neon_nan_in_chunk_zeros_whole_row`,
`neon_nan_in_tail_zeros_whole_row`, `neon_masked_lane_in_chunk_is_exact_zero`,
`neon_matches_scalar_on_finite_row`, and the rest).

Re-benched against the PR's own baseline commit (`d4a606f40`, the same commit round 1's FAIL
numbers above were measured against) with the round-2 fixes (this NEON change + all mutation
test additions) applied on top. Ran it twice (quick-mode Criterion noise on this machine is
real, per `LOOP_RUNBOOK`/prior sessions), both runs shown for honesty rather than cherry-picking
the better one:

| Bench | Run A (isolated group) | Run B (full default suite) | Round-1 (pre-fix) |
|---|---:|---:|---:|
| `softmax_attention/128` | -5.26% [-5.44%, -5.07%] | -9.95% [-10.30%, -9.59%] | +22.45% ❌ FAIL |
| `softmax_attention/512` | +4.66% [+2.55%, +6.81%] ⚠ WARN | -6.28% [-7.36%, -5.19%] | +20.87% ❌ FAIL |

Both runs agree on the conclusion even though the point estimates differ (noise): **both FAILs
are resolved** — `/128` is now a net improvement in both runs, and `/512` ranges from a small
WARN down to an outright WIN, never exceeding the 7% fail threshold either way.

**End-to-end prefill measurement**: attempted via `crates/inference/benches/attention_bench.rs`
(materialized-vs-tiled multi-head attention timing at realistic BERT-style shapes, CPU only, no
GPU) but its harness asserts materialized/tiled output parity before printing any timing, and
that assertion **fails on the clean pre-round-2 baseline** (`bge-small seq_len=64
max_abs_diff=0.38`) — confirmed via a same-worktree stash A/B (round-2 changes stashed, ran
against the exact `d4a606f40` state, same failure). This is a pre-existing bug unrelated to
#785/ADR-080 C1, blocking that harness's timing output; not fixed here (out of scope). The
`softmax_attention` Criterion group above is itself a direct, representative measurement of the
prefill-shaped (seq_len × seq_len) attention-softmax kernel this PR's perf fix targets.

The remaining WARNs/improvements in the full run below are lattice-embed SIMD noise (known,
#714) unrelated to this PR's inference changes.

Keeping the `bench-allow-regression` label on this PR since Run A's `/512` point estimate still
lands in WARN territory (even though Run B's did not) — the safer, non-cherry-picked read per
ADR-058's override path.

<details>
<summary>Round 1 raw bench-compare output (superseded — see Round 2 numbers above)</summary>

```
=== Full gate report ===
### `local-compare` — perf regression report

**❌ 2 FAIL** (regression >7.0% confirmed by 95% CI)
**⚠ 6 WARN** (regression 3.0-7.0% confirmed)
**🚀 21 confirmed improvement**

| Bench | Δ point | 95% CI | new ns | base ns | verdict |
|---|---:|---|---:|---:|---|
| `softmax_attention/128` | +22.45% | [+20.75%, +24.15%] | 4485.0 | 3662.8 | ❌ FAIL |
| `softmax_attention/512` | +20.87% | [+20.45%, +21.28%] | 76743.0 | 63494.3 | ❌ FAIL |
| `int8_raw_dot_product/dot_product_i8_raw/128` | +8.17% | [+6.31%, +10.04%] | 4.5 | 4.2 | ⚠ WARN |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_4c` | +5.28% | [+4.64%, +5.91%] | 141.5 | 134.4 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_1000c` | +5.76% | [+4.28%, +7.24%] | 66341.7 | 62729.3 | ⚠ WARN |
| `int8_prepared_dot_product/prepared/129` | +4.50% | [+3.48%, +5.53%] | 5.7 | 5.5 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_16c` | +3.55% | [+3.26%, +3.84%] | 442.1 | 426.9 | ⚠ WARN |
| `int8_raw_dot_product/dot_product_i8_raw/384` | +4.18% | [+3.14%, +5.23%] | 9.1 | 8.7 | ⚠ WARN |
| `simd_throughput_384/normalize` | -3.24% | [-3.36%, -3.13%] | 99.0 | 102.3 | 🚀 WIN |
| `simd_batch_cosine/scalar_loop/1000` | -3.22% | [-4.05%, -2.38%] | 691898.0 | 714930.2 | 🚀 WIN |
| `simd_dot_product/simd/384` | -3.21% | [-4.08%, -2.34%] | 27.3 | 28.2 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_16c` | -4.00% | [-4.27%, -3.73%] | 858.5 | 894.3 | 🚀 WIN |
| `int8_vs_float32_cosine/float32_simd/1536` | -4.10% | [-4.64%, -3.56%] | 123.8 | 129.1 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_1000c` | -3.18% | [-4.72%, -1.60%] | 32491.2 | 33558.4 | 🚀 WIN |
| `int8_batch_cosine/float32_simd/1000` | -3.93% | [-5.03%, -2.81%] | 43275.1 | 45043.7 | 🚀 WIN |
| `binary_cosine_distance/float32_simd/384` | -4.25% | [-5.17%, -3.31%] | 38.8 | 40.5 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/simd_batch/384d_1000c` | -5.37% | [-5.93%, -4.81%] | 31346.4 | 33125.5 | 🚀 WIN |
| `simd_cosine_similarity/simd/1536` | -3.90% | [-5.97%, -1.78%] | 123.2 | 128.2 | 🚀 WIN |
| `int4_cosine_distance/float32_simd/1536` | -5.35% | [-6.15%, -4.54%] | 123.7 | 130.7 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_256c` | -6.14% | [-6.64%, -5.64%] | 8013.8 | 8537.8 | 🚀 WIN |
| `simd_normalize/simd/384` | -6.00% | [-6.66%, -5.33%] | 72.2 | 76.8 | 🚀 WIN |
| `simd_cosine_similarity/simd/768` | -4.70% | [-7.12%, -2.27%] | 64.5 | 67.7 | 🚀 WIN |
| `simd_dot_product/simd/1536` | -5.91% | [-7.28%, -4.53%] | 113.8 | 121.0 | 🚀 WIN |
| `simd_batch_dot_product/simd_batch/100` | -7.23% | [-7.72%, -6.74%] | 4233.5 | 4563.3 | 🚀 WIN |
| `simd_batch_cosine/simd_batch/100` | -7.20% | [-8.15%, -6.24%] | 4143.4 | 4464.8 | 🚀 WIN |
| `simd_query_batch_dot_product/pair_loop/128d_64c` | -5.59% | [-8.81%, -2.22%] | 650.4 | 688.9 | 🚀 WIN |
| `binary_cosine_distance/float32_simd/1024` | -8.83% | [-10.48%, -7.13%] | 83.4 | 91.5 | 🚀 WIN |
| `simd_batch_cosine/simd_batch/1000` | -13.97% | [-14.19%, -13.75%] | 38153.7 | 44350.4 | 🚀 WIN |
| `simd_batch_dot_product/simd_batch/1000` | -14.50% | [-15.23%, -13.77%] | 38583.6 | 45126.3 | 🚀 WIN |

<details><summary>All 263 measurements</summary>

| Bench | Δ point | CI-lower | CI-upper |
|---|---:|---:|---:|
| `add_bias_gelu/4096` | +0.30% | -2.03% | +2.64% |
| `add_bias_gelu/896` | +0.52% | -0.23% | +1.28% |
| `binary_cosine_distance/binary/1024` | -2.70% | -4.09% | -1.29% |
| `binary_cosine_distance/binary/1536` | -0.70% | -2.67% | +1.35% |
| `binary_cosine_distance/binary/384` | +1.67% | +0.60% | +2.74% |
| `binary_cosine_distance/binary/768` | +1.55% | +0.79% | +2.33% |
| `binary_cosine_distance/float32_simd/1024` | -8.83% | -10.48% | -7.13% |
| `binary_cosine_distance/float32_simd/1536` | -1.06% | -2.57% | +0.48% |
| `binary_cosine_distance/float32_simd/384` | -4.25% | -5.17% | -3.31% |
| `binary_cosine_distance/float32_simd/768` | +0.04% | -0.40% | +0.49% |
| `elementwise_mul/4096` | -1.44% | -1.80% | -1.09% |
| `gelu/4096` | -0.34% | -1.14% | +0.46% |
| `gelu/896` | -0.43% | -0.93% | +0.07% |
| `int4_cosine_distance/float32_simd/1024` | +0.89% | -0.36% | +2.16% |
| `int4_cosine_distance/float32_simd/1536` | -5.35% | -6.15% | -4.54% |
| `int4_cosine_distance/float32_simd/384` | -2.85% | -3.72% | -1.98% |
| `int4_cosine_distance/float32_simd/768` | +0.39% | -0.18% | +0.95% |
| `int4_cosine_distance/int4/1024` | +0.57% | +0.05% | +1.10% |
| `int4_cosine_distance/int4/1536` | -1.33% | -2.24% | -0.42% |
| `int4_cosine_distance/int4/384` | +3.62% | +1.10% | +6.20% |
| `int4_cosine_distance/int4/768` | -0.01% | -2.22% | +2.23% |
| `int8_batch_cosine/float32_simd/10` | -2.03% | -3.38% | -0.65% |
| `int8_batch_cosine/float32_simd/100` | -0.88% | -2.27% | +0.53% |
| `int8_batch_cosine/float32_simd/1000` | -3.93% | -5.03% | -2.81% |
| `int8_batch_cosine/int8_loop/10` | -2.23% | -3.14% | -1.31% |
| `int8_batch_cosine/int8_loop/100` | -2.22% | -2.34% | -2.10% |
| `int8_batch_cosine/int8_loop/1000` | -1.24% | -2.48% | +0.01% |
| `int8_prepared_dot_product/per_call/1024` | -0.51% | -0.94% | -0.08% |
| `int8_prepared_dot_product/per_call/127` | +0.24% | -1.19% | +1.70% |
| `int8_prepared_dot_product/per_call/128` | +1.44% | +0.43% | +2.45% |
| `int8_prepared_dot_product/per_call/129` | -1.41% | -6.52% | +3.99% |
| `int8_prepared_dot_product/per_call/384` | +0.98% | -0.14% | +2.11% |
| `int8_prepared_dot_product/per_call/768` | -0.42% | -2.63% | +1.82% |
| `int8_prepared_dot_product/prepared/1024` | -2.21% | -2.58% | -1.85% |
| `int8_prepared_dot_product/prepared/127` | -0.84% | -1.40% | -0.28% |
| `int8_prepared_dot_product/prepared/128` | -1.58% | -2.61% | -0.54% |
| `int8_prepared_dot_product/prepared/129` | +4.50% | +3.48% | +5.53% |
| `int8_prepared_dot_product/prepared/384` | +0.34% | -0.13% | +0.81% |
| `int8_prepared_dot_product/prepared/768` | -1.00% | -1.78% | -0.21% |
| `int8_quantization/quantize/1024` | +2.83% | -0.14% | +5.81% |
| `int8_quantization/quantize/1536` | +0.67% | +0.32% | +1.02% |
| `int8_quantization/quantize/384` | -2.17% | -3.39% | -0.95% |
| `int8_quantization/quantize/768` | -1.00% | -1.34% | -0.65% |
| `int8_raw_dot_product/dot_product_i8/1024` | +1.00% | -0.34% | +2.36% |
| `int8_raw_dot_product/dot_product_i8/127` | +0.90% | -0.93% | +2.75% |
| `int8_raw_dot_product/dot_product_i8/128` | -1.53% | -3.78% | +0.82% |
| `int8_raw_dot_product/dot_product_i8/129` | -0.82% | -3.29% | +1.70% |
| `int8_raw_dot_product/dot_product_i8/384` | +3.91% | +2.33% | +5.50% |
| `int8_raw_dot_product/dot_product_i8/768` | +1.85% | +0.97% | +2.75% |
| `int8_raw_dot_product/dot_product_i8_raw/1024` | -0.10% | -1.47% | +1.29% |
| `int8_raw_dot_product/dot_product_i8_raw/127` | -0.30% | -1.47% | +0.88% |
| `int8_raw_dot_product/dot_product_i8_raw/128` | +8.17% | +6.31% | +10.04% |
| `int8_raw_dot_product/dot_product_i8_raw/129` | +1.45% | -0.37% | +3.30% |
| `int8_raw_dot_product/dot_product_i8_raw/384` | +4.18% | +3.14% | +5.23% |
| `int8_raw_dot_product/dot_product_i8_raw/768` | +2.40% | +1.17% | +3.64% |
| `int8_vs_float32_cosine/float32_simd/1024` | -1.49% | -1.68% | -1.30% |
| `int8_vs_float32_cosine/float32_simd/1536` | -4.10% | -4.64% | -3.56% |
| `int8_vs_float32_cosine/float32_simd/384` | -2.23% | -3.75% | -0.70% |
| `int8_vs_float32_cosine/float32_simd/768` | -2.13% | -2.42% | -1.84% |
| `int8_vs_float32_cosine/int8/1024` | -0.16% | -1.33% | +1.03% |
| `int8_vs_float32_cosine/int8/1536` | -0.70% | -1.95% | +0.57% |
| `int8_vs_float32_cosine/int8/384` | +0.13% | -0.49% | +0.76% |
| `int8_vs_float32_cosine/int8/768` | -1.91% | -4.10% | +0.33% |
| `layer_norm/4096` | -0.28% | -0.42% | -0.14% |
| `layer_norm/896` | +0.25% | -0.92% | +1.44% |
| `memory_size/search_1000_float32` | -2.61% | -3.89% | -1.32% |
| `memory_size/search_1000_int8` | -0.32% | -1.34% | +0.72% |
| `residual_add_layer_norm/fused/hidden384_seq128` | -1.27% | -1.41% | -1.13% |
| `residual_add_layer_norm/fused/hidden768_seq128` | +2.76% | +0.86% | +4.70% |
| `residual_add_layer_norm/unfused/hidden384_seq128` | -1.06% | -1.82% | -0.29% |
| `residual_add_layer_norm/unfused/hidden768_seq128` | -1.99% | -2.63% | -1.35% |
| `rms_norm/4096` | +1.03% | +0.13% | +1.94% |
| `rms_norm/896` | +0.40% | +0.02% | +0.78% |
| `silu_inplace/4096` | -2.91% | -3.21% | -2.61% |
| `silu_inplace/896` | -0.54% | -1.11% | +0.03% |
| `simd_batch_cosine/scalar_loop/10` | -1.78% | -2.38% | -1.17% |
| `simd_batch_cosine/scalar_loop/100` | -0.38% | -1.30% | +0.55% |
| `simd_batch_cosine/scalar_loop/1000` | -3.22% | -4.05% | -2.38% |
| `simd_batch_cosine/simd_batch/10` | +0.61% | -1.60% | +2.87% |
| `simd_batch_cosine/simd_batch/100` | -7.20% | -8.15% | -6.24% |
| `simd_batch_cosine/simd_batch/1000` | -13.97% | -14.19% | -13.75% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_1000c` | -2.06% | -3.04% | -1.07% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_16c` | +2.62% | +1.51% | +3.73% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_256c` | +0.93% | -0.05% | +1.92% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_4c` | +0.08% | -0.39% | +0.55% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c` | -1.33% | -2.89% | +0.25% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_1000c` | +0.02% | -1.04% | +1.09% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_16c` | -0.11% | -0.42% | +0.20% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_256c` | +0.82% | +0.22% | +1.41% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_4c` | +5.28% | +4.64% | +5.91% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_64c` | -0.96% | -3.08% | +1.26% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_1000c` | -1.36% | -1.96% | -0.75% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_16c` | -0.10% | -0.66% | +0.47% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_256c` | +1.68% | +1.24% | +2.12% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_4c` | +1.06% | -0.02% | +2.16% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_64c` | +0.11% | -2.42% | +2.74% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_1000c` | +1.59% | +0.88% | +2.31% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_16c` | +1.19% | +0.35% | +2.04% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_256c` | +1.86% | +0.72% | +3.01% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_4c` | +2.72% | +1.96% | +3.49% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_64c` | +0.06% | -0.72% | +0.84% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_1000c` | -0.25% | -0.36% | -0.14% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_16c` | -2.00% | -5.22% | +1.36% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_256c` | -6.14% | -6.64% | -5.64% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_4c` | +1.22% | +0.70% | +1.75% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_64c` | +2.55% | +0.94% | +4.18% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_1000c` | +1.10% | -0.03% | +2.24% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_16c` | +2.48% | +1.44% | +3.52% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_256c` | +2.11% | +1.71% | +2.52% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_4c` | -0.64% | -1.00% | -0.28% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_64c` | +1.02% | -0.16% | +2.22% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_1000c` | +1.60% | +1.20% | +2.01% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_16c` | +2.36% | +1.61% | +3.10% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_256c` | +2.03% | +1.07% | +3.00% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_4c` | +0.74% | -0.06% | +1.54% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_64c` | -0.36% | -1.01% | +0.30% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_1000c` | -3.18% | -4.72% | -1.60% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_16c` | +2.78% | +1.81% | +3.76% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_256c` | -2.73% | -3.20% | -2.24% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_4c` | +3.24% | +2.85% | +3.63% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_64c` | +1.98% | +1.46% | +2.51% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_1000c` | +0.50% | -0.04% | +1.05% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_16c` | -1.09% | -1.62% | -0.55% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_256c` | -0.49% | -1.84% | +0.89% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_4c` | -1.76% | -3.33% | -0.16% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_64c` | +1.42% | +0.89% | +1.96% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_1000c` | +0.03% | -2.39% | +2.54% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_16c` | +1.68% | +1.48% | +1.87% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_256c` | +2.56% | +1.08% | +4.06% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_4c` | +1.96% | +1.65% | +2.28% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c` | -1.14% | -2.76% | +0.51% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_1000c` | +0.17% | -1.50% | +1.86% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_16c` | +3.55% | +3.26% | +3.84% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_256c` | -1.24% | -1.68% | -0.81% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_4c` | +3.44% | +2.83% | +4.05% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_64c` | +1.73% | +0.51% | +2.96% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_1000c` | +5.76% | +4.28% | +7.24% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_16c` | -4.00% | -4.27% | -3.73% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_256c` | +0.97% | +0.24% | +1.70% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_4c` | -2.78% | -3.79% | -1.75% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_64c` | -0.34% | -1.27% | +0.59% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_1000c` | +1.48% | +0.75% | +2.23% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_16c` | +1.70% | +1.10% | +2.31% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_256c` | +2.57% | +2.35% | +2.78% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_4c` | +2.32% | +0.86% | +3.80% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_64c` | +2.78% | +2.48% | +3.08% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_1000c` | -5.37% | -5.93% | -4.81% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_16c` | +0.99% | -0.22% | +2.22% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_256c` | +0.64% | -1.43% | +2.73% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_4c` | +2.05% | +1.15% | +2.95% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_64c` | -1.84% | -3.11% | -0.55% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_1000c` | -0.63% | -1.29% | +0.02% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_16c` | +0.17% | -0.55% | +0.89% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_256c` | +2.71% | +2.01% | +3.40% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_4c` | +0.07% | -0.55% | +0.68% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_64c` | +2.36% | +1.45% | +3.28% |
| `simd_batch_dot_product/scalar_loop/10` | -2.15% | -3.45% | -0.84% |
| `simd_batch_dot_product/scalar_loop/100` | -1.25% | -2.56% | +0.06% |
| `simd_batch_dot_product/scalar_loop/1000` | -1.16% | -2.24% | -0.06% |
| `simd_batch_dot_product/simd_batch/10` | +1.19% | +0.44% | +1.94% |
| `simd_batch_dot_product/simd_batch/100` | -7.23% | -7.72% | -6.74% |
| `simd_batch_dot_product/simd_batch/1000` | -14.50% | -15.23% | -13.77% |
| `simd_cosine_similarity/scalar/1024` | -1.30% | -2.51% | -0.09% |
| `simd_cosine_similarity/scalar/1536` | -2.99% | -3.33% | -2.65% |
| `simd_cosine_similarity/scalar/384` | -0.55% | -0.83% | -0.27% |
| `simd_cosine_similarity/scalar/768` | -0.37% | -0.98% | +0.24% |
| `simd_cosine_similarity/simd/1024` | +0.22% | -1.03% | +1.48% |
| `simd_cosine_similarity/simd/1536` | -3.90% | -5.97% | -1.78% |
| `simd_cosine_similarity/simd/384` | -1.67% | -2.57% | -0.77% |
| `simd_cosine_similarity/simd/768` | -4.70% | -7.12% | -2.27% |
| `simd_dot_product/scalar/1024` | -2.72% | -2.91% | -2.53% |
| `simd_dot_product/scalar/1536` | -2.29% | -3.76% | -0.82% |
| `simd_dot_product/scalar/384` | -2.83% | -3.64% | -2.02% |
| `simd_dot_product/scalar/768` | -2.72% | -3.58% | -1.85% |
| `simd_dot_product/simd/1024` | -1.91% | -2.33% | -1.48% |
| `simd_dot_product/simd/1536` | -5.91% | -7.28% | -4.53% |
| `simd_dot_product/simd/384` | -3.21% | -4.08% | -2.34% |
| `simd_dot_product/simd/768` | -0.07% | -1.74% | +1.61% |
| `simd_euclidean_distance/scalar/1024` | -1.80% | -2.48% | -1.12% |
| `simd_euclidean_distance/scalar/1536` | +0.48% | +0.45% | +0.50% |
| `simd_euclidean_distance/scalar/384` | -1.69% | -1.99% | -1.38% |
| `simd_euclidean_distance/scalar/768` | -0.43% | -1.93% | +1.10% |
| `simd_euclidean_distance/simd/1024` | -1.86% | -2.08% | -1.64% |
| `simd_euclidean_distance/simd/1536` | -0.16% | -1.97% | +1.67% |
| `simd_euclidean_distance/simd/384` | -0.75% | -1.88% | +0.39% |
| `simd_euclidean_distance/simd/768` | -2.28% | -3.98% | -0.53% |
| `simd_normalize/scalar/1024` | +0.73% | -0.02% | +1.48% |
| `simd_normalize/scalar/1536` | -1.17% | -2.15% | -0.20% |
| `simd_normalize/scalar/384` | -2.17% | -2.90% | -1.43% |
| `simd_normalize/scalar/768` | -1.44% | -2.01% | -0.87% |
| `simd_normalize/simd/1024` | +0.62% | -2.44% | +3.71% |
| `simd_normalize/simd/1536` | -0.20% | -1.15% | +0.74% |
| `simd_normalize/simd/384` | -6.00% | -6.66% | -5.33% |
| `simd_normalize/simd/768` | -0.55% | -1.01% | -0.08% |
| `simd_normalized_cosine_fast_path/cosine_full/1024` | -1.59% | -3.27% | +0.10% |
| `simd_normalized_cosine_fast_path/cosine_full/384` | +2.38% | +1.75% | +3.01% |
| `simd_normalized_cosine_fast_path/cosine_full/768` | -0.18% | -1.10% | +0.74% |
| `simd_normalized_cosine_fast_path/dot_product/1024` | +1.17% | +0.45% | +1.88% |
| `simd_normalized_cosine_fast_path/dot_product/384` | +2.14% | +1.46% | +2.82% |
| `simd_normalized_cosine_fast_path/dot_product/768` | +0.35% | -0.75% | +1.46% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/1024` | +1.24% | +1.21% | +1.27% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/384` | +0.64% | -0.02% | +1.32% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/768` | +1.41% | +0.14% | +2.70% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/1024` | -0.18% | -1.51% | +1.17% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/384` | -0.15% | -0.62% | +0.32% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/768` | -1.24% | -4.14% | +1.76% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/1024` | +3.10% | +1.15% | +5.07% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/384` | -1.99% | -2.82% | -1.16% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/768` | +0.30% | -0.90% | +1.51% |
| `simd_query_batch_dot_product/pair_loop/128d_16c` | -2.83% | -3.13% | -2.54% |
| `simd_query_batch_dot_product/pair_loop/128d_256c` | +2.26% | +0.95% | +3.58% |
| `simd_query_batch_dot_product/pair_loop/128d_4c` | +1.51% | -0.25% | +3.29% |
| `simd_query_batch_dot_product/pair_loop/128d_64c` | -5.59% | -8.81% | -2.22% |
| `simd_query_batch_dot_product/pair_loop/384d_16c` | +1.62% | -0.69% | +3.99% |
| `simd_query_batch_dot_product/pair_loop/384d_256c` | +0.49% | -0.78% | +1.79% |
| `simd_query_batch_dot_product/pair_loop/384d_4c` | +1.65% | +0.70% | +2.61% |
| `simd_query_batch_dot_product/pair_loop/384d_64c` | -0.68% | -2.42% | +1.06% |
| `simd_query_batch_dot_product/pair_loop/768d_16c` | +0.26% | -0.80% | +1.34% |
| `simd_query_batch_dot_product/pair_loop/768d_256c` | +0.60% | -0.24% | +1.44% |
| `simd_query_batch_dot_product/pair_loop/768d_4c` | +0.70% | +0.35% | +1.06% |
| `simd_query_batch_dot_product/pair_loop/768d_64c` | -1.03% | -2.42% | +0.38% |
| `simd_query_batch_dot_product/simd_batch/128d_16c` | -1.17% | -1.40% | -0.94% |
| `simd_query_batch_dot_product/simd_batch/128d_256c` | +3.68% | +2.71% | +4.66% |
| `simd_query_batch_dot_product/simd_batch/128d_4c` | -0.41% | -0.78% | -0.04% |
| `simd_query_batch_dot_product/simd_batch/128d_64c` | +0.34% | +0.19% | +0.50% |
| `simd_query_batch_dot_product/simd_batch/384d_16c` | +0.96% | -0.06% | +1.98% |
| `simd_query_batch_dot_product/simd_batch/384d_256c` | -0.51% | -1.09% | +0.08% |
| `simd_query_batch_dot_product/simd_batch/384d_4c` | -0.72% | -1.85% | +0.42% |
| `simd_query_batch_dot_product/simd_batch/384d_64c` | -0.08% | -0.82% | +0.67% |
| `simd_query_batch_dot_product/simd_batch/768d_16c` | +0.19% | -0.56% | +0.95% |
| `simd_query_batch_dot_product/simd_batch/768d_256c` | +1.65% | +1.04% | +2.27% |
| `simd_query_batch_dot_product/simd_batch/768d_4c` | +4.51% | +2.40% | +6.63% |
| `simd_query_batch_dot_product/simd_batch/768d_64c` | +0.43% | +0.15% | +0.72% |
| `simd_squared_euclidean_fast_path/euclidean_full/1024` | +3.04% | +1.07% | +5.04% |
| `simd_squared_euclidean_fast_path/euclidean_full/384` | +1.56% | +0.44% | +2.69% |
| `simd_squared_euclidean_fast_path/euclidean_full/768` | -0.41% | -1.27% | +0.46% |
| `simd_squared_euclidean_fast_path/squared_euclidean/1024` | +2.09% | +1.63% | +2.56% |
| `simd_squared_euclidean_fast_path/squared_euclidean/384` | +1.96% | +1.68% | +2.24% |
| `simd_squared_euclidean_fast_path/squared_euclidean/768` | +1.43% | -0.37% | +3.24% |
| `simd_throughput_384/cosine_similarity` | -0.43% | -0.68% | -0.18% |
| `simd_throughput_384/dot_product` | +0.02% | +0.00% | +0.04% |
| `simd_throughput_384/euclidean_distance` | -1.98% | -2.77% | -1.19% |
| `simd_throughput_384/normalize` | -3.24% | -3.36% | -3.13% |
| `softmax_attention/128` | +22.45% | +20.75% | +24.15% |
| `softmax_attention/512` | +20.87% | +20.45% | +21.28% |
| `tier_prepared_batch_sizes/int4_batch_prepared/10` | +0.59% | -1.01% | +2.20% |
| `tier_prepared_batch_sizes/int4_batch_prepared/100` | -0.76% | -1.07% | -0.45% |
| `tier_prepared_batch_sizes/int4_batch_prepared/1000` | +1.10% | +0.72% | +1.48% |
| `tier_prepared_batch_sizes/int4_query_per_call/10` | -1.28% | -2.62% | +0.08% |
| `tier_prepared_batch_sizes/int4_query_per_call/100` | -1.32% | -2.02% | -0.61% |
| `tier_prepared_batch_sizes/int4_query_per_call/1000` | +1.23% | +0.34% | +2.15% |
| `tier_prepared_batch_sizes/int8_batch_prepared/10` | -1.50% | -3.03% | +0.04% |
| `tier_prepared_batch_sizes/int8_batch_prepared/100` | +0.85% | +0.46% | +1.24% |
| `tier_prepared_batch_sizes/int8_batch_prepared/1000` | +1.79% | +0.91% | +2.66% |
| `tier_prepared_batch_sizes/int8_query_per_call/10` | +0.61% | -0.04% | +1.26% |
| `tier_prepared_batch_sizes/int8_query_per_call/100` | +0.70% | -0.28% | +1.68% |
| `tier_prepared_batch_sizes/int8_query_per_call/1000` | -0.79% | -1.50% | -0.07% |
| `tier_prepared_query/binary_query_once_1000` | -2.25% | -3.67% | -0.81% |
| `tier_prepared_query/binary_query_per_call_1000` | +1.27% | +0.10% | +2.45% |
| `tier_prepared_query/int4_query_once_1000` | -1.73% | -2.63% | -0.80% |
| `tier_prepared_query/int4_query_per_call_1000` | +0.53% | -0.00% | +1.07% |
| `tier_prepared_query/int8_query_once_1000` | -2.23% | -2.39% | -2.07% |
| `tier_prepared_query/int8_query_per_call_1000` | +0.45% | +0.06% | +0.85% |

</details>

_Rule: CI-lower of change ≤3.0% passes silently; (3.0%, 7.0%] warns; >7.0% fails. Override via PR label `bench-allow-regression`._


Done. Base=origin/main (41cda99f1), Head=HEAD (d4a606f40)
```

</details>

<details>
<summary>Round 2 raw bench-compare output (Run B, full default suite, softmax_attention rows highlighted)</summary>

```
=== Full gate report ===
### `local-compare` — perf regression report

**❌ 2 FAIL** (regression >7.0% confirmed by 95% CI) — both `lattice-embed` SIMD noise (#714),
unrelated to this PR's inference changes: `simd_euclidean_distance/scalar/1536` (+10.73%),
`simd_cosine_similarity/simd/768` (+8.94%).
**⚠ 21 WARN** — `lattice-embed` SIMD noise, same class, unrelated to this PR.
**🚀 15 confirmed improvement**, including both `softmax_attention` groups:

| Bench | Δ point | 95% CI | new ns | base ns | verdict |
|---|---:|---|---:|---:|---|
| `softmax_attention/128` | -9.95% | [-10.30%, -9.59%] | 3960.6 | 4398.1 | 🚀 WIN |
| `softmax_attention/512` | -6.28% | [-7.36%, -5.19%] | 70889.3 | 75637.5 | 🚀 WIN |

Base=d4a606f40, Head=HEAD (working tree with round-2 fixes, uncommitted at capture time).
```

</details>


