### PR TITLE
fix(inference): fail-closed Metal fused_attention finalize + delete dead kernels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,13 +245,14 @@ jobs:
           LATTICE_METAL_TEST_ENFORCE: '1'
         run: cargo test -p lattice-inference --features f16,metal-gpu --lib q4 -- --nocapture
       # ADR-080 C1 / #789: the `forward::metal::` module's assembled-MSL check and the
-      # NaN/+inf fused_attention fail-closed regressions (codex round-1 major on PR
-      # #794) silently early-returned when no Metal device was present and were never
-      # actually run by any required workflow — the `q4` filter above does not match
-      # this module. LATTICE_METAL_TEST_ENFORCE=1 makes a missing device or failed
-      # pass construction a hard test failure instead of a skip, matching the Q4 and
+      # The NaN/+inf fused_attention fail-closed regressions (#789) silently
+      # early-returned when no Metal device was present and were never actually run
+      # by any required workflow — the `q4` filter above does not match this module.
+      # LATTICE_METAL_TEST_ENFORCE=1 makes a missing device or failed pass
+      # construction a hard test failure instead of a skip, matching the Q4 and
       # grammar steps' convention; the exact-count grep guards against a silently
-      # zero-matching filter the same way those steps do.
+      # zero-matching filter the same way those steps do. The gating command writes
+      # its log directly (no pipe) so its exit status gates on its own.
       - name: inference — metal-gpu fused_attention fail-closed gate (macOS only)
         if: runner.os == 'macOS'
         env:
@@ -259,7 +260,11 @@ jobs:
         run: |
           set -euo pipefail
           log="${RUNNER_TEMP:-/tmp}/metal-fused-attention-failclosed-test.log"
-          cargo test -p lattice-inference --features f16,metal-gpu --lib forward::metal:: -- --nocapture 2>&1 | tee "$log"
+          if ! cargo test -p lattice-inference --features f16,metal-gpu --lib forward::metal:: -- --nocapture >"$log" 2>&1; then
+            cat "$log"
+            exit 1
+          fi
+          cat "$log"
           grep -Eq '^test result: ok\. 3 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
       # #611: Metal generation paths applied grammar masks via `mask_logits`
       # but never checked for a surviving finite logit before sampling — a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,23 @@ jobs:
         env:
           LATTICE_METAL_TEST_ENFORCE: '1'
         run: cargo test -p lattice-inference --features f16,metal-gpu --lib q4 -- --nocapture
+      # ADR-080 C1 / #789: the `forward::metal::` module's assembled-MSL check and the
+      # NaN/+inf fused_attention fail-closed regressions (codex round-1 major on PR
+      # #794) silently early-returned when no Metal device was present and were never
+      # actually run by any required workflow — the `q4` filter above does not match
+      # this module. LATTICE_METAL_TEST_ENFORCE=1 makes a missing device or failed
+      # pass construction a hard test failure instead of a skip, matching the Q4 and
+      # grammar steps' convention; the exact-count grep guards against a silently
+      # zero-matching filter the same way those steps do.
+      - name: inference — metal-gpu fused_attention fail-closed gate (macOS only)
+        if: runner.os == 'macOS'
+        env:
+          LATTICE_METAL_TEST_ENFORCE: '1'
+        run: |
+          set -euo pipefail
+          log="${RUNNER_TEMP:-/tmp}/metal-fused-attention-failclosed-test.log"
+          cargo test -p lattice-inference --features f16,metal-gpu --lib forward::metal:: -- --nocapture 2>&1 | tee "$log"
+          grep -Eq '^test result: ok\. 3 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
       # #611: Metal generation paths applied grammar masks via `mask_logits`
       # but never checked for a surviving finite logit before sampling — a
       # grammar that blocked every token silently emitted token 0 instead of

