### PR TITLE
docs(tune): extract lib/train/checkpoint narrative into docs/, condense

### DIFF
--- a/crates/tune/docs/INDEX.md
+++ b/crates/tune/docs/INDEX.md
@@ -1,0 +1,10 @@
+# lattice-tune — extended docs
+
+Deeper documentation for the crate, kept alongside the source so it stays current
+as the code changes. The crate-level rustdoc (`src/lib.rs`) and `README.md` hold
+the summary and public API surface; the files here hold the longer-form narrative.
+
+- [design.md](design.md) — the distillation/training/registry pipeline, walkthroughs
+  for each stage, the `inference-hook` bridge, and the `Checkpoint` JSON schema.
+- `adr/`, `ADR-*.md` — accepted architecture decisions for this crate (unchanged by
+  this index; see each ADR for the alternatives considered and why).

--- a/crates/tune/docs/design.md
+++ b/crates/tune/docs/design.md
@@ -1,0 +1,221 @@
+# lattice-tune design
+
+`lattice-tune` is the training side of Lattice: a knowledge-distillation pipeline that
+turns teacher-model (Claude, GPT, Gemini) responses into a compact student network, plus
+the training loop, LoRA adapters, and a model registry that tracks what got trained and
+why.
+
+## Pipeline
+
+```text
+Raw Data → Teacher (LLM) → Soft Labels → Dataset → Training → Model → Registry
+                                                        ↓
+                                                   Deployment
+```
+
+- **`data`** — `TrainingExample`, `Dataset`, and `Batch`: the labeled-example format and
+  batching used throughout the rest of the crate.
+- **`distill`** — pipelines a teacher model (Claude/GPT/Gemini) over raw text into soft
+  labels, producing `TrainingExample`s.
+- **`train`** — the training loop, optimizer, LR schedule, early stopping, checkpointing,
+  and (behind the `gpu` feature) GPU-accelerated forward/backward.
+- **`registry`** — versions and stores trained models with training-config and metric
+  provenance, plus shadow-deployment and rollback support.
+
+## Design principles
+
+1. **Data-first** — a well-defined training-example format with full traceability from
+   raw input through to the trained model.
+2. **Modular** — distillation, training, and registry are separate concerns that compose
+   through the shared `data` types.
+3. **Extensible** — teacher providers (Claude, GPT, Gemini) are pluggable via
+   `TeacherConfig`/`TeacherProvider`.
+4. **Traceable** — every registered model carries its version, training config, and
+   metrics.
+
+## Distillation walkthrough
+
+```ignore
+use lattice_tune::distill::{TeacherConfig, DistillationPipeline, RawExample};
+
+// Configure teacher model
+let teacher = TeacherConfig::claude_sonnet();
+
+// Create distillation pipeline
+let mut pipeline = DistillationPipeline::with_teacher(teacher)?;
+
+// Create raw examples (text, not embeddings)
+let raw = RawExample::new(
+    vec!["Hello".to_string(), "How are you?".to_string()],
+    "What's the weather like?",
+);
+
+// Label with teacher
+let result = pipeline.label_single(&raw)?;
+println!("Labeled with confidence: {}", result.confidence);
+```
+
+## Training walkthrough
+
+```ignore
+use lattice_tune::train::{TrainingConfig, TrainingLoop};
+use lattice_tune::data::Dataset;
+
+// Configure training
+let config = TrainingConfig::default()
+    .epochs(100)
+    .batch_size(32)
+    .learning_rate(0.001);
+
+// Train
+let mut trainer = TrainingLoop::new(config)?;
+let metrics = trainer.train(&mut dataset)?;
+
+println!("Final loss: {:.4}", metrics.final_train_loss);
+```
+
+### GPU training
+
+With the `gpu` feature enabled, forward/backward passes and validation run on the GPU:
+
+```ignore
+use lattice_tune::train::{GpuTrainer, GpuTrainerBuilder, TrainingConfig};
+use lattice_fann::Activation;
+
+// Build GPU trainer
+let mut trainer = GpuTrainerBuilder::new(768, 6)
+    .hidden(64, Activation::ReLU)
+    .hidden(32, Activation::ReLU)
+    .config(TrainingConfig::default())
+    .build()?;
+
+// Train batches
+for batch in dataset.batches() {
+    let loss = trainer.train_batch(&batch)?;
+}
+```
+
+`GpuTrainer::train_batch` currently returns `Err` for every optimizer choice — the
+GPU weight-update gap documented on `lattice_tune::train`'s module docs
+(<https://github.com/ohdearquant/lattice/issues/797>) — while `GpuTrainer::validate`
+(forward-only) works today.
+
+## Registry walkthrough
+
+```rust
+use lattice_tune::registry::{ModelRegistry, RegisteredModel, ModelMetadata};
+
+// Create a registry
+let registry = ModelRegistry::in_memory();
+
+// Register a model
+let metadata = ModelMetadata::classifier(768, 6, 10000);
+let model = RegisteredModel::new("intent_classifier", "1.0.0")
+    .with_metadata(metadata)
+    .with_description("Intent classification model");
+
+let weights = vec![0u8; 1000]; // Model weights
+let id = registry.register(model, &weights).unwrap();
+
+// Retrieve the model
+let loaded = registry.get("intent_classifier", "1.0.0").unwrap();
+println!("Loaded: {}", loaded.full_name());
+```
+
+## Consuming the `inference-hook` bridge
+
+To inject a trained `LoraAdapter` into a running `lattice-inference` forward pass, enable
+the `inference-hook` feature. It pulls in `lattice-inference` and implements
+`lattice_inference::lora_hook::LoraHook` for `LoraAdapter`, so an adapter can be handed to
+the engine as a `Box<dyn LoraHook>`:
+
+```toml
+[dependencies]
+lattice-tune = { version = "0.4.2", features = ["inference-hook"] }
+lattice-inference = "0.4.2" # provides the LoraHook trait
+```
+
+```ignore
+use lattice_tune::lora::LoraAdapter;
+use lattice_inference::lora_hook::LoraHook;
+
+let adapter: LoraAdapter = /* load via LoraAdapter::load_peft_safetensors(...) */;
+let hook: Box<dyn LoraHook> = Box::new(adapter);
+// hand `hook` to the inference engine; on each projection it calls
+// hook.apply(layer_idx, module, x, output)
+```
+
+The trait path is `lattice_inference::lora_hook::LoraHook` (it is not re-exported at the
+inference crate root). Without the `inference-hook` feature, `LoraAdapter` is a pure
+training type and carries no dependency on `lattice-inference`.
+
+## Checkpoint serialization format
+
+`Checkpoint` serializes to JSON when the `serde` feature is enabled:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "epoch": 10,
+  "global_step": 5000,
+  "metrics": {
+    "final_train_loss": 0.05,
+    "final_val_loss": 0.06,
+    "epochs_completed": 10,
+    "total_steps": 5000,
+    "best_epoch": 8,
+    "best_val_loss": 0.055
+  },
+  "created_at": "2024-01-15T10:30:00Z",
+  "weights": "<base64-encoded bytes>",
+  "optimizer_state": "<base64-encoded bytes>"
+}
+```
+
+| Field             | Type            | Description                                      |
+| ----------------- | ---------------- | ------------------------------------------------ |
+| `id`              | UUID v4          | Unique identifier for this checkpoint            |
+| `epoch`           | usize            | Training epoch when created (0-indexed)          |
+| `global_step`     | usize            | Total batches processed                          |
+| `metrics`         | TrainingMetrics  | Training statistics at checkpoint time           |
+| `created_at`      | ISO 8601         | UTC timestamp of creation                        |
+| `weights`         | bytes            | Serialized model parameters (byte layout below)  |
+| `optimizer_state` | bytes            | Serialized optimizer momentum/state (below)      |
+
+The byte-level layout of `weights` and `optimizer_state` is the load-bearing part of this
+format and stays on `Checkpoint` itself in `src/train/loop/checkpoint.rs`, so a consumer
+parsing the raw bytes has it without a docs/ round-trip:
+
+- `weights`: little-endian `f32` values, concatenated layer-by-layer (each layer's weight
+  matrix in row-major order, then its biases; input-to-output order across layers). For a
+  network with layers `[4->8, 8->2]`: `[layer0_weights: 32 floats][layer0_biases: 8
+  floats][layer1_weights: 16 floats][layer1_biases: 2 floats]`.
+- `optimizer_state`: SGD-with-momentum stores one velocity vector per parameter; Adam
+  stores first (`m`) and second (`v`) moment vectors per parameter.
+
+### Loading a checkpoint
+
+```ignore
+use lattice_tune::Checkpoint;
+
+// Load from JSON file
+let json = std::fs::read_to_string("checkpoint_epoch_10.json")?;
+let checkpoint: Checkpoint = serde_json::from_str(&json)?;
+
+// Restore model weights
+model.load_weights(&checkpoint.weights);
+optimizer.load_state(&checkpoint.optimizer_state);
+```
+
+### Naming convention
+
+Recommended file naming: `checkpoint_epoch_{epoch:04d}_step_{step:08d}.json` — for
+example, `checkpoint_epoch_0010_step_00005000.json`.
+
+## Feature flags
+
+- `std` (default): standard library support.
+- `serde`: serialization support for all types, including `Checkpoint`.
+- `gpu`: GPU-accelerated training via `GpuTrainer`.
+- `inference-hook`: implements `lattice_inference::lora_hook::LoraHook` for `LoraAdapter`,
+  so a trained adapter can be handed straight to `lattice-inference` as a `Box<dyn LoraHook>`.

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -2,24 +2,17 @@
 #![allow(clippy::needless_borrows_for_generic_args)]
 #![allow(clippy::field_reassign_with_default)]
 
-//! lattice-tune - Training infrastructure for Lattice neural models
+//! Training infrastructure for Lattice neural models: knowledge distillation, dataset
+//! management, the training loop, LoRA adapters, and a model registry with lineage.
 //!
-//! Provides a complete pipeline for training neural networks through knowledge distillation:
+//! The pipeline runs data -> teacher (LLM) -> soft labels -> dataset -> training -> model
+//! -> registry. [`data`] holds training examples and batching, [`distill`] drives knowledge
+//! distillation from teacher models (Claude, GPT, Gemini), [`train`] is the training loop,
+//! optimizer, and checkpointing, and [`registry`] versions, stores, and tracks deployment of
+//! trained models. [`lora`] adapters can be trained here and, via the `inference-hook`
+//! feature, applied directly to a running `lattice-inference` forward pass.
 //!
-//! - **Data**: Training examples, datasets, and batching
-//! - **Distill**: Knowledge distillation from teacher models (Claude, GPT, Gemini)
-//! - **Train**: Training loop, optimization, and checkpointing
-//! - **Registry**: Model versioning, storage, and deployment tracking
-//!
-//! # Architecture
-//!
-//! ```text
-//! Raw Data → Teacher (LLM) → Soft Labels → Dataset → Training → Model → Registry
-//!                                                        ↓
-//!                                                   Deployment
-//! ```
-//!
-//! # Quick Start
+//! # Quick start
 //!
 //! ```rust
 //! use lattice_tune::data::{TrainingExample, IntentLabels, Dataset, DatasetConfig};
