### PR TITLE
docs(fann): extract crate narrative into docs/, condense rustdoc

### DIFF
--- a/crates/fann/docs/INDEX.md
+++ b/crates/fann/docs/INDEX.md
@@ -1,0 +1,9 @@
+# lattice-fann — extended docs
+
+Deeper documentation for the crate, kept alongside the source so it stays current
+as the code changes. The crate-level rustdoc (`src/lib.rs`) and `README.md` hold
+the summary and public API surface; the files here hold the longer-form narrative.
+
+- [design.md](design.md) — network/training architecture, the zero-allocation
+  inference design, and the GPU backend (buffer pooling, circuit breaker,
+  Apple Silicon tuning).

--- a/crates/fann/docs/design.md
+++ b/crates/fann/docs/design.md
@@ -1,0 +1,146 @@
+# lattice-fann design
+
+`lattice-fann` implements lightweight neural network primitives for sub-5ms CPU
+inference on small dense networks (up to roughly 100K parameters) — the kind of
+model used as a knowledge-distillation student rather than a full transformer.
+It provides a fluent `NetworkBuilder`, the common activations (ReLU, Sigmoid,
+Tanh, Softmax, LeakyReLU), basic backpropagation training with momentum, and
+optional feature-gated batch inference (`parallel`), serialization (`serde`),
+and GPU acceleration (`gpu`).
+
+## Architecture
+
+```text
+NetworkBuilder --> Network --> [Layer, Layer, ...] --> output
+                     |
+                     +-- pre-allocated buffers (no alloc during inference)
+```
+
+`NetworkBuilder::build()` allocates every intermediate activation buffer once,
+up front, sized from the layer dimensions. Each `Layer::forward` then writes
+in place into its pre-allocated output buffer, and the top-level `Network::forward`
+ping-pongs between two buffers via `split_at_mut()` to satisfy the borrow checker
+without copying. This removes heap allocation from the inference hot path
+entirely (see ADR-021 for the full rationale and the buffer-ping-pong mechanics).
+
+## Training
+
+`BackpropTrainer` implements gradient descent with momentum, driven by a
+`TrainingConfig` (learning rate, max epochs, and related knobs). A typical
+training loop:
+
+```rust
+use lattice_fann::{NetworkBuilder, Activation, BackpropTrainer, TrainingConfig, Trainer};
+
+let mut network = NetworkBuilder::new()
+    .input(2)
+    .hidden(4, Activation::Tanh)
+    .output(1, Activation::Tanh)
+    .build()
+    .unwrap();
+
+// XOR training data
+let inputs = vec![
+    vec![0.0, 0.0],
+    vec![0.0, 1.0],
+    vec![1.0, 0.0],
+    vec![1.0, 1.0],
+];
+let targets = vec![
+    vec![0.0],
+    vec![1.0],
+    vec![1.0],
+    vec![0.0],
+];
+
+let mut trainer = BackpropTrainer::new();
+let config = TrainingConfig::new()
+    .learning_rate(0.5)
+    .max_epochs(1000);
+
+let result = trainer.train(&mut network, &inputs, &targets, &config);
+```
+
+`GradientGuardStrategy` controls how the trainer reacts to NaN/Inf gradients
+during backprop (see ADR-022 for the guard strategies and their trade-offs).
+
+## GPU backend (`gpu` feature)
+
+```text
+GpuContext (device/queue) ─┬─> BufferPool (3-tier, lifecycle tracking)
+                           ├─> ShaderManager (compiled pipelines)
+                           └─> CircuitBreaker (memory pressure)
+
+GpuNetwork (inference) ──> GpuContext
+GpuTrainer (training) ───> GpuContext
+```
+
+`GpuNetwork` wraps a CPU `Network` and keeps it as the fallback path. A static
+`should_use_gpu(elements, batch_size)` predicate gates every dispatch, since GPU
+kernel launch overhead dominates for the small networks this crate targets:
+
+| Operation      | Threshold          | Rationale                                 |
+| -------------- | ------------------ | ------------------------------------------ |
+| Matrix-vector  | >10,000 elements   | GPU launch overhead dominates below this   |
+| Batch matmul   | batch_size > 100   | Amortize kernel launch cost                |
+| Activation     | >1,000 elements    | Element-wise is memory-bound               |
+| Max dispatch   | 100,000 elements   | Stay under the Metal 2ms watchdog          |
+
+Softmax always runs on CPU after reading the output buffer back from GPU — the
+only softmax use in this crate is a final classification layer, so the
+CPU post-processing pass is on the cold path, not the hot one.
+
+### Apple Silicon tuning
+
+- Buffers are aligned to 256 bytes (`apple_silicon::BUFFER_ALIGNMENT`).
+- Buffers are capped at 128MB (`apple_silicon::MAX_BUFFER_SIZE`).
+- Matmul shaders dispatch with a 32-lane workgroup (matches Apple Silicon's SIMD
+  group width); other shaders use a 256-lane workgroup for throughput.
+- Dispatches are kept under a 1.5ms headroom against the Metal 2ms watchdog
+  (`thresholds::MAX_DISPATCH_TIME_MS`) — if a single layer would exceed it, the
+  entire forward pass falls back to CPU rather than risking a GPU timeout.
+
+### Buffer pool
+
+`BufferPool` categorizes buffers by size to avoid the ~100-500us cost of a fresh
+GPU allocation on every call:
+
+| Tier   | Size range | Max pooled | Max age | Typical use            |
+| ------ | ---------- | ---------- | ------- | ----------------------- |
+| Small  | < 1MB      | 256        | 5 min   | Biases, small activations |
+| Medium | 1-10MB     | 64         | 3 min   | Layer weights            |
+| Large  | > 10MB     | 16         | 1 min   | Batch data, large layers |
+
+Each pooled buffer tracks creation time, last-used time, and use count, so idle
+or aged-out buffers can be evicted independently per tier.
+
+GPU deallocation is asynchronous even though Rust's `Drop` runs synchronously.
+A training loop that repeatedly allocates without releasing can hit an
+out-of-memory condition despite buffers appearing freed on the Rust side.
+Call `BufferPool::flush` (which releases every cached buffer immediately) and
+then poll the device periodically — for example once per epoch:
+
+```ignore
+for epoch in 0..epochs {
+    for batch in dataset.batches() {
+        train_step(&mut network, batch);
+    }
+    ctx.buffer_pool().flush();
+    ctx.poll(); // process pending GPU deallocations
+}
+```
+
+### Circuit breaker
+
+`CircuitBreaker` classifies memory pressure from a `usage / budget` ratio into
+`MemoryPressure::{Low, Medium, High, Critical}` and exposes its own
+`CircuitBreakerState::{Closed, Open, HalfOpen}` (the standard circuit-breaker
+pattern: closed allows requests, open blocks them, half-open probes recovery).
+`GpuContext::set_memory_pressure_handler` registers a callback invoked by
+`notify_memory_pressure()` so callers can react — e.g. trigger aggressive
+buffer eviction — before the breaker opens and forces CPU fallback.
+
+See ADR-025 for the full alternatives-considered analysis (CUDA, native Metal,
+candle/burn) and the known limitations (the buffer pool is not yet wired into
+`GpuNetwork::forward_gpu`'s own buffer creation, and softmax in hidden layers
+is not GPU-accelerated).

