### PR TITLE
feat(embed): wasm32 SIMD128 kernels for dot/L2/cosine/normalize

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -75,7 +75,7 @@ jobs:
           # still triggers wasm-parity. Without them, engine stays false and the
           # required parity-gate could pass green without the wasm path ever
           # running, a fail-open on the gate itself.
-          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/e2e_parity_check\.py$|^\.github/workflows/e2e-parity\.yml$|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$|^scripts/ppl_gate_check\.py$|^crates/inference/tests/fixtures/ppl_gate_v1/|^crates/inference/src/bin/eval_perplexity\.rs$|^crates/inference/src/bin/quantize_q4\.rs$|^docs/bench_results/wiki\.test\.raw$' <<<"$CHANGED" >/dev/null; then
+          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/e2e_parity_check\.py$|^\.github/workflows/e2e-parity\.yml$|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^scripts/wasm-simd128-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$|^scripts/ppl_gate_check\.py$|^crates/inference/tests/fixtures/ppl_gate_v1/|^crates/inference/src/bin/eval_perplexity\.rs$|^crates/inference/src/bin/quantize_q4\.rs$|^docs/bench_results/wiki\.test\.raw$' <<<"$CHANGED" >/dev/null; then
             echo "engine=true" >> "$GITHUB_OUTPUT"
             echo "→ engine surface changed: parity REQUIRED"
           else
@@ -402,6 +402,60 @@ jobs:
           LATTICE_WASM_PARITY_ENFORCE: '1'
         run: ./scripts/wasm-parity.sh
 
+  # wasm32 SIMD128 kernel dispatch-parity gate. Proves the wasm32 SIMD128
+  # dot/L2/cosine/normalize kernels (crates/embed/src/simd/*.rs) agree with
+  # the scalar reference by building `lattice-embed` for wasm32 twice (plain
+  # vs `-C target-feature=+simd128`) and comparing both against a JS scalar
+  # oracle, plus a dispatch-state assertion proving each build actually
+  # dispatched to the kernel tier it claims to. No model weights needed here
+  # (pure vector-op kernels, not the BERT forward pass), so provisioning is
+  # the same rust/wasm-bindgen setup as wasm-parity above minus the model
+  # caching steps. See scripts/wasm-simd128-parity.sh for the local driver
+  # and crates/embed/tests/wasm/simd128_parity_wasm.mjs for the harness.
+  wasm-simd128-parity:
+    name: wasm SIMD128 kernel parity gate
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm-simd128-parity
+
+      - name: Cache wasm-bindgen-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-bindgen
+          key: wasm-bindgen-cli-0.2.105-${{ runner.os }}
+
+      # Pinned exactly to match the `wasm-bindgen` crate dependency version in
+      # crates/embed/Cargo.toml (the CLI and crate embed a schema version that
+      # must match exactly). Skips the (slow) reinstall if the cached binary
+      # is already the right version.
+      - name: Install wasm-bindgen-cli
+        run: |
+          if command -v wasm-bindgen >/dev/null 2>&1 && [ "$(wasm-bindgen --version)" = "wasm-bindgen 0.2.105" ]; then
+            echo "wasm-bindgen 0.2.105 already present (cache hit)"
+          else
+            cargo install wasm-bindgen-cli --version 0.2.105
+          fi
+
+      - name: Run wasm SIMD128 parity gate
+        # LATTICE_WASM_SIMD128_ENFORCE=1 makes the driver fail closed if any
+        # prerequisite (node, wasm-bindgen, cargo, or the wasm32 target) is
+        # still missing at this point: a provisioning failure must not
+        # masquerade as a skipped, green job.
+        env:
+          LATTICE_WASM_SIMD128_ENFORCE: '1'
+        run: ./scripts/wasm-simd128-parity.sh
+
   # Composed rotated(QuaRot)+Q4 forward-path gate (issue #320). The converter's
   # own f64 forward-equivalence check (quant/quarot/forward_equivalence.rs) gates
   # the rotation-fusion math PRE-quantization; nothing previously exercised the
@@ -640,14 +694,24 @@ jobs:
 
   # REQUIRED status check. Always runs, always reports. Passes when the engine
   # did not change (nothing to verify); mirrors the parity, embed-drift,
-  # wasm-parity, q4-composed, ppl-gate-selftest, and q4-ppl-quality verdicts when
-  # it did. Fails closed if change-detection itself errored. metal-parity is
-  # deliberately excluded (informational — see its comment above). q4-ppl-quality
-  # is now armed (golden captured on run 28841919096) and gates the shipping Q4
-  # tier for regressions.
+  # wasm-parity, wasm-simd128-parity, q4-composed, ppl-gate-selftest, and
+  # q4-ppl-quality verdicts when it did. Fails closed if change-detection
+  # itself errored. metal-parity is deliberately excluded (informational — see
+  # its comment above). q4-ppl-quality is now armed (golden captured on run
+  # 28841919096) and gates the shipping Q4 tier for regressions.
   parity-gate:
     name: parity-gate
-    needs: [changes, parity, embed-drift, wasm-parity, q4-composed, ppl-gate-selftest, q4-ppl-quality]
+    needs:
+      [
+        changes,
+        parity,
+        embed-drift,
+        wasm-parity,
+        wasm-simd128-parity,
+        q4-composed,
+        ppl-gate-selftest,
+        q4-ppl-quality,
+      ]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -658,10 +722,11 @@ jobs:
           PARITY_RESULT="${{ needs.parity.result }}"
           DRIFT_RESULT="${{ needs.embed-drift.result }}"
           WASM_RESULT="${{ needs.wasm-parity.result }}"
+          WASM_SIMD128_RESULT="${{ needs.wasm-simd128-parity.result }}"
           Q4_RESULT="${{ needs.q4-composed.result }}"
           PPL_SELFTEST_RESULT="${{ needs.ppl-gate-selftest.result }}"
           Q4PPL_RESULT="${{ needs.q4-ppl-quality.result }}"
-          echo "changes=$CHANGES_RESULT engine=$ENGINE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT q4-composed=$Q4_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT q4-ppl-quality=$Q4PPL_RESULT"
+          echo "changes=$CHANGES_RESULT engine=$ENGINE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT wasm-simd128-parity=$WASM_SIMD128_RESULT q4-composed=$Q4_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT q4-ppl-quality=$Q4PPL_RESULT"
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::change-detection did not succeed — failing closed."
             exit 1
@@ -682,6 +747,10 @@ jobs:
             echo "::error::Engine changed and wasm-parity gate did not succeed (result=$WASM_RESULT)."
             exit 1
           fi
+          if [ "$WASM_SIMD128_RESULT" != "success" ]; then
+            echo "::error::Engine changed and wasm-simd128-parity gate did not succeed (result=$WASM_SIMD128_RESULT)."
+            exit 1
+          fi
           if [ "$Q4_RESULT" != "success" ]; then
             echo "::error::Engine changed and q4-composed golden did not succeed (result=$Q4_RESULT)."
             exit 1
@@ -694,5 +763,5 @@ jobs:
             echo "::error::Engine changed and q4-ppl-quality regression gate did not succeed (result=$Q4PPL_RESULT)."
             exit 1
           fi
-          echo "Engine changed; parity, embed-drift, wasm-parity, q4-composed, ppl-gate-selftest, and q4-ppl-quality all PASSED."
+          echo "Engine changed; parity, embed-drift, wasm-parity, wasm-simd128-parity, q4-composed, ppl-gate-selftest, and q4-ppl-quality all PASSED."
           exit 0

--- a/crates/embed/src/simd/cosine.rs
+++ b/crates/embed/src/simd/cosine.rs
@@ -6,6 +6,9 @@ use std::arch::x86_64::*;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+use std::arch::wasm32::*;
+
 use std::sync::OnceLock;
 
 use super::simd_config;
@@ -15,6 +18,9 @@ use super::dot_product::{horizontal_sum_avx2, horizontal_sum_avx512};
 
 #[cfg(target_arch = "aarch64")]
 use super::dot_product::horizontal_sum_neon;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+use super::dot_product::horizontal_sum_simd128;
 
 type CosineKernel = fn(&[f32], &[f32]) -> f32;
 static COSINE_KERNEL: OnceLock<CosineKernel> = OnceLock::new();
@@ -44,6 +50,13 @@ fn resolve_cosine_kernel() -> CosineKernel {
         }
     }
 
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        if config.simd128_enabled {
+            return cosine_simd128_kernel;
+        }
+    }
+
     cosine_similarity_scalar
 }
 
