### PR TITLE
docs(adr): ADR-058 post-acceptance note — CI-confidence escalation reduces power; gate stays unarmed

### DIFF
--- a/docs/adr/ADR-058-cpu-perf-regression-ci.md
+++ b/docs/adr/ADR-058-cpu-perf-regression-ci.md
@@ -254,3 +254,32 @@ Bench wall time (~5-10 min on shared runners) would double the CI duration for e
 - ARM runner availability: <https://github.blog/2024-09-03-arm64-on-github-actions-powering-faster-more-efficient-build-systems/>
 - Issue #77 — GPU contention variance (M2 Max local bench noise)
 - PR #76 — context for catastrophic-cancellation revert (layer_norm two-pass)
+
+## Post-acceptance note (2026-07-12): the 95% → 99% escalation is unsound — do not arm it
+
+A subsequent adversarial statistical review of this design found the confidence-escalation
+path (D3 "Why 7% on CI-lower-bound" and Rollout step 5: on persistent false positives,
+tighten the CI confidence from 95% to 99% "rather than weakening the 7% sensitivity")
+to be backwards. At a fixed threshold, requiring higher confidence widens the margin the
+lower bound must clear before tripping, which *reduces* power against genuine regressions;
+it does not preserve sensitivity. If observed flake is high, the honest levers are more
+samples per run, better runner isolation, or an explicitly raised threshold.
+
+Two further findings compound the problem as specified:
+
+- Criterion's within-run CI measures sampling noise inside one runner session. True
+  cross-runner variance on shared CI hardware is far larger (the review's worked example
+  put the understatement above an order of magnitude), so a "statistically confident"
+  within-run bound is not confidence about the run-to-run distribution the gate actually
+  faces; bimodal shared-runner latency can produce confident false failures at zero true
+  regression.
+- Updating the baseline on every push to main can ratchet a real regression into the
+  baseline before any gate observes it.
+
+Status: the D2/D3 hard merge gate described here was never armed. Merge gating shipped
+instead as same-runner end-to-end token parity against a reference implementation plus a
+relative perplexity-delta gate, both of which sidestep cross-runner variance by comparing
+within a single run. Criterion micro-benchmarks are collected as trend data only
+(`bench-update.yml` / `perf-baselines`). Any future revival of a hard Criterion gate needs
+a cross-run variance model measured on the actual runner pool, not the escalation path in
+this document.

--- a/docs/adr/ADR-058-cpu-perf-regression-ci.md
+++ b/docs/adr/ADR-058-cpu-perf-regression-ci.md
@@ -267,19 +267,23 @@ samples per run, better runner isolation, or an explicitly raised threshold.
 
 Two further findings compound the problem as specified:
 
-- Criterion's within-run CI measures sampling noise inside one runner session. True
-  cross-runner variance on shared CI hardware is far larger (the review's worked example
-  put the understatement above an order of magnitude), so a "statistically confident"
-  within-run bound is not confidence about the run-to-run distribution the gate actually
-  faces; bimodal shared-runner latency can produce confident false failures at zero true
-  regression.
-- Updating the baseline on every push to main can ratchet a real regression into the
-  baseline before any gate observes it.
+- Criterion's change CI is bootstrapped from the observed baseline and candidate benchmark
+  sessions; it does not model between-session or runner-pool variance. On shared CI
+  hardware, run-to-run variance can be substantially larger than what one observed pair of
+  sessions shows, so a "statistically confident" bound from that pair is not confidence
+  about the distribution the gate actually faces; a bimodal runner pool can hand the
+  bootstrap two internally stable sessions from different modes, yielding a narrow,
+  confidently wrong comparison and false failures at zero true regression.
+- Refreshing the baseline on each qualifying main update (path-filtered pushes, plus
+  scheduled and manual refreshes) can ratchet a real regression into the baseline before
+  any gate observes it.
 
-Status: the D2/D3 hard merge gate described here was never armed. Merge gating shipped
-instead as same-runner end-to-end token parity against a reference implementation plus a
-relative perplexity-delta gate, both of which sidestep cross-runner variance by comparing
-within a single run. Criterion micro-benchmarks are collected as trend data only
+Status: the D2/D3 hard merge gate described here was never armed (an advisory-mode
+workflow was implemented, then removed). Merge gating shipped instead as same-run
+end-to-end greedy-token parity against a reference implementation (a within-run
+comparison), plus an absolute Q4 perplexity golden captured on the CI runner class and
+enforced with a fixed tolerance (a cross-run comparison by construction, carrying its own
+environment-drift risk). Criterion micro-benchmarks are collected as trend data only
 (`bench-update.yml` / `perf-baselines`). Any future revival of a hard Criterion gate needs
 a cross-run variance model measured on the actual runner pool, not the escalation path in
 this document.


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Appends a dated post-acceptance note to ADR-058 (CPU perf regression CI). Docs-only; no behavior change.

## Why

An adversarial statistical review of the ADR's D2/D3 hard-gate design found the confidence-escalation path (on persistent false positives, tighten Criterion's CI confidence from 95% to 99% at the fixed 7% threshold, claimed to preserve sensitivity) to be statistically backwards: at a fixed threshold, higher required confidence widens the margin the lower bound must clear, reducing power against genuine regressions. Two compounding findings are recorded alongside it: within-run Criterion CIs understate cross-runner variance by more than an order of magnitude on shared CI hardware, and push-to-main baseline updates can ratchet a real regression into the baseline before any gate observes it.

The note also records status honestly: the hard merge gate described in the ADR was never armed. Merge gating shipped instead as same-runner e2e token parity plus a relative PPL-delta gate; Criterion micro-benchmarks are trend data only. The note exists so the escalation path is never armed as written by a future reader.

## Verification

- Docs-only diff (one file, appended section).
- Pre-commit doc lint (deno) passed.