--- a/crates/fann/src/gpu/buffer.rs
+++ b/crates/fann/src/gpu/buffer.rs
@@ -1,61 +1,17 @@
-//! GPU Buffer Pool - 3-tier memory management with lifecycle tracking
+//! GPU buffer pool: 3-tier size-categorized pooling (see [`BufferCategory`]) with
+//! per-buffer lifecycle tracking, to avoid the ~100-500us cost of a fresh GPU
+//! allocation on every call. Integrates with [`CircuitBreaker`] to throttle
+//! pooling and force CPU fallback under memory pressure.
 //!
-//! # Memory Management Strategy
+//! GPU deallocation is asynchronous even though Rust's `Drop` runs synchronously,
+//! so a training loop that repeatedly allocates without releasing can hit an
+//! out-of-memory condition despite buffers appearing freed on the Rust side.
+//! Call [`BufferPool::flush`] (and then poll the device) periodically — e.g. once
+//! per epoch — to force pending GPU deallocations through before the next batch.
 //!
-//! This module implements a production-grade GPU buffer pooling system designed
-//! to address key challenges in GPU memory management:
-//!
-//! ## Problem
-//!
-//! 1. **Allocation Overhead**: GPU buffer allocation is expensive (~100-500μs per call)
-//! 2. **Fragmentation**: Frequent alloc/dealloc leads to memory fragmentation
-//! 3. **Async Deallocation**: Rust's `Drop` is synchronous but GPU dealloc is async,
-//!    causing OOM during training loops despite "freeing" memory
-//!
-//! ## Solution: 3-Tier Buffer Pool
-//!
-//! Buffers are categorized by size and managed in separate pools:
-//!
-//! | Tier   | Size Range | Max Pooled | Max Age | Use Case |
-//! |--------|------------|------------|---------|----------|
-//! | Small  | < 1MB      | 256        | 5 min   | Biases, small activations |
-//! | Medium | 1-10MB     | 64         | 3 min   | Layer weights |
-//! | Large  | > 10MB     | 16         | 1 min   | Batch data, large layers |
-//!
-//! ## Lifecycle Management
-//!
-//! Each buffer tracks:
-//! - **Creation time**: For age-based eviction
-//! - **Last used time**: For idle-based cleanup
-//! - **Use count**: For reuse efficiency metrics
-//!
-//! ## Memory Pressure Handling
-//!
-//! The pool integrates with [`CircuitBreaker`] to handle memory pressure:
-//!
-//! - **Normal**: Regular pooling and reuse
-//! - **Low/Medium**: Aggressive cleanup of idle buffers
-//! - **High/Critical**: Block new allocations, force CPU fallback
-//!
-//! ## Explicit Flush
-//!
-//! For training loops, call [`BufferPool::flush`] periodically to:
-//! 1. Release all cached buffers immediately
-//! 2. Prevent OOM from async deallocation lag
-//!
-//! ## Example
-//!
-//! ```ignore
-//! // During training loop
-//! for epoch in 0..epochs {
-//!     for batch in dataset.batches() {
-//!         train_step(&mut network, batch);
-//!     }
-//!     // Flush every epoch to prevent memory buildup
-//!     ctx.buffer_pool().flush();
-//!     ctx.poll(); // Process pending deallocations
-//! }
-//! ```
+//! Tier sizing/capacity and the full memory-pressure handling design: see
+//! ADR-025 and
+//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/fann/docs/design.md).
 
 use super::apple_silicon::BUFFER_ALIGNMENT;
 use super::circuit_breaker::{CircuitBreaker, MemoryPressure};

