### PR TITLE
feat(inference): offline MoE cache-admission policy simulator (#682 stage 3)

### DIFF
--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -88,6 +88,10 @@ name = "quantize_q4"
 path = "src/bin/quantize_q4.rs"
 
 [[bin]]
+name = "moe_admission_sim"
+path = "src/bin/moe_admission_sim.rs"
+
+[[bin]]
 name = "chat_metal"
 path = "src/bin/chat_metal.rs"
 required-features = ["f16", "metal-gpu"]

--- a/crates/inference/src/bin/moe_admission_sim.rs
+++ b/crates/inference/src/bin/moe_admission_sim.rs
@@ -1,0 +1,189 @@
+//! Offline MoE expert-cache admission-policy simulator (issue #682 Stage 3).
+//!
+//! Thin CLI wrapper around [`lattice_inference::moe_admission`] — see that
+//! module's doc comment for the full design rationale (why this exists, the
+//! trace format, and the fidelity notes for each policy). This binary only
+//! parses arguments, reads the trace file, and prints the report; all
+//! simulation logic lives in the library module so it is covered by
+//! `cargo test -p lattice-inference --lib`.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --bin moe_admission_sim -- \
+//!   --trace routing_trace.jsonl \
+//!   --num-slots 32 \
+//!   --top-k 8 \
+//!   [--window 8] \
+//!   [--json-out report.json]
+//! ```
+
+use lattice_inference::moe_admission::{
+    PolicySpec, SimConfig, format_table, group_by_layer, read_trace, run_simulation,
+};
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+fn print_usage_and_exit() -> ! {
+    eprintln!(
+        "moe_admission_sim: replay a JSONL MoE routing trace against the shipped LRU \
+         expert-cache policy and challenger admission policies (issue #682 Stage 3)\n\n\
+         Usage:\n\
+         \x20 moe_admission_sim --trace <path.jsonl> --num-slots <N> --top-k <K> \
+         [--window <W>] [--json-out <path>]\n\n\
+         Options:\n\
+         \x20 --trace <path>      JSONL routing trace: one {{layer_idx, token_idx, \
+         selected_ids, gate_weights}} object per line (required)\n\
+         \x20 --num-slots <N>     per-layer cache capacity in expert slots (required)\n\
+         \x20 --top-k <K>         experts selected per token; N must be >= K (required)\n\
+         \x20 --window <W>        freq-admission sliding-window size (default 8)\n\
+         \x20 --json-out <path>   also write the full report as JSON to this path"
+    );
+    std::process::exit(1);
+}
+
+struct Args {
+    trace: PathBuf,
+    num_slots: usize,
+    top_k: usize,
+    window: usize,
+    json_out: Option<PathBuf>,
+}
+
+fn parse_args() -> Args {
+    let raw: Vec<String> = std::env::args().collect();
+    let mut trace: Option<PathBuf> = None;
+    let mut num_slots: Option<usize> = None;
+    let mut top_k: Option<usize> = None;
+    let mut window: usize = 8;
+    let mut json_out: Option<PathBuf> = None;
+
+    let mut i = 1;
+    while i < raw.len() {
+        match raw[i].as_str() {
+            "--trace" => {
+                i += 1;
+                trace = Some(PathBuf::from(raw.get(i).unwrap_or_else(|| {
+                    eprintln!("--trace requires an argument");
+                    print_usage_and_exit();
+                })));
+            }
+            "--num-slots" => {
+                i += 1;
+                num_slots = Some(parse_usize_arg("--num-slots", raw.get(i)));
+            }
+            "--top-k" => {
+                i += 1;
+                top_k = Some(parse_usize_arg("--top-k", raw.get(i)));
+            }
+            "--window" => {
+                i += 1;
+                window = parse_usize_arg("--window", raw.get(i));
+            }
+            "--json-out" => {
+                i += 1;
+                json_out = Some(PathBuf::from(raw.get(i).unwrap_or_else(|| {
+                    eprintln!("--json-out requires an argument");
+                    print_usage_and_exit();
+                })));
+            }
+            "-h" | "--help" => print_usage_and_exit(),
+            other => {
+                eprintln!("Unknown argument: {other}");
+                print_usage_and_exit();
+            }
+        }
+        i += 1;
+    }
+
+    let trace = trace.unwrap_or_else(|| {
+        eprintln!("--trace is required");
+        print_usage_and_exit();
+    });
+    let num_slots = num_slots.unwrap_or_else(|| {
+        eprintln!("--num-slots is required");
+        print_usage_and_exit();
+    });
+    let top_k = top_k.unwrap_or_else(|| {
+        eprintln!("--top-k is required");
+        print_usage_and_exit();
+    });
+
+    Args {
+        trace,
+        num_slots,
+        top_k,
+        window,
+        json_out,
+    }
+}
+
+fn parse_usize_arg(flag: &str, raw: Option<&String>) -> usize {
+    let raw = raw.unwrap_or_else(|| {
+        eprintln!("{flag} requires an argument");
+        print_usage_and_exit();
+    });
+    raw.parse::<usize>().unwrap_or_else(|e| {
+        eprintln!("{flag}={raw:?} is not a valid non-negative integer: {e}");
+        print_usage_and_exit();
+    })
+}
+
+fn main() {
+    let args = parse_args();
+
+    let file = File::open(&args.trace).unwrap_or_else(|e| {
+        eprintln!("failed to open trace {}: {e}", args.trace.display());
+        std::process::exit(1);
+    });
+    let records = read_trace(BufReader::new(file)).unwrap_or_else(|e| {
+        eprintln!("failed to parse trace {}: {e}", args.trace.display());
+        std::process::exit(1);
+    });
+    if records.is_empty() {
+        eprintln!("trace {} contains zero records", args.trace.display());
+        std::process::exit(1);
+    }
+    let num_records = records.len();
+    let layers = group_by_layer(records);
+    eprintln!(
+        "[moe_admission_sim] loaded {num_records} records across {} layers from {}",
+        layers.len(),
+        args.trace.display()
+    );
+
+    let cfg = SimConfig {
+        num_slots: args.num_slots,
+        top_k: args.top_k,
+    };
+    let policies = vec![
+        PolicySpec::Lru,
+        PolicySpec::Arc,
+        PolicySpec::FreqAdmission {
+            window: args.window,
+        },
+    ];
+
+    let reports = run_simulation(&layers, &cfg, &policies).unwrap_or_else(|e| {
+        eprintln!("simulation failed: {e}");
+        std::process::exit(1);
+    });
+
+    println!("{}", format_table(&reports));
+
+    if let Some(json_path) = &args.json_out {
+        let json = serde_json::to_string_pretty(&reports).unwrap_or_else(|e| {
+            eprintln!("failed to serialize report to JSON: {e}");
+            std::process::exit(1);
+        });
+        std::fs::write(json_path, json).unwrap_or_else(|e| {
+            eprintln!("failed to write {}: {e}", json_path.display());
+            std::process::exit(1);
+        });
+        eprintln!(
+            "[moe_admission_sim] wrote JSON report to {}",
+            json_path.display()
+        );
+    }
+}

--- a/crates/inference/src/lib.rs
+++ b/crates/inference/src/lib.rs
@@ -73,6 +73,12 @@ pub mod metrics;
 /// Requires the `mixture` feature.
 #[cfg(feature = "mixture")]
 pub mod mixture;
+/// Offline MoE expert-cache admission-policy simulator (issue #682 Stage 3):
+/// replays a JSONL routing trace against [`forward::moe_expert_cache`]'s
+/// shipped LRU policy plus challenger policies (ARC, sequence-local
+/// frequency admission) to measure hit-rate deltas before any engine
+/// eviction-policy change. See [`moe_admission`]'s module doc comment.
+pub mod moe_admission;
 /// Embedding pooling helpers (mean, CLS, last-token) including [`BertPooling`]. Used by
 /// [`model::BertModel`] and [`model::QwenModel`].
 pub mod pool;

--- a/crates/inference/src/moe_admission.rs
+++ b/crates/inference/src/moe_admission.rs
@@ -45,11 +45,18 @@
 //! [`LruPolicy`] mirrors [`crate::forward::moe_expert_cache::ExpertSlotCache`]'s
 //! `touch`/`pick_eviction_slot` order exactly, including the within-token
 //! "never evict a slot touched earlier this token" guard (moe_expert_cache.rs
-//! `pick_eviction_slot`, `touch`, `plan_prefetch`). [`ArcPolicy`] and
-//! [`FreqAdmissionPolicy`] do not implement that guard — see their doc
-//! comments for why real per-token `selected_ids` (duplicate-free top-k
-//! routing output) never exercises it, so its absence does not bias the
-//! hit-rate comparison against the baseline.
+//! `pick_eviction_slot`, `touch`, `plan_prefetch`). That guard protects
+//! EVERY slot resolved earlier in the current token, not only literal
+//! duplicate ids — production's `resolve` sets the touched flag on every
+//! slot it touches, hit or miss, and `pick_eviction_slot` only ever selects
+//! an untouched one (`moe_expert_cache.rs:47`-`58`, `887`-`912`). [`ArcPolicy`]
+//! implements the equivalent token-local protection via
+//! `protected_this_token` (see its doc comment). [`FreqAdmissionPolicy`]
+//! needs no explicit guard — see its doc comment for the structural proof —
+//! but both were audited against this invariant, not assumed safe because
+//! `selected_ids` is duplicate-free (duplicate-freedom was never the
+//! relevant property: evicting a *different* id touched earlier the same
+//! token is just as physically unreachable as evicting a literal repeat).
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::BufRead;
@@ -272,17 +279,22 @@ impl AdmissionPolicy for LruPolicy {
 /// literature credits for beating bare LRU under bursty expert reuse
 /// (e.g. a small hot expert set interleaved with a long one-off scan).
 ///
-/// No same-token eviction guard (contrast [`LruPolicy`]): a token's
-/// `selected_ids` never contains a duplicate — the real router's top-k
-/// selection is duplicate-free (see `moe_expert_cache.rs`'s
-/// `plan_prefetch` doc comment) — so no policy here is ever asked to
-/// resolve the same id twice within one `begin_token` window, and the
-/// GPU-buffer-lifetime hazard the guard exists for (evicting a slot a
-/// still-open command buffer references) cannot arise without a same-token
-/// repeat. A future engine implementation of ARC would still need its own
-/// guard analogous to `LruPolicy`'s; this simulator scores achievable hit
-/// rate over the real per-token id sequence, not the exact eviction
-/// bookkeeping a production implementation would additionally need.
+/// Same-token eviction guard, analogous to [`LruPolicy`]'s: `access`
+/// records every id it resolves (hit or miss) into `protected_this_token`,
+/// cleared each `begin_token`. Eviction victim selection (in `replace` and
+/// Case IV's direct `t1` discard) skips protected ids — a token resolved
+/// earlier THIS token must not be evicted before the token boundary,
+/// exactly as production requires (see the module doc comment and
+/// `moe_expert_cache.rs:47`-`58`, `887`-`912`). With `capacity >= top_k`
+/// (validated by `run_simulation`), an unprotected resident always exists
+/// when eviction is needed: a token touches at most `top_k` distinct ids,
+/// so at most `top_k - 1` residents can be protected by the time the next
+/// one needs room. ARC's `p`-adaptive target still picks WHICH list
+/// (`t1`/`t2`) to prefer evicting from; the guard only constrains WHICH
+/// resident within that choice, falling back to the other list if the
+/// preferred one is fully protected — the physical slot has to come from
+/// somewhere, and which ghost list absorbs it is a secondary adaptation
+/// detail, not a correctness requirement.
 pub struct ArcPolicy {
     capacity: usize,
     p: usize,
@@ -291,6 +303,9 @@ pub struct ArcPolicy {
     b1: VecDeque<usize>,
     b2: VecDeque<usize>,
     evictions: usize,
+    /// Ids resolved earlier in the current token — see the struct doc
+    /// comment. Cleared by `begin_token`.
+    protected_this_token: HashSet<usize>,
 }
 
 impl ArcPolicy {
@@ -304,6 +319,7 @@ impl ArcPolicy {
             b1: VecDeque::new(),
             b2: VecDeque::new(),
             evictions: 0,
+            protected_this_token: HashSet::new(),
         }
     }
 
@@ -323,22 +339,53 @@ impl ArcPolicy {
         }
     }
 
+    /// Remove and return the oldest (front-most) id in `list` that is NOT
+    /// in `protected` — the LRU-among-unprotected victim. `None` if every
+    /// id in `list` is protected this token.
+    fn evict_unprotected_from(
+        list: &mut VecDeque<usize>,
+        protected: &HashSet<usize>,
+    ) -> Option<usize> {
+        let pos = list.iter().position(|id| !protected.contains(id))?;
+        list.remove(pos)
+    }
+
     /// REPLACE(x, p): evict one resident id from `t1` or `t2` into the
     /// corresponding ghost list, per the ARC paper's rule — prefer
     /// evicting from `t1` when it exceeds its adaptive target `p` (or sits
     /// exactly at `p` and the id that triggered this REPLACE call came
-    /// from `b2`), otherwise evict from `t2`.
+    /// from `b2`), otherwise evict from `t2`. The victim is additionally
+    /// constrained to ids not in `protected_this_token` (see the struct
+    /// doc comment); if the ARC-preferred list has no unprotected
+    /// candidate, fall back to the other resident list before giving up.
     fn replace(&mut self, triggered_by_b2_hit: bool) {
         let evict_from_t1 = !self.t1.is_empty()
             && (self.t1.len() > self.p || (triggered_by_b2_hit && self.t1.len() == self.p));
-        if evict_from_t1 {
-            if let Some(y) = self.t1.pop_front() {
-                self.b2_or_b1_push(true, y);
+        let victim = if evict_from_t1 {
+            Self::evict_unprotected_from(&mut self.t1, &self.protected_this_token)
+                .map(|y| (y, true))
+                .or_else(|| {
+                    Self::evict_unprotected_from(&mut self.t2, &self.protected_this_token)
+                        .map(|y| (y, false))
+                })
+        } else {
+            Self::evict_unprotected_from(&mut self.t2, &self.protected_this_token)
+                .map(|y| (y, false))
+                .or_else(|| {
+                    Self::evict_unprotected_from(&mut self.t1, &self.protected_this_token)
+                        .map(|y| (y, true))
+                })
+        };
+        match victim {
+            Some((y, from_t1)) => {
+                self.b2_or_b1_push(from_t1, y);
                 self.evictions += 1;
             }
-        } else if let Some(y) = self.t2.pop_front() {
-            self.b2_or_b1_push(false, y);
-            self.evictions += 1;
+            None => panic!(
+                "ArcPolicy::replace: no unprotected resident available for eviction — \
+                 indicates capacity < top_k (should have been rejected by \
+                 run_simulation) or a bug in protected_this_token bookkeeping"
+            ),
         }
     }
 
@@ -356,10 +403,19 @@ impl AdmissionPolicy for ArcPolicy {
         "arc"
     }
 
-    fn begin_token(&mut self) {}
+    fn begin_token(&mut self) {
+        self.protected_this_token.clear();
+    }
 
     fn access(&mut self, x: usize) -> AccessOutcome {
         let c = self.capacity;
+        // Mark x protected from eviction by any LATER access in this same
+        // token, mirroring production's `resolve` setting the touched
+        // flag on every slot it touches, hit or miss (see struct doc
+        // comment). x itself is never a candidate for eviction within
+        // this call — it is not yet resident in t1/t2 at this point on
+        // any path that evicts something to make room for it.
+        self.protected_this_token.insert(x);
 
         // Case I: cache hit.
         if Self::remove_from(&mut self.t1, x) {
@@ -402,8 +458,15 @@ impl AdmissionPolicy for ArcPolicy {
             if self.t1.len() < c {
                 self.b1.pop_front();
                 self.replace(false);
-            } else if self.t1.pop_front().is_some() {
-                self.evictions += 1;
+            } else {
+                match Self::evict_unprotected_from(&mut self.t1, &self.protected_this_token) {
+                    Some(_) => self.evictions += 1,
+                    None => panic!(
+                        "ArcPolicy Case IV: t1 full at capacity with b1 empty, but every \
+                         resident id is protected this token — indicates capacity < \
+                         top_k (should have been rejected by run_simulation)"
+                    ),
+                }
             }
         } else if t1_b1 < c {
             let total = self.t1.len() + self.t2.len() + self.b1.len() + self.b2.len();
@@ -437,9 +500,17 @@ impl AdmissionPolicy for ArcPolicy {
 /// literature (e.g. HOBBIT, ProMoE) motivates as a low-overhead
 /// alternative to full ARC.
 ///
-/// No same-token eviction guard, for the same reason as [`ArcPolicy`] (see
-/// its doc comment): real per-token `selected_ids` never repeats an id
-/// within one token.
+/// No explicit same-token eviction guard is needed, unlike [`ArcPolicy`].
+/// `admit`'s only eviction path is `self.lru.pop_front()`, and every
+/// successful `access` (hit or admission) moves that id to the back of
+/// `self.lru` before returning — so an id touched earlier in the current
+/// token is always more-recently-touched than any not-yet-touched id, and
+/// can only become the front-of-queue victim if it is the cache's ONLY
+/// resident (`capacity == 1`). A token with more than one distinct
+/// selected id requires `capacity > 1` (`run_simulation` validates
+/// `capacity (num_slots) >= top_k`), so that degenerate case cannot occur
+/// for a multi-id token. See `freq_admission_never_evicts_a_same_token_touched_id_without_an_explicit_guard`
+/// for the proof trace.
 pub struct FreqAdmissionPolicy {
     capacity: usize,
     window: usize,
@@ -497,10 +568,15 @@ impl AdmissionPolicy for FreqAdmissionPolicy {
             self.touch_lru(id);
             return AccessOutcome::Hit;
         }
+        // Strict `<`, not `<=`: a `window`-access sliding window ending at
+        // the current position `pos` covers positions
+        // `[pos - window + 1, pos]`, i.e. `pos - prev < window`. A prior
+        // touch exactly `window` positions back sits one position outside
+        // that range.
         let eligible = self
             .last_seen_pos
             .get(&id)
-            .is_some_and(|&prev| self.pos - prev <= self.window);
+            .is_some_and(|&prev| self.pos - prev < self.window);
         self.last_seen_pos.insert(id, self.pos);
         if eligible {
             self.admit(id);
@@ -519,9 +595,14 @@ impl AdmissionPolicy for FreqAdmissionPolicy {
 
 /// Named policy constructor — how the driver enumerates the baseline plus
 /// challenger policies (issue #682 Stage 3 item 3), each rebuilt fresh per
-/// layer (mirroring the real engine's one `ExpertSlotCache` instance per
-/// (layer, gate_up|down) tensor — no cross-layer cache sharing). Adding a
-/// new challenger is one new variant plus one `AdmissionPolicy` impl.
+/// layer — no cross-layer cache sharing. This models ONE logical
+/// (layer, tensor) cache per layer, NOT the two physical
+/// `ExpertSlotCache` instances (gate_up and down) production actually
+/// runs per MoE layer (`metal_qwen35.rs` constructs both with the same
+/// `num_slots` and plans both against the same `selected` id sequence —
+/// see [`LayerStats`]'s doc comment for what this means for reported raw
+/// counts). Adding a new challenger is one new variant plus one
+/// `AdmissionPolicy` impl.
 #[derive(Debug, Clone)]
 pub enum PolicySpec {
     Lru,
@@ -555,6 +636,19 @@ impl PolicySpec {
 
 /// Hit/miss/eviction tally for one policy over one layer's (or the whole
 /// trace's) accesses.
+///
+/// **These counts are per single LOGICAL (layer, tensor) cache, not
+/// physical runtime events.** Production instantiates two `ExpertSlotCache`
+/// instances per MoE layer (gate_up and down) and replays the same
+/// selected-expert id sequence into both (`metal_qwen35.rs`'s
+/// `encode_moe_ffn`), so each miss and eviction reported here happens
+/// TWICE physically — once per tensor — with identical resident histories
+/// in both (same ids, same order, same `num_slots`). `hit_rate` and
+/// `delta_vs_baseline_pp` are unaffected by this (both tensors compute the
+/// same ratio); only the raw `hits`/`misses`/`evictions` integers
+/// understate physical dequant/eviction event counts by 2x. Multiply by 2
+/// for physical totals, or treat these as the logical/representative
+/// count they are.
 #[derive(Debug, Clone, Copy, Default, Serialize)]
 pub struct LayerStats {
     pub hits: usize,
@@ -630,12 +724,44 @@ pub fn run_simulation(
     cfg: &SimConfig,
     policies: &[PolicySpec],
 ) -> Result<Vec<PolicyReport>, String> {
+    // Fail closed on zero-valued sizing inputs BEFORE any policy is
+    // constructed — `LruPolicy::new`/`ArcPolicy::new`/
+    // `FreqAdmissionPolicy::new` assert `capacity/window > 0` and will
+    // panic on these, which is fine as an internal invariant but wrong as
+    // the response to an ordinary bad CLI argument (e.g. `--num-slots 0`
+    // or `--window 0`). Checked here, not just in the CLI, so it is
+    // covered by `cargo test -p lattice-inference --lib` directly.
+    if cfg.num_slots == 0 {
+        return Err(
+            "num_slots must be > 0 — a zero-capacity cache cannot hold any \
+                     expert"
+                .to_string(),
+        );
+    }
+    if cfg.top_k == 0 {
+        return Err(
+            "top_k must be > 0 — a token that selects zero experts is not a \
+                     valid MoE routing trace"
+                .to_string(),
+        );
+    }
     if cfg.num_slots < cfg.top_k {
         return Err(format!(
             "num_slots ({}) must be >= top_k ({}) — mirrors moe_expert_cache_num_slots's \
              validated invariant; a smaller cache cannot serve one token's routed-expert set",
             cfg.num_slots, cfg.top_k
         ));
+    }
+    for spec in policies {
+        if let PolicySpec::FreqAdmission { window } = spec
+            && *window == 0
+        {
+            return Err(
+                "freq-admission window must be > 0 — a zero-width sliding window can \
+                 never observe a repeat touch"
+                    .to_string(),
+            );
+        }
     }
     if !policies.iter().any(PolicySpec::is_baseline) {
         return Err("policies must include PolicySpec::Lru as the baseline".to_string());
@@ -695,6 +821,13 @@ pub fn run_simulation(
 pub fn format_table(reports: &[PolicyReport]) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "NOTE: hits/misses/evictions are per single LOGICAL (layer, tensor) cache. \
+         Production runs TWO such caches per MoE layer (gate_up + down) replaying the \
+         same selected-expert sequence into both — physical event totals are these \
+         figures x2; hit_rate/delta_pp are unaffected (see LayerStats doc comment)."
+    );
     let _ = writeln!(out, "=== overall (all layers) ===");
     let _ = writeln!(
         out,
@@ -749,6 +882,11 @@ mod tests {
             gate_weights: Vec::new(),
             extra: HashMap::new(),
         }
+    }
+
+    /// `VecDeque` has no `PartialEq<Vec<_>>` impl — convert for `assert_eq!`.
+    fn dq(v: &VecDeque<usize>) -> Vec<usize> {
+        v.iter().copied().collect()
     }
 
     // -----------------------------------------------------------------
@@ -955,17 +1093,174 @@ mod tests {
     fn arc_never_exceeds_capacity() {
         let capacity = 3;
         let mut arc = ArcPolicy::new(capacity);
-        // Mixed pattern: repeats, one-offs, and ghost-list churn.
+        // Mixed pattern: repeats, one-offs, and ghost-list churn. One id
+        // per token (begin_token before each) — isolates ARC's ordinary
+        // per-request adaptation from the same-token protection guard
+        // exercised separately below.
         let ids = [
             1, 2, 3, 4, 1, 5, 2, 6, 7, 1, 8, 9, 2, 10, 1, 2, 3, 11, 12, 13,
         ];
         for &id in &ids {
+            arc.begin_token();
             arc.access(id);
             assert!(
                 arc.resident_len() <= capacity,
                 "resident count exceeded capacity after accessing {id}"
             );
         }
+    }
+
+    // -----------------------------------------------------------------
+    // BLOCKER regression (review round 1, finding 1): ArcPolicy must not
+    // evict an id resolved earlier in the SAME token. Replays the exact
+    // three-token scenario from the review verdict.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn arc_never_evicts_a_same_token_touched_id() {
+        // capacity = top_k = 2. Token 0 fills t1 = [X, Y] (both cold).
+        // Token 1 re-touches both, promoting them to t2 (p stays 0,
+        // t2 = [X, Y] — Case I hits on both). Token 2 is the hazard: A is
+        // a total miss (Case IV) that evicts an unprotected t2 resident
+        // and lands in t1; B, in the SAME token as A, is also a total
+        // miss — ARC's ordinary per-request algorithm alone would pick
+        // A (t1's sole, and therefore LRU, resident) as B's eviction
+        // victim, which production physically cannot survive: a token's
+        // forward pass encodes every routed expert's GEMV into ONE Metal
+        // command buffer before committing (module doc comment;
+        // moe_expert_cache.rs:47-58, 887-912).
+        let capacity = 2;
+        let mut arc = ArcPolicy::new(capacity);
+        let (x, y, a, b) = (10usize, 20usize, 30usize, 40usize);
+        use AccessOutcome::{Hit, Miss};
+
+        arc.begin_token();
+        assert_eq!(arc.access(x), Miss);
+        assert_eq!(arc.access(y), Miss);
+        assert_eq!(dq(&arc.t1), vec![x, y]);
+
+        arc.begin_token();
+        assert_eq!(arc.access(x), Hit);
+        assert_eq!(arc.access(y), Hit);
+        assert!(
+            arc.t1.is_empty(),
+            "both promoted out of t1 by their 2nd touch"
+        );
+        assert_eq!(
+            dq(&arc.t2),
+            vec![x, y],
+            "both promoted to t2 (frequency-protected)"
+        );
+
+        arc.begin_token();
+        assert_eq!(arc.access(a), Miss);
+        assert_eq!(arc.access(b), Miss);
+        assert_eq!(
+            dq(&arc.t1),
+            vec![a, b],
+            "A must survive B's SAME-token admission — production cannot evict a slot \
+             resolved earlier this token"
+        );
+        assert!(arc.t2.is_empty());
+        assert_eq!(arc.evictions(), 2, "X and Y evicted from t2, not A");
+
+        // Physically-achievable next-token outcome: both A and B, having
+        // survived their shared token, are ordinary cache hits.
+        arc.begin_token();
+        assert_eq!(arc.access(a), Hit);
+        assert_eq!(arc.access(b), Hit);
+    }
+
+    // -----------------------------------------------------------------
+    // Finding 5: hand-computed ARC B1/B2 ghost-hit adaptation trace,
+    // asserting p, T1/T2/B1/B2 contents, and victim choice at each step —
+    // not just the resident-capacity invariant `arc_never_exceeds_capacity`
+    // checks (which a sign-flipped or victim-swapped adaptation could
+    // still satisfy).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn arc_ghost_hit_adaptation_hand_computed() {
+        // capacity=2. One access per token (begin_token before each) —
+        // orthogonal to the same-token guard above; isolates ARC's
+        // ordinary Case I-IV adaptation logic.
+        let capacity = 2;
+        let mut arc = ArcPolicy::new(capacity);
+        use AccessOutcome::{Hit, Miss};
+
+        // t1=[1] (cold miss).
+        arc.begin_token();
+        assert_eq!(arc.access(1), Miss);
+        assert_eq!(dq(&arc.t1), vec![1]);
+
+        // t1=[1,2] (cold miss, cache now full).
+        arc.begin_token();
+        assert_eq!(arc.access(2), Miss);
+        assert_eq!(dq(&arc.t1), vec![1, 2]);
+
+        // Case I (t1 hit): 1 promoted to t2. t1=[2], t2=[1].
+        arc.begin_token();
+        assert_eq!(arc.access(1), Hit);
+        assert_eq!(dq(&arc.t1), vec![2]);
+        assert_eq!(dq(&arc.t2), vec![1]);
+
+        // Case IV (t1_b1 < c, total == c): evicts 2 (t1's only resident)
+        // into b1. t1=[3], t2=[1], b1=[2]. p unchanged by this branch.
+        arc.begin_token();
+        assert_eq!(arc.access(3), Miss);
+        assert_eq!(dq(&arc.t1), vec![3]);
+        assert_eq!(dq(&arc.t2), vec![1]);
+        assert_eq!(dq(&arc.b1), vec![2]);
+        assert_eq!(arc.evictions(), 1);
+        assert_eq!(arc.p, 0);
+
+        // Case I (t2 hit, re-promote 1): no structural change beyond Hit.
+        arc.begin_token();
+        assert_eq!(arc.access(1), Hit);
+
+        // Case II: B1 ghost hit on 2. ratio = (|b2|=0 / |b1|=1).max(1) =
+        // 1. p = (0 + 1).min(2) = 1 — B1 hit must ADAPT p UP (favor t1/
+        // recency). evict_from_t1 = t1.len()(1) > p(1)? false; tie clause
+        // needs triggered_by_b2_hit which is false here -> evict from t2
+        // instead: victim = 1 (t2's only resident) -> b2=[1]. 2 leaves
+        // b1 and is re-admitted into t2 (not t1).
+        arc.begin_token();
+        assert_eq!(arc.access(2), Miss);
+        assert_eq!(arc.p, 1, "B1 ghost hit must increase p toward t1/recency");
+        assert!(arc.b1.is_empty(), "2 must leave b1 once re-admitted");
+        assert_eq!(
+            dq(&arc.t2),
+            vec![2],
+            "2 re-admitted into t2, not t1 (ARC Case II)"
+        );
+        assert_eq!(dq(&arc.t1), vec![3], "t1 untouched by this Case II call");
+        assert_eq!(
+            dq(&arc.b2),
+            vec![1],
+            "evicted victim (1, from t2) becomes a b2 ghost"
+        );
+        assert_eq!(arc.evictions(), 2);
+
+        // Case III: B2 ghost hit on 1. ratio = (|b1|=0 / |b2|=1).max(1) =
+        // 1. p = 1.saturating_sub(1) = 0 — B2 hit must ADAPT p DOWN (favor
+        // t2/frequency). evict_from_t1 = t1.len()(1) > p(0)? true ->
+        // evict t1's only resident (3) into b1. 1 leaves b2 and is
+        // re-admitted into t2.
+        arc.begin_token();
+        assert_eq!(arc.access(1), Miss);
+        assert_eq!(arc.p, 0, "B2 ghost hit must decrease p toward t2/frequency");
+        assert!(arc.b2.is_empty(), "1 must leave b2 once re-admitted");
+        assert_eq!(dq(&arc.t2), vec![2, 1], "1 re-admitted into t2");
+        assert!(
+            arc.t1.is_empty(),
+            "t1's only resident (3) was the Case III victim"
+        );
+        assert_eq!(
+            dq(&arc.b1),
+            vec![3],
+            "evicted victim (3, from t1) becomes a b1 ghost"
+        );
+        assert_eq!(arc.evictions(), 3);
     }
 
     // -----------------------------------------------------------------
@@ -991,10 +1286,69 @@ mod tests {
         // pos=4: gap since A's last touch (pos 1) is 3 > window(2) — NOT
         // admitted, treated as a fresh first touch.
         assert_eq!(policy.access(1), Miss);
-        // pos=5: gap since pos 4 is 1 <= window(2) — admitted now.
+        // pos=5: gap since pos 4 is 1 < window(2) — admitted now.
         assert_eq!(policy.access(1), Miss);
         // pos=6: resident from the previous access — hit.
         assert_eq!(policy.access(1), Hit);
+    }
+
+    // -----------------------------------------------------------------
+    // Finding 2 regression: gap == window is OUTSIDE the sliding window
+    // (off-by-one), not the boundary-inclusive edge.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn freq_admission_gap_equal_to_window_is_not_eligible() {
+        let mut policy = FreqAdmissionPolicy::new(4, 2);
+        use AccessOutcome::{Hit, Miss};
+        assert_eq!(policy.access(1), Miss); // pos=1: A's first touch.
+        assert_eq!(policy.access(2), Miss); // pos=2: filler, unrelated id.
+        // pos=3: gap since A's pos-1 touch is exactly 2 == window. A
+        // 2-access window ending at pos 3 covers positions {2, 3};
+        // position 1 is outside it, so A must NOT be admitted here. With
+        // the old (buggy) `<=` comparator this WOULD admit A.
+        assert_eq!(policy.access(1), Miss);
+        // pos=4: if pos 3 had (incorrectly) admitted A, this would be a
+        // Hit (A already resident). It must be another Miss, proving A
+        // is still not resident after the gap==window touch.
+        assert_eq!(policy.access(1), Miss);
+        // pos=4's own gap (4-3=1 < window) DOES admit A — pos=5 confirms.
+        assert_eq!(policy.access(1), Hit);
+    }
+
+    // -----------------------------------------------------------------
+    // Finding 1 audit (per its closing instruction: "Do the same audit
+    // for every future non-LRU policy"): FreqAdmissionPolicy needs no
+    // explicit same-token guard — proof trace for the struct doc
+    // comment's claim.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn freq_admission_never_evicts_a_same_token_touched_id_without_an_explicit_guard() {
+        let capacity = 2;
+        let window = 100;
+        let records = vec![
+            record(0, 0, &[100]),      // P: first touch
+            record(0, 1, &[200]),      // Q: first touch
+            record(0, 2, &[100]),      // P: admitted
+            record(0, 3, &[200]),      // Q: admitted -> resident = {P, Q}, cache full
+            record(0, 4, &[300]),      // A: first touch
+            record(0, 5, &[400]),      // B: first touch
+            record(0, 6, &[300, 400]), // SAME token: A then B, both admitted here
+        ];
+        let mut policy = FreqAdmissionPolicy::new(capacity, window);
+        for r in &records {
+            policy.begin_token();
+            for &id in &r.selected_ids {
+                policy.access(id);
+            }
+        }
+        assert!(
+            policy.resident.contains(&300) && policy.resident.contains(&400),
+            "A (300) and B (400), both touched in the SAME final token, must both \
+             survive that token"
+        );
+        assert_eq!(policy.evictions(), 2, "P and Q evicted, not A or B");
     }
 
     #[test]
@@ -1028,6 +1382,100 @@ mod tests {
         };
         let err = run_simulation(&layers, &cfg, &[PolicySpec::Lru]).unwrap_err();
         assert!(err.contains("num_slots"), "unexpected error: {err}");
+    }
+
+    // -----------------------------------------------------------------
+    // Finding 3 regression: zero-valued sizing inputs must fail closed as
+    // an ordinary simulation error, not a policy-constructor panic.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn run_simulation_rejects_zero_num_slots() {
+        let layers = vec![(0usize, vec![record(0, 0, &[])])];
+        let cfg = SimConfig {
+            num_slots: 0,
+            top_k: 0,
+        };
+        let err = run_simulation(&layers, &cfg, &[PolicySpec::Lru]).unwrap_err();
+        assert!(err.contains("num_slots"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn run_simulation_rejects_zero_top_k() {
+        let layers = vec![(0usize, vec![record(0, 0, &[])])];
+        let cfg = SimConfig {
+            num_slots: 4,
+            top_k: 0,
+        };
+        let err = run_simulation(&layers, &cfg, &[PolicySpec::Lru]).unwrap_err();
+        assert!(err.contains("top_k"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn run_simulation_rejects_zero_num_slots_and_top_k_together() {
+        // The exact failure scenario from the review verdict: a one-record
+        // trace with `selected_ids: []` and `--num-slots 0 --top-k 0`.
+        let layers = vec![(0usize, vec![record(0, 0, &[])])];
+        let cfg = SimConfig {
+            num_slots: 0,
+            top_k: 0,
+        };
+        let err = run_simulation(&layers, &cfg, &[PolicySpec::Lru]).unwrap_err();
+        assert!(err.contains("num_slots"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn run_simulation_rejects_zero_freq_admission_window() {
+        let layers = vec![(0usize, vec![record(0, 0, &[1])])];
+        let cfg = SimConfig {
+            num_slots: 4,
+            top_k: 1,
+        };
+        let err = run_simulation(
+            &layers,
+            &cfg,
+            &[PolicySpec::Lru, PolicySpec::FreqAdmission { window: 0 }],
+        )
+        .unwrap_err();
+        assert!(err.contains("window"), "unexpected error: {err}");
+    }
+
+    // -----------------------------------------------------------------
+    // Finding 4 regression: reported raw counts are per single LOGICAL
+    // cache, not the two physical ExpertSlotCache instances (gate_up +
+    // down) production runs per layer.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn overall_stats_are_per_single_logical_cache_not_physical_two_cache_totals() {
+        // Cold one-layer, one-token, one-expert trace: production would
+        // perform this exact miss in BOTH the gate_up and down
+        // ExpertSlotCache for this layer (identical selected_ids
+        // sequence) — two physical misses. This simulator models one
+        // logical cache per layer, so it reports ONE.
+        let layers = vec![(0usize, vec![record(0, 0, &[42])])];
+        let cfg = SimConfig {
+            num_slots: 1,
+            top_k: 1,
+        };
+        let reports = run_simulation(&layers, &cfg, &[PolicySpec::Lru]).unwrap();
+        assert_eq!(
+            reports[0].overall.misses, 1,
+            "logical single-cache count, not the physical x2 production performs"
+        );
+        assert_eq!(reports[0].overall.hits, 0);
+        assert_eq!(
+            reports[0].overall.evictions, 0,
+            "first-ever access into an empty slot pool is never an eviction"
+        );
+
+        // Forced eviction: capacity=1, two distinct ids across two
+        // tokens — one logical eviction here; production performs this
+        // same eviction independently in both its gate_up and down
+        // caches (physical x2, logical x1).
+        let layers2 = vec![(0usize, vec![record(0, 0, &[1]), record(0, 1, &[2])])];
+        let reports2 = run_simulation(&layers2, &cfg, &[PolicySpec::Lru]).unwrap();
+        assert_eq!(reports2[0].overall.evictions, 1);
     }
 
     #[test]

--- a/crates/inference/src/moe_admission.rs
+++ b/crates/inference/src/moe_admission.rs
@@ -1,0 +1,1083 @@
+//! Offline MoE expert-cache admission-policy simulator (issue #682, Stage 3:
+//! "simulate admission policies against routing traces before touching the
+//! engine's cache eviction logic").
+//!
+//! ## Why this exists
+//!
+//! [`crate::forward::moe_expert_cache`] ships a single admission/eviction
+//! policy for the routed-expert dequant cache: bounded, per-(layer,
+//! gate_up|down) LRU with a within-token "touched slot" eviction guard (see
+//! that module's doc comment for the full GPU-buffer-lifetime rationale
+//! this guard exists for). Published MoE-offloading literature (Mixtral-
+//! Offloading, MoE-Infinity, AdapMoE, HOBBIT, ProMoE, ExpertFlow)
+//! consistently reports that sequence-local-frequency or ARC-style
+//! admission beats bare LRU on real routing traces. Before changing the
+//! engine's eviction policy, this module lets a routing trace (JSONL, one
+//! record per `(layer_idx, token_idx)`) be replayed offline against the
+//! CURRENT policy and a small set of challenger policies, so any policy
+//! change is justified by a measured hit-rate delta rather than intuition.
+//! The pre-registered decision gate a challenger must clear on a real trace
+//! (a >= 2.0 absolute-percentage-point overall hit-rate improvement over
+//! the baseline LRU policy; ties keep LRU) is recorded alongside this
+//! lane's synthetic-trace validation results, not in this module.
+//!
+//! This module is pure simulation: no Metal, no real weight dequant, no
+//! change to [`crate::forward::moe_expert_cache`]'s runtime behavior. It
+//! consumes only the expert *ids* a real forward pass selected, replaying
+//! them against small in-memory policy structs.
+//!
+//! ## Trace format
+//!
+//! One JSON object per line, one line per `(layer_idx, token_idx)`:
+//!
+//! ```text
+//! {"layer_idx": 3, "token_idx": 17, "selected_ids": [4, 91, 12, 200], "gate_weights": [0.31, 0.28, 0.22, 0.19]}
+//! ```
+//!
+//! `gate_weights` is read but not used by any policy here — admission
+//! decisions are id-sequence-only, matching what the engine's own LRU cache
+//! observes. Extra fields are tolerated and ignored (flattened into a
+//! discarded map) so this reader does not need to change in lockstep with
+//! the trace-collector's schema.
+//!
+//! ## Fidelity notes
+//!
+//! [`LruPolicy`] mirrors [`crate::forward::moe_expert_cache::ExpertSlotCache`]'s
+//! `touch`/`pick_eviction_slot` order exactly, including the within-token
+//! "never evict a slot touched earlier this token" guard (moe_expert_cache.rs
+//! `pick_eviction_slot`, `touch`, `plan_prefetch`). [`ArcPolicy`] and
+//! [`FreqAdmissionPolicy`] do not implement that guard — see their doc
+//! comments for why real per-token `selected_ids` (duplicate-free top-k
+//! routing output) never exercises it, so its absence does not bias the
+//! hit-rate comparison against the baseline.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::BufRead;
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Trace reading
+// ---------------------------------------------------------------------------
+
+/// One `(layer_idx, token_idx)` record from a routing trace.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TraceRecord {
+    pub layer_idx: usize,
+    pub token_idx: usize,
+    pub selected_ids: Vec<usize>,
+    #[serde(default)]
+    pub gate_weights: Vec<f32>,
+    /// Tolerates any additional fields a newer trace-collector schema adds
+    /// without breaking this reader — this reader targets exactly
+    /// `layer_idx`/`token_idx`/`selected_ids`/`gate_weights` and must not
+    /// hard-fail on extras from the sibling trace-collector lane.
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// A trace parse failure, naming the offending line.
+#[derive(Debug)]
+pub struct TraceReadError {
+    pub line_no: usize,
+    pub message: String,
+}
+
+impl std::fmt::Display for TraceReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "line {}: {}", self.line_no, self.message)
+    }
+}
+
+impl std::error::Error for TraceReadError {}
+
+/// Read a JSONL routing trace from any [`BufRead`] source. Blank lines are
+/// skipped; anything else that fails to parse as a [`TraceRecord`] is a
+/// hard error naming the offending line — a reader that silently dropped
+/// malformed rows would corrupt the temporal LRU sequence for every layer,
+/// not just the record itself.
+pub fn read_trace<R: BufRead>(reader: R) -> Result<Vec<TraceRecord>, TraceReadError> {
+    let mut records = Vec::new();
+    for (i, line) in reader.lines().enumerate() {
+        let line_no = i + 1;
+        let line = line.map_err(|e| TraceReadError {
+            line_no,
+            message: format!("I/O error: {e}"),
+        })?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let record: TraceRecord = serde_json::from_str(trimmed).map_err(|e| TraceReadError {
+            line_no,
+            message: format!("JSON parse error: {e}"),
+        })?;
+        records.push(record);
+    }
+    Ok(records)
+}
+
+/// Group trace records by `layer_idx`, sorting each layer's records by
+/// `token_idx`. Required regardless of the trace file's own on-disk order —
+/// a collector may legitimately emit token-major (every layer of token 0
+/// before any of token 1) rather than layer-major — because every policy
+/// below replays a per-layer cache strictly in token order.
+pub fn group_by_layer(records: Vec<TraceRecord>) -> Vec<(usize, Vec<TraceRecord>)> {
+    let mut by_layer: HashMap<usize, Vec<TraceRecord>> = HashMap::new();
+    for r in records {
+        by_layer.entry(r.layer_idx).or_default().push(r);
+    }
+    let mut layers: Vec<(usize, Vec<TraceRecord>)> = by_layer.into_iter().collect();
+    for (_, recs) in layers.iter_mut() {
+        recs.sort_by_key(|r| r.token_idx);
+    }
+    layers.sort_by_key(|(layer_idx, _)| *layer_idx);
+    layers
+}
+
+// ---------------------------------------------------------------------------
+// Admission policy trait
+// ---------------------------------------------------------------------------
+
+/// One access outcome the simulator's driver tallies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessOutcome {
+    Hit,
+    Miss,
+}
+
+/// A pluggable expert-cache admission/eviction policy, replayed one
+/// `(layer, token)` at a time. Each implementation models a single
+/// (layer, gate_up|down)-shaped cache of fixed `capacity` slots — see each
+/// impl's doc comment for its eviction rule. Object-safe so the simulation
+/// driver can hold policies as `Box<dyn AdmissionPolicy>`.
+pub trait AdmissionPolicy {
+    /// Human-readable policy name for reporting.
+    fn name(&self) -> &'static str;
+    /// Called once per token, before that token's `access` calls. Clears
+    /// per-token bookkeeping; a no-op for policies that don't need the
+    /// same-token eviction guard (see their doc comments).
+    fn begin_token(&mut self);
+    /// Resolve one expert id, returning whether it was already resident.
+    fn access(&mut self, expert_id: usize) -> AccessOutcome;
+    /// Cumulative count of resident-data evictions (ARC's ghost-list
+    /// pruning does not count — no resident data is discarded by it).
+    fn evictions(&self) -> usize;
+}
+
+// ---------------------------------------------------------------------------
+// Baseline: faithful LRU mirror
+// ---------------------------------------------------------------------------
+
+/// Faithful mirror of
+/// [`crate::forward::moe_expert_cache::ExpertSlotCache`]'s admission and
+/// eviction order (Stage 1, shipped): a fixed pool of `capacity` slots,
+/// each holding at most one expert id, evicted least-recently-used, with
+/// the "never evict a slot touched earlier THIS token" guard from that
+/// module's `pick_eviction_slot`/`touch` (moe_expert_cache.rs, roughly
+/// lines 887-969) — required there because the real cache's slots back
+/// live Metal buffers a single token's still-open command buffer may
+/// reference (see that module's doc comment for the full invariant).
+///
+/// Driving this policy with `access()` once per id in trace order
+/// reproduces exactly the same side effects as a `plan_prefetch` call over
+/// the same ids in the same order — `moe_expert_cache.rs`'s own doc
+/// comment for `plan_prefetch` states this equivalence explicitly — so
+/// this simulator does not need to separately model the real cache's
+/// plan/spawn/apply split.
+pub struct LruPolicy {
+    slot_owner: Vec<Option<usize>>,
+    expert_to_slot: HashMap<usize, usize>,
+    slot_touched: Vec<bool>,
+    /// Slot indices in LRU order, front = least-recently-used.
+    lru: VecDeque<usize>,
+    evictions: usize,
+}
+
+impl LruPolicy {
+    pub fn new(capacity: usize) -> Self {
+        assert!(capacity > 0, "LruPolicy requires capacity > 0");
+        Self {
+            slot_owner: vec![None; capacity],
+            expert_to_slot: HashMap::with_capacity(capacity),
+            slot_touched: vec![false; capacity],
+            lru: (0..capacity).collect(),
+            evictions: 0,
+        }
+    }
+
+    fn touch(&mut self, slot: usize) {
+        self.slot_touched[slot] = true;
+        if let Some(pos) = self.lru.iter().position(|&s| s == slot) {
+            self.lru.remove(pos);
+        }
+        self.lru.push_back(slot);
+    }
+
+    fn pick_eviction_slot(&mut self) -> usize {
+        let pos = self.lru.iter().position(|&s| !self.slot_touched[s]).expect(
+            "no untouched slot available for eviction — capacity must be >= the number of \
+                 distinct experts one token requests (mirrors moe_expert_cache_num_slots's \
+                 num_slots >= top_k invariant); this indicates a misconfigured \
+                 --num-slots/--top-k pair, not a trace problem",
+        );
+        self.lru
+            .remove(pos)
+            .expect("pos was just found via position() on this same self.lru")
+    }
+}
+
+impl AdmissionPolicy for LruPolicy {
+    fn name(&self) -> &'static str {
+        "lru (baseline)"
+    }
+
+    fn begin_token(&mut self) {
+        self.slot_touched.iter_mut().for_each(|t| *t = false);
+    }
+
+    fn access(&mut self, expert_id: usize) -> AccessOutcome {
+        if let Some(&slot) = self.expert_to_slot.get(&expert_id) {
+            self.touch(slot);
+            return AccessOutcome::Hit;
+        }
+        let slot = self.pick_eviction_slot();
+        if let Some(old_owner) = self.slot_owner[slot].take() {
+            self.expert_to_slot.remove(&old_owner);
+            self.evictions += 1;
+        }
+        self.slot_owner[slot] = Some(expert_id);
+        self.expert_to_slot.insert(expert_id, slot);
+        self.touch(slot);
+        AccessOutcome::Miss
+    }
+
+    fn evictions(&self) -> usize {
+        self.evictions
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Challenger 1: ARC (Adaptive Replacement Cache)
+// ---------------------------------------------------------------------------
+
+/// Adaptive Replacement Cache (Megiddo & Modha, FAST 2003), adapted to
+/// expert ids as the cached "pages": `t1`/`t2` are resident recency-/
+/// frequency-segmented lists (`t1.len() + t2.len() <= capacity`), `b1`/`b2`
+/// are ghost (id-only, no data) histories of ids recently evicted from
+/// `t1`/`t2`, and `p` is the adaptively-tuned target size for `t1`. A ghost
+/// hit (`b1`/`b2`) nudges `p` toward whichever list is proving more
+/// valuable, then re-admits the id directly into `t2` (frequency segment)
+/// without needing a third touch — the mechanism the MoE-offloading
+/// literature credits for beating bare LRU under bursty expert reuse
+/// (e.g. a small hot expert set interleaved with a long one-off scan).
+///
+/// No same-token eviction guard (contrast [`LruPolicy`]): a token's
+/// `selected_ids` never contains a duplicate — the real router's top-k
+/// selection is duplicate-free (see `moe_expert_cache.rs`'s
+/// `plan_prefetch` doc comment) — so no policy here is ever asked to
+/// resolve the same id twice within one `begin_token` window, and the
+/// GPU-buffer-lifetime hazard the guard exists for (evicting a slot a
+/// still-open command buffer references) cannot arise without a same-token
+/// repeat. A future engine implementation of ARC would still need its own
+/// guard analogous to `LruPolicy`'s; this simulator scores achievable hit
+/// rate over the real per-token id sequence, not the exact eviction
+/// bookkeeping a production implementation would additionally need.
+pub struct ArcPolicy {
+    capacity: usize,
+    p: usize,
+    t1: VecDeque<usize>,
+    t2: VecDeque<usize>,
+    b1: VecDeque<usize>,
+    b2: VecDeque<usize>,
+    evictions: usize,
+}
+
+impl ArcPolicy {
+    pub fn new(capacity: usize) -> Self {
+        assert!(capacity > 0, "ArcPolicy requires capacity > 0");
+        Self {
+            capacity,
+            p: 0,
+            t1: VecDeque::new(),
+            t2: VecDeque::new(),
+            b1: VecDeque::new(),
+            b2: VecDeque::new(),
+            evictions: 0,
+        }
+    }
+
+    /// Resident id count across `t1` + `t2` — must never exceed `capacity`;
+    /// exercised by the invariant test below.
+    #[cfg(test)]
+    fn resident_len(&self) -> usize {
+        self.t1.len() + self.t2.len()
+    }
+
+    fn remove_from(list: &mut VecDeque<usize>, id: usize) -> bool {
+        if let Some(pos) = list.iter().position(|&x| x == id) {
+            list.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// REPLACE(x, p): evict one resident id from `t1` or `t2` into the
+    /// corresponding ghost list, per the ARC paper's rule — prefer
+    /// evicting from `t1` when it exceeds its adaptive target `p` (or sits
+    /// exactly at `p` and the id that triggered this REPLACE call came
+    /// from `b2`), otherwise evict from `t2`.
+    fn replace(&mut self, triggered_by_b2_hit: bool) {
+        let evict_from_t1 = !self.t1.is_empty()
+            && (self.t1.len() > self.p || (triggered_by_b2_hit && self.t1.len() == self.p));
+        if evict_from_t1 {
+            if let Some(y) = self.t1.pop_front() {
+                self.b2_or_b1_push(true, y);
+                self.evictions += 1;
+            }
+        } else if let Some(y) = self.t2.pop_front() {
+            self.b2_or_b1_push(false, y);
+            self.evictions += 1;
+        }
+    }
+
+    fn b2_or_b1_push(&mut self, from_t1: bool, id: usize) {
+        if from_t1 {
+            self.b1.push_back(id);
+        } else {
+            self.b2.push_back(id);
+        }
+    }
+}
+
+impl AdmissionPolicy for ArcPolicy {
+    fn name(&self) -> &'static str {
+        "arc"
+    }
+
+    fn begin_token(&mut self) {}
+
+    fn access(&mut self, x: usize) -> AccessOutcome {
+        let c = self.capacity;
+
+        // Case I: cache hit.
+        if Self::remove_from(&mut self.t1, x) {
+            self.t2.push_back(x);
+            return AccessOutcome::Hit;
+        }
+        if self.t2.contains(&x) {
+            Self::remove_from(&mut self.t2, x);
+            self.t2.push_back(x);
+            return AccessOutcome::Hit;
+        }
+
+        // Case II: ghost hit in b1 — recency history says "admit sooner".
+        // Ratio uses |b1| INCLUDING x (matches the ARC paper's ordering:
+        // adapt p, then REPLACE, then move x out of b1) — computed before
+        // the removal below, not after.
+        if self.b1.contains(&x) {
+            let ratio = (self.b2.len() / self.b1.len().max(1)).max(1);
+            self.p = (self.p + ratio).min(c);
+            self.replace(false);
+            Self::remove_from(&mut self.b1, x);
+            self.t2.push_back(x);
+            return AccessOutcome::Miss;
+        }
+
+        // Case III: ghost hit in b2 — frequency history says "admit later".
+        // Same before-removal ratio ordering as Case II above.
+        if self.b2.contains(&x) {
+            let ratio = (self.b1.len() / self.b2.len().max(1)).max(1);
+            self.p = self.p.saturating_sub(ratio);
+            self.replace(true);
+            Self::remove_from(&mut self.b2, x);
+            self.t2.push_back(x);
+            return AccessOutcome::Miss;
+        }
+
+        // Case IV: total miss — not resident, not in either ghost list.
+        let t1_b1 = self.t1.len() + self.b1.len();
+        if t1_b1 == c {
+            if self.t1.len() < c {
+                self.b1.pop_front();
+                self.replace(false);
+            } else if self.t1.pop_front().is_some() {
+                self.evictions += 1;
+            }
+        } else if t1_b1 < c {
+            let total = self.t1.len() + self.t2.len() + self.b1.len() + self.b2.len();
+            if total >= c {
+                if total == 2 * c {
+                    self.b2.pop_front();
+                }
+                self.replace(false);
+            }
+        }
+        self.t1.push_back(x);
+        AccessOutcome::Miss
+    }
+
+    fn evictions(&self) -> usize {
+        self.evictions
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Challenger 2: sequence-local frequency admission
+// ---------------------------------------------------------------------------
+
+/// Sequence-local frequency admission: an id is only ADMITTED into the
+/// resident cache once it has been seen at least twice within a sliding
+/// window of `window` accesses (to this same per-layer policy instance).
+/// The first sighting of an id is always a miss with no cache mutation
+/// beyond recording when it was seen. Once admitted, eviction among
+/// resident ids is plain LRU. This models the cheapest form of "don't
+/// cache one-shot experts" admission filtering the MoE-offloading
+/// literature (e.g. HOBBIT, ProMoE) motivates as a low-overhead
+/// alternative to full ARC.
+///
+/// No same-token eviction guard, for the same reason as [`ArcPolicy`] (see
+/// its doc comment): real per-token `selected_ids` never repeats an id
+/// within one token.
+pub struct FreqAdmissionPolicy {
+    capacity: usize,
+    window: usize,
+    resident: HashSet<usize>,
+    lru: VecDeque<usize>,
+    last_seen_pos: HashMap<usize, usize>,
+    pos: usize,
+    evictions: usize,
+}
+
+impl FreqAdmissionPolicy {
+    pub fn new(capacity: usize, window: usize) -> Self {
+        assert!(capacity > 0, "FreqAdmissionPolicy requires capacity > 0");
+        assert!(window > 0, "FreqAdmissionPolicy requires window > 0");
+        Self {
+            capacity,
+            window,
+            resident: HashSet::with_capacity(capacity),
+            lru: VecDeque::new(),
+            last_seen_pos: HashMap::new(),
+            pos: 0,
+            evictions: 0,
+        }
+    }
+
+    fn touch_lru(&mut self, id: usize) {
+        if let Some(p) = self.lru.iter().position(|&x| x == id) {
+            self.lru.remove(p);
+        }
+        self.lru.push_back(id);
+    }
+
+    fn admit(&mut self, id: usize) {
+        if self.resident.len() >= self.capacity
+            && let Some(victim) = self.lru.pop_front()
+        {
+            self.resident.remove(&victim);
+            self.evictions += 1;
+        }
+        self.resident.insert(id);
+        self.lru.push_back(id);
+    }
+}
+
+impl AdmissionPolicy for FreqAdmissionPolicy {
+    fn name(&self) -> &'static str {
+        "freq-admission"
+    }
+
+    fn begin_token(&mut self) {}
+
+    fn access(&mut self, id: usize) -> AccessOutcome {
+        self.pos += 1;
+        if self.resident.contains(&id) {
+            self.touch_lru(id);
+            return AccessOutcome::Hit;
+        }
+        let eligible = self
+            .last_seen_pos
+            .get(&id)
+            .is_some_and(|&prev| self.pos - prev <= self.window);
+        self.last_seen_pos.insert(id, self.pos);
+        if eligible {
+            self.admit(id);
+        }
+        AccessOutcome::Miss
+    }
+
+    fn evictions(&self) -> usize {
+        self.evictions
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Policy catalog + simulation driver
+// ---------------------------------------------------------------------------
+
+/// Named policy constructor — how the driver enumerates the baseline plus
+/// challenger policies (issue #682 Stage 3 item 3), each rebuilt fresh per
+/// layer (mirroring the real engine's one `ExpertSlotCache` instance per
+/// (layer, gate_up|down) tensor — no cross-layer cache sharing). Adding a
+/// new challenger is one new variant plus one `AdmissionPolicy` impl.
+#[derive(Debug, Clone)]
+pub enum PolicySpec {
+    Lru,
+    Arc,
+    FreqAdmission { window: usize },
+}
+
+impl PolicySpec {
+    pub fn label(&self) -> String {
+        match self {
+            PolicySpec::Lru => "lru (baseline)".to_string(),
+            PolicySpec::Arc => "arc".to_string(),
+            PolicySpec::FreqAdmission { window } => format!("freq-admission(w={window})"),
+        }
+    }
+
+    pub fn build(&self, capacity: usize) -> Box<dyn AdmissionPolicy> {
+        match self {
+            PolicySpec::Lru => Box::new(LruPolicy::new(capacity)),
+            PolicySpec::Arc => Box::new(ArcPolicy::new(capacity)),
+            PolicySpec::FreqAdmission { window } => {
+                Box::new(FreqAdmissionPolicy::new(capacity, *window))
+            }
+        }
+    }
+
+    pub fn is_baseline(&self) -> bool {
+        matches!(self, PolicySpec::Lru)
+    }
+}
+
+/// Hit/miss/eviction tally for one policy over one layer's (or the whole
+/// trace's) accesses.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct LayerStats {
+    pub hits: usize,
+    pub misses: usize,
+    pub evictions: usize,
+}
+
+impl LayerStats {
+    pub fn total(&self) -> usize {
+        self.hits + self.misses
+    }
+
+    pub fn hit_rate(&self) -> f64 {
+        if self.total() == 0 {
+            0.0
+        } else {
+            self.hits as f64 / self.total() as f64
+        }
+    }
+}
+
+/// Run one policy instance over one layer's token-ordered records, calling
+/// `begin_token` once per record before that token's `access` calls — the
+/// same per-token contract [`crate::forward::moe_expert_cache::ExpertSlotCache`]
+/// requires of its own callers.
+pub fn simulate_layer(records: &[TraceRecord], policy: &mut dyn AdmissionPolicy) -> LayerStats {
+    let mut stats = LayerStats::default();
+    for record in records {
+        policy.begin_token();
+        for &id in &record.selected_ids {
+            match policy.access(id) {
+                AccessOutcome::Hit => stats.hits += 1,
+                AccessOutcome::Miss => stats.misses += 1,
+            }
+        }
+    }
+    stats.evictions = policy.evictions();
+    stats
+}
+
+/// Cache-sizing knobs for a simulation run — the CLI's `--num-slots`/
+/// `--top-k` inputs.
+#[derive(Debug, Clone, Copy)]
+pub struct SimConfig {
+    pub num_slots: usize,
+    pub top_k: usize,
+}
+
+/// One layer's stats row in a [`PolicyReport`].
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct LayerRow {
+    pub layer_idx: usize,
+    pub stats: LayerStats,
+}
+
+/// Full simulation result for one policy: an overall (all layers combined)
+/// tally, a per-layer breakdown, and the overall hit-rate delta (in
+/// percentage points) versus the baseline LRU policy.
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyReport {
+    pub policy: String,
+    pub overall: LayerStats,
+    pub per_layer: Vec<LayerRow>,
+    pub delta_vs_baseline_pp: f64,
+}
+
+/// Replay `layers` (as produced by [`group_by_layer`]) against every policy
+/// in `policies`, returning one [`PolicyReport`] per policy. `policies`
+/// MUST include [`PolicySpec::Lru`] — it is the baseline every other
+/// policy's `delta_vs_baseline_pp` is measured against.
+pub fn run_simulation(
+    layers: &[(usize, Vec<TraceRecord>)],
+    cfg: &SimConfig,
+    policies: &[PolicySpec],
+) -> Result<Vec<PolicyReport>, String> {
+    if cfg.num_slots < cfg.top_k {
+        return Err(format!(
+            "num_slots ({}) must be >= top_k ({}) — mirrors moe_expert_cache_num_slots's \
+             validated invariant; a smaller cache cannot serve one token's routed-expert set",
+            cfg.num_slots, cfg.top_k
+        ));
+    }
+    if !policies.iter().any(PolicySpec::is_baseline) {
+        return Err("policies must include PolicySpec::Lru as the baseline".to_string());
+    }
+
+    for (layer_idx, records) in layers {
+        for r in records {
+            if r.selected_ids.len() > cfg.top_k {
+                return Err(format!(
+                    "layer {layer_idx} token {}: selected_ids has {} entries, exceeds \
+                     --top-k={}",
+                    r.token_idx,
+                    r.selected_ids.len(),
+                    cfg.top_k
+                ));
+            }
+        }
+    }
+
+    let mut reports = Vec::with_capacity(policies.len());
+    let mut baseline_hit_rate = 0.0;
+
+    for spec in policies {
+        let mut overall = LayerStats::default();
+        let mut per_layer = Vec::with_capacity(layers.len());
+        for (layer_idx, records) in layers {
+            let mut policy = spec.build(cfg.num_slots);
+            let stats = simulate_layer(records, policy.as_mut());
+            overall.hits += stats.hits;
+            overall.misses += stats.misses;
+            overall.evictions += stats.evictions;
+            per_layer.push(LayerRow {
+                layer_idx: *layer_idx,
+                stats,
+            });
+        }
+        if spec.is_baseline() {
+            baseline_hit_rate = overall.hit_rate();
+        }
+        reports.push(PolicyReport {
+            policy: spec.label(),
+            overall,
+            per_layer,
+            delta_vs_baseline_pp: 0.0,
+        });
+    }
+
+    for report in reports.iter_mut() {
+        report.delta_vs_baseline_pp = (report.overall.hit_rate() - baseline_hit_rate) * 100.0;
+    }
+
+    Ok(reports)
+}
+
+/// Render `reports` as a plain-text table: an overall summary row per
+/// policy, then a per-layer breakdown.
+pub fn format_table(reports: &[PolicyReport]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "=== overall (all layers) ===");
+    let _ = writeln!(
+        out,
+        "{:<24} {:>10} {:>8} {:>8} {:>10} {:>10}",
+        "policy", "hit_rate", "hits", "misses", "evictions", "delta_pp"
+    );
+    for r in reports {
+        let _ = writeln!(
+            out,
+            "{:<24} {:>9.2}% {:>8} {:>8} {:>10} {:>+10.2}",
+            r.policy,
+            r.overall.hit_rate() * 100.0,
+            r.overall.hits,
+            r.overall.misses,
+            r.overall.evictions,
+            r.delta_vs_baseline_pp,
+        );
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(out, "=== per-layer ===");
+    let _ = writeln!(
+        out,
+        "{:<24} {:>8} {:>10} {:>8} {:>8} {:>10}",
+        "policy", "layer", "hit_rate", "hits", "misses", "evictions"
+    );
+    for r in reports {
+        for row in &r.per_layer {
+            let _ = writeln!(
+                out,
+                "{:<24} {:>8} {:>9.2}% {:>8} {:>8} {:>10}",
+                r.policy,
+                row.layer_idx,
+                row.stats.hit_rate() * 100.0,
+                row.stats.hits,
+                row.stats.misses,
+                row.stats.evictions,
+            );
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(layer_idx: usize, token_idx: usize, selected_ids: &[usize]) -> TraceRecord {
+        TraceRecord {
+            layer_idx,
+            token_idx,
+            selected_ids: selected_ids.to_vec(),
+            gate_weights: Vec::new(),
+            extra: HashMap::new(),
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Trace reading
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn reads_jsonl_and_tolerates_extra_fields() {
+        let jsonl = "\
+{\"layer_idx\": 0, \"token_idx\": 0, \"selected_ids\": [1, 2], \"gate_weights\": [0.5, 0.5]}
+
+{\"layer_idx\": 1, \"token_idx\": 0, \"selected_ids\": [3], \"gate_weights\": [1.0], \"extra_field\": \"ignored\", \"nested\": {\"a\": 1}}
+";
+        let records =
+            read_trace(jsonl.as_bytes()).expect("valid trace parses (blank line skipped)");
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].layer_idx, 0);
+        assert_eq!(records[0].selected_ids, vec![1, 2]);
+        assert_eq!(records[1].layer_idx, 1);
+        assert_eq!(records[1].selected_ids, vec![3]);
+        assert!(records[1].extra.contains_key("extra_field"));
+        assert!(records[1].extra.contains_key("nested"));
+    }
+
+    #[test]
+    fn malformed_line_errors_with_line_number() {
+        let jsonl = "{\"layer_idx\": 0, \"token_idx\": 0, \"selected_ids\": [1]}\nnot json\n";
+        let err = read_trace(jsonl.as_bytes()).expect_err("malformed second line must error");
+        assert_eq!(err.line_no, 2);
+    }
+
+    #[test]
+    fn group_by_layer_sorts_within_layer_regardless_of_file_order() {
+        // Token-major on disk (layer interleaved) — grouping must still
+        // recover strict per-layer token order.
+        let records = vec![
+            record(0, 2, &[1]),
+            record(1, 0, &[9]),
+            record(0, 0, &[1]),
+            record(1, 1, &[9]),
+            record(0, 1, &[1]),
+        ];
+        let layers = group_by_layer(records);
+        assert_eq!(layers.len(), 2);
+        assert_eq!(layers[0].0, 0);
+        let token_order: Vec<usize> = layers[0].1.iter().map(|r| r.token_idx).collect();
+        assert_eq!(token_order, vec![0, 1, 2]);
+        assert_eq!(layers[1].0, 1);
+        let token_order: Vec<usize> = layers[1].1.iter().map(|r| r.token_idx).collect();
+        assert_eq!(token_order, vec![0, 1]);
+    }
+
+    // -----------------------------------------------------------------
+    // 5(c): hand-computed LRU sequence, including the within-token
+    // touched-slot eviction guard (the exact invariant
+    // moe_expert_cache.rs's pick_eviction_slot/touch enforce).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn lru_hand_computed_hit_miss_sequence_and_within_token_touch_guard() {
+        let mut policy = LruPolicy::new(2);
+        let mut outcomes = Vec::new();
+
+        // token 0: A, B — both cold (cache starts empty).
+        policy.begin_token();
+        outcomes.push(policy.access(100)); // A
+        outcomes.push(policy.access(200)); // B
+
+        // token 1: A (hit), C (miss — evicts B, the untouched slot this
+        // token; A is protected because it was just touched this token).
+        policy.begin_token();
+        outcomes.push(policy.access(100)); // A
+        outcomes.push(policy.access(300)); // C
+
+        // token 2: B (miss — evicts A; A's "touched" protection from
+        // token 1 must NOT carry over, proving begin_token resets it per
+        // token), C (hit).
+        policy.begin_token();
+        outcomes.push(policy.access(200)); // B
+        outcomes.push(policy.access(300)); // C
+
+        use AccessOutcome::{Hit, Miss};
+        assert_eq!(
+            outcomes,
+            vec![Miss, Miss, Hit, Miss, Miss, Hit],
+            "hand-computed LRU hit/miss sequence mismatch"
+        );
+        assert_eq!(
+            policy.evictions(),
+            2,
+            "expected exactly 2 evictions (B at token 1, A at token 2)"
+        );
+    }
+
+    /// Same scenario, driven through the full `simulate_layer` +
+    /// `TraceRecord` path (not the policy directly) — proves the driver's
+    /// per-record `begin_token` wiring matches the hand trace above.
+    #[test]
+    fn simulate_layer_reproduces_hand_computed_lru_sequence() {
+        let records = vec![
+            record(0, 0, &[100, 200]),
+            record(0, 1, &[100, 300]),
+            record(0, 2, &[200, 300]),
+        ];
+        let mut policy = LruPolicy::new(2);
+        let stats = simulate_layer(&records, &mut policy);
+        assert_eq!(stats.hits, 2);
+        assert_eq!(stats.misses, 4);
+        assert_eq!(stats.evictions, 2);
+        assert!((stats.hit_rate() - (2.0 / 6.0)).abs() < 1e-9);
+    }
+
+    // -----------------------------------------------------------------
+    // 5(b): pure-LRU-friendly cyclic trace — ARC and LRU tie.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn arc_ties_lru_on_cache_resident_cyclic_pattern() {
+        let capacity = 4;
+        let records: Vec<TraceRecord> = (0..50)
+            .map(|token_idx| record(0, token_idx, &[token_idx % capacity]))
+            .collect();
+
+        let mut lru = LruPolicy::new(capacity);
+        let lru_stats = simulate_layer(&records, &mut lru);
+
+        let mut arc = ArcPolicy::new(capacity);
+        let arc_stats = simulate_layer(&records, &mut arc);
+
+        // Working set (4 distinct ids) exactly fits capacity (4): after the
+        // first full cycle, neither policy should ever evict again, so
+        // both tie exactly.
+        assert_eq!(lru_stats.evictions, 0);
+        assert_eq!(arc_stats.evictions, 0);
+        assert_eq!(lru_stats.hits, arc_stats.hits);
+        assert_eq!(lru_stats.misses, arc_stats.misses);
+        assert!((lru_stats.hit_rate() - arc_stats.hit_rate()).abs() < 1e-9);
+        // Sanity: this really is a high-hit-rate regime, not a
+        // vacuous all-miss tie.
+        assert!(lru_stats.hit_rate() > 0.8, "got {}", lru_stats.hit_rate());
+    }
+
+    // -----------------------------------------------------------------
+    // 5(a): repeat-heavy trace (hot set + polluting scan) — ARC beats LRU.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn arc_beats_lru_on_hot_set_plus_scan_pollution() {
+        let capacity = 4;
+        let hot_set = [0usize, 1usize];
+        let scan_size = 8;
+        let rounds = 30;
+
+        // Each round: touch the 2-id hot set TWICE each (back to back),
+        // then flood with `scan_size` never-repeated ids — a one-off scan
+        // long enough to fully displace a bare-LRU cache of `capacity`
+        // slots before the next round's hot-set accesses arrive. The
+        // back-to-back double touch matters: a single touch per round
+        // never gives ARC's `t1` a chance to promote a hot id into `t2`
+        // (frequency-protected) before the very next round's scan evicts
+        // it straight out of `t1` — capacity(4) is smaller than one
+        // round's non-hot traffic (scan_size=8), so a once-touched id
+        // never survives to be re-touched a round later. The immediate
+        // repeat is what lets ARC's Case I promotion (`t1` hit -> moved
+        // to `t2`) run at all; without it this test would degenerate to
+        // ARC behaving identically to bare LRU (both purely FIFO-evicting
+        // out of `t1`, no ghost-list learning ever triggered) and the
+        // assertion below would fail. top_k=1 for this synthetic trace
+        // (one id selected per token).
+        let mut records = Vec::new();
+        let mut token_idx = 0;
+        let mut next_scan_id = 1000usize;
+        for _round in 0..rounds {
+            for &hot_id in &hot_set {
+                records.push(record(0, token_idx, &[hot_id]));
+                token_idx += 1;
+            }
+            for &hot_id in &hot_set {
+                records.push(record(0, token_idx, &[hot_id]));
+                token_idx += 1;
+            }
+            for _ in 0..scan_size {
+                records.push(record(0, token_idx, &[next_scan_id]));
+                next_scan_id += 1;
+                token_idx += 1;
+            }
+        }
+
+        let mut lru = LruPolicy::new(capacity);
+        let lru_stats = simulate_layer(&records, &mut lru);
+
+        let mut arc = ArcPolicy::new(capacity);
+        let arc_stats = simulate_layer(&records, &mut arc);
+
+        assert!(
+            arc_stats.hit_rate() > lru_stats.hit_rate() + 0.02,
+            "expected ARC to beat LRU by >2pp on hot-set+scan trace: lru={:.4} arc={:.4}",
+            lru_stats.hit_rate(),
+            arc_stats.hit_rate()
+        );
+    }
+
+    #[test]
+    fn arc_never_exceeds_capacity() {
+        let capacity = 3;
+        let mut arc = ArcPolicy::new(capacity);
+        // Mixed pattern: repeats, one-offs, and ghost-list churn.
+        let ids = [
+            1, 2, 3, 4, 1, 5, 2, 6, 7, 1, 8, 9, 2, 10, 1, 2, 3, 11, 12, 13,
+        ];
+        for &id in &ids {
+            arc.access(id);
+            assert!(
+                arc.resident_len() <= capacity,
+                "resident count exceeded capacity after accessing {id}"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // FreqAdmissionPolicy
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn freq_admission_admits_on_second_touch() {
+        let mut policy = FreqAdmissionPolicy::new(4, 100);
+        use AccessOutcome::{Hit, Miss};
+        assert_eq!(policy.access(42), Miss); // 1st touch: never admitted
+        assert_eq!(policy.access(42), Miss); // 2nd touch: admits, still a miss
+        assert_eq!(policy.access(42), Hit); // 3rd touch: now resident
+    }
+
+    #[test]
+    fn freq_admission_window_expiry_resets_eligibility() {
+        let mut policy = FreqAdmissionPolicy::new(4, 2);
+        use AccessOutcome::{Hit, Miss};
+        assert_eq!(policy.access(1), Miss); // pos=1, A first touch
+        assert_eq!(policy.access(2), Miss); // pos=2, filler
+        assert_eq!(policy.access(3), Miss); // pos=3, filler
+        // pos=4: gap since A's last touch (pos 1) is 3 > window(2) — NOT
+        // admitted, treated as a fresh first touch.
+        assert_eq!(policy.access(1), Miss);
+        // pos=5: gap since pos 4 is 1 <= window(2) — admitted now.
+        assert_eq!(policy.access(1), Miss);
+        // pos=6: resident from the previous access — hit.
+        assert_eq!(policy.access(1), Hit);
+    }
+
+    #[test]
+    fn freq_admission_evicts_lru_among_admitted() {
+        let mut policy = FreqAdmissionPolicy::new(2, 100);
+        // Admit 1 and 2 (each needs 2 touches).
+        for id in [1, 2, 1, 2] {
+            policy.access(id);
+        }
+        assert_eq!(policy.evictions(), 0);
+        // Admit 3 (2 touches) — cache is full (1, 2 resident), must evict
+        // the LRU of the two: 1 was touched at pos 3 (its 2nd touch),
+        // 2 at pos 4 (its 2nd touch), so 1 is LRU.
+        policy.access(3);
+        policy.access(3);
+        assert_eq!(policy.evictions(), 1);
+        // 1 was evicted to make room for 3 — a fresh access is a miss.
+        assert_eq!(policy.access(1), AccessOutcome::Miss);
+    }
+
+    // -----------------------------------------------------------------
+    // Simulation driver / reporting
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn run_simulation_rejects_num_slots_below_top_k() {
+        let layers = vec![(0usize, vec![record(0, 0, &[1, 2, 3])])];
+        let cfg = SimConfig {
+            num_slots: 2,
+            top_k: 3,
+        };
+        let err = run_simulation(&layers, &cfg, &[PolicySpec::Lru]).unwrap_err();
+        assert!(err.contains("num_slots"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn run_simulation_rejects_missing_baseline() {
+        let layers = vec![(0usize, vec![record(0, 0, &[1])])];
+        let cfg = SimConfig {
+            num_slots: 4,
+            top_k: 1,
+        };
+        let err = run_simulation(&layers, &cfg, &[PolicySpec::Arc]).unwrap_err();
+        assert!(err.contains("baseline"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn run_simulation_rejects_selected_ids_exceeding_top_k() {
+        let layers = vec![(0usize, vec![record(0, 0, &[1, 2, 3])])];
+        let cfg = SimConfig {
+            num_slots: 4,
+            top_k: 2,
+        };
+        let err = run_simulation(&layers, &cfg, &[PolicySpec::Lru]).unwrap_err();
+        assert!(err.contains("exceeds --top-k"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn run_simulation_delta_vs_baseline_is_zero_for_baseline_itself() {
+        let layers = vec![(0usize, vec![record(0, 0, &[1, 2])])];
+        let cfg = SimConfig {
+            num_slots: 4,
+            top_k: 2,
+        };
+        let reports = run_simulation(&layers, &cfg, &[PolicySpec::Lru]).unwrap();
+        assert_eq!(reports.len(), 1);
+        assert!((reports[0].delta_vs_baseline_pp).abs() < 1e-9);
+    }
+
+    #[test]
+    fn format_table_includes_every_policy_and_layer() {
+        let layers = vec![
+            (0usize, vec![record(0, 0, &[1, 2])]),
+            (1usize, vec![record(1, 0, &[3])]),
+        ];
+        let cfg = SimConfig {
+            num_slots: 4,
+            top_k: 2,
+        };
+        let reports = run_simulation(&layers, &cfg, &[PolicySpec::Lru, PolicySpec::Arc]).unwrap();
+        let table = format_table(&reports);
+        assert!(table.contains("lru (baseline)"));
+        assert!(table.contains("arc"));
+        assert!(table.contains("layer"));
+    }
+}


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Adds an offline simulator for MoE expert-cache admission policies (issue #682, Stage 3).
The shipped Stage 1 cache (`moe_expert_cache.rs`) uses bare LRU. Published MoE-offloading
literature (Mixtral-Offloading, MoE-Infinity, AdapMoE, HOBBIT, ProMoE, ExpertFlow)
consistently reports that sequence-local-frequency or ARC-style admission beats bare LRU on
real routing traces. Before changing the engine's eviction policy, this tool lets a routing
trace be replayed offline against the current policy and challenger policies, so any future
change is justified by a measured hit-rate delta rather than intuition.

**This PR makes no change to the engine's cache behavior.** It adds a new library module
(`crates/inference/src/moe_admission.rs`) and a new binary (`moe_admission_sim`), plus the
one-line `pub mod` wire-up in `lib.rs`. No existing source file's logic changes.

## What it does

- Reads a JSONL routing trace: one `{layer_idx, token_idx, selected_ids, gate_weights}`
  record per line (extra fields tolerated/ignored, matching the sibling trace-collector
  lane's schema).
- Replays it per-layer, in token order, against three policies:
  - **`lru (baseline)`** — a faithful mirror of `ExpertSlotCache`'s shipped touch/eviction
    order, including the within-token "never evict a slot touched earlier this token" guard
    that the Metal command-buffer lifetime invariant requires.
  - **`arc`** — Adaptive Replacement Cache (Megiddo & Modha, FAST 2003), adapted to expert
    ids, with the same within-token protected-resident guard as the LRU baseline (see
    "Fix round 1" below — this was missing in the version first submitted for review).
  - **`freq-admission(w=N)`** — sequence-local frequency admission: admit on second touch
    within a sliding window of `N` accesses, LRU eviction otherwise.
- Reports hit rate (overall + per layer), evictions, and hit-rate delta vs baseline, as a
  plain table or JSON (`--json-out`). The printed table now carries an explicit `NOTE:` line
  stating the counts are per single logical (layer, tensor) cache, not physical runtime
  totals (see "Fix round 1", finding 4).
- Policies are a small trait (`AdmissionPolicy`), so adding a new challenger is one enum
  variant plus one impl.

## Fix round 1 (external review — REJECT, all 5 findings addressed)

The version first opened here got a REJECT verdict from external review. All 5 findings are
fixed in this branch's head commit. Summarized (full detail in the review + the fix commit):

1. **[BLOCKER] ARC could reach a state production cannot physically enter.** With
   `capacity = top_k = 2`, replaying `[X,Y]`, `[X,Y]`, `[A,B]` as three tokens, the old
   `replace()` could evict `A` from `T1` to admit `B` in the *same* token that had just
   admitted `A` — but a token's forward pass encodes every routed expert's GEMV into one
   Metal command buffer before committing, so the production cache protects every slot
   touched earlier in the same token, not just literal duplicate ids
   (`moe_expert_cache.rs:47-58, 887-912`). Fixed by adding a token-local
   `protected_this_token: HashSet<usize>` to `ArcPolicy`, populated on every `access()` and
   cleared on `begin_token()`, consulted by `replace()`'s victim selection (with a cross-list
   fallback between `T1`/`T2`) and by the direct Case-IV eviction path. Regression test:
   the exact three-token scenario from the review, hand-traced and asserting the
   next-token outcome is one production could actually reach.
2. **[MAJOR] Frequency-admission window was off by one.** `pos - prev <= window` admitted a
   repeat access exactly at the window boundary; the documented contract is an N-access
   sliding window, which requires strict `<`. Fixed the comparator; added the
   `gap == window` boundary regression from the review.
3. **[MAJOR] Zero-valued `--num-slots`/`--top-k`/`--window` reached a library `assert!` and
   panicked instead of failing closed as an ordinary CLI/simulation error.** `run_simulation`
   now validates all three (including the `0/0` combination from the review) before
   constructing any policy. Added one test per rejected value plus the `0/0` combination.
4. **[MEDIUM] Reported hits/misses/evictions understated physical cache events by 2x.**
   Production builds *two* `ExpertSlotCache`s per MoE layer (gate_up + down) and replays the
   same selected-id sequence into both; the simulator models one logical cache per
   (layer, tensor). `hit_rate`/`delta_vs_baseline_pp` were already correct (both tensors see
   identical resident histories), but the raw counts were not runtime totals. Documented this
   explicitly in the doc comments and in a new table `NOTE:` line; added a one-layer
   cold-miss/forced-eviction accounting test pinning the logical-count semantics.
5. **[MEDIUM] Mutation coverage didn't reach ARC's adaptation logic or the window
   boundary.** Added a hand-computed ARC trace exercising a Case II (B1 ghost hit) then
   Case III (B2 ghost hit) sequence with exact `p`/`T1`/`T2`/`B1`/`B2` assertions at each
   step, plus a same-token audit test proving `FreqAdmissionPolicy` needs no explicit guard
   (structural proof: its only eviction path is `lru.pop_front()`, and every access moves
   that id to the back, so a same-token-touched id can only be the front-of-queue victim if
   `capacity == 1` — impossible given the already-validated `num_slots >= top_k`).

All three new invariants (same-token ARC guard, ARC `p`-adaptation sign, frequency window
comparator) were mutation-tested during this fix: each fix was temporarily reverted in place,
its guarding test confirmed to fail (and *only* that test — the other 24 stayed green), then
restored and reconfirmed green.

Test count: 16 -> 25 in `moe_admission`; full `lattice-inference --lib` suite: 1756 -> 1765
passed (net +9, matching the new tests exactly), 0 failed.

## Synthetic-trace validation

No real routing trace exists yet (the collector is a sibling in-flight lane), so this PR's
evidence is synthetic-trace-only: correctness/property validation, not a policy
recommendation. 25 unit tests (`cargo test -p lattice-inference --lib moe_admission`),
including:

- A hand-computed 2-slot LRU hit/miss sequence that specifically exercises the within-token
  touched-slot eviction guard, cross-checked against the mirrored production semantics.
  Mutation-tested: swapping the eviction-order scan direction (`position` -> `rposition`)
  made this test fail; reverting restored green.
- The fix-round ARC same-token regression, ARC ghost-hit adaptation trace, frequency-window
  boundary trace, zero-sizing rejection tests, and logical-vs-physical accounting test
  described above.
- A cyclic working-set-fits-in-cache trace where ARC and LRU tie exactly (zero evictions on
  either side).
- A hot-set-plus-scan-pollution trace where ARC beats LRU by construction (the scan is long
  enough to evict a bare-LRU cache every round; ARC's frequency segment protects the hot
  set once touched twice in short succession).
- An ARC resident-count-never-exceeds-capacity invariant check over a mixed access pattern.
- `FreqAdmissionPolicy` admit-on-second-touch and sliding-window-expiry behavior.

End-to-end run against a synthetic 2-layer, 960-record trace (`--num-slots 4 --top-k 1
--window 8`, hot-set-plus-scan-pollution shape, 40 rounds/layer), **re-run against the
fix-round head commit**:

```
NOTE: hits/misses/evictions are per single LOGICAL (layer, tensor) cache. Production runs
TWO such caches per MoE layer (gate_up + down) replaying the same selected-expert sequence
into both — physical event totals are these figures x2; hit_rate/delta_pp are unaffected.
=== overall (all layers) ===
policy                     hit_rate     hits   misses  evictions   delta_pp
lru (baseline)               16.67%      160      800        792      +0.00
arc                          32.92%      316      644        636     +16.25
freq-admission(w=8)          32.50%      312      648          0     +15.83
```

**These numbers are numerically identical to the pre-fix run.** This is a genuine, verified
finding about this specific trace's topology, not an oversight: every token in this trace
selects exactly one id (`top_k=1`), so the ARC same-token guard (finding 1) never has a
second id in the same token to protect against — it is structurally unreachable on this
trace. Separately, this trace's round structure (4-access hot-set burst + 8-access scan,
`window=8`) never lands a repeat access at exactly `gap == window`, so the off-by-one fix
(finding 2) also never changes an outcome here. Both fixes are still real and are covered
directly by the new mutation-tested unit tests above, independent of this particular CLI
smoke trace's insensitivity to them — a multi-id-per-token real trace (the expected shape
once the collector lands, since production `top_k` is normally > 1) will exercise finding 1
directly.

Every number above is otherwise hand-derivable from the trace's own construction: LRU never
retains the 2-id hot set across an 8-id scan (capacity 4 < scan length 8), so it gets exactly
2 hits + 10 misses per 12-access round; freq-admission and ARC both learn the hot set after
its first round and hold it resident for the remaining 39 rounds, converging on 4 hits + 8
misses per round thereafter. This is a **synthetic property demonstration only** — real
routing traces will show a different (likely smaller) gap; see the decision gate below.

## Pre-registered decision gate (before any real-trace numbers exist)

A challenger policy justifies an engine implementation change only if, on a **real** routing
trace, it beats baseline LRU's overall hit rate by **>= 2.0 absolute percentage points**
(`delta_vs_baseline_pp` in the tool's own output). Ties or smaller deltas keep LRU —
simplicity wins ties, since Stage 1 LRU is already correct, tested, and load-bearing for the
Metal command-buffer lifetime invariant. This gate was written down before this lane ran any
real-trace replay (none exists yet) and is unaffected by the synthetic numbers above or by
the fix round.

## How to feed a real trace once the collector lands

```
cargo run --release --bin moe_admission_sim -- \
  --trace <collected_trace>.jsonl \
  --num-slots <production num_slots for that checkpoint/device> \
  --top-k <model's top_k> \
  --json-out real_trace_report.json
```

Check `delta_vs_baseline_pp` in the output against the 2.0pp gate above.

## Gates

- `cargo fmt` — clean
- `cargo clippy --workspace -- -D warnings` — clean (one `collapsible_if` fixed during
  initial development)
- `cargo test -p lattice-inference --lib` — 1765 passed, 0 failed, 18 ignored (pre-existing),
  including all 25 `moe_admission` tests (16 original + 9 from the fix round)
- `make bench-compare` — **not re-run for the fix round.** `git diff --stat` against the
  round 1 commit confirms the fix-round diff touches only `crates/inference/src/moe_admission.rs`
  (no `lib.rs`, no `Cargo.toml`); the original bench-compare trigger (the `pub mod` wire-up in
  `lib.rs`) was already satisfied and reported below from round 1, and the fix round is
  entirely additive within that already-covered, already-new module with zero engine or other
  production source touched. Full round 1 verbatim output retained below.

  **Reading the round 1 output**: the automated pass/fail step (`=== Full gate report ===`)
  itself warned `no change/estimates.json ... baseline missing` — this repo's own convention
  exports `CARGO_TARGET_DIR` to a shared location outside the worktree
  (`/Users/lion/projects/khive/.lattice-shared-target`), and `bench-compare.sh`'s gate-report
  step looks for Criterion's `change/estimates.json` under the worktree's own `target/`, so it
  never found a baseline to diff against; the base-vs-head timing runs above it completed and
  produced real numbers regardless. Those per-benchmark deltas show unusually large swings in
  both directions (some +70-80%, some -80%) across groups this diff does not touch
  (`elementwise_mul`, `simd_normalize`, and others). At measurement time this machine was
  concurrently running multiple unrelated heavy cargo jobs from other repos (`cargo test -p
  khive-query -p khive-pack-kg`, `cargo test -p khive-vamana --no-default-features`, a
  `ruvector-diskann` PQ-tuning sweep, and two other agent-driven build/test processes actively compiling/testing) —
  confirmed via `ps` during the run. That is CPU contention noise, not a regression from this
  PR: the diff adds a new module and a new binary and changes zero lines in any function this
  benchmark suite measures. Per this repo's documented quick-mode-noise precedent, reporting it
  honestly rather than re-running to make it look cleaner.

<details>
<summary>Full <code>make bench-compare</code> output from round 1 (verbatim)</summary>

```
[heavy-lane] waiting (holder: pid=3470 label=lattice:884-nll-parity since=2026-07-12 13:39:03)
[heavy-lane] acquired: lattice:682-s3-bench-r2
BENCH_GROUPS_INFERENCE="" BENCH_GROUPS_EMBED="" ./scripts/bench-compare.sh origin/main HEAD
=== bench-compare: origin/main (7c88b4b1b3) vs HEAD (fe07e80959) ===
HEAD is now at 7c88b4b1b3 refactor(inference): private weight-ingress validation seam for safetensors (#873)

--- Building + benching BASE (7c88b4b1b3) ---
rms_norm/896            time:   [137.06 ns 137.88 ns 138.09 ns]
rms_norm/4096           time:   [579.98 ns 586.53 ns 612.71 ns]
layer_norm/896          time:   [210.82 ns 212.30 ns 212.67 ns]
layer_norm/4096         time:   [1.4253 µs 1.4392 µs 1.4947 µs]
silu_inplace/896        time:   [729.76 ns 736.01 ns 761.00 ns]
silu_inplace/4096       time:   [3.6155 µs 3.6348 µs 3.7122 µs]
gelu/896                time:   [878.95 ns 907.78 ns 914.98 ns]
gelu/4096               time:   [2.6856 µs 2.8105 µs 2.8418 µs]
add_bias_gelu/896       time:   [614.97 ns 621.46 ns 647.44 ns]
add_bias_gelu/4096      time:   [2.9478 µs 2.9563 µs 2.9902 µs]
softmax_attention/128   time:   [6.2655 µs 6.5568 µs 6.6296 µs]
softmax_attention/512   time:   [117.07 µs 119.58 µs 120.21 µs]
elementwise_mul/4096    time:   [352.70 ns 380.92 ns 493.78 ns]
                        time:   [17.493 µs 19.418 µs 19.899 µs]
                        time:   [74.833 µs 75.412 µs 77.725 µs]
                        time:   [53.548 µs 53.644 µs 54.027 µs]
                        time:   [178.13 µs 180.80 µs 181.47 µs]
                        time:   [1.0951 µs 1.1170 µs 1.1225 µs]
                        time:   [38.867 ns 39.076 ns 39.915 ns]
                        time:   [2.0732 µs 2.0787 µs 2.1006 µs]
                        time:   [69.943 ns 71.512 ns 71.904 ns]
                        time:   [2.4852 µs 2.4935 µs 2.5267 µs]
                        time:   [115.23 ns 116.15 ns 119.84 ns]
                        time:   [3.8881 µs 3.9239 µs 3.9329 µs]
                        time:   [148.47 ns 151.85 ns 152.70 ns]
                        time:   [234.07 ns 234.45 ns 234.54 ns]
                        time:   [27.529 ns 27.613 ns 27.947 ns]
                        time:   [648.40 ns 678.59 ns 686.14 ns]
                        time:   [71.271 ns 74.251 ns 74.996 ns]
                        time:   [822.02 ns 823.43 ns 829.10 ns]
                        time:   [75.365 ns 75.427 ns 75.675 ns]
                        time:   [1.2816 µs 1.2850 µs 1.2989 µs]
                        time:   [143.67 ns 144.19 ns 146.30 ns]
                        time:   [376.40 ns 377.32 ns 380.99 ns]
simd_normalize/simd/384 time:   [76.831 ns 78.544 ns 78.972 ns]
                        time:   [784.71 ns 789.31 ns 790.46 ns]
simd_normalize/simd/768 time:   [139.65 ns 140.61 ns 140.85 ns]
                        time:   [1.2700 µs 1.2873 µs 1.2916 µs]
                        time:   [159.07 ns 164.26 ns 165.56 ns]
                        time:   [1.5097 µs 1.5108 µs 1.5151 µs]
                        time:   [229.24 ns 231.45 ns 240.29 ns]
                        time:   [243.82 ns 246.98 ns 247.77 ns]
                        time:   [29.649 ns 29.720 ns 30.002 ns]
                        time:   [682.46 ns 684.53 ns 692.79 ns]
                        time:   [90.016 ns 90.151 ns 90.694 ns]
                        time:   [846.72 ns 867.43 ns 872.61 ns]
                        time:   [100.44 ns 279.13 ns 323.81 ns]
                        time:   [3.7063 µs 3.8026 µs 3.8267 µs]
                        time:   [493.38 ns 497.57 ns 514.32 ns]
                        time:   [10.645 µs 11.291 µs 13.875 µs]
                        time:   [663.57 ns 795.70 ns 828.73 ns]
                        time:   [171.38 µs 173.39 µs 173.89 µs]
                        time:   [5.0687 µs 5.2895 µs 6.1725 µs]

... [946 lines omitted for GitHub's PR-body length limit — full
verbatim output was captured this run; ask in this PR's thread for the complete log if needed] ...

                        time:   [-6.2668% -3.6883% -0.9763%] (p = 0.10 > 0.05)
                        time:   [5.3936 µs 5.5235 µs 5.5560 µs]
                 change:
                        time:   [-3.1554% -1.3165% +0.5366%] (p = 0.53 > 0.05)
                        time:   [5.3301 µs 5.3355 µs 5.3569 µs]
                 change:
                        time:   [-6.2346% -5.9179% -5.6006%] (p = 0.07 > 0.05)
                        time:   [23.114 µs 23.129 µs 23.190 µs]
                 change:
                        time:   [+7.2653% +8.1942% +9.1361%] (p = 0.10 > 0.05)
                        time:   [22.417 µs 23.256 µs 26.612 µs]
                 change:
                        time:   [-4.4790% +7.2750% +19.680%] (p = 0.62 > 0.05)
                        time:   [84.976 µs 85.392 µs 87.056 µs]
                 change:
                        time:   [+1.3133% +3.2019% +5.1145%] (p = 0.13 > 0.05)
                        time:   [139.94 µs 140.41 µs 142.30 µs]
                 change:
                        time:   [+74.936% +77.296% +79.679%] (p = 0.10 > 0.05)
                        time:   [19.181 µs 19.793 µs 19.945 µs]
                 change:
                        time:   [+73.021% +76.514% +80.009%] (p = 0.08 > 0.05)
                        time:   [153.63 ns 159.02 ns 160.37 ns]
                 change:
                        time:   [+32.378% +35.899% +39.453%] (p = 0.08 > 0.05)
                        time:   [15.459 µs 15.828 µs 15.920 µs]
                 change:
                        time:   [+1.4006% +3.2679% +5.1482%] (p = 0.12 > 0.05)
                        time:   [244.41 ns 254.61 ns 257.16 ns]
                 change:
                        time:   [-0.3771% +2.6330% +5.6674%] (p = 0.53 > 0.05)
                        time:   [110.57 µs 110.62 µs 110.85 µs]
                 change:
                        time:   [-6.7850% -6.0635% -5.3327%] (p = 0.05 < 0.05)
                        time:   [1.0209 µs 1.0268 µs 1.0503 µs]
                 change:
                        time:   [+2.8280% +4.8197% +6.8311%] (p = 0.10 > 0.05)
                        time:   [153.58 µs 154.77 µs 155.07 µs]
                 change:
                        time:   [+1.7436% +2.4518% +3.1629%] (p = 0.08 > 0.05)
                        time:   [2.6216 µs 2.7193 µs 2.7437 µs]
                 change:
                        time:   [-4.6302% -1.9310% +0.7948%] (p = 0.55 > 0.05)
                        time:   [1.1106 ms 1.1117 ms 1.1159 ms]
                 change:
                        time:   [-2.0727% -0.7799% +0.5412%] (p = 0.70 > 0.05)
                        time:   [10.850 µs 10.895 µs 11.075 µs]
                 change:
                        time:   [-2.9493% -0.6699% +1.6695%] (p = 0.66 > 0.05)
                        time:   [1.5428 ms 1.5449 ms 1.5534 ms]
                 change:
                        time:   [+1.0319% +1.6986% +2.3695%] (p = 0.10 > 0.05)
                        time:   [22.884 µs 22.915 µs 23.036 µs]
                 change:
                        time:   [-0.5740% -0.0281% +0.5201%] (p = 0.86 > 0.05)

=== Full gate report ===
warn: no change/estimates.json under /Users/lion/projects/khive/lattice-682-s3/target/criterion; baseline missing?

Done. Base=origin/main (7c88b4b1b3), Head=HEAD (fe07e80959)
```

</details>

## Test plan

- [x] `cargo test -p lattice-inference --lib moe_admission` — 25/25 pass (16 original + 9 from
      the fix round)
- [x] `cargo test -p lattice-inference --lib` — full suite green (1765 passed, 0 failed)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Mutation-sensitivity proof on the LRU hand-computed test (round 1) and on all three
      fix-round invariants (ARC same-token guard, ARC `p`-adaptation sign, frequency window
      comparator) — each temporarily reverted, guarding test confirmed to fail in isolation,
      then restored and reconfirmed green
- [x] `make bench-compare` — run in round 1 (see output above); not re-run in the fix round,
      diff scope confirmed via `git diff --stat` to touch only the already-covered
      `moe_admission.rs`
- [x] End-to-end CLI run against a synthetic trace, re-run against the fix-round head commit,
      numbers hand-verified and confirmed unchanged with a topological explanation of why
