### PR TITLE
fix(inference): reject empty prompts with typed Err in shared preflight on all paths (#856)

### DIFF
--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -862,11 +862,10 @@ pub fn generate_f16(
     let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
     let prompt_len = prompt_ids.len();
 
-    if prompt_len == 0 {
-        return Err(crate::error::InferenceError::Inference(
-            "empty prompt".into(),
-        ));
-    }
+    // #856: single shared preflight, unified with the Metal paths (which
+    // used to accept an empty prompt and return an empty Ok) — see
+    // `check_prompt_not_empty` (model::qwen35::generation).
+    crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
 
     // max_new_tokens == 0 means "generate nothing": return before sampling so
     // we never emit a token the caller did not ask for. Mirrors the guard in
@@ -1835,6 +1834,54 @@ mod tests {
         assert!(
             out.stopped,
             "generate_f16 must set stopped=true when the decode-loop stop fires"
+        );
+    }
+
+    /// `generate_f16` must reject an empty prompt with a typed
+    /// `Err(Inference("empty prompt"))` before any weight dereference or
+    /// state allocation (#856): this is one of the three CPU forward paths
+    /// the shared `check_prompt_not_empty` preflight unifies with the four
+    /// Metal paths, which used to silently accept an empty prompt and
+    /// return an empty `Ok`. See docs/generation-entrypoint-matrix.md row 2.
+    ///
+    /// The guard fires before any weight dereference, so empty weight vecs
+    /// are sufficient (mirrors `generate_f16_rejects_grammar_config_before_sampling`
+    /// below).
+    ///
+    /// Mutation sensitivity: reverting the `check_prompt_not_empty` call at
+    /// this call site makes the function proceed past the guard with a
+    /// zero-length prompt, either panicking in the prefill/decode loop
+    /// (`all_ids.last()` on an empty vec) or producing a non-`Inference`
+    /// error — this assert fails either way.
+    #[test]
+    fn generate_f16_rejects_empty_prompt() {
+        use crate::error::InferenceError;
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let weights = F16ModelWeights {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            layers: vec![],
+        };
+        let gen_cfg = GenerateConfig::default();
+
+        let result = generate_f16(&weights, &cfg, &tokenizer, &rope, "", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
+            "generate_f16 must reject an empty prompt with Err(Inference(\"empty \
+             prompt\")) (#856); got {result:?}"
         );
     }
 

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -715,11 +715,10 @@ pub fn generate_q8(
     let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
     let prompt_len = prompt_ids.len();
 
-    if prompt_len == 0 {
-        return Err(crate::error::InferenceError::Inference(
-            "empty prompt".into(),
-        ));
-    }
+    // #856: single shared preflight, unified with the Metal paths (which
+    // used to accept an empty prompt and return an empty Ok) — see
+    // `check_prompt_not_empty` (model::qwen35::generation).
+    crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
 
     // max_new_tokens == 0 is a valid request: "score this prompt, return no tokens".
     // Guard here so the decode loop (`for _ in 1..0`) never accidentally samples one
@@ -1546,6 +1545,49 @@ mod tests {
         assert!(
             msg.contains("context window"),
             "error must name the context window; got: {msg}"
+        );
+    }
+
+    /// `generate_q8` must reject an empty prompt with a typed
+    /// `Err(Inference("empty prompt"))` before any weight dereference or
+    /// state allocation (#856): this is one of the three CPU forward paths
+    /// the shared `check_prompt_not_empty` preflight unifies with the four
+    /// Metal paths, which used to silently accept an empty prompt and
+    /// return an empty `Ok`. See docs/generation-entrypoint-matrix.md row 2.
+    ///
+    /// Mutation sensitivity: reverting the `check_prompt_not_empty` call at
+    /// this call site makes the function proceed past the guard with a
+    /// zero-length prompt, either panicking in the prefill/decode loop or
+    /// producing a non-`Inference` error — this assert fails either way.
+    #[test]
+    fn generate_q8_rejects_empty_prompt() {
+        use crate::error::InferenceError;
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let weights = Q8ModelWeights {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            layers: vec![],
+        };
+        let gen_cfg = GenerateConfig::default();
+
+        let result = generate_q8(&weights, &cfg, &tokenizer, &rope, "", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
+            "generate_q8 must reject an empty prompt with Err(Inference(\"empty \
+             prompt\")) (#856); got {result:?}"
         );
     }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -30414,7 +30414,22 @@ mod inner {
         /// `..._rejects_logprobs_request_preserves_warm_entry` immediately
         /// below: warm the slot first, submit the empty-prompt request,
         /// assert both the exact error and that the pre-existing entry is
-        /// byte-identical afterward.
+        /// unchanged afterward.
+        ///
+        /// PR #915 review, second pass: the first version of this
+        /// test only compared `generic.token_ids` while claiming
+        /// "byte-identical" survival; `MetalCrossTurnPrefixEntry` also
+        /// carries `gdn_snapshot` and sparse `checkpoints`. This version
+        /// compares every field: `generic` (`kv_cache::CrossTurnPrefixEntry`,
+        /// which derives `PartialEq`/`Eq` over `slot_id`, `metadata`,
+        /// `token_ids`, `represented_len`, the `kv` handle -- itself a
+        /// small `Copy` value type of offsets/lengths, not a raw device
+        /// pointer -- and `gdn_snapshot_len`) via a direct `==`, plus
+        /// `gdn_snapshot` (`Vec<(Vec<f32>, Vec<f32>)>`) and each
+        /// `checkpoints` entry's `(len, snapshot)` via element-wise `==`
+        /// (neither type derives `PartialEq` itself, but their constituent
+        /// `Vec<f32>`/tuple/`usize` fields all do). There is no field on
+        /// `MetalCrossTurnPrefixEntry` this leaves uncompared.
         ///
         /// Mutation sensitivity: reverting the `check_prompt_not_empty`
         /// call in the wrapper makes this fail two ways -- the call
@@ -30455,10 +30470,14 @@ mod inner {
                 .cross_turn_prefix_cache
                 .entry
                 .as_ref()
-                .expect("precondition: the warm-up call must retain a cache entry")
-                .generic
-                .token_ids
-                .clone();
+                .expect("precondition: the warm-up call must retain a cache entry");
+            let warm_generic = warm_entry.generic.clone();
+            let warm_gdn_snapshot = warm_entry.gdn_snapshot.clone();
+            let warm_checkpoints: Vec<(usize, crate::attention::gdn::GdnSnapshot)> = warm_entry
+                .checkpoints
+                .iter()
+                .map(|c| (c.len, c.snapshot.clone()))
+                .collect();
 
             let rejected_cfg = cross_turn_test_gen_cfg(9, 2);
             let result = state.generate_streaming_with_prefix_cache(
@@ -30474,18 +30493,32 @@ mod inner {
                  prompt with Err(Inference(\"empty prompt\")) (#856); got {result:?}"
             );
 
-            let entry_after = state
-                .cross_turn_prefix_cache
-                .entry
-                .as_ref()
-                .map(|e| e.generic.token_ids.clone());
-            assert_eq!(
-                entry_after,
-                Some(warm_entry),
+            let entry_after = state.cross_turn_prefix_cache.entry.as_ref().expect(
                 "an empty-prompt rejection must not evict a pre-existing \
-                 cache entry it never touched -- the guard runs before \
-                 _inner's destructive Err-recovery block, same invariant \
-                 as the logprobs/MTP preflight tests"
+                     cache entry it never touched -- the guard runs before \
+                     _inner's destructive Err-recovery block, same invariant \
+                     as the logprobs/MTP preflight tests",
+            );
+            assert_eq!(
+                entry_after.generic, warm_generic,
+                "the retained entry's generic (slot_id/metadata/token_ids/\
+                 represented_len/kv handle/gdn_snapshot_len) must be \
+                 unchanged by a rejected empty-prompt request"
+            );
+            assert_eq!(
+                entry_after.gdn_snapshot, warm_gdn_snapshot,
+                "the retained entry's GDN recurrent-state snapshot must be \
+                 unchanged by a rejected empty-prompt request"
+            );
+            let after_checkpoints: Vec<(usize, crate::attention::gdn::GdnSnapshot)> = entry_after
+                .checkpoints
+                .iter()
+                .map(|c| (c.len, c.snapshot.clone()))
+                .collect();
+            assert_eq!(
+                after_checkpoints, warm_checkpoints,
+                "the retained entry's sparse GDN checkpoints must be \
+                 unchanged by a rejected empty-prompt request"
             );
         }
 
@@ -32913,30 +32946,53 @@ impl MetalQwen35State {
         Vec::new()
     }
 
-    /// **Unstable**: Metal generate stub; always errors without metal-gpu feature.
+    /// **Unstable**: Metal generate stub; always panics without metal-gpu feature.
     ///
-    /// #856 follow-up (PR #915 review feedback): this used to return an
-    /// unconditional `Ok(GenerateOutput { .. })` with empty text/tokens for
-    /// *every* prompt, including non-empty ones. Because `MetalQwen35State`
-    /// is a public unit struct on this cfg (directly constructible without
-    /// going through the fallible `new`/`from_q4_dir`), that made this the
-    /// one reachable fail-open hole in the #856 unified empty-prompt
-    /// contract: an external caller building without the `metal-gpu`
-    /// feature could construct the stub directly and get a *successful*
-    /// empty completion back from an empty (or any) prompt. This now
-    /// matches the real (metal-gpu-enabled) `generate`'s fallible
-    /// signature and always returns a capability error instead, for every
-    /// input, so the empty-prompt case and every other case both fail
-    /// closed here too.
+    /// #856 follow-up (PR #915 review, first pass): this used to
+    /// return an unconditional `Ok(GenerateOutput { .. })` with empty
+    /// text/tokens for *every* prompt, including non-empty ones. Because
+    /// `MetalQwen35State` is a public unit struct on this cfg (directly
+    /// constructible without going through the fallible
+    /// `new`/`from_q4_dir`), that made this the one reachable fail-open
+    /// hole in the #856 unified empty-prompt contract: an external caller
+    /// building without the `metal-gpu` feature could construct the stub
+    /// directly and get a *successful* empty completion back from an
+    /// empty (or any) prompt.
+    ///
+    /// PR #915 review, second pass: the first fix changed this
+    /// method's return type to `Result<GenerateOutput, InferenceError>`,
+    /// which is itself a semver-breaking signature change -- this stub is
+    /// what every **default** build gets (`metal-gpu` is not a default
+    /// feature), so any existing downstream default-build caller
+    /// consuming a bare `GenerateOutput` would stop compiling, and
+    /// `cargo-semver-checks`' inherent-method lint would not catch a
+    /// non-unit-to-non-unit return type change. `lattice-inference` v0.6.1
+    /// just shipped, so the signature is restored to the published
+    /// `-> GenerateOutput`.
+    ///
+    /// Instead this fails **loud**: it panics with a message identifying
+    /// the missing capability, rather than silently returning a
+    /// successful-looking empty completion. That is strictly better than
+    /// the pre-#856/#915 fail-open state (a panic is impossible to miss;
+    /// an empty `Ok` looked like a real, if vacuous, generation) and
+    /// matches the v0.6.0 release notes' fail-loudly convention for
+    /// unimplemented GPU arms elsewhere in this crate. It is not the
+    /// intended long-term shape -- a panic in a library function is still
+    /// a rougher contract than a typed `Err` -- so the eventual fallible
+    /// signature is tracked for a semver-major-eligible release at
+    /// <https://github.com/ohdearquant/lattice/issues/917> (targets
+    /// 0.7.0, sibling to #916's `generate_with_speculation` tracking).
     pub fn generate(
         &mut self,
         _prompt: &str,
         _tokenizer: &crate::tokenizer::bpe::BpeTokenizer,
         _cfg: &crate::model::qwen35_config::GenerateConfig,
-    ) -> Result<crate::model::qwen35_config::GenerateOutput, crate::error::InferenceError> {
-        Err(crate::error::InferenceError::Inference(
-            "Metal GPU not available (requires macOS + metal-gpu feature)".into(),
-        ))
+    ) -> crate::model::qwen35_config::GenerateOutput {
+        panic!(
+            "MetalQwen35State::generate called on a build compiled without \
+             the metal-gpu feature; construct via new() which returns an \
+             error on such builds"
+        );
     }
 
     /// **Unstable**: load LoRA adapter stub; always errors without metal-gpu feature.
@@ -32988,13 +33044,19 @@ impl MetalQwen35State {
 /// build where `MetalQwen35State` is directly constructible as a public
 /// unit struct without going through the fallible `new`/`from_q4_dir`.
 ///
+/// PR #915 review, second pass: the stub's `generate` keeps its
+/// published `-> GenerateOutput` signature (changing it to `Result` would
+/// itself be a semver break for every default build, since `metal-gpu` is
+/// not a default feature) and instead panics with a message identifying
+/// the missing capability. These tests assert the panic, not a `Result`.
+///
 /// Mutation sensitivity: reverting the stub's `generate` to its old
-/// unconditional `Ok(GenerateOutput { .. })` return makes both assertions
-/// below fail (`matches!` against `Err` no longer matches an `Ok`).
+/// unconditional `GenerateOutput { .. }` return (no panic) makes both
+/// tests below fail (`#[should_panic]` requires the call to panic; a
+/// normal return is a test failure).
 #[cfg(all(test, not(all(target_os = "macos", feature = "metal-gpu"))))]
 mod non_metal_stub_tests {
     use super::MetalQwen35State;
-    use crate::error::InferenceError;
     use crate::model::qwen35_config::GenerateConfig;
     use crate::tokenizer::bpe::BpeTokenizer;
     use std::collections::HashMap;
@@ -33012,35 +33074,28 @@ mod non_metal_stub_tests {
     }
 
     #[test]
+    #[should_panic(expected = "metal-gpu")]
     fn non_metal_stub_generate_rejects_empty_prompt() {
         let tokenizer = tiny_tokenizer();
         let gen_cfg = GenerateConfig::default();
         let mut state = MetalQwen35State;
 
-        let result = state.generate("", &tokenizer, &gen_cfg);
-        assert!(
-            matches!(result, Err(InferenceError::Inference(_))),
-            "the non-metal-gpu MetalQwen35State stub must reject an empty \
-             prompt with a typed Err, not the old Ok(empty GenerateOutput); \
-             got {result:?}"
-        );
+        // Must panic (fail loud) rather than return a successful-looking
+        // empty GenerateOutput for an empty prompt.
+        let _ = state.generate("", &tokenizer, &gen_cfg);
     }
 
-    /// The stub fails closed for every prompt, not only the empty one --
+    /// The stub fails loud for every prompt, not only the empty one --
     /// directly-constructing it (bypassing the fallible `new`/`from_q4_dir`)
     /// must never yield a successful (if vacuous) completion.
     #[test]
+    #[should_panic(expected = "metal-gpu")]
     fn non_metal_stub_generate_rejects_nonempty_prompt() {
         let tokenizer = tiny_tokenizer();
         let gen_cfg = GenerateConfig::default();
         let mut state = MetalQwen35State;
 
-        let result = state.generate("hello", &tokenizer, &gen_cfg);
-        assert!(
-            matches!(result, Err(InferenceError::Inference(_))),
-            "the non-metal-gpu MetalQwen35State stub must reject every \
-             prompt (capability error), not just an empty one; got {result:?}"
-        );
+        let _ = state.generate("hello", &tokenizer, &gen_cfg);
     }
 }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -8699,17 +8699,16 @@ mod inner {
             let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
             let prompt_len = prompt_ids.len();
 
-            if prompt_len == 0 {
-                return Ok(GenerateOutput {
-                    text: String::new(),
-                    token_ids: vec![],
-                    prompt_tokens: 0,
-                    generated_tokens: 0,
-                    stopped: false,
-                    stop_reason: None,
-                    token_logprobs: vec![],
-                });
-            }
+            // Empty prompt is rejected with a typed Err on every generation
+            // entry point as of #856. This used to return an empty
+            // Ok(GenerateOutput { stopped: false, stop_reason: None, .. })
+            // here, diverging from all three CPU forward paths, which
+            // reject via this exact same shared guard. See
+            // docs/generation-entrypoint-matrix.md row 2. Runs before
+            // `reset_state()` below, so a rejected request never mutates
+            // session/cache state (mirrors the reasoning_budget/logprobs
+            // guards immediately after).
+            crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
 
             // max_new_tokens == 0 means "generate nothing": return before prefill/sampling
             // so we never emit a token the caller did not ask for. Mirrors the CPU
@@ -13237,17 +13236,18 @@ mod inner {
             let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
             let prompt_len = prompt_ids.len();
 
-            if prompt_len == 0 {
-                return Ok(GenerateOutput {
-                    text: String::new(),
-                    token_ids: vec![],
-                    prompt_tokens: 0,
-                    generated_tokens: 0,
-                    stopped: false,
-                    stop_reason: None,
-                    token_logprobs: vec![],
-                });
-            }
+            // Empty prompt is rejected with a typed Err on every generation
+            // entry point as of #856 (this covers both `generate_streaming`
+            // and `generate_streaming_with_cancel`, since the former is a
+            // thin `should_cancel = || false` wrapper over this function).
+            // This used to return an empty
+            // Ok(GenerateOutput { stopped: false, stop_reason: None, .. }),
+            // diverging from the CPU streaming guard and the `generate()`
+            // guard above, which both reject via this exact same shared
+            // guard. See docs/generation-entrypoint-matrix.md row 2. Runs
+            // before `reset_state()` below, so a rejected request never
+            // mutates session/cache state.
+            crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
 
             // max_new_tokens == 0 means "generate nothing": return before prefill/sampling
             // so we never emit a token the caller did not ask for, and on_token is never
@@ -15973,6 +15973,17 @@ mod inner {
             let input = tokenizer.tokenize(prompt);
             let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
 
+            // #856: empty prompt is rejected here too, same reasoning as the
+            // two preflights above (PR #787) -- `_inner` no longer special-
+            // cases an empty prompt as an early `Ok` (it now unifies on this
+            // exact typed `Err` like every other entry point, see
+            // `check_prompt_not_empty` and docs/generation-entrypoint-matrix.md
+            // row 2), so this must reject before `_inner` is even called, or
+            // the rejection would flow through the destructive `Err`-recovery
+            // match below and evict a valid pre-existing cross-turn entry
+            // this call never touched.
+            crate::model::qwen35::check_prompt_not_empty(prompt_ids.len())?;
+
             // #835: validate the suffix a reuse plan would select for this
             // slot BEFORE calling `_inner` at all -- same reasoning as the
             // `check_logprobs_not_set`/`check_mtp_not_requested` preflights
@@ -15985,14 +15996,14 @@ mod inner {
             // reachable), or a valid pre-existing cross-turn entry this call
             // never touched would be destroyed alongside it.
             //
-            // Skipped for the same three trivial-request shapes `_inner`
-            // itself special-cases with an early `Ok` (empty prompt, zero
-            // `max_new_tokens`, prompt longer than the cache): none of those
-            // reach `_inner`'s mutating match either, so validating a plan
-            // for them here would reject requests `_inner` legitimately
-            // accepts (e.g. an empty prompt always plans an empty "suffix",
-            // which is exactly the shape `plan_prefix_request` rejects for a
-            // real request).
+            // The `!prompt_ids.is_empty()` clause below is now always true
+            // (empty prompt already returned above) and is kept only because
+            // this condition still gates on the other two trivial-request
+            // shapes `_inner` special-cases with an early `Ok` (zero
+            // `max_new_tokens`, prompt longer than the cache): neither of
+            // those reaches `_inner`'s mutating match either, so validating a
+            // plan for them here would reject requests `_inner` legitimately
+            // accepts.
             if !prompt_ids.is_empty()
                 && gen_cfg.max_new_tokens > 0
                 && prompt_ids.len() <= self.max_context()
@@ -16038,16 +16049,23 @@ mod inner {
             use crate::error::InferenceError;
             use crate::kv_cache::PrefixReuseMode;
 
-            // The `logprobs` / `enable_mtp` config preflight checks (PR #787),
-            // and the suffix-content preflight below (#835), live in the public
-            // wrapper `generate_streaming_with_prefix_cache_and_cancel`, not
-            // here: that wrapper's error-recovery path unconditionally
-            // evicts the cache slot on any `Err` from this function, so a
+            // The `logprobs` / `enable_mtp` / empty-prompt config preflight
+            // checks (PR #787, #856), and the suffix-content preflight below
+            // (#835), live in the public wrapper
+            // `generate_streaming_with_prefix_cache_and_cancel`, not here:
+            // that wrapper's error-recovery path unconditionally evicts the
+            // cache slot on any `Err` from this function, so a
             // preflight-only rejection must never reach `_inner` in the first
             // place, or a valid pre-existing cross-turn entry this call never
             // touched would be destroyed alongside it. `prompt_ids` arrives
             // already tokenized by the wrapper (which needs them to run that
-            // preflight) so this function never re-tokenizes `prompt`.
+            // preflight) so this function never re-tokenizes `prompt`, and
+            // is therefore guaranteed non-empty by the time it reaches this
+            // function -- unlike `logprobs`/`enable_mtp`/suffix-content,
+            // empty-prompt has no cheap "run it again here as defense in
+            // depth" form: any duplicate check inside `_inner` would have to
+            // return `Err`, and an `Err` from `_inner` is exactly what the
+            // wrapper's blanket eviction match treats as cache-invalidating.
             // `plan_cross_turn_reuse`/`plan_prefix_request` are still run
             // again below, cheaply, as defense in depth (this function's own
             // safety invariant should not depend solely on its one caller
@@ -16074,30 +16092,19 @@ mod inner {
             };
 
             let prompt_len = prompt_ids.len();
+            debug_assert!(
+                prompt_len > 0,
+                "the wrapper's check_prompt_not_empty (#856) must reject an \
+                 empty prompt before calling _inner"
+            );
 
-            // These three guards are byte-for-byte the same as
+            // These two guards are byte-for-byte the same as
             // `generate_streaming` and run before any state mutation, so an
-            // existing cache entry (if any) is left exactly as-is.
-            if prompt_len == 0 {
-                return Ok(CachedGenerateOutput {
-                    output: GenerateOutput {
-                        text: String::new(),
-                        token_ids: vec![],
-                        prompt_tokens: 0,
-                        generated_tokens: 0,
-                        stopped: false,
-                        stop_reason: None,
-                        token_logprobs: vec![],
-                    },
-                    cache: CrossTurnCacheStats {
-                        slot_id,
-                        prompt_tokens: 0,
-                        reused_tokens: 0,
-                        prefetched_tokens: 0,
-                        mode: PrefixReuseMode::FullRefill,
-                    },
-                });
-            }
+            // existing cache entry (if any) is left exactly as-is. (A third,
+            // empty-prompt, guard used to live here too -- see the
+            // `check_prompt_not_empty` note above this function for why
+            // #856 moved it to the wrapper instead of leaving a duplicate
+            // here.)
             if gen_cfg.max_new_tokens == 0 {
                 return Ok(CachedGenerateOutput {
                     output: GenerateOutput {
@@ -25528,6 +25535,58 @@ mod inner {
         }
 
         /// `MetalQwen35State::generate` (the plain/direct entry point) must
+        /// reject an empty prompt with a typed `Err(Inference("empty
+        /// prompt"))` (#856), unifying it with all three CPU forward paths
+        /// instead of the empty `Ok(GenerateOutput { stopped: false,
+        /// stop_reason: None, .. })` it used to return. See
+        /// docs/generation-entrypoint-matrix.md row 2.
+        ///
+        /// This is the production-seam test for the guard added to `generate`
+        /// itself; `check_prompt_not_empty_rejects_zero` /
+        /// `_allows_nonzero` (model::qwen35::generation) already cover the
+        /// pure guard logic without a GPU device.
+        ///
+        /// Mutation sensitivity: reverting the `check_prompt_not_empty` call
+        /// in `generate` lets this request proceed through prefill and
+        /// sampling instead of erroring, so `result.is_err()` fails (and the
+        /// old `Ok` shape would additionally have `stop_reason: None`, the
+        /// invariant-violating result #856 fixes).
+        #[test]
+        fn metal_generate_plain_rejects_empty_prompt() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 4,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(42),
+                stop_token_ids: vec![],
+                enable_thinking: true,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: None,
+            };
+
+            let result = state.generate("", &tokenizer, &gen_cfg);
+            assert!(
+                matches!(result, Err(crate::error::InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
+                "MetalQwen35State::generate must reject an empty prompt with \
+                 Err(Inference(\"empty prompt\")) (#856); got {result:?}"
+            );
+        }
+
+        /// `MetalQwen35State::generate` (the plain/direct entry point) must
         /// reject a `GenerateConfig` with `reasoning_budget` set, with a typed
         /// `InvalidInput` error, rather than silently ignoring the budget and
         /// generating unbudgeted output (ADR-080 C3, #783).
@@ -25619,6 +25678,65 @@ mod inner {
                 matches!(result, Err(crate::error::InferenceError::InvalidInput(_))),
                 "MetalQwen35State::generate must fail closed with InvalidInput when \
                  logprobs is set (PR #787); got {result:?}"
+            );
+        }
+
+        /// `generate_streaming` must reject an empty prompt with a typed
+        /// `Err(Inference("empty prompt"))` (#856), unifying it with all
+        /// three CPU forward paths instead of the empty `Ok` (`on_token`
+        /// never invoked, `stopped: false`, `stop_reason: None`) it used to
+        /// return. `generate_streaming` is a thin `should_cancel = || false`
+        /// wrapper over `generate_streaming_with_cancel` (the actual guard
+        /// call site fixed by #856), so this one test covers both. See
+        /// docs/generation-entrypoint-matrix.md row 2.
+        ///
+        /// Mutation sensitivity: reverting the `check_prompt_not_empty` call
+        /// in `generate_streaming_with_cancel` lets this request proceed
+        /// through prefill and sampling instead of erroring, so
+        /// `result.is_err()` fails.
+        #[test]
+        fn metal_generate_streaming_rejects_empty_prompt() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 4,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(1),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: None,
+            };
+
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+
+            let mut calls = 0u32;
+            let result = state.generate_streaming("", &tokenizer, &gen_cfg, |_delta, _id| {
+                calls += 1;
+                true
+            });
+
+            assert!(
+                matches!(result, Err(crate::error::InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
+                "generate_streaming must reject an empty prompt with \
+                 Err(Inference(\"empty prompt\")) (#856); got {result:?}"
+            );
+            assert_eq!(
+                calls, 0,
+                "an empty-prompt rejection must never invoke on_token, got {calls} call(s)"
             );
         }
 
@@ -30255,6 +30373,77 @@ mod inner {
             assert!(
                 state.cross_turn_prefix_cache.entry.is_none(),
                 "a grammar-fail-closed turn must not leave a stale cache entry behind"
+            );
+        }
+
+        /// `generate_streaming_with_prefix_cache` must reject an empty
+        /// prompt with a typed `Err(Inference("empty prompt"))` (#856),
+        /// unifying it with all three CPU forward paths instead of the
+        /// empty `Ok(CachedGenerateOutput { output: GenerateOutput {
+        /// stopped: false, stop_reason: None, .. }, .. })` `_inner` used to
+        /// return. The guard now lives in the public wrapper
+        /// (`generate_streaming_with_prefix_cache_and_cancel`), before
+        /// `_inner` is ever called, so a rejected call must not create (or
+        /// evict) a cache entry -- same invariant the logprobs/MTP preflight
+        /// tests above and below assert. See
+        /// docs/generation-entrypoint-matrix.md row 2.
+        ///
+        /// Mutation sensitivity: reverting the `check_prompt_not_empty` call
+        /// in the wrapper makes this assertion fail (the call proceeds to
+        /// `_inner` and returns `Ok` instead of `Err`).
+        #[test]
+        fn generate_streaming_with_prefix_cache_rejects_empty_prompt() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            use crate::error::InferenceError;
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 2,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(1),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: None,
+            };
+
+            let result = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "",
+                &tokenizer,
+                &gen_cfg,
+                |_, _| true,
+            );
+
+            assert!(
+                matches!(result, Err(InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
+                "generate_streaming_with_prefix_cache must reject an empty \
+                 prompt with Err(Inference(\"empty prompt\")) (#856); got {result:?}"
+            );
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_none(),
+                "an empty-prompt rejection must not create a cache entry -- \
+                 the guard runs before any state mutation"
             );
         }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -25551,9 +25551,19 @@ mod inner {
         /// sampling instead of erroring, so `result.is_err()` fails (and the
         /// old `Ok` shape would additionally have `stop_reason: None`, the
         /// invariant-violating result #856 fixes).
+        ///
+        /// PR #915 review feedback (fix 4): honors
+        /// `LATTICE_METAL_TEST_ENFORCE` like the prefix-cache empty-prompt
+        /// test, so a required Metal CI leg fails loud on a missing device
+        /// instead of silently passing without ever exercising the guard.
         #[test]
         fn metal_generate_plain_rejects_empty_prompt() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
             let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
                 return;
             };
             let _gpu_guard = gpu_test_lock();
@@ -25694,9 +25704,19 @@ mod inner {
         /// in `generate_streaming_with_cancel` lets this request proceed
         /// through prefill and sampling instead of erroring, so
         /// `result.is_err()` fails.
+        ///
+        /// PR #915 review feedback (fix 4): honors
+        /// `LATTICE_METAL_TEST_ENFORCE` like the prefix-cache empty-prompt
+        /// test, so a required Metal CI leg fails loud on a missing device
+        /// instead of silently passing without ever exercising the guard.
         #[test]
         fn metal_generate_streaming_rejects_empty_prompt() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
             let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
                 return;
             };
             let _gpu_guard = gpu_test_lock();
@@ -30383,14 +30403,25 @@ mod inner {
         /// stopped: false, stop_reason: None, .. }, .. })` `_inner` used to
         /// return. The guard now lives in the public wrapper
         /// (`generate_streaming_with_prefix_cache_and_cancel`), before
-        /// `_inner` is ever called, so a rejected call must not create (or
-        /// evict) a cache entry -- same invariant the logprobs/MTP preflight
-        /// tests above and below assert. See
-        /// docs/generation-entrypoint-matrix.md row 2.
+        /// `_inner` is ever called.
         ///
-        /// Mutation sensitivity: reverting the `check_prompt_not_empty` call
-        /// in the wrapper makes this assertion fail (the call proceeds to
-        /// `_inner` and returns `Ok` instead of `Err`).
+        /// PR #915 review feedback (fix 3): a fresh-state / `entry ==
+        /// None` assertion alone does not exercise the property that
+        /// motivated putting the guard in the wrapper rather than
+        /// `_inner` -- a *warmed* slot survives the rejection, because the
+        /// guard returns before `_inner`'s unconditional Err-recovery
+        /// eviction ever runs. This mirrors
+        /// `..._rejects_logprobs_request_preserves_warm_entry` immediately
+        /// below: warm the slot first, submit the empty-prompt request,
+        /// assert both the exact error and that the pre-existing entry is
+        /// byte-identical afterward.
+        ///
+        /// Mutation sensitivity: reverting the `check_prompt_not_empty`
+        /// call in the wrapper makes this fail two ways -- the call
+        /// proceeds to `_inner` and returns `Ok` instead of `Err`, AND
+        /// (if the guard were instead duplicated as an `Err` inside
+        /// `_inner`, the alternative bug this guards against) the warmed
+        /// entry would be evicted by `_inner`'s destructive recovery arm.
         #[test]
         fn generate_streaming_with_prefix_cache_rejects_empty_prompt() {
             let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
@@ -30404,46 +30435,57 @@ mod inner {
             let _guard = gpu_test_lock();
 
             use crate::error::InferenceError;
-            use crate::model::qwen35_config::GenerateConfig;
 
             let tokenizer = single_char_vocab_tokenizer();
             let (cfg, weights) = tiny_hybrid_fixture();
             let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
             let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
 
-            let gen_cfg = GenerateConfig {
-                max_new_tokens: 2,
-                temperature: 0.0,
-                top_k: 1,
-                top_p: 1.0,
-                repetition_penalty: 1.0,
-                seed: Some(1),
-                stop_token_ids: vec![],
-                enable_thinking: false,
-                enable_mtp: Some(false),
-                grammar: None,
-                stop_strings: vec![],
-                reasoning_budget: None,
-                logprobs: None,
-            };
+            let warm_cfg = cross_turn_test_gen_cfg(9, 2);
+            state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &warm_cfg,
+                    |_, _| true,
+                )
+                .expect("warm-up call must succeed");
+            let warm_entry = state
+                .cross_turn_prefix_cache
+                .entry
+                .as_ref()
+                .expect("precondition: the warm-up call must retain a cache entry")
+                .generic
+                .token_ids
+                .clone();
 
+            let rejected_cfg = cross_turn_test_gen_cfg(9, 2);
             let result = state.generate_streaming_with_prefix_cache(
                 slot_id,
                 "",
                 &tokenizer,
-                &gen_cfg,
+                &rejected_cfg,
                 |_, _| true,
             );
-
             assert!(
                 matches!(result, Err(InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
                 "generate_streaming_with_prefix_cache must reject an empty \
                  prompt with Err(Inference(\"empty prompt\")) (#856); got {result:?}"
             );
-            assert!(
-                state.cross_turn_prefix_cache.entry.is_none(),
-                "an empty-prompt rejection must not create a cache entry -- \
-                 the guard runs before any state mutation"
+
+            let entry_after = state
+                .cross_turn_prefix_cache
+                .entry
+                .as_ref()
+                .map(|e| e.generic.token_ids.clone());
+            assert_eq!(
+                entry_after,
+                Some(warm_entry),
+                "an empty-prompt rejection must not evict a pre-existing \
+                 cache entry it never touched -- the guard runs before \
+                 _inner's destructive Err-recovery block, same invariant \
+                 as the logprobs/MTP preflight tests"
             );
         }
 
@@ -32871,22 +32913,30 @@ impl MetalQwen35State {
         Vec::new()
     }
 
-    /// **Unstable**: Metal generate stub; always returns empty output without metal-gpu feature.
+    /// **Unstable**: Metal generate stub; always errors without metal-gpu feature.
+    ///
+    /// #856 follow-up (PR #915 review feedback): this used to return an
+    /// unconditional `Ok(GenerateOutput { .. })` with empty text/tokens for
+    /// *every* prompt, including non-empty ones. Because `MetalQwen35State`
+    /// is a public unit struct on this cfg (directly constructible without
+    /// going through the fallible `new`/`from_q4_dir`), that made this the
+    /// one reachable fail-open hole in the #856 unified empty-prompt
+    /// contract: an external caller building without the `metal-gpu`
+    /// feature could construct the stub directly and get a *successful*
+    /// empty completion back from an empty (or any) prompt. This now
+    /// matches the real (metal-gpu-enabled) `generate`'s fallible
+    /// signature and always returns a capability error instead, for every
+    /// input, so the empty-prompt case and every other case both fail
+    /// closed here too.
     pub fn generate(
         &mut self,
         _prompt: &str,
         _tokenizer: &crate::tokenizer::bpe::BpeTokenizer,
         _cfg: &crate::model::qwen35_config::GenerateConfig,
-    ) -> crate::model::qwen35_config::GenerateOutput {
-        crate::model::qwen35_config::GenerateOutput {
-            text: String::new(),
-            token_ids: vec![],
-            prompt_tokens: 0,
-            generated_tokens: 0,
-            stopped: false,
-            stop_reason: None,
-            token_logprobs: vec![],
-        }
+    ) -> Result<crate::model::qwen35_config::GenerateOutput, crate::error::InferenceError> {
+        Err(crate::error::InferenceError::Inference(
+            "Metal GPU not available (requires macOS + metal-gpu feature)".into(),
+        ))
     }
 
     /// **Unstable**: load LoRA adapter stub; always errors without metal-gpu feature.
@@ -32928,6 +32978,69 @@ impl MetalQwen35State {
         Err(crate::error::InferenceError::Inference(
             "Metal GPU not available (requires macOS + metal-gpu feature)".into(),
         ))
+    }
+}
+
+/// Regression coverage for the non-metal-gpu `MetalQwen35State` stub (#856
+/// follow-up, PR #915 review feedback). This runs in the DEFAULT build (no
+/// `metal-gpu` feature, hence no `#[cfg(metal-gpu)]` on the test itself) --
+/// exactly the build a downstream crate gets by default, and exactly the
+/// build where `MetalQwen35State` is directly constructible as a public
+/// unit struct without going through the fallible `new`/`from_q4_dir`.
+///
+/// Mutation sensitivity: reverting the stub's `generate` to its old
+/// unconditional `Ok(GenerateOutput { .. })` return makes both assertions
+/// below fail (`matches!` against `Err` no longer matches an `Ok`).
+#[cfg(all(test, not(all(target_os = "macos", feature = "metal-gpu"))))]
+mod non_metal_stub_tests {
+    use super::MetalQwen35State;
+    use crate::error::InferenceError;
+    use crate::model::qwen35_config::GenerateConfig;
+    use crate::tokenizer::bpe::BpeTokenizer;
+    use std::collections::HashMap;
+
+    fn tiny_tokenizer() -> BpeTokenizer {
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap()
+    }
+
+    #[test]
+    fn non_metal_stub_generate_rejects_empty_prompt() {
+        let tokenizer = tiny_tokenizer();
+        let gen_cfg = GenerateConfig::default();
+        let mut state = MetalQwen35State;
+
+        let result = state.generate("", &tokenizer, &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::Inference(_))),
+            "the non-metal-gpu MetalQwen35State stub must reject an empty \
+             prompt with a typed Err, not the old Ok(empty GenerateOutput); \
+             got {result:?}"
+        );
+    }
+
+    /// The stub fails closed for every prompt, not only the empty one --
+    /// directly-constructing it (bypassing the fallible `new`/`from_q4_dir`)
+    /// must never yield a successful (if vacuous) completion.
+    #[test]
+    fn non_metal_stub_generate_rejects_nonempty_prompt() {
+        let tokenizer = tiny_tokenizer();
+        let gen_cfg = GenerateConfig::default();
+        let mut state = MetalQwen35State;
+
+        let result = state.generate("hello", &tokenizer, &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::Inference(_))),
+            "the non-metal-gpu MetalQwen35State stub must reject every \
+             prompt (capability error), not just an empty one; got {result:?}"
+        );
     }
 }
 

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -900,11 +900,10 @@ pub fn generate_q8_neon(
     let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
     let prompt_len = prompt_ids.len();
 
-    if prompt_len == 0 {
-        return Err(crate::error::InferenceError::Inference(
-            "empty prompt".into(),
-        ));
-    }
+    // #856: single shared preflight, unified with the Metal paths (which
+    // used to accept an empty prompt and return an empty Ok) — see
+    // `check_prompt_not_empty` (model::qwen35::generation).
+    crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
 
     // max_new_tokens == 0 means "generate nothing": return before sampling so
     // we never emit a token the caller did not ask for. Mirrors the guard in
@@ -2706,6 +2705,52 @@ mod tests {
         assert!(
             out.stopped,
             "generate_q8_neon must set stopped=true when the decode-loop stop fires"
+        );
+    }
+
+    /// `generate_q8_neon` must reject an empty prompt with a typed
+    /// `Err(Inference("empty prompt"))` before any weight dereference or
+    /// state allocation (#856): this is one of the three CPU forward paths
+    /// the shared `check_prompt_not_empty` preflight unifies with the four
+    /// Metal paths, which used to silently accept an empty prompt and
+    /// return an empty `Ok`. See docs/generation-entrypoint-matrix.md row 2.
+    ///
+    /// Mutation sensitivity: reverting the `check_prompt_not_empty` call at
+    /// this call site makes the function proceed past the guard with a
+    /// zero-length prompt, either panicking in the prefill/decode loop or
+    /// producing a non-`Inference` error — this assert fails either way.
+    #[test]
+    fn generate_q8_neon_rejects_empty_prompt() {
+        use crate::error::InferenceError;
+        use std::collections::HashMap;
+
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o"].iter().enumerate() {
+            vocab.insert((*c).to_string(), i as u32);
+        }
+        let merges = vec![
+            ("h".to_string(), "e".to_string()),
+            ("he".to_string(), "l".to_string()),
+        ];
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, merges).unwrap();
+
+        let cfg = Qwen35Config::qwen35_2b();
+        let rope = RopeTable::new(cfg.rope_dim(), 8, cfg.rope_theta);
+        let model = Q8NeonModel {
+            embed_tokens: vec![],
+            final_norm: vec![],
+            lm_head_packed: vec![],
+            lm_head_rows: 0,
+            lm_head_cols: 0,
+            layers: vec![],
+        };
+        let gen_cfg = GenerateConfig::default();
+
+        let result = generate_q8_neon(&model, &cfg, &tokenizer, &rope, "", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
+            "generate_q8_neon must reject an empty prompt with Err(Inference(\"empty \
+             prompt\")) (#856); got {result:?}"
         );
     }
 

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -62,9 +62,9 @@ impl Qwen35Model {
         let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
         let prompt_len = prompt_ids.len();
 
-        if prompt_len == 0 {
-            return Err(InferenceError::Inference("empty prompt".into()));
-        }
+        // #856: single shared preflight, see `check_prompt_not_empty` (same
+        // module) for the full CPU/Metal unification rationale.
+        check_prompt_not_empty(prompt_len)?;
 
         // max_new_tokens == 0 means "generate nothing": return before sampling so
         // we never emit a token the caller did not ask for. Mirrors the identical
@@ -468,9 +468,9 @@ impl Qwen35Model {
         let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
         let prompt_len = prompt_ids.len();
 
-        if prompt_len == 0 {
-            return Err(InferenceError::Inference("empty prompt".into()));
-        }
+        // #856: single shared preflight, see `check_prompt_not_empty` (same
+        // module) for the full CPU/Metal unification rationale.
+        check_prompt_not_empty(prompt_len)?;
 
         // max_new_tokens == 0 means "generate nothing": return before sampling so
         // we never emit a token the caller did not ask for.
@@ -2201,6 +2201,36 @@ pub(crate) fn check_mtp_not_requested(gen_cfg: &GenerateConfig) -> Result<(), In
     Ok(())
 }
 
+/// Preflight guard unifying the empty-prompt contract across every Qwen3.5
+/// generation entry point (#856).
+///
+/// Before this fix, `docs/generation-entrypoint-matrix.md` row 2 recorded a
+/// hard behavior split: the three CPU forward paths (`generate_f16`,
+/// `generate_q8`, `generate_q8_neon`) rejected an empty prompt with this
+/// same typed `Err`, inline and duplicated per file, while the four Metal
+/// paths (`MetalQwen35State::generate`, `generate_streaming` /
+/// `generate_streaming_with_cancel`, and
+/// `generate_streaming_with_prefix_cache_and_cancel`) silently accepted it
+/// and returned a normal-looking empty `Ok(GenerateOutput { stopped: false,
+/// stop_reason: None, .. })` — a result shape that is itself
+/// invariant-violating (a "completed" generation that neither stopped nor
+/// gives a reason). Maintainer sign-off on the matrix (PR #855) ruled this
+/// unify on the CPU behavior; this function is that shared preflight, and
+/// every one of the seven entry points now calls it instead of carrying its
+/// own inline `if prompt_len == 0` copy.
+///
+/// Unlike the `check_*_not_set` siblings above (which reject an unsupported
+/// *config field*), this guard rejects the *input*: `prompt_len` is the
+/// tokenized prompt length every call site already computes before any
+/// state allocation, so this call replaces each site's own inline check
+/// rather than adding a new one alongside it.
+pub(crate) fn check_prompt_not_empty(prompt_len: usize) -> Result<(), InferenceError> {
+    if prompt_len == 0 {
+        return Err(InferenceError::Inference("empty prompt".into()));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2596,6 +2626,40 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // check_prompt_not_empty (#856) — the shared empty-prompt preflight every
+    // one of the seven CPU/Metal generation entry points now calls instead of
+    // its own inline `if prompt_len == 0` copy. Pure-function unit tests
+    // here; per-entry-point production-seam tests live alongside each real
+    // call site (cpu_f16.rs, cpu_q8.rs, neon_forward.rs,
+    // forward/metal_qwen35.rs) and `qwen35_model_generate_rejects_empty_prompt`
+    // below, which exercises this exact function through `Qwen35Model::generate`.
+    // -----------------------------------------------------------------------
+
+    /// Mutation sensitivity: change `check_prompt_not_empty` to always return
+    /// `Ok(())` → this assertion fails, catching a regression that would let
+    /// an empty prompt silently pass through every entry point that calls it
+    /// (the CPU-vs-Metal split #856 fixes).
+    #[test]
+    fn check_prompt_not_empty_rejects_zero() {
+        let result = check_prompt_not_empty(0);
+        assert!(
+            matches!(result, Err(InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
+            "prompt_len == 0 must be rejected with Err(Inference(\"empty prompt\")); got {result:?}"
+        );
+    }
+
+    /// Mutation sensitivity: change the guard to always return `Err(..)` →
+    /// this assertion fails, catching a regression that would reject every
+    /// non-empty-prompt caller too.
+    #[test]
+    fn check_prompt_not_empty_allows_nonzero() {
+        assert!(
+            check_prompt_not_empty(1).is_ok(),
+            "prompt_len == 1 (a real prompt) must be allowed"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // StopReason mutation-sensitive tests (#456)
     // -----------------------------------------------------------------------
     //
@@ -2776,6 +2840,35 @@ mod tests {
         assert_eq!(
             result.generated_tokens, 0,
             "zero max_new_tokens must produce no tokens"
+        );
+    }
+
+    /// `Qwen35Model::generate` must reject an empty prompt with a typed
+    /// `Err` via the shared `check_prompt_not_empty` guard (#856) -- this is
+    /// a bonus dedup alongside the seven audited entry points: this
+    /// function already had this exact behavior before #856 (it is not one
+    /// of the CPU-vs-Metal divergent paths), but its inline check is now
+    /// routed through the same shared preflight rather than carrying its
+    /// own duplicate copy, so this test also proves that wiring.
+    ///
+    /// Mutation sensitivity: reverting this call site back to a no-op (or
+    /// removing it) lets an empty prompt reach `all_ids.last()` in the
+    /// decode loop with a zero-length prompt, which either panics or
+    /// silently generates from no context -- `result.is_err()` fails either
+    /// way.
+    #[test]
+    fn qwen35_model_generate_rejects_empty_prompt() {
+        let model = build_tiny_zero_model();
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 4,
+            temperature: 0.0,
+            ..Default::default()
+        };
+        let result = model.generate("", &gen_cfg);
+        assert!(
+            matches!(result, Err(InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
+            "Qwen35Model::generate must reject an empty prompt with \
+             Err(Inference(\"empty prompt\")); got {result:?}"
         );
     }
 

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -55,6 +55,11 @@ pub(crate) use generation::check_logprobs_not_set;
 // Sibling guards for `stop_strings` / `reasoning_budget` on the same unwired
 // paths (ADR-080 C3, #783).
 pub(crate) use generation::{check_reasoning_budget_not_set, check_stop_strings_not_set};
+// Shared empty-prompt preflight (#856): every CPU forward path (cpu_q8,
+// cpu_f16, neon_forward) and every Metal generation entry point
+// (forward::metal_qwen35) calls this instead of its own inline
+// `if prompt_len == 0` copy, unifying the CPU/Metal empty-prompt contract.
+pub(crate) use generation::check_prompt_not_empty;
 // Shared backend-neutral decode-policy struct (reasoning-budget accounting +
 // logprobs formatting), consumed by the Metal streaming loops in
 // `crate::forward::metal_qwen35` so the same bookkeeping isn't re-duplicated

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -2191,6 +2191,27 @@ where
 /// # Returns
 ///
 /// The generated token IDs (excluding the prompt).
+///
+/// # Empty-prompt exception (#856/#915)
+///
+/// Every Qwen3.5 generation entry point rejects an empty prompt with a
+/// typed `Err(InferenceError::Inference("empty prompt"))` via a shared
+/// preflight (`model::qwen35::generation::check_prompt_not_empty`,
+/// see `docs/generation-entrypoint-matrix.md`). **This function is an
+/// intentional, documented exception to that unified contract**: it
+/// returns `Vec<u32>`, not a `Result`, so it cannot reject anything --
+/// an empty `prompt_tokens` returns `Vec::new()` (a vacuous success, not
+/// an error), locked in by
+/// `generate_with_speculation_empty_prompt_returns_empty` below.
+///
+/// This is not the intended long-term shape: it is kept as-is here only
+/// because `lattice-inference` v0.6.1 just shipped, and turning this
+/// public free function fallible (`Result<Vec<u32>, InferenceError>`) is
+/// a breaking signature change that does not belong in a same-version
+/// bugfix. Tracked for the next semver-major-eligible release in
+/// <https://github.com/ohdearquant/lattice/issues/916> (targets 0.7.0),
+/// which will change this to reject an empty `prompt_tokens` the same
+/// way every other entry point does.
 pub fn generate_with_speculation<F>(
     prompt_tokens: &[u32],
     max_new_tokens: usize,
@@ -4511,6 +4532,14 @@ mod tests {
     fn generate_with_speculation_empty_prompt_returns_empty() {
         // Empty prompt cannot seed speculation; must return empty, not panic on
         // `all_tokens.last()` in the first decode step.
+        //
+        // This locks in the *documented* empty-input -> empty-output
+        // sentinel described on `generate_with_speculation` above (the
+        // one intentional exception to the #856/#915 unified
+        // empty-prompt-Err contract, tracked for a fallible signature at
+        // https://github.com/ohdearquant/lattice/issues/916, targets
+        // 0.7.0). If/when that issue lands, this assertion flips to
+        // expect `Err(InferenceError::Inference("empty prompt"))`.
         let out = generate_with_speculation(&[], 8, 999, |_tok, _pos| vec![0.0; 4], 3, 4);
         assert!(out.is_empty());
     }

--- a/docs/generation-entrypoint-matrix.md
+++ b/docs/generation-entrypoint-matrix.md
@@ -100,6 +100,16 @@ empty-prompt early-return at all (dead code once the wrapper always rejects firs
 removing rather than duplicating it as an `Err` avoided reintroducing the same
 destructive-eviction hazard those two existing guards were already routed around.
 
+**Scope note:** "unified" above means the seven `MetalQwen35State`/CPU-forward paths
+this document tracks (eight physical call sites once the CPU dispatcher/streaming
+entry points that call into the three CPU forward functions are counted separately —
+see #915's PR body). It does **not** cover
+`lattice_inference::speculative::generate_with_speculation`
+(`crates/inference/src/speculative.rs`) — a separate, model-agnostic, non-`Result`
+public helper outside this issue's original scope. That function has its own
+documented empty-input exception (see its doc comment) and is tracked for a fallible
+signature at <https://github.com/ohdearquant/lattice/issues/916> (targets 0.7.0).
+
 Re-verify these line numbers before relying on them; `metal_qwen35.rs` changes
 frequently (see the file-level warning at the top of this document).
 

--- a/docs/generation-entrypoint-matrix.md
+++ b/docs/generation-entrypoint-matrix.md
@@ -73,7 +73,40 @@ wall-clock nanoseconds since epoch, itself remapped `0 → 1` in the pathologica
 
 ### 2. Empty prompt
 
-| Path               | Location                      | Outcome                                                                                                                                                                          |
+**RESOLVED (#856, unified on `Err`):** all seven entry points now reject an empty
+prompt with the same typed `Err(InferenceError::Inference("empty prompt"))`, via one
+shared preflight, `check_prompt_not_empty` (`model/qwen35/generation.rs:2227`). This
+replaced each CPU path's own inline copy of the check and added the equivalent call to
+the four Metal paths, which previously accepted an empty prompt and returned a normal
+empty `Ok` completion (see "Original divergence" below for what that looked like and
+why maintainer sign-off ruled the CPU behavior as the contract to keep).
+
+| Path               | Location                                                                                        | Outcome                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| CPU f16            | `cpu_f16.rs:868` (call site)                                                                    | `Err(InferenceError::Inference("empty prompt"))`                                    |
+| CPU q8             | `cpu_q8.rs:721` (call site)                                                                     | `Err(InferenceError::Inference("empty prompt"))`                                    |
+| CPU q8 NEON        | `neon_forward.rs:906` (call site)                                                               | `Err(InferenceError::Inference("empty prompt"))`                                    |
+| Metal direct       | `metal_qwen35.rs:8711` (call site)                                                              | `Err(InferenceError::Inference("empty prompt"))`                                    |
+| Metal streaming    | `metal_qwen35.rs:13250` (call site, in `generate_streaming_with_cancel`)                        | `Err(InferenceError::Inference("empty prompt"))`; `on_token` never invoked          |
+| Metal prefix-cache | `metal_qwen35.rs:15985` (call site, in the public wrapper, _before_ `_inner` -- see note below) | `Err(InferenceError::Inference("empty prompt"))`; no cache entry created or evicted |
+
+Note on the prefix-cache path: the guard had to land in the public wrapper
+(`generate_streaming_with_prefix_cache_and_cancel`), not in `_inner`, alongside the
+existing `check_logprobs_not_set`/`check_mtp_not_requested` preflights (row 5/8's
+"CONTRACT, preserve" pattern) — `_inner`'s caller unconditionally evicts the cache slot
+on any `Err` it returns, so a preflight-only rejection has to return before `_inner` is
+even called, exactly like those two guards. `_inner` no longer carries its own
+empty-prompt early-return at all (dead code once the wrapper always rejects first);
+removing rather than duplicating it as an `Err` avoided reintroducing the same
+destructive-eviction hazard those two existing guards were already routed around.
+
+Re-verify these line numbers before relying on them; `metal_qwen35.rs` changes
+frequently (see the file-level warning at the top of this document).
+
+<details>
+<summary>Original divergence (pre-#856), preserved for history</summary>
+
+| Path               | Location (pre-#856)           | Outcome (pre-#856)                                                                                                                                                               |
 | ------------------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | CPU f16            | `cpu_f16.rs:865-869`          | `Err(InferenceError::Inference("empty prompt"))`                                                                                                                                 |
 | CPU q8             | `cpu_q8.rs:718-722`           | `Err(InferenceError::Inference("empty prompt"))`                                                                                                                                 |
@@ -82,11 +115,15 @@ wall-clock nanoseconds since epoch, itself remapped `0 → 1` in the pathologica
 | Metal streaming    | `metal_qwen35.rs:12982-12995` | Same `Ok` shape as Metal direct; `on_token` never invoked                                                                                                                        |
 | Metal prefix-cache | `metal_qwen35.rs:15422-15448` | `Ok(CachedGenerateOutput{ output: GenerateOutput{ stopped:false, stop_reason:None, .. }, cache: CrossTurnCacheStats{ prompt_tokens:0, reused_tokens:0, mode:FullRefill, .. } })` |
 
-**Divergence (CONTRACT, preserve):** all three CPU paths reject an empty prompt with a
-typed `Err`; all three Metal paths accept it and return a normal empty `Ok` completion
-with `stop_reason: None`. Any consolidation must decide which contract wins, or thread
-this as an explicit parameter — it is currently a real, live difference in what a
-caller observes for the same input.
+**Divergence (was CONTRACT, preserve; now RESOLVED, see above):** all three CPU paths
+rejected an empty prompt with a typed `Err`; all three Metal paths accepted it and
+returned a normal empty `Ok` completion with `stop_reason: None` -- itself an
+invariant-violating result shape (a "completed" generation that neither stopped nor
+gives a reason). Question 2 in "Questions for maintainer sign-off" below flagged this
+split explicitly; the maintainer ruling (recorded on #856) was to unify on the CPU
+`Err` behavior in the shared preflight rather than preserve the split.
+
+</details>
 
 ### 3. Zero-budget (`max_new_tokens == 0`)
 
@@ -302,13 +339,15 @@ here; they are recorded for explicit maintainer judgment on whether each is CONT
    direct intentional, or should an unmet-precondition MTP request surface some signal
    to the caller (as it does, hard, on Metal prefix-cache)?
 
-2. **Empty-prompt contract split (row 2) is a hard `Err` vs `Ok` divergence,
-   independent of the already-tracked over-context split (row 9).** All three CPU
-   paths reject an empty prompt; all three Metal paths accept it and return an empty
-   completion. Is this intentional (e.g. CPU paths are more commonly called with
-   programmatically-assembled prompts where empty is always a caller bug, while Metal
-   paths serve interactive/streaming callers where an empty turn is a normal no-op)?
-   If so, worth stating explicitly so a consolidation doesn't quietly unify it.
+2. **RESOLVED (#856).** Empty-prompt contract split (row 2) was a hard `Err` vs `Ok`
+   divergence, independent of the already-tracked over-context split (row 9): all
+   three CPU paths rejected an empty prompt; all three Metal paths accepted it and
+   returned an empty completion. Maintainer ruling (recorded on #856): not
+   intentional -- unify on the CPU `Err` behavior via a shared preflight, since the
+   Metal `Ok` shape (`stopped: false, stop_reason: None`) is itself
+   invariant-violating (a "completed" generation that neither stopped nor gives a
+   reason), not a deliberate no-op contract for interactive callers. See row 2 above
+   for the resulting shared guard and the caller audit performed before landing it.
 
 3. **Stale-looking doc comment at `metal_qwen35.rs:15710-15712`** (row 7): claims the
    reasoning-budget policy is "shared ... with the CPU `model::qwen35::generation`
@@ -337,7 +376,7 @@ here; they are recorded for explicit maintainer judgment on whether each is CONT
 | Behavior                | CPU f16                              | CPU q8          | CPU q8 NEON     | Metal direct                                                    | Metal streaming (wrapper)                                        | Metal streaming (impl) | Metal prefix-cache                                                                                                                 |
 | ----------------------- | ------------------------------------ | --------------- | --------------- | --------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Seed 0/nonzero/unset    | remap 0→1, time fallback             | same            | same            | same                                                            | same                                                             | same                   | same                                                                                                                               |
-| Empty prompt            | `Err`                                | `Err`           | `Err`           | `Ok` empty                                                      | `Ok` empty                                                       | `Ok` empty             | `Ok` empty                                                                                                                         |
+| Empty prompt (#856)     | `Err`                                | `Err`           | `Err`           | `Err`                                                           | `Err`                                                            | `Err`                  | `Err`                                                                                                                              |
 | Zero budget             | `Ok` Length                          | `Ok` Length     | `Ok` Length     | `Ok` Length                                                     | `Ok` Length                                                      | `Ok` Length            | `Ok` Length                                                                                                                        |
 | Grammar                 | `Err`                                | `Err`           | `Err`           | supported, route needs `grammar.is_none()`                      | supported, route needs `grammar.is_none() && logprobs.is_none()` | same as wrapper        | supported, route needs `grammar.is_none() && logprobs.is_none()`                                                                   |
 | Logprobs                | `Err`                                | `Err`           | `Err`           | `Err`                                                           | **supported**                                                    | **supported**          | `Err`                                                                                                                              |


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## What / why

Closes #856. Empty-prompt handling diverged across the Qwen3.5 generation
entry points: the three CPU forward paths already rejected an empty prompt
with a typed `Err(InferenceError::Inference("empty prompt"))`, while all four
Metal generation entry points silently accepted it and returned an empty `Ok`
result instead. This PR adds one shared preflight,
`check_prompt_not_empty(prompt_len: usize) -> Result<(), InferenceError>`
(`crates/inference/src/model/qwen35/generation.rs:2227`), and wires every
entry point through it so the contract is identical everywhere: reject with
`Err(InferenceError::Inference("empty prompt"))`.

## Entry-point map / sibling audit

All call sites now route through the one shared guard (`grep -n
check_prompt_not_empty` output below is exhaustive over `crates/inference/`):

| Path | Call site | Outcome (after this PR) |
|---|---|---|
| CPU f16 | `cpu_f16.rs:868` | `Err(Inference("empty prompt"))` |
| CPU q8 | `cpu_q8.rs:721` | `Err(Inference("empty prompt"))` |
| CPU q8 NEON | `neon_forward.rs:906` | `Err(Inference("empty prompt"))` |
| `Qwen35Model::generate` (CPU dispatcher) | `generation.rs:67` | `Err(Inference("empty prompt"))` |
| `generate_streaming_with_observer` (CPU streaming) | `generation.rs:473` | `Err(Inference("empty prompt"))` |
| `MetalQwen35State::generate` | `metal_qwen35.rs:8711` | `Err(Inference("empty prompt"))` — was `Ok` before this PR |
| `generate_streaming_with_cancel` (also backs the `generate_streaming` thin wrapper) | `metal_qwen35.rs:13250` | `Err(Inference("empty prompt"))` — was `Ok` before this PR |
| `generate_streaming_with_prefix_cache_and_cancel` (public wrapper) | `metal_qwen35.rs:15985` | `Err(Inference("empty prompt"))` — was `Ok` before this PR |

Bonus dedup: the three CPU paths (`cpu_f16.rs`, `cpu_q8.rs`,
`neon_forward.rs`) each had their own inline `if prompt_len == 0 { return
Err(...) }` copy with independently-typed messages; all three now call the
one shared guard instead, closing a latent divergence (same `Err` variant,
but three separately-maintained message strings) before it could drift.

**Why the guard lives in the wrapper, not `_inner`.** The prefix-cache path
has a public wrapper (`generate_streaming_with_prefix_cache_and_cancel`) and
a private `_inner` helper with exactly one caller — the wrapper. `_inner`'s
caller unconditionally evicts the cross-turn prefix-cache slot on any `Err`
`_inner` returns (that's the correct behavior for the guards that *are*
duplicated there, e.g. logprobs/mtp — those checks run in both places as
defense-in-depth against future callers of `_inner`). An empty-prompt guard
inside `_inner` would trip that same destructive eviction for a rejection
that never touched the cache in the first place, since the empty-prompt
check is the very first thing that runs, before any cache read. So the guard
is placed once, in the wrapper, ahead of the suffix-validation logic; the
stale `_inner` early-return `Ok` block (the dead code causing the pre-fix
Metal/prefix-cache divergence) is removed and replaced with a
`debug_assert!` at `metal_qwen35.rs:16097` documenting the invariant that the
wrapper always screens empty prompts first.

**Siblings checked and deliberately left out of scope**, with rationale:

- `crate::generate::generate` (`src/generate.rs`) — deprecated top-level
  free function, already rejects empty prompt but with a *different* typed
  variant (`InvalidInput`) and message (`"Empty prompt"`); not part of the
  Qwen3.5 entry-point surface this issue scopes to, and changing a
  deprecated function's error variant is its own (out-of-scope) decision.
- `Qwen35Model::generate_with_batch_prefill` (`batch_prefill.rs`) —
  `#[allow(dead_code)]`, deprecated, unreferenced by any live entry point.
- `generate_multimodal` — checks `total_len` (visual + text tokens
  combined), a different precondition than a bare empty *text* prompt;
  out of scope for #856.
- `batch/worker.rs::submit` — returns `Option<SeqId>`, not a `Result`; not
  the same API shape as the guarded entry points.
- `kv_cache/cross_turn.rs::plan_cross_turn_reuse` — cache-planning helper,
  not an accept/reject boundary for a prompt.
- `model/qwen35/debug.rs::forward_prompt_debug` — debug-only forward pass,
  not a production generation entry point.

Two siblings the first pass of review missed were **reachable fail-open
paths**, not genuinely out of scope — see "Fixes from review" below:
non-`metal-gpu` build stub of `MetalQwen35State::generate` (fixed; fails
**loud** via `panic!` now instead of failing open, signature unchanged for
semver reasons — see round 2 below — with the fallible-`Result` shape
tracked for 0.7.0 in ohdearquant/lattice#917) and
`speculative.rs::generate_with_speculation` (documented intentional
exception, tracked for 0.7.0 in ohdearquant/lattice#916).

`docs/generation-entrypoint-matrix.md` (the maintainer-signed-off behavior
matrix from #822/#855) is updated: the "Empty prompt" row now shows `Err`
across all 7 documented paths, with the original pre-fix divergence
preserved verbatim in a collapsible `<details>` block for history. A new
scope note clarifies that "unified" refers to the seven
`MetalQwen35State`/CPU-forward paths this document tracks (eight physical
call sites counting the CPU dispatcher/streaming wrappers separately) and
explicitly excludes `generate_with_speculation`.

## Fixes from review (PR #915)

An earlier round of review on this PR caught two reachable fail-open paths
this diff had missed and two test-robustness gaps. Fixed in this push,
same branch:

1. **`speculative::generate_with_speculation(&[], ...)` returns `Ok`/`Vec::new()` on an empty prompt** (public, model-agnostic, non-`Result` helper) — contradicts the unified contract. Not signature-ified here: `lattice-inference` v0.6.1 just shipped, and turning this public free function fallible is a breaking change that doesn't belong in a same-version bugfix. Instead: documented the empty-input → empty-output sentinel explicitly on the function's doc comment as an intentional, temporary exception; narrowed this PR's claims (above) and `docs/generation-entrypoint-matrix.md`'s scope note accordingly; filed ohdearquant/lattice#916 (targets 0.7.0) to make it fallible, referenced from the doc comment; kept the existing regression test (`generate_with_speculation_empty_prompt_returns_empty`) and added a comment that it locks in the documented sentinel rather than an oversight.
2. **Non-`metal-gpu` build stub of `MetalQwen35State` was a fail-open hole**: the struct is a public unit type (directly constructible without the fallible `new`/`from_q4_dir`), and its `generate` stub returned `Ok(GenerateOutput{ .. })` for *every* prompt, including empty ones. **This fix went through two rounds** — see "Round 2 fixes" below for why the first attempt (changing the stub's return type to `Result`) was itself a semver break and had to be reverted in favor of a `panic!`-based fail-loud fix that keeps the published `-> GenerateOutput` signature.
3. **The prefix-cache empty-prompt test only asserted a fresh, empty cache** (`entry.is_none()`), which would still pass even if a future change moved the guard into `_inner` and took its destructive Err-recovery eviction path on a *warmed* slot — i.e. it didn't exercise the preservation property that motivated the wrapper-not-`_inner` placement in the first place. Fixed: rewrote `generate_streaming_with_prefix_cache_rejects_empty_prompt` to mirror the existing `..._rejects_logprobs_request_preserves_warm_entry` pattern — warm a real cache entry for the slot first, submit the empty prompt, assert the exact `Err`, then assert the pre-existing entry is unchanged afterward (extended further in round 2 — see below).
4. **Two of the three new Metal tests skipped silently when no Metal device was present**, unlike the third (prefix-cache) test, which already checked `LATTICE_METAL_TEST_ENFORCE` before accepting a device-absent skip. A required Metal CI leg without a device could report green on `metal_generate_plain_rejects_empty_prompt` / `metal_generate_streaming_rejects_empty_prompt` without ever running their assertions. Fixed: both now honor `LATTICE_METAL_TEST_ENFORCE` the same way — one shared fail-closed device precondition across all three.

## Round 2 fixes

A second review pass verified findings 1/3/4 above resolved, but caught
that the the first review pass's fix for finding 2 introduced a new semver problem, plus a
gap in how thoroughly the the first review pass's fix for finding 3 actually verified
"byte-identical":

1. **MAJOR — the the first review pass's stub fix was itself a semver-breaking signature change.** Changing the non-`metal-gpu` stub's `generate` from the published `-> GenerateOutput` to `-> Result<GenerateOutput, InferenceError>` breaks every existing **default**-build downstream caller that consumes a bare `GenerateOutput` — `metal-gpu` is not a default feature, so the stub (not the real implementation) is what a default build gets, and this module is public. `cargo-semver-checks`' inherent-method lint would not have caught it (it only detects a value-to-`()` transition, not one non-unit type changing to another). **Fixed**: restored the published `-> GenerateOutput` signature and made the stub fail **loud** instead — it now `panic!`s with `"MetalQwen35State::generate called on a build compiled without the metal-gpu feature; construct via new() which returns an error on such builds"` for every input. This is strictly better than the pre-#856/#915 fail-open state (impossible to miss, vs. an empty `Ok` that looked like a real generation) and matches the v0.6.0 release notes' fail-loudly convention for unimplemented GPU arms elsewhere in this crate. It is not the intended long-term shape (a panic is still rougher than a typed `Err`), so filed a **sibling** issue, ohdearquant/lattice#917 (targets 0.7.0, distinct from #916 which is `speculative`-specific), and referenced it from the stub's doc comment. Converted `non_metal_stub_generate_rejects_empty_prompt` / `non_metal_stub_generate_rejects_nonempty_prompt` to `#[should_panic(expected = "metal-gpu")]`. No other stub method's signature was touched by this PR (`git diff <published-base> -- metal_qwen35.rs | grep -E '^[-+].*\) -> '` shows exactly one changed return-type line, this one) — the "streaming variants" the reviewer asked to double-check don't exist as stubs at all; only `generate` has a body in the non-`metal-gpu` `impl` block that produces output, everything else already either returns a fixed scalar/`Result::Err` or is unreachable from a non-Metal build.
2. **MEDIUM — the the first review pass's prefix-cache survival test claimed "byte-identical" but only compared `generic.token_ids`.** `MetalCrossTurnPrefixEntry` also carries `gdn_snapshot` (`Vec<(Vec<f32>, Vec<f32>)>`) and sparse `checkpoints` (`Vec<MetalGdnCheckpoint { len, snapshot }>`); `CrossTurnPrefixEntry` itself (the `generic` field) has fields beyond `token_ids` (`slot_id`, `metadata`, `represented_len`, a `kv` handle, `gdn_snapshot_len`). **Fixed (preferred option — extended the comparison, not narrowed the claim)**: verified every one of those types is genuinely comparable — `CrossTurnPrefixEntry` and its `KvPrefixHandle`/`CrossTurnPrefixMetadata` fields all derive `PartialEq`/`Eq` (the `kv` handle is a small `Copy` value type of offsets/lengths, not a raw device pointer), and `gdn_snapshot`/`checkpoints`, while their containing structs don't derive `PartialEq`, are built entirely from `Vec<f32>`/tuple/`usize` pieces that do. The test now snapshots `generic` (compared via `==` on the whole derived-`Eq` struct), `gdn_snapshot`, and `checkpoints` (mapped to `(len, snapshot)` pairs) before the rejected call, and asserts all three are unchanged after. There is no field on `MetalCrossTurnPrefixEntry` this leaves uncompared, so "byte-identical" is now an accurate claim rather than an aspirational one.

## Regression tests

11 new tests, all touching only the guard / entry points above:

- `check_prompt_not_empty_rejects_zero`, `check_prompt_not_empty_allows_nonzero`
  (pure-guard unit tests, `generation.rs`)
- `qwen35_model_generate_rejects_empty_prompt` (CPU integration test via
  `Qwen35Model::generate`, `generation.rs`)
- `generate_f16_rejects_empty_prompt`, `generate_q8_rejects_empty_prompt`,
  `generate_q8_neon_rejects_empty_prompt` (one per CPU forward path)
- `metal_generate_plain_rejects_empty_prompt`,
  `metal_generate_streaming_rejects_empty_prompt` (one per direct/streaming
  Metal entry point; `gpu_test_lock()`, now honor
  `LATTICE_METAL_TEST_ENFORCE` on device-absent skip — fix 4)
- `generate_streaming_with_prefix_cache_rejects_empty_prompt` (Metal
  prefix-cache wrapper; `gpu_test_lock()`, `LATTICE_METAL_TEST_ENFORCE`;
  now warms a real cache entry first and asserts it survives the rejection
  — fix 3)
- `non_metal_stub_generate_rejects_empty_prompt`,
  `non_metal_stub_generate_rejects_nonempty_prompt` (fix 2; run in the
  **default** build, construct the non-`metal-gpu` `MetalQwen35State` stub
  directly; `#[should_panic(expected = "metal-gpu")]` as of round 2, not
  an `Err` assertion — see "Round 2 fixes")

## Mutation-sensitivity proof

Original round: reverse-applied the guard (restored the old CPU inline
checks / old Metal `Ok`-return blocks), `touch`ed the changed files to
force a rebuild, and re-ran the exact test sets above with the guard
neutered:

- CPU + pure-guard leg (6 tests): 5/6 failed as expected (the sixth,
  `check_prompt_not_empty_allows_nonzero`, correctly still passed — it
  never exercises the empty-prompt branch).
- Metal leg (3 tests): 3/3 failed, including a live observation of Metal
  actually generating garbage tokens (`"aaaa"`, `token_ids [0,0,0,0]`) from
  an empty prompt with the guard removed.

Review-fix round 1: reverse-applied fix 2 (restored the stub's old
unconditional `Ok(GenerateOutput{ .. })`), `touch`ed the file, re-ran the
two new stub tests — both failed with the `Ok(...)` value printed in the
panic message. Restored the fix; both pass again.

Review-fix round 2: reverse-applied the `panic!` (restored a plain,
non-panicking `GenerateOutput { .. }` return), `touch`ed the file, re-ran
the two stub tests under their new `#[should_panic]` form — both failed
with `note: test did not panic as expected`. Restored the `panic!`; both
pass again.

Restored every guard/fix in every leg; re-ran — all 11 pass again (see
full-suite output below). No mutation scaffolding was left in the tree
(`grep -rn "MUTATION-PROOF" crates/` returns nothing).

## Gates

- `cargo fmt --check -p lattice-inference` — clean
- `cargo clippy -p lattice-inference --all-targets -- -D warnings` — clean
- `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings` — clean
- `cargo check -p lattice-inference` (truly no features) and `cargo check -p lattice-inference` (default features) — both clean; confirms the restored `-> GenerateOutput` stub signature compiles the default build exactly as published
- `cargo check -p lattice-inference --bins --features f16,metal-gpu,serve` and `--bins` (default) — both clean (confirms no in-crate caller depends on the stub's signature either way; every binary gates its Metal-calling code behind the `metal-gpu` feature)
- `cargo test -p lattice-inference --lib` (default features): **1788 passed; 0 failed; 18 ignored**
- `cargo test -p lattice-inference --features metal-gpu --lib -- <9 shared+Metal test names> --test-threads=1`: **6 passed; 0 failed** (pure-guard + CPU-integration leg shown; Metal leg run separately under `gpu_test_lock()`, 3/3 passed; the 2 non-metal-stub tests are gated to the default build and don't apply under this feature set)

Bench-compare was **not** re-run for either fix round: none of the fixes
touch a benchmarked code path. Fix 1 is a doc-comment-only change. Fix 2
(both rounds) changes a stub function that's dead code within this
crate's own compiled binaries (every in-crate caller of Metal generation
gates behind the `metal-gpu` feature, confirmed by the `--bins` checks
above) — its only reachability is from an external, non-`metal-gpu`
downstream build; round 2 additionally reverts it to the exact
zero-runtime-cost shape it had in the published base (a `panic!` compiles
to no more code on the hot path than the old empty-`Ok` construction it
replaced — this stub is never on any benchmarked path either way). Fixes
3 and 4 are `#[cfg(test)]`-only. The original bench-compare run (below)
already covers the diff's only hot-path change (the preflight call
sites), and none of that changed in either fix round.

## bench-compare

Diff touches `crates/inference/`, so `make bench-compare` is mandatory. Ran
under `HEAVY_LANE_EXCLUSIVE=1` (solo-machine measurement) via
`with-heavy-lane.sh` after an initial non-exclusive run showed heavy
contention noise from other concurrent jobs on the machine (discarded).

Base=`origin/main` (`b118d3871b`), Head=`HEAD` (`64c0059924`), `--quick` mode.

The only groups this diff can plausibly affect are the `crates/inference`
elementwise/norm/softmax groups the preflight sits next to — the guard is a
single `prompt_len == 0` check on cold entry, off the hot generation loop:

| Bench | Δ point | 95% CI |
|---|---:|---|
| `rms_norm/896` | +0.10% | [-2.60%, +2.87%] |
| `rms_norm/4096` | +1.45% | [-0.01%, +2.94%] |
| `layer_norm/896` | +0.28% | [-3.17%, +3.82%] |
| `layer_norm/4096` | +0.13% | [-2.17%, +2.43%] |
| `silu_inplace/896` | -5.35% | [-6.06%, -4.64%] (🚀 confirmed win, not this diff) |
| `silu_inplace/4096` | -2.67% | [-3.20%, -2.14%] |
| `gelu/896` | -0.28% | [-1.27%, +0.73%] |
| `gelu/4096` | +2.66% | [-0.03%, +5.47%] |
| `add_bias_gelu/896` | -0.03% | [-2.27%, +2.26%] |
| `add_bias_gelu/4096` | +0.02% | [-2.08%, +2.17%] |
| `elementwise_mul/4096` | -2.44% | [-3.90%, -0.94%] |
| `softmax_attention/128` | +0.31% | [-1.28%, +1.94%] |
| `softmax_attention/512` | -0.33% | [-1.34%, +0.68%] |

All within the harness's own noise band; no group in `crates/inference`
crosses the 3.0% CI-lower gate threshold.

The full gate report separately flagged **1 FAIL + 10 WARN** — every one of
them in `lattice-embed` SIMD groups (`simd_batch_dot_product`,
`simd_batch_cosine_normalized_query`, `binary_cosine_distance`,
`simd_normalize`, `simd_squared_euclidean_fast_path`,
`int4_cosine_distance`). This diff does not touch `crates/embed/` at all —
none of those files appear in `git diff --stat` for this branch — and the
same report shows 30 *improvements* in the same crate's sibling benchmark
cases (e.g. `simd_batch_cosine_non_normalized_query` improving while
`simd_batch_cosine_normalized_query` regresses), the standard signature of
pre-existing micro-benchmark noise in that crate rather than a real
regression from this PR.

`bench-allow-regression` is not requested since the flagged groups are
outside this PR's diff.
