### PR TITLE
refactor(inference): extract shared Metal RMS-norm reduction helper (#854)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,11 @@ jobs:
       # grammar steps' convention; the exact-count grep guards against a silently
       # zero-matching filter the same way those steps do. The gating command writes
       # its log directly (no pipe) so its exit status gates on its own.
+      # The count is 5 since #854: the shared RMS-norm reduction tests
+      # (flash_attention_rms_norm_uses_shared_reduction_helper,
+      # rms_norm_matches_pre_854_oracle_on_finite_input) live in this same
+      # `forward::metal::` module and match the filter. Adding or removing a
+      # test in that module requires updating this count in the same PR.
       - name: inference — metal-gpu fused_attention fail-closed gate (macOS only)
         if: runner.os == 'macOS'
         env:
@@ -315,7 +320,7 @@ jobs:
             exit 1
           fi
           cat "$log"
-          grep -Eq '^test result: ok\. 3 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
+          grep -Eq '^test result: ok\. 5 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
       # #611: Metal generation paths applied grammar masks via `mask_logits`
       # but never checked for a surviving finite logit before sampling — a
       # grammar that blocked every token silently emitted token 0 instead of

--- a/crates/inference/src/forward/metal.rs
+++ b/crates/inference/src/forward/metal.rs
@@ -904,6 +904,189 @@ mod inner {
             }
         }
 
