### PR TITLE
fix(bench): enforce declared abs+pct AND condition in memory gate math

### DIFF
--- a/scripts/bench_cpu_flagship_supervisor.py
+++ b/scripts/bench_cpu_flagship_supervisor.py
@@ -888,7 +888,20 @@ def build_decode_cell_aggregate(session: dict, policy: dict, rng_seed: int) -> t
         ci_low = _percentile(boot_means, 0.025) or point_estimate
         ci_high = _percentile(boot_means, 0.975) or point_estimate
         alpha_familywise = policy["gate_math"]["alpha_familywise"]
-        corrected_lower_bound = gate_math.bootstrap_upper_bound(
+        # bench-gate math audit finding #8: this previously called
+        # `bootstrap_upper_bound` (the wrong, two-sided-diagnostic UPPER
+        # tail) while assigning the result to `corrected_lower_bound` --
+        # exactly the wrong-tail mis-wiring round 1's original defect (see
+        # `bootstrap_lower_bound`'s docstring in bench_gate_math.py) warns
+        # against, and the same class of bug the rename to
+        # `_diagnostic_bootstrap_upper_bound` is meant to make harder to
+        # reproduce. This module is shadow-mode-only (PR 2's binding
+        # condition -- `verdict` here is downgraded to "unsupported" before
+        # any gated required cell consumes it), so no CI has ever gated on
+        # the wrong value, but the reported bound was still silently
+        # overstated (upper-tail > lower-tail). Fixed to the correct
+        # one-sided LOWER bound.
+        corrected_lower_bound = gate_math.bootstrap_lower_bound(
             log_slowdowns, order_ab_flags, b, random.Random(rng_seed + 1), corrected_alpha=alpha_familywise
         )
     else:

--- a/scripts/bench_cpu_flagship_supervisor.py
+++ b/scripts/bench_cpu_flagship_supervisor.py
@@ -66,6 +66,7 @@ import ctypes.util
 import hashlib
 import importlib.util
 import json
+import math
 import os
 import platform
 import random
@@ -895,12 +896,16 @@ def build_decode_cell_aggregate(session: dict, policy: dict, rng_seed: int) -> t
         # `bootstrap_lower_bound`'s docstring in bench_gate_math.py) warns
         # against, and the same class of bug the rename to
         # `_diagnostic_bootstrap_upper_bound` is meant to make harder to
-        # reproduce. This module is shadow-mode-only (PR 2's binding
-        # condition -- `verdict` here is downgraded to "unsupported" before
-        # any gated required cell consumes it), so no CI has ever gated on
-        # the wrong value, but the reported bound was still silently
-        # overstated (upper-tail > lower-tail). Fixed to the correct
-        # one-sided LOWER bound.
+        # reproduce. This module is shadow-mode-only: even a sufficiently-
+        # powered session (`gate_eligible` below) can reach a real
+        # FAIL/WARN/PASS verdict -- shadow-mode protection is NOT "verdict
+        # is always unsupported," it is that no CI workflow or Makefile
+        # target invokes this script (or `evaluate_family_gate`, per #877
+        # binding condition 1) as a blocking check yet, so nothing has ever
+        # gated a build on the wrong value. The reported bound was still
+        # silently overstated (upper-tail > lower-tail) for any human/agent
+        # reading the emitted report. Fixed to the correct one-sided LOWER
+        # bound.
         corrected_lower_bound = gate_math.bootstrap_lower_bound(
             log_slowdowns, order_ab_flags, b, random.Random(rng_seed + 1), corrected_alpha=alpha_familywise
         )
@@ -1008,6 +1013,57 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return p
 
 
+def decode_verdict(
+    aggregate: "harness.CellAggregate",
+    diagnostics: dict,
+    *,
+    fail_pct: float,
+    warn_pct: float,
+) -> tuple[str, str | None]:
+    """Pure PASS/WARN/FAIL/unsupported verdict for one `build_decode_cell_
+    aggregate` result, extracted out of `main()` (PR #898 review, round 1
+    finding #2) so the units-correct comparison is independently unit-
+    testable without spawning a real trial session.
+
+    `aggregate.corrected_lower_bound` and `aggregate.point_estimate` are
+    both LOG-space (`bootstrap_lower_bound`/`statistics.fmean` were fed
+    `log_slowdowns` in `build_decode_cell_aggregate`), but `fail_pct`/
+    `warn_pct` are RAW fractions straight off `perf-policy.toml` (e.g.
+    0.07 == "7%"). Comparing a log-space bound to a raw fraction directly
+    under-reports every verdict: `bench_gate_math.py`'s own evaluator
+    never makes this mistake (`tau_fail = math.log(1.0 + fail_pct *
+    margin)`, `evaluate_family_gate`), and this function converts the
+    same way -- `math.log1p(x)` is the same `log(1+x)` threshold, just
+    numerically preferred for small x. A bound sitting in `(log1p(0.07),
+    0.07]` (~(0.0677, 0.07]) is a genuine policy FAIL that a raw-fraction
+    comparison would silently report as WARN or PASS.
+
+    A session whose paired `n` is smaller than its own measured-CV-derived
+    `required_n` (`diagnostics["required_n"]`, `bench_gate_math.required_n`
+    correction 1) is downgraded to "unsupported" -- this is the ONLY case
+    this module ever reports "unsupported"; a sufficiently-powered session
+    (`gate_eligible` below) always reaches a real FAIL/WARN/PASS verdict
+    from the comparisons above, it is never unconditionally suppressed.
+    """
+    n_valid = diagnostics["n_pairs"]
+    required_n = diagnostics["required_n"]
+    measured_cv = diagnostics["measured_cv"]
+    tau_fail = math.log1p(fail_pct)
+    tau_warn = math.log1p(warn_pct)
+    gate_eligible = measured_cv is not None and required_n is not None and n_valid >= required_n
+    if not gate_eligible:
+        return "unsupported", (
+            f"n_valid={n_valid} < required_n={required_n} for measured_cv={measured_cv} "
+            "(bench_gate_math.required_n, correction 1) -- shadow/demonstration run, not a gated cell"
+        )
+    cb = aggregate.corrected_lower_bound
+    if cb is not None and cb > tau_fail:
+        return "FAIL", None
+    if aggregate.point_estimate > tau_warn:
+        return "WARN", None
+    return "PASS", None
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_arg_parser().parse_args(argv)
 
@@ -1079,27 +1135,11 @@ def main(argv: list[str] | None = None) -> int:
         }
     )
 
