### PR TITLE
ci: prepare required checks for merge queue

### DIFF
--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -7,9 +7,9 @@ name: app-binaries
 # See scripts/build-app-bins.sh for the rationale and the two regressions that
 # motivated it.
 #
-# Required-check shape (ADR-066 F-1): the workflow ALWAYS triggers on PRs (no
-# `paths:` filter on the PR event), but the expensive macOS build job only runs
-# when app-binary-relevant files change. The cheap always-running
+# Required-check shape (ADR-066 F-1): the workflow ALWAYS triggers on PRs and
+# merge groups (no `paths:` filter on either event), but the expensive macOS
+# build job only runs when app-binary-relevant files change. The cheap always-running
 # `app-binaries-gate` job is the status context to mark required — it passes
 # when there is nothing to build and mirrors the build result when there is.
 # This avoids the trap where a path-filtered required check never reports on
@@ -25,9 +25,13 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'scripts/build-app-bins.sh'
+      - 'scripts/ci-changed-files.sh'
       - 'apps/macos/scripts/package-app.sh'
       - '.github/workflows/app-binaries.yml'
   workflow_dispatch:
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
 
 # Cancel a PR's own superseded runs so they stop occupying the shared macOS
 # runner pool (~5 concurrent, account-wide) while a newer push on the same PR
@@ -61,21 +65,23 @@ jobs:
         with:
           fetch-depth: 0
       - id: filter
+        env:
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
-            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-              || git diff --name-only "HEAD~1...HEAD")
-          else
-            CHANGED=$(git diff --name-only "HEAD~1...HEAD" 2>/dev/null || true)
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "bins=true" >> "$GITHUB_OUTPUT"
+            echo "→ manual dispatch: app-binary build REQUIRED"
+            exit 0
           fi
+          CHANGED=$(./scripts/ci-changed-files.sh)
           echo "Changed files:"
           echo "$CHANGED"
           # here-string, not `echo | grep -q`: -q exits at first match, echo gets
           # SIGPIPE, and under pipefail the pipeline reports 141 → the else branch
           # would silently skip the build on large diffs (fail-open).
-          if grep -E '^crates/|^Cargo\.(toml|lock)$|^scripts/build-app-bins\.sh$|^apps/macos/scripts/package-app\.sh$|^\.github/workflows/app-binaries\.yml$' <<<"$CHANGED" >/dev/null; then
+          if grep -E '^crates/|^Cargo\.(toml|lock)$|^scripts/(build-app-bins|ci-changed-files)\.sh$|^apps/macos/scripts/package-app\.sh$|^\.github/workflows/app-binaries\.yml$' <<<"$CHANGED" >/dev/null; then
             echo "bins=true" >> "$GITHUB_OUTPUT"
             echo "→ app-binary surface changed: build REQUIRED"
           else
@@ -98,9 +104,8 @@ jobs:
       - name: Build all app-shipped binaries (required-features included)
         run: ./scripts/build-app-bins.sh
 
-  # The status context to mark required once it has reported reliably on a few
-  # PRs (ADR-066 F-1 phased rollout). Fails closed on change-detection failure,
-  # passes when nothing relevant changed, otherwise mirrors the build result.
+  # Required status context (ADR-066 F-1). Fails closed on change-detection
+  # failure, passes when nothing relevant changed, otherwise mirrors the build.
   app-binaries-gate:
     name: app-binaries-gate
     needs: [changes, build-app-bins]

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -9,20 +9,15 @@ name: cargo audit
 # see .cargo/audit.toml for the documented, individually-justified ignore
 # list, and never add a vulnerability-severity advisory to that list.
 #
