### PR TITLE
refactor(inference): backend-neutral decode policy, apply-or-fail-closed (ADR-080 C3)

### DIFF
--- a/crates/inference/src/forward/batch_prefill.rs
+++ b/crates/inference/src/forward/batch_prefill.rs
@@ -26,7 +26,8 @@ use crate::forward::cpu::{elementwise_mul, matmul_bt, silu_inplace};
 use crate::model::qwen35::{
     AttentionWeights, CommonLayerWeights, DenseFfnWeights, FeedForwardWeights, ForwardScratch,
     FullAttentionLayerWeights, KvCache, Qwen35Model, check_grammar_not_set, check_logprobs_not_set,
-    decode_tokens, qwen35_rms_norm, resize, sample_token, should_stop_token,
+    check_reasoning_budget_not_set, check_stop_strings_not_set, decode_tokens, qwen35_rms_norm,
+    resize, sample_token, should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::stop_reason::StopReason;
@@ -432,6 +433,10 @@ impl Qwen35Model {
         // Same rationale for logprobs capture, which is also not wired into this
         // generate loop (#585).
         check_logprobs_not_set(gen_cfg)?;
+        // Same rationale for stop_strings matching and reasoning-budget forcing,
+        // neither of which is wired into this generate loop (ADR-080 C3, #783).
+        check_stop_strings_not_set(gen_cfg)?;
+        check_reasoning_budget_not_set(gen_cfg)?;
         // Context preflight. apply_partial_rope indexes the precomputed cos/sin table
         // without bounds checks, so a position at or past max_context() is an out-of-bounds
         // slice access — a release panic, not a clean error. Mirror the same total-token
@@ -2072,6 +2077,60 @@ mod tests {
             matches!(result, Err(InferenceError::InvalidInput(_))),
             "generate_with_batch_prefill must fail closed with InvalidInput when grammar is \
              set (#397/#398); got {result:?}"
+        );
+    }
+
+    /// `generate_with_batch_prefill` must reject a `GenerateConfig` that sets
+    /// `stop_strings` with a typed `InvalidInput` error before sampling any token
+    /// (ADR-080 C3, #783).
+    ///
+    /// Mutation sensitivity: removing `check_stop_strings_not_set` causes the
+    /// function to proceed through the full prefill + decode path with the tiny
+    /// weights, returning `Ok(...)`. The `matches!` assert then fails.
+    #[test]
+    fn generate_with_batch_prefill_rejects_stop_strings_config_before_sampling() {
+        use crate::error::InferenceError;
+
+        let cfg = tiny_test_config();
+        let model = build_random_model(cfg, 0x1234_5678_abcd_ef01);
+
+        let gen_cfg = GenerateConfig {
+            stop_strings: vec!["</s>".to_string()],
+            ..Default::default()
+        };
+
+        let result = model.generate_with_batch_prefill("a b c", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "generate_with_batch_prefill must fail closed with InvalidInput when \
+             stop_strings is set (ADR-080 C3, #783); got {result:?}"
+        );
+    }
+
+    /// `generate_with_batch_prefill` must reject a `GenerateConfig` that sets
+    /// `reasoning_budget` with a typed `InvalidInput` error before sampling any
+    /// token (ADR-080 C3, #783).
+    ///
+    /// Mutation sensitivity: removing `check_reasoning_budget_not_set` causes the
+    /// function to proceed through the full prefill + decode path with the tiny
+    /// weights, returning `Ok(...)`. The `matches!` assert then fails.
+    #[test]
+    fn generate_with_batch_prefill_rejects_reasoning_budget_config_before_sampling() {
+        use crate::error::InferenceError;
+
+        let cfg = tiny_test_config();
+        let model = build_random_model(cfg, 0x1234_5678_abcd_ef01);
+
+        let gen_cfg = GenerateConfig {
+            reasoning_budget: Some(16),
+            ..Default::default()
+        };
+
+        let result = model.generate_with_batch_prefill("a b c", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "generate_with_batch_prefill must fail closed with InvalidInput when \
+             reasoning_budget is set (ADR-080 C3, #783); got {result:?}"
         );
     }
 

--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -891,6 +891,10 @@ pub fn generate_f16(
     // Same rationale for logprobs capture, which is also not wired into this
     // generate loop (#585).
     crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
+    // Same rationale for stop_strings matching and reasoning-budget forcing,
+    // neither of which is wired into this generate loop (ADR-080 C3, #783).
+    crate::model::qwen35::check_stop_strings_not_set(gen_cfg)?;
+    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
 
     // Context preflight. The RoPE cos/sin tables are indexed unchecked in
     // forward_step_f16 (`rope.cos_at(base + i)`), so a position at or past the
@@ -1884,6 +1888,90 @@ mod tests {
             matches!(result, Err(InferenceError::InvalidInput(_))),
             "generate_f16 must fail closed with InvalidInput when grammar is set (#397/#398); \
              got {result:?}"
+        );
+    }
+
+    /// `generate_f16` must reject a `GenerateConfig` that sets `stop_strings` with a
+    /// typed `InvalidInput` error before sampling any token (ADR-080 C3, #783).
+    ///
+    /// Mutation sensitivity: removing the `check_stop_strings_not_set` call makes the
+    /// function proceed past the guard and attempt to forward with empty weights,
+    /// producing a panic or a non-`InvalidInput` error — this assert fails either way.
+    #[test]
+    fn generate_f16_rejects_stop_strings_config_before_sampling() {
+        use crate::error::InferenceError;
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let weights = F16ModelWeights {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            layers: vec![],
+        };
+
+        let gen_cfg = GenerateConfig {
+            stop_strings: vec!["</s>".to_string()],
+            ..Default::default()
+        };
+
+        let result = generate_f16(&weights, &cfg, &tokenizer, &rope, "hello", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "generate_f16 must fail closed with InvalidInput when stop_strings is set \
+             (ADR-080 C3, #783); got {result:?}"
+        );
+    }
+
+    /// `generate_f16` must reject a `GenerateConfig` that sets `reasoning_budget` with
+    /// a typed `InvalidInput` error before sampling any token (ADR-080 C3, #783).
+    ///
+    /// Mutation sensitivity: removing the `check_reasoning_budget_not_set` call makes
+    /// the function proceed past the guard and attempt to forward with empty weights,
+    /// producing a panic or a non-`InvalidInput` error — this assert fails either way.
+    #[test]
+    fn generate_f16_rejects_reasoning_budget_config_before_sampling() {
+        use crate::error::InferenceError;
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let weights = F16ModelWeights {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            layers: vec![],
+        };
+
+        let gen_cfg = GenerateConfig {
+            reasoning_budget: Some(16),
+            ..Default::default()
+        };
+
+        let result = generate_f16(&weights, &cfg, &tokenizer, &rope, "hello", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "generate_f16 must fail closed with InvalidInput when reasoning_budget is set \
+             (ADR-080 C3, #783); got {result:?}"
         );
     }
 

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -743,6 +743,10 @@ pub fn generate_q8(
     // Same rationale for logprobs capture, which is also not wired into this
     // generate loop (#585).
     crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
+    // Same rationale for stop_strings matching and reasoning-budget forcing,
+    // neither of which is wired into this generate loop (ADR-080 C3, #783).
+    crate::model::qwen35::check_stop_strings_not_set(gen_cfg)?;
+    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
 
     // Context preflight. The RoPE cos/sin tables are indexed unchecked in
     // full_attention_step_q8 (`rope.cos_at(position * half + i)`), so a position
@@ -1595,6 +1599,93 @@ mod tests {
             matches!(result, Err(InferenceError::InvalidInput(_))),
             "generate_q8 must fail closed with InvalidInput when grammar is set (#397/#398); \
              got {result:?}"
+        );
+    }
+
+    /// `generate_q8` must reject a `GenerateConfig` that sets `stop_strings` with a
+    /// typed `InvalidInput` error before sampling any token (ADR-080 C3, #783).
+    ///
+    /// Mirrors `generate_q8_rejects_grammar_config_before_sampling`'s structure: the
+    /// guard fires before any weight dereference, so empty weight vecs are sufficient.
+    ///
+    /// Mutation sensitivity: removing the `check_stop_strings_not_set` call makes the
+    /// function proceed past the guard and attempt to forward with empty weights,
+    /// producing a panic or a non-`InvalidInput` error — this assert fails either way.
+    #[test]
+    fn generate_q8_rejects_stop_strings_config_before_sampling() {
+        use crate::error::InferenceError;
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let weights = Q8ModelWeights {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            layers: vec![],
+        };
+
+        let gen_cfg = GenerateConfig {
+            stop_strings: vec!["</s>".to_string()],
+            ..Default::default()
+        };
+
+        let result = generate_q8(&weights, &cfg, &tokenizer, &rope, "hello", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "generate_q8 must fail closed with InvalidInput when stop_strings is set \
+             (ADR-080 C3, #783); got {result:?}"
+        );
+    }
+
+    /// `generate_q8` must reject a `GenerateConfig` that sets `reasoning_budget` with
+    /// a typed `InvalidInput` error before sampling any token (ADR-080 C3, #783).
+    ///
+    /// Mutation sensitivity: removing the `check_reasoning_budget_not_set` call makes
+    /// the function proceed past the guard and attempt to forward with empty weights,
+    /// producing a panic or a non-`InvalidInput` error — this assert fails either way.
+    #[test]
+    fn generate_q8_rejects_reasoning_budget_config_before_sampling() {
+        use crate::error::InferenceError;
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let weights = Q8ModelWeights {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            layers: vec![],
+        };
+
+        let gen_cfg = GenerateConfig {
+            reasoning_budget: Some(16),
+            ..Default::default()
+        };
+
+        let result = generate_q8(&weights, &cfg, &tokenizer, &rope, "hello", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "generate_q8 must fail closed with InvalidInput when reasoning_budget is set \
+             (ADR-080 C3, #783); got {result:?}"
         );
     }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -558,6 +558,13 @@ mod mtp_resolve_tests {
 /// `gen_cfg.stop_strings.is_empty()` is load-bearing: MTP's draft/verify loop
 /// has no string-stop awareness, so any non-empty `stop_strings` must route
 /// around it to the plain loop (which does check stops after every token).
+///
+/// `gen_cfg.reasoning_budget.is_none()` is the same kind of load-bearing
+/// route-around (ADR-080 C3, #783): MTP's draft/verify loop has no
+/// budget-forcing awareness (no `decode_cap` / `force_close_think` wiring),
+/// so any set `reasoning_budget` must route around it to the plain loop,
+/// which either applies budget forcing or rejects the config via
+/// `check_reasoning_budget_not_set`.
 #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
 fn mtp_route_active(
     mtp_present: bool,
@@ -572,12 +579,13 @@ fn mtp_route_active(
         && !use_compact
         && gen_cfg.grammar.is_none()
         && gen_cfg.stop_strings.is_empty()
+        && gen_cfg.reasoning_budget.is_none()
 }
 
 /// Whether `generate()` should take the GDN-first self-speculative greedy
 /// branch. Mirrors the `use_self_spec` computation inline in
-/// `MetalQwen35State::generate` exactly -- same `stop_strings.is_empty()`
-/// route-around rationale as [`mtp_route_active`].
+/// `MetalQwen35State::generate` exactly -- same `stop_strings.is_empty()` /
+/// `reasoning_budget.is_none()` route-around rationale as [`mtp_route_active`].
 #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
 fn self_spec_route_active(
     gdn_checkpoints_present: bool,
@@ -593,6 +601,7 @@ fn self_spec_route_active(
         && !use_compact
         && gen_cfg.grammar.is_none()
         && gen_cfg.stop_strings.is_empty()
+        && gen_cfg.reasoning_budget.is_none()
         && num_active_linear_attention_layers > 0
 }
 
@@ -661,6 +670,43 @@ mod route_predicate_tests {
             !self_spec_route_active(true, true, &gen_cfg, false, 1),
             "self-spec must not activate when stop_strings is non-empty -- \
              same string-stop-unaware draft/verify loop as MTP"
+        );
+    }
+
+    /// ADR-080 C3 (#783): a set `reasoning_budget` must route around MTP even
+    /// though every other MTP precondition is satisfied -- MTP's draft/verify
+    /// loop has no budget-forcing (`decode_cap` / `force_close_think`)
+    /// awareness, mirroring the `stop_strings` route-around above.
+    ///
+    /// Mutation sensitivity: removing the `reasoning_budget.is_none()` clause
+    /// from `mtp_route_active` makes this assertion fail (the route stays
+    /// active), which would silently drop the caller's reasoning budget once
+    /// MTP takes over decoding.
+    #[test]
+    fn mtp_route_blocked_by_set_reasoning_budget() {
+        let gen_cfg = GenerateConfig {
+            reasoning_budget: Some(64),
+            ..greedy_gen_cfg(vec![])
+        };
+        assert!(
+            !mtp_route_active(true, true, &gen_cfg, false),
+            "MTP must not activate when reasoning_budget is set -- its \
+             draft/verify loop has no budget-forcing awareness"
+        );
+    }
+
+    /// Sibling to `mtp_route_blocked_by_set_reasoning_budget` for the
+    /// self-speculative route (ADR-080 C3, #783).
+    #[test]
+    fn self_spec_route_blocked_by_set_reasoning_budget() {
+        let gen_cfg = GenerateConfig {
+            reasoning_budget: Some(64),
+            ..greedy_gen_cfg(vec![])
+        };
+        assert!(
+            !self_spec_route_active(true, true, &gen_cfg, false, 1),
+            "self-spec must not activate when reasoning_budget is set -- same \
+             budget-forcing-unaware draft/verify loop as MTP"
         );
     }
 }
@@ -7855,14 +7901,11 @@ mod inner {
                 };
             }
 
-            // Greedy argmax from prefill logits.
-            let pending_first = prefill_logits
-                .iter()
-                .copied()
-                .enumerate()
-                .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-                .map(|(i, _)| i as u32)
-                .unwrap_or(0);
+            // Greedy argmax from prefill logits. Shared first-wins helper
+            // (ADR-080 C3, #783) rather than a hand-rolled `max_by`, which
+            // keeps the LAST tied maximum instead of the engine-wide-contract
+            // first tied maximum.
+            let pending_first = crate::sampling::argmax_f32_first_wins(prefill_logits);
 
             let is_stop = |id: u32| id == cfg.eos_token_id || gen_cfg.stop_token_ids.contains(&id);
 
@@ -8100,15 +8143,10 @@ mod inner {
                 };
             }
 
-            let argmax_logits = |logits: &[f32]| -> u32 {
-                logits
-                    .iter()
-                    .copied()
-                    .enumerate()
-                    .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-                    .map(|(i, _)| i as u32)
-                    .unwrap_or(0)
-            };
+            // Shared first-wins argmax helper (ADR-080 C3, #783) rather than a
+            // hand-rolled `max_by` closure, which kept the LAST tied maximum
+            // instead of the engine-wide-contract first tied maximum.
+            let argmax_logits = crate::sampling::argmax_f32_first_wins;
 
             let is_stop = |id: u32| id == cfg.eos_token_id || gen_cfg.stop_token_ids.contains(&id);
 
@@ -8453,6 +8491,16 @@ mod inner {
                     token_logprobs: vec![],
                 });
             }
+
+            // Reject reasoning_budget before any prefill/state work (ADR-080 C3,
+            // #783): budget-forcing (`decode_cap` / `force_close_think`) is not
+            // wired into this decode loop, unlike `generate_streaming` /
+            // `generate_streaming_with_cancel` below, which do apply it. Without
+            // this guard the field would be silently ignored, producing
+            // unbudgeted output despite a reasoning budget being requested.
+            // `stop_strings` does not need an equivalent guard here: this loop
+            // already applies it via `stop_text_state` further down.
+            crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
 
             // Fail-closed: a prompt longer than the KV cache would trip the
             // forward_prefill length assertion (n <= max_cache_len) and panic the
@@ -22779,6 +22827,54 @@ mod inner {
             );
         }
 
+        /// `MetalQwen35State::generate` (the plain/direct entry point) must
+        /// reject a `GenerateConfig` with `reasoning_budget` set, with a typed
+        /// `InvalidInput` error, rather than silently ignoring the budget and
+        /// generating unbudgeted output (ADR-080 C3, #783).
+        ///
+        /// This is the production-seam test for the guard added to `generate`
+        /// itself, proving the call site is real — `route_predicate_tests`
+        /// and `multimodal_preflight_tests` already cover the pure guard
+        /// logic without a GPU device.
+        ///
+        /// Mutation sensitivity: removing the `check_reasoning_budget_not_set`
+        /// call from `generate` lets this request proceed through prefill and
+        /// sampling instead of erroring, so `result.is_err()` fails.
+        #[test]
+        fn metal_generate_plain_rejects_reasoning_budget_config() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 4,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(42),
+                stop_token_ids: vec![],
+                enable_thinking: true,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: Some(2),
+                logprobs: None,
+            };
+
+            let result = state.generate("a", &tokenizer, &gen_cfg);
+            assert!(
+                matches!(result, Err(crate::error::InferenceError::InvalidInput(_))),
+                "MetalQwen35State::generate must fail closed with InvalidInput when \
+                 reasoning_budget is set (ADR-080 C3, #783); got {result:?}"
+            );
+        }
+
         /// `generate_streaming`'s `max_new_tokens == 0` guard must return before the
         /// prefill token is sampled, pushed, or streamed, matching the CPU
         /// `generate_streaming()` contract (model::qwen35::generation): zero tokens,
@@ -27601,6 +27697,12 @@ mod topk_boundary_tie_tests {
 /// wired into this path either, so `gen_cfg.logprobs` is rejected the same
 /// way rather than silently returning an empty `token_logprobs`.
 ///
+/// Reasoning-budget forcing (ADR-080 C3, #783) is not wired into this path
+/// either (no `decode_cap` / `force_close_think`), so `gen_cfg.reasoning_budget`
+/// is rejected the same way. `gen_cfg.stop_strings` does NOT need an
+/// equivalent guard here: `generate_multimodal` already applies it via its own
+/// `stop_text_state` / `StopStringMatcher` wiring further down.
+///
 /// Compiled when Metal-GPU is enabled (the production caller lives inside
 /// `mod inner`) or during test builds so that the module-level test can
 /// exercise the guard logic on any platform without GPU hardware.
@@ -27609,7 +27711,8 @@ pub(crate) fn multimodal_generate_preflight(
     gen_cfg: &crate::model::qwen35_config::GenerateConfig,
 ) -> Result<(), crate::error::InferenceError> {
     crate::model::qwen35::check_grammar_not_set(gen_cfg)?;
-    crate::model::qwen35::check_logprobs_not_set(gen_cfg)
+    crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
+    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)
 }
 
 #[cfg(test)]
