### PR TITLE
ci: add cargo-audit gate + clear RUSTSEC-2026-0204 (crossbeam-epoch)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,35 @@
+# cargo-audit configuration — supply-chain vulnerability gate for the lattice
+# workspace. Enforced in CI by `.github/workflows/cargo-audit.yml`, which
+# runs `cargo audit` and fails the job on any *vulnerability*-severity
+# advisory. This file exists solely to document and ignore advisories that
+# are warnings only (unmaintained / unsound-with-no-semver-compatible-fix)
+# and have no actionable remediation today. Never add a vulnerability-severity
+# advisory here — those must be fixed by an upgrade, not silenced.
+#
+# Companion note: `deny.toml` already runs `cargo deny check advisories` as
+# an INFORMATIONAL step inside the existing `cargo-deny` CI job (continue-on-
+# error, so it cannot block merges). This file is for the separate, blocking
+# `cargo-audit` gate — the two run different tools against the same
+# advisory-db and are deliberately independent (cargo-deny stays soft/broad,
+# cargo-audit is the hard vulnerability gate).
+
+[advisories]
+ignore = [
+    # paste 1.0.15 — unmaintained (author archived the crate, no successor
+    # published). Transitive only: pulled in via macro_rules_attribute
+    # (-> tokenizers -> lattice-inference) and via metal/wgpu-hal (-> wgpu ->
+    # lattice-fann/lattice-tune/lattice-inference). We have no direct
+    # dependency to bump or drop; removing it means waiting on upstream
+    # tokenizers/wgpu-hal to migrate off it. No known vulnerability, purely
+    # an unmaintained-status warning.
+    "RUSTSEC-2024-0436",
+
+    # lru 0.12.5 — unsound `IterMut` (Stacked-Borrows violation). Direct
+    # dependency of crates/embed (Cargo.toml pins "0.12"). The fix landed at
+    # >=0.16.3, a semver-incompatible major bump (0.12 -> 0.16) that would
+    # require reviewing lattice-embed's lru usage for API breakage before
+    # taking it; deferred as a follow-up crate bump, not a drop-in `cargo
+    # update`. Verified 2026-07-11: `cargo update -p lru` resolves no newer
+    # 0.12.x release (0.12.5 is latest in-range).
+    "RUSTSEC-2026-0002",
+]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -29,7 +29,7 @@ ignore = [
     # >=0.16.3, a semver-incompatible major bump (0.12 -> 0.16) that would
     # require reviewing lattice-embed's lru usage for API breakage before
     # taking it; deferred as a follow-up crate bump, not a drop-in `cargo
-    # update`. Verified 2026-07-11: `cargo update -p lru` resolves no newer
-    # 0.12.x release (0.12.5 is latest in-range).
+    # update`. Tracked at #886. Verified 2026-07-11: `cargo update -p lru`
+    # resolves no newer 0.12.x release (0.12.5 is latest in-range).
     "RUSTSEC-2026-0002",
 ]

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,56 @@
+name: cargo audit
+#
+# Dedicated vulnerability gate. `ci.yml`'s `cargo-deny` job already runs
+# `cargo deny check advisories`, but that step is deliberately INFORMATIONAL
+# (continue-on-error) so an unrelated upstream disclosure never wedges a
+# merge — see deny.toml's header comment. This workflow is the hard gate:
+# `cargo audit` FAILS the job on any vulnerability-severity RUSTSEC advisory.
+# Warnings (unmaintained / unsound-with-no-fix) are informational here too —
+# see .cargo/audit.toml for the documented, individually-justified ignore
+# list, and never add a vulnerability-severity advisory to that list.
+#
+# Triggered on manifest/lockfile changes (a bump can introduce or resolve an
+# advisory), on changes to the audit config itself, weekly on a schedule
+# (fresh advisory-db entries land with no code change of ours), and on
+# manual dispatch.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'crates/**/Cargo.toml'
+      - '.cargo/audit.toml'
+      - '.github/workflows/cargo-audit.yml'
+  schedule:
+    - cron: '0 6 * * 1'  # weekly Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.94.1
+      - name: Pin the real toolchain bin on PATH
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+      - name: Cache cargo-audit binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-bin-${{ runner.os }}-v0.22.2
+      - name: Install cargo-audit
+        run: |
+          if [ ! -x ~/.cargo/bin/cargo-audit ]; then
+            cargo install cargo-audit --version 0.22.2 --locked
+          fi
+      - name: cargo audit (fails on vulnerabilities, warnings informational per .cargo/audit.toml)
+        run: cargo audit

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -9,20 +9,41 @@ name: cargo audit
 # see .cargo/audit.toml for the documented, individually-justified ignore
 # list, and never add a vulnerability-severity advisory to that list.
 #
