### PR TITLE
chore(inference): deprecate crate::generate module and Qwen35Model::generate_with_batch_prefill on 0.5.x (remove in 0.6.0)

### DIFF
--- a/crates/inference/src/forward/batch_prefill.rs
+++ b/crates/inference/src/forward/batch_prefill.rs
@@ -6,11 +6,13 @@
 //! If you instead wire it from `lib.rs`, the same code works after promoting the
 //! touched internals to `pub(crate)`.
 //!
-//! The legacy `generate()` method already exists in `qwen35_model.rs`, so this
-//! module exposes the replacement body as `generate_with_batch_prefill()` to
-//! avoid a duplicate inherent-method definition. Integration is a one-line swap:
-//! either rename this method to `generate`, or have the existing `generate()`
-//! delegate to it.
+//! This module's `Qwen35Model::prefill_tokens_batched_for_generate` batched-prefill
+//! core is what the canonical `Qwen35Model::generate` / `generate_streaming`
+//! (`crates/inference/src/model/qwen35/generation.rs`) delegate their own prefill phase
+//! to (PR #680). [`Qwen35Model::generate_with_batch_prefill`] predates that delegation:
+//! it is a standalone, now-redundant decode loop built directly on the same core and is
+//! **deprecated** as of 0.5.1 (issue #807) — new callers should use the canonical
+//! `generate` / `generate_streaming` methods instead.
 //!
 //! LoRA adapters are applied per-token in all projection steps, matching the
 //! decode path. Each `matmul_bt` over the `[seq_len, dim]` batch is followed by
@@ -361,15 +363,26 @@ impl Qwen35Model {
         )
     }
 
-    /// **Unstable**: batched prefill generate; API will stabilize once legacy generate is removed.
+    /// **Unstable**: batched prefill generate.
     ///
-    /// Replacement generate body that uses `prefill_prompt()` for the prompt
+    /// A standalone generate body that uses `prefill_prompt()` for the prompt
     /// phase and then falls back to the existing single-token decode loop.
     ///