@@ -39,109 +32,9 @@
 //! println!("Dataset has {} examples", stats.num_examples);
 //! ```
 //!
-//! # Distillation Example
-//!
-//! ```ignore
-//! use lattice_tune::distill::{TeacherConfig, DistillationPipeline, RawExample};
-//!
-//! // Configure teacher model
-//! let teacher = TeacherConfig::claude_sonnet();
-//!
-//! // Create distillation pipeline
-//! let mut pipeline = DistillationPipeline::with_teacher(teacher)?;
-//!
-//! // Create raw examples (text, not embeddings)
-//! let raw = RawExample::new(
-//!     vec!["Hello".to_string(), "How are you?".to_string()],
-//!     "What's the weather like?",
-//! );
-//!
-//! // Label with teacher
-//! let result = pipeline.label_single(&raw)?;
-//! println!("Labeled with confidence: {}", result.confidence);
-//! ```
-//!
-//! # Training Example
-//!
-//! ```ignore
-//! use lattice_tune::train::{TrainingConfig, TrainingLoop};
-//! use lattice_tune::data::Dataset;
-//!
-//! // Configure training
-//! let config = TrainingConfig::default()
-//!     .epochs(100)
-//!     .batch_size(32)
-//!     .learning_rate(0.001);
-//!
-//! // Train
-//! let mut trainer = TrainingLoop::new(config)?;
-//! let metrics = trainer.train(&mut dataset)?;
-//!
-//! println!("Final loss: {:.4}", metrics.final_train_loss);
-//! ```
-//!
-//! # Registry Example
-//!
-//! ```rust
-//! use lattice_tune::registry::{ModelRegistry, RegisteredModel, ModelMetadata};
-//!
-//! // Create a registry
-//! let registry = ModelRegistry::in_memory();
-//!
-//! // Register a model
-//! let metadata = ModelMetadata::classifier(768, 6, 10000);
-//! let model = RegisteredModel::new("intent_classifier", "1.0.0")
-//!     .with_metadata(metadata)
-//!     .with_description("Intent classification model");
-//!
-//! let weights = vec![0u8; 1000]; // Model weights
-//! let id = registry.register(model, &weights).unwrap();
-//!
-//! // Retrieve the model
-//! let loaded = registry.get("intent_classifier", "1.0.0").unwrap();
-//! println!("Loaded: {}", loaded.full_name());
-//! ```
-//!
-//! # Consuming the `inference-hook` bridge
-//!
-//! To inject a trained [`LoraAdapter`] into a running
-//! `lattice-inference` forward pass, enable the `inference-hook` feature. It
-//! pulls in `lattice-inference` and provides `impl
-//! lattice_inference::lora_hook::LoraHook for LoraAdapter`, so an adapter can be
-//! handed to the engine as a `Box<dyn LoraHook>`:
-//!
-//! ```toml
-//! [dependencies]
-//! lattice-tune = { version = "0.4.2", features = ["inference-hook"] }
-//! lattice-inference = "0.4.2" # provides the LoraHook trait
-//! ```
-//!
-//! ```ignore
-//! use lattice_tune::lora::LoraAdapter;
-//! use lattice_inference::lora_hook::LoraHook;
-//!
-//! let adapter: LoraAdapter = /* load via LoraAdapter::load_peft_safetensors(...) */;
-//! let hook: Box<dyn LoraHook> = Box::new(adapter);
-//! // hand `hook` to the inference engine; on each projection it calls
-//! // hook.apply(layer_idx, module, x, output)
-//! ```
-//!
-//! The trait path is `lattice_inference::lora_hook::LoraHook` (it is not
-//! re-exported at the inference crate root). Without the `inference-hook`
-//! feature, `LoraAdapter` is a pure training type and carries no dependency on
-//! `lattice-inference`.
-//!
-//! # Design Principles
-//!
-//! 1. **Data-first**: Well-defined training example format with full traceability
-//! 2. **Modular**: Distillation, training, and registry are separate concerns
-//! 3. **Extensible**: Support different teacher models (Claude, GPT, Gemini)
-//! 4. **Traceable**: All models have version, training config, and metrics
-//!
-//! # Feature Flags
-//!
-//! - `std` (default): Standard library support
-//! - `serde`: Serialization support for all types
+//! See [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/tune/docs/design.md)
+//! for the distillation, training, and registry walkthroughs, the `inference-hook` bridge in
+//! full, and the `Checkpoint` JSON schema.
 
 #![warn(missing_docs)]
 

