### PR TITLE
refactor(tune): validated TrainCtx replaces ten-argument train-tape signatures

### DIFF
--- a/crates/tune/src/bin/train_grad_full.rs
+++ b/crates/tune/src/bin/train_grad_full.rs
@@ -41,9 +41,9 @@ use lattice_inference::model::qwen35::Qwen35Model;
 use lattice_inference::tokenizer::Tokenizer;
 use lattice_tune::lora::AdamState;
 use lattice_tune::lora::train_core::{
-    Dims, GdnDims, GdnLoraParams, Head, LayerW, LoraParams, MixerKind, SeqCtx, TOP_LAYER,
-    apply_adam_updates, apply_gdn_adam_updates, eval_chain_nll, forward_full, nll_and_grads,
-    rand_fill, shifted,
+    AdamConfig, Dims, GdnDims, GdnLoraParams, Head, LayerW, LoraParams, MixerKind, SeqCtx,
+    SlotLayout, TOP_LAYER, TapeGeometry, TrainCtx, apply_adam_updates, apply_gdn_adam_updates,
+    eval_chain_nll, forward_full, nll_and_grads, rand_fill, shifted,
 };
 
 fn parse_arg(args: &[String], flag: &str) -> Option<String> {
@@ -361,7 +361,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         eps: cfg.rms_norm_eps,
     };
     let gdn_dims = GdnDims::from_cfg(&cfg);
-    let scale = alpha / rank as f32;
     println!(
         "  hidden={}  vocab={}  q_dim={}  kv_dim={}  inter={}",
         dims.hidden, dims.vocab, dims.q_dim, dims.kv_dim, dims.inter
@@ -455,6 +454,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err("no GQA or GDN layers in range — nothing to train".into());
     }
 
+    let (beta1, beta2, eps_adam) = (0.9f32, 0.999f32, 1e-8f32);
+    let train_ctx = TrainCtx::try_new(
+        TapeGeometry::new(&dims, &gdn_dims, &cfg),
+        rank,
+        alpha,
+        SlotLayout::new(&slot_layers, &gdn_slot_layers),
+        AdamConfig::new(lr, beta1, beta2, eps_adam),
+    )?;
+
     let tokenizer = model.tokenizer().clone();
     println!("\nLoading dataset from {}...", data_dir.display());
     let train_samples = load_jsonl(
@@ -539,11 +547,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &zero_loras,
             &zero_gdn_loras,
             &head,
-            &dims,
-            &gdn_dims,
-            &cfg,
-            rank,
-            scale,
+            &train_ctx,
         )?;
         let diff = (model_masked - chain_masked).abs();
         println!(
@@ -573,21 +577,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut gdn_loras: Vec<GdnLoraParams> =
             gradcheck_gdn_loras(num_gdn_slots, rank, dims.hidden, &gdn_dims, rng);
 
-        let fwd = forward_full(
-            &caches[0], &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
-        )?;
-        let (_, _, analytic, gdn_analytic) = nll_and_grads(
-            &fwd,
-            &layers,
-            &loras,
-            &head,
-            &dims,
-            &gdn_dims,
-            num_slots,
-            num_gdn_slots,
-            rank,
-            scale,
-        )?;
+        let fwd = forward_full(&caches[0], &layers, &loras, &gdn_loras, &head, &train_ctx)?;
+        let (_, _, analytic, gdn_analytic) =
+            nll_and_grads(&fwd, &layers, &loras, &head, &train_ctx)?;
 
         println!("  fd-eps center {fd_eps:.0e}  (per-entry min over 0.25/0.5/1/2x)");
         let mut worst = 0.0f64;
@@ -660,11 +652,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             &loras,
                             &gdn_loras,
                             &head,
-                            &dims,
-                            &gdn_dims,
-                            &cfg,
-                            rank,
-                            scale,
+                            &train_ctx,
                         )?;
                         bump(&mut loras, save - e);
                         let lm = eval_chain_nll(
@@ -673,11 +661,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             &loras,
                             &gdn_loras,
                             &head,
-                            &dims,
-                            &gdn_dims,
-                            &cfg,
-                            rank,
-                            scale,
+                            &train_ctx,
                         )?;
                         let fd = (lp - lm) / (2.0 * e);
                         let rel = (a - fd).abs() as f64 / (a.abs().max(fd.abs()).max(1e-6)) as f64;
@@ -777,11 +761,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             &loras,
                             &gdn_loras,
                             &head,
-                            &dims,
-                            &gdn_dims,
-                            &cfg,
-                            rank,
-                            scale,
+                            &train_ctx,
                         )?;
                         field_mut(&mut gdn_loras[slot], name)[k] = save - e;
                         let lm = eval_chain_nll(
@@ -790,11 +770,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             &loras,
                             &gdn_loras,
                             &head,
-                            &dims,
-                            &gdn_dims,
-                            &cfg,
-                            rank,
-                            scale,
+                            &train_ctx,
                         )?;
                         let fd = (lp - lm) / (2.0 * e);
                         let rel = (a - fd).abs() as f64 / (a.abs().max(fd.abs()).max(1e-6)) as f64;
@@ -849,7 +825,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         zero_b_gdn_loras(num_gdn_slots, rank, dims.hidden, &gdn_dims, rng, init_amp);
 
     let mut adam = AdamState::new();
-    let (beta1, beta2, eps_adam) = (0.9f32, 0.999f32, 1e-8f32);
 
     let eval_valid = |loras: &[LoraParams],
                       gdn_loras: &[GdnLoraParams]|
@@ -863,17 +838,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             loras,
             gdn_loras,
             &head,
-            &dims,
-            &gdn_dims,
-            &cfg,
-            rank,
-            scale,
+            &train_ctx,
         )?))
     };
 
