### PR TITLE
bench(scripts): migrate bench_apples_to_apples.sh to the shared decode-bench harness (#813)

### DIFF
--- a/scripts/bench_apples_to_apples.sh
+++ b/scripts/bench_apples_to_apples.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Apples-to-apple decode-throughput benchmark — slope (marginal) method.
 #
-# Measures three engines IDENTICALLY at two quantization tiers:
-#   decode_tok_per_s = (N2 - N1) / (T_total(N2) - T_total(N1))
-#
-# Prefill, model load, and per-call overhead are constant for a fixed prompt
-# so they cancel in the difference — leaving the true marginal decode rate,
-# methodology-identical across engines.
+# Thin wrapper (issue #813 step 2, first migration): all methodology
+# (warmup policy, repeat count, aggregation, confidence interval, output
+# rendering) now lives in scripts/bench_decode_harness.py, configured by the
+# apples_to_apples_q8/apples_to_apples_q4 profiles in
+# scripts/bench_decode_profiles.toml. This script only execs the harness
+# (via scripts/bench_decode_adapters_apples_to_apples.py, which registers
+# the lattice/ollama/mlx engine adapters) once per tier. Parameters are
+# unchanged from the pre-migration version of this script: N1=32, N2=256,
+# 5 measured repeats, the same fixed prompt, and the same per-engine warmup
+# shape (only mlx warms up, once, at 8 tokens).
 #
 # Q8 tier (lattice default for <2B params, ollama default, mlx explicit):
 #   - lattice: F16 safetensors → auto-quantized to Q8_0 on Metal upload
@@ -24,142 +28,27 @@
 set -uo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-LAT_BIN="$REPO/target/release/bench_decode_ab"
-Q8_DIR="$HOME/.lattice/models/qwen3.5-0.8b"
-Q4_DIR="$HOME/.lattice/models/qwen3.5-0.8b-q4-quarot"
-N1=32
-N2=256
-RUNS=5
-PROMPT="The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
 OUT="$REPO/docs/bench_results"
 mkdir -p "$OUT"
-DATA="$OUT/a2a_raw.tsv"   # tier<TAB>engine<TAB>N<TAB>run<TAB>total_s<TAB>native_tok_s
-: > "$DATA"
 
-echo "=== Apples-to-apple decode bench | Qwen3.5-0.8B | N1=$N1 N2=$N2 runs=$RUNS ==="
-echo "  Output: $DATA"
+echo "=== Apples-to-apple decode bench | Qwen3.5-0.8B | N1=32 N2=256 runs=5 ==="
+echo "  Harness: scripts/bench_decode_harness.py (profiles apples_to_apples_q8 / apples_to_apples_q4)"
 echo ""
 
-bench_lattice() {
-  local tier="$1" model_dir="$2" tokenizer_dir="$3" quant_env="$4"
-  if [[ ! -x "$LAT_BIN" ]]; then echo "  lattice/$tier: BIN MISSING — build first"; return; fi
-  if [[ ! -d "$model_dir" ]]; then echo "  lattice/$tier: MODEL MISSING ($model_dir)"; return; fi
-  for N in $N1 $N2; do
-    env BENCH_N=$N BENCH_RUNS=$RUNS LATTICE_MODEL_DIR="$model_dir" \
-        LATTICE_TOKENIZER_DIR="$tokenizer_dir" $quant_env "$LAT_BIN" 2>/dev/null \
-    | awk -v tier="$tier" -v N=$N '/^RESULT/{
-        for(i=1;i<=NF;i++){split($i,kv,"="); v[kv[1]]=kv[2]}
-        printf "%s\tlattice\t%s\t%d\t%.6f\t\n", tier, N, ++r, v["total_ms"]/1000.0
-      }' >> "$DATA"
-  done
-  echo "  lattice/$tier: done"
-}
-
-bench_ollama() {
-  local tier="$1" model_tag="$2"
-  if ! command -v ollama >/dev/null 2>&1; then echo "  ollama/$tier: not installed"; return; fi
-  ollama list 2>/dev/null | grep -q "$model_tag" || ollama pull "$model_tag" >/dev/null 2>&1 || {
-    echo "  ollama/$tier: pull failed for $model_tag — skipping"; return; }
-  curl -s localhost:11434/api/tags >/dev/null 2>&1 || { ollama serve >/dev/null 2>&1 & sleep 3; }
-  for N in $N1 $N2; do
-    for run in $(seq 1 $RUNS); do
-      R=$(curl -s localhost:11434/api/generate -d "{\"model\":\"$model_tag\",\"prompt\":$(python3 -c "import json,sys;print(json.dumps('$PROMPT'))"),\"stream\":false,\"options\":{\"num_predict\":$N,\"temperature\":0}}")
-      echo "$R" | python3 -c "
-import sys,json
-d=json.load(sys.stdin)
-tot=d.get('total_duration',0)/1e9
-ec=d.get('eval_count',0); ed=d.get('eval_duration',1)/1e9
-print(f'$tier\tollama\t$N\t$run\t{tot:.6f}\t{ec/ed:.3f}')" >> "$DATA"
-    done
-  done
-  echo "  ollama/$tier: done"
-}
-
-bench_mlx() {
-  local tier="$1" bits="$2"
-  uv run --quiet --with mlx-lm python3 - "$Q8_DIR" "$N1" "$N2" "$RUNS" "$PROMPT" "$tier" "$bits" <<'PY' >> "$DATA" 2>/dev/null
-import sys, time
-mdir, n1, n2, runs, prompt, tier, bits = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]), sys.argv[5], sys.argv[6], int(sys.argv[7])
-import mlx.core as mx, mlx.nn as nn
-from mlx_lm import load, generate
-from mlx_lm.sample_utils import make_sampler
-try:    model, tok = load(mdir)
-except: model, tok = load("Qwen/Qwen3.5-0.8B")
-nn.quantize(model, bits=bits, group_size=64); mx.eval(model.parameters())
-samp = make_sampler(temp=0.0)
-generate(model, tok, prompt=prompt, max_tokens=8, sampler=samp, verbose=False)  # warmup
-for N in (n1, n2):
-    for run in range(1, runs+1):
-        t0 = time.time()
-        generate(model, tok, prompt=prompt, max_tokens=N, sampler=samp, verbose=False)
-        dt = time.time() - t0
-        print(f"{tier}\tmlx\t{N}\t{run}\t{dt:.6f}\t")
-PY
-  echo "  mlx/$tier: done"
-}
-
-echo "─── Q8 tier (apples — public Metal compute API) ───"
-bench_lattice "q8" "$Q8_DIR" "$Q8_DIR" ""
-bench_ollama  "q8" "qwen3.5:0.8b"
-echo "─── Q8 reference (MLX uses private MPS/AMX — different category) ───"
-bench_mlx     "q8" "8"
-echo ""
-echo "─── Q4 tier (lattice differentiator — QuaRot rotation) ───"
-bench_lattice "q4" "$Q4_DIR" "$Q8_DIR" "LATTICE_QUANT_FORMAT=Q4"
-echo "─── Q4 reference (MLX Q4 g64) ───"
-bench_mlx     "q4" "4"
+echo "─── Q8 tier (apples — public Metal compute API; MLX reference uses private AMX) ───"
+uv run --quiet --with mlx-lm python3 "$REPO/scripts/bench_decode_adapters_apples_to_apples.py" \
+  run --profile apples_to_apples_q8 --allow-missing-engine --out "$OUT/a2a_q8_raw.jsonl"
+q8_status=$?
 echo ""
 
-# ---- Slope + report ----
-python3 - "$DATA" "$N1" "$N2" <<'PY'
-import sys, statistics as st, collections
-data, N1, N2 = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-# rows[tier][engine][N] = list[total_s]
-rows=collections.defaultdict(lambda: collections.defaultdict(lambda: collections.defaultdict(list)))
-nat =collections.defaultdict(lambda: collections.defaultdict(list))
-for ln in open(data):
-    p=ln.rstrip("\n").split("\t")
-    if len(p)<5 or not p[4]: continue
-    tier,eng,N,_,tot = p[0],p[1],int(p[2]),p[3],float(p[4])
-    rows[tier][eng][N].append(tot)
-    if len(p)>=6 and p[5]: nat[tier][eng].append(float(p[5]))
+echo "─── Q4 tier (lattice differentiator — QuaRot rotation; MLX Q4 g64 reference) ───"
+uv run --quiet --with mlx-lm python3 "$REPO/scripts/bench_decode_adapters_apples_to_apples.py" \
+  run --profile apples_to_apples_q4 --allow-missing-engine --out "$OUT/a2a_q4_raw.jsonl"
+q4_status=$?
+echo ""
 
-def slope(t1,t2): return (N2-N1)/(t2-t1) if t2>t1 else float('nan')
+echo "Raw observations: $OUT/a2a_q8_raw.jsonl, $OUT/a2a_q4_raw.jsonl"
 
