### PR TITLE
docs(transport): extract crate narrative into docs/, condense rustdoc (shape-setter)

### DIFF
--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -1,8 +1,7 @@
 # lattice-transport
 
-**Stability tier: Unstable.** The Sinkhorn API is functional but consumed by only one crate.
-API shape may change as Brain Phase 7 Objective synthesis adopts it. The crate will be promoted
-to Stable after a second consumer lands. See `foundation/STABILITY.md` for the full policy.
+**Stability tier: Unstable.** The Sinkhorn API is functional but currently consumed by only one
+crate, so its shape may still change.
 
 ---
 
@@ -13,8 +12,8 @@ in log-domain for numerical stability. Its primary use case is quantifying how m
 geometry shifts between model versions — for example, when `lattice-embed` swaps from
 BGE-small to mE5-small and needs to detect distribution drift across stored embeddings.
 
-The crate was extracted from `foundation/score` in Wave4 so that Brain Phase 7 Objective
-synthesis can consume optimal-transport primitives independently of the scoring infrastructure.
+For the architecture layers and the design rationale behind the log-domain formulation, see
+[`docs/design.md`](docs/design.md).
 
 ---
 

--- a/crates/transport/docs/INDEX.md
+++ b/crates/transport/docs/INDEX.md
@@ -1,0 +1,8 @@
+# lattice-transport — extended docs
+
+Deeper documentation for the crate, kept alongside the source so it stays current
+as the code changes. The crate-level rustdoc (`src/lib.rs`) and `README.md` hold
+the summary and public API surface; the files here hold the longer-form narrative.
+
+- [design.md](design.md) — architecture layers, the log-domain invariant and why it
+  matters, workspace preallocation, and the no-external-linear-algebra constraint.

--- a/crates/transport/docs/design.md
+++ b/crates/transport/docs/design.md
@@ -1,0 +1,49 @@
+# lattice-transport design
+
+`lattice-transport` implements entropy-regularized optimal transport (the
+Sinkhorn-Knopp algorithm) in the log domain. Its primary use case is quantifying
+how much embedding geometry shifts between model versions — for example, when
+`lattice-embed` swaps from BGE-small to mE5-small and needs to detect distribution
+drift across stored embeddings.
+
+## Architecture
+
+The crate is organized into layers, leaf-most first:
+
+- **Numerical foundation** — `math`, `logsumexp`: stable log-domain arithmetic.
+- **Cost abstraction** — `cost`: the `CostMatrix` trait and its implementations
+  (`DenseCostMatrix`, `PairwiseCostMatrix`, `SquaredEuclidean`, `CosineDistance`).
+- **Core solvers** — `sinkhorn` (balanced), `sinkhorn_log` (epsilon-scaling
+  schedule, more stable at small epsilon), `unbalanced` (KL-relaxed marginals for
+  imprecise source/target masses).
+- **Post-processing** — `transport_plan` (sparse plan extraction), `divergence`
+  (debiased Sinkhorn divergence, which removes the self-transport bias from raw
+  optimal-transport cost).
+- **High-level API** — `drift` (embedding drift detection), `online_drift`
+  (streaming sliding-window detection), `barycenter` (Wasserstein barycenters).
+
+## Key design choices
+
+**Log-domain throughout.** The solvers never materialize the Gibbs kernel
+`exp(-C/epsilon)` directly; all scaling vectors stay in log space and combine
+through `logsumexp`. This is the crate's load-bearing numerical invariant: it
+prevents underflow at small regularization epsilon, where the kernel entries would
+otherwise round to zero in `f32`.
+
+**Pre-allocated workspaces.** `SinkhornWorkspace` holds the scratch buffers the
+inner iteration needs, so a caller allocates once and reuses the workspace across
+many solves rather than allocating on the heap each call.
+
+**No external linear algebra.** All arithmetic is pure Rust with no BLAS/LAPACK
+requirement. The log-domain formulation is what makes this practical without a
+tuned numerical library underneath.
+
+**f32-only.** All tensor inputs and computation use `f32`; there are no f16, bf16,
+or integer paths.
+
+**Leaf crate.** `lattice-transport` has no intra-workspace dependencies. It pulls
+in only `rayon` and `serde` at runtime and depends on no other lattice crate, so a
+consumer can take these optimal-transport primitives without pulling in the
+transformer stack. The inference-side bridge that would feed live statistics into
+`OnlineDriftDetector` sits at the opposite end of the dependency graph and is
+tracked in ADR-055.

--- a/crates/transport/docs/design.md
+++ b/crates/transport/docs/design.md
@@ -11,8 +11,9 @@ drift across stored embeddings.
 The crate is organized into layers, leaf-most first:
 
 - **Numerical foundation** — `math`, `logsumexp`: stable log-domain arithmetic.
-- **Cost abstraction** — `cost`: the `CostMatrix` trait and its implementations
-  (`DenseCostMatrix`, `PairwiseCostMatrix`, `SquaredEuclidean`, `CosineDistance`).
+- **Cost abstraction** — `cost`: the `CostMatrix` trait with its `DenseCostMatrix`
+  and `PairwiseCostMatrix` implementations, plus the `PointMetric` distance types
+  `SquaredEuclidean` and `CosineDistance`.
 - **Core solvers** — `sinkhorn` (balanced), `sinkhorn_log` (epsilon-scaling
   schedule, more stable at small epsilon), `unbalanced` (KL-relaxed marginals for
   imprecise source/target masses).

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,40 +1,23 @@
-//! **Stability tier**: Unstable
+//! Sinkhorn optimal transport for embedding distribution drift detection.
 //!
