### PR TITLE
chore(embed): bump lru to 0.16 (RUSTSEC-2026-0002)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -23,13 +23,4 @@ ignore = [
     # tokenizers/wgpu-hal to migrate off it. No known vulnerability, purely
     # an unmaintained-status warning.
     "RUSTSEC-2024-0436",
-
-    # lru 0.12.5 — unsound `IterMut` (Stacked-Borrows violation). Direct
-    # dependency of crates/embed (Cargo.toml pins "0.12"). The fix landed at
-    # >=0.16.3, a semver-incompatible major bump (0.12 -> 0.16) that would
-    # require reviewing lattice-embed's lru usage for API breakage before
-    # taking it; deferred as a follow-up crate bump, not a drop-in `cargo
-    # update`. Tracked at #886. Verified 2026-07-11: `cargo update -p lru`
-    # resolves no newer 0.12.x release (0.12.5 is latest in-range).
-    "RUSTSEC-2026-0002",
 ]

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 
 # Caching
-lru = "0.12"
+lru = "0.16.3"
 blake3 = { workspace = true }
 parking_lot = { workspace = true }
 


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What changed

Bumps `lru` in `crates/embed` from `"0.12"` to `"0.16.3"` (resolves to `0.16.4`), fixing RUSTSEC-2026-0002 (unsound `IterMut`, Stacked Borrows violation). `Cargo.lock` is regenerated via `cargo update -p lru` (the workspace does not track `Cargo.lock` in git — it's gitignored — so no lockfile diff is part of this PR).

Also removes the `RUSTSEC-2026-0002` entry from `.cargo/audit.toml`'s ignore list, per the acceptance criteria in #886.

## API-migration notes per call site

`lru` is used in exactly one place in the workspace: `crates/embed/src/cache.rs` (`CacheShard`, backing `EmbeddingCache`'s sharded LRU eviction). Reviewed every method call against the 0.12 -> 0.16.3 changelog:

- `LruCache::new(capacity: NonZeroUsize)` — signature unchanged. Already using `NonZeroUsize` on the 0.12 pin, so no change needed at either shard-construction call site.
- `.get(&key)` — signature unchanged (`&mut self` on `LruCache`, called through `RwLock::write()`, unaffected by the lock type).
- `.put(key, value)` — signature unchanged.
- `.len()` / `.clear()` — signatures unchanged.
- `IterMut` — never used anywhere in this codebase, so the actual advisory (unsound `IterMut`) was never triggered here; the fix in 0.16.3 has no visible effect on lattice-embed's behavior either way.

No call-site changes were required. Confirmed via `docs.rs/lru/0.16.3` that the methods exercised here (`new`, `get`, `put`, `len`, `clear`) kept identical signatures across the 0.12 -> 0.16 line; the documented breaking changes in that range (0.14: `NonZeroUsize`-only capacity, already satisfied; 0.15: `promote`/`demote` now return `bool`) don't touch anything this crate calls.

## Gate results

- `cargo clippy --workspace -- -D warnings` — clean, zero warnings.
- `cargo test -p lattice-embed` — 19 unit tests + 3 tokenizer-parity integration tests + 20 doctests, all passing. Cache-specific coverage (`cache::tests::*`, including `test_cache_lru_eviction_within_shard`, `test_cache_eviction`, `test_cache_basic_operations`, `test_concurrent_access`) all green.
- `cargo audit` — clean at exit 0 with the `RUSTSEC-2026-0002` ignore entry removed (only the unrelated, still-justified `RUSTSEC-2024-0436` `paste` ignore remains).

## bench-compare

`crates/embed`'s bench suite (`benches/embeddings.rs`, `simd.rs`, `simd_bench.rs`, `simd_opt_bench.rs`, `simsimd_comparison.rs`) does not exercise `EmbeddingCache` or `cache.rs` at all — none of the benched groups reference the cache module, and the `lru` dependency bump is call-site-equivalent (identical signatures, same semantics, `IterMut` unused), so no change was expected on any benched group. Ran `make bench-compare` (quick mode, origin/main `d9f08e57c` vs HEAD `676271d2a`) against the `simd_dot_product` and `int8_raw` groups to get real numbers rather than rely on the waiver alone:

```
### `local-compare` — perf regression report

**❌ 1 FAIL** (regression >7.0% confirmed by 95% CI)
**⚠ 1 WARN** (regression 3.0-7.0% confirmed)
**🚀 9 confirmed improvement**

| Bench | Δ point | 95% CI | new ns | base ns | verdict |
|---|---:|---|---:|---:|---|
| `int8_raw_dot_product/dot_product_i8/128` | +25.35% | [+23.29%, +27.42%] | 6.3 | 5.1 | ❌ FAIL |
| `int8_raw_dot_product/dot_product_i8/384` | +4.43% | [+3.83%, +5.04%] | 10.8 | 10.3 | ⚠ WARN |
| `int8_raw_dot_product/dot_product_i8/768` | -3.12% | [-3.52%, -2.72%] | 17.2 | 17.8 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/127` | -4.94% | [-5.94%, -3.93%] | 6.8 | 7.2 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/768` | -5.89% | [-6.07%, -5.70%] | 15.7 | 16.7 | 🚀 WIN |
| `rms_norm/896` | -5.70% | [-6.68%, -4.70%] | 133.8 | 141.9 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/129` | -6.03% | [-8.07%, -3.90%] | 4.7 | 5.0 | 🚀 WIN |
| `residual_add_layer_norm/unfused/hidden768_seq128` | -5.98% | [-8.12%, -3.76%] | 90757.2 | 96525.8 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/384` | -8.02% | [-10.07%, -5.91%] | 8.8 | 9.6 | 🚀 WIN |
| `rms_norm/4096` | -8.75% | [-11.13%, -6.30%] | 571.0 | 625.8 | 🚀 WIN |
| `gelu/896` | -20.04% | [-21.53%, -18.53%] | 382.6 | 478.5 | 🚀 WIN |

**ℹ️ 8 informational** (below quick-mode resolution — lattice-embed SIMD micro-benches, tracked in #714; not gated here, re-run `--full` for a gated verdict)
| Bench | Δ point | 95% CI | new ns | base ns | (would-be verdict) |
|---|---:|---|---:|---:|---|
| `simd_dot_product/scalar/768` | -5.39% | [-5.72%, -5.05%] | 589.5 | 623.1 | 🚀 WIN (informational) |
| `simd_dot_product/simd/1024` | -6.50% | [-7.67%, -5.30%] | 77.3 | 82.7 | 🚀 WIN (informational) |
```

**Conclusion.** Two entries moved in the regression direction and are reported as measured, not suppressed: the FAIL `int8_raw_dot_product/dot_product_i8/128` (+25.35%, 5.1ns -> 6.3ns, sub-2ns absolute) and the WARN `int8_raw_dot_product/dot_product_i8/384` (+4.43%, with a wholly positive CI of [+3.83%, +5.04%]). No changed source is on either benched path — this crate's `lru` usage is confined to `cache.rs` cache operations while these benches call `simd::dot_product_i8` directly. One indirect mechanism is acknowledged rather than ruled out: the bump swaps `lru`'s transitive dependency (`hashbrown` 0.15 -> `foldhash` chain), which can perturb link layout enough to move a 5-10ns microbenchmark without any kernel change; that is not evidence of a kernel regression, but causality is unproven at quick-mode resolution. Quick-mode embed SIMD is classified visible-only (never gating) in `scripts/perf-policy.toml`, and quick-mode A/A instability on these targets is documented in `scripts/bench-compare.sh`; a full-mode or same-binary A/A rerun on `int8_raw_dot_product` is the discriminating follow-up if a stronger claim is ever needed. Every remaining group is an improvement or within CI overlap, consistent with the waiver reasoning that this change touches no benched hot path.

Closes #886

## AI-assisted change checklist

- [x] Full diff read end-to-end before committing (2 files, 11 lines).
- [x] Tests run locally: `cargo clippy --workspace -- -D warnings`, `cargo test -p lattice-embed`, `cargo audit`.
- [x] `make bench-compare` run and included above (origin/main vs HEAD).
- [x] No internal tooling references (no internal ops content, agent names, or workspace paths in the diff or this description).