@@ -27682,6 +27785,39 @@ mod multimodal_preflight_tests {
         assert!(
             multimodal_generate_preflight(&GenerateConfig::default()).is_ok(),
             "logprobs = None must not trigger the preflight guard"
+        );
+    }
+
+    /// Reasoning-budget forcing (ADR-080 C3, #783) is not wired into the
+    /// multimodal path; the preflight must reject a config with
+    /// `reasoning_budget` set rather than silently returning an unbudgeted
+    /// output.
+    ///
+    /// Mutation sensitivity: change `multimodal_generate_preflight` to always
+    /// return `Ok(())` (or drop the new `check_reasoning_budget_not_set` call)
+    /// → `result.is_err()` below fails, catching the regression.
+    #[test]
+    fn generate_multimodal_reasoning_budget_guard_rejects_budget_config() {
+        let cfg_with_budget = GenerateConfig {
+            reasoning_budget: Some(32),
+            ..Default::default()
+        };
+
+        let result = multimodal_generate_preflight(&cfg_with_budget);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "multimodal preflight must return InvalidInput when reasoning_budget is set; \
+             got {result:?}"
+        );
+    }
+
+    /// A config with `reasoning_budget` unset must pass through the preflight
+    /// without error.
+    #[test]
+    fn generate_multimodal_reasoning_budget_guard_allows_no_budget() {
+        assert!(
+            multimodal_generate_preflight(&GenerateConfig::default()).is_ok(),
+            "reasoning_budget = None must not trigger the preflight guard"
         );
     }
 }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -13213,6 +13213,11 @@ mod inner {
             // independently. `prefill_logits` is untouched since
             // `forward_prefill()` populated it above, and reflects the same
             // distribution `next_id` was sampled from.
+            // `streaming: true` selects `StopMode::Streaming`'s incremental
+            // byte-holdback for a non-empty `gen_cfg.stop_strings` (codex
+            // round-3 major #1, PR #787 / Leo's ruling) -- `policy.stop_mode`
+            // now owns the `StopStringMatcher` this call site used to
+            // construct and drive by hand.
             let mut policy = crate::model::qwen35::DecodePolicy::init(
                 gen_cfg,
                 think_close_id,
@@ -13221,79 +13226,56 @@ mod inner {
                 &prefill_logits,
                 gen_cfg.temperature,
                 generated_ids.len(),
+                true,
             );
             let mut last_pushed_id = next_id;
             // `text` is the caller-owned full output — the detokenizer itself only
             // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
             let mut text = String::new();
-            // String-stop path: mirrors the CPU stop-string matcher exactly (#643).
-            // Holds back a partial suffix that could still become a stop match, so
-            // `text`/`on_token` never see a stop string that spans a token boundary.
-            let mut stop_matcher = if gen_cfg.stop_strings.is_empty() {
-                None
-            } else {
-                Some(StopStringMatcher::new(&gen_cfg.stop_strings))
-            };
+            let mut throwaway_offsets: Vec<usize> = Vec::new();
             let delta = detok.push(tokenizer, next_id);
-            if !delta.is_empty() {
-                if let Some(matcher) = stop_matcher.as_mut() {
-                    let mut caller_interrupted = false;
-                    let stop_matched = matcher.push(&delta, &mut |emit| {
-                        if !caller_interrupted && !emit.is_empty() {
-                            text.push_str(emit);
-                            if !on_token(emit, next_id) {
-                                caller_interrupted = true;
-                            }
-                        }
-                    });
-                    if caller_interrupted {
-                        if use_compact {
-                            self.session.compact_topk = 0;
-                            self.session.compact_route = GpuTopkRoute::CpuFallback;
-                        }
-                        return Ok(GenerateOutput {
-                            text,
-                            token_ids: generated_ids.clone(),
-                            prompt_tokens: prompt_len,
-                            generated_tokens: generated_ids.len(),
-                            stopped: false, // caller interrupted the stream, not a stop condition
-                            stop_reason: Some(StopReason::Interrupt),
-                            token_logprobs: token_logprobs.clone(),
-                        });
-                    }
-                    if stop_matched {
-                        if use_compact {
-                            self.session.compact_topk = 0;
-                            self.session.compact_route = GpuTopkRoute::CpuFallback;
-                        }
-                        return Ok(GenerateOutput {
-                            text,
-                            token_ids: generated_ids.clone(),
-                            prompt_tokens: prompt_len,
-                            generated_tokens: generated_ids.len(),
-                            stopped: true,
-                            stop_reason: Some(StopReason::Eos),
-                            token_logprobs: token_logprobs.clone(),
-                        });
-                    }
-                } else {
-                    text.push_str(&delta);
-                    if !on_token(&delta, next_id) {
-                        if use_compact {
-                            self.session.compact_topk = 0;
-                            self.session.compact_route = GpuTopkRoute::CpuFallback;
-                        }
-                        return Ok(GenerateOutput {
-                            text,
-                            token_ids: generated_ids.clone(),
-                            prompt_tokens: prompt_len,
-                            generated_tokens: generated_ids.len(),
-                            stopped: false, // caller interrupted the stream, not a stop condition
-                            stop_reason: Some(StopReason::Interrupt),
-                            token_logprobs: token_logprobs.clone(),
-                        });
-                    }
+            let initial_outcome = policy.check_initial_stop(
+                &mut token_logprobs,
+                &mut text,
+                &mut throwaway_offsets,
+                &delta,
+                |s| on_token(s, next_id),
+            );
+            if matches!(
+                initial_outcome,
+                crate::model::qwen35::StopCheckOutcome::Interrupted
+            ) {
+                if use_compact {
+                    self.session.compact_topk = 0;
+                    self.session.compact_route = GpuTopkRoute::CpuFallback;
                 }
+                return Ok(GenerateOutput {
+                    text,
+                    token_ids: generated_ids.clone(),
+                    prompt_tokens: prompt_len,
+                    generated_tokens: generated_ids.len(),
+                    stopped: false, // caller interrupted the stream, not a stop condition
+                    stop_reason: Some(StopReason::Interrupt),
+                    token_logprobs: token_logprobs.clone(),
+                });
+            }
+            if matches!(
+                initial_outcome,
+                crate::model::qwen35::StopCheckOutcome::Stopped
+            ) {
+                if use_compact {
+                    self.session.compact_topk = 0;
+                    self.session.compact_route = GpuTopkRoute::CpuFallback;
+                }
+                return Ok(GenerateOutput {
+                    text,
+                    token_ids: generated_ids.clone(),
+                    prompt_tokens: prompt_len,
+                    generated_tokens: generated_ids.len(),
+                    stopped: true,
+                    stop_reason: Some(StopReason::Eos),
+                    token_logprobs: token_logprobs.clone(),
+                });
             }
             let mut stopped = false;
             let mut stopped_by_caller = false;
@@ -13355,12 +13337,12 @@ mod inner {
                 // This is fail-closed (no grammar-illegal output emitted) but silent. The
                 // combination of grammar + reasoning_budget is unusual; document, don't change.
                 //
-                // The `stop_check` closure (codex round-2 major #2, PR #787 /
-                // Leo's ruling) owns this path's detok + (optional)
-                // `StopStringMatcher` byte-holdback check + `on_token` sink --
-                // moving it into the mandatory callback makes it structurally
-                // impossible for this call site to invoke `transition` while
-                // skipping the stop check.
+                // `policy.stop_mode` (fixed to `StopMode::Streaming` or
+                // `Disabled` at construction) now owns this path's byte-
+                // holdback stop check itself (codex round-3 major #1, PR
+                // #787 / Leo's ruling) -- this call site supplies only
+                // `decode_delta` (this loop's own detokenizer) and the
+                // shared `text`/`throwaway_offsets` buffers.
                 let generated_len_before = generated_ids.len();
                 let outcome = policy.transition(
                     &mut token_logprobs,
@@ -13380,35 +13362,10 @@ mod inner {
                         generated_ids.push(next_id);
                         all_ids.push(next_id);
                     },
-                    |next_id, _token_logprobs| {
-                        let delta = detok.push(tokenizer, next_id);
-                        if delta.is_empty() {
-                            return crate::model::qwen35::StopCheckOutcome::Continue;
-                        }
-                        if let Some(matcher) = stop_matcher.as_mut() {
-                            let mut caller_interrupted = false;
-                            let stop_matched = matcher.push(&delta, &mut |emit| {
-                                if !caller_interrupted && !emit.is_empty() {
-                                    text.push_str(emit);
-                                    if !on_token(emit, next_id) {
-                                        caller_interrupted = true;
-                                    }
-                                }
-                            });
-                            if caller_interrupted {
-                                return crate::model::qwen35::StopCheckOutcome::Interrupted;
-                            }
-                            if stop_matched {
-                                return crate::model::qwen35::StopCheckOutcome::Stopped;
-                            }
-                        } else {
-                            text.push_str(&delta);
-                            if !on_token(&delta, next_id) {
-                                return crate::model::qwen35::StopCheckOutcome::Interrupted;
-                            }
-                        }
-                        crate::model::qwen35::StopCheckOutcome::Continue
-                    },
+                    |next_id| detok.push(tokenizer, next_id),
+                    &mut text,
+                    &mut throwaway_offsets,
+                    |s, next_id| on_token(s, next_id),
                 );
 
                 let (next_id, answer_budget_exhausted) = match outcome {
@@ -13456,30 +13413,18 @@ mod inner {
             // so streamed deltas concatenate to exactly the returned text. Skip when
             // the caller asked to stop — it is no longer consuming the stream.
             if !stopped_by_caller {
+                // This flush emits the residual incomplete-UTF-8 bytes of the
+                // already-generated final token, not a new generation step —
+                // generation has already terminated for the stop_reason decided
+                // above. A late cancel here (return value intentionally unused)
+                // does not change why generation stopped, so treating it as
+                // Interrupt would misattribute the stop cause to this flush.
                 let tail = detok.finish();
-                if let Some(matcher) = stop_matcher.as_mut() {
-                    // No-op if a stop already matched inside the loop; otherwise a
-                    // stop string can still complete in the final detokenizer tail.
-                    let already_stopped = matcher.stopped();
-                    matcher.finish(&tail, &mut |emit| {
-                        if !emit.is_empty() {
-                            text.push_str(emit);
-                            on_token(emit, last_pushed_id);
-                        }
-                    });
-                    if !already_stopped && matcher.stopped() {
-                        stopped = true;
-                        stop_reason = StopReason::Eos;
-                    }
-                } else if !tail.is_empty() {
-                    // This flush emits the residual incomplete-UTF-8 bytes of the
-                    // already-generated final token, not a new generation step —
-                    // generation has already terminated for the stop_reason decided
-                    // above. A late cancel here (return value intentionally unused)
-                    // does not change why generation stopped, so treating it as
-                    // Interrupt would misattribute the stop cause to this flush.
-                    text.push_str(&tail);
-                    on_token(&tail, last_pushed_id);
+                let tail_stopped =
+                    policy.finish_stop(&mut text, &tail, |s| on_token(s, last_pushed_id));
+                if tail_stopped && !stopped {
+                    stopped = true;
+                    stop_reason = StopReason::Eos;
                 }
             }
             Ok(GenerateOutput {
@@ -15775,6 +15720,11 @@ mod inner {
             // so this site is structurally indistinguishable from the other
             // five at the `DecodePolicy::init` / `transition` call sites.
             let mut token_logprobs: Vec<TokenLogprob> = Vec::new();
+            // `streaming: true` selects `StopMode::Streaming`'s incremental
+            // byte-holdback for a non-empty `gen_cfg.stop_strings` (codex
+            // round-3 major #1, PR #787 / Leo's ruling) -- `policy.stop_mode`
+            // now owns the `StopStringMatcher` this call site used to
+            // construct and drive by hand.
             let mut policy = crate::model::qwen35::DecodePolicy::init(
                 gen_cfg,
                 think_close_id,
@@ -15783,98 +15733,74 @@ mod inner {
                 &prefill_logits,
                 gen_cfg.temperature,
                 generated_ids.len(),
+                true,
             );
             let mut last_pushed_id = next_id;
             // `text` is the caller-owned full output — the detokenizer itself only
             // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
             let mut text = String::new();
-            // String-stop path: mirrors the CPU stop-string matcher exactly (#643).
-            let mut stop_matcher = if gen_cfg.stop_strings.is_empty() {
-                None
-            } else {
-                Some(StopStringMatcher::new(&gen_cfg.stop_strings))
-            };
+            let mut throwaway_offsets: Vec<usize> = Vec::new();
             // Set when a stop string matches: CPU-identical semantics can retain
             // token ids whose text was truncated, so the tokens behind a
             // string-stop match must never be saved into the cross-turn cache —
             // that would represent text the caller never received.
             let mut stopped_by_stop_string = false;
             let delta = detok.push(tokenizer, next_id);
-            if !delta.is_empty() {
-                if let Some(matcher) = stop_matcher.as_mut() {
-                    let mut caller_interrupted = false;
-                    let stop_matched = matcher.push(&delta, &mut |emit| {
-                        if !caller_interrupted && !emit.is_empty() {
-                            text.push_str(emit);
-                            if !on_token(emit, next_id) {
-                                caller_interrupted = true;
-                            }
-                        }
-                    });
-                    if caller_interrupted {
-                        if use_compact {
-                            self.session.compact_topk = 0;
-                            self.session.compact_route = GpuTopkRoute::CpuFallback;
-                        }
-                        return Ok(CachedGenerateOutput {
-                            output: GenerateOutput {
-                                text,
-                                token_ids: generated_ids.clone(),
-                                prompt_tokens: prompt_len,
-                                generated_tokens: generated_ids.len(),
-                                stopped: false,
-                                stop_reason: Some(StopReason::Interrupt),
-                                token_logprobs: vec![],
-                            },
-                            cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
-                        });
-                    }
-                    if stop_matched {
-                        if use_compact {
-                            self.session.compact_topk = 0;
-                            self.session.compact_route = GpuTopkRoute::CpuFallback;
-                        }
-                        self.cross_turn_prefix_cache.remove(slot_id);
-                        return Ok(CachedGenerateOutput {
-                            output: GenerateOutput {
-                                text,
-                                token_ids: generated_ids.clone(),
-                                prompt_tokens: prompt_len,
-                                generated_tokens: generated_ids.len(),
-                                stopped: true,
-                                stop_reason: Some(StopReason::Eos),
-                                token_logprobs: vec![],
-                            },
-                            cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
-                        });
-                    }
-                } else {
-                    text.push_str(&delta);
-                    if !on_token(&delta, next_id) {
-                        if use_compact {
-                            self.session.compact_topk = 0;
-                            self.session.compact_route = GpuTopkRoute::CpuFallback;
-                        }
-                        // The caller cut the stream after exactly one forwarded
-                        // token (the prefill sample) — state represents prompt +
-                        // that one token already (forward happens on the *next*
-                        // iteration in the loop below, which never runs here).
-                        // Nothing further was forwarded, so do not save a cache
-                        // entry claiming more than live state represents.
-                        return Ok(CachedGenerateOutput {
-                            output: GenerateOutput {
-                                text,
-                                token_ids: generated_ids.clone(),
-                                prompt_tokens: prompt_len,
-                                generated_tokens: generated_ids.len(),
-                                stopped: false,
-                                stop_reason: Some(StopReason::Interrupt),
-                                token_logprobs: vec![],
-                            },
-                            cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
-                        });
-                    }
+            let initial_outcome = policy.check_initial_stop(
+                &mut token_logprobs,
+                &mut text,
+                &mut throwaway_offsets,
+                &delta,
+                |s| on_token(s, next_id),
+            );
+            if matches!(
+                initial_outcome,
+                crate::model::qwen35::StopCheckOutcome::Interrupted
+            ) {
+                if use_compact {
+                    self.session.compact_topk = 0;
+                    self.session.compact_route = GpuTopkRoute::CpuFallback;
                 }
+                // The caller cut the stream after exactly one forwarded
+                // token (the prefill sample) — state represents prompt +
+                // that one token already (forward happens on the *next*
+                // iteration in the loop below, which never runs here).
+                // Nothing further was forwarded, so do not save a cache
+                // entry claiming more than live state represents.
+                return Ok(CachedGenerateOutput {
+                    output: GenerateOutput {
+                        text,
+                        token_ids: generated_ids.clone(),
+                        prompt_tokens: prompt_len,
+                        generated_tokens: generated_ids.len(),
+                        stopped: false,
+                        stop_reason: Some(StopReason::Interrupt),
+                        token_logprobs: vec![],
+                    },
+                    cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
+                });
+            }
+            if matches!(
+                initial_outcome,
+                crate::model::qwen35::StopCheckOutcome::Stopped
+            ) {
+                if use_compact {
+                    self.session.compact_topk = 0;
+                    self.session.compact_route = GpuTopkRoute::CpuFallback;
+                }
+                self.cross_turn_prefix_cache.remove(slot_id);
+                return Ok(CachedGenerateOutput {
+                    output: GenerateOutput {
+                        text,
+                        token_ids: generated_ids.clone(),
+                        prompt_tokens: prompt_len,
+                        generated_tokens: generated_ids.len(),
+                        stopped: true,
+                        stop_reason: Some(StopReason::Eos),
+                        token_logprobs: vec![],
+                    },
+                    cache: cache_stats(plan.mode, plan.reusable_len, plan.suffix_len),
+                });
             }
             let mut stopped = false;
             let mut stopped_by_caller = false;
@@ -15929,14 +15855,12 @@ mod inner {
                     sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
                 };
 
-                // One atomic per-step transition (ADR-080 C3 / codex round-1
-                // major #3, PR #787) -- see `DecodePolicy::transition`. The
-                // `stop_check` closure (codex round-2 major #2, PR #787 /
-                // Leo's ruling) owns this path's detok + (optional)
-                // `StopStringMatcher` byte-holdback check + `on_token` sink
-                // -- moving it into the mandatory callback makes it
-                // structurally impossible for this call site to invoke
-                // `transition` while skipping the stop check.
+                // `policy.stop_mode` (fixed to `StopMode::Streaming` or
+                // `Disabled` at construction) now owns this path's byte-
+                // holdback stop check itself (codex round-3 major #1, PR
+                // #787 / Leo's ruling) -- this call site supplies only
+                // `decode_delta` (this loop's own detokenizer) and the
+                // shared `text`/`throwaway_offsets` buffers.
                 let generated_len_before = generated_ids.len();
                 let outcome = policy.transition(
                     &mut token_logprobs,
@@ -15956,35 +15880,10 @@ mod inner {
                         generated_ids.push(next_id);
                         all_ids.push(next_id);
                     },
-                    |next_id, _token_logprobs| {
-                        let delta = detok.push(tokenizer, next_id);
-                        if delta.is_empty() {
-                            return crate::model::qwen35::StopCheckOutcome::Continue;
-                        }
-                        if let Some(matcher) = stop_matcher.as_mut() {
-                            let mut caller_interrupted = false;
-                            let stop_matched = matcher.push(&delta, &mut |emit| {
-                                if !caller_interrupted && !emit.is_empty() {
-                                    text.push_str(emit);
-                                    if !on_token(emit, next_id) {
-                                        caller_interrupted = true;
-                                    }
-                                }
-                            });
-                            if caller_interrupted {
-                                return crate::model::qwen35::StopCheckOutcome::Interrupted;
-                            }
-                            if stop_matched {
-                                return crate::model::qwen35::StopCheckOutcome::Stopped;
-                            }
-                        } else {
-                            text.push_str(&delta);
-                            if !on_token(&delta, next_id) {
-                                return crate::model::qwen35::StopCheckOutcome::Interrupted;
-                            }
-                        }
-                        crate::model::qwen35::StopCheckOutcome::Continue
-                    },
+                    |next_id| detok.push(tokenizer, next_id),
+                    &mut text,
+                    &mut throwaway_offsets,
+                    |s, next_id| on_token(s, next_id),
                 );
 
                 let (next_id, answer_budget_exhausted) = match outcome {
@@ -16033,22 +15932,12 @@ mod inner {
             // must also suppress caching the truncated generation (see below).
             if !stopped_by_caller {
                 let tail = detok.finish();
-                if let Some(matcher) = stop_matcher.as_mut() {
-                    let already_stopped = matcher.stopped();
-                    matcher.finish(&tail, &mut |emit| {
-                        if !emit.is_empty() {
-                            text.push_str(emit);
-                            on_token(emit, last_pushed_id);
-                        }
-                    });
-                    if !already_stopped && matcher.stopped() {
-                        stopped = true;
-                        stopped_by_stop_string = true;
-                        stop_reason = StopReason::Eos;
-                    }
-                } else if !tail.is_empty() {
-                    text.push_str(&tail);
-                    on_token(&tail, last_pushed_id);
+                let tail_stopped =
+                    policy.finish_stop(&mut text, &tail, |s| on_token(s, last_pushed_id));
+                if tail_stopped && !stopped {
+                    stopped = true;
+                    stopped_by_stop_string = true;
+                    stop_reason = StopReason::Eos;
                 }
             }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -732,9 +732,7 @@ mod inner {
     use crate::model::qwen35::detokenize::IncrementalDetokenizer;
     use crate::model::qwen35::stop_strings::StopStringMatcher;
     use crate::model::qwen35::{AttentionWeights, ModelWeights};
-    use crate::model::qwen35_config::{
-        GenerateConfig, GenerateOutput, Qwen35Config, TokenLogprob, decode_cap, force_close_think,
-    };
+    use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config, TokenLogprob};
     use crate::sampling::record_logprob;
     use crate::stop_reason::StopReason;
     use crate::tokenizer::bpe::BpeTokenizer;
@@ -12922,7 +12920,6 @@ mod inner {
             } else {
                 None
             };
-            let mut thinking_closed = false;
 
             // Checked independently of `on_token`: a client that disconnected
             // between dequeue and here must not pay for the (potentially large,
@@ -13028,20 +13025,11 @@ mod inner {
                 });
             }
 
-            // Track whether the thinking block has been closed after prefill sampling.
-            // Enables budget=1 to behave sanely (prefill token counts against budget).
-            if Some(next_id) == think_close_id {
-                thinking_closed = true;
-            }
-
             // Incremental detokenization: stream only complete-UTF-8 deltas. A
             // byte-level BPE codepoint (CJK/emoji) can span several tokens, so
             // per-token lossy decode would emit U+FFFD mojibake the caller cannot
             // retract. Mirrors the non-Metal path (model::qwen35::generation).
             let mut detok = IncrementalDetokenizer::new();
-            // Tracks the generated_ids length at the moment </think> was emitted;
-            // used by the answer-budget break below.
-            let mut reasoning_end_len: Option<usize> = None;
             generated_ids.push(next_id);
             all_ids.push(next_id);
             // #585: record the prefill token's logprob (no-op unless requested).
@@ -13054,10 +13042,17 @@ mod inner {
                 gen_cfg.temperature,
                 gen_cfg.logprobs,
             );
-            // Capture close-point after the prefill push (covers budget=1 edge case).
-            if thinking_closed && reasoning_end_len.is_none() {
-                reasoning_end_len = Some(generated_ids.len());
-            }
+            // Backend-neutral reasoning-budget + logprobs policy (ADR-080 C3):
+            // constructed here (post-prefill-push) so its `thinking_closed` /
+            // `reasoning_end_len` seed covers the budget=1 edge case exactly as
+            // the pre-extraction inline bookkeeping did. Shared with the CPU
+            // `model::qwen35::generation` loops -- see `DecodePolicy`'s doc comment.
+            let mut policy = crate::model::qwen35::DecodePolicy::new(
+                gen_cfg,
+                think_close_id,
+                next_id,
+                generated_ids.len(),
+            );
             let mut last_pushed_id = next_id;
             // `text` is the caller-owned full output — the detokenizer itself only
             // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
@@ -13137,7 +13132,7 @@ mod inner {
 
             // Autoregressive decode with streaming.
             // cap = rb + max_new_tokens when budgeting; max_new_tokens otherwise (parity-safe).
-            let cap = decode_cap(gen_cfg.reasoning_budget, gen_cfg.max_new_tokens);
+            let cap = policy.cap();
             for _ in 1..cap {
                 // Checked before any per-step GPU work, independent of whether this
                 // iteration's delta ends up non-empty -- closes the gap where a run
@@ -13186,14 +13181,7 @@ mod inner {
 
                 // Budget forcing: override sampled token with </think> when the
                 // reasoning budget is exhausted and the block is still open.
-                let next_id = force_close_think(
-                    gen_cfg.reasoning_budget,
-                    gen_cfg.enable_thinking,
-                    thinking_closed,
-                    generated_ids.len(),
-                    think_close_id,
-                )
-                .unwrap_or(sampled_id);
+                let next_id = policy.apply_override(generated_ids.len(), sampled_id);
 
                 // Advance grammar state after sampling (or forced token).
                 // Interaction note: if reasoning_budget AND grammar are both active and the
@@ -13208,9 +13196,7 @@ mod inner {
                 }
 
                 // Track when the thinking block closes (natural or forced).
-                if Some(next_id) == think_close_id {
-                    thinking_closed = true;
-                }
+                policy.note_emitted(next_id);
 
                 if is_stop(next_id) {
                     stopped = true;
@@ -13223,18 +13209,15 @@ mod inner {
                 // #585: record this step's logprob (no-op unless requested). next_id
                 // here is the final, post-force_close_think token — step_logits is
                 // the distribution it was actually sampled/forced from.
-                record_logprob(
+                policy.record_logprob(
                     &mut token_logprobs,
                     &step_logits,
                     next_id,
                     gen_cfg.temperature,
-                    gen_cfg.logprobs,
                 );
                 // Capture the close-point after the push so </think> is the
                 // last reasoning token (not the first answer token).
-                if thinking_closed && reasoning_end_len.is_none() {
-                    reasoning_end_len = Some(generated_ids.len());
-                }
+                policy.capture_reasoning_end(generated_ids.len());
                 last_pushed_id = next_id;
                 let delta = detok.push(tokenizer, next_id);
                 if !delta.is_empty() {
@@ -13272,9 +13255,7 @@ mod inner {
                     break;
                 }
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-                if let Some(end) = reasoning_end_len
-                    && generated_ids.len().saturating_sub(end) >= gen_cfg.max_new_tokens
-                {
+                if policy.answer_budget_exhausted(generated_ids.len()) {
                     break;
                 }
             }
@@ -15444,7 +15425,6 @@ mod inner {
             } else {
                 None
             };
-            let mut thinking_closed = false;
 
             // The one line that differs structurally from `generate_streaming`:
             // prefill only the divergent suffix, at its true absolute position.
@@ -15569,17 +15549,21 @@ mod inner {
                 });
             }
 
-            if Some(next_id) == think_close_id {
-                thinking_closed = true;
-            }
-
             let mut detok = IncrementalDetokenizer::new();
-            let mut reasoning_end_len: Option<usize> = None;
             generated_ids.push(next_id);
             all_ids.push(next_id);
-            if thinking_closed && reasoning_end_len.is_none() {
-                reasoning_end_len = Some(generated_ids.len());
-            }
+            // Backend-neutral reasoning-budget policy (ADR-080 C3), shared with
+            // `generate_streaming` above and the CPU `model::qwen35::generation`
+            // loops. This path has never recorded per-token logprobs (see the
+            // `token_logprobs: vec![]` returns throughout this function) --
+            // `policy.record_logprob` is deliberately not called below, matching
+            // that pre-existing (out-of-scope-for-C3) behavior exactly.
+            let mut policy = crate::model::qwen35::DecodePolicy::new(
+                gen_cfg,
+                think_close_id,
+                next_id,
+                generated_ids.len(),
+            );
             let mut last_pushed_id = next_id;
             // `text` is the caller-owned full output — the detokenizer itself only
             // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
@@ -15676,7 +15660,7 @@ mod inner {
             let mut stopped_by_caller = false;
             let mut stop_reason = StopReason::Length;
 
-            let cap = decode_cap(gen_cfg.reasoning_budget, gen_cfg.max_new_tokens);
+            let cap = policy.cap();
             for _ in 1..cap {
                 // Checked before any per-step GPU work, independent of whether
                 // this iteration's delta ends up non-empty — mirrors
@@ -15725,14 +15709,7 @@ mod inner {
                     sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
                 };
 
-                let next_id = force_close_think(
-                    gen_cfg.reasoning_budget,
-                    gen_cfg.enable_thinking,
-                    thinking_closed,
-                    generated_ids.len(),
-                    think_close_id,
-                )
-                .unwrap_or(sampled_id);
+                let next_id = policy.apply_override(generated_ids.len(), sampled_id);
 
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state)
                     && !engine.advance(gs, next_id)
@@ -15741,9 +15718,7 @@ mod inner {
                     break;
                 }
 
-                if Some(next_id) == think_close_id {
-                    thinking_closed = true;
-                }
+                policy.note_emitted(next_id);
 
                 if is_stop(next_id) {
                     stopped = true;
@@ -15753,9 +15728,7 @@ mod inner {
 
                 generated_ids.push(next_id);
                 all_ids.push(next_id);
-                if thinking_closed && reasoning_end_len.is_none() {
-                    reasoning_end_len = Some(generated_ids.len());
-                }
+                policy.capture_reasoning_end(generated_ids.len());
                 last_pushed_id = next_id;
                 let delta = detok.push(tokenizer, next_id);
                 if !delta.is_empty() {
@@ -15793,9 +15766,7 @@ mod inner {
                     stop_reason = StopReason::KvFull;
                     break;
                 }
-                if let Some(end) = reasoning_end_len
-                    && generated_ids.len().saturating_sub(end) >= gen_cfg.max_new_tokens
-                {
+                if policy.answer_budget_exhausted(generated_ids.len()) {
                     break;
                 }
             }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -574,6 +574,12 @@ mod mtp_resolve_tests {
 /// greedy-argmax-optimal, so this is an output-correctness issue, not only a
 /// performance one. Any non-1.0 penalty must route around MTP to the plain
 /// loop, which samples via `sample_token` and applies it.
+///
+/// `gen_cfg.logprobs.is_none()` is likewise load-bearing (codex round-2
+/// blocker #1, PR #787): `generate_greedy_mtp` unconditionally returns
+/// `token_logprobs: vec![]`, so a set `logprobs` request must route around
+/// MTP to the plain loop, which either captures logprobs or rejects the
+/// config via `check_logprobs_not_set`.
 #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
 fn mtp_route_active(
     mtp_present: bool,
@@ -590,6 +596,7 @@ fn mtp_route_active(
         && gen_cfg.stop_strings.is_empty()
         && gen_cfg.reasoning_budget.is_none()
         && gen_cfg.repetition_penalty == 1.0
+        && gen_cfg.logprobs.is_none()
 }
 
 /// Whether `generate()` should take the GDN-first self-speculative greedy
@@ -598,6 +605,9 @@ fn mtp_route_active(
 /// `reasoning_budget.is_none()` / `repetition_penalty == 1.0` route-around
 /// rationale as [`mtp_route_active`] (codex round-1 blocker #2, PR #787):
 /// self-spec's verify step also selects via raw argmax, never `sample_token`.
+/// `gen_cfg.logprobs.is_none()` is the same round-2 blocker #1 route-around
+/// as [`mtp_route_active`]: `generate_greedy_self_spec` also unconditionally
+/// returns `token_logprobs: vec![]`.
 #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
 fn self_spec_route_active(
     gdn_checkpoints_present: bool,
@@ -615,6 +625,7 @@ fn self_spec_route_active(
         && gen_cfg.stop_strings.is_empty()
         && gen_cfg.reasoning_budget.is_none()
         && gen_cfg.repetition_penalty == 1.0
+        && gen_cfg.logprobs.is_none()
         && num_active_linear_attention_layers > 0
 }
 
@@ -812,6 +823,50 @@ mod route_predicate_tests {
              MTP/self-spec around non-identity repetition_penalty closes"
         );
     }
+
+    /// Codex round-2 blocker #1 (PR #787): a set `logprobs` must route
+    /// around MTP even though every other MTP precondition (present,
+    /// enabled, greedy, non-compact, no grammar, no stop strings, no
+    /// reasoning budget, identity repetition penalty) is satisfied.
+    /// `generate_greedy_mtp` unconditionally returns `token_logprobs: vec![]`,
+    /// so a caller requesting logprobs would otherwise get `Ok` with the
+    /// requested output silently absent.
+    ///
+    /// Codex's exact falsification recipe: add `logprobs: Some(0)` to the
+    /// otherwise-active predicate fixture and assert the route is inactive.
+    ///
+    /// Mutation sensitivity: removing the `logprobs.is_none()` clause from
+    /// `mtp_route_active` makes this assertion fail (the route stays
+    /// active), reproducing codex's reported failure mode exactly.
+    #[test]
+    fn mtp_route_blocked_by_set_logprobs() {
+        let gen_cfg = GenerateConfig {
+            logprobs: Some(0),
+            ..greedy_gen_cfg(vec![])
+        };
+        assert!(
+            !mtp_route_active(true, true, &gen_cfg, false),
+            "MTP must not activate when logprobs is set -- its output path \
+             unconditionally returns an empty token_logprobs vector"
+        );
+    }
+
+    /// Sibling to `mtp_route_blocked_by_set_logprobs` for the
+    /// self-speculative route (codex round-2 blocker #1, PR #787):
+    /// `generate_greedy_self_spec` has the same unconditional empty-vector
+    /// return.
+    #[test]
+    fn self_spec_route_blocked_by_set_logprobs() {
+        let gen_cfg = GenerateConfig {
+            logprobs: Some(0),
+            ..greedy_gen_cfg(vec![])
+        };
+        assert!(
+            !self_spec_route_active(true, true, &gen_cfg, false, 1),
+            "self-spec must not activate when logprobs is set -- same \
+             unconditional empty-token_logprobs output path as MTP"
+        );
+    }
 }
 
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
@@ -836,7 +891,6 @@ mod inner {
     use crate::model::qwen35::stop_strings::StopStringMatcher;
     use crate::model::qwen35::{AttentionWeights, ModelWeights};
     use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config, TokenLogprob};
-    use crate::sampling::record_logprob;
     use crate::stop_reason::StopReason;
     use crate::tokenizer::bpe::BpeTokenizer;
     use crate::tokenizer::common::Tokenizer;
@@ -8605,6 +8659,15 @@ mod inner {
             // already applies it via `stop_text_state` further down.
             crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
 
+            // Reject logprobs before any prefill/state work (codex round-2
+            // blocker #1, PR #787): this entry point unconditionally returns
+            // `token_logprobs: vec![]` on every return path below (including
+            // the MTP and self-spec fast-path delegations), so a caller
+            // requesting `gen_cfg.logprobs` would otherwise get `Ok` with the
+            // requested output silently absent -- the same apply-or-fail-closed
+            // defect as `check_reasoning_budget_not_set` above guards against.
+            crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
+
             // Fail-closed: a prompt longer than the KV cache would trip the
             // forward_prefill length assertion (n <= max_cache_len) and panic the
             // caller thread. Return a clean empty completion instead. Mirrors the
@@ -12973,8 +13036,9 @@ mod inner {
             let mut generated_ids: Vec<u32> = Vec::with_capacity(gen_cfg.max_new_tokens);
             let mut all_ids = prompt_ids.clone();
             // Per-token log-probabilities (#585): empty and untouched unless
-            // gen_cfg.logprobs is Some — record_logprob() below is a no-op in that
-            // case, so the default (no logprobs requested) path pays no extra cost.
+            // gen_cfg.logprobs is Some — DecodePolicy::init / transition's
+            // internal record_logprob call is a no-op in that case, so the
+            // default (no logprobs requested) path pays no extra cost.
             let mut token_logprobs: Vec<TokenLogprob> = Vec::new();
 
             // Issue #171: try the block-top-k route first — far fewer threadgroups
@@ -13137,25 +13201,25 @@ mod inner {
             let mut detok = IncrementalDetokenizer::new();
             generated_ids.push(next_id);
             all_ids.push(next_id);
-            // #585: record the prefill token's logprob (no-op unless requested).
-            // prefill_logits is untouched since forward_prefill() populated it above,
-            // and reflects the same distribution next_id was sampled from.
-            record_logprob(
-                &mut token_logprobs,
-                &prefill_logits,
-                next_id,
-                gen_cfg.temperature,
-                gen_cfg.logprobs,
-            );
             // Backend-neutral reasoning-budget + logprobs policy (ADR-080 C3):
             // constructed here (post-prefill-push) so its `thinking_closed` /
             // `reasoning_end_len` seed covers the budget=1 edge case exactly as
             // the pre-extraction inline bookkeeping did. Shared with the CPU
             // `model::qwen35::generation` loops -- see `DecodePolicy`'s doc comment.
-            let mut policy = crate::model::qwen35::DecodePolicy::new(
+            // `DecodePolicy::init` (codex round-2 major #2, PR #787) records
+            // the prefill token's logprob (#585, no-op unless requested) in
+            // the same call that constructs the policy -- replaces the
+            // freestanding `record_logprob(...)` call this site used to make
+            // independently. `prefill_logits` is untouched since
+            // `forward_prefill()` populated it above, and reflects the same
+            // distribution `next_id` was sampled from.
+            let mut policy = crate::model::qwen35::DecodePolicy::init(
                 gen_cfg,
                 think_close_id,
+                &mut token_logprobs,
                 next_id,
+                &prefill_logits,
+                gen_cfg.temperature,
                 generated_ids.len(),
             );
             let mut last_pushed_id = next_id;
@@ -13290,6 +13354,13 @@ mod inner {
                 // grammar disallows </think> at this position, advance returns false → break.
                 // This is fail-closed (no grammar-illegal output emitted) but silent. The
                 // combination of grammar + reasoning_budget is unusual; document, don't change.
+                //
+                // The `stop_check` closure (codex round-2 major #2, PR #787 /
+                // Leo's ruling) owns this path's detok + (optional)
+                // `StopStringMatcher` byte-holdback check + `on_token` sink --
+                // moving it into the mandatory callback makes it structurally
+                // impossible for this call site to invoke `transition` while
+                // skipping the stop check.
                 let generated_len_before = generated_ids.len();
                 let outcome = policy.transition(
                     &mut token_logprobs,
@@ -13309,6 +13380,35 @@ mod inner {
                         generated_ids.push(next_id);
                         all_ids.push(next_id);
                     },
+                    |next_id, _token_logprobs| {
+                        let delta = detok.push(tokenizer, next_id);
+                        if delta.is_empty() {
+                            return crate::model::qwen35::StopCheckOutcome::Continue;
+                        }
+                        if let Some(matcher) = stop_matcher.as_mut() {
+                            let mut caller_interrupted = false;
+                            let stop_matched = matcher.push(&delta, &mut |emit| {
+                                if !caller_interrupted && !emit.is_empty() {
+                                    text.push_str(emit);
+                                    if !on_token(emit, next_id) {
+                                        caller_interrupted = true;
+                                    }
+                                }
+                            });
+                            if caller_interrupted {
+                                return crate::model::qwen35::StopCheckOutcome::Interrupted;
+                            }
+                            if stop_matched {
+                                return crate::model::qwen35::StopCheckOutcome::Stopped;
+                            }
+                        } else {
+                            text.push_str(&delta);
+                            if !on_token(&delta, next_id) {
+                                return crate::model::qwen35::StopCheckOutcome::Interrupted;
+                            }
+                        }
+                        crate::model::qwen35::StopCheckOutcome::Continue
+                    },
                 );
 
                 let (next_id, answer_budget_exhausted) = match outcome {
@@ -13321,43 +13421,22 @@ mod inner {
                         stop_reason = StopReason::Eos;
                         break;
                     }
+                    crate::model::qwen35::StepOutcome::Stopped => {
+                        stopped = true;
+                        stop_reason = StopReason::Eos;
+                        break;
+                    }
+                    crate::model::qwen35::StepOutcome::Interrupted => {
+                        stopped_by_caller = true;
+                        stop_reason = StopReason::Interrupt;
+                        break;
+                    }
                     crate::model::qwen35::StepOutcome::Emitted {
                         token_id,
                         answer_budget_exhausted,
                     } => (token_id, answer_budget_exhausted),
                 };
                 last_pushed_id = next_id;
-                let delta = detok.push(tokenizer, next_id);
-                if !delta.is_empty() {
-                    if let Some(matcher) = stop_matcher.as_mut() {
-                        let mut caller_interrupted = false;
-                        let stop_matched = matcher.push(&delta, &mut |emit| {
-                            if !caller_interrupted && !emit.is_empty() {
-                                text.push_str(emit);
-                                if !on_token(emit, next_id) {
-                                    caller_interrupted = true;
-                                }
-                            }
-                        });
-                        if caller_interrupted {
-                            stopped_by_caller = true;
-                            stop_reason = StopReason::Interrupt;
-                            break;
-                        }
-                        if stop_matched {
-                            stopped = true;
-                            stop_reason = StopReason::Eos;
-                            break;
-                        }
-                    } else {
-                        text.push_str(&delta);
-                        if !on_token(&delta, next_id) {
-                            stopped_by_caller = true;
-                            stop_reason = StopReason::Interrupt;
-                            break;
-                        }
-                    }
-                }
                 if self.session.kv_cache.seq_len >= self.session.kv_cache.max_cache_len {
                     stop_reason = StopReason::KvFull;
                     break;
@@ -15316,6 +15395,20 @@ mod inner {
             F: FnMut(&str, u32) -> bool,
             C: FnMut() -> bool,
         {
+            // Config preflight checks live here, in the public wrapper, and
+            // must return BEFORE the `match` below (codex round-2 medium #3,
+            // PR #787): the error-recovery arm of that `match` unconditionally
+            // calls `reset_state()` and removes the cache slot on ANY `Err`
+            // from `_inner`, including a not-yet-attempted preflight
+            // rejection. A caller passing an unsupported config (e.g.
+            // `logprobs` or an active `enable_mtp`) never touches cache/session
+            // state in the first place, so routing that rejection through the
+            // destructive recovery path would evict a valid pre-existing
+            // cross-turn entry the call never mutated. Returning here, before
+            // `_inner` is even called, leaves any existing entry untouched.
+            crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
+            crate::model::qwen35::check_mtp_not_requested(gen_cfg)?;
+
             match self.generate_streaming_with_prefix_cache_and_cancel_inner(
                 slot_id,
                 prompt,
@@ -15352,16 +15445,14 @@ mod inner {
             use crate::error::InferenceError;
             use crate::kv_cache::PrefixReuseMode;
 
-            // Codex round-1 blocker #1 (PR #787): this path never wired
-            // per-token logprobs capture into the cross-turn cache decode
-            // loop (see the `token_logprobs: vec![]` returns throughout this
-            // function) -- a caller requesting `gen_cfg.logprobs` previously
-            // got `Ok` with silently empty logprobs, the exact defect ADR-080
-            // C3's apply-or-fail-closed contract exists to close. Guard-reject
-            // before any cache/state mutation rather than silently drop the
-            // field, mirroring `multimodal_generate_preflight`'s identical
-            // choice for the same not-yet-wired capability.
-            crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
+            // The `logprobs` / `enable_mtp` config preflight checks (codex
+            // round-1 blocker #1, round-2 medium #3/#4, PR #787) live in the
+            // public wrapper `generate_streaming_with_prefix_cache_and_cancel`,
+            // not here: that wrapper's error-recovery path unconditionally
+            // evicts the cache slot on any `Err` from this function, so a
+            // preflight-only rejection must never reach `_inner` in the first
+            // place, or a valid pre-existing cross-turn entry this call never
+            // touched would be destroyed alongside it.
 
             let cfg = self.engine.config.clone();
 
@@ -15678,18 +15769,21 @@ mod inner {
             // throwaway sink: this path does not wire per-token logprobs
             // capture, and the `check_logprobs_not_set` guard above already
             // rejects any request that would need it, so `gen_cfg.logprobs`
-            // is always `None` here and `transition`'s logprob recording is
-            // always a no-op (codex round-1 blocker #1, PR #787) -- passed
-            // through uniformly rather than special-cased, so this site is
-            // structurally indistinguishable from the other five at the
-            // `transition` call site.
-            let mut policy = crate::model::qwen35::DecodePolicy::new(
+            // is always `None` here and `DecodePolicy::init` / `transition`'s
+            // logprob recording is always a no-op (codex round-1 blocker #1,
+            // PR #787) -- passed through uniformly rather than special-cased,
+            // so this site is structurally indistinguishable from the other
+            // five at the `DecodePolicy::init` / `transition` call sites.
+            let mut token_logprobs: Vec<TokenLogprob> = Vec::new();
+            let mut policy = crate::model::qwen35::DecodePolicy::init(
                 gen_cfg,
                 think_close_id,
+                &mut token_logprobs,
                 next_id,
+                &prefill_logits,
+                gen_cfg.temperature,
                 generated_ids.len(),
             );
-            let mut token_logprobs: Vec<TokenLogprob> = Vec::new();
             let mut last_pushed_id = next_id;
             // `text` is the caller-owned full output — the detokenizer itself only
             // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
@@ -15836,7 +15930,13 @@ mod inner {
                 };
 
                 // One atomic per-step transition (ADR-080 C3 / codex round-1
-                // major #3, PR #787) -- see `DecodePolicy::transition`.
+                // major #3, PR #787) -- see `DecodePolicy::transition`. The
+                // `stop_check` closure (codex round-2 major #2, PR #787 /
+                // Leo's ruling) owns this path's detok + (optional)
+                // `StopStringMatcher` byte-holdback check + `on_token` sink
+                // -- moving it into the mandatory callback makes it
+                // structurally impossible for this call site to invoke
+                // `transition` while skipping the stop check.
                 let generated_len_before = generated_ids.len();
                 let outcome = policy.transition(
                     &mut token_logprobs,
@@ -15856,6 +15956,35 @@ mod inner {
                         generated_ids.push(next_id);
                         all_ids.push(next_id);
                     },
+                    |next_id, _token_logprobs| {
+                        let delta = detok.push(tokenizer, next_id);
+                        if delta.is_empty() {
+                            return crate::model::qwen35::StopCheckOutcome::Continue;
+                        }
+                        if let Some(matcher) = stop_matcher.as_mut() {
+                            let mut caller_interrupted = false;
+                            let stop_matched = matcher.push(&delta, &mut |emit| {
+                                if !caller_interrupted && !emit.is_empty() {
+                                    text.push_str(emit);
+                                    if !on_token(emit, next_id) {
+                                        caller_interrupted = true;
+                                    }
+                                }
+                            });
+                            if caller_interrupted {
+                                return crate::model::qwen35::StopCheckOutcome::Interrupted;
+                            }
+                            if stop_matched {
+                                return crate::model::qwen35::StopCheckOutcome::Stopped;
+                            }
+                        } else {
+                            text.push_str(&delta);
+                            if !on_token(&delta, next_id) {
+                                return crate::model::qwen35::StopCheckOutcome::Interrupted;
+                            }
+                        }
+                        crate::model::qwen35::StopCheckOutcome::Continue
+                    },
                 );
 
                 let (next_id, answer_budget_exhausted) = match outcome {
@@ -15868,44 +15997,23 @@ mod inner {
                         stop_reason = StopReason::Eos;
                         break;
                     }
+                    crate::model::qwen35::StepOutcome::Stopped => {
+                        stopped = true;
+                        stopped_by_stop_string = true;
+                        stop_reason = StopReason::Eos;
+                        break;
+                    }
+                    crate::model::qwen35::StepOutcome::Interrupted => {
+                        stopped_by_caller = true;
+                        stop_reason = StopReason::Interrupt;
+                        break;
+                    }
                     crate::model::qwen35::StepOutcome::Emitted {
                         token_id,
                         answer_budget_exhausted,
                     } => (token_id, answer_budget_exhausted),
                 };
                 last_pushed_id = next_id;
-                let delta = detok.push(tokenizer, next_id);
-                if !delta.is_empty() {
-                    if let Some(matcher) = stop_matcher.as_mut() {
-                        let mut caller_interrupted = false;
-                        let stop_matched = matcher.push(&delta, &mut |emit| {
-                            if !caller_interrupted && !emit.is_empty() {
-                                text.push_str(emit);
-                                if !on_token(emit, next_id) {
-                                    caller_interrupted = true;
-                                }
-                            }
-                        });
-                        if caller_interrupted {
-                            stopped_by_caller = true;
-                            stop_reason = StopReason::Interrupt;
-                            break;
-                        }
-                        if stop_matched {
-                            stopped = true;
-                            stopped_by_stop_string = true;
-                            stop_reason = StopReason::Eos;
-                            break;
-                        }
-                    } else {
-                        text.push_str(&delta);
-                        if !on_token(&delta, next_id) {
-                            stopped_by_caller = true;
-                            stop_reason = StopReason::Interrupt;
-                            break;
-                        }
-                    }
-                }
                 if self.session.kv_cache.seq_len >= self.session.kv_cache.max_cache_len {
                     stop_reason = StopReason::KvFull;
                     break;
@@ -22990,6 +23098,53 @@ mod inner {
             );
         }
 
+        /// Sibling to `metal_generate_plain_rejects_reasoning_budget_config`
+        /// (codex round-2 blocker #1, PR #787): `MetalQwen35State::generate`
+        /// (the plain/direct entry point) unconditionally returns
+        /// `token_logprobs: vec![]` on every return path, including the MTP
+        /// and self-spec fast-path delegations, and had no
+        /// `check_logprobs_not_set` preflight at all -- routing a `logprobs`
+        /// request around the MTP/self-spec predicates alone would not have
+        /// closed this, since the plain fallback path is exactly as silent.
+        ///
+        /// Mutation sensitivity: removing the `check_logprobs_not_set` call
+        /// from `generate` lets this request proceed through prefill and
+        /// sampling instead of erroring, so `result.is_err()` fails.
+        #[test]
+        fn metal_generate_plain_rejects_logprobs_config() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 4,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(42),
+                stop_token_ids: vec![],
+                enable_thinking: true,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: Some(0),
+            };
+
+            let result = state.generate("a", &tokenizer, &gen_cfg);
+            assert!(
+                matches!(result, Err(crate::error::InferenceError::InvalidInput(_))),
+                "MetalQwen35State::generate must fail closed with InvalidInput when \
+                 logprobs is set (codex round-2 blocker #1, PR #787); got {result:?}"
+            );
+        }
+
         /// `generate_streaming`'s `max_new_tokens == 0` guard must return before the
         /// prefill token is sampled, pushed, or streamed, matching the CPU
         /// `generate_streaming()` contract (model::qwen35::generation): zero tokens,
@@ -26726,6 +26881,147 @@ mod inner {
             assert!(
                 state.cross_turn_prefix_cache.entry.is_none(),
                 "a logprobs-rejected call must not create or leave a cache \
+                 entry behind -- the guard runs before any state mutation"
+            );
+        }
+
+        /// Codex round-2 medium #3 (PR #787): the round-1 fix guarded the
+        /// NO-entry case, but not the case where a valid entry already
+        /// exists. The public wrapper
+        /// `generate_streaming_with_prefix_cache_and_cancel` used to catch
+        /// EVERY `Err` from `_inner` -- including a preflight-only rejection
+        /// that never attempted cache/state mutation -- and unconditionally
+        /// call `reset_state()` + remove the slot. A caller who warms a live
+        /// cross-turn entry and then makes one invalid (`logprobs`-set)
+        /// call would have that valid entry destroyed even though the
+        /// rejected call touched nothing.
+        ///
+        /// Mutation sensitivity: hoisting the preflight checks in
+        /// `generate_streaming_with_prefix_cache_and_cancel` back below the
+        /// `match` (i.e. routing them through `_inner` again) makes this
+        /// test fail: the wrapper's `Err` arm evicts the warm entry.
+        #[test]
+        fn generate_streaming_with_prefix_cache_rejects_logprobs_request_preserves_warm_entry() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            use crate::error::InferenceError;
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+
+            let warm_cfg = cross_turn_test_gen_cfg(9, 2);
+            state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &warm_cfg,
+                    |_, _| true,
+                )
+                .expect("warm-up call must succeed");
+            let warm_entry = state
+                .cross_turn_prefix_cache
+                .entry
+                .as_ref()
+                .expect("precondition: the warm-up call must retain a cache entry")
+                .generic
+                .token_ids
+                .clone();
+
+            let rejected_cfg = GenerateConfig {
+                logprobs: Some(0),
+                ..cross_turn_test_gen_cfg(9, 2)
+            };
+            let result = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "ab",
+                &tokenizer,
+                &rejected_cfg,
+                |_, _| true,
+            );
+            assert!(
+                matches!(result, Err(InferenceError::InvalidInput(_))),
+                "the logprobs-set call must still fail closed; got {result:?}"
+            );
+
+            let entry_after = state
+                .cross_turn_prefix_cache
+                .entry
+                .as_ref()
+                .map(|e| e.generic.token_ids.clone());
+            assert_eq!(
+                entry_after,
+                Some(warm_entry),
+                "a preflight-only rejection must not evict a pre-existing \
+                 cache entry it never touched -- the public wrapper must \
+                 return before its destructive Err-recovery block runs"
+            );
+        }
+
+        /// Codex round-2 medium #4 (PR #787): the prefix-cache path accepts
+        /// `GenerateConfig` but never reads `enable_mtp`, unlike the direct
+        /// Metal `generate()` entry point, which resolves it and delegates
+        /// to `generate_greedy_mtp`. An active MTP request (explicit
+        /// `Some(true)` or `LATTICE_MTP` set with `enable_mtp: None`) must
+        /// be rejected before any cache/state mutation rather than silently
+        /// falling back to plain per-token decode with no MTP applied and
+        /// no indication the request was ignored.
+        ///
+        /// Mutation sensitivity: removing the `check_mtp_not_requested` call
+        /// in `generate_streaming_with_prefix_cache_and_cancel` makes this
+        /// assertion fail (the call returns `Ok` instead of `Err`).
+        #[test]
+        fn generate_streaming_with_prefix_cache_rejects_active_mtp_request() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            use crate::error::InferenceError;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+
+            let gen_cfg = crate::model::qwen35_config::GenerateConfig {
+                enable_mtp: Some(true),
+                ..cross_turn_test_gen_cfg(1, 2)
+            };
+
+            let result = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "a",
+                &tokenizer,
+                &gen_cfg,
+                |_, _| true,
+            );
+
+            assert!(
+                matches!(result, Err(InferenceError::InvalidInput(_))),
+                "an explicit enable_mtp: Some(true) request must fail closed \
+                 via generate_streaming_with_prefix_cache() instead of \
+                 silently falling back to plain decode; got {result:?}"
+            );
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_none(),
+                "an MTP-rejected call must not create or leave a cache \
                  entry behind -- the guard runs before any state mutation"
             );
         }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -565,6 +565,15 @@ mod mtp_resolve_tests {
 /// so any set `reasoning_budget` must route around it to the plain loop,
 /// which either applies budget forcing or rejects the config via
 /// `check_reasoning_budget_not_set`.
+///
+/// `gen_cfg.repetition_penalty == 1.0` is likewise load-bearing (codex round-1
+/// blocker #2, PR #787): both the MTP draft (`mtp_forward_one`) and verify
+/// steps select tokens via raw `argmax_f32_first_wins` over logits, never
+/// through `sample_token`, so a non-identity penalty configured by the caller
+/// would be silently ignored -- a set penalty can change which token is
+/// greedy-argmax-optimal, so this is an output-correctness issue, not only a
+/// performance one. Any non-1.0 penalty must route around MTP to the plain
+/// loop, which samples via `sample_token` and applies it.
 #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
 fn mtp_route_active(
     mtp_present: bool,
@@ -580,12 +589,15 @@ fn mtp_route_active(
         && gen_cfg.grammar.is_none()
         && gen_cfg.stop_strings.is_empty()
         && gen_cfg.reasoning_budget.is_none()
+        && gen_cfg.repetition_penalty == 1.0
 }
 
 /// Whether `generate()` should take the GDN-first self-speculative greedy
 /// branch. Mirrors the `use_self_spec` computation inline in
 /// `MetalQwen35State::generate` exactly -- same `stop_strings.is_empty()` /
-/// `reasoning_budget.is_none()` route-around rationale as [`mtp_route_active`].
+/// `reasoning_budget.is_none()` / `repetition_penalty == 1.0` route-around
+/// rationale as [`mtp_route_active`] (codex round-1 blocker #2, PR #787):
+/// self-spec's verify step also selects via raw argmax, never `sample_token`.
 #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
 fn self_spec_route_active(
     gdn_checkpoints_present: bool,
@@ -602,6 +614,7 @@ fn self_spec_route_active(
         && gen_cfg.grammar.is_none()
         && gen_cfg.stop_strings.is_empty()
         && gen_cfg.reasoning_budget.is_none()
+        && gen_cfg.repetition_penalty == 1.0
         && num_active_linear_attention_layers > 0
 }
 
@@ -707,6 +720,96 @@ mod route_predicate_tests {
             !self_spec_route_active(true, true, &gen_cfg, false, 1),
             "self-spec must not activate when reasoning_budget is set -- same \
              budget-forcing-unaware draft/verify loop as MTP"
+        );
+    }
+
+    /// Codex round-1 blocker #2 (PR #787): a non-identity `repetition_penalty`
+    /// must route around MTP even though every other MTP precondition
+    /// (present, enabled, greedy, non-compact, no grammar, no stop strings,
+    /// no reasoning budget) is satisfied. MTP's draft/verify loop selects via
+    /// raw `argmax_f32_first_wins`, never `sample_token`, so a caller-supplied
+    /// penalty would otherwise be silently ignored.
+    ///
+    /// Mutation sensitivity: removing the `repetition_penalty == 1.0` clause
+    /// from `mtp_route_active` makes this assertion fail (the route stays
+    /// active), reproducing codex's reported failure mode exactly.
+    #[test]
+    fn mtp_route_blocked_by_nonidentity_repetition_penalty() {
+        let gen_cfg = GenerateConfig {
+            repetition_penalty: 1.1,
+            ..greedy_gen_cfg(vec![])
+        };
+        assert!(
+            !mtp_route_active(true, true, &gen_cfg, false),
+            "MTP must not activate when repetition_penalty is not 1.0 -- its \
+             draft/verify loop selects via raw argmax and has no \
+             repetition-penalty awareness"
+        );
+    }
+
+    /// Sibling to `mtp_route_blocked_by_nonidentity_repetition_penalty` for
+    /// the self-speculative route (codex round-1 blocker #2, PR #787).
+    #[test]
+    fn self_spec_route_blocked_by_nonidentity_repetition_penalty() {
+        let gen_cfg = GenerateConfig {
+            repetition_penalty: 1.1,
+            ..greedy_gen_cfg(vec![])
+        };
+        assert!(
+            !self_spec_route_active(true, true, &gen_cfg, false, 1),
+            "self-spec must not activate when repetition_penalty is not 1.0 \
+             -- same raw-argmax-selecting, penalty-unaware draft/verify loop \
+             as MTP"
+        );
+    }
+
+    /// Output-level discriminating case (codex round-1 blocker #2, PR #787):
+    /// proves the route-around above is not merely cosmetic. With
+    /// `repetition_penalty = 1.0` the raw dense argmax MTP/self-spec use
+    /// (`argmax_f32_first_wins`) agrees with the canonical
+    /// repetition-penalty-aware `sample_token` path. Once a previously-seen
+    /// token depresses the raw argmax below the runner-up (same mechanism as
+    /// `test_repetition_penalty_can_flip_greedy_argmax_when_seen_in_history`
+    /// in `model::qwen35::sampling`), the two paths disagree -- exactly the
+    /// silent-divergence scenario the new predicate clause closes.
+    #[test]
+    fn nonidentity_repetition_penalty_flips_winner_vs_raw_argmax() {
+        use crate::sampling::{argmax_f32_first_wins, sample_full_logits as sample_token};
+
+        // Token 0 has the highest raw logit; token 1 is a close second, chosen
+        // so 5.0 / 1.1 falls below token 1's unpenalized 4.6.
+        let logits = [5.0_f32, 4.6, 0.1];
+        let previous_ids = [0_u32, 0, 0];
+
+        // Raw dense argmax (what MTP/self-spec actually call): always token 0,
+        // with no notion of `previous_ids` or `repetition_penalty` at all.
+        assert_eq!(
+            argmax_f32_first_wins(&logits),
+            0,
+            "raw argmax is penalty-blind by construction"
+        );
+
+        // Canonical path with the caller's non-identity penalty and the
+        // argmax token already in history: the penalized pick flips to the
+        // runner-up.
+        let gen_cfg = GenerateConfig {
+            repetition_penalty: 1.1,
+            ..greedy_gen_cfg(vec![])
+        };
+        let mut rng = 7u64;
+        let canonical = sample_token(&logits, &gen_cfg, &previous_ids, &mut rng);
+        assert_eq!(
+            canonical, 1,
+            "sample_token must penalize the previously-seen argmax enough to \
+             flip greedy selection to the runner-up"
+        );
+
+        assert_ne!(
+            argmax_f32_first_wins(&logits),
+            canonical,
+            "raw argmax and the canonical repetition-aware pick must disagree \
+             here -- this is exactly the output-correctness gap that routing \
+             MTP/self-spec around non-identity repetition_penalty closes"
         );
     }
 }
@@ -5406,14 +5509,16 @@ mod inner {
             cmd2.wait_until_completed();
 
             // ---- Phase 3: CPU ----
+            // Codex round-1 medium #4 (PR #787): this was the one surviving
+            // production last-wins `max_by` argmax after the #280 fix -- the
+            // MTP draft-token pick, called from `generate_greedy_mtp`. Swapped
+            // for the shared first-wins `argmax_f32_first_wins` helper so a
+            // tie at the draft boundary resolves the same way as every other
+            // greedy pick in the crate (a differing draft tie can only reduce
+            // speculative acceptance, never change final target output, but
+            // the duplicate last-wins contract itself is the defect).
             let logits = unsafe { read_buffer(&*buf_logits, cfg.vocab_size) };
-            let draft_token = logits
-                .iter()
-                .copied()
-                .enumerate()
-                .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-                .map(|(i, _)| i as u32)
-                .unwrap_or(0);
+            let draft_token = crate::sampling::argmax_f32_first_wins(&logits);
 
             // Advance MTP KV cache.
             if let Some(ref mut mtp) = self.session.mtp {
@@ -13179,45 +13284,48 @@ mod inner {
                     sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
                 };
 
-                // Budget forcing: override sampled token with </think> when the
-                // reasoning budget is exhausted and the block is still open.
-                let next_id = policy.apply_override(generated_ids.len(), sampled_id);
-
-                // Advance grammar state after sampling (or forced token).
+                // One atomic per-step transition (ADR-080 C3 / codex round-1
+                // major #3, PR #787) -- see `DecodePolicy::transition`.
                 // Interaction note: if reasoning_budget AND grammar are both active and the
                 // grammar disallows </think> at this position, advance returns false → break.
                 // This is fail-closed (no grammar-illegal output emitted) but silent. The
                 // combination of grammar + reasoning_budget is unusual; document, don't change.
-                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state)
-                    && !engine.advance(gs, next_id)
-                {
-                    stop_reason = StopReason::Grammar;
-                    break;
-                }
-
-                // Track when the thinking block closes (natural or forced).
-                policy.note_emitted(next_id);
-
-                if is_stop(next_id) {
-                    stopped = true;
-                    stop_reason = StopReason::Eos;
-                    break;
-                }
-
-                generated_ids.push(next_id);
-                all_ids.push(next_id);
-                // #585: record this step's logprob (no-op unless requested). next_id
-                // here is the final, post-force_close_think token — step_logits is
-                // the distribution it was actually sampled/forced from.
-                policy.record_logprob(
+                let generated_len_before = generated_ids.len();
+                let outcome = policy.transition(
                     &mut token_logprobs,
+                    sampled_id,
                     &step_logits,
-                    next_id,
                     gen_cfg.temperature,
+                    generated_len_before,
+                    |next_id| {
+                        if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                            engine.advance(gs, next_id)
+                        } else {
+                            true
+                        }
+                    },
+                    &is_stop,
+                    |next_id| {
+                        generated_ids.push(next_id);
+                        all_ids.push(next_id);
+                    },
                 );
-                // Capture the close-point after the push so </think> is the
-                // last reasoning token (not the first answer token).
-                policy.capture_reasoning_end(generated_ids.len());
+
+                let (next_id, answer_budget_exhausted) = match outcome {
+                    crate::model::qwen35::StepOutcome::GrammarStop => {
+                        stop_reason = StopReason::Grammar;
+                        break;
+                    }
+                    crate::model::qwen35::StepOutcome::Eos => {
+                        stopped = true;
+                        stop_reason = StopReason::Eos;
+                        break;
+                    }
+                    crate::model::qwen35::StepOutcome::Emitted {
+                        token_id,
+                        answer_budget_exhausted,
+                    } => (token_id, answer_budget_exhausted),
+                };
                 last_pushed_id = next_id;
                 let delta = detok.push(tokenizer, next_id);
                 if !delta.is_empty() {
@@ -13255,7 +13363,7 @@ mod inner {
                     break;
                 }
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-                if policy.answer_budget_exhausted(generated_ids.len()) {
+                if answer_budget_exhausted {
                     break;
                 }
             }
@@ -15244,6 +15352,17 @@ mod inner {
             use crate::error::InferenceError;
             use crate::kv_cache::PrefixReuseMode;
 
+            // Codex round-1 blocker #1 (PR #787): this path never wired
+            // per-token logprobs capture into the cross-turn cache decode
+            // loop (see the `token_logprobs: vec![]` returns throughout this
+            // function) -- a caller requesting `gen_cfg.logprobs` previously
+            // got `Ok` with silently empty logprobs, the exact defect ADR-080
+            // C3's apply-or-fail-closed contract exists to close. Guard-reject
+            // before any cache/state mutation rather than silently drop the
+            // field, mirroring `multimodal_generate_preflight`'s identical
+            // choice for the same not-yet-wired capability.
+            crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
+
             let cfg = self.engine.config.clone();
 
             let mut rng_state = match gen_cfg.seed {
@@ -15554,16 +15673,23 @@ mod inner {
             all_ids.push(next_id);
             // Backend-neutral reasoning-budget policy (ADR-080 C3), shared with
             // `generate_streaming` above and the CPU `model::qwen35::generation`
-            // loops. This path has never recorded per-token logprobs (see the
-            // `token_logprobs: vec![]` returns throughout this function) --
-            // `policy.record_logprob` is deliberately not called below, matching
-            // that pre-existing (out-of-scope-for-C3) behavior exactly.
+            // loops, driven through the one atomic `DecodePolicy::transition`
+            // (codex round-1 major #3, PR #787). `token_logprobs` below is a
+            // throwaway sink: this path does not wire per-token logprobs
+            // capture, and the `check_logprobs_not_set` guard above already
+            // rejects any request that would need it, so `gen_cfg.logprobs`
+            // is always `None` here and `transition`'s logprob recording is
+            // always a no-op (codex round-1 blocker #1, PR #787) -- passed
+            // through uniformly rather than special-cased, so this site is
+            // structurally indistinguishable from the other five at the
+            // `transition` call site.
             let mut policy = crate::model::qwen35::DecodePolicy::new(
                 gen_cfg,
                 think_close_id,
                 next_id,
                 generated_ids.len(),
             );
+            let mut token_logprobs: Vec<TokenLogprob> = Vec::new();
             let mut last_pushed_id = next_id;
             // `text` is the caller-owned full output — the detokenizer itself only
             // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
@@ -15709,26 +15835,44 @@ mod inner {
                     sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
                 };
 
-                let next_id = policy.apply_override(generated_ids.len(), sampled_id);
+                // One atomic per-step transition (ADR-080 C3 / codex round-1
+                // major #3, PR #787) -- see `DecodePolicy::transition`.
+                let generated_len_before = generated_ids.len();
+                let outcome = policy.transition(
+                    &mut token_logprobs,
+                    sampled_id,
+                    &step_logits,
+                    gen_cfg.temperature,
+                    generated_len_before,
+                    |next_id| {
+                        if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                            engine.advance(gs, next_id)
+                        } else {
+                            true
+                        }
+                    },
+                    &is_stop,
+                    |next_id| {
+                        generated_ids.push(next_id);
+                        all_ids.push(next_id);
+                    },
+                );
 
-                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state)
-                    && !engine.advance(gs, next_id)
-                {
-                    stop_reason = StopReason::Grammar;
-                    break;
-                }
-
-                policy.note_emitted(next_id);
-
-                if is_stop(next_id) {
-                    stopped = true;
-                    stop_reason = StopReason::Eos;
-                    break;
-                }
-
-                generated_ids.push(next_id);
-                all_ids.push(next_id);
-                policy.capture_reasoning_end(generated_ids.len());
+                let (next_id, answer_budget_exhausted) = match outcome {
+                    crate::model::qwen35::StepOutcome::GrammarStop => {
+                        stop_reason = StopReason::Grammar;
+                        break;
+                    }
+                    crate::model::qwen35::StepOutcome::Eos => {
+                        stopped = true;
+                        stop_reason = StopReason::Eos;
+                        break;
+                    }
+                    crate::model::qwen35::StepOutcome::Emitted {
+                        token_id,
+                        answer_budget_exhausted,
+                    } => (token_id, answer_budget_exhausted),
+                };
                 last_pushed_id = next_id;
                 let delta = detok.push(tokenizer, next_id);
                 if !delta.is_empty() {
@@ -15766,7 +15910,7 @@ mod inner {
                     stop_reason = StopReason::KvFull;
                     break;
                 }
-                if policy.answer_budget_exhausted(generated_ids.len()) {
+                if answer_budget_exhausted {
                     break;
                 }
             }
@@ -26513,6 +26657,76 @@ mod inner {
             assert!(
                 state.cross_turn_prefix_cache.entry.is_none(),
                 "a grammar-fail-closed turn must not leave a stale cache entry behind"
+            );
+        }
+
+        /// Codex round-1 blocker #1 (PR #787):
+        /// `generate_streaming_with_prefix_cache` never wires per-token
+        /// logprobs capture into its decode loop. Before the fix, a caller
+        /// requesting `gen_cfg.logprobs` got `Ok` back with silently empty
+        /// `token_logprobs` -- the exact silent-omission defect ADR-080 C3's
+        /// apply-or-fail-closed contract exists to close. The guard must
+        /// reject the request before any cache/state mutation, so no cache
+        /// entry is created (or consumed) for the rejected call.
+        ///
+        /// Mutation sensitivity: removing the `check_logprobs_not_set` call
+        /// at the top of `generate_streaming_with_prefix_cache_and_cancel_inner`
+        /// makes this assertion fail (the call returns `Ok` with empty
+        /// `token_logprobs` instead of `Err`).
+        #[test]
+        fn generate_streaming_with_prefix_cache_rejects_logprobs_request() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            use crate::error::InferenceError;
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 2,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(1),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: Some(5),
+            };
+
+            let result = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "a",
+                &tokenizer,
+                &gen_cfg,
+                |_, _| true,
+            );
+
+            assert!(
+                matches!(result, Err(InferenceError::InvalidInput(_))),
+                "a logprobs request must fail closed via \
+                 generate_streaming_with_prefix_cache() instead of silently \
+                 returning empty token_logprobs; got {result:?}"
+            );
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_none(),
+                "a logprobs-rejected call must not create or leave a cache \
+                 entry behind -- the guard runs before any state mutation"
             );
         }
 

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -929,6 +929,10 @@ pub fn generate_q8_neon(
     // Same rationale for logprobs capture, which is also not wired into this
     // generate loop (#585).
     crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
+    // Same rationale for stop_strings matching and reasoning-budget forcing,
+    // neither of which is wired into this generate loop (ADR-080 C3, #783).
+    crate::model::qwen35::check_stop_strings_not_set(gen_cfg)?;
+    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
 
     // Reject requests whose total token budget exceeds the RoPE table's
     // position capacity before allocating caches or dereferencing weights.
@@ -2758,6 +2762,96 @@ mod tests {
             matches!(result, Err(InferenceError::InvalidInput(_))),
             "generate_q8_neon must fail closed with InvalidInput when grammar is set \
              (#397/#398); got {result:?}"
+        );
+    }
+
+    /// `generate_q8_neon` must reject a `GenerateConfig` that sets `stop_strings`
+    /// with a typed `InvalidInput` error before sampling any token (ADR-080 C3, #783).
+    ///
+    /// Mutation sensitivity: removing the `check_stop_strings_not_set` call makes the
+    /// function proceed past the guard and attempt to forward with empty weights,
+    /// producing a panic or a non-`InvalidInput` error — this assert fails either way.
+    #[test]
+    fn generate_q8_neon_rejects_stop_strings_config_before_sampling() {
+        use crate::error::InferenceError;
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let model = Q8NeonModel {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            lm_head_packed: vec![],
+            lm_head_rows: 0,
+            lm_head_cols: 0,
+            layers: vec![],
+        };
+
+        let gen_cfg = GenerateConfig {
+            stop_strings: vec!["</s>".to_string()],
+            ..Default::default()
+        };
+
+        let result = generate_q8_neon(&model, &cfg, &tokenizer, &rope, "hello", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "generate_q8_neon must fail closed with InvalidInput when stop_strings is set \
+             (ADR-080 C3, #783); got {result:?}"
+        );
+    }
+
+    /// `generate_q8_neon` must reject a `GenerateConfig` that sets `reasoning_budget`
+    /// with a typed `InvalidInput` error before sampling any token (ADR-080 C3, #783).
+    ///
+    /// Mutation sensitivity: removing the `check_reasoning_budget_not_set` call makes
+    /// the function proceed past the guard and attempt to forward with empty weights,
+    /// producing a panic or a non-`InvalidInput` error — this assert fails either way.
+    #[test]
+    fn generate_q8_neon_rejects_reasoning_budget_config_before_sampling() {
+        use crate::error::InferenceError;
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let model = Q8NeonModel {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            lm_head_packed: vec![],
+            lm_head_rows: 0,
+            lm_head_cols: 0,
+            layers: vec![],
+        };
+
+        let gen_cfg = GenerateConfig {
+            reasoning_budget: Some(16),
+            ..Default::default()
+        };
+
+        let result = generate_q8_neon(&model, &cfg, &tokenizer, &rope, "hello", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "generate_q8_neon must fail closed with InvalidInput when reasoning_budget is \
+             set (ADR-080 C3, #783); got {result:?}"
         );
     }
 

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -12,7 +12,7 @@ use crate::grammar::pda::GrammarState;
 use crate::model::qwen35_config::{
     GenerateConfig, GenerateOutput, Qwen35Config, TokenLogprob, decode_cap, force_close_think,
 };
-use crate::sampling::record_logprob;
+use crate::sampling::compute_step_logprobs;
 use crate::stop_reason::StopReason;
 use crate::tokenizer::common::Tokenizer;
 
@@ -256,6 +256,7 @@ impl Qwen35Model {
             &scratch.logits[..cfg.vocab_size],
             gen_cfg.temperature,
             generated_ids.len(),
+            false,
         );
 
         if gen_cfg.stop_strings.is_empty() {
@@ -290,7 +291,7 @@ impl Qwen35Model {
             // String-stop path: accumulate decoded text and check after every token.
             let mut detok = IncrementalDetokenizer::new();
             let first_delta = detok.push(&self.tokenizer, next_id);
-            let mut full = first_delta;
+            let mut full = String::new();
 
             // Tracks, per recorded `token_logprobs` entry, the length of `full`
             // immediately after that token's delta landed — grown in lockstep
@@ -298,20 +299,24 @@ impl Qwen35Model {
             // a stop-string truncation can drop exactly the trailing entries
             // whose text didn't fully survive. See
             // `truncate_token_logprobs_to_retained_text`.
-            let mut token_logprob_end_offsets: Vec<usize> = if token_logprobs.is_empty() {
-                Vec::new()
-            } else {
-                vec![full.len()]
-            };
+            let mut token_logprob_end_offsets: Vec<usize> = Vec::new();
 
-            // Check stop strings after the first token.
-            if let Some(hit) = earliest_stop_match(&full, &gen_cfg.stop_strings) {
-                full.truncate(hit);
-                truncate_token_logprobs_to_retained_text(
+            // Check stop strings after the first token (codex round-3 major
+            // #1, PR #787 / Leo's ruling): routed through the policy's owned
+            // stop-mode adapter (`check_initial_stop`) instead of the free
+            // `earliest_stop_match` call this site used to make directly --
+            // `full`/`token_logprob_end_offsets` are populated by the adapter
+            // itself, not by this call site.
+            if matches!(
+                policy.check_initial_stop(
                     &mut token_logprobs,
-                    &token_logprob_end_offsets,
-                    hit,
-                );
+                    &mut full,
+                    &mut token_logprob_end_offsets,
+                    &first_delta,
+                    |_| true,
+                ),
+                StopCheckOutcome::Stopped
+            ) {
                 // generated_ids already contains next_id; we cannot un-generate it,
                 // so token_ids/generated_tokens reflect all tokens up to the match.
                 return Ok(GenerateOutput {
@@ -625,6 +630,7 @@ impl Qwen35Model {
             &scratch.logits[..cfg.vocab_size],
             gen_cfg.temperature,
             generated_ids.len(),
+            true,
         );
 
         // Incremental detokenization: emit only complete-UTF-8 text deltas. A
@@ -638,20 +644,31 @@ impl Qwen35Model {
             // `text` is the caller-owned full output — the detokenizer itself only
             // retains a small undecided UTF-8 boundary tail (see IncrementalDetokenizer).
             let mut text = String::new();
+            let mut throwaway_offsets: Vec<usize> = Vec::new();
             let delta = detok.push(&self.tokenizer, next_id);
-            if !delta.is_empty() {
-                text.push_str(&delta);
-                if !on_token(&delta) {
-                    return Ok(GenerateOutput {
-                        text,
-                        token_ids: generated_ids.clone(),
-                        prompt_tokens: prompt_len,
-                        generated_tokens: generated_ids.len(),
-                        stopped: false, // caller interrupted the stream, not a stop condition
-                        stop_reason: Some(StopReason::Interrupt),
-                        token_logprobs,
-                    });
-                }
+            // Codex round-3 major #1, PR #787 / Leo's ruling: routed through
+            // the policy's owned stop-mode adapter (always `Disabled` here,
+            // since `gen_cfg.stop_strings` is empty) instead of a manual
+            // `text.push_str` + `on_token` call.
+            if matches!(
+                policy.check_initial_stop(
+                    &mut token_logprobs,
+                    &mut text,
+                    &mut throwaway_offsets,
+                    &delta,
+                    |s| on_token(s),
+                ),
+                StopCheckOutcome::Interrupted
+            ) {
+                return Ok(GenerateOutput {
+                    text,
+                    token_ids: generated_ids.clone(),
+                    prompt_tokens: prompt_len,
+                    generated_tokens: generated_ids.len(),
+                    stopped: false, // caller interrupted the stream, not a stop condition
+                    stop_reason: Some(StopReason::Interrupt),
+                    token_logprobs,
+                });
             }
 
             let mut stopped = false;
@@ -707,13 +724,12 @@ impl Qwen35Model {
                 // major #3, PR #787) -- see `DecodePolicy::transition`. Set
                 // stopped=true on a grammar stop so the caller sees a
                 // grammar-terminal stop as stopped=true, matching
-                // decode_loop's `return Ok(true)`. The `stop_check` closure
-                // (codex round-2 major #2, PR #787 / Leo's ruling) owns this
-                // fast path's delta-push + `on_token` interrupt check --
-                // there is no stop-string matching on this path
-                // (`gen_cfg.stop_strings` is empty), but the callback is
-                // still required, so it reports `Interrupted` when the
-                // caller's sink can no longer consume output.
+                // decode_loop's `return Ok(true)`. `policy.stop_mode` is
+                // always `Disabled` on this path (`gen_cfg.stop_strings` is
+                // empty); the adapter still threads text through to
+                // `on_token` and reports `Interrupted` when the caller's sink
+                // can no longer consume output (codex round-3 major #1, PR
+                // #787 / Leo's ruling).
                 let generated_len_before = generated_ids.len();
                 let outcome = policy.transition(
                     &mut token_logprobs,
@@ -733,16 +749,10 @@ impl Qwen35Model {
                         generated_ids.push(next_id);
                         all_ids.push(next_id);
                     },
-                    |next_id, _token_logprobs| {
-                        let delta = detok.push(&self.tokenizer, next_id);
-                        if !delta.is_empty() {
-                            text.push_str(&delta);
-                            if !on_token(&delta) {
-                                return StopCheckOutcome::Interrupted;
-                            }
-                        }
-                        StopCheckOutcome::Continue
-                    },
+                    |next_id| detok.push(&self.tokenizer, next_id),
+                    &mut text,
+                    &mut throwaway_offsets,
+                    |s, _next_id| on_token(s),
                 );
 
                 let answer_budget_exhausted = match outcome {
@@ -803,25 +813,24 @@ impl Qwen35Model {
                 token_logprobs,
             })
         } else {
-            // String-stop path: use StopStreamer to hold back (max_stop - 1) bytes and
-            // never emit a partial stop prefix before we can confirm it is not a match.
-            let mut streamer = StopStringMatcher::new(&gen_cfg.stop_strings);
-
-            // `StopStringMatcher::push`'s sink is `FnMut(&str)` (no return
-            // value), so a caller-requested stop is threaded through a
-            // captured flag instead -- mirrors the Metal
-            // `generate_streaming_with_cancel`'s `caller_interrupted` idiom
-            // exactly, for the same structural reason.
-            let mut caller_interrupted = false;
+            // String-stop path: `policy.stop_mode` is `StopMode::Streaming`
+            // (constructed in `DecodePolicy::init` above from the same
+            // non-empty `gen_cfg.stop_strings`), holding back (max_stop - 1)
+            // bytes so a partial stop prefix is never emitted before it is
+            // confirmed not to be a match.
+            let mut text = String::new();
+            let mut throwaway_offsets: Vec<usize> = Vec::new();
             let first_delta = detok.push(&self.tokenizer, next_id);
-            let stop_matched = streamer.push(&first_delta, &mut |s| {
-                if !caller_interrupted && !on_token(s) {
-                    caller_interrupted = true;
-                }
-            });
-            if caller_interrupted {
+            let initial_outcome = policy.check_initial_stop(
+                &mut token_logprobs,
+                &mut text,
+                &mut throwaway_offsets,
+                &first_delta,
+                |s| on_token(s),
+            );
+            if matches!(initial_outcome, StopCheckOutcome::Interrupted) {
                 return Ok(GenerateOutput {
-                    text: streamer.into_text(),
+                    text,
                     token_ids: generated_ids.clone(),
                     prompt_tokens: prompt_len,
                     generated_tokens: generated_ids.len(),
@@ -830,11 +839,11 @@ impl Qwen35Model {
                     token_logprobs,
                 });
             }
-            if stop_matched {
+            if matches!(initial_outcome, StopCheckOutcome::Stopped) {
                 // Stop matched in the very first token.
                 // token_ids already contain next_id; cannot un-generate it.
                 return Ok(GenerateOutput {
-                    text: streamer.into_text(),
+                    text,
                     token_ids: generated_ids.clone(),
                     prompt_tokens: prompt_len,
                     generated_tokens: generated_ids.len(),
@@ -890,13 +899,14 @@ impl Qwen35Model {
                 );
 
                 // One atomic per-step transition (ADR-080 C3 / codex round-1
-                // major #3, PR #787) -- see `DecodePolicy::transition`. The
-                // `stop_check` closure (codex round-2 major #2, PR #787 /
-                // Leo's ruling) owns this path's incremental byte-holdback
-                // stop-string match via `StopStringMatcher` -- moving it into
-                // the mandatory callback makes it structurally impossible
-                // for this call site to invoke `transition` while skipping
-                // the stop check.
+                // major #3, PR #787) -- see `DecodePolicy::transition`.
+                // `policy.stop_mode` (fixed to `StopMode::Streaming` at
+                // construction) owns the incremental byte-holdback
+                // stop-string match itself now (codex round-3 major #1, PR
+                // #787 / Leo's ruling) -- this call site supplies only
+                // `decode_delta` (this loop's own detokenizer) and the
+                // shared `text`/`throwaway_offsets` buffers, so it can no
+                // longer independently choose to skip the real stop check.
                 let generated_len_before = generated_ids.len();
                 let outcome = policy.transition(
                     &mut token_logprobs,
@@ -916,22 +926,10 @@ impl Qwen35Model {
                         generated_ids.push(next_id);
                         all_ids.push(next_id);
                     },
-                    |next_id, _token_logprobs| {
-                        let delta = detok.push(&self.tokenizer, next_id);
-                        let mut iter_interrupted = false;
-                        let stop_matched = streamer.push(&delta, &mut |s| {
-                            if !iter_interrupted && !on_token(s) {
-                                iter_interrupted = true;
-                            }
-                        });
-                        if iter_interrupted {
-                            return StopCheckOutcome::Interrupted;
-                        }
-                        if stop_matched {
-                            return StopCheckOutcome::Stopped;
-                        }
-                        StopCheckOutcome::Continue
-                    },
+                    |next_id| detok.push(&self.tokenizer, next_id),
+                    &mut text,
+                    &mut throwaway_offsets,
+                    |s, _next_id| on_token(s),
                 );
 
                 let answer_budget_exhausted = match outcome {
@@ -972,18 +970,16 @@ impl Qwen35Model {
             // the stream, and `on_token`'s return value here would not change
             // why generation actually stopped.
             if !stopped_by_caller {
-                streamer.finish(&detok.finish(), &mut |s| {
-                    on_token(s);
-                });
-                // finish() may itself complete a stop in the tail bytes.
-                if streamer.stopped() && !stopped {
+                let tail_stopped = policy.finish_stop(&mut text, &detok.finish(), |s| on_token(s));
+                // finish_stop may itself complete a stop in the tail bytes.
+                if tail_stopped && !stopped {
                     stopped = true;
                     stop_reason = StopReason::Eos;
                 }
             }
 
             Ok(GenerateOutput {
-                text: streamer.into_text(),
+                text,
                 token_ids: generated_ids.clone(),
                 prompt_tokens: prompt_len,
                 generated_tokens: generated_ids.len(),
@@ -1031,22 +1027,13 @@ pub(crate) enum StepOutcome {
     },
 }
 
-/// Outcome of the mandatory per-step stop-check callback [`DecodePolicy::transition`]
-/// drives (Leo's ruling on codex round-2 major #2, PR #787): the backend-specific
-/// stop-string consumption shape — streaming incremental byte-holdback via
-/// [`StopStringMatcher`], or non-streaming full-text rescan via
-/// `earliest_stop_match_from` — still differs by call site (these are genuinely
-/// different shapes per the existing round-1 rationale, not arbitrary
-/// duplication), and each shape needs its own backend-owned text buffer /
-/// `on_token` sink, which cannot move into this crate-shared enum. What
-/// changes is that a call site can no longer independently choose whether to
-/// check for a stop-string match at all: `transition` now takes the
-/// stop-check callback as a *required* parameter (the exact same footing as
-/// its existing `grammar_advance` / `is_eos` callbacks) and drives it at the
-/// one fixed point in the per-step order every site already used before this
-/// change. Omitting the callback is a compile error, not a silent gap — the
-/// no-stop-strings fast paths supply a trivial `|_, _| StopCheckOutcome::Continue`
-/// closure rather than skipping the parameter.
+/// Outcome of the mandatory per-step stop-check [`DecodePolicy::transition`]
+/// drives internally (codex round-3 major #1, PR #787: the round-2 mandatory
+/// `stop_check` closure could still compile as a trivial
+/// `|_, _| StopCheckOutcome::Continue` for a configuration that actually had
+/// stop strings — an arbitrary outcome-producing closure cannot be forced to
+/// consult real matcher state. `transition` no longer accepts one at all; see
+/// [`StopMode`] and [`DecodePolicy::stop_check`]).
 pub(crate) enum StopCheckOutcome {
     /// No stop-string match yet (or `stop_strings` is not configured for
     /// this generation at all) — keep decoding.
@@ -1096,22 +1083,22 @@ pub(crate) enum StopCheckOutcome {
 /// to skip a control, and doing so breaks every one of these behaviors at
 /// once rather than silently dropping just one.
 ///
-/// Stop-string matching (codex round-2 major #2, PR #787 / Leo's ruling): the
-/// streaming callers need [`StopStringMatcher`]'s incremental byte-holdback
-/// semantics (a partial match must never reach `on_token`), while the
-/// non-streaming path scans the fully accumulated string via
-/// `earliest_stop_match` / `earliest_stop_match_from` — genuinely different
-/// consumption shapes, each needing its own backend-owned text buffer /
-/// `on_token` sink that cannot move into this crate-shared struct (the sink
-/// signature itself differs: CPU's is `FnMut(&str) -> bool`, Metal's is
-/// `FnMut(&str, u32) -> bool`). What changed: `transition` now takes the
-/// stop-check as a sixth, *required* parameter — same footing as
-/// `grammar_advance` / `is_eos` — and drives it internally at the one fixed
-/// point every site already ran it at (see [`StopCheckOutcome`]). A call site
-/// can no longer invoke `transition` while independently choosing whether to
-/// check for a stop-string match at all: omitting the callback is a compile
-/// error, not a silent gap, and the no-stop-strings fast paths must supply an
-/// explicit no-op closure rather than skipping the parameter.
+/// Stop-string matching (codex round-3 major #1, PR #787 / Leo's Option A
+/// ruling): the streaming vs non-streaming consumption shapes genuinely
+/// differ (incremental byte-holdback via [`StopStringMatcher`] vs full-text
+/// rescan via `earliest_stop_match_from`), but which one applies — and
+/// whether checking happens at all — is now [`StopMode`], a value chosen
+/// exactly once from the real `gen_cfg.stop_strings` at [`DecodePolicy::init`]
+/// time and stored privately on the policy. A caller can no longer supply a
+/// closure that *decides* the stop outcome (round 2's `stop_check` parameter,
+/// which could compile as a trivial `|_, _| Continue` for any configuration
+/// regardless of what `stop_strings` actually held); it supplies only raw
+/// per-token I/O primitives — a decoded delta (`decode_delta`) and a
+/// confirmed-text sink (`emit_confirmed`) — and [`DecodePolicy::stop_check`]
+/// (called from both [`DecodePolicy::check_initial_stop`], for the
+/// prefill-derived first token, and `transition`, for every token after)
+/// dispatches on `self.stop_mode` to decide, using the real adapter for that
+/// mode, not caller-supplied decision logic.
 pub(crate) struct DecodePolicy {
     reasoning_budget: Option<usize>,
     enable_thinking: bool,
@@ -1120,6 +1107,54 @@ pub(crate) struct DecodePolicy {
     think_close_id: Option<u32>,
     thinking_closed: bool,
     reasoning_end_len: Option<usize>,
+    stop_mode: StopMode,
+}
+
+/// The stop-string check adapter a [`DecodePolicy`] owns (codex round-3
+/// major #1, PR #787 / Leo's Option A ruling). The only place a value of this
+/// type is ever produced is the private [`StopMode::for_config`], called once
+/// from [`DecodePolicy::init`] on the real `gen_cfg.stop_strings` — there is
+/// no public constructor, so a caller cannot independently choose (or swap
+/// in) `Disabled` for a configuration that actually has stop strings: the
+/// variant a given policy drives is fixed by the config it was built from,
+/// not by anything a call site writes.
+enum StopMode {
+    /// `gen_cfg.stop_strings` was empty at construction — there is nothing to
+    /// match, so [`DecodePolicy::stop_check`] only threads decoded text
+    /// through to the caller's sink (still needed for streaming callers'
+    /// `on_token`; a no-op for `decode_loop`, which has no text pipeline at
+    /// all).
+    Disabled,
+    /// Streaming incremental byte-holdback: the owned [`StopStringMatcher`]
+    /// ensures a partial match never reaches the caller's confirmed-text
+    /// sink. Used by every streaming call site with `stop_strings` set (CPU
+    /// `generate_streaming_with_cancel`'s stop-string branch, both Metal
+    /// streaming loops).
+    Streaming(StopStringMatcher),
+    /// Non-streaming full-text rescan, bounded to the suffix that could
+    /// contain a new match (`stop_scan_search_start`). Used only by CPU
+    /// `decode_loop_with_stops` (via `Qwen35Model::generate`'s stop-string
+    /// branch), which has no external consumer to hold text back from.
+    FullScan {
+        stop_strings: Vec<String>,
+        max_stop: usize,
+    },
+}
+
+impl StopMode {
+    fn for_config(stop_strings: &[String], streaming: bool) -> Self {
+        if stop_strings.is_empty() {
+            StopMode::Disabled
+        } else if streaming {
+            StopMode::Streaming(StopStringMatcher::new(stop_strings))
+        } else {
+            let max_stop = stop_strings.iter().map(String::len).max().unwrap_or(1);
+            StopMode::FullScan {
+                stop_strings: stop_strings.to_vec(),
+                max_stop,
+            }
+        }
+    }
 }
 
 impl DecodePolicy {
@@ -1143,7 +1178,13 @@ impl DecodePolicy {
     /// before the decode loop starts (the prefill-derived first token), covering the
     /// `reasoning_budget == 1` edge case exactly as the six duplicated call sites did.
     /// `first_logits` / `temperature` are the same values the free-function
-    /// `record_logprob` call used to take directly.
+    /// `record_logprob` call used to take directly. `streaming` selects which
+    /// [`StopMode`] a non-empty `gen_cfg.stop_strings` resolves to
+    /// (`Streaming`'s incremental holdback vs `FullScan`'s full-text rescan;
+    /// see [`StopMode::for_config`]) — pass `true` for every streaming caller
+    /// (CPU `generate_streaming_with_cancel`, both Metal streaming loops),
+    /// `false` for non-streaming callers (`Qwen35Model::generate`). An empty
+    /// `stop_strings` always resolves to `Disabled` regardless of `streaming`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn init(
         gen_cfg: &GenerateConfig,
@@ -1153,6 +1194,7 @@ impl DecodePolicy {
         first_logits: &[f32],
         temperature: f32,
         first_generated_len: usize,
+        streaming: bool,
     ) -> Self {
         let thinking_closed = Some(first_emitted_id) == think_close_id;
         let reasoning_end_len = if thinking_closed {
@@ -1168,6 +1210,7 @@ impl DecodePolicy {
             think_close_id,
             thinking_closed,
             reasoning_end_len,
+            stop_mode: StopMode::for_config(&gen_cfg.stop_strings, streaming),
         };
         policy.record_logprob(token_logprobs, first_logits, first_emitted_id, temperature);
         policy
@@ -1233,12 +1276,22 @@ impl DecodePolicy {
             .is_some_and(|end| generated_len.saturating_sub(end) >= self.max_new_tokens)
     }
 
-    /// Thin, zero-behavior-change wrapper over `crate::sampling::record_logprob`,
-    /// so logprobs formatting is owned by the same struct as the other two
-    /// backend-neutral policy legs (ADR-080 C3 contract text).
+    /// Appends one decode step's logprob data to `token_logprobs` when
+    /// `self.logprobs` requests it; a no-op otherwise (so callers can invoke
+    /// it unconditionally on every step -- the softmax pass over the full
+    /// vocabulary is paid only when logprobs were actually requested).
+    ///
+    /// This is the ONLY place in the crate that pushes onto a
+    /// `token_logprobs: &mut Vec<TokenLogprob>` accumulator (codex round-3
+    /// medium #2, PR #787 / Leo's ruling): `crate::sampling` exposes only
+    /// the pure computation (`compute_step_logprobs`), not a freestanding
+    /// "record" function a sibling decode call site could invoke directly
+    /// to recreate the exact duplicate-choreography bug this method's
+    /// privacy already closes for the other four constituent methods.
     ///
     /// Private (codex round-1 major #3, PR #787): only reachable through
-    /// [`DecodePolicy::transition`], which owns the full per-step ordering.
+    /// [`DecodePolicy::transition`] / [`DecodePolicy::init`], which own the
+    /// full per-step ordering.
     fn record_logprob(
         &self,
         token_logprobs: &mut Vec<TokenLogprob>,
@@ -1246,7 +1299,128 @@ impl DecodePolicy {
         token_id: u32,
         temperature: f32,
     ) {
-        record_logprob(token_logprobs, logits, token_id, temperature, self.logprobs);
+        let Some(top_n) = self.logprobs else {
+            return;
+        };
+        let (logprob, top) = compute_step_logprobs(logits, token_id, temperature, top_n);
+        token_logprobs.push(TokenLogprob {
+            token_id,
+            logprob,
+            top,
+        });
+    }
+
+    /// The stop-check adapter dispatch (codex round-3 major #1, PR #787 /
+    /// Leo's Option A ruling): drives whichever [`StopMode`] this policy was
+    /// constructed with, given the caller's freshly decoded delta text for
+    /// the current token. The caller supplies no decision logic at all — only
+    /// the decoded text and a sink for whatever text is confirmed safe to
+    /// release (`emit_confirmed`, called with the post-holdback-safe
+    /// substring for `Streaming`, the raw delta for `Disabled`, never for
+    /// `FullScan`, which has no external consumer). Shared by
+    /// [`DecodePolicy::check_initial_stop`] (the prefill-derived first token,
+    /// called once before the decode loop) and `transition` (every token
+    /// after) — the same `self.stop_mode` instance is mutated across both
+    /// calls, so `Streaming`'s incremental byte-holdback state carries over
+    /// correctly from the first token onward, exactly as it did when each
+    /// call site constructed and drove its own matcher by hand.
+    ///
+    /// Private (codex round-1 major #3 / round-3 major #1, PR #787): only
+    /// reachable through the two methods above.
+    fn stop_check(
+        &mut self,
+        token_logprobs: &mut Vec<TokenLogprob>,
+        text: &mut String,
+        token_logprob_end_offsets: &mut Vec<usize>,
+        delta: &str,
+        mut emit_confirmed: impl FnMut(&str) -> bool,
+    ) -> StopCheckOutcome {
+        match &mut self.stop_mode {
+            StopMode::Disabled => {
+                if delta.is_empty() {
+                    return StopCheckOutcome::Continue;
+                }
+                text.push_str(delta);
+                if emit_confirmed(delta) {
+                    StopCheckOutcome::Continue
+                } else {
+                    StopCheckOutcome::Interrupted
+                }
+            }
+            StopMode::Streaming(matcher) => {
+                let mut interrupted = false;
+                let stop_matched = matcher.push(delta, &mut |s| {
+                    if !s.is_empty() {
+                        text.push_str(s);
+                        if !interrupted && !emit_confirmed(s) {
+                            interrupted = true;
+                        }
+                    }
+                });
+                if interrupted {
+                    StopCheckOutcome::Interrupted
+                } else if stop_matched {
+                    StopCheckOutcome::Stopped
+                } else {
+                    StopCheckOutcome::Continue
+                }
+            }
+            StopMode::FullScan {
+                stop_strings,
+                max_stop,
+            } => {
+                let prev_len = text.len();
+                if !delta.is_empty() {
+                    text.push_str(delta);
+                }
+                // Keep the offset tracker in lockstep with token_logprobs'
+                // conditional growth (record_logprob is a no-op unless
+                // gen_cfg.logprobs is set).
+                if token_logprobs.len() > token_logprob_end_offsets.len() {
+                    token_logprob_end_offsets.push(text.len());
+                }
+                let search_start = stop_scan_search_start(text, prev_len, *max_stop);
+                if let Some(hit) = earliest_stop_match_from(text, stop_strings, search_start) {
+                    text.truncate(hit);
+                    truncate_token_logprobs_to_retained_text(
+                        token_logprobs,
+                        token_logprob_end_offsets,
+                        hit,
+                    );
+                    StopCheckOutcome::Stopped
+                } else {
+                    StopCheckOutcome::Continue
+                }
+            }
+        }
+    }
+
+    /// Checks the prefill-derived first token's already-decoded delta text
+    /// against this policy's stop-mode (codex round-3 major #1, PR #787 /
+    /// Leo's ruling), before the decode loop starts — the first token is
+    /// pushed and its logprob recorded by [`DecodePolicy::init`] outside
+    /// `transition`'s per-step scope (it has no preceding grammar-advance /
+    /// EOS check of its own to run through `transition` for), so its
+    /// stop-string check needs its own entry point. Uses the SAME
+    /// `self.stop_mode` instance `transition` will keep driving for every
+    /// subsequent token, so `Streaming`'s byte-holdback state is continuous
+    /// across the boundary — critical for a match that spans the first and
+    /// second tokens, which a freshly-constructed second matcher would miss.
+    pub(crate) fn check_initial_stop(
+        &mut self,
+        token_logprobs: &mut Vec<TokenLogprob>,
+        text: &mut String,
+        token_logprob_end_offsets: &mut Vec<usize>,
+        delta: &str,
+        emit_confirmed: impl FnMut(&str) -> bool,
+    ) -> StopCheckOutcome {
+        self.stop_check(
+            token_logprobs,
+            text,
+            token_logprob_end_offsets,
+            delta,
+            emit_confirmed,
+        )
     }
 
     /// The one per-step transition (ADR-080 C3 / codex round-1 major #3, PR
@@ -1255,7 +1429,7 @@ impl DecodePolicy {
     /// callback, the emitted-token bookkeeping, the backend's EOS/stop-token
     /// callback, the backend's push callback (into its own `generated_ids` /
     /// `all_ids` or Metal-equivalent vectors), per-token logprobs recording,
-    /// reasoning-end capture, the backend's stop-string check, and the
+    /// reasoning-end capture, the owned stop-check adapter, and the
     /// answer-budget check.
     ///
     /// `grammar_advance` and `is_eos` are backend callbacks because grammar
@@ -1269,26 +1443,24 @@ impl DecodePolicy {
     /// the *next* loop iteration (`all_ids.last()` feeds the next
     /// `forward_step`) — the caller cannot hand that ownership to the policy.
     ///
-    /// `stop_check` is likewise a required backend callback (codex round-2
-    /// major #2, PR #787 / Leo's ruling): the incremental byte-holdback
-    /// (streaming) vs full-text rescan (non-streaming) shapes, and their
-    /// backend-owned text buffers / `on_token` sinks, remain genuinely
-    /// backend-specific — but the callback itself is no longer optional
-    /// choreography a call site can skip. It receives the emitted token id
-    /// and a reborrow of `token_logprobs` (so a non-streaming caller can
-    /// retroactively drop trailing logprob entries whose text a stop match
-    /// truncated away, exactly as `decode_loop_with_stops` already did), and
-    /// runs after logprobs recording / reasoning-end capture, before the
-    /// answer-budget check — the same position every site already ran its
-    /// stop-check code at before this change.
+    /// `decode_delta` / `text` / `token_logprob_end_offsets` / `emit_confirmed`
+    /// (codex round-3 major #1, PR #787 / Leo's ruling) replace round-2's
+    /// arbitrary outcome-producing `stop_check` closure: the caller supplies
+    /// only raw I/O (decode a token to text; a buffer to accumulate into; an
+    /// offset tracker only `StopMode::FullScan` consults; a sink for
+    /// confirmed-safe text), and [`DecodePolicy::stop_check`] — driven from
+    /// `self.stop_mode`, fixed at construction from the real
+    /// `gen_cfg.stop_strings` — decides the outcome. A call site can no
+    /// longer claim `Continue` for a configuration that actually has stop
+    /// strings, because it no longer produces the outcome at all.
     ///
     /// Returns [`StepOutcome::GrammarStop`] / [`StepOutcome::Eos`] without
     /// ever calling `push` when the token is rejected before emission
     /// (matching the existing contract that a stop token is never present in
     /// `token_ids`); [`StepOutcome::Stopped`] / [`StepOutcome::Interrupted`]
-    /// when `stop_check` reports either outcome (the answer-budget check is
-    /// skipped in both cases, matching every site's original control flow,
-    /// which broke out of the loop before ever reaching it); or
+    /// when the stop-check adapter reports either outcome (the answer-budget
+    /// check is skipped in both cases, matching every site's original control
+    /// flow, which broke out of the loop before ever reaching it); or
     /// [`StepOutcome::Emitted`] once the token has been pushed and every
     /// remaining control, including a `Continue` stop-check, applied.
     #[allow(clippy::too_many_arguments)]
@@ -1302,7 +1474,10 @@ impl DecodePolicy {
         mut grammar_advance: impl FnMut(u32) -> bool,
         mut is_eos: impl FnMut(u32) -> bool,
         mut push: impl FnMut(u32),
-        mut stop_check: impl FnMut(u32, &mut Vec<TokenLogprob>) -> StopCheckOutcome,
+        mut decode_delta: impl FnMut(u32) -> String,
+        text: &mut String,
+        token_logprob_end_offsets: &mut Vec<usize>,
+        mut emit_confirmed: impl FnMut(&str, u32) -> bool,
     ) -> StepOutcome {
         let next_id = self.apply_override(generated_len_before, sampled_id);
 
@@ -1322,7 +1497,15 @@ impl DecodePolicy {
         self.record_logprob(token_logprobs, logits, next_id, temperature);
         self.capture_reasoning_end(generated_len_after);
 
-        match stop_check(next_id, token_logprobs) {
+        let delta = decode_delta(next_id);
+        let stop_outcome = self.stop_check(
+            token_logprobs,
+            text,
+            token_logprob_end_offsets,
+            &delta,
+            |s| emit_confirmed(s, next_id),
+        );
+        match stop_outcome {
             StopCheckOutcome::Stopped => return StepOutcome::Stopped,
             StopCheckOutcome::Interrupted => return StepOutcome::Interrupted,
             StopCheckOutcome::Continue => {}
@@ -1331,6 +1514,49 @@ impl DecodePolicy {
         StepOutcome::Emitted {
             token_id: next_id,
             answer_budget_exhausted: self.answer_budget_exhausted(generated_len_after),
+        }
+    }
+
+    /// Natural-end flush (decode loop ended by cap/EOS/grammar-stop, not by
+    /// `stop_check` reporting `Stopped`/`Interrupted`). `tail` is the
+    /// detokenizer's own end-of-generation flush (`detok.finish()`).
+    ///
+    /// A no-op for `Disabled` beyond appending+emitting `tail` directly (there
+    /// is nothing held back to reconcile) and for `FullScan` (the
+    /// non-streaming caller owns its own tail-flush against its `full` buffer
+    /// directly, e.g. `decode_loop_with_stops`, since it has no external
+    /// consumer to hold text back from in the first place). Only `Streaming`
+    /// mode's owned [`StopStringMatcher`] can be holding back up to
+    /// `max_stop - 1` unconfirmed bytes that must be reconciled once the
+    /// token source is exhausted — mirrors `StopStringMatcher::finish`
+    /// exactly, since that is the only mode this call does real work for.
+    ///
+    /// Returns `true` when the tail flush itself completed a stop match
+    /// (`Streaming` only; always `false` for `Disabled`/`FullScan`).
+    pub(crate) fn finish_stop(
+        &mut self,
+        text: &mut String,
+        tail: &str,
+        mut emit_confirmed: impl FnMut(&str) -> bool,
+    ) -> bool {
+        match &mut self.stop_mode {
+            StopMode::Disabled => {
+                if !tail.is_empty() {
+                    text.push_str(tail);
+                    emit_confirmed(tail);
+                }
+                false
+            }
+            StopMode::Streaming(matcher) => {
+                matcher.finish(tail, &mut |s| {
+                    if !s.is_empty() {
+                        text.push_str(s);
+                        emit_confirmed(s);
+                    }
+                });
+                matcher.stopped()
+            }
+            StopMode::FullScan { .. } => false,
         }
     }
 }
@@ -1435,14 +1661,22 @@ fn decode_loop(
         // One atomic per-step transition (ADR-080 C3 / codex round-1 major
         // #3, PR #787): budget override, grammar-advance callback, emitted
         // bookkeeping, EOS callback, push callback, logprobs, reasoning-end
-        // capture, the (here, no-op) stop-check callback, and the
-        // answer-budget check, all in the fixed required order -- see
-        // `DecodePolicy::transition`. This function is only ever called when
-        // `gen_cfg.stop_strings` is empty (see `generate()`'s branch), so
-        // `stop_check` is a trivial `Continue` (codex round-2 major #2, PR
-        // #787 / Leo's ruling: the callback is required on every call, not
-        // just where a real check is needed).
+        // capture, the stop-check adapter, and the answer-budget check, all
+        // in the fixed required order -- see `DecodePolicy::transition`. This
+        // function is only ever called when `gen_cfg.stop_strings` is empty
+        // (see `generate()`'s branch), so `policy.stop_mode` is always
+        // `StopMode::Disabled` here, and this function has no text/detok
+        // pipeline of its own at all (it returns raw token ids, decoded once
+        // at the very end by `decode_tokens`) -- `decode_delta`/`text`/
+        // `token_logprob_end_offsets`/`emit_confirmed` are therefore
+        // throwaway values the `Disabled` dispatch never populates
+        // meaningfully (codex round-3 major #1, PR #787 / Leo's ruling: this
+        // is honest, not an escape hatch -- the empty-stop_strings guarantee
+        // now lives in `policy.stop_mode`, derived from the real config at
+        // `DecodePolicy::init`, not in a caller-chosen closure).
         let generated_len_before = generated_ids.len();
+        let mut throwaway_text = String::new();
+        let mut throwaway_offsets: Vec<usize> = Vec::new();
         let outcome = policy.transition(
             token_logprobs,
             sampled_id,
@@ -1461,7 +1695,10 @@ fn decode_loop(
                 generated_ids.push(next_id);
                 all_ids.push(next_id);
             },
-            |_next_id, _token_logprobs| StopCheckOutcome::Continue,
+            |_next_id| String::new(),
+            &mut throwaway_text,
+            &mut throwaway_offsets,
+            |_delta, _next_id| true,
         );
 
         match outcome {
@@ -1514,17 +1751,6 @@ fn decode_loop_with_stops(
     let mut stopped = false;
     let mut stop_reason = StopReason::Length;
     let cap = policy.cap();
-    // Longest configured stop string, used to bound the per-token stop scan to
-    // the suffix that could contain a new match (see `earliest_stop_match_from`).
-    // `full` already reflects everything scanned before this function was
-    // called (the pre-loop first-token check), so its current length is the
-    // correct starting point for the "already scanned" prefix.
-    let max_stop = gen_cfg
-        .stop_strings
-        .iter()
-        .map(String::len)
-        .max()
-        .unwrap_or(1);
     for _ in 1..cap {
         let pos = kv_cache.seq_len;
         let Some(&last_token) = all_ids.last() else {
@@ -1554,12 +1780,15 @@ fn decode_loop_with_stops(
         );
 
         // One atomic per-step transition (ADR-080 C3 / codex round-1 major
-        // #3, PR #787) -- see `DecodePolicy::transition`. The `stop_check`
-        // closure (codex round-2 major #2, PR #787 / Leo's ruling) now owns
-        // exactly the detok/rescan/truncate work this loop used to run
-        // separately AFTER `transition` returned -- moving it into the
-        // mandatory callback makes it structurally impossible for this call
-        // site to invoke `transition` while skipping the stop check.
+        // #3, PR #787) -- see `DecodePolicy::transition`. The stop-check
+        // adapter (codex round-3 major #1, PR #787 / Leo's ruling) now owns
+        // the rescan/truncate work this loop used to run itself in a
+        // `stop_check` closure -- this call site supplies only `decode_delta`
+        // (this loop's own detokenizer) and the shared `full`/
+        // `token_logprob_end_offsets` buffers; `policy.stop_mode` (fixed to
+        // `StopMode::FullScan` at construction, since this function is only
+        // called when `gen_cfg.stop_strings` is non-empty) does the actual
+        // rescan/truncate, not caller-supplied closure logic.
         let generated_len_before = generated_ids.len();
         let outcome = policy.transition(
             token_logprobs,
@@ -1579,43 +1808,10 @@ fn decode_loop_with_stops(
                 generated_ids.push(next_id);
                 all_ids.push(next_id);
             },
-            |next_id, token_logprobs| {
-                let prev_len = full.len();
-                let delta = detok.push(&model.tokenizer, next_id);
-                if !delta.is_empty() {
-                    full.push_str(&delta);
-                }
-
-                // Keep the offset tracker in lockstep with token_logprobs'
-                // conditional growth (record_logprob is a no-op unless
-                // gen_cfg.logprobs is set).
-                if token_logprobs.len() > token_logprob_end_offsets.len() {
-                    token_logprob_end_offsets.push(full.len());
-                }
-
-                // Only the suffix that could contain a NEW match needs
-                // rescanning -- any match fully inside `full[..prev_len]`
-                // would already have been found on a prior iteration (see
-                // `earliest_stop_match_from`'s doc comment). Bounds
-                // per-token work instead of rescanning all of `full`.
-                // Shared with `StopStringMatcher::push` via
-                // `stop_scan_search_start` so both call sites derive the
-                // bound identically.
-                let search_start = stop_scan_search_start(full, prev_len, max_stop);
-                if let Some(hit) =
-                    earliest_stop_match_from(full, &gen_cfg.stop_strings, search_start)
-                {
-                    full.truncate(hit);
-                    truncate_token_logprobs_to_retained_text(
-                        token_logprobs,
-                        token_logprob_end_offsets,
-                        hit,
-                    );
-                    StopCheckOutcome::Stopped
-                } else {
-                    StopCheckOutcome::Continue
-                }
-            },
+            |next_id| detok.push(&model.tokenizer, next_id),
+            full,
+            token_logprob_end_offsets,
+            |_delta, _next_id| true,
         );
 
         let (_next_id, answer_budget_exhausted) = match outcome {
@@ -2786,8 +2982,8 @@ mod tests {
     /// this test pins that alternate code path independently of the fast
     /// path above).
     ///
-    /// Mutation sensitivity: dropping the `caller_interrupted` check after
-    /// the pre-loop `streamer.push` call lets generation continue into the
+    /// Mutation sensitivity: dropping the interrupted check after the
+    /// pre-loop `check_initial_stop` call lets generation continue into the
     /// decode loop, failing `generated_tokens == 1`.
     #[test]
     fn generate_streaming_with_cancel_on_token_false_stops_generation_stop_string_path() {
@@ -2902,6 +3098,41 @@ mod tests {
             result.token_logprobs.is_empty(),
             "both tokens' text was only partially retained after truncation, so both \
              logprobs entries must be dropped; got {} entries",
+            result.token_logprobs.len()
+        );
+    }
+
+    /// Codex round-3 medium #2 (PR #787 / Leo's ruling): with `gen_cfg.logprobs`
+    /// left at its default (`None`), `DecodePolicy::record_logprob` (driven by
+    /// both `init` for the prefill token and `transition` for every token
+    /// after) must be a true no-op -- `token_logprobs` stays empty for the
+    /// whole generation, not just for the truncated-text case the test above
+    /// covers. Replaces `sampling.rs`'s now-removed
+    /// `test_record_logprob_noop_when_not_requested`: that free function no
+    /// longer exists (its mutation into `crate::sampling` was the whole
+    /// point of the fix), so its behavioral contract is asserted here, at
+    /// the only place that can still exercise it.
+    ///
+    /// Mutation sensitivity: removing the `let Some(top_n) = self.logprobs
+    /// else { return; };` guard inside `DecodePolicy::record_logprob` makes
+    /// every token here get an (incorrect) `TokenLogprob` entry, failing
+    /// `token_logprobs.is_empty()`.
+    #[test]
+    fn decode_policy_record_logprob_noop_when_not_requested() {
+        let model = build_tiny_zero_model();
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 3,
+            temperature: 0.0,
+            logprobs: None,
+            ..Default::default()
+        };
+        let result = model
+            .generate("a", &gen_cfg)
+            .expect("plain generate must succeed");
+        assert!(
+            result.token_logprobs.is_empty(),
+            "logprobs: None must record nothing across the whole generation \
+             (prefill token via init, decode tokens via transition); got {} entries",
             result.token_logprobs.len()
         );
     }

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -251,7 +251,7 @@ impl Qwen35Model {
         } else {
             None
         };
-        let thinking_closed_seed = Some(next_id) == think_close_id;
+        let mut policy = DecodePolicy::new(gen_cfg, think_close_id, next_id, generated_ids.len());
 
         if gen_cfg.stop_strings.is_empty() {
             // Fast path: no string-level stops. Behaviour byte-for-byte identical
@@ -266,8 +266,7 @@ impl Qwen35Model {
                 &mut kv_cache,
                 &mut scratch,
                 &mut grammar_state,
-                think_close_id,
-                thinking_closed_seed,
+                &mut policy,
                 &mut token_logprobs,
             )?;
 
@@ -333,8 +332,7 @@ impl Qwen35Model {
                 &mut detok,
                 &mut full,
                 &mut grammar_state,
-                think_close_id,
-                thinking_closed_seed,
+                &mut policy,
                 &mut token_logprobs,
                 &mut token_logprob_end_offsets,
             )?;
@@ -617,14 +615,7 @@ impl Qwen35Model {
         } else {
             None
         };
-        let mut thinking_closed = Some(next_id) == think_close_id;
-        // Tracks generated_ids length at the moment </think> was emitted, for the
-        // answer-budget break. None when reasoning_budget is disabled (parity-safe).
-        let mut reasoning_end_len: Option<usize> = None;
-        // Capture close-point after prefill push (covers budget=1 edge case).
-        if thinking_closed && reasoning_end_len.is_none() {
-            reasoning_end_len = Some(generated_ids.len());
-        }
+        let mut policy = DecodePolicy::new(gen_cfg, think_close_id, next_id, generated_ids.len());
 
         // Incremental detokenization: emit only complete-UTF-8 text deltas. A
         // byte-level BPE codepoint can span several tokens, so we buffer raw bytes
@@ -658,7 +649,7 @@ impl Qwen35Model {
             let mut stop_reason = StopReason::Length;
             // Decode loop (mirrors decode_loop free function exactly).
             // cap = rb + max_new_tokens when budgeting; max_new_tokens otherwise (parity-safe).
-            let cap = decode_cap(gen_cfg.reasoning_budget, gen_cfg.max_new_tokens);
+            let cap = policy.cap();
             for _ in 1..cap {
                 // Checked before any per-step work, independent of whether this
                 // iteration's delta ends up non-empty -- closes the gap where a
@@ -704,14 +695,7 @@ impl Qwen35Model {
 
                 // Budget forcing: override sampled token with </think> when the
                 // reasoning budget is exhausted and the block is still open.
-                let next_id = force_close_think(
-                    gen_cfg.reasoning_budget,
-                    gen_cfg.enable_thinking,
-                    thinking_closed,
-                    generated_ids.len(),
-                    think_close_id,
-                )
-                .unwrap_or(sampled_id);
+                let next_id = policy.apply_override(generated_ids.len(), sampled_id);
 
                 // Grammar advance on the actually-emitted token (after any budget
                 // override): a false return signals grammar completion. Set
@@ -726,9 +710,7 @@ impl Qwen35Model {
                 }
 
                 // Track when the thinking block closes (natural or forced).
-                if Some(next_id) == think_close_id {
-                    thinking_closed = true;
-                }
+                policy.note_emitted(next_id);
 
                 if should_stop_token(cfg, gen_cfg, next_id) {
                     stopped = true;
@@ -738,17 +720,14 @@ impl Qwen35Model {
 
                 generated_ids.push(next_id);
                 all_ids.push(next_id);
-                record_logprob(
+                policy.record_logprob(
                     &mut token_logprobs,
                     &scratch.logits[..cfg.vocab_size],
                     next_id,
                     gen_cfg.temperature,
-                    gen_cfg.logprobs,
                 );
                 // Capture close-point after push so </think> is the last reasoning token.
-                if thinking_closed && reasoning_end_len.is_none() {
-                    reasoning_end_len = Some(generated_ids.len());
-                }
+                policy.capture_reasoning_end(generated_ids.len());
 
                 let delta = detok.push(&self.tokenizer, next_id);
                 if !delta.is_empty() {
@@ -761,9 +740,7 @@ impl Qwen35Model {
                 }
 
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-                if let Some(end) = reasoning_end_len
-                    && generated_ids.len().saturating_sub(end) >= gen_cfg.max_new_tokens
-                {
+                if policy.answer_budget_exhausted(generated_ids.len()) {
                     break;
                 }
             }
@@ -835,7 +812,7 @@ impl Qwen35Model {
             let mut stop_reason = StopReason::Length;
             // Decode loop for the string-stop path.
             // cap = rb + max_new_tokens when budgeting; max_new_tokens otherwise (parity-safe).
-            let cap = decode_cap(gen_cfg.reasoning_budget, gen_cfg.max_new_tokens);
+            let cap = policy.cap();
             for _ in 1..cap {
                 if should_cancel() {
                     stopped_by_caller = true;
@@ -877,14 +854,7 @@ impl Qwen35Model {
 
                 // Budget forcing: override sampled token with </think> when the
                 // reasoning budget is exhausted and the block is still open.
-                let next_id = force_close_think(
-                    gen_cfg.reasoning_budget,
-                    gen_cfg.enable_thinking,
-                    thinking_closed,
-                    generated_ids.len(),
-                    think_close_id,
-                )
-                .unwrap_or(sampled_id);
+                let next_id = policy.apply_override(generated_ids.len(), sampled_id);
 
                 // Grammar advance on the actually-emitted token (after any budget
                 // override): break cleanly when the grammar signals completion.
@@ -897,9 +867,7 @@ impl Qwen35Model {
                 }
 
                 // Track when the thinking block closes (natural or forced).
-                if Some(next_id) == think_close_id {
-                    thinking_closed = true;
-                }
+                policy.note_emitted(next_id);
 
                 if should_stop_token(cfg, gen_cfg, next_id) {
                     stopped = true;
@@ -909,17 +877,14 @@ impl Qwen35Model {
 
                 generated_ids.push(next_id);
                 all_ids.push(next_id);
-                record_logprob(
+                policy.record_logprob(
                     &mut token_logprobs,
                     &scratch.logits[..cfg.vocab_size],
                     next_id,
                     gen_cfg.temperature,
-                    gen_cfg.logprobs,
                 );
                 // Capture close-point after push so </think> is the last reasoning token.
-                if thinking_closed && reasoning_end_len.is_none() {
-                    reasoning_end_len = Some(generated_ids.len());
-                }
+                policy.capture_reasoning_end(generated_ids.len());
 
                 let delta = detok.push(&self.tokenizer, next_id);
                 let mut iter_interrupted = false;
@@ -940,9 +905,7 @@ impl Qwen35Model {
                 }
 
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-                if let Some(end) = reasoning_end_len
-                    && generated_ids.len().saturating_sub(end) >= gen_cfg.max_new_tokens
-                {
+                if policy.answer_budget_exhausted(generated_ids.len()) {
                     break;
                 }
             }
@@ -972,6 +935,146 @@ impl Qwen35Model {
                 token_logprobs,
             })
         }
+    }
+}
+
+/// Backend-neutral decode-policy state (ADR-080 C3): reasoning-budget
+/// accounting and logprobs formatting, shared by every canonical/streaming
+/// decode loop — CPU [`decode_loop`], [`decode_loop_with_stops`], both
+/// branches of [`Qwen35Model::generate_streaming_with_cancel`], and the Metal
+/// `generate_streaming` / `generate_streaming_with_prefix_cache_and_cancel_inner`
+/// loops in `crate::forward::metal_qwen35` — via a per-step forward callback
+/// seam: each backend keeps `forward_step`, grammar masking/advance,
+/// sampling, and EOS/stop-token checking entirely to itself, and only hands
+/// the policy the token its own pipeline just sampled
+/// ([`DecodePolicy::apply_override`], which may replace it with the forced
+/// `</think>` token), then reports back once the final token is actually
+/// emitted ([`DecodePolicy::note_emitted`] / [`DecodePolicy::capture_reasoning_end`])
+/// so the policy can tell the loop when the answer-budget window has closed
+/// ([`DecodePolicy::answer_budget_exhausted`]).
+///
+/// Before this struct existed, this exact bookkeeping (`think_close_id`
+/// resolution, `thinking_closed` / `reasoning_end_len` tracking, the
+/// `decode_cap` / `force_close_think` calls, and the answer-budget break
+/// condition) was hand-duplicated across six independent decode loops —
+/// exactly the drift ADR-080 C3 exists to prevent: a seventh loop could add
+/// its own copy and silently diverge from the other six. `DecodePolicy` also
+/// owns per-step logprobs recording ([`DecodePolicy::record_logprob`]), which
+/// was already a single shared free function (`crate::sampling::record_logprob`)
+/// called identically by all six sites; wrapping it here keeps every piece of
+/// backend-neutral per-step policy under one owner.
+///
+/// Stop-string matching state is deliberately *not* folded into this struct:
+/// the streaming callers need [`StopStringMatcher`]'s incremental
+/// byte-holdback semantics (a partial match must never reach `on_token`),
+/// while the non-streaming path scans the fully accumulated string via
+/// `earliest_stop_match` / `earliest_stop_match_from`. Both were already
+/// unified at the type/free-function level before this PR (every streaming
+/// caller, CPU and Metal, shares the one `StopStringMatcher` type; every
+/// non-streaming caller shares the one `earliest_stop_match*` pair) — there
+/// is no per-loop duplication left to remove there, only two genuinely
+/// different consumption modes of the same shared components, mirroring the
+/// same "document, don't force" principle applied to backend-specific Metal
+/// logic elsewhere in this cluster.
+pub(crate) struct DecodePolicy {
+    reasoning_budget: Option<usize>,
+    enable_thinking: bool,
+    max_new_tokens: usize,
+    logprobs: Option<usize>,
+    think_close_id: Option<u32>,
+    thinking_closed: bool,
+    reasoning_end_len: Option<usize>,
+}
+
+impl DecodePolicy {
+    /// `think_close_id` is resolved by the caller (`tokenizer.special_token_id("</think>")`
+    /// when `gen_cfg.reasoning_budget.is_some()`, `None` otherwise) since each backend
+    /// reaches its tokenizer differently. `first_emitted_id` / `first_generated_len` seed
+    /// `thinking_closed` / `reasoning_end_len` from the token already sampled and pushed
+    /// before the decode loop starts (the prefill-derived first token), covering the
+    /// `reasoning_budget == 1` edge case exactly as the six duplicated call sites did.
+    pub(crate) fn new(
+        gen_cfg: &GenerateConfig,
+        think_close_id: Option<u32>,
+        first_emitted_id: u32,
+        first_generated_len: usize,
+    ) -> Self {
+        let thinking_closed = Some(first_emitted_id) == think_close_id;
+        let reasoning_end_len = if thinking_closed {
+            Some(first_generated_len)
+        } else {
+            None
+        };
+        Self {
+            reasoning_budget: gen_cfg.reasoning_budget,
+            enable_thinking: gen_cfg.enable_thinking,
+            max_new_tokens: gen_cfg.max_new_tokens,
+            logprobs: gen_cfg.logprobs,
+            think_close_id,
+            thinking_closed,
+            reasoning_end_len,
+        }
+    }
+
+    /// Total decode-loop iteration cap (`rb + max_new_tokens + 1` when budgeted,
+    /// `max_new_tokens` otherwise) — see [`decode_cap`].
+    pub(crate) fn cap(&self) -> usize {
+        decode_cap(self.reasoning_budget, self.max_new_tokens)
+    }
+
+    /// Overrides `sampled_id` with the forced `</think>` token when the reasoning
+    /// budget is exhausted and the block is still open; a no-op pass-through
+    /// otherwise. Call after sampling, before grammar-advance (the actually-emitted
+    /// token, post-override, is what grammar must advance on).
+    pub(crate) fn apply_override(&self, generated_len: usize, sampled_id: u32) -> u32 {
+        force_close_think(
+            self.reasoning_budget,
+            self.enable_thinking,
+            self.thinking_closed,
+            generated_len,
+            self.think_close_id,
+        )
+        .unwrap_or(sampled_id)
+    }
+
+    /// Marks the thinking block closed when `next_id` (the actually-emitted,
+    /// post-override token) is the `</think>` token. Call after grammar-advance
+    /// succeeds, before the EOS/stop-token check — mirrors the original inline
+    /// ordering across all six sites.
+    pub(crate) fn note_emitted(&mut self, next_id: u32) {
+        if Some(next_id) == self.think_close_id {
+            self.thinking_closed = true;
+        }
+    }
+
+    /// Captures the answer-budget window start the first time the thinking block
+    /// closes, using the generated-token count *after* the token was pushed (so
+    /// `</think>` itself is the last reasoning token, not the first answer token).
+    /// A no-op once already captured or while the block is still open.
+    pub(crate) fn capture_reasoning_end(&mut self, generated_len_after_push: usize) {
+        if self.thinking_closed && self.reasoning_end_len.is_none() {
+            self.reasoning_end_len = Some(generated_len_after_push);
+        }
+    }
+
+    /// True once `max_new_tokens` answer tokens have followed the `</think>` close
+    /// point — the decode loop should break on this, in addition to its normal cap.
+    pub(crate) fn answer_budget_exhausted(&self, generated_len: usize) -> bool {
+        self.reasoning_end_len
+            .is_some_and(|end| generated_len.saturating_sub(end) >= self.max_new_tokens)
+    }
+
+    /// Thin, zero-behavior-change wrapper over `crate::sampling::record_logprob`,
+    /// so logprobs formatting is owned by the same struct as the other two
+    /// backend-neutral policy legs (ADR-080 C3 contract text).
+    pub(crate) fn record_logprob(
+        &self,
+        token_logprobs: &mut Vec<TokenLogprob>,
+        logits: &[f32],
+        token_id: u32,
+        temperature: f32,
+    ) {
+        record_logprob(token_logprobs, logits, token_id, temperature, self.logprobs);
     }
 }
 
@@ -1039,18 +1142,11 @@ fn decode_loop(
     kv_cache: &mut KvCache,
     scratch: &mut ForwardScratch,
     grammar_state: &mut Option<GrammarState>,
-    think_close_id: Option<u32>,
-    thinking_closed_seed: bool,
+    policy: &mut DecodePolicy,
     token_logprobs: &mut Vec<TokenLogprob>,
 ) -> Result<(bool, StopReason), InferenceError> {
     let cfg = &model.config;
-    let mut thinking_closed = thinking_closed_seed;
-    let mut reasoning_end_len: Option<usize> = if thinking_closed {
-        Some(generated_ids.len())
-    } else {
-        None
-    };
-    let cap = decode_cap(gen_cfg.reasoning_budget, gen_cfg.max_new_tokens);
+    let cap = policy.cap();
     for _ in 1..cap {
         let pos = kv_cache.seq_len;
         let Some(&last_token) = all_ids.last() else {
@@ -1081,14 +1177,7 @@ fn decode_loop(
 
         // Budget forcing: override the sampled token with </think> when the
         // reasoning budget is exhausted and the block is still open.
-        let next_id = force_close_think(
-            gen_cfg.reasoning_budget,
-            gen_cfg.enable_thinking,
-            thinking_closed,
-            generated_ids.len(),
-            think_close_id,
-        )
-        .unwrap_or(sampled_id);
+        let next_id = policy.apply_override(generated_ids.len(), sampled_id);
 
         // Grammar advance on the actually-emitted token (after any budget
         // override); a false return signals grammar completion.
@@ -1099,9 +1188,7 @@ fn decode_loop(
         }
 
         // Track when the thinking block closes (natural or forced).
-        if Some(next_id) == think_close_id {
-            thinking_closed = true;
-        }
+        policy.note_emitted(next_id);
 
         if should_stop_token(cfg, gen_cfg, next_id) {
             return Ok((true, StopReason::Eos));
@@ -1109,22 +1196,17 @@ fn decode_loop(
 
         generated_ids.push(next_id);
         all_ids.push(next_id);
-        record_logprob(
+        policy.record_logprob(
             token_logprobs,
             &scratch.logits[..cfg.vocab_size],
             next_id,
             gen_cfg.temperature,
-            gen_cfg.logprobs,
         );
         // Capture close-point after push so </think> is the last reasoning token.
-        if thinking_closed && reasoning_end_len.is_none() {
-            reasoning_end_len = Some(generated_ids.len());
-        }
+        policy.capture_reasoning_end(generated_ids.len());
 
         // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-        if let Some(end) = reasoning_end_len
-            && generated_ids.len().saturating_sub(end) >= gen_cfg.max_new_tokens
-        {
+        if policy.answer_budget_exhausted(generated_ids.len()) {
             break;
         }
     }
@@ -1153,21 +1235,14 @@ fn decode_loop_with_stops(
     detok: &mut IncrementalDetokenizer,
     full: &mut String,
     grammar_state: &mut Option<GrammarState>,
-    think_close_id: Option<u32>,
-    thinking_closed_seed: bool,
+    policy: &mut DecodePolicy,
     token_logprobs: &mut Vec<TokenLogprob>,
     token_logprob_end_offsets: &mut Vec<usize>,
 ) -> Result<(bool, StopReason), InferenceError> {
     let cfg = &model.config;
     let mut stopped = false;
     let mut stop_reason = StopReason::Length;
-    let mut thinking_closed = thinking_closed_seed;
-    let mut reasoning_end_len: Option<usize> = if thinking_closed {
-        Some(generated_ids.len())
-    } else {
-        None
-    };
-    let cap = decode_cap(gen_cfg.reasoning_budget, gen_cfg.max_new_tokens);
+    let cap = policy.cap();
     // Longest configured stop string, used to bound the per-token stop scan to
     // the suffix that could contain a new match (see `earliest_stop_match_from`).
     // `full` already reflects everything scanned before this function was
@@ -1209,14 +1284,7 @@ fn decode_loop_with_stops(
 
         // Budget forcing: override the sampled token with </think> when the
         // reasoning budget is exhausted and the block is still open.
-        let next_id = force_close_think(
-            gen_cfg.reasoning_budget,
-            gen_cfg.enable_thinking,
-            thinking_closed,
-            generated_ids.len(),
-            think_close_id,
-        )
-        .unwrap_or(sampled_id);
+        let next_id = policy.apply_override(generated_ids.len(), sampled_id);
 
         // Grammar advance on the actually-emitted token (after any budget
         // override); a false return signals grammar completion.
@@ -1229,9 +1297,7 @@ fn decode_loop_with_stops(
         }
 
         // Track when the thinking block closes (natural or forced).
-        if Some(next_id) == think_close_id {
-            thinking_closed = true;
-        }
+        policy.note_emitted(next_id);
 
         if should_stop_token(cfg, gen_cfg, next_id) {
             stopped = true;
@@ -1241,17 +1307,14 @@ fn decode_loop_with_stops(
 
         generated_ids.push(next_id);
         all_ids.push(next_id);
-        record_logprob(
+        policy.record_logprob(
             token_logprobs,
             &scratch.logits[..cfg.vocab_size],
             next_id,
             gen_cfg.temperature,
-            gen_cfg.logprobs,
         );
         // Capture close-point after push so </think> is the last reasoning token.
-        if thinking_closed && reasoning_end_len.is_none() {
-            reasoning_end_len = Some(generated_ids.len());
-        }
+        policy.capture_reasoning_end(generated_ids.len());
 
         let prev_len = full.len();
         let delta = detok.push(&model.tokenizer, next_id);
@@ -1285,9 +1348,7 @@ fn decode_loop_with_stops(
         }
 
         // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-        if let Some(end) = reasoning_end_len
-            && generated_ids.len().saturating_sub(end) >= gen_cfg.max_new_tokens
-        {
+        if policy.answer_budget_exhausted(generated_ids.len()) {
             break;
         }
     }

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -1402,6 +1402,61 @@ pub(crate) fn check_logprobs_not_set(gen_cfg: &GenerateConfig) -> Result<(), Inf
     Ok(())
 }
 
+/// Sibling guard to [`check_grammar_not_set`] / [`check_logprobs_not_set`]
+/// (ADR-080 C3, #783): fails closed instead of silently dropping a
+/// `stop_strings` request on a generation path that has not wired
+/// string-level stop matching into its decode loop.
+///
+/// Callers: `generate_f16` (`forward/cpu_f16.rs`), `generate_q8`
+/// (`forward/cpu_q8.rs`), `generate_q8_neon` (`forward/neon_forward.rs`),
+/// `Qwen35Model::generate_with_batch_prefill` (`forward/batch_prefill.rs`).
+///
+/// The base CPU `generate()` / `generate_streaming()` paths in this module,
+/// and the Metal `generate()` / `generate_streaming()` / `generate_multimodal`
+/// family, all wire `stop_strings` matching directly and therefore do not
+/// call this guard.
+pub(crate) fn check_stop_strings_not_set(gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
+    if !gen_cfg.stop_strings.is_empty() {
+        return Err(InferenceError::InvalidInput(
+            "stop_strings is not yet supported on this generation path; \
+             use the Qwen3.5 CPU generate() / generate_streaming() or the Metal \
+             generate() / generate_streaming(), which implement stop-string matching"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Sibling guard to [`check_stop_strings_not_set`] (ADR-080 C3, #783): fails
+/// closed instead of silently dropping a `reasoning_budget` request on a
+/// generation path that has not wired budget-forcing (`decode_cap` /
+/// `force_close_think`) into its decode loop.
+///
+/// Same CPU caller list as [`check_stop_strings_not_set`]. On the Metal side,
+/// the plain `generate()` entry point and `multimodal_generate_preflight`
+/// (`generate_multimodal`) both call this guard directly; the MTP and
+/// self-speculative greedy fast paths never see a set `reasoning_budget` in
+/// the first place — their route predicates (`mtp_route_active` /
+/// `self_spec_route_active`) exclude it, falling through to plain
+/// `generate()`, which rejects it via this same guard.
+///
+/// The base CPU `generate()` / `generate_streaming()` paths in this module,
+/// and the Metal `generate_streaming()` family, wire reasoning-budget forcing
+/// directly and therefore do not call this guard.
+pub(crate) fn check_reasoning_budget_not_set(
+    gen_cfg: &GenerateConfig,
+) -> Result<(), InferenceError> {
+    if gen_cfg.reasoning_budget.is_some() {
+        return Err(InferenceError::InvalidInput(
+            "reasoning_budget is not yet supported on this generation path; \
+             use the Qwen3.5 CPU generate() / generate_streaming() or the Metal \
+             generate_streaming(), which implement reasoning-budget forcing"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1732,6 +1787,68 @@ mod tests {
         };
         assert_eq!(cfg.stop_strings.len(), 2);
         assert_eq!(cfg.stop_strings[0], "</s>");
+    }
+
+    // -----------------------------------------------------------------------
+    // check_stop_strings_not_set / check_reasoning_budget_not_set
+    // (ADR-080 C3, #783) — mutation-sensitive unit tests for the shared guard
+    // primitives every alternate CPU/Metal decode loop calls.
+    // -----------------------------------------------------------------------
+
+    /// Mutation sensitivity: change `check_stop_strings_not_set` to always
+    /// return `Ok(())` → this assertion fails, catching a regression that
+    /// would let a non-empty `stop_strings` silently pass through an
+    /// unwired decode loop.
+    #[test]
+    fn check_stop_strings_not_set_rejects_nonempty() {
+        let cfg = GenerateConfig {
+            stop_strings: vec!["</s>".to_string()],
+            ..Default::default()
+        };
+        let result = check_stop_strings_not_set(&cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "non-empty stop_strings must be rejected with InvalidInput; got {result:?}"
+        );
+    }
+
+    /// Mutation sensitivity: change the guard to always return `Err(..)` →
+    /// this assertion fails, catching a regression that would reject every
+    /// caller including the default (no stop strings requested) config.
+    #[test]
+    fn check_stop_strings_not_set_allows_empty() {
+        assert!(
+            check_stop_strings_not_set(&GenerateConfig::default()).is_ok(),
+            "empty stop_strings (the default) must be allowed"
+        );
+    }
+
+    /// Mutation sensitivity: change `check_reasoning_budget_not_set` to
+    /// always return `Ok(())` → this assertion fails, catching a regression
+    /// that would let a set `reasoning_budget` silently pass through an
+    /// unwired decode loop.
+    #[test]
+    fn check_reasoning_budget_not_set_rejects_some() {
+        let cfg = GenerateConfig {
+            reasoning_budget: Some(128),
+            ..Default::default()
+        };
+        let result = check_reasoning_budget_not_set(&cfg);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "Some(reasoning_budget) must be rejected with InvalidInput; got {result:?}"
+        );
+    }
+
+    /// Mutation sensitivity: change the guard to always return `Err(..)` →
+    /// this assertion fails, catching a regression that would reject every
+    /// caller including the default (no reasoning budget requested) config.
+    #[test]
+    fn check_reasoning_budget_not_set_allows_none() {
+        assert!(
+            check_reasoning_budget_not_set(&GenerateConfig::default()).is_ok(),
+            "reasoning_budget: None (the default) must be allowed"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -772,10 +772,11 @@ impl Qwen35Model {
                         break;
                     }
                     StepOutcome::Stopped => {
-                        // Unreachable on this path (no stop_strings
-                        // configured; the closure never returns
-                        // `StopCheckOutcome::Stopped`), handled for
-                        // exhaustiveness/defense-in-depth.
+                        // Unreachable on this path (`policy.stop_mode` is
+                        // always `Disabled` here -- no `stop_strings`
+                        // configured -- and `Disabled`'s `stop_check` arm
+                        // never returns `StopCheckOutcome::Stopped`), handled
+                        // for exhaustiveness/defense-in-depth.
                         stopped = true;
                         stop_reason = StopReason::Eos;
                         break;
@@ -1002,15 +1003,16 @@ pub(crate) enum StepOutcome {
     /// was never pushed. The loop must stop with `stopped = true`,
     /// `stop_reason = Eos`.
     Eos,
-    /// The mandatory `stop_check` callback (codex round-2 major #2, PR #787)
+    /// [`DecodePolicy::stop_check`] — driven internally from `self.stop_mode`
+    /// (codex round-3 major #1, PR #787 / Leo's ruling; see [`StopMode`]) —
     /// reported that a configured stop string matched as of this token. The
     /// token was pushed (via `push`) and every other backend-neutral
     /// per-step control already applied before `stop_check` ran; the loop
     /// must stop with `stopped = true`, `stop_reason = Eos`.
     Stopped,
-    /// The mandatory `stop_check` callback reported that the caller's
-    /// streaming sink can no longer consume output (e.g. a dropped SSE
-    /// receiver) — not a stop condition. The loop must stop with
+    /// [`DecodePolicy::stop_check`] reported that the caller's
+    /// streaming sink (`emit_confirmed`) can no longer consume output (e.g. a
+    /// dropped SSE receiver) — not a stop condition. The loop must stop with
     /// `stopped = false`, `stop_reason = Interrupt`.
     Interrupted,
     /// The token was pushed (via the caller's `push` callback), `stop_check`
@@ -1056,13 +1058,15 @@ pub(crate) enum StopCheckOutcome {
 /// transition ([`DecodePolicy::transition`]): each backend keeps
 /// `forward_step`, grammar masking, sampling, and its own token vectors
 /// (`generated_ids` / `all_ids` or the Metal equivalents) entirely to itself,
-/// hands `transition` the token its own pipeline just sampled plus four
+/// hands `transition` the token its own pipeline just sampled plus three
 /// backend callbacks (grammar-advance, EOS/stop-token check, the push into
-/// its own vectors, and the stop-string check below), and gets back a
+/// its own vectors) and raw per-token I/O primitives for the stop check
+/// (`decode_delta`, a `text`/`token_logprob_end_offsets` buffer pair, and
+/// `emit_confirmed` — see [`StopMode`] below), and gets back a
 /// [`StepOutcome`] that already reflects budget-override, reasoning-block
-/// tracking, logprobs recording, reasoning-end capture, the stop-string
-/// check, and the answer-budget check — in that fixed order, every time, for
-/// every site.
+/// tracking, logprobs recording, reasoning-end capture, the stop check, and
+/// the answer-budget check — in that fixed order, every time, for every
+/// site.
 ///
 /// Before this struct existed, this exact bookkeeping (`think_close_id`
 /// resolution, `thinking_closed` / `reasoning_end_len` tracking, the
@@ -1831,9 +1835,11 @@ fn decode_loop_with_stops(
                 break;
             }
             StepOutcome::Interrupted => {
-                // Unreachable from this closure (it never returns
-                // `StopCheckOutcome::Interrupted`; only the streaming call
-                // sites do), handled for exhaustiveness/defense-in-depth.
+                // Unreachable on this path (`policy.stop_mode` is
+                // `StopMode::FullScan` here, whose `stop_check` arm never
+                // returns `StopCheckOutcome::Interrupted` -- only
+                // `StopMode::Streaming`'s arm does, for the streaming call
+                // sites), handled for exhaustiveness/defense-in-depth.
                 stop_reason = StopReason::Interrupt;
                 break;
             }

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -232,13 +232,6 @@ impl Qwen35Model {
 
         generated_ids.push(next_id);
         all_ids.push(next_id);
-        record_logprob(
-            &mut token_logprobs,
-            &scratch.logits[..cfg.vocab_size],
-            next_id,
-            gen_cfg.temperature,
-            gen_cfg.logprobs,
-        );
 
         // Budget forcing: resolve </think> once and seed thinking_closed from the
         // prefill token so budget=1 works. Mirrors generate_streaming exactly;
@@ -251,7 +244,19 @@ impl Qwen35Model {
         } else {
             None
         };
-        let mut policy = DecodePolicy::new(gen_cfg, think_close_id, next_id, generated_ids.len());
+        // `DecodePolicy::init` (codex round-2 major #2, PR #787) constructs
+        // the policy AND records this prefill-derived first token's logprob
+        // in the same call -- replaces the freestanding `record_logprob(...)`
+        // call this site used to make independently of the policy.
+        let mut policy = DecodePolicy::init(
+            gen_cfg,
+            think_close_id,
+            &mut token_logprobs,
+            next_id,
+            &scratch.logits[..cfg.vocab_size],
+            gen_cfg.temperature,
+            generated_ids.len(),
+        );
 
         if gen_cfg.stop_strings.is_empty() {
             // Fast path: no string-level stops. Behaviour byte-for-byte identical
@@ -600,13 +605,6 @@ impl Qwen35Model {
 
         generated_ids.push(next_id);
         all_ids.push(next_id);
-        record_logprob(
-            &mut token_logprobs,
-            &scratch.logits[..cfg.vocab_size],
-            next_id,
-            gen_cfg.temperature,
-            gen_cfg.logprobs,
-        );
 
         // Budget forcing setup: resolve the </think> token id once and seed
         // the thinking_closed state from the prefill token so budget=1 works.
@@ -615,7 +613,19 @@ impl Qwen35Model {
         } else {
             None
         };
-        let mut policy = DecodePolicy::new(gen_cfg, think_close_id, next_id, generated_ids.len());
+        // `DecodePolicy::init` (codex round-2 major #2, PR #787) constructs
+        // the policy AND records this prefill-derived first token's logprob
+        // in the same call -- replaces the freestanding `record_logprob(...)`
+        // call this site used to make independently of the policy.
+        let mut policy = DecodePolicy::init(
+            gen_cfg,
+            think_close_id,
+            &mut token_logprobs,
+            next_id,
+            &scratch.logits[..cfg.vocab_size],
+            gen_cfg.temperature,
+            generated_ids.len(),
+        );
 
         // Incremental detokenization: emit only complete-UTF-8 text deltas. A
         // byte-level BPE codepoint can span several tokens, so we buffer raw bytes
@@ -697,7 +707,13 @@ impl Qwen35Model {
                 // major #3, PR #787) -- see `DecodePolicy::transition`. Set
                 // stopped=true on a grammar stop so the caller sees a
                 // grammar-terminal stop as stopped=true, matching
-                // decode_loop's `return Ok(true)`.
+                // decode_loop's `return Ok(true)`. The `stop_check` closure
+                // (codex round-2 major #2, PR #787 / Leo's ruling) owns this
+                // fast path's delta-push + `on_token` interrupt check --
+                // there is no stop-string matching on this path
+                // (`gen_cfg.stop_strings` is empty), but the callback is
+                // still required, so it reports `Interrupted` when the
+                // caller's sink can no longer consume output.
                 let generated_len_before = generated_ids.len();
                 let outcome = policy.transition(
                     &mut token_logprobs,
@@ -717,9 +733,19 @@ impl Qwen35Model {
                         generated_ids.push(next_id);
                         all_ids.push(next_id);
                     },
+                    |next_id, _token_logprobs| {
+                        let delta = detok.push(&self.tokenizer, next_id);
+                        if !delta.is_empty() {
+                            text.push_str(&delta);
+                            if !on_token(&delta) {
+                                return StopCheckOutcome::Interrupted;
+                            }
+                        }
+                        StopCheckOutcome::Continue
+                    },
                 );
 
-                let (next_id, answer_budget_exhausted) = match outcome {
+                let answer_budget_exhausted = match outcome {
                     StepOutcome::GrammarStop => {
                         stopped = true;
                         stop_reason = StopReason::Grammar;
@@ -730,21 +756,25 @@ impl Qwen35Model {
                         stop_reason = StopReason::Eos;
                         break;
                     }
-                    StepOutcome::Emitted {
-                        token_id,
-                        answer_budget_exhausted,
-                    } => (token_id, answer_budget_exhausted),
-                };
-
-                let delta = detok.push(&self.tokenizer, next_id);
-                if !delta.is_empty() {
-                    text.push_str(&delta);
-                    if !on_token(&delta) {
+                    StepOutcome::Interrupted => {
                         stopped_by_caller = true;
                         stop_reason = StopReason::Interrupt;
                         break;
                     }
-                }
+                    StepOutcome::Stopped => {
+                        // Unreachable on this path (no stop_strings
+                        // configured; the closure never returns
+                        // `StopCheckOutcome::Stopped`), handled for
+                        // exhaustiveness/defense-in-depth.
+                        stopped = true;
+                        stop_reason = StopReason::Eos;
+                        break;
+                    }
+                    StepOutcome::Emitted {
+                        answer_budget_exhausted,
+                        ..
+                    } => answer_budget_exhausted,
+                };
 
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
                 if answer_budget_exhausted {
@@ -860,7 +890,13 @@ impl Qwen35Model {
                 );
 
                 // One atomic per-step transition (ADR-080 C3 / codex round-1
-                // major #3, PR #787) -- see `DecodePolicy::transition`.
+                // major #3, PR #787) -- see `DecodePolicy::transition`. The
+                // `stop_check` closure (codex round-2 major #2, PR #787 /
+                // Leo's ruling) owns this path's incremental byte-holdback
+                // stop-string match via `StopStringMatcher` -- moving it into
+                // the mandatory callback makes it structurally impossible
+                // for this call site to invoke `transition` while skipping
+                // the stop check.
                 let generated_len_before = generated_ids.len();
                 let outcome = policy.transition(
                     &mut token_logprobs,
@@ -880,9 +916,25 @@ impl Qwen35Model {
                         generated_ids.push(next_id);
                         all_ids.push(next_id);
                     },
+                    |next_id, _token_logprobs| {
+                        let delta = detok.push(&self.tokenizer, next_id);
+                        let mut iter_interrupted = false;
+                        let stop_matched = streamer.push(&delta, &mut |s| {
+                            if !iter_interrupted && !on_token(s) {
+                                iter_interrupted = true;
+                            }
+                        });
+                        if iter_interrupted {
+                            return StopCheckOutcome::Interrupted;
+                        }
+                        if stop_matched {
+                            return StopCheckOutcome::Stopped;
+                        }
+                        StopCheckOutcome::Continue
+                    },
                 );
 
-                let (next_id, answer_budget_exhausted) = match outcome {
+                let answer_budget_exhausted = match outcome {
                     StepOutcome::GrammarStop => {
                         stopped = true;
                         stop_reason = StopReason::Grammar;
@@ -893,29 +945,21 @@ impl Qwen35Model {
                         stop_reason = StopReason::Eos;
                         break;
                     }
-                    StepOutcome::Emitted {
-                        token_id,
-                        answer_budget_exhausted,
-                    } => (token_id, answer_budget_exhausted),
-                };
-
-                let delta = detok.push(&self.tokenizer, next_id);
-                let mut iter_interrupted = false;
-                let stop_matched = streamer.push(&delta, &mut |s| {
-                    if !iter_interrupted && !on_token(s) {
-                        iter_interrupted = true;
+                    StepOutcome::Interrupted => {
+                        stopped_by_caller = true;
+                        stop_reason = StopReason::Interrupt;
+                        break;
                     }
-                });
-                if iter_interrupted {
-                    stopped_by_caller = true;
-                    stop_reason = StopReason::Interrupt;
-                    break;
-                }
-                if stop_matched {
-                    stopped = true;
-                    stop_reason = StopReason::Eos;
-                    break;
-                }
+                    StepOutcome::Stopped => {
+                        stopped = true;
+                        stop_reason = StopReason::Eos;
+                        break;
+                    }
+                    StepOutcome::Emitted {
+                        answer_budget_exhausted,
+                        ..
+                    } => answer_budget_exhausted,
+                };
 
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
                 if answer_budget_exhausted {
@@ -962,9 +1006,21 @@ pub(crate) enum StepOutcome {
     /// was never pushed. The loop must stop with `stopped = true`,
     /// `stop_reason = Eos`.
     Eos,
-    /// The token was pushed (via the caller's `push` callback) and every
-    /// backend-neutral per-step control (logprobs, reasoning-end capture,
-    /// answer-budget accounting) has already been applied for it.
+    /// The mandatory `stop_check` callback (codex round-2 major #2, PR #787)
+    /// reported that a configured stop string matched as of this token. The
+    /// token was pushed (via `push`) and every other backend-neutral
+    /// per-step control already applied before `stop_check` ran; the loop
+    /// must stop with `stopped = true`, `stop_reason = Eos`.
+    Stopped,
+    /// The mandatory `stop_check` callback reported that the caller's
+    /// streaming sink can no longer consume output (e.g. a dropped SSE
+    /// receiver) — not a stop condition. The loop must stop with
+    /// `stopped = false`, `stop_reason = Interrupt`.
+    Interrupted,
+    /// The token was pushed (via the caller's `push` callback), `stop_check`
+    /// reported [`StopCheckOutcome::Continue`], and every backend-neutral
+    /// per-step control (logprobs, reasoning-end capture, answer-budget
+    /// accounting) has already been applied for it.
     Emitted {
         /// The actually-emitted token id (post budget-override).
         token_id: u32,
@@ -973,6 +1029,35 @@ pub(crate) enum StepOutcome {
         /// normal cap) when this is `true`.
         answer_budget_exhausted: bool,
     },
+}
+
+/// Outcome of the mandatory per-step stop-check callback [`DecodePolicy::transition`]
+/// drives (Leo's ruling on codex round-2 major #2, PR #787): the backend-specific
+/// stop-string consumption shape — streaming incremental byte-holdback via
+/// [`StopStringMatcher`], or non-streaming full-text rescan via
+/// `earliest_stop_match_from` — still differs by call site (these are genuinely
+/// different shapes per the existing round-1 rationale, not arbitrary
+/// duplication), and each shape needs its own backend-owned text buffer /
+/// `on_token` sink, which cannot move into this crate-shared enum. What
+/// changes is that a call site can no longer independently choose whether to
+/// check for a stop-string match at all: `transition` now takes the
+/// stop-check callback as a *required* parameter (the exact same footing as
+/// its existing `grammar_advance` / `is_eos` callbacks) and drives it at the
+/// one fixed point in the per-step order every site already used before this
+/// change. Omitting the callback is a compile error, not a silent gap — the
+/// no-stop-strings fast paths supply a trivial `|_, _| StopCheckOutcome::Continue`
+/// closure rather than skipping the parameter.
+pub(crate) enum StopCheckOutcome {
+    /// No stop-string match yet (or `stop_strings` is not configured for
+    /// this generation at all) — keep decoding.
+    Continue,
+    /// A configured stop string matched as of this token. The callback has
+    /// already truncated/finalized the backend's own accumulated output
+    /// (text buffer or streaming sink) before returning this.
+    Stopped,
+    /// The caller's streaming sink (`on_token`) signaled it can no longer
+    /// consume output — not a stop condition.
+    Interrupted,
 }
 
 /// Backend-neutral decode-policy state (ADR-080 C3): reasoning-budget
@@ -984,12 +1069,13 @@ pub(crate) enum StepOutcome {
 /// transition ([`DecodePolicy::transition`]): each backend keeps
 /// `forward_step`, grammar masking, sampling, and its own token vectors
 /// (`generated_ids` / `all_ids` or the Metal equivalents) entirely to itself,
-/// hands `transition` the token its own pipeline just sampled plus three
-/// backend callbacks (grammar-advance, EOS/stop-token check, and the push
-/// into its own vectors), and gets back a [`StepOutcome`] that already
-/// reflects budget-override, reasoning-block tracking, logprobs recording,
-/// reasoning-end capture, and the answer-budget check — in that fixed order,
-/// every time, for every site.
+/// hands `transition` the token its own pipeline just sampled plus four
+/// backend callbacks (grammar-advance, EOS/stop-token check, the push into
+/// its own vectors, and the stop-string check below), and gets back a
+/// [`StepOutcome`] that already reflects budget-override, reasoning-block
+/// tracking, logprobs recording, reasoning-end capture, the stop-string
+/// check, and the answer-budget check — in that fixed order, every time, for
+/// every site.
 ///
 /// Before this struct existed, this exact bookkeeping (`think_close_id`
 /// resolution, `thinking_closed` / `reasoning_end_len` tracking, the
@@ -1010,18 +1096,22 @@ pub(crate) enum StepOutcome {
 /// to skip a control, and doing so breaks every one of these behaviors at
 /// once rather than silently dropping just one.
 ///
-/// Stop-string matching remains outside `transition`'s return value: the
+/// Stop-string matching (codex round-2 major #2, PR #787 / Leo's ruling): the
 /// streaming callers need [`StopStringMatcher`]'s incremental byte-holdback
 /// semantics (a partial match must never reach `on_token`), while the
 /// non-streaming path scans the fully accumulated string via
-/// `earliest_stop_match` / `earliest_stop_match_from`. These are genuinely
-/// different consumption shapes of the same shared components (every
-/// streaming caller, CPU and Metal, shares the one `StopStringMatcher` type;
-/// every non-streaming caller shares the one `earliest_stop_match*` pair),
-/// and both already run strictly after `transition`'s `push` callback at
-/// every site, using the token id `transition` returns — there is no
-/// remaining site where stop-matching could be silently skipped independent
-/// of the other controls this struct owns.
+/// `earliest_stop_match` / `earliest_stop_match_from` — genuinely different
+/// consumption shapes, each needing its own backend-owned text buffer /
+/// `on_token` sink that cannot move into this crate-shared struct (the sink
+/// signature itself differs: CPU's is `FnMut(&str) -> bool`, Metal's is
+/// `FnMut(&str, u32) -> bool`). What changed: `transition` now takes the
+/// stop-check as a sixth, *required* parameter — same footing as
+/// `grammar_advance` / `is_eos` — and drives it internally at the one fixed
+/// point every site already ran it at (see [`StopCheckOutcome`]). A call site
+/// can no longer invoke `transition` while independently choosing whether to
+/// check for a stop-string match at all: omitting the callback is a compile
+/// error, not a silent gap, and the no-stop-strings fast paths must supply an
+/// explicit no-op closure rather than skipping the parameter.
 pub(crate) struct DecodePolicy {
     reasoning_budget: Option<usize>,
     enable_thinking: bool,
@@ -1033,16 +1123,35 @@ pub(crate) struct DecodePolicy {
 }
 
 impl DecodePolicy {
+    /// The first-step transition (codex round-2 major #2, PR #787 / Leo's
+    /// ruling): constructs the policy AND atomically records the
+    /// prefill-derived first token's logprob in the same call, so there is no
+    /// longer any way to build a `DecodePolicy` without also recording its
+    /// first token's logprob. Before this, `new()` only built the struct and
+    /// left every call site to separately invoke the freestanding
+    /// `crate::sampling::record_logprob` for that one token — three
+    /// call sites (this module's `generate()` / `generate_streaming_with_cancel()`,
+    /// and Metal's `generate_streaming`) duplicated that call independently,
+    /// the exact drift pattern codex's round-1 blocker #1 already proved live
+    /// once for the *other* four constituent methods (see the struct-level
+    /// doc comment above).
+    ///
     /// `think_close_id` is resolved by the caller (`tokenizer.special_token_id("</think>")`
     /// when `gen_cfg.reasoning_budget.is_some()`, `None` otherwise) since each backend
     /// reaches its tokenizer differently. `first_emitted_id` / `first_generated_len` seed
     /// `thinking_closed` / `reasoning_end_len` from the token already sampled and pushed
     /// before the decode loop starts (the prefill-derived first token), covering the
     /// `reasoning_budget == 1` edge case exactly as the six duplicated call sites did.
-    pub(crate) fn new(
+    /// `first_logits` / `temperature` are the same values the free-function
+    /// `record_logprob` call used to take directly.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn init(
         gen_cfg: &GenerateConfig,
         think_close_id: Option<u32>,
+        token_logprobs: &mut Vec<TokenLogprob>,
         first_emitted_id: u32,
+        first_logits: &[f32],
+        temperature: f32,
         first_generated_len: usize,
     ) -> Self {
         let thinking_closed = Some(first_emitted_id) == think_close_id;
@@ -1051,7 +1160,7 @@ impl DecodePolicy {
         } else {
             None
         };
-        Self {
+        let policy = Self {
             reasoning_budget: gen_cfg.reasoning_budget,
             enable_thinking: gen_cfg.enable_thinking,
             max_new_tokens: gen_cfg.max_new_tokens,
@@ -1059,7 +1168,9 @@ impl DecodePolicy {
             think_close_id,
             thinking_closed,
             reasoning_end_len,
-        }
+        };
+        policy.record_logprob(token_logprobs, first_logits, first_emitted_id, temperature);
+        policy
     }
 
     /// Total decode-loop iteration cap (`rb + max_new_tokens + 1` when budgeted,
@@ -1144,7 +1255,8 @@ impl DecodePolicy {
     /// callback, the emitted-token bookkeeping, the backend's EOS/stop-token
     /// callback, the backend's push callback (into its own `generated_ids` /
     /// `all_ids` or Metal-equivalent vectors), per-token logprobs recording,
-    /// reasoning-end capture, and the answer-budget check.
+    /// reasoning-end capture, the backend's stop-string check, and the
+    /// answer-budget check.
     ///
     /// `grammar_advance` and `is_eos` are backend callbacks because grammar
     /// masking/advance and EOS/stop-token identification remain genuinely
@@ -1157,11 +1269,28 @@ impl DecodePolicy {
     /// the *next* loop iteration (`all_ids.last()` feeds the next
     /// `forward_step`) — the caller cannot hand that ownership to the policy.
     ///
+    /// `stop_check` is likewise a required backend callback (codex round-2
+    /// major #2, PR #787 / Leo's ruling): the incremental byte-holdback
+    /// (streaming) vs full-text rescan (non-streaming) shapes, and their
+    /// backend-owned text buffers / `on_token` sinks, remain genuinely
+    /// backend-specific — but the callback itself is no longer optional
+    /// choreography a call site can skip. It receives the emitted token id
+    /// and a reborrow of `token_logprobs` (so a non-streaming caller can
+    /// retroactively drop trailing logprob entries whose text a stop match
+    /// truncated away, exactly as `decode_loop_with_stops` already did), and
+    /// runs after logprobs recording / reasoning-end capture, before the
+    /// answer-budget check — the same position every site already ran its
+    /// stop-check code at before this change.
+    ///
     /// Returns [`StepOutcome::GrammarStop`] / [`StepOutcome::Eos`] without
     /// ever calling `push` when the token is rejected before emission
     /// (matching the existing contract that a stop token is never present in
-    /// `token_ids`), or [`StepOutcome::Emitted`] once the token has been
-    /// pushed and every remaining control applied.
+    /// `token_ids`); [`StepOutcome::Stopped`] / [`StepOutcome::Interrupted`]
+    /// when `stop_check` reports either outcome (the answer-budget check is
+    /// skipped in both cases, matching every site's original control flow,
+    /// which broke out of the loop before ever reaching it); or
+    /// [`StepOutcome::Emitted`] once the token has been pushed and every
+    /// remaining control, including a `Continue` stop-check, applied.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn transition(
         &mut self,
@@ -1173,6 +1302,7 @@ impl DecodePolicy {
         mut grammar_advance: impl FnMut(u32) -> bool,
         mut is_eos: impl FnMut(u32) -> bool,
         mut push: impl FnMut(u32),
+        mut stop_check: impl FnMut(u32, &mut Vec<TokenLogprob>) -> StopCheckOutcome,
     ) -> StepOutcome {
         let next_id = self.apply_override(generated_len_before, sampled_id);
 
@@ -1191,6 +1321,12 @@ impl DecodePolicy {
 
         self.record_logprob(token_logprobs, logits, next_id, temperature);
         self.capture_reasoning_end(generated_len_after);
+
+        match stop_check(next_id, token_logprobs) {
+            StopCheckOutcome::Stopped => return StepOutcome::Stopped,
+            StopCheckOutcome::Interrupted => return StepOutcome::Interrupted,
+            StopCheckOutcome::Continue => {}
+        }
 
         StepOutcome::Emitted {
             token_id: next_id,
@@ -1299,8 +1435,13 @@ fn decode_loop(
         // One atomic per-step transition (ADR-080 C3 / codex round-1 major
         // #3, PR #787): budget override, grammar-advance callback, emitted
         // bookkeeping, EOS callback, push callback, logprobs, reasoning-end
-        // capture, and the answer-budget check, all in the fixed required
-        // order -- see `DecodePolicy::transition`.
+        // capture, the (here, no-op) stop-check callback, and the
+        // answer-budget check, all in the fixed required order -- see
+        // `DecodePolicy::transition`. This function is only ever called when
+        // `gen_cfg.stop_strings` is empty (see `generate()`'s branch), so
+        // `stop_check` is a trivial `Continue` (codex round-2 major #2, PR
+        // #787 / Leo's ruling: the callback is required on every call, not
+        // just where a real check is needed).
         let generated_len_before = generated_ids.len();
         let outcome = policy.transition(
             token_logprobs,
@@ -1320,11 +1461,14 @@ fn decode_loop(
                 generated_ids.push(next_id);
                 all_ids.push(next_id);
             },
+            |_next_id, _token_logprobs| StopCheckOutcome::Continue,
         );
 
         match outcome {
             StepOutcome::GrammarStop => return Ok((true, StopReason::Grammar)),
             StepOutcome::Eos => return Ok((true, StopReason::Eos)),
+            StepOutcome::Stopped => return Ok((true, StopReason::Eos)),
+            StepOutcome::Interrupted => return Ok((false, StopReason::Interrupt)),
             StepOutcome::Emitted {
                 answer_budget_exhausted,
                 ..
@@ -1410,7 +1554,12 @@ fn decode_loop_with_stops(
         );
 
         // One atomic per-step transition (ADR-080 C3 / codex round-1 major
-        // #3, PR #787) -- see `DecodePolicy::transition`.
+        // #3, PR #787) -- see `DecodePolicy::transition`. The `stop_check`
+        // closure (codex round-2 major #2, PR #787 / Leo's ruling) now owns
+        // exactly the detok/rescan/truncate work this loop used to run
+        // separately AFTER `transition` returned -- moving it into the
+        // mandatory callback makes it structurally impossible for this call
+        // site to invoke `transition` while skipping the stop check.
         let generated_len_before = generated_ids.len();
         let outcome = policy.transition(
             token_logprobs,
@@ -1430,9 +1579,46 @@ fn decode_loop_with_stops(
                 generated_ids.push(next_id);
                 all_ids.push(next_id);
             },
+            |next_id, token_logprobs| {
+                let prev_len = full.len();
+                let delta = detok.push(&model.tokenizer, next_id);
+                if !delta.is_empty() {
+                    full.push_str(&delta);
+                }
+
+                // Keep the offset tracker in lockstep with token_logprobs'
+                // conditional growth (record_logprob is a no-op unless
+                // gen_cfg.logprobs is set).
+                if token_logprobs.len() > token_logprob_end_offsets.len() {
+                    token_logprob_end_offsets.push(full.len());
+                }
+
+                // Only the suffix that could contain a NEW match needs
+                // rescanning -- any match fully inside `full[..prev_len]`
+                // would already have been found on a prior iteration (see
+                // `earliest_stop_match_from`'s doc comment). Bounds
+                // per-token work instead of rescanning all of `full`.
+                // Shared with `StopStringMatcher::push` via
+                // `stop_scan_search_start` so both call sites derive the
+                // bound identically.
+                let search_start = stop_scan_search_start(full, prev_len, max_stop);
+                if let Some(hit) =
+                    earliest_stop_match_from(full, &gen_cfg.stop_strings, search_start)
+                {
+                    full.truncate(hit);
+                    truncate_token_logprobs_to_retained_text(
+                        token_logprobs,
+                        token_logprob_end_offsets,
+                        hit,
+                    );
+                    StopCheckOutcome::Stopped
+                } else {
+                    StopCheckOutcome::Continue
+                }
+            },
         );
 
-        let (next_id, answer_budget_exhausted) = match outcome {
+        let (_next_id, answer_budget_exhausted) = match outcome {
             StepOutcome::GrammarStop => {
                 stopped = true;
                 stop_reason = StopReason::Grammar;
@@ -1443,42 +1629,23 @@ fn decode_loop_with_stops(
                 stop_reason = StopReason::Eos;
                 break;
             }
+            StepOutcome::Stopped => {
+                stopped = true;
+                stop_reason = StopReason::Eos;
+                break;
+            }
+            StepOutcome::Interrupted => {
+                // Unreachable from this closure (it never returns
+                // `StopCheckOutcome::Interrupted`; only the streaming call
+                // sites do), handled for exhaustiveness/defense-in-depth.
+                stop_reason = StopReason::Interrupt;
+                break;
+            }
             StepOutcome::Emitted {
                 token_id,
                 answer_budget_exhausted,
             } => (token_id, answer_budget_exhausted),
         };
-
-        let prev_len = full.len();
-        let delta = detok.push(&model.tokenizer, next_id);
-        if !delta.is_empty() {
-            full.push_str(&delta);
-        }
-
-        // Keep the offset tracker in lockstep with token_logprobs' conditional
-        // growth (record_logprob is a no-op unless gen_cfg.logprobs is set).
-        if token_logprobs.len() > token_logprob_end_offsets.len() {
-            token_logprob_end_offsets.push(full.len());
-        }
-
-        // Only the suffix that could contain a NEW match needs rescanning —
-        // any match fully inside `full[..prev_len]` would already have been
-        // found on a prior iteration (see `earliest_stop_match_from`'s doc
-        // comment). Bounds per-token work instead of rescanning all of `full`.
-        // Shared with `StopStringMatcher::push` via `stop_scan_search_start`
-        // so both call sites derive the bound identically.
-        let search_start = stop_scan_search_start(full, prev_len, max_stop);
-        if let Some(hit) = earliest_stop_match_from(full, &gen_cfg.stop_strings, search_start) {
-            full.truncate(hit);
-            truncate_token_logprobs_to_retained_text(
-                token_logprobs,
-                token_logprob_end_offsets,
-                hit,
-            );
-            stopped = true;
-            stop_reason = StopReason::Eos;
-            break;
-        }
 
         // Answer-budget break: stop once max_new_tokens answer tokens follow
         // </think>. Computed inside `transition` and carried out via the
@@ -1648,6 +1815,38 @@ pub(crate) fn check_reasoning_budget_not_set(
             "reasoning_budget is not yet supported on this generation path; \
              use the Qwen3.5 CPU generate() / generate_streaming() or the Metal \
              generate_streaming(), which implement reasoning-budget forcing"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Sibling guard to [`check_reasoning_budget_not_set`] (codex round-2 medium
+/// #4, PR #787): fails closed instead of silently ignoring an active MTP
+/// request on a generation path that never reads `gen_cfg.enable_mtp`.
+///
+/// Resolves `enable_mtp` exactly like the Metal `generate()` entry point
+/// (`gen_cfg.enable_mtp.unwrap_or_else(|| LATTICE_MTP env set)`), so a caller
+/// or environment combination that would activate MTP on the direct path is
+/// rejected here too, rather than silently falling back to plain per-token
+/// decode with no indication MTP was skipped.
+///
+/// Sole caller: the Metal cross-turn prefix-cache path
+/// (`generate_streaming_with_prefix_cache_and_cancel`), which has no MTP
+/// draft/verify wiring at all -- gated identically to that Metal-only
+/// consumer (same gate as the `DecodePolicy`/`StepOutcome` re-export in
+/// `mod.rs`) so non-metal-gpu builds don't carry an unused function.
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+pub(crate) fn check_mtp_not_requested(gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
+    let mtp_enabled = gen_cfg
+        .enable_mtp
+        .unwrap_or_else(|| std::env::var("LATTICE_MTP").is_ok());
+    if mtp_enabled {
+        return Err(InferenceError::InvalidInput(
+            "enable_mtp (or LATTICE_MTP) is not supported on the cross-turn \
+             prefix-cache generation path, which has no MTP draft/verify \
+             wiring; use the Metal generate() / generate_streaming() paths, \
+             which implement MTP"
                 .into(),
         ));
     }
@@ -2704,6 +2903,55 @@ mod tests {
             "both tokens' text was only partially retained after truncation, so both \
              logprobs entries must be dropped; got {} entries",
             result.token_logprobs.len()
+        );
+    }
+
+    /// Codex round-2 major #2 (PR #787 / Leo's ruling): isolates
+    /// `DecodePolicy::init`'s first-step logprob ownership from
+    /// `transition`'s per-step logprob ownership, which
+    /// `transition_records_one_logprob_per_generated_token` below already
+    /// covers but does not itself distinguish. With `max_new_tokens: 1`,
+    /// `decode_loop`'s cap is 1, so its `for _ in 1..cap` loop body never
+    /// executes and `DecodePolicy::transition` is never called at all -- the
+    /// entire generation consists of the one prefill-derived token `init`
+    /// records. If that one `TokenLogprob` entry exists, it can only have
+    /// come from `init`.
+    ///
+    /// Mutation sensitivity: removing the
+    /// `policy.record_logprob(token_logprobs, first_logits, ...)` call
+    /// inside `DecodePolicy::init` makes `token_logprobs` come back empty
+    /// while `token_ids` still has 1 entry -- this test fails with a length
+    /// mismatch (`0 != 1`) instead of passing.
+    #[test]
+    fn init_records_the_prefill_tokens_logprob_before_any_transition_call() {
+        let model = build_tiny_zero_model();
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            temperature: 0.0,
+            logprobs: Some(0),
+            ..Default::default()
+        };
+        let result = model
+            .generate("a", &gen_cfg)
+            .expect("single-token generate must succeed");
+
+        assert_eq!(
+            result.generated_tokens, 1,
+            "max_new_tokens: 1 must generate exactly the prefill-derived \
+             first token and never enter decode_loop; got {}",
+            result.generated_tokens
+        );
+        assert_eq!(
+            result.token_logprobs.len(),
+            1,
+            "the sole generated token's logprob must be recorded by \
+             DecodePolicy::init alone (transition is never called when \
+             max_new_tokens == 1); got {} entries",
+            result.token_logprobs.len()
+        );
+        assert_eq!(
+            result.token_logprobs[0].token_id, result.token_ids[0],
+            "the recorded logprob entry must describe the actual first token"
         );
     }
 

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -693,41 +693,48 @@ impl Qwen35Model {
                     &mut rng_state,
                 );
 
-                // Budget forcing: override sampled token with </think> when the
-                // reasoning budget is exhausted and the block is still open.
-                let next_id = policy.apply_override(generated_ids.len(), sampled_id);
-
-                // Grammar advance on the actually-emitted token (after any budget
-                // override): a false return signals grammar completion. Set
-                // stopped=true before breaking so the caller sees a grammar-terminal
-                // stop as stopped=true, matching decode_loop's `return Ok(true)`.
-                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state)
-                    && !engine.advance(gs, next_id)
-                {
-                    stopped = true;
-                    stop_reason = StopReason::Grammar;
-                    break;
-                }
-
-                // Track when the thinking block closes (natural or forced).
-                policy.note_emitted(next_id);
-
-                if should_stop_token(cfg, gen_cfg, next_id) {
-                    stopped = true;
-                    stop_reason = StopReason::Eos;
-                    break;
-                }
-
-                generated_ids.push(next_id);
-                all_ids.push(next_id);
-                policy.record_logprob(
+                // One atomic per-step transition (ADR-080 C3 / codex round-1
+                // major #3, PR #787) -- see `DecodePolicy::transition`. Set
+                // stopped=true on a grammar stop so the caller sees a
+                // grammar-terminal stop as stopped=true, matching
+                // decode_loop's `return Ok(true)`.
+                let generated_len_before = generated_ids.len();
+                let outcome = policy.transition(
                     &mut token_logprobs,
+                    sampled_id,
                     &scratch.logits[..cfg.vocab_size],
-                    next_id,
                     gen_cfg.temperature,
+                    generated_len_before,
+                    |next_id| {
+                        if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                            engine.advance(gs, next_id)
+                        } else {
+                            true
+                        }
+                    },
+                    |next_id| should_stop_token(cfg, gen_cfg, next_id),
+                    |next_id| {
+                        generated_ids.push(next_id);
+                        all_ids.push(next_id);
+                    },
                 );
-                // Capture close-point after push so </think> is the last reasoning token.
-                policy.capture_reasoning_end(generated_ids.len());
+
+                let (next_id, answer_budget_exhausted) = match outcome {
+                    StepOutcome::GrammarStop => {
+                        stopped = true;
+                        stop_reason = StopReason::Grammar;
+                        break;
+                    }
+                    StepOutcome::Eos => {
+                        stopped = true;
+                        stop_reason = StopReason::Eos;
+                        break;
+                    }
+                    StepOutcome::Emitted {
+                        token_id,
+                        answer_budget_exhausted,
+                    } => (token_id, answer_budget_exhausted),
+                };
 
                 let delta = detok.push(&self.tokenizer, next_id);
                 if !delta.is_empty() {
@@ -740,7 +747,7 @@ impl Qwen35Model {
                 }
 
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-                if policy.answer_budget_exhausted(generated_ids.len()) {
+                if answer_budget_exhausted {
                     break;
                 }
             }
@@ -852,39 +859,45 @@ impl Qwen35Model {
                     &mut rng_state,
                 );
 
-                // Budget forcing: override sampled token with </think> when the
-                // reasoning budget is exhausted and the block is still open.
-                let next_id = policy.apply_override(generated_ids.len(), sampled_id);
-
-                // Grammar advance on the actually-emitted token (after any budget
-                // override): break cleanly when the grammar signals completion.
-                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state)
-                    && !engine.advance(gs, next_id)
-                {
-                    stopped = true;
-                    stop_reason = StopReason::Grammar;
-                    break;
-                }
-
-                // Track when the thinking block closes (natural or forced).
-                policy.note_emitted(next_id);
-
-                if should_stop_token(cfg, gen_cfg, next_id) {
-                    stopped = true;
-                    stop_reason = StopReason::Eos;
-                    break;
-                }
-
-                generated_ids.push(next_id);
-                all_ids.push(next_id);
-                policy.record_logprob(
+                // One atomic per-step transition (ADR-080 C3 / codex round-1
+                // major #3, PR #787) -- see `DecodePolicy::transition`.
+                let generated_len_before = generated_ids.len();
+                let outcome = policy.transition(
                     &mut token_logprobs,
+                    sampled_id,
                     &scratch.logits[..cfg.vocab_size],
-                    next_id,
                     gen_cfg.temperature,
+                    generated_len_before,
+                    |next_id| {
+                        if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                            engine.advance(gs, next_id)
+                        } else {
+                            true
+                        }
+                    },
+                    |next_id| should_stop_token(cfg, gen_cfg, next_id),
+                    |next_id| {
+                        generated_ids.push(next_id);
+                        all_ids.push(next_id);
+                    },
                 );
-                // Capture close-point after push so </think> is the last reasoning token.
-                policy.capture_reasoning_end(generated_ids.len());
+
+                let (next_id, answer_budget_exhausted) = match outcome {
+                    StepOutcome::GrammarStop => {
+                        stopped = true;
+                        stop_reason = StopReason::Grammar;
+                        break;
+                    }
+                    StepOutcome::Eos => {
+                        stopped = true;
+                        stop_reason = StopReason::Eos;
+                        break;
+                    }
+                    StepOutcome::Emitted {
+                        token_id,
+                        answer_budget_exhausted,
+                    } => (token_id, answer_budget_exhausted),
+                };
 
                 let delta = detok.push(&self.tokenizer, next_id);
                 let mut iter_interrupted = false;
@@ -905,7 +918,7 @@ impl Qwen35Model {
                 }
 
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-                if policy.answer_budget_exhausted(generated_ids.len()) {
+                if answer_budget_exhausted {
                     break;
                 }
             }
@@ -938,44 +951,77 @@ impl Qwen35Model {
     }
 }
 
+/// Outcome of [`DecodePolicy::transition`], the one per-step call every decode
+/// loop drives through (ADR-080 C3 / codex round-1 major #3, PR #787).
+pub(crate) enum StepOutcome {
+    /// The (possibly budget-overridden) token was rejected by the backend's
+    /// own grammar advance before ever being pushed. The loop must stop with
+    /// `stopped = true`, `stop_reason = Grammar`.
+    GrammarStop,
+    /// The (possibly budget-overridden) token is EOS / a stop-token id and
+    /// was never pushed. The loop must stop with `stopped = true`,
+    /// `stop_reason = Eos`.
+    Eos,
+    /// The token was pushed (via the caller's `push` callback) and every
+    /// backend-neutral per-step control (logprobs, reasoning-end capture,
+    /// answer-budget accounting) has already been applied for it.
+    Emitted {
+        /// The actually-emitted token id (post budget-override).
+        token_id: u32,
+        /// Whether the answer-budget window has closed as of this token —
+        /// the loop should break after this iteration (in addition to its
+        /// normal cap) when this is `true`.
+        answer_budget_exhausted: bool,
+    },
+}
+
 /// Backend-neutral decode-policy state (ADR-080 C3): reasoning-budget
 /// accounting and logprobs formatting, shared by every canonical/streaming
 /// decode loop — CPU [`decode_loop`], [`decode_loop_with_stops`], both
 /// branches of [`Qwen35Model::generate_streaming_with_cancel`], and the Metal
 /// `generate_streaming` / `generate_streaming_with_prefix_cache_and_cancel_inner`
-/// loops in `crate::forward::metal_qwen35` — via a per-step forward callback
-/// seam: each backend keeps `forward_step`, grammar masking/advance,
-/// sampling, and EOS/stop-token checking entirely to itself, and only hands
-/// the policy the token its own pipeline just sampled
-/// ([`DecodePolicy::apply_override`], which may replace it with the forced
-/// `</think>` token), then reports back once the final token is actually
-/// emitted ([`DecodePolicy::note_emitted`] / [`DecodePolicy::capture_reasoning_end`])
-/// so the policy can tell the loop when the answer-budget window has closed
-/// ([`DecodePolicy::answer_budget_exhausted`]).
+/// loops in `crate::forward::metal_qwen35` — via one atomic per-step
+/// transition ([`DecodePolicy::transition`]): each backend keeps
+/// `forward_step`, grammar masking, sampling, and its own token vectors
+/// (`generated_ids` / `all_ids` or the Metal equivalents) entirely to itself,
+/// hands `transition` the token its own pipeline just sampled plus three
+/// backend callbacks (grammar-advance, EOS/stop-token check, and the push
+/// into its own vectors), and gets back a [`StepOutcome`] that already
+/// reflects budget-override, reasoning-block tracking, logprobs recording,
+/// reasoning-end capture, and the answer-budget check — in that fixed order,
+/// every time, for every site.
 ///
 /// Before this struct existed, this exact bookkeeping (`think_close_id`
 /// resolution, `thinking_closed` / `reasoning_end_len` tracking, the
 /// `decode_cap` / `force_close_think` calls, and the answer-budget break
 /// condition) was hand-duplicated across six independent decode loops —
 /// exactly the drift ADR-080 C3 exists to prevent: a seventh loop could add
-/// its own copy and silently diverge from the other six. `DecodePolicy` also
-/// owns per-step logprobs recording ([`DecodePolicy::record_logprob`]), which
-/// was already a single shared free function (`crate::sampling::record_logprob`)
-/// called identically by all six sites; wrapping it here keeps every piece of
-/// backend-neutral per-step policy under one owner.
+/// its own copy and silently diverge from the other six. The struct
+/// originally exposed each of these as a separate method
+/// (`apply_override` / `note_emitted` / `record_logprob` /
+/// `capture_reasoning_end` / `answer_budget_exhausted`), which let a call
+/// site choreograph a subset of them and skip another — codex round-1
+/// blocker #1 was exactly that failure mode: the Metal prefix-cache loop
+/// called four of the five and silently never called `record_logprob`.
+/// `transition` replaces all five with the one call above; the five
+/// constituent methods are now private to this module, so a caller in a
+/// different module (e.g. `crate::forward::metal_qwen35`) cannot reach any of
+/// them individually even by mistake — omitting `transition` is the only way
+/// to skip a control, and doing so breaks every one of these behaviors at
+/// once rather than silently dropping just one.
 ///
-/// Stop-string matching state is deliberately *not* folded into this struct:
-/// the streaming callers need [`StopStringMatcher`]'s incremental
-/// byte-holdback semantics (a partial match must never reach `on_token`),
-/// while the non-streaming path scans the fully accumulated string via
-/// `earliest_stop_match` / `earliest_stop_match_from`. Both were already
-/// unified at the type/free-function level before this PR (every streaming
-/// caller, CPU and Metal, shares the one `StopStringMatcher` type; every
-/// non-streaming caller shares the one `earliest_stop_match*` pair) — there
-/// is no per-loop duplication left to remove there, only two genuinely
-/// different consumption modes of the same shared components, mirroring the
-/// same "document, don't force" principle applied to backend-specific Metal
-/// logic elsewhere in this cluster.
+/// Stop-string matching remains outside `transition`'s return value: the
+/// streaming callers need [`StopStringMatcher`]'s incremental byte-holdback
+/// semantics (a partial match must never reach `on_token`), while the
+/// non-streaming path scans the fully accumulated string via
+/// `earliest_stop_match` / `earliest_stop_match_from`. These are genuinely
+/// different consumption shapes of the same shared components (every
+/// streaming caller, CPU and Metal, shares the one `StopStringMatcher` type;
+/// every non-streaming caller shares the one `earliest_stop_match*` pair),
+/// and both already run strictly after `transition`'s `push` callback at
+/// every site, using the token id `transition` returns — there is no
+/// remaining site where stop-matching could be silently skipped independent
+/// of the other controls this struct owns.
 pub(crate) struct DecodePolicy {
     reasoning_budget: Option<usize>,
     enable_thinking: bool,
@@ -1026,7 +1072,10 @@ impl DecodePolicy {
     /// budget is exhausted and the block is still open; a no-op pass-through
     /// otherwise. Call after sampling, before grammar-advance (the actually-emitted
     /// token, post-override, is what grammar must advance on).
-    pub(crate) fn apply_override(&self, generated_len: usize, sampled_id: u32) -> u32 {
+    ///
+    /// Private (codex round-1 major #3, PR #787): only reachable through
+    /// [`DecodePolicy::transition`], which owns the full per-step ordering.
+    fn apply_override(&self, generated_len: usize, sampled_id: u32) -> u32 {
         force_close_think(
             self.reasoning_budget,
             self.enable_thinking,
@@ -1041,7 +1090,10 @@ impl DecodePolicy {
     /// post-override token) is the `</think>` token. Call after grammar-advance
     /// succeeds, before the EOS/stop-token check — mirrors the original inline
     /// ordering across all six sites.
-    pub(crate) fn note_emitted(&mut self, next_id: u32) {
+    ///
+    /// Private (codex round-1 major #3, PR #787): only reachable through
+    /// [`DecodePolicy::transition`], which owns the full per-step ordering.
+    fn note_emitted(&mut self, next_id: u32) {
         if Some(next_id) == self.think_close_id {
             self.thinking_closed = true;
         }
@@ -1051,7 +1103,10 @@ impl DecodePolicy {
     /// closes, using the generated-token count *after* the token was pushed (so
     /// `</think>` itself is the last reasoning token, not the first answer token).
     /// A no-op once already captured or while the block is still open.
-    pub(crate) fn capture_reasoning_end(&mut self, generated_len_after_push: usize) {
+    ///
+    /// Private (codex round-1 major #3, PR #787): only reachable through
+    /// [`DecodePolicy::transition`], which owns the full per-step ordering.
+    fn capture_reasoning_end(&mut self, generated_len_after_push: usize) {
         if self.thinking_closed && self.reasoning_end_len.is_none() {
             self.reasoning_end_len = Some(generated_len_after_push);
         }
@@ -1059,7 +1114,10 @@ impl DecodePolicy {
 
     /// True once `max_new_tokens` answer tokens have followed the `</think>` close
     /// point — the decode loop should break on this, in addition to its normal cap.
-    pub(crate) fn answer_budget_exhausted(&self, generated_len: usize) -> bool {
+    ///
+    /// Private (codex round-1 major #3, PR #787): only reachable through
+    /// [`DecodePolicy::transition`], which owns the full per-step ordering.
+    fn answer_budget_exhausted(&self, generated_len: usize) -> bool {
         self.reasoning_end_len
             .is_some_and(|end| generated_len.saturating_sub(end) >= self.max_new_tokens)
     }
@@ -1067,7 +1125,10 @@ impl DecodePolicy {
     /// Thin, zero-behavior-change wrapper over `crate::sampling::record_logprob`,
     /// so logprobs formatting is owned by the same struct as the other two
     /// backend-neutral policy legs (ADR-080 C3 contract text).
-    pub(crate) fn record_logprob(
+    ///
+    /// Private (codex round-1 major #3, PR #787): only reachable through
+    /// [`DecodePolicy::transition`], which owns the full per-step ordering.
+    fn record_logprob(
         &self,
         token_logprobs: &mut Vec<TokenLogprob>,
         logits: &[f32],
@@ -1075,6 +1136,66 @@ impl DecodePolicy {
         temperature: f32,
     ) {
         record_logprob(token_logprobs, logits, token_id, temperature, self.logprobs);
+    }
+
+    /// The one per-step transition (ADR-080 C3 / codex round-1 major #3, PR
+    /// #787): atomically applies, in the fixed order every decode loop
+    /// requires, the reasoning-budget override, the backend's grammar-advance
+    /// callback, the emitted-token bookkeeping, the backend's EOS/stop-token
+    /// callback, the backend's push callback (into its own `generated_ids` /
+    /// `all_ids` or Metal-equivalent vectors), per-token logprobs recording,
+    /// reasoning-end capture, and the answer-budget check.
+    ///
+    /// `grammar_advance` and `is_eos` are backend callbacks because grammar
+    /// masking/advance and EOS/stop-token identification remain genuinely
+    /// backend-specific per ADR-080 C3 scope — each backend owns its own
+    /// `GrammarState` and `cfg.eos_token_id` / `stop_token_ids` wiring, and
+    /// `grammar_advance` must run on the *actually-emitted* (post-override)
+    /// token before `is_eos` sees it, exactly mirroring the inline ordering
+    /// every site used before this method existed. `push` is a callback
+    /// because the token vectors are owned by the caller and are also read on
+    /// the *next* loop iteration (`all_ids.last()` feeds the next
+    /// `forward_step`) — the caller cannot hand that ownership to the policy.
+    ///
+    /// Returns [`StepOutcome::GrammarStop`] / [`StepOutcome::Eos`] without
+    /// ever calling `push` when the token is rejected before emission
+    /// (matching the existing contract that a stop token is never present in
+    /// `token_ids`), or [`StepOutcome::Emitted`] once the token has been
+    /// pushed and every remaining control applied.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn transition(
+        &mut self,
+        token_logprobs: &mut Vec<TokenLogprob>,
+        sampled_id: u32,
+        logits: &[f32],
+        temperature: f32,
+        generated_len_before: usize,
+        mut grammar_advance: impl FnMut(u32) -> bool,
+        mut is_eos: impl FnMut(u32) -> bool,
+        mut push: impl FnMut(u32),
+    ) -> StepOutcome {
+        let next_id = self.apply_override(generated_len_before, sampled_id);
+
+        if !grammar_advance(next_id) {
+            return StepOutcome::GrammarStop;
+        }
+
+        self.note_emitted(next_id);
+
+        if is_eos(next_id) {
+            return StepOutcome::Eos;
+        }
+
+        push(next_id);
+        let generated_len_after = generated_len_before + 1;
+
+        self.record_logprob(token_logprobs, logits, next_id, temperature);
+        self.capture_reasoning_end(generated_len_after);
+
+        StepOutcome::Emitted {
+            token_id: next_id,
+            answer_budget_exhausted: self.answer_budget_exhausted(generated_len_after),
+        }
     }
 }
 
@@ -1175,39 +1296,45 @@ fn decode_loop(
             rng_state,
         );
 
-        // Budget forcing: override the sampled token with </think> when the
-        // reasoning budget is exhausted and the block is still open.
-        let next_id = policy.apply_override(generated_ids.len(), sampled_id);
-
-        // Grammar advance on the actually-emitted token (after any budget
-        // override); a false return signals grammar completion.
-        if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut *grammar_state)
-            && !engine.advance(gs, next_id)
-        {
-            return Ok((true, StopReason::Grammar));
-        }
-
-        // Track when the thinking block closes (natural or forced).
-        policy.note_emitted(next_id);
-
-        if should_stop_token(cfg, gen_cfg, next_id) {
-            return Ok((true, StopReason::Eos));
-        }
-
-        generated_ids.push(next_id);
-        all_ids.push(next_id);
-        policy.record_logprob(
+        // One atomic per-step transition (ADR-080 C3 / codex round-1 major
+        // #3, PR #787): budget override, grammar-advance callback, emitted
+        // bookkeeping, EOS callback, push callback, logprobs, reasoning-end
+        // capture, and the answer-budget check, all in the fixed required
+        // order -- see `DecodePolicy::transition`.
+        let generated_len_before = generated_ids.len();
+        let outcome = policy.transition(
             token_logprobs,
+            sampled_id,
             &scratch.logits[..cfg.vocab_size],
-            next_id,
             gen_cfg.temperature,
+            generated_len_before,
+            |next_id| {
+                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut *grammar_state) {
+                    engine.advance(gs, next_id)
+                } else {
+                    true
+                }
+            },
+            |next_id| should_stop_token(cfg, gen_cfg, next_id),
+            |next_id| {
+                generated_ids.push(next_id);
+                all_ids.push(next_id);
+            },
         );
-        // Capture close-point after push so </think> is the last reasoning token.
-        policy.capture_reasoning_end(generated_ids.len());
 
-        // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-        if policy.answer_budget_exhausted(generated_ids.len()) {
-            break;
+        match outcome {
+            StepOutcome::GrammarStop => return Ok((true, StopReason::Grammar)),
+            StepOutcome::Eos => return Ok((true, StopReason::Eos)),
+            StepOutcome::Emitted {
+                answer_budget_exhausted,
+                ..
+            } => {
+                // Answer-budget break: stop once max_new_tokens answer tokens
+                // follow </think>.
+                if answer_budget_exhausted {
+                    break;
+                }
+            }
         }
     }
     Ok((false, StopReason::Length))
@@ -1282,39 +1409,45 @@ fn decode_loop_with_stops(
             rng_state,
         );
 
-        // Budget forcing: override the sampled token with </think> when the
-        // reasoning budget is exhausted and the block is still open.
-        let next_id = policy.apply_override(generated_ids.len(), sampled_id);
-
-        // Grammar advance on the actually-emitted token (after any budget
-        // override); a false return signals grammar completion.
-        if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut *grammar_state)
-            && !engine.advance(gs, next_id)
-        {
-            stopped = true;
-            stop_reason = StopReason::Grammar;
-            break;
-        }
-
-        // Track when the thinking block closes (natural or forced).
-        policy.note_emitted(next_id);
-
-        if should_stop_token(cfg, gen_cfg, next_id) {
-            stopped = true;
-            stop_reason = StopReason::Eos;
-            break;
-        }
-
-        generated_ids.push(next_id);
-        all_ids.push(next_id);
-        policy.record_logprob(
+        // One atomic per-step transition (ADR-080 C3 / codex round-1 major
+        // #3, PR #787) -- see `DecodePolicy::transition`.
+        let generated_len_before = generated_ids.len();
+        let outcome = policy.transition(
             token_logprobs,
+            sampled_id,
             &scratch.logits[..cfg.vocab_size],
-            next_id,
             gen_cfg.temperature,
+            generated_len_before,
+            |next_id| {
+                if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut *grammar_state) {
+                    engine.advance(gs, next_id)
+                } else {
+                    true
+                }
+            },
+            |next_id| should_stop_token(cfg, gen_cfg, next_id),
+            |next_id| {
+                generated_ids.push(next_id);
+                all_ids.push(next_id);
+            },
         );
-        // Capture close-point after push so </think> is the last reasoning token.
-        policy.capture_reasoning_end(generated_ids.len());
+
+        let (next_id, answer_budget_exhausted) = match outcome {
+            StepOutcome::GrammarStop => {
+                stopped = true;
+                stop_reason = StopReason::Grammar;
+                break;
+            }
+            StepOutcome::Eos => {
+                stopped = true;
+                stop_reason = StopReason::Eos;
+                break;
+            }
+            StepOutcome::Emitted {
+                token_id,
+                answer_budget_exhausted,
+            } => (token_id, answer_budget_exhausted),
+        };
 
         let prev_len = full.len();
         let delta = detok.push(&model.tokenizer, next_id);
@@ -1347,8 +1480,11 @@ fn decode_loop_with_stops(
             break;
         }
 
-        // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
-        if policy.answer_budget_exhausted(generated_ids.len()) {
+        // Answer-budget break: stop once max_new_tokens answer tokens follow
+        // </think>. Computed inside `transition` and carried out via the
+        // `Emitted` outcome above (`answer_budget_exhausted` is now private
+        // to this module -- only `transition` may call it).
+        if answer_budget_exhausted {
             break;
         }
     }
@@ -2569,6 +2705,53 @@ mod tests {
              logprobs entries must be dropped; got {} entries",
             result.token_logprobs.len()
         );
+    }
+
+    /// Codex round-1 major #3 (PR #787): `DecodePolicy::transition` owns
+    /// `record_logprob` internally now (the constituent method is private,
+    /// only reachable through `transition`). This asserts the positive case
+    /// the truncation test above does not: with no stop string to truncate
+    /// anything, every generated token gets exactly one `TokenLogprob` entry,
+    /// and its `token_id` matches the corresponding `token_ids` entry.
+    ///
+    /// Mutation sensitivity: commenting out the `self.record_logprob(...)`
+    /// call inside `DecodePolicy::transition` makes `token_logprobs` come
+    /// back empty while `token_ids` still has 3 entries -- this test fails
+    /// with a length mismatch (`0 != 3`) instead of passing.
+    #[test]
+    fn transition_records_one_logprob_per_generated_token() {
+        let model = build_tiny_zero_model();
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 3,
+            temperature: 0.0,
+            logprobs: Some(0),
+            ..Default::default()
+        };
+        let result = model
+            .generate("a", &gen_cfg)
+            .expect("plain generate must succeed");
+
+        assert_eq!(
+            result.token_logprobs.len(),
+            result.token_ids.len(),
+            "every generated token must get exactly one TokenLogprob entry \
+             when logprobs is requested and nothing truncates the output; \
+             got {} logprobs for {} tokens",
+            result.token_logprobs.len(),
+            result.token_ids.len()
+        );
+        for (i, (logprob, &token_id)) in result
+            .token_logprobs
+            .iter()
+            .zip(result.token_ids.iter())
+            .enumerate()
+        {
+            assert_eq!(
+                logprob.token_id, token_id,
+                "token_logprobs[{i}] must describe the token actually emitted \
+                 at that position"
+            );
+        }
     }
 
     // -------------------------------------------------------------------

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -62,7 +62,12 @@ pub(crate) use generation::{check_reasoning_budget_not_set, check_stop_strings_n
 // gated identically) consumer needs the re-export; `generation.rs` itself
 // uses `DecodePolicy` directly within its own module.
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
-pub(crate) use generation::{DecodePolicy, StepOutcome};
+pub(crate) use generation::{DecodePolicy, StepOutcome, StopCheckOutcome};
+// Sibling guard for `enable_mtp` on the cross-turn prefix-cache path, which
+// has no MTP draft/verify wiring (codex round-2 medium #4, PR #787). Only
+// that Metal-only path needs it, same gate as `DecodePolicy`/`StepOutcome`.
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+pub(crate) use generation::check_mtp_not_requested;
 pub(crate) use norm::qwen35_rms_norm;
 pub(crate) use sampling::sample_token;
 pub(crate) use weights::{

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -62,7 +62,7 @@ pub(crate) use generation::{check_reasoning_budget_not_set, check_stop_strings_n
 // gated identically) consumer needs the re-export; `generation.rs` itself
 // uses `DecodePolicy` directly within its own module.
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
-pub(crate) use generation::DecodePolicy;
+pub(crate) use generation::{DecodePolicy, StepOutcome};
 pub(crate) use norm::qwen35_rms_norm;
 pub(crate) use sampling::sample_token;
 pub(crate) use weights::{

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -55,6 +55,14 @@ pub(crate) use generation::check_logprobs_not_set;
 // Sibling guards for `stop_strings` / `reasoning_budget` on the same unwired
 // paths (ADR-080 C3, #783).
 pub(crate) use generation::{check_reasoning_budget_not_set, check_stop_strings_not_set};
+// Shared backend-neutral decode-policy struct (reasoning-budget accounting +
+// logprobs formatting), consumed by the Metal streaming loops in
+// `crate::forward::metal_qwen35` so the same bookkeeping isn't re-duplicated
+// across the CPU/Metal boundary (ADR-080 C3). Only the Metal (`mod inner`,
+// gated identically) consumer needs the re-export; `generation.rs` itself
+// uses `DecodePolicy` directly within its own module.
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+pub(crate) use generation::DecodePolicy;
 pub(crate) use norm::qwen35_rms_norm;
 pub(crate) use sampling::sample_token;
 pub(crate) use weights::{

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -52,6 +52,9 @@ pub(crate) use detokenize::decode_tokens;
 pub(crate) use generation::check_grammar_not_set;
 // Sibling guard for `logprobs` on the same unwired paths (#585).
 pub(crate) use generation::check_logprobs_not_set;
+// Sibling guards for `stop_strings` / `reasoning_budget` on the same unwired
+// paths (ADR-080 C3, #783).
+pub(crate) use generation::{check_reasoning_budget_not_set, check_stop_strings_not_set};
 pub(crate) use norm::qwen35_rms_norm;
 pub(crate) use sampling::sample_token;
 pub(crate) use weights::{

--- a/crates/inference/src/model/qwen35/stop_strings.rs
+++ b/crates/inference/src/model/qwen35/stop_strings.rs
@@ -115,22 +115,28 @@ pub(crate) fn stop_scan_search_start(haystack: &str, prev_len: usize, max_stop: 
 /// `finish` is called once after the decode loop ends (natural stop / EOS / token cap).
 /// If `stopped` is already true it is a no-op; otherwise it appends the `detok.finish()` tail,
 /// checks for a stop in the result, and emits whatever is safe.
-pub(crate) struct StopStringMatcher<'a> {
+pub(crate) struct StopStringMatcher {
     full: String,
     emitted: usize,
     max_stop: usize,
-    stops: &'a [String],
+    stops: Vec<String>,
     stopped: bool,
 }
 
-impl<'a> StopStringMatcher<'a> {
-    pub(crate) fn new(stops: &'a [String]) -> Self {
+impl StopStringMatcher {
+    /// `stops` is cloned into an owned `Vec<String>` (codex round-3 major #1,
+    /// PR #787): a `DecodePolicy`-owned `StopMode::Streaming(StopStringMatcher)`
+    /// variant cannot borrow `gen_cfg.stop_strings`'s lifetime without
+    /// infecting `DecodePolicy` itself with a lifetime parameter threaded
+    /// through every call site; the stop-string list is tiny and constructed
+    /// once per generation, so cloning it is free relative to the decode loop.
+    pub(crate) fn new(stops: &[String]) -> Self {
         let max_stop = stops.iter().map(String::len).max().unwrap_or(1);
         Self {
             full: String::new(),
             emitted: 0,
             max_stop,
-            stops,
+            stops: stops.to_vec(),
             stopped: false,
         }
     }
@@ -163,7 +169,7 @@ impl<'a> StopStringMatcher<'a> {
         }
         let search_start = stop_scan_search_start(&self.full, prev_len, self.max_stop);
 
-        if let Some(hit) = earliest_stop_match_from(&self.full, self.stops, search_start) {
+        if let Some(hit) = earliest_stop_match_from(&self.full, &self.stops, search_start) {
             let slice = &self.full[self.emitted..hit];
             if !slice.is_empty() {
                 sink(slice);
@@ -204,7 +210,7 @@ impl<'a> StopStringMatcher<'a> {
             self.full.push_str(tail);
         }
         // A stop string could complete inside the tail bytes.
-        if let Some(hit) = earliest_stop_match(&self.full, self.stops) {
+        if let Some(hit) = earliest_stop_match(&self.full, &self.stops) {
             let slice = &self.full[self.emitted..hit];
             if !slice.is_empty() {
                 sink(slice);
@@ -227,6 +233,15 @@ impl<'a> StopStringMatcher<'a> {
     }
 
     /// Consume the streamer and return the final (possibly truncated) text.
+    ///
+    /// Only reachable from Metal's non-streaming `generate()` fast/self-spec
+    /// paths (which construct and drive their own local `StopStringMatcher`
+    /// directly, outside `DecodePolicy` -- out of ADR-080 C3's scope) and
+    /// this module's own tests; every `DecodePolicy`-driven call site
+    /// (CPU and Metal streaming) accumulates into a caller-owned
+    /// `text: &mut String` via `stop_check`/`finish_stop` instead (codex
+    /// round-3 major #1, PR #787).
+    #[cfg(any(test, feature = "metal-gpu"))]
     pub(crate) fn into_text(self) -> String {
         self.full
     }

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -5,6 +5,102 @@
 
 use crate::model::qwen35_config::{GenerateConfig, TokenLogprob, TopLogprob};
 
+/// Greedy argmax over a dense `f32` logit slice, with **first-wins** tie-break
+/// (ADR-080 C3, #783; held finding from the ADR-080 duplication audit).
+///
+/// `Iterator::max_by` keeps the *last* element on `Ordering::Equal`, so tied
+/// maximum logits (e.g. `[0.0, 1.0, 1.0]`) return the higher token id — the
+/// opposite of the engine-wide greedy contract. [`CandidateSet::argmax`],
+/// `attention` decode paths, and `torch.argmax` all return the *first*
+/// occurrence on a tie; this is the canonical shared implementation every
+/// dense-logit-slice greedy call site should use instead of hand-rolling its
+/// own `max_by` closure (the duplication this ADR-080 cluster closes).
+///
+/// Strict `>` from `NEG_INFINITY` skips `NaN` (a `NaN` comparison is always
+/// false) and returns `0` on empty / all-`NaN` / fully-masked (all
+/// `NEG_INFINITY`) input — the dense-array form of the engine-wide
+/// fail-closed-to-first-in-set contract, never a panic.
+///
+/// Its only production callers today (`generate_greedy_mtp`,
+/// `generate_greedy_self_spec` in `forward/metal_qwen35.rs`) live behind the
+/// `metal-gpu` feature, so a default-feature build never calls it outside
+/// this module's own tests.
+#[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
+pub(crate) fn argmax_f32_first_wins(logits: &[f32]) -> u32 {
+    let mut best_idx = 0u32;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &v) in logits.iter().enumerate() {
+        if v > best_val {
+            best_val = v;
+            best_idx = i as u32;
+        }
+    }
+    best_idx
+}
+
+#[cfg(test)]
+mod argmax_f32_first_wins_tests {
+    use super::argmax_f32_first_wins;
+
+    /// Mutation sensitivity: replacing the strict `>` comparison with `>=`
+    /// (or switching to `Iterator::max_by`, which keeps the LAST tied
+    /// element) flips this to return index 2 instead of 1.
+    #[test]
+    fn tie_break_is_first_wins() {
+        let logits = [0.0_f32, 1.0, 1.0, 0.5];
+        assert_eq!(
+            argmax_f32_first_wins(&logits),
+            1,
+            "tied maximum logits must resolve to the FIRST index, not the last"
+        );
+    }
+
+    #[test]
+    fn no_tie_returns_true_max() {
+        let logits = [0.1_f32, -2.0, 5.5, -0.001];
+        assert_eq!(argmax_f32_first_wins(&logits), 2);
+    }
+
+    /// Mutation sensitivity: initializing `best_val` to `0.0` instead of
+    /// `NEG_INFINITY` would make this return 0 (all-negative logits never
+    /// beat a 0.0 floor) instead of the true argmax at index 1.
+    #[test]
+    fn all_negative_logits_still_find_true_max() {
+        let logits = [-5.0_f32, -1.0, -3.0];
+        assert_eq!(argmax_f32_first_wins(&logits), 1);
+    }
+
+    /// A NaN in a non-max position must never win: `NaN > best_val` is
+    /// always false, so the comparison silently skips it.
+    #[test]
+    fn nan_in_nonmax_position_is_skipped() {
+        let logits = [1.0_f32, f32::NAN, 2.0];
+        assert_eq!(argmax_f32_first_wins(&logits), 2);
+    }
+
+    /// All-NaN input must fail closed to index 0, never panic.
+    #[test]
+    fn all_nan_fails_closed_to_zero() {
+        let logits = [f32::NAN, f32::NAN, f32::NAN];
+        assert_eq!(argmax_f32_first_wins(&logits), 0);
+    }
+
+    /// Empty input must fail closed to index 0, never panic.
+    #[test]
+    fn empty_slice_fails_closed_to_zero() {
+        let logits: [f32; 0] = [];
+        assert_eq!(argmax_f32_first_wins(&logits), 0);
+    }
+
+    /// All-`NEG_INFINITY` (a fully-masked grammar/top-k step) must fail
+    /// closed to index 0.
+    #[test]
+    fn all_neg_infinity_fails_closed_to_zero() {
+        let logits = [f32::NEG_INFINITY; 4];
+        assert_eq!(argmax_f32_first_wins(&logits), 0);
+    }
+}
+
 /// **Unstable**: sampling configuration for decoder-only generation; fields
 /// and defaults may change as the generation API evolves.
 #[derive(Debug, Clone)]

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -3,7 +3,7 @@
 //! Supports temperature scaling, top-k filtering, top-p (nucleus) sampling,
 //! and repetition penalty.
 
-use crate::model::qwen35_config::{GenerateConfig, TokenLogprob, TopLogprob};
+use crate::model::qwen35_config::{GenerateConfig, TopLogprob};
 
 /// Greedy argmax over a dense `f32` logit slice, with **first-wins** tie-break
 /// (ADR-080 C3, #783; held finding from the ADR-080 duplication audit).
@@ -750,7 +750,17 @@ const LOGPROB_NEG_SENTINEL: f32 = -1.0e9;
 /// Falls back to [`LOGPROB_NEG_SENTINEL`] wherever a value would otherwise be
 /// non-finite (e.g. every logit non-finite) or `token_id` is outside the
 /// vocabulary covered by `logits`.
-fn compute_step_logprobs(
+///
+/// `pub(crate)` (codex round-3 medium #2, PR #787 / Leo's ruling): this is
+/// the pure-computation half of what `record_logprob` used to expose as one
+/// combined `pub(crate)` function. `DecodePolicy::record_logprob`
+/// (`model::qwen35::generation`) is the only place that pushes the result
+/// into a `token_logprobs: &mut Vec<TokenLogprob>` -- a decode call site can
+/// read a logprob distribution for its own purposes, but it can no longer
+/// independently append to a `token_logprobs` accumulator without going
+/// through `DecodePolicy`, since no freestanding "record" function exists to
+/// call anymore.
+pub(crate) fn compute_step_logprobs(
     logits: &[f32],
     token_id: u32,
     temperature: f32,
@@ -832,31 +842,6 @@ fn compute_step_logprobs(
     };
 
     (token_logprob, top)
-}
-
-/// Appends one decode step's logprob data to `token_logprobs` when requested.
-///
-/// `logprobs_requested` is the caller's `top_logprobs` count (`Some(0)` when
-/// `logprobs` was requested without a `top_logprobs` count); `None` disables
-/// capture entirely and this is a no-op, so callers can invoke it
-/// unconditionally on every decode step -- the cost of the softmax pass over
-/// the full vocabulary is paid only when logprobs were actually requested.
-pub(crate) fn record_logprob(
-    token_logprobs: &mut Vec<TokenLogprob>,
-    logits: &[f32],
-    token_id: u32,
-    temperature: f32,
-    logprobs_requested: Option<usize>,
-) {
-    let Some(top_n) = logprobs_requested else {
-        return;
-    };
-    let (logprob, top) = compute_step_logprobs(logits, token_id, temperature, top_n);
-    token_logprobs.push(TokenLogprob {
-        token_id,
-        logprob,
-        top,
-    });
 }
 
 /// Fail-closed pre-scan for `sample_full_logits`: detects whether `logits`
@@ -2392,32 +2377,14 @@ mod tests {
         assert!((top[0].logprob - reference[2]).abs() < 1e-4);
     }
 
-    #[test]
-    fn test_record_logprob_noop_when_not_requested() {
-        let mut token_logprobs = Vec::new();
-        record_logprob(&mut token_logprobs, &[1.0, 2.0, 3.0], 2, 1.0, None);
-        assert!(
-            token_logprobs.is_empty(),
-            "record_logprob must not allocate/push anything when logprobs \
-             were not requested -- this is the zero-cost default path"
-        );
-    }
-
-    #[test]
-    fn test_record_logprob_appends_entry_when_requested() {
-        let mut token_logprobs = Vec::new();
-        record_logprob(&mut token_logprobs, &[1.0, 2.0, 3.0], 2, 1.0, Some(2));
-        assert_eq!(token_logprobs.len(), 1);
-        assert_eq!(token_logprobs[0].token_id, 2);
-        assert_eq!(token_logprobs[0].top.len(), 2);
-
-        // A second call appends rather than overwrites, matching per-step
-        // accumulation across a whole generation.
-        record_logprob(&mut token_logprobs, &[3.0, 2.0, 1.0], 0, 1.0, Some(0));
-        assert_eq!(token_logprobs.len(), 2);
-        assert_eq!(token_logprobs[1].token_id, 0);
-        assert!(token_logprobs[1].top.is_empty());
-    }
+    // `record_logprob`'s noop/appends behavior moved to
+    // `model::qwen35::generation`'s `DecodePolicy::record_logprob` tests
+    // (codex round-3 medium #2, PR #787 / Leo's ruling) -- see
+    // `decode_policy_record_logprob_noop_when_not_requested` and
+    // `transition_records_one_logprob_per_generated_token` there. The
+    // freestanding `pub(crate) record_logprob` this module used to export no
+    // longer exists: only `compute_step_logprobs` (pure computation) remains
+    // shared, and mutating `token_logprobs` is exclusively `DecodePolicy`'s.
 
     // -------------------------------------------------------------------
     // CPU-side microbench (issue #650): before/after `sample_full_logits`.


### PR DESCRIPTION
## Contract

ADR-080 cluster C3: backend-neutral decode policy, apply-or-fail-closed.

Decode-policy controls (stop-string matching, reasoning-budget accounting,
logprobs formatting) live in one policy struct, `DecodePolicy`, in
`model/qwen35/generation.rs`. Construction (`DecodePolicy::init`) and every
per-step transition (`DecodePolicy::transition`) are the only two ways any
caller can drive the policy: `init` builds the struct, records the
prefill-derived first token's logprob in the same call, and constructs the
policy's private `StopMode` (`Disabled` / `Streaming` / `FullScan`) from the
real `gen_cfg.stop_strings` — the only place a `StopMode` value is ever
produced, so which stop-check behavior applies (or whether it applies at
all) is fixed by the config the policy was built from, not by anything a
call site writes. `transition` takes a backend-specific per-step forward
callback plus raw per-token I/O primitives for the stop check
(`decode_delta`, a `text`/`token_logprob_end_offsets` buffer pair, and
`emit_confirmed`) — each backend keeps `forward_step`, grammar
masking/advance, sampling, and EOS/stop-token checking entirely to itself,
and hands `transition` the token its own pipeline just sampled plus three
backend callbacks (grammar-advance, EOS/stop-token check, push into its own
token vectors) and those I/O primitives, which `DecodePolicy::stop_check`
alone uses to decide the stop outcome by dispatching on `self.stop_mode`.
`transition` returns whether to stop (grammar/EOS/stop-string/interrupt) or
the emitted token plus whether the answer-budget window has closed, having
already applied the reasoning-budget override, logprobs recording, and
reasoning-end capture in the process. Every decode loop either drives
through `init`+`transition`, or explicitly rejects the unsupported
`GenerateConfig` field at its entry point via the existing
`check_grammar_not_set` / `check_logprobs_not_set` precedent, extended here
with sibling `check_stop_strings_not_set` / `check_reasoning_budget_not_set`
/ `check_mtp_not_requested` guards. Silent omission — a caller sets a field,
gets no error, and the field is quietly ignored — is the defect this
cluster closes.

Three held findings from ADR-080 are also resolved here:

1. **Reasoning-budget bookkeeping and logprobs recording were hand-duplicated
   six times.** CPU `decode_loop`, `decode_loop_with_stops`, both branches of
   `generate_streaming_with_cancel` (all four in `model/qwen35/generation.rs`),
   and both Metal streaming loops (`generate_streaming` /
   `generate_streaming_with_cancel` and
   `generate_streaming_with_prefix_cache_and_cancel_inner`, in
   `forward/metal_qwen35.rs`) each independently reimplemented identical
   `think_close_id` resolution, `thinking_closed` / `reasoning_end_len`
   tracking, the `decode_cap` / `force_close_think` calls, the answer-budget
   break condition, and per-token logprobs recording — confirmed
   byte-for-byte identical across the CPU/Metal boundary. All six now drive
   the same `DecodePolicy::init` / `DecodePolicy::transition` calls instead.
2. `generate_greedy_mtp` / `generate_greedy_self_spec` each carried their own
   inline `max_by` argmax, which keeps the **last** tied index on equal
   logits rather than the first — inconsistent with the rest of the crate's
   tie-break convention (issue #280 class). Both now call one shared
   `crate::sampling::argmax_f32_first_wins`; a second surviving last-wins
   `max_by` in `mtp_forward_one`'s draft-token selection (missed in the
   initial sweep) is fixed the same way.
3. `mtp_route_active` / `self_spec_route_active` already excluded
   `stop_strings` and `reasoning_budget` from their fast-path eligibility but
   not `repetition_penalty` — a config with a non-identity penalty could
   silently enter a fast path that selects via raw argmax and never applies
   it (an output-correctness gap, not just perf: MTP/self-spec never call
   `sample_token`). Both predicates now exclude `repetition_penalty != 1.0`
   as well.

`DecodePolicy`'s constituent operations (budget override, emitted
bookkeeping, logprobs recording, reasoning-end capture, answer-budget check)
are private to `model/qwen35/generation.rs` — `init`/`transition` are the
only way any of the six sites, three of them in a different module
(`forward/metal_qwen35.rs`), can reach them, so a call site can no longer
apply a subset and silently skip another. Stop-string matching itself is
owned by `StopMode`, a private enum on `DecodePolicy` with no public
constructor other than `DecodePolicy::init`: `Streaming` wraps
`StopStringMatcher`'s incremental byte-holdback semantics (a partial match
must never reach the caller's confirmed-text sink) for streaming callers,
`FullScan` wraps the non-streaming full-text rescan
(`earliest_stop_match` / `earliest_stop_match_from`), and `Disabled` covers
an empty `gen_cfg.stop_strings` — genuinely different consumption shapes of
the same shared components, selected once from the real config rather than
by a closure a call site could supply. A caller cannot construct, name, or
swap a `StopMode` at all (the type isn't reachable outside
`generation.rs`); omitting the stop check entirely is a compile error
(`transition`'s I/O-primitive parameters are non-optional), not a silent
gap.

## Per-site disposition

| Site | Verdict | Notes |
|---|---|---|
| `model/qwen35/generation.rs` — `Qwen35Model::generate` (CPU canonical, direct) | routed via `DecodePolicy::init`/`transition` | `decode_loop` / `decode_loop_with_stops` both drive the one atomic transition |
| `model/qwen35/generation.rs` — `generate_streaming` / `generate_streaming_with_cancel` (CPU canonical, streaming) | routed via `DecodePolicy::init`/`transition` | both inline loops (fast-path and stop-string-path) drive the transition; grammar/sampling/detokenizer logic untouched |
| `forward/cpu_f16.rs` — `generate_f16` | rejects | previously silently omitted both fields |
| `forward/cpu_q8.rs` — `generate_q8` | rejects | previously silently omitted both fields |
| `forward/neon_forward.rs` — `generate_q8_neon` | rejects | previously silently omitted both fields |
| `forward/batch_prefill.rs` — `Qwen35Model::generate_with_batch_prefill` | rejects | previously silently omitted both fields |
| `forward/metal_qwen35.rs` — `MetalQwen35State::generate` (direct) | mixed | `stop_strings` already routed (#657); `reasoning_budget` + `logprobs` now reject |
| `forward/metal_qwen35.rs` — `generate_streaming` / `generate_streaming_with_cancel` | routed via `DecodePolicy::init`/`transition` | drives the same transition as the CPU loops (re-exported `pub(crate)`, gated identically to its Metal-only consumer) |
| `forward/metal_qwen35.rs` — `generate_streaming_with_prefix_cache_and_cancel_inner`, wrapped by `generate_streaming_with_prefix_cache_and_cancel` | routed via `DecodePolicy::init`/`transition`, rejects logprobs + active MTP | the public wrapper now runs `check_logprobs_not_set` + `check_mtp_not_requested` before any cache/state mutation, so a rejection never evicts a warm cross-turn entry |
| `forward/metal_qwen35.rs` — `generate_greedy_mtp` (MTP fast path) | exempt-with-reason | draft/verify loop can't support stop-strings, reasoning-budget, non-identity repetition-penalty, or logprobs; route predicate now excludes all four, falls through to `generate` (which itself rejects/honors `logprobs`/`enable_mtp`). Draft-token selection now uses the shared first-wins argmax |
| `forward/metal_qwen35.rs` — `generate_greedy_self_spec` (self-spec fast path) | exempt-with-reason | same as MTP |
| `forward/metal_qwen35.rs` — `generate_multimodal` | mixed | `stop_strings` already routed; `reasoning_budget` now rejects via `multimodal_generate_preflight` |
| `generate.rs` (legacy `Qwen3`/`QwenModel`) | exempt-with-reason | different config schema entirely — no `stop_strings`/`reasoning_budget` fields exist on it |
| `bin/*.rs` (all CLI tools) | routed (transitively) | all call into the entry points above; no independent decode loop found |

Sibling grep for completion: `grep -rl "sample_token(\|GenerateConfig" crates/inference/src` enumerated every file touching the Qwen3.5 decode-policy surface; every hit is accounted for above. Sibling grep for the argmax fix: `grep -n "max_by\b" crates/inference/src/forward/metal_qwen35.rs` returns only the fixed `mtp_forward_one` site (replaced) and two `#[cfg(test)]`-gated oracle helpers in sibling test modules — no other production last-wins argmax remains.

## Codex round-2 review — 4 findings, all fixed

Codex round-2 (head `09a33838d`) returned REJECT: 1 blocker, 1 major (a held
architecture-contract fork escalated for a ruling before implementation), 2
mediums. All four are fixed in this PR's current head.

- **Blocker** — `gen_cfg.logprobs` was not gated on the MTP/self-spec fast
  paths, and the direct Metal `generate()` entry point had no
  `check_logprobs_not_set` preflight at all: all three silently returned
  empty `token_logprobs` instead of rejecting the request. Fixed by adding
  `logprobs.is_none()` to `mtp_route_active` / `self_spec_route_active`, and
  a `check_logprobs_not_set` preflight at the top of `generate()`.
- **Medium** — the prefix-cache path's public wrapper caught every `Err`
  from its inner implementation and unconditionally called `reset_state()`
  plus evicted the cache slot, so a preflight-only rejection (e.g.
  `logprobs`) destroyed a valid pre-existing warm cross-turn entry. Fixed by
  hoisting the preflight checks to the public wrapper, before the
  destructive `Err`-recovery match.
- **Medium** — the same prefix-cache path accepted
  `GenerateConfig::enable_mtp` but never read or rejected it, unlike the
  direct Metal entry point. Fixed with a new sibling guard,
  `check_mtp_not_requested`, called alongside the logprobs guard in the
  hoisted wrapper location.
- **Major** (Leo's ruling: extend the design, do not amend ADR-080, scoped
  to exactly two additions) —
  1. `DecodePolicy::new` → `DecodePolicy::init`, which now records the
     prefill-derived first token's logprob as part of construction, killing
     three duplicated freestanding `record_logprob` call sites that
     previously lived outside the policy.
  2. `DecodePolicy::transition` gained a sixth, mandatory `stop_check`
     closure parameter. Omitting it is a compile error (verified:
     `E0061: this method takes 9 arguments but 8 arguments were supplied`).
     All six call sites now supply this closure explicitly (the
     no-stop-strings fast paths supply `|_, _| StopCheckOutcome::Continue`
     rather than omitting the parameter).

Every fix is mutation-verified (reverse-apply in place → confirm red →
restore → confirm green) or backed by the compiler-error observation for
the two structural guarantees (this and the round-1 `E0624` privacy proof).
Full per-finding mutation log kept locally (gitignored
`.khive/codex_reviews/`, not part of this diff).

## Codex round-3 review — 1 major + 2 mediums, all fixed

Codex round-3 (head `69d14b7ed`) returned APPROVE-WITH-FIXES: every
round-1/round-2 output-bug concern was confirmed closed (route-predicate
logprobs gating, direct-Metal ordering, prefix-cache ordering/MTP-guard,
`init`'s first-token logprob ownership, the full `GenerateConfig` field
re-sweep, CI green). What remained was hardening the round-2 `stop_check`
closure parameter itself: it could still compile as a trivial
`|_, _| StopCheckOutcome::Continue` for **any** configuration, including one
with real `stop_strings` set — the API could not structurally distinguish
"a real matcher adapter" from "a no-op."

- **Major** — `DecodePolicy::transition`'s `stop_check` closure parameter
  was an arbitrary outcome-producing callback: nothing prevented a call site
  from claiming `Continue` without actually checking anything, for a config
  that genuinely has stop strings. Fixed by replacing the closure with a
  private `StopMode` enum (`Disabled` / `Streaming(StopStringMatcher)` /
  `FullScan { stop_strings, max_stop }`) owned by `DecodePolicy` as a new
  `stop_mode` field, constructed exactly once via the private
  `StopMode::for_config(stop_strings, streaming)` inside `DecodePolicy::init`
  (which gained a trailing `streaming: bool` parameter) — no call site can
  construct, pass in, or swap a `StopMode` independently of the config the
  policy was built from; the type isn't even nameable outside
  `generation.rs` (verified: `error[E0603]: module 'generation' is private`
  when referenced from `forward/metal_qwen35.rs`). `transition` now takes
  only raw I/O primitives (`decode_delta`, a `text: &mut String` buffer, a
  `token_logprob_end_offsets` buffer, and `emit_confirmed`) and a new private
  `stop_check` method drives the actual decision from `self.stop_mode`. A
  new `pub(crate) check_initial_stop` covers the prefill-derived first
  token's check (before the decode loop) using the *same* `stop_mode`
  instance `transition` keeps driving — critical for `Streaming`'s
  byte-holdback continuity across the first/second-token boundary, a real
  correctness risk in a naive two-matcher design caught during this fix. A
  new `finish_stop` mirrors the natural-end tail flush the same way. All 6
  `transition` call sites (CPU `decode_loop`, `decode_loop_with_stops`, both
  branches of CPU `generate_streaming_with_cancel`, both Metal streaming
  functions) converted; `StopStringMatcher` lost its lifetime parameter
  (owns a cloned `Vec<String>` instead of borrowing) so it could be embedded
  directly in `StopMode::Streaming` without threading a lifetime through
  every `DecodePolicy` call site.
- **Medium** — `crate::sampling::record_logprob` was `pub(crate)` and
  imported directly into `generation.rs`, so any sibling decode site could
  call it and independently append to `token_logprobs`, recreating the
  duplicate-choreography bug this cluster closes for the other four
  constituent methods. Fixed by deleting the freestanding function: the
  pure computation (`compute_step_logprobs`) is now `pub(crate)`, but the
  `token_logprobs.push(...)` mutation lives only inside the already-private
  `DecodePolicy::record_logprob`. Verified: a probe call to
  `crate::sampling::record_logprob(...)` from `forward/metal_qwen35.rs` now
  fails with `error[E0425]: cannot find function 'record_logprob' in module
  'crate::sampling'` — the function no longer exists to be called from
  anywhere outside `DecodePolicy`.
- **Medium** — the PR's bench-compare claim was wrong: `elementwise_cpu_bench`
  (the only `lattice-inference` group `make bench-compare` runs by default)
  times standalone norm/activation/softmax kernels directly and never
  constructs a `DecodePolicy`, calls `transition`, or enters a generation
  loop, so its clean result did not support the claim that it was "the
  group this refactor could affect." No existing bench in
  `crates/inference/benches/` drives `Qwen35Model::generate`/
  `generate_streaming` either. Building a new Criterion harness was judged
  out of this round's scope (new bench infrastructure is itself new
  reviewable surface); corrected below instead of crediting
  `elementwise_cpu_bench`.

All three fixes are mutation/compile-fail-verified (reverse-apply →
observe red/compile-error → restore → confirm green). Mutation log updated
locally (gitignored `.khive/codex_reviews/`, not part of this diff).

## Testing

- 27 new/changed sites across both codex rounds, each covered by a
  dedicated unit test, all mutation-verified.
- New round-2 tests: `mtp_route_blocked_by_set_logprobs`,
  `self_spec_route_blocked_by_set_logprobs`,
  `metal_generate_plain_rejects_logprobs_config`,
  `generate_streaming_with_prefix_cache_rejects_logprobs_request_preserves_warm_entry`
  (warms a real cross-turn entry, makes a rejected `logprobs` call, asserts
  the same token ids are still cached afterward),
  `generate_streaming_with_prefix_cache_rejects_active_mtp_request`,
  `init_records_the_prefill_tokens_logprob_before_any_transition_call`
  (uses `max_new_tokens: 1` so `transition` never executes, isolating that
  the sole logprob can only have come from `init`).
- Full `cargo test -p lattice-inference --lib --features f16,metal-gpu -- --test-threads=1`, run under the GPU lock after this PR's final head: **1795 passed; 2 failed; 20 ignored** (4041.85s). Both failures are confirmed pre-existing and unrelated:
  - `f16_kv_metal_path_executes_and_reports_capability` — gated on unset `LATTICE_KV_F16=1`, same confirmed-pre-existing case from the prior round.
  - `metal_qwen35_chunked_prefill_long_prompt_matches_step_loop` — failed only the test's own loose logit-value regression guard (`max_abs_diff=0.848629` vs its `<0.5` bound); **argmax matched exactly** (271==271). The test's own in-source comment ("KNOWN ISSUE (2026-06-03)") documents this as a pre-existing, nondeterministic, occupancy-sensitive GPU race in `gdn_recurrence_fused`/`decode_attention`, confirmed present verbatim on `origin/main` before any change in this PR. Neither `forward_prefill`, `forward_step`, nor either kernel is touched by this PR's diff.
- Targeted Metal test run (route predicates, prefix-cache rejection tests, direct-generate rejection tests): 15 passed, 0 failed.
- Default-feature `cargo test -p lattice-inference --lib` (no Metal required): 1629 passed, 0 failed, 18 ignored.
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --check`: clean under both default features and `--features f16,metal-gpu`.
- Greedy-token output is byte-identical on every routed path: the redesign only replaces local bookkeeping and separate method calls with atomic calls in the same order — no sampling, forward, grammar, or stop-condition logic changed. e2e-parity (greedy token match vs HF transformers) is CI-gated and confirms this on the canonical CPU path.
- **Round-3 (this head, `34161ce7f`):** `cargo test -p lattice-inference --lib --features f16` (default, no Metal): **1632 passed, 0 failed, 18 ignored** (124.09s). Full `forward::metal_qwen35::` module under the GPU lock, `--test-threads=4`: **236 passed, 3 failed** (3840.11s) — triaged per this repo's flaky-vs-deterministic protocol (re-run solo, `--test-threads=1`, idle GPU): `f16_kv_metal_path_executes_and_reports_capability` is the same env-gated (`LATTICE_KV_F16` unset) pre-existing case noted above; `metal_qwen35_chunked_prefill_length_1_final_chunk_matches_step_loop` and `metal_qwen35_prefill_all_logits_long_prompt_no_longer_panics` both went **green solo** (2 passed, 0 failed, 140.97s) — same argmax-matches-but-tight-logit-guard contended-GPU signature as the round-1/2 KNOWN-ISSUE case above, not a regression; neither test's code path is touched by this round's diff. Targeted new-adapter tests (12 Metal stop-string/route tests, 3 new CPU `DecodePolicy`/`record_logprob` tests): all green. `cargo clippy -p lattice-inference --lib` and `cargo clippy --workspace`, both `--features f16` and `--features f16,metal-gpu`, `-D warnings`: clean, all 4 combinations. `cargo fmt --check`: clean.

## Bench-compare

**Correction (codex round-3 medium):** an earlier version of this section
credited `elementwise_cpu_bench`'s clean Qwen3.5-adjacent group as evidence
this refactor doesn't regress performance. That was wrong: that bench times
standalone norm/activation/softmax kernels directly and never constructs a
`DecodePolicy`, calls `transition`, or runs a generation loop at all — it
cannot observe anything this PR changes. No bench in
`crates/inference/benches/` drives `Qwen35Model::generate` /
`generate_streaming` (the closest, `inference_bench.rs`, is a BERT-only
encode/layer-op bench). Building a new Criterion harness for
`DecodePolicy::transition`/orchestration overhead was judged out of this
round's scope. **This refactor is therefore unmeasured by the default
`make bench-compare` suite** — it is a like-for-like call-order
restructuring (same branches, same allocations, same per-step work moved
behind method calls instead of inline), so no throughput change is
expected, but that expectation is architectural reasoning, not a
measurement, and should be read as such.

`make bench-compare`, base `origin/main` @ 65865ecb5, head @ 69d14b7ed (this PR, rounds 1-2): **14 FAIL / 14 WARN / 59 WIN**. Every FAIL/WARN row is either (a) one of `crates/embed`'s `simd`/`int8`/`tier_prepared_batch_sizes` benches — a crate this PR touches zero lines of, with the same bench families showing both large FAILs and large WINs on sibling size/shape variants of the identical op (the documented contended-machine-noise signature; 3-4 sibling bench jobs were queued/contending on this machine's heavy lane during the run window), or (b) `residual_add_layer_norm/unfused/hidden384_seq128` (+5.88% WARN), a BERT CPU norm kernel this PR's diff never touches. Neither category exercises the decode-policy code path this PR actually changes (see correction above) — they are cited only as evidence nothing in `crates/embed`/BERT-CPU regressed, not as evidence about `DecodePolicy` itself.

**Round-3 re-run attempted, contended — not usable as evidence.** `make bench-compare` was re-run twice against this round's head (`34161ce7f`) but both runs landed while unrelated fleet activity was hammering this shared machine (a separate lambda's `kkernel-bench` process + a large `rustfmt` sweep, load average 36-44 at the time). The second attempt showed +90% to +277% "regressions" exclusively in `crates/embed`'s `simd`/`int8` benches — the same untouched crate/bench-family as the round-1/2 noise above, but at a magnitude an order of magnitude larger than anything in this PR's diff could plausibly cause, confirming machine contention rather than a real signal. No clean, uncontended re-run was obtained this round. This does not change the substance of the correction above: the default suite still does not exercise `DecodePolicy`/`transition`, so this refactor remains unmeasured by `make bench-compare` regardless of contention.

## Scope note

The ADR-080 C3 checklist's first line item — a shared policy struct wrapping
a per-step callback in `model/qwen35/generation.rs` — is implemented as
`DecodePolicy::init` + `DecodePolicy::transition`, described above. The
defect this cluster exists to close (silent field omission, plus the
duplicated-bookkeeping drift risk) is fully closed by this PR, including
every instance codex's round-1 and round-2 reviews found in the initial
implementation.

Refs: #783, #778 (ADR-080)