--- a/crates/fann/src/gpu/mod.rs
+++ b/crates/fann/src/gpu/mod.rs
@@ -1,37 +1,9 @@
-//! GPU compute backend for lattice-fann
-//!
-//! Production-grade GPU acceleration with:
-//! - 3-tier buffer pooling (Small/Medium/Large)
-//! - Circuit breaker for memory pressure
-//! - Pipeline caching
-//! - Intelligent GPU/CPU switching
-//! - Apple Silicon optimizations
-//!
-//! # Architecture
-//!
-//! ```text
-//! GpuContext (device/queue) ─┬─> BufferPool (3-tier, lifecycle tracking)
-//!                            ├─> ShaderManager (compiled pipelines)
-//!                            └─> CircuitBreaker (memory pressure)
-//!
-//! GpuNetwork (inference) ──> GpuContext
-//! GpuTrainer (training) ───> GpuContext
-//! ```
-//!
-//! # GPU/CPU Decision Heuristics
-//!
-//! | Operation | GPU Threshold | Rationale |
-//! |-----------|---------------|-----------|
-//! | Matrix-vector | >10K elements | GPU launch overhead dominates small ops |
-//! | Batch matmul | >100 batch size | Amortize kernel launch |
-//! | Activation | >1K elements | Element-wise is memory-bound |
-//!
-//! # Apple Silicon Specifics
-//!
-//! - 256-byte buffer alignment required
-//! - 128MB max buffer size
-//! - 2ms Metal watchdog (tile large dispatches)
-//! - 32-lane SIMD workgroups
+//! GPU compute backend for lattice-fann: buffer pooling, circuit-breaker memory
+//! pressure handling, pipeline caching, and Apple Silicon (Metal) tuning, with
+//! automatic CPU fallback below the size thresholds in [`thresholds`] where GPU
+//! launch overhead would dominate the computation (see ADR-025 for the full
+//! architecture, the GPU/CPU decision heuristics, and
+//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/fann/docs/design.md)).
 
 mod buffer;
 mod circuit_breaker;

--- a/crates/fann/src/lib.rs
+++ b/crates/fann/src/lib.rs
@@ -1,19 +1,19 @@
-//! lattice-fann: Fast neural network primitives for Lattice
+//! lattice-fann: fast neural network primitives for sub-5ms CPU inference.
 //!