@@ -66,6 +79,14 @@ fn cosine_avx2_kernel(a: &[f32], b: &[f32]) -> f32 {
 fn cosine_neon_kernel(a: &[f32], b: &[f32]) -> f32 {
     // SAFETY: only stored in COSINE_KERNEL when neon was detected at init time (always true on aarch64).
     unsafe { cosine_similarity_neon_unrolled(a, b) }
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+fn cosine_simd128_kernel(a: &[f32], b: &[f32]) -> f32 {
+    // SAFETY: only stored in COSINE_KERNEL when compiled with the wasm32
+    // `simd128` target feature (compile-time gate, see `SimdConfig::simd128_enabled`).
+    unsafe { cosine_similarity_simd128_unrolled(a, b) }
 }
 
 /// Cosine similarity over equal-length, non-empty `f32` slices.
@@ -400,6 +421,109 @@ unsafe fn cosine_similarity_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut dot = horizontal_sum_neon(dot_vec);
     let mut norm_a = horizontal_sum_neon(na_vec);
     let mut norm_b = horizontal_sum_neon(nb_vec);
+
+    // Handle remainder
+    let remainder_start = chunks * CHUNK_SIZE;
+    for i in remainder_start..n {
+        let av = a[i];
+        let bv = b[i];
+        dot += av * bv;
+        norm_a += av * av;
+        norm_b += bv * bv;
+    }
+
+    norm_a = norm_a.sqrt();
+    norm_b = norm_b.sqrt();
+
+    if norm_a == 0.0 || norm_b == 0.0 {
+        0.0
+    } else {
+        dot / (norm_a * norm_b)
+    }
+}
+
+/// wasm32 SIMD128-accelerated cosine similarity with 4x unrolling.
+///
+/// Computes dot(a,b) / (|a| * |b|) in a single pass with 4 accumulators each,
+/// mirroring the NEON kernel above. See `dot_product::dot_product_simd128_unrolled`
+/// for the reassociation caveat (not bit-identical to the scalar path) and the
+/// wasm safety notes (no runtime feature detection, alignment-free loads).
+///
+/// # Safety
+///
+/// Caller must ensure:
+/// - Compiled with the wasm32 `simd128` target feature (compile-time
+///   precondition; this function only exists under `#[cfg(target_feature =
+///   "simd128")]`)
+/// - `a` and `b` have equal, non-zero length (checked by caller)
+///
+/// Memory safety:
+/// - Uses `v128_load` for loads (wasm loads are alignment-free by spec)
+/// - Pointer arithmetic stays within slice bounds via chunk calculation
+/// - Remainder loop uses safe indexing
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+unsafe fn cosine_similarity_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
+    const SIMD_WIDTH: usize = 4;
+    const UNROLL: usize = 4;
+    const CHUNK_SIZE: usize = SIMD_WIDTH * UNROLL;
+    let n = a.len();
+    debug_assert_eq!(n, b.len());
+    debug_assert!(n > 0);
+    let chunks = n / CHUNK_SIZE;
+
+    // 4 accumulators for each of 3 sums (dot, norm_a, norm_b)
+    let mut dot0 = f32x4_splat(0.0);
+    let mut dot1 = f32x4_splat(0.0);
+    let mut dot2 = f32x4_splat(0.0);
+    let mut dot3 = f32x4_splat(0.0);
+
+    let mut na0 = f32x4_splat(0.0);
+    let mut na1 = f32x4_splat(0.0);
+    let mut na2 = f32x4_splat(0.0);
+    let mut na3 = f32x4_splat(0.0);
+
+    let mut nb0 = f32x4_splat(0.0);
+    let mut nb1 = f32x4_splat(0.0);
+    let mut nb2 = f32x4_splat(0.0);
+    let mut nb3 = f32x4_splat(0.0);
+
+    for i in 0..chunks {
+        let base = i * CHUNK_SIZE;
+
+        let a0 = v128_load(a.as_ptr().add(base) as *const v128);
+        let b0 = v128_load(b.as_ptr().add(base) as *const v128);
+        dot0 = f32x4_add(dot0, f32x4_mul(a0, b0));
+        na0 = f32x4_add(na0, f32x4_mul(a0, a0));
+        nb0 = f32x4_add(nb0, f32x4_mul(b0, b0));
+
+        let a1 = v128_load(a.as_ptr().add(base + SIMD_WIDTH) as *const v128);
+        let b1 = v128_load(b.as_ptr().add(base + SIMD_WIDTH) as *const v128);
+        dot1 = f32x4_add(dot1, f32x4_mul(a1, b1));
+        na1 = f32x4_add(na1, f32x4_mul(a1, a1));
+        nb1 = f32x4_add(nb1, f32x4_mul(b1, b1));
+
+        let a2 = v128_load(a.as_ptr().add(base + SIMD_WIDTH * 2) as *const v128);
+        let b2 = v128_load(b.as_ptr().add(base + SIMD_WIDTH * 2) as *const v128);
+        dot2 = f32x4_add(dot2, f32x4_mul(a2, b2));
+        na2 = f32x4_add(na2, f32x4_mul(a2, a2));
+        nb2 = f32x4_add(nb2, f32x4_mul(b2, b2));
+
+        let a3 = v128_load(a.as_ptr().add(base + SIMD_WIDTH * 3) as *const v128);
+        let b3 = v128_load(b.as_ptr().add(base + SIMD_WIDTH * 3) as *const v128);
+        dot3 = f32x4_add(dot3, f32x4_mul(a3, b3));
+        na3 = f32x4_add(na3, f32x4_mul(a3, a3));
+        nb3 = f32x4_add(nb3, f32x4_mul(b3, b3));
+    }
+
+    // Combine accumulators
+    let dot_vec = f32x4_add(f32x4_add(dot0, dot1), f32x4_add(dot2, dot3));
+    let na_vec = f32x4_add(f32x4_add(na0, na1), f32x4_add(na2, na3));
+    let nb_vec = f32x4_add(f32x4_add(nb0, nb1), f32x4_add(nb2, nb3));
+
+    let mut dot = horizontal_sum_simd128(dot_vec);
+    let mut norm_a = horizontal_sum_simd128(na_vec);
+    let mut norm_b = horizontal_sum_simd128(nb_vec);
 
     // Handle remainder
     let remainder_start = chunks * CHUNK_SIZE;

--- a/crates/embed/src/simd/cosine.rs
+++ b/crates/embed/src/simd/cosine.rs
@@ -52,7 +52,7 @@ fn resolve_cosine_kernel() -> CosineKernel {
 
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     {
-        if config.simd128_enabled {
+        if config.simd128_enabled() {
             return cosine_simd128_kernel;
         }
     }

--- a/crates/embed/src/simd/distance.rs
+++ b/crates/embed/src/simd/distance.rs
@@ -6,6 +6,9 @@ use std::arch::x86_64::*;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+use std::arch::wasm32::*;
+
 use super::simd_config;
 
 #[cfg(target_arch = "x86_64")]
@@ -13,6 +16,9 @@ use super::dot_product::{horizontal_sum_avx2, horizontal_sum_avx512};
 
 #[cfg(target_arch = "aarch64")]
 use super::dot_product::horizontal_sum_neon;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+use super::dot_product::horizontal_sum_simd128;
 
 #[inline(always)]
 fn dispatch_squared(a: &[f32], b: &[f32]) -> f32 {
@@ -32,6 +38,13 @@ fn dispatch_squared(a: &[f32], b: &[f32]) -> f32 {
     {
         if config.neon_enabled {
             return unsafe { squared_euclidean_distance_neon_unrolled(a, b) };
+        }
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        if config.simd128_enabled {
+            return unsafe { squared_euclidean_distance_simd128_unrolled(a, b) };
         }
     }
 
@@ -298,6 +311,76 @@ unsafe fn squared_euclidean_distance_neon_unrolled(a: &[f32], b: &[f32]) -> f32 
 
     let sum_vec = vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3));
     let mut sum = horizontal_sum_neon(sum_vec);
+
+    // Handle remainder
+    for i in (chunks * CHUNK_SIZE)..n {
+        let diff = a[i] - b[i];
+        sum += diff * diff;
+    }
+
+    sum
+}
+
+/// wasm32 SIMD128-accelerated squared Euclidean distance with 4x unrolling.
+///
+/// Mirrors `squared_euclidean_distance_neon_unrolled` above; see
+/// `dot_product::dot_product_simd128_unrolled` for the reassociation caveat
+/// (results are not bit-identical to the scalar reference) and the wasm
+/// safety notes (no runtime feature detection, alignment-free loads).
+///
+/// # Safety
+///
+/// Caller must ensure:
+/// - Compiled with the wasm32 `simd128` target feature (compile-time
+///   precondition; this function only exists under `#[cfg(target_feature =
+///   "simd128")]`)
+/// - `a` and `b` have equal length (checked by caller)
+///
+/// Memory safety:
+/// - Uses `v128_load` for loads (wasm loads are alignment-free by spec)
+/// - Pointer arithmetic stays within slice bounds via chunk calculation
+/// - Remainder loop uses safe indexing
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+unsafe fn squared_euclidean_distance_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
+    const SIMD_WIDTH: usize = 4;
+    const UNROLL: usize = 4;
+    const CHUNK_SIZE: usize = SIMD_WIDTH * UNROLL;
+    let n = a.len();
+    debug_assert_eq!(n, b.len());
+    let chunks = n / CHUNK_SIZE;
+
+    let mut sum0 = f32x4_splat(0.0);
+    let mut sum1 = f32x4_splat(0.0);
+    let mut sum2 = f32x4_splat(0.0);
+    let mut sum3 = f32x4_splat(0.0);
+
+    for i in 0..chunks {
+        let base = i * CHUNK_SIZE;
+
+        let a0 = v128_load(a.as_ptr().add(base) as *const v128);
+        let b0 = v128_load(b.as_ptr().add(base) as *const v128);
+        let diff0 = f32x4_sub(a0, b0);
+        sum0 = f32x4_add(sum0, f32x4_mul(diff0, diff0));
+
+        let a1 = v128_load(a.as_ptr().add(base + SIMD_WIDTH) as *const v128);
+        let b1 = v128_load(b.as_ptr().add(base + SIMD_WIDTH) as *const v128);
+        let diff1 = f32x4_sub(a1, b1);
+        sum1 = f32x4_add(sum1, f32x4_mul(diff1, diff1));
+
+        let a2 = v128_load(a.as_ptr().add(base + SIMD_WIDTH * 2) as *const v128);
+        let b2 = v128_load(b.as_ptr().add(base + SIMD_WIDTH * 2) as *const v128);
+        let diff2 = f32x4_sub(a2, b2);
+        sum2 = f32x4_add(sum2, f32x4_mul(diff2, diff2));
+
+        let a3 = v128_load(a.as_ptr().add(base + SIMD_WIDTH * 3) as *const v128);
+        let b3 = v128_load(b.as_ptr().add(base + SIMD_WIDTH * 3) as *const v128);
+        let diff3 = f32x4_sub(a3, b3);
+        sum3 = f32x4_add(sum3, f32x4_mul(diff3, diff3));
+    }
+
+    let sum_vec = f32x4_add(f32x4_add(sum0, sum1), f32x4_add(sum2, sum3));
+    let mut sum = horizontal_sum_simd128(sum_vec);
 
     // Handle remainder
     for i in (chunks * CHUNK_SIZE)..n {

--- a/crates/embed/src/simd/distance.rs
+++ b/crates/embed/src/simd/distance.rs
@@ -43,7 +43,7 @@ fn dispatch_squared(a: &[f32], b: &[f32]) -> f32 {
 
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     {
-        if config.simd128_enabled {
+        if config.simd128_enabled() {
             return unsafe { squared_euclidean_distance_simd128_unrolled(a, b) };
         }
     }

--- a/crates/embed/src/simd/dot_product.rs
+++ b/crates/embed/src/simd/dot_product.rs
@@ -48,7 +48,7 @@ fn resolve_dot_product_kernel() -> DotKernel {
 
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     {
-        if config.simd128_enabled {
+        if config.simd128_enabled() {
             return dot_product_simd128_kernel;
         }
     }

--- a/crates/embed/src/simd/dot_product.rs
+++ b/crates/embed/src/simd/dot_product.rs
@@ -6,6 +6,9 @@ use std::arch::x86_64::*;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+use std::arch::wasm32::*;
+
 use std::sync::OnceLock;
 
 use super::simd_config;
@@ -40,6 +43,13 @@ fn resolve_dot_product_kernel() -> DotKernel {
     {
         if config.neon_enabled {
             return dot_product_neon_kernel;
+        }
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        if config.simd128_enabled {
+            return dot_product_simd128_kernel;
         }
     }
 
@@ -158,6 +168,15 @@ fn dot_product_avx2_kernel(a: &[f32], b: &[f32]) -> f32 {
 fn dot_product_neon_kernel(a: &[f32], b: &[f32]) -> f32 {
     // SAFETY: only stored in DOT_PRODUCT_KERNEL when neon was detected at init time (always true on aarch64).
     unsafe { dot_product_neon_unrolled(a, b) }
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+fn dot_product_simd128_kernel(a: &[f32], b: &[f32]) -> f32 {
+    // SAFETY: only stored in DOT_PRODUCT_KERNEL when compiled with the wasm32
+    // `simd128` target feature (the `#[cfg(target_feature = "simd128")]` gate
+    // above is compile-time, not runtime -- see `SimdConfig::simd128_enabled`).
+    unsafe { dot_product_simd128_unrolled(a, b) }
 }
 
 /// Dot product over equal-length `f32` slices.
@@ -749,6 +768,126 @@ unsafe fn dot_product_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
 #[inline]
 pub(crate) unsafe fn horizontal_sum_neon(v: float32x4_t) -> f32 {
     vaddvq_f32(v)
+}
+
+/// wasm32 SIMD128-accelerated dot product with 4x unrolling and multiple accumulators.
+///
+/// Processes 16 floats per iteration (4 x 4 floats) with 4 independent accumulators,
+/// mirroring the NEON kernel's structure above. wasm SIMD128 has no fused
+/// multiply-add instruction (unlike AVX2/AVX-512/NEON), so each lane does a
+/// separate multiply then add (`f32x4_add(acc, f32x4_mul(...))`).
+///
+/// # Reassociation warning
+///
+/// Like every SIMD kernel in this module, lane-parallel accumulation reorders
+/// the summation relative to the scalar left-to-right reference (`a.iter().zip(b.iter())...sum()`),
+/// so results are NOT bit-identical to [`dot_product_scalar`] -- only equal within
+/// a tight relative epsilon (~1e-6). See the module-level docs and the parity
+/// tests in `simd/tests.rs`.
+///
+/// # Safety
+///
+/// Caller must ensure:
+/// - Compiled with the wasm32 `simd128` target feature (this function only
+///   exists under `#[cfg(target_feature = "simd128")]`; wasm has no runtime
+///   feature detection, so this is a compile-time, not runtime, precondition
+///   -- unlike the `is_x86_feature_detected!`/`is_aarch64_feature_detected!`
+///   guards above)
+/// - `a` and `b` have equal length (checked by caller)
+///
+/// Memory safety:
+/// - Uses `v128_load` for loads. wasm's alignment immediate is a performance
+///   hint only -- misaligned loads are always well-defined, so this is safe
+///   for any pointer alignment (matching `_mm256_loadu_ps`/`vld1q_f32` above,
+///   not the aligned `_mm256_load_ps` family).
+/// - Pointer arithmetic stays within slice bounds via chunk/remainder
+///   calculation: `chunks = n / CHUNK_SIZE` (floor), so `chunks * CHUNK_SIZE
+///   <= n`. `remaining_chunks = remaining / SIMD_WIDTH` (floor), so all
+///   SIMD128 loads stay in bounds.
+/// - Final scalar loop iterates `scalar_start..n` using safe `a[i]` / `b[i]`
+///   indexing and never reads past the end of the slice.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+unsafe fn dot_product_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
+    const SIMD_WIDTH: usize = 4;
+    const UNROLL: usize = 4;
+    const CHUNK_SIZE: usize = SIMD_WIDTH * UNROLL; // 16 floats per iteration
+
+    let n = a.len();
+    debug_assert_eq!(n, b.len());
+    let chunks = n / CHUNK_SIZE;
+
+    // 4 independent accumulators to break dependency chains
+    let mut sum0 = f32x4_splat(0.0);
+    let mut sum1 = f32x4_splat(0.0);
+    let mut sum2 = f32x4_splat(0.0);
+    let mut sum3 = f32x4_splat(0.0);
+
+    for i in 0..chunks {
+        let base = i * CHUNK_SIZE;
+
+        let a0 = v128_load(a.as_ptr().add(base) as *const v128);
+        let b0 = v128_load(b.as_ptr().add(base) as *const v128);
+        sum0 = f32x4_add(sum0, f32x4_mul(a0, b0));
+
+        let a1 = v128_load(a.as_ptr().add(base + SIMD_WIDTH) as *const v128);
+        let b1 = v128_load(b.as_ptr().add(base + SIMD_WIDTH) as *const v128);
+        sum1 = f32x4_add(sum1, f32x4_mul(a1, b1));
+
+        let a2 = v128_load(a.as_ptr().add(base + SIMD_WIDTH * 2) as *const v128);
+        let b2 = v128_load(b.as_ptr().add(base + SIMD_WIDTH * 2) as *const v128);
+        sum2 = f32x4_add(sum2, f32x4_mul(a2, b2));
+
+        let a3 = v128_load(a.as_ptr().add(base + SIMD_WIDTH * 3) as *const v128);
+        let b3 = v128_load(b.as_ptr().add(base + SIMD_WIDTH * 3) as *const v128);
+        sum3 = f32x4_add(sum3, f32x4_mul(a3, b3));
+    }
+
+    // Combine accumulators (dependencies are introduced only once at the end)
+    let sum01 = f32x4_add(sum0, sum1);
+    let sum23 = f32x4_add(sum2, sum3);
+    let sum_vec = f32x4_add(sum01, sum23);
+
+    let mut total = horizontal_sum_simd128(sum_vec);
+
+    // Handle remainder with single-vector loop
+    let main_processed = chunks * CHUNK_SIZE;
+    let remaining = n - main_processed;
+    let remaining_chunks = remaining / SIMD_WIDTH;
+
+    let mut remainder_sum = f32x4_splat(0.0);
+    for i in 0..remaining_chunks {
+        let offset = main_processed + i * SIMD_WIDTH;
+        let a_vec = v128_load(a.as_ptr().add(offset) as *const v128);
+        let b_vec = v128_load(b.as_ptr().add(offset) as *const v128);
+        remainder_sum = f32x4_add(remainder_sum, f32x4_mul(a_vec, b_vec));
+    }
+
+    total += horizontal_sum_simd128(remainder_sum);
+
+    // Final scalar remainder
+    let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
+    for i in scalar_start..n {
+        total += a[i] * b[i];
+    }
+
+    total
+}
+
+/// Horizontal sum of a wasm32 SIMD128 register (4 floats -> 1 float).
+///
+/// # Safety
+///
+/// Caller must ensure the crate was compiled with the wasm32 `simd128` target
+/// feature (this function only exists under `#[cfg(target_feature =
+/// "simd128")]`).
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+pub(crate) unsafe fn horizontal_sum_simd128(v: v128) -> f32 {
+    f32x4_extract_lane::<0>(v)
+        + f32x4_extract_lane::<1>(v)
+        + f32x4_extract_lane::<2>(v)
+        + f32x4_extract_lane::<3>(v)
 }
 
 /// NEON batch-4 dot product kernel wrapper.

--- a/crates/embed/src/simd/mod.rs
+++ b/crates/embed/src/simd/mod.rs
@@ -4,6 +4,9 @@
 //! - **x86_64 (float32)**: AVX-512F > AVX2 + FMA > scalar
 //! - **x86_64 (int8)**: AVX-512 VNNI > AVX2 > scalar
 //! - **aarch64**: ARM NEON with multiple accumulators and loop unrolling
+//! - **wasm32**: SIMD128 with multiple accumulators and loop unrolling, gated at
+//!   compile time via `target-feature=+simd128` (wasm has no runtime feature
+//!   detection, unlike x86_64/aarch64 — see [`SimdConfig::simd128_enabled`])
 //! - **Other**: Scalar fallback
 //!
 //! ## Optimizations
@@ -75,6 +78,15 @@ pub struct SimdConfig {
     /// Mandatory on Armv8.4+; optional on Armv8.2/v8.3. Always false on non-aarch64.
     /// SDOT kernels must only be dispatched when this is `true`.
     pub dotprod_enabled: bool,
+    /// **Unstable**: wasm32 SIMD128 support available.
+    ///
+    /// Unlike the x86_64/aarch64 fields above, this is a **compile-time**, not
+    /// runtime, signal: wasm has no runtime CPU feature detection (a given
+    /// `.wasm` binary either was or wasn't compiled with `-C
+    /// target-feature=+simd128`; there is no dispatching between two
+    /// codepaths inside one binary). Mirrors `cfg!(target_feature =
+    /// "simd128")`. Always false on non-wasm32 targets.
+    pub simd128_enabled: bool,
 }
 
 impl Default for SimdConfig {
@@ -99,6 +111,7 @@ impl SimdConfig {
                     && is_x86_feature_detected!("avx512vnni"),
                 neon_enabled: false,
                 dotprod_enabled: false,
+                simd128_enabled: false,
             }
         }
         #[cfg(target_arch = "aarch64")]
@@ -113,9 +126,31 @@ impl SimdConfig {
                 avx512vnni_enabled: false,
                 neon_enabled: true,
                 dotprod_enabled: std::arch::is_aarch64_feature_detected!("dotprod"),
+                simd128_enabled: false,
             }
         }
-        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        #[cfg(target_arch = "wasm32")]
+        {
+            // No runtime detection on wasm32: `simd128` is either compiled in
+            // for the whole module (via `-C target-feature=+simd128`) or not.
+            // `cfg!` reads the same compile-time flag the `#[cfg(...)]` gates
+            // on the SIMD kernel functions themselves key off, so this stays
+            // consistent with which kernels actually exist in the binary.
+            Self {
+                avx512f_enabled: false,
+                avx2_enabled: false,
+                fma_enabled: false,
+                avx512vnni_enabled: false,
+                neon_enabled: false,
+                dotprod_enabled: false,
+                simd128_enabled: cfg!(target_feature = "simd128"),
+            }
+        }
+        #[cfg(not(any(
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "wasm32"
+        )))]
         {
             Self {
                 avx512f_enabled: false,
@@ -124,6 +159,7 @@ impl SimdConfig {
                 avx512vnni_enabled: false,
                 neon_enabled: false,
                 dotprod_enabled: false,
+                simd128_enabled: false,
             }
         }
     }
@@ -131,7 +167,11 @@ impl SimdConfig {
     /// **Unstable**: check if any SIMD is available; logic may expand with new ISAs.
     #[inline]
     pub fn simd_available(&self) -> bool {
-        self.avx512f_enabled || self.avx512vnni_enabled || self.avx2_enabled || self.neon_enabled
+        self.avx512f_enabled
+            || self.avx512vnni_enabled
+            || self.avx2_enabled
+            || self.neon_enabled
+            || self.simd128_enabled
     }
 
     /// Force scalar-only mode (useful for testing).
@@ -144,6 +184,7 @@ impl SimdConfig {
             avx512vnni_enabled: false,
             neon_enabled: false,
             dotprod_enabled: false,
+            simd128_enabled: false,
         }
     }
 }

--- a/crates/embed/src/simd/mod.rs
+++ b/crates/embed/src/simd/mod.rs
@@ -78,15 +78,6 @@ pub struct SimdConfig {
     /// Mandatory on Armv8.4+; optional on Armv8.2/v8.3. Always false on non-aarch64.
     /// SDOT kernels must only be dispatched when this is `true`.
     pub dotprod_enabled: bool,
-    /// **Unstable**: wasm32 SIMD128 support available.
-    ///
-    /// Unlike the x86_64/aarch64 fields above, this is a **compile-time**, not
-    /// runtime, signal: wasm has no runtime CPU feature detection (a given
-    /// `.wasm` binary either was or wasn't compiled with `-C
-    /// target-feature=+simd128`; there is no dispatching between two
-    /// codepaths inside one binary). Mirrors `cfg!(target_feature =
-    /// "simd128")`. Always false on non-wasm32 targets.
-    pub simd128_enabled: bool,
 }
 
 impl Default for SimdConfig {
@@ -111,7 +102,6 @@ impl SimdConfig {
                     && is_x86_feature_detected!("avx512vnni"),
                 neon_enabled: false,
                 dotprod_enabled: false,
-                simd128_enabled: false,
             }
         }
         #[cfg(target_arch = "aarch64")]
@@ -126,7 +116,6 @@ impl SimdConfig {
                 avx512vnni_enabled: false,
                 neon_enabled: true,
                 dotprod_enabled: std::arch::is_aarch64_feature_detected!("dotprod"),
-                simd128_enabled: false,
             }
         }
         #[cfg(target_arch = "wasm32")]
@@ -143,7 +132,6 @@ impl SimdConfig {
                 avx512vnni_enabled: false,
                 neon_enabled: false,
                 dotprod_enabled: false,
-                simd128_enabled: cfg!(target_feature = "simd128"),
             }
         }
         #[cfg(not(any(
@@ -159,9 +147,22 @@ impl SimdConfig {
                 avx512vnni_enabled: false,
                 neon_enabled: false,
                 dotprod_enabled: false,
-                simd128_enabled: false,
             }
         }
