### PR TITLE
feat(inference): bounded metal-worker admission with backpressure rejection (#932)

### DIFF
--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -66,7 +66,17 @@ enum Command {
         /// no shared worker queue to bound. Conservative default: this
         /// worker serializes all generation onto one dedicated thread, so a
         /// deep queue just means memory growth with no throughput benefit.
-        #[arg(long, default_value = "32")]
+        /// Must be between 1 and `tokio::sync::Semaphore::MAX_PERMITS`
+        /// (issue #939): zero would admit nothing (every request fails
+        /// admission), and clap rejects anything larger here instead of
+        /// deferring to `MetalWorker::spawn`'s own
+        /// `Semaphore::new`-precondition panic.
+        #[arg(
+            long,
+            default_value = "32",
+            value_parser = clap::builder::RangedU64ValueParser::<usize>::new()
+                .range(1..=(tokio::sync::Semaphore::MAX_PERMITS as u64))
+        )]
         max_pending: usize,
     },
     /// Preflight check: memory fit and artifact compatibility, without
@@ -86,6 +96,78 @@ enum Command {
         #[arg(long)]
         tokenizer_dir: Option<String>,
     },
+}
+
+// ─── #939 CLI boundary tests: `--max-pending` range validation ────────────
+//
+// clap's own `value_parser!(usize).range(1..=Semaphore::MAX_PERMITS)` on the
+// `Serve::max_pending` field (above) is the ONLY validation this binary
+// needs for zero / too-large values -- unlike `lattice_serve.rs`'s hand
+// rolled argv parser, clap already rejects a malformed string (`abc`,
+// `-1`) itself, before this range check ever runs. These tests exercise
+// that `value_parser` wiring directly through `Cli::try_parse_from`,
+// rather than duplicating the range logic anywhere in this binary.
+#[cfg(test)]
+mod max_pending_cli_tests {
+    use super::*;
+
+    fn parse_max_pending(args: &[&str]) -> Result<usize, clap::Error> {
+        let mut full = vec!["lattice", "serve", "--model", "/tmp/model"];
+        full.extend_from_slice(args);
+        match Cli::try_parse_from(full)?.command {
+            Command::Serve { max_pending, .. } => Ok(max_pending),
+            _ => panic!("expected Command::Serve, got a different Command variant"),
+        }
+    }
+
+    #[test]
+    fn max_pending_omitted_defaults_to_32() {
+        assert_eq!(parse_max_pending(&[]).expect("no --max-pending"), 32);
+    }
+
+    #[test]
+    fn max_pending_zero_is_rejected() {
+        parse_max_pending(&["--max-pending", "0"])
+            .expect_err("0 admits nothing and must be rejected, not silently accepted");
+    }
+
+    #[test]
+    fn max_pending_one_above_max_permits_is_rejected() {
+        let too_big = (tokio::sync::Semaphore::MAX_PERMITS as u128 + 1).to_string();
+        parse_max_pending(&["--max-pending", &too_big]).expect_err(
+            "Semaphore::MAX_PERMITS + 1 must be rejected before it can panic Semaphore::new",
+        );
+    }
+
+    #[test]
+    fn max_pending_at_max_permits_is_accepted() {
+        let at_max = tokio::sync::Semaphore::MAX_PERMITS.to_string();
+        assert_eq!(
+            parse_max_pending(&["--max-pending", &at_max])
+                .expect("Semaphore::MAX_PERMITS itself is the inclusive upper bound"),
+            tokio::sync::Semaphore::MAX_PERMITS
+        );
+    }
+
+    #[test]
+    fn max_pending_negative_is_rejected() {
+        parse_max_pending(&["--max-pending", "-1"])
+            .expect_err("a negative value must be rejected, not silently defaulted");
+    }
+
+    #[test]
+    fn max_pending_malformed_is_rejected() {
+        parse_max_pending(&["--max-pending", "not-a-number"])
+            .expect_err("a non-numeric value must be rejected, not silently defaulted");
+    }
+
+    #[test]
+    fn max_pending_valid_override_is_accepted() {
+        assert_eq!(
+            parse_max_pending(&["--max-pending", "8"]).expect("8 is a valid cap"),
+            8
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2535,16 +2617,56 @@ mod serve {
             &self,
             messages: Vec<ChatMessage>,
             gen_cfg: GenerateConfig,
-            mut on_token: impl FnMut(&str) -> bool + Send + 'static,
+            on_token: impl FnMut(&str) -> bool + Send + 'static,
             cancel: tokio::sync::watch::Receiver<bool>,
         ) -> Result<GenerateOutput, ApiError> {
-            use lattice_inference::serve::metal_worker::WorkerEvent;
-
             // #932: the ONE way `MetalWorkerClient::submit` fails outwardly
             // -- the shared worker's outstanding-job admission cap is full.
             // Surfaces as an ordinary `ApiError::ServiceUnavailable` (503),
             // exactly like any other `Err` this method already returns.
-            let mut rx = self.client.submit(messages, gen_cfg, cancel)?;
+            let mut rx = self.submit(messages, gen_cfg, cancel)?;
+            Self::drain(&mut rx, on_token).await
+        }
+
+        /// Admission-only half of [`Self::generate_streaming_with_cancel`]
+        /// (#939): runs `MetalWorkerClient::submit`'s synchronous admission
+        /// check (issue #932's `Semaphore::try_acquire_owned`) and returns
+        /// immediately, before any event is drained from the worker.
+        ///
+        /// Split out so `chat_completions`'s streaming arm can call this
+        /// directly -- and propagate `Err(ApiError::ServiceUnavailable)`
+        /// with `?` -- BEFORE building and returning the SSE response,
+        /// instead of discovering admission failure only after a detached
+        /// `tokio::spawn` task (which may not even have started running
+        /// yet) reaches this call. Draining is [`Self::drain`], called
+        /// separately once the response has been committed.
+        fn submit(
+            &self,
+            messages: Vec<ChatMessage>,
+            gen_cfg: GenerateConfig,
+            cancel: tokio::sync::watch::Receiver<bool>,
+        ) -> Result<
+            tokio::sync::mpsc::UnboundedReceiver<
+                lattice_inference::serve::metal_worker::WorkerEvent,
+            >,
+            ApiError,
+        > {
+            self.client.submit(messages, gen_cfg, cancel)
+        }
+
+        /// Drains a receiver obtained from [`Self::submit`], forwarding
+        /// token deltas to `on_token` and normalizing
+        /// `WorkerEvent::Cancelled` -- exactly the loop
+        /// `generate_streaming_with_cancel` ran inline before admission was
+        /// split out of it (#939).
+        async fn drain(
+            rx: &mut tokio::sync::mpsc::UnboundedReceiver<
+                lattice_inference::serve::metal_worker::WorkerEvent,
+            >,
+            mut on_token: impl FnMut(&str) -> bool + Send + 'static,
+        ) -> Result<GenerateOutput, ApiError> {
+            use lattice_inference::serve::metal_worker::WorkerEvent;
+
             let mut deliver_deltas = true;
             loop {
                 let Some(ev) = rx.recv().await else {
@@ -2733,6 +2855,12 @@ mod serve {
                 StartupError::ThreadExited => {
                     "Metal worker thread exited before loading finished".to_string()
                 }
+                // #939: clap's own `value_parser` range already rejects an
+                // out-of-range `--max-pending` before this call, so this
+                // arm is unreachable in practice through the CLI -- kept
+                // for exhaustiveness and as defense in depth against any
+                // other future `spawn_metal` caller.
+                err @ StartupError::InvalidMaxPending { .. } => err.to_string(),
             })?;
             // `owner` (and the `JoinHandle` it carries) is dropped here,
             // immediately: this binary's prior `MetalHandle::spawn` never
@@ -3804,20 +3932,23 @@ mod serve {
                 }
                 #[cfg(feature = "metal-gpu")]
                 ModelBackend::Metal { handle, .. } => {
+                    // #939: submit synchronously, before any SSE response is
+                    // built. `handle.submit` runs `MetalWorkerClient::submit`'s
+                    // admission check (#932) directly on this task -- not
+                    // inside the `tokio::spawn` below -- so an admission
+                    // rejection propagates via `?` as an ordinary
+                    // `ApiError::ServiceUnavailable` (503) before this
+                    // handler ever returns `Sse::new(...)`. Only draining the
+                    // already-admitted job happens in the detached task.
+                    let mut rx = handle.submit(chat_messages, gen_cfg, cancel_rx)?;
                     tokio::spawn(async move {
                         let tx_delta = tx.clone();
-                        let result = handle
-                            .generate_streaming_with_cancel(
-                                chat_messages,
-                                gen_cfg,
-                                move |delta| {
-                                    tx_delta
-                                        .unbounded_send(StreamMsg::Delta(delta.to_string()))
-                                        .is_ok()
-                                },
-                                cancel_rx,
-                            )
-                            .await;
+                        let result = MetalHandle::drain(&mut rx, move |delta| {
+                            tx_delta
+                                .unbounded_send(StreamMsg::Delta(delta.to_string()))
+                                .is_ok()
+                        })
+                        .await;
                         match result {
                             Ok(output) => finish_streaming(output),
                             Err(e) => {
@@ -3981,10 +4112,20 @@ mod serve {
                 ModelBackend::Metal { handle, .. } => handle
                     .generate_streaming(chat_messages, gen_cfg, |_delta| true)
                     .await
-                    .map_err(|e| {
-                        eprintln!("generation error (metal): {e:?}");
-                        ApiError::Internal {
-                            message: "inference failed".to_string(),
+                    .map_err(|e| match e {
+                        // #939: admission rejection (#932's outstanding-job
+                        // cap) must surface as the shared 503 `server_busy`
+                        // envelope unchanged -- collapsing it into
+                        // `ApiError::Internal` here made every non-streaming
+                        // Metal admission rejection an indistinguishable 500.
+                        ApiError::ServiceUnavailable { message } => {
+                            ApiError::ServiceUnavailable { message }
+                        }
+                        other => {
+                            eprintln!("generation error (metal): {other:?}");
+                            ApiError::Internal {
+                                message: "inference failed".to_string(),
+                            }
                         }
                     })?,
                 // ADR-080 C2 added
@@ -4114,6 +4255,219 @@ mod serve {
             }
             let (client, _jobs_rx) = lattice_inference::serve::metal_worker::test_client_and_jobs();
             let _handle: MetalHandle = build_from_shared_client(client);
+        }
+
+        /// #939 regression coverage: the unified `lattice serve` HTTP
+        /// adapter's admission ordering. Before this fix, the Metal
+        /// streaming arm called `MetalWorkerClient::submit` (the ONE way
+        /// admission (#932) can reject a request) INSIDE a detached
+        /// `tokio::spawn` task, after `chat_completions` had already
+        /// returned `Sse::new(...).into_response()` -- so an admission
+        /// rejection surfaced as a normal-looking stream that immediately
+        /// ended, never as HTTP 503. The non-streaming arm separately
+        /// collapsed `ApiError::ServiceUnavailable` into a generic 500. Both
+        /// arms are driven here through the REAL `router()` + a real
+        /// worker thread (`spawn_fake_with_cap`, cap=1, `generate` blocked
+        /// on a channel so exactly one request is provably "in flight"),
+        /// mirroring `lattice_serve.rs`'s own
+        /// `real_router_admission_cap::chat_completions_returns_503_json_envelope_when_admission_cap_reached`
+        /// -- that test alone did not catch this bug because it only
+        /// covers the daemon's separate, already-correct adapter.
+        #[cfg(all(feature = "metal-gpu", feature = "test-utils"))]
+        mod admission_cap_939 {
+            use super::*;
+            use axum::body::Body;
+            use axum::http::StatusCode;
+            use lattice_inference::serve::metal_worker::{
+                ContextWindowPolicy, spawn_fake_with_cap,
+            };
+            use std::sync::mpsc as std_mpsc;
+            use tower::ServiceExt as _;
+
+            /// A real (if tiny) tokenizer -- NOT a hand-rolled minimal
+            /// vocab. `lattice_serve.rs`'s equivalent
+            /// `real_router_admission_cap::single_slot_blocking_state` uses
+            /// the same `test_support::tiny_zero_model` tokenizer for
+            /// exactly this reason: a hand-rolled single-entry vocab (e.g.
+            /// just `{"hi": 0}`) lacks the byte-level fallback tokens a
+            /// real BPE tokenizer's byte-encoder table relies on, so
+            /// tokenizing the full rendered ChatML prompt against it can
+            /// silently misbehave in ways a real tokenizer never does.
+            fn tiny_tokenizer() -> lattice_inference::tokenizer::bpe::BpeTokenizer {
+                lattice_inference::model::qwen35::test_support::tiny_zero_model()
+                    .tokenizer()
+                    .clone()
+            }
+
+            /// A real worker thread (cap=1) whose `generate` blocks on
+            /// `unblock_rx.recv()` until the test releases it, so exactly
+            /// one request can be "in flight" for as long as the test
+            /// needs -- long enough to prove a second concurrent request is
+            /// rejected by admission rather than racing to observe an
+            /// already-freed slot. Mirrors `lattice_serve.rs`'s
+            /// `real_router_admission_cap::single_slot_blocking_state`.
+            fn single_slot_blocking_state()
+            -> (AppState, std_mpsc::Sender<()>, std_mpsc::Receiver<()>) {
+                let (unblock_tx, unblock_rx) = std_mpsc::channel::<()>();
+                let unblock_rx = std::sync::Mutex::new(unblock_rx);
+                let (started_tx, started_rx) = std_mpsc::channel::<()>();
+                let client = spawn_fake_with_cap(
+                    1,
+                    ContextWindowPolicy::PromptAndMaxTokens,
+                    4096,
+                    tiny_tokenizer(),
+                    move |_messages, _cfg, prompt_tokens, _on_token, _should_cancel| {
+                        let _ = started_tx.send(());
+                        // Blocks the dedicated fake-worker OS thread (not
+                        // the tokio runtime) until the test explicitly lets
+                        // it proceed.
+                        let _ = unblock_rx.lock().unwrap().recv();
+                        Ok(GenerateOutput {
+                            text: String::new(),
+                            token_ids: vec![],
+                            prompt_tokens,
+                            generated_tokens: 0,
+                            stopped: true,
+                            stop_reason: None,
+                            token_logprobs: vec![],
+                        })
+                    },
+                );
+                let state = AppState {
+                    model: ModelBackend::Metal {
+                        handle: MetalHandle { client },
+                        tokenizer: Arc::new(tiny_tokenizer()),
+                        max_context: 4096,
+                    },
+                    default_max_tokens: 16,
+                    max_tokens_cap: 4096,
+                    model_id: "test-model".to_string(),
+                    request_counter: Arc::new(AtomicU64::new(0)),
+                };
+                (state, unblock_tx, started_rx)
+            }
+
+            fn chat_request(stream: bool) -> axum::http::Request<Body> {
+                let body = if stream {
+                    r#"{"model":"test-model","messages":[{"role":"user","content":"hi"}],"stream":true}"#
+                } else {
+                    r#"{"model":"test-model","messages":[{"role":"user","content":"hi"}]}"#
+                };
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .expect("fixture request must build")
+            }
+
+            /// Asserts the shared 503 `server_busy` JSON envelope, AND that
+            /// no SSE response was ever committed (issue #939's exact
+            /// regression for the streaming arm: a 200 SSE response whose
+            /// body happened to end immediately would previously slip past
+            /// a status-code-only assertion).
+            async fn assert_503_server_busy_no_sse(
+                response: axum::http::Response<Body>,
+                case: &str,
+            ) {
+                assert_eq!(
+                    response.status(),
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "{case}: a request submitted while the admission cap is full must be \
+                     rejected with HTTP 503, fail-fast, before any response -- streaming \
+                     or not -- is committed"
+                );
+                let content_type = response
+                    .headers()
+                    .get(axum::http::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default()
+                    .to_string();
+                assert!(
+                    !content_type.contains("text/event-stream"),
+                    "{case}: a 503 rejection must never carry an SSE content-type -- that \
+                     would mean a streaming response had already committed before \
+                     admission was checked: {content_type}"
+                );
+                let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .expect("503 response body must be readable");
+                let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+                    panic!("{case}: 503 response must be JSON, not an SSE body: {e}")
+                });
+                assert_eq!(value["error"]["code"], "server_busy", "{case}: {value}");
+                assert_eq!(value["error"]["type"], "server_error", "{case}: {value}");
+                assert!(value["error"]["param"].is_null(), "{case}: {value}");
+                assert!(
+                    !value["error"]["message"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .is_empty(),
+                    "{case}: 503 envelope must carry a human-readable message: {value}"
+                );
+            }
+
+            #[tokio::test]
+            async fn chat_completions_streaming_returns_503_before_sse_commit_at_cap() {
+                let (state, unblock_tx, started_rx) = single_slot_blocking_state();
+                let app = router(state);
+
+                let app1 = app.clone();
+                let handle1 = tokio::spawn(async move { app1.oneshot(chat_request(false)).await });
+                tokio::task::spawn_blocking(move || started_rx.recv())
+                    .await
+                    .expect("blocking wait must not panic")
+                    .expect("request 1's worker-thread generate() must signal it started");
+
+                let response2 = app
+                    .clone()
+                    .oneshot(chat_request(true))
+                    .await
+                    .expect("router must produce a response, not a transport error");
+                assert_503_server_busy_no_sse(response2, "stream:true").await;
+
+                unblock_tx.send(()).expect("unblock send must succeed");
+                let response1 = handle1
+                    .await
+                    .expect("request 1's task must not panic")
+                    .expect("router must produce a response, not a transport error");
+                assert_eq!(
+                    response1.status(),
+                    StatusCode::OK,
+                    "request 1 itself was never over any cap and must succeed normally"
+                );
+            }
+
+            #[tokio::test]
+            async fn chat_completions_non_streaming_returns_503_server_busy_not_500_at_cap() {
+                let (state, unblock_tx, started_rx) = single_slot_blocking_state();
+                let app = router(state);
+
+                let app1 = app.clone();
+                let handle1 = tokio::spawn(async move { app1.oneshot(chat_request(false)).await });
+                tokio::task::spawn_blocking(move || started_rx.recv())
+                    .await
+                    .expect("blocking wait must not panic")
+                    .expect("request 1's worker-thread generate() must signal it started");
+
+                let response2 = app
+                    .clone()
+                    .oneshot(chat_request(false))
+                    .await
+                    .expect("router must produce a response, not a transport error");
+                assert_503_server_busy_no_sse(response2, "non-streaming").await;
+
+                unblock_tx.send(()).expect("unblock send must succeed");
+                let response1 = handle1
+                    .await
+                    .expect("request 1's task must not panic")
+                    .expect("router must produce a response, not a transport error");
+                assert_eq!(
+                    response1.status(),
+                    StatusCode::OK,
+                    "request 1 itself was never over any cap and must succeed normally"
+                );
+            }
         }
 
         #[test]

--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -60,6 +60,14 @@ enum Command {
         /// co-located tokenizer; safetensors directories always ship one).
         #[arg(long)]
         tokenizer_dir: Option<String>,
+        /// Cap on outstanding (queued + in-flight) requests to the Metal GPU
+        /// worker (issue #932) before new requests are rejected with HTTP
+        /// 503. Only applies to Q4/Metal-backed serving; the CPU backend has
+        /// no shared worker queue to bound. Conservative default: this
+        /// worker serializes all generation onto one dedicated thread, so a
+        /// deep queue just means memory growth with no throughput benefit.
+        #[arg(long, default_value = "32")]
+        max_pending: usize,
     },
     /// Preflight check: memory fit and artifact compatibility, without
     /// loading any model weights (config + tensor index inspection only).
@@ -2532,7 +2540,11 @@ mod serve {
         ) -> Result<GenerateOutput, ApiError> {
             use lattice_inference::serve::metal_worker::WorkerEvent;
 
-            let mut rx = self.client.submit(messages, gen_cfg, cancel);
+            // #932: the ONE way `MetalWorkerClient::submit` fails outwardly
+            // -- the shared worker's outstanding-job admission cap is full.
+            // Surfaces as an ordinary `ApiError::ServiceUnavailable` (503),
+            // exactly like any other `Err` this method already returns.
+            let mut rx = self.client.submit(messages, gen_cfg, cancel)?;
             let mut deliver_deltas = true;
             loop {
                 let Some(ev) = rx.recv().await else {
@@ -2651,6 +2663,7 @@ mod serve {
         pub fn spawn_metal(
             model_dir: std::path::PathBuf,
             tokenizer_dir: Option<std::path::PathBuf>,
+            max_pending: usize,
         ) -> Result<(Self, usize), String> {
             use lattice_inference::serve::metal_worker::{
                 ContextWindowPolicy, MetalWorker, StartupError, WorkerMetadata,
@@ -2687,26 +2700,29 @@ mod serve {
             let max_context = super::MetalChatBackend::MAX_CACHE_LEN;
             let model_dir_for_loader = model_dir.clone();
             let tokenizer_path_for_loader = tokenizer_path.clone();
-            let (owner, client, _meta) = MetalWorker::spawn(move || {
-                let cfg = super::load_q4_config(&model_dir_for_loader)?;
-                let state =
-                    lattice_inference::forward::metal_qwen35::MetalQwen35State::from_q4_dir(
-                        &model_dir_for_loader,
-                        &tokenizer_path_for_loader,
-                        &cfg,
-                        max_context,
-                    )
-                    .map_err(|e| format!("Q4 model load failed: {e}"))?;
-                Ok((
-                    state,
-                    tokenizer_for_worker,
-                    WorkerMetadata {
-                        format: "q4".to_string(),
-                        model_max_context: max_context,
-                        context_window_policy: ContextWindowPolicy::PromptAndMaxTokens,
-                    },
-                ))
-            })
+            let (owner, client, _meta) = MetalWorker::spawn(
+                move || {
+                    let cfg = super::load_q4_config(&model_dir_for_loader)?;
+                    let state =
+                        lattice_inference::forward::metal_qwen35::MetalQwen35State::from_q4_dir(
+                            &model_dir_for_loader,
+                            &tokenizer_path_for_loader,
+                            &cfg,
+                            max_context,
+                        )
+                        .map_err(|e| format!("Q4 model load failed: {e}"))?;
+                    Ok((
+                        state,
+                        tokenizer_for_worker,
+                        WorkerMetadata {
+                            format: "q4".to_string(),
+                            model_max_context: max_context,
+                            context_window_policy: ContextWindowPolicy::PromptAndMaxTokens,
+                        },
+                    ))
+                },
+                max_pending,
+            )
             .map_err(|e| match e {
                 StartupError::Load(msg) => msg,
                 // Preserves this binary's exact prior wording (distinct
@@ -6391,6 +6407,7 @@ async fn main() {
             max_tokens,
             model_id,
             tokenizer_dir,
+            max_pending,
         } => {
             use std::path::Path;
             use std::sync::Arc;
@@ -6430,6 +6447,7 @@ async fn main() {
                         match serve::ModelBackend::spawn_metal(
                             model_path.to_path_buf(),
                             tokenizer_dir_path,
+                            max_pending,
                         ) {
                             Ok((backend, _max_context)) => backend,
                             Err(e) => {
@@ -6441,6 +6459,7 @@ async fn main() {
                     #[cfg(not(feature = "metal-gpu"))]
                     {
                         let _ = &tokenizer_dir;
+                        let _ = max_pending;
                         eprintln!("Error: {}", backend::metal_gpu_required_message(model_path));
                         std::process::exit(1);
                     }

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -1194,13 +1194,28 @@ mod imp {
         let created = unix_secs();
 
         let (cancel_guard, cancel_rx) = lattice_inference::serve::cancel_pair();
-        // `MetalWorkerClient::submit` (issue #832) never fails outwardly --
-        // if the worker thread is no longer running, the returned receiver
-        // simply closes with zero events, which both branches below detect
-        // via their own first-event peek (`rx.recv()` returning `None`) and
-        // report identically to this binary's prior up-front
-        // `jobs.send(..).is_err()` check.
-        let mut rx = s.jobs.submit(messages, cfg, cancel_rx);
+        // `MetalWorkerClient::submit` (issue #832) never fails outwardly
+        // EXCEPT for admission (issue #932, checked synchronously here,
+        // before any tokenization/model work): if the worker thread is no
+        // longer running, the returned receiver simply closes with zero
+        // events, which both branches below detect via their own
+        // first-event peek (`rx.recv()` returning `None`) and report
+        // identically to this binary's prior up-front `jobs.send(..).is_err()`
+        // check.
+        let mut rx = match s.jobs.submit(messages, cfg, cancel_rx) {
+            Ok(rx) => rx,
+            Err(api_err) => {
+                emit_serve_event(
+                    "POST",
+                    "/v1/chat/completions",
+                    503,
+                    None,
+                    timer.elapsed().as_secs_f64() * 1000.0,
+                    false,
+                );
+                return api_err.into_response();
+            }
+        };
         // Dropped when nobody cares about the response anymore: at the end of
         // this SSE stream (moved in below) or at the end of this function for
         // the non-streaming branch. Either way that's the client disconnect
@@ -1714,6 +1729,15 @@ mod imp {
                 .filter(|&n| n > 0),
         };
 
+        // Bounded admission cap on outstanding (queued + in-flight) jobs on
+        // the shared Metal worker (issue #932) -- see
+        // `metal_worker::DEFAULT_MAX_PENDING_JOBS`'s doc comment for why a
+        // conservative default is correct even though this binary only ever
+        // runs one generation at a time.
+        let max_pending: usize = parse_arg(&args, "--max-pending")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(lattice_inference::serve::metal_worker::DEFAULT_MAX_PENDING_JOBS);
+
         eprintln!(
             "[lattice_serve] loading model from {} ({}) ...",
             model_dir.display(),
@@ -1738,23 +1762,26 @@ mod imp {
                 model_max_context,
                 ..
             },
-        ) = match MetalWorker::spawn(move || {
-            let LoadedModel {
-                metal,
-                tokenizer,
-                format,
-                model_max_context,
-            } = load_model(&model_dir_for_loader, &tokenizer_path, format)?;
-            Ok((
-                metal,
-                tokenizer,
-                WorkerMetadata {
+        ) = match MetalWorker::spawn(
+            move || {
+                let LoadedModel {
+                    metal,
+                    tokenizer,
                     format,
                     model_max_context,
-                    context_window_policy: ContextWindowPolicy::PromptAndDecodeWithDelimiter,
-                },
-            ))
-        }) {
+                } = load_model(&model_dir_for_loader, &tokenizer_path, format)?;
+                Ok((
+                    metal,
+                    tokenizer,
+                    WorkerMetadata {
+                        format,
+                        model_max_context,
+                        context_window_policy: ContextWindowPolicy::PromptAndDecodeWithDelimiter,
+                    },
+                ))
+            },
+            max_pending,
+        ) {
             Ok(triple) => triple,
             Err(StartupError::Load(e)) => return Err(e.into()),
             // Preserves this binary's exact prior wording (distinct from
@@ -2620,6 +2647,157 @@ mod imp {
                 let value: serde_json::Value =
                     serde_json::from_slice(&bytes).expect("error response must be JSON");
                 assert_eq!(value["error"]["code"], "context_length_exceeded");
+            }
+        }
+
+        /// HTTP-level admission/backpressure test (issue #932): a real
+        /// worker thread running the actual production `MetalWorkerClient`
+        /// (via `metal_worker::spawn_fake_with_cap`, the same cross-binary
+        /// test seam `real_router_overflow_parity` above uses, with an
+        /// explicit small cap instead of the effectively-unbounded
+        /// default), driven through this binary's real `router()` end to
+        /// end. Proves the 503 JSON envelope shape a real OpenAI-compatible
+        /// client would see, and that it is returned fail-fast (before the
+        /// worker thread's `generate` closure -- which would tokenize the
+        /// prompt -- is ever reached for the rejected request).
+        #[cfg(all(feature = "metal-gpu", feature = "test-utils"))]
+        mod real_router_admission_cap {
+            use super::*;
+            use lattice_inference::serve::metal_worker::spawn_fake_with_cap;
+            use std::sync::mpsc as std_mpsc;
+            use tower::ServiceExt as _;
+
+            /// A real worker thread (cap=1) whose `generate` blocks on
+            /// `unblock_rx.recv()` until the test releases it, so exactly
+            /// one request can be "in flight" for as long as the test needs
+            /// -- long enough to prove a second concurrent request is
+            /// rejected by admission rather than racing to observe an
+            /// already-freed slot.
+            fn single_slot_blocking_state() -> (
+                AppState,
+                std_mpsc::Sender<()>,
+                std_mpsc::Receiver<()>, // "generate() started" signal
+            ) {
+                let tokenizer = lattice_inference::model::qwen35::test_support::tiny_zero_model()
+                    .tokenizer()
+                    .clone();
+                let (unblock_tx, unblock_rx) = std_mpsc::channel::<()>();
+                let unblock_rx = std::sync::Mutex::new(unblock_rx);
+                let (started_tx, started_rx) = std_mpsc::channel::<()>();
+                let jobs = spawn_fake_with_cap(
+                    1,
+                    ContextWindowPolicy::PromptAndDecodeWithDelimiter,
+                    4096,
+                    tokenizer,
+                    move |_messages, _cfg, prompt_tokens, _on_token, _should_cancel| {
+                        let _ = started_tx.send(());
+                        // Blocks the dedicated fake-worker OS thread (not
+                        // the tokio runtime) until the test explicitly lets
+                        // it proceed.
+                        let _ = unblock_rx.lock().unwrap().recv();
+                        Ok(GenerateOutput {
+                            text: String::new(),
+                            token_ids: vec![],
+                            prompt_tokens,
+                            generated_tokens: 0,
+                            stopped: true,
+                            stop_reason: None,
+                            token_logprobs: vec![],
+                        })
+                    },
+                );
+                let state = AppState {
+                    jobs,
+                    model_id: Arc::from("test-model"),
+                    defaults: Defaults {
+                        max_tokens: 100,
+                        temperature: 0.7,
+                        top_k: 50,
+                        top_p: 0.9,
+                        repetition_penalty: 1.1,
+                        reasoning_budget: None,
+                    },
+                    model_max_context: 4096,
+                };
+                (state, unblock_tx, started_rx)
+            }
+
+            fn simple_chat_request() -> axum::http::Request<Body> {
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"model":"test-model","messages":[{"role":"user","content":"hi"}]}"#
+                            .to_string(),
+                    ))
+                    .expect("fixture request must build")
+            }
+
+            #[tokio::test]
+            async fn chat_completions_returns_503_json_envelope_when_admission_cap_reached() {
+                let (state, unblock_tx, started_rx) = single_slot_blocking_state();
+                let app = router(state);
+
+                // Request 1: admitted (cap=1, 0 outstanding); its worker-thread
+                // `generate` call blocks until we release it below. Driven in
+                // a background task since it will not resolve until then.
+                let app1 = app.clone();
+                let request1 = simple_chat_request();
+                let handle1 = tokio::spawn(async move { app1.oneshot(request1).await });
+
+                // Deterministic readiness: wait for `generate` to actually
+                // start (i.e. request 1's job has been dequeued and its
+                // admission permit is held) before firing request 2, rather
+                // than a fixed sleep.
+                tokio::task::spawn_blocking(move || started_rx.recv())
+                    .await
+                    .expect("blocking wait must not panic")
+                    .expect("request 1's worker-thread generate() must signal it started");
+
+                // Request 2: cap is now full (1/1) -- must be rejected with
+                // a 503 JSON envelope, fail-fast, before it ever reaches the
+                // worker thread's tokenizer/generate call.
+                let request2 = simple_chat_request();
+                let response2 = app
+                    .clone()
+                    .oneshot(request2)
+                    .await
+                    .expect("router must produce a response, not a transport error");
+                assert_eq!(
+                    response2.status(),
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "a request submitted while the admission cap is full must be \
+                     rejected with HTTP 503, fail-fast, before any SSE stream is \
+                     committed and before any tokenization/generation work runs"
+                );
+                let bytes2 = axum::body::to_bytes(response2.into_body(), usize::MAX)
+                    .await
+                    .expect("503 response body must be readable");
+                let value2: serde_json::Value =
+                    serde_json::from_slice(&bytes2).expect("503 response must be JSON");
+                assert_eq!(value2["error"]["code"], "server_busy");
+                assert_eq!(value2["error"]["type"], "server_error");
+                assert!(
+                    !value2["error"]["message"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .is_empty(),
+                    "503 envelope must carry a human-readable message: {value2}"
+                );
+
+                // Release request 1 so it completes normally and the
+                // background task/worker thread wind down cleanly.
+                unblock_tx.send(()).expect("unblock send must succeed");
+                let response1 = handle1
+                    .await
+                    .expect("request 1's task must not panic")
+                    .expect("router must produce a response, not a transport error");
+                assert_eq!(
+                    response1.status(),
+                    StatusCode::OK,
+                    "request 1 itself was never over any cap and must succeed normally"
+                );
             }
         }
 

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -1633,6 +1633,23 @@ mod imp {
             .cloned()
     }
 
+    /// Parses `--max-pending`, rejecting a malformed or negative value
+    /// outright instead of silently substituting the default (issue #939):
+    /// the prior `.and_then(|s| s.parse().ok()).unwrap_or(DEFAULT)` chain
+    /// could not distinguish "flag omitted" from "flag given garbage" --
+    /// `--max-pending -1` silently became `32`. Range validation (zero, or
+    /// above `Semaphore::MAX_PERMITS`) is deliberately NOT duplicated here:
+    /// it happens once, downstream, in `MetalWorker::spawn`
+    /// (`StartupError::InvalidMaxPending`), shared with `lattice.rs`.
+    fn parse_max_pending(args: &[String]) -> Result<usize, String> {
+        match parse_arg(args, "--max-pending") {
+            Some(raw) => raw.parse::<usize>().map_err(|_| {
+                format!("--max-pending: invalid value {raw:?} (expected a positive integer)")
+            }),
+            None => Ok(lattice_inference::serve::metal_worker::DEFAULT_MAX_PENDING_JOBS),
+        }
+    }
+
     fn default_model_cache() -> std::path::PathBuf {
         std::env::var("LATTICE_MODEL_CACHE")
             .map(std::path::PathBuf::from)
@@ -1734,9 +1751,7 @@ mod imp {
         // `metal_worker::DEFAULT_MAX_PENDING_JOBS`'s doc comment for why a
         // conservative default is correct even though this binary only ever
         // runs one generation at a time.
-        let max_pending: usize = parse_arg(&args, "--max-pending")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(lattice_inference::serve::metal_worker::DEFAULT_MAX_PENDING_JOBS);
+        let max_pending: usize = parse_max_pending(&args)?;
 
         eprintln!(
             "[lattice_serve] loading model from {} ({}) ...",
@@ -1790,6 +1805,11 @@ mod imp {
             // exited/panicked before ever sending a readiness signal.
             Err(StartupError::ThreadExited) => {
                 return Err("worker thread exited during model load".into());
+            }
+            // #939: zero, or above `Semaphore::MAX_PERMITS` -- a
+            // configuration error caught before `Semaphore::new` panics.
+            Err(err @ StartupError::InvalidMaxPending { .. }) => {
+                return Err(err.to_string().into());
             }
         };
         // Retains the worker thread's `JoinHandle` for the life of the
@@ -2087,6 +2107,67 @@ mod imp {
         #[test]
         fn model_context_falls_back_to_4096_when_absent() {
             assert_eq!(model_context_from_config(None), FALLBACK_MODEL_MAX_CONTEXT);
+        }
+
+        // ── #939 `--max-pending` daemon-arg boundary tests ────────────────
+        //
+        // `parse_max_pending` only rejects a MALFORMED string here (this
+        // binary's own hand-rolled argv parser, unlike `lattice.rs`'s clap
+        // `value_parser`); zero and above-`Semaphore::MAX_PERMITS` are valid
+        // `usize`s that parse fine and are instead caught once, downstream,
+        // by `MetalWorker::spawn`'s own `StartupError::InvalidMaxPending`
+        // (covered by that module's own boundary tests).
+
+        #[test]
+        fn max_pending_omitted_defaults_to_32() {
+            let args: Vec<String> = vec![];
+            assert_eq!(
+                parse_max_pending(&args).expect("no --max-pending flag"),
+                lattice_inference::serve::metal_worker::DEFAULT_MAX_PENDING_JOBS,
+            );
+        }
+
+        #[test]
+        fn max_pending_valid_override_is_accepted() {
+            let args: Vec<String> = vec!["--max-pending".to_string(), "8".to_string()];
+            assert_eq!(parse_max_pending(&args).expect("8 is well-formed"), 8);
+        }
+
+        #[test]
+        fn max_pending_negative_is_rejected_not_silently_defaulted() {
+            let args: Vec<String> = vec!["--max-pending".to_string(), "-1".to_string()];
+            let err = parse_max_pending(&args)
+                .expect_err("-1 must be rejected, not silently replaced by the default");
+            assert!(
+                err.contains("-1"),
+                "error must name the offending value: {err}"
+            );
+        }
+
+        #[test]
+        fn max_pending_malformed_is_rejected_not_silently_defaulted() {
+            let args: Vec<String> = vec!["--max-pending".to_string(), "not-a-number".to_string()];
+            let err = parse_max_pending(&args)
+                .expect_err("a non-numeric value must be rejected, not silently replaced");
+            assert!(
+                err.contains("not-a-number"),
+                "error must name the offending value: {err}"
+            );
+        }
+
+        #[test]
+        fn max_pending_zero_parses_ok_and_is_left_to_metal_worker_spawn_to_reject() {
+            // Zero is a syntactically valid `usize` -- `parse_max_pending`
+            // itself does not range-check it (that check lives once, in
+            // `MetalWorker::spawn`, shared with `lattice.rs`). This test
+            // pins that division of responsibility down: it must NOT start
+            // rejecting zero itself without `MetalWorker::spawn`'s own
+            // boundary tests changing too.
+            let args: Vec<String> = vec!["--max-pending".to_string(), "0".to_string()];
+            assert_eq!(
+                parse_max_pending(&args).expect("0 parses as a valid usize"),
+                0
+            );
         }
 
         // ── HTTP-level 400 tests ──────────────────────────────────────────

--- a/crates/inference/src/serve/metal_worker.rs
+++ b/crates/inference/src/serve/metal_worker.rs
@@ -55,7 +55,19 @@ use crate::model::qwen35_config::{GenerateConfig, GenerateOutput};
 use crate::serve::ApiError;
 use crate::tokenizer::Tokenizer as _;
 use crate::tokenizer::bpe::BpeTokenizer;
-use tokio::sync::{mpsc, watch};
+use std::sync::Arc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, watch};
+
+/// Default cap on outstanding (queued + in-flight) jobs a [`MetalWorkerClient`]
+/// admits before rejecting new submissions (issue #932). Conservative on
+/// purpose: this worker serializes ALL generation onto one dedicated thread
+/// (see the module docs), so a queue depth in the hundreds/thousands under
+/// bursty load just means O(N * request_size) memory growth (retained
+/// messages, sampling config, and an open SSE/event channel per queued job)
+/// with no matching throughput benefit — the extra jobs cannot run any
+/// sooner. Both binaries expose this as an overridable `--max-pending` flag;
+/// this constant is only the default when that flag is omitted.
+pub const DEFAULT_MAX_PENDING_JOBS: usize = 32;
 
 /// Selects the context-window formula enforced before Metal generation.
 /// Each serve adapter supplies the policy matching its pre-worker contract.
@@ -152,6 +164,17 @@ pub struct WorkerJob {
     cfg: GenerateConfig,
     tx: mpsc::UnboundedSender<WorkerEvent>,
     cancel: watch::Receiver<bool>,
+    /// Admission slot for this job (issue #932), held from
+    /// [`MetalWorkerClient::submit`] until `run_worker_loop` finishes with
+    /// this job (whatever the outcome — `Complete`, `Rejected`, `Failed`, or
+    /// a dequeue-time `Cancelled`) and drops it, exactly once, via ordinary
+    /// struct-field `Drop` — never released early, never released twice,
+    /// and never forgotten on any of those paths because nothing in
+    /// `run_worker_loop` ever moves it out of `job` or calls
+    /// `mem::forget`/`mem::drop` on it directly. The leading underscore
+    /// silences "field is never read" (this field's only job is to exist
+    /// and be dropped) without needing `#[allow(dead_code)]`.
+    _admission_permit: OwnedSemaphorePermit,
 }
 
 /// Owns the dedicated worker thread's `JoinHandle`. See the module docs'
@@ -171,32 +194,59 @@ pub struct MetalWorkerOwner {
 #[derive(Debug, Clone)]
 pub struct MetalWorkerClient {
     jobs: mpsc::UnboundedSender<WorkerJob>,
+    /// Bounded-admission cap (issue #932): `Semaphore::new(max_pending)`, one
+    /// permit per outstanding job (queued + in-flight, i.e. from `submit`
+    /// until `run_worker_loop` is done with it). `Arc`-shared with every
+    /// clone of this client so the cap is process-wide, not per-clone.
+    admission: Arc<Semaphore>,
 }
 
 impl MetalWorkerClient {
     /// Submit one generation request; the worker thread processes jobs
-    /// strictly FIFO. Returns immediately with the event receiver -- if the
+    /// strictly FIFO. Returns the event receiver on success -- if the
     /// worker thread is no longer running, the returned receiver closes
     /// with zero events (`recv()` resolves to `None` on the first poll).
     /// Callers must treat that the same as an explicit "worker unavailable"
     /// error, mirroring each binary's prior `jobs.send(..).is_err()` check.
+    ///
+    /// Returns `Err(ApiError::ServiceUnavailable)` -- the ONE way this
+    /// method is allowed to fail outwardly -- when the outstanding-job cap
+    /// (issue #932) is already full: `max_pending` jobs are currently
+    /// either queued or in-flight on the shared worker thread. This check
+    /// runs synchronously, before the job is enqueued at all, so a caller
+    /// rejected here has done zero tokenization/model work and the worker
+    /// thread never sees the request -- admission is a pure "should this
+    /// job exist at all" gate, never a mid-stream failure. Every other
+    /// `MetalWorkerClient::submit` failure mode (worker gone, context
+    /// window overflow, generation error) still flows through the
+    /// zero-events-on-`rx`/`WorkerEvent::Rejected`/`WorkerEvent::Failed`
+    /// contract unchanged.
     pub fn submit(
         &self,
         messages: Vec<ChatMessage>,
         gen_cfg: GenerateConfig,
         cancel: watch::Receiver<bool>,
-    ) -> mpsc::UnboundedReceiver<WorkerEvent> {
+    ) -> Result<mpsc::UnboundedReceiver<WorkerEvent>, ApiError> {
+        let permit = self.admission.clone().try_acquire_owned().map_err(|_| {
+            ApiError::ServiceUnavailable {
+                message: "too many outstanding requests; the inference worker's pending-job \
+                          queue is full, retry shortly"
+                    .to_string(),
+            }
+        })?;
         let (tx, rx) = mpsc::unbounded_channel();
         let job = WorkerJob {
             messages,
             cfg: gen_cfg,
             tx,
             cancel,
+            _admission_permit: permit,
         };
-        // On failure `job` (including `tx`) is simply dropped here, closing
-        // `rx` with zero events -- see the doc comment above.
+        // On failure `job` (including `tx` and the admission permit) is
+        // simply dropped here, closing `rx` with zero events and freeing
+        // the slot immediately -- see the doc comment above.
         let _ = self.jobs.send(job);
-        rx
+        Ok(rx)
     }
 }
 
@@ -358,12 +408,20 @@ impl MetalWorker {
     /// a caller never binds its HTTP listener before the model is confirmed
     /// ready, and never gets a `MetalWorkerClient` it could submit jobs to
     /// before that point either.
+    ///
+    /// `max_pending` (issue #932) is the returned `MetalWorkerClient`'s
+    /// outstanding-job admission cap -- see [`MetalWorkerClient::submit`].
+    /// Both binaries pass their own `--max-pending`-derived value (default
+    /// [`DEFAULT_MAX_PENDING_JOBS`]); this function applies no default of
+    /// its own.
     pub fn spawn(
         loader: impl FnOnce() -> Result<(MetalQwen35State, BpeTokenizer, WorkerMetadata), String>
         + Send
         + 'static,
+        max_pending: usize,
     ) -> Result<(MetalWorkerOwner, MetalWorkerClient, WorkerMetadata), StartupError> {
         let (job_tx, job_rx) = mpsc::unbounded_channel::<WorkerJob>();
+        let admission = Arc::new(Semaphore::new(max_pending));
         let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<WorkerMetadata, String>>();
 
         let join_handle = std::thread::spawn(move || match loader() {
@@ -430,7 +488,10 @@ impl MetalWorker {
                 MetalWorkerOwner {
                     join_handle: Some(join_handle),
                 },
-                MetalWorkerClient { jobs: job_tx },
+                MetalWorkerClient {
+                    jobs: job_tx,
+                    admission,
+                },
                 meta,
             )),
             Ok(Err(e)) => Err(StartupError::Load(e)),
@@ -475,9 +536,38 @@ impl WorkerJob {
 /// pair.
 #[cfg(feature = "test-utils")]
 pub fn test_client_and_jobs() -> (MetalWorkerClient, mpsc::UnboundedReceiver<WorkerJob>) {
-    let (job_tx, job_rx) = mpsc::unbounded_channel::<WorkerJob>();
-    (MetalWorkerClient { jobs: job_tx }, job_rx)
+    // A large, effectively-unbounded cap: the overwhelming majority of
+    // existing callers of this seam predate the #932 admission cap and
+    // exercise request validation / routing / cancellation, not admission
+    // itself -- they must keep behaving as if the queue were unbounded.
+    // Tests that specifically exercise the cap use
+    // `test_client_and_jobs_with_cap` instead.
+    test_client_and_jobs_with_cap(TEST_EFFECTIVELY_UNBOUNDED_CAP)
 }
+
+/// Same as [`test_client_and_jobs`], with an explicit admission cap (issue
+/// #932) instead of the effectively-unbounded default -- for tests that
+/// exercise `MetalWorkerClient::submit`'s admission rejection itself.
+#[cfg(feature = "test-utils")]
+pub fn test_client_and_jobs_with_cap(
+    max_pending: usize,
+) -> (MetalWorkerClient, mpsc::UnboundedReceiver<WorkerJob>) {
+    let (job_tx, job_rx) = mpsc::unbounded_channel::<WorkerJob>();
+    (
+        MetalWorkerClient {
+            jobs: job_tx,
+            admission: Arc::new(Semaphore::new(max_pending)),
+        },
+        job_rx,
+    )
+}
+
+/// See [`test_client_and_jobs`]'s doc comment: the cap
+/// `test_client_and_jobs`/`spawn_fake` (the two test-utils seams that predate
+/// issue #932) use so pre-existing callers keep seeing effectively-unbounded
+/// admission unless they opt into the `_with_cap` variant.
+#[cfg(feature = "test-utils")]
+const TEST_EFFECTIVELY_UNBOUNDED_CAP: usize = 1_000_000;
 
 /// A [`MetalWorkerClient`] backed by a REAL background thread running the
 /// exact production FIFO/cancellation loop ([`run_worker_loop`]) and the
@@ -498,6 +588,39 @@ pub fn test_client_and_jobs() -> (MetalWorkerClient, mpsc::UnboundedReceiver<Wor
 #[cfg(feature = "test-utils")]
 #[allow(clippy::type_complexity)]
 pub fn spawn_fake(
+    context_window_policy: ContextWindowPolicy,
+    model_max_context: usize,
+    tokenizer: BpeTokenizer,
+    generate: impl FnMut(
+        &[ChatMessage],
+        &GenerateConfig,
+        usize,
+        &mut dyn FnMut(&str, u32) -> bool,
+        &mut dyn FnMut() -> bool,
+    ) -> Result<GenerateOutput, String>
+    + Send
+    + 'static,
+) -> MetalWorkerClient {
+    // See `test_client_and_jobs`'s doc comment: effectively-unbounded so
+    // this seam's many pre-#932 callers (request validation / routing /
+    // cancellation fixtures, not admission itself) keep behaving as before.
+    spawn_fake_with_cap(
+        TEST_EFFECTIVELY_UNBOUNDED_CAP,
+        context_window_policy,
+        model_max_context,
+        tokenizer,
+        generate,
+    )
+}
+
+/// Same as [`spawn_fake`], with an explicit admission cap (issue #932)
+/// instead of the effectively-unbounded default -- for tests that exercise
+/// `MetalWorkerClient::submit`'s admission rejection at the real-router
+/// (HTTP) layer.
+#[cfg(feature = "test-utils")]
+#[allow(clippy::type_complexity)]
+pub fn spawn_fake_with_cap(
+    max_pending: usize,
     context_window_policy: ContextWindowPolicy,
     model_max_context: usize,
     tokenizer: BpeTokenizer,
@@ -522,7 +645,10 @@ pub fn spawn_fake(
                 .map_err(WorkerFailure::Failed)
         });
     });
-    MetalWorkerClient { jobs: job_tx }
+    MetalWorkerClient {
+        jobs: job_tx,
+        admission: Arc::new(Semaphore::new(max_pending)),
+    }
 }
 
 #[cfg(test)]
@@ -660,11 +786,20 @@ mod tests {
     ) {
         let (tx, rx) = mpsc::unbounded_channel::<WorkerEvent>();
         let (cancel_guard, cancel_rx) = crate::serve::cancel_pair();
+        // These FIFO/cancellation-loop tests drive `WorkerJob` directly
+        // (bypassing `MetalWorkerClient::submit`'s admission check
+        // entirely), so each job gets its own throwaway one-permit
+        // semaphore rather than sharing a real admission cap -- these tests
+        // are not exercising #932's admission behavior at all.
+        let permit = Arc::new(Semaphore::new(1))
+            .try_acquire_owned()
+            .expect("fresh single-permit semaphore must have a permit available");
         let job = WorkerJob {
             messages: vec![ChatMessage::user("hi")],
             cfg: GenerateConfig::default(),
             tx,
             cancel: cancel_rx,
+            _admission_permit: permit,
         };
         (job, rx, cancel_guard)
     }
@@ -758,11 +893,15 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel::<WorkerEvent>();
         drop(rx);
         let (_guard, cancel_rx) = crate::serve::cancel_pair();
+        let permit = Arc::new(Semaphore::new(1))
+            .try_acquire_owned()
+            .expect("fresh single-permit semaphore must have a permit available");
         let job = WorkerJob {
             messages: vec![ChatMessage::user("hi")],
             cfg: GenerateConfig::default(),
             tx,
             cancel: cancel_rx,
+            _admission_permit: permit,
         };
         job_tx.send(job).unwrap();
         drop(job_tx);
@@ -1015,7 +1154,10 @@ mod tests {
     fn loader_failure_before_readiness_is_reported_without_touching_a_device() {
         // The `Ok` arm's type (`MetalQwen35State`) is never constructed --
         // this typechecks and runs with zero GPU involvement.
-        let result = MetalWorker::spawn(|| Err("simulated load failure".to_string()));
+        let result = MetalWorker::spawn(
+            || Err("simulated load failure".to_string()),
+            DEFAULT_MAX_PENDING_JOBS,
+        );
         match result {
             Err(StartupError::Load(message)) => {
                 assert_eq!(message, "simulated load failure");
@@ -1148,5 +1290,243 @@ mod tests {
             )
             .is_ok()
         );
+    }
+
+    // ── admission cap / backpressure (issue #932) ─────────────────────────
+
+    /// Cap enforcement: with `max_pending=2`, job 1 (dequeued immediately,
+    /// running) plus job 2 (queued behind it) fill the cap; a 3rd submission
+    /// must be rejected with `ApiError::ServiceUnavailable` before it ever
+    /// reaches the job channel.
+    ///
+    /// Mutation-verified by hand (issue #932 implementation): temporarily
+    /// raising the cap passed to `test_client_and_jobs_with_cap` below from
+    /// 2 to 3 makes the 3rd submission succeed and this test's
+    /// `expect_err` panic -- confirming the assertion actually depends on
+    /// the cap value rather than trivially passing regardless.
+    #[test]
+    fn submit_rejects_once_admission_cap_reached() {
+        let cap = 2;
+        let (client, job_rx) = test_client_and_jobs_with_cap(cap);
+        let started = Arc::new(AtomicUsize::new(0));
+        let ran_tokens = Arc::new(AtomicUsize::new(0));
+        let started2 = started.clone();
+        let ran2 = ran_tokens.clone();
+        let handle = std::thread::spawn(move || {
+            run_worker_loop(job_rx, fake_generate(2000, started2, ran2))
+        });
+
+        // Job 1: admitted, immediately dequeued (nothing else queued yet),
+        // and running fake_generate's 2000-iteration/5ms-per-iteration
+        // loop -- long enough to stay in-flight for the rest of this test.
+        let (guard1, cancel1) = crate::serve::cancel_pair();
+        let rx1 = client
+            .submit(
+                vec![ChatMessage::user("hi")],
+                GenerateConfig::default(),
+                cancel1,
+            )
+            .expect("job 1 must be admitted: cap=2, 0 outstanding");
+        std::thread::sleep(Duration::from_millis(30));
+
+        // Job 2: admitted (2nd of 2 permits); sits queued behind job 1
+        // since the single worker thread is still busy with it.
+        let (guard2, cancel2) = crate::serve::cancel_pair();
+        let rx2 = client
+            .submit(
+                vec![ChatMessage::user("hi")],
+                GenerateConfig::default(),
+                cancel2,
+            )
+            .expect("job 2 must be admitted: cap=2, 1 outstanding");
+
+        // Job 3: cap is now full (job 1 in-flight + job 2 queued == 2 ==
+        // cap) -- must be rejected, and must never reach the job channel
+        // (no tokenization/model work for a rejected admission).
+        let (_guard3, cancel3) = crate::serve::cancel_pair();
+        let err = client
+            .submit(
+                vec![ChatMessage::user("hi")],
+                GenerateConfig::default(),
+                cancel3,
+            )
+            .expect_err("job 3 must be rejected once the cap is reached");
+        match err {
+            ApiError::ServiceUnavailable { message } => {
+                assert!(
+                    message.contains("outstanding") || message.contains("pending"),
+                    "rejection message should explain admission capacity: {message}"
+                );
+            }
+            other => panic!("expected ServiceUnavailable, got {other:?}"),
+        }
+
+        // Cleanup: cancel jobs 1 and 2 so fake_generate's should_cancel
+        // check stops them quickly, then drain and join.
+        drop(guard1);
+        drop(guard2);
+        drop(rx1);
+        drop(rx2);
+        drop(client);
+        handle.join().expect("worker thread must not panic");
+    }
+
+    /// Slot release on NORMAL completion: a cap=1 client must admit a
+    /// second job only after the first job's terminal `Complete` event has
+    /// been delivered and `run_worker_loop` has moved past it (dropping the
+    /// `WorkerJob`, and with it the admission permit it owns).
+    #[test]
+    fn admission_slot_is_released_when_a_job_completes() {
+        let cap = 1;
+        let (client, job_rx) = test_client_and_jobs_with_cap(cap);
+        let started = Arc::new(AtomicUsize::new(0));
+        let ran_tokens = Arc::new(AtomicUsize::new(0));
+        let started2 = started.clone();
+        let ran2 = ran_tokens.clone();
+        let handle =
+            std::thread::spawn(move || run_worker_loop(job_rx, fake_generate(5, started2, ran2)));
+
+        let (_guard1, cancel1) = crate::serve::cancel_pair();
+        let mut rx1 = client
+            .submit(
+                vec![ChatMessage::user("hi")],
+                GenerateConfig::default(),
+                cancel1,
+            )
+            .expect("job 1 must be admitted");
+
+        // Drain job 1 to its terminal Complete event -- fake_generate(5, ..)
+        // runs to completion in ~25ms and is never cancelled.
+        let mut completed = false;
+        while let Some(ev) = rx1.blocking_recv() {
+            if matches!(ev, WorkerEvent::Complete(_)) {
+                completed = true;
+            }
+        }
+        assert!(completed, "job 1 must complete normally");
+
+        // The permit `run_worker_loop` held for job 1 is dropped along with
+        // `job` at the end of that loop iteration, essentially immediately
+        // after the `Complete` send above -- retry briefly rather than
+        // assume that has already happened on this exact instruction by the
+        // time this (different) thread observes the event.
+        let mut admitted = false;
+        for _ in 0..50 {
+            let (_guard2, cancel2) = crate::serve::cancel_pair();
+            match client.submit(
+                vec![ChatMessage::user("hi")],
+                GenerateConfig::default(),
+                cancel2,
+            ) {
+                Ok(_rx2) => {
+                    admitted = true;
+                    break;
+                }
+                Err(_) => std::thread::sleep(Duration::from_millis(5)),
+            }
+        }
+        assert!(
+            admitted,
+            "slot must be released once job 1 completes, admitting job 2 at the same cap=1"
+        );
+
+        drop(client);
+        handle.join().expect("worker thread must not panic");
+    }
+
+    /// THE REGRESSION THIS TEST GUARDS (issue #932): a client-cancelled
+    /// job that is still sitting in the queue (not yet dequeued) must NOT
+    /// release its admission slot early -- it is still real, unprocessed
+    /// work occupying a place in the FIFO queue -- but once the worker
+    /// actually dequeues it and observes the cancellation (sending exactly
+    /// one `WorkerEvent::Cancelled`, the existing #832 dequeue-time-cancel
+    /// contract), its slot MUST be released, same as any other terminal
+    /// outcome. A permit leaked specifically on this path would let the
+    /// outstanding-job count only ever grow -- every cancelled queued
+    /// request would permanently cost one admission slot, eventually
+    /// wedging admission shut with zero real work outstanding.
+    #[test]
+    fn admission_slot_is_released_when_a_queued_job_is_cancelled() {
+        let cap = 2;
+        let (client, job_rx) = test_client_and_jobs_with_cap(cap);
+        let started = Arc::new(AtomicUsize::new(0));
+        let ran_tokens = Arc::new(AtomicUsize::new(0));
+        let started2 = started.clone();
+        let ran2 = ran_tokens.clone();
+        let handle = std::thread::spawn(move || {
+            run_worker_loop(job_rx, fake_generate(2000, started2, ran2))
+        });
+
+        // Job 1: admitted, immediately dequeued, running.
+        let (guard1, cancel1) = crate::serve::cancel_pair();
+        let rx1 = client
+            .submit(
+                vec![ChatMessage::user("hi")],
+                GenerateConfig::default(),
+                cancel1,
+            )
+            .expect("job 1 must be admitted");
+        std::thread::sleep(Duration::from_millis(30));
+
+        // Job 2: admitted (2nd of 2 permits), queued behind job 1. Cancel
+        // it immediately, client-side, WHILE it is still sitting in the
+        // queue, unprocessed.
+        let (guard2, cancel2) = crate::serve::cancel_pair();
+        let mut rx2 = client
+            .submit(
+                vec![ChatMessage::user("hi")],
+                GenerateConfig::default(),
+                cancel2,
+            )
+            .expect("job 2 must be admitted");
+        drop(guard2);
+
+        // Cap is full (2/2) right now: a 3rd submit must be rejected --
+        // proving a client-cancelled-but-still-queued job legitimately
+        // still occupies its slot before it has actually been dequeued.
+        let (_guard3, cancel3) = crate::serve::cancel_pair();
+        client
+            .submit(
+                vec![ChatMessage::user("hi")],
+                GenerateConfig::default(),
+                cancel3,
+            )
+            .expect_err("cap must still be full: job 2's slot isn't released until dequeued");
+
+        // Let job 1 finish (cancel it too) so the worker dequeues job 2
+        // next, observes its cancel flag, and emits exactly one Cancelled
+        // event for it.
+        drop(guard1);
+        match rx2.blocking_recv() {
+            Some(WorkerEvent::Cancelled) => {}
+            other => panic!("expected job 2's exactly-one Cancelled event, got {other:?}"),
+        }
+
+        // The slot must now be free: a 4th submission must succeed without
+        // needing job 1 (already finished) or anything else to release
+        // more capacity.
+        let mut admitted = false;
+        for _ in 0..50 {
+            let (_guard4, cancel4) = crate::serve::cancel_pair();
+            match client.submit(
+                vec![ChatMessage::user("hi")],
+                GenerateConfig::default(),
+                cancel4,
+            ) {
+                Ok(_rx4) => {
+                    admitted = true;
+                    break;
+                }
+                Err(_) => std::thread::sleep(Duration::from_millis(5)),
+            }
+        }
+        assert!(
+            admitted,
+            "job 2's slot must be released after its Cancelled event, not leaked"
+        );
+
+        drop(rx1);
+        drop(client);
+        handle.join().expect("worker thread must not panic");
     }
 }

--- a/crates/inference/src/serve/metal_worker.rs
+++ b/crates/inference/src/serve/metal_worker.rs
@@ -131,12 +131,21 @@ enum WorkerFailure {
 }
 
 /// Worker startup failure: either the `loader` itself returned `Err`
-/// (model/tokenizer load failure), or the worker thread exited/panicked
-/// before ever sending a readiness signal.
+/// (model/tokenizer load failure), the worker thread exited/panicked
+/// before ever sending a readiness signal, or the requested admission cap
+/// (issue #939) was outside `Semaphore::new`'s valid range.
 #[derive(Debug)]
 pub enum StartupError {
     Load(String),
     ThreadExited,
+    /// `max_pending` was `0` (admits nothing -- every request would fail
+    /// admission before any generation work could ever run) or greater
+    /// than `Semaphore::MAX_PERMITS` (`Semaphore::new` panics outright on
+    /// such a value). Caught here, before `Semaphore::new` is ever called,
+    /// as an ordinary configuration error instead of a startup panic.
+    InvalidMaxPending {
+        max_pending: usize,
+    },
 }
 
 impl std::fmt::Display for StartupError {
@@ -146,6 +155,11 @@ impl std::fmt::Display for StartupError {
             StartupError::ThreadExited => {
                 write!(f, "worker thread exited before loading finished")
             }
+            StartupError::InvalidMaxPending { max_pending } => write!(
+                f,
+                "--max-pending must be between 1 and {} (got {max_pending})",
+                Semaphore::MAX_PERMITS
+            ),
         }
     }
 }
@@ -420,6 +434,12 @@ impl MetalWorker {
         + 'static,
         max_pending: usize,
     ) -> Result<(MetalWorkerOwner, MetalWorkerClient, WorkerMetadata), StartupError> {
+        // #939: validate BEFORE `Semaphore::new`, which panics outright for
+        // `max_pending > Semaphore::MAX_PERMITS` and would otherwise let
+        // `max_pending == 0` silently build a worker that admits nothing.
+        if max_pending == 0 || max_pending > Semaphore::MAX_PERMITS {
+            return Err(StartupError::InvalidMaxPending { max_pending });
+        }
         let (job_tx, job_rx) = mpsc::unbounded_channel::<WorkerJob>();
         let admission = Arc::new(Semaphore::new(max_pending));
         let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<WorkerMetadata, String>>();
@@ -1173,6 +1193,52 @@ mod tests {
             StartupError::ThreadExited.to_string(),
             "worker thread exited before loading finished"
         );
+        assert_eq!(
+            StartupError::InvalidMaxPending { max_pending: 0 }.to_string(),
+            format!(
+                "--max-pending must be between 1 and {} (got 0)",
+                Semaphore::MAX_PERMITS
+            )
+        );
+    }
+
+    // ── #939 max_pending boundary tests ───────────────────────────────────
+    //
+    // Validated BEFORE `Semaphore::new` in `MetalWorker::spawn`, so -- like
+    // `loader_failure_before_readiness_is_reported_without_touching_a_device`
+    // above -- these never construct a real `MetalQwen35State` and need no
+    // GPU: an out-of-range `max_pending` returns `Err` before `loader` would
+    // even be called (a loader that panics if invoked proves that).
+
+    #[test]
+    fn max_pending_zero_is_rejected_before_semaphore_new() {
+        let result = MetalWorker::spawn(
+            || -> Result<(MetalQwen35State, BpeTokenizer, WorkerMetadata), String> {
+                panic!("loader must not run: max_pending=0 must be rejected first")
+            },
+            0,
+        );
+        match result {
+            Err(StartupError::InvalidMaxPending { max_pending: 0 }) => {}
+            other => panic!("expected InvalidMaxPending{{max_pending: 0}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn max_pending_above_max_permits_is_rejected_before_semaphore_new() {
+        let too_big = Semaphore::MAX_PERMITS + 1;
+        let result = MetalWorker::spawn(
+            || -> Result<(MetalQwen35State, BpeTokenizer, WorkerMetadata), String> {
+                panic!("loader must not run: max_pending above MAX_PERMITS must be rejected first")
+            },
+            too_big,
+        );
+        match result {
+            Err(StartupError::InvalidMaxPending { max_pending }) => {
+                assert_eq!(max_pending, too_big);
+            }
+            other => panic!("expected InvalidMaxPending, got {other:?}"),
+        }
     }
 
     // ── check_prompt_fits_window, ported from lattice_serve.rs's
@@ -1502,28 +1568,44 @@ mod tests {
             other => panic!("expected job 2's exactly-one Cancelled event, got {other:?}"),
         }
 
-        // The slot must now be free: a 4th submission must succeed without
-        // needing job 1 (already finished) or anything else to release
-        // more capacity.
-        let mut admitted = false;
+        // The slot must now be free -- and specifically BOTH slots, not
+        // just one. A single successful 4th admission (the original form
+        // of this assertion) does not distinguish "job 2's queued-cancel
+        // path correctly released its own permit" from "only job 1's
+        // ordinary completion released a permit and job 2's leaked": at
+        // this point job 1 has already finished (releasing one permit
+        // unconditionally, regression or not), so a leak confined to job
+        // 2's queued-cancel path still leaves exactly one usable permit --
+        // enough for one admission to spuriously succeed. Poll the
+        // semaphore's own count directly (this test module is a child of
+        // `metal_worker`, so `client.admission` -- private outside this
+        // file -- is visible here) rather than relying on dequeue timing
+        // for a second, indirect proof.
+        let mut permits_restored = false;
         for _ in 0..50 {
-            let (_guard4, cancel4) = crate::serve::cancel_pair();
-            match client.submit(
+            if client.admission.available_permits() == cap {
+                permits_restored = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(
+            permits_restored,
+            "both permits (job 1's own release AND job 2's queued-cancel release) must be \
+             free once job 2's Cancelled event has fired, got {} of {cap}",
+            client.admission.available_permits()
+        );
+
+        // And the caller-observable contract still holds: a fresh
+        // admission at full cap succeeds.
+        let (_guard4, cancel4) = crate::serve::cancel_pair();
+        client
+            .submit(
                 vec![ChatMessage::user("hi")],
                 GenerateConfig::default(),
                 cancel4,
-            ) {
-                Ok(_rx4) => {
-                    admitted = true;
-                    break;
-                }
-                Err(_) => std::thread::sleep(Duration::from_millis(5)),
-            }
-        }
-        assert!(
-            admitted,
-            "job 2's slot must be released after its Cancelled event, not leaked"
-        );
+            )
+            .expect("job 2's slot must be released after its Cancelled event, not leaked");
 
         drop(rx1);
         drop(client);

--- a/crates/inference/src/serve/metal_worker.rs
+++ b/crates/inference/src/serve/metal_worker.rs
@@ -515,7 +515,7 @@ impl MetalWorker {
 // `lattice_inference::model::qwen35::test_support`'s own doc comment for the
 // same reasoning spelled out in full).
 
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 impl WorkerJob {
     /// Reply to this job with one event, exactly as the production worker
     /// loop would via its own `job.tx.send(..)`. Returns `false` once the
@@ -534,7 +534,7 @@ impl WorkerJob {
 /// generalized so both binaries' test suites build on one shared seam
 /// instead of each rolling its own raw `mpsc::unbounded_channel::<Job>()`
 /// pair.
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 pub fn test_client_and_jobs() -> (MetalWorkerClient, mpsc::UnboundedReceiver<WorkerJob>) {
     // A large, effectively-unbounded cap: the overwhelming majority of
     // existing callers of this seam predate the #932 admission cap and
@@ -548,7 +548,7 @@ pub fn test_client_and_jobs() -> (MetalWorkerClient, mpsc::UnboundedReceiver<Wor
 /// Same as [`test_client_and_jobs`], with an explicit admission cap (issue
 /// #932) instead of the effectively-unbounded default -- for tests that
 /// exercise `MetalWorkerClient::submit`'s admission rejection itself.
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 pub fn test_client_and_jobs_with_cap(
     max_pending: usize,
 ) -> (MetalWorkerClient, mpsc::UnboundedReceiver<WorkerJob>) {
@@ -566,7 +566,7 @@ pub fn test_client_and_jobs_with_cap(
 /// `test_client_and_jobs`/`spawn_fake` (the two test-utils seams that predate
 /// issue #932) use so pre-existing callers keep seeing effectively-unbounded
 /// admission unless they opt into the `_with_cap` variant.
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 const TEST_EFFECTIVELY_UNBOUNDED_CAP: usize = 1_000_000;
 
 /// A [`MetalWorkerClient`] backed by a REAL background thread running the
@@ -585,7 +585,7 @@ const TEST_EFFECTIVELY_UNBOUNDED_CAP: usize = 1_000_000;
 /// value the real window-check computed) alongside `messages`/`cfg`, so a
 /// caller can build a faithful `GenerateOutput`/observation without
 /// re-deriving that count independently.
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 #[allow(clippy::type_complexity)]
 pub fn spawn_fake(
     context_window_policy: ContextWindowPolicy,
@@ -617,7 +617,7 @@ pub fn spawn_fake(
 /// instead of the effectively-unbounded default -- for tests that exercise
 /// `MetalWorkerClient::submit`'s admission rejection at the real-router
 /// (HTTP) layer.
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 #[allow(clippy::type_complexity)]
 pub fn spawn_fake_with_cap(
     max_pending: usize,

--- a/crates/inference/src/serve/mod.rs
+++ b/crates/inference/src/serve/mod.rs
@@ -72,6 +72,15 @@ pub enum ApiError {
     PayloadTooLarge { message: String },
     /// Server-side failure — HTTP 500.
     Internal { message: String },
+    /// Admission rejected: the shared Metal worker's outstanding-job cap
+    /// (queued + in-flight) is already full — HTTP 503 (issue #932). This is
+    /// the ONE place `MetalWorkerClient::submit` is allowed to fail
+    /// outwardly (see that method's doc comment): every other failure mode
+    /// on that path still closes the returned receiver with zero events
+    /// instead. Deliberately 503 ("server busy, try again"), not 429: this
+    /// is a shared, single-GPU capacity limit on the server as a whole, not
+    /// a per-caller rate limit — the request itself was perfectly fine.
+    ServiceUnavailable { message: String },
 }
 
 impl ApiError {
@@ -82,6 +91,7 @@ impl ApiError {
             ApiError::BadRequest { message, .. } => message,
             ApiError::PayloadTooLarge { message } => message,
             ApiError::Internal { message } => message,
+            ApiError::ServiceUnavailable { message } => message,
         }
     }
 }
@@ -134,6 +144,17 @@ impl IntoResponse for ApiError {
                     },
                 });
                 (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
+            }
+            ApiError::ServiceUnavailable { message } => {
+                let body = Json(ErrorBody {
+                    error: ErrorDetail {
+                        message,
+                        r#type: "server_error",
+                        code: "server_busy".to_string(),
+                        param: None,
+                    },
+                });
+                (StatusCode::SERVICE_UNAVAILABLE, body).into_response()
             }
         }
     }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #932.

The shared Metal worker's job queue was unbounded: any number of HTTP requests could pile up behind the single-GPU worker with no admission cap. This adds bounded admission with fail-fast rejection.

## Design

- `MetalWorkerClient` holds an `Arc<tokio::sync::Semaphore>`; `submit()` does a synchronous `try_acquire_owned()` **before** enqueueing anything. The `OwnedSemaphorePermit` is stored as a private RAII field on `WorkerJob`, so the slot releases automatically wherever the worker loop finishes with the job (`Complete`, `Rejected`, `Failed`, or dequeue-time `Cancelled`) — no per-branch cleanup to forget.
- `submit()`'s previous "never fails outwardly" contract is deliberately replaced: the ONE new failure mode is `ApiError::ServiceUnavailable` → HTTP **503** with code `server_busy`, returned before any tokenization or model work. 503 over 429 because this is shared single-GPU capacity, not a per-caller rate limit. Contract docs updated at the definition and both consumers.
- Default cap 32 (`DEFAULT_MAX_PENDING_JOBS`), overridable via `--max-pending` on both `lattice_serve` and `lattice serve` (Q4/Metal path only; the CPU backend has no shared worker queue).
- Cancellation of a still-queued job does not free the slot early (the `mpsc` queue has no removal API); it frees at the same FIFO dequeue point #832 established, via the existing `Cancelled` event. Documented in the module docs, and the no-leak property is regression-tested.

## Tests (all GPU-free, via the existing fake-worker seam)

- Cap enforcement — mutation-verified (cap raised 2→3 makes the rejection assertion fail; restored, green).
- Slot release on normal completion.
- Slot release on cancellation of a queued job (`admission_slot_is_released_when_a_queued_job_is_cancelled`).
- HTTP-level test asserting the real 503 JSON envelope through a real router + worker thread.

## Gates

- `cargo fmt --all -- --check` clean; `cargo clippy --workspace -- -D warnings` clean; feature-gated clippy (`f16,metal-gpu,serve,test-utils`, both bins + lib + tests) clean
- metal_worker unit tests 17/17; `lattice_serve` suite 37/37; `lattice` suite 133/133; whole-crate default suite 1798 passed / 0 failed / 18 ignored

bench-compare: not run — no measured bench group's code is touched (diff is serve-layer admission: `serve/metal_worker.rs`, `serve/mod.rs`, two binaries; attention/GEMM/elementwise kernels and generation loops unchanged). Runtime cost is one atomic semaphore acquire per HTTP request at admission, off the token loop. Structural unreachability disclosed per convention.