### PR TITLE
feat(tune): GDN LoRA weight gradients via train_core (port of #202)

### DIFF
--- a/crates/inference/examples/diff_gdn_layer.rs
+++ b/crates/inference/examples/diff_gdn_layer.rs
@@ -99,7 +99,25 @@ fn main() {
         eps,
     );
     let mut mat_out = vec![0.0f32; seq_len * hidden];
-    gdn_forward_save(&normed, gdn_w, cfg, &mut saved, &mut mat_out);
+    gdn_forward_save(
+        &normed,
+        gdn_w,
+        cfg,
+        &mut saved,
+        &mut mat_out,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        0,
+        0.0,
+    );
 
     assert_eq!(mat_out.len(), real_out.len(), "output length mismatch");
     let (mut max_diff, mut argmax) = (0.0f32, 0usize);

--- a/crates/inference/src/attention/gdn_backward.rs
+++ b/crates/inference/src/attention/gdn_backward.rs
@@ -1,9 +1,10 @@
 //! Reverse-mode backward (VJP) for a single GatedDeltaNet token sequence.
 //!
 //! Scope: computes grad_input (d_loss/d_input for each token) for a sequence
-//! processed through one GDN layer.  Parameter (weight) gradients are out of
-//! scope here — only input-gradients are needed for LoRA gradient flow through
-//! the 18 frozen GDN layers to reach lower GQA layers.
+//! processed through one GDN layer, AND (when LoRA is present) the LoRA weight
+//! gradients for each of the 5 GDN projections (qkv, z, b/beta, a/alpha, out).
+//! This is "surface-B" LoRA: mirrors the GQA surface-A implementation in
+//! backward/attention_gqa.rs, using the same lora_vjp primitive from ops.rs.
 //!
 //! # Forward recap (matches `gdn_fused.rs` hot path)
 //!
@@ -65,7 +66,33 @@
 //! eliminate catastrophic cancellation at eps = 1e-3.
 
 use crate::attention::gdn::{sigmoid, softplus};
+use crate::backward::ops::lora_vjp;
 use crate::model::qwen35_config::Qwen35Config;
+
+/// Gradients of the GDN layer w.r.t. LoRA params for all 5 projections.
+///
+/// Naming and layout mirror AttnGrads in backward/attention_gqa.rs.
+/// grad_a_* shape: [rank * d_in], grad_b_* shape: [d_out * rank].
+/// Fields are zero-length Vec when LoRA is absent (no-LoRA forward).
+pub struct GdnGrads {
+    /// in_proj_qkv LoRA: d_in=hidden, d_out=qkv_dim
+    pub grad_a_qkv: Vec<f32>,
+    pub grad_b_qkv: Vec<f32>,
+    /// in_proj_z LoRA: d_in=hidden, d_out=output_dim
+    pub grad_a_z: Vec<f32>,
+    pub grad_b_z: Vec<f32>,
+    /// in_proj_b (beta sigmoid) LoRA: d_in=hidden, d_out=num_kh
+    pub grad_a_b: Vec<f32>,
+    pub grad_b_b: Vec<f32>,
+    /// in_proj_a (alpha decay) LoRA: d_in=hidden, d_out=num_kh
+    pub grad_a_a: Vec<f32>,
+    pub grad_b_a: Vec<f32>,
+    /// out_proj LoRA: d_in=output_dim, d_out=hidden
+    pub grad_a_out: Vec<f32>,
+    pub grad_b_out: Vec<f32>,
+    /// Input gradient (always present): [seq_len, hidden_size]
+    pub dx: Vec<f32>,
+}
 
 /// Saved activations for one forward pass over a sequence.
 ///
@@ -140,6 +167,52 @@ pub struct GdnSaved {
     /// SiLU(z) per value-head: [seq_len, value_heads, value_dim]
     /// Stored because backward through gated_rms_norm needs it.
     pub silu_z: Vec<f32>,
+
+    // ---- LoRA caches (populated only when LoRA is present) ----
+    // h_* = A_proj @ x for each projection; shape [seq_len * lora_rank].
+    // Empty when LoRA absent.
+    /// LoRA rank used (0 = no LoRA)
+    pub lora_rank: usize,
+    /// LoRA scale factor
+    pub lora_scale: f32,
+
+    /// h_qkv = A_qkv @ x: [seq_len, lora_rank]
+    pub h_qkv: Vec<f32>,
+    /// h_z = A_z @ x: [seq_len, lora_rank]
+    pub h_z: Vec<f32>,
+    /// h_b = A_b @ x: [seq_len, lora_rank]  (beta sigmoid projection)
+    pub h_b: Vec<f32>,
+    /// h_a = A_a @ x: [seq_len, lora_rank]  (alpha decay projection)
+    pub h_a: Vec<f32>,
+    /// h_out = A_out @ gated_buf: [seq_len, lora_rank]  (output projection input)
+    pub h_out: Vec<f32>,
+    /// gated_buf (input to out_proj + LoRA_out): [seq_len, output_dim]
+    /// Needed for the out_proj LoRA backward (x side of that linear).
+    pub gated_buf: Vec<f32>,
+
+    // ---- LoRA weight matrices (cloned from forward params for backward) ----
+    // Storing these avoids threading 10 extra args through gdn_backward.
+    // Empty Vec when LoRA absent.
+    /// A_qkv: [rank, hidden]
+    pub lora_a_qkv: Vec<f32>,
+    /// B_qkv: [qkv_dim, rank]
+    pub lora_b_qkv: Vec<f32>,
+    /// A_z: [rank, hidden]
+    pub lora_a_z: Vec<f32>,
+    /// B_z: [output_dim, rank]
+    pub lora_b_z: Vec<f32>,
+    /// A_b: [rank, hidden]
+    pub lora_a_b: Vec<f32>,
+    /// B_b: [num_kh, rank]
+    pub lora_b_b: Vec<f32>,
+    /// A_a: [rank, hidden]
+    pub lora_a_a: Vec<f32>,
+    /// B_a: [num_kh, rank]
+    pub lora_b_a: Vec<f32>,
+    /// A_out: [rank, output_dim]
+    pub lora_a_out: Vec<f32>,
+    /// B_out: [hidden, rank]
+    pub lora_b_out: Vec<f32>,
 }
 
 impl GdnSaved {
@@ -197,6 +270,26 @@ impl GdnSaved {
             o_heads: vec![0.0; seq_len * value_heads * value_dim],
             rms_vals: vec![0.0; seq_len * value_heads],
             silu_z: vec![0.0; seq_len * value_heads * value_dim],
+            // LoRA caches: start empty; populated in gdn_forward_save when LoRA present.
+            lora_rank: 0,
+            lora_scale: 0.0,
+            h_qkv: Vec::new(),
+            h_z: Vec::new(),
+            h_b: Vec::new(),
+            h_a: Vec::new(),
+            h_out: Vec::new(),
+            gated_buf: Vec::new(),
+            // LoRA weight matrices: start empty; cloned from params in gdn_forward_save.
+            lora_a_qkv: Vec::new(),
+            lora_b_qkv: Vec::new(),
+            lora_a_z: Vec::new(),
+            lora_b_z: Vec::new(),
+            lora_a_b: Vec::new(),
+            lora_b_b: Vec::new(),
+            lora_a_a: Vec::new(),
+            lora_b_a: Vec::new(),
+            lora_a_out: Vec::new(),
+            lora_b_out: Vec::new(),
         }
     }
 }