+    }
+
+    /// **Unstable**: wasm32 SIMD128 support available.
+    ///
+    /// Unlike the x86_64/aarch64 fields, this is a **compile-time**, not
+    /// runtime, signal: wasm has no runtime CPU feature detection (a given
+    /// `.wasm` binary either was or wasn't compiled with `-C
+    /// target-feature=+simd128`; there is no dispatching between two
+    /// codepaths inside one binary). Mirrors `cfg!(target_feature =
+    /// "simd128")` and is always false on non-wasm32 targets. A method rather
+    /// than a field so existing `SimdConfig` struct literals keep compiling.
+    #[inline]
+    pub fn simd128_enabled(&self) -> bool {
+        cfg!(all(target_arch = "wasm32", target_feature = "simd128"))
     }
 
     /// **Unstable**: check if any SIMD is available; logic may expand with new ISAs.
@@ -171,7 +172,7 @@ impl SimdConfig {
             || self.avx512vnni_enabled
             || self.avx2_enabled
             || self.neon_enabled
-            || self.simd128_enabled
+            || self.simd128_enabled()
     }
 
     /// Force scalar-only mode (useful for testing).
@@ -184,7 +185,6 @@ impl SimdConfig {
             avx512vnni_enabled: false,
             neon_enabled: false,
             dotprod_enabled: false,
-            simd128_enabled: false,
         }
     }
 }

