### PR TITLE
chore(release): v0.6.1 - version bump + release notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 # MSRV, verified end-to-end (workspace + deps) on 1.93.1 and guarded by the msrv CI
 # job (aarch64 macOS, f16,metal-gpu, --all-targets) so a newer-toolchain-only API

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -55,14 +55,14 @@ tracing = "0.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["sync", "rt"] }
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.6.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.6.1", path = "../inference", optional = true, features = ["f16"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.0", default-features = false, features = ["sync", "rt"] }
 # Same crate, trimmed to the CPU compute path: `std` + `f16`, without
 # `download` (ureq) or `serve` (axum/tokio-net/mio), none of which compile to
 # wasm32-unknown-unknown.
-lattice-inference = { version = "0.6.0", path = "../inference", optional = true, default-features = false, features = [
+lattice-inference = { version = "0.6.1", path = "../inference", optional = true, default-features = false, features = [
     "std",
     "f16",
 ] }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -71,7 +71,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.6.0", path = "../fann", optional = true }
+lattice-fann = { version = "0.6.1", path = "../fann", optional = true }
 
 [[bin]]
 name = "lattice"

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -30,7 +30,7 @@ sqlite = ["dep:rusqlite", "serde"]
 mixture = ["lattice-fann/online-router"]
 
 [dependencies]
-lattice-fann = { version = "0.6.0", path = "../fann" }
+lattice-fann = { version = "0.6.1", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -51,7 +51,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.6.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.6.1", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/docs/releases/v0.6.1.md
+++ b/docs/releases/v0.6.1.md
@@ -1,0 +1,63 @@
+# lattice v0.6.1
+
+12 commits since v0.6.0 (plus #900, merging into this release — see below). Patch bump:
+additive only, no public API changes. Verified
+against the published v0.6.0 baseline with `cargo semver-checks check-release` across
+all five publishable crates: 196/196 checks pass, "no semver update required" on native
+targets.
+
+## Headline: wasm32 SIMD128 kernels for `lattice-embed` (#900)
+
+`lattice-embed`'s wasm32 build previously had no SIMD path at all — every vector op
+fell through to the portable scalar loop regardless of what the target `.wasm` binary
+was compiled with, since wasm32 has no runtime CPU-feature detection (unlike this
+crate's existing `is_x86_feature_detected!` / NEON dispatch paths). This release adds
+`core::arch::wasm32` SIMD128 kernels for the four vector ops `lattice-embed` exposes as
+its stable public contract — `dot_product`, `squared_euclidean_distance`,
+`cosine_similarity`, `normalize` — gated behind `#[cfg(all(target_arch = "wasm32",
+target_feature = "simd128"))]`. Zero API change: the existing dispatch resolvers pick
+the new kernels automatically when the crate is built with `-C target-feature=+simd128`;
+every other target and call site is untouched.
+
+- Five new `#[wasm_bindgen]`-exposed functions in `crates/embed/src/wasm.rs`
+  (`simdDotProduct`, `simdSquaredEuclideanDistance`, `simdCosineSimilarity`,
+  `simdNormalize`, and a test-facing dispatch-state diagnostic,
+  `simdSimd128Dispatch`) give JS callers direct access to the same SIMD-accelerated
+  ops a native Rust consumer already has via `lattice_embed::simd::*`.
+- A wasm-vs-wasm correctness parity gate (`scripts/wasm-simd128-parity.sh`, baseline
+  build vs simd128 build, both checked against an f32-faithful JS scalar reference) is
+  wired into required CI as a new `wasm-simd128-parity` job in `e2e-parity.yml`,
+  fail-closed under `LATTICE_WASM_SIMD128_ENFORCE=1`.
+- Measured Node A/B speedups (`scripts/bench_wasm_simd.mjs`, Node v25.6.0,
+  `process.hrtime.bigint()`, 5000 timed reps + 500 warmup per cell) across embedding
+  dims 384-4096: `dot_product` 1.75x-5.17x, `squared_euclidean_distance` 1.75x-4.92x,
+  `cosine_similarity` 4.14x-11.89x (largest win — fuses three reductions into one
+  SIMD128 pass), `normalize` 2.12x-4.43x. Speedup grows with dimension across all four
+  kernels.
+
+## MoE expert-cache streaming (#682)
+
+Continuation of the dequant-on-demand MoE expert cache (tracked issue #682, parked at
+end-to-end feasibility in v0.6.0's `from_q4_dir` loader work):
+
+- **Dequant-on-demand MoE expert cache with bounded LRU residency** (#894): routed
+  expert weights are dequantized into a fixed-size LRU-managed slot cache sized to the
+  device's working-set budget, instead of eagerly dequantizing every expert up front.
+- **Prefetch routed-expert loads to overlap I/O with shared-expert encoding** (#895):
+  once CPU routing decides a token's top-k experts, every routed-expert cache load is
+  issued up front (right after routing, before the shared-expert GEMVs are encoded)
+  instead of one at a time inside the dispatch loop, so cold-expert mmap read + CPU
+  dequant can overlap with shared-expert GEMV dispatch instead of serializing after it.
+
+## Fixes
+
+- Bumped `lru` 0.12 -> 0.16 in `lattice-embed`, clearing RUSTSEC-2026-0002 (unsound
+  `IterMut`); the crate only uses `LruCache::new`/`get`/`put`/`len`/`clear`, none of
+  which changed signature, and `IterMut` was never exercised (#896, closes #886).
+
+## Bench / CI infrastructure
+
+- Fixed the benchmark memory gate to enforce its declared abs-and-pct AND condition
+  (`perf-policy.toml`'s `fail_abs_mib` leg was parsed but never checked against);
+  also fixed a live consumer that was assigning the wrong-tail bootstrap bound to a
+  variable named for the opposite tail, shadow-mode-only so never gated (#898).


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Version bump 0.6.0 -> 0.6.1 + `docs/releases/v0.6.1.md`. Patch release, additive only.

Bumps `[workspace.package].version` and every internal path-dependency `version =`
field in lockstep (`crates/embed`, `crates/inference`, `crates/tune`), matching the
exact file set the v0.6.0 and v0.5.1 release commits touched. `Cargo.lock` is
gitignored in this repo, so no lockfile change is part of this diff.

## Why 0.6.1 (patch, not minor)

`cargo semver-checks check-release` against the **published v0.6.0** crates.io
baseline passes clean — 196/196 checks, "no semver update required" on native
targets — confirmed both by an independent run on the `feat/embed-wasm-simd128`
(#900) branch this session and by that PR's own `semver-checks` CI job
(https://github.com/ohdearquant/lattice/actions/runs/29201844169/job/86674453065).
The wasm32 SIMD128 kernels this release ships are additive (new `#[cfg(target_arch
= "wasm32", target_feature = "simd128")]` code paths + new `#[wasm_bindgen]`
exports); no existing public signature changes. Additive changes in a 0.x series
are compatible within the same minor (0.6.x) per Cargo semver conventions, so this
stays a patch bump rather than 0.7.0.

## What ships in v0.6.1

- **wasm32 SIMD128 kernels for `lattice-embed`** (#900): `dot_product`,
  `squared_euclidean_distance`, `cosine_similarity`, `normalize` all gain
  compile-time-dispatched SIMD128 kernels, five new `#[wasm_bindgen]` exports
  (four ops + a dispatch-state diagnostic), and a two-build wasm-vs-wasm parity
  gate wired into required CI (`wasm-simd128-parity` job in `e2e-parity.yml`).
  Measured Node A/B speedups across dims 384-4096: dot_product 1.75x-5.17x,
  squared_l2 1.75x-4.92x, cosine 4.14x-11.89x, normalize 2.12x-4.43x.
- **MoE expert-cache streaming** (#682): dequant-on-demand cache with bounded LRU
  residency (#894) + prefetch overlap of routed-expert loads with shared-expert
  encoding (#895).
- `lru` 0.12 -> 0.16 in `lattice-embed`, clearing RUSTSEC-2026-0002 (#896).
- Benchmark memory-gate math fix: enforce the declared abs-and-pct AND condition
  (#898).

Full notes: `docs/releases/v0.6.1.md`.

## MERGE ORDER

**This PR merges only after #900 (wasm32 SIMD128 kernels) lands on `main`.** It is
opened as a draft now so the version bump and release notes are ready to land
immediately behind #900, without a review-latency gap where `main` sits on an
unreleased wasm feature. Do not mark ready or arm auto-merge until #900 is merged.

## Gates

- `cargo check --workspace` (5/5 crates at 0.6.1): clean, via the machine-wide GPU
  test lock's sibling heavy-lane serializer.
- Pre-commit hooks (doc lint via deno, capability-matrix fixture check): passed.
- Hygiene grep on `git diff origin/main...HEAD`: no matches.
- No test suite run (version/docs-only change; nothing in the diff touches runtime
  code).
