### PR TITLE
docs(adr): resolve ADR-070 numbering collision + index reconciliation

### DIFF
--- a/docs/adr/ADR-062-metal-fa2-prefill.md
+++ b/docs/adr/ADR-062-metal-fa2-prefill.md
@@ -1,6 +1,6 @@
 # ADR-062: Metal FlashAttention-2 Prefill + KV Cache Quantization Chain
 
-**Status**: Proposed (partially superseded — see implementation status below)
+**Status**: Proposed (partially superseded — see implementation status below; KV-quant sequencing further superseded at the priority level by ADR-073)
 **Date**: 2026-05-27
 **Crate**: lattice-inference (Metal shaders, KV cache). Phase 0 proposes extracting shaders into a `crates/lattice-metal/` directory tree. **This introduces a new workspace member** — see Crate Layout below for dependency direction, feature gating, and publish-order consequences. If the team prefers keeping shaders inside `crates/inference/`, the same file structure applies under `crates/inference/src/metal/` without a new crate.
 **Research**: RQ-4 (`workspaces/20260527/04.md`)

--- a/docs/adr/ADR-071-gdn-state-object-priority.md
+++ b/docs/adr/ADR-071-gdn-state-object-priority.md
@@ -133,7 +133,7 @@ additionally needs KV page-table integration; its scope is decided once the obje
 The B=128 device-scratch + `simdgroup_matrix` variant is the *sole* untried chunk-scan sub-lever,
 and it is **low priority**: decode profiling (S10) makes GDN the cheapest mixer, so the chunk scan
 is a prefill-only concern already meeting ≥5×@4K (S8). Revisit only if prefill attention becomes