--- a/crates/tune/src/train/loop/checkpoint.rs
+++ b/crates/tune/src/train/loop/checkpoint.rs
@@ -9,79 +9,17 @@ use serde::{Deserialize, Serialize};
 
 /// Checkpoint of training state.
 ///
-/// # Serialization Format
+/// # Serialization format (load-bearing)
 ///
-/// When serialized with the `serde` feature, checkpoints use JSON format with the following structure:
+/// With the `serde` feature, checkpoints serialize to JSON. See
+/// [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/tune/docs/design.md)
+/// for the full JSON schema, a loading example, and the file naming convention. Two fields
+/// carry a byte-level contract that is not visible from their `Vec<u8>` type:
 ///
-/// ```json
-/// {
-///   "id": "550e8400-e29b-41d4-a716-446655440000",
-///   "epoch": 10,
-///   "global_step": 5000,
-///   "metrics": {
-///     "final_train_loss": 0.05,
-///     "final_val_loss": 0.06,
-///     "epochs_completed": 10,
-///     "total_steps": 5000,
-///     "best_epoch": 8,
-///     "best_val_loss": 0.055
-///   },
-///   "created_at": "2024-01-15T10:30:00Z",
-///   "weights": "<base64-encoded bytes>",
-///   "optimizer_state": "<base64-encoded bytes>"
-/// }
-/// ```
-///
-/// ## Field Details
-///
-/// | Field | Type | Description |
-/// |-------|------|-------------|
-/// | `id` | UUID v4 | Unique identifier for this checkpoint |
-/// | `epoch` | usize | Training epoch when created (0-indexed) |
-/// | `global_step` | usize | Total batches processed |
-/// | `metrics` | TrainingMetrics | Training statistics at checkpoint time |
-/// | `created_at` | ISO 8601 | UTC timestamp of creation |
-/// | `weights` | bytes | Serialized model parameters |
-/// | `optimizer_state` | bytes | Serialized optimizer momentum/state |
-///
-/// ## Weight Serialization
-///
-/// The `weights` field contains model parameters serialized as:
-/// 1. Little-endian f32 values concatenated
-/// 2. Layer order: input-to-output (layer 0 weights, layer 0 biases, layer 1...)
-/// 3. Weight matrices in row-major order
-///
-/// For a network with layers [4->8, 8->2], weights layout:
-/// ```text
-/// [layer0_weights: 32 floats][layer0_biases: 8 floats][layer1_weights: 16 floats][layer1_biases: 2 floats]
-/// ```
-///
-/// ## Optimizer State Serialization
-///
-/// The `optimizer_state` field contains optimizer-specific state:
-///
-/// - **SGD with momentum**: Velocity vectors matching weight dimensions
-/// - **Adam**: First moment (m) + second moment (v) for each parameter
-///
-/// ## Loading Checkpoints
-///
-/// ```ignore
-/// use lattice_tune::Checkpoint;
-///
-/// // Load from JSON file
-/// let json = std::fs::read_to_string("checkpoint_epoch_10.json")?;
-/// let checkpoint: Checkpoint = serde_json::from_str(&json)?;
-///
-/// // Restore model weights
-/// model.load_weights(&checkpoint.weights);
-/// optimizer.load_state(&checkpoint.optimizer_state);
-/// ```
-///
-/// ## Checkpoint Naming Convention
-///
-/// Recommended file naming: `checkpoint_epoch_{epoch:04d}_step_{step:08d}.json`
-///
-/// Example: `checkpoint_epoch_0010_step_00005000.json`
+/// - `weights`: little-endian `f32` values, concatenated layer-by-layer (each layer's weight
+///   matrix in row-major order, then its biases; input-to-output order across layers).
+/// - `optimizer_state`: optimizer-specific — SGD-with-momentum stores one velocity vector per
+///   parameter; Adam stores first (`m`) and second (`v`) moment vectors per parameter.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Checkpoint {

