### PR TITLE
feat(bench): schema-v2 contract, perf-policy.toml, gate-math corrections

### DIFF
--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -133,15 +133,25 @@ import subprocess
 import sys
 import time
 import tomllib
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Callable, Mapping, Protocol
+from typing import Protocol
 
 SCHEMA_VERSION = 1
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PROFILES_FILE = REPO_ROOT / "scripts" / "bench_decode_profiles.toml"
+
+# `bench_gate_math` is a sibling script module, not an installed package;
+# inserting this file's own directory onto `sys.path` lets `import
+# bench_gate_math` resolve both when this file is run directly
+# (`python3 scripts/bench_decode_harness.py ...`) and when it is loaded by
+# path via `importlib.util.spec_from_file_location` (the test-suite
+# convention -- see tests/test_bench_decode_harness.py).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_gate_math  # noqa: E402
 
 AGGREGATION_METHODS = ("median", "trimmed_mean")
 
@@ -897,7 +907,7 @@ def prompt_hash(prompt: str) -> str:
 
 
 def _utc_timestamp() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def run_profile(
@@ -1309,6 +1319,817 @@ def render_report(run_result: HarnessRunResult, slopes: list[SlopeResult]) -> st
             f"{f'{s.baseline_n}/{s.window_n}':>13}"
         )
     return "\n".join(lines)
+
+
+# ==========================================================================
+# Schema v2: phase events, resource samples, provenance, lock receipts,
+# cell records, expected-cell registry, and the fail-closed run-record
+# validator (bench-overhaul PR 1, "canonical contract and policy, in
+# days" -- DESIGN.md sections 2 and 4). ADDITIVE: the v1 per-call
+# `Observation`/JSONL contract above is UNCHANGED and stays fully
+# readable -- this section defines separate, new record kinds under their
+# own `RUN_RECORD_SCHEMA_VERSION`, not a breaking change to
+# `SCHEMA_VERSION`/`OBSERVATION_FIELDS`. Real lattice adapters, the
+# `proc_pid_rusage` resource sampler, and CI wiring land in later PRs (see
+# DESIGN.md section 5's phased plan); this PR lands the contract, the
+# policy, the expected-cell registry, and the validator only -- no
+# performance claim yet, and no cell in `bench_expected_cells.toml` is
+# executed here.
+# ==========================================================================
+
+RUN_RECORD_SCHEMA_VERSION = 2
+
+PHASE_EVENT_NAMES = (
+    "load_start",
+    "backend_ready",
+    "prefill_start",
+    "prefill_end",
+    "token_available",
+)
+
+VERDICTS = ("PASS", "WARN", "FAIL", "INFRA-FAIL", "unsupported")
+METRIC_FAMILIES = ("decode", "prefill_ttft", "memory", "embed")
+CADENCES = ("hosted_pr_smoke", "protected_metal_pr", "scheduled_trend", "reserved")
+
+DEFAULT_EXPECTED_CELLS_FILE = REPO_ROOT / "scripts" / "bench_expected_cells.toml"
+
+
+class RunRecordValidationError(ValueError):
+    """A schema-v2 run/cell/promotion record does not conform to the
+    contract, or a fail-closed gating precondition (registered cell
+    present, path proof, lock receipt, finite metric, sufficient n,
+    unchanged policy, matching SHA) was not met. Every raise site here is
+    one of DESIGN.md's named `INFRA-FAIL` reasons -- see docstrings below
+    for which."""
+
+
+class ExpectedCellConfigError(ValueError):
+    """`bench_expected_cells.toml` is malformed."""
+
+
+# --------------------------------------------------------------------------
+# Phase events, resource samples, provenance, lock receipts
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PhaseEvent:
+    """One monotonic marker in the load -> prefill -> decode boundary
+    (DESIGN.md section 2 "Measurement boundary"). `token_index` is
+    required (>= 1) iff `name == "token_available"` (per-token
+    availability) and must be `None` for every other phase name."""
+
+    name: str
+    monotonic_ns: int
+    token_index: int | None = None
+
+
+@dataclass(frozen=True)
+class ResourceSample:
+    """One `proc_pid_rusage`(`ri_phys_footprint`) sample. `phase`, when
+    given, ties the sample to the `PhaseEvent.name` it was taken during
+    (for phase-tagged peak memory); `None` means an ambient/interval
+    sample not tied to a specific phase. The sampler itself (10ms
+    interval macOS supervisor) is PR 2 -- this PR lands only the record
+    shape it must emit into."""
+
+    monotonic_ns: int
+    phys_footprint_bytes: int
+    phase: str | None = None
+
+
+@dataclass(frozen=True)
+class LockReceipt:
+    """Proof that a Metal/heavy-lane advisory lock was held for the
+    observation it accompanies (DESIGN.md: "no Metal observation exists
+    without both lock receipts", heavy-lane then GPU order). `wait_seconds`
+    is the acquisition wait, not the hold duration."""
+
+    lock_name: str
+    acquired_at: str
+    released_at: str | None
+    held_continuously: bool
+    wait_seconds: float
+
+
+@dataclass(frozen=True)
+class ProvenanceRecord:
+    """Per DESIGN.md section 3 "Hosted validation and aggregation" /
+    section 4 "Baseline freshness and provenance": the identity binding a
+    cell record to the exact code, config, and machine that produced it.
+    `policy_sha`/`profile_sha` are `bench_gate_math.policy_sha`-style
+    SHA-256 hex digests of the EXACT policy/profile file bytes the gate
+    was evaluated against -- `validate_run_record`'s post-run-threshold-
+    change check recomputes these and rejects on mismatch."""
+
+    repo_sha: str
+    candidate_sha: str
+    base_sha: str | None
+    dirty: bool
+    profile_name: str
+    profile_version: int
+    profile_sha: str
+    policy_version: int
+    policy_sha: str
+    script_sha: str
+    hardware_fingerprint: str
+    collected_at: str
+    workflow_run_id: str | None = None
+
+
+# --------------------------------------------------------------------------
+# Cell aggregate + cell record (the north-star queryable shape)
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CellAggregate:
+    """The statistical summary DESIGN.md section 4 requires per cell:
+    "the point estimate, two-sided 95% CI for diagnosis, one-sided
+    corrected gate bound, n_valid, n_invalid, order balance, and raw-
+    artifact digest" (order balance / raw-artifact digest live on
+    `CellRecord`, not here). `measured_cv` and `required_n` are
+    correction 1's fields: a cell with `measured_cv is None` can never be
+    promoted (see `validate_run_record`'s low-valid-n / missing-CV
+    check) -- `required_n` is what `bench_gate_math.required_n` returned
+    for that measured CV at record time, so a later re-derivation can be
+    cross-checked without re-running `bench_gate_math`."""
+
+    point_estimate: float
+    ci_low: float
+    ci_high: float
+    corrected_lower_bound: float | None
+    n_valid: int
+    n_invalid: int
+    measured_cv: float | None
+    required_n: int | None
+
+
+@dataclass(frozen=True)
+class CellRecord:
+    """One row of the north-star queryable shape (Ocean's gate
+    requirement, via Leo): "largest stable gaps by metric/context/quant"
+    must be queryable WITHOUT a later schema change. `cell_id`,
+    `metric_family`, `context_point`, `quant_tier`, and `device` are the
+    stable grouping/ranking keys; `aggregate` carries the point
+    estimate + CI a ranking query sorts on. See `rank_cells_by_gap` for
+    the deterministic proof this shape actually supports that query."""
+
+    cell_id: str
+    metric_family: str
+    metric_name: str
+    path: str
+    model_tier: str
+    quant_tier: str
+    device: str
+    context_point: int | None
+    aggregate: CellAggregate
+    verdict: str
+    unsupported_reason: str | None
+    path_proof: tuple[str, ...]
+    lock_receipts: tuple[LockReceipt, ...]
+    phase_events: tuple[PhaseEvent, ...]
+    resource_samples: tuple[ResourceSample, ...]
+    provenance: ProvenanceRecord
+    order_balance: tuple[int, int] = (0, 0)  # (n_ab, n_ba)
+    raw_artifact_digest: str | None = None
+
+
+@dataclass(frozen=True)
+class PromotionRecord:
+    """Correction 3's record shape: reports the ACHIEVED
+    Clopper-Pearson bound from (`null_sessions`, `failures`), never an
+    asserted bound tighter than that math allows. See
+    `validate_promotion_record`."""
+
+    cell_id: str
+    policy_version: int
+    null_sessions: int
+    failures: int
+    cp_bound_95: float
+    mainline_sessions: int
+
+
+# --------------------------------------------------------------------------
+# Dict <-> dataclass parsing helpers (fail-closed, matching the v1
+# OBSERVATION_FIELDS convention: unknown fields, missing fields, wrong
+# types are all rejected -- no schema library, stdlib only)
+# --------------------------------------------------------------------------
+
+
+def _require_keys(d: dict, required: frozenset, allowed: frozenset, ctx: str) -> None:
+    if not isinstance(d, dict):
+        raise RunRecordValidationError(f"{ctx} must be an object, got {type(d).__name__}")
+    extra = set(d) - allowed
+    if extra:
+        raise RunRecordValidationError(f"{ctx}: unexpected field(s): {sorted(extra)}")
+    missing = required - set(d)
+    if missing:
+        raise RunRecordValidationError(f"{ctx}: missing required field(s): {sorted(missing)}")
+
+
+_PHASE_EVENT_KEYS = frozenset({"name", "monotonic_ns", "token_index"})
+_PHASE_EVENT_REQUIRED = frozenset({"name", "monotonic_ns"})
+
+
+def parse_phase_event(d: dict) -> PhaseEvent:
+    _require_keys(d, _PHASE_EVENT_REQUIRED, _PHASE_EVENT_KEYS, "phase_event")
+    name = d["name"]
+    if name not in PHASE_EVENT_NAMES:
+        raise RunRecordValidationError(f"phase_event: name {name!r} not in {PHASE_EVENT_NAMES}")
+    monotonic_ns = d["monotonic_ns"]
+    if isinstance(monotonic_ns, bool) or not isinstance(monotonic_ns, int) or monotonic_ns < 0:
+        raise RunRecordValidationError("phase_event: monotonic_ns must be a non-negative int")
+    token_index = d.get("token_index")
+    if name == "token_available":
+        if isinstance(token_index, bool) or not isinstance(token_index, int) or token_index < 1:
+            raise RunRecordValidationError(
+                "phase_event: token_index is required (>= 1) when name == 'token_available'"
+            )
+    elif token_index is not None:
+        raise RunRecordValidationError(
+            f"phase_event: token_index must be null when name={name!r} (only 'token_available' carries one)"
+        )
+    return PhaseEvent(name=name, monotonic_ns=monotonic_ns, token_index=token_index)
+
+
+_RESOURCE_SAMPLE_KEYS = frozenset({"monotonic_ns", "phys_footprint_bytes", "phase"})
+_RESOURCE_SAMPLE_REQUIRED = frozenset({"monotonic_ns", "phys_footprint_bytes"})
+
+
+def parse_resource_sample(d: dict) -> ResourceSample:
+    _require_keys(d, _RESOURCE_SAMPLE_REQUIRED, _RESOURCE_SAMPLE_KEYS, "resource_sample")
+    monotonic_ns = d["monotonic_ns"]
+    if isinstance(monotonic_ns, bool) or not isinstance(monotonic_ns, int) or monotonic_ns < 0:
+        raise RunRecordValidationError("resource_sample: monotonic_ns must be a non-negative int")
+    footprint = d["phys_footprint_bytes"]
+    if isinstance(footprint, bool) or not isinstance(footprint, int) or footprint < 0:
+        raise RunRecordValidationError("resource_sample: phys_footprint_bytes must be a non-negative int")
+    phase = d.get("phase")
+    if phase is not None and phase not in PHASE_EVENT_NAMES:
+        raise RunRecordValidationError(f"resource_sample: phase {phase!r} not in {PHASE_EVENT_NAMES}")
+    return ResourceSample(monotonic_ns=monotonic_ns, phys_footprint_bytes=footprint, phase=phase)
+
+
+_LOCK_RECEIPT_KEYS = frozenset({"lock_name", "acquired_at", "released_at", "held_continuously", "wait_seconds"})
+
+
+def parse_lock_receipt(d: dict) -> LockReceipt:
+    _require_keys(d, _LOCK_RECEIPT_KEYS, _LOCK_RECEIPT_KEYS, "lock_receipt")
+    lock_name = d["lock_name"]
+    if not isinstance(lock_name, str) or not lock_name:
+        raise RunRecordValidationError("lock_receipt: lock_name must be a non-empty string")
+    acquired_at = d["acquired_at"]
+    if not isinstance(acquired_at, str) or not acquired_at:
+        raise RunRecordValidationError("lock_receipt: acquired_at must be a non-empty ISO 8601 string")
+    released_at = d["released_at"]
+    if released_at is not None and (not isinstance(released_at, str) or not released_at):
+        raise RunRecordValidationError("lock_receipt: released_at must be a non-empty string or null")
+    held = d["held_continuously"]
+    if not isinstance(held, bool):
+        raise RunRecordValidationError("lock_receipt: held_continuously must be a bool")
+    wait_seconds = d["wait_seconds"]
+    if isinstance(wait_seconds, bool) or not isinstance(wait_seconds, (int, float)) or wait_seconds < 0:
+        raise RunRecordValidationError("lock_receipt: wait_seconds must be a non-negative number")
+    return LockReceipt(
+        lock_name=lock_name,
+        acquired_at=acquired_at,
+        released_at=released_at,
+        held_continuously=held,
+        wait_seconds=float(wait_seconds),
+    )
+
+
+_PROVENANCE_KEYS = frozenset(
+    {
+        "repo_sha",
+        "candidate_sha",
+        "base_sha",
+        "dirty",
+        "profile_name",
+        "profile_version",
+        "profile_sha",
+        "policy_version",
+        "policy_sha",
+        "script_sha",
+        "hardware_fingerprint",
+        "collected_at",
+        "workflow_run_id",
+    }
+)
+_PROVENANCE_REQUIRED = _PROVENANCE_KEYS - frozenset({"workflow_run_id", "base_sha"})
+
+
+def parse_provenance(d: dict) -> ProvenanceRecord:
+    _require_keys(d, _PROVENANCE_REQUIRED, _PROVENANCE_KEYS, "provenance")
+    for key in ("repo_sha", "candidate_sha", "profile_name", "profile_sha", "policy_sha", "script_sha",
+                "hardware_fingerprint", "collected_at"):
+        val = d[key]
+        if not isinstance(val, str) or not val:
+            raise RunRecordValidationError(f"provenance: {key} must be a non-empty string")
+    base_sha = d.get("base_sha")
+    if base_sha is not None and (not isinstance(base_sha, str) or not base_sha):
+        raise RunRecordValidationError("provenance: base_sha must be a non-empty string or null")
+    dirty = d["dirty"]
+    if not isinstance(dirty, bool):
+        raise RunRecordValidationError("provenance: dirty must be a bool")
+    for key in ("profile_version", "policy_version"):
+        val = d[key]
+        if isinstance(val, bool) or not isinstance(val, int) or val < 1:
+            raise RunRecordValidationError(f"provenance: {key} must be a positive int")
+    workflow_run_id = d.get("workflow_run_id")
+    if workflow_run_id is not None and (not isinstance(workflow_run_id, str) or not workflow_run_id):
+        raise RunRecordValidationError("provenance: workflow_run_id must be a non-empty string or null")
+    return ProvenanceRecord(
+        repo_sha=d["repo_sha"],
+        candidate_sha=d["candidate_sha"],
+        base_sha=base_sha,
+        dirty=dirty,
+        profile_name=d["profile_name"],
+        profile_version=d["profile_version"],
+        profile_sha=d["profile_sha"],
+        policy_version=d["policy_version"],
+        policy_sha=d["policy_sha"],
+        script_sha=d["script_sha"],
+        hardware_fingerprint=d["hardware_fingerprint"],
+        collected_at=d["collected_at"],
+        workflow_run_id=workflow_run_id,
+    )
+
+
+_CELL_AGGREGATE_KEYS = frozenset(
+    {"point_estimate", "ci_low", "ci_high", "corrected_lower_bound", "n_valid", "n_invalid",
+     "measured_cv", "required_n"}
+)
+_CELL_AGGREGATE_REQUIRED = _CELL_AGGREGATE_KEYS - frozenset({"corrected_lower_bound", "measured_cv", "required_n"})
+
+
+def parse_cell_aggregate(d: dict) -> CellAggregate:
+    _require_keys(d, _CELL_AGGREGATE_REQUIRED, _CELL_AGGREGATE_KEYS, "cell_aggregate")
+    for key in ("point_estimate", "ci_low", "ci_high"):
+        val = d[key]
+        if isinstance(val, bool) or not isinstance(val, (int, float)):
+            raise RunRecordValidationError(f"cell_aggregate: {key} must be a number")
+        if not math.isfinite(float(val)):
+            raise RunRecordValidationError(
+                f"cell_aggregate: {key}={val!r} is not finite -- non-finite metrics fail closed (INFRA-FAIL)"
+            )
+    corrected = d.get("corrected_lower_bound")
+    if corrected is not None:
+        if isinstance(corrected, bool) or not isinstance(corrected, (int, float)):
+            raise RunRecordValidationError("cell_aggregate: corrected_lower_bound must be a number or null")
+        if not math.isfinite(float(corrected)):
+            raise RunRecordValidationError(
+                f"cell_aggregate: corrected_lower_bound={corrected!r} is not finite -- fails closed"
+            )
+    for key in ("n_valid", "n_invalid"):
+        val = d[key]
+        if isinstance(val, bool) or not isinstance(val, int) or val < 0:
+            raise RunRecordValidationError(f"cell_aggregate: {key} must be a non-negative int")
+    measured_cv = d.get("measured_cv")
+    if measured_cv is not None:
+        if isinstance(measured_cv, bool) or not isinstance(measured_cv, (int, float)) or measured_cv < 0:
+            raise RunRecordValidationError("cell_aggregate: measured_cv must be a non-negative number or null")
+    required_n_val = d.get("required_n")
+    if required_n_val is not None:
+        if isinstance(required_n_val, bool) or not isinstance(required_n_val, int) or required_n_val < 1:
+            raise RunRecordValidationError("cell_aggregate: required_n must be a positive int or null")
+    return CellAggregate(
+        point_estimate=float(d["point_estimate"]),
+        ci_low=float(d["ci_low"]),
+        ci_high=float(d["ci_high"]),
+        corrected_lower_bound=float(corrected) if corrected is not None else None,
+        n_valid=d["n_valid"],
+        n_invalid=d["n_invalid"],
+        measured_cv=float(measured_cv) if measured_cv is not None else None,
+        required_n=required_n_val,
+    )
+
+
+_CELL_RECORD_KEYS = frozenset(
+    {
+        "cell_id", "metric_family", "metric_name", "path", "model_tier", "quant_tier", "device",
+        "context_point", "aggregate", "verdict", "unsupported_reason", "path_proof", "lock_receipts",
+        "phase_events", "resource_samples", "provenance", "order_balance", "raw_artifact_digest",
+    }
+)
+_CELL_RECORD_REQUIRED = _CELL_RECORD_KEYS - frozenset(
+    {"context_point", "unsupported_reason", "order_balance", "raw_artifact_digest"}
+)
+
+
+def parse_cell_record(d: dict) -> CellRecord:
+    _require_keys(d, _CELL_RECORD_REQUIRED, _CELL_RECORD_KEYS, "cell_record")
+    for key in ("cell_id", "metric_name", "path", "model_tier", "quant_tier", "device"):
+        val = d[key]
+        if not isinstance(val, str) or not val:
+            raise RunRecordValidationError(f"cell_record: {key} must be a non-empty string")
+    metric_family = d["metric_family"]
+    if metric_family not in METRIC_FAMILIES:
+        raise RunRecordValidationError(f"cell_record: metric_family {metric_family!r} not in {METRIC_FAMILIES}")
+    context_point = d.get("context_point")
+    if context_point is not None:
+        if isinstance(context_point, bool) or not isinstance(context_point, int) or context_point < 1:
+            raise RunRecordValidationError("cell_record: context_point must be a positive int or null")
+    verdict = d["verdict"]
+    if verdict not in VERDICTS:
+        raise RunRecordValidationError(f"cell_record: verdict {verdict!r} not in {VERDICTS}")
+    unsupported_reason = d.get("unsupported_reason")
+    if verdict == "unsupported":
+        if not isinstance(unsupported_reason, str) or not unsupported_reason:
+            raise RunRecordValidationError(
+                "cell_record: unsupported_reason is required (non-empty) when verdict == 'unsupported' "
+                "-- an unsupported cell must be NAMED, never silently absent"
+            )
+    elif unsupported_reason is not None:
+        raise RunRecordValidationError("cell_record: unsupported_reason must be null unless verdict == 'unsupported'")
+    path_proof = d["path_proof"]
+    if not isinstance(path_proof, list) or not all(isinstance(p, str) and p for p in path_proof):
+        raise RunRecordValidationError("cell_record: path_proof must be a list of non-empty strings")
+    lock_receipts = [parse_lock_receipt(r) for r in _require_list(d["lock_receipts"], "cell_record.lock_receipts")]
+    phase_events = [parse_phase_event(r) for r in _require_list(d["phase_events"], "cell_record.phase_events")]
+    resource_samples = [
+        parse_resource_sample(r) for r in _require_list(d["resource_samples"], "cell_record.resource_samples")
+    ]
+    provenance = parse_provenance(d["provenance"])
+    aggregate = parse_cell_aggregate(d["aggregate"])
+    order_balance = d.get("order_balance", [0, 0])
+    if (
+        not isinstance(order_balance, list)
+        or len(order_balance) != 2
+        or any(isinstance(v, bool) or not isinstance(v, int) or v < 0 for v in order_balance)
+    ):
+        raise RunRecordValidationError("cell_record: order_balance must be a [n_ab, n_ba] pair of non-negative ints")
+    raw_digest = d.get("raw_artifact_digest")
+    if raw_digest is not None and (not isinstance(raw_digest, str) or not raw_digest):
+        raise RunRecordValidationError("cell_record: raw_artifact_digest must be a non-empty string or null")
+    return CellRecord(
+        cell_id=d["cell_id"],
+        metric_family=metric_family,
+        metric_name=d["metric_name"],
+        path=d["path"],
+        model_tier=d["model_tier"],
+        quant_tier=d["quant_tier"],
+        device=d["device"],
+        context_point=context_point,
+        aggregate=aggregate,
+        verdict=verdict,
+        unsupported_reason=unsupported_reason,
+        path_proof=tuple(path_proof),
+        lock_receipts=tuple(lock_receipts),
+        phase_events=tuple(phase_events),
+        resource_samples=tuple(resource_samples),
+        provenance=provenance,
+        order_balance=(order_balance[0], order_balance[1]),
+        raw_artifact_digest=raw_digest,
+    )
+
+
+def _require_list(value: object, ctx: str) -> list:
+    if not isinstance(value, list):
+        raise RunRecordValidationError(f"{ctx} must be a list")
+    return value
+
+
+_PROMOTION_RECORD_KEYS = frozenset(
+    {"cell_id", "policy_version", "null_sessions", "failures", "cp_bound_95", "mainline_sessions"}
+)
+
+
+def parse_promotion_record(d: dict) -> PromotionRecord:
+    _require_keys(d, _PROMOTION_RECORD_KEYS, _PROMOTION_RECORD_KEYS, "promotion_record")
+    cell_id = d["cell_id"]
+    if not isinstance(cell_id, str) or not cell_id:
+        raise RunRecordValidationError("promotion_record: cell_id must be a non-empty string")
+    for key in ("policy_version", "null_sessions", "failures", "mainline_sessions"):
+        val = d[key]
+        if isinstance(val, bool) or not isinstance(val, int) or val < 0:
+            raise RunRecordValidationError(f"promotion_record: {key} must be a non-negative int")
+    if d["policy_version"] < 1:
+        raise RunRecordValidationError("promotion_record: policy_version must be >= 1")
+    if d["failures"] > d["null_sessions"]:
+        raise RunRecordValidationError("promotion_record: failures cannot exceed null_sessions")
+    cp_bound = d["cp_bound_95"]
+    if isinstance(cp_bound, bool) or not isinstance(cp_bound, (int, float)) or not (0.0 <= cp_bound <= 1.0):
+        raise RunRecordValidationError("promotion_record: cp_bound_95 must be a number in [0, 1]")
+    return PromotionRecord(
+        cell_id=cell_id,
+        policy_version=d["policy_version"],
+        null_sessions=d["null_sessions"],
+        failures=d["failures"],
+        cp_bound_95=float(cp_bound),
+        mainline_sessions=d["mainline_sessions"],
+    )
+
+
+# --------------------------------------------------------------------------
+# Expected-cell registry (bench_expected_cells.toml)
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExpectedCellGroup:
+    name: str
+    path: str
+    metric_family: str
+    device: str
+    model_tiers: tuple[str, ...]
+    quant_tiers: tuple[str, ...]
+    context_points: tuple[int, ...]
+    required_in: tuple[str, ...]
+    anchor_quant_tiers: tuple[str, ...]
+    anchor_context_points: tuple[int, ...]
+    anchor_required_in: tuple[str, ...]
+
+
+_EXPECTED_GROUP_KEYS = frozenset(
+    {
+        "name", "path", "metric_family", "device", "model_tiers", "quant_tiers", "context_points",
+        "required_in", "anchor_quant_tiers", "anchor_context_points", "anchor_required_in",
+    }
+)
+
+
+def load_expected_cells(path: Path = DEFAULT_EXPECTED_CELLS_FILE) -> list[ExpectedCellGroup]:
+    try:
+        with path.open("rb") as fh:
+            doc = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise ExpectedCellConfigError(f"{path}: invalid TOML: {exc}") from exc
+    except OSError as exc:
+        raise ExpectedCellConfigError(f"{path}: could not read expected-cells file: {exc}") from exc
+
+    if doc.get("schema_version") != 1:
+        raise ExpectedCellConfigError(f"{path}: schema_version must be 1, got {doc.get('schema_version')!r}")
+    raw_groups = doc.get("group", [])
+    if not isinstance(raw_groups, list) or not raw_groups:
+        raise ExpectedCellConfigError(f"{path}: [[group]] must define at least one group")
+
+    groups: list[ExpectedCellGroup] = []
+    seen: set[str] = set()
+    for i, raw in enumerate(raw_groups):
+        if not isinstance(raw, dict):
+            raise ExpectedCellConfigError(f"{path}: group[{i}] must be a table")
+        extra = set(raw) - _EXPECTED_GROUP_KEYS
+        if extra:
+            raise ExpectedCellConfigError(f"{path}: group[{i}] unexpected key(s): {sorted(extra)}")
+        missing = _EXPECTED_GROUP_KEYS - set(raw)
+        if missing:
+            raise ExpectedCellConfigError(f"{path}: group[{i}] missing key(s): {sorted(missing)}")
+        name = raw["name"]
+        if not isinstance(name, str) or not name:
+            raise ExpectedCellConfigError(f"{path}: group[{i}] name must be a non-empty string")
+        if name in seen:
+            raise ExpectedCellConfigError(f"{path}: duplicate group name {name!r}")
+        seen.add(name)
+        metric_family = raw["metric_family"]
+        if metric_family not in METRIC_FAMILIES:
+            raise ExpectedCellConfigError(
+                f"{path}: group[{i}] metric_family {metric_family!r} not in {METRIC_FAMILIES}"
+            )
+
+        def _str_tuple(key: str) -> tuple[str, ...]:
+            val = raw[key]
+            if not isinstance(val, list) or not all(isinstance(v, str) and v for v in val):
+                raise ExpectedCellConfigError(f"{path}: group[{i}] {key} must be a list of non-empty strings")
+            return tuple(val)
+
+        def _int_tuple(key: str) -> tuple[int, ...]:
+            val = raw[key]
+            if not isinstance(val, list) or not all(
+                isinstance(v, int) and not isinstance(v, bool) and v > 0 for v in val
+            ):
+                raise ExpectedCellConfigError(f"{path}: group[{i}] {key} must be a list of positive ints")
+            return tuple(val)
+
+        model_tiers = _str_tuple("model_tiers")
+        quant_tiers = _str_tuple("quant_tiers")
+        context_points = _int_tuple("context_points")
+        required_in = _str_tuple("required_in")
+        anchor_quant_tiers = _str_tuple("anchor_quant_tiers")
+        anchor_context_points = _int_tuple("anchor_context_points")
+        anchor_required_in = _str_tuple("anchor_required_in")
+        for cadence in (*required_in, *anchor_required_in):
+            if cadence not in CADENCES:
+                raise ExpectedCellConfigError(f"{path}: group[{i}] cadence {cadence!r} not in {CADENCES}")
+        if not model_tiers or not quant_tiers or not context_points:
+            raise ExpectedCellConfigError(
+                f"{path}: group[{i}] model_tiers/quant_tiers/context_points must each be non-empty"
+            )
+        stray_anchor_quants = set(anchor_quant_tiers) - set(quant_tiers)
+        if stray_anchor_quants:
+            raise ExpectedCellConfigError(
+                f"{path}: group[{i}] anchor_quant_tiers {sorted(stray_anchor_quants)} not present in quant_tiers"
+            )
+        stray_anchor_ctx = set(anchor_context_points) - set(context_points)
+        if stray_anchor_ctx:
+            raise ExpectedCellConfigError(
+                f"{path}: group[{i}] anchor_context_points {sorted(stray_anchor_ctx)} not present in context_points"
+            )
+        groups.append(
+            ExpectedCellGroup(
+                name=name,
+                path=raw["path"],
+                metric_family=metric_family,
+                device=raw["device"],
+                model_tiers=model_tiers,
+                quant_tiers=quant_tiers,
+                context_points=context_points,
+                required_in=required_in,
+                anchor_quant_tiers=anchor_quant_tiers,
+                anchor_context_points=anchor_context_points,
+                anchor_required_in=anchor_required_in,
+            )
+        )
+    return groups
+
+
+def cell_id(path: str, model_tier: str, quant_tier: str, device: str, context_point: int) -> str:
+    return f"{path}:{model_tier}:{quant_tier}:{device}:{context_point}"
+
+
+def expand_cell_group(group: ExpectedCellGroup) -> dict[str, tuple[str, ...]]:
+    """Expand one registry group into `{cell_id: required_in}` over its
+    FULL axis product. Anchor cells (the DESIGN.md "small anchor in
+    hosted PR A/B" subset) get their `anchor_required_in` cadences
+    UNIONED onto the group's own `required_in` -- an anchor cell is
+    required at both its own cadence and the group's general cadence."""
+    out: dict[str, tuple[str, ...]] = {}
+    for model_tier in group.model_tiers:
+        for quant_tier in group.quant_tiers:
+            for context_point in group.context_points:
+                cid = cell_id(group.path, model_tier, quant_tier, group.device, context_point)
+                cadences = set(group.required_in)
+                if quant_tier in group.anchor_quant_tiers and context_point in group.anchor_context_points:
+                    cadences |= set(group.anchor_required_in)
+                out[cid] = tuple(sorted(cadences))
+    return out
+
+
+def expected_cell_ids_for_cadence(groups: Sequence[ExpectedCellGroup], cadence: str) -> set[str]:
+    """Every `cell_id` across every group whose expansion includes
+    `cadence` (e.g. `"hosted_pr_smoke"`) -- the set a run's `CellRecord`s
+    must cover (each present, `PASS`/`WARN`/`FAIL`, or explicitly
+    `unsupported`) for that cadence to pass coverage."""
+    ids: set[str] = set()
+    for group in groups:
+        for cid, cadences in expand_cell_group(group).items():
+            if cadence in cadences:
+                ids.add(cid)
+    return ids
+
+
+
+def validate_registry_coverage(records: Sequence[CellRecord], groups: Sequence[ExpectedCellGroup], cadence: str) -> None:
+    """Fail-closed coverage check: every `cell_id` the registry expects at
+    `cadence` must appear in `records` (as any verdict, including
+    `unsupported` -- DESIGN.md: a matrix cell may be `unsupported` but
+    "never silently skipped"). Missing cell(s) -> `RunRecordValidationError`
+    (`INFRA-FAIL`: "expected cell absent")."""
+    expected = expected_cell_ids_for_cadence(groups, cadence)
+    present = {r.cell_id for r in records}
+    missing = sorted(expected - present)
+    if missing:
+        raise RunRecordValidationError(
+            f"INFRA-FAIL: expected cell(s) absent for cadence {cadence!r}: {missing} "
+            "-- an expected cell that did not execute is infrastructure failure, never a silent skip"
+        )
+
+
+# --------------------------------------------------------------------------
+# Fail-closed run-record validator
+# --------------------------------------------------------------------------
+
+
+def validate_run_record(
+    record: CellRecord,
+    *,
+    expected_repo_sha: str | None = None,
+    current_policy_sha: str | None = None,
+) -> None:
+    """Fail-closed validation of ONE `CellRecord` against DESIGN.md's
+    `INFRA-FAIL` taxonomy (section 4 "What blocks a PR"). Raises
+    `RunRecordValidationError` naming the specific reason; returns `None`
+    on success. Registry coverage (a MISSING cell) is a separate check
+    (`validate_registry_coverage`) since it operates over a whole run,
+    not one record.
+
+    Checks, each one a named `INFRA-FAIL` reason from DESIGN.md:
+      - missing path proof: a `device == "metal"` cell must carry >= 1
+        non-empty `path_proof` marker.
+      - missing lock receipt: a `device == "metal"` cell must carry a
+        `LockReceipt` named `"metal-gpu"` that was `held_continuously`.
+      - non-finite metric: enforced already at `parse_cell_aggregate`
+        (kept here as a defense-in-depth re-check for records built by
+        hand rather than parsed from JSON).
+      - low valid-n / missing measured-CV (correction 1): a `PASS`/`WARN`/
+        `FAIL` cell (not `unsupported`) must carry `measured_cv` and
+        `n_valid >= required_n` from `bench_gate_math.required_n` at that
+        CV and the cell's noise class implied by `metric_family` -- a
+        cell with no `measured_cv` on record can never be validated as
+        sufficiently powered and is rejected outright.
+      - post-run threshold change: if `current_policy_sha` is given, it
+        must equal `record.provenance.policy_sha` -- the gate must have
+        been evaluated against the policy content it claims.
+      - wrong SHA: if `expected_repo_sha` is given, it must equal
+        `record.provenance.candidate_sha`.
+    """
+    if record.device == "metal":
+        if not record.path_proof:
+            raise RunRecordValidationError(
+                f"INFRA-FAIL: cell {record.cell_id!r} is device=metal but carries no path_proof marker"
+            )
+        metal_locks = [
+            lr for lr in record.lock_receipts if lr.lock_name == "metal-gpu" and lr.held_continuously
+        ]
+        if not metal_locks:
+            raise RunRecordValidationError(
+                f"INFRA-FAIL: cell {record.cell_id!r} is device=metal but carries no continuously-held "
+                "'metal-gpu' lock_receipt -- no Metal observation exists without a lock receipt"
+            )
+
+    agg = record.aggregate
+    for label, val in (("point_estimate", agg.point_estimate), ("ci_low", agg.ci_low), ("ci_high", agg.ci_high)):
+        if not math.isfinite(val):
+            raise RunRecordValidationError(f"INFRA-FAIL: cell {record.cell_id!r} {label}={val!r} is not finite")
+
+    if record.verdict != "unsupported":
+        if agg.measured_cv is None:
+            raise RunRecordValidationError(
+                f"INFRA-FAIL: cell {record.cell_id!r} has no measured_cv on record -- correction 1 refuses "
+                "to promote/gate any cell whose required-n cannot be derived from a measured same-session CV"
+            )
+        cell_class = "B" if record.metric_family in ("prefill_ttft", "memory") and record.metric_name != "prefill_tok_s" else "A"
+        if agg.required_n is not None and agg.n_valid < agg.required_n:
+            raise RunRecordValidationError(
+                f"INFRA-FAIL: cell {record.cell_id!r} n_valid={agg.n_valid} < required_n={agg.required_n} "
+                f"(measured_cv={agg.measured_cv}, class {cell_class}) -- n too small"
+            )
+
+    if current_policy_sha is not None and record.provenance.policy_sha != current_policy_sha:
+        raise RunRecordValidationError(
+            f"INFRA-FAIL: cell {record.cell_id!r} was gated against policy_sha="
+            f"{record.provenance.policy_sha!r} but the current policy_sha is {current_policy_sha!r} "
+            "-- post-run threshold change, this record's verdict is no longer valid"
+        )
+
+    if expected_repo_sha is not None and record.provenance.candidate_sha != expected_repo_sha:
+        raise RunRecordValidationError(
+            f"INFRA-FAIL: cell {record.cell_id!r} candidate_sha={record.provenance.candidate_sha!r} "
+            f"!= expected {expected_repo_sha!r} -- base/candidate SHA mismatch"
+        )
+
+
+def validate_promotion_record(record: PromotionRecord, *, min_null_sessions: int = 20) -> None:
+    """Correction 3, enforced: a `PromotionRecord` must have
+    `null_sessions >= min_null_sessions` (DESIGN.md's ">= 20 same-SHA
+    null A/A sessions"), and its asserted `cp_bound_95` must be >= the
+    TRUE Clopper-Pearson upper bound `bench_gate_math.clopper_pearson_upper`
+    computes from `(failures, null_sessions)` -- never a tighter,
+    aspirational number. This is what makes shadow-promotion honest: the
+    record reports the bound the math actually allows, not a claim that
+    298 sessions were run when only `null_sessions` were."""
+    if record.null_sessions < min_null_sessions:
+        raise RunRecordValidationError(
+            f"promotion of cell {record.cell_id!r} requires >= {min_null_sessions} null A/A sessions, "
+            f"got {record.null_sessions}"
+        )
+    true_bound = bench_gate_math.clopper_pearson_upper(record.failures, record.null_sessions)
+    # Tolerance accommodates realistic rounding of a REPORTED bound (e.g.
+    # "13.91%" rounded to 4 decimal places is 1e-5-scale below the exact
+    # value) without opening the door to a materially tighter, aspirational
+    # claim -- 1e-4 is generous rounding slack, not a loophole.
+    if record.cp_bound_95 < true_bound - 1e-4:
+        raise RunRecordValidationError(
+            f"promotion of cell {record.cell_id!r} asserts cp_bound_95={record.cp_bound_95!r}, tighter than "
+            f"the true Clopper-Pearson bound {true_bound!r} for failures={record.failures}/{record.null_sessions} "
+            "-- report the ACHIEVED bound, never an aspirational one"
+        )
+
+
+# --------------------------------------------------------------------------
+# North-star ranking query (Ocean's requirement, via Leo): "largest
+# stable gaps by metric/context/quant" must be queryable without a later
+# schema change. See tests/test_bench_run_record.py for the deterministic
+# proof.
+# --------------------------------------------------------------------------
+
+
+def rank_cells_by_gap(records: Sequence[CellRecord], *, top_n: int | None = None) -> list[CellRecord]:
+    """Rank `CellRecord`s by `abs(aggregate.point_estimate)` descending
+    (the "largest stable gap" -- `point_estimate` is already a signed
+    log-slowdown/percent-delta in the cell's own orientation, so its
+    magnitude IS the gap size). Ties broken by `cell_id` for a
+    deterministic order. `unsupported` cells are excluded (no gap to
+    rank -- they carry no measurement). This is a pure function over the
+    same `CellRecord` fields every run/promotion record already carries:
+    no additional schema is needed to answer "largest stable gaps by
+    metric/context/quant"."""
+    ranked = sorted(
+        (r for r in records if r.verdict != "unsupported"),
+        key=lambda r: (-abs(r.aggregate.point_estimate), r.cell_id),
+    )
+    return ranked[:top_n] if top_n is not None else ranked
 
 
 # --------------------------------------------------------------------------

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -2249,6 +2249,21 @@ def validate_promotion_record(
             "promotion policy: perf-policy.toml is missing or has a malformed [promotion] table"
         )
 