-    let base_nll = eval_chain_nll(
-        &caches, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
-    )?;
+    let base_nll = eval_chain_nll(&caches, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
     let base_valid = eval_valid(&loras, &gdn_loras)?;
     match base_valid {
         Some(v) => println!("\n  step    0  train NLL: {base_nll:.4}  held-out NLL: {v:.4}"),
@@ -883,47 +852,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tstep = Instant::now();
     for step in 1..=steps {
         let ctx = &caches[(step - 1) % caches.len()];
-        let fwd = forward_full(
-            ctx, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
-        )?;
-        let (_nll, _n, grads, gdn_grads) = nll_and_grads(
-            &fwd,
-            &layers,
-            &loras,
-            &head,
-            &dims,
-            &gdn_dims,
-            num_slots,
-            num_gdn_slots,
-            rank,
-            scale,
-        )?;
+        let fwd = forward_full(ctx, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
+        let (_nll, _n, grads, gdn_grads) = nll_and_grads(&fwd, &layers, &loras, &head, &train_ctx)?;
 
-        apply_adam_updates(
-            &mut adam,
-            &mut loras,
-            &grads,
-            &slot_layers,
-            lr,
-            beta1,
-            beta2,
-            eps_adam,
-        );
-        apply_gdn_adam_updates(
-            &mut adam,
-            &mut gdn_loras,
-            &gdn_grads,
-            &gdn_slot_layers,
-            lr,
-            beta1,
-            beta2,
-            eps_adam,
-        );
+        apply_adam_updates(&mut adam, &mut loras, &grads, &train_ctx);
+        apply_gdn_adam_updates(&mut adam, &mut gdn_loras, &gdn_grads, &train_ctx);
 
         if step % log_every == 0 || step == steps {
-            let mean_nll = eval_chain_nll(
-                &caches, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
-            )?;
+            let mean_nll = eval_chain_nll(&caches, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
             match eval_valid(&loras, &gdn_loras)? {
                 Some(v) => println!(
                     "  step {step:4}  train NLL: {mean_nll:.4}  held-out NLL: {v:.4}  (train d {:+.4})",
@@ -937,9 +873,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let final_nll = eval_chain_nll(
-        &caches, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
-    )?;
+    let final_nll = eval_chain_nll(&caches, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
     let secs = tstep.elapsed().as_secs_f64();
     match (base_valid, eval_valid(&loras, &gdn_loras)?) {
         (Some(b), Some(f)) => println!(

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -10,8 +10,9 @@ use lattice_inference::model::qwen35::Qwen35Model;
 
 use crate::error::{Result, TuneError};
 use crate::lora::train_core::{
-    Dims, GdnDims, GdnLoraParams, Head, LayerW, LoraParams, MixerKind, SeqCtx, TOP_LAYER,
-    apply_adam_updates, forward_full, nll_and_grads, rand_fill, shifted,
+    AdamConfig, Dims, GdnDims, GdnLoraParams, Head, LayerW, LoraParams, MixerKind, SeqCtx,
+    SlotLayout, TOP_LAYER, TapeGeometry, TrainCtx, apply_adam_updates, forward_full, nll_and_grads,
+    rand_fill, shifted,
 };
 use crate::lora::{AdamState, LoraAdapter, LoraConfig, LoraLayer};
 
@@ -233,7 +234,6 @@ pub fn train_micro_lora(
     let gdn_dims = GdnDims::from_cfg(&cfg);
     let rank = config.rank;
     let alpha = config.alpha;
-    let scale = alpha / rank as f32;
     let first_layer = config.first_layer;
 
     // Head weights.
@@ -374,25 +374,21 @@ pub fn train_micro_lora(
     // LoRA request surface yet), so the GDN slot arrays stay empty — forward_full
     // and nll_and_grads fall back to the byte-identical no-LoRA GDN path.
     let gdn_loras: Vec<GdnLoraParams> = Vec::new();
+    let gdn_slot_layers: Vec<usize> = Vec::new();
+    let train_ctx = TrainCtx::try_new(
+        TapeGeometry::new(&dims, &gdn_dims, &cfg),
+        rank,
+        alpha,
+        SlotLayout::new(&slot_layers, &gdn_slot_layers),
+        AdamConfig::new(lr, beta1, beta2, eps_adam),
+    )?;
     for step in 1..=config.steps {
         let ctx = &caches[(step - 1) % caches.len()];
-        let fwd = forward_full(
-            ctx, &layers, &loras, &gdn_loras, &head, &dims, &gdn_dims, &cfg, rank, scale,
-        )?;
-        let (_nll, _n, grads, _gdn_grads) = nll_and_grads(
-            &fwd, &layers, &loras, &head, &dims, &gdn_dims, num_slots, 0, rank, scale,
-        )?;
+        let fwd = forward_full(ctx, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
+        let (_nll, _n, grads, _gdn_grads) =
+            nll_and_grads(&fwd, &layers, &loras, &head, &train_ctx)?;
 
-        apply_adam_updates(
-            &mut adam,
-            &mut loras,
-            &grads,
-            &slot_layers,
-            lr,
-            beta1,
-            beta2,
-            eps_adam,
-        );
+        apply_adam_updates(&mut adam, &mut loras, &grads, &train_ctx);
     }
 
     // Assemble LoraAdapter from trained slot params.

--- a/crates/tune/src/lora/train_core.rs
+++ b/crates/tune/src/lora/train_core.rs
@@ -358,6 +358,12 @@ impl<'a> TrainCtx<'a> {
 
         let d = geometry.dims;
         let m = geometry.model;
+        if !d.eps.is_finite() {
+            return Err(TuneError::Validation(format!(
+                "TrainCtx::try_new: Dims.eps must be finite, got {}",
+                d.eps
+            )));
+        }
         if d.hidden != m.hidden_size
             || d.vocab != m.vocab_size
             || d.num_q_heads != m.num_attention_heads
@@ -375,6 +381,12 @@ impl<'a> TrainCtx<'a> {
         }
         let expected_gdn = GdnDims::from_cfg(m);
         let gd = geometry.gdn_dims;
+        if !gd.scale.is_finite() {
+            return Err(TuneError::Validation(format!(
+                "TrainCtx::try_new: GdnDims.scale must be finite, got {}",
+                gd.scale
+            )));
+        }
         if gd.num_kh != expected_gdn.num_kh
             || gd.value_heads != expected_gdn.value_heads
             || gd.key_dim != expected_gdn.key_dim
@@ -397,6 +409,12 @@ impl<'a> TrainCtx<'a> {
                     "TrainCtx::try_new: gqa slot layer {li} out of range (model has {num_hidden_layers} layers)"
                 )));
             }
+            if !m.is_full_attention(li) {
+                return Err(TuneError::Validation(format!(
+                    "TrainCtx::try_new: gqa slot layer {li} is not a full-attention (GQA) layer \
+                     in this model (mixer-kind/slot-index mismatch)"
+                )));
+            }
             if !seen.insert(li) {
                 return Err(TuneError::Validation(format!(
                     "TrainCtx::try_new: duplicate gqa slot layer {li}"
@@ -408,6 +426,12 @@ impl<'a> TrainCtx<'a> {
             if li >= num_hidden_layers {
                 return Err(TuneError::Validation(format!(
                     "TrainCtx::try_new: gdn slot layer {li} out of range (model has {num_hidden_layers} layers)"
+                )));
+            }
+            if m.is_full_attention(li) {
+                return Err(TuneError::Validation(format!(
+                    "TrainCtx::try_new: gdn slot layer {li} is a full-attention (GQA) layer in \
+                     this model, not GatedDeltaNet (mixer-kind/slot-index mismatch)"
                 )));
             }
             if !seen_gdn.insert(li) {
@@ -443,57 +467,57 @@ impl<'a> TrainCtx<'a> {
     }
 
     /// Global model layer index per GQA slot.
-    pub fn gqa_layers(&self) -> &[usize] {
+    fn gqa_layers(&self) -> &[usize] {
         self.slots.gqa_layers
     }
 
     /// Global model layer index per GDN slot.
-    pub fn gdn_layers(&self) -> &[usize] {
+    fn gdn_layers(&self) -> &[usize] {
         self.slots.gdn_layers
     }
 
     /// LoRA rank.
-    pub fn rank(&self) -> usize {
+    fn rank(&self) -> usize {
         self.lora.rank
     }
 
     /// Execution-only LoRA scale (`alpha / rank`).
-    pub fn scale(&self) -> f32 {
+    fn scale(&self) -> f32 {
         self.lora.scale
     }
 
     /// Flat per-array dimensions.
-    pub fn dims(&self) -> &Dims {
+    fn dims(&self) -> &Dims {
         self.geometry.dims
     }
 
     /// GDN-specific dimensions.
-    pub fn gdn_dims(&self) -> &GdnDims {
+    fn gdn_dims(&self) -> &GdnDims {
         self.geometry.gdn_dims
     }
 
     /// The model config the geometry was derived from.
-    pub fn model(&self) -> &Qwen35Config {
+    fn model(&self) -> &Qwen35Config {
         self.geometry.model
     }
 
     /// Adam learning rate.
-    pub fn learning_rate(&self) -> f32 {
+    fn learning_rate(&self) -> f32 {
         self.adam.learning_rate
     }
 
     /// Adam beta1.
-    pub fn beta1(&self) -> f32 {
+    fn beta1(&self) -> f32 {
         self.adam.beta1
     }
 
     /// Adam beta2.
-    pub fn beta2(&self) -> f32 {
+    fn beta2(&self) -> f32 {
         self.adam.beta2
     }
 
     /// Adam epsilon.
-    pub fn epsilon(&self) -> f32 {
+    fn epsilon(&self) -> f32 {
         self.adam.epsilon
     }
 }
@@ -1128,7 +1152,14 @@ mod gdn_lora_tests {
         };
         let real_gdn_dims = GdnDims::from_cfg(&cfg);
         let gqa_layers: [usize; 0] = [];
-        let gdn_layers = [7usize];
+        // Layer 7 was a full-attention (GQA) layer on the 0.8B preset — an
+        // arbitrary index was fine before TrainCtx validated per-slot mixer
+        // kind. Now the fixture must name an actual GatedDeltaNet layer.
+        assert!(
+            !cfg.is_full_attention(20),
+            "layer 20 must be GDN on the 0.8B preset"
+        );
+        let gdn_layers = [20usize];
         let train = TrainCtx::try_new(
             TapeGeometry::new(&dims, &real_gdn_dims, &cfg),
             rank,
@@ -1271,7 +1302,10 @@ mod train_ctx_tests {
 
     /// Mutation-sensitive: a layer index claimed by both the GQA and GDN
     /// slot lists is a mixer-kind conflict — the same layer cannot be
-    /// trained as both mixer kinds in one materialised tape.
+    /// trained as both mixer kinds in one materialised tape. (Layer 19 is
+    /// full-attention on the 0.8B preset, so this also exercises the
+    /// one-sided "gdn slot layer is actually GQA" rejection below — either
+    /// way, `TrainCtx` must not construct.)
     #[test]
     fn try_new_rejects_mixer_kind_slot_index_mismatch() {
         let g = valid_geometry();
@@ -1287,6 +1321,78 @@ mod train_ctx_tests {
         assert!(
             err.contains("mixer-kind"),
             "expected mixer-kind/slot-index mismatch rejection; got: {err}"
+        );
+    }
+
+    /// Mutation-sensitive, one-sided misclassification: layer 20 is
+    /// GatedDeltaNet (not full-attention) on the 0.8B preset, so it must be
+    /// rejected when claimed as a GQA slot even though nothing else conflicts.
+    #[test]
+    fn try_new_rejects_gqa_slot_layer_wrong_kind() {
+        let g = valid_geometry();
+        assert!(
+            !g.cfg.is_full_attention(20),
+            "fixture assumption: layer 20 must be GDN on the 0.8B preset"
+        );
+        let gqa = [20usize];
+        let gdn: [usize; 0] = [];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("mixer-kind"),
+            "expected gqa-slot-wrong-kind rejection; got: {err}"
+        );
+    }
+
+    /// Mutation-sensitive, one-sided misclassification: layer 19 is
+    /// full-attention (GQA) on the 0.8B preset, so it must be rejected when
+    /// claimed as a GDN slot even though nothing else conflicts.
+    #[test]
+    fn try_new_rejects_gdn_slot_layer_wrong_kind() {
+        let g = valid_geometry();
+        assert!(
+            g.cfg.is_full_attention(19),
+            "fixture assumption: layer 19 must be full-attention on the 0.8B preset"
+        );
+        let gqa: [usize; 0] = [];
+        let gdn = [19usize];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("mixer-kind"),
+            "expected gdn-slot-wrong-kind rejection; got: {err}"
+        );
+    }
+
+    /// Mutation-sensitive: the exact swap codex round 1 found unrejected
+    /// pre-fix — `gqa_layers = [20]` (actually GDN), `gdn_layers = [19]`
+    /// (actually GQA) — both wrong, together. Must be rejected; before this
+    /// fix `TrainCtx::try_new(...).is_ok()` on this input.
+    #[test]
+    fn try_new_rejects_gqa_gdn_slot_swap_19_20() {
+        let g = valid_geometry();
+        let gqa = [20usize];
+        let gdn = [19usize];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("mixer-kind"),
+            "expected 19/20 swap rejection; got: {err}"
         );
     }
 
@@ -1399,6 +1505,54 @@ mod train_ctx_tests {
         assert!(
             err.contains("GdnDims"),
             "expected GdnDims/model mismatch rejection; got: {err}"
+        );
+    }
+
+    /// Mutation-sensitive: NaN bypasses `(a - b).abs() > 1e-9` (NaN
+    /// comparisons are always false), so a non-finite `Dims.eps` would
+    /// silently pass the tolerance check and poison every RMSNorm call in
+    /// the tape. The finite check ahead of the tolerance comparison must
+    /// catch it explicitly.
+    #[test]
+    fn try_new_rejects_non_finite_dims_eps() {
+        let g = valid_geometry();
+        let mut nan_dims = g.dims;
+        nan_dims.eps = f32::NAN;
+        let gqa = [19usize];
+        let gdn: [usize; 0] = [];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&nan_dims, &g.gdn_dims, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("eps"),
+            "expected non-finite Dims.eps rejection; got: {err}"
+        );
+    }
+
+    /// Mutation-sensitive: same NaN-bypasses-tolerance hole as `Dims.eps`,
+    /// for `GdnDims.scale` — a non-finite scale would poison every
+    /// GatedDeltaNet forward/backward call in the tape.
+    #[test]
+    fn try_new_rejects_non_finite_gdn_scale() {
+        let g = valid_geometry();
+        let mut nan_gdn = g.gdn_dims;
+        nan_gdn.scale = f32::NAN;
+        let gqa = [19usize];
+        let gdn: [usize; 0] = [];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &nan_gdn, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("scale"),
+            "expected non-finite GdnDims.scale rejection; got: {err}"
         );
     }
 }

--- a/crates/tune/src/lora/train_core.rs
+++ b/crates/tune/src/lora/train_core.rs
@@ -210,6 +210,294 @@ impl GdnLoraParams {
     }
 }
 
+/// Geometry inputs shared by every tape entry point: the flat per-array
+/// dimensions (`Dims`), the GDN-specific dimensions (`GdnDims`), and the model
+/// config both were derived from. Held as references so the tape borrows the
+/// caller's already-computed geometry instead of cloning it per call.
+pub struct TapeGeometry<'a> {
+    dims: &'a Dims,
+    gdn_dims: &'a GdnDims,
+    model: &'a Qwen35Config,
+}
+
+impl<'a> TapeGeometry<'a> {
+    /// Bundle references to the tape's geometry. Consistency between `dims`,
+    /// `gdn_dims`, and `model` is checked by [`TrainCtx::try_new`], not here —
+    /// this constructor is a plain aggregate, not a validator.
+    pub fn new(dims: &'a Dims, gdn_dims: &'a GdnDims, model: &'a Qwen35Config) -> Self {
+        Self {
+            dims,
+            gdn_dims,
+            model,
+        }
+    }
+}
+
+/// The private, execution-only `{rank, scale}` pair derived from
+/// `alpha / rank` by [`TrainCtx::try_new`]. Not adapter governance (the
+/// adapter descriptor scoped to issue #615 owns rank/alpha/target-module
+/// governance) — this is just the two scalars the forward/backward tape
+/// multiplies LoRA deltas by.
+struct LoraExecution {
+    rank: usize,
+    scale: f32,
+}
+
+/// The GQA-slot and GDN-slot layer index layout for a materialised tape run.
+/// `gqa_layers[slot]` / `gdn_layers[slot]` give the global model layer index
+/// trained by that slot; slot count is the slice length (see
+/// [`TrainCtx::num_gqa_slots`] / [`TrainCtx::num_gdn_slots`]).
+pub struct SlotLayout<'a> {
+    gqa_layers: &'a [usize],
+    gdn_layers: &'a [usize],
+}
+
+impl<'a> SlotLayout<'a> {
+    /// Bundle the GQA/GDN slot-layer index slices. Uniqueness, in-range, and
+    /// mixer-kind agreement are checked by [`TrainCtx::try_new`], not here.
+    pub fn new(gqa_layers: &'a [usize], gdn_layers: &'a [usize]) -> Self {
+        Self {
+            gqa_layers,
+            gdn_layers,
+        }
+    }
+}
+
+/// Adam hyperparameters shared by every optimizer step in a training run.
+pub struct AdamConfig {
+    learning_rate: f32,
+    beta1: f32,
+    beta2: f32,
+    epsilon: f32,
+}
+
+impl AdamConfig {
+    /// Bundle Adam hyperparameters. Finiteness is checked by
+    /// [`TrainCtx::try_new`], not here.
+    pub fn new(learning_rate: f32, beta1: f32, beta2: f32, epsilon: f32) -> Self {
+        Self {
+            learning_rate,
+            beta1,
+            beta2,
+            epsilon,
+        }
+    }
+}
+
+/// Validated, immutable run context for the training tape's core entry
+/// points (`forward_full`, `eval_chain_nll`, `nll_and_grads`,
+/// `apply_adam_updates`, `apply_gdn_adam_updates`).
+///
+/// `TrainCtx::try_new` is the only constructor: it validates rank and
+/// hyperparameter finiteness, checks that `geometry`'s `Dims`/`GdnDims` agree
+/// with `geometry.model`, and checks that `slots`' GQA/GDN layer indices are
+/// each unique, in-range for `geometry.model`, and never claim the same layer
+/// index for both mixer kinds. A `TrainCtx` cannot exist unless all of that
+/// holds, so callers of the narrowed entry points no longer have to
+/// reconstruct — or get wrong — the positional-argument agreement the old
+/// ten-argument signatures relied on.
+///
+/// Non-goal: `TrainCtx` owns geometry, layout, and optimizer policy only — it
+/// never owns weights, caches, gradients, LoRA vectors, or optimizer state
+/// (see issue #844's Non-goals).
+pub struct TrainCtx<'a> {
+    geometry: TapeGeometry<'a>,
+    lora: LoraExecution,
+    slots: SlotLayout<'a>,
+    adam: AdamConfig,
+}
+
+impl<'a> TrainCtx<'a> {
+    /// Construct a validated `TrainCtx`.
+    ///
+    /// `alpha` is not stored: the execution-only `scale = alpha / rank` is
+    /// derived once here and held privately alongside `rank`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TuneError::Validation)` if:
+    /// - `rank == 0`.
+    /// - `alpha`, `adam.learning_rate`, `adam.beta1`, `adam.beta2`, or
+    ///   `adam.epsilon` is non-finite (NaN or +/-inf).
+    /// - `geometry.dims` or `geometry.gdn_dims` disagree with
+    ///   `geometry.model` (a geometry built from a different config than the
+    ///   one the tape will index weights through).
+    /// - `slots.gqa_layers` or `slots.gdn_layers` contains a duplicate layer
+    ///   index, an index `>= geometry.model.num_hidden_layers`, or a layer
+    ///   index that appears in both lists (a mixer-kind conflict: the same
+    ///   layer cannot be trained as both GQA and GDN).
+    pub fn try_new(
+        geometry: TapeGeometry<'a>,
+        rank: usize,
+        alpha: f32,
+        slots: SlotLayout<'a>,
+        adam: AdamConfig,
+    ) -> Result<Self> {
+        if rank == 0 {
+            return Err(TuneError::Validation(
+                "TrainCtx::try_new: rank must be > 0".to_string(),
+            ));
+        }
+        if !alpha.is_finite() {
+            return Err(TuneError::Validation(format!(
+                "TrainCtx::try_new: alpha must be finite, got {alpha}"
+            )));
+        }
+        for (name, v) in [
+            ("learning_rate", adam.learning_rate),
+            ("beta1", adam.beta1),
+            ("beta2", adam.beta2),
+            ("epsilon", adam.epsilon),
+        ] {
+            if !v.is_finite() {
+                return Err(TuneError::Validation(format!(
+                    "TrainCtx::try_new: adam.{name} must be finite, got {v}"
+                )));
+            }
+        }
+
+        let d = geometry.dims;
+        let m = geometry.model;
+        if d.hidden != m.hidden_size
+            || d.vocab != m.vocab_size
+            || d.num_q_heads != m.num_attention_heads
+            || d.num_kv_heads != m.num_key_value_heads
+            || d.head_dim != m.head_dim
+            || d.rope_dim != m.rope_dim()
+            || d.inter != m.intermediate_size
+            || d.q_dim != m.full_q_dim()
+            || d.kv_dim != m.full_kv_dim()
+            || (d.eps - m.rms_norm_eps).abs() > 1e-9
+        {
+            return Err(TuneError::Validation(
+                "TrainCtx::try_new: Dims does not match TapeGeometry.model".to_string(),
+            ));
+        }
+        let expected_gdn = GdnDims::from_cfg(m);
+        let gd = geometry.gdn_dims;
+        if gd.num_kh != expected_gdn.num_kh
+            || gd.value_heads != expected_gdn.value_heads
+            || gd.key_dim != expected_gdn.key_dim
+            || gd.value_dim != expected_gdn.value_dim
+            || gd.qkv_dim != expected_gdn.qkv_dim
+            || gd.output_dim != expected_gdn.output_dim
+            || gd.kernel_size != expected_gdn.kernel_size
+            || (gd.scale - expected_gdn.scale).abs() > 1e-9
+        {
+            return Err(TuneError::Validation(
+                "TrainCtx::try_new: GdnDims does not match TapeGeometry.model".to_string(),
+            ));
+        }
+
+        let num_hidden_layers = m.num_hidden_layers;
+        let mut seen = std::collections::HashSet::new();
+        for &li in slots.gqa_layers {
+            if li >= num_hidden_layers {
+                return Err(TuneError::Validation(format!(
+                    "TrainCtx::try_new: gqa slot layer {li} out of range (model has {num_hidden_layers} layers)"
+                )));
+            }
+            if !seen.insert(li) {
+                return Err(TuneError::Validation(format!(
+                    "TrainCtx::try_new: duplicate gqa slot layer {li}"
+                )));
+            }
+        }
+        let mut seen_gdn = std::collections::HashSet::new();
+        for &li in slots.gdn_layers {
+            if li >= num_hidden_layers {
+                return Err(TuneError::Validation(format!(
+                    "TrainCtx::try_new: gdn slot layer {li} out of range (model has {num_hidden_layers} layers)"
+                )));
+            }
+            if !seen_gdn.insert(li) {
+                return Err(TuneError::Validation(format!(
+                    "TrainCtx::try_new: duplicate gdn slot layer {li}"
+                )));
+            }
+            if seen.contains(&li) {
+                return Err(TuneError::Validation(format!(
+                    "TrainCtx::try_new: layer {li} claimed by both gqa and gdn slot layouts \
+                     (mixer-kind/slot-index mismatch)"
+                )));
+            }
+        }
+
+        let scale = alpha / rank as f32;
+        Ok(Self {
+            geometry,
+            lora: LoraExecution { rank, scale },
+            slots,
+            adam,
+        })
+    }
+
+    /// Number of GQA LoRA slots (== `slots.gqa_layers.len()`).
+    pub fn num_gqa_slots(&self) -> usize {
+        self.slots.gqa_layers.len()
+    }
+
+    /// Number of GDN LoRA slots (== `slots.gdn_layers.len()`).
+    pub fn num_gdn_slots(&self) -> usize {
+        self.slots.gdn_layers.len()
+    }
+
+    /// Global model layer index per GQA slot.
+    pub fn gqa_layers(&self) -> &[usize] {
+        self.slots.gqa_layers
+    }
+
+    /// Global model layer index per GDN slot.
+    pub fn gdn_layers(&self) -> &[usize] {
+        self.slots.gdn_layers
+    }
+
+    /// LoRA rank.
+    pub fn rank(&self) -> usize {
+        self.lora.rank
+    }
+
+    /// Execution-only LoRA scale (`alpha / rank`).
+    pub fn scale(&self) -> f32 {
+        self.lora.scale
+    }
+
+    /// Flat per-array dimensions.
+    pub fn dims(&self) -> &Dims {
+        self.geometry.dims
+    }
+
+    /// GDN-specific dimensions.
+    pub fn gdn_dims(&self) -> &GdnDims {
+        self.geometry.gdn_dims
+    }
+
+    /// The model config the geometry was derived from.
+    pub fn model(&self) -> &Qwen35Config {
+        self.geometry.model
+    }
+
+    /// Adam learning rate.
+    pub fn learning_rate(&self) -> f32 {
+        self.adam.learning_rate
+    }
+
+    /// Adam beta1.
+    pub fn beta1(&self) -> f32 {
+        self.adam.beta1
+    }
+
+    /// Adam beta2.
+    pub fn beta2(&self) -> f32 {
+        self.adam.beta2
+    }
+
+    /// Adam epsilon.
+    pub fn epsilon(&self) -> f32 {
+        self.adam.epsilon
+    }
+}
+
 pub struct SeqCtx {
     pub h_in: Vec<f32>,
     pub cos: Vec<f32>,
@@ -283,19 +571,19 @@ fn position_nll(logits: &[f32], target: u32) -> f32 {
     (-log_prob) as f32
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn forward_full(
     ctx: &SeqCtx,
     layers: &[LayerW<'_>],
     loras: &[LoraParams],
     gdn_loras: &[GdnLoraParams],
     head: &Head<'_>,
-    d: &Dims,
-    gdn_dims: &GdnDims,
-    cfg: &Qwen35Config,
-    rank: usize,
-    scale: f32,
+    train: &TrainCtx<'_>,
 ) -> Result<FullFwd> {
+    let d = train.dims();
+    let gdn_dims = train.gdn_dims();
+    let cfg = train.model();
+    let rank = train.rank();
+    let scale = train.scale();
     let hidden = d.hidden;
     let seq = ctx.seq_len;
     let mut h = ctx.h_in.clone();
@@ -464,25 +752,18 @@ pub fn forward_full(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn eval_chain_nll(
     caches: &[SeqCtx],
     layers: &[LayerW<'_>],
     loras: &[LoraParams],
     gdn_loras: &[GdnLoraParams],
     head: &Head<'_>,
-    d: &Dims,
-    gdn_dims: &GdnDims,
-    cfg: &Qwen35Config,
-    rank: usize,
-    scale: f32,
+    train: &TrainCtx<'_>,
 ) -> Result<f32> {
     let mut nll_sum = 0.0f64;
     let mut n = 0usize;
     for ctx in caches {
-        let fwd = forward_full(
-            ctx, layers, loras, gdn_loras, head, d, gdn_dims, cfg, rank, scale,
-        )?;
+        let fwd = forward_full(ctx, layers, loras, gdn_loras, head, train)?;
         for p in &fwd.positions {
             nll_sum += position_nll(&p.logits, p.target) as f64;
             n += 1;
@@ -497,19 +778,19 @@ pub fn eval_chain_nll(
 /// `num_gdn_slots`/the returned `Vec<GdnLoraParams>` cover the GDN LoRA slots
 /// (surface-B, ported from lattice PR #202) — empty when no GDN layer in the
 /// materialised range carries a LoRA slot.
-#[allow(clippy::too_many_arguments)]
 pub fn nll_and_grads(
     fwd: &FullFwd,
     layers: &[LayerW<'_>],
     loras: &[LoraParams],
     head: &Head<'_>,
-    d: &Dims,
-    gdn_dims: &GdnDims,
-    num_slots: usize,
-    num_gdn_slots: usize,
-    rank: usize,
-    scale: f32,
+    train: &TrainCtx<'_>,
 ) -> Result<(f32, usize, Vec<Grads>, Vec<GdnLoraParams>)> {
+    let d = train.dims();
+    let gdn_dims = train.gdn_dims();
+    let rank = train.rank();
+    let scale = train.scale();
+    let num_slots = train.num_gqa_slots();
+    let num_gdn_slots = train.num_gdn_slots();
     let hidden = d.hidden;
     let seq = fwd.h_final.len() / hidden;
     let n_comp = fwd.positions.len().max(1) as f32;
@@ -658,17 +939,17 @@ pub fn rand_fill(rng: &mut u64, n: usize, amp: f32) -> Vec<f32> {
         .collect()
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn apply_adam_updates(
     adam: &mut AdamState,
     loras: &mut [LoraParams],
     grads: &[Grads],
-    slot_layers: &[usize],
-    lr: f32,
-    beta1: f32,
-    beta2: f32,
-    eps_adam: f32,
+    train: &TrainCtx<'_>,
 ) {
+    let slot_layers = train.gqa_layers();
+    let lr = train.learning_rate();
+    let beta1 = train.beta1();
+    let beta2 = train.beta2();
+    let eps_adam = train.epsilon();
     for slot in 0..slot_layers.len() {
         let li = slot_layers[slot];
         adam.step(
@@ -721,17 +1002,17 @@ pub fn apply_adam_updates(
 /// Adam step for the GDN LoRA slots (surface-B). Mirrors `apply_adam_updates`
 /// but steps all 5 GDN projections' A/B pairs (10 arrays/slot) instead of the
 /// 2 GQA projections' A/B pairs (4 arrays/slot).
-#[allow(clippy::too_many_arguments)]
 pub fn apply_gdn_adam_updates(
     adam: &mut AdamState,
     gdn_loras: &mut [GdnLoraParams],
     gdn_grads: &[GdnLoraParams],
-    slot_layers: &[usize],
-    lr: f32,
-    beta1: f32,
-    beta2: f32,
-    eps_adam: f32,
+    train: &TrainCtx<'_>,
 ) {
+    let slot_layers = train.gdn_layers();
+    let lr = train.learning_rate();
+    let beta1 = train.beta1();
+    let beta2 = train.beta2();
+    let eps_adam = train.epsilon();
     for slot in 0..slot_layers.len() {
         let li = slot_layers[slot];
         macro_rules! step {
@@ -827,17 +1108,38 @@ mod gdn_lora_tests {
         }
         let gdn_grads = vec![grads];
 
+        // apply_gdn_adam_updates only reads `train`'s gdn slot layout and Adam
+        // hyperparameters (not its geometry), so a real preset's consistent
+        // Dims/GdnDims/Qwen35Config triple is enough here — it need not match
+        // `gd` (the tiny fixture the GdnLoraParams shapes above were built
+        // from).
+        let cfg = Qwen35Config::qwen35_0_8b();
+        let dims = Dims {
+            hidden: cfg.hidden_size,
+            vocab: cfg.vocab_size,
+            num_q_heads: cfg.num_attention_heads,
+            num_kv_heads: cfg.num_key_value_heads,
+            head_dim: cfg.head_dim,
+            rope_dim: cfg.rope_dim(),
+            inter: cfg.intermediate_size,
+            q_dim: cfg.full_q_dim(),
+            kv_dim: cfg.full_kv_dim(),
+            eps: cfg.rms_norm_eps,
+        };
+        let real_gdn_dims = GdnDims::from_cfg(&cfg);
+        let gqa_layers: [usize; 0] = [];
+        let gdn_layers = [7usize];
+        let train = TrainCtx::try_new(
+            TapeGeometry::new(&dims, &real_gdn_dims, &cfg),
+            rank,
+            (rank as f32) * 2.0,
+            SlotLayout::new(&gqa_layers, &gdn_layers),
+            AdamConfig::new(0.1, 0.9, 0.999, 1e-8),
+        )
+        .expect("valid TrainCtx");
+
         let mut adam = AdamState::new();
-        apply_gdn_adam_updates(
-            &mut adam,
-            &mut gdn_loras,
-            &gdn_grads,
-            &[7],
-            0.1,
-            0.9,
-            0.999,
-            1e-8,
-        );
+        apply_gdn_adam_updates(&mut adam, &mut gdn_loras, &gdn_grads, &train);
 
         // Adam moves params opposite the gradient sign: positive grad -> param
         // decreases from its zero init; negative grad -> param increases.
@@ -853,5 +1155,250 @@ mod gdn_lora_tests {
         );
         // Untouched (zero-grad) arrays stay at their zero init.
         assert!(gdn_loras[0].a_z.iter().all(|&v| v == 0.0));
+    }
+}
+
+#[cfg(test)]
+mod train_ctx_tests {
+    use super::*;
+
+    /// A geometry triple that satisfies `TrainCtx::try_new`'s consistency
+    /// check by construction: `Dims`/`GdnDims` are derived from the same
+    /// `Qwen35Config` the way every real call site (`train.rs`,
+    /// `train_grad_full.rs`) builds them.
+    struct Geometry {
+        cfg: Qwen35Config,
+        dims: Dims,
+        gdn_dims: GdnDims,
+    }
+
+    fn valid_geometry() -> Geometry {
+        let cfg = Qwen35Config::qwen35_0_8b();
+        let dims = Dims {
+            hidden: cfg.hidden_size,
+            vocab: cfg.vocab_size,
+            num_q_heads: cfg.num_attention_heads,
+            num_kv_heads: cfg.num_key_value_heads,
+            head_dim: cfg.head_dim,
+            rope_dim: cfg.rope_dim(),
+            inter: cfg.intermediate_size,
+            q_dim: cfg.full_q_dim(),
+            kv_dim: cfg.full_kv_dim(),
+            eps: cfg.rms_norm_eps,
+        };
+        let gdn_dims = GdnDims::from_cfg(&cfg);
+        Geometry {
+            cfg,
+            dims,
+            gdn_dims,
+        }
+    }
+
+    fn valid_adam() -> AdamConfig {
+        AdamConfig::new(1e-3, 0.9, 0.999, 1e-8)
+    }
+
+    /// `TrainCtx` intentionally has no `Debug` impl (it borrows a `Qwen35Config`
+    /// among other things, and nothing needs to print one), so
+    /// `Result::unwrap_err` isn't available — extract the error message by hand.
+    fn expect_err(result: Result<TrainCtx<'_>>) -> String {
+        match result {
+            Ok(_) => panic!("expected TrainCtx::try_new to reject this input"),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    #[test]
+    fn try_new_accepts_valid_inputs() {
+        let g = valid_geometry();
+        let gqa = [19usize, 23];
+        let gdn = [20usize, 21, 22];
+        let train = TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        )
+        .expect("valid geometry/rank/slots/adam must construct a TrainCtx");
+        assert_eq!(train.num_gqa_slots(), 2);
+        assert_eq!(train.num_gdn_slots(), 3);
+        assert_eq!(train.rank(), 8);
+        assert!((train.scale() - 2.0).abs() < 1e-6); // alpha / rank = 16 / 8
+    }
+
+    /// Mutation-sensitive: an out-of-range GQA slot layer (>= num_hidden_layers)
+    /// must be rejected — without this guard the tape indexes
+    /// `model.weights.layers[idx]` (or an equivalent slot array) out of bounds.
+    #[test]
+    fn try_new_rejects_out_of_range_slot_layer() {
+        let g = valid_geometry();
+        let gqa = [g.cfg.num_hidden_layers]; // one past the last valid index
+        let gdn: [usize; 0] = [];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("out of range"),
+            "expected out-of-range rejection; got: {err}"
+        );
+    }
+
+    /// Mutation-sensitive: a duplicate layer index within one slot list must
+    /// be rejected — two slots claiming the same layer would silently alias
+    /// the same LoRA weights to two different gradient accumulators.
+    #[test]
+    fn try_new_rejects_duplicate_slot_layer() {
+        let g = valid_geometry();
+        let gqa = [19usize, 19];
+        let gdn: [usize; 0] = [];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("duplicate"),
+            "expected duplicate-layer rejection; got: {err}"
+        );
+    }
+
+    /// Mutation-sensitive: a layer index claimed by both the GQA and GDN
+    /// slot lists is a mixer-kind conflict — the same layer cannot be
+    /// trained as both mixer kinds in one materialised tape.
+    #[test]
+    fn try_new_rejects_mixer_kind_slot_index_mismatch() {
+        let g = valid_geometry();
+        let gqa = [19usize];
+        let gdn = [19usize];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("mixer-kind"),
+            "expected mixer-kind/slot-index mismatch rejection; got: {err}"
+        );
+    }
+
+    #[test]
+    fn try_new_rejects_zero_rank() {
+        let g = valid_geometry();
+        let gqa = [19usize];
+        let gdn: [usize; 0] = [];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+            0,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("rank"),
+            "expected rank-zero rejection; got: {err}"
+        );
+    }
+
+    /// Mutation-sensitive: non-finite alpha must be rejected before it can
+    /// propagate into `scale = alpha / rank` and poison every LoRA-scaled
+    /// forward/backward computation with NaN/inf.
+    #[test]
+    fn try_new_rejects_non_finite_alpha() {
+        let g = valid_geometry();
+        let gqa = [19usize];
+        let gdn: [usize; 0] = [];
+        for bad_alpha in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let err = expect_err(TrainCtx::try_new(
+                TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+                8,
+                bad_alpha,
+                SlotLayout::new(&gqa, &gdn),
+                valid_adam(),
+            ));
+            assert!(
+                err.contains("alpha"),
+                "expected alpha rejection for {bad_alpha}; got: {err}"
+            );
+        }
+    }
+
+    /// Mutation-sensitive: non-finite Adam hyperparameters (learning rate,
+    /// beta1, beta2, epsilon) must each be rejected — any one of them
+    /// propagates NaN/inf into every optimizer step.
+    #[test]
+    fn try_new_rejects_non_finite_adam_hyperparams() {
+        let g = valid_geometry();
+        let gqa = [19usize];
+        let gdn: [usize; 0] = [];
+        let cases: [(&str, AdamConfig); 4] = [
+            ("learning_rate", AdamConfig::new(f32::NAN, 0.9, 0.999, 1e-8)),
+            ("beta1", AdamConfig::new(1e-3, f32::INFINITY, 0.999, 1e-8)),
+            ("beta2", AdamConfig::new(1e-3, 0.9, f32::NEG_INFINITY, 1e-8)),
+            ("epsilon", AdamConfig::new(1e-3, 0.9, 0.999, f32::NAN)),
+        ];
+        for (name, adam) in cases {
+            let err = expect_err(TrainCtx::try_new(
+                TapeGeometry::new(&g.dims, &g.gdn_dims, &g.cfg),
+                8,
+                16.0,
+                SlotLayout::new(&gqa, &gdn),
+                adam,
+            ));
+            assert!(err.contains(name), "expected {name} rejection; got: {err}");
+        }
+    }
+
+    /// Mutation-sensitive: `Dims` built from a different model than
+    /// `TapeGeometry.model` must be rejected — this is the geometry-
+    /// consistency check the ten-argument signatures had no way to enforce.
+    #[test]
+    fn try_new_rejects_dims_model_mismatch() {
+        let g = valid_geometry();
+        let mut mismatched_dims = g.dims;
+        mismatched_dims.hidden += 1;
+        let gqa = [19usize];
+        let gdn: [usize; 0] = [];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&mismatched_dims, &g.gdn_dims, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("Dims"),
+            "expected Dims/model mismatch rejection; got: {err}"
+        );
+    }
+
+    /// Mutation-sensitive: `GdnDims` built from a different model than
+    /// `TapeGeometry.model` must be rejected, mirroring the `Dims` check.
+    #[test]
+    fn try_new_rejects_gdn_dims_model_mismatch() {
+        let g = valid_geometry();
+        let mut mismatched_gdn = g.gdn_dims;
+        mismatched_gdn.value_heads += 1;
+        let gqa = [19usize];
+        let gdn: [usize; 0] = [];
+        let err = expect_err(TrainCtx::try_new(
+            TapeGeometry::new(&g.dims, &mismatched_gdn, &g.cfg),
+            8,
+            16.0,
+            SlotLayout::new(&gqa, &gdn),
+            valid_adam(),
+        ));
+        assert!(
+            err.contains("GdnDims"),
+            "expected GdnDims/model mismatch rejection; got: {err}"
+        );
     }
 }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Introduces `TrainCtx` (+ `TapeGeometry`, `LoraExecution`, `SlotLayout`,
`AdamConfig`) in `crates/tune/src/lora/train_core.rs`, replacing the
ten-argument positional signatures on `forward_full`, `eval_chain_nll`,
`nll_and_grads`, `apply_adam_updates`, and `apply_gdn_adam_updates` with the
narrowed shapes from #844:

```rust
forward_full(seq, layers, gqa_loras, gdn_loras, head, train)
eval_chain_nll(seqs, layers, gqa_loras, gdn_loras, head, train)
nll_and_grads(fwd, layers, gqa_loras, head, train)
apply_adam_updates(adam, gqa_loras, grads, train)
apply_gdn_adam_updates(adam, gdn_loras, grads, train)
```

`TrainCtx::try_new` validates:
- `rank > 0`
- `alpha` and every Adam hyperparameter (`learning_rate`/`beta1`/`beta2`/`epsilon`) finite
- `Dims.eps` and `GdnDims.scale` finite (checked explicitly, ahead of the tolerance
  comparison below — `(a - b).abs() > 1e-9` is silently `false` for NaN and would
  otherwise let non-finite geometry through)
- `Dims`/`GdnDims` agree with `TapeGeometry.model` (recomputed via `GdnDims::from_cfg` and
  the same field derivations every call site already used)
- every GQA slot layer is actually a full-attention layer on `model`
  (`model.is_full_attention(li)`), and every GDN slot layer is actually a
  GatedDeltaNet layer (`!model.is_full_attention(li)`) — not just "unique and
  in-range," the real per-layer mixer kind
- GQA/GDN slot-layer indices are each unique, in-range for `model.num_hidden_layers`, and
  never claim the same layer index for both mixer kinds (mixer-kind/slot-index agreement)

`scale = alpha / rank` is derived once inside `try_new` and held privately in
`LoraExecution` — never stored as `alpha`, never exported. All of `TrainCtx`'s
internal accessors (`gqa_layers`/`gdn_layers`/`rank`/`scale`/`dims`/`gdn_dims`/
`model`/the four Adam getters) are module-private `fn`, not `pub fn` — every
consumer is inside `train_core.rs`. The only public surface issue #844 asks
for, `num_gqa_slots()`/`num_gdn_slots()`, stays `pub`.

Both `#[allow(clippy::too_many_arguments)]` escapes are removed.

## Migrated call sites

- `crates/tune/src/lora/train.rs` (`train_micro_lora`)
- `crates/tune/src/bin/train_grad_full.rs` (TBV check, gradcheck mode, training mode)

`train_grad_layer23.rs` and `train_grad.rs` are **untouched** — both define their
own fully self-contained local types (`Lora`, `Grads`, local `nll_and_grads`) and
never import from `train_core`, so they are out of scope per #844's Sequencing
section ("Does not touch `train_grad_layer23.rs`").

## Non-goals honored

No math, CLI, initialization, or serialization changed — this is a
signature/type refactor only. `TrainCtx` owns geometry, layout, and optimizer
policy only (no weights/caches/gradients/LoRA vectors/optimizer state). No new
adapter-descriptor governance (issue #615 scope untouched).

## Tests added

`crates/tune/src/lora/train_core.rs` — `train_ctx_tests` module (14 tests):
- `try_new_accepts_valid_inputs`
- `try_new_rejects_out_of_range_slot_layer`
- `try_new_rejects_duplicate_slot_layer`
- `try_new_rejects_mixer_kind_slot_index_mismatch` (same layer claimed by both lists)
- `try_new_rejects_gqa_slot_layer_wrong_kind` (one-sided: a real GDN layer claimed as GQA)
- `try_new_rejects_gdn_slot_layer_wrong_kind` (one-sided: a real GQA layer claimed as GDN)
- `try_new_rejects_gqa_gdn_slot_swap_19_20` (codex round-1's exact repro: `gqa=[20]`,
  `gdn=[19]` on the 0.8B preset — both wrong, simultaneously; pre-fix this constructed
  successfully)
- `try_new_rejects_zero_rank`
- `try_new_rejects_non_finite_alpha`
- `try_new_rejects_non_finite_adam_hyperparams`
- `try_new_rejects_non_finite_dims_eps` (NaN-bypasses-tolerance regression test)
- `try_new_rejects_non_finite_gdn_scale` (NaN-bypasses-tolerance regression test)
- `try_new_rejects_dims_model_mismatch`
- `try_new_rejects_gdn_dims_model_mismatch`

Each rejection test is mutation-sensitive by construction (asserts on
`TuneError::Validation`; the pre-refactor code had no way to reject these
inputs at all). I verified mutation-sensitivity directly: neutralized the four
new guards (mixer-kind × 2, `eps`/`scale` finiteness × 2) with `if false &&`,
confirmed exactly the 5 corresponding new tests fail (`try_new_rejects_gqa_
slot_layer_wrong_kind`, `_gdn_slot_layer_wrong_kind`, `_gqa_gdn_slot_swap_19_
20`, `_non_finite_dims_eps`, `_non_finite_gdn_scale`), then reverted.

Updated the existing `apply_gdn_adam_updates_moves_nonzero_grad_params` test:
it previously claimed layer 7 (a full-attention layer on the 0.8B preset) as a
GDN slot, which the new kind check now correctly rejects — switched the
fixture to layer 20 (a real GatedDeltaNet layer) and rebuilds a `TrainCtx`
through the public constructors.

## Gates

- **`cargo fmt --check -p lattice-tune`**: clean.
- **`cargo clippy -p lattice-tune --features train-backward --bins --tests -- -D warnings`**: clean.
- **`cargo clippy --workspace --features lattice-tune/train-backward --tests --bins -- -D warnings`**: clean, both `too_many_arguments` allows removed.
- **`cargo test -p lattice-tune --features train-backward --lib --bins`**: 270 lib tests + 2 `train_grad_full` bin tests, all pass (0 failed, 1 ignored — pre-existing `#[ignore]` placeholder unrelated to this PR).
- **Primitive gradchecks** (issue's "existing primitive gradchecks... unaffected"): `cargo test -p lattice-inference --features train-backward,f16 --lib gdn_backward` (6 pass, incl. `gradcheck_gdn_backward`, `gradcheck_gdn_lora_weight_grads[_multi_head]`) and `--lib attention_gqa` (4 pass, incl. `gqa_lora_gradcheck`) — both crates unaffected by this refactor, confirmed green.
- **Real-model TBV**: ran `train_grad_full` against the local `qwen3.5-0.8b` checkpoint (`~/.lattice/models/qwen3.5-0.8b`). TBV (assembled chain NLL vs `Qwen35Model::compute_token_nlls`) passed at both `--first-layer 19` (diff `3.10e-6`) and `--first-layer 23` (diff `4.05e-6`), both well under the `1e-2` gate.
- **Training-mode smoke test**: 5-step run at `--first-layer 19` on real weights — train NLL fell `1.3709 → 0.2936`, held-out NLL fell `1.7192 → 1.3360`, no errors. Exercises `forward_full`/`nll_and_grads`/`apply_adam_updates`/`apply_gdn_adam_updates` end-to-end through `TrainCtx` on both GQA and GDN slots.
- **Full-tape `--gradcheck` at layers 19 and 23**: ran against the real checkpoint. With only a synthetic 2-sample smoke dataset (no `data/lora-train` fixture ships in the repo — it's a caller-supplied `--data-dir`), the finite-difference probe reported `FAIL` at both layers (e.g. layer 19 slot 0 `a_q`: mean `3.03e-2` max `1.04e-1`; layer 23 slot 0 `a_q`: mean `9.48e-2` max `3.28e-1`). **This is not a regression**: I built a second worktree pinned to this PR's exact pre-refactor base commit (`d18f50ebb`, `crates/tune` at the old ten-argument signatures) and ran the identical command/dataset — the FAIL lines match the refactored build to displayed precision at both layers (byte-identical mean/max per array, e.g. layer 19 `a_q` mean `3.03e-2` max `1.04e-1` on both builds; layer 23 all 4 arrays match exactly). The refactor computes bit-identical numbers; the FAIL itself is a pre-existing property of this ad-hoc 2-token-completion dataset (no committed fixture exists to gradcheck against), not something #844 introduced or is scoped to fix.
- **Mutation gate**: covered by the new `try_new_rejects_gqa_gdn_slot_swap_19_20`, `try_new_rejects_gqa_slot_layer_wrong_kind`, and `try_new_rejects_gdn_slot_layer_wrong_kind` tests (a slot-index swap onto the wrong mixer kind is rejected by construction — `TrainCtx` cannot exist with an inconsistent layout, so there is no runtime call site left to swap a slot index at). Mutation-sensitivity of these plus the two NaN-geometry tests was verified directly (see Tests added above).
- **Bench-compare**: not applicable — this PR touches only `crates/tune`, no changes to `crates/inference/src` (confirmed via `git diff --stat`).

## Spec deviations

None. Followed #844's struct definitions, narrowed signatures, and Gates/Sequencing sections as written.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] SIMD intrinsics, if any, were manually verified — not just reviewed by an AI (n/a — no SIMD in this diff)
- [x] Any agent-authored comment / PR body / issue starts with the attribution line from AGENTS.md
- [x] `cargo test` output included for any behavior-changing code; `cargo bench` output for perf-sensitive changes (n/a — no perf-sensitive change; bench-compare not applicable, see Gates)

Refs #844
