### PR TITLE
docs: replace machine-local absolute paths with repo-relative references

### DIFF
--- a/docs/adr/ADR-015-embedding-cache.md
+++ b/docs/adr/ADR-015-embedding-cache.md
@@ -95,6 +95,6 @@ This avoids cross-shard contention on the counter updates — there is no shared
 
 ## References
 
-- [`crates/embed/src/cache.rs`](/Users/lion/projects/lattice/crates/embed/src/cache.rs) — full implementation
-- [`crates/embed/src/service/cached.rs`](/Users/lion/projects/lattice/crates/embed/src/service/cached.rs) — `CachedEmbeddingService` consumer
-- [`crates/embed/src/model.rs`](/Users/lion/projects/lattice/crates/embed/src/model.rs) — `ModelConfig::dimensions()` used for key construction
+- [`crates/embed/src/cache.rs`](../../crates/embed/src/cache.rs) — full implementation
+- [`crates/embed/src/service/cached.rs`](../../crates/embed/src/service/cached.rs) — `CachedEmbeddingService` consumer
+- [`crates/embed/src/model.rs`](../../crates/embed/src/model.rs) — `ModelConfig::dimensions()` used for key construction

--- a/docs/adr/ADR-016-model-variants.md
+++ b/docs/adr/ADR-016-model-variants.md
@@ -132,5 +132,5 @@ with the download URL.
 
 ## References
 
-- [`crates/embed/src/model.rs`](/Users/lion/projects/lattice/crates/embed/src/model.rs) — `EmbeddingModel`, `ModelConfig`, `ModelProvenance`
-- [`crates/embed/src/service/native.rs`](/Users/lion/projects/lattice/crates/embed/src/service/native.rs) — model loading, `qwen_model_dir`, `LATTICE_QWEN_MODEL_DIR`
+- [`crates/embed/src/model.rs`](../../crates/embed/src/model.rs) — `EmbeddingModel`, `ModelConfig`, `ModelProvenance`
+- [`crates/embed/src/service/native.rs`](../../crates/embed/src/service/native.rs) — model loading, `qwen_model_dir`, `LATTICE_QWEN_MODEL_DIR`

--- a/docs/adr/ADR-017-native-embedding-service.md
+++ b/docs/adr/ADR-017-native-embedding-service.md
@@ -118,6 +118,6 @@ multiplex through a higher-level router.
 
 ## References
 
-- [`crates/embed/src/service/native.rs`](/Users/lion/projects/lattice/crates/embed/src/service/native.rs) — full implementation
-- [`crates/embed/src/service/cached.rs`](/Users/lion/projects/lattice/crates/embed/src/service/cached.rs) — `CachedEmbeddingService` wrapper
-- [`crates/embed/src/service/mod.rs`](/Users/lion/projects/lattice/crates/embed/src/service/mod.rs) — `EmbeddingService` trait definition
+- [`crates/embed/src/service/native.rs`](../../crates/embed/src/service/native.rs) — full implementation
+- [`crates/embed/src/service/cached.rs`](../../crates/embed/src/service/cached.rs) — `CachedEmbeddingService` wrapper
+- [`crates/embed/src/service/mod.rs`](../../crates/embed/src/service/mod.rs) — `EmbeddingService` trait definition

--- a/docs/adr/ADR-018-quantized-vectors.md
+++ b/docs/adr/ADR-018-quantized-vectors.md
@@ -124,7 +124,7 @@ by eliminating two norm-squared accumulations and two square roots.
 
 ## References
 
-- [`crates/embed/src/simd/quantized.rs`](/Users/lion/projects/lattice/crates/embed/src/simd/quantized.rs) — INT8 implementation, NEON/AVX2/VNNI kernels
-- [`crates/embed/src/simd/int4.rs`](/Users/lion/projects/lattice/crates/embed/src/simd/int4.rs) — INT4 nibble packing
-- [`crates/embed/src/simd/binary.rs`](/Users/lion/projects/lattice/crates/embed/src/simd/binary.rs) — binary quantization, Hamming distance
-- [`crates/embed/src/simd/tier.rs`](/Users/lion/projects/lattice/crates/embed/src/simd/tier.rs) — `QuantizationTier`, `QuantizedData`, `PreparedQuery`, distance dispatch
+- [`crates/embed/src/simd/quantized.rs`](../../crates/embed/src/simd/quantized.rs) — INT8 implementation, NEON/AVX2/VNNI kernels
+- [`crates/embed/src/simd/int4.rs`](../../crates/embed/src/simd/int4.rs) — INT4 nibble packing
+- [`crates/embed/src/simd/binary.rs`](../../crates/embed/src/simd/binary.rs) — binary quantization, Hamming distance
+- [`crates/embed/src/simd/tier.rs`](../../crates/embed/src/simd/tier.rs) — `QuantizationTier`, `QuantizedData`, `PreparedQuery`, distance dispatch

