### PR TITLE
docs(embed): correct unsafe-block inventory and scope wasm32 SIMD128 claims to f32 kernels

### DIFF
--- a/crates/embed/README.md
+++ b/crates/embed/README.md
@@ -52,16 +52,19 @@ let emb2 = cached.embed_one("Hello", EmbeddingModel::default()).await?; // cache
 
 ## SIMD Vector Operations
 
-On x86_64 and aarch64, operations use runtime feature detection with automatic scalar
-fallback. On wasm32 the SIMD choice is fixed at compile time and covers the f32 kernels
-only (see below).
+Dispatch is resolved per platform. x86_64 uses runtime feature detection with automatic
+scalar fallback. On aarch64 the f32 kernels always use NEON (mandatory on that
+architecture, no runtime check), while the int8 kernel runtime-detects SDOT. On wasm32
+the SIMD choice is fixed at compile time and covers the f32 kernels only (see below).
 
-| Platform | Instructions                                      |
-| -------- | ------------------------------------------------- |
-| x86_64   | AVX-512 VNNI > AVX2 + FMA > scalar                |
-| aarch64  | ARM NEON (mandatory)                              |
-| wasm32   | SIMD128 (compile-time, f32 kernels only) > scalar |
-| Other    | Scalar fallback                                   |
+| Platform       | Instructions                                       |
+| -------------- | -------------------------------------------------- |
+| x86_64 (f32)   | AVX-512F > AVX2 + FMA > scalar                     |
+| x86_64 (int8)  | AVX-512 VNNI (`avx512` feature) > AVX2 > scalar    |
+| aarch64 (f32)  | ARM NEON (mandatory, always on)                    |
+| aarch64 (int8) | NEON SDOT (runtime-detected) > scalar              |
+| wasm32         | SIMD128 (compile-time, f32 kernels only) > scalar  |
+| Other          | Scalar fallback                                    |
 
 ### wasm32 (SIMD128)
 

--- a/crates/embed/README.md
+++ b/crates/embed/README.md
@@ -52,16 +52,22 @@ let emb2 = cached.embed_one("Hello", EmbeddingModel::default()).await?; // cache
 
 ## SIMD Vector Operations
 
-All operations use runtime feature detection with automatic scalar fallback.
+On x86_64 and aarch64, operations use runtime feature detection with automatic scalar
+fallback. On wasm32 the SIMD choice is fixed at compile time and covers the f32 kernels
+only (see below).
 
-| Platform | Instructions                       |
-| -------- | ---------------------------------- |
-| x86_64   | AVX-512 VNNI > AVX2 + FMA > scalar |
-| aarch64  | ARM NEON (mandatory)               |
-| wasm32   | SIMD128 (compile-time) > scalar    |
-| Other    | Scalar fallback                    |
+| Platform | Instructions                                      |
+| -------- | ------------------------------------------------- |
+| x86_64   | AVX-512 VNNI > AVX2 + FMA > scalar                |
+| aarch64  | ARM NEON (mandatory)                              |
+| wasm32   | SIMD128 (compile-time, f32 kernels only) > scalar |
+| Other    | Scalar fallback                                   |
 
 ### wasm32 (SIMD128)
+
+The SIMD128 route exists for the four f32 kernels: `dot_product`, `cosine_similarity`,
+squared Euclidean distance, and `normalize`. The int8 path (`dot_product_i8`) has no
+SIMD128 branch and always dispatches to the scalar kernel on wasm32.
 
 Unlike the x86_64/aarch64 rows above, wasm32 has no runtime CPU-feature detection: a given
 `.wasm` binary either was or wasn't compiled with `-C target-feature=+simd128`, and that

--- a/crates/embed/src/lib.rs
+++ b/crates/embed/src/lib.rs
@@ -12,7 +12,8 @@
 //! distance; SIMD is not bit-identical to scalar and promises no exact ordering of near-ties).
 //! The rest of `simd/` remains unstable.
 //!
-//! The 21 `unsafe` blocks are gated SIMD intrinsic calls (AVX512/AVX2/NEON).
+//! The 25 `unsafe` blocks are gated SIMD intrinsic calls: 21 on the
+//! AVX512/AVX2/NEON paths plus 4 wasm32 SIMD128 dispatch sites.
 //! See `foundation/STABILITY.md` for the full policy.
 //!
 //! # lattice-embed


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Review follow-up to #909 and #910 (both merged): two documentation-accuracy corrections in `lattice-embed`.

1. **`crates/embed/src/lib.rs`** — the crate-level claim said "21 `unsafe` blocks ... (AVX512/AVX2/NEON)". The production count is 25: the 21 AVX512/AVX2/NEON sites plus 4 wasm32 SIMD128 dispatch sites (`dot_product.rs:179`, `cosine.rs:89`, `distance.rs:47`, `normalize.rs:61`). Verified by enumerating `unsafe {` occurrences under `crates/embed/src/` and excluding the three inside `#[cfg(test)]` modules (`int4.rs`, `quantized.rs` ×2). A safety audit using the old sentence as a complete inventory would have missed every wasm block.

2. **`crates/embed/README.md`** — the SIMD section opened with "All operations use runtime feature detection", contradicting the wasm32 row (compile-time) three lines below, and the wasm32 row implied SIMD128 covers every operation in the performance table. The int8 path (`dot_product_i8`) has no SIMD128 branch — `resolve_i8_dot_kernel` falls to the scalar kernel on wasm32 (`crates/embed/src/simd/quantized.rs:581-606`). Rewrote the opening sentence platform-qualified and scoped the wasm32 claims to the four f32 kernels.

Docs-only: no compiled source changed, so no bench-compare (per ADR-058 scope).