### PR TITLE
docs(fann): deep-extract inline narrative into docs/, condense rustdoc

### DIFF
--- a/crates/fann/docs/INDEX.md
+++ b/crates/fann/docs/INDEX.md
@@ -1,9 +1,14 @@
-# lattice-fann — extended docs
+# lattice-fann documentation
 
-Deeper documentation for the crate, kept alongside the source so it stays current
-as the code changes. The crate-level rustdoc (`src/lib.rs`) and `README.md` hold
-the summary and public API surface; the files here hold the longer-form narrative.
+This directory contains the long-form design reference for `lattice-fann`.
+Crate rustdoc and public item documentation remain the API entry points; these
+pages explain the algorithms, invariants, formats, and operational boundaries.
 
-- [design.md](design.md) — network/training architecture, the zero-allocation
-  inference design, and the GPU backend (buffer pooling, circuit breaker,
-  Apple Silicon tuning).
+- [design.md](design.md) — crate architecture and how the builder, layers,
+  network, training module, and optional GPU path fit together.
+- [network.md](network.md) — dense-layer mechanics, preallocated activation
+  buffers, activation behavior, SIMD dispatch, validation, and binary format.
+- [training.md](training.md) — backpropagation, optimizer behavior, and
+  gradient safeguards.
+- [gpu.md](gpu.md) — optional GPU execution, resources, dispatch policy, and
+  CPU fallback behavior.

--- a/crates/fann/docs/design.md
+++ b/crates/fann/docs/design.md
@@ -1,146 +1,189 @@
 # lattice-fann design
 
-`lattice-fann` implements lightweight neural network primitives for sub-5ms CPU
-inference on small dense networks (up to roughly 100K parameters) — the kind of
-model used as a knowledge-distillation student rather than a full transformer.
-It provides a fluent `NetworkBuilder`, the common activations (ReLU, Sigmoid,
-Tanh, Softmax, LeakyReLU), basic backpropagation training with momentum, and
-optional feature-gated batch inference (`parallel`), serialization (`serde`),
-and GPU acceleration (`gpu`).
+`lattice-fann` is a compact, dense, feedforward neural-network crate. It is
+intended for local student models and classifiers where CPU inference must stay
+predictable. It is not a general tensor runtime: its core operation is a dense
+matrix-vector multiply followed by an activation.
 
-## Architecture
+The crate is CPU-first. GPU execution, parallel batches, and persistence are
+optional capabilities around the same layer and network representation; a
+complete CPU path does not depend on any of them.
+
+## Component map
 
 ```text
-NetworkBuilder --> Network --> [Layer, Layer, ...] --> output
-                     |
-                     +-- pre-allocated buffers (no alloc during inference)
+NetworkBuilder ──creates──> Layer ──owned by──> Network
+       │                         │                 │
+       │                         │                 ├── CPU forward inference
+       │                         │                 ├── optional parallel batches
+       │                         │                 └── binary / serde persistence
+       │                         │
+       │                         └── weights + biases + Activation
+       │
+BackpropTrainer ──updates──> Network::layers_mut() / Layer parameters
+
+GpuContext + GpuNetwork (feature = "gpu") ──optional accelerated path──> CPU model
 ```
 
-`NetworkBuilder::build()` allocates every intermediate activation buffer once,
-up front, sized from the layer dimensions. Each `Layer::forward` then writes
-in place into its pre-allocated output buffer, and the top-level `Network::forward`
-ping-pongs between two buffers via `split_at_mut()` to satisfy the borrow checker
-without copying. This removes heap allocation from the inference hot path
-entirely (see ADR-021 for the full rationale and the buffer-ping-pong mechanics).
+| Component | Owns | Responsibility |
+| --- | --- | --- |
+| `NetworkBuilder` | Input width and ordered layer specifications | Validates an architecture and initializes layers. |
+| `Layer` | Shape, row-major weights, biases, activation | Writes one dense affine transform and activation into a supplied buffer. |
+| `Network` | Layers and preallocated activation buffers | Checks connectivity, sequences CPU inference, and provides inspection APIs. |
+| Training types | Optimizer and gradient state | Update a network's existing parameter storage. |
+| GPU types | Device-facing context and acceleration state | Provide an optional execution route while retaining the CPU model. |
 
-## Training
+A `Layer` does not allocate an output vector for `forward`. A `Network` owns the
+mutable buffers that carry a sample through its layers. This separates immutable
+parameters from per-inference activations and keeps allocation out of the normal
+single-sample forward path.
 
-`BackpropTrainer` implements gradient descent with momentum, driven by a
-`TrainingConfig` (learning rate, max epochs, and related knobs). A typical
-training loop:
+## Building a network
+
+A builder records an input width and a sequence of output widths and
+activations. `input(n)` establishes the width consumed by the first layer;
+every `hidden` or `output` call appends a layer. `hidden` and `output` are
+runtime-equivalent; the latter documents the caller's intent and the last
+appended layer is the actual output layer.
 
 ```rust
-use lattice_fann::{NetworkBuilder, Activation, BackpropTrainer, TrainingConfig, Trainer};
+use lattice_fann::{Activation, NetworkBuilder};
 
 let mut network = NetworkBuilder::new()
-    .input(2)
-    .hidden(4, Activation::Tanh)
-    .output(1, Activation::Tanh)
-    .build()
-    .unwrap();
-
-// XOR training data
-let inputs = vec![
-    vec![0.0, 0.0],
-    vec![0.0, 1.0],
-    vec![1.0, 0.0],
-    vec![1.0, 1.0],
-];
-let targets = vec![
-    vec![0.0],
-    vec![1.0],
-    vec![1.0],
-    vec![0.0],
-];
-
-let mut trainer = BackpropTrainer::new();
-let config = TrainingConfig::new()
-    .learning_rate(0.5)
-    .max_epochs(1000);
-
-let result = trainer.train(&mut network, &inputs, &targets, &config);
+    .input(4)
+    .hidden(8, Activation::ReLU)
+    .output(3, Activation::Softmax)
+    .build_with_seed(7)?;
+# Ok::<(), lattice_fann::FannError>(())
 ```
 
-`GradientGuardStrategy` controls how the trainer reacts to NaN/Inf gradients
-during backprop (see ADR-022 for the guard strategies and their trade-offs).
+`build` initializes weights from entropy. `build_with_seed` instead feeds one
+`SmallRng` seeded from the supplied `u64` through every layer construction, so
+the same architecture and seed produce the same parameter values. Both paths
+enforce the same rules:
 
-## GPU backend (`gpu` feature)
+1. The input width is present and nonzero.
+2. At least one layer is specified, and every layer width is nonzero.
+3. Softmax is used only in the final layer.
+4. Layer allocation limits are respected during construction.
+5. Adjacent layer widths match when `Network::new` constructs the result.
+
+The final connectivity check is repeated by `Network::new`, because callers can
+also construct a network directly from `Layer` values.
+
+### Why Softmax is terminal
+
+Softmax couples the values in its output vector. Its derivative is a Jacobian,
+not a pointwise function. The trainer computes the output-layer relationship
+where it has the required context, while `Activation` derivative helpers expose
+only the Jacobian diagonal. An interior Softmax would therefore train with an
+incomplete gradient, so the builder rejects it. See ADR-023 for the accepted
+limitation.
+
+## CPU inference lifecycle
+
+Construction performs the allocations normal inference needs. `Network::new`
+creates one zero-filled activation buffer per layer; buffer *i* has exactly
+`layers[i].num_outputs()` elements. The caller's input is borrowed directly and
+is not copied into the buffer set.
 
 ```text
-GpuContext (device/queue) ─┬─> BufferPool (3-tier, lifecycle tracking)
-                           ├─> ShaderManager (compiled pipelines)
-                           └─> CircuitBreaker (memory pressure)
-
-GpuNetwork (inference) ──> GpuContext
-GpuTrainer (training) ───> GpuContext
+caller input ──> Layer 0 ──> buffer 0 ──> Layer 1 ──> buffer 1 ──> ... ──> buffer last
 ```
 
-`GpuNetwork` wraps a CPU `Network` and keeps it as the fallback path. A static
-`should_use_gpu(elements, batch_size)` predicate gates every dispatch, since GPU
-kernel launch overhead dominates for the small networks this crate targets:
+For each layer, the network writes `activation(Wx + b)` into its buffer and
+checks the result for `NaN` or infinity. The next layer reads the previous
+buffer and writes its own. Internally, `split_at_mut` yields distinct borrows of
+the previous and current buffer without copying an activation vector.
 
-| Operation      | Threshold          | Rationale                                 |
-| -------------- | ------------------ | ------------------------------------------ |
-| Matrix-vector  | >10,000 elements   | GPU launch overhead dominates below this   |
-| Batch matmul   | batch_size > 100   | Amortize kernel launch cost                |
-| Activation     | >1,000 elements    | Element-wise is memory-bound               |
-| Max dispatch   | 100,000 elements   | Stay under the Metal 2ms watchdog          |
+This is a chain of preallocated buffers, not a two-buffer implementation. The
+network retains every layer's latest activation so `Network::activations(i)` can
+expose it for debugging or training. A later forward pass overwrites all of
+them.
 
-Softmax always runs on CPU after reading the output buffer back from GPU — the
-only softmax use in this crate is a final classification layer, so the
-CPU post-processing pass is on the cold path, not the hot one.
+`Network::forward` takes `&mut self` because it overwrites these buffers and
+returns a borrowed view of the final one. The result remains current only until
+the next mutable use of the network. `forward_async` performs the same CPU work
+but returns an owned copy for compatibility with the GPU-facing API.
 
-### Apple Silicon tuning
+With the `parallel` feature, `forward_batch` shares read-only layer parameters
+across Rayon workers and creates a separate activation-buffer set for each
+input. It avoids cloning weights but intentionally trades per-input allocations
+for independent concurrent mutable state.
 
-- Buffers are aligned to 256 bytes (`apple_silicon::BUFFER_ALIGNMENT`).
-- Buffers are capped at 128MB (`apple_silicon::MAX_BUFFER_SIZE`).
-- Matmul shaders dispatch with a 32-lane workgroup (matches Apple Silicon's SIMD
-  group width); other shaders use a 256-lane workgroup for throughput.
-- Dispatches are kept under a 1.5ms headroom against the Metal 2ms watchdog
-  (`thresholds::MAX_DISPATCH_TIME_MS`) — if a single layer would exceed it, the
-  entire forward pass falls back to CPU rather than risking a GPU timeout.
+For shapes, matrix layout, numerical checks, SIMD dispatch, and serialization,
+see [network.md](network.md).
 
-### Buffer pool
+## Training integration
 
-`BufferPool` categorizes buffers by size to avoid the ~100-500us cost of a fresh
-GPU allocation on every call:
+The training module uses the same `Network` representation as deployment.
+`Network::layer_mut` and `Network::layers_mut` let training reach parameter
+storage; `Layer::weights_mut` and `Layer::biases_mut` expose the slices it
+updates. Model format, initialization, activations, and forward math therefore
+remain shared between training and inference.
 
-| Tier   | Size range | Max pooled | Max age | Typical use            |
-| ------ | ---------- | ---------- | ------- | ----------------------- |
-| Small  | < 1MB      | 256        | 5 min   | Biases, small activations |
-| Medium | 1-10MB     | 64         | 3 min   | Layer weights            |
-| Large  | > 10MB     | 16         | 1 min   | Batch data, large layers |
+`BackpropTrainer` is configured through `TrainingConfig`.
+`GradientGuardStrategy` controls how training reacts to non-finite gradients.
+Those are training-time choices: independently, inference scans every layer
+output and returns `FannError::NumericInstability` rather than returning a
+non-finite prediction. Parameter updates do not invalidate the reusable
+activation buffers; the next forward pass overwrites them with new values.
 
-Each pooled buffer tracks creation time, last-used time, and use count, so idle
-or aged-out buffers can be evicted independently per tier.
+Read [training.md](training.md) for the backpropagation algorithm, optimizer
+state, and gradient safety mechanisms.
 
-GPU deallocation is asynchronous even though Rust's `Drop` runs synchronously.
-A training loop that repeatedly allocates without releasing can hit an
-out-of-memory condition despite buffers appearing freed on the Rust side.
-Call `BufferPool::flush` (which releases every cached buffer immediately) and
-then poll the device periodically — for example once per epoch:
+## Optional GPU integration
 
