### PR TITLE
fix(inference): non-metal-gpu generate stub returns Result instead of panicking (#917)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -34142,7 +34142,7 @@ impl MetalQwen35State {
         Vec::new()
     }
 
-    /// **Unstable**: Metal generate stub; always panics without metal-gpu feature.
+    /// **Unstable**: Metal generate stub; always errors without metal-gpu feature.
     ///
     /// #856 follow-up (PR #915 review, first pass): this used to
     /// return an unconditional `Ok(GenerateOutput { .. })` with empty
@@ -34155,40 +34155,39 @@ impl MetalQwen35State {
     /// directly and get a *successful* empty completion back from an
     /// empty (or any) prompt.
     ///
-    /// PR #915 review, second pass: the first fix changed this
-    /// method's return type to `Result<GenerateOutput, InferenceError>`,
-    /// which is itself a semver-breaking signature change -- this stub is
-    /// what every **default** build gets (`metal-gpu` is not a default
-    /// feature), so any existing downstream default-build caller
-    /// consuming a bare `GenerateOutput` would stop compiling, and
-    /// `cargo-semver-checks`' inherent-method lint would not catch a
-    /// non-unit-to-non-unit return type change. `lattice-inference` v0.6.1
-    /// just shipped, so the signature is restored to the published
-    /// `-> GenerateOutput`.
+    /// PR #915 review, second pass: changing this method's return type
+    /// from `-> GenerateOutput` to `-> Result<GenerateOutput,
+    /// InferenceError>` directly is itself a semver-breaking signature
+    /// change -- this stub is what every **default** build gets
+    /// (`metal-gpu` is not a default feature), so any existing downstream
+    /// default-build caller consuming a bare `GenerateOutput` would stop
+    /// compiling, and `cargo-semver-checks`' inherent-method lint would
+    /// not catch a non-unit-to-non-unit return type change. As an interim
+    /// step (v0.6.1), the signature was kept as `-> GenerateOutput` and
+    /// the stub panicked instead: fail-loud rather than fail-open, but
+    /// still a rougher contract than a typed `Err`.
     ///
-    /// Instead this fails **loud**: it panics with a message identifying
-    /// the missing capability, rather than silently returning a
-    /// successful-looking empty completion. That is strictly better than
-    /// the pre-#856/#915 fail-open state (a panic is impossible to miss;
-    /// an empty `Ok` looked like a real, if vacuous, generation) and
-    /// matches the v0.6.0 release notes' fail-loudly convention for
-    /// unimplemented GPU arms elsewhere in this crate. It is not the
-    /// intended long-term shape -- a panic in a library function is still
-    /// a rougher contract than a typed `Err` -- so the eventual fallible
-    /// signature is tracked for a semver-major-eligible release at
-    /// <https://github.com/ohdearquant/lattice/issues/917> (targets
-    /// 0.7.0, sibling to #916's `generate_with_speculation` tracking).
+    /// #917 (this signature, targeting the 0.7.0 semver-major release
+    /// alongside the other already-known 0.7.0 breaking changes): the
+    /// return type is now `Result<GenerateOutput, InferenceError>`,
+    /// matching the real metal-gpu-enabled implementation's signature
+    /// exactly. This is a deliberate breaking change gated to 0.7.0; it
+    /// replaces the v0.6.1 panic with a typed capability error, following
+    /// the same "fail with `Err(InferenceError::Inference(..))`" pattern
+    /// used by every other stub method on this type
+    /// (`blend_lora_layer_data`, `load_lora_adapter`,
+    /// `compute_token_nlls`, `compute_perplexity`). See
+    /// <https://github.com/ohdearquant/lattice/issues/917> (sibling to
+    /// #916's `generate_with_speculation` tracking).
     pub fn generate(
         &mut self,
         _prompt: &str,
         _tokenizer: &crate::tokenizer::bpe::BpeTokenizer,
         _cfg: &crate::model::qwen35_config::GenerateConfig,
-    ) -> crate::model::qwen35_config::GenerateOutput {
-        panic!(
-            "MetalQwen35State::generate called on a build compiled without \
-             the metal-gpu feature; construct via new() which returns an \
-             error on such builds"
-        );
+    ) -> Result<crate::model::qwen35_config::GenerateOutput, crate::error::InferenceError> {
+        Err(crate::error::InferenceError::Inference(
+            "Metal GPU not available (requires macOS + metal-gpu feature)".into(),
+        ))
     }
 
     /// **Unstable**: load LoRA adapter stub; always errors without metal-gpu feature.
@@ -34234,25 +34233,26 @@ impl MetalQwen35State {
 }
 
 /// Regression coverage for the non-metal-gpu `MetalQwen35State` stub (#856
-/// follow-up, PR #915 review feedback). This runs in the DEFAULT build (no
-/// `metal-gpu` feature, hence no `#[cfg(metal-gpu)]` on the test itself) --
-/// exactly the build a downstream crate gets by default, and exactly the
-/// build where `MetalQwen35State` is directly constructible as a public
-/// unit struct without going through the fallible `new`/`from_q4_dir`.
+/// follow-up, PR #915 review feedback; #917 follow-up). This runs in the
+/// DEFAULT build (no `metal-gpu` feature, hence no `#[cfg(metal-gpu)]` on
+/// the test itself) -- exactly the build a downstream crate gets by
+/// default, and exactly the build where `MetalQwen35State` is directly
+/// constructible as a public unit struct without going through the
+/// fallible `new`/`from_q4_dir`.
 ///
-/// PR #915 review, second pass: the stub's `generate` keeps its
-/// published `-> GenerateOutput` signature (changing it to `Result` would
-/// itself be a semver break for every default build, since `metal-gpu` is
-/// not a default feature) and instead panics with a message identifying
-/// the missing capability. These tests assert the panic, not a `Result`.
+/// #917: the stub's `generate` now returns
+/// `Result<GenerateOutput, InferenceError>`, matching the metal-gpu-enabled
+/// implementation's signature. These tests assert the typed `Err`, not a
+/// panic (the v0.6.1 interim behavior).
 ///
-/// Mutation sensitivity: reverting the stub's `generate` to its old
-/// unconditional `GenerateOutput { .. }` return (no panic) makes both
-/// tests below fail (`#[should_panic]` requires the call to panic; a
-/// normal return is a test failure).
+/// Mutation sensitivity: reverting the stub's `generate` to the v0.6.1
+/// panic (or to the original unconditional `Ok(GenerateOutput { .. })`)
+/// makes both tests below fail -- neither a panic nor a bare `Ok` matches
+/// the `Err(InferenceError::Inference(..))` assertion.
 #[cfg(all(test, not(all(target_os = "macos", feature = "metal-gpu"))))]
 mod non_metal_stub_tests {
     use super::MetalQwen35State;
+    use crate::error::InferenceError;
     use crate::model::qwen35_config::GenerateConfig;
     use crate::tokenizer::bpe::BpeTokenizer;
     use std::collections::HashMap;
@@ -34270,28 +34270,44 @@ mod non_metal_stub_tests {
     }
 
     #[test]
-    #[should_panic(expected = "metal-gpu")]
     fn non_metal_stub_generate_rejects_empty_prompt() {
         let tokenizer = tiny_tokenizer();
         let gen_cfg = GenerateConfig::default();
         let mut state = MetalQwen35State;
 
-        // Must panic (fail loud) rather than return a successful-looking
-        // empty GenerateOutput for an empty prompt.
-        let _ = state.generate("", &tokenizer, &gen_cfg);
+        // Must return a typed Err (fail loud, not fail open) rather than a
+        // successful-looking empty GenerateOutput for an empty prompt.
+        let result = state.generate("", &tokenizer, &gen_cfg);
+        match result {
+            Err(InferenceError::Inference(msg)) => {
+                assert!(
+                    msg.contains("metal-gpu"),
+                    "expected capability error mentioning metal-gpu, got: {msg}"
+                );
+            }
+            other => panic!("expected Err(InferenceError::Inference(..)), got: {other:?}"),
+        }
     }
 
-    /// The stub fails loud for every prompt, not only the empty one --
+    /// The stub errors for every prompt, not only the empty one --
     /// directly-constructing it (bypassing the fallible `new`/`from_q4_dir`)
     /// must never yield a successful (if vacuous) completion.
     #[test]
-    #[should_panic(expected = "metal-gpu")]
     fn non_metal_stub_generate_rejects_nonempty_prompt() {
         let tokenizer = tiny_tokenizer();
         let gen_cfg = GenerateConfig::default();
         let mut state = MetalQwen35State;
 
-        let _ = state.generate("hello", &tokenizer, &gen_cfg);
+        let result = state.generate("hello", &tokenizer, &gen_cfg);
+        match result {
+            Err(InferenceError::Inference(msg)) => {
+                assert!(
+                    msg.contains("metal-gpu"),
+                    "expected capability error mentioning metal-gpu, got: {msg}"
+                );
+            }
+            other => panic!("expected Err(InferenceError::Inference(..)), got: {other:?}"),
+        }
     }
 }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -34155,7 +34155,7 @@ impl MetalQwen35State {
     /// directly and get a *successful* empty completion back from an
     /// empty (or any) prompt.
     ///
-    /// PR #915 review, second pass: changing this method's return type
+    /// Changing this method's return type
     /// from `-> GenerateOutput` to `-> Result<GenerateOutput,
     /// InferenceError>` directly is itself a semver-breaking signature
     /// change -- this stub is what every **default** build gets
@@ -34233,7 +34233,7 @@ impl MetalQwen35State {
 }
 
 /// Regression coverage for the non-metal-gpu `MetalQwen35State` stub (#856
-/// follow-up, PR #915 review feedback; #917 follow-up). This runs in the
+/// follow-up; #917 follow-up). This runs in the
 /// DEFAULT build (no `metal-gpu` feature, hence no `#[cfg(metal-gpu)]` on
 /// the test itself) -- exactly the build a downstream crate gets by
 /// default, and exactly the build where `MetalQwen35State` is directly


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #917.

The non-`metal-gpu` build's `MetalQwen35State::generate` stub panicked (the v0.6.1 interim fail-loud fix from the #856/#915 review chain). With the 0.7.0 semver-major line open on main, this lands the intended long-term shape: the stub returns `Result<GenerateOutput, InferenceError>`, matching the real metal-gpu implementation's signature exactly and the typed-`Err` pattern of every sibling stub on the type (`blend_lora_layer_data`, `load_lora_adapter`, `compute_token_nlls`, `compute_perplexity`).

## Changes
- Stub signature `-> GenerateOutput` (panicking) → `-> Result<GenerateOutput, InferenceError>` returning `Err(InferenceError::Inference("Metal GPU not available (requires macOS + metal-gpu feature)"))`.
- Doc comment rewritten to record the full #856 → #915 → v0.6.1 panic → 0.7.0 typed-Err history.
- Both regression tests updated from `#[should_panic]` to asserting the typed `Err`; mutation-verified (reintroducing the old fail-open `Ok(..)` fails both; the fix restores green).

## Caller sweep
All ~70 workspace `.generate(` call sites checked: every caller of this type is gated behind `metal-gpu` via `required-features`, so no call-site propagation is needed; only the stub's own test module consumes it.

## Gates
- `cargo test -p lattice-inference --lib`: 1802 passed / 0 failed / 18 ignored
- `cargo clippy --workspace -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `cargo check -p lattice-inference --features f16,metal-gpu`: clean (gated arm unchanged)

bench-compare: not run — no-code-path change on any measured configuration (the touched function is the non-metal stub, unreachable in the benched metal-gpu builds; default-build change is a constant `Err` return). Structural unreachability disclosed per convention.

One pre-existing, unrelated flake observed during gates (`grammar_wiring_mask_logits_called_in_generate` under heavy machine contention) — being investigated separately; not touched by this diff.