### PR TITLE
docs(embed): SimdConfig force-scalar overrides cannot re-route a simd128 wasm build (#904)

### DIFF
--- a/crates/embed/README.md
+++ b/crates/embed/README.md
@@ -58,7 +58,19 @@ All operations use runtime feature detection with automatic scalar fallback.
 | -------- | ---------------------------------- |
 | x86_64   | AVX-512 VNNI > AVX2 + FMA > scalar |
 | aarch64  | ARM NEON (mandatory)               |
+| wasm32   | SIMD128 (compile-time) > scalar    |
 | Other    | Scalar fallback                    |
+
+### wasm32 (SIMD128)
+
+Unlike the x86_64/aarch64 rows above, wasm32 has no runtime CPU-feature detection: a given
+`.wasm` binary either was or wasn't compiled with `-C target-feature=+simd128`, and that
+choice is fixed for the whole artifact. `SimdConfig::simd128_enabled()` mirrors this
+directly (`cfg!(target_feature = "simd128")`) rather than reading a field, so it is not
+something a config value can override -- a force-scalar-style `SimdConfig` cannot re-route a
+simd128-compiled wasm build back to the scalar kernels. To get scalar dispatch on wasm32,
+build without the `simd128` target feature; there is no runtime override for a build that
+has it.
 
 ### Performance (384-dim vectors)
 

--- a/crates/embed/src/simd/mod.rs
+++ b/crates/embed/src/simd/mod.rs
@@ -160,6 +160,19 @@ impl SimdConfig {
     /// codepaths inside one binary). Mirrors `cfg!(target_feature =
     /// "simd128")` and is always false on non-wasm32 targets. A method rather
     /// than a field so existing `SimdConfig` struct literals keep compiling.
+    ///
+    /// Because this ignores `self` entirely, no `SimdConfig` value -- not
+    /// `SimdConfig::scalar_only` (the existing test-only force-scalar
+    /// helper), not a hypothetical future runtime override -- can flip it
+    /// back to `false` on a simd128-compiled wasm artifact: it always
+    /// re-derives the same compile-time `cfg!` regardless of which instance
+    /// calls it. The four dispatch resolvers that gate on
+    /// this method (`resolve_dot_product_kernel` in `dot_product.rs`,
+    /// `resolve_cosine_kernel` in `cosine.rs`, `dispatch_squared` in
+    /// `distance.rs`, and `normalize`'s inline dispatch in `normalize.rs`)
+    /// inherit the same property. The only way to get scalar dispatch on
+    /// wasm32 is to build without the `simd128` target feature in the first
+    /// place; there is no runtime escape hatch.
     #[inline]
     pub fn simd128_enabled(&self) -> bool {
         cfg!(all(target_arch = "wasm32", target_feature = "simd128"))


### PR DESCRIPTION
_PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Follow-up from #900 review (non-blocking). Documents, in two places, that a
`SimdConfig` force-scalar-style override cannot re-route a `simd128`-compiled
wasm32 build back to the scalar kernels:

- Doc comment on `SimdConfig::simd128_enabled()` in
  `crates/embed/src/simd/mod.rs:154-176`.
- New "wasm32 (SIMD128)" subsection in `crates/embed/README.md` (the crate's
  `README.md` had no wasm-specific section before this change; the platform
  table under "SIMD Vector Operations" only listed x86_64/aarch64/Other).

## Mechanism (verified at source before writing anything)

`SimdConfig::simd128_enabled(&self)` at
`crates/embed/src/simd/mod.rs:164-166` is:

```rust
pub fn simd128_enabled(&self) -> bool {
    cfg!(all(target_arch = "wasm32", target_feature = "simd128"))
}
```

It takes `&self` but never reads any field on it — the return value is
`cfg!(...)`, a compile-time constant baked into the binary at build time.
Every `SimdConfig` instance in a given build, no matter how its fields were
set, returns the same value from this method. Concretely: `SimdConfig`'s
only existing "force scalar" constructor,
`SimdConfig::scalar_only()` (`crates/embed/src/simd/mod.rs:178-189`,
`#[cfg(test)]`-gated, all six ISA-tier fields set to `false`), still returns
`true` from `.simd128_enabled()` on a `simd128`-compiled wasm32 build,
because that call never looks at the fields `scalar_only()` cleared.

The four public vector-op dispatch points that gate on this method inherit
the same property, and are additionally wrapped in their own compile-time
`#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]`, so the
SIMD128 kernel branch — and the kernel function itself — doesn't exist at
all in a binary built without that target feature:

- `resolve_dot_product_kernel()` — `crates/embed/src/simd/dot_product.rs:29-57` (branch at 49-54)
- `resolve_cosine_kernel()` — `crates/embed/src/simd/cosine.rs:33-61` (branch at 53-58)
- `dispatch_squared()` — `crates/embed/src/simd/distance.rs:23-52` (branch at 44-49)
- `normalize()`'s inline dispatch — `crates/embed/src/simd/normalize.rs:25-66` (branch at 54-63)

So there are two independent compile-time gates stacking, and no runtime
knob anywhere in the chain: a build without `-C target-feature=+simd128`
never has the SIMD128 kernels or branches at all (falls through to the
scalar kernel unconditionally); a build with it always dispatches to the
SIMD128 kernel, because the predicate it checks re-derives the same `cfg!`
regardless of which `SimdConfig` value is passed in. Confirmed this premise
holds (not "subtly wrong") before writing the note — there is no path in
this crate today where a config override changes wasm32 dispatch.

## Where the note landed

- `crates/embed/src/simd/mod.rs` — doc comment addition on
  `SimdConfig::simd128_enabled()`, naming `scalar_only()` and all four
  dispatch resolvers explicitly.
- `crates/embed/README.md` — new "wasm32 (SIMD128)" subsection plus a wasm32
  row in the existing platform table, under "SIMD Vector Operations".

## Scope

Docs-only (comment + README prose). No code, no test, no behavior change.
No `make bench-compare` — nothing here touches a code path a benchmark
measures.

## Gates

- `cargo fmt -p lattice-embed -- --check`: clean.
- `cargo clippy -p lattice-embed -- -D warnings` (via
  `with-heavy-lane.sh`): 0 warnings, 0 errors.
- `cargo doc -p lattice-embed --no-deps` with
  `RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links"`:
  clean (checked specifically because the new doc comment references the
  `#[cfg(test)]`-only `scalar_only()`; that reference is a plain code span,
  not an intra-doc link, so it can't break under a non-test doc build).
- Pre-commit hook (`cargo fmt --all -- --check`, workspace
  `cargo clippy --all-targets -- -D warnings`, `scripts/lint-docs.sh`): all
  passed.
