### PR TITLE
bench(scripts): decode-benchmark harness core with CI-wired schema tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,8 +476,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: python3 -m unittest tests/test_bench_decode_harness.py
-        run: python3 -m unittest discover -s tests -p 'test_bench_decode_harness.py' -v
+      - name: python3 tests/test_bench_decode_harness.py
+        run: python3 tests/test_bench_decode_harness.py -v
 
   # cargo-semver-checks against the latest published crates.io release for
   # every internal path-dependency crate, so a breaking public API change is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,6 +464,21 @@ jobs:
         with:
           version: '1.7.12'
 
+  # Deterministic fake-adapter unit tests + raw-observation schema validation
+  # for the decode-benchmark harness core (issue #813 step 1). Stdlib-only,
+  # no engine binary or model weights required — cheap ubuntu-only, so it is
+  # ungated like typos/actionlint above rather than routed through ci-gate.
+  bench-decode-harness-tests:
+    name: bench-decode-harness-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: python3 -m unittest tests/test_bench_decode_harness.py
+        run: python3 -m unittest discover -s tests -p 'test_bench_decode_harness.py' -v
+
   # cargo-semver-checks against the latest published crates.io release for
   # every internal path-dependency crate, so a breaking public API change is
   # flagged before it ships unversioned, the way #634 was not. Gated through

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -23,6 +23,19 @@ then `bench_decode_profiles.toml` carries no profile definitions and the
 `run` subcommand below has nothing registered in `ADAPTER_REGISTRY`, so an
 engine request always resolves as "missing" (see `--allow-missing-engine`).
 
+A profile's `engines` list is an ordered set of per-engine run groups, not
+a flat list of names: each entry carries its own `warmup_repeats`, `model`,
+and `quantization` (see `EngineRunGroup`), because the legacy scripts this
+harness consolidates give each engine its own warmup schedule and, for the
+Q4/Q8 comparison, a different quantization per engine within one profile.
+`windows`, `measured_repeats`, and `prompt` stay profile-wide because every
+legacy script keeps those uniform across engines. The requested
+model/quantization is passed into `EngineAdapter.run()`; an adapter that
+invokes a different artifact than requested (fallback, missing checkpoint,
+...) reports the actual identity back via `AdapterRunResult.actual_model`/
+`actual_quantization`, and raw observations always record the actual
+invoked identity, never a value merely assumed from the profile.
+
 Raw JSONL observation schema (the contract; see `OBSERVATION_FIELDS` /
 `validate_observation`): schema version, git SHA, profile name, engine +
 version, model/quantization, prompt hash, requested and actual prompt/
@@ -31,7 +44,13 @@ harness-measured elapsed nanoseconds, an optional engine-native nanosecond
 figure, a hardware identifier, and a timestamp. Reports render from this raw
 data; they are not the source of truth.
 
-Run with: python3 -m unittest tests/test_bench_decode_harness.py -v
+`trimmed_mean` aggregation reports `slope_ci95_legacy`: the pre-existing
+`bench_apples_precise.sh` normal-approximation spread heuristic, carried
+over unchanged. It is NOT a coverage-valid 95% confidence interval for the
+slope -- statistical-methodology correction is explicitly out of scope for
+issue #813 and is deferred to a separately reviewed follow-up.
+
+Run with: python3 tests/test_bench_decode_harness.py -v
 (the module itself is stdlib-only; no engine binaries or third-party
 packages are required to exercise it).
 """
@@ -246,19 +265,54 @@ def write_jsonl(observations: list[Observation], path: Path) -> None:
 
 
 @dataclass(frozen=True)
+class EngineRunGroup:
+    """One engine's schedule within a profile.
+
+    Every legacy script gives each engine its own warmup count and its own
+    model/quantization identity (`bench_apples_to_apples.sh`: only MLX gets
+    a warmup; `bench_q4_apples.sh`: Lattice and MLX run Q4, Ollama runs Q8 as
+    a reference). `measured_repeats`, `windows`, and `prompt` stay profile-
+    wide because every legacy script keeps those uniform across engines.
+    """
+
+    name: str
+    warmup_repeats: int
+    model: str
+    quantization: str
+
+
+@dataclass(frozen=True)
 class ProfileConfig:
     name: str
     description: str
     windows: tuple[int, ...]
-    warmup_repeats: int
     measured_repeats: int
-    engines: tuple[str, ...]
+    engine_groups: tuple[EngineRunGroup, ...]
     prompt: str
-    model: str
-    quantization: str
     aggregation: str = "median"
     trim: int = 0
     requested_prompt_tokens: int | None = None
+
+    @property
+    def engines(self) -> tuple[str, ...]:
+        """Engine names in schedule order (for aggregation/reporting)."""
+        return tuple(g.name for g in self.engine_groups)
+
+
+_TOP_LEVEL_ALLOWED_KEYS = frozenset({"schema_version", "profiles"})
+_PROFILE_ALLOWED_KEYS = frozenset(
+    {
+        "description",
+        "windows",
+        "measured_repeats",
+        "engines",
+        "prompt",
+        "aggregation",
+        "trim",
+        "requested_prompt_tokens",
+    }
+)
+_ENGINE_GROUP_ALLOWED_KEYS = frozenset({"name", "warmup_repeats", "model", "quantization"})
 
 
 def load_profiles_file(path: Path) -> tuple[int, dict[str, ProfileConfig]]:
@@ -269,6 +323,10 @@ def load_profiles_file(path: Path) -> tuple[int, dict[str, ProfileConfig]]:
         raise ProfileConfigError(f"{path}: invalid TOML: {exc}") from exc
     except OSError as exc:
         raise ProfileConfigError(f"{path}: could not read profiles file: {exc}") from exc
+
+    extra_top = set(doc) - _TOP_LEVEL_ALLOWED_KEYS
+    if extra_top:
+        raise ProfileConfigError(f"{path}: unexpected top-level key(s): {sorted(extra_top)}")
 
     schema_version = doc.get("schema_version")
     if schema_version != SCHEMA_VERSION:
@@ -289,6 +347,10 @@ def load_profiles_file(path: Path) -> tuple[int, dict[str, ProfileConfig]]:
 
 
 def _parse_profile(name: str, raw: dict) -> ProfileConfig:
+    extra = set(raw) - _PROFILE_ALLOWED_KEYS
+    if extra:
+        raise ProfileConfigError(f"profile {name!r}: unexpected key(s): {sorted(extra)}")
+
     def require(key: str, expected_type: type) -> object:
         if key not in raw:
             raise ProfileConfigError(f"profile {name!r}: missing required key {key!r}")
@@ -301,7 +363,14 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
             )
         return value
 
-    description = str(raw.get("description", ""))
+    if "description" in raw:
+        if not isinstance(raw["description"], str):
+            raise ProfileConfigError(
+                f"profile {name!r}: key 'description' must be str, got {type(raw['description']).__name__}"
+            )
+        description = raw["description"]
+    else:
+        description = ""
 
     windows_raw = require("windows", list)
     if len(windows_raw) < 2:
@@ -314,10 +383,6 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
     if windows != sorted(windows) or len(set(windows)) != len(windows):
         raise ProfileConfigError(f"profile {name!r}: windows must be strictly increasing, got {windows}")
 
-    warmup_repeats = require("warmup_repeats", int)
-    if warmup_repeats < 0:
-        raise ProfileConfigError(f"profile {name!r}: warmup_repeats must be >= 0")
-
     measured_repeats = require("measured_repeats", int)
     if measured_repeats < 1:
         raise ProfileConfigError(f"profile {name!r}: measured_repeats must be >= 1")
@@ -325,26 +390,57 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
     engines_raw = require("engines", list)
     if not engines_raw:
         raise ProfileConfigError(f"profile {name!r}: engines must not be empty")
-    engines: list[str] = []
-    for e in engines_raw:
-        if not isinstance(e, str) or not e:
-            raise ProfileConfigError(f"profile {name!r}: engines entries must be non-empty strings")
-        engines.append(e)
-    if len(set(engines)) != len(engines):
-        raise ProfileConfigError(f"profile {name!r}: engines must not contain duplicates, got {engines}")
+    engine_groups: list[EngineRunGroup] = []
+    seen_names: set[str] = set()
+    for idx, eg_raw in enumerate(engines_raw):
+        if not isinstance(eg_raw, dict):
+            raise ProfileConfigError(f"profile {name!r}: engines[{idx}] must be a table")
+        eg_extra = set(eg_raw) - _ENGINE_GROUP_ALLOWED_KEYS
+        if eg_extra:
+            raise ProfileConfigError(f"profile {name!r}: engines[{idx}] has unexpected key(s): {sorted(eg_extra)}")
+
+        def eg_require(key: str, expected_type: type, *, _idx: int = idx, _eg_raw: dict = eg_raw) -> object:
+            if key not in _eg_raw:
+                raise ProfileConfigError(f"profile {name!r}: engines[{_idx}] missing required key {key!r}")
+            value = _eg_raw[key]
+            if expected_type is int and isinstance(value, bool):
+                raise ProfileConfigError(f"profile {name!r}: engines[{_idx}] key {key!r} must be int, got bool")
+            if not isinstance(value, expected_type):
+                raise ProfileConfigError(
+                    f"profile {name!r}: engines[{_idx}] key {key!r} must be "
+                    f"{expected_type.__name__}, got {type(value).__name__}"
+                )
+            return value
+
+        eg_name = eg_require("name", str)
+        if not eg_name:
+            raise ProfileConfigError(f"profile {name!r}: engines[{idx}] name must be non-empty")
+        if eg_name in seen_names:
+            raise ProfileConfigError(f"profile {name!r}: engines must not contain duplicate name {eg_name!r}")
+        seen_names.add(eg_name)
+
+        eg_warmup = eg_require("warmup_repeats", int)
+        if eg_warmup < 0:
+            raise ProfileConfigError(f"profile {name!r}: engines[{idx}] warmup_repeats must be >= 0")
+
+        eg_model = eg_require("model", str)
+        if not eg_model:
+            raise ProfileConfigError(f"profile {name!r}: engines[{idx}] model must be non-empty")
+
+        eg_quantization = eg_require("quantization", str)
+        if not eg_quantization:
+            raise ProfileConfigError(f"profile {name!r}: engines[{idx}] quantization must be non-empty")
+
+        engine_groups.append(
+            EngineRunGroup(name=eg_name, warmup_repeats=eg_warmup, model=eg_model, quantization=eg_quantization)
+        )
 
     prompt = require("prompt", str)
     if not prompt:
         raise ProfileConfigError(f"profile {name!r}: prompt must be non-empty")
-    model = require("model", str)
-    if not model:
-        raise ProfileConfigError(f"profile {name!r}: model must be non-empty")
-    quantization = require("quantization", str)
-    if not quantization:
-        raise ProfileConfigError(f"profile {name!r}: quantization must be non-empty")
 
-    aggregation = str(raw.get("aggregation", "median"))
-    if aggregation not in AGGREGATION_METHODS:
+    aggregation = raw.get("aggregation", "median")
+    if not isinstance(aggregation, str) or aggregation not in AGGREGATION_METHODS:
         raise ProfileConfigError(
             f"profile {name!r}: aggregation must be one of {AGGREGATION_METHODS}, got {aggregation!r}"
         )
@@ -370,12 +466,9 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
         name=name,
         description=description,
         windows=tuple(windows),
-        warmup_repeats=warmup_repeats,
         measured_repeats=measured_repeats,
-        engines=tuple(engines),
+        engine_groups=tuple(engine_groups),
         prompt=prompt,
-        model=model,
-        quantization=quantization,
         aggregation=aggregation,
         trim=trim,
         requested_prompt_tokens=requested_prompt_tokens,
@@ -395,16 +488,28 @@ class AdapterRunResult:
     counts, discard samples, or compute verdicts. `native_ns`, when present,
     is surfaced as a diagnostic field alongside the harness-measured timing,
     never as a replacement for it.
+
+    `actual_model`/`actual_quantization` report the identity the adapter
+    actually invoked. They default to `None`, meaning "the requested
+    identity was invoked verbatim" -- the harness then records the
+    requested `model`/`quantization` it passed into `run()`. An adapter
+    that falls back to a different artifact than requested (a missing
+    checkpoint, a resolved default, ...) MUST set these so the raw
+    observation records what actually ran, not what was asked for.
     """
 
     actual_completion_tokens: int
     actual_prompt_tokens: int | None = None
     native_ns: int | None = None
     engine_version: str = "unknown"
+    actual_model: str | None = None
+    actual_quantization: str | None = None
 
 
 class EngineAdapter(Protocol):
-    def run(self, *, prompt: str, n_tokens: int, warmup: bool) -> AdapterRunResult: ...
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> AdapterRunResult: ...
 
 
 # Populated by engine-adapter modules landed alongside each script migration
@@ -476,25 +581,26 @@ def run_profile(
 ) -> HarnessRunResult:
     """Execute `profile` against `adapters` and return every raw observation.
 
-    Run order is the requested schedule in list order: for each engine (in
-    `profile.engines` order), for each window (in `profile.windows` order —
-    `windows[0]` is the shared baseline, executed once and reused for every
-    comparison window that follows it), warmup runs first, then measured
-    runs. `order_index` is a single counter across the entire call, so a
-    later statistical pass (issue #714) can test for order/thermal bias
-    without another schema migration.
+    Run order is the requested schedule in list order: for each engine run
+    group (in `profile.engine_groups` order), for each window (in
+    `profile.windows` order — `windows[0]` is the shared baseline, executed
+    once and reused for every comparison window that follows it), that
+    engine's own warmup runs first, then measured runs. `order_index` is a
+    single counter across the entire call, so a later statistical pass
+    (issue #714) can test for order/thermal bias without another schema
+    migration.
     """
     resolved_git_sha = git_sha_value if git_sha_value is not None else git_sha(repo_root)
     resolved_hardware_id = hardware_id_value if hardware_id_value is not None else hardware_id()
     p_hash = prompt_hash(profile.prompt)
 
-    active: dict[str, EngineAdapter] = {}
+    active: dict[str, EngineRunGroup] = {}
     missing: list[str] = []
-    for engine in profile.engines:
-        if engine in adapters:
-            active[engine] = adapters[engine]
+    for group in profile.engine_groups:
+        if group.name in adapters:
+            active[group.name] = group
         else:
