### PR TITLE
fix(inference): doctor fails closed when weights exceed RAM or context is 0

### DIFF
--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -532,14 +532,23 @@ mod doctor {
     ///   file, or a CPU-concat fallback), which has no manifest/directory
     ///   entry of its own — so each contributes 2x total.
     /// - `embed_tokens`: dequantized into a full f16 buffer for the CPU
-    ///   embedding lookup (3.2x, same ratio as `in_proj_a`/`b`) AND
-    ///   separately mmap'd at its own on-disk size for the GPU logits GEMV
-    ///   (`embed_tokens_q8`) — 4.2x total. (In the untied-embeddings case
-    ///   the logits mmap actually targets a separate `lm_head.weight.q4`
-    ///   file instead, which is already its own correctly-1x manifest
-    ///   entry; treating `embed_tokens` as a flat 4.2x in both cases is a
-    ///   deliberate, harmless over-estimate rather than added branching on
-    ///   `tie_word_embeddings` for a difference this small.)
+    ///   embedding lookup (3.2x, same ratio as `in_proj_a`/`b`) AND, only in
+    ///   the *tied* (`tie_word_embeddings == true`) case, ALSO separately
+    ///   mmap'd at its own on-disk size for the GPU logits GEMV
+    ///   (`embed_tokens_q8`) — 4.2x total for tied checkpoints. In the
+    ///   *untied* case, `MetalQwen35State::from_q4_dir` immediately shadows
+    ///   that same-named local binding with a fresh mmap of the separate
+    ///   `lm_head.weight.q4` file (`metal_qwen35.rs`, the
+    ///   `!cfg.tie_word_embeddings` branch a few lines after the tied
+    ///   assignment) — the embedding's own Q4 mmap is dropped before the
+    ///   function returns, so only the 3.2x f16 dequant survives, and
+    ///   `lm_head.weight` is counted separately (and correctly, as a plain
+    ///   1x mmap) via its own manifest/directory entry. Flattening this to
+    ///   a constant 4.2x regardless of `tie_word_embeddings` was a
+    ///   deliberate simplification when this estimator was pure telemetry,
+    ///   but it over-counts untied checkpoints by one full embedding-sized
+    ///   mmap once the estimate started gating a hard pass/fail verdict
+    ///   (#881 review) — hence the `tie_word_embeddings` parameter below.
     /// - Everything else (full-attention `q/k/v/o_proj`, `mlp.down_proj`,
     ///   `mlp.gate_proj`/`up_proj` fused by plain concatenation into
     ///   `gate_up_proj`, `linear_attn.out_proj`, `lm_head`) is mmap'd
@@ -550,7 +559,14 @@ mod doctor {
     /// `q4_tensor_path`-style filename (dots already replaced with `_`,
     /// optionally with a trailing `.q4`/`.f16` extension) — both retain the
     /// same distinguishing suffix tokens after normalizing separators.
-    fn q4_resident_bytes(name_or_file: &str, on_disk_bytes: u64) -> u64 {
+    ///
+    /// Even with the `tie_word_embeddings` correction this remains an
+    /// ESTIMATE of peak resident footprint, not a measurement: every mmap
+    /// counted here is a lazy, file-backed no-copy mapping whose pages
+    /// fault into physical memory on first touch rather than at map time,
+    /// so on-disk byte length is an upper bound on eventual residency, not
+    /// proof of it at any given instant.
+    fn q4_resident_bytes(name_or_file: &str, on_disk_bytes: u64, tie_word_embeddings: bool) -> u64 {
         let mut n = name_or_file.replace('.', "_");
         if let Some(stripped) = n.strip_suffix("_q4").or_else(|| n.strip_suffix("_f16")) {
             n = stripped.to_string();
@@ -571,7 +587,8 @@ mod doctor {
             return on_disk_bytes.saturating_mul(2);
         }
         if n.ends_with("embed_tokens_weight") {
-            return (on_disk_bytes as f64 * 4.2).round() as u64;
+            let ratio = if tie_word_embeddings { 4.2 } else { 3.2 };
+            return (on_disk_bytes as f64 * ratio).round() as u64;
         }
         on_disk_bytes
     }
@@ -639,7 +656,8 @@ mod doctor {
                 let file_path = dir.join(&entry.file);
                 match std::fs::metadata(&file_path) {
                     Ok(meta) => {
-                        total_bytes += q4_resident_bytes(&entry.name, meta.len());
+                        total_bytes +=
+                            q4_resident_bytes(&entry.name, meta.len(), cfg.tie_word_embeddings);
                         present_names.insert(entry.name.clone());
                         has_mtp_tensors |= entry.name.starts_with("mtp.");
                     }
@@ -687,7 +705,7 @@ mod doctor {
                 if (name.ends_with(".q4") || name.ends_with(".f16"))
                     && let Ok(meta) = entry.metadata()
                 {
-                    total_bytes += q4_resident_bytes(name, meta.len());
+                    total_bytes += q4_resident_bytes(name, meta.len(), cfg.tie_word_embeddings);
                     tensor_count += 1;
                     has_mtp_tensors |= name.starts_with("mtp_");
                 }
@@ -966,8 +984,11 @@ mod doctor {
             && inventory.total_bytes > avail
         {
             blocking_reasons.push(format!(
-                "weight memory {} exceeds detected system memory {}: this model cannot be \
-                 loaded on this machine",
+                "estimated weight memory {} exceeds detected system memory {}: this model is \
+                 unlikely to load on this machine (estimate of peak resident footprint from \
+                 on-disk tensor sizes -- mmap'd weights fault into physical memory lazily on \
+                 first touch, so this is not a measurement of memory actually held at any \
+                 instant)",
                 human_bytes(inventory.total_bytes),
                 human_bytes(avail)
             ));
@@ -1417,92 +1438,138 @@ mod doctor {
             // Direct unit coverage for the classifier itself, independent of
             // the manifest/fallback-scan plumbing above -- also exercises
             // the sanitized-filename form (dots -> `_`, `.q4`/`.f16` suffix)
-            // used by the no-manifest fallback path.
+            // used by the no-manifest fallback path. `tie_word_embeddings`
+            // is fixed at `true` throughout this test except where noted --
+            // see `q4_resident_bytes_embed_tokens_scales_by_tie_word_embeddings`
+            // for the tied/untied comparison this parameter exists for.
             assert_eq!(
-                q4_resident_bytes("model.language_model.norm.weight", 100),
+                q4_resident_bytes("model.language_model.norm.weight", 100, true),
                 200
             );
             assert_eq!(
-                q4_resident_bytes("model_language_model_norm_weight.f16", 100),
+                q4_resident_bytes("model_language_model_norm_weight.f16", 100, true),
                 200
             );
             assert_eq!(
-                q4_resident_bytes("model.language_model.layers.0.linear_attn.A_log", 100),
+                q4_resident_bytes("model.language_model.layers.0.linear_attn.A_log", 100, true),
                 200
             );
             assert_eq!(
-                q4_resident_bytes("model.language_model.layers.0.linear_attn.dt_bias", 100),
+                q4_resident_bytes(
+                    "model.language_model.layers.0.linear_attn.dt_bias",
+                    100,
+                    true
+                ),
                 200
             );
             assert_eq!(
                 q4_resident_bytes(
                     "model.language_model.layers.0.linear_attn.conv1d.weight",
-                    100
+                    100,
+                    true
                 ),
                 200
             );
             assert_eq!(
                 q4_resident_bytes(
                     "model.language_model.layers.0.linear_attn.in_proj_a.weight",
-                    100
+                    100,
+                    true
                 ),
                 320
             );
             assert_eq!(
                 q4_resident_bytes(
                     "model.language_model.layers.0.linear_attn.in_proj_b.weight",
-                    100
+                    100,
+                    true
                 ),
                 320
             );
             assert_eq!(
                 q4_resident_bytes(
                     "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
-                    100
+                    100,
+                    true
                 ),
                 200
             );
             assert_eq!(
                 q4_resident_bytes(
                     "model.language_model.layers.0.linear_attn.in_proj_z.weight",
-                    100
+                    100,
+                    true
                 ),
                 200
             );
             assert_eq!(
-                q4_resident_bytes("model.language_model.embed_tokens.weight", 100),
+                q4_resident_bytes("model.language_model.embed_tokens.weight", 100, true),
                 420
             );
             assert_eq!(
-                q4_resident_bytes("mtp.pre_fc_norm_embedding.weight", 100),
-                200
-            );
-            assert_eq!(q4_resident_bytes("mtp.pre_fc_norm_hidden.weight", 100), 200);
-            assert_eq!(
-                q4_resident_bytes("mtp_pre_fc_norm_embedding_weight.f16", 100),
+                q4_resident_bytes("mtp.pre_fc_norm_embedding.weight", 100, true),
                 200
             );
             assert_eq!(
-                q4_resident_bytes("mtp_pre_fc_norm_hidden_weight.f16", 100),
+                q4_resident_bytes("mtp.pre_fc_norm_hidden.weight", 100, true),
                 200
             );
-            // Unaffected categories stay at exactly 1x.
             assert_eq!(
-                q4_resident_bytes("model.language_model.layers.0.self_attn.q_proj.weight", 100),
+                q4_resident_bytes("mtp_pre_fc_norm_embedding_weight.f16", 100, true),
+                200
+            );
+            assert_eq!(
+                q4_resident_bytes("mtp_pre_fc_norm_hidden_weight.f16", 100, true),
+                200
+            );
+            // Unaffected categories stay at exactly 1x, regardless of
+            // tie_word_embeddings (only embed_tokens reads that flag).
+            assert_eq!(
+                q4_resident_bytes(
+                    "model.language_model.layers.0.self_attn.q_proj.weight",
+                    100,
+                    true
+                ),
                 100
             );
             assert_eq!(
-                q4_resident_bytes("model.language_model.layers.0.mlp.gate_proj.weight", 100),
+                q4_resident_bytes(
+                    "model.language_model.layers.0.mlp.gate_proj.weight",
+                    100,
+                    false
+                ),
                 100
             );
             assert_eq!(
                 q4_resident_bytes(
                     "model.language_model.layers.0.linear_attn.out_proj.weight",
-                    100
+                    100,
+                    true
                 ),
                 100
             );
-            assert_eq!(q4_resident_bytes("lm_head.weight", 100), 100);
+            assert_eq!(q4_resident_bytes("lm_head.weight", 100, false), 100);
+        }
+
+        #[test]
+        fn q4_resident_bytes_embed_tokens_scales_by_tie_word_embeddings() {
+            // #881 review (medium): a tied checkpoint's `embed_tokens_q8`
+            // binding keeps the raw Q4 mmap of `embed_tokens.weight` itself
+            // (1x) on top of the dequantized f16 lookup buffer (3.2x) =
+            // 4.2x. An untied checkpoint's `from_q4_dir` immediately
+            // shadows that same binding with a fresh mmap of the separate
+            // `lm_head.weight.q4` file, dropping the embedding's own Q4
+            // mmap before the function returns -- only the 3.2x f16 dequant
+            // survives, and `lm_head.weight` is counted on its own (as a
+            // plain 1x, via a different `q4_resident_bytes` call for that
+            // name, which does not match any expansion category).
+            let tensor = "model.language_model.embed_tokens.weight";
+            assert_eq!(q4_resident_bytes(tensor, 1000, true), 4200);
+            assert_eq!(q4_resident_bytes(tensor, 1000, false), 3200);
+            // lm_head itself is always a plain 1x mmap in the inventory,
+            // independent of tie_word_embeddings.
+            assert_eq!(q4_resident_bytes("lm_head.weight", 1000, true), 1000);
+            assert_eq!(q4_resident_bytes("lm_head.weight", 1000, false), 1000);
         }
 
         #[test]
@@ -1922,6 +1989,111 @@ mod doctor {
                 report.blocking_reasons
             );
             assert!(report.max_context_len.unwrap_or(0) > 0);
+            fs::remove_dir_all(&dir).ok();
+        }
+
+        /// Minimal Q4 fixture for the threshold-regression tests below: just
+        /// two manifest entries (an `embed_tokens` tensor and one
+        /// never-expanded tensor, e.g. a plain `q_proj`) rather than the
+        /// full `qwen_required_tensor_names` set. `inspect_q4_dir` sums
+        /// `total_bytes` only over manifest entries actually present, so
+        /// this keeps the expected total small enough to state as a closed
+        /// formula in the test -- computed independently of
+        /// `q4_resident_bytes`/`inspect_q4_dir` themselves, so a regression
+        /// in either is caught rather than silently absorbed into a
+        /// self-referential expectation. `missing_tensors` will list the
+        /// rest of `qwen_required_tensor_names(cfg)` as absent, which is
+        /// irrelevant here: it drives a separate, unrelated blocking
+        /// reason, not the "exceeds detected system memory" one under test.
+        fn write_minimal_q4_fixture(dir: &Path, cfg: &Qwen35Config) -> (u64, u64) {
+            write_fake_q4_file(&dir.join("embed.q4"), 2, &[32], 32, 5);
+            write_fake_q4_file(&dir.join("q_proj.q4"), 2, &[32], 32, 3);
+            let embed_bytes = fs::metadata(dir.join("embed.q4")).unwrap().len();
+            let q_proj_bytes = fs::metadata(dir.join("q_proj.q4")).unwrap().len();
+            let index = serde_json::json!([
+                {"name": "model.language_model.embed_tokens.weight", "file": "embed.q4", "quantized": true, "shape": [32], "numel": 32},
+                {"name": "model.language_model.layers.0.self_attn.q_proj.weight", "file": "q_proj.q4", "quantized": true, "shape": [32], "numel": 32},
+            ]);
+            fs::write(
+                dir.join("quantize_index.json"),
+                serde_json::to_vec(&index).unwrap(),
+            )
+            .unwrap();
+            write_config_json(dir, cfg);
+            fs::write(dir.join("tokenizer.json"), b"{}").unwrap();
+            (embed_bytes, q_proj_bytes)
+        }
+
+        #[test]
+        fn build_report_q4_untied_embed_tokens_threshold_no_longer_overcounts() {
+            // #881 review (medium): before this fix, `q4_resident_bytes`
+            // charged `embed_tokens` at a flat 4.2x on-disk size regardless
+            // of `tie_word_embeddings`, even though an UNTIED checkpoint's
+            // loader drops the embedding's own Q4 mmap and only keeps the
+            // 3.2x f16 dequant (see `q4_resident_bytes`'s doc comment). That
+            // stale 4.2x overcounted an untied checkpoint by exactly one
+            // embedding-file's worth of bytes -- enough to push a
+            // near-boundary checkpoint across the new hard-fail threshold
+            // for a machine it would actually fit on.
+            //
+            // Reproduce at the boundary: pick a memory override strictly
+            // between an INDEPENDENTLY hand-computed corrected (3.2x) total
+            // and what the stale flat-4.2x estimate would have been for the
+            // same on-disk bytes -- both computed here with the `* 3.2`/
+            // `* 4.2` arithmetic directly, not by calling
+            // `q4_resident_bytes`/`inspect_q4_dir`, so a regression back to
+            // the flat-4.2x behavior actually pushes `report`'s real
+            // `inventory.total_bytes` back over this test's override and
+            // is caught.
+            let dir = tempdir("report-q4-untied-threshold");
+            let mut cfg = Qwen35Config::qwen35_0_8b();
+            cfg.tie_word_embeddings = false;
+            let (embed_bytes, q_proj_bytes) = write_minimal_q4_fixture(&dir, &cfg);
+
+            let corrected_total = (embed_bytes as f64 * 3.2).round() as u64 + q_proj_bytes; // untied: 3.2x + 1x
+            let stale_would_have_been = (embed_bytes as f64 * 4.2).round() as u64 + q_proj_bytes; // old flat 4.2x + 1x
+            assert!(stale_would_have_been > corrected_total);
+            let threshold_override =
+                corrected_total + (stale_would_have_been - corrected_total) / 2;
+            assert!(threshold_override > corrected_total);
+            assert!(threshold_override < stale_would_have_been);
+
+            let report = build_report(&dir, None, None, Some(threshold_override)).unwrap();
+            assert!(
+                !report
+                    .blocking_reasons
+                    .iter()
+                    .any(|r| r.contains("exceeds detected system memory")),
+                "corrected Q4 estimate must fit within a budget between the corrected and \
+                 stale flat-4.2x estimate; blocking reasons: {:?}",
+                report.blocking_reasons
+            );
+            fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn build_report_q4_true_over_budget_still_fails() {
+            // Belt-and-suspenders alongside the threshold test above: a Q4
+            // checkpoint that genuinely exceeds even the corrected
+            // (tie_word_embeddings-aware) estimate must still fail closed
+            // -- the fix must not turn into a blanket pass for Q4. Same
+            // independent hand-computed formula as the test above.
+            let dir = tempdir("report-q4-true-over-budget");
+            let mut cfg = Qwen35Config::qwen35_0_8b();
+            cfg.tie_word_embeddings = false;
+            let (embed_bytes, q_proj_bytes) = write_minimal_q4_fixture(&dir, &cfg);
+
+            let corrected_total = (embed_bytes as f64 * 3.2).round() as u64 + q_proj_bytes;
+            let report = build_report(&dir, None, None, Some(corrected_total - 1)).unwrap();
+            assert!(
+                report
+                    .blocking_reasons
+                    .iter()
+                    .any(|r| r.contains("exceeds detected system memory")),
+                "a checkpoint exceeding even the corrected estimate must still fail closed; \
+                 blocking reasons: {:?}",
+                report.blocking_reasons
+            );
             fs::remove_dir_all(&dir).ok();
         }
 

--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -957,6 +957,28 @@ mod doctor {
                 "requested context {requested} does not fit: max feasible is {max_ctx} tokens"
             ));
         }
+        // Fail closed on the doctor's own computed numbers even when no
+        // `--context` was requested (#875): a machine that cannot even fit
+        // the weights, or that fits weights but leaves zero room for a
+        // single token of KV cache, is not "ready to load" regardless of
+        // whether the caller asked about a specific context length.
+        if let Some(avail) = available_memory_bytes
+            && inventory.total_bytes > avail
+        {
+            blocking_reasons.push(format!(
+                "weight memory {} exceeds detected system memory {}: this model cannot be \
+                 loaded on this machine",
+                human_bytes(inventory.total_bytes),
+                human_bytes(avail)
+            ));
+        }
+        if max_context_len == Some(0) {
+            blocking_reasons.push(
+                "max feasible context length is 0 tokens: weights and/or KV cache do not fit \
+                 in available memory (not even a single token of context)"
+                    .to_string(),
+            );
+        }
 
         Ok(DoctorReport {
             model_dir: model_dir.to_path_buf(),
@@ -1825,6 +1847,81 @@ mod doctor {
                 assert_eq!(report.requested_fits, Some(false));
                 assert!(!report.is_ready());
             }
+            fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn build_report_weights_exceed_ram_fails_without_explicit_context() {
+            // Issue #875: doctor's own numbers said weights (64.60 GiB)
+            // exceeded system memory (32.00 GiB) yet the verdict was still
+            // "OK" because no `--context` was passed. Reproduce with no
+            // requested context at all -- the fail-closed check must not
+            // depend on `requested_fits`.
+            let dir = tempdir("report-weights-exceed-ram-no-ctx");
+            let cfg = Qwen35Config::qwen35_0_8b();
+            write_complete_safetensors_fixture(&dir, &cfg);
+            let weight_bytes = required_tensor_fixture(&cfg).len() as u64 * 64;
+
+            let report = build_report(&dir, None, None, Some(weight_bytes - 1)).unwrap();
+            assert!(!report.is_ready());
+            assert_eq!(report.requested_context, None);
+            assert!(
+                report
+                    .blocking_reasons
+                    .iter()
+                    .any(|r| r.contains("exceeds detected system memory")),
+                "blocking reasons: {:?}",
+                report.blocking_reasons
+            );
+            fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn build_report_zero_feasible_context_fails_without_explicit_context() {
+            // Weights alone fit, but leave less than one KV-cache token's
+            // worth of headroom -- max feasible context is 0. Must fail
+            // closed even though no `--context` was requested.
+            let dir = tempdir("report-zero-ctx-no-request");
+            let cfg = Qwen35Config::qwen35_0_8b();
+            write_complete_safetensors_fixture(&dir, &cfg);
+            let weight_bytes = required_tensor_fixture(&cfg).len() as u64 * 64;
+            let kv_bytes_per_token = cfg.kv_bytes_per_token(kv_cache_dtype_bytes()) as u64;
+            assert!(
+                kv_bytes_per_token > 1,
+                "fixture assumption: at least 2 bytes/token of KV cache"
+            );
+
+            let report = build_report(&dir, None, None, Some(weight_bytes + 1)).unwrap();
+            assert_eq!(report.max_context_len, Some(0));
+            assert!(!report.is_ready());
+            assert_eq!(report.requested_context, None);
+            assert!(
+                report
+                    .blocking_reasons
+                    .iter()
+                    .any(|r| r.contains("max feasible context length is 0 tokens")),
+                "blocking reasons: {:?}",
+                report.blocking_reasons
+            );
+            fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn build_report_fits_within_ram_is_ready_without_explicit_context() {
+            // Existing passing configurations must still report OK when no
+            // `--context` is requested (acceptance criterion: no
+            // regression on the happy path).
+            let dir = tempdir("report-fits-no-ctx");
+            let cfg = Qwen35Config::qwen35_0_8b();
+            write_complete_safetensors_fixture(&dir, &cfg);
+
+            let report = build_report(&dir, None, None, Some(1u64 << 40)).unwrap();
+            assert!(
+                report.is_ready(),
+                "blocking reasons: {:?}",
+                report.blocking_reasons
+            );
+            assert!(report.max_context_len.unwrap_or(0) > 0);
             fs::remove_dir_all(&dir).ok();
         }
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## AI-assisted development disclosure

- [x] This PR was developed with AI assistance (Claude, an Anthropic agent).
- [x] A human reviewed the diff before requesting review.
- [x] Tests were run locally and pass (see Test plan).
- [x] No secrets, credentials, or internal-only content are included.

## Summary

Closes #875. `lattice doctor` printed `Result: OK -- ready to load` for a 64.60 GiB Q4 checkpoint on a 32.00 GiB machine, with the report's own line reading `Max feasible context length: 0 tokens` right above the OK verdict. The bug: the only feasibility check that fed `blocking_reasons` was `requested_fits == Some(false)`, and `requested_fits` is `requested_context.map(...)` -- it stays `None` (not `Some(false)`) whenever the caller does not pass `--context`. So the doctor's own arithmetic said "impossible" while the verdict said "OK" on the default (no-`--context`) invocation.

## Fix

`build_report` (`crates/inference/src/bin/lattice.rs`) now pushes two additional, independent blocking reasons that run regardless of whether `requested_context` was supplied:

- `inventory.total_bytes > available_memory_bytes` -> `"estimated weight memory <X> exceeds detected system memory <Y>: ..."`
- `max_context_len == Some(0)` -> `"max feasible context length is 0 tokens: weights and/or KV cache do not fit in available memory (not even a single token of context)"`

These are separate checks with distinct messages (per the issue's acceptance criteria) because they're not always redundant: weights can fit within system memory while still leaving less than one KV-cache token's worth of headroom, which is caught by the second check alone. Both checks are skipped only when `available_memory_bytes` is `None` (system memory genuinely undetectable), consistent with the report's existing "unknown" handling elsewhere.

No exit-code change was needed: the CLI's `Doctor` command already does `if !report.is_ready() { ...; std::process::exit(1); }`, and `is_ready()` is just `blocking_reasons.is_empty()` -- so feeding these two new reasons into the existing `blocking_reasons` Vec automatically routes through the existing nonzero-exit path.

## Tests

Added to `doctor::tests` in `crates/inference/src/bin/lattice.rs`, all with `requested_context: None` (i.e. no `--context` flag) to reproduce the reported bug exactly:

- `build_report_weights_exceed_ram_fails_without_explicit_context` -- weight bytes deliberately exceed the memory override; asserts `!is_ready()` and the "exceeds detected system memory" reason.
- `build_report_zero_feasible_context_fails_without_explicit_context` -- weights fit but leave `< kv_bytes_per_token` bytes of headroom (`max_context_len == Some(0)`); asserts `!is_ready()` and the "max feasible context length is 0 tokens" reason.
- `build_report_fits_within_ram_is_ready_without_explicit_context` -- generous memory override, no `--context`; asserts existing passing configurations still report OK (regression guard, acceptance criterion #3).

Mutation sensitivity verified manually: reverted the two new blocking-reason checks (kept the tests), reran `cargo test -p lattice-inference --bin lattice doctor::` -- both new tests failed (`assertion failed: !report.is_ready()`) while all other doctor tests still passed. Restored the fix and reran; all 40 doctor tests green.

## Review fixes

| Round | Verdict | Finding | Fix |
|---|---|---|---|
| 1 (codex) | APPROVE-WITH-FIXES (1 medium) | `lattice.rs:966` -- the new hard-fail weight check promoted a known Q4 inventory overestimate into a false-negative verdict. `q4_resident_bytes` charged `embed_tokens` at a flat 4.2x on-disk size regardless of `tie_word_embeddings`; for untied checkpoints the loader drops the embedding's own Q4 mmap (shadowed by a separate `lm_head` mmap) and only keeps the 3.2x f16 dequant, so a near-boundary untied Q4 checkpoint could be falsely rejected. Also: the blocking-reason wording overclaimed certainty given mmap pages fault in lazily. | `q4_resident_bytes` now takes `tie_word_embeddings: bool` and applies 4.2x only when tied, 3.2x when untied (both `inspect_q4_dir` call sites updated). Reworded the blocking reason to `"estimated weight memory ... "` and explicitly notes mmap'd weights fault in lazily, so on-disk size is not proof of immediate residency. Added `q4_resident_bytes_embed_tokens_scales_by_tie_word_embeddings` (direct 4.2x/3.2x unit coverage) plus two `build_report`-level threshold tests (`build_report_q4_untied_embed_tokens_threshold_no_longer_overcounts`, `build_report_q4_true_over_budget_still_fails`) using an independently hand-computed expected total (not derived by calling `q4_resident_bytes`/`inspect_q4_dir` themselves), so they stay mutation-sensitive to a regression back to the flat 4.2x estimate. Verified manually: reverted the `tie_word_embeddings` branch, reran the doctor test module -- the direct unit test and the untied-threshold `build_report` test both failed as expected; restored the fix and reran, all 43 doctor tests green. |

## Gates

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace -- -D warnings`: clean
- `cargo clippy -p lattice-inference --bin lattice -- -D warnings`: clean
- `cargo test -p lattice-inference --bin lattice doctor::`: 43 passed, 0 failed
- `cargo test -p lattice-inference --lib --bins`: 1832 passed, 0 failed, 18 ignored (pre-existing, unrelated)
- bench-compare: N/A -- this PR touches only the `doctor` module's verdict-assembly logic in `crates/inference/src/bin/lattice.rs` (a CLI report/verdict path), not any inference or embed library forward-pass or kernel code exercised by a Criterion bench group.

## Test plan

- [x] `cargo test -p lattice-inference --bin lattice doctor::` -- 43/43 pass, including 6 new tests
- [x] `cargo test -p lattice-inference --lib --bins` -- full crate suite green
- [x] `cargo fmt --all -- --check` -- clean
- [x] `cargo clippy --workspace -- -D warnings` -- clean
- [x] Mutation check (round 1): reverting the fail-closed checks fails the two original new tests; restoring passes them
- [x] Mutation check (round 2 fix): reverting the `tie_word_embeddings` branch in `q4_resident_bytes` fails the direct unit test and the untied-threshold `build_report` test; restoring passes them