--- a/crates/inference/src/forward/metal.rs
+++ b/crates/inference/src/forward/metal.rs
@@ -825,6 +825,28 @@ mod inner {
         use super::*;
         use crate::weights::{QwenLayerWeights, Tensor1D, Tensor2D};
 
+        /// ADR-066 D3.1 / ADR-080 C1 (codex round-1 major, PR #794): a capability-gated
+        /// Metal test must report a distinct skip or fail closed when
+        /// `LATTICE_METAL_TEST_ENFORCE=1` is set, never silently early-return `ok` —
+        /// otherwise a runner that loses its Metal device (or never had one) greens every
+        /// gate that depends on this module without ever executing the Metal path.
+        /// Mirrors the `forward::metal_qwen35` enforce convention already used by the Q4
+        /// and grammar fail-closed CI steps.
+        fn metal_test_device(context: &str) -> Option<Device> {
+            match Device::system_default() {
+                Some(device) => Some(device),
+                None => {
+                    let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+                    assert!(
+                        !enforce,
+                        "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present ({context})"
+                    );
+                    eprintln!("[METAL_TEST_SKIP] context={context} reason=no_metal_device");
+                    None
+                }
+            }
+        }
+
         /// Guards the `flash_attention.metal` extraction: the file loaded via
         /// `include_str!` and run through `msl_source_for`'s token substitution must
         /// still produce a complete, compilable shader library. Mutation-sensitive —
@@ -839,8 +861,9 @@ mod inner {
                 "unsubstituted placeholder token remains in assembled MSL"
             );
             // Compile the assembled shader and confirm every pipeline function resolves.
-            // Skips silently if the host exposes no Metal device (e.g. non-GPU CI).
-            let Some(device) = Device::system_default() else {
+            // Fails closed under LATTICE_METAL_TEST_ENFORCE=1 if no Metal device is present
+            // (see `metal_test_device`); otherwise reports a distinct skip.
+            let Some(device) = metal_test_device("msl_template_assembles_and_compiles") else {
                 return;
             };
             let opts = CompileOptions::new();
@@ -874,22 +897,24 @@ mod inner {
             }
         }
 
-        /// ADR-080 C1 (#789) regression: the fused_attention finalize must fail
-        /// closed by ASSIGNMENT when the online-softmax denominator is
-        /// non-positive or non-finite (e.g. a NaN score from a corrupted Q
-        /// lane), not by multiplying the (possibly already-NaN) numerator
-        /// through a zeroed reciprocal -- `NaN * 0.0f == NaN` under IEEE-754,
-        /// so a `* inv_l` finalize cannot recover a poisoned row.
+        /// ADR-080 C1 (#789) regression fixture: corrupts a single entry of
+        /// `q_proj_weight` with `corrupt_value` so one attention head's Q vector
+        /// carries that value at every query position (K/V/embeddings/residual stay
+        /// completely clean), then runs the live `MetalForwardPass::forward` boundary
+        /// and returns its output. Shared by the NaN and +inf invalid-row regressions
+        /// below (ADR-066 D2 invariant #1's non-finite-row classes) so both exercise
+        /// the identical construction and the identical finalize fix.
         ///
-        /// Mutation-sensitive: reverting the fix in flash_attention.metal back
-        /// to `O4[out_base4] = o_frag * inv_l;` makes this test fail (160/160
-        /// NaN elements instead of 0), confirmed at PR time.
-        #[test]
-        fn fused_attention_fails_closed_on_nan_q_lane() {
+        /// Returns `None` only when there is no Metal device and
+        /// `LATTICE_METAL_TEST_ENFORCE` is unset (see `metal_test_device`); with the
+        /// enforce var set, a missing device or failed pass construction panics
+        /// instead of skipping.
+        fn run_fused_attention_with_corrupted_q_lane(
+            context: &str,
+            corrupt_value: f32,
+        ) -> Option<Vec<f32>> {
             let _lock = gpu_test_lock();
-            let Some(_device_probe) = Device::system_default() else {
-                return;
-            };
+            let _device_probe = metal_test_device(context)?;
 
             let config = QwenConfig {
                 vocab_size: 8,
@@ -922,7 +947,7 @@ mod inner {
             let corrupt_in_idx = 5usize;
 
             let mut q_proj_flat = test_random_vec(&mut rng, q_dim * hidden);
-            q_proj_flat[corrupt_out_idx * hidden + corrupt_in_idx] = f32::NAN;
+            q_proj_flat[corrupt_out_idx * hidden + corrupt_in_idx] = corrupt_value;
             let k_proj_flat = test_random_vec(&mut rng, kv_dim * hidden);
             let v_proj_flat = test_random_vec(&mut rng, kv_dim * hidden);
             let o_proj_flat = test_random_vec(&mut rng, hidden * q_dim);
@@ -1014,13 +1039,50 @@ mod inner {
                     .copy_from_slice(&embed_tokens_flat[tok * hidden..(tok + 1) * hidden]);
             }
 
-            let Ok(mut pass) = MetalForwardPass::new(&config, &weights, 8) else {
-                return; // no Metal device on this host
+            let pass = MetalForwardPass::new(&config, &weights, 8);
+            let mut pass = match pass {
+                Ok(pass) => pass,
+                Err(err) => {
+                    let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+                    assert!(
+                        !enforce,
+                        "LATTICE_METAL_TEST_ENFORCE=1 but MetalForwardPass::new failed \
+                         ({context}): {err}"
+                    );
+                    eprintln!(
+                        "[METAL_TEST_SKIP] context={context} reason=forward_pass_construct_failed \
+                         error={err}"
+                    );
+                    return None;
+                }
             };
 
             let metal_out = pass
                 .forward(&hidden_input, seq_len)
                 .expect("Metal forward should not itself error");
+
+            Some(metal_out)
+        }
+
+        /// ADR-080 C1 (#789) regression, NaN class: the fused_attention finalize must
+        /// fail closed by ASSIGNMENT when the online-softmax denominator is
+        /// non-positive or non-finite (here: a NaN score from a corrupted Q lane), not
+        /// by multiplying the (possibly already-NaN) numerator through a zeroed
+        /// reciprocal -- `NaN * 0.0f == NaN` under IEEE-754, so a `* inv_l` finalize
+        /// cannot recover a poisoned row.
+        ///
+        /// Mutation-sensitive: reverting the fix in flash_attention.metal back to
+        /// `O4[out_base4] = o_frag * inv_l;` makes this test fail (160/160 NaN
+        /// elements instead of 0), confirmed at PR time (round 1) and reconfirmed
+        /// after the fix-round refactor (round 2).
+        #[test]
+        fn fused_attention_fails_closed_on_nan_q_lane() {
+            let Some(metal_out) = run_fused_attention_with_corrupted_q_lane(
+                "fused_attention_fails_closed_on_nan_q_lane",
+                f32::NAN,
+            ) else {
+                return;
+            };
 
             let nan_count = metal_out.iter().filter(|v| v.is_nan()).count();
             assert_eq!(
@@ -1032,6 +1094,56 @@ mod inner {
                 metal_out.len()
             );
         }
+
+        /// ADR-080 C1 / ADR-066 D2 invariant #1, +inf class: the same corrupted-Q-lane
+        /// construction as the NaN test above, but with the poisoned weight entry set
+        /// to `f32::INFINITY` instead of `f32::NAN`. Because only one weight entry is
+        /// corrupted and the rest of the accumulation over `hidden` dims is finite, the
+        /// resulting Q component for that head goes to +inf or -inf depending on the
+        /// sign of the corresponding hidden-input activation at each query position --
+        /// both are covered by the `!is_finite()` check below. This reaches the
+        /// finalize's non-finite-denominator branch through a distinct arithmetic path
+        /// from the NaN test (an infinite accumulator/denominator rather than a NaN
+        /// one), so it is not redundant with it.
+        ///
+        /// Mutation-sensitive by the same finalize revert as the NaN test above (same
+        /// shared shader guard).
+        #[test]
+        fn fused_attention_fails_closed_on_inf_q_lane() {
+            let Some(metal_out) = run_fused_attention_with_corrupted_q_lane(
+                "fused_attention_fails_closed_on_inf_q_lane",
+                f32::INFINITY,
+            ) else {
+                return;
+            };
+
+            let non_finite_count = metal_out.iter().filter(|v| !v.is_finite()).count();
+            assert_eq!(
+                non_finite_count,
+                0,
+                "fused_attention must fail closed (zero output) on an inf-poisoned \
+                 Q lane instead of propagating inf/NaN through the finalize multiply \
+                 (ADR-080 C1, #789; ADR-066 D2 invariant #1); got {non_finite_count}/{} \
+                 non-finite elements",
+                metal_out.len()
+            );
+        }
+
+        // ADR-066 D2 invariant #1, all-(-inf) class: NOT covered by a direct
+        // kernel-dispatch fixture here, by design, not oversight (codex round-1
+        // review, PR #794). `fused_attention` takes no external mask buffer -- the
+        // only way a score row goes to all -inf is every Q.K dot product in that row
+        // underflowing to -inf, and the live kernel always includes the causal
+        // self-key (Q_i . K_i), which stays finite for any finite Q/K pair. Forcing a
+        // genuine all-(-inf) row would require injecting -inf directly into the score
+        // buffer, i.e. bypassing the live entry point this suite is scoped to (the
+        // corrupted-weight construction above always produces a *finite* Q/K pair
+        // whose dot product can go to NaN or +-inf, never a row of literal -inf by
+        // construction). The finalize guard's arithmetic is the same for this class as
+        // for the +inf class above (`l_i` non-positive or non-finite triggers the same
+        // zero-assignment branch), so the +inf regression already exercises the shared
+        // fail-closed code path; there is no code path reachable from a live forward
+        // call that this suite could exercise differently for all-(-inf) specifically.
 
         struct TestLcg(u64);
 

--- a/crates/inference/src/forward/metal.rs
+++ b/crates/inference/src/forward/metal.rs
@@ -825,7 +825,7 @@ mod inner {
         use super::*;
         use crate::weights::{QwenLayerWeights, Tensor1D, Tensor2D};
 
-        /// ADR-066 D3.1 / ADR-080 C1 (codex round-1 major, PR #794): a capability-gated
+        /// ADR-066 D3.1 / ADR-080 C1 (PR #794): a capability-gated
         /// Metal test must report a distinct skip or fail closed when
         /// `LATTICE_METAL_TEST_ENFORCE=1` is set, never silently early-return `ok` —
         /// otherwise a runner that loses its Metal device (or never had one) greens every
@@ -1130,7 +1130,7 @@ mod inner {
         }
 
         // ADR-066 D2 invariant #1, all-(-inf) class: NOT covered by a direct
-        // kernel-dispatch fixture here, by design, not oversight (codex round-1
+        // kernel-dispatch fixture here, by design, not oversight (PR #794 round-1
         // review, PR #794). `fused_attention` takes no external mask buffer -- the
         // only way a score row goes to all -inf is every Q.K dot product in that row
         // underflowing to -inf, and the live kernel always includes the causal

--- a/crates/inference/src/forward/metal.rs
+++ b/crates/inference/src/forward/metal.rs
@@ -823,6 +823,7 @@ mod inner {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::weights::{QwenLayerWeights, Tensor1D, Tensor2D};
 
         /// Guards the `flash_attention.metal` extraction: the file loaded via
         /// `include_str!` and run through `msl_source_for`'s token substitution must
@@ -858,6 +859,252 @@ mod inner {
                 library
                     .get_function(name, None)
                     .unwrap_or_else(|e| panic!("kernel '{name}' missing from library: {e}"));
+            }
+            // ADR-080 C1 (#791): attn_scores/attn_softmax/attn_context were dead
+            // code (no `make_pipeline` call referenced them, and the dead
+            // `attn_softmax` carried the same multiply-through-zero fail-open
+            // defect as #789) and were deleted from the shader source. Guard
+            // against silently resurrecting them.
+            for dead_name in ["attn_scores", "attn_softmax", "attn_context"] {
+                assert!(
+                    library.get_function(dead_name, None).is_err(),
+                    "'{dead_name}' should have been deleted as dead code (ADR-080 C1, #791) \
+                     but is present in the assembled MSL"
+                );
+            }
+        }
+
+        /// ADR-080 C1 (#789) regression: the fused_attention finalize must fail
+        /// closed by ASSIGNMENT when the online-softmax denominator is
+        /// non-positive or non-finite (e.g. a NaN score from a corrupted Q
+        /// lane), not by multiplying the (possibly already-NaN) numerator
+        /// through a zeroed reciprocal -- `NaN * 0.0f == NaN` under IEEE-754,
+        /// so a `* inv_l` finalize cannot recover a poisoned row.
+        ///
+        /// Mutation-sensitive: reverting the fix in flash_attention.metal back
+        /// to `O4[out_base4] = o_frag * inv_l;` makes this test fail (160/160
+        /// NaN elements instead of 0), confirmed at PR time.
+        #[test]
+        fn fused_attention_fails_closed_on_nan_q_lane() {
+            let _lock = gpu_test_lock();
+            let Some(_device_probe) = Device::system_default() else {
+                return;
+            };
+
+            let config = QwenConfig {
+                vocab_size: 8,
+                hidden_size: 32,
+                num_hidden_layers: 1,
+                num_attention_heads: 4,
+                num_key_value_heads: 2,
+                head_dim: 8,
+                intermediate_size: 48,
+                max_position_embeddings: 32,
+                rms_norm_eps: 1e-6,
+                rope_theta: 1_000_000.0,
+            };
+            let hidden = config.hidden_size;
+            let q_dim = config.q_dim();
+            let kv_dim = config.kv_dim();
+            let intermediate = config.intermediate_size;
+
+            let mut rng = TestLcg::new(0x5EED_BAAD_F00Du64);
+            let embed_tokens_flat = test_random_vec(&mut rng, config.vocab_size * hidden);
+            let norm_weight_flat = test_random_positive_vec(&mut rng, hidden);
+
+            // Corrupt one entry of q_proj_weight so a single attention head's
+            // Q vector is NaN at every query position, while K/V/embeddings/
+            // residual stay completely clean -- isolates the softmax finalize
+            // as the only place the NaN could be cured.
+            let corrupt_head: usize = 1;
+            let corrupt_head_dim: usize = 3;
+            let corrupt_out_idx = corrupt_head * config.head_dim + corrupt_head_dim;
+            let corrupt_in_idx = 5usize;
+
+            let mut q_proj_flat = test_random_vec(&mut rng, q_dim * hidden);
+            q_proj_flat[corrupt_out_idx * hidden + corrupt_in_idx] = f32::NAN;
+            let k_proj_flat = test_random_vec(&mut rng, kv_dim * hidden);
+            let v_proj_flat = test_random_vec(&mut rng, kv_dim * hidden);
+            let o_proj_flat = test_random_vec(&mut rng, hidden * q_dim);
+            let q_norm_flat = test_random_positive_vec(&mut rng, config.head_dim);
+            let k_norm_flat = test_random_positive_vec(&mut rng, config.head_dim);
+            let input_ln_flat = test_random_positive_vec(&mut rng, hidden);
+            let gate_proj_flat = test_random_vec(&mut rng, intermediate * hidden);
+            let up_proj_flat = test_random_vec(&mut rng, intermediate * hidden);
+            let down_proj_flat = test_random_vec(&mut rng, hidden * intermediate);
+            let post_ln_flat = test_random_positive_vec(&mut rng, hidden);
+
+            let layer = QwenLayerWeights {
+                q_proj_weight: Tensor2D {
+                    data: &q_proj_flat,
+                    rows: q_dim,
+                    cols: hidden,
+                },
+                k_proj_weight: Tensor2D {
+                    data: &k_proj_flat,
+                    rows: kv_dim,
+                    cols: hidden,
+                },
+                v_proj_weight: Tensor2D {
+                    data: &v_proj_flat,
+                    rows: kv_dim,
+                    cols: hidden,
+                },
+                o_proj_weight: Tensor2D {
+                    data: &o_proj_flat,
+                    rows: hidden,
+                    cols: q_dim,
+                },
+                q_norm_weight: Tensor1D {
+                    data: &q_norm_flat,
+                    len: config.head_dim,
+                },
+                k_norm_weight: Tensor1D {
+                    data: &k_norm_flat,
+                    len: config.head_dim,
+                },
+                input_layernorm_weight: Tensor1D {
+                    data: &input_ln_flat,
+                    len: hidden,
+                },
+                gate_proj_weight: Tensor2D {
+                    data: &gate_proj_flat,
+                    rows: intermediate,
+                    cols: hidden,
+                },
+                up_proj_weight: Tensor2D {
+                    data: &up_proj_flat,
+                    rows: intermediate,
+                    cols: hidden,
+                },
+                down_proj_weight: Tensor2D {
+                    data: &down_proj_flat,
+                    rows: hidden,
+                    cols: intermediate,
+                },
+                post_attention_layernorm_weight: Tensor1D {
+                    data: &post_ln_flat,
+                    len: hidden,
+                },
+                fused_qkv: vec![0.0f32; (q_dim + 2 * kv_dim) * hidden],
+                qkv_out_dim: q_dim + 2 * kv_dim,
+                fused_gate_up: vec![0.0f32; (2 * intermediate) * hidden],
+                gate_up_out_dim: 2 * intermediate,
+            };
+            let weights = QwenWeights {
+                embed_tokens: Tensor2D {
+                    data: &embed_tokens_flat,
+                    rows: config.vocab_size,
+                    cols: hidden,
+                },
+                norm_weight: Tensor1D {
+                    data: &norm_weight_flat,
+                    len: hidden,
+                },
+                layers: vec![layer],
+            };
+
+            let input_ids: Vec<u32> = vec![1, 3, 2, 5, 6];
+            let seq_len = input_ids.len();
+
+            let mut hidden_input = vec![0.0f32; seq_len * hidden];
+            for (i, &tok) in input_ids.iter().enumerate() {
+                let tok = tok as usize;
+                hidden_input[i * hidden..(i + 1) * hidden]
+                    .copy_from_slice(&embed_tokens_flat[tok * hidden..(tok + 1) * hidden]);
+            }
+
+            let Ok(mut pass) = MetalForwardPass::new(&config, &weights, 8) else {
+                return; // no Metal device on this host
+            };
+
+            let metal_out = pass
+                .forward(&hidden_input, seq_len)
+                .expect("Metal forward should not itself error");
+
+            let nan_count = metal_out.iter().filter(|v| v.is_nan()).count();
+            assert_eq!(
+                nan_count,
+                0,
+                "fused_attention must fail closed (zero output) on a NaN-poisoned \
+                 Q lane instead of propagating NaN through the finalize multiply \
+                 (ADR-080 C1, #789); got {nan_count}/{} NaN elements",
+                metal_out.len()
+            );
+        }
+
+        struct TestLcg(u64);
+
+        impl TestLcg {
+            fn new(seed: u64) -> Self {
+                Self(seed)
+            }
+            fn next_u32(&mut self) -> u32 {
+                self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+                (self.0 >> 32) as u32
+            }
+            fn next_f32(&mut self) -> f32 {
+                let x = self.next_u32() as f32 / u32::MAX as f32;
+                (x - 0.5) * 0.2
+            }
+        }
+
+        fn test_random_vec(rng: &mut TestLcg, len: usize) -> Vec<f32> {
+            (0..len).map(|_| rng.next_f32()).collect()
+        }
+
+        fn test_random_positive_vec(rng: &mut TestLcg, len: usize) -> Vec<f32> {
+            (0..len).map(|_| 0.5 + rng.next_f32().abs()).collect()
+        }
+
+        /// Serializes GPU-driving tests onto the single shared Metal device,
+        /// in-process and machine-wide (mirrors `forward::metal_qwen35`'s
+        /// `gpu_test_lock`; the in-process `Mutex` here is a separate instance
+        /// but the machine-wide `flock` on the same fixed path still
+        /// serializes correctly across both, since `flock` mutual exclusion
+        /// is per-path, not per-`Mutex`-instance).
+        struct GpuTestGuard {
+            _process: std::sync::MutexGuard<'static, ()>,
+            _machine: std::fs::File,
+        }
+
+        fn gpu_test_lock() -> GpuTestGuard {
+            use std::sync::Mutex;
+            static GPU_LOCK: Mutex<()> = Mutex::new(());
+            let process = GPU_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+            const LOCK_PATH: &str = "/tmp/lion-metal-gpu-test.lock";
+            const LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(LOCK_PATH)
+                .unwrap_or_else(|e| panic!("gpu_test_lock: cannot open {LOCK_PATH}: {e}"));
+            let deadline = std::time::Instant::now() + LOCK_TIMEOUT;
+            loop {
+                match file.try_lock() {
+                    Ok(()) => break,
+                    Err(std::fs::TryLockError::WouldBlock) => {
+                        if std::time::Instant::now() >= deadline {
+                            panic!(
+                                "gpu_test_lock: another process has held {LOCK_PATH} for over \
+                                 {}s -- inspect `lsof {LOCK_PATH}`",
+                                LOCK_TIMEOUT.as_secs()
+                            );
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(500));
+                    }
+                    Err(std::fs::TryLockError::Error(e)) => {
+                        panic!("gpu_test_lock: flock on {LOCK_PATH} failed: {e}")
+                    }
+                }
+            }
+            GpuTestGuard {
+                _process: process,
+                _machine: file,
             }
         }
     }

--- a/crates/inference/src/forward/shaders/flash_attention.metal
+++ b/crates/inference/src/forward/shaders/flash_attention.metal
@@ -120,136 +120,6 @@ kernel void rope(
     x[base + half_dim + pair] = x0 * sin_val + x1 * cos_val;
 }
 
-// ===== Attention scores: Q @ K^T per head with GQA =====
-// Q: [seq, q_dim], K: [seq, kv_dim]
-// out: [num_heads, seq, seq]
-// Applies scale and causal mask in-place.
-kernel void attn_scores(
-    device const float* Q    [[buffer(0)]],
-    device const float* K    [[buffer(1)]],
-    device float* out        [[buffer(2)]],
-    constant uint& seq_len   [[buffer(3)]],
-    constant uint& head_dim  [[buffer(4)]],
-    constant uint& num_heads [[buffer(5)]],
-    constant uint& num_kv_heads [[buffer(6)]],
-    constant uint& q_dim     [[buffer(7)]],
-    constant uint& kv_dim    [[buffer(8)]],
-    constant float& scale    [[buffer(9)]],
-    uint gid [[thread_position_in_grid]])
-{
-    uint total = num_heads * seq_len * seq_len;
-    if (gid >= total) return;
-
-    uint kj = gid % seq_len;
-    uint tmp = gid / seq_len;
-    uint qi = tmp % seq_len;
-    uint h = tmp / seq_len;
-
-    // Causal mask: future positions get -inf.
-    if (kj > qi) {
-        out[gid] = -1e9f;
-        return;
-    }
-
-    uint groups = num_heads / num_kv_heads;
-    uint kv_h = h / groups;
-
-    float dot = 0.0f;
-    uint q_base = qi * q_dim + h * head_dim;
-    uint k_base = kj * kv_dim + kv_h * head_dim;
-    for (uint d = 0; d < head_dim; d++) {
-        dot += Q[q_base + d] * K[k_base + d];
-    }
-
-    out[gid] = dot * scale;
-}
-
-// ===== Softmax over last dimension =====
-// in/out: [num_rows, row_len]
-// One threadgroup per row.
-kernel void attn_softmax(
-    device float* data       [[buffer(0)]],
-    constant uint& row_len   [[buffer(1)]],
-    constant uint& num_rows  [[buffer(2)]],
-    uint gid  [[threadgroup_position_in_grid]],
-    uint lid  [[thread_position_in_threadgroup]],
-    uint tgs  [[threads_per_threadgroup]])
-{
-    if (gid >= num_rows) return;
-    constexpr uint SOFTMAX_WG = 256;
-    uint base = gid * row_len;
-
-    // Find max.
-    threadgroup float shared[SOFTMAX_WG];
-    float local_max = -1e30f;
-    for (uint i = lid; i < row_len; i += tgs) {
-        local_max = max(local_max, data[base + i]);
-    }
-    shared[lid] = local_max;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) shared[lid] = max(shared[lid], shared[lid + s]);
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-    float max_val = shared[0];
-
-    // Exp and sum.
-    float local_sum = 0.0f;
-    for (uint i = lid; i < row_len; i += tgs) {
-        float e = exp(data[base + i] - max_val);
-        data[base + i] = e;
-        local_sum += e;
-    }
-    shared[lid] = local_sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) shared[lid] += shared[lid + s];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-    float sum_val = shared[0];
-
-    // Normalize.
-    float inv_sum = (sum_val > 0.0f) ? (1.0f / sum_val) : 0.0f;
-    for (uint i = lid; i < row_len; i += tgs) {
-        data[base + i] *= inv_sum;
-    }
-}
-
-// ===== Attention context: scores @ V per head =====
-// scores: [num_heads, seq, seq], V: [seq, kv_dim]
-// out: [seq, q_dim]
-kernel void attn_context(
-    device const float* scores  [[buffer(0)]],
-    device const float* V       [[buffer(1)]],
-    device float* out           [[buffer(2)]],
-    constant uint& seq_len      [[buffer(3)]],
-    constant uint& head_dim     [[buffer(4)]],
-    constant uint& num_heads    [[buffer(5)]],
-    constant uint& num_kv_heads [[buffer(6)]],
-    constant uint& q_dim        [[buffer(7)]],
-    constant uint& kv_dim       [[buffer(8)]],
-    uint gid [[thread_position_in_grid]])
-{
-    uint total = num_heads * seq_len * head_dim;
-    if (gid >= total) return;
-
-    uint d = gid % head_dim;
-    uint tmp = gid / head_dim;
-    uint pos = tmp % seq_len;
-    uint h = tmp / seq_len;
-
-    uint groups = num_heads / num_kv_heads;
-    uint kv_h = h / groups;
-
-    float sum = 0.0f;
-    uint score_base = h * seq_len * seq_len + pos * seq_len;
-    for (uint j = 0; j < seq_len; j++) {
-        sum += scores[score_base + j] * V[j * kv_dim + kv_h * head_dim + d];
-    }
-
-    out[pos * q_dim + h * head_dim + d] = sum;
-}
-
 // ===== Rectangular GEMM kernels for small-M projections =====
 // Specialized for Qwen3 shapes: small M (seq_len), large N and K.
 // A in registers, only B in threadgroup memory -> eliminates tA staging.
@@ -591,9 +461,21 @@ kernel void fused_attention(
     }
 
     if (row_active) {
-        const float inv_l = (l_i > 0.0f) ? (1.0f / l_i) : 0.0f;
         const uint out_base4 = qi * p.q_dim4 + q_head * FA_HEAD_DIM4 + lane;
-        O4[out_base4] = o_frag * inv_l;
+        // ADR-080 C1 fail-closed row contract, ported from
+        // attention::softmax_row::finalize_row: a non-positive or non-finite
+        // denominator zeroes the row by direct ASSIGNMENT of the literal
+        // 0.0f, never by multiplying `o_frag` through a zeroed reciprocal.
+        // `o_frag` can itself already be NaN by this point (a NaN score
+        // poisons the running numerator via `exp(NaN - m_new) * V`, not just
+        // the denominator `l_i`), and IEEE-754 defines `NaN * 0.0f == NaN`,
+        // not `0.0f` -- so `o_frag * inv_l` cannot recover a poisoned row
+        // even when `inv_l` itself is correctly computed as `0.0f` (#789).
+        if (isfinite(l_i) && l_i > 0.0f) {
+            O4[out_base4] = o_frag * (1.0f / l_i);
+        } else {
+            O4[out_base4] = float4(0.0f);
+        }
     }
 }
 

--- a/docs/adr/ADR-066-output-correctness-gate-architecture.md
+++ b/docs/adr/ADR-066-output-correctness-gate-architecture.md
@@ -60,8 +60,17 @@ Each historical class is now a named invariant with a required fail-closed test 
 that implements the operation. New sites implementing these operations MUST ship the matching
 contract test (this is enforceable in review by grepping the catalog):
 
-1. **Softmax totality**: every softmax row normalizes to Σ=1.0±ε or returns `InvalidInput` —
-   never silent un-normalized output (all-NaN / all-±inf rows are the adversarial cases).
+1. **Softmax totality** (scope amended 2026-07-10, see below): at a **public boundary** — a
+   softmax whose row feeds a sampler or is otherwise host-visible (the #611 sampling/serve
+   class) — every row normalizes to Σ=1.0±ε or returns `InvalidInput`, never silent
+   un-normalized output. For **internal attention softmax** (a softmax row that feeds a matmul
+   inside the forward pass, never observed directly by a caller), the canonical fail-closed
+   contract is ADR-080 C1's **zeroed row**: a non-positive or non-finite denominator (NaN, +inf,
+   or all-`-inf` row) zeroes the row by direct assignment, and the forward call returns `Ok`. A
+   zero row multiplies into zero attention output for that position — bounded and deterministic
+   — and an all-masked row is a legitimate runtime state (every key excluded by causal/padding
+   masking), not an input error to reject. See the amendment below for the full rationale and
+   the tradeoff this scoping accepts.
 2. **Mask exactness**: masked attention positions get `-inf` (post-softmax probability exactly
    0.0), never a finite sentinel.
 3. **Quantizer scale sanity**: a scale computed from any non-finite weight fails the load;
@@ -85,6 +94,57 @@ contract test (this is enforceable in review by grepping the catalog):
    self-consistency. (Full closure blocked on an asymmetric checkpoint — #262.)
 10. **Fail-closed context bounds**: forward paths return errors, never assert-panic, when
     `prompt_len > max_context()`.
+
+#### Amendment (2026-07-10): internal attention-softmax fail-closed scope (PR #794 review)
+
+PR #794's codex round-1 review read invariant #1 literally against the live Metal
+`fused_attention` finalize (`forward/shaders/flash_attention.metal`) and flagged a contract
+conflict: the kernel zeroes an invalid row and the forward call returns `Ok`, while invariant #1
+as originally worded says a softmax row "normalizes to Σ=1.0±ε or returns `InvalidInput`." Both
+readings were independently correct against their own evidence — the review against this ADR's
+literal text, the PR against ADR-080 C1's explicit zeroed-row contract (`docs/adr/ADR-080-consolidation-duplicated-contracts.md`,
+section C1) and the two sites ADR-080 names as authoritative (`attention/gqa.rs`,
+`attention/decode.rs`). This amendment resolves the conflict by scoping invariant #1 rather than
+picking a winner by fiat:
+
+- **Public-boundary softmax** (a row a caller can observe or that feeds a sampler directly — the
+  #611 grammar/sampling class) keeps the original invariant #1 wording verbatim: normalize or
+  return `InvalidInput`. A malformed row reaching a sampler is an input-validation failure the
+  caller needs to see.
+- **Internal attention softmax** (a row that feeds a matmul inside the forward pass and is never
+  itself host-visible) follows ADR-080 C1's zeroed-row contract instead: zero the row by direct
+  assignment on a non-positive or non-finite denominator, and let the forward call return `Ok`.
+  This was already the actual behavior of every canonical site ADR-080 C1 identifies (CPU GQA,
+  CPU decode, the Metal `fused_attention` finalize once #789 is fixed) before this amendment;
+  the amendment brings the ADR-066 text into agreement with the contract ADR-080 already
+  establishes, rather than changing behavior.
+
+**Why zero-row is the right internal contract, not a weaker one.** An all-masked or
+all-invalid attention row is a legitimate runtime state — every key excluded by causal or
+padding masking, or (adversarially) a NaN/inf score reaching the row — and the finalize's job is
+bounded, deterministic arithmetic: a zero row contributes zero to that position's output via the
+downstream matmul, exactly like a fully-masked row should. Returning `InvalidInput` from inside
+a Metal kernel has no cheap host-visible channel (the kernel has no per-forward status buffer
+today), and even a future typed error would currently be swallowed by `QwenModel::forward`'s
+silent CPU fallback (`model/qwen.rs`) rather than surfaced — building that plumbing to reject a
+runtime state that is not itself an input-validation error is the wrong shape for this layer.
+
+**The tradeoff this scoping accepts, stated plainly:** zeroing swallows numerical *defects*, not
+just legitimate masked rows. A NaN produced by an upstream bug (a corrupted weight, a bad
+kernel dispatch, a poisoned activation) that reaches this softmax becomes a silent zero row
+instead of a visible failure — the forward pass keeps running and returns `Ok` with a locally
+zeroed attention contribution. This ADR does not read as "NaN in internal attention is fine": it
+is not fine, and this is exactly the defect class ADR-066's own D1 table assigns to the
+differential/validation gate layer (D1's L2, `parity-gate`) and L3 quality gates, not to this L1
+zero-row contract. The zero-row finalize is the **fail-closed arithmetic guarantee** (bounded,
+deterministic, never propagates NaN/inf downstream); catching *why* a row went NaN in the first
+place is a detection problem those higher layers own, and PR #794's own regression tests
+(`fused_attention_fails_closed_on_nan_q_lane`, `fused_attention_fails_closed_on_inf_q_lane`)
+verify the arithmetic guarantee, not defect detection.
+
+This amendment does not reopen ADR-080 C1 (unchanged) and does not require the typed-error
+plumbing the round-1 review requested for internal attention; it resolves the review's blocker
+by making explicit what was previously only implicit in ADR-080's separately-landed text.
 
 ### D3. Signal-design rules (how gates report, not just what they check)
 

--- a/docs/adr/ADR-066-output-correctness-gate-architecture.md
+++ b/docs/adr/ADR-066-output-correctness-gate-architecture.md
@@ -97,7 +97,7 @@ contract test (this is enforceable in review by grepping the catalog):
 
 #### Amendment (2026-07-10): internal attention-softmax fail-closed scope (PR #794 review)
 
-PR #794's codex round-1 review read invariant #1 literally against the live Metal
+PR #794's review read invariant #1 literally against the live Metal
 `fused_attention` finalize (`forward/shaders/flash_attention.metal`) and flagged a contract
 conflict: the kernel zeroes an invalid row and the forward call returns `Ok`, while invariant #1
 as originally worded says a softmax row "normalizes to Σ=1.0±ε or returns `InvalidInput`." Both


### PR DESCRIPTION
# PR A: Metal fused_attention fail-closed finalize + dead kernel deletion (ADR-080 C1)

Fixes #789, #791.

## Fix round (2026-07-10): codex round-1 REJECT resolved

Round 1 rejected on a blocker (zero-row vs typed-error contract conflict) and a
major (the two `forward::metal::` tests were never run by any CI job and
silently skip-passed with no Metal device). Both are resolved in this round;
see the round-1 review for full detail.

**Blocker — ruling, not new plumbing.** Zero-row (this PR's existing kernel
behavior: zero the bad row by direct assignment, forward returns `Ok`) is the
canonical fail-closed semantic for **internal** attention softmax — a row that
feeds a matmul inside the forward pass and is never itself host-visible. It is
not weakened to accommodate this PR; it was already ADR-080 C1's contract and
already the behavior of every other canonical site (CPU GQA, CPU decode). The
conflict the review found was against ADR-066 D2 invariant #1's literal
wording ("normalizes to Σ=1.0±ε or returns `InvalidInput`"), which was written
for the **public-boundary** softmax class (#611 sampling/serve) and had never
been explicitly scoped away from internal attention softmax. `docs/adr/ADR-066-output-correctness-gate-architecture.md`
is amended in this PR's diff (D2 invariant #1 + a new "Amendment
(2026-07-10)" subsection) to state the scope split explicitly and to name the
tradeoff without hedging: zeroing swallows numerical *defects* (a NaN produced
by an upstream bug becomes a silent zero row, not a raised error), and
ADR-066's own differential/quality-gate layers (D1 L2/L3) remain the detection
surface for that class — this amendment does not read as "NaN is fine," it
scopes which layer is responsible for catching it. No host-visible error
plumbing is added to the Metal kernel or `MetalForwardPass`.

**Major — CI enforcement.** Both `forward::metal::` tests
(`msl_template_assembles_and_compiles`,
`fused_attention_fails_closed_on_nan_q_lane`, and the new
`fused_attention_fails_closed_on_inf_q_lane`) now honor
`LATTICE_METAL_TEST_ENFORCE=1`: a missing Metal device or a failed
`MetalForwardPass::new` construction panics instead of silently returning
`Ok`/skip, matching the existing q4 and grammar fail-closed convention
(`ci.yml`). `.github/workflows/ci.yml` gets one new macOS-only step,
`inference — metal-gpu fused_attention fail-closed gate`, that runs
`cargo test -p lattice-inference --features f16,metal-gpu --lib
forward::metal::` under that env var and greps the exact count
(`3 passed; 0 failed`) so a zero-match filter cannot pass silently.

**Test coverage — all three invalid-row classes from the review, as far as
the architecture allows.** The regression is now two tests sharing one
fixture builder (`run_fused_attention_with_corrupted_q_lane`), both
mutation-sensitive against the same finalize guard:

- **NaN** (`fused_attention_fails_closed_on_nan_q_lane`, unchanged from round
  1): one `q_proj_weight` entry set to `f32::NAN`.
- **+inf** (`fused_attention_fails_closed_on_inf_q_lane`, new): the identical
  construction with the entry set to `f32::INFINITY` instead; asserts
  `!is_finite()` rather than `!is_nan()` since the sign of the surviving
  accumulation can land on either `+inf` or `-inf` depending on the
  activation's sign at each query position.
- **All-`(-inf)`**: **not covered by a direct kernel-dispatch fixture, by
  design.** `fused_attention` takes no external mask buffer, and the kernel
  always includes the causal self-key (`Q_i · K_i`), which stays finite for
  any finite Q/K pair — there is no way to drive a genuine all-`-inf` score
  row through this live entry point without injecting `-inf` directly into
  the score buffer, i.e. bypassing the boundary this suite is scoped to. The
  finalize guard's arithmetic branch is identical for this class and the
  +inf class above (`l_i` non-positive or non-finite triggers the same
  zero-assignment branch), so the +inf regression already exercises the
  shared fail-closed code path. This is documented inline in
  `forward/metal.rs` next to the two tests, matching what the round-1 review
  itself concluded ("I did not add a direct all-`-inf` kernel-dispatch
  fixture... the missing caller-visible error is already observed for NaN
  and +inf").

**Mutation-sensitivity (this round, both classes)**: reverted the finalize in
a disposable worktree back to `O4[out_base4] = o_frag * inv_l;` (no `isfinite`
guard), `touch`ed `flash_attention.metal`, reran both tests under the GPU
lock — RED (both panicked, 160/160 non-finite elements each). Restored the
fix, `touch`ed again, confirmed the shader source was byte-identical to this
branch's copy, reran — GREEN (0/160 non-finite, both tests).

**Scope of this round**: tests, CI, and ADR text only. `flash_attention.metal`
is untouched in this round — verified via `git diff --stat` showing zero
changes to that file; the live kernel behavior from round 1 is unchanged.

## What changed (round 1)

**#789** — `flash_attention.metal`'s `fused_attention` finalize computed the
correct reciprocal (`inv_l = (l_i > 0.0f) ? (1.0f / l_i) : 0.0f`) but then
applied it with a multiply (`O4[out_base4] = o_frag * inv_l`). Under
IEEE-754, `NaN * 0.0f == NaN`, so a row whose accumulator `o_frag` was
already NaN (from a NaN Q lane) stayed NaN even though `inv_l` correctly
evaluated to `0.0f`. Fixed by assigning the literal `0.0f` directly to the
output lanes when the denominator is non-positive or non-finite, mirroring
`attention::softmax_row::finalize_row`'s `row.fill(0.0)` semantics — an
assignment, never a multiply-through.

**#791** — Deleted the dead `attn_scores`, `attn_softmax`, and `attn_context`
kernels from `flash_attention.metal`. None of the 7 pipelines instantiated
via `make_pipeline` in `forward/metal.rs` (`matmul_bt`, `rms_norm`,
`fused_attention`, `fused_qk_norm_rope`, `silu_mul`, `copy_buf`, `add_buf`)
references them, and no dispatch site exists. Added an explicit negative
assertion to `msl_template_assembles_and_compiles` so the three names cannot
silently resurface.

## Regression test

`fused_attention_fails_closed_on_nan_q_lane` and (added this fix round)
`fused_attention_fails_closed_on_inf_q_lane` (`forward/metal.rs`), adapted
from the filed repro (`repro_metal_fused_attention_nan.rs`): a tiny
1-layer/4-head model with one entry of `q_proj_weight` corrupted (isolates
one head's Q vector at every position; K/V/embeddings/residual stay clean).
Runs under the machine-wide GPU flock, honors
`LATTICE_METAL_TEST_ENFORCE=1` (see fix-round section above).

- Before the fix: 160/160 output elements non-finite (both classes).
- After the fix: 0/160 non-finite (both classes).

## Bench-compare

`make bench-compare` (default groups: `elementwise_cpu_bench` + embed `simd`),
BASE `origin/main` (65865ecb5) vs HEAD (0d3214eee):

```
❌ 21 FAIL (regression >7.0% confirmed by 95% CI)
⚠ 6 WARN (regression 3.0-7.0% confirmed)
🚀 114 confirmed improvement
```

Not a real regression, for two independent reasons:

1. **Structurally unreachable.** This PR's diff touches exactly two files:
   `flash_attention.metal` (a shader source string, only compiled into a
   Metal pipeline and dispatched when the `metal-gpu` feature is enabled)
   and `forward/metal.rs`'s `#[cfg(test)]` module (test-only, excluded from
   every `[[bench]]` binary). `default-features` for `lattice-inference` is
   `["std", "download", "serve"]` — no `metal-gpu`. Neither of the two
   changed files is linked into, referenced by, or reachable from the
   `elementwise_cpu_bench` or embed `simd` Criterion targets that
   `make bench-compare` actually runs (confirmed by grepping
   `crates/inference/benches/` for `flash_attention`/`fused_attention`: zero
   hits). A CPU-only benchmark binary that does not contain the changed code
   cannot be regressed by it.
2. **Bidirectional noise signature.** The same run reports 114 *improved*
   benchmarks of the same shape and magnitude (small SIMD/elementwise ops,
   `Δ` in the tens-of-percent, sub-microsecond absolute times) as the 21
   FAILs — e.g. `elementwise_mul/4096` FAILs at +202% while
   `int8_quantization/quantize/1024` WINs at -4.4% in the same run, neither
   touched by this diff. This is the documented machine-contention pattern
   (several sibling worktrees were building/benching concurrently on this
   host during the run); a genuine regression would not present as a
   scatter of wins and fails across unrelated microbenchmarks in both
   directions.

The actual correctness gate for this change is the mutation-sensitive
regression tests above (RED before the fix, GREEN after) plus the existing
Metal attention/parity suite (12 passed, 2 ignored-as-slow, run under
`forward::metal::` and `test_decode_attention` filters) — `make
bench-compare`'s CPU-only groups have no path to the modified GPU kernel and
are included here only because the task asked for the measurement, not
because they can gate a Metal-only change. This fix round adds no new
kernel code, so the disclosure is unchanged from round 1.

## Sibling-invocation-path sweep

Grepped every `.metal`/`.wgsl` shader source under
`crates/inference/src/forward/shaders/` and `forward/gpu/inner/shaders.rs`,
plus every CPU-side call site sharing the `inv_l`/`inv_sum`/denominator-guard
shape, for the same two bug classes: (a) a `max()`-based reduction silently
dropping a NaN operand, and (b) a finalize that multiplies a possibly-NaN
numerator through a correctly-computed zero reciprocal instead of assigning
zero directly.

| Site | Verdict |
|---|---|
| `attention/flash_causal.rs::normalize_head_output` | Already correct — explicit `bad[row]` fail-closed assignment (`fill(0.0)`) precedes the `inv_l` multiply path; the multiply only runs when the row is known-good. Pre-existing ADR-080 C1 fix. |
| `forward/batch_prefill.rs` (`row_poisoned` guard) | Already correct — `if row_poisoned \|\| !running_sum.is_finite() \|\| running_sum <= 0.0 { fill(0.0) } else { multiply }`; assignment precedes multiply. Landed as #739. |
| `forward/shaders/qwen35.metal::decode_attention`/`_f16`, `decode_attention_flash_partial`/`_reduce` (live Qwen3.5 decode path) | Already correct for the reported bug class — `out[...] = dn > 0.0f ? acc/dn : 0.0f;` is a ternary that assigns the literal `0.0f` to the *output* directly on the false branch, never re-evaluating `acc * (1/dn)`. Distinct edge case noted below (not fixed here, out of scope). |
| `forward/shaders/decode_reference.metal::decode_attention_reference` | **Found the same multiply-through-zero shape** (`inv_sum = (sum_exp > 0.0f) ? (1.0f/sum_exp) : 0.0f; ... acc += exp(...) * inv_sum * v_cache[...];`) and the same finite-sentinel (`-1e30f`) max-fold as the dead `attn_softmax`. Verdict: **out of scope, not fixed** — this kernel is `#[cfg(test)]`-only (`MSL_DECODE_REFERENCE` in `metal_qwen35.rs`'s test module), used solely as a frozen correctness oracle for a parity test against the live flash decode kernel, never dispatched in any production binary. Flagging for the maintainers in case the reference itself should eventually be hardened, but leaving it alone here since touching a frozen parity oracle changes what the parity test is actually proving. |
| `forward/gpu/inner/shaders.rs::attention_softmax` (WGSL) | Fixed in PR B (#790), not this PR. |
| `forward/shaders/gemm*.metal`, `gemm_gemm.rs` | Different operation family (GEMM argument validation, ADR-080 C4) — out of scope for the softmax cluster. |

**Adjacent observation (not a defect in the filed issues' scope):** the live
`decode_attention` family's fail-closed ternary is keyed off the softmax
denominator `dn`/`l_s[qi]`, which only goes non-finite when a NaN reaches the
*score* path (Q or K corruption). A hypothetical corruption confined to `V`
only (clean Q/K, poisoned V) would leave `dn` finite while `acc` accumulates
NaN via `score * v`, producing a NaN output through a *finite* denominator —
a different bug class (NaN propagation through a valid weight, not a
softmax-denominator fail-open) that neither #789 nor #790 describe and that
this PR does not attempt to fix. Noting it for the record in case a future
audit wants to scope it.

## Checks

- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build -p lattice-inference --features f16,metal-gpu`
- [x] `cargo test -p lattice-inference --features "f16,metal-gpu" --lib forward::metal::` (GPU lock,
      `LATTICE_METAL_TEST_ENFORCE=1`) — 3 passed (msl-assembly + NaN + +inf), 0 failed
- [x] Mutation sensitivity (this round, disposable worktree): revert finalize → RED (both new/updated
      tests, 160/160 non-finite) → restore → GREEN (0/160), byte-identical shader confirmed after restore
- [x] `make bench-compare` — see analysis above; not gate-blocking (structurally unreachable change,
      unchanged from round 1 since no kernel code changed this round)
- [x] `actionlint .github/workflows/ci.yml` — clean



## Round 2 update (head 3a305fa19)

Review round 2 returned APPROVE-WITH-FIXES with one medium, applied: the new CI gate no longer pipes its gating command through `tee` — the test writes its log via redirection and gates on its own exit status (explicit fail-cat-exit), per the repository's CI authoring rule. Source comments also drop review-round narration in favor of the invariant/issue references. `actionlint` and fmt clean; no kernel or test-behavior change (the 3-test enforced group is unchanged).