-```ignore
-for epoch in 0..epochs {
-    for batch in dataset.batches() {
-        train_step(&mut network, batch);
-    }
-    ctx.buffer_pool().flush();
-    ctx.poll(); // process pending GPU deallocations
-}
-```
+The `gpu` feature accelerates rather than replaces the core model. Without it,
+the `gpu` module is absent and CPU `Network` is the complete implementation.
+With it, `GpuContext` supplies device-facing resources and `GpuNetwork` provides
+an accelerated network interface. The CPU representation remains available as
+the compatibility and fallback path.
 
-### Circuit breaker
+This division keeps model construction, validation, CPU execution, and
+serialization free of device requirements. It also keeps GPU resource lifetime
+and dispatch policy out of the `Layer` API, so small CPU models do not pay for a
+GPU dependency. See [gpu.md](gpu.md) for device policy, resource reuse, and
+fallback behavior.
 
-`CircuitBreaker` classifies memory pressure from a `usage / budget` ratio into
-`MemoryPressure::{Low, Medium, High, Critical}` and exposes its own
-`CircuitBreakerState::{Closed, Open, HalfOpen}` (the standard circuit-breaker
-pattern: closed allows requests, open blocks them, half-open probes recovery).
-`GpuContext::set_memory_pressure_handler` registers a callback invoked by
-`notify_memory_pressure()` so callers can react — e.g. trigger aggressive
-buffer eviction — before the breaker opens and forces CPU fallback.
+## Features and portability
 
-See ADR-025 for the full alternatives-considered analysis (CUDA, native Metal,
-candle/burn) and the known limitations (the buffer pool is not yet wired into
-`GpuNetwork::forward_gpu`'s own buffer creation, and softmax in hidden layers
-is not GPU-accelerated).
+| Feature | Effect |
+| --- | --- |
+| `std` | Default standard-library support. |
+| `simd` | Enables target-specific CPU matrix-vector and activation kernels with scalar fallback. |
+| `parallel` | Adds Rayon-backed batch inference with shared weights and per-input buffers. |
+| `serde` | Enables structured persistence that reconstructs transient buffers during load. |
+| `gpu` | Adds the WGPU-based acceleration interface without changing CPU availability. |
+
+SIMD is an optimization, not a different numerical model. Unsupported
+architectures and unavailable x86 capabilities fall back to scalar code.
+
+## Validation and failure boundaries
+
+Validation occurs at boundaries where invalid data could otherwise create an
+oversized allocation, an out-of-bounds parameter access, or a misleading result.
+
+| Boundary | Check | Failure |
+| --- | --- | --- |
+| Layer construction | Nonzero dimensions, checked product, 100,000,000-element cap | `InvalidLayerDimensions` or `ShapeTooLarge` |
+| Explicit parameters | Exact weights and biases for the declared shape | Count-mismatch error |
+| Network construction | Nonempty stack and matching adjacent dimensions | `EmptyNetwork` or `InvalidLayerDimensions` |
+| CPU forward | Input/output widths and finite layer results | Size mismatch or `NumericInstability` |
+| Binary loading | Header, version, bounds before allocation, exact payload length | `InvalidBuilder`, `ShapeTooLarge`, or `EmptyNetwork` |
+| Serde loading | Constructor validation and buffer reconstruction | Deserialization error rather than unusable state |
+
+The 100,000,000-element guard applies to a single requested tensor allocation.
+At four bytes per `f32`, that is approximately 400 MB. It is both a practical
+memory limit and a binary-parser hardening boundary: the parser applies it
+before it reads and collects a declared weight payload.
+
+## Documentation map
+
+- [network.md](network.md): layer mechanics, builder validation, CPU execution,
+  activations, SIMD, errors, and the binary format.
+- [training.md](training.md): backpropagation, optimizer state, and gradient
+  safeguards.
+- [gpu.md](gpu.md): optional device backend, resource lifecycle, and fallback
+  policy.
+- [INDEX.md](INDEX.md): entry point for this documentation set.