-def report_tier(tier, engines, header):
-    if not any(N1 in rows[tier][e] and N2 in rows[tier][e] for e in engines): return None
-    print(f"\n{header}")
-    print(f"  {'engine':<10}{'slope tok/s':>13}{'native tok/s':>15}{'naive N2/T2':>14}")
-    print("  " + "-"*52)
-    out={}
-    for eng in engines:
-        if N1 not in rows[tier][eng] or N2 not in rows[tier][eng]:
-            print(f"  {eng:<10}{'(no data)':>13}"); continue
-        t1,t2 = st.median(rows[tier][eng][N1]), st.median(rows[tier][eng][N2])
-        s = slope(t1,t2); naive = N2/t2
-        native = st.median(nat[tier][eng]) if nat[tier][eng] else float('nan')
-        out[eng] = s
-        ns = f"{native:13.1f}" if native==native else f"{'—':>13}"
-        print(f"  {eng:<10}{s:13.1f}{ns:>15}{naive:14.1f}")
-    return out
-
-q8 = report_tier("q8", ["lattice","ollama","mlx"], "═══ Q8 tier ═══")
-q4 = report_tier("q4", ["lattice","mlx"],          "═══ Q4 tier (lattice product differentiator) ═══")
-
-print("\n═══ Apples-to-apple verdict (public Metal API only) ═══")
-if q8 and "lattice" in q8 and "ollama" in q8 and q8["ollama"]>0:
-    d = (q8["lattice"]/q8["ollama"]-1)*100
-    print(f"  Q8: Lattice is {abs(d):.1f}% {'FASTER' if d>0 else 'SLOWER'} than Ollama")
-if q4 and "lattice" in q4:
-    print(f"  Q4: Lattice {q4['lattice']:.1f} tok/s (no public-API Q4 peer — Ollama lacks 0.8b Q4)")
-
-print("\n═══ Reference (different category — AMX private API) ═══")
-if q8 and "lattice" in q8 and "mlx" in q8 and q8["mlx"]>0:
-    d = (q8["lattice"]/q8["mlx"]-1)*100
-    print(f"  Q8 vs MLX: Lattice is {abs(d):.1f}% {'FASTER' if d>0 else 'SLOWER'} (MLX uses AMX)")
-if q4 and "lattice" in q4 and "mlx" in q4 and q4["mlx"]>0:
-    d = (q4["lattice"]/q4["mlx"]-1)*100
-    print(f"  Q4 vs MLX: Lattice is {abs(d):.1f}% {'FASTER' if d>0 else 'SLOWER'} (MLX uses AMX)")
-
-print(f"\nRaw data: {data}")
-PY
+if [[ $q8_status -ne 0 || $q4_status -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/bench_decode_adapters_apples_to_apples.py
+++ b/scripts/bench_decode_adapters_apples_to_apples.py
@@ -35,21 +35,27 @@ the harness's PRIMARY reported slope always uses its own wall-clock
 intentional harness invariant (`AdapterRunResult.native_ns` is a diagnostic,
 "never a replacement" for it), not something an adapter can override, so the
 primary slope column is NOT claimed to be byte-for-byte identical to the
-legacy script's per-engine self-timed metric. MLX's primary metric IS an
-exact match regardless: this adapter times nothing beyond `generate()`
-itself (no post-generation retokenization happens inside `run()` at all, see
-`MlxAdapter.run()`), so the harness's wall-clock window equals the legacy
-script's own `t0 = time.time(); generate(...); dt = ...` window exactly,
-model load amortized identically via the same first-call warmup shape.
-Ollama's primary metric is NOT byte-identical to the legacy script's
-`total_duration`-based figure -- the harness's wall clock additionally
-includes the local HTTP round trip's connection/JSON marshalling overhead,
-which the legacy script's own duration source did not -- but the
-legacy-equivalent number is not lost: ollama's `total_duration` (exactly the
-field the legacy script used for its own primary slope, NOT the decode-only
-`eval_duration`) is preserved losslessly via `AdapterRunResult.native_ns`,
-reported as the harness's "native tok/s" diagnostic column, same mechanism
-as lattice's entry above.
+legacy script's per-engine self-timed metric for EITHER engine. MLX has had
+its MATERIAL divergence removed, not all divergence: this adapter times
+nothing beyond `generate()` itself -- no post-generation retokenization
+happens inside `run()` at all (see `MlxAdapter.run()`), which was the
+significant gap (a real, output-length-dependent cost) -- but the harness's
+wall-clock window still additionally covers the cached `_load()`
+lookup/tuple-unpacking immediately before `generate()` and the
+`AdapterRunResult` construction immediately after, neither of which the
+legacy script's own `t0 = time.time(); generate(...); dt = ...` window
+included. That residual is ordinary adapter/harness call overhead (a cache
+dict lookup and a dataclass construction, not a variable, output-dependent
+cost like retokenization was), not claimed to be zero. Ollama's primary
+metric is NOT byte-identical to the legacy script's `total_duration`-based
+figure either -- the harness's wall clock additionally includes the local
+HTTP round trip's connection/JSON marshalling overhead, which the legacy
+script's own duration source did not -- but the legacy-equivalent number is
+not lost: ollama's `total_duration` (exactly the field the legacy script
+used for its own primary slope, NOT the decode-only `eval_duration`) is
+preserved losslessly via `AdapterRunResult.native_ns`, reported as the
+harness's "native tok/s" diagnostic column, same mechanism as lattice's
+entry above.
 
 Run with (from repo root): `uv run --quiet --with mlx-lm python3
 scripts/bench_decode_adapters_apples_to_apples.py run --profile
@@ -330,6 +336,14 @@ def ollama_response_to_result(data: dict) -> harness.AdapterRunResult:
     "successful" observation. `eval_duration` is required and type-checked
     for response-shape integrity even though it is not the field this
     function extracts into `native_ns`.
+
+    All three fields must be non-boolean `int` -- ollama's own API
+    documents `eval_count`/`eval_duration`/`total_duration` as integers
+    (nanosecond counts / token counts), so a `float` (e.g. `31.9`) is
+    rejected too, not just a missing or wrong-type field: silently
+    truncating a fractional value via `int(31.9) == 31` would be the same
+    fake-observation class this function exists to close, just reached
+    through a technically-numeric value instead of a missing one.
     """
     if "error" in data:
         raise OllamaResponseError(f"ollama: response is an error body: {data['error']!r}")
@@ -337,9 +351,9 @@ def ollama_response_to_result(data: dict) -> harness.AdapterRunResult:
         if field not in data:
             raise OllamaResponseError(f"ollama: response missing required field {field!r}: {data!r}")
         value = data[field]
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
+        if isinstance(value, bool) or not isinstance(value, int):
             raise OllamaResponseError(
-                f"ollama: response field {field!r} has non-numeric type "
+                f"ollama: response field {field!r} must be a non-boolean int, got "
                 f"{type(value).__name__}: {data!r}"
             )
     eval_count = data["eval_count"]
@@ -451,8 +465,13 @@ class MlxAdapter:
     the harness's wall-clock `elapsed_ns` wraps the entire `run()` call --
     any work added after `generate()` returns would silently inflate the
     harness's primary timing beyond decode alone. Trusting `n_tokens`
-    verbatim, exactly like the legacy script did, keeps that window equal to
-    `generate()`'s own duration.
+    verbatim, exactly like the legacy script did, removes that
+    output-length-dependent divergence from the harness's timing window.
+    The window is not claimed to equal `generate()`'s own duration exactly:
+    it still includes the cached `_load()` lookup/unpacking immediately
+    before `generate()` and the `AdapterRunResult` construction immediately
+    after -- ordinary, near-fixed adapter/harness call overhead, not a
+    variable cost like retokenization was.
     """
 
     def __init__(self, source_model_dir: Path = Q8_MODEL_DIR):
@@ -536,7 +555,13 @@ def register_available_adapters(argv: list[str] | None = None) -> None:
     """
     argv = sys.argv[1:] if argv is None else argv
     profile = _peek_requested_profile(argv)
-    should_register, missing_model_dirs = lattice_registration_status(profile)
+    # Pass the module-level LAT_BIN explicitly (looked up fresh here, at
+    # call time) rather than relying on lattice_registration_status's own
+    # `bin_path` default -- a keyword-only default is bound ONCE when the
+    # function is defined, so a test (or any caller) that reassigns the
+    # module-level LAT_BIN after import would silently keep hitting the
+    # original path if this call omitted it.
+    should_register, missing_model_dirs = lattice_registration_status(profile, bin_path=LAT_BIN)
     if should_register:
         harness.register_adapter("lattice", LatticeAdapter())
         print("  lattice: adapter registered")

--- a/scripts/bench_decode_adapters_apples_to_apples.py
+++ b/scripts/bench_decode_adapters_apples_to_apples.py
@@ -27,13 +27,29 @@ harness's separate "native tok/s" diagnostic column -- this is exactly the
 distinction `Observation.elapsed_ns` vs `Observation.engine_native_ns` exists
 for. Closing this gap fully would need a persistent/server mode for
 `bench_decode_ab`, which is out of scope for this migration (no Rust source
-under `crates/inference/` is touched here). Ollama and MLX do not have this
-issue: ollama's harness call is a single HTTP round trip (methodology-
-identical to the legacy script's `curl` call), and MLX's model is loaded and
-quantized once, in-process, lazily on this module's first call for a given
-(model, quantization) pair -- reproducing the legacy script's one-load-per-
-tier shape exactly, since `generate()` alone is timed per call, same as the
-legacy script's own `t0 = time.time(); generate(...); dt = ...`.
+under `crates/inference/` is touched here).
+
+Duration-boundary parity for ollama and MLX (declared, post-hardening):
+the harness's PRIMARY reported slope always uses its own wall-clock
+`elapsed_ns` around the whole `adapter.run()` call -- this is a fixed,
+intentional harness invariant (`AdapterRunResult.native_ns` is a diagnostic,
+"never a replacement" for it), not something an adapter can override, so the
+primary slope column is NOT claimed to be byte-for-byte identical to the
+legacy script's per-engine self-timed metric. MLX's primary metric IS an
+exact match regardless: this adapter times nothing beyond `generate()`
+itself (no post-generation retokenization happens inside `run()` at all, see
+`MlxAdapter.run()`), so the harness's wall-clock window equals the legacy
+script's own `t0 = time.time(); generate(...); dt = ...` window exactly,
+model load amortized identically via the same first-call warmup shape.
+Ollama's primary metric is NOT byte-identical to the legacy script's
+`total_duration`-based figure -- the harness's wall clock additionally
+includes the local HTTP round trip's connection/JSON marshalling overhead,
+which the legacy script's own duration source did not -- but the
+legacy-equivalent number is not lost: ollama's `total_duration` (exactly the
+field the legacy script used for its own primary slope, NOT the decode-only
+`eval_duration`) is preserved losslessly via `AdapterRunResult.native_ns`,
+reported as the harness's "native tok/s" diagnostic column, same mechanism
+as lattice's entry above.
 
 Run with (from repo root): `uv run --quiet --with mlx-lm python3
 scripts/bench_decode_adapters_apples_to_apples.py run --profile
@@ -45,7 +61,9 @@ matching the legacy script's own `uv run --with mlx-lm` invocation).
 
 from __future__ import annotations
 
+import argparse
 import json
+import math
 import os
 import re
 import shutil
@@ -76,17 +94,20 @@ _LATTICE_MODEL_DIRS: dict[str, Path] = {
 # -- ollama: exactly bench_apples_to_apples.sh's model_tag / API shape --
 OLLAMA_BASE_URL = os.environ.get("LATTICE_BENCH_OLLAMA_URL", "http://localhost:11434")
 
-_RESULT_RE = re.compile(r"RESULT n_req=(\d+) completion=(\d+) total_ms=([\d.]+)")
+_RESULT_RE = re.compile(r"^RESULT n_req=(\d+) completion=(\d+) total_ms=([\d.]+)$")
 
 
 def parse_lattice_result_line(line: str) -> tuple[int, int, float] | None:
-    """Parse one `bench_decode_ab` stdout line. Returns `(n_req, completion,
-    total_ms)` or `None` if the line is not a RESULT line (the binary also
-    prints `[bench] ...` progress lines to stderr, and may print other
-    stdout noise -- callers scan all stdout lines and use the last match,
-    mirroring the legacy awk filter `/^RESULT/`).
+    """Parse one `bench_decode_ab` stdout line as a full-line RESULT record.
+    Returns `(n_req, completion, total_ms)`, or `None` if the line is not an
+    EXACT `RESULT n_req=<int> completion=<int> total_ms=<float>` match -- no
+    prefix or suffix noise tolerated. The legacy script's awk filter
+    (`/^RESULT/`) matched a RESULT-bearing SUBSTRING anywhere in the line;
+    this adapter invokes with `BENCH_RUNS=1` (one clean line expected per
+    call), so a stricter full-line anchor rejects a stale/prefixed/noisy
+    line outright instead of scavenging a match out of it.
     """
-    m = _RESULT_RE.search(line)
+    m = _RESULT_RE.match(line)
     if m is None:
         return None
     return int(m.group(1)), int(m.group(2)), float(m.group(3))
@@ -94,6 +115,54 @@ def parse_lattice_result_line(line: str) -> tuple[int, int, float] | None:
 
 class LatticeUnavailableError(RuntimeError):
     """`bench_decode_ab` is not built, or the requested model dir is missing."""
+
+
+class LatticeResultError(RuntimeError):
+    """`bench_decode_ab` ran and exited 0, but its RESULT output failed
+    validation: not exactly one full-line RESULT record, a `n_req` that
+    does not match the window actually requested, or a non-finite/negative
+    measurement. Distinct from `LatticeUnavailableError` (binary/model not
+    present, a registration-time condition) -- this is a data-integrity
+    failure from an engine that DID run, and must crash loud rather than
+    silently become a fabricated or mislabeled observation.
+    """
+
+
+def extract_single_result(stdout: str, *, n_tokens: int) -> tuple[int, int, float]:
+    """Scan `stdout` for full-line RESULT records (see
+    `parse_lattice_result_line`) and return the single one expected for a
+    `BENCH_RUNS=1` invocation, as `(n_req, completion, total_ms)`.
+
+    Raises `LatticeResultError` if there is not EXACTLY one RESULT line (zero
+    -- no output; more than one -- a stale/duplicated line, since one
+    `BENCH_RUNS=1` call must print exactly one), if the line's `n_req` does
+    not equal the `n_tokens` window that was actually requested (a stale or
+    wrong binary emitting a RESULT line for a different window must not
+    silently become an observation labeled as the requested window), or if
+    `completion`/`total_ms` are not finite and non-negative.
+    """
+    matches = [
+        parsed
+        for parsed in (parse_lattice_result_line(line) for line in stdout.splitlines())
+        if parsed is not None
+    ]
+    if len(matches) == 0:
+        raise LatticeResultError(f"lattice: no full-line RESULT record found in stdout: {stdout[-500:]!r}")
+    if len(matches) > 1:
+        raise LatticeResultError(
+            f"lattice: expected exactly one RESULT record for BENCH_RUNS=1, found {len(matches)}: {matches!r}"
+        )
+    n_req, completion, total_ms = matches[0]
+    if n_req != n_tokens:
+        raise LatticeResultError(
+            f"lattice: RESULT n_req={n_req} does not match the requested window "
+            f"n_tokens={n_tokens} (stale or wrong binary?)"
+        )
+    if completion < 0:
+        raise LatticeResultError(f"lattice: RESULT completion={completion} is negative")
+    if not math.isfinite(total_ms) or total_ms < 0:
+        raise LatticeResultError(f"lattice: RESULT total_ms={total_ms} is not finite and non-negative")
+    return n_req, completion, total_ms
 
 
 class LatticeAdapter:
@@ -136,17 +205,10 @@ class LatticeAdapter:
             raise LatticeUnavailableError(
                 f"lattice: bench_decode_ab exited {proc.returncode}: {proc.stderr.strip()[-2000:]}"
             )
-        parsed = None
-        for out_line in proc.stdout.splitlines():
-            result = parse_lattice_result_line(out_line)
-            if result is not None:
-                parsed = result
-        if parsed is None:
-            raise LatticeUnavailableError(
-                "lattice: no RESULT line in bench_decode_ab stdout "
-                f"(stderr: {proc.stderr.strip()[-500:]})"
-            )
-        _n_req, completion, total_ms = parsed
+        try:
+            _n_req, completion, total_ms = extract_single_result(proc.stdout, n_tokens=n_tokens)
+        except LatticeResultError as exc:
+            raise LatticeResultError(f"{exc} (stderr: {proc.stderr.strip()[-500:]})") from exc
         return harness.AdapterRunResult(
             actual_completion_tokens=completion,
             native_ns=round(total_ms * 1e6),
@@ -158,26 +220,140 @@ def lattice_available(bin_path: Path = LAT_BIN) -> bool:
     return bin_path.is_file() and os.access(bin_path, os.X_OK)
 
 
+def _lattice_required_model_dirs(profile: harness.ProfileConfig) -> tuple[Path, ...]:
+    """Every local model directory the profile's `lattice` engine group(s)
+    will need, resolved via `_LATTICE_MODEL_DIRS`. Empty if the profile has
+    no `lattice` engine group.
+    """
+    dirs: list[Path] = []
+    for group in profile.engine_groups:
+        if group.name != "lattice":
+            continue
+        model_dir = _LATTICE_MODEL_DIRS.get(group.model)
+        if model_dir is not None:
+            dirs.append(model_dir)
+    return tuple(dirs)
+
+
+def lattice_registration_status(
+    profile: harness.ProfileConfig | None, *, bin_path: Path = LAT_BIN
+) -> tuple[bool, tuple[Path, ...]]:
+    """Whether the lattice adapter should be registered for `profile`, and
+    which of the profile's required model directories (if any) are missing.
+
+    Binary presence alone is NOT sufficient: a binary present with a
+    profile-required model directory absent must reproduce the legacy
+    script's per-engine graceful skip (`bench_lattice`'s own
+    `[[ ! -d "$model_dir" ]] && echo MODEL MISSING && return`) at
+    REGISTRATION time, not surface as a `LatticeUnavailableError` raised
+    mid-run that `--allow-missing-engine` cannot catch (the harness only
+    treats an engine as "missing" when its name is absent from the adapter
+    registry entirely -- see `bench_decode_harness.run_profile`).
+
+    `profile=None` (the requested profile could not be determined, e.g. no
+    `--profile` argument was found while peeking argv) falls back to
+    binary-only availability -- the pre-fix behavior, so an unrecognized
+    invocation shape still registers lattice and lets the harness's
+    `MissingEngineError` / this module's `LatticeUnavailableError` surface
+    any problem, rather than silently never registering lattice at all.
+    """
+    bin_ok = bin_path.is_file() and os.access(bin_path, os.X_OK)
+    if not bin_ok:
+        return False, ()
+    if profile is None:
+        return True, ()
+    required = _lattice_required_model_dirs(profile)
+    missing = tuple(d for d in required if not d.is_dir())
+    return (len(missing) == 0), missing
+
+
+def _peek_requested_profile(argv: list[str]) -> harness.ProfileConfig | None:
+    """Best-effort peek at the `--profile`/`--profiles-file` arguments
+    `bench_decode_harness.main()` will parse, so lattice's model-dir
+    availability can be checked for the SPECIFIC profile about to run.
+    Registration happens at module-import time (`register_available_adapters`
+    runs before `harness.main()` parses `argv`), so this module has to do its
+    own lightweight peek rather than wait for the harness's own parse.
+
+    Returns `None` (never raises) on anything unexpected: no `--profile`
+    found, an unknown profile name, or a profiles file that fails to load --
+    `lattice_registration_status` treats `None` as "fall back to binary-only
+    availability", matching this module's pre-fix behavior.
+    """
+    peek = argparse.ArgumentParser(add_help=False)
+    peek.add_argument("--profile", default=None)
+    peek.add_argument("--profiles-file", type=Path, default=harness.DEFAULT_PROFILES_FILE)
+    try:
+        known, _ignored = peek.parse_known_args(argv)
+    except SystemExit:
+        return None
+    if known.profile is None:
+        return None
+    try:
+        _schema_version, profiles = harness.load_profiles_file(known.profiles_file)
+    except harness.ProfileConfigError:
+        return None
+    return profiles.get(known.profile)
+
+
 # --------------------------------------------------------------------------
 # ollama
 # --------------------------------------------------------------------------
 
 
-def ollama_response_to_result(data: dict, *, requested_tokens: int) -> harness.AdapterRunResult:
-    """Pure translation of one `/api/generate` JSON body into an
-    `AdapterRunResult`, mirroring the legacy script's
-    `ec=d.get('eval_count',0); ed=d.get('eval_duration',1)/1e9; ec/ed` native
-    rate. `eval_duration` is already nanoseconds in ollama's response, so it
-    is used directly as `native_ns` (no unit conversion needed, unlike the
-    legacy script's own `/1e9` which converts to seconds only for its
-    printed ratio).
+class OllamaResponseError(RuntimeError):
+    """An ollama `/api/generate` response is an error body, or is missing a
+    required field, or has a required field of the wrong type. A
+    structurally-valid-JSON error response (e.g. a proxy or an overloaded
+    server returning `{"error": "..."}` with HTTP 200) must never be
+    silently translated into a fabricated measurement -- it must crash the
+    call loud instead.
     """
