### PR TITLE
fix(tune): reject non-finite LoRA alpha at parse, config, and manifest boundaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 # MSRV, verified end-to-end (workspace + deps) on 1.93.1 and guarded by the msrv CI
 # job (aarch64 macOS, f16,metal-gpu, --all-targets) so a newer-toolchain-only API

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -55,14 +55,14 @@ tracing = "0.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["sync", "rt"] }
 # Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.6.1", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.7.0", path = "../inference", optional = true, features = ["f16"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.0", default-features = false, features = ["sync", "rt"] }
 # Same crate, trimmed to the CPU compute path: `std` + `f16`, without
 # `download` (ureq) or `serve` (axum/tokio-net/mio), none of which compile to
 # wasm32-unknown-unknown.
-lattice-inference = { version = "0.6.1", path = "../inference", optional = true, default-features = false, features = [
+lattice-inference = { version = "0.7.0", path = "../inference", optional = true, default-features = false, features = [
     "std",
     "f16",
 ] }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -71,7 +71,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.6.1", path = "../fann", optional = true }
+lattice-fann = { version = "0.7.0", path = "../fann", optional = true }
 
 [[bin]]
 name = "lattice"

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -30,7 +30,7 @@ sqlite = ["dep:rusqlite", "serde"]
 mixture = ["lattice-fann/online-router"]
 
 [dependencies]
-lattice-fann = { version = "0.6.1", path = "../fann" }
+lattice-fann = { version = "0.7.0", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -51,7 +51,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.6.1", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.7.0", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/crates/tune/src/bin/generate_lora.rs
+++ b/crates/tune/src/bin/generate_lora.rs
@@ -119,8 +119,8 @@ fn main() {
                 println!(
                     "  Adapter: {} pairs, rank={}, scale={:.2}, {} parameters",
                     adapter.num_adapted_layers(),
-                    adapter.config.rank,
-                    adapter.config.scale(),
+                    adapter.config().rank,
+                    adapter.config().scale(),
                     adapter.num_parameters()
                 );
                 model.set_lora(Box::new(adapter));

--- a/crates/tune/src/bin/generate_lora.rs
+++ b/crates/tune/src/bin/generate_lora.rs
@@ -112,6 +112,10 @@ fn main() {
 
         match lattice_tune::lora::LoraAdapter::from_safetensors(lora) {
             Ok(adapter) => {
+                if let Err(e) = adapter.validate_against(model.config()) {
+                    eprintln!("LoRA adapter incompatible with loaded model: {e}");
+                    std::process::exit(1);
+                }
                 println!(
                     "  Adapter: {} pairs, rank={}, scale={:.2}, {} parameters",
                     adapter.num_adapted_layers(),
@@ -119,10 +123,6 @@ fn main() {
                     adapter.config.scale(),
                     adapter.num_parameters()
                 );
-                if let Err(e) = adapter.validate_against(model.config()) {
-                    eprintln!("LoRA adapter incompatible with loaded model: {e}");
-                    std::process::exit(1);
-                }
                 model.set_lora(Box::new(adapter));
                 println!(
                     "  LoRA active (loaded in {}ms)",

--- a/crates/tune/src/bin/train_grad.rs
+++ b/crates/tune/src/bin/train_grad.rs
@@ -205,6 +205,7 @@ fn nll_and_grad(
 /// Typed CLI config for `train_grad`. Field defaults are the documented
 /// contract in `usage()` and issue #845's flag table — the snapshot tests
 /// below pin them.
+#[derive(Debug)]
 struct Config {
     model_dir: PathBuf,
     data_dir: PathBuf,
@@ -217,8 +218,21 @@ struct Config {
     log_every: usize,
 }
 
-fn parse_config(argv: &ArgView) -> Config {
-    Config {
+fn parse_alpha(argv: &ArgView) -> Result<f32, String> {
+    let Some(value) = argv.arg("--alpha") else {
+        return Ok(16.0);
+    };
+    let alpha = value
+        .parse::<f32>()
+        .map_err(|_| format!("invalid --alpha '{value}': expected a finite number"))?;
+    if !alpha.is_finite() {
+        return Err(format!("invalid --alpha '{value}': value must be finite"));
+    }
+    Ok(alpha)
+}
+
+fn parse_config(argv: &ArgView) -> Result<Config, String> {
+    Ok(Config {
         model_dir: argv
             .arg("--model-dir")
             .map(PathBuf::from)
@@ -236,10 +250,7 @@ fn parse_config(argv: &ArgView) -> Config {
             .and_then(|s| s.parse().ok())
             .unwrap_or(1e-3),
         rank: argv.arg("--rank").and_then(|s| s.parse().ok()).unwrap_or(8),
-        alpha: argv
-            .arg("--alpha")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(16.0),
+        alpha: parse_alpha(argv)?,
         seq_len: argv
             .arg("--seq-len")
             .and_then(|s| s.parse().ok())
@@ -252,7 +263,7 @@ fn parse_config(argv: &ArgView) -> Config {
             .arg("--log-every")
             .and_then(|s| s.parse().ok())
             .unwrap_or(10),
-    }
+    })
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -273,7 +284,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         seq_len,
         max_train,
         log_every,
-    } = parse_config(&argv);
+    } = parse_config(&argv)
+        .map_err(|message| std::io::Error::new(std::io::ErrorKind::InvalidInput, message))?;
 
     println!("=== exact-gradient LoRA trainer (lm_head) ===");
     println!("model-dir:  {}", model_dir.display());
@@ -440,7 +452,7 @@ mod cli_contract_tests {
     #[test]
     fn defaults_match_documented_table() {
         let a = args(&[]);
-        let cfg = parse_config(&ArgView::new(&a));
+        let cfg = parse_config(&ArgView::new(&a)).expect("default config must parse");
         assert_eq!(cfg.data_dir, PathBuf::from("data/lora-train"));
         assert_eq!(cfg.steps, 150);
         assert_eq!(cfg.lr, 1e-3);
@@ -474,7 +486,7 @@ mod cli_contract_tests {
             "--log-every",
             "1",
         ]);
-        let cfg = parse_config(&ArgView::new(&a));
+        let cfg = parse_config(&ArgView::new(&a)).expect("explicit config must parse");
         assert_eq!(cfg.model_dir, PathBuf::from("/tmp/m"));
         assert_eq!(cfg.data_dir, PathBuf::from("/tmp/d"));
         assert_eq!(cfg.steps, 5);
@@ -484,6 +496,16 @@ mod cli_contract_tests {
         assert_eq!(cfg.seq_len, 32);
         assert_eq!(cfg.max_train, 2);
         assert_eq!(cfg.log_every, 1);
+    }
+
+    #[test]
+    fn rejects_invalid_alpha_values() {
+        for alpha in ["nan", "inf", "-inf", "invalid"] {
+            let a = args(&["--alpha", alpha]);
+            let err = parse_config(&ArgView::new(&a))
+                .expect_err("invalid --alpha must fail parsing before training");
+            assert!(err.contains("--alpha"));
+        }
     }
 
     #[test]

--- a/crates/tune/src/bin/train_grad.rs
+++ b/crates/tune/src/bin/train_grad.rs
@@ -219,9 +219,12 @@ struct Config {
 }
 
 fn parse_alpha(argv: &ArgView) -> Result<f32, String> {
-    let Some(value) = argv.arg("--alpha") else {
+    if !argv.flag("--alpha") {
         return Ok(16.0);
-    };
+    }
+    let value = argv
+        .arg("--alpha")
+        .ok_or_else(|| "invalid --alpha: missing value".to_string())?;
     let alpha = value
         .parse::<f32>()
         .map_err(|_| format!("invalid --alpha '{value}': expected a finite number"))?;
@@ -506,6 +509,14 @@ mod cli_contract_tests {
                 .expect_err("invalid --alpha must fail parsing before training");
             assert!(err.contains("--alpha"));
         }
+    }
+
+    #[test]
+    fn rejects_missing_alpha_value() {
+        let a = args(&["--alpha"]);
+        let err = parse_config(&ArgView::new(&a))
+            .expect_err("--alpha without a value must fail parsing before training");
+        assert!(err.contains("--alpha"));
     }
 
     #[test]

--- a/crates/tune/src/bin/train_grad_full.rs
+++ b/crates/tune/src/bin/train_grad_full.rs
@@ -978,7 +978,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 alpha,
                 target_modules,
             };
-            let adapter = LoraAdapter::new(config, adapter_layers);
+            let adapter = LoraAdapter::new(config, adapter_layers)
+                .map_err(|e| format!("construct adapter: {e}"))?;
             adapter
                 .save_safetensors(std::path::Path::new(path), None)
                 .map_err(|e| format!("save adapter: {e}"))?;

--- a/crates/tune/src/bin/train_grad_layer23.rs
+++ b/crates/tune/src/bin/train_grad_layer23.rs
@@ -334,6 +334,7 @@ fn shifted(gamma: &[f32]) -> Vec<f32> {
 /// Typed CLI config for `train_grad_layer23`. Field defaults are the
 /// documented contract in `usage()` and issue #845's flag table — the
 /// snapshot tests below pin them.
+#[derive(Debug)]
 struct Config {
     model_dir: PathBuf,
     data_dir: PathBuf,
@@ -347,8 +348,21 @@ struct Config {
     save_path: Option<String>,
 }
 
-fn parse_config(argv: &ArgView) -> Config {
-    Config {
+fn parse_alpha(argv: &ArgView) -> Result<f32, String> {
+    let Some(value) = argv.arg("--alpha") else {
+        return Ok(16.0);
+    };
+    let alpha = value
+        .parse::<f32>()
+        .map_err(|_| format!("invalid --alpha '{value}': expected a finite number"))?;
+    if !alpha.is_finite() {
+        return Err(format!("invalid --alpha '{value}': value must be finite"));
+    }
+    Ok(alpha)
+}
+
+fn parse_config(argv: &ArgView) -> Result<Config, String> {
+    Ok(Config {
         model_dir: argv
             .arg("--model-dir")
             .map(PathBuf::from)
@@ -366,10 +380,7 @@ fn parse_config(argv: &ArgView) -> Config {
             .and_then(|s| s.parse().ok())
             .unwrap_or(1e-3),
         rank: argv.arg("--rank").and_then(|s| s.parse().ok()).unwrap_or(8),
-        alpha: argv
-            .arg("--alpha")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(16.0),
+        alpha: parse_alpha(argv)?,
         seq_len_cap: argv
             .arg("--seq-len")
             .and_then(|s| s.parse().ok())
@@ -383,7 +394,7 @@ fn parse_config(argv: &ArgView) -> Config {
             .and_then(|s| s.parse().ok())
             .unwrap_or(5),
         save_path: argv.arg("--save"),
-    }
+    })
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -405,7 +416,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_train,
         log_every,
         save_path,
-    } = parse_config(&argv);
+    } = parse_config(&argv)
+        .map_err(|message| std::io::Error::new(std::io::ErrorKind::InvalidInput, message))?;
 
     println!("=== exact-gradient LoRA trainer (layer {LAYER}, gated GQA) ===");
     println!("model-dir:  {}", model_dir.display());
@@ -696,7 +708,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 alpha,
                 target_modules: vec!["q_proj".to_string(), "v_proj".to_string()],
             };
-            let adapter = LoraAdapter::new(config, layers);
+            let adapter =
+                LoraAdapter::new(config, layers).map_err(|e| format!("construct adapter: {e}"))?;
             adapter
                 .save_safetensors(std::path::Path::new(save_path), None)
                 .map_err(|e| format!("save adapter: {e}"))?;
@@ -725,7 +738,7 @@ mod cli_contract_tests {
     #[test]
     fn defaults_match_documented_table() {
         let a = args(&[]);
-        let cfg = parse_config(&ArgView::new(&a));
+        let cfg = parse_config(&ArgView::new(&a)).expect("default config must parse");
         assert_eq!(cfg.data_dir, PathBuf::from("data/lora-train"));
         assert_eq!(cfg.steps, 25);
         assert_eq!(cfg.lr, 1e-3);
@@ -762,7 +775,7 @@ mod cli_contract_tests {
             "--save",
             "/tmp/out.safetensors",
         ]);
-        let cfg = parse_config(&ArgView::new(&a));
+        let cfg = parse_config(&ArgView::new(&a)).expect("explicit config must parse");
         assert_eq!(cfg.model_dir, PathBuf::from("/tmp/m"));
         assert_eq!(cfg.data_dir, PathBuf::from("/tmp/d"));
         assert_eq!(cfg.steps, 7);
@@ -773,6 +786,16 @@ mod cli_contract_tests {
         assert_eq!(cfg.max_train, 1);
         assert_eq!(cfg.log_every, 2);
         assert_eq!(cfg.save_path, Some("/tmp/out.safetensors".to_string()));
+    }
+
+    #[test]
+    fn rejects_invalid_alpha_values() {
+        for alpha in ["nan", "inf", "-inf", "invalid"] {
+            let a = args(&["--alpha", alpha]);
+            let err = parse_config(&ArgView::new(&a))
+                .expect_err("invalid --alpha must fail parsing before training");
+            assert!(err.contains("--alpha"));
+        }
     }
 
     #[test]

--- a/crates/tune/src/bin/train_grad_layer23.rs
+++ b/crates/tune/src/bin/train_grad_layer23.rs
@@ -349,9 +349,12 @@ struct Config {
 }
 
 fn parse_alpha(argv: &ArgView) -> Result<f32, String> {
-    let Some(value) = argv.arg("--alpha") else {
+    if !argv.flag("--alpha") {
         return Ok(16.0);
-    };
+    }
+    let value = argv
+        .arg("--alpha")
+        .ok_or_else(|| "invalid --alpha: missing value".to_string())?;
     let alpha = value
         .parse::<f32>()
         .map_err(|_| format!("invalid --alpha '{value}': expected a finite number"))?;
@@ -796,6 +799,14 @@ mod cli_contract_tests {
                 .expect_err("invalid --alpha must fail parsing before training");
             assert!(err.contains("--alpha"));
         }
+    }
+
+    #[test]
+    fn rejects_missing_alpha_value() {
+        let a = args(&["--alpha"]);
+        let err = parse_config(&ArgView::new(&a))
+            .expect_err("--alpha without a value must fail parsing before training");
+        assert!(err.contains("--alpha"));
     }
 
     #[test]

--- a/crates/tune/src/lora/blend.rs
+++ b/crates/tune/src/lora/blend.rs
@@ -89,9 +89,9 @@ pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapt
     // Value: list of (LoraLayer ref, effective_weight = w_e * s_e).
     let mut grouped: HashMap<(usize, String), Vec<(&LoraLayer, f32)>> = HashMap::new();
     for (adapter, weight) in adapters {
-        let s_e = adapter.config.scale();
+        let s_e = adapter.config().scale();
         let eff = weight * s_e;
-        for ((layer_idx, module), layer) in &adapter.layers {
+        for ((layer_idx, module), layer) in adapter.layers() {
             grouped
                 .entry((*layer_idx, module.clone()))
                 .or_default()
@@ -314,8 +314,8 @@ mod tests {
 
     // Apply a LoraAdapter to x and return the delta (excludes base output).
     fn lora_delta(adapter: &LoraAdapter, x: &[f32]) -> Vec<f32> {
-        let (_, layer) = adapter.layers.iter().next().unwrap();
-        let scale = adapter.config.scale();
+        let (_, layer) = adapter.layers().iter().next().unwrap();
+        let scale = adapter.config().scale();
         let rank = layer.rank;
         let d_in = layer.d_in;
         let d_out = layer.d_out;
@@ -376,8 +376,8 @@ mod tests {
 
         let delta_orig = lora_delta(&adapter, &x);
         // Blended adapter has scale=1.0 (alpha=rank_total).
-        let blended_layer = blended.layers.get(&(0, "q_proj".to_string())).unwrap();
-        let delta_blend = layer_delta(blended_layer, blended.config.scale(), &x);
+        let blended_layer = blended.layers().get(&(0, "q_proj".to_string())).unwrap();
+        let delta_blend = layer_delta(blended_layer, blended.config().scale(), &x);
 
         let max_diff = delta_orig
             .iter()
@@ -415,8 +415,8 @@ mod tests {
         // Expected: w1*Δ1 + w2*Δ2
         let expected: Vec<f32> = d1.iter().zip(&d2).map(|(a, b)| w1 * a + w2 * b).collect();
 
-        let blended_layer = blended.layers.get(&(0, "q_proj".to_string())).unwrap();
-        let actual = layer_delta(blended_layer, blended.config.scale(), &x);
+        let blended_layer = blended.layers().get(&(0, "q_proj".to_string())).unwrap();
+        let actual = layer_delta(blended_layer, blended.config().scale(), &x);
 
         let max_diff = expected
             .iter()
@@ -440,7 +440,7 @@ mod tests {
 
         let blended = blend_lora_adapters(&[(&adapter1, 0.5), (&adapter2, 0.5)]).unwrap();
 
-        let blended_layer = blended.layers.get(&(0, "q_proj".to_string())).unwrap();
+        let blended_layer = blended.layers().get(&(0, "q_proj".to_string())).unwrap();
         assert_eq!(
             blended_layer.rank,
             1 + 2,
@@ -620,7 +620,7 @@ mod tests {
         .expect("valid adapter config");
 
         let blended = blend_lora_adapters(&[(&adapter, w)]).unwrap();
-        let blended_layer = blended.layers.get(&(0, "q_proj".to_string())).unwrap();
+        let blended_layer = blended.layers().get(&(0, "q_proj".to_string())).unwrap();
 
         let x: Vec<f32> = (0..d_in).map(|i| (i + 1) as f32).collect();
         let scale = alpha / rank as f32; // = 2.0
@@ -635,7 +635,7 @@ mod tests {
             .collect();
 
         // Blended adapter has alpha=rank_total so scale()=1.0; use layer_delta directly.
-        let actual = layer_delta(blended_layer, blended.config.scale(), &x);
+        let actual = layer_delta(blended_layer, blended.config().scale(), &x);
 
         let max_diff = expected
             .iter()
@@ -665,7 +665,7 @@ mod tests {
         let adapter2 = make_adapter(r2, d_in, d_out, 2.0);
 
         let blended = blend_lora_adapters(&[(&adapter1, w1), (&adapter2, w2)]).unwrap();
-        let blended_layer = blended.layers.get(&(0, "q_proj".to_string())).unwrap();
+        let blended_layer = blended.layers().get(&(0, "q_proj".to_string())).unwrap();
 
         assert_eq!(blended_layer.rank, r1 + r2);
 
@@ -678,7 +678,7 @@ mod tests {
             .map(|(a, b)| w1 * a + w2 * b)
             .collect();
 
-        let actual = layer_delta(blended_layer, blended.config.scale(), &x);
+        let actual = layer_delta(blended_layer, blended.config().scale(), &x);
 
         let max_diff = expected
             .iter()

--- a/crates/tune/src/lora/blend.rs
+++ b/crates/tune/src/lora/blend.rs
@@ -165,7 +165,7 @@ pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapt
         target_modules,
     };
 
-    Ok(LoraAdapter::new(config, blended_layers))
+    LoraAdapter::new(config, blended_layers)
 }
 
 /// Blend multiple `(LoraLayer, effective_weight)` entries for a single
@@ -309,6 +309,7 @@ mod tests {
             },
             layers,
         )
+        .expect("valid adapter config")
     }
 
     // Apply a LoraAdapter to x and return the delta (excludes base output).
@@ -496,7 +497,8 @@ mod tests {
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        );
+        )
+        .expect("valid adapter config");
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
         assert!(
             result.is_err(),
@@ -533,7 +535,8 @@ mod tests {
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        );
+        )
+        .expect("valid adapter config");
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
         assert!(
             result.is_err(),
@@ -570,7 +573,8 @@ mod tests {
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        );
+        )
+        .expect("valid adapter config");
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
         assert!(
             result.is_err(),
@@ -612,7 +616,8 @@ mod tests {
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        );
+        )
+        .expect("valid adapter config");
 
         let blended = blend_lora_adapters(&[(&adapter, w)]).unwrap();
         let blended_layer = blended.layers.get(&(0, "q_proj".to_string())).unwrap();
@@ -716,7 +721,8 @@ mod tests {
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        );
+        )
+        .expect("valid adapter config");
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
         // The pre-pass catches the overflow in rank_total*(d_in+d_out); the
         // per-entry checked_mul is defense-in-depth for the same class.
@@ -795,7 +801,8 @@ mod tests {
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        );
+        )
+        .expect("valid adapter config");
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
         assert!(result.is_err(), "aggregate budget exceeded must return Err");
         let msg = result.unwrap_err().to_string();

--- a/crates/tune/src/lora/loader.rs
+++ b/crates/tune/src/lora/loader.rs
@@ -12,16 +12,16 @@ use std::path::Path;
 
 const ALPHA_TOLERANCE: f32 = 1e-4;
 
-fn validate_manifest_alpha(adapter: &LoraAdapter, entry: &ManifestEntry) -> Result<()> {
-    let difference = (adapter.config.alpha - entry.alpha).abs();
-    if !adapter.config.alpha.is_finite()
+fn validate_manifest_alpha(adapter_alpha: f32, entry: &ManifestEntry) -> Result<()> {
+    let difference = (adapter_alpha - entry.alpha).abs();
+    if !adapter_alpha.is_finite()
         || !entry.alpha.is_finite()
         || !difference.is_finite()
         || difference > ALPHA_TOLERANCE
     {
         return Err(TuneError::Validation(format!(
             "alpha mismatch for '{}': manifest says {}, file has {}",
-            entry.id, entry.alpha, adapter.config.alpha
+            entry.id, entry.alpha, adapter_alpha
         )));
     }
     Ok(())
@@ -289,10 +289,12 @@ pub fn load_adapters_from_manifest(
             })?;
 
         // Check 6: Rank must match the manifest entry.
-        if adapter.config.rank != entry.rank {
+        if adapter.config().rank != entry.rank {
             return Err(TuneError::Validation(format!(
                 "rank mismatch for '{}': manifest says {}, file has {}",
-                entry.id, entry.rank, adapter.config.rank
+                entry.id,
+                entry.rank,
+                adapter.config().rank
             )));
         }
 
@@ -304,10 +306,10 @@ pub fn load_adapters_from_manifest(
         // whose header omits alpha — the synthesised 16 ≠ declared 64. The
         // synthesis fallback therefore cannot smuggle a mismatched alpha past the
         // governed loader.
-        validate_manifest_alpha(&adapter, entry)?;
+        validate_manifest_alpha(adapter.config().alpha, entry)?;
 
         // Check 8: target_modules in adapter must be a subset of entry's list.
-        for module in &adapter.config.target_modules {
+        for module in &adapter.config().target_modules {
             if !entry.target_modules.contains(module) {
                 return Err(TuneError::Validation(format!(
                     "target_modules mismatch for '{}': adapter module '{}' \
@@ -711,7 +713,7 @@ mod tests {
         let loaded = result.unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].id, "valid-adapter");
-        assert_eq!(loaded[0].adapter.config.rank, 4);
+        assert_eq!(loaded[0].adapter.config().rank, 4);
     }
 
     #[test]
@@ -942,14 +944,6 @@ mod tests {
 
     #[test]
     fn loader_rejects_nan_adapter_alpha_against_finite_manifest_alpha() {
-        let adapter = LoraAdapter {
-            config: super::super::LoraConfig {
-                rank: 4,
-                alpha: f32::NAN,
-                target_modules: vec!["q_proj".to_string()],
-            },
-            layers: std::collections::HashMap::new(),
-        };
         let entry = make_entry(
             "nan-alpha",
             "adapter.safetensors",
@@ -960,7 +954,7 @@ mod tests {
             vec!["q_proj".to_string()],
         );
 
-        let err = validate_manifest_alpha(&adapter, &entry).unwrap_err();
+        let err = validate_manifest_alpha(f32::NAN, &entry).unwrap_err();
         assert!(err.to_string().contains("alpha mismatch"));
     }
 

--- a/crates/tune/src/lora/loader.rs
+++ b/crates/tune/src/lora/loader.rs
@@ -942,14 +942,14 @@ mod tests {
 
     #[test]
     fn loader_rejects_nan_adapter_alpha_against_finite_manifest_alpha() {
-        let adapter = LoraAdapter::new(
-            super::super::LoraConfig {
+        let adapter = LoraAdapter {
+            config: super::super::LoraConfig {
                 rank: 4,
                 alpha: f32::NAN,
                 target_modules: vec!["q_proj".to_string()],
             },
-            std::collections::HashMap::new(),
-        );
+            layers: std::collections::HashMap::new(),
+        };
         let entry = make_entry(
             "nan-alpha",
             "adapter.safetensors",

--- a/crates/tune/src/lora/loader.rs
+++ b/crates/tune/src/lora/loader.rs
@@ -10,6 +10,23 @@ use crate::error::{Result, TuneError};
 use crate::registry::sha256_hash;
 use std::path::Path;
 
+const ALPHA_TOLERANCE: f32 = 1e-4;
+
+fn validate_manifest_alpha(adapter: &LoraAdapter, entry: &ManifestEntry) -> Result<()> {
+    let difference = (adapter.config.alpha - entry.alpha).abs();
+    if !adapter.config.alpha.is_finite()
+        || !entry.alpha.is_finite()
+        || !difference.is_finite()
+        || difference > ALPHA_TOLERANCE
+    {
+        return Err(TuneError::Validation(format!(
+            "alpha mismatch for '{}': manifest says {}, file has {}",
+            entry.id, entry.alpha, adapter.config.alpha
+        )));
+    }
+    Ok(())
+}
+
 /// A successfully loaded and fully validated adapter.
 #[derive(Debug)]
 pub struct LoadedAdapter {
@@ -287,12 +304,7 @@ pub fn load_adapters_from_manifest(
         // whose header omits alpha — the synthesised 16 ≠ declared 64. The
         // synthesis fallback therefore cannot smuggle a mismatched alpha past the
         // governed loader.
-        if (adapter.config.alpha - entry.alpha).abs() > 1e-4 {
-            return Err(TuneError::Validation(format!(
-                "alpha mismatch for '{}': manifest says {}, file has {}",
-                entry.id, entry.alpha, adapter.config.alpha
-            )));
-        }
+        validate_manifest_alpha(&adapter, entry)?;
 
         // Check 8: target_modules in adapter must be a subset of entry's list.
         for module in &adapter.config.target_modules {
@@ -926,6 +938,30 @@ mod tests {
             msg.contains("alpha mismatch"),
             "expected alpha mismatch rejection; got: {msg}"
         );
+    }
+
+    #[test]
+    fn loader_rejects_nan_adapter_alpha_against_finite_manifest_alpha() {
+        let adapter = LoraAdapter::new(
+            super::super::LoraConfig {
+                rank: 4,
+                alpha: f32::NAN,
+                target_modules: vec!["q_proj".to_string()],
+            },
+            std::collections::HashMap::new(),
+        );
+        let entry = make_entry(
+            "nan-alpha",
+            "adapter.safetensors",
+            "unused",
+            4,
+            8.0,
+            AdapterStatus::Approved,
+            vec!["q_proj".to_string()],
+        );
+
+        let err = validate_manifest_alpha(&adapter, &entry).unwrap_err();
+        assert!(err.to_string().contains("alpha mismatch"));
     }
 
     /// FIX-3 (round 2), mutation-sensitive: a symlink inside base_dir that points

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -81,11 +81,42 @@ pub struct LoraConfig {
 impl LoraConfig {
     /// Compute the LoRA scaling factor: `alpha / rank`.
     pub fn scale(&self) -> f32 {
-        if self.rank == 0 {
+        let scale = if self.rank == 0 {
             0.0
         } else {
             self.alpha / self.rank as f32
+        };
+        if self.alpha.is_finite() && scale.is_finite() {
+            scale
+        } else {
+            0.0
         }
+    }
+
+    /// Validate that the LoRA alpha and effective scale are finite.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::TuneError::Validation`] when `alpha` or the
+    /// effective `alpha / rank` scale is not finite.
+    pub fn validate(&self) -> crate::error::Result<()> {
+        if !self.alpha.is_finite() {
+            return Err(crate::error::TuneError::Validation(format!(
+                "LoRA alpha must be finite, got {}",
+                self.alpha
+            )));
+        }
+        let scale = if self.rank == 0 {
+            0.0
+        } else {
+            self.alpha / self.rank as f32
+        };
+        if !scale.is_finite() {
+            return Err(crate::error::TuneError::Validation(format!(
+                "LoRA effective scale must be finite, got {scale}"
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -223,6 +254,7 @@ impl LoraAdapter {
         &self,
         config: &lattice_inference::model::qwen35_config::Qwen35Config,
     ) -> crate::error::Result<()> {
+        self.config.validate()?;
         for ((layer_idx, module), layer) in &self.layers {
             if *layer_idx >= config.num_hidden_layers {
                 return Err(crate::error::TuneError::Validation(format!(
@@ -330,6 +362,21 @@ mod tests {
             target_modules: vec![],
         };
         assert_eq!(config_zero.scale(), 0.0);
+    }
+
+    #[test]
+    fn test_config_rejects_non_finite_alpha_and_scale_fails_closed() {
+        for alpha in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let config = LoraConfig {
+                rank: 8,
+                alpha,
+                target_modules: vec![],
+            };
+
+            let err = config.validate().unwrap_err();
+            assert!(err.to_string().contains("alpha must be finite"));
+            assert_eq!(config.scale(), 0.0);
+        }
     }
 
     #[test]

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -143,13 +143,43 @@ pub struct LoraLayer {
 ///
 /// Loaded from a PEFT-format safetensors file and applied at inference time
 /// to modify the output of specific linear projections in the transformer.
+///
+/// ```compile_fail
+/// use lattice_tune::lora::{LoraAdapter, LoraConfig};
+/// use std::collections::HashMap;
+///
+/// let adapter = LoraAdapter {
+///     config: LoraConfig {
+///         rank: 8,
+///         alpha: f32::NAN,
+///         target_modules: Vec::new(),
+///     },
+///     layers: HashMap::new(),
+/// };
+/// ```
+///
+/// ```compile_fail
+/// use lattice_tune::lora::{LoraAdapter, LoraConfig};
+/// use std::collections::HashMap;
+///
+/// let mut adapter = LoraAdapter::new(
+///     LoraConfig {
+///         rank: 8,
+///         alpha: 16.0,
+///         target_modules: Vec::new(),
+///     },
+///     HashMap::new(),
+/// )
+/// .unwrap();
+/// adapter.config.alpha = f32::NAN;
+/// ```
 #[derive(Debug, Clone)]
 pub struct LoraAdapter {
     /// Adapter configuration.
-    pub config: LoraConfig,
+    config: LoraConfig,
     /// Per-layer, per-module LoRA weights.
     /// Key: `(layer_idx, module_name)` e.g. `(5, "q_proj")`.
-    pub layers: HashMap<(usize, String), LoraLayer>,
+    layers: HashMap<(usize, String), LoraLayer>,
 }
 
 impl LoraAdapter {
@@ -200,6 +230,20 @@ impl LoraAdapter {
         Ok(Self { config, layers })
     }
 
+    /// Return the validated adapter configuration.
+    pub fn config(&self) -> &LoraConfig {
+        &self.config
+    }
+
+    /// Return the adapter weights keyed by transformer layer and module name.
+    pub fn layers(&self) -> &HashMap<(usize, String), LoraLayer> {
+        &self.layers
+    }
+
+    fn layers_mut(&mut self) -> &mut HashMap<(usize, String), LoraLayer> {
+        &mut self.layers
+    }
+
     /// Apply the LoRA adapter to a single projection output.
     ///
     /// Looks up the adapter for `(layer_idx, module)`. If no adapter exists
@@ -213,32 +257,32 @@ impl LoraAdapter {
     /// * `base_output` - Base projection output to modify in-place (length = d_out)
     pub fn apply(&self, layer_idx: usize, module: &str, x: &[f32], base_output: &mut [f32]) {
         let key = (layer_idx, module.to_string());
-        if let Some(lora_layer) = self.layers.get(&key) {
-            let scale = self.config.scale();
+        if let Some(lora_layer) = self.layers().get(&key) {
+            let scale = self.config().scale();
             apply_lora(lora_layer, scale, x, base_output);
         }
     }
 
     /// Check if the adapter has weights for a specific layer and module.
     pub fn has_adapter(&self, layer_idx: usize, module: &str) -> bool {
-        self.layers.contains_key(&(layer_idx, module.to_string()))
+        self.layers().contains_key(&(layer_idx, module.to_string()))
     }
 
     /// Return the number of adapted projection layers.
     pub fn num_adapted_layers(&self) -> usize {
-        self.layers.len()
+        self.layers().len()
     }
 
     /// Return the total number of LoRA parameters (A + B matrices).
     pub fn num_parameters(&self) -> usize {
-        self.layers.values().map(|l| l.a.len() + l.b.len()).sum()
+        self.layers().values().map(|l| l.a.len() + l.b.len()).sum()
     }
 
     /// Return `(layer_idx, module_name)` pairs whose module is not in `known`.
     ///
     /// Useful for detecting typos in adapter target modules before inference.
     pub fn validate_modules(&self, known: &[&str]) -> Vec<(usize, String)> {
-        self.layers
+        self.layers()
             .keys()
             .filter(|(_, m)| !known.iter().any(|k| k == m))
             .cloned()
@@ -262,8 +306,8 @@ impl LoraAdapter {
         &self,
         config: &lattice_inference::model::qwen35_config::Qwen35Config,
     ) -> crate::error::Result<()> {
-        self.config.validate()?;
-        for ((layer_idx, module), layer) in &self.layers {
+        self.config().validate()?;
+        for ((layer_idx, module), layer) in self.layers() {
             if *layer_idx >= config.num_hidden_layers {
                 return Err(crate::error::TuneError::Validation(format!(
                     "LoRA layer index {layer_idx} >= model num_hidden_layers {} (module: {module})",

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -188,8 +188,16 @@ impl LoraAdapter {
 
     /// Construct an adapter from pre-built components (for testing or
     /// when loading from a custom format).
-    pub fn new(config: LoraConfig, layers: HashMap<(usize, String), LoraLayer>) -> Self {
-        Self { config, layers }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the adapter configuration is invalid.
+    pub fn new(
+        config: LoraConfig,
+        layers: HashMap<(usize, String), LoraLayer>,
+    ) -> crate::error::Result<Self> {
+        config.validate()?;
+        Ok(Self { config, layers })
     }
 
     /// Apply the LoRA adapter to a single projection output.
@@ -344,7 +352,7 @@ mod tests {
             },
         );
 
-        LoraAdapter::new(config, layers)
+        LoraAdapter::new(config, layers).expect("valid adapter config")
     }
 
     #[test]
@@ -376,6 +384,23 @@ mod tests {
             let err = config.validate().unwrap_err();
             assert!(err.to_string().contains("alpha must be finite"));
             assert_eq!(config.scale(), 0.0);
+        }
+    }
+
+    #[test]
+    fn test_adapter_construction_rejects_non_finite_alpha() {
+        for alpha in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let result = LoraAdapter::new(
+                LoraConfig {
+                    rank: 8,
+                    alpha,
+                    target_modules: vec![],
+                },
+                HashMap::new(),
+            );
+
+            let err = result.expect_err("non-finite alpha must reject adapter construction");
+            assert!(err.to_string().contains("alpha must be finite"));
         }
     }
 
@@ -469,7 +494,7 @@ mod tests {
                 rank: 2,
             },
         );
-        let adapter = LoraAdapter::new(config, layers);
+        let adapter = LoraAdapter::new(config, layers).expect("valid adapter config");
         let unknown = adapter.validate_modules(&["q_proj", "v_proj"]);
         assert_eq!(unknown.len(), 1);
         assert_eq!(unknown[0], (0, "q_porj".to_string()));
@@ -482,7 +507,7 @@ mod tests {
             alpha: 4.0,
             target_modules: vec![],
         };
-        let adapter = LoraAdapter::new(config, HashMap::new());
+        let adapter = LoraAdapter::new(config, HashMap::new()).expect("valid adapter config");
         let unknown = adapter.validate_modules(&["q_proj"]);
         assert!(unknown.is_empty());
     }
@@ -518,6 +543,7 @@ mod tests {
                 },
                 layers,
             )
+            .expect("valid adapter config")
         }
 
         #[test]

--- a/crates/tune/src/lora/online.rs
+++ b/crates/tune/src/lora/online.rs
@@ -165,7 +165,7 @@ mod tests {
                 rank: 2,
             },
         );
-        LoraAdapter::new(config, layers)
+        LoraAdapter::new(config, layers).expect("valid adapter config")
     }
 
     #[test]

--- a/crates/tune/src/lora/online.rs
+++ b/crates/tune/src/lora/online.rs
@@ -43,11 +43,11 @@ pub fn adapt_step(
     target_delta: &[f32],
     learning_rate: f32,
 ) -> Result<AdaptStepResult, TuneError> {
-    // Extract scale before any mutable borrow of adapter.layers.
-    let scale = adapter.config.scale();
+    // Extract scale before any mutable borrow of adapter layers.
+    let scale = adapter.config().scale();
 
     let lora = adapter
-        .layers
+        .layers_mut()
         .get_mut(&(layer_idx, module.to_string()))
         .ok_or_else(|| TuneError::Training(format!("no LoRA layer for ({layer_idx}, {module})")))?;
 
@@ -172,8 +172,8 @@ mod tests {
     fn test_adapt_step_basic() {
         let mut adapter = make_small_adapter();
         let key = (0usize, "q_proj".to_string());
-        let a_init = adapter.layers[&key].a.clone();
-        let b_init = adapter.layers[&key].b.clone();
+        let a_init = adapter.layers()[&key].a.clone();
+        let b_init = adapter.layers()[&key].b.clone();
 
         let input = [1.0f32, 2.0, 3.0];
         let target_delta = [5.0f32, 5.0];
@@ -183,8 +183,8 @@ mod tests {
 
         assert!(r1.loss > 0.0, "initial loss must be positive");
         assert!(r1.grad_norm > 0.0, "initial grad_norm must be positive");
-        assert_ne!(adapter.layers[&key].a, a_init, "A must change after step");
-        assert_ne!(adapter.layers[&key].b, b_init, "B must change after step");
+        assert_ne!(adapter.layers()[&key].a, a_init, "A must change after step");
+        assert_ne!(adapter.layers()[&key].b, b_init, "B must change after step");
 
         let r2 = adapt_step(&mut adapter, 0, "q_proj", &input, &target_delta, 0.01)
             .expect("second adapt_step should succeed");
@@ -266,7 +266,7 @@ mod tests {
         );
 
         let key = (0usize, "q_proj".to_string());
-        assert_eq!(adapter1.layers[&key].a, adapter2.layers[&key].a);
-        assert_eq!(adapter1.layers[&key].b, adapter2.layers[&key].b);
+        assert_eq!(adapter1.layers()[&key].a, adapter2.layers()[&key].a);
+        assert_eq!(adapter1.layers()[&key].b, adapter2.layers()[&key].b);
     }
 }

--- a/crates/tune/src/lora/optimizer.rs
+++ b/crates/tune/src/lora/optimizer.rs
@@ -289,7 +289,7 @@ mod tests {
                 rank: 2,
             },
         );
-        LoraAdapter::new(config, layers)
+        LoraAdapter::new(config, layers).expect("valid adapter config")
     }
 
     // ─── gradient computation tests ────────────────────────────────────────

--- a/crates/tune/src/lora/optimizer.rs
+++ b/crates/tune/src/lora/optimizer.rs
@@ -179,10 +179,10 @@ pub fn compute_lora_gradients(
     input: &[f32],
     target_delta: &[f32],
 ) -> Result<LoraGradients, TuneError> {
-    let scale = adapter.config.scale();
+    let scale = adapter.config().scale();
 
     let lora = adapter
-        .layers
+        .layers()
         .get(&(layer_idx, module.to_string()))
         .ok_or_else(|| TuneError::Training(format!("no LoRA layer for ({layer_idx}, {module})")))?;
 

--- a/crates/tune/src/lora/safetensors.rs
+++ b/crates/tune/src/lora/safetensors.rs
@@ -393,9 +393,7 @@ pub(crate) fn load_peft_safetensors_bytes(bytes: &[u8]) -> Result<LoraAdapter, T
         alpha,
         target_modules: target_modules.into_iter().collect(),
     };
-    config.validate()?;
-
-    Ok(LoraAdapter { config, layers })
+    LoraAdapter::new(config, layers)
 }
 
 /// Read the `adapter_id` metadata key from a PEFT safetensors byte slice.
@@ -1182,7 +1180,7 @@ mod tests {
             },
         );
 
-        let adapter = LoraAdapter::new(config, layers);
+        let adapter = LoraAdapter::new(config, layers).expect("valid adapter config");
 
         let temp = NamedTempFile::new().unwrap();
         save_peft_safetensors(&adapter, temp.path(), None).unwrap();
@@ -1239,7 +1237,7 @@ mod tests {
                 rank,
             },
         );
-        let adapter = LoraAdapter::new(config, layers);
+        let adapter = LoraAdapter::new(config, layers).expect("valid adapter config");
 
         let governance = AdapterGovernance {
             name: "test-adapter".to_string(),
@@ -1286,7 +1284,7 @@ mod tests {
                 rank,
             },
         );
-        let adapter = LoraAdapter::new(config, layers);
+        let adapter = LoraAdapter::new(config, layers).expect("valid adapter config");
 
         let temp = NamedTempFile::new().unwrap();
         save_peft_safetensors(&adapter, temp.path(), None).unwrap();
@@ -1354,7 +1352,7 @@ mod tests {
             },
         );
 
-        let adapter = LoraAdapter::new(config, layers);
+        let adapter = LoraAdapter::new(config, layers).expect("valid adapter config");
         let temp = NamedTempFile::new().unwrap();
         save_peft_safetensors(&adapter, temp.path(), None).unwrap();
         let loaded = load_peft_safetensors(temp.path()).unwrap();
@@ -1503,7 +1501,7 @@ mod tests {
             },
         );
 
-        let adapter = LoraAdapter::new(config, layers);
+        let adapter = LoraAdapter::new(config, layers).expect("valid adapter config");
 
         let temp = NamedTempFile::new().unwrap();
         // This was the regression: pre-fix this call returned Err(InvalidTensorView).

--- a/crates/tune/src/lora/safetensors.rs
+++ b/crates/tune/src/lora/safetensors.rs
@@ -604,12 +604,12 @@ pub fn save_peft_safetensors(
     path: &Path,
     governance: Option<&AdapterGovernance>,
 ) -> Result<(), TuneError> {
-    adapter.config.validate()?;
+    adapter.config().validate()?;
 
     // Collect owned byte buffers first; TensorView borrows from these.
     let mut byte_data: Vec<(String, Vec<usize>, Vec<u8>)> = Vec::new();
 
-    for ((layer_idx, module), layer) in &adapter.layers {
+    for ((layer_idx, module), layer) in adapter.layers() {
         // A LoRA layer with an empty factor buffer means "this module was not trained"
         // (e.g. GDN-attention slots leave q_proj/v_proj empty). Skip it rather than
         // emit an InvalidTensorView for a zero-byte tensor with non-zero shape.
@@ -644,11 +644,11 @@ pub fn save_peft_safetensors(
     }
 
     let mut metadata_map = HashMap::new();
-    metadata_map.insert("rank".to_string(), adapter.config.rank.to_string());
-    metadata_map.insert("alpha".to_string(), adapter.config.alpha.to_string());
+    metadata_map.insert("rank".to_string(), adapter.config().rank.to_string());
+    metadata_map.insert("alpha".to_string(), adapter.config().alpha.to_string());
     metadata_map.insert(
         "target_modules".to_string(),
-        adapter.config.target_modules.join(","),
+        adapter.config().target_modules.join(","),
     );
     if let Some(governance) = governance {
         metadata_map.insert("gov_name".to_string(), governance.name.clone());
@@ -888,28 +888,28 @@ mod tests {
         let adapter = load_peft_safetensors(&path).unwrap();
 
         // Check config
-        assert_eq!(adapter.config.rank, rank);
-        assert_eq!(adapter.config.target_modules.len(), 2);
+        assert_eq!(adapter.config().rank, rank);
+        assert_eq!(adapter.config().target_modules.len(), 2);
         assert!(
             adapter
-                .config
+                .config()
                 .target_modules
                 .contains(&"q_proj".to_string())
         );
         assert!(
             adapter
-                .config
+                .config()
                 .target_modules
                 .contains(&"gate_proj".to_string())
         );
 
         // Check we got both layers
-        assert_eq!(adapter.layers.len(), 2);
-        assert!(adapter.layers.contains_key(&(0, "q_proj".to_string())));
-        assert!(adapter.layers.contains_key(&(2, "gate_proj".to_string())));
+        assert_eq!(adapter.layers().len(), 2);
+        assert!(adapter.layers().contains_key(&(0, "q_proj".to_string())));
+        assert!(adapter.layers().contains_key(&(2, "gate_proj".to_string())));
 
         // Check dimensions
-        let q_lora = &adapter.layers[&(0, "q_proj".to_string())];
+        let q_lora = &adapter.layers()[&(0, "q_proj".to_string())];
         assert_eq!(q_lora.rank, rank);
         assert_eq!(q_lora.d_in, d_in);
         assert_eq!(q_lora.d_out, d_out);
@@ -922,7 +922,7 @@ mod tests {
         assert!((q_lora.a[2] - 0.02).abs() < 1e-6);
 
         // Check gate_proj layer
-        let g_lora = &adapter.layers[&(2, "gate_proj".to_string())];
+        let g_lora = &adapter.layers()[&(2, "gate_proj".to_string())];
         assert_eq!(g_lora.rank, rank);
         assert!((g_lora.a[1] - (-0.01)).abs() < 1e-6);
     }
@@ -965,9 +965,9 @@ mod tests {
         std::fs::write(&path, bytes).unwrap();
 
         let adapter = load_peft_safetensors(&path).unwrap();
-        assert_eq!(adapter.config.rank, 2);
+        assert_eq!(adapter.config().rank, 2);
 
-        let lora = &adapter.layers[&(0, "q_proj".to_string())];
+        let lora = &adapter.layers()[&(0, "q_proj".to_string())];
         assert_eq!(lora.rank, 2);
         assert_eq!(lora.d_in, 4);
         assert_eq!(lora.d_out, 3);
@@ -1013,17 +1013,17 @@ mod tests {
         std::fs::write(&path, bytes).unwrap();
 
         let adapter = load_peft_safetensors(&path).unwrap();
-        assert_eq!(adapter.config.rank, 1);
+        assert_eq!(adapter.config().rank, 1);
         // Default alpha = rank = 1, so scale = 1.0
 
-        let lora = &adapter.layers[&(0, "v_proj".to_string())];
+        let lora = &adapter.layers()[&(0, "v_proj".to_string())];
         // x = [3, 5]
         // A @ x = [0*3 + 1*5] = [5]
         // B @ [5] = [1*5, 0*5] = [5, 0]
         // scale = 1.0 => output += [5, 0]
         let x = [3.0f32, 5.0];
         let mut output = [10.0, 20.0];
-        super::super::apply_lora(lora, adapter.config.scale(), &x, &mut output);
+        super::super::apply_lora(lora, adapter.config().scale(), &x, &mut output);
 
         assert!((output[0] - 15.0).abs() < 1e-6);
         assert!((output[1] - 20.0).abs() < 1e-6);
@@ -1187,13 +1187,13 @@ mod tests {
 
         let loaded = load_peft_safetensors(temp.path()).unwrap();
 
-        assert_eq!(loaded.layers.len(), adapter.layers.len());
-        assert_eq!(loaded.config.rank, adapter.config.rank);
-        assert_eq!(loaded.config.alpha, adapter.config.alpha);
+        assert_eq!(loaded.layers().len(), adapter.layers().len());
+        assert_eq!(loaded.config().rank, adapter.config().rank);
+        assert_eq!(loaded.config().alpha, adapter.config().alpha);
 
-        for (key, orig) in &adapter.layers {
+        for (key, orig) in adapter.layers() {
             let got = loaded
-                .layers
+                .layers()
                 .get(key)
                 .expect("layer key missing after round-trip");
             assert_eq!(got.rank, orig.rank);
@@ -1357,9 +1357,9 @@ mod tests {
         save_peft_safetensors(&adapter, temp.path(), None).unwrap();
         let loaded = load_peft_safetensors(temp.path()).unwrap();
 
-        assert_eq!(loaded.config.rank, 4);
-        assert_eq!(loaded.config.alpha, 16.0);
-        assert!((loaded.config.alpha - 16.0).abs() < f32::EPSILON);
+        assert_eq!(loaded.config().rank, 4);
+        assert_eq!(loaded.config().alpha, 16.0);
+        assert!((loaded.config().alpha - 16.0).abs() < f32::EPSILON);
     }
 
     #[test]
@@ -1391,8 +1391,8 @@ mod tests {
         std::fs::write(&path, bytes).unwrap();
 
         let loaded = load_peft_safetensors(&path).unwrap();
-        assert_eq!(loaded.config.rank, 2);
-        assert_eq!(loaded.config.alpha, 2.0);
+        assert_eq!(loaded.config().rank, 2);
+        assert_eq!(loaded.config().alpha, 2.0);
     }
 
     #[test]
@@ -1513,19 +1513,19 @@ mod tests {
         // The real layer is present.
         let real_key = (19usize, "q_proj".to_string());
         assert!(
-            loaded.layers.contains_key(&real_key),
+            loaded.layers().contains_key(&real_key),
             "real GQA layer (19, q_proj) must be present after round-trip"
         );
 
         // The empty layer was dropped — it must NOT appear in the saved file.
         let empty_key = (20usize, "v_proj".to_string());
         assert!(
-            !loaded.layers.contains_key(&empty_key),
+            !loaded.layers().contains_key(&empty_key),
             "empty GDN-slot layer (20, v_proj) must be absent from saved adapter"
         );
 
         // The A buffer of the real layer must be bit-exact.
-        let got = &loaded.layers[&real_key];
+        let got = &loaded.layers()[&real_key];
         let expected_a = vec![0.1f32; rank * 1024];
         assert_eq!(got.a.len(), expected_a.len());
         for (g, w) in got.a.iter().zip(&expected_a) {

--- a/crates/tune/src/lora/safetensors.rs
+++ b/crates/tune/src/lora/safetensors.rs
@@ -366,29 +366,36 @@ pub(crate) fn load_peft_safetensors_bytes(bytes: &[u8]) -> Result<LoraAdapter, T
 
     let rank = rank.unwrap_or(0);
 
-    // Recover the LoRA alpha from the safetensors header metadata that
-    // save_peft_safetensors writes. Without this, every adapter would load with
-    // alpha = rank (scale = 1.0), applying a model trained at alpha != rank at the
-    // wrong magnitude. Fall back to `rank` (scale = 1.0) when the metadata is
-    // absent or unparseable, preserving behavior for adapters that lack it.
-    let alpha = SafeTensors::read_metadata(bytes)
+    let alpha_metadata = SafeTensors::read_metadata(bytes)
         .ok()
         .and_then(|(_, meta)| {
             meta.metadata()
                 .as_ref()
                 .and_then(|m| m.get("alpha").cloned())
-        })
-        .and_then(|s| s.parse::<f32>().ok())
-        .unwrap_or(rank as f32);
+        });
+    let alpha = match alpha_metadata {
+        Some(value) => {
+            let alpha = value.parse::<f32>().map_err(|e| {
+                TuneError::Serialization(format!("invalid LoRA alpha metadata '{value}': {e}"))
+            })?;
+            if !alpha.is_finite() {
+                return Err(TuneError::Serialization(format!(
+                    "LoRA alpha metadata must be finite, got '{value}'"
+                )));
+            }
+            alpha
+        }
+        None => rank as f32,
+    };
 
-    Ok(LoraAdapter {
-        config: LoraConfig {
-            rank,
-            alpha,
-            target_modules: target_modules.into_iter().collect(),
-        },
-        layers,
-    })
+    let config = LoraConfig {
+        rank,
+        alpha,
+        target_modules: target_modules.into_iter().collect(),
+    };
+    config.validate()?;
+
+    Ok(LoraAdapter { config, layers })
 }
 
 /// Read the `adapter_id` metadata key from a PEFT safetensors byte slice.
@@ -599,6 +606,8 @@ pub fn save_peft_safetensors(
     path: &Path,
     governance: Option<&AdapterGovernance>,
 ) -> Result<(), TuneError> {
+    adapter.config.validate()?;
+
     // Collect owned byte buffers first; TensorView borrows from these.
     let mut byte_data: Vec<(String, Vec<usize>, Vec<u8>)> = Vec::new();
 
@@ -1028,6 +1037,38 @@ mod tests {
         bytes.extend_from_slice(header.as_bytes());
         bytes.extend_from_slice(data);
         std::fs::write(path, bytes).unwrap();
+    }
+
+    fn peft_bytes_with_alpha(alpha: &str) -> Vec<u8> {
+        use safetensors::Dtype;
+        use safetensors::tensor::{TensorView, serialize};
+
+        let a_bytes = 1.0f32.to_le_bytes();
+        let b_bytes = 1.0f32.to_le_bytes();
+        let mut tensors = HashMap::new();
+        tensors.insert(
+            "model.layers.0.self_attn.q_proj.lora_A.weight".to_string(),
+            TensorView::new(Dtype::F32, vec![1, 1], &a_bytes).unwrap(),
+        );
+        tensors.insert(
+            "model.layers.0.self_attn.q_proj.lora_B.weight".to_string(),
+            TensorView::new(Dtype::F32, vec![1, 1], &b_bytes).unwrap(),
+        );
+        let metadata = HashMap::from([("alpha".to_string(), alpha.to_string())]);
+        serialize(&tensors, &Some(metadata)).unwrap()
+    }
+
+    #[test]
+    fn test_rejects_non_finite_alpha_metadata() {
+        for alpha in ["nan", "inf", "-inf"] {
+            let bytes = peft_bytes_with_alpha(alpha);
+            let err = load_peft_safetensors_bytes(&bytes).unwrap_err();
+            let message = err.to_string();
+            assert!(
+                message.contains("LoRA alpha metadata must be finite"),
+                "expected descriptive rejection for {alpha}, got: {message}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -420,7 +420,7 @@ pub fn train_micro_lora(
         alpha,
         target_modules: vec!["q_proj".to_string(), "v_proj".to_string()],
     };
-    Ok(LoraAdapter::new(lora_config, adapter_layers))
+    LoraAdapter::new(lora_config, adapter_layers)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Fixes #750.

## What

Non-finite LoRA alpha (`"nan"`/`"inf"`/`"-inf"` in safetensors metadata, CLI flags, or programmatic construction) was accepted by every CPU-side boundary — the metadata parser had no `is_finite()` gate, `LoraConfig::scale()` returned NaN/Inf to arithmetic callers, and the governed-manifest tolerance check `(adapter.alpha - entry.alpha).abs() > tol` is always false for NaN, so a NaN-alpha adapter passed the manifest gate against a finite declared alpha. Only the Metal attach path rejected non-finite scale.

Now fail-closed at each boundary:
- `safetensors.rs`: absent alpha keeps the documented `alpha = rank` fallback; present-but-malformed or non-finite alpha is a descriptive loader error (and non-finite alpha is rejected on save, so invalid metadata cannot be emitted).
- `mod.rs`: new `LoraConfig::validate()` (finite alpha + finite effective scale). `LoraAdapter::new` validates and returns `Result`, and the adapter's `config`/`layers` state is now private with read-only accessors, so an invalid adapter cannot be literal-constructed or mutated into existence — it is rejected before reaching the infallible `apply`/`LoraHook`, blend, gradient, or online-update paths. `scale()` fails closed to `0.0` instead of returning NaN/Inf (consistent with its existing `rank == 0` behavior).
- `loader.rs`: manifest alpha comparison rejects non-finite adapter alpha, manifest alpha, or difference before applying the `1e-4` tolerance.
- `generate_lora.rs`: validates the adapter before reporting or attaching it.
- `train_grad.rs` / `train_grad_layer23.rs`: `--alpha` parsing rejects non-finite and unparseable values, and a present `--alpha` with a missing value is an explicit error; the `16.0` default applies only when the flag is truly absent.

## Tests (mutation-verified)

Each regression was verified to fail with its specific guard reverted: non-finite metadata rejection (nan/inf/-inf), NaN-alpha adapter vs finite manifest rejection, config validation + fail-closed scale, checked-constructor rejection, two compile-fail doctests pinning that `LoraAdapter` cannot be literal-constructed or field-mutated (both fail when field privacy is reverted), and per-binary CLI parser rejections including the bare-`--alpha` case. The finite-alpha round-trip and the absent-metadata `alpha = rank` fallback were already covered by pre-existing tests, which stay green throughout.

`cargo test -p lattice-tune` across default, `safetensors,serde,inference-hook`, and `train-backward` feature sets: all green. `cargo clippy --workspace -- -D warnings` clean.

No bench-compare: `lattice-tune` only — no `crates/inference/` or `crates/embed/` code touched (the two `Cargo.toml` version lines in inference/embed are dependency-version metadata, not code).

## Version

Hiding `LoraAdapter`'s previously public `config`/`layers` fields is a semver-major change against the published 0.6.1 crates (flagged by cargo-semver-checks), so this PR bumps the workspace and internal path-dependency versions to 0.7.0 in lockstep, opening the 0.7.0 line.