-# NOTE: no `paths` filter on the `pull_request` trigger below, matching the
-# reasoning in `ci.yml`'s header comment. `cargo-audit-gate` at the bottom of
-# this file is meant to become a *required* status check, and a required
-# check whose workflow never even runs leaves a PR stuck on "Expected,
-# waiting for status to be reported" forever. So this workflow always
-# triggers on every PR to main; dependency-irrelevant PRs are instead
-# handled by gating `audit` and `audit-native` on the `changes` job below,
-# exactly like `ci.yml` gates `ci`/`feature-matrix`/`bench-compile`/`msrv` on
-# its own `changes` job. `cargo-audit-gate` always runs and always reports,
-# so it is the safe context to require — mirroring `ci-gate` in ci.yml,
-# `parity-gate` in e2e-parity.yml, and `app-binaries-gate` in
-# app-binaries.yml. Flipping `cargo-audit-gate` into the branch ruleset's
-# required-checks list is a separate maintainer step (not done by this PR —
-# see the PR description).
+# NOTE: no `paths` filter on the `pull_request` or `merge_group` triggers below,
+# matching the reasoning in `ci.yml`'s header comment. `cargo-audit-gate` is a
+# required status check, and a required check whose workflow never even runs
+# leaves a PR stuck on "Expected, waiting for status to be reported" forever.
+# So this workflow always triggers on every PR and queue entry targeting main;
+# dependency-irrelevant changes are instead handled by gating `audit` and
+# `audit-native` on the `changes` job below, exactly like `ci.yml` gates its
+# expensive jobs. `cargo-audit-gate` always runs, always reports, and fails
+# closed when change detection fails.
 #
 # Two audit jobs cover the two independent Cargo dependency graphs this repo
 # ships: `audit` for the root workspace's tracked `Cargo.lock`, and
@@ -44,6 +39,9 @@ name: cargo audit
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
   schedule:
     - cron: '0 6 * * 1'  # weekly Monday 06:00 UTC
   workflow_dispatch:
@@ -68,12 +66,13 @@ jobs:
         with:
           fetch-depth: 0
       - id: filter
+        env:
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
-            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-              || git diff --name-only "HEAD~1...HEAD")
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
+            CHANGED=$(./scripts/ci-changed-files.sh)
             echo "Changed files:"
             echo "$CHANGED"
             # Two single greps against a here-string, not a `grep | grep -q`
@@ -82,7 +81,7 @@ jobs:
             # as the pipeline's exit code instead of the match result
             # (fail-open on a large diff) — see the matching comment in
             # ci.yml's `changes` job.
-            MATCH=$(grep -E '(^Cargo\.lock$|^Cargo\.toml$|^crates/.*/Cargo\.toml$|^npm/lattice-embed-native/Cargo\.toml$|^\.cargo/audit\.toml$|^\.github/workflows/cargo-audit\.yml$)' <<<"$CHANGED" || true)
+            MATCH=$(grep -E '(^Cargo\.lock$|^Cargo\.toml$|^crates/.*/Cargo\.toml$|^npm/lattice-embed-native/Cargo\.toml$|^\.cargo/audit\.toml$|^scripts/ci-changed-files\.sh$|^\.github/workflows/cargo-audit\.yml$)' <<<"$CHANGED" || true)
             if grep -q . <<<"$MATCH"; then
               echo "deps=true" >> "$GITHUB_OUTPUT"
               echo "→ dependency-relevant change: audit REQUIRED"
@@ -91,9 +90,9 @@ jobs:
               echo "→ no dependency-relevant change: audit work skipped"
             fi
           else
-            # schedule / workflow_dispatch: no PR diff to gate on, always audit.
+            # schedule / workflow_dispatch: no event diff to gate on, always audit.
             echo "deps=true" >> "$GITHUB_OUTPUT"
-            echo "→ non-PR trigger (${{ github.event_name }}): audit REQUIRED"
+            echo "→ non-diff trigger (${{ github.event_name }}): audit REQUIRED"
           fi
 
   audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: CI
 
-# NOTE: no `paths-ignore` on the triggers below. Every job here is (or can be)
-# a *required* status check, and a required check whose workflow never even
-# runs leaves a PR stuck on "Expected, waiting for status to be reported"
-# forever. So this workflow always triggers on every PR to main. Docs-only
-# PRs are instead handled by gating `ci`, `feature-matrix`, `bench-compile`,
-# and `msrv` on the `changes` job below.
+# NOTE: no `paths-ignore` on the PR or merge-group triggers below. Every job
+# here is (or can be) a *required* status check, and a required check whose
+# workflow never even runs leaves a PR or queue entry stuck on "Expected,
+# waiting for status to be reported" forever. So this workflow always
+# triggers on both. Docs-only changes are instead handled by gating `ci`,
+# `feature-matrix`, `bench-compile`, and `msrv` on the `changes` job below.
 #
 # `ci` and `feature-matrix` are matrix jobs, so their required-check contexts
 # come from matrix expansion ("CI (macos-latest)", "feature-matrix
@@ -17,20 +17,22 @@ name: CI
 # names are NOT the required contexts here: `ci-gate` at the bottom of this
 # file is, mirroring `parity-gate` in e2e-parity.yml and `app-binaries-gate`
 # in app-binaries.yml. It always runs, always reports, and fails closed if