-    eval_count = data.get("eval_count", 0) or 0
-    eval_duration = data.get("eval_duration")
-    native_ns = eval_duration if eval_duration else None
+
+
+_REQUIRED_OLLAMA_FIELDS = ("eval_count", "eval_duration", "total_duration")
+
+
+def ollama_response_to_result(data: dict) -> harness.AdapterRunResult:
+    """Pure translation of one `/api/generate` JSON body into an
+    `AdapterRunResult`.
+
+    `native_ns` mirrors the legacy script's PRIMARY slope metric exactly:
+    `tot = d.get('total_duration',0)/1e9`, the field the legacy script fed
+    directly into its own slope calculation -- NOT the decode-only
+    `eval_duration` (that was the legacy script's separate `ec/ed`
+    reference-only "native tok/s" column, a different number). Requires and
+    type-checks `eval_count`/`eval_duration`/`total_duration`; rejects an
+    error body (a top-level `"error"` key) or any missing/non-numeric
+    required field by raising `OllamaResponseError` rather than substituting
+    a default -- a `0` or an absent field must never quietly become a fake
+    "successful" observation. `eval_duration` is required and type-checked
+    for response-shape integrity even though it is not the field this
+    function extracts into `native_ns`.
+    """
+    if "error" in data:
+        raise OllamaResponseError(f"ollama: response is an error body: {data['error']!r}")
+    for field in _REQUIRED_OLLAMA_FIELDS:
+        if field not in data:
+            raise OllamaResponseError(f"ollama: response missing required field {field!r}: {data!r}")
+        value = data[field]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise OllamaResponseError(
+                f"ollama: response field {field!r} has non-numeric type "
+                f"{type(value).__name__}: {data!r}"
+            )
+    eval_count = data["eval_count"]
+    eval_duration = data["eval_duration"]
+    total_duration = data["total_duration"]
+    if eval_count < 0:
+        raise OllamaResponseError(f"ollama: eval_count={eval_count!r} is negative: {data!r}")
+    if eval_duration < 0:
+        raise OllamaResponseError(f"ollama: eval_duration={eval_duration!r} is negative: {data!r}")
+    if total_duration <= 0:
+        raise OllamaResponseError(f"ollama: total_duration={total_duration!r} must be positive: {data!r}")
     return harness.AdapterRunResult(
-        actual_completion_tokens=eval_count or requested_tokens,
-        native_ns=native_ns,
+        actual_completion_tokens=int(eval_count),
+        native_ns=int(total_duration),
         engine_version="ollama",
     )
 
@@ -210,7 +386,7 @@ class OllamaAdapter:
         )
         with urllib.request.urlopen(req, timeout=600) as resp:
             data = json.loads(resp.read())
-        return ollama_response_to_result(data, requested_tokens=n_tokens)
+        return ollama_response_to_result(data)
 
 
 def ollama_available(
@@ -267,11 +443,25 @@ class MlxAdapter:
     reproducing the legacy script's one-load-per-tier shape (a fresh
     process per profile run keeps Q8 and Q4 tiers independent, matching the
     legacy script's separate `uv run` invocation per tier).
+
+    `run()` does no work after `generate()` returns (no retokenization, no
+    length verification): the legacy script never verified actual token
+    count either (`generate(..., max_tokens=N, ...)` under `temp=0.0`, its
+    printed row always used the REQUESTED `N`, never a verified count), and
+    the harness's wall-clock `elapsed_ns` wraps the entire `run()` call --
+    any work added after `generate()` returns would silently inflate the
+    harness's primary timing beyond decode alone. Trusting `n_tokens`
+    verbatim, exactly like the legacy script did, keeps that window equal to
+    `generate()`'s own duration.
     """
 
     def __init__(self, source_model_dir: Path = Q8_MODEL_DIR):
         self.source_model_dir = source_model_dir
-        self._cache: dict[tuple[str, str], tuple[object, object, object]] = {}
+        # (mlx_model, tok, sampler, fallback_model_id) -- fallback_model_id
+        # is None when the requested source_model_dir loaded successfully,
+        # else the Hub identifier that was actually loaded instead (see
+        # `run()`'s `actual_model` below).
+        self._cache: dict[tuple[str, str], tuple[object, object, object, str | None]] = {}
 
     def _load(self, model: str, quantization: str):
         key = (model, quantization)
@@ -284,28 +474,35 @@ class MlxAdapter:
         from mlx_lm.sample_utils import make_sampler
 
         bits = 4 if quantization == "q4" else 8
+        fallback_model_id: str | None = None
         try:
             mlx_model, tok = load(str(self.source_model_dir))
         except Exception:  # noqa: BLE001 -- legacy script's own bare except fallback
             mlx_model, tok = load("Qwen/Qwen3.5-0.8B")
+            fallback_model_id = "Qwen/Qwen3.5-0.8B"
         nn.quantize(mlx_model, bits=bits, group_size=64)
         mx.eval(mlx_model.parameters())
         sampler = make_sampler(temp=0.0)
-        self._cache[key] = (mlx_model, tok, sampler)
-        return mlx_model, tok, sampler
+        entry = (mlx_model, tok, sampler, fallback_model_id)
+        self._cache[key] = entry
+        return entry
 
     def run(
         self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
     ) -> harness.AdapterRunResult:
         from mlx_lm import generate
 
-        mlx_model, tok, sampler = self._load(model, quantization)
-        result = generate(
-            mlx_model, tok, prompt=prompt, max_tokens=n_tokens, sampler=sampler, verbose=False
-        )
-        actual_tokens = len(tok.encode(result)) if isinstance(result, str) else n_tokens
+        mlx_model, tok, sampler, fallback_model_id = self._load(model, quantization)
+        generate(mlx_model, tok, prompt=prompt, max_tokens=n_tokens, sampler=sampler, verbose=False)
         return harness.AdapterRunResult(
-            actual_completion_tokens=actual_tokens, engine_version="mlx_lm"
+            actual_completion_tokens=n_tokens,
+            engine_version="mlx_lm",
+            # Provenance: a fallback load means the observation actually
+            # measured Qwen/Qwen3.5-0.8B from the Hub, not the requested
+            # local artifact -- record what really ran (see
+            # AdapterRunResult.actual_model's contract) instead of letting
+            # the raw observation silently mislabel it as the local model.
+            actual_model=fallback_model_id,
         )
 
 
@@ -322,15 +519,30 @@ def mlx_available() -> bool:
 # --------------------------------------------------------------------------
 
 
-def register_available_adapters() -> None:
+def register_available_adapters(argv: list[str] | None = None) -> None:
     """Registers whichever of lattice/ollama/mlx are actually available,
     printing a legacy-style message for each -- mirroring
     `bench_apples_to_apples.sh`'s per-engine graceful skip (missing binary /
     missing model dir / ollama not installed all print-and-continue rather
-    than aborting the whole run)."""
-    if lattice_available():
+    than aborting the whole run).
+
+    Lattice's registration is MODEL-aware, not just binary-aware: the binary
+    can be present while the specific profile about to run needs a model
+    directory that is not (e.g. Q8 weights present, Q4 weights absent). A
+    `LatticeUnavailableError` raised mid-run for that case is not caught
+    anywhere `--allow-missing-engine` can act on, so it must not be
+    registered in the first place -- see `lattice_registration_status` and
+    `_peek_requested_profile`.
+    """
+    argv = sys.argv[1:] if argv is None else argv
+    profile = _peek_requested_profile(argv)
+    should_register, missing_model_dirs = lattice_registration_status(profile)
+    if should_register:
         harness.register_adapter("lattice", LatticeAdapter())
         print("  lattice: adapter registered")
