### PR TITLE
chore(npm): prep lattice-embed-wasm v0.6.1 with SIMD128 enabled

### DIFF
--- a/npm/lattice-embed-wasm/README.md
+++ b/npm/lattice-embed-wasm/README.md
@@ -55,6 +55,53 @@ An error raised while actually running an already-loaded model is thrown,
 not swallowed, since it means something is broken rather than "this
 particular option is unavailable."
 
+## Performance (WebAssembly SIMD128)
+
+The wasm core is built with `-C target-feature=+simd128`, which activates
+SIMD128 kernels for the four vector ops on the crate's stable public
+contract (`dot_product`, `squared_euclidean_distance`/L2, `cosine_similarity`,
+`normalize`). wasm32 has no runtime CPU-feature detection, so this is a
+compile-time choice: this package ships one artifact, built with the flag
+on, and there is no separate non-SIMD128 fallback build published from this
+flow.
+
+Median per-call latency, baseline (scalar, no SIMD128) vs. SIMD128, measured
+in Node v25.6.0 with `process.hrtime.bigint()`, 5000 timed reps + 500 warmup
+reps per cell, both variants marshaling identical `Float32Array` inputs
+through wasm-bindgen so the delta isolates the kernel, not call overhead:
+
+| op | dim | baseline median (ns) | baseline p95 (ns) | simd128 median (ns) | simd128 p95 (ns) | median speedup |
+|---|---|---|---|---|---|---|
+| dot_product | 384 | 583.0 | 958.0 | 333.0 | 417.0 | 1.75x |
+| squared_l2 | 384 | 584.0 | 1250.0 | 333.0 | 417.0 | 1.75x |
+| cosine | 384 | 1208.0 | 1292.0 | 292.0 | 500.0 | 4.14x |
+| normalize | 384 | 708.0 | 1375.0 | 334.0 | 916.0 | 2.12x |
+| dot_product | 768 | 1042.0 | 1125.0 | 334.0 | 375.0 | 3.12x |
+| squared_l2 | 768 | 1000.0 | 1084.0 | 333.0 | 375.0 | 3.00x |
+| cosine | 768 | 2459.0 | 2584.0 | 375.0 | 416.0 | 6.56x |
+| normalize | 768 | 1208.0 | 1292.0 | 375.0 | 459.0 | 3.22x |
+| dot_product | 1024 | 1375.0 | 1458.0 | 375.0 | 417.0 | 3.67x |
+| squared_l2 | 1024 | 1292.0 | 1375.0 | 375.0 | 417.0 | 3.45x |
+| cosine | 1024 | 3333.0 | 3417.0 | 458.0 | 542.0 | 7.28x |
+| normalize | 1024 | 1584.0 | 1708.0 | 500.0 | 542.0 | 3.17x |
+| dot_product | 4096 | 4959.0 | 6875.0 | 959.0 | 1000.0 | 5.17x |
+| squared_l2 | 4096 | 4916.0 | 4959.0 | 1000.0 | 1000.0 | 4.92x |
+| cosine | 4096 | 13375.0 | 26708.0 | 1125.0 | 1250.0 | 11.89x |
+| normalize | 4096 | 5541.0 | 5791.0 | 1250.0 | 2583.0 | 4.43x |
+
+Speedup is consistent (1.75x-11.9x median) across all four kernels and
+grows with dimension; `cosine` shows the largest win because it fuses three
+reductions (dot, norm_a, norm_b) into one SIMD128 pass. These numbers cover
+the four vector-op kernels directly; end-to-end `embed()` latency also
+includes tokenization and the BERT forward pass, which are unaffected by
+this flag.
+
+**Runtime floor**: WebAssembly SIMD128 is a baseline feature in every
+evergreen browser (shipped across Chrome, Firefox, Edge, and Safari since
+2021-2023) and in Node.js since 16.4. This package's `engines.node` field
+already requires `>=18`, comfortably above that floor, so no environment
+that can load this package at all falls short of the SIMD128 requirement.
+
 ## Supported models
 
 | name | pooling | dimensions |