--- a/docs/adr/ADR-019-backfill-pipeline.md
+++ b/docs/adr/ADR-019-backfill-pipeline.md
@@ -122,7 +122,7 @@ window resets on process restart — this is intentional and accepted.
 
 ## References
 
-- [`crates/embed/src/backfill/coordinator.rs`](/Users/lion/projects/lattice/crates/embed/src/backfill/coordinator.rs) — `BackfillCoordinator` implementation
-- [`crates/embed/src/backfill/types.rs`](/Users/lion/projects/lattice/crates/embed/src/backfill/types.rs) — `EmbeddingRoute`, `RoutingPhase`, `BackfillConfig`, `EmbeddingRoutingConfig`
-- [`crates/embed/src/migration/controller.rs`](/Users/lion/projects/lattice/crates/embed/src/migration/controller.rs) — `MigrationController` state machine
-- [`crates/embed/src/migration/types.rs`](/Users/lion/projects/lattice/crates/embed/src/migration/types.rs) — `MigrationPlan`, `MigrationProgress`, `MigrationState`
+- [`crates/embed/src/backfill/coordinator.rs`](../../crates/embed/src/backfill/coordinator.rs) — `BackfillCoordinator` implementation
+- [`crates/embed/src/backfill/types.rs`](../../crates/embed/src/backfill/types.rs) — `EmbeddingRoute`, `RoutingPhase`, `BackfillConfig`, `EmbeddingRoutingConfig`
+- [`crates/embed/src/migration/controller.rs`](../../crates/embed/src/migration/controller.rs) — `MigrationController` state machine
+- [`crates/embed/src/migration/types.rs`](../../crates/embed/src/migration/types.rs) — `MigrationPlan`, `MigrationProgress`, `MigrationState`

--- a/docs/adr/ADR-035-sinkhorn-solver.md
+++ b/docs/adr/ADR-035-sinkhorn-solver.md
@@ -119,6 +119,6 @@ whether to retry with more iterations or a larger epsilon.
 
 ## References
 
-- [`crates/transport/src/sinkhorn.rs`](/Users/lion/projects/lattice/crates/transport/src/sinkhorn.rs) — full solver implementation
-- [`crates/transport/src/logsumexp.rs`](/Users/lion/projects/lattice/crates/transport/src/logsumexp.rs) — `OnlineLogSumExp`, `safe_ln`, `safe_exp`, `logaddexp`
+- [`crates/transport/src/sinkhorn.rs`](../../crates/transport/src/sinkhorn.rs) — full solver implementation
+- [`crates/transport/src/logsumexp.rs`](../../crates/transport/src/logsumexp.rs) — `OnlineLogSumExp`, `safe_ln`, `safe_exp`, `logaddexp`
 - Cuturi, "Sinkhorn Distances: Lightspeed Computation of Optimal Transport", NeurIPS 2013

--- a/docs/adr/ADR-036-log-domain-stability.md
+++ b/docs/adr/ADR-036-log-domain-stability.md
@@ -157,7 +157,7 @@ carry over. This is a subtle API contract documented in the type.
 
 ## References
 