+    elif missing_model_dirs:
+        joined = ", ".join(str(d) for d in missing_model_dirs)
+        print(f"  lattice: MODEL MISSING ({joined}) — build/download first — skipping")
     else:
         print(
             f"  lattice: BIN MISSING ({LAT_BIN}) — build first "

--- a/scripts/bench_decode_adapters_apples_to_apples.py
+++ b/scripts/bench_decode_adapters_apples_to_apples.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Engine adapters for the `apples_to_apples_q8`/`apples_to_apples_q4`
+profiles (issue #813 step 2: migrate `bench_apples_to_apples.sh`).
+
+This is the "thin wrapper that execs the harness" the issue calls for: it
+registers three `EngineAdapter`s (lattice, ollama, mlx) that invoke exactly
+what `bench_apples_to_apples.sh`'s `bench_lattice`/`bench_ollama`/`bench_mlx`
+shell functions invoked, then delegates argument parsing and execution to
+`bench_decode_harness.main()`. All repeat-count, warmup, and verdict
+decisions stay in the harness/profile (`bench_decode_profiles.toml`); this
+module owns invocation and parsing only, per `EngineAdapter`'s contract.
+
+Known, disclosed methodology note (lattice only): `bench_decode_ab` amortizes
+one model load across `BENCH_RUNS` internal repeats within a single process
+(its own per-run timer starts AFTER load, so load never enters any of its
+`total_ms` values). The harness's contract is one `EngineAdapter.run()` call
+per measured repeat, each independently wall-clock-timed by the harness
+itself around the call -- there is no persistent-server mode for
+`bench_decode_ab` to reuse a loaded model across separate harness-driven
+calls, so this adapter invokes it with `BENCH_RUNS=1` per call. Each of the
+five `elapsed_ns` measurements per window therefore includes one subprocess
+spawn + model load + `bench_decode_ab`'s own internal untimed warmup, which
+the legacy script's `total_ms` excluded entirely. The engine's own
+decode-only `total_ms` (methodology-identical to the legacy metric) is
+preserved losslessly via `AdapterRunResult.native_ns`, reported as the
+harness's separate "native tok/s" diagnostic column -- this is exactly the
+distinction `Observation.elapsed_ns` vs `Observation.engine_native_ns` exists
+for. Closing this gap fully would need a persistent/server mode for
+`bench_decode_ab`, which is out of scope for this migration (no Rust source
+under `crates/inference/` is touched here). Ollama and MLX do not have this
+issue: ollama's harness call is a single HTTP round trip (methodology-
+identical to the legacy script's `curl` call), and MLX's model is loaded and
+quantized once, in-process, lazily on this module's first call for a given
+(model, quantization) pair -- reproducing the legacy script's one-load-per-
+tier shape exactly, since `generate()` alone is timed per call, same as the
+legacy script's own `t0 = time.time(); generate(...); dt = ...`.
+
+Run with (from repo root): `uv run --quiet --with mlx-lm python3
+scripts/bench_decode_adapters_apples_to_apples.py run --profile
+apples_to_apples_q8 --allow-missing-engine` (mlx-lm must be available in the
+invoking environment since the mlx engine is present in both profiles; the
+`--with mlx-lm` flag is how `scripts/bench_apples_to_apples.sh` provides it,
+matching the legacy script's own `uv run --with mlx-lm` invocation).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_decode_harness as harness  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# -- lattice: exactly bench_apples_to_apples.sh's Q8_DIR/Q4_DIR/LAT_BIN --
+LAT_BIN = REPO_ROOT / "target" / "release" / "bench_decode_ab"
+Q8_MODEL_DIR = Path.home() / ".lattice" / "models" / "qwen3.5-0.8b"
+Q4_MODEL_DIR = Path.home() / ".lattice" / "models" / "qwen3.5-0.8b-q4-quarot"
+# The legacy script's Q4 lattice invocation keeps LATTICE_TOKENIZER_DIR
+# pointed at Q8_DIR even for the Q4 tier (`bench_lattice "q4" "$Q4_DIR"
+# "$Q8_DIR" "LATTICE_QUANT_FORMAT=Q4"`); preserved verbatim here.
+_LATTICE_MODEL_DIRS: dict[str, Path] = {
+    "qwen3.5-0.8b": Q8_MODEL_DIR,
+    "qwen3.5-0.8b-q4-quarot": Q4_MODEL_DIR,
+}
+
+# -- ollama: exactly bench_apples_to_apples.sh's model_tag / API shape --
+OLLAMA_BASE_URL = os.environ.get("LATTICE_BENCH_OLLAMA_URL", "http://localhost:11434")
+
+_RESULT_RE = re.compile(r"RESULT n_req=(\d+) completion=(\d+) total_ms=([\d.]+)")
+
+
+def parse_lattice_result_line(line: str) -> tuple[int, int, float] | None:
+    """Parse one `bench_decode_ab` stdout line. Returns `(n_req, completion,
+    total_ms)` or `None` if the line is not a RESULT line (the binary also
+    prints `[bench] ...` progress lines to stderr, and may print other
+    stdout noise -- callers scan all stdout lines and use the last match,
+    mirroring the legacy awk filter `/^RESULT/`).
+    """
+    m = _RESULT_RE.search(line)
+    if m is None:
+        return None
+    return int(m.group(1)), int(m.group(2)), float(m.group(3))
+
+
+class LatticeUnavailableError(RuntimeError):
+    """`bench_decode_ab` is not built, or the requested model dir is missing."""
+
+
+class LatticeAdapter:
+    """Invokes `target/release/bench_decode_ab`, mirroring
+    `bench_apples_to_apples.sh`'s `bench_lattice()` exactly, one measured
+    repeat per call (`BENCH_RUNS=1`) -- see module docstring for the
+    disclosed model-load-per-call methodology note.
+    """
+
+    def __init__(self, bin_path: Path = LAT_BIN, tokenizer_dir: Path = Q8_MODEL_DIR):
+        self.bin_path = bin_path
+        self.tokenizer_dir = tokenizer_dir
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        model_dir = _LATTICE_MODEL_DIRS.get(model)
+        if model_dir is None:
+            raise LatticeUnavailableError(f"lattice: no known model dir for model={model!r}")
+        if not model_dir.is_dir():
+            raise LatticeUnavailableError(f"lattice: model dir missing ({model_dir})")
+
+        env = os.environ.copy()
+        env["BENCH_N"] = str(n_tokens)
+        env["BENCH_RUNS"] = "1"
+        env["LATTICE_MODEL_DIR"] = str(model_dir)
+        env["LATTICE_TOKENIZER_DIR"] = str(self.tokenizer_dir)
+        if quantization == "q4":
+            env["LATTICE_QUANT_FORMAT"] = "Q4"
+
+        proc = subprocess.run(
+            [str(self.bin_path)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise LatticeUnavailableError(
+                f"lattice: bench_decode_ab exited {proc.returncode}: {proc.stderr.strip()[-2000:]}"
+            )
+        parsed = None
+        for out_line in proc.stdout.splitlines():
+            result = parse_lattice_result_line(out_line)
+            if result is not None:
+                parsed = result
+        if parsed is None:
+            raise LatticeUnavailableError(
+                "lattice: no RESULT line in bench_decode_ab stdout "
+                f"(stderr: {proc.stderr.strip()[-500:]})"
+            )
+        _n_req, completion, total_ms = parsed
+        return harness.AdapterRunResult(
+            actual_completion_tokens=completion,
+            native_ns=round(total_ms * 1e6),
+            engine_version="lattice-bench_decode_ab",
+        )
+
+
+def lattice_available(bin_path: Path = LAT_BIN) -> bool:
+    return bin_path.is_file() and os.access(bin_path, os.X_OK)
+
+
+# --------------------------------------------------------------------------
+# ollama
+# --------------------------------------------------------------------------
+
+
+def ollama_response_to_result(data: dict, *, requested_tokens: int) -> harness.AdapterRunResult:
+    """Pure translation of one `/api/generate` JSON body into an
+    `AdapterRunResult`, mirroring the legacy script's
+    `ec=d.get('eval_count',0); ed=d.get('eval_duration',1)/1e9; ec/ed` native
+    rate. `eval_duration` is already nanoseconds in ollama's response, so it
+    is used directly as `native_ns` (no unit conversion needed, unlike the
+    legacy script's own `/1e9` which converts to seconds only for its
+    printed ratio).
+    """
+    eval_count = data.get("eval_count", 0) or 0
+    eval_duration = data.get("eval_duration")
+    native_ns = eval_duration if eval_duration else None
+    return harness.AdapterRunResult(
+        actual_completion_tokens=eval_count or requested_tokens,
+        native_ns=native_ns,
+        engine_version="ollama",
+    )
+
+
+class OllamaAdapter:
+    """Invokes ollama's `/api/generate`, mirroring
+    `bench_apples_to_apples.sh`'s `bench_ollama()` exactly: one HTTP call per
+    measured repeat (the shell script also issues no warmup for ollama, and
+    neither does this profile)."""
+
+    def __init__(self, base_url: str = OLLAMA_BASE_URL):
+        self.base_url = base_url
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        payload = json.dumps(
+            {
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "options": {"num_predict": n_tokens, "temperature": 0},
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.base_url}/api/generate",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            data = json.loads(resp.read())
+        return ollama_response_to_result(data, requested_tokens=n_tokens)
+
+
+def ollama_available(
+    base_url: str = OLLAMA_BASE_URL, *, model_tag: str, start_if_down: bool = True
+) -> bool:
+    """Mirrors `bench_apples_to_apples.sh`'s `bench_ollama()` preflight:
+    binary installed, model pulled (best-effort pull if missing), server
+    reachable (best-effort `ollama serve &` + 3s settle if not)."""
+    if shutil.which("ollama") is None:
+        return False
+    try:
+        listed = subprocess.run(
+            ["ollama", "list"], capture_output=True, text=True, timeout=30, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if model_tag not in listed.stdout:
+        pulled = subprocess.run(
+            ["ollama", "pull", model_tag], capture_output=True, text=True, timeout=600, check=False
+        )
+        if pulled.returncode != 0:
+            return False
+    try:
+        urllib.request.urlopen(f"{base_url}/api/tags", timeout=3).read()
+        return True
+    except (urllib.error.URLError, OSError):
+        if not start_if_down:
+            return False
+        try:
+            subprocess.Popen(
+                ["ollama", "serve"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+        except OSError:
+            return False
+        time.sleep(3)
+        try:
+            urllib.request.urlopen(f"{base_url}/api/tags", timeout=3).read()
+            return True
+        except (urllib.error.URLError, OSError):
+            return False
+
+
+# --------------------------------------------------------------------------
+# mlx
+# --------------------------------------------------------------------------
+
+
+class MlxAdapter:
+    """Invokes `mlx_lm` in-process, mirroring `bench_apples_to_apples.sh`'s
+    `bench_mlx()`: load the Q8_DIR safetensors model once, `nn.quantize` it
+    to the requested bit width once, run ONE 8-token warmup, then time only
+    `generate()` per measured call -- model load/quantize is cached per
+    `(model, quantization)` pair across calls within this process, exactly
+    reproducing the legacy script's one-load-per-tier shape (a fresh
+    process per profile run keeps Q8 and Q4 tiers independent, matching the
+    legacy script's separate `uv run` invocation per tier).
+    """
+
+    def __init__(self, source_model_dir: Path = Q8_MODEL_DIR):
+        self.source_model_dir = source_model_dir
+        self._cache: dict[tuple[str, str], tuple[object, object, object]] = {}
+
+    def _load(self, model: str, quantization: str):
+        key = (model, quantization)
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+        import mlx.core as mx
+        import mlx.nn as nn
+        from mlx_lm import load
+        from mlx_lm.sample_utils import make_sampler
+
+        bits = 4 if quantization == "q4" else 8
+        try:
+            mlx_model, tok = load(str(self.source_model_dir))
+        except Exception:  # noqa: BLE001 -- legacy script's own bare except fallback
+            mlx_model, tok = load("Qwen/Qwen3.5-0.8B")
+        nn.quantize(mlx_model, bits=bits, group_size=64)
+        mx.eval(mlx_model.parameters())
+        sampler = make_sampler(temp=0.0)
+        self._cache[key] = (mlx_model, tok, sampler)
+        return mlx_model, tok, sampler
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        from mlx_lm import generate
+
+        mlx_model, tok, sampler = self._load(model, quantization)
+        result = generate(
+            mlx_model, tok, prompt=prompt, max_tokens=n_tokens, sampler=sampler, verbose=False
+        )
+        actual_tokens = len(tok.encode(result)) if isinstance(result, str) else n_tokens
+        return harness.AdapterRunResult(
+            actual_completion_tokens=actual_tokens, engine_version="mlx_lm"
+        )
+
+
+def mlx_available() -> bool:
+    try:
+        import mlx_lm  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# --------------------------------------------------------------------------
+# registration + CLI delegation
+# --------------------------------------------------------------------------
+
+
+def register_available_adapters() -> None:
+    """Registers whichever of lattice/ollama/mlx are actually available,
+    printing a legacy-style message for each -- mirroring
+    `bench_apples_to_apples.sh`'s per-engine graceful skip (missing binary /
+    missing model dir / ollama not installed all print-and-continue rather
+    than aborting the whole run)."""
+    if lattice_available():
+        harness.register_adapter("lattice", LatticeAdapter())
+        print("  lattice: adapter registered")
+    else:
+        print(
+            f"  lattice: BIN MISSING ({LAT_BIN}) — build first "
+            "(cargo build --release --bin bench_decode_ab)"
+        )
+
+    if ollama_available(model_tag="qwen3.5:0.8b"):
+        harness.register_adapter("ollama", OllamaAdapter())
+        print("  ollama: adapter registered")
+    else:
+        print("  ollama: not installed, unreachable, or model pull failed — skipping")
+
+    if mlx_available():
+        harness.register_adapter("mlx", MlxAdapter())
+        print("  mlx: adapter registered")
+    else:
+        print("  mlx: mlx_lm not importable — run via `uv run --with mlx-lm ...` — skipping")
+
+
+if __name__ == "__main__":
+    register_available_adapters()
+    sys.exit(harness.main())

--- a/scripts/bench_decode_profiles.toml
+++ b/scripts/bench_decode_profiles.toml
@@ -184,3 +184,66 @@
 schema_version = 1
 
 [profiles]
+
+# bench_apples_to_apples.sh migration (issue #813 step 2, first script).
+# Two profiles because the legacy script runs two independent tiers with
+# different engine sets and different lattice/mlx quantization: Q8
+# (lattice safetensors auto-quant, ollama registry default, mlx
+# nn.quantize(bits=8)) and Q4 (lattice QuaRot .q4 dir, mlx
+# nn.quantize(bits=4); ollama has no Q4 variant for qwen3.5:0.8b, so it is
+# simply absent from this profile's engines list -- the harness's
+# missing-engine handling is not needed here since ollama was never
+# requested for Q4, not requested-and-unavailable).
+#
+# windows/measured_repeats/prompt are IDENTICAL to bench_apples_to_apples.sh's
+# N1=32, N2=256, RUNS=5, and PROMPT. Neither lattice nor ollama gets a
+# harness-level warmup (the shell script issues no extra warmup call for
+# either); only mlx gets warmup_repeats=1/warmup_tokens=8, reproducing the
+# script's single pre-loop 8-token MLX-only warmup exactly (see
+# bench_decode_harness.py's own `test_heterogeneous_engine_schedule_exact_call_
+# sequence_and_identities`, which validates this identical shape).
+[profiles.apples_to_apples_q8]
+description = "bench_apples_to_apples.sh Q8 tier: lattice (Metal auto Q8) vs ollama vs mlx (private AMX reference)"
+windows = [32, 256]
+measured_repeats = 5
+prompt = "The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
+aggregation = "median"
+
+[[profiles.apples_to_apples_q8.engines]]
+name = "lattice"
+warmup_repeats = 0
+model = "qwen3.5-0.8b"
+quantization = "q8"
+
+[[profiles.apples_to_apples_q8.engines]]
+name = "ollama"
+warmup_repeats = 0
+model = "qwen3.5:0.8b"
+quantization = "q8"
+
+[[profiles.apples_to_apples_q8.engines]]
+name = "mlx"
+warmup_repeats = 1
+warmup_tokens = 8
+model = "qwen3.5-0.8b"
+quantization = "q8"
+
+[profiles.apples_to_apples_q4]
+description = "bench_apples_to_apples.sh Q4 tier: lattice (QuaRot Q4) vs mlx Q4 (ollama has no Q4 variant, omitted)"
+windows = [32, 256]
+measured_repeats = 5
+prompt = "The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
+aggregation = "median"
+
+[[profiles.apples_to_apples_q4.engines]]
+name = "lattice"
+warmup_repeats = 0
+model = "qwen3.5-0.8b-q4-quarot"
+quantization = "q4"
+
+[[profiles.apples_to_apples_q4.engines]]
+name = "mlx"
+warmup_repeats = 1
+warmup_tokens = 8
+model = "qwen3.5-0.8b"
+quantization = "q4"

--- a/tests/test_bench_decode_adapters_apples_to_apples.py
+++ b/tests/test_bench_decode_adapters_apples_to_apples.py
@@ -392,6 +392,15 @@ class OllamaResponseParsingTest(unittest.TestCase):
         with self.assertRaises(adapters.OllamaResponseError):
             adapters.ollama_response_to_result(data)
 
+    def test_fractional_eval_duration_alone_raises(self):
+        # eval_count is validated first, so the all-fractional case above
+        # never reaches eval_duration; this isolates it (a "clean" 1.0
+        # would survive int() conversion without truncation, so it is the
+        # sharpest float to reject on type alone).
+        data = {"eval_count": 32, "eval_duration": 1.0, "total_duration": 1}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
     def test_fractional_total_duration_alone_raises(self):
         data = {"eval_count": 32, "eval_duration": 1, "total_duration": 2.9}
         with self.assertRaises(adapters.OllamaResponseError):

--- a/tests/test_bench_decode_adapters_apples_to_apples.py
+++ b/tests/test_bench_decode_adapters_apples_to_apples.py
@@ -268,35 +268,131 @@ class LatticeResultParsingTest(unittest.TestCase):
         self.assertIsNone(adapters.parse_lattice_result_line("[bench] prompt_tokens=42"))
         self.assertIsNone(adapters.parse_lattice_result_line(""))
 
-    def test_uses_last_result_line_on_multiple(self):
+    def test_rejects_prefixed_noise(self):
+        # A RESULT-bearing SUBSTRING is no longer good enough: the legacy
+        # awk filter (`/^RESULT/`, matches anywhere) would have accepted
+        # this; the stricter BENCH_RUNS=1 contract requires a full-line
+        # match and must not scavenge a match out of a noisy line.
+        line = "[stale-cache] RESULT n_req=32 completion=32 total_ms=812.345"
+        self.assertIsNone(adapters.parse_lattice_result_line(line))
+
+    def test_rejects_suffixed_noise(self):
+        line = "RESULT n_req=32 completion=32 total_ms=812.345 (cached)"
+        self.assertIsNone(adapters.parse_lattice_result_line(line))
+
+
+class ExtractSingleResultTest(unittest.TestCase):
+    """`extract_single_result` is the BENCH_RUNS=1 contract: exactly one
+    full-line RESULT record, whose n_req matches what was actually
+    requested, with finite/non-negative fields -- anything else raises
+    `LatticeResultError` rather than silently accepting a stale, mismatched,
+    or duplicated measurement.
+    """
+
+    def test_happy_path(self):
+        stdout = "[bench] loading model\nRESULT n_req=32 completion=32 total_ms=812.345\n"
+        result = adapters.extract_single_result(stdout, n_tokens=32)
+        self.assertEqual(result, (32, 32, 812.345))
+
+    def test_rejects_no_result_lines(self):
+        with self.assertRaises(adapters.LatticeResultError):
+            adapters.extract_single_result("[bench] loading model\n[bench] done\n", n_tokens=32)
+
+    def test_rejects_duplicate_result_lines(self):
+        # BENCH_RUNS=1 means exactly one RESULT line is expected; two
+        # (e.g. a stale binary that ignored BENCH_RUNS, or leaked output
+        # from a prior invocation) must fail loud, never silently resolve
+        # to "the last one" the way the pre-fix scan did.
         stdout = (
             "RESULT n_req=32 completion=32 total_ms=100.0\n"
             "RESULT n_req=32 completion=32 total_ms=200.0\n"
         )
-        parsed = None
-        for line in stdout.splitlines():
-            result = adapters.parse_lattice_result_line(line)
-            if result is not None:
-                parsed = result
-        self.assertEqual(parsed, (32, 32, 200.0))
+        with self.assertRaises(adapters.LatticeResultError):
+            adapters.extract_single_result(stdout, n_tokens=32)
+
+    def test_rejects_wrong_n_req(self):
+        # A stale/wrong binary emitting a RESULT line for a DIFFERENT
+        # window than the one just requested must not silently become an
+        # observation labeled as the requested window.
+        stdout = "RESULT n_req=256 completion=256 total_ms=1900.0\n"
+        with self.assertRaises(adapters.LatticeResultError):
+            adapters.extract_single_result(stdout, n_tokens=32)
+
+    def test_rejects_prefixed_noise_end_to_end(self):
+        stdout = "[stale-cache] RESULT n_req=32 completion=32 total_ms=812.345\n"
+        with self.assertRaises(adapters.LatticeResultError):
+            adapters.extract_single_result(stdout, n_tokens=32)
 
 
 class OllamaResponseParsingTest(unittest.TestCase):
-    def test_translates_eval_count_and_duration_to_native_ns(self):
+    """`ollama_response_to_result` mirrors the legacy script's PRIMARY slope
+    field exactly (`total_duration`, not the decode-only `eval_duration`),
+    and requires+type-checks the response shape rather than substituting
+    defaults for missing/invalid fields -- a structurally-valid-JSON error
+    body must crash the call loud, never become a fake measurement.
+    """
+
+    def test_translates_total_duration_to_native_ns(self):
         data = {"eval_count": 256, "eval_duration": 2_000_000_000, "total_duration": 2_500_000_000}
-        result = adapters.ollama_response_to_result(data, requested_tokens=256)
+        result = adapters.ollama_response_to_result(data)
         self.assertEqual(result.actual_completion_tokens, 256)
-        self.assertEqual(result.native_ns, 2_000_000_000)
+        # native_ns is total_duration (the legacy script's own primary slope
+        # field), NOT eval_duration (that was the legacy script's separate
+        # decode-only reference column).
+        self.assertEqual(result.native_ns, 2_500_000_000)
 
-    def test_falls_back_to_requested_tokens_when_eval_count_absent(self):
-        result = adapters.ollama_response_to_result({}, requested_tokens=32)
-        self.assertEqual(result.actual_completion_tokens, 32)
-        self.assertIsNone(result.native_ns)
+    def test_error_body_raises(self):
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result({"error": "model not found"})
 
-    def test_zero_eval_duration_yields_no_native_ns(self):
-        data = {"eval_count": 10, "eval_duration": 0}
-        result = adapters.ollama_response_to_result(data, requested_tokens=10)
-        self.assertIsNone(result.native_ns)
+    def test_empty_dict_raises(self):
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result({})
+
+    def test_missing_eval_count_raises(self):
+        data = {"eval_duration": 1, "total_duration": 1}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_missing_eval_duration_raises(self):
+        data = {"eval_count": 32, "total_duration": 1}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_missing_total_duration_raises(self):
+        data = {"eval_count": 32, "eval_duration": 1}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_non_numeric_field_type_raises(self):
+        data = {"eval_count": "32", "eval_duration": 1, "total_duration": 1}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_bool_field_type_raises(self):
+        # bool is an int subclass in Python -- must not sneak past the
+        # numeric-type check.
+        data = {"eval_count": True, "eval_duration": 1, "total_duration": 1}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_negative_eval_count_raises(self):
+        data = {"eval_count": -1, "eval_duration": 1, "total_duration": 1}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_zero_total_duration_raises(self):
+        data = {"eval_count": 10, "eval_duration": 1, "total_duration": 0}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_eval_count_zero_is_trusted_not_substituted(self):
+        # A real, validly-typed zero must be reported as-is -- never
+        # silently replaced with the requested token count (that would be
+        # exactly the kind of fabrication this hardening pass closes).
+        data = {"eval_count": 0, "eval_duration": 1, "total_duration": 1}
+        result = adapters.ollama_response_to_result(data)
+        self.assertEqual(result.actual_completion_tokens, 0)
 
 
 class AvailabilityCheckTest(unittest.TestCase):
@@ -320,6 +416,156 @@ class AvailabilityCheckTest(unittest.TestCase):
         # mlx_lm is a declared project dependency (pyproject.toml); this
         # documents the expectation rather than mocking import machinery.
         self.assertTrue(adapters.mlx_available())
+
+
+# --------------------------------------------------------------------------
+# Model-aware --allow-missing-engine: binary present + model dir absent must
+# reproduce the legacy per-engine graceful skip, not raise mid-run.
+# --------------------------------------------------------------------------
+
+
+class LatticeModelAwareAvailabilityTest(unittest.TestCase):
+    """Real-adapter coverage: a present, executable binary with a missing
+    model directory must (a) make the real `LatticeAdapter.run()` raise
+    cleanly (defense in depth, unchanged), and (b) make the REGISTRATION
+    decision skip lattice entirely for the profile that needs that model,
+    so `--allow-missing-engine` actually engages instead of a
+    `LatticeUnavailableError` aborting the tier mid-run.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+
+    def test_lattice_adapter_run_raises_when_model_dir_missing(self):
+        # The literal "binary present, model dir absent" scenario, exercised
+        # against the REAL LatticeAdapter (not a fake).
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "bench_decode_ab"
+            bin_path.write_text("#!/bin/sh\necho should-not-run\n")
+            bin_path.chmod(0o755)
+            adapter = adapters.LatticeAdapter(bin_path=bin_path, tokenizer_dir=Path(tmp))
+            missing_dir = Path(tmp) / "does-not-exist"
+            with mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"qwen3.5-0.8b": missing_dir}):
+                with self.assertRaises(adapters.LatticeUnavailableError):
+                    adapter.run(
+                        prompt="p", n_tokens=32, warmup=False, model="qwen3.5-0.8b", quantization="q8"
+                    )
+
+    def test_registration_status_skips_when_profile_model_dir_missing(self):
+        profile = self.profiles["apples_to_apples_q8"]
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "bench_decode_ab"
+            bin_path.write_text("#!/bin/sh\n")
+            bin_path.chmod(0o755)
+            missing_dir = Path(tmp) / "does-not-exist"
+            with mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"qwen3.5-0.8b": missing_dir}):
+                should_register, missing = adapters.lattice_registration_status(profile, bin_path=bin_path)
+        self.assertFalse(should_register)
+        self.assertEqual(missing, (missing_dir,))
+
+    def test_registration_status_registers_when_binary_and_model_dir_present(self):
+        profile = self.profiles["apples_to_apples_q8"]
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "bench_decode_ab"
+            bin_path.write_text("#!/bin/sh\n")
+            bin_path.chmod(0o755)
+            model_dir = Path(tmp) / "model"
+            model_dir.mkdir()
+            with mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"qwen3.5-0.8b": model_dir}):
+                should_register, missing = adapters.lattice_registration_status(profile, bin_path=bin_path)
+        self.assertTrue(should_register)
+        self.assertEqual(missing, ())
+
+    def test_registration_status_false_when_binary_missing_even_if_model_present(self):
+        profile = self.profiles["apples_to_apples_q8"]
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "bench_decode_ab"  # never created
+            model_dir = Path(tmp) / "model"
+            model_dir.mkdir()
+            with mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"qwen3.5-0.8b": model_dir}):
+                should_register, missing = adapters.lattice_registration_status(profile, bin_path=bin_path)
+        self.assertFalse(should_register)
+        self.assertEqual(missing, ())  # binary check fails before model dirs are even inspected
+
+    def test_registration_status_falls_back_to_binary_only_when_profile_unknown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "bench_decode_ab"
+            bin_path.write_text("#!/bin/sh\n")
+            bin_path.chmod(0o755)
+            should_register, missing = adapters.lattice_registration_status(None, bin_path=bin_path)
+        self.assertTrue(should_register)
+        self.assertEqual(missing, ())
+
+    def test_end_to_end_missing_model_dir_yields_graceful_skip_via_harness(self):
+        # Closes the loop: when registration correctly declines to register
+        # lattice, harness.run_profile's own --allow-missing-engine path
+        # (not a mid-run exception) is what handles it, with other engines
+        # still producing observations.
+        profile = self.profiles["apples_to_apples_q8"]
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "bench_decode_ab"
+            bin_path.write_text("#!/bin/sh\n")
+            bin_path.chmod(0o755)
+            missing_dir = Path(tmp) / "does-not-exist"
+            with mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"qwen3.5-0.8b": missing_dir}):
+                should_register, _missing = adapters.lattice_registration_status(profile, bin_path=bin_path)
+        self.assertFalse(should_register)
+        result = harness.run_profile(
+            profile,
+            {"ollama": _FakeAdapter(), "mlx": _FakeAdapter()},  # lattice deliberately NOT registered
+            allow_missing_engine=True,
+            clock=_FakeClock(),
+        )
+        self.assertIn("lattice", result.missing_engines)
+        self.assertTrue(any(o.engine in ("ollama", "mlx") for o in result.observations))
+
+
+class MlxFallbackProvenanceTest(unittest.TestCase):
+    """A missing/corrupt local model dir makes `MlxAdapter` fall back to the
+    Hub artifact -- the raw observation must record that via `actual_model`,
+    never silently label it as the requested local artifact.
+    """
+
+    def test_fallback_load_reports_hub_identifier_via_actual_model(self):
+        fake_model, fake_tok, fake_sampler = mock.MagicMock(), mock.MagicMock(), mock.MagicMock()
+        fake_model.parameters.return_value = mock.MagicMock()
+
+        def fake_load(path):
+            if path == "Qwen/Qwen3.5-0.8B":
+                return fake_model, fake_tok
+            raise OSError(f"no such local model: {path}")
+
+        adapter = adapters.MlxAdapter(source_model_dir=Path("/nonexistent/local/model"))
+        with (
+            mock.patch("mlx_lm.load", side_effect=fake_load),
+            mock.patch("mlx.nn.quantize"),
+            mock.patch("mlx.core.eval"),
+            mock.patch("mlx_lm.sample_utils.make_sampler", return_value=fake_sampler),
+            mock.patch("mlx_lm.generate", return_value="irrelevant generated text"),
+        ):
+            result = adapter.run(
+                prompt="p", n_tokens=32, warmup=False, model="qwen3.5-0.8b", quantization="q8"
+            )
+        self.assertEqual(result.actual_model, "Qwen/Qwen3.5-0.8B")
+        self.assertEqual(result.actual_completion_tokens, 32)
+
+    def test_local_load_success_reports_no_fallback(self):
+        fake_model, fake_tok, fake_sampler = mock.MagicMock(), mock.MagicMock(), mock.MagicMock()
+        fake_model.parameters.return_value = mock.MagicMock()
+
+        adapter = adapters.MlxAdapter(source_model_dir=Path("/some/local/model"))
+        with (
+            mock.patch("mlx_lm.load", return_value=(fake_model, fake_tok)),
+            mock.patch("mlx.nn.quantize"),
+            mock.patch("mlx.core.eval"),
+            mock.patch("mlx_lm.sample_utils.make_sampler", return_value=fake_sampler),
+            mock.patch("mlx_lm.generate", return_value="irrelevant generated text"),
+        ):
+            result = adapter.run(
+                prompt="p", n_tokens=32, warmup=False, model="qwen3.5-0.8b", quantization="q8"
+            )
+        self.assertIsNone(result.actual_model)
 
 
 if __name__ == "__main__":

--- a/tests/test_bench_decode_adapters_apples_to_apples.py
+++ b/tests/test_bench_decode_adapters_apples_to_apples.py
@@ -1,0 +1,326 @@
+"""Deterministic tests for scripts/bench_decode_adapters_apples_to_apples.py
+(issue #813 step 2: migrate bench_apples_to_apples.sh onto the shared
+decode-bench harness).
+
+No engine binary or network access is required to run this file: real
+adapters are exercised only through their pure parsing helpers
+(`parse_lattice_result_line`, `ollama_response_to_result`); the profile ->
+call-schedule equivalence is checked with the harness's own deterministic
+`_FakeAdapter`, matching `tests/test_bench_decode_harness.py`'s convention
+and the issue #813 gate: "Deterministic fake-adapter tests and raw-schema
+validation pass without any engine binary present."
+
+Run with: python3 tests/test_bench_decode_adapters_apples_to_apples.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from unittest import mock
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = _REPO_ROOT / "scripts"
+
+sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+harness = _load_module("bench_decode_harness", "bench_decode_harness.py")
+adapters = _load_module(
+    "bench_decode_adapters_apples_to_apples", "bench_decode_adapters_apples_to_apples.py"
+)
+
+DEFAULT_PROFILES_FILE = _SCRIPTS / "bench_decode_profiles.toml"
+
+
+# --------------------------------------------------------------------------
+# Fakes (mirrors tests/test_bench_decode_harness.py's _FakeAdapter/_FakeClock)
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeClock:
+    step_ns: int = 1_000_000
+    start_ns: int = 0
+    _calls: int = 0
+
+    def __call__(self) -> int:
+        value = self.start_ns + self.step_ns * self._calls
+        self._calls += 1
+        return value
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self.calls: list[tuple[int, bool, str, str]] = []
+
+    def run(self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str):
+        self.calls.append((n_tokens, warmup, model, quantization))
+        return harness.AdapterRunResult(
+            actual_completion_tokens=n_tokens, native_ns=n_tokens * 1000, engine_version="fake-1.0"
+        )
+
+
+# --------------------------------------------------------------------------
+# Profile parameter equivalence (the issue #813 gate: byte-for-byte
+# equivalent window/repeats/warmup parameters vs the legacy script)
+# --------------------------------------------------------------------------
+
+
+class ProfileParameterEquivalenceTest(unittest.TestCase):
+    """bench_apples_to_apples.sh: N1=32, N2=256, RUNS=5, no lattice/ollama
+    warmup, mlx warms up once at 8 tokens -- see the script's own
+    N1/N2/RUNS constants and its single pre-loop `generate(..., max_tokens=8,
+    ...)` warmup call before the N1/N2 loop."""
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+
+    def test_both_profiles_defined(self):
+        self.assertIn("apples_to_apples_q8", self.profiles)
+        self.assertIn("apples_to_apples_q4", self.profiles)
+
+    def test_q8_windows_and_repeats_match_legacy_n1_n2_runs(self):
+        p = self.profiles["apples_to_apples_q8"]
+        self.assertEqual(p.windows, (32, 256))
+        self.assertEqual(p.measured_repeats, 5)
+        self.assertEqual(p.aggregation, "median")
+
+    def test_q4_windows_and_repeats_match_legacy_n1_n2_runs(self):
+        p = self.profiles["apples_to_apples_q4"]
+        self.assertEqual(p.windows, (32, 256))
+        self.assertEqual(p.measured_repeats, 5)
+
+    def test_q8_prompt_matches_legacy_prompt_variable(self):
+        p = self.profiles["apples_to_apples_q8"]
+        self.assertEqual(
+            p.prompt,
+            "The quick brown fox jumps over the lazy dog. Once upon a time in a land "
+            "far away, there lived a",
+        )
+
+    def test_q8_engines_and_order_match_legacy_section_order(self):
+        p = self.profiles["apples_to_apples_q8"]
+        self.assertEqual(p.engines, ("lattice", "ollama", "mlx"))
+
+    def test_q4_engines_omit_ollama_no_q4_variant(self):
+        p = self.profiles["apples_to_apples_q4"]
+        self.assertEqual(p.engines, ("lattice", "mlx"))
+
+    def test_q8_only_mlx_has_a_warmup(self):
+        p = self.profiles["apples_to_apples_q8"]
+        groups = {g.name: g for g in p.engine_groups}
+        self.assertEqual(groups["lattice"].warmup_repeats, 0)
+        self.assertEqual(groups["ollama"].warmup_repeats, 0)
+        self.assertEqual(groups["mlx"].warmup_repeats, 1)
+        self.assertEqual(groups["mlx"].warmup_tokens, 8)
+
+    def test_q4_only_mlx_has_a_warmup(self):
+        p = self.profiles["apples_to_apples_q4"]
+        groups = {g.name: g for g in p.engine_groups}
+        self.assertEqual(groups["lattice"].warmup_repeats, 0)
+        self.assertEqual(groups["mlx"].warmup_repeats, 1)
+        self.assertEqual(groups["mlx"].warmup_tokens, 8)
+
+    def test_q8_quantization_tiers(self):
+        p = self.profiles["apples_to_apples_q8"]
+        groups = {g.name: g for g in p.engine_groups}
+        self.assertEqual(groups["lattice"].quantization, "q8")
+        self.assertEqual(groups["ollama"].quantization, "q8")
+        self.assertEqual(groups["mlx"].quantization, "q8")
+
+    def test_q4_quantization_tiers_lattice_quarot_mlx_bits4(self):
+        p = self.profiles["apples_to_apples_q4"]
+        groups = {g.name: g for g in p.engine_groups}
+        self.assertEqual(groups["lattice"].model, "qwen3.5-0.8b-q4-quarot")
+        self.assertEqual(groups["lattice"].quantization, "q4")
+        self.assertEqual(groups["mlx"].quantization, "q4")
+        # MLX loads from the Q8 safetensors dir and quantizes on the fly to
+        # 4 bits -- same source model as the Q8 tier, matching the legacy
+        # script's bench_mlx() which always loads $Q8_DIR regardless of tier.
+        self.assertEqual(groups["mlx"].model, "qwen3.5-0.8b")
+
+
+# --------------------------------------------------------------------------
+# Call-schedule equivalence via fake adapters (no engine binary needed)
+# --------------------------------------------------------------------------
+
+
+class CallScheduleEquivalenceTest(unittest.TestCase):
+    """Runs the REAL shipped profiles through harness.run_profile with fake
+    adapters, proving the produced call schedule matches
+    bench_apples_to_apples.sh's loop structure exactly: lattice/ollama get
+    N1 x5 then N2 x5 with no warmup; mlx gets one 8-token warmup, then N1 x5
+    then N2 x5."""
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+
+    def test_q8_tier_call_sequence(self):
+        profile = self.profiles["apples_to_apples_q8"]
+        lattice, ollama, mlx = _FakeAdapter(), _FakeAdapter(), _FakeAdapter()
+        harness.run_profile(
+            profile,
+            {"lattice": lattice, "ollama": ollama, "mlx": mlx},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        self.assertEqual(
+            lattice.calls,
+            [(32, False, "qwen3.5-0.8b", "q8")] * 5 + [(256, False, "qwen3.5-0.8b", "q8")] * 5,
+        )
+        self.assertEqual(
+            ollama.calls,
+            [(32, False, "qwen3.5:0.8b", "q8")] * 5 + [(256, False, "qwen3.5:0.8b", "q8")] * 5,
+        )
+        self.assertEqual(
+            mlx.calls,
+            [(8, True, "qwen3.5-0.8b", "q8")]
+            + [(32, False, "qwen3.5-0.8b", "q8")] * 5
+            + [(256, False, "qwen3.5-0.8b", "q8")] * 5,
+        )
+
+    def test_q4_tier_call_sequence_no_ollama(self):
+        profile = self.profiles["apples_to_apples_q4"]
+        lattice, mlx = _FakeAdapter(), _FakeAdapter()
+        result = harness.run_profile(
+            profile,
+            {"lattice": lattice, "mlx": mlx},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        self.assertEqual(
+            lattice.calls,
+            [(32, False, "qwen3.5-0.8b-q4-quarot", "q4")] * 5
+            + [(256, False, "qwen3.5-0.8b-q4-quarot", "q4")] * 5,
+        )
+        self.assertEqual(
+            mlx.calls,
+            [(8, True, "qwen3.5-0.8b", "q4")]
+            + [(32, False, "qwen3.5-0.8b", "q4")] * 5
+            + [(256, False, "qwen3.5-0.8b", "q4")] * 5,
+        )
+        self.assertNotIn("ollama", [o.engine for o in result.observations])
+
+    def test_q8_produces_schema_valid_observations(self):
+        profile = self.profiles["apples_to_apples_q8"]
+        result = harness.run_profile(
+            profile,
+            {"lattice": _FakeAdapter(), "ollama": _FakeAdapter(), "mlx": _FakeAdapter()},
+            clock=_FakeClock(),
+        )
+        for obs in result.observations:
+            harness.validate_observation(obs.to_dict())
+
+    def test_missing_engine_binary_falls_back_to_allow_missing_engine(self):
+        # Reproduces the wrapper script's --allow-missing-engine usage: an
+        # engine with no adapter registered (e.g. lattice not built) is
+        # skipped, not fatal, matching the legacy script's per-engine
+        # graceful skip.
+        profile = self.profiles["apples_to_apples_q8"]
+        result = harness.run_profile(
+            profile,
+            {"mlx": _FakeAdapter()},
+            allow_missing_engine=True,
+            clock=_FakeClock(),
+        )
+        self.assertEqual(set(result.missing_engines), {"lattice", "ollama"})
+        self.assertTrue(all(o.engine == "mlx" for o in result.observations))
+
+
+# --------------------------------------------------------------------------
+# Pure parsing helpers (real-adapter plumbing, no process/network needed)
+# --------------------------------------------------------------------------
+
+
+class LatticeResultParsingTest(unittest.TestCase):
+    def test_parses_result_line(self):
+        line = "RESULT n_req=32 completion=32 total_ms=812.345"
+        parsed = adapters.parse_lattice_result_line(line)
+        self.assertEqual(parsed, (32, 32, 812.345))
+
+    def test_parses_result_line_with_differing_actual_completion(self):
+        # completion can differ from n_req (e.g. early stop) -- both are
+        # recorded independently, never assumed equal.
+        line = "RESULT n_req=256 completion=201 total_ms=1900.0"
+        parsed = adapters.parse_lattice_result_line(line)
+        self.assertEqual(parsed, (256, 201, 1900.0))
+
+    def test_ignores_non_result_lines(self):
+        self.assertIsNone(adapters.parse_lattice_result_line("[bench] loading /some/dir (Q4)"))
+        self.assertIsNone(adapters.parse_lattice_result_line("[bench] prompt_tokens=42"))
+        self.assertIsNone(adapters.parse_lattice_result_line(""))
+
+    def test_uses_last_result_line_on_multiple(self):
+        stdout = (
+            "RESULT n_req=32 completion=32 total_ms=100.0\n"
+            "RESULT n_req=32 completion=32 total_ms=200.0\n"
+        )
+        parsed = None
+        for line in stdout.splitlines():
+            result = adapters.parse_lattice_result_line(line)
+            if result is not None:
+                parsed = result
+        self.assertEqual(parsed, (32, 32, 200.0))
+
+
+class OllamaResponseParsingTest(unittest.TestCase):
+    def test_translates_eval_count_and_duration_to_native_ns(self):
+        data = {"eval_count": 256, "eval_duration": 2_000_000_000, "total_duration": 2_500_000_000}
+        result = adapters.ollama_response_to_result(data, requested_tokens=256)
+        self.assertEqual(result.actual_completion_tokens, 256)
+        self.assertEqual(result.native_ns, 2_000_000_000)
+
+    def test_falls_back_to_requested_tokens_when_eval_count_absent(self):
+        result = adapters.ollama_response_to_result({}, requested_tokens=32)
+        self.assertEqual(result.actual_completion_tokens, 32)
+        self.assertIsNone(result.native_ns)
+
+    def test_zero_eval_duration_yields_no_native_ns(self):
+        data = {"eval_count": 10, "eval_duration": 0}
+        result = adapters.ollama_response_to_result(data, requested_tokens=10)
+        self.assertIsNone(result.native_ns)
+
+
+class AvailabilityCheckTest(unittest.TestCase):
+    def test_lattice_available_false_when_binary_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "bench_decode_ab"
+            self.assertFalse(adapters.lattice_available(missing))
+
+    def test_lattice_available_true_when_binary_executable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "bench_decode_ab"
+            bin_path.write_text("#!/bin/sh\n")
+            bin_path.chmod(0o755)
+            self.assertTrue(adapters.lattice_available(bin_path))
+
+    def test_ollama_available_false_when_binary_not_on_path(self):
+        with mock.patch.object(adapters.shutil, "which", return_value=None):
+            self.assertFalse(adapters.ollama_available(model_tag="qwen3.5:0.8b"))
+
+    def test_mlx_available_reflects_import_success(self):
+        # mlx_lm is a declared project dependency (pyproject.toml); this
+        # documents the expectation rather than mocking import machinery.
+        self.assertTrue(adapters.mlx_available())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_decode_adapters_apples_to_apples.py
+++ b/tests/test_bench_decode_adapters_apples_to_apples.py
@@ -371,8 +371,29 @@ class OllamaResponseParsingTest(unittest.TestCase):
 
     def test_bool_field_type_raises(self):
         # bool is an int subclass in Python -- must not sneak past the
-        # numeric-type check.
+        # int-only check.
         data = {"eval_count": True, "eval_duration": 1, "total_duration": 1}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_fractional_field_values_raise(self):
+        # The API documents eval_count/eval_duration/total_duration as
+        # integers; a float (even a "clean" one like 1.0) must be rejected
+        # outright rather than silently truncated via int(31.9) == 31 --
+        # that truncation is exactly the fake-observation class this
+        # function exists to close, reached through a technically-numeric
+        # value instead of a missing one.
+        data = {"eval_count": 31.9, "eval_duration": 1.0, "total_duration": 2.9}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_fractional_eval_count_alone_raises(self):
+        data = {"eval_count": 31.9, "eval_duration": 1, "total_duration": 1}
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(data)
+
+    def test_fractional_total_duration_alone_raises(self):
+        data = {"eval_count": 32, "eval_duration": 1, "total_duration": 2.9}
         with self.assertRaises(adapters.OllamaResponseError):
             adapters.ollama_response_to_result(data)
 
@@ -519,6 +540,153 @@ class LatticeModelAwareAvailabilityTest(unittest.TestCase):
         )
         self.assertIn("lattice", result.missing_engines)
         self.assertTrue(any(o.engine in ("ollama", "mlx") for o in result.observations))
+
+
+class RegisterAvailableAdaptersEndToEndTest(unittest.TestCase):
+    """End-to-end coverage for the ACTUAL registration entry points --
+    `_peek_requested_profile` and `register_available_adapters` -- not just
+    `lattice_registration_status` called directly. A bug in the argv-peeking
+    path itself (the `--profile name` / `--profile=name` / `--profiles-file`
+    / omitted-`--profile` forms) would not fail any of
+    `LatticeModelAwareAvailabilityTest`'s tests, since those call
+    `lattice_registration_status` directly with an already-resolved profile
+    object -- this class drives the real argv shape
+    `bench_decode_adapters_apples_to_apples.py run --profile ... [...]`
+    produces through the module-global entry point instead.
+    """
+
+    def _write_solo_lattice_profile(self, tmp: Path) -> Path:
+        # A minimal single-engine profile: only "lattice" is declared, so
+        # the registration decision under test is isolated from ollama/mlx.
+        profiles_file = tmp / "profiles.toml"
+        profiles_file.write_text(
+            "schema_version = 1\n"
+            "\n"
+            "[profiles.solo_lattice]\n"
+            "windows = [8, 16]\n"
+            "measured_repeats = 1\n"
+            'prompt = "hello"\n'
+            'aggregation = "median"\n'
+            "\n"
+            "[[profiles.solo_lattice.engines]]\n"
+            'name = "lattice"\n'
+            "warmup_repeats = 0\n"
+            'model = "test-model"\n'
+            'quantization = "q8"\n'
+        )
+        return profiles_file
+
+    def _make_binary(self, tmp: Path) -> Path:
+        bin_path = tmp / "bench_decode_ab"
+        bin_path.write_text("#!/bin/sh\n")
+        bin_path.chmod(0o755)
+        return bin_path
+
+    def setUp(self):
+        # register_available_adapters() mutates the module-global registry
+        # -- isolate this test class from it and from every other test.
+        self._registry_backup = dict(harness.ADAPTER_REGISTRY)
+        harness.ADAPTER_REGISTRY.clear()
+        self.addCleanup(self._restore_registry)
+        # Real ollama/mlx probing does real subprocess/import work that is
+        # unrelated to what this class covers (the lattice argv-peek path)
+        # -- stub both out so this stays fast and hermetic, matching this
+        # file's own no-binary/no-network design (see module docstring).
+        patcher_ollama = mock.patch.object(adapters, "ollama_available", return_value=False)
+        patcher_mlx = mock.patch.object(adapters, "mlx_available", return_value=False)
+        patcher_ollama.start()
+        patcher_mlx.start()
+        self.addCleanup(patcher_ollama.stop)
+        self.addCleanup(patcher_mlx.stop)
+
+    def _restore_registry(self):
+        harness.ADAPTER_REGISTRY.clear()
+        harness.ADAPTER_REGISTRY.update(self._registry_backup)
+
+    def test_skips_lattice_when_selected_profile_model_dir_missing(self):
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            profiles_file = self._write_solo_lattice_profile(tmp)
+            bin_path = self._make_binary(tmp)
+            missing_dir = tmp / "does-not-exist"
+            with (
+                mock.patch.object(adapters, "LAT_BIN", bin_path),
+                mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"test-model": missing_dir}),
+            ):
+                adapters.register_available_adapters(
+                    ["run", "--profile", "solo_lattice", "--profiles-file", str(profiles_file)]
+                )
+        self.assertNotIn("lattice", harness.ADAPTER_REGISTRY)
+
+    def test_registers_lattice_when_selected_profile_model_dir_present(self):
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            profiles_file = self._write_solo_lattice_profile(tmp)
+            bin_path = self._make_binary(tmp)
+            model_dir = tmp / "model"
+            model_dir.mkdir()
+            with (
+                mock.patch.object(adapters, "LAT_BIN", bin_path),
+                mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"test-model": model_dir}),
+            ):
+                adapters.register_available_adapters(
+                    ["run", "--profile", "solo_lattice", "--profiles-file", str(profiles_file)]
+                )
+        self.assertIn("lattice", harness.ADAPTER_REGISTRY)
+
+    def test_peek_handles_profile_equals_name_form(self):
+        # `--profile=solo_lattice` (single-token `=` form), not the
+        # two-token `--profile solo_lattice` form the other tests use.
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            profiles_file = self._write_solo_lattice_profile(tmp)
+            bin_path = self._make_binary(tmp)
+            missing_dir = tmp / "does-not-exist"
+            with (
+                mock.patch.object(adapters, "LAT_BIN", bin_path),
+                mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"test-model": missing_dir}),
+            ):
+                adapters.register_available_adapters(
+                    ["run", "--profile=solo_lattice", "--profiles-file", str(profiles_file)]
+                )
+        self.assertNotIn("lattice", harness.ADAPTER_REGISTRY)
+
+    def test_peek_handles_profiles_file_flag_before_profile_flag(self):
+        # Argument order independence: --profiles-file appears BEFORE
+        # --profile on the command line (argparse doesn't care, but the
+        # hand-rolled peek must not assume a fixed order either).
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            profiles_file = self._write_solo_lattice_profile(tmp)
+            bin_path = self._make_binary(tmp)
+            model_dir = tmp / "model"
+            model_dir.mkdir()
+            with (
+                mock.patch.object(adapters, "LAT_BIN", bin_path),
+                mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"test-model": model_dir}),
+            ):
+                adapters.register_available_adapters(
+                    ["run", "--profiles-file", str(profiles_file), "--profile", "solo_lattice"]
+                )
+        self.assertIn("lattice", harness.ADAPTER_REGISTRY)
+
+    def test_peek_falls_back_to_binary_only_when_profile_omitted(self):
+        # No --profile at all: _peek_requested_profile can't resolve a
+        # profile (harness.main() itself would later fail closed on the
+        # missing required argument), so registration falls back to
+        # binary-only availability -- the pre-fix behavior -- rather than
+        # silently never registering lattice for an unrecognized invocation.
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            profiles_file = self._write_solo_lattice_profile(tmp)
+            bin_path = self._make_binary(tmp)
+            missing_dir = tmp / "does-not-exist"
+            with (
+                mock.patch.object(adapters, "LAT_BIN", bin_path),
+                mock.patch.object(adapters, "_LATTICE_MODEL_DIRS", {"test-model": missing_dir}),
+            ):
+                adapters.register_available_adapters(["run", "--profiles-file", str(profiles_file)])
+        self.assertIn("lattice", harness.ADAPTER_REGISTRY)
 
 
 class MlxFallbackProvenanceTest(unittest.TestCase):

--- a/tests/test_bench_decode_harness.py
+++ b/tests/test_bench_decode_harness.py
@@ -662,10 +662,17 @@ class ProfileConfigTest(unittest.TestCase):
 
 
 class LoadProfilesFileTest(unittest.TestCase):
-    def test_scaffold_file_loads_with_no_profiles(self):
+    def test_shipped_file_loads_and_parses_cleanly(self):
+        # Issue #813 step 2 migrates live consumers onto this file one
+        # script per PR; it no longer stays empty past the first migration
+        # (bench_apples_to_apples.sh -- see
+        # tests/test_bench_decode_adapters_apples_to_apples.py for the
+        # parameter- and call-schedule-equivalence gates on those profiles).
+        # This test only asserts the file itself is well-formed against the
+        # shipped schema version, independent of which profiles it defines.
         schema_version, profiles = harness.load_profiles_file(harness.DEFAULT_PROFILES_FILE)
         self.assertEqual(schema_version, harness.SCHEMA_VERSION)
-        self.assertEqual(profiles, {})
+        self.assertIsInstance(profiles, dict)
 
     def test_wrong_schema_version_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
_PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Issue #813 step 2, first of five live-consumer migrations onto the shared
decode-benchmark harness (harness core landed in #857; companion dead-script
removal landed in #869/#814). This PR migrates `scripts/bench_apples_to_apples.sh`
— listed first in the issue's migration order — onto
`scripts/bench_decode_harness.py`.

- `scripts/bench_decode_profiles.toml`: adds `apples_to_apples_q8` and
  `apples_to_apples_q4` profile definitions. Parameters match the pre-migration
  script exactly: windows `[32, 256]` (the legacy `N1=32`/`N2=256` slope-method
  pair), `measured_repeats = 5`, the same fixed prompt, `median` aggregation.
  Only `mlx` warms up (once, at 8 tokens), matching the legacy script's single
  pre-loop MLX-only warmup — lattice and ollama get zero warmup, also matching
  legacy behavior.
- `scripts/bench_decode_adapters_apples_to_apples.py` (new): registers real
  `EngineAdapter` implementations for lattice, ollama, and mlx, mirroring the
  legacy script's `bench_lattice`/`bench_ollama`/`bench_mlx` shell functions,
  then delegates to `bench_decode_harness.main()`.
- `scripts/bench_apples_to_apples.sh`: rewritten as a thin wrapper (44 lines,
  down from the original inline implementation) that execs the adapter module
  once per tier via `--allow-missing-engine`, preserving the legacy script's
  per-engine graceful-skip behavior. CLI invocation is unchanged.
- `tests/test_bench_decode_adapters_apples_to_apples.py` (new, 25 tests):
  profile-parameter equivalence against the legacy script's
  N1/N2/RUNS/prompt/warmup shape, exact call-schedule equivalence via the
  harness's own fake-adapter/fake-clock test pattern, and pure parsing-helper
  tests for the lattice `RESULT` line and the ollama JSON response.
- `tests/test_bench_decode_harness.py`: one test renamed and its assertion
  relaxed (`test_scaffold_file_loads_with_no_profiles` →
  `test_shipped_file_loads_and_parses_cleanly`) since the shipped profiles
  file is no longer empty past this first migration. This is the minimal
  in-scope fix for a test that directly asserts on the file this PR modifies.

## Disclosed methodology note

`bench_decode_ab` (the Rust bin) amortizes one model load across
`BENCH_RUNS` internal repeats within a single process, timing only the decode
window per repeat and excluding load time from its own `total_ms`. The
harness's per-call contract is different: each `EngineAdapter.run()` call is
one independently harness-timed measured repeat. There is no way to reconcile
these two shapes without a persistent-server mode on the Rust side, which is
out of scope for a scripts-only migration PR.

The adapter resolves this honestly rather than silently: it invokes the bin
with `BENCH_RUNS=1` per harness-measured repeat, so the harness's own
`elapsed_ns` (and therefore the reported "slope tok/s") now includes
subprocess-spawn and model-load overhead that the legacy script's `total_ms`
excluded. The true decode-only timing is not lost — it is preserved losslessly
via `AdapterRunResult.native_ns`, the harness's existing diagnostic field
designed for exactly this kind of engine-reported timing, and surfaces in the
report's separate "native tok/s" column.

**Update after a review pass** (see Verification below): the duration-
boundary methodology for ollama and MLX needed the same honesty treatment.
The harness's PRIMARY reported slope always uses its own wall-clock
`elapsed_ns` around the whole `adapter.run()` call — a fixed harness
invariant, not something an adapter can override — so it is not claimed to
be byte-for-byte identical to the legacy script's per-engine self-timed
metric. MLX's primary metric has had its material retokenization divergence
removed: `run()` no longer does any work after `generate()` returns (the
initial version retokenized the output to count tokens, which silently
pulled that work inside the harness's timing window and also diverged from
the legacy script, which never verified actual token count either — it
trusted the requested `N` directly, same as this adapter does now). This is
not claimed to be an exact match against the legacy window: the harness's
`elapsed_ns` still additionally covers the cached `_load()` lookup/unpacking
immediately before `generate()` and the `AdapterRunResult` construction
immediately after — ordinary, near-fixed adapter/harness call overhead, not
a variable cost like retokenization was. Ollama's primary metric still
includes negligible local HTTP/JSON overhead beyond ollama's own
`total_duration` and is not claimed as byte-identical, but the
legacy-equivalent number is no longer lost or wrong: `native_ns` now sources
from `total_duration` — the field the legacy script's own primary slope
used — instead of the decode-only `eval_duration` the initial version of
this adapter incorrectly used there.

## Review-fix pass

A review of the first commit surfaced five findings, all in the fail-open /
fake-observation class, fixed here (`scripts/bench_decode_adapters_apples_to_apples.py`
+ its test file only — no change to the harness core or the profiles file):

1. **`--allow-missing-engine` is now model-aware for lattice, not just
   binary-aware.** A binary present with a profile-required model dir absent
   (e.g. Q8 weights present, Q4 absent) previously raised
   `LatticeUnavailableError` mid-run, which `--allow-missing-engine` could
   not catch, aborting the whole tier instead of gracefully skipping lattice
   the way the legacy script did. `register_available_adapters()` now peeks
   `--profile`/`--profiles-file` out of argv and checks that SPECIFIC
   profile's required model directory (`lattice_registration_status()`)
   before deciding whether to register lattice at all.
2. **Duration-boundary methodology** — see the section above.
3. **Lattice `RESULT` parsing hardened**: a new `extract_single_result()`
   helper requires exactly one full-line RESULT record (anchored regex, no
   prefix/suffix noise tolerated), validates `n_req` equals the window that
   was actually requested, and validates `completion`/`total_ms` are finite
   and non-negative. A stale/wrong binary emitting a RESULT line for the
   wrong window, or two RESULT lines where one was expected, now raises
   `LatticeResultError` instead of silently producing a mislabeled
   observation or picking the last of several lines.
4. **Ollama response validation hardened**: `ollama_response_to_result` now
   requires and type-checks `eval_count`/`eval_duration`/`total_duration`,
   rejects a top-level `"error"` body, and no longer substitutes the
   requested token count for a missing or absent `eval_count` — a
   structurally-valid-JSON error response (HTTP 200, `{"error": ...}`) now
   raises `OllamaResponseError` instead of becoming a fake measurement.
5. **MLX Hub-fallback provenance**: a missing/corrupt local model directory
   makes `MlxAdapter` fall back to `Qwen/Qwen3.5-0.8B` from the Hub; the raw
   observation now records that via `AdapterRunResult.actual_model` instead
   of silently mislabeling it as the requested local artifact.

## Review-fix pass 2

A second review pass found the ollama hardening from pass 1 still had a gap,
the MLX wording above still overstated parity, and the registration fix's
test coverage didn't exercise its real entry points. Three fixes, same two
files only:

1. **Ollama validation now rejects fractional values, not just non-numeric
   ones.** Pass 1's type check accepted `float` alongside `int`, so a
   response like `{"eval_count": 31.9, "eval_duration": 1.0,
   "total_duration": 2.9}` passed validation and silently truncated to
   `actual_completion_tokens=31`/`native_ns=2` — recreating the
   fake-observation class the pass-1 fix set out to remove.
   `ollama_response_to_result` now requires a non-boolean `int` for all
   three fields; fractional values raise `OllamaResponseError`. New
   regression tests cover the exact fractional example above plus each
   field fractional in isolation.
2. **MLX wording corrected** — see the "Update after a review pass" section
   above, now reworded to say the material retokenization divergence is
   removed while ordinary adapter/harness overhead remains inside the timed
   window, rather than claiming an exact match against the legacy window.
3. **Registration fix now has real end-to-end test coverage.** Pass 1's
   tests called `lattice_registration_status()` directly; none exercised
   `_peek_requested_profile()` or `register_available_adapters()` — the
   actual argv-parsing path the fix changed. New tests build a temporary
   profiles file and real argv (`--profile name`, `--profile=name`,
   `--profiles-file ... --profile ...`, and profile omitted) and assert
   registration through `register_available_adapters()` itself. Writing
   these tests surfaced a real latent bug: `register_available_adapters()`
   called `lattice_registration_status(profile)` without passing
   `bin_path=`, so patching the module-level binary path in a test had no
   effect on that call (Python binds a keyword-only default once, at
   function-definition time, not at call time). Fixed by passing
   `bin_path=LAT_BIN` explicitly at the call site.

## Verification

- `uv run pytest tests/ -q`: 375 passed (up from 367 after review pass 1,
  142 at the first commit; `tests/test_bench_decode_adapters_apples_to_apples.py`
  now covers all findings from both review passes with real-adapter,
  mocked-load, and end-to-end argv/registration cases, not just the
  fake-adapter call-schedule tests from the first commit).
- `bash -n scripts/bench_apples_to_apples.sh`: clean.
- `cargo fmt --check`: N/A, no Rust touched (pre-commit's full
  `cargo check --workspace` + doc lint + capability-matrix check ran clean
  on both commits regardless).
- Live end-to-end re-run against real engines (ollama + mlx) after the
  hardening pass, confirming the adapters still function correctly and the
  corrected duration methodology takes effect:

  Q8 tier:
  ```
  lattice: BIN MISSING (.../target/release/bench_decode_ab) — build first (cargo build --release --bin bench_decode_ab)
  ollama: adapter registered
  mlx: adapter registered
  === apples_to_apples_q8 | windows=[32, 256] | aggregation=median ===
    (missing engine adapter(s), skipped: lattice)
    engine      window  slope tok/s legacy ±CI  native tok/s  n(base/win)
    ---------------------------------------------------------------------
    ollama         256        106.9          —          77.8          5/5
    mlx            256        153.5          —             —          5/5
  ```

  Q4 tier:
  ```
  lattice: BIN MISSING (.../target/release/bench_decode_ab) — build first (cargo build --release --bin bench_decode_ab)
  ollama: adapter registered
  mlx: adapter registered
  === apples_to_apples_q4 | windows=[32, 256] | aggregation=median ===
    (missing engine adapter(s), skipped: lattice)
    engine      window  slope tok/s legacy ±CI  native tok/s  n(base/win)
    ---------------------------------------------------------------------
    mlx            256        375.5          —             —          5/5
  ```

  Both raw JSONL outputs validate cleanly against the harness schema:
  `validate docs/bench_results/a2a_q8_raw.jsonl` → `OK: 21 observation(s)
  valid against schema v1`; `a2a_q4_raw.jsonl` → `OK: 11 observation(s)
  valid against schema v1` (21 = ollama's 2 windows × 5 repeats + mlx's 1
  warmup + 2 windows × 5 repeats; 11 = mlx only, ollama has no Q4 registry
  variant and self-skips by design, matching the legacy script's comment).
  A spot-check of a real ollama observation confirms finding 2/4's fix took
  effect: `elapsed_ns` and `engine_native_ns` are now within ~0.05% of each
  other (previously `native_ns` used the decode-only `eval_duration`, a
  meaningfully smaller number than the harness's whole-request wall clock).
  Ollama's graceful `--allow-missing-engine` skip is exercised for real in
  the Q4 tier above (no code path is untested). The throughput figures
  themselves are not directly comparable across the two live runs in this
  PR (different machine-load conditions between them, not a code change —
  MLX in particular is sensitive to concurrent GPU/CPU contention from other
  processes on this machine); they are included as functional evidence, not
  as a performance claim.

  The lattice leg itself was not exercised live in this session: the release
  build (`cargo build --release -p lattice-inference --bin bench_decode_ab
  --features f16,metal-gpu`) has been queued behind another lambda's
  exclusive heavy-lane job for the session's duration, so `BIN MISSING`
  above is the harness's own documented graceful-skip path, not a bug in
  this PR. The lattice adapter's subprocess invocation, `RESULT` line
  parsing/validation, and harness call-schedule are covered by deterministic
  unit tests (no binary required), including a real-`LatticeAdapter` test
  that exercises the binary-present/model-absent scenario directly, and pin
  the exact env vars (`LATTICE_MODEL_DIR`, `LATTICE_TOKENIZER_DIR`,
  `BENCH_N`, `BENCH_RUNS=1`) and argument shape the real binary expects.

## Out of scope

- The four remaining live consumers listed in #813
  (`bench_apples_precise.sh`, `bench_q4_apples.sh`,
  `bench_context_scaling.sh`, `bench_compare_1k.py`) — separate PRs per the
  issue's stated one-script-per-PR sequencing.
- Any change to `crates/inference/` (a persistent-server mode for
  `bench_decode_ab` would remove the lattice-adapter timing caveat above, but
  is a Rust-side change well outside a scripts-only migration PR).
- `.github/workflows/*` — untouched, per the CI-change-serial lane.