-# change-detection itself failed. `cargo-deny`, `rustdoc-lint`, and
-# `unwrap-in-lib-lint` stay ungated and directly required: they are already
-# cheap ubuntu-only jobs, so gating them would save nothing.
+# change-detection itself failed. `cargo-deny`, `typos`, and `actionlint` stay
+# directly required because they are cheap ubuntu-only jobs. `rustdoc-lint` and
+# `unwrap-in-lib-lint` remain informational and are deliberately not required.
 #
 # Rollout note: branch protection's required contexts were swapped on
 # 2026-07-04 from the seven heavy job/matrix names to `ci-gate` (plus the
-# unchanged cargo-deny, parity-gate, app-binaries-gate, and q4 composed
-# golden). PRs branched from a pre-ci-gate main must update their branch
-# (strict up-to-date protection forces this anyway) to produce the context.
+# unchanged direct required contexts). The `merge_group` trigger below makes
+# the same contexts report on the synthetic queue commit before it can land.
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
 
 # Cancel a PR's own superseded runs so they stop occupying the shared
 # macOS runner pool (~5 concurrent, account-wide) while a newer push on the
@@ -62,15 +64,12 @@ jobs:
         with:
           fetch-depth: 0
       - id: filter
+        env:
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
-            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-              || git diff --name-only "HEAD~1...HEAD")
-          else
-            CHANGED=$(git diff --name-only "HEAD~1...HEAD" 2>/dev/null || true)
-          fi
+          CHANGED=$(./scripts/ci-changed-files.sh)
           echo "Changed files:"
           echo "$CHANGED"
           # Docs set: **/*.md, docs/**, LICENSE*, .gitignore. Everything else
@@ -528,10 +527,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: crate-ci/typos@v1.48.0
 
-  # Cheap ubuntu workflow lint. Catches malformed expressions, unknown
-  # contexts/inputs, and shellcheck-level issues inside `run:` steps before
-  # they only surface as a confusing failure on a live runner. Ungated for the
-  # same reason as `typos`: it is a fast, dependency-light static check.
+  # Cheap ubuntu workflow/config lint. Catches malformed expressions, unknown
+  # contexts/inputs, shellcheck-level issues, and changed-file range regressions
+  # before they only surface as a confusing failure on a live runner. Ungated
+  # for the same reason as `typos`: it is a fast, dependency-light check.
   actionlint:
     name: actionlint
     runs-on: ubuntu-latest
@@ -540,6 +539,8 @@ jobs:
       - uses: raven-actions/actionlint@v2.2.0
         with:
           version: '1.7.12'
+      - name: merge-queue config tests
+        run: python3 tests/test_ci_changed_files.py -v
 
   # Deterministic fake-adapter unit tests + raw-observation schema validation
   # for the decode-benchmark harness core (issue #813 step 1). Stdlib-only,

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -4,8 +4,8 @@ name: e2e-parity
 # Gates on greedy token agreement, reports speed informationally.
 #
 # Required-check shape: the workflow ALWAYS triggers (no `paths:` filter on the
-# PR event), but the expensive macOS `parity` job only runs when engine files
-# actually change. A cheap always-running `parity-gate` job is the *required*
+# PR or merge-group event), but the expensive macOS `parity` job only runs when
+# engine files actually change. A cheap always-running `parity-gate` job is the *required*
 # status context — it passes when there is nothing to check and mirrors the
 # parity result when there is. This avoids the classic trap where a required
 # check is path-filtered, never reports on unrelated PRs, and wedges them on
@@ -19,9 +19,13 @@ on:
     paths:
       - 'crates/inference/src/**'
       - 'crates/embed/src/**'
+      - 'scripts/ci-changed-files.sh'
   schedule:
     - cron: '0 6 * * 1'  # weekly Monday 06:00 UTC
   workflow_dispatch:
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
 
 # Cancel a PR's own superseded runs so they stop occupying the shared macOS
 # runner pool (~5 concurrent, account-wide) while a newer push on the same PR
@@ -56,15 +60,17 @@ jobs:
         with:
           fetch-depth: 0
       - id: filter