-# Triggered on manifest/lockfile changes (a bump can introduce or resolve an
-# advisory), on changes to the audit config itself, weekly on a schedule
-# (fresh advisory-db entries land with no code change of ours), and on
-# manual dispatch.
+# NOTE: no `paths` filter on the `pull_request` trigger below, matching the
+# reasoning in `ci.yml`'s header comment. `cargo-audit-gate` at the bottom of
+# this file is meant to become a *required* status check, and a required
+# check whose workflow never even runs leaves a PR stuck on "Expected,
+# waiting for status to be reported" forever. So this workflow always
+# triggers on every PR to main; dependency-irrelevant PRs are instead
+# handled by gating `audit` and `audit-native` on the `changes` job below,
+# exactly like `ci.yml` gates `ci`/`feature-matrix`/`bench-compile`/`msrv` on
+# its own `changes` job. `cargo-audit-gate` always runs and always reports,
+# so it is the safe context to require — mirroring `ci-gate` in ci.yml,
+# `parity-gate` in e2e-parity.yml, and `app-binaries-gate` in
+# app-binaries.yml. Flipping `cargo-audit-gate` into the branch ruleset's
+# required-checks list is a separate maintainer step (not done by this PR —
+# see the PR description).
+#
+# Two audit jobs cover the two independent Cargo dependency graphs this repo
+# ships: `audit` for the root workspace's tracked `Cargo.lock`, and
+# `audit-native` for `npm/lattice-embed-native`, which declares its own
+# single-crate `[workspace]` (see that manifest's header comment) and is
+# gitignored at the repo root's `Cargo.lock` pattern, so it has no tracked
+# lockfile to scan directly. `audit-native` generates one at CI time with
+# `cargo generate-lockfile` and audits that. cargo-audit's config discovery
+# walks up from the current directory the same way cargo's own config
+# discovery does, so running `cargo audit` from inside
+# npm/lattice-embed-native still picks up the root `.cargo/audit.toml`
+# ignore list — verified locally 2026-07-11 (only the documented lru
+# warning surfaces, exit 0).
+#
+# Also triggered weekly on a schedule (fresh advisory-db entries land with
+# no code change of ours) and on manual dispatch; both always run the full
+# audit regardless of `changes`, since there is no PR diff to gate on.
 
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'Cargo.lock'
-      - 'Cargo.toml'
-      - 'crates/**/Cargo.toml'
-      - '.cargo/audit.toml'
-      - '.github/workflows/cargo-audit.yml'
   schedule:
     - cron: '0 6 * * 1'  # weekly Monday 06:00 UTC
   workflow_dispatch:
@@ -34,8 +55,51 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Decide whether anything that can change either Cargo dependency graph
+  # was touched. A PR that touches neither manifest set cannot introduce or
+  # resolve an advisory, so it does not need either audit job below.
+  changes:
+    name: detect-dependency-changes
+    runs-on: ubuntu-latest
+    outputs:
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
+            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+              || git diff --name-only "HEAD~1...HEAD")
+            echo "Changed files:"
+            echo "$CHANGED"
+            # Two single greps against a here-string, not a `grep | grep -q`
+            # pipe: a downstream `-q` can close its end of a pipe early and
+            # SIGPIPE the upstream producer, which under `pipefail` reports
+            # as the pipeline's exit code instead of the match result
+            # (fail-open on a large diff) — see the matching comment in
+            # ci.yml's `changes` job.
+            MATCH=$(grep -E '(^Cargo\.lock$|^Cargo\.toml$|^crates/.*/Cargo\.toml$|^npm/lattice-embed-native/Cargo\.toml$|^\.cargo/audit\.toml$|^\.github/workflows/cargo-audit\.yml$)' <<<"$CHANGED" || true)
+            if grep -q . <<<"$MATCH"; then
+              echo "deps=true" >> "$GITHUB_OUTPUT"
+              echo "→ dependency-relevant change: audit REQUIRED"
+            else
+              echo "deps=false" >> "$GITHUB_OUTPUT"
+              echo "→ no dependency-relevant change: audit work skipped"
+            fi
+          else
+            # schedule / workflow_dispatch: no PR diff to gate on, always audit.
+            echo "deps=true" >> "$GITHUB_OUTPUT"
+            echo "→ non-PR trigger (${{ github.event_name }}): audit REQUIRED"
+          fi
+
   audit:
-    name: cargo audit
+    name: cargo audit (root workspace)
+    needs: changes
+    if: needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,3 +118,70 @@ jobs:
           fi
       - name: cargo audit (fails on vulnerabilities, warnings informational per .cargo/audit.toml)
         run: cargo audit