-//! This crate provides lightweight neural network building blocks optimized
-//! for fast CPU inference (<5ms). Designed for tiny models that need to run
-//! quickly without GPU acceleration.
+//! Lightweight building blocks for tiny models — knowledge-distillation students
+//! rather than full transformers — that need to run without GPU acceleration:
+//! pre-allocated layer buffers so the forward pass makes no allocations (see
+//! ADR-021), a fluent [`NetworkBuilder`], the common activations (ReLU, Sigmoid,
+//! Tanh, Softmax, LeakyReLU), and basic backpropagation training with momentum
+//! (`BackpropTrainer`, gradient guards per ADR-022). Batch inference (`parallel`),
+//! serialization (`serde`), and GPU acceleration via wgpu (`gpu`, see ADR-025) are
+//! optional features.
 //!
-//! # Features
+//! For the network/training architecture and the GPU backend's buffer-pool and
+//! circuit-breaker design, see
+//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/fann/docs/design.md).
 //!
-//! - **Fast inference**: Pre-allocated buffers, no allocations during forward pass
-//! - **Fluent API**: `NetworkBuilder` for easy network construction
-//! - **Common activations**: ReLU, Sigmoid, Tanh, Softmax, LeakyReLU
-//! - **Training support**: Basic backpropagation with momentum
-//! - **Optional parallelism**: Feature-gated batch inference
-//! - **Serialization**: Optional serde support
-//!
-//! # Quick Start
+//! # Example
 //!
 //! ```
 //! use lattice_fann::{Network, NetworkBuilder, Activation};
@@ -34,48 +34,6 @@
 //! assert_eq!(output.len(), 3);
 //! let sum: f32 = output.iter().sum();
 //! assert!((sum - 1.0).abs() < 1e-5);
-//! ```
-//!
-//! # Architecture
-//!
-//! ```text
-//! NetworkBuilder --> Network --> [Layer, Layer, ...] --> output
-//!                      |
-//!                      +-- pre-allocated buffers (no alloc during inference)
-//! ```
-//!
-//! # Training
-//!
-//! ```
-//! use lattice_fann::{NetworkBuilder, Activation, BackpropTrainer, TrainingConfig, Trainer};
-//!
-//! let mut network = NetworkBuilder::new()
-//!     .input(2)
-//!     .hidden(4, Activation::Tanh)
-//!     .output(1, Activation::Tanh)
-//!     .build()
-//!     .unwrap();
-//!
-//! // XOR training data
-//! let inputs = vec![
-//!     vec![0.0, 0.0],
-//!     vec![0.0, 1.0],
-//!     vec![1.0, 0.0],
-//!     vec![1.0, 1.0],
-//! ];
-//! let targets = vec![
-//!     vec![0.0],
-//!     vec![1.0],
-//!     vec![1.0],
-//!     vec![0.0],
-//! ];
-//!
-//! let mut trainer = BackpropTrainer::new();
-//! let config = TrainingConfig::new()
-//!     .learning_rate(0.5)
-//!     .max_epochs(1000);
-//!
-//! let result = trainer.train(&mut network, &inputs, &targets, &config);
 //! ```
 //!
 //! # Feature Flags


### PR DESCRIPTION
This pull request adds comprehensive, up-to-date design documentation for the `lattice-fann` crate and improves the crate's inline documentation to be more concise, current, and maintainable. The main focus is on making the architecture, buffer pooling, and GPU backend design clearer, referencing the new extended docs where appropriate, and reducing duplication between code comments and external documentation.

**Documentation improvements:**

* Added a new `docs/` directory with `INDEX.md` and a detailed `design.md` covering architecture, training, buffer pooling, GPU backend, and Apple Silicon tuning. [[1]](diffhunk://#diff-488d7f79bdd0bf4307e14127c778f90b2c9ae7ac4536f751be9d38ddd1df7c26R1-R9) [[2]](diffhunk://#diff-a802caf3dfe7cef850dfe552c18b390ce9cdb2ca0da2f598b82b8bbf020bc62fR1-R146)
* Updated crate-level docs in `src/lib.rs` to be more concise, point to `docs/design.md` for in-depth explanations, and clarify the crate's focus and features.
* Removed redundant architecture and training examples from the main docs, consolidating them in the new extended documentation.

**GPU backend documentation:**

* Rewrote `src/gpu/mod.rs` and `src/gpu/buffer.rs` docs to summarize the design, reference the new `design.md`, and reduce duplication. [[1]](diffhunk://#diff-c19cfd2c18e80763accc71cc05a9f54881be38f5157b6c02fb01e9c11d15c801L1-R6) [[2]](diffhunk://#diff-091c7c4af69da5b0d0b921f2a659abe9a6eaa9b3f3914cbea465ff18d31a7f60L1-R14)

These changes make it much easier for contributors and users to understand the design and rationale behind `lattice-fann`, while keeping the code comments focused and maintainable.