+        env:
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
-            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-              || git diff --name-only "HEAD~1...HEAD")
-          else
-            CHANGED=$(git diff --name-only "HEAD~1...HEAD" 2>/dev/null || true)
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+            echo "engine=true" >> "$GITHUB_OUTPUT"
+            echo "→ $GITHUB_EVENT_NAME trigger: full parity suite REQUIRED"
+            exit 0
           fi
+          CHANGED=$(./scripts/ci-changed-files.sh)
           echo "Changed files:"
           echo "$CHANGED"
           # here-string, not `echo | grep -q`: -q exits at first match, echo gets
@@ -75,7 +81,7 @@ jobs:
           # still triggers wasm-parity. Without them, engine stays false and the
           # required parity-gate could pass green without the wasm path ever
           # running, a fail-open on the gate itself.
-          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/e2e_parity_check\.py$|^\.github/workflows/e2e-parity\.yml$|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^scripts/wasm-simd128-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$|^scripts/ppl_gate_check\.py$|^crates/inference/tests/fixtures/ppl_gate_v1/|^crates/inference/src/bin/eval_perplexity\.rs$|^crates/inference/src/bin/quantize_q4\.rs$|^docs/bench_results/wiki\.test\.raw$' <<<"$CHANGED" >/dev/null; then
+          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/(ci-changed-files\.sh|e2e_parity_check\.py)$|^\.github/workflows/e2e-parity\.yml$|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^scripts/wasm-simd128-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$|^scripts/ppl_gate_check\.py$|^crates/inference/tests/fixtures/ppl_gate_v1/|^crates/inference/src/bin/eval_perplexity\.rs$|^crates/inference/src/bin/quantize_q4\.rs$|^docs/bench_results/wiki\.test\.raw$' <<<"$CHANGED" >/dev/null; then
             echo "engine=true" >> "$GITHUB_OUTPUT"
             echo "→ engine surface changed: parity REQUIRED"
           else
@@ -186,11 +192,13 @@ jobs:
   #
   # Deliberately NOT added to parity-gate.needs below: this is an informational
   # signal only. Making it required is a maintainer decision (repo branch
-  # protection), out of scope for this change.
+  # protection), out of scope for this change. It is also skipped on merge-group
+  # events so this non-required macOS work cannot delay the required queue jobs;
+  # the PR run remains its observation point.
   metal-parity:
     name: metal attention parity (informational)
     needs: changes
-    if: needs.changes.outputs.engine == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: (needs.changes.outputs.engine == 'true' && github.event_name != 'merge_group') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: macos-latest
     timeout-minutes: 25
     steps:

--- a/scripts/ci-changed-files.sh
+++ b/scripts/ci-changed-files.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+case "${GITHUB_EVENT_NAME:-}" in
+    pull_request | merge_group | push) ;;
+    *)
+        echo "unsupported change-detection event: ${GITHUB_EVENT_NAME:-<unset>}" >&2
+        exit 2
+        ;;
+esac
+
+base_sha=${CI_BASE_SHA:-}
+head_sha=${CI_HEAD_SHA:-}
+
+if [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
+    echo "CI_BASE_SHA and CI_HEAD_SHA are required" >&2
+    exit 2
+fi
+
+case "$base_sha$head_sha" in
+    *[!0-9a-fA-F]*)
+        echo "CI_BASE_SHA and CI_HEAD_SHA must be hexadecimal commit IDs" >&2
+        exit 2
+        ;;
+esac
+
+actual_head=$(git rev-parse HEAD)
+if [ "$actual_head" != "$head_sha" ]; then
+    echo "checked-out HEAD $actual_head does not match event head $head_sha" >&2
+    exit 1
+fi
+
+zero_sha=0000000000000000000000000000000000000000
+if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$base_sha" = "$zero_sha" ]; then
+    changed=$(git -c core.quotePath=false ls-tree -r --name-only "$head_sha")
+else
+    if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+        echo "event base $base_sha is not available as a commit" >&2
+        exit 1
+    fi
+
+    if ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+        echo "event head $head_sha is not available as a commit" >&2
+        exit 1
+    fi
+
+    if ! git merge-base --is-ancestor "$base_sha" "$head_sha"; then
+        echo "event base $base_sha is not an ancestor of event head $head_sha" >&2
+        exit 1
+    fi
+
+    changed=$(git -c core.quotePath=false diff --name-only --no-renames "${base_sha}..${head_sha}")
+fi
+
+case "$changed" in
+    \"* | *'
+"'*)
+        echo "changed path requires Git quoting; refusing ambiguous classification" >&2
+        exit 1
+        ;;
+esac
+
+printf '%s\n' "$changed"

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -1,0 +1,210 @@
+"""Tests for the fail-closed CI changed-file range selector."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "ci-changed-files.sh"
+_ROOT = _SCRIPT.parent.parent
+_ZERO_SHA = "0" * 40
+_REQUIRED_WORKFLOWS = (
+    ".github/workflows/app-binaries.yml",
+    ".github/workflows/cargo-audit.yml",
+    ".github/workflows/ci.yml",
+    ".github/workflows/e2e-parity.yml",
+)
+
+
+class ChangedFilesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tempdir.name)
+        self._git("init", "-q", "-b", "main")
+        self._git("config", "user.name", "CI Test")
+        self._git("config", "user.email", "ci-test@example.invalid")
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def _git(self, *args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def _commit(self, path: str, contents: str) -> str:
+        target = self.repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents, encoding="utf-8")
+        self._git("add", path)
+        self._git("commit", "-q", "-m", f"write {path}")
+        return self._git("rev-parse", "HEAD")
+
+    def _run(
+        self,
+        event: str,
+        base_sha: str,
+        head_sha: str,
+        *,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            GITHUB_EVENT_NAME=event,
+            CI_BASE_SHA=base_sha,
+            CI_HEAD_SHA=head_sha,
+        )
+        return subprocess.run(
+            [str(_SCRIPT)],
+            cwd=self.repo,
+            env=env,
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_merge_group_reports_every_change_in_the_event_range(self) -> None:
+        base = self._commit("README.md", "base\n")
+        self._commit("docs/queue.md", "docs\n")
+        head = self._commit("crates/inference/src/queue.rs", "code\n")
+
+        result = self._run("merge_group", base, head)
+
+        self.assertEqual(
+            result.stdout.splitlines(),
+            ["crates/inference/src/queue.rs", "docs/queue.md"],
+        )
+
+    def test_pull_request_uses_the_event_base(self) -> None:
+        base = self._commit("README.md", "base\n")
+        head = self._commit("crates/embed/src/change.rs", "code\n")
+
+        result = self._run("pull_request", base, head)
+
+        self.assertEqual(result.stdout.splitlines(), ["crates/embed/src/change.rs"])
+
+    def test_multi_commit_push_is_not_reduced_to_the_last_commit(self) -> None:
+        base = self._commit("README.md", "base\n")
+        self._commit("crates/fann/src/change.rs", "code\n")
+        head = self._commit("docs/followup.md", "docs\n")
+
+        result = self._run("push", base, head)
+
+        self.assertEqual(
+            result.stdout.splitlines(),
+            ["crates/fann/src/change.rs", "docs/followup.md"],
+        )
+
+    def test_rename_reports_the_relevant_source_and_destination(self) -> None:
+        base = self._commit("crates/embed/src/moved.rs", "code\n")
+        (self.repo / "docs").mkdir()
+        self._git("mv", "crates/embed/src/moved.rs", "docs/moved.md")
+        self._git("commit", "-q", "-m", "move code into docs")
+        head = self._git("rev-parse", "HEAD")
+
+        result = self._run("merge_group", base, head)
+
+        self.assertEqual(
+            result.stdout.splitlines(),
+            ["crates/embed/src/moved.rs", "docs/moved.md"],
+        )
+
+    def test_unicode_path_remains_classifiable(self) -> None:
+        base = self._commit("README.md", "base\n")
+        head = self._commit("crates/inference/src/café.rs", "code\n")
+
+        result = self._run("merge_group", base, head)
+
+        self.assertEqual(
+            result.stdout.splitlines(), ["crates/inference/src/café.rs"]
+        )
+
+    def test_control_character_path_fails_closed(self) -> None:
+        base = self._commit("README.md", "base\n")
+        head = self._commit("crates/inference/src/line\nbreak.rs", "code\n")
+
+        result = self._run("merge_group", base, head, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requires Git quoting", result.stderr)
+
+    def test_first_push_reports_root_commit_files(self) -> None:
+        head = self._commit("Cargo.toml", "[workspace]\n")
+
+        result = self._run("push", _ZERO_SHA, head)
+
+        self.assertEqual(result.stdout.splitlines(), ["Cargo.toml"])
+
+    def test_first_push_with_history_reports_the_entire_tree(self) -> None:
+        self._commit("crates/inference/src/change.rs", "code\n")
+        head = self._commit("docs/followup.md", "docs\n")
+
+        result = self._run("push", _ZERO_SHA, head)
+
+        self.assertEqual(
+            result.stdout.splitlines(),
+            ["crates/inference/src/change.rs", "docs/followup.md"],
+        )
+
+    def test_checkout_head_mismatch_fails_closed(self) -> None:
+        base = self._commit("README.md", "base\n")
+        expected_head = self._commit("docs/change.md", "change\n")
+        self._git("checkout", "-q", base)
+
+        result = self._run("merge_group", base, expected_head, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not match event head", result.stderr)
+
+    def test_non_ancestor_base_fails_closed(self) -> None:
+        base = self._commit("README.md", "base\n")
+        self._git("checkout", "-q", "--orphan", "other")
+        head = self._commit("other.txt", "unrelated\n")
+
+        result = self._run("merge_group", base, head, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is not an ancestor", result.stderr)
+
+    def test_non_hexadecimal_revision_fails_before_git_parsing(self) -> None:
+        head = self._commit("README.md", "base\n")
+
+        result = self._run("merge_group", "HEAD^{tree}", head, check=False)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("must be hexadecimal commit IDs", result.stderr)
+
+    def test_schedule_requires_explicit_workflow_policy(self) -> None:
+        head = self._commit("README.md", "base\n")
+
+        result = self._run("schedule", head, head, check=False)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("unsupported change-detection event", result.stderr)
+
+
+class MergeQueueWorkflowTests(unittest.TestCase):
+    def test_every_required_workflow_listens_for_merge_group_checks(self) -> None:
+        trigger = (
+            "  merge_group:\n"
+            "    branches: [main]\n"
+            "    types: [checks_requested]\n"
+        )
+
+        for relative_path in _REQUIRED_WORKFLOWS:
+            with self.subTest(workflow=relative_path):
+                contents = (_ROOT / relative_path).read_text(encoding="utf-8")
+                self.assertIn(trigger, contents)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

Prepare every effective required status check to run against GitHub merge-group commits:

- add unfiltered `merge_group: checks_requested` triggers to CI, e2e parity, app binaries, and cargo audit;
- replace `HEAD~1` / suppressed-diff fallbacks with one fail-closed event-range selector for pull requests, merge groups, and multi-commit pushes;
- verify the checkout, commit availability, and ancestry before classification; report both sides of renames, preserve Unicode paths, and reject ambiguous quoted paths;
- run 13 regression/static tests in the directly required `actionlint` job;
- make scheduled/manual parity and manual app dispatches exercise their full suites;
- keep informational Metal parity off the merge-group critical path while retaining it on PR, scheduled, and manual runs.

The seven effective required contexts covered are `ci-gate`, `cargo-deny`, `typos`, `actionlint`, `parity-gate`, `app-binaries-gate`, and `cargo-audit-gate`.

## Why

Merge queue cannot be safely enabled while required Actions workflows omit the `merge_group` event. The previous non-PR classifier also compared only `HEAD~1` and suppressed some diff failures, which could classify a grouped or multi-commit ref as irrelevant and let an expensive gate skip.

This PR makes the workflow layer queue-ready. It deliberately does **not** enable merge queue yet; these workflow definitions must land on `main` first. See [GitHub's merge queue documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

## Validation

- `make ci`
- `python3 tests/test_ci_changed_files.py -v` — 13 passed
- `actionlint -color`
- `shellcheck scripts/ci-changed-files.sh`
- `git diff --check`
- repository pre-commit hook — passed

Benchmarks are not applicable because the diff is limited to workflows, a shell helper, and its tests.

## Post-merge activation

1. Confirm all four workflow files are present on `main`.
2. Add a merge-queue rule to ruleset `16354934` with:
   - `ALLGREEN` grouping;
   - squash merge;
   - 90-minute check-response timeout;
   - one entry built at a time initially;
   - minimum one entry to merge;
   - short or zero minimum wait.
3. Queue a docs-only canary and confirm all seven required contexts report while irrelevant heavy work skips.
4. Queue a code canary and confirm the full fan-ins run against the merge-group SHA.
5. Before consolidating classic protection into the ruleset, preserve the current one-approval requirement; the ruleset currently records zero approvals.
6. Remove broad always-bypass permissions if “every commit is queue-tested” is intended literally.

Release trusted publishing and fail-closed Apple GPU coverage are intentionally separate follow-up changes because they require distinct infrastructure and review.