+
+  audit-native:
+    name: cargo audit (lattice-embed-native)
+    needs: changes
+    if: needs.changes.outputs.deps == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.94.1
+      - name: Pin the real toolchain bin on PATH
+        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+      - name: Cache cargo-audit binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-bin-${{ runner.os }}-v0.22.2
+      - name: Install cargo-audit
+        run: |
+          if [ ! -x ~/.cargo/bin/cargo-audit ]; then
+            cargo install cargo-audit --version 0.22.2 --locked
+          fi
+      - name: Generate lockfile for the native N-API package
+        # This package is its own single-crate workspace (see
+        # npm/lattice-embed-native/Cargo.toml's header comment) and its
+        # Cargo.lock is gitignored, so there is nothing tracked to scan.
+        # Resolve one at CI time instead.
+        working-directory: npm/lattice-embed-native
+        run: cargo generate-lockfile
+      - name: cargo audit (fails on vulnerabilities, warnings informational per .cargo/audit.toml)
+        working-directory: npm/lattice-embed-native
+        run: cargo audit
+
+  # Always runs, always reports — the safe required-check context. `audit`
+  # and `audit-native` are gated on `changes`, so neither is individually
+  # safe to require: a skipped job still reports success, but only this job
+  # fails closed if `changes` itself blew up. Mirrors `ci-gate` in ci.yml.
+  cargo-audit-gate:
+    name: cargo-audit-gate
+    needs: [changes, audit, audit-native]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve gate
+        run: |
+          CHANGES_RESULT="${{ needs.changes.result }}"
+          DEPS="${{ needs.changes.outputs.deps }}"
+          AUDIT_RESULT="${{ needs.audit.result }}"
+          AUDIT_NATIVE_RESULT="${{ needs.audit-native.result }}"
+          echo "changes=$CHANGES_RESULT deps=$DEPS audit=$AUDIT_RESULT audit-native=$AUDIT_NATIVE_RESULT"
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::change-detection did not succeed, failing closed."
+            exit 1
+          fi
+          if [ "$DEPS" != "true" ]; then
+            echo "No dependency-relevant change, audit jobs not required. PASS."
+            exit 0
+          fi
+          if [ "$AUDIT_RESULT" != "success" ]; then
+            echo "::error::audit (root workspace) did not succeed (result=$AUDIT_RESULT)."
+            exit 1
+          fi
+          if [ "$AUDIT_NATIVE_RESULT" != "success" ]; then
+            echo "::error::audit-native (lattice-embed-native) did not succeed (result=$AUDIT_NATIVE_RESULT)."
+            exit 1
+          fi
+          echo "Dependency-relevant change; both audit jobs PASSED."
+          exit 0


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## AI-assisted development disclosure

- [x] This PR was developed with AI assistance (Claude, an Anthropic agent).
- [ ] A human reviewed the diff before requesting review.
- [x] Tests were run locally and pass (see Test plan).
- [x] No secrets, credentials, or internal-only content are included.

## Summary

A downstream consumer's audit run prompted verifying our own dependency tree. Tracing their failing advisories: the two high-severity `quick-xml` findings involve a crate that is not present anywhere in this workspace's dependency graph, and their `crossbeam-epoch` hit enters through their own direct dependencies, not through the lattice crates they consume — so none of the red findings originate here. Our own tree at current main is vulnerability-free; this PR adds a dedicated `cargo-audit` CI gate so it stays that way, and documents the two remaining warning-level advisories.

## What changed

**Dependency state (verified 2026-07-11, this worktree's `main` HEAD):** the tree had already moved past the vulnerability originally reported — `crossbeam-epoch` is already at 0.9.20 (RUSTSEC-2026-0204's fixed range) and `anyhow`/`memmap2`'s previously-flagged versions are no longer in the resolved graph at all (memmap2 is at 0.9.11, already past RUSTSEC-2026-0186's fix; anyhow isn't a dependency of the current tree). `cargo update -p crossbeam-epoch -p memmap2 -p lru` confirmed zero lockfile changes — everything reachable within semver is already current. `cargo audit` on this branch reports **zero vulnerabilities**.

Two warning-severity advisories remain, both without an actionable in-range fix:

- **`paste` 1.0.15** — unmaintained (RUSTSEC-2024-0436). Fully transitive (via `macro_rules_attribute` → `tokenizers` → `lattice-inference`, and via `metal`/`wgpu-hal` → `wgpu` → `lattice-fann`/`lattice-tune`/`lattice-inference`). No direct dependency to bump or drop.
- **`lru` 0.12.5** — unsound `IterMut` (RUSTSEC-2026-0002). Direct dependency of `crates/embed` (pinned `"0.12"`). The fix requires `>=0.16.3`, a semver-incompatible major bump that needs an API-usage review before taking — deferred as a follow-up crate bump, not a drop-in `cargo update`. Tracked at #886.