-- [`crates/transport/src/logsumexp.rs`](/Users/lion/projects/lattice/crates/transport/src/logsumexp.rs) — all numerical primitives
-- [`crates/transport/src/sinkhorn_log.rs`](/Users/lion/projects/lattice/crates/transport/src/sinkhorn_log.rs) — `LogDomainSinkhornSolver`, `EpsilonScalingSchedule`
-- [`crates/transport/src/sinkhorn.rs`](/Users/lion/projects/lattice/crates/transport/src/sinkhorn.rs) — base solver using these primitives
+- [`crates/transport/src/logsumexp.rs`](../../crates/transport/src/logsumexp.rs) — all numerical primitives
+- [`crates/transport/src/sinkhorn_log.rs`](../../crates/transport/src/sinkhorn_log.rs) — `LogDomainSinkhornSolver`, `EpsilonScalingSchedule`
+- [`crates/transport/src/sinkhorn.rs`](../../crates/transport/src/sinkhorn.rs) — base solver using these primitives
 - Schmitzer, "Stabilized Sparse Scaling Algorithms for Entropy Regularized Transport Problems", SIAM J. Sci. Comput. 2019

--- a/docs/adr/ADR-037-cost-matrices.md
+++ b/docs/adr/ADR-037-cost-matrices.md
@@ -123,5 +123,5 @@ Before building any cost matrix from point sets, `validate_point_set` checks: no
 
 ## References
 
-- [`crates/transport/src/cost.rs`](/Users/lion/projects/lattice/crates/transport/src/cost.rs) — all cost matrix types and metrics
-- [`crates/transport/src/divergence.rs`](/Users/lion/projects/lattice/crates/transport/src/divergence.rs) — 16 MB dense/lazy selection logic
+- [`crates/transport/src/cost.rs`](../../crates/transport/src/cost.rs) — all cost matrix types and metrics
+- [`crates/transport/src/divergence.rs`](../../crates/transport/src/divergence.rs) — 16 MB dense/lazy selection logic

--- a/docs/adr/ADR-038-barycenters.md
+++ b/docs/adr/ADR-038-barycenters.md
@@ -133,7 +133,7 @@ outer iteration (points move), so only owned data structures are appropriate.
 
 ## References
 
-- [`crates/transport/src/barycenter.rs`](/Users/lion/projects/lattice/crates/transport/src/barycenter.rs) — both barycenter algorithms
-- [`crates/transport/src/logsumexp.rs`](/Users/lion/projects/lattice/crates/transport/src/logsumexp.rs) — `OnlineLogSumExp`, `max_abs_diff`, `normalize_log_weights`
-- [`crates/transport/src/sinkhorn.rs`](/Users/lion/projects/lattice/crates/transport/src/sinkhorn.rs) — `SinkhornSolver` used as inner loop
+- [`crates/transport/src/barycenter.rs`](../../crates/transport/src/barycenter.rs) — both barycenter algorithms
+- [`crates/transport/src/logsumexp.rs`](../../crates/transport/src/logsumexp.rs) — `OnlineLogSumExp`, `max_abs_diff`, `normalize_log_weights`
+- [`crates/transport/src/sinkhorn.rs`](../../crates/transport/src/sinkhorn.rs) — `SinkhornSolver` used as inner loop
 - Cuturi & Doucet, "Fast Computation of Wasserstein Barycenters", ICML 2014

--- a/docs/adr/ADR-039-divergence-measures.md
+++ b/docs/adr/ADR-039-divergence-measures.md
@@ -138,7 +138,7 @@ important for debugging cases where one of the three solves failed to converge.
 
 ## References
 
-- [`crates/transport/src/divergence.rs`](/Users/lion/projects/lattice/crates/transport/src/divergence.rs) — full implementation
-- [`crates/transport/src/sinkhorn.rs`](/Users/lion/projects/lattice/crates/transport/src/sinkhorn.rs) — `SinkhornResult.regularized_cost` field
-- [`crates/transport/src/cost.rs`](/Users/lion/projects/lattice/crates/transport/src/cost.rs) — `DenseCostMatrix`, `PairwiseCostMatrix` used for selection
+- [`crates/transport/src/divergence.rs`](../../crates/transport/src/divergence.rs) — full implementation
+- [`crates/transport/src/sinkhorn.rs`](../../crates/transport/src/sinkhorn.rs) — `SinkhornResult.regularized_cost` field
+- [`crates/transport/src/cost.rs`](../../crates/transport/src/cost.rs) — `DenseCostMatrix`, `PairwiseCostMatrix` used for selection
 - Genevay, Peyré, Cuturi, "Learning Generative Models with Sinkhorn Divergences", AISTATS 2018