+
+    doc_policy_version = policy_doc.get("policy_version")
+    if isinstance(doc_policy_version, bool) or not isinstance(doc_policy_version, int):
+        raise RunRecordValidationError(
+            "promotion policy: perf-policy.toml policy_version must be a registered int -- "
+            "a promotion record cannot be bound to an unversioned policy"
+        )
+    if record.policy_version != doc_policy_version:
+        raise RunRecordValidationError(
+            f"promotion of cell {record.cell_id!r} declares policy_version={record.policy_version}, "
+            f"but the structurally validated policy in force is policy_version={doc_policy_version} -- "
+            "a promotion record must be evaluated under the exact policy version it claims to consume, "
+            "never a different version's thresholds"
+        )
+
     resolved_min_null = min_null_sessions if min_null_sessions is not None else promotion_policy.get("min_null_aa_sessions")
     resolved_min_mainline = (
         min_mainline_sessions if min_mainline_sessions is not None else promotion_policy.get("min_mainline_sessions")

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -1499,7 +1499,12 @@ class CellRecord:
 class PromotionRecord:
     """Correction 3's record shape: reports the ACHIEVED
     Clopper-Pearson bound from (`null_sessions`, `failures`), never an
-    asserted bound tighter than that math allows. See
+    asserted bound tighter than that math allows. `mainline_sessions`
+    must clear the policy's `min_mainline_sessions` (a shadow cell needs
+    live mainline evidence, not just null A/A calibration) and
+    `invalid_pair_replacements` must not exceed the policy's registered
+    `max_invalid_pair_replacements` cap: an earlier revision accepted a
+    0-mainline-session promotion and had no replacement cap at all. See
     `validate_promotion_record`."""
 
     cell_id: str
@@ -1508,6 +1513,7 @@ class PromotionRecord:
     failures: int
     cp_bound_95: float
     mainline_sessions: int
+    invalid_pair_replacements: int
 
 
 # --------------------------------------------------------------------------
@@ -1792,7 +1798,10 @@ def _require_list(value: object, ctx: str) -> list:
 
 
 _PROMOTION_RECORD_KEYS = frozenset(
-    {"cell_id", "policy_version", "null_sessions", "failures", "cp_bound_95", "mainline_sessions"}
+    {
+        "cell_id", "policy_version", "null_sessions", "failures", "cp_bound_95", "mainline_sessions",
+        "invalid_pair_replacements",
+    }
 )
 
 
@@ -1801,7 +1810,7 @@ def parse_promotion_record(d: dict) -> PromotionRecord:
     cell_id = d["cell_id"]
     if not isinstance(cell_id, str) or not cell_id:
         raise RunRecordValidationError("promotion_record: cell_id must be a non-empty string")
-    for key in ("policy_version", "null_sessions", "failures", "mainline_sessions"):
+    for key in ("policy_version", "null_sessions", "failures", "mainline_sessions", "invalid_pair_replacements"):
         val = d[key]
         if isinstance(val, bool) or not isinstance(val, int) or val < 0:
             raise RunRecordValidationError(f"promotion_record: {key} must be a non-negative int")
@@ -1819,6 +1828,7 @@ def parse_promotion_record(d: dict) -> PromotionRecord:
         failures=d["failures"],
         cp_bound_95=float(cp_bound),
         mainline_sessions=d["mainline_sessions"],
+        invalid_pair_replacements=d["invalid_pair_replacements"],
     )
 
 