-    /// Rename this method to `generate()` once the legacy implementation is
-    /// removed from `qwen35_model.rs`, or have the legacy `generate()` delegate
-    /// to this method.
-    #[allow(dead_code)] // TODO(#1958): roadmap — replace legacy generate() once prefill API stabilises
+    /// This method predates the canonical [`Qwen35Model::generate`] /
+    /// [`Qwen35Model::generate_streaming`] delegating their own prefill phase to
+    /// `Self::prefill_tokens_batched_for_generate` (the same batched-prefill core
+    /// this method calls internally, see `crates/inference/src/model/qwen35/generation.rs`
+    /// around line 153). That delegation, wired in PR #680, made this method's
+    /// independent decode loop redundant; it has no production caller (issue #807).
+    #[deprecated(
+        since = "0.5.1",
+        note = "generate_with_batch_prefill is repository-dead and duplicates the canonical \
+                Qwen3.5 decode loop (Qwen35Model::generate / generate_streaming, which already \
+                delegate their prefill phase to the same batched-prefill core this method calls). \
+                Migrate to Qwen35Model::generate / generate_streaming. \
+                Scheduled for removal in 0.6.0."
+    )]
+    #[allow(dead_code)] // TODO(#1958): roadmap — remove in 0.6.0 (tracked by issue #807's follow-up removal PR)
     pub fn generate_with_batch_prefill(
         &self,
         prompt: &str,
@@ -1210,6 +1223,7 @@ fn softplus_prefill(x: f32) -> f32 {
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // exercises generate_with_batch_prefill itself during its deprecation window (issue #807)
 mod tests {
     use super::*;
     use crate::lora_hook::LoraHook;

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -11,6 +11,43 @@
 //!                        ↓                           ↓
 //!                   fill KV cache              append to KV cache
 //! ```
+//!
+//! # Deprecated (since 0.5.1, removal targeted for 0.6.0)
+//!
+//! This module's decode loop (built on [`crate::model::QwenModel`]/[`crate::model::QwenConfig`])
+//! is repository-dead: an exact-reference sweep of the workspace finds no production caller
+//! (bin, example, library, or app), only this module's own tests, doc comments, and a benchmark
+//! wrapper around its unrelated `compute_attention` internals. It duplicates the canonical
+//! Qwen3.5 decode loop ([`crate::model::Qwen35Model::generate`] /
+//! [`crate::model::Qwen35Model::generate_streaming`]), which has been the actively maintained
+//! path since PR #680 wired the batched-prefill core directly into it.
+//!
+//! **Embedding users** (consumers of [`crate::model::QwenModel`] via `lattice-embed`) are
+//! unaffected by this deprecation — `QwenModel::encode` is live production code (ADR-017) and
+//! nothing it depends on is being removed. Only the generic text-decode stack built on top of it
+//! (`generate`, `GenerateConfig`, `GenerateOutput` — all in this module) is being retired.
+//!
+//! **Text-generation users** should migrate to [`crate::model::Qwen35Model::generate`] /
+//! [`crate::model::Qwen35Model::generate_streaming`] and [`crate::model::GenerateConfig`] (the
+//! Qwen3.5 model's own config type, distinct from this module's `GenerateConfig`). The two
+//! `GenerateConfig`/`GenerateOutput` pairs are **not** drop-in compatible; verified field-by-field
+//! mapping (read at source, `crates/inference/src/model/qwen35_config.rs`):
+//!
+//! | This module (`crate::generate::GenerateConfig`) | Canonical (`crate::model::GenerateConfig`) | Notes |
+//! |---|---|---|
+//! | `max_new_tokens: usize` | `max_new_tokens: usize` | same name and meaning |
+//! | `sampling: SamplingConfig` | `temperature`, `top_k`, `top_p`, `repetition_penalty` | canonical flattens the nested `SamplingConfig` into top-level fields |
+//! | `eos_token_id: Option<u32>` | *(none — read from `Qwen35Config::eos_token_id`)* | canonical EOS is fixed per loaded model, not per-request; use `stop_token_ids: Vec<u32>` for additional per-request stop tokens |
+//! | `include_prompt: bool` | *(no equivalent)* | canonical `generate`/`generate_streaming` **always** exclude the prompt from `GenerateOutput::text`/`token_ids` — there is no option to include it. A caller relying on `include_prompt = true` must prepend the prompt string to `GenerateOutput::text` itself after calling the canonical path. |
+//! | `grammar: Option<Arc<GrammarEngine>>` | `grammar: Option<Arc<GrammarEngine>>` | same name and type |
+//! | `kv_cache_capacity: Option<usize>` | *(no equivalent)* | canonical path sizes its KV cache from `prompt_len` + the effective decode cap; there is no opt-in per-request cache-capacity clamp |
+//!
+//! `GenerateOutput`'s `stop_reason`/stop-token-exclusion contract is unchanged in the canonical
+//! type (see `crates/inference/src/stop_token_contract.rs`), so no migration is needed there
+//! beyond the field differences above.
+//!
+//! Both APIs in this module continue to work exactly as before during the deprecation window —
+//! this is a notice-only change, not a behavior change.
 
 use crate::attention::gqa::GqaConfig;
 use crate::error::InferenceError;
@@ -24,6 +61,14 @@ use std::sync::Arc;
 
 /// **Unstable**: text generation configuration; fields and defaults are
 /// subject to change as the generation API matures.
+#[deprecated(
+    since = "0.5.1",
+    note = "crate::generate is repository-dead and duplicates the canonical Qwen3.5 decode loop; \
+            text-generation users should migrate to Qwen35Model::generate / generate_streaming \
+            with model::GenerateConfig (embedding users of QwenModel are unaffected). \
+            See the module-level migration guide in crates/inference/src/generate.rs. \
+            Scheduled for removal in 0.6.0."
+)]
 #[derive(Clone)]
 pub struct GenerateConfig {
     /// Maximum number of new tokens to generate.
@@ -55,6 +100,7 @@ pub struct GenerateConfig {
     pub kv_cache_capacity: Option<usize>,
 }
 
+#[allow(deprecated)] // Self is already deprecated; this impl only needs to keep compiling during the window (issue #807)
 impl std::fmt::Debug for GenerateConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GenerateConfig")
@@ -68,6 +114,7 @@ impl std::fmt::Debug for GenerateConfig {
     }
 }
 
+#[allow(deprecated)] // Self is already deprecated; this impl only needs to keep compiling during the window (issue #807)
 impl Default for GenerateConfig {
     fn default() -> Self {
         Self {
@@ -91,6 +138,14 @@ impl Default for GenerateConfig {
 /// in this crate honours this contract (see the `stop_token_contract` test
 /// module for the cross-path regression sweep). `generated_tokens` always
 /// equals `token_ids.len()`.
+#[deprecated(
+    since = "0.5.1",
+    note = "crate::generate is repository-dead and duplicates the canonical Qwen3.5 decode loop; \
+            text-generation users should migrate to Qwen35Model::generate / generate_streaming \
+            with model::qwen35_config::GenerateOutput (embedding users of QwenModel are unaffected). \
+            See the module-level migration guide in crates/inference/src/generate.rs. \
+            Scheduled for removal in 0.6.0."
+)]
 #[derive(Debug)]
 pub struct GenerateOutput {
     /// The generated text (excluding prompt unless include_prompt is set).
@@ -409,6 +464,15 @@ fn has_finite_logit(logits: &[f32]) -> bool {
 /// Qwen3 models tie `lm_head` weights with `embed_tokens` (transposed).
 /// The logits are computed as: `logits = hidden_state @ embed_tokens^T`.
 /// This avoids loading a separate lm_head weight.
+#[deprecated(
+    since = "0.5.1",
+    note = "crate::generate::generate is repository-dead and duplicates the canonical Qwen3.5 \
+            decode loop; text-generation users should migrate to Qwen35Model::generate / \
+            generate_streaming (embedding users of QwenModel are unaffected). \
+            See the module-level migration guide in crates/inference/src/generate.rs. \
+            Scheduled for removal in 0.6.0."
+)]
+#[allow(deprecated)] // body reads/constructs the equally-deprecated GenerateConfig/GenerateOutput fields (issue #807)
 pub fn generate(
     model: &QwenModel,
     prompt: &str,
@@ -1228,6 +1292,7 @@ pub mod bench_support {
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // covers this deprecation window's own regression tests (issue #807)
 mod tests {
     use super::*;
 

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -40,11 +40,19 @@
 //! | `eos_token_id: Option<u32>` | *(none — read from `Qwen35Config::eos_token_id`)* | canonical EOS is fixed per loaded model, not per-request; use `stop_token_ids: Vec<u32>` for additional per-request stop tokens |
 //! | `include_prompt: bool` | *(no equivalent)* | canonical `generate`/`generate_streaming` **always** exclude the prompt from `GenerateOutput::text`/`token_ids` — there is no option to include it. A caller relying on `include_prompt = true` must prepend the prompt string to `GenerateOutput::text` itself after calling the canonical path. |
 //! | `grammar: Option<Arc<GrammarEngine>>` | `grammar: Option<Arc<GrammarEngine>>` | same name and type |
-//! | `kv_cache_capacity: Option<usize>` | *(no equivalent)* | canonical path sizes its KV cache from `prompt_len` + the effective decode cap; there is no opt-in per-request cache-capacity clamp |
+//! | `kv_cache_capacity: Option<usize>` | *(no equivalent)* | the canonical cache has no per-request capacity clamp: it reserves the prompt length on the dense batched-prefill path and grows as decode appends tokens |
 //!
-//! `GenerateOutput`'s `stop_reason`/stop-token-exclusion contract is unchanged in the canonical
-//! type (see `crates/inference/src/stop_token_contract.rs`), so no migration is needed there
-//! beyond the field differences above.
+//! `GenerateOutput` field mapping (the two output types are also NOT drop-in compatible):
+//!
+//! | this module's `GenerateOutput` | canonical `model::GenerateOutput` | notes |
+//! |---|---|---|
+//! | `text: String` | `text: String` | same meaning (canonical never includes the prompt) |
+//! | `token_ids: Vec<u32>` | `token_ids: Vec<u32>` | same stop-token-exclusion contract (see `crate::stop_token_contract`) |
+//! | `prompt_tokens: usize` | `prompt_tokens: usize` | same |
+//! | `generated_tokens: usize` | `generated_tokens: usize` | same |
+//! | `stopped_by_eos: bool` | `stopped: bool` | **broader semantics**: canonical `stopped` is true for ANY stop condition (EOS, stop token, or stop string), not only EOS. Callers needing EOS-specific behavior must check `stop_reason == Some(StopReason::Eos)` instead. |
+//! | `stop_reason: Option<StopReason>` | `stop_reason: Option<StopReason>` | same |
+//! | *(none)* | `token_logprobs: Vec<TokenLogprob>` | new in the canonical type; empty unless `GenerateConfig::logprobs` was requested |
 //!
 //! Both APIs in this module continue to work exactly as before during the deprecation window —
 //! this is a notice-only change, not a behavior change.

--- a/crates/inference/src/stop_token_contract.rs
+++ b/crates/inference/src/stop_token_contract.rs
@@ -253,6 +253,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // exercises the deprecated path itself during its deprecation window (issue #807)
     fn qwen35_model_generate_with_batch_prefill_excludes_stop_token() {
         let model = zero_layer_qwen35_model();
         let out = model

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,6 +152,14 @@ This section traces the decoder (Qwen3) generate path end to end. All references
 `crates/inference/src/` unless a full path is given. The encoder (BERT/BGE) path is
 structurally similar but uses bidirectional attention and skips the KV cache and decode loop.
 
+**Deprecated (since 0.5.1, removal targeted for 0.6.0, issue #807):** `crate::generate` (the
+path traced below) is repository-dead — it has no production caller — and duplicates the
+canonical, actively maintained Qwen3.5 decode loop. Text-generation users should use
+`Qwen35Model::generate` / `Qwen35Model::generate_streaming` instead; see the
+[Qwen3.5 Generation Path](#qwen35-generation-path) section below. This trace is kept for anyone
+still debugging the deprecated path during its deprecation window; embedding users of
+`QwenModel` (via `lattice-embed`) are unaffected either way.
+
 ### 1. Model Load
 
 `QwenModel::load` (`model/qwen.rs`) opens the model directory and calls
@@ -314,7 +322,8 @@ local safetensors directory -> Qwen35Model::from_safetensors
   -> load_weights                                    (model/qwen35/loading.rs)
   -> BpeTokenizer::from_tokenizer_json                (tokenizer.json)
   -> Tokenizer::tokenize(prompt)                      (tokenizer/common.rs)
-  -> prefill_prompt                                   (forward/batch_prefill.rs)
+  -> prefill_tokens_batched_for_generate              (forward/batch_prefill.rs)
+       -> prefill_prompt                              (forward/batch_prefill.rs)
   -> sample_token (first generated token)             (model/qwen35/sampling.rs)
   -> forward_step (decode loop, one call per token)   (model/qwen35/forward.rs)
   -> sample_token (each subsequent generated token)
@@ -323,11 +332,19 @@ local safetensors directory -> Qwen35Model::from_safetensors
 `Qwen35Model::from_safetensors` (`model/qwen35/model.rs`) resolves either `model.safetensors` or
 a sharded `model.safetensors.index.json`, validates the required tensor names against the
 config, then calls `load_weights` to materialize embedding, layer, and norm weights, and loads
-the tokenizer from `tokenizer.json`. Generation itself (`Qwen35Model::generate_with_batch_prefill`,
-`forward/batch_prefill.rs`) tokenizes the prompt with `Tokenizer::tokenize`, runs a single batched
-`prefill_prompt` pass over the whole prompt, samples the first token with `sample_token`, then
-enters a decode loop that calls the single-token `forward_step` (`model/qwen35/forward.rs`) and
+the tokenizer from `tokenizer.json`. Generation itself is the canonical `Qwen35Model::generate` /
+`Qwen35Model::generate_streaming` (`model/qwen35/generation.rs`): both tokenize the prompt with
+`Tokenizer::tokenize`, then delegate their prefill phase to
+`Qwen35Model::prefill_tokens_batched_for_generate` (`forward/batch_prefill.rs`), which runs a
+single batched `prefill_prompt` pass over the whole prompt (PR #680) and returns the final
+prompt position's logits. Both then sample the first token with `sample_token`, and enter a
+decode loop that calls the single-token `forward_step` (`model/qwen35/forward.rs`) and
 `sample_token` once per generated token.
+
+Note: `Qwen35Model::generate_with_batch_prefill` (`forward/batch_prefill.rs`) is a separate,
+**deprecated** (since 0.5.1, issue #807) standalone decode loop that predates the delegation
+above — it calls the same batched-prefill core directly but is not the canonical entry point.
+New callers should use `Qwen35Model::generate` / `generate_streaming`.
 
 Note: the tokenizer trait method is `tokenize`, not `encode` — `encode` is a method on the
 separate `QwenModel` embedding path (`model/qwen.rs`), not on the `Tokenizer` trait used here.


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

- Marks `crate::generate`'s exported items (`GenerateConfig`, `GenerateOutput`, `generate`) and `Qwen35Model::generate_with_batch_prefill` `#[deprecated(since = "0.5.1", ...)]`, scheduled for removal in 0.6.0. Both paths are repository-dead (no production caller — bin, example, library, or app) and duplicate the canonical, actively maintained Qwen3.5 decode loop (`Qwen35Model::generate` / `generate_streaming`, which already delegates its prefill phase to the same batched-prefill core via PR #680).
- **No code removed, no behavior change.** This is a deprecation-notice-only PR: every deprecated item keeps compiling and working exactly as before during the deprecation window.
- Adds a module-level migration guide in `crates/inference/src/generate.rs` (verified field-by-field `GenerateConfig` mapping, read at source) and corrects `docs/architecture.md`'s prose/trace, which previously described `Qwen35Model::generate_with_batch_prefill` as the generation entry point — the actually-canonical entry points are `Qwen35Model::generate` / `generate_streaming`.
- Fixes two stale doc comments in `crates/inference/src/forward/batch_prefill.rs` left over from before PR #680's delegation landed (they said `generate_with_batch_prefill` was slated to become/replace `generate()`, which is now backwards).

## Migration mapping summary (full table in `generate.rs` module docs)

| `crate::generate::GenerateConfig` | Canonical (`crate::model::GenerateConfig`) | Notes |
|---|---|---|
| `max_new_tokens: usize` | `max_new_tokens: usize` | same |
| `sampling: SamplingConfig` | `temperature`, `top_k`, `top_p`, `repetition_penalty` | canonical flattens the nested config |
| `eos_token_id: Option<u32>` | *(none — read from `Qwen35Config::eos_token_id`)* | canonical EOS is fixed per loaded model; use `stop_token_ids` for extra per-request stops |
| `include_prompt: bool` | *(no equivalent)* | canonical `generate`/`generate_streaming` **always** exclude the prompt from `GenerateOutput::text`/`token_ids` — verified at source (`model/qwen35_config.rs`, `GenerateOutput::text` doc: "excluding prompt"). Callers must prepend the prompt themselves if they need it. |
| `grammar: Option<Arc<GrammarEngine>>` | `grammar: Option<Arc<GrammarEngine>>` | same |
| `kv_cache_capacity: Option<usize>` | *(no equivalent)* | canonical path has no opt-in per-request cache-capacity clamp |

Embedding users (`QwenModel` via `lattice-embed`) are unaffected — `QwenModel::encode` is untouched (ADR-017); only the generic text-decode stack built on top of it is being retired.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean (via the heavy-lane gate)
- [x] `cargo test -p lattice-inference --lib` — 1683 passed, 0 failed, 18 ignored (same counts as pre-diff; deprecated paths keep their existing coverage via targeted `#[allow(deprecated)]` on their own tests/impls, not crate-wide)
- [x] `cargo doc -p lattice-inference --no-deps --lib` with `RUSTDOCFLAGS="-D warnings"` — this diff introduces **zero new** broken intra-doc links. Baseline (pre-diff, `6768f8911`) already has 6 unrelated pre-existing rustdoc errors (`encode_batch`/`bert.rs`, `mtp_verify_draft*`/`speculative.rs`, one `unresolved link to generate` in `model/qwen35/generation.rs`); this branch has exactly the same 6, verified by diffing the error list against baseline. The repo's actual doc gate, `make lint-docs`, passes clean (markdown lint + capability-matrix fixture check; does not invoke rustdoc).
- [x] `cargo semver-checks check-release -p lattice-inference --baseline-rev 6768f8911` — **196 checks: 196 pass, 57 skip. Summary: no semver update required.** Confirms the diff is additive/non-breaking (deprecation attributes alone don't break semver).
- [x] `cargo bench -p lattice-inference --bench compute_attention_bench --features bench-internals --no-run` — compiles clean (untouched by this PR; its removal is scoped to the follow-up 0.6.0 PR)
- Semver class: **non-breaking / additive** (deprecation notice only). Confirmed by `cargo semver-checks` above.
- bench-compare: **N/A by construction** — every changed hunk in `crates/inference/src/generate.rs`, `crates/inference/src/forward/batch_prefill.rs`, and `crates/inference/src/stop_token_contract.rs` is either a `#[deprecated(...)]` attribute, an `#[allow(deprecated)]` attribute, or a doc comment; `docs/architecture.md` is prose-only. No executable code path changed. Verified by re-reading the diff hunk-by-hunk before opening this PR.

## ADR

n/a — small fix, no ADR (deprecation-notice-only, tracked by issue #807 and its follow-up 0.6.0 removal issues).

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] SIMD intrinsics, if any, were manually verified — not just reviewed by an AI (n/a — no SIMD touched)
- [x] Any agent-authored comment / PR body / issue starts with the attribution line from AGENTS.md
- [x] `cargo test` output included for any behavior-changing code; `cargo bench` output for perf-sensitive changes (n/a for behavior — see test plan above for the actual `cargo test` counts)

## Out of scope

- No code removal (that's the follow-up 0.6.0 PRs referenced in issue #807's "Depended on by" section).
- `docs/forward-pass.md` still references `crate::generate::generate` descriptively (not as "the" canonical path) — left untouched; issue #807 scoped the doc fix to `docs/architecture.md` specifically.
- No behavior change of any kind — this is deprecation-notice only.

Closes #807