--- a/crates/fann/docs/gpu.md
+++ b/crates/fann/docs/gpu.md
@@ -1,0 +1,400 @@
+# GPU backend
+
+`lattice-fann`'s GPU backend executes dense feed-forward inference through `wgpu` compute
+pipelines. It is an acceleration path, not a separate network representation: `GpuNetwork`
+keeps an owned CPU `Network` for fallback while holding a GPU upload of each layer's weights
+and biases.
+
+This reference describes the implementation in `src/gpu/`, its dispatch policy, and the
+operational limits a caller must respect.
+
+## Backend at a glance
+
+```text
+GpuContext
+  ├── wgpu Device + Queue
+  ├── BufferPool ──> CircuitBreaker
+  └── ShaderManager ──> cached ComputePipelines
+
+GpuNetwork
+  ├── owned CPU Network ──> CPU fallback
+  └── GPU layer uploads ──> matmul / activation dispatches ──> staging-buffer readback
+```
+
+The backend has four cooperating parts:
+
+| Component | Responsibility |
+| --- | --- |
+| `GpuContext` | Selects an adapter, creates the `wgpu` device and queue, records device metadata, owns the pool and pipeline cache, and exposes synchronization and pressure APIs. |
+| `BufferPool` | Reuses compatible buffers in small, medium, and large tiers, tracks pool-managed bytes, and sheds cached buffers under pressure. |
+| `CircuitBreaker` | Stops repeated allocation attempts from cascading after recorded failures, then permits a recovery probe after a cooldown. |
+| `GpuNetwork` | Uploads an ordinary `Network`, chooses CPU or GPU inference, submits per-layer work, and reads the final vector back to the CPU. |
+
+The `shaders` module supplies the WGSL source used by `ShaderManager`. `ShaderType` is the
+closed set of operations exposed to the current inference path.
+
+## Availability and context creation
+
+`is_gpu_available()` performs a blocking adapter request with the default `wgpu` instance. It
+requests a high-performance adapter, has no presentation surface, and does not force a fallback
+adapter. It answers only whether an adapter was obtained; it does not create a device or compile
+pipelines.
+
+`get_gpu_info()` repeats adapter selection and returns the adapter name, vendor, device type,
+backend, maximum buffer size, and maximum compute-workgroup size in the X dimension. Use it for
+diagnostics before constructing a context, not as a promise that later device creation will
+succeed.
+
+`GpuContext::new()` is asynchronous. It:
+
+1. selects the same high-performance, headless adapter;
+2. captures adapter information and reported limits;
+3. requests a device with no required optional features, default `wgpu` limits, and performance
+   memory hints;
+4. creates a `BufferPool` for that device; and
+5. creates a `ShaderManager` and warms its common inference pipelines.
+
+`GpuContext::new_blocking()` is the synchronous wrapper around that procedure. Context creation
+can return `GpuError::NotAvailable` when no adapter is found or `GpuError::DeviceCreation` when
+the device request fails. A caller that wants a CPU-only experience must choose that fallback
+when context creation fails; constructing `GpuNetwork` itself requires an existing context.
+
+The context owns `Arc`s for its `Device` and `Queue`, so its pool and manager share the same
+device. `info()` exposes `GpuDeviceInfo`, while `device()`, `queue()`, `buffer_pool()`, and
+`shader_manager()` expose the corresponding runtime components.
+
+### Polling, waiting, and pool flushing
+
+`poll()` asks `wgpu` to make progress without waiting. `wait()` blocks until pending GPU work
+completes. `flush_memory()` first drains the buffer pool and then calls `wait()`, returning the
+number of pool bytes it dropped.
+
+This ordering matters. Rust dropping a `wgpu::Buffer` removes the host object, but physical GPU
+deallocation can lag while queued work still references resources. A loop can therefore see
+buffers disappear at the Rust level while the device retains enough memory to reject the next
+allocation. For long-running work, flush the pool and poll or wait at a controlled boundary such
+as an epoch boundary; a pool flush alone is not a synchronous release.
+
+`memory_usage()` is pool accounting, not a device-wide memory meter. It includes allocations made
+through `BufferPool` until the pool drops them, including checked-out buffers, but it excludes
+buffers allocated directly with `wgpu`. In particular, the current `GpuNetwork` creates its
+input, output, uniform, and staging buffers directly, so those allocations are neither pooled
+nor included in this counter.
+
+## Dispatch policy and platform limits
+
+The module exports the following policy constants. They are deliberately visible so callers can
+make the same choices as the built-in wrapper.
+
+| Constant | Value | Current use |
+| --- | ---: | --- |
+| `MATMUL_MIN_ELEMENTS` | 10,000 | A one-input network uses GPU only at or above this parameter count. |
+| `BATCH_MIN_SIZE` | 100 | Part of the batch heuristic: for `batch_size > 1`, `elements * batch_size` must be at least `100 * 100` (10,000). |
+| `ACTIVATION_MIN_ELEMENTS` | 1,000 | Published activation crossover policy; the current `GpuNetwork` does not independently gate activation dispatches with it. |
+| `MAX_ELEMENTS_PER_DISPATCH` | 100,000 | A layer with more elements than this causes the whole `GpuNetwork` forward pass to restart on CPU. Exactly 100,000 is allowed. |
+| `MAX_DISPATCH_TIME_MS` | 1.5 ms | Target headroom for the element-count cap; it is not measured dynamically by the current code. |
+
+`should_use_gpu(elements, batch_size)` uses a simple threshold rather than a runtime benchmark:
+
+```text
+batch_size == 1:  elements >= 10,000
+batch_size > 1:   elements * batch_size >= 10,000
+```
+
+The GPU wrapper calls this once at construction using `network.total_params()` and a batch size
+of one. It therefore does not reevaluate the decision per forward pass, and it currently exposes
+no batched-forward API. A network below the single-input threshold still uploads its layer data
+when constructed, but `forward` takes the CPU route.
+
+### Metal and Apple Silicon
+
+Metal has an approximately 2 ms watchdog limit for a dispatch. The backend reserves a 1.5 ms
+target to leave 0.5 ms of headroom for variance. It avoids the watchdog by declining GPU execution
+when a layer's `num_inputs * num_outputs` is greater than 100,000; it does not tile oversized
+layers. That condition falls back to `forward_cpu(input)` for the entire network, rather than
+mixing GPU and CPU layers.
+
+The Apple-Silicon tuning constants are:
+
+| Constant | Value | Meaning |
+| --- | ---: | --- |
+| `BUFFER_ALIGNMENT` | 256 bytes | Buffer-pool requests are rounded up to this boundary. |
+| `MAX_BUFFER_SIZE` | 128 MiB | Published platform limit; the pool and network do not currently enforce it themselves. |
+| `WORKGROUP_SIZE` | 32 | Matmul workgroup width, matching Apple Silicon's 32-lane SIMD width. |
+| `ACTIVATION_WORKGROUP_SIZE` | 256 | Element-wise workgroup width chosen for throughput. |
+
+`GpuContext::is_apple_silicon()` recognizes a Metal backend whose name includes `Apple`, `M1`,
+`M2`, or `M3`. `optimal_workgroup_size("matmul")` reports 32 for those devices and 64 elsewhere;
+it reports 256 for other operations on both. This is advisory today: the WGSL shaders embed their
+own workgroup sizes, and `GpuNetwork` dispatches using `ShaderType::workgroup_size()`.
+
+## Buffer-pool design
+
+Creating a new GPU allocation can cost roughly 100–500 microseconds, so the pool keeps returned
+buffers for a compatible future request. It has three categories based on the **aligned** size:
+
+| Category | Size range | Maximum retained | Maximum age |
+| --- | --- | ---: | ---: |
+| `Small` | less than 1 MiB | 256 | 300 seconds |
+| `Medium` | 1 MiB through less than 10 MiB | 64 | 180 seconds |
+| `Large` | 10 MiB or more | 16 | 60 seconds |
+
+### Allocation and reuse
+
+`BufferPool::allocate(size, usage, label)` performs these steps:
+
+1. asks its `CircuitBreaker` whether a request is allowed;
+2. rounds the requested size up to a 256-byte boundary;
+3. classifies that aligned size into a tier;
+4. looks for a returned buffer in that tier with identical `BufferUsages`, a size at least as large
+   as requested, and a size no more than twice the request; and
+5. either returns the reused buffer or creates a new `wgpu::Buffer` of the aligned size.
+
+The same-usage requirement prevents a buffer from being reused with an incompatible binding or
+copy capability. The two-times cap prevents a small request from monopolizing a much larger
+allocation. `align_size` uses bit rounding, so the alignment must remain a power of two; the
+current 256-byte constant satisfies that requirement.
+
+Each `GpuBuffer` records its size, usage, category, creation time, last-use time, use count, and
+an allocation identifier intended for tracing. `mark_used()` updates last use and increments the
+counter. A buffer is retainable only while younger than its tier's age limit and when it was used
+within the last 60 seconds **or** its reuse rate exceeds one use per hour.
+
+### Returning, evicting, and cleaning
+
+`return_buffer` immediately drops a buffer that is no longer retainable and subtracts its size
+from pool accounting. Otherwise it appends the buffer to its category. If that category is at its
+configured capacity, it evicts the retained buffer with the lowest use count before inserting the
+new one. The implementation's selection is use-count based even though an adjacent code comment
+uses the word “oldest”.
+
+`cleanup(pressure)` shrinks every tier to a pressure-dependent target. It sorts the tier by use
+count and drops the least-reused buffers first. The target is the floored product
+`(1 - cleanup_aggressiveness) * tier_capacity`:
+
+| Pressure | Cleanup aggressiveness | Retained target |
+| --- | ---: | ---: |
+| `None` | 0.1 | 90% of capacity |
+| `Low` | 0.3 | 70% of capacity |
+| `Medium` | 0.5 | 50% of capacity |
+| `High` | 0.7 | 30% of capacity |
+| `Critical` | 1.0 | 0 buffers |
+
+`flush()` drains all categories; `flush_category(category)` drains only one. Both report bytes
+dropped and update evictions and current-memory accounting. `pooled_count()` reports the number
+of currently returned buffers, while `stats()` supplies allocation, hit, miss, eviction, and
+current-byte atomics. `PoolStats::hit_rate()` returns zero when no lookup has occurred.
+
+The pool exposes `record_failure()` and `record_success()` but does not call them automatically
+inside `allocate`. Integrations that identify allocation success or failure are responsible for
+recording those outcomes if they want circuit-breaker state to reflect them.
+
+## Memory pressure and circuit breaking
+
+`GpuContext` can maintain a caller-provided memory budget. Once set, it maps
+`memory_usage() / budget` to `MemoryPressure`:
+
+| Usage ratio | Level | Intended response |
+| --- | --- | --- |
+| below 60% | `None` | Normal operation; light cleanup still retains 90% of each tier. |
+| 60% to below 70% | `Low` | Begin monitoring and reduce the cache target. |
+| 70% to below 80% | `Medium` | Reduce allocations and retain half of each tier. |
+| 80% to below 90% | `High` | Clean aggressively. |
+| 90% or more | `Critical` | Signal that callers should block new allocations and remove all cached pool buffers. |
+
+`check_memory_pressure()` returns `None` until a budget is configured. The context does not
+validate the budget or automatically invoke cleanup or allocation blocking. Call
+`notify_memory_pressure()` after significant allocations to calculate the current level and
+invoke an installed handler with the level and pool-accounted byte count. Notification is not
+edge-triggered: each explicit call can invoke the handler even if the level did not change.
+
+An application can use the handler to reduce its own batch size, flush pooled buffers, or change
+to CPU work:
+
+```rust,ignore
+context.set_memory_budget(512 * 1024 * 1024);
+context.set_memory_pressure_handler(|level, bytes| {
+    if matches!(level, MemoryPressureLevel::High | MemoryPressureLevel::Critical) {
+        eprintln!("GPU pool uses {} MiB at {level:?}", bytes / 1024 / 1024);
+    }
+});
+```
+
+The circuit breaker defaults to five recorded failures and a 30-second recovery timeout in a
+new buffer pool. Its state machine is:
+
+```text
+Closed -- failures reach threshold --> Open
+  ^                                  |
+  |                                  | recovery timeout elapses
+  |                                  v
+  +--------- success ----------- HalfOpen
+                                      |
+                                      | failure
+                                      v
+                                    Open
+```
+
+- In `Closed`, requests are allowed. The breaker opens when the cumulative failure count reaches
+  its configured threshold.
+- In `Open`, requests are denied until the recovery timeout has elapsed. The next
+  `allow_request()` moves the breaker to `HalfOpen` and allows the recovery probe.
+- In `HalfOpen`, a recorded success closes the circuit and resets the failure count; a recorded
+  failure immediately reopens it. Although the state represents recovery testing, the current
+  implementation allows every `allow_request()` call while it remains half-open; it does not
+  enforce a single-probe limit.
+
+Lock poisoning is treated conservatively in the request path: `allow_request()` and `state()`
+fail closed, reporting or behaving as `Open`. Statistics and reset paths instead make a
+best-effort update. `reset()` returns the breaker to `Closed`, clears both counters and the last
+failure time, and refreshes the state-change timestamp.
+
+## Shader inventory and pipeline caching
+
+`ShaderManager` maps a `ShaderType` to WGSL source, a debug label, and a fixed workgroup size.
+
+| Shader type | Operation | Workgroup |
+| --- | --- | ---: |
+| `MatrixVectorMultiply` | `y = W x + b` | 32 × 1 × 1 |
+| `MatrixVectorMultiplyRelu` | `max(0, W x + b)` in one kernel | 32 × 1 × 1 |
+| `ReLU` | In-place `max(0, x)` | 256 × 1 × 1 |
+| `LeakyReLU` | In-place `x` when positive, otherwise `alpha * x` | 256 × 1 × 1 |
+| `Sigmoid` | In-place logistic function | 256 × 1 × 1 |
+| `Tanh` | In-place hyperbolic tangent | 256 × 1 × 1 |
+
+Context construction warms `MatrixVectorMultiply`, `MatrixVectorMultiplyRelu`, `ReLU`,
+`Sigmoid`, and `Tanh`. `LeakyReLU` remains lazy and is compiled on its first request. A cache hit
+returns a cloned `Arc<ComputePipeline>`. A miss compiles the pipeline, inserts it under its
+`ShaderType`, and records the elapsed compile time. `CacheStats` provides hit rate, compilation
+count, and average compile time; both rate helpers return zero with no observations.
+
+The cache releases the read lock before compiling and takes a write lock only to insert. This
+keeps the long compilation step out of the write-locked region, but concurrent first requests for
+the same shader can compile it more than once before one insertion replaces the other. The cache
+does not currently use a double-check or single-flight mechanism.
+
+`clear_cache()` drops cached pipeline references, while `cached_count()` counts the present
+entries. A poisoned cache lock becomes `GpuError::LockPoisoned` for `get_or_compile`; the
+best-effort statistics accessor returns default statistics if its read lock is poisoned.
+
+### Kernel behavior
+
+The matmul shader assigns one global invocation to one output row. For row `r`, it calculates:
+
+```text
+output[r] = bias[r] + sum(weights[r * cols + c] * input[c], c = 0..cols)
+```
+
+It handles the first multiple-of-four columns through four explicit multiply-add statements per
+loop iteration, then handles the tail one column at a time. The guard `row >= rows` ensures the
+ceil-rounded dispatch does not write beyond the output vector. The fused variant performs the
+same computation and writes `max(0, sum)`.
+
+Element-wise shaders guard `index >= size` for the same reason. Sigmoid clamps inputs to
+`[-10, 10]` before `exp`; this prevents the `f32` exponential overflow associated with very large
+positive values but deliberately makes the extreme tails behave as if they were at the clamp
+boundary. Tanh clamps inputs to `[-5, 5]` before evaluating `tanh`, reflecting its faster
+saturation. These are part of the GPU numerical behavior.
+
+## `GpuNetwork` execution
+
+`GpuNetwork::new(context, network)` owns the supplied CPU network and immediately uploads every
+layer's weight and bias slices into storage buffers. It also computes `use_gpu` once from the
+network's total parameter count and the single-input threshold. The CPU network remains available
+through `cpu_network()` and is the implementation of all CPU fallbacks.
+
+The upload occurs even when `is_using_gpu()` will be false. Construct a plain `Network` instead
+when a context and these unused GPU uploads are not wanted.
+
+### Forward pass
+
+`forward(input)` is asynchronous and first validates that `input.len()` exactly matches the CPU
+network's input width. It returns `GpuError::InvalidDimensions` on a mismatch. `forward_sync()`
+blocks on the same method.
+
+If the constructor chose CPU, `forward` delegates directly to the owned CPU network. Otherwise it
+runs this sequence:
+
+1. Upload the input to a fresh storage/copy-source buffer.
+2. For each layer, check `num_inputs * num_outputs`. If it exceeds 100,000, abandon the GPU path
+   and recompute the complete network from the original input on CPU.
+3. Choose `MatrixVectorMultiplyRelu` for a ReLU layer; all other activations use
+   `MatrixVectorMultiply` first.
+4. Allocate a fresh output buffer and a 16-byte uniform buffer containing the output-row and
+   input-column counts. Bind uniforms, weights, the current vector, biases, and output at the
+   shader's five bindings.
+5. Submit `ceil(num_outputs / workgroup_size)` workgroups. The matrix shaders use 32 threads per
+   workgroup.
+6. For Leaky ReLU, sigmoid, or tanh, submit a second in-place element-wise dispatch with its own
+   uniform buffer. Linear needs no activation dispatch. Queue submission order keeps this second
+   dispatch after its matrix result.
+7. Treat the output as the next layer's input, then copy the final vector into a fresh map-readable
+   staging buffer and wait for mapping to complete.
+
+The final mapped bytes are copied into a `Vec<f32>` and returned. The staging buffer is temporary;
+the final result is CPU-owned.
+
+### Activation support and softmax limitation
+
+ReLU is the only fused activation, saving one compute submission. Leaky ReLU carries its `alpha`
+parameter in the activation uniform. Sigmoid and tanh use the clamped numerical behavior described
+above. Linear is a no-op.
+
+Softmax is not a WGSL activation in this backend. If the **last** layer declares softmax,
+`read_buffer` computes a stable CPU softmax after readback by subtracting the maximum logit,
+exponentiating, summing, and normalizing. This costs a device-to-host round trip but avoids a GPU
+reduction kernel.
+
+A non-final softmax is unsupported: the GPU activation stage performs no softmax for it, so the
+following GPU layer receives the preceding layer's unnormalized output. Do not use an architecture
+with hidden softmax layers on this GPU path. Use the CPU network instead until per-layer softmax
+fallback or a GPU softmax kernel is implemented.
+
+### Weight synchronization and flushing
+
+`sync_weights()` overwrites each uploaded weight and bias buffer with the current values in the
+owned CPU network. Call it after modifying those values through whatever owns or updates the
+network; creating `GpuNetwork` does not establish automatic weight synchronization.
+
+`GpuNetwork::flush()` delegates to `GpuContext::flush_memory()`. It drains only the context's
+buffer pool and waits for queued work. It does not retroactively pool the network's direct
+working buffers, but the wait is still the important synchronization boundary when managing
+asynchronous GPU destruction.
+
+## Errors and fallback decisions
+
+`GpuResult<T>` is `Result<T, GpuError>`. The error taxonomy separates unavailable hardware,
+device creation, invalid dimensions, pool and allocation pressure, shader or pipeline failures,
+execution failures, mapping failures, network failures, watchdog risk, and poisoned internal
+locks.
+
+`GpuError::is_recoverable()` returns true for `MemoryPressure`, `PoolExhausted`, and `Execution`.
+`GpuError::should_fallback_to_cpu()` returns true for `NotAvailable`, `DeviceCreation`,
+`MemoryPressure`, and `WatchdogRisk`. These predicates are guidance for an outer scheduling
+policy; the current `GpuNetwork` automatically falls back only for its size decision and an
+oversized-layer watchdog guard. It propagates other GPU errors to its caller.
+
+## Operational guidance
+
+Use the GPU path where each dense inference is substantial enough to amortize upload, dispatch,
+and readback overhead. The thresholds are deliberately conservative and should not be interpreted
+as a universal benchmark result for every adapter or architecture.
+
+For sustained workloads:
+
+1. Construct one context and reuse it, so warmed pipelines and the pool can pay back their setup
+   cost.
+2. Configure a realistic pool budget if the process needs pressure visibility, and explicitly
+   notify the context after significant pool activity.
+3. Return eligible `GpuBuffer`s to the pool when using the pool API; otherwise no reuse occurs.
+4. At safe workload boundaries, flush pooled buffers and wait or poll so asynchronous releases
+   reach the device before the next allocation burst.
+5. Keep GPU layers at or below the dispatch cap. Split or redesign larger work outside this
+   backend rather than relying on it to tile the layer.
+6. Restrict GPU network activations to linear, ReLU, Leaky ReLU, sigmoid, tanh, and final-layer
+   softmax. Route hidden-softmax networks through CPU.
+
+For diagnostics, inspect `GpuContext::info()`, `BufferPool::stats()`, pipeline `CacheStats`, and
+the circuit-breaker state and counters. A low pool hit rate can mean the workload's allocation
+sizes or usage flags are too variable for reuse; it is not evidence that direct allocations made
+by `GpuNetwork` are being pooled.