--- a/docs/q4-quantization.md
+++ b/docs/q4-quantization.md
@@ -56,15 +56,15 @@ A real run against the 0.8B checkpoint (which also carries a vision tower and an
 
 ```
 === quantize_q4: SafeTensors → Q4_0 ===
-Model dir:  /Users/lion/.lattice/models/qwen3.5-0.8b
-Output dir: /Users/lion/.lattice/models/qwen3.5-0.8b-q4
+Model dir:  ~/.lattice/models/qwen3.5-0.8b
+Output dir: ~/.lattice/models/qwen3.5-0.8b-q4
 Tensors:    488
 
   [1/488] F16   model.language_model.embed_tokens.weight  shape=[151936, 1024]  296.8MB  dtype=BF16  0.128s
   [2/488] Q4_0  model.language_model.layers.0.self_attn.q_proj.weight  shape=[4096, 1024]  8.0MB→2.5MB  0.02s
   ...
   [488/488] F16   mtp.pre_fc_norm_hidden.weight  shape=[1024]  0.0MB  dtype=BF16  0.000s
-Index written: /Users/lion/.lattice/models/qwen3.5-0.8b-q4/quantize_index.json
+Index written: ~/.lattice/models/qwen3.5-0.8b-q4/quantize_index.json
 
 === Summary ===
 Tensors processed: 488
@@ -164,8 +164,8 @@ Real output from that command:
 
 ```
 === quantize_quarot: QuaRot Q4_0 converter ===
-Model dir:   /Users/lion/.lattice/models/qwen3.5-0.8b
-Output dir:  /Users/lion/.lattice/models/qwen3.5-0.8b-q4-quarot
+Model dir:   ~/.lattice/models/qwen3.5-0.8b
+Output dir:  ~/.lattice/models/qwen3.5-0.8b-q4-quarot
 Seed:        0x0000000000c0ffee
 Tolerance:   0.00001
 Probe toks:  4

--- a/docs/serve-http-api.md
+++ b/docs/serve-http-api.md
@@ -54,7 +54,7 @@ model directory's basename (`qwen3.5-0.8b`, `qwen3.5-0.8b-q4-quarot`, etc.).
 Startup output:
 
 ```
-Loading model from /Users/lion/.lattice/models/qwen3.5-0.8b...
+Loading model from ~/.lattice/models/qwen3.5-0.8b...
 Model loaded. Serving as 'qwen3.5-0.8b'.
 Listening on 127.0.0.1:8080  (model: qwen3.5-0.8b, max_tokens default: 64)
   POST /v1/chat/completions


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Publication-hygiene sweep of `docs/`: `/Users/lion/...` absolute paths are both an internal-ops leak (dev-machine identity) and dead pointers on any machine but ours.

- `docs/adr/ADR-015/016/017/018/019/035/036/037/038/039`: source-file reference links converted from `/Users/lion/projects/lattice/crates/...` to repo-relative `../../crates/...` (each target verified to exist in-tree with `test -f`)
- `docs/serve-http-api.md`, `docs/q4-quantization.md`: illustrative CLI-output examples showing the model cache path converted from `/Users/lion/.lattice/models/...` to the documented runtime cache location `~/.lattice/models/...` (this is a real, documented runtime convention — not a dev-machine leak)

Full scan (`rg -in '/Users/|/Volumes/|/private/tmp|/tmp/' docs/`) also surfaced hits in `docs/cli-tools.md`, `docs/releases/v0.5.0.md`, and ADR-074/075/076/077 referencing `/tmp/lion-metal-gpu-test.lock` (a documented machine-wide GPU-serialization convention, see root `CLAUDE.md`) and one `CORPUS` env-var default (`/tmp/wikitext2_test.txt`) that matches the actual source default in `crates/inference/src/bin/ppl_metal.rs` — both left as-is; they are generic conventions, not machine-specific leaks.

No overlap with PR #890 (`docs/kg-reference-hygiene`, ADR-044..063).

## Test plan

- [x] Re-ran the identical `rg` scan after edits — residual hits are only the allowlisted `/tmp/lion-metal-gpu-test.lock` and `CORPUS` default lines
- [x] `test -f` verified all 19 converted relative crate-file links resolve to real files in-tree
- [x] `deno fmt` (doc-lint) passed clean on all changed files
- [x] Repo's pre-commit hook (build check + doc lint + capability-matrix check) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)