@@ -133,7 +180,8 @@ npm run smoke   # runs a local end-to-end check against cached model weights
 
 Building requires `cargo`, the `wasm32-unknown-unknown` Rust target, and the
 `wasm-bindgen` CLI at the version pinned in the workspace's `Cargo.toml`
-(`cargo install wasm-bindgen-cli --version 0.2.105`). See
+(`cargo install wasm-bindgen-cli --version 0.2.105`). The build compiles
+with `-C target-feature=+simd128` (see "Performance" above); see
 `scripts/build-wasm.sh`.
 
 ## License

--- a/npm/lattice-embed-wasm/package.json
+++ b/npm/lattice-embed-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khive-ai/lattice-embed-wasm",
-  "version": "0.1.0",
+  "version": "0.6.1",
   "description": "Pure-Rust BERT-family text embeddings compiled to WebAssembly, with a small Node adapter for model resolution, caching, and pooling.",
   "type": "module",
   "license": "Apache-2.0",

--- a/npm/lattice-embed-wasm/scripts/assert-simd128-dispatch.mjs
+++ b/npm/lattice-embed-wasm/scripts/assert-simd128-dispatch.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Post-build guard for build-wasm.sh: loads the wasm-bindgen bindings that
+// script just generated and asserts the built artifact is actually
+// dispatching to the wasm32 SIMD128 kernels, not silently falling back to
+// scalar.
+//
+// This exists because a stale or misconfigured build can produce bindings
+// that look entirely normal (same exports, same API surface, builds
+// without error) while the underlying .wasm was never actually built with
+// `-C target-feature=+simd128` in effect on the consumed artifact -- e.g. a
+// shared CARGO_TARGET_DIR pointing wasm-bindgen at an old binary, or an
+// inherited CARGO_ENCODED_RUSTFLAGS silently overriding the flag (see
+// build-wasm.sh's own guard for that case). `simdSimd128Dispatch()`
+// (crates/embed/src/wasm.rs, exported via wasm/lattice_embed.js) reports
+// the crate's own dispatch decision (`SimdConfig::simd128_enabled()`), the
+// same probe crates/embed/tests/wasm/simd128_parity_wasm.mjs checks before
+// trusting any numeric comparison in that crate-level parity gate -- this
+// script applies the identical check to the actual npm package artifact
+// right after build-wasm.sh produces it.
+//
+// Usage: node assert-simd128-dispatch.mjs <out-dir>
+//   <out-dir> must contain lattice_embed.js + lattice_embed_bg.wasm, i.e.
+//   the --out-dir wasm-bindgen was just pointed at.
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const outDir = process.argv[2];
+if (!outDir) {
+  console.error('assert-simd128-dispatch: usage: node assert-simd128-dispatch.mjs <out-dir>');
+  process.exit(1);
+}
+
+const jsPath = path.join(outDir, 'lattice_embed.js');
+const wasmPath = path.join(outDir, 'lattice_embed_bg.wasm');
+
+const bindings = await import(pathToFileURL(jsPath).href);
+const wasmBytes = readFileSync(wasmPath);
+// Same init call shape index.mjs uses for the shipped package: synchronous,
+// bundled-bytes init via the `{ module }` form (see `initSync` in
+// lattice_embed.js) -- no fetch, no network, exactly one instance.
+bindings.initSync({ module: wasmBytes });
+
+const dispatch = bindings.simdSimd128Dispatch();
+console.log(`assert-simd128-dispatch: simdSimd128Dispatch() = ${dispatch}`);
+if (dispatch !== true) {
+  console.error(
+    'assert-simd128-dispatch: FAIL - the built artifact is not dispatching to the wasm32 SIMD128 kernels ' +
+      '(simdSimd128Dispatch() returned false). This means the .wasm wasm-bindgen just consumed was not actually ' +
+      'built with -C target-feature=+simd128 in effect -- a stale artifact from a mismatched target directory, ' +
+      'or a RUSTFLAGS override, are the two known causes (see build-wasm.sh).',
+  );
+  process.exit(1);
+}
+console.log('assert-simd128-dispatch: PASS (simd128 dispatch confirmed)');