--- a/crates/fann/docs/network.md
+++ b/crates/fann/docs/network.md
@@ -1,0 +1,334 @@
+# Network core reference
+
+This page describes the CPU network core: dense-layer storage and evaluation,
+builder validation, preallocated activation buffers, activation behavior, and
+persistence. For training and the optional GPU path, see
+[design.md](design.md).
+
+## Mathematical model
+
+`Network` is an ordered, nonempty sequence of `Layer` values. A layer maps an
+input vector of width *I* to an output vector of width *O*:
+
+```text
+z[o] = bias[o] + sum(input[i] * weight[o, i], i = 0..I)
+output[o] = activation(z[o])
+```
+
+The output width of layer *k* must equal the input width of layer *k + 1*.
+`Network::new` checks this whether layers originate from a builder, binary data,
+Serde, or direct construction. There is no input-layer object: the first layer
+consumes the slice given to `Network::forward`, and the final layer buffer is the
+network result.
+
+## Layer representation
+
+`Layer` owns the data below.
+
+| Field | Shape | Meaning |
+| --- | --- | --- |
+| `num_inputs` | scalar | Width of a vector accepted by the layer. |
+| `num_outputs` | scalar | Width written by the layer. |
+| `weights` | `num_outputs * num_inputs` `f32`s | Dense matrix in output-major row order. |
+| `biases` | `num_outputs` `f32`s | One additive bias for each output. |
+| `activation` | `Activation` | Function applied after the affine calculation. |
+
+The row for output `o` begins at `o * num_inputs`. A two-output, three-input
+layer stores its matrix as:
+
+```text
+[ w00, w01, w02,  w10, w11, w12 ]
+   └── output 0 ──┘  └── output 1 ──┘
+```
+
+With input `[x0, x1, x2]`, weights `[1, 2, 3, 4, 5, 6]`, and biases
+`[0.1, 0.2]`, the affine values are `1*x0 + 2*x1 + 3*x2 + 0.1` and
+`4*x0 + 5*x1 + 6*x2 + 0.2` before activation.
+
+`Layer::forward` requires an input slice of exactly `num_inputs` and an output
+slice of exactly `num_outputs`. It writes in place—there is no output allocation
+or returned vector. Width mismatches are errors before matrix computation.
+
+### Creation and parameter checks
+
+`Layer::new` creates zero biases and samples weights from a normal
+Xavier/Glorot distribution:
+
+```text
+mean = 0
+standard deviation = sqrt(2 / (num_inputs + num_outputs))
+```
+
+`Layer::new_with_rng` uses the same distribution but accepts a caller RNG,
+supporting reproducible builder initialization. `Layer::zeros` creates zero
+weights and biases. `Layer::with_weights` accepts existing parameter vectors only
+after validating all of these invariants:
+
+- both dimensions are nonzero;
+- the `num_inputs * num_outputs` product does not overflow;
+- the weight tensor has at most 100,000,000 elements;
+- the weight vector length exactly equals that product; and
+- the bias vector length exactly equals `num_outputs`.
+
+These checks make row indexing safe in `forward` and reject unreasonable
+allocation requests. The 100,000,000-element cap is roughly 400 MB for one
+`f32` allocation. It is enforced by `validate_layer_dimensions` and applied by
+decoding before a weight payload is collected.
+
+`weights`, `biases`, and their mutable forms expose slices for persistence and
+training. `Layer::num_params` counts weights plus biases. `get_weight` and
+`set_weight` use the output-major index and return `None` or `false` for an
+invalid coordinate instead of panicking.
+
+## Builder behavior
+
+`NetworkBuilder` is the usual construction API:
+
+```rust
+use lattice_fann::{Activation, NetworkBuilder};
+
+let network = NetworkBuilder::new()
+    .input(784)
+    .hidden(128, Activation::ReLU)
+    .dense(64)
+    .output(10, Activation::Softmax)
+    .build()?;
+# Ok::<(), lattice_fann::FannError>(())
+```
+
+The builder stores one input width and ordered `(output_width, activation)`
+pairs. Calling `input` again replaces the prior input size. `hidden` and `output`
+both append a pair; `output` is a readability marker and does not have distinct
+runtime behavior. `dense(size)` is `hidden(size, Activation::ReLU)`.
+
+`build` uses entropy-seeded initialization. `build_with_seed(seed)` creates one
+seeded `SmallRng` and passes it through every layer initialization. Given the same
+architecture and seed, it produces identical parameter values.
+
+Both build paths reject a missing input, zero input, no layers, or a zero-size
+layer. They also reject Softmax before the final layer, then construct each layer
+using the preceding width as its input. `Network::new` rechecks the final chain
+and allocates reusable activation buffers.
+
+### Softmax is output-only
+
+Softmax normalizes across a vector and has a full Jacobian:
+
+```text
+J[i, j] = s[i] * (delta(i, j) - s[j])
+```
+
+The general `Activation` derivative helpers provide only its diagonal,
+`s[i] * (1 - s[i])`. Output-layer backpropagation has the context to use the
+complete relationship, but an interior Softmax would silently train using the
+diagonal approximation. The builder rejects that topology; see ADR-023 for the
+accepted limitation.
+
+## Preallocated forward execution
+
+When a network is constructed, it allocates exactly one activation `Vec<f32>`
+for every layer. Buffer *i* has `layers[i].num_outputs()` values. The user input
+is borrowed by the first layer rather than copied.
+
+```text
+layers:  L0 (I0 -> O0)       L1 (O0 -> O1)       L2 (O1 -> O2)
+buffers:         [O0]                 [O1]                 [O2]
+
+input ───> L0 ───> buffer 0 ───> L1 ───> buffer 1 ───> L2 ───> buffer 2
+```
+
+The first layer writes buffer 0. For each later layer, the previous buffer is
+read and the current layer buffer is written. `split_at_mut` makes the two
+borrows disjoint without cloning or copying activations. Therefore the normal
+`Network::forward` hot path makes no activation-buffer allocation.
+
+This is not a two-buffer ping-pong design: the network retains every layer's
+latest output. `Network::activations(layer_index)` can expose any current buffer
+for debugging or training, and the next forward pass overwrites all of them.
+
+`forward` takes `&mut self` and returns a slice borrowed from the final buffer.
+It remains the current output only until the network is mutably used again.
+`forward_async` does the same CPU work but copies the final slice into an owned
+`Vec<f32>` for an asynchronous interface compatible with the GPU API.
+
+### Finite-output check
+
+After every layer, the network checks each produced value for `NaN` and
+infinity. This check is active in release builds: it returns
+`FannError::NumericInstability` with the layer and element position rather than
+returning a non-finite prediction. The error string is formatted only after a
+failure, not on each successful hot-path call.
+
+Shape validation and finite-output validation solve different problems. A valid
+shape can still produce `NaN` or infinity from bad input, bad parameters, or
+overflow, so both checks are necessary.
+
+### Parallel batches
+
+With the `parallel` feature, `forward_batch` shares immutable layer weights and
+biases across Rayon workers. Each input gets its own freshly allocated
+activation-buffer set, avoiding mutable sharing without cloning parameter
+matrices. This intentionally differs from the single-sample path: it exchanges
+per-input allocations for independent parallel execution.
+
+## Activation reference
+
+`Activation` supports single-value evaluation, in-place batch evaluation, and
+derivatives calculated from an activation output `y`. `forward` is useful for
+pointwise functions. A scalar Softmax evaluates to `1.0`; use `forward_batch` to
+normalize an actual output vector.
+
+| Variant | Forward rule | Derivative from output | Range |
+| --- | --- | --- | --- |
+| `Linear` | `x` | `1` | unbounded |
+| `Sigmoid` | `1 / (1 + exp(-x))` | `y * (1 - y)` | `(0, 1)` for finite input |
+| `Tanh` | `tanh(x)` | `1 - y²` | `[-1, 1]` |
+| `ReLU` | `max(0, x)` | `1` when `y > 0`, else `0` | `[0, infinity)` |
+| `LeakyReLU(a)` | `x` if `x > 0`, else `a*x` | `1` when `y > 0`, else `a` | usually unbounded |
+| `Softmax` | normalized exponentials over the slice | diagonal only: `y * (1 - y)` | finite results sum to `1` |
+
+`ReLU` is the default. `Activation::DEFAULT_LEAKY_ALPHA` is `0.01`, while a
+`LeakyReLU` value stores its chosen alpha. `is_bounded` is true for Sigmoid,
+Tanh, and Softmax; `is_softmax` identifies the vector-valued case.
+
+### Stable Sigmoid and Softmax
+
+Sigmoid uses equivalent formulas on either side of zero:
+
+```text
+x >= 0:  1 / (1 + exp(-x))
+x < 0:   exp(x) / (1 + exp(x))
+```
+
+For a large negative input, the latter avoids evaluating `exp(-x)` with a huge
+positive exponent. Batch Softmax first subtracts the largest input `m`, then
+normalizes `exp(x[i] - m)`. This translation does not change probabilities but
+avoids overflow for uniformly large logits.
+
+An empty Softmax slice remains empty. If the exponent sum is zero, no division
+is performed. Activations do not repair non-finite input; the network's
+layer-output check reports non-finite results after evaluation.
+
+### Derivative scope
+
+Pointwise derivatives can be computed from the output, avoiding a second
+pre-activation buffer. Softmax is different: its full derivative couples all
+outputs. `derivative` and `derivative_batch` deliberately expose only the
+diagonal; output-layer backpropagation handles the full Jacobian. They are not a
+general full-Softmax-Jacobian API.
+
+## SIMD paths
+
+The `simd` feature changes implementation strategy, not layer semantics.
+
+| Target | Dot-product path | Vector work | Scalar tail |
+| --- | --- | --- | --- |
+| AArch64 | NEON | Four 4-lane FMA accumulators: 16 values | 0–3 values |
+| x86_64 with AVX-512F | AVX-512 | Four 16-lane FMA accumulators: 64 values | 0–15 values |
+| x86_64 with AVX2 + FMA | AVX2/FMA | Four 8-lane FMA accumulators: 32 values | 0–7 values |
+| Other or unsupported runtime | Scalar | One value at a time | not applicable |
+
+On x86, runtime feature checks choose AVX-512F first, then AVX2 plus FMA, then
+the scalar loop. AArch64 relies on mandatory NEON. The independent accumulators
+reduce FMA dependency latency before being combined. x86 matrix code prefetches
+the next weight row when one exists; the hint does not change correctness.
+
+Batch ReLU and LeakyReLU also use SIMD: NEON processes four values at a time and
+AVX2 processes eight. LeakyReLU uses vector selection instead of a per-lane
+branch. Every vector routine handles its remaining tail scalarly, and x86 code
+runs only after the required CPU feature is detected.
+
+## Binary format
+
+`Network::to_bytes` emits compact little-endian version-1 data. It has no
+padding, footer, checksum, or optional fields; a decoder must consume exactly
+the bytes specified below.
+
+### Header
+
+| Bytes | Encoding | Value |
+| --- | --- | --- |
+| `0..4` | four ASCII bytes | Magic `FANN` |
+| `4..8` | little-endian `u32` | Version `1` |
+| `8..12` | little-endian `u32` | Layer count `L` |
+
+`L` cannot be zero. The first layer begins at byte 12.
+
+### Layer records
+
+Each layer is written in network order:
+
+| Field | Encoding | Notes |
+| --- | --- | --- |
+| input width | little-endian `u32` | `I`, nonzero when decoded |
+| output width | little-endian `u32` | `O`, nonzero when decoded |
+| activation tag | `u8` | Listed below |
+| LeakyReLU alpha | little-endian `f32` | Present only for tag `4` |
+| weights | `I * O` little-endian `f32`s | Output-major row layout |
+| biases | `O` little-endian `f32`s | Output order |
+
+| Tag | Activation | Extra bytes |
+| --- | --- | --- |
+| `0` | `Linear` | none |
+| `1` | `Sigmoid` | none |
+| `2` | `Tanh` | none |
+| `3` | `ReLU` | none |
+| `4` | `LeakyReLU(alpha)` | alpha `f32` |
+| `5` | `Softmax` | none |
+
+A non-LeakyReLU record is `9 + 4*I*O + 4*O` bytes. LeakyReLU adds four alpha
+bytes. The total serialized size is the 12-byte header plus all layer records.
+
+### Versioning and parsing rules
+
+The reader accepts version `1` only. A changed field order, width, tag, or
+semantic must receive a new version and explicit reader support; the current
+parser rejects unknown versions rather than guessing an interpretation.
+
+`Network::from_bytes` treats input as untrusted and validates before allocating:
+
+1. Each read checks remaining bytes by subtraction, avoiding an overflow-prone
+   `position + count` bounds calculation with hostile counts.
+2. Before reserving the layer vector, declared `L` must fit the remaining byte
+   budget divided by nine, the smallest layer header.
+3. The layer count also receives the general allocation-size guard.
+4. Every `I` and `O` is validated before reading weights: zero values,
+   multiplication overflow, and more than 100,000,000 elements fail before a
+   large payload can be collected.
+5. Weight and bias byte counts use checked multiplication before reading.
+6. Completed records pass through `Layer::with_weights`; `Network::new` then
+   validates connectivity and recreates transient activation buffers.
+7. The final reader position must equal the source length. Trailing data is an
+   error, never ignored padding.
+
+Bad magic, unsupported version, truncation, unknown tags, impossible counts,
+arithmetic overflow, or trailing data produce an error instead of a partial
+model. An empty declared network returns `EmptyNetwork`; an oversized layer is
+rejected as `ShapeTooLarge` at the early dimension check.
+
+## Serde and errors
+
+The optional `serde` representation is distinct from the compact binary format.
+Runtime activation buffers are skipped because they are transient output state,
+not model parameters. On deserialization, a `NetworkData` shadow routes layers
+through `Network::new` to validate connectivity and rebuild buffers. A `LayerData`
+shadow routes vectors through `Layer::with_weights` to validate their lengths.
+This prevents a parameter-valid-looking network from reaching a first forward
+pass with empty buffers or malformed row storage.
+
+`FannResult<T>` is `Result<T, FannError>`. Core error variants identify the
+failed boundary:
+
+| Error | Typical source |
+| --- | --- |
+| `InputSizeMismatch` / `OutputSizeMismatch` | Forward slice has the wrong width. |
+| `WeightCountMismatch` / `BiasCountMismatch` | Parameter vectors disagree with a declared shape. |
+| `InvalidLayerDimensions` | A width is zero or adjacent layers do not connect. |
+| `ShapeTooLarge` | A tensor exceeds the cap or its product overflows. |
+| `EmptyNetwork` | Construction or decoding has no layers. |
+| `InvalidBuilder` | Builder setup or binary input is malformed. |
+| `NumericInstability` | A layer output contains `NaN` or infinity. |
+| `InvalidDistributionParams` | Xavier/Glorot distribution setup failed. |
+| `SerializationError` | Serde-specific failure when that feature is enabled. |
+
+For `TrainingError` and `GradientError`, see [training.md](training.md).