--- a/crates/tune/src/train/mod.rs
+++ b/crates/tune/src/train/mod.rs
@@ -1,67 +1,18 @@
-//! Training orchestration module
+//! Training orchestration: the training loop, optimizer configuration, checkpointing,
+//! early stopping, and GPU-accelerated training behind the `gpu` feature.
 //!
-//! This module provides the training loop and configuration for
-//! training neural models on labeled data.
+//! See [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/tune/docs/design.md)
+//! for the pipeline diagram and CPU/GPU training walkthroughs.
 //!
-//! # Architecture
+//! # GPU weight-update gap (load-bearing)
 //!
-//! ```text
-//! Dataset → Training Loop → Model Updates → Checkpoints → Registry
-//! ```
-//!
-//! # Example
-//!
-//! ```ignore
-//! use lattice_tune::train::{TrainingConfig, TrainingLoop, TrainingMetrics};
-//! use lattice_tune::data::Dataset;
-//!
-//! // Configure training
-//! let config = TrainingConfig::default()
-//!     .epochs(100)
-//!     .learning_rate(0.001)
-//!     .batch_size(32);
-//!
-//! // Create training loop
-//! let mut trainer = TrainingLoop::new(model, config)?;
-//!
-//! // Train
-//! let metrics = trainer.train(&dataset)?;
-//! ```
-//!
-//! # GPU Training
-//!
-//! With the `gpu` feature enabled, GPU-accelerated forward/backward passes
-//! and validation are available:
-//!
-//! ```ignore
-//! use lattice_tune::train::{GpuTrainer, GpuTrainerBuilder, TrainingConfig};
-//! use lattice_fann::Activation;
-//!
-//! // Build GPU trainer
-//! let mut trainer = GpuTrainerBuilder::new(768, 6)
-//!     .hidden(64, Activation::ReLU)
-//!     .hidden(32, Activation::ReLU)
-//!     .config(TrainingConfig::default())
-//!     .build()?;
-//!
-//! // Train batches
-//! for batch in dataset.batches() {
-//!     let loss = trainer.train_batch(&batch)?;
-//! }
-//! ```
-//!
-//! # Current limitation (GPU weight updates)
-//!
-//! `GpuTrainer::train_batch` above will return `Err(TuneError::Training(_))`
-//! for **every** optimizer choice (Adam, AdamW, SGD-momentum, plain SGD,
-//! RMSprop): the GPU-shader optimizer dispatch has no buffer bindings wired
-//! to the network's weight/gradient buffers, and the CPU-side plain-SGD arm
-//! has neither real gradient plumbing nor a mutable weight write-back path.
-//! Forward pass and loss computation work correctly — `GpuTrainer::validate`
-//! is a forward-only, GPU-accelerated path that does not touch the
-//! optimizer. Only the weight-update step is unimplemented. See
-//! <https://github.com/ohdearquant/lattice/issues/797>. This note will be
-//! removed once that wiring lands.
+//! `GpuTrainer::train_batch` returns `Err(TuneError::Training(_))` for **every** optimizer
+//! choice (Adam, AdamW, SGD-momentum, plain SGD, RMSprop): the GPU-shader optimizer dispatch
+//! has no buffer bindings wired to the network's weight/gradient buffers, and the CPU-side
+//! plain-SGD arm has neither real gradient plumbing nor a mutable weight write-back path.
+//! `GpuTrainer::validate` is a forward-only, GPU-accelerated path unaffected by this gap.
+//! See <https://github.com/ohdearquant/lattice/issues/797>; this note goes away once the
+//! wiring lands.
 
 mod config;
 mod jit;


