### PR TITLE
refactor(inference): one canonical model-format detector, remove the duplicated decision sites

### DIFF
--- a/crates/inference/src/bin/bench_decode_ab.rs
+++ b/crates/inference/src/bin/bench_decode_ab.rs
@@ -36,6 +36,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     use lattice_inference::forward::metal_qwen35::{ChatMessage, MetalQwen35State};
     use lattice_inference::model::qwen35::Qwen35Model;
     use lattice_inference::model::qwen35_config::{GenerateConfig, Qwen35Config};
+    use lattice_inference::model_format::{ModelFormat, detect_format};
     use lattice_inference::tokenizer::{BpeTokenizer, Tokenizer};
 
     let home = std::env::var("HOME")?;
@@ -52,19 +53,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(5);
 
-    // Detect Q4 dir (no model.safetensors, has .q4 files) — same dispatch as chat_metal.
-    let is_q4_dir = !dir.join("model.safetensors").exists()
-        && std::fs::read_dir(dir)
-            .ok()
-            .and_then(|mut entries| {
-                entries.find(|e| {
-                    e.as_ref()
-                        .ok()
-                        .and_then(|e| e.file_name().to_str().map(|n| n.ends_with(".q4")))
-                        .unwrap_or(false)
-                })
-            })
-            .is_some();
+    // Detect Q4 dir via the canonical detector — same dispatch as chat_metal.
+    // Unknown falls through to the safetensors branch below, matching this
+    // binary's pre-existing two-way (Q4 / not-Q4) behavior exactly.
+    let is_q4 = matches!(detect_format(dir), ModelFormat::Q4);
 
     let tokenizer_dir_str =
         std::env::var("LATTICE_TOKENIZER_DIR").unwrap_or_else(|_| model_dir_str.clone());
@@ -72,7 +64,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!(
         "[bench] loading {model_dir_str} ({})",
-        if is_q4_dir { "Q4" } else { "safetensors" }
+        if is_q4 { "Q4" } else { "safetensors" }
     );
 
     // Two ownership paths: Q4 owns a separately-loaded tokenizer; safetensors
@@ -81,7 +73,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut metal: MetalQwen35State;
     let tokenizer: BpeTokenizer;
 