--- a/crates/embed/src/simd/normalize.rs
+++ b/crates/embed/src/simd/normalize.rs
@@ -53,7 +53,7 @@ pub fn normalize(vector: &mut [f32]) {
 
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     {
-        if config.simd128_enabled {
+        if config.simd128_enabled() {
             // SAFETY: compiled with wasm32 simd128 (compile-time gate, see
             // `SimdConfig::simd128_enabled`). The mutable slice is valid for
             // the call lifetime; the callee uses alignment-free loads/stores

--- a/crates/embed/src/simd/normalize.rs
+++ b/crates/embed/src/simd/normalize.rs
@@ -6,6 +6,9 @@ use std::arch::x86_64::*;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+use std::arch::wasm32::*;
+
 use super::simd_config;
 
 #[cfg(target_arch = "x86_64")]
@@ -13,6 +16,9 @@ use super::dot_product::{horizontal_sum_avx2, horizontal_sum_avx512};
 
 #[cfg(target_arch = "aarch64")]
 use super::dot_product::horizontal_sum_neon;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+use super::dot_product::horizontal_sum_simd128;
 
 /// **Unstable**: SIMD dispatch layer; use `lattice_embed::utils::normalize` for the stable wrapper.
 #[inline]
@@ -42,6 +48,17 @@ pub fn normalize(vector: &mut [f32]) {
             // for the call lifetime; the callee uses unaligned loads/stores and
             // bounded chunk/remainder loops that stay inside the slice.
             return unsafe { normalize_neon_unrolled(vector) };
+        }
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        if config.simd128_enabled {
+            // SAFETY: compiled with wasm32 simd128 (compile-time gate, see
+            // `SimdConfig::simd128_enabled`). The mutable slice is valid for
+            // the call lifetime; the callee uses alignment-free loads/stores
+            // and bounded chunk/remainder loops that stay inside the slice.
+            return unsafe { normalize_simd128_unrolled(vector) };
         }
     }
 
@@ -388,5 +405,109 @@ unsafe fn normalize_neon_unrolled(vector: &mut [f32]) {
     // Remainder for scaling
     for val in vector.iter_mut().skip(chunks * CHUNK_SIZE) {
         *val *= inv_norm;
+    }
+}
+
+/// wasm32 SIMD128-accelerated normalization with 4x unrolling.
+///
+/// Mirrors `normalize_avx2_unrolled` above (plain `sqrt` + scalar reciprocal,
+/// not the NEON kernel's `vrsqrteq_f32`+Newton-Raphson estimate -- wasm's
+/// `f32x4_sqrt` is already a single instruction, so there is no equivalent
+/// estimate-and-refine trick to apply here).
+///
+/// # Safety
+///
+/// Caller must ensure:
+/// - Compiled with the wasm32 `simd128` target feature (compile-time
+///   precondition; this function only exists under `#[cfg(target_feature =
+///   "simd128")]`)
+///
+/// Memory safety:
+/// - Uses `v128_load`/`v128_store` for loads/stores (wasm loads/stores are
+///   alignment-free by spec)
+/// - Pointer arithmetic stays within slice bounds via chunk calculation
+/// - Remainder loop uses safe indexing
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+unsafe fn normalize_simd128_unrolled(vector: &mut [f32]) {
+    const SIMD_WIDTH: usize = 4;
+    const UNROLL: usize = 4;
+    const CHUNK_SIZE: usize = SIMD_WIDTH * UNROLL;
+    let n = vector.len();
+    let chunks = n / CHUNK_SIZE;
+
+    // First pass: compute L2 norm with 4 accumulators
+    let mut norm0 = f32x4_splat(0.0);
+    let mut norm1 = f32x4_splat(0.0);
+    let mut norm2 = f32x4_splat(0.0);
+    let mut norm3 = f32x4_splat(0.0);
+
+    for i in 0..chunks {
+        let base = i * CHUNK_SIZE;
+
+        let v0 = v128_load(vector.as_ptr().add(base) as *const v128);
+        norm0 = f32x4_add(norm0, f32x4_mul(v0, v0));
+
+        let v1 = v128_load(vector.as_ptr().add(base + SIMD_WIDTH) as *const v128);
+        norm1 = f32x4_add(norm1, f32x4_mul(v1, v1));
+
+        let v2 = v128_load(vector.as_ptr().add(base + SIMD_WIDTH * 2) as *const v128);
+        norm2 = f32x4_add(norm2, f32x4_mul(v2, v2));
+
+        let v3 = v128_load(vector.as_ptr().add(base + SIMD_WIDTH * 3) as *const v128);
+        norm3 = f32x4_add(norm3, f32x4_mul(v3, v3));
+    }
+
+    let norm_vec = f32x4_add(f32x4_add(norm0, norm1), f32x4_add(norm2, norm3));
+    let mut norm_sq = horizontal_sum_simd128(norm_vec);
+
+    // Remainder for norm calculation
+    for i in (chunks * CHUNK_SIZE)..n {
+        norm_sq += vector[i] * vector[i];
+    }
+
+    let norm = norm_sq.sqrt();
+    // Match `normalize_scalar`: reject 0.0 and NaN alike so a NaN-containing
+    // vector is left unchanged rather than scaled by NaN. `is_nan() || <= 0.0`
+    // is the lint-clean equivalent of `!(norm > 0.0)`.
+    if norm.is_nan() || norm <= 0.0 {
+        return;
+    }
+
+    let inv_norm = 1.0 / norm;
+    let inv_norm_vec = f32x4_splat(inv_norm);
+
+    // Second pass: divide by norm with 4x unrolling
+    for i in 0..chunks {
+        let base = i * CHUNK_SIZE;
+
+        let v0 = v128_load(vector.as_ptr().add(base) as *const v128);
+        v128_store(
+            vector.as_mut_ptr().add(base) as *mut v128,
+            f32x4_mul(v0, inv_norm_vec),
+        );
+
+        let v1 = v128_load(vector.as_ptr().add(base + SIMD_WIDTH) as *const v128);
+        v128_store(
+            vector.as_mut_ptr().add(base + SIMD_WIDTH) as *mut v128,
+            f32x4_mul(v1, inv_norm_vec),
+        );
+
+        let v2 = v128_load(vector.as_ptr().add(base + SIMD_WIDTH * 2) as *const v128);
+        v128_store(
+            vector.as_mut_ptr().add(base + SIMD_WIDTH * 2) as *mut v128,
+            f32x4_mul(v2, inv_norm_vec),
+        );
+
+        let v3 = v128_load(vector.as_ptr().add(base + SIMD_WIDTH * 3) as *const v128);
+        v128_store(
+            vector.as_mut_ptr().add(base + SIMD_WIDTH * 3) as *mut v128,
+            f32x4_mul(v3, inv_norm_vec),
+        );
+    }
+
+    // Remainder for scaling
+    for i in (chunks * CHUNK_SIZE)..n {
+        vector[i] *= inv_norm;
     }
 }

--- a/crates/embed/src/wasm.rs
+++ b/crates/embed/src/wasm.rs
@@ -145,3 +145,21 @@ pub fn simd_cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 pub fn simd_normalize(v: &mut [f32]) {
     crate::simd::normalize(v)
 }
+
+/// Reports whether the four `simd*` bindings above are dispatching to the
+/// wasm32 SIMD128 kernels in *this* build.
+///
+/// Returns the exact same value the kernels themselves read to choose a
+/// codepath (`crate::simd::simd_config().simd128_enabled()`), not a fresh
+/// `cfg!(target_feature = "simd128")` re-derived here -- a binding-local
+/// re-check could drift from the real dispatch condition without anyone
+/// noticing. Exists so a two-build parity harness (one plain
+/// `wasm32-unknown-unknown` build, one built with
+/// `-C target-feature=+simd128`) can assert the SIMD128 build is actually
+/// exercising the SIMD128 kernels instead of a stale or misconfigured
+/// artifact silently falling back to scalar; see
+/// `crates/embed/tests/wasm/simd128_parity_wasm.mjs`.
+#[wasm_bindgen(js_name = simdSimd128Dispatch)]
+pub fn simd_simd128_dispatch() -> bool {
+    crate::simd::simd_config().simd128_enabled()
+}

--- a/crates/embed/src/wasm.rs
+++ b/crates/embed/src/wasm.rs
@@ -93,3 +93,55 @@ impl LatticeEmbedder {
         self.model.dimensions()
     }
 }
+
+// ---------------------------------------------------------------------------
+// Vector-op bindings: expose `simd::*` directly to JS/wasm callers.
+//
+// Unrelated to `LatticeEmbedder` above (which wraps the BERT-family forward
+// pass). These four are the `simd::*` khive ANN consumer contract
+// (`dot_product`, `squared_euclidean_distance`, `cosine_similarity`,
+// `normalize`; see `lib.rs`'s crate-level doc comment) made callable from JS,
+// so a wasm/JS consumer benefits from the same SIMD128 kernels a native
+// consumer gets, instead of falling back to a hand-rolled JS loop. Also the
+// entry points `scripts/bench_wasm_simd.mjs` calls for its A/B measurement.
+// ---------------------------------------------------------------------------
+
+/// Dot product of two equal-length vectors via `simd::dot_product`.
+///
+/// Dispatches to the wasm32 SIMD128 kernel when this crate is built with
+/// `-C target-feature=+simd128`, otherwise falls back to the scalar
+/// implementation. Returns `0.0` if `a` and `b` have different lengths.
+#[wasm_bindgen(js_name = simdDotProduct)]
+pub fn simd_dot_product(a: &[f32], b: &[f32]) -> f32 {
+    crate::simd::dot_product(a, b)
+}
+
+/// Squared Euclidean (L2) distance between two equal-length vectors via
+/// `simd::squared_euclidean_distance`.
+///
+/// Skips the final square root (see the Rust docs on
+/// [`crate::simd::squared_euclidean_distance`] for the ordering invariant
+/// this preserves). Returns `f32::MAX` if `a` and `b` have different lengths.
+#[wasm_bindgen(js_name = simdSquaredEuclideanDistance)]
+pub fn simd_squared_euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
+    crate::simd::squared_euclidean_distance(a, b)
+}
+
+/// Cosine similarity of two equal-length, non-empty vectors via
+/// `simd::cosine_similarity`.
+///
+/// Returns a value in `[-1.0, 1.0]`, or `0.0` for empty or mismatched-length
+/// inputs.
+#[wasm_bindgen(js_name = simdCosineSimilarity)]
+pub fn simd_cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    crate::simd::cosine_similarity(a, b)
+}
+
+/// L2-normalize a vector in place via `simd::normalize`.
+///
+/// Leaves the vector unchanged if its norm is zero or NaN (matches the
+/// scalar reference; see `simd::normalize`'s doc comment).
+#[wasm_bindgen(js_name = simdNormalize)]
+pub fn simd_normalize(v: &mut [f32]) {
+    crate::simd::normalize(v)
+}

--- a/crates/embed/tests/wasm/simd128_parity_wasm.mjs
+++ b/crates/embed/tests/wasm/simd128_parity_wasm.mjs
@@ -13,13 +13,17 @@
 //     `RUSTFLAGS="-C target-feature=+simd128"` -- dispatch picks the new
 //     wasm32 SIMD128 kernels.
 //
-// Both builds expose the same four JS bindings (simdDotProduct,
-// simdSquaredEuclideanDistance, simdCosineSimilarity, simdNormalize; see
-// wasm.rs), so this is a same-process, same-language, wasm-vs-wasm
-// comparison: no cross-framework or cross-model tolerance is needed, just a
-// tight relative epsilon (see ASSERT below), which is the same discipline
-// this crate's native tests apply to AVX-512/AVX2/NEON vs scalar (see
-// crates/embed/src/simd/tests.rs).
+// Both builds expose the same five JS bindings (simdDotProduct,
+// simdSquaredEuclideanDistance, simdCosineSimilarity, simdNormalize,
+// simdSimd128Dispatch; see wasm.rs), so this is a same-process,
+// same-language, wasm-vs-wasm comparison: no cross-framework or cross-model
+// tolerance is needed, just a tight relative epsilon (see ASSERT below),
+// which is the same discipline this crate's native tests apply to
+// AVX-512/AVX2/NEON vs scalar (see crates/embed/src/simd/tests.rs).
+// `simdSimd128Dispatch` is checked first, before any numeric case, so a
+// stale or misconfigured build cannot pass the numeric comparisons by both
+// sides silently agreeing on the scalar answer (see the dispatch-state
+// assertion below).
 //
 // Run via `scripts/wasm-simd128-parity.sh` (builds both variants, then
 // invokes this script) or directly with LATTICE_WASM_JS_BASELINE /
@@ -30,7 +34,12 @@
 // (crates/embed/src/simd/dot_product.rs) -- dropping lane 3 from the 4-lane
 // reduction so only 3 of 4 SIMD128 lanes are summed -- then re-verified to
 // PASS after reverting. See this PR's description for the before/after run
-// transcript.
+// transcript. The dispatch-state assertion has an equivalent
+// mutation-sensitivity proof of its own: pointing both
+// LATTICE_WASM_JS_BASELINE and LATTICE_WASM_JS_SIMD128 at the same
+// SIMD128-enabled build makes `assertDispatchState(baseline, false, ...)`
+// fail, since a real baseline build would report `false` and this
+// substitution reports `true`.
 
 import { existsSync } from 'node:fs';
 import path from 'node:path';