+        /// #854: guards against a reintroduced manual copy of the RMS-norm
+        /// reduction tree. `rms_norm` must be the sole call site of the shared
+        /// `rms_inv_from_local_sum` helper in the assembled `flash_attention.metal`
+        /// translation unit (one definition + one caller).
+        #[test]
+        fn flash_attention_rms_norm_uses_shared_reduction_helper() {
+            let msl = msl_source_for(128, 2);
+            let helper_occurrences = msl.matches("rms_inv_from_local_sum(").count();
+            assert_eq!(
+                helper_occurrences, 2,
+                "expected 1 definition (rms_reduce.metal fragment) + 1 call site \
+                 (rms_norm) in the assembled flash_attention.metal, got {helper_occurrences}"
+            );
+            let inline_leftover = msl.matches("shared[lid] = local_sum;").count();
+            assert_eq!(
+                inline_leftover, 1,
+                "expected exactly one occurrence, inside rms_inv_from_local_sum's own \
+                 body; any additional occurrence is a reintroduced manual copy of the \
+                 reduction tree"
+            );
+        }
+
+        /// #854 numeric parity fixture (pre-refactor vs. post-refactor): `rms_norm`'s
+        /// reduction tree before this PR (frozen verbatim below as
+        /// `RMS_NORM_PRE_854_ORACLE`, byte-identical to the body this PR replaced —
+        /// see commit history) vs. the live post-refactor kernel that calls
+        /// `rms_inv_from_local_sum`. Both run on the same GPU with the same compile
+        /// options and identical finite input; the only source difference is
+        /// inline-body vs. helper-call, so any numeric drift here would mean the
+        /// extraction changed the barrier count, tree order, or rsqrt expression —
+        /// exactly the class of regression this PR's bit-exactness constraint
+        /// forbids (RMS-norm is a nonlinearity; f32 reduction order is part of the
+        /// contract).
+        #[test]
+        fn rms_norm_matches_pre_854_oracle_on_finite_input() {
+            const RMS_NORM_PRE_854_ORACLE: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void rms_norm_pre_854_oracle(
+    device float* x           [[buffer(0)]],
+    device const float* gamma [[buffer(1)]],
+    constant uint& row_len    [[buffer(2)]],
+    constant uint& num_rows   [[buffer(3)]],
+    constant float& eps       [[buffer(4)]],
+    uint gid  [[threadgroup_position_in_grid]],
+    uint lid  [[thread_position_in_threadgroup]],
+    uint tgs  [[threads_per_threadgroup]])
+{
+    if (gid >= num_rows) return;
+    constexpr uint RMS_WG = 256;
+    uint base = gid * row_len;
+
+    threadgroup float shared[RMS_WG];
+    float local_sum = 0.0f;
+    for (uint i = lid; i < row_len; i += tgs) {
+        float v = x[base + i];
+        local_sum += v * v;
+    }
+    shared[lid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint s = tgs / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            shared[lid] += shared[lid + s];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    float rms = rsqrt(shared[0] / float(row_len) + eps);
+
+    for (uint i = lid; i < row_len; i += tgs) {
+        x[base + i] = x[base + i] * rms * gamma[i];
+    }
+}
+"#;
+
+            let Some(device) = metal_test_device("rms_norm_matches_pre_854_oracle_on_finite_input")
+            else {
+                return;
+            };
+            let _gpu = gpu_test_lock();
+
+            fn f32_buf(device: &Device, data: &[f32]) -> Buffer {
+                device.new_buffer_with_data(
+                    data.as_ptr() as *const _,
+                    std::mem::size_of_val(data) as u64,
+                    MTLResourceOptions::StorageModeShared,
+                )
+            }
+            fn read_f32(buf: &Buffer, len: usize) -> Vec<f32> {
+                // SAFETY: buffer is StorageModeShared, written by a completed
+                // command buffer, and sized for `len` f32 elements.
+                unsafe { std::slice::from_raw_parts(buf.contents() as *const f32, len).to_vec() }
+            }
+            fn lcg_vec(seed: u64, n: usize) -> Vec<f32> {
+                let mut state = seed;
+                (0..n)
+                    .map(|_| {
+                        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                        (((state >> 32) as u32) as f32 / u32::MAX as f32 - 0.5) * 4.0
+                    })
+                    .collect()
+            }
+
+            fn run(
+                device: &Device,
+                lib: &metal::Library,
+                kernel_name: &str,
+                x: &[f32],
+                gamma: &[f32],
+                row_len: u32,
+                num_rows: u32,
+                eps: f32,
+            ) -> Vec<f32> {
+                let func = lib
+                    .get_function(kernel_name, None)
+                    .unwrap_or_else(|e| panic!("kernel {kernel_name} missing: {e}"));
+                let pipe = device
+                    .new_compute_pipeline_state_with_function(&func)
+                    .unwrap_or_else(|e| panic!("pipeline for {kernel_name} failed: {e}"));
+                let x_buf = f32_buf(device, x);
+                let gamma_buf = f32_buf(device, gamma);
+                let queue = device.new_command_queue();
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(&pipe);
+                enc.set_buffer(0, Some(&x_buf), 0);
+                enc.set_buffer(1, Some(&gamma_buf), 0);
+                enc.set_bytes(2, 4, &row_len as *const u32 as *const _);
+                enc.set_bytes(3, 4, &num_rows as *const u32 as *const _);
+                enc.set_bytes(4, 4, &eps as *const f32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(num_rows as u64, 1, 1),
+                    MTLSize::new(256, 1, 1),
+                );
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                read_f32(&x_buf, x.len())
+            }
+
+            // Finite fixture: 3 rows x 130 elements (non-multiple-of-256, exercises
+            // the strided accumulation loop's tail), includes small/negative/near-zero
+            // values.
+            let row_len = 130u32;
+            let num_rows = 3u32;
+            let n = (row_len * num_rows) as usize;
+            let mut x = lcg_vec(42, n);
+            x[0] = 1e-6; // near-zero lane, exercises the `+ eps` floor
+            x[row_len as usize] = -3.5;
+            let gamma = lcg_vec(7, row_len as usize);
+            let eps = 1e-6f32;
+
+            let opts = CompileOptions::new();
+            let oracle_lib = device
+                .new_library_with_source(RMS_NORM_PRE_854_ORACLE, &opts)
+                .expect("frozen pre-#854 oracle must compile");
+            let live_lib = device
+                .new_library_with_source(&msl_source_for(128, 2), &opts)
+                .expect("live post-#854 flash_attention.metal must compile");
+
+            let oracle_out = run(
+                &device,
+                &oracle_lib,
+                "rms_norm_pre_854_oracle",
+                &x,
+                &gamma,
+                row_len,
+                num_rows,
+                eps,
+            );
+            let live_out = run(
+                &device, &live_lib, "rms_norm", &x, &gamma, row_len, num_rows, eps,
+            );
+
+            assert_eq!(
+                oracle_out, live_out,
+                "rms_norm output diverged from the frozen pre-#854 oracle on a finite \
+                 fixture — the reduction-tree extraction must be bit-exact"
+            );
+        }
+
         /// ADR-080 C1 (#789) regression fixture: corrupts a single entry of
         /// `q_proj_weight` with `corrupt_value` so one attention head's Q vector
         /// carries that value at every query position (K/V/embeddings/residual stay

--- a/crates/inference/src/forward/metal.rs
+++ b/crates/inference/src/forward/metal.rs
@@ -14,7 +14,14 @@ mod inner {
     // MSL Compute Shaders
     // ---------------------------------------------------------------------------
 
-    const MSL_TEMPLATE: &str = include_str!("shaders/flash_attention.metal");
+    // #854: the shared RMS-norm reduction helper is assembled as a prefix
+    // fragment ahead of the kernel bodies that call it (Metal requires the
+    // callee be visible textually before its call sites in the same
+    // translation unit).
+    const MSL_TEMPLATE: &str = concat!(
+        include_str!("shaders/rms_reduce.metal"),
+        include_str!("shaders/flash_attention.metal")
+    );
 
     // ---------------------------------------------------------------------------
     // Weight and Activation Buffer Structs

--- a/crates/inference/src/forward/metal.rs
+++ b/crates/inference/src/forward/metal.rs
@@ -1009,6 +1009,55 @@ kernel void rms_norm_pre_854_oracle(
                     .collect()
             }
 
+            /// Builds `num_rows` rows of `row_len` elements each, with row 0 forced to
+            /// an exact all-near-zero constant and row 1 forced to the exact smallest
+            /// positive f32 subnormal (`f32::from_bits(1)`, ~1.4e-45) — two distinct
+            /// epsilon-floor edge cases a whole-row-of-ordinary-magnitude fixture
+            /// cannot exercise: the reduction's `rsqrt(sum_sq / width + eps)` is
+            /// dominated by `eps` only when `sum_sq` itself is vanishingly small
+            /// across the *whole* row, not just one lane. Remaining rows are ordinary
+            /// pseudo-random data (regression coverage).
+            fn row_batch(seed: u64, row_len: usize, num_rows: usize) -> Vec<f32> {
+                let mut v = Vec::with_capacity(row_len * num_rows);
+                for r in 0..num_rows {
+                    match r {
+                        0 => v.extend(std::iter::repeat_n(1e-20f32, row_len)),
+                        1 => v.extend(std::iter::repeat_n(f32::from_bits(1), row_len)),
+                        _ => v.extend(lcg_vec(seed + r as u64, row_len)),
+                    }
+                }
+                v
+            }
+
+            /// Confirms `row_batch`'s row 0 / row 1 actually landed as the exact
+            /// near-zero / subnormal constants (construction proof) and prints their
+            /// sum-of-squares so a test run makes the new coverage visible, not just
+            /// implicit in a later bit-identical comparison.
+            fn assert_edge_rows(label: &str, data: &[f32], row_len: usize) {
+                let near_zero = &data[0..row_len];
+                let subnormal = &data[row_len..2 * row_len];
+                assert!(
+                    near_zero.iter().all(|v| *v == 1e-20f32),
+                    "{label}: row 0 fixture must be the exact all-near-zero constant"
+                );
+                assert!(
+                    subnormal.iter().all(|v| v.to_bits() == 1),
+                    "{label}: row 1 fixture must be the exact f32 subnormal (from_bits(1))"
+                );
+                eprintln!(
+                    "[RMS_854_FIXTURE] {label}: row0(near_zero) sum_sq={:.3e} \
+                     row1(subnormal) sum_sq={:.3e}",
+                    near_zero
+                        .iter()
+                        .map(|v| (*v as f64) * (*v as f64))
+                        .sum::<f64>(),
+                    subnormal
+                        .iter()
+                        .map(|v| (*v as f64) * (*v as f64))
+                        .sum::<f64>(),
+                );
+            }
+
             fn run(
                 device: &Device,
                 lib: &metal::Library,
@@ -1046,15 +1095,14 @@ kernel void rms_norm_pre_854_oracle(
                 read_f32(&x_buf, x.len())
             }
 
-            // Finite fixture: 3 rows x 130 elements (non-multiple-of-256, exercises
-            // the strided accumulation loop's tail), includes small/negative/near-zero
-            // values.
+            // Finite fixture: 4 rows x 130 elements (non-multiple-of-256, exercises the
+            // strided accumulation loop's tail). Row 0 = all-near-zero, row 1 =
+            // all-f32-subnormal (both dedicated epsilon-floor edge cases), rows 2-3 =
+            // ordinary pseudo-random data (includes negative lanes).
             let row_len = 130u32;
-            let num_rows = 3u32;
-            let n = (row_len * num_rows) as usize;
-            let mut x = lcg_vec(42, n);
-            x[0] = 1e-6; // near-zero lane, exercises the `+ eps` floor
-            x[row_len as usize] = -3.5;
+            let num_rows = 4u32;
+            let x = row_batch(42, row_len as usize, num_rows as usize);
+            assert_edge_rows("rms_norm (flash)", &x, row_len as usize);
             let gamma = lcg_vec(7, row_len as usize);
             let eps = 1e-6f32;
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -17095,6 +17095,55 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     .collect()
             }
 
+            /// Builds `num_rows` rows of `row_len` elements each, with row 0 forced to
+            /// an exact all-near-zero constant and row 1 forced to the exact smallest
+            /// positive f32 subnormal (`f32::from_bits(1)`, ~1.4e-45) — two distinct
+            /// epsilon-floor edge cases a whole-row-of-ordinary-magnitude fixture
+            /// cannot exercise: the reduction's `rsqrt(sum_sq / width + eps)` is
+            /// dominated by `eps` only when `sum_sq` itself is vanishingly small
+            /// across the *whole* row, not just one lane. Remaining rows are ordinary
+            /// pseudo-random data (regression coverage).
+            fn row_batch(seed: u64, row_len: usize, num_rows: usize) -> Vec<f32> {
+                let mut v = Vec::with_capacity(row_len * num_rows);
+                for r in 0..num_rows {
+                    match r {
+                        0 => v.extend(std::iter::repeat_n(1e-20f32, row_len)),
+                        1 => v.extend(std::iter::repeat_n(f32::from_bits(1), row_len)),
+                        _ => v.extend(lcg_vec(seed + r as u64, row_len)),
+                    }
+                }
+                v
+            }
+
+            /// Confirms `row_batch`'s row 0 / row 1 actually landed as the exact
+            /// near-zero / subnormal constants (construction proof) and prints their
+            /// sum-of-squares so a test run makes the new coverage visible, not just
+            /// implicit in a later bit-identical comparison.
+            fn assert_edge_rows(label: &str, data: &[f32], row_len: usize) {
+                let near_zero = &data[0..row_len];
+                let subnormal = &data[row_len..2 * row_len];
+                assert!(
+                    near_zero.iter().all(|v| *v == 1e-20f32),
+                    "{label}: row 0 fixture must be the exact all-near-zero constant"
+                );
+                assert!(
+                    subnormal.iter().all(|v| v.to_bits() == 1),
+                    "{label}: row 1 fixture must be the exact f32 subnormal (from_bits(1))"
+                );
+                eprintln!(
+                    "[RMS_854_FIXTURE] {label}: row0(near_zero) sum_sq={:.3e} \
+                     row1(subnormal) sum_sq={:.3e}",
+                    near_zero
+                        .iter()
+                        .map(|v| (*v as f64) * (*v as f64))
+                        .sum::<f64>(),
+                    subnormal
+                        .iter()
+                        .map(|v| (*v as f64) * (*v as f64))
+                        .sum::<f64>(),
+                );
+            }
+
             fn pipeline_for(device: &Device, lib: &Library, name: &str) -> ComputePipelineState {
                 let func = lib
                     .get_function(name, None)
@@ -17360,10 +17409,22 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
 
             #[test]
             fn qwen35_rms_kernels_match_pre_854_oracle_on_finite_input() {
+                // Fail-closed device probe (matches `metal::inner::tests::metal_test_device`'s
+                // convention): a runner with no Metal device reports a distinct skip, unless
+                // LATTICE_METAL_TEST_ENFORCE=1 is set, in which case a missing device is a
+                // hard failure rather than a silent pass. Without this, a CI runner that lost
+                // its Metal device would report this parity gate as `ok` without ever
+                // compiling or comparing either library.
+                let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
                 let Some(device) = Device::system_default() else {
                     eprintln!(
-                        "skipping qwen35_rms_kernels_match_pre_854_oracle_on_finite_input: \
-                         no Metal device"
+                        "[METAL_TEST_SKIP] context=qwen35_rms_kernels_match_pre_854_oracle_on_finite_input \
+                         reason=no_metal_device"
+                    );
+                    assert!(
+                        !enforce,
+                        "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present \
+                         (qwen35_rms_kernels_match_pre_854_oracle_on_finite_input)"
                     );
                     return;
                 };
@@ -17388,8 +17449,8 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
 
                 // 1. rms_norm_qwen35
                 {
-                    let mut x = lcg_vec(11, (row_len * num_rows) as usize);
-                    x[0] = 1e-6;
+                    let x = row_batch(11, row_len as usize, num_rows as usize);
+                    assert_edge_rows("rms_norm_qwen35", &x, row_len as usize);
                     let gamma = lcg_vec(12, row_len as usize);
                     let oracle = run_rms_norm_qwen35(
                         &device,
@@ -17421,7 +17482,8 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
 
                 // 2. per_head_rms_norm
                 {
-                    let x = lcg_vec(21, (head_dim * num_heads) as usize);
+                    let x = row_batch(21, head_dim as usize, num_heads as usize);
+                    assert_edge_rows("per_head_rms_norm", &x, head_dim as usize);
                     let gamma = lcg_vec(22, head_dim as usize);
                     let oracle = run_per_head_rms_norm(
                         &device,
@@ -17451,10 +17513,26 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     );
                 }
 
-                // 3. fused_residual_add_norm
-                {
-                    let base = lcg_vec(31, row_len as usize);
-                    let delta = lcg_vec(32, row_len as usize);
+                // 3. fused_residual_add_norm — single threadgroup, no row/head batch
+                // dimension, so near-zero/subnormal residual-input coverage runs as
+                // separate dispatches instead of dedicated rows within one dispatch.
+                for (label, base, delta) in [
+                    (
+                        "normal",
+                        lcg_vec(31, row_len as usize),
+                        lcg_vec(32, row_len as usize),
+                    ),
+                    (
+                        "near_zero_residual",
+                        vec![1e-20f32; row_len as usize],
+                        vec![1e-20f32; row_len as usize],
+                    ),
+                    (
+                        "subnormal_residual",
+                        vec![f32::from_bits(1); row_len as usize],
+                        vec![f32::from_bits(1); row_len as usize],
+                    ),
+                ] {
                     let gamma = lcg_vec(33, row_len as usize);
                     let oracle = run_fused_residual_add_norm(
                         &device,
@@ -17480,13 +17558,24 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     );
                     assert_eq!(
                         oracle, live,
-                        "fused_residual_add_norm diverged from pre-#854 oracle"
+                        "fused_residual_add_norm ({label} fixture) diverged from pre-#854 oracle"
+                    );
+                    eprintln!(
+                        "[RMS_854_FIXTURE] fused_residual_add_norm: {label} fixture executed"
                     );
                 }
 
-                // 4. copy_and_rms_norm
-                {
-                    let src = lcg_vec(41, row_len as usize);
+                // 4. copy_and_rms_norm — single threadgroup, no row/head batch
+                // dimension, so near-zero/subnormal coverage runs as separate
+                // dispatches instead of dedicated rows within one dispatch.
+                for (label, src) in [
+                    ("normal", lcg_vec(41, row_len as usize)),
+                    ("near_zero_residual", vec![1e-20f32; row_len as usize]),
+                    (
+                        "subnormal_residual",
+                        vec![f32::from_bits(1); row_len as usize],
+                    ),
+                ] {
                     let gamma = lcg_vec(42, row_len as usize);
                     let oracle = run_copy_and_rms_norm(
                         &device,
@@ -17510,13 +17599,15 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     );
                     assert_eq!(
                         oracle, live,
-                        "copy_and_rms_norm diverged from pre-#854 oracle"
+                        "copy_and_rms_norm ({label} fixture) diverged from pre-#854 oracle"
                     );
+                    eprintln!("[RMS_854_FIXTURE] copy_and_rms_norm: {label} fixture executed");
                 }
 
                 // 5. copy_and_rms_norm_batch
                 {
-                    let src = lcg_vec(51, (row_len * num_rows) as usize);
+                    let src = row_batch(51, row_len as usize, num_rows as usize);
+                    assert_edge_rows("copy_and_rms_norm_batch", &src, row_len as usize);
                     let gamma = lcg_vec(52, row_len as usize);
                     let oracle = run_copy_and_rms_norm_batch(
                         &device,
@@ -17546,10 +17637,23 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     );
                 }
 
-                // 6. fused_residual_add_norm_batch
+                // 6. fused_residual_add_norm_batch — both residual inputs (base and
+                // delta) get dedicated near-zero/subnormal rows, since this kernel's
+                // reduction runs over the post-add residual sum, not either input
+                // alone.
                 {
-                    let base = lcg_vec(61, (row_len * num_rows) as usize);
-                    let delta = lcg_vec(62, (row_len * num_rows) as usize);
+                    let base = row_batch(61, row_len as usize, num_rows as usize);
+                    assert_edge_rows(
+                        "fused_residual_add_norm_batch/base",
+                        &base,
+                        row_len as usize,
+                    );
+                    let delta = row_batch(62, row_len as usize, num_rows as usize);
+                    assert_edge_rows(
+                        "fused_residual_add_norm_batch/delta",
+                        &delta,
+                        row_len as usize,
+                    );
                     let gamma = lcg_vec(63, row_len as usize);
                     let oracle = run_fused_residual_add_norm_batch(
                         &device,
@@ -17581,9 +17685,13 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     );
                 }
 
-                // 7. per_head_rms_norm_batch
+                // 7. per_head_rms_norm_batch — row-major layout is
+                // base = t*(num_heads*head_dim) + head*head_dim, so a batch of
+                // num_heads*num_tokens rows of width head_dim lines up exactly
+                // with row_batch's row-major ordering.
                 {
-                    let x = lcg_vec(71, (head_dim * num_heads * num_tokens) as usize);
+                    let x = row_batch(71, head_dim as usize, (num_heads * num_tokens) as usize);
+                    assert_edge_rows("per_head_rms_norm_batch", &x, head_dim as usize);
                     let gamma = lcg_vec(72, head_dim as usize);
                     let oracle = run_per_head_rms_norm_batch(
                         &device,

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -984,7 +984,14 @@ mod inner {
     // MSL Compute Shaders
     // ---------------------------------------------------------------------------
 
-    const MSL_SOURCE: &str = include_str!("shaders/qwen35.metal");
+    // #854: the shared RMS-norm reduction helper is assembled as a prefix
+    // fragment ahead of the kernel bodies that call it (Metal requires the
+    // callee be visible textually before its call sites in the same
+    // translation unit).
+    const MSL_SOURCE: &str = concat!(
+        include_str!("shaders/rms_reduce.metal"),
+        include_str!("shaders/qwen35.metal")
+    );
 
     const MSL_Q4_TILED_SOURCE: &str = include_str!("shaders/gemm_q4_tiled.metal");
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -16774,6 +16774,849 @@ mod inner {
         };
         use crate::model::qwen35_config::LayerType;
 
+        /// #854: guards against a reintroduced manual copy of the RMS-norm
+        /// reduction tree across qwen35.metal's seven RMS-norm-family kernels
+        /// (rms_norm_qwen35, per_head_rms_norm, fused_residual_add_norm,
+        /// copy_and_rms_norm, copy_and_rms_norm_batch, fused_residual_add_norm_batch,
+        /// per_head_rms_norm_batch). `rms_inv_from_local_sum` must have exactly one
+        /// definition (the shared fragment) plus exactly seven call sites in the
+        /// assembled qwen35.metal translation unit.
+        #[test]
+        fn qwen35_rms_norm_kernels_use_shared_reduction_helper() {
+            let helper_occurrences = MSL_SOURCE.matches("rms_inv_from_local_sum(").count();
+            assert_eq!(
+                helper_occurrences, 8,
+                "expected 1 definition (rms_reduce.metal fragment) + 7 call sites in \
+                 the assembled qwen35.metal, got {helper_occurrences}"
+            );
+            let inline_leftover = MSL_SOURCE.matches("shared[lid] = local_sum;").count();
+            assert_eq!(
+                inline_leftover, 1,
+                "expected exactly one occurrence, inside rms_inv_from_local_sum's own \
+                 body; any additional occurrence is a reintroduced manual copy of the \
+                 reduction tree (no thirteenth manual copy)"
+            );
+        }
+
+        /// #854 numeric parity fixtures (pre-refactor vs. post-refactor) for all
+        /// seven qwen35.metal RMS-norm-family kernels. Each kernel's pre-refactor
+        /// inline reduction tree is frozen verbatim below (renamed with a
+        /// `_pre_854_oracle` suffix, bodies otherwise byte-identical to what this
+        /// PR replaced) and compiled as an independent oracle library; the live
+        /// post-refactor kernel is dispatched from the real `MSL_SOURCE`. Both run
+        /// on the same GPU with the same compile options and identical finite
+        /// input — the only source difference is inline-body vs. helper-call — so
+        /// bit-identical output proves the extraction preserved barrier count, tree
+        /// order, and the rsqrt expression for every call site (RMS-norm is a
+        /// nonlinearity; f32 reduction order is part of the contract).
+        mod rms_reduce_854_parity {
+            use super::*;
+
+            const ORACLE_MSL: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void rms_norm_qwen35_pre_854_oracle(
+    device float* x           [[buffer(0)]],
+    device const float* gamma [[buffer(1)]],
+    constant uint& row_len    [[buffer(2)]],
+    constant uint& num_rows   [[buffer(3)]],
+    constant float& eps       [[buffer(4)]],
+    uint gid  [[threadgroup_position_in_grid]],
+    uint lid  [[thread_position_in_threadgroup]],
+    uint tgs  [[threads_per_threadgroup]])
+{
+    if (gid >= num_rows) return;
+    constexpr uint RMS_WG = 256;
+    uint base = gid * row_len;
+
+    threadgroup float shared[RMS_WG];
+    float local_sum = 0.0f;
+    for (uint i = lid; i < row_len; i += tgs) {
+        float v = x[base + i];
+        local_sum += v * v;
+    }
+    shared[lid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint s = tgs / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            shared[lid] += shared[lid + s];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    float rms = rsqrt(shared[0] / float(row_len) + eps);
+
+    for (uint i = lid; i < row_len; i += tgs) {
+        x[base + i] = x[base + i] * rms * (1.0f + gamma[i]);
+    }
+}
+
+kernel void per_head_rms_norm_pre_854_oracle(
+    device float* x           [[buffer(0)]],
+    device const float* gamma [[buffer(1)]],
+    constant uint& num_heads  [[buffer(2)]],
+    constant uint& head_dim   [[buffer(3)]],
+    constant float& eps       [[buffer(4)]],
+    uint gid  [[threadgroup_position_in_grid]],
+    uint lid  [[thread_position_in_threadgroup]],
+    uint tgs  [[threads_per_threadgroup]])
+{
+    if (gid >= num_heads) return;
+    constexpr uint NORM_WG = 256;
+    uint base = gid * head_dim;
+
+    threadgroup float shared[NORM_WG];
+    float local_sum = 0.0f;
+    for (uint i = lid; i < head_dim; i += tgs) {
+        float v = x[base + i];
+        local_sum += v * v;
+    }
+    shared[lid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint s = tgs / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            shared[lid] += shared[lid + s];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    float rms = rsqrt(shared[0] / float(head_dim) + eps);
+
+    for (uint i = lid; i < head_dim; i += tgs) {
+        x[base + i] = x[base + i] * rms * (1.0f + gamma[i]);
+    }
+}
+
+kernel void fused_residual_add_norm_pre_854_oracle(
+    device const float* base     [[buffer(0)]],
+    device const float* delta    [[buffer(1)]],
+    device float* residual_out   [[buffer(2)]],
+    device float* normed_out     [[buffer(3)]],
+    device const float* gamma    [[buffer(4)]],
+    constant uint& row_len       [[buffer(5)]],
+    constant float& eps          [[buffer(6)]],
+    uint lid  [[thread_position_in_threadgroup]],
+    uint tgs  [[threads_per_threadgroup]])
+{
+    constexpr uint WG = 256;
+    threadgroup float shared[WG];
+
+    float local_sum = 0.0f;
+    for (uint i = lid; i < row_len; i += tgs) {
+        float val = base[i] + delta[i];
+        residual_out[i] = val;
+        local_sum += val * val;
+    }
+
+    shared[lid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = tgs / 2; s > 0; s >>= 1) {
+        if (lid < s) shared[lid] += shared[lid + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    float rms = rsqrt(shared[0] / float(row_len) + eps);
+
+    for (uint i = lid; i < row_len; i += tgs) {
+        normed_out[i] = residual_out[i] * rms * (1.0f + gamma[i]);
+    }
+}
+
+kernel void copy_and_rms_norm_pre_854_oracle(
+    device float* src            [[buffer(0)]],
+    device float* residual_out   [[buffer(1)]],
+    device const float* gamma    [[buffer(2)]],
+    constant uint& row_len       [[buffer(3)]],
+    constant float& eps          [[buffer(4)]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgs [[threads_per_threadgroup]])
+{
+    constexpr uint WG = 256;
+    threadgroup float shared[WG];
+
+    float local_sum = 0.0f;
+    for (uint i = lid; i < row_len; i += tgs) {
+        float v = src[i];
+        residual_out[i] = v;
+        local_sum += v * v;
+    }
+
+    shared[lid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = tgs / 2; s > 0; s >>= 1) {
+        if (lid < s) shared[lid] += shared[lid + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    float rms = rsqrt(shared[0] / float(row_len) + eps);
+
+    for (uint i = lid; i < row_len; i += tgs) {
+        src[i] = src[i] * rms * (1.0f + gamma[i]);
+    }
+}
+
+kernel void copy_and_rms_norm_batch_pre_854_oracle(
+    device float* src            [[buffer(0)]],
+    device float* residual_out   [[buffer(1)]],
+    device const float* gamma    [[buffer(2)]],
+    constant uint& row_len       [[buffer(3)]],
+    constant uint& num_rows      [[buffer(4)]],
+    constant float& eps          [[buffer(5)]],
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgs [[threads_per_threadgroup]])
+{
+    if (gid >= num_rows) return;
+    constexpr uint WG = 256;
+    threadgroup float shared[WG];
+    uint base = gid * row_len;
+
+    float local_sum = 0.0f;
+    for (uint i = lid; i < row_len; i += tgs) {
+        float v = src[base + i];
+        residual_out[base + i] = v;
+        local_sum += v * v;
+    }
+
+    shared[lid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = tgs / 2; s > 0; s >>= 1) {
+        if (lid < s) shared[lid] += shared[lid + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    float rms = rsqrt(shared[0] / float(row_len) + eps);
+
+    for (uint i = lid; i < row_len; i += tgs) {
+        src[base + i] = src[base + i] * rms * (1.0f + gamma[i]);
+    }
+}
+
+kernel void fused_residual_add_norm_batch_pre_854_oracle(
+    device const float* base     [[buffer(0)]],
+    device const float* delta    [[buffer(1)]],
+    device float* residual_out   [[buffer(2)]],
+    device float* normed_out     [[buffer(3)]],
+    device const float* gamma    [[buffer(4)]],
+    constant uint& row_len       [[buffer(5)]],
+    constant uint& num_rows      [[buffer(6)]],
+    constant float& eps          [[buffer(7)]],
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgs [[threads_per_threadgroup]])
+{
+    if (gid >= num_rows) return;
+    constexpr uint WG = 256;
+    threadgroup float shared[WG];
+    uint base_off = gid * row_len;
+
+    float local_sum = 0.0f;
+    for (uint i = lid; i < row_len; i += tgs) {
+        float val = base[base_off + i] + delta[base_off + i];
+        residual_out[base_off + i] = val;
+        local_sum += val * val;
+    }
+
+    shared[lid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = tgs / 2; s > 0; s >>= 1) {
+        if (lid < s) shared[lid] += shared[lid + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    float rms = rsqrt(shared[0] / float(row_len) + eps);
+
+    for (uint i = lid; i < row_len; i += tgs) {
+        normed_out[base_off + i] = residual_out[base_off + i] * rms * (1.0f + gamma[i]);
+    }
+}
+
+kernel void per_head_rms_norm_batch_pre_854_oracle(
+    device float* x              [[buffer(0)]],
+    device const float* gamma    [[buffer(1)]],
+    constant uint& num_tokens    [[buffer(2)]],
+    constant uint& num_heads     [[buffer(3)]],
+    constant uint& head_dim      [[buffer(4)]],
+    constant float& eps          [[buffer(5)]],
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint tgs [[threads_per_threadgroup]])
+{
+    if (gid >= num_tokens * num_heads) return;
+
+    uint t    = gid / num_heads;
+    uint head = gid % num_heads;
+    uint base = t * (num_heads * head_dim) + head * head_dim;
+
+    constexpr uint NORM_WG = 256;
+    threadgroup float shared[NORM_WG];
+
+    float local_sum = 0.0f;
+    for (uint i = lid; i < head_dim; i += tgs) {
+        float v = x[base + i];
+        local_sum += v * v;
+    }
+    shared[lid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint s = tgs / 2; s > 0; s >>= 1) {
+        if (lid < s) shared[lid] += shared[lid + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    float rms = rsqrt(shared[0] / float(head_dim) + eps);
+
+    for (uint i = lid; i < head_dim; i += tgs) {
+        x[base + i] = x[base + i] * rms * (1.0f + gamma[i]);
+    }
+}
+"#;
+
+            fn f32_buf(device: &Device, data: &[f32]) -> Buffer {
+                device.new_buffer_with_data(
+                    data.as_ptr() as *const _,
+                    std::mem::size_of_val(data) as u64,
+                    MTLResourceOptions::StorageModeShared,
+                )
+            }
+
+            fn read_f32(buf: &Buffer, len: usize) -> Vec<f32> {
+                // SAFETY: buffer is StorageModeShared, written by a completed
+                // command buffer, and sized for `len` f32 elements.
+                unsafe { std::slice::from_raw_parts(buf.contents() as *const f32, len).to_vec() }
+            }
+
+            fn lcg_vec(seed: u64, n: usize) -> Vec<f32> {
+                let mut state = seed;
+                (0..n)
+                    .map(|_| {
+                        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                        (((state >> 32) as u32) as f32 / u32::MAX as f32 - 0.5) * 4.0
+                    })
+                    .collect()
+            }
+
+            fn pipeline_for(device: &Device, lib: &Library, name: &str) -> ComputePipelineState {
+                let func = lib
+                    .get_function(name, None)
+                    .unwrap_or_else(|e| panic!("kernel {name} missing: {e}"));
+                device
+                    .new_compute_pipeline_state_with_function(&func)
+                    .unwrap_or_else(|e| panic!("pipeline for {name} failed: {e}"))
+            }
+
+            /// rms_norm_qwen35(x, gamma, row_len, num_rows, eps) — in-place on x.
+            #[allow(clippy::too_many_arguments)]
+            fn run_rms_norm_qwen35(
+                device: &Device,
+                queue: &CommandQueue,
+                lib: &Library,
+                name: &str,
+                x: &[f32],
+                gamma: &[f32],
+                row_len: u32,
+                num_rows: u32,
+                eps: f32,
+            ) -> Vec<f32> {
+                let pipe = pipeline_for(device, lib, name);
+                let x_buf = f32_buf(device, x);
+                let gamma_buf = f32_buf(device, gamma);
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(&pipe);
+                enc.set_buffer(0, Some(&x_buf), 0);
+                enc.set_buffer(1, Some(&gamma_buf), 0);
+                enc.set_bytes(2, 4, &row_len as *const u32 as *const _);
+                enc.set_bytes(3, 4, &num_rows as *const u32 as *const _);
+                enc.set_bytes(4, 4, &eps as *const f32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(num_rows as u64, 1, 1),
+                    MTLSize::new(256, 1, 1),
+                );
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                read_f32(&x_buf, x.len())
+            }
+
+            /// per_head_rms_norm(x, gamma, num_heads, head_dim, eps) — in-place on x.
+            #[allow(clippy::too_many_arguments)]
+            fn run_per_head_rms_norm(
+                device: &Device,
+                queue: &CommandQueue,
+                lib: &Library,
+                name: &str,
+                x: &[f32],
+                gamma: &[f32],
+                num_heads: u32,
+                head_dim: u32,
+                eps: f32,
+            ) -> Vec<f32> {
+                let pipe = pipeline_for(device, lib, name);
+                let x_buf = f32_buf(device, x);
+                let gamma_buf = f32_buf(device, gamma);
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(&pipe);
+                enc.set_buffer(0, Some(&x_buf), 0);
+                enc.set_buffer(1, Some(&gamma_buf), 0);
+                enc.set_bytes(2, 4, &num_heads as *const u32 as *const _);
+                enc.set_bytes(3, 4, &head_dim as *const u32 as *const _);
+                enc.set_bytes(4, 4, &eps as *const f32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(num_heads as u64, 1, 1),
+                    MTLSize::new(256, 1, 1),
+                );
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                read_f32(&x_buf, x.len())
+            }
+
+            /// fused_residual_add_norm(base, delta, residual_out, normed_out, gamma,
+            /// row_len, eps) — single threadgroup, returns normed_out.
+            #[allow(clippy::too_many_arguments)]
+            fn run_fused_residual_add_norm(
+                device: &Device,
+                queue: &CommandQueue,
+                lib: &Library,
+                name: &str,
+                base: &[f32],
+                delta: &[f32],
+                gamma: &[f32],
+                row_len: u32,
+                eps: f32,
+            ) -> Vec<f32> {
+                let pipe = pipeline_for(device, lib, name);
+                let base_buf = f32_buf(device, base);
+                let delta_buf = f32_buf(device, delta);
+                let residual_buf = f32_buf(device, &vec![0.0f32; row_len as usize]);
+                let normed_buf = f32_buf(device, &vec![0.0f32; row_len as usize]);
+                let gamma_buf = f32_buf(device, gamma);
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(&pipe);
+                enc.set_buffer(0, Some(&base_buf), 0);
+                enc.set_buffer(1, Some(&delta_buf), 0);
+                enc.set_buffer(2, Some(&residual_buf), 0);
+                enc.set_buffer(3, Some(&normed_buf), 0);
+                enc.set_buffer(4, Some(&gamma_buf), 0);
+                enc.set_bytes(5, 4, &row_len as *const u32 as *const _);
+                enc.set_bytes(6, 4, &eps as *const f32 as *const _);
+                enc.dispatch_thread_groups(MTLSize::new(1, 1, 1), MTLSize::new(256, 1, 1));
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                read_f32(&normed_buf, row_len as usize)
+            }
+
+            /// copy_and_rms_norm(src, residual_out, gamma, row_len, eps) — single
+            /// threadgroup, returns src (normalized in place).
+            #[allow(clippy::too_many_arguments)]
+            fn run_copy_and_rms_norm(
+                device: &Device,
+                queue: &CommandQueue,
+                lib: &Library,
+                name: &str,
+                src: &[f32],
+                gamma: &[f32],
+                row_len: u32,
+                eps: f32,
+            ) -> Vec<f32> {
+                let pipe = pipeline_for(device, lib, name);
+                let src_buf = f32_buf(device, src);
+                let residual_buf = f32_buf(device, &vec![0.0f32; row_len as usize]);
+                let gamma_buf = f32_buf(device, gamma);
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(&pipe);
+                enc.set_buffer(0, Some(&src_buf), 0);
+                enc.set_buffer(1, Some(&residual_buf), 0);
+                enc.set_buffer(2, Some(&gamma_buf), 0);
+                enc.set_bytes(3, 4, &row_len as *const u32 as *const _);
+                enc.set_bytes(4, 4, &eps as *const f32 as *const _);
+                enc.dispatch_thread_groups(MTLSize::new(1, 1, 1), MTLSize::new(256, 1, 1));
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                read_f32(&src_buf, row_len as usize)
+            }
+
+            /// copy_and_rms_norm_batch(src, residual_out, gamma, row_len, num_rows,
+            /// eps) — returns src (normalized in place).
+            #[allow(clippy::too_many_arguments)]
+            fn run_copy_and_rms_norm_batch(
+                device: &Device,
+                queue: &CommandQueue,
+                lib: &Library,
+                name: &str,
+                src: &[f32],
+                gamma: &[f32],
+                row_len: u32,
+                num_rows: u32,
+                eps: f32,
+            ) -> Vec<f32> {
+                let pipe = pipeline_for(device, lib, name);
+                let src_buf = f32_buf(device, src);
+                let residual_buf = f32_buf(device, &vec![0.0f32; src.len()]);
+                let gamma_buf = f32_buf(device, gamma);
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(&pipe);
+                enc.set_buffer(0, Some(&src_buf), 0);
+                enc.set_buffer(1, Some(&residual_buf), 0);
+                enc.set_buffer(2, Some(&gamma_buf), 0);
+                enc.set_bytes(3, 4, &row_len as *const u32 as *const _);
+                enc.set_bytes(4, 4, &num_rows as *const u32 as *const _);
+                enc.set_bytes(5, 4, &eps as *const f32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(num_rows as u64, 1, 1),
+                    MTLSize::new(256, 1, 1),
+                );
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                read_f32(&src_buf, src.len())
+            }
+
+            /// fused_residual_add_norm_batch(base, delta, residual_out, normed_out,
+            /// gamma, row_len, num_rows, eps) — returns normed_out.
+            #[allow(clippy::too_many_arguments)]
+            fn run_fused_residual_add_norm_batch(
+                device: &Device,
+                queue: &CommandQueue,
+                lib: &Library,
+                name: &str,
+                base: &[f32],
+                delta: &[f32],
+                gamma: &[f32],
+                row_len: u32,
+                num_rows: u32,
+                eps: f32,
+            ) -> Vec<f32> {
+                let pipe = pipeline_for(device, lib, name);
+                let n = (row_len * num_rows) as usize;
+                let base_buf = f32_buf(device, base);
+                let delta_buf = f32_buf(device, delta);
+                let residual_buf = f32_buf(device, &vec![0.0f32; n]);
+                let normed_buf = f32_buf(device, &vec![0.0f32; n]);
+                let gamma_buf = f32_buf(device, gamma);
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(&pipe);
+                enc.set_buffer(0, Some(&base_buf), 0);
+                enc.set_buffer(1, Some(&delta_buf), 0);
+                enc.set_buffer(2, Some(&residual_buf), 0);
+                enc.set_buffer(3, Some(&normed_buf), 0);
+                enc.set_buffer(4, Some(&gamma_buf), 0);
+                enc.set_bytes(5, 4, &row_len as *const u32 as *const _);
+                enc.set_bytes(6, 4, &num_rows as *const u32 as *const _);
+                enc.set_bytes(7, 4, &eps as *const f32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(num_rows as u64, 1, 1),
+                    MTLSize::new(256, 1, 1),
+                );
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                read_f32(&normed_buf, n)
+            }
+
+            /// per_head_rms_norm_batch(x, gamma, num_tokens, num_heads, head_dim,
+            /// eps) — returns x (normalized in place).
+            #[allow(clippy::too_many_arguments)]
+            fn run_per_head_rms_norm_batch(
+                device: &Device,
+                queue: &CommandQueue,
+                lib: &Library,
+                name: &str,
+                x: &[f32],
+                gamma: &[f32],
+                num_tokens: u32,
+                num_heads: u32,
+                head_dim: u32,
+                eps: f32,
+            ) -> Vec<f32> {
+                let pipe = pipeline_for(device, lib, name);
+                let x_buf = f32_buf(device, x);
+                let gamma_buf = f32_buf(device, gamma);
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(&pipe);
+                enc.set_buffer(0, Some(&x_buf), 0);
+                enc.set_buffer(1, Some(&gamma_buf), 0);
+                enc.set_bytes(2, 4, &num_tokens as *const u32 as *const _);
+                enc.set_bytes(3, 4, &num_heads as *const u32 as *const _);
+                enc.set_bytes(4, 4, &head_dim as *const u32 as *const _);
+                enc.set_bytes(5, 4, &eps as *const f32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new((num_tokens * num_heads) as u64, 1, 1),
+                    MTLSize::new(256, 1, 1),
+                );
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                read_f32(&x_buf, x.len())
+            }
+
+            #[test]
+            fn qwen35_rms_kernels_match_pre_854_oracle_on_finite_input() {
+                let Some(device) = Device::system_default() else {
+                    eprintln!(
+                        "skipping qwen35_rms_kernels_match_pre_854_oracle_on_finite_input: \
+                         no Metal device"
+                    );
+                    return;
+                };
+                let _gpu = gpu_test_lock();
+                let opts = CompileOptions::new();
+                let oracle_lib = device
+                    .new_library_with_source(ORACLE_MSL, &opts)
+                    .expect("frozen pre-#854 oracle MSL must compile");
+                let live_lib = device
+                    .new_library_with_source(MSL_SOURCE, &opts)
+                    .expect("live post-#854 qwen35.metal (MSL_SOURCE) must compile");
+                let queue = device.new_command_queue();
+
+                // Non-multiple-of-256 dims exercise the strided accumulation loop's
+                // tail; includes small/negative/near-zero lanes.
+                let row_len = 130u32;
+                let num_rows = 3u32;
+                let head_dim = 64u32;
+                let num_heads = 5u32;
+                let num_tokens = 3u32;
+                let eps = 1e-6f32;
+
+                // 1. rms_norm_qwen35
+                {
+                    let mut x = lcg_vec(11, (row_len * num_rows) as usize);
+                    x[0] = 1e-6;
+                    let gamma = lcg_vec(12, row_len as usize);
+                    let oracle = run_rms_norm_qwen35(
+                        &device,
+                        &queue,
+                        &oracle_lib,
+                        "rms_norm_qwen35_pre_854_oracle",
+                        &x,
+                        &gamma,
+                        row_len,
+                        num_rows,
+                        eps,
+                    );
+                    let live = run_rms_norm_qwen35(
+                        &device,
+                        &queue,
+                        &live_lib,
+                        "rms_norm_qwen35",
+                        &x,
+                        &gamma,
+                        row_len,
+                        num_rows,
+                        eps,
+                    );
+                    assert_eq!(
+                        oracle, live,
+                        "rms_norm_qwen35 diverged from pre-#854 oracle"
+                    );
+                }
+
+                // 2. per_head_rms_norm
+                {
+                    let x = lcg_vec(21, (head_dim * num_heads) as usize);
+                    let gamma = lcg_vec(22, head_dim as usize);
+                    let oracle = run_per_head_rms_norm(
+                        &device,
+                        &queue,
+                        &oracle_lib,
+                        "per_head_rms_norm_pre_854_oracle",
+                        &x,
+                        &gamma,
+                        num_heads,
+                        head_dim,
+                        eps,
+                    );
+                    let live = run_per_head_rms_norm(
+                        &device,
+                        &queue,
+                        &live_lib,
+                        "per_head_rms_norm",
+                        &x,
+                        &gamma,
+                        num_heads,
+                        head_dim,
+                        eps,
+                    );
+                    assert_eq!(
+                        oracle, live,
+                        "per_head_rms_norm diverged from pre-#854 oracle"
+                    );
+                }
+
+                // 3. fused_residual_add_norm
+                {
+                    let base = lcg_vec(31, row_len as usize);
+                    let delta = lcg_vec(32, row_len as usize);
+                    let gamma = lcg_vec(33, row_len as usize);
+                    let oracle = run_fused_residual_add_norm(
+                        &device,
+                        &queue,
+                        &oracle_lib,
+                        "fused_residual_add_norm_pre_854_oracle",
+                        &base,
+                        &delta,
+                        &gamma,
+                        row_len,
+                        eps,
+                    );
+                    let live = run_fused_residual_add_norm(
+                        &device,
+                        &queue,
+                        &live_lib,
+                        "fused_residual_add_norm",
+                        &base,
+                        &delta,
+                        &gamma,
+                        row_len,
+                        eps,
+                    );
+                    assert_eq!(
+                        oracle, live,
+                        "fused_residual_add_norm diverged from pre-#854 oracle"
+                    );
+                }
+
+                // 4. copy_and_rms_norm
+                {
+                    let src = lcg_vec(41, row_len as usize);
+                    let gamma = lcg_vec(42, row_len as usize);
+                    let oracle = run_copy_and_rms_norm(
+                        &device,
+                        &queue,
+                        &oracle_lib,
+                        "copy_and_rms_norm_pre_854_oracle",
+                        &src,
+                        &gamma,
+                        row_len,
+                        eps,
+                    );
+                    let live = run_copy_and_rms_norm(
+                        &device,
+                        &queue,
+                        &live_lib,
+                        "copy_and_rms_norm",
+                        &src,
+                        &gamma,
+                        row_len,
+                        eps,
+                    );
+                    assert_eq!(
+                        oracle, live,
+                        "copy_and_rms_norm diverged from pre-#854 oracle"
+                    );
+                }
+
+                // 5. copy_and_rms_norm_batch
+                {
+                    let src = lcg_vec(51, (row_len * num_rows) as usize);
+                    let gamma = lcg_vec(52, row_len as usize);
+                    let oracle = run_copy_and_rms_norm_batch(
+                        &device,
+                        &queue,
+                        &oracle_lib,
+                        "copy_and_rms_norm_batch_pre_854_oracle",
+                        &src,
+                        &gamma,
+                        row_len,
+                        num_rows,
+                        eps,
+                    );
+                    let live = run_copy_and_rms_norm_batch(
+                        &device,
+                        &queue,
+                        &live_lib,
+                        "copy_and_rms_norm_batch",
+                        &src,
+                        &gamma,
+                        row_len,
+                        num_rows,
+                        eps,
+                    );
+                    assert_eq!(
+                        oracle, live,
+                        "copy_and_rms_norm_batch diverged from pre-#854 oracle"
+                    );
+                }
+
+                // 6. fused_residual_add_norm_batch
+                {
+                    let base = lcg_vec(61, (row_len * num_rows) as usize);
+                    let delta = lcg_vec(62, (row_len * num_rows) as usize);
+                    let gamma = lcg_vec(63, row_len as usize);
+                    let oracle = run_fused_residual_add_norm_batch(
+                        &device,
+                        &queue,
+                        &oracle_lib,
+                        "fused_residual_add_norm_batch_pre_854_oracle",
+                        &base,
+                        &delta,
+                        &gamma,
+                        row_len,
+                        num_rows,
+                        eps,
+                    );
+                    let live = run_fused_residual_add_norm_batch(
+                        &device,
+                        &queue,
+                        &live_lib,
+                        "fused_residual_add_norm_batch",
+                        &base,
+                        &delta,
+                        &gamma,
+                        row_len,
+                        num_rows,
+                        eps,
+                    );
+                    assert_eq!(
+                        oracle, live,
+                        "fused_residual_add_norm_batch diverged from pre-#854 oracle"
+                    );
+                }
+
+                // 7. per_head_rms_norm_batch
+                {
+                    let x = lcg_vec(71, (head_dim * num_heads * num_tokens) as usize);
+                    let gamma = lcg_vec(72, head_dim as usize);
+                    let oracle = run_per_head_rms_norm_batch(
+                        &device,
+                        &queue,
+                        &oracle_lib,
+                        "per_head_rms_norm_batch_pre_854_oracle",
+                        &x,
+                        &gamma,
+                        num_tokens,
+                        num_heads,
+                        head_dim,
+                        eps,
+                    );
+                    let live = run_per_head_rms_norm_batch(
+                        &device,
+                        &queue,
+                        &live_lib,
+                        "per_head_rms_norm_batch",
+                        &x,
+                        &gamma,
+                        num_tokens,
+                        num_heads,
+                        head_dim,
+                        eps,
+                    );
+                    assert_eq!(
+                        oracle, live,
+                        "per_head_rms_norm_batch diverged from pre-#854 oracle"
+                    );
+                }
+            }
+        }
+
         #[test]
         fn test_f32_f16_roundtrip_basic() {
             // Verify f32 -> f16 -> f32 roundtrip for typical weight values

--- a/crates/inference/src/forward/shaders/flash_attention.metal
+++ b/crates/inference/src/forward/shaders/flash_attention.metal
@@ -66,18 +66,7 @@ kernel void rms_norm(
         float v = x[base + i];
         local_sum += v * v;
     }
-    shared[lid] = local_sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    // Tree reduction.
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) {
-            shared[lid] += shared[lid + s];
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-
-    float rms = rsqrt(shared[0] / float(row_len) + eps);
+    float rms = rms_inv_from_local_sum(shared, local_sum, lid, tgs, row_len, eps);
 
     // Scale each element.
     for (uint i = lid; i < row_len; i += tgs) {

--- a/crates/inference/src/forward/shaders/qwen35.metal
+++ b/crates/inference/src/forward/shaders/qwen35.metal
@@ -269,17 +269,7 @@ kernel void rms_norm_qwen35(
         float v = x[base + i];
         local_sum += v * v;
     }
-    shared[lid] = local_sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) {
-            shared[lid] += shared[lid + s];
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-
-    float rms = rsqrt(shared[0] / float(row_len) + eps);
+    float rms = rms_inv_from_local_sum(shared, local_sum, lid, tgs, row_len, eps);
 
     // Qwen3.5: shifted RMSNorm (1 + gamma). Empirically required — plain
     // gamma produces garbage logits on this model.
@@ -346,17 +336,7 @@ kernel void per_head_rms_norm(
         float v = x[base + i];
         local_sum += v * v;
     }
-    shared[lid] = local_sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) {
-            shared[lid] += shared[lid + s];
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-
-    float rms = rsqrt(shared[0] / float(head_dim) + eps);
+    float rms = rms_inv_from_local_sum(shared, local_sum, lid, tgs, head_dim, eps);
 
     // Qwen3.5: shifted RMSNorm (1 + gamma) — per-head variant for q_norm/k_norm.
     for (uint i = lid; i < head_dim; i += tgs) {
@@ -789,14 +769,7 @@ kernel void fused_residual_add_norm(
         local_sum += val * val;
     }
 
-    // Reduce sum of squares
-    shared[lid] = local_sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) shared[lid] += shared[lid + s];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-    float rms = rsqrt(shared[0] / float(row_len) + eps);
+    float rms = rms_inv_from_local_sum(shared, local_sum, lid, tgs, row_len, eps);
 
     // Phase 2: normed_out = residual_out * rms * (1 + gamma) (Qwen3.5 shifted RMSNorm).
     for (uint i = lid; i < row_len; i += tgs) {
@@ -2133,14 +2106,7 @@ kernel void copy_and_rms_norm(
         local_sum += v * v;
     }
 
-    // Reduce sum of squares
-    shared[lid] = local_sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) shared[lid] += shared[lid + s];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-    float rms = rsqrt(shared[0] / float(row_len) + eps);
+    float rms = rms_inv_from_local_sum(shared, local_sum, lid, tgs, row_len, eps);
 
     // Phase 2: normalize src in-place with Qwen3.5 shifted RMSNorm (1 + gamma).
     for (uint i = lid; i < row_len; i += tgs) {
@@ -2173,13 +2139,7 @@ kernel void copy_and_rms_norm_batch(
         local_sum += v * v;
     }
 
-    shared[lid] = local_sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) shared[lid] += shared[lid + s];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-    float rms = rsqrt(shared[0] / float(row_len) + eps);
+    float rms = rms_inv_from_local_sum(shared, local_sum, lid, tgs, row_len, eps);
 
     for (uint i = lid; i < row_len; i += tgs) {
         src[base + i] = src[base + i] * rms * (1.0f + gamma[i]);
@@ -2213,13 +2173,7 @@ kernel void fused_residual_add_norm_batch(
         local_sum += val * val;
     }
 
-    shared[lid] = local_sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) shared[lid] += shared[lid + s];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-    float rms = rsqrt(shared[0] / float(row_len) + eps);
+    float rms = rms_inv_from_local_sum(shared, local_sum, lid, tgs, row_len, eps);
 
     for (uint i = lid; i < row_len; i += tgs) {
         normed_out[base_off + i] = residual_out[base_off + i] * rms * (1.0f + gamma[i]);
@@ -2420,15 +2374,7 @@ kernel void per_head_rms_norm_batch(
         float v = x[base + i];
         local_sum += v * v;
     }
-    shared[lid] = local_sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    for (uint s = tgs / 2; s > 0; s >>= 1) {
-        if (lid < s) shared[lid] += shared[lid + s];
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-    }
-
-    float rms = rsqrt(shared[0] / float(head_dim) + eps);
+    float rms = rms_inv_from_local_sum(shared, local_sum, lid, tgs, head_dim, eps);
 
     // Qwen3.5 shifted RMSNorm: same (1 + gamma) convention as per_head_rms_norm.
     for (uint i = lid; i < head_dim; i += tgs) {

--- a/crates/inference/src/forward/shaders/rms_reduce.metal
+++ b/crates/inference/src/forward/shaders/rms_reduce.metal
@@ -1,0 +1,44 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// ===== Shared RMS-norm threadgroup reduction (#854) =====
+// The barriered sum-of-squares reduction tree below — write to `shared[lid]`,
+// barrier, tree-reduce in `tgs/2` steps, `rsqrt(mean + eps)` — was duplicated
+// verbatim across eight Metal kernels (rms_norm, rms_norm_qwen35,
+// per_head_rms_norm, fused_residual_add_norm, copy_and_rms_norm,
+// copy_and_rms_norm_batch, fused_residual_add_norm_batch,
+// per_head_rms_norm_batch). This is a mechanical extraction only: barrier
+// count, tree order, and the final rsqrt expression are unchanged from every
+// prior copy — RMS-norm is a nonlinearity and f32 reduction order is part of
+// the numerical contract, so this helper must never reassociate the tree.
+//
+// Callers keep their own `local_sum` accumulation (and any input scan / copy
+// / residual-add work fused into that phase), their own `threadgroup float
+// shared[...]` array declaration, and their own epilogue gamma scaling
+// (plain `gamma[i]` for `rms_norm`, Qwen3.5 shifted `(1 + gamma[i])`
+// everywhere else) — this helper covers only the shared reduction, not the
+// epilogue, since the epilogue differs per caller.
+//
+// Every thread in the threadgroup must call this on the same control-flow
+// path (no call behind lane-local divergence) — the barriers inside require
+// full threadgroup participation.
+inline float rms_inv_from_local_sum(
+    threadgroup float* shared,
+    float local_sum,
+    uint lid,
+    uint tgs,
+    uint width,
+    float eps)
+{
+    shared[lid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint s = tgs / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            shared[lid] += shared[lid + s];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    return rsqrt(shared[0] / float(width) + eps);
+}


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What

Extracts the barriered RMS-norm reduction tree — `shared[lid] = local_sum` →
barrier → tree-reduce in `tgs/2` steps → `rsqrt(mean + eps)` — duplicated
across eight Metal kernels into one shared inline helper,
`rms_inv_from_local_sum`, added in `crates/inference/src/forward/shaders/rms_reduce.metal`
and assembled as a prefix fragment ahead of both `flash_attention.metal` and
`qwen35.metal` via `concat!(include_str!(...), include_str!(...))`.

The eight call sites:

- `flash_attention.metal::rms_norm`
- `qwen35.metal::rms_norm_qwen35`
- `qwen35.metal::per_head_rms_norm`
- `qwen35.metal::fused_residual_add_norm`
- `qwen35.metal::copy_and_rms_norm`
- `qwen35.metal::copy_and_rms_norm_batch`
- `qwen35.metal::fused_residual_add_norm_batch`
- `qwen35.metal::per_head_rms_norm_batch`

Two commits, per the issue's sequencing:

1. `b6717dcc31` — mechanical lift: add the fragment + `concat!` assembly,
   all eight bodies still inline and byte-for-byte unchanged.
2. `dad1bdc144` — route all eight bodies through the helper.

## Why

Eight independently-maintained copies of the same reduction tree meant any
future fix to barrier count, tree shape, or epsilon handling would need to
land eight times, with drift risk between copies.

## Helper design

```metal
inline float rms_inv_from_local_sum(
    threadgroup float* shared,
    float local_sum,
    uint lid,
    uint tgs,
    uint width,
    float eps);
```

Callers keep their own `local_sum` accumulation (and any fused copy /
residual-add work), their own `threadgroup float shared[...]` declaration,
and their own epilogue gamma scaling — `rms_norm` uses plain `gamma[i]`,
every other call site uses Qwen3.5's shifted `(1.0f + gamma[i])`. The helper
covers only the shared reduction; nothing else was harmonized. No finite-input
formula, epsilon handling, gamma/buffer layout, or threadgroup geometry
changed.

## Verification

### Commit 1 — mechanical-lift byte-reversibility (per-translation-unit)

Stripping the known fragment-length prefix off each assembled MSL translation
unit reproduces the pre-lift file content byte-for-byte (throwaway script,
diffed against `origin/main`):

```
fragment length: 1862 bytes
[FLASH] BYTE-IDENTICAL: stripped(assembled) == origin/main:crates/inference/src/forward/shaders/flash_attention.metal
[QWEN] BYTE-IDENTICAL: stripped(assembled) == origin/main:crates/inference/src/forward/shaders/qwen35.metal
```

### Commit 2 — exact enumeration + per-kernel numeric parity (all eight sites)

Two new enumeration tests (`flash_attention_rms_norm_uses_shared_reduction_helper`
in `metal.rs`, `qwen35_rms_norm_kernels_use_shared_reduction_helper` in
`metal_qwen35.rs`) assert the assembled MSL contains exactly one definition +
N call sites of `rms_inv_from_local_sum` (1+1 in `flash_attention.metal`,
1+7 in `qwen35.metal`) and exactly one occurrence of the old
`shared[lid] = local_sum;` pattern (inside the helper's own body) — a
reintroduced manual copy at any of the eight sites fails this test.

For numeric parity, each kernel's pre-refactor reduction tree is frozen
verbatim (renamed with a `_pre_854_oracle` suffix, bodies otherwise
byte-identical to what this PR replaced) and compiled as an independent
oracle Metal library. The live post-refactor kernel (dispatched from the real
`MSL_SOURCE`/`MSL_TEMPLATE`) is run against the frozen oracle on the same GPU,
same compile options, identical finite input (non-multiple-of-256 row/head
dims to exercise the strided-accumulation tail, plus dedicated all-near-zero
and f32-subnormal (`f32::from_bits(1)`) rows — including the residual inputs
on the two fused kernels — alongside ordinary pseudo-random negative/positive
lanes) — the only source difference is inline-body vs. helper-call, so
bit-identical output proves the barrier count, tree order, and `rsqrt`
expression are unchanged for every one of the eight sites, at both ordinary
magnitude and at the epsilon floor:

Run with `LATTICE_METAL_TEST_ENFORCE=1` so a missing Metal device fails the
gate instead of silently skipping it (both oracle tests use this repo's
existing fail-closed device-probe convention, `metal_test_device` /
its `metal_qwen35.rs` equivalent — a runner that lost its GPU would report
these as `ok` without comparing anything otherwise):

```
running 5 tests
test forward::metal::inner::tests::flash_attention_rms_norm_uses_shared_reduction_helper ... ok
test forward::metal::inner::tests::msl_template_assembles_and_compiles ... ok
test forward::metal::inner::tests::rms_norm_matches_pre_854_oracle_on_finite_input ... [RMS_854_FIXTURE] rms_norm (flash): row0(near_zero) sum_sq=1.300e-38 row1(subnormal) sum_sq=2.553e-88
ok
test forward::metal_qwen35::inner::tests::qwen35_rms_norm_kernels_use_shared_reduction_helper ... ok
test forward::metal_qwen35::inner::tests::rms_reduce_854_parity::qwen35_rms_kernels_match_pre_854_oracle_on_finite_input ... [RMS_854_FIXTURE] rms_norm_qwen35: row0(near_zero) sum_sq=1.300e-38 row1(subnormal) sum_sq=2.553e-88
[RMS_854_FIXTURE] per_head_rms_norm: row0(near_zero) sum_sq=6.400e-39 row1(subnormal) sum_sq=1.257e-88
[RMS_854_FIXTURE] fused_residual_add_norm: normal fixture executed
[RMS_854_FIXTURE] fused_residual_add_norm: near_zero_residual fixture executed
[RMS_854_FIXTURE] fused_residual_add_norm: subnormal_residual fixture executed
[RMS_854_FIXTURE] copy_and_rms_norm: normal fixture executed
[RMS_854_FIXTURE] copy_and_rms_norm: near_zero_residual fixture executed
[RMS_854_FIXTURE] copy_and_rms_norm: subnormal_residual fixture executed
[RMS_854_FIXTURE] copy_and_rms_norm_batch: row0(near_zero) sum_sq=1.300e-38 row1(subnormal) sum_sq=2.553e-88
[RMS_854_FIXTURE] fused_residual_add_norm_batch/base: row0(near_zero) sum_sq=1.300e-38 row1(subnormal) sum_sq=2.553e-88
[RMS_854_FIXTURE] fused_residual_add_norm_batch/delta: row0(near_zero) sum_sq=1.300e-38 row1(subnormal) sum_sq=2.553e-88
[RMS_854_FIXTURE] per_head_rms_norm_batch: row0(near_zero) sum_sq=6.400e-39 row1(subnormal) sum_sq=1.257e-88
ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1997 filtered out; finished in 0.16s
```

(`rms_norm_matches_pre_854_oracle_on_finite_input` covers `rms_norm`;
`qwen35_rms_kernels_match_pre_854_oracle_on_finite_input` covers the other
seven, individually, inside the same test — all eight sites' bit-identical
comparisons passed, at ordinary magnitude, all-near-zero, and f32-subnormal
input. The `[RMS_854_FIXTURE]` lines are a construction proof that those
dedicated edge-case rows actually landed in the dispatched buffer and were
compared, not just implied by a passing `ok`.)

Both GPU tests run under `gpu_test_lock()` (the in-tree machine-wide Metal
serialization convention).

## Gates

- `cargo fmt` — clean.
- `cargo clippy --workspace -- -D warnings` — clean.
- `cargo clippy --workspace --features f16,metal-gpu -- -D warnings` (incl.
  `--tests`, to lint the new GPU test module) — clean.
- The 5 tests above — all pass.

## Bench-compare

`crates/inference/` is touched, so `make bench-compare` is mandatory. Default
Criterion groups (`elementwise_cpu_bench`, `simd`) are CPU-only and cannot see
a Metal-shader-only change — `metal_decode_q4`/`metal_decode_q8`
(`benches/metal_decode_bench.rs`) are the only groups whose call graph
actually reaches the eight changed kernels (per-token decode dispatches
`rms_norm_qwen35`, `per_head_rms_norm`, `copy_and_rms_norm`, etc. every step),
so bench-compare was run with `BENCHES_INFERENCE=metal_decode_bench
CARGO_FEATURES_INFERENCE=metal-gpu,f16`, quick mode, `origin/main` (`b118d3871b`)
vs this branch's head (`dad1bdc144`):

| Bench | Δ point | 95% CI | verdict |
|---|---:|---|---|
| `metal_decode_q4/forward_step/no_adapter` | -7.21% | [-8.25%, -6.15%] | within noise, no regression |
| `metal_decode_q4/forward_step/lora_rank8` | -3.56% | [-5.33%, -1.73%] | within noise, no regression |
| `metal_decode_q8/forward_step/no_adapter` | -1.75% | [-5.05%, +1.71%] | neutral (CI crosses 0) |

No regression on any group this PR's diff can reach. The `metal_decode_q4`
point estimates are favorable but not significant: the underlying t-test
p-values on those same Criterion runs were 0.07-0.59, i.e. not significant at
the conventional p<0.05 threshold, so both rows read as within noise even
though this repo's own CI-lower-bound-based gate rule (CI excludes 0) would
otherwise mark them as passing/confirmed — that gate rule is a useful cheap
screen but is not itself a significance test, and this mechanical, bit-exact
extraction should not be read as an intentional performance change either
way. `rms_inv_from_local_sum` is `inline`, so Metal's compiler is expected to
fold it into each call site; a plausible mechanism for the point estimates,
if they held up under a repeated/tighter-CI run, is instruction-cache
pressure from removing eight duplicate reduction-tree copies — but that is
speculation, not a claimed result of this PR. The bench run also swept
`cargo bench -p lattice-embed`'s default
group (unfiltered `BENCH_GROUPS_EMBED`) as `make bench-compare` always runs
both crates; several `lattice-embed` SIMD micro-benches show FAIL/WARN deltas
in that same run, but `lattice-embed` is untouched by this diff (this PR only
touches `crates/inference/src/forward/`) — those are pre-existing machine-load
noise, unrelated to #854, and out of scope for this PR.

## Sequencing

Both of this issue's stated dependencies (GDN fail-open fix, `flash_attention.metal`
dead-kernel purge) are already merged on `main`.
