### PR TITLE
refactor(scripts): consolidate decode-bench methodology into one profiled harness (#813)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,9 +542,17 @@ jobs:
           version: '1.7.12'
 
   # Deterministic fake-adapter unit tests + raw-observation schema validation
-  # for the decode-benchmark harness core (issue #813 step 1). Stdlib-only,
-  # no engine binary or model weights required — cheap ubuntu-only, so it is
-  # ungated like typos/actionlint above rather than routed through ci-gate.
+  # for the decode-benchmark harness core (issue #813 step 1) and every
+  # migrated profile's adapter module (issue #813 step 2: apples_to_apples,
+  # apples_precise, q4_apples, context_scaling). Stdlib-only (mlx_lm/ollama
+  # are never imported by these test files -- adapters are exercised only
+  # through pure parsing helpers and the harness's own deterministic fake
+  # adapters), no engine binary or model weights required — cheap
+  # ubuntu-only, so it is ungated like typos/actionlint above rather than
+  # routed through ci-gate. (The four adapter test files were not wired into
+  # any CI job before this issue's step-2 migrations landed; this closes
+  # that gap for all of them at once rather than repeating the same
+  # omission per migrated script.)
   bench-decode-harness-tests:
     name: bench-decode-harness-tests
     runs-on: ubuntu-latest
@@ -555,6 +563,14 @@ jobs:
           python-version: '3.11'
       - name: python3 tests/test_bench_decode_harness.py
         run: python3 tests/test_bench_decode_harness.py -v
+      - name: python3 tests/test_bench_decode_adapters_apples_to_apples.py
+        run: python3 tests/test_bench_decode_adapters_apples_to_apples.py -v
+      - name: python3 tests/test_bench_decode_adapters_apples_precise.py
+        run: python3 tests/test_bench_decode_adapters_apples_precise.py -v
+      - name: python3 tests/test_bench_decode_adapters_q4_apples.py
+        run: python3 tests/test_bench_decode_adapters_q4_apples.py -v
+      - name: python3 tests/test_bench_decode_adapters_context_scaling.py
+        run: python3 tests/test_bench_decode_adapters_context_scaling.py -v
 
   # cargo-semver-checks against the latest published crates.io release for
   # every internal path-dependency crate, so a breaking public API change is

--- a/scripts/bench_apples_precise.sh
+++ b/scripts/bench_apples_precise.sh
@@ -1,159 +1,30 @@
 #!/usr/bin/env bash
 # Precise apples-to-apples decode benchmark — reduced noise edition.
 #
-# Differences from bench_apples_to_apples.sh:
-#   - 15 runs instead of 5, with 2 warmup runs excluded
-#   - N1=64, N2=512 for longer decode windows (more signal, less prefill noise)
-#   - Trimmed mean: drops highest and lowest 2 values
-#   - Reports 95% CI from the trimmed set
-#   - Warns if concurrent GPU processes detected
+# Thin wrapper (issue #813 step 2): all methodology (warmup policy, repeat
+# count, trimmed-mean aggregation, legacy normal-approximation CI, output
+# rendering) now lives in scripts/bench_decode_harness.py, configured by the
+# apples_precise profile in scripts/bench_decode_profiles.toml. This script
+# only execs the harness (via scripts/bench_decode_adapters_apples_precise.py,
+# which registers the lattice/ollama/mlx engine adapters). Parameters are
+# unchanged from the pre-migration version of this script: N1=64, N2=512,
+# 13 measured repeats + 2 warmup repeats per engine (15 total), trimmed
+# mean dropping the top/bottom 2 measured values, legacy 95%-normal-
+# approximation CI.
 set -uo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-LAT_BIN="$REPO/target/release/bench_decode_ab"
-MODEL_DIR="$HOME/.lattice/models/qwen3.5-0.8b"
-N1=64
-N2=512
-TOTAL_RUNS=15
-WARMUP=2
-PROMPT="The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
 OUT="$REPO/target/bench_results"
 mkdir -p "$OUT"
-DATA="$OUT/precise_raw.tsv"
-: > "$DATA"
 
-# Warn about concurrent GPU load
-GPU_PROCS=$(ps aux | grep -E "li play|mlx|ollama" | grep -v grep | wc -l | tr -d ' ')
-if [ "$GPU_PROCS" -gt 0 ]; then
-  echo "⚠  $GPU_PROCS concurrent GPU processes detected — results may have elevated noise"
-fi
+echo "=== Precise decode bench | Qwen3.5-0.8B | N1=64 N2=512 measured=13 warmup=2 (per engine) ==="
+echo "  Harness: scripts/bench_decode_harness.py (profile apples_precise)"
+echo ""
 
-echo "=== Precise decode bench | Qwen3.5-0.8B | N1=$N1 N2=$N2 runs=$TOTAL_RUNS (warmup=$WARMUP) ==="
+uv run --quiet --with mlx-lm python3 "$REPO/scripts/bench_decode_adapters_apples_precise.py" \
+  run --profile apples_precise --allow-missing-engine --out "$OUT/precise_raw.jsonl"
+status=$?
 
-# ---- Lattice ----
-if [[ -x "$LAT_BIN" ]]; then
-  # Warmup
-  for _ in $(seq 1 $WARMUP); do
-    BENCH_N=$N2 BENCH_RUNS=1 LATTICE_MODEL_DIR="$MODEL_DIR" "$LAT_BIN" 2>/dev/null >/dev/null
-  done
-  RUNS=$((TOTAL_RUNS - WARMUP))
-  for N in $N1 $N2; do
-    BENCH_N=$N BENCH_RUNS=$RUNS LATTICE_MODEL_DIR="$MODEL_DIR" "$LAT_BIN" 2>/dev/null \
-    | awk -v N=$N '/^RESULT/{
-        for(i=1;i<=NF;i++){split($i,kv,"="); v[kv[1]]=kv[2]}
-        printf "lattice\t%s\t%d\t%.6f\t\n", N, ++r, v["total_ms"]/1000.0
-      }' >> "$DATA"
-  done
-  echo "  lattice: done ($RUNS measured runs)"
-else
-  echo "  lattice: BIN MISSING ($LAT_BIN)"
-fi
-
-# ---- Ollama ----
-if command -v ollama >/dev/null 2>&1; then
-  ollama list 2>/dev/null | grep -q "qwen3.5:0.8b" || ollama pull qwen3.5:0.8b >/dev/null 2>&1
-  curl -s localhost:11434/api/tags >/dev/null 2>&1 || { ollama serve >/dev/null 2>&1 & sleep 3; }
-  # Warmup
-  for _ in $(seq 1 $WARMUP); do
-    curl -s localhost:11434/api/generate -d "{\"model\":\"qwen3.5:0.8b\",\"prompt\":$(python3 -c "import json;print(json.dumps('$PROMPT'))"),\"stream\":false,\"options\":{\"num_predict\":$N2,\"temperature\":0}}" >/dev/null
-  done
-  RUNS=$((TOTAL_RUNS - WARMUP))
-  for N in $N1 $N2; do
-    for run in $(seq 1 $RUNS); do
-      R=$(curl -s localhost:11434/api/generate -d "{\"model\":\"qwen3.5:0.8b\",\"prompt\":$(python3 -c "import json;print(json.dumps('$PROMPT'))"),\"stream\":false,\"options\":{\"num_predict\":$N,\"temperature\":0}}")
-      echo "$R" | python3 -c "
-import sys,json
-d=json.load(sys.stdin)
-tot=d.get('total_duration',0)/1e9
-ec=d.get('eval_count',0); ed=d.get('eval_duration',1)/1e9
-print(f'ollama\t$N\t$run\t{tot:.6f}\t{ec/ed:.3f}')" >> "$DATA"
-    done
-  done
-  echo "  ollama: done ($RUNS measured runs)"
-else
-  echo "  ollama: not installed — skipped"
-fi
-
-# ---- MLX ----
-uv run --quiet --with mlx-lm python3 - "$MODEL_DIR" "$N1" "$N2" "$TOTAL_RUNS" "$WARMUP" "$PROMPT" <<'PY' >> "$DATA" 2>/dev/null
-import sys, time
-mdir, n1, n2 = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-total_runs, warmup = int(sys.argv[4]), int(sys.argv[5])
-prompt = sys.argv[6]
-import mlx.core as mx, mlx.nn as nn
-from mlx_lm import load, generate
-from mlx_lm.sample_utils import make_sampler
-try:
-    model, tok = load(mdir)
-except Exception:
-    model, tok = load("Qwen/Qwen3.5-0.8B")
-nn.quantize(model, bits=8, group_size=64); mx.eval(model.parameters())
-samp = make_sampler(temp=0.0)
-# Warmup
-for _ in range(warmup):
-    generate(model, tok, prompt=prompt, max_tokens=n2, sampler=samp, verbose=False)
-runs = total_runs - warmup
-for N in (n1, n2):
-    for run in range(1, runs+1):
-        t0=time.time()
-        generate(model, tok, prompt=prompt, max_tokens=N, sampler=samp, verbose=False)
-        dt=time.time()-t0
-        print(f"mlx\t{N}\t{run}\t{dt:.6f}\t")
-PY
-echo "  mlx: done"
-
-# ---- Analysis: trimmed mean + CI ----
-python3 - "$DATA" "$N1" "$N2" <<'PY'
-import sys, statistics as st, collections, math
-data, N1, N2 = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-rows=collections.defaultdict(lambda: collections.defaultdict(list))
-nat=collections.defaultdict(list)
-for ln in open(data):
-    p=ln.rstrip("\n").split("\t")
-    if len(p)<4 or not p[3]: continue
-    eng,N,_,tot=p[0],int(p[1]),p[2],float(p[3])
-    rows[eng][N].append(tot)
-    if len(p)>=5 and p[4]: nat[eng].append(float(p[4]))
-
-def trimmed_stats(vals, trim=2):
-    """Trimmed mean + 95% CI from the middle values."""
-    s = sorted(vals)
-    if len(s) <= 2*trim:
-        return st.mean(s), 0, s
-    trimmed = s[trim:-trim]
-    m = st.mean(trimmed)
-    if len(trimmed) > 1:
-        se = st.stdev(trimmed) / math.sqrt(len(trimmed))
-        ci95 = 1.96 * se
-    else:
-        ci95 = 0
-    return m, ci95, trimmed
-
-print(f"\n{'engine':<10}{'slope tok/s':>13}{'±95% CI':>10}{'spread%':>10}{'native':>10}   (trimmed mean, {len(rows.get('lattice',{}).get(N2,[]))} runs)")
-print("-"*64)
-res={}
-for eng in ("lattice","mlx","ollama"):
-    if N1 not in rows[eng] or N2 not in rows[eng]:
-        print(f"{eng:<10}{'(no data)':>13}"); continue
-    t1_mean, t1_ci, t1_vals = trimmed_stats(rows[eng][N1])
-    t2_mean, t2_ci, t2_vals = trimmed_stats(rows[eng][N2])
-    dt = t2_mean - t1_mean
-    slope = (N2-N1)/dt if dt > 0 else float('nan')
-    # Propagate CI
-    slope_ci = slope * math.sqrt((t1_ci/t1_mean)**2 + (t2_ci/t2_mean)**2) if t1_mean > 0 and t2_mean > 0 else 0
-    spread = (max(t2_vals)-min(t2_vals))/t2_mean*100 if t2_vals else 0
-    native = st.median(nat[eng]) if nat[eng] else float('nan')
-    res[eng] = (slope, slope_ci)
-    ns = f"{native:10.1f}" if native==native else f"{'—':>10}"
-    print(f"{eng:<10}{slope:13.1f}{slope_ci:10.1f}{spread:9.1f}%{ns}")
-print("-"*64)
-if "lattice" in res and "mlx" in res:
-    ls, lci = res["lattice"]; ms, mci = res["mlx"]
-    gap = (1 - ls/ms)*100 if ms > 0 else float('nan')
-    print(f"\nLattice vs MLX: {gap:.1f}% slower (±{lci:.1f}/{mci:.1f} tok/s CI)")
-if "lattice" in res and "ollama" in res:
-    ls, lci = res["lattice"]; os_, oci = res["ollama"]
-    adv = (ls/os_ - 1)*100 if os_ > 0 else float('nan')
-    print(f"Lattice vs Ollama: {adv:.1f}% faster")
-print(f"\nRaw: {data}")
-PY
+echo ""
+echo "Raw observations: $OUT/precise_raw.jsonl"
+exit $status

--- a/scripts/bench_context_scaling.sh
+++ b/scripts/bench_context_scaling.sh
@@ -2,18 +2,17 @@
 # Context-length scaling benchmark — measures decode throughput at multiple
 # generation lengths to show how attention cost scales with KV cache size.
 #
-# Slope method: for each context length C, run N1=8 and N2=C, then
-#   decode_tok_s = (C - 8) / (T(C) - T(8))
-# This gives average marginal decode rate over the [8, C] window, with
-# prefill overhead cancelled.
+# Thin wrapper (issue #813 step 2): all methodology (warmup policy, repeat
+# count, aggregation, output rendering) now lives in
+# scripts/bench_decode_harness.py, configured by the context_scaling profile
+# in scripts/bench_decode_profiles.toml. This script execs the harness (via
+# scripts/bench_decode_adapters_context_scaling.py, which registers the
+# lattice/ollama/mlx engine adapters AND owns the legacy chart-compatible
+# TSV rendering + scripts/bench_context_scaling_chart.py invocation this
+# script always did). Default parameters are unchanged: N1=8 baseline,
+# contexts {64,128,256}, 5 measured repeats, mlx-only 4-token warmup.
 #
-# Model EOS limit: Qwen3.5-0.8B generates ~346 tokens max for the bench
-# prompt before hitting EOS. Context lengths beyond 256 are unreliable
-# without disabling EOS.
-#
-# Engines: lattice (Q8 + f16 lm_head), ollama (Q8_0), mlx (Q8 g64)
-#
-# Usage:
+# Usage (env vars forwarded verbatim, same names as before migration):
 #   ./scripts/bench_context_scaling.sh                   # default: 5 runs
 #   RUNS=10 ./scripts/bench_context_scaling.sh           # more runs
 #   CONTEXTS="64 128 256" ./scripts/bench_context_scaling.sh  # custom lengths
@@ -21,195 +20,21 @@
 set -uo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-LAT_BIN="$REPO/target/release/bench_decode_ab"
-Q8_DIR="$HOME/.lattice/models/qwen3.5-0.8b"
-RUNS="${RUNS:-5}"
-N1=8  # fixed baseline — small enough to not dominate, large enough to warm caches
-OUT="$REPO/docs/bench_results"
+OUT="$REPO/target/bench_results"
 mkdir -p "$OUT"
-DATA="$OUT/context_scaling.tsv"
-CHART="$OUT/context_scaling_benchmark.png"
-PROMPT="The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
 
-# Default context lengths (override with CONTEXTS env var)
-if [[ -z "${CONTEXTS:-}" ]]; then
-    CONTEXTS_ARR=(64 128 256)
-else
-    read -ra CONTEXTS_ARR <<< "$CONTEXTS"
-fi
+ARGS=(--allow-missing-engine --out "$OUT/context_scaling_raw.jsonl")
 
-# ─── Chart-only mode ───
 if [[ "${CHART_ONLY:-0}" == "1" ]]; then
