### PR TITLE
fix(inference): fail closed on missing config.json across all loaders

### DIFF
--- a/crates/inference/examples/bench_concurrent.rs
+++ b/crates/inference/examples/bench_concurrent.rs
@@ -419,12 +419,8 @@ fn run() -> Result<(), String> {
     let device_name = device.name().to_string();
 
     // --- Load config ---
-    let cfg = if model_dir.join("config.json").exists() {
-        Qwen35Config::from_config_json(&model_dir.join("config.json"))
-            .map_err(|err| format!("failed to parse config.json: {err}"))?
-    } else {
-        Qwen35Config::qwen36_27b()
-    };
+    let cfg = Qwen35Config::from_model_dir(&model_dir)
+        .map_err(|err| format!("failed to load model config.json: {err}"))?;
 
     // Validate tokenizer path by loading it (path check is not enough for corrupted files)
     let _tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_path).map_err(|err| {

--- a/crates/inference/examples/bench_gdn_decode.rs
+++ b/crates/inference/examples/bench_gdn_decode.rs
@@ -34,11 +34,7 @@ fn run() {
     let dir = std::path::Path::new(&model_dir_str);
     let tokenizer_path = std::path::Path::new(&tokenizer_dir_str).join("tokenizer.json");
 
-    let cfg = if dir.join("config.json").exists() {
-        Qwen35Config::from_config_json(&dir.join("config.json")).expect("parse config.json")
-    } else {
-        Qwen35Config::qwen36_27b()
-    };
+    let cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
 
     eprintln!(
         "[bench_gdn_decode] Loading Q4 model from {} ...",

--- a/crates/inference/examples/bench_gdn_state.rs
+++ b/crates/inference/examples/bench_gdn_state.rs
@@ -83,11 +83,7 @@ fn run() {
     );
 
     let mut state: MetalQwen35State = if is_q4 {
-        let cfg = if dir.join("config.json").exists() {
-            Qwen35Config::from_config_json(&dir.join("config.json")).expect("parse config.json")
-        } else {
-            Qwen35Config::qwen35_0_8b()
-        };
+        let cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
         let tokenizer_path = dir.join("tokenizer.json");
         MetalQwen35State::from_q4_dir(dir, &tokenizer_path, &cfg, 512)
             .expect("from_q4_dir failed — MSL compile or weight load error")

--- a/crates/inference/examples/bench_persistent_state.rs
+++ b/crates/inference/examples/bench_persistent_state.rs
@@ -40,11 +40,7 @@ fn run() {
     let dir = std::path::Path::new(&model_dir_str);
     let tokenizer_path = std::path::Path::new(&tokenizer_dir_str).join("tokenizer.json");
 
-    let cfg = if dir.join("config.json").exists() {
-        Qwen35Config::from_config_json(&dir.join("config.json")).expect("parse config.json")
-    } else {
-        Qwen35Config::qwen36_27b()
-    };
+    let cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
 
     eprintln!("[bench] Loading Q4 model from {} ...", dir.display());
     let t_load = Instant::now();

--- a/crates/inference/examples/bench_pruning.rs
+++ b/crates/inference/examples/bench_pruning.rs
@@ -32,11 +32,7 @@ fn run() {
     let dir = std::path::Path::new(&model_dir_str);
     let tokenizer_path = std::path::Path::new(&tokenizer_dir_str).join("tokenizer.json");
 
-    let base_cfg = if dir.join("config.json").exists() {
-        Qwen35Config::from_config_json(&dir.join("config.json")).expect("parse config.json")
-    } else {
-        Qwen35Config::qwen36_27b()
-    };
+    let base_cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
 
     let num_layers = base_cfg.num_hidden_layers;
     eprintln!("[bench_pruning] Model: {num_layers}-layer Qwen3.6-27B Q4");

--- a/crates/inference/examples/bench_q4_prefill.rs
+++ b/crates/inference/examples/bench_q4_prefill.rs
@@ -31,11 +31,7 @@ fn run() {
     let dir = std::path::Path::new(&model_dir_str);
     let tokenizer_path = std::path::Path::new(&tokenizer_dir_str).join("tokenizer.json");
 
-    let cfg = if dir.join("config.json").exists() {
-        Qwen35Config::from_config_json(&dir.join("config.json")).expect("parse config.json")
-    } else {
-        Qwen35Config::qwen36_27b()
-    };
+    let cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
 
     eprintln!("[bench] Loading Q4 model from {} ...", dir.display());
     let t0 = Instant::now();

--- a/crates/inference/examples/bench_quality.rs
+++ b/crates/inference/examples/bench_quality.rs
@@ -42,11 +42,7 @@ fn run() {
     let dir = std::path::Path::new(&model_dir_str);
     let tokenizer_path = std::path::Path::new(&tokenizer_dir_str).join("tokenizer.json");
 
-    let base_cfg = if dir.join("config.json").exists() {
-        Qwen35Config::from_config_json(&dir.join("config.json")).expect("parse config.json")
-    } else {
-        Qwen35Config::qwen36_27b()
-    };
+    let base_cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
     let num_layers = base_cfg.num_hidden_layers;
 
     let tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_path).expect("load tokenizer");

--- a/crates/inference/examples/bench_stability.rs
+++ b/crates/inference/examples/bench_stability.rs
@@ -52,11 +52,7 @@ fn run() {
     let dir = std::path::Path::new(&model_dir_str);
     let tokenizer_path = std::path::Path::new(&tokenizer_dir_str).join("tokenizer.json");
 
-    let cfg = if dir.join("config.json").exists() {
-        Qwen35Config::from_config_json(&dir.join("config.json")).expect("parse config.json")
-    } else {
-        Qwen35Config::qwen36_27b()
-    };
+    let cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
 
     let tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_path).expect("load tokenizer");
 

--- a/crates/inference/examples/decode_profile.rs
+++ b/crates/inference/examples/decode_profile.rs
@@ -58,11 +58,7 @@ fn run() {
 
     let t_load = Instant::now();
     let mut state: MetalQwen35State = if is_q4 {
-        let cfg = if dir.join("config.json").exists() {
-            Qwen35Config::from_config_json(&dir.join("config.json")).expect("parse config.json")
-        } else {
-            Qwen35Config::qwen35_0_8b()
-        };
+        let cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
         let tokenizer_path = dir.join("tokenizer.json");
         MetalQwen35State::from_q4_dir(dir, &tokenizer_path, &cfg, 512)
             .expect("from_q4_dir failed — MSL compile or weight load error")

--- a/crates/inference/src/bin/bench_decode_ab.rs
+++ b/crates/inference/src/bin/bench_decode_ab.rs
@@ -80,12 +80,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let tokenizer: BpeTokenizer;
 
     if is_q4 {
-        let cfg = if dir.join("config.json").exists() {
-            Qwen35Config::from_config_json(&dir.join("config.json"))
-                .map_err(|e| format!("config.json parse: {e}"))?
-        } else {
-            Qwen35Config::qwen35_0_8b()
-        };
+        let cfg =
+            Qwen35Config::from_model_dir(dir).map_err(|e| format!("config.json load: {e}"))?;
         metal =
             MetalQwen35State::from_q4_dir(dir, &tokenizer_dir.join("tokenizer.json"), &cfg, 4096)
                 .map_err(|e| format!("Metal Q4 init: {e}"))?;

--- a/crates/inference/src/bin/bench_decode_slopefit.rs
+++ b/crates/inference/src/bin/bench_decode_slopefit.rs
@@ -164,12 +164,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut metal: MetalQwen35State;
 
     if is_q4 {
-        let cfg = if dir.join("config.json").exists() {
-            Qwen35Config::from_config_json(&dir.join("config.json"))
-                .map_err(|e| format!("config.json parse: {e}"))?
-        } else {
-            Qwen35Config::qwen35_0_8b()
-        };
+        let cfg =
+            Qwen35Config::from_model_dir(dir).map_err(|e| format!("config.json load: {e}"))?;
         metal = MetalQwen35State::from_q4_dir(
             dir,
             &tokenizer_dir.join("tokenizer.json"),

--- a/crates/inference/src/bin/bench_lora_mixture.rs
+++ b/crates/inference/src/bin/bench_lora_mixture.rs
@@ -177,12 +177,7 @@ fn run_gpu_decode_bench(
 
     eprintln!("[bench_lora_mixture] loading model from {model_dir_str}");
 
-    let cfg = if dir.join("config.json").exists() {
-        Qwen35Config::from_config_json(&dir.join("config.json"))
-            .map_err(|e| format!("config.json parse: {e}"))?
-    } else {
-        Qwen35Config::qwen35_0_8b()
-    };
+    let cfg = Qwen35Config::from_model_dir(dir).map_err(|e| format!("config.json load: {e}"))?;
 
     let mut metal = MetalQwen35State::from_q4_dir(dir, &tokenizer_path, &cfg, 512)
         .map_err(|e| format!("Metal Q4 init: {e}"))?;

--- a/crates/inference/src/bin/chat_metal.rs
+++ b/crates/inference/src/bin/chat_metal.rs
@@ -763,13 +763,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 "[chat_metal] Detected Q4 model directory: {}",
                 dir.display()
             );
-            let cfg = if dir.join("config.json").exists() {
-                Qwen35Config::from_config_json(&dir.join("config.json"))
-                    .map_err(|e| format!("failed to parse config.json: {e}"))?
-            } else {
-                eprintln!("[chat_metal] No config.json; using qwen36_27b preset");
-                Qwen35Config::qwen36_27b()
-            };
+            let cfg = Qwen35Config::from_model_dir(dir)
+                .map_err(|e| format!("failed to load config.json: {e}"))?;
             eprintln!("[chat_metal] Loading Q4 model...");
             let t0 = std::time::Instant::now();
             metal = MetalQwen35State::from_q4_dir(

--- a/crates/inference/src/bin/eval_perplexity.rs
+++ b/crates/inference/src/bin/eval_perplexity.rs
@@ -498,13 +498,8 @@ fn tokenize_with(
 }
 
 fn load_cfg_for_q4(dir: &std::path::Path) -> Result<Qwen35Config, ExitCode> {
-    let config_path = dir.join("config.json");
-    if !config_path.exists() {
-        eprintln!("ERROR: Q4 dir {} is missing config.json", dir.display());
-        return Err(ExitCode::FAILURE);
-    }
-    Qwen35Config::from_config_json(&config_path).map_err(|e| {
-        eprintln!("ERROR: failed to parse {}: {e}", config_path.display());
+    Qwen35Config::from_model_dir(dir).map_err(|e| {
+        eprintln!("ERROR: {e}");
         ExitCode::FAILURE
     })
 }
@@ -765,5 +760,37 @@ mod tests {
             100,
             "--max-tokens cap must still apply after uncap"
         );
+    }
+
+    // -- #923: load_cfg_for_q4 is fail-closed on a missing config.json ----
+    //
+    // This binary was already fail-closed before the fix (unlike the other
+    // three loaders named in the issue), just via its own inline check
+    // duplicating the same policy. It now goes through the single shared
+    // `Qwen35Config::from_model_dir` helper instead of its own copy.
+    // Reverting this call site back to the inline duplicate makes this test
+    // fail only if that duplicate ever silently regresses to a preset --
+    // the real value here is deleting the duplicate, verified by keeping
+    // the observable behavior (error on missing config.json) pinned.
+
+    #[test]
+    fn load_cfg_for_q4_errors_on_missing_config_json() {
+        let dir = std::env::temp_dir().join(format!(
+            "lattice_eval_ppl_q4_no_config_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("test setup: create model dir");
+        // Deliberately no config.json.
+
+        let result = load_cfg_for_q4(&dir);
+        assert!(
+            result.is_err(),
+            "a Q4 dir with no config.json must be a hard error, not a guessed preset"
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -893,29 +893,14 @@ mod doctor {
 
         let (placement, cfg, inventory) = match format {
             crate::backend::ModelFormat::Safetensors => {
-                let config_path = model_dir.join("config.json");
-                let cfg = if config_path.exists() {
-                    Qwen35Config::from_config_json(&config_path)
-                        .map_err(|e| format!("config.json parse failed: {e}"))?
-                } else {
-                    // Mirrors `Qwen35Model::from_safetensors`'s own fallback.
-                    Qwen35Config::qwen35_2b()
-                };
+                let cfg = Qwen35Config::from_model_dir(model_dir)
+                    .map_err(|e| format!("config.json load failed: {e}"))?;
                 let inventory = inspect_safetensors_dir(model_dir, &cfg)?;
                 (Placement::Cpu, cfg, inventory)
             }
             crate::backend::ModelFormat::Q4 => {
-                let config_path = model_dir.join("config.json");
-                let cfg = if config_path.exists() {
-                    Qwen35Config::from_config_json(&config_path)
-                        .map_err(|e| format!("config.json parse failed: {e}"))?
-                } else {
-                    // Mirrors `load_q4_config`'s own fallback (that function
-                    // is `metal-gpu`-only; `doctor` must work without the
-                    // feature too, so the two-line fallback is duplicated
-                    // here rather than shared across the cfg-gate).
-                    Qwen35Config::qwen36_27b()
-                };
+                let cfg = Qwen35Config::from_model_dir(model_dir)
+                    .map_err(|e| format!("config.json load failed: {e}"))?;
                 let inventory = inspect_q4_dir(model_dir, &cfg)?;
                 (Placement::Metal, cfg, inventory)
             }
@@ -2124,6 +2109,62 @@ mod doctor {
             fs::remove_dir_all(&dir).ok();
         }
 
+        // ---- #923: missing config.json is a hard, uniform error -----------
+        //
+        // Before the fix, this Safetensors branch silently substituted
+        // `Qwen35Config::qwen35_2b()` and the Q4 branch silently substituted
+        // `Qwen35Config::qwen36_27b()` -- two different guessed presets, and
+        // neither told the caller a config.json was even missing. Both
+        // branches now go through the same `Qwen35Config::from_model_dir`
+        // fail-closed helper as every other loader in this crate. Reverting
+        // either branch's call site back to the old exists-then-preset
+        // pattern makes its half of this test fail (it would return `Ok`
+        // instead of an error naming `config.json`).
+
+        #[test]
+        fn build_report_safetensors_missing_config_json_is_hard_error() {
+            let dir = tempdir("report-safetensors-no-config");
+            let cfg = Qwen35Config::qwen35_0_8b();
+            let tensors = required_tensor_fixture(&cfg);
+            let refs: Vec<(&str, &str, u64, u64)> = tensors
+                .iter()
+                .map(|(n, d, s, e)| (n.as_str(), d.as_str(), *s, *e))
+                .collect();
+            write_fake_safetensors(&dir.join("model.safetensors"), &refs);
+            // Deliberately no config.json and no tokenizer.json.
+
+            let err = build_report(&dir, None, None, Some(1u64 << 40)).unwrap_err();
+            assert!(
+                err.contains("config.json"),
+                "error must name the missing config.json, not a guessed preset: {err}"
+            );
+            fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn build_report_q4_missing_config_json_is_hard_error() {
+            let dir = tempdir("report-q4-no-config");
+            write_fake_q4_file(&dir.join("embed.q4"), 2, &[32], 32, 5);
+            write_fake_q4_file(&dir.join("q_proj.q4"), 2, &[32], 32, 3);
+            let index = serde_json::json!([
+                {"name": "model.language_model.embed_tokens.weight", "file": "embed.q4", "quantized": true, "shape": [32], "numel": 32},
+                {"name": "model.language_model.layers.0.self_attn.q_proj.weight", "file": "q_proj.q4", "quantized": true, "shape": [32], "numel": 32},
+            ]);
+            fs::write(
+                dir.join("quantize_index.json"),
+                serde_json::to_vec(&index).unwrap(),
+            )
+            .unwrap();
+            // Deliberately no config.json.
+
+            let err = build_report(&dir, None, None, Some(1u64 << 40)).unwrap_err();
+            assert!(
+                err.contains("config.json"),
+                "error must name the missing config.json, not a guessed preset: {err}"
+            );
+            fs::remove_dir_all(&dir).ok();
+        }
+
         // ---- DoctorReport Display: MTP disclosure --------------------------
 
         fn minimal_doctor_report(has_mtp_tensors: bool) -> DoctorReport {
@@ -2180,25 +2221,17 @@ mod doctor {
 // chat subcommand
 // ---------------------------------------------------------------------------
 
-/// Load `config.json` for a Q4 directory, falling back to the Qwen3.6-27B
-/// default config (matching `chat_metal.rs` / `lattice_serve.rs`) when the
-/// directory has none, with a visible warning so a missing config.json is
-/// never silently misinterpreted as intentional.
+/// Load `config.json` for a Q4 directory, via the single shared
+/// config-resolution policy (`Qwen35Config::from_model_dir`, #923) used by
+/// every loader in this crate: a missing `config.json` is a hard,
+/// descriptive error naming the directory, never a silently-substituted
+/// architecture preset.
 #[cfg(feature = "metal-gpu")]
 fn load_q4_config(
     dir: &std::path::Path,
 ) -> Result<lattice_inference::model::qwen35_config::Qwen35Config, String> {
-    let config_path = dir.join("config.json");
-    if config_path.exists() {
-        lattice_inference::model::qwen35_config::Qwen35Config::from_config_json(&config_path)
-            .map_err(|e| format!("config.json parse failed: {e}"))
-    } else {
-        eprintln!(
-            "Warning: {} has no config.json; falling back to the Qwen3.6-27B default config.",
-            dir.display()
-        );
-        Ok(lattice_inference::model::qwen35_config::Qwen35Config::qwen36_27b())
-    }
+    lattice_inference::model::qwen35_config::Qwen35Config::from_model_dir(dir)
+        .map_err(|e| format!("config.json load failed: {e}"))
 }
 
 /// Metal-GPU chat backend: owns a `MetalQwen35State` plus the tokenizer and

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -986,18 +986,9 @@ mod imp {
 
         match format {
             ModelFormat::Q4 => {
-                let has_config_json = model_dir.join("config.json").exists();
-                let cfg = if has_config_json {
-                    Qwen35Config::from_config_json(&model_dir.join("config.json"))
-                        .map_err(|e| format!("config.json parse failed: {e}"))?
-                } else {
-                    Qwen35Config::qwen36_27b()
-                };
-                let requested_context = if has_config_json {
-                    model_context_from_config(Some(&cfg))
-                } else {
-                    model_context_from_config(None)
-                };
+                let cfg = Qwen35Config::from_model_dir(model_dir)
+                    .map_err(|e| format!("config.json load failed: {e}"))?;
+                let requested_context = model_context_from_config(Some(&cfg));
                 let metal = MetalQwen35State::from_q4_dir(
                     model_dir,
                     tokenizer_path,

--- a/crates/inference/src/model/qwen35/model.rs
+++ b/crates/inference/src/model/qwen35/model.rs
@@ -34,12 +34,7 @@ impl Qwen35Model {
             )));
         };
 
-        let config_path = path.join("config.json");
-        let config = if config_path.exists() {
-            Qwen35Config::from_config_json(&config_path)?
-        } else {
-            Qwen35Config::qwen35_2b()
-        };
+        let config = Qwen35Config::from_model_dir(path)?;
 
         validate_required_tensor_names(source.as_mut(), &config)?;
 

--- a/crates/inference/src/model/qwen35/tests.rs
+++ b/crates/inference/src/model/qwen35/tests.rs
@@ -871,3 +871,51 @@ mod lora_serving {
         );
     }
 }
+
+// -- #923: from_safetensors' config resolution is fail-closed --------
+//
+// Before the fix, a config-less directory silently loaded under the
+// hardcoded `qwen35_2b()` preset here -- the one *silent* fallback among
+// the issue's four divergent loaders, since this is the library path
+// every binary ultimately calls through. It now delegates to the same
+// `Qwen35Config::from_model_dir` fail-closed helper as every other
+// loader in the crate. Reverting this call site back to the old
+// exists-then-preset pattern makes this test fail (it would return `Ok`
+// instead of an error naming `config.json`).
+
+fn write_metadata_only_safetensors(path: &std::path::Path) {
+    // No tensors, just a metadata-only header -- from_safetensors
+    // resolves `config.json` before validating required tensor names,
+    // so a minimally-openable safetensors file is enough to reach (and
+    // isolate) the config-resolution step under test.
+    let header = r#"{"__metadata__":{"format":"pt"}}"#;
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(header.as_bytes());
+    std::fs::write(path, bytes).expect("test setup: write metadata-only safetensors file");
+}
+
+#[test]
+fn from_safetensors_missing_config_json_is_hard_error() {
+    let dir = std::env::temp_dir().join(format!(
+        "lattice_from_safetensors_no_config_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("test setup: create model dir");
+    write_metadata_only_safetensors(&dir.join("model.safetensors"));
+    // Deliberately no config.json.
+
+    let Err(err) = Qwen35Model::from_safetensors(&dir) else {
+        panic!("a directory with no config.json must be a hard error")
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("config.json"),
+        "error must name the missing config.json, not a guessed preset: {msg}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -354,6 +354,34 @@ impl Qwen35Config {
         Self::from_config_json_str(&json)
     }
 
+    /// Resolve the architecture config for a model directory, requiring a
+    /// real `config.json`.
+    ///
+    /// This is the single fallback policy for every loader in this crate
+    /// (library and binaries alike; see issue #923). Every supported Qwen
+    /// checkpoint ships a `config.json` describing its exact geometry, so a
+    /// missing file is a hard, descriptive error naming the directory rather
+    /// than a silently-substituted architecture preset. Before this helper
+    /// existed, independent call sites each guessed a different preset
+    /// (`qwen35_2b`, `qwen36_27b`, `qwen35_0_8b`) on a missing file — pointing
+    /// the same config-less directory at different tools silently produced
+    /// different model geometries, and the wrong-preset case failed later at
+    /// tensor validation with an error that named the weights, not the
+    /// missing config. Callers that need directory-not-found context in a
+    /// different error type (e.g. the CLI binaries' `String` errors) should
+    /// wrap this with `.map_err(...)`, not reimplement the existence check.
+    pub fn from_model_dir(dir: &Path) -> Result<Self, InferenceError> {
+        let config_path = dir.join("config.json");
+        if !config_path.exists() {
+            return Err(InferenceError::ModelNotFound(format!(
+                "missing config.json in {} -- every supported Qwen checkpoint ships one; \
+                 no architecture preset is inferred from a config-less directory",
+                dir.display()
+            )));
+        }
+        Self::from_config_json(&config_path)
+    }
+
     /// Parse HF config.json text into a `Qwen35Config`.
     pub fn from_config_json_str(json: &str) -> Result<Self, InferenceError> {
         let parsed: HfQwenConfigFile = serde_json::from_str(json)
@@ -1743,6 +1771,55 @@ mod tests {
             force_close_think(Some(10), true, false, 0, Some(close_id)),
             None,
             "must not force when zero tokens generated"
+        );
+    }
+
+    // -- from_model_dir: the single shared config-resolution policy (#923) --
+
+    #[test]
+    fn from_model_dir_errors_on_missing_config_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Directory exists but has no config.json at all.
+        let err = Qwen35Config::from_model_dir(tmp.path())
+            .expect_err("a directory with no config.json must be a hard error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("config.json"),
+            "error must name the missing file: {msg}"
+        );
+        assert!(
+            msg.contains(&tmp.path().display().to_string()),
+            "error must name the offending directory: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_model_dir_loads_a_real_config_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let json = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/qwen35_0_8b_config.json"
+        ));
+        std::fs::write(tmp.path().join("config.json"), json).unwrap();
+
+        let cfg = Qwen35Config::from_model_dir(tmp.path())
+            .expect("a directory with a valid config.json must load");
+        assert_eq!(
+            cfg.hidden_size, 1024,
+            "must parse the real 0.8B config, not a preset"
+        );
+    }
+
+    #[test]
+    fn from_model_dir_propagates_a_malformed_config_json_parse_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("config.json"), "not valid json {{{").unwrap();
+
+        let err = Qwen35Config::from_model_dir(tmp.path())
+            .expect_err("malformed config.json must still be a parse error, not a preset");
+        assert!(
+            err.to_string().contains("config.json") || err.to_string().contains("invalid Qwen"),
+            "error must reflect the parse failure: {err}"
         );
     }
 }

--- a/crates/inference/tests/examples_no_preset_fallback.rs
+++ b/crates/inference/tests/examples_no_preset_fallback.rs
@@ -1,0 +1,41 @@
+//! Regression guard for #923/#942 (round 2): every example binary that loads a
+//! Q4 model directory must resolve its architecture config via
+//! `Qwen35Config::from_model_dir`, which fails closed on a missing
+//! `config.json` instead of silently substituting a guessed preset.
+//!
+//! #942 round 1 fixed the library loaders but left nine example `main()`s on
+//! the old `dir.join("config.json").exists() { from_config_json } else {
+//! qwenXX_preset() }` pattern — a sibling-invocation-path miss of the exact
+//! class the fix was meant to close. This test greps `examples/*.rs` for the
+//! anti-pattern so a reintroduction fails CI instead of silently reappearing.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn examples_never_reintroduce_config_json_preset_fallback() {
+    let examples_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples");
+    let mut offenders = Vec::new();
+
+    for entry in fs::read_dir(&examples_dir).expect("read crates/inference/examples") {
+        let entry = entry.expect("read dir entry");
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let src = fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+        if src.contains("join(\"config.json\").exists()") {
+            offenders.push(path.display().to_string());
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "example loader(s) reintroduced the config.json-exists()-then-preset \
+         silent fallback (the class of bug fixed in #923/#942): {offenders:?}. \
+         Route model-directory config loading through \
+         Qwen35Config::from_model_dir(dir), which fails closed on a missing \
+         config.json instead of guessing an architecture preset."
+    );
+}


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Closes #923.

## What

Nine call sites across the crate silently substituted a hard-coded architecture preset when a model directory had no `config.json`, each with its own (sometimes divergent) preset choice. A wrong-preset load still failed, but later and misleadingly: at tensor-shape validation, naming the weights file instead of the missing config.

This PR makes the policy fail-closed everywhere via one shared helper, `Qwen35Config::from_model_dir(dir)`: missing `config.json` is a hard `ModelNotFound` error naming the offending directory. Rationale: every supported Qwen checkpoint (0.8B, 2B, 27B, 35B-A3B) ships a real `config.json`; no existing test relied on the fallback (all pre-existing tests write a `config.json` fixture first); the issue's own suggested fix names this option.

Sites unified: `qwen35/model.rs` (`from_safetensors`), `chat_metal.rs`, `lattice_serve.rs` (+ dead-branch cleanup), `bench_decode_ab.rs`, `lattice.rs` (3 sites, incl. doctor's `build_report`), `bench_decode_slopefit.rs`, `bench_lora_mixture.rs`, `eval_perplexity.rs` (dedup of an already-fail-closed site).

## Testing

- New tests: `from_model_dir` unit tests (present/missing/malformed config), a `from_safetensors` missing-config hard-error test, and two `lattice doctor` tests including `build_report_safetensors_missing_config_json_is_hard_error`.
- Mutation-verified: reverting `build_report`'s call site to the old `exists() { from_config_json } else { qwen35_2b() }` pattern makes the doctor test fail; restored and reran clean.
- Full `--features f16` lib suite: 1807 passed, 0 failed. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean.

## Bench

No hot-path change: this touches model-load config resolution only (one extra `Path::exists` check at load time). bench-compare not applicable (structural unreachability from decode/prefill loops).