-            missing.append(engine)
+            missing.append(group.name)
     if missing and not allow_missing_engine:
         raise MissingEngineError(
             f"profile {profile.name!r} requires engine adapter(s) {missing} that are not registered; "
@@ -503,24 +609,34 @@ def run_profile(
 
     observations: list[Observation] = []
     order_index = 0
-    for engine_name in profile.engines:
-        adapter = active.get(engine_name)
-        if adapter is None:
+    for group in profile.engine_groups:
+        if group.name not in active:
             continue
+        adapter = adapters[group.name]
         for window in profile.windows:
-            for is_warmup, count in ((True, profile.warmup_repeats), (False, profile.measured_repeats)):
+            for is_warmup, count in ((True, group.warmup_repeats), (False, profile.measured_repeats)):
                 for run_index in range(1, count + 1):
                     t0 = clock()
-                    result = adapter.run(prompt=profile.prompt, n_tokens=window, warmup=is_warmup)
+                    result = adapter.run(
+                        prompt=profile.prompt,
+                        n_tokens=window,
+                        warmup=is_warmup,
+                        model=group.model,
+                        quantization=group.quantization,
+                    )
                     t1 = clock()
+                    actual_model = result.actual_model if result.actual_model is not None else group.model
+                    actual_quantization = (
+                        result.actual_quantization if result.actual_quantization is not None else group.quantization
+                    )
                     obs = Observation(
                         schema_version=SCHEMA_VERSION,
                         git_sha=resolved_git_sha,
                         profile=profile.name,
-                        engine=engine_name,
+                        engine=group.name,
                         engine_version=result.engine_version,
-                        model=profile.model,
-                        quantization=profile.quantization,
+                        model=actual_model,
+                        quantization=actual_quantization,
                         prompt_hash=p_hash,
                         requested_prompt_tokens=profile.requested_prompt_tokens,
                         actual_prompt_tokens=result.actual_prompt_tokens,
@@ -555,7 +671,17 @@ class SlopeResult:
     baseline_window: int
     window: int
     slope_tok_per_s: float
-    slope_ci95: float | None
+    # Legacy normal-approximation heuristic carried over verbatim from
+    # `bench_apples_precise.sh:118-143` (issue #813 explicitly defers
+    # statistical-methodology changes to a separately reviewed follow-up).
+    # This is NOT a coverage-valid 95% confidence interval for the slope:
+    # it treats the trimmed subset as an ordinary sample, applies a
+    # large-sample z=1.96 multiplier regardless of the retained sample
+    # size, and combines the two window CIs with relative-error
+    # (product/ratio) propagation rather than the sensitivity-coefficient
+    # propagation a difference-then-reciprocal statistic requires. Present
+    # it to a reader as a legacy spread heuristic only, never as "±95% CI".
+    slope_ci95_legacy: float | None
     baseline_n: int
     window_n: int
 
@@ -573,14 +699,21 @@ def _median_stat(values: list[float]) -> tuple[float, None]:
 
 
 def _trimmed_mean_stat(values: list[float], trim: int) -> tuple[float, float]:
+    """Trimmed mean + the legacy normal-approximation spread heuristic.
+
+    The second return value is `bench_apples_precise.sh`'s pre-existing
+    `1.96 * stdev / sqrt(n)` heuristic over the *retained* (trimmed)
+    subset, carried over verbatim rather than corrected -- see
+    `SlopeResult.slope_ci95_legacy` for why it is not a coverage-valid CI.
+    """
     ordered = sorted(values)
     trimmed = ordered[trim: len(ordered) - trim] if trim > 0 and len(ordered) > 2 * trim else ordered
     mean = statistics.mean(trimmed)
     if len(trimmed) > 1:
-        ci95 = 1.96 * (statistics.stdev(trimmed) / math.sqrt(len(trimmed)))
+        ci95_legacy = 1.96 * (statistics.stdev(trimmed) / math.sqrt(len(trimmed)))
     else:
-        ci95 = 0.0
-    return mean, ci95
+        ci95_legacy = 0.0
+    return mean, ci95_legacy
 
 
 def _window_stat(values: list[float], aggregation: str, trim: int) -> tuple[float, float | None]:
@@ -595,6 +728,12 @@ def aggregate(run_result: HarnessRunResult) -> list[SlopeResult]:
     `slope_tok_per_s = (window - baseline_window) / (T(window) - T(baseline))`,
     with `T` the profile's configured aggregation of measured (non-warmup)
     elapsed time. `baseline_window` is always `profile.windows[0]`.
+
+    `SlopeResult.slope_ci95_legacy`, when the profile uses `trimmed_mean`
+    aggregation, is the pre-existing `bench_apples_precise.sh` spread
+    heuristic propagated through the slope's product/ratio form -- a
+    legacy carry-over, not a corrected or coverage-valid CI (issue #813
+    defers statistical-methodology changes to a separate review).
     """
     profile = run_result.profile
     baseline_window = profile.windows[0]
@@ -603,31 +742,33 @@ def aggregate(run_result: HarnessRunResult) -> list[SlopeResult]:
         baseline_values = _measured_elapsed_seconds(run_result.observations, engine, baseline_window)
         if not baseline_values:
             continue
-        baseline_mean, baseline_ci = _window_stat(baseline_values, profile.aggregation, profile.trim)
+        baseline_mean, baseline_ci_legacy = _window_stat(baseline_values, profile.aggregation, profile.trim)
         for window in profile.windows[1:]:
             values = _measured_elapsed_seconds(run_result.observations, engine, window)
             if not values:
                 continue
-            window_mean, window_ci = _window_stat(values, profile.aggregation, profile.trim)
+            window_mean, window_ci_legacy = _window_stat(values, profile.aggregation, profile.trim)
             dt = window_mean - baseline_mean
             slope = (window - baseline_window) / dt if dt > 0 else float("nan")
-            slope_ci: float | None = None
+            slope_ci_legacy: float | None = None
             if (
                 profile.aggregation == "trimmed_mean"
-                and baseline_ci is not None
-                and window_ci is not None
+                and baseline_ci_legacy is not None
+                and window_ci_legacy is not None
                 and baseline_mean > 0
                 and window_mean > 0
                 and slope == slope  # not NaN
             ):
-                slope_ci = slope * math.sqrt((baseline_ci / baseline_mean) ** 2 + (window_ci / window_mean) ** 2)
+                slope_ci_legacy = slope * math.sqrt(
+                    (baseline_ci_legacy / baseline_mean) ** 2 + (window_ci_legacy / window_mean) ** 2
+                )
             results.append(
                 SlopeResult(
                     engine=engine,
                     baseline_window=baseline_window,
                     window=window,
                     slope_tok_per_s=slope,
-                    slope_ci95=slope_ci,
+                    slope_ci95_legacy=slope_ci_legacy,
                     baseline_n=len(baseline_values),
                     window_n=len(values),
                 )
@@ -658,11 +799,16 @@ def render_report(run_result: HarnessRunResult, slopes: list[SlopeResult]) -> st
     if not slopes:
         lines.append("  (no measured data)")
         return "\n".join(lines)
-    lines.append(f"  {'engine':<10}{'window':>8}{'slope tok/s':>13}{'±95% CI':>10}{'native tok/s':>14}{'n(base/win)':>13}")
-    lines.append("  " + "-" * 68)
+    # "legacy ±CI" -- the normal-approximation heuristic carried over from
+    # bench_apples_precise.sh, not a coverage-valid 95% CI. See
+    # SlopeResult.slope_ci95_legacy.
+    lines.append(
+        f"  {'engine':<10}{'window':>8}{'slope tok/s':>13}{'legacy ±CI':>11}{'native tok/s':>14}{'n(base/win)':>13}"
+    )
+    lines.append("  " + "-" * 69)
     for s in slopes:
         native = native_throughput(run_result, s.engine)
-        ci_str = f"{s.slope_ci95:10.1f}" if s.slope_ci95 is not None else f"{'—':>10}"
+        ci_str = f"{s.slope_ci95_legacy:11.1f}" if s.slope_ci95_legacy is not None else f"{'—':>11}"
         native_str = f"{native:14.1f}" if native is not None else f"{'—':>14}"
         lines.append(
             f"  {s.engine:<10}{s.window:>8}{s.slope_tok_per_s:13.1f}{ci_str}{native_str}"

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+"""Decode-benchmark harness core (issue #813).
+
+`scripts/` grew seven independent implementations of the same
+prompt/decode-benchmark shape (`bench_apples_to_apples.sh`,
+`bench_apples_precise.sh`, `bench_q4_apples.sh`, `bench_context_scaling.sh`,
+`bench_compare_1k.py`, plus two proven-dead scripts tracked separately), each
+owning its own copy of warmup policy, sample-count policy,
+aggregation/confidence-interval method, and output rendering. This module is
+the single place that owns all of that: configuration validation, warmup
+count, requested schedule, run order, monotonic wall timing, the raw
+observation schema, aggregation, confidence-interval calculation, and output
+rendering.
+
+Engine adapters (Lattice, Ollama, MLX) own only invocation and parsing: they
+implement `EngineAdapter.run()`, may surface an engine-native duration as a
+diagnostic field, and MUST NOT choose repeat counts, discard samples, or
+compute verdicts. No adapters ship in this module yet — this lands the
+harness core only ("no public command change", issue #813 step 1). The five
+live scripts above are migrated onto profiles defined in
+`bench_decode_profiles.toml` one script per PR (issue #813 step 2); until
+then `bench_decode_profiles.toml` carries no profile definitions and the
+`run` subcommand below has nothing registered in `ADAPTER_REGISTRY`, so an
+engine request always resolves as "missing" (see `--allow-missing-engine`).
+
+Raw JSONL observation schema (the contract; see `OBSERVATION_FIELDS` /
+`validate_observation`): schema version, git SHA, profile name, engine +
+version, model/quantization, prompt hash, requested and actual prompt/
+completion token counts, warmup/measured flag, run and order indices, the
+harness-measured elapsed nanoseconds, an optional engine-native nanosecond
+figure, a hardware identifier, and a timestamp. Reports render from this raw
+data; they are not the source of truth.
+
+Run with: python3 -m unittest tests/test_bench_decode_harness.py -v
+(the module itself is stdlib-only; no engine binaries or third-party
+packages are required to exercise it).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import math
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+import tomllib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Mapping, Protocol
+
+SCHEMA_VERSION = 1
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PROFILES_FILE = REPO_ROOT / "scripts" / "bench_decode_profiles.toml"
+
+AGGREGATION_METHODS = ("median", "trimmed_mean")
+
+
+class ProfileConfigError(ValueError):
+    """A profile definition in `bench_decode_profiles.toml` is invalid."""
+
+
+class ObservationValidationError(ValueError):
+    """A raw observation does not conform to the schema contract."""
+
+
+class MissingEngineError(RuntimeError):
+    """A profile requested an engine with no adapter registered for it."""
+
+
+# --------------------------------------------------------------------------
+# Raw observation schema (the contract)
+# --------------------------------------------------------------------------
+
+# name -> expected type, or a tuple of types (nullable fields use (T, NoneType))
+OBSERVATION_FIELDS: dict[str, object] = {
+    "schema_version": int,
+    "git_sha": str,
+    "profile": str,
+    "engine": str,
+    "engine_version": str,
+    "model": str,
+    "quantization": str,
+    "prompt_hash": str,
+    "requested_prompt_tokens": (int, type(None)),
+    "actual_prompt_tokens": (int, type(None)),
+    "requested_completion_tokens": int,
+    "actual_completion_tokens": int,
+    "warmup": bool,
+    "run_index": int,
+    "order_index": int,
+    "elapsed_ns": int,
+    "engine_native_ns": (int, type(None)),
+    "hardware_id": str,
+    "timestamp": str,
+}
+
+_NON_EMPTY_STRING_FIELDS = (
+    "git_sha",
+    "profile",
+    "engine",
+    "engine_version",
+    "model",
+    "quantization",
+    "prompt_hash",
+    "hardware_id",
+)
+
+
+@dataclass(frozen=True)
+class Observation:
+    schema_version: int
+    git_sha: str
+    profile: str
+    engine: str
+    engine_version: str
+    model: str
+    quantization: str
+    prompt_hash: str
+    requested_prompt_tokens: int | None
+    actual_prompt_tokens: int | None
+    requested_completion_tokens: int
+    actual_completion_tokens: int
+    warmup: bool
+    run_index: int
+    order_index: int
+    elapsed_ns: int
+    engine_native_ns: int | None
+    hardware_id: str
+    timestamp: str
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+def validate_observation(row: dict) -> None:
+    """Validate a raw observation dict against the schema contract.
+
+    Fail-closed: unknown fields, missing fields, wrong types, and
+    out-of-range values are all rejected. Raises `ObservationValidationError`
+    on any violation; returns None on success.
+    """
+    if not isinstance(row, dict):
+        raise ObservationValidationError(f"observation must be an object, got {type(row).__name__}")
+
+    extra = set(row) - set(OBSERVATION_FIELDS)
+    if extra:
+        raise ObservationValidationError(f"unexpected field(s): {sorted(extra)}")
+    missing = set(OBSERVATION_FIELDS) - set(row)
+    if missing:
+        raise ObservationValidationError(f"missing required field(s): {sorted(missing)}")
+
+    for name, expected in OBSERVATION_FIELDS.items():
+        _check_field_type(name, row[name], expected)
+
+    if row["schema_version"] != SCHEMA_VERSION:
+        raise ObservationValidationError(
+            f"schema_version {row['schema_version']!r} != supported {SCHEMA_VERSION}"
+        )
+    for name in _NON_EMPTY_STRING_FIELDS:
+        if not row[name]:
+            raise ObservationValidationError(f"field {name!r} must be non-empty")
+    if row["requested_completion_tokens"] < 0:
+        raise ObservationValidationError("requested_completion_tokens must be >= 0")
+    if row["actual_completion_tokens"] < 0:
+        raise ObservationValidationError("actual_completion_tokens must be >= 0")
+    for name in ("requested_prompt_tokens", "actual_prompt_tokens"):
+        if row[name] is not None and row[name] < 0:
+            raise ObservationValidationError(f"field {name!r} must be >= 0 or null")
+    if row["run_index"] < 1:
+        raise ObservationValidationError("run_index must be >= 1")
+    if row["order_index"] < 0:
+        raise ObservationValidationError("order_index must be >= 0")
+    if row["elapsed_ns"] < 0:
+        raise ObservationValidationError("elapsed_ns must be >= 0")
+    if row["engine_native_ns"] is not None and row["engine_native_ns"] < 0:
+        raise ObservationValidationError("engine_native_ns must be >= 0 or null")
+    try:
+        datetime.fromisoformat(row["timestamp"].replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ObservationValidationError(f"timestamp {row['timestamp']!r} is not ISO 8601: {exc}") from exc
+
+
+def _check_field_type(name: str, value: object, expected: object) -> None:
+    # bool is a subclass of int in Python -- reject it everywhere an int (or
+    # int-or-None) is expected, and require it explicitly where `bool` itself
+    # is the declared type, so a stray `1`/`0` cannot silently pass as a flag
+    # (or vice versa).
+    if expected is bool:
+        if not isinstance(value, bool):
+            raise ObservationValidationError(f"field {name!r} must be bool, got {type(value).__name__}")
+        return
+    if expected is int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ObservationValidationError(f"field {name!r} must be int, got {type(value).__name__}")
+        return
+    if isinstance(expected, tuple):
+        if isinstance(value, bool) or not isinstance(value, expected):
+            names = "/".join(t.__name__ for t in expected)
+            raise ObservationValidationError(f"field {name!r} must be one of {names}, got {type(value).__name__}")
+        return
+    if not isinstance(value, expected):
+        raise ObservationValidationError(
+            f"field {name!r} must be {expected.__name__}, got {type(value).__name__}"
+        )
+
+
+def validate_jsonl(path: Path) -> list[dict]:
+    """Validate every line of a raw-observation JSONL file. Returns the parsed rows."""
+    rows: list[dict] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ObservationValidationError(f"{path}:{line_no}: invalid JSON: {exc}") from exc
+            try:
+                validate_observation(row)
+            except ObservationValidationError as exc:
+                raise ObservationValidationError(f"{path}:{line_no}: {exc}") from exc
+            rows.append(row)
+    return rows
+
+
+def write_jsonl(observations: list[Observation], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for obs in observations:
+            fh.write(json.dumps(obs.to_dict(), sort_keys=True))
+            fh.write("\n")
+
+
+# --------------------------------------------------------------------------
+# Profile configuration
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    name: str
+    description: str
+    windows: tuple[int, ...]
+    warmup_repeats: int
+    measured_repeats: int
+    engines: tuple[str, ...]
+    prompt: str
+    model: str
+    quantization: str
+    aggregation: str = "median"
+    trim: int = 0
+    requested_prompt_tokens: int | None = None
+
+
+def load_profiles_file(path: Path) -> tuple[int, dict[str, ProfileConfig]]:
+    try:
+        with path.open("rb") as fh:
+            doc = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise ProfileConfigError(f"{path}: invalid TOML: {exc}") from exc
+    except OSError as exc:
+        raise ProfileConfigError(f"{path}: could not read profiles file: {exc}") from exc
+
+    schema_version = doc.get("schema_version")
+    if schema_version != SCHEMA_VERSION:
+        raise ProfileConfigError(
+            f"{path}: schema_version {schema_version!r} != supported {SCHEMA_VERSION}"
+        )
+
+    raw_profiles = doc.get("profiles", {})
+    if not isinstance(raw_profiles, dict):
+        raise ProfileConfigError(f"{path}: [profiles] must be a table")
+
+    profiles: dict[str, ProfileConfig] = {}
+    for name, raw in raw_profiles.items():
+        if not isinstance(raw, dict):
+            raise ProfileConfigError(f"{path}: profile {name!r} must be a table")
+        profiles[name] = _parse_profile(name, raw)
+    return schema_version, profiles
+
+
+def _parse_profile(name: str, raw: dict) -> ProfileConfig:
+    def require(key: str, expected_type: type) -> object:
+        if key not in raw:
+            raise ProfileConfigError(f"profile {name!r}: missing required key {key!r}")
+        value = raw[key]
+        if expected_type is int and isinstance(value, bool):
+            raise ProfileConfigError(f"profile {name!r}: key {key!r} must be int, got bool")
+        if not isinstance(value, expected_type):
+            raise ProfileConfigError(
+                f"profile {name!r}: key {key!r} must be {expected_type.__name__}, got {type(value).__name__}"
+            )
+        return value
+
+    description = str(raw.get("description", ""))
+
+    windows_raw = require("windows", list)
+    if len(windows_raw) < 2:
+        raise ProfileConfigError(f"profile {name!r}: windows must contain at least 2 values")
+    windows: list[int] = []
+    for w in windows_raw:
+        if isinstance(w, bool) or not isinstance(w, int) or w <= 0:
+            raise ProfileConfigError(f"profile {name!r}: windows entries must be positive integers, got {w!r}")
+        windows.append(w)
+    if windows != sorted(windows) or len(set(windows)) != len(windows):
+        raise ProfileConfigError(f"profile {name!r}: windows must be strictly increasing, got {windows}")
+
+    warmup_repeats = require("warmup_repeats", int)
+    if warmup_repeats < 0:
+        raise ProfileConfigError(f"profile {name!r}: warmup_repeats must be >= 0")
+
+    measured_repeats = require("measured_repeats", int)
+    if measured_repeats < 1:
+        raise ProfileConfigError(f"profile {name!r}: measured_repeats must be >= 1")
+
+    engines_raw = require("engines", list)
+    if not engines_raw:
+        raise ProfileConfigError(f"profile {name!r}: engines must not be empty")
+    engines: list[str] = []
+    for e in engines_raw:
+        if not isinstance(e, str) or not e:
+            raise ProfileConfigError(f"profile {name!r}: engines entries must be non-empty strings")
+        engines.append(e)
+    if len(set(engines)) != len(engines):
+        raise ProfileConfigError(f"profile {name!r}: engines must not contain duplicates, got {engines}")
+
+    prompt = require("prompt", str)
+    if not prompt:
+        raise ProfileConfigError(f"profile {name!r}: prompt must be non-empty")
+    model = require("model", str)
+    if not model:
+        raise ProfileConfigError(f"profile {name!r}: model must be non-empty")
+    quantization = require("quantization", str)
+    if not quantization:
+        raise ProfileConfigError(f"profile {name!r}: quantization must be non-empty")
+
+    aggregation = str(raw.get("aggregation", "median"))
+    if aggregation not in AGGREGATION_METHODS:
+        raise ProfileConfigError(
+            f"profile {name!r}: aggregation must be one of {AGGREGATION_METHODS}, got {aggregation!r}"
+        )
+
+    trim = raw.get("trim", 0)
+    if isinstance(trim, bool) or not isinstance(trim, int) or trim < 0:
+        raise ProfileConfigError(f"profile {name!r}: trim must be a non-negative int")
+    if aggregation == "median" and trim != 0:
+        raise ProfileConfigError(f"profile {name!r}: trim is only meaningful for aggregation='trimmed_mean'")
+    if aggregation == "trimmed_mean" and 2 * trim >= measured_repeats:
+        raise ProfileConfigError(
+            f"profile {name!r}: trim={trim} leaves no measured samples for measured_repeats={measured_repeats}"
+        )
+
+    requested_prompt_tokens = raw.get("requested_prompt_tokens")
+    if requested_prompt_tokens is not None:
+        if isinstance(requested_prompt_tokens, bool) or not isinstance(requested_prompt_tokens, int):
+            raise ProfileConfigError(f"profile {name!r}: requested_prompt_tokens must be an int or omitted")
+        if requested_prompt_tokens < 0:
+            raise ProfileConfigError(f"profile {name!r}: requested_prompt_tokens must be >= 0")
+
+    return ProfileConfig(
+        name=name,
+        description=description,
+        windows=tuple(windows),
+        warmup_repeats=warmup_repeats,
+        measured_repeats=measured_repeats,
+        engines=tuple(engines),
+        prompt=prompt,
+        model=model,
+        quantization=quantization,
+        aggregation=aggregation,
+        trim=trim,
+        requested_prompt_tokens=requested_prompt_tokens,
+    )
+
+
+# --------------------------------------------------------------------------
+# Engine adapters
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AdapterRunResult:
+    """What an engine adapter reports for one decode call.
+
+    Adapters own invocation and parsing only: they must not choose repeat
+    counts, discard samples, or compute verdicts. `native_ns`, when present,
+    is surfaced as a diagnostic field alongside the harness-measured timing,
+    never as a replacement for it.
+    """
+
+    actual_completion_tokens: int
+    actual_prompt_tokens: int | None = None
+    native_ns: int | None = None
+    engine_version: str = "unknown"
+
+
+class EngineAdapter(Protocol):
+    def run(self, *, prompt: str, n_tokens: int, warmup: bool) -> AdapterRunResult: ...
+
+
+# Populated by engine-adapter modules landed alongside each script migration
+# (issue #813 step 2). Empty at harness-core landing time by design: no
+# adapter means every profile's engines resolve as "missing" (see
+# `run_profile` / `--allow-missing-engine`), so the CLI never presents a
+# fabricated result for an engine it cannot actually invoke.
+ADAPTER_REGISTRY: dict[str, EngineAdapter] = {}
+
+
+def register_adapter(name: str, adapter: EngineAdapter) -> None:
+    ADAPTER_REGISTRY[name] = adapter
+
+
+# --------------------------------------------------------------------------
+# Run
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HarnessRunResult:
+    profile: ProfileConfig
+    observations: tuple[Observation, ...]
+    missing_engines: tuple[str, ...]
+
+
+def git_sha(repo_root: Path | None = None) -> str:
+    root = repo_root or REPO_ROOT
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return "unknown"
+    sha = proc.stdout.strip()
+    return sha if sha else "unknown"
+
+
+def hardware_id() -> str:
+    override = os.environ.get("LATTICE_BENCH_HARDWARE_ID")
+    if override:
+        return override
+    return f"{platform.system()}-{platform.machine()}-{platform.node()}"
+
+
+def prompt_hash(prompt: str) -> str:
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def run_profile(
+    profile: ProfileConfig,
+    adapters: Mapping[str, EngineAdapter],
+    *,
+    allow_missing_engine: bool = False,
+    clock: Callable[[], int] = time.perf_counter_ns,
+    git_sha_value: str | None = None,
+    hardware_id_value: str | None = None,
+    timestamp_fn: Callable[[], str] = _utc_timestamp,
+    repo_root: Path | None = None,
+) -> HarnessRunResult:
+    """Execute `profile` against `adapters` and return every raw observation.
+
+    Run order is the requested schedule in list order: for each engine (in
+    `profile.engines` order), for each window (in `profile.windows` order —
+    `windows[0]` is the shared baseline, executed once and reused for every
+    comparison window that follows it), warmup runs first, then measured
+    runs. `order_index` is a single counter across the entire call, so a
+    later statistical pass (issue #714) can test for order/thermal bias
+    without another schema migration.
+    """
+    resolved_git_sha = git_sha_value if git_sha_value is not None else git_sha(repo_root)
+    resolved_hardware_id = hardware_id_value if hardware_id_value is not None else hardware_id()
+    p_hash = prompt_hash(profile.prompt)
+
+    active: dict[str, EngineAdapter] = {}
+    missing: list[str] = []
+    for engine in profile.engines:
+        if engine in adapters:
+            active[engine] = adapters[engine]
+        else:
+            missing.append(engine)
+    if missing and not allow_missing_engine:
+        raise MissingEngineError(
+            f"profile {profile.name!r} requires engine adapter(s) {missing} that are not registered; "
+            "pass --allow-missing-engine to run without them (stale/prior results are never substituted)"
+        )
+
+    observations: list[Observation] = []
+    order_index = 0
+    for engine_name in profile.engines:
+        adapter = active.get(engine_name)
+        if adapter is None:
+            continue
+        for window in profile.windows:
+            for is_warmup, count in ((True, profile.warmup_repeats), (False, profile.measured_repeats)):
+                for run_index in range(1, count + 1):
+                    t0 = clock()
+                    result = adapter.run(prompt=profile.prompt, n_tokens=window, warmup=is_warmup)
+                    t1 = clock()
+                    obs = Observation(
+                        schema_version=SCHEMA_VERSION,
+                        git_sha=resolved_git_sha,
+                        profile=profile.name,
+                        engine=engine_name,
+                        engine_version=result.engine_version,
+                        model=profile.model,
+                        quantization=profile.quantization,
+                        prompt_hash=p_hash,
+                        requested_prompt_tokens=profile.requested_prompt_tokens,
+                        actual_prompt_tokens=result.actual_prompt_tokens,
+                        requested_completion_tokens=window,
+                        actual_completion_tokens=result.actual_completion_tokens,
+                        warmup=is_warmup,
+                        run_index=run_index,
+                        order_index=order_index,
+                        elapsed_ns=t1 - t0,
+                        engine_native_ns=result.native_ns,
+                        hardware_id=resolved_hardware_id,
+                        timestamp=timestamp_fn(),
+                    )
+                    validate_observation(obs.to_dict())
+                    observations.append(obs)
+                    order_index += 1
+    return HarnessRunResult(
+        profile=profile,
+        observations=tuple(observations),
+        missing_engines=tuple(missing),
+    )
+
+
+# --------------------------------------------------------------------------
+# Aggregation
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SlopeResult:
+    engine: str
+    baseline_window: int
+    window: int
+    slope_tok_per_s: float
+    slope_ci95: float | None
+    baseline_n: int
+    window_n: int
+
+
+def _measured_elapsed_seconds(observations: tuple[Observation, ...], engine: str, window: int) -> list[float]:
+    return [
+        o.elapsed_ns / 1e9
+        for o in observations
+        if o.engine == engine and o.requested_completion_tokens == window and not o.warmup
+    ]
+
+
+def _median_stat(values: list[float]) -> tuple[float, None]:
+    return statistics.median(values), None
+
+
+def _trimmed_mean_stat(values: list[float], trim: int) -> tuple[float, float]:
+    ordered = sorted(values)
+    trimmed = ordered[trim: len(ordered) - trim] if trim > 0 and len(ordered) > 2 * trim else ordered
+    mean = statistics.mean(trimmed)
+    if len(trimmed) > 1:
+        ci95 = 1.96 * (statistics.stdev(trimmed) / math.sqrt(len(trimmed)))
+    else:
+        ci95 = 0.0
+    return mean, ci95
+
+
+def _window_stat(values: list[float], aggregation: str, trim: int) -> tuple[float, float | None]:
+    if aggregation == "trimmed_mean":
+        return _trimmed_mean_stat(values, trim)
+    return _median_stat(values)
+
+
+def aggregate(run_result: HarnessRunResult) -> list[SlopeResult]:
+    """Compute the marginal decode-throughput slope for every (engine, window) pair.
+
+    `slope_tok_per_s = (window - baseline_window) / (T(window) - T(baseline))`,
+    with `T` the profile's configured aggregation of measured (non-warmup)
+    elapsed time. `baseline_window` is always `profile.windows[0]`.
+    """
+    profile = run_result.profile
+    baseline_window = profile.windows[0]
+    results: list[SlopeResult] = []
+    for engine in profile.engines:
+        baseline_values = _measured_elapsed_seconds(run_result.observations, engine, baseline_window)
+        if not baseline_values:
+            continue
+        baseline_mean, baseline_ci = _window_stat(baseline_values, profile.aggregation, profile.trim)
+        for window in profile.windows[1:]:
+            values = _measured_elapsed_seconds(run_result.observations, engine, window)
+            if not values:
+                continue
+            window_mean, window_ci = _window_stat(values, profile.aggregation, profile.trim)
+            dt = window_mean - baseline_mean
+            slope = (window - baseline_window) / dt if dt > 0 else float("nan")
+            slope_ci: float | None = None
+            if (
+                profile.aggregation == "trimmed_mean"
+                and baseline_ci is not None
+                and window_ci is not None
+                and baseline_mean > 0
+                and window_mean > 0
+                and slope == slope  # not NaN
+            ):
+                slope_ci = slope * math.sqrt((baseline_ci / baseline_mean) ** 2 + (window_ci / window_mean) ** 2)
+            results.append(
+                SlopeResult(
+                    engine=engine,
+                    baseline_window=baseline_window,
+                    window=window,
+                    slope_tok_per_s=slope,
+                    slope_ci95=slope_ci,
+                    baseline_n=len(baseline_values),
+                    window_n=len(values),
+                )
+            )
+    return results
+
+
+def native_throughput(run_result: HarnessRunResult, engine: str) -> float | None:
+    """Median engine-native tok/s across every measured observation with a native duration, or None."""
+    rates = [
+        o.actual_completion_tokens / (o.engine_native_ns / 1e9)
+        for o in run_result.observations
+        if o.engine == engine and not o.warmup and o.engine_native_ns
+    ]
+    return statistics.median(rates) if rates else None
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+def render_report(run_result: HarnessRunResult, slopes: list[SlopeResult]) -> str:
+    profile = run_result.profile
+    lines = [f"=== {profile.name} | windows={list(profile.windows)} | aggregation={profile.aggregation} ==="]
+    if run_result.missing_engines:
+        lines.append(f"  (missing engine adapter(s), skipped: {', '.join(run_result.missing_engines)})")
+    if not slopes:
+        lines.append("  (no measured data)")
+        return "\n".join(lines)
+    lines.append(f"  {'engine':<10}{'window':>8}{'slope tok/s':>13}{'±95% CI':>10}{'native tok/s':>14}{'n(base/win)':>13}")
+    lines.append("  " + "-" * 68)
+    for s in slopes:
+        native = native_throughput(run_result, s.engine)
+        ci_str = f"{s.slope_ci95:10.1f}" if s.slope_ci95 is not None else f"{'—':>10}"
+        native_str = f"{native:14.1f}" if native is not None else f"{'—':>14}"
+        lines.append(
+            f"  {s.engine:<10}{s.window:>8}{s.slope_tok_per_s:13.1f}{ci_str}{native_str}"
+            f"{f'{s.baseline_n}/{s.window_n}':>13}"
+        )
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bench_decode_harness.py",
+        description="Consolidated decode-benchmark harness (issue #813).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_p = sub.add_parser("run", help="Run a profile and report decode-throughput slopes.")
+    run_p.add_argument("--profile", required=True, help="Profile name from bench_decode_profiles.toml")
+    run_p.add_argument("--profiles-file", type=Path, default=DEFAULT_PROFILES_FILE)
+    run_p.add_argument(
+        "--allow-missing-engine",
+        action="store_true",
+        help="Continue with whatever engine adapters are registered instead of failing on a missing one.",
+    )
+    run_p.add_argument("--out", type=Path, default=None, help="Write raw observations as JSONL to this path.")
+
+    val_p = sub.add_parser("validate", help="Validate a raw-observation JSONL file against the schema.")
+    val_p.add_argument("path", type=Path)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+
+    if args.command == "validate":
+        try:
+            rows = validate_jsonl(args.path)
+        except ObservationValidationError as exc:
+            print(f"FAIL: {exc}", file=sys.stderr)
+            return 1
+        except OSError as exc:
+            print(f"FAIL: could not read {args.path}: {exc}", file=sys.stderr)
+            return 1
+        print(f"OK: {len(rows)} observation(s) valid against schema v{SCHEMA_VERSION}")
+        return 0
+
+    if args.command == "run":
+        try:
+            _, profiles = load_profiles_file(args.profiles_file)
+        except ProfileConfigError as exc:
+            print(f"FAIL: {exc}", file=sys.stderr)
+            return 1
+        profile = profiles.get(args.profile)
+        if profile is None:
+            available = ", ".join(sorted(profiles)) or "(none defined yet)"
+            print(f"FAIL: unknown profile {args.profile!r}. Available: {available}", file=sys.stderr)
+            return 1
+        try:
+            result = run_profile(profile, ADAPTER_REGISTRY, allow_missing_engine=args.allow_missing_engine)
+        except MissingEngineError as exc:
+            print(f"FAIL: {exc}", file=sys.stderr)
+            return 1
+        slopes = aggregate(result)
+        print(render_report(result, slopes))
+        if args.out is not None:
+            write_jsonl(list(result.observations), args.out)
+            print(f"\nRaw observations: {args.out}")
+        return 0
+
+    return 1  # pragma: no cover -- argparse `required=True` makes this unreachable
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -24,15 +24,25 @@ then `bench_decode_profiles.toml` carries no profile definitions and the
 engine request always resolves as "missing" (see `--allow-missing-engine`).
 
 A profile's `engines` list is an ordered set of per-engine run groups, not
-a flat list of names: each entry carries its own `warmup_repeats`, `model`,
-and `quantization` (see `EngineRunGroup`), because the legacy scripts this
-harness consolidates give each engine its own warmup schedule and, for the
+a flat list of names: each entry carries its own warmup schedule
+(`warmup_repeats`, `warmup_tokens`, optional `warmup_prompt`), `model`, and
+`quantization` (see `EngineRunGroup`), because the legacy scripts this
+harness consolidates give each engine its own warmup shape and, for the
 Q4/Q8 comparison, a different quantization per engine within one profile.
-`windows`, `measured_repeats`, and `prompt` stay profile-wide because every
-legacy script keeps those uniform across engines. The requested
-model/quantization is passed into `EngineAdapter.run()`; an adapter that
-invokes a different artifact than requested (fallback, missing checkpoint,
-...) reports the actual identity back via `AdapterRunResult.actual_model`/
+A warmup is an explicit pre-window batch: `warmup_repeats` calls at
+`warmup_tokens` completion tokens execute ONCE per engine, entirely before
+that engine's measured windows -- never once per window -- so
+`bench_apples_to_apples.sh`'s single pre-loop 8-token MLX warmup,
+`bench_apples_precise.sh`'s twice-at-N2 warmup for every engine, and
+`bench_context_scaling.sh`'s single pre-loop 4-token MLX warmup are each
+exactly representable, including `bench_compare_1k.py`'s distinct
+per-engine warmup prompts via `warmup_prompt` (defaults to `profile.prompt`
+when omitted). `windows`, `measured_repeats`, and the measured `prompt`
+stay profile-wide because every legacy script keeps those uniform across
+engines; only the warmup differs per engine. The requested model/
+quantization is passed into `EngineAdapter.run()`; an adapter that invokes
+a different artifact than requested (fallback, missing checkpoint, ...)
+reports the actual identity back via `AdapterRunResult.actual_model`/
 `actual_quantization`, and raw observations always record the actual
 invoked identity, never a value merely assumed from the profile.
 
@@ -268,15 +278,27 @@ def write_jsonl(observations: list[Observation], path: Path) -> None:
 class EngineRunGroup:
     """One engine's schedule within a profile.
 
-    Every legacy script gives each engine its own warmup count and its own
-    model/quantization identity (`bench_apples_to_apples.sh`: only MLX gets
-    a warmup; `bench_q4_apples.sh`: Lattice and MLX run Q4, Ollama runs Q8 as
-    a reference). `measured_repeats`, `windows`, and `prompt` stay profile-
-    wide because every legacy script keeps those uniform across engines.
+    Every legacy script gives each engine its own warmup schedule and its
+    own model/quantization identity (`bench_apples_to_apples.sh`: only MLX
+    gets a warmup, once, at 8 tokens, before the N1/N2 loop;
+    `bench_apples_precise.sh`: every engine warms twice at N2=512, once
+    before both measured windows; `bench_context_scaling.sh`: MLX warms
+    once at 4 tokens before the baseline/comparison loop;
+    `bench_compare_1k.py`: Ollama and MLX each warm at 4 tokens with their
+    own warmup prompt, distinct from the measured prompt). A warmup is
+    therefore an explicit pre-window batch -- `warmup_repeats` calls at
+    `warmup_tokens` completion tokens, using `warmup_prompt` if given or
+    `profile.prompt` otherwise -- executed once per engine, entirely
+    before that engine's measured windows, never once per window.
+    `measured_repeats`, `windows`, and the measured `prompt` stay
+    profile-wide because every legacy script keeps those uniform across
+    engines; only the warmup differs per engine.
     """
 
     name: str
     warmup_repeats: int
+    warmup_tokens: int | None
+    warmup_prompt: str | None
     model: str
     quantization: str
 
@@ -312,7 +334,9 @@ _PROFILE_ALLOWED_KEYS = frozenset(
         "requested_prompt_tokens",
     }
 )
-_ENGINE_GROUP_ALLOWED_KEYS = frozenset({"name", "warmup_repeats", "model", "quantization"})
+_ENGINE_GROUP_ALLOWED_KEYS = frozenset(
+    {"name", "warmup_repeats", "warmup_tokens", "warmup_prompt", "model", "quantization"}
+)
 
 
 def load_profiles_file(path: Path) -> tuple[int, dict[str, ProfileConfig]]:
@@ -423,6 +447,40 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
         if eg_warmup < 0:
             raise ProfileConfigError(f"profile {name!r}: engines[{idx}] warmup_repeats must be >= 0")
 
+        # Warmup is an explicit pre-window batch: `warmup_tokens` is the
+        # completion-token budget for those `warmup_repeats` calls, and is
+        # only meaningful (and only required) when there is a warmup to
+        # schedule -- the same "only meaningful together" pattern as
+        # aggregation='trimmed_mean'/trim above.
+        eg_warmup_tokens_raw = eg_raw.get("warmup_tokens")
+        if eg_warmup_tokens_raw is not None:
+            if isinstance(eg_warmup_tokens_raw, bool) or not isinstance(eg_warmup_tokens_raw, int):
+                raise ProfileConfigError(f"profile {name!r}: engines[{idx}] warmup_tokens must be an int")
+            if eg_warmup_tokens_raw <= 0:
+                raise ProfileConfigError(f"profile {name!r}: engines[{idx}] warmup_tokens must be a positive int")
+        if eg_warmup > 0 and eg_warmup_tokens_raw is None:
+            raise ProfileConfigError(
+                f"profile {name!r}: engines[{idx}] warmup_tokens is required when warmup_repeats > 0"
+            )
+        if eg_warmup == 0 and eg_warmup_tokens_raw is not None:
+            raise ProfileConfigError(
+                f"profile {name!r}: engines[{idx}] warmup_tokens is only meaningful when warmup_repeats > 0"
+            )
+        eg_warmup_tokens = eg_warmup_tokens_raw
+
+        # warmup_prompt is optional at any warmup_repeats value (it is
+        # simply unused when warmup_repeats == 0); when omitted, the
+        # warmup uses `profile.prompt` (see `run_profile`).
+        eg_warmup_prompt_raw = eg_raw.get("warmup_prompt")
+        if eg_warmup_prompt_raw is not None:
+            if not isinstance(eg_warmup_prompt_raw, str):
+                raise ProfileConfigError(f"profile {name!r}: engines[{idx}] warmup_prompt must be a string")
+            if not eg_warmup_prompt_raw:
+                raise ProfileConfigError(
+                    f"profile {name!r}: engines[{idx}] warmup_prompt must be non-empty if provided"
+                )
+        eg_warmup_prompt = eg_warmup_prompt_raw
+
         eg_model = eg_require("model", str)
         if not eg_model:
             raise ProfileConfigError(f"profile {name!r}: engines[{idx}] model must be non-empty")
@@ -432,7 +490,14 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
             raise ProfileConfigError(f"profile {name!r}: engines[{idx}] quantization must be non-empty")
 
         engine_groups.append(
-            EngineRunGroup(name=eg_name, warmup_repeats=eg_warmup, model=eg_model, quantization=eg_quantization)
+            EngineRunGroup(
+                name=eg_name,
+                warmup_repeats=eg_warmup,
+                warmup_tokens=eg_warmup_tokens,
+                warmup_prompt=eg_warmup_prompt,
+                model=eg_model,
+                quantization=eg_quantization,
+            )
         )
 
     prompt = require("prompt", str)
@@ -582,17 +647,23 @@ def run_profile(
     """Execute `profile` against `adapters` and return every raw observation.
 
     Run order is the requested schedule in list order: for each engine run
-    group (in `profile.engine_groups` order), for each window (in
-    `profile.windows` order — `windows[0]` is the shared baseline, executed
-    once and reused for every comparison window that follows it), that
-    engine's own warmup runs first, then measured runs. `order_index` is a
-    single counter across the entire call, so a later statistical pass
-    (issue #714) can test for order/thermal bias without another schema
-    migration.
+    group (in `profile.engine_groups` order), that engine's warmup batch —
+    `warmup_repeats` calls at `warmup_tokens` completion tokens, using
+    `warmup_prompt` if given or `profile.prompt` otherwise — executes
+    ONCE, entirely before any of that engine's measured windows (never
+    once per window; this is what makes `bench_apples_to_apples.sh`'s
+    single pre-loop MLX warmup, `bench_apples_precise.sh`'s twice-at-N2
+    warmup, and `bench_context_scaling.sh`'s single pre-loop warmup all
+    exactly representable). Measured runs then execute for each window (in
+    `profile.windows` order — `windows[0]` is the shared baseline,
+    executed once and reused for every comparison window that follows it).
+    `order_index` is a single counter across the entire call, so a later
+    statistical pass (issue #714) can test for order/thermal bias without
+    another schema migration.
     """
     resolved_git_sha = git_sha_value if git_sha_value is not None else git_sha(repo_root)
     resolved_hardware_id = hardware_id_value if hardware_id_value is not None else hardware_id()
-    p_hash = prompt_hash(profile.prompt)
+    measured_prompt_hash = prompt_hash(profile.prompt)
 
     active: dict[str, EngineRunGroup] = {}
     missing: list[str] = []
@@ -609,50 +680,92 @@ def run_profile(
 
     observations: list[Observation] = []
     order_index = 0
+
+    def _record(
+        *,
+        adapter: EngineAdapter,
+        group: EngineRunGroup,
+        call_prompt: str,
+        call_prompt_hash: str,
+        n_tokens: int,
+        is_warmup: bool,
+        run_index: int,
+    ) -> None:
+        nonlocal order_index
+        t0 = clock()
+        result = adapter.run(
+            prompt=call_prompt,
+            n_tokens=n_tokens,
+            warmup=is_warmup,
+            model=group.model,
+            quantization=group.quantization,
+        )
+        t1 = clock()
+        actual_model = result.actual_model if result.actual_model is not None else group.model
+        actual_quantization = (
+            result.actual_quantization if result.actual_quantization is not None else group.quantization
+        )
+        obs = Observation(
+            schema_version=SCHEMA_VERSION,
+            git_sha=resolved_git_sha,
+            profile=profile.name,
+            engine=group.name,
+            engine_version=result.engine_version,
+            model=actual_model,
+            quantization=actual_quantization,
+            prompt_hash=call_prompt_hash,
+            requested_prompt_tokens=profile.requested_prompt_tokens,
+            actual_prompt_tokens=result.actual_prompt_tokens,
+            requested_completion_tokens=n_tokens,
+            actual_completion_tokens=result.actual_completion_tokens,
+            warmup=is_warmup,
+            run_index=run_index,
+            order_index=order_index,
+            elapsed_ns=t1 - t0,
+            engine_native_ns=result.native_ns,
+            hardware_id=resolved_hardware_id,
+            timestamp=timestamp_fn(),
+        )
+        validate_observation(obs.to_dict())
+        observations.append(obs)
+        order_index += 1
+
     for group in profile.engine_groups:
         if group.name not in active:
             continue
         adapter = adapters[group.name]
+
+        # Warmup batch: once, before any measured window, at the group's
+        # own token budget and prompt (default: profile.prompt).
+        if group.warmup_repeats > 0:
+            warmup_prompt = group.warmup_prompt if group.warmup_prompt is not None else profile.prompt
+            warmup_prompt_hash = (
+                measured_prompt_hash if group.warmup_prompt is None else prompt_hash(group.warmup_prompt)
+            )
+            for run_index in range(1, group.warmup_repeats + 1):
+                _record(
+                    adapter=adapter,
+                    group=group,
+                    call_prompt=warmup_prompt,
+                    call_prompt_hash=warmup_prompt_hash,
+                    n_tokens=group.warmup_tokens,
+                    is_warmup=True,
+                    run_index=run_index,
+                )
+
+        # Measured windows: run_index resets per window.
         for window in profile.windows:
-            for is_warmup, count in ((True, group.warmup_repeats), (False, profile.measured_repeats)):
-                for run_index in range(1, count + 1):
-                    t0 = clock()
-                    result = adapter.run(
-                        prompt=profile.prompt,
-                        n_tokens=window,
-                        warmup=is_warmup,
-                        model=group.model,
-                        quantization=group.quantization,
-                    )
-                    t1 = clock()
-                    actual_model = result.actual_model if result.actual_model is not None else group.model
-                    actual_quantization = (
-                        result.actual_quantization if result.actual_quantization is not None else group.quantization
-                    )
-                    obs = Observation(
-                        schema_version=SCHEMA_VERSION,
-                        git_sha=resolved_git_sha,
-                        profile=profile.name,
-                        engine=group.name,
-                        engine_version=result.engine_version,
-                        model=actual_model,
-                        quantization=actual_quantization,
-                        prompt_hash=p_hash,
-                        requested_prompt_tokens=profile.requested_prompt_tokens,
-                        actual_prompt_tokens=result.actual_prompt_tokens,
-                        requested_completion_tokens=window,
-                        actual_completion_tokens=result.actual_completion_tokens,
-                        warmup=is_warmup,
-                        run_index=run_index,
-                        order_index=order_index,
-                        elapsed_ns=t1 - t0,
-                        engine_native_ns=result.native_ns,
-                        hardware_id=resolved_hardware_id,
-                        timestamp=timestamp_fn(),
-                    )
-                    validate_observation(obs.to_dict())
-                    observations.append(obs)
-                    order_index += 1
+            for run_index in range(1, profile.measured_repeats + 1):
+                _record(
+                    adapter=adapter,
+                    group=group,
+                    call_prompt=profile.prompt,
+                    call_prompt_hash=measured_prompt_hash,
+                    n_tokens=window,
+                    is_warmup=False,
+                    run_index=run_index,
+                )
+
     return HarnessRunResult(
         profile=profile,
         observations=tuple(observations),

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -25,10 +25,13 @@ engine request always resolves as "missing" (see `--allow-missing-engine`).
 
 A profile's `engines` list is an ordered set of per-engine run groups, not
 a flat list of names: each entry carries its own warmup schedule
-(`warmup_repeats`, `warmup_tokens`, optional `warmup_prompt`), `model`, and
-`quantization` (see `EngineRunGroup`), because the legacy scripts this
-harness consolidates give each engine its own warmup shape and, for the
-Q4/Q8 comparison, a different quantization per engine within one profile.
+(`warmup_repeats`, `warmup_tokens`, optional `warmup_prompt`), its own
+MEASURED schedule (`measured_calls`, `measured_order` -- see below), and
+`model`/`quantization` (see `EngineRunGroup`), because the legacy scripts
+this harness consolidates give each engine its own warmup shape, its own
+measured call shape, and, for the Q4/Q8 comparison, a different
+quantization per engine within one profile.
+
 A warmup is an explicit pre-window batch: `warmup_repeats` calls at
 `warmup_tokens` completion tokens execute ONCE per engine, entirely before
 that engine's measured windows -- never once per window -- so
@@ -37,12 +40,43 @@ that engine's measured windows -- never once per window -- so
 `bench_context_scaling.sh`'s single pre-loop 4-token MLX warmup are each
 exactly representable, including `bench_compare_1k.py`'s distinct
 per-engine warmup prompts via `warmup_prompt` (defaults to `profile.prompt`
-when omitted). `windows`, `measured_repeats`, and the measured `prompt`
-stay profile-wide because every legacy script keeps those uniform across
-engines; only the warmup differs per engine. The requested model/
-quantization is passed into `EngineAdapter.run()`; an adapter that invokes
-a different artifact than requested (fallback, missing checkpoint, ...)
-reports the actual identity back via `AdapterRunResult.actual_model`/
+when omitted).
+
+An EARLIER version of this module claimed `windows`/`measured_repeats`
+alone (profile-wide, one call per window, executed uniformly as
+`[w1 x R, w2 x R, ...]` for every engine) were sufficient to represent
+every legacy script's MEASURED schedule. That claim was FALSE:
+`bench_compare_1k.py` has three different measured shapes in one profile
+-- Lattice runs all 1-token calls then all 100-token calls (window-major,
+which the uniform default does reproduce); Ollama issues exactly ONE
+100-token call per repeat and derives BOTH a window=1 (TTFT) and a
+window=100 (total) observation from that single response's two
+engine-reported timing components; MLX alternates a 1-token call and a
+100-token call inside every repeat (repeat-major, not window-major). No
+choice of profile-wide `windows`/`measured_repeats` can produce all three.
+
+Each `EngineRunGroup` therefore carries an optional `measured_calls`: an
+ordered tuple of `MeasuredCall(n_tokens, yields_windows)`. When omitted,
+the harness derives the default -- one call per `profile.windows` entry,
+`yields_windows=(window,)` -- which reproduces every uniform-window
+script (`bench_apples_to_apples.sh`, `bench_apples_precise.sh`,
+`bench_q4_apples.sh`, `bench_context_scaling.sh`, and Lattice's half of
+`bench_compare_1k.py`) unchanged. `measured_order` (`"window_major"`,
+the default, or `"repeat_major"`) controls whether the call plan replays
+as "all repeats of call[0], then all repeats of call[1], ..." or "one
+full pass through the call plan per repeat" -- MLX's alternating
+`bench_compare_1k.py` shape needs `"repeat_major"`. A `MeasuredCall` with
+`len(yields_windows) > 1` (Ollama's shape: one 100-token call yielding
+both window=1 and window=100) requires the adapter to report
+`AdapterRunResult.component_ns`, a `{window: elapsed_ns}` map with an
+entry for every yielded window -- the harness never re-invokes the engine
+to synthesize a second measurement, and never fabricates one from the
+single call's own wall-clock time for more than the primary window.
+Missing `component_ns` (or a missing window entry within it) raises
+`AdapterContractError`, fail-closed. The requested model/quantization is
+passed into `EngineAdapter.run()`; an adapter that invokes a different
+artifact than requested (fallback, missing checkpoint, ...) reports the
+actual identity back via `AdapterRunResult.actual_model`/
 `actual_quantization`, and raw observations always record the actual
 invoked identity, never a value merely assumed from the profile.
 
@@ -102,6 +136,16 @@ class ObservationValidationError(ValueError):
 
 class MissingEngineError(RuntimeError):
     """A profile requested an engine with no adapter registered for it."""
+
+
+class AdapterContractError(RuntimeError):
+    """An adapter's returned result did not satisfy the harness's measured-call
+    contract for a multi-window `MeasuredCall` (missing or incomplete
+    `AdapterRunResult.component_ns`). Fail-closed: the harness never
+    re-invokes the engine to synthesize a missing measurement, and never
+    fabricates one from the call's own wall-clock time for more than the
+    call's primary window.
+    """
 
 
 # --------------------------------------------------------------------------
@@ -275,24 +319,67 @@ def write_jsonl(observations: list[Observation], path: Path) -> None:
 
 
 @dataclass(frozen=True)
+class MeasuredCall:
+    """One call within an engine's measured schedule.
+
+    `n_tokens` is the completion-token budget actually requested from the
+    adapter for this call. `yields_windows` names, in order, which
+    window(s) (`requested_completion_tokens` values recorded in the raw
+    observations) this ONE call produces a measured observation for. The
+    common case is `len(yields_windows) == 1` (one call -> one
+    observation, `yields_windows == (n_tokens,)`) -- every legacy script
+    except `bench_compare_1k.py`'s Ollama adapter fits this shape.
+    Ollama's shape is the exception: it issues one `n_tokens=100` call per
+    repeat and derives BOTH a window=1 (TTFT) and a window=100 (total)
+    observation from that single response's two engine-reported timing
+    components, so `yields_windows == (1, 100)` for a call with
+    `n_tokens == 100`. When `len(yields_windows) > 1`, every yielded
+    window's `elapsed_ns` comes from `AdapterRunResult.component_ns`
+    (adapter-reported), never from the harness's own wall-clock
+    measurement of the whole call and never fabricated -- see
+    `AdapterRunResult.component_ns` and `AdapterContractError`.
+    """
+
+    n_tokens: int
+    yields_windows: tuple[int, ...]
+
+
+_MEASURED_ORDER_VALUES = ("window_major", "repeat_major")
+
+
+@dataclass(frozen=True)
 class EngineRunGroup:
     """One engine's schedule within a profile.
 
-    Every legacy script gives each engine its own warmup schedule and its
-    own model/quantization identity (`bench_apples_to_apples.sh`: only MLX
-    gets a warmup, once, at 8 tokens, before the N1/N2 loop;
-    `bench_apples_precise.sh`: every engine warms twice at N2=512, once
-    before both measured windows; `bench_context_scaling.sh`: MLX warms
-    once at 4 tokens before the baseline/comparison loop;
-    `bench_compare_1k.py`: Ollama and MLX each warm at 4 tokens with their
-    own warmup prompt, distinct from the measured prompt). A warmup is
-    therefore an explicit pre-window batch -- `warmup_repeats` calls at
+    Every legacy script gives each engine its own warmup schedule, its
+    own measured call shape, and its own model/quantization identity
+    (`bench_apples_to_apples.sh`: only MLX gets a warmup, once, at 8
+    tokens, before the N1/N2 loop; `bench_apples_precise.sh`: every
+    engine warms twice at N2=512, once before both measured windows;
+    `bench_context_scaling.sh`: MLX warms once at 4 tokens before the
+    baseline/comparison loop; `bench_compare_1k.py`: Ollama and MLX each
+    warm at 4 tokens with their own warmup prompt, distinct from the
+    measured prompt, AND the three engines' MEASURED shapes differ --
+    Lattice is window-major `[1 x R, 100 x R]`, MLX is repeat-major
+    `(1, 100) x R`, and Ollama is one 100-token call per repeat yielding
+    both a window=1 and a window=100 observation). A warmup is an
+    explicit pre-window batch -- `warmup_repeats` calls at
     `warmup_tokens` completion tokens, using `warmup_prompt` if given or
     `profile.prompt` otherwise -- executed once per engine, entirely
-    before that engine's measured windows, never once per window.
-    `measured_repeats`, `windows`, and the measured `prompt` stay
-    profile-wide because every legacy script keeps those uniform across
-    engines; only the warmup differs per engine.
+    before that engine's measured calls, never once per window.
+
+    `measured_calls`, when given, overrides the default measured schedule
+    (one call per `profile.windows` entry, `yields_windows=(window,)`)
+    with an explicit ordered `MeasuredCall` tuple -- required for Ollama's
+    single-call-yields-two-windows shape, optional for engines that only
+    need a different token budget than `profile.windows` implies.
+    `measured_order` (`"window_major"`, the default, or `"repeat_major"`)
+    controls whether the (default or explicit) call plan replays as "all
+    repeats of call[0], then all repeats of call[1], ..." or "one full
+    pass through the call plan per repeat"; `profile.measured_repeats`
+    stays profile-wide (every legacy script keeps the repeat COUNT
+    uniform across engines; only the call shape/order/token-budget
+    differs per engine).
     """
 
     name: str
@@ -301,6 +388,8 @@ class EngineRunGroup:
     warmup_prompt: str | None
     model: str
     quantization: str
+    measured_calls: tuple[MeasuredCall, ...] | None = None
+    measured_order: str = "window_major"
 
 
 @dataclass(frozen=True)
@@ -335,8 +424,18 @@ _PROFILE_ALLOWED_KEYS = frozenset(
     }
 )
 _ENGINE_GROUP_ALLOWED_KEYS = frozenset(
-    {"name", "warmup_repeats", "warmup_tokens", "warmup_prompt", "model", "quantization"}
+    {
+        "name",
+        "warmup_repeats",
+        "warmup_tokens",
+        "warmup_prompt",
+        "model",
+        "quantization",
+        "measured_order",
+        "measured_calls",
+    }
 )
+_MEASURED_CALL_ALLOWED_KEYS = frozenset({"n_tokens", "yields_windows"})
 
 
 def load_profiles_file(path: Path) -> tuple[int, dict[str, ProfileConfig]]:
@@ -489,6 +588,75 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
         if not eg_quantization:
             raise ProfileConfigError(f"profile {name!r}: engines[{idx}] quantization must be non-empty")
 
+        # measured_order: how this engine's measured call plan (default or
+        # explicit measured_calls) replays across profile.measured_repeats
+        # -- "window_major" (all repeats of call[0], then call[1], ...) or
+        # "repeat_major" (one full pass through the plan per repeat, the
+        # shape MLX's alternating bench_compare_1k.py calls need).
+        eg_measured_order = eg_raw.get("measured_order", "window_major")
+        if not isinstance(eg_measured_order, str) or eg_measured_order not in _MEASURED_ORDER_VALUES:
+            raise ProfileConfigError(
+                f"profile {name!r}: engines[{idx}] measured_order must be one of "
+                f"{_MEASURED_ORDER_VALUES}, got {eg_measured_order!r}"
+            )
+
+        # measured_calls: an explicit ordered call plan overriding the
+        # default (one call per profile.windows entry). Required for any
+        # engine whose measured shape the default cannot represent (e.g.
+        # Ollama's one-call-yields-two-windows shape).
+        eg_measured_calls_raw = eg_raw.get("measured_calls")
+        eg_measured_calls: tuple[MeasuredCall, ...] | None = None
+        if eg_measured_calls_raw is not None:
+            if not isinstance(eg_measured_calls_raw, list) or not eg_measured_calls_raw:
+                raise ProfileConfigError(
+                    f"profile {name!r}: engines[{idx}] measured_calls must be a non-empty list"
+                )
+            parsed_calls: list[MeasuredCall] = []
+            for call_idx, call_raw in enumerate(eg_measured_calls_raw):
+                if not isinstance(call_raw, dict):
+                    raise ProfileConfigError(
+                        f"profile {name!r}: engines[{idx}] measured_calls[{call_idx}] must be a table"
+                    )
+                call_extra = set(call_raw) - _MEASURED_CALL_ALLOWED_KEYS
+                if call_extra:
+                    raise ProfileConfigError(
+                        f"profile {name!r}: engines[{idx}] measured_calls[{call_idx}] has "
+                        f"unexpected key(s): {sorted(call_extra)}"
+                    )
+                call_missing = _MEASURED_CALL_ALLOWED_KEYS - set(call_raw)
+                if call_missing:
+                    raise ProfileConfigError(
+                        f"profile {name!r}: engines[{idx}] measured_calls[{call_idx}] missing "
+                        f"required key(s): {sorted(call_missing)}"
+                    )
+                call_n_tokens = call_raw["n_tokens"]
+                if isinstance(call_n_tokens, bool) or not isinstance(call_n_tokens, int) or call_n_tokens <= 0:
+                    raise ProfileConfigError(
+                        f"profile {name!r}: engines[{idx}] measured_calls[{call_idx}] n_tokens "
+                        f"must be a positive int, got {call_n_tokens!r}"
+                    )
+                call_yields_raw = call_raw["yields_windows"]
+                if not isinstance(call_yields_raw, list) or not call_yields_raw:
+                    raise ProfileConfigError(
+                        f"profile {name!r}: engines[{idx}] measured_calls[{call_idx}] yields_windows "
+                        "must be a non-empty list"
+                    )
+                call_yields: list[int] = []
+                for y in call_yields_raw:
+                    if isinstance(y, bool) or not isinstance(y, int) or y <= 0:
+                        raise ProfileConfigError(
+                            f"profile {name!r}: engines[{idx}] measured_calls[{call_idx}] yields_windows "
+                            f"entries must be positive integers, got {y!r}"
+                        )
+                    call_yields.append(y)
+                if len(set(call_yields)) != len(call_yields):
+                    raise ProfileConfigError(
+                        f"profile {name!r}: engines[{idx}] measured_calls[{call_idx}] yields_windows "
+                        f"must not contain duplicates, got {call_yields}"
+                    )
+                parsed_calls.append(MeasuredCall(n_tokens=call_n_tokens, yields_windows=tuple(call_yields)))
+            eg_measured_calls = tuple(parsed_calls)
+
         engine_groups.append(
             EngineRunGroup(
                 name=eg_name,
@@ -497,6 +665,8 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
                 warmup_prompt=eg_warmup_prompt,
                 model=eg_model,
                 quantization=eg_quantization,
+                measured_calls=eg_measured_calls,
+                measured_order=eg_measured_order,
             )
         )
 
@@ -561,6 +731,19 @@ class AdapterRunResult:
     that falls back to a different artifact than requested (a missing
     checkpoint, a resolved default, ...) MUST set these so the raw
     observation records what actually ran, not what was asked for.
+
+    `component_ns` is REQUIRED when the harness's `MeasuredCall` for this
+    invocation declared `len(yields_windows) > 1` (one physical call
+    producing observations for multiple windows, e.g. Ollama deriving
+    both a TTFT-equivalent and a total-equivalent reading from one
+    `/api/generate` response): it must map every window in
+    `yields_windows` to that window's adapter-reported elapsed
+    nanoseconds. It is ignored when the call yields exactly one window
+    (that window's `elapsed_ns` always comes from the harness's own
+    wall-clock measurement of the call). A missing map, or a map missing
+    an entry for one of the declared windows, raises
+    `AdapterContractError` -- the harness never fabricates a component it
+    was not told.
     """
 
     actual_completion_tokens: int
@@ -569,6 +752,7 @@ class AdapterRunResult:
     engine_version: str = "unknown"
     actual_model: str | None = None
     actual_quantization: str | None = None
+    component_ns: Mapping[int, int] | None = None
 
 
 class EngineAdapter(Protocol):
@@ -650,16 +834,26 @@ def run_profile(
     group (in `profile.engine_groups` order), that engine's warmup batch —
     `warmup_repeats` calls at `warmup_tokens` completion tokens, using
     `warmup_prompt` if given or `profile.prompt` otherwise — executes
-    ONCE, entirely before any of that engine's measured windows (never
-    once per window; this is what makes `bench_apples_to_apples.sh`'s
-    single pre-loop MLX warmup, `bench_apples_precise.sh`'s twice-at-N2
-    warmup, and `bench_context_scaling.sh`'s single pre-loop warmup all
-    exactly representable). Measured runs then execute for each window (in
-    `profile.windows` order — `windows[0]` is the shared baseline,
-    executed once and reused for every comparison window that follows it).
-    `order_index` is a single counter across the entire call, so a later
-    statistical pass (issue #714) can test for order/thermal bias without
-    another schema migration.
+    ONCE, entirely before any of that engine's measured calls (never once
+    per window; this is what makes `bench_apples_to_apples.sh`'s single
+    pre-loop MLX warmup, `bench_apples_precise.sh`'s twice-at-N2 warmup,
+    and `bench_context_scaling.sh`'s single pre-loop warmup all exactly
+    representable).
+
+    Measured calls then execute per the group's OWN plan: `group.
+    measured_calls` if given, else the default derived from
+    `profile.windows` (one call per window, `yields_windows=(window,)`).
+    `group.measured_order` selects "window_major" (default -- all repeats
+    of call[0], then all repeats of call[1], ...) or "repeat_major" (one
+    full pass through the call plan per repeat -- MLX's alternating
+    `bench_compare_1k.py` shape). A call with more than one yielded window
+    (Ollama's one-call-yields-two-windows shape) produces one Observation
+    per yielded window from a SINGLE adapter invocation, using
+    `AdapterRunResult.component_ns` for every window's `elapsed_ns` — see
+    `MeasuredCall` and `AdapterContractError`. `order_index` is a single
+    counter across the entire call, so a later statistical pass (issue
+    #714) can test for order/thermal bias without another schema
+    migration.
     """
     resolved_git_sha = git_sha_value if git_sha_value is not None else git_sha(repo_root)
     resolved_hardware_id = hardware_id_value if hardware_id_value is not None else hardware_id()
@@ -681,26 +875,17 @@ def run_profile(
     observations: list[Observation] = []
     order_index = 0
 
-    def _record(
+    def _append_observation(
         *,
-        adapter: EngineAdapter,
         group: EngineRunGroup,
-        call_prompt: str,
+        result: AdapterRunResult,
         call_prompt_hash: str,
-        n_tokens: int,
+        window: int,
         is_warmup: bool,
         run_index: int,
+        elapsed_ns: int,
     ) -> None:
         nonlocal order_index
-        t0 = clock()
-        result = adapter.run(
-            prompt=call_prompt,
-            n_tokens=n_tokens,
-            warmup=is_warmup,
-            model=group.model,
-            quantization=group.quantization,
-        )
-        t1 = clock()
         actual_model = result.actual_model if result.actual_model is not None else group.model
         actual_quantization = (
             result.actual_quantization if result.actual_quantization is not None else group.quantization
@@ -716,12 +901,12 @@ def run_profile(
             prompt_hash=call_prompt_hash,
             requested_prompt_tokens=profile.requested_prompt_tokens,
             actual_prompt_tokens=result.actual_prompt_tokens,
-            requested_completion_tokens=n_tokens,
+            requested_completion_tokens=window,
             actual_completion_tokens=result.actual_completion_tokens,
             warmup=is_warmup,
             run_index=run_index,
             order_index=order_index,
-            elapsed_ns=t1 - t0,
+            elapsed_ns=elapsed_ns,
             engine_native_ns=result.native_ns,
             hardware_id=resolved_hardware_id,
             timestamp=timestamp_fn(),
@@ -730,12 +915,100 @@ def run_profile(
         observations.append(obs)
         order_index += 1
 
+    def _record(
+        *,
+        adapter: EngineAdapter,
+        group: EngineRunGroup,
+        call_prompt: str,
+        call_prompt_hash: str,
+        n_tokens: int,
+        is_warmup: bool,
+        run_index: int,
+    ) -> None:
+        """Single call, single window (warmup calls always take this path)."""
+        t0 = clock()
+        result = adapter.run(
+            prompt=call_prompt,
+            n_tokens=n_tokens,
+            warmup=is_warmup,
+            model=group.model,
+            quantization=group.quantization,
+        )
+        t1 = clock()
+        _append_observation(
+            group=group,
+            result=result,
+            call_prompt_hash=call_prompt_hash,
+            window=n_tokens,
+            is_warmup=is_warmup,
+            run_index=run_index,
+            elapsed_ns=t1 - t0,
+        )
+
+    def _record_measured_call(
+        *,
+        adapter: EngineAdapter,
+        group: EngineRunGroup,
+        call: MeasuredCall,
+        call_prompt: str,
+        call_prompt_hash: str,
+        run_index: int,
+    ) -> None:
+        """One measured call, possibly yielding more than one window's
+        observation from a single adapter invocation (see `MeasuredCall`).
+        """
+        t0 = clock()
+        result = adapter.run(
+            prompt=call_prompt,
+            n_tokens=call.n_tokens,
+            warmup=False,
+            model=group.model,
+            quantization=group.quantization,
+        )
+        t1 = clock()
+        if len(call.yields_windows) == 1:
+            _append_observation(
+                group=group,
+                result=result,
+                call_prompt_hash=call_prompt_hash,
+                window=call.yields_windows[0],
+                is_warmup=False,
+                run_index=run_index,
+                elapsed_ns=t1 - t0,
+            )
+            return
+        if result.component_ns is None:
+            raise AdapterContractError(
+                f"engine {group.name!r}: measured call n_tokens={call.n_tokens} declares "
+                f"yields_windows={call.yields_windows} but AdapterRunResult.component_ns is None"
+            )
+        missing_windows = [w for w in call.yields_windows if w not in result.component_ns]
+        if missing_windows:
+            raise AdapterContractError(
+                f"engine {group.name!r}: measured call n_tokens={call.n_tokens} "
+                f"component_ns is missing entries for window(s) {missing_windows} "
+                f"(declared yields_windows={call.yields_windows})"
+            )
+        for window in call.yields_windows:
+            _append_observation(
+                group=group,
+                result=result,
+                call_prompt_hash=call_prompt_hash,
+                window=window,
+                is_warmup=False,
+                run_index=run_index,
+                elapsed_ns=result.component_ns[window],
+            )
+
+    def _default_measured_calls() -> tuple[MeasuredCall, ...]:
+        return tuple(MeasuredCall(n_tokens=w, yields_windows=(w,)) for w in profile.windows)
+
     for group in profile.engine_groups:
         if group.name not in active:
             continue
         adapter = adapters[group.name]
 
-        # Warmup batch: once, before any measured window, at the group's
+        # Warmup batch: once, before any measured call, at the group's
         # own token budget and prompt (default: profile.prompt).
         if group.warmup_repeats > 0:
             warmup_prompt = group.warmup_prompt if group.warmup_prompt is not None else profile.prompt
@@ -753,18 +1026,31 @@ def run_profile(
                     run_index=run_index,
                 )
 
-        # Measured windows: run_index resets per window.
-        for window in profile.windows:
+        # Measured calls: this engine's own plan (default or explicit),
+        # replayed window-major or repeat-major per group.measured_order.
+        calls = group.measured_calls if group.measured_calls is not None else _default_measured_calls()
+        if group.measured_order == "window_major":
+            for call in calls:
+                for run_index in range(1, profile.measured_repeats + 1):
+                    _record_measured_call(
+                        adapter=adapter,
+                        group=group,
+                        call=call,
+                        call_prompt=profile.prompt,
+                        call_prompt_hash=measured_prompt_hash,
+                        run_index=run_index,
+                    )
+        else:  # "repeat_major"
             for run_index in range(1, profile.measured_repeats + 1):
-                _record(
-                    adapter=adapter,
-                    group=group,
-                    call_prompt=profile.prompt,
-                    call_prompt_hash=measured_prompt_hash,
-                    n_tokens=window,
-                    is_warmup=False,
-                    run_index=run_index,
-                )
+                for call in calls:
+                    _record_measured_call(
+                        adapter=adapter,
+                        group=group,
+                        call=call,
+                        call_prompt=profile.prompt,
+                        call_prompt_hash=measured_prompt_hash,
+                        run_index=run_index,
+                    )
 
     return HarnessRunResult(
         profile=profile,

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -73,12 +73,32 @@ entry for every yielded window -- the harness never re-invokes the engine
 to synthesize a second measurement, and never fabricates one from the
 single call's own wall-clock time for more than the primary window.
 Missing `component_ns` (or a missing window entry within it) raises
-`AdapterContractError`, fail-closed. The requested model/quantization is
-passed into `EngineAdapter.run()`; an adapter that invokes a different
-artifact than requested (fallback, missing checkpoint, ...) reports the
-actual identity back via `AdapterRunResult.actual_model`/
-`actual_quantization`, and raw observations always record the actual
-invoked identity, never a value merely assumed from the profile.
+`AdapterContractError`, fail-closed. Every explicit `measured_calls` plan
+is ALSO validated against `profile.windows`: the flattened
+`yields_windows` across the whole plan must cover every declared window
+exactly once -- a missing window silently erases a slope, an undeclared
+window produces an observation outside the report contract, and a window
+yielded twice silently doubles that window's sample count/aggregation
+weight. All three are rejected fail-closed at parse time, naming the
+engine index and the missing/undeclared/duplicate windows.
+
+A SECOND earlier version of this module additionally assumed the
+MEASURED prompt could stay profile-wide (`profile.prompt`, passed
+verbatim to every engine's measured calls). That assumption was ALSO
+FALSE: `bench_compare_1k.py` requires each engine to receive a DIFFERENT
+measured prompt for the same nominal context -- Lattice and MLX build a
+tokenizer-padded prompt, Ollama builds a distinct character-count-
+heuristic prompt. `EngineRunGroup.measured_prompt` (mirroring
+`warmup_prompt`) lets an engine override the measured prompt; the harness
+passes exactly that resolved string to the adapter and hashes exactly
+that string, never a placeholder the adapter is trusted to reinterpret --
+prompt construction stays a harness-owned request, not an adapter
+implementation detail. The requested model/quantization is passed into
+`EngineAdapter.run()`; an adapter that invokes a different artifact than
+requested (fallback, missing checkpoint, ...) reports the actual identity
+back via `AdapterRunResult.actual_model`/`actual_quantization`, and raw
+observations always record the actual invoked identity, never a value
+merely assumed from the profile.
 
 Raw JSONL observation schema (the contract; see `OBSERVATION_FIELDS` /
 `validate_observation`): schema version, git SHA, profile name, engine +
@@ -380,6 +400,18 @@ class EngineRunGroup:
     stays profile-wide (every legacy script keeps the repeat COUNT
     uniform across engines; only the call shape/order/token-budget
     differs per engine).
+
+    `measured_prompt`, when given, overrides `profile.prompt` for THIS
+    engine's measured calls only -- mirroring `warmup_prompt`'s override
+    of the warmup prompt. `bench_compare_1k.py` needs this: Lattice and
+    MLX build a tokenizer-padded prompt to reach a target context length,
+    while Ollama builds a character-count-heuristic prompt for the SAME
+    target -- two different strings for the same nominal context. The
+    harness passes exactly the resolved prompt (per-engine override or
+    `profile.prompt`) to the adapter and hashes exactly that string, never
+    a placeholder the adapter is trusted to reinterpret: prompt
+    construction/ownership stays in the harness's request, not the
+    adapter's implementation.
     """
 
     name: str
@@ -390,6 +422,7 @@ class EngineRunGroup:
     quantization: str
     measured_calls: tuple[MeasuredCall, ...] | None = None
     measured_order: str = "window_major"
+    measured_prompt: str | None = None
 
 
 @dataclass(frozen=True)
@@ -433,6 +466,7 @@ _ENGINE_GROUP_ALLOWED_KEYS = frozenset(
         "quantization",
         "measured_order",
         "measured_calls",
+        "measured_prompt",
     }
 )
 _MEASURED_CALL_ALLOWED_KEYS = frozenset({"n_tokens", "yields_windows"})
@@ -655,7 +689,55 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
                         f"must not contain duplicates, got {call_yields}"
                     )
                 parsed_calls.append(MeasuredCall(n_tokens=call_n_tokens, yields_windows=tuple(call_yields)))
+
+            # Fail-closed relationship check: the flattened yields_windows
+            # across the WHOLE plan (one pass through `calls`) must cover
+            # profile.windows exactly once each -- no missing window (an
+            # erased slope), no undeclared window (an observation outside
+            # the report contract), and no window yielded twice across
+            # different calls (a silently doubled sample count/aggregation
+            # weight). Order across the flattened plan is NOT required to
+            # match `windows`' order: measured_order/call order governs
+            # REPLAY order (window-major vs repeat-major), not which
+            # windows exist -- only coverage (each exactly once) is
+            # enforced here.
+            flattened_windows = [w for c in parsed_calls for w in c.yields_windows]
+            flattened_counts: dict[int, int] = {}
+            for w in flattened_windows:
+                flattened_counts[w] = flattened_counts.get(w, 0) + 1
+            declared_windows = set(windows)
+            flattened_set = set(flattened_windows)
+            missing_windows = sorted(declared_windows - flattened_set)
+            undeclared_windows = sorted(flattened_set - declared_windows)
+            duplicate_windows = sorted(w for w, c in flattened_counts.items() if c > 1 and w in declared_windows)
+            if missing_windows or undeclared_windows or duplicate_windows:
+                problems = []
+                if missing_windows:
+                    problems.append(f"missing window(s) {missing_windows}")
+                if undeclared_windows:
+                    problems.append(f"undeclared window(s) {undeclared_windows}")
+                if duplicate_windows:
+                    problems.append(f"duplicate window(s) {duplicate_windows}")
+                raise ProfileConfigError(
+                    f"profile {name!r}: engines[{idx}] measured_calls yields_windows "
+                    f"must cover profile windows {windows} exactly once each: {'; '.join(problems)}"
+                )
+
             eg_measured_calls = tuple(parsed_calls)
+
+        # measured_prompt: overrides profile.prompt for THIS engine's
+        # measured calls only (mirrors warmup_prompt). Optional at any
+        # measured_calls value -- unused (falls back to profile.prompt)
+        # when omitted.
+        eg_measured_prompt_raw = eg_raw.get("measured_prompt")
+        if eg_measured_prompt_raw is not None:
+            if not isinstance(eg_measured_prompt_raw, str):
+                raise ProfileConfigError(f"profile {name!r}: engines[{idx}] measured_prompt must be a string")
+            if not eg_measured_prompt_raw:
+                raise ProfileConfigError(
+                    f"profile {name!r}: engines[{idx}] measured_prompt must be non-empty if provided"
+                )
+        eg_measured_prompt = eg_measured_prompt_raw
 
         engine_groups.append(
             EngineRunGroup(
@@ -667,6 +749,7 @@ def _parse_profile(name: str, raw: dict) -> ProfileConfig:
                 quantization=eg_quantization,
                 measured_calls=eg_measured_calls,
                 measured_order=eg_measured_order,
+                measured_prompt=eg_measured_prompt,
             )
         )
 
@@ -850,9 +933,13 @@ def run_profile(
     (Ollama's one-call-yields-two-windows shape) produces one Observation
     per yielded window from a SINGLE adapter invocation, using
     `AdapterRunResult.component_ns` for every window's `elapsed_ns` — see
-    `MeasuredCall` and `AdapterContractError`. `order_index` is a single
-    counter across the entire call, so a later statistical pass (issue
-    #714) can test for order/thermal bias without another schema
+    `MeasuredCall` and `AdapterContractError`. Every measured call for a
+    group uses that group's `measured_prompt` (default: `profile.prompt`)
+    — the exact string is what is passed to `adapter.run(prompt=...)` and
+    what `prompt_hash` records, never a placeholder the adapter
+    reinterprets (see `EngineRunGroup.measured_prompt`). `order_index` is
+    a single counter across the entire call, so a later statistical pass
+    (issue #714) can test for order/thermal bias without another schema
     migration.
     """
     resolved_git_sha = git_sha_value if git_sha_value is not None else git_sha(repo_root)
@@ -1027,8 +1114,16 @@ def run_profile(
                 )
 
         # Measured calls: this engine's own plan (default or explicit),
-        # replayed window-major or repeat-major per group.measured_order.
+        # replayed window-major or repeat-major per group.measured_order,
+        # using this engine's own measured prompt (default: profile.prompt)
+        # -- e.g. bench_compare_1k.py's Lattice/MLX tokenizer-padded prompt
+        # vs Ollama's character-count-heuristic prompt for the same
+        # nominal context: two different strings, hashed exactly as sent.
         calls = group.measured_calls if group.measured_calls is not None else _default_measured_calls()
+        group_measured_prompt = group.measured_prompt if group.measured_prompt is not None else profile.prompt
+        group_measured_prompt_hash = (
+            measured_prompt_hash if group.measured_prompt is None else prompt_hash(group.measured_prompt)
+        )
         if group.measured_order == "window_major":
             for call in calls:
                 for run_index in range(1, profile.measured_repeats + 1):
@@ -1036,8 +1131,8 @@ def run_profile(
                         adapter=adapter,
                         group=group,
                         call=call,
-                        call_prompt=profile.prompt,
-                        call_prompt_hash=measured_prompt_hash,
+                        call_prompt=group_measured_prompt,
+                        call_prompt_hash=group_measured_prompt_hash,
                         run_index=run_index,
                     )
         else:  # "repeat_major"
@@ -1047,8 +1142,8 @@ def run_profile(
                         adapter=adapter,
                         group=group,
                         call=call,
-                        call_prompt=profile.prompt,
-                        call_prompt_hash=measured_prompt_hash,
+                        call_prompt=group_measured_prompt,
+                        call_prompt_hash=group_measured_prompt_hash,
                         run_index=run_index,
                     )
 

--- a/scripts/bench_decode_profiles.toml
+++ b/scripts/bench_decode_profiles.toml
@@ -10,10 +10,18 @@
 #
 # Every engine gets its own `[[profiles.<name>.engines]]` table -- an
 # ordered array, not a flat name list -- because the legacy scripts this
-# harness consolidates give each engine its own warmup schedule (e.g. only
-# MLX warms up in `bench_apples_to_apples.sh`) and, for the Q4/Q8
-# comparison in `bench_q4_apples.sh`, a different quantization per engine
-# within one profile (Lattice Q4, MLX Q4, Ollama Q8 as reference only).
+# harness consolidates give each engine its own warmup shape (e.g. only
+# MLX warms up in `bench_apples_to_apples.sh`, once, at 8 tokens, before
+# the N1/N2 loop) and, for the Q4/Q8 comparison in `bench_q4_apples.sh`, a
+# different quantization per engine within one profile (Lattice Q4, MLX
+# Q4, Ollama Q8 as reference only). A warmup is an explicit pre-window
+# batch: `warmup_repeats` calls at `warmup_tokens` completion tokens run
+# ONCE per engine, entirely before that engine's measured windows -- never
+# once per window -- so `bench_apples_precise.sh`'s "warm twice at N2=512
+# before both windows" and `bench_context_scaling.sh`'s "warm once at 4
+# tokens before the baseline/comparison loop" are both exactly
+# representable, including `bench_compare_1k.py`'s distinct per-engine
+# warmup prompts via `warmup_prompt`.
 #
 # This file intentionally defines no profiles yet. The five live consumers
 # (`bench_apples_to_apples.sh`, `bench_apples_precise.sh`, `bench_q4_apples.sh`,
@@ -30,15 +38,20 @@
 #                            each table:
 #     name                     string, non-empty
 #     warmup_repeats           int, >= 0
+#     warmup_tokens            int, > 0; required iff warmup_repeats > 0
+#     warmup_prompt            string, non-empty, optional; defaults to the
+#                              profile's `prompt` when omitted; unused when
+#                              warmup_repeats == 0
 #     model                    string, non-empty
 #     quantization             string, non-empty
-#   prompt                   string, non-empty
+#   prompt                   string, non-empty (the MEASURED-window prompt)
 #   aggregation              "median" (default) or "trimmed_mean"
 #   trim                     int, >= 0; only valid when aggregation = "trimmed_mean"
 #   requested_prompt_tokens  int, optional
 #
 # Example (not a live profile -- illustrates the Q4/Q8-mixed shape from
-# bench_q4_apples.sh; uncomment and rename to activate):
+# bench_q4_apples.sh, with MLX's single pre-loop 8-token warmup from
+# bench_apples_to_apples.sh; uncomment and rename to activate):
 #
 # [profiles.example_q4_apples]
 # description = "example only, see bench_q4_apples.sh for the real profile"
@@ -56,6 +69,7 @@
 # [[profiles.example_q4_apples.engines]]
 # name = "mlx"
 # warmup_repeats = 1
+# warmup_tokens = 8
 # model = "qwen3.5-0.8b"
 # quantization = "q4"
 #

--- a/scripts/bench_decode_profiles.toml
+++ b/scripts/bench_decode_profiles.toml
@@ -12,16 +12,28 @@
 # ordered array, not a flat name list -- because the legacy scripts this
 # harness consolidates give each engine its own warmup shape (e.g. only
 # MLX warms up in `bench_apples_to_apples.sh`, once, at 8 tokens, before
-# the N1/N2 loop) and, for the Q4/Q8 comparison in `bench_q4_apples.sh`, a
-# different quantization per engine within one profile (Lattice Q4, MLX
-# Q4, Ollama Q8 as reference only). A warmup is an explicit pre-window
-# batch: `warmup_repeats` calls at `warmup_tokens` completion tokens run
-# ONCE per engine, entirely before that engine's measured windows -- never
-# once per window -- so `bench_apples_precise.sh`'s "warm twice at N2=512
-# before both windows" and `bench_context_scaling.sh`'s "warm once at 4
-# tokens before the baseline/comparison loop" are both exactly
-# representable, including `bench_compare_1k.py`'s distinct per-engine
-# warmup prompts via `warmup_prompt`.
+# the N1/N2 loop), its own MEASURED call shape (see below), and, for the
+# Q4/Q8 comparison in `bench_q4_apples.sh`, a different quantization per
+# engine within one profile (Lattice Q4, MLX Q4, Ollama Q8 as reference
+# only). A warmup is an explicit pre-window batch: `warmup_repeats` calls
+# at `warmup_tokens` completion tokens run ONCE per engine, entirely
+# before that engine's measured calls -- never once per window -- so
+# `bench_apples_precise.sh`'s "warm twice at N2=512 before both windows"
+# and `bench_context_scaling.sh`'s "warm once at 4 tokens before the
+# baseline/comparison loop" are both exactly representable, including
+# `bench_compare_1k.py`'s distinct per-engine warmup prompts via
+# `warmup_prompt`.
+#
+# `windows`/`measured_repeats` alone are NOT always sufficient to
+# represent an engine's measured shape: `bench_compare_1k.py` has THREE
+# different measured shapes in one profile (Lattice: window-major
+# `[1 x R, 100 x R]`, the default derived from `windows`; Ollama: ONE
+# 100-token call per repeat, yielding both a window=1 and a window=100
+# observation from that single response's two timing components; MLX:
+# repeat-major, alternating `(1, 100)` every repeat). An engine whose
+# shape the default can't represent sets its own `measured_calls`
+# (an explicit ordered call plan) and/or `measured_order` -- see schema
+# below.
 #
 # This file intentionally defines no profiles yet. The five live consumers
 # (`bench_apples_to_apples.sh`, `bench_apples_precise.sh`, `bench_q4_apples.sh`,
@@ -44,6 +56,24 @@
 #                              warmup_repeats == 0
 #     model                    string, non-empty
 #     quantization             string, non-empty
+#     measured_order           "window_major" (default) or "repeat_major";
+#                              window_major = all repeats of measured_calls[0],
+#                              then all repeats of measured_calls[1], ...;
+#                              repeat_major = one full pass through
+#                              measured_calls per repeat (MLX's alternating
+#                              bench_compare_1k.py shape)
+#     measured_calls           list[table], optional; overrides the default
+#                              measured plan (one call per `windows` entry,
+#                              yields_windows=[that window]); each table:
+#       n_tokens                 int, > 0 (completion-token budget for this call)
+#       yields_windows            list[int], non-empty, no duplicates -- the
+#                                window(s) this ONE call produces an
+#                                observation for. len() > 1 (e.g. Ollama
+#                                deriving both a window=1 and a window=100
+#                                reading from one call) REQUIRES the adapter
+#                                to return AdapterRunResult.component_ns with
+#                                an entry for every listed window -- see
+#                                bench_decode_harness.py:AdapterRunResult.
 #   prompt                   string, non-empty (the MEASURED-window prompt)
 #   aggregation              "median" (default) or "trimmed_mean"
 #   trim                     int, >= 0; only valid when aggregation = "trimmed_mean"
@@ -67,17 +97,61 @@
 # quantization = "q4"
 #
 # [[profiles.example_q4_apples.engines]]
+# name = "ollama"
+# warmup_repeats = 0
+# model = "qwen3.5:0.8b"
+# quantization = "q8"
+#
+# [[profiles.example_q4_apples.engines]]
 # name = "mlx"
 # warmup_repeats = 1
 # warmup_tokens = 8
 # model = "qwen3.5-0.8b"
 # quantization = "q4"
 #
-# [[profiles.example_q4_apples.engines]]
-# name = "ollama"
+# Example 2 (not a live profile -- illustrates bench_compare_1k.py's three
+# distinct measured shapes: Lattice window-major (the default, no
+# measured_calls needed), Ollama's one-call-yields-two-windows shape, and
+# MLX's repeat-major alternation; uncomment and rename to activate):
+#
+# [profiles.example_agentic]
+# description = "example only, see bench_compare_1k.py for the real profile"
+# windows = [1, 100]
+# measured_repeats = 5
+# prompt = "<ctx-padded prompt, built per-engine at the adapter level>"
+# aggregation = "median"
+#
+# [[profiles.example_agentic.engines]]
+# name = "lattice"
 # warmup_repeats = 0
+# model = "qwen3.5-0.8b"
+# quantization = "q8"
+#
+# [[profiles.example_agentic.engines]]
+# name = "ollama"
+# warmup_repeats = 1
+# warmup_tokens = 4
+# warmup_prompt = "hi"
 # model = "qwen3.5:0.8b"
 # quantization = "q8"
+# [[profiles.example_agentic.engines.measured_calls]]
+# n_tokens = 100
+# yields_windows = [1, 100]
+#
+# [[profiles.example_agentic.engines]]
+# name = "mlx"
+# warmup_repeats = 1
+# warmup_tokens = 4
+# warmup_prompt = "BASE"
+# model = "qwen3.5-0.8b"
+# quantization = "q8"
+# measured_order = "repeat_major"
+# [[profiles.example_agentic.engines.measured_calls]]
+# n_tokens = 1
+# yields_windows = [1]
+# [[profiles.example_agentic.engines.measured_calls]]
+# n_tokens = 100
+# yields_windows = [100]
 
 schema_version = 1
 

--- a/scripts/bench_decode_profiles.toml
+++ b/scripts/bench_decode_profiles.toml
@@ -2,10 +2,18 @@
 #
 # Each `[profiles.<name>]` table fully specifies one decode-benchmark
 # configuration for `scripts/bench_decode_harness.py run --profile <name>`:
-# the window schedule, warmup/measured repeat counts, engines, aggregation
-# method, and the fixed prompt. `windows[0]` is the shared baseline; every
-# later value in `windows` is compared against it to compute a marginal
-# decode-throughput slope (see `bench_decode_harness.py:aggregate`).
+# the window schedule, measured repeat count, per-engine run groups,
+# aggregation method, and the fixed prompt. `windows[0]` is the shared
+# baseline; every later value in `windows` is compared against it to
+# compute a marginal decode-throughput slope (see
+# `bench_decode_harness.py:aggregate`).
+#
+# Every engine gets its own `[[profiles.<name>.engines]]` table -- an
+# ordered array, not a flat name list -- because the legacy scripts this
+# harness consolidates give each engine its own warmup schedule (e.g. only
+# MLX warms up in `bench_apples_to_apples.sh`) and, for the Q4/Q8
+# comparison in `bench_q4_apples.sh`, a different quantization per engine
+# within one profile (Lattice Q4, MLX Q4, Ollama Q8 as reference only).
 #
 # This file intentionally defines no profiles yet. The five live consumers
 # (`bench_apples_to_apples.sh`, `bench_apples_precise.sh`, `bench_q4_apples.sh`,
@@ -15,17 +23,47 @@
 # exact parameters before it is added below.
 #
 # Schema (for reference; enforced by `bench_decode_harness.py:_parse_profile`):
-#   description             string, optional
-#   windows                 list[int], >= 2 entries, strictly increasing
-#   warmup_repeats           int, >= 0
+#   description              string, optional
+#   windows                  list[int], >= 2 entries, strictly increasing
 #   measured_repeats         int, >= 1
-#   engines                  list[string], non-empty, no duplicates
+#   engines                  list[table], non-empty, no duplicate `name`s;
+#                            each table:
+#     name                     string, non-empty
+#     warmup_repeats           int, >= 0
+#     model                    string, non-empty
+#     quantization             string, non-empty
 #   prompt                   string, non-empty
-#   model                    string, non-empty
-#   quantization             string, non-empty
 #   aggregation              "median" (default) or "trimmed_mean"
 #   trim                     int, >= 0; only valid when aggregation = "trimmed_mean"
 #   requested_prompt_tokens  int, optional
+#
+# Example (not a live profile -- illustrates the Q4/Q8-mixed shape from
+# bench_q4_apples.sh; uncomment and rename to activate):
+#
+# [profiles.example_q4_apples]
+# description = "example only, see bench_q4_apples.sh for the real profile"
+# windows = [32, 256]
+# measured_repeats = 5
+# prompt = "The quick brown fox jumps over the lazy dog."
+# aggregation = "median"
+#
+# [[profiles.example_q4_apples.engines]]
+# name = "lattice"
+# warmup_repeats = 0
+# model = "qwen3.5-0.8b-q4"
+# quantization = "q4"
+#
+# [[profiles.example_q4_apples.engines]]
+# name = "mlx"
+# warmup_repeats = 1
+# model = "qwen3.5-0.8b"
+# quantization = "q4"
+#
+# [[profiles.example_q4_apples.engines]]
+# name = "ollama"
+# warmup_repeats = 0
+# model = "qwen3.5:0.8b"
+# quantization = "q8"
 
 schema_version = 1
 

--- a/scripts/bench_decode_profiles.toml
+++ b/scripts/bench_decode_profiles.toml
@@ -33,7 +33,18 @@
 # repeat-major, alternating `(1, 100)` every repeat). An engine whose
 # shape the default can't represent sets its own `measured_calls`
 # (an explicit ordered call plan) and/or `measured_order` -- see schema
-# below.
+# below. Every explicit `measured_calls` plan's flattened `yields_windows`
+# must cover `windows` exactly once each (fail-closed at parse time) --
+# missing/undeclared/duplicate windows are all rejected.
+#
+# The MEASURED `prompt` is ALSO not always uniform across engines:
+# `bench_compare_1k.py` needs Lattice/MLX to receive a tokenizer-padded
+# prompt and Ollama to receive a DIFFERENT character-count-heuristic
+# prompt for the same nominal context. `measured_prompt` on an engine
+# group overrides `profile.prompt` for that engine's measured calls only
+# (mirrors `warmup_prompt`'s override of the warmup prompt) -- the exact
+# string is what is sent to the adapter and what the raw observation's
+# `prompt_hash` records, never a placeholder.
 #
 # This file intentionally defines no profiles yet. The five live consumers
 # (`bench_apples_to_apples.sh`, `bench_apples_precise.sh`, `bench_q4_apples.sh`,
@@ -64,7 +75,11 @@
 #                              bench_compare_1k.py shape)
 #     measured_calls           list[table], optional; overrides the default
 #                              measured plan (one call per `windows` entry,
-#                              yields_windows=[that window]); each table:
+#                              yields_windows=[that window]); flattened
+#                              yields_windows across the WHOLE list must
+#                              cover `windows` exactly once each (fail-closed:
+#                              missing/undeclared/duplicate windows rejected);
+#                              each table:
 #       n_tokens                 int, > 0 (completion-token budget for this call)
 #       yields_windows            list[int], non-empty, no duplicates -- the
 #                                window(s) this ONE call produces an
@@ -74,7 +89,13 @@
 #                                to return AdapterRunResult.component_ns with
 #                                an entry for every listed window -- see
 #                                bench_decode_harness.py:AdapterRunResult.
-#   prompt                   string, non-empty (the MEASURED-window prompt)
+#     measured_prompt           string, non-empty, optional; overrides the
+#                              profile's `prompt` for THIS engine's measured
+#                              calls only (e.g. Ollama's character-count
+#                              heuristic prompt vs Lattice/MLX's
+#                              tokenizer-padded `prompt`)
+#   prompt                   string, non-empty (the default MEASURED prompt,
+#                            used by any engine without its own `measured_prompt`)
 #   aggregation              "median" (default) or "trimmed_mean"
 #   trim                     int, >= 0; only valid when aggregation = "trimmed_mean"
 #   requested_prompt_tokens  int, optional
@@ -110,15 +131,21 @@
 # quantization = "q4"
 #
 # Example 2 (not a live profile -- illustrates bench_compare_1k.py's three
-# distinct measured shapes: Lattice window-major (the default, no
-# measured_calls needed), Ollama's one-call-yields-two-windows shape, and
-# MLX's repeat-major alternation; uncomment and rename to activate):
+# distinct measured shapes AND its two distinct measured prompts: Lattice
+# window-major (the default, no measured_calls needed) and MLX
+# repeat-major both use the profile-wide tokenizer-padded `prompt`;
+# Ollama's one-call-yields-two-windows shape uses its OWN
+# `measured_prompt` override (a character-count-heuristic prompt for the
+# same nominal context, per bench_compare_1k.py's actual two-method
+# prompt-building split -- NOT a placeholder an adapter reinterprets: the
+# harness sends this exact string and hashes it); uncomment and rename to
+# activate):
 #
 # [profiles.example_agentic]
 # description = "example only, see bench_compare_1k.py for the real profile"
 # windows = [1, 100]
 # measured_repeats = 5
-# prompt = "<ctx-padded prompt, built per-engine at the adapter level>"
+# prompt = "<tokenizer-padded prompt for the target ctx length, shared by lattice/mlx>"
 # aggregation = "median"
 #
 # [[profiles.example_agentic.engines]]
@@ -134,6 +161,7 @@
 # warmup_prompt = "hi"
 # model = "qwen3.5:0.8b"
 # quantization = "q8"
+# measured_prompt = "<char-count-heuristic prompt for the same target ctx length>"
 # [[profiles.example_agentic.engines.measured_calls]]
 # n_tokens = 100
 # yields_windows = [1, 100]

--- a/scripts/bench_decode_profiles.toml
+++ b/scripts/bench_decode_profiles.toml
@@ -1,0 +1,32 @@
+# Decode-benchmark harness profile definitions (issue #813).
+#
+# Each `[profiles.<name>]` table fully specifies one decode-benchmark
+# configuration for `scripts/bench_decode_harness.py run --profile <name>`:
+# the window schedule, warmup/measured repeat counts, engines, aggregation
+# method, and the fixed prompt. `windows[0]` is the shared baseline; every
+# later value in `windows` is compared against it to compute a marginal
+# decode-throughput slope (see `bench_decode_harness.py:aggregate`).
+#
+# This file intentionally defines no profiles yet. The five live consumers
+# (`bench_apples_to_apples.sh`, `bench_apples_precise.sh`, `bench_q4_apples.sh`,
+# `bench_context_scaling.sh`, `bench_compare_1k.py`) are migrated onto
+# profiles defined here one script per PR (issue #813 step 2), each PR
+# proving old-vs-new raw-observation equivalence under the legacy script's
+# exact parameters before it is added below.
+#
+# Schema (for reference; enforced by `bench_decode_harness.py:_parse_profile`):
+#   description             string, optional
+#   windows                 list[int], >= 2 entries, strictly increasing
+#   warmup_repeats           int, >= 0
+#   measured_repeats         int, >= 1
+#   engines                  list[string], non-empty, no duplicates
+#   prompt                   string, non-empty
+#   model                    string, non-empty
+#   quantization             string, non-empty
+#   aggregation              "median" (default) or "trimmed_mean"
+#   trim                     int, >= 0; only valid when aggregation = "trimmed_mean"
+#   requested_prompt_tokens  int, optional
+
+schema_version = 1
+
+[profiles]

--- a/tests/test_bench_decode_harness.py
+++ b/tests/test_bench_decode_harness.py
@@ -95,9 +95,19 @@ class _FakeAdapter:
 
 
 def _engine(
-    name: str = "fake", warmup_repeats: int = 0, model: str = "qwen3.5-0.8b", quantization: str = "q8"
+    name: str = "fake",
+    warmup_repeats: int = 0,
+    warmup_tokens: int | None = None,
+    warmup_prompt: str | None = None,
+    model: str = "qwen3.5-0.8b",
+    quantization: str = "q8",
 ) -> dict:
-    return {"name": name, "warmup_repeats": warmup_repeats, "model": model, "quantization": quantization}
+    d = {"name": name, "warmup_repeats": warmup_repeats, "model": model, "quantization": quantization}
+    if warmup_tokens is not None:
+        d["warmup_tokens"] = warmup_tokens
+    if warmup_prompt is not None:
+        d["warmup_prompt"] = warmup_prompt
+    return d
 
 
 def _profile(**overrides) -> "harness.ProfileConfig":
@@ -224,6 +234,8 @@ class ProfileConfigTest(unittest.TestCase):
         self.assertEqual(profile.engines, ("fake",))
         self.assertEqual(len(profile.engine_groups), 1)
         self.assertEqual(profile.engine_groups[0].warmup_repeats, 0)
+        self.assertIsNone(profile.engine_groups[0].warmup_tokens)
+        self.assertIsNone(profile.engine_groups[0].warmup_prompt)
         self.assertEqual(profile.engine_groups[0].model, "qwen3.5-0.8b")
         self.assertEqual(profile.engine_groups[0].quantization, "q8")
 
@@ -265,6 +277,67 @@ class ProfileConfigTest(unittest.TestCase):
     def test_negative_engine_warmup_rejected(self):
         with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_repeats"):
             _profile(engines=[_engine(warmup_repeats=-1)])
+
+    # -- Warmup is an explicit pre-window batch (round-2 blocker fix):
+    # warmup_tokens is the completion-token budget for that batch, and is
+    # only meaningful together with a positive warmup_repeats. --
+
+    def test_warmup_tokens_required_when_warmup_repeats_positive(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_tokens.*required"):
+            _profile(engines=[_engine(warmup_repeats=1)])
+
+    def test_warmup_tokens_rejected_when_warmup_repeats_zero(self):
+        raw_engine = {"name": "fake", "warmup_repeats": 0, "warmup_tokens": 8, "model": "m", "quantization": "q8"}
+        with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_tokens.*only meaningful"):
+            _profile(engines=[raw_engine])
+
+    def test_warmup_tokens_must_be_positive(self):
+        raw_engine = {"name": "fake", "warmup_repeats": 1, "warmup_tokens": 0, "model": "m", "quantization": "q8"}
+        with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_tokens.*positive"):
+            _profile(engines=[raw_engine])
+
+    def test_warmup_tokens_wrong_type_rejected(self):
+        raw_engine = {
+            "name": "fake",
+            "warmup_repeats": 1,
+            "warmup_tokens": "eight",
+            "model": "m",
+            "quantization": "q8",
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_tokens"):
+            _profile(engines=[raw_engine])
+
+    def test_warmup_prompt_optional_at_zero_warmup(self):
+        # warmup_prompt is simply unused when warmup_repeats == 0, so it is
+        # not rejected the way warmup_tokens is -- there is nothing
+        # ambiguous about specifying it (it would only matter if warmups
+        # were ever scheduled).
+        profile = _profile(engines=[_engine(warmup_repeats=0, warmup_prompt="unused prompt")])
+        self.assertEqual(profile.engine_groups[0].warmup_prompt, "unused prompt")
+
+    def test_warmup_prompt_must_be_non_empty_if_provided(self):
+        raw_engine = {
+            "name": "fake",
+            "warmup_repeats": 1,
+            "warmup_tokens": 8,
+            "warmup_prompt": "",
+            "model": "m",
+            "quantization": "q8",
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_prompt"):
+            _profile(engines=[raw_engine])
+
+    def test_warmup_prompt_wrong_type_rejected(self):
+        raw_engine = {
+            "name": "fake",
+            "warmup_repeats": 1,
+            "warmup_tokens": 8,
+            "warmup_prompt": 123,
+            "model": "m",
+            "quantization": "q8",
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_prompt"):
+            _profile(engines=[raw_engine])
 
     def test_empty_engine_model_rejected(self):
         with self.assertRaisesRegex(harness.ProfileConfigError, "model must be non-empty"):
@@ -378,6 +451,7 @@ prompt = "hello world"
 [[profiles.smoke.engines]]
 name = "fake"
 warmup_repeats = 1
+warmup_tokens = 8
 model = "qwen3.5-0.8b"
 quantization = "q8"
 """,
@@ -388,6 +462,7 @@ quantization = "q8"
             self.assertEqual(profiles["smoke"].windows, (32, 256))
             self.assertEqual(profiles["smoke"].engines, ("fake",))
             self.assertEqual(profiles["smoke"].engine_groups[0].warmup_repeats, 1)
+            self.assertEqual(profiles["smoke"].engine_groups[0].warmup_tokens, 8)
 
     def test_heterogeneous_q4_q8_profile_round_trips(self):
         # Reproduces bench_q4_apples.sh's shape in one profile: Lattice and
@@ -413,6 +488,7 @@ quantization = "q4"
 [[profiles.q4_apples.engines]]
 name = "mlx"
 warmup_repeats = 1
+warmup_tokens = 8
 model = "qwen3.5-0.8b"
 quantization = "q4"
 
@@ -431,6 +507,7 @@ quantization = "q8"
             self.assertEqual(groups["lattice"].warmup_repeats, 0)
             self.assertEqual(groups["lattice"].quantization, "q4")
             self.assertEqual(groups["mlx"].warmup_repeats, 1)
+            self.assertEqual(groups["mlx"].warmup_tokens, 8)
             self.assertEqual(groups["mlx"].quantization, "q4")
             self.assertEqual(groups["ollama"].warmup_repeats, 0)
             self.assertEqual(groups["ollama"].quantization, "q8")
@@ -443,7 +520,9 @@ quantization = "q8"
 
 class RunProfileTest(unittest.TestCase):
     def test_produces_expected_observation_count(self):
-        profile = _profile(engines=[_engine(warmup_repeats=2)], measured_repeats=3, windows=[32, 256])
+        profile = _profile(
+            engines=[_engine(warmup_repeats=2, warmup_tokens=8)], measured_repeats=3, windows=[32, 256]
+        )
         adapter = _FakeAdapter()
         result = harness.run_profile(
             profile,
@@ -452,23 +531,44 @@ class RunProfileTest(unittest.TestCase):
             git_sha_value="deadbeef",
             hardware_id_value="test-host",
         )
-        # 1 engine * 2 windows * (2 warmup + 3 measured) = 10
-        self.assertEqual(len(result.observations), 10)
+        # 1 engine * (2 warmups, once, NOT per window) + 1 engine * 2 windows * 3 measured = 2 + 6 = 8
+        self.assertEqual(len(result.observations), 8)
         self.assertEqual(result.missing_engines, ())
 
-    def test_warmup_flag_and_run_index_reset_per_group(self):
-        profile = _profile(engines=[_engine(warmup_repeats=2)], measured_repeats=3, windows=[32, 256])
+    def test_warmup_executes_once_before_all_measured_windows(self):
+        # The round-2 blocker fix: warmup is a pre-window batch at its own
+        # token budget, not looped once per measured window.
+        profile = _profile(
+            engines=[_engine(warmup_repeats=2, warmup_tokens=8)], measured_repeats=3, windows=[32, 256]
+        )
         result = harness.run_profile(
             profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
         )
-        window_32 = [o for o in result.observations if o.requested_completion_tokens == 32]
-        warmups = [o for o in window_32 if o.warmup]
-        measured = [o for o in window_32 if not o.warmup]
+        warmups = [o for o in result.observations if o.warmup]
+        measured = [o for o in result.observations if not o.warmup]
+
+        # Exactly warmup_repeats warmup rows total (not per window), all at
+        # warmup_tokens, never at a measured window's token count.
+        self.assertEqual(len(warmups), 2)
+        self.assertEqual([o.requested_completion_tokens for o in warmups], [8, 8])
         self.assertEqual([o.run_index for o in warmups], [1, 2])
-        self.assertEqual([o.run_index for o in measured], [1, 2, 3])
+
+        # Every warmup observation's order_index precedes every measured
+        # observation's -- the warmup batch runs first, in full, before any
+        # measured window.
+        self.assertLess(max(o.order_index for o in warmups), min(o.order_index for o in measured))
+
+        # Measured run_index still resets per window (unaffected by the
+        # warmup-schedule fix).
+        measured_32 = [o for o in measured if o.requested_completion_tokens == 32]
+        measured_256 = [o for o in measured if o.requested_completion_tokens == 256]
+        self.assertEqual([o.run_index for o in measured_32], [1, 2, 3])
+        self.assertEqual([o.run_index for o in measured_256], [1, 2, 3])
 
     def test_order_index_strictly_increasing(self):
-        profile = _profile(engines=[_engine(warmup_repeats=1)], measured_repeats=2, windows=[32, 128, 256])
+        profile = _profile(
+            engines=[_engine(warmup_repeats=1, warmup_tokens=8)], measured_repeats=2, windows=[32, 128, 256]
+        )
         result = harness.run_profile(
             profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
         )
@@ -505,7 +605,9 @@ class RunProfileTest(unittest.TestCase):
             self.assertEqual(obs.actual_prompt_tokens, 7)
 
     def test_every_observation_is_schema_valid(self):
-        profile = _profile(engines=[_engine(warmup_repeats=1)], measured_repeats=2, windows=[32, 256])
+        profile = _profile(
+            engines=[_engine(warmup_repeats=1, warmup_tokens=8)], measured_repeats=2, windows=[32, 256]
+        )
         result = harness.run_profile(
             profile,
             {"fake": _FakeAdapter(native_ns_per_token=30_000)},
@@ -589,8 +691,12 @@ class RunProfileTest(unittest.TestCase):
 
     def test_heterogeneous_engine_schedule_exact_call_sequence_and_identities(self):
         """The blocker fix: reproduce bench_q4_apples.sh (Lattice Q4, MLX
-        Q4, Ollama Q8-reference) with bench_apples_to_apples.sh's MLX-only
-        warmup, all inside one profile."""
+        Q4, Ollama Q8-reference) with bench_apples_to_apples.sh's single
+        pre-loop 8-token MLX-only warmup, all inside one profile. MLX's
+        warmup is scheduled once, at its OWN 8-token budget -- distinct
+        from both measured windows (32, 256) -- entirely before its
+        measured runs, exactly reproducing the legacy script's call order.
+        """
         profile = harness._parse_profile(
             "q4_apples",
             {
@@ -599,7 +705,7 @@ class RunProfileTest(unittest.TestCase):
                 "prompt": "the quick brown fox",
                 "engines": [
                     _engine("lattice", warmup_repeats=0, model="qwen3.5-0.8b-q4", quantization="q4"),
-                    _engine("mlx", warmup_repeats=1, model="qwen3.5-0.8b", quantization="q4"),
+                    _engine("mlx", warmup_repeats=1, warmup_tokens=8, model="qwen3.5-0.8b", quantization="q4"),
                     _engine("ollama", warmup_repeats=0, model="qwen3.5:0.8b", quantization="q8"),
                 ],
             },
@@ -616,9 +722,10 @@ class RunProfileTest(unittest.TestCase):
         )
 
         # Exact call sequence per engine. lattice/ollama: 0 warmup + 2
-        # measured per window = 4 calls. mlx: 1 warmup + 2 measured per
-        # window = 6 calls -- the MLX-only-warmup mix bench_apples_to_apples.sh
-        # needs, now representable within a single profile.
+        # measured per window = 4 calls. mlx: ONE 8-token warmup call,
+        # then 2 measured per window = 5 calls -- exactly
+        # bench_apples_to_apples.sh's single pre-loop MLX warmup, not a
+        # warmup repeated at every measured window's token count.
         self.assertEqual(
             lattice.calls,
             [
@@ -631,10 +738,9 @@ class RunProfileTest(unittest.TestCase):
         self.assertEqual(
             mlx.calls,
             [
-                (32, True, "qwen3.5-0.8b", "q4"),
+                (8, True, "qwen3.5-0.8b", "q4"),
                 (32, False, "qwen3.5-0.8b", "q4"),
                 (32, False, "qwen3.5-0.8b", "q4"),
-                (256, True, "qwen3.5-0.8b", "q4"),
                 (256, False, "qwen3.5-0.8b", "q4"),
                 (256, False, "qwen3.5-0.8b", "q4"),
             ],
@@ -654,7 +760,7 @@ class RunProfileTest(unittest.TestCase):
         # of mlx's, then all of ollama's.
         self.assertEqual(
             [o.engine for o in result.observations],
-            ["lattice"] * 4 + ["mlx"] * 6 + ["ollama"] * 4,
+            ["lattice"] * 4 + ["mlx"] * 5 + ["ollama"] * 4,
         )
 
         # Per-row identity: each observation records ITS OWN engine's
@@ -669,6 +775,92 @@ class RunProfileTest(unittest.TestCase):
                 self.assertEqual((obs.model, obs.quantization), ("qwen3.5:0.8b", "q8"))
             else:  # pragma: no cover -- defensive, should be unreachable
                 self.fail(f"unexpected engine {obs.engine!r}")
+
+    def test_precise_style_warmup_twice_before_both_measured_windows(self):
+        """Reproduces bench_apples_precise.sh: every engine warms twice at
+        N2=512, once before both measured windows (N1=64, N2=512) --
+        never once per window (which would be 4 warmups: 2x64, 2x512)."""
+        profile = harness._parse_profile(
+            "precise",
+            {
+                "windows": [64, 512],
+                "measured_repeats": 13,
+                "prompt": "the quick brown fox",
+                "engines": [_engine("fake", warmup_repeats=2, warmup_tokens=512)],
+            },
+        )
+        adapter = _FakeAdapter()
+        harness.run_profile(
+            profile, {"fake": adapter}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        expected = (
+            [(512, True, "qwen3.5-0.8b", "q8")] * 2
+            + [(64, False, "qwen3.5-0.8b", "q8")] * 13
+            + [(512, False, "qwen3.5-0.8b", "q8")] * 13
+        )
+        self.assertEqual(adapter.calls, expected)
+
+    def test_context_scaling_style_single_warmup_before_all_comparison_windows(self):
+        """Reproduces bench_context_scaling.sh: MLX warms once at 4 tokens
+        before the N1=8 baseline and every N2 comparison window
+        ({64, 128, 256}) -- one warmup total, not one per window."""
+        profile = harness._parse_profile(
+            "context_scaling",
+            {
+                "windows": [8, 64, 128, 256],
+                "measured_repeats": 5,
+                "prompt": "the quick brown fox",
+                "engines": [_engine("mlx", warmup_repeats=1, warmup_tokens=4)],
+            },
+        )
+        adapter = _FakeAdapter()
+        result = harness.run_profile(
+            profile, {"mlx": adapter}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        expected = (
+            [(4, True, "qwen3.5-0.8b", "q8")]
+            + [(8, False, "qwen3.5-0.8b", "q8")] * 5
+            + [(64, False, "qwen3.5-0.8b", "q8")] * 5
+            + [(128, False, "qwen3.5-0.8b", "q8")] * 5
+            + [(256, False, "qwen3.5-0.8b", "q8")] * 5
+        )
+        self.assertEqual(adapter.calls, expected)
+        warmups = [o for o in result.observations if o.warmup]
+        self.assertEqual(len(warmups), 1)
+        self.assertEqual(warmups[0].requested_completion_tokens, 4)
+
+    def test_default_warmup_prompt_uses_profile_prompt(self):
+        profile = _profile(
+            engines=[_engine(warmup_repeats=1, warmup_tokens=8)],
+            measured_repeats=1,
+            windows=[32, 256],
+            prompt="the measured prompt",
+        )
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        warmup_obs = [o for o in result.observations if o.warmup][0]
+        measured_obs = [o for o in result.observations if not o.warmup][0]
+        self.assertEqual(warmup_obs.prompt_hash, measured_obs.prompt_hash)
+        self.assertEqual(warmup_obs.prompt_hash, harness.prompt_hash("the measured prompt"))
+
+    def test_custom_warmup_prompt_overrides_profile_prompt(self):
+        """Reproduces bench_compare_1k.py's distinct per-engine warmup
+        prompt, separate from the measured prompt."""
+        profile = _profile(
+            engines=[_engine(warmup_repeats=1, warmup_tokens=4, warmup_prompt="a distinct warmup prompt")],
+            measured_repeats=1,
+            windows=[32, 256],
+            prompt="the measured prompt",
+        )
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        warmup_obs = [o for o in result.observations if o.warmup][0]
+        measured_obs = [o for o in result.observations if not o.warmup][0]
+        self.assertEqual(warmup_obs.prompt_hash, harness.prompt_hash("a distinct warmup prompt"))
+        self.assertEqual(measured_obs.prompt_hash, harness.prompt_hash("the measured prompt"))
+        self.assertNotEqual(warmup_obs.prompt_hash, measured_obs.prompt_hash)
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_bench_decode_harness.py
+++ b/tests/test_bench_decode_harness.py
@@ -74,11 +74,25 @@ class _FakeClock:
 
 
 class _FakeAdapter:
-    """Deterministic fake engine adapter: fixed tok/s, exact requested token counts."""
+    """Deterministic fake engine adapter: fixed tok/s, exact requested token counts.
 
-    def __init__(self, engine_version: str = "fake-1.0", native_ns_per_token: int | None = None):
+    `component_ns`, when given, is returned verbatim as
+    `AdapterRunResult.component_ns` on every call -- for tests exercising a
+    `MeasuredCall` with `len(yields_windows) > 1` (e.g. Ollama's
+    one-call-yields-two-windows shape), where every call in the test only
+    ever requests the one multi-yield `n_tokens` budget so a single static
+    map is sufficient.
+    """
+
+    def __init__(
+        self,
+        engine_version: str = "fake-1.0",
+        native_ns_per_token: int | None = None,
+        component_ns: dict[int, int] | None = None,
+    ):
         self.engine_version = engine_version
         self.native_ns_per_token = native_ns_per_token
+        self.component_ns = component_ns
         self.calls: list[tuple[int, bool, str, str]] = []
 
     def run(
@@ -91,6 +105,7 @@ class _FakeAdapter:
             actual_prompt_tokens=len(prompt.split()),
             native_ns=native_ns,
             engine_version=self.engine_version,
+            component_ns=self.component_ns,
         )
 
 
@@ -101,12 +116,18 @@ def _engine(
     warmup_prompt: str | None = None,
     model: str = "qwen3.5-0.8b",
     quantization: str = "q8",
+    measured_order: str | None = None,
+    measured_calls: list[dict] | None = None,
 ) -> dict:
     d = {"name": name, "warmup_repeats": warmup_repeats, "model": model, "quantization": quantization}
     if warmup_tokens is not None:
         d["warmup_tokens"] = warmup_tokens
     if warmup_prompt is not None:
         d["warmup_prompt"] = warmup_prompt
+    if measured_order is not None:
+        d["measured_order"] = measured_order
+    if measured_calls is not None:
+        d["measured_calls"] = measured_calls
     return d
 
 
@@ -346,6 +367,121 @@ class ProfileConfigTest(unittest.TestCase):
     def test_empty_engine_quantization_rejected(self):
         with self.assertRaisesRegex(harness.ProfileConfigError, "quantization must be non-empty"):
             _profile(engines=[_engine(quantization="")])
+
+    # -- Round-3 blocker fix: measured_order / measured_calls, the
+    # per-engine measured-schedule contract that windows/measured_repeats
+    # alone could not represent (bench_compare_1k.py). --
+
+    def test_measured_order_defaults_to_window_major(self):
+        profile = _profile(engines=[_engine()])
+        self.assertEqual(profile.engine_groups[0].measured_order, "window_major")
+
+    def test_measured_order_accepts_repeat_major(self):
+        profile = _profile(engines=[_engine(measured_order="repeat_major")])
+        self.assertEqual(profile.engine_groups[0].measured_order, "repeat_major")
+
+    def test_measured_order_rejects_unknown_value(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "measured_order"):
+            _profile(engines=[_engine(measured_order="engine_major")])
+
+    def test_measured_order_wrong_type_rejected(self):
+        raw_engine = {
+            "name": "fake",
+            "warmup_repeats": 0,
+            "model": "m",
+            "quantization": "q8",
+            "measured_order": 1,
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, "measured_order"):
+            _profile(engines=[raw_engine])
+
+    def test_measured_calls_defaults_to_none(self):
+        profile = _profile(engines=[_engine()])
+        self.assertIsNone(profile.engine_groups[0].measured_calls)
+
+    def test_measured_calls_parsed_into_tuple_of_measured_call(self):
+        profile = _profile(
+            engines=[_engine(measured_calls=[{"n_tokens": 100, "yields_windows": [1, 100]}])]
+        )
+        calls = profile.engine_groups[0].measured_calls
+        self.assertEqual(calls, (harness.MeasuredCall(n_tokens=100, yields_windows=(1, 100)),))
+
+    def test_measured_calls_empty_list_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "measured_calls.*non-empty"):
+            _profile(engines=[_engine(measured_calls=[])])
+
+    def test_measured_calls_entry_not_a_table_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "measured_calls\\[0\\].*table"):
+            _profile(engines=[_engine(measured_calls=["not-a-table"])])
+
+    def test_measured_calls_unexpected_key_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "unexpected key.*prompt_override"):
+            _profile(
+                engines=[
+                    _engine(
+                        measured_calls=[
+                            {"n_tokens": 100, "yields_windows": [100], "prompt_override": "x"}
+                        ]
+                    )
+                ]
+            )
+
+    def test_measured_calls_missing_n_tokens_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "missing required key.*n_tokens"):
+            _profile(engines=[_engine(measured_calls=[{"yields_windows": [100]}])])
+
+    def test_measured_calls_missing_yields_windows_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "missing required key.*yields_windows"):
+            _profile(engines=[_engine(measured_calls=[{"n_tokens": 100}])])
+
+    def test_measured_calls_n_tokens_must_be_positive(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "n_tokens.*positive"):
+            _profile(engines=[_engine(measured_calls=[{"n_tokens": 0, "yields_windows": [1]}])])
+
+    def test_measured_calls_n_tokens_wrong_type_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "n_tokens"):
+            _profile(engines=[_engine(measured_calls=[{"n_tokens": "100", "yields_windows": [100]}])])
+
+    def test_measured_calls_n_tokens_bool_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "n_tokens"):
+            _profile(engines=[_engine(measured_calls=[{"n_tokens": True, "yields_windows": [1]}])])
+
+    def test_measured_calls_yields_windows_must_be_non_empty(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "yields_windows.*non-empty"):
+            _profile(engines=[_engine(measured_calls=[{"n_tokens": 100, "yields_windows": []}])])
+
+    def test_measured_calls_yields_windows_entry_must_be_positive(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "yields_windows.*positive"):
+            _profile(engines=[_engine(measured_calls=[{"n_tokens": 100, "yields_windows": [0]}])])
+
+    def test_measured_calls_yields_windows_entry_bool_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "yields_windows.*positive"):
+            _profile(engines=[_engine(measured_calls=[{"n_tokens": 100, "yields_windows": [True]}])])
+
+    def test_measured_calls_yields_windows_duplicate_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "yields_windows.*duplicate"):
+            _profile(engines=[_engine(measured_calls=[{"n_tokens": 100, "yields_windows": [1, 1]}])])
+
+    def test_measured_calls_multiple_entries_parsed_in_order(self):
+        profile = _profile(
+            engines=[
+                _engine(
+                    measured_order="repeat_major",
+                    measured_calls=[
+                        {"n_tokens": 1, "yields_windows": [1]},
+                        {"n_tokens": 100, "yields_windows": [100]},
+                    ],
+                )
+            ]
+        )
+        calls = profile.engine_groups[0].measured_calls
+        self.assertEqual(
+            calls,
+            (
+                harness.MeasuredCall(n_tokens=1, yields_windows=(1,)),
+                harness.MeasuredCall(n_tokens=100, yields_windows=(100,)),
+            ),
+        )
 
     def test_unexpected_engine_key_rejected(self):
         bad_engine = {"name": "fake", "warmup_repeats": 0, "model": "m", "quantization": "q8", "warmups": 1}
@@ -696,6 +832,13 @@ class RunProfileTest(unittest.TestCase):
         warmup is scheduled once, at its OWN 8-token budget -- distinct
         from both measured windows (32, 256) -- entirely before its
         measured runs, exactly reproducing the legacy script's call order.
+
+        Engine order is Lattice -> Ollama -> MLX, matching
+        `bench_q4_apples.sh`'s (and `bench_apples_to_apples.sh`'s,
+        `bench_apples_precise.sh`'s) actual script section order -- NOT
+        Lattice -> MLX -> Ollama (a round-3 review finding: an earlier
+        version of this test asserted the wrong global order while
+        claiming to reproduce the legacy schedule).
         """
         profile = harness._parse_profile(
             "q4_apples",
@@ -705,17 +848,17 @@ class RunProfileTest(unittest.TestCase):
                 "prompt": "the quick brown fox",
                 "engines": [
                     _engine("lattice", warmup_repeats=0, model="qwen3.5-0.8b-q4", quantization="q4"),
-                    _engine("mlx", warmup_repeats=1, warmup_tokens=8, model="qwen3.5-0.8b", quantization="q4"),
                     _engine("ollama", warmup_repeats=0, model="qwen3.5:0.8b", quantization="q8"),
+                    _engine("mlx", warmup_repeats=1, warmup_tokens=8, model="qwen3.5-0.8b", quantization="q4"),
                 ],
             },
         )
         lattice = _FakeAdapter()
-        mlx = _FakeAdapter()
         ollama = _FakeAdapter()
+        mlx = _FakeAdapter()
         result = harness.run_profile(
             profile,
-            {"lattice": lattice, "mlx": mlx, "ollama": ollama},
+            {"lattice": lattice, "ollama": ollama, "mlx": mlx},
             clock=_FakeClock(),
             git_sha_value="x",
             hardware_id_value="h",
@@ -736,6 +879,15 @@ class RunProfileTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
+            ollama.calls,
+            [
+                (32, False, "qwen3.5:0.8b", "q8"),
+                (32, False, "qwen3.5:0.8b", "q8"),
+                (256, False, "qwen3.5:0.8b", "q8"),
+                (256, False, "qwen3.5:0.8b", "q8"),
+            ],
+        )
+        self.assertEqual(
             mlx.calls,
             [
                 (8, True, "qwen3.5-0.8b", "q4"),
@@ -745,22 +897,14 @@ class RunProfileTest(unittest.TestCase):
                 (256, False, "qwen3.5-0.8b", "q4"),
             ],
         )
-        self.assertEqual(
-            ollama.calls,
-            [
-                (32, False, "qwen3.5:0.8b", "q8"),
-                (32, False, "qwen3.5:0.8b", "q8"),
-                (256, False, "qwen3.5:0.8b", "q8"),
-                (256, False, "qwen3.5:0.8b", "q8"),
-            ],
-        )
 
         # Engine run order in the raw observation stream matches the
         # profile's engines order exactly: all of lattice's rows, then all
-        # of mlx's, then all of ollama's.
+        # of ollama's, then all of mlx's -- the legacy Lattice -> Ollama ->
+        # MLX global order.
         self.assertEqual(
             [o.engine for o in result.observations],
-            ["lattice"] * 4 + ["mlx"] * 5 + ["ollama"] * 4,
+            ["lattice"] * 4 + ["ollama"] * 4 + ["mlx"] * 5,
         )
 
         # Per-row identity: each observation records ITS OWN engine's
@@ -861,6 +1005,330 @@ class RunProfileTest(unittest.TestCase):
         self.assertEqual(warmup_obs.prompt_hash, harness.prompt_hash("a distinct warmup prompt"))
         self.assertEqual(measured_obs.prompt_hash, harness.prompt_hash("the measured prompt"))
         self.assertNotEqual(warmup_obs.prompt_hash, measured_obs.prompt_hash)
+
+    # -- Round-3 blocker fix: the MEASURED-side schedule contract
+    # (`measured_calls` / `measured_order` / `AdapterRunResult.
+    # component_ns`), added because windows/measured_repeats alone cannot
+    # represent bench_compare_1k.py's three distinct measured shapes. --
+
+    def test_measured_order_repeat_major_alternates_calls_per_repeat(self):
+        """MLX's bench_compare_1k.py shape: an explicit two-call plan
+        (1-token, 100-token) replayed repeat-major -- (1, 100) alternating
+        every repeat -- NOT window-major (all 1s then all 100s)."""
+        profile = harness._parse_profile(
+            "agentic_mlx_only",
+            {
+                "windows": [1, 100],
+                "measured_repeats": 3,
+                "prompt": "the padded ctx prompt",
+                "engines": [
+                    _engine(
+                        "fake",
+                        measured_order="repeat_major",
+                        measured_calls=[
+                            {"n_tokens": 1, "yields_windows": [1]},
+                            {"n_tokens": 100, "yields_windows": [100]},
+                        ],
+                    )
+                ],
+            },
+        )
+        adapter = _FakeAdapter()
+        harness.run_profile(
+            profile, {"fake": adapter}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        expected = [(1, False, "qwen3.5-0.8b", "q8"), (100, False, "qwen3.5-0.8b", "q8")] * 3
+        self.assertEqual(adapter.calls, expected)
+
+    def test_measured_calls_default_matches_explicit_window_major_equivalent(self):
+        """Sanity: an engine with no measured_calls (implicit default,
+        derived from profile.windows) produces the identical call sequence
+        as the same shape written out explicitly with measured_order=
+        'window_major' (the default)."""
+        implicit = harness._parse_profile(
+            "implicit", {"windows": [32, 256], "measured_repeats": 2, "prompt": "x", "engines": [_engine()]}
+        )
+        explicit = harness._parse_profile(
+            "explicit",
+            {
+                "windows": [32, 256],
+                "measured_repeats": 2,
+                "prompt": "x",
+                "engines": [
+                    _engine(
+                        measured_calls=[
+                            {"n_tokens": 32, "yields_windows": [32]},
+                            {"n_tokens": 256, "yields_windows": [256]},
+                        ]
+                    )
+                ],
+            },
+        )
+        a1, a2 = _FakeAdapter(), _FakeAdapter()
+        harness.run_profile(implicit, {"fake": a1}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h")
+        harness.run_profile(explicit, {"fake": a2}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h")
+        self.assertEqual(a1.calls, a2.calls)
+
+    def test_measured_call_multi_yield_uses_component_ns_for_elapsed_ns(self):
+        """Ollama's bench_compare_1k.py shape: ONE 100-token call per
+        repeat yields BOTH a window=1 and a window=100 observation, with
+        elapsed_ns for each coming from the adapter-reported component --
+        never from the harness's own single wall-clock span for the whole
+        call (which would conflate the two components)."""
+        profile = harness._parse_profile(
+            "agentic_ollama_only",
+            {
+                "windows": [1, 100],
+                "measured_repeats": 2,
+                "prompt": "the padded ctx prompt",
+                "engines": [_engine("fake", measured_calls=[{"n_tokens": 100, "yields_windows": [1, 100]}])],
+            },
+        )
+        adapter = _FakeAdapter(component_ns={1: 40_000_000, 100: 400_000_000})
+        result = harness.run_profile(
+            profile, {"fake": adapter}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        # Exactly ONE physical call per repeat -- the harness never
+        # re-invokes the engine to synthesize the second window.
+        self.assertEqual(adapter.calls, [(100, False, "qwen3.5-0.8b", "q8")] * 2)
+
+        measured = [o for o in result.observations if not o.warmup]
+        self.assertEqual([o.requested_completion_tokens for o in measured], [1, 100, 1, 100])
+        self.assertEqual([o.elapsed_ns for o in measured], [40_000_000, 400_000_000, 40_000_000, 400_000_000])
+        # Both windows from the SAME physical call share the same
+        # run_index (they are one repeat's two derived readings) and the
+        # SAME actual_completion_tokens (the real underlying call
+        # requested/generated 100 tokens, regardless of which window a
+        # given derived observation represents).
+        self.assertEqual([o.run_index for o in measured], [1, 1, 2, 2])
+        self.assertTrue(all(o.actual_completion_tokens == 100 for o in measured))
+
+    def test_measured_call_multi_yield_missing_component_ns_raises(self):
+        profile = harness._parse_profile(
+            "agentic_ollama_only",
+            {
+                "windows": [1, 100],
+                "measured_repeats": 1,
+                "prompt": "x",
+                "engines": [_engine("fake", measured_calls=[{"n_tokens": 100, "yields_windows": [1, 100]}])],
+            },
+        )
+        adapter = _FakeAdapter()  # component_ns=None
+        with self.assertRaisesRegex(harness.AdapterContractError, "component_ns is None"):
+            harness.run_profile(
+                profile, {"fake": adapter}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+            )
+
+    def test_measured_call_multi_yield_missing_window_entry_raises(self):
+        profile = harness._parse_profile(
+            "agentic_ollama_only",
+            {
+                "windows": [1, 100],
+                "measured_repeats": 1,
+                "prompt": "x",
+                "engines": [_engine("fake", measured_calls=[{"n_tokens": 100, "yields_windows": [1, 100]}])],
+            },
+        )
+        adapter = _FakeAdapter(component_ns={100: 400_000_000})  # window=1 missing
+        with self.assertRaisesRegex(harness.AdapterContractError, r"missing entries for window\(s\) \[1\]"):
+            harness.run_profile(
+                profile, {"fake": adapter}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+            )
+
+    def test_agentic_style_global_flattened_sequence_lattice_ollama_mlx(self):
+        """The round-3 blocker fix, end to end: reproduce
+        `bench_compare_1k.py`'s complete Lattice -> Ollama -> MLX stream in
+        one profile. Lattice is window-major (all 1-token then all
+        100-token calls, the default shape). Ollama warms once at 4
+        tokens with its own 'hi' prompt, then issues ONE 100-token call
+        per repeat yielding both a window=1 (TTFT) and window=100 (total)
+        observation via component_ns. MLX warms once at 4 tokens with its
+        own 'BASE' prompt, then alternates (1, 100) every repeat
+        (repeat-major)."""
+        profile = harness._parse_profile(
+            "agentic",
+            {
+                "windows": [1, 100],
+                "measured_repeats": 2,
+                "prompt": "the padded ctx prompt",
+                "engines": [
+                    _engine("lattice", model="qwen3.5-0.8b", quantization="q8"),
+                    _engine(
+                        "ollama",
+                        warmup_repeats=1,
+                        warmup_tokens=4,
+                        warmup_prompt="hi",
+                        model="qwen3.5:0.8b",
+                        quantization="q8",
+                        measured_calls=[{"n_tokens": 100, "yields_windows": [1, 100]}],
+                    ),
+                    _engine(
+                        "mlx",
+                        warmup_repeats=1,
+                        warmup_tokens=4,
+                        warmup_prompt="BASE",
+                        model="qwen3.5-0.8b",
+                        quantization="q8",
+                        measured_order="repeat_major",
+                        measured_calls=[
+                            {"n_tokens": 1, "yields_windows": [1]},
+                            {"n_tokens": 100, "yields_windows": [100]},
+                        ],
+                    ),
+                ],
+            },
+        )
+        lattice = _FakeAdapter()
+        ollama = _FakeAdapter(component_ns={1: 40_000_000, 100: 400_000_000})
+        mlx = _FakeAdapter()
+        result = harness.run_profile(
+            profile,
+            {"lattice": lattice, "ollama": ollama, "mlx": mlx},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+
+        # Lattice: no warmup, all 1-token calls then all 100-token calls.
+        self.assertEqual(
+            lattice.calls,
+            [
+                (1, False, "qwen3.5-0.8b", "q8"),
+                (1, False, "qwen3.5-0.8b", "q8"),
+                (100, False, "qwen3.5-0.8b", "q8"),
+                (100, False, "qwen3.5-0.8b", "q8"),
+            ],
+        )
+        # Ollama: one 4-token 'hi' warmup, then exactly TWO physical
+        # 100-token calls (one per repeat) -- never four.
+        self.assertEqual(
+            ollama.calls,
+            [
+                (4, True, "qwen3.5:0.8b", "q8"),
+                (100, False, "qwen3.5:0.8b", "q8"),
+                (100, False, "qwen3.5:0.8b", "q8"),
+            ],
+        )
+        # MLX: one 4-token 'BASE' warmup, then (1, 100) alternating per repeat.
+        self.assertEqual(
+            mlx.calls,
+            [
+                (4, True, "qwen3.5-0.8b", "q8"),
+                (1, False, "qwen3.5-0.8b", "q8"),
+                (100, False, "qwen3.5-0.8b", "q8"),
+                (1, False, "qwen3.5-0.8b", "q8"),
+                (100, False, "qwen3.5-0.8b", "q8"),
+            ],
+        )
+
+        # Global observation stream: all of lattice's rows (4, no warmup),
+        # then all of ollama's (1 warmup + 4 measured -- two calls, two
+        # yielded windows each), then all of mlx's (1 warmup + 4 measured).
+        self.assertEqual(
+            [o.engine for o in result.observations],
+            ["lattice"] * 4 + ["ollama"] * 5 + ["mlx"] * 5,
+        )
+        # Ollama's measured rows: window=1 (TTFT-equivalent, from
+        # component_ns) immediately followed by window=100 (total), twice.
+        ollama_measured = [o for o in result.observations if o.engine == "ollama" and not o.warmup]
+        self.assertEqual([o.requested_completion_tokens for o in ollama_measured], [1, 100, 1, 100])
+        self.assertEqual(
+            [o.elapsed_ns for o in ollama_measured], [40_000_000, 400_000_000, 40_000_000, 400_000_000]
+        )
+        # MLX's measured rows alternate (1, 100) per repeat -- repeat-major.
+        mlx_measured = [o for o in result.observations if o.engine == "mlx" and not o.warmup]
+        self.assertEqual([o.requested_completion_tokens for o in mlx_measured], [1, 100, 1, 100])
+
+    def test_precise_style_global_flattened_sequence_all_three_engines(self):
+        """`bench_apples_precise.sh` reproduced with its actual three
+        engines (Lattice, Ollama, MLX), each warming identically -- twice
+        at N2=512, once before both measured windows -- confirming the
+        warmup mechanism holds across every engine in the real script, not
+        just a single stand-in adapter."""
+        profile = harness._parse_profile(
+            "precise",
+            {
+                "windows": [64, 512],
+                "measured_repeats": 3,
+                "prompt": "the quick brown fox",
+                "engines": [
+                    _engine("lattice", warmup_repeats=2, warmup_tokens=512, model="qwen3.5-0.8b", quantization="q8"),
+                    _engine("ollama", warmup_repeats=2, warmup_tokens=512, model="qwen3.5:0.8b", quantization="q8"),
+                    _engine("mlx", warmup_repeats=2, warmup_tokens=512, model="qwen3.5-0.8b", quantization="q8"),
+                ],
+            },
+        )
+        lattice, ollama, mlx = _FakeAdapter(), _FakeAdapter(), _FakeAdapter()
+        result = harness.run_profile(
+            profile,
+            {"lattice": lattice, "ollama": ollama, "mlx": mlx},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        expected_per_engine = (
+            [(512, True, "qwen3.5-0.8b", "q8")] * 2
+            + [(64, False, "qwen3.5-0.8b", "q8")] * 3
+            + [(512, False, "qwen3.5-0.8b", "q8")] * 3
+        )
+        expected_ollama = (
+            [(512, True, "qwen3.5:0.8b", "q8")] * 2
+            + [(64, False, "qwen3.5:0.8b", "q8")] * 3
+            + [(512, False, "qwen3.5:0.8b", "q8")] * 3
+        )
+        self.assertEqual(lattice.calls, expected_per_engine)
+        self.assertEqual(ollama.calls, expected_ollama)
+        self.assertEqual(mlx.calls, expected_per_engine)
+        self.assertEqual(
+            [o.engine for o in result.observations],
+            ["lattice"] * 8 + ["ollama"] * 8 + ["mlx"] * 8,
+        )
+
+    def test_context_scaling_style_global_flattened_sequence_all_three_engines(self):
+        """`bench_context_scaling.sh` reproduced with its actual three
+        engines: only MLX warms (once, at 4 tokens, before the N1=8
+        baseline and every N2 comparison window) -- Lattice and Ollama
+        have no separate warmup step in this script."""
+        profile = harness._parse_profile(
+            "context_scaling",
+            {
+                "windows": [8, 64, 128, 256],
+                "measured_repeats": 2,
+                "prompt": "the quick brown fox",
+                "engines": [
+                    _engine("lattice", warmup_repeats=0, model="qwen3.5-0.8b", quantization="q8"),
+                    _engine("ollama", warmup_repeats=0, model="qwen3.5:0.8b", quantization="q8"),
+                    _engine("mlx", warmup_repeats=1, warmup_tokens=4, model="qwen3.5-0.8b", quantization="q8"),
+                ],
+            },
+        )
+        lattice, ollama, mlx = _FakeAdapter(), _FakeAdapter(), _FakeAdapter()
+        result = harness.run_profile(
+            profile,
+            {"lattice": lattice, "ollama": ollama, "mlx": mlx},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        no_warmup_expected = (
+            [(8, False, "qwen3.5-0.8b", "q8")] * 2
+            + [(64, False, "qwen3.5-0.8b", "q8")] * 2
+            + [(128, False, "qwen3.5-0.8b", "q8")] * 2
+            + [(256, False, "qwen3.5-0.8b", "q8")] * 2
+        )
+        self.assertEqual(lattice.calls, no_warmup_expected)
+        self.assertEqual(
+            ollama.calls,
+            [(c[0], c[1], "qwen3.5:0.8b", "q8") for c in no_warmup_expected],
+        )
+        self.assertEqual(
+            mlx.calls,
+            [(4, True, "qwen3.5-0.8b", "q8")] + no_warmup_expected,
+        )
+        self.assertEqual(
+            [o.engine for o in result.observations],
+            ["lattice"] * 8 + ["ollama"] * 8 + ["mlx"] * 9,
+        )
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_bench_decode_harness.py
+++ b/tests/test_bench_decode_harness.py
@@ -3,7 +3,7 @@
 Deterministic fake-adapter tests and raw-schema validation only -- no engine
 binary is required to run this file, matching the harness-core landing gate.
 
-Run with: python3 -m unittest tests/test_bench_decode_harness.py -v
+Run with: python3 tests/test_bench_decode_harness.py -v
 (or `python3 -m pytest tests/test_bench_decode_harness.py -v` -- no
 pytest-only features are used).
 """
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import math
+import statistics
 import sys
 import tempfile
 import unittest
@@ -77,10 +79,12 @@ class _FakeAdapter:
     def __init__(self, engine_version: str = "fake-1.0", native_ns_per_token: int | None = None):
         self.engine_version = engine_version
         self.native_ns_per_token = native_ns_per_token
-        self.calls: list[tuple[int, bool]] = []
+        self.calls: list[tuple[int, bool, str, str]] = []
 
-    def run(self, *, prompt: str, n_tokens: int, warmup: bool) -> "harness.AdapterRunResult":
-        self.calls.append((n_tokens, warmup))
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> "harness.AdapterRunResult":
+        self.calls.append((n_tokens, warmup, model, quantization))
         native_ns = self.native_ns_per_token * n_tokens if self.native_ns_per_token else None
         return harness.AdapterRunResult(
             actual_completion_tokens=n_tokens,
@@ -90,16 +94,19 @@ class _FakeAdapter:
         )
 
 
+def _engine(
+    name: str = "fake", warmup_repeats: int = 0, model: str = "qwen3.5-0.8b", quantization: str = "q8"
+) -> dict:
+    return {"name": name, "warmup_repeats": warmup_repeats, "model": model, "quantization": quantization}
+
+
 def _profile(**overrides) -> "harness.ProfileConfig":
     raw = {
         "description": "unit test profile",
         "windows": [32, 256],
-        "warmup_repeats": 0,
         "measured_repeats": 3,
-        "engines": ["fake"],
+        "engines": [_engine()],
         "prompt": "the quick brown fox",
-        "model": "qwen3.5-0.8b",
-        "quantization": "q8",
     }
     raw.update(overrides)
     return harness._parse_profile("unit_test", raw)
@@ -214,6 +221,11 @@ class ProfileConfigTest(unittest.TestCase):
         profile = _profile()
         self.assertEqual(profile.windows, (32, 256))
         self.assertEqual(profile.aggregation, "median")
+        self.assertEqual(profile.engines, ("fake",))
+        self.assertEqual(len(profile.engine_groups), 1)
+        self.assertEqual(profile.engine_groups[0].warmup_repeats, 0)
+        self.assertEqual(profile.engine_groups[0].model, "qwen3.5-0.8b")
+        self.assertEqual(profile.engine_groups[0].quantization, "q8")
 
     def test_single_window_rejected(self):
         with self.assertRaisesRegex(harness.ProfileConfigError, "at least 2"):
@@ -227,10 +239,6 @@ class ProfileConfigTest(unittest.TestCase):
         with self.assertRaisesRegex(harness.ProfileConfigError, "strictly increasing"):
             _profile(windows=[32, 32])
 
-    def test_negative_warmup_rejected(self):
-        with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_repeats"):
-            _profile(warmup_repeats=-1)
-
     def test_zero_measured_repeats_rejected(self):
         with self.assertRaisesRegex(harness.ProfileConfigError, "measured_repeats"):
             _profile(measured_repeats=0)
@@ -239,9 +247,57 @@ class ProfileConfigTest(unittest.TestCase):
         with self.assertRaisesRegex(harness.ProfileConfigError, "engines"):
             _profile(engines=[])
 
-    def test_duplicate_engines_rejected(self):
-        with self.assertRaisesRegex(harness.ProfileConfigError, "duplicates"):
-            _profile(engines=["fake", "fake"])
+    def test_engine_entry_must_be_a_table(self):
+        # The old flat `engines = ["fake"]` name-list shape is no longer
+        # representable -- every engine now needs its own warmup/model/
+        # quantization, so a bare string entry is rejected.
+        with self.assertRaisesRegex(harness.ProfileConfigError, "must be a table"):
+            _profile(engines=["fake"])
+
+    def test_duplicate_engine_names_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "duplicate"):
+            _profile(engines=[_engine("fake"), _engine("fake")])
+
+    def test_empty_engine_name_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "name must be non-empty"):
+            _profile(engines=[_engine(name="")])
+
+    def test_negative_engine_warmup_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_repeats"):
+            _profile(engines=[_engine(warmup_repeats=-1)])
+
+    def test_empty_engine_model_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "model must be non-empty"):
+            _profile(engines=[_engine(model="")])
+
+    def test_empty_engine_quantization_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "quantization must be non-empty"):
+            _profile(engines=[_engine(quantization="")])
+
+    def test_unexpected_engine_key_rejected(self):
+        bad_engine = {"name": "fake", "warmup_repeats": 0, "model": "m", "quantization": "q8", "warmups": 1}
+        with self.assertRaisesRegex(harness.ProfileConfigError, "unexpected key"):
+            _profile(engines=[bad_engine])
+
+    def test_missing_required_engine_key_rejected(self):
+        raw = {
+            "windows": [32, 256],
+            "measured_repeats": 3,
+            "engines": [{"name": "fake", "warmup_repeats": 0, "model": "m"}],  # quantization omitted
+            "prompt": "x",
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, "quantization"):
+            harness._parse_profile("bad", raw)
+
+    def test_missing_required_top_level_key_rejected(self):
+        raw = {
+            "windows": [32, 256],
+            "measured_repeats": 3,
+            "engines": [_engine()],
+            # prompt omitted
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, "prompt"):
+            harness._parse_profile("bad", raw)
 
     def test_unknown_aggregation_rejected(self):
         with self.assertRaisesRegex(harness.ProfileConfigError, "aggregation"):
@@ -255,18 +311,33 @@ class ProfileConfigTest(unittest.TestCase):
         with self.assertRaisesRegex(harness.ProfileConfigError, "trim"):
             _profile(aggregation="trimmed_mean", trim=2, measured_repeats=3)
 
-    def test_missing_required_key_rejected(self):
-        raw = {
-            "windows": [32, 256],
-            "warmup_repeats": 0,
-            "measured_repeats": 3,
-            "engines": ["fake"],
-            "prompt": "x",
-            "model": "m",
-            # quantization omitted
-        }
-        with self.assertRaisesRegex(harness.ProfileConfigError, "quantization"):
-            harness._parse_profile("bad", raw)
+    def test_description_wrong_type_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "description"):
+            _profile(description=123)
+
+    # -- Fail-closed on unknown/misspelled profile keys (round-1 major: a
+    # typo in an optional methodology key must never silently fall back to
+    # a default instead of being rejected). --
+
+    def test_misspelled_aggregation_key_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, r"unexpected key.*aggregtion"):
+            _profile(aggregtion="trimmed_mean")
+
+    def test_misspelled_trim_key_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, r"unexpected key.*trmi"):
+            _profile(trmi=1)
+
+    def test_misspelled_measured_repeats_key_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, r"unexpected key.*measured_repeat\b"):
+            _profile(measured_repeat=3)
+
+    def test_misspelled_requested_prompt_tokens_key_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, r"unexpected key.*requested_prompt_tokenz"):
+            _profile(requested_prompt_tokenz=10)
+
+    def test_misspelled_description_key_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, r"unexpected key.*description2"):
+            _profile(description2="typo")
 
 
 class LoadProfilesFileTest(unittest.TestCase):
@@ -282,6 +353,16 @@ class LoadProfilesFileTest(unittest.TestCase):
             with self.assertRaisesRegex(harness.ProfileConfigError, "schema_version"):
                 harness.load_profiles_file(path)
 
+    def test_unexpected_top_level_key_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "profiles.toml"
+            path.write_text(
+                "schema_version = 1\nextra_top_level_key = true\n\n[profiles]\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(harness.ProfileConfigError, "unexpected top-level key"):
+                harness.load_profiles_file(path)
+
     def test_named_profile_round_trips(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "profiles.toml"
@@ -291,10 +372,12 @@ schema_version = 1
 
 [profiles.smoke]
 windows = [32, 256]
-warmup_repeats = 1
 measured_repeats = 5
-engines = ["fake"]
 prompt = "hello world"
+
+[[profiles.smoke.engines]]
+name = "fake"
+warmup_repeats = 1
 model = "qwen3.5-0.8b"
 quantization = "q8"
 """,
@@ -303,7 +386,54 @@ quantization = "q8"
             _, profiles = harness.load_profiles_file(path)
             self.assertIn("smoke", profiles)
             self.assertEqual(profiles["smoke"].windows, (32, 256))
-            self.assertEqual(profiles["smoke"].warmup_repeats, 1)
+            self.assertEqual(profiles["smoke"].engines, ("fake",))
+            self.assertEqual(profiles["smoke"].engine_groups[0].warmup_repeats, 1)
+
+    def test_heterogeneous_q4_q8_profile_round_trips(self):
+        # Reproduces bench_q4_apples.sh's shape in one profile: Lattice and
+        # MLX both run Q4, Ollama runs Q8 as a reference only, and only MLX
+        # gets a warmup (bench_apples_to_apples.sh's pattern).
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "profiles.toml"
+            path.write_text(
+                """
+schema_version = 1
+
+[profiles.q4_apples]
+windows = [32, 256]
+measured_repeats = 5
+prompt = "hello world"
+
+[[profiles.q4_apples.engines]]
+name = "lattice"
+warmup_repeats = 0
+model = "qwen3.5-0.8b-q4"
+quantization = "q4"
+
+[[profiles.q4_apples.engines]]
+name = "mlx"
+warmup_repeats = 1
+model = "qwen3.5-0.8b"
+quantization = "q4"
+
+[[profiles.q4_apples.engines]]
+name = "ollama"
+warmup_repeats = 0
+model = "qwen3.5:0.8b"
+quantization = "q8"
+""",
+                encoding="utf-8",
+            )
+            _, profiles = harness.load_profiles_file(path)
+            profile = profiles["q4_apples"]
+            self.assertEqual(profile.engines, ("lattice", "mlx", "ollama"))
+            groups = {g.name: g for g in profile.engine_groups}
+            self.assertEqual(groups["lattice"].warmup_repeats, 0)
+            self.assertEqual(groups["lattice"].quantization, "q4")
+            self.assertEqual(groups["mlx"].warmup_repeats, 1)
+            self.assertEqual(groups["mlx"].quantization, "q4")
+            self.assertEqual(groups["ollama"].warmup_repeats, 0)
+            self.assertEqual(groups["ollama"].quantization, "q8")
 
 
 # --------------------------------------------------------------------------
@@ -313,7 +443,7 @@ quantization = "q8"
 
 class RunProfileTest(unittest.TestCase):
     def test_produces_expected_observation_count(self):
-        profile = _profile(warmup_repeats=2, measured_repeats=3, windows=[32, 256])
+        profile = _profile(engines=[_engine(warmup_repeats=2)], measured_repeats=3, windows=[32, 256])
         adapter = _FakeAdapter()
         result = harness.run_profile(
             profile,
@@ -327,7 +457,7 @@ class RunProfileTest(unittest.TestCase):
         self.assertEqual(result.missing_engines, ())
 
     def test_warmup_flag_and_run_index_reset_per_group(self):
-        profile = _profile(warmup_repeats=2, measured_repeats=3, windows=[32, 256])
+        profile = _profile(engines=[_engine(warmup_repeats=2)], measured_repeats=3, windows=[32, 256])
         result = harness.run_profile(
             profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
         )
@@ -338,7 +468,7 @@ class RunProfileTest(unittest.TestCase):
         self.assertEqual([o.run_index for o in measured], [1, 2, 3])
 
     def test_order_index_strictly_increasing(self):
-        profile = _profile(warmup_repeats=1, measured_repeats=2, windows=[32, 128, 256])
+        profile = _profile(engines=[_engine(warmup_repeats=1)], measured_repeats=2, windows=[32, 128, 256])
         result = harness.run_profile(
             profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
         )
@@ -348,7 +478,7 @@ class RunProfileTest(unittest.TestCase):
     def test_baseline_window_executed_once_not_per_comparison(self):
         # Mirrors bench_context_scaling.sh's shape: N1 is a shared baseline
         # run once, not re-executed for every comparison window.
-        profile = _profile(warmup_repeats=0, measured_repeats=4, windows=[8, 64, 128, 256])
+        profile = _profile(measured_repeats=4, windows=[8, 64, 128, 256])
         result = harness.run_profile(
             profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
         )
@@ -359,14 +489,14 @@ class RunProfileTest(unittest.TestCase):
         class _DriftingAdapter:
             engine_version = "drift-1.0"
 
-            def run(self, *, prompt, n_tokens, warmup):
+            def run(self, *, prompt, n_tokens, warmup, model, quantization):
                 return harness.AdapterRunResult(
                     actual_completion_tokens=n_tokens - 1,  # engine stopped one token early
                     actual_prompt_tokens=7,
                     engine_version=self.engine_version,
                 )
 
-        profile = _profile(warmup_repeats=0, measured_repeats=1, windows=[32, 256])
+        profile = _profile(measured_repeats=1, windows=[32, 256])
         result = harness.run_profile(
             profile, {"fake": _DriftingAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
         )
@@ -375,7 +505,7 @@ class RunProfileTest(unittest.TestCase):
             self.assertEqual(obs.actual_prompt_tokens, 7)
 
     def test_every_observation_is_schema_valid(self):
-        profile = _profile(warmup_repeats=1, measured_repeats=2, windows=[32, 256])
+        profile = _profile(engines=[_engine(warmup_repeats=1)], measured_repeats=2, windows=[32, 256])
         result = harness.run_profile(
             profile,
             {"fake": _FakeAdapter(native_ns_per_token=30_000)},
@@ -387,12 +517,12 @@ class RunProfileTest(unittest.TestCase):
             harness.validate_observation(obs.to_dict())  # must not raise
 
     def test_missing_engine_fails_closed_by_default(self):
-        profile = _profile(engines=["fake", "ghost"])
+        profile = _profile(engines=[_engine("fake"), _engine("ghost")])
         with self.assertRaises(harness.MissingEngineError):
             harness.run_profile(profile, {"fake": _FakeAdapter()}, clock=_FakeClock())
 
     def test_missing_engine_allowed_with_flag(self):
-        profile = _profile(engines=["fake", "ghost"])
+        profile = _profile(engines=[_engine("fake"), _engine("ghost")])
         result = harness.run_profile(
             profile,
             {"fake": _FakeAdapter()},
@@ -405,12 +535,140 @@ class RunProfileTest(unittest.TestCase):
         self.assertTrue(all(o.engine == "fake" for o in result.observations))
 
     def test_missing_engine_never_fabricates_observations(self):
-        profile = _profile(engines=["ghost"])
+        profile = _profile(engines=[_engine("ghost")])
         result = harness.run_profile(
             profile, {}, allow_missing_engine=True, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
         )
         self.assertEqual(result.observations, ())
         self.assertEqual(result.missing_engines, ("ghost",))
+
+    def test_adapter_default_identity_matches_requested(self):
+        profile = _profile(
+            engines=[_engine("fake", model="qwen3.5-0.8b-q4", quantization="q4")],
+            measured_repeats=1,
+            windows=[32, 256],
+        )
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        for obs in result.observations:
+            self.assertEqual(obs.model, "qwen3.5-0.8b-q4")
+            self.assertEqual(obs.quantization, "q4")
+
+    def test_adapter_reported_actual_identity_overrides_requested(self):
+        class _DriftingIdentityAdapter:
+            engine_version = "drift-1.0"
+
+            def run(self, *, prompt, n_tokens, warmup, model, quantization):
+                return harness.AdapterRunResult(
+                    actual_completion_tokens=n_tokens,
+                    actual_prompt_tokens=4,
+                    engine_version=self.engine_version,
+                    actual_model="qwen3.5-0.8b-fallback",
+                    actual_quantization="q8",
+                )
+
+        profile = _profile(
+            engines=[_engine("fake", model="qwen3.5-0.8b-q4", quantization="q4")],
+            measured_repeats=1,
+            windows=[32, 256],
+        )
+        result = harness.run_profile(
+            profile,
+            {"fake": _DriftingIdentityAdapter()},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        for obs in result.observations:
+            # The profile requested Q4, but the adapter reports it actually
+            # invoked a fallback Q8 artifact -- the raw observation must
+            # record what actually ran, never the requested identity.
+            self.assertEqual(obs.model, "qwen3.5-0.8b-fallback")
+            self.assertEqual(obs.quantization, "q8")
+
+    def test_heterogeneous_engine_schedule_exact_call_sequence_and_identities(self):
+        """The blocker fix: reproduce bench_q4_apples.sh (Lattice Q4, MLX
+        Q4, Ollama Q8-reference) with bench_apples_to_apples.sh's MLX-only
+        warmup, all inside one profile."""
+        profile = harness._parse_profile(
+            "q4_apples",
+            {
+                "windows": [32, 256],
+                "measured_repeats": 2,
+                "prompt": "the quick brown fox",
+                "engines": [
+                    _engine("lattice", warmup_repeats=0, model="qwen3.5-0.8b-q4", quantization="q4"),
+                    _engine("mlx", warmup_repeats=1, model="qwen3.5-0.8b", quantization="q4"),
+                    _engine("ollama", warmup_repeats=0, model="qwen3.5:0.8b", quantization="q8"),
+                ],
+            },
+        )
+        lattice = _FakeAdapter()
+        mlx = _FakeAdapter()
+        ollama = _FakeAdapter()
+        result = harness.run_profile(
+            profile,
+            {"lattice": lattice, "mlx": mlx, "ollama": ollama},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+
+        # Exact call sequence per engine. lattice/ollama: 0 warmup + 2
+        # measured per window = 4 calls. mlx: 1 warmup + 2 measured per
+        # window = 6 calls -- the MLX-only-warmup mix bench_apples_to_apples.sh
+        # needs, now representable within a single profile.
+        self.assertEqual(
+            lattice.calls,
+            [
+                (32, False, "qwen3.5-0.8b-q4", "q4"),
+                (32, False, "qwen3.5-0.8b-q4", "q4"),
+                (256, False, "qwen3.5-0.8b-q4", "q4"),
+                (256, False, "qwen3.5-0.8b-q4", "q4"),
+            ],
+        )
+        self.assertEqual(
+            mlx.calls,
+            [
+                (32, True, "qwen3.5-0.8b", "q4"),
+                (32, False, "qwen3.5-0.8b", "q4"),
+                (32, False, "qwen3.5-0.8b", "q4"),
+                (256, True, "qwen3.5-0.8b", "q4"),
+                (256, False, "qwen3.5-0.8b", "q4"),
+                (256, False, "qwen3.5-0.8b", "q4"),
+            ],
+        )
+        self.assertEqual(
+            ollama.calls,
+            [
+                (32, False, "qwen3.5:0.8b", "q8"),
+                (32, False, "qwen3.5:0.8b", "q8"),
+                (256, False, "qwen3.5:0.8b", "q8"),
+                (256, False, "qwen3.5:0.8b", "q8"),
+            ],
+        )
+
+        # Engine run order in the raw observation stream matches the
+        # profile's engines order exactly: all of lattice's rows, then all
+        # of mlx's, then all of ollama's.
+        self.assertEqual(
+            [o.engine for o in result.observations],
+            ["lattice"] * 4 + ["mlx"] * 6 + ["ollama"] * 4,
+        )
+
+        # Per-row identity: each observation records ITS OWN engine's
+        # requested model/quantization, never another engine's or a
+        # profile-wide value (the blocker this schema fixes).
+        for obs in result.observations:
+            if obs.engine == "lattice":
+                self.assertEqual((obs.model, obs.quantization), ("qwen3.5-0.8b-q4", "q4"))
+            elif obs.engine == "mlx":
+                self.assertEqual((obs.model, obs.quantization), ("qwen3.5-0.8b", "q4"))
+            elif obs.engine == "ollama":
+                self.assertEqual((obs.model, obs.quantization), ("qwen3.5:0.8b", "q8"))
+            else:  # pragma: no cover -- defensive, should be unreachable
+                self.fail(f"unexpected engine {obs.engine!r}")
 
 
 # --------------------------------------------------------------------------
@@ -423,7 +681,7 @@ class AggregateTest(unittest.TestCase):
         # Fixed 1ms-per-call harness clock overhead is negligible next to the
         # adapter's own synthetic timing, so drive elapsed_ns directly via a
         # clock that advances by a known amount per adapter call.
-        profile = _profile(warmup_repeats=0, measured_repeats=3, windows=[32, 256], aggregation="median")
+        profile = _profile(measured_repeats=3, windows=[32, 256], aggregation="median")
         # 10 tok/s target: dt = (256-32)/10 = 22.4s. Each window's 3 measured
         # runs get identical elapsed_ns so the median is exact.
         # window 32: elapsed = 3.2s/call (32 tok @ 10 tok/s)
@@ -436,24 +694,60 @@ class AggregateTest(unittest.TestCase):
         slopes = harness.aggregate(result)
         self.assertEqual(len(slopes), 1)
         self.assertAlmostEqual(slopes[0].slope_tok_per_s, 10.0, places=6)
-        self.assertIsNone(slopes[0].slope_ci95)
+        self.assertIsNone(slopes[0].slope_ci95_legacy)
 
-    def test_trimmed_mean_slope_has_ci(self):
-        profile = _profile(
-            warmup_repeats=0, measured_repeats=5, windows=[32, 256], aggregation="trimmed_mean", trim=1
-        )
-        steps = [3.0e9, 3.2e9, 3.2e9, 3.2e9, 3.4e9, 25.0e9, 25.6e9, 25.6e9, 25.6e9, 26.0e9]
-        clock = _StepClock(steps)
+    def test_trimmed_mean_stat_exact_with_asymmetric_outliers(self):
+        # Direct unit test of the trimming primitive: a low and a high
+        # outlier that trimming must remove for the trimmed mean to differ
+        # measurably from the plain mean. Mutation `trimmed = ordered`
+        # (dropping the trim entirely) changes this result from 3.2 to
+        # 4.52 -- verified locally by reverting the trim slice and
+        # confirming this test fails, then restoring it.
+        values = [3.0, 3.1, 3.2, 3.3, 10.0]
+        trimmed_subset = [3.1, 3.2, 3.3]
+        expected_mean = statistics.mean(trimmed_subset)
+        expected_ci_legacy = 1.96 * statistics.stdev(trimmed_subset) / math.sqrt(len(trimmed_subset))
+
+        mean, ci_legacy = harness._trimmed_mean_stat(values, trim=1)
+
+        self.assertAlmostEqual(mean, expected_mean, places=10)
+        self.assertAlmostEqual(ci_legacy, expected_ci_legacy, places=10)
+        # The untrimmed mean is far enough away that a trim-removal
+        # mutation cannot accidentally still pass these assertions.
+        self.assertNotAlmostEqual(mean, statistics.mean(values), places=1)
+
+    def test_trimmed_mean_slope_exact_with_asymmetric_outliers(self):
+        profile = _profile(measured_repeats=5, windows=[32, 256], aggregation="trimmed_mean", trim=1)
+        # Both windows carry one high outlier each so the plain mean and
+        # the trimmed mean diverge; the trimmed subset is known exactly, so
+        # the expected slope and legacy CI are computable by hand from it.
+        baseline_steps = [3.0e9, 3.1e9, 3.2e9, 3.3e9, 10.0e9]
+        window_steps = [25.0e9, 25.1e9, 25.2e9, 25.3e9, 40.0e9]
+        clock = _StepClock(baseline_steps + window_steps)
         result = harness.run_profile(
             profile, {"fake": _FakeAdapter()}, clock=clock, git_sha_value="x", hardware_id_value="h"
         )
         slopes = harness.aggregate(result)
         self.assertEqual(len(slopes), 1)
-        self.assertIsNotNone(slopes[0].slope_ci95)
-        self.assertGreater(slopes[0].slope_tok_per_s, 0)
+
+        trimmed_baseline = [3.1, 3.2, 3.3]
+        trimmed_window = [25.1, 25.2, 25.3]
+        expected_baseline_mean = statistics.mean(trimmed_baseline)
+        expected_window_mean = statistics.mean(trimmed_window)
+        expected_baseline_ci = 1.96 * statistics.stdev(trimmed_baseline) / math.sqrt(len(trimmed_baseline))
+        expected_window_ci = 1.96 * statistics.stdev(trimmed_window) / math.sqrt(len(trimmed_window))
+        expected_slope = (256 - 32) / (expected_window_mean - expected_baseline_mean)
+        expected_ci_legacy = expected_slope * math.sqrt(
+            (expected_baseline_ci / expected_baseline_mean) ** 2
+            + (expected_window_ci / expected_window_mean) ** 2
+        )
+
+        self.assertAlmostEqual(slopes[0].slope_tok_per_s, expected_slope, places=6)
+        self.assertIsNotNone(slopes[0].slope_ci95_legacy)
+        self.assertAlmostEqual(slopes[0].slope_ci95_legacy, expected_ci_legacy, places=6)
 
     def test_multi_window_produces_one_slope_per_comparison_window(self):
-        profile = _profile(warmup_repeats=0, measured_repeats=2, windows=[8, 64, 128])
+        profile = _profile(measured_repeats=2, windows=[8, 64, 128])
         result = harness.run_profile(
             profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
         )
@@ -462,7 +756,7 @@ class AggregateTest(unittest.TestCase):
         self.assertTrue(all(s.baseline_window == 8 for s in slopes))
 
     def test_native_throughput_uses_actual_completion_tokens(self):
-        profile = _profile(warmup_repeats=0, measured_repeats=1, windows=[32, 256])
+        profile = _profile(measured_repeats=1, windows=[32, 256])
         result = harness.run_profile(
             profile,
             {"fake": _FakeAdapter(native_ns_per_token=1_000_000)},  # 1000 tok/s native
@@ -475,7 +769,7 @@ class AggregateTest(unittest.TestCase):
         self.assertAlmostEqual(native, 1000.0, places=3)
 
     def test_native_throughput_none_when_unreported(self):
-        profile = _profile(warmup_repeats=0, measured_repeats=1, windows=[32, 256])
+        profile = _profile(measured_repeats=1, windows=[32, 256])
         result = harness.run_profile(
             profile, {"fake": _FakeAdapter(native_ns_per_token=None)}, clock=_FakeClock(),
             git_sha_value="x", hardware_id_value="h",
@@ -508,7 +802,7 @@ class _StepClock:
 
 class RenderReportTest(unittest.TestCase):
     def test_report_mentions_profile_and_missing_engines(self):
-        profile = _profile(engines=["fake", "ghost"])
+        profile = _profile(engines=[_engine("fake"), _engine("ghost")])
         result = harness.run_profile(
             profile,
             {"fake": _FakeAdapter()},
@@ -524,7 +818,7 @@ class RenderReportTest(unittest.TestCase):
         self.assertIn("fake", report)
 
     def test_report_handles_no_measured_data(self):
-        profile = _profile(engines=["ghost"])
+        profile = _profile(engines=[_engine("ghost")])
         result = harness.run_profile(profile, {}, allow_missing_engine=True, clock=_FakeClock())
         report = harness.render_report(result, harness.aggregate(result))
         self.assertIn("no measured data", report)
@@ -563,10 +857,12 @@ schema_version = 1
 
 [profiles.smoke]
 windows = [32, 256]
-warmup_repeats = 0
 measured_repeats = 1
-engines = ["nonexistent-engine"]
 prompt = "hello"
+
+[[profiles.smoke.engines]]
+name = "nonexistent-engine"
+warmup_repeats = 0
 model = "m"
 quantization = "q8"
 """,
@@ -584,10 +880,12 @@ schema_version = 1
 
 [profiles.smoke]
 windows = [32, 256]
-warmup_repeats = 0
 measured_repeats = 1
-engines = ["nonexistent-engine"]
 prompt = "hello"
+
+[[profiles.smoke.engines]]
+name = "nonexistent-engine"
+warmup_repeats = 0
 model = "m"
 quantization = "q8"
 """,

--- a/tests/test_bench_decode_harness.py
+++ b/tests/test_bench_decode_harness.py
@@ -94,11 +94,17 @@ class _FakeAdapter:
         self.native_ns_per_token = native_ns_per_token
         self.component_ns = component_ns
         self.calls: list[tuple[int, bool, str, str]] = []
+        # Index-aligned with `calls`: the EXACT prompt string this call was
+        # invoked with, so tests can assert per-engine measured/warmup
+        # prompt identity (round-4 blocker fix) without changing the
+        # `calls` tuple shape every other test already asserts against.
+        self.prompts: list[str] = []
 
     def run(
         self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
     ) -> "harness.AdapterRunResult":
         self.calls.append((n_tokens, warmup, model, quantization))
+        self.prompts.append(prompt)
         native_ns = self.native_ns_per_token * n_tokens if self.native_ns_per_token else None
         return harness.AdapterRunResult(
             actual_completion_tokens=n_tokens,
@@ -118,6 +124,7 @@ def _engine(
     quantization: str = "q8",
     measured_order: str | None = None,
     measured_calls: list[dict] | None = None,
+    measured_prompt: str | None = None,
 ) -> dict:
     d = {"name": name, "warmup_repeats": warmup_repeats, "model": model, "quantization": quantization}
     if warmup_tokens is not None:
@@ -128,6 +135,8 @@ def _engine(
         d["measured_order"] = measured_order
     if measured_calls is not None:
         d["measured_calls"] = measured_calls
+    if measured_prompt is not None:
+        d["measured_prompt"] = measured_prompt
     return d
 
 
@@ -401,7 +410,8 @@ class ProfileConfigTest(unittest.TestCase):
 
     def test_measured_calls_parsed_into_tuple_of_measured_call(self):
         profile = _profile(
-            engines=[_engine(measured_calls=[{"n_tokens": 100, "yields_windows": [1, 100]}])]
+            windows=[1, 100],
+            engines=[_engine(measured_calls=[{"n_tokens": 100, "yields_windows": [1, 100]}])],
         )
         calls = profile.engine_groups[0].measured_calls
         self.assertEqual(calls, (harness.MeasuredCall(n_tokens=100, yields_windows=(1, 100)),))
@@ -464,6 +474,7 @@ class ProfileConfigTest(unittest.TestCase):
 
     def test_measured_calls_multiple_entries_parsed_in_order(self):
         profile = _profile(
+            windows=[1, 100],
             engines=[
                 _engine(
                     measured_order="repeat_major",
@@ -472,7 +483,7 @@ class ProfileConfigTest(unittest.TestCase):
                         {"n_tokens": 100, "yields_windows": [100]},
                     ],
                 )
-            ]
+            ],
         )
         calls = profile.engine_groups[0].measured_calls
         self.assertEqual(
@@ -482,6 +493,107 @@ class ProfileConfigTest(unittest.TestCase):
                 harness.MeasuredCall(n_tokens=100, yields_windows=(100,)),
             ),
         )
+
+    # -- Round-4 major fix: an explicit measured_calls plan must cover
+    # profile.windows exactly once each -- a missing window silently
+    # erases a slope, an undeclared window produces an observation
+    # outside the report contract, and a cross-call duplicate silently
+    # doubles a window's sample count. --
+
+    def test_measured_calls_missing_declared_window_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, r"missing window\(s\) \[256\]"):
+            _profile(
+                windows=[32, 256],
+                engines=[_engine(measured_calls=[{"n_tokens": 32, "yields_windows": [32]}])],
+            )
+
+    def test_measured_calls_undeclared_window_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, r"undeclared window\(s\) \[999\]"):
+            _profile(
+                windows=[32, 256],
+                engines=[
+                    _engine(
+                        measured_calls=[
+                            {"n_tokens": 32, "yields_windows": [32]},
+                            {"n_tokens": 256, "yields_windows": [256, 999]},
+                        ]
+                    )
+                ],
+            )
+
+    def test_measured_calls_cross_call_duplicate_window_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, r"duplicate window\(s\) \[32\]"):
+            _profile(
+                windows=[32, 256],
+                engines=[
+                    _engine(
+                        measured_calls=[
+                            {"n_tokens": 32, "yields_windows": [32]},
+                            {"n_tokens": 33, "yields_windows": [32, 256]},
+                        ]
+                    )
+                ],
+            )
+
+    def test_measured_calls_exact_coverage_accepted(self):
+        # Sanity: a plan that DOES cover every window exactly once,
+        # regardless of physical call order, is accepted.
+        profile = _profile(
+            windows=[32, 256],
+            engines=[
+                _engine(
+                    measured_calls=[
+                        {"n_tokens": 256, "yields_windows": [256]},
+                        {"n_tokens": 32, "yields_windows": [32]},
+                    ]
+                )
+            ],
+        )
+        self.assertEqual(len(profile.engine_groups[0].measured_calls), 2)
+
+    # -- Round-4 blocker fix: measured_prompt, mirroring warmup_prompt,
+    # overrides profile.prompt for one engine's measured calls only. --
+
+    def test_measured_prompt_defaults_to_none(self):
+        profile = _profile(engines=[_engine()])
+        self.assertIsNone(profile.engine_groups[0].measured_prompt)
+
+    def test_measured_prompt_override_parsed(self):
+        profile = _profile(engines=[_engine(measured_prompt="a distinct measured prompt")])
+        self.assertEqual(profile.engine_groups[0].measured_prompt, "a distinct measured prompt")
+
+    def test_measured_prompt_empty_string_rejected(self):
+        raw_engine = {
+            "name": "fake",
+            "warmup_repeats": 0,
+            "model": "m",
+            "quantization": "q8",
+            "measured_prompt": "",
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, "measured_prompt"):
+            _profile(engines=[raw_engine])
+
+    def test_measured_prompt_wrong_type_rejected(self):
+        raw_engine = {
+            "name": "fake",
+            "warmup_repeats": 0,
+            "model": "m",
+            "quantization": "q8",
+            "measured_prompt": 123,
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, "measured_prompt"):
+            _profile(engines=[raw_engine])
+
+    def test_misspelled_measured_prompt_key_rejected(self):
+        raw_engine = {
+            "name": "fake",
+            "warmup_repeats": 0,
+            "model": "m",
+            "quantization": "q8",
+            "measured_prmopt": "typo",
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, r"unexpected key.*measured_prmopt"):
+            _profile(engines=[raw_engine])
 
     def test_unexpected_engine_key_rejected(self):
         bad_engine = {"name": "fake", "warmup_repeats": 0, "model": "m", "quantization": "q8", "warmups": 1}
@@ -1136,21 +1248,36 @@ class RunProfileTest(unittest.TestCase):
             )
 
     def test_agentic_style_global_flattened_sequence_lattice_ollama_mlx(self):
-        """The round-3 blocker fix, end to end: reproduce
+        """The round-3 + round-4 blocker fixes, end to end: reproduce
         `bench_compare_1k.py`'s complete Lattice -> Ollama -> MLX stream in
-        one profile. Lattice is window-major (all 1-token then all
-        100-token calls, the default shape). Ollama warms once at 4
-        tokens with its own 'hi' prompt, then issues ONE 100-token call
-        per repeat yielding both a window=1 (TTFT) and window=100 (total)
-        observation via component_ns. MLX warms once at 4 tokens with its
-        own 'BASE' prompt, then alternates (1, 100) every repeat
-        (repeat-major)."""
+        one profile, including per-engine MEASURED prompts (round-4's
+        remaining gap). Lattice is window-major (all 1-token then all
+        100-token calls, the default shape) using the shared
+        tokenizer-padded `profile.prompt`. Ollama warms once at 4 tokens
+        with its own 'hi' prompt, then issues ONE 100-token call per
+        repeat yielding both a window=1 (TTFT) and window=100 (total)
+        observation via component_ns -- using its OWN character-count-
+        heuristic `measured_prompt`, distinct from Lattice/MLX's
+        tokenizer-padded prompt (bench_compare_1k.py's actual two-method
+        prompt-building split). MLX warms once at 4 tokens with its own
+        'BASE' prompt, then alternates (1, 100) every repeat (repeat-major)
+        using the shared tokenizer-padded `profile.prompt` (no override).
+
+        This test asserts, for every physical call/row: engine, exact
+        prompt string AND its hash, token budget, warmup flag, yielded
+        window(s), run index, model, and quantization -- it must fail if
+        Ollama ever receives the Lattice/MLX prompt, if a warmup call ever
+        receives the measured prompt, or if any recorded `prompt_hash`
+        differs from the exact string the adapter was invoked with.
+        """
+        TOKENIZER_PADDED_PROMPT = "the tokenizer-padded ctx prompt"
+        OLLAMA_CHAR_HEURISTIC_PROMPT = "the char-heuristic padded ctx prompt"
         profile = harness._parse_profile(
             "agentic",
             {
                 "windows": [1, 100],
                 "measured_repeats": 2,
-                "prompt": "the padded ctx prompt",
+                "prompt": TOKENIZER_PADDED_PROMPT,
                 "engines": [
                     _engine("lattice", model="qwen3.5-0.8b", quantization="q8"),
                     _engine(
@@ -1161,6 +1288,7 @@ class RunProfileTest(unittest.TestCase):
                         model="qwen3.5:0.8b",
                         quantization="q8",
                         measured_calls=[{"n_tokens": 100, "yields_windows": [1, 100]}],
+                        measured_prompt=OLLAMA_CHAR_HEURISTIC_PROMPT,
                     ),
                     _engine(
                         "mlx",
@@ -1178,6 +1306,13 @@ class RunProfileTest(unittest.TestCase):
                 ],
             },
         )
+        # Sanity on the profile itself: Ollama's measured_prompt is an
+        # override distinct from profile.prompt; MLX/Lattice have none.
+        engines_by_name = {g.name: g for g in profile.engine_groups}
+        self.assertEqual(engines_by_name["ollama"].measured_prompt, OLLAMA_CHAR_HEURISTIC_PROMPT)
+        self.assertIsNone(engines_by_name["lattice"].measured_prompt)
+        self.assertIsNone(engines_by_name["mlx"].measured_prompt)
+
         lattice = _FakeAdapter()
         ollama = _FakeAdapter(component_ns={1: 40_000_000, 100: 400_000_000})
         mlx = _FakeAdapter()
@@ -1189,7 +1324,8 @@ class RunProfileTest(unittest.TestCase):
             hardware_id_value="h",
         )
 
-        # Lattice: no warmup, all 1-token calls then all 100-token calls.
+        # Lattice: no warmup, all 1-token calls then all 100-token calls,
+        # every call using the shared tokenizer-padded prompt.
         self.assertEqual(
             lattice.calls,
             [
@@ -1199,8 +1335,12 @@ class RunProfileTest(unittest.TestCase):
                 (100, False, "qwen3.5-0.8b", "q8"),
             ],
         )
+        self.assertEqual(lattice.prompts, [TOKENIZER_PADDED_PROMPT] * 4)
+
         # Ollama: one 4-token 'hi' warmup, then exactly TWO physical
-        # 100-token calls (one per repeat) -- never four.
+        # 100-token calls (one per repeat) -- never four -- every measured
+        # call using Ollama's OWN char-heuristic prompt, NEVER the
+        # Lattice/MLX tokenizer-padded prompt.
         self.assertEqual(
             ollama.calls,
             [
@@ -1209,7 +1349,11 @@ class RunProfileTest(unittest.TestCase):
                 (100, False, "qwen3.5:0.8b", "q8"),
             ],
         )
-        # MLX: one 4-token 'BASE' warmup, then (1, 100) alternating per repeat.
+        self.assertEqual(ollama.prompts, ["hi", OLLAMA_CHAR_HEURISTIC_PROMPT, OLLAMA_CHAR_HEURISTIC_PROMPT])
+
+        # MLX: one 4-token 'BASE' warmup, then (1, 100) alternating per
+        # repeat, every measured call using the shared tokenizer-padded
+        # prompt (no measured_prompt override).
         self.assertEqual(
             mlx.calls,
             [
@@ -1220,6 +1364,7 @@ class RunProfileTest(unittest.TestCase):
                 (100, False, "qwen3.5-0.8b", "q8"),
             ],
         )
+        self.assertEqual(mlx.prompts, ["BASE"] + [TOKENIZER_PADDED_PROMPT] * 4)
 
         # Global observation stream: all of lattice's rows (4, no warmup),
         # then all of ollama's (1 warmup + 4 measured -- two calls, two
@@ -1228,16 +1373,55 @@ class RunProfileTest(unittest.TestCase):
             [o.engine for o in result.observations],
             ["lattice"] * 4 + ["ollama"] * 5 + ["mlx"] * 5,
         )
-        # Ollama's measured rows: window=1 (TTFT-equivalent, from
-        # component_ns) immediately followed by window=100 (total), twice.
-        ollama_measured = [o for o in result.observations if o.engine == "ollama" and not o.warmup]
-        self.assertEqual([o.requested_completion_tokens for o in ollama_measured], [1, 100, 1, 100])
-        self.assertEqual(
-            [o.elapsed_ns for o in ollama_measured], [40_000_000, 400_000_000, 40_000_000, 400_000_000]
+
+        # Every raw observation's prompt_hash is EXACTLY hash(the string
+        # that engine's adapter was actually invoked with) -- the harness
+        # never hashes a placeholder or a different engine's prompt.
+        lattice_obs = [o for o in result.observations if o.engine == "lattice"]
+        self.assertTrue(all(o.prompt_hash == harness.prompt_hash(TOKENIZER_PADDED_PROMPT) for o in lattice_obs))
+
+        ollama_obs = [o for o in result.observations if o.engine == "ollama"]
+        ollama_warmup_obs = [o for o in ollama_obs if o.warmup]
+        ollama_measured_obs = [o for o in ollama_obs if not o.warmup]
+        self.assertTrue(all(o.prompt_hash == harness.prompt_hash("hi") for o in ollama_warmup_obs))
+        self.assertTrue(
+            all(o.prompt_hash == harness.prompt_hash(OLLAMA_CHAR_HEURISTIC_PROMPT) for o in ollama_measured_obs)
         )
+        # Ollama's warmup and measured prompts are provably distinct
+        # strings, so their hashes must differ too (a warmup row must
+        # never carry the measured prompt's hash, or vice versa).
+        self.assertNotEqual(ollama_warmup_obs[0].prompt_hash, ollama_measured_obs[0].prompt_hash)
+        # Ollama's measured prompt hash must differ from Lattice/MLX's
+        # shared tokenizer-padded prompt hash (the exact defect round 4
+        # found: every engine's measured_prompt collapsing to one string).
+        self.assertNotEqual(
+            ollama_measured_obs[0].prompt_hash, harness.prompt_hash(TOKENIZER_PADDED_PROMPT)
+        )
+
+        mlx_obs = [o for o in result.observations if o.engine == "mlx"]
+        mlx_warmup_obs = [o for o in mlx_obs if o.warmup]
+        mlx_measured_obs = [o for o in mlx_obs if not o.warmup]
+        self.assertTrue(all(o.prompt_hash == harness.prompt_hash("BASE") for o in mlx_warmup_obs))
+        self.assertTrue(
+            all(o.prompt_hash == harness.prompt_hash(TOKENIZER_PADDED_PROMPT) for o in mlx_measured_obs)
+        )
+        self.assertNotEqual(mlx_warmup_obs[0].prompt_hash, mlx_measured_obs[0].prompt_hash)
+
+        # Ollama's measured rows: window=1 (TTFT-equivalent, from
+        # component_ns) immediately followed by window=100 (total), twice
+        # -- both derived from the SAME physical call, so they share the
+        # SAME prompt_hash (one call, one prompt, two derived readings).
+        self.assertEqual([o.requested_completion_tokens for o in ollama_measured_obs], [1, 100, 1, 100])
+        self.assertEqual(
+            [o.elapsed_ns for o in ollama_measured_obs], [40_000_000, 400_000_000, 40_000_000, 400_000_000]
+        )
+        self.assertEqual(len({o.prompt_hash for o in ollama_measured_obs}), 1)
         # MLX's measured rows alternate (1, 100) per repeat -- repeat-major.
-        mlx_measured = [o for o in result.observations if o.engine == "mlx" and not o.warmup]
-        self.assertEqual([o.requested_completion_tokens for o in mlx_measured], [1, 100, 1, 100])
+        self.assertEqual([o.requested_completion_tokens for o in mlx_measured_obs], [1, 100, 1, 100])
+
+        # run_index: Lattice/MLX reset per their own schedule; Ollama's two
+        # derived rows per physical call share that call's run_index.
+        self.assertEqual([o.run_index for o in ollama_measured_obs], [1, 1, 2, 2])
 
     def test_precise_style_global_flattened_sequence_all_three_engines(self):
         """`bench_apples_precise.sh` reproduced with its actual three

--- a/tests/test_bench_decode_harness.py
+++ b/tests/test_bench_decode_harness.py
@@ -1,0 +1,603 @@
+"""Unit tests for scripts/bench_decode_harness.py (issue #813).
+
+Deterministic fake-adapter tests and raw-schema validation only -- no engine
+binary is required to run this file, matching the harness-core landing gate.
+
+Run with: python3 -m unittest tests/test_bench_decode_harness.py -v
+(or `python3 -m pytest tests/test_bench_decode_harness.py -v` -- no
+pytest-only features are used).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "bench_decode_harness.py"
+_SPEC = importlib.util.spec_from_file_location("bench_decode_harness", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+harness = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = harness
+_SPEC.loader.exec_module(harness)
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+
+def _valid_observation(**overrides) -> dict:
+    row = {
+        "schema_version": harness.SCHEMA_VERSION,
+        "git_sha": "deadbeefcafebabe",
+        "profile": "unit_test",
+        "engine": "fake",
+        "engine_version": "1.0.0",
+        "model": "qwen3.5-0.8b",
+        "quantization": "q8",
+        "prompt_hash": "abc123",
+        "requested_prompt_tokens": 12,
+        "actual_prompt_tokens": 12,
+        "requested_completion_tokens": 32,
+        "actual_completion_tokens": 32,
+        "warmup": False,
+        "run_index": 1,
+        "order_index": 0,
+        "elapsed_ns": 1_000_000,
+        "engine_native_ns": 900_000,
+        "hardware_id": "Darwin-arm64-testhost",
+        "timestamp": "2026-07-10T00:00:00+00:00",
+    }
+    row.update(overrides)
+    return row
+
+
+@dataclass
+class _FakeClock:
+    """Deterministic monotonic clock: each call returns start + step*calls."""
+
+    step_ns: int = 1_000_000
+    start_ns: int = 0
+    _calls: int = 0
+
+    def __call__(self) -> int:
+        value = self.start_ns + self.step_ns * self._calls
+        self._calls += 1
+        return value
+
+
+class _FakeAdapter:
+    """Deterministic fake engine adapter: fixed tok/s, exact requested token counts."""
+
+    def __init__(self, engine_version: str = "fake-1.0", native_ns_per_token: int | None = None):
+        self.engine_version = engine_version
+        self.native_ns_per_token = native_ns_per_token
+        self.calls: list[tuple[int, bool]] = []
+
+    def run(self, *, prompt: str, n_tokens: int, warmup: bool) -> "harness.AdapterRunResult":
+        self.calls.append((n_tokens, warmup))
+        native_ns = self.native_ns_per_token * n_tokens if self.native_ns_per_token else None
+        return harness.AdapterRunResult(
+            actual_completion_tokens=n_tokens,
+            actual_prompt_tokens=len(prompt.split()),
+            native_ns=native_ns,
+            engine_version=self.engine_version,
+        )
+
+
+def _profile(**overrides) -> "harness.ProfileConfig":
+    raw = {
+        "description": "unit test profile",
+        "windows": [32, 256],
+        "warmup_repeats": 0,
+        "measured_repeats": 3,
+        "engines": ["fake"],
+        "prompt": "the quick brown fox",
+        "model": "qwen3.5-0.8b",
+        "quantization": "q8",
+    }
+    raw.update(overrides)
+    return harness._parse_profile("unit_test", raw)
+
+
+# --------------------------------------------------------------------------
+# Schema validation
+# --------------------------------------------------------------------------
+
+
+class ValidateObservationTest(unittest.TestCase):
+    def test_valid_observation_passes(self):
+        harness.validate_observation(_valid_observation())  # must not raise
+
+    def test_nullable_fields_accept_none(self):
+        harness.validate_observation(
+            _valid_observation(
+                requested_prompt_tokens=None, actual_prompt_tokens=None, engine_native_ns=None
+            )
+        )
+
+    def test_missing_field_rejected(self):
+        row = _valid_observation()
+        del row["engine"]
+        with self.assertRaisesRegex(harness.ObservationValidationError, "missing required field"):
+            harness.validate_observation(row)
+
+    def test_unexpected_field_rejected(self):
+        row = _valid_observation(extra_field="nope")
+        with self.assertRaisesRegex(harness.ObservationValidationError, "unexpected field"):
+            harness.validate_observation(row)
+
+    def test_wrong_schema_version_rejected(self):
+        row = _valid_observation(schema_version=999)
+        with self.assertRaisesRegex(harness.ObservationValidationError, "schema_version"):
+            harness.validate_observation(row)
+
+    def test_bool_rejected_where_int_expected(self):
+        row = _valid_observation(run_index=True)
+        with self.assertRaisesRegex(harness.ObservationValidationError, "run_index"):
+            harness.validate_observation(row)
+
+    def test_int_rejected_where_bool_expected(self):
+        row = _valid_observation(warmup=1)
+        with self.assertRaisesRegex(harness.ObservationValidationError, "warmup"):
+            harness.validate_observation(row)
+
+    def test_negative_elapsed_ns_rejected(self):
+        row = _valid_observation(elapsed_ns=-1)
+        with self.assertRaisesRegex(harness.ObservationValidationError, "elapsed_ns"):
+            harness.validate_observation(row)
+
+    def test_run_index_must_be_at_least_one(self):
+        row = _valid_observation(run_index=0)
+        with self.assertRaisesRegex(harness.ObservationValidationError, "run_index"):
+            harness.validate_observation(row)
+
+    def test_empty_string_field_rejected(self):
+        row = _valid_observation(engine="")
+        with self.assertRaisesRegex(harness.ObservationValidationError, "engine"):
+            harness.validate_observation(row)
+
+    def test_non_iso_timestamp_rejected(self):
+        row = _valid_observation(timestamp="not-a-timestamp")
+        with self.assertRaisesRegex(harness.ObservationValidationError, "timestamp"):
+            harness.validate_observation(row)
+
+    def test_zulu_timestamp_accepted(self):
+        harness.validate_observation(_valid_observation(timestamp="2026-07-10T00:00:00Z"))
+
+
+class ValidateJsonlTest(unittest.TestCase):
+    def test_valid_file_round_trips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "obs.jsonl"
+            rows = [_valid_observation(run_index=i + 1) for i in range(3)]
+            path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+            parsed = harness.validate_jsonl(path)
+            self.assertEqual(len(parsed), 3)
+
+    def test_blank_lines_are_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "obs.jsonl"
+            path.write_text(f"\n{json.dumps(_valid_observation())}\n\n", encoding="utf-8")
+            parsed = harness.validate_jsonl(path)
+            self.assertEqual(len(parsed), 1)
+
+    def test_malformed_json_reports_line_number(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "obs.jsonl"
+            path.write_text(f"{json.dumps(_valid_observation())}\nnot json\n", encoding="utf-8")
+            with self.assertRaisesRegex(harness.ObservationValidationError, ":2:"):
+                harness.validate_jsonl(path)
+
+    def test_invalid_row_reports_line_number(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "obs.jsonl"
+            bad = _valid_observation()
+            del bad["engine"]
+            path.write_text(f"{json.dumps(_valid_observation())}\n{json.dumps(bad)}\n", encoding="utf-8")
+            with self.assertRaisesRegex(harness.ObservationValidationError, ":2:"):
+                harness.validate_jsonl(path)
+
+
+# --------------------------------------------------------------------------
+# Profile configuration validation
+# --------------------------------------------------------------------------
+
+
+class ProfileConfigTest(unittest.TestCase):
+    def test_valid_profile_parses(self):
+        profile = _profile()
+        self.assertEqual(profile.windows, (32, 256))
+        self.assertEqual(profile.aggregation, "median")
+
+    def test_single_window_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "at least 2"):
+            _profile(windows=[32])
+
+    def test_non_increasing_windows_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "strictly increasing"):
+            _profile(windows=[256, 32])
+
+    def test_duplicate_windows_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "strictly increasing"):
+            _profile(windows=[32, 32])
+
+    def test_negative_warmup_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "warmup_repeats"):
+            _profile(warmup_repeats=-1)
+
+    def test_zero_measured_repeats_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "measured_repeats"):
+            _profile(measured_repeats=0)
+
+    def test_empty_engines_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "engines"):
+            _profile(engines=[])
+
+    def test_duplicate_engines_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "duplicates"):
+            _profile(engines=["fake", "fake"])
+
+    def test_unknown_aggregation_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "aggregation"):
+            _profile(aggregation="fastest")
+
+    def test_trim_with_median_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "trim"):
+            _profile(aggregation="median", trim=1)
+
+    def test_trim_too_large_for_repeats_rejected(self):
+        with self.assertRaisesRegex(harness.ProfileConfigError, "trim"):
+            _profile(aggregation="trimmed_mean", trim=2, measured_repeats=3)
+
+    def test_missing_required_key_rejected(self):
+        raw = {
+            "windows": [32, 256],
+            "warmup_repeats": 0,
+            "measured_repeats": 3,
+            "engines": ["fake"],
+            "prompt": "x",
+            "model": "m",
+            # quantization omitted
+        }
+        with self.assertRaisesRegex(harness.ProfileConfigError, "quantization"):
+            harness._parse_profile("bad", raw)
+
+
+class LoadProfilesFileTest(unittest.TestCase):
+    def test_scaffold_file_loads_with_no_profiles(self):
+        schema_version, profiles = harness.load_profiles_file(harness.DEFAULT_PROFILES_FILE)
+        self.assertEqual(schema_version, harness.SCHEMA_VERSION)
+        self.assertEqual(profiles, {})
+
+    def test_wrong_schema_version_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "profiles.toml"
+            path.write_text("schema_version = 999\n", encoding="utf-8")
+            with self.assertRaisesRegex(harness.ProfileConfigError, "schema_version"):
+                harness.load_profiles_file(path)
+
+    def test_named_profile_round_trips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "profiles.toml"
+            path.write_text(
+                """
+schema_version = 1
+
+[profiles.smoke]
+windows = [32, 256]
+warmup_repeats = 1
+measured_repeats = 5
+engines = ["fake"]
+prompt = "hello world"
+model = "qwen3.5-0.8b"
+quantization = "q8"
+""",
+                encoding="utf-8",
+            )
+            _, profiles = harness.load_profiles_file(path)
+            self.assertIn("smoke", profiles)
+            self.assertEqual(profiles["smoke"].windows, (32, 256))
+            self.assertEqual(profiles["smoke"].warmup_repeats, 1)
+
+
+# --------------------------------------------------------------------------
+# run_profile (fake-adapter, deterministic)
+# --------------------------------------------------------------------------
+
+
+class RunProfileTest(unittest.TestCase):
+    def test_produces_expected_observation_count(self):
+        profile = _profile(warmup_repeats=2, measured_repeats=3, windows=[32, 256])
+        adapter = _FakeAdapter()
+        result = harness.run_profile(
+            profile,
+            {"fake": adapter},
+            clock=_FakeClock(),
+            git_sha_value="deadbeef",
+            hardware_id_value="test-host",
+        )
+        # 1 engine * 2 windows * (2 warmup + 3 measured) = 10
+        self.assertEqual(len(result.observations), 10)
+        self.assertEqual(result.missing_engines, ())
+
+    def test_warmup_flag_and_run_index_reset_per_group(self):
+        profile = _profile(warmup_repeats=2, measured_repeats=3, windows=[32, 256])
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        window_32 = [o for o in result.observations if o.requested_completion_tokens == 32]
+        warmups = [o for o in window_32 if o.warmup]
+        measured = [o for o in window_32 if not o.warmup]
+        self.assertEqual([o.run_index for o in warmups], [1, 2])
+        self.assertEqual([o.run_index for o in measured], [1, 2, 3])
+
+    def test_order_index_strictly_increasing(self):
+        profile = _profile(warmup_repeats=1, measured_repeats=2, windows=[32, 128, 256])
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        order_indices = [o.order_index for o in result.observations]
+        self.assertEqual(order_indices, list(range(len(order_indices))))
+
+    def test_baseline_window_executed_once_not_per_comparison(self):
+        # Mirrors bench_context_scaling.sh's shape: N1 is a shared baseline
+        # run once, not re-executed for every comparison window.
+        profile = _profile(warmup_repeats=0, measured_repeats=4, windows=[8, 64, 128, 256])
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        baseline_runs = [o for o in result.observations if o.requested_completion_tokens == 8]
+        self.assertEqual(len(baseline_runs), 4)
+
+    def test_actual_and_requested_token_counts_recorded_independently(self):
+        class _DriftingAdapter:
+            engine_version = "drift-1.0"
+
+            def run(self, *, prompt, n_tokens, warmup):
+                return harness.AdapterRunResult(
+                    actual_completion_tokens=n_tokens - 1,  # engine stopped one token early
+                    actual_prompt_tokens=7,
+                    engine_version=self.engine_version,
+                )
+
+        profile = _profile(warmup_repeats=0, measured_repeats=1, windows=[32, 256])
+        result = harness.run_profile(
+            profile, {"fake": _DriftingAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        for obs in result.observations:
+            self.assertEqual(obs.actual_completion_tokens, obs.requested_completion_tokens - 1)
+            self.assertEqual(obs.actual_prompt_tokens, 7)
+
+    def test_every_observation_is_schema_valid(self):
+        profile = _profile(warmup_repeats=1, measured_repeats=2, windows=[32, 256])
+        result = harness.run_profile(
+            profile,
+            {"fake": _FakeAdapter(native_ns_per_token=30_000)},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        for obs in result.observations:
+            harness.validate_observation(obs.to_dict())  # must not raise
+
+    def test_missing_engine_fails_closed_by_default(self):
+        profile = _profile(engines=["fake", "ghost"])
+        with self.assertRaises(harness.MissingEngineError):
+            harness.run_profile(profile, {"fake": _FakeAdapter()}, clock=_FakeClock())
+
+    def test_missing_engine_allowed_with_flag(self):
+        profile = _profile(engines=["fake", "ghost"])
+        result = harness.run_profile(
+            profile,
+            {"fake": _FakeAdapter()},
+            allow_missing_engine=True,
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        self.assertEqual(result.missing_engines, ("ghost",))
+        self.assertTrue(all(o.engine == "fake" for o in result.observations))
+
+    def test_missing_engine_never_fabricates_observations(self):
+        profile = _profile(engines=["ghost"])
+        result = harness.run_profile(
+            profile, {}, allow_missing_engine=True, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        self.assertEqual(result.observations, ())
+        self.assertEqual(result.missing_engines, ("ghost",))
+
+
+# --------------------------------------------------------------------------
+# Aggregation
+# --------------------------------------------------------------------------
+
+
+class AggregateTest(unittest.TestCase):
+    def test_median_slope_matches_hand_computed_value(self):
+        # Fixed 1ms-per-call harness clock overhead is negligible next to the
+        # adapter's own synthetic timing, so drive elapsed_ns directly via a
+        # clock that advances by a known amount per adapter call.
+        profile = _profile(warmup_repeats=0, measured_repeats=3, windows=[32, 256], aggregation="median")
+        # 10 tok/s target: dt = (256-32)/10 = 22.4s. Each window's 3 measured
+        # runs get identical elapsed_ns so the median is exact.
+        # window 32: elapsed = 3.2s/call (32 tok @ 10 tok/s)
+        # window 256: elapsed = 25.6s/call (256 tok @ 10 tok/s)
+        steps = [3.2e9] * 3 + [25.6e9] * 3
+        clock = _StepClock(steps)
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter()}, clock=clock, git_sha_value="x", hardware_id_value="h"
+        )
+        slopes = harness.aggregate(result)
+        self.assertEqual(len(slopes), 1)
+        self.assertAlmostEqual(slopes[0].slope_tok_per_s, 10.0, places=6)
+        self.assertIsNone(slopes[0].slope_ci95)
+
+    def test_trimmed_mean_slope_has_ci(self):
+        profile = _profile(
+            warmup_repeats=0, measured_repeats=5, windows=[32, 256], aggregation="trimmed_mean", trim=1
+        )
+        steps = [3.0e9, 3.2e9, 3.2e9, 3.2e9, 3.4e9, 25.0e9, 25.6e9, 25.6e9, 25.6e9, 26.0e9]
+        clock = _StepClock(steps)
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter()}, clock=clock, git_sha_value="x", hardware_id_value="h"
+        )
+        slopes = harness.aggregate(result)
+        self.assertEqual(len(slopes), 1)
+        self.assertIsNotNone(slopes[0].slope_ci95)
+        self.assertGreater(slopes[0].slope_tok_per_s, 0)
+
+    def test_multi_window_produces_one_slope_per_comparison_window(self):
+        profile = _profile(warmup_repeats=0, measured_repeats=2, windows=[8, 64, 128])
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter()}, clock=_FakeClock(), git_sha_value="x", hardware_id_value="h"
+        )
+        slopes = harness.aggregate(result)
+        self.assertEqual({s.window for s in slopes}, {64, 128})
+        self.assertTrue(all(s.baseline_window == 8 for s in slopes))
+
+    def test_native_throughput_uses_actual_completion_tokens(self):
+        profile = _profile(warmup_repeats=0, measured_repeats=1, windows=[32, 256])
+        result = harness.run_profile(
+            profile,
+            {"fake": _FakeAdapter(native_ns_per_token=1_000_000)},  # 1000 tok/s native
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        native = harness.native_throughput(result, "fake")
+        self.assertIsNotNone(native)
+        self.assertAlmostEqual(native, 1000.0, places=3)
+
+    def test_native_throughput_none_when_unreported(self):
+        profile = _profile(warmup_repeats=0, measured_repeats=1, windows=[32, 256])
+        result = harness.run_profile(
+            profile, {"fake": _FakeAdapter(native_ns_per_token=None)}, clock=_FakeClock(),
+            git_sha_value="x", hardware_id_value="h",
+        )
+        self.assertIsNone(harness.native_throughput(result, "fake"))
+
+
+@dataclass
+class _StepClock:
+    """Deterministic clock driven by an explicit list of per-call durations (ns)."""
+
+    durations_ns: list[float]
+    _t: float = 0.0
+    _idx: int = 0
+
+    def __call__(self) -> int:
+        # First call in a pair returns current t, second call advances by the
+        # next scheduled duration then returns the new t.
+        if self._idx % 2 == 1:
+            self._t += self.durations_ns[self._idx // 2]
+        value = int(self._t)
+        self._idx += 1
+        return value
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+
+class RenderReportTest(unittest.TestCase):
+    def test_report_mentions_profile_and_missing_engines(self):
+        profile = _profile(engines=["fake", "ghost"])
+        result = harness.run_profile(
+            profile,
+            {"fake": _FakeAdapter()},
+            allow_missing_engine=True,
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        slopes = harness.aggregate(result)
+        report = harness.render_report(result, slopes)
+        self.assertIn("unit_test", report)
+        self.assertIn("ghost", report)
+        self.assertIn("fake", report)
+
+    def test_report_handles_no_measured_data(self):
+        profile = _profile(engines=["ghost"])
+        result = harness.run_profile(profile, {}, allow_missing_engine=True, clock=_FakeClock())
+        report = harness.render_report(result, harness.aggregate(result))
+        self.assertIn("no measured data", report)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+class CliTest(unittest.TestCase):
+    def test_validate_subcommand_reports_ok(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "obs.jsonl"
+            path.write_text(json.dumps(_valid_observation()) + "\n", encoding="utf-8")
+            rc = harness.main(["validate", str(path)])
+            self.assertEqual(rc, 0)
+
+    def test_validate_subcommand_fails_closed_on_bad_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "obs.jsonl"
+            path.write_text("not json\n", encoding="utf-8")
+            rc = harness.main(["validate", str(path)])
+            self.assertEqual(rc, 1)
+
+    def test_run_subcommand_unknown_profile_fails_closed(self):
+        rc = harness.main(["run", "--profile", "does-not-exist"])
+        self.assertEqual(rc, 1)
+
+    def test_run_subcommand_missing_engine_fails_closed_without_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "profiles.toml"
+            path.write_text(
+                """
+schema_version = 1
+
+[profiles.smoke]
+windows = [32, 256]
+warmup_repeats = 0
+measured_repeats = 1
+engines = ["nonexistent-engine"]
+prompt = "hello"
+model = "m"
+quantization = "q8"
+""",
+                encoding="utf-8",
+            )
+            rc = harness.main(["run", "--profile", "smoke", "--profiles-file", str(path)])
+            self.assertEqual(rc, 1)
+
+    def test_run_subcommand_missing_engine_allowed_exits_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "profiles.toml"
+            path.write_text(
+                """
+schema_version = 1
+
+[profiles.smoke]
+windows = [32, 256]
+warmup_repeats = 0
+measured_repeats = 1
+engines = ["nonexistent-engine"]
+prompt = "hello"
+model = "m"
+quantization = "q8"
+""",
+                encoding="utf-8",
+            )
+            rc = harness.main(
+                ["run", "--profile", "smoke", "--profiles-file", str(path), "--allow-missing-engine"]
+            )
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes step 1 of #813 ("Harness core, no public command change").

## What

- `scripts/bench_decode_harness.py` — stdlib-only decode-benchmark harness
  core. Owns configuration validation, requested schedule/run order,
  monotonic wall timing, the raw JSONL observation schema, aggregation
  (median and trimmed-mean+legacy-CI), and report rendering. A profile's
  `engines` list is an ordered set of per-engine run groups (`name`,
  `warmup_repeats`, `warmup_tokens`, `warmup_prompt`, `model`,
  `quantization`, `measured_calls`, `measured_order`, `measured_prompt`),
  not a flat name list, because the five legacy scripts each give
  individual engines their own warmup schedule, their own MEASURED call
  shape, their own MEASURED prompt, and, for the Q4/Q8 comparison, their
  own quantization within one profile.

  Warmup is an explicit pre-window batch: when `warmup_repeats > 0`, the
  group's full warmup batch runs once, entirely before that group's
  measured calls, at its own `warmup_tokens` completion-token budget and
  an optional `warmup_prompt` (defaults to `profile.prompt` when absent).

  The MEASURED schedule is an explicit per-engine call plan:
  `measured_calls` is an ordered tuple of `(n_tokens, yields_windows)`
  calls; when omitted, the harness derives the default (one call per
  `profile.windows` entry, `yields_windows=(window,)`), which reproduces
  every uniform-window script unchanged. `measured_order`
  (`"window_major"`, the default, or `"repeat_major"`) controls whether
  the call plan replays as "all repeats of call[0], then call[1], ..." or
  "one full pass through the plan per repeat". A call with
  `len(yields_windows) > 1` (one physical call producing observations for
  more than one window) requires the adapter's `AdapterRunResult.
  component_ns` to map every yielded window to its own elapsed
  nanoseconds — the harness never re-invokes the engine to synthesize a
  second measurement and never fabricates one from the call's own
  wall-clock span for more than the primary window; a missing or
  incomplete `component_ns` raises `AdapterContractError`, fail-closed.
  An explicit `measured_calls` plan's flattened `yields_windows` must
  cover `profile.windows` exactly once each (order not enforced — call
  order governs replay/interleaving, not window existence); a missing,
  undeclared, or cross-call-duplicate window is rejected at parse time
  with a `ProfileConfigError` naming the engine index and the exact
  missing/undeclared/duplicate windows, never silently accepted into a
  slope with an erased or double-weighted sample.

  The MEASURED prompt is an explicit per-engine override, not always
  profile-wide: `measured_prompt` on an `EngineRunGroup` overrides
  `profile.prompt` for that engine's measured calls only (mirroring
  `warmup_prompt`'s override of the warmup prompt). The harness passes
  exactly the resolved string (the override, or `profile.prompt` when
  absent) to the adapter and hashes exactly that string — never a
  placeholder the adapter is trusted to reinterpret.

  The requested model/quantization is passed into `EngineAdapter.run()`;
  an adapter that invokes a different artifact than requested reports the
  actual identity back via `AdapterRunResult`, and raw observations
  always record the actual invoked identity. Profile TOML parsing is
  fail-closed on unknown top-level, per-profile, per-engine-group, and
  per-measured-call keys — a misspelled optional field is rejected with a
  `ProfileConfigError` naming the unexpected key, never silently
  defaulted. Ships the `EngineAdapter` protocol only — no concrete
  Lattice/Ollama/MLX adapters land here; those arrive with each script
  migration in #813 step 2. Until then every profile's requested engines
  resolve as "missing" and the `run` subcommand fails closed unless
  `--allow-missing-engine` is passed (no stale/fabricated result is ever
  substituted for a live run). `SlopeResult.slope_ci95_legacy` is
  explicitly labeled and documented as `bench_apples_precise.sh`'s
  pre-existing normal-approximation spread heuristic carried over
  unchanged — not a coverage-valid 95% CI; statistical-methodology
  correction stays out of scope for this issue.
- `scripts/bench_decode_profiles.toml` — profile scaffold, intentionally
  empty (`schema_version = 1`, no `[profiles.*]` entries yet), with the
  per-engine run-group schema (including `measured_calls`/
  `measured_order`/`measured_prompt`, `warmup_tokens`/`warmup_prompt`,
  and the windows-coverage fail-closed relationship) documented inline
  plus two commented-out examples: the Q4/Q8-mixed shape from
  `bench_q4_apples.sh`, and the three-distinct-measured-shapes,
  two-distinct-measured-prompts agentic example illustrating
  `bench_compare_1k.py`'s Lattice/Ollama/MLX plans.
- `tests/test_bench_decode_harness.py` — 117 deterministic unit tests
  using fake adapters and an injectable clock: raw-schema validation,
  fail-closed profile-config validation (top-level, per-profile,
  per-engine, and per-measured-call keys; `warmup_tokens`/`warmup_prompt`/
  `measured_order`/`measured_calls`/`measured_prompt` type and
  relationship checks, including the windows-coverage relationship
  between a `measured_calls` plan and `profile.windows`),
  `run_profile`'s warmup-batch-before-all-measured-calls placement,
  order-index bookkeeping, and missing-engine fail-closed behavior, an
  exact-call-sequence test reproducing the legacy Lattice → Ollama → MLX
  global order (Q4/apples-to-apples shape), global flattened-sequence
  tests for `bench_apples_precise.sh` and `bench_context_scaling.sh`
  using all three real engines (not a single stand-in adapter), a
  complete Lattice → Ollama → MLX global flattened-sequence test
  reproducing `bench_compare_1k.py`'s full three-shape, two-prompt
  schedule end to end (Lattice window-major on the shared tokenizer-
  padded prompt, Ollama's one-call-yields-two-windows shape via
  `component_ns` on its own character-count-heuristic `measured_prompt`,
  MLX's repeat-major alternation on the shared prompt) — asserting, per
  physical call, the exact prompt string invoked (via a `_FakeAdapter`
  capture) and, per raw observation, that `prompt_hash` matches
  `hash()` of that exact invoked string, `AdapterContractError`
  tests for missing/incomplete `component_ns`, three windows-coverage
  fail-closed tests (missing/undeclared/cross-call-duplicate window),
  adapter actual-identity override behavior, median and
  trimmed-mean+legacy-CI aggregation
  against hand-computed asymmetric-outlier data, and the `run`/`validate`
  CLI subcommands. No engine binary required.
- `.github/workflows/ci.yml` — one job, `bench-decode-harness-tests`,
  ungated like the existing `typos`/`actionlint` jobs, invoking the test
  file directly (`python3 tests/test_bench_decode_harness.py -v`) so a
  missing/renamed test file fails the job instead of a discovery pattern
  silently matching zero tests. **This is the only CI-workflow change in
  this PR** (rounds 2, 3, and 4 made no further changes here — every fix
  since round 1 has been contained to the harness/profile-schema/test
  files).

## Design: two explicit schedule contracts, not a uniform-windows model

**This PR's earlier round claimed `windows`/`measured_repeats` alone
(profile-wide, one call per window, executed uniformly as `[w1 x R, w2 x
R, ...]` for every engine) were sufficient to represent every legacy
script's measured shape. That claim was FALSE, and round-3 review caught
it: `bench_compare_1k.py` has three different measured shapes in one
profile that no choice of profile-wide fields can produce.** Lattice runs
all 1-token calls then all 100-token calls (window-major — the uniform
default does reproduce this one). Ollama issues exactly ONE 100-token
call per repeat and derives BOTH a window=1 (TTFT) and a window=100
(total) observation from that single response's two engine-reported
timing components. MLX alternates a 1-token call and a 100-token call
inside every repeat (repeat-major, not window-major). An adapter cannot
repair this gap without taking schedule ownership away from the harness
or fabricating a second measurement — the fix had to happen in the
harness's schedule model itself.

The corrected design (round 3): each `EngineRunGroup` carries its own
`measured_calls` (an ordered tuple of `MeasuredCall(n_tokens,
yields_windows)`) and `measured_order` (`"window_major"` or
`"repeat_major"`). Omitting `measured_calls` derives the pre-existing
default from `profile.windows` — every uniform-window legacy script
(`bench_apples_to_apples.sh`, `bench_apples_precise.sh`,
`bench_q4_apples.sh`, `bench_context_scaling.sh`, and Lattice's half of
`bench_compare_1k.py`) is unaffected by this change and needs no new
per-engine configuration. Engines whose shape the default can't
represent set an explicit plan: MLX sets `measured_order = "repeat_major"`
with a two-call plan; Ollama sets a single `MeasuredCall(n_tokens=100,
yields_windows=[1, 100])` and its adapter must report
`AdapterRunResult.component_ns = {1: ..., 100: ...}`.

An ordered-operation-list model (fully general per-engine operation
sequences, warmup and measured calls unified into one arbitrary list) was
considered again at this round, now with the measured-side evidence in
hand. Still rejected for the same reason as round 2's warmup design
choice: every actual legacy shape — including `bench_compare_1k.py`'s
three-way divergence — fits "warmup batch, then an ordered measured call
plan, replayed window-major or repeat-major," with no engine needing
warmup and measured calls interleaved with each other. The closed
two-field contract (`measured_calls`, `measured_order`) keeps the TOML
validators exhaustive and keeps `run_profile` two fixed, enumerable
iteration shapes instead of an interpreter over an arbitrary op sequence.
`AdapterRunResult.component_ns` is the multi-component timing extension
the review asked for: it lets one physical call report more than one
window's elapsed time without the harness inventing data the adapter
never measured.

**Round 3's own Design section claimed the measured prompt could stay
profile-wide (`profile.prompt`, sent unchanged to every engine's
measured calls) once the call-shape/timing fix landed. Round-4 review
caught that this claim was ALSO FALSE, and this line retracts it
explicitly rather than leaving it in place:** `bench_compare_1k.py`
requires two different measured prompts for the same nominal context —
Lattice and MLX build a tokenizer-padded prompt (`_build_padded_prompt`
mirrored on the Lattice side by a tokenizer-driven builder), while
Ollama builds a distinct character-count heuristic prompt
(`_make_prompt`). A single profile-wide `prompt` field cannot represent
both, and the earlier commented agentic TOML example admitted the gap
with a `"<ctx-padded prompt, built per-engine at the adapter level>"`
placeholder — which would have moved prompt ownership out of the
harness and made every raw `prompt_hash` describe the placeholder
string rather than the string actually sent to the engine.

The corrected design (round 4): `EngineRunGroup.measured_prompt`
(optional `str`, defaults to `None`) overrides `profile.prompt` for
that engine's measured calls only, mirroring the pre-existing
`warmup_prompt` override of the warmup prompt. `run_profile` resolves
each group's own measured prompt/hash once — the override if present,
else `profile.prompt` — and passes that resolved string to every
measured call for the group; the raw observation's `prompt_hash` is
computed from the exact same string, never from a placeholder or a
value the adapter is trusted to reinterpret. This keeps prompt
construction a harness-owned request rather than an adapter
implementation detail, matching the model/quantization identity
contract already in place. The commented agentic TOML example now uses
`measured_prompt` on the Ollama engine block instead of the placeholder.

## Out of scope (left for later #813-step-2 PRs / sibling issues)

Migrating the five live scripts (`bench_apples_to_apples.sh`,
`bench_apples_precise.sh`, `bench_q4_apples.sh`, `bench_context_scaling.sh`,
`bench_compare_1k.py`) onto profiles, adding concrete engine adapters, and
removing/renaming anything are all untouched here, per #813's own
"one script per PR" sequencing. Nothing from #814/#815/#817/#818 is
touched. Statistical-methodology correction for the legacy CI heuristic
stays deferred to its own separately reviewed issue, per #813's explicit
scope boundary.

## Gates / evidence

- Head: `ef191f364b7c75a4cf107900f8ca5c1db7d1c7a5` (up to date with
  `origin/main` — verified via `git merge-base --is-ancestor origin/main
  HEAD`).
- `python3 tests/test_bench_decode_harness.py -v` → `Ran 117 tests ... OK`.
- `python3 -m py_compile scripts/bench_decode_harness.py
  tests/test_bench_decode_harness.py` → clean.
- Mutation checks, verified locally by temporarily reverting a fix (via a
  `cp` backup, restored via `cp` and re-verified with `diff` against the
  backup — never `git checkout` over uncommitted work), confirming the
  affected test(s) fail, then restoring:
  - Round 1: removing the trimmed-mean slice fails both
    `test_trimmed_mean_stat_exact_with_asymmetric_outliers` and
    `test_trimmed_mean_slope_exact_with_asymmetric_outliers`.
  - Round 2: reverting the warmup batch to loop once per measured window
    (instead of once, before all measured calls) fails 5 tests:
    `test_warmup_executes_once_before_all_measured_windows`,
    `test_heterogeneous_engine_schedule_exact_call_sequence_and_identities`,
    `test_precise_style_warmup_twice_before_both_measured_windows`,
    `test_context_scaling_style_single_warmup_before_all_comparison_windows`,
    and `test_produces_expected_observation_count`.
  - Round 3: (a) ignoring `measured_order` and always taking the
    `window_major` branch fails the 2 tests exercising repeat-major
    ordering (`test_measured_order_repeat_major_alternates_calls_per_repeat`,
    `test_agentic_style_global_flattened_sequence_lattice_ollama_mlx`);
    (b) disabling the `component_ns` multi-yield path (always treating a
    measured call as single-yield, keyed by `n_tokens`, using the
    harness's own wall-clock span) fails the 4 tests exercising the
    multi-yield contract
    (`test_measured_call_multi_yield_uses_component_ns_for_elapsed_ns`,
    `test_measured_call_multi_yield_missing_component_ns_raises`,
    `test_measured_call_multi_yield_missing_window_entry_raises`,
    `test_agentic_style_global_flattened_sequence_lattice_ollama_mlx`).
    Both mutations restored and the clean tree re-verified at 108/108
    green after each (test count at round 3).
  - Round 4: (a) ignoring `measured_prompt` and always resolving/hashing
    `profile.prompt` for every engine's measured calls fails exactly 1
    test, `test_agentic_style_global_flattened_sequence_lattice_ollama_mlx`
    (its per-call prompt and per-observation `prompt_hash` assertions
    catch Ollama silently receiving the Lattice/MLX prompt); (b)
    disabling the windows-coverage relationship check (skipping the
    flattened-`yields_windows`-vs-`profile.windows` comparison) fails
    exactly 3 tests, the three new relationship tests
    (`test_measured_calls_missing_declared_window_rejected`,
    `test_measured_calls_undeclared_window_rejected`,
    `test_measured_calls_cross_call_duplicate_window_rejected`). Both
    mutations applied via `cp` backup, restored via `cp` and
    re-verified byte-identical with `diff` against the backup — never
    `git checkout` — and the clean tree re-verified at 117/117 green
    after each.
- CLI smoke-tested directly: `run --profile <unknown>` and
  `run --profile <profile> --profiles-file <toml requesting an
  unregistered engine>` both fail closed (exit 1) without
  `--allow-missing-engine`, and exit 0 with it, emitting a report with
  the missing engine explicitly named — never a fabricated result.
  `validate <missing-file>` and `<malformed-toml>` fail closed with a
  clean message instead of an unhandled traceback.
- `actionlint .github/workflows/ci.yml` → clean (rc=0); no changes to
  this file in rounds 2, 3, or 4.
- `typos` → clean on all four changed files.
- `git diff --check origin/main...HEAD` → clean.
- Publication-hygiene grep (internal-ops markers, CJK, workspace paths)
  on all four changed files → no matches.
- No Rust files touched by this PR's own commits, so `cargo fmt`/`clippy`
  are not applicable to this diff. `origin/main` gained one unrelated
  Rust commit (`634a8a8c4`, WGPU attention_softmax fail-closed fix)
  since round 3; merged cleanly into this branch with no conflicts and
  no changes to any of the four gate files.

## Spec deviations

None identified against the current design. Two earlier-round claims
have been corrected rather than left in place with incorrect framing:
(1) round 3 corrected round 1/2's claim that `windows`/`measured_repeats`
alone were sufficient to represent every legacy script's measured
schedule (see Design section above); (2) **round 4 corrects round 3's
own claim that the measured `prompt` could stay profile-wide once the
call-shape/timing fix landed — that was also false, and is retracted
above.** `windows`, `measured_repeats`, and the measured `prompt` stay
profile-wide as the DEFAULT (every legacy script keeps those uniform
across engines when nothing more specific is given), while individual
engines override with `measured_calls`/`measured_order`/`measured_prompt`
only where the default cannot represent their actual shape — that
"default profile-wide, explicit per-engine override" pattern is now
applied consistently to schedule shape, timing, AND prompt identity,
not asserted as sufficient on its own without the override path.

The harness's window/aggregation model otherwise generalizes cleanly
over all five legacy scripts' shapes without needing a `baseline_reuse`
flag or similar: a flat, once-each `windows` list (`windows[0]` =
baseline, later entries = comparison points) reproduces
`bench_context_scaling.sh`'s "N1 run once, reused across every context"
behavior for free, and `bench_compare_1k.py`'s per-prompt-context matrix
maps to one profile per context length rather than a special case in the
harness — that mapping decision is deferred to its own migration PR per
the issue's step-2 sequencing, not decided here. The per-engine
run-group schema (`engines` as an array of tables rather than a flat
name list, now carrying a warmup plan, a measured call plan, and a
measured prompt override) is a structural change from the harness's
initial landing, made to represent every legacy script's per-engine
schedule and prompt without another schema migration later.

