### PR TITLE
chore(release): v0.6.0 - version bump + release notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 # MSRV, verified end-to-end (workspace + deps) on 1.93.1 and guarded by the msrv CI
 # job (aarch64 macOS, f16,metal-gpu, --all-targets) so a newer-toolchain-only API

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -55,14 +55,14 @@ tracing = "0.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["sync", "rt"] }
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.5.1", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.6.0", path = "../inference", optional = true, features = ["f16"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.0", default-features = false, features = ["sync", "rt"] }
 # Same crate, trimmed to the CPU compute path: `std` + `f16`, without
 # `download` (ureq) or `serve` (axum/tokio-net/mio), none of which compile to
 # wasm32-unknown-unknown.
-lattice-inference = { version = "0.5.1", path = "../inference", optional = true, default-features = false, features = [
+lattice-inference = { version = "0.6.0", path = "../inference", optional = true, default-features = false, features = [
     "std",
     "f16",
 ] }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -67,7 +67,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.5.1", path = "../fann", optional = true }
+lattice-fann = { version = "0.6.0", path = "../fann", optional = true }
 
 [[bin]]
 name = "lattice"

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -30,7 +30,7 @@ sqlite = ["dep:rusqlite", "serde"]
 mixture = ["lattice-fann/online-router"]
 
 [dependencies]
-lattice-fann = { version = "0.5.1", path = "../fann" }
+lattice-fann = { version = "0.6.0", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -51,7 +51,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.5.1", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.6.0", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,223 @@
+# lattice v0.6.0
+
+59 commits since v0.5.1. Minor release under 0.x semver (breaking changes land in the
+minor slot pre-1.0): includes public API breaks, called out explicitly in
+`## Breaking changes` below. Verified against the published v0.5.1 baseline with
+`cargo semver-checks check-release` across all five publishable crates; see this PR's
+description for the per-crate results.
+
+## Headline: MoE Q4 quantization end to end (Qwen3.6-35B-A3B)
+
+- **`quantize_q4` now converts MoE routed-expert tensors** (#878, closes #874).
+  `should_quantize()` previously gated purely on a `.weight` name suffix, which
+  routed-expert tensors (`mlp.experts.gate_up_proj` / `mlp.experts.down_proj`, fused
+  per-layer 3-D arrays with no `.weight` suffix) never matched, so they were written
+  through at source precision. On the Qwen3.6-35B-A3B checkpoint (256 experts/layer)
+  that is roughly 92% of parameters. Fixed by matching the expert-tensor names
+  explicitly ahead of the suffix gate.
+
+  Measured on the real 66.97 GB bf16 Qwen3.6-35B-A3B checkpoint: output dropped from
+  63.21 GB (pre-fix, 1.06x ratio) to **20.93 GiB (3.20x ratio)**. All 82 routed-expert
+  tensors (40 main-model layers + 1 MTP layer) are quantized, carrying 19.22 GiB of the
+  20.93 GiB Q4 payload (91.9%). The remaining ~10% gap versus the 19.03 GiB
+  mlx-community reference is attributed in the PR to lattice's Q4 block format itself
+  (32-element asymmetric blocks, 5.000 bits/element, versus 4.500 bits/element for both
+  the GGUF and mlx-community reference formats), not to any unconverted tensor.
+- **`from_q4_dir` gained a MoE FFN loading branch** (#883, closes #876). The Q4 loader's
+  per-layer FFN construction previously assumed a Dense checkpoint unconditionally and
+  crashed at layer 0 on a MoE Q4 directory. Adds a `cfg.is_moe()` branch that mmaps and
+  dequantizes routed/shared expert tensors from the mapped Q4 payload (no intermediate
+  owned raw-Q4 copy before dequant),
+  matching the f16 GPU representation `MetalQwen35Engine::new()` already uses for MoE
+  (ADR-053), plus a cumulative (not just per-layer) headroom guard so a checkpoint whose
+  total dequantized expert-weight footprint exceeds the machine's unified memory fails
+  closed with a diagnostic instead of running into an OOM partway through generation.
+  On this checkpoint's real 32 GB-memory test machine, full end-to-end generation is not
+  reachable with the current eager-per-layer dequant design (~60 GiB needed); the loader
+  fails closed at layer 14 with a clear message rather than crashing or hanging. A
+  streaming/partial-residency MoE loader is tracked separately (#682).
+
+## Breaking changes
+
+- **GDN LoRA backward API** (#792): `GdnSaved` (`crates/inference/src/attention/gdn_backward.rs`)
+  gained 18 new public fields carrying LoRA rank/scale and the per-projection hidden/gate
+  buffers needed for GatedDeltaNet LoRA weight gradients, and the signatures of
+  `gdn_backward` (4 params -> 3) and `gdn_forward_save` (5 params -> 17) changed to
+  match. This only affects code that constructs `GdnSaved` via a struct literal or calls
+  `gdn_backward` / `gdn_forward_save` directly — i.e. custom GDN backward-pass drivers.
+  The high-level training entry points (`train_core` and friends) are unaffected; callers
+  going through those do not need to change anything.
+- **`ChatCompletionOutput` gained a `stopped: bool` field** (#786, part of the shared
+  HTTP serving contract in ADR-080's C2): any 0.5.1 code that builds a
+  `ChatCompletionOutput` via an exhaustive struct literal, or destructures one with a
+  fixed field list (`let ChatCompletionOutput { message, prompt_tokens, .. } = out` still
+  works; a pattern without `..` does not), needs to add the new field to compile.
+
+A 0.5.1 user upgrading who does not touch `GdnSaved`, `gdn_backward`, `gdn_forward_save`,
+or construct/destructure `ChatCompletionOutput` exhaustively needs no source changes.
+
+## Highlights
+
+- **Query-likelihood reranking** (#718): `Qwen35Model::rerank(query, candidates)` scores
+  each candidate by the mean negative log-likelihood of the query conditioned on the
+  candidate, over the existing CPU log-likelihood path, using no new kernels. Fail-closed on
+  empty/over-length inputs; a composed LoRA adapter applies transparently through the
+  same scoring path.
+- **GDN LoRA weight gradients** (#792, re-homed port of #202): GatedDeltaNet layers can
+  now carry a trainable LoRA adapter with real weight gradients through `train_core`,
+  matching the existing GQA/attention-layer LoRA training path. Fixed a latent
+  alpha/beta dimensioning bug uncovered during the port (alpha/beta are per-value-head,
+  not per-key-head, invisible on symmetric checkpoints like the 0.8B but load-bearing on
+  the 4B/27B's asymmetric head counts) and added an independent source-parity oracle
+  test class for it.
+- **S1 GDN chunkwise-prefill oracle completed** (#716, part of #175): the parity oracle
+  is reformulated in log space to remove a reciprocal-overflow underflow on strong-decay
+  heads (`alpha ~ 1e-4`) that previously poisoned a chunk with NaN, adds a strong-decay
+  regression fixture, and is now validated against real Qwen3.5-0.8B activations
+  (`<= 1e-5` chunkwise-vs-sequential across layers/heads/chunk sizes, test-only surface).
+- **Prefill attention occupancy: group-size-specialized kernel selection** (#709). The
+  prefill attention kernel previously sized its threadgroup memory for the fleet-maximum
+  group size (8) on every model, forcing 1x occupancy on models with a smaller
+  group size. Specializing the kernel to each model's actual group size (4, 6, or 8)
+  keeps smaller-group models under the occupancy cliff. Self-measured (M2 Max,
+  Qwen3.5-0.8B-Q4, idle GPU, same session, production dispatch path):
+
+  | prompt tokens | previous (group-8 kernel) | this change (group-4 kernel) | delta |
+  |---:|---:|---:|---:|
+  | 2048 | 1204.3 ms | 1062.3 ms (std 1.9) | -11.8% |
+  | 4096 | 3179.2 ms | 2600.3 ms (std 3.5) | -18.2% |
+
+  Output is bit-identical per model; this is purely an occupancy/scheduling change.
+- **Skip discarded terminal work on intermediate long-prefill chunks** (#708): chunked
+  prefill (prompts longer than `max_prefill`) no longer runs the final RMSNorm /
+  full-vocab `lm_head` GEMV / top-k tail on chunks whose logits are discarded anyway.
+  Not a throughput claim: the PR's own accounting puts the removed work at roughly
+  seven full-vocab GEMVs against a multi-second TTFT, below A/B measurement resolution;
+  the value is the removed waste plus a new mutation-sensitive correctness regression
+  test guarding it.
+- **BERT/embedding epilogue fusions.** Residual-add fused into the LayerNorm epilogue
+  (#700): primitive-level A/B on the same binary shows the fused epilogue at 3.18x-3.33x
+  the unfused two-step version (hidden=384/seq=128: 14.46us vs 46.00us; hidden=768/seq=128:
+  27.44us vs 91.42us); end-to-end `encode`/`encode_batch` effect is small and mostly
+  within noise except at larger batch sizes, per the PR's own reporting. Varlen/packed
+  batching for `encode_batch` (#701) skips padding-row compute on mixed-length batches
+  (no throughput number reported in the PR; correctness verified to ~2e-7 against the
+  bit-identical longest-sequence case, expected under f32 reassociation). The
+  LoRA-adapter BERT FFN path now also uses the fused `add_bias_gelu` kernel (#699),
+  closing the one remaining unfused site; no performance claim made for this one.
+- **Metal shaders extracted to `.metal` files** (#710): all inline MSL shader source in
+  `crates/inference/src/forward/` (~85 kernels, ~4,566 lines across 6 holders) moved out
+  of Rust string literals into real `.metal` files loaded via `include_str!`, proven
+  byte-identical per extraction method (line-for-line diff for raw-string holders,
+  reversibility check for the two `concat!()`-assembled holders). Pure refactor, no
+  runtime behavior change; makes the native-Metal kernel library diffable,
+  syntax-highlighted, and easier to compare against other Metal engines.
+
+## Correctness and robustness (ADR-080 fail-closed consolidation)
+
+ADR-080 (merged this cycle, #778, marked Implemented in #863) consolidated several
+duplicated numeric-contract helpers across CPU/Metal/WGPU into single shared, fail-closed
+implementations:
+
+- **C1: shared fail-closed softmax row finalizer.** A softmax row with a NaN input, an
+  `+inf` max, or a non-positive/non-finite denominator is now zeroed in full rather than
+  partially normalized or silently clamped, via one shared row-finalizer routed through
+  every CPU production attention-softmax site (#785), the Metal `fused_attention`
+  finalize path (#794, also deletes dead kernels), and the WGPU `attention_softmax`
+  shader, which previously floor-clamped its denominator in a way that let a NaN
+  numerator survive as a finite-looking output (#795).
+- **C2: shared HTTP serving contract** for `lattice` and `lattice_serve` (#786),
+  fixing two real bugs the prior duplication had let drift apart: `lattice_serve`
+  hardcoded `finish_reason: "stop"` regardless of the engine's actual stop cause
+  (length-capped completions were misreported as explicit stops), and `lattice`'s CPU
+  streaming path lacked the disconnect-cancellation behavior `lattice_serve` already had.
+- **C3: backend-neutral decode policy** (#787): stop-string matching, reasoning-budget
+  accounting, and logprobs formatting now live in one `DecodePolicy` struct with a single
+  construction path and a single per-step transition path, shared across backends.
+- **C4: checked GEMM argument validator** (#796): every safe GEMM/GEMV/matvec entry
+  point across CPU, WGPU, and Metal now runs shape-product overflow checks
+  (`checked_mul`) before those products size or index a buffer, as release-active
+  assertions rather than `debug_assert!`.
+- **Fail-closed GDN Q/K normalization on non-finite input** (#862, CPU and Metal): the
+  L2-normalization guard on all eight GDN Q/K sites correctly zeroed the reciprocal on a
+  near-zero or non-finite norm, but multiplied it back through the input lane
+  (`NaN * 0.0 == NaN` under IEEE-754), letting a poisoned value survive into GDN's
+  cross-token recurrent state. Fixed to zero the vector by direct assignment.
+- **Cross-turn prefix-cache suffix validated before the cache-mutating restore**
+  (#867): an out-of-vocab, empty, or overflowing suffix was previously only rejected
+  after the cache slot had already been consumed/reset, destroying a valid warmed
+  cache entry on a request that was going to be rejected anyway. A pure preflight now
+  runs before any cache mutation.
+- **`lattice doctor` fails closed on infeasible memory/context** (#881): the doctor
+  could print `Result: OK` for a checkpoint that would not fit in system RAM, or whose
+  own computed max feasible context was 0 tokens, whenever the caller did not pass
+  `--context` explicitly. Both conditions now independently block the OK verdict.
+- **GPU optimizer training step fails loudly instead of silently no-opping** (#798,
+  tune crate): the Adam/AdamW/SGD-momentum GPU optimizer arms submitted an empty
+  command encoder and returned success while performing zero weight updates; RMSprop
+  silently substituted plain SGD. All arms now fail loudly instead of reporting a
+  successful no-op step.
+- **First-wins tie-break in MTP/self-speculative test oracles** (#859): the private
+  test-only `argmax()` helpers used last-wins tie-breaking, while the production
+  reference (`crate::speculative::argmax`) is documented and implemented as
+  first-wins, so a last-wins test oracle could mask a first-wins regression in the real
+  decode path on an exact-tie logit pair. Oracles now delegate to the production
+  tie-break directly.
+- **`matmul_bt_q8` dimension-product overflow guard** (#707).
+
+## Deprecations
+
+- `crate::generate` (`GenerateConfig`, `GenerateOutput`, `generate`) and
+  `Qwen35Model::generate_with_batch_prefill` are marked `#[deprecated(since = "0.5.1")]`.
+  Originally scheduled for removal in 0.6.0 (#865); the removal target slips to
+  **0.7.0** (deliberate — give downstream consumers a full extra release to migrate off
+  the deprecated paths before this release also lands unrelated breaking changes; see
+  `## Breaking changes` above). Both paths are unused by any in-repo binary, example, or
+  library caller and duplicate the canonical decode loop (`Qwen35Model::generate` /
+  `generate_streaming`). No code removed and no behavior change in this release. A
+  migration guide with a field-by-field config mapping is in
+  `crates/inference/src/generate.rs`'s module docs. `lattice-embed`'s `QwenModel::encode`
+  is unaffected.
+- ADR-069 (vision encoder recalibration for Qwen3.5-0.8B) also now targets **0.7.0**;
+  it remains parked off `main` as an ADR document only, no code on `main` in this
+  release.
+
+## Fixes
+
+- Runnable download command for the Qwen3-Embedding fetch path (#691, #692, #693, #697).
+
+## Bench / CI infrastructure
+
+- A dedicated `cargo-audit` CI gate (weekly schedule plus every PR to `main`) now blocks
+  on any vulnerability-severity advisory in the workspace dependency tree, with two
+  remaining warning-level advisories (`paste`, unmaintained; `lru`, unsound `IterMut`,
+  tracked at #886) documented and explicitly ignored so the gate stays green rather than
+  permanently red on unfixable warnings. Also covers the gitignored-lockfile
+  `npm/lattice-embed-native` package, which the plain root-workspace audit could not see
+  (#885).
+- Schema-v2 measurement contract, `perf-policy.toml`, and corrected gate math
+  (order-stratified bootstrap, Holm step-down correction, Clopper-Pearson promotion
+  bound) for the benchmark harness overhaul (#877). No performance claim: no adapters
+  or CI wiring are live from this PR alone; it lands the contract and policy only.
+- `bench-compare`'s quick-mode gate now excludes two issue-evidenced noise-dominated
+  `lattice-embed` SIMD groups (`simd_dot_product`, `simd_cosine_similarity`) from the
+  FAIL/WARN gate via a reviewed allowlist; `--full` mode still gates them (#872, see
+  #714 for the underlying noise reproduction).
+- Regenerated the `perplexity.tsv` quality baseline against current code (the prior
+  numbers predated the RoPE fix and no longer reflected reality) and wired a Q4
+  perplexity CI gate that self-bootstraps its golden value on first run and requires a
+  maintainer to arm it (#705, closes #616).
+
+## Docs
+
+- ADR-080 (numeric-contract-helper consolidation, #778, marked Implemented in #863) and
+  a priority/roadmap ADR series covering GDN recurrent state (#723), weight
+  quantization (#724), KV-cache quantization (#725), MTP/speculative decoding (#726),
+  MoE expert offload (#727), adaptive reasoning budget (#728), pruning and distillation
+  (#729), multimodal/vision serving deferral (#731), and the adaptive micro-LoRA brain
+  (#732), plus a prefill-GEMM optimization priority ADR and its measured-results fold
+  (#721, #722).
+- ADR-044 amendment superseding its step-4 QuaRot-beats-Q4 conclusion, based on the
+  code-bisection in #705 (#704).
+- Post-#787 generation entry-point behavior-matrix docs (#855).
+- README CLI quick-start: fixed stale version pins, added a get-a-model step (#720).


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Bumps workspace + internal path-dep versions `0.5.1 -> 0.6.0` (root `Cargo.toml`
`[workspace.package].version` plus the 5 internal path-dep entries: `crates/inference/Cargo.toml`
(`lattice-fann`), `crates/embed/Cargo.toml` x2 (`lattice-inference`), `crates/tune/Cargo.toml` x2
(`lattice-fann`, `lattice-inference`)) and adds `docs/releases/v0.6.0.md`. 59 commits since v0.5.1.

## Why 0.6.0, not 0.5.2

`cargo semver-checks check-release` against the published v0.5.1 baseline found two required-major
violations in `lattice-inference` (full results below). Under 0.x semver the minor digit is the
compatibility boundary, so this ships as a minor release rather than a patch. The breaking surface
is scoped and documented in the release notes' new `## Breaking changes` section:

- **GDN LoRA backward API** (#792): `GdnSaved` (`crates/inference/src/attention/gdn_backward.rs`)
  gained 18 new public fields (LoRA rank/scale + per-projection hidden/gate buffers), and
  `gdn_backward` (4 params -> 3) / `gdn_forward_save` (5 params -> 17) changed arity. Affects only
  code that constructs `GdnSaved` via struct literal or calls these functions directly — custom GDN
  backward-pass drivers. The high-level `train_core` entry points are unaffected.
- **`ChatCompletionOutput` gained a `stopped: bool` field** (#786, part of ADR-080's C2 shared HTTP
  serving contract): breaks exhaustive struct literals/destructuring of that type.

A 0.5.1 user who does not touch `GdnSaved`/`gdn_backward`/`gdn_forward_save` or construct/destructure
`ChatCompletionOutput` exhaustively needs no source changes.

Also in this cycle: the `crate::generate` / `generate_with_batch_prefill` deprecation's removal
target slips from 0.6.0 to **0.7.0** (deliberate — give consumers a full release to migrate before
this release also lands the LoRA/serve breaks above), and ADR-069 vision-encoder work now also
targets 0.7.0 (still parked off `main`, ADR doc only).

## semver-checks evidence (v0.5.1 -> 0.6.0, all five publishable crates)

```
lattice-fann:       Checked 0 checks: 0 pass, 253 skip (major change) -- no semver update required
lattice-transport:  Checked 0 checks: 0 pass, 253 skip (major change) -- no semver update required
lattice-inference:  Checked 0 checks: 0 pass, 253 skip (major change) -- no semver update required
lattice-embed:      Checked 0 checks: 0 pass, 253 skip (major change) -- no semver update required
lattice-tune:       Checked 0 checks: 0 pass, 253 skip (major change) -- no semver update required
```

`lattice-inference` is the one that mattered: at a `0.5.2` (patch) target it failed with
`constructible_struct_adds_field` (`GdnSaved`, `ChatCompletionOutput`) and
`function_parameter_count_changed` (`gdn_backward`, `gdn_forward_save`) — 2 major-required checks
failed. Re-run against the `0.6.0` target: `cargo-semver-checks` classifies 0.5.1 -> 0.6.0 as a
"major change" under Cargo's 0.x pre-1.0 rule, so all lints that only apply within a
compatible-version window are skipped and the tool reports the bump itself as sufficient. All five
crates pass clean.

## What ships in 0.6.0

- **MoE Q4 quantization end to end** (Qwen3.6-35B-A3B): `quantize_q4` now converts routed-expert
  tensors (#878, closes #874) — measured 63.21 GB -> 20.93 GiB (3.20x) on the real checkpoint, all
  82 expert tensors covered. `from_q4_dir` gained a MoE FFN loading branch (#883, closes #876) with
  a cumulative headroom guard that fails closed instead of OOMing.
- **Breaking**: GDN LoRA weight gradients (#792) and the `ChatCompletionOutput.stopped` field (#786)
  — see above.
- Query-likelihood reranking (#718), S1 GDN chunkwise-prefill oracle fix (#716), prefill attention
  occupancy group-size specialization (#709, self-measured -11.8%/-18.2% at 2048/4096 tokens),
  skip-discarded-terminal-work on chunked prefill (#708), BERT/embedding epilogue fusions
  (#700/#701/#699), Metal shaders extracted to `.metal` files (#710).
- ADR-080 fail-closed consolidation: shared softmax row finalizer (#785/#794/#795), shared HTTP
  serving contract (#786), backend-neutral decode policy (#787), checked GEMM argument validator
  (#796), fail-closed GDN Q/K normalization (#862), prefix-cache suffix preflight (#867),
  `lattice doctor` fails closed on infeasible memory/context (#881), GPU optimizer fails loudly
  instead of silently no-opping (#798), first-wins tie-break test-oracle fix (#859).
- Full details, PR-by-PR: `docs/releases/v0.6.0.md`.

## Gates

- `cargo check --workspace`: clean at 0.6.0 (`Cargo.lock` gitignored in this repo, updated locally).
- Pre-commit hook (doc-lint + capability-matrix fixture check): passed on commit.
- `cargo semver-checks check-release` per publishable crate: all five pass (table above).
- Version/docs-only change: no bench-compare (no runtime code paths touched by this PR itself).

## Test plan

- [x] `grep -rn 'version = "0.5.1"' Cargo.toml crates/*/Cargo.toml` returns zero hits post-bump;
      all 6 sites (root + 5 path-deps) confirmed at `0.6.0`.
- [x] `cargo check --workspace` — clean.
- [x] `cargo semver-checks check-release -p <crate>` for all five publishable crates — all pass.
- [x] `docs/releases/v0.6.0.md` matches the `v0.5.1.md` file/heading convention; internal
      runner-checklist HTML-comment block stripped from the copied body.
- [ ] Tag + `make publish` + `gh release create` — deliberately NOT done in this PR; happens after
      merge, per the release runbook.

## Release mechanics (after merge, Ocean-held)

- Tag `v0.6.0` -> `make publish` (crates.io, publish DAG: fann, transport -> inference -> embed, tune).
- `gh release create v0.6.0 --title v0.6.0 --notes-file docs/releases/v0.6.0.md`.
- Post-release: verify all five crates show v0.6.0 on crates.io; smoke-test
  `cargo add lattice-inference@0.6.0` in a fresh project.

This PR intentionally does not tag, publish, or mark itself ready for merge.