@@ -211,15 +304,54 @@ impl GdnSaved {
 /// `inputs`:      [seq_len, hidden_size]
 /// `weights`:     frozen GDN layer weights
 /// `cfg`:         model config
-/// `norm_weight`: gamma for gated RMSNorm [value_dim]
 /// `saved`:       output struct, must be pre-allocated via `GdnSaved::new`
 /// `outputs`:     [seq_len, hidden_size] — written in-place
+///
+/// Optional LoRA parameters for the 5 GDN projections (qkv, z, b, a, out).
+/// When all five pairs are `Some`, the forward adds `scale * (x @ A^T) @ B^T`
+/// to each projection output and caches `h = A @ x` for the backward.
+/// When any pair is `None`, the forward is byte-identical to the no-LoRA path.
+#[allow(clippy::too_many_arguments)]
+/// The ten LoRA weight-matrix slices bound for one GDN forward, in fixed order:
+/// (a_qkv, b_qkv, a_z, b_z, a_b, b_b, a_a, b_a, a_out, b_out). Factored out to keep
+/// the `lora_bound` binding under clippy's type-complexity threshold (this module is
+/// `train-backward`-gated, so default clippy never lints it — see the app-bins gate).
+type LoraBound<'a> = (
+    &'a [f32],
+    &'a [f32],
+    &'a [f32],
+    &'a [f32],
+    &'a [f32],
+    &'a [f32],
+    &'a [f32],
+    &'a [f32],
+    &'a [f32],
+    &'a [f32],
+);
+
 pub fn gdn_forward_save(
     inputs: &[f32],
     weights: &crate::attention::gdn::GatedDeltaNetWeights,
     _cfg: &Qwen35Config,
     saved: &mut GdnSaved,
     outputs: &mut [f32],
+    // LoRA params for in_proj_qkv: a=[rank,hidden], b=[qkv_dim,rank]
+    lora_a_qkv: Option<&[f32]>,
+    lora_b_qkv: Option<&[f32]>,
+    // LoRA params for in_proj_z: a=[rank,hidden], b=[output_dim,rank]
+    lora_a_z: Option<&[f32]>,
+    lora_b_z: Option<&[f32]>,
+    // LoRA params for in_proj_b (beta): a=[rank,hidden], b=[num_kh,rank]
+    lora_a_b: Option<&[f32]>,
+    lora_b_b: Option<&[f32]>,
+    // LoRA params for in_proj_a (alpha): a=[rank,hidden], b=[num_kh,rank]
+    lora_a_a: Option<&[f32]>,
+    lora_b_a: Option<&[f32]>,
+    // LoRA params for out_proj: a=[rank,output_dim], b=[hidden,rank]
+    lora_a_out: Option<&[f32]>,
+    lora_b_out: Option<&[f32]>,
+    lora_rank: usize,
+    lora_scale: f32,
 ) {
     use crate::forward::cpu::matmul_bt;
 
@@ -238,6 +370,80 @@ pub fn gdn_forward_save(
     let buf_len = kernel_size.saturating_sub(1);
     let q_total = num_kh * key_dim;
 
+    // Bind all ten LoRA slices at once.  If any pair is None or rank==0 the entire
+    // LoRA path is skipped and the forward is byte-identical to the no-LoRA path.
+    // Option<&[f32]> is Copy, so destructuring copies the refs — no heap allocation.
+    let lora_bound: Option<LoraBound> = if lora_rank > 0 {
+        match (
+            lora_a_qkv, lora_b_qkv, lora_a_z, lora_b_z, lora_a_b, lora_b_b, lora_a_a, lora_b_a,
+            lora_a_out, lora_b_out,
+        ) {
+            (
+                Some(a_qkv),
+                Some(b_qkv),
+                Some(a_z),
+                Some(b_z),
+                Some(a_b),
+                Some(b_b),
+                Some(a_a),
+                Some(b_a),
+                Some(a_out),
+                Some(b_out),
+            ) => Some((a_qkv, b_qkv, a_z, b_z, a_b, b_b, a_a, b_a, a_out, b_out)),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    // Reset LoRA cache state unconditionally. `saved` is a reusable buffer; a
+    // prior LoRA-bound call would otherwise leave stale rank/matrices/h_* here.
+    // gdn_backward gates its LoRA-gradient path on saved.lora_rank, so a leftover
+    // nonzero rank after a no-LoRA call computes phantom gradients. The Some branch
+    // below repopulates these; the None path now stays truly LoRA-free.
+    saved.lora_rank = 0;
+    saved.lora_scale = 0.0;
+    saved.h_qkv.clear();
+    saved.h_z.clear();
+    saved.h_b.clear();
+    saved.h_a.clear();
+    saved.h_out.clear();
+    saved.gated_buf.clear();
+    saved.lora_a_qkv.clear();
+    saved.lora_b_qkv.clear();
+    saved.lora_a_z.clear();
+    saved.lora_b_z.clear();
+    saved.lora_a_b.clear();
+    saved.lora_b_b.clear();
+    saved.lora_a_a.clear();
+    saved.lora_b_a.clear();
+    saved.lora_a_out.clear();
+    saved.lora_b_out.clear();
+
+    // Initialise LoRA cache buffers on the saved struct when LoRA is active.
+    // Also clone the weight matrices so gdn_backward doesn't need them threaded through.
+    if let Some((a_qkv, b_qkv, a_z, b_z, a_b, b_b, a_a, b_a, a_out, b_out)) = lora_bound {
+        saved.lora_rank = lora_rank;
+        saved.lora_scale = lora_scale;
+        saved.h_qkv = vec![0.0f32; seq_len * lora_rank];
+        saved.h_z = vec![0.0f32; seq_len * lora_rank];
+        saved.h_b = vec![0.0f32; seq_len * lora_rank];
+        saved.h_a = vec![0.0f32; seq_len * lora_rank];
+        saved.h_out = vec![0.0f32; seq_len * lora_rank];
+        saved.gated_buf = vec![0.0f32; seq_len * output_dim];
+        // Clone weight matrices for backward use.
+        saved.lora_a_qkv = a_qkv.to_vec();
+        saved.lora_b_qkv = b_qkv.to_vec();
+        saved.lora_a_z = a_z.to_vec();
+        saved.lora_b_z = b_z.to_vec();
+        saved.lora_a_b = a_b.to_vec();
+        saved.lora_b_b = b_b.to_vec();
+        saved.lora_a_a = a_a.to_vec();
+        saved.lora_b_a = b_a.to_vec();
+        saved.lora_a_out = a_out.to_vec();
+        saved.lora_b_out = b_out.to_vec();
+    }
+
     // Rolling conv buffer (shared across time, updated per step)
     let mut conv_buf_live = vec![0.0f32; qkv_dim * buf_len];
 
@@ -252,13 +458,103 @@ pub fn gdn_forward_save(
         let qkv_out = &mut saved.qkv_proj[t * qkv_dim..(t + 1) * qkv_dim];
         matmul_bt(x, &weights.in_proj_qkv, qkv_out, 1, hidden, qkv_dim);
 
+        // LoRA for in_proj_qkv: output += scale * (x @ A_qkv^T) @ B_qkv^T
+        // Cache h_qkv = A_qkv @ x for the backward.
+        if let Some((a_qkv, b_qkv, _, _, _, _, _, _, _, _)) = lora_bound {
+            let h = &mut saved.h_qkv[t * lora_rank..(t + 1) * lora_rank];
+            for r in 0..lora_rank {
+                h[r] = a_qkv[r * hidden..(r + 1) * hidden]
+                    .iter()
+                    .zip(x.iter())
+                    .map(|(a, xi)| a * xi)
+                    .sum();
+            }
+            let qkv_out = &mut saved.qkv_proj[t * qkv_dim..(t + 1) * qkv_dim];
+            for i in 0..qkv_dim {
+                let acc: f32 = lora_scale
+                    * b_qkv[i * lora_rank..(i + 1) * lora_rank]
+                        .iter()
+                        .zip(h.iter())
+                        .map(|(b, hi)| b * hi)
+                        .sum::<f32>();
+                qkv_out[i] += acc;
+            }
+        }
+
         let z_out = &mut saved.z_proj[t * output_dim..(t + 1) * output_dim];
         matmul_bt(x, &weights.in_proj_z, z_out, 1, hidden, output_dim);
 
+        // LoRA for in_proj_z
+        if let Some((_, _, a_z, b_z, _, _, _, _, _, _)) = lora_bound {
+            let h = &mut saved.h_z[t * lora_rank..(t + 1) * lora_rank];
+            for r in 0..lora_rank {
+                h[r] = a_z[r * hidden..(r + 1) * hidden]
+                    .iter()
+                    .zip(x.iter())
+                    .map(|(a, xi)| a * xi)
+                    .sum();
+            }
+            let z_out = &mut saved.z_proj[t * output_dim..(t + 1) * output_dim];
+            for i in 0..output_dim {
+                let acc: f32 = lora_scale
+                    * b_z[i * lora_rank..(i + 1) * lora_rank]
+                        .iter()
+                        .zip(h.iter())
+                        .map(|(b, hi)| b * hi)
+                        .sum::<f32>();
+                z_out[i] += acc;
+            }
+        }
+
         let beta_out = &mut saved.beta_raw[t * num_kh..(t + 1) * num_kh];
         matmul_bt(x, &weights.in_proj_b, beta_out, 1, hidden, num_kh);
+
+        // LoRA for in_proj_b (beta, pre-sigmoid linear output)
+        if let Some((_, _, _, _, a_b, b_b, _, _, _, _)) = lora_bound {
+            let h = &mut saved.h_b[t * lora_rank..(t + 1) * lora_rank];
+            for r in 0..lora_rank {
+                h[r] = a_b[r * hidden..(r + 1) * hidden]
+                    .iter()
+                    .zip(x.iter())
+                    .map(|(a, xi)| a * xi)
+                    .sum();
+            }
+            let beta_out = &mut saved.beta_raw[t * num_kh..(t + 1) * num_kh];
+            for i in 0..num_kh {
+                let acc: f32 = lora_scale
+                    * b_b[i * lora_rank..(i + 1) * lora_rank]
+                        .iter()
+                        .zip(h.iter())
+                        .map(|(b, hi)| b * hi)
+                        .sum::<f32>();
+                beta_out[i] += acc;
+            }
+        }
+
         let alpha_out = &mut saved.alpha_proj[t * num_kh..(t + 1) * num_kh];
         matmul_bt(x, &weights.in_proj_a, alpha_out, 1, hidden, num_kh);
+
+        // LoRA for in_proj_a (alpha, pre-softplus linear output)
+        if let Some((_, _, _, _, _, _, a_a, b_a, _, _)) = lora_bound {
+            let h = &mut saved.h_a[t * lora_rank..(t + 1) * lora_rank];
+            for r in 0..lora_rank {
+                h[r] = a_a[r * hidden..(r + 1) * hidden]
+                    .iter()
+                    .zip(x.iter())
+                    .map(|(a, xi)| a * xi)
+                    .sum();
+            }
+            let alpha_out = &mut saved.alpha_proj[t * num_kh..(t + 1) * num_kh];
+            for i in 0..num_kh {
+                let acc: f32 = lora_scale
+                    * b_a[i * lora_rank..(i + 1) * lora_rank]
+                        .iter()
+                        .zip(h.iter())
+                        .map(|(b, hi)| b * hi)
+                        .sum::<f32>();
+                alpha_out[i] += acc;
+            }
+        }
 
         // sigmoid(beta)
         for kh in 0..num_kh {
@@ -409,8 +705,37 @@ pub fn gdn_forward_save(
             }
         }
 
+        // Save gated_buf when LoRA is active (needed as the x-side input for out_proj LoRA backward).
+        if lora_bound.is_some() {
+            saved.gated_buf[t * output_dim..(t + 1) * output_dim].copy_from_slice(&gated_buf);
+        }
+
         let y_t = &mut outputs[t * hidden..(t + 1) * hidden];
         matmul_bt(&gated_buf, &weights.out_proj, y_t, 1, output_dim, hidden);
+
+        // LoRA for out_proj: y_t += scale * (gated_buf @ A_out^T) @ B_out^T
+        // out_proj is [hidden, output_dim], so d_out=hidden, d_in=output_dim.
+        // Cache h_out = A_out @ gated_buf for the backward.
+        if let Some((_, _, _, _, _, _, _, _, a_out, b_out)) = lora_bound {
+            let h_slot = &mut saved.h_out[t * lora_rank..(t + 1) * lora_rank];
+            for r in 0..lora_rank {
+                h_slot[r] = a_out[r * output_dim..(r + 1) * output_dim]
+                    .iter()
+                    .zip(gated_buf.iter())
+                    .map(|(a, xi)| a * xi)
+                    .sum();
+            }
+            let y_t = &mut outputs[t * hidden..(t + 1) * hidden];
+            for i in 0..hidden {
+                let acc: f32 = lora_scale
+                    * b_out[i * lora_rank..(i + 1) * lora_rank]
+                        .iter()
+                        .zip(h_slot.iter())
+                        .map(|(b, hi)| b * hi)
+                        .sum::<f32>();
+                y_t[i] += acc;
+            }
+        }
     }
 }
 
@@ -420,16 +745,19 @@ pub fn gdn_forward_save(
 
 /// VJP of the GDN sequence forward.
 ///
+/// Returns a `GdnGrads` containing the input gradient (dx, always populated)
+/// and — when the saved activations carry LoRA caches (i.e. `gdn_forward_save`
+/// was called with LoRA params) — the weight gradients for each of the 5
+/// projections. When LoRA is absent, the grad_a_*/grad_b_* Vecs are empty.
+///
 /// `grad_outputs`:  [seq_len, hidden_size] — upstream gradient of loss w.r.t. output
 /// `saved`:         activations from `gdn_forward_save`
 /// `weights`:       same frozen weights used in forward
-/// `grad_inputs`:   [seq_len, hidden_size] — output, grad of loss w.r.t. input
 pub fn gdn_backward(
     grad_outputs: &[f32],
     saved: &GdnSaved,
     weights: &crate::attention::gdn::GatedDeltaNetWeights,
-    grad_inputs: &mut [f32],
-) {
+) -> GdnGrads {
     let seq_len = saved.seq_len;
     let hidden = saved.hidden_size;
     let num_kh = saved.num_key_heads;
@@ -445,7 +773,63 @@ pub fn gdn_backward(
     let q_total = num_kh * key_dim;
     let gamma = &weights.norm_weight[..value_dim];
 
-    grad_inputs.fill(0.0);
+    let have_lora = saved.lora_rank > 0 && !saved.h_qkv.is_empty();
+    let lora_rank = saved.lora_rank;
+    let lora_scale = saved.lora_scale;
+
+    // Allocate LoRA weight grad accumulators (empty when no LoRA).
+    let mut grad_a_qkv = if have_lora {
+        vec![0.0f32; lora_rank * hidden]
+    } else {
+        Vec::new()
+    };
+    let mut grad_b_qkv = if have_lora {
+        vec![0.0f32; qkv_dim * lora_rank]
+    } else {
+        Vec::new()
+    };
+    let mut grad_a_z = if have_lora {
+        vec![0.0f32; lora_rank * hidden]
+    } else {
+        Vec::new()
+    };
+    let mut grad_b_z = if have_lora {
+        vec![0.0f32; output_dim * lora_rank]
+    } else {
+        Vec::new()
+    };
+    let mut grad_a_b = if have_lora {
+        vec![0.0f32; lora_rank * hidden]
+    } else {
+        Vec::new()
+    };
+    let mut grad_b_b = if have_lora {
+        vec![0.0f32; num_kh * lora_rank]
+    } else {
+        Vec::new()
+    };
+    let mut grad_a_a = if have_lora {
+        vec![0.0f32; lora_rank * hidden]
+    } else {
+        Vec::new()
+    };
+    let mut grad_b_a = if have_lora {
+        vec![0.0f32; num_kh * lora_rank]
+    } else {
+        Vec::new()
+    };
+    let mut grad_a_out = if have_lora {
+        vec![0.0f32; lora_rank * output_dim]
+    } else {
+        Vec::new()
+    };
+    let mut grad_b_out = if have_lora {
+        vec![0.0f32; hidden * lora_rank]
+    } else {
+        Vec::new()
+    };
+
+    let mut grad_inputs = vec![0.0f32; seq_len * hidden];
 
     // Adjoint state dS: accumulated across timesteps, flows backward.
     // dS[h] is dL/d(S_t) for head h, updated as t decreases.
@@ -464,10 +848,17 @@ pub fn gdn_backward(
 
     for t in (0..seq_len).rev() {
         let dy = &grad_outputs[t * hidden..(t + 1) * hidden];
+        let x_t = &saved.inputs[t * hidden..(t + 1) * hidden];
 
         // ---- 1. Backward through out_proj: d_gated_buf = W_out^T @ dy ----
         // W_out is [hidden, output_dim].  out = gated_buf @ W_out^T means
         // d_gated_buf[j] = sum_i W_out[i,j] * dy[i]
+        //
+        // When LoRA is present: y_t = base_out + scale*(gated_buf@A_out^T)@B_out^T
+        // The upstream gradient dy is w.r.t. the total y_t.
+        // lora_vjp(dy, gated_buf_t, h_out_t, a_out, b_out, rank, output_dim, hidden, scale)
+        // returns (grad_b_out delta, grad_a_out delta, d_gated_buf_lora_delta).
+        // d_gated_buf = W_out^T dy  +  lora_vjp dx contribution (d_gated_buf from LoRA path).
         let mut d_gated_buf = vec![0.0f32; output_dim];
         for j in 0..output_dim {
             let mut acc = 0.0f64;
@@ -475,6 +866,35 @@ pub fn gdn_backward(
                 acc += weights.out_proj[i * output_dim + j] as f64 * dy[i] as f64;
             }
             d_gated_buf[j] = acc as f32;
+        }
+
+        // LoRA weight grads for out_proj + dx contribution to d_gated_buf.
+        // out_proj layout: [hidden, output_dim] → d_in=output_dim, d_out=hidden.
+        // lora_vjp(g=dy, x=gated_buf_t, h=h_out_t, a=lora_a_out, b=lora_b_out,
+        //          rank, d_in=output_dim, d_out=hidden, scale)
+        if have_lora {
+            let gated_buf_t = &saved.gated_buf[t * output_dim..(t + 1) * output_dim];
+            let h_out_t = &saved.h_out[t * lora_rank..(t + 1) * lora_rank];
+            let (gb, ga, dx_lora) = lora_vjp(
+                dy,
+                gated_buf_t,
+                h_out_t,
+                &saved.lora_a_out,
+                &saved.lora_b_out,
+                lora_rank,
+                output_dim,
+                hidden,
+                lora_scale,
+            );
+            for k in 0..ga.len() {
+                grad_a_out[k] += ga[k];
+            }
+            for k in 0..gb.len() {
+                grad_b_out[k] += gb[k];
+            }
+            for j in 0..output_dim {
+                d_gated_buf[j] += dx_lora[j];
+            }
         }
 
         // ---- 2. Backward through gated RMSNorm for each value-head ----
@@ -525,8 +945,13 @@ pub fn gdn_backward(
             }
         }
 
-        // ---- 3. Accumulate d_z_proj → d_x via W_z^T ----
-        // z_proj = W_z @ x,  d_x += W_z^T @ d_z_proj
+        // ---- 3. Accumulate d_z_proj → d_x via W_z^T, then LoRA weight grads ----
+        // z_proj = W_z @ x  (+LoRA when present),  d_x += W_z^T @ d_z_proj
+        //
+        // d_z_proj IS the pre-nonlinearity linear-projection-output gradient for z.
+        // (z goes through SiLU in the gated RMSNorm; d_z_proj is the gradient
+        // w.r.t. the linear output of in_proj_z, BEFORE SiLU — that is what step 2
+        // computes via the SiLU backward inside the RMSNorm loop.)
         let dx_t = &mut grad_inputs[t * hidden..(t + 1) * hidden];
         for j in 0..output_dim {
             let dz_j = d_z_proj[j];
@@ -537,12 +962,42 @@ pub fn gdn_backward(
                 dx_t[i] += weights.in_proj_z[j * hidden + i] * dz_j;
             }
         }
+        // LoRA weight grads for in_proj_z.
+        // g = d_z_proj, x = x_t, h = h_z_t, d_in=hidden, d_out=output_dim
+        if have_lora {
+            let h_z_t = &saved.h_z[t * lora_rank..(t + 1) * lora_rank];
+            let (gb, ga, dx_lora) = lora_vjp(
+                &d_z_proj,
+                x_t,
+                h_z_t,
+                &saved.lora_a_z,
+                &saved.lora_b_z,
+                lora_rank,
+                hidden,
+                output_dim,
+                lora_scale,
+            );
+            for k in 0..ga.len() {
+                grad_a_z[k] += ga[k];
+            }
+            for k in 0..gb.len() {
+                grad_b_z[k] += gb[k];
+            }
+            for j in 0..hidden {
+                dx_t[j] += dx_lora[j];
+            }
+        }
 
         // ---- 4. Per value-head recurrence backward ----
         // We process heads in REVERSE order (arbitrary — no inter-head deps).
         // We work with the per-head adjoint dS[h] which carries across time.
 
         let mut d_conv_out = vec![0.0f32; qkv_dim];
+        // Per key-head accumulators for alpha and beta scalar grads (multiple
+        // value-heads share one key-head, so we must sum across value-heads first
+        // before applying lora_vjp to avoid double-counting the d_in/d_out shape).
+        let mut d_alpha_kh = vec![0.0f32; num_kh]; // d_loss / d(alpha_proj[t, kh])
+        let mut d_beta_raw_kh = vec![0.0f32; num_kh]; // d_loss / d(beta_raw[t, kh])
 
         for h in 0..value_heads {
             let kh = h / ratio;
@@ -709,19 +1164,78 @@ pub fn gdn_backward(
             let sig = sigmoid(beta_raw_h);
             let d_beta_raw_h = d_beta_h * sig * (1.0 - sig);
 
-            // ---- 4i. Accumulate scalar grads into per-head gradient arrays ----
-            // We accumulate per-head d_alpha and d_beta_raw into d_alpha_proj / d_beta_proj
-            // arrays.  Since multiple value-heads share the same key-head, we sum.
-            // We'll accumulate directly into d_x via W_a^T and W_b^T below.
-            // Store in temporary scalars indexed by kh (accumulate across h sharing kh).
-            // Use a local accumulator since the inner-most scope is per-h.
-            // We immediately push to d_x to avoid extra allocations.
-            let dx_t = &mut grad_inputs[t * hidden..(t + 1) * hidden];
-            for i in 0..hidden {
-                dx_t[i] += weights.in_proj_a[kh * hidden + i] * d_alpha_from_g;
-                dx_t[i] += weights.in_proj_b[kh * hidden + i] * d_beta_raw_h;
-            }
+            // ---- 4i. Accumulate per key-head scalar grads ----
+            // Multiple value-heads share the same key-head; accumulate into kh slots.
+            // These will be fed to W_a^T/W_b^T and lora_vjp after this loop.
+            d_alpha_kh[kh] += d_alpha_from_g;
+            d_beta_raw_kh[kh] += d_beta_raw_h;
         } // end per-head loop
+
+        // ---- Apply per key-head alpha/beta grads → d_x and LoRA weight grads ----
+        // d_alpha_proj[t, kh] = d_alpha_kh[kh]  (scalar per head)
+        // d_beta_raw[t, kh]   = d_beta_raw_kh[kh]
+        //
+        // For lora_vjp on the beta and alpha projections, we need the full
+        // d_proj_output vector of shape [num_kh].  We built those above.
+        //
+        // g for in_proj_b  = d_beta_raw_kh   (pre-sigmoid linear-output gradient)
+        // g for in_proj_a  = d_alpha_kh      (pre-softplus linear-output gradient)
+        let dx_t = &mut grad_inputs[t * hidden..(t + 1) * hidden];
+        for kh in 0..num_kh {
+            let d_a = d_alpha_kh[kh];
+            let d_b = d_beta_raw_kh[kh];
+            for i in 0..hidden {
+                dx_t[i] += weights.in_proj_a[kh * hidden + i] * d_a;
+                dx_t[i] += weights.in_proj_b[kh * hidden + i] * d_b;
+            }
+        }
+        // LoRA weight grads for in_proj_a and in_proj_b.
+        // g = d_alpha_kh (full [num_kh] vector), x = x_t, h_a_t, d_in=hidden, d_out=num_kh
+        if have_lora {
+            let h_b_t = &saved.h_b[t * lora_rank..(t + 1) * lora_rank];
+            let (gb, ga, dx_lora) = lora_vjp(
+                &d_beta_raw_kh,
+                x_t,
+                h_b_t,
+                &saved.lora_a_b,
+                &saved.lora_b_b,
+                lora_rank,
+                hidden,
+                num_kh,
+                lora_scale,
+            );
+            for k in 0..ga.len() {
+                grad_a_b[k] += ga[k];
+            }
+            for k in 0..gb.len() {
+                grad_b_b[k] += gb[k];
+            }
+            for j in 0..hidden {
+                dx_t[j] += dx_lora[j];
+            }
+
+            let h_a_t = &saved.h_a[t * lora_rank..(t + 1) * lora_rank];
+            let (gb, ga, dx_lora) = lora_vjp(
+                &d_alpha_kh,
+                x_t,
+                h_a_t,
+                &saved.lora_a_a,
+                &saved.lora_b_a,
+                lora_rank,
+                hidden,
+                num_kh,
+                lora_scale,
+            );
+            for k in 0..ga.len() {
+                grad_a_a[k] += ga[k];
+            }
+            for k in 0..gb.len() {
+                grad_b_a[k] += gb[k];
+            }
+            for j in 0..hidden {
+                dx_t[j] += dx_lora[j];
+            }
+        }
 
         // ---- 5. Backward through conv1d + SiLU ----
         //
@@ -778,6 +1292,9 @@ pub fn gdn_backward(
         // d_qkv_proj_all[t] now contains the complete gradient for token t because:
         //   - future-timestep conv contributions were written when t' > t was processed
         //   - current-timestep conv contribution was written in step 5 above
+        //
+        // g for in_proj_qkv = d_qkv_proj_all[t]  (pre-conv-SiLU linear-output gradient
+        // summed over time, complete only after all future-t conv contributions land).
         let dx_t = &mut grad_inputs[t * hidden..(t + 1) * hidden];
         for j in 0..qkv_dim {
             let dq = d_qkv_proj_all[t * qkv_dim + j];
@@ -788,7 +1305,51 @@ pub fn gdn_backward(
                 dx_t[i] += weights.in_proj_qkv[j * hidden + i] * dq;
             }
         }
+        // LoRA weight grads for in_proj_qkv.
+        // The LoRA forward added scale*(x@A_qkv^T)@B_qkv^T to qkv_proj[t].
+        // That delta passed through conv1d+SiLU, whose backward already produced
+        // d_qkv_proj_all[t] as the full gradient w.r.t. qkv_proj[t] (both base
+        // and LoRA delta). So d_qkv_proj_all[t] is exactly the g for lora_vjp.
+        // x = x_t (the original input), h = h_qkv_t.
+        if have_lora {
+            let d_qkv_g = &d_qkv_proj_all[t * qkv_dim..(t + 1) * qkv_dim];
+            let h_qkv_t = &saved.h_qkv[t * lora_rank..(t + 1) * lora_rank];
+            let (gb, ga, dx_lora) = lora_vjp(
+                d_qkv_g,
+                x_t,
+                h_qkv_t,
+                &saved.lora_a_qkv,
+                &saved.lora_b_qkv,
+                lora_rank,
+                hidden,
+                qkv_dim,
+                lora_scale,
+            );
+            for k in 0..ga.len() {
+                grad_a_qkv[k] += ga[k];
+            }
+            for k in 0..gb.len() {
+                grad_b_qkv[k] += gb[k];
+            }
+            for j in 0..hidden {
+                dx_t[j] += dx_lora[j];
+            }
+        }
     } // end reverse time loop
+
+    GdnGrads {
+        grad_a_qkv,
+        grad_b_qkv,
+        grad_a_z,
+        grad_b_z,
+        grad_a_b,
+        grad_b_b,
+        grad_a_a,
+        grad_b_a,
+        grad_a_out,
+        grad_b_out,
+        dx: grad_inputs,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1036,8 +1597,44 @@ mod tests {
             let mut out_p = vec![0.0f32; seq_len * hidden];
             let mut out_m = vec![0.0f32; seq_len * hidden];
 
-            gdn_forward_save(&inp_p_f32, weights, cfg, &mut saved_p, &mut out_p);
-            gdn_forward_save(&inp_m_f32, weights, cfg, &mut saved_m, &mut out_m);
+            gdn_forward_save(
+                &inp_p_f32,
+                weights,
+                cfg,
+                &mut saved_p,
+                &mut out_p,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                0,
+                0.0,
+            );
+            gdn_forward_save(
+                &inp_m_f32,
+                weights,
+                cfg,
+                &mut saved_m,
+                &mut out_m,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                0,
+                0.0,
+            );
 
             let lp = linear_loss(&out_p, coeffs);
             let lm = linear_loss(&out_m, coeffs);
@@ -1099,9 +1696,27 @@ mod tests {
             cfg.rms_norm_eps,
         );
         let mut outputs = vec![0.0f32; seq_len * hidden];
-        gdn_forward_save(&inputs, &weights, &cfg, &mut saved, &mut outputs);
-        let mut analytic = vec![0.0f32; seq_len * hidden];
-        gdn_backward(&coeffs, &saved, &weights, &mut analytic);
+        gdn_forward_save(
+            &inputs,
+            &weights,
+            &cfg,
+            &mut saved,
+            &mut outputs,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            0,
+            0.0,
+        );
+        let gdn_grads = gdn_backward(&coeffs, &saved, &weights);
+        let analytic = gdn_grads.dx;
 
         // FD
         let fd = fd_grad_inputs_linear(&inputs, &weights, &cfg, seq_len, hidden, eps, &coeffs);
@@ -1212,11 +1827,29 @@ mod tests {
             cfg.rms_norm_eps,
         );
         let mut outputs = vec![0.0f32; seq_len * hidden];
-        gdn_forward_save(&inputs, &weights, &cfg, &mut saved, &mut outputs);
+        gdn_forward_save(
+            &inputs,
+            &weights,
+            &cfg,
+            &mut saved,
+            &mut outputs,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            0,
+            0.0,
+        );
 
         let grad_out = vec![0.0f32; seq_len * hidden];
-        let mut analytic = vec![0.0f32; seq_len * hidden];
-        gdn_backward(&grad_out, &saved, &weights, &mut analytic);
+        let gdn_grads = gdn_backward(&grad_out, &saved, &weights);
+        let analytic = gdn_grads.dx;
 
         for (i, &v) in analytic.iter().enumerate() {
             assert!(
@@ -1224,5 +1857,360 @@ mod tests {
                 "zero upstream grad should give zero input grad at [{i}], got {v}"
             );
         }
+    }
+
+    // ---------------------------------------------------------------------------
+    // LoRA weight-grad gradcheck
+    // ---------------------------------------------------------------------------
+    //
+    // Finite-difference check for the 10 LoRA weight gradients (grad_a_*/grad_b_*).
+    // The existing gradcheck_gdn_backward tests only cover dx with LoRA OFF.
+    // This test runs gdn_forward_save with LoRA ON and checks that the weight grads
+    // returned by gdn_backward agree with central-difference estimates.
+    //
+    // DO NOT RUN this test manually until the AM gradcheck pass is scheduled.
+    // (Compile-gate only — verifies the test compiles under --all-targets.)
+
+    /// Helper: run one forward + backward with the given LoRA arrays and return the
+    /// full GdnGrads.  All ten LoRA slices must be Some.
+    #[allow(clippy::too_many_arguments)]
+    fn run_lora_forward_backward(
+        inputs: &[f32],
+        weights: &GatedDeltaNetWeights,
+        cfg: &Qwen35Config,
+        seq_len: usize,
+        coeffs: &[f32],
+        lora_rank: usize,
+        lora_scale: f32,
+        a_qkv: &[f32],
+        b_qkv: &[f32],
+        a_z: &[f32],
+        b_z: &[f32],
+        a_b: &[f32],
+        b_b: &[f32],
+        a_a: &[f32],
+        b_a: &[f32],
+        a_out: &[f32],
+        b_out: &[f32],
+    ) -> GdnGrads {
+        let hidden = cfg.hidden_size;
+        let num_kh = cfg.linear_num_key_heads;
+        let num_vh = cfg.linear_num_value_heads();
+        let key_dim = cfg.linear_key_head_dim;
+        let value_dim = cfg.linear_value_head_dim;
+        let kernel_size = cfg.linear_conv_kernel_dim;
+        let qkv_dim = cfg.linear_qkv_dim();
+        let output_dim = cfg.linear_output_dim();
+        let scale = 1.0 / (key_dim as f32).sqrt();
+
+        let mut saved = GdnSaved::new(
+            seq_len,
+            num_kh,
+            num_vh,
+            key_dim,
+            value_dim,
+            hidden,
+            qkv_dim,
+            output_dim,
+            kernel_size,
+            scale,
+            cfg.rms_norm_eps,
+        );
+        let mut outputs = vec![0.0f32; seq_len * hidden];
+        gdn_forward_save(
+            inputs,
+            weights,
+            cfg,
+            &mut saved,
+            &mut outputs,
+            Some(a_qkv),
+            Some(b_qkv),
+            Some(a_z),
+            Some(b_z),
+            Some(a_b),
+            Some(b_b),
+            Some(a_a),
+            Some(b_a),
+            Some(a_out),
+            Some(b_out),
+            lora_rank,
+            lora_scale,
+        );
+        gdn_backward(coeffs, &saved, weights)
+    }
+
+    /// Central-difference estimate of d(loss)/d(param[idx]) for a single entry.
+    #[allow(clippy::too_many_arguments)]
+    fn fd_lora_weight_entry(
+        inputs: &[f32],
+        weights: &GatedDeltaNetWeights,
+        cfg: &Qwen35Config,
+        seq_len: usize,
+        coeffs: &[f32],
+        lora_rank: usize,
+        lora_scale: f32,
+        a_qkv: &[f32],
+        b_qkv: &[f32],
+        a_z: &[f32],
+        b_z: &[f32],
+        a_b: &[f32],
+        b_b: &[f32],
+        a_a: &[f32],
+        b_a: &[f32],
+        a_out: &[f32],
+        b_out: &[f32],
+        // Which of the 10 arrays to perturb, and which entry:
+        which: usize, // 0=a_qkv 1=b_qkv 2=a_z 3=b_z 4=a_b 5=b_b 6=a_a 7=b_a 8=a_out 9=b_out
+        idx: usize,
+        eps: f32,
+    ) -> f32 {
+        // Helper: clone an array, perturb entry [idx] by delta, re-run, return loss.
+        let perturbed_loss = |delta: f32| -> f32 {
+            let mut aq = a_qkv.to_vec();
+            let mut bq = b_qkv.to_vec();
+            let mut az = a_z.to_vec();
+            let mut bz = b_z.to_vec();
+            let mut ab = a_b.to_vec();
+            let mut bb = b_b.to_vec();
+            let mut aa = a_a.to_vec();
+            let mut ba = b_a.to_vec();
+            let mut ao = a_out.to_vec();
+            let mut bo = b_out.to_vec();
+            let arr: &mut Vec<f32> = match which {
+                0 => &mut aq,
+                1 => &mut bq,
+                2 => &mut az,
+                3 => &mut bz,
+                4 => &mut ab,
+                5 => &mut bb,
+                6 => &mut aa,
+                7 => &mut ba,
+                8 => &mut ao,
+                _ => &mut bo,
+            };
+            arr[idx] += delta;
+            let hidden = cfg.hidden_size;
+            let num_kh = cfg.linear_num_key_heads;
+            let num_vh = cfg.linear_num_value_heads();
+            let key_dim = cfg.linear_key_head_dim;
+            let value_dim = cfg.linear_value_head_dim;
+            let kernel_size = cfg.linear_conv_kernel_dim;
+            let qkv_dim = cfg.linear_qkv_dim();
+            let output_dim = cfg.linear_output_dim();
+            let scale = 1.0 / (key_dim as f32).sqrt();
+            let mut saved = GdnSaved::new(
+                seq_len,
+                num_kh,
+                num_vh,
+                key_dim,
+                value_dim,
+                hidden,
+                qkv_dim,
+                output_dim,
+                kernel_size,
+                scale,
+                cfg.rms_norm_eps,
+            );
+            let mut outputs = vec![0.0f32; seq_len * hidden];
+            gdn_forward_save(
+                inputs,
+                weights,
+                cfg,
+                &mut saved,
+                &mut outputs,
+                Some(&aq),
+                Some(&bq),
+                Some(&az),
+                Some(&bz),
+                Some(&ab),
+                Some(&bb),
+                Some(&aa),
+                Some(&ba),
+                Some(&ao),
+                Some(&bo),
+                lora_rank,
+                lora_scale,
+            );
+            outputs
+                .iter()
+                .zip(coeffs.iter())
+                .map(|(&y, &c)| y * c)
+                .sum()
+        };
+        let lp = perturbed_loss(eps);
+        let lm = perturbed_loss(-eps);
+        (lp - lm) / (2.0 * eps)
+    }
+
+    // Core helper that exercises weight-grad gradcheck for any fixture.
+    // Returns (max_rel_err, n_tested).
+    #[allow(clippy::too_many_arguments)]
+    fn run_lora_weight_gradcheck(
+        hidden: usize,
+        num_kh: usize,
+        num_vh: usize,
+        key_dim: usize,
+        value_dim: usize,
+        kernel_size: usize,
+        seq_len: usize,
+        lora_rank: usize,
+        lora_scale: f32,
+        weight_seed: u64,
+        input_seed: u64,
+        lora_seed: u64,
+        coeff_seed: u64,
+        eps: f32,
+    ) -> (f32, usize) {
+        let cfg = tiny_cfg(hidden, num_kh, num_vh, key_dim, value_dim, kernel_size);
+        let weights = make_tiny_weights(
+            hidden,
+            num_kh,
+            num_vh,
+            key_dim,
+            value_dim,
+            kernel_size,
+            weight_seed,
+        );
+        let qkv_dim = cfg.linear_qkv_dim();
+        let output_dim = cfg.linear_output_dim();
+
+        // Inputs
+        let mut rng_in = Rng::new(input_seed);
+        let mut inputs = vec![0.0f32; seq_len * hidden];
+        rng_in.fill(&mut inputs, -0.5, 0.5);
+
+        // Upstream coeffs (linear loss)
+        let mut rng_c = Rng::new(coeff_seed);
+        let mut coeffs = vec![0.0f32; seq_len * hidden];
+        rng_c.fill(&mut coeffs, -1.0, 1.0);
+
+        // LoRA matrices — small random values so grad_A and grad_B are non-vacuous.
+        // Shapes: A=[rank, d_in], B=[d_out, rank] for each projection.
+        let mut rng_l = Rng::new(lora_seed);
+        let mut a_qkv = vec![0.0f32; lora_rank * hidden]; // [rank, hidden]
+        let mut b_qkv = vec![0.0f32; qkv_dim * lora_rank]; // [qkv_dim, rank]
+        let mut a_z = vec![0.0f32; lora_rank * hidden]; // [rank, hidden]
+        let mut b_z = vec![0.0f32; output_dim * lora_rank]; // [output_dim, rank]
+        let mut a_b = vec![0.0f32; lora_rank * hidden]; // [rank, hidden]
+        let mut b_b = vec![0.0f32; num_kh * lora_rank]; // [num_kh, rank]
+        let mut a_a = vec![0.0f32; lora_rank * hidden]; // [rank, hidden]
+        let mut b_a = vec![0.0f32; num_kh * lora_rank]; // [num_kh, rank]
+        let mut a_out = vec![0.0f32; lora_rank * output_dim]; // [rank, output_dim]
+        let mut b_out = vec![0.0f32; hidden * lora_rank]; // [hidden, rank]
+        for arr in [
+            &mut a_qkv, &mut b_qkv, &mut a_z, &mut b_z, &mut a_b, &mut b_b, &mut a_a, &mut b_a,
+            &mut a_out, &mut b_out,
+        ]
+        .iter_mut()
+        {
+            rng_l.fill(arr, -0.05, 0.05);
+        }
+
+        // Analytic weight grads via forward+backward.
+        let grads = run_lora_forward_backward(
+            &inputs, &weights, &cfg, seq_len, &coeffs, lora_rank, lora_scale, &a_qkv, &b_qkv, &a_z,
+            &b_z, &a_b, &b_b, &a_a, &b_a, &a_out, &b_out,
+        );
+
+        // Collect (which_array, analytic_grad_slice, array_len) triples.
+        let analytic_arrays: [(&[f32], usize); 10] = [
+            (&grads.grad_a_qkv, a_qkv.len()),
+            (&grads.grad_b_qkv, b_qkv.len()),
+            (&grads.grad_a_z, a_z.len()),
+            (&grads.grad_b_z, b_z.len()),
+            (&grads.grad_a_b, a_b.len()),
+            (&grads.grad_b_b, b_b.len()),
+            (&grads.grad_a_a, a_a.len()),
+            (&grads.grad_b_a, b_a.len()),
+            (&grads.grad_a_out, a_out.len()),
+            (&grads.grad_b_out, b_out.len()),
+        ];
+
+        let mut max_rel = 0.0f32;
+        let mut n_tested = 0usize;
+
+        for (which, (analytic_slice, arr_len)) in analytic_arrays.iter().enumerate() {
+            // Sample up to 6 entries spread across each array.
+            let step = (arr_len / 6).max(1);
+            let mut idx = 0usize;
+            while idx < *arr_len {
+                let analytic_v = analytic_slice[idx];
+                let fd_v = fd_lora_weight_entry(
+                    &inputs, &weights, &cfg, seq_len, &coeffs, lora_rank, lora_scale, &a_qkv,
+                    &b_qkv, &a_z, &b_z, &a_b, &b_b, &a_a, &b_a, &a_out, &b_out, which, idx, eps,
+                );
+                let mag = fd_v.abs().max(analytic_v.abs());
+                if mag >= 1e-4 {
+                    n_tested += 1;
+                    let rel = (fd_v - analytic_v).abs() / mag;
+                    if rel > max_rel {
+                        max_rel = rel;
+                    }
+                }
+                idx += step;
+            }
+        }
+
+        (max_rel, n_tested)
+    }
+
+    #[test]
+    fn gradcheck_gdn_lora_weight_grads() {
+        // Tiny GDN: hidden=32, num_kh=1, value_heads=1, key_dim=8, value_dim=8,
+        // kernel_size=3, seq=6; rank=2; scale=2.0.
+        //
+        // lora_scale bumped 0.5->2.0 vs the original draft: with num_kh=1 the
+        // beta/alpha LoRA arrays (b_b/b_a) are only [1, rank] = 2 entries each,
+        // and at scale=0.5 too many sampled entries across all 10 arrays fell
+        // under the 1e-4 magnitude floor (only 6 testable, below the >=10
+        // gate) — the LoRA delta was too small relative to the GDN's internal
+        // L2-normalization to leave a measurable footprint on a 4-step
+        // sequence. scale=2.0 + seq=6 amplifies the signal without changing
+        // what is being verified (the same 10 weight-gradient arrays).
+        let (max_rel, n_tested) = run_lora_weight_gradcheck(
+            32, 1, 1, 8, 8, 3, 6,    // hidden, num_kh, num_vh, key_dim, value_dim, kernel, seq
+            2,    // lora_rank
+            2.0,  // lora_scale
+            42,   // weight_seed
+            1337, // input_seed
+            777,  // lora_seed
+            999,  // coeff_seed
+            1e-3, // eps
+        );
+        assert!(
+            n_tested >= 10,
+            "lora weight gradcheck: too few testable entries ({n_tested}); \
+             increase array sizes or tighten threshold"
+        );
+        assert!(
+            max_rel < 1e-2,
+            "gdn lora weight gradcheck failed: max_rel={max_rel:.3e} \
+             (n_tested={n_tested})"
+        );
+    }
+
+    #[test]
+    fn gradcheck_gdn_lora_weight_grads_multi_head() {
+        // Multi-head variant: num_kh=2, value_heads=4 exercises alpha/beta head-sharing reduction.
+        let (max_rel, n_tested) = run_lora_weight_gradcheck(
+            32, 2, 4, 8, 8, 3,
+            4,    // hidden, num_kh=2, num_vh=4, key_dim=8, value_dim=8, kernel, seq
+            2,    // lora_rank
+            0.5,  // lora_scale
+            99,   // weight_seed
+            2024, // input_seed
+            555,  // lora_seed
+            111,  // coeff_seed
+            1e-3, // eps
+        );
+        assert!(
+            n_tested >= 10,
+            "lora weight gradcheck (multi-head): too few testable entries ({n_tested})"
+        );
+        assert!(
+            max_rel < 1e-2,
+            "gdn lora weight gradcheck (multi-head) failed: max_rel={max_rel:.3e} \
+             (n_tested={n_tested})"
+        );
     }
 }

--- a/crates/inference/src/attention/gdn_backward.rs
+++ b/crates/inference/src/attention/gdn_backward.rs
@@ -18,12 +18,15 @@
 //!
 //! c_t     = conv1d_silu(qkv_t)        (causal depthwise conv, then SiLU)
 //!
-//! For each value-head h  (key-head k_head = h / ratio):
-//!   q_hat = L2norm( c_t[q_start..] )
-//!   k_hat = L2norm( c_t[k_start..] )
+//! For each value-head h  (key-head k_head = h / ratio, used only for Q/K sharing):
+//!   q_hat = L2norm( c_t[q_start..] )   (q_start from k_head)
+//!   k_hat = L2norm( c_t[k_start..] )   (k_start from k_head)
 //!   v     = c_t[v_start..]
 //!
-//!   g   = exp(-exp(a_log) * softplus(alpha_t[k_head] + dt_bias[k_head]))
+//!   beta_t, alpha_t, a_log, dt_bias are all indexed by h directly — GDN's
+//!   decay gate and update rate are per VALUE head, not per key head. Only
+//!   Q/K projections are shared across a key-head's group of value-heads.
+//!   g   = exp(-exp(a_log[h]) * softplus(alpha_t[h] + dt_bias[h]))
 //!
 //!   kv_mem_t = S_{t-1}^T @ k_hat      (retrieval from *pre-decayed* state)
 //!   delta_t  = (v - kv_mem_t * g) * beta_t
@@ -81,10 +84,10 @@ pub struct GdnGrads {
     /// in_proj_z LoRA: d_in=hidden, d_out=output_dim
     pub grad_a_z: Vec<f32>,
     pub grad_b_z: Vec<f32>,
-    /// in_proj_b (beta sigmoid) LoRA: d_in=hidden, d_out=num_kh
+    /// in_proj_b (beta sigmoid) LoRA: d_in=hidden, d_out=value_heads
     pub grad_a_b: Vec<f32>,
     pub grad_b_b: Vec<f32>,
-    /// in_proj_a (alpha decay) LoRA: d_in=hidden, d_out=num_kh
+    /// in_proj_a (alpha decay) LoRA: d_in=hidden, d_out=value_heads
     pub grad_a_a: Vec<f32>,
     pub grad_b_a: Vec<f32>,
     /// out_proj LoRA: d_in=output_dim, d_out=hidden
@@ -119,13 +122,13 @@ pub struct GdnSaved {
     pub qkv_proj: Vec<f32>,
     /// z projection: [seq_len, output_dim]
     pub z_proj: Vec<f32>,
-    /// raw beta pre-sigmoid: [seq_len, num_key_heads]
+    /// raw beta pre-sigmoid: [seq_len, value_heads] (per VALUE head, not key head)
     pub beta_raw: Vec<f32>,
-    /// alpha projection: [seq_len, num_key_heads]
+    /// alpha projection: [seq_len, value_heads] (per VALUE head, not key head)
     pub alpha_proj: Vec<f32>,
-    /// beta = sigmoid(beta_raw): [seq_len, num_key_heads]
+    /// beta = sigmoid(beta_raw): [seq_len, value_heads]
     pub beta: Vec<f32>,
-    /// decay gate g per key-head: [seq_len, num_key_heads]
+    /// decay gate g per value-head: [seq_len, value_heads]
     pub g: Vec<f32>,
 
     /// Conv1d SiLU output: [seq_len, qkv_dim]
@@ -203,11 +206,11 @@ pub struct GdnSaved {
     pub lora_b_z: Vec<f32>,
     /// A_b: [rank, hidden]
     pub lora_a_b: Vec<f32>,
-    /// B_b: [num_kh, rank]
+    /// B_b: [value_heads, rank]
     pub lora_b_b: Vec<f32>,
     /// A_a: [rank, hidden]
     pub lora_a_a: Vec<f32>,
-    /// B_a: [num_kh, rank]
+    /// B_a: [value_heads, rank]
     pub lora_b_a: Vec<f32>,
     /// A_out: [rank, output_dim]
     pub lora_a_out: Vec<f32>,
@@ -252,10 +255,10 @@ impl GdnSaved {
             inputs: vec![0.0; seq_len * hidden_size],
             qkv_proj: vec![0.0; seq_len * qkv_dim],
             z_proj: vec![0.0; seq_len * output_dim],
-            beta_raw: vec![0.0; seq_len * num_key_heads],
-            alpha_proj: vec![0.0; seq_len * num_key_heads],
-            beta: vec![0.0; seq_len * num_key_heads],
-            g: vec![0.0; seq_len * num_key_heads],
+            beta_raw: vec![0.0; seq_len * value_heads],
+            alpha_proj: vec![0.0; seq_len * value_heads],
+            beta: vec![0.0; seq_len * value_heads],
+            g: vec![0.0; seq_len * value_heads],
             conv_out: vec![0.0; seq_len * qkv_dim],
             conv_buffers: vec![0.0; seq_len * qkv_dim * buf_len],
             q_hat: vec![0.0; seq_len * value_heads * key_dim],
@@ -341,10 +344,10 @@ pub fn gdn_forward_save(
     // LoRA params for in_proj_z: a=[rank,hidden], b=[output_dim,rank]
     lora_a_z: Option<&[f32]>,
     lora_b_z: Option<&[f32]>,
-    // LoRA params for in_proj_b (beta): a=[rank,hidden], b=[num_kh,rank]
+    // LoRA params for in_proj_b (beta): a=[rank,hidden], b=[value_heads,rank]
     lora_a_b: Option<&[f32]>,
     lora_b_b: Option<&[f32]>,
-    // LoRA params for in_proj_a (alpha): a=[rank,hidden], b=[num_kh,rank]
+    // LoRA params for in_proj_a (alpha): a=[rank,hidden], b=[value_heads,rank]
     lora_a_a: Option<&[f32]>,
     lora_b_a: Option<&[f32]>,
     // LoRA params for out_proj: a=[rank,output_dim], b=[hidden,rank]
@@ -506,8 +509,12 @@ pub fn gdn_forward_save(
             }
         }
 
-        let beta_out = &mut saved.beta_raw[t * num_kh..(t + 1) * num_kh];
-        matmul_bt(x, &weights.in_proj_b, beta_out, 1, hidden, num_kh);
+        // beta/alpha are projected per VALUE head (in_proj_b/in_proj_a have
+        // value_heads rows, matching the shipping gdn_fused forward and the
+        // f16 weight loader) — NOT per key head. Only Q/K share a key-head's
+        // projection; beta/alpha/a_log/dt_bias never do.
+        let beta_out = &mut saved.beta_raw[t * value_heads..(t + 1) * value_heads];
+        matmul_bt(x, &weights.in_proj_b, beta_out, 1, hidden, value_heads);
 
         // LoRA for in_proj_b (beta, pre-sigmoid linear output)
         if let Some((_, _, _, _, a_b, b_b, _, _, _, _)) = lora_bound {
@@ -519,8 +526,8 @@ pub fn gdn_forward_save(
                     .map(|(a, xi)| a * xi)
                     .sum();
             }
-            let beta_out = &mut saved.beta_raw[t * num_kh..(t + 1) * num_kh];
-            for i in 0..num_kh {
+            let beta_out = &mut saved.beta_raw[t * value_heads..(t + 1) * value_heads];
+            for i in 0..value_heads {
                 let acc: f32 = lora_scale
                     * b_b[i * lora_rank..(i + 1) * lora_rank]
                         .iter()
@@ -531,8 +538,8 @@ pub fn gdn_forward_save(
             }
         }
 
-        let alpha_out = &mut saved.alpha_proj[t * num_kh..(t + 1) * num_kh];
-        matmul_bt(x, &weights.in_proj_a, alpha_out, 1, hidden, num_kh);
+        let alpha_out = &mut saved.alpha_proj[t * value_heads..(t + 1) * value_heads];
+        matmul_bt(x, &weights.in_proj_a, alpha_out, 1, hidden, value_heads);
 
         // LoRA for in_proj_a (alpha, pre-softplus linear output)
         if let Some((_, _, _, _, _, _, a_a, b_a, _, _)) = lora_bound {
@@ -544,8 +551,8 @@ pub fn gdn_forward_save(
                     .map(|(a, xi)| a * xi)
                     .sum();
             }
-            let alpha_out = &mut saved.alpha_proj[t * num_kh..(t + 1) * num_kh];
-            for i in 0..num_kh {
+            let alpha_out = &mut saved.alpha_proj[t * value_heads..(t + 1) * value_heads];
+            for i in 0..value_heads {
                 let acc: f32 = lora_scale
                     * b_a[i * lora_rank..(i + 1) * lora_rank]
                         .iter()
@@ -556,18 +563,18 @@ pub fn gdn_forward_save(
             }
         }
 
-        // sigmoid(beta)
-        for kh in 0..num_kh {
-            let raw = saved.beta_raw[t * num_kh + kh];
-            saved.beta[t * num_kh + kh] = sigmoid(raw);
+        // sigmoid(beta), indexed per value-head
+        for vh in 0..value_heads {
+            let raw = saved.beta_raw[t * value_heads + vh];
+            saved.beta[t * value_heads + vh] = sigmoid(raw);
         }
 
-        // decay gate g per key-head
-        for kh in 0..num_kh {
-            let alpha_h = saved.alpha_proj[t * num_kh + kh];
-            let a = weights.a_log[kh].exp();
-            let sp = softplus(alpha_h + weights.dt_bias[kh]);
-            saved.g[t * num_kh + kh] = (-a * sp).exp();
+        // decay gate g per value-head
+        for vh in 0..value_heads {
+            let alpha_h = saved.alpha_proj[t * value_heads + vh];
+            let a = weights.a_log[vh].exp();
+            let sp = softplus(alpha_h + weights.dt_bias[vh]);
+            saved.g[t * value_heads + vh] = (-a * sp).exp();
         }
 
         // --- Causal conv1d + SiLU ---
@@ -629,8 +636,8 @@ pub fn gdn_forward_save(
             saved.q_hat[q_off..q_off + key_dim].copy_from_slice(&q_raw);
             saved.k_hat[k_off..k_off + key_dim].copy_from_slice(&k_raw);
 
-            let g_h = saved.g[t * num_kh + kh];
-            let beta_h = saved.beta[t * num_kh + kh];
+            let g_h = saved.g[t * value_heads + h];
+            let beta_h = saved.beta[t * value_heads + h];
 
             // S_{t-1} for this head
             let s_off = h * key_dim * value_dim;
@@ -804,7 +811,7 @@ pub fn gdn_backward(
         Vec::new()
     };
     let mut grad_b_b = if have_lora {
-        vec![0.0f32; num_kh * lora_rank]
+        vec![0.0f32; value_heads * lora_rank]
     } else {
         Vec::new()
     };
@@ -814,7 +821,7 @@ pub fn gdn_backward(
         Vec::new()
     };
     let mut grad_b_a = if have_lora {
-        vec![0.0f32; num_kh * lora_rank]
+        vec![0.0f32; value_heads * lora_rank]
     } else {
         Vec::new()
     };
@@ -993,11 +1000,12 @@ pub fn gdn_backward(
         // We work with the per-head adjoint dS[h] which carries across time.
 
         let mut d_conv_out = vec![0.0f32; qkv_dim];
-        // Per key-head accumulators for alpha and beta scalar grads (multiple
-        // value-heads share one key-head, so we must sum across value-heads first
-        // before applying lora_vjp to avoid double-counting the d_in/d_out shape).
-        let mut d_alpha_kh = vec![0.0f32; num_kh]; // d_loss / d(alpha_proj[t, kh])
-        let mut d_beta_raw_kh = vec![0.0f32; num_kh]; // d_loss / d(beta_raw[t, kh])
+        // Per value-head accumulators for alpha and beta scalar grads. Unlike
+        // Q/K (shared across a key-head's group of value-heads), alpha/beta/
+        // a_log/dt_bias are genuinely one-per-value-head — no reduction across
+        // heads is needed or correct here.
+        let mut d_alpha_vh = vec![0.0f32; value_heads]; // d_loss / d(alpha_proj[t, h])
+        let mut d_beta_raw_vh = vec![0.0f32; value_heads]; // d_loss / d(beta_raw[t, h])
 
         for h in 0..value_heads {
             let kh = h / ratio;
@@ -1005,8 +1013,8 @@ pub fn gdn_backward(
             let k_start = q_total + kh * key_dim;
             let v_start = q_total * 2 + h * value_dim;
 
-            let g_h = saved.g[t * num_kh + kh];
-            let beta_h = saved.beta[t * num_kh + kh];
+            let g_h = saved.g[t * value_heads + h];
+            let beta_h = saved.beta[t * value_heads + h];
 
             let q_off = (t * value_heads + h) * key_dim;
             let k_off = (t * value_heads + h) * key_dim;
@@ -1123,9 +1131,9 @@ pub fn gdn_backward(
             // dg/d_alpha = g * (-exp(a_log)) * sigmoid(alpha + dt_bias)
             //            = g * (-exp(a_log)) * softplus'(alpha + dt_bias)
             // where softplus'(x) = sigmoid(x)
-            let alpha_h = saved.alpha_proj[t * num_kh + kh];
-            let a_val = weights.a_log[kh].exp();
-            let sp_arg = alpha_h + weights.dt_bias[kh];
+            let alpha_h = saved.alpha_proj[t * value_heads + h];
+            let a_val = weights.a_log[h].exp();
+            let sp_arg = alpha_h + weights.dt_bias[h];
             let sp_deriv = sigmoid(sp_arg); // d/dx softplus(x) = sigmoid(x)
             // dg/d_alpha = g * (-a_val) * sp_deriv
             let d_alpha_from_g = d_g_h * g_h * (-a_val) * sp_deriv;
@@ -1160,48 +1168,48 @@ pub fn gdn_backward(
             // ---- 4h. Backward through sigmoid(beta_raw) → d_beta_raw ----
             // beta = sigmoid(beta_raw)
             // d_beta_raw = d_beta * beta * (1 - beta)
-            let beta_raw_h = saved.beta_raw[t * num_kh + kh];
+            let beta_raw_h = saved.beta_raw[t * value_heads + h];
             let sig = sigmoid(beta_raw_h);
             let d_beta_raw_h = d_beta_h * sig * (1.0 - sig);
 
-            // ---- 4i. Accumulate per key-head scalar grads ----
-            // Multiple value-heads share the same key-head; accumulate into kh slots.
+            // ---- 4i. Store per value-head scalar grads ----
+            // No reduction across heads: alpha/beta are one-per-value-head.
             // These will be fed to W_a^T/W_b^T and lora_vjp after this loop.
-            d_alpha_kh[kh] += d_alpha_from_g;
-            d_beta_raw_kh[kh] += d_beta_raw_h;
+            d_alpha_vh[h] += d_alpha_from_g;
+            d_beta_raw_vh[h] += d_beta_raw_h;
         } // end per-head loop
 
-        // ---- Apply per key-head alpha/beta grads → d_x and LoRA weight grads ----
-        // d_alpha_proj[t, kh] = d_alpha_kh[kh]  (scalar per head)
-        // d_beta_raw[t, kh]   = d_beta_raw_kh[kh]
+        // ---- Apply per value-head alpha/beta grads → d_x and LoRA weight grads ----
+        // d_alpha_proj[t, h] = d_alpha_vh[h]  (scalar per value-head)
+        // d_beta_raw[t, h]   = d_beta_raw_vh[h]
         //
         // For lora_vjp on the beta and alpha projections, we need the full
-        // d_proj_output vector of shape [num_kh].  We built those above.
+        // d_proj_output vector of shape [value_heads]. We built those above.
         //
-        // g for in_proj_b  = d_beta_raw_kh   (pre-sigmoid linear-output gradient)
-        // g for in_proj_a  = d_alpha_kh      (pre-softplus linear-output gradient)
+        // g for in_proj_b  = d_beta_raw_vh   (pre-sigmoid linear-output gradient)
+        // g for in_proj_a  = d_alpha_vh      (pre-softplus linear-output gradient)
         let dx_t = &mut grad_inputs[t * hidden..(t + 1) * hidden];
-        for kh in 0..num_kh {
-            let d_a = d_alpha_kh[kh];
-            let d_b = d_beta_raw_kh[kh];
+        for vh in 0..value_heads {
+            let d_a = d_alpha_vh[vh];
+            let d_b = d_beta_raw_vh[vh];
             for i in 0..hidden {
-                dx_t[i] += weights.in_proj_a[kh * hidden + i] * d_a;
-                dx_t[i] += weights.in_proj_b[kh * hidden + i] * d_b;
+                dx_t[i] += weights.in_proj_a[vh * hidden + i] * d_a;
+                dx_t[i] += weights.in_proj_b[vh * hidden + i] * d_b;
             }
         }
         // LoRA weight grads for in_proj_a and in_proj_b.
-        // g = d_alpha_kh (full [num_kh] vector), x = x_t, h_a_t, d_in=hidden, d_out=num_kh
+        // g = d_alpha_vh (full [value_heads] vector), x = x_t, h_a_t, d_in=hidden, d_out=value_heads
         if have_lora {
             let h_b_t = &saved.h_b[t * lora_rank..(t + 1) * lora_rank];
             let (gb, ga, dx_lora) = lora_vjp(
-                &d_beta_raw_kh,
+                &d_beta_raw_vh,
                 x_t,
                 h_b_t,
                 &saved.lora_a_b,
                 &saved.lora_b_b,
                 lora_rank,
                 hidden,
-                num_kh,
+                value_heads,
                 lora_scale,
             );
             for k in 0..ga.len() {
@@ -1216,14 +1224,14 @@ pub fn gdn_backward(
 
             let h_a_t = &saved.h_a[t * lora_rank..(t + 1) * lora_rank];
             let (gb, ga, dx_lora) = lora_vjp(
-                &d_alpha_kh,
+                &d_alpha_vh,
                 x_t,
                 h_a_t,
                 &saved.lora_a_a,
                 &saved.lora_b_a,
                 lora_rank,
                 hidden,
-                num_kh,
+                value_heads,
                 lora_scale,
             );
             for k in 0..ga.len() {
@@ -1459,13 +1467,16 @@ mod tests {
 
         let mut in_proj_qkv = vec![0.0f32; qkv_dim * hidden];
         let mut in_proj_z = vec![0.0f32; output_dim * hidden];
-        let mut in_proj_b = vec![0.0f32; num_kh * hidden];
-        let mut in_proj_a = vec![0.0f32; num_kh * hidden];
+        // in_proj_b/in_proj_a/a_log/dt_bias are dimensioned by VALUE heads
+        // (num_vh), matching the shipping f16 weight loader and gdn_fused —
+        // not by key heads. Only Q/K share a key-head's projection.
+        let mut in_proj_b = vec![0.0f32; num_vh * hidden];
+        let mut in_proj_a = vec![0.0f32; num_vh * hidden];
         let mut conv1d_weight = vec![0.0f32; qkv_dim * kernel_size];
         let mut out_proj = vec![0.0f32; hidden * output_dim];
         let mut norm_weight = vec![0.0f32; value_dim];
-        let mut a_log = vec![0.0f32; num_kh];
-        let mut dt_bias = vec![0.0f32; num_kh];
+        let mut a_log = vec![0.0f32; num_vh];
+        let mut dt_bias = vec![0.0f32; num_vh];
 
         rng.fill(&mut in_proj_qkv, -scale, scale);
         rng.fill(&mut in_proj_z, -scale, scale);
@@ -1476,8 +1487,13 @@ mod tests {
         for g in &mut norm_weight {
             *g = rng.f32_range(0.9, 1.1);
         }
+        // Wider than the original (-2.0, -0.5): a steeper a_log range makes
+        // the decay gate g more sensitive to alpha (dg/d_alpha scales with
+        // exp(a_log)), which is one of the two levers (with lora_scale/seq_len
+        // in the gradcheck fixtures below) needed to lift the alpha/beta LoRA
+        // gradient signal above the finite-difference noise floor.
         for a in &mut a_log {
-            *a = rng.f32_range(-2.0, -0.5);
+            *a = rng.f32_range(-0.3, 2.0);
         }
         for dt in &mut dt_bias {
             *dt = rng.f32_range(-0.1, 0.1);
@@ -1491,10 +1507,10 @@ mod tests {
             in_proj_z_rows: output_dim,
             in_proj_z_cols: hidden,
             in_proj_b,
-            in_proj_b_rows: num_kh,
+            in_proj_b_rows: num_vh,
             in_proj_b_cols: hidden,
             in_proj_a,
-            in_proj_a_rows: num_kh,
+            in_proj_a_rows: num_vh,
             in_proj_a_cols: hidden,
             a_log,
             dt_bias,
@@ -1965,7 +1981,11 @@ mod tests {
         eps: f32,
     ) -> f32 {
         // Helper: clone an array, perturb entry [idx] by delta, re-run, return loss.
-        let perturbed_loss = |delta: f32| -> f32 {
+        // Loss accumulates in f64 (forward stays f32, matching production) to avoid
+        // catastrophic cancellation in (lp - lm) when lora_scale/seq_len are large
+        // enough to push output magnitudes up — the same precision discipline as
+        // fd_grad_inputs_linear's f64 accumulation above.
+        let perturbed_loss = |delta: f32| -> f64 {
             let mut aq = a_qkv.to_vec();
             let mut bq = b_qkv.to_vec();
             let mut az = a_z.to_vec();
@@ -2034,16 +2054,40 @@ mod tests {
             outputs
                 .iter()
                 .zip(coeffs.iter())
-                .map(|(&y, &c)| y * c)
+                .map(|(&y, &c)| (y as f64) * (c as f64))
                 .sum()
         };
         let lp = perturbed_loss(eps);
         let lm = perturbed_loss(-eps);
-        (lp - lm) / (2.0 * eps)
+        ((lp - lm) / (2.0 * eps as f64)) as f32
+    }
+
+    /// Names of the 10 GDN LoRA weight-gradient arrays, in `which` order.
+    const LORA_ARRAY_NAMES: [&str; 10] = [
+        "grad_a_qkv",
+        "grad_b_qkv",
+        "grad_a_z",
+        "grad_b_z",
+        "grad_a_b",
+        "grad_b_b",
+        "grad_a_a",
+        "grad_b_a",
+        "grad_a_out",
+        "grad_b_out",
+    ];
+
+    /// Per-array gradcheck coverage: (n_tested, max_rel) for each of the 10 arrays.
+    struct PerArrayCoverage {
+        /// (n_tested, max_rel) per array, in `LORA_ARRAY_NAMES` order.
+        per_array: [(usize, f32); 10],
+        overall_max_rel: f32,
+        overall_n_tested: usize,
     }
 
     // Core helper that exercises weight-grad gradcheck for any fixture.
-    // Returns (max_rel_err, n_tested).
+    // Returns per-array AND aggregate coverage — the aggregate alone hid the
+    // fact that whole arrays (alpha/beta) went completely untested (codex
+    // review round 1, PR #792).
     #[allow(clippy::too_many_arguments)]
     fn run_lora_weight_gradcheck(
         hidden: usize,
@@ -2060,7 +2104,7 @@ mod tests {
         lora_seed: u64,
         coeff_seed: u64,
         eps: f32,
-    ) -> (f32, usize) {
+    ) -> PerArrayCoverage {
         let cfg = tiny_cfg(hidden, num_kh, num_vh, key_dim, value_dim, kernel_size);
         let weights = make_tiny_weights(
             hidden,
@@ -2092,9 +2136,9 @@ mod tests {
         let mut a_z = vec![0.0f32; lora_rank * hidden]; // [rank, hidden]
         let mut b_z = vec![0.0f32; output_dim * lora_rank]; // [output_dim, rank]
         let mut a_b = vec![0.0f32; lora_rank * hidden]; // [rank, hidden]
-        let mut b_b = vec![0.0f32; num_kh * lora_rank]; // [num_kh, rank]
+        let mut b_b = vec![0.0f32; num_vh * lora_rank]; // [value_heads, rank]
         let mut a_a = vec![0.0f32; lora_rank * hidden]; // [rank, hidden]
-        let mut b_a = vec![0.0f32; num_kh * lora_rank]; // [num_kh, rank]
+        let mut b_a = vec![0.0f32; num_vh * lora_rank]; // [value_heads, rank]
         let mut a_out = vec![0.0f32; lora_rank * output_dim]; // [rank, output_dim]
         let mut b_out = vec![0.0f32; hidden * lora_rank]; // [hidden, rank]
         for arr in [
@@ -2111,7 +2155,6 @@ mod tests {
             &inputs, &weights, &cfg, seq_len, &coeffs, lora_rank, lora_scale, &a_qkv, &b_qkv, &a_z,
             &b_z, &a_b, &b_b, &a_a, &b_a, &a_out, &b_out,
         );
-
         // Collect (which_array, analytic_grad_slice, array_len) triples.
         let analytic_arrays: [(&[f32], usize); 10] = [
             (&grads.grad_a_qkv, a_qkv.len()),
@@ -2126,13 +2169,16 @@ mod tests {
             (&grads.grad_b_out, b_out.len()),
         ];
 
-        let mut max_rel = 0.0f32;
-        let mut n_tested = 0usize;
+        let mut overall_max_rel = 0.0f32;
+        let mut overall_n_tested = 0usize;
+        let mut per_array = [(0usize, 0.0f32); 10];
 
         for (which, (analytic_slice, arr_len)) in analytic_arrays.iter().enumerate() {
             // Sample up to 6 entries spread across each array.
             let step = (arr_len / 6).max(1);
             let mut idx = 0usize;
+            let mut arr_n_tested = 0usize;
+            let mut arr_max_rel = 0.0f32;
             while idx < *arr_len {
                 let analytic_v = analytic_slice[idx];
                 let fd_v = fd_lora_weight_entry(
@@ -2141,76 +2187,238 @@ mod tests {
                 );
                 let mag = fd_v.abs().max(analytic_v.abs());
                 if mag >= 1e-4 {
-                    n_tested += 1;
+                    arr_n_tested += 1;
+                    overall_n_tested += 1;
                     let rel = (fd_v - analytic_v).abs() / mag;
-                    if rel > max_rel {
-                        max_rel = rel;
+                    if rel > arr_max_rel {
+                        arr_max_rel = rel;
+                    }
+                    if rel > overall_max_rel {
+                        overall_max_rel = rel;
                     }
                 }
                 idx += step;
             }
+            per_array[which] = (arr_n_tested, arr_max_rel);
         }
 
-        (max_rel, n_tested)
+        PerArrayCoverage {
+            per_array,
+            overall_max_rel,
+            overall_n_tested,
+        }
     }
 
     #[test]
     fn gradcheck_gdn_lora_weight_grads() {
         // Tiny GDN: hidden=32, num_kh=1, value_heads=1, key_dim=8, value_dim=8,
-        // kernel_size=3, seq=6; rank=2; scale=2.0.
+        // kernel_size=3, seq=14; rank=2; lora_scale=16.0.
         //
-        // lora_scale bumped 0.5->2.0 vs the original draft: with num_kh=1 the
-        // beta/alpha LoRA arrays (b_b/b_a) are only [1, rank] = 2 entries each,
-        // and at scale=0.5 too many sampled entries across all 10 arrays fell
-        // under the 1e-4 magnitude floor (only 6 testable, below the >=10
-        // gate) — the LoRA delta was too small relative to the GDN's internal
-        // L2-normalization to leave a measurable footprint on a 4-step
-        // sequence. scale=2.0 + seq=6 amplifies the signal without changing
-        // what is being verified (the same 10 weight-gradient arrays).
-        let (max_rel, n_tested) = run_lora_weight_gradcheck(
-            32, 1, 1, 8, 8, 3, 6,    // hidden, num_kh, num_vh, key_dim, value_dim, kernel, seq
+        // Per-array coverage (codex review round 1, PR #792): the PREVIOUS
+        // fixture (seq=6, scale=2.0) hit the overall n_tested>=10 aggregate
+        // gate while grad_a_b/grad_b_b/grad_a_a/grad_b_a (the alpha/beta
+        // arrays) had ZERO entries above the 1e-4 floor in EITHER fixture —
+        // the aggregate threshold hid four completely unverified arrays.
+        // alpha/beta only reach the output through a SCALAR decay gate/update
+        // rate feeding a recurrent state (an indirect path), unlike
+        // qkv/z/out which sit directly in the per-token output computation —
+        // their gradient magnitude is intrinsically much smaller for the same
+        // input/weight scale. Fix: seq_len 6->14 (more recurrent steps to
+        // accumulate signal) + lora_scale 2.0->16.0 (amplifies the LoRA
+        // delta feeding alpha/beta) lifts all 10 arrays' gradients above the
+        // floor; run_lora_weight_gradcheck now tracks and gates per-array
+        // coverage (below), not just an aggregate count, so this can't
+        // silently regress. fd_lora_weight_entry's loss also switched to f64
+        // accumulation (was f32) to keep the larger scale's finite-difference
+        // estimate accurate rather than just louder.
+        let cov = run_lora_weight_gradcheck(
+            32, 1, 1, 8, 8, 3, 14,   // hidden, num_kh, num_vh, key_dim, value_dim, kernel, seq
             2,    // lora_rank
-            2.0,  // lora_scale
+            16.0, // lora_scale
             42,   // weight_seed
             1337, // input_seed
             777,  // lora_seed
             999,  // coeff_seed
             1e-3, // eps
         );
+        for (name, (n, rel)) in LORA_ARRAY_NAMES.iter().zip(cov.per_array.iter()) {
+            println!("  {name:<12}: n_tested={n}  max_rel={rel:.3e}");
+        }
+        for (name, (n, _)) in LORA_ARRAY_NAMES.iter().zip(cov.per_array.iter()) {
+            assert!(
+                *n >= 1,
+                "lora weight gradcheck: array {name} has ZERO testable entries \
+                 above the 1e-4 floor — this array is not actually being verified"
+            );
+        }
         assert!(
-            n_tested >= 10,
-            "lora weight gradcheck: too few testable entries ({n_tested}); \
-             increase array sizes or tighten threshold"
+            cov.overall_n_tested >= 10,
+            "lora weight gradcheck: too few testable entries ({}); \
+             increase array sizes or tighten threshold",
+            cov.overall_n_tested
         );
         assert!(
-            max_rel < 1e-2,
-            "gdn lora weight gradcheck failed: max_rel={max_rel:.3e} \
-             (n_tested={n_tested})"
+            cov.overall_max_rel < 1e-2,
+            "gdn lora weight gradcheck failed: max_rel={:.3e} (n_tested={})",
+            cov.overall_max_rel,
+            cov.overall_n_tested
         );
     }
 
     #[test]
     fn gradcheck_gdn_lora_weight_grads_multi_head() {
-        // Multi-head variant: num_kh=2, value_heads=4 exercises alpha/beta head-sharing reduction.
-        let (max_rel, n_tested) = run_lora_weight_gradcheck(
+        // Asymmetric-head variant: num_kh=2, value_heads=4 — exercises the
+        // real value-head-scoped alpha/beta projection (in_proj_a/in_proj_b
+        // have 4 rows, not 2; Q/K still share via kh=h/ratio=h/2).
+        let cov = run_lora_weight_gradcheck(
             32, 2, 4, 8, 8, 3,
-            4,    // hidden, num_kh=2, num_vh=4, key_dim=8, value_dim=8, kernel, seq
+            20,   // hidden, num_kh=2, num_vh=4, key_dim=8, value_dim=8, kernel, seq
             2,    // lora_rank
-            0.5,  // lora_scale
+            12.0, // lora_scale
             99,   // weight_seed
             2024, // input_seed
             555,  // lora_seed
             111,  // coeff_seed
             1e-3, // eps
         );
+        for (name, (n, rel)) in LORA_ARRAY_NAMES.iter().zip(cov.per_array.iter()) {
+            println!("  {name:<12}: n_tested={n}  max_rel={rel:.3e}");
+        }
+        for (name, (n, _)) in LORA_ARRAY_NAMES.iter().zip(cov.per_array.iter()) {
+            assert!(
+                *n >= 1,
+                "lora weight gradcheck (multi-head): array {name} has ZERO testable \
+                 entries above the 1e-4 floor — this array is not actually being verified"
+            );
+        }
         assert!(
-            n_tested >= 10,
-            "lora weight gradcheck (multi-head): too few testable entries ({n_tested})"
+            cov.overall_n_tested >= 10,
+            "lora weight gradcheck (multi-head): too few testable entries ({})",
+            cov.overall_n_tested
         );
         assert!(
-            max_rel < 1e-2,
-            "gdn lora weight gradcheck (multi-head) failed: max_rel={max_rel:.3e} \
-             (n_tested={n_tested})"
+            cov.overall_max_rel < 1e-2,
+            "gdn lora weight gradcheck (multi-head) failed: max_rel={:.3e} (n_tested={})",
+            cov.overall_max_rel,
+            cov.overall_n_tested
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Source-parity: gdn_forward_save (training path) vs gdn_fused (shipping
+    // inference path), LoRA off, on an ASYMMETRIC-head fixture.
+    // ---------------------------------------------------------------------------
+    //
+    // Codex review round 1 (PR #792) blocker: gdn_forward_save/gdn_backward
+    // originally sized in_proj_a/in_proj_b/a_log/dt_bias (and everything
+    // downstream: gates, LoRA B factors, PEFT export, validate_against) by
+    // KEY heads instead of VALUE heads. Every prior gradcheck used a fixture
+    // where the weights fed to BOTH the analytic and finite-difference paths
+    // shared the same (buggy) shape, so the two sides agreed with each other
+    // on the wrong graph — self-consistency, not correctness. The only way
+    // to catch this class of bug is to compare against an INDEPENDENT
+    // implementation that has the right shape baked in: the shipping
+    // `gated_delta_net_step_fused` path, which the f16 weight loader and
+    // production inference actually use. This test builds a fixture where
+    // num_key_heads (2) != num_value_heads (4) and asserts the two forwards
+    // agree, LoRA off.
+    #[test]
+    fn source_parity_forward_save_vs_fused_asymmetric_heads() {
+        use crate::attention::gdn::GatedDeltaNetState;
+        use crate::attention::gdn_fused::{GatedDeltaNetFusedScratch, gated_delta_net_step_fused};
+        use crate::lora_hook::NoopLoraHook;
+
+        let hidden = 32;
+        let num_kh = 2;
+        let num_vh = 4; // asymmetric: ratio = 2, matches the 4B/27B shape class
+        let key_dim = 8;
+        let value_dim = 8;
+        let kernel_size = 3;
+        let seq_len = 6;
+
+        let cfg = tiny_cfg(hidden, num_kh, num_vh, key_dim, value_dim, kernel_size);
+        let weights =
+            make_tiny_weights(hidden, num_kh, num_vh, key_dim, value_dim, kernel_size, 321);
+        let qkv_dim = cfg.linear_qkv_dim();
+        let output_dim = cfg.linear_output_dim();
+        let scale = 1.0 / (key_dim as f32).sqrt();
+
+        let mut rng = Rng::new(654);
+        let mut inputs = vec![0.0f32; seq_len * hidden];
+        rng.fill(&mut inputs, -0.5, 0.5);
+
+        // --- Path A: gdn_forward_save (training path), LoRA off ---
+        let mut saved = GdnSaved::new(
+            seq_len,
+            num_kh,
+            num_vh,
+            key_dim,
+            value_dim,
+            hidden,
+            qkv_dim,
+            output_dim,
+            kernel_size,
+            scale,
+            cfg.rms_norm_eps,
+        );
+        let mut outputs_a = vec![0.0f32; seq_len * hidden];
+        gdn_forward_save(
+            &inputs,
+            &weights,
+            &cfg,
+            &mut saved,
+            &mut outputs_a,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            0,
+            0.0,
+        );
+
+        // --- Path B: gated_delta_net_step_fused (shipping inference path), per token ---
+        let mut state = GatedDeltaNetState::new(&cfg);
+        let mut scratch = GatedDeltaNetFusedScratch::default();
+        let hook = NoopLoraHook;
+        let mut outputs_b = vec![0.0f32; seq_len * hidden];
+        for t in 0..seq_len {
+            let x_t = &inputs[t * hidden..(t + 1) * hidden];
+            let y_t = &mut outputs_b[t * hidden..(t + 1) * hidden];
+            gated_delta_net_step_fused(
+                x_t,
+                &mut state,
+                &weights,
+                &cfg,
+                &mut scratch,
+                y_t,
+                &hook,
+                0,
+            );
+        }
+
+        let mut max_abs_diff = 0.0f32;
+        let mut worst = 0;
+        for i in 0..outputs_a.len() {
+            let d = (outputs_a[i] - outputs_b[i]).abs();
+            if d > max_abs_diff {
+                max_abs_diff = d;
+                worst = i;
+            }
+        }
+        assert!(
+            max_abs_diff < 1e-4,
+            "gdn_forward_save diverges from the shipping gated_delta_net_step_fused \
+             on an asymmetric-head fixture (num_kh={num_kh}, num_vh={num_vh}): \
+             max_abs_diff={max_abs_diff:.3e} at flat index {worst} \
+             (a={}, b={})",
+            outputs_a[worst],
+            outputs_b[worst],
         );
     }
 }

--- a/crates/tune/src/bin/train_grad_full.rs
+++ b/crates/tune/src/bin/train_grad_full.rs
@@ -195,6 +195,81 @@ fn strided_probes(len: usize, count: usize, seed: u64) -> Vec<usize> {
     out
 }
 
+/// Gradcheck-mode GDN LoRA initialization: every array (A and B) filled with
+/// small non-zero random noise, so both `grad_A` and the gate path are
+/// non-vacuous for the finite-difference probe.
+///
+/// Extracted into a standalone, testable function per #792 codex round-2:
+/// this is the exact constructor that had drifted to `gdn_dims.num_kh` for
+/// `b_b`/`b_a` while `GdnLoraParams::zeros` (fixed in round-1) used the
+/// correct `value_heads`. Now routes through `GdnLoraParams::shaped`, the
+/// single shape source of truth.
+fn gradcheck_gdn_loras(
+    num_gdn_slots: usize,
+    rank: usize,
+    hidden: usize,
+    gdn_dims: &GdnDims,
+    seed: u64,
+) -> Vec<GdnLoraParams> {
+    // rand_fill takes `&mut u64`; two closures can't each hold that mutable
+    // borrow as separate `shaped` arguments, so thread it through a `Cell`
+    // (each closure captures `&rng_cell`, a shared reference, so both can
+    // coexist as separate arguments).
+    let rng_cell = std::cell::Cell::new(seed);
+    (0..num_gdn_slots)
+        .map(|_| {
+            GdnLoraParams::shaped(
+                rank,
+                hidden,
+                gdn_dims,
+                |n| {
+                    let mut r = rng_cell.get();
+                    let v = rand_fill(&mut r, n, 0.05);
+                    rng_cell.set(r);
+                    v
+                },
+                |n| {
+                    let mut r = rng_cell.get();
+                    let v = rand_fill(&mut r, n, 0.05);
+                    rng_cell.set(r);
+                    v
+                },
+            )
+            .expect("gdn lora gradcheck-mode shapes should not overflow")
+        })
+        .collect()
+}
+
+/// Training-mode GDN LoRA initialization: A ~ U(-init_amp, +init_amp), B
+/// zero (delta=0 at init reproduces the base; grad_B != 0 so B moves first).
+///
+/// Extracted into a standalone, testable function per #792 codex round-2:
+/// see [`gradcheck_gdn_loras`] for why this must route through
+/// `GdnLoraParams::shaped` rather than re-deriving `b_b`/`b_a`'s length
+/// inline (the same drift existed at this call site independently).
+fn zero_b_gdn_loras(
+    num_gdn_slots: usize,
+    rank: usize,
+    hidden: usize,
+    gdn_dims: &GdnDims,
+    seed: u64,
+    init_amp: f32,
+) -> Vec<GdnLoraParams> {
+    let mut rng = seed;
+    (0..num_gdn_slots)
+        .map(|_| {
+            GdnLoraParams::shaped(
+                rank,
+                hidden,
+                gdn_dims,
+                |n| rand_fill(&mut rng, n, init_amp),
+                |n| vec![0.0; n],
+            )
+            .expect("gdn lora training-mode shapes should not overflow")
+        })
+        .collect()
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
     if parse_flag(&args, "-h") || parse_flag(&args, "--help") {
@@ -495,20 +570,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 b_v: rand_fill(&mut rng, dims.kv_dim * rank, 0.05),
             })
             .collect();
-        let mut gdn_loras: Vec<GdnLoraParams> = (0..num_gdn_slots)
-            .map(|_| GdnLoraParams {
-                a_qkv: rand_fill(&mut rng, rank * dims.hidden, 0.05),
-                b_qkv: rand_fill(&mut rng, gdn_dims.qkv_dim * rank, 0.05),
-                a_z: rand_fill(&mut rng, rank * dims.hidden, 0.05),
-                b_z: rand_fill(&mut rng, gdn_dims.output_dim * rank, 0.05),
-                a_b: rand_fill(&mut rng, rank * dims.hidden, 0.05),
-                b_b: rand_fill(&mut rng, gdn_dims.num_kh * rank, 0.05),
-                a_a: rand_fill(&mut rng, rank * dims.hidden, 0.05),
-                b_a: rand_fill(&mut rng, gdn_dims.num_kh * rank, 0.05),
-                a_out: rand_fill(&mut rng, rank * gdn_dims.output_dim, 0.05),
-                b_out: rand_fill(&mut rng, dims.hidden * rank, 0.05),
-            })
-            .collect();
+        let mut gdn_loras: Vec<GdnLoraParams> =
+            gradcheck_gdn_loras(num_gdn_slots, rank, dims.hidden, &gdn_dims, rng);
 
         let fwd = forward_full(
             &caches[0], &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
@@ -780,20 +843,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             b_v: vec![0.0; dims.kv_dim * rank],
         })
         .collect();
-    let mut gdn_loras: Vec<GdnLoraParams> = (0..num_gdn_slots)
-        .map(|_| GdnLoraParams {
-            a_qkv: rand_fill(&mut rng, rank * dims.hidden, init_amp),
-            b_qkv: vec![0.0; gdn_dims.qkv_dim * rank],
-            a_z: rand_fill(&mut rng, rank * dims.hidden, init_amp),
-            b_z: vec![0.0; gdn_dims.output_dim * rank],
-            a_b: rand_fill(&mut rng, rank * dims.hidden, init_amp),
-            b_b: vec![0.0; gdn_dims.num_kh * rank],
-            a_a: rand_fill(&mut rng, rank * dims.hidden, init_amp),
-            b_a: vec![0.0; gdn_dims.num_kh * rank],
-            a_out: rand_fill(&mut rng, rank * gdn_dims.output_dim, init_amp),
-            b_out: vec![0.0; dims.hidden * rank],
-        })
-        .collect();
+    // Reuses `rng`'s current stream position as the seed (matches the prior
+    // inline behavior of drawing from the same generator as `loras` above).
+    let mut gdn_loras: Vec<GdnLoraParams> =
+        zero_b_gdn_loras(num_gdn_slots, rank, dims.hidden, &gdn_dims, rng, init_amp);
 
     let mut adam = AdamState::new();
     let (beta1, beta2, eps_adam) = (0.9f32, 0.999f32, 1e-8f32);
@@ -1019,4 +1072,93 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod gdn_lora_ctor_tests {
+    use super::*;
+
+    /// Asymmetric fixture (num_kh=2, value_heads=4) — the only shape that can
+    /// distinguish "sized by key heads" from "sized by value heads"; a
+    /// symmetric config (e.g. num_kh == value_heads) would pass either way.
+    /// #792 codex round-2 blocker: `gradcheck_gdn_loras`/`zero_b_gdn_loras`
+    /// (this binary's two GDN LoRA initializers) had independently
+    /// re-derived `b_b`/`b_a` as `num_kh * rank` instead of
+    /// `value_heads * rank`, breaking on exactly this shape class.
+    fn asymmetric_gdn_dims() -> GdnDims {
+        let key_dim = 8;
+        let value_dim = 8;
+        let num_kh = 2;
+        let value_heads = 4;
+        GdnDims {
+            num_kh,
+            value_heads,
+            key_dim,
+            value_dim,
+            qkv_dim: 2 * key_dim * num_kh + value_heads * value_dim,
+            output_dim: value_heads * value_dim,
+            kernel_size: 3,
+            scale: 1.0 / (key_dim as f32).sqrt(),
+        }
+    }
+
+    #[test]
+    fn gradcheck_gdn_loras_sizes_b_b_and_b_a_by_value_heads() {
+        let gd = asymmetric_gdn_dims();
+        let hidden = 16;
+        let rank = 3;
+        let loras = gradcheck_gdn_loras(2, rank, hidden, &gd, 0x1234_5678);
+        assert_eq!(loras.len(), 2);
+        for lora in &loras {
+            assert_eq!(
+                lora.b_b.len(),
+                gd.value_heads * rank,
+                "b_b must be sized by value_heads ({}), not num_kh ({})",
+                gd.value_heads,
+                gd.num_kh
+            );
+            assert_eq!(
+                lora.b_a.len(),
+                gd.value_heads * rank,
+                "b_a must be sized by value_heads ({}), not num_kh ({})",
+                gd.value_heads,
+                gd.num_kh
+            );
+            // Non-zero: gradcheck mode fills both A and B with random noise.
+            assert!(lora.b_b.iter().any(|&v| v != 0.0));
+            assert!(lora.b_a.iter().any(|&v| v != 0.0));
+        }
+    }
+
+    #[test]
+    fn zero_b_gdn_loras_sizes_b_b_and_b_a_by_value_heads() {
+        let gd = asymmetric_gdn_dims();
+        let hidden = 16;
+        let rank = 3;
+        let init_amp = 1.0 / (hidden as f32).sqrt();
+        let loras = zero_b_gdn_loras(2, rank, hidden, &gd, 0xFEED_FACE, init_amp);
+        assert_eq!(loras.len(), 2);
+        for lora in &loras {
+            assert_eq!(
+                lora.b_b.len(),
+                gd.value_heads * rank,
+                "b_b must be sized by value_heads ({}), not num_kh ({})",
+                gd.value_heads,
+                gd.num_kh
+            );
+            assert_eq!(
+                lora.b_a.len(),
+                gd.value_heads * rank,
+                "b_a must be sized by value_heads ({}), not num_kh ({})",
+                gd.value_heads,
+                gd.num_kh
+            );
+            // Training-mode: B is zero at init (delta=0 reproduces the base).
+            assert!(lora.b_b.iter().all(|&v| v == 0.0));
+            assert!(lora.b_a.iter().all(|&v| v == 0.0));
+            // A is non-zero random.
+            assert!(lora.a_b.iter().any(|&v| v != 0.0));
+            assert!(lora.a_a.iter().any(|&v| v != 0.0));
+        }
+    }
 }

--- a/crates/tune/src/bin/train_grad_full.rs
+++ b/crates/tune/src/bin/train_grad_full.rs
@@ -41,8 +41,9 @@ use lattice_inference::model::qwen35::Qwen35Model;
 use lattice_inference::tokenizer::Tokenizer;
 use lattice_tune::lora::AdamState;
 use lattice_tune::lora::train_core::{
-    Dims, GdnDims, Head, LayerW, LoraParams, MixerKind, SeqCtx, TOP_LAYER, apply_adam_updates,
-    eval_chain_nll, forward_full, nll_and_grads, rand_fill, shifted,
+    Dims, GdnDims, GdnLoraParams, Head, LayerW, LoraParams, MixerKind, SeqCtx, TOP_LAYER,
+    apply_adam_updates, apply_gdn_adam_updates, eval_chain_nll, forward_full, nll_and_grads,
+    rand_fill, shifted,
 };
 
 fn parse_arg(args: &[String], flag: &str) -> Option<String> {
@@ -300,9 +301,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Build the materialised layer stack [first_layer ..= 23], assigning a LoRA
-    // slot to each GQA layer. All weight slices are borrowed from `model`.
+    // slot to every layer: GQA layers get a slot into `loras` (surface-A,
+    // q_proj/v_proj), GDN layers get a slot into `gdn_loras` (surface-B, the
+    // 5 GDN projections — ported from lattice PR #202). All weight slices are
+    // borrowed from `model`.
     let mut layers: Vec<LayerW> = Vec::new();
-    let mut slot_layers: Vec<usize> = Vec::new(); // global layer index per slot
+    let mut slot_layers: Vec<usize> = Vec::new(); // global layer index per GQA slot
+    let mut gdn_slot_layers: Vec<usize> = Vec::new(); // global layer index per GDN slot
     for layer_idx in first_layer..=TOP_LAYER {
         if let Some((w_q, w_k, w_v, w_o, q_norm, k_norm, pre, post, gate, up, down)) =
             model.gqa_layer_weights(layer_idx)
@@ -326,6 +331,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 lora_slot: Some(slot),
             });
         } else if let Some((gdn, pre, post, gate, up, down)) = model.gdn_layer_weights(layer_idx) {
+            let slot = gdn_slot_layers.len();
+            gdn_slot_layers.push(layer_idx);
             layers.push(LayerW {
                 kind: MixerKind::Gdn,
                 w_q: &[],
@@ -340,7 +347,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 w_gate: gate,
                 w_up: up,
                 w_down: down,
-                lora_slot: None,
+                lora_slot: Some(slot),
             });
         } else {
             return Err(
@@ -349,6 +356,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     let num_slots = slot_layers.len();
+    let num_gdn_slots = gdn_slot_layers.len();
     let kinds: String = layers
         .iter()
         .map(|l| match l.kind {
@@ -357,17 +365,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .collect();
     println!(
-        "  materialised {} layers [{}]: {kinds}  ({} GQA LoRA slots at layers {:?})",
+        "  materialised {} layers [{}]: {kinds}  ({} GQA LoRA slots at layers {:?}, \
+         {num_gdn_slots} GDN LoRA slots at layers {:?})",
         layers.len(),
         (first_layer..=TOP_LAYER)
             .map(|i| i.to_string())
             .collect::<Vec<_>>()
             .join(","),
         num_slots,
-        slot_layers
+        slot_layers,
+        gdn_slot_layers,
     );
-    if num_slots == 0 {
-        return Err("no GQA layers in range — nothing to train".into());
+    if num_slots == 0 && num_gdn_slots == 0 {
+        return Err("no GQA or GDN layers in range — nothing to train".into());
     }
 
     let tokenizer = model.tokenizer().clone();
@@ -439,6 +449,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let zero_loras: Vec<LoraParams> = (0..num_slots)
         .map(|_| LoraParams::zeros(rank, &dims))
         .collect::<Result<Vec<_>, _>>()?;
+    let zero_gdn_loras: Vec<GdnLoraParams> = (0..num_gdn_slots)
+        .map(|_| GdnLoraParams::zeros(rank, dims.hidden, &gdn_dims))
+        .collect::<Result<Vec<_>, _>>()?;
     {
         let s0 = &train_samples[0];
         let model_nlls = model.compute_token_nlls(&s0.tokens)?;
@@ -449,6 +462,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &caches[..1],
             &layers,
             &zero_loras,
+            &zero_gdn_loras,
             &head,
             &dims,
             &gdn_dims,
@@ -481,12 +495,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 b_v: rand_fill(&mut rng, dims.kv_dim * rank, 0.05),
             })
             .collect();
+        let mut gdn_loras: Vec<GdnLoraParams> = (0..num_gdn_slots)
+            .map(|_| GdnLoraParams {
+                a_qkv: rand_fill(&mut rng, rank * dims.hidden, 0.05),
+                b_qkv: rand_fill(&mut rng, gdn_dims.qkv_dim * rank, 0.05),
+                a_z: rand_fill(&mut rng, rank * dims.hidden, 0.05),
+                b_z: rand_fill(&mut rng, gdn_dims.output_dim * rank, 0.05),
+                a_b: rand_fill(&mut rng, rank * dims.hidden, 0.05),
+                b_b: rand_fill(&mut rng, gdn_dims.num_kh * rank, 0.05),
+                a_a: rand_fill(&mut rng, rank * dims.hidden, 0.05),
+                b_a: rand_fill(&mut rng, gdn_dims.num_kh * rank, 0.05),
+                a_out: rand_fill(&mut rng, rank * gdn_dims.output_dim, 0.05),
+                b_out: rand_fill(&mut rng, dims.hidden * rank, 0.05),
+            })
+            .collect();
 
         let fwd = forward_full(
-            &caches[0], &layers, &loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
+            &caches[0], &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
         )?;
-        let (_, _, analytic) =
-            nll_and_grads(&fwd, &layers, &loras, &head, &dims, num_slots, rank, scale)?;
+        let (_, _, analytic, gdn_analytic) = nll_and_grads(
+            &fwd,
+            &layers,
+            &loras,
+            &head,
+            &dims,
+            &gdn_dims,
+            num_slots,
+            num_gdn_slots,
+            rank,
+            scale,
+        )?;
 
         println!("  fd-eps center {fd_eps:.0e}  (per-entry min over 0.25/0.5/1/2x)");
         let mut worst = 0.0f64;
@@ -557,6 +595,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             &caches[..1],
                             &layers,
                             &loras,
+                            &gdn_loras,
                             &head,
                             &dims,
                             &gdn_dims,
@@ -569,6 +608,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             &caches[..1],
                             &layers,
                             &loras,
+                            &gdn_loras,
                             &head,
                             &dims,
                             &gdn_dims,
@@ -594,6 +634,124 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 );
             }
         }
+        // ---- GDN LoRA slots (surface-B, ported from lattice PR #202) ----
+        for slot in 0..num_gdn_slots {
+            let layer_idx = gdn_slot_layers[slot];
+            for (name, alen) in [
+                ("a_qkv", gdn_analytic[slot].a_qkv.len()),
+                ("b_qkv", gdn_analytic[slot].b_qkv.len()),
+                ("a_z", gdn_analytic[slot].a_z.len()),
+                ("b_z", gdn_analytic[slot].b_z.len()),
+                ("a_b", gdn_analytic[slot].a_b.len()),
+                ("b_b", gdn_analytic[slot].b_b.len()),
+                ("a_a", gdn_analytic[slot].a_a.len()),
+                ("b_a", gdn_analytic[slot].b_a.len()),
+                ("a_out", gdn_analytic[slot].a_out.len()),
+                ("b_out", gdn_analytic[slot].b_out.len()),
+            ] {
+                fn field<'a>(g: &'a GdnLoraParams, name: &str) -> &'a [f32] {
+                    match name {
+                        "a_qkv" => &g.a_qkv,
+                        "b_qkv" => &g.b_qkv,
+                        "a_z" => &g.a_z,
+                        "b_z" => &g.b_z,
+                        "a_b" => &g.a_b,
+                        "b_b" => &g.b_b,
+                        "a_a" => &g.a_a,
+                        "b_a" => &g.b_a,
+                        "a_out" => &g.a_out,
+                        _ => &g.b_out,
+                    }
+                }
+                fn field_mut<'a>(g: &'a mut GdnLoraParams, name: &str) -> &'a mut [f32] {
+                    match name {
+                        "a_qkv" => &mut g.a_qkv,
+                        "b_qkv" => &mut g.b_qkv,
+                        "a_z" => &mut g.a_z,
+                        "b_z" => &mut g.b_z,
+                        "a_b" => &mut g.a_b,
+                        "b_b" => &mut g.b_b,
+                        "a_a" => &mut g.a_a,
+                        "b_a" => &mut g.b_a,
+                        "a_out" => &mut g.a_out,
+                        _ => &mut g.b_out,
+                    }
+                }
+                let agrad = field(&gdn_analytic[slot], name);
+                let mut idxs = top_k_indices(agrad, probe.min(alen));
+                let seed = (100
+                    + slot as u64 * 10
+                    + match name {
+                        "a_qkv" => 0,
+                        "b_qkv" => 1,
+                        "a_z" => 2,
+                        "b_z" => 3,
+                        "a_b" => 4,
+                        "b_b" => 5,
+                        "a_a" => 6,
+                        "b_a" => 7,
+                        "a_out" => 8,
+                        _ => 9,
+                    })
+                    ^ 0xBEEF;
+                for p in strided_probes(alen, probe.min(alen), seed) {
+                    if !idxs.contains(&p) {
+                        idxs.push(p);
+                    }
+                }
+                let mut max_rel = 0.0f64;
+                let mut sum_rel = 0.0f64;
+                for &k in &idxs {
+                    let a = field(&gdn_analytic[slot], name)[k];
+                    let save = field(&gdn_loras[slot], name)[k];
+                    let eps_set = [fd_eps * 0.25, fd_eps * 0.5, fd_eps, fd_eps * 2.0];
+                    let mut best = f64::INFINITY;
+                    for &e in &eps_set {
+                        field_mut(&mut gdn_loras[slot], name)[k] = save + e;
+                        let lp = eval_chain_nll(
+                            &caches[..1],
+                            &layers,
+                            &loras,
+                            &gdn_loras,
+                            &head,
+                            &dims,
+                            &gdn_dims,
+                            &cfg,
+                            rank,
+                            scale,
+                        )?;
+                        field_mut(&mut gdn_loras[slot], name)[k] = save - e;
+                        let lm = eval_chain_nll(
+                            &caches[..1],
+                            &layers,
+                            &loras,
+                            &gdn_loras,
+                            &head,
+                            &dims,
+                            &gdn_dims,
+                            &cfg,
+                            rank,
+                            scale,
+                        )?;
+                        let fd = (lp - lm) / (2.0 * e);
+                        let rel = (a - fd).abs() as f64 / (a.abs().max(fd.abs()).max(1e-6)) as f64;
+                        best = best.min(rel);
+                    }
+                    field_mut(&mut gdn_loras[slot], name)[k] = save;
+                    max_rel = max_rel.max(best);
+                    sum_rel += best;
+                }
+                let mean_rel = sum_rel / idxs.len().max(1) as f64;
+                worst = worst.max(max_rel);
+                let ok = max_rel < 2e-2;
+                all_pass &= ok;
+                println!(
+                    "  layer {layer_idx:2} gdn-slot {slot} {name:<5}: mean {mean_rel:.2e}  max {max_rel:.2e}  {}",
+                    if ok { "ok" } else { "FAIL" }
+                );
+            }
+        }
+
         println!("\n  worst rel-err across all probed entries: {worst:.2e}");
         if all_pass {
             println!(
@@ -622,11 +780,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             b_v: vec![0.0; dims.kv_dim * rank],
         })
         .collect();
+    let mut gdn_loras: Vec<GdnLoraParams> = (0..num_gdn_slots)
+        .map(|_| GdnLoraParams {
+            a_qkv: rand_fill(&mut rng, rank * dims.hidden, init_amp),
+            b_qkv: vec![0.0; gdn_dims.qkv_dim * rank],
+            a_z: rand_fill(&mut rng, rank * dims.hidden, init_amp),
+            b_z: vec![0.0; gdn_dims.output_dim * rank],
+            a_b: rand_fill(&mut rng, rank * dims.hidden, init_amp),
+            b_b: vec![0.0; gdn_dims.num_kh * rank],
+            a_a: rand_fill(&mut rng, rank * dims.hidden, init_amp),
+            b_a: vec![0.0; gdn_dims.num_kh * rank],
+            a_out: rand_fill(&mut rng, rank * gdn_dims.output_dim, init_amp),
+            b_out: vec![0.0; dims.hidden * rank],
+        })
+        .collect();
 
     let mut adam = AdamState::new();
     let (beta1, beta2, eps_adam) = (0.9f32, 0.999f32, 1e-8f32);
 
-    let eval_valid = |loras: &[LoraParams]| -> Result<Option<f32>, Box<dyn std::error::Error>> {
+    let eval_valid = |loras: &[LoraParams],
+                      gdn_loras: &[GdnLoraParams]|
+     -> Result<Option<f32>, Box<dyn std::error::Error>> {
         if valid_caches.is_empty() {
             return Ok(None);
         }
@@ -634,6 +808,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &valid_caches,
             &layers,
             loras,
+            gdn_loras,
             &head,
             &dims,
             &gdn_dims,
@@ -644,9 +819,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let base_nll = eval_chain_nll(
-        &caches, &layers, &loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
+        &caches, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
     )?;
-    let base_valid = eval_valid(&loras)?;
+    let base_valid = eval_valid(&loras, &gdn_loras)?;
     match base_valid {
         Some(v) => println!("\n  step    0  train NLL: {base_nll:.4}  held-out NLL: {v:.4}"),
         None => println!("\n  step    0  train NLL: {base_nll:.4}"),
@@ -656,10 +831,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for step in 1..=steps {
         let ctx = &caches[(step - 1) % caches.len()];
         let fwd = forward_full(
-            ctx, &layers, &loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
+            ctx, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
         )?;
-        let (_nll, _n, grads) =
-            nll_and_grads(&fwd, &layers, &loras, &head, &dims, num_slots, rank, scale)?;
+        let (_nll, _n, grads, gdn_grads) = nll_and_grads(
+            &fwd,
+            &layers,
+            &loras,
+            &head,
+            &dims,
+            &gdn_dims,
+            num_slots,
+            num_gdn_slots,
+            rank,
+            scale,
+        )?;
 
         apply_adam_updates(
             &mut adam,
@@ -671,12 +856,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             beta2,
             eps_adam,
         );
+        apply_gdn_adam_updates(
+            &mut adam,
+            &mut gdn_loras,
+            &gdn_grads,
+            &gdn_slot_layers,
+            lr,
+            beta1,
+            beta2,
+            eps_adam,
+        );
 
         if step % log_every == 0 || step == steps {
             let mean_nll = eval_chain_nll(
-                &caches, &layers, &loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
+                &caches, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
             )?;
-            match eval_valid(&loras)? {
+            match eval_valid(&loras, &gdn_loras)? {
                 Some(v) => println!(
                     "  step {step:4}  train NLL: {mean_nll:.4}  held-out NLL: {v:.4}  (train d {:+.4})",
                     mean_nll - base_nll
@@ -690,10 +885,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let final_nll = eval_chain_nll(
-        &caches, &layers, &loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
+        &caches, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
     )?;
     let secs = tstep.elapsed().as_secs_f64();
-    match (base_valid, eval_valid(&loras)?) {
+    match (base_valid, eval_valid(&loras, &gdn_loras)?) {
         (Some(b), Some(f)) => println!(
             "\n=== done: train {base_nll:.4}→{final_nll:.4} ({:+.4})  |  held-out {b:.4}→{f:.4} ({:+.4})  in {secs:.1}s ===",
             final_nll - base_nll,
@@ -733,16 +928,84 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     },
                 );
             }
+            let mut target_modules = vec!["q_proj".to_string(), "v_proj".to_string()];
+            if num_gdn_slots > 0 {
+                target_modules.extend([
+                    "in_proj_qkv".to_string(),
+                    "in_proj_z".to_string(),
+                    "in_proj_b".to_string(),
+                    "in_proj_a".to_string(),
+                    "out_proj".to_string(),
+                ]);
+                // GDN LoRA (surface-B, ported from lattice PR #202). All five
+                // module names are recognised by `LoraAdapter::validate_against`
+                // (crates/tune/src/lora/mod.rs, inference-hook feature).
+                for (slot, &li) in gdn_slot_layers.iter().enumerate() {
+                    let g = &gdn_loras[slot];
+                    adapter_layers.insert(
+                        (li, "in_proj_qkv".to_string()),
+                        LoraLayer {
+                            a: g.a_qkv.clone(),
+                            b: g.b_qkv.clone(),
+                            d_in: dims.hidden,
+                            d_out: gdn_dims.qkv_dim,
+                            rank,
+                        },
+                    );
+                    adapter_layers.insert(
+                        (li, "in_proj_z".to_string()),
+                        LoraLayer {
+                            a: g.a_z.clone(),
+                            b: g.b_z.clone(),
+                            d_in: dims.hidden,
+                            d_out: gdn_dims.output_dim,
+                            rank,
+                        },
+                    );
+                    adapter_layers.insert(
+                        (li, "in_proj_b".to_string()),
+                        LoraLayer {
+                            a: g.a_b.clone(),
+                            b: g.b_b.clone(),
+                            d_in: dims.hidden,
+                            d_out: gdn_dims.num_kh,
+                            rank,
+                        },
+                    );
+                    adapter_layers.insert(
+                        (li, "in_proj_a".to_string()),
+                        LoraLayer {
+                            a: g.a_a.clone(),
+                            b: g.b_a.clone(),
+                            d_in: dims.hidden,
+                            d_out: gdn_dims.num_kh,
+                            rank,
+                        },
+                    );
+                    adapter_layers.insert(
+                        (li, "out_proj".to_string()),
+                        LoraLayer {
+                            a: g.a_out.clone(),
+                            b: g.b_out.clone(),
+                            d_in: gdn_dims.output_dim,
+                            d_out: dims.hidden,
+                            rank,
+                        },
+                    );
+                }
+            }
             let config = LoraConfig {
                 rank,
                 alpha,
-                target_modules: vec!["q_proj".to_string(), "v_proj".to_string()],
+                target_modules,
             };
             let adapter = LoraAdapter::new(config, adapter_layers);
             adapter
                 .save_safetensors(std::path::Path::new(path), None)
                 .map_err(|e| format!("save adapter: {e}"))?;
-            println!("saved adapter ({num_slots} GQA slots, rank {rank}) → {path}");
+            println!(
+                "saved adapter ({num_slots} GQA slots, {num_gdn_slots} GDN slots, rank {rank}) → {path}"
+            );
         }
         #[cfg(not(feature = "safetensors"))]
         {

--- a/crates/tune/src/bin/train_grad_full.rs
+++ b/crates/tune/src/bin/train_grad_full.rs
@@ -968,7 +968,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             a: g.a_b.clone(),
                             b: g.b_b.clone(),
                             d_in: dims.hidden,
-                            d_out: gdn_dims.num_kh,
+                            // beta is projected per VALUE head (matches the
+                            // shipping gdn_fused forward and the f16 weight
+                            // loader), not per key head (#792 codex blocker).
+                            d_out: gdn_dims.value_heads,
                             rank,
                         },
                     );
@@ -978,7 +981,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             a: g.a_a.clone(),
                             b: g.b_a.clone(),
                             d_in: dims.hidden,
-                            d_out: gdn_dims.num_kh,
+                            // alpha is likewise projected per VALUE head.
+                            d_out: gdn_dims.value_heads,
                             rank,
                         },
                     );

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -239,6 +239,8 @@ impl LoraAdapter {
                 ("o_proj", true) => (config.full_q_dim(), config.hidden_size),
                 ("in_proj_qkv", false) => (config.hidden_size, config.linear_qkv_dim()),
                 ("in_proj_z", false) => (config.hidden_size, config.linear_output_dim()),
+                ("in_proj_b", false) => (config.hidden_size, config.linear_num_key_heads),
+                ("in_proj_a", false) => (config.hidden_size, config.linear_num_key_heads),
                 ("out_proj", false) => (config.linear_output_dim(), config.hidden_size),
                 ("gate_proj", _) => (config.hidden_size, config.intermediate_size),
                 ("up_proj", _) => (config.hidden_size, config.intermediate_size),
@@ -507,6 +509,34 @@ mod tests {
             let adapter = make_adapter_for_layer(3, "xq_proj_typo", 1024, 4096);
             let err = adapter.validate_against(&cfg).unwrap_err();
             assert!(err.to_string().contains("not a recognised"));
+        }
+
+        #[test]
+        fn test_validate_against_gdn_all_modules_pass() {
+            // Regression: train_grad_full --save emits all five GDN LoRA modules
+            // (in_proj_qkv/z/b/a, out_proj). The forward applies every one of them
+            // (gdn_fused.rs), so validate_against must accept each with the dims the
+            // loader and trainer use. Dims are derived from the config, not hardcoded,
+            // so this stays correct if the reference dims change.
+            let cfg = Qwen35Config::qwen35_0_8b();
+            let gdn_layer = (0..cfg.num_hidden_layers)
+                .find(|&i| !cfg.is_full_attention(i))
+                .expect("0.8b config has linear-attention layers");
+            let h = cfg.hidden_size;
+            let cases = [
+                ("in_proj_qkv", h, cfg.linear_qkv_dim()),
+                ("in_proj_z", h, cfg.linear_output_dim()),
+                ("in_proj_b", h, cfg.linear_num_key_heads),
+                ("in_proj_a", h, cfg.linear_num_key_heads),
+                ("out_proj", cfg.linear_output_dim(), h),
+            ];
+            for (module, d_in, d_out) in cases {
+                let adapter = make_adapter_for_layer(gdn_layer, module, d_in, d_out);
+                assert!(
+                    adapter.validate_against(&cfg).is_ok(),
+                    "GDN LoRA module {module} should validate (d_in={d_in}, d_out={d_out})"
+                );
+            }
         }
     }
 }

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -239,8 +239,12 @@ impl LoraAdapter {
                 ("o_proj", true) => (config.full_q_dim(), config.hidden_size),
                 ("in_proj_qkv", false) => (config.hidden_size, config.linear_qkv_dim()),
                 ("in_proj_z", false) => (config.hidden_size, config.linear_output_dim()),
-                ("in_proj_b", false) => (config.hidden_size, config.linear_num_key_heads),
-                ("in_proj_a", false) => (config.hidden_size, config.linear_num_key_heads),
+                // beta/alpha are projected per VALUE head (matches the shipping
+                // gdn_fused forward and the f16 weight loader), not per key head
+                // (#792 codex round-1 blocker: this was linear_num_key_heads,
+                // wrong for asymmetric 4B/27B shapes where value_heads != key_heads).
+                ("in_proj_b", false) => (config.hidden_size, config.linear_num_value_heads()),
+                ("in_proj_a", false) => (config.hidden_size, config.linear_num_value_heads()),
                 ("out_proj", false) => (config.linear_output_dim(), config.hidden_size),
                 ("gate_proj", _) => (config.hidden_size, config.intermediate_size),
                 ("up_proj", _) => (config.hidden_size, config.intermediate_size),
@@ -526,8 +530,8 @@ mod tests {
             let cases = [
                 ("in_proj_qkv", h, cfg.linear_qkv_dim()),
                 ("in_proj_z", h, cfg.linear_output_dim()),
-                ("in_proj_b", h, cfg.linear_num_key_heads),
-                ("in_proj_a", h, cfg.linear_num_key_heads),
+                ("in_proj_b", h, cfg.linear_num_value_heads()),
+                ("in_proj_a", h, cfg.linear_num_value_heads()),
                 ("out_proj", cfg.linear_output_dim(), h),
             ];
             for (module, d_in, d_out) in cases {
@@ -537,6 +541,70 @@ mod tests {
                     "GDN LoRA module {module} should validate (d_in={d_in}, d_out={d_out})"
                 );
             }
+        }
+
+        /// Regression for #792 codex round-1 blocker: in_proj_b/in_proj_a
+        /// dims must be keyed by `linear_num_value_heads()`, not
+        /// `linear_num_key_heads`. Asymmetric-head configs (key_heads !=
+        /// value_heads) are the only ones that can tell these apart —
+        /// `qwen35_0_8b` has key_heads == value_heads == 16 and would pass
+        /// either way.
+        #[test]
+        fn test_validate_against_gdn_asymmetric_value_heads_35b_a3b() {
+            let cfg = Qwen35Config::qwen36_35b_a3b();
+            assert_eq!(cfg.linear_num_key_heads, 16);
+            assert_eq!(cfg.linear_num_value_heads(), 32);
+            let gdn_layer = (0..cfg.num_hidden_layers)
+                .find(|&i| !cfg.is_full_attention(i))
+                .expect("config has linear-attention layers");
+            let h = cfg.hidden_size;
+
+            // Correct dims (value_heads=32) must validate.
+            let ok_b = make_adapter_for_layer(gdn_layer, "in_proj_b", h, 32);
+            assert!(ok_b.validate_against(&cfg).is_ok());
+            let ok_a = make_adapter_for_layer(gdn_layer, "in_proj_a", h, 32);
+            assert!(ok_a.validate_against(&cfg).is_ok());
+
+            // The old (wrong) key-head dim (16) must be rejected.
+            let bad_b = make_adapter_for_layer(gdn_layer, "in_proj_b", h, 16);
+            assert!(
+                bad_b.validate_against(&cfg).is_err(),
+                "in_proj_b with key-head dim (16) must fail on a 16-key/32-value config"
+            );
+            let bad_a = make_adapter_for_layer(gdn_layer, "in_proj_a", h, 16);
+            assert!(
+                bad_a.validate_against(&cfg).is_err(),
+                "in_proj_a with key-head dim (16) must fail on a 16-key/32-value config"
+            );
+        }
+
+        #[test]
+        fn test_validate_against_gdn_asymmetric_value_heads_27b() {
+            let cfg = Qwen35Config::qwen36_27b();
+            assert_eq!(cfg.linear_num_key_heads, 16);
+            assert_eq!(cfg.linear_num_value_heads(), 48);
+            let gdn_layer = (0..cfg.num_hidden_layers)
+                .find(|&i| !cfg.is_full_attention(i))
+                .expect("config has linear-attention layers");
+            let h = cfg.hidden_size;
+
+            // Correct dims (value_heads=48) must validate.
+            let ok_b = make_adapter_for_layer(gdn_layer, "in_proj_b", h, 48);
+            assert!(ok_b.validate_against(&cfg).is_ok());
+            let ok_a = make_adapter_for_layer(gdn_layer, "in_proj_a", h, 48);
+            assert!(ok_a.validate_against(&cfg).is_ok());
+
+            // The old (wrong) key-head dim (16) must be rejected.
+            let bad_b = make_adapter_for_layer(gdn_layer, "in_proj_b", h, 16);
+            assert!(
+                bad_b.validate_against(&cfg).is_err(),
+                "in_proj_b with key-head dim (16) must fail on a 16-key/48-value config"
+            );
+            let bad_a = make_adapter_for_layer(gdn_layer, "in_proj_a", h, 16);
+            assert!(
+                bad_a.validate_against(&cfg).is_err(),
+                "in_proj_a with key-head dim (16) must fail on a 16-key/48-value config"
+            );
         }
     }
 }

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -10,8 +10,8 @@ use lattice_inference::model::qwen35::Qwen35Model;
 
 use crate::error::{Result, TuneError};
 use crate::lora::train_core::{
-    Dims, GdnDims, Head, LayerW, LoraParams, MixerKind, SeqCtx, TOP_LAYER, apply_adam_updates,
-    forward_full, nll_and_grads, rand_fill, shifted,
+    Dims, GdnDims, GdnLoraParams, Head, LayerW, LoraParams, MixerKind, SeqCtx, TOP_LAYER,
+    apply_adam_updates, forward_full, nll_and_grads, rand_fill, shifted,
 };
 use crate::lora::{AdamState, LoraAdapter, LoraConfig, LoraLayer};
 
@@ -370,13 +370,18 @@ pub fn train_micro_lora(
     let (beta1, beta2, eps_adam) = (0.9f32, 0.999f32, 1e-8f32);
     let lr = config.learning_rate;
 
+    // This library entry point trains GQA q_proj/v_proj slots only (no GDN
+    // LoRA request surface yet), so the GDN slot arrays stay empty — forward_full
+    // and nll_and_grads fall back to the byte-identical no-LoRA GDN path.
+    let gdn_loras: Vec<GdnLoraParams> = Vec::new();
     for step in 1..=config.steps {
         let ctx = &caches[(step - 1) % caches.len()];
         let fwd = forward_full(
-            ctx, &layers, &loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
+            ctx, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
         )?;
-        let (_nll, _n, grads) =
-            nll_and_grads(&fwd, &layers, &loras, &head, &dims, num_slots, rank, scale)?;
+        let (_nll, _n, grads, _gdn_grads) = nll_and_grads(
+            &fwd, &layers, &loras, &head, &dims, &gdn_dims, num_slots, 0, rank, scale,
+        )?;
 
         apply_adam_updates(
             &mut adam,

--- a/crates/tune/src/lora/train_core.rs
+++ b/crates/tune/src/lora/train_core.rs
@@ -28,14 +28,14 @@ pub struct Dims {
 
 #[derive(Clone, Copy)]
 pub struct GdnDims {
-    num_kh: usize,
-    value_heads: usize,
-    key_dim: usize,
-    value_dim: usize,
-    qkv_dim: usize,
-    output_dim: usize,
-    kernel_size: usize,
-    scale: f32,
+    pub num_kh: usize,
+    pub value_heads: usize,
+    pub key_dim: usize,
+    pub value_dim: usize,
+    pub qkv_dim: usize,
+    pub output_dim: usize,
+    pub kernel_size: usize,
+    pub scale: f32,
 }
 
 impl GdnDims {
@@ -130,6 +130,56 @@ impl LoraParams {
 
 pub type Grads = LoraParams;
 
+/// LoRA parameters (and, doubling as the gradient container, LoRA gradients)
+/// for the 5 GDN projections: in_proj_qkv, in_proj_z, in_proj_b (beta),
+/// in_proj_a (alpha), out_proj. Mirrors `GdnGrads` in
+/// `lattice_inference::attention::gdn_backward` field-for-field so a
+/// `GdnGrads` can be converted straight into a `GdnLoraParams` gradient slot.
+///
+/// Shapes (rank = LoRA rank, dims from `GdnDims`):
+///   a_qkv: [rank, hidden]        b_qkv: [qkv_dim, rank]
+///   a_z:   [rank, hidden]        b_z:   [output_dim, rank]
+///   a_b:   [rank, hidden]        b_b:   [num_kh, rank]
+///   a_a:   [rank, hidden]        b_a:   [num_kh, rank]
+///   a_out: [rank, output_dim]    b_out: [hidden, rank]
+#[derive(Clone)]
+pub struct GdnLoraParams {
+    pub a_qkv: Vec<f32>,
+    pub b_qkv: Vec<f32>,
+    pub a_z: Vec<f32>,
+    pub b_z: Vec<f32>,
+    pub a_b: Vec<f32>,
+    pub b_b: Vec<f32>,
+    pub a_a: Vec<f32>,
+    pub b_a: Vec<f32>,
+    pub a_out: Vec<f32>,
+    pub b_out: Vec<f32>,
+}
+
+impl GdnLoraParams {
+    pub fn zeros(rank: usize, hidden: usize, gd: &GdnDims) -> Result<Self> {
+        let checked = |a: usize, b: usize, label: &str| -> Result<usize> {
+            a.checked_mul(b).ok_or_else(|| {
+                TuneError::Validation(format!(
+                    "{label} overflows GDN LoRA gradient buffer size ({a} * {b})"
+                ))
+            })
+        };
+        Ok(Self {
+            a_qkv: vec![0.0; checked(rank, hidden, "rank*hidden (a_qkv)")?],
+            b_qkv: vec![0.0; checked(gd.qkv_dim, rank, "qkv_dim*rank (b_qkv)")?],
+            a_z: vec![0.0; checked(rank, hidden, "rank*hidden (a_z)")?],
+            b_z: vec![0.0; checked(gd.output_dim, rank, "output_dim*rank (b_z)")?],
+            a_b: vec![0.0; checked(rank, hidden, "rank*hidden (a_b)")?],
+            b_b: vec![0.0; checked(gd.num_kh, rank, "num_kh*rank (b_b)")?],
+            a_a: vec![0.0; checked(rank, hidden, "rank*hidden (a_a)")?],
+            b_a: vec![0.0; checked(gd.num_kh, rank, "num_kh*rank (b_a)")?],
+            a_out: vec![0.0; checked(rank, gd.output_dim, "rank*output_dim (a_out)")?],
+            b_out: vec![0.0; checked(hidden, rank, "hidden*rank (b_out)")?],
+        })
+    }
+}
+
 pub struct SeqCtx {
     pub h_in: Vec<f32>,
     pub cos: Vec<f32>,
@@ -208,6 +258,7 @@ pub fn forward_full(
     ctx: &SeqCtx,
     layers: &[LayerW<'_>],
     loras: &[LoraParams],
+    gdn_loras: &[GdnLoraParams],
     head: &Head<'_>,
     d: &Dims,
     gdn_dims: &GdnDims,
@@ -274,7 +325,51 @@ pub fn forward_full(
                     d.eps,
                 );
                 let mut out = vec![0.0f32; seq * hidden];
-                gdn_forward_save(&normed_pre, gdn_w, cfg, &mut saved, &mut out);
+                match lw.lora_slot {
+                    Some(slot) => {
+                        let l = &gdn_loras[slot];
+                        gdn_forward_save(
+                            &normed_pre,
+                            gdn_w,
+                            cfg,
+                            &mut saved,
+                            &mut out,
+                            Some(&l.a_qkv),
+                            Some(&l.b_qkv),
+                            Some(&l.a_z),
+                            Some(&l.b_z),
+                            Some(&l.a_b),
+                            Some(&l.b_b),
+                            Some(&l.a_a),
+                            Some(&l.b_a),
+                            Some(&l.a_out),
+                            Some(&l.b_out),
+                            rank,
+                            scale,
+                        );
+                    }
+                    None => {
+                        gdn_forward_save(
+                            &normed_pre,
+                            gdn_w,
+                            cfg,
+                            &mut saved,
+                            &mut out,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            0,
+                            0.0,
+                        );
+                    }
+                }
                 (out, MixerCache::Gdn(Box::new(saved)))
             }
         };
@@ -344,6 +439,7 @@ pub fn eval_chain_nll(
     caches: &[SeqCtx],
     layers: &[LayerW<'_>],
     loras: &[LoraParams],
+    gdn_loras: &[GdnLoraParams],
     head: &Head<'_>,
     d: &Dims,
     gdn_dims: &GdnDims,
@@ -354,7 +450,9 @@ pub fn eval_chain_nll(
     let mut nll_sum = 0.0f64;
     let mut n = 0usize;
     for ctx in caches {
-        let fwd = forward_full(ctx, layers, loras, head, d, gdn_dims, cfg, rank, scale)?;
+        let fwd = forward_full(
+            ctx, layers, loras, gdn_loras, head, d, gdn_dims, cfg, rank, scale,
+        )?;
         for p in &fwd.positions {
             nll_sum += position_nll(&p.logits, p.target) as f64;
             n += 1;
@@ -363,6 +461,12 @@ pub fn eval_chain_nll(
     Ok((nll_sum / n.max(1) as f64) as f32)
 }
 
+/// Reverse-mode NLL + gradients over the assembled multi-layer tape.
+///
+/// `num_slots`/`grads` cover the GQA LoRA slots (surface-A, unchanged).
+/// `num_gdn_slots`/the returned `Vec<GdnLoraParams>` cover the GDN LoRA slots
+/// (surface-B, ported from lattice PR #202) — empty when no GDN layer in the
+/// materialised range carries a LoRA slot.
 #[allow(clippy::too_many_arguments)]
 pub fn nll_and_grads(
     fwd: &FullFwd,
@@ -370,15 +474,20 @@ pub fn nll_and_grads(
     loras: &[LoraParams],
     head: &Head<'_>,
     d: &Dims,
+    gdn_dims: &GdnDims,
     num_slots: usize,
+    num_gdn_slots: usize,
     rank: usize,
     scale: f32,
-) -> Result<(f32, usize, Vec<Grads>)> {
+) -> Result<(f32, usize, Vec<Grads>, Vec<GdnLoraParams>)> {
     let hidden = d.hidden;
     let seq = fwd.h_final.len() / hidden;
     let n_comp = fwd.positions.len().max(1) as f32;
     let mut grads: Vec<Grads> = (0..num_slots)
         .map(|_| LoraParams::zeros(rank, d))
+        .collect::<Result<Vec<_>>>()?;
+    let mut gdn_grads: Vec<GdnLoraParams> = (0..num_gdn_slots)
+        .map(|_| GdnLoraParams::zeros(rank, hidden, gdn_dims))
         .collect::<Result<Vec<_>>>()?;
 
     let mut d_h = vec![0.0f32; seq * hidden];
@@ -467,9 +576,22 @@ pub fn nll_and_grads(
                 let gdn_w = lw.gdn.ok_or_else(|| {
                     TuneError::Validation("GDN layer missing weights in backward".to_string())
                 })?;
-                let mut dx = vec![0.0f32; seq * hidden];
-                gdn_backward(&d_h_mid, saved, gdn_w, &mut dx);
-                dx
+                let g = gdn_backward(&d_h_mid, saved, gdn_w);
+                if let Some(slot) = lw.lora_slot {
+                    gdn_grads[slot] = GdnLoraParams {
+                        a_qkv: g.grad_a_qkv,
+                        b_qkv: g.grad_b_qkv,
+                        a_z: g.grad_a_z,
+                        b_z: g.grad_b_z,
+                        a_b: g.grad_a_b,
+                        b_b: g.grad_b_b,
+                        a_a: g.grad_a_a,
+                        b_a: g.grad_b_a,
+                        a_out: g.grad_a_out,
+                        b_out: g.grad_b_out,
+                    };
+                }
+                g.dx
             }
         };
 
@@ -488,7 +610,7 @@ pub fn nll_and_grads(
         d_h = d_h_new;
     }
 
-    Ok((nll_sum as f32, fwd.positions.len(), grads))
+    Ok((nll_sum as f32, fwd.positions.len(), grads, gdn_grads))
 }
 
 pub fn shifted(gamma: &[f32]) -> Vec<f32> {
@@ -563,5 +685,143 @@ pub fn apply_adam_updates(
             0.0,
             false,
         );
+    }
+}
+
+/// Adam step for the GDN LoRA slots (surface-B). Mirrors `apply_adam_updates`
+/// but steps all 5 GDN projections' A/B pairs (10 arrays/slot) instead of the
+/// 2 GQA projections' A/B pairs (4 arrays/slot).
+#[allow(clippy::too_many_arguments)]
+pub fn apply_gdn_adam_updates(
+    adam: &mut AdamState,
+    gdn_loras: &mut [GdnLoraParams],
+    gdn_grads: &[GdnLoraParams],
+    slot_layers: &[usize],
+    lr: f32,
+    beta1: f32,
+    beta2: f32,
+    eps_adam: f32,
+) {
+    for slot in 0..slot_layers.len() {
+        let li = slot_layers[slot];
+        macro_rules! step {
+            ($field:ident, $tag:literal) => {
+                adam.step(
+                    &format!("l{li}_gdn_{}", $tag),
+                    &mut gdn_loras[slot].$field,
+                    &gdn_grads[slot].$field,
+                    lr,
+                    beta1,
+                    beta2,
+                    eps_adam,
+                    0.0,
+                    false,
+                );
+            };
+        }
+        step!(a_qkv, "a_qkv");
+        step!(b_qkv, "b_qkv");
+        step!(a_z, "a_z");
+        step!(b_z, "b_z");
+        step!(a_b, "a_b");
+        step!(b_b, "b_b");
+        step!(a_a, "a_a");
+        step!(b_a, "b_a");
+        step!(a_out, "a_out");
+        step!(b_out, "b_out");
+    }
+}
+
+#[cfg(test)]
+mod gdn_lora_tests {
+    use super::*;
+
+    fn tiny_gdn_dims() -> GdnDims {
+        // hidden=16, num_kh=2, value_heads=4, key_dim=4, value_dim=4 — matches
+        // the shapes exercised by gdn_backward's own multi-head gradcheck fixture.
+        GdnDims {
+            num_kh: 2,
+            value_heads: 4,
+            key_dim: 4,
+            value_dim: 4,
+            qkv_dim: 2 * (2 * 4) + 4 * 4, // 2*key_dim*num_kh + value_heads*value_dim = 32
+            output_dim: 4 * 4,            // value_heads * value_dim = 16
+            kernel_size: 3,
+            scale: 0.5,
+        }
+    }
+
+    #[test]
+    fn gdn_lora_params_zeros_shapes_match_gdn_dims() {
+        let gd = tiny_gdn_dims();
+        let hidden = 16;
+        let rank = 3;
+        let p = GdnLoraParams::zeros(rank, hidden, &gd).expect("zeros should not overflow");
+
+        assert_eq!(p.a_qkv.len(), rank * hidden);
+        assert_eq!(p.b_qkv.len(), gd.qkv_dim * rank);
+        assert_eq!(p.a_z.len(), rank * hidden);
+        assert_eq!(p.b_z.len(), gd.output_dim * rank);
+        assert_eq!(p.a_b.len(), rank * hidden);
+        assert_eq!(p.b_b.len(), gd.num_kh * rank);
+        assert_eq!(p.a_a.len(), rank * hidden);
+        assert_eq!(p.b_a.len(), gd.num_kh * rank);
+        assert_eq!(p.a_out.len(), rank * gd.output_dim);
+        assert_eq!(p.b_out.len(), hidden * rank);
+        // Zero-initialised.
+        assert!(p.a_qkv.iter().all(|&v| v == 0.0));
+        assert!(p.b_out.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn gdn_lora_params_zeros_rejects_overflowing_rank() {
+        let gd = tiny_gdn_dims();
+        // rank so large that rank * hidden overflows usize on any platform.
+        let err = GdnLoraParams::zeros(usize::MAX / 2, 16, &gd);
+        assert!(err.is_err(), "overflowing rank*hidden should be rejected");
+    }
+
+    #[test]
+    fn apply_gdn_adam_updates_moves_nonzero_grad_params() {
+        let gd = tiny_gdn_dims();
+        let hidden = 16;
+        let rank = 3;
+        let mut gdn_loras = vec![GdnLoraParams::zeros(rank, hidden, &gd).unwrap()];
+        // Non-zero, non-uniform gradient so the Adam step has a definite sign.
+        let mut grads = GdnLoraParams::zeros(rank, hidden, &gd).unwrap();
+        for (i, v) in grads.a_qkv.iter_mut().enumerate() {
+            *v = 0.01 * (i as f32 + 1.0);
+        }
+        for (i, v) in grads.b_out.iter_mut().enumerate() {
+            *v = -0.02 * (i as f32 + 1.0);
+        }
+        let gdn_grads = vec![grads];
+
+        let mut adam = AdamState::new();
+        apply_gdn_adam_updates(
+            &mut adam,
+            &mut gdn_loras,
+            &gdn_grads,
+            &[7],
+            0.1,
+            0.9,
+            0.999,
+            1e-8,
+        );
+
+        // Adam moves params opposite the gradient sign: positive grad -> param
+        // decreases from its zero init; negative grad -> param increases.
+        assert!(
+            gdn_loras[0].a_qkv.iter().all(|&v| v < 0.0),
+            "a_qkv should move negative under positive grad: {:?}",
+            gdn_loras[0].a_qkv
+        );
+        assert!(
+            gdn_loras[0].b_out.iter().all(|&v| v > 0.0),
+            "b_out should move positive under negative grad: {:?}",
+            gdn_loras[0].b_out
+        );
+        // Untouched (zero-grad) arrays stay at their zero init.
+        assert!(gdn_loras[0].a_z.iter().all(|&v| v == 0.0));
     }
 }

--- a/crates/tune/src/lora/train_core.rs
+++ b/crates/tune/src/lora/train_core.rs
@@ -157,7 +157,29 @@ pub struct GdnLoraParams {
 }
 
 impl GdnLoraParams {
-    pub fn zeros(rank: usize, hidden: usize, gd: &GdnDims) -> Result<Self> {
+    /// Shape-aware constructor: the single source of truth for every GDN LoRA
+    /// array's length (mirrors the `d_out`/`d_in` table in the struct's doc
+    /// comment above). `fill_a`/`fill_b` receive the exact element count and
+    /// return the initialised vec, so callers that need randomized or
+    /// zero-B initialization go through the SAME shape derivation as `zeros`
+    /// instead of re-deriving `d_out` per array per call site.
+    ///
+    /// This exists because of a real drift: #792 codex round-2 found that
+    /// `train_grad_full.rs` had two independent call sites (gradcheck-mode
+    /// and training-mode initialization) that re-derived `b_b`/`b_a` as
+    /// `num_kh * rank` instead of `value_heads * rank` — the exact blocker
+    /// round-1 fixed in `zeros`, but round-1's fix never touched those two
+    /// inline constructors because they didn't call `zeros` at all. Routing
+    /// both through `shaped` (and `zeros` through `shaped`) makes that class
+    /// of drift a compile-time-shared-code property instead of a
+    /// grep-and-hope one.
+    pub fn shaped(
+        rank: usize,
+        hidden: usize,
+        gd: &GdnDims,
+        mut fill_a: impl FnMut(usize) -> Vec<f32>,
+        mut fill_b: impl FnMut(usize) -> Vec<f32>,
+    ) -> Result<Self> {
         let checked = |a: usize, b: usize, label: &str| -> Result<usize> {
             a.checked_mul(b).ok_or_else(|| {
                 TuneError::Validation(format!(
@@ -166,21 +188,25 @@ impl GdnLoraParams {
             })
         };
         Ok(Self {
-            a_qkv: vec![0.0; checked(rank, hidden, "rank*hidden (a_qkv)")?],
-            b_qkv: vec![0.0; checked(gd.qkv_dim, rank, "qkv_dim*rank (b_qkv)")?],
-            a_z: vec![0.0; checked(rank, hidden, "rank*hidden (a_z)")?],
-            b_z: vec![0.0; checked(gd.output_dim, rank, "output_dim*rank (b_z)")?],
-            a_b: vec![0.0; checked(rank, hidden, "rank*hidden (a_b)")?],
+            a_qkv: fill_a(checked(rank, hidden, "rank*hidden (a_qkv)")?),
+            b_qkv: fill_b(checked(gd.qkv_dim, rank, "qkv_dim*rank (b_qkv)")?),
+            a_z: fill_a(checked(rank, hidden, "rank*hidden (a_z)")?),
+            b_z: fill_b(checked(gd.output_dim, rank, "output_dim*rank (b_z)")?),
+            a_b: fill_a(checked(rank, hidden, "rank*hidden (a_b)")?),
             // beta (in_proj_b) is projected per VALUE head, matching the
             // shipping gdn_fused forward and the f16 weight loader — NOT
             // per key head (#792 codex round-1 blocker fix).
-            b_b: vec![0.0; checked(gd.value_heads, rank, "value_heads*rank (b_b)")?],
-            a_a: vec![0.0; checked(rank, hidden, "rank*hidden (a_a)")?],
+            b_b: fill_b(checked(gd.value_heads, rank, "value_heads*rank (b_b)")?),
+            a_a: fill_a(checked(rank, hidden, "rank*hidden (a_a)")?),
             // alpha (in_proj_a) is likewise per VALUE head.
-            b_a: vec![0.0; checked(gd.value_heads, rank, "value_heads*rank (b_a)")?],
-            a_out: vec![0.0; checked(rank, gd.output_dim, "rank*output_dim (a_out)")?],
-            b_out: vec![0.0; checked(hidden, rank, "hidden*rank (b_out)")?],
+            b_a: fill_b(checked(gd.value_heads, rank, "value_heads*rank (b_a)")?),
+            a_out: fill_a(checked(rank, gd.output_dim, "rank*output_dim (a_out)")?),
+            b_out: fill_b(checked(hidden, rank, "hidden*rank (b_out)")?),
         })
+    }
+
+    pub fn zeros(rank: usize, hidden: usize, gd: &GdnDims) -> Result<Self> {
+        Self::shaped(rank, hidden, gd, |n| vec![0.0; n], |n| vec![0.0; n])
     }
 }
 

--- a/crates/tune/src/lora/train_core.rs
+++ b/crates/tune/src/lora/train_core.rs
@@ -139,8 +139,8 @@ pub type Grads = LoraParams;
 /// Shapes (rank = LoRA rank, dims from `GdnDims`):
 ///   a_qkv: [rank, hidden]        b_qkv: [qkv_dim, rank]
 ///   a_z:   [rank, hidden]        b_z:   [output_dim, rank]
-///   a_b:   [rank, hidden]        b_b:   [num_kh, rank]
-///   a_a:   [rank, hidden]        b_a:   [num_kh, rank]
+///   a_b:   [rank, hidden]        b_b:   [value_heads, rank]
+///   a_a:   [rank, hidden]        b_a:   [value_heads, rank]
 ///   a_out: [rank, output_dim]    b_out: [hidden, rank]
 #[derive(Clone)]
 pub struct GdnLoraParams {
@@ -171,9 +171,13 @@ impl GdnLoraParams {
             a_z: vec![0.0; checked(rank, hidden, "rank*hidden (a_z)")?],
             b_z: vec![0.0; checked(gd.output_dim, rank, "output_dim*rank (b_z)")?],
             a_b: vec![0.0; checked(rank, hidden, "rank*hidden (a_b)")?],
-            b_b: vec![0.0; checked(gd.num_kh, rank, "num_kh*rank (b_b)")?],
+            // beta (in_proj_b) is projected per VALUE head, matching the
+            // shipping gdn_fused forward and the f16 weight loader — NOT
+            // per key head (#792 codex round-1 blocker fix).
+            b_b: vec![0.0; checked(gd.value_heads, rank, "value_heads*rank (b_b)")?],
             a_a: vec![0.0; checked(rank, hidden, "rank*hidden (a_a)")?],
-            b_a: vec![0.0; checked(gd.num_kh, rank, "num_kh*rank (b_a)")?],
+            // alpha (in_proj_a) is likewise per VALUE head.
+            b_a: vec![0.0; checked(gd.value_heads, rank, "value_heads*rank (b_a)")?],
             a_out: vec![0.0; checked(rank, gd.output_dim, "rank*output_dim (a_out)")?],
             b_out: vec![0.0; checked(hidden, rank, "hidden*rank (b_out)")?],
         })
@@ -763,9 +767,9 @@ mod gdn_lora_tests {
         assert_eq!(p.a_z.len(), rank * hidden);
         assert_eq!(p.b_z.len(), gd.output_dim * rank);
         assert_eq!(p.a_b.len(), rank * hidden);
-        assert_eq!(p.b_b.len(), gd.num_kh * rank);
+        assert_eq!(p.b_b.len(), gd.value_heads * rank);
         assert_eq!(p.a_a.len(), rank * hidden);
-        assert_eq!(p.b_a.len(), gd.num_kh * rank);
+        assert_eq!(p.b_a.len(), gd.value_heads * rank);
         assert_eq!(p.a_out.len(), rank * gd.output_dim);
         assert_eq!(p.b_out.len(), hidden * rank);
         // Zero-initialised.


### PR DESCRIPTION
## What

Re-homes PR #202's GDN LoRA weight-gradient surface (surface-B) onto the `train_core.rs` shared module introduced by #445/#488, so both training binaries that share `train_core` benefit from it, instead of the feature living only in the old monolithic `train_grad_full.rs` that PR #202 was written against.

## Why

PR #202 added LoRA weight-gradient support for GatedDeltaNet (GDN) layers — previously only GQA/attention layers had trainable weight gradients; GDN layers only propagated the activation gradient (`dx`) through, with no way to attach or train a LoRA adapter on them. Since #202 was opened, #445/#488 refactored the trainer internals (`Dims`, `GdnDims`, `MixerKind`, `LoraParams`, `forward_full`, `nll_and_grads`, `apply_adam_updates`, etc.) out of the monolithic binary into `crates/tune/src/lora/train_core.rs`, shrinking `train_grad_full.rs` from 1236 to 755 lines. #202 no longer applies as a rebase; this PR re-implements its algorithmic core against the current architecture.

## Ported (from #202, algorithm unchanged)

- `crates/inference/src/attention/gdn_backward.rs`: `gdn_forward_save` now accepts 10 optional LoRA weight slices (one A/B pair per GDN projection: `in_proj_qkv`, `in_proj_z`, `in_proj_b`, `in_proj_a`, `out_proj`) plus rank/scale — byte-identical to the prior no-LoRA path when omitted (all `None`, rank 0). `gdn_backward` now returns `GdnGrads { grad_a_*, grad_b_*, dx }` instead of writing `dx` into a caller-supplied buffer.
- `crates/tune/src/lora/mod.rs`: `LoraAdapter::validate_against` now recognises `in_proj_b`/`in_proj_a` (previously only `in_proj_qkv`/`in_proj_z`/`out_proj` were recognised — a saved GDN adapter's beta/alpha LoRA layers would have failed validation on load).
- `crates/inference/examples/diff_gdn_layer.rs`: mechanical call-site update for the new `gdn_forward_save` signature.

## Re-homed onto train_core (new relative to #202, adapting its slot-per-layer design onto train_core's structure)

- `crates/tune/src/lora/train_core.rs`: new `GdnLoraParams` (10-array LoRA container, doubling as the gradient container the same way the existing `LoraParams`/`Grads` pattern does), `forward_full`/`eval_chain_nll`/`nll_and_grads` extended with a `gdn_loras` slice + GDN slot count, and a new `apply_gdn_adam_updates` optimizer step mirroring `apply_adam_updates`. GQA surface-A is untouched (verified via lib test suite + clippy).
- `crates/tune/src/bin/train_grad_full.rs`: GDN layers in the materialised range now get their own LoRA slot (mirroring the existing GQA slot bookkeeping), wired through the TBV check (chain NLL vs real model), gradcheck mode (adds a second finite-difference loop over the 10 GDN LoRA arrays per slot, alongside the existing GQA loop), the training loop, and `--save` (adds `in_proj_qkv/z/b/a/out_proj` to the PEFT safetensors export).
- `crates/tune/src/lora/train.rs`: the library `train_micro_lora` entry point (GQA-only) passes empty GDN LoRA arrays — behavior is unchanged (byte-identical no-LoRA GDN path), it simply had to accept the new function signatures.

`train_grad_layer23.rs` is unaffected and not wired: it has its own self-contained single-layer implementation and only ever materialises layer 23, which is a GQA layer, so there is no GDN layer for it to attach LoRA to.

## Deliberately NOT ported

- `ops.rs`/`tape.rs` shifted-gamma changes: #202 baked `(1 + gamma)` into `rms_norm_forward`/`rmsnorm_backward` themselves. Main already resolves the same shifted-gamma requirement at the call site — `train_core::shifted()` pre-adds 1 to gamma before calling those primitives with plain-gamma semantics. Porting #202's primitive-level diff verbatim would double-shift gamma (a real numerical bug). Left as-is.
- `lora_forward_parity_test.rs` (917-line new test file): a diagnostic investigating exactly the plain-vs-shifted-gamma question above, predating the discovery that main solves it differently. Its premise ("tape.rs uses plain gamma, that's a bug") no longer holds, so porting it would test a stale hypothesis.

## Codex round-1 fix (this round)

Round 1 came back **REJECT** with one blocker and one medium; both are fixed here.

**Blocker — alpha/beta were dimensioned per KEY head, but the model defines them per VALUE head.** `in_proj_b`/`in_proj_a` (and their gates `a_log`/`dt_bias`) must have `linear_num_value_heads()` rows to match the authoritative f16 weight loader (`f16_weights.rs`) and the shipping fused forward (`gdn_fused.rs`), which project and index them per value head. The ported code instead projected to `num_kh` and indexed gates through `kh = h / ratio`, silently reducing distinct value-head adjoints into shared key-head slots. This is invisible on Qwen3.5-0.8B (`num_kh == value_heads == 16`) but wrong on the 4B (16 key / 32 value) and 27B (16 key / 48 value) shapes — the known #262 asymmetric-heads trap, now load-bearing because it propagated into LoRA export/validation.

Fixed by re-dimensioning by `value_heads` throughout, keeping key-head sharing *only* for the Q/K projections (`kh = h / ratio` remains correct and unchanged there):
- `crates/inference/src/attention/gdn_backward.rs`: `GdnSaved`'s `beta_raw`/`alpha_proj`/`beta`/`g` buffers, the per-value-head accumulators in `gdn_backward` (renamed `d_alpha_vh`/`d_beta_raw_vh`, no cross-head reduction — alpha/beta are genuinely one-per-value-head), and the LoRA B-factor allocations in `gdn_forward_save`/`gdn_backward`.
- `crates/tune/src/lora/train_core.rs`: `GdnLoraParams::zeros`'s `b_b`/`b_a` sizing (`gd.num_kh` → `gd.value_heads`).
- `crates/tune/src/bin/train_grad_full.rs`: PEFT export `d_out` for `in_proj_b`/`in_proj_a` (`gdn_dims.num_kh` → `gdn_dims.value_heads`).
- `crates/tune/src/lora/mod.rs`: `LoraAdapter::validate_against`'s expected dims for `in_proj_b`/`in_proj_a` (`config.linear_num_key_heads` → `config.linear_num_value_heads()`), plus two new asymmetric-config regression tests (`test_validate_against_gdn_asymmetric_value_heads_35b_a3b` at value_heads=32, `test_validate_against_gdn_asymmetric_value_heads_27b` at value_heads=48) that assert the correct dim validates and the old key-head dim (16) is rejected — `qwen35_0_8b` can't distinguish these because it's symmetric.

Note: this dimension bug pre-dates this PR — confirmed via `git show origin/main:.../gdn_backward.rs` that the same `num_kh`-scoped alpha/beta indexing already existed on main before this port, as a latent bug in the (previously LoRA-less, weight-grad-less) backward path. It became load-bearing only once wired into LoRA export/validation here.

Added the exact test class codex named as the one that "would have caught it": `source_parity_forward_save_vs_fused_asymmetric_heads`, a LoRA-off comparison of `gdn_forward_save` (training path) against the shipping `gated_delta_net_step_fused` (inference path) on a genuinely asymmetric 2-key/4-value-head fixture. This is deliberately an *independent* oracle — unlike the finite-difference gradcheck, which shares the same (previously buggy) shape assumption on both its analytic and numerical sides and so could not have caught this class by construction. TBV: ran this exact test against the pre-fix code (`git show efe20fd46:...` — this PR's own prior head) and confirmed it fails hard (`matmul_bt: b too short for n*k`); it passes clean on the fixed code.

**Medium — the gradcheck's aggregate `n_tested >= 10` threshold hid that 4 of the 10 arrays (`grad_a_b`, `grad_b_b`, `grad_a_a`, `grad_b_a` — exactly the alpha/beta ones) had zero entries above the finite-difference noise floor in both fixtures.** Replaced the aggregate-only gate with per-array coverage tracking (`PerArrayCoverage`, one `(n_tested, max_rel)` pair per named array) and an assertion requiring `n_tested >= 1` for *every* array, not just the sum. Getting real (non-fixture-hacked) coverage on the alpha/beta arrays required two things: (1) widening the fixture's `a_log` range and increasing `lora_scale`/`seq_len` to strengthen the genuinely-indirect scalar-gate signal path, and (2) fixing a real precision bug in the finite-difference oracle itself — `fd_lora_weight_entry`'s `perturbed_loss` accumulated in f32 (unlike its sibling `fd_grad_inputs_linear`, which correctly used f64), causing catastrophic-cancellation error growth once scale/seq_len were pushed high enough to lift the alpha/beta signal. Switched it to f64 accumulation (forward stays f32, matching production).

Mutation-tested the fixed alpha/beta path directly (scaling one A-side alpha accumulation term by 0.5): both gradcheck tests now correctly fail (`max_rel≈0.50` on `grad_a_a`), confirming the per-array gate is sensitive to the exact class codex flagged, not passing vacuously. Reverted after confirming.

## Gradient verification (updated, per-array — supersedes the prior "across all 10 arrays" claim)

Real per-array coverage from both final gradcheck runs (`n_tested`, `max_rel`, all comfortably under the `1e-2` gate):

```
gradcheck_gdn_lora_weight_grads (single-head):
  grad_a_qkv  : n_tested=7  max_rel=2.087e-4
  grad_b_qkv  : n_tested=6  max_rel=1.382e-4
  grad_a_z    : n_tested=7  max_rel=3.170e-5
  grad_b_z    : n_tested=8  max_rel=7.218e-5
  grad_a_b    : n_tested=3  max_rel=1.835e-3
  grad_b_b    : n_tested=2  max_rel=2.210e-4
  grad_a_a    : n_tested=2  max_rel=1.766e-3
  grad_b_a    : n_tested=2  max_rel=3.071e-4
  grad_a_out  : n_tested=8  max_rel=1.920e-4
  grad_b_out  : n_tested=6  max_rel=3.977e-5

gradcheck_gdn_lora_weight_grads_multi_head (asymmetric, num_kh=2/value_heads=4):
  grad_a_qkv  : n_tested=7  max_rel=4.100e-4
  grad_b_qkv  : n_tested=7  max_rel=7.769e-5
  grad_a_z    : n_tested=7  max_rel=5.993e-4
  grad_b_z    : n_tested=7  max_rel=9.411e-5
  grad_a_b    : n_tested=6  max_rel=4.378e-3
  grad_b_b    : n_tested=8  max_rel=2.244e-3
  grad_a_a    : n_tested=4  max_rel=5.272e-3
  grad_b_a    : n_tested=4  max_rel=2.886e-3
  grad_a_out  : n_tested=7  max_rel=3.144e-5
  grad_b_out  : n_tested=7  max_rel=3.309e-6
```

Both tests pass with every array individually asserted `n_tested >= 1` (no aggregate escape hatch).

Added `train_core.rs` unit tests for the re-homed plumbing (`GdnLoraParams::zeros` shape/overflow checks, `apply_gdn_adam_updates` sign-of-update check) and mutation-verified the optimizer-step test by disabling one array's update and confirming the test catches it (then restored).

## Gates

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --features train-backward,safetensors,inference-hook -- -D warnings` — clean
- `cargo test -p lattice-inference -p lattice-tune --features train-backward,safetensors,inference-hook` — all green (1623 lib tests in `lattice-inference` incl. the source-parity test, 264 in `lattice-tune` lib incl. the 2 asymmetric `validate_against` regressions, 2 new `train_grad_full` binary-level unit tests for the round-2 shape-aware constructors, plus all other bin/integration/doctest targets)
- `cargo build --workspace` (default features) — clean, no new default-build warnings

## Bench (ADR-058)

This PR touches `crates/inference/` (`gdn_backward.rs`), so ADR-058's before/after gate applies even though the change is additive-only to the LoRA argument surface (all pre-existing, non-LoRA call sites pass `None`/`0`/`0.0` unchanged). Two runs, both disclosed:

**Run 1 (invalidated — sibling-lane contention):**

```
bash /Users/lion/projects/firm/resources/scripts/with-heavy-lane.sh "lattice:792-bench" -- make bench-compare
```

106 FAIL / 12 WARN / 113 confirmed-improvement, but the pattern was whole-crate and symmetric across benchmark groups this diff never touches: every `lattice-embed` SIMD/cosine-distance benchmark showed up to +386% "regression," while every `lattice-inference` `elementwise_cpu_bench` benchmark (`gelu`, `layer_norm`, `rms_norm`, `silu_inplace`, `softmax_attention`, `residual_add_layer_norm`, `memory_size`) showed up to -88% "improvement" — uniformly in one direction per crate, unconnected to the actual code changed. Concurrent heavy-lane jobs from sibling worktrees (`lattice:c3-r2-metal-final`, `lattice:c3-r2-full-suite`, and others) were running during this measurement window. Discarded as contention-corrupted, not written up as a regression or improvement claim.

**Run 2 (standing — clean re-run):**

```
bash /Users/lion/projects/firm/resources/scripts/with-heavy-lane.sh "lattice:792-bench-rerun2" -- bash -c "cd /Users/lion/projects/khive/lattice-pr202port && make bench-compare"
```

Base=`origin/main` (`65865ecb5`), Head=`HEAD` (`efe20fd46`). The whole-crate symmetric pattern is gone: **zero FAIL/WARN entries in `lattice-inference`'s `elementwise_cpu_bench` group** — every one of `gelu`/`layer_norm`/`rms_norm`/`silu_inplace`/`softmax_attention`/`residual_add_layer_norm`/`memory_size` sits within ±2%, consistent with noise, and this is the group that actually exercises the crate this PR modifies. `lattice-embed`'s unrelated SIMD/cosine-distance group (a crate this PR does not touch at all) still shows 9 FAIL / 29 WARN / 13 confirmed-improvement, single-digit-to-high-teens percent, mixed direction — ordinary microbenchmark jitter on microsecond-scale ops, not the systemic whole-crate corruption seen in run 1.

Net: no bench evidence of a regression in the code this PR actually changes. Not re-run this round (this round's fix is a dimension/coverage correction, no algorithmic/perf-shaped change to the touched benchmark group).

## Codex round-2 fix

Round 2 came back **REJECT** with one surviving blocker (everything else reconfirmed clean: value-head re-dimensioning internally consistent across `GdnSaved`/forward/backward/VJPs, the parity test mutation-sensitive, per-array counts reproducing exactly, `f64` oracle-only, save→load→validate round-trips passing for 32 and 48 value heads).

**Blocker** — `crates/tune/src/bin/train_grad_full.rs` still allocated `b_b`/`b_a` with `gdn_dims.num_kh * rank` at four sites (the gradcheck-mode and training-mode LoRA-array constructors), independently of the round-1 fix to `GdnLoraParams::zeros`. Since `forward_full` feeds those slices into the corrected `gdn_forward_save` (which now expects `value_heads` rows), the binary's real gradcheck/training path would have broken on any asymmetric config, and the PEFT export would label `d_out = value_heads` while the stored buffer was shorter. Round-1's `validate_against` tests missed this because they construct correctly-sized adapters directly rather than going through the binary's own constructors.

Fixed by:
- Adding `GdnLoraParams::shaped` (`crates/tune/src/lora/train_core.rs`) — a shape-aware constructor that is now the single source of truth for every GDN LoRA array's length; `zeros()` is reimplemented on top of it.
- Extracting `train_grad_full.rs`'s two inline LoRA-array constructors into named, testable functions (`gradcheck_gdn_loras`, `zero_b_gdn_loras`), both routed through `::shaped`, so this class of drift is now a compile-time-shared-code property instead of a grep-and-hope one.
- Adding unit tests for both extracted functions against an asymmetric `GdnDims{num_kh: 2, value_heads: 4}` fixture, asserting `b_b`/`b_a` are sized by `value_heads` (`gradcheck_gdn_loras_sizes_b_b_and_b_a_by_value_heads`, `zero_b_gdn_loras_sizes_b_b_and_b_a_by_value_heads`).
- Final `num_kh` grep sweep across all four codex-cited files: zero remaining key-head-scoped alpha/beta sizing. The one surviving `gdn_dims.num_kh` reference (`train_core.rs:346`) is `GdnSaved::new`'s `num_key_heads` parameter — a legitimate Q/K-sharing use, verified against `GdnSaved::new`'s signature (takes `num_key_heads` and `value_heads` as distinct params).

Branch refreshed onto `origin/main` (merge, no conflicts — docs-only diff) before this push, per the strict up-to-date-and-green merge gate.

All gates green at the merged head: fmt, clippy `-D warnings`, full `lattice-inference` + `lattice-tune` test suite including the new binary-level unit tests (1623 + 264 + 2 passed, 0 failed).

## Follow-up

Once this merges, #202 should be closed in favor of it (do not close #202 from this PR — leaving that to the owning maintainer).

Refs #202