### PR DESCRIPTION
This pull request adds comprehensive extended documentation for the `lattice-tune` crate, centralizing all long-form design, architecture, and usage walkthroughs in a new `docs/` directory. It also updates crate-level and module documentation to reference these new docs, streamlining the in-source comments and reducing duplication. The checkpoint serialization and training module docs are clarified and now direct users to the new design documentation for details.

**Documentation improvements and centralization:**

- Added a new `docs/INDEX.md` and `docs/design.md` with detailed pipeline diagrams, walkthroughs for distillation, training, registry, LoRA adapters, the `inference-hook` bridge, checkpoint JSON schema, and feature flags. [[1]](diffhunk://#diff-0444e163af8e0155a50ddb51baa383a917d1a7011ca68d17236e8bda1fa25facR1-R10) [[2]](diffhunk://#diff-c8dd0570e409ff82f4ad07ea4e3314b1aae15a5f1a1ca5790005aed387f5e85eR1-R221)
- Updated crate-level docs in `src/lib.rs` to summarize the API surface and direct users to `docs/design.md` for in-depth guides and examples, removing redundant long-form walkthroughs from the rustdoc. [[1]](diffhunk://#diff-fc15298fd2b1e55aeb7997b7f849ff47590cac540082fff57892b37f4ef57293L5-R15) [[2]](diffhunk://#diff-fc15298fd2b1e55aeb7997b7f849ff47590cac540082fff57892b37f4ef57293L42-R37)
- Simplified and clarified the checkpoint serialization documentation in `checkpoint.rs`, removing inline JSON schema and pointing to the canonical `docs/design.md` for the authoritative format and loading instructions.
- Updated the `train` module docs to reference the new design documentation for pipeline diagrams and usage, and clarified the current GPU training limitations, again pointing to the canonical doc for details.

These changes make the documentation more maintainable, reduce duplication, and ensure that detailed design and usage information stays up-to-date alongside the source code.