-the top prefill lever (tied to ADR-070's deferred FA2 track).
+the top prefill lever (tied to ADR-081's deferred FA2 track).
 
 ## Consequences
 

--- a/docs/adr/ADR-081-prefill-gemm-optimization-priority.md
+++ b/docs/adr/ADR-081-prefill-gemm-optimization-priority.md
@@ -1,8 +1,12 @@
-# ADR-070: Prefill GEMM Optimization Priority (Metal)
+# ADR-081: Prefill GEMM Optimization Priority (Metal)
 
 **Status**: Proposed
 **Date**: 2026-07-08
 **Crate**: lattice-inference
+
+> Renumbered from ADR-070 on 2026-07-10 to resolve a numbering collision with
+> ADR-070-cpu-embedding-batched-encode.md (both files were independently merged under
+> number 070 three days apart, PR #671 and PR #721/#722).
 
 > **Evidence basis**: The Decision below is grounded in this engine's own measured
 > profiling and A/B results (the **Measured** table). A parallel external prior-art

--- a/docs/adr/ADR-ALIGNMENT-AUDIT.md
+++ b/docs/adr/ADR-ALIGNMENT-AUDIT.md
@@ -4,6 +4,8 @@
 **Date**: 2026-06-30
 **Scope**: `docs/adr/` (65 numbered ADRs + `INDEX.md`)
 
+This audit's classification is frozen at 2026-06-30 and covers ADR-001 through ADR-065 only; ADR-066 onward (including the ADR-070 numbering collision resolved by ADR-081) postdate it and are not classified here.
+
 Source ref: `origin/main` at `4772d5b`.
 
 Inventory basis: `../explorer/adr-inventory.md` listed 65 markdown files under `docs/adr/` on `origin/main`: 64 numbered ADRs plus `INDEX.md`. This change adds ADR-065 (the companion methodology ADR), bringing committed HEAD to 65 numbered ADRs plus `INDEX.md`. Statuses below are classified from source evidence or concrete source gaps, not ADR prose alone. If an ADR makes no current code-checkable claim beyond an implemented path, it is marked `current` with the relevant source path.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -116,7 +116,7 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | [078](ADR-078-multimodal-serving-deferral-priority.md) | Multimodal / Vision Serving Priority (Deferral)             | Proposed     | ADR-049, 069, 071 |
 | [079](ADR-079-adaptive-micro-lora-brain.md)        | Adaptive Micro-LoRA Brain — Composed Train→Govern→Compose→Route→Consume Loop | Proposed | ADR-008/031/043/045/054/056/057 |
 | [080](ADR-080-consolidation-duplicated-contracts.md) | Consolidation of Duplicated Numeric-Contract Helpers (Softmax, HTTP Serving, Decode Policy, GEMM Validation) | Proposed | ADR-058, ADR-064, ADR-066 |
-| [081](ADR-081-prefill-gemm-optimization-priority.md) | Prefill GEMM Optimization Priority (Metal) — renumbered from ADR-070 on 2026-07-10 | Proposed | none |
+| [081](ADR-081-prefill-gemm-optimization-priority.md) | Prefill GEMM Optimization Priority (Metal) | Proposed | none |
 
 ## informational
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -106,8 +106,17 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | [068](ADR-068-grammar-wire-contract.md)            | Pluggable Custom-Grammar Wire Contract for the OpenAI-Compatible Serving Surface | Proposed | ADR-046, 063 |
 | [069](ADR-069-vision-encoder-qwen35-recalibration.md) | Vision Encoder Recalibration for Qwen3.5-0.8B                 | Proposed     | none         |
 | [070](ADR-070-cpu-embedding-batched-encode.md)     | CPU Embedding Performance: Fused Batched Encode and the ONNX Parity Gate | Proposed | ADR-058 |
+| [071](ADR-071-gdn-state-object-priority.md)        | GDN Recurrent State as a First-Class Serveable Object — Priority and Scope | Proposed | none |
+| [072](ADR-072-weight-quantization-priority.md)     | Weight Quantization Priority (Metal)                           | Proposed     | ADR-044, 051 |
+| [073](ADR-073-kv-cache-quantization-priority.md)   | KV-Cache Quantization Priority (Metal)                          | Proposed     | ADR-048, 062, 072 |
+| [074](ADR-074-mtp-speculative-decoding-priority.md) | MTP / Speculative-Decoding Priority (Metal)                    | Proposed     | ADR-006, 050, 051, 073 |
+| [075](ADR-075-moe-expert-offload-priority.md)      | MoE Expert-Offload Priority (Metal)                             | Proposed     | ADR-053, 072, 073, 074 |
+| [076](ADR-076-adaptive-reasoning-priority.md)      | Adaptive Reasoning-Budget Priority (Metal + CPU)                | Proposed     | ADR-073, 074 |
+| [077](ADR-077-pruning-distill-priority.md)         | Pruning + Distillation Priority (Metal + CPU)                   | Proposed     | ADR-060, 073, 076 |
+| [078](ADR-078-multimodal-serving-deferral-priority.md) | Multimodal / Vision Serving Priority (Deferral)             | Proposed     | ADR-049, 069, 071 |
 | [079](ADR-079-adaptive-micro-lora-brain.md)        | Adaptive Micro-LoRA Brain — Composed Train→Govern→Compose→Route→Consume Loop | Proposed | ADR-008/031/043/045/054/056/057 |
 | [080](ADR-080-consolidation-duplicated-contracts.md) | Consolidation of Duplicated Numeric-Contract Helpers (Softmax, HTTP Serving, Decode Policy, GEMM Validation) | Proposed | ADR-058, ADR-064, ADR-066 |
+| [081](ADR-081-prefill-gemm-optimization-priority.md) | Prefill GEMM Optimization Priority (Metal) — renumbered from ADR-070 on 2026-07-10 | Proposed | none |
 
 ## informational
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Docs-only reconciliation of the `docs/adr/` corpus (no source-code changes).

**Flag A — ADR-070 number collision.** Two independent PRs merged three days apart under the same
number: `ADR-070-cpu-embedding-batched-encode.md` (PR #671, commit `307d62cef`, 2026-07-05) and
`ADR-070-prefill-gemm-optimization-priority.md` (PR #721/#722, commits `2c7e68dfb`/`011f7fe25`,
2026-07-08). The later-issued file (prefill-GEMM) is renumbered to `ADR-081` (next free number
after ADR-080), keeping the earlier `ADR-070` (CPU embedding) unchanged. The cross-reference in
`ADR-071-gdn-state-object-priority.md:136` ("tied to ADR-070's deferred FA2 track") is updated to
`ADR-081`, since it unambiguously meant the prefill-GEMM document (ADR-071 is the next ADR in the
same priority-sequencing bundle: 070/081-prefill-gemm, 071-gdn-state, ..., 078-multimodal). The
renamed file's header carries a one-line renumbering note.

**Flag B — INDEX.md missing 8 ADRs.** `docs/adr/INDEX.md`'s "architecture / research" table jumped
directly from row 070 to rows 079/080. Added rows for ADR-071 through ADR-078 (all merged
2026-07-08/09) and for the renumbered ADR-081, with a `Depends on` column derived from each
document's own in-body ADR citations.

**Flag C — ADR-ALIGNMENT-AUDIT.md stale scope.** The audit self-scopes to 65 numbered ADRs as of
2026-06-30 (ADR-001 through ADR-065) but its filename implies corpus-wide coverage. Added one
sentence stating the classification is frozen at 2026-06-30/ADR-065 and does not cover ADR-066
onward.

**P4 (from the reconciliation report, optional/low-priority).** `ADR-062-metal-fa2-prefill.md`'s
status line now notes that `ADR-073-kv-cache-quantization-priority.md:183` supersedes its KV-quant
sequencing at the priority level (a claim ADR-073 already makes unilaterally; ADR-062 did not yet
acknowledge it).

## Evidence

- ADR-070 (CPU embedding) merge: PR #671, commit `307d62cef`
- ADR-070/081 (prefill-GEMM) merge: PR #721 + PR #722, commits `2c7e68dfb` / `011f7fe25`
- ADR-071 (GDN state) merge: 2026-07-08, contains the citation resolved by this PR
- ADR-073 (KV-cache quant priority) merge: 2026-07-09, contains the supersession claim resolved by this PR

## Test plan

- [x] `make lint-docs` passes (deno fmt/lint + capability-matrix fixture check)
- [x] Repo-wide grep confirms no remaining references to the old filename or an unresolved `ADR-070` citation meaning the prefill-GEMM document
- [x] `docs/releases/v0.5.1.md`'s existing `ADR-070` reference (the CPU-embedding one) is unaffected, correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