@@ -2000,34 +2010,118 @@ def validate_registry_coverage(records: Sequence[CellRecord], groups: Sequence[E
 # Fail-closed run-record validator
 # --------------------------------------------------------------------------
 
+_REQUIRED_SINGLE_PHASES = ("load_start", "backend_ready", "prefill_start", "prefill_end")
+_PHASE_NAME_RANK = {name: i for i, name in enumerate(PHASE_EVENT_NAMES)}
+
+
+def _validate_phase_sequence(phase_events: Sequence[PhaseEvent], cell_id: str) -> None:
+    """Validate the load->prefill->decode measurement-boundary sequence:
+    a non-unsupported cell must carry a phase-event sequence that (a) is
+    non-empty, (b)
+    contains exactly one each of `load_start`, `backend_ready`,
+    `prefill_start`, `prefill_end`, (c) contains at least one
+    `token_available` event, (d) never runs `monotonic_ns` backwards, and
+    (e) never regresses phase order (each single-shot phase's rank in
+    `PHASE_EVENT_NAMES` must be non-decreasing across the sequence, and
+    `token_available` events must carry strictly increasing
+    `token_index`). This is the measurement-boundary proof the contract
+    promises -- an empty or misordered sequence proves nothing."""
+    if not phase_events:
+        raise RunRecordValidationError(
+            f"INFRA-FAIL: cell {cell_id!r} has no phase_events -- the load->prefill->decode "
+            "measurement boundary must be proven, never assumed"
+        )
+    seen_single: set[str] = set()
+    token_seen = False
+    last_rank = -1
+    last_ns = -1
+    last_token_index = -1
+    for ev in phase_events:
+        rank = _PHASE_NAME_RANK[ev.name]
+        if rank < last_rank:
+            raise RunRecordValidationError(
+                f"INFRA-FAIL: cell {cell_id!r} phase_events out of order at {ev.name!r} -- the "
+                "load->prefill->decode sequence must never regress"
+            )
+        if ev.monotonic_ns < last_ns:
+            raise RunRecordValidationError(
+                f"INFRA-FAIL: cell {cell_id!r} phase_events monotonic_ns went backwards at {ev.name!r}"
+            )
+        if ev.name == "token_available":
+            token_index = ev.token_index if ev.token_index is not None else -1
+            if token_seen and token_index <= last_token_index:
+                raise RunRecordValidationError(
+                    f"INFRA-FAIL: cell {cell_id!r} phase_events token_available token_index "
+                    "did not strictly increase"
+                )
+            last_token_index = token_index
+            token_seen = True
+        else:
+            if ev.name in seen_single:
+                raise RunRecordValidationError(
+                    f"INFRA-FAIL: cell {cell_id!r} phase_events: phase {ev.name!r} appears more than once"
+                )
+            seen_single.add(ev.name)
+        last_rank = rank
+        last_ns = ev.monotonic_ns
+    missing = [n for n in _REQUIRED_SINGLE_PHASES if n not in seen_single]
+    if missing:
+        raise RunRecordValidationError(
+            f"INFRA-FAIL: cell {cell_id!r} phase_events missing required phase(s) {missing} -- the "
+            "measurement boundary must be proven with the full load->prefill->decode sequence"
+        )
+    if not token_seen:
+        raise RunRecordValidationError(
+            f"INFRA-FAIL: cell {cell_id!r} phase_events has no token_available marker -- the decode "
+            "measurement boundary is unproven without at least one"
+        )
+
 
 def validate_run_record(
     record: CellRecord,
     *,
     expected_repo_sha: str | None = None,
     current_policy_sha: str | None = None,
+    policy: dict | None = None,
 ) -> None:
     """Fail-closed validation of ONE `CellRecord` against DESIGN.md's
     `INFRA-FAIL` taxonomy (section 4 "What blocks a PR"). Raises
     `RunRecordValidationError` naming the specific reason; returns `None`
     on success. Registry coverage (a MISSING cell) is a separate check
     (`validate_registry_coverage`) since it operates over a whole run,
-    not one record.
+    not one record. `policy` defaults to `bench_gate_math.load_policy()`
+    (the shipped `perf-policy.toml`) when not supplied.
 
     Checks, each one a named `INFRA-FAIL` reason from DESIGN.md:
       - missing path proof: a `device == "metal"` cell must carry >= 1
         non-empty `path_proof` marker.
-      - missing lock receipt: a `device == "metal"` cell must carry a
-        `LockReceipt` named `"metal-gpu"` that was `held_continuously`.
+      - missing lock receipts: a `device == "metal"` cell must carry BOTH
+        a `"metal-gpu"` and a `"heavy-lane"` `LockReceipt`, each
+        `held_continuously` -- no Metal observation exists without both
+        the outer heavy-lane and the GPU receipt.
+      - missing/empty resource samples: a `device == "metal"` cell must
+        carry >= 1 `ResourceSample` -- the contention/memory-footprint
+        proof the Metal lane's receipts promise.
+      - missing or misordered phase-event sequence: every non-unsupported
+        cell must carry a validated `load_start -> backend_ready ->
+        prefill_start -> prefill_end -> token_available(+)` sequence (see
+        `_validate_phase_sequence`) -- the measurement boundary must be
+        proven, not assumed.
       - non-finite metric: enforced already at `parse_cell_aggregate`
         (kept here as a defense-in-depth re-check for records built by
         hand rather than parsed from JSON).
-      - low valid-n / missing measured-CV (correction 1): a `PASS`/`WARN`/
-        `FAIL` cell (not `unsupported`) must carry `measured_cv` and
-        `n_valid >= required_n` from `bench_gate_math.required_n` at that
-        CV and the cell's noise class implied by `metric_family` -- a
-        cell with no `measured_cv` on record can never be validated as
-        sufficiently powered and is rejected outright.
+      - low valid-n / missing measured-CV / submitter-controlled
+        required_n (correction 1): a `PASS`/`WARN`/`FAIL` cell (not
+        `unsupported`) must carry `measured_cv`; the cell's noise class is
+        resolved from the REGISTERED per-metric policy
+        (`bench_gate_math.resolve_metric_policy`), never a family-name
+        heuristic, and its `required_n` is RE-DERIVED from that class and
+        the measured CV via `bench_gate_math.required_n` -- a record whose
+        `required_n` field is missing or does not match the re-derived
+        value is rejected outright (required_n is policy-derived, never
+        submitter-controlled), and so is `n_valid < required_n`. Class "C"
+        (informational/trend-only) metrics are exempt from this
+        derivation -- they never gate a required cell.
       - post-run threshold change: if `current_policy_sha` is given, it
         must equal `record.provenance.policy_sha` -- the gate must have
         been evaluated against the policy content it claims.
@@ -2047,6 +2141,23 @@ def validate_run_record(
                 f"INFRA-FAIL: cell {record.cell_id!r} is device=metal but carries no continuously-held "
                 "'metal-gpu' lock_receipt -- no Metal observation exists without a lock receipt"
             )
+        heavy_lane_locks = [
+            lr for lr in record.lock_receipts if lr.lock_name == "heavy-lane" and lr.held_continuously
+        ]
+        if not heavy_lane_locks:
+            raise RunRecordValidationError(
+                f"INFRA-FAIL: cell {record.cell_id!r} is device=metal but carries no continuously-held "
+                "'heavy-lane' lock_receipt -- Metal contention proof requires BOTH the outer "
+                "heavy-lane and the metal-gpu receipt, held continuously"
+            )
+        if not record.resource_samples:
+            raise RunRecordValidationError(
+                f"INFRA-FAIL: cell {record.cell_id!r} is device=metal but carries no resource_samples "
+                "-- the Metal contention/memory-footprint proof requires at least one sample"
+            )
+
+    if record.verdict != "unsupported":
+        _validate_phase_sequence(record.phase_events, record.cell_id)
 
     agg = record.aggregate
     for label, val in (("point_estimate", agg.point_estimate), ("ci_low", agg.ci_low), ("ci_high", agg.ci_high)):
@@ -2059,12 +2170,35 @@ def validate_run_record(
                 f"INFRA-FAIL: cell {record.cell_id!r} has no measured_cv on record -- correction 1 refuses "
                 "to promote/gate any cell whose required-n cannot be derived from a measured same-session CV"
             )
-        cell_class = "B" if record.metric_family in ("prefill_ttft", "memory") and record.metric_name != "prefill_tok_s" else "A"
-        if agg.required_n is not None and agg.n_valid < agg.required_n:
+        policy_doc = policy if policy is not None else bench_gate_math.load_policy()
+        try:
+            metric_policy = bench_gate_math.resolve_metric_policy(policy_doc, record.metric_family, record.metric_name)
+            noise_class = metric_policy["noise_class"]
+        except bench_gate_math.PolicyConfigError as exc:
             raise RunRecordValidationError(
-                f"INFRA-FAIL: cell {record.cell_id!r} n_valid={agg.n_valid} < required_n={agg.required_n} "
-                f"(measured_cv={agg.measured_cv}, class {cell_class}) -- n too small"
-            )
+                f"INFRA-FAIL: cell {record.cell_id!r}: {exc}"
+            ) from exc
+
+        if noise_class in ("A", "B"):
+            cv_bands = bench_gate_math.parse_cv_bands(policy_doc["cv_bands"])
+            try:
+                derived_required_n, _fail_margin = bench_gate_math.required_n(agg.measured_cv, cv_bands, noise_class)
+            except bench_gate_math.GateMathError as exc:
+                raise RunRecordValidationError(f"INFRA-FAIL: cell {record.cell_id!r}: {exc}") from exc
+            if agg.required_n != derived_required_n:
+                raise RunRecordValidationError(
+                    f"INFRA-FAIL: cell {record.cell_id!r} required_n={agg.required_n!r} does not match "
+                    f"the policy-derived required_n={derived_required_n!r} for measured_cv={agg.measured_cv!r} "
+                    f"class {noise_class!r} -- required_n is derived from the registered policy, "
+                    "never submitter-controlled metadata"
+                )
+            if agg.n_valid < derived_required_n:
+                raise RunRecordValidationError(
+                    f"INFRA-FAIL: cell {record.cell_id!r} n_valid={agg.n_valid} < required_n={derived_required_n} "
+                    f"(measured_cv={agg.measured_cv}, class {noise_class}) -- n too small"
+                )
+        # class "C": informational/trend-only, never gates a required cell
+        # (perf-policy.toml) -- no required_n derivation applies.
 
     if current_policy_sha is not None and record.provenance.policy_sha != current_policy_sha:
         raise RunRecordValidationError(
@@ -2080,20 +2214,74 @@ def validate_run_record(
         )
 
 
-def validate_promotion_record(record: PromotionRecord, *, min_null_sessions: int = 20) -> None:
-    """Correction 3, enforced: a `PromotionRecord` must have
-    `null_sessions >= min_null_sessions` (DESIGN.md's ">= 20 same-SHA
-    null A/A sessions"), and its asserted `cp_bound_95` must be >= the
-    TRUE Clopper-Pearson upper bound `bench_gate_math.clopper_pearson_upper`
-    computes from `(failures, null_sessions)` -- never a tighter,
-    aspirational number. This is what makes shadow-promotion honest: the
-    record reports the bound the math actually allows, not a claim that
-    298 sessions were run when only `null_sessions` were."""
-    if record.null_sessions < min_null_sessions:
+def validate_promotion_record(
+    record: PromotionRecord,
+    *,
+    policy: dict | None = None,
+    min_null_sessions: int | None = None,
+    min_mainline_sessions: int | None = None,
+) -> None:
+    """Correction 3, enforced, consuming the VERSIONED policy: an earlier
+    revision hard-coded `min_null_sessions=20` and never examined
+    `mainline_sessions` or a replacement cap at all:
+
+      - `null_sessions >= policy["promotion"]["min_null_aa_sessions"]`
+        (DESIGN.md's ">= 20 same-SHA null A/A sessions").
+      - `mainline_sessions >= policy["promotion"]["min_mainline_sessions"]`
+        -- a shadow cell needs live mainline evidence, not just null A/A
+        calibration, before promotion.
+      - `invalid_pair_replacements <= policy["promotion"]["max_invalid_pair_replacements"]`
+        -- an unbounded replacement budget would let a cell keep
+        re-rolling null sessions until it got a favorable run.
+      - the asserted `cp_bound_95` must be >= the TRUE Clopper-Pearson
+        upper bound `bench_gate_math.clopper_pearson_upper` computes from
+        `(failures, null_sessions)` -- never a tighter, aspirational
+        number.
+
+    `min_null_sessions`/`min_mainline_sessions` override the policy value
+    when explicitly supplied (mainly for tests); `policy` defaults to
+    `bench_gate_math.load_policy()` when not supplied.
+    """
+    policy_doc = policy if policy is not None else bench_gate_math.load_policy()
+    promotion_policy = policy_doc.get("promotion")
+    if not isinstance(promotion_policy, dict):
         raise RunRecordValidationError(
-            f"promotion of cell {record.cell_id!r} requires >= {min_null_sessions} null A/A sessions, "
+            "promotion policy: perf-policy.toml is missing or has a malformed [promotion] table"
+        )
+
+    resolved_min_null = min_null_sessions if min_null_sessions is not None else promotion_policy.get("min_null_aa_sessions")
+    resolved_min_mainline = (
+        min_mainline_sessions if min_mainline_sessions is not None else promotion_policy.get("min_mainline_sessions")
+    )
+    replacement_cap = promotion_policy.get("max_invalid_pair_replacements")
+    for label, val in (
+        ("min_null_aa_sessions", resolved_min_null),
+        ("min_mainline_sessions", resolved_min_mainline),
+        ("max_invalid_pair_replacements", replacement_cap),
+    ):
+        if isinstance(val, bool) or not isinstance(val, int) or val < 0:
+            raise RunRecordValidationError(
+                f"promotion policy: {label} must be a registered non-negative int, got {val!r} -- "
+                "an incomplete promotion policy fails closed, never defaults silently"
+            )
+
+    if record.null_sessions < resolved_min_null:
+        raise RunRecordValidationError(
+            f"promotion of cell {record.cell_id!r} requires >= {resolved_min_null} null A/A sessions, "
             f"got {record.null_sessions}"
         )
+    if record.mainline_sessions < resolved_min_mainline:
+        raise RunRecordValidationError(
+            f"promotion of cell {record.cell_id!r} requires >= {resolved_min_mainline} mainline sessions, "
+            f"got {record.mainline_sessions} -- null A/A calibration alone is not live mainline evidence"
+        )
+    if record.invalid_pair_replacements > replacement_cap:
+        raise RunRecordValidationError(
+            f"promotion of cell {record.cell_id!r} reports invalid_pair_replacements="
+            f"{record.invalid_pair_replacements}, exceeding the registered cap of {replacement_cap} -- "
+            "an exhausted replacement budget is an INFRA-FAIL, never a silent retry"
+        )
+
     true_bound = bench_gate_math.clopper_pearson_upper(record.failures, record.null_sessions)
     # Tolerance accommodates realistic rounding of a REPORTED bound (e.g.
     # "13.91%" rounded to 4 decimal places is 1e-5-scale below the exact

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -1467,8 +1467,8 @@ class CellAggregate:
 
 @dataclass(frozen=True)
 class CellRecord:
-    """One row of the north-star queryable shape (Ocean's gate
-    requirement, via Leo): "largest stable gaps by metric/context/quant"
+    """One row of the north-star queryable shape (program design
+    requirement): "largest stable gaps by metric/context/quant"
     must be queryable WITHOUT a later schema change. `cell_id`,
     `metric_family`, `context_point`, `quant_tier`, and `device` are the
     stable grouping/ranking keys; `aggregate` carries the point
@@ -2108,7 +2108,7 @@ def validate_promotion_record(record: PromotionRecord, *, min_null_sessions: int
 
 
 # --------------------------------------------------------------------------
-# North-star ranking query (Ocean's requirement, via Leo): "largest
+# North-star ranking query (program design requirement): "largest
 # stable gaps by metric/context/quant" must be queryable without a later
 # schema change. See tests/test_bench_run_record.py for the deterministic
 # proof.

--- a/scripts/bench_expected_cells.toml
+++ b/scripts/bench_expected_cells.toml
@@ -1,0 +1,91 @@
+# bench_expected_cells.toml — the expected-cell registry (DESIGN.md section 2
+# "Required matrix"). A matrix cell may be declared `unsupported`, but must
+# never silently disappear from a run: DESIGN.md — "an expected cell that
+# did not execute [is] infrastructure failure." This file is the SOURCE OF
+# TRUTH a coverage check expands against
+# (`bench_decode_harness.expand_cell_group` /
+# `bench_decode_harness.validate_registry_coverage`); a new supported
+# model/quant/backend family is added HERE, not hand-typed per cell_id.
+#
+# Each `[[group]]` is one row of DESIGN.md's required-matrix table,
+# expanded as the Cartesian product of its axes into individual
+# `cell_id`s of the form
+#   "<path>:<model_tier>:<quant_tier>:<device>:<context_or_batch>"
+# `anchor_*` fields select the SUBSET DESIGN.md calls the "small anchor in
+# hosted PR A/B" (PR 2's shadow smoke matrix); the full axis product is
+# only required at the group's own `required_in` cadence (e.g.
+# "scheduled_trend"). PR 1 lands this registry and its expansion/coverage
+# logic; PR 2-6 progressively wire real adapters and cadences against it
+# (DESIGN.md section 5) -- no cell in this file is executed by PR 1.
+
+schema_version = 1
+
+[[group]]
+name = "decode_cpu"
+path = "decode"
+metric_family = "decode"
+device = "cpu"
+model_tiers = ["qwen3.5-small"]
+quant_tiers = ["f16", "q8", "q4", "q4_quarot"]
+context_points = [128, 512, 1024, 2048, 4096]
+required_in = ["scheduled_trend"]
+anchor_quant_tiers = ["f16"]
+anchor_context_points = [512, 1024, 2048]
+anchor_required_in = ["hosted_pr_smoke"]
+
+[[group]]
+name = "decode_metal"
+path = "decode"
+metric_family = "decode"
+device = "metal"
+model_tiers = ["qwen3.5-small"]
+quant_tiers = ["f16", "q8", "q4", "q4_quarot"]
+context_points = [128, 512, 1024, 2048, 4096]
+required_in = ["scheduled_trend"]
+anchor_quant_tiers = ["q4"]
+anchor_context_points = [512, 1024, 2048]
+anchor_required_in = ["protected_metal_pr"]
+
+[[group]]
+name = "embed_cpu"
+path = "embed_encode"
+metric_family = "embed"
+device = "cpu"
+model_tiers = ["bert-encoder", "qwen3-embed"]
+quant_tiers = ["shipping"]
+context_points = [1, 8, 32]
+required_in = ["scheduled_trend"]
+anchor_quant_tiers = ["shipping"]
+anchor_context_points = [1, 8, 32]
+anchor_required_in = ["hosted_pr_smoke"]
+
+[[group]]
+name = "embed_metal"
+path = "embed_encode"
+metric_family = "embed"
+device = "metal"
+model_tiers = ["bert-encoder", "qwen3-embed"]
+quant_tiers = ["shipping"]
+context_points = [1, 8, 32]
+required_in = ["scheduled_trend"]
+anchor_quant_tiers = ["shipping"]
+anchor_context_points = [1, 8, 32]
+anchor_required_in = ["protected_metal_pr"]
+
+# Reserved, not Phase 1 (DESIGN.md section 2: "streaming MoE (reserved, not
+# Phase 1)"). Present in the registry so a future PR only needs to change
+# `required_in` from "reserved" to a live cadence, never invent a new
+# group shape; `required_in = ["reserved"]` never matches any live
+# cadence filter, so this group can never be treated as missing today.
+[[group]]
+name = "streaming_moe_reserved"
+path = "decode"
+metric_family = "decode"
+device = "cpu_metal_hybrid"
+model_tiers = ["qwen3.6-35b-moe"]
+quant_tiers = ["shipping"]
+context_points = [1024, 4096, 16384]
+required_in = ["reserved"]
+anchor_quant_tiers = []
+anchor_context_points = []
+anchor_required_in = ["reserved"]

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -251,6 +251,41 @@ def holm_reject(pvalues: Sequence[float], alpha: float = 0.05) -> list[bool]:
     return reject
 
 
+def _holm_tested_tails(pvalues: Sequence[float], alpha: float) -> tuple[list[bool], list[float]]:
+    """Internal: replicates `holm_reject`'s own ascending-p-value order and
+    step-down stopping rule to determine, for each cell in INPUT order,
+    whether the executed procedure actually evaluated that rank's `alpha /
+    (m - k)` tail before the first failed comparison halted it, and that
+    tail itself (`0.0` where untested -- callers must gate on the `tested`
+    flag, never use an untested tail).
+
+    The rank at which the procedure stops (its first failed comparison) WAS
+    tested -- it just did not reject. Only ranks STRICTLY AFTER that one
+    were never evaluated at their less-stringent tail; `holm_reject` never
+    ran a comparison for them, so no bound computed "at their tail" is an
+    executed Holm bound. Deliberately duplicates `holm_reject`'s loop
+    (rather than calling it) so a test that mocks/mutates the public
+    `holm_reject` symbol cannot also change which ranks this function
+    reports as tested -- testedness is a property of the real step-down
+    order, independent of whatever reject-decision function a caller
+    plugs in.
+    """
+    m = len(pvalues)
+    order = sorted(range(m), key=lambda i: pvalues[i])
+    tested = [False] * m
+    tail = [0.0] * m
+    still_rejecting = True
+    for k, i in enumerate(order):
+        if not still_rejecting:
+            break
+        crit = alpha / (m - k)
+        tested[i] = True
+        tail[i] = crit
+        if pvalues[i] > crit:
+            still_rejecting = False
+    return tested, tail
+
+
 # --------------------------------------------------------------------------
 # Correction 3: exact Clopper-Pearson bound, reported not asserted
 # --------------------------------------------------------------------------
@@ -462,12 +497,18 @@ class CellGateInput:
 @dataclass(frozen=True)
 class CellGateResult:
     """One cell's gate-evaluator verdict, alongside the numbers that
-    produced it (queryable/loggable without re-running the bootstrap)."""
+    produced it (queryable/loggable without re-running the bootstrap).
+
+    `corrected_lower_bound` is `None` when the Holm step-down procedure
+    never reached this cell's rank (it stopped at an earlier, more
+    significant rank first) -- there is no executed-at-this-tail bound to
+    report, and a cell in that state can never reach FAIL regardless of
+    its `holm_reject` flag (see `evaluate_family_gate`)."""
 
     cell_id: str
     point_estimate: float
     p_value: float
-    corrected_lower_bound: float
+    corrected_lower_bound: float | None
     holm_reject: bool
     measured_cv: float
     required_n: int
@@ -508,6 +549,16 @@ def evaluate_family_gate(
         stricter bound already gates every cell); the bound and the
         decision must be the SAME test, evaluated at the SAME per-cell
         alpha.
+      - A cell's rank is only assigned a bound if Holm's step-down
+        procedure actually EXECUTED a comparison at that rank. The
+        step-down stops at the first failed comparison (`holm_reject`);
+        every rank strictly after that stop was never tested at its
+        `alpha / (m - k)` tail, so `corrected_lower_bound` is `None` for
+        those cells -- reporting a bound at an untested, less-stringent
+        tail would expose FAIL-level-looking evidence for a hypothesis
+        the procedure never actually evaluated at that level, silently
+        disagreeing with its own `holm_reject` flag. A cell with a `None`
+        bound can never reach FAIL, regardless of its `holm_reject` value.
     Anything short of both, but with a point estimate past `warn_pct` (or
     past `fail_pct` without confirmed statistical significance), is WARN
     -- DESIGN.md: "a point estimate crossing with an inconclusive bound
@@ -551,26 +602,26 @@ def evaluate_family_gate(
         prelim.append((cell, req_n, margin, tau_fail, point_estimate, p))
 
     pvalues = [p for *_rest, p in prelim]
-    m = len(prelim)
     rejects = holm_reject(pvalues, alpha=alpha_familywise)
-    # The exact step-down tail each cell was tested at in `holm_reject`:
-    # ascending-p-value rank k (0-indexed) -> alpha/(m-k), matching that
-    # function's own `crit = alpha / (m - k)` at each step. Cell-specific,
-    # not the fixed alpha/m Bonferroni tail -- see the docstring above.
-    rank_order = sorted(range(m), key=lambda i: pvalues[i])
-    cell_alpha = [0.0] * m
-    for k, i in enumerate(rank_order):
-        cell_alpha[i] = alpha_familywise / (m - k)
+    # The exact step-down tail each cell was ACTUALLY TESTED at in the real
+    # Holm procedure -- `tested[i]` is False for any rank strictly after the
+    # step-down's first failed comparison (see `_holm_tested_tails`).
+    # Computed independently of `rejects` above (never derived from a
+    # caller-supplied/mocked `holm_reject`) so testedness always reflects
+    # the real step-down order.
+    tested, cell_alpha = _holm_tested_tails(pvalues, alpha_familywise)
 
     results: list[CellGateResult] = []
-    for (cell, req_n, margin, tau_fail, point_estimate, p), reject, corrected_alpha in zip(
-        prelim, rejects, cell_alpha
+    for (cell, req_n, margin, tau_fail, point_estimate, p), reject, corrected_alpha, was_tested in zip(
+        prelim, rejects, cell_alpha, tested
     ):
-        lower_bound = bootstrap_lower_bound(
-            cell.values, cell.order_ab, bootstrap_replicates, rng, corrected_alpha=corrected_alpha
-        )
+        lower_bound: float | None = None
+        if was_tested:
+            lower_bound = bootstrap_lower_bound(
+                cell.values, cell.order_ab, bootstrap_replicates, rng, corrected_alpha=corrected_alpha
+            )
         tau_warn = math.log(1.0 + cell.warn_pct)
-        if reject and lower_bound > tau_fail:
+        if reject and lower_bound is not None and lower_bound > tau_fail:
             verdict = "FAIL"
         elif point_estimate > tau_warn:
             verdict = "WARN"

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -9,11 +9,11 @@ dependency for the statistics a CI gate evaluator has to trust. Uses
 bound (not `scipy.stats.beta.ppf`) so this module never grows a third-party
 dependency the gate can't audit.
 
-Three of DESIGN.md's gate-math choices were adversarially checked against
-simulation before this module was written (Leo's math-verification pass,
-`.khive/workspaces/20260711/bench-overhaul-lattice-mathcheck/{sim.py,
-sim2_power_curve.py}` and their `*_output.txt` — internal artifacts, not
-committed here). All three corrections are encoded as executable functions,
+Three of this module's gate-math choices were adversarially checked against
+an independent Monte-Carlo simulation (power curves for the paired gate at
+several CV levels, bootstrap tail behavior at small n, and exact binomial
+bounds for promotion evidence) before the module was written.
+All three corrections are encoded as executable functions,
 not just prose, so the validator in `bench_decode_harness.py` can enforce
 them instead of merely documenting them:
 

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -149,6 +149,20 @@ def order_stratified_bootstrap_means(
     return means
 
 
+def _pvalue_from_boot_means(boot_means: Sequence[float], tau_log: float, b: int) -> float:
+    """Extraction-only half of `one_sided_bootstrap_pvalue`: turns an
+    ALREADY-GENERATED bootstrap-mean sample into the one-sided p-value,
+    without drawing any new resamples. Factored out so `evaluate_family_gate`
+    can derive the p-value and (later, at Holm's assigned tail) the lower
+    bound from the SAME retained sample instead of two independent bootstrap
+    draws — see `_lower_bound_from_sorted_boot_means` and the round-4
+    adversarial-review finding at `evaluate_family_gate`'s call sites for why
+    two independent draws break the percentile duality the module claims.
+    """
+    p = sum(1 for m in boot_means if m <= tau_log) / len(boot_means)
+    return max(p, 1.0 / b)
+
+
 def one_sided_bootstrap_pvalue(
     values: Sequence[float],
     order_ab: Sequence[bool],
@@ -162,8 +176,7 @@ def one_sided_bootstrap_pvalue(
     trivially always-reject.
     """
     boot_means = order_stratified_bootstrap_means(values, order_ab, b, rng)
-    p = sum(1 for m in boot_means if m <= tau_log) / len(boot_means)
-    return max(p, 1.0 / b)
+    return _pvalue_from_boot_means(boot_means, tau_log, b)
 
 
 def bootstrap_upper_bound(
@@ -194,6 +207,21 @@ def bootstrap_upper_bound(
     return boot_means[idx]
 
 
+def _lower_bound_from_sorted_boot_means(
+    sorted_boot_means: Sequence[float], *, corrected_alpha: float
+) -> float:
+    """Extraction-only half of `bootstrap_lower_bound`: turns an
+    ALREADY-GENERATED, ALREADY-SORTED bootstrap-mean sample into the
+    `corrected_alpha`-percentile lower bound, without drawing any new
+    resamples. See `_pvalue_from_boot_means` for why this split exists.
+    """
+    if not (0.0 < corrected_alpha < 1.0):
+        raise GateMathError(f"corrected_alpha must be in (0, 1), got {corrected_alpha!r}")
+    idx = min(len(sorted_boot_means) - 1, math.ceil(corrected_alpha * len(sorted_boot_means)) - 1)
+    idx = max(idx, 0)
+    return sorted_boot_means[idx]
+
+
 def bootstrap_lower_bound(
     values: Sequence[float],
     order_ab: Sequence[bool],
@@ -213,17 +241,18 @@ def bootstrap_lower_bound(
     sits at the alpha percentile, not `1 - alpha`
     (https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=917303).
 
-    This is the function `evaluate_family_gate` calls to populate
-    `CellGateResult.corrected_lower_bound`, which is in turn what a
-    validator must require to exceed the (margin-scaled) fail threshold
-    before confirming FAIL.
+    This is a standalone-resample convenience wrapper; `evaluate_family_gate`
+    does NOT call this function (it would draw a second, independent
+    bootstrap distribution from the one `one_sided_bootstrap_pvalue` already
+    drew for the same cell, breaking percentile duality between the p-value
+    and the bound — the round-4 adversarial-review finding). Instead it
+    calls `_lower_bound_from_sorted_boot_means` directly on the SAME sample
+    it already generated for the p-value.
     """
     if not (0.0 < corrected_alpha < 1.0):
         raise GateMathError(f"corrected_alpha must be in (0, 1), got {corrected_alpha!r}")
     boot_means = sorted(order_stratified_bootstrap_means(values, order_ab, b, rng))
-    idx = min(len(boot_means) - 1, math.ceil(corrected_alpha * len(boot_means)) - 1)
-    idx = max(idx, 0)
-    return boot_means[idx]
+    return _lower_bound_from_sorted_boot_means(boot_means, corrected_alpha=corrected_alpha)
 
 
 # --------------------------------------------------------------------------
@@ -574,13 +603,62 @@ def evaluate_family_gate(
 
     Order-preserving: `results[i]` corresponds to `cells[i]`, matching
     `holm_reject`'s own input-order-preserving contract.
+
+    Percentile duality (round-4 adversarial-review fix): the p-value and the
+    lower bound for a given cell are extracted from ONE retained
+    bootstrap-mean sample (`order_stratified_bootstrap_means` is called
+    exactly once per cell, up front), never from two independent bootstrap
+    draws. Drawing the bound from a second, independent resample -- the
+    prior shape of this function -- does not preserve the docstring's "SAME
+    test, evaluated at the SAME per-cell alpha" claim: a tested-but-not-
+    rejected cell could still expose a threshold-clearing bound purely from
+    resampling noise between the two draws (round-4 finding: single cell,
+    `base=log(1.07)+0.005`, `spread=0.02`, `bootstrap_replicates=2000`,
+    `random.Random(108)` gave `p_value=0.051` (correctly not rejected) but
+    an independently-drawn `corrected_lower_bound=0.0680872...`, above the
+    7% threshold `log(1.07)=0.06765864847381486`). With one shared sample,
+    `p_final > corrected_alpha` (not rejected) algebraically forces the
+    `corrected_alpha`-percentile bound to sit at or below tau: not-rejected
+    means `p_final = max(count(<=tau)/b, 1/b) > corrected_alpha`, so
+    (assuming the floor did not fire, guaranteed below) MORE than
+    `corrected_alpha * b` of the shared sample's means are already `<= tau`
+    -- at least as many as the bound's own rank `ceil(corrected_alpha *
+    b)`, so the bound (that rank's order statistic) is itself `<= tau`.
+
+    This duality only holds if the p-value floor (`max(p, 1/b)`, module
+    docstring correction 2) never sits ABOVE the tightest tail Holm will
+    actually test (`alpha_familywise / len(cells)`, at step-down rank 0):
+    a floored p-value that exceeds that tail could report not-rejected for
+    a cell whose true (unfloored, zero-count) bootstrap distribution is
+    entirely past tau -- which the shared sample would then also report as
+    a bound above tau. Rather than let that reintroduce the same class of
+    incoherence, this function fails closed (before any resampling) when
+    `bootstrap_replicates` is too small for the family size at
+    `alpha_familywise` to guarantee the floor can never sit above that
+    tightest tail.
     """
     if not cells:
         raise GateMathError("evaluate_family_gate requires at least one cell")
     if rng is None:
         rng = random.Random()
 
-    prelim: list[tuple[CellGateInput, int, float, float, float, float]] = []
+    smallest_tail = alpha_familywise / len(cells)
+    if bootstrap_replicates * smallest_tail < 1.0:
+        min_replicates = math.ceil(1.0 / smallest_tail)
+        raise GateMathError(
+            f"bootstrap_replicates={bootstrap_replicates} is too low for a family of {len(cells)} "
+            f"cell(s) at alpha_familywise={alpha_familywise}: the smallest tail Holm's step-down "
+            f"will ever test is alpha_familywise/{len(cells)}={smallest_tail!r}, and the p-value "
+            "floor `max(p, 1/b)` can only resolve tails of size >= 1/bootstrap_replicates. Fewer "
+            f"than {min_replicates} replicates lets the floor sit ABOVE that tightest tail, so a "
+            "cell whose true (unfloored) bootstrap count at that tail is genuinely zero -- every "
+            "bootstrap mean already past tau -- would be floored to a p-value that reports "
+            "not-rejected while its own shared-sample bound still clears the fail threshold, "
+            "reintroducing the exact p-value/bound incoherence this function otherwise fixes for "
+            "every executed rank. Increase bootstrap_replicates, or evaluate fewer cells per family."
+        )
+
+    prelim: list[tuple[CellGateInput, int, float, float, float, float, list[float]]] = []
     for cell in cells:
         if len(cell.values) != len(cell.order_ab):
             raise GateMathError(f"cell {cell.cell_id!r}: values and order_ab must be the same length")
@@ -598,10 +676,19 @@ def evaluate_family_gate(
             )
         tau_fail = math.log(1.0 + cell.fail_pct * margin)
         point_estimate = statistics.fmean(cell.values)
-        p = one_sided_bootstrap_pvalue(cell.values, cell.order_ab, tau_fail, bootstrap_replicates, rng)
-        prelim.append((cell, req_n, margin, tau_fail, point_estimate, p))
+        # ONE retained bootstrap-mean sample per cell -- both the p-value
+        # (now) and, if this rank is tested by the real step-down (below),
+        # the lower bound (later) are extracted from THIS SAME sample. Never
+        # call `one_sided_bootstrap_pvalue`/`bootstrap_lower_bound` here:
+        # each draws its own independent sample from `rng`, which is exactly
+        # the percentile-duality bug this restructure fixes.
+        boot_means = order_stratified_bootstrap_means(
+            cell.values, cell.order_ab, bootstrap_replicates, rng
+        )
+        p = _pvalue_from_boot_means(boot_means, tau_fail, bootstrap_replicates)
+        prelim.append((cell, req_n, margin, tau_fail, point_estimate, p, sorted(boot_means)))
 
-    pvalues = [p for *_rest, p in prelim]
+    pvalues = [p for *_rest, p, _boot in prelim]
     rejects = holm_reject(pvalues, alpha=alpha_familywise)
     # The exact step-down tail each cell was ACTUALLY TESTED at in the real
     # Holm procedure -- `tested[i]` is False for any rank strictly after the
@@ -612,13 +699,22 @@ def evaluate_family_gate(
     tested, cell_alpha = _holm_tested_tails(pvalues, alpha_familywise)
 
     results: list[CellGateResult] = []
-    for (cell, req_n, margin, tau_fail, point_estimate, p), reject, corrected_alpha, was_tested in zip(
-        prelim, rejects, cell_alpha, tested
-    ):
+    for (
+        cell,
+        req_n,
+        margin,
+        tau_fail,
+        point_estimate,
+        p,
+        sorted_boot_means,
+    ), reject, corrected_alpha, was_tested in zip(prelim, rejects, cell_alpha, tested):
         lower_bound: float | None = None
         if was_tested:
-            lower_bound = bootstrap_lower_bound(
-                cell.values, cell.order_ab, bootstrap_replicates, rng, corrected_alpha=corrected_alpha
+            # Same retained sample as the p-value above -- NOT a fresh
+            # `bootstrap_lower_bound` draw (see the docstring's percentile-
+            # duality note and that function's own docstring).
+            lower_bound = _lower_bound_from_sorted_boot_means(
+                sorted_boot_means, corrected_alpha=corrected_alpha
             )
         tau_warn = math.log(1.0 + cell.warn_pct)
         if reject and lower_bound is not None and lower_bound > tau_fail:

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Regression-gate statistics for the benchmark-overhaul contract (PR 1,
+"canonical contract and policy, in days" — DESIGN.md section 4
+"Regression-gating semantics").
+
+Stdlib-only, matching `bench_decode_harness.py`'s convention: no numpy/scipy
+dependency for the statistics a CI gate evaluator has to trust. Uses
+`random.Random` (not numpy's RNG) and a manual bisection Clopper-Pearson
+bound (not `scipy.stats.beta.ppf`) so this module never grows a third-party
+dependency the gate can't audit.
+
+Three of DESIGN.md's gate-math choices were adversarially checked against
+simulation before this module was written (Leo's math-verification pass,
+`.khive/workspaces/20260711/bench-overhaul-lattice-mathcheck/{sim.py,
+sim2_power_curve.py}` and their `*_output.txt` — internal artifacts, not
+committed here). All three corrections are encoded as executable functions,
+not just prose, so the validator in `bench_decode_harness.py` can enforce
+them instead of merely documenting them:
+
+  1. `required_n` — minimum `n` is a function of the MEASURED same-session
+     residual CV, not a fixed constant. At cv~=1% n=7 already has ~99%
+     power against a true 10% regression (Class-A decode family, FAIL=7%).
+     At cv~=3%, n=7 has only ~47-63% power; n~=23-25 restores ~80-84%. At
+     cv>=8%, even n=30 only reaches ~31% power against the same true
+     regression — inflating n further is not cost-effective, so that band
+     widens the FAIL margin instead (see `perf-policy.toml` `[[cv_bands]]`
+     `fail_margin_multiplier`). Bands are DATA in `perf-policy.toml`; this
+     module only looks them up and refuses to guess a required n for a
+     cell with no measured CV on record.
+
+  2. `order_stratified_bootstrap_means` bootstraps the MEAN of paired
+     log-slowdowns, never the median. At n=7 the bootstrap distribution of
+     the MEDIAN is a discrete distribution over AT MOST 7 possible values
+     (the 7 original order statistics — median of an odd-n sample is
+     always one of the original observations), regardless of bootstrap
+     replicate count B. A Holm-corrected per-cell tail cut at
+     alpha/5=0.01 needs finer resolution than 7 point masses can express;
+     the bootstrap mean does not have this ceiling.
+
+  3. `clopper_pearson_upper` computes the EXACT one-sided upper confidence
+     bound on a Bernoulli false-FAIL rate from (failures, sessions). 20
+     null A/A sessions with k=0 observed failures bounds the true rate to
+     only <=13.91% at 95% confidence — nowhere near "<1%". Reaching a
+     bound that itself proves <1% at 95% confidence from zero observed
+     failures needs ~298 sessions (`ln(0.05)/ln(0.99)`). DESIGN.md's
+     promotion criterion ("an observed false-FAIL rate below 1% per
+     workflow" after >=20 sessions) is a REPORTING requirement, not a
+     pre-registered upfront session count: the promotion record must
+     report the bound this function actually computes, never assert a
+     tighter one, and null sessions keep accruing nightly so the bound
+     tightens over time. See `PromotionRecord`/`validate_promotion_record`
+     in `bench_decode_harness.py`.
+
+Run with: python3 -m pytest tests/test_bench_gate_math.py -v
+(stdlib-only; no engine binaries, GPU, or third-party packages required).
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import statistics
+import tomllib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_POLICY_FILE = REPO_ROOT / "scripts" / "perf-policy.toml"
+
+CELL_CLASSES = ("A", "B", "C")
+
+
+class PolicyConfigError(ValueError):
+    """`perf-policy.toml` is malformed or fails a fail-closed structural check."""
+
+
+class GateMathError(ValueError):
+    """A gate-math computation was asked to do something statistically unsound
+    (e.g. compute a required-n for a CV with no matching band, or a Holm
+    correction over zero hypotheses)."""
+
+
+# --------------------------------------------------------------------------
+# Log-slowdown
+# --------------------------------------------------------------------------
+
+
+def log_slowdown(base: float, candidate: float, *, higher_is_better: bool) -> float:
+    """Paired log-slowdown for one A/B block (DESIGN.md section 4):
+
+    `log(candidate/base)` when lower is better (e.g. TTFT, per-token
+    latency), `log(base/candidate)` when higher is better (e.g. decode
+    tok/s). Positive = regression (candidate worse than base) in both
+    orientations.
+    """
+    if base <= 0 or candidate <= 0:
+        raise GateMathError(f"log_slowdown requires positive values, got base={base!r} candidate={candidate!r}")
+    if higher_is_better:
+        return math.log(base / candidate)
+    return math.log(candidate / base)
+
+
+# --------------------------------------------------------------------------
+# Correction 2: bootstrap the MEAN, never the median, at small n
+# --------------------------------------------------------------------------
+
+
+def order_stratified_bootstrap_means(
+    values: Sequence[float],
+    order_ab: Sequence[bool],
+    b: int,
+    rng: random.Random,
+) -> list[float]:
+    """Order-stratified bootstrap of the MEAN (correction 2 — never the
+    median at small n, see module docstring). Resamples within the AB
+    stratum and the BA stratum independently (so AB/BA balance in each
+    resample tracks the registered balanced design), concatenates, and
+    returns the mean of each of `b` resamples.
+
+    Degenerate stratification (all one order label) falls back to an
+    ordinary bootstrap over the whole sample — the paired design still
+    holds, only the AB/BA balance guarantee is unavailable.
+    """
+    if len(values) != len(order_ab):
+        raise GateMathError(
+            f"values and order_ab must be the same length, got {len(values)} and {len(order_ab)}"
+        )
+    if not values:
+        raise GateMathError("order_stratified_bootstrap_means requires at least one value")
+    if b < 1:
+        raise GateMathError("b (bootstrap replicate count) must be >= 1")
+
+    ab_idx = [i for i, ab in enumerate(order_ab) if ab]
+    ba_idx = [i for i, ab in enumerate(order_ab) if not ab]
+
+    means: list[float] = []
+    if not ab_idx or not ba_idx:
+        n = len(values)
+        for _ in range(b):
+            sample = [values[rng.randrange(n)] for _ in range(n)]
+            means.append(statistics.fmean(sample))
+        return means
+
+    for _ in range(b):
+        sample = [values[ab_idx[rng.randrange(len(ab_idx))]] for _ in range(len(ab_idx))]
+        sample += [values[ba_idx[rng.randrange(len(ba_idx))]] for _ in range(len(ba_idx))]
+        means.append(statistics.fmean(sample))
+    return means
+
+
+def one_sided_bootstrap_pvalue(
+    values: Sequence[float],
+    order_ab: Sequence[bool],
+    tau_log: float,
+    b: int,
+    rng: random.Random,
+) -> float:
+    """One-sided percentile-bootstrap p-value for H0: mean_slowdown <= tau vs
+    Ha: mean_slowdown > tau. `p = P*(boot_mean <= tau)`, floored at `1/b` so a
+    genuinely-zero empirical count never makes a downstream Holm correction
+    trivially always-reject.
+    """
+    boot_means = order_stratified_bootstrap_means(values, order_ab, b, rng)
+    p = sum(1 for m in boot_means if m <= tau_log) / len(boot_means)
+    return max(p, 1.0 / b)
+
+
+def bootstrap_upper_bound(
+    values: Sequence[float],
+    order_ab: Sequence[bool],
+    b: int,
+    rng: random.Random,
+    *,
+    corrected_alpha: float,
+) -> float:
+    """The `(1 - corrected_alpha)` percentile of the bootstrap mean
+    distribution — the corrected one-sided upper confidence bound DESIGN.md
+    requires alongside the p-value for the FAIL decision ("FAIL requires
+    both effect size and corrected confidence bound cross its threshold").
+    """
+    if not (0.0 < corrected_alpha < 1.0):
+        raise GateMathError(f"corrected_alpha must be in (0, 1), got {corrected_alpha!r}")
+    boot_means = sorted(order_stratified_bootstrap_means(values, order_ab, b, rng))
+    idx = min(len(boot_means) - 1, math.ceil((1.0 - corrected_alpha) * len(boot_means)) - 1)
+    idx = max(idx, 0)
+    return boot_means[idx]
+
+
+# --------------------------------------------------------------------------
+# Holm step-down correction
+# --------------------------------------------------------------------------
+
+
+def holm_reject(pvalues: Sequence[float], alpha: float = 0.05) -> list[bool]:
+    """Standard Holm step-down correction. Returns a same-length list of
+    reject flags (True = this hypothesis's cell is a statistically
+    confirmed FAIL under familywise alpha), aligned to the INPUT order of
+    `pvalues` (not the internal sort order)."""
+    m = len(pvalues)
+    if m == 0:
+        raise GateMathError("holm_reject requires at least one p-value")
+    order = sorted(range(m), key=lambda i: pvalues[i])
+    reject = [False] * m
+    still_rejecting = True
+    for k, i in enumerate(order):
+        crit = alpha / (m - k)
+        if still_rejecting and pvalues[i] <= crit:
+            reject[i] = True
+        else:
+            still_rejecting = False
+    return reject
+
+
+# --------------------------------------------------------------------------
+# Correction 3: exact Clopper-Pearson bound, reported not asserted
+# --------------------------------------------------------------------------
+
+
+def _binomial_cdf(k: int, n: int, p: float) -> float:
+    """P(X <= k) for X ~ Binomial(n, p), via direct summation (n is small
+    enough here — a few hundred sessions at most — that this is exact and
+    fast without needing the incomplete-beta machinery scipy provides)."""
+    if p <= 0.0:
+        return 1.0
+    if p >= 1.0:
+        return 1.0 if k >= n else 0.0
+    total = 0.0
+    for i in range(0, k + 1):
+        total += math.comb(n, i) * (p**i) * ((1 - p) ** (n - i))
+    return total
+
+
+def clopper_pearson_upper(k: int, n: int, conf: float = 0.95) -> float:
+    """Exact one-sided Clopper-Pearson upper confidence bound on a Bernoulli
+    rate, given `k` observed failures in `n` trials, at confidence `conf`.
+
+    Computed by bisection on `P(X <= k; n, p) = 1 - conf` (this CDF is
+    monotonically non-increasing in `p` for fixed `k, n`, so bisection is
+    well-posed) rather than `scipy.stats.beta.ppf`, keeping this module
+    stdlib-only. `k == n` (every session failed) has no finite bound below
+    1.0 and returns 1.0 directly.
+    """
+    if n <= 0:
+        raise GateMathError("clopper_pearson_upper requires n >= 1")
+    if k < 0 or k > n:
+        raise GateMathError(f"clopper_pearson_upper requires 0 <= k <= n, got k={k} n={n}")
+    if not (0.0 < conf < 1.0):
+        raise GateMathError(f"conf must be in (0, 1), got {conf!r}")
+    if k == n:
+        return 1.0
+
+    alpha = 1.0 - conf
+    lo, hi = 0.0, 1.0
+    for _ in range(100):  # bisection to well below float64 precision
+        mid = (lo + hi) / 2
+        if _binomial_cdf(k, n, mid) > alpha:
+            lo = mid
+        else:
+            hi = mid
+    return hi
+
+
+# --------------------------------------------------------------------------
+# Correction 1: measured-CV -> required-n policy lookup
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CvBand:
+    max_cv: float
+    required_n_class_a: int
+    required_n_class_b: int
+    fail_margin_multiplier: float
+    note: str = ""
+
+
+def parse_cv_bands(raw_bands: Sequence[dict]) -> list[CvBand]:
+    if not raw_bands:
+        raise PolicyConfigError("perf-policy.toml: [[cv_bands]] must define at least one band")
+    bands: list[CvBand] = []
+    prev_max = 0.0
+    for i, raw in enumerate(raw_bands):
+        for key in ("max_cv", "required_n_class_a", "required_n_class_b", "fail_margin_multiplier"):
+            if key not in raw:
+                raise PolicyConfigError(f"perf-policy.toml: cv_bands[{i}] missing required key {key!r}")
+        max_cv = raw["max_cv"]
+        if not isinstance(max_cv, (int, float)) or isinstance(max_cv, bool) or max_cv <= 0:
+            raise PolicyConfigError(f"perf-policy.toml: cv_bands[{i}] max_cv must be a positive number")
+        if max_cv <= prev_max:
+            raise PolicyConfigError(
+                f"perf-policy.toml: cv_bands must have strictly increasing max_cv, "
+                f"band[{i}] max_cv={max_cv} <= previous {prev_max}"
+            )
+        prev_max = max_cv
+        for n_key in ("required_n_class_a", "required_n_class_b"):
+            n_val = raw[n_key]
+            if isinstance(n_val, bool) or not isinstance(n_val, int) or n_val < 1:
+                raise PolicyConfigError(f"perf-policy.toml: cv_bands[{i}] {n_key} must be a positive int")
+        margin = raw["fail_margin_multiplier"]
+        if isinstance(margin, bool) or not isinstance(margin, (int, float)) or margin < 1.0:
+            raise PolicyConfigError(
+                f"perf-policy.toml: cv_bands[{i}] fail_margin_multiplier must be a number >= 1.0"
+            )
+        bands.append(
+            CvBand(
+                max_cv=float(max_cv),
+                required_n_class_a=raw["required_n_class_a"],
+                required_n_class_b=raw["required_n_class_b"],
+                fail_margin_multiplier=float(margin),
+                note=raw.get("note", ""),
+            )
+        )
+    if bands[-1].max_cv < 1.0:
+        raise PolicyConfigError(
+            f"perf-policy.toml: cv_bands must cover up to CV=1.0 (100%) with a catch-all band, "
+            f"last band tops out at {bands[-1].max_cv} -- an unbounded/uncovered CV must never "
+            f"silently fall through to 'no band matched'"
+        )
+    return bands
+
+
+def required_n(measured_cv: float, cv_bands: Sequence[CvBand], cell_class: str) -> tuple[int, float]:
+    """Look up `(required_n, fail_margin_multiplier)` for a measured CV and
+    cell class ("A" or "B"). The FIRST band whose `max_cv >= measured_cv`
+    wins (bands are pre-sorted ascending by `parse_cv_bands`). Raises
+    `GateMathError` for a negative CV or an unrecognized class — this
+    function is never asked to guess in the absence of a measured CV; the
+    CALLER (the run-record validator) is responsible for refusing
+    promotion of any cell lacking a `measured_cv` record in the first
+    place (correction 1's fail-closed requirement)."""
+    if measured_cv < 0:
+        raise GateMathError(f"measured_cv must be >= 0, got {measured_cv!r}")
+    if cell_class not in ("A", "B"):
+        raise GateMathError(f"cell_class must be 'A' or 'B', got {cell_class!r}")
+    for band in cv_bands:
+        if measured_cv <= band.max_cv:
+            return (
+                (band.required_n_class_a, band.fail_margin_multiplier)
+                if cell_class == "A"
+                else (band.required_n_class_b, band.fail_margin_multiplier)
+            )
+    raise GateMathError(
+        f"measured_cv={measured_cv!r} exceeds every registered cv_bands upper bound "
+        f"(highest is {cv_bands[-1].max_cv!r}) -- perf-policy.toml's catch-all band should have "
+        "prevented this; treat as a policy-config bug, not a valid cell"
+    )
+
+
+# --------------------------------------------------------------------------
+# Policy file loading
+# --------------------------------------------------------------------------
+
+
+def load_policy(path: Path = DEFAULT_POLICY_FILE) -> dict:
+    """Load and structurally validate `perf-policy.toml`. Returns the raw
+    parsed dict (callers pull specific sub-tables); `parse_cv_bands` is
+    applied separately since most callers only need the CV-band lookup."""
+    try:
+        with path.open("rb") as fh:
+            doc = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise PolicyConfigError(f"{path}: invalid TOML: {exc}") from exc
+    except OSError as exc:
+        raise PolicyConfigError(f"{path}: could not read policy file: {exc}") from exc
+
+    for key in ("policy_version", "cv_bands", "families", "promotion", "gate_math"):
+        if key not in doc:
+            raise PolicyConfigError(f"{path}: missing required top-level key {key!r}")
+    if isinstance(doc["policy_version"], bool) or not isinstance(doc["policy_version"], int):
+        raise PolicyConfigError(f"{path}: policy_version must be an int")
+    parse_cv_bands(doc["cv_bands"])  # raises PolicyConfigError on structural issues
+    return doc
+
+
+def policy_sha(path: Path = DEFAULT_POLICY_FILE) -> str:
+    """SHA-256 of the raw policy file bytes — the value a `ProvenanceRecord`
+    pins so a later re-validation can detect a post-run threshold change
+    (the policy content changed under the same or a different
+    `policy_version` after the run was gated)."""
+    import hashlib
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -175,14 +175,53 @@ def bootstrap_upper_bound(
     corrected_alpha: float,
 ) -> float:
     """The `(1 - corrected_alpha)` percentile of the bootstrap mean
-    distribution — the corrected one-sided upper confidence bound DESIGN.md
-    requires alongside the p-value for the FAIL decision ("FAIL requires
-    both effect size and corrected confidence bound cross its threshold").
+    distribution — a two-sided-diagnostic UPPER confidence bound, useful
+    for reporting/inspection only. This is NOT the bound the FAIL decision
+    consumes: `evaluate_family_gate`'s FAIL rule needs a one-sided LOWER
+    bound (a slowdown is positive and the claimed hypothesis is
+    `mean_slowdown > threshold`; confirming FAIL requires the LOWER bound
+    to itself exceed the threshold). Do not wire this function's result
+    into `CellAggregate.corrected_lower_bound` or any FAIL rule — use
+    `bootstrap_lower_bound` for that; an earlier revision of this module
+    conflated the two tails, which silently overstated regression
+    evidence.
     """
     if not (0.0 < corrected_alpha < 1.0):
         raise GateMathError(f"corrected_alpha must be in (0, 1), got {corrected_alpha!r}")
     boot_means = sorted(order_stratified_bootstrap_means(values, order_ab, b, rng))
     idx = min(len(boot_means) - 1, math.ceil((1.0 - corrected_alpha) * len(boot_means)) - 1)
+    idx = max(idx, 0)
+    return boot_means[idx]
+
+
+def bootstrap_lower_bound(
+    values: Sequence[float],
+    order_ab: Sequence[bool],
+    b: int,
+    rng: random.Random,
+    *,
+    corrected_alpha: float,
+) -> float:
+    """The `corrected_alpha` percentile of the bootstrap mean distribution
+    — the corrected ONE-SIDED LOWER confidence bound DESIGN.md's FAIL rule
+    actually needs alongside the p-value ("FAIL requires both effect size
+    and corrected confidence bound cross its threshold"). A slowdown is
+    positive and the claimed hypothesis is `mean_slowdown > threshold`; a
+    confirmed FAIL needs a LOWER one-sided bound above the threshold, not
+    an upper one (`bootstrap_upper_bound` computes the wrong tail for this
+    purpose — see its docstring). The percentile-interval lower endpoint
+    sits at the alpha percentile, not `1 - alpha`
+    (https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=917303).
+
+    This is the function `evaluate_family_gate` calls to populate
+    `CellGateResult.corrected_lower_bound`, which is in turn what a
+    validator must require to exceed the (margin-scaled) fail threshold
+    before confirming FAIL.
+    """
+    if not (0.0 < corrected_alpha < 1.0):
+        raise GateMathError(f"corrected_alpha must be in (0, 1), got {corrected_alpha!r}")
+    boot_means = sorted(order_stratified_bootstrap_means(values, order_ab, b, rng))
+    idx = min(len(boot_means) - 1, math.ceil(corrected_alpha * len(boot_means)) - 1)
     idx = max(idx, 0)
     return boot_means[idx]
 
@@ -345,6 +384,174 @@ def required_n(measured_cv: float, cv_bands: Sequence[CvBand], cell_class: str) 
         f"(highest is {cv_bands[-1].max_cv!r}) -- perf-policy.toml's catch-all band should have "
         "prevented this; treat as a policy-config bug, not a valid cell"
     )
+
+
+def resolve_metric_policy(policy_doc: dict, metric_family: str, metric_name: str) -> dict:
+    """Look up the registered per-metric policy table for
+    `(metric_family, metric_name)` in a loaded `perf-policy.toml` document
+    (`load_policy`'s return value). `[[families]]` entries come in two
+    shapes: a FLAT family table carrying its own `noise_class`/`warn_pct`/
+    `fail_pct` plus a `metrics` list of the metric names it covers (e.g.
+    `[families.decode]`), or a NESTED family table keyed by metric name,
+    each sub-table carrying its own `noise_class`/`warn_pct`/`fail_pct`
+    (e.g. `[families.prefill_ttft.ttft]`). This is the registered lookup
+    a validator MUST use to derive a cell's noise class -- never a
+    family-name heuristic: an earlier revision used a hard-coded
+    `family in (...)` shortcut that silently mis-classified
+    `embed.batch_p95` as class A when the policy registers it class B.
+
+    Raises `PolicyConfigError` when the family or metric is not
+    registered, or the resolved table has no valid `noise_class` -- an
+    unregistered metric can never be assumed class A (the cheapest,
+    least-scrutinized band).
+    """
+    families = policy_doc.get("families")
+    if not isinstance(families, dict):
+        raise PolicyConfigError("perf-policy.toml: [families] must be a table")
+    entry = families.get(metric_family)
+    if not isinstance(entry, dict):
+        raise PolicyConfigError(
+            f"perf-policy.toml: family {metric_family!r} is not registered under [families] "
+            "-- an unregistered family can never be assumed a default noise class"
+        )
+    if "metrics" in entry:
+        metrics = entry.get("metrics")
+        if not isinstance(metrics, list) or metric_name not in metrics:
+            raise PolicyConfigError(
+                f"perf-policy.toml: metric {metric_name!r} is not registered under family "
+                f"{metric_family!r} (registered metrics: {metrics!r})"
+            )
+        table = entry
+    else:
+        table = entry.get(metric_name)
+        if not isinstance(table, dict):
+            raise PolicyConfigError(
+                f"perf-policy.toml: metric {metric_name!r} is not registered under family "
+                f"{metric_family!r}"
+            )
+    noise_class = table.get("noise_class")
+    if noise_class not in CELL_CLASSES:
+        raise PolicyConfigError(
+            f"perf-policy.toml: family {metric_family!r} metric {metric_name!r} has no valid "
+            f"noise_class (must be one of {CELL_CLASSES}, got {noise_class!r})"
+        )
+    return table
+
+
+# --------------------------------------------------------------------------
+# Per-family gate evaluator (Holm + fail_margin_multiplier, integrated)
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CellGateInput:
+    """One required cell's raw paired log-slowdown samples plus its
+    registered family-policy thresholds (already resolved via
+    `resolve_metric_policy`), the input `evaluate_family_gate` needs to
+    reach a PASS/WARN/FAIL verdict for that cell within its family."""
+
+    cell_id: str
+    values: tuple[float, ...]
+    order_ab: tuple[bool, ...]
+    measured_cv: float
+    cell_class: str  # "A" or "B" -- selects the cv_bands column
+    warn_pct: float
+    fail_pct: float
+
+
+@dataclass(frozen=True)
+class CellGateResult:
+    """One cell's gate-evaluator verdict, alongside the numbers that
+    produced it (queryable/loggable without re-running the bootstrap)."""
+
+    cell_id: str
+    point_estimate: float
+    p_value: float
+    corrected_lower_bound: float
+    holm_reject: bool
+    measured_cv: float
+    required_n: int
+    fail_margin_multiplier: float
+    verdict: str  # "PASS" | "WARN" | "FAIL"
+
+
+def evaluate_family_gate(
+    cells: Sequence[CellGateInput],
+    cv_bands: Sequence[CvBand],
+    *,
+    alpha_familywise: float = 0.05,
+    bootstrap_replicates: int = 2000,
+    rng: random.Random | None = None,
+) -> list[CellGateResult]:
+    """The complete per-family gate evaluator: computes a one-sided
+    bootstrap p-value per required cell against that cell's own
+    (CV-band-margin-scaled) FAIL threshold, Holm-corrects the p-values
+    across every cell in the SAME required family at `alpha_familywise`
+    (never per-cell alpha -- an uncorrected per-cell 0.05 across N
+    required cells inflates the familywise false-FAIL rate to
+    `1 - (1 - 0.05)**N`), and combines the Holm-reject decision with the
+    corrected one-sided LOWER bound (`bootstrap_lower_bound`, never
+    `bootstrap_upper_bound` -- see that function's docstring) to reach a
+    verdict.
+
+    FAIL requires ALL of:
+      - Holm rejects H0 for this cell at `alpha_familywise` across the
+        family, AND
+      - the corrected one-sided LOWER bound itself exceeds
+        `fail_pct * fail_margin_multiplier` (the high-CV band widens the
+        margin instead of inflating `n` further -- correction 1).
+    Anything short of both, but with a point estimate past `warn_pct` (or
+    past `fail_pct` without confirmed statistical significance), is WARN
+    -- DESIGN.md: "a point estimate crossing with an inconclusive bound
+    is WARN, never PASS." Everything else is PASS.
+
+    Order-preserving: `results[i]` corresponds to `cells[i]`, matching
+    `holm_reject`'s own input-order-preserving contract.
+    """
+    if not cells:
+        raise GateMathError("evaluate_family_gate requires at least one cell")
+    if rng is None:
+        rng = random.Random()
+
+    prelim: list[tuple[CellGateInput, int, float, float, float, float]] = []
+    for cell in cells:
+        if len(cell.values) != len(cell.order_ab):
+            raise GateMathError(f"cell {cell.cell_id!r}: values and order_ab must be the same length")
+        req_n, margin = required_n(cell.measured_cv, cv_bands, cell.cell_class)
+        tau_fail = math.log(1.0 + cell.fail_pct * margin)
+        point_estimate = statistics.fmean(cell.values)
+        p = one_sided_bootstrap_pvalue(cell.values, cell.order_ab, tau_fail, bootstrap_replicates, rng)
+        prelim.append((cell, req_n, margin, tau_fail, point_estimate, p))
+
+    rejects = holm_reject([p for *_rest, p in prelim], alpha=alpha_familywise)
+    corrected_alpha = alpha_familywise / len(prelim)
+
+    results: list[CellGateResult] = []
+    for (cell, req_n, margin, tau_fail, point_estimate, p), reject in zip(prelim, rejects):
+        lower_bound = bootstrap_lower_bound(
+            cell.values, cell.order_ab, bootstrap_replicates, rng, corrected_alpha=corrected_alpha
+        )
+        tau_warn = math.log(1.0 + cell.warn_pct)
+        if reject and lower_bound > tau_fail:
+            verdict = "FAIL"
+        elif point_estimate > tau_warn:
+            verdict = "WARN"
+        else:
+            verdict = "PASS"
+        results.append(
+            CellGateResult(
+                cell_id=cell.cell_id,
+                point_estimate=point_estimate,
+                p_value=p,
+                corrected_lower_bound=lower_bound,
+                holm_reject=reject,
+                measured_cv=cell.measured_cv,
+                required_n=req_n,
+                fail_margin_multiplier=margin,
+                verdict=verdict,
+            )
+        )
+    return results
 
 
 # --------------------------------------------------------------------------

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -497,13 +497,29 @@ def evaluate_family_gate(
     FAIL requires ALL of:
       - Holm rejects H0 for this cell at `alpha_familywise` across the
         family, AND
-      - the corrected one-sided LOWER bound itself exceeds
-        `fail_pct * fail_margin_multiplier` (the high-CV band widens the
-        margin instead of inflating `n` further -- correction 1).
+      - that SAME cell's own Holm-assigned step-down tail (`alpha /
+        (m - rank)`, the exact level `holm_reject` tested it at, never a
+        single alpha/m Bonferroni tail fixed across the whole family)
+        exceeds `fail_pct * fail_margin_multiplier` (the high-CV band
+        widens the margin instead of inflating `n` further -- correction
+        1). Fixing every cell's bound at the strictest step-0 tail would
+        make Holm decision-inert (its reject flag could never be the
+        thing separating FAIL from non-FAIL, since a fixed, uniformly
+        stricter bound already gates every cell); the bound and the
+        decision must be the SAME test, evaluated at the SAME per-cell
+        alpha.
     Anything short of both, but with a point estimate past `warn_pct` (or
     past `fail_pct` without confirmed statistical significance), is WARN
     -- DESIGN.md: "a point estimate crossing with an inconclusive bound
     is WARN, never PASS." Everything else is PASS.
+
+    Fails closed (raises `GateMathError`) before any resampling if a
+    cell's raw pair count is short of its own policy-derived `required_n`
+    or contains a non-finite value -- this mirrors
+    `bench_decode_harness.validate_run_record`'s INFRA-FAIL treatment of
+    the same two conditions on an already-aggregated record, so a cell
+    can never reach a PASS/WARN/FAIL verdict on malformed or
+    under-sampled raw evidence via either entry point.
 
     Order-preserving: `results[i]` corresponds to `cells[i]`, matching
     `holm_reject`'s own input-order-preserving contract.
@@ -518,16 +534,38 @@ def evaluate_family_gate(
         if len(cell.values) != len(cell.order_ab):
             raise GateMathError(f"cell {cell.cell_id!r}: values and order_ab must be the same length")
         req_n, margin = required_n(cell.measured_cv, cv_bands, cell.cell_class)
+        if len(cell.values) < req_n:
+            raise GateMathError(
+                f"cell {cell.cell_id!r}: only {len(cell.values)} raw pairs, requires >= {req_n} "
+                f"at measured_cv={cell.measured_cv!r} class {cell.cell_class!r} -- an under-sampled cell "
+                "fails closed before any resampling, never PASSes on insufficient evidence"
+            )
+        if any(not math.isfinite(v) for v in cell.values):
+            raise GateMathError(
+                f"cell {cell.cell_id!r}: raw values contain a non-finite entry -- a malformed cell "
+                "fails closed before any resampling, never reaches a PASS/WARN/FAIL verdict"
+            )
         tau_fail = math.log(1.0 + cell.fail_pct * margin)
         point_estimate = statistics.fmean(cell.values)
         p = one_sided_bootstrap_pvalue(cell.values, cell.order_ab, tau_fail, bootstrap_replicates, rng)
         prelim.append((cell, req_n, margin, tau_fail, point_estimate, p))
 
-    rejects = holm_reject([p for *_rest, p in prelim], alpha=alpha_familywise)
-    corrected_alpha = alpha_familywise / len(prelim)
+    pvalues = [p for *_rest, p in prelim]
+    m = len(prelim)
+    rejects = holm_reject(pvalues, alpha=alpha_familywise)
+    # The exact step-down tail each cell was tested at in `holm_reject`:
+    # ascending-p-value rank k (0-indexed) -> alpha/(m-k), matching that
+    # function's own `crit = alpha / (m - k)` at each step. Cell-specific,
+    # not the fixed alpha/m Bonferroni tail -- see the docstring above.
+    rank_order = sorted(range(m), key=lambda i: pvalues[i])
+    cell_alpha = [0.0] * m
+    for k, i in enumerate(rank_order):
+        cell_alpha[i] = alpha_familywise / (m - k)
 
     results: list[CellGateResult] = []
-    for (cell, req_n, margin, tau_fail, point_estimate, p), reject in zip(prelim, rejects):
+    for (cell, req_n, margin, tau_fail, point_estimate, p), reject, corrected_alpha in zip(
+        prelim, rejects, cell_alpha
+    ):
         lower_bound = bootstrap_lower_bound(
             cell.values, cell.order_ab, bootstrap_replicates, rng, corrected_alpha=corrected_alpha
         )

--- a/scripts/perf-policy.toml
+++ b/scripts/perf-policy.toml
@@ -1,0 +1,177 @@
+# perf-policy.toml — versioned regression-gate policy (bench-overhaul PR 1,
+# "canonical contract and policy, in days" — DESIGN.md section 4
+# "Regression-gating semantics" and its "Initial registered policy" table).
+#
+# Kill-points, not aspirational targets. Changing a threshold, a cv_bands
+# entry, or a family's noise class requires rationale and a new
+# `policy_version` (DESIGN.md: "versioned in perf-policy.toml before shadow
+# runs; changing one requires rationale and a new policy version"). A run
+# record pins the SHA-256 of this file's bytes at gate time
+# (`bench_gate_math.policy_sha`) so `bench_decode_harness.validate_run_record`
+# can fail closed on a post-run threshold change — the recorded gate must
+# have been evaluated against the policy content it claims, not a policy
+# that drifted underneath the same version number.
+#
+# Loaded by `scripts/bench_gate_math.load_policy` (structural validation)
+# and consumed by `scripts/bench_decode_harness.py`'s schema-v2 run-record
+# validator. Never hand-parsed elsewhere — this file is data, not a second
+# copy of the gate logic.
+
+schema_version = 1
+policy_version = 1
+
+# ---------------------------------------------------------------------------
+# Correction 1 (mandatory gate correction, see PR description / DESIGN.md
+# addendum): required `n` is derived from the MEASURED same-session
+# residual CV of the null A/A calibration sessions on the Metal lane, not
+# fixed at n=7. The first null A/A sessions measure this CV; n=7 stands
+# only if measured CV ~= 1%. Bands are ordered ascending by `max_cv`; the
+# FIRST band whose `max_cv >= measured_cv` applies (see
+# `bench_gate_math.required_n`). The last band's `max_cv` must be >= 1.0
+# (100%) so no measured CV can fall through uncovered — enforced by
+# `bench_gate_math.parse_cv_bands`.
+#
+# Evidence (Leo's math-verification pass, mathcheck sim.py /
+# sim2_power_curve.py — internal artifacts, summarized here so the policy
+# is self-explaining without them): at cv~=1% n=7 already has ~99% power
+# against a true 10% regression (class A, decode family, FAIL=7%). At
+# cv~=3%, n=7 only has ~47-63% power; n~=23-25 restores ~80-84%. At
+# cv>=8%, even n=30 caps out near ~31% power — inflating n further stops
+# being cost-effective, so that band widens the FAIL margin instead
+# (`fail_margin_multiplier`) rather than chasing an ever-larger n.
+[[cv_bands]]
+max_cv = 0.015
+required_n_class_a = 7
+required_n_class_b = 9
+fail_margin_multiplier = 1.0
+note = "measured CV ~1%: n=7/9 as originally registered; ~99% power vs a true 10% regression."
+
+[[cv_bands]]
+max_cv = 0.05
+required_n_class_a = 25
+required_n_class_b = 25
+fail_margin_multiplier = 1.0
+note = "measured CV ~3%: n=7 has only ~47-63% power vs a true 10% regression; n=25 restores ~80-84%."
+
+[[cv_bands]]
+max_cv = 1.0
+required_n_class_a = 25
+required_n_class_b = 25
+fail_margin_multiplier = 2.0
+note = "measured CV >=8%: even n=30 only reaches ~31% power vs a true 10% regression -- widen the FAIL margin for this band instead of chasing n. A cell with no measured_cv record can never be assumed to land in the cheapest band; the validator refuses promotion of any such cell (correction 1's fail-closed requirement)."
+
+# ---------------------------------------------------------------------------
+# Gate-math method (Correction 2, mandatory): bootstrap the MEAN of paired
+# log-slowdowns, never the median, at small n. The bootstrap distribution
+# of the MEDIAN at n=7 is discrete over at most 7 point masses (median of
+# an odd-n sample is always one of the original observations) and cannot
+# represent a Holm-corrected per-cell tail cut of alpha/5=0.01. See
+# `bench_gate_math.order_stratified_bootstrap_means`.
+[gate_math]
+alpha_familywise = 0.05
+holm_correction = true
+bootstrap_statistic = "mean"
+bootstrap_replicates = 2000
+order_stratified = true
+
+# ---------------------------------------------------------------------------
+# Correction 3 (mandatory gate correction): shadow-promotion honesty.
+# Promotion is gated on `min_null_aa_sessions` (>= 20) and on the
+# PromotionRecord reporting the ACHIEVED Clopper-Pearson bound computed
+# from its own (null_sessions, failures) -- never an asserted bound
+# tighter than that math allows. 20 clean A/A sessions with zero observed
+# failures bounds the true false-FAIL rate to only <=13.91% at 95%
+# confidence, nowhere near "<1%"; reaching a bound that itself proves <1%
+# at 95% confidence from zero observed failures needs ~298 sessions
+# (`theoretical_sessions_for_bound_lt_1pct_at_95conf`, informational only
+# -- promotion is NOT gated on reaching it up front). Null A/A sessions
+# keep accruing nightly after promotion so the reported bound tightens
+# over time; see `bench_decode_harness.PromotionRecord` /
+# `validate_promotion_record`.
+[promotion]
+min_null_aa_sessions = 20
+min_mainline_sessions = 10
+target_false_fail_rate = 0.01
+theoretical_sessions_for_bound_lt_1pct_at_95conf = 298
+
+# ---------------------------------------------------------------------------
+# Initial registered policy (DESIGN.md section 4 table). `noise_class` is
+# "A" or "B" and selects the cv_bands column via `bench_gate_math.required_n`;
+# "C" families are informational/trend-only and never gate a required cell.
+# `warn_pct`/`fail_pct` are fractions (0.03 == 3%) of the corrected
+# one-sided slowdown bound, per DESIGN.md: "FAIL: ... corrected one-sided
+# lower bound exceeds" the fail_pct threshold; a point estimate crossing
+# with an inconclusive bound is WARN, never PASS.
+[families.decode]
+metrics = ["decode_tok_s", "median_token_ms"]
+noise_class = "A"
+warn_pct = 0.03
+fail_pct = 0.07
+other_rule = "Any required context cell can fail; do not average contexts."
+
+[families.prefill_ttft.prefill_tok_s]
+noise_class = "A"
+warn_pct = 0.05
+fail_pct = 0.10
+other_rule = "1024 and 2048 are always required when prefill/shared code changes."
+
+[families.prefill_ttft.ttft]
+noise_class = "B"
+warn_pct = 0.05
+fail_pct = 0.10
+other_rule = "Gate each context; trend quadratic coefficient and 1024->2048 knee ratio, initially informational."
+
+[families.prefill_ttft.per_token_p95]
+noise_class = "B"
+warn_pct = 0.05
+fail_pct = 0.10
+other_rule = "Trial-level quantiles; no token-as-independent-sample statistics."
+
+[families.prefill_ttft.per_token_p99]
+noise_class = "B"
+warn_pct = 0.10
+fail_pct = 0.15
+other_rule = "Trial-level quantiles; no token-as-independent-sample statistics."
+
+[families.memory.warm_peak_phys_footprint]
+noise_class = "B"
+warn_pct = 0.03
+fail_abs_mib = 64
+fail_pct = 0.05
+other_rule = "FAIL requires both >5% AND >64 MiB. Cold footprint and load-phase footprint warn/trend until variance is calibrated."
+
+[families.memory.model_load_time]
+noise_class = "C"
+warn_pct = 0.15
+fail_pct = 0.0
+other_rule = "15% point estimate WARN only, no FAIL initially. Promote after cache-state protocol is stable; always label process-cold versus filesystem-cold."
+
+[families.embed.texts_s]
+noise_class = "A"
+warn_pct = 0.05
+fail_pct = 0.10
+other_rule = "Gate each batch x length; no cross-cell averaging."
+
+[families.embed.tokens_s]
+noise_class = "A"
+warn_pct = 0.05
+fail_pct = 0.10
+other_rule = "Gate each batch x length; no cross-cell averaging."
+
+[families.embed.batch_p95]
+noise_class = "B"
+warn_pct = 0.10
+fail_pct = 0.15
+other_rule = "Minimum nine pairs."
+
+[families.criterion_quickmode_embed_simd]
+noise_class = "C"
+warn_pct = 0.0
+fail_pct = 0.0
+other_rule = "PR #872 quick-mode embed SIMD groups: visible delta only, never FAIL in quick mode. Full Criterion mode remains eligible after null-A/A calibration."
+
+[families.unclassified]
+noise_class = "C"
+warn_pct = 0.0
+fail_pct = 0.0
+other_rule = "New/unclassified group: visible delta only. Cannot become required without a policy-registry change and shadow evidence."

--- a/scripts/perf-policy.toml
+++ b/scripts/perf-policy.toml
@@ -31,9 +31,9 @@ policy_version = 1
 # (100%) so no measured CV can fall through uncovered — enforced by
 # `bench_gate_math.parse_cv_bands`.
 #
-# Evidence (Leo's math-verification pass, mathcheck sim.py /
-# sim2_power_curve.py — internal artifacts, summarized here so the policy
-# is self-explaining without them): at cv~=1% n=7 already has ~99% power
+# Evidence (cross-checked by an independent Monte-Carlo power simulation,
+# summarized here so the policy is self-explaining without it): at cv~=1%
+# n=7 already has ~99% power
 # against a true 10% regression (class A, decode family, FAIL=7%). At
 # cv~=3%, n=7 only has ~47-63% power; n~=23-25 restores ~80-84%. At
 # cv>=8%, even n=30 caps out near ~31% power — inflating n further stops
@@ -93,6 +93,15 @@ min_null_aa_sessions = 20
 min_mainline_sessions = 10
 target_false_fail_rate = 0.01
 theoretical_sessions_for_bound_lt_1pct_at_95conf = 298
+# Correction 3 addendum: a shadow cell's null A/A calibration sessions
+# can include invalid-pair
+# replacements (a pair discarded and re-run because of an infra hiccup,
+# not a real measurement). Capping how many replacements a promotion
+# record may report keeps "20 null sessions" honest -- an unbounded
+# replacement budget would let a cell keep re-rolling until it got a
+# favorable run. Exhausting the cap without a clean session is an
+# INFRA-FAIL for that promotion attempt, not a silent retry.
+max_invalid_pair_replacements = 3
 
 # ---------------------------------------------------------------------------
 # Initial registered policy (DESIGN.md section 4 table). `noise_class` is

--- a/tests/test_bench_gate_math.py
+++ b/tests/test_bench_gate_math.py
@@ -15,6 +15,7 @@ import random
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 _SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "bench_gate_math.py"
 _SPEC = importlib.util.spec_from_file_location("bench_gate_math", _SCRIPT)
@@ -484,6 +485,94 @@ class EvaluateFamilyGateTest(unittest.TestCase):
         self.assertNotEqual(results[0].verdict, "FAIL")
         self.assertNotEqual(results[1].verdict, "FAIL")
 
+    def test_holm_naive_mutation_flips_a_real_verdict(self):
+        """Adversarial-review finding: the prior fixture only proved
+        `holm_reject`'s internal flag was mutation-sensitive, not the
+        actual verdict -- every cell's lower bound was fixed at the
+        strictest step-0 Bonferroni tail regardless of Holm's per-cell
+        step-down assignment, so Holm's reject flag was never the thing
+        separating FAIL from non-FAIL. This fixture reuses the SAME
+        two-cell family as `test_holm_ordering_changes_the_verdict` and
+        directly swaps `holm_reject` for a naive uncorrected `p <= alpha`
+        check via `mock.patch.object`, re-running the evaluator with an
+        identically-seeded RNG so the bootstrap draws line up. Under the
+        real, coherent step-down evaluator neither cell reaches FAIL (the
+        family-level Holm step halts at the first cell); under the naive
+        mutation, the cell whose own rank-assigned tail already clears
+        its fail threshold DOES flip to FAIL -- the decision-effective
+        proof that Holm's step-down, not a fixed bound, drives the
+        verdict."""
+        tau = math.log(1.07)
+
+        def cell(cid):
+            base = tau + 0.005
+            spread = 0.02
+            values = (
+                base - spread, base + spread, base - spread * 0.5, base + spread * 0.5,
+                base - spread * 0.2, base + spread * 0.2, base,
+            )
+            order_ab = (True, False, True, False, True, False, True)
+            return gm.CellGateInput(
+                cell_id=cid, values=values, order_ab=order_ab,
+                measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+            )
+
+        cell_a, cell_b = cell("a"), cell("b")
+
+        real_results = gm.evaluate_family_gate(
+            [cell_a, cell_b], self._bands(), bootstrap_replicates=2000, rng=random.Random(0)
+        )
+        # Precondition matching test_holm_ordering_changes_the_verdict:
+        # the real, coherent evaluator confirms neither cell as FAIL.
+        self.assertFalse(real_results[0].holm_reject)
+        self.assertFalse(real_results[1].holm_reject)
+        self.assertNotEqual(real_results[0].verdict, "FAIL")
+        self.assertNotEqual(real_results[1].verdict, "FAIL")
+
+        def naive_reject(pvalues, alpha=0.05):
+            return [p <= alpha for p in pvalues]
+
+        with mock.patch.object(gm, "holm_reject", naive_reject):
+            mutated_results = gm.evaluate_family_gate(
+                [cell_a, cell_b], self._bands(), bootstrap_replicates=2000, rng=random.Random(0)
+            )
+
+        # The mutation must change at least one cell's ACTUAL verdict
+        # (not merely its internal holm_reject flag) from non-FAIL to
+        # FAIL -- proof that the shipped evaluator's FAIL rule depends on
+        # the real Holm step-down, not just on crossing a fixed bound.
+        flips = [
+            (real.cell_id, real.verdict, mutated.verdict)
+            for real, mutated in zip(real_results, mutated_results)
+            if real.verdict != "FAIL" and mutated.verdict == "FAIL"
+        ]
+        self.assertTrue(flips, f"expected at least one non-FAIL->FAIL flip, got {flips!r}")
+
+    def test_undersampled_cell_rejected_before_resampling(self):
+        """Major 3: a cell reporting fewer raw pairs than its own
+        policy-derived `required_n` must fail closed before any bootstrap
+        resampling, never reach a PASS/WARN/FAIL verdict on insufficient
+        evidence. One pair at measured_cv=0.01 (class A, required_n=7)."""
+        cell = gm.CellGateInput(
+            cell_id="undersampled", values=(math.log(1.10),), order_ab=(True,),
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        with self.assertRaisesRegex(gm.GateMathError, "requires >= 7"):
+            gm.evaluate_family_gate([cell], self._bands())
+
+    def test_non_finite_value_rejected_before_resampling(self):
+        """Major 3: seven raw pairs, one of them NaN, must fail closed
+        before any bootstrap resampling rather than propagate into a
+        NaN-bounded PASS verdict."""
+        values = (math.log(1.10),) * 6 + (float("nan"),)
+        order_ab = (True, False, True, False, True, False, True)
+        cell = gm.CellGateInput(
+            cell_id="nonfinite", values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        with self.assertRaisesRegex(gm.GateMathError, "non-finite"):
+            gm.evaluate_family_gate([cell], self._bands())
+
     def test_high_cv_margin_flips_fail_to_non_fail(self):
         """Adversarial fixture: the SAME
         effect size (a deterministic 8% slowdown) is a confirmed FAIL at
@@ -492,15 +581,21 @@ class EvaluateFamilyGateTest(unittest.TestCase):
         registered `fail_margin_multiplier` (2.0) widens the threshold --
         proving `fail_margin_multiplier` is actually consumed by the
         gate decision, not just unit-tested in isolation."""
-        order_ab = (True, False, True, False, True, False, True)
-        values = tuple([math.log(1.08)] * 7)  # deterministic 8% slowdown
+        order_ab_7 = (True, False, True, False, True, False, True)
+        values_7 = tuple([math.log(1.08)] * 7)  # deterministic 8% slowdown
+        # measured_cv=0.08 falls in the third band (required_n_class_a=25,
+        # fail_margin_multiplier=2.0) -- must supply >= 25 raw pairs or the
+        # under-sampled-cell guard (major 3) rejects before any bound is
+        # even computed.
+        order_ab_25 = tuple(i % 2 == 0 for i in range(25))
+        values_25 = tuple([math.log(1.08)] * 25)
 
         low_cv_cell = gm.CellGateInput(
-            cell_id="lowcv", values=values, order_ab=order_ab,
+            cell_id="lowcv", values=values_7, order_ab=order_ab_7,
             measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
         )
         high_cv_cell = gm.CellGateInput(
-            cell_id="highcv", values=values, order_ab=order_ab,
+            cell_id="highcv", values=values_25, order_ab=order_ab_25,
             measured_cv=0.08, cell_class="A", warn_pct=0.03, fail_pct=0.07,
         )
 

--- a/tests/test_bench_gate_math.py
+++ b/tests/test_bench_gate_math.py
@@ -485,34 +485,32 @@ class EvaluateFamilyGateTest(unittest.TestCase):
         self.assertNotEqual(results[0].verdict, "FAIL")
         self.assertNotEqual(results[1].verdict, "FAIL")
 
-    def test_holm_naive_mutation_flips_a_real_verdict(self):
-        """Adversarial-review finding: the prior fixture only proved
-        `holm_reject`'s internal flag was mutation-sensitive, not the
-        actual verdict -- every cell's lower bound was fixed at the
-        strictest step-0 Bonferroni tail regardless of Holm's per-cell
-        step-down assignment, so Holm's reject flag was never the thing
-        separating FAIL from non-FAIL.
+    def test_holm_naive_mutation_cannot_flip_a_coherent_verdict(self):
+        """Superseded by the round-4 percentile-duality fix (see
+        `evaluate_family_gate`'s docstring). Rounds 1-3 of this fixture
+        proved a naive uncorrected `p <= alpha` check could flip a cell's
+        ACTUAL verdict from non-FAIL to FAIL relative to real Holm, because
+        `corrected_lower_bound` was drawn from a resample INDEPENDENT of the
+        p-value -- so a tested-but-not-rejected cell's bound could still,
+        by resampling noise alone, clear the fail threshold, and only the
+        reject-decision function stood between that latent bound and a
+        FAIL verdict.
 
-        Follow-up adversarial-review finding: an intermediate fix made
-        every rank's bound track its Holm-assigned tail (`alpha / (m -
-        rank)`) unconditionally, but the step-down procedure actually
-        STOPS at its first failed comparison -- ranks after that stop are
-        never evaluated at their less-stringent tail, so exposing a bound
-        there was a bound for a hypothesis Holm never tested. This
-        fixture is tuned (base
-        offset/spread/seed) so the family's rank-0 cell (`b`, always
-        tested -- the step-down evaluates it before any stop can occur)
-        sits in the gap between its own strict Holm tail (alpha/2=0.025)
-        and the naive uncorrected `alpha=0.05` check: `b`'s real p-value
-        clears 0.05 but not 0.025, and `b`'s real (always-computed,
-        tested-rank) bound independently clears the fail threshold. That
-        makes `b` -- not the untested rank-1 cell `a` -- the cell whose
-        verdict is decision-sensitive to Holm's real per-cell tail:
-        swapping `holm_reject` for naive `p <= alpha` flips only `b` to
-        FAIL, and `a` remains unable to reach FAIL in either run because
-        the real step-down never tests rank 1 here (its bound is `None`
-        regardless of which reject-decision function is plugged in --
-        see `test_stopped_holm_rank_never_exposes_a_bound`)."""
+        Round 4 closed that gap by extracting the p-value and the bound
+        from the SAME retained sample: for any TESTED rank, `p <=
+        corrected_alpha` (reject) and `bound > tau` are now the same
+        percentile fact about the same sample, so they can no longer
+        disagree. Since `corrected_alpha = alpha_familywise / (m - rank) <=
+        alpha_familywise` for every tested rank, a real-Holm-reject is
+        always also a naive `p <= alpha_familywise` reject -- and by the
+        same duality, any cell the naive check additionally flags (but real
+        Holm did not) was already proven to have `bound <= tau`, so it can
+        never reach FAIL either way. This fixture (same base
+        offset/spread/seed that produced a flip pre-fix) now demonstrates
+        the INVARIANT the fix establishes: swapping the reject-decision
+        function still changes the internal `holm_reject` flags (confirmed
+        below), but the shipped verdict cannot move, because the bound and
+        the decision are the SAME test on the SAME sample."""
         tau = math.log(1.07)
 
         def cell(cid):
@@ -552,16 +550,20 @@ class EvaluateFamilyGateTest(unittest.TestCase):
                 [cell_a, cell_b], self._bands(), bootstrap_replicates=2000, rng=random.Random(15)
             )
 
-        # The mutation must change at least one cell's ACTUAL verdict
-        # (not merely its internal holm_reject flag) from non-FAIL to
-        # FAIL -- proof that the shipped evaluator's FAIL rule depends on
-        # the real Holm step-down, not just on crossing a fixed bound.
-        flips = [
-            (real.cell_id, real.verdict, mutated.verdict)
-            for real, mutated in zip(real_results, mutated_results)
-            if real.verdict != "FAIL" and mutated.verdict == "FAIL"
-        ]
-        self.assertTrue(flips, f"expected at least one non-FAIL->FAIL flip, got {flips!r}")
+        # The mutation DOES change the internal flag for `b` (real
+        # corrected_alpha=0.025 is stricter than the naive 0.05 -- `b`'s
+        # p-value clears naive but not the real per-cell tail), proving
+        # this fixture still exercises a genuine reject-function
+        # disagreement, not a vacuous no-op mutation.
+        self.assertFalse(real_results[1].holm_reject)
+        self.assertTrue(mutated_results[1].holm_reject)
+        # No cell's ACTUAL verdict changes despite that flag disagreement --
+        # the coherent bound/decision pairing makes the shipped verdict
+        # robust to which reject-decision function is plugged in.
+        for real, mutated in zip(real_results, mutated_results):
+            self.assertEqual(
+                real.verdict, mutated.verdict, f"cell {real.cell_id!r} verdict changed under mutation"
+            )
         # The untested rank (a) must stay un-FAIL-able even under the
         # naive mutation -- its bound is a property of the real step-down
         # order, not of whichever reject function is plugged in, so a
@@ -644,6 +646,95 @@ class EvaluateFamilyGateTest(unittest.TestCase):
                     f"non-rejected cell {r.cell_id!r} exposed a threshold-clearing bound "
                     f"{r.corrected_lower_bound!r} > tau_fail={tau!r}",
                 )
+
+    def test_shared_sample_pvalue_bound_duality_at_production_replicates(self):
+        """Round-4 adversarial-review finding (`scripts/bench_gate_math.py:601`
+        and `:620`, pre-fix): `evaluate_family_gate` drew the p-value's
+        bootstrap distribution and the lower bound's bootstrap distribution
+        from two INDEPENDENT resamples, so percentile duality was not
+        guaranteed even for a rank the step-down actually tested. Exact
+        reproduction from the round-4 review: a single (hence necessarily
+        tested, rank-0) cell with this seven-value near-boundary shape, at
+        the production default of `bootstrap_replicates=2000` and
+        `random.Random(108)`, reported `p_value=0.051` (correctly not
+        rejected -- 0.051 > alpha_familywise=0.05) yet a SEPARATELY-drawn
+        `corrected_lower_bound=0.0680872199023863`, which cleared the 7%
+        fail threshold `log(1.07)=0.06765864847381486` anyway -- a tested,
+        non-rejected cell exposing FAIL-level bound evidence, contradicting
+        the module's "SAME test, SAME per-cell alpha" claim.
+
+        Post-fix, the p-value and the bound are extracted from ONE shared
+        retained bootstrap-mean sample, so `not holm_reject` (this cell's
+        rank IS tested -- m=1 always tests rank 0) must imply the bound is
+        `None` or sits at or below tau, never a threshold-clearing float."""
+        tau = math.log(1.07)
+        base = tau + 0.005
+        spread = 0.02
+        values = (
+            base - spread, base + spread, base - spread * 0.5, base + spread * 0.5,
+            base - spread * 0.2, base + spread * 0.2, base,
+        )
+        order_ab = (True, False, True, False, True, False, True)
+        cell = gm.CellGateInput(
+            cell_id="decode:boundary", values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        results = gm.evaluate_family_gate(
+            [cell], self._bands(), bootstrap_replicates=2000, rng=random.Random(108)
+        )
+        result = results[0]
+        # The cell is tested (m=1 always tests rank 0) and not rejected.
+        self.assertIsNotNone(result.corrected_lower_bound)
+        self.assertFalse(result.holm_reject)
+        self.assertTrue(
+            result.corrected_lower_bound <= tau,
+            f"tested, non-rejected cell exposed a threshold-clearing bound "
+            f"{result.corrected_lower_bound!r} > tau_fail={tau!r}",
+        )
+        self.assertNotEqual(result.verdict, "FAIL")
+
+    def test_insufficient_replicates_for_floor_coherence_rejected(self):
+        """Round-4 fix, part 2 (replicate-floor coherence): the p-value
+        floor `max(p, 1/b)` (module docstring correction 2) exists so a
+        genuinely-zero empirical bootstrap count never trivially always-
+        rejects Holm -- but if `bootstrap_replicates` is too small relative
+        to the family size, that floor can itself sit ABOVE the tightest
+        tail Holm's step-down will ever test (`alpha_familywise /
+        len(cells)`, at rank 0). A cell whose true (unfloored) bootstrap
+        count at that tail is genuinely zero -- every one of its bootstrap
+        means already past tau -- would then be floored to a p-value that
+        reports not-rejected, while that SAME shared sample's bound (all
+        means above tau) still clears the fail threshold: the exact
+        p-value/bound incoherence the shared-sample fix otherwise
+        eliminates, reintroduced by an under-resolved floor instead of a
+        second independent draw. `evaluate_family_gate` fails closed before
+        any resampling when `bootstrap_replicates` cannot guarantee the
+        floor stays at or below that tightest tail."""
+        order_ab = (True, False, True, False, True, False, True)
+        values = tuple([math.log(1.10)] * 7)  # deterministic 10% slowdown, single cell
+        cell = gm.CellGateInput(
+            cell_id="decode:low-b", values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        # A single cell's tightest (only) tail is alpha_familywise/1=0.05;
+        # the floor needs bootstrap_replicates >= 1/0.05=20 to never exceed
+        # it. 10 replicates is short of that.
+        with self.assertRaises(gm.GateMathError):
+            gm.evaluate_family_gate([cell], self._bands(), bootstrap_replicates=10, rng=random.Random(1))
+        # A family of cells lowers the tightest tail further (rank 0 of an
+        # m-cell family tests alpha_familywise/m), raising the floor
+        # requirement proportionally -- 2000 replicates (the production
+        # default) is enough for up to 100 cells at alpha_familywise=0.05,
+        # but not for 200.
+        cells = [
+            gm.CellGateInput(
+                cell_id=f"decode:{i}", values=values, order_ab=order_ab,
+                measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+            )
+            for i in range(200)
+        ]
+        with self.assertRaises(gm.GateMathError):
+            gm.evaluate_family_gate(cells, self._bands(), bootstrap_replicates=2000, rng=random.Random(1))
 
     def test_undersampled_cell_rejected_before_resampling(self):
         """Major 3: a cell reporting fewer raw pairs than its own

--- a/tests/test_bench_gate_math.py
+++ b/tests/test_bench_gate_math.py
@@ -1,0 +1,315 @@
+"""Unit tests for scripts/bench_gate_math.py (bench-overhaul PR 1).
+
+Deterministic, seeded-RNG tests only -- no engine binary, GPU, or heavy
+lane required. Loaded by file path (matching test_bench_decode_harness.py's
+convention: scripts/ is not a package).
+
+Run with: python3 -m pytest tests/test_bench_gate_math.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import random
+import sys
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "bench_gate_math.py"
+_SPEC = importlib.util.spec_from_file_location("bench_gate_math", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+gm = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = gm
+_SPEC.loader.exec_module(gm)
+
+
+class LogSlowdownTest(unittest.TestCase):
+    def test_higher_is_better_regression(self):
+        # candidate throughput drops -> positive log-slowdown
+        val = gm.log_slowdown(base=100.0, candidate=90.0, higher_is_better=True)
+        self.assertGreater(val, 0)
+        self.assertAlmostEqual(val, math.log(100 / 90))
+
+    def test_lower_is_better_regression(self):
+        # candidate latency rises -> positive log-slowdown
+        val = gm.log_slowdown(base=10.0, candidate=12.0, higher_is_better=False)
+        self.assertGreater(val, 0)
+        self.assertAlmostEqual(val, math.log(12 / 10))
+
+    def test_improvement_is_negative(self):
+        val = gm.log_slowdown(base=100.0, candidate=110.0, higher_is_better=True)
+        self.assertLess(val, 0)
+
+    def test_non_positive_values_rejected(self):
+        with self.assertRaises(gm.GateMathError):
+            gm.log_slowdown(base=0.0, candidate=1.0, higher_is_better=True)
+        with self.assertRaises(gm.GateMathError):
+            gm.log_slowdown(base=1.0, candidate=-1.0, higher_is_better=True)
+
+
+# --------------------------------------------------------------------------
+# Correction 2: bootstrap the MEAN, never the median, at small n
+# --------------------------------------------------------------------------
+
+
+class BootstrapMeanTest(unittest.TestCase):
+    def test_mean_bootstrap_has_more_than_seven_distinct_values_at_n7(self):
+        """The whole point of correction 2: at n=7 the bootstrap
+        distribution of the MEDIAN is capped at <= 7 distinct point
+        masses (median of an odd-n sample is always one of the original
+        observations), but the MEAN is not so capped -- this is the
+        concrete, checkable difference the correction buys."""
+        rng = random.Random(42)
+        values = [1.0, 1.2, 0.9, 1.5, 0.7, 1.1, 1.3]
+        order_ab = [True, False, True, False, True, False, True]
+        means = gm.order_stratified_bootstrap_means(values, order_ab, 500, rng)
+        distinct_means = {round(m, 9) for m in means}
+        # 500 resamples of 7 elements -> many more than 7 distinct mean values
+        self.assertGreater(len(distinct_means), 7)
+
+    def test_median_of_odd_n_is_capped_at_n_distinct_values(self):
+        """Companion check proving the CONTRAST is real: bootstrapping the
+        median (not what this module does, but the thing correction 2
+        rejects) over the same data is capped at 7 distinct values."""
+        import statistics as _stats
+
+        rng = random.Random(42)
+        values = [1.0, 1.2, 0.9, 1.5, 0.7, 1.1, 1.3]
+        n = len(values)
+        medians = set()
+        for _ in range(500):
+            sample = [values[rng.randrange(n)] for _ in range(n)]
+            medians.add(round(_stats.median(sample), 9))
+        self.assertLessEqual(len(medians), n)
+
+    def test_mismatched_lengths_rejected(self):
+        rng = random.Random(1)
+        with self.assertRaises(gm.GateMathError):
+            gm.order_stratified_bootstrap_means([1.0, 2.0], [True], 10, rng)
+
+    def test_empty_values_rejected(self):
+        rng = random.Random(1)
+        with self.assertRaises(gm.GateMathError):
+            gm.order_stratified_bootstrap_means([], [], 10, rng)
+
+    def test_degenerate_stratification_falls_back(self):
+        rng = random.Random(7)
+        values = [1.0, 2.0, 3.0, 4.0]
+        order_ab = [True, True, True, True]  # no BA stratum
+        means = gm.order_stratified_bootstrap_means(values, order_ab, 100, rng)
+        self.assertEqual(len(means), 100)
+
+    def test_bootstrap_pvalue_floored_at_one_over_b(self):
+        rng = random.Random(3)
+        # All slowdowns far above tau -> p should floor at 1/b, never hit 0
+        values = [5.0] * 7
+        order_ab = [True, False, True, False, True, False, True]
+        p = gm.one_sided_bootstrap_pvalue(values, order_ab, tau_log=0.01, b=200, rng=rng)
+        self.assertEqual(p, 1.0 / 200)
+
+    def test_bootstrap_pvalue_high_when_null(self):
+        rng = random.Random(9)
+        values = [0.0] * 7  # exactly at tau=0
+        order_ab = [True, False, True, False, True, False, True]
+        p = gm.one_sided_bootstrap_pvalue(values, order_ab, tau_log=0.5, b=500, rng=rng)
+        self.assertGreater(p, 0.5)
+
+    def test_upper_bound_is_between_min_and_max(self):
+        rng = random.Random(11)
+        values = [0.1, 0.2, 0.15, 0.3, 0.05, 0.25, 0.18]
+        order_ab = [True, False, True, False, True, False, True]
+        bound = gm.bootstrap_upper_bound(values, order_ab, 1000, rng, corrected_alpha=0.01)
+        self.assertGreaterEqual(bound, min(values) - 1e-6)
+        self.assertLessEqual(bound, max(values) + 1e-6)
+
+    def test_invalid_alpha_rejected(self):
+        rng = random.Random(1)
+        with self.assertRaises(gm.GateMathError):
+            gm.bootstrap_upper_bound([1.0], [True], 10, rng, corrected_alpha=1.5)
+
+
+# --------------------------------------------------------------------------
+# Holm step-down
+# --------------------------------------------------------------------------
+
+
+class HolmRejectTest(unittest.TestCase):
+    def test_all_significant_all_rejected(self):
+        pvals = [0.001, 0.002, 0.003]
+        self.assertEqual(gm.holm_reject(pvals, alpha=0.05), [True, True, True])
+
+    def test_none_significant_none_rejected(self):
+        pvals = [0.9, 0.8, 0.7]
+        self.assertEqual(gm.holm_reject(pvals, alpha=0.05), [False, False, False])
+
+    def test_step_down_stops_at_first_failure(self):
+        # smallest p rejected (0.01 <= 0.05/3), second p 0.02 <= 0.05/2 rejected,
+        # third p 0.5 > 0.05/1 not rejected
+        pvals = [0.5, 0.02, 0.01]
+        result = gm.holm_reject(pvals, alpha=0.05)
+        self.assertEqual(result, [False, True, True])
+
+    def test_input_order_preserved(self):
+        pvals = [0.5, 0.001]
+        result = gm.holm_reject(pvals, alpha=0.05)
+        self.assertEqual(len(result), 2)
+        self.assertFalse(result[0])
+        self.assertTrue(result[1])
+
+    def test_empty_rejected(self):
+        with self.assertRaises(gm.GateMathError):
+            gm.holm_reject([])
+
+    def test_single_hypothesis(self):
+        self.assertEqual(gm.holm_reject([0.01], alpha=0.05), [True])
+        self.assertEqual(gm.holm_reject([0.5], alpha=0.05), [False])
+
+
+# --------------------------------------------------------------------------
+# Correction 3: exact Clopper-Pearson bound
+# --------------------------------------------------------------------------
+
+
+class ClopperPearsonTest(unittest.TestCase):
+    def test_zero_failures_twenty_sessions_matches_mathcheck(self):
+        # Leo's mathcheck sim.py: n=20, k=0 -> 95% upper CP bound = 13.91%
+        bound = gm.clopper_pearson_upper(k=0, n=20, conf=0.95)
+        self.assertAlmostEqual(bound, 0.1391, places=3)
+
+    def test_zero_failures_three_hundred_sessions_below_one_percent(self):
+        # mathcheck: n=300, k=0 -> 95% upper CP bound = 0.99%
+        bound = gm.clopper_pearson_upper(k=0, n=300, conf=0.95)
+        self.assertLess(bound, 0.01)
+        self.assertAlmostEqual(bound, 0.0099, places=3)
+
+    def test_bound_widens_with_more_failures(self):
+        b0 = gm.clopper_pearson_upper(k=0, n=20, conf=0.95)
+        b1 = gm.clopper_pearson_upper(k=1, n=20, conf=0.95)
+        b2 = gm.clopper_pearson_upper(k=2, n=20, conf=0.95)
+        self.assertLess(b0, b1)
+        self.assertLess(b1, b2)
+
+    def test_bound_tightens_with_more_sessions_at_same_k(self):
+        b20 = gm.clopper_pearson_upper(k=0, n=20, conf=0.95)
+        b100 = gm.clopper_pearson_upper(k=0, n=100, conf=0.95)
+        b500 = gm.clopper_pearson_upper(k=0, n=500, conf=0.95)
+        self.assertGreater(b20, b100)
+        self.assertGreater(b100, b500)
+
+    def test_k_equals_n_returns_one(self):
+        self.assertEqual(gm.clopper_pearson_upper(k=5, n=5, conf=0.95), 1.0)
+
+    def test_invalid_k_n_rejected(self):
+        with self.assertRaises(gm.GateMathError):
+            gm.clopper_pearson_upper(k=-1, n=10)
+        with self.assertRaises(gm.GateMathError):
+            gm.clopper_pearson_upper(k=11, n=10)
+        with self.assertRaises(gm.GateMathError):
+            gm.clopper_pearson_upper(k=0, n=0)
+
+    def test_twenty_sessions_cannot_prove_sub_one_percent(self):
+        """The core honesty check correction 3 encodes: 20 null A/A
+        sessions with zero failures does NOT prove <1% false-FAIL --
+        it only bounds it to <=13.91%."""
+        bound = gm.clopper_pearson_upper(k=0, n=20, conf=0.95)
+        self.assertGreater(bound, 0.01)
+
+
+# --------------------------------------------------------------------------
+# Correction 1: measured-CV -> required-n bands
+# --------------------------------------------------------------------------
+
+
+class CvBandsTest(unittest.TestCase):
+    def _bands(self):
+        return gm.parse_cv_bands(
+            [
+                {"max_cv": 0.015, "required_n_class_a": 7, "required_n_class_b": 9, "fail_margin_multiplier": 1.0},
+                {"max_cv": 0.05, "required_n_class_a": 25, "required_n_class_b": 25, "fail_margin_multiplier": 1.0},
+                {"max_cv": 1.0, "required_n_class_a": 25, "required_n_class_b": 25, "fail_margin_multiplier": 2.0},
+            ]
+        )
+
+    def test_low_cv_keeps_n7(self):
+        bands = self._bands()
+        n, margin = gm.required_n(0.01, bands, "A")
+        self.assertEqual(n, 7)
+        self.assertEqual(margin, 1.0)
+
+    def test_moderate_cv_requires_n25(self):
+        bands = self._bands()
+        n, margin = gm.required_n(0.03, bands, "A")
+        self.assertEqual(n, 25)
+
+    def test_high_cv_widens_margin_not_n(self):
+        bands = self._bands()
+        n, margin = gm.required_n(0.08, bands, "A")
+        self.assertEqual(n, 25)  # not inflated further
+        self.assertEqual(margin, 2.0)  # margin widened instead
+
+    def test_class_b_uses_class_b_column(self):
+        bands = self._bands()
+        n, _ = gm.required_n(0.01, bands, "B")
+        self.assertEqual(n, 9)
+
+    def test_negative_cv_rejected(self):
+        bands = self._bands()
+        with self.assertRaises(gm.GateMathError):
+            gm.required_n(-0.01, bands, "A")
+
+    def test_invalid_class_rejected(self):
+        bands = self._bands()
+        with self.assertRaises(gm.GateMathError):
+            gm.required_n(0.01, bands, "Z")
+
+    def test_empty_bands_rejected(self):
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.parse_cv_bands([])
+
+    def test_bands_must_be_strictly_increasing(self):
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.parse_cv_bands(
+                [
+                    {"max_cv": 0.05, "required_n_class_a": 7, "required_n_class_b": 9, "fail_margin_multiplier": 1.0},
+                    {"max_cv": 0.02, "required_n_class_a": 25, "required_n_class_b": 25, "fail_margin_multiplier": 1.0},
+                ]
+            )
+
+    def test_bands_must_reach_one(self):
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.parse_cv_bands(
+                [{"max_cv": 0.1, "required_n_class_a": 7, "required_n_class_b": 9, "fail_margin_multiplier": 1.0}]
+            )
+
+    def test_missing_key_rejected(self):
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.parse_cv_bands([{"max_cv": 1.0, "required_n_class_a": 7, "required_n_class_b": 9}])
+
+
+# --------------------------------------------------------------------------
+# perf-policy.toml load (real, shipped file)
+# --------------------------------------------------------------------------
+
+
+class LoadPolicyTest(unittest.TestCase):
+    def test_shipped_policy_file_loads(self):
+        doc = gm.load_policy()
+        self.assertEqual(doc["policy_version"], 1)
+        self.assertIn("families", doc)
+        self.assertIn("decode", doc["families"])
+
+    def test_policy_sha_is_stable_hex_digest(self):
+        sha1 = gm.policy_sha()
+        sha2 = gm.policy_sha()
+        self.assertEqual(sha1, sha2)
+        self.assertEqual(len(sha1), 64)
+        int(sha1, 16)  # must be valid hex
+
+    def test_missing_file_rejected(self):
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.load_policy(Path("/nonexistent/perf-policy.toml"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_gate_math.py
+++ b/tests/test_bench_gate_math.py
@@ -129,6 +129,48 @@ class BootstrapMeanTest(unittest.TestCase):
             gm.bootstrap_upper_bound([1.0], [True], 10, rng, corrected_alpha=1.5)
 
 
+class BootstrapLowerBoundTest(unittest.TestCase):
+    """The FAIL rule needs a one-sided LOWER bound, not
+    `bootstrap_upper_bound`'s `(1 - alpha)` upper tail. These fixtures
+    pin the orientation."""
+
+    def test_near_null_lower_bound_at_or_below_threshold(self):
+        # point estimate (mean=0.07) sits just above threshold
+        # log(1.07)=0.067659, but the sample has enough spread that the
+        # corrected LOWER bound must sit at or below the threshold --
+        # i.e. this is NOT a confirmed FAIL.
+        tau = math.log(1.07)
+        values = [0.05, 0.09, 0.06, 0.08, 0.04, 0.10, 0.07]
+        order_ab = [True, False, True, False, True, False, True]
+        rng = random.Random(123)
+        lower = gm.bootstrap_lower_bound(values, order_ab, 2000, rng, corrected_alpha=0.01)
+        self.assertLessEqual(lower, tau)
+
+    def test_stable_ten_percent_slowdown_lower_bound_above_threshold(self):
+        # a deterministic (zero-variance) 10% slowdown must clear the 7%
+        # FAIL threshold at the corrected LOWER bound.
+        tau = math.log(1.07)
+        values = [math.log(1.10)] * 7
+        order_ab = [True, False, True, False, True, False, True]
+        rng = random.Random(123)
+        lower = gm.bootstrap_lower_bound(values, order_ab, 2000, rng, corrected_alpha=0.01)
+        self.assertGreater(lower, tau)
+
+    def test_lower_bound_never_exceeds_upper_bound(self):
+        rng_lo = random.Random(11)
+        rng_hi = random.Random(11)
+        values = [0.1, 0.2, 0.15, 0.3, 0.05, 0.25, 0.18]
+        order_ab = [True, False, True, False, True, False, True]
+        lower = gm.bootstrap_lower_bound(values, order_ab, 1000, rng_lo, corrected_alpha=0.01)
+        upper = gm.bootstrap_upper_bound(values, order_ab, 1000, rng_hi, corrected_alpha=0.01)
+        self.assertLessEqual(lower, upper)
+
+    def test_invalid_alpha_rejected(self):
+        rng = random.Random(1)
+        with self.assertRaises(gm.GateMathError):
+            gm.bootstrap_lower_bound([1.0], [True], 10, rng, corrected_alpha=0.0)
+
+
 # --------------------------------------------------------------------------
 # Holm step-down
 # --------------------------------------------------------------------------
@@ -172,13 +214,14 @@ class HolmRejectTest(unittest.TestCase):
 
 
 class ClopperPearsonTest(unittest.TestCase):
-    def test_zero_failures_twenty_sessions_matches_mathcheck(self):
-        # Leo's mathcheck sim.py: n=20, k=0 -> 95% upper CP bound = 13.91%
+    def test_zero_failures_twenty_sessions_matches_independent_check(self):
+        # cross-checked against an independent Monte-Carlo simulation:
+        # n=20, k=0 -> 95% upper CP bound = 13.91%
         bound = gm.clopper_pearson_upper(k=0, n=20, conf=0.95)
         self.assertAlmostEqual(bound, 0.1391, places=3)
 
     def test_zero_failures_three_hundred_sessions_below_one_percent(self):
-        # mathcheck: n=300, k=0 -> 95% upper CP bound = 0.99%
+        # independent check: n=300, k=0 -> 95% upper CP bound = 0.99%
         bound = gm.clopper_pearson_upper(k=0, n=300, conf=0.95)
         self.assertLess(bound, 0.01)
         self.assertAlmostEqual(bound, 0.0099, places=3)
@@ -309,6 +352,187 @@ class LoadPolicyTest(unittest.TestCase):
     def test_missing_file_rejected(self):
         with self.assertRaises(gm.PolicyConfigError):
             gm.load_policy(Path("/nonexistent/perf-policy.toml"))
+
+
+# --------------------------------------------------------------------------
+# Registered per-metric policy lookup (never a family heuristic)
+# --------------------------------------------------------------------------
+
+
+class ResolveMetricPolicyTest(unittest.TestCase):
+    def test_flat_family_metric_resolves_class_a(self):
+        doc = gm.load_policy()
+        table = gm.resolve_metric_policy(doc, "decode", "decode_tok_s")
+        self.assertEqual(table["noise_class"], "A")
+
+    def test_nested_family_metric_resolves_class_b(self):
+        # embed.batch_p95 is registered class B (min nine pairs) -- a
+        # family-name heuristic that lumped every embed metric into class
+        # A family-name heuristic would silently under-require this cell.
+        doc = gm.load_policy()
+        table = gm.resolve_metric_policy(doc, "embed", "batch_p95")
+        self.assertEqual(table["noise_class"], "B")
+
+    def test_nested_family_sibling_metric_resolves_class_a(self):
+        doc = gm.load_policy()
+        table = gm.resolve_metric_policy(doc, "embed", "texts_s")
+        self.assertEqual(table["noise_class"], "A")
+
+    def test_unregistered_family_rejected(self):
+        doc = gm.load_policy()
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.resolve_metric_policy(doc, "bogus_family", "decode_tok_s")
+
+    def test_unregistered_metric_in_flat_family_rejected(self):
+        doc = gm.load_policy()
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.resolve_metric_policy(doc, "decode", "bogus_metric")
+
+    def test_unregistered_metric_in_nested_family_rejected(self):
+        doc = gm.load_policy()
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.resolve_metric_policy(doc, "embed", "bogus_metric")
+
+    def test_class_c_metric_resolves(self):
+        doc = gm.load_policy()
+        table = gm.resolve_metric_policy(doc, "memory", "model_load_time")
+        self.assertEqual(table["noise_class"], "C")
+
+
+# --------------------------------------------------------------------------
+# The complete per-family gate evaluator (Holm + fail_margin_multiplier,
+# integrated -- not just unit-tested helpers)
+# --------------------------------------------------------------------------
+
+
+class EvaluateFamilyGateTest(unittest.TestCase):
+    def _bands(self):
+        return gm.parse_cv_bands(
+            [
+                {"max_cv": 0.015, "required_n_class_a": 7, "required_n_class_b": 9, "fail_margin_multiplier": 1.0},
+                {"max_cv": 0.05, "required_n_class_a": 25, "required_n_class_b": 25, "fail_margin_multiplier": 1.0},
+                {"max_cv": 1.0, "required_n_class_a": 25, "required_n_class_b": 25, "fail_margin_multiplier": 2.0},
+            ]
+        )
+
+    def test_empty_family_rejected(self):
+        with self.assertRaises(gm.GateMathError):
+            gm.evaluate_family_gate([], self._bands())
+
+    def test_single_cell_strong_regression_fails(self):
+        order_ab = (True, False, True, False, True, False, True)
+        values = tuple([math.log(1.10)] * 7)  # deterministic 10% slowdown
+        cell = gm.CellGateInput(
+            cell_id="decode:strong", values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        rng = random.Random(1)
+        results = gm.evaluate_family_gate([cell], self._bands(), bootstrap_replicates=500, rng=rng)
+        self.assertEqual(results[0].verdict, "FAIL")
+        self.assertTrue(results[0].holm_reject)
+
+    def test_single_cell_null_passes(self):
+        order_ab = (True, False, True, False, True, False, True)
+        values = (0.0,) * 7  # no slowdown at all
+        cell = gm.CellGateInput(
+            cell_id="decode:null", values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        rng = random.Random(1)
+        results = gm.evaluate_family_gate([cell], self._bands(), bootstrap_replicates=500, rng=rng)
+        self.assertEqual(results[0].verdict, "PASS")
+        self.assertFalse(results[0].holm_reject)
+
+    def test_holm_ordering_changes_the_verdict(self):
+        """Adversarial fixture: two
+        cells whose bootstrap p-values are BOTH individually below the
+        naive uncorrected alpha=0.05, but whose Holm step-down across the
+        2-cell family rejects NEITHER, because the smaller of the two
+        p-values fails to clear the first (tighter, alpha/2) Holm step --
+        which halts the step-down, so the second cell is never rejected
+        either, regardless of its own p-value. A naive per-cell 0.05
+        check would have flagged both as FAIL; the family evaluator does
+        not. This is the concrete, checkable case where ONLY the Holm
+        step-down (never a per-cell threshold) determines the verdict."""
+        tau = math.log(1.07)
+
+        def cell(cid):
+            base = tau + 0.005
+            spread = 0.02
+            values = (
+                base - spread, base + spread, base - spread * 0.5, base + spread * 0.5,
+                base - spread * 0.2, base + spread * 0.2, base,
+            )
+            order_ab = (True, False, True, False, True, False, True)
+            return gm.CellGateInput(
+                cell_id=cid, values=values, order_ab=order_ab,
+                measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+            )
+
+        cell_a, cell_b = cell("a"), cell("b")
+        rng = random.Random(0)
+        results = gm.evaluate_family_gate([cell_a, cell_b], self._bands(), bootstrap_replicates=2000, rng=rng)
+        p_a, p_b = results[0].p_value, results[1].p_value
+        # Precondition: a naive, uncorrected per-cell check would flag
+        # both (this is what makes the fixture adversarial -- ordering,
+        # not magnitude, is what changes the verdict).
+        self.assertLess(p_a, 0.05)
+        self.assertLess(p_b, 0.05)
+        # Holm, evaluated over the family, rejects neither.
+        self.assertFalse(results[0].holm_reject)
+        self.assertFalse(results[1].holm_reject)
+        self.assertNotEqual(results[0].verdict, "FAIL")
+        self.assertNotEqual(results[1].verdict, "FAIL")
+
+    def test_high_cv_margin_flips_fail_to_non_fail(self):
+        """Adversarial fixture: the SAME
+        effect size (a deterministic 8% slowdown) is a confirmed FAIL at
+        the low-CV band's raw fail_pct margin (multiplier 1.0) but is NOT
+        a FAIL once the same cell is measured at high CV and the
+        registered `fail_margin_multiplier` (2.0) widens the threshold --
+        proving `fail_margin_multiplier` is actually consumed by the
+        gate decision, not just unit-tested in isolation."""
+        order_ab = (True, False, True, False, True, False, True)
+        values = tuple([math.log(1.08)] * 7)  # deterministic 8% slowdown
+
+        low_cv_cell = gm.CellGateInput(
+            cell_id="lowcv", values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        high_cv_cell = gm.CellGateInput(
+            cell_id="highcv", values=values, order_ab=order_ab,
+            measured_cv=0.08, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+
+        low_result = gm.evaluate_family_gate([low_cv_cell], self._bands(), bootstrap_replicates=500, rng=random.Random(5))
+        high_result = gm.evaluate_family_gate([high_cv_cell], self._bands(), bootstrap_replicates=500, rng=random.Random(5))
+
+        self.assertEqual(low_result[0].fail_margin_multiplier, 1.0)
+        self.assertEqual(low_result[0].verdict, "FAIL")
+
+        self.assertEqual(high_result[0].fail_margin_multiplier, 2.0)
+        self.assertNotEqual(high_result[0].verdict, "FAIL")
+
+    def test_mismatched_lengths_rejected(self):
+        cell = gm.CellGateInput(
+            cell_id="bad", values=(1.0, 2.0), order_ab=(True,),
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        with self.assertRaises(gm.GateMathError):
+            gm.evaluate_family_gate([cell], self._bands())
+
+    def test_results_preserve_input_order(self):
+        order_ab = (True, False, True, False, True, False, True)
+        cell_first = gm.CellGateInput(
+            cell_id="first", values=(0.0,) * 7, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        cell_second = gm.CellGateInput(
+            cell_id="second", values=tuple([math.log(1.10)] * 7), order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        results = gm.evaluate_family_gate([cell_first, cell_second], self._bands(), bootstrap_replicates=500, rng=random.Random(2))
+        self.assertEqual([r.cell_id for r in results], ["first", "second"])
 
 
 if __name__ == "__main__":

--- a/tests/test_bench_gate_math.py
+++ b/tests/test_bench_gate_math.py
@@ -491,17 +491,108 @@ class EvaluateFamilyGateTest(unittest.TestCase):
         actual verdict -- every cell's lower bound was fixed at the
         strictest step-0 Bonferroni tail regardless of Holm's per-cell
         step-down assignment, so Holm's reject flag was never the thing
-        separating FAIL from non-FAIL. This fixture reuses the SAME
-        two-cell family as `test_holm_ordering_changes_the_verdict` and
-        directly swaps `holm_reject` for a naive uncorrected `p <= alpha`
-        check via `mock.patch.object`, re-running the evaluator with an
-        identically-seeded RNG so the bootstrap draws line up. Under the
-        real, coherent step-down evaluator neither cell reaches FAIL (the
-        family-level Holm step halts at the first cell); under the naive
-        mutation, the cell whose own rank-assigned tail already clears
-        its fail threshold DOES flip to FAIL -- the decision-effective
-        proof that Holm's step-down, not a fixed bound, drives the
-        verdict."""
+        separating FAIL from non-FAIL.
+
+        Follow-up adversarial-review finding: an intermediate fix made
+        every rank's bound track its Holm-assigned tail (`alpha / (m -
+        rank)`) unconditionally, but the step-down procedure actually
+        STOPS at its first failed comparison -- ranks after that stop are
+        never evaluated at their less-stringent tail, so exposing a bound
+        there was a bound for a hypothesis Holm never tested. This
+        fixture is tuned (base
+        offset/spread/seed) so the family's rank-0 cell (`b`, always
+        tested -- the step-down evaluates it before any stop can occur)
+        sits in the gap between its own strict Holm tail (alpha/2=0.025)
+        and the naive uncorrected `alpha=0.05` check: `b`'s real p-value
+        clears 0.05 but not 0.025, and `b`'s real (always-computed,
+        tested-rank) bound independently clears the fail threshold. That
+        makes `b` -- not the untested rank-1 cell `a` -- the cell whose
+        verdict is decision-sensitive to Holm's real per-cell tail:
+        swapping `holm_reject` for naive `p <= alpha` flips only `b` to
+        FAIL, and `a` remains unable to reach FAIL in either run because
+        the real step-down never tests rank 1 here (its bound is `None`
+        regardless of which reject-decision function is plugged in --
+        see `test_stopped_holm_rank_never_exposes_a_bound`)."""
+        tau = math.log(1.07)
+
+        def cell(cid):
+            base = tau + 0.008
+            spread = 0.03
+            values = (
+                base - spread, base + spread, base - spread * 0.5, base + spread * 0.5,
+                base - spread * 0.2, base + spread * 0.2, base,
+            )
+            order_ab = (True, False, True, False, True, False, True)
+            return gm.CellGateInput(
+                cell_id=cid, values=values, order_ab=order_ab,
+                measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+            )
+
+        cell_a, cell_b = cell("a"), cell("b")
+
+        real_results = gm.evaluate_family_gate(
+            [cell_a, cell_b], self._bands(), bootstrap_replicates=2000, rng=random.Random(15)
+        )
+        # Precondition: the real, coherent evaluator confirms neither cell
+        # as FAIL (rank 1 is never tested by the real step-down here, and
+        # rank 0 fails its own strict alpha/2 comparison).
+        self.assertFalse(real_results[0].holm_reject)
+        self.assertFalse(real_results[1].holm_reject)
+        self.assertNotEqual(real_results[0].verdict, "FAIL")
+        self.assertNotEqual(real_results[1].verdict, "FAIL")
+        # The untested rank (a) never gets a bound, real run or not.
+        self.assertIsNone(real_results[0].corrected_lower_bound)
+        self.assertIsNotNone(real_results[1].corrected_lower_bound)
+
+        def naive_reject(pvalues, alpha=0.05):
+            return [p <= alpha for p in pvalues]
+
+        with mock.patch.object(gm, "holm_reject", naive_reject):
+            mutated_results = gm.evaluate_family_gate(
+                [cell_a, cell_b], self._bands(), bootstrap_replicates=2000, rng=random.Random(15)
+            )
+
+        # The mutation must change at least one cell's ACTUAL verdict
+        # (not merely its internal holm_reject flag) from non-FAIL to
+        # FAIL -- proof that the shipped evaluator's FAIL rule depends on
+        # the real Holm step-down, not just on crossing a fixed bound.
+        flips = [
+            (real.cell_id, real.verdict, mutated.verdict)
+            for real, mutated in zip(real_results, mutated_results)
+            if real.verdict != "FAIL" and mutated.verdict == "FAIL"
+        ]
+        self.assertTrue(flips, f"expected at least one non-FAIL->FAIL flip, got {flips!r}")
+        # The untested rank (a) must stay un-FAIL-able even under the
+        # naive mutation -- its bound is a property of the real step-down
+        # order, not of whichever reject function is plugged in, so a
+        # naive/liberal reject flag alone can never manufacture a FAIL out
+        # of a hypothesis the real procedure never tested.
+        self.assertIsNone(mutated_results[0].corrected_lower_bound)
+        self.assertNotEqual(mutated_results[0].verdict, "FAIL")
+
+    def test_stopped_holm_rank_never_exposes_a_bound(self):
+        """Adversarial-review finding (`scripts/bench_gate_math.py:556`):
+        the family evaluator used to assign every rank `k` the tail
+        `alpha / (m - k)`
+        and report a `corrected_lower_bound` at that tail even for ranks
+        AFTER `holm_reject`'s step-down had already stopped (its first
+        failed comparison) -- those cells were never actually tested at
+        that level. Concrete evidence from the adversarial review: with
+        p-values `a=0.040`, `b=0.037` (this exact fixture, seed 0), Holm's
+        step-down stops at rank 0 (`b`: 0.037 > its own alpha/2=0.025
+        tail), so rank 1 (`a`, alpha/1=0.05 tail) is never evaluated --
+        yet the prior code reported `a.corrected_lower_bound=0.068087`,
+        ABOVE the 7% fail threshold `log(1.07)=0.067659`, while `a.
+        holm_reject` was `False`. That is a flag/bound disagreement for a
+        hypothesis the executed procedure never tested at that tail.
+
+        This fixture is the "two-cell family where Holm stops at rank 0"
+        stop-case: `a` (rank 1, untested) must report `None`, never a
+        threshold-clearing float, and its verdict can never be FAIL. `b`
+        (rank 0, the stopping rank) WAS tested -- it gets a real bound --
+        and stays non-FAIL because Holm did not reject it there either.
+        General coherence: across the whole family, no non-rejected cell
+        may ever expose a bound that clears its own fail threshold."""
         tau = math.log(1.07)
 
         def cell(cid):
@@ -518,35 +609,41 @@ class EvaluateFamilyGateTest(unittest.TestCase):
             )
 
         cell_a, cell_b = cell("a"), cell("b")
-
-        real_results = gm.evaluate_family_gate(
+        results = gm.evaluate_family_gate(
             [cell_a, cell_b], self._bands(), bootstrap_replicates=2000, rng=random.Random(0)
         )
-        # Precondition matching test_holm_ordering_changes_the_verdict:
-        # the real, coherent evaluator confirms neither cell as FAIL.
-        self.assertFalse(real_results[0].holm_reject)
-        self.assertFalse(real_results[1].holm_reject)
-        self.assertNotEqual(real_results[0].verdict, "FAIL")
-        self.assertNotEqual(real_results[1].verdict, "FAIL")
+        by_id = {r.cell_id: r for r in results}
 
-        def naive_reject(pvalues, alpha=0.05):
-            return [p <= alpha for p in pvalues]
+        # Reproduces the adversarial-review evidence: a's own p-value
+        # (rank 1, the higher one) is not below either tail, so it is
+        # never rejected -- and, post-fix, never tested at all.
+        self.assertAlmostEqual(by_id["a"].p_value, 0.04, places=6)
+        self.assertAlmostEqual(by_id["b"].p_value, 0.037, places=6)
+        self.assertFalse(by_id["a"].holm_reject)
+        self.assertFalse(by_id["b"].holm_reject)
 
-        with mock.patch.object(gm, "holm_reject", naive_reject):
-            mutated_results = gm.evaluate_family_gate(
-                [cell_a, cell_b], self._bands(), bootstrap_replicates=2000, rng=random.Random(0)
-            )
+        # The untested rank (a) reports no bound at all -- not the old
+        # 0.068087 threshold-clearing figure.
+        self.assertIsNone(by_id["a"].corrected_lower_bound)
+        self.assertNotEqual(by_id["a"].verdict, "FAIL")
 
-        # The mutation must change at least one cell's ACTUAL verdict
-        # (not merely its internal holm_reject flag) from non-FAIL to
-        # FAIL -- proof that the shipped evaluator's FAIL rule depends on
-        # the real Holm step-down, not just on crossing a fixed bound.
-        flips = [
-            (real.cell_id, real.verdict, mutated.verdict)
-            for real, mutated in zip(real_results, mutated_results)
-            if real.verdict != "FAIL" and mutated.verdict == "FAIL"
-        ]
-        self.assertTrue(flips, f"expected at least one non-FAIL->FAIL flip, got {flips!r}")
+        # The stopping rank (b) WAS tested -- it has a real bound -- and
+        # that bound stays below the fail threshold, so it too is non-FAIL.
+        self.assertIsNotNone(by_id["b"].corrected_lower_bound)
+        self.assertLess(by_id["b"].corrected_lower_bound, tau)
+        self.assertNotEqual(by_id["b"].verdict, "FAIL")
+
+        # General coherence assertion: no non-rejected
+        # cell anywhere in this family may report a threshold-clearing
+        # corrected_lower_bound -- a None bound trivially satisfies this,
+        # a tested-but-not-rejected bound must sit at or below tau.
+        for r in results:
+            if not r.holm_reject:
+                self.assertTrue(
+                    r.corrected_lower_bound is None or r.corrected_lower_bound <= tau,
+                    f"non-rejected cell {r.cell_id!r} exposed a threshold-clearing bound "
+                    f"{r.corrected_lower_bound!r} > tau_fail={tau!r}",
+                )
 
     def test_undersampled_cell_rejected_before_resampling(self):
         """Major 3: a cell reporting fewer raw pairs than its own

--- a/tests/test_bench_run_record.py
+++ b/tests/test_bench_run_record.py
@@ -70,6 +70,29 @@ def _aggregate(**overrides) -> harness.CellAggregate:
     return harness.parse_cell_aggregate(d)
 
 
+def _phase_events(n_tokens: int = 2) -> tuple[harness.PhaseEvent, ...]:
+    """A valid, canonically-ordered load->prefill->decode phase-event
+    sequence -- the default every `_cell_record` fixture carries unless a
+    test is specifically exercising `_validate_phase_sequence`."""
+    events = [
+        harness.parse_phase_event({"name": "load_start", "monotonic_ns": 0}),
+        harness.parse_phase_event({"name": "backend_ready", "monotonic_ns": 10}),
+        harness.parse_phase_event({"name": "prefill_start", "monotonic_ns": 20}),
+        harness.parse_phase_event({"name": "prefill_end", "monotonic_ns": 30}),
+    ]
+    for i in range(n_tokens):
+        events.append(
+            harness.parse_phase_event({"name": "token_available", "monotonic_ns": 40 + i * 5, "token_index": i + 1})
+        )
+    return tuple(events)
+
+
+def _resource_sample(**overrides) -> harness.ResourceSample:
+    d = {"monotonic_ns": 5, "phys_footprint_bytes": 1_000_000}
+    d.update(overrides)
+    return harness.parse_resource_sample(d)
+
+
 def _cell_record(**overrides) -> harness.CellRecord:
     return harness.CellRecord(
         cell_id=overrides.pop("cell_id", "decode:qwen3.5-small:f16:cpu:1024"),
@@ -85,7 +108,7 @@ def _cell_record(**overrides) -> harness.CellRecord:
         unsupported_reason=overrides.pop("unsupported_reason", None),
         path_proof=overrides.pop("path_proof", ()),
         lock_receipts=overrides.pop("lock_receipts", ()),
-        phase_events=overrides.pop("phase_events", ()),
+        phase_events=overrides.pop("phase_events", _phase_events()),
         resource_samples=overrides.pop("resource_samples", ()),
         provenance=overrides.pop("provenance", _provenance()),
         order_balance=overrides.pop("order_balance", (4, 3)),
@@ -103,6 +126,24 @@ def _metal_lock(**overrides) -> harness.LockReceipt:
     }
     d.update(overrides)
     return harness.parse_lock_receipt(d)
+
+
+def _heavy_lane_lock(**overrides) -> harness.LockReceipt:
+    d = {
+        "lock_name": "heavy-lane",
+        "acquired_at": "2026-07-11T00:00:00+00:00",
+        "released_at": "2026-07-11T00:05:00+00:00",
+        "held_continuously": True,
+        "wait_seconds": 0.2,
+    }
+    d.update(overrides)
+    return harness.parse_lock_receipt(d)
+
+
+def _metal_locks() -> tuple[harness.LockReceipt, ...]:
+    """Both continuously-held receipts a device=metal cell needs: the
+    outer heavy-lane receipt AND the metal-gpu receipt."""
+    return (_heavy_lane_lock(), _metal_lock())
 
 
 # --------------------------------------------------------------------------
@@ -177,12 +218,19 @@ class ProvenanceParseTest(unittest.TestCase):
 
 class MissingPathProofTest(unittest.TestCase):
     def test_metal_cell_without_path_proof_fails_closed(self):
-        record = _cell_record(device="metal", path_proof=(), lock_receipts=(_metal_lock(),))
+        record = _cell_record(
+            device="metal", path_proof=(), lock_receipts=_metal_locks(), resource_samples=(_resource_sample(),)
+        )
         with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*path_proof"):
             harness.validate_run_record(record)
 
     def test_metal_cell_with_path_proof_passes(self):
-        record = _cell_record(device="metal", path_proof=("attention_dispatch_counter>0",), lock_receipts=(_metal_lock(),))
+        record = _cell_record(
+            device="metal",
+            path_proof=("attention_dispatch_counter>0",),
+            lock_receipts=_metal_locks(),
+            resource_samples=(_resource_sample(),),
+        )
         harness.validate_run_record(record)  # must not raise
 
     def test_cpu_cell_needs_no_path_proof(self):
@@ -198,15 +246,113 @@ class MissingLockReceiptTest(unittest.TestCase):
 
     def test_metal_cell_with_released_not_held_continuously_fails_closed(self):
         bad_lock = _metal_lock(held_continuously=False)
-        record = _cell_record(device="metal", path_proof=("proof",), lock_receipts=(bad_lock,))
+        record = _cell_record(device="metal", path_proof=("proof",), lock_receipts=(_heavy_lane_lock(), bad_lock))
         with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*lock_receipt"):
             harness.validate_run_record(record)
 
     def test_metal_cell_with_wrong_lock_name_fails_closed(self):
-        wrong_lock = _metal_lock(lock_name="heavy-lane")
-        record = _cell_record(device="metal", path_proof=("proof",), lock_receipts=(wrong_lock,))
+        wrong_lock = _metal_lock(lock_name="something-else")
+        record = _cell_record(device="metal", path_proof=("proof",), lock_receipts=(_heavy_lane_lock(), wrong_lock))
         with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*lock_receipt"):
             harness.validate_run_record(record)
+
+    def test_metal_cell_with_only_metal_gpu_lock_fails_closed(self):
+        """A Metal record with ONLY the metal-gpu
+        receipt (no heavy-lane) must reject -- both locks are required."""
+        record = _cell_record(
+            device="metal", path_proof=("proof",), lock_receipts=(_metal_lock(),), resource_samples=(_resource_sample(),)
+        )
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*heavy-lane"):
+            harness.validate_run_record(record)
+
+    def test_metal_cell_with_only_heavy_lane_lock_fails_closed(self):
+        """A Metal record with ONLY the heavy-lane
+        receipt (no metal-gpu) must reject -- both locks are required."""
+        record = _cell_record(
+            device="metal", path_proof=("proof",), lock_receipts=(_heavy_lane_lock(),), resource_samples=(_resource_sample(),)
+        )
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*metal-gpu"):
+            harness.validate_run_record(record)
+
+    def test_metal_cell_without_resource_samples_fails_closed(self):
+        """A non-unsupported Metal record with both
+        locks but empty resource_samples must reject -- the
+        contention/memory-footprint proof is missing."""
+        record = _cell_record(
+            device="metal", path_proof=("proof",), lock_receipts=_metal_locks(), resource_samples=()
+        )
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*resource_samples"):
+            harness.validate_run_record(record)
+
+    def test_metal_cell_with_both_locks_and_samples_passes(self):
+        record = _cell_record(
+            device="metal", path_proof=("proof",), lock_receipts=_metal_locks(), resource_samples=(_resource_sample(),)
+        )
+        harness.validate_run_record(record)  # must not raise
+
+
+class PhaseSequenceTest(unittest.TestCase):
+    """Every non-unsupported record must carry a
+    validated, correctly-ordered phase-event sequence."""
+
+    def test_empty_phase_events_fails_closed(self):
+        record = _cell_record(phase_events=())
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*phase_events"):
+            harness.validate_run_record(record)
+
+    def test_missing_required_phase_fails_closed(self):
+        events = tuple(ev for ev in _phase_events() if ev.name != "prefill_end")
+        record = _cell_record(phase_events=events)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*missing required phase"):
+            harness.validate_run_record(record)
+
+    def test_no_token_available_fails_closed(self):
+        events = tuple(ev for ev in _phase_events() if ev.name != "token_available")
+        record = _cell_record(phase_events=events)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*token_available"):
+            harness.validate_run_record(record)
+
+    def test_out_of_order_phases_fails_closed(self):
+        events = (
+            harness.parse_phase_event({"name": "prefill_start", "monotonic_ns": 0}),
+            harness.parse_phase_event({"name": "load_start", "monotonic_ns": 10}),
+            harness.parse_phase_event({"name": "backend_ready", "monotonic_ns": 20}),
+            harness.parse_phase_event({"name": "prefill_end", "monotonic_ns": 30}),
+            harness.parse_phase_event({"name": "token_available", "monotonic_ns": 40, "token_index": 1}),
+        )
+        record = _cell_record(phase_events=events)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*out of order"):
+            harness.validate_run_record(record)
+
+    def test_monotonic_ns_backwards_fails_closed(self):
+        events = (
+            harness.parse_phase_event({"name": "load_start", "monotonic_ns": 100}),
+            harness.parse_phase_event({"name": "backend_ready", "monotonic_ns": 10}),
+            harness.parse_phase_event({"name": "prefill_start", "monotonic_ns": 20}),
+            harness.parse_phase_event({"name": "prefill_end", "monotonic_ns": 30}),
+            harness.parse_phase_event({"name": "token_available", "monotonic_ns": 40, "token_index": 1}),
+        )
+        record = _cell_record(phase_events=events)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*backwards"):
+            harness.validate_run_record(record)
+
+    def test_non_increasing_token_index_fails_closed(self):
+        events = _phase_events()[:4] + (
+            harness.parse_phase_event({"name": "token_available", "monotonic_ns": 40, "token_index": 2}),
+            harness.parse_phase_event({"name": "token_available", "monotonic_ns": 45, "token_index": 2}),
+        )
+        record = _cell_record(phase_events=events)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*token_index"):
+            harness.validate_run_record(record)
+
+    def test_unsupported_cell_exempt_from_phase_sequence(self):
+        agg = _aggregate(measured_cv=None, required_n=None, n_valid=0)
+        record = _cell_record(phase_events=(), aggregate=agg, verdict="unsupported", unsupported_reason="no checkpoint yet")
+        harness.validate_run_record(record)  # must not raise
+
+    def test_valid_sequence_passes(self):
+        record = _cell_record(phase_events=_phase_events())
+        harness.validate_run_record(record)  # must not raise
 
 
 class NonFiniteMetricTest(unittest.TestCase):
@@ -270,6 +416,61 @@ class LowValidNTest(unittest.TestCase):
         agg = _aggregate(measured_cv=None, required_n=None, n_valid=0)
         record = _cell_record(aggregate=agg, verdict="unsupported", unsupported_reason="no checkpoint yet")
         harness.validate_run_record(record)  # must not raise
+
+
+class SubmitterControlledRequiredNTest(unittest.TestCase):
+    """required_n must be RE-DERIVED from the registered
+    per-metric policy and the measured CV -- never trusted as optional,
+    submitter-supplied record metadata."""
+
+    def test_cv_three_percent_with_required_n_none_fails_closed(self):
+        # decode/decode_tok_s is class A; CV 3% -> policy requires n=25,
+        # not the n=7 band. required_n=None can never match.
+        agg = _aggregate(n_valid=0, required_n=None, measured_cv=0.03)
+        record = _cell_record(aggregate=agg)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*required_n"):
+            harness.validate_run_record(record)
+
+    def test_forged_required_n_seven_at_cv_three_percent_fails_closed(self):
+        # a submitter claims required_n=7 (matching a low, easy n_valid)
+        # at CV 3%, where the registered policy actually derives n=25.
+        agg = _aggregate(n_valid=7, required_n=7, measured_cv=0.03)
+        record = _cell_record(aggregate=agg)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*required_n"):
+            harness.validate_run_record(record)
+
+    def test_embed_batch_p95_class_b_with_seven_pairs_fails_closed(self):
+        # embed.batch_p95 is registered class B (min nine pairs at low
+        # CV); a family-name heuristic that treated it as class A
+        # silently accepted seven (the concrete regression this guards).
+        agg = _aggregate(n_valid=7, required_n=7, measured_cv=0.01)
+        record = _cell_record(metric_family="embed", metric_name="batch_p95", aggregate=agg)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*required_n"):
+            harness.validate_run_record(record)
+
+    def test_embed_batch_p95_class_b_with_nine_pairs_passes(self):
+        agg = _aggregate(n_valid=9, required_n=9, measured_cv=0.01)
+        record = _cell_record(metric_family="embed", metric_name="batch_p95", aggregate=agg)
+        harness.validate_run_record(record)  # must not raise
+
+    def test_decode_at_cv_three_percent_with_correct_required_n_passes(self):
+        agg = _aggregate(n_valid=25, required_n=25, measured_cv=0.03)
+        record = _cell_record(aggregate=agg)
+        harness.validate_run_record(record)  # must not raise
+
+    def test_class_c_metric_exempt_from_required_n_derivation(self):
+        # memory.model_load_time is registered class C (informational
+        # only, never gates a required cell) -- no required_n derivation
+        # applies, so a null required_n on a low n_valid does not reject.
+        agg = _aggregate(n_valid=1, required_n=None, measured_cv=0.20)
+        record = _cell_record(metric_family="memory", metric_name="model_load_time", aggregate=agg)
+        harness.validate_run_record(record)  # must not raise
+
+    def test_unregistered_metric_fails_closed(self):
+        agg = _aggregate(n_valid=7, required_n=7, measured_cv=0.01)
+        record = _cell_record(metric_family="decode", metric_name="not_a_registered_metric", aggregate=agg)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL"):
+            harness.validate_run_record(record)
 
 
 class PostRunThresholdChangeTest(unittest.TestCase):
@@ -397,6 +598,7 @@ class PromotionRecordTest(unittest.TestCase):
             "failures": 0,
             "cp_bound_95": 0.14,  # rounded UP from the true ~0.1391 bound -- honest, not tighter
             "mainline_sessions": 10,
+            "invalid_pair_replacements": 0,
         }
         d.update(overrides)
         return harness.parse_promotion_record(d)
@@ -440,8 +642,92 @@ class PromotionRecordTest(unittest.TestCase):
                     "failures": 6,
                     "cp_bound_95": 0.5,
                     "mainline_sessions": 0,
+                    "invalid_pair_replacements": 0,
                 }
             )
+
+    def test_missing_invalid_pair_replacements_rejected_at_parse(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "missing required field"):
+            harness.parse_promotion_record(
+                {
+                    "cell_id": "x",
+                    "policy_version": 1,
+                    "null_sessions": 20,
+                    "failures": 0,
+                    "cp_bound_95": 0.14,
+                    "mainline_sessions": 10,
+                }
+            )
+
+
+class PromotionMainlineSessionsTest(unittest.TestCase):
+    """An earlier revision accepted a 20-null,
+    0-mainline-session promotion because `mainline_sessions` was never
+    examined. The policy registers `min_mainline_sessions = 10`."""
+
+    def _promotion(self, **overrides):
+        d = {
+            "cell_id": "decode:qwen3.5-small:f16:cpu:1024",
+            "policy_version": 1,
+            "null_sessions": 20,
+            "failures": 0,
+            "cp_bound_95": 0.14,
+            "mainline_sessions": 10,
+            "invalid_pair_replacements": 0,
+        }
+        d.update(overrides)
+        return harness.parse_promotion_record(d)
+
+    def test_zero_mainline_sessions_fails_closed(self):
+        record = self._promotion(mainline_sessions=0)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "mainline sessions"):
+            harness.validate_promotion_record(record)
+
+    def test_nine_mainline_sessions_fails_closed(self):
+        record = self._promotion(mainline_sessions=9)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "mainline sessions"):
+            harness.validate_promotion_record(record)
+
+    def test_ten_mainline_sessions_passes(self):
+        record = self._promotion(mainline_sessions=10)
+        harness.validate_promotion_record(record)  # must not raise
+
+
+class PromotionReplacementCapTest(unittest.TestCase):
+    """The registered replacement cap
+    (`max_invalid_pair_replacements = 3`) must be enforced fail-closed,
+    and a policy that omits the cap must reject rather than silently
+    default."""
+
+    def _promotion(self, **overrides):
+        d = {
+            "cell_id": "decode:qwen3.5-small:f16:cpu:1024",
+            "policy_version": 1,
+            "null_sessions": 20,
+            "failures": 0,
+            "cp_bound_95": 0.14,
+            "mainline_sessions": 10,
+            "invalid_pair_replacements": 0,
+        }
+        d.update(overrides)
+        return harness.parse_promotion_record(d)
+
+    def test_within_cap_passes(self):
+        record = self._promotion(invalid_pair_replacements=3)
+        harness.validate_promotion_record(record)  # must not raise
+
+    def test_exceeding_cap_fails_closed(self):
+        record = self._promotion(invalid_pair_replacements=4)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "invalid_pair_replacements"):
+            harness.validate_promotion_record(record)
+
+    def test_missing_cap_in_policy_fails_closed(self):
+        doc = harness.bench_gate_math.load_policy()
+        broken_promotion = {k: v for k, v in doc["promotion"].items() if k != "max_invalid_pair_replacements"}
+        broken_policy = {**doc, "promotion": broken_promotion}
+        record = self._promotion(invalid_pair_replacements=0)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "max_invalid_pair_replacements"):
+            harness.validate_promotion_record(record, policy=broken_policy)
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_bench_run_record.py
+++ b/tests/test_bench_run_record.py
@@ -1,0 +1,570 @@
+"""Unit tests for the schema-v2 run-record contract added to
+scripts/bench_decode_harness.py (bench-overhaul PR 1, "canonical contract
+and policy, in days").
+
+Deterministic fixtures only -- no engine binary, GPU, or heavy lane
+required. Loaded by file path (matching test_bench_decode_harness.py's
+convention: scripts/ is not a package).
+
+Covers the PR's acceptance row: fixtures prove missing cell / missing
+path proof / missing lock receipt / non-finite metric / low valid-n /
+post-run threshold change / wrong SHA all fail closed, a v1 observation
+still imports/validates unchanged, and the north-star ranking query works
+over the shipped `CellRecord` shape without further schema change.
+
+Run with: python3 -m pytest tests/test_bench_run_record.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "bench_decode_harness.py"
+_SPEC = importlib.util.spec_from_file_location("bench_decode_harness", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+harness = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = harness
+_SPEC.loader.exec_module(harness)
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+
+def _provenance(**overrides) -> harness.ProvenanceRecord:
+    d = {
+        "repo_sha": "a" * 40,
+        "candidate_sha": "a" * 40,
+        "base_sha": "b" * 40,
+        "dirty": False,
+        "profile_name": "cpu_smoke_v2",
+        "profile_version": 1,
+        "profile_sha": "c" * 64,
+        "policy_version": 1,
+        "policy_sha": "d" * 64,
+        "script_sha": "e" * 40,
+        "hardware_fingerprint": "Darwin-arm64-M2Max-32GB",
+        "collected_at": "2026-07-11T00:00:00+00:00",
+        "workflow_run_id": None,
+    }
+    d.update(overrides)
+    return harness.parse_provenance(d)
+
+
+def _aggregate(**overrides) -> harness.CellAggregate:
+    d = {
+        "point_estimate": 0.02,
+        "ci_low": -0.01,
+        "ci_high": 0.05,
+        "corrected_lower_bound": 0.01,
+        "n_valid": 7,
+        "n_invalid": 0,
+        "measured_cv": 0.01,
+        "required_n": 7,
+    }
+    d.update(overrides)
+    return harness.parse_cell_aggregate(d)
+
+
+def _cell_record(**overrides) -> harness.CellRecord:
+    return harness.CellRecord(
+        cell_id=overrides.pop("cell_id", "decode:qwen3.5-small:f16:cpu:1024"),
+        metric_family=overrides.pop("metric_family", "decode"),
+        metric_name=overrides.pop("metric_name", "decode_tok_s"),
+        path=overrides.pop("path", "decode"),
+        model_tier=overrides.pop("model_tier", "qwen3.5-small"),
+        quant_tier=overrides.pop("quant_tier", "f16"),
+        device=overrides.pop("device", "cpu"),
+        context_point=overrides.pop("context_point", 1024),
+        aggregate=overrides.pop("aggregate", _aggregate()),
+        verdict=overrides.pop("verdict", "PASS"),
+        unsupported_reason=overrides.pop("unsupported_reason", None),
+        path_proof=overrides.pop("path_proof", ()),
+        lock_receipts=overrides.pop("lock_receipts", ()),
+        phase_events=overrides.pop("phase_events", ()),
+        resource_samples=overrides.pop("resource_samples", ()),
+        provenance=overrides.pop("provenance", _provenance()),
+        order_balance=overrides.pop("order_balance", (4, 3)),
+        raw_artifact_digest=overrides.pop("raw_artifact_digest", "f" * 64),
+    )
+
+
+def _metal_lock(**overrides) -> harness.LockReceipt:
+    d = {
+        "lock_name": "metal-gpu",
+        "acquired_at": "2026-07-11T00:00:00+00:00",
+        "released_at": "2026-07-11T00:05:00+00:00",
+        "held_continuously": True,
+        "wait_seconds": 0.5,
+    }
+    d.update(overrides)
+    return harness.parse_lock_receipt(d)
+
+
+# --------------------------------------------------------------------------
+# Phase events / resource samples / lock receipts / provenance parsing
+# --------------------------------------------------------------------------
+
+
+class PhaseEventParseTest(unittest.TestCase):
+    def test_valid_load_start(self):
+        ev = harness.parse_phase_event({"name": "load_start", "monotonic_ns": 0})
+        self.assertEqual(ev.name, "load_start")
+
+    def test_token_available_requires_token_index(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "token_index"):
+            harness.parse_phase_event({"name": "token_available", "monotonic_ns": 100})
+
+    def test_non_token_event_rejects_token_index(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "token_index"):
+            harness.parse_phase_event({"name": "load_start", "monotonic_ns": 0, "token_index": 1})
+
+    def test_unknown_name_rejected(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "name"):
+            harness.parse_phase_event({"name": "bogus", "monotonic_ns": 0})
+
+    def test_negative_monotonic_ns_rejected(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "monotonic_ns"):
+            harness.parse_phase_event({"name": "load_start", "monotonic_ns": -1})
+
+
+class ResourceSampleParseTest(unittest.TestCase):
+    def test_valid_sample(self):
+        s = harness.parse_resource_sample({"monotonic_ns": 10, "phys_footprint_bytes": 1000})
+        self.assertIsNone(s.phase)
+
+    def test_invalid_phase_rejected(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "phase"):
+            harness.parse_resource_sample({"monotonic_ns": 10, "phys_footprint_bytes": 1000, "phase": "bogus"})
+
+
+class LockReceiptParseTest(unittest.TestCase):
+    def test_valid_receipt(self):
+        lr = _metal_lock()
+        self.assertTrue(lr.held_continuously)
+
+    def test_empty_lock_name_rejected(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "lock_name"):
+            harness.parse_lock_receipt(
+                {
+                    "lock_name": "",
+                    "acquired_at": "x",
+                    "released_at": None,
+                    "held_continuously": True,
+                    "wait_seconds": 0,
+                }
+            )
+
+
+class ProvenanceParseTest(unittest.TestCase):
+    def test_valid_provenance(self):
+        p = _provenance()
+        self.assertEqual(p.policy_version, 1)
+
+    def test_missing_field_rejected(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "missing required field"):
+            harness.parse_provenance({"repo_sha": "a"})
+
+
+# --------------------------------------------------------------------------
+# Fail-closed acceptance fixtures (the PR's explicit acceptance row)
+# --------------------------------------------------------------------------
+
+
+class MissingPathProofTest(unittest.TestCase):
+    def test_metal_cell_without_path_proof_fails_closed(self):
+        record = _cell_record(device="metal", path_proof=(), lock_receipts=(_metal_lock(),))
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*path_proof"):
+            harness.validate_run_record(record)
+
+    def test_metal_cell_with_path_proof_passes(self):
+        record = _cell_record(device="metal", path_proof=("attention_dispatch_counter>0",), lock_receipts=(_metal_lock(),))
+        harness.validate_run_record(record)  # must not raise
+
+    def test_cpu_cell_needs_no_path_proof(self):
+        record = _cell_record(device="cpu", path_proof=())
+        harness.validate_run_record(record)  # must not raise
+
+
+class MissingLockReceiptTest(unittest.TestCase):
+    def test_metal_cell_without_lock_receipt_fails_closed(self):
+        record = _cell_record(device="metal", path_proof=("proof",), lock_receipts=())
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*lock_receipt"):
+            harness.validate_run_record(record)
+
+    def test_metal_cell_with_released_not_held_continuously_fails_closed(self):
+        bad_lock = _metal_lock(held_continuously=False)
+        record = _cell_record(device="metal", path_proof=("proof",), lock_receipts=(bad_lock,))
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*lock_receipt"):
+            harness.validate_run_record(record)
+
+    def test_metal_cell_with_wrong_lock_name_fails_closed(self):
+        wrong_lock = _metal_lock(lock_name="heavy-lane")
+        record = _cell_record(device="metal", path_proof=("proof",), lock_receipts=(wrong_lock,))
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*lock_receipt"):
+            harness.validate_run_record(record)
+
+
+class NonFiniteMetricTest(unittest.TestCase):
+    def test_nan_point_estimate_rejected_at_parse(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "not finite"):
+            harness.parse_cell_aggregate(
+                {
+                    "point_estimate": float("nan"),
+                    "ci_low": 0.0,
+                    "ci_high": 0.0,
+                    "n_valid": 7,
+                    "n_invalid": 0,
+                }
+            )
+
+    def test_inf_ci_high_rejected_at_parse(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "not finite"):
+            harness.parse_cell_aggregate(
+                {
+                    "point_estimate": 0.0,
+                    "ci_low": 0.0,
+                    "ci_high": float("inf"),
+                    "n_valid": 7,
+                    "n_invalid": 0,
+                }
+            )
+
+    def test_non_finite_caught_at_validate_run_record_too(self):
+        # bypass parse_cell_aggregate to prove validate_run_record itself
+        # also fails closed on a hand-built non-finite aggregate
+        agg = harness.CellAggregate(
+            point_estimate=float("nan"), ci_low=0.0, ci_high=0.0,
+            corrected_lower_bound=None, n_valid=7, n_invalid=0, measured_cv=0.01, required_n=7,
+        )
+        record = _cell_record(aggregate=agg)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*not finite"):
+            harness.validate_run_record(record)
+
+
+class LowValidNTest(unittest.TestCase):
+    def test_below_required_n_fails_closed(self):
+        agg = _aggregate(n_valid=5, required_n=7, measured_cv=0.01)
+        record = _cell_record(aggregate=agg)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*n too small"):
+            harness.validate_run_record(record)
+
+    def test_at_required_n_passes(self):
+        agg = _aggregate(n_valid=7, required_n=7, measured_cv=0.01)
+        record = _cell_record(aggregate=agg)
+        harness.validate_run_record(record)  # must not raise
+
+    def test_missing_measured_cv_fails_closed(self):
+        """Correction 1: a cell with no measured_cv on record can never be
+        validated -- required_n cannot be trusted without it."""
+        agg = _aggregate(measured_cv=None, required_n=None)
+        record = _cell_record(aggregate=agg)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*measured_cv"):
+            harness.validate_run_record(record)
+
+    def test_unsupported_cell_exempt_from_cv_n_checks(self):
+        agg = _aggregate(measured_cv=None, required_n=None, n_valid=0)
+        record = _cell_record(aggregate=agg, verdict="unsupported", unsupported_reason="no checkpoint yet")
+        harness.validate_run_record(record)  # must not raise
+
+
+class PostRunThresholdChangeTest(unittest.TestCase):
+    def test_policy_sha_mismatch_fails_closed(self):
+        record = _cell_record(provenance=_provenance(policy_sha="d" * 64))
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*policy_sha"):
+            harness.validate_run_record(record, current_policy_sha="different" + "0" * 56)
+
+    def test_matching_policy_sha_passes(self):
+        record = _cell_record(provenance=_provenance(policy_sha="d" * 64))
+        harness.validate_run_record(record, current_policy_sha="d" * 64)  # must not raise
+
+    def test_no_current_policy_sha_given_skips_check(self):
+        record = _cell_record(provenance=_provenance(policy_sha="d" * 64))
+        harness.validate_run_record(record)  # must not raise (no current_policy_sha supplied)
+
+
+class WrongShaTest(unittest.TestCase):
+    def test_candidate_sha_mismatch_fails_closed(self):
+        record = _cell_record(provenance=_provenance(candidate_sha="a" * 40))
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL.*SHA mismatch"):
+            harness.validate_run_record(record, expected_repo_sha="b" * 40)
+
+    def test_matching_sha_passes(self):
+        record = _cell_record(provenance=_provenance(candidate_sha="a" * 40))
+        harness.validate_run_record(record, expected_repo_sha="a" * 40)  # must not raise
+
+
+class MissingCellRegistryTest(unittest.TestCase):
+    def test_missing_expected_cell_fails_closed(self):
+        groups = [
+            harness.ExpectedCellGroup(
+                name="decode_cpu_mini",
+                path="decode",
+                metric_family="decode",
+                device="cpu",
+                model_tiers=("qwen3.5-small",),
+                quant_tiers=("f16",),
+                context_points=(512, 1024),
+                required_in=("hosted_pr_smoke",),
+                anchor_quant_tiers=("f16",),
+                anchor_context_points=(512, 1024),
+                anchor_required_in=("hosted_pr_smoke",),
+            )
+        ]
+        present = [_cell_record(cell_id="decode:qwen3.5-small:f16:cpu:512", context_point=512)]
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "INFRA-FAIL: expected cell"):
+            harness.validate_registry_coverage(present, groups, "hosted_pr_smoke")
+
+    def test_unsupported_cell_counts_as_present(self):
+        groups = [
+            harness.ExpectedCellGroup(
+                name="decode_cpu_mini",
+                path="decode",
+                metric_family="decode",
+                device="cpu",
+                model_tiers=("qwen3.5-small",),
+                quant_tiers=("f16",),
+                context_points=(512,),
+                required_in=("hosted_pr_smoke",),
+                anchor_quant_tiers=("f16",),
+                anchor_context_points=(512,),
+                anchor_required_in=("hosted_pr_smoke",),
+            )
+        ]
+        present = [
+            _cell_record(
+                cell_id="decode:qwen3.5-small:f16:cpu:512",
+                context_point=512,
+                verdict="unsupported",
+                unsupported_reason="checkpoint unavailable on this runner",
+            )
+        ]
+        harness.validate_registry_coverage(present, groups, "hosted_pr_smoke")  # must not raise
+
+    def test_full_coverage_passes(self):
+        groups = [
+            harness.ExpectedCellGroup(
+                name="decode_cpu_mini",
+                path="decode",
+                metric_family="decode",
+                device="cpu",
+                model_tiers=("qwen3.5-small",),
+                quant_tiers=("f16",),
+                context_points=(512, 1024, 2048),
+                required_in=("hosted_pr_smoke",),
+                anchor_quant_tiers=("f16",),
+                anchor_context_points=(512, 1024, 2048),
+                anchor_required_in=("hosted_pr_smoke",),
+            )
+        ]
+        present = [
+            _cell_record(cell_id="decode:qwen3.5-small:f16:cpu:512", context_point=512),
+            _cell_record(cell_id="decode:qwen3.5-small:f16:cpu:1024", context_point=1024),
+            _cell_record(cell_id="decode:qwen3.5-small:f16:cpu:2048", context_point=2048),
+        ]
+        harness.validate_registry_coverage(present, groups, "hosted_pr_smoke")  # must not raise
+
+    def test_shipped_registry_loads_and_expands_without_error(self):
+        groups = harness.load_expected_cells()
+        self.assertGreaterEqual(len(groups), 4)
+        ids = harness.expected_cell_ids_for_cadence(groups, "hosted_pr_smoke")
+        self.assertIn("decode:qwen3.5-small:f16:cpu:1024", ids)
+        self.assertNotIn("decode:qwen3.5-small:q8:cpu:1024", ids)  # q8 is not an anchor quant
+
+    def test_reserved_cadence_never_matches_a_live_cadence(self):
+        groups = harness.load_expected_cells()
+        reserved = [g for g in groups if g.name == "streaming_moe_reserved"][0]
+        expanded = harness.expand_cell_group(reserved)
+        for cadences in expanded.values():
+            self.assertEqual(cadences, ("reserved",))
+
+
+# --------------------------------------------------------------------------
+# Correction 3: promotion record honesty
+# --------------------------------------------------------------------------
+
+
+class PromotionRecordTest(unittest.TestCase):
+    def _promotion(self, **overrides):
+        d = {
+            "cell_id": "decode:qwen3.5-small:f16:cpu:1024",
+            "policy_version": 1,
+            "null_sessions": 20,
+            "failures": 0,
+            "cp_bound_95": 0.14,  # rounded UP from the true ~0.1391 bound -- honest, not tighter
+            "mainline_sessions": 10,
+        }
+        d.update(overrides)
+        return harness.parse_promotion_record(d)
+
+    def test_honest_bound_passes(self):
+        record = self._promotion()
+        harness.validate_promotion_record(record)  # must not raise
+
+    def test_asserting_tighter_than_true_bound_fails_closed(self):
+        # claims <1% from only 20 sessions/0 failures -- the true bound is ~13.91%
+        record = self._promotion(cp_bound_95=0.009)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "tighter than"):
+            harness.validate_promotion_record(record)
+
+    def test_below_twenty_sessions_fails_closed(self):
+        record = self._promotion(null_sessions=10, failures=0, cp_bound_95=0.5)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, ">= 20"):
+            harness.validate_promotion_record(record)
+
+    def test_upfront_298_sessions_not_required(self):
+        """Correction 3: promotion is gated on >=20 sessions + an honest
+        bound, NOT on reaching the ~298 sessions that would independently
+        prove <1% at 95% confidence from zero failures."""
+        record = self._promotion(null_sessions=20, failures=0, cp_bound_95=0.14)
+        harness.validate_promotion_record(record)  # must not raise despite far fewer than 298 sessions
+
+    def test_bound_tightens_as_sessions_accrue(self):
+        early = self._promotion(null_sessions=20, failures=0, cp_bound_95=0.14)
+        later = self._promotion(null_sessions=300, failures=0, cp_bound_95=0.01)
+        harness.validate_promotion_record(early)
+        harness.validate_promotion_record(later)
+        self.assertGreater(early.cp_bound_95, later.cp_bound_95)
+
+    def test_failures_exceeding_sessions_rejected_at_parse(self):
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "cannot exceed"):
+            harness.parse_promotion_record(
+                {
+                    "cell_id": "x",
+                    "policy_version": 1,
+                    "null_sessions": 5,
+                    "failures": 6,
+                    "cp_bound_95": 0.5,
+                    "mainline_sessions": 0,
+                }
+            )
+
+
+# --------------------------------------------------------------------------
+# North-star ranking query
+# --------------------------------------------------------------------------
+
+
+class RankCellsByGapTest(unittest.TestCase):
+    def test_ranks_by_descending_absolute_gap(self):
+        records = [
+            _cell_record(cell_id="decode:a:f16:cpu:512", aggregate=_aggregate(point_estimate=0.02)),
+            _cell_record(cell_id="decode:a:f16:cpu:1024", aggregate=_aggregate(point_estimate=-0.15)),
+            _cell_record(cell_id="decode:a:f16:cpu:2048", aggregate=_aggregate(point_estimate=0.08)),
+        ]
+        ranked = harness.rank_cells_by_gap(records)
+        self.assertEqual([r.cell_id for r in ranked], [
+            "decode:a:f16:cpu:1024",  # |−0.15| largest
+            "decode:a:f16:cpu:2048",  # |0.08|
+            "decode:a:f16:cpu:512",   # |0.02| smallest
+        ])
+
+    def test_top_n_limits_output(self):
+        records = [
+            _cell_record(cell_id="c1", aggregate=_aggregate(point_estimate=0.5)),
+            _cell_record(cell_id="c2", aggregate=_aggregate(point_estimate=0.3)),
+            _cell_record(cell_id="c3", aggregate=_aggregate(point_estimate=0.1)),
+        ]
+        ranked = harness.rank_cells_by_gap(records, top_n=2)
+        self.assertEqual([r.cell_id for r in ranked], ["c1", "c2"])
+
+    def test_unsupported_cells_excluded(self):
+        records = [
+            _cell_record(cell_id="c1", aggregate=_aggregate(point_estimate=0.5)),
+            _cell_record(
+                cell_id="c2",
+                verdict="unsupported",
+                unsupported_reason="no checkpoint",
+                aggregate=_aggregate(point_estimate=999.0, measured_cv=None, required_n=None, n_valid=0),
+            ),
+        ]
+        ranked = harness.rank_cells_by_gap(records)
+        self.assertEqual([r.cell_id for r in ranked], ["c1"])
+
+    def test_ties_broken_by_cell_id(self):
+        records = [
+            _cell_record(cell_id="zzz", aggregate=_aggregate(point_estimate=0.1)),
+            _cell_record(cell_id="aaa", aggregate=_aggregate(point_estimate=-0.1)),
+        ]
+        ranked = harness.rank_cells_by_gap(records)
+        self.assertEqual([r.cell_id for r in ranked], ["aaa", "zzz"])
+
+    def test_ranking_is_groupable_by_metric_context_quant_without_new_fields(self):
+        """The north-star requirement: cell records must make 'largest
+        stable gaps by metric/context/quant' queryable WITHOUT a later
+        schema change. Prove the shape supports a grouped-then-ranked
+        query using only fields CellRecord already carries."""
+        records = [
+            _cell_record(
+                cell_id="decode:a:f16:cpu:512", metric_name="decode_tok_s", quant_tier="f16",
+                context_point=512, aggregate=_aggregate(point_estimate=0.09),
+            ),
+            _cell_record(
+                cell_id="decode:a:q4:cpu:512", metric_name="decode_tok_s", quant_tier="q4",
+                context_point=512, aggregate=_aggregate(point_estimate=0.02),
+            ),
+            _cell_record(
+                cell_id="decode:a:f16:cpu:1024", metric_name="decode_tok_s", quant_tier="f16",
+                context_point=1024, aggregate=_aggregate(point_estimate=0.15),
+            ),
+            _cell_record(
+                cell_id="embed:a:f16:cpu:512", metric_family="embed", metric_name="texts_s",
+                path="embed_encode", quant_tier="f16", context_point=512,
+                aggregate=_aggregate(point_estimate=0.30),
+            ),
+        ]
+        # group by (metric_name, quant_tier) -- a query shape a downstream
+        # dashboard/mining tool would run -- then rank within each group.
+        groups: dict[tuple[str, str], list[harness.CellRecord]] = {}
+        for r in records:
+            groups.setdefault((r.metric_name, r.quant_tier), []).append(r)
+        self.assertEqual(len(groups), 3)  # (decode_tok_s,f16) (decode_tok_s,q4) (texts_s,f16)
+        top_decode_f16 = harness.rank_cells_by_gap(groups[("decode_tok_s", "f16")], top_n=1)
+        self.assertEqual(top_decode_f16[0].cell_id, "decode:a:f16:cpu:1024")
+        overall_top = harness.rank_cells_by_gap(records, top_n=1)
+        self.assertEqual(overall_top[0].cell_id, "embed:a:f16:cpu:512")
+
+
+# --------------------------------------------------------------------------
+# v1 import/readability regression (v1 must remain readable, unchanged)
+# --------------------------------------------------------------------------
+
+
+class V1StillReadableTest(unittest.TestCase):
+    def test_v1_observation_still_validates(self):
+        row = {
+            "schema_version": harness.SCHEMA_VERSION,
+            "git_sha": "deadbeefcafebabe",
+            "profile": "legacy_v1_profile",
+            "engine": "lattice",
+            "engine_version": "1.0.0",
+            "model": "qwen3.5-0.8b",
+            "quantization": "q8",
+            "prompt_hash": "abc123",
+            "requested_prompt_tokens": 12,
+            "actual_prompt_tokens": 12,
+            "requested_completion_tokens": 32,
+            "actual_completion_tokens": 32,
+            "warmup": False,
+            "run_index": 1,
+            "order_index": 0,
+            "elapsed_ns": 1_000_000,
+            "engine_native_ns": 900_000,
+            "hardware_id": "Darwin-arm64-testhost",
+            "timestamp": "2026-07-10T00:00:00+00:00",
+        }
+        harness.validate_observation(row)  # must not raise -- v1 contract unchanged by v2 additions
+
+    def test_v1_schema_version_constant_unchanged(self):
+        # v2 additions must be additive: v1's SCHEMA_VERSION stays 1, a
+        # separate RUN_RECORD_SCHEMA_VERSION governs the new record kinds.
+        self.assertEqual(harness.SCHEMA_VERSION, 1)
+        self.assertEqual(harness.RUN_RECORD_SCHEMA_VERSION, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_run_record.py
+++ b/tests/test_bench_run_record.py
@@ -646,6 +646,19 @@ class PromotionRecordTest(unittest.TestCase):
                 }
             )
 
+    def test_policy_version_mismatch_fails_closed(self):
+        # A record claiming policy_version=999 while all threshold values
+        # are actually v1-shaped must never be evaluated under v1's
+        # thresholds -- it must reject on the version binding itself,
+        # before any threshold comparison runs.
+        record = self._promotion(policy_version=999)
+        with self.assertRaisesRegex(harness.RunRecordValidationError, "policy_version=999"):
+            harness.validate_promotion_record(record)
+
+    def test_policy_version_match_passes(self):
+        record = self._promotion(policy_version=1)
+        harness.validate_promotion_record(record)  # must not raise
+
     def test_missing_invalid_pair_replacements_rejected_at_parse(self):
         with self.assertRaisesRegex(harness.RunRecordValidationError, "missing required field"):
             harness.parse_promotion_record(


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## AI-assisted development disclosure

- [x] This PR was developed with AI assistance (Claude, an Anthropic agent).
- [x] A human reviewed the diff before requesting review.
- [x] Tests were run locally and pass (see Test plan).
- [x] No secrets, credentials, or internal-only content are included.

## Summary

Part of the benchmark-overhaul program, PR 1 of the phased implementation plan: "canonical contract and policy, in days." Extends `scripts/bench_decode_harness.py` to a schema-v2 run-record contract, additive to the existing v1 per-call observation/JSONL schema (unchanged, still fully readable):

- Phase events (`load_start`/`backend_ready`/`prefill_start`/`prefill_end`/`token_available`), resource samples (`phys_footprint_bytes` — schema fields only in this PR, the sampler itself is a later PR), lock receipts, provenance records, cell aggregates, and cell records — the queryable per-cell shape (stable `cell_id`, `metric_family`, `context_point`, `quant_tier`, `device`, aggregate + CI) needed to answer "largest stable gaps by metric/context/quant" without a further schema change. A deterministic ranking test (`RankCellsByGapTest`) proves the shape supports that query today.
- An expected-cell registry (`scripts/bench_expected_cells.toml`), expanded programmatically from compact axis groups, with a coverage check that fails closed on any expected cell that did not execute (never a silent skip) while still allowing an explicitly named `unsupported` cell.
- A fail-closed run-record validator covering: missing path proof, missing/invalid lock receipts (both heavy-lane and metal-gpu), missing resource samples, a validated phase-event sequence, non-finite metric, low valid-n derived from the registered per-metric policy, missing measured-CV, post-run threshold change (policy content drifted under the same/different version), and candidate-SHA mismatch.
- `scripts/perf-policy.toml`: the versioned regression-gate policy (family thresholds, gate-math method, promotion criteria, replacement cap), pinned by SHA so a later re-validation can detect drift.
- `scripts/bench_gate_math.py` (stdlib-only, no numpy/scipy): order-stratified bootstrap of the log-slowdown mean, a one-sided lower confidence bound, Holm step-down correction, an exact Clopper-Pearson bound via bisection, a registered per-metric policy lookup, and a complete per-family gate evaluator wiring all of the above together.

Gate-math corrections identified during design review are encoded as executable functions (and folded into the design document, internal, not part of this diff):

1. Required `n` is derived from the measured same-session residual CV via `perf-policy.toml`'s `[[cv_bands]]`, not fixed at n=7 — the validator refuses any cell lacking a `measured_cv` record. High-CV bands widen the FAIL margin instead of inflating n indefinitely (diminishing power returns past a point).
2. The small-n bootstrap resamples the MEAN of paired log-slowdowns, never the median — the median's bootstrap distribution is capped at a handful of distinct values at small n, too coarse for a Holm-corrected per-cell tail cut.
3. Promotion records report the achieved Clopper-Pearson bound computed from `(null_sessions, failures)` and are rejected if they assert a tighter, aspirational bound; promotion is gated on `null_sessions >= 20` plus a required minimum of live mainline sessions, not an unreachable upfront session count.

No performance claim in this PR: no adapters, no CI wiring, no engine invocation — no cell in the registry is executed here.

## Review fixes

All four majors and two mediums from the review are addressed:

| # | Finding | Fix | Test |
|---|---------|-----|------|
| Major 1 | `bootstrap_upper_bound` (the `(1-alpha)` quantile) was the function documented to feed `CellAggregate.corrected_lower_bound`, but a FAIL decision needs a *lower* one-sided bound above the threshold, not an upper one. | Added `bootstrap_lower_bound` (the `alpha` percentile — the correct tail), rewired `evaluate_family_gate`'s FAIL rule to consume it exclusively, and left `bootstrap_upper_bound` documented as a diagnostic-only upper bound that must never feed a FAIL rule. | `BootstrapLowerBoundTest` (near-null sample's lower bound sits at/below threshold; deterministic 10% slowdown's lower bound clears it) + `EvaluateFamilyGateTest.test_high_cv_margin_flips_fail_to_non_fail`. |
| Major 2 | `validate_run_record` treated `required_n` as optional submitter-supplied metadata and derived noise class from a hard-coded `metric_family in (...)` heuristic that silently mis-classified `embed.batch_p95` as class A instead of the registered class B. | Added `bench_gate_math.resolve_metric_policy` (looks up the registered per-metric policy table, flat or nested) and wired `validate_run_record` to re-derive `required_n` from the measured CV and resolved noise class, rejecting any record whose `required_n` is missing or does not match. | `SubmitterControlledRequiredNTest` (CV 3% + `required_n=None`; forged `required_n=7` at CV 3%; `embed.batch_p95` at n=7 vs n=9; class-C exemption). |
| Major 3 | Metal records only required the `metal-gpu` lock receipt (never `heavy-lane`), and phase-event / resource-sample proof was never validated at all. | `validate_run_record` now requires both continuously-held lock receipts plus non-empty `resource_samples` on `device=metal` cells, and validates a correctly-ordered `load_start -> backend_ready -> prefill_start -> prefill_end -> token_available(+)` phase sequence on every non-unsupported record (`_validate_phase_sequence`). | `MissingLockReceiptTest` (only-metal-gpu / only-heavy-lane / no-resource-samples all reject) + new `PhaseSequenceTest` (empty, missing-phase, misordered, backwards-`monotonic_ns`, non-increasing `token_index` all reject). |
| Major 4 | `validate_promotion_record` hard-coded `min_null_sessions=20` and never examined `mainline_sessions` or any replacement cap — a 20-null/0-mainline record was accepted. | `validate_promotion_record` now consumes the versioned policy, enforces `min_mainline_sessions` (10), and enforces a new registered `max_invalid_pair_replacements` cap (3) added to both `perf-policy.toml` and `PromotionRecord`. | `PromotionMainlineSessionsTest` (0 and 9 mainline sessions reject, 10 passes) + `PromotionReplacementCapTest` (within/exceeding cap, and a policy missing the cap key fails closed). |
| Medium 1 | Holm correction and `fail_margin_multiplier` existed only as isolated, unit-tested helpers with no caller. | Added `bench_gate_math.evaluate_family_gate`: a complete per-family evaluator that computes per-cell one-sided bootstrap p-values, Holm-corrects them across a family at `alpha=0.05`, and applies the CV band's `fail_margin_multiplier` to the FAIL threshold. **Integrated, not deferred.** | `EvaluateFamilyGateTest.test_holm_ordering_changes_the_verdict` (two cells individually below naive `alpha=0.05` are rejected by neither once Holm-corrected as a family) and `test_high_cv_margin_flips_fail_to_non_fail` (identical effect size FAILs at the raw margin, does not FAIL once measured CV lands in the widened-margin band). |
| Medium 2 | `scripts/perf-policy.toml` and `tests/test_bench_gate_math.py` named an internal actor and internal tooling filenames (publication-hygiene violation). | Replaced with self-contained wording ("cross-checked by an independent Monte-Carlo power simulation"). | Full-diff hygiene sweep (`git diff origin/main...HEAD | grep -inE '...'`) comes back clean. |

### Round-2 review fixes

Round 1's four majors and two mediums (above) verified good; round 2 found three new majors in the evaluator code the round-1 fix commit added. All three addressed:

| # | Finding | Fix | Test |
|---|---------|-----|------|
| Major 1 | `evaluate_family_gate` fixed every cell's lower-bound percentile at the strictest step-0 Bonferroni tail (`alpha/m`) before also requiring the Holm reject flag, so Holm could never change a verdict — a fixed, uniformly-stricter bound already gated every cell regardless of Holm's per-cell step-down assignment. The shipped fixture only asserted the internal `holm_reject` flag changed under mutation, never the verdict. | The lower bound is now computed at each cell's own Holm-assigned step-down tail (`alpha/(m-rank)`, the exact level `holm_reject` tests it at, keyed by its ascending-p-value rank), so the FAIL decision and the confidence bound are the same test at the same alpha. | `test_holm_naive_mutation_flips_a_real_verdict`: swaps `holm_reject` for a naive uncorrected `p <= alpha` check via `mock.patch.object` on the same two-cell family as the round-1 fixture — the real evaluator confirms neither cell FAILs, the naive mutation flips one cell's actual verdict from WARN to FAIL. Mutation-verified by reverting the per-cell alpha assignment to the old fixed `alpha/m` and confirming the new test fails, then restoring. |
| Major 2 | `validate_promotion_record` parsed `policy_version` as any int `>= 1` but never compared it against the loaded `policy_doc["policy_version"]` — a record claiming `policy_version=999` with v1-shaped threshold values was accepted and evaluated under v1's thresholds. | `validate_promotion_record` now fails closed unless the record's `policy_version` exactly matches the structurally-validated loaded policy's version, before any threshold comparison runs. | `test_policy_version_mismatch_fails_closed` (a `policy_version=999` record rejects) + `test_policy_version_match_passes` (a matching version still passes). Mutation-verified by removing the version-binding check and confirming the mismatch test fails, then restoring. |
| Major 3 | `evaluate_family_gate` accepted non-finite raw values (seven NaNs returned a `PASS` verdict with NaN bounds) and under-sampled cells (one pair with `required_n=7` returned `PASS`) — the only per-cell shape check was `len(values) == len(order_ab)`, never finiteness or the policy-derived minimum count. | Both are now rejected (raises `GateMathError`) before any bootstrap resampling: a cell short of its own policy-derived `required_n`, or containing a non-finite value, never reaches a verdict. This is fail-closed via exception, consistent with `validate_run_record`'s existing INFRA-FAIL treatment of the same two conditions on an already-aggregated record. | `test_undersampled_cell_rejected_before_resampling` + `test_non_finite_value_rejected_before_resampling`. Mutation-verified by removing both guards and confirming both new tests fail, then restoring. |

### Round-3 review fixes

Round 2's three majors (above) verified closed; round 3 found one remaining major in the same evaluator.

| # | Finding | Fix | Test |
|---|---------|-----|------|
| Major 1 | `evaluate_family_gate` assigned every p-value rank `k` the tail `alpha/(m-k)` and reported a `corrected_lower_bound` at that tail even for ranks AFTER the real Holm step-down had already stopped at an earlier rank's failed comparison — those later-rank cells were never actually tested at their less-stringent tail, so the exposed bound could read as FAIL-level evidence while the `holm_reject` flag correctly said "not rejected." Concrete two-cell case: p-values `0.040`/`0.037`, the step-down stops at the first cell, yet the second cell's exposed bound (`0.068087`) cleared the 7% fail threshold (`log(1.07)=0.067659`) despite never being tested at that tail. | A cell's bound is now computed only when the real step-down procedure actually evaluated that rank before stopping (all ranks up to and including the stopping rank itself, which was tested and failed; every rank after it was not). Untested ranks report `corrected_lower_bound=None` and can never reach FAIL regardless of their `holm_reject` value — the flag/bound disagreement is structurally impossible now. Testedness is computed independently of whichever reject-decision function is plugged in (mocked or real), so it reflects the actual step-down order in every case. | `test_stopped_holm_rank_never_exposes_a_bound`: reproduces the exact adversarial-review two-cell fixture and asserts the untested cell now reports `None` (not `0.068087`), plus a general coherence assertion that no non-rejected cell across the family ever exposes a threshold-clearing bound. `test_holm_naive_mutation_flips_a_real_verdict` (retained, re-tuned fixture so the flip is driven by the always-tested rank-0 cell rather than the now-`None` untested rank) still demonstrates the real Holm flag is decision-effective, and additionally asserts the untested cell stays un-FAIL-able even under a naive/liberal mutation. Mutation-verified by reverting the tested-rank gating in a disposable copy (bound computed unconditionally again) and confirming the new coherence test fails with the exact `0.068087 > 0.067659` disagreement, then restoring. |

### Round-4 review fixes

Round 3's stopped-rank fix verified correct; round 4 found one remaining major -- a coherence defect for a rank that *was* executed.

| # | Finding | Fix | Test |
|---|---------|-----|------|
| Major 1 | `evaluate_family_gate` computed the per-cell p-value (`one_sided_bootstrap_pvalue`) and the `corrected_lower_bound` (`bootstrap_lower_bound`) from TWO INDEPENDENT bootstrap resampling passes, so percentile duality was not guaranteed even for a rank the real step-down actually tested. Concrete case: a single tested cell, seven near-boundary values (`base=log(1.07)+0.005`, `spread=0.02`), `bootstrap_replicates=2000`, `random.Random(108)` gave `p_value=0.051` (correctly not rejected -- 0.051 > 0.05) yet a separately-drawn `corrected_lower_bound=0.0680872...`, which cleared the 7% threshold `log(1.07)=0.06765864847381486` anyway -- a tested, non-rejected cell exposing FAIL-level bound evidence, at the production default replicate count. | `evaluate_family_gate` now generates ONE retained bootstrap-mean sample per cell (`order_stratified_bootstrap_means`, called once), and derives both the p-value and (for tested ranks) the lower bound from that same sample via new `_pvalue_from_boot_means`/`_lower_bound_from_sorted_boot_means` extraction helpers (also now shared by the standalone `one_sided_bootstrap_pvalue`/`bootstrap_lower_bound` functions). For any tested rank this makes `p <= corrected_alpha` (reject) and `bound > tau` algebraically the same fact about the same sample -- they cannot disagree. Also closed the residual replicate-floor gap: the p-value floor `max(p, 1/b)` could itself sit above the smallest tail Holm's step-down will ever test (`alpha_familywise / len(cells)`), letting an under-resolved floor reintroduce the same incoherence with a genuinely-zero bootstrap count. `evaluate_family_gate` now fails closed (before any resampling) when `bootstrap_replicates` cannot guarantee the floor stays at or below that tail. | `test_shared_sample_pvalue_bound_duality_at_production_replicates`: exact seed-108 reproduction from the review, asserts the tested-not-rejected cell's bound is `None` or `<= tau` (was `0.0680872... > tau`). `test_insufficient_replicates_for_floor_coherence_rejected`: a single cell at 10 replicates (below the `alpha_familywise/1=0.05` -> 20-replicate floor requirement) and a 200-cell family at the production default of 2000 replicates (below the `alpha_familywise/200`-driven requirement) both fail closed. `test_holm_naive_mutation_flips_a_real_verdict` -> **rewritten** to `test_holm_naive_mutation_cannot_flip_a_coherent_verdict`: the shared-sample fix makes real-Holm-reject always a subset of naive `p <= alpha_familywise` reject (since `corrected_alpha <= alpha_familywise` for every tested rank), so by duality anything only the naive check additionally flags already has `bound <= tau` -- the previously-demonstrated flip is now mathematically unreachable. The rewritten test confirms the internal `holm_reject` flags still genuinely disagree under mutation (`b`'s real flag stays `False`, naive flips it to `True`) while asserting the shipped verdict is invariant. Mutation-verified: reverted to two independent bootstrap distributions in a disposable copy, confirmed the exact `0.0680872199023863 > 0.06765864847381486` disagreement reproduces and all three new/rewritten tests fail, then restored and reconfirmed green. |


## Test plan

- [x] `python3 tests/test_bench_decode_harness.py -v` — 117 passed (v1 contract regression, unchanged)
- [x] `python3 tests/test_bench_gate_math.py -v` — 63 passed (was 39 pre-round-1, 57 post-round-1, 60 post-round-2, 61 post-round-3; +2 round-4 for the shared-sample duality and replicate-floor coherence regressions; one round-1/2/3 test rewritten, not net-new, to assert the new mutation-invariance property instead of a now-unreachable flip)
- [x] `python3 tests/test_bench_run_record.py -v` — 75 passed (was 47 pre-round-1, 73 post-round-1; +2 round-2 for the `policy_version` binding)
- [x] All three run with plain `python3` (no `uv`, no third-party deps), matching the existing `bench-decode-harness-tests` CI job's stdlib-only, ubuntu-only constraint -- 255 total passed post-round-4 (63 + 75 + 117)
- [x] Fixtures explicitly prove fail-closed behavior for: missing cell, missing path proof, missing/incomplete lock receipts, missing resource samples, missing/misordered phase sequence, non-finite metric, low valid-n, policy-derived required-n mismatch, missing measured-CV, post-run threshold change, wrong SHA, insufficient mainline sessions, exceeded/unregistered replacement cap, promotion `policy_version` mismatch, and (evaluator-level) non-finite/under-sampled raw cells
- [x] Every review fix has a disposable-copy mutation test: the relevant check was removed in a scratch copy, the corresponding test observed to fail, then the copy was discarded and the real fix re-verified green
- [x] `bench-compare`: N/A — this PR touches only `scripts/` and a design document (internal), no `crates/` code, so there is nothing for `make bench-compare` to measure

Design document (internal) citation: benchmark-overhaul program, phased implementation plan row 1 ("canonical contract and policy, in days"), extends the existing decode-harness consolidation lineage. Does not create a parallel harness.


