### PR TITLE
perf(tune): vectorize backward-tape hot loops (#737 stage 1)

### DIFF
--- a/crates/inference/src/backward/ops.rs
+++ b/crates/inference/src/backward/ops.rs
@@ -50,21 +50,19 @@ pub fn cross_entropy_backward(
 /// computes dL/dx = W^T g.
 ///
 /// `w` is row-major [d_out, d_in].  `g` is [d_out].  Returns [d_in].
+///
+/// Reuses the same GEMM dispatch the forward path uses (`matmul_into`, m=1):
+/// `dx = g @ W` treating `g` as a `[1, d_out]` row and `w` as `[d_out, d_in]`
+/// row-major — Accelerate/AMX on macOS, SIMD-tiled fallback elsewhere. This is
+/// the single largest scalar loop in the tape (`d_out` reaches vocab_size at
+/// the LM head), so dispatching it through the same kernel as the forward
+/// pass is the primary lever in #737 stage 1.
 pub fn linear_vjp(w: &[f32], g: &[f32], d_in: usize, d_out: usize) -> Vec<f32> {
     assert_eq!(w.len(), d_out * d_in);
     assert_eq!(g.len(), d_out);
 
     let mut dx = vec![0.0f32; d_in];
-    for i in 0..d_out {
-        let gi = g[i];
-        if gi == 0.0 {
-            continue;
-        }
-        let row = &w[i * d_in..(i + 1) * d_in];
-        for (j, &wij) in row.iter().enumerate() {
-            dx[j] += wij * gi;
-        }
-    }
+    crate::forward::cpu::matmul_into(g, w, &mut dx, 1, d_out, d_in);
     dx
 }
 
@@ -93,7 +91,8 @@ pub fn lora_vjp(
     assert_eq!(x.len(), d_in);
     assert_eq!(h.len(), rank);
 
-    // grad_B[i, r] = scale * g[i] * h[r]
+    // grad_B[i, r] = scale * g[i] * h[r]  (outer product; O(d_out*rank), already
+    // a contiguous auto-vectorizable broadcast-multiply — left as a plain loop).
     let mut grad_b = vec![0.0f32; d_out * rank];
     for i in 0..d_out {
         for r in 0..rank {
@@ -101,17 +100,13 @@ pub fn lora_vjp(
         }
     }
 
-    // bt_g[r] = B^T g = Σ_i B[i,r] * g[i]
+    // bt_g[r] = B^T g = Σ_i B[i,r] * g[i]. Same matmul-transpose-accumulation
+    // shape as `linear_vjp`: B is [d_out, rank] row-major, g is [1, d_out] ⇒
+    // bt_g = g @ B via the shared GEMM dispatch (m=1, k=d_out, n=rank).
     let mut bt_g = vec![0.0f32; rank];
-    for r in 0..rank {
-        let mut acc = 0.0f32;
-        for i in 0..d_out {
-            acc += b[i * rank + r] * g[i];
-        }
-        bt_g[r] = acc;
-    }
+    crate::forward::cpu::matmul_into(g, b, &mut bt_g, 1, d_out, rank);
 
-    // grad_A[r, j] = scale * bt_g[r] * x[j]
+    // grad_A[r, j] = scale * bt_g[r] * x[j]  (outer product; same shape as grad_B).
     let mut grad_a = vec![0.0f32; rank * d_in];
     for r in 0..rank {
         for j in 0..d_in {
@@ -119,15 +114,11 @@ pub fn lora_vjp(
         }
     }
 
-    // dx = A^T (bt_g): dx[j] = scale * Σ_r A[r,j] * bt_g[r]
+    // dx = A^T (bt_g): dx[j] = scale * Σ_r A[r,j] * bt_g[r]. A is [rank, d_in]
+    // row-major ⇒ dx = (scale*bt_g) @ A via the shared GEMM dispatch.
+    let scaled_bt_g: Vec<f32> = bt_g.iter().map(|&v| v * scale).collect();
     let mut dx = vec![0.0f32; d_in];
-    for r in 0..rank {
-        let scaled_bt_g = scale * bt_g[r];
-        let row = &a[r * d_in..(r + 1) * d_in];
-        for (j, &aij) in row.iter().enumerate() {
-            dx[j] += aij * scaled_bt_g;
-        }
-    }
+    crate::forward::cpu::matmul_into(&scaled_bt_g, a, &mut dx, 1, rank, d_in);
 
     (grad_b, grad_a, dx)
 }
@@ -218,7 +209,105 @@ pub fn swiglu_backward(
     assert_eq!(w_gate.len(), inter * hidden);
     assert_eq!(w_up.len(), inter * hidden);
 
-    // dL/dm = W_down^T dy   [inter]
+    // dL/dm = W_down^T dy   [inter]. W_down is [hidden, inter] row-major, dy is
+    // [1, hidden] ⇒ dm = dy @ W_down via the shared GEMM dispatch (matches the
+    // forward `swiglu_forward`'s own down-proj matmul shape).
+    let mut dm = vec![0.0f32; inter];
+    crate::forward::cpu::matmul_into(dy, w_down, &mut dm, 1, hidden, inter);
+
+    // Elementwise SwiGLU-gate backward: silu'(gate) and the up/gate splits.
+    // O(inter), dominated by `exp()` (not a reduction) — left as a scan.
+    let mut d_up = vec![0.0f32; inter];
+    let mut d_gate_pre = vec![0.0f32; inter];
+    for j in 0..inter {
+        let a = gate_pre[j];
+        let sigma_a = 1.0 / (1.0 + (-a).exp());
+        let silu_a = a * sigma_a;
+        let up_j = up_pre[j];
+        let dm_j = dm[j];
+
+        d_up[j] = dm_j * silu_a;
+        let d_s = dm_j * up_j;
+        let silu_prime = sigma_a + a * sigma_a * (1.0 - sigma_a);
+        d_gate_pre[j] = d_s * silu_prime;
+    }
+
+    // dx = W_up^T d_up + W_gate^T d_gate_pre. Both W_up/W_gate are [inter, hidden]
+    // row-major, so each term is a `[1, inter] @ [inter, hidden]` GEMM — same
+    // matmul-transpose-accumulation shape as `dm` above.
+    let mut dx = vec![0.0f32; hidden];
+    crate::forward::cpu::matmul_into(&d_up, w_up, &mut dx, 1, inter, hidden);
+    let mut dx_gate = vec![0.0f32; hidden];
+    crate::forward::cpu::matmul_into(&d_gate_pre, w_gate, &mut dx_gate, 1, inter, hidden);
+    for (dxi, dgi) in dx.iter_mut().zip(dx_gate.iter()) {
+        *dxi += *dgi;
+    }
+
+    (dx, dm)
+}
+
+// ---------------------------------------------------------------------------
+// Scalar reference oracles (#737 stage 1) — the pre-vectorization loops,
+// preserved verbatim behind `#[cfg(test)]` so the GEMM-dispatched versions
+// above can be parity-checked against a known-naive accumulation order.
+// f32 sums are NOT reorder-invariant around nonlinearities, but these are
+// pure linear reductions, so parity is expected to hold to a tight tolerance
+// (not bit-exact — see `PARITY_TOL` below).
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+fn linear_vjp_scalar(w: &[f32], g: &[f32], d_in: usize, d_out: usize) -> Vec<f32> {
+    let mut dx = vec![0.0f32; d_in];
+    for i in 0..d_out {
+        let gi = g[i];
+        let row = &w[i * d_in..(i + 1) * d_in];
+        for (j, &wij) in row.iter().enumerate() {
+            dx[j] += wij * gi;
+        }
+    }
+    dx
+}
+
+#[cfg(test)]
+fn lora_bt_g_dx_scalar(
+    g: &[f32],
+    a: &[f32],
+    b: &[f32],
+    rank: usize,
+    d_in: usize,
+    d_out: usize,
+    scale: f32,
+) -> (Vec<f32>, Vec<f32>) {
+    let mut bt_g = vec![0.0f32; rank];
+    for r in 0..rank {
+        let mut acc = 0.0f32;
+        for i in 0..d_out {
+            acc += b[i * rank + r] * g[i];
+        }
+        bt_g[r] = acc;
+    }
+    let mut dx = vec![0.0f32; d_in];
+    for r in 0..rank {
+        let scaled_bt_g = scale * bt_g[r];
+        let row = &a[r * d_in..(r + 1) * d_in];
+        for (j, &aij) in row.iter().enumerate() {
+            dx[j] += aij * scaled_bt_g;
+        }
+    }
+    (bt_g, dx)
+}
+
+#[cfg(test)]
+fn swiglu_backward_scalar(
+    dy: &[f32],
+    gate_pre: &[f32],
+    up_pre: &[f32],
+    w_down: &[f32],
+    w_gate: &[f32],
+    w_up: &[f32],
+    hidden: usize,
+    inter: usize,
+) -> (Vec<f32>, Vec<f32>) {
     let mut dm = vec![0.0f32; inter];
     for j in 0..inter {
         let mut acc = 0.0f32;
@@ -611,5 +700,121 @@ mod tests {
         let err = rel_err(&analytic_dx, &fd);
         eprintln!("swiglu_backward rel_err={err:.2e}");
         assert!(err < TOL, "swiglu rel_err {err:.2e} >= {TOL:.2e}");
+    }
+
+    // -------------------------------------------------------------------
+    // GEMM-dispatch vs scalar-reference parity (#737 stage 1).
+    //
+    // The gradcheck tests above already prove correctness against finite
+    // differences at small sizes. These tests additionally prove the
+    // vectorized (matmul_into-dispatched) path agrees with the exact
+    // pre-vectorization scalar accumulation order at sizes representative
+    // of real backward-tape shapes (non-multiple-of-lane-width dims
+    // included on purpose, to exercise scalar remainder paths in the SIMD
+    // kernels). Tolerance is not bit-exact: BLAS/SIMD reassociate the sum,
+    // which is not f32-exact around a pure linear reduction, but should
+    // still agree to a tight relative tolerance.
+    // -------------------------------------------------------------------
+
+    const PARITY_TOL: f64 = 1e-4;
+
+    /// Deterministic xorshift64 float generator so parity tests are
+    /// reproducible without pulling in a `rand` dev-dependency here.
+    fn xorshift_fill(seed: u64, n: usize, amp: f32) -> Vec<f32> {
+        let mut state = seed | 1;
+        (0..n)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                ((state >> 32) as u32 as f32 / u32::MAX as f32 * 2.0 - 1.0) * amp
+            })
+            .collect()
+    }
+
+    #[test]
+    fn linear_vjp_parity_vs_scalar() {
+        // Non-power-of-2 dims on purpose: exercises the scalar remainder tail
+        // in the SIMD/BLAS dispatch, not just the fast-path multiple-of-lane case.
+        let d_in = 517;
+        let d_out = 251;
+        let w = xorshift_fill(1, d_out * d_in, 0.5);
+        let g = xorshift_fill(2, d_out, 1.0);
+
+        let vectorized = linear_vjp(&w, &g, d_in, d_out);
+        let scalar = linear_vjp_scalar(&w, &g, d_in, d_out);
+
+        let err = rel_err(&vectorized, &scalar);
+        eprintln!("linear_vjp parity rel_err={err:.2e}");
+        assert!(
+            err < PARITY_TOL,
+            "linear_vjp vectorized vs scalar rel_err {err:.2e} >= {PARITY_TOL:.2e}"
+        );
+    }
+
+    #[test]
+    fn lora_vjp_parity_vs_scalar() {
+        let rank = 11;
+        let d_in = 199;
+        let d_out = 257;
+        let scale = 0.37f32;
+
+        let g = xorshift_fill(3, d_out, 1.0);
+        let x = xorshift_fill(4, d_in, 0.5);
+        let a = xorshift_fill(5, rank * d_in, 0.3);
+        let b = xorshift_fill(6, d_out * rank, 0.3);
+        let h = xorshift_fill(7, rank, 0.4);
+
+        let (_grad_b, _grad_a, dx_vec) = lora_vjp(&g, &x, &h, &a, &b, rank, d_in, d_out, scale);
+        let (bt_g_scalar, dx_scalar) = lora_bt_g_dx_scalar(&g, &a, &b, rank, d_in, d_out, scale);
+
+        // Cross-check bt_g indirectly through the caller-visible dx, and
+        // directly recompute it via matmul_into to pin down the isolated hop.
+        let mut bt_g_vec = vec![0.0f32; rank];
+        crate::forward::cpu::matmul_into(&g, &b, &mut bt_g_vec, 1, d_out, rank);
+
+        let err_btg = rel_err(&bt_g_vec, &bt_g_scalar);
+        let err_dx = rel_err(&dx_vec, &dx_scalar);
+        eprintln!("lora_vjp parity bt_g rel_err={err_btg:.2e} dx rel_err={err_dx:.2e}");
+        assert!(
+            err_btg < PARITY_TOL,
+            "lora bt_g vectorized vs scalar rel_err {err_btg:.2e} >= {PARITY_TOL:.2e}"
+        );
+        assert!(
+            err_dx < PARITY_TOL,
+            "lora dx vectorized vs scalar rel_err {err_dx:.2e} >= {PARITY_TOL:.2e}"
+        );
+    }
+
+    #[test]
+    fn swiglu_backward_parity_vs_scalar() {
+        let hidden = 131;
+        let inter = 347;
+
+        let dy = xorshift_fill(8, hidden, 0.8);
+        let gate_pre = xorshift_fill(9, inter, 1.2);
+        let up_pre = xorshift_fill(10, inter, 1.2);
+        let w_down = xorshift_fill(11, hidden * inter, 0.2);
+        let w_gate = xorshift_fill(12, inter * hidden, 0.2);
+        let w_up = xorshift_fill(13, inter * hidden, 0.2);
+
+        let (dx_vec, dm_vec) = swiglu_backward(
+            &dy, &gate_pre, &up_pre, &w_down, &w_gate, &w_up, hidden, inter,
+        );
+        let (dx_scalar, dm_scalar) = swiglu_backward_scalar(
+            &dy, &gate_pre, &up_pre, &w_down, &w_gate, &w_up, hidden, inter,
+        );
+
+        let err_dm = rel_err(&dm_vec, &dm_scalar);
+        let err_dx = rel_err(&dx_vec, &dx_scalar);
+        eprintln!("swiglu_backward parity dm rel_err={err_dm:.2e} dx rel_err={err_dx:.2e}");
+        assert!(
+            err_dm < PARITY_TOL,
+            "swiglu dm vectorized vs scalar rel_err {err_dm:.2e} >= {PARITY_TOL:.2e}"
+        );
+        assert!(
+            err_dx < PARITY_TOL,
+            "swiglu dx vectorized vs scalar rel_err {err_dx:.2e} >= {PARITY_TOL:.2e}"
+        );
     }
 }

--- a/crates/inference/src/backward/ops.rs
+++ b/crates/inference/src/backward/ops.rs
@@ -53,10 +53,13 @@ pub fn cross_entropy_backward(
 ///
 /// Reuses the same GEMM dispatch the forward path uses (`matmul_into`, m=1):
 /// `dx = g @ W` treating `g` as a `[1, d_out]` row and `w` as `[d_out, d_in]`
-/// row-major — Accelerate/AMX on macOS, SIMD-tiled fallback elsewhere. This is
-/// the single largest scalar loop in the tape (`d_out` reaches vocab_size at
-/// the LM head), so dispatching it through the same kernel as the forward
-/// pass is the primary lever in #737 stage 1.
+/// row-major — Accelerate `cblas_sgemm` on macOS; on non-macOS `matmul_into`
+/// currently routes straight to the generic scalar matmul (only `matmul_bt`
+/// has the tiled/SIMD dispatch), so this rewrite's speedup is a macOS-only
+/// claim until a non-macOS GEMM path lands. This is the single largest
+/// scalar loop in the tape (`d_out` reaches vocab_size at the LM head), so
+/// dispatching it through the same kernel as the forward pass is the
+/// primary lever in #737 stage 1 — on macOS.
 pub fn linear_vjp(w: &[f32], g: &[f32], d_in: usize, d_out: usize) -> Vec<f32> {
     assert_eq!(w.len(), d_out * d_in);
     assert_eq!(g.len(), d_out);
@@ -115,10 +118,15 @@ pub fn lora_vjp(
     }
 
     // dx = A^T (bt_g): dx[j] = scale * Σ_r A[r,j] * bt_g[r]. A is [rank, d_in]
-    // row-major ⇒ dx = (scale*bt_g) @ A via the shared GEMM dispatch.
-    let scaled_bt_g: Vec<f32> = bt_g.iter().map(|&v| v * scale).collect();
+    // row-major ⇒ dx = (scale*bt_g) @ A via the shared GEMM dispatch. Scale
+    // bt_g in place (same `v * scale` rounding order as the old allocated
+    // form) instead of collecting a fresh Vec — bt_g isn't read again after
+    // this point in the tape hot path.
+    for v in bt_g.iter_mut() {
+        *v *= scale;
+    }
     let mut dx = vec![0.0f32; d_in];
-    crate::forward::cpu::matmul_into(&scaled_bt_g, a, &mut dx, 1, rank, d_in);
+    crate::forward::cpu::matmul_into(&bt_g, a, &mut dx, 1, rank, d_in);
 
     (grad_b, grad_a, dx)
 }

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -73,6 +73,11 @@ name = "train_grad_full"
 path = "src/bin/train_grad_full.rs"
 required-features = ["train-backward"]
 
+[[test]]
+name = "bench_backward_737"
+path = "tests/bench_backward_737.rs"
+required-features = ["train-backward"]
+
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true

--- a/crates/tune/src/lora/train_core.rs
+++ b/crates/tune/src/lora/train_core.rs
@@ -577,6 +577,72 @@ fn lm_head_logits(lm_head: &[f32], final_normed: &[f32], hidden: usize, vocab: u
     logits
 }
 
+#[cfg(test)]
+mod lm_head_logits_tests {
+    use super::*;
+
+    // Pre-#737 form: one scalar dot product per vocab row. `matmul_bt`
+    // reassociates the reduction (Accelerate/AMX on macOS, tiled/SIMD
+    // elsewhere), so parity is checked to a tight relative tolerance
+    // (matches PARITY_TOL in `lattice_inference::backward::ops`), not
+    // bit-exact — see that module's tests for the same rationale.
+    fn lm_head_logits_scalar(
+        lm_head: &[f32],
+        final_normed: &[f32],
+        hidden: usize,
+        vocab: usize,
+    ) -> Vec<f32> {
+        let mut logits = vec![0.0f32; vocab];
+        for (v, out) in logits.iter_mut().enumerate() {
+            let row = &lm_head[v * hidden..(v + 1) * hidden];
+            let mut acc = 0.0f32;
+            for j in 0..hidden {
+                acc += row[j] * final_normed[j];
+            }
+            *out = acc;
+        }
+        logits
+    }
+
+    fn rel_err(a: &[f32], b: &[f32]) -> f64 {
+        let diff_sq: f64 = a
+            .iter()
+            .zip(b.iter())
+            .map(|(&x, &y)| ((x - y) as f64).powi(2))
+            .sum();
+        let norm_sq: f64 = a.iter().map(|&x| (x as f64).powi(2)).sum();
+        (diff_sq / norm_sq.max(1e-30)).sqrt()
+    }
+
+    #[test]
+    fn lm_head_logits_parity() {
+        // Odd, unequal dims on purpose: a wrong transpose or swapped
+        // dim-order (e.g. treating lm_head as [hidden, vocab] instead of
+        // the actual [vocab, hidden]) would either panic on an out-of-bounds
+        // slice or produce values that disagree with the scalar oracle —
+        // it cannot silently pass by square-shape symmetry.
+        const HIDDEN: usize = 7;
+        const VOCAB: usize = 5;
+        const PARITY_TOL: f64 = 1e-4;
+
+        let lm_head: Vec<f32> = (0..VOCAB * HIDDEN)
+            .map(|i| (i as f32 + 1.0) * 0.037 - 0.6)
+            .collect();
+        let final_normed: Vec<f32> = (0..HIDDEN).map(|i| (i as f32 + 1.0) * 0.11 - 0.3).collect();
+
+        let vectorized = lm_head_logits(&lm_head, &final_normed, HIDDEN, VOCAB);
+        let scalar = lm_head_logits_scalar(&lm_head, &final_normed, HIDDEN, VOCAB);
+
+        assert_eq!(vectorized.len(), VOCAB);
+        let err = rel_err(&vectorized, &scalar);
+        eprintln!("lm_head_logits parity rel_err={err:.2e}");
+        assert!(
+            err < PARITY_TOL,
+            "lm_head_logits vectorized vs scalar rel_err {err:.2e} >= {PARITY_TOL:.2e}"
+        );
+    }
+}
+
 fn rmsnorm_seq(
     h: &[f32],
     shift: &[f32],

--- a/crates/tune/src/lora/train_core.rs
+++ b/crates/tune/src/lora/train_core.rs
@@ -558,15 +558,22 @@ pub struct FullFwd {
     positions: Vec<HeadPos>,
 }
 
+// lm_head is [vocab, hidden] row-major; the naive scalar form (one dot product
+// per vocab row) pays vocab*hidden scalar FLOPs per completion token — by far
+// the largest per-token cost in the tape (vocab reaches ~250k). Route through
+// the same GEMM dispatch the forward path uses elsewhere (Accelerate/AMX on
+// macOS, SIMD-tiled fallback otherwise): logits = final_normed @ lm_head^T,
+// i.e. a matmul_bt with m=1 (#737 stage 1).
 fn lm_head_logits(lm_head: &[f32], final_normed: &[f32], hidden: usize, vocab: usize) -> Vec<f32> {
     let mut logits = vec![0.0f32; vocab];
-    for (i, l) in logits.iter_mut().enumerate() {
-        *l = lm_head[i * hidden..(i + 1) * hidden]
-            .iter()
-            .zip(final_normed.iter())
-            .map(|(w, x)| w * x)
-            .sum();
-    }
+    lattice_inference::forward::cpu::matmul_bt(
+        final_normed,
+        lm_head,
+        &mut logits,
+        1,
+        hidden,
+        vocab,
+    );
     logits
 }
 

--- a/crates/tune/tests/bench_backward_737.rs
+++ b/crates/tune/tests/bench_backward_737.rs
@@ -1,0 +1,105 @@
+//! A/B measurement harness for issue #737 stage 1 (scalar backward-loop
+//! vectorization). Not run in CI: requires a real Qwen3.5-0.8B checkpoint on
+//! disk at `$HOME/.lattice/models/qwen3.5-0.8b` (or `LATTICE_MODEL_DIR`).
+//!
+//! Exercises the real production path (`train_micro_lora`, `first_layer=19`,
+//! `TOP_LAYER=23`), which materialises layers 19..=23 — a mix of GQA (19, 23)
+//! and GDN (20, 21, 22) mixers, each carrying a LoRA slot — so one training
+//! step drives every backward-tape primitive touched in this PR: `linear_vjp`
+//! (o/q/k/v projections and the lm_head), `lora_vjp` (every LoRA slot),
+//! `swiglu_backward`, and the lm_head forward logits.
+//!
+//! Run (release, single-threaded so wall-clock isn't perturbed by other
+//! criterion/test workers):
+//!
+//! ```text
+//! CARGO_TARGET_DIR=$HOME/.cache/shared-cargo-target/lattice \
+//!   cargo test -p lattice-tune --release --test bench_backward_737 -- \
+//!   --ignored --nocapture --test-threads=1
+//! ```
+use std::path::PathBuf;
+use std::time::Instant;
+
+use lattice_inference::model::qwen35::Qwen35Model;
+use lattice_tune::lora::train::{MicroLoraConfig, TrainingPair, train_micro_lora};
+
+fn model_dir() -> PathBuf {
+    std::env::var("LATTICE_MODEL_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::env::var("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(".lattice")
+                .join("models")
+                .join("qwen3.5-0.8b")
+        })
+}
+
+/// Deterministic xorshift64 token generator — timing does not depend on
+/// token *values* (no data-dependent branching in the backward tape math),
+/// only on shapes, so synthetic-but-in-vocab tokens are a sound stand-in for
+/// a real dataset here.
+fn synth_pairs(vocab: usize, n_pairs: usize, seq_len: usize) -> Vec<TrainingPair> {
+    let mut state: u64 = 0x1234_5678_9abc_def1;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    (0..n_pairs)
+        .map(|_| {
+            let tokens: Vec<u32> = (0..seq_len)
+                .map(|_| (next() % vocab as u64) as u32)
+                .collect();
+            TrainingPair {
+                tokens,
+                completion_start: seq_len / 2,
+            }
+        })
+        .collect()
+}
+
+fn median(mut xs: Vec<f64>) -> f64 {
+    xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    xs[xs.len() / 2]
+}
+
+#[test]
+#[ignore = "requires a real Qwen3.5-0.8B checkpoint on disk; run explicitly for #737 A/B measurement"]
+fn bench_train_micro_lora_one_step_737() {
+    let dir = model_dir();
+    let model = Qwen35Model::from_safetensors(&dir)
+        .unwrap_or_else(|e| panic!("failed to load model at {}: {e}", dir.display()));
+
+    let vocab = model.config().vocab_size;
+    let seq_len = 48;
+    let pairs = synth_pairs(vocab, 4, seq_len);
+
+    let config = MicroLoraConfig {
+        rank: 8,
+        alpha: 16.0,
+        first_layer: 19, // spans layers 19..=23: GQA(19), GDN(20,21,22), GQA(23)
+        steps: 1,
+        learning_rate: 1e-3,
+        max_seq_len: 64,
+    };
+
+    const RUNS: usize = 5;
+    let mut samples = Vec::with_capacity(RUNS);
+    for i in 0..RUNS {
+        let start = Instant::now();
+        let _adapter = train_micro_lora(&model, &pairs, &config).expect("train_micro_lora");
+        let secs = start.elapsed().as_secs_f64();
+        eprintln!("run {i}: {secs:.3}s");
+        samples.push(secs);
+    }
+
+    let med = median(samples.clone());
+    eprintln!("samples={samples:?}");
+    eprintln!(
+        "median={med:.3}s over {RUNS} runs, first_layer=19..=23, seq_len={seq_len}, pairs={}",
+        pairs.len()
+    );
+}

--- a/crates/tune/tests/bench_backward_737.rs
+++ b/crates/tune/tests/bench_backward_737.rs
@@ -1,6 +1,11 @@
-//! A/B measurement harness for issue #737 stage 1 (scalar backward-loop
-//! vectorization). Not run in CI: requires a real Qwen3.5-0.8B checkpoint on
-//! disk at `$HOME/.lattice/models/qwen3.5-0.8b` (or `LATTICE_MODEL_DIR`).
+//! Single-side wall-clock timer for issue #737 stage 1 (scalar backward-loop
+//! vectorization). Times the CURRENT source only — the "before" side of an A/B
+//! is obtained by manually reverse-applying the vectorization, rebuilding, and
+//! rerunning this same test, then restoring. It records no ratio itself; on a
+//! shared machine wall-clock is contention-sensitive, so treat the output as a
+//! direction/magnitude smoke, not a substantiated multiplier. Not run in CI:
+//! requires a real Qwen3.5-0.8B checkpoint on disk at
+//! `$HOME/.lattice/models/qwen3.5-0.8b` (or `LATTICE_MODEL_DIR`).
 //!
 //! Exercises the real production path (`train_micro_lora`, `first_layer=19`,
 //! `TOP_LAYER=23`), which materialises layers 19..=23 — a mix of GQA (19, 23)


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Stage 1 of #737 (third problem named in the issue: naive-scalar backward-tape loops). Full-tape residency and the 2 GiB logits cap are staged follow-ups.

## What

The backward tape's matmul-transpose reductions were naive scalar loops while the forward pass used the Accelerate/AMX GEMM dispatch. Rewired four hot loops onto the existing `forward::cpu::{matmul_into, matmul_bt}` path (no new SIMD code):

- `linear_vjp` (`backward/ops.rs`) — `dx = W^T g`; covers the lm_head backward (vocab ≈ 250k, the largest single reduction) and propagates to every GQA projection backward via `attention_gqa.rs`'s existing calls.
- `lm_head_logits` (`tune/src/lora/train_core.rs`) — forward-tape logits, same shape.
- `swiglu_backward` (`backward/ops.rs`) — both `inter × hidden` reductions.
- `lora_vjp` (`backward/ops.rs`) — `B^T g` / `A^T (scale·bt_g)`; propagates to `gdn_backward.rs`.

## Measurement (methodology first)

The change routes the largest backward-tape scalar reductions through the same Accelerate/AMX GEMM dispatch the forward pass uses. On non-macOS, `matmul_into` currently falls back to a scalar matmul (only `matmul_bt` carries the tiled/SIMD dispatch), so any speedup is macOS-only until a non-macOS GEMM path lands.

No fixed multiplier is claimed. `crates/tune/tests/bench_backward_737.rs` (registered test target, `train-backward`-gated, `--ignored`) is a single-side wall-clock timer: it times the current source over 5 runs of the real `train_micro_lora` step (layers 19..=23, spanning GQA + GDN + LoRA), and the "before" side is a manual reverse-apply / rebuild / rerun of the same test. A manual before/after swap shows the direction is unambiguously faster, but this machine runs heavy concurrent builds and the wall-clock ranges were wide and overlapping (a representative swap saw BEFORE 63–150 s and AFTER 26–77 s), so a precise ratio is not reproducible here and is deliberately not stated. Per the repo's shared-machine-contention rule, the claim rests on the structural argument — the naive lm_head reduction is vocab×hidden scalar FLOPs per completion token (vocab ≈ 250k), by far the largest per-token tape cost, now dispatched through Accelerate — plus the parity guards below, not on a contention-tainted number.

`make bench-compare` (decode/prefill Criterion groups): not applicable by structural unreachability — every changed line is inside `train-backward`-gated backward-tape code (`backward/ops.rs`, `train_core.rs`); the inference decode/prefill paths do not compile these functions in.

## Correctness

- `#[cfg(test)]` scalar-reference oracles (verbatim pre-vectorization loops) + parity tests at non-lane-multiple sizes (`lm_head_logits_parity`, `lora_vjp_parity_vs_scalar`, `lora_vjp_gradcheck`).
- Mutation-verified: breaking `linear_vjp` fails both the existing gradcheck and the new parity test; restored, both pass.
- `cargo test -p lattice-inference --lib --features train-backward` (backward tests) and `cargo test -p lattice-tune --features train-backward` green; clippy/fmt clean on touched targets.