@@ -54,7 +63,19 @@ function mulberry32(seed) {
 function randomVec(dim, seed) {
   const rng = mulberry32(seed);
   const v = new Float32Array(dim);
-  for (let i = 0; i < dim; i++) v[i] = rng() * 2 - 1; // [-1, 1)
+  for (let i = 0; i < dim; i++) {
+    const x = rng() * 2 - 1; // [-1, 1)
+    // Enforced, not just documented: the fixed epsilon below (see
+    // assertClose) is only a defensible bound for this declared domain. A
+    // future change to mulberry32/its scaling that silently widened the
+    // range would otherwise let out-of-domain values reach assertClose and
+    // fail there with a confusing tolerance mismatch instead of a clear
+    // domain violation here.
+    if (!(x >= -1 && x < 1)) {
+      throw new Error(`randomVec: generated value ${x} at index ${i} (dim=${dim}, seed=${seed}) is outside the declared [-1, 1) domain`);
+    }
+    v[i] = x;
+  }
   return v;
 }
 
@@ -113,6 +134,28 @@ const TYPICAL_DIMS = [384, 768, 1024, 4096];
 let failures = 0;
 let checks = 0;
 
+// Tolerance validity domain: `relTol`/`absTol` below are defensible ONLY for
+// the bounded, well-conditioned input domain this harness actually
+// generates -- `randomVec`'s values in [-1, 1) (enforced there, see its
+// comment), plus the small handcrafted fixtures nearby (zeros, denormals
+// down to 1e-40, the 1e6/1e-6 alternating-magnitude case, and lane-position
+// spikes bounded by a few units), none of which drive catastrophic
+// cancellation in a 4-lane f32 accumulator tree.
+//
+// Reassociated f32 reduction error is a function of the input's condition
+// number, not just its dimension: a SIMD kernel that splits a reduction
+// across N accumulator lanes and horizontally sums them at the end produces
+// a *different but equally valid* floating-point result than a strict
+// left-to-right scalar fold whenever the terms have widely different
+// magnitudes and opposite signs. An adversarial cancellation input such as
+// `a = [1e20, -1e20, 1e20, -1e20, 1, 0, ...]` with `b = [1; 16]` is
+// deliberately out of domain for this gate: the scalar left fold yields `1`
+// while a 4-lane split-then-reduce accumulator can drop the `1` entirely
+// when it lands in a lane already holding `+-1e20`, and reduce to `0` --
+// both are IEEE-754-correct given each kernel's own accumulation order, so
+// no epsilon bridges that gap. Dispatch parity for such ill-conditioned
+// inputs is not part of this gate's contract; only relative correctness
+// within the declared bounded domain is.
 function assertClose(actual, expected, label) {
   checks++;
   const relTol = 1e-5;
@@ -261,6 +304,39 @@ for (const [name, p] of [['LATTICE_WASM_JS_BASELINE', baselinePath], ['LATTICE_W
 
 const baseline = await import(path.resolve(baselinePath));
 const simd128 = await import(path.resolve(simd128Path));
+
+// Dispatch-state assertion, checked BEFORE any numeric case runs. The
+// numeric comparisons below only demonstrate what they claim to (SIMD128
+// kernel vs scalar reference) if the "simd128" module is actually
+// dispatching to the SIMD128 kernels and the "baseline" module is actually
+// falling back to scalar. `simdSimd128Dispatch()` reports the exact value
+// each build's kernel dispatch reads (`SimdConfig::simd128_enabled()`), not
+// a `cfg!` re-derived in this script -- so this is a machine-checkable proof
+// tied to the dispatched kernel itself, not just to the `RUSTFLAGS` the
+// driver script requested. Without this, a stale cached artifact, a build
+// that silently failed to pick up `RUSTFLAGS`, or a future dispatch-logic
+// regression could leave both modules serving scalar and every numeric
+// assertion below would still pass, proving nothing about SIMD128.
+function assertDispatchState(mod, expected, label) {
+  checks++;
+  const actual = mod.simdSimd128Dispatch();
+  if (actual !== expected) {
+    failures++;
+    console.error(`FAIL [dispatch-state ${label}] simdSimd128Dispatch()=${actual}, expected=${expected}`);
+  } else {
+    console.log(`[dispatch-state ${label}] simdSimd128Dispatch()=${actual} (expected)`);
+  }
+}
+
+assertDispatchState(baseline, false, 'baseline');
+assertDispatchState(simd128, true, 'simd128');
+
+if (failures > 0) {
+  console.error(
+    `\nwasm32 SIMD128 parity gate: dispatch-state assertion failed (${failures} failure(s)) -- aborting before numeric cases, since they would prove nothing.`,
+  );
+  process.exit(1);
+}
 
 // Sanity: the baseline build (no simd128 target feature) must be exercising
 // the scalar kernel, i.e. it must itself agree with the JS scalar reference

--- a/crates/embed/tests/wasm/simd128_parity_wasm.mjs
+++ b/crates/embed/tests/wasm/simd128_parity_wasm.mjs
@@ -1,0 +1,283 @@
+// wasm32 SIMD128 kernel parity gate.
+//
+// Compares the crate's `simd::{dot_product, squared_euclidean_distance,
+// cosine_similarity, normalize}` wasm32 SIMD128 kernels (crates/embed/src/simd/
+// {dot_product,distance,cosine,normalize}.rs) against the scalar reference,
+// by loading TWO wasm-bindgen builds of the same crate side by side:
+//
+//   - baseline: plain `wasm32-unknown-unknown` build (no `simd128` target
+//     feature) -- every `#[cfg(target_feature = "simd128")]` kernel in this
+//     module is absent from the binary, so `SimdConfig::simd128_enabled` is
+//     `false` and dispatch always falls through to the scalar kernel.
+//   - simd128: same crate, same source, built with
+//     `RUSTFLAGS="-C target-feature=+simd128"` -- dispatch picks the new
+//     wasm32 SIMD128 kernels.
+//
+// Both builds expose the same four JS bindings (simdDotProduct,
+// simdSquaredEuclideanDistance, simdCosineSimilarity, simdNormalize; see
+// wasm.rs), so this is a same-process, same-language, wasm-vs-wasm
+// comparison: no cross-framework or cross-model tolerance is needed, just a
+// tight relative epsilon (see ASSERT below), which is the same discipline
+// this crate's native tests apply to AVX-512/AVX2/NEON vs scalar (see
+// crates/embed/src/simd/tests.rs).
+//
+// Run via `scripts/wasm-simd128-parity.sh` (builds both variants, then
+// invokes this script) or directly with LATTICE_WASM_JS_BASELINE /
+// LATTICE_WASM_JS_SIMD128 pointing at pre-built wasm-bindgen nodejs output.
+//
+// Mutation-sensitivity: this suite was manually verified to FAIL when a
+// deliberate bug was introduced into `horizontal_sum_simd128`
+// (crates/embed/src/simd/dot_product.rs) -- dropping lane 3 from the 4-lane
+// reduction so only 3 of 4 SIMD128 lanes are summed -- then re-verified to
+// PASS after reverting. See this PR's description for the before/after run
+// transcript.
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Deterministic PRNG (mulberry32) -- reproducible test vectors, no external
+// dependency.
+// ---------------------------------------------------------------------------
+
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomVec(dim, seed) {
+  const rng = mulberry32(seed);
+  const v = new Float32Array(dim);
+  for (let i = 0; i < dim; i++) v[i] = rng() * 2 - 1; // [-1, 1)
+  return v;
+}
+
+// f32-faithful scalar reference: `Math.fround` after every multiply/add
+// rounds each intermediate to f32 the same way Rust's `f32 * f32 -> f32` /
+// `f32 + f32 -> f32` do. Without this, JS's native double-precision math
+// silently disagrees with Rust at the extremes (e.g. a f32 subnormal squared
+// underflows to exactly 0.0 in f32, but not in f64) -- not a SIMD-vs-scalar
+// difference, just this reference computing in the wrong precision. Every
+// element read from a Float32Array is already an exact f32 value widened to
+// a JS double, so only the arithmetic *results* need rounding, matching
+// Rust's `a.iter().zip(b.iter())....sum()` left-to-right f32 fold exactly.
+const f32 = Math.fround;
+
+function scalarDot(a, b) {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) s = f32(s + f32(a[i] * b[i]));
+  return s;
+}
+
+function scalarSqL2(a, b) {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) {
+    const d = f32(a[i] - b[i]);
+    s = f32(s + f32(d * d));
+  }
+  return s;
+}
+
+function scalarCosine(a, b) {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot = f32(dot + f32(a[i] * b[i]));
+    na = f32(na + f32(a[i] * a[i]));
+    nb = f32(nb + f32(b[i] * b[i]));
+  }
+  na = f32(Math.sqrt(na));
+  nb = f32(Math.sqrt(nb));
+  if (na === 0 || nb === 0) return 0;
+  return f32(dot / f32(na * nb));
+}
+
+// ---------------------------------------------------------------------------
+// Test vector cases
+// ---------------------------------------------------------------------------
+
+// Dims deliberately not all multiples of the wasm128 kernel's 16-float
+// unrolled chunk size, so every case exercises the SIMD-main-body +
+// remainder-vector + scalar-tail split (dot_product_simd128_unrolled's
+// CHUNK_SIZE=16, SIMD_WIDTH=4).
+const REMAINDER_DIMS = [1, 2, 3, 5, 7, 17, 385];
+const TYPICAL_DIMS = [384, 768, 1024, 4096];
+
+let failures = 0;
+let checks = 0;
+
+function assertClose(actual, expected, label) {
+  checks++;
+  const relTol = 1e-5;
+  const absTol = 1e-6;
+  const diff = Math.abs(actual - expected);
+  const limit = Math.max(absTol, relTol * Math.max(Math.abs(expected), 1));
+  if (!(diff <= limit)) {
+    failures++;
+    console.error(
+      `FAIL [${label}] actual=${actual} expected=${expected} diff=${diff.toExponential(3)} limit=${limit.toExponential(3)}`,
+    );
+  }
+}
+
+function assertVecClose(actual, expected, label) {
+  for (let i = 0; i < expected.length; i++) {
+    assertClose(actual[i], expected[i], `${label}[${i}]`);
+  }
+}
+
+function runPairCases(mod, label) {
+  const cases = [];
+
+  for (const dim of [...REMAINDER_DIMS, ...TYPICAL_DIMS]) {
+    cases.push({ name: `random dim=${dim}`, a: randomVec(dim, 1000 + dim), b: randomVec(dim, 2000 + dim) });
+  }
+
+  // Zeros: exercises the norm==0 guards in cosine/normalize.
+  cases.push({ name: 'zeros dim=64', a: new Float32Array(64), b: new Float32Array(64) });
+
+  // Denormals: subnormal f32 range starts below ~1.1755e-38.
+  {
+    const dim = 64;
+    const a = new Float32Array(dim).fill(1e-40);
+    const b = new Float32Array(dim).fill(-1e-40);
+    cases.push({ name: 'denormals dim=64', a, b });
+  }
+
+  // Adversarial: magnitude alternates by 12 orders every element -- a
+  // reduction-order bug shows up as a large relative error here even though
+  // it might hide in a uniformly-scaled random vector.
+  for (const dim of [16, 17, 64, 385]) {
+    const a = new Float32Array(dim);
+    const b = new Float32Array(dim);
+    for (let i = 0; i < dim; i++) {
+      a[i] = i % 2 === 0 ? 1e6 : 1e-6;
+      b[i] = i % 2 === 0 ? 1.0 : -1.0;
+    }
+    cases.push({ name: `alternating-magnitude dim=${dim}`, a, b });
+  }
+
+  // Lane-position spikes: a single nonzero element at each of the 4 SIMD128
+  // lane offsets (0,1,2,3 mod 4), isolated across otherwise-zero vectors, so
+  // a lane-drop or lane-swap bug in the horizontal-sum/accumulator-combine
+  // step is caught regardless of which lane it targets.
+  for (const lane of [0, 1, 2, 3]) {
+    const dim = 32;
+    const a = new Float32Array(dim);
+    const b = new Float32Array(dim);
+    for (let i = lane; i < dim; i += 4) {
+      a[i] = 3.0 + i * 0.1;
+      b[i] = -2.0 + i * 0.05;
+    }
+    cases.push({ name: `lane-spike lane=${lane}`, a, b });
+  }
+
+  for (const c of cases) {
+    const dot = mod.simdDotProduct(c.a, c.b);
+    assertClose(dot, scalarDot(c.a, c.b), `${label} dot ${c.name}`);
+
+    const sqL2 = mod.simdSquaredEuclideanDistance(c.a, c.b);
+    assertClose(sqL2, scalarSqL2(c.a, c.b), `${label} sqL2 ${c.name}`);
+
+    if (c.a.length > 0) {
+      const cos = mod.simdCosineSimilarity(c.a, c.b);
+      assertClose(cos, scalarCosine(c.a, c.b), `${label} cosine ${c.name}`);
+    }
+  }
+
+  console.log(`[${label}] pair cases: ${cases.length}`);
+}
+
+function runNormalizeCases(mod, label) {
+  const dims = [...REMAINDER_DIMS, ...TYPICAL_DIMS];
+  for (const dim of dims) {
+    const v = randomVec(dim, 5000 + dim);
+    const expected = Float32Array.from(v);
+    const norm = f32(Math.sqrt(scalarDot(expected, expected)));
+    if (norm > 0) {
+      for (let i = 0; i < dim; i++) expected[i] /= norm;
+    }
+
+    const actual = Float32Array.from(v);
+    mod.simdNormalize(actual);
+    assertVecClose(actual, expected, `${label} normalize dim=${dim}`);
+  }
+
+  // Zero vector: must stay unchanged (norm == 0 guard).
+  {
+    const zeros = new Float32Array(16);
+    mod.simdNormalize(zeros);
+    assertVecClose(zeros, new Float32Array(16), `${label} normalize zeros`);
+  }
+
+  // NaN element: the whole vector's L2 norm is NaN, so both the scalar and
+  // every SIMD kernel in this module must leave the vector byte-unchanged
+  // (see normalize.rs's `norm.is_nan() || norm <= 0.0` guard) rather than
+  // scale by a NaN inverse norm. Dims deliberately not multiples of the
+  // unrolled chunk size so the NaN can land in either the SIMD main body or
+  // the scalar tail.
+  for (const dim of [17, 129, 385]) {
+    for (const nanAt of [3, dim - 1]) {
+      const original = randomVec(dim, 6000 + dim + nanAt);
+      original[nanAt] = NaN;
+      const actual = Float32Array.from(original);
+      mod.simdNormalize(actual);
+      for (let i = 0; i < dim; i++) {
+        checks++;
+        const a = actual[i];
+        const o = original[i];
+        const same = Number.isNaN(a) && Number.isNaN(o) ? true : Object.is(a, o);
+        if (!same) {
+          failures++;
+          console.error(`FAIL [${label} normalize NaN dim=${dim} nan_at=${nanAt}] index ${i}: ${a} vs original ${o}`);
+        }
+      }
+    }
+  }
+
+  console.log(`[${label}] normalize cases: ${dims.length + 1 + 6}`);
+}
+
+// ---------------------------------------------------------------------------
+// Load both wasm-bindgen builds and run
+// ---------------------------------------------------------------------------
+
+const baselinePath = process.env.LATTICE_WASM_JS_BASELINE;
+const simd128Path = process.env.LATTICE_WASM_JS_SIMD128;
+
+for (const [name, p] of [['LATTICE_WASM_JS_BASELINE', baselinePath], ['LATTICE_WASM_JS_SIMD128', simd128Path]]) {
+  if (!p || !existsSync(p)) {
+    console.error(`simd128_parity_wasm.mjs: ${name} not set or file missing (got ${p}). Run via scripts/wasm-simd128-parity.sh.`);
+    process.exit(1);
+  }
+}
+
+const baseline = await import(path.resolve(baselinePath));
+const simd128 = await import(path.resolve(simd128Path));
+
+// Sanity: the baseline build (no simd128 target feature) must be exercising
+// the scalar kernel, i.e. it must itself agree with the JS scalar reference
+// closely -- this is what makes the wasm-vs-wasm comparison below meaningful
+// evidence about the SIMD128 kernel specifically, not just "two builds agree
+// with each other by coincidence."
+runPairCases(baseline, 'baseline-vs-scalar-reference');
+runNormalizeCases(baseline, 'baseline-vs-scalar-reference');
+
+// The check that matters: simd128-enabled build vs the same scalar reference.
+runPairCases(simd128, 'simd128-vs-scalar-reference');
+runNormalizeCases(simd128, 'simd128-vs-scalar-reference');
+
+console.log(`\nwasm32 SIMD128 parity gate: ${checks} checks, ${failures} failure(s)`);
+if (failures > 0) {
+  console.error('wasm32 SIMD128 parity gate FAILED');
+  process.exit(1);
+}
+console.log('wasm32 SIMD128 parity gate PASSED');
+process.exit(0);

--- a/scripts/bench_wasm_simd.mjs
+++ b/scripts/bench_wasm_simd.mjs
@@ -26,8 +26,10 @@
 //     microbenchmark. Both variants pay the identical marshalling cost, so
 //     the A/B delta isolates the kernel change.
 //   - `normalize` mutates its argument in place; the input buffer is reset
-//     from a template array before each timed call, with the reset kept
-//     OUTSIDE the timed region.
+//     from a template array before each timed call via `timeCalls`' `prep`
+//     callback, which runs before `t0` on every rep (including warmup), so
+//     the reset copy is excluded from the timed region -- only the
+//     wasm-bindgen call + kernel are measured.
 //   - Timing uses `process.hrtime.bigint()` (nanosecond resolution). A
 //     warmup phase runs before the timed reps to let V8 JIT the call site.
 
@@ -146,10 +148,18 @@ function percentile(sortedNs, p) {
   return sortedNs[idx];
 }
 
-function timeCalls(fn, reps, warmup) {
-  for (let i = 0; i < warmup; i++) fn();
+// `prep`, when given, runs once per rep (warmup reps included) immediately
+// BEFORE `t0` -- for ops like `normalize` that mutate their input in place
+// and need a fresh copy each call, this keeps the reset out of the timed
+// region instead of folding it into the measured latency.
+function timeCalls(fn, reps, warmup, prep) {
+  for (let i = 0; i < warmup; i++) {
+    if (prep) prep();
+    fn();
+  }
   const samples = new Float64Array(reps);
   for (let i = 0; i < reps; i++) {
+    if (prep) prep();
     const t0 = process.hrtime.bigint();
     fn();
     const t1 = process.hrtime.bigint();
@@ -169,13 +179,9 @@ function benchPairOp(mod, opName, dim, seed, reps, warmup) {
 function benchNormalize(mod, dim, seed, reps, warmup) {
   const template = randomVec(dim, seed);
   const scratch = new Float32Array(dim);
-  const fn = () => {
-    scratch.set(template);
-    mod.simdNormalize(scratch);
-  };
-  // timeCalls' warmup calls fn() directly, which is fine here since each
-  // call resets scratch from template first.
-  return timeCalls(fn, reps, warmup);
+  const prep = () => scratch.set(template);
+  const fn = () => mod.simdNormalize(scratch);
+  return timeCalls(fn, reps, warmup, prep);
 }
 
 const OPS = [

--- a/scripts/bench_wasm_simd.mjs
+++ b/scripts/bench_wasm_simd.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+// bench_wasm_simd.mjs: A/B benchmark of lattice-embed's wasm32 build with and
+// without the `simd128` target feature.
+//
+// Builds lattice-embed for wasm32-unknown-unknown twice:
+//   - baseline: `cargo build --target wasm32-unknown-unknown --features wasm`
+//   - simd128:  same, with `RUSTFLAGS="-C target-feature=+simd128"`
+// then wasm-bindgen's both to nodejs-target JS glue, loads the four vector-op
+// bindings (simdDotProduct, simdSquaredEuclideanDistance,
+// simdCosineSimilarity, simdNormalize -- see crates/embed/src/wasm.rs) from
+// each, and times them over a range of embedding dimensions, reporting
+// median and p95 latency in nanoseconds per call.
+//
+// Usage:
+//   node scripts/bench_wasm_simd.mjs
+//   node scripts/bench_wasm_simd.mjs --dims 384,768 --reps 5000
+//
+// Skip-graceful: exits 0 with a one-line reason if cargo, the wasm32 target,
+// or wasm-bindgen are unavailable (mirrors scripts/wasm-parity.sh). Set
+// LATTICE_BENCH_WASM_SIMD_ENFORCE=1 to turn a skip into a hard failure.
+//
+// Methodology notes (also printed in the output header):
+//   - Each timed call passes fresh Float32Array inputs through wasm-bindgen's
+//     normal marshalling path (copy into wasm linear memory), i.e. this
+//     measures realistic JS-caller latency, not a hand-tuned zero-copy
+//     microbenchmark. Both variants pay the identical marshalling cost, so
+//     the A/B delta isolates the kernel change.
+//   - `normalize` mutates its argument in place; the input buffer is reset
+//     from a template array before each timed call, with the reset kept
+//     OUTSIDE the timed region.
+//   - Timing uses `process.hrtime.bigint()` (nanosecond resolution). A
+//     warmup phase runs before the timed reps to let V8 JIT the call site.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..');
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const out = { dims: [384, 768, 1024, 4096], reps: 4000, warmup: 300, seed: 0xC0FFEE };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dims') out.dims = argv[++i].split(',').map(Number);
+    else if (a === '--reps') out.reps = Number(argv[++i]);
+    else if (a === '--warmup') out.warmup = Number(argv[++i]);
+    else if (a === '--seed') out.seed = Number(argv[++i]);
+  }
+  return out;
+}
+
+const ARGS = parseArgs(process.argv.slice(2));
+const ENFORCE = process.env.LATTICE_BENCH_WASM_SIMD_ENFORCE;
+
+function skipOrFail(reason) {
+  if (ENFORCE) {
+    console.error(`bench_wasm_simd: FAIL (LATTICE_BENCH_WASM_SIMD_ENFORCE=1): ${reason}`);
+    process.exit(1);
+  }
+  console.log(`bench_wasm_simd: SKIPPED: ${reason}`);
+  process.exit(0);
+}
+
+function hasCmd(cmd) {
+  try {
+    execFileSync(cmd, ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!hasCmd('cargo')) skipOrFail('cargo not found on PATH');
+if (!hasCmd('wasm-bindgen')) skipOrFail('wasm-bindgen (CLI) not found on PATH; install with: cargo install wasm-bindgen-cli --version 0.2.105');
+try {
+  const installed = execFileSync('rustup', ['target', 'list', '--installed']).toString();
+  if (!installed.includes('wasm32-unknown-unknown')) {
+    execFileSync('rustup', ['target', 'add', 'wasm32-unknown-unknown'], { stdio: 'inherit' });
+  }
+} catch {
+  skipOrFail('wasm32-unknown-unknown target not installed and could not be added (rustup unavailable?)');
+}
+
+// ---------------------------------------------------------------------------
+// Build both variants
+// ---------------------------------------------------------------------------
+
+function buildVariant(label, rustflags, outDir) {
+  console.error(`=== bench_wasm_simd: building ${label} (RUSTFLAGS=${JSON.stringify(rustflags)}) ===`);
+  execFileSync(
+    'cargo',
+    ['build', '--release', '--target', 'wasm32-unknown-unknown', '-p', 'lattice-embed', '--no-default-features', '--features', 'wasm'],
+    { cwd: REPO, stdio: 'inherit', env: { ...process.env, RUSTFLAGS: rustflags } },
+  );
+  mkdirSync(outDir, { recursive: true });
+  execFileSync(
+    'wasm-bindgen',
+    ['--target', 'nodejs', '--out-dir', outDir, path.join(REPO, 'target/wasm32-unknown-unknown/release/lattice_embed.wasm')],
+    { stdio: 'inherit' },
+  );
+  return path.join(outDir, 'lattice_embed.js');
+}
+
+const baselineJs = buildVariant('baseline', '', path.join(REPO, 'target/bench-wasm-simd-baseline'));
+const simd128Js = buildVariant('simd128', '-C target-feature=+simd128', path.join(REPO, 'target/bench-wasm-simd-simd128'));
+
+const baseline = await import(path.resolve(baselineJs));
+const simd128 = await import(path.resolve(simd128Js));
+
+// ---------------------------------------------------------------------------
+// Deterministic input generation (mulberry32, same generator as the parity
+// test -- reproducible across runs given the same --seed).
+// ---------------------------------------------------------------------------
+
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomVec(dim, seed) {
+  const rng = mulberry32(seed);
+  const v = new Float32Array(dim);
+  for (let i = 0; i < dim; i++) v[i] = rng() * 2 - 1;
+  return v;
+}
+
+// ---------------------------------------------------------------------------
+// Timing
+// ---------------------------------------------------------------------------
+
+function percentile(sortedNs, p) {
+  const idx = Math.min(sortedNs.length - 1, Math.floor(sortedNs.length * p));
+  return sortedNs[idx];
+}
+
+function timeCalls(fn, reps, warmup) {
+  for (let i = 0; i < warmup; i++) fn();
+  const samples = new Float64Array(reps);
+  for (let i = 0; i < reps; i++) {
+    const t0 = process.hrtime.bigint();
+    fn();
+    const t1 = process.hrtime.bigint();
+    samples[i] = Number(t1 - t0);
+  }
+  const sorted = Array.from(samples).sort((a, b) => a - b);
+  return { median: percentile(sorted, 0.5), p95: percentile(sorted, 0.95) };
+}
+
+function benchPairOp(mod, opName, dim, seed, reps, warmup) {
+  const a = randomVec(dim, seed);
+  const b = randomVec(dim, seed + 1);
+  const fn = () => mod[opName](a, b);
+  return timeCalls(fn, reps, warmup);
+}
+
+function benchNormalize(mod, dim, seed, reps, warmup) {
+  const template = randomVec(dim, seed);
+  const scratch = new Float32Array(dim);
+  const fn = () => {
+    scratch.set(template);
+    mod.simdNormalize(scratch);
+  };
+  // timeCalls' warmup calls fn() directly, which is fine here since each
+  // call resets scratch from template first.
+  return timeCalls(fn, reps, warmup);
+}
+
+const OPS = [
+  { name: 'dot_product', fn: (mod, dim, seed, reps, warmup) => benchPairOp(mod, 'simdDotProduct', dim, seed, reps, warmup) },
+  { name: 'squared_l2', fn: (mod, dim, seed, reps, warmup) => benchPairOp(mod, 'simdSquaredEuclideanDistance', dim, seed, reps, warmup) },
+  { name: 'cosine', fn: (mod, dim, seed, reps, warmup) => benchPairOp(mod, 'simdCosineSimilarity', dim, seed, reps, warmup) },
+  { name: 'normalize', fn: (mod, dim, seed, reps, warmup) => benchNormalize(mod, dim, seed, reps, warmup) },
+];
+
+// ---------------------------------------------------------------------------
+// Run + report
+// ---------------------------------------------------------------------------
+
+console.log('# wasm32 SIMD128 A/B bench: lattice-embed simd:: kernels');
+console.log('#');
+console.log(`# node: ${process.version}`);
+console.log(`# platform: ${os.platform()} ${os.arch()} ${os.release()}`);
+console.log(`# rustc: ${execFileSync('rustc', ['--version']).toString().trim()}`);
+console.log(`# wasm-bindgen: ${execFileSync('wasm-bindgen', ['--version']).toString().trim()}`);
+console.log('# baseline build: cargo build --release --target wasm32-unknown-unknown -p lattice-embed --no-default-features --features wasm');
+console.log('# simd128 build:  RUSTFLAGS="-C target-feature=+simd128" cargo build --release --target wasm32-unknown-unknown -p lattice-embed --no-default-features --features wasm');
+console.log(`# dims: ${ARGS.dims.join(',')}`);
+console.log(`# reps: ${ARGS.reps}, warmup: ${ARGS.warmup}, seed: ${ARGS.seed}`);
+console.log('#');
+console.log('| op | dim | baseline median (ns) | baseline p95 (ns) | simd128 median (ns) | simd128 p95 (ns) | median speedup |');
+console.log('|---|---|---|---|---|---|---|');
+
+for (const dim of ARGS.dims) {
+  for (const op of OPS) {
+    const b = op.fn(baseline, dim, ARGS.seed, ARGS.reps, ARGS.warmup);
+    const s = op.fn(simd128, dim, ARGS.seed, ARGS.reps, ARGS.warmup);
+    const speedup = b.median / s.median;
+    console.log(
+      `| ${op.name} | ${dim} | ${b.median.toFixed(1)} | ${b.p95.toFixed(1)} | ${s.median.toFixed(1)} | ${s.p95.toFixed(1)} | ${speedup.toFixed(2)}x |`,
+    );
+  }
+}

--- a/scripts/wasm-simd128-parity.sh
+++ b/scripts/wasm-simd128-parity.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# wasm-simd128-parity.sh: build lattice-embed for wasm32 twice (plain vs
+# `-C target-feature=+simd128`) and gate the SIMD128 build's
+# dot_product/squared_euclidean_distance/cosine_similarity/normalize output
+# against the scalar reference, via
+# crates/embed/tests/wasm/simd128_parity_wasm.mjs.
+#
+# Usage:
+#   scripts/wasm-simd128-parity.sh
+#
+# Skip-graceful: if node, wasm-bindgen, or the wasm32 target are missing,
+# prints a one-line reason and exits 0, mirroring scripts/wasm-parity.sh.
+# Set LATTICE_WASM_SIMD128_ENFORCE=1 to turn a skip into a hard failure.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+ENFORCE="${LATTICE_WASM_SIMD128_ENFORCE:-}"
+
+skip_or_fail() {
+  reason="$1"
+  if [ -n "$ENFORCE" ]; then
+    echo "wasm-simd128-parity: FAIL (LATTICE_WASM_SIMD128_ENFORCE=1): $reason" >&2
+    exit 1
+  fi
+  echo "wasm-simd128-parity: SKIPPED: $reason"
+  exit 0
+}
+
+command -v node >/dev/null 2>&1 || skip_or_fail "node not found on PATH"
+command -v wasm-bindgen >/dev/null 2>&1 || skip_or_fail "wasm-bindgen (CLI) not found on PATH; install with: cargo install wasm-bindgen-cli --version 0.2.105"
+command -v cargo >/dev/null 2>&1 || skip_or_fail "cargo not found on PATH"
+
+if ! rustup target list --installed 2>/dev/null | grep -q '^wasm32-unknown-unknown$'; then
+  rustup target add wasm32-unknown-unknown >/dev/null 2>&1 \
+    || skip_or_fail "wasm32-unknown-unknown target not installed and could not be added"
+fi
+
+BASELINE_OUT="$REPO/target/wasm-simd128-parity-baseline"
+SIMD128_OUT="$REPO/target/wasm-simd128-parity-simd128"
+mkdir -p "$BASELINE_OUT" "$SIMD128_OUT"
+
+echo "=== wasm-simd128-parity: building baseline (no simd128) ==="
+cargo build --release --target wasm32-unknown-unknown -p lattice-embed \
+  --no-default-features --features wasm
+wasm-bindgen --target nodejs --out-dir "$BASELINE_OUT" \
+  "$REPO/target/wasm32-unknown-unknown/release/lattice_embed.wasm"
+
+echo "=== wasm-simd128-parity: building simd128 (-C target-feature=+simd128) ==="
+RUSTFLAGS="-C target-feature=+simd128" cargo build --release --target wasm32-unknown-unknown -p lattice-embed \
+  --no-default-features --features wasm
+wasm-bindgen --target nodejs --out-dir "$SIMD128_OUT" \
+  "$REPO/target/wasm32-unknown-unknown/release/lattice_embed.wasm"
+
+echo "=== wasm-simd128-parity: running Node harness ==="
+LATTICE_WASM_JS_BASELINE="$BASELINE_OUT/lattice_embed.js" \
+LATTICE_WASM_JS_SIMD128="$SIMD128_OUT/lattice_embed.js" \
+  node "$REPO/crates/embed/tests/wasm/simd128_parity_wasm.mjs"


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Adds `core::arch::wasm32` SIMD128 kernels for the four vector ops
`lattice-embed` exposes as its stable public contract
(`dot_product`, `squared_euclidean_distance`, `cosine_similarity`,
`normalize`), gated behind `#[cfg(all(target_arch = "wasm32", target_feature
= "simd128"))]`. Zero API change — the existing dispatch resolvers in
`crates/embed/src/simd/{dot_product,distance,cosine,normalize}.rs` pick the
new kernels automatically when the crate is built with `-C
target-feature=+simd128`; every other target and every existing call site is
untouched.

Also adds:
- `crates/embed/tests/wasm/simd128_parity_wasm.mjs` + driver script
  `scripts/wasm-simd128-parity.sh` — wasm-vs-wasm correctness gate (baseline
  vs simd128 build, both checked against an f32-faithful JS scalar
  reference), now wired into required CI (see "CI gate" below).
- `scripts/bench_wasm_simd.mjs` — self-building Node A/B harness, times both
  wasm builds across four embedding dimensions.
- Five `#[wasm_bindgen]`-exposed functions in `crates/embed/src/wasm.rs`
  (`simdDotProduct`, `simdSquaredEuclideanDistance`, `simdCosineSimilarity`,
  `simdNormalize`, `simdSimd128Dispatch`) — the existing wasm bindings only
  expose the full `LatticeEmbedder` class, not the `simd::*` vector-op
  layer; these give JS callers direct access to the same SIMD-accelerated
  ops a native Rust consumer already has via `lattice_embed::simd::*`.
  `simdSimd128Dispatch` is test-facing: it reports the exact dispatch state
  (`simd_config().simd128_enabled()`) the other four bindings' kernel
  dispatch reads, so the parity harness can prove which kernel tier a given
  build is actually exercising instead of inferring it from the `RUSTFLAGS`
  a build script requested.

## Why

`lattice-embed`'s wasm32 build had no SIMD path at all — every vector op
fell through to the portable scalar loop regardless of what the target
`.wasm` binary was compiled with. wasm32 has no runtime CPU-feature
detection (unlike the existing `is_x86_feature_detected!` / NEON paths in
this module), so this is a pure compile-time dispatch addition: a binary
built with `-C target-feature=+simd128` gets the new kernels, one built
without it keeps behaving exactly as before.

## wasm A/B results

Node v25.6.0, `process.hrtime.bigint()`, 5000 timed reps + 500 warmup per
cell, seed 0xC0FFEE (both variants marshal identical `Float32Array` inputs
through wasm-bindgen, so the delta isolates the kernel change, not call
overhead). `normalize` mutates its argument in place; its reset copy runs
via an explicit `prep` callback that `timeCalls` invokes immediately before
the timer starts (see "Bench timing correction" below for a methodology fix
applied to this table since the numbers were first posted):

| op | dim | baseline median (ns) | baseline p95 (ns) | simd128 median (ns) | simd128 p95 (ns) | median speedup |
|---|---|---|---|---|---|---|
| dot_product | 384 | 583.0 | 958.0 | 333.0 | 417.0 | 1.75x |
| squared_l2 | 384 | 584.0 | 1250.0 | 333.0 | 417.0 | 1.75x |
| cosine | 384 | 1208.0 | 1292.0 | 292.0 | 500.0 | 4.14x |
| normalize | 384 | 708.0 | 1375.0 | 334.0 | 916.0 | 2.12x |
| dot_product | 768 | 1042.0 | 1125.0 | 334.0 | 375.0 | 3.12x |
| squared_l2 | 768 | 1000.0 | 1084.0 | 333.0 | 375.0 | 3.00x |
| cosine | 768 | 2459.0 | 2584.0 | 375.0 | 416.0 | 6.56x |
| normalize | 768 | 1208.0 | 1292.0 | 375.0 | 459.0 | 3.22x |
| dot_product | 1024 | 1375.0 | 1458.0 | 375.0 | 417.0 | 3.67x |
| squared_l2 | 1024 | 1292.0 | 1375.0 | 375.0 | 417.0 | 3.45x |
| cosine | 1024 | 3333.0 | 3417.0 | 458.0 | 542.0 | 7.28x |
| normalize | 1024 | 1584.0 | 1708.0 | 500.0 | 542.0 | 3.17x |
| dot_product | 4096 | 4959.0 | 6875.0 | 959.0 | 1000.0 | 5.17x |
| squared_l2 | 4096 | 4916.0 | 4959.0 | 1000.0 | 1000.0 | 4.92x |
| cosine | 4096 | 13375.0 | 26708.0 | 1125.0 | 1250.0 | 11.89x |
| normalize | 4096 | 5541.0 | 5791.0 | 1250.0 | 2583.0 | 4.43x |

Consistent 1.75x-11.9x median speedup across all four kernels and all four
dims, growing with dimension. `cosine` shows the largest win since it fuses
three reductions (dot, norm_a, norm_b) into one SIMD128 pass — the same
structural reason the existing AVX2/NEON cosine kernels win big natively.

Reproduce: `node scripts/bench_wasm_simd.mjs --reps 5000 --warmup 500`
(self-building; requires `wasm-bindgen-cli` 0.2.105 and the
`wasm32-unknown-unknown` target).

### Bench timing correction

The first posted table's `normalize` rows included the per-iteration reset
copy (`scratch.set(template)`, required because `normalize` mutates its
argument in place) *inside* the timed region — `timeCalls` started the
clock before invoking its closure, and the reset ran inside that closure.
The copy was identical on both variants, so it never produced a false
correctness signal, but it was fixed overhead shared by both sides that
diluted the `normalize` speedup ratio specifically. `timeCalls` now takes an
optional `prep` callback that runs immediately before the timer starts on
every rep (warmup included); `normalize`'s reset moved there. Old vs new,
`normalize` only (the rows this fix actually changes):

| dim | baseline median: old → new | simd128 median: old → new | speedup: old → new |
|---|---|---|---|
| 384 | 750.0 → 708.0 ns | 459.0 → 334.0 ns | 1.63x → 2.12x |
| 768 | 1250.0 → 1208.0 ns | 417.0 → 375.0 ns | 3.00x → 3.22x |
| 1024 | 1708.0 → 1584.0 ns | 583.0 → 500.0 ns | 2.93x → 3.17x |
| 4096 | 5750.0 → 5541.0 ns | 1500.0 → 1250.0 ns | 3.83x → 4.43x |

Both sides got faster once the shared reset left the timed region, and the
speedup ratio increased at every dimension — consistent with the reset
overhead having diluted the ratio more than either side's raw median. The
other three ops (`dot_product`, `squared_l2`, `cosine`) never had a prep
step, so their table cells above reflect this fix's re-run rather than a
change in what is measured; the deltas versus the original posting (e.g.
`cosine`/384 2.58x → 4.14x) are ordinary run-to-run JIT/scheduling variance
between two separate `node` invocations on a shared dev machine, not an
effect of this fix.

## Correctness

`scripts/wasm-simd128-parity.sh` builds both wasm variants and runs
`crates/embed/tests/wasm/simd128_parity_wasm.mjs`: **15,668 checks, 0
failures** (15,666 numeric checks, unchanged, plus 2 new dispatch-state
checks below), covering remainder-length dims (1,2,3,5,7,17,385), typical
dims (384,768,1024,4096), zero vectors, denormals, alternating-magnitude
adversarial inputs, and isolated lane-position spikes (one nonzero element
at each of the 4 SIMD128 lane offsets) for dot/squared-L2/cosine, plus
`normalize` including the NaN-norm-leaves-vector-unchanged guard.

**Mutation-sensitivity, verified manually**: temporarily broke the shared
`horizontal_sum_simd128` helper (dropped lane 3 from the 4-lane reduction),
rebuilt the simd128 variant, and re-ran the parity script — **7,215 of
15,666 checks failed**, confirming the suite actually catches a broken
kernel. Reverted and re-ran: back to 0 failures, no test file left modified.

### Dispatch-state assertion

The numeric checks above only demonstrate SIMD128-vs-scalar correctness if
the "simd128" module is actually dispatching to the SIMD128 kernels and the
"baseline" module is actually falling back to scalar. Added
`simdSimd128Dispatch()` (returns `simd_config().simd128_enabled()`, the
exact value the kernel dispatch itself reads) and an assertion in the
harness that checks `false` for the baseline module and `true` for the
simd128 module *before* any numeric case runs, so a stale artifact, a build
that silently failed to pick up `RUSTFLAGS`, or a future dispatch regression
cannot pass the numeric checks by both sides quietly agreeing on the scalar
answer.

Mutation-sensitivity proof: pointed both `LATTICE_WASM_JS_BASELINE` and
`LATTICE_WASM_JS_SIMD128` at the simd128 build's artifact and ran the
harness directly:

```
FAIL [dispatch-state baseline] simdSimd128Dispatch()=true, expected=false
[dispatch-state simd128] simdSimd128Dispatch()=true (expected)

wasm32 SIMD128 parity gate: dispatch-state assertion failed (1 failure(s)) -- aborting before numeric cases, since they would prove nothing.
```

exit code 1. Restored the correct pairing and re-ran: back to 15,668 checks,
0 failures.

### Tolerance validity domain

The fixed `1e-5` relative / `1e-6` absolute epsilon in `assertClose` is only
a defensible bound for the harness's actual input domain: `[-1, 1)` via
`randomVec`, plus a handful of small handcrafted fixtures (zeros, denormals,
an alternating-magnitude case, lane-position spikes) — none of which drive
catastrophic cancellation in a 4-lane f32 accumulator tree. Added a comment
at the epsilon definition stating this explicitly, with a concrete
adversarial-cancellation counterexample (`a=[1e20,-1e20,...]`, `b=[1;16]`)
that is deliberately out of domain: a strict left-to-right scalar fold and a
4-lane split-then-reduce accumulator can legitimately disagree by more than
any fixed epsilon on such inputs (both are IEEE-754-correct given their own
accumulation order), so dispatch parity there is not part of this gate's
contract. `randomVec` now asserts every generated value is within `[-1,
1)`, enforcing the domain rather than only documenting it.

## CI gate

`scripts/wasm-simd128-parity.sh` was not previously invoked by any CI
workflow — a SIMD128 kernel regression could have merged with every existing
wasm CI check green. Added a `wasm-simd128-parity` job to
`.github/workflows/e2e-parity.yml`, mirroring the existing `wasm-parity`
job's rust-toolchain / `wasm32-unknown-unknown` target / pinned
`wasm-bindgen-cli` provisioning (no model-weight provisioning needed here,
since this gate covers only the four vector-op kernels, not the BERT
forward pass). The job runs with `LATTICE_WASM_SIMD128_ENFORCE=1` and is
wired into the `parity-gate` aggregate job's `needs` list and pass/fail
resolution, plus the engine change-detection path filter, the same way the
existing `parity`/`embed-drift`/`wasm-parity` gates are.

Fail-closed proof (driver script directly, prerequisite hidden via a
restricted `PATH`):

```
$ PATH=<no wasm-bindgen> LATTICE_WASM_SIMD128_ENFORCE=1 bash scripts/wasm-simd128-parity.sh
wasm-simd128-parity: FAIL (LATTICE_WASM_SIMD128_ENFORCE=1): wasm-bindgen (CLI) not found on PATH; install with: cargo install wasm-bindgen-cli --version 0.2.105
exit code: 1

$ PATH=<no wasm-bindgen> bash scripts/wasm-simd128-parity.sh   # no ENFORCE
wasm-simd128-parity: SKIPPED: wasm-bindgen (CLI) not found on PATH; install with: cargo install wasm-bindgen-cli --version 0.2.105
exit code: 0
```

`actionlint .github/workflows/e2e-parity.yml`: clean, no findings.

## Native impact (ADR-058)

This PR only adds `#[cfg(target_arch = "wasm32", target_feature =
"simd128")]`-gated code (including the new `simdSimd128Dispatch` binding,
gated on `target_arch = "wasm32"` + `feature = "wasm"`) — none of it exists
in a native x86_64/aarch64 build, and the CI-wiring/harness/bench changes in
this fix round touch no `crates/*/src/` files outside `wasm.rs`. Required
`make bench-compare` evidence, quick mode (unchanged from the original
posting — nothing native to re-measure):

```
BENCH_GROUPS_INFERENCE="" BENCH_GROUPS_EMBED="simd_dot_product" ./scripts/bench-compare.sh origin/main HEAD
```

Base=origin/main (539cb8fe8f), Head=HEAD (aaa96db840):

```
### `local-compare` — perf regression report

**3 FAIL** (regression >7.0% confirmed by 95% CI)
**1 WARN** (regression 3.0-7.0% confirmed)
**7 confirmed improvement**

| Bench | Δ point | 95% CI | new ns | base ns | verdict |
|---|---:|---|---:|---:|---|
| `residual_add_layer_norm/fused/hidden384_seq128` | +81.43% | [+58.33%, +104.59%] | 30465.1 | 16792.0 | FAIL |
| `rms_norm/896` | +74.29% | [+41.78%, +108.11%] | 318.5 | 182.7 | FAIL |
| `layer_norm/4096` | +55.87% | [+18.48%, +99.05%] | 1965.9 | 1261.2 | FAIL |
| `softmax_attention/512` | +12.96% | [+3.22%, +22.88%] | 111518.8 | 98722.0 | WARN |
| `residual_add_layer_norm/fused/hidden768_seq128` | -20.15% | [-23.78%, -16.35%] | 45586.9 | 57088.5 | WIN |
| `gelu/896` | -15.31% | [-24.97%, -3.39%] | 594.7 | 702.3 | WIN |
| `add_bias_gelu/896` | -21.50% | [-25.54%, -17.11%] | 473.7 | 603.4 | WIN |
| `add_bias_gelu/4096` | -23.03% | [-26.90%, -18.94%] | 2332.7 | 3030.6 | WIN |
| `silu_inplace/4096` | -28.52% | [-30.45%, -26.49%] | 2676.8 | 3744.5 | WIN |
| `residual_add_layer_norm/unfused/hidden384_seq128` | -24.45% | [-32.42%, -14.77%] | 73849.4 | 97748.1 | WIN |
| `residual_add_layer_norm/unfused/hidden768_seq128` | -34.04% | [-43.72%, -24.06%] | 128419.4 | 194695.9 | WIN |

**8 informational** (below quick-mode resolution — lattice-embed SIMD micro-benches, tracked in #714; not gated)
| Bench | Δ point | 95% CI | new ns | base ns |
|---|---:|---|---:|---:|
| `simd_dot_product/simd/1536` | +139.72% | [+137.39%, +142.07%] | 372.8 | 155.5 |
| `simd_dot_product/simd/1024` | +7.89% | [+5.41%, +10.46%] | 108.2 | 100.2 |
| `simd_dot_product/scalar/768` | -22.00% | [-31.97%, -9.24%] | 753.5 | 966.0 |
| `simd_dot_product/simd/768` | -35.10% | [-36.64%, -33.49%] | 59.9 | 92.4 |
| `simd_dot_product/scalar/1024` | -43.71% | [-44.17%, -43.24%] | 889.1 | 1579.4 |
| `simd_dot_product/scalar/384` | -44.55% | [-46.61%, -42.39%] | 263.9 | 476.0 |
| `simd_dot_product/scalar/1536` | -44.30% | [-54.68%, -27.80%] | 1544.6 | 2773.2 |
| `simd_dot_product/simd/384` | -54.01% | [-63.60%, -37.60%] | 28.3 | 61.5 |
```

**Why the FAIL/WARN entries are not attributable to this diff**: every
flagged bench (`residual_add_layer_norm`, `rms_norm`, `layer_norm`,
`softmax_attention`) lives in `crates/inference`, which this PR does not
touch at all — `git log $(git merge-base HEAD origin/main)..origin/main --
crates/inference/` returns zero commits, i.e. the inference crate's source
is byte-identical between base and head for this comparison. These are
quick-mode measurement-noise deltas from two independently-built binaries,
not a code-driven regression.

The 8 informational `simd_dot_product` entries are the *existing* native
x86_64/AVX2/aarch64-NEON dot-product dispatch (not the new wasm32 kernels
this PR adds) — the tool itself excludes this group from gating and the
deltas are internally contradictory (e.g. `scalar/768` -22% vs `simd/1536`
+139% in the same run), consistent with known noise for this group. This is
also the mechanically expected result: the only change to
`resolve_dot_product_kernel()` is one additional `wasm32`-gated branch,
compiled out entirely on native targets — the existing kernel bodies are
byte-unchanged.

## Gates

- `cargo fmt -p lattice-embed`: clean.
- `cargo clippy -p lattice-embed --all-targets -- -D warnings` (native): 0
  errors, 0 warnings.
- `cargo test -p lattice-embed --lib`: 262 passed, 0 failed (all
  pre-existing `simd::` tests included, run natively — unaffected).
- wasm32 baseline build (`--features wasm`, no RUSTFLAGS): clean.
- wasm32 simd128 build (`RUSTFLAGS="-C target-feature=+simd128"`): clean.
- wasm32-target clippy is not part of this repo's `clippy` gate (the
  Makefile's `clippy:` target is native-only, no `--target` flag). Ran it
  out of curiosity anyway: pre-existing `lattice-inference` failures
  (`drop_non_drop`, `needless_return`) block `-D warnings` on a wasm32
  cross-compile even on a clean `main` checkout, unrelated to this PR and
  out of scope here.
- `bash scripts/wasm-simd128-parity.sh`: 15,668 checks, 0 failures
  (includes the new dispatch-state assertions).
- `actionlint .github/workflows/e2e-parity.yml`: clean, no findings.

## Test invocation

```
# native
cargo test -p lattice-embed --lib

# wasm32 correctness parity (fail-closed in CI via LATTICE_WASM_SIMD128_ENFORCE=1)
scripts/wasm-simd128-parity.sh

# wasm32 A/B bench
node scripts/bench_wasm_simd.mjs --reps 5000 --warmup 500
```

Co-Authored-By: Leo <noreply@khive.ai>
