### PR TITLE
fix(tune): fail loudly on unimplemented GPU optimizer dispatch instead of silent no-op (#797)

### DIFF
--- a/crates/tune/README.md
+++ b/crates/tune/README.md
@@ -326,11 +326,20 @@ let finetuned = RegisteredModel::new("intent_classifier", "1.1.0")
 | ---------------- | ------- | ------------------------------------------------------------ |
 | `std`            | Yes     | Standard library support                                     |
 | `serde`          | No      | Serialization (propagates to lattice-fann)                   |
-| `gpu`            | No      | GPU-accelerated training                                     |
+| `gpu`            | No      | GPU-accelerated forward/backward passes and validation[^gpu-limitation] |
 | `gpu-tests`      | No      | GPU tests requiring hardware                                 |
 | `safetensors`    | No      | Safe checkpoint serialization                                |
 | `inference-hook` | No      | `impl LoraHook for LoraAdapter` (pulls in `lattice-inference`) |
 | `train-backward` | No      | Backward/gradient training surface (pulls in `lattice-inference`) |
+
+[^gpu-limitation]: **Current limitation**: `GpuTrainer::train_batch` returns
+`Err` for every optimizer choice (Adam, AdamW, SGD-momentum, plain SGD,
+RMSprop) — the GPU-shader optimizer dispatch has no buffer bindings wired to
+the network's weight/gradient buffers, and the CPU-side plain-SGD arm has
+neither real gradient plumbing nor a mutable weight write-back path. Forward
+pass and loss computation work correctly; only the weight-update step is
+unimplemented. See [issue #797](https://github.com/ohdearquant/lattice/issues/797).
+This note will be removed once that wiring lands.
 
 ```toml
 [dependencies]

--- a/crates/tune/src/train/gpu/mod.rs
+++ b/crates/tune/src/train/gpu/mod.rs
@@ -21,6 +21,19 @@ use std::sync::Arc;
 ///
 /// Provides GPU-accelerated forward/backward passes and weight updates
 /// using lattice-fann's wgpu backend.
+///
+/// # Current limitation
+///
+/// [`Self::train_batch`] returns `Err(TuneError::Training(_))` for every
+/// optimizer choice (Adam, AdamW, SGD-momentum, plain SGD, RMSprop): the
+/// GPU-shader optimizer dispatch has no buffer bindings wired to the
+/// network's weight/gradient buffers, and the CPU-side plain-SGD arm has
+/// neither real gradient plumbing nor a mutable weight write-back path.
+/// Forward pass and loss computation work correctly — [`Self::validate`] is
+/// a forward-only path that does not touch the optimizer. Only the
+/// weight-update step is unimplemented. See
+/// <https://github.com/ohdearquant/lattice/issues/797>. This note will be
+/// removed once that wiring lands.
 pub struct GpuTrainer {
     /// GPU context (device, queue, shader manager)
     ctx: Arc<GpuContext>,
@@ -180,8 +193,6 @@ impl GpuTrainer {
     ///
     /// Returns the batch loss.
     pub fn train_batch(&mut self, batch: &Batch) -> Result<f32> {
-        self.global_step += 1;
-
         // Forward pass
         let (outputs, activations) = self.forward_batch(batch)?;
 
@@ -203,6 +214,14 @@ impl GpuTrainer {
 
         // Update weights
         self.update_weights()?;
+
+        // Only a fully completed step (forward + backward + optimizer
+        // update all succeeded) counts toward global_step/LR/epoch
+        // accounting. A failed step above must not advance this counter —
+        // see #797: every GpuOptimizer arm currently errors until real
+        // buffer/gradient wiring lands, so this guards against every
+        // failed call silently inflating the step count.
+        self.global_step += 1;
 
         // Update learning rate
         self.current_lr = self.config.lr_schedule.get_lr(

--- a/crates/tune/src/train/gpu/optimizers.rs
+++ b/crates/tune/src/train/gpu/optimizers.rs
@@ -1,4 +1,11 @@
 //! GPU optimizer implementations
+//!
+//! Every `GpuOptimizer` arm (Adam, AdamW, SGD-momentum, plain SGD, RMSprop)
+//! currently fails loudly with `TuneError::Training` rather than performing a
+//! real weight update: the shader-based arms have no buffer bindings wired
+//! to the network's weight/gradient buffers, and the CPU-side plain-SGD arm
+//! has neither real gradient plumbing nor a mutable weight write-back path.
+//! See #797. Wiring the real dispatch/write-back is tracked follow-up work.
 
 use super::state::LayerGradients;
 use crate::error::{Result, TuneError};
@@ -84,7 +91,9 @@ impl GpuOptimizer {
             Optimizer::SGD => Self::update_sgd(network, current_lr)?,
             Optimizer::RMSprop => {
                 return Err(TuneError::Training(
-                    "GPU RMSprop optimizer not implemented; select SGD explicitly (#797)"
+                    "GPU RMSprop optimizer not implemented: this arm previously silently \
+                     substituted plain SGD instead of running the requested algorithm; every \
+                     GpuOptimizer arm fails loudly until real buffer/gradient wiring lands (#797)"
                         .to_string(),
                 ));
             }
@@ -105,34 +114,23 @@ impl GpuOptimizer {
 
     /// Plain SGD update (CPU fallback - no shader for plain SGD)
     ///
-    /// NOTE (#797 follow-up, out of scope for this fix): this arm computes
-    /// updated weights/biases but `GpuNetwork` exposes only an immutable
-    /// `cpu_network()` accessor, so the computed values are never written
-    /// back — this is untouched, pre-existing behavior, tracked separately
-    /// from the shader-dispatch fail-loud fix above.
-    fn update_sgd(network: &lattice_fann::gpu::GpuNetwork, current_lr: f32) -> Result<()> {
-        // Plain SGD without momentum - apply on CPU
-        // This is a simple w = w - lr * grad
-        let cpu_network = network.cpu_network();
-
-        for layer in cpu_network.layers().iter() {
-            let mut weights = layer.weights().to_vec();
-            let mut biases = layer.biases().to_vec();
-
-            // Simple gradient descent
-            let grad_scale = 0.01; // Placeholder gradient magnitude
-
-            for w in weights.iter_mut() {
-                *w -= current_lr * grad_scale;
-            }
-            for b in biases.iter_mut() {
-                *b -= current_lr * grad_scale;
-            }
-
-            // Write back (would need mutable network access)
-            let _ = (weights, biases); // Silence unused warning for now
-        }
-
-        Ok(())
+    /// # Errors
+    ///
+    /// Always returns `TuneError::Training`: this is not real SGD (#797).
+    /// The previous body used a constant placeholder gradient magnitude
+    /// (`grad_scale = 0.01`) instead of the actual per-layer gradients
+    /// accumulated in `LayerGradients`, and had no mutable write-back path
+    /// from `GpuNetwork` (only the immutable `cpu_network()` accessor
+    /// exists) even if it had used real gradients — so the computed values
+    /// were always discarded. A working plain-SGD arm needs both real
+    /// gradient plumbing and a mutable weight-write path on `GpuNetwork`;
+    /// until then it fails loudly like every other arm rather than
+    /// reporting success for a step that changed nothing.
+    fn update_sgd(_network: &lattice_fann::gpu::GpuNetwork, _current_lr: f32) -> Result<()> {
+        Err(TuneError::Training(
+            "GPU SGD optimizer update not implemented: no real gradient plumbing or mutable \
+             weight write-back from GpuNetwork is wired (#797)"
+                .to_string(),
+        ))
     }
 }

--- a/crates/tune/src/train/gpu/optimizers.rs
+++ b/crates/tune/src/train/gpu/optimizers.rs
@@ -1,7 +1,6 @@
 //! GPU optimizer implementations
 
 use super::state::LayerGradients;
-use super::uniforms::{AdamUniforms, AdamWUniforms, SgdMomentumUniforms};
 use crate::error::{Result, TuneError};
 use crate::train::config::{Optimizer, TrainingConfig};
 use lattice_fann::gpu::GpuContext;
@@ -12,137 +11,60 @@ pub struct GpuOptimizer;
 
 impl GpuOptimizer {
     /// Adam optimizer update using GPU shader
+    ///
+    /// # Errors
+    ///
+    /// Always returns `TuneError::Training`: the GPU dispatch has no buffer
+    /// bindings wired to the network's weight/gradient buffers (#797). Wiring
+    /// the real dispatch is tracked as follow-up work; until then this arm
+    /// fails loudly instead of silently performing a zero-effect update.
     pub fn update_adam(
-        ctx: &Arc<GpuContext>,
-        layer_gradients: &[LayerGradients],
-        config: &TrainingConfig,
-        current_lr: f32,
+        _ctx: &Arc<GpuContext>,
+        _layer_gradients: &[LayerGradients],
+        _config: &TrainingConfig,
+        _current_lr: f32,
     ) -> Result<()> {
-        use lattice_fann::gpu::ShaderType;
-
-        let pipeline = ctx
-            .shader_manager()
-            .get_or_compile(ShaderType::Adam)
-            .map_err(|e| TuneError::Training(format!("Adam shader compile failed: {e}")))?;
-
-        let opt_config = &config.optimizer;
-
-        for layer_grads in layer_gradients.iter() {
-            let size = (layer_grads.num_weights + layer_grads.num_biases) as u32;
-            let t = layer_grads.optimizer_state.t as f32 + 1.0;
-
-            let uniforms = AdamUniforms {
-                size,
-                learning_rate: current_lr,
-                beta1: opt_config.beta1,
-                beta2: opt_config.beta2,
-                epsilon: opt_config.epsilon,
-                t,
-                _pad0: 0,
-                _pad1: 0,
-            };
-
-            Self::dispatch_optimizer_update(ctx, &pipeline, &uniforms)?;
-        }
-
-        Ok(())
+        Err(TuneError::Training(
+            "GPU Adam optimizer update not implemented: optimizer shader dispatch has no \
+             buffer bindings wired to the network's weight/gradient buffers (#797)"
+                .to_string(),
+        ))
     }
 
     /// AdamW optimizer update using GPU shader
+    ///
+    /// # Errors
+    ///
+    /// Always returns `TuneError::Training`: see [`Self::update_adam`] (#797).
     pub fn update_adamw(
-        ctx: &Arc<GpuContext>,
-        layer_gradients: &[LayerGradients],
-        config: &TrainingConfig,
-        current_lr: f32,
+        _ctx: &Arc<GpuContext>,
+        _layer_gradients: &[LayerGradients],
+        _config: &TrainingConfig,
+        _current_lr: f32,
     ) -> Result<()> {
-        use lattice_fann::gpu::ShaderType;
-
-        let pipeline = ctx
-            .shader_manager()
-            .get_or_compile(ShaderType::AdamW)
-            .map_err(|e| TuneError::Training(format!("AdamW shader compile failed: {e}")))?;
-
-        let opt_config = &config.optimizer;
-
-        for layer_grads in layer_gradients.iter() {
-            let size = (layer_grads.num_weights + layer_grads.num_biases) as u32;
-            let t = layer_grads.optimizer_state.t as f32 + 1.0;
-
-            let uniforms = AdamWUniforms {
-                size,
-                learning_rate: current_lr,
-                beta1: opt_config.beta1,
-                beta2: opt_config.beta2,
-                epsilon: opt_config.epsilon,
-                weight_decay: opt_config.weight_decay,
-                t,
-                _pad: 0,
-            };
-
-            Self::dispatch_optimizer_update(ctx, &pipeline, &uniforms)?;
-        }
-
-        Ok(())
+        Err(TuneError::Training(
+            "GPU AdamW optimizer update not implemented: optimizer shader dispatch has no \
+             buffer bindings wired to the network's weight/gradient buffers (#797)"
+                .to_string(),
+        ))
     }
 
     /// SGD with momentum update using GPU shader
+    ///
+    /// # Errors
+    ///
+    /// Always returns `TuneError::Training`: see [`Self::update_adam`] (#797).
     pub fn update_sgd_momentum(
-        ctx: &Arc<GpuContext>,
-        layer_gradients: &[LayerGradients],
-        config: &TrainingConfig,
-        current_lr: f32,
+        _ctx: &Arc<GpuContext>,
+        _layer_gradients: &[LayerGradients],
+        _config: &TrainingConfig,
+        _current_lr: f32,
     ) -> Result<()> {
-        use lattice_fann::gpu::ShaderType;
-
-        let pipeline = ctx
-            .shader_manager()
-            .get_or_compile(ShaderType::SgdMomentum)
-            .map_err(|e| TuneError::Training(format!("SGD momentum shader compile failed: {e}")))?;
-
-        let opt_config = &config.optimizer;
-
-        for layer_grads in layer_gradients.iter() {
-            let size = (layer_grads.num_weights + layer_grads.num_biases) as u32;
-
-            let uniforms = SgdMomentumUniforms {
-                size,
-                learning_rate: current_lr,
-                momentum: opt_config.momentum,
-                _pad: 0,
-            };
-
-            Self::dispatch_optimizer_update(ctx, &pipeline, &uniforms)?;
-        }
-
-        Ok(())
-    }
-
-    /// Dispatch optimizer shader
-    fn dispatch_optimizer_update<U: bytemuck::Pod>(
-        ctx: &Arc<GpuContext>,
-        pipeline: &wgpu::ComputePipeline,
-        uniforms: &U,
-    ) -> Result<()> {
-        use wgpu::util::DeviceExt;
-
-        let device = ctx.device();
-        let queue = ctx.queue();
-
-        let _uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("optimizer_uniforms"),
-            contents: bytemuck::bytes_of(uniforms),
-            usage: wgpu::BufferUsages::UNIFORM,
-        });
-
-        // Note: This is a simplified bind group - actual implementation would need
-        // proper weight buffer access from GpuNetwork
-        let _bind_group_layout = pipeline.get_bind_group_layout(0);
-
-        // TODO(FP-165): submits no actual compute — needs access to weight buffers from GpuNetwork
-        let encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-        queue.submit(std::iter::once(encoder.finish()));
-
-        Ok(())
+        Err(TuneError::Training(
+            "GPU SGD-momentum optimizer update not implemented: optimizer shader dispatch \
+             has no buffer bindings wired to the network's weight/gradient buffers (#797)"
+                .to_string(),
+        ))
     }
 
     /// Select and run appropriate optimizer update
@@ -160,7 +82,12 @@ impl GpuOptimizer {
                 Self::update_sgd_momentum(ctx, layer_gradients, config, current_lr)?
             }
             Optimizer::SGD => Self::update_sgd(network, current_lr)?,
-            Optimizer::RMSprop => Self::update_sgd(network, current_lr)?, // Fallback
+            Optimizer::RMSprop => {
+                return Err(TuneError::Training(
+                    "GPU RMSprop optimizer not implemented; select SGD explicitly (#797)"
+                        .to_string(),
+                ));
+            }
         }
 
         // Increment timestep for optimizer state
@@ -177,6 +104,12 @@ impl GpuOptimizer {
     }
 
     /// Plain SGD update (CPU fallback - no shader for plain SGD)
+    ///
+    /// NOTE (#797 follow-up, out of scope for this fix): this arm computes
+    /// updated weights/biases but `GpuNetwork` exposes only an immutable
+    /// `cpu_network()` accessor, so the computed values are never written
+    /// back — this is untouched, pre-existing behavior, tracked separately
+    /// from the shader-dispatch fail-loud fix above.
     fn update_sgd(network: &lattice_fann::gpu::GpuNetwork, current_lr: f32) -> Result<()> {
         // Plain SGD without momentum - apply on CPU
         // This is a simple w = w - lr * grad

--- a/crates/tune/src/train/gpu/state.rs
+++ b/crates/tune/src/train/gpu/state.rs
@@ -1,12 +1,20 @@
 //! GPU buffer state management
 
 /// GPU buffer for optimizer state
+///
+/// `m`, `v`, and `velocity` are pre-allocated by `GpuTrainer::init_gradients`
+/// but not yet bound to any shader dispatch: the GPU-shader optimizer arms
+/// (Adam, AdamW, SGD-momentum) fail loudly instead of running until the real
+/// buffer bindings are wired (#797). Kept as placeholders for that follow-up.
 pub struct OptimizerState {
     /// First moment (Adam)
+    #[allow(dead_code, reason = "pre-allocated for #797 follow-up buffer wiring")]
     pub m: wgpu::Buffer,
     /// Second moment (Adam)
+    #[allow(dead_code, reason = "pre-allocated for #797 follow-up buffer wiring")]
     pub v: wgpu::Buffer,
     /// Velocity (SGD momentum)
+    #[allow(dead_code, reason = "pre-allocated for #797 follow-up buffer wiring")]
     pub velocity: wgpu::Buffer,
     /// Current timestep
     pub t: u32,
@@ -17,6 +25,8 @@ pub struct LayerGradients {
     pub weight_grads: wgpu::Buffer,
     pub bias_grads: wgpu::Buffer,
     pub optimizer_state: OptimizerState,
+    #[allow(dead_code, reason = "pre-allocated for #797 follow-up buffer wiring")]
     pub num_weights: usize,
+    #[allow(dead_code, reason = "pre-allocated for #797 follow-up buffer wiring")]
     pub num_biases: usize,
 }

--- a/crates/tune/src/train/gpu/tests.rs
+++ b/crates/tune/src/train/gpu/tests.rs
@@ -335,7 +335,7 @@ fn test_check_numeric_stability_inf() {
 
 #[test]
 #[cfg_attr(not(feature = "gpu-tests"), ignore = "requires GPU hardware")]
-fn test_learning_rate_tracking() {
+fn test_failed_step_preserves_lr_and_global_step() {
     if skip_if_no_gpu() {
         return;
     }
@@ -349,8 +349,9 @@ fn test_learning_rate_tracking() {
     // instead of dodging via a "harmless" optimizer choice (there isn't
     // one), this test now asserts what *is* true today: a failed optimizer
     // step propagates the error and does not silently advance the learning
-    // rate. This is a real, currently-meaningful invariant (no partial/silent
-    // state drift on failure), not a weakened stand-in for LR tracking.
+    // rate OR the public global-step counter. Both are real,
+    // currently-meaningful invariants (no partial/silent state drift on
+    // failure), not a weakened stand-in for LR/step tracking.
     let config = TrainingConfig {
         optimizer: OptimizerConfig {
             optimizer: Optimizer::Adam,
@@ -368,6 +369,7 @@ fn test_learning_rate_tracking() {
 
     let initial_lr = trainer.current_lr();
     assert!((initial_lr - 0.001).abs() < 1e-6);
+    assert_eq!(trainer.global_step(), 0);
 
     let batch = make_test_batch(2);
     let result = trainer.train_batch(&batch);
@@ -383,6 +385,16 @@ fn test_learning_rate_tracking() {
     assert!(
         (lr_after_failed_step - initial_lr).abs() < 1e-9,
         "learning rate must not change on a failed optimizer step: {initial_lr} -> {lr_after_failed_step}"
+    );
+
+    // global_step must also be untouched: it is now incremented after
+    // `update_weights()?` succeeds, so a failed optimizer step must not
+    // count as a completed training step (it previously did, feeding
+    // incorrect values into LR/epoch math on every failed call).
+    assert_eq!(
+        trainer.global_step(),
+        0,
+        "a failed optimizer step must not advance global_step"
     );
 }
 

--- a/crates/tune/src/train/gpu/tests.rs
+++ b/crates/tune/src/train/gpu/tests.rs
@@ -41,20 +41,18 @@ fn test_gpu_trainer_forward() {
         return;
     }
 
-    // Explicit SGD: the only optimizer arm that does not fail loudly (#797 —
-    // Adam/AdamW/SGDMomentum/RMSprop all error until GPU buffer bindings are
-    // wired). This test exercises forward+loss, not the optimizer step.
-    let config = TrainingConfig {
-        optimizer: OptimizerConfig {
-            optimizer: Optimizer::SGD,
-            ..Default::default()
-        },
-        ..TrainingConfig::quick()
-    };
-
+    // #797: every GpuOptimizer arm (Adam/AdamW/SGDMomentum/SGD/RMSprop) now
+    // fails loudly instead of performing a silent no-op update, so the full
+    // `train_batch` pipeline (forward -> backward -> update_weights -> LR
+    // step) can never complete today regardless of optimizer choice. This
+    // test's actual subject is forward-pass + loss computation, not the
+    // optimizer, so it calls `forward_batch`/`compute_loss` directly —
+    // bypassing `update_weights` entirely — to keep verifying exactly what
+    // it verified before, without depending on optimizer behavior that is
+    // honestly unimplemented.
     let mut trainer = GpuTrainerBuilder::new(6, 6)
         .hidden(16, Activation::ReLU)
-        .config(config)
+        .config(TrainingConfig::quick())
         .build()
         .unwrap();
 
@@ -65,10 +63,14 @@ fn test_gpu_trainer_forward() {
     );
 
     let batch = Batch::from_examples(vec![example], 0);
-    let result = trainer.train_batch(&batch);
 
-    assert!(result.is_ok());
-    let loss = result.unwrap();
+    let (outputs, _activations) = trainer
+        .forward_batch(&batch)
+        .expect("forward pass should succeed");
+    let loss = trainer
+        .compute_loss(&outputs, &batch)
+        .expect("loss computation should succeed");
+
     assert!(loss > 0.0);
 }
 
@@ -272,7 +274,7 @@ fn test_update_rmsprop_fails_loud() {
 
 #[test]
 #[cfg_attr(not(feature = "gpu-tests"), ignore = "requires GPU hardware")]
-fn test_update_sgd_plain() {
+fn test_update_sgd_fails_loud() {
     if skip_if_no_gpu() {
         return;
     }
@@ -292,15 +294,21 @@ fn test_update_sgd_plain() {
         .build()
         .unwrap();
 
-    for _ in 0..3 {
-        let batch = make_test_batch(2);
-        let result = trainer.train_batch(&batch);
-        assert!(
-            result.is_ok(),
-            "Plain SGD training step failed: {:?}",
-            result.err()
-        );
-    }
+    // #797: plain SGD is not real SGD either — its previous body used a
+    // constant placeholder gradient magnitude (never the actual per-layer
+    // gradients) and had no mutable weight write-back path from GpuNetwork,
+    // so any computed values were always discarded. It must fail loudly
+    // like every other GpuOptimizer arm rather than report success for a
+    // step that changed nothing.
+    let batch = make_test_batch(2);
+    let result = trainer.train_batch(&batch);
+
+    let err = result.expect_err("plain SGD GPU optimizer must fail until it is real SGD");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("SGD") && msg.contains("not implemented"),
+        "unexpected error message: {msg}"
+    );
 }
 
 #[test]
@@ -332,14 +340,20 @@ fn test_learning_rate_tracking() {
         return;
     }
 
-    // SGD, not Adam: this test targets learning-rate-schedule tracking, which
-    // is orthogonal to the optimizer's weight-update mechanism. Adam/AdamW/
-    // SGDMomentum/RMSprop all fail loudly until GPU buffer bindings are
-    // wired (#797); SGD is the one arm that still runs `train_batch` to
-    // completion.
+    // #797: every GpuOptimizer arm fails loudly now (none is real yet), so
+    // `train_batch` cannot reach the LR-schedule update line (it runs after
+    // `update_weights()?` in `train_batch`, and `?` returns early on error
+    // regardless of which optimizer is configured). This test's original
+    // assertion — that `current_lr()` reflects the schedule after a batch —
+    // cannot be verified honestly until a real optimizer arm lands, so
+    // instead of dodging via a "harmless" optimizer choice (there isn't
+    // one), this test now asserts what *is* true today: a failed optimizer
+    // step propagates the error and does not silently advance the learning
+    // rate. This is a real, currently-meaningful invariant (no partial/silent
+    // state drift on failure), not a weakened stand-in for LR tracking.
     let config = TrainingConfig {
         optimizer: OptimizerConfig {
-            optimizer: Optimizer::SGD,
+            optimizer: Optimizer::Adam,
             learning_rate: 0.001,
             ..Default::default()
         },
@@ -356,10 +370,20 @@ fn test_learning_rate_tracking() {
     assert!((initial_lr - 0.001).abs() < 1e-6);
 
     let batch = make_test_batch(2);
-    trainer.train_batch(&batch).unwrap();
+    let result = trainer.train_batch(&batch);
+    assert!(
+        result.is_err(),
+        "train_batch must fail until a real GPU optimizer arm lands (#797)"
+    );
 
-    let updated_lr = trainer.current_lr();
-    assert!(updated_lr > 0.0);
+    // current_lr must be untouched: the LR-schedule assignment in
+    // `train_batch` runs strictly after the optimizer-update `?`, so a
+    // failed update must never advance it.
+    let lr_after_failed_step = trainer.current_lr();
+    assert!(
+        (lr_after_failed_step - initial_lr).abs() < 1e-9,
+        "learning rate must not change on a failed optimizer step: {initial_lr} -> {lr_after_failed_step}"
+    );
 }
 
 #[test]

--- a/crates/tune/src/train/gpu/tests.rs
+++ b/crates/tune/src/train/gpu/tests.rs
@@ -41,9 +41,20 @@ fn test_gpu_trainer_forward() {
         return;
     }
 
+    // Explicit SGD: the only optimizer arm that does not fail loudly (#797 —
+    // Adam/AdamW/SGDMomentum/RMSprop all error until GPU buffer bindings are
+    // wired). This test exercises forward+loss, not the optimizer step.
+    let config = TrainingConfig {
+        optimizer: OptimizerConfig {
+            optimizer: Optimizer::SGD,
+            ..Default::default()
+        },
+        ..TrainingConfig::quick()
+    };
+
     let mut trainer = GpuTrainerBuilder::new(6, 6)
         .hidden(16, Activation::ReLU)
-        .config(TrainingConfig::quick())
+        .config(config)
         .build()
         .unwrap();
 
@@ -112,7 +123,7 @@ fn test_validate_empty_dataset() {
 
 #[test]
 #[cfg_attr(not(feature = "gpu-tests"), ignore = "requires GPU hardware")]
-fn test_update_adam() {
+fn test_update_adam_fails_loud() {
     if skip_if_no_gpu() {
         return;
     }
@@ -135,22 +146,25 @@ fn test_update_adam() {
         .build()
         .unwrap();
 
-    for _ in 0..3 {
-        let batch = make_test_batch(2);
-        let result = trainer.train_batch(&batch);
-        assert!(
-            result.is_ok(),
-            "Adam training step failed: {:?}",
-            result.err()
-        );
-    }
+    let batch = make_test_batch(2);
+    let result = trainer.train_batch(&batch);
 
-    assert_eq!(trainer.global_step(), 3);
+    // #797: the GPU Adam optimizer dispatch has no buffer bindings wired —
+    // it must fail loudly rather than silently reporting a successful
+    // zero-effect update. If this assertion ever fails because the empty
+    // command-buffer no-op was restored, that is the regression this test
+    // guards against.
+    let err = result.expect_err("Adam GPU optimizer must fail until buffer bindings are wired");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Adam") && msg.contains("not implemented"),
+        "unexpected error message: {msg}"
+    );
 }
 
 #[test]
 #[cfg_attr(not(feature = "gpu-tests"), ignore = "requires GPU hardware")]
-fn test_update_adamw() {
+fn test_update_adamw_fails_loud() {
     if skip_if_no_gpu() {
         return;
     }
@@ -174,22 +188,20 @@ fn test_update_adamw() {
         .build()
         .unwrap();
 
-    for _ in 0..3 {
-        let batch = make_test_batch(2);
-        let result = trainer.train_batch(&batch);
-        assert!(
-            result.is_ok(),
-            "AdamW training step failed: {:?}",
-            result.err()
-        );
-    }
+    let batch = make_test_batch(2);
+    let result = trainer.train_batch(&batch);
 
-    assert_eq!(trainer.global_step(), 3);
+    let err = result.expect_err("AdamW GPU optimizer must fail until buffer bindings are wired");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("AdamW") && msg.contains("not implemented"),
+        "unexpected error message: {msg}"
+    );
 }
 
 #[test]
 #[cfg_attr(not(feature = "gpu-tests"), ignore = "requires GPU hardware")]
-fn test_update_sgd_momentum() {
+fn test_update_sgd_momentum_fails_loud() {
     if skip_if_no_gpu() {
         return;
     }
@@ -210,17 +222,52 @@ fn test_update_sgd_momentum() {
         .build()
         .unwrap();
 
-    for _ in 0..3 {
-        let batch = make_test_batch(2);
-        let result = trainer.train_batch(&batch);
-        assert!(
-            result.is_ok(),
-            "SGD momentum training step failed: {:?}",
-            result.err()
-        );
+    let batch = make_test_batch(2);
+    let result = trainer.train_batch(&batch);
+
+    let err =
+        result.expect_err("SGD-momentum GPU optimizer must fail until buffer bindings are wired");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("SGD-momentum") && msg.contains("not implemented"),
+        "unexpected error message: {msg}"
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "gpu-tests"), ignore = "requires GPU hardware")]
+fn test_update_rmsprop_fails_loud() {
+    if skip_if_no_gpu() {
+        return;
     }
 
-    assert_eq!(trainer.global_step(), 3);
+    let config = TrainingConfig {
+        optimizer: OptimizerConfig {
+            optimizer: Optimizer::RMSprop,
+            learning_rate: 0.01,
+            ..Default::default()
+        },
+        ..TrainingConfig::quick()
+    };
+
+    let mut trainer = GpuTrainerBuilder::new(6, 6)
+        .hidden(16, Activation::ReLU)
+        .config(config)
+        .build()
+        .unwrap();
+
+    let batch = make_test_batch(2);
+    let result = trainer.train_batch(&batch);
+
+    // #797 adjacent defect: RMSprop used to silently substitute plain SGD
+    // instead of running the requested algorithm. It must fail loudly and
+    // name the alternative instead.
+    let err = result.expect_err("RMSprop GPU optimizer must fail loudly, not silently fall back");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("RMSprop") && msg.contains("not implemented"),
+        "unexpected error message: {msg}"
+    );
 }
 
 #[test]
@@ -285,9 +332,14 @@ fn test_learning_rate_tracking() {
         return;
     }
 
+    // SGD, not Adam: this test targets learning-rate-schedule tracking, which
+    // is orthogonal to the optimizer's weight-update mechanism. Adam/AdamW/
+    // SGDMomentum/RMSprop all fail loudly until GPU buffer bindings are
+    // wired (#797); SGD is the one arm that still runs `train_batch` to
+    // completion.
     let config = TrainingConfig {
         optimizer: OptimizerConfig {
-            optimizer: Optimizer::Adam,
+            optimizer: Optimizer::SGD,
             learning_rate: 0.001,
             ..Default::default()
         },

--- a/crates/tune/src/train/mod.rs
+++ b/crates/tune/src/train/mod.rs
@@ -30,7 +30,8 @@
 //!
 //! # GPU Training
 //!
-//! With the `gpu` feature enabled, GPU-accelerated training is available:
+//! With the `gpu` feature enabled, GPU-accelerated forward/backward passes
+//! and validation are available:
 //!
 //! ```ignore
 //! use lattice_tune::train::{GpuTrainer, GpuTrainerBuilder, TrainingConfig};
@@ -48,6 +49,19 @@
 //!     let loss = trainer.train_batch(&batch)?;
 //! }
 //! ```
+//!
+//! # Current limitation (GPU weight updates)
+//!
+//! `GpuTrainer::train_batch` above will return `Err(TuneError::Training(_))`
+//! for **every** optimizer choice (Adam, AdamW, SGD-momentum, plain SGD,
+//! RMSprop): the GPU-shader optimizer dispatch has no buffer bindings wired
+//! to the network's weight/gradient buffers, and the CPU-side plain-SGD arm
+//! has neither real gradient plumbing nor a mutable weight write-back path.
+//! Forward pass and loss computation work correctly — `GpuTrainer::validate`
+//! is a forward-only, GPU-accelerated path that does not touch the
+//! optimizer. Only the weight-update step is unimplemented. See
+//! <https://github.com/ohdearquant/lattice/issues/797>. This note will be
+//! removed once that wiring lands.
 
 mod config;
 mod jit;


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Closes #797. `GpuOptimizer::dispatch_optimizer_update` submitted an empty
command encoder and returned `Ok(())` for the Adam, AdamW, and SGD-momentum
GPU optimizer arms — training with any of these silently performed zero
weight updates every step while reporting success. `RMSprop` silently
substituted plain SGD instead of running the requested algorithm.

**Every arm of `GpuOptimizer::update` now fails loudly** (`Adam`, `AdamW`,
`SGDMomentum`, `SGD`, `RMSprop`) instead of reporting success for a step that
changed nothing. See the "Scope grew during review" section below for why
plain SGD is included — it was not part of the original narrow ask, but
verifying it (per the task brief's "confirm it actually works") turned up a
worse defect than the write-back gap I initially found, and the coordinator
directed extending the fix to it (documented as a comment on #797).

- `GpuOptimizer::update_adam` / `update_adamw` / `update_sgd_momentum` now
  return `TuneError::Training(...)` naming the optimizer and stating the GPU
  shader dispatch has no buffer bindings wired to the network's
  weight/gradient buffers (#797), replacing the `TODO(FP-165)` marker and the
  dead uniform-buffer / bind-group-layout scaffolding that never got used for
  anything (no bind group was ever built or bound).
- `GpuOptimizer::update_sgd` (plain SGD, CPU-side) now returns
  `TuneError::Training(...)` too. See below for why.
- `Optimizer::RMSprop` now returns an explicit error naming the defect
  (previous silent substitution of SGD) instead of running SGD under the
  hood — and no longer points users at SGD as a working alternative, since
  SGD fails loudly too now.

## Why fail-loud-first, not the full fix

Per the issue: wiring the real weight/gradient buffer bindings into the bind
group (Adam/AdamW/SGDMomentum) and real gradient plumbing + mutable weight
access (plain SGD) is larger follow-up work. The immediate defect — success
reported for a step that updated nothing — is high severity (plausibly
misread as "model converged" or "training is slow") and is fixable narrowly
today by making every arm honest about its actual state: unimplemented.

## Scope grew during review: plain SGD included too

My first pass left `update_sgd` untouched, on the read that fixing it needed
a new mutable-access API on `GpuNetwork` (real feature work, not a
fail-loud-only change), and flagged the finding instead of silently treating
it as "verified working" per the task brief.

The coordinator verified `update_sgd` at source and found it's worse than "no
write-back": the loop uses `let grad_scale = 0.01; // Placeholder gradient
magnitude` — a constant, not the actual per-layer gradients accumulated in
`LayerGradients`. So even with a mutable write-back path, the arm would
compute `w -= lr * 0.01`, which is not SGD by any definition — it's
unconditional weight decay unrelated to the loss. That reframes the
question: fixing plain SGD (real gradients + mutable write-back) is
follow-up work, but *making it stop reporting success* is exactly the same
narrow, low-risk change as the other three arms. Directive: extend the
fail-loud fix to `update_sgd`, documented as a comment on #797.

`update_sgd` now:
- Deletes the placeholder loop body (constant-gradient theater).
- Returns `TuneError::Training("GPU SGD optimizer update not implemented: no
  real gradient plumbing or mutable weight write-back from GpuNetwork is
  wired (#797)")`.
- Carries a doc comment stating what real SGD needs: real gradient plumbing
  from `LayerGradients` **and** a mutable weight-write path on `GpuNetwork`
  (today only `cpu_network()`, an immutable accessor, exists).

Net effect: the GPU trainer's `update_weights` step fails for every optimizer
choice until real dispatch/gradient/write-back wiring lands. This makes the
GPU trainer honestly unusable for weight updates right now, which is its
actual state — previously that was hidden behind a false "success."

## Codex round 1 (APPROVE-WITH-FIXES) — applied

Full review: see PR comment / `pr_review_r1.md`. Three findings, all fixed:

1. **Major** — `GpuTrainer::train_batch` incremented `self.global_step` at
   the top of the function, before forward/backward/`update_weights()?`. So
   every fail-loud optimizer error still advanced the public
   `global_step()` counter: failed steps counted as completed training
   steps and fed into the LR/epoch-approximation math. Fixed by moving the
   increment to immediately after `update_weights()?` succeeds (still
   before the LR-schedule calculation that reads it). `global_step()` is
   now `0` after any failed `train_batch` call, for any optimizer.
2. **Medium** — public docs still promised working GPU training:
   `train/mod.rs`'s module rustdoc (with a `train_batch` example),
   `train/gpu/mod.rs`'s `GpuTrainer` doc, and `crates/tune/README.md`'s
   feature table. Added a `# Current limitation` note to each (module doc,
   struct doc, README footnote) stating forward pass and loss computation
   work, but weight-update training returns `TuneError::Training` for every
   optimizer until #797's wiring lands; each note references the issue and
   states it will be removed once that lands. Validated with
   `RUSTDOCFLAGS="-D warnings" cargo doc -p lattice-tune --no-deps` (default
   features) and again with `--features gpu` — both clean, no broken links.
3. **Minor** — the PR body originally attributed the pre-existing
   `test_is_using_gpu` failure to a speculative "paravirtual/Metal-adapter
   quirk." That was wrong and unverified. Corrected above: the test's
   6→8→6 network (110 parameters) is under the 10,000-element
   `should_use_gpu` threshold, so `is_using_gpu()` is deterministically
   `false` — a small-network CPU heuristic, not a platform quirk.

Test changes for the global-step fix: `test_learning_rate_tracking` renamed
to `test_failed_step_preserves_lr_and_global_step` (codex's suggestion,
adopted — more accurately describes what it now asserts) and extended to
assert `trainer.global_step() == 0` both before and after the expected
failed `train_batch` call, alongside the existing unchanged-LR assertion.

Mutation-verified separately (appended to `.mutation_log.md`): reverted just
the `global_step` reorder (moved the increment back to the top of
`train_batch`, matching the pre-fix control flow), touched, ran
`test_failed_step_preserves_lr_and_global_step` — failed
(`global_step() == 1`, not `0`). Restored the fix, re-ran — passes. Full
`train::gpu` suite after restoring: 17 passed, 1 pre-existing/unrelated
failure (`test_is_using_gpu`, cause corrected above), 0 ignored.

## Sibling-invocation-path grep

Grepped the workspace for the same "create empty command encoder, submit,
report success" pattern:

```
grep -rn "create_command_encoder(&wgpu::CommandEncoderDescriptor::default())" crates/
```

Three other call sites exist, all in `crates/fann/src/gpu/network.rs`
(forward-pass layer dispatch, activation dispatch, and buffer readback). Read
each one: all three build a real bind group against the pipeline's layout
with actual weight/input/output buffer bindings and call
`begin_compute_pass` + `dispatch_workgroups` before submitting — they are not
instances of the same defect. Only `lattice-tune`'s optimizer dispatch built
an unused bind-group-layout handle and submitted an empty encoder.

## Tests

Mutation-sensitive tests in `crates/tune/src/train/gpu/tests.rs` (gated the
same way existing GPU tests in this file are: runtime `skip_if_no_gpu()`
plus `#[cfg_attr(not(feature = "gpu-tests"), ignore)]`):

- `test_update_adam_fails_loud`, `test_update_adamw_fails_loud`,
  `test_update_sgd_momentum_fails_loud`, `test_update_sgd_fails_loud`,
  `test_update_rmsprop_fails_loud` — one per optimizer, each configures a
  `GpuTrainer`, calls `train_batch`, and asserts the error fires with the
  expected message fragment (optimizer name + "not implemented").
- `test_gpu_trainer_forward`: previously exercised the default optimizer
  (AdamW) through the full `train_batch` pipeline to check forward-pass loss
  is positive. Since **no** optimizer choice lets `train_batch` complete
  anymore, this test now calls the trainer's `forward_batch` +
  `compute_loss` directly (private methods, accessible from the same-crate
  test module), bypassing `update_weights` entirely — it keeps verifying
  exactly what it verified before (forward pass produces valid positive
  loss) without depending on any optimizer's behavior.
- `test_learning_rate_tracking` → renamed
  `test_failed_step_preserves_lr_and_global_step` (codex round 1): previously
  called `train_batch` (via Adam) and checked that `current_lr()` reflects
  the schedule afterward — that specific claim (LR advances after a batch)
  cannot be verified honestly anymore since `update_weights` always fails
  before the LR-schedule assignment runs. Rather than dodge into a "let me
  just switch to a harmless optimizer" (there isn't one now), the assertion
  now checks what actually holds today: `train_batch` returns `Err`, and
  both `current_lr()` and `global_step()` are provably unchanged afterward
  (both assignments in `train_batch` run strictly after the optimizer `?`,
  so a failed step must not silently advance either). Real, currently-true
  invariants — not a weakened stand-in for the original claim, which will
  need to come back once a real optimizer arm lands.
- `test_update_sgd_plain` (previously asserting `Ok` for 3 successive
  batches) renamed to `test_update_sgd_fails_loud` and rewritten to assert
  the error, matching the other four.

**Mutation verification** (recorded locally in `.mutation_log.md`, not
committed — local-only record, matches this repo's convention for internal
review artifacts):

- Round 1 (Adam/AdamW/SGDMomentum/RMSprop): reverted `optimizers.rs` to the
  pre-fix version in place (`git show HEAD:... > optimizers.rs`, no
  destructive `git checkout` over uncommitted work), touched the file, ran
  the four tests — all four panicked because `train_batch` still returned
  `Ok(loss)` under the reverted no-op code. Restored the fix, re-ran — all
  four green.
- Round 2 (plain SGD): reverted only `update_sgd`'s behavior back to the
  first-round committed state (still the old placeholder-loop `Ok(())`
  body), touched, ran `test_update_sgd_fails_loud` — failed with `.expect_err`
  panicking on `Ok(1.475...)`. Restored the fix, re-ran — passes. Full
  `train::gpu` suite re-run after restoring: 17 passed, 1 pre-existing
  unrelated failure (below), 0 ignored.

This dev machine has a real Metal GPU, so `--features gpu-tests` genuinely
exercises the GPU path here (not just `ignore`-skipped). One pre-existing,
unrelated test failure was observed and confirmed present on the unmodified
branch base (65865ecb5) via `git stash`: `test_is_using_gpu` —
`assert!(trainer.is_using_gpu())` fails. Cause (corrected after codex round 1
review — my original claim of a "paravirtual/Metal-adapter quirk" was
speculation and wrong): the test builds a 6→8→6 network (110 total
parameters), and `GpuNetwork::new` sets `use_gpu =
should_use_gpu(total_params, 1)` (`crates/fann/src/gpu/network.rs:59-61`),
where the single-item threshold is 10,000 elements
(`crates/fann/src/gpu/mod.rs:137-141`) — so `is_using_gpu()` is
deterministically `false` for a network this small, regardless of platform.
Not touched; pre-existing and unrelated to #797.

## Gates

- `cargo fmt -p lattice-tune -- --check` — clean.
- `cargo clippy --workspace -- -D warnings` — clean (this is the gate CI
  actually runs; matches `.github/workflows/ci.yml`'s default-feature
  `cargo clippy --workspace` lane).
- `cargo clippy -p lattice-tune --all-targets --features gpu-tests -- -D
  warnings` — **not clean**, but the failures are 6 pre-existing clippy
  violations inside `crates/fann/src/gpu/{buffer,context,network}.rs`
  (collapsible-if, redundant-closure, cloned-instead-of-copied), unrelated to
  this PR's files. Confirmed pre-existing by stashing this diff and
  re-running the same command against the unmodified branch base — identical
  6 errors. CI itself never lints under the `gpu`/`gpu-tests` feature (only
  `lattice-inference`/`lattice-embed` have dedicated `metal-gpu` clippy lanes
  in `ci.yml`; `lattice-tune`/`lattice-fann`'s `gpu` feature has no clippy
  lane at all), so this is not a regression this PR introduces or is gated on.
- `cargo test -p lattice-tune` (default features) — 50 passed, 0 failed.
- `cargo build -p lattice-tune --features gpu-tests` — clean.
- `cargo test -p lattice-tune --features gpu-tests train::gpu` — 17 passed,
  1 failed (`test_is_using_gpu`, pre-existing/unrelated per above), 0 ignored.
- `cargo test -p lattice-tune --features gpu` (no `gpu-tests`, matches how
  most CI machines without `gpu-tests` opted in would build/test) — 8 passed,
  0 failed, 10 ignored.

## Bench-compare scope (ADR-058)

Not included. This PR touches only `crates/tune/src/train/gpu/{optimizers,state,tests}.rs`
— no `crates/inference` or `crates/embed` source changed — so the
bench-compare requirement doesn't apply per this repo's CLAUDE.md scoping
rule.

## Deviations from plan

- Scope grew beyond the original ask (three shader arms + RMSprop) to
  include plain SGD, on explicit coordinator direction after the `let
  grad_scale = 0.01` constant-placeholder finding — see "Scope grew during
  review" above.
- `state.rs`: three `OptimizerState` buffer fields (`m`/`v`/`velocity`) and
  two `LayerGradients` fields (`num_weights`/`num_biases`) lost their only
  reader once the per-layer uniform/dispatch loop was removed. Rather than
  deleting the (still-useful, pre-allocated) buffers/fields, added
  `#[allow(dead_code, reason = "...")]` referencing #797, since the follow-up
  buffer-wiring work will need them.

Not marking ready or enabling auto-merge — leaving that to review/gating.
