### PR TITLE
docs(embed): extract crate narrative into docs/, condense rustdoc

### DIFF
--- a/crates/embed/docs/INDEX.md
+++ b/crates/embed/docs/INDEX.md
@@ -1,0 +1,9 @@
+# lattice-embed — extended docs
+
+Deeper documentation for the crate, kept alongside the source so it stays current
+as the code changes. The crate-level rustdoc (`src/lib.rs`) and `README.md` hold
+the summary and public API surface; the files here hold the longer-form narrative.
+
+- [design.md](design.md) — module architecture and the model-migration/backfill
+  workflow (`migration` + `backfill` modules): the state machine, the routing table,
+  and the four-stage migration sequence.

--- a/crates/embed/docs/design.md
+++ b/crates/embed/docs/design.md
@@ -1,0 +1,73 @@
+# lattice-embed design
+
+`lattice-embed` generates vector embeddings for the lattice-runtime substrate: pure-Rust
+local inference (no ONNX, no Python) over the BGE and multilingual E5/Qwen3 model
+families, plus an async `EmbeddingService` API and SIMD-accelerated vector ops
+(`utils::cosine_similarity`, `dot_product`, `normalize`, `euclidean_distance`) consumed
+directly by khive's ANN indexes.
+
+For model variants, MRL truncation, the two-layer cache, and batch-processing internals,
+see `DESIGN.md` at the crate root (line-numbered design notes with invariants and
+rejected alternatives). This file covers the model-migration/backfill workflow, which is
+large enough to warrant its own narrative.
+
+## Architecture
+
+The crate is organized leaf-most first:
+
+- **Model & config** — `model`: the `EmbeddingModel` enum and `ModelConfig` (MRL output
+  dimension, validation).
+- **Cache** — `cache`: sharded in-memory LRU (`EmbeddingCache`), Blake3-keyed.
+- **Services** — `service`: the `EmbeddingService` trait, `NativeEmbeddingService` (local
+  inference), `CachedEmbeddingService` (LRU wrapper).
+- **SIMD** — `simd`: dot product, cosine similarity, normalization, and int8/int4/binary
+  quantized distance kernels with per-platform dispatch (AVX-512/AVX2/NEON/wasm32
+  SIMD128). See the module-level docs inside `simd/` for the numeric and dispatch
+  invariants — those stay inline because they are load-bearing correctness notes, not
+  background.
+- **Migration** — `migration`: the `MigrationController` state machine that tracks a
+  single embedding-model migration from `Planned` through `Completed`.
+- **Backfill** — `backfill`: the `BackfillCoordinator`, which wraps a
+  `MigrationController` and adds request/query routing plus batch-size management on top
+  of the state machine.
+- **wasm** (optional, `wasm` feature + `wasm32` target only) — `wasm-bindgen` bindings
+  over the SIMD utility functions.
+
+## Model migration and backfill
+
+Swapping embedding models (for example BGE-small to multilingual-E5-small) requires
+re-embedding every stored document without an all-at-once cutover. The migration and
+backfill modules split this into two layers:
+
+1. **`MigrationController`** (in `migration`) is a plain state machine over a
+   `MigrationPlan`: `Planned -> InProgress -> Completed`, with `Paused`, `Failed`, and
+   `Cancelled` as side states. It has no opinion about routing — it only tracks progress
+   (`record_progress`) and exposes the current `MigrationState`.
+2. **`BackfillCoordinator`** (in `backfill`) wraps a `MigrationController` and answers the
+   question every request needs answered: *which model handles this?* It layers routing
+   decisions on top of the same state machine:
+
+   | State       | New Doc Route | Existing Doc Route | Query Route         |
+   |-------------|---------------|---------------------|----------------------|
+   | Planned     | Legacy        | Legacy              | Legacy               |
+   | InProgress  | DualWrite*    | Legacy               | Legacy or Target**  |
+   | Paused      | Legacy        | Legacy              | Legacy               |
+   | Completed   | Target        | Target              | Target               |
+   | Failed      | Legacy        | Legacy              | Legacy               |
+   | Cancelled   | Legacy        | Legacy              | Legacy               |
+
+   \* Only when `dual_write` is enabled in `BackfillConfig`.
+   \*\* Switches to `Target` once backfill progress reaches `target_query_threshold`.
+
+The overall migration sequence a caller drives is:
+
+1. Continue serving queries against the existing (legacy) embeddings.
+2. Route new document embeddings appropriately (dual-write during `InProgress`, or
+   target-only once cutover is safe).
+3. Backfill old documents with the new model's embeddings in batches
+   (`BackfillCoordinator` computes batch sizes from progress).
+4. Switch queries to the new model once coverage crosses `target_query_threshold`.
+
+This separation keeps the state machine (`migration`) reusable for any two-phase model
+swap, while the routing policy (`backfill`) stays specific to the embedding read/write
+paths.

