### PR TITLE
chore(inference): exclude heavy test fixtures from published package

### DIFF
--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -7,6 +7,10 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Pure Rust transformer inference engine — safetensors loading, SIMD matmul, BGE/Qwen3 embeddings"
+# Heavy test-only fixtures (~40MB raw) push the packaged crate past the
+# crates.io 10MB upload limit. They are consumed only by integration tests,
+# which are never run from the published crate.
+exclude = ["tests/fixtures/tokenizers", "tests/fixtures/gdn_chunk"]
 
 [features]
 default = ["std", "download", "serve"]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Adds a `package.exclude` for `tests/fixtures/tokenizers` (~29MB raw) and `tests/fixtures/gdn_chunk` (~11MB raw) in `crates/inference/Cargo.toml`.

## Why

The v0.6.0 publish is blocked mid-flight: `lattice-fann` and `lattice-transport` are live at 0.6.0, but `lattice-inference` packaged at **12.0MiB compressed — over the crates.io 10MB upload limit** (uploads fail with an opaque `HTTP/2 stream error`, not a clean 413). 0.5.1 was 7.8MiB; the delta is the tokenizer JSON fixtures and the GDN chunk-parity fixtures added since.

These directories are consumed only by integration tests, which are never run from the published crate. The one fixture referenced from `src/` (`qwen35_0_8b_config.json`, via a `#[cfg(test)]` `include_str!`) is small and stays packaged.

## Verification

- `cargo package -p lattice-inference` (with verify build): **246 files, 7.4MiB raw, 1.6MiB compressed** — passes, lib builds from the packaged source.
- Repo CI is unaffected: `exclude` changes packaging only; fixtures remain in the repo and all tests run as before.
- `lattice-embed` / `lattice-tune` packages are tiny (<1.5MB) — no equivalent risk.

## AI-generated code checklist

- [x] I have reviewed the diff
- [x] Tests/verification are described above and were run this session
- [x] No secrets, credentials, or internal-ops content in the diff

## bench-compare waiver

Waived: the diff is 4 lines of Cargo.toml packaging metadata (`package.exclude`). No source file, no compiled code path, and no build flags change; the produced binaries are byte-identical. `make bench-compare` would measure identical artifacts.