--- a/npm/lattice-embed-wasm/scripts/build-wasm.sh
+++ b/npm/lattice-embed-wasm/scripts/build-wasm.sh
@@ -24,10 +24,21 @@ if ! rustup target list --installed 2>/dev/null | grep -q '^wasm32-unknown-unkno
   rustup target add wasm32-unknown-unknown
 fi
 
-echo "=== build-wasm: compiling lattice-embed for wasm32 ==="
+echo "=== build-wasm: compiling lattice-embed for wasm32 (SIMD128) ==="
+# -C target-feature=+simd128 turns on wasm32 SIMD128 kernels in
+# crates/embed/src/simd/{dot_product,distance,cosine,normalize}.rs (the
+# dispatch resolvers there pick a SIMD128 kernel automatically when the
+# crate is built this way; see README.md "Performance" for measured
+# speedups). Runtime floor: WebAssembly SIMD128 is a baseline feature in
+# every evergreen browser and in Node >=16 (this package's `engines.node`
+# field already requires >=18, so no consumer of this package can be below
+# the floor). There is no non-simd128 fallback artifact published from this
+# flow; a caller needing a pre-SIMD128 runtime should build from source
+# without this flag.
 (
   cd "$REPO_ROOT"
-  cargo build --release --target wasm32-unknown-unknown -p lattice-embed \
+  RUSTFLAGS="-C target-feature=+simd128" \
+    cargo build --release --target wasm32-unknown-unknown -p lattice-embed \
     --no-default-features --features wasm
 )
 

--- a/npm/lattice-embed-wasm/scripts/build-wasm.sh
+++ b/npm/lattice-embed-wasm/scripts/build-wasm.sh
@@ -19,12 +19,50 @@ command -v wasm-bindgen >/dev/null 2>&1 || {
   echo "  install with: cargo install wasm-bindgen-cli --version 0.2.105" >&2
   exit 1
 }
+command -v node >/dev/null 2>&1 || {
+  echo "build-wasm: node not found on PATH (needed for the post-build SIMD128 dispatch assertion)" >&2
+  exit 1
+}
 
 if ! rustup target list --installed 2>/dev/null | grep -q '^wasm32-unknown-unknown$'; then
   rustup target add wasm32-unknown-unknown
 fi
 