--- a/crates/embed/src/backfill/coordinator.rs
+++ b/crates/embed/src/backfill/coordinator.rs
@@ -1,16 +1,8 @@
-//! Backfill coordinator: orchestrates embedding migration with routing logic.
-//!
-//! # Overview
-//!
-//! When migrating from one embedding model to another, the system needs to:
-//!
-//! 1. Continue serving queries against existing (legacy) embeddings
-//! 2. Route new document embeddings appropriately (dual-write or target-only)
-//! 3. Backfill old documents with the new model's embeddings in batches
-//! 4. Switch queries to the new model once sufficient coverage exists
-//!
-//! The [`BackfillCoordinator`] wraps a [`MigrationController`] and adds routing
-//! logic and batch management on top of the state machine.
+//! Backfill coordinator: orchestrates embedding migration with routing logic. See
+//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/embed/docs/design.md)
+//! for the four-stage migration workflow this coordinates. The [`BackfillCoordinator`]
+//! wraps a [`MigrationController`] and adds routing logic and batch management on top of
+//! the state machine.
 //!
 //! # Example
 //!

--- a/crates/embed/src/backfill/mod.rs
+++ b/crates/embed/src/backfill/mod.rs
@@ -1,19 +1,8 @@
-//! Backfill coordinator for embedding migration.
-//!
-//! Orchestrates the re-embedding of documents during model migration,
-//! routing new requests to the target model while backfilling old embeddings.
-//!
-//! # Overview
-//!
-//! When migrating from one embedding model to another, the system needs to:
-//!
-//! 1. Continue serving queries against existing (legacy) embeddings
-//! 2. Route new document embeddings appropriately (dual-write or target-only)
-//! 3. Backfill old documents with the new model's embeddings in batches
-//! 4. Switch queries to the new model once sufficient coverage exists
-//!
-//! The [`BackfillCoordinator`] wraps a [`crate::migration::MigrationController`] and adds
-//! routing logic and batch management on top of the state machine.
+//! Backfill coordinator for embedding migration: routes new requests to the target model
+//! while backfilling old embeddings in batches. See
+//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/embed/docs/design.md)
+//! for the four-stage migration workflow and how [`BackfillCoordinator`] layers routing on
+//! top of [`crate::migration::MigrationController`].
 //!
 //! # Example
 //!

--- a/crates/embed/src/lib.rs
+++ b/crates/embed/src/lib.rs
@@ -1,40 +1,27 @@
-//! **Stability tier**: Unstable
-//!
-//! The SIMD dispatch layer (`simd/`) and model-loading API are actively evolving.
-//! Platform consumers should use this crate via `lattice-engine`, not directly.
+//! **Stability tier: Unstable.** The SIMD dispatch layer (`simd/`) and model-loading API
+//! are actively evolving; platform consumers should use this crate via `lattice-engine`,
+//! not directly.
 //!
 //! **Exception — stable khive ANN consumer contract:**
 //! `simd::{squared_euclidean_distance, euclidean_distance, dot_product, cosine_similarity}`
 //! are a stable consumer contract for khive's ANN indexes (`khive-hnsw`, `khive-vamana`;
 //! ADR-012): their `(&[f32], &[f32]) -> f32` signatures and documented degenerate-input
 //! behaviour are guaranteed across the 0.4.x line, as is the squared-L2 ordering invariant
-//! relative to this crate's Euclidean wrapper (both derive from the same accumulated squared
-//! distance; SIMD is not bit-identical to scalar and promises no exact ordering of near-ties).
-//! The rest of `simd/` remains unstable.
-//!
-//! The 25 `unsafe` blocks are gated SIMD intrinsic calls: 21 on the
-//! AVX512/AVX2/NEON paths plus 4 wasm32 SIMD128 dispatch sites.
-//! See `foundation/STABILITY.md` for the full policy.
+//! relative to this crate's Euclidean wrapper (SIMD is not bit-identical to scalar and
+//! promises no exact ordering of near-ties). The rest of `simd/` remains unstable. The 25
+//! `unsafe` blocks in the crate are gated SIMD intrinsic calls: 21 on the AVX-512/AVX2/NEON
+//! paths plus 4 wasm32 SIMD128 dispatch sites.
 //!
 //! # lattice-embed
-
-#![warn(missing_docs)]
-#![allow(clippy::clone_on_copy)]
 //!
-//! Vector embedding generation with SIMD-accelerated operations for the lattice-runtime substrate.
+//! Vector embedding generation with SIMD-accelerated operations for the lattice-runtime
+//! substrate: pure-Rust local inference (no ONNX, no Python) over the BGE and multilingual
+//! E5/Qwen3 model families, an async API, and an in-process migration/backfill workflow for
+//! moving stored embeddings between model versions. See
+//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/embed/docs/design.md)
+//! for the module map and the migration/backfill architecture.
 //!
-//! This crate provides embedding generation services that convert text into
-//! high-dimensional vector representations suitable for semantic search and
-//! similarity matching.
-//!
-//! ## Features
-//!
-//! - **Native Embeddings**: Generate embeddings locally using pure Rust inference (default)
-//! - **BGE Models**: Support for BGE family of models (small/base/large)
-//! - **Async API**: Full async/await support with tokio
-//! - **SIMD Acceleration**: AVX2/NEON optimized vector operations
-//!
-//! ## Quick Start
+//! # Example
 //!
 //! ```rust,no_run
 //! use lattice_embed::{EmbeddingService, EmbeddingModel, NativeEmbeddingService};
@@ -54,36 +41,9 @@
 //!     Ok(())
 //! }
 //! ```
-//!
-//! ## Batch Processing
-//!
-//! ```rust,no_run
-//! use lattice_embed::{EmbeddingService, EmbeddingModel, NativeEmbeddingService};
-//!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let service = NativeEmbeddingService::default();
-//!
-//!     let texts = vec![
-//!         "First document".to_string(),
-//!         "Second document".to_string(),
-//!         "Third document".to_string(),
-//!     ];
-//!
-//!     let embeddings = service.embed(&texts, EmbeddingModel::BgeSmallEnV15).await?;
-//!     assert_eq!(embeddings.len(), 3);
-//!
-//!     Ok(())
-//! }
-//! ```
-//!
-//! ## Available Models
-//!
-//! | Model | Dimensions | Use Case |
-//! |-------|------------|----------|
-//! | `BgeSmallEnV15` | 384 | Fast, general purpose (default) |
-//! | `BgeBaseEnV15` | 768 | Balanced quality/speed |
-//! | `BgeLargeEnV15` | 1024 | Highest quality |
+
+#![warn(missing_docs)]
+#![allow(clippy::clone_on_copy)]
 
 pub mod backfill;
 mod cache;

--- a/crates/embed/src/migration/mod.rs
+++ b/crates/embed/src/migration/mod.rs
@@ -1,7 +1,7 @@
-//! Migration module: state machine for embedding model migration.
-//!
-//! Provides the [`MigrationController`] state machine, migration plan types,
-//! and progress tracking for embedding model migrations.
+//! Migration module: state machine for embedding model migration. Provides the
+//! [`MigrationController`] state machine, migration plan types, and progress tracking. See
+//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/embed/docs/design.md)
+//! for how this fits into the wider [`crate::backfill`] workflow.
 //!
 //! # Quick Start
 //!


### PR DESCRIPTION
This pull request introduces comprehensive extended documentation for the `lattice-embed` crate and improves the clarity and maintainability of both the codebase and its documentation. The main changes include adding in-depth design docs, streamlining and updating crate-level and module-level doc comments, and ensuring documentation stays current and accessible.

**Documentation additions and improvements:**

* Added `docs/INDEX.md` and `docs/design.md` to provide a detailed, narrative overview of the crate’s architecture, the model migration/backfill workflow, and module responsibilities. [[1]](diffhunk://#diff-b7dce446a60066bb0b712d65a013ae63ee44239f14e68092dad9b18197b00154R1-R9) [[2]](diffhunk://#diff-f1f4aebbf13b6575e306a9320720a33a4e6bf53ddffdab0789d9a4634dfb5850R1-R73)
* Updated crate-level documentation in `lib.rs` to concisely describe the crate’s purpose, stability guarantees, and migration/backfill features, and to reference the new design docs for deeper explanations. Redundant sections (batch processing example, model table) were removed for brevity. [[1]](diffhunk://#diff-caf78b4bd43bcaae444e23c54ad2f1d09ded61dfe9c627a5b3709547646bcbc9L1-R24) [[2]](diffhunk://#diff-caf78b4bd43bcaae444e23c54ad2f1d09ded61dfe9c627a5b3709547646bcbc9L57-R46)

**Module-level doc updates:**

* Simplified and clarified doc comments in `backfill/mod.rs` and `backfill/coordinator.rs`, replacing inline overviews with references to the new design documentation. [[1]](diffhunk://#diff-922fb96b12282baf521ed4cd11130167c363f1eb5c44056609d6318a3f2d8c48L1-R5) [[2]](diffhunk://#diff-f80b4f686fc329ce3958b9905fabe600980b12eedef7522dfef07ec1163d3068L1-R5)
* Updated `migration/mod.rs` documentation to reference the new design docs and clarify its role in the overall workflow.