Both are documented and ignored in `.cargo/audit.toml` with per-advisory justification comments, so the new gate is a real, currently-green vulnerability check rather than a check permanently red on unfixable warnings.

**New workflow:** `.github/workflows/cargo-audit.yml` — runs `cargo audit`, fails on any vulnerability-severity advisory, warnings stay informational via `.cargo/audit.toml`. Weekly `schedule` (Monday 06:00 UTC, matching the existing `bench-update.yml`/`e2e-parity.yml` convention) and `workflow_dispatch` are unchanged from round 1. `permissions: contents: read` only. `ci.yml`'s existing `cargo-deny` job already runs `cargo deny check advisories` but deliberately as an informational/continue-on-error step (see `deny.toml`'s header) — this new workflow is the separate, blocking vulnerability gate; the two are intentionally independent.

## Review fixes

The initial review pass on this PR came back APPROVE-WITH-FIXES (3 majors, 1 minor). This revision addresses the majors that are this PR's responsibility and the minor; the remaining major is a branch-ruleset change routed separately (see below).

- **Path-filter vs required-check incompatibility (fixed).** The `pull_request` trigger's `paths` filter is gone. A path-filtered workflow is left "Expected, waiting for status" forever on PRs that don't touch the filtered paths once its check is required — GitHub does not report a skipped run as passing for a required context. The workflow now always triggers on every PR to `main`, matching `ci.yml`'s own trigger comment and `changes`-job pattern: a new `changes` job diffs against the PR's merge base and outputs `deps`; the `audit` and `audit-native` jobs are gated on `needs.changes.outputs.deps == 'true'`; a new `cargo-audit-gate` job always runs (`if: always()`) and mirrors the gated jobs' results, exactly like `ci-gate` in `ci.yml`, `parity-gate` in `e2e-parity.yml`, and `app-binaries-gate` in `app-binaries.yml`. `cargo-audit-gate` is the job name to add to the branch ruleset, not `cargo audit`.
- **`npm/lattice-embed-native` escapes the audit (fixed — covered, not just documented).** That package declares its own single-crate `[workspace]` and its `Cargo.lock` is gitignored (no tracked lockfile to scan), so a dependency bump there was invisible to both the old path filter and a plain root-workspace `cargo audit`. Chose to cover it rather than punt to a follow-up: `npm/lattice-embed-native/Cargo.toml` is now in the `changes` job's dependency-file patterns, and a new `audit-native` job runs `cargo generate-lockfile` inside that directory (fast, network-only, no flaky toolchain quirks — verified locally) and then `cargo audit` there. Verified locally that `cargo audit` run from inside `npm/lattice-embed-native` still picks up the root `.cargo/audit.toml` ignore list (cargo-audit's config discovery walks up parent directories the same way cargo's own config discovery does, independent of `[workspace]` boundaries) — only the documented `lru` warning surfaces, exit 0. `cargo-audit-gate` now also depends on `audit-native`'s result.
- **`lru` ignore justification not linked to its tracking issue (fixed).** `.cargo/audit.toml`'s `lru` entry now references `#886`.
- **Job not in the required-checks list (not this PR's scope).** Confirmed: `cargo-audit`'s old job name isn't in the `main` branch ruleset today. Flipping the (now always-reporting) `cargo-audit-gate` context into `required_status_checks` is a separate maintainer step, done after this PR merges and a fresh PR run has produced the context — not done here.

## Gates

- `cargo check --workspace`: clean
- `cargo audit` (root workspace, with `.cargo/audit.toml` in place): 0 vulnerabilities, 0 warnings, exit 0
- `cargo audit` (`npm/lattice-embed-native`, freshly generated lockfile): 0 vulnerabilities, 1 documented warning (`lru`), exit 0
- `actionlint .github/workflows/cargo-audit.yml`: clean
- Publication-hygiene grep on the diff: clean (only false-positive matches on the English word "advisory"/"advisories")

## Test plan

- [x] `cargo update -p crossbeam-epoch -p memmap2 -p lru` — confirmed no lockfile changes needed (already at latest in-range versions)
- [x] `timeout 900 cargo check --workspace` — clean
- [x] `cargo audit` (root workspace) before `.cargo/audit.toml` — 2 warnings (paste, lru), 0 vulnerabilities, exit 0
- [x] `cargo audit` (root workspace) after `.cargo/audit.toml` — 0 warnings, 0 vulnerabilities, exit 0
- [x] `cd npm/lattice-embed-native && cargo generate-lockfile && cargo audit` — 1 documented warning (lru, via root `.cargo/audit.toml`), 0 vulnerabilities, exit 0
- [x] `actionlint .github/workflows/cargo-audit.yml` — clean