+# CARGO_ENCODED_RUSTFLAGS takes precedence over a plain RUSTFLAGS= assignment
+# on the cargo invocation below (documented cargo flag precedence: encoded
+# beats plain regardless of which is "more local"), so an inherited encoded
+# flag set without +simd128 would silently override this script's
+# RUSTFLAGS="-C target-feature=+simd128" and produce a scalar-only artifact
+# that otherwise looks like a normal successful build. There is no safe way
+# to merge into an already-encoded flag set from a shell script, so fail
+# loudly instead of shipping something this script can't verify.
+if [ -n "${CARGO_ENCODED_RUSTFLAGS:-}" ]; then
+  echo "build-wasm: CARGO_ENCODED_RUSTFLAGS is set in the environment." >&2
+  echo "  cargo gives CARGO_ENCODED_RUSTFLAGS precedence over this script's" >&2
+  echo "  RUSTFLAGS=\"-C target-feature=+simd128\" assignment, so building" >&2
+  echo "  with it set would silently drop the SIMD128 target-feature flag" >&2
+  echo "  and ship a scalar-only artifact. Unset CARGO_ENCODED_RUSTFLAGS" >&2
+  echo "  (and whatever tool or shell config set it) before running this" >&2
+  echo "  script." >&2
+  exit 1
+fi
+
+# One target-dir variable feeds both the cargo build below and the
+# wasm-bindgen consume step further down, so they can never disagree about
+# where the artifact landed. Without this, a caller with CARGO_TARGET_DIR set
+# (e.g. to share a build cache across worktrees) would have cargo write the
+# fresh .wasm somewhere else while wasm-bindgen kept reading the default
+# target/wasm32-unknown-unknown/release/lattice_embed.wasm path -- packaging
+# whatever stale artifact (or nothing at all) happened to already be sitting
+# there instead of the build that just ran.
+TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/target}"
+case "$TARGET_DIR" in
+  /*) ;;
+  *) TARGET_DIR="$REPO_ROOT/$TARGET_DIR" ;;
+esac
+
 echo "=== build-wasm: compiling lattice-embed for wasm32 (SIMD128) ==="
+echo "    target-dir: $TARGET_DIR"
 # -C target-feature=+simd128 turns on wasm32 SIMD128 kernels in
 # crates/embed/src/simd/{dot_product,distance,cosine,normalize}.rs (the
 # dispatch resolvers there pick a SIMD128 kernel automatically when the
@@ -39,12 +77,28 @@ echo "=== build-wasm: compiling lattice-embed for wasm32 (SIMD128) ==="
   cd "$REPO_ROOT"
   RUSTFLAGS="-C target-feature=+simd128" \
     cargo build --release --target wasm32-unknown-unknown -p lattice-embed \
-    --no-default-features --features wasm
+    --no-default-features --features wasm \
+    --target-dir "$TARGET_DIR"
 )
+
+WASM_ARTIFACT="$TARGET_DIR/wasm32-unknown-unknown/release/lattice_embed.wasm"
+if [ ! -f "$WASM_ARTIFACT" ]; then
+  echo "build-wasm: expected build artifact missing at $WASM_ARTIFACT" >&2
+  exit 1
+fi
 
 echo "=== build-wasm: generating JS bindings (--target web) ==="
 mkdir -p "$OUT_DIR"
-wasm-bindgen --target web --out-dir "$OUT_DIR" \
-  "$REPO_ROOT/target/wasm32-unknown-unknown/release/lattice_embed.wasm"
+wasm-bindgen --target web --out-dir "$OUT_DIR" "$WASM_ARTIFACT"
+
+echo "=== build-wasm: verifying SIMD128 dispatch in the generated bindings ==="
+# Loads the bindings just written to $OUT_DIR and asserts the built .wasm is
+# actually dispatching to the SIMD128 kernels (simdSimd128Dispatch(), the
+# same probe crates/embed/tests/wasm/simd128_parity_wasm.mjs checks before
+# trusting any numeric comparison) rather than silently serving scalar
+# because the target-feature flag above didn't take effect on the consumed
+# artifact. Fails the build rather than shipping an artifact this check
+# can't confirm is SIMD128.
+node "$PKG_DIR/scripts/assert-simd128-dispatch.mjs" "$OUT_DIR"
 
 echo "build-wasm: done. Output in $OUT_DIR"


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Preps the `@khive-ai/lattice-embed-wasm` npm package for a v0.6.1 refresh
with WebAssembly SIMD128 enabled:

- `npm/lattice-embed-wasm/package.json`: version `0.1.0` -> `0.6.1`. This
  field is a manual literal (verified: neither `scripts/build-wasm.sh` nor
  `scripts/publish-npm.sh` derive it from the workspace `Cargo.toml`), so
  it is hand-set here rather than templated.
- `npm/lattice-embed-wasm/scripts/build-wasm.sh`: the wasm32 release build
  now sets `RUSTFLAGS="-C target-feature=+simd128"`, which activates the
  SIMD128 kernel paths in `crates/embed/src/simd/{dot_product,distance,
  cosine,normalize}.rs`'s dispatch resolvers. This package publishes a
  single artifact (no dual SIMD128/baseline build or runtime feature
  detection exists for this flow), so the flag is unconditional. The
  build and the `wasm-bindgen` consume step now derive a single
  `TARGET_DIR` (honoring `CARGO_TARGET_DIR` when the caller has it set,
  so a shared build-cache directory can no longer leave `wasm-bindgen`
  reading a stale artifact from the default path), the script fails
  loudly if `CARGO_ENCODED_RUSTFLAGS` is set in the environment (it
  takes precedence over the `RUSTFLAGS=` assignment above and would
  otherwise silently drop the SIMD128 flag), and the script now asserts
  `simdSimd128Dispatch()` on the freshly generated bindings before
  considering the build done (new
  `npm/lattice-embed-wasm/scripts/assert-simd128-dispatch.mjs`, loading
  the bindings the same synchronous, bundled-bytes way `index.mjs`
  does).
- `npm/lattice-embed-wasm/README.md`: adds a "Performance (WebAssembly
  SIMD128)" section with the measured per-kernel speedup table and a
  runtime-floor note (WASM SIMD128 is a baseline feature in every
  evergreen browser and in Node >=16; this package's `engines.node`
  already requires >=18).

## Runtime floor

WebAssembly SIMD128 has no feature-detection fallback at the wasm32 target
level (unlike the crate's native `is_x86_feature_detected!`/NEON paths).
This package therefore ships one SIMD128-only artifact. Every consumer
environment capable of loading this package (Node >=18 per `engines`, or
any evergreen browser) is already above the SIMD128 floor, so this is not
a compatibility regression versus the previous non-SIMD128 build.

## Status: both prerequisites merged; branch rebuilt + reverified against them

Both gating prerequisites named in the original "Dependency / publish
order" section below have landed on `main`:

1. **crates.io v0.6.1** shipped (all 5 workspace crates published).
2. **The wasm32 SIMD128 kernels** landed via #900
   (`23cb1a7993`, `feat(embed): wasm32 SIMD128 kernels for dot/L2/cosine/
   normalize`) — the explicit, hand-tuned `core::arch::wasm32` `f32x4`
   kernels in `crates/embed/src/simd/{dot_product,distance,cosine,
   normalize}.rs` that this PR's README performance table is measured
   from. #901 (`36a06caed1`) carried the workspace v0.6.1 version bump in
   the same merge.

This branch predated both, so it was merged forward (`git merge
origin/main`, merge commit `6100485198`, **zero conflicts** — this PR's
three touched files (`package.json`, `scripts/build-wasm.sh`, `README.md`)
never intersect #900/#901's touched files) and the npm artifact was
rebuilt and reverified from scratch against that merged state:

**Build**: `bash npm/lattice-embed-wasm/scripts/build-wasm.sh` (via the
repo's heavy-lane build serialization). Output: `npm/lattice-embed-wasm/
wasm/lattice_embed_bg.wasm`, 381.3 kB (up from the pre-#900 build's 347.5
kB reported in the tarball table below — expected, since the artifact now
contains the real explicit SIMD128 kernel bodies rather than only
auto-vectorized scalar code).

**`npm run smoke`** (`npm/lattice-embed-wasm/smoke.mjs`, against locally
cached + sha256-verified model weights for all three wasm-supported
models):

```
=== minilm (pooling=mean) ===
  dims=384 norm=1.000000
  cosine(dog, puppy)=0.874630  cosine(dog, report)=0.003478
  PASS

=== bge (pooling=cls) ===
  dims=384 norm=1.000000
  cosine(dog, puppy)=0.935397  cosine(dog, report)=0.364860
  PASS

=== paraphrase-minilm (pooling=mean) ===
  dims=384 norm=1.000000
  cosine(dog, puppy)=0.931475  cosine(dog, report)=0.077414
  PASS

=== degrade check: qwen3-0.6b (not a wasm-supported model) ===
  embed('x', 'qwen3-0.6b') = null
  PASS

smoke test: PASS
```

**`npm run test:init`** (`init-race.test.mjs`): `init race test: PASS`.

**#900's own wasm32 SIMD128 parity gate** (`LATTICE_WASM_SIMD128_ENFORCE=1
bash scripts/wasm-simd128-parity.sh`, run against this merged branch state
via the heavy lane) — this is a crate-level, two-build parity gate:
`scripts/wasm-simd128-parity.sh` builds `lattice-embed` for wasm32 twice
directly via `cargo build` + `wasm-bindgen --target nodejs` into its own
scratch output directories (`target/wasm-simd128-parity-{baseline,
simd128}`); it does not invoke
`npm/lattice-embed-wasm/scripts/build-wasm.sh` or `npm pack`, so it is
proof that the crate's hand-tuned SIMD128 kernels are numerically correct
against the scalar reference, not proof about this package's own build or
packaging path. See "Package-path verification" below for the check that
covers that path specifically.

```
[dispatch-state baseline] simdSimd128Dispatch()=false (expected)
[dispatch-state simd128] simdSimd128Dispatch()=true (expected)
[baseline-vs-scalar-reference] pair cases: 21
[baseline-vs-scalar-reference] normalize cases: 18
[simd128-vs-scalar-reference] pair cases: 21
[simd128-vs-scalar-reference] normalize cases: 18

wasm32 SIMD128 parity gate: 15668 checks, 0 failure(s)
wasm32 SIMD128 parity gate PASSED
```

Same check count (15,668) and same PASS result #900 itself reported, now
re-run against this branch's merged state (the crate's SIMD128 kernel
source is unchanged since #900, so an identical result is expected here).

## Package-path verification

The parity gate above tests the crate directly; it never runs this
package's own `scripts/build-wasm.sh` or `npm pack`/`prepack` flow. This
section covers that path specifically, against the hardened
`build-wasm.sh` described in "What" above.

**Regression scenario** (the failure mode the target-dir fix closes): set
`CARGO_TARGET_DIR` to a scratch directory outside the repo, planted a
truncated 4 KB junk file at the old default artifact path
(`target/wasm32-unknown-unknown/release/lattice_embed.wasm`), then ran the
fixed `build-wasm.sh`. Result: the build consumed the fresh artifact from
the scratch `CARGO_TARGET_DIR` (its sha256 matched a known-good prior
build byte-for-byte, since the build is otherwise deterministic); the
4 KB decoy at the default path was left completely untouched (sha256
unchanged, confirmed by direct comparison before/after); and the
post-build `simdSimd128Dispatch()` assertion passed against the bindings
generated from the scratch-dir artifact. The decoy was removed and the
original default-path file restored afterward.

**`CARGO_ENCODED_RUSTFLAGS` guard**: ran `build-wasm.sh` with
`CARGO_ENCODED_RUSTFLAGS` set to an arbitrary value in the environment.
The script exited 1 immediately, before invoking `cargo`, with an explicit
message naming the precedence issue.

**Full rebuild + package flow**, `CARGO_TARGET_DIR` unset (default path):
`bash scripts/build-wasm.sh` (via the heavy lane) completed, ending in
`assert-simd128-dispatch: PASS (simd128 dispatch confirmed)`; `npm run
smoke` and `npm run test:init` both passed against the rebuilt package;
`npm pack --dry-run` (which runs the `prepack` hook, i.e. this same fixed
`build-wasm.sh`, as part of packaging itself, not as a separate step)
reported version `0.6.1` and the same 9 allowlisted files at the same
sizes as the tarball table below, with the dispatch assertion passing
inline as part of that `npm pack` invocation. Final `wasm/
lattice_embed_bg.wasm`: 381,255 bytes, sha256
`d8e7f6f8450c05ca453924ce773f33dcb624faef9040d9456441018ca0dc184a`.

## Tarball verification (local `npm pack`, not published) — rebuilt

`npm pack` (not `--dry-run`) inside `npm/lattice-embed-wasm/`, from the
merged branch state:

```
npm notice 📦  @khive-ai/lattice-embed-wasm@0.6.1
npm notice Tarball Contents
npm notice 8.9kB README.md
npm notice 6.5kB index.mjs
npm notice 1.3kB package.json
npm notice 6.2kB registry.mjs
npm notice 8.9kB resolve.mjs
npm notice 381.3kB wasm/lattice_embed_bg.wasm
npm notice 1.3kB wasm/lattice_embed_bg.wasm.d.ts
npm notice 6.4kB wasm/lattice_embed.d.ts
npm notice 16.2kB wasm/lattice_embed.js
npm notice Tarball Details
npm notice name: @khive-ai/lattice-embed-wasm
npm notice version: 0.6.1
npm notice filename: khive-ai-lattice-embed-wasm-0.6.1.tgz
npm notice package size: 165.6 kB
npm notice unpacked size: 436.9 kB
npm notice total files: 9
```

Extracted the tarball to a scratch directory and confirmed: `package.json`
reports `"version": "0.6.1"`; `wasm/lattice_embed_bg.wasm` inside the
tarball is byte-identical (sha256 match) to the file the build step
produced; `import('./index.mjs')` from the extracted package directory
resolves cleanly and exports `{ Embedder, embed, embedText, init, initSync
}` with no load errors. Local verification tarball was not committed and
has been discarded (`npm pack`, not `npm publish`).

<details>
<summary>Original pre-merge tarball verification + codegen differential (kept for history; superseded by the re-verification above once #900's kernels landed)</summary>

Built via `bash npm/lattice-embed-wasm/scripts/build-wasm.sh` from this
worktree, then `npm pack` (not `--dry-run`) inside `npm/lattice-embed-wasm/`:

```
npm notice 📦  @khive-ai/lattice-embed-wasm@0.6.1
npm notice Tarball Contents
npm notice 8.9kB README.md
npm notice 6.5kB index.mjs
npm notice 1.3kB package.json
npm notice 6.2kB registry.mjs
npm notice 8.9kB resolve.mjs
npm notice 347.5kB wasm/lattice_embed_bg.wasm
npm notice 949B wasm/lattice_embed_bg.wasm.d.ts
npm notice 3.9kB wasm/lattice_embed.d.ts
npm notice 12.3kB wasm/lattice_embed.js
npm notice Tarball Details
npm notice name: @khive-ai/lattice-embed-wasm
npm notice version: 0.6.1
npm notice filename: khive-ai-lattice-embed-wasm-0.6.1.tgz
npm notice package size: 151.6 kB
npm notice unpacked size: 396.4 kB
npm notice total files: 9
```

**SIMD128 codegen check** (differential, same method this repo's own
debugging conventions use): built the identical crate/target/features a
second time into a scratch `CARGO_TARGET_DIR` *without* the new
`RUSTFLAGS`, then compared the raw (pre-`wasm-bindgen`) `.wasm` binaries.
The `0xFD` byte is the SIMD-instruction-prefix opcode in the WebAssembly
binary encoding (every `v128.*` op is prefixed with it):

| build | raw `.wasm` size | `0xFD` prefix count |
|---|---:|---:|
| baseline (no `RUSTFLAGS`) | 632,064 B | 177 |
| `RUSTFLAGS="-C target-feature=+simd128"` | 626,637 B | 1,833 |

At the time this table was measured, `main` did not yet contain #900's
explicit kernels, so this differential only demonstrated LLVM
auto-vectorization under the flag, not the hand-tuned kernel paths. The
re-verification above (dispatch-state assertion + 15,668-check parity gate
against the merged state) supersedes this as proof of what actually ships
now.

</details>

## Dependency / publish order (original gating; both items now met — see Status section above)

This PR only touches packaging plumbing under `npm/lattice-embed-wasm/`;
it does not touch `crates/embed/src/`. Two things gated an actual npm
publish of this refresh, in order, both now merged to `main`:

1. ~~**crates.io v0.6.1** must ship first~~ — shipped.
2. ~~**The wasm32 SIMD128 kernels themselves** must land on `main`~~ —
   landed via #900.

**Do not `npm publish` this refresh until an orchestrator/maintainer
explicitly does so** — this PR still does not publish; see "What was NOT
done" below, unchanged.

## What was NOT done

- No npm publish, no `npm dist-tag`/`ready` changes, no CI trigger.
- No change to `npm/lattice-embed-native` (out of scope; this PR is the
  wasm channel only).
- No change to `crates/embed/src/` in this PR's own diff — the SIMD128
  kernel code lives in #900, already merged to `main` and brought into
  this branch via the merge commit above; this PR's own diff still only
  wires the build flag + docs.

Co-Authored-By: Leo <noreply@khive.ai>

