### PR TITLE
docs: state technical rationale directly in comments

### DIFF
--- a/crates/embed/src/simd/tests.rs
+++ b/crates/embed/src/simd/tests.rs
@@ -706,7 +706,8 @@ fn test_batch_dot_product_same_query_matches_per_pair() {
 #[test]
 fn test_batch_dot_product_unit_vectors_equals_cosine() {
     // For unit-normalized vectors, dot product == cosine similarity.
-    // This validates the Round-3 fast path: normalized cosine routes through dot.
+    // This validates the fast path that routes normalized cosine similarity
+    // through a plain dot product.
     let mut q = generate_random_vector_seeded(384, 42);
     let mut c = generate_random_vector_seeded(384, 43);
     normalize(&mut q);

--- a/crates/inference/src/attention/gdn_fused.rs
+++ b/crates/inference/src/attention/gdn_fused.rs
@@ -1790,8 +1790,8 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // #850 blocker 2 follow-up: the SHIPPING scalar/AVX2/NEON l2-normalize
-    // paths must fail closed identically to the reference helper.
+    // The SHIPPING scalar/AVX2/NEON l2-normalize paths must fail closed
+    // identically to the reference helper.
     // -----------------------------------------------------------------------
 
     /// Table test for `scalar_l2_normalize` and, on the architecture the test runs on,
@@ -1939,14 +1939,14 @@ mod tests {
         }
     }
 
-    /// #850/#862 round-2 major-3 follow-up: state-isolation proof through the SHIPPING
-    /// fused path (`gated_delta_net_step_fused`) using the REAL Qwen3.5 conv kernel size
+    /// State-isolation proof through the SHIPPING fused path
+    /// (`gated_delta_net_step_fused`) using the REAL Qwen3.5 conv kernel size
     /// (`linear_conv_kernel_dim == 4`, i.e. `Qwen35Config::qwen35_2b()` unmodified — no
     /// `kernel_dim = 1` override), so `state.conv_buffer`'s rolling history is genuinely
     /// exercised, not sidestepped.
     ///
     /// ## Conv-window mechanics (read from `apply_causal_conv1d` in `attention/gdn.rs`
-    /// before writing this test, per the #862 round-2 mandate)
+    /// before writing this test)
     ///
     /// `apply_causal_conv1d` stores each step's RAW per-channel projection value in a
     /// rolling `buf_len = kernel_size - 1` (= 3) history *before* L2-normalization runs;
@@ -1961,9 +1961,9 @@ mod tests {
     ///
     /// Both runs use `weights_window` (head-0's entire K row block zeroed) for ALL FOUR
     /// window steps (0-3), not just step 0 — the poisoned run additionally sets exactly
-    /// one weight entry to NaN, ONLY at step 0. Steps 4-7 (four clean tokens, satisfying
-    /// #862 round-2's "at least 4 subsequent clean tokens" ask) use ordinary
-    /// `weights_clean`, identical in both runs.
+    /// one weight entry to NaN, ONLY at step 0. Steps 4-7 (four clean tokens, the number
+    /// needed to observe the poisoned value fully age out of the `kernel_size == 4`
+    /// conv window) use ordinary `weights_clean`, identical in both runs.
     ///
     /// This is a deliberate, disclosed choice, not a narrowing of the claim: holding the
     /// K row at true zero for the *whole* contamination window (not just step 0) is the
@@ -1981,7 +1981,7 @@ mod tests {
     /// Holding K at true zero through the full window on BOTH sides isolates exactly the
     /// contract this PR fixes (whole-vector zero-by-assignment on a non-finite reduced
     /// norm) from that separate, inherent, whole-vector-zero-granularity information
-    /// cost, and is the literal question #862 round-2 major-3 asks: does the guard's
+    /// cost, and is the literal question this test answers: does the guard's
     /// zeroing take the identical numerical path as true-zero weights, for as long as
     /// the corruption persists in the conv window, and does state fully re-converge
     /// (`state.snapshot()`: `s_matrices` AND `conv_buffer`) once the window closes?
@@ -1999,7 +1999,7 @@ mod tests {
     ///   conv window, and the complete `state.snapshot()` (both `s_matrices` and
     ///   `conv_buffer`) is finite and bit-identical to the reference unconditionally
     ///   (no guard involvement needed) -- the concrete "recovers to bit-identical once
-    ///   aged out of the conv window" proof #862 round-2 major-3 asked for.
+    ///   aged out of the conv window" proof this test exists to provide.
     ///
     /// Mutation-sensitive: reverting the `!norm_sq.is_finite()` guard in
     /// `simd_l2_normalize` (any backend) makes the poisoned run's step-0 output/state
@@ -2024,7 +2024,7 @@ mod tests {
         );
         let kernel_size = cfg.linear_conv_kernel_dim;
         let window = kernel_size; // # of dispatch steps a single poisoned raw value contaminates
-        let clean_tail = 4; // #862 round-2 major-3: "at least 4 subsequent clean tokens"
+        let clean_tail = 4; // number of clean tokens needed to fully evict the poisoned value from the kernel_size=4 conv window
         let total_steps = window + clean_tail;
 
         let (base_weights, cfg) = make_test_weights_for_cfg(cfg, 77);
@@ -2179,7 +2179,7 @@ mod tests {
             } else {
                 // Window fully closed: conv_buffer must now be completely finite and
                 // bit-identical -- the concrete "recovers to bit-identical once aged out
-                // of the conv window" proof #862 round-2 major-3 asked for.
+                // of the conv window" proof this test provides.
                 let poisoned_non_finite = poisoned_conv.iter().filter(|v| !v.is_finite()).count();
                 assert_eq!(
                     poisoned_non_finite,

--- a/crates/inference/src/attention/gdn_fused.rs
+++ b/crates/inference/src/attention/gdn_fused.rs
@@ -1961,9 +1961,11 @@ mod tests {
     ///
     /// Both runs use `weights_window` (head-0's entire K row block zeroed) for ALL FOUR
     /// window steps (0-3), not just step 0 — the poisoned run additionally sets exactly
-    /// one weight entry to NaN, ONLY at step 0. Steps 4-7 (four clean tokens, the number
-    /// needed to observe the poisoned value fully age out of the `kernel_size == 4`
-    /// conv window) use ordinary `weights_clean`, identical in both runs.
+    /// one weight entry to NaN, ONLY at step 0. Steps 4-7 (four extra clean tokens
+    /// exercising post-window recovery; the poisoned value has already aged out of the
+    /// conv buffer by the post-step-3 snapshot, since the rolling buffer holds
+    /// `kernel_size - 1 == 3` past values) use ordinary `weights_clean`, identical in
+    /// both runs.
     ///
     /// This is a deliberate, disclosed choice, not a narrowing of the claim: holding the
     /// K row at true zero for the *whole* contamination window (not just step 0) is the
@@ -2024,7 +2026,7 @@ mod tests {
         );
         let kernel_size = cfg.linear_conv_kernel_dim;
         let window = kernel_size; // # of dispatch steps a single poisoned raw value contaminates
-        let clean_tail = 4; // number of clean tokens needed to fully evict the poisoned value from the kernel_size=4 conv window
+        let clean_tail = 4; // extra clean tokens exercising post-window recovery (the poisoned value is already evicted by the post-step-3 snapshot)
         let total_steps = window + clean_tail;
 
         let (base_weights, cfg) = make_test_weights_for_cfg(cfg, 77);

--- a/crates/inference/src/backward/attention_gqa.rs
+++ b/crates/inference/src/backward/attention_gqa.rs
@@ -527,7 +527,7 @@ pub fn gqa_forward_with_cache(
                 probs_all[prob_start + s] = dot * scale;
             }
 
-            // ADR-080 C1 (#785 round-1 major 1): this forward-recompute builds
+            // ADR-080 C1: this forward-recompute builds
             // `softmax_probs` for the backward tape, not a vocabulary softmax and
             // not the `gqa.rs` test oracle -- a NaN/`+inf` score must zero the
             // whole probability row (and its context row), not poison the
@@ -822,7 +822,7 @@ mod tests {
         assert!(err_bv < 1e-2, "GQA grad_B_v rel_err {err_bv:.2e} >= 1e-2");
     }
 
-    /// ADR-080 C1 (#785 round-1 major 1): `gqa_forward_with_cache`'s
+    /// ADR-080 C1: `gqa_forward_with_cache`'s
     /// forward-recompute causal attention (used to build `softmax_probs` and
     /// `context` for the backward tape) is a production attention row, not the
     /// `gqa.rs` test oracle and not a vocabulary softmax. Poisoning ONE Q

--- a/crates/inference/src/bin/qwen35_generate.rs
+++ b/crates/inference/src/bin/qwen35_generate.rs
@@ -348,8 +348,8 @@ fn run_emit_phase_events(args: &[String]) -> i32 {
     // the ones the supervisor aggregates into the five mandated metrics.
     //
     // `prefill_end` and `token_available` are emitted from
-    // `generate_streaming_with_observer`'s raw-event observer (codex
-    // round-1 blocker #1), not from the text-delta callback below: the
+    // `generate_streaming_with_observer`'s raw-event observer, not from
+    // the text-delta callback below: the
     // incremental UTF-8 detokenizer deliberately buffers incomplete
     // multi-byte codepoints, so one text delta is not guaranteed to equal
     // one raw sampled token, and marking `prefill_end` off the first delta
@@ -391,7 +391,7 @@ fn run_emit_phase_events(args: &[String]) -> i32 {
     // this count is expected to always equal `generated_tokens` by
     // construction; fail loud rather than silently trust it, since the
     // supervisor's phase-sequence validator depends on this invariant
-    // holding (codex round-1 blocker #1's adapter-side requirement).
+    // holding.
     if raw_token_count != output.generated_tokens {
         eprintln!(
             "FAIL: internal error -- raw phase-event token count ({raw_token_count}) \

--- a/crates/inference/src/forward/cpu/softmax.rs
+++ b/crates/inference/src/forward/cpu/softmax.rs
@@ -137,7 +137,7 @@ unsafe fn softmax_attention_neon(x: &mut [f32], seq_len: usize, num_heads: usize
             let chunks = n / CHUNK;
 
             // --- Step 1: Find row max with 4x unrolling ---
-            // ADR-080 C1 (#785 round-1 perf): use the plain FMAX intrinsics
+            // ADR-080 C1: use the plain FMAX intrinsics
             // (vmaxq/vmaxvq), which PROPAGATE a NaN operand, instead of the
             // maxNum FMAXNM intrinsics (vmaxnmq/vmaxnmvq) paired with an
             // explicit `vceqq`/`vandq` NaN-tracking mask. The C1 contract

--- a/crates/inference/src/forward/metal.rs
+++ b/crates/inference/src/forward/metal.rs
@@ -1130,8 +1130,8 @@ mod inner {
         }
 
         // ADR-066 D2 invariant #1, all-(-inf) class: NOT covered by a direct
-        // kernel-dispatch fixture here, by design, not oversight (PR #794 round-1
-        // review, PR #794). `fused_attention` takes no external mask buffer -- the
+        // kernel-dispatch fixture here, by design, not oversight.
+        // `fused_attention` takes no external mask buffer -- the
         // only way a score row goes to all -inf is every Q.K dot product in that row
         // underflowing to -inf, and the live kernel always includes the causal
         // self-key (Q_i . K_i), which stays finite for any finite Q/K pair. Forcing a

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -2844,7 +2844,7 @@ mod tests {
 
     /// Standalone `{"type":"string","enum":[1,2]}` is unsatisfiable;
     /// `compile_string_type` must emit the empty language, not the `json_string`
-    /// fallback (issue #472 blocker 2, standalone path). Mutation guard: the
+    /// fallback (standalone path). Mutation guard: the
     /// `json_string` fallback accepts "zzz".
     #[test]
     fn standalone_typed_enum_no_string_members_rejects_all() {
@@ -2858,8 +2858,8 @@ mod tests {
 
     /// Standalone const/enum intersection through `compile_string_type`, which
     /// `compile_schema_inner` reaches via the `enum` dispatch — without the
-    /// intersection a sibling `const` would be silently ignored (issue #472
-    /// blocker 1, standalone path). Mutation guard: dropping the const-narrowing
+    /// intersection a sibling `const` would be silently ignored (standalone
+    /// path). Mutation guard: dropping the const-narrowing
     /// accepts "y" in both cases.
     #[test]
     fn standalone_string_const_enum_intersection() {

--- a/crates/inference/src/kv_cache/cross_turn.rs
+++ b/crates/inference/src/kv_cache/cross_turn.rs
@@ -116,7 +116,7 @@ pub fn longest_common_token_prefix(a: &[u32], b: &[u32]) -> usize {
 /// decline-beats-fabricate for the token-identity invariant.
 ///
 /// `ExactAppend` additionally requires a non-empty suffix
-/// (`new_prompt_ids.len() > shared`, #516 round-1 remediation D5): an
+/// (`new_prompt_ids.len() > shared`): an
 /// exact-equal retry of the represented prompt has no divergent suffix to
 /// prefill, and the Metal integration's `forward_prefill_from` treats an
 /// empty suffix as an internal invariant violation, not a valid no-op. That
@@ -319,16 +319,16 @@ mod tests {
         assert_eq!(plan.old_represented_len, 3);
     }
 
-    // #516 round-1 remediation D5 (finding 4): an exact-equal prompt retry
-    // has shared == represented_len but a zero-length suffix. Before D5 this
-    // produced `ExactAppend` with `suffix_len == 0`, which the Metal
+    // An exact-equal prompt retry has shared == represented_len but a
+    // zero-length suffix. Without the `new_prompt_ids.len() > shared` guard
+    // this produces `ExactAppend` with `suffix_len == 0`, which the Metal
     // integration's `forward_prefill_from` rejects as an empty-suffix error
     // instead of treating as a valid (degenerate) reuse. The planner must
     // fall back to `FullRefill` instead.
     //
     // Mutation sensitivity: dropping the `new_prompt_ids.len() > shared`
-    // conjunct (reverting to the pre-D5 condition) makes this test fail,
-    // because the plan would again be `ExactAppend` with `suffix_len == 0`.
+    // conjunct makes this test fail, because the plan would again be
+    // `ExactAppend` with `suffix_len == 0`.
     #[test]
     fn plan_exact_equal_prompt_is_full_refill() {
         let e = entry(vec![1, 2, 3], 3, 3);

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -426,8 +426,7 @@ impl Qwen35Model {
     }
 
     /// [`Self::generate_streaming_with_cancel`] plus a raw generation-lifecycle
-    /// observer (benchmark-overhaul row 2, codex round-1 blocker #1): fires
-    /// [`RawGenEvent::PrefillEnd`] once, after the prefill forward pass has
+    /// observer: fires [`RawGenEvent::PrefillEnd`] once, after the prefill forward pass has
     /// produced logits and *before* the first token is sampled, and
     /// [`RawGenEvent::RawToken`] once per token that actually becomes part of
     /// `GenerateOutput` (both the prefill-derived first token and every
@@ -618,13 +617,13 @@ impl Qwen35Model {
         }
 
         // Prefill logits are ready and the first token has not been sampled
-        // yet -- the true prefill/decode boundary (codex round-1 blocker #1).
+        // yet -- the true prefill/decode boundary.
         // Fired unconditionally here (not gated on the eventual grammar/EOS
         // outcome below), since prefill itself always completed by this
         // point regardless of what the first sampled token turns out to be.
         on_raw_event(RawGenEvent::PrefillEnd);
 
-        // Test-only seam (codex round-2 medium, PR #882): stamp "first sample
+        // Test-only seam: stamp "first sample
         // entered" right at the point sampling actually begins, so a test can
         // assert PrefillEnd fired before this instant, not merely before the
         // RawToken callback further below. No-op outside `cfg(test)`.
@@ -813,8 +812,7 @@ impl Qwen35Model {
                         all_ids.push(next_id);
                         // Raw-token event fired from the same `push` point
                         // that increments `generated_ids` -- never reached on
-                        // a grammar-stop/EOS step that returns before `push`
-                        // (codex round-1 blocker #1).
+                        // a grammar-stop/EOS step that returns before `push`.
                         on_raw_event(RawGenEvent::RawToken {
                             index: generated_ids.len(),
                         });
@@ -997,8 +995,7 @@ impl Qwen35Model {
                         all_ids.push(next_id);
                         // Raw-token event fired from the same `push` point
                         // that increments `generated_ids` -- never reached on
-                        // a grammar-stop/EOS step that returns before `push`
-                        // (codex round-1 blocker #1).
+                        // a grammar-stop/EOS step that returns before `push`.
                         on_raw_event(RawGenEvent::RawToken {
                             index: generated_ids.len(),
                         });
@@ -1071,10 +1068,9 @@ impl Qwen35Model {
 /// Raw generation-lifecycle event fired by
 /// [`Qwen35Model::generate_streaming_with_observer`], independent of the
 /// caller's text-delta callback and unaffected by incremental UTF-8
-/// detokenizer buffering (benchmark-overhaul row 2, codex round-1 blocker
-/// #1: a text delta is not guaranteed to equal one raw sampled token, and
-/// measuring `prefill_end` off the first delta fires it after sampling
-/// instead of before).
+/// detokenizer buffering: a text delta is not guaranteed to equal one raw
+/// sampled token, and measuring `prefill_end` off the first delta fires it
+/// after sampling instead of before.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RawGenEvent {
     /// Fired exactly once, after the prefill forward pass has produced
@@ -1090,7 +1086,7 @@ pub enum RawGenEvent {
     RawToken { index: usize },
 }
 
-// Test-only seam (codex round-2 medium finding, PR #882): the existing
+// Test-only seam: the existing
 // mutation-sensitive test below only proves `PrefillEnd` fires before the
 // `RawToken` *callback*, not before `sample_token` itself. A `PrefillEnd`
 // moved to just after `generated_ids.push` (after sampling, before the
@@ -3309,7 +3305,6 @@ mod tests {
 
     // -----------------------------------------------------------------------
     // generate_streaming_with_observer / RawGenEvent mutation-sensitive tests
-    // (benchmark-overhaul row 2, codex round-1 blocker #1, PR #882)
     // -----------------------------------------------------------------------
 
     /// `RawGenEvent::PrefillEnd` must fire exactly once, before the first
@@ -3374,25 +3369,22 @@ mod tests {
     }
 
     /// `RawGenEvent::PrefillEnd` must fire before `sample_token` is entered
-    /// for the first time, not merely before the `RawToken` *callback*
-    /// (codex round-2 medium finding, PR #882): the test above cannot
-    /// distinguish "PrefillEnd fired before sampling" from "PrefillEnd
-    /// fired after sampling but before the RawToken push", because both
-    /// orderings produce the same `[PrefillEnd, RawToken, RawToken,
-    /// RawToken]` event sequence. This test uses the `test_record_first_sample_entry`
-    /// seam, planted at the exact point `sample_token` is called for the
-    /// prefill-derived first token, to check the ordering codex's mutation
-    /// actually exercises.
+    /// for the first time, not merely before the `RawToken` *callback*: the
+    /// test above cannot distinguish "PrefillEnd fired before sampling" from
+    /// "PrefillEnd fired after sampling but before the RawToken push",
+    /// because both orderings produce the same `[PrefillEnd, RawToken,
+    /// RawToken, RawToken]` event sequence. This test uses the
+    /// `test_record_first_sample_entry` seam, planted at the exact point
+    /// `sample_token` is called for the prefill-derived first token, to
+    /// check that ordering directly.
     ///
     /// Mutation sensitivity: moving `on_raw_event(RawGenEvent::PrefillEnd)`
     /// to immediately after `generated_ids.push(next_id)` (still before the
-    /// `RawToken` callback -- the exact mutation codex applied in its round-2
-    /// review) leaves the event-order test above green, but makes this test's
-    /// `on_raw_event` closure observe `PrefillEnd` only *after*
-    /// `test_record_first_sample_entry` already ran, so
+    /// `RawToken` callback) leaves the event-order test above green, but
+    /// makes this test's `on_raw_event` closure observe `PrefillEnd` only
+    /// *after* `test_record_first_sample_entry` already ran, so
     /// `test_take_first_sample_saw_prefill_end()` returns `Some(false)`
-    /// instead of `Some(true)` and the assertion below fails. Verified by
-    /// reverting the fix (see PR body's mutation log for this test).
+    /// instead of `Some(true)` and the assertion below fails.
     #[test]
     fn raw_observer_prefill_end_precedes_first_sample_not_just_first_raw_token() {
         test_reset_sample_seam();
@@ -3430,10 +3422,10 @@ mod tests {
 
     /// One raw-token event fires per generated token even when the
     /// text-delta stream buffers an incomplete multi-byte UTF-8 sequence and
-    /// therefore does NOT call `on_token` for that step at all (codex
-    /// round-1 blocker #1's core claim: measuring prefill/decode boundaries
-    /// off text deltas is not equivalent to measuring off raw sampled
-    /// tokens, and can *lag* the true boundary by one or more tokens).
+    /// therefore does NOT call `on_token` for that step at all: measuring
+    /// prefill/decode boundaries off text deltas is not equivalent to
+    /// measuring off raw sampled tokens, and can *lag* the true boundary by
+    /// one or more tokens.
     ///
     /// Token id 0 is defined (via a custom tiny tokenizer vocab) to decode to
     /// the single raw byte `0xC2` -- the lead byte of a 2-byte UTF-8 sequence

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -85,8 +85,7 @@ pub use detokenize::bytes_to_unicode;
 pub(crate) use generation::should_stop_token;
 // Public raw generation-lifecycle observer event, consumed by
 // `--emit-phase-events` in `qwen35_generate.rs` via
-// `Qwen35Model::generate_streaming_with_observer` (benchmark-overhaul row 2,
-// codex round-1 blocker #1).
+// `Qwen35Model::generate_streaming_with_observer`.
 pub use generation::RawGenEvent;
 
 /// Exposed for consumers that need to drive a per-layer coverage check

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -145,7 +145,7 @@ struct ParsedEntry {
 /// crate. Kept inline rather than depending on `safetensors` to match
 /// the hand-roll pattern of [`crate::weights::f32_weights`] (which also
 /// parses safetensors headers directly). When upstream adds a dtype,
-/// add it here and to the round-4 regression tests.
+/// add it here and to the dtype-coverage regression tests.
 fn safetensors_bits_per_elem(dtype_str: &str) -> Option<usize> {
     match dtype_str {
         "F4" => Some(4),

--- a/crates/inference/tests/native_sparse_attention_test.rs
+++ b/crates/inference/tests/native_sparse_attention_test.rs
@@ -7,8 +7,8 @@
 //! the paper's equations (Yuan et al., arXiv:2502.11089, Eq. 5, 7–12). It shares NO code
 //! with the kernel body — but, like the kernel, it transcribes its spec from the paper
 //! via ADR-042, so a kernel-vs-oracle parity test is implementation-independent, *not*
-//! specification-independent. (Round-1 review caught an Eq. 9 sign error that both had
-//! copied from this ADR.) The Eq. 9 index is therefore also checked against the paper
+//! specification-independent. (Both the kernel and the oracle previously carried an
+//! Eq. 9 sign error copied from this ADR.) The Eq. 9 index is therefore also checked against the paper
 //! directly by `aggregate_selection_importance`'s hand-computed unit test in the kernel
 //! module — that test, not this parity oracle, is the spec-level anchor for Eq. 9.
 //!
@@ -994,7 +994,7 @@ fn test_causal_masking_integration() {
     );
 }
 
-/// Selection-branch causal-leak regression (round-2 review, finding 1).
+/// Selection-branch causal-leak regression.
 ///
 /// Soft-masking future tokens with a finite sentinel (e.g. `-10000`) leaks when a
 /// *real* valid score falls below the sentinel: after softmax the masked future
@@ -1160,7 +1160,7 @@ fn assert_prefix_invariant(
     }
 }
 
-/// Causal prefix-invariance regression (round-3 review, finding 1; broadened round-4).
+/// Causal prefix-invariance regression.
 ///
 /// The selection-block count was computed with `floor`, so a short prefix could have
 /// *zero* selection blocks while the same prefix inside a longer sequence had one —

--- a/scripts/bench_cpu_flagship_supervisor.py
+++ b/scripts/bench_cpu_flagship_supervisor.py
@@ -303,7 +303,7 @@ class TrialFailure(RuntimeError):
 def _validate_trial_trace(phase_events: list[dict], summary: dict, trial_label: str) -> None:
     """Validates ONE trial's raw phase-event trace in the EXACT order the
     child printed it to stdout, before any aggregation, sorting, or
-    verdict-downgrade decision ever touches it (codex round-1 blocker #2).
+    verdict-downgrade decision ever touches it.
 
     The pre-fix supervisor accepted a malformed trace outright: it
     `sorted()`-ed `token_available` records by `token_index` before this
@@ -400,11 +400,11 @@ def _drain_stdout_lines(
     non-daemon-joined background thread is silently swallowed by the
     interpreter, so the main thread must observe failures through this
     list after joining, not via a try/except around the thread itself
-    (codex round-1 major #1: the old code did this inline on the MAIN
-    thread via a blocking `for raw_line in proc.stdout`, which is exactly
-    why a hung child with stdout still open could never reach the
-    `proc.wait(timeout=...)` below it -- moving it here, running
-    concurrently with `proc.wait`, is what makes the timeout enforceable).
+    (running this inline on the MAIN thread via a blocking
+    `for raw_line in proc.stdout` is exactly why a hung child with stdout
+    still open could never reach the `proc.wait(timeout=...)` below it --
+    moving it here, running concurrently with `proc.wait`, is what makes
+    the timeout enforceable).
     """
     try:
         assert proc.stdout is not None
@@ -443,8 +443,7 @@ def _drain_stderr_chunks(proc: subprocess.Popen, chunks: list[str]) -> None:
     Without this, a child that fills the OS pipe buffer writing to stderr
     (while the parent is busy blocked elsewhere) can deadlock: the child
     blocks on its own stderr write, the parent never reads it because it
-    is blocked on stdout/wait, and neither side makes progress
-    (codex round-1 major #1's "drain stderr concurrently" requirement)."""
+    is blocked on stdout/wait, and neither side makes progress."""
     try:
         assert proc.stderr is not None
         for chunk in proc.stderr:
@@ -481,8 +480,7 @@ def run_one_trial(
     starve the timeout the way a blocking `for raw_line in proc.stdout`
     (the pre-fix code) did. On timeout the child is killed and reaped
     (`proc.wait()` again, after `kill()`) before this function returns or
-    raises -- never left as a leaked/zombie process (codex round-1 major
-    #1).
+    raises -- never left as a leaked/zombie process.
     """
     cmd = [
         str(binary),
@@ -631,8 +629,8 @@ def compute_trial_metrics(trial: dict) -> dict:
     # already proven `token_index` is strictly contiguous in stdout arrival
     # order for every trial reaching this point, so re-sorting here would
     # only ever mask a bug in that guarantee rather than fix real data
-    # (codex round-1 blocker #2: sorting here previously accepted a
-    # reversed/out-of-order stream by silently repairing it).
+    # (sorting here would silently repair a reversed/out-of-order stream
+    # instead of surfacing the bug).
     token_events = [e for e in events if e["name"] == "token_available"]
     if not token_events:
         raise TrialFailure("no token_available events observed")

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -155,9 +155,9 @@ def _pvalue_from_boot_means(boot_means: Sequence[float], tau_log: float, b: int)
     without drawing any new resamples. Factored out so `evaluate_family_gate`
     can derive the p-value and (later, at Holm's assigned tail) the lower
     bound from the SAME retained sample instead of two independent bootstrap
-    draws — see `_lower_bound_from_sorted_boot_means` and the round-4
-    adversarial-review finding at `evaluate_family_gate`'s call sites for why
-    two independent draws break the percentile duality the module claims.
+    draws — see `_lower_bound_from_sorted_boot_means` and
+    `evaluate_family_gate`'s call sites for why two independent draws break
+    the percentile duality the module claims.
     """
     p = sum(1 for m in boot_means if m <= tau_log) / len(boot_means)
     return max(p, 1.0 / b)
@@ -255,7 +255,7 @@ def bootstrap_lower_bound(
     does NOT call this function (it would draw a second, independent
     bootstrap distribution from the one `one_sided_bootstrap_pvalue` already
     drew for the same cell, breaking percentile duality between the p-value
-    and the bound — the round-4 adversarial-review finding). Instead it
+    and the bound). Instead it
     calls `_lower_bound_from_sorted_boot_means` directly on the SAME sample
     it already generated for the p-value.
     """
@@ -650,7 +650,7 @@ def evaluate_family_gate(
     Order-preserving: `results[i]` corresponds to `cells[i]`, matching
     `holm_reject`'s own input-order-preserving contract.
 
-    Percentile duality (round-4 adversarial-review fix): the p-value and the
+    Percentile duality: the p-value and the
     lower bound for a given cell are extracted from ONE retained
     bootstrap-mean sample (`order_stratified_bootstrap_means` is called
     exactly once per cell, up front), never from two independent bootstrap
@@ -658,7 +658,7 @@ def evaluate_family_gate(
     prior shape of this function -- does not preserve the docstring's "SAME
     test, evaluated at the SAME per-cell alpha" claim: a tested-but-not-
     rejected cell could still expose a threshold-clearing bound purely from
-    resampling noise between the two draws (round-4 finding: single cell,
+    resampling noise between the two draws (concrete counterexample: single cell,
     `base=log(1.07)+0.005`, `spread=0.02`, `bootstrap_replicates=2000`,
     `random.Random(108)` gave `p_value=0.051` (correctly not rejected) but
     an independently-drawn `corrected_lower_bound=0.0680872...`, above the


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Comments-only cleanup. A number of comments carried provenance markers (finding numbers, iteration tags, tooling references) instead of stating the underlying technical reason directly. This restates each one to its technical rationale, with the provenance stripped out. No code or test logic changed.

## Files touched (one line per rewrite class)

- `crates/embed/src/simd/tests.rs`: comment restated to explain what the fast-path assumption under test actually is.
- `crates/inference/tests/native_sparse_attention_test.rs`: two module/test doc comments restated to describe the sign-error history and the causal-leak/prefix-invariance regressions directly.
- `crates/inference/src/quant/quarot/io.rs`: comment restated to reference "dtype-coverage regression tests" generically instead of an iteration tag.
- `crates/inference/src/attention/gdn_fused.rs`: a cluster of test doc comments and inline comments restated to describe the fail-closed contract, the conv-window mechanics, and the token-count rationale directly, without iteration/finding tags.
- `crates/inference/src/grammar/json_schema.rs`: two test doc comments restated to drop finding-number tags while keeping the "standalone path" mutation-guard rationale.
- `crates/inference/src/bin/qwen35_generate.rs`: two comments restated to describe the raw-event vs. text-delta timing distinction directly.
- `crates/inference/src/backward/attention_gqa.rs`: two comments restated to keep the ADR-080 C1 contract reference and drop the finding tag.
- `crates/inference/src/kv_cache/cross_turn.rs`: doc comment and test comment restated to explain the non-empty-suffix guard purely in terms of the invariant it protects.
- `crates/inference/src/model/qwen35/generation.rs`: largest cluster — doc comments and inline comments across the raw-event-observer path and its mutation-sensitive tests restated to describe the prefill/decode boundary semantics directly, without iteration/finding tags. One occurrence remains inside a test assertion message string (not a comment) and was left untouched.
- `crates/inference/src/model/qwen35/mod.rs`: comment restated to describe the re-export purpose directly.
- `crates/inference/src/forward/metal.rs`: comment restated to explain why the all-(-inf) class is untested by design, without the iteration tag.
- `crates/inference/src/forward/cpu/softmax.rs`: comment restated to keep the ADR-080 C1 reference and drop the iteration tag.
- `scripts/bench_cpu_flagship_supervisor.py`: five docstring/comment restatements describing trace-validation ordering, background-thread failure handling, and stderr-draining deadlock avoidance directly.
- `scripts/bench_gate_math.py`: four docstring restatements describing the percentile-duality/shared-bootstrap-sample rationale directly, without iteration tags.

## Test plan

- [x] Comments-only diff; no logic, test bodies, or public API changed.
- [x] `cargo clippy --workspace -- -D warnings` (doc-comment compilation included)
- [x] Verified no residual provenance markers remain in touched files beyond one occurrence embedded in a test assertion message (code, not a comment).
