### PR TITLE
fix(macos): Serve footer shows the real lattice_serve invocation

### DIFF
--- a/apps/macos/Sources/LatticeStudio/Bridge/ServeController.swift
+++ b/apps/macos/Sources/LatticeStudio/Bridge/ServeController.swift
@@ -40,6 +40,8 @@ final class ServeController {
     private(set) var lastError: String?
     /// The model name the running daemon was launched with (for the tray label).
     private(set) var servingModelName: String?
+    /// The model path the running daemon was launched with (`--model`), for the CLI footer.
+    private(set) var servingModelPath: URL?
     /// True after the daemon emits its `ready` event; false on stop or process exit.
     private(set) var isReady: Bool = false
     /// Live request log — newest entry last, capped at 200 rows.
@@ -76,6 +78,7 @@ final class ServeController {
             if self.handle === h {
                 self.handle = nil
                 self.servingModelName = nil
+                self.servingModelPath = nil
                 self.isReady = false
                 self.onChange?()
             }
@@ -112,6 +115,7 @@ final class ServeController {
             try h.start(spec)
             handle = h
             servingModelName = model.name
+            servingModelPath = model.path
             lastError = nil
             onChange?()
             return true
@@ -126,6 +130,7 @@ final class ServeController {
         handle?.stop()
         handle = nil
         servingModelName = nil
+        servingModelPath = nil
         isReady = false
         onChange?()
     }

--- a/apps/macos/Sources/LatticeStudio/Components/CLIFooter.swift
+++ b/apps/macos/Sources/LatticeStudio/Components/CLIFooter.swift
@@ -94,7 +94,7 @@ struct CLIFooter: View {
     VStack(spacing: 0) {
         Spacer()
         CLIFooter(
-            command: "lattice serve qwen3.5-0.8b --host 127.0.0.1 --port 11435",
+            command: "lattice_serve --model /Users/you/.lattice/models/qwen3.5-0.8b --port 11435",
             caption: "http://127.0.0.1:11435/v1"
         )
     }

--- a/apps/macos/Sources/LatticeStudio/Shell/MainColumn.swift
+++ b/apps/macos/Sources/LatticeStudio/Shell/MainColumn.swift
@@ -46,11 +46,15 @@ struct MainColumn: View {
             return raw.replacingOccurrences(of: "  ", with: " ")
 
         case .serve:
-            let model = store.serve?.servingModelName
-                ?? store.targetModel?.name
-                ?? "model"
+            // Mirrors ServeController.start(): it launches the standalone `lattice_serve`
+            // binary with `--model <path> --port <port>` (no `--host` — the daemon always
+            // binds 127.0.0.1), so the footer must match that shape, not the `lattice`
+            // CLI's unrelated `serve` subcommand.
+            let modelPath = store.serve?.servingModelPath?.path
+                ?? store.targetModel?.path.path
+                ?? "<model-path>"
             let port = store.serve?.port ?? 11435
-            return "lattice serve \(model) --host 127.0.0.1 --port \(port)"
+            return "lattice_serve --model \(modelPath) --port \(port)"
 
         case .quantize, .train, .inspect:
             return nil


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Fixes #925.

The Serve tab footer displayed `lattice serve <model-name> --host 127.0.0.1 --port <port>`, but `ServeController.start()` actually spawns the standalone `lattice_serve` binary with `--model <path> --port <port>` (no `--host`; `--model` resolves a name against `~/.lattice/models` or takes a path). Copying the footer command therefore failed for every user.

The footer now builds `lattice_serve --model <path> --port <port>` from a new `servingModelPath` tracked by `ServeController` (set on start, cleared on stop/exit, falling back to the selected model pre-launch). The corrected invocation was verified against `lattice_serve.rs`'s actual argument parser, not inferred. The identical fictional string in `CLIFooter.swift`'s preview is fixed; a repo-wide sweep found every other `lattice serve` reference correctly refers to the `lattice` CLI's real serve subcommand and was left untouched.

Swift-only change; `swift build` clean. No Rust code touched, so no bench-compare (per ADR-058 scope: crates/inference and crates/embed only).