-    if is_q4_dir {
+    if is_q4 {
         let cfg = if dir.join("config.json").exists() {
             Qwen35Config::from_config_json(&dir.join("config.json"))
                 .map_err(|e| format!("config.json parse: {e}"))?

--- a/crates/inference/src/bin/bench_decode_ab.rs
+++ b/crates/inference/src/bin/bench_decode_ab.rs
@@ -55,7 +55,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // Detect Q4 dir via the canonical detector — same dispatch as chat_metal.
     // Unknown falls through to the safetensors branch below, matching this
-    // binary's pre-existing two-way (Q4 / not-Q4) behavior exactly.
+    // binary's pre-existing two-way (Q4 / not-Q4) dispatch, with one
+    // corrected exception: the old inline heuristic here only checked
+    // model.safetensors, never model.safetensors.index.json, so a directory
+    // with an index file *and* stray .q4 files used to route to the Q4
+    // loader; the canonical index-aware detector now routes it to
+    // safetensors instead (the precedence this binary inherits going
+    // forward).
     let is_q4 = matches!(detect_format(dir), ModelFormat::Q4);
 
     let tokenizer_dir_str =

--- a/crates/inference/src/bin/bench_decode_slopefit.rs
+++ b/crates/inference/src/bin/bench_decode_slopefit.rs
@@ -114,7 +114,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // Detect Q4 dir via the canonical detector (same dispatch as bench_decode_ab).
     // Unknown falls through to the safetensors branch below, matching this
-    // binary's pre-existing two-way (Q4 / not-Q4) behavior exactly.
+    // binary's pre-existing two-way (Q4 / not-Q4) dispatch, with one
+    // corrected exception: the old inline heuristic here only checked
+    // model.safetensors, never model.safetensors.index.json, so a directory
+    // with an index file *and* stray .q4 files used to route to the Q4
+    // loader; the canonical index-aware detector now routes it to
+    // safetensors instead (the precedence this binary inherits going
+    // forward).
     let is_q4 = matches!(detect_format(dir), ModelFormat::Q4);
 
     let tokenizer_dir_str =

--- a/crates/inference/src/bin/bench_decode_slopefit.rs
+++ b/crates/inference/src/bin/bench_decode_slopefit.rs
@@ -70,6 +70,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     use lattice_inference::forward::metal_qwen35::MetalQwen35State;
     use lattice_inference::model::qwen35::Qwen35Model;
     use lattice_inference::model::qwen35_config::{GenerateConfig, Qwen35Config};
+    use lattice_inference::model_format::{ModelFormat, detect_format};
     use lattice_inference::tokenizer::{BpeTokenizer, Tokenizer};
 
     let home = std::env::var("HOME")?;
@@ -111,19 +112,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let max_ctx = grid.iter().copied().max().unwrap_or(512);
 
-    // Detect Q4 dir (same heuristic as bench_decode_ab).
-    let is_q4_dir = !dir.join("model.safetensors").exists()
-        && std::fs::read_dir(dir)
-            .ok()
-            .and_then(|mut entries| {
-                entries.find(|e| {
-                    e.as_ref()
-                        .ok()
-                        .and_then(|e| e.file_name().to_str().map(|n| n.ends_with(".q4")))
-                        .unwrap_or(false)
-                })
-            })
-            .is_some();
+    // Detect Q4 dir via the canonical detector (same dispatch as bench_decode_ab).
+    // Unknown falls through to the safetensors branch below, matching this
+    // binary's pre-existing two-way (Q4 / not-Q4) behavior exactly.
+    let is_q4 = matches!(detect_format(dir), ModelFormat::Q4);
 
     let tokenizer_dir_str =
         std::env::var("LATTICE_TOKENIZER_DIR").unwrap_or_else(|_| model_dir_str.clone());
@@ -131,7 +123,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!(
         "[slopefit] loading {model_dir_str} ({})",
-        if is_q4_dir { "Q4" } else { "safetensors" }
+        if is_q4 { "Q4" } else { "safetensors" }
     );
 
     // Tokenizer first — the KV cache must hold the *padded* prompt, and the pad
@@ -165,7 +157,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Load model — same dual ownership pattern as bench_decode_ab.
     let mut metal: MetalQwen35State;
 
-    if is_q4_dir {
+    if is_q4 {
         let cfg = if dir.join("config.json").exists() {
             Qwen35Config::from_config_json(&dir.join("config.json"))
                 .map_err(|e| format!("config.json parse: {e}"))?

--- a/crates/inference/src/bin/bench_logit_dump.rs
+++ b/crates/inference/src/bin/bench_logit_dump.rs
@@ -57,7 +57,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("[bench_logit_dump] tokens: {} positions", tokens.len());
 
     // Unknown falls through to the safetensors branch below, matching this
-    // binary's pre-existing two-way (Q4 / not-Q4) behavior exactly.
+    // binary's pre-existing two-way (Q4 / not-Q4) dispatch, with one
+    // corrected exception: the old inline heuristic here only checked
+    // model.safetensors, never model.safetensors.index.json, so a directory
+    // with an index file *and* stray .q4 files used to route to the Q4
+    // loader; the canonical index-aware detector now routes it to
+    // safetensors instead (the precedence this binary inherits going
+    // forward).
     let is_q4 = matches!(detect_format(dir), ModelFormat::Q4);
 
     let (mut metal, cfg) = if is_q4 {

--- a/crates/inference/src/bin/bench_logit_dump.rs
+++ b/crates/inference/src/bin/bench_logit_dump.rs
@@ -30,6 +30,7 @@ fn main() {
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     use lattice_inference::forward::metal_qwen35::MetalQwen35State;
     use lattice_inference::model::qwen35::Qwen35Model;
+    use lattice_inference::model_format::{ModelFormat, detect_format};
 
     let home = std::env::var("HOME")?;
     let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
@@ -55,20 +56,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("[bench_logit_dump] loading {model_dir_str}");
     eprintln!("[bench_logit_dump] tokens: {} positions", tokens.len());
 
-    let is_q4_dir = !dir.join("model.safetensors").exists()
-        && std::fs::read_dir(dir)
-            .ok()
-            .and_then(|mut e| {
-                e.find(|e| {
-                    e.as_ref()
-                        .ok()
-                        .and_then(|e| e.file_name().to_str().map(|n| n.ends_with(".q4")))
-                        .unwrap_or(false)
-                })
-            })
-            .is_some();
+    // Unknown falls through to the safetensors branch below, matching this
+    // binary's pre-existing two-way (Q4 / not-Q4) behavior exactly.
+    let is_q4 = matches!(detect_format(dir), ModelFormat::Q4);
 
-    let (mut metal, cfg) = if is_q4_dir {
+    let (mut metal, cfg) = if is_q4 {
         let cfg = lattice_inference::model::qwen35_config::Qwen35Config::from_config_json(
             &dir.join("config.json"),
         )

--- a/crates/inference/src/bin/chat_metal.rs
+++ b/crates/inference/src/bin/chat_metal.rs
@@ -628,6 +628,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     use lattice_inference::model::qwen35_config::{
         GenerateConfig, QWEN_CHAT_IM_END_TOKEN_ID, Qwen35Config,
     };
+    use lattice_inference::model_format::{self, ModelFormat};
     use lattice_inference::tokenizer::bpe::BpeTokenizer;
     use std::io::Write;
 
@@ -703,19 +704,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let dir = model_dir.as_path();
 
-    let is_q4_dir = !dir.join("model.safetensors").exists()
-        && !dir.join("model.safetensors.index.json").exists()
-        && std::fs::read_dir(dir)
-            .ok()
-            .and_then(|mut entries| {
-                entries.find(|e| {
-                    e.as_ref()
-                        .ok()
-                        .and_then(|e| e.file_name().to_str().map(|n| n.ends_with(".q4")))
-                        .unwrap_or(false)
-                })
-            })
-            .is_some();
+    let format = model_format::detect_format(dir);
 
     // Tokenizer lives alongside the model; for Q4 models --tokenizer-dir or env var override.
     let tokenizer_dir_str = parse_arg(&args, "--tokenizer-dir")
@@ -735,58 +724,59 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     // ── Load model ───────────────────────────────────────────────────────────
 
     let mut metal;
-    let model_format; // "bf16" | "q4"
+    let model_format_label; // "bf16" | "q4"
 
-    if is_q4_dir {
-        eprintln!(
-            "[chat_metal] Detected Q4 model directory: {}",
-            dir.display()
-        );
-        let cfg = if dir.join("config.json").exists() {
-            Qwen35Config::from_config_json(&dir.join("config.json"))
-                .map_err(|e| format!("failed to parse config.json: {e}"))?
-        } else {
-            eprintln!("[chat_metal] No config.json; using qwen36_27b preset");
-            Qwen35Config::qwen36_27b()
-        };
-        eprintln!("[chat_metal] Loading Q4 model...");
-        let t0 = std::time::Instant::now();
-        metal =
-            MetalQwen35State::from_q4_dir(dir, &tokenizer_dir.join("tokenizer.json"), &cfg, 4096)
-                .map_err(|e| format!("failed to initialize Metal from Q4 dir: {e}"))?;
-        eprintln!(
-            "[chat_metal] Q4 model loaded in {:.1}s",
-            t0.elapsed().as_secs_f64()
-        );
-        model_format = "q4";
-    } else {
-        if !dir.join("model.safetensors").exists()
-            && !dir.join("model.safetensors.index.json").exists()
-        {
-            return Err(format!(
-                "no model found at {} (expected model.safetensors or .q4 files)",
+    match format {
+        ModelFormat::Q4 => {
+            eprintln!(
+                "[chat_metal] Detected Q4 model directory: {}",
                 dir.display()
+            );
+            let cfg = if dir.join("config.json").exists() {
+                Qwen35Config::from_config_json(&dir.join("config.json"))
+                    .map_err(|e| format!("failed to parse config.json: {e}"))?
+            } else {
+                eprintln!("[chat_metal] No config.json; using qwen36_27b preset");
+                Qwen35Config::qwen36_27b()
+            };
+            eprintln!("[chat_metal] Loading Q4 model...");
+            let t0 = std::time::Instant::now();
+            metal = MetalQwen35State::from_q4_dir(
+                dir,
+                &tokenizer_dir.join("tokenizer.json"),
+                &cfg,
+                4096,
             )
-            .into());
+            .map_err(|e| format!("failed to initialize Metal from Q4 dir: {e}"))?;
+            eprintln!(
+                "[chat_metal] Q4 model loaded in {:.1}s",
+                t0.elapsed().as_secs_f64()
+            );
+            model_format_label = "q4";
         }
-        eprintln!("[chat_metal] Loading bf16 model from {}...", dir.display());
-        let t0 = std::time::Instant::now();
-        let model =
-            Qwen35Model::from_safetensors(dir).map_err(|e| format!("failed to load model: {e}"))?;
-        let cfg = model.config().clone();
-        eprintln!(
-            "[chat_metal] Model loaded in {:.1}s",
-            t0.elapsed().as_secs_f64()
-        );
-        eprintln!("[chat_metal] Initializing Metal GPU...");
-        let t1 = std::time::Instant::now();
-        metal = MetalQwen35State::new(model.weights(), &cfg, 4096)
-            .map_err(|e| format!("failed to init Metal: {e}"))?;
-        eprintln!(
-            "[chat_metal] Metal ready in {:.1}s",
-            t1.elapsed().as_secs_f64()
-        );
-        model_format = "bf16";
+        ModelFormat::Safetensors => {
+            eprintln!("[chat_metal] Loading bf16 model from {}...", dir.display());
+            let t0 = std::time::Instant::now();
+            let model = Qwen35Model::from_safetensors(dir)
+                .map_err(|e| format!("failed to load model: {e}"))?;
+            let cfg = model.config().clone();
+            eprintln!(
+                "[chat_metal] Model loaded in {:.1}s",
+                t0.elapsed().as_secs_f64()
+            );
+            eprintln!("[chat_metal] Initializing Metal GPU...");
+            let t1 = std::time::Instant::now();
+            metal = MetalQwen35State::new(model.weights(), &cfg, 4096)
+                .map_err(|e| format!("failed to init Metal: {e}"))?;
+            eprintln!(
+                "[chat_metal] Metal ready in {:.1}s",
+                t1.elapsed().as_secs_f64()
+            );
+            model_format_label = "bf16";
+        }
+        ModelFormat::Unknown => {
+            return Err(model_format::unrecognized_format_message(dir).into());
+        }
     }
 
     // ── Load LoRA adapter (if requested) ────────────────────────────────────
@@ -925,7 +915,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     &mut metal,
                     &tokenizer,
                     &req_cfg,
-                    model_format,
+                    model_format_label,
                     lora_tag,
                 ) {
                     eprintln!("[chat_metal] serve: generation stopped: {e}");
@@ -947,7 +937,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             &mut metal,
             &tokenizer,
             &gen_cfg,
-            model_format,
+            model_format_label,
             lora_tag,
         )?;
         return Ok(());
@@ -958,7 +948,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     use std::io::BufRead;
 
     let lora_tag = if has_lora { "+LoRA" } else { "" };
-    eprintln!("\n=== GPU Metal {model_format}{lora_tag} — Qwen3.5 Chat ===");
+    eprintln!("\n=== GPU Metal {model_format_label}{lora_tag} — Qwen3.5 Chat ===");
     eprintln!("Type your message. Empty line or Ctrl-D to quit.\n");
 
     let system_msg = ChatMessage::system("You are a helpful assistant. Be concise and direct.");
@@ -1025,7 +1015,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             0.0
         };
         eprintln!(
-            "[{} prompt + {} gen in {:.1}ms = {:.1} tok/s | GPU Metal {model_format} | cache: {:?} reused {}/{}]",
+            "[{} prompt + {} gen in {:.1}ms = {:.1} tok/s | GPU Metal {model_format_label} | cache: {:?} reused {}/{}]",
             result.prompt_tokens,
             result.completion_tokens,
             elapsed.as_secs_f64() * 1000.0,

--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -84,198 +84,21 @@ enum Command {
 // backend: model-directory format detection + Q4/Metal loading
 //
 // `lattice chat`/`lattice serve` originally only understood a safetensors
-// directory (`model.safetensors` or a sharded index). This module adds
-// support for native Q4 quantized directories (per-tensor `.q4` files, the
-// output of `quantize_q4`) by detecting the format up front and routing to
-// the Metal GPU forward pass. Safetensors directories are completely
+// directory (`model.safetensors` or a sharded index). Native Q4 quantized
+// directories (per-tensor `.q4` files, the output of `quantize_q4`) route to
+// the Metal GPU forward pass instead. Safetensors directories are completely
 // unaffected: `detect_format` returns `Safetensors` for them exactly as
 // before, and the safetensors load path is untouched.
+//
+// The detector itself (`ModelFormat` + `detect_format` + the two error
+// message helpers) now lives in `lattice_inference::model_format` (ADR-080
+// amendment, #829): it is shared, unmodified, with `lattice_serve.rs` and
+// `chat_metal.rs`, which cannot see a `pub(crate)` item defined in this
+// binary's own crate root. `backend` here is a local alias so every existing
+// `backend::...` / `crate::backend::...` call site below is unchanged.
 // ---------------------------------------------------------------------------
 
-mod backend {
-    use std::path::Path;
-
-    /// The on-disk format of a model directory, decided before any tensor I/O.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub enum ModelFormat {
-        /// `model.safetensors` or `model.safetensors.index.json` present.
-        Safetensors,
-        /// No safetensors file, but at least one `*.q4` tensor file present
-        /// (the output of `quantize_q4`).
-        Q4,
-        /// Neither a safetensors file nor a `.q4` file was found.
-        Unknown,
-    }
-
-    /// Detect whether `dir` is a safetensors model directory, a native Q4
-    /// quantized directory, or neither.
-    ///
-    /// Mirrors the detection heuristic already shipped in `chat_metal.rs` and
-    /// `lattice_serve.rs`: a directory is Q4 when it has no safetensors file
-    /// and contains at least one file whose name ends in `.q4`.
-    pub fn detect_format(dir: &Path) -> ModelFormat {
-        if dir.join("model.safetensors").exists()
-            || dir.join("model.safetensors.index.json").exists()
-        {
-            return ModelFormat::Safetensors;
-        }
-        let has_q4_file = std::fs::read_dir(dir)
-            .ok()
-            .and_then(|mut entries| {
-                entries.find(|e| {
-                    e.as_ref()
-                        .ok()
-                        .and_then(|e| e.file_name().to_str().map(|n| n.ends_with(".q4")))
-                        .unwrap_or(false)
-                })
-            })
-            .is_some();
-        if has_q4_file {
-            ModelFormat::Q4
-        } else {
-            ModelFormat::Unknown
-        }
-    }
-
-    /// Error message shown when a Q4 directory is passed to a binary that was
-    /// built without the `metal-gpu` feature. Q4 inference only runs on the
-    /// Metal GPU forward pass; there is no CPU fallback for `.q4` tensors, so
-    /// this is a hard, fail-closed error rather than a silent degrade.
-    ///
-    /// Only reachable from the `#[cfg(not(feature = "metal-gpu"))]` call sites
-    /// in `run_chat` / `main`; a `metal-gpu` build never calls this (it loads
-    /// Q4 directories instead), so it is legitimately unused in that
-    /// configuration rather than by mistake.
-    #[cfg_attr(feature = "metal-gpu", allow(dead_code))]
-    pub fn metal_gpu_required_message(dir: &Path) -> String {
-        format!(
-            "model directory '{}' is a native Q4 quantized checkpoint, which requires \
-             the Metal GPU forward pass. This binary was built without the `metal-gpu` \
-             feature. Rebuild with `--features \"f16 metal-gpu\"` (macOS only), or point \
-             --model at a safetensors directory instead.",
-            dir.display()
-        )
-    }
-
-    /// Error message for a directory that is neither safetensors nor Q4.
-    pub fn unrecognized_format_message(dir: &Path) -> String {
-        format!(
-            "'{}' is not a recognized model directory: no model.safetensors, \
-             model.safetensors.index.json, or *.q4 tensor files were found",
-            dir.display()
-        )
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use std::fs;
-
-        fn tempdir(name: &str) -> std::path::PathBuf {
-            let mut dir = std::env::temp_dir();
-            dir.push(format!(
-                "lattice-backend-test-{name}-{}-{}",
-                std::process::id(),
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_nanos())
-                    .unwrap_or(0)
-            ));
-            fs::create_dir_all(&dir).expect("create tempdir");
-            dir
-        }
-
-        #[test]
-        fn detect_format_safetensors_file() {
-            let dir = tempdir("safetensors-file");
-            fs::write(dir.join("model.safetensors"), b"stub").unwrap();
-            assert_eq!(detect_format(&dir), ModelFormat::Safetensors);
-            fs::remove_dir_all(&dir).ok();
-        }
-
-        #[test]
-        fn detect_format_safetensors_index_only() {
-            let dir = tempdir("safetensors-index");
-            fs::write(dir.join("model.safetensors.index.json"), b"{}").unwrap();
-            assert_eq!(detect_format(&dir), ModelFormat::Safetensors);
-            fs::remove_dir_all(&dir).ok();
-        }
-
-        #[test]
-        fn detect_format_q4_dir() {
-            let dir = tempdir("q4");
-            fs::write(dir.join("model_layers_0_weight.q4"), b"stub").unwrap();
-            fs::write(dir.join("config.json"), b"{}").unwrap();
-            assert_eq!(detect_format(&dir), ModelFormat::Q4);
-            fs::remove_dir_all(&dir).ok();
-        }
-
-        #[test]
-        fn detect_format_prefers_safetensors_over_q4_files() {
-            // A directory that (unusually) has both a safetensors file and a
-            // stray .q4 file must resolve as Safetensors — the safetensors
-            // loader path is untouched and takes priority.
-            let dir = tempdir("mixed");
-            fs::write(dir.join("model.safetensors"), b"stub").unwrap();
-            fs::write(dir.join("leftover.q4"), b"stub").unwrap();
-            assert_eq!(detect_format(&dir), ModelFormat::Safetensors);
-            fs::remove_dir_all(&dir).ok();
-        }
-
-        #[test]
-        fn detect_format_empty_dir_is_unknown() {
-            let dir = tempdir("empty");
-            assert_eq!(detect_format(&dir), ModelFormat::Unknown);
-            fs::remove_dir_all(&dir).ok();
-        }
-
-        #[test]
-        fn detect_format_unrelated_files_is_unknown() {
-            let dir = tempdir("unrelated");
-            fs::write(dir.join("readme.txt"), b"hello").unwrap();
-            fs::write(dir.join("config.json"), b"{}").unwrap();
-            assert_eq!(detect_format(&dir), ModelFormat::Unknown);
-            fs::remove_dir_all(&dir).ok();
-        }
-
-        #[test]
-        fn metal_gpu_required_message_mentions_rebuild_flags() {
-            let msg = metal_gpu_required_message(Path::new("/tmp/some-q4-dir"));
-            assert!(msg.contains("metal-gpu"));
-            assert!(msg.contains("--features"));
-        }
-
-        #[test]
-        fn unrecognized_format_message_mentions_expected_files() {
-            let msg = unrecognized_format_message(Path::new("/tmp/bogus"));
-            assert!(msg.contains("model.safetensors"));
-            assert!(msg.contains(".q4"));
-        }
-
-        // Fail-closed without metal-gpu: a Q4 directory must never silently
-        // fall back to the CPU safetensors loader. This test only compiles
-        // (and only means anything) when the binary is built WITHOUT the
-        // metal-gpu feature — it asserts that the code path this binary
-        // would take for a Q4 directory is the explicit error message above,
-        // never `Qwen35Model::from_safetensors`.
-        #[cfg(not(feature = "metal-gpu"))]
-        #[test]
-        fn q4_dir_without_metal_gpu_feature_fails_closed() {
-            let dir = tempdir("q4-no-metal");
-            fs::write(dir.join("model_layers_0_weight.q4"), b"stub").unwrap();
-            assert_eq!(detect_format(&dir), ModelFormat::Q4);
-            // Scope: detection + message content only. This proves a Q4 dir
-            // classifies as `ModelFormat::Q4` (so the `run_chat`/`main` match
-            // arms take the fail-closed branch, never
-            // `Qwen35Model::from_safetensors`) and that the error names the
-            // rebuild flags. It does not drive `run_chat`/`main` themselves —
-            // those exit the process, which a unit test cannot cross.
-            let msg = metal_gpu_required_message(&dir);
-            assert!(msg.contains("metal-gpu"));
-            fs::remove_dir_all(&dir).ok();
-        }
-    }
-}
+use lattice_inference::model_format as backend;
 
 // ---------------------------------------------------------------------------
 // doctor subcommand: memory-fit + artifact-compatibility preflight

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -72,6 +72,7 @@ mod imp {
     use lattice_inference::model::qwen35_config::{
         GenerateConfig, QWEN_CHAT_IM_END_TOKEN_ID, Qwen35Config,
     };
+    use lattice_inference::model_format::{self, ModelFormat};
     use lattice_inference::tokenizer::Tokenizer as _;
     use lattice_inference::tokenizer::bpe::BpeTokenizer;
     use serde::Deserialize;
@@ -1057,12 +1058,12 @@ mod imp {
     fn spawn_worker(
         model_dir: std::path::PathBuf,
         tokenizer_path: std::path::PathBuf,
-        is_q4: bool,
+        format: ModelFormat,
         ready: std::sync::mpsc::Sender<Result<WorkerReady, String>>,
     ) -> mpsc::UnboundedSender<Job> {
         let (job_tx, job_rx) = mpsc::unbounded_channel::<Job>();
         std::thread::spawn(move || {
-            let loaded = load_model(&model_dir, &tokenizer_path, is_q4);
+            let loaded = load_model(&model_dir, &tokenizer_path, format);
             let LoadedModel {
                 mut metal,
                 tokenizer,
@@ -1226,48 +1227,56 @@ mod imp {
     fn load_model(
         model_dir: &std::path::Path,
         tokenizer_path: &std::path::Path,
-        is_q4: bool,
+        format: ModelFormat,
     ) -> Result<LoadedModel, String> {
         let tokenizer = BpeTokenizer::from_tokenizer_json(tokenizer_path)
             .map_err(|e| format!("tokenizer load failed ({}): {e}", tokenizer_path.display()))?;
 
-        if is_q4 {
-            let has_config_json = model_dir.join("config.json").exists();
-            let cfg = if has_config_json {
-                Qwen35Config::from_config_json(&model_dir.join("config.json"))
-                    .map_err(|e| format!("config.json parse failed: {e}"))?
-            } else {
-                Qwen35Config::qwen36_27b()
-            };
-            let requested_context = if has_config_json {
-                model_context_from_config(Some(&cfg))
-            } else {
-                model_context_from_config(None)
-            };
-            let metal =
-                MetalQwen35State::from_q4_dir(model_dir, tokenizer_path, &cfg, requested_context)
-                    .map_err(|e| format!("Q4 model load failed: {e}"))?;
-            let model_max_context = metal.max_context();
-            Ok(LoadedModel {
-                metal,
-                tokenizer,
-                format: "q4".to_string(),
-                model_max_context,
-            })
-        } else {
-            let model = Qwen35Model::from_safetensors(model_dir)
-                .map_err(|e| format!("safetensors load failed: {e}"))?;
-            let cfg = model.config().clone();
-            let requested_context = model_context_from_config(Some(&cfg));
-            let metal = MetalQwen35State::new(model.weights(), &cfg, requested_context)
-                .map_err(|e| format!("Metal init failed: {e}"))?;
-            let model_max_context = metal.max_context();
-            Ok(LoadedModel {
-                metal,
-                tokenizer,
-                format: "bf16".to_string(),
-                model_max_context,
-            })
+        match format {
+            ModelFormat::Q4 => {
+                let has_config_json = model_dir.join("config.json").exists();
+                let cfg = if has_config_json {
+                    Qwen35Config::from_config_json(&model_dir.join("config.json"))
+                        .map_err(|e| format!("config.json parse failed: {e}"))?
+                } else {
+                    Qwen35Config::qwen36_27b()
+                };
+                let requested_context = if has_config_json {
+                    model_context_from_config(Some(&cfg))
+                } else {
+                    model_context_from_config(None)
+                };
+                let metal = MetalQwen35State::from_q4_dir(
+                    model_dir,
+                    tokenizer_path,
+                    &cfg,
+                    requested_context,
+                )
+                .map_err(|e| format!("Q4 model load failed: {e}"))?;
+                let model_max_context = metal.max_context();
+                Ok(LoadedModel {
+                    metal,
+                    tokenizer,
+                    format: "q4".to_string(),
+                    model_max_context,
+                })
+            }
+            ModelFormat::Safetensors => {
+                let model = Qwen35Model::from_safetensors(model_dir)
+                    .map_err(|e| format!("safetensors load failed: {e}"))?;
+                let cfg = model.config().clone();
+                let requested_context = model_context_from_config(Some(&cfg));
+                let metal = MetalQwen35State::new(model.weights(), &cfg, requested_context)
+                    .map_err(|e| format!("Metal init failed: {e}"))?;
+                let model_max_context = metal.max_context();
+                Ok(LoadedModel {
+                    metal,
+                    tokenizer,
+                    format: "bf16".to_string(),
+                    model_max_context,
+                })
+            }
+            ModelFormat::Unknown => Err(model_format::unrecognized_format_message(model_dir)),
         }
     }
 
@@ -1867,22 +1876,6 @@ mod imp {
         }
     }
 
-    fn detect_q4(dir: &std::path::Path) -> bool {
-        !dir.join("model.safetensors").exists()
-            && !dir.join("model.safetensors.index.json").exists()
-            && std::fs::read_dir(dir)
-                .ok()
-                .and_then(|mut entries| {
-                    entries.find(|e| {
-                        e.as_ref()
-                            .ok()
-                            .and_then(|e| e.file_name().to_str().map(|n| n.ends_with(".q4")))
-                            .unwrap_or(false)
-                    })
-                })
-                .is_some()
-    }
-
     /// Builds the daemon's router in isolation from `run()`'s process
     /// startup (arg parsing, model loading, binding a listener) so tests --
     /// including the cross-binary parity table in
@@ -1916,7 +1909,7 @@ mod imp {
         if !model_dir.exists() {
             return Err(format!("model directory not found: {}", model_dir.display()).into());
         }
-        let is_q4 = detect_q4(&model_dir);
+        let format = model_format::detect_format(&model_dir);
         let tokenizer_path = parse_arg(&args, "--tokenizer-dir")
             .map(|d| std::path::Path::new(&d).join("tokenizer.json"))
             .unwrap_or_else(|| model_dir.join("tokenizer.json"));
@@ -1955,10 +1948,14 @@ mod imp {
         eprintln!(
             "[lattice_serve] loading model from {} ({}) ...",
             model_dir.display(),
-            if is_q4 { "q4" } else { "bf16" }
+            match format {
+                ModelFormat::Q4 => "q4",
+                ModelFormat::Safetensors => "bf16",
+                ModelFormat::Unknown => "unknown",
+            }
         );
         let (ready_tx, ready_rx) = std::sync::mpsc::channel();
-        let jobs = spawn_worker(model_dir.clone(), tokenizer_path, is_q4, ready_tx);
+        let jobs = spawn_worker(model_dir.clone(), tokenizer_path, format, ready_tx);
         let WorkerReady {
             format: fmt,
             model_max_context,

--- a/crates/inference/src/lib.rs
+++ b/crates/inference/src/lib.rs
@@ -36,6 +36,10 @@ pub mod forward;
 /// Model configs and loaders (BERT, Qwen, Qwen3.5, BitNet). Each submodule owns its
 /// safetensors load path and forward-pass dispatch; see [`weights`], [`tokenizer`], and [`forward`].
 pub mod model;
+/// Canonical model-directory format detector (`ModelFormat`/`detect_format`) shared by
+/// the `lattice`, `lattice_serve`, and `chat_metal` binaries (ADR-080 amendment, #829).
+/// **Unstable, internal-binaries-only** -- see the module's own doc comment.
+pub mod model_format;
 /// Tokenizer implementations (`WordPiece`, `SentencePiece`, byte-level BPE) behind the
 /// [`Tokenizer`] trait, plus the [`load_tokenizer`] auto-detect helper. See [`model`].
 pub mod tokenizer;

--- a/crates/inference/src/model_format.rs
+++ b/crates/inference/src/model_format.rs
@@ -1,0 +1,215 @@
+//! Canonical model-directory format detector (ADR-080 amendment, #829).
+//!
+//! **Stability**: unstable, internal-binaries-only. This module exists solely
+//! so the three serving/chat binaries in `src/bin/` (`lattice`, `lattice_serve`,
+//! `chat_metal`) -- which are separate Cargo binary targets and therefore
+//! cannot see one another's `pub(crate)` items -- can share a single
+//! model-directory format decision instead of each carrying its own copy. It
+//! is not part of `lattice-inference`'s documented public API and may change
+//! shape without a semver-relevant deprecation cycle; downstream consumers of
+//! this crate should go through [`crate::model`] and [`crate::forward`]
+//! instead. See the crate-level `Stability tier: Experimental` note in
+//! `lib.rs` and `docs/adr/ADR-080-consolidation-duplicated-contracts.md`
+//! (implementation record amendment) for the full rationale.
+//!
+//! Before this module existed, the same detection logic (and the same
+//! precedence rule -- a `model.safetensors`/`model.safetensors.index.json`
+//! file always wins over a `.q4` tensor file, and an unreadable or
+//! non-matching directory fails closed to [`ModelFormat::Unknown`]) was
+//! implemented independently in `bin/lattice.rs` (`backend::detect_format`,
+//! enum-valued, with its own unit tests), `bin/lattice_serve.rs`
+//! (`detect_q4`, bool-valued), and `bin/chat_metal.rs` (`is_q4_dir`,
+//! bool-valued, plus a fourth, partial decision site that only re-checked
+//! safetensors absence inside the non-Q4 branch). All three binaries now
+//! match on this single [`ModelFormat`] enum; none re-checks sentinel files
+//! after the match.
+
+use std::path::Path;
+
+/// The on-disk format of a model directory, decided before any tensor I/O.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelFormat {
+    /// `model.safetensors` or `model.safetensors.index.json` present.
+    Safetensors,
+    /// No safetensors file, but at least one `*.q4` tensor file present
+    /// (the output of `quantize_q4`).
+    Q4,
+    /// Neither a safetensors file nor a `.q4` file was found.
+    Unknown,
+}
+
+/// Detect whether `dir` is a safetensors model directory, a native Q4
+/// quantized directory, or neither.
+///
+/// A directory is Q4 when it has no safetensors file and contains at least
+/// one file whose name ends in `.q4`. Safetensors presence always wins over
+/// `.q4` presence (a directory containing both resolves to `Safetensors`),
+/// and an unreadable directory (`read_dir` failure) or one matching neither
+/// pattern resolves to `Unknown` -- fail-closed, never a silent guess.
+pub fn detect_format(dir: &Path) -> ModelFormat {
+    if dir.join("model.safetensors").exists() || dir.join("model.safetensors.index.json").exists() {
+        return ModelFormat::Safetensors;
+    }
+    let has_q4_file = std::fs::read_dir(dir)
+        .ok()
+        .and_then(|mut entries| {
+            entries.find(|e| {
+                e.as_ref()
+                    .ok()
+                    .and_then(|e| e.file_name().to_str().map(|n| n.ends_with(".q4")))
+                    .unwrap_or(false)
+            })
+        })
+        .is_some();
+    if has_q4_file {
+        ModelFormat::Q4
+    } else {
+        ModelFormat::Unknown
+    }
+}
+
+/// Error message shown when a Q4 directory is passed to a binary that was
+/// built without the `metal-gpu` feature. Q4 inference only runs on the
+/// Metal GPU forward pass; there is no CPU fallback for `.q4` tensors, so
+/// this is a hard, fail-closed error rather than a silent degrade.
+pub fn metal_gpu_required_message(dir: &Path) -> String {
+    format!(
+        "model directory '{}' is a native Q4 quantized checkpoint, which requires \
+         the Metal GPU forward pass. This binary was built without the `metal-gpu` \
+         feature. Rebuild with `--features \"f16 metal-gpu\"` (macOS only), or point \
+         --model at a safetensors directory instead.",
+        dir.display()
+    )
+}
+
+/// Error message for a directory that is neither safetensors nor Q4.
+pub fn unrecognized_format_message(dir: &Path) -> String {
+    format!(
+        "'{}' is not a recognized model directory: no model.safetensors, \
+         model.safetensors.index.json, or *.q4 tensor files were found",
+        dir.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tempdir(name: &str) -> std::path::PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "lattice-model-format-test-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        fs::create_dir_all(&dir).expect("create tempdir");
+        dir
+    }
+
+    #[test]
+    fn detect_format_safetensors_file() {
+        let dir = tempdir("safetensors-file");
+        fs::write(dir.join("model.safetensors"), b"stub").unwrap();
+        assert_eq!(detect_format(&dir), ModelFormat::Safetensors);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn detect_format_safetensors_index_only() {
+        let dir = tempdir("safetensors-index");
+        fs::write(dir.join("model.safetensors.index.json"), b"{}").unwrap();
+        assert_eq!(detect_format(&dir), ModelFormat::Safetensors);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn detect_format_q4_dir() {
+        let dir = tempdir("q4");
+        fs::write(dir.join("model_layers_0_weight.q4"), b"stub").unwrap();
+        fs::write(dir.join("config.json"), b"{}").unwrap();
+        assert_eq!(detect_format(&dir), ModelFormat::Q4);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn detect_format_prefers_safetensors_over_q4_files() {
+        // A directory that (unusually) has both a safetensors file and a
+        // stray .q4 file must resolve as Safetensors — the safetensors
+        // loader path is untouched and takes priority.
+        let dir = tempdir("mixed");
+        fs::write(dir.join("model.safetensors"), b"stub").unwrap();
+        fs::write(dir.join("leftover.q4"), b"stub").unwrap();
+        assert_eq!(detect_format(&dir), ModelFormat::Safetensors);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn detect_format_empty_dir_is_unknown() {
+        let dir = tempdir("empty");
+        assert_eq!(detect_format(&dir), ModelFormat::Unknown);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn detect_format_unrelated_files_is_unknown() {
+        let dir = tempdir("unrelated");
+        fs::write(dir.join("readme.txt"), b"hello").unwrap();
+        fs::write(dir.join("config.json"), b"{}").unwrap();
+        assert_eq!(detect_format(&dir), ModelFormat::Unknown);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn detect_format_unreadable_dir_is_unknown() {
+        // A directory that does not exist at all: `read_dir` fails, and the
+        // fail-closed path (`.ok()` -> `None` -> `is_some() == false`) must
+        // resolve to `Unknown` rather than panicking or defaulting to a
+        // recognized format.
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "lattice-model-format-test-does-not-exist-{}",
+            std::process::id()
+        ));
+        assert_eq!(detect_format(&dir), ModelFormat::Unknown);
+    }
+
+    #[test]
+    fn metal_gpu_required_message_mentions_rebuild_flags() {
+        let msg = metal_gpu_required_message(Path::new("/tmp/some-q4-dir"));
+        assert!(msg.contains("metal-gpu"));
+        assert!(msg.contains("--features"));
+    }
+
+    #[test]
+    fn unrecognized_format_message_mentions_expected_files() {
+        let msg = unrecognized_format_message(Path::new("/tmp/bogus"));
+        assert!(msg.contains("model.safetensors"));
+        assert!(msg.contains(".q4"));
+    }
+
+    // Fail-closed without metal-gpu: a Q4 directory must never silently
+    // fall back to the CPU safetensors loader. This test only compiles
+    // (and only means anything) when the binary is built WITHOUT the
+    // metal-gpu feature — it asserts that the code path this binary
+    // would take for a Q4 directory is the explicit error message above,
+    // never `Qwen35Model::from_safetensors`.
+    #[cfg(not(feature = "metal-gpu"))]
+    #[test]
+    fn q4_dir_without_metal_gpu_feature_fails_closed() {
+        let dir = tempdir("q4-no-metal");
+        fs::write(dir.join("model_layers_0_weight.q4"), b"stub").unwrap();
+        assert_eq!(detect_format(&dir), ModelFormat::Q4);
+        // Scope: detection + message content only. This proves a Q4 dir
+        // classifies as `ModelFormat::Q4` (so a caller's `match` takes the
+        // fail-closed branch, never a safetensors load) and that the error
+        // names the rebuild flags. It does not drive any binary's `main`
+        // itself — those exit the process, which a unit test cannot cross.
+        let msg = metal_gpu_required_message(&dir);
+        assert!(msg.contains("metal-gpu"));
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/inference/src/model_format.rs
+++ b/crates/inference/src/model_format.rs
@@ -5,10 +5,12 @@
 //! `chat_metal`) -- which are separate Cargo binary targets and therefore
 //! cannot see one another's `pub(crate)` items -- can share a single
 //! model-directory format decision instead of each carrying its own copy. It
-//! is not part of `lattice-inference`'s documented public API and may change
-//! shape without a semver-relevant deprecation cycle; downstream consumers of
-//! this crate should go through [`crate::model`] and [`crate::forward`]
-//! instead. See the crate-level `Stability tier: Experimental` note in
+//! is public but unstable and internal-use: `pub mod model_format` is
+//! externally nameable, but its compatibility follows the crate's
+//! Experimental stability policy rather than semver-relevant deprecation
+//! cycles, and it may change shape at any time; downstream consumers of this
+//! crate should go through [`crate::model`] and [`crate::forward`] instead.
+//! See the crate-level `Stability tier: Experimental` note in
 //! `lib.rs` and `docs/adr/ADR-080-consolidation-duplicated-contracts.md`
 //! (implementation record amendment) for the full rationale.
 //!

--- a/crates/inference/src/model_format.rs
+++ b/crates/inference/src/model_format.rs
@@ -1,11 +1,13 @@
 //! Canonical model-directory format detector (ADR-080 amendment, #829).
 //!
-//! **Stability**: unstable, internal-binaries-only. This module exists solely
-//! so the three serving/chat binaries in `src/bin/` (`lattice`, `lattice_serve`,
-//! `chat_metal`) -- which are separate Cargo binary targets and therefore
-//! cannot see one another's `pub(crate)` items -- can share a single
-//! model-directory format decision instead of each carrying its own copy. It
-//! is public but unstable and internal-use: `pub mod model_format` is
+//! **Stability**: unstable, internal-binaries-only. This module exists so
+//! internal binaries in `src/bin/` -- including the three serving/chat
+//! binaries (`lattice`, `lattice_serve`, `chat_metal`) and the three
+//! benchmark binaries (`bench_decode_ab`, `bench_decode_slopefit`,
+//! `bench_logit_dump`) -- which are separate Cargo binary targets and
+//! therefore cannot see one another's `pub(crate)` items -- can share a
+//! single model-directory format decision instead of each carrying its own
+//! copy. It is public but unstable and internal-use: `pub mod model_format` is
 //! externally nameable, but its compatibility follows the crate's
 //! Experimental stability policy rather than semver-relevant deprecation
 //! cycles, and it may change shape at any time; downstream consumers of this
@@ -144,6 +146,23 @@ mod tests {
         // loader path is untouched and takes priority.
         let dir = tempdir("mixed");
         fs::write(dir.join("model.safetensors"), b"stub").unwrap();
+        fs::write(dir.join("leftover.q4"), b"stub").unwrap();
+        assert_eq!(detect_format(&dir), ModelFormat::Safetensors);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn detect_format_prefers_safetensors_index_over_q4_files() {
+        // A directory that has an index.json (sharded safetensors) and a
+        // stray .q4 file must also resolve as Safetensors. This is the
+        // precedence the three benchmark binaries' old inline heuristic got
+        // wrong: `!model.safetensors.exists() && has_q4_file` never checked
+        // index.json, so a directory with an index file plus .q4 files used
+        // to route those binaries to the Q4 loader. The canonical detector
+        // checks both sentinel files before falling through to .q4, so this
+        // case now resolves to Safetensors everywhere.
+        let dir = tempdir("mixed-index");
+        fs::write(dir.join("model.safetensors.index.json"), b"{}").unwrap();
         fs::write(dir.join("leftover.q4"), b"stub").unwrap();
         assert_eq!(detect_format(&dir), ModelFormat::Safetensors);
         fs::remove_dir_all(&dir).ok();

--- a/docs/adr/ADR-080-consolidation-duplicated-contracts.md
+++ b/docs/adr/ADR-080-consolidation-duplicated-contracts.md
@@ -276,10 +276,12 @@ helpers (`metal_gpu_required_message`, `unrecognized_format_message`) moved, unm
 behavior, into a new `crates/inference/src/model_format.rs` — a `pub mod` of the library crate
 rather than a `pub(crate)` module of one binary, because separate Cargo `[[bin]]` targets
 (`lattice`, `lattice_serve`, `chat_metal`) cannot see one another's `pub(crate)` items; only a
-library module is visible to all three. The module is documented unstable and
-internal-binaries-only (not part of the crate's public API surface) rather than hidden behind
-`#[doc(hidden)]`, matching the existing convention set by the C2 `serve` module (also a
-cross-binary-only shared contract, also a plain documented `pub mod`, not `#[doc(hidden)]`).
+library module is visible to all three. The module is a plain `pub mod` (externally nameable,
+so public for semver purposes) documented as unstable and internal-use, with compatibility
+following the crate's Experimental stability policy rather than semver-relevant deprecation
+cycles, rather than hidden behind `#[doc(hidden)]`, matching the existing convention set by the
+C2 `serve` module (also a cross-binary-only shared contract, also a plain documented `pub mod`,
+not `#[doc(hidden)]`).
 All three binaries now `match` on the shared `ModelFormat` enum (`Safetensors | Q4 | Unknown`)
 instead of a bespoke boolean or a partial re-check; the message helpers give `lattice_serve.rs`
 and `chat_metal.rs` the same fail-closed `Unknown`-directory error `lattice.rs` already had,

--- a/docs/adr/ADR-080-consolidation-duplicated-contracts.md
+++ b/docs/adr/ADR-080-consolidation-duplicated-contracts.md
@@ -14,6 +14,10 @@
 - C3 — backend-neutral decode policy, apply-or-fail-closed: PR #787 (merged 2026-07-10).
 - C4 — checked GEMM argument validator at every safe entry point: PR #796
   (merged 2026-07-11).
+- Amendment (#829) — canonical model-directory format detector (`ModelFormat`/
+  `detect_format`, plus its two error-message helpers) consolidated into
+  `crates/inference/src/model_format.rs`, shared by `lattice`, `lattice_serve`,
+  and `chat_metal`; see "Amendment: model-format detector consolidation" below.
 
 The cluster defect tickets (#739–#741, resolved by C1; #744–#746, resolved by C2) are
 closed against the merged PRs above. The non-cluster audit items from the same sweep
@@ -250,6 +254,41 @@ macOS FFI call, validate standalone WGPU/Metal GEMM slices before dispatch, prom
 GEMV checks to release-active validation shared with the safe wrapper, reject short activations in
 the training SwiGLU projection, and unify oversized-input handling across f32/f16/Q8 GDN
 projections.
+
+### Amendment (2026-07-11): model-format detector consolidation (#829)
+
+**Scope note.** This ADR was originally scoped to the four numeric-contract clusters above
+(softmax, http-serve, sampling-decode, matmul-gemm). A fifth, smaller duplicated-decision
+site was found in the same `src/bin/` surface C2 already touches: model-directory format
+detection (safetensors vs. native Q4 vs. unrecognized) was implemented independently in
+`lattice.rs` (`backend::detect_format`, enum-valued, with its own unit tests),
+`lattice_serve.rs` (`detect_q4`, bool-valued), and `chat_metal.rs` (`is_q4_dir`, bool-valued,
+plus a fourth, partial decision site that only re-checked safetensors absence inside the
+non-Q4 branch). This joins the shared-contract set this ADR already establishes for the two
+HTTP binaries in C2, so the fix is recorded here as an amendment to the existing Accepted
+decision rather than a new ADR. **This does not change the ADR's Status or its four original
+clusters** — it extends the implementation record with a fifth, out-of-cluster consolidation
+that follows the same "extract one small, checked, module-level helper" pattern C1–C4 already
+establish.
+
+**Extraction plan.** `ModelFormat`, `detect_format`, and the two format-specific error-message
+helpers (`metal_gpu_required_message`, `unrecognized_format_message`) moved, unmodified in
+behavior, into a new `crates/inference/src/model_format.rs` — a `pub mod` of the library crate
+rather than a `pub(crate)` module of one binary, because separate Cargo `[[bin]]` targets
+(`lattice`, `lattice_serve`, `chat_metal`) cannot see one another's `pub(crate)` items; only a
+library module is visible to all three. The module is documented unstable and
+internal-binaries-only (not part of the crate's public API surface) rather than hidden behind
+`#[doc(hidden)]`, matching the existing convention set by the C2 `serve` module (also a
+cross-binary-only shared contract, also a plain documented `pub mod`, not `#[doc(hidden)]`).
+All three binaries now `match` on the shared `ModelFormat` enum (`Safetensors | Q4 | Unknown`)
+instead of a bespoke boolean or a partial re-check; the message helpers give `lattice_serve.rs`
+and `chat_metal.rs` the same fail-closed `Unknown`-directory error `lattice.rs` already had,
+closing a real behavior gap (`lattice_serve.rs` previously had no explicit `Unknown` case at
+all — an unrecognized directory fell through to a generic "safetensors load failed" error from
+the CPU loader instead of a clear "not a recognized model directory" message).
+
+**Resolves**: #829 — one canonical model-format detector, zero remaining local
+re-implementations in `lattice.rs`, `lattice_serve.rs`, or `chat_metal.rs`.
 
 ## What we are NOT doing
 

--- a/docs/adr/ADR-080-consolidation-duplicated-contracts.md
+++ b/docs/adr/ADR-080-consolidation-duplicated-contracts.md
@@ -273,7 +273,8 @@ establish.
 
 **Extraction plan.** `ModelFormat`, `detect_format`, and the two format-specific error-message
 helpers (`metal_gpu_required_message`, `unrecognized_format_message`) moved, unmodified in
-behavior, into a new `crates/inference/src/model_format.rs` — a `pub mod` of the library crate
+behavior for `lattice.rs`, `lattice_serve.rs`, and `chat_metal.rs` (their own detectors were
+already index-aware), into a new `crates/inference/src/model_format.rs` — a `pub mod` of the library crate
 rather than a `pub(crate)` module of one binary, because separate Cargo `[[bin]]` targets
 (`lattice`, `lattice_serve`, `chat_metal`) cannot see one another's `pub(crate)` items; only a
 library module is visible to all three. The module is a plain `pub mod` (externally nameable,
@@ -289,8 +290,20 @@ closing a real behavior gap (`lattice_serve.rs` previously had no explicit `Unkn
 all — an unrecognized directory fell through to a generic "safetensors load failed" error from
 the CPU loader instead of a clear "not a recognized model directory" message).
 
+The three benchmark binaries (`bench_decode_ab.rs`, `bench_decode_slopefit.rs`,
+`bench_logit_dump.rs`) were migrated onto the same `detect_format` in a follow-up commit,
+closing the repository-wide sibling gate. That migration is not behavior-unmodified: each
+bench binary's removed inline heuristic checked only `model.safetensors`, never
+`model.safetensors.index.json`, before falling through to a `.q4` scan. A directory containing
+both an index file and stray `.q4` files therefore used to route those three binaries to the Q4
+loader; the canonical detector's index-aware precedence now routes the same directory to
+`Safetensors`. Ordinary safetensors-only, ordinary Q4-only, and Unknown/no-sentinel directories
+are unaffected. See `detect_format_prefers_safetensors_index_over_q4_files` in
+`model_format.rs` for the regression test covering this case.
+
 **Resolves**: #829 — one canonical model-format detector, zero remaining local
-re-implementations in `lattice.rs`, `lattice_serve.rs`, or `chat_metal.rs`.
+re-implementations in `lattice.rs`, `lattice_serve.rs`, `chat_metal.rs`, or the three
+benchmark binaries.
 
 ## What we are NOT doing
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

- Move `ModelFormat`/`detect_format` (plus the two format-specific error-message
  helpers, `metal_gpu_required_message` and `unrecognized_format_message`) out of
  `lattice.rs`'s private `backend` module into a new
  `crates/inference/src/model_format.rs` library module — a plain `pub mod`,
  externally nameable (public for semver purposes), documented as unstable and
  internal-use, with compatibility following the crate's Experimental
  stability policy rather than semver-relevant deprecation cycles.
  `lattice.rs`, `lattice_serve.rs`, and `chat_metal.rs` now all `match` on the
  same `Safetensors | Q4 | Unknown` enum instead of each carrying its own
  boolean heuristic or partial re-check.
- Delete `detect_q4` (`lattice_serve.rs`), `is_q4_dir` (`chat_metal.rs`), and the
  partial safetensors-absence re-check in `chat_metal.rs`'s non-Q4 branch. No
  caller re-checks sentinel files after matching on the enum (grep evidence
  below).
- `lattice_serve.rs`'s `load_model`/`spawn_worker` now take `ModelFormat`
  instead of `is_q4: bool`, and gain an explicit `Unknown` arm that returns
  `unrecognized_format_message` — closing a real gap where an unrecognized
  model directory previously fell through to a generic "safetensors load
  failed" error from the CPU loader instead of a clear message.
- Migrate the three benchmark binaries (`bench_decode_ab.rs`,
  `bench_decode_slopefit.rs`, `bench_logit_dump.rs`) off their own inline
  `is_q4_dir` heuristic onto `model_format::detect_format` as well, closing
  issue #829's repository-wide sibling gate (not just the three binaries
  named in the issue's checklist). This is **not** a behavior-preserving
  move for one input class: each removed heuristic was
  `!model.safetensors.exists() && any .q4`, which never checked
  `model.safetensors.index.json`, while the canonical detector checks both
  sentinel files before falling through to `.q4`. A directory containing an
  index file *and* stray `.q4` files therefore used to route these three
  binaries to the Q4 loader; it now resolves to `Safetensors`. Ordinary
  safetensors-only, ordinary Q4-only, and Unknown/no-sentinel directories are
  unaffected, and `lattice.rs`/`lattice_serve.rs`/`chat_metal.rs` were
  already index-aware before this refactor. Covered by the new
  `detect_format_prefers_safetensors_index_over_q4_files` test.
- Amend `docs/adr/ADR-080-consolidation-duplicated-contracts.md` with an
  implementation-record entry and a short amendment section covering this
  fifth, out-of-cluster consolidation (Status stays Accepted; C1–C4 unchanged).

## Why

Three independent implementations of the same safetensors/Q4/unrecognized
decision (plus a fourth, partial decision site) had to stay in sync by hand
across three separate binaries. This follows the same "extract one small,
checked, module-level helper" pattern ADR-080's C1–C4 clusters already
establish for this crate.

## Sibling-site grep gate

```
$ rg -n "\bis_q4_dir\b|\bfn detect_q4\(|fn detect_format\b" crates/inference/src/bin crates/inference/src/model_format.rs --glob '*.rs'
crates/inference/src/model_format.rs:21://! (`detect_q4`, bool-valued), and `bin/chat_metal.rs` (`is_q4_dir`,
crates/inference/src/model_format.rs:49:pub fn detect_format(dir: &Path) -> ModelFormat {
```

Repository-wide: exactly one detector definition in the library (the
remaining `is_q4_dir` hit is prose in the module's own historical-context
rustdoc, not a re-implementation); zero local re-implementations in any
binary anywhere in the tree, including the three benchmark binaries that
were previously out of scope.

## Mutation sensitivity (reverse-apply → confirm red → restore → confirm green,
in the live worktree each cycle; never `git checkout` over uncommitted work)

1. **Reverse safetensors precedence** (check `.q4` before safetensors in
   `detect_format`): `detect_format_prefers_safetensors_over_q4_files` failed
   (`left: Q4, right: Safetensors`). Restored — 10/10 `model_format` tests
   green (11/11 after the round-2 regression test below was added).
2. **Remove `.q4` recognition** (`detect_format` always returns `Unknown` for
   a would-be-Q4 dir): `detect_format_q4_dir` and
   `q4_dir_without_metal_gpu_feature_fails_closed` both failed. Restored —
   10/10 green.
3. **Force a `read_dir` failure path to a non-`Unknown` default** (unreadable
   dir defaults to `Q4` instead of failing closed): the new
   `detect_format_unreadable_dir_is_unknown` test failed
   (`left: Q4, right: Unknown`). Restored — 10/10 green.
4. **Change one caller back to a bool heuristic** (reintroduced a local
   `is_q4_dir` fn inside `lattice_serve.rs`'s `run()`): the sibling-site grep
   gate above went from 0 matches to 2 (`is_q4_dir` fn def + call site).
   Restored — grep gate back to 0 matches, `cargo check` clean.

Each cycle's file was `touch`ed after reverse-apply to force a rebuild; each
restore was verified against `git diff --stat` showing no residual diff before
moving on.

## Test plan

- [x] `cargo test -p lattice-inference --lib model_format` — 11/11 pass
      (8 moved + `detect_format_unreadable_dir_is_unknown`, added for stronger
      coverage, + the existing `q4_dir_without_metal_gpu_feature_fails_closed`,
      + `detect_format_prefers_safetensors_index_over_q4_files`, added in
      review round 2 to cover the indexed-safetensors-plus-`.q4` precedence
      case described above).
- [x] `cargo test -p lattice-inference --lib` — 1709 passed, 18 ignored, 0 failed.
- [x] `cargo check -p lattice-inference --bin lattice --bin lattice_serve --bin
      chat_metal --features f16,metal-gpu,serve,test-utils` — clean.
- [x] `cargo check -p lattice-inference --bins --features f16,metal-gpu` — clean
      (covers the three migrated benchmark binaries).
- [x] `cargo clippy -p lattice-inference --bin lattice --bin lattice_serve
      --bin chat_metal --features f16,metal-gpu,serve,test-utils -- -D
      warnings` — clean.
- [x] `cargo clippy -p lattice-inference --lib --all-targets --features
      f16,metal-gpu -- -D warnings` — clean.
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] `cargo test -p lattice-inference --bin lattice_serve --features
      f16,metal-gpu,test-utils` (CI's exact command) — 42/42 passed, including
      `parity_table::chat_completions_matches_shared_parity_table` and
      `production_adapter_observation::*` proof markers.
- [x] `cargo test -p lattice-inference --bin chat_metal --features
      f16,metal-gpu` (CI's exact command) — 6/6 passed.
- [x] `cargo test -p lattice-inference --bin lattice --features
      f16,metal-gpu,test-utils` (CI's exact command) — 126/126 passed,
      including the parity_table/production_adapter_observation proof
      markers.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `make lint-docs` — passed (doc lint + capability-matrix fixture check;
      the pre-existing `NOTE:` lines are unrelated informational output, not
      failures).

## semver-checks

`cargo semver-checks -p lattice-inference` reports 2 pre-existing failures
(`GdnSaved` struct fields, `gdn_backward`/`gdn_forward_save` arity) in
`crates/attention/gdn_backward.rs` and `forward/metal_qwen35.rs` — both
unrelated to this PR's diff (not touched here) and present before this
branch. The new `pub mod model_format` (additive: one new enum, three new
functions) is **not** flagged by semver-checks, as expected for an additive
change under semver.

## Bench-compare

Ran the required comparison under the repository's controlled A/B harness:
`bash scripts/with-heavy-lane.sh "lattice:866-bench-compare" -- make bench-compare`
(base `origin/main` @ `5047e08ec`, head @ `51f957e15`, serialized against other
GPU/heavy work on the machine via the heavy-lane lock). The head measured here
predates the review-round-2 precedence-wording fix commit (`8b40f1efa`), which
changes only comments, rustdoc, and a new unit test — no executable dispatch
path — so this evidence still accurately describes the diff's runtime
behavior at the current head.

This diff is startup-only (process-launch model-directory dispatch in three
`src/bin/` binaries plus three benchmark binaries); it touches no code under
`crates/inference/src/attention/`, `crates/inference/src/forward/`, or any
`crates/embed/` kernel. The default `bench-compare` sweep still runs the
full default Criterion suite (`elementwise_cpu_bench` for inference, `simd`
for embed) rather than a scoped subset, so the raw table below includes many
unrelated groups. The gate found:

- **16 FAIL, 7 WARN** — every one of the 23 flagged rows is a
  `simd_*`/`int8_raw_dot_product` group from `lattice-embed`'s `simd` bench
  target (batch cosine/dot-product/normalize/euclidean variants). None is in
  `crates/inference` at all, and none of the flagged embed groups sits on a
  code path this PR modifies (`model_format.rs` and the three migrated
  `src/bin/*.rs` startup-dispatch call sites are the entire diff).
- **0 FAIL/WARN** in any `lattice-inference` group (`rms_norm`, `layer_norm`,
  `silu_inplace`, `gelu`, `add_bias_gelu`, `softmax_attention`,
  `elementwise_mul`) — the crate this PR actually touches shows no flagged
  regression.
- 14 confirmed improvements, same noisy-embed-group pattern.

By-construction argument: this PR's source diff is identical release-mode
input for every kernel in both `elementwise_cpu_bench` and `simd` — no line
in `crates/inference/src/attention/`, `crates/inference/src/forward/`, or
`crates/embed/src/` changed, so base and head compile to identical machine
code for every flagged benchmark. The FAIL/WARN spread is consistent with
this repository's documented bench-compare noise profile for two-worktree
A/B runs (large `simd_*` batch groups swing ±5-40% run to run under thermal/
scheduling contention even with an unmodified binary); it is not a causal
effect of this PR's diff. Full table:

<details>
<summary>bench-compare gate report (23 FAIL/WARN rows, all lattice-embed simd/int8_raw groups; 14 improvements)</summary>

### `local-compare` — perf regression report

**❌ 16 FAIL** (regression >7.0% confirmed by 95% CI)
**⚠ 7 WARN** (regression 3.0-7.0% confirmed)
**🚀 14 confirmed improvement**

| Bench | Δ point | 95% CI | new ns | base ns | verdict |
|---|---:|---|---:|---:|---|
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_64c` | +80.68% | [+75.60%, +85.84%] | 3657.9 | 2024.5 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/768d_256c` | +41.15% | [+37.24%, +45.09%] | 17552.7 | 12435.1 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/384d_64c` | +37.16% | [+34.03%, +40.33%] | 2417.1 | 1762.2 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/768d_256c` | +34.12% | [+31.97%, +36.31%] | 20946.0 | 15617.9 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/384d_256c` | +26.37% | [+25.87%, +26.87%] | 8335.0 | 6595.6 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/384d_64c` | +22.12% | [+20.86%, +23.39%] | 1220.1 | 999.2 | ❌ FAIL |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_64c` | +21.72% | [+18.35%, +25.13%] | 2152.2 | 1768.2 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/768d_64c` | +17.75% | [+16.79%, +18.71%] | 3677.9 | 3123.5 | ❌ FAIL |
| `simd_batch_cosine/simd_batch/1000` | +16.50% | [+15.31%, +17.70%] | 45988.5 | 39475.0 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/384d_256c` | +15.24% | [+14.26%, +16.23%] | 9804.7 | 8507.8 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/384d_16c` | +16.98% | [+13.86%, +20.14%] | 305.0 | 260.7 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/768d_4c` | +16.05% | [+13.81%, +18.31%] | 263.0 | 226.6 | ❌ FAIL |
| `simd_batch_dot_product/simd_batch/1000` | +12.59% | [+11.85%, +13.34%] | 45547.1 | 40453.0 | ❌ FAIL |
| `simd_batch_dot_product/simd_batch/100` | +9.75% | [+9.40%, +10.10%] | 4741.7 | 4320.4 | ❌ FAIL |
| `simd_batch_cosine/simd_batch/100` | +9.30% | [+8.44%, +10.16%] | 4730.0 | 4327.6 | ❌ FAIL |
| `simd_normalize/simd/768` | +7.49% | [+7.39%, +7.60%] | 136.1 | 126.6 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/768d_16c` | +8.24% | [+5.81%, +10.69%] | 939.0 | 867.5 | ⚠ WARN |
| `simd_query_batch_dot_product/pair_loop/768d_64c` | +6.86% | [+5.73%, +7.99%] | 4238.4 | 3966.3 | ⚠ WARN |
| `simd_query_batch_dot_product/simd_batch/768d_16c` | +6.89% | [+5.52%, +8.27%] | 530.4 | 496.2 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c` | +5.19% | [+4.21%, +6.19%] | 5336.0 | 5072.6 | ⚠ WARN |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_1000c` | +6.33% | [+4.16%, +8.50%] | 65748.4 | 61836.2 | ⚠ WARN |
| `int8_raw_dot_product/dot_product_i8/128` | +6.17% | [+3.82%, +8.57%] | 5.0 | 4.7 | ⚠ WARN |
| `int8_raw_dot_product/dot_product_i8_raw/127` | +3.51% | [+3.09%, +3.94%] | 7.1 | 6.9 | ⚠ WARN |

</details>

_Rule: CI-lower of change ≤3.0% passes silently; (3.0%, 7.0%] warns; >7.0% fails._


## ADR

Amends `docs/adr/ADR-080-consolidation-duplicated-contracts.md` (Accepted) —
adds an implementation-record bullet plus a new "Amendment (2026-07-11):
model-format detector consolidation (#829)" section. Status is unchanged;
C1–C4 are unchanged. `docs/adr/INDEX.md`'s ADR-080 row text is unaffected (no
title/status change), so it was left as-is. The amendment section's wording
was corrected during review round 1 to describe `model_format` as public but
unstable (rather than "not part of the crate's public API surface") — a
plain `pub mod` is externally nameable and therefore public for semver
purposes even though its compatibility follows the crate's Experimental
policy. Review round 2 found the amendment's "moved, unmodified in behavior"
sentence was only true for `lattice.rs`, `lattice_serve.rs`, and
`chat_metal.rs`; the section now scopes that claim to those three and adds a
paragraph describing the indexed-safetensors-plus-`.q4` precedence exception
for the three benchmark binaries (same case as the Summary bullet above).

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] SIMD intrinsics, if any, were manually verified — not just reviewed by an AI (n/a — this PR touches no SIMD code)
- [x] Any agent-authored comment / PR body / issue starts with the attribution line from AGENTS.md
- [x] `cargo test` output included for any behavior-changing code; `cargo bench` output for perf-sensitive changes (see Test plan and Bench-compare above)

## Out of scope

No behavior change to the safetensors or Q4 load paths themselves; only the
format decision and its error messages are consolidated.

Closes #829