-//! Extracted from `foundation/score` in Wave4. The Sinkhorn API is functional but
-//! not yet consumed by more than one crate. API shape may change as Brain Phase 7
-//! Objective synthesis adopts it. Promote to Stable after second consumer lands.
-//! See `foundation/STABILITY.md` for the full policy.
+//! **Stability tier: Unstable.** The Sinkhorn API is functional but currently
+//! consumed by only one crate; its shape may still change.
 //!
-//! Sinkhorn Optimal Transport for embedding distribution drift detection.
+//! This crate implements entropy-regularized optimal transport (the Sinkhorn-Knopp
+//! algorithm) in the log domain, for quantifying how much embedding geometry shifts
+//! between model versions (for example, BGE-small to mE5-small). The load-bearing
+//! numerical invariant is that the solvers stay in log space throughout and never
+//! materialize the Gibbs kernel `exp(-C/epsilon)`, which prevents underflow at small
+//! regularization epsilon. The crate is a dependency-free leaf: pure-Rust math with
+//! no BLAS/LAPACK, and [`SinkhornWorkspace`] preallocates the inner-loop buffers so
+//! callers allocate once and reuse.
 //!
-//! This crate implements entropy-regularized optimal transport (Sinkhorn algorithm)
-//! in log-domain for numerical stability. It is designed for quantifying how much
-//! embedding geometry shifts between model versions (e.g., BGE-small to mE5-small).
-//!
-//! Extracted from `foundation/score` as a peer crate so that Brain Phase 7
-//! Objective synthesis can consume optimal-transport primitives independently
-//! of scoring infrastructure.
-//!
-//! # Architecture
-//!
-//! The crate is organized into layers:
-//!
-//! - **Numerical foundation**: `math`, [`logsumexp`] -- stable log-domain arithmetic
-//! - **Cost abstraction**: [`cost`] -- cost matrix traits and implementations
-//! - **Core solvers**: [`sinkhorn`] (balanced), [`sinkhorn_log`] (epsilon-scaling),
-//!   [`unbalanced`] (KL-relaxed marginals)
-//! - **Post-processing**: [`transport_plan`] (sparse plan extraction),
-//!   [`divergence`] (debiased Sinkhorn divergence)
-//! - **High-level API**: [`drift`] (embedding drift detection),
-//!   [`barycenter`] (Wasserstein barycenters)
-//!
-//! # Key Design Choices
-//!
-//! - **Log-domain throughout**: Never materializes the Gibbs kernel `exp(-C/epsilon)`
-//!   directly. All scaling vectors stay in log space.
-//! - **Pre-allocated buffers**: [`SinkhornWorkspace`] avoids heap allocation during
-//!   the inner iteration loop.
-//! - **No external dependencies**: Pure Rust math, no BLAS/LAPACK requirement.
+//! The layers run from the numerical foundation ([`logsumexp`]) up through the
+//! [`cost`] abstraction, the core solvers ([`sinkhorn`], [`sinkhorn_log`],
+//! [`unbalanced`]), post-processing ([`transport_plan`], [`divergence`]), and the
+//! high-level [`drift`] and [`barycenter`] APIs. See
+//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/transport/docs/design.md)
+//! for the architecture and design rationale in full.
 //!
 //! # Example
 //!

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -8,9 +8,9 @@
 //! between model versions (for example, BGE-small to mE5-small). The load-bearing
 //! numerical invariant is that the solvers stay in log space throughout and never
 //! materialize the Gibbs kernel `exp(-C/epsilon)`, which prevents underflow at small
-//! regularization epsilon. The crate is a dependency-free leaf: pure-Rust math with
-//! no BLAS/LAPACK, and [`SinkhornWorkspace`] preallocates the inner-loop buffers so
-//! callers allocate once and reuse.
+//! regularization epsilon. The crate is a leaf with no intra-workspace dependencies:
+//! pure-Rust math with no BLAS/LAPACK, and [`SinkhornWorkspace`] preallocates the
+//! inner-loop buffers so callers allocate once and reuse.
 //!
 //! The layers run from the numerical foundation ([`logsumexp`]) up through the
 //! [`cost`] abstraction, the core solvers ([`sinkhorn`], [`sinkhorn_log`],


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Shape-setter for the inline-doc consolidation sweep. Transport is the smallest crate, so it establishes the pattern on a small, low-risk surface before it scales to the larger crates.

## What this establishes

**A per-crate `docs/` layer.** `crates/transport/docs/INDEX.md` indexes the crate's extended docs; `crates/transport/docs/design.md` holds the living architecture/design narrative (the layer map, the log-domain invariant and why it matters, workspace preallocation, the no-external-linear-algebra constraint).

**Condensed rustdoc.** The `src/lib.rs` `//!` block goes from ~40 lines to a substantive summary that still stands alone at the public-surface level — what the crate is, its one load-bearing numerical invariant, the layer map, a working example — followed by a pointer to `docs/design.md` for the full rationale. The runnable doctest example is unchanged.

**README stays the API overview** and gains a pointer to the design doc.

## The three-way split applied here

- Load-bearing invariant (log-domain, never materialize the Gibbs kernel) kept inline, condensed.
- Extended how-it-works narrative moved to `docs/design.md` (a living doc, updated when the code changes).
- No design-decision content rose to the ADR bar in this crate.

## Also

Removed stale cross-references that no longer resolve in this repository (paths and subsystem names carried over from the crate's pre-extraction home) from both the rustdoc and the README. They pointed at files that do not exist here.

## Verification

Comment/doc-only — no code or behavior change. `cargo doc -p lattice-transport --no-deps` passes under `-D warnings -D rustdoc::broken_intra_doc_links` (the CI rustdoc lint is non-blocking, so this was run locally).

Opening as a draft for shape sign-off before the pattern scales to the larger crates.