-    n_valid = diagnostics["n_pairs"]
-    required_n = diagnostics["required_n"]
-    measured_cv = diagnostics["measured_cv"]
     fail_pct = policy["families"]["decode"]["fail_pct"]
     warn_pct = policy["families"]["decode"]["warn_pct"]
-    gate_eligible = measured_cv is not None and required_n is not None and n_valid >= required_n
-    if not gate_eligible:
-        verdict = "unsupported"
-        unsupported_reason = (
-            f"n_valid={n_valid} < required_n={required_n} for measured_cv={measured_cv} "
-            "(bench_gate_math.required_n, correction 1) -- shadow/demonstration run, not a gated cell"
-        )
-    else:
-        cb = aggregate.corrected_lower_bound
-        if cb is not None and cb > fail_pct:
-            verdict = "FAIL"
-        elif aggregate.point_estimate > warn_pct:
-            verdict = "WARN"
-        else:
-            verdict = "PASS"
-        unsupported_reason = None
+    verdict, unsupported_reason = decode_verdict(
+        aggregate, diagnostics, fail_pct=fail_pct, warn_pct=warn_pct
+    )
 
     # #877's _validate_phase_sequence requires every non-"unsupported"
     # CellRecord to carry a real, correctly-ordered load_start->

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -179,7 +179,7 @@ def one_sided_bootstrap_pvalue(
     return _pvalue_from_boot_means(boot_means, tau_log, b)
 
 
-def bootstrap_upper_bound(
+def _diagnostic_bootstrap_upper_bound(
     values: Sequence[float],
     order_ab: Sequence[bool],
     b: int,
@@ -187,17 +187,27 @@ def bootstrap_upper_bound(
     *,
     corrected_alpha: float,
 ) -> float:
-    """The `(1 - corrected_alpha)` percentile of the bootstrap mean
-    distribution — a two-sided-diagnostic UPPER confidence bound, useful
-    for reporting/inspection only. This is NOT the bound the FAIL decision
-    consumes: `evaluate_family_gate`'s FAIL rule needs a one-sided LOWER
-    bound (a slowdown is positive and the claimed hypothesis is
-    `mean_slowdown > threshold`; confirming FAIL requires the LOWER bound
-    to itself exceed the threshold). Do not wire this function's result
-    into `CellAggregate.corrected_lower_bound` or any FAIL rule — use
-    `bootstrap_lower_bound` for that; an earlier revision of this module
-    conflated the two tails, which silently overstated regression
-    evidence.
+    """DIAGNOSTIC-ONLY. The `(1 - corrected_alpha)` percentile of the
+    bootstrap mean distribution — a two-sided-diagnostic UPPER confidence
+    bound, useful for reporting/inspection only. This is NOT the bound the
+    FAIL decision consumes: `evaluate_family_gate`'s FAIL rule needs a
+    one-sided LOWER bound (a slowdown is positive and the claimed
+    hypothesis is `mean_slowdown > threshold`; confirming FAIL requires the
+    LOWER bound to itself exceed the threshold).
+
+    NAMING IS THE GUARD (bench-gate math audit, finding #8): this function
+    used to be named `bootstrap_upper_bound`, public, with the same call
+    signature as `bootstrap_lower_bound` — a one-character-different name
+    that round 1's original defect (see `bootstrap_lower_bound`'s
+    docstring) and a live `bench_cpu_flagship_supervisor.py` call site
+    (fixed alongside this rename — it was assigning this function's result
+    to a variable literally named `corrected_lower_bound`) both independently
+    mis-wired into a FAIL/lower-bound role. The leading underscore plus the
+    `_DIAGNOSTIC` name are deliberate: this symbol must never look like a
+    drop-in replacement for `bootstrap_lower_bound` at a glance, and must
+    never be assigned to anything named `*lower_bound*` or wired into a FAIL
+    rule or `CellAggregate.corrected_lower_bound`. Use `bootstrap_lower_bound`
+    for that.
     """
     if not (0.0 < corrected_alpha < 1.0):
         raise GateMathError(f"corrected_alpha must be in (0, 1), got {corrected_alpha!r}")
@@ -236,8 +246,8 @@ def bootstrap_lower_bound(
     and corrected confidence bound cross its threshold"). A slowdown is
     positive and the claimed hypothesis is `mean_slowdown > threshold`; a
     confirmed FAIL needs a LOWER one-sided bound above the threshold, not
-    an upper one (`bootstrap_upper_bound` computes the wrong tail for this
-    purpose — see its docstring). The percentile-interval lower endpoint
+    an upper one (`_diagnostic_bootstrap_upper_bound` computes the wrong
+    tail for this purpose — see its docstring). The percentile-interval lower endpoint
     sits at the alpha percentile, not `1 - alpha`
     (https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=917303).
 
@@ -467,7 +477,13 @@ def resolve_metric_policy(policy_doc: dict, metric_family: str, metric_name: str
     Raises `PolicyConfigError` when the family or metric is not
     registered, or the resolved table has no valid `noise_class` -- an
     unregistered metric can never be assumed class A (the cheapest,
-    least-scrutinized band).
+    least-scrutinized band). Also validates that a table declaring
+    `fail_abs_mib` (the absolute-MiB AND-gate leg, e.g.
+    `families.memory.warm_peak_phys_footprint`) registers it as a positive
+    number -- structurally the same fail-closed treatment `parse_cv_bands`
+    gives every other numeric threshold field (bench-gate math audit
+    finding #2). `fail_abs_mib` is otherwise optional; its absence means
+    the metric has no absolute-floor leg at all.
     """
     families = policy_doc.get("families")
     if not isinstance(families, dict):
@@ -499,6 +515,13 @@ def resolve_metric_policy(policy_doc: dict, metric_family: str, metric_name: str
             f"perf-policy.toml: family {metric_family!r} metric {metric_name!r} has no valid "
             f"noise_class (must be one of {CELL_CLASSES}, got {noise_class!r})"
         )
+    if "fail_abs_mib" in table:
+        fail_abs_mib = table["fail_abs_mib"]
+        if isinstance(fail_abs_mib, bool) or not isinstance(fail_abs_mib, (int, float)) or fail_abs_mib <= 0:
+            raise PolicyConfigError(
+                f"perf-policy.toml: family {metric_family!r} metric {metric_name!r} declares "
+                f"fail_abs_mib={fail_abs_mib!r}, must be a positive number"
+            )
     return table
 
 
@@ -512,7 +535,23 @@ class CellGateInput:
     """One required cell's raw paired log-slowdown samples plus its
     registered family-policy thresholds (already resolved via
     `resolve_metric_policy`), the input `evaluate_family_gate` needs to
-    reach a PASS/WARN/FAIL verdict for that cell within its family."""
+    reach a PASS/WARN/FAIL verdict for that cell within its family.
+
+    `fail_abs_mib`/`abs_delta_mib` (bench-gate math audit finding #2):
+    some policy-registered metrics (e.g.
+    `families.memory.warm_peak_phys_footprint`) declare an explicit AND of
+    a relative threshold (`fail_pct`, evaluated via the paired log-slowdown
+    bootstrap below) and an absolute-MiB floor
+    (`perf-policy.toml`'s `fail_abs_mib`) -- "FAIL requires both >5% AND
+    >64 MiB." `values`/`order_ab` carry only the RELATIVE (log-ratio)
+    samples the bootstrap needs; they cannot express an absolute-MiB
+    delta, so a cell whose policy declares `fail_abs_mib` must also supply
+    the already-computed absolute delta (candidate-minus-base, in MiB) via
+    `abs_delta_mib`. Both default to `None` (no absolute-floor leg,
+    matching every family that does not declare one) -- `fail_abs_mib`
+    without a matching `abs_delta_mib` fails closed in
+    `evaluate_family_gate` rather than silently skipping the AND
+    condition."""
 
     cell_id: str
     values: tuple[float, ...]
@@ -521,6 +560,8 @@ class CellGateInput:
     cell_class: str  # "A" or "B" -- selects the cv_bands column
     warn_pct: float
     fail_pct: float
+    fail_abs_mib: float | None = None
+    abs_delta_mib: float | None = None
 
 
 @dataclass(frozen=True)
@@ -543,6 +584,8 @@ class CellGateResult:
     required_n: int
     fail_margin_multiplier: float
     verdict: str  # "PASS" | "WARN" | "FAIL"
+    fail_abs_mib: float | None = None
+    abs_delta_mib: float | None = None
 
 
 def evaluate_family_gate(
@@ -561,8 +604,11 @@ def evaluate_family_gate(
     required cells inflates the familywise false-FAIL rate to
     `1 - (1 - 0.05)**N`), and combines the Holm-reject decision with the
     corrected one-sided LOWER bound (`bootstrap_lower_bound`, never
-    `bootstrap_upper_bound` -- see that function's docstring) to reach a
-    verdict.
+    `_diagnostic_bootstrap_upper_bound` -- see that function's docstring)
+    to reach a verdict. FAIL additionally requires the cell's declared
+    absolute-delta floor (`fail_abs_mib`, when the policy registers one) to
+    clear, alongside the relative bound above -- see the `fail_abs_mib`/
+    `abs_delta_mib` handling below (bench-gate math audit finding #2).
 
     FAIL requires ALL of:
       - Holm rejects H0 for this cell at `alpha_familywise` across the
@@ -674,6 +720,23 @@ def evaluate_family_gate(
                 f"cell {cell.cell_id!r}: raw values contain a non-finite entry -- a malformed cell "
                 "fails closed before any resampling, never reaches a PASS/WARN/FAIL verdict"
             )
+        if cell.fail_abs_mib is not None:
+            if not math.isfinite(cell.fail_abs_mib) or cell.fail_abs_mib <= 0:
+                raise GateMathError(
+                    f"cell {cell.cell_id!r}: fail_abs_mib must be a positive finite number, "
+                    f"got {cell.fail_abs_mib!r}"
+                )
+            if cell.abs_delta_mib is None:
+                raise GateMathError(
+                    f"cell {cell.cell_id!r}: declares fail_abs_mib={cell.fail_abs_mib!r} (an AND-gate "
+                    "absolute-MiB floor) but supplies no abs_delta_mib -- fails closed rather than "
+                    "silently evaluating only the relative leg of a declared two-condition AND rule "
+                    "(bench-gate math audit finding #2)"
+                )
+            if not math.isfinite(cell.abs_delta_mib):
+                raise GateMathError(
+                    f"cell {cell.cell_id!r}: abs_delta_mib must be finite, got {cell.abs_delta_mib!r}"
+                )
         tau_fail = math.log(1.0 + cell.fail_pct * margin)
         point_estimate = statistics.fmean(cell.values)
         # ONE retained bootstrap-mean sample per cell -- both the p-value
@@ -717,7 +780,17 @@ def evaluate_family_gate(
                 sorted_boot_means, corrected_alpha=corrected_alpha
             )
         tau_warn = math.log(1.0 + cell.warn_pct)
-        if reject and lower_bound is not None and lower_bound > tau_fail:
+        # AND-gate (bench-gate math audit finding #2): a cell whose policy
+        # declares fail_abs_mib must ALSO clear the absolute-MiB floor to
+        # FAIL, matching perf-policy.toml's declared "FAIL requires both
+        # >X% AND >Y MiB" rule -- the relative bound crossing tau_fail is
+        # necessary but no longer sufficient when an absolute floor is
+        # registered. `abs_ok` is vacuously True when the cell's policy
+        # declares no absolute floor at all (fail_abs_mib is None).
+        abs_ok = cell.fail_abs_mib is None or (
+            cell.abs_delta_mib is not None and abs(cell.abs_delta_mib) > cell.fail_abs_mib
+        )
+        if reject and lower_bound is not None and lower_bound > tau_fail and abs_ok:
             verdict = "FAIL"
         elif point_estimate > tau_warn:
             verdict = "WARN"
@@ -734,6 +807,8 @@ def evaluate_family_gate(
                 required_n=req_n,
                 fail_margin_multiplier=margin,
                 verdict=verdict,
+                fail_abs_mib=cell.fail_abs_mib,
+                abs_delta_mib=cell.abs_delta_mib,
             )
         )
     return results

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -787,8 +787,19 @@ def evaluate_family_gate(
         # necessary but no longer sufficient when an absolute floor is
         # registered. `abs_ok` is vacuously True when the cell's policy
         # declares no absolute floor at all (fail_abs_mib is None).
+        #
+        # SIGNED comparison, deliberately no abs() (PR #898 review, round 1
+        # finding #1): `abs_delta_mib` is documented (CellGateInput's
+        # docstring) as `candidate - base`, positive meaning growth/worse.
+        # `fail_abs_mib` is validated positive-only by `resolve_metric_policy`.
+        # Absolute-valuing the delta would let a large IMPROVEMENT (a
+        # strongly negative delta, e.g. -70 MiB -- memory usage DROPPED 70
+        # MiB) satisfy `abs(delta) > floor` and clear the absolute leg of a
+        # rule whose entire purpose is gating on GROWTH -- a memory
+        # improvement must never contribute to a FAIL verdict. Only a
+        # signed delta that itself exceeds the positive floor counts.
         abs_ok = cell.fail_abs_mib is None or (
-            cell.abs_delta_mib is not None and abs(cell.abs_delta_mib) > cell.fail_abs_mib
+            cell.abs_delta_mib is not None and cell.abs_delta_mib > cell.fail_abs_mib
         )
         if reject and lower_bound is not None and lower_bound > tau_fail and abs_ok:
             verdict = "FAIL"

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -15,7 +15,10 @@ Usage:
 
 Exit codes:
   0 — pass (no gated FAILs)
-  1 — at least one gated FAIL (regression > 7% confirmed by 95% CI)
+  1 — at least one gated FAIL (regression > 7%, using the LOWER bound of
+      Criterion's two-sided 95% CI as a one-sided cutoff — see the
+      WARN_PCT/FAIL_PCT note below for the actual one-sided confidence
+      level this implies, which is tighter than "95%")
   2 — parse error / bad input
 
 --informational-groups-file (lattice#714): quick-mode Criterion runs on
@@ -40,6 +43,21 @@ from dataclasses import dataclass
 from pathlib import Path
 
 # Thresholds — ADR-058 §D3. Edit here; the workflow imports nothing else.
+#
+# Precision note (bench-gate math audit, finding #4): `ci_low`/`ci_high` are
+# Criterion's own TWO-SIDED 95% CI endpoints. Using `ci_low` as a one-sided
+# FAIL cutoff is directionally sound (a slowdown is a one-sided hypothesis,
+# and gating on the lower endpoint of a two-sided interval can only be MORE
+# conservative than a properly-computed one-sided 95% bound, never less —
+# assuming Criterion's CI is symmetric two-sided at 0.95, `ci_low` sits at
+# roughly a 97.5%-one-sided-confidence level, not 95%). This raises the bar
+# for FAIL (fewer true positives caught), never lowers it, so it cannot by
+# itself produce a false FAIL — but "regression >7% confirmed by 95% CI" in
+# this module's docstring/comments overstates precision and should be read
+# as "confirmed at approximately a 97.5% one-sided level via the two-sided
+# 95% CI's lower bound," not a calibrated one-sided-95% test. Verify against
+# the `criterion` crate's own CI-construction source before relying on the
+# exact number if it ever matters (not independently checked here).
 WARN_PCT = 3.0   # CI-lower above this => warning
 FAIL_PCT = 7.0   # CI-lower above this => FAIL
 CELEBRATE_PCT = -3.0  # point estimate below this AND CI-upper<0 => celebrate

--- a/tests/test_bench_cpu_flagship_supervisor.py
+++ b/tests/test_bench_cpu_flagship_supervisor.py
@@ -20,6 +20,7 @@ Run with: python3 -m pytest tests/test_bench_cpu_flagship_supervisor.py -v
 from __future__ import annotations
 
 import importlib.util
+import math
 import os
 import statistics
 import sys
@@ -672,6 +673,80 @@ class BuildDecodeCellAggregateTest(unittest.TestCase):
         session["arm_a"][0]["decode_tok_s"] = None
         with self.assertRaises(ValueError):
             supervisor.build_decode_cell_aggregate(session, self.policy, rng_seed=1)
+
+
+class DecodeVerdictTest(unittest.TestCase):
+    """PR #898 review, round 1 finding #2: `decode_verdict` must compare
+    `aggregate.corrected_lower_bound`/`aggregate.point_estimate` (both
+    LOG-space, since `build_decode_cell_aggregate` bootstraps
+    `log_slowdowns`) against LOG-space thresholds (`math.log1p(fail_pct)`/
+    `math.log1p(warn_pct)`), never the raw `perf-policy.toml` fractions
+    directly. These fixtures pin a concrete boundary window
+    `(log1p(x), x]` where a raw-fraction comparison and the correct
+    log-space comparison DISAGREE, so the fix is provably load-bearing
+    rather than a no-op relabeling -- not just "some value below 0.07",
+    but specifically a value the pre-fix comparison would have missed."""
+
+    def _agg(self, *, point_estimate, corrected_lower_bound, n_valid=7, required_n=7, measured_cv=0.01):
+        return harness.CellAggregate(
+            point_estimate=point_estimate,
+            ci_low=point_estimate,
+            ci_high=point_estimate,
+            corrected_lower_bound=corrected_lower_bound,
+            n_valid=n_valid,
+            n_invalid=0,
+            measured_cv=measured_cv,
+            required_n=required_n,
+        )
+
+    def test_bound_in_log1p_boundary_window_is_fail(self):
+        fail_pct = 0.07
+        tau_fail = math.log1p(fail_pct)
+        cb = (tau_fail + fail_pct) / 2.0  # strictly inside (tau_fail, fail_pct]
+        self.assertGreater(cb, tau_fail)
+        self.assertLessEqual(cb, fail_pct)
+        # Precondition proving this window actually disagrees with a raw-
+        # fraction comparison: cb does NOT clear the raw fail_pct itself,
+        # so the pre-fix `cb > fail_pct` comparison would have reported
+        # WARN/PASS here instead of the genuine policy FAIL.
+        self.assertFalse(cb > fail_pct)
+        aggregate = self._agg(point_estimate=0.01, corrected_lower_bound=cb)
+        diagnostics = {"n_pairs": 7, "required_n": 7, "measured_cv": 0.01}
+        verdict, reason = supervisor.decode_verdict(aggregate, diagnostics, fail_pct=fail_pct, warn_pct=0.03)
+        self.assertEqual(verdict, "FAIL")
+        self.assertIsNone(reason)
+
+    def test_point_estimate_in_log1p_boundary_window_is_warn(self):
+        warn_pct = 0.03
+        tau_warn = math.log1p(warn_pct)
+        pe = (tau_warn + warn_pct) / 2.0  # strictly inside (tau_warn, warn_pct]
+        self.assertGreater(pe, tau_warn)
+        self.assertLessEqual(pe, warn_pct)
+        self.assertFalse(pe > warn_pct)
+        aggregate = self._agg(point_estimate=pe, corrected_lower_bound=None)
+        diagnostics = {"n_pairs": 7, "required_n": 7, "measured_cv": 0.01}
+        verdict, reason = supervisor.decode_verdict(aggregate, diagnostics, fail_pct=0.07, warn_pct=warn_pct)
+        self.assertEqual(verdict, "WARN")
+        self.assertIsNone(reason)
+
+    def test_undersampled_session_reports_unsupported_regardless_of_bound(self):
+        aggregate = self._agg(point_estimate=10.0, corrected_lower_bound=10.0, n_valid=2, required_n=7)
+        diagnostics = {"n_pairs": 2, "required_n": 7, "measured_cv": 0.01}
+        verdict, reason = supervisor.decode_verdict(aggregate, diagnostics, fail_pct=0.07, warn_pct=0.03)
+        self.assertEqual(verdict, "unsupported")
+        self.assertIsNotNone(reason)
+
+    def test_gate_eligible_session_can_reach_a_real_verdict(self):
+        """Reconciliation check (PR #898 review, round 1 finding #2): a
+        sufficiently-powered session is NOT unconditionally downgraded to
+        'unsupported' -- it reaches a genuine PASS/WARN/FAIL verdict, so
+        the module docstring/comments must never claim shadow-mode safety
+        comes from an always-unsupported verdict."""
+        aggregate = self._agg(point_estimate=0.0, corrected_lower_bound=0.0)
+        diagnostics = {"n_pairs": 7, "required_n": 7, "measured_cv": 0.01}
+        verdict, reason = supervisor.decode_verdict(aggregate, diagnostics, fail_pct=0.07, warn_pct=0.03)
+        self.assertEqual(verdict, "PASS")
+        self.assertIsNone(reason)
 
 
 class ValidateRunRecordRoundTripTest(unittest.TestCase):

--- a/tests/test_bench_gate_math.py
+++ b/tests/test_bench_gate_math.py
@@ -887,6 +887,29 @@ class EvaluateFamilyGateTest(unittest.TestCase):
         results = gm.evaluate_family_gate([cell], self._bands(), bootstrap_replicates=2000, rng=random.Random(1))
         self.assertNotEqual(results[0].verdict, "FAIL")
 
+    def test_abs_mib_and_gate_large_negative_delta_never_fails(self):
+        """PR #898 review, round 1 finding #1: `abs_delta_mib` is a SIGNED
+        `candidate - base` (CellGateInput's own docstring), and
+        `fail_abs_mib` is a positive floor -- a large NEGATIVE delta means
+        memory usage DROPPED (an improvement), which must never contribute
+        to a FAIL verdict no matter how large its magnitude. Pre-fix, the
+        AND-gate wrapped the delta in `abs()`, so `abs_delta_mib=-70`
+        (memory improved by 70 MiB) satisfied `abs(-70) > 64` exactly like
+        a genuine 70 MiB regression would -- silently inverting the sign
+        contract. Same relative shape as `test_abs_mib_and_gate_crosses_both_is_fail`
+        (which confirms a POSITIVE 70 MiB delta over the same floor DOES
+        fail), but with the sign flipped: must NOT fail here."""
+        cell = self._memory_cell("memory:warm_peak", abs_delta_mib=-70.0)
+        results = gm.evaluate_family_gate([cell], self._bands(), bootstrap_replicates=2000, rng=random.Random(1))
+        result = results[0]
+        # Precondition: the relative leg alone still clears (same fixture
+        # shape as the crosses-both-is-fail test) -- this is a genuine
+        # AND-gate/sign test, not a case where the relative leg was
+        # already non-FAIL for an unrelated reason.
+        self.assertTrue(result.holm_reject)
+        self.assertIsNotNone(result.corrected_lower_bound)
+        self.assertNotEqual(result.verdict, "FAIL")
+
     def test_families_without_fail_abs_mib_are_unaffected(self):
         """A cell whose policy declares no absolute floor (fail_abs_mib
         defaults to None, matching every non-memory family) must reach

--- a/tests/test_bench_gate_math.py
+++ b/tests/test_bench_gate_math.py
@@ -120,19 +120,19 @@ class BootstrapMeanTest(unittest.TestCase):
         rng = random.Random(11)
         values = [0.1, 0.2, 0.15, 0.3, 0.05, 0.25, 0.18]
         order_ab = [True, False, True, False, True, False, True]
-        bound = gm.bootstrap_upper_bound(values, order_ab, 1000, rng, corrected_alpha=0.01)
+        bound = gm._diagnostic_bootstrap_upper_bound(values, order_ab, 1000, rng, corrected_alpha=0.01)
         self.assertGreaterEqual(bound, min(values) - 1e-6)
         self.assertLessEqual(bound, max(values) + 1e-6)
 
     def test_invalid_alpha_rejected(self):
         rng = random.Random(1)
         with self.assertRaises(gm.GateMathError):
-            gm.bootstrap_upper_bound([1.0], [True], 10, rng, corrected_alpha=1.5)
+            gm._diagnostic_bootstrap_upper_bound([1.0], [True], 10, rng, corrected_alpha=1.5)
 
 
 class BootstrapLowerBoundTest(unittest.TestCase):
     """The FAIL rule needs a one-sided LOWER bound, not
-    `bootstrap_upper_bound`'s `(1 - alpha)` upper tail. These fixtures
+    `_diagnostic_bootstrap_upper_bound`'s `(1 - alpha)` upper tail. These fixtures
     pin the orientation."""
 
     def test_near_null_lower_bound_at_or_below_threshold(self):
@@ -163,7 +163,7 @@ class BootstrapLowerBoundTest(unittest.TestCase):
         values = [0.1, 0.2, 0.15, 0.3, 0.05, 0.25, 0.18]
         order_ab = [True, False, True, False, True, False, True]
         lower = gm.bootstrap_lower_bound(values, order_ab, 1000, rng_lo, corrected_alpha=0.01)
-        upper = gm.bootstrap_upper_bound(values, order_ab, 1000, rng_hi, corrected_alpha=0.01)
+        upper = gm._diagnostic_bootstrap_upper_bound(values, order_ab, 1000, rng_hi, corrected_alpha=0.01)
         self.assertLessEqual(lower, upper)
 
     def test_invalid_alpha_rejected(self):
@@ -398,6 +398,27 @@ class ResolveMetricPolicyTest(unittest.TestCase):
         doc = gm.load_policy()
         table = gm.resolve_metric_policy(doc, "memory", "model_load_time")
         self.assertEqual(table["noise_class"], "C")
+
+    def test_memory_warm_peak_resolves_declared_fail_abs_mib(self):
+        # perf-policy.toml declares fail_abs_mib=64 for this metric --
+        # resolve_metric_policy must surface it unmodified so a caller can
+        # thread it into CellGateInput.fail_abs_mib (bench-gate math audit
+        # finding #2).
+        doc = gm.load_policy()
+        table = gm.resolve_metric_policy(doc, "memory", "warm_peak_phys_footprint")
+        self.assertEqual(table["fail_abs_mib"], 64)
+
+    def test_fail_abs_mib_must_be_positive_number(self):
+        doc = gm.load_policy()
+        doc["families"]["memory"]["warm_peak_phys_footprint"]["fail_abs_mib"] = -1
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.resolve_metric_policy(doc, "memory", "warm_peak_phys_footprint")
+
+    def test_fail_abs_mib_must_be_a_number_not_a_bool(self):
+        doc = gm.load_policy()
+        doc["families"]["memory"]["warm_peak_phys_footprint"]["fail_abs_mib"] = True
+        with self.assertRaises(gm.PolicyConfigError):
+            gm.resolve_metric_policy(doc, "memory", "warm_peak_phys_footprint")
 
 
 # --------------------------------------------------------------------------
@@ -800,6 +821,110 @@ class EvaluateFamilyGateTest(unittest.TestCase):
         cell = gm.CellGateInput(
             cell_id="bad", values=(1.0, 2.0), order_ab=(True,),
             measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        with self.assertRaises(gm.GateMathError):
+            gm.evaluate_family_gate([cell], self._bands())
+
+    # ----------------------------------------------------------------
+    # fail_abs_mib AND-gate (bench-gate math audit finding #2): the
+    # policy's own declared rule for
+    # `families.memory.warm_peak_phys_footprint` is "FAIL requires both
+    # >5% AND >64 MiB." Counterexample from the audit: base=1000 MiB,
+    # candidate=1055 MiB -> relative delta 5.5% (clears fail_pct=0.05)
+    # but absolute delta 55 MiB (does NOT clear fail_abs_mib=64) -- the
+    # evaluator must not FAIL this cell even though the relative leg
+    # alone would confirm a FAIL.
+    # ----------------------------------------------------------------
+
+    def _memory_cell(self, cid, *, abs_delta_mib, fail_abs_mib=64.0, n=9):
+        # class B (memory family's registered noise_class): first band
+        # (max_cv=0.015) requires n=9 for class B.
+        slowdown = math.log(1055.0 / 1000.0)
+        values = tuple([slowdown] * n)
+        order_ab = tuple(i % 2 == 0 for i in range(n))
+        return gm.CellGateInput(
+            cell_id=cid, values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="B", warn_pct=0.03, fail_pct=0.05,
+            fail_abs_mib=fail_abs_mib, abs_delta_mib=abs_delta_mib,
+        )
+
+    def test_abs_mib_and_gate_crosses_pct_not_mib_is_not_fail(self):
+        """The audit's exact counterexample: 5.5% clears fail_pct=0.05 and
+        (pre-fix) would have been a confirmed FAIL via the relative bound
+        alone -- but 55 MiB does not clear the declared fail_abs_mib=64
+        floor, so the AND-gated verdict must not be FAIL."""
+        cell = self._memory_cell("memory:warm_peak", abs_delta_mib=55.0)
+        results = gm.evaluate_family_gate([cell], self._bands(), bootstrap_replicates=2000, rng=random.Random(1))
+        result = results[0]
+        # Precondition: the relative leg alone WOULD have confirmed FAIL
+        # (Holm rejects and the lower bound clears tau_fail) -- proving
+        # this is a genuine AND-gate test, not a case where the relative
+        # leg was already non-FAIL for an unrelated reason.
+        self.assertTrue(result.holm_reject)
+        self.assertIsNotNone(result.corrected_lower_bound)
+        tau_fail = math.log(1.0 + 0.05 * 1.0)
+        self.assertGreater(result.corrected_lower_bound, tau_fail)
+        # But the AND-gated verdict is not FAIL -- the absolute leg (55
+        # MiB) does not clear the declared 64 MiB floor.
+        self.assertNotEqual(result.verdict, "FAIL")
+        self.assertEqual(result.verdict, "WARN")
+        self.assertEqual(result.fail_abs_mib, 64.0)
+        self.assertEqual(result.abs_delta_mib, 55.0)
+
+    def test_abs_mib_and_gate_crosses_both_is_fail(self):
+        """Same relative shape, but the absolute delta (70 MiB) clears
+        the declared 64 MiB floor too -- both legs of the AND now hold,
+        so the verdict is FAIL."""
+        cell = self._memory_cell("memory:warm_peak", abs_delta_mib=70.0)
+        results = gm.evaluate_family_gate([cell], self._bands(), bootstrap_replicates=2000, rng=random.Random(1))
+        self.assertEqual(results[0].verdict, "FAIL")
+
+    def test_abs_mib_and_gate_exactly_at_floor_is_not_fail(self):
+        """`fail_abs_mib` is a strict '>' floor (perf-policy.toml: 'FAIL
+        requires both >5% AND >64 MiB') -- exactly 64 MiB does not clear
+        it."""
+        cell = self._memory_cell("memory:warm_peak", abs_delta_mib=64.0)
+        results = gm.evaluate_family_gate([cell], self._bands(), bootstrap_replicates=2000, rng=random.Random(1))
+        self.assertNotEqual(results[0].verdict, "FAIL")
+
+    def test_families_without_fail_abs_mib_are_unaffected(self):
+        """A cell whose policy declares no absolute floor (fail_abs_mib
+        defaults to None, matching every non-memory family) must reach
+        FAIL on the relative bound alone -- the AND-gate must be a no-op
+        when the policy registers no absolute leg."""
+        order_ab = (True, False, True, False, True, False, True)
+        values = tuple([math.log(1.10)] * 7)
+        cell = gm.CellGateInput(
+            cell_id="decode:strong", values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+        )
+        self.assertIsNone(cell.fail_abs_mib)
+        self.assertIsNone(cell.abs_delta_mib)
+        results = gm.evaluate_family_gate([cell], self._bands(), bootstrap_replicates=500, rng=random.Random(1))
+        self.assertEqual(results[0].verdict, "FAIL")
+
+    def test_fail_abs_mib_without_abs_delta_mib_fails_closed(self):
+        """A cell that declares fail_abs_mib (an AND-gate floor) but
+        supplies no abs_delta_mib must fail closed rather than silently
+        evaluating only the relative leg of a declared two-condition AND
+        rule."""
+        order_ab = (True, False, True, False, True, False, True)
+        values = tuple([math.log(1.10)] * 7)
+        cell = gm.CellGateInput(
+            cell_id="decode:strong", values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+            fail_abs_mib=64.0, abs_delta_mib=None,
+        )
+        with self.assertRaisesRegex(gm.GateMathError, "fail_abs_mib"):
+            gm.evaluate_family_gate([cell], self._bands())
+
+    def test_fail_abs_mib_must_be_positive(self):
+        order_ab = (True, False, True, False, True, False, True)
+        values = tuple([math.log(1.10)] * 7)
+        cell = gm.CellGateInput(
+            cell_id="decode:strong", values=values, order_ab=order_ab,
+            measured_cv=0.01, cell_class="A", warn_pct=0.03, fail_pct=0.07,
+            fail_abs_mib=-1.0, abs_delta_mib=5.0,
         )
         with self.assertRaises(gm.GateMathError):
             gm.evaluate_family_gate([cell], self._bands())


### PR DESCRIPTION
_PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Three math/shape corrections to the (not-yet-CI-wired) bench-gate schema-v2 evaluator and the live ADR-058 CPU-bench gate. Scripts-only diff; no CI wiring in this PR — `evaluate_family_gate` still has no production caller (`bench_decode_harness.py`'s per-family verdict aggregator that would wire it is separate, later work).

### Finding #2 — memory absolute-MiB AND-gate (the substantive fix)

`perf-policy.toml` declares `families.memory.warm_peak_phys_footprint` as an AND of a relative and an absolute threshold:

```toml
[families.memory.warm_peak_phys_footprint]
warn_pct = 0.03
fail_abs_mib = 64
fail_pct = 0.05
other_rule = "FAIL requires both >5% AND >64 MiB. ..."
```

but `CellGateInput`/`evaluate_family_gate` in `scripts/bench_gate_math.py` only implemented the relative leg (`fail_pct`) — `fail_abs_mib` was never read anywhere outside the TOML file.

**Counterexample reproduced**: base `warm_peak_phys_footprint` = 1000 MiB, candidate = 1055 MiB.
- Absolute delta = 55 MiB — does **not** clear the declared 64 MiB floor.
- Relative delta = 5.5% — clears the 5% `fail_pct`.

Before the fix, a cell with this shape (fed as a deterministic 7/9-pair paired log-slowdown of `log(1055/1000)`) reaches `FAIL` via the relative bound alone, contradicting the policy's own written "requires both" rule. This is currently latent — the memory family is not yet a gated required cell — but would silently ship a wrong verdict the day it becomes one.

**Fix**: added `fail_abs_mib: float | None` and `abs_delta_mib: float | None` to `CellGateInput` (both default `None`, so every family without a declared absolute floor is unaffected). `evaluate_family_gate`'s FAIL rule now additionally requires `abs_delta_mib` to exceed `fail_abs_mib` when the cell declares one. A cell that sets `fail_abs_mib` without supplying `abs_delta_mib` fails closed (`GateMathError`) rather than silently evaluating only the relative leg. `resolve_metric_policy` now structurally validates that a declared `fail_abs_mib` is a positive number, matching the fail-closed treatment every other policy-numeric field already gets.

While updating this module, also fixed a **live** bug in `bench_cpu_flagship_supervisor.py` (the shadow-mode-only PR-2 supervisor): it was calling `bootstrap_upper_bound` — the wrong, two-sided-diagnostic UPPER tail — and assigning the result to a variable literally named `corrected_lower_bound`. This is exactly the wrong-tail mis-wiring class round 1's original defect (documented in `bootstrap_lower_bound`'s docstring) and finding #8 (below) warn about, caught by grepping for callers of the renamed function before landing the rename. Shadow-mode-only, so nothing was ever gated on the wrong value, but the reported bound was silently overstated. Fixed to call `bootstrap_lower_bound`.

### Finding #4 — ADR-058 gate docstring precision (comment-only)

`scripts/perf-bench-gate.py`'s `verdict()` uses Criterion's two-sided 95% CI lower bound as a one-sided FAIL cutoff. This is directionally sound — it can only be *more* conservative than a properly-computed one-sided 95% bound, never less, so it cannot itself produce a false FAIL — but the module's docstring/exit-code comment ("regression > 7% confirmed by 95% CI") overstates precision: using a two-sided-CI lower percentile as a one-sided cutoff is closer to a ~97.5%-one-sided-confidence bound, not a calibrated one-sided 95% bound. Corrected the docstring and added a precision note next to `WARN_PCT`/`FAIL_PCT`. No logic change.

### Finding #8 — guard against re-wiring the wrong-tail bootstrap function

`bootstrap_upper_bound` was public, same call signature as `bootstrap_lower_bound`, with only a docstring warning against wiring it into a FAIL rule. Renamed to `_diagnostic_bootstrap_upper_bound` (non-public, name signals diagnostic-only) so a future caller can't reproduce round 1's original defect by a one-character-different-name mistake at a glance. Updated all references (docstrings, tests) and the one production call site found via `grep` (`bench_cpu_flagship_supervisor.py`, described above).

## Mutation-sensitivity proof (finding #2's AND-gate)

Per Π_TBV, the new AND-gate tests were verified to actually exercise the fix, not just pass vacuously:

1. Applied the fix and wrote 3 new tests exercising the AND-gate (`test_abs_mib_and_gate_crosses_pct_not_mib_is_not_fail`, `test_abs_mib_and_gate_crosses_both_is_fail`, `test_abs_mib_and_gate_exactly_at_floor_is_not_fail`).
2. Reverse-applied the fix (removed the `abs_ok` condition from the FAIL rule, restoring the pre-fix relative-only check) and re-ran just those 3 tests: **2 of 3 failed** (`crosses_pct_not_mib_is_not_fail` and `exactly_at_floor_is_not_fail` both incorrectly reported `FAIL`), reproducing the audit's counterexample exactly.
3. Restored the fix; all 3 tests pass again.

## Docstring + visibility corrections

- `scripts/perf-bench-gate.py`: exit-code doc + `WARN_PCT`/`FAIL_PCT` comment corrected to state the actual one-sided confidence level implied by using a two-sided CI's lower bound.
- `scripts/bench_gate_math.py`: `bootstrap_upper_bound` → `_diagnostic_bootstrap_upper_bound` (module-private), docstring rewritten to explain the naming-as-guard rationale; cross-references in `bootstrap_lower_bound` and `evaluate_family_gate`'s docstrings updated.

## Test results

```
uv run python3 -m pytest tests/test_bench_gate_math.py tests/test_bench_cpu_flagship_supervisor.py tests/test_bench_decode_harness.py -q
220 passed, 1 warning in 3.16s
```

15 new tests added to `tests/test_bench_gate_math.py` covering: the AND-gate FAIL/non-FAIL boundary (including the audit's exact counterexample), the "no absolute floor declared" no-op case, fail-closed validation when `fail_abs_mib` is set without `abs_delta_mib`, `resolve_metric_policy`'s structural check on `fail_abs_mib`, and the renamed diagnostic function's existing coverage carried forward.

**Scripts-only diff; no CI wiring in this PR** — no Rust changes, so `make bench-compare`/clippy do not apply here.

## AI-assisted change checklist

- [x] Read the referenced audit and independently re-verified each finding against the current source before writing any fix (confirmed the finding #2 counterexample by tracing `CellGateInput`/`evaluate_family_gate`/`resolve_metric_policy`; confirmed finding #4 is directional-not-magnitude by re-deriving the one-sided-vs-two-sided relationship; confirmed finding #8's risk was already live by grepping every caller of `bootstrap_upper_bound`).
- [x] Added regression tests for every behavioral change; proved the AND-gate test is mutation-sensitive by reverse-applying the fix and observing the expected test failures, then restoring it.
- [x] Ran the full relevant local test suite (`test_bench_gate_math.py`, `test_bench_cpu_flagship_supervisor.py`, `test_bench_decode_harness.py`) — 220/220 passing.
- [x] No CI workflow files touched; this PR is intentionally scoped to math/shape corrections only, per the audit's own phased fix plan.
