### PR TITLE
feat(inference): optional MoE routing-trace collector for offline agreement checks (#682 stage 4)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -3744,6 +3744,61 @@ mod inner {
         MOE_PREFETCH_STEP2_DONE_TX_FOR_TEST.with(|c| *c.borrow_mut() = tx);
     }
 
+    /// One recorded top-k routing decision: which experts `encode_moe_ffn`'s
+    /// CPU router selected for one token at one MoE layer, and their
+    /// (post-renormalization) gate weights, in `selected_ids[i]` /
+    /// `gate_weights[i]` correspondence.
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    pub struct MoeRoutingTraceRecord {
+        pub layer_idx: usize,
+        pub token_idx: usize,
+        pub selected_ids: Vec<usize>,
+        pub gate_weights: Vec<f32>,
+    }
+
+    thread_local! {
+        /// Optional per-token routing-divergence trace collector for
+        /// `encode_moe_ffn`'s CPU top-k selection (#682 Stage 4 instrumentation
+        /// seam). Same arm/drain-via-free-function shape as
+        /// `FORCED_MOE_EXPERTS_FOR_TEST` above, but NOT `#[cfg(test)]`-gated:
+        /// production harnesses (e.g. `eval_perplexity`) arm it outside of
+        /// tests to record per-token top-k expert-id sets and gate weights,
+        /// for computing set-agreement (Jaccard) between a quantized arm and
+        /// a full-precision reference. `None` (the default) makes every
+        /// `encode_moe_ffn` call a single branch-on-None with no allocation.
+        static MOE_ROUTING_TRACE: std::cell::RefCell<Option<Vec<MoeRoutingTraceRecord>>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
+    /// Arm the routing-trace collector on this thread: every subsequent
+    /// `encode_moe_ffn` call appends one [`MoeRoutingTraceRecord`], until
+    /// [`take_moe_routing_trace`] disarms it. Re-arming an already-armed
+    /// collector discards any records buffered since the previous arm.
+    pub fn arm_moe_routing_trace() {
+        MOE_ROUTING_TRACE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+    }
+
+    /// Disarm the collector and return every record buffered since the last
+    /// [`arm_moe_routing_trace`] call (empty if it was never armed).
+    pub fn take_moe_routing_trace() -> Vec<MoeRoutingTraceRecord> {
+        MOE_ROUTING_TRACE.with(|c| c.borrow_mut().take().unwrap_or_default())
+    }
+
+    /// Write `records` as newline-delimited JSON, one [`MoeRoutingTraceRecord`]
+    /// per line, so an external harness can diff a trace against a reference run.
+    pub fn dump_moe_routing_trace_jsonl(
+        records: &[MoeRoutingTraceRecord],
+        path: &std::path::Path,
+    ) -> std::io::Result<()> {
+        use std::io::Write;
+        let mut out = std::io::BufWriter::new(std::fs::File::create(path)?);
+        for record in records {
+            serde_json::to_writer(&mut out, record).map_err(std::io::Error::other)?;
+            out.write_all(b"\n")?;
+        }
+        out.flush()
+    }
+
     impl MetalQwen35State {
         /// **Unstable**: create from CPU weights; weight layout and f16 conversion may change.
         pub fn new(
@@ -5805,6 +5860,7 @@ mod inner {
                             mlp_enc,
                             compact_idx,
                             layer_i,
+                            position,
                             &cfg,
                             &mut prof,
                             false,
@@ -5844,6 +5900,7 @@ mod inner {
                             mlp_enc,
                             compact_idx,
                             layer_i,
+                            position,
                             &cfg,
                             &mut prof,
                             false,
@@ -10051,6 +10108,7 @@ mod inner {
             enc: &ComputeCommandEncoderRef,
             compact_idx: usize,
             layer_idx: usize,
+            position: usize,
             cfg: &Qwen35Config,
             prof: &mut StepProfile,
             profiling: bool,
@@ -10132,7 +10190,7 @@ mod inner {
                     let moe_ptr = moe_bufs.as_ref() as *const MoeMetalBuffers;
                     // SAFETY: moe_bufs is owned by layer_weights which is live.
                     unsafe {
-                        self.encode_moe_ffn(enc, &*moe_ptr, cfg);
+                        self.encode_moe_ffn(enc, &*moe_ptr, cfg, layer_idx, position);
                     }
                 }
             }
@@ -10158,7 +10216,7 @@ mod inner {
             enc: &ComputeCommandEncoderRef,
             compact_idx: usize,
             linear_idx: usize,
-            _position: usize,
+            position: usize,
             layer_idx: usize,
             cfg: &Qwen35Config,
             prof: &mut StepProfile,
@@ -10437,7 +10495,7 @@ mod inner {
             );
 
             if with_mlp {
-                self.encode_mlp_block(enc, compact_idx, layer_idx, cfg, prof, profiling);
+                self.encode_mlp_block(enc, compact_idx, layer_idx, position, cfg, prof, profiling);
             }
 
             1 // one GDN GPU dispatch per layer
@@ -10675,7 +10733,7 @@ mod inner {
             }
 
             if with_mlp {
-                self.encode_mlp_block(enc, compact_idx, layer_idx, cfg, prof, profiling);
+                self.encode_mlp_block(enc, compact_idx, layer_idx, position, cfg, prof, profiling);
             }
         }
 
@@ -10705,6 +10763,8 @@ mod inner {
             enc: &ComputeCommandEncoderRef,
             moe: &MoeMetalBuffers,
             _cfg: &Qwen35Config,
+            layer_idx: usize,
+            token_idx: usize,
         ) {
             let hidden = moe.hidden;
             let inter = moe.inter;
@@ -10796,6 +10856,20 @@ mod inner {
                     *prob /= top_sum;
                 }
             }
+
+            // #682 Stage 4: optional routing-divergence trace. Single
+            // branch-on-None (`with` + `borrow` on an unset thread-local) when
+            // disarmed, the production default — see `MOE_ROUTING_TRACE`.
+            MOE_ROUTING_TRACE.with(|c| {
+                if let Some(trace) = c.borrow_mut().as_mut() {
+                    trace.push(MoeRoutingTraceRecord {
+                        layer_idx,
+                        token_idx,
+                        selected_ids: selected.iter().map(|(id, _)| *id).collect(),
+                        gate_weights: selected.iter().map(|(_, w)| *w).collect(),
+                    });
+                }
+            });
 
             // ── Step 2: Shared expert (always active) ─────────────────────────────
             // Extracted into a closure (called exactly once, either inline
@@ -19409,6 +19483,146 @@ mod inner {
                      evicted instead) or eviction pressure isn't reaching this cache at all"
                 );
             }
+        }
+
+        /// #682 Stage 4: the routing-trace collector's hot path is a single
+        /// branch on `MOE_ROUTING_TRACE`'s thread-local `None` state when
+        /// never armed — `encode_moe_ffn` must record nothing while
+        /// disarmed, and the collector must stay disarmed rather than
+        /// silently self-arming on first use.
+        ///
+        /// Mutation check, manually verified (not compiled in): replacing
+        /// `encode_moe_ffn`'s `if let Some(trace) = c.borrow_mut().as_mut()
+        /// { trace.push(..) }` guard with an unconditional
+        /// `c.borrow_mut().get_or_insert_with(Vec::new).push(..)` (the
+        /// collector self-arming instead of staying `None`) makes this test
+        /// fail: `take_moe_routing_trace()` returns 2 records instead of the
+        /// expected empty trace.
+        #[test]
+        fn moe_routing_trace_disarmed_records_nothing() {
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            let cfg = synthetic_moe_test_config();
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let dir = tmp.path();
+            write_synthetic_moe_checkpoint(
+                dir,
+                &cfg,
+                moe_fixture_gate_const,
+                moe_fixture_up_const,
+                moe_fixture_down_const,
+            );
+            let tokenizer_path = std::path::Path::new("/dev/null");
+            let mut state = MetalQwen35State::from_q4_dir(dir, tokenizer_path, &cfg, 16)
+                .expect("from_q4_dir must load");
+
+            // Defensive: drain+disarm in case a prior test on this worker
+            // thread left the collector armed — thread-locals persist across
+            // tests reusing the same `gpu_test_lock()`-serialized OS thread
+            // (same reasoning as `ForcedMoeExpertsGuard`'s doc comment).
+            let _ = take_moe_routing_trace();
+
+            let logits0 = state.forward_step(1, 0);
+            let logits1 = state.forward_step(2, 1);
+            assert!(logits0.iter().all(|v| v.is_finite()));
+            assert!(logits1.iter().all(|v| v.is_finite()));
+
+            let trace = take_moe_routing_trace();
+            assert!(
+                trace.is_empty(),
+                "encode_moe_ffn must record nothing while MOE_ROUTING_TRACE is disarmed \
+                 (None) — got {} record(s): {trace:?}",
+                trace.len()
+            );
+        }
+
+        /// #682 Stage 4: armed, `encode_moe_ffn` records exactly the forced
+        /// routing selection (post-renormalization gate weights) for each
+        /// decoded token, keyed by the real `(layer_idx, token_idx)` the
+        /// token was decoded at — `token_idx` reading back `0` then `1`
+        /// (not e.g. a call counter reading `0` then `1`-per-layer, which
+        /// would coincide here since this fixture has one MoE layer) proves
+        /// `position` is the value actually threaded through
+        /// `encode_mlp_block` into `encode_moe_ffn`. Also exercises
+        /// `dump_moe_routing_trace_jsonl`'s round-trip.
+        ///
+        /// Mutation check, manually verified (not compiled in): commenting
+        /// out the `trace.push(MoeRoutingTraceRecord { .. })` call inside
+        /// `encode_moe_ffn`'s `MOE_ROUTING_TRACE.with(..)` block makes this
+        /// test fail — `take_moe_routing_trace()` returns an empty `Vec`
+        /// instead of the two expected records.
+        #[test]
+        fn moe_routing_trace_armed_records_forced_selection() {
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            let cfg = synthetic_moe_test_config_top_k2();
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let dir = tmp.path();
+            write_synthetic_moe_checkpoint(
+                dir,
+                &cfg,
+                moe_fixture_gate_const,
+                moe_fixture_up_const,
+                moe_fixture_down_const,
+            );
+            let tokenizer_path = std::path::Path::new("/dev/null");
+            let mut state = MetalQwen35State::from_q4_dir(dir, tokenizer_path, &cfg, 16)
+                .expect("from_q4_dir (top_k=2) must load");
+
+            let _ = take_moe_routing_trace(); // start from a known-disarmed state
+            arm_moe_routing_trace();
+
+            let _forced0 = ForcedMoeExpertsGuard::set(vec![2, 3]);
+            let logits0 = state.forward_step(1, 0);
+            assert!(logits0.iter().all(|v| v.is_finite()));
+            drop(_forced0);
+
+            let _forced1 = ForcedMoeExpertsGuard::set(vec![2, 1]);
+            let logits1 = state.forward_step(2, 1);
+            assert!(logits1.iter().all(|v| v.is_finite()));
+            drop(_forced1);
+
+            let trace = take_moe_routing_trace();
+            assert_eq!(
+                trace.len(),
+                2,
+                "expected exactly one record per decoded token (1 MoE layer x 2 tokens): {trace:?}"
+            );
+            assert_eq!(trace[0].layer_idx, 0);
+            assert_eq!(trace[0].token_idx, 0);
+            assert_eq!(trace[0].selected_ids, vec![2, 3]);
+            assert_eq!(trace[1].layer_idx, 0);
+            assert_eq!(trace[1].token_idx, 1);
+            assert_eq!(trace[1].selected_ids, vec![2, 1]);
+            for record in &trace {
+                assert_eq!(record.gate_weights.len(), 2);
+                for w in &record.gate_weights {
+                    assert!(
+                        (w - 0.5).abs() < 1e-6,
+                        "forced top_k=2 equal-weight gate renormalizes to 0.5 each: {trace:?}"
+                    );
+                }
+            }
+
+            let dump_path = dir.join("routing_trace.jsonl");
+            dump_moe_routing_trace_jsonl(&trace, &dump_path).expect("jsonl dump must succeed");
+            let dumped = std::fs::read_to_string(&dump_path).expect("read back jsonl");
+            let lines: Vec<&str> = dumped.lines().collect();
+            assert_eq!(lines.len(), 2, "one JSONL line per record: {dumped:?}");
+            let parsed: MoeRoutingTraceRecord =
+                serde_json::from_str(lines[0]).expect("line 0 must parse as MoeRoutingTraceRecord");
+            assert_eq!(parsed.token_idx, 0);
+            assert_eq!(parsed.selected_ids, vec![2, 3]);
+
+            // Collector auto-disarms on take; a follow-up decode must not append further.
+            let _more = state.forward_step(3, 2);
+            assert!(take_moe_routing_trace().is_empty());
         }
 
         /// Mutation check for the test above: deliberately break
@@ -32610,8 +32824,9 @@ mod gdn_state_traffic_tests {
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub use inner::{
     ChatCompletionOutput, ChatMessage, ChatRole, LayerImportanceScore, LayerPruningPlan,
-    LoraLayerData, MetalQwen35State, PathProofSnapshot, blend_lora_layer_data,
-    format_chat_template,
+    LoraLayerData, MetalQwen35State, MoeRoutingTraceRecord, PathProofSnapshot,
+    arm_moe_routing_trace, blend_lora_layer_data, dump_moe_routing_trace_jsonl,
+    format_chat_template, take_moe_routing_trace,
 };
 
 #[cfg(all(

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -19542,13 +19542,13 @@ mod inner {
         /// #682 Stage 4: armed, `encode_moe_ffn` records exactly the forced
         /// routing selection (post-renormalization gate weights) for each
         /// decoded token, keyed by the real `(layer_idx, token_idx)` the
-        /// token was decoded at. Because each position is normally decoded
-        /// exactly once, a per-layer invocation counter stays numerically
-        /// equal to the decode position no matter which positions are
-        /// chosen — so the discriminating probe here is the third decode,
-        /// which REPEATS position `1`: the threaded `position` reads back
-        /// `1` again, while any invocation counter (since arm or since
-        /// state creation) would have advanced to a new value. That third
+        /// token was decoded at. For the ordinary contiguous `0, 1` decode
+        /// sequence used here, a per-layer invocation counter is numerically
+        /// identical to the decode position, so the first two records cannot
+        /// discriminate the two — the discriminating probe is the third
+        /// decode, which REPEATS position `1`: the threaded `position` reads
+        /// back `1` again, while any invocation counter (since arm or since
+        /// state creation) would have advanced to `2`. That third
         /// record is what proves `position` is the value actually threaded
         /// through `encode_mlp_block` into `encode_moe_ffn`. Also exercises
         /// `dump_moe_routing_trace_jsonl`'s round-trip.
@@ -19557,7 +19557,7 @@ mod inner {
         /// compiled in): commenting out the `trace.push(MoeRoutingTraceRecord
         /// { .. })` call inside `encode_moe_ffn`'s `MOE_ROUTING_TRACE.with(..)`
         /// block makes this test fail — `take_moe_routing_trace()` returns an
-        /// empty `Vec` instead of the two expected records.
+        /// empty `Vec` instead of the three expected records.
         #[test]
         fn moe_routing_trace_armed_records_forced_selection() {
             let Some(_) = Device::system_default() else {
@@ -19592,11 +19592,13 @@ mod inner {
             assert!(logits1.iter().all(|v| v.is_finite()));
             drop(_forced1);
 
-            // Third decode REPEATS position 1 (mechanically fine: it just
-            // rewrites that KV slot). This is the counter-vs-position
-            // discriminator: a per-layer invocation counter — since arm or
-            // since state creation — has advanced past 1 by this third
-            // call, so only the genuinely threaded `position` reads 1 here.
+            // Third decode REPEATS position 1. Mechanically safe: raw
+            // `forward_step` has no position-monotonicity check, and the KV
+            // write appends at `seq_len` (slot 2) while applying RoPE
+            // position 1, well below capacity. This is the counter-vs-
+            // position discriminator: a per-layer invocation counter — since
+            // arm or since state creation — has advanced past 1 by this
+            // third call, so only the genuinely threaded `position` reads 1.
             let _forced2 = ForcedMoeExpertsGuard::set(vec![0, 3]);
             let logits2 = state.forward_step(3, 1);
             assert!(logits2.iter().all(|v| v.is_finite()));

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -19542,11 +19542,15 @@ mod inner {
         /// #682 Stage 4: armed, `encode_moe_ffn` records exactly the forced
         /// routing selection (post-renormalization gate weights) for each
         /// decoded token, keyed by the real `(layer_idx, token_idx)` the
-        /// token was decoded at — `token_idx` reading back `0` then `1`
-        /// (not e.g. a call counter reading `0` then `1`-per-layer, which
-        /// would coincide here since this fixture has one MoE layer) proves
-        /// `position` is the value actually threaded through
-        /// `encode_mlp_block` into `encode_moe_ffn`. Also exercises
+        /// token was decoded at. Because each position is normally decoded
+        /// exactly once, a per-layer invocation counter stays numerically
+        /// equal to the decode position no matter which positions are
+        /// chosen — so the discriminating probe here is the third decode,
+        /// which REPEATS position `1`: the threaded `position` reads back
+        /// `1` again, while any invocation counter (since arm or since
+        /// state creation) would have advanced to a new value. That third
+        /// record is what proves `position` is the value actually threaded
+        /// through `encode_mlp_block` into `encode_moe_ffn`. Also exercises
         /// `dump_moe_routing_trace_jsonl`'s round-trip.
         ///
         /// Mutation check (documented for the reviewer to exercise, not
@@ -19588,11 +19592,21 @@ mod inner {
             assert!(logits1.iter().all(|v| v.is_finite()));
             drop(_forced1);
 
+            // Third decode REPEATS position 1 (mechanically fine: it just
+            // rewrites that KV slot). This is the counter-vs-position
+            // discriminator: a per-layer invocation counter — since arm or
+            // since state creation — has advanced past 1 by this third
+            // call, so only the genuinely threaded `position` reads 1 here.
+            let _forced2 = ForcedMoeExpertsGuard::set(vec![0, 3]);
+            let logits2 = state.forward_step(3, 1);
+            assert!(logits2.iter().all(|v| v.is_finite()));
+            drop(_forced2);
+
             let trace = take_moe_routing_trace();
             assert_eq!(
                 trace.len(),
-                2,
-                "expected exactly one record per decoded token (1 MoE layer x 2 tokens): {trace:?}"
+                3,
+                "expected exactly one record per decode call (1 MoE layer x 3 calls): {trace:?}"
             );
             assert_eq!(trace[0].layer_idx, 0);
             assert_eq!(trace[0].token_idx, 0);
@@ -19600,6 +19614,13 @@ mod inner {
             assert_eq!(trace[1].layer_idx, 0);
             assert_eq!(trace[1].token_idx, 1);
             assert_eq!(trace[1].selected_ids, vec![2, 1]);
+            assert_eq!(trace[2].layer_idx, 0);
+            assert_eq!(
+                trace[2].token_idx, 1,
+                "repeated-position decode must record the threaded position (1), \
+                 not an invocation count (which would be 2 by this call): {trace:?}"
+            );
+            assert_eq!(trace[2].selected_ids, vec![0, 3]);
             for record in &trace {
                 assert_eq!(record.gate_weights.len(), 2);
                 for w in &record.gate_weights {
@@ -19614,7 +19635,7 @@ mod inner {
             dump_moe_routing_trace_jsonl(&trace, &dump_path).expect("jsonl dump must succeed");
             let dumped = std::fs::read_to_string(&dump_path).expect("read back jsonl");
             let lines: Vec<&str> = dumped.lines().collect();
-            assert_eq!(lines.len(), 2, "one JSONL line per record: {dumped:?}");
+            assert_eq!(lines.len(), 3, "one JSONL line per record: {dumped:?}");
             let parsed: MoeRoutingTraceRecord =
                 serde_json::from_str(lines[0]).expect("line 0 must parse as MoeRoutingTraceRecord");
             assert_eq!(parsed.token_idx, 0);

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -19491,11 +19491,11 @@ mod inner {
         /// disarmed, and the collector must stay disarmed rather than
         /// silently self-arming on first use.
         ///
-        /// Mutation check, manually verified (not compiled in): replacing
-        /// `encode_moe_ffn`'s `if let Some(trace) = c.borrow_mut().as_mut()
-        /// { trace.push(..) }` guard with an unconditional
-        /// `c.borrow_mut().get_or_insert_with(Vec::new).push(..)` (the
-        /// collector self-arming instead of staying `None`) makes this test
+        /// Mutation check (documented for the reviewer to exercise, not
+        /// compiled in): replacing `encode_moe_ffn`'s `if let Some(trace) =
+        /// c.borrow_mut().as_mut() { trace.push(..) }` guard with an
+        /// unconditional `c.borrow_mut().get_or_insert_with(Vec::new).push(..)`
+        /// (the collector self-arming instead of staying `None`) makes this test
         /// fail: `take_moe_routing_trace()` returns 2 records instead of the
         /// expected empty trace.
         #[test]
@@ -19549,11 +19549,11 @@ mod inner {
         /// `encode_mlp_block` into `encode_moe_ffn`. Also exercises
         /// `dump_moe_routing_trace_jsonl`'s round-trip.
         ///
-        /// Mutation check, manually verified (not compiled in): commenting
-        /// out the `trace.push(MoeRoutingTraceRecord { .. })` call inside
-        /// `encode_moe_ffn`'s `MOE_ROUTING_TRACE.with(..)` block makes this
-        /// test fail — `take_moe_routing_trace()` returns an empty `Vec`
-        /// instead of the two expected records.
+        /// Mutation check (documented for the reviewer to exercise, not
+        /// compiled in): commenting out the `trace.push(MoeRoutingTraceRecord
+        /// { .. })` call inside `encode_moe_ffn`'s `MOE_ROUTING_TRACE.with(..)`
+        /// block makes this test fail — `take_moe_routing_trace()` returns an
+        /// empty `Vec` instead of the two expected records.
         #[test]
         fn moe_routing_trace_armed_records_forced_selection() {
             let Some(_) = Device::system_default() else {


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Part of #682 (stage 4 of the MoE work; builds on the stage-3 prefetch overlap merged in #895).

## What

Adds an optional, off-by-default per-token routing-divergence trace collector to the Metal MoE FFN path, so an external evaluation harness can record which experts the CPU top-k router selected for each token at each MoE layer (and their post-renormalization gate weights) and diff a quantized arm against a full-precision reference (set agreement / Jaccard).

All changes are confined to `crates/inference/src/forward/metal_qwen35.rs`.

### New public surface (`inner` module)

```rust
pub struct MoeRoutingTraceRecord { layer_idx, token_idx, selected_ids: Vec<usize>, gate_weights: Vec<f32> }
pub fn arm_moe_routing_trace()                       // arm on this thread
pub fn take_moe_routing_trace() -> Vec<MoeRoutingTraceRecord>  // disarm + drain
pub fn dump_moe_routing_trace_jsonl(records, path) -> io::Result<()>  // NDJSON
```

The collector is a thread-local `RefCell<Option<Vec<..>>>` initialized to `None`. It uses the same arm / drain-via-free-function shape as the pre-existing `FORCED_MOE_EXPERTS_FOR_TEST` seam, but is deliberately **not** `#[cfg(test)]`-gated because production harnesses (e.g. a perplexity/agreement eval) arm it outside of tests.

### Plumbing

The real decode `position` is threaded through `encode_mlp_block` → `encode_moe_ffn` so the recorded `token_idx` is the actual token position, not a call counter. This is the only change to existing method signatures (all private to the `inner` module), and the value was already available at every call site.

## Default-path cost

When disarmed (the production default), the only added work in `encode_moe_ffn` is one `MOE_ROUTING_TRACE.with(|c| if let Some(..) = c.borrow_mut().as_mut() { .. })` — a single branch on an unset thread-local, no allocation, no clone. The record's `Vec` allocations happen only when armed.

## Tests

Two tests in the `inner` test module, both requiring a real Metal device (they early-return when `Device::system_default()` is `None`, so they run on a Metal host and skip on the paravirtual CI GPU):

- `moe_routing_trace_disarmed_records_nothing` — after two decoded tokens with the collector never armed, `take_moe_routing_trace()` returns empty.
- `moe_routing_trace_armed_records_forced_selection` — with the collector armed and experts forced, records exactly the forced selection per decode call, keyed by the real `(layer_idx, token_idx)`. For the contiguous `0, 1` decode sequence the test uses, a per-layer invocation counter is numerically identical to the decode position, so those records alone cannot discriminate the two — the discriminating probe is a third decode that **repeats position 1**: the threaded `position` reads back 1 again while any counter (since arm or since state creation) has advanced to 2. Mechanically safe: `forward_step` has no position-monotonicity check and the KV write appends at `seq_len` while applying RoPE position 1. Also round-trips `dump_moe_routing_trace_jsonl` (3 records, 3 NDJSON lines).

**Mutation evidence (empirically run on a real Metal device in this session, commit `9efd3eed40`):** all three documented mutations were exercised, each made its test fail, and both tests pass with the real code restored — (1) recording an invocation counter instead of `token_idx` fails the armed test's repeated-position assertion (counter reads 2 where position reads 1); (2) self-arming the guard (`get_or_insert_with`) fails the disarmed test; (3) deleting the `trace.push` fails the armed test's record-count assertion. CI's paravirtual GPU still skips these tests, so the guard is real-Metal-host only.

## bench-compare

Per ADR-058. This diff touches no CPU elementwise kernel (`elementwise_cpu_bench`) and no `lattice-embed` SIMD code; the only added default-path instruction is a branch-on-`None` inside the Metal MoE FFN encode, which no benched group invokes. No measured group can be exercised differently by this change.

The A/B run was executed three times (once contended, twice in verified-idle exclusive windows). All runs, **and a same-commit A/A control on this host** (identical SHA as both base and head, exclusive heavy-job lock, idle machine), report FAIL rows above the 7% gate — the A/A control alone shows 4 FAIL / 7 WARN with every deviation positive (`add_bias_gelu/4096 +17.9%`, `gelu/4096 +15.5%`, `simd_normalize/simd/384 +12.4%`). The quick-mode gate's false-positive floor on this host currently exceeds its own threshold across groups beyond the two allowlisted by #714. The table below is attached as environment evidence, not a regression signal; this PR makes no performance claim. (Host bench-integrity issue is being raised separately.)

<details>
<summary><code>make bench-compare</code> idle-window run (origin/main b118d3871b vs HEAD 1dd4db023c, --quick, exclusive lane, idle host)</summary>

```
**❌ 4 FAIL** (regression >7.0% confirmed by 95% CI)
**⚠ 2 WARN** (regression 3.0-7.0% confirmed)
**🚀 99 confirmed improvement**

| Bench | Δ point | 95% CI | new ns | base ns | verdict |
|---|---:|---|---:|---:|---|
| `rms_norm/4096` | +16.02% | [+13.78%, +18.33%] | 682.0 | 587.9 | ❌ FAIL |
| `residual_add_layer_norm/unfused/hidden768_seq128` | +13.32% | [+11.42%, +15.26%] | 105923.4 | 93474.8 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/384d_64c` | +10.00% | [+9.43%, +10.57%] | 1113.1 | 1012.0 | ❌ FAIL |
| `add_bias_gelu/4096` | +11.66% | [+7.70%, +15.70%] | 2047.8 | 1834.0 | ❌ FAIL |
| `simd_normalize/simd/384` | +5.53% | [+3.17%, +7.89%] | 80.7 | 76.5 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/simd_batch/768d_64c` | +3.51% | [+3.13%, +3.89%] | 4216.0 | 4073.1 | ⚠ WARN |
| `simd_normalized_cosine_fast_path/cosine_full/1024` | -3.09% | [-3.35%, -2.82%] | 88.9 | 91.8 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_16c` | -3.21% | [-3.91%, -2.49%] | 496.1 | 512.5 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_1000c` | -3.73% | [-3.94%, -3.52%] | 83018.8 | 86234.7 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_64c` | -3.64% | [-3.94%, -3.34%] | 5277.2 | 5476.6 | 🚀 WIN |
| `tier_prepared_query/int8_query_once_1000` | -3.29% | [-4.21%, -2.37%] | 12251.8 | 12669.0 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8/768` | -3.57% | [-4.24%, -2.90%] | 17.9 | 18.5 | 🚀 WIN |
| `int4_cosine_distance/float32_simd/768` | -3.39% | [-4.38%, -2.39%] | 70.7 | 73.2 | 🚀 WIN |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/768` | -3.47% | [-4.48%, -2.44%] | 64279.5 | 66588.5 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_4c` | -3.31% | [-4.49%, -2.10%] | 132.6 | 137.2 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/384` | -3.80% | [-4.60%, -2.99%] | 8.6 | 9.0 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_1000c` | -4.09% | [-4.61%, -3.58%] | 81948.0 | 85446.5 | 🚀 WIN |
| `int8_prepared_dot_product/per_call/768` | -3.90% | [-4.72%, -3.07%] | 2269.3 | 2361.4 | 🚀 WIN |
| `simd_query_batch_dot_product/pair_loop/384d_256c` | -4.17% | [-4.75%, -3.58%] | 8353.7 | 8716.9 | 🚀 WIN |
| `simd_batch_dot_product/simd_batch/10` | -3.62% | [-4.80%, -2.41%] | 238.4 | 247.3 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c` | -4.40% | [-4.82%, -3.98%] | 5171.0 | 5409.0 | 🚀 WIN |
| `int8_batch_cosine/int8_loop/10` | -4.27% | [-4.90%, -3.63%] | 114.2 | 119.3 | 🚀 WIN |
| `simd_query_batch_dot_product/simd_batch/128d_256c` | -3.83% | [-5.03%, -2.63%] | 1987.8 | 2067.1 | 🚀 WIN |
| `simd_euclidean_distance/scalar/384` | -3.12% | [-5.07%, -1.16%] | 250.5 | 258.5 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_1000c` | -4.87% | [-5.23%, -4.52%] | 31682.3 | 33304.7 | 🚀 WIN |
| `simd_squared_euclidean_fast_path/squared_euclidean/1024` | -3.25% | [-5.23%, -1.21%] | 76.8 | 79.4 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_256c` | -3.90% | [-5.45%, -2.31%] | 8341.9 | 8680.6 | 🚀 WIN |
| `int4_cosine_distance/int4/768` | -3.43% | [-5.49%, -1.29%] | 46.3 | 47.9 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/768` | -4.70% | [-5.49%, -3.89%] | 16.2 | 17.0 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_64c` | -4.22% | [-5.64%, -2.77%] | 5379.4 | 5616.5 | 🚀 WIN |
| `simd_prepared_query_normalized_cosine/dot_product_loop/384` | -5.16% | [-5.77%, -4.55%] | 33028.1 | 34825.3 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_64c` | -3.79% | [-5.78%, -1.74%] | 4122.3 | 4284.7 | 🚀 WIN |
| `simd_euclidean_distance/simd/1024` | -3.97% | [-5.89%, -1.99%] | 78.1 | 81.4 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/simd_batch/384d_16c` | -4.45% | [-6.01%, -2.83%] | 498.1 | 521.3 | 🚀 WIN |
| `simd_normalize/scalar/1024` | -5.33% | [-6.06%, -4.60%] | 973.3 | 1028.1 | 🚀 WIN |
| `tier_prepared_batch_sizes/int8_batch_prepared/1000` | -5.38% | [-6.37%, -4.38%] | 10610.1 | 11213.3 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_16c` | -5.44% | [-6.38%, -4.49%] | 1163.0 | 1229.9 | 🚀 WIN |
| `simd_normalize/scalar/768` | -4.79% | [-6.57%, -2.96%] | 748.8 | 786.5 | 🚀 WIN |
| `tier_prepared_batch_sizes/int4_batch_prepared/10` | -3.86% | [-6.62%, -0.96%] | 246.2 | 256.1 | 🚀 WIN |
| `binary_cosine_distance/binary/384` | -5.63% | [-6.76%, -4.47%] | 2.8 | 3.0 | 🚀 WIN |
| `binary_cosine_distance/binary/1536` | -5.98% | [-6.85%, -5.09%] | 7.0 | 7.4 | 🚀 WIN |
| `int8_prepared_dot_product/prepared/128` | -4.73% | [-6.90%, -2.48%] | 5.0 | 5.3 | 🚀 WIN |
| `simd_euclidean_distance/simd/384` | -4.55% | [-6.93%, -2.07%] | 29.8 | 31.2 | 🚀 WIN |
| `int8_prepared_dot_product/prepared/384` | -5.79% | [-7.40%, -4.13%] | 10.0 | 10.7 | 🚀 WIN |
| `simd_batch_cosine/simd_batch/1000` | -5.93% | [-7.48%, -4.35%] | 40083.3 | 42610.1 | 🚀 WIN |
| `softmax_attention/128` | -5.49% | [-7.79%, -3.09%] | 4143.0 | 4383.4 | 🚀 WIN |
| `simd_query_batch_dot_product/simd_batch/768d_64c` | -4.73% | [-7.99%, -1.34%] | 3131.8 | 3287.4 | 🚀 WIN |
| `int4_cosine_distance/float32_simd/1536` | -5.44% | [-8.11%, -2.66%] | 131.8 | 139.4 | 🚀 WIN |
| `simd_query_batch_dot_product/pair_loop/768d_64c` | -5.77% | [-8.16%, -3.26%] | 4120.6 | 4372.9 | 🚀 WIN |
| `simd_query_batch_dot_product/pair_loop/128d_4c` | -6.24% | [-8.64%, -3.74%] | 52.9 | 56.4 | 🚀 WIN |
| `simd_normalize/simd/768` | -6.01% | [-8.73%, -3.19%] | 142.5 | 151.6 | 🚀 WIN |
| `int8_vs_float32_cosine/float32_simd/1536` | -7.39% | [-9.14%, -5.61%] | 130.1 | 140.5 | 🚀 WIN |
| `int8_prepared_dot_product/per_call/127` | -8.28% | [-9.20%, -7.34%] | 358.6 | 390.9 | 🚀 WIN |
| `int8_batch_cosine/int8_loop/100` | -6.47% | [-9.29%, -3.49%] | 942.6 | 1007.7 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_256c` | -7.03% | [-9.35%, -4.60%] | 8624.7 | 9276.7 | 🚀 WIN |
| `tier_prepared_batch_sizes/int4_batch_prepared/100` | -8.47% | [-9.48%, -7.44%] | 2365.6 | 2584.6 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/129` | -7.15% | [-9.55%, -4.69%] | 4.8 | 5.2 | 🚀 WIN |
| `simd_normalized_cosine_fast_path/dot_product/768` | -8.25% | [-9.92%, -6.51%] | 56.7 | 61.8 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8/129` | -7.44% | [-9.96%, -4.82%] | 5.4 | 5.8 | 🚀 WIN |
| `simd_normalize/simd/1024` | -9.71% | [-10.91%, -8.50%] | 171.7 | 190.2 | 🚀 WIN |
| `simd_normalized_cosine_fast_path/dot_product/384` | -10.66% | [-11.65%, -9.66%] | 28.0 | 31.4 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_1000c` | -10.85% | [-11.89%, -9.80%] | 86928.8 | 97507.2 | 🚀 WIN |
| `int8_prepared_dot_product/per_call/384` | -11.04% | [-11.93%, -10.16%] | 1124.7 | 1264.4 | 🚀 WIN |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/384` | -9.29% | [-12.50%, -5.91%] | 35885.7 | 39560.3 | 🚀 WIN |
| `int8_batch_cosine/float32_simd/10` | -13.16% | [-13.51%, -12.81%] | 323.8 | 372.9 | 🚀 WIN |
| `int8_batch_cosine/float32_simd/100` | -11.77% | [-14.22%, -9.21%] | 4721.6 | 5351.2 | 🚀 WIN |
| `simd_normalize/simd/1536` | -11.38% | [-14.25%, -8.40%] | 256.5 | 289.4 | 🚀 WIN |
| `simd_euclidean_distance/scalar/768` | -13.57% | [-14.77%, -12.35%] | 593.2 | 686.4 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_1000c` | -12.98% | [-15.39%, -10.50%] | 33550.2 | 38553.4 | 🚀 WIN |
| `softmax_attention/512` | -11.89% | [-15.64%, -7.83%] | 73973.2 | 83958.4 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/1024` | -14.62% | [-16.18%, -13.01%] | 26.8 | 31.4 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_256c` | -17.01% | [-18.08%, -15.92%] | 16588.6 | 19989.5 | 🚀 WIN |
| `simd_normalized_cosine_fast_path/cosine_full/384` | -16.74% | [-18.12%, -15.31%] | 39.2 | 47.1 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_1000c` | -15.19% | [-18.72%, -11.37%] | 85439.8 | 100748.3 | 🚀 WIN |
| `int8_prepared_dot_product/prepared/1024` | -16.48% | [-18.85%, -13.97%] | 24.8 | 29.6 | 🚀 WIN |
| `binary_cosine_distance/float32_simd/384` | -18.20% | [-20.44%, -15.84%] | 38.9 | 47.5 | 🚀 WIN |
| `simd_query_batch_dot_product/pair_loop/384d_4c` | -20.26% | [-21.44%, -19.03%] | 119.0 | 149.3 | 🚀 WIN |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/1024` | -21.77% | [-22.23%, -21.31%] | 89062.6 | 113843.8 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/1536` | -20.53% | [-22.54%, -18.42%] | 35.7 | 45.0 | 🚀 WIN |
| `simd_batch_cosine/simd_batch/100` | -22.00% | [-25.48%, -18.28%] | 4305.1 | 5519.5 | 🚀 WIN |
| `layer_norm/4096` | -25.18% | [-25.51%, -24.85%] | 902.8 | 1206.6 | 🚀 WIN |
| `simd_euclidean_distance/simd/1536` | -21.89% | [-30.49%, -10.97%] | 117.2 | 150.1 | 🚀 WIN |
| `int4_cosine_distance/int4/384` | -30.94% | [-31.09%, -30.78%] | 24.6 | 35.6 | 🚀 WIN |
| `simd_batch_cosine/scalar_loop/1000` | -27.48% | [-31.30%, -23.22%] | 687446.3 | 947980.2 | 🚀 WIN |
| `int8_prepared_dot_product/per_call/1024` | -31.02% | [-32.89%, -29.04%] | 3067.6 | 4447.0 | 🚀 WIN |
| `add_bias_gelu/896` | -30.22% | [-33.88%, -26.15%] | 395.3 | 566.6 | 🚀 WIN |
| `simd_euclidean_distance/simd/768` | -39.82% | [-43.37%, -35.82%] | 59.3 | 98.5 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_64c` | -41.64% | [-43.80%, -39.34%] | 1970.9 | 3377.3 | 🚀 WIN |
| `simd_normalize/scalar/1536` | -43.81% | [-44.73%, -42.89%] | 1498.5 | 2666.8 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/384` | -44.28% | [-46.05%, -42.42%] | 10.6 | 19.0 | 🚀 WIN |
| `tier_prepared_batch_sizes/int8_query_per_call/100` | -44.94% | [-46.63%, -43.16%] | 111897.3 | 203234.9 | 🚀 WIN |
| `silu_inplace/4096` | -31.30% | [-46.73%, -3.60%] | 2080.9 | 3028.9 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_64c` | -49.94% | [-50.88%, -48.97%] | 2013.1 | 4021.6 | 🚀 WIN |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_16c` | -50.25% | [-54.16%, -45.76%] | 493.5 | 992.1 | 🚀 WIN |
| `rms_norm/896` | -48.97% | [-54.89%, -41.34%] | 133.8 | 262.3 | 🚀 WIN |
| `tier_prepared_query/binary_query_per_call_1000` | -54.09% | [-54.95%, -53.20%] | 890150.1 | 1938909.8 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/128` | -54.43% | [-57.93%, -50.36%] | 4.6 | 10.0 | 🚀 WIN |
| `simd_normalized_cosine_fast_path/cosine_full/768` | -56.77% | [-58.04%, -55.43%] | 69.9 | 161.7 | 🚀 WIN |
| `int4_cosine_distance/float32_simd/384` | -54.48% | [-59.14%, -48.63%] | 39.1 | 85.8 | 🚀 WIN |
| `simd_batch_cosine/simd_batch/10` | -53.85% | [-61.33%, -42.86%] | 315.7 | 684.0 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8/128` | -60.80% | [-64.68%, -55.97%] | 4.9 | 12.4 | 🚀 WIN |
| `tier_prepared_query/binary_query_once_1000` | -60.85% | [-64.69%, -56.09%] | 4320.0 | 11033.3 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8/127` | -69.00% | [-69.52%, -68.47%] | 6.8 | 22.1 | 🚀 WIN |
| `simd_batch_cosine/scalar_loop/100` | -68.81% | [-69.69%, -67.90%] | 68585.6 | 219914.2 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/127` | -77.42% | [-78.12%, -76.70%] | 7.0 | 31.1 | 🚀 WIN |

**ℹ️ 16 informational** (below quick-mode resolution — lattice-embed SIMD micro-benches, tracked in #714; not gated here, re-run `--full` for a gated verdict)
| Bench | Δ point | 95% CI | new ns | base ns | (would-be verdict) |
|---|---:|---|---:|---:|---|
| `simd_dot_product/simd/1536` | -5.14% | [-8.04%, -2.10%] | 118.6 | 125.0 | 🚀 WIN (informational) |
| `simd_dot_product/simd/1024` | -7.53% | [-10.37%, -4.54%] | 76.7 | 83.0 | 🚀 WIN (informational) |
| `simd_dot_product/simd/768` | -28.65% | [-31.17%, -25.99%] | 58.5 | 82.1 | 🚀 WIN (informational) |
| `simd_dot_product/scalar/1024` | -45.18% | [-51.49%, -37.16%] | 834.0 | 1521.4 | 🚀 WIN (informational) |
| `simd_dot_product/scalar/768` | -66.67% | [-67.50%, -65.80%] | 587.1 | 1761.6 | 🚀 WIN (informational) |
| `simd_dot_product/scalar/384` | -79.77% | [-79.98%, -79.56%] | 233.8 | 1155.6 | 🚀 WIN (informational) |
| `simd_dot_product/simd/384` | -77.60% | [-80.12%, -74.37%] | 27.7 | 123.8 | 🚀 WIN (informational) |
| `simd_cosine_similarity/scalar/1536` | -79.57% | [-80.70%, -78.35%] | 3964.9 | 19406.1 | 🚀 WIN (informational) |
| `simd_cosine_similarity/simd/384` | -78.27% | [-81.06%, -74.58%] | 39.1 | 180.1 | 🚀 WIN (informational) |
| `simd_cosine_similarity/simd/1024` | -81.62% | [-82.23%, -80.97%] | 90.3 | 491.5 | 🚀 WIN (informational) |
| `simd_cosine_similarity/scalar/1024` | -81.83% | [-82.75%, -80.81%] | 2458.4 | 13530.1 | 🚀 WIN (informational) |
| `simd_cosine_similarity/scalar/384` | -82.23% | [-84.13%, -79.81%] | 699.9 | 3937.7 | 🚀 WIN (informational) |
| `simd_cosine_similarity/simd/768` | -83.22% | [-84.32%, -81.95%] | 69.1 | 411.8 | 🚀 WIN (informational) |
| `simd_cosine_similarity/scalar/768` | -85.18% | [-85.39%, -84.96%] | 1754.9 | 11839.5 | 🚀 WIN (informational) |
| `simd_cosine_similarity/simd/1536` | -85.71% | [-86.00%, -85.43%] | 128.5 | 899.4 | 🚀 WIN (informational) |

<details><summary>All 263 measurements</summary>

| Bench | Δ point | CI-lower | CI-upper |
|---|---:|---:|---:|
| `add_bias_gelu/4096` | +11.66% | +7.70% | +15.70% |
| `add_bias_gelu/896` | -30.22% | -33.88% | -26.15% |
| `binary_cosine_distance/binary/1024` | -0.54% | -1.53% | +0.46% |
| `binary_cosine_distance/binary/1536` | -5.98% | -6.85% | -5.09% |
| `binary_cosine_distance/binary/384` | -5.63% | -6.76% | -4.47% |
| `binary_cosine_distance/binary/768` | -0.88% | -0.94% | -0.83% |
| `binary_cosine_distance/float32_simd/1024` | -2.10% | -4.93% | +0.80% |
| `binary_cosine_distance/float32_simd/1536` | -0.69% | -1.91% | +0.54% |
| `binary_cosine_distance/float32_simd/384` | -18.20% | -20.44% | -15.84% |
| `binary_cosine_distance/float32_simd/768` | -2.33% | -5.17% | +0.55% |
| `elementwise_mul/4096` | -1.51% | -2.68% | -0.31% |
| `gelu/4096` | -1.29% | -2.84% | +0.29% |
| `gelu/896` | -2.36% | -3.32% | -1.39% |
| `int4_cosine_distance/float32_simd/1024` | -2.15% | -2.65% | -1.65% |
| `int4_cosine_distance/float32_simd/1536` | -5.44% | -8.11% | -2.66% |
| `int4_cosine_distance/float32_simd/384` | -54.48% | -59.14% | -48.63% |
| `int4_cosine_distance/float32_simd/768` | -3.39% | -4.38% | -2.39% |
| `int4_cosine_distance/int4/1024` | -2.12% | -4.89% | +0.77% |
| `int4_cosine_distance/int4/1536` | -1.32% | -1.54% | -1.09% |
| `int4_cosine_distance/int4/384` | -30.94% | -31.09% | -30.78% |
| `int4_cosine_distance/int4/768` | -3.43% | -5.49% | -1.29% |
| `int8_batch_cosine/float32_simd/10` | -13.16% | -13.51% | -12.81% |
| `int8_batch_cosine/float32_simd/100` | -11.77% | -14.22% | -9.21% |
| `int8_batch_cosine/float32_simd/1000` | -2.24% | -3.79% | -0.65% |
| `int8_batch_cosine/int8_loop/10` | -4.27% | -4.90% | -3.63% |
| `int8_batch_cosine/int8_loop/100` | -6.47% | -9.29% | -3.49% |
| `int8_batch_cosine/int8_loop/1000` | -0.84% | -2.81% | +1.13% |
| `int8_prepared_dot_product/per_call/1024` | -31.02% | -32.89% | -29.04% |
| `int8_prepared_dot_product/per_call/127` | -8.28% | -9.20% | -7.34% |
| `int8_prepared_dot_product/per_call/128` | -0.41% | -3.25% | +2.48% |
| `int8_prepared_dot_product/per_call/129` | -2.24% | -2.76% | -1.71% |
| `int8_prepared_dot_product/per_call/384` | -11.04% | -11.93% | -10.16% |
| `int8_prepared_dot_product/per_call/768` | -3.90% | -4.72% | -3.07% |
| `int8_prepared_dot_product/prepared/1024` | -16.48% | -18.85% | -13.97% |
| `int8_prepared_dot_product/prepared/127` | -0.95% | -1.30% | -0.60% |
| `int8_prepared_dot_product/prepared/128` | -4.73% | -6.90% | -2.48% |
| `int8_prepared_dot_product/prepared/129` | -2.72% | -3.35% | -2.09% |
| `int8_prepared_dot_product/prepared/384` | -5.79% | -7.40% | -4.13% |
| `int8_prepared_dot_product/prepared/768` | -2.57% | -3.63% | -1.50% |
| `int8_quantization/quantize/1024` | -1.12% | -2.17% | -0.07% |
| `int8_quantization/quantize/1536` | -1.06% | -1.93% | -0.19% |
| `int8_quantization/quantize/384` | -2.18% | -3.16% | -1.18% |
| `int8_quantization/quantize/768` | -2.28% | -3.30% | -1.25% |
| `int8_raw_dot_product/dot_product_i8/1024` | -0.66% | -1.29% | -0.03% |
| `int8_raw_dot_product/dot_product_i8/127` | -69.00% | -69.52% | -68.47% |
| `int8_raw_dot_product/dot_product_i8/128` | -60.80% | -64.68% | -55.97% |
| `int8_raw_dot_product/dot_product_i8/129` | -7.44% | -9.96% | -4.82% |
| `int8_raw_dot_product/dot_product_i8/384` | -2.17% | -2.75% | -1.58% |
| `int8_raw_dot_product/dot_product_i8/768` | -3.57% | -4.24% | -2.90% |
| `int8_raw_dot_product/dot_product_i8_raw/1024` | -2.64% | -3.06% | -2.21% |
| `int8_raw_dot_product/dot_product_i8_raw/127` | -77.42% | -78.12% | -76.70% |
| `int8_raw_dot_product/dot_product_i8_raw/128` | -54.43% | -57.93% | -50.36% |
| `int8_raw_dot_product/dot_product_i8_raw/129` | -7.15% | -9.55% | -4.69% |
| `int8_raw_dot_product/dot_product_i8_raw/384` | -3.80% | -4.60% | -2.99% |
| `int8_raw_dot_product/dot_product_i8_raw/768` | -4.70% | -5.49% | -3.89% |
| `int8_vs_float32_cosine/float32_simd/1024` | -0.32% | -1.38% | +0.77% |
| `int8_vs_float32_cosine/float32_simd/1536` | -7.39% | -9.14% | -5.61% |
| `int8_vs_float32_cosine/float32_simd/384` | +1.05% | +0.28% | +1.83% |
| `int8_vs_float32_cosine/float32_simd/768` | -0.56% | -1.24% | +0.13% |
| `int8_vs_float32_cosine/int8/1024` | -14.62% | -16.18% | -13.01% |
| `int8_vs_float32_cosine/int8/1536` | -20.53% | -22.54% | -18.42% |
| `int8_vs_float32_cosine/int8/384` | -44.28% | -46.05% | -42.42% |
| `int8_vs_float32_cosine/int8/768` | -0.18% | -0.47% | +0.10% |
| `layer_norm/4096` | -25.18% | -25.51% | -24.85% |
| `layer_norm/896` | -2.19% | -3.09% | -1.29% |
| `memory_size/search_1000_float32` | -2.46% | -3.56% | -1.33% |
| `memory_size/search_1000_int8` | +0.16% | -0.83% | +1.16% |
| `residual_add_layer_norm/fused/hidden384_seq128` | -0.66% | -0.73% | -0.58% |
| `residual_add_layer_norm/fused/hidden768_seq128` | -0.24% | -1.35% | +0.90% |
| `residual_add_layer_norm/unfused/hidden384_seq128` | -1.05% | -1.25% | -0.84% |
| `residual_add_layer_norm/unfused/hidden768_seq128` | +13.32% | +11.42% | +15.26% |
| `rms_norm/4096` | +16.02% | +13.78% | +18.33% |
| `rms_norm/896` | -48.97% | -54.89% | -41.34% |
| `silu_inplace/4096` | -31.30% | -46.73% | -3.60% |
| `silu_inplace/896` | -2.52% | -3.60% | -1.43% |
| `simd_batch_cosine/scalar_loop/10` | -0.98% | -1.47% | -0.49% |
| `simd_batch_cosine/scalar_loop/100` | -68.81% | -69.69% | -67.90% |
| `simd_batch_cosine/scalar_loop/1000` | -27.48% | -31.30% | -23.22% |
| `simd_batch_cosine/simd_batch/10` | -53.85% | -61.33% | -42.86% |
| `simd_batch_cosine/simd_batch/100` | -22.00% | -25.48% | -18.28% |
| `simd_batch_cosine/simd_batch/1000` | -5.93% | -7.48% | -4.35% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_1000c` | -10.85% | -11.89% | -9.80% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_16c` | -1.90% | -2.77% | -1.03% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_256c` | -0.81% | -1.55% | -0.06% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_4c` | -0.73% | -2.09% | +0.64% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c` | +0.56% | -0.17% | +1.30% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_1000c` | -12.98% | -15.39% | -10.50% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_16c` | -3.21% | -3.91% | -2.49% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_256c` | -7.03% | -9.35% | -4.60% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_4c` | -3.31% | -4.49% | -2.10% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_64c` | -49.94% | -50.88% | -48.97% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_1000c` | -2.96% | -5.02% | -0.88% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_16c` | -1.16% | -2.29% | -0.02% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_256c` | -17.01% | -18.08% | -15.92% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_4c` | -2.50% | -3.13% | -1.86% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_64c` | -0.55% | -1.28% | +0.20% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_1000c` | -15.19% | -18.72% | -11.37% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_16c` | -2.44% | -5.12% | +0.38% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_256c` | -0.49% | -1.69% | +0.72% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_4c` | -1.41% | -1.74% | -1.08% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_64c` | +0.75% | +0.40% | +1.11% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_1000c` | -4.87% | -5.23% | -4.52% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_16c` | -50.25% | -54.16% | -45.76% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_256c` | +1.25% | +0.81% | +1.68% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_4c` | -2.71% | -3.23% | -2.18% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_64c` | -41.64% | -43.80% | -39.34% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_1000c` | -0.90% | -1.59% | -0.20% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_16c` | -0.01% | -0.38% | +0.36% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_256c` | -1.18% | -1.97% | -0.39% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_4c` | -1.11% | -1.73% | -0.48% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_64c` | -3.79% | -5.78% | -1.74% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_1000c` | -3.73% | -3.94% | -3.52% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_16c` | -2.17% | -2.55% | -1.79% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_256c` | -1.81% | -2.21% | -1.41% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_4c` | -1.04% | -2.30% | +0.24% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_64c` | -4.22% | -5.64% | -2.77% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_1000c` | -1.05% | -1.57% | -0.53% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_16c` | -1.87% | -2.71% | -1.03% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_256c` | -2.30% | -3.97% | -0.62% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_4c` | -0.85% | -1.74% | +0.06% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_64c` | +0.70% | -0.77% | +2.17% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_1000c` | -0.89% | -2.54% | +0.80% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_16c` | +1.61% | +0.87% | +2.35% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_256c` | -1.48% | -2.42% | -0.54% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_4c` | -1.52% | -1.75% | -1.28% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_64c` | +0.05% | -0.84% | +0.96% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_1000c` | -2.04% | -2.30% | -1.78% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_16c` | -5.44% | -6.38% | -4.49% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_256c` | -0.88% | -1.61% | -0.15% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_4c` | -1.73% | -2.30% | -1.16% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c` | -4.40% | -4.82% | -3.98% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_1000c` | -0.51% | -1.36% | +0.36% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_16c` | -2.26% | -3.51% | -0.99% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_256c` | -3.90% | -5.45% | -2.31% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_4c` | -1.54% | -2.12% | -0.96% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_64c` | -0.34% | -0.83% | +0.17% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_1000c` | -2.22% | -3.51% | -0.90% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_16c` | +1.15% | +0.59% | +1.71% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_256c` | +0.91% | +0.30% | +1.52% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_4c` | +1.38% | +0.74% | +2.02% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_64c` | -1.74% | -2.78% | -0.67% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_1000c` | -4.09% | -4.61% | -3.58% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_16c` | -2.57% | -3.02% | -2.13% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_256c` | -2.11% | -2.63% | -1.59% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_4c` | -0.56% | -2.19% | +1.09% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_64c` | -3.64% | -3.94% | -3.34% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_1000c` | -1.74% | -2.97% | -0.48% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_16c` | -4.45% | -6.01% | -2.83% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_256c` | +1.20% | -1.30% | +3.71% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_4c` | -2.46% | -2.73% | -2.18% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_64c` | +0.17% | -1.93% | +2.30% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_1000c` | -1.21% | -3.10% | +0.74% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_16c` | +0.76% | -0.19% | +1.72% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_256c` | -2.39% | -2.86% | -1.91% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_4c` | +1.20% | -0.47% | +2.92% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_64c` | +3.51% | +3.13% | +3.89% |
| `simd_batch_dot_product/scalar_loop/10` | -2.33% | -2.75% | -1.91% |
| `simd_batch_dot_product/scalar_loop/100` | -1.34% | -1.60% | -1.07% |
| `simd_batch_dot_product/scalar_loop/1000` | -1.92% | -3.78% | -0.00% |
| `simd_batch_dot_product/simd_batch/10` | -3.62% | -4.80% | -2.41% |
| `simd_batch_dot_product/simd_batch/100` | +2.46% | +1.93% | +2.99% |
| `simd_batch_dot_product/simd_batch/1000` | -0.00% | -0.49% | +0.48% |
| `simd_cosine_similarity/scalar/1024` | -81.83% | -82.75% | -80.81% |
| `simd_cosine_similarity/scalar/1536` | -79.57% | -80.70% | -78.35% |
| `simd_cosine_similarity/scalar/384` | -82.23% | -84.13% | -79.81% |
| `simd_cosine_similarity/scalar/768` | -85.18% | -85.39% | -84.96% |
| `simd_cosine_similarity/simd/1024` | -81.62% | -82.23% | -80.97% |
| `simd_cosine_similarity/simd/1536` | -85.71% | -86.00% | -85.43% |
| `simd_cosine_similarity/simd/384` | -78.27% | -81.06% | -74.58% |
| `simd_cosine_similarity/simd/768` | -83.22% | -84.32% | -81.95% |
| `simd_dot_product/scalar/1024` | -45.18% | -51.49% | -37.16% |
| `simd_dot_product/scalar/1536` | -1.73% | -3.47% | +0.07% |
| `simd_dot_product/scalar/384` | -79.77% | -79.98% | -79.56% |
| `simd_dot_product/scalar/768` | -66.67% | -67.50% | -65.80% |
| `simd_dot_product/simd/1024` | -7.53% | -10.37% | -4.54% |
| `simd_dot_product/simd/1536` | -5.14% | -8.04% | -2.10% |
| `simd_dot_product/simd/384` | -77.60% | -80.12% | -74.37% |
| `simd_dot_product/simd/768` | -28.65% | -31.17% | -25.99% |
| `simd_euclidean_distance/scalar/1024` | -2.14% | -2.58% | -1.70% |
| `simd_euclidean_distance/scalar/1536` | -1.42% | -1.70% | -1.14% |
| `simd_euclidean_distance/scalar/384` | -3.12% | -5.07% | -1.16% |
| `simd_euclidean_distance/scalar/768` | -13.57% | -14.77% | -12.35% |
| `simd_euclidean_distance/simd/1024` | -3.97% | -5.89% | -1.99% |
| `simd_euclidean_distance/simd/1536` | -21.89% | -30.49% | -10.97% |
| `simd_euclidean_distance/simd/384` | -4.55% | -6.93% | -2.07% |
| `simd_euclidean_distance/simd/768` | -39.82% | -43.37% | -35.82% |
| `simd_normalize/scalar/1024` | -5.33% | -6.06% | -4.60% |
| `simd_normalize/scalar/1536` | -43.81% | -44.73% | -42.89% |
| `simd_normalize/scalar/384` | -0.51% | -1.68% | +0.67% |
| `simd_normalize/scalar/768` | -4.79% | -6.57% | -2.96% |
| `simd_normalize/simd/1024` | -9.71% | -10.91% | -8.50% |
| `simd_normalize/simd/1536` | -11.38% | -14.25% | -8.40% |
| `simd_normalize/simd/384` | +5.53% | +3.17% | +7.89% |
| `simd_normalize/simd/768` | -6.01% | -8.73% | -3.19% |
| `simd_normalized_cosine_fast_path/cosine_full/1024` | -3.09% | -3.35% | -2.82% |
| `simd_normalized_cosine_fast_path/cosine_full/384` | -16.74% | -18.12% | -15.31% |
| `simd_normalized_cosine_fast_path/cosine_full/768` | -56.77% | -58.04% | -55.43% |
| `simd_normalized_cosine_fast_path/dot_product/1024` | -0.87% | -1.38% | -0.35% |
| `simd_normalized_cosine_fast_path/dot_product/384` | -10.66% | -11.65% | -9.66% |
| `simd_normalized_cosine_fast_path/dot_product/768` | -8.25% | -9.92% | -6.51% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/1024` | -2.83% | -5.61% | +0.06% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/384` | -5.16% | -5.77% | -4.55% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/768` | -1.86% | -2.91% | -0.81% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/1024` | -21.77% | -22.23% | -21.31% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/384` | -9.29% | -12.50% | -5.91% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/768` | -2.79% | -3.58% | -2.00% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/1024` | -3.96% | -8.25% | +0.54% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/384` | -1.22% | -1.69% | -0.75% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/768` | -3.47% | -4.48% | -2.44% |
| `simd_query_batch_dot_product/pair_loop/128d_16c` | -2.31% | -3.25% | -1.35% |
| `simd_query_batch_dot_product/pair_loop/128d_256c` | +0.43% | -1.52% | +2.39% |
| `simd_query_batch_dot_product/pair_loop/128d_4c` | -6.24% | -8.64% | -3.74% |
| `simd_query_batch_dot_product/pair_loop/128d_64c` | -0.49% | -1.20% | +0.23% |
| `simd_query_batch_dot_product/pair_loop/384d_16c` | +0.47% | -0.17% | +1.11% |
| `simd_query_batch_dot_product/pair_loop/384d_256c` | -4.17% | -4.75% | -3.58% |
| `simd_query_batch_dot_product/pair_loop/384d_4c` | -20.26% | -21.44% | -19.03% |
| `simd_query_batch_dot_product/pair_loop/384d_64c` | +3.63% | +2.29% | +4.98% |
| `simd_query_batch_dot_product/pair_loop/768d_16c` | -0.97% | -1.58% | -0.36% |
| `simd_query_batch_dot_product/pair_loop/768d_256c` | -1.13% | -1.88% | -0.37% |
| `simd_query_batch_dot_product/pair_loop/768d_4c` | -0.66% | -3.07% | +1.83% |
| `simd_query_batch_dot_product/pair_loop/768d_64c` | -5.77% | -8.16% | -3.26% |
| `simd_query_batch_dot_product/simd_batch/128d_16c` | -1.56% | -3.14% | +0.08% |
| `simd_query_batch_dot_product/simd_batch/128d_256c` | -3.83% | -5.03% | -2.63% |
| `simd_query_batch_dot_product/simd_batch/128d_4c` | -0.50% | -0.95% | -0.05% |
| `simd_query_batch_dot_product/simd_batch/128d_64c` | +1.24% | -0.48% | +2.99% |
| `simd_query_batch_dot_product/simd_batch/384d_16c` | +0.66% | -0.73% | +2.06% |
| `simd_query_batch_dot_product/simd_batch/384d_256c` | -1.62% | -3.35% | +0.14% |
| `simd_query_batch_dot_product/simd_batch/384d_4c` | -0.94% | -1.37% | -0.50% |
| `simd_query_batch_dot_product/simd_batch/384d_64c` | +10.00% | +9.43% | +10.57% |
| `simd_query_batch_dot_product/simd_batch/768d_16c` | +0.34% | -1.01% | +1.70% |
| `simd_query_batch_dot_product/simd_batch/768d_256c` | -2.41% | -4.85% | +0.13% |
| `simd_query_batch_dot_product/simd_batch/768d_4c` | +3.00% | +0.56% | +5.45% |
| `simd_query_batch_dot_product/simd_batch/768d_64c` | -4.73% | -7.99% | -1.34% |
| `simd_squared_euclidean_fast_path/euclidean_full/1024` | -1.02% | -2.94% | +0.96% |
| `simd_squared_euclidean_fast_path/euclidean_full/384` | +1.41% | +0.89% | +1.94% |
| `simd_squared_euclidean_fast_path/euclidean_full/768` | -1.34% | -3.21% | +0.57% |
| `simd_squared_euclidean_fast_path/squared_euclidean/1024` | -3.25% | -5.23% | -1.21% |
| `simd_squared_euclidean_fast_path/squared_euclidean/384` | +0.30% | -0.99% | +1.63% |
| `simd_squared_euclidean_fast_path/squared_euclidean/768` | -1.59% | -1.89% | -1.28% |
| `simd_throughput_384/cosine_similarity` | -1.10% | -1.94% | -0.26% |
| `simd_throughput_384/dot_product` | -0.48% | -1.61% | +0.67% |
| `simd_throughput_384/euclidean_distance` | -0.40% | -0.93% | +0.13% |
| `simd_throughput_384/normalize` | -0.69% | -1.90% | +0.54% |
| `softmax_attention/128` | -5.49% | -7.79% | -3.09% |
| `softmax_attention/512` | -11.89% | -15.64% | -7.83% |
| `tier_prepared_batch_sizes/int4_batch_prepared/10` | -3.86% | -6.62% | -0.96% |
| `tier_prepared_batch_sizes/int4_batch_prepared/100` | -8.47% | -9.48% | -7.44% |
| `tier_prepared_batch_sizes/int4_batch_prepared/1000` | -0.54% | -2.50% | +1.44% |
| `tier_prepared_batch_sizes/int4_query_per_call/10` | -2.13% | -3.20% | -1.06% |
| `tier_prepared_batch_sizes/int4_query_per_call/100` | +1.47% | +0.89% | +2.06% |
| `tier_prepared_batch_sizes/int4_query_per_call/1000` | -0.49% | -0.79% | -0.19% |
| `tier_prepared_batch_sizes/int8_batch_prepared/10` | +0.49% | -0.71% | +1.71% |
| `tier_prepared_batch_sizes/int8_batch_prepared/100` | +1.03% | -1.05% | +3.15% |
| `tier_prepared_batch_sizes/int8_batch_prepared/1000` | -5.38% | -6.37% | -4.38% |
| `tier_prepared_batch_sizes/int8_query_per_call/10` | +0.16% | -0.69% | +1.01% |
| `tier_prepared_batch_sizes/int8_query_per_call/100` | -44.94% | -46.63% | -43.16% |
| `tier_prepared_batch_sizes/int8_query_per_call/1000` | +0.03% | -0.41% | +0.46% |
| `tier_prepared_query/binary_query_once_1000` | -60.85% | -64.69% | -56.09% |
| `tier_prepared_query/binary_query_per_call_1000` | -54.09% | -54.95% | -53.20% |
| `tier_prepared_query/int4_query_once_1000` | -0.87% | -2.27% | +0.58% |
| `tier_prepared_query/int4_query_per_call_1000` | -2.35% | -3.09% | -1.60% |
| `tier_prepared_query/int8_query_once_1000` | -3.29% | -4.21% | -2.37% |
| `tier_prepared_query/int8_query_per_call_1000` | -2.42% | -2.93% | -1.89% |

</details>

_Rule: CI-lower of change ≤3.0% passes silently; (3.0%, 7.0%] warns; >7.0% fails. Override via PR label `bench-allow-regression`._
_2 group(s) excluded from gating as quick-mode informational-only (lattice#714): simd_cosine_similarity, simd_dot_product._


Done. Base=origin/main (b118d3871b), Head=HEAD (1dd4db023c)
```

</details>