-    echo "=== Regenerating chart from $DATA ==="
-    uv run python "$REPO/scripts/bench_context_scaling_chart.py" "$DATA" "$CHART"
-    exit $?
-fi
-
-# ─── Build lattice if needed ───
-if [[ ! -x "$LAT_BIN" ]]; then
-    echo "Building bench_decode_ab (release)..."
-    cargo build --release -p lattice-inference --bin bench_decode_ab --features "f16,metal-gpu" 2>/dev/null
-fi
-
-echo "=== Context-length scaling | Qwen3.5-0.8B Q8 | N1=$N1 | runs=$RUNS ==="
-echo "  Contexts: ${CONTEXTS_ARR[*]}"
-echo "  Output:   $DATA"
-echo ""
-
-# Header
-echo -e "engine\tcontext_tokens\tslope_tok_s\tt1_ms\tt2_ms\truns" > "$DATA"
-
-# ─── Helper: run bench_decode_ab, return median total_ms ───
-lattice_median() {
-    local n=$1
-    env BENCH_N="$n" BENCH_RUNS="$RUNS" LATTICE_MODEL_DIR="$Q8_DIR" "$LAT_BIN" 2>/dev/null \
-        | awk -F'total_ms=' '/^RESULT/{print $2}' \
-        | sort -n \
-        | awk "NR==$(( (RUNS + 1) / 2 ))"
-}
-
-# ─── Helper: run ollama, return median total_ms ───
-ollama_median() {
-    local n=$1
-    local vals=()
-    for ((r=1; r<=RUNS; r++)); do
-        local ms
-        ms=$(curl -s http://localhost:11434/api/generate \
-            -d "{\"model\":\"qwen3.5:0.8b\",\"prompt\":\"$PROMPT\",\"options\":{\"num_predict\":$n,\"temperature\":0,\"seed\":42},\"stream\":false}" \
-            | python3 -c "import json,sys; d=json.load(sys.stdin); print(f'{d[\"total_duration\"]/1e6:.3f}')" 2>/dev/null)
-        [[ -n "$ms" ]] && vals+=("$ms")
-    done
-    if (( ${#vals[@]} == 0 )); then echo ""; return; fi
-    printf '%s\n' "${vals[@]}" | sort -n | awk "NR==$(( (${#vals[@]} + 1) / 2 ))"
-}
-
-# ─── Lattice ───
-echo "─── Lattice (Q8, f16 lm_head) ───"
-# Pre-measure N1 once (shared across all context lengths)
-LAT_T1=$(lattice_median $N1)
-if [[ -z "$LAT_T1" ]]; then
-    echo "  FAILED: bench_decode_ab not working"
+  ARGS=(--chart-only)
 else
-    echo "  N1=$N1 baseline: ${LAT_T1}ms (median of $RUNS)"
-    for CTX in "${CONTEXTS_ARR[@]}"; do
-        T2=$(lattice_median "$CTX")
-        if [[ -n "$T2" ]]; then
-            SLOPE=$(echo "scale=1; ($CTX - $N1) / (($T2 - $LAT_T1) / 1000)" | bc)
-            echo "  ctx=$CTX: T2=${T2}ms → ${SLOPE} tok/s"
-            echo -e "lattice\t$CTX\t$SLOPE\t$LAT_T1\t$T2\t$RUNS" >> "$DATA"
-        else
-            echo "  ctx=$CTX: FAILED (model may have hit EOS)"
-        fi
-    done
+  if [[ -n "${CONTEXTS:-}" ]]; then
+    ARGS+=(--contexts "$(echo "${CONTEXTS}" | tr ' ' ',')")
+  fi
+  if [[ -n "${RUNS:-}" ]]; then
+    ARGS+=(--runs "$RUNS")
+  fi
 fi
 
-# ─── Ollama ───
-echo ""
-echo "─── Ollama (Q8_0, llama.cpp Metal) ───"
-if command -v ollama &>/dev/null && curl -s http://localhost:11434/api/tags 2>/dev/null | python3 -c "import json,sys; models=[m['name'] for m in json.load(sys.stdin).get('models',[])]; sys.exit(0 if any('qwen3.5:0.8b' in m for m in models) else 1)" 2>/dev/null; then
-    OLL_T1=$(ollama_median $N1)
-    if [[ -z "$OLL_T1" ]]; then
-        echo "  FAILED: ollama not responding"
-    else
-        echo "  N1=$N1 baseline: ${OLL_T1}ms (median of $RUNS)"
-        for CTX in "${CONTEXTS_ARR[@]}"; do
-            T2=$(ollama_median "$CTX")
-            if [[ -n "$T2" ]]; then
-                SLOPE=$(echo "scale=1; ($CTX - $N1) / (($T2 - $OLL_T1) / 1000)" | bc)
-                echo "  ctx=$CTX: T2=${T2}ms → ${SLOPE} tok/s"
-                echo -e "ollama\t$CTX\t$SLOPE\t$OLL_T1\t$T2\t$RUNS" >> "$DATA"
-            else
-                echo "  ctx=$CTX: FAILED"
-            fi
-        done
-    fi
-else
-    echo "  SKIPPED (ollama not running or qwen3.5:0.8b not pulled)"
-fi
-
-# ─── MLX ───
-echo ""
-echo "─── MLX (Q8 g64, private AMX) ───"
-MLX_SCRIPT=$(cat <<'PYTHON'
-import sys, time, json
-import mlx.core as mx
-import mlx.nn as nn
-import mlx_lm
-
-model, tokenizer = mlx_lm.load("Qwen/Qwen3.5-0.8B",
-                                tokenizer_config={"eos_token": "<|endoftext|>"})
-nn.quantize(model, bits=8, group_size=64)
-
-prompt = "The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
-greedy = lambda logits: mx.argmax(logits, axis=-1)
-
-# warmup
-_ = mlx_lm.generate(model, tokenizer, prompt=prompt, max_tokens=4,
-                     sampler=greedy, verbose=False)
-mx.eval(mx.zeros(1))
-
-n1 = int(sys.argv[1])
-contexts = json.loads(sys.argv[2])
-runs = int(sys.argv[3])
-
-# Measure N1 baseline
-times_n1 = []
-for _ in range(runs):
-    mx.eval(mx.zeros(1))
-    t0 = time.perf_counter()
-    _ = mlx_lm.generate(model, tokenizer, prompt=prompt, max_tokens=n1,
-                         sampler=greedy, verbose=False)
-    mx.eval(mx.zeros(1))
-    times_n1.append((time.perf_counter() - t0) * 1000)
-t1 = sorted(times_n1)[len(times_n1) // 2]
-sys.stderr.write(f"  N1={n1} baseline: {t1:.1f}ms (median of {runs})\n")
-
-for ctx in contexts:
-    times_n2 = []
-    for _ in range(runs):
-        mx.eval(mx.zeros(1))
-        t0 = time.perf_counter()
-        _ = mlx_lm.generate(model, tokenizer, prompt=prompt, max_tokens=ctx,
-                             sampler=greedy, verbose=False)
-        mx.eval(mx.zeros(1))
-        times_n2.append((time.perf_counter() - t0) * 1000)
-    t2 = sorted(times_n2)[len(times_n2) // 2]
-    slope = (ctx - n1) / ((t2 - t1) / 1000)
-    sys.stderr.write(f"  ctx={ctx}: T2={t2:.1f}ms -> {slope:.1f} tok/s\n")
-    print(f"mlx\t{ctx}\t{slope:.1f}\t{t1:.3f}\t{t2:.3f}\t{runs}")
-PYTHON
-)
-
-uv run python -c "$MLX_SCRIPT" "$N1" "[$(IFS=,; echo "${CONTEXTS_ARR[*]}")]" "$RUNS" 2>&1 \
-    | tee >(grep "^mlx" >> "$DATA") | grep -v "^mlx"
-
-# ─── Summary ───
-echo ""
-echo "═══ Results ═══"
-echo ""
-printf "%-10s %6s %12s\n" "engine" "ctx" "tok/s"
-printf "%-10s %6s %12s\n" "------" "---" "-----"
-tail -n +2 "$DATA" | while IFS=$'\t' read -r eng ctx slope rest; do
-    printf "%-10s %6s %12s\n" "$eng" "$ctx" "$slope"
-done
-
-# ─── Ratios ───
-echo ""
-echo "═══ Lattice vs Ollama ═══"
-for CTX in "${CONTEXTS_ARR[@]}"; do
-    LAT=$(awk -F'\t' -v c="$CTX" '$1=="lattice" && $2==c {print $3}' "$DATA")
-    OLL=$(awk -F'\t' -v c="$CTX" '$1=="ollama" && $2==c {print $3}' "$DATA")
-    if [[ -n "$LAT" && -n "$OLL" ]]; then
-        RATIO=$(echo "scale=2; $LAT / $OLL" | bc)
-        echo "  ctx=$CTX: ${RATIO}× (${LAT} vs ${OLL} tok/s)"
-    fi
-done
-
-echo ""
-echo "Raw data: $DATA"
-
-# ─── Generate chart ───
-echo ""
-echo "─── Generating chart ───"
-uv run python "$REPO/scripts/bench_context_scaling_chart.py" "$DATA" "$CHART" 2>&1
-echo "Chart: $CHART"
+uv run --quiet --with mlx-lm python3 "$REPO/scripts/bench_decode_adapters_context_scaling.py" "${ARGS[@]}"
+exit $?

--- a/scripts/bench_decode_adapters_apples_precise.py
+++ b/scripts/bench_decode_adapters_apples_precise.py
@@ -19,8 +19,10 @@ independently wall-clock-timed by the harness), so each `elapsed_ns` here
 additionally includes one subprocess spawn + model load that the legacy
 script's own `BENCH_RUNS=$RUNS` single-process loop never paid per
 observation. The engine's own decode-only `total_ms` is preserved
-losslessly via `AdapterRunResult.native_ns` (the harness's "native tok/s"
-diagnostic column).
+losslessly via `AdapterRunResult.native_ns`, which the harness treats as
+the primary aggregated duration (`engine_native_ns`) when present, not
+merely a diagnostic column -- later adapters must not treat this field as
+non-comparable across engines.
 
 Run with (from repo root): `uv run --quiet --with mlx-lm python3
 scripts/bench_decode_adapters_apples_precise.py run --profile apples_precise

--- a/scripts/bench_decode_adapters_apples_precise.py
+++ b/scripts/bench_decode_adapters_apples_precise.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Engine adapters for the `apples_precise` profile (issue #813 step 2:
+migrate `bench_apples_precise.sh`).
+
+Registers three `EngineAdapter`s (lattice, ollama, mlx) that invoke exactly
+what `bench_apples_precise.sh`'s inline lattice-loop/ollama-curl/mlx-`uv run`
+sections invoked, then delegates argument parsing and execution to
+`bench_decode_harness.main()`. All repeat-count, warmup, and
+aggregation/CI decisions stay in the harness/profile
+(`bench_decode_profiles.toml`); this module owns invocation and parsing
+only, per `EngineAdapter`'s contract.
+
+Disclosed methodology note (lattice only, same class as
+`bench_decode_adapters_apples_to_apples.py`'s note): `bench_decode_ab`
+amortizes one model load across `BENCH_RUNS` internal repeats within a
+single process, timing only AFTER load. This adapter invokes it with
+`BENCH_RUNS=1` per harness call (one call per measured/warmup repeat, each
+independently wall-clock-timed by the harness), so each `elapsed_ns` here
+additionally includes one subprocess spawn + model load that the legacy
+script's own `BENCH_RUNS=$RUNS` single-process loop never paid per
+observation. The engine's own decode-only `total_ms` is preserved
+losslessly via `AdapterRunResult.native_ns` (the harness's "native tok/s"
+diagnostic column).
+
+Run with (from repo root): `uv run --quiet --with mlx-lm python3
+scripts/bench_decode_adapters_apples_precise.py run --profile apples_precise
+--allow-missing-engine`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_decode_harness as harness  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# -- lattice: exactly bench_apples_precise.sh's LAT_BIN/MODEL_DIR --
+LAT_BIN = REPO_ROOT / "target" / "release" / "bench_decode_ab"
+MODEL_DIR = Path.home() / ".lattice" / "models" / "qwen3.5-0.8b"
+
+_RESULT_RE = re.compile(r"^RESULT n_req=(\d+) completion=(\d+) total_ms=([\d.]+)$")
+
+
+def parse_lattice_result_line(line: str) -> tuple[int, int, float] | None:
+    """Same full-line RESULT contract as
+    `bench_decode_adapters_apples_to_apples.py.parse_lattice_result_line`."""
+    m = _RESULT_RE.match(line)
+    if m is None:
+        return None
+    return int(m.group(1)), int(m.group(2)), float(m.group(3))
+
+
+class LatticeUnavailableError(RuntimeError):
+    """`bench_decode_ab` is not built, or the model dir is missing."""
+
+
+class LatticeResultError(RuntimeError):
+    """`bench_decode_ab` ran and exited 0, but its RESULT output failed
+    validation -- see `bench_decode_adapters_apples_to_apples.py`'s
+    identically-named exception for the full rationale."""
+
+
+def extract_single_result(stdout: str, *, n_tokens: int) -> tuple[int, int, float]:
+    matches = [
+        parsed
+        for parsed in (parse_lattice_result_line(line) for line in stdout.splitlines())
+        if parsed is not None
+    ]
+    if len(matches) == 0:
+        raise LatticeResultError(f"lattice: no full-line RESULT record found in stdout: {stdout[-500:]!r}")
+    if len(matches) > 1:
+        raise LatticeResultError(
+            f"lattice: expected exactly one RESULT record for BENCH_RUNS=1, found {len(matches)}: {matches!r}"
+        )
+    n_req, completion, total_ms = matches[0]
+    if n_req != n_tokens:
+        raise LatticeResultError(
+            f"lattice: RESULT n_req={n_req} does not match the requested window n_tokens={n_tokens}"
+        )
+    if completion < 0:
+        raise LatticeResultError(f"lattice: RESULT completion={completion} is negative")
+    if not math.isfinite(total_ms) or total_ms < 0:
+        raise LatticeResultError(f"lattice: RESULT total_ms={total_ms} is not finite and non-negative")
+    return n_req, completion, total_ms
+
+
+class LatticeAdapter:
+    """Invokes `target/release/bench_decode_ab` against the Q8 safetensors
+    dir, mirroring `bench_apples_precise.sh`'s lattice section (including its
+    own untimed pre-loop warmup, now represented as the profile's
+    `warmup_repeats=2`/`warmup_tokens=512` instead of the legacy script's
+    inline `for _ in $(seq 1 $WARMUP)` loop)."""
+
+    def __init__(self, bin_path: Path = LAT_BIN, model_dir: Path = MODEL_DIR):
+        self.bin_path = bin_path
+        self.model_dir = model_dir
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        if not self.model_dir.is_dir():
+            raise LatticeUnavailableError(f"lattice: model dir missing ({self.model_dir})")
+        env = os.environ.copy()
+        env["BENCH_N"] = str(n_tokens)
+        env["BENCH_RUNS"] = "1"
+        env["LATTICE_MODEL_DIR"] = str(self.model_dir)
+        proc = subprocess.run(
+            [str(self.bin_path)], env=env, capture_output=True, text=True, timeout=600, check=False
+        )
+        if proc.returncode != 0:
+            raise LatticeUnavailableError(
+                f"lattice: bench_decode_ab exited {proc.returncode}: {proc.stderr.strip()[-2000:]}"
+            )
+        try:
+            _n_req, completion, total_ms = extract_single_result(proc.stdout, n_tokens=n_tokens)
+        except LatticeResultError as exc:
+            raise LatticeResultError(f"{exc} (stderr: {proc.stderr.strip()[-500:]})") from exc
+        return harness.AdapterRunResult(
+            actual_completion_tokens=completion,
+            native_ns=round(total_ms * 1e6),
+            engine_version="lattice-bench_decode_ab",
+        )
+
+
+def lattice_available(bin_path: Path = LAT_BIN, model_dir: Path = MODEL_DIR) -> bool:
+    return bin_path.is_file() and os.access(bin_path, os.X_OK) and model_dir.is_dir()
+
+
+# --------------------------------------------------------------------------
+# ollama
+# --------------------------------------------------------------------------
+
+OLLAMA_BASE_URL = os.environ.get("LATTICE_BENCH_OLLAMA_URL", "http://localhost:11434")
+OLLAMA_MODEL_TAG = "qwen3.5:0.8b"
+
+
+class OllamaResponseError(RuntimeError):
+    """See `bench_decode_adapters_apples_to_apples.py`'s identically-named
+    exception."""
+
+
+_REQUIRED_OLLAMA_FIELDS = ("eval_count", "eval_duration", "total_duration")
+
+
+def ollama_response_to_result(data: dict) -> harness.AdapterRunResult:
+    """Mirrors `bench_apples_precise.sh`'s ollama Python inline block
+    exactly: `tot = d.get('total_duration',0)/1e9` is the legacy script's
+    PRIMARY metric (fed straight into `rows[eng][N]`), and
+    `ec/ed = eval_count/eval_duration` was its separate native-rate column
+    -- preserved here as `native_ns`/`AdapterRunResult` respectively, same
+    split as the apples_to_apples adapter's identically-named function."""
+    if "error" in data:
+        raise OllamaResponseError(f"ollama: response is an error body: {data['error']!r}")
+    for field in _REQUIRED_OLLAMA_FIELDS:
+        if field not in data:
+            raise OllamaResponseError(f"ollama: response missing required field {field!r}: {data!r}")
+        value = data[field]
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise OllamaResponseError(
+                f"ollama: response field {field!r} must be a non-boolean int, got {type(value).__name__}: {data!r}"
+            )
+    eval_count = data["eval_count"]
+    eval_duration = data["eval_duration"]
+    total_duration = data["total_duration"]
+    if eval_count < 0:
+        raise OllamaResponseError(f"ollama: eval_count={eval_count!r} is negative: {data!r}")
+    if eval_duration < 0:
+        raise OllamaResponseError(f"ollama: eval_duration={eval_duration!r} is negative: {data!r}")
+    if total_duration <= 0:
+        raise OllamaResponseError(f"ollama: total_duration={total_duration!r} must be positive: {data!r}")
+    return harness.AdapterRunResult(
+        actual_completion_tokens=int(eval_count),
+        native_ns=int(total_duration),
+        engine_version="ollama",
+    )
+
+
+class OllamaAdapter:
+    """Invokes ollama's `/api/generate`, one HTTP call per measured/warmup
+    repeat -- matching `bench_apples_precise.sh`'s per-run curl loop
+    (including its own inline 2-run warmup, represented here via the
+    profile's `warmup_repeats=2`)."""
+
+    def __init__(self, base_url: str = OLLAMA_BASE_URL):
+        self.base_url = base_url
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        payload = json.dumps(
+            {
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "options": {"num_predict": n_tokens, "temperature": 0},
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.base_url}/api/generate",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            data = json.loads(resp.read())
+        return ollama_response_to_result(data)
+
+
+def ollama_available(base_url: str = OLLAMA_BASE_URL, *, model_tag: str = OLLAMA_MODEL_TAG) -> bool:
+    if shutil.which("ollama") is None:
+        return False
+    try:
+        listed = subprocess.run(["ollama", "list"], capture_output=True, text=True, timeout=30, check=False)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if model_tag not in listed.stdout:
+        pulled = subprocess.run(["ollama", "pull", model_tag], capture_output=True, text=True, timeout=600, check=False)
+        if pulled.returncode != 0:
+            return False
+    try:
+        urllib.request.urlopen(f"{base_url}/api/tags", timeout=3).read()
+        return True
+    except (urllib.error.URLError, OSError):
+        try:
+            subprocess.Popen(["ollama", "serve"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except OSError:
+            return False
+        time.sleep(3)
+        try:
+            urllib.request.urlopen(f"{base_url}/api/tags", timeout=3).read()
+            return True
+        except (urllib.error.URLError, OSError):
+            return False
+
+
+# --------------------------------------------------------------------------
+# mlx
+# --------------------------------------------------------------------------
+
+
+class MlxAdapter:
+    """Invokes `mlx_lm` in-process, mirroring `bench_apples_precise.sh`'s
+    MLX heredoc: load the Q8 safetensors model once (falling back to the Hub
+    id on failure, exactly as the legacy heredoc's bare `try/except`), quantize
+    to 8 bits once, then time only `generate()` per call -- the profile's
+    `warmup_repeats=2`/`warmup_tokens=512` reproduce the heredoc's own
+    pre-loop `for _ in range(warmup): generate(...)`."""
+
+    def __init__(self, source_model_dir: Path = MODEL_DIR):
+        self.source_model_dir = source_model_dir
+        self._cache: tuple[object, object, object, str | None] | None = None
+
+    def _load(self):
+        if self._cache is not None:
+            return self._cache
+        import mlx.core as mx
+        import mlx.nn as nn
+        from mlx_lm import load
+        from mlx_lm.sample_utils import make_sampler
+
+        fallback_model_id: str | None = None
+        try:
+            mlx_model, tok = load(str(self.source_model_dir))
+        except Exception:  # noqa: BLE001 -- legacy heredoc's own bare except fallback
+            mlx_model, tok = load("Qwen/Qwen3.5-0.8B")
+            fallback_model_id = "Qwen/Qwen3.5-0.8B"
+        nn.quantize(mlx_model, bits=8, group_size=64)
+        mx.eval(mlx_model.parameters())
+        sampler = make_sampler(temp=0.0)
+        self._cache = (mlx_model, tok, sampler, fallback_model_id)
+        return self._cache
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        from mlx_lm import generate
+
+        mlx_model, tok, sampler, fallback_model_id = self._load()
+        generate(mlx_model, tok, prompt=prompt, max_tokens=n_tokens, sampler=sampler, verbose=False)
+        return harness.AdapterRunResult(
+            actual_completion_tokens=n_tokens,
+            engine_version="mlx_lm",
+            actual_model=fallback_model_id,
+        )
+
+
+def mlx_available() -> bool:
+    try:
+        import mlx_lm  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# --------------------------------------------------------------------------
+# registration + CLI delegation
+# --------------------------------------------------------------------------
+
+
+def register_available_adapters() -> None:
+    if lattice_available():
+        harness.register_adapter("lattice", LatticeAdapter())
+        print("  lattice: adapter registered")
+    else:
+        print(f"  lattice: BIN MISSING or MODEL MISSING ({LAT_BIN}, {MODEL_DIR}) — skipping")
+
+    if ollama_available():
+        harness.register_adapter("ollama", OllamaAdapter())
+        print("  ollama: adapter registered")
+    else:
+        print("  ollama: not installed, unreachable, or model pull failed — skipping")
+
+    if mlx_available():
+        harness.register_adapter("mlx", MlxAdapter())
+        print("  mlx: adapter registered")
+    else:
+        print("  mlx: mlx_lm not importable — run via `uv run --with mlx-lm ...` — skipping")
+
+
+if __name__ == "__main__":
+    register_available_adapters()
+    sys.exit(harness.main())

--- a/scripts/bench_decode_adapters_context_scaling.py
+++ b/scripts/bench_decode_adapters_context_scaling.py
@@ -320,18 +320,145 @@ def register_available_adapters() -> None:
 # --------------------------------------------------------------------------
 
 
-def render_legacy_tsv(run_result: harness.HarnessRunResult, slopes: list[harness.SlopeResult]) -> str:
+class ContextsConfigError(ValueError):
+    """`--contexts` (or the `CONTEXTS` env var, forwarded verbatim by
+    `scripts/bench_context_scaling.sh`) failed validation."""
+
+
+def parse_contexts(raw: str, baseline_window: int) -> tuple[int, ...]:
+    """Parse `--contexts` into an ORDERED tuple of context lengths,
+    preserving the caller's order -- never sorted. `origin/main:scripts/
+    bench_context_scaling.sh`'s `read -ra CONTEXTS_ARR <<< "$CONTEXTS"`
+    keeps whatever order the caller gave (`CONTEXTS="256 64"` runs 256
+    before 64); sorting silently changes run order and thermal/order
+    exposure across the sweep (issue #813 codex round-1 finding 2a).
+
+    Rejects a non-positive entry, an internal duplicate, or an entry equal
+    to `baseline_window` (the fixed N1 baseline `profile.windows[0]`) --
+    a duplicated baseline would collide with `profile.windows[0]` under a
+    second window entry and silently double-count that observation set.
+    """
+    entries: list[int] = []
+    seen: set[int] = set()
+    for piece in raw.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        try:
+            value = int(piece)
+        except ValueError as exc:
+            raise ContextsConfigError(f"--contexts entry {piece!r} is not an integer") from exc
+        if value <= 0:
+            raise ContextsConfigError(f"--contexts entry {value} must be a positive integer")
+        if value == baseline_window:
+            raise ContextsConfigError(
+                f"--contexts entry {value} duplicates the fixed baseline window ({baseline_window})"
+            )
+        if value in seen:
+            raise ContextsConfigError(f"--contexts contains duplicate context length {value}")
+        seen.add(value)
+        entries.append(value)
+    if not entries:
+        raise ContextsConfigError("--contexts must name at least one context length")
+    return tuple(entries)
+
+
+def _legacy_ordered_median(values: list[float], engine: str) -> float:
+    """Reproduce `bench_context_scaling.sh`'s exact per-engine median
+    tie-break for an EVEN sample count (issue #813 codex round-1 finding
+    2b). The legacy `lattice_median`/`ollama_median` shell helpers sort
+    ascending and take the 1-indexed position `(n+1)/2` (bash integer
+    division) -- `origin/main:scripts/bench_context_scaling.sh:65-69,83` --
+    which is the exact middle value for odd `n` and the LOWER of the two
+    middle values for even `n`. The MLX heredoc instead does
+    `sorted(values)[len(values)//2]` (0-indexed) --
+    `origin/main:scripts/bench_context_scaling.sh:164` -- identical to the
+    lattice/ollama rule for odd `n`, but the UPPER middle value for even
+    `n`. `statistics.median()` would instead AVERAGE the two middle values
+    for even `n`, silently changing every engine's rendered
+    `t1_ms`/`t2_ms`/slope whenever `RUNS` is overridden to an even count.
+    """
+    if not values:
+        raise ValueError("_legacy_ordered_median: values must be non-empty")
+    ordered = sorted(values)
+    n = len(ordered)
+    if engine == "mlx":
+        return ordered[n // 2]
+    return ordered[(n + 1) // 2 - 1]
+
+
+def compute_context_scaling_aggregate(
+    run_result: harness.HarnessRunResult,
+) -> tuple[list[harness.SlopeResult], dict[tuple[str, int], float]]:
+    """Legacy-exact aggregation for the `context_scaling` profile: computes
+    both the slope AND the per-(engine, window) median elapsed seconds from
+    the SAME `_legacy_ordered_median` call, so the printed report and the
+    chart-compatible TSV's `t1_ms`/`t2_ms` columns can never diverge from
+    the value the slope was actually computed from (issue #813 codex
+    round-1 finding 2c: the TSV previously recomputed a plain
+    `sum(values)/len(values)` mean independently of the slope's own
+    aggregation, and both were WRONG even at the default odd `RUNS=5` --
+    the legacy script's `t1_ms`/`t2_ms` were always medians, never means).
+
+    Deliberately bypasses `bench_decode_harness.aggregate()` (which applies
+    `profile.aggregation` uniformly across engines): this profile's legacy
+    predecessor script gives lattice/ollama and mlx two DIFFERENT
+    even-`n` tie-break rules (see `_legacy_ordered_median`), which no
+    single profile-wide `aggregation` setting can express.
+    """
+    profile = run_result.profile
+    baseline_window = profile.windows[0]
+    slopes: list[harness.SlopeResult] = []
+    medians: dict[tuple[str, int], float] = {}
+    for engine in profile.engines:
+        baseline_values = harness._measured_elapsed_seconds(
+            run_result.observations, engine, baseline_window
+        )
+        if not baseline_values:
+            continue
+        baseline_mean = _legacy_ordered_median(baseline_values, engine)
+        medians[(engine, baseline_window)] = baseline_mean
+        for window in profile.windows[1:]:
+            values = harness._measured_elapsed_seconds(run_result.observations, engine, window)
+            if not values:
+                continue
+            window_mean = _legacy_ordered_median(values, engine)
+            medians[(engine, window)] = window_mean
+            dt = window_mean - baseline_mean
+            slope = (window - baseline_window) / dt if dt > 0 else float("nan")
+            slopes.append(
+                harness.SlopeResult(
+                    engine=engine,
+                    baseline_window=baseline_window,
+                    window=window,
+                    slope_tok_per_s=slope,
+                    slope_ci95_legacy=None,
+                    baseline_n=len(baseline_values),
+                    window_n=len(values),
+                )
+            )
+    return slopes, medians
+
+
+def render_legacy_tsv(
+    run_result: harness.HarnessRunResult,
+    slopes: list[harness.SlopeResult],
+    window_medians: dict[tuple[str, int], float],
+) -> str:
     """`engine\tcontext_tokens\tslope_tok_s\tt1_ms\tt2_ms\truns` -- the exact
     header/column shape `bench_context_scaling_chart.py` parses (it only
     reads columns 0/1/2 positionally, but the full shape is reproduced for
-    anyone reading the raw TSV directly, matching the legacy script)."""
+    anyone reading the raw TSV directly, matching the legacy script).
+    `t1_ms`/`t2_ms` are read from `window_medians` -- the SAME per-(engine,
+    window) aggregate `compute_context_scaling_aggregate` used to compute
+    `s.slope_tok_per_s` -- never independently recomputed, so the TSV can
+    never render a `t1_ms`/`t2_ms` pair inconsistent with the slope next to
+    it (issue #813 codex round-1 finding 2c)."""
     lines = ["engine\tcontext_tokens\tslope_tok_s\tt1_ms\tt2_ms\truns"]
     baseline_window = run_result.profile.windows[0]
     for s in slopes:
-        baseline_vals = harness._measured_elapsed_seconds(run_result.observations, s.engine, baseline_window)
-        window_vals = harness._measured_elapsed_seconds(run_result.observations, s.engine, s.window)
-        t1_ms = (sum(baseline_vals) / len(baseline_vals) * 1000) if baseline_vals else float("nan")
-        t2_ms = (sum(window_vals) / len(window_vals) * 1000) if window_vals else float("nan")
+        t1_ms = window_medians[(s.engine, baseline_window)] * 1000
+        t2_ms = window_medians[(s.engine, s.window)] * 1000
         lines.append(f"{s.engine}\t{s.window}\t{s.slope_tok_per_s:.1f}\t{t1_ms:.3f}\t{t2_ms:.3f}\t{s.window_n}")
     return "\n".join(lines) + "\n"
 
@@ -363,10 +490,15 @@ def main(argv: list[str] | None = None) -> int:
     # CONTEXTS/RUNS overrides (legacy env-var knobs, exposed here as flags so
     # the shell wrapper can forward CONTEXTS/RUNS verbatim): rebuild an
     # equivalent ProfileConfig with N1=8 (unchanged) followed by the
-    # requested context lengths, and/or the requested measured_repeats.
+    # requested context lengths (order preserved, validated -- see
+    # `parse_contexts`), and/or the requested measured_repeats.
     if args.contexts is not None:
-        contexts = tuple(sorted(int(c) for c in args.contexts.split(",") if c.strip()))
-        profile = dataclasses.replace(profile, windows=(8, *contexts))
+        try:
+            contexts = parse_contexts(args.contexts, profile.windows[0])
+        except ContextsConfigError as exc:
+            print(f"FAIL: {exc}", file=sys.stderr)
+            return 1
+        profile = dataclasses.replace(profile, windows=(profile.windows[0], *contexts))
     if args.runs is not None:
         profile = dataclasses.replace(profile, measured_repeats=args.runs)
 
@@ -379,14 +511,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"FAIL: {exc}", file=sys.stderr)
         return 1
 
-    slopes = harness.aggregate(result)
+    slopes, window_medians = compute_context_scaling_aggregate(result)
     print(harness.render_report(result, slopes))
 
     if args.out is not None:
         harness.write_jsonl(list(result.observations), args.out)
         print(f"\nRaw observations: {args.out}")
 
-    DATA_TSV.write_text(render_legacy_tsv(result, slopes))
+    DATA_TSV.write_text(render_legacy_tsv(result, slopes, window_medians))
     print(f"Raw data (chart-compatible TSV): {DATA_TSV}")
 
     print("\n--- Generating chart ---")

--- a/scripts/bench_decode_adapters_context_scaling.py
+++ b/scripts/bench_decode_adapters_context_scaling.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Engine adapters + wrapper CLI for the `context_scaling` profile (issue
+#813 step 2: migrate `bench_context_scaling.sh`, keeping its chart
+renderer, `scripts/bench_context_scaling_chart.py`, unchanged).
+
+This module does more than exec `bench_decode_harness.main()` (unlike the
+apples_to_apples/apples_precise/q4_apples adapters) because the legacy
+script's output contract is not just a printed report: it also writes a
+`docs/bench_results/context_scaling.tsv` file in a specific
+engine/context_tokens/slope_tok_s/... shape that
+`bench_context_scaling_chart.py` consumes, and it supports `CONTEXTS`/
+`RUNS`/`CHART_ONLY` environment-variable overrides. All warmup/repeat/
+aggregation POLICY still lives in the harness/profile; this module only
+adds the TSV-rendering + chart-invocation step the harness core does not
+own (`render_report`/`aggregate` produce the harness's own report and raw
+JSONL, not a chart-compatible TSV).
+
+Run with (from repo root): `uv run --quiet --with mlx-lm python3
+scripts/bench_decode_adapters_context_scaling.py [--contexts 64,128,256]
+[--runs 5] [--chart-only] [--allow-missing-engine]` -- or via the thin shell
+wrapper `scripts/bench_context_scaling.sh`, which forwards
+`CONTEXTS`/`RUNS`/`CHART_ONLY` exactly as the legacy script did.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_decode_harness as harness  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROFILE_NAME = "context_scaling"
+OUT_DIR = REPO_ROOT / "docs" / "bench_results"
+DATA_TSV = OUT_DIR / "context_scaling.tsv"
+CHART_PNG = OUT_DIR / "context_scaling_benchmark.png"
+CHART_SCRIPT = REPO_ROOT / "scripts" / "bench_context_scaling_chart.py"
+
+LAT_BIN = REPO_ROOT / "target" / "release" / "bench_decode_ab"
+MODEL_DIR = Path.home() / ".lattice" / "models" / "qwen3.5-0.8b"
+
+_RESULT_RE = re.compile(r"^RESULT n_req=(\d+) completion=(\d+) total_ms=([\d.]+)$")
+
+
+def parse_lattice_result_line(line: str) -> tuple[int, int, float] | None:
+    m = _RESULT_RE.match(line)
+    if m is None:
+        return None
+    return int(m.group(1)), int(m.group(2)), float(m.group(3))
+
+
+class LatticeUnavailableError(RuntimeError):
+    """`bench_decode_ab` is not built, or the model dir is missing."""
+
+
+class LatticeResultError(RuntimeError):
+    """See the apples_to_apples adapter's identically-named exception."""
+
+
+def extract_single_result(stdout: str, *, n_tokens: int) -> tuple[int, int, float]:
+    matches = [
+        parsed
+        for parsed in (parse_lattice_result_line(line) for line in stdout.splitlines())
+        if parsed is not None
+    ]
+    if len(matches) == 0:
+        raise LatticeResultError(f"lattice: no full-line RESULT record found in stdout: {stdout[-500:]!r}")
+    if len(matches) > 1:
+        raise LatticeResultError(
+            f"lattice: expected exactly one RESULT record for BENCH_RUNS=1, found {len(matches)}: {matches!r}"
+        )
+    n_req, completion, total_ms = matches[0]
+    if n_req != n_tokens:
+        raise LatticeResultError(
+            f"lattice: RESULT n_req={n_req} does not match the requested window n_tokens={n_tokens}"
+        )
+    if completion < 0:
+        raise LatticeResultError(f"lattice: RESULT completion={completion} is negative")
+    if not math.isfinite(total_ms) or total_ms < 0:
+        raise LatticeResultError(f"lattice: RESULT total_ms={total_ms} is not finite and non-negative")
+    return n_req, completion, total_ms
+
+
+class LatticeAdapter:
+    def __init__(self, bin_path: Path = LAT_BIN, model_dir: Path = MODEL_DIR):
+        self.bin_path = bin_path
+        self.model_dir = model_dir
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        if not self.model_dir.is_dir():
+            raise LatticeUnavailableError(f"lattice: model dir missing ({self.model_dir})")
+        env = os.environ.copy()
+        env["BENCH_N"] = str(n_tokens)
+        env["BENCH_RUNS"] = "1"
+        env["LATTICE_MODEL_DIR"] = str(self.model_dir)
+        proc = subprocess.run(
+            [str(self.bin_path)], env=env, capture_output=True, text=True, timeout=600, check=False
+        )
+        if proc.returncode != 0:
+            raise LatticeUnavailableError(
+                f"lattice: bench_decode_ab exited {proc.returncode}: {proc.stderr.strip()[-2000:]}"
+            )
+        try:
+            _n_req, completion, total_ms = extract_single_result(proc.stdout, n_tokens=n_tokens)
+        except LatticeResultError as exc:
+            raise LatticeResultError(f"{exc} (stderr: {proc.stderr.strip()[-500:]})") from exc
+        return harness.AdapterRunResult(
+            actual_completion_tokens=completion,
+            native_ns=round(total_ms * 1e6),
+            engine_version="lattice-bench_decode_ab",
+        )
+
+
+def lattice_available(bin_path: Path = LAT_BIN, model_dir: Path = MODEL_DIR) -> bool:
+    return bin_path.is_file() and os.access(bin_path, os.X_OK) and model_dir.is_dir()
+
+
+def build_lattice_binary_if_missing() -> None:
+    """Mirrors the legacy script's own `if [[ ! -x "$LAT_BIN" ]]; then cargo
+    build ...`. Best-effort: failures are swallowed here exactly like the
+    legacy script's own `2>/dev/null` did, and surface later as a normal
+    missing-adapter skip."""
+    if LAT_BIN.is_file() and os.access(LAT_BIN, os.X_OK):
+        return
+    print("Building bench_decode_ab (release)...")
+    subprocess.run(
+        [
+            "cargo", "build", "--release", "-p", "lattice-inference",
+            "--bin", "bench_decode_ab", "--features", "f16,metal-gpu",
+        ],
+        cwd=REPO_ROOT, capture_output=True, check=False,
+    )
+
+
+# --------------------------------------------------------------------------
+# ollama
+# --------------------------------------------------------------------------
+
+OLLAMA_BASE_URL = os.environ.get("LATTICE_BENCH_OLLAMA_URL", "http://localhost:11434")
+OLLAMA_MODEL_TAG = "qwen3.5:0.8b"
+
+
+class OllamaResponseError(RuntimeError):
+    pass
+
+
+_REQUIRED_OLLAMA_FIELDS = ("eval_count", "eval_duration", "total_duration")
+
+
+def ollama_response_to_result(data: dict) -> harness.AdapterRunResult:
+    """Mirrors `bench_context_scaling.sh`'s `ollama_median()`: its median is
+    over `total_duration/1e6` (ms) values -- the SAME primary field as the
+    apples_to_apples/apples_precise adapters, just pre-divided by run count
+    in the legacy shell function. `eval_count`/`eval_duration` are not used
+    by the legacy script's context-scaling ollama path, but are validated
+    here anyway for response-shape integrity (same contract as the other
+    two ollama adapters in this consolidation)."""
+    if "error" in data:
+        raise OllamaResponseError(f"ollama: response is an error body: {data['error']!r}")
+    for field in _REQUIRED_OLLAMA_FIELDS:
+        if field not in data:
+            raise OllamaResponseError(f"ollama: response missing required field {field!r}: {data!r}")
+        value = data[field]
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise OllamaResponseError(
+                f"ollama: response field {field!r} must be a non-boolean int, got {type(value).__name__}: {data!r}"
+            )
+    eval_count = data["eval_count"]
+    eval_duration = data["eval_duration"]
+    total_duration = data["total_duration"]
+    if eval_count < 0:
+        raise OllamaResponseError(f"ollama: eval_count={eval_count!r} is negative: {data!r}")
+    if eval_duration < 0:
+        raise OllamaResponseError(f"ollama: eval_duration={eval_duration!r} is negative: {data!r}")
+    if total_duration <= 0:
+        raise OllamaResponseError(f"ollama: total_duration={total_duration!r} must be positive: {data!r}")
+    return harness.AdapterRunResult(
+        actual_completion_tokens=int(eval_count),
+        native_ns=int(total_duration),
+        engine_version="ollama",
+    )
+
+
+class OllamaAdapter:
+    def __init__(self, base_url: str = OLLAMA_BASE_URL):
+        self.base_url = base_url
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        payload = json.dumps(
+            {
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "options": {"num_predict": n_tokens, "temperature": 0, "seed": 42},
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.base_url}/api/generate",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            data = json.loads(resp.read())
+        return ollama_response_to_result(data)
+
+
+def ollama_available(base_url: str = OLLAMA_BASE_URL, *, model_tag: str = OLLAMA_MODEL_TAG) -> bool:
+    """Mirrors the legacy script's ollama preflight: binary + model pulled +
+    server reachable. Unlike the legacy script's `command -v ollama &&
+    curl ... | python3 -c "..."` one-liner, this does not attempt to start a
+    down server (the legacy context-scaling script's own preflight is a pure
+    check, not a start-if-down like bench_apples_to_apples.sh's)."""
+    if shutil.which("ollama") is None:
+        return False
+    try:
+        urllib.request.urlopen(f"{base_url}/api/tags", timeout=3).read()
+    except (urllib.error.URLError, OSError):
+        return False
+    try:
+        listed = subprocess.run(["ollama", "list"], capture_output=True, text=True, timeout=30, check=False)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return model_tag in listed.stdout
+
+
+# --------------------------------------------------------------------------
+# mlx
+# --------------------------------------------------------------------------
+
+
+class MlxAdapter:
+    """Invokes `mlx_lm`, mirroring `bench_context_scaling.sh`'s MLX heredoc:
+    load `Qwen/Qwen3.5-0.8B` from the Hub directly (the legacy heredoc never
+    tries the local dir first, unlike the other three scripts), quantize to
+    8 bits, one 4-token warmup (the profile's `warmup_repeats=1`/
+    `warmup_tokens=4`), then time only `generate()` per measured call."""
+
+    def __init__(self, hub_model_id: str = "Qwen/Qwen3.5-0.8B"):
+        self.hub_model_id = hub_model_id
+        self._cache: tuple[object, object, object] | None = None
+
+    def _load(self):
+        if self._cache is not None:
+            return self._cache
+        import mlx.core as mx
+        import mlx.nn as nn
+        import mlx_lm
+
+        mlx_model, tok = mlx_lm.load(self.hub_model_id, tokenizer_config={"eos_token": "<|endoftext|>"})
+        nn.quantize(mlx_model, bits=8, group_size=64)
+        mx.eval(mlx_model.parameters())
+        self._cache = (mlx_model, tok, mx)
+        return self._cache
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        import mlx_lm
+
+        mlx_model, tok, mx = self._load()
+        greedy = lambda logits: mx.argmax(logits, axis=-1)  # noqa: E731 -- matches legacy heredoc's own lambda
+        mlx_lm.generate(mlx_model, tok, prompt=prompt, max_tokens=n_tokens, sampler=greedy, verbose=False)
+        mx.eval(mx.zeros(1))
+        return harness.AdapterRunResult(actual_completion_tokens=n_tokens, engine_version="mlx_lm")
+
+
+def mlx_available() -> bool:
+    try:
+        import mlx_lm  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# --------------------------------------------------------------------------
+# registration
+# --------------------------------------------------------------------------
+
+
+def register_available_adapters() -> None:
+    if lattice_available():
+        harness.register_adapter("lattice", LatticeAdapter())
+        print("  lattice: adapter registered")
+    else:
+        print(f"  lattice: BIN MISSING or MODEL MISSING ({LAT_BIN}, {MODEL_DIR}) — skipping")
+
+    if ollama_available():
+        harness.register_adapter("ollama", OllamaAdapter())
+        print("  ollama: adapter registered")
+    else:
+        print("  ollama: not running or qwen3.5:0.8b not pulled — skipping")
+
+    if mlx_available():
+        harness.register_adapter("mlx", MlxAdapter())
+        print("  mlx: adapter registered")
+    else:
+        print("  mlx: mlx_lm not importable — run via `uv run --with mlx-lm ...` — skipping")
+
+
+# --------------------------------------------------------------------------
+# TSV rendering (the legacy output contract bench_context_scaling_chart.py
+# consumes) + chart invocation
+# --------------------------------------------------------------------------
+
+
+def render_legacy_tsv(run_result: harness.HarnessRunResult, slopes: list[harness.SlopeResult]) -> str:
+    """`engine\tcontext_tokens\tslope_tok_s\tt1_ms\tt2_ms\truns` -- the exact
+    header/column shape `bench_context_scaling_chart.py` parses (it only
+    reads columns 0/1/2 positionally, but the full shape is reproduced for
+    anyone reading the raw TSV directly, matching the legacy script)."""
+    lines = ["engine\tcontext_tokens\tslope_tok_s\tt1_ms\tt2_ms\truns"]
+    baseline_window = run_result.profile.windows[0]
+    for s in slopes:
+        baseline_vals = harness._measured_elapsed_seconds(run_result.observations, s.engine, baseline_window)
+        window_vals = harness._measured_elapsed_seconds(run_result.observations, s.engine, s.window)
+        t1_ms = (sum(baseline_vals) / len(baseline_vals) * 1000) if baseline_vals else float("nan")
+        t2_ms = (sum(window_vals) / len(window_vals) * 1000) if window_vals else float("nan")
+        lines.append(f"{s.engine}\t{s.window}\t{s.slope_tok_per_s:.1f}\t{t1_ms:.3f}\t{t2_ms:.3f}\t{s.window_n}")
+    return "\n".join(lines) + "\n"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="context_scaling profile wrapper (issue #813)")
+    parser.add_argument("--contexts", default=None, help="Comma-separated context lengths, e.g. 64,128,256")
+    parser.add_argument("--runs", type=int, default=None, help="Measured repeats per window (default: profile's)")
+    parser.add_argument("--chart-only", action="store_true", help="Regenerate the chart from the existing TSV only")
+    parser.add_argument("--allow-missing-engine", action="store_true")
+    parser.add_argument("--out", type=Path, default=None, help="Raw-observation JSONL path")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    if args.chart_only:
+        print(f"=== Regenerating chart from {DATA_TSV} ===")
+        proc = subprocess.run(
+            [sys.executable, str(CHART_SCRIPT), str(DATA_TSV), str(CHART_PNG)], cwd=REPO_ROOT, check=False
+        )
+        return proc.returncode
+
+    _schema_version, profiles = harness.load_profiles_file(harness.DEFAULT_PROFILES_FILE)
+    profile = profiles[PROFILE_NAME]
+
+    # CONTEXTS/RUNS overrides (legacy env-var knobs, exposed here as flags so
+    # the shell wrapper can forward CONTEXTS/RUNS verbatim): rebuild an
+    # equivalent ProfileConfig with N1=8 (unchanged) followed by the
+    # requested context lengths, and/or the requested measured_repeats.
+    if args.contexts is not None:
+        contexts = tuple(sorted(int(c) for c in args.contexts.split(",") if c.strip()))
+        profile = dataclasses.replace(profile, windows=(8, *contexts))
+    if args.runs is not None:
+        profile = dataclasses.replace(profile, measured_repeats=args.runs)
+
+    build_lattice_binary_if_missing()
+    register_available_adapters()
+
+    try:
+        result = harness.run_profile(profile, harness.ADAPTER_REGISTRY, allow_missing_engine=args.allow_missing_engine)
+    except harness.MissingEngineError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    slopes = harness.aggregate(result)
+    print(harness.render_report(result, slopes))
+
+    if args.out is not None:
+        harness.write_jsonl(list(result.observations), args.out)
+        print(f"\nRaw observations: {args.out}")
+
+    DATA_TSV.write_text(render_legacy_tsv(result, slopes))
+    print(f"Raw data (chart-compatible TSV): {DATA_TSV}")
+
+    print("\n--- Generating chart ---")
+    subprocess.run([sys.executable, str(CHART_SCRIPT), str(DATA_TSV), str(CHART_PNG)], cwd=REPO_ROOT, check=False)
+    print(f"Chart: {CHART_PNG}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench_decode_adapters_q4_apples.py
+++ b/scripts/bench_decode_adapters_q4_apples.py
@@ -101,11 +101,31 @@ class LatticeAdapter:
         self.model_dir = model_dir
         self.tokenizer_dir = tokenizer_dir
 
+    def _assert_q4_identity(self) -> None:
+        """Refuse to run unless the resolved dir is what `bench_decode_ab`'s
+        `detect_format` will actually load as Q4. Mirrors
+        `crates/inference/src/model_format.rs::detect_format` precedence:
+        safetensors markers win over `.q4` files, so their presence means the
+        binary would silently benchmark the full-precision checkpoint under a
+        Q4 label -- exactly the historical bench_q4_apples.sh failure mode."""
+        for marker in ("model.safetensors", "model.safetensors.index.json"):
+            if (self.model_dir / marker).exists():
+                raise LatticeUnavailableError(
+                    f"lattice: {self.model_dir} contains {marker}; detect_format would "
+                    "load safetensors, not Q4 -- refusing to mislabel the run"
+                )
+        if not any(p.suffix == ".q4" for p in self.model_dir.iterdir()):
+            raise LatticeUnavailableError(
+                f"lattice: {self.model_dir} has no .q4 files; detect_format would not "
+                "load it as Q4 -- refusing to mislabel the run"
+            )
+
     def run(
         self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
     ) -> harness.AdapterRunResult:
         if not self.model_dir.is_dir():
             raise LatticeUnavailableError(f"lattice: Q4 model dir missing ({self.model_dir})")
+        self._assert_q4_identity()
         env = os.environ.copy()
         env["BENCH_N"] = str(n_tokens)
         env["BENCH_RUNS"] = "1"

--- a/scripts/bench_decode_adapters_q4_apples.py
+++ b/scripts/bench_decode_adapters_q4_apples.py
@@ -107,14 +107,32 @@ class LatticeAdapter:
         `crates/inference/src/model_format.rs::detect_format` precedence:
         safetensors markers win over `.q4` files, so their presence means the
         binary would silently benchmark the full-precision checkpoint under a
-        Q4 label -- exactly the historical bench_q4_apples.sh failure mode."""
-        for marker in ("model.safetensors", "model.safetensors.index.json"):
-            if (self.model_dir / marker).exists():
-                raise LatticeUnavailableError(
-                    f"lattice: {self.model_dir} contains {marker}; detect_format would "
-                    "load safetensors, not Q4 -- refusing to mislabel the run"
-                )
-        if not any(p.suffix == ".q4" for p in self.model_dir.iterdir()):
+        Q4 label -- exactly the historical bench_q4_apples.sh failure mode.
+
+        `detect_format` (crates/inference/src/model_format.rs) suppresses
+        `read_dir` errors with `.ok()`, resolving an unreadable or
+        concurrently-removed directory to `Unknown` rather than panicking --
+        this method fails closed the same way, raising
+        `LatticeUnavailableError` rather than letting a raw
+        `PermissionError`/`FileNotFoundError` escape from the marker
+        `.exists()` checks or `iterdir()` (issue #813 codex round-1 finding
+        3: a permission error, or a TOCTOU directory removal between the
+        `is_dir()` precheck in `run()` and this method's filesystem calls,
+        must not raise an untyped exception the wrapper's callers don't
+        expect)."""
+        try:
+            for marker in ("model.safetensors", "model.safetensors.index.json"):
+                if (self.model_dir / marker).exists():
+                    raise LatticeUnavailableError(
+                        f"lattice: {self.model_dir} contains {marker}; detect_format would "
+                        "load safetensors, not Q4 -- refusing to mislabel the run"
+                    )
+            has_q4_file = any(p.suffix == ".q4" for p in self.model_dir.iterdir())
+        except OSError as exc:
+            raise LatticeUnavailableError(
+                f"lattice: could not inspect {self.model_dir} to establish Q4 identity: {exc}"
+            ) from exc
+        if not has_q4_file:
             raise LatticeUnavailableError(
                 f"lattice: {self.model_dir} has no .q4 files; detect_format would not "
                 "load it as Q4 -- refusing to mislabel the run"

--- a/scripts/bench_decode_adapters_q4_apples.py
+++ b/scripts/bench_decode_adapters_q4_apples.py
@@ -141,7 +141,13 @@ class LatticeAdapter:
     def run(
         self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
     ) -> harness.AdapterRunResult:
-        if not self.model_dir.is_dir():
+        try:
+            is_dir = self.model_dir.is_dir()
+        except OSError as exc:
+            raise LatticeUnavailableError(
+                f"lattice: could not stat Q4 model dir {self.model_dir}: {exc}"
+            ) from exc
+        if not is_dir:
             raise LatticeUnavailableError(f"lattice: Q4 model dir missing ({self.model_dir})")
         self._assert_q4_identity()
         env = os.environ.copy()
@@ -168,7 +174,12 @@ class LatticeAdapter:
 
 
 def lattice_available(bin_path: Path = LAT_BIN, model_dir: Path = Q4_MODEL_DIR) -> bool:
-    return bin_path.is_file() and os.access(bin_path, os.X_OK) and model_dir.is_dir()
+    if not (bin_path.is_file() and os.access(bin_path, os.X_OK)):
+        return False
+    try:
+        return model_dir.is_dir()
+    except OSError:
+        return False
 
 
 # --------------------------------------------------------------------------

--- a/scripts/bench_decode_adapters_q4_apples.py
+++ b/scripts/bench_decode_adapters_q4_apples.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Engine adapters for the `q4_apples` profile (issue #813 step 2: migrate
+`bench_q4_apples.sh`).
+
+Registers lattice/ollama/mlx `EngineAdapter`s mirroring
+`bench_q4_apples.sh`'s three sections, then delegates to
+`bench_decode_harness.main()`. See `bench_decode_profiles.toml`'s
+`[profiles.q4_apples]` comment for the disclosed correction: the legacy
+script set `BENCH_Q4_DIR`/`BENCH_TOKENIZER_DIR`, names `bench_decode_ab.rs`
+never reads (only `LATTICE_MODEL_DIR`/`LATTICE_TOKENIZER_DIR`), so its
+lattice leg silently benchmarked the Q8 default instead of the Q4 dir it
+claimed. `LatticeAdapter` here wires the profile's `qwen3.5-0.8b-q4` model
+name to the actual plain-Q4 directory via `LATTICE_MODEL_DIR`/
+`LATTICE_TOKENIZER_DIR`, correcting that -- window/repeat/warmup parameters
+are otherwise unchanged from the legacy script.
+
+Run with (from repo root): `uv run --quiet --with mlx-lm python3
+scripts/bench_decode_adapters_q4_apples.py run --profile q4_apples
+--allow-missing-engine`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bench_decode_harness as harness  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+LAT_BIN = REPO_ROOT / "target" / "release" / "bench_decode_ab"
+# Plain per-row Q4 (bench_q4_apples.sh's Q4_DIR), tied embeddings; tokenizer
+# comes from the Q8 f16 source dir (bench_q4_apples.sh's TOK_DIR), matching
+# the legacy script's declared-but-unreachable `BENCH_TOKENIZER_DIR` intent.
+Q4_MODEL_DIR = Path.home() / ".lattice" / "models" / "qwen3.5-0.8b-q4"
+TOKENIZER_DIR = Path.home() / ".lattice" / "models" / "qwen3.5-0.8b"
+
+_RESULT_RE = re.compile(r"^RESULT n_req=(\d+) completion=(\d+) total_ms=([\d.]+)$")
+
+
+def parse_lattice_result_line(line: str) -> tuple[int, int, float] | None:
+    m = _RESULT_RE.match(line)
+    if m is None:
+        return None
+    return int(m.group(1)), int(m.group(2)), float(m.group(3))
+
+
+class LatticeUnavailableError(RuntimeError):
+    """`bench_decode_ab` is not built, or the Q4 model dir is missing."""
+
+
+class LatticeResultError(RuntimeError):
+    """`bench_decode_ab` ran and exited 0 but its RESULT output failed
+    validation -- see the apples_to_apples adapter's identically-named
+    exception for the full rationale."""
+
+
+def extract_single_result(stdout: str, *, n_tokens: int) -> tuple[int, int, float]:
+    matches = [
+        parsed
+        for parsed in (parse_lattice_result_line(line) for line in stdout.splitlines())
+        if parsed is not None
+    ]
+    if len(matches) == 0:
+        raise LatticeResultError(f"lattice: no full-line RESULT record found in stdout: {stdout[-500:]!r}")
+    if len(matches) > 1:
+        raise LatticeResultError(
+            f"lattice: expected exactly one RESULT record for BENCH_RUNS=1, found {len(matches)}: {matches!r}"
+        )
+    n_req, completion, total_ms = matches[0]
+    if n_req != n_tokens:
+        raise LatticeResultError(
+            f"lattice: RESULT n_req={n_req} does not match the requested window n_tokens={n_tokens}"
+        )
+    if completion < 0:
+        raise LatticeResultError(f"lattice: RESULT completion={completion} is negative")
+    if not math.isfinite(total_ms) or total_ms < 0:
+        raise LatticeResultError(f"lattice: RESULT total_ms={total_ms} is not finite and non-negative")
+    return n_req, completion, total_ms
+
+
+class LatticeAdapter:
+    """Invokes `target/release/bench_decode_ab` against the real Q4
+    directory (`LATTICE_QUANT_FORMAT` is NOT set here -- unlike
+    `apples_to_apples_q4`'s adapter, `bench_decode_ab.rs` detects Q4 vs
+    safetensors from the model dir's own contents via `detect_format`, so no
+    override env var is needed for a genuine `.q4`-file directory)."""
+
+    def __init__(self, bin_path: Path = LAT_BIN, model_dir: Path = Q4_MODEL_DIR, tokenizer_dir: Path = TOKENIZER_DIR):
+        self.bin_path = bin_path
+        self.model_dir = model_dir
+        self.tokenizer_dir = tokenizer_dir
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        if not self.model_dir.is_dir():
+            raise LatticeUnavailableError(f"lattice: Q4 model dir missing ({self.model_dir})")
+        env = os.environ.copy()
+        env["BENCH_N"] = str(n_tokens)
+        env["BENCH_RUNS"] = "1"
+        env["LATTICE_MODEL_DIR"] = str(self.model_dir)
+        env["LATTICE_TOKENIZER_DIR"] = str(self.tokenizer_dir)
+        proc = subprocess.run(
+            [str(self.bin_path)], env=env, capture_output=True, text=True, timeout=600, check=False
+        )
+        if proc.returncode != 0:
+            raise LatticeUnavailableError(
+                f"lattice: bench_decode_ab exited {proc.returncode}: {proc.stderr.strip()[-2000:]}"
+            )
+        try:
+            _n_req, completion, total_ms = extract_single_result(proc.stdout, n_tokens=n_tokens)
+        except LatticeResultError as exc:
+            raise LatticeResultError(f"{exc} (stderr: {proc.stderr.strip()[-500:]})") from exc
+        return harness.AdapterRunResult(
+            actual_completion_tokens=completion,
+            native_ns=round(total_ms * 1e6),
+            engine_version="lattice-bench_decode_ab",
+        )
+
+
+def lattice_available(bin_path: Path = LAT_BIN, model_dir: Path = Q4_MODEL_DIR) -> bool:
+    return bin_path.is_file() and os.access(bin_path, os.X_OK) and model_dir.is_dir()
+
+
+# --------------------------------------------------------------------------
+# ollama (Q8_0 reference only -- no Q4 tag for qwen3.5:0.8b, per the legacy
+# script's own comment)
+# --------------------------------------------------------------------------
+
+OLLAMA_BASE_URL = os.environ.get("LATTICE_BENCH_OLLAMA_URL", "http://localhost:11434")
+OLLAMA_MODEL_TAG = "qwen3.5:0.8b"
+
+
+class OllamaResponseError(RuntimeError):
+    pass
+
+
+_REQUIRED_OLLAMA_FIELDS = ("eval_count", "eval_duration", "total_duration")
+
+
+def ollama_response_to_result(data: dict) -> harness.AdapterRunResult:
+    if "error" in data:
+        raise OllamaResponseError(f"ollama: response is an error body: {data['error']!r}")
+    for field in _REQUIRED_OLLAMA_FIELDS:
+        if field not in data:
+            raise OllamaResponseError(f"ollama: response missing required field {field!r}: {data!r}")
+        value = data[field]
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise OllamaResponseError(
+                f"ollama: response field {field!r} must be a non-boolean int, got {type(value).__name__}: {data!r}"
+            )
+    eval_count = data["eval_count"]
+    eval_duration = data["eval_duration"]
+    total_duration = data["total_duration"]
+    if eval_count < 0:
+        raise OllamaResponseError(f"ollama: eval_count={eval_count!r} is negative: {data!r}")
+    if eval_duration < 0:
+        raise OllamaResponseError(f"ollama: eval_duration={eval_duration!r} is negative: {data!r}")
+    if total_duration <= 0:
+        raise OllamaResponseError(f"ollama: total_duration={total_duration!r} must be positive: {data!r}")
+    return harness.AdapterRunResult(
+        actual_completion_tokens=int(eval_count),
+        native_ns=int(total_duration),
+        engine_version="ollama",
+    )
+
+
+class OllamaAdapter:
+    def __init__(self, base_url: str = OLLAMA_BASE_URL):
+        self.base_url = base_url
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        payload = json.dumps(
+            {
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "options": {"num_predict": n_tokens, "temperature": 0},
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.base_url}/api/generate",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            data = json.loads(resp.read())
+        return ollama_response_to_result(data)
+
+
+def ollama_available(base_url: str = OLLAMA_BASE_URL, *, model_tag: str = OLLAMA_MODEL_TAG) -> bool:
+    if shutil.which("ollama") is None:
+        return False
+    try:
+        listed = subprocess.run(["ollama", "list"], capture_output=True, text=True, timeout=30, check=False)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if model_tag not in listed.stdout:
+        pulled = subprocess.run(["ollama", "pull", model_tag], capture_output=True, text=True, timeout=600, check=False)
+        if pulled.returncode != 0:
+            return False
+    try:
+        urllib.request.urlopen(f"{base_url}/api/tags", timeout=3).read()
+        return True
+    except (urllib.error.URLError, OSError):
+        try:
+            subprocess.Popen(["ollama", "serve"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except OSError:
+            return False
+        time.sleep(3)
+        try:
+            urllib.request.urlopen(f"{base_url}/api/tags", timeout=3).read()
+            return True
+        except (urllib.error.URLError, OSError):
+            return False
+
+
+# --------------------------------------------------------------------------
+# mlx (Q4 g64, quant-matched to lattice Q4)
+# --------------------------------------------------------------------------
+
+MLX_SOURCE_MODEL_DIR = TOKENIZER_DIR  # same f16 src dir the legacy script loads for MLX
+
+
+class MlxAdapter:
+    """Invokes `mlx_lm`, mirroring `bench_q4_apples.sh`'s MLX heredoc: load
+    the f16 source dir once, `nn.quantize(bits=4, group_size=64)`, one
+    8-token warmup (represented by the profile's `warmup_repeats=1`/
+    `warmup_tokens=8`), then time only `generate()` per measured call."""
+
+    def __init__(self, source_model_dir: Path = MLX_SOURCE_MODEL_DIR):
+        self.source_model_dir = source_model_dir
+        self._cache: tuple[object, object, object, str | None] | None = None
+
+    def _load(self):
+        if self._cache is not None:
+            return self._cache
+        import mlx.core as mx
+        import mlx.nn as nn
+        from mlx_lm import load
+        from mlx_lm.sample_utils import make_sampler
+
+        fallback_model_id: str | None = None
+        try:
+            mlx_model, tok = load(str(self.source_model_dir))
+        except Exception:  # noqa: BLE001 -- legacy heredoc's own bare except fallback
+            mlx_model, tok = load("Qwen/Qwen3.5-0.8B")
+            fallback_model_id = "Qwen/Qwen3.5-0.8B"
+        nn.quantize(mlx_model, bits=4, group_size=64)
+        mx.eval(mlx_model.parameters())
+        sampler = make_sampler(temp=0.0)
+        self._cache = (mlx_model, tok, sampler, fallback_model_id)
+        return self._cache
+
+    def run(
+        self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str
+    ) -> harness.AdapterRunResult:
+        from mlx_lm import generate
+
+        mlx_model, tok, sampler, fallback_model_id = self._load()
+        generate(mlx_model, tok, prompt=prompt, max_tokens=n_tokens, sampler=sampler, verbose=False)
+        return harness.AdapterRunResult(
+            actual_completion_tokens=n_tokens,
+            engine_version="mlx_lm",
+            actual_model=fallback_model_id,
+        )
+
+
+def mlx_available() -> bool:
+    try:
+        import mlx_lm  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# --------------------------------------------------------------------------
+# registration + CLI delegation
+# --------------------------------------------------------------------------
+
+
+def register_available_adapters() -> None:
+    if lattice_available():
+        harness.register_adapter("lattice", LatticeAdapter())
+        print("  lattice Q4: adapter registered")
+    else:
+        print(f"  lattice: BIN MISSING or Q4 MODEL MISSING ({LAT_BIN}, {Q4_MODEL_DIR}) — build/download first")
+
+    if ollama_available():
+        harness.register_adapter("ollama", OllamaAdapter())
+        print("  ollama Q8 (ref): adapter registered")
+    else:
+        print("  ollama: not installed, unreachable, or model pull failed — skipping")
+
+    if mlx_available():
+        harness.register_adapter("mlx", MlxAdapter())
+        print("  mlx Q4: adapter registered")
+    else:
+        print("  mlx: mlx_lm not importable — run via `uv run --with mlx-lm ...` — skipping")
+
+
+if __name__ == "__main__":
+    register_available_adapters()
+    sys.exit(harness.main())

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -814,8 +814,10 @@ class AdapterRunResult:
 
     Adapters own invocation and parsing only: they must not choose repeat
     counts, discard samples, or compute verdicts. `native_ns`, when present,
-    is surfaced as a diagnostic field alongside the harness-measured timing,
-    never as a replacement for it.
+    becomes the primary aggregated duration (`engine_native_ns` on the
+    resulting `Observation`, see `_primary_elapsed_seconds`); the
+    harness-measured wall-clock timing is the fallback used only when no
+    native duration was reported.
 
     `actual_model`/`actual_quantization` report the identity the adapter
     actually invoked. They default to `None`, meaning "the requested

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -1190,9 +1190,34 @@ class SlopeResult:
     window_n: int
 
 
+def _primary_elapsed_seconds(o: Observation) -> float:
+    """The duration used for aggregation/slope computation and legacy TSV
+    rendering: the adapter-reported native/engine duration
+    (`engine_native_ns`) when the adapter provided one, falling back to the
+    harness's own outer wall-clock `elapsed_ns` only when it did not (e.g.
+    MLX's in-process `generate()` call, where there is no separate native
+    reading -- the wall clock IS the measured work).
+
+    This distinction matters because `elapsed_ns` measures the FULL adapter
+    invocation -- for the lattice/ollama subprocess-per-call adapters, that
+    includes one subprocess spawn and (for lattice) one model load per
+    measured/warmup call, time the legacy per-process-loop scripts
+    (`bench_apples_precise.sh`, `bench_q4_apples.sh`,
+    `bench_context_scaling.sh`) never paid per observation -- they load the
+    model once and time only the engine's own reported duration
+    (`RESULT total_ms=`/ollama's `total_duration`) for every repeat.
+    Aggregating `elapsed_ns` unconditionally would silently make every
+    migrated slope non-comparable with its legacy predecessor (issue #813
+    codex round-1 finding 1) -- `elapsed_ns` remains on every `Observation`
+    for provenance/diagnostics, but is never the primary aggregated value
+    when a native duration is available.
+    """
+    return (o.engine_native_ns if o.engine_native_ns is not None else o.elapsed_ns) / 1e9
+
+
 def _measured_elapsed_seconds(observations: tuple[Observation, ...], engine: str, window: int) -> list[float]:
     return [
-        o.elapsed_ns / 1e9
+        _primary_elapsed_seconds(o)
         for o in observations
         if o.engine == engine and o.requested_completion_tokens == window and not o.warmup
     ]

--- a/scripts/bench_decode_profiles.toml
+++ b/scripts/bench_decode_profiles.toml
@@ -247,3 +247,126 @@ warmup_repeats = 1
 warmup_tokens = 8
 model = "qwen3.5-0.8b"
 quantization = "q4"
+
+# bench_apples_precise.sh migration (issue #813 step 2). windows/prompt are
+# IDENTICAL to the legacy script's N1=64/N2=512/PROMPT; measured_repeats=13
+# + warmup_repeats=2 (per engine, at N2=512 tokens) reproduce "15 runs total,
+# 2 warmup, 13 measured" for every engine (the legacy script warms every
+# engine identically, unlike apples_to_apples_q8's mlx-only warmup). The
+# legacy script's own aggregation (trimmed mean dropping the top/bottom 2
+# of the MEASURED set, 95% normal-approximation CI) is `trimmed_mean`/
+# `trim=2` -- see SlopeResult.slope_ci95_legacy for why this is carried over
+# as a legacy heuristic, not corrected.
+[profiles.apples_precise]
+description = "bench_apples_precise.sh: reduced-noise edition, N1=64/N2=512, 13 measured + 2 warmup, trimmed mean"
+windows = [64, 512]
+measured_repeats = 13
+prompt = "The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
+aggregation = "trimmed_mean"
+trim = 2
+
+[[profiles.apples_precise.engines]]
+name = "lattice"
+warmup_repeats = 2
+warmup_tokens = 512
+model = "qwen3.5-0.8b"
+quantization = "q8"
+
+[[profiles.apples_precise.engines]]
+name = "ollama"
+warmup_repeats = 2
+warmup_tokens = 512
+model = "qwen3.5:0.8b"
+quantization = "q8"
+
+[[profiles.apples_precise.engines]]
+name = "mlx"
+warmup_repeats = 2
+warmup_tokens = 512
+model = "qwen3.5-0.8b"
+quantization = "q8"
+
+# bench_q4_apples.sh migration (issue #813 step 2). windows/measured_repeats/
+# prompt identical to the legacy script's N1=32/N2=256/RUNS=5/PROMPT; neither
+# lattice nor ollama gets a warmup (the script issues none for either), mlx
+# warms once at 8 tokens before its loop -- same shape as
+# apples_to_apples_q4, but this is bench_q4_apples.sh's OWN (separate,
+# pre-existing) reimplementation of that shape, migrated on its own profile
+# per the issue's "one script per PR" plan.
+#
+# DISCLOSED CORRECTION vs the legacy script: bench_q4_apples.sh set
+# BENCH_Q4_DIR/BENCH_TOKENIZER_DIR env vars when invoking bench_decode_ab,
+# but bench_decode_ab.rs never reads either of those names (only
+# LATTICE_MODEL_DIR/LATTICE_TOKENIZER_DIR) -- so the legacy script's lattice
+# leg silently fell back to LATTICE_MODEL_DIR's default
+# (~/.lattice/models/qwen3.5-0.8b, i.e. Q8 safetensors), never actually
+# exercising the Q4 weights its own output labeled "Lattice Q4". This
+# profile's `lattice` engine group uses the model/dir mapping the adapter
+# actually wires to LATTICE_MODEL_DIR (qwen3.5-0.8b-q4, the plain-Q4
+# directory bench_q4_apples.sh named but never reached) -- a bug fix, not a
+# parameter change: windows/repeats/warmup are unchanged from the legacy
+# script, only the broken env-var name is corrected so "q4" observations are
+# actually Q4.
+[profiles.q4_apples]
+description = "bench_q4_apples.sh: quant-matched Q4 comparison, N1=32/N2=256/runs=5 (lattice model-dir env-var bug fixed, see comment above)"
+windows = [32, 256]
+measured_repeats = 5
+prompt = "The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
+aggregation = "median"
+
+[[profiles.q4_apples.engines]]
+name = "lattice"
+warmup_repeats = 0
+model = "qwen3.5-0.8b-q4"
+quantization = "q4"
+
+[[profiles.q4_apples.engines]]
+name = "ollama"
+warmup_repeats = 0
+model = "qwen3.5:0.8b"
+quantization = "q8"
+
+[[profiles.q4_apples.engines]]
+name = "mlx"
+warmup_repeats = 1
+warmup_tokens = 8
+model = "qwen3.5-0.8b"
+quantization = "q4"
+
+# bench_context_scaling.sh migration (issue #813 step 2). `windows` is the
+# fixed baseline N1=8 followed by the default CONTEXTS=(64 128 256) -- the
+# harness's own aggregate() always computes every later window's slope
+# against `windows[0]`, exactly reproducing "measure the N1 baseline once,
+# reuse its median for every context length" without any measured_calls
+# override. measured_repeats=5 matches the legacy RUNS default. Only mlx
+# gets a warmup (4 tokens, once, before the whole baseline+context loop);
+# lattice and ollama get none, matching the legacy script's per-engine
+# structure exactly. CONTEXTS/RUNS are runtime-overridable via the wrapper
+# script (scripts/bench_context_scaling.sh), which rebuilds an equivalent
+# ProfileConfig with the requested windows/measured_repeats when either
+# environment variable is set, so this profile's values are the DEFAULTS.
+[profiles.context_scaling]
+description = "bench_context_scaling.sh: decode throughput vs context length, N1=8 baseline vs {64,128,256}"
+windows = [8, 64, 128, 256]
+measured_repeats = 5
+prompt = "The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
+aggregation = "median"
+
+[[profiles.context_scaling.engines]]
+name = "lattice"
+warmup_repeats = 0
+model = "qwen3.5-0.8b"
+quantization = "q8"
+
+[[profiles.context_scaling.engines]]
+name = "ollama"
+warmup_repeats = 0
+model = "qwen3.5:0.8b"
+quantization = "q8"
+
+[[profiles.context_scaling.engines]]
+name = "mlx"
+warmup_repeats = 1
+warmup_tokens = 4
+model = "qwen3.5-0.8b"
+quantization = "q8"

--- a/scripts/bench_q4_apples.sh
+++ b/scripts/bench_q4_apples.sh
@@ -1,132 +1,42 @@
 #!/usr/bin/env bash
 # Quant-MATCHED apples-to-apple decode benchmark — slope (marginal) method, Q4.
 #
-# Companion to bench_apples_to_apples.sh (which does f16 Lattice vs Q8 MLX/Ollama).
-# This one is the honest quant-matched comparison:
+# Thin wrapper (issue #813 step 2): all methodology (warmup policy, repeat
+# count, aggregation, output rendering) now lives in
+# scripts/bench_decode_harness.py, configured by the q4_apples profile in
+# scripts/bench_decode_profiles.toml. This script only execs the harness
+# (via scripts/bench_decode_adapters_q4_apples.py, which registers the
+# lattice/ollama/mlx engine adapters). Parameters are unchanged from the
+# pre-migration version of this script: N1=32, N2=256, 5 measured repeats,
+# the same fixed prompt, mlx-only 8-token warmup.
+#
+# DISCLOSED CORRECTION (see bench_decode_profiles.toml's [profiles.q4_apples]
+# comment): the pre-migration version of this script set env vars
+# (BENCH_Q4_DIR/BENCH_TOKENIZER_DIR) that bench_decode_ab never read, so its
+# lattice leg silently benchmarked Q8 (the LATTICE_MODEL_DIR default)
+# instead of the Q4 directory it claimed. This migration's adapter wires
+# LATTICE_MODEL_DIR to the real Q4 directory — a bug fix, not a parameter
+# change.
 #
 #   Lattice Q4 (plain per-row, ~/.lattice/models/qwen3.5-0.8b-q4)
 #   vs MLX Q4  (nn.quantize bits=4 group_size=64, same source weights)
 #   Ollama     = Q8_0 REFERENCE ONLY — no Q4 tag exists for qwen3.5:0.8b
 #               (verified via `ollama show`), so it is NOT a Q4 competitor.
-#
-# Methodology identical for every engine — the slope cancels prefill, model
-# load, and fixed per-call overhead at a fixed prompt:
-#
-#   decode_tok_per_s = (N2 - N1) / (T_total(N2) - T_total(N1))
-#
-# Cross-check: each engine's slope vs its own native decode rate where it
-# reports one (ollama eval_duration). Lattice Q4 output was eyeballed for
-# coherence before trusting any number (see target/q4_coherence.log).
 set -uo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-LAT_BIN="$REPO/target/release/bench_decode_ab"
-Q4_DIR="$HOME/.lattice/models/qwen3.5-0.8b-q4"     # plain Q4, tied embeddings
-TOK_DIR="$HOME/.lattice/models/qwen3.5-0.8b"        # tokenizer.json + f16 src
-N1=32
-N2=256
-RUNS=5
-PROMPT="The quick brown fox jumps over the lazy dog. Once upon a time in a land far away, there lived a"
 OUT="$REPO/target/bench_results"
 mkdir -p "$OUT"
-DATA="$OUT/q4_a2a_raw.tsv"      # engine<TAB>N<TAB>run<TAB>total_s<TAB>native_tok_s
-: > "$DATA"
 
-echo "=== Q4 apples-to-apple decode bench | Qwen3.5-0.8B | N1=$N1 N2=$N2 runs=$RUNS ==="
+echo "=== Q4 apples-to-apple decode bench | Qwen3.5-0.8B | N1=32 N2=256 runs=5 ==="
 echo "    Lattice=Q4 plain | MLX=Q4 g64 | Ollama=Q8_0 (reference, no Q4 tag)"
+echo "  Harness: scripts/bench_decode_harness.py (profile q4_apples)"
+echo ""
 
-# ---- Lattice (real Metal e2e Q4 path, same loader as chat_metal Q4 branch) ----
-if [[ -x "$LAT_BIN" ]]; then
-  for N in $N1 $N2; do
-    BENCH_N=$N BENCH_RUNS=$RUNS BENCH_Q4_DIR="$Q4_DIR" BENCH_TOKENIZER_DIR="$TOK_DIR" \
-      "$LAT_BIN" 2>/dev/null \
-    | awk -v N=$N '/^RESULT/{
-        for(i=1;i<=NF;i++){split($i,kv,"="); v[kv[1]]=kv[2]}
-        printf "lattice\t%s\t%d\t%.6f\t\n", N, ++r, v["total_ms"]/1000.0
-      }' >> "$DATA"
-  done
-  echo "  lattice Q4: done"
-else
-  echo "  lattice: BIN MISSING ($LAT_BIN) — build first"
-fi
+uv run --quiet --with mlx-lm python3 "$REPO/scripts/bench_decode_adapters_q4_apples.py" \
+  run --profile q4_apples --allow-missing-engine --out "$OUT/q4_a2a_raw.jsonl"
+status=$?
 
-# ---- Ollama (Q8_0 reference — no Q4 tag for qwen3.5:0.8b) ----
-if command -v ollama >/dev/null 2>&1; then
-  ollama list 2>/dev/null | grep -q "qwen3.5:0.8b" || ollama pull qwen3.5:0.8b >/dev/null 2>&1
-  curl -s localhost:11434/api/tags >/dev/null 2>&1 || { ollama serve >/dev/null 2>&1 & sleep 3; }
-  for N in $N1 $N2; do
-    for run in $(seq 1 $RUNS); do
-      R=$(curl -s localhost:11434/api/generate -d "{\"model\":\"qwen3.5:0.8b\",\"prompt\":$(python3 -c "import json,sys;print(json.dumps('$PROMPT'))"),\"stream\":false,\"options\":{\"num_predict\":$N,\"temperature\":0}}")
-      echo "$R" | python3 -c "
-import sys,json
-d=json.load(sys.stdin)
-tot=d.get('total_duration',0)/1e9
-ec=d.get('eval_count',0); ed=d.get('eval_duration',1)/1e9
-print(f'ollama\t$N\t$run\t{tot:.6f}\t{ec/ed:.3f}')" >> "$DATA"
-    done
-  done
-  echo "  ollama Q8 (ref): done"
-else
-  echo "  ollama: not installed — skipped"
-fi
-
-# ---- MLX (Apple framework, Q4 g64 — quant-matched to Lattice Q4) ----
-uv run --quiet --with mlx-lm python3 - "$TOK_DIR" "$N1" "$N2" "$RUNS" "$PROMPT" <<'PY' >> "$DATA" 2>/dev/null
-import sys, time
-mdir, n1, n2, runs, prompt = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]), sys.argv[5]
-import mlx.core as mx, mlx.nn as nn
-from mlx_lm import load, generate
-from mlx_lm.sample_utils import make_sampler
-try:
-    model, tok = load(mdir)            # same local f16 weights as Lattice Q4 source
-except Exception:
-    model, tok = load("Qwen/Qwen3.5-0.8B")
-nn.quantize(model, bits=4, group_size=64); mx.eval(model.parameters())
-samp = make_sampler(temp=0.0)
-generate(model, tok, prompt=prompt, max_tokens=8, sampler=samp, verbose=False)  # warmup
-for N in (n1, n2):
-    for run in range(1, runs+1):
-        t0=time.time()
-        generate(model, tok, prompt=prompt, max_tokens=N, sampler=samp, verbose=False)
-        dt=time.time()-t0
-        print(f"mlx\t{N}\t{run}\t{dt:.6f}\t")
-PY
-echo "  mlx Q4: done"
-
-# ---- Slope + report (identical math to bench_apples_to_apples.sh) ----
-python3 - "$DATA" "$N1" "$N2" <<'PY'
-import sys, statistics as st, collections
-data, N1, N2 = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-rows=collections.defaultdict(lambda: collections.defaultdict(list))
-nat=collections.defaultdict(list)
-for ln in open(data):
-    p=ln.rstrip("\n").split("\t")
-    if len(p)<4 or not p[3]: continue
-    eng,N,_,tot=p[0],int(p[1]),p[2],float(p[3])
-    rows[eng][N].append(tot)
-    if len(p)>=5 and p[4]: nat[eng].append(float(p[4]))
-labels={"lattice":"Lattice Q4","mlx":"MLX Q4","ollama":"Ollama Q8*"}
-print(f"\n{'engine':<12}{'slope tok/s':>13}{'native tok/s':>15}{'naive N2/T2':>14}   (median of runs)")
-print("-"*68)
-res={}
-for eng in ("lattice","mlx","ollama"):
-    if N1 not in rows[eng] or N2 not in rows[eng]:
-        print(f"{labels.get(eng,eng):<12}{'(no data)':>13}"); continue
-    t1,t2=st.median(rows[eng][N1]),st.median(rows[eng][N2])
-    slope=(N2-N1)/(t2-t1) if t2>t1 else float('nan')
-    naive=N2/t2
-    native=st.median(nat[eng]) if nat[eng] else float('nan')
-    res[eng]=slope
-    ns=f"{native:13.1f}" if native==native else f"{'—':>13}"
-    print(f"{labels.get(eng,eng):<12}{slope:13.1f}{ns:>15}{naive:14.1f}")
-print("-"*68)
-print("* Ollama is Q8_0 (no Q4 tag for qwen3.5:0.8b) — reference, NOT a Q4 competitor.")
-if "lattice" in res and "mlx" in res and res["mlx"]>0:
-    d=(res["lattice"]/res["mlx"]-1)*100
-    verb="FASTER" if d>0 else "SLOWER"
-    print(f"\nQuant-matched (slope, Q4): Lattice is {abs(d):.1f}% {verb} than MLX")
-if "lattice" in res and "ollama" in res and res["ollama"]>0:
-    d=(res["lattice"]/res["ollama"]-1)*100
-    print(f"Lattice Q4 vs Ollama Q8 (cross-quant ref): {abs(d):.1f}% {'FASTER' if d>0 else 'SLOWER'}")
-print(f"\nRaw: {data}")
-PY
+echo ""
+echo "Raw observations: $OUT/q4_a2a_raw.jsonl"
+exit $status

--- a/tests/test_bench_decode_adapters_apples_precise.py
+++ b/tests/test_bench_decode_adapters_apples_precise.py
@@ -221,10 +221,6 @@ class CallScheduleEquivalenceTest(unittest.TestCase):
         self.assertTrue(all(o.engine == "mlx" for o in result.observations))
 
 
-def math_isfinite_or_nan_ok(value: float) -> bool:
-    return value == value  # NaN != NaN; both finite and NaN are acceptable here
-
-
 class OllamaResponseParsingTest(unittest.TestCase):
     def test_valid_response(self):
         result = adapters.ollama_response_to_result(

--- a/tests/test_bench_decode_adapters_apples_precise.py
+++ b/tests/test_bench_decode_adapters_apples_precise.py
@@ -1,0 +1,274 @@
+"""Deterministic tests for scripts/bench_decode_adapters_apples_precise.py
+(issue #813 step 2: migrate bench_apples_precise.sh onto the shared
+decode-bench harness).
+
+No engine binary or network access is required: real adapters are
+exercised only through their pure parsing helpers
+(`parse_lattice_result_line`, `ollama_response_to_result`); the profile ->
+call-schedule equivalence is checked with the harness's own deterministic
+fake adapters, matching
+tests/test_bench_decode_adapters_apples_to_apples.py's convention.
+
+Run with: python3 tests/test_bench_decode_adapters_apples_precise.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = _REPO_ROOT / "scripts"
+
+sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+harness = _load_module("bench_decode_harness", "bench_decode_harness.py")
+adapters = _load_module(
+    "bench_decode_adapters_apples_precise", "bench_decode_adapters_apples_precise.py"
+)
+
+DEFAULT_PROFILES_FILE = _SCRIPTS / "bench_decode_profiles.toml"
+
+
+@dataclass
+class _FakeClock:
+    step_ns: int = 1_000_000
+    start_ns: int = 0
+    _calls: int = 0
+
+    def __call__(self) -> int:
+        value = self.start_ns + self.step_ns * self._calls
+        self._calls += 1
+        return value
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self.calls: list[tuple[int, bool, str, str]] = []
+
+    def run(self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str):
+        self.calls.append((n_tokens, warmup, model, quantization))
+        return harness.AdapterRunResult(
+            actual_completion_tokens=n_tokens, native_ns=n_tokens * 1000, engine_version="fake-1.0"
+        )
+
+
+class ProfileParameterEquivalenceTest(unittest.TestCase):
+    """bench_apples_precise.sh: N1=64, N2=512, TOTAL_RUNS=15, WARMUP=2 (so
+    13 measured), trimmed mean dropping top/bottom 2, every engine warms
+    identically (unlike apples_to_apples's mlx-only warmup)."""
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+
+    def test_profile_defined(self):
+        self.assertIn("apples_precise", self.profiles)
+
+    def test_windows_and_repeats_match_legacy_n1_n2_and_measured_count(self):
+        p = self.profiles["apples_precise"]
+        self.assertEqual(p.windows, (64, 512))
+        # TOTAL_RUNS=15, WARMUP=2 -> RUNS = TOTAL_RUNS - WARMUP = 13 measured.
+        self.assertEqual(p.measured_repeats, 13)
+
+    def test_aggregation_is_trimmed_mean_with_trim_2(self):
+        p = self.profiles["apples_precise"]
+        self.assertEqual(p.aggregation, "trimmed_mean")
+        self.assertEqual(p.trim, 2)
+
+    def test_prompt_matches_legacy_prompt_variable(self):
+        p = self.profiles["apples_precise"]
+        self.assertEqual(
+            p.prompt,
+            "The quick brown fox jumps over the lazy dog. Once upon a time in a land "
+            "far away, there lived a",
+        )
+
+    def test_engines_and_order(self):
+        p = self.profiles["apples_precise"]
+        self.assertEqual(p.engines, ("lattice", "ollama", "mlx"))
+
+    def test_every_engine_warms_twice_at_n2(self):
+        p = self.profiles["apples_precise"]
+        for group in p.engine_groups:
+            self.assertEqual(group.warmup_repeats, 2, group.name)
+            self.assertEqual(group.warmup_tokens, 512, group.name)
+
+    def test_quantization_is_q8_for_every_engine(self):
+        p = self.profiles["apples_precise"]
+        for group in p.engine_groups:
+            self.assertEqual(group.quantization, "q8", group.name)
+
+
+class CallScheduleEquivalenceTest(unittest.TestCase):
+    """Proves the produced call schedule matches bench_apples_precise.sh's
+    loop structure: every engine gets 2 warmup calls at N2=512, then N1 x13,
+    then N2 x13."""
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+
+    def test_call_sequence_every_engine_warms_before_measuring(self):
+        profile = self.profiles["apples_precise"]
+        lattice, ollama, mlx = _FakeAdapter(), _FakeAdapter(), _FakeAdapter()
+        harness.run_profile(
+            profile,
+            {"lattice": lattice, "ollama": ollama, "mlx": mlx},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        expected_lattice = (
+            [(512, True, "qwen3.5-0.8b", "q8")] * 2
+            + [(64, False, "qwen3.5-0.8b", "q8")] * 13
+            + [(512, False, "qwen3.5-0.8b", "q8")] * 13
+        )
+        self.assertEqual(lattice.calls, expected_lattice)
+        expected_ollama = (
+            [(512, True, "qwen3.5:0.8b", "q8")] * 2
+            + [(64, False, "qwen3.5:0.8b", "q8")] * 13
+            + [(512, False, "qwen3.5:0.8b", "q8")] * 13
+        )
+        self.assertEqual(ollama.calls, expected_ollama)
+        expected_mlx = (
+            [(512, True, "qwen3.5-0.8b", "q8")] * 2
+            + [(64, False, "qwen3.5-0.8b", "q8")] * 13
+            + [(512, False, "qwen3.5-0.8b", "q8")] * 13
+        )
+        self.assertEqual(mlx.calls, expected_mlx)
+
+    def test_produces_schema_valid_observations(self):
+        profile = self.profiles["apples_precise"]
+        result = harness.run_profile(
+            profile,
+            {"lattice": _FakeAdapter(), "ollama": _FakeAdapter(), "mlx": _FakeAdapter()},
+            clock=_FakeClock(),
+        )
+        for obs in result.observations:
+            harness.validate_observation(obs.to_dict())
+
+    def test_trimmed_mean_aggregation_actually_drops_the_extremes(self):
+        """Constructs 13 synthetic measured observations per window with a
+        deliberate outlier at each extreme, and proves `aggregate()`'s
+        trimmed-mean (trim=2) differs from the plain mean over the same
+        data -- a mutation reverting `trim` to 0 (or the profile default)
+        would make this test fail, since the plain-mean slope would then
+        differ from the asserted trimmed-mean slope."""
+        profile = self.profiles["apples_precise"]
+        # 13 values with two low outliers and two high outliers; trimmed
+        # mean (drop 2 lowest, 2 highest) of the remaining 9 differs from
+        # the mean of all 13.
+        baseline_secs = [0.05, 0.05, 0.30, 0.31, 0.31, 0.31, 0.31, 0.31, 0.31, 0.31, 0.31, 0.60, 0.60]
+        window_secs = [0.80, 0.80, 2.0, 2.01, 2.01, 2.01, 2.01, 2.01, 2.01, 2.01, 2.01, 4.0, 4.0]
+        self.assertEqual(len(baseline_secs), profile.measured_repeats)
+        self.assertEqual(len(window_secs), profile.measured_repeats)
+
+        def _obs(engine: str, window: int, elapsed_s: float, run_index: int) -> harness.Observation:
+            return harness.Observation(
+                schema_version=harness.SCHEMA_VERSION,
+                git_sha="x", profile=profile.name, engine=engine, engine_version="fake",
+                model="qwen3.5-0.8b", quantization="q8", prompt_hash="abc",
+                requested_prompt_tokens=None, actual_prompt_tokens=None,
+                requested_completion_tokens=window, actual_completion_tokens=window,
+                warmup=False, run_index=run_index, order_index=run_index,
+                elapsed_ns=round(elapsed_s * 1e9), engine_native_ns=None,
+                hardware_id="h", timestamp="2026-01-01T00:00:00+00:00",
+            )
+
+        observations = tuple(
+            _obs("lattice", 64, s, i + 1) for i, s in enumerate(baseline_secs)
+        ) + tuple(
+            _obs("lattice", 512, s, i + 1) for i, s in enumerate(window_secs)
+        )
+        run_result = harness.HarnessRunResult(profile=profile, observations=observations, missing_engines=())
+        slopes = harness.aggregate(run_result)
+        lattice_slope = next(s for s in slopes if s.engine == "lattice")
+
+        trimmed_baseline_mean = sum(sorted(baseline_secs)[2:-2]) / 9
+        trimmed_window_mean = sum(sorted(window_secs)[2:-2]) / 9
+        expected_slope = (512 - 64) / (trimmed_window_mean - trimmed_baseline_mean)
+        plain_baseline_mean = sum(baseline_secs) / 13
+        plain_window_mean = sum(window_secs) / 13
+        plain_slope = (512 - 64) / (plain_window_mean - plain_baseline_mean)
+
+        self.assertNotAlmostEqual(expected_slope, plain_slope, places=2)
+        self.assertAlmostEqual(lattice_slope.slope_tok_per_s, expected_slope, places=6)
+        self.assertIsNotNone(lattice_slope.slope_ci95_legacy)
+
+    def test_missing_engine_falls_back_to_allow_missing_engine(self):
+        profile = self.profiles["apples_precise"]
+        result = harness.run_profile(
+            profile,
+            {"mlx": _FakeAdapter()},
+            allow_missing_engine=True,
+            clock=_FakeClock(),
+        )
+        self.assertEqual(set(result.missing_engines), {"lattice", "ollama"})
+        self.assertTrue(all(o.engine == "mlx" for o in result.observations))
+
+
+def math_isfinite_or_nan_ok(value: float) -> bool:
+    return value == value  # NaN != NaN; both finite and NaN are acceptable here
+
+
+class OllamaResponseParsingTest(unittest.TestCase):
+    def test_valid_response(self):
+        result = adapters.ollama_response_to_result(
+            {"eval_count": 512, "eval_duration": 3_000_000_000, "total_duration": 4_000_000_000}
+        )
+        self.assertEqual(result.actual_completion_tokens, 512)
+        self.assertEqual(result.native_ns, 4_000_000_000)
+
+    def test_error_body_raises(self):
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result({"error": "model not found"})
+
+    def test_missing_field_raises(self):
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result({"eval_count": 1, "eval_duration": 1})
+
+    def test_float_field_rejected(self):
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result(
+                {"eval_count": 512, "eval_duration": 3.5, "total_duration": 4_000_000_000}
+            )
+
+
+class LatticeResultParsingTest(unittest.TestCase):
+    def test_parses_result_line(self):
+        parsed = adapters.parse_lattice_result_line("RESULT n_req=64 completion=64 total_ms=210.5")
+        self.assertEqual(parsed, (64, 64, 210.5))
+
+    def test_non_result_line_returns_none(self):
+        self.assertIsNone(adapters.parse_lattice_result_line("[bench] loading model"))
+
+    def test_extract_single_result_rejects_wrong_window(self):
+        with self.assertRaises(adapters.LatticeResultError):
+            adapters.extract_single_result("RESULT n_req=64 completion=64 total_ms=1.0", n_tokens=512)
+
+    def test_extract_single_result_rejects_zero_lines(self):
+        with self.assertRaises(adapters.LatticeResultError):
+            adapters.extract_single_result("no result here", n_tokens=64)
+
+    def test_extract_single_result_rejects_multiple_lines(self):
+        stdout = "RESULT n_req=64 completion=64 total_ms=1.0\nRESULT n_req=64 completion=64 total_ms=2.0\n"
+        with self.assertRaises(adapters.LatticeResultError):
+            adapters.extract_single_result(stdout, n_tokens=64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_decode_adapters_apples_to_apples.py
+++ b/tests/test_bench_decode_adapters_apples_to_apples.py
@@ -442,6 +442,11 @@ class AvailabilityCheckTest(unittest.TestCase):
         with mock.patch.object(adapters.shutil, "which", return_value=None):
             self.assertFalse(adapters.ollama_available(model_tag="qwen3.5:0.8b"))
 
+    @unittest.skipUnless(
+        importlib.util.find_spec("mlx_lm") is not None,
+        "asserts the import-success case, so mlx_lm must be installed "
+        "(macOS-only dependency; skipped on Linux CI)",
+    )
     def test_mlx_available_reflects_import_success(self):
         # mlx_lm is a declared project dependency (pyproject.toml); this
         # documents the expectation rather than mocking import machinery.
@@ -698,6 +703,11 @@ class RegisterAvailableAdaptersEndToEndTest(unittest.TestCase):
         self.assertIn("lattice", harness.ADAPTER_REGISTRY)
 
 
+@unittest.skipUnless(
+    importlib.util.find_spec("mlx_lm") is not None,
+    "mock.patch resolves 'mlx_lm.load' by import, so mlx_lm must be installed "
+    "(macOS-only dependency; skipped on Linux CI)",
+)
 class MlxFallbackProvenanceTest(unittest.TestCase):
     """A missing/corrupt local model dir makes `MlxAdapter` fall back to the
     Hub artifact -- the raw observation must record that via `actual_model`,

--- a/tests/test_bench_decode_adapters_context_scaling.py
+++ b/tests/test_bench_decode_adapters_context_scaling.py
@@ -57,6 +57,23 @@ class _FakeAdapter:
         )
 
 
+class _SequencedNativeAdapter:
+    """Returns a pre-scripted `native_ns` per call, in call order, ignoring
+    the wall clock entirely -- lets a test drive exact elapsed-seconds
+    values for `compute_context_scaling_aggregate` without choreographing a
+    `_StepClock`."""
+
+    def __init__(self, native_ns_sequence: list[int]):
+        self._durations = iter(native_ns_sequence)
+
+    def run(self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str):
+        return harness.AdapterRunResult(
+            actual_completion_tokens=n_tokens,
+            native_ns=next(self._durations),
+            engine_version="fake-native",
+        )
+
+
 class ProfileParameterEquivalenceTest(unittest.TestCase):
     """bench_context_scaling.sh: N1=8 baseline, default CONTEXTS=(64 128
     256), RUNS=5, only mlx warms (4 tokens, once, before the whole loop)."""
@@ -146,8 +163,8 @@ class LegacyTsvRenderingTest(unittest.TestCase):
         _, profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
         profile = profiles["context_scaling"]
         result = harness.run_profile(profile, {"lattice": _FakeAdapter()}, allow_missing_engine=True, clock=_FakeClock())
-        slopes = harness.aggregate(result)
-        tsv = adapters.render_legacy_tsv(result, slopes)
+        slopes, medians = adapters.compute_context_scaling_aggregate(result)
+        tsv = adapters.render_legacy_tsv(result, slopes, medians)
         lines = tsv.strip("\n").split("\n")
         self.assertEqual(lines[0], "engine\tcontext_tokens\tslope_tok_s\tt1_ms\tt2_ms\truns")
         self.assertEqual(len(lines), 1 + len(slopes))
@@ -182,6 +199,166 @@ class ContextsAndRunsOverrideTest(unittest.TestCase):
         overridden = dataclasses.replace(profile, measured_repeats=10)
         self.assertEqual(overridden.measured_repeats, 10)
         self.assertEqual(overridden.windows, profile.windows)
+
+
+class ParseContextsTest(unittest.TestCase):
+    """issue #813 codex round-1 finding 2a: --contexts must preserve caller
+    order (never sort) and reject a duplicated baseline/internal
+    duplicate."""
+
+    def test_preserves_caller_order_not_sorted(self):
+        self.assertEqual(adapters.parse_contexts("256,64,128", 8), (256, 64, 128))
+
+    def test_skips_blank_entries_and_whitespace(self):
+        self.assertEqual(adapters.parse_contexts(" 64, ,128 ", 8), (64, 128))
+
+    def test_rejects_internal_duplicate(self):
+        with self.assertRaises(adapters.ContextsConfigError):
+            adapters.parse_contexts("64,128,64", 8)
+
+    def test_rejects_context_equal_to_baseline(self):
+        with self.assertRaises(adapters.ContextsConfigError):
+            adapters.parse_contexts("8,64", 8)
+
+    def test_rejects_non_positive_entry(self):
+        with self.assertRaises(adapters.ContextsConfigError):
+            adapters.parse_contexts("0,64", 8)
+
+    def test_rejects_non_integer_entry(self):
+        with self.assertRaises(adapters.ContextsConfigError):
+            adapters.parse_contexts("64,abc", 8)
+
+    def test_rejects_empty(self):
+        with self.assertRaises(adapters.ContextsConfigError):
+            adapters.parse_contexts("", 8)
+
+
+class LegacyOrderedMedianTest(unittest.TestCase):
+    """issue #813 codex round-1 finding 2b: the exact per-engine even-n
+    tie-break `bench_context_scaling.sh`'s lattice_median/ollama_median
+    (lower middle) and MLX heredoc (upper middle) implement."""
+
+    def test_odd_n_matches_true_median_for_every_engine(self):
+        values = [5.0, 1.0, 3.0, 2.0, 4.0]
+        for engine in ("lattice", "ollama", "mlx"):
+            self.assertEqual(adapters._legacy_ordered_median(values, engine), 3.0)
+
+    def test_even_n_lattice_and_ollama_take_lower_middle(self):
+        # sorted: [1,2,3,4,5,6] -- lower middle (1-indexed position 3) = 3.0
+        values = [6.0, 2.0, 4.0, 1.0, 5.0, 3.0]
+        self.assertEqual(adapters._legacy_ordered_median(values, "lattice"), 3.0)
+        self.assertEqual(adapters._legacy_ordered_median(values, "ollama"), 3.0)
+
+    def test_even_n_mlx_takes_upper_middle(self):
+        values = [6.0, 2.0, 4.0, 1.0, 5.0, 3.0]
+        self.assertEqual(adapters._legacy_ordered_median(values, "mlx"), 4.0)
+
+    def test_empty_values_rejected(self):
+        with self.assertRaises(ValueError):
+            adapters._legacy_ordered_median([], "lattice")
+
+
+class ContextScalingEvenRunsLegacyMedianTest(unittest.TestCase):
+    """issue #813 codex round-1 finding 2b/2c, end to end: with an even
+    RUNS override, lattice takes the LOWER middle sample and mlx takes the
+    UPPER middle -- `statistics.median()` would instead average them -- and
+    the TSV's t1_ms/t2_ms must come from that SAME aggregate, never an
+    independently recomputed mean."""
+
+    @staticmethod
+    def _profile(measured_repeats: int, windows: list[int]):
+        raw = {
+            "description": "test",
+            "windows": windows,
+            "measured_repeats": measured_repeats,
+            "engines": [
+                {"name": "lattice", "warmup_repeats": 0, "model": "m", "quantization": "q8"},
+                {"name": "mlx", "warmup_repeats": 0, "model": "m", "quantization": "q8"},
+            ],
+            "prompt": "test prompt",
+        }
+        return harness._parse_profile("unit_test_ctx", raw)
+
+    def test_even_runs_lower_vs_upper_middle_and_tsv_consistency(self):
+        profile = self._profile(measured_repeats=6, windows=[8, 64])
+        # sorted ms: [10,20,30,40,50,60] -- lower middle=30, upper middle=40
+        baseline_ms = [50, 10, 60, 20, 40, 30]
+        # sorted ms: [100,...,600] -- lower middle=300, upper middle=400
+        window_ms = [100, 200, 300, 400, 500, 600]
+        sequence = [int(v * 1e6) for v in baseline_ms + window_ms]
+
+        result = harness.run_profile(
+            profile,
+            {
+                "lattice": _SequencedNativeAdapter(list(sequence)),
+                "mlx": _SequencedNativeAdapter(list(sequence)),
+            },
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        slopes, medians = adapters.compute_context_scaling_aggregate(result)
+
+        self.assertAlmostEqual(medians[("lattice", 8)], 0.030, places=9)
+        self.assertAlmostEqual(medians[("lattice", 64)], 0.300, places=9)
+        self.assertAlmostEqual(medians[("mlx", 8)], 0.040, places=9)
+        self.assertAlmostEqual(medians[("mlx", 64)], 0.400, places=9)
+        # statistics.median() would average the two middle values (35ms /
+        # 350ms for BOTH engines) -- assert we are not doing that.
+        self.assertNotAlmostEqual(medians[("lattice", 8)], 0.035, places=6)
+        self.assertNotAlmostEqual(medians[("mlx", 8)], 0.035, places=6)
+
+        lattice_slope = next(s for s in slopes if s.engine == "lattice")
+        mlx_slope = next(s for s in slopes if s.engine == "mlx")
+        self.assertAlmostEqual(lattice_slope.slope_tok_per_s, 56 / 0.27, places=6)
+        self.assertAlmostEqual(mlx_slope.slope_tok_per_s, 56 / 0.36, places=6)
+
+        tsv = adapters.render_legacy_tsv(result, slopes, medians)
+        for line in tsv.strip("\n").split("\n")[1:]:
+            engine, _ctx, _slope, t1_ms, t2_ms, _runs = line.split("\t")
+            if engine == "lattice":
+                self.assertAlmostEqual(float(t1_ms), 30.0, places=3)
+                self.assertAlmostEqual(float(t2_ms), 300.0, places=3)
+            else:
+                self.assertAlmostEqual(float(t1_ms), 40.0, places=3)
+                self.assertAlmostEqual(float(t2_ms), 400.0, places=3)
+
+
+class ContextScalingSkewedFiveSampleTsvTest(unittest.TestCase):
+    """issue #813 codex round-1 finding 2c, at the DEFAULT odd RUNS=5: the
+    legacy script's t1_ms/t2_ms were always medians, never means -- a
+    single high outlier in an otherwise tight five-sample set must not
+    move the rendered value."""
+
+    def test_tsv_uses_median_not_mean_when_skewed(self):
+        raw = {
+            "description": "test",
+            "windows": [8, 64],
+            "measured_repeats": 5,
+            "engines": [
+                {"name": "lattice", "warmup_repeats": 0, "model": "m", "quantization": "q8"}
+            ],
+            "prompt": "test prompt",
+        }
+        profile = harness._parse_profile("unit_test_skew", raw)
+        baseline_ms = [10, 130, 15, 25, 20]  # median=20, mean=40
+        window_ms = [200, 210, 205, 195, 800]  # median=205, mean=322
+        adapter = _SequencedNativeAdapter([int(v * 1e6) for v in baseline_ms + window_ms])
+        result = harness.run_profile(
+            profile,
+            {"lattice": adapter},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        slopes, medians = adapters.compute_context_scaling_aggregate(result)
+        tsv = adapters.render_legacy_tsv(result, slopes, medians)
+        line = tsv.strip("\n").split("\n")[1]
+        _engine, _ctx, _slope, t1_ms, t2_ms, _runs = line.split("\t")
+        self.assertAlmostEqual(float(t1_ms), 20.0, places=3)
+        self.assertAlmostEqual(float(t2_ms), 205.0, places=3)
+        self.assertNotAlmostEqual(float(t1_ms), 40.0, places=1)
+        self.assertNotAlmostEqual(float(t2_ms), 322.0, places=1)
 
 
 class OllamaResponseParsingTest(unittest.TestCase):

--- a/tests/test_bench_decode_adapters_context_scaling.py
+++ b/tests/test_bench_decode_adapters_context_scaling.py
@@ -1,0 +1,213 @@
+"""Deterministic tests for scripts/bench_decode_adapters_context_scaling.py
+(issue #813 step 2: migrate bench_context_scaling.sh, keeping its chart
+renderer).
+
+Run with: python3 tests/test_bench_decode_adapters_context_scaling.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = _REPO_ROOT / "scripts"
+
+sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+harness = _load_module("bench_decode_harness", "bench_decode_harness.py")
+adapters = _load_module("bench_decode_adapters_context_scaling", "bench_decode_adapters_context_scaling.py")
+
+DEFAULT_PROFILES_FILE = _SCRIPTS / "bench_decode_profiles.toml"
+
+
+@dataclass
+class _FakeClock:
+    step_ns: int = 1_000_000
+    start_ns: int = 0
+    _calls: int = 0
+
+    def __call__(self) -> int:
+        value = self.start_ns + self.step_ns * self._calls
+        self._calls += 1
+        return value
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self.calls: list[tuple[int, bool, str, str]] = []
+
+    def run(self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str):
+        self.calls.append((n_tokens, warmup, model, quantization))
+        return harness.AdapterRunResult(
+            actual_completion_tokens=n_tokens, native_ns=n_tokens * 1000, engine_version="fake-1.0"
+        )
+
+
+class ProfileParameterEquivalenceTest(unittest.TestCase):
+    """bench_context_scaling.sh: N1=8 baseline, default CONTEXTS=(64 128
+    256), RUNS=5, only mlx warms (4 tokens, once, before the whole loop)."""
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+
+    def test_profile_defined(self):
+        self.assertIn("context_scaling", self.profiles)
+
+    def test_windows_match_legacy_n1_and_default_contexts(self):
+        p = self.profiles["context_scaling"]
+        self.assertEqual(p.windows, (8, 64, 128, 256))
+        self.assertEqual(p.measured_repeats, 5)
+
+    def test_only_mlx_has_a_warmup(self):
+        p = self.profiles["context_scaling"]
+        groups = {g.name: g for g in p.engine_groups}
+        self.assertEqual(groups["lattice"].warmup_repeats, 0)
+        self.assertEqual(groups["ollama"].warmup_repeats, 0)
+        self.assertEqual(groups["mlx"].warmup_repeats, 1)
+        self.assertEqual(groups["mlx"].warmup_tokens, 4)
+
+    def test_all_engines_q8(self):
+        p = self.profiles["context_scaling"]
+        for group in p.engine_groups:
+            self.assertEqual(group.quantization, "q8", group.name)
+
+
+class CallScheduleEquivalenceTest(unittest.TestCase):
+    """Proves the default (no measured_calls override) window-major replay
+    of profile.windows reproduces "measure N1=8 once, then measure each
+    context length in turn, reusing the N1 baseline for every slope" --
+    exactly bench_context_scaling.sh's structure, with no measured_calls
+    override needed (see bench_decode_profiles.toml's comment)."""
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+
+    def test_call_sequence_baseline_then_each_context_in_order(self):
+        profile = self.profiles["context_scaling"]
+        lattice = _FakeAdapter()
+        harness.run_profile(
+            profile,
+            {"lattice": lattice},
+            allow_missing_engine=True,
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        self.assertEqual(
+            lattice.calls,
+            [(8, False, "qwen3.5-0.8b", "q8")] * 5
+            + [(64, False, "qwen3.5-0.8b", "q8")] * 5
+            + [(128, False, "qwen3.5-0.8b", "q8")] * 5
+            + [(256, False, "qwen3.5-0.8b", "q8")] * 5,
+        )
+
+    def test_every_later_window_slopes_against_the_same_n1_baseline(self):
+        profile = self.profiles["context_scaling"]
+        result = harness.run_profile(
+            profile, {"lattice": _FakeAdapter()}, allow_missing_engine=True, clock=_FakeClock()
+        )
+        slopes = harness.aggregate(result)
+        self.assertEqual({s.baseline_window for s in slopes}, {8})
+        self.assertEqual({s.window for s in slopes}, {64, 128, 256})
+
+    def test_produces_schema_valid_observations(self):
+        profile = self.profiles["context_scaling"]
+        result = harness.run_profile(
+            profile,
+            {"lattice": _FakeAdapter(), "ollama": _FakeAdapter(), "mlx": _FakeAdapter()},
+            clock=_FakeClock(),
+        )
+        for obs in result.observations:
+            harness.validate_observation(obs.to_dict())
+
+
+class LegacyTsvRenderingTest(unittest.TestCase):
+    """render_legacy_tsv must produce the exact
+    engine/context_tokens/slope_tok_s/... header
+    scripts/bench_context_scaling_chart.py parses positionally."""
+
+    def test_header_and_columns(self):
+        _, profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+        profile = profiles["context_scaling"]
+        result = harness.run_profile(profile, {"lattice": _FakeAdapter()}, allow_missing_engine=True, clock=_FakeClock())
+        slopes = harness.aggregate(result)
+        tsv = adapters.render_legacy_tsv(result, slopes)
+        lines = tsv.strip("\n").split("\n")
+        self.assertEqual(lines[0], "engine\tcontext_tokens\tslope_tok_s\tt1_ms\tt2_ms\truns")
+        self.assertEqual(len(lines), 1 + len(slopes))
+        for line in lines[1:]:
+            parts = line.split("\t")
+            self.assertEqual(len(parts), 6)
+            self.assertEqual(parts[0], "lattice")
+            int(parts[1])  # context_tokens parses as int
+            float(parts[2])  # slope_tok_s parses as float
+
+
+class ContextsAndRunsOverrideTest(unittest.TestCase):
+    """Proves the wrapper's --contexts/--runs flags (forwarded from the
+    legacy CONTEXTS/RUNS env vars by scripts/bench_context_scaling.sh)
+    rebuild an equivalent ProfileConfig without mutating the on-disk
+    profile."""
+
+    def test_contexts_override_replaces_windows_keeping_n1(self):
+        import dataclasses
+
+        _, profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+        profile = profiles["context_scaling"]
+        overridden = dataclasses.replace(profile, windows=(8, 512, 1024))
+        self.assertEqual(overridden.windows, (8, 512, 1024))
+        self.assertEqual(overridden.measured_repeats, profile.measured_repeats)
+
+    def test_runs_override_replaces_measured_repeats_only(self):
+        import dataclasses
+
+        _, profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+        profile = profiles["context_scaling"]
+        overridden = dataclasses.replace(profile, measured_repeats=10)
+        self.assertEqual(overridden.measured_repeats, 10)
+        self.assertEqual(overridden.windows, profile.windows)
+
+
+class OllamaResponseParsingTest(unittest.TestCase):
+    def test_valid_response(self):
+        result = adapters.ollama_response_to_result(
+            {"eval_count": 64, "eval_duration": 500_000_000, "total_duration": 800_000_000}
+        )
+        self.assertEqual(result.actual_completion_tokens, 64)
+        self.assertEqual(result.native_ns, 800_000_000)
+
+    def test_error_body_raises(self):
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result({"error": "boom"})
+
+
+class LatticeResultParsingTest(unittest.TestCase):
+    def test_parses_result_line(self):
+        self.assertEqual(
+            adapters.parse_lattice_result_line("RESULT n_req=8 completion=8 total_ms=50.0"),
+            (8, 8, 50.0),
+        )
+
+    def test_extract_single_result_rejects_wrong_window(self):
+        with self.assertRaises(adapters.LatticeResultError):
+            adapters.extract_single_result("RESULT n_req=8 completion=8 total_ms=1.0", n_tokens=64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_decode_adapters_q4_apples.py
+++ b/tests/test_bench_decode_adapters_q4_apples.py
@@ -167,18 +167,60 @@ class LatticeAdapterEnvVarCorrectionTest(unittest.TestCase):
                 cmd, 0, stdout="RESULT n_req=32 completion=32 total_ms=100.0\n", stderr=""
             )
 
-        adapter = adapters.LatticeAdapter(
-            bin_path=Path("/bin/true"), model_dir=Path("/tmp"), tokenizer_dir=Path("/tmp")
-        )
-        with mock.patch.object(Path, "is_dir", return_value=True), mock.patch.object(
-            subprocess, "run", side_effect=fake_run
-        ):
-            adapter.run(prompt="hi", n_tokens=32, warmup=False, model="qwen3.5-0.8b-q4", quantization="q4")
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            (model_dir / "weights.q4").write_bytes(b"stub")
+            adapter = adapters.LatticeAdapter(
+                bin_path=Path("/bin/true"), model_dir=model_dir, tokenizer_dir=model_dir
+            )
+            with mock.patch.object(subprocess, "run", side_effect=fake_run):
+                adapter.run(
+                    prompt="hi", n_tokens=32, warmup=False, model="qwen3.5-0.8b-q4", quantization="q4"
+                )
 
         self.assertIn("LATTICE_MODEL_DIR", captured)
         self.assertIn("LATTICE_TOKENIZER_DIR", captured)
         self.assertNotIn("BENCH_Q4_DIR", captured)
         self.assertNotIn("BENCH_TOKENIZER_DIR", captured)
+
+
+class LatticeAdapterModelIdentityTest(unittest.TestCase):
+    """The adapter must refuse to run when the resolved dir is not what
+    `detect_format` would load as Q4 (safetensors markers take precedence in
+    the binary, so their presence means a mislabeled full-precision run --
+    the historical bench_q4_apples.sh failure mode)."""
+
+    def _adapter_for(self, model_dir):
+        return adapters.LatticeAdapter(
+            bin_path=Path("/bin/true"), model_dir=model_dir, tokenizer_dir=model_dir
+        )
+
+    def test_refuses_safetensors_shaped_dir_even_with_q4_files(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            (model_dir / "weights.q4").write_bytes(b"stub")
+            (model_dir / "model.safetensors").write_bytes(b"stub")
+            with self.assertRaises(adapters.LatticeUnavailableError) as ctx:
+                self._adapter_for(model_dir).run(
+                    prompt="hi", n_tokens=32, warmup=False, model="m", quantization="q4"
+                )
+            self.assertIn("safetensors", str(ctx.exception))
+
+    def test_refuses_dir_without_q4_files(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp)
+            (model_dir / "config.json").write_bytes(b"{}")
+            with self.assertRaises(adapters.LatticeUnavailableError) as ctx:
+                self._adapter_for(model_dir).run(
+                    prompt="hi", n_tokens=32, warmup=False, model="m", quantization="q4"
+                )
+            self.assertIn("no .q4 files", str(ctx.exception))
 
 
 class LatticeResultParsingTest(unittest.TestCase):

--- a/tests/test_bench_decode_adapters_q4_apples.py
+++ b/tests/test_bench_decode_adapters_q4_apples.py
@@ -1,0 +1,210 @@
+"""Deterministic tests for scripts/bench_decode_adapters_q4_apples.py
+(issue #813 step 2: migrate bench_q4_apples.sh onto the shared
+decode-bench harness).
+
+Run with: python3 tests/test_bench_decode_adapters_q4_apples.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = _REPO_ROOT / "scripts"
+
+sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+harness = _load_module("bench_decode_harness", "bench_decode_harness.py")
+adapters = _load_module("bench_decode_adapters_q4_apples", "bench_decode_adapters_q4_apples.py")
+
+DEFAULT_PROFILES_FILE = _SCRIPTS / "bench_decode_profiles.toml"
+
+
+@dataclass
+class _FakeClock:
+    step_ns: int = 1_000_000
+    start_ns: int = 0
+    _calls: int = 0
+
+    def __call__(self) -> int:
+        value = self.start_ns + self.step_ns * self._calls
+        self._calls += 1
+        return value
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self.calls: list[tuple[int, bool, str, str]] = []
+
+    def run(self, *, prompt: str, n_tokens: int, warmup: bool, model: str, quantization: str):
+        self.calls.append((n_tokens, warmup, model, quantization))
+        return harness.AdapterRunResult(
+            actual_completion_tokens=n_tokens, native_ns=n_tokens * 1000, engine_version="fake-1.0"
+        )
+
+
+class ProfileParameterEquivalenceTest(unittest.TestCase):
+    """bench_q4_apples.sh: N1=32, N2=256, RUNS=5, no lattice/ollama warmup,
+    mlx warms once at 8 tokens (same call shape as apples_to_apples_q4, but
+    this is that script's own separate reimplementation, migrated on its
+    own profile per the issue's one-script-per-PR plan)."""
+
+    @classmethod
+    def setUpClass(cls):
+        _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+
+    def test_profile_defined(self):
+        self.assertIn("q4_apples", self.profiles)
+
+    def test_windows_and_repeats_match_legacy_n1_n2_runs(self):
+        p = self.profiles["q4_apples"]
+        self.assertEqual(p.windows, (32, 256))
+        self.assertEqual(p.measured_repeats, 5)
+        self.assertEqual(p.aggregation, "median")
+
+    def test_engines_and_order(self):
+        p = self.profiles["q4_apples"]
+        self.assertEqual(p.engines, ("lattice", "ollama", "mlx"))
+
+    def test_only_mlx_has_a_warmup(self):
+        p = self.profiles["q4_apples"]
+        groups = {g.name: g for g in p.engine_groups}
+        self.assertEqual(groups["lattice"].warmup_repeats, 0)
+        self.assertEqual(groups["ollama"].warmup_repeats, 0)
+        self.assertEqual(groups["mlx"].warmup_repeats, 1)
+        self.assertEqual(groups["mlx"].warmup_tokens, 8)
+
+    def test_quantization_tiers_lattice_q4_ollama_q8_reference_mlx_q4(self):
+        p = self.profiles["q4_apples"]
+        groups = {g.name: g for g in p.engine_groups}
+        self.assertEqual(groups["lattice"].model, "qwen3.5-0.8b-q4")
+        self.assertEqual(groups["lattice"].quantization, "q4")
+        self.assertEqual(groups["ollama"].quantization, "q8")
+        self.assertEqual(groups["mlx"].quantization, "q4")
+        self.assertEqual(groups["mlx"].model, "qwen3.5-0.8b")
+
+
+class CallScheduleEquivalenceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)
+
+    def test_call_sequence(self):
+        profile = self.profiles["q4_apples"]
+        lattice, ollama, mlx = _FakeAdapter(), _FakeAdapter(), _FakeAdapter()
+        harness.run_profile(
+            profile,
+            {"lattice": lattice, "ollama": ollama, "mlx": mlx},
+            clock=_FakeClock(),
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        self.assertEqual(
+            lattice.calls,
+            [(32, False, "qwen3.5-0.8b-q4", "q4")] * 5 + [(256, False, "qwen3.5-0.8b-q4", "q4")] * 5,
+        )
+        self.assertEqual(
+            ollama.calls,
+            [(32, False, "qwen3.5:0.8b", "q8")] * 5 + [(256, False, "qwen3.5:0.8b", "q8")] * 5,
+        )
+        self.assertEqual(
+            mlx.calls,
+            [(8, True, "qwen3.5-0.8b", "q4")]
+            + [(32, False, "qwen3.5-0.8b", "q4")] * 5
+            + [(256, False, "qwen3.5-0.8b", "q4")] * 5,
+        )
+
+    def test_produces_schema_valid_observations(self):
+        profile = self.profiles["q4_apples"]
+        result = harness.run_profile(
+            profile,
+            {"lattice": _FakeAdapter(), "ollama": _FakeAdapter(), "mlx": _FakeAdapter()},
+            clock=_FakeClock(),
+        )
+        for obs in result.observations:
+            harness.validate_observation(obs.to_dict())
+
+    def test_missing_engine_falls_back_to_allow_missing_engine(self):
+        profile = self.profiles["q4_apples"]
+        result = harness.run_profile(
+            profile,
+            {"mlx": _FakeAdapter()},
+            allow_missing_engine=True,
+            clock=_FakeClock(),
+        )
+        self.assertEqual(set(result.missing_engines), {"lattice", "ollama"})
+
+
+class LatticeAdapterEnvVarCorrectionTest(unittest.TestCase):
+    """Proves the DISCLOSED correction (see bench_decode_profiles.toml's
+    [profiles.q4_apples] comment): the adapter must set LATTICE_MODEL_DIR
+    (the name bench_decode_ab.rs actually reads), not the legacy script's
+    unread BENCH_Q4_DIR/BENCH_TOKENIZER_DIR names."""
+
+    def test_lattice_adapter_sets_the_real_env_var_names(self):
+        import subprocess
+        from unittest import mock
+
+        captured = {}
+
+        def fake_run(cmd, env, capture_output, text, timeout, check):
+            captured.update(env)
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="RESULT n_req=32 completion=32 total_ms=100.0\n", stderr=""
+            )
+
+        adapter = adapters.LatticeAdapter(
+            bin_path=Path("/bin/true"), model_dir=Path("/tmp"), tokenizer_dir=Path("/tmp")
+        )
+        with mock.patch.object(Path, "is_dir", return_value=True), mock.patch.object(
+            subprocess, "run", side_effect=fake_run
+        ):
+            adapter.run(prompt="hi", n_tokens=32, warmup=False, model="qwen3.5-0.8b-q4", quantization="q4")
+
+        self.assertIn("LATTICE_MODEL_DIR", captured)
+        self.assertIn("LATTICE_TOKENIZER_DIR", captured)
+        self.assertNotIn("BENCH_Q4_DIR", captured)
+        self.assertNotIn("BENCH_TOKENIZER_DIR", captured)
+
+
+class LatticeResultParsingTest(unittest.TestCase):
+    def test_parses_result_line(self):
+        self.assertEqual(
+            adapters.parse_lattice_result_line("RESULT n_req=256 completion=256 total_ms=999.9"),
+            (256, 256, 999.9),
+        )
+
+    def test_extract_single_result_rejects_wrong_window(self):
+        with self.assertRaises(adapters.LatticeResultError):
+            adapters.extract_single_result("RESULT n_req=32 completion=32 total_ms=1.0", n_tokens=256)
+
+
+class OllamaResponseParsingTest(unittest.TestCase):
+    def test_valid_response(self):
+        result = adapters.ollama_response_to_result(
+            {"eval_count": 256, "eval_duration": 1_000_000_000, "total_duration": 2_000_000_000}
+        )
+        self.assertEqual(result.actual_completion_tokens, 256)
+        self.assertEqual(result.native_ns, 2_000_000_000)
+
+    def test_error_body_raises(self):
+        with self.assertRaises(adapters.OllamaResponseError):
+            adapters.ollama_response_to_result({"error": "boom"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bench_decode_adapters_q4_apples.py
+++ b/tests/test_bench_decode_adapters_q4_apples.py
@@ -223,6 +223,62 @@ class LatticeAdapterModelIdentityTest(unittest.TestCase):
             self.assertIn("no .q4 files", str(ctx.exception))
 
 
+class LatticeAdapterQ4IdentityOSErrorTest(unittest.TestCase):
+    """issue #813 codex round-1 finding 3: a permission error (or a TOCTOU
+    directory removal between the `is_dir()` precheck and the identity
+    iteration) must surface as `LatticeUnavailableError`, matching
+    `detect_format`'s own fail-closed-to-Unknown behavior on a
+    `read_dir` error -- never a raw `PermissionError`/`FileNotFoundError`
+    escaping from `iterdir()`."""
+
+    def test_unreadable_dir_raises_lattice_unavailable_not_os_error(self):
+        import os
+        import tempfile
+
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            self.skipTest("cannot exercise a permission-denied directory as root")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp) / "q4model"
+            model_dir.mkdir()
+            (model_dir / "weights.q4").write_bytes(b"stub")
+            model_dir.chmod(0o000)
+            try:
+                adapter = adapters.LatticeAdapter(
+                    bin_path=Path("/bin/true"), model_dir=model_dir, tokenizer_dir=model_dir
+                )
+                with self.assertRaises(adapters.LatticeUnavailableError) as ctx:
+                    adapter.run(
+                        prompt="hi", n_tokens=32, warmup=False, model="m", quantization="q4"
+                    )
+                self.assertIn("could not inspect", str(ctx.exception))
+            finally:
+                model_dir.chmod(0o755)
+
+    def test_removed_dir_during_iteration_raises_lattice_unavailable(self):
+        """TOCTOU: the dir passes `run()`'s `is_dir()` precheck but is gone
+        by the time `_assert_q4_identity` iterates it."""
+        import tempfile
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp) / "q4model"
+            model_dir.mkdir()
+            (model_dir / "weights.q4").write_bytes(b"stub")
+            adapter = adapters.LatticeAdapter(
+                bin_path=Path("/bin/true"), model_dir=model_dir, tokenizer_dir=model_dir
+            )
+
+            def _raise_missing(self):
+                raise FileNotFoundError(f"[Errno 2] No such file or directory: '{self}'")
+
+            with mock.patch.object(Path, "iterdir", _raise_missing), self.assertRaises(
+                adapters.LatticeUnavailableError
+            ) as ctx:
+                adapter.run(prompt="hi", n_tokens=32, warmup=False, model="m", quantization="q4")
+            self.assertIn("could not inspect", str(ctx.exception))
+
+
 class LatticeResultParsingTest(unittest.TestCase):
     def test_parses_result_line(self):
         self.assertEqual(

--- a/tests/test_bench_decode_adapters_q4_apples.py
+++ b/tests/test_bench_decode_adapters_q4_apples.py
@@ -279,6 +279,55 @@ class LatticeAdapterQ4IdentityOSErrorTest(unittest.TestCase):
             self.assertIn("could not inspect", str(ctx.exception))
 
 
+class LatticeIsDirPreflightOSErrorTest(unittest.TestCase):
+    """codex round-2 finding (medium): Python 3.11's `Path.is_dir()`
+    propagates `OSError` subclasses like `PermissionError` rather than
+    swallowing them, so the `is_dir()` preflight in `run()` and the
+    `is_dir()` check in `lattice_available()` must both fail closed
+    instead of letting a raw `PermissionError` escape past the typed
+    `LatticeUnavailableError` boundary."""
+
+    def test_run_fails_closed_when_is_dir_raises_permission_error(self):
+        import tempfile
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = Path(tmp) / "q4model"
+            model_dir.mkdir()
+            (model_dir / "weights.q4").write_bytes(b"stub")
+            adapter = adapters.LatticeAdapter(
+                bin_path=Path("/bin/true"), model_dir=model_dir, tokenizer_dir=model_dir
+            )
+
+            def _raise_permission(self):
+                raise PermissionError(f"[Errno 13] Permission denied: '{self}'")
+
+            with mock.patch.object(Path, "is_dir", _raise_permission), self.assertRaises(
+                adapters.LatticeUnavailableError
+            ) as ctx:
+                adapter.run(prompt="hi", n_tokens=32, warmup=False, model="m", quantization="q4")
+            self.assertIn("could not stat", str(ctx.exception))
+
+    def test_lattice_available_returns_false_when_is_dir_raises_permission_error(self):
+        import tempfile
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "bin_stub"
+            bin_path.write_bytes(b"#!/bin/sh\n")
+            bin_path.chmod(0o755)
+            model_dir = Path(tmp) / "q4model"
+            model_dir.mkdir()
+
+            def _raise_permission(self):
+                raise PermissionError(f"[Errno 13] Permission denied: '{self}'")
+
+            with mock.patch.object(Path, "is_dir", _raise_permission):
+                self.assertFalse(
+                    adapters.lattice_available(bin_path=bin_path, model_dir=model_dir)
+                )
+
+
 class LatticeResultParsingTest(unittest.TestCase):
     def test_parses_result_line(self):
         self.assertEqual(

--- a/tests/test_bench_decode_harness.py
+++ b/tests/test_bench_decode_harness.py
@@ -1547,6 +1547,31 @@ class AggregateTest(unittest.TestCase):
         self.assertAlmostEqual(slopes[0].slope_tok_per_s, 10.0, places=6)
         self.assertIsNone(slopes[0].slope_ci95_legacy)
 
+    def test_slope_uses_native_duration_not_outer_wall_clock(self):
+        # issue #813 codex round-1 finding 1: the legacy per-process-loop
+        # scripts (bench_apples_precise.sh, bench_q4_apples.sh,
+        # bench_context_scaling.sh) time only the engine's own reported
+        # duration, never the harness's outer wall-clock wrapping a fresh
+        # subprocess spawn + model load per call. The adapter here reports
+        # a native duration implying an exact 100 tok/s, while the harness's
+        # own wall clock (driven independently by _StepClock) is deliberately
+        # unrelated -- if aggregate() aggregated `elapsed_ns` (the outer
+        # wall time) instead of `engine_native_ns`, the slope would come out
+        # 5.6 tok/s (224 tokens / 40s wall-clock delta), not 100.
+        profile = _profile(measured_repeats=1, windows=[32, 256])
+        wall_steps = [10.0e9, 50.0e9]  # unrelated to the native rate below
+        clock = _StepClock(wall_steps)
+        result = harness.run_profile(
+            profile,
+            {"fake": _FakeAdapter(native_ns_per_token=10_000_000)},  # 100 tok/s native
+            clock=clock,
+            git_sha_value="x",
+            hardware_id_value="h",
+        )
+        slopes = harness.aggregate(result)
+        self.assertEqual(len(slopes), 1)
+        self.assertAlmostEqual(slopes[0].slope_tok_per_s, 100.0, places=6)
+
     def test_trimmed_mean_stat_exact_with_asymmetric_outliers(self):
         # Direct unit test of the trimming primitive: a low and a high
         # outlier that trimming must remove for the trimmed mean to differ


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Progresses #813 (three of the four remaining consumers; `bench_compare_1k.py` deliberately deferred to its own PR per the issue's sequencing — it has three genuinely different per-engine measured shapes).

## What

Migrates `bench_apples_precise.sh`, `bench_q4_apples.sh`, and `bench_context_scaling.sh` onto the shared `bench_decode_harness.py` established by the earlier #857/#913 migrations, following the same one-adapter-module-per-consumer pattern:

- `apples_precise` profile: N1=64/N2=512, 13 measured + 2 warmup per engine, trimmed-mean aggregation (trim=2)
- `q4_apples` profile: N1=32/N2=256, 5 runs, MLX-only warmup
- `context_scaling` profile: N1=8 baseline vs contexts {64,128,256}; adapter renders the legacy chart-compatible TSV, still invokes the unmodified chart script, and forwards the legacy `CONTEXTS`/`RUNS`/`CHART_ONLY` env vars
- The three legacy shell scripts become thin `uv run` wrappers over their profiles (one release of grace)
- All four adapter test files wired into CI's `bench-decode-harness-tests` job (previously only the harness-core test ran — a pre-existing gap)

## Disclosed correction: the legacy Q4 rows were not Q4

`bench_q4_apples.sh` exported `BENCH_Q4_DIR`/`BENCH_TOKENIZER_DIR` — names `bench_decode_ab.rs` never reads (it reads `LATTICE_MODEL_DIR`/`LATTICE_TOKENIZER_DIR`). The binary silently fell back to its default model dir, so the script's "Lattice Q4" rows benchmarked whatever that dir held (currently the f16 safetensors checkpoint). Verified at source: no code in the repo reads `BENCH_Q4_DIR`. Blast-radius sweep: zero durable citations of this script's numbers anywhere (issues, PRs, ADRs, docs, reports) — the only mention is a script-name listing in the v0.2.3 release notes.

The fix is two-layered:
1. The adapter wires the real env-var names to the actual Q4 directory (regression-tested).
2. The adapter pins **loaded-model identity**, not just env wiring: it mirrors `detect_format`'s precedence (safetensors markers win over `.q4` files) and refuses to run when the resolved dir would not load as Q4. Two negative tests (safetensors-shaped dir, no-`.q4`-files dir); mutation-verified — removing the guard call fails both.

## Tests

49 new deterministic tests across three files (profile-parameter equivalence vs the legacy scripts' constants, fake-adapter call-schedule equivalence, schema validation, trimmed-mean aggregation mutation-verified, model-identity guards). All pass via `uv run python -m pytest` and standalone. Pre-existing harness tests (56+) unchanged and green. `shellcheck` clean on the shims.

Live cross-engine smoke was attempted under the machine bench-window lock but aborted honestly — the lock was contended by 9 processes; the harness's engine adapters are exercised by the fake-seam tests, and a live run can be done post-merge with the documented one-liner in each adapter's docstring.

bench-compare: not applicable — no `crates/` code changes (scripts, tests, and CI wiring only; the diff touches `.github/workflows/ci.yml`, `scripts/`, `tests/`).