--- a/crates/fann/docs/training.md
+++ b/crates/fann/docs/training.md
@@ -1,0 +1,445 @@
+# Training
+
+`lattice-fann` ships three training tools:
+
+- [`BackpropTrainer`](#backprop--momentum) — the default, always-available trainer:
+  full-batch or mini-batch gradient descent with momentum and weight decay.
+- [`DiagonalFisher`](#elastic-weight-consolidation-ewc) (`training::ewc`, feature
+  `online-router`) — an Elastic Weight Consolidation forgetting guard, composed
+  alongside another trainer rather than used standalone.
+- [`RlooTrainer`](#reinforce-with-leave-one-out-rloo) (`training::rloo`, feature
+  `online-router`) — a REINFORCE policy-gradient trainer for selector-gate networks
+  (e.g. adapter/expert routers), with an optional leave-one-out variance reducer.
+
+Backprop and RLOO operate directly on `Network`/`Layer` buffers — there is no
+separate training-graph representation. Their gradients are computed by
+hand-rolled reverse-mode backprop over the layer stack, not by a general
+autodiff engine. EWC instead remains deliberately independent of `Network` and
+works on caller-provided flat parameter slices.
+
+## Availability and shared types
+
+The basic training surface is always present. `BackpropTrainer`,
+`TrainingConfig`, `TrainingResult`, `Trainer`, and `GradientGuardStrategy` are
+available without optional features. `DiagonalFisher`, `RlooConfig`, and
+`RlooTrainer`, together with their `training::ewc` and `training::rloo`
+modules, are compiled only with the `online-router` feature.
+
+`TrainingConfig` is the configuration used by the `Trainer` implementation;
+its builder methods simply replace the corresponding field and return the
+configuration. The defaults are:
+
+| Field | Default | Meaning |
+| --- | ---: | --- |
+| `learning_rate` | `0.01` | Base step size before batch-size scaling. |
+| `momentum` | `0.9` | Coefficient applied to the prior weight and bias velocities. |
+| `weight_decay` | `0.0001` | L2 coefficient applied to weights, not biases. |
+| `max_epochs` | `1000` | Maximum completed epoch count. |
+| `target_error` | `0.001` | Strict early-stop threshold for mean squared error. |
+| `batch_size` | `32` | Samples accumulated before an update; `1` is SGD. |
+| `shuffle` | `true` | Shuffle sample indices before each epoch. |
+| `gradient_guard` | `Error` | Response to a non-finite accumulated gradient. |
+| `seed` | `None` | Entropy-seeded shuffle RNG; `Some(seed)` makes its shuffle sequence reproducible. |
+
+The builder does not normalize hyperparameters or impose ranges on learning
+rate, momentum, weight decay, epoch count, or target error. Callers therefore
+own choosing finite, meaningful values. `batch_size` is the exception:
+`BackpropTrainer::train` rejects zero before training starts.
+
+### Dataset validation and results
+
+`Trainer::train` expects a nonempty input collection and exactly one target
+vector per input vector. Each input must have `network.num_inputs()` values and
+each target must have `network.num_outputs()` values; a mismatch returns a
+`TrainingError` before velocities or gradient buffers are initialized.
+
+`TrainingResult` records the final per-sample mean squared error,
+`epochs_trained`, an `error_history` entry for every completed epoch, and the
+`converged` flag. An epoch converges only when its average error is *strictly*
+less than `target_error`. If `max_epochs` is zero, no epoch runs: the result is
+non-converged, has an empty history, and reports `f32::MAX` as its final error.
+
+## Backprop + momentum
+
+`BackpropTrainer` (`training/backprop.rs`) implements standard SGD with momentum
+and L2 weight decay, driven by a `TrainingConfig`:
+
+```rust
+use lattice_fann::{NetworkBuilder, Activation, BackpropTrainer, TrainingConfig, Trainer};
+
+let mut network = NetworkBuilder::new()
+    .input(2)
+    .hidden(4, Activation::Tanh)
+    .output(1, Activation::Tanh)
+    .build()
+    .unwrap();
+
+let mut trainer = BackpropTrainer::new();
+let config = TrainingConfig::new().learning_rate(0.5).max_epochs(1000);
+let result = trainer.train(&mut network, &inputs, &targets, &config);
+```
+
+The trainer initializes fresh, zeroed velocity buffers at the start of every
+`train` call. Momentum is consequently preserved across batches and epochs of
+one call, but not across two separate calls on the same `BackpropTrainer`.
+
+### Per-sample gradient computation
+
+`compute_gradients` runs one forward pass per sample, then walks the layer stack
+backward:
+
+1. **Output-layer delta.** For a Softmax output layer, the *full* Jacobian is
+   used (not the diagonal approximation — see [Activations](network.md#activations)):
+   `delta[i] = Σ_j (output[j] − target[j]) · J[j,i]` where `J[j,i] = output[j]·(δ_ij − output[i])`.
+   For every other output activation, `delta[i] = (output[i] − target[i]) · f'(output[i])`
+   (plain MSE-derivative chain rule).
+2. **Hidden-layer deltas**, propagated backward layer by layer:
+   `delta_i^(l) = f'(a_i^(l)) · Σ_j W_ji^(l+1) · delta_j^(l+1)`, reading the
+   next layer's weight matrix in its row-major `[out * num_inputs + in]` layout.
+3. **Weight/bias gradients**: `dW[i,j] = delta[i] · input[j]`, `dB[i] = delta[i]`,
+   accumulated over every sample in the batch before the update step runs.
+
+Both `BackpropTrainer::compute_gradients` and `RlooTrainer::backprop_and_apply`
+(below) implement the *same* backward recursion independently — the RLOO
+trainer's comment block explicitly cites the `backprop.rs` line numbers it
+mirrors. A bug found in one hidden-layer backward loop should be checked
+against the other.
+
+### Momentum + weight decay update
+
+Once gradients are accumulated over a batch, `apply_gradients` runs classic
+momentum SGD, one velocity buffer per weight and bias. Weight updates are:
+
+```text
+v ← momentum · v − lr · (grad + weight_decay · w)
+w ← w + v
+```
+
+`lr` is `config.learning_rate / batch_size` — gradients are summed (not
+averaged) over the batch, so the learning rate divides by the actual batch
+size to keep the effective step size independent of batch size. Biases use the
+same velocity recurrence but omit the `weight_decay · w` term.
+
+The final batch of an epoch may contain fewer than `config.batch_size` samples;
+the divisor is that final batch's actual size, not the configured maximum.
+
+### Epoch flow and error accounting
+
+For each epoch, the trainer optionally shuffles an index vector, clears the
+reused gradient buffers for each batch, and sums the per-sample gradients. A
+sample's error is the squared output difference summed over outputs and divided
+by the output width. The epoch error is the sum of accepted sample errors
+divided by the count of accepted samples.
+
+This separation matters for `SkipBatch`: a rejected batch contributes neither
+an update nor its error. If all batches are skipped, the denominator would be
+zero and the epoch metric would be meaningless, so training returns
+`NumericInstability` immediately. The trainer also rejects a completed epoch
+whose average error is `NaN` or infinite instead of returning a misleading
+result.
+
+### Gradient guard strategies
+
+Every batch's accumulated gradients are checked for NaN/Inf before the update
+is applied (`GradientGuardStrategy`, in `training/gradient.rs`):
+
+| Strategy | Behavior |
+|---|---|
+| `Error` (default) | Abort the whole `train()` call with `NumericInstability` |
+| `Sanitize` | Zero out NaN/Inf entries and apply the update anyway; batch error is still counted |
+| `SkipBatch` | Discard the batch's gradients *and* its error contribution, continue to the next batch |
+
+If every batch in an epoch is skipped under `SkipBatch`, `train()` returns
+`NumericInstability` rather than a division-by-zero-derived `NaN` `final_error`
+— `batch_count == 0` is a fail-loud condition, not silently reported as
+"converged" or "error 0.0".
+
+The guard examines accumulated weight and bias gradients before an update; it
+does not make invalid configuration values or non-finite forward-pass errors
+safe. In particular, `Sanitize` replaces only non-finite gradient entries with
+zero. It cannot repair a non-finite error metric, which is still rejected at
+the end of the epoch.
+
+### Softmax hidden-layer limitation
+
+`NetworkBuilder::build()` rejects Softmax on any hidden (non-output) layer at
+construction time. Softmax normalizes over the whole layer's output simplex,
+so its gradient is inherently a full Jacobian, not a per-element derivative;
+allowing it on a hidden layer would require every caller of
+`Activation::derivative` (a per-element `f32 -> f32` function) to instead
+carry the whole-layer Jacobian, which the trainer doesn't implement for hidden
+layers (see ADR-023). This is enforced once, at build time, so it can never
+surface as a silent wrong-gradient bug during training.
+
+## Elastic Weight Consolidation (EWC)
+
+`training::ewc::DiagonalFisher` (feature `online-router`) prevents catastrophic
+forgetting during online/continual learning by penalizing updates to parameters
+that were important for a prior task. It operates on flat `&[f32]` parameter
+slices with no `Network` dependency, so it is suitable for caller-controlled
+training loops that can inspect gradients or updates before writing parameters.
+
+References: Kirkpatrick et al., "Overcoming catastrophic forgetting in neural
+networks", PNAS 2017; Chaudhry et al., "Efficient Lifelong Learning with
+A-GEM", ICLR 2019 (the EWC++ online variant this module implements).
+
+### State and lifecycle
+
+`DiagonalFisher` contains two same-length vectors and an EMA decay:
+
+| State | Role |
+| --- | --- |
+| `values` | The diagonal Fisher estimate `F`, one importance value per parameter. |
+| `anchor` | The parameter snapshot `θ*` that a later task is discouraged from leaving. |
+| `decay` | The fraction of the previous importance retained by the next observation. |
+
+The caller owns the parameter layout because the guard intentionally has no
+`Network` dependency. Use the same flat ordering for every gradient, parameter
+snapshot, gradient buffer, and update slice passed to a guard. Construction
+creates zeroed `values` and `anchor` vectors; `observe_gradient` records prior
+task gradients, and `set_anchor` records the associated finished-task
+parameters before training a new task. Then either add `penalty_gradient` to
+the new task's gradient or run `project_delta` on a prospective update.
+
+The public vectors should be treated as one unit. The constructor and setter
+establish equal lengths, but modifying `values` or `anchor` independently can
+break the correspondence on which the penalty relies. `observe_gradient` and
+`penalty_gradient` validate their input/output slices against the Fisher length;
+`set_anchor` validates against the current anchor length. `project_delta` is
+the intentional exception: it processes the common prefix, allowing a guard to
+cover a parameter sub-slice without an error.
+
+### Diagonal Fisher information as an importance estimate
+
+The full Fisher information matrix is `num_params × num_params` — infeasible to
+track for anything but tiny networks. EWC++ instead tracks only the **diagonal**:
+one scalar per parameter, updated online as an exponential moving average (EMA)
+of squared gradients:
+
+```text
+F_i ← decay · F_i + (1 − decay) · g_i²
+```
+
+A large `F_i` means parameter `i`'s gradient has consistently had large
+magnitude — i.e. the loss is sensitive to it, so it was "important" to
+whatever task produced those gradients. `decay` must be strictly inside the
+open interval `(0, 1)`: `decay = 1` freezes the estimate, while `decay > 1`
+makes `(1 − decay)` negative and reverses the contribution of new
+squared-gradient signal. `decay = 0` collapses to pure replacement with no
+memory at all (the EMA degenerates to `F_i = g_i²` every step). Both ends, plus
+non-finite `decay`, are rejected in `DiagonalFisher::new` before any allocation.
+
+The constructor also checks its allocation request against the crate's safety
+limit before allocating either vector. Gradient observations themselves are not
+silently sanitized: callers should provide finite gradients and a finite
+regularization coefficient so that the stored importance and subsequent update
+remain finite.
+
+### Anchor + penalty gradient
+
+At a task boundary, `set_anchor(params)` snapshots the current parameter
+vector `θ*` as the reference point for the *next* task's training. The EWC
+regularization loss is:
+
+```text
+L_ewc = (λ/2) · Σ_i F_i · (θ_i − θ*_i)²
+```
+
+`penalty_gradient` computes `∂L_ewc/∂θ_i = λ · F_i · (θ_i − θ*_i)` and
+*adds* it into the caller's gradient buffer (the caller is expected to combine
+it with the task loss's own gradient and then subtract the combined vector in
+its own descent step — this module never mutates network weights directly).
+Because the gradient is proportional to `F_i`, parameters that were unimportant
+to the prior task (`F_i ≈ 0`) are essentially unconstrained, while parameters
+that were highly important are pulled back toward their anchor value in
+proportion to both their importance and how far they've drifted.
+
+`penalty_gradient` accumulates rather than overwrites `out`. Start with the
+task-loss gradient (or another deliberate initial value), add the EWC term, and
+perform the ordinary descent update only after both are present. This behavior
+lets multiple regularizers share one gradient buffer, but it also means a stale
+buffer will be counted again if the caller fails to clear it between updates.
+
+### Null-space delta projection
+
+`project_delta` offers a second, distinct use of the same Fisher estimate: given
+a raw parameter update `delta` (e.g. a policy-gradient step, not necessarily one
+this module computed), damp the components that touch high-Fisher parameters:
+
+```text
+scale_i = max(0, 1 − F_i / F_max)
+delta_i ← delta_i · scale_i
+```
+
+Parameters at the maximum observed Fisher value are scaled to (near) zero —
+their update is blocked entirely. Parameters with `F_i = 0` pass through
+unchanged (`scale_i = 1`). This is a diagonal (per-parameter) approximation to
+projecting the update into the null space of the Fisher matrix; a full
+SVD-based null-space projection is more accurate but `O(n³)`, and is deferred
+in favor of this `O(n)` approximation, which is judged adequate for online
+continual learning where updates arrive one sample or small batch at a time.
+
+**Degenerate-Fisher guard**: if no gradient has ever been observed
+(`F_max < 1e-8`), `project_delta` returns immediately without modifying
+`delta` — there's no importance signal yet, so treating it as identity avoids
+a division by (near-)zero.
+
+Projection does not use the anchor and is not equivalent to adding the penalty
+gradient. It is a direct, relative suppression of an already computed update:
+the largest Fisher entry receives scale zero, while lower-importance entries
+receive a scale relative to that maximum. Choose one approach deliberately, or
+combine them only when the resulting amount of protection is intended.
+
+## REINFORCE with Leave-One-Out (RLOO)
+
+`training::rloo::RlooTrainer` (feature `online-router`) trains a *selector gate*
+— a small `Network` whose job is to output logits over a set of discrete
+choices (e.g. which adapter/expert to route to) — via policy gradient. It is
+intentionally decoupled from EWC: `DiagonalFisher` can protect
+caller-controlled parameter updates when forgetting protection is needed, while
+this trainer implements only the policy-gradient update.
+
+**Gate contract**: the gate network's *output* layer activation must be
+`Activation::Linear` (raw logits). Softmax is applied inside this module's loss
+computation, not baked into the network, because the policy-gradient formulas
+below need direct access to both the logits (for the log-sum-exp z-loss term)
+and the softmax probabilities.
+
+### Configuration and validation
+
+`RlooConfig` has deliberately small, direct settings:
+
+| Field | Default | Effect |
+| --- | ---: | --- |
+| `learning_rate` | `0.001` | Plain-SGD step size for all gate weights and biases. |
+| `aux_loss_coeff` | `0.01` | Multiplier for the load-balance gradient. |
+| `z_loss_coeff` | `0.001` | Multiplier for the router z-loss gradient. |
+
+The trainer does not use `TrainingConfig`: it updates one policy-gradient
+example at a time, with neither momentum nor weight decay. `new` seeds its
+sampling RNG from system entropy; `with_seed` fixes that stream for repeatable
+multi-sample tests or experiments.
+
+Both `step` and `rloo_step` check that `context` has the gate's input width,
+that the action/preferred index is an output index, and that the output layer is
+linear. `rloo_step` additionally requires `1 <= k <= num_outputs` and
+`m_samples >= 1`. Before it allocates retained subsets, it bounds both
+`m_samples` and `m_samples * k` against the crate allocation limit and uses a
+checked multiply to turn an overflowing product into an error. The configuration
+coefficients and `reward` itself are not range-checked, so finite, appropriate
+values remain the caller's responsibility.
+
+EWC is not injected into either RLOO update path. `DiagonalFisher` remains a
+separate, flat-slice guard for integrations that control their own parameter
+updates; `RlooTrainer` has no automatic EWC penalty or projection hook.
+
+### Phase 1: single-sample REINFORCE (`step`, the active path)
+
+Given a context vector, an `action_idx` (which output the reward is about), and
+a scalar `reward` (`+1.0`/`−1.0` explicit or `+0.5`/`−0.5` implicit — magnitude
+encodes confidence, sign encodes direction), `step` computes a single-sample
+policy-gradient update:
+
+1. Forward pass through the gate → `logits`, then `probs = softmax(logits)`.
+2. Output-layer gradient combines three terms:
+   ```text
+   g[j] = reward · (p[j] − onehot(action)[j])                         (policy)
+        + aux_coeff · (2/K) · p[j] · (p[j] − 1/K − c)                  (load-balance)
+        + z_coeff   · 2 · LSE · p[j]                                    (z-loss)
+   ```
+   where `c = Σ p_i² − 1/K` and `LSE = log Σ exp(logits)`. Because the output
+   activation is `Linear` (derivative 1), this *is* the pre-activation error —
+   no extra derivative multiply, unlike the general backprop path.
+3. `backprop_and_apply` propagates this delta through hidden layers (mirroring
+   `backprop.rs`'s hidden-layer recursion and plain-SGD apply, batch size 1,
+   no momentum) and updates the gate's weights in place.
+
+The returned scalar is the policy term only,
+`−reward · log(max(p[action_idx], 1e-9))`, for logging. It does not include the
+auxiliary losses and is not a full objective value. The probability floor keeps
+the logging expression finite when a probability underflows; it does not alter
+the gradient formula used for the update.
+
+**Single code path for both reward polarities.** The policy term
+`reward · (p[j] − onehot[j])` naturally flips sign with `reward`: a positive
+reward pulls `p[action]` up (standard cross-entropy-style gradient toward the
+action), a negative reward pushes it down. There is deliberately no
+special-casing for negative reward — a regression test
+(`rloo_negative_reward_decreases_action_score`) pins this polarity, because a
+plausible-looking bug here (e.g. accidentally taking `reward.abs()`) would
+silently convert "push this down" feedback into "pull this up" feedback.
+
+**Auxiliary losses**, always added regardless of reward sign:
+- *Load-balance loss* `(1/K) Σ_i (p_i − 1/K)²` penalizes routing collapse
+  (one action absorbing all probability mass) — pulls the distribution toward
+  uniform.
+- *Router z-loss* `(log Σ exp(logits))²` penalizes logit magnitude explosion,
+  which otherwise makes the softmax increasingly saturated/overconfident over
+  training.
+
+The public `load_balance_aux_loss` and `router_z_loss` functions expose these
+scalar definitions for inspection or external logging. The load-balance helper
+returns zero for an empty probability slice. The z-loss helper defines
+log-sum-exp of an empty logits slice as zero, and therefore also returns zero.
+For nonempty logits, the internal softmax and log-sum-exp routines subtract the
+maximum logit before exponentiating to avoid overflow.
+
+### Phase 2: multi-sample RLOO (`rloo_step`, not the default path)
+
+`rloo_step` draws `m_samples` independent top-`k` subsets via Gumbel-max
+sampling (perturb each logit with `Gumbel(0,1)` noise, take the top `k` by
+perturbed value — the standard trick for sampling a `k`-subset without
+replacement in proportion to the softmax distribution) and computes a reward
+per sample: `+1.0` if `preferred_idx` is in the sampled subset, `−1.0`
+otherwise. It then applies a **leave-one-out baseline** to reduce gradient
+variance:
+
+```text
+baseline_m = (Σ R − R_m) / (M − 1)     (0 if M == 1)
+advantage_m = R_m − baseline_m
+g[j] += −(1/M) · advantage_m · (count(j ∈ subset_m) − k · p[j])
+```
+
+This is not the default training path — it exists for the bench harness that
+compares its convergence against Phase 1. **Invariant for any future
+activation of this path**: it only consumes preferred-known (positive) events,
+so it must always be paired with the Phase-1 negative path; a positive-only
+convergence run collapses to near-zero policy entropy (mass piles onto a
+single output) because there's no signal pushing a wrongly-selected output
+back down. This was verified empirically in the convergence bench, not just
+reasoned about — treat it as a correctness requirement for any caller, not a
+tuning knob.
+
+Both `m_samples` and `m_samples * k` (the aggregate retained-subset storage)
+are bounds-checked against `MAX_ALLOWED_ELEMENTS` before any allocation, since
+both are caller-controlled and the product can overflow or drive an
+unreasonably large `Vec::with_capacity`.
+
+#### Sampling and update sequence
+
+For each sample, the trainer draws one Gumbel perturbation per logit,
+
+```text
+u_i ~ Uniform(0, 1)
+g_i = s_i - ln(-ln(u_i))
+subset = indices of the largest k values of g
+```
+
+and assigns reward `+1` when `preferred_idx` appears in that subset or `−1`
+otherwise. The uniform draw is clamped strictly inside the open interval before
+the nested logarithms, which prevents `ln(0)` at an endpoint. Gumbel-top-k
+therefore creates a top-`k` sample without replacement whose ordering is driven
+by the policy logits.
+
+The leave-one-out baseline for sample `m` excludes that sample's reward. For a
+single draw it is defined as zero, avoiding a division by zero; for multiple
+draws it makes the update respond to how the sample compared with its peers.
+After accumulating the policy-gradient contributions, the trainer adds the same
+load-balance and z-loss gradients used by Phase 1, backpropagates through each
+hidden layer, and applies plain SGD to every weight and bias.
+
+As with the ordinary backprop trainer, hidden-layer deltas read the next layer's
+row-major weight matrix at `[output * num_inputs + input]`, multiply by the
+next-layer deltas, and multiply by the current activation derivative. The RLOO
+path computes this recurrence independently so the policy-loss output delta can
+replace the normal MSE output delta.

--- a/crates/fann/src/activation.rs
+++ b/crates/fann/src/activation.rs
@@ -1,7 +1,9 @@
-//! Activation functions for neural networks
+//! Activation functions for dense networks.
 //!
-//! Provides common activation functions with forward and derivative computations.
-//! Optimized for fast inference with minimal branching.
+//! Element-wise and batch evaluation cover the common nonlinearities; batch
+//! Softmax normalizes the entire layer. ReLU variants use SIMD when available.
+//!
+//! See `docs/network.md` for formulas, numerical rules, and derivative limits.
 
 /// Activation function types
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -312,18 +314,11 @@ impl Activation {
         }
     }
 
-    /// Compute derivative of activation function at given output value
+    /// Compute an activation derivative from its output value.
     ///
-    /// For backpropagation, we typically have the activation output `y = f(x)`
-    /// and need `f'(x)`. For efficiency, many activation derivatives can be
-    /// computed from the output `y` directly.
-    ///
-    /// For Softmax, both this method and `derivative_batch` return only the
-    /// **diagonal** of the Jacobian: `s_i * (1 − s_i)`.  The full Jacobian
-    /// (`J[i,j] = s_i * (δ_ij − s_j)`) is required for mathematically correct
-    /// Softmax gradients; it is implemented for the output layer in
-    /// `backprop.rs::compute_gradients`.  Hidden-layer Softmax uses only the
-    /// diagonal approximation (accepted limitation, see ADR-023).
+    /// Softmax returns only the Jacobian diagonal. Output-layer backpropagation
+    /// computes the full Jacobian; the builder rejects hidden-layer Softmax
+    /// (see ADR-023).
     #[inline]
     pub fn derivative(&self, output: f32) -> f32 {
         match self {

--- a/crates/fann/src/error.rs
+++ b/crates/fann/src/error.rs
@@ -1,4 +1,7 @@
-//! Error types for lattice-fann
+//! Error types and allocation-shape validation for `lattice-fann`.
+//!
+//! Dimension checks reject zero-sized or excessively large tensors before
+//! allocation. See `docs/network.md` for the limits and parser invariants.
 
 use thiserror::Error;
 

--- a/crates/fann/src/gpu/buffer.rs
+++ b/crates/fann/src/gpu/buffer.rs
@@ -1,17 +1,9 @@
-//! GPU buffer pool: 3-tier size-categorized pooling (see [`BufferCategory`]) with
-//! per-buffer lifecycle tracking, to avoid the ~100-500us cost of a fresh GPU
-//! allocation on every call. Integrates with [`CircuitBreaker`] to throttle
-//! pooling and force CPU fallback under memory pressure.
+//! Three-tier GPU buffer reuse pool with lifecycle-based eviction and pressure control.
 //!
-//! GPU deallocation is asynchronous even though Rust's `Drop` runs synchronously,
-//! so a training loop that repeatedly allocates without releasing can hit an
-//! out-of-memory condition despite buffers appearing freed on the Rust side.
-//! Call [`BufferPool::flush`] (and then poll the device) periodically — e.g. once
-//! per epoch — to force pending GPU deallocations through before the next batch.
-//!
-//! Tier sizing/capacity and the full memory-pressure handling design: see
-//! ADR-025 and
-//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/fann/docs/design.md).
+//! Allocation sizes are rounded to the required 256-byte Apple-Silicon alignment.
+//! GPU `Drop` is asynchronous: periodically flush the pool *and* poll or wait for
+//! completion during long-running work, or apparently freed buffers can still OOM.
+//! See ADR-025 and `docs/gpu.md` for the full backend design.
 
 use super::apple_silicon::BUFFER_ALIGNMENT;
 use super::circuit_breaker::{CircuitBreaker, MemoryPressure};

--- a/crates/fann/src/gpu/circuit_breaker.rs
+++ b/crates/fann/src/gpu/circuit_breaker.rs
@@ -1,7 +1,9 @@
-//! Circuit breaker for memory pressure handling
+//! Memory-pressure levels and a fail-closed circuit breaker for GPU allocations.
 //!
-//! Prevents cascade failures by temporarily rejecting requests
-//! when too many allocation failures occur.
+//! Pressure maps pool usage against a caller-set budget; `Critical` signals that
+//! callers should block allocations. The breaker transitions `Closed` -> `Open` ->
+//! `HalfOpen` after its recovery timeout, and reopens on a failed recovery probe.
+//! See `docs/gpu.md` for thresholds, cleanup policy, and state-machine details.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/fann/src/gpu/context.rs
+++ b/crates/fann/src/gpu/context.rs
@@ -1,4 +1,8 @@
-//! GPU compute context - device, queue, and resource management
+//! GPU device context: adapter selection, queue ownership, pooled memory, and pipelines.
+//!
+//! `flush_memory` drops pooled buffers and waits for pending work. GPU destruction is
+//! asynchronous, so dropping buffers without polling or waiting can still cause OOM.
+//! See `docs/gpu.md` for the full backend design.
 
 use super::buffer::BufferPool;
 use super::circuit_breaker::MemoryPressure;

--- a/crates/fann/src/gpu/error.rs
+++ b/crates/fann/src/gpu/error.rs
@@ -1,4 +1,7 @@
-//! GPU error types with proper categorization
+//! Error taxonomy and recovery classification for GPU operations.
+//!
+//! Callers can distinguish retryable pressure or execution failures from errors that
+//! should immediately use the CPU path. See `docs/gpu.md` for recovery guidance.
 
 use thiserror::Error;
 

--- a/crates/fann/src/gpu/mod.rs
+++ b/crates/fann/src/gpu/mod.rs
@@ -1,9 +1,9 @@
-//! GPU compute backend for lattice-fann: buffer pooling, circuit-breaker memory
-//! pressure handling, pipeline caching, and Apple Silicon (Metal) tuning, with
-//! automatic CPU fallback below the size thresholds in [`thresholds`] where GPU
-//! launch overhead would dominate the computation (see ADR-025 for the full
-//! architecture, the GPU/CPU decision heuristics, and
-//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/fann/docs/design.md)).
+//! GPU compute backend: contexts, pooled memory, WGSL pipelines, and dense inference.
+//!
+//! CPU selection uses a 10,000 effective-element threshold; activation policy uses 1,000.
+//! Keep each dispatch at or below 100,000 elements to retain 1.5 ms headroom beneath Metal's
+//! 2 ms watchdog. Apple Silicon uses 256-byte pool-buffer alignment and 32-thread matmul /
+//! 256-thread element-wise workgroups. See ADR-025 and `docs/gpu.md`.
 
 mod buffer;
 mod circuit_breaker;

--- a/crates/fann/src/gpu/network.rs
+++ b/crates/fann/src/gpu/network.rs
@@ -1,4 +1,9 @@
-//! GPU-accelerated neural network inference
+//! GPU dense-network inference with size-based CPU fallback.
+//!
+//! ReLU is fused with matrix-vector multiplication; other supported activations use
+//! a second dispatch. GPU softmax is applied only for the final layer during readback;
+//! a non-final softmax is unsupported on this path.
+//! See `docs/gpu.md` for execution, fallback, and synchronization details.
 
 use super::context::GpuContext;
 use super::error::{GpuError, GpuResult};

--- a/crates/fann/src/gpu/shader_manager.rs
+++ b/crates/fann/src/gpu/shader_manager.rs
@@ -1,7 +1,8 @@
-//! Shader compilation and pipeline caching
+//! WGSL compute-pipeline selection, warmup, and cache accounting.
 //!
-//! Precompiles and caches compute pipelines to avoid
-//! compilation overhead during inference.
+//! Common inference pipelines are compiled when a [`ShaderManager`] is created;
+//! remaining shader types compile on their first request.
+//! See `docs/gpu.md` for the shader inventory and cache behavior.
 
 use super::error::GpuResult;
 use super::shaders;

--- a/crates/fann/src/layer.rs
+++ b/crates/fann/src/layer.rs
@@ -1,7 +1,10 @@
-//! Neural network layer implementation
+//! Dense feedforward-layer storage and inference.
 //!
-//! A layer consists of a weight matrix, bias vector, and activation function.
-//! Optimized for fast inference with pre-allocated buffers.
+//! A layer owns row-major weights, biases, and an activation, and writes its
+//! result into a caller-provided buffer. SIMD matrix-vector kernels are used
+//! when the enabled target supports them.
+//!
+//! See `docs/network.md` for layout, initialization, and dispatch details.
 
 use crate::activation::Activation;
 use crate::error::{FannError, FannResult, validate_layer_dimensions};
@@ -37,11 +40,7 @@ fn simd_dot_product(a: &[f32], b: &[f32]) -> f32 {
     }
 }
 
-/// NEON dot product — 4x4-wide FMA (16 elements/iter) with 4 independent accumulators.
-///
-/// Uses 4 independent accumulator registers to hide the 4-cycle FMA latency on
-/// typical ARM cores (Cortex-A76, Apple M-series). Each accumulator processes 4
-/// f32 elements per iteration = 16 elements total per loop body.
+/// NEON dot product with four independent FMA accumulators (16 elements/iteration).
 ///
 /// # Safety
 /// Caller must ensure `a.len() == b.len()`. NEON is mandatory on aarch64.
@@ -113,11 +112,7 @@ unsafe fn simd_dot_product_neon(a: &[f32], b: &[f32]) -> f32 {
     result
 }
 
-/// AVX2+FMA dot product — 4x8-wide FMA (32 elements/iter) with 4 independent accumulators.
-///
-/// Uses 4 independent __m256 accumulators to hide FMA latency (typically 4-5 cycles
-/// on Haswell/Skylake). Each accumulator processes 8 f32 elements per iteration =
-/// 32 elements total per loop body.
+/// AVX2+FMA dot product with four independent accumulators (32 elements/iteration).
 ///
 /// # Safety
 /// Caller must ensure AVX2+FMA are available and `a.len() == b.len()`.
@@ -198,10 +193,7 @@ unsafe fn simd_dot_product_avx2(a: &[f32], b: &[f32]) -> f32 {
     result
 }
 
-/// AVX-512 dot product — 4x16-wide FMA (64 elements/iter) with 4 independent accumulators.
-///
-/// Uses 512-bit registers (16 f32 lanes each) with 4 independent accumulators =
-/// 64 elements per loop iteration. Available on Skylake-X, Ice Lake, Zen 4+.
+/// AVX-512 dot product with four independent accumulators (64 elements/iteration).
 ///
 /// # Safety
 /// Caller must ensure AVX-512F is available and `a.len() == b.len()`.
@@ -299,11 +291,7 @@ pub struct Layer {
     activation: Activation,
 }
 
-/// Deserialization shadow for [`Layer`] that routes through [`Layer::with_weights`].
-///
-/// A corrupt or hand-crafted serialized layer whose `weights`/`biases` lengths
-/// disagree with its dimensions is rejected with a `FannError` instead of
-/// triggering an out-of-bounds panic during `forward`.
+/// Serde input that validates dimensions and tensor lengths through [`Layer::with_weights`].
 #[cfg(feature = "serde")]
 #[derive(serde::Deserialize)]
 struct LayerData {

--- a/crates/fann/src/lib.rs
+++ b/crates/fann/src/lib.rs
@@ -1,48 +1,12 @@
-//! lattice-fann: fast neural network primitives for sub-5ms CPU inference.
+//! `lattice-fann` provides small dense neural networks for CPU-first inference.
 //!
-//! Lightweight building blocks for tiny models — knowledge-distillation students
-//! rather than full transformers — that need to run without GPU acceleration:
-//! pre-allocated layer buffers so the forward pass makes no allocations (see
-//! ADR-021), a fluent [`NetworkBuilder`], the common activations (ReLU, Sigmoid,
-//! Tanh, Softmax, LeakyReLU), and basic backpropagation training with momentum
-//! (`BackpropTrainer`, gradient guards per ADR-022). Batch inference (`parallel`),
-//! serialization (`serde`), and GPU acceleration via wgpu (`gpu`, see ADR-025) are
-//! optional features.
+//! Use [`NetworkBuilder`] to assemble layers, [`Network`] to run them, and
+//! [`BackpropTrainer`] to train them. The CPU forward path reuses activation
+//! buffers; `parallel`, `serde`, and `gpu` add batch inference, persistence, and
+//! optional GPU acceleration. `simd` accelerates supported CPU kernels.
 //!
-//! For the network/training architecture and the GPU backend's buffer-pool and
-//! circuit-breaker design, see
-//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/fann/docs/design.md).
-//!
-//! # Example
-//!
-//! ```
-//! use lattice_fann::{Network, NetworkBuilder, Activation};
-//!
-//! // Build a simple classifier: 4 inputs -> 8 hidden -> 3 outputs
-//! let mut network = NetworkBuilder::new()
-//!     .input(4)
-//!     .hidden(8, Activation::ReLU)
-//!     .output(3, Activation::Softmax)
-//!     .build()
-//!     .unwrap();
-//!
-//! // Run inference
-//! let input = [1.0, 2.0, 3.0, 4.0];
-//! let output = network.forward(&input).unwrap();
-//!
-//! // Output is a probability distribution (sums to 1.0)
-//! assert_eq!(output.len(), 3);
-//! let sum: f32 = output.iter().sum();
-//! assert!((sum - 1.0).abs() < 1e-5);
-//! ```
-//!
-//! # Feature Flags
-//!
-//! - `std` (default): Enable standard library support
-//! - `simd` (default): Enable SIMD optimizations for matrix operations
-//! - `parallel`: Enable parallel batch inference via rayon
-//! - `serde`: Enable serialization/deserialization support
-//! - `gpu`: Enable GPU acceleration via wgpu (Metal/Vulkan/DX12)
+//! See `docs/design.md` for the crate architecture and `docs/network.md` for
+//! the network, activation, and binary-format reference.
 
 #![warn(missing_docs)]
 

--- a/crates/fann/src/network/builder.rs
+++ b/crates/fann/src/network/builder.rs
@@ -1,6 +1,10 @@
-//! Network builder for fluent API construction
+//! Fluent construction of dense feedforward networks.
 //!
-//! Provides `NetworkBuilder` for constructing neural networks with a fluent API.
+//! The builder records layer sizes and activations, then validates and creates
+//! `Layer` objects at build time. It can use either entropy or a caller seed
+//! for Xavier/Glorot initialization.
+//!
+//! See `docs/network.md` for build-time validation and buffer allocation.
 
 use crate::activation::Activation;
 use crate::error::{FannError, FannResult};
@@ -31,12 +35,7 @@ pub struct NetworkBuilder {
     layers: Vec<(usize, Activation)>,
 }
 
-/// Reject Softmax on any hidden (non-final) layer.
-///
-/// Softmax normalises over the simplex — meaningful only at the output.
-/// On hidden layers the gradient degrades to the diagonal approximation
-/// `s_i*(1-s_i)`, producing silently wrong gradients (accepted limitation,
-/// see ADR-023).
+/// Reject Softmax before the final layer: its derivative here is only diagonal (see ADR-023).
 fn validate_no_hidden_softmax(layers: &[(usize, Activation)]) -> FannResult<()> {
     if layers.len() < 2 {
         return Ok(());

--- a/crates/fann/src/network/mod.rs
+++ b/crates/fann/src/network/mod.rs
@@ -1,7 +1,10 @@
-//! Neural network implementation
+//! Feedforward-network execution and construction.
 //!
-//! Provides the `Network` struct for fast inference and `NetworkBuilder`
-//! for fluent network construction.
+//! `Network` validates layer connectivity, pre-allocates one activation buffer
+//! per layer, and rejects non-finite layer outputs. `NetworkBuilder` constructs
+//! compatible dense stacks.
+//!
+//! See `docs/network.md` for the execution model and binary format.
 
 mod builder;
 mod serialization;
@@ -11,14 +14,7 @@ pub use builder::NetworkBuilder;
 use crate::error::{FannError, FannResult};
 use crate::layer::Layer;
 
-/// Check for NaN or Inf values in a layer's output buffer.
-///
-/// Takes a layer index instead of a string to avoid format!() allocation
-/// on every call in the forward pass hot path. The string is only
-/// formatted in the error branch.
-///
-/// This check is always active, including release builds, so inference fails
-/// closed instead of returning non-finite activations.
+/// Reject non-finite layer output in every build; format an error only on failure.
 #[inline]
 fn check_numeric_stability(values: &[f32], layer_index: usize) -> FannResult<()> {
     for (i, &v) in values.iter().enumerate() {
@@ -36,11 +32,7 @@ fn check_numeric_stability(values: &[f32], layer_index: usize) -> FannResult<()>
     Ok(())
 }
 
-/// Run a forward pass through layers using provided buffers.
-///
-/// This is the core forward-pass logic, extracted so that `forward_batch` can
-/// share the (read-only) layer weights across threads without cloning the
-/// entire network — only the mutable activation buffers are per-thread.
+/// Shared forward pass using caller-provided, per-layer activation buffers.
 #[inline]
 fn forward_into_buffers(
     layers: &[Layer],
@@ -91,17 +83,12 @@ pub struct Network {
     /// Network layers
     layers: Vec<Layer>,
     /// Pre-allocated buffers for intermediate activations
-    /// buffers[i] holds output of layer i (or input for i=0)
+    /// `buffers[i]` holds the output of layer `i`.
     #[cfg_attr(feature = "serde", serde(skip))]
     buffers: Vec<Vec<f32>>,
 }
 
-/// Deserialization shadow for [`Network`] that routes through [`Network::new`].
-///
-/// `buffers` is `#[serde(skip)]`, so a directly-deserialized `Network` would
-/// have empty buffers and panic on the first `forward`. Routing through `new`
-/// rebuilds the buffers from the layer dimensions and rejects empty or
-/// dimension-incompatible layer stacks with a `FannError`.
+/// Serde input that rebuilds skipped activation buffers through [`Network::new`].
 #[cfg(feature = "serde")]
 #[derive(serde::Deserialize)]
 struct NetworkData {

--- a/crates/fann/src/network/serialization.rs
+++ b/crates/fann/src/network/serialization.rs
@@ -1,6 +1,10 @@
-//! Network serialization and deserialization
+//! Compact binary network serialization.
 //!
-//! Provides binary serialization for efficient network storage and loading.
+//! The format is little-endian, versioned, and contains each layer's shape,
+//! activation, weights, and biases. Parsing validates bounds before allocation
+//! and requires an exact-length blob.
+//!
+//! See `docs/network.md` for the complete on-disk format and invariants.
 
 use crate::activation::Activation;
 use crate::error::{FannError, FannResult, validate_allocation_size, validate_layer_dimensions};
@@ -8,19 +12,8 @@ use crate::layer::Layer;
 use crate::network::Network;
 
 impl Network {
-    /// Serialize the network to a compact binary format
-    ///
-    /// Format:
-    /// - Magic: 4 bytes "FANN"
-    /// - Version: u32 little-endian (1)
-    /// - Num layers: u32 little-endian
-    /// - For each layer:
-    ///   - num_inputs: u32 little-endian
-    ///   - num_outputs: u32 little-endian
-    ///   - activation_type: u8 (0=Linear, 1=Sigmoid, 2=Tanh, 3=ReLU, 4=LeakyReLU, 5=Softmax)
-    ///   - If LeakyReLU: alpha f32 little-endian
-    ///   - weights: num_inputs * num_outputs f32s little-endian
-    ///   - biases: num_outputs f32s little-endian
+    /// Serialize the network to the versioned little-endian format documented
+    /// in `docs/network.md`.
     ///
     /// # Example
     ///

--- a/crates/fann/src/training/ewc.rs
+++ b/crates/fann/src/training/ewc.rs
@@ -1,13 +1,10 @@
 //! Elastic Weight Consolidation (EWC++) diagonal-Fisher forgetting guard.
 //!
-//! Prevents catastrophic forgetting during online or continual learning by
-//! penalising updates to parameters that were important for prior tasks.
-//! "Importance" is measured via an exponential moving average of squared
-//! gradients — a diagonal approximation to the Fisher information matrix.
+//! Tracks per-parameter importance from squared gradients and uses it to
+//! penalise or damp changes to parameters important to earlier tasks.
+//! The guard is independent of `Network` and operates on flat parameter slices.
 //!
-//! Reference: Kirkpatrick et al., "Overcoming catastrophic forgetting in
-//! neural networks", PNAS 2017; Chaudhry et al., "Efficient Lifelong Learning
-//! with A-GEM", ICLR 2019 (EWC++ online variant).
+//! See `docs/training.md` for the EWC model, lifecycle, and update formulas.
 
 use crate::error::{FannError, FannResult, validate_allocation_size};
 

--- a/crates/fann/src/training/mod.rs
+++ b/crates/fann/src/training/mod.rs
@@ -1,7 +1,9 @@
-//! Training module for neural networks
+//! Training algorithms and their shared configuration.
 //!
-//! Provides basic backpropagation training with configurable learning rates
-//! and optimization strategies.
+//! Provides momentum backpropagation, gradient-instability policies, and the
+//! feature-gated EWC and RLOO tools for online routing.
+//!
+//! See `docs/training.md` for training flow, configuration, and algorithms.
 
 mod backprop;
 #[cfg(feature = "online-router")]

--- a/crates/fann/src/training/rloo.rs
+++ b/crates/fann/src/training/rloo.rs
@@ -1,12 +1,10 @@
 //! REINFORCE with Leave-One-Out baseline (RLOO) policy-gradient trainer.
 //!
-//! Trains a selector gate network to prefer adapters that produce positive
-//! reward signals. The gate network must use `Activation::Linear` on its
-//! output layer (raw logits); softmax is applied inside this module.
+//! Trains a selector gate from rewards over its raw output logits. Its output
+//! layer must use `Activation::Linear`; this module applies softmax itself.
+//! EWC integration remains an independent call-site concern.
 //!
-//! EWC forgetting-guard integration is intentionally absent here — compose
-//! [`crate::training::ewc::DiagonalFisher`] at the call site to pin prior-task
-//! parameters independently of the policy-gradient update.
+//! See `docs/training.md` for reward semantics, RLOO sampling, and loss terms.
 
 use crate::activation::Activation;
 use crate::error::{FannError, FannResult, validate_allocation_size};


### PR DESCRIPTION
Follow-up to #947. The first extraction pass was a lib.rs-only summary (design.md ~146 lines against ~1244 lines of inline narrative) — too shallow. This pass transposes the full substance of the crate's long inline `//!` narrative into properly-written topic docs.

## What

- New `docs/gpu.md`, `docs/network.md`, `docs/training.md` carry the deep material (WGSL/wgpu backend + circuit breaker + shader manager; network builder/serialization; EWC/RLOO training).
- `docs/design.md` is the crate architecture overview; `docs/INDEX.md` points to every topic doc.
- Source `//!` blocks condensed to a summary + pointer to the topic doc. Load-bearing invariants, safety notes, and numeric/limit gotchas are kept inline (they must be visible at the code, not buried in prose).

## Verification

- `RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links" cargo doc -p lattice-fann --no-deps` — clean (no broken links, no warnings).
- `cargo fmt -p lattice-fann --check` — clean.
- Docs-only: no source logic changed, only `//!`/`///` comment volume and new markdown; no bench-compare applicable.
