### PR TITLE
fix(inference): grammar/tokenizer correctness — detok finalization on EOS/grammar stop, SentencePiece ID+added-token guards, exact grammar byte tables

### DIFF
--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -3353,13 +3353,8 @@ mod serve {
         tokenizer: &lattice_inference::tokenizer::bpe::BpeTokenizer,
         token_id: u32,
     ) -> (String, Option<Vec<u8>>) {
-        match tokenizer.token_for_id(token_id) {
-            Some(tok_str) => (
-                lattice_inference::tokenizer::bpe::byte_decode_token(tok_str),
-                Some(lattice_inference::tokenizer::bpe::byte_decode_token_bytes(
-                    tok_str,
-                )),
-            ),
+        match tokenizer.token_bytes_for_id(token_id) {
+            Some(bytes) => (String::from_utf8_lossy(&bytes).into_owned(), Some(bytes)),
             None => (format!("<|unresolved_token_{token_id}|>"), None),
         }
     }

--- a/crates/inference/src/bin/qwen35_debug.rs
+++ b/crates/inference/src/bin/qwen35_debug.rs
@@ -1,7 +1,15 @@
 //! Debug diagnostic for Qwen3.5-2B — checks each stage of the forward pass.
 
+use lattice_inference::tokenizer::bpe::BpeTokenizer;
 use lattice_inference::tokenizer::common::Tokenizer;
 use std::path::PathBuf;
+
+fn decode_token(tokenizer: &BpeTokenizer, token_id: u32) -> String {
+    tokenizer
+        .token_bytes_for_id(token_id)
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+        .unwrap_or_else(|| "??".to_string())
+}
 
 fn main() {
     let model_dir = std::env::var("LATTICE_MODEL_CACHE")
@@ -45,8 +53,7 @@ fn main() {
 
             // Decode each token
             for &tid in &output.token_ids {
-                let tok = tokenizer.token_for_id(tid).unwrap_or("??");
-                let decoded = lattice_inference::tokenizer::bpe::byte_decode_token(tok);
+                let decoded = decode_token(tokenizer, tid);
                 println!("  {tid} -> {decoded:?}");
             }
         }
@@ -72,8 +79,7 @@ fn main() {
     si.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     println!("Top-5:");
     for (i, (tok, logit)) in si.iter().take(5).enumerate() {
-        let name = tokenizer.token_for_id(*tok as u32).unwrap_or("??");
-        let decoded = lattice_inference::tokenizer::bpe::byte_decode_token(name);
+        let decoded = decode_token(tokenizer, *tok as u32);
         println!("  {i}: token_id={tok}, logit={logit:.4}, decoded={decoded:?}");
     }
     println!("Python: 2614(' following')=12.69, 220(' ')=11.50, 7193(' purpose')=11.13");
@@ -95,8 +101,7 @@ fn main() {
     println!("\nTop-10 tokens:");
     println!("Python top: 11751(' Paris')=18.875, 279(' the')=16.5, 264(' a')=16.25");
     for (i, (tok, logit)) in indexed.iter().take(10).enumerate() {
-        let name = tokenizer.token_for_id(*tok as u32).unwrap_or("??");
-        let decoded = lattice_inference::tokenizer::bpe::byte_decode_token(name);
+        let decoded = decode_token(tokenizer, *tok as u32);
         println!("  {i}: token_id={tok}, logit={logit:.4}, decoded={decoded:?}");
     }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -13102,10 +13102,7 @@ mod inner {
     }
 
     fn decode_tokens(tokenizer: &BpeTokenizer, ids: &[u32]) -> String {
-        ids.iter()
-            .filter_map(|id| tokenizer.token_for_id(*id))
-            .map(crate::tokenizer::bpe::byte_decode_token)
-            .collect()
+        crate::model::qwen35::detokenize::decode_tokens(tokenizer, ids)
     }
 
     // -----------------------------------------------------------------------

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -143,7 +143,7 @@ impl GrammarEngine {
     /// Build a `GrammarEngine` from a `GrammarSpec` and the model vocabulary.
     ///
     /// `vocab_bytes[i]` is the UTF-8 / byte-level representation of token `i`.
-    /// For BPE tokenizers, obtain this via `BpeTokenizer::vocab_bytes()`.
+    /// For BPE tokenizers, obtain this via `BpeTokenizer::vocab_bytes(model_vocab_size)`.
     ///
     /// This runs in O(|states| × vocab_size × max_token_len) time.  For
     /// large vocabularies (e.g. Qwen3 at 248,320 tokens) this may take

--- a/crates/inference/src/grammar/mod.rs
+++ b/crates/inference/src/grammar/mod.rs
@@ -26,7 +26,7 @@
 //! use lattice_inference::generate::GenerateConfig;
 //!
 //! let spec = GrammarSpec::json_schema_str(r#"{"type":"object","properties":{"name":{"type":"string"}}}"#)?;
-//! let vocab_bytes: Vec<Vec<u8>> = tokenizer.vocab_bytes();
+//! let vocab_bytes: Vec<Vec<u8>> = tokenizer.vocab_bytes(model.config().vocab_size)?;
 //! let engine = Arc::new(GrammarEngine::new(&spec, vocab_bytes)?);
 //!
 //! let config = GenerateConfig {

--- a/crates/inference/src/model/qwen35/detokenize.rs
+++ b/crates/inference/src/model/qwen35/detokenize.rs
@@ -22,14 +22,7 @@ fn append_token_bytes(
     byte_decoder: &HashMap<char, u8>,
     out: &mut Vec<u8>,
 ) {
-    if let Some(token_str) = tokenizer.token_for_id(id) {
-        for ch in token_str.chars() {
-            if let Some(&b) = byte_decoder.get(&ch) {
-                out.push(b);
-            }
-            // Skip characters not in byte_decoder (e.g., special tokens)
-        }
-    }
+    tokenizer.append_token_bytes(id, byte_decoder, out);
 }
 
 /// Decode token IDs back to text using the BPE tokenizer's reverse lookup.

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -924,6 +924,7 @@ impl Qwen35Model {
 
             let mut stopped = false;
             let mut stopped_by_caller = false;
+            let mut confirmed_stop_string_match = false;
             let mut stop_reason = StopReason::Length;
             // Decode loop for the string-stop path.
             // cap = rb + max_new_tokens when budgeting; max_new_tokens otherwise (parity-safe).
@@ -1024,6 +1025,7 @@ impl Qwen35Model {
                     }
                     StepOutcome::Stopped => {
                         stopped = true;
+                        confirmed_stop_string_match = true;
                         stop_reason = StopReason::Eos;
                         break;
                     }
@@ -1043,8 +1045,10 @@ impl Qwen35Model {
             // Skip when the caller asked to stop -- it is no longer consuming
             // the stream, and `on_token`'s return value here would not change
             // why generation actually stopped.
-            if !stopped_by_caller {
-                let tail_stopped = policy.finish_stop(&mut text, &detok.finish(), |s| on_token(s));
+            if !stopped_by_caller
+                && let Some(tail) = finish_detokenizer(&mut detok, confirmed_stop_string_match)
+            {
+                let tail_stopped = policy.finish_stop(&mut text, &tail, |s| on_token(s));
                 // finish_stop may itself complete a stop in the tail bytes.
                 if tail_stopped && !stopped {
                     stopped = true;
@@ -1739,6 +1743,13 @@ fn initial_rng_state(seed: Option<u64>) -> u64 {
     }
 }
 
+fn finish_detokenizer(
+    detok: &mut IncrementalDetokenizer,
+    confirmed_stop_string_match: bool,
+) -> Option<String> {
+    (!confirmed_stop_string_match).then(|| detok.finish())
+}
+
 fn prefill_tokens(
     model: &Qwen35Model,
     prompt_ids: &[u32],
@@ -1895,6 +1906,7 @@ fn decode_loop_with_stops(
 ) -> Result<(bool, StopReason), InferenceError> {
     let cfg = &model.config;
     let mut stopped = false;
+    let mut confirmed_stop_string_match = false;
     let mut stop_reason = StopReason::Length;
     let cap = policy.cap();
     for _ in 1..cap {
@@ -1973,6 +1985,7 @@ fn decode_loop_with_stops(
             }
             StepOutcome::Stopped => {
                 stopped = true;
+                confirmed_stop_string_match = true;
                 stop_reason = StopReason::Eos;
                 break;
             }
@@ -2000,23 +2013,24 @@ fn decode_loop_with_stops(
         }
     }
 
-    // Only flush detok tail when no stop was hit. A stop already truncated `full` to
-    // the correct position; appending tail bytes from past the stop would corrupt it.
-    if !stopped {
-        let tail = detok.finish();
-        if !tail.is_empty() {
-            full.push_str(&tail);
-            // The tail itself might complete a stop string.
-            if let Some(hit) = earliest_stop_match(full, &gen_cfg.stop_strings) {
-                full.truncate(hit);
-                truncate_token_logprobs_to_retained_text(
-                    token_logprobs,
-                    token_logprob_end_offsets,
-                    hit,
-                );
+    if let Some(tail) = finish_detokenizer(detok, confirmed_stop_string_match)
+        && !tail.is_empty()
+    {
+        full.push_str(&tail);
+        // The tail itself might complete a stop string.
+        if let Some(hit) = earliest_stop_match(full, &gen_cfg.stop_strings) {
+            full.truncate(hit);
+            truncate_token_logprobs_to_retained_text(
+                token_logprobs,
+                token_logprob_end_offsets,
+                hit,
+            );
+            if !stopped {
                 return Ok((true, StopReason::Eos));
             }
         }
+    }
+    if !stopped {
         return Ok((false, StopReason::Length));
     }
     Ok((stopped, stop_reason))
@@ -3629,6 +3643,44 @@ mod tests {
              have missed or mis-timed this token entirely; got {} prior on_token calls",
             snapshots_at_raw_event.borrow()[0]
         );
+    }
+
+    #[test]
+    fn eos_flushes_incomplete_utf8_tail_in_streaming_and_nonstreaming() {
+        const TOK_JSON: &str = r#"{
+  "version":"1.0","truncation":null,"padding":null,
+  "added_tokens":[{"id":7,"content":"</think>","special":false}],
+  "normalizer":null,
+  "pre_tokenizer":{"type":"ByteLevel","add_prefix_space":false,"trim_offsets":true,"use_regex":true},
+  "post_processor":null,
+  "decoder":{"type":"ByteLevel","add_prefix_space":true,"trim_offsets":true,"use_regex":true},
+  "model":{"type":"BPE","dropout":null,"unk_token":"<unk>","continuing_subword_prefix":null,
+    "end_of_word_suffix":null,"fuse_unk":false,"byte_fallback":false,"ignore_merges":false,
+    "vocab":{"Â":0,"<unk>":1,"a":2},"merges":[]}
+}"#;
+        let model = build_tiny_zero_model_tok(TOK_JSON);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 3,
+            temperature: 0.0,
+            enable_thinking: true,
+            reasoning_budget: Some(1),
+            stop_token_ids: vec![7],
+            stop_strings: vec!["never".to_string()],
+            ..Default::default()
+        };
+
+        let nonstreaming = model.generate("a", &gen_cfg).unwrap();
+        let mut streamed_text = String::new();
+        let streaming = model
+            .generate_streaming("a", &gen_cfg, |delta| streamed_text.push_str(delta))
+            .unwrap();
+
+        assert_eq!(nonstreaming.stop_reason, Some(StopReason::Eos));
+        assert_eq!(streaming.stop_reason, Some(StopReason::Eos));
+        assert_eq!(nonstreaming.token_ids, vec![0]);
+        assert_eq!(nonstreaming.text, "�");
+        assert_eq!(nonstreaming.text, streaming.text);
+        assert_eq!(streaming.text, streamed_text);
     }
 
     /// Stop-string truncation must drop `token_logprobs` entries whose decoded

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -467,18 +467,19 @@ impl BpeTokenizer {
         self.inner.special_tokens.get(name).copied()
     }
 
-    /// **Unstable**: return the byte representation of every token in the vocabulary.
+    /// **Unstable**: return the byte representation of every model token ID.
     ///
-    /// `vocab_bytes()[i]` is the UTF-8 byte sequence that token `i` decodes to,
-    /// after applying the GPT-2 byte-level encoding reversal.
-    /// The table includes added-token IDs; skipped control-token slots are empty.
+    /// `vocab_bytes(vocab_size)?[i]` is the byte sequence that token `i` decodes
+    /// to. Base BPE entries use GPT-2 byte-level reversal; renderable added tokens
+    /// use their literal UTF-8 bytes. Unknown and skipped control-token slots are
+    /// empty so grammar masking fails closed across the model's full logit space.
     ///
     /// Used by [`GrammarEngine::new`](crate::grammar::GrammarEngine::new) to build
     /// the precomputed vocabulary partition for grammar-constrained decoding (ADR-046).
     ///
     /// Cost: O(vocab_size) — called once at engine initialisation.
-    pub fn vocab_bytes(&self) -> Vec<Vec<u8>> {
-        let max_added_id = self
+    pub fn vocab_bytes(&self, vocab_size: usize) -> Result<Vec<Vec<u8>>, InferenceError> {
+        let required_vocab_size = self
             .inner
             .special_tokens
             .values()
@@ -486,14 +487,51 @@ impl BpeTokenizer {
             .copied()
             .max()
             .map_or(0usize, |id| id as usize + 1);
-        let model_vocab_size = self.inner.id_to_token.len().max(max_added_id);
-        (0..model_vocab_size)
-            .map(|id| {
-                self.token_for_id(id as u32)
-                    .map(byte_decode_token_bytes)
-                    .unwrap_or_default()
-            })
-            .collect()
+        let required_vocab_size = self.inner.id_to_token.len().max(required_vocab_size);
+        if vocab_size < required_vocab_size {
+            return Err(InferenceError::Tokenizer(format!(
+                "model vocabulary size {vocab_size} cannot represent tokenizer token ID {}",
+                required_vocab_size - 1
+            )));
+        }
+
+        let byte_decoder = byte_decoder();
+        let mut vocab_bytes = Vec::with_capacity(vocab_size);
+        for id in 0..vocab_size {
+            let mut bytes = Vec::new();
+            self.append_token_bytes(id as u32, &byte_decoder, &mut bytes);
+            vocab_bytes.push(bytes);
+        }
+        Ok(vocab_bytes)
+    }
+
+    /// **Unstable**: resolve one token ID to the exact bytes it emits.
+    ///
+    /// Base BPE entries are GPT-2 byte-decoded. Added tokens with `special=false`
+    /// are returned as literal UTF-8, while unknown and skipped special IDs return
+    /// `None`.
+    pub fn token_bytes_for_id(&self, id: u32) -> Option<Vec<u8>> {
+        let byte_decoder = byte_decoder();
+        let mut bytes = Vec::new();
+        self.append_token_bytes(id, &byte_decoder, &mut bytes)
+            .then_some(bytes)
+    }
+
+    pub(crate) fn append_token_bytes(
+        &self,
+        id: u32,
+        byte_decoder: &HashMap<char, u8>,
+        out: &mut Vec<u8>,
+    ) -> bool {
+        if let Some(content) = self.inner.added_render.get(&id) {
+            out.extend_from_slice(content.as_bytes());
+            return true;
+        }
+        let Some(token_str) = self.inner.id_to_token.get(id as usize) else {
+            return false;
+        };
+        append_byte_decoded_token_bytes(token_str, byte_decoder, out);
+        true
     }
 
     fn tokenize_to_ids(&self, text: &str) -> Vec<u32> {
@@ -769,8 +807,12 @@ impl Tokenizer for BpeTokenizer {
     }
 
     fn decode(&self, ids: &[u32]) -> Option<String> {
-        let encoded: String = ids.iter().filter_map(|&id| self.token_for_id(id)).collect();
-        Some(byte_decode_token(&encoded))
+        let byte_decoder = byte_decoder();
+        let mut bytes = Vec::new();
+        for &id in ids {
+            self.append_token_bytes(id, &byte_decoder, &mut bytes);
+        }
+        Some(String::from_utf8_lossy(&bytes).into_owned())
     }
 
     fn vocab_size(&self) -> usize {
@@ -868,15 +910,30 @@ fn bytes_to_unicode() -> Vec<char> {
 /// text). Used by the `logprobs`/`top_logprobs` response `bytes` field
 /// (#585), where callers reconstruct the original output byte-for-byte.
 pub fn byte_decode_token_bytes(token_str: &str) -> Vec<u8> {
-    let table = bytes_to_unicode();
-    let mut decoder = std::collections::HashMap::new();
-    for (byte_val, &ch) in table.iter().enumerate() {
-        decoder.insert(ch, byte_val as u8);
-    }
-    token_str
-        .chars()
-        .filter_map(|ch| decoder.get(&ch).copied())
+    let decoder = byte_decoder();
+    let mut bytes = Vec::new();
+    append_byte_decoded_token_bytes(token_str, &decoder, &mut bytes);
+    bytes
+}
+
+fn byte_decoder() -> HashMap<char, u8> {
+    bytes_to_unicode()
+        .into_iter()
+        .enumerate()
+        .map(|(byte, ch)| (ch, byte as u8))
         .collect()
+}
+
+fn append_byte_decoded_token_bytes(
+    token_str: &str,
+    byte_decoder: &HashMap<char, u8>,
+    out: &mut Vec<u8>,
+) {
+    out.extend(
+        token_str
+            .chars()
+            .filter_map(|ch| byte_decoder.get(&ch).copied()),
+    );
 }
 
 /// **Unstable**: byte-decode helper; encoding table and fallback behavior may change.
@@ -1517,7 +1574,7 @@ mod tests {
         vocab.insert(byte_encoder[0xA5].to_string(), 1);
         vocab.insert(byte_encoder[0xBD].to_string(), 2);
         let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, Vec::new()).unwrap();
-        let vocab_bytes = tokenizer.vocab_bytes();
+        let vocab_bytes = tokenizer.vocab_bytes(3).unwrap();
         assert_eq!(vocab_bytes, vec![vec![0xE5], vec![0xA5], vec![0xBD]]);
 
         let spec = GrammarSpec::Gbnf("root ::= \"好\"\n".to_string());
@@ -1546,7 +1603,7 @@ mod tests {
             ]
         }"#;
         let tokenizer = BpeTokenizer::from_tokenizer_json_str(json).unwrap();
-        let vocab_bytes = tokenizer.vocab_bytes();
+        let vocab_bytes = tokenizer.vocab_bytes(101).unwrap();
         assert_eq!(vocab_bytes.len(), 101);
         assert!(vocab_bytes[99].is_empty());
         assert_eq!(vocab_bytes[100], b"<extra>");
@@ -1558,6 +1615,92 @@ mod tests {
         engine.mask_logits(&mut state, &mut logits);
         assert_eq!(logits[99], f32::NEG_INFINITY);
         assert_eq!(logits[100], f32::NEG_INFINITY);
+    }
+
+    fn non_ascii_added_tokenizer() -> BpeTokenizer {
+        let json = r#"{
+            "model":{"type":"BPE","vocab":{"a":0},"merges":[]},
+            "added_tokens":[
+                {"id":100,"content":"好","special":false},
+                {"id":101,"content":"café","special":false}
+            ]
+        }"#;
+        BpeTokenizer::from_tokenizer_json_str(json).unwrap()
+    }
+
+    #[test]
+    fn grammar_vocab_fail_closes_qwen_reserved_tail() {
+        use crate::grammar::{GrammarEngine, GrammarSpec};
+        use crate::model::qwen35_config::Qwen35Config;
+
+        let json = r#"{
+            "model":{"type":"BPE","vocab":{"a":0},"merges":[]},
+            "added_tokens":[
+                {"id":248069,"content":"<control>","special":true}
+            ]
+        }"#;
+        let tokenizer = BpeTokenizer::from_tokenizer_json_str(json).unwrap();
+        let cfg = Qwen35Config::qwen35_0_8b();
+        let vocab_bytes = tokenizer.vocab_bytes(cfg.vocab_size).unwrap();
+        let table_len = vocab_bytes.len();
+        let spec = GrammarSpec::Gbnf("root ::= \"a\"\n".to_string());
+        let engine = GrammarEngine::new(&spec, vocab_bytes).unwrap();
+        let mut state = engine.initial_state();
+        let mut logits = vec![0.0; cfg.vocab_size];
+
+        engine.mask_logits(&mut state, &mut logits);
+
+        assert!(
+            logits[248_070..]
+                .iter()
+                .all(|logit| *logit == f32::NEG_INFINITY),
+            "reserved logits above the tokenizer maximum must be masked"
+        );
+        assert_eq!(table_len, cfg.vocab_size);
+    }
+
+    #[test]
+    fn grammar_vocab_uses_literal_non_ascii_added_token_bytes() {
+        use crate::grammar::{GrammarEngine, GrammarSpec};
+
+        let tokenizer = non_ascii_added_tokenizer();
+        let err = tokenizer.vocab_bytes(101).unwrap_err();
+        assert!(err.to_string().contains("token ID 101"));
+        let vocab_bytes = tokenizer.vocab_bytes(102).unwrap();
+        assert_eq!(vocab_bytes[100], "好".as_bytes());
+        assert_eq!(vocab_bytes[101], "café".as_bytes());
+
+        let spec = GrammarSpec::Gbnf("root ::= \"好\" | \"café\"\n".to_string());
+        let engine = GrammarEngine::new(&spec, vocab_bytes).unwrap();
+        let mut state = engine.initial_state();
+        let mut logits = vec![0.0; 102];
+        engine.mask_logits(&mut state, &mut logits);
+        assert!(logits[100].is_finite());
+        assert!(logits[101].is_finite());
+    }
+
+    #[test]
+    fn decode_and_incremental_detokenize_render_non_ascii_added_tokens() {
+        use crate::model::qwen35::detokenize::IncrementalDetokenizer;
+
+        let tokenizer = non_ascii_added_tokenizer();
+        assert_eq!(
+            tokenizer.token_bytes_for_id(100).as_deref(),
+            Some("好".as_bytes())
+        );
+        assert_eq!(
+            tokenizer.token_bytes_for_id(101).as_deref(),
+            Some("café".as_bytes())
+        );
+        assert_eq!(tokenizer.decode(&[100, 101]), Some("好café".to_string()));
+
+        let mut detok = IncrementalDetokenizer::new();
+        let mut text = String::new();
+        for id in [100, 101] {
+            text.push_str(&detok.push(&tokenizer, id));
+        }
+        text.push_str(&detok.finish());
+        assert_eq!(text, "好café");
     }
 
     #[test]
@@ -1620,7 +1763,7 @@ mod tests {
         // ids and special flags from the shipped qwen tokenizer.json (verified identical
         // on both qwen3.5-0.8b and qwen3.6-27b): `<think>`=248068, `</think>`=248069 are
         // special=false and live FAR above the base vocab max (248043). This exercises
-        // the full wiring parse_rendered_added_tokens → added_render → token_for_id →
+        // the full wiring parse_rendered_added_tokens → added_render → append_token_bytes →
         // decode; a token-level parity gate (e2e-parity compares token IDS) is BLIND to
         // this class because the ids matched while the rendered text dropped the tag.
         let json = r#"{

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -471,19 +471,27 @@ impl BpeTokenizer {
     ///
     /// `vocab_bytes()[i]` is the UTF-8 byte sequence that token `i` decodes to,
     /// after applying the GPT-2 byte-level encoding reversal.
+    /// The table includes added-token IDs; skipped control-token slots are empty.
     ///
     /// Used by [`GrammarEngine::new`](crate::grammar::GrammarEngine::new) to build
     /// the precomputed vocabulary partition for grammar-constrained decoding (ADR-046).
     ///
     /// Cost: O(vocab_size) — called once at engine initialisation.
     pub fn vocab_bytes(&self) -> Vec<Vec<u8>> {
-        self.inner
-            .id_to_token
-            .iter()
-            .map(|token_str| {
-                // Apply GPT-2 byte-level encoding reversal (same as byte_decode_token).
-                let decoded = byte_decode_token(token_str);
-                decoded.into_bytes()
+        let max_added_id = self
+            .inner
+            .special_tokens
+            .values()
+            .chain(self.inner.added_render.keys())
+            .copied()
+            .max()
+            .map_or(0usize, |id| id as usize + 1);
+        let model_vocab_size = self.inner.id_to_token.len().max(max_added_id);
+        (0..model_vocab_size)
+            .map(|id| {
+                self.token_for_id(id as u32)
+                    .map(byte_decode_token_bytes)
+                    .unwrap_or_default()
             })
             .collect()
     }
@@ -1497,6 +1505,59 @@ mod tests {
         // prior generate.rs detokenize block discarded the text entirely.
         assert_eq!(tokenizer.decode(&ids), Some("hello world".to_string()));
         assert_eq!(tokenizer.decode(&[]), Some(String::new()));
+    }
+
+    #[test]
+    fn test_grammar_vocab_preserves_split_utf8_bytes() {
+        use crate::grammar::{GrammarEngine, GrammarSpec};
+
+        let byte_encoder = bytes_to_unicode();
+        let mut vocab = HashMap::new();
+        vocab.insert(byte_encoder[0xE5].to_string(), 0);
+        vocab.insert(byte_encoder[0xA5].to_string(), 1);
+        vocab.insert(byte_encoder[0xBD].to_string(), 2);
+        let tokenizer = BpeTokenizer::from_vocab_and_merges(vocab, Vec::new()).unwrap();
+        let vocab_bytes = tokenizer.vocab_bytes();
+        assert_eq!(vocab_bytes, vec![vec![0xE5], vec![0xA5], vec![0xBD]]);
+
+        let spec = GrammarSpec::Gbnf("root ::= \"好\"\n".to_string());
+        let engine = GrammarEngine::new(&spec, vocab_bytes).unwrap();
+        let mut state = engine.initial_state();
+        for token_id in 0..3u32 {
+            let mut logits = vec![0.0; 3];
+            engine.mask_logits(&mut state, &mut logits);
+            assert!(
+                logits[token_id as usize].is_finite(),
+                "split UTF-8 token {token_id} must remain grammar-legal"
+            );
+            assert!(engine.advance(&mut state, token_id));
+        }
+    }
+
+    #[test]
+    fn test_grammar_vocab_masks_rendered_added_tokens_and_controls() {
+        use crate::grammar::{GrammarEngine, GrammarSpec};
+
+        let json = r#"{
+            "model":{"type":"BPE","vocab":{"a":0,"b":1},"merges":[]},
+            "added_tokens":[
+                {"id":99,"content":"<control>","special":true},
+                {"id":100,"content":"<extra>","special":false}
+            ]
+        }"#;
+        let tokenizer = BpeTokenizer::from_tokenizer_json_str(json).unwrap();
+        let vocab_bytes = tokenizer.vocab_bytes();
+        assert_eq!(vocab_bytes.len(), 101);
+        assert!(vocab_bytes[99].is_empty());
+        assert_eq!(vocab_bytes[100], b"<extra>");
+
+        let spec = GrammarSpec::Gbnf("root ::= \"a\"\n".to_string());
+        let engine = GrammarEngine::new(&spec, vocab_bytes).unwrap();
+        let mut state = engine.initial_state();
+        let mut logits = vec![0.0; 101];
+        engine.mask_logits(&mut state, &mut logits);
+        assert_eq!(logits[99], f32::NEG_INFINITY);
+        assert_eq!(logits[100], f32::NEG_INFINITY);
     }
 
     #[test]

--- a/crates/inference/src/tokenizer/sentencepiece.rs
+++ b/crates/inference/src/tokenizer/sentencepiece.rs
@@ -7,7 +7,7 @@
 use crate::error::InferenceError;
 use crate::tokenizer::common::{
     JsonValue, ThreadSafeLruCache, TokenizedInput, Tokenizer, json_path, known_special_id, pad_ids,
-    parse_json, parse_post_processor_flags, push_eos_preserving_limit,
+    parse_added_tokens, parse_json, parse_post_processor_flags, push_eos_preserving_limit,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -75,6 +75,8 @@ struct SentencePieceInner {
     remove_extra_whitespaces: bool,
     escape_whitespaces: bool,
     byte_fallback_ids: Vec<Option<u32>>,
+    added_tokens: HashMap<String, u32>,
+    added_tokens_sorted: Vec<String>,
     cache: ThreadSafeLruCache<String, Vec<u32>>,
 }
 
@@ -145,6 +147,7 @@ struct ParsedSentencePieceModel {
     dummy_prefix: bool,
     remove_extra_whitespaces: bool,
     escape_whitespaces: bool,
+    added_tokens: HashMap<String, u32>,
 }
 
 impl Default for ParsedSentencePieceModel {
@@ -160,6 +163,7 @@ impl Default for ParsedSentencePieceModel {
             dummy_prefix: true,
             remove_extra_whitespaces: true,
             escape_whitespaces: true,
+            added_tokens: HashMap::new(),
         }
     }
 }
@@ -261,7 +265,8 @@ impl SentencePieceTokenizer {
 
         let unk_id = json_path(&root, &["model", "unk_id"])
             .and_then(JsonValue::as_u64)
-            .map(|v| v as u32)
+            .map(|value| checked_special_id(value, "unk_id"))
+            .transpose()?
             .or_else(|| known_special_id(&vocab_map, &["<unk>"]));
         let bos_id = known_special_id(&vocab_map, &["<bos>", "<s>"]);
         let eos_id = known_special_id(&vocab_map, &["<eos>", "</s>"]);
@@ -283,6 +288,7 @@ impl SentencePieceTokenizer {
             dummy_prefix: true,
             remove_extra_whitespaces: true,
             escape_whitespaces: true,
+            added_tokens: parse_added_tokens(&root),
         };
 
         Self::from_parsed_model(
@@ -293,7 +299,7 @@ impl SentencePieceTokenizer {
     }
 
     fn from_parsed_model(
-        model: ParsedSentencePieceModel,
+        mut model: ParsedSentencePieceModel,
         cache_capacity: usize,
         max_seq_len: usize,
     ) -> Result<Self, InferenceError> {
@@ -304,8 +310,8 @@ impl SentencePieceTokenizer {
 
         // A malformed tokenizer.json (`model.unk_id`) or native `.model` trainer_spec
         // (unk/bos/eos/pad fields) can declare a special-token id past the end of the
-        // vocabulary — the value is cast `as u32` with no bounds check at parse time.
-        // viterbi_encode emits `unk_id` directly for unmatched input, and bos/eos are
+        // vocabulary even when it fits in u32. viterbi_encode emits `unk_id` directly
+        // for unmatched input, and bos/eos are
         // prepended/appended, so an out-of-range id flows straight into the model's
         // embedding gather (out-of-bounds read) or `id_to_piece` lookup. Reject the
         // malformed model at construction rather than emit an invalid token id (mirrors
@@ -331,6 +337,9 @@ impl SentencePieceTokenizer {
             .iter()
             .map(|piece| piece.score)
             .fold(f32::INFINITY, f32::min);
+        model.added_tokens.retain(|token, _| !token.is_empty());
+        let mut added_tokens_sorted: Vec<String> = model.added_tokens.keys().cloned().collect();
+        added_tokens_sorted.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
         let mut trie = ByteTrie::new();
         let mut byte_fallback_ids = vec![None; 256];
         let mut id_to_piece = Vec::with_capacity(model.pieces.len());
@@ -369,6 +378,8 @@ impl SentencePieceTokenizer {
             remove_extra_whitespaces: model.remove_extra_whitespaces,
             escape_whitespaces: model.escape_whitespaces,
             byte_fallback_ids,
+            added_tokens: model.added_tokens,
+            added_tokens_sorted,
             cache: ThreadSafeLruCache::new(cache_capacity),
         };
 
@@ -395,6 +406,7 @@ impl SentencePieceTokenizer {
                 dummy_prefix: true,
                 remove_extra_whitespaces: true,
                 escape_whitespaces: true,
+                added_tokens: HashMap::new(),
             },
             DEFAULT_SENTENCEPIECE_CACHE_CAPACITY,
             DEFAULT_SENTENCEPIECE_MAX_SEQ_LEN,
@@ -421,6 +433,8 @@ impl SentencePieceTokenizer {
             remove_extra_whitespaces: self.inner.remove_extra_whitespaces,
             escape_whitespaces: self.inner.escape_whitespaces,
             byte_fallback_ids: self.inner.byte_fallback_ids.clone(),
+            added_tokens: self.inner.added_tokens.clone(),
+            added_tokens_sorted: self.inner.added_tokens_sorted.clone(),
             cache: self.inner.cache.clone(),
         };
         Self {
@@ -532,24 +546,58 @@ impl SentencePieceTokenizer {
     }
 
     fn tokenize_to_ids(&self, text: &str) -> Vec<u32> {
+        let mut ids = Vec::new();
+        if self.inner.added_tokens_sorted.is_empty() {
+            self.tokenize_regular_segment(text, &mut ids);
+        } else {
+            let mut pos = 0usize;
+            while pos < text.len() {
+                if let Some((end, id)) = self.match_added_token(text, pos) {
+                    ids.push(id);
+                    pos = end;
+                } else {
+                    let segment_start = pos;
+                    while pos < text.len() && self.match_added_token(text, pos).is_none() {
+                        let ch = text[pos..]
+                            .chars()
+                            .next()
+                            .expect("invariant: pos is inside non-empty UTF-8 text");
+                        pos += ch.len_utf8();
+                    }
+                    self.tokenize_regular_segment(&text[segment_start..pos], &mut ids);
+                }
+            }
+        }
+        self.add_special_tokens_and_truncate(&mut ids);
+        ids
+    }
+
+    fn tokenize_regular_segment(&self, text: &str, ids: &mut Vec<u32>) {
         let normalized = self.normalize(text);
         if normalized.is_empty() {
-            let mut ids = Vec::new();
-            self.add_special_tokens_and_truncate(&mut ids);
-            return ids;
+            return;
         }
 
         if let Some(cached) = self.inner.cache.get(&normalized) {
-            let mut ids = cached.as_ref().clone();
-            self.add_special_tokens_and_truncate(&mut ids);
-            return ids;
+            ids.extend(cached.iter().copied());
+            return;
         }
 
-        let mut ids = self.viterbi_encode(&normalized);
-        self.inner.cache.insert(normalized, ids.clone());
+        let segment_ids = self.viterbi_encode(&normalized);
+        self.inner.cache.insert(normalized, segment_ids.clone());
+        ids.extend(segment_ids);
+    }
 
-        self.add_special_tokens_and_truncate(&mut ids);
-        ids
+    fn match_added_token(&self, text: &str, pos: usize) -> Option<(usize, u32)> {
+        let tail = &text[pos..];
+        for token in &self.inner.added_tokens_sorted {
+            if tail.starts_with(token)
+                && let Some(&id) = self.inner.added_tokens.get(token)
+            {
+                return Some((pos + token.len(), id));
+            }
+        }
+        None
     }
 
     fn viterbi_encode(&self, sentence: &str) -> Vec<u32> {
@@ -696,6 +744,12 @@ fn parse_byte_piece(piece: &str) -> Option<u8> {
     u8::from_str_radix(hex, 16).ok()
 }
 
+fn checked_special_id(value: u64, name: &str) -> Result<u32, InferenceError> {
+    u32::try_from(value).map_err(|_| {
+        InferenceError::Tokenizer(format!("SentencePiece {name} ({value}) exceeds u32 range"))
+    })
+}
+
 fn parse_sentencepiece_model(bytes: &[u8]) -> Result<ParsedSentencePieceModel, InferenceError> {
     let mut model = ParsedSentencePieceModel::default();
     let mut pos = 0usize;
@@ -778,10 +832,18 @@ fn parse_trainer_spec(
     while pos < bytes.len() {
         let (field, wire_type) = read_key(bytes, &mut pos)?;
         match (field, wire_type) {
-            (40, 0) => model.unk_id = Some(read_varint(bytes, &mut pos)? as u32),
-            (41, 0) => model.bos_id = Some(read_varint(bytes, &mut pos)? as u32),
-            (42, 0) => model.eos_id = Some(read_varint(bytes, &mut pos)? as u32),
-            (43, 0) => model.pad_id = Some(read_varint(bytes, &mut pos)? as u32),
+            (40, 0) => {
+                model.unk_id = Some(checked_special_id(read_varint(bytes, &mut pos)?, "unk_id")?)
+            }
+            (41, 0) => {
+                model.bos_id = Some(checked_special_id(read_varint(bytes, &mut pos)?, "bos_id")?)
+            }
+            (42, 0) => {
+                model.eos_id = Some(checked_special_id(read_varint(bytes, &mut pos)?, "eos_id")?)
+            }
+            (43, 0) => {
+                model.pad_id = Some(checked_special_id(read_varint(bytes, &mut pos)?, "pad_id")?)
+            }
             _ => skip_field(bytes, &mut pos, wire_type)?,
         }
     }
@@ -937,11 +999,11 @@ mod tests {
     #[test]
     fn test_out_of_range_special_id_rejected_at_construction() {
         // A malformed tokenizer.json / .model can declare unk_id (or bos/eos/pad) past
-        // the end of the vocab; the value is cast `as u32` with no bounds check at parse
-        // time. Without the construction guard, from_parsed_model would build a tokenizer
-        // that emits that out-of-range id from viterbi_encode's unmatched-char fallback,
-        // which then indexes the model's embedding table out of bounds. Construction must
-        // reject it. Here vocab has 3 pieces (ids 0..3) and unk_id = 5.
+        // the end of the vocab even when the value fits in u32. Without the construction
+        // guard, from_parsed_model would build a tokenizer that emits that out-of-range id
+        // from viterbi_encode's unmatched-char fallback, which then indexes the model's
+        // embedding table out of bounds. Construction must reject it. Here vocab has 3
+        // pieces (ids 0..3) and unk_id = 5.
         let pieces = vec![
             SentencePieceEntry {
                 piece: "<unk>".to_string(),
@@ -968,17 +1030,57 @@ mod tests {
 
     #[test]
     fn test_out_of_range_unk_id_rejected_from_json() {
-        // The tokenizer.json loader path (from_tokenizer_json_str -> from_parsed_model)
-        // casts `model.unk_id` `as u32` with no bounds check. A malformed file declaring
-        // unk_id past the vocab end must be rejected at construction, mirroring the
-        // .model path covered by from_pieces_for_test above. Vocab has 2 pieces (ids 0,1)
-        // and unk_id = 4.
+        // A malformed file declaring unk_id past the vocab end must be rejected at
+        // construction, mirroring the .model path covered by from_pieces_for_test above.
+        // Vocab has 2 pieces (ids 0,1) and unk_id = 4.
         let json = r#"{"model":{"type":"Unigram","unk_id":4,"vocab":[["<unk>",0.0],["▁a",-1.0]]}}"#;
         let result = SentencePieceTokenizer::from_tokenizer_json_str(json);
         assert!(
             result.is_err(),
             "an out-of-range unk_id from tokenizer.json must be rejected at construction"
         );
+    }
+
+    #[test]
+    fn test_overflowing_unk_id_rejected_from_json() {
+        let json = r#"{"model":{"type":"Unigram","unk_id":4294967296,"vocab":[["<unk>",0.0],["▁a",-1.0]]}}"#;
+        let result = SentencePieceTokenizer::from_tokenizer_json_str(json);
+        assert!(
+            result.is_err(),
+            "a SentencePiece special id outside the u32 domain must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_overflowing_special_id_rejected_from_protobuf() {
+        fn push_varint(mut value: u64, out: &mut Vec<u8>) {
+            while value >= 0x80 {
+                out.push((value as u8 & 0x7f) | 0x80);
+                value >>= 7;
+            }
+            out.push(value as u8);
+        }
+
+        let mut trainer_spec = Vec::new();
+        push_varint(40 << 3, &mut trainer_spec);
+        push_varint(u64::from(u32::MAX) + 1, &mut trainer_spec);
+        let mut model = ParsedSentencePieceModel::default();
+        let result = parse_trainer_spec(&trainer_spec, &mut model);
+        assert!(
+            result.is_err(),
+            "a protobuf SentencePiece special id outside the u32 domain must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_json_added_token_matches_before_normalization() {
+        let json = r#"{
+            "added_tokens":[{"id":2,"content":"<extra>","special":false}],
+            "model":{"type":"Unigram","unk_id":0,"vocab":[["<unk>",0.0],["▁a",-1.0]]}
+        }"#;
+        let tokenizer = SentencePieceTokenizer::from_tokenizer_json_str(json).unwrap();
+        let input = tokenizer.tokenize("<extra>");
+        assert_eq!(&input.input_ids[..input.real_length], &[2]);
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Fixes #751. Closes #772.

## What

Five correctness fixes across the detokenizer termination path and the tokenizer/grammar boundary:

1. **Non-streaming detokenizer finalization (#751)**: `generate` only flushed the incremental detokenizer's incomplete-UTF-8 tail when `stopped` was false, but `stopped` is set uniformly by stop-string match, EOS, and grammar completion. Only a confirmed stop-string match truncates the output buffer, so EOS/grammar/length termination silently dropped a legitimate trailing byte sequence that `generate_streaming` (which finalizes unconditionally) emitted as a replacement character — the two public paths disagreed for the same generation. Now a confirmed stop-string match is tracked separately from other termination causes, and both call sites share one finalization predicate: stop-string match skips the tail, everything else flushes it.
2. **SentencePiece special-ID overflow**: u64 special-token IDs outside the u32 domain wrapped silently (4294967296 became ID 0) and passed downstream range checks. Both the JSON Unigram and native protobuf loaders now reject out-of-range IDs through one checked conversion helper covering `unk_id`, `bos_id`, `eos_id`, and `pad_id`.
3. **SentencePiece added tokens**: top-level `added_tokens` in a Unigram `tokenizer.json` were not honored before normalization, so an added token absent from the base vocab could never emit its ID — unlike the sibling BPE/WordPiece loaders. Added-token matching now runs against the original input before normalization, longest-first and deterministic.
4. **Grammar vocabulary raw bytes**: `vocab_bytes` decoded BPE byte-placeholder characters through a lossy path, yielding `EF BF BD` (U+FFFD) instead of the raw byte, so a grammar could reject the valid first byte of a CJK/emoji sequence split across tokens. Entries now map through the same exact byte decoding as `decode`.
5. **Grammar vocabulary added-token coverage**: added-token IDs were absent from the grammar byte table while `decode` rendered them, leaving their logits unmasked. The table is now built over the same dense model-sized ID space as decoding, with empty slots for skipped control tokens so they stay maskable.

## Tests (mutation-verified)

Six new regressions, each observed failing against the unfixed code before the fix landed and passing after: EOS-termination streaming/non-streaming parity on a mid-codepoint boundary, overflowing special IDs rejected from both JSON and protobuf, added-token round-trip through the Unigram loader, split-UTF-8 grammar acceptance, and grammar masking of rendered added tokens and control slots.

Sibling-path sweep: both string-stop loops now share the finalization helper; the Metal generation paths were checked and already handle finalization correctly per termination cause (no change needed); the checked ID helper covers both SentencePiece parsers; BPE and WordPiece added-token paths already matched pre-normalization; `vocab_bytes` is the single production grammar-vocabulary constructor and all production grammar clients consume it.

`cargo test -p lattice-inference` (default and `--features f16`): all green (1,795 and 1,800 library tests respectively, zero failures across binary/integration/doctest suites). `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check` clean.

## bench-compare (ADR-058)

Methodology: `make bench-compare` (quick mode) at base `origin/main` 77316a1005 vs head, then a second run filtered to the failing groups plus `rms_norm` to test reproducibility. Runnable commands and full tables are in the two runs' output below.

The only benchmark group on code this diff touches, `rms_norm`, is at parity (-0.37%, p=0.05). All FAIL rows in both runs are `lattice-embed` SIMD kernels; this diff changes three `crates/inference` tokenizer/generation files and `git diff origin/main...HEAD -- crates/embed/` is empty, so both sides of those benches build from byte-identical source — any measured delta there is harness/machine noise by construction. Consistent with that, the FAIL sets do not reproduce between the two runs: the four `simd_normalize` FAILs from run 1 (up to +15.6%) disappeared in run 2, and remaining magnitudes shifted well outside their run-1 confidence intervals. Known confound: this machine runs concurrent compile load from other work; the bench-window lock serializes benches but not all background compilation (documented false-positive class).

<details><summary>Run 1 (full default groups) and run 2 (filtered recheck) FAIL tables</summary>

Run 1: 10 FAIL, all lattice-embed SIMD groups (simd_normalize ×4 up to +15.6%, int8_vs_float32_cosine ×3, simd_batch ×2, binary_cosine_distance ×1). Run 2 (same base/head, filtered): simd_normalize FAILs absent; int8_vs_float32_cosine/384 moved from +19.8% [CI +19.0,+20.7] to +12.6% [CI +9.3,+15.9]. rms_norm: -0.37% [CI -0.51,-0.23].

</details>
