### PR TITLE
bench(scripts): widen quick-mode informational allowlist per isolated A/A evidence (#714)

### DIFF
--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -16,11 +16,14 @@
 #   lattice-embed: simd
 # Uses a git worktree for the base ref so your working tree stays untouched.
 #
-# lattice#714: two of the lattice-embed `simd` bench target's groups
-# (simd_dot_product, simd_cosine_similarity) are confirmed noise-dominated in
-# --quick mode by a same-toolchain A/A reproduction on identical refs
-# (FAIL/WARN sign flipped across dozens of entries in those groups run to
-# run). In --quick mode (the default), only those two named groups are
+# lattice#714: five of the lattice-embed bench targets' groups
+# (simd_dot_product, simd_cosine_similarity, int8_batch_cosine,
+# int4_cosine_distance, simd_batch_cosine_non_normalized_query) are confirmed
+# noise-dominated in --quick mode by same-toolchain A/A reproductions on
+# identical refs (the original pair: FAIL/WARN sign flipped across dozens of
+# entries run to run; the 2026-07-13 additions: confirmed-CI FAIL rows inside
+# exclusive bench windows with DISJOINT failing groups across two same-commit
+# runs). In --quick mode (the default), only those named groups are
 # measured and reported but excluded from the FAIL/WARN gate and exit code —
 # see the "informational" section of the report and INFO_GROUPS_ALLOWLIST
 # below. Every other group in the target, including any added later, gates

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -123,10 +123,11 @@ fi
 
 # --- Quick-mode informational-groups (lattice#714) ---
 # Fixed, reviewed allowlist of the issue-evidenced noisy groups only — NOT a
-# target-wide dump. lattice#714's quantitative reproduction (same-toolchain
-# A/A runs on identical refs, --quick mode) confined every flip-signed FAIL/
-# WARN to two lattice-embed `simd` groups; no other group in that target has
-# issue-backed noise evidence, so no other group is exempted here. The
+# target-wide dump. Every entry carries same-toolchain A/A evidence on
+# identical refs in --quick mode (lattice#714's original reproduction for
+# the first two; isolated bench-window A/A runs for the 2026-07-13
+# additions); no other group in that target has that evidence, so no other
+# group is exempted here. The
 # allowlist itself and the intersection-with-the-real-listing logic live in
 # scripts/lib/bench-informational-groups.sh, invoked below — kept in its own
 # file (rather than inline here) so scripts/perf-bench-gate.py --selftest can
@@ -138,7 +139,7 @@ fi
 # if that ever becomes a concern, namespace by target (e.g. "embed:<group>")
 # on both sides of the handoff instead of trusting name uniqueness. Adding a
 # group requires the same kind of same-toolchain A/A quantitative evidence
-# that justified the current two, reviewed in a PR — never derived
+# that justified every current entry, reviewed in a PR — never derived
 # automatically from `--list`, which would silently exempt every future
 # group added to the target.
 INFO_GROUPS_FILE="$REPO/.cache/bench-compare-informational-groups.txt"

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -25,6 +25,15 @@ set -euo pipefail
 INFO_GROUPS_ALLOWLIST=(
   "simd_dot_product"
   "simd_cosine_similarity"
+  # Added 2026-07-13: two same-commit A/A runs, each inside an exclusive
+  # machine-wide bench window (/tmp/lion-bench-window.lock), still produced
+  # confirmed-CI FAIL rows (>7%) in these embed micro-groups — with DISJOINT
+  # failing groups across the two runs, the signature of a noise floor above
+  # the quick-mode gate rather than a regression. Evidence tables in the PR
+  # that added these entries.
+  "int8_batch_cosine"
+  "int4_cosine_distance"
+  "simd_batch_cosine_non_normalized_query"
 )
 
 input="${1:-/dev/stdin}"

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -7,7 +7,7 @@
 # the top-level group names actually present in that listing — one name per
 # line, sorted.
 #
-# scripts/bench-compare.sh sources this file for the real run so the exact
+# scripts/bench-compare.sh invokes this file for the real run so the exact
 # same array and intersection logic feeds the gate. scripts/perf-bench-gate.py
 # --selftest invokes this script two ways: with --print-allowlist (dump the
 # raw array, no listing) so the Python-side expected set is compared against

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -9,17 +9,19 @@
 #
 # scripts/bench-compare.sh sources this file for the real run so the exact
 # same array and intersection logic feeds the gate. scripts/perf-bench-gate.py
-# --selftest also invokes this script directly (as a subprocess, against a
-# controlled listing) so a shell-only regression here — e.g. a name added
-# only to this array — fails the selftest instead of staying invisible. An
-# earlier fixture kept its own hardcoded copy of this list in Python and
-# never exercised this file at all; extracting the logic here closed that.
+# --selftest invokes this script two ways: with --print-allowlist (dump the
+# raw array, no listing) so the Python-side expected set is compared against
+# the ACTUAL array — a name added only here, or only there, fails the
+# selftest — and as the intersection subprocess against a controlled listing
+# so the production code path is exercised end-to-end. An earlier fixture
+# kept its own hardcoded copy of this list in Python and never exercised
+# this file at all; extracting the logic here closed that.
 #
 # Adding a group to the allowlist requires the same kind of same-toolchain
-# A/A quantitative evidence that justified these two (see scripts/bench-
-# compare.sh's "Quick-mode informational-groups" comment), reviewed in a PR —
-# never derived automatically from `--list`, which would silently exempt
-# every future group added to the target.
+# A/A quantitative evidence that justified every current entry (see scripts/
+# bench-compare.sh's "Quick-mode informational-groups" comment), reviewed in
+# a PR — never derived automatically from `--list`, which would silently
+# exempt every future group added to the target.
 set -euo pipefail
 
 INFO_GROUPS_ALLOWLIST=(
@@ -35,6 +37,11 @@ INFO_GROUPS_ALLOWLIST=(
   "int4_cosine_distance"
   "simd_batch_cosine_non_normalized_query"
 )
+
+if [ "${1:-}" = "--print-allowlist" ]; then
+  printf '%s\n' "${INFO_GROUPS_ALLOWLIST[@]}" | sort
+  exit 0
+fi
 
 input="${1:-/dev/stdin}"
 listed_groups=$(awk -F/ '/: benchmark$/{print $1}' "$input" | sort -u)

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -425,7 +425,7 @@ def run_selftest() -> int:
         # bench-compare.sh sources for production runs) against a
         # controlled Criterion `--list`-shaped listing, feed its emitted
         # file into the Python classifier, and assert the full
-        # pipeline: only the two approved names come out of the shell step,
+        # pipeline: only the approved names come out of the shell step,
         # and an unapproved embed group, an inference group, and a
         # similarly-prefixed-but-distinct embed group all still gate.
         helper = Path(__file__).resolve().parent / "lib" / "bench-informational-groups.sh"
@@ -443,6 +443,9 @@ def run_selftest() -> int:
                 "simd_normalize/scalar/384: benchmark\n"
                 "simd_dot_product_extra/scalar/384: benchmark\n"
                 "rms_norm/4096: benchmark\n"
+                "int8_batch_cosine/float32_simd/100: benchmark\n"
+                "int4_cosine_distance/int4/768: benchmark\n"
+                "simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c: benchmark\n"
             )
             proc = subprocess.run(
                 ["bash", str(helper), str(listing_file)],
@@ -455,11 +458,17 @@ def run_selftest() -> int:
                 failures.append(
                     f"allowlist-handoff: shell helper exited {proc.returncode}: {proc.stderr}"
                 )
-            elif shell_emitted != {"simd_dot_product", "simd_cosine_similarity"}:
+            elif shell_emitted != {
+                "simd_dot_product",
+                "simd_cosine_similarity",
+                "int8_batch_cosine",
+                "int4_cosine_distance",
+                "simd_batch_cosine_non_normalized_query",
+            }:
                 failures.append(
                     "allowlist-handoff: shell helper emitted "
-                    f"{sorted(shell_emitted)}, expected exactly "
-                    "['simd_cosine_similarity', 'simd_dot_product']"
+                    f"{sorted(shell_emitted)}, expected the five approved "
+                    "allowlist groups"
                 )
             else:
                 allowlist_dir = root / "allowlist"

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -422,7 +422,7 @@ def run_selftest() -> int:
         # regression that added a group only to bench-compare.sh's array
         # (e.g. simd_normalize) stayed invisible. Two probes against the
         # real helper (scripts/lib/bench-informational-groups.sh, the same
-        # file bench-compare.sh sources for production runs): first dump
+        # file bench-compare.sh invokes for production runs): first dump
         # the raw array (--print-allowlist) and require it to equal the
         # reviewed expectation set — this is what catches an array-only
         # addition — then run the intersection against a controlled

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -420,18 +420,54 @@ def run_selftest() -> int:
         # end. An earlier fixture kept its own hardcoded `shell_allowlist`
         # set instead of reading it from the actual shell code — a
         # regression that added a group only to bench-compare.sh's array
-        # (e.g. simd_normalize) stayed invisible. Run the real helper
-        # (scripts/lib/bench-informational-groups.sh, the same file
-        # bench-compare.sh sources for production runs) against a
-        # controlled Criterion `--list`-shaped listing, feed its emitted
-        # file into the Python classifier, and assert the full
+        # (e.g. simd_normalize) stayed invisible. Two probes against the
+        # real helper (scripts/lib/bench-informational-groups.sh, the same
+        # file bench-compare.sh sources for production runs): first dump
+        # the raw array (--print-allowlist) and require it to equal the
+        # reviewed expectation set — this is what catches an array-only
+        # addition — then run the intersection against a controlled
+        # Criterion `--list`-shaped listing, feed its emitted file into
+        # the Python classifier, and assert the full
         # pipeline: only the approved names come out of the shell step,
         # and an unapproved embed group, an inference group, and a
         # similarly-prefixed-but-distinct embed group all still gate.
         helper = Path(__file__).resolve().parent / "lib" / "bench-informational-groups.sh"
+        # The reviewed allowlist, duplicated here on purpose: the selftest
+        # compares this set against the shell array itself (via
+        # --print-allowlist below), so a name added to only ONE side —
+        # shell array or this expectation — fails the selftest. The
+        # listing-intersection test alone cannot catch an array-only
+        # addition (a fixed listing never contains the new name, so the
+        # intersection output is unchanged).
+        approved_allowlist = frozenset({
+            "simd_dot_product",
+            "simd_cosine_similarity",
+            "int8_batch_cosine",
+            "int4_cosine_distance",
+            "simd_batch_cosine_non_normalized_query",
+        })
         if not helper.exists():
             failures.append(f"allowlist-handoff: shell helper missing at {helper}")
         else:
+            raw_proc = subprocess.run(
+                ["bash", str(helper), "--print-allowlist"],
+                capture_output=True, text=True, timeout=30,
+            )
+            raw_array = frozenset(
+                ln.strip() for ln in raw_proc.stdout.splitlines() if ln.strip()
+            )
+            if raw_proc.returncode != 0:
+                failures.append(
+                    f"allowlist-handoff: --print-allowlist exited "
+                    f"{raw_proc.returncode}: {raw_proc.stderr}"
+                )
+            elif raw_array != approved_allowlist:
+                failures.append(
+                    "allowlist-handoff: shell array and selftest expectation "
+                    f"disagree — array-only: {sorted(raw_array - approved_allowlist)}, "
+                    f"expectation-only: {sorted(approved_allowlist - raw_array)}. "
+                    "Every allowlist change must update both sides in one PR."
+                )
             listing_dir = root / "allowlist-listing"
             listing_dir.mkdir(parents=True, exist_ok=True)
             listing_file = listing_dir / "list.txt"
@@ -458,16 +494,10 @@ def run_selftest() -> int:
                 failures.append(
                     f"allowlist-handoff: shell helper exited {proc.returncode}: {proc.stderr}"
                 )
-            elif shell_emitted != {
-                "simd_dot_product",
-                "simd_cosine_similarity",
-                "int8_batch_cosine",
-                "int4_cosine_distance",
-                "simd_batch_cosine_non_normalized_query",
-            }:
+            elif shell_emitted != approved_allowlist:
                 failures.append(
                     "allowlist-handoff: shell helper emitted "
-                    f"{sorted(shell_emitted)}, expected the five approved "
+                    f"{sorted(shell_emitted)}, expected the approved "
                     "allowlist groups"
                 )
             else:


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Widens the #714 quick-mode informational-groups allowlist by three lattice-embed micro-bench groups, carrying the same-toolchain A/A evidence the allowlist's own contract requires.

## What

Adds `int8_batch_cosine`, `int4_cosine_distance`, and `simd_batch_cosine_non_normalized_query` to `INFO_GROUPS_ALLOWLIST` in `scripts/lib/bench-informational-groups.sh`. In `--quick` mode these groups are still measured and reported, but excluded from the FAIL/WARN gate and exit code (the existing #714 mechanism, unchanged). `--full` mode still gates every group normally, so a real regression in these groups remains catchable.

Also updates the `perf-bench-gate.py --selftest` fixture so the shell→Python allowlist handoff exercises the new names end-to-end (the selftest pins the emitted set exactly, so an array-only edit fails it), and refreshes the two comments that described the allowlist as two groups.

## Evidence

Two A/A runs (`scripts/bench-compare.sh HEAD HEAD`, quick mode, identical commit `c29e9a7f9d` as both base and head) were executed on 2026-07-13, each holding the machine-wide EXCLUSIVE bench-isolation lock (`/tmp/lion-bench-window.lock`) for the whole run, on an otherwise idle host with all concurrent builds routed through the SHARED side of the same lock. Since base and head are the same commit, every confirmed FAIL/WARN row is by construction a false positive.

Run 1 — 2 FAIL / 8 WARN / 40 "confirmed improvement" on identical code:

```
| int8_batch_cosine/float32_simd/100                        | +9.21% | [+8.32%, +10.11%] | FAIL |
| int4_cosine_distance/float32_simd/768                     | +8.18% | [+7.81%, +8.55%]  | FAIL |
| int8_vs_float32_cosine/float32_simd/1536                  | +6.27% | [+5.11%, +7.46%]  | WARN |
| int8_batch_cosine/float32_simd/1000                       | +4.59% | [+3.84%, +5.34%]  | WARN |
| residual_add_layer_norm/unfused/hidden384_seq128          | +3.97% | [+3.69%, +4.25%]  | WARN |
| residual_add_layer_norm/unfused/hidden768_seq128          | +4.65% | [+3.46%, +5.84%]  | WARN |
| residual_add_layer_norm/fused/hidden768_seq128            | +3.58% | [+3.41%, +3.75%]  | WARN |
| memory_size/search_1000_int8                              | +4.44% | [+3.38%, +5.50%]  | WARN |
| simd_normalize/simd/1024                                  | +3.29% | [+3.11%, +3.46%]  | WARN |
| simd_batch_cosine_non_normalized_query/simd_batch/384d_4c | +4.11% | [+3.00%, +5.22%]  | WARN |
```

Run 2 — 1 FAIL / 4 WARN / 76 "confirmed improvement" on identical code:

```
| simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c | +7.48% | [+7.05%, +7.92%]  | FAIL |
| int8_raw_dot_product/dot_product_i8/127                    | +7.98% | [+5.42%, +10.53%] | WARN |
| simd_normalized_cosine_fast_path/cosine_full/768           | +7.07% | [+5.12%, +9.08%]  | WARN |
| simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c | +4.56% | [+3.93%, +5.21%]  | WARN |
| simd_squared_euclidean_fast_path/euclidean_full/384        | +5.26% | [+3.84%, +6.70%]  | WARN |
```

The decisive property: the FAIL sets of the two runs are **disjoint**. Identical commit, identical isolation, different groups exceeding the 7% gate with tight CIs — the signature of a noise floor above the quick-mode threshold on these sub-microsecond-to-tens-of-microseconds micro-benches, not of any code effect. The dozens of simultaneous "confirmed improvement" rows on identical code corroborate: the CI machinery is confidently resolving jitter in both directions.

## Scope of the widening

Only the groups that produced a confirmed-CI FAIL (>7%) in at least one isolated A/A run are added. WARN-only groups (`residual_add_layer_norm`, `memory_size`, `simd_normalize`, `int8_raw_dot_product`, `int8_vs_float32_cosine`, `simd_normalized_cosine_fast_path`, `simd_batch_cosine_normalized_query`, `simd_squared_euclidean_fast_path`) are NOT added: WARN does not block the gate, and keeping them gated preserves signal for genuine large regressions. If any of them later produces an isolated-A/A FAIL, that run's table is the evidence for a follow-up widening.

## Replay

```
bash <bench-window-wrapper> "<label>" -- scripts/bench-compare.sh HEAD HEAD
```

quick mode (default), any commit checked out at an otherwise idle host with builds routed through the shared lock side. Full run logs retained locally.

## Verification

- `scripts/perf-bench-gate.py --selftest` passes: the shell helper now emits exactly the five approved names against the extended listing fixture, the prefix-distinct decoy (`simd_dot_product_extra`), unapproved embed group, and inference group all still gate.
- No production kernel or bench code changes; scripts + comments only.
