### PR TITLE
docs(embed): deep-extract inline narrative into docs/, condense rustdoc

### DIFF
--- a/crates/embed/docs/INDEX.md
+++ b/crates/embed/docs/INDEX.md
@@ -1,9 +1,18 @@
-# lattice-embed — extended docs
+# lattice-embed extended documentation
 
-Deeper documentation for the crate, kept alongside the source so it stays current
-as the code changes. The crate-level rustdoc (`src/lib.rs`) and `README.md` hold
-the summary and public API surface; the files here hold the longer-form narrative.
+These guides hold the design narrative behind the public Rust API. Start with the architecture
+guide, then follow the subsystem relevant to the code or operational decision at hand.
 
-- [design.md](design.md) — module architecture and the model-migration/backfill
-  workflow (`migration` + `backfill` modules): the state machine, the routing table,
-  and the four-stage migration sequence.
+| Guide | Covers |
+| --- | --- |
+| [design.md](design.md) | Crate architecture, component boundaries, cache identity, migration fit, and WebAssembly bindings |
+| [simd.md](simd.md) | SIMD dispatch, numerical behavior, and quantized-vector operations |
+| [model.md](model.md) | Supported models, model configuration, prompts, pooling, provenance, and MRL dimensions |
+| [backfill.md](backfill.md) | Backfill coordination, routing policy, dual writes, and batch progression |
+| [migration.md](migration.md) | Migration plan/state lifecycle, progress, and failure handling |
+| [service.md](service.md) | Async service contract, native loading, cache wrapper, validation, and error handling |
+
+The crate-level Rust documentation is the short entry point; API-level contracts remain beside
+their types and functions in `src/`.
+
+

--- a/crates/embed/docs/backfill.md
+++ b/crates/embed/docs/backfill.md
@@ -1,0 +1,241 @@
+# Embedding backfill
+
+## Purpose and boundary
+
+Changing an embedding model changes the vector space used by an index. A source embedding
+and a target embedding can differ in model family, dimension, tokenization, instruction
+format, or all of those at once. They must therefore be treated as separate versions of the
+same document data, not as vectors that can be mixed in one index.
+
+The backfill subsystem makes that transition gradual. It has one narrow responsibility:
+given the migration state, decide which model or models an application should use for reads
+and writes, and report how much historical work remains. It does not fetch documents, invoke
+an embedding service, persist vectors, create indexes, schedule workers, or checkpoint
+application state. Those operations belong to the caller.
+
+<code>BackfillCoordinator</code> wraps a
+<code>MigrationController</code>. The controller owns lifecycle transitions and work
+accounting; the coordinator adds embedding-specific routing, batch sizing, and a
+post-cutover rollback window. This separation lets the migration state machine remain
+independent of an application's storage and query implementation.
+
+## The transition being protected
+
+A safe model change has two distinct races:
+
+1. Historical documents need target embeddings before their target index can be complete.
+2. New documents can arrive while historical data is being re-embedded.
+
+Backfill handles the second race with dual writes. While a migration is active, a new
+document can be embedded with both source and target models, so the target index does not
+fall behind while historical records are processed. A completed migration can keep doing
+that for a bounded rollback period. The application must maintain distinct source and target
+index namespaces; the coordinator selects models but does not provide that storage isolation.
+
+The migration plan identifies the source and target models, total historical embedding
+count, preferred plan batch size, identifier, and creation timestamp. The coordinator has
+its own <code>BackfillConfig</code>, so its processing batch policy need not be identical to
+the plan's descriptive batch size.
+
+## Lifecycle ownership
+
+Construct a coordinator with a plan and a configuration, then call <code>start</code>. That
+delegates the <code>Planned → InProgress</code> transition to the controller. The coordinator
+then exposes the same pause, resume, cancel, state, and progress operations.
+
+The coordinator records the cutover time only when its own <code>record_batch</code> call
+causes the underlying controller to become <code>Completed</code>. The timestamp uses
+<code>Instant</code>, so it measures elapsed time in the current process and is not a
+persisted wall-clock cutover record. Constructing a new coordinator starts with no cutover
+timestamp, even if an external system has retained migration metadata.
+
+<code>BackfillCoordinator</code> is a policy layer, not a worker pool. In particular,
+<code>max_concurrent</code> is stored in configuration but this type does not start, limit,
+or join concurrent batches. A caller that runs workers must apply the limit and make the
+read-embed-write operation idempotent for its own storage system.
+
+## Routing interfaces
+
+The coordinator offers two levels of routing information:
+
+- <code>route_request(is_new_document)</code> returns one
+  <code>EmbeddingRoute</code> for a write-like embedding request.
+- <code>route_query()</code> returns one <code>EmbeddingRoute</code> for a query.
+- <code>routing_config()</code> returns the complete read model, write-model set, phase, and
+  optional migration identifier. Use this form when the application must carry out dual
+  writes or respect the rollback window.
+
+An <code>EmbeddingRoute</code> is an instruction to the caller:
+
+| Route | Required application behavior |
+| --- | --- |
+| <code>Legacy</code> | Use only the source model and source index. |
+| <code>Target</code> | Use only the target model and target index. |
+| <code>DualWrite</code> | Produce and persist both source and target embeddings. |
+
+Returning <code>DualWrite</code> does not itself issue two embedding calls or commit two
+index writes.
+
+### Coarse request routing
+
+<code>route_request</code> distinguishes new documents from existing documents. The
+existing-document case represents ordinary re-embedding rather than the historical work that
+the backfill worker is processing.
+
+| Migration state | New document | Existing document |
+| --- | --- | --- |
+| Planned | Legacy | Legacy |
+| InProgress, dual write enabled | DualWrite | Legacy |
+| InProgress, dual write disabled | Legacy | Legacy |
+| Completed | Target | Target |
+| Paused, Failed, or Cancelled | Legacy | Legacy |
+
+Disabling <code>dual_write</code> means newly indexed documents are not automatically added
+to the target index while the migration is in progress. The caller must accept that coverage
+gap or provide a separate reconciliation path.
+
+This helper is intentionally coarser than <code>routing_config</code>: once state is
+<code>Completed</code>, it returns <code>Target</code> even during the rollback window. A
+write path that needs the source copy preserved during that window must use the full routing
+configuration rather than treating this single route as a complete write plan.
+
+### Query routing and the threshold
+
+<code>route_query</code> chooses the target only after completion or while an active
+migration has reached <code>target_query_threshold</code>. Its in-progress calculation is:
+
+    processed / total
+
+When <code>total</code> is zero, it treats progress as 1.0 and returns the target route.
+Every non-active state, including <code>Paused</code> and <code>Failed</code>, returns the
+legacy route regardless of any prior progress.
+
+The threshold comparison uses the raw processed and total counts, not effective coverage
+after permanent skips. If skips matter to an application's cutover policy, it must inspect
+the migration progress itself and choose a threshold policy deliberately.
+
+### Full read/write configuration
+
+<code>EmbeddingRoutingConfig</code> is the authoritative representation for an application
+that manages separate query and write paths:
+
+| Controller state and timing | Query model | Write models | Phase | Migration ID |
+| --- | --- | --- | --- | --- |
+| Planned | source | source | Stable | absent |
+| InProgress, dual write enabled | source | source, target | Migrating | present |
+| InProgress, dual write disabled | source | source | Migrating | present |
+| Completed, rollback window open | target | source, target | RollbackWindow | present |
+| Completed, rollback window elapsed | target | target | Stable | absent |
+| Paused, Failed, or Cancelled | source | source | Stable | absent |
+
+The rollback-window row always writes both models; it does not depend on the
+<code>dual_write</code> setting that applies during <code>InProgress</code>. That preserves
+all documents created after query cutover in both indexes, allowing a caller to restore
+source queries without losing those newly written records.
+
+<code>RoutingPhase::Stable</code> describes the current routing arrangement, not necessarily
+a successful completed migration. It is also returned for planned, paused, failed, and
+cancelled states. Code that needs to know the actual lifecycle state must read
+<code>state()</code>; a missing migration identifier likewise means there is no active
+routing transition in this configuration.
+
+## Batch accounting
+
+The coordinator does not select documents. It tells a worker how many entries it may take
+next:
+
+    remaining = saturating_sub(saturating_sub(total, processed), skipped)
+    next_batch_size = min(remaining, configured_batch_size)
+
+The result is zero unless the controller is in <code>InProgress</code>. Saturating
+subtraction prevents an underflow if a caller has supplied counts that exceed the original
+budget. The formula matches the controller's completion threshold, whose effective total is
+<code>total - skipped</code>.
+
+A typical worker loop is:
+
+~~~rust
+coordinator.start()?;
+
+loop {
+    let batch_size = coordinator.next_batch_size();
+    if batch_size == 0 {
+        break;
+    }
+
+    // Load at most batch_size historical records, embed with the target model,
+    // and commit their target-index entries before reporting the completed count.
+    coordinator.record_batch(batch_size)?;
+}
+~~~
+
+The sketch only shows coordinator calls. A production worker must use a durable work cursor
+or equivalent claim mechanism; otherwise retries can embed or count the same record more
+than once. It must report only records that have reached the application's intended durable
+write boundary.
+
+<code>record_batch(count)</code> adds <code>count</code> to
+<code>backfilled_count</code> and delegates to the controller's
+<code>record_progress</code>. It also records the cutover timestamp if that progress call
+transitions from active to completed. The count is incremented before the delegated call can
+return an invalid-transition error, so callers should invoke it only while active and should
+not use it as a transactional acknowledgement of storage work.
+
+The underlying migration state supports permanently skipped entries, and
+<code>next_batch_size</code> accounts for their count. The public coordinator facade does
+not expose a method to record an individual skip; applications that require skip reporting
+must account for that limitation when integrating the controller and coordinator APIs.
+
+## Rollback window
+
+Completion is a query cutover, not immediate retirement of the source index. For
+<code>rollback_window_secs</code> after the coordinator observes completion:
+
+- queries use the target model;
+- writes continue to source and target;
+- the routing phase is <code>RollbackWindow</code>;
+- the migration identifier remains available in the routing configuration.
+
+After the elapsed interval, routing becomes stable target-only and the migration identifier
+is omitted. A zero-second window expires immediately. Before completion, or if completion
+was not observed through <code>record_batch</code>, <code>in_rollback_window()</code> is
+false.
+
+The coordinator only preserves a source copy during the window. It does not provide a
+method to reverse index aliases, delete target data, or re-open the controller's completed
+state. An application rollback procedure must supply those storage and serving actions.
+
+## Configuration
+
+<code>BackfillConfig::default()</code> uses the following policy:
+
+| Field | Default | Meaning |
+| --- | ---: | --- |
+| <code>batch_size</code> | 100 | Maximum entries suggested by <code>next_batch_size</code>. |
+| <code>max_concurrent</code> | 4 | Concurrency budget for the caller to enforce. |
+| <code>dual_write</code> | true | Dual-write new documents while active. |
+| <code>target_query_threshold</code> | 0.8 | Raw progress fraction at which <code>route_query</code> may choose target. |
+| <code>rollback_window_secs</code> | 86,400 | Time to retain source writes after completed cutover. |
+
+The configuration and full routing configuration are serializable with snake-case phase
+names. A serialized routing configuration includes concrete model selections and should be
+treated as a snapshot: recompute it from a live coordinator whenever the lifecycle state or
+rollback timer may have changed.
+
+## Operational checks
+
+Before starting a transition, ensure that:
+
+1. Source and target embeddings will be written to distinct, versioned index locations.
+2. The target index has the schema and dimension required by the target model.
+3. New-document writes honor <code>routing_config</code>, not just a single coarse route,
+   when rollback is enabled.
+4. The backfill worker persists a progress cursor outside this in-memory coordinator.
+5. The query threshold reflects the application's tolerance for incomplete target coverage,
+   including its policy for skipped entries.
+6. Source indexes are retained at least through the intended rollback period and any
+   external validation period.
+
+The coordinator provides deterministic routing from its local state. Correct migration
+outcomes still depend on the caller making embedding writes, index updates, cursor commits,
+and query aliases agree with that routing decision.

--- a/crates/embed/docs/design.md
+++ b/crates/embed/docs/design.md
@@ -1,73 +1,175 @@
-# lattice-embed design
+# lattice-embed architecture
 
-`lattice-embed` generates vector embeddings for the lattice-runtime substrate: pure-Rust
-local inference (no ONNX, no Python) over the BGE and multilingual E5/Qwen3 model
-families, plus an async `EmbeddingService` API and SIMD-accelerated vector ops
-(`utils::cosine_similarity`, `dot_product`, `normalize`, `euclidean_distance`) consumed
-directly by khive's ANN indexes.
+`lattice-embed` turns text into local vector embeddings and provides the supporting pieces
+needed to use those vectors safely: model selection, role-aware caching, SIMD similarity
+operations, and staged migration to a new embedding space. The native path is pure Rust and
+uses `lattice-inference`; it does not depend on an external ML runtime.
 
-For model variants, MRL truncation, the two-layer cache, and batch-processing internals,
-see `DESIGN.md` at the crate root (line-numbered design notes with invariants and
-rejected alternatives). This file covers the model-migration/backfill workflow, which is
-large enough to warrant its own narrative.
+The crate is mostly an unstable implementation layer intended to sit below a higher-level
+consumer. One deliberately narrow exception is the 0.4.x ANN consumer contract: the public
+SIMD squared-L2/L2 distance, dot-product, and cosine-similarity functions retain their slice
+signatures and documented behavior for degenerate input. Implementations may use different
+instruction sets, so callers must not treat near-equal SIMD results as bit-identical scalar
+results or depend on an exact near-tie ordering.
 
-## Architecture
+## System map
 
-The crate is organized leaf-most first:
+```text
+application text
+       |
+       v
+EmbeddingService  -- query/passage prefix selection --> EmbeddingModel / ModelConfig
+       |                                                    |
+       | native builds                                      v
+       +--> CachedEmbeddingService --> EmbeddingCache --> cache key identity
+       |            |                                      (text + model revision + dim + role)
+       |            v
+       +------> NativeEmbeddingService --> lattice-inference --> normalized vectors
+                                                            |
+                                                            v
+                                                simd vector comparison / ANN index
 
-- **Model & config** — `model`: the `EmbeddingModel` enum and `ModelConfig` (MRL output
-  dimension, validation).
-- **Cache** — `cache`: sharded in-memory LRU (`EmbeddingCache`), Blake3-keyed.
-- **Services** — `service`: the `EmbeddingService` trait, `NativeEmbeddingService` (local
-  inference), `CachedEmbeddingService` (LRU wrapper).
-- **SIMD** — `simd`: dot product, cosine similarity, normalization, and int8/int4/binary
-  quantized distance kernels with per-platform dispatch (AVX-512/AVX2/NEON/wasm32
-  SIMD128). See the module-level docs inside `simd/` for the numeric and dispatch
-  invariants — those stay inline because they are load-bearing correctness notes, not
-  background.
-- **Migration** — `migration`: the `MigrationController` state machine that tracks a
-  single embedding-model migration from `Planned` through `Completed`.
-- **Backfill** — `backfill`: the `BackfillCoordinator`, which wraps a
-  `MigrationController` and adds request/query routing plus batch-size management on top
-  of the state machine.
-- **wasm** (optional, `wasm` feature + `wasm32` target only) — `wasm-bindgen` bindings
-  over the SIMD utility functions.
+stored vectors <--> migration state machine <--> backfill routing and batch coordination
+```
 
-## Model migration and backfill
+The components have intentionally separate responsibilities. The service produces vectors;
+the cache avoids repeated production; SIMD compares vectors after they exist; and migration
+and backfill coordinate a change from one vector space to another. Neither the cache nor a
+service itself decides when an index may cut over to a different model.
 
-Swapping embedding models (for example BGE-small to multilingual-E5-small) requires
-re-embedding every stored document without an all-at-once cutover. The migration and
-backfill modules split this into two layers:
+| Area | Module | Responsibility | Detailed reference |
+| --- | --- | --- | --- |
+| Model identity and configuration | `model` | Supported variants, provenance, native and MRL output dimensions, model prompts, pooling selection | [model.md](model.md) |
+| In-memory reuse | `cache` | Sharded LRU and cache-key construction | This document and [service.md](service.md) |
+| Vector arithmetic | `simd` | Runtime/compile-time dispatch and exact public operation contracts | [simd.md](simd.md) |
+| Embedding production | `service` | Async API, prompt application, native model lifecycle, and cache wrapper | [service.md](service.md) |
+| Migration state | `migration` | Model-swap state machine and progress tracking | [migration.md](migration.md) |
+| Migration execution policy | `backfill` | Request/query routing, dual writes, and backfill batches | [backfill.md](backfill.md) |
+| Browser boundary | `wasm` | In-memory BERT bindings and wasm SIMD utility exports | [WebAssembly bindings](#webassembly-bindings) |
+| Shared values | `types`, `error` | Embedding metadata and typed operational failures | [service.md#error-boundaries](service.md#error-boundaries) |
 
-1. **`MigrationController`** (in `migration`) is a plain state machine over a
-   `MigrationPlan`: `Planned -> InProgress -> Completed`, with `Paused`, `Failed`, and
-   `Cancelled` as side states. It has no opinion about routing — it only tracks progress
-   (`record_progress`) and exposes the current `MigrationState`.
-2. **`BackfillCoordinator`** (in `backfill`) wraps a `MigrationController` and answers the
-   question every request needs answered: *which model handles this?* It layers routing
-   decisions on top of the same state machine:
+## Embedding flow and identity
 
-   | State       | New Doc Route | Existing Doc Route | Query Route         |
-   |-------------|---------------|---------------------|----------------------|
-   | Planned     | Legacy        | Legacy              | Legacy               |
-   | InProgress  | DualWrite*    | Legacy               | Legacy or Target**  |
-   | Paused      | Legacy        | Legacy              | Legacy               |
-   | Completed   | Target        | Target              | Target               |
-   | Failed      | Legacy        | Legacy              | Legacy               |
-   | Cancelled   | Legacy        | Legacy              | Legacy               |
+An embedding is meaningful only in the space that produced it. In practice, that space is more
+specific than an `EmbeddingModel` enum variant: it also includes the model's key revision and
+the active output dimension. A configurable Qwen MRL output dimension changes the space even
+when the base model is the same. Indexes and cache entries must therefore not mix vectors from
+different `ModelConfig` values.
 
-   \* Only when `dual_write` is enabled in `BackfillConfig`.
-   \*\* Switches to `Target` once backfill progress reaches `target_query_threshold`.
+The normal native flow is:
 
-The overall migration sequence a caller drives is:
+1. Construct a `NativeEmbeddingService` for one `EmbeddingModel` or `ModelConfig`. The native
+   service accepts requests only for that configured model.
+2. Choose the semantic operation: `embed` for generic text, `embed_query` for a retrieval
+   query, or `embed_passage` for stored document text. The latter two apply the selected
+   model's instruction prefix before inference.
+3. Optionally place a `CachedEmbeddingService` around the native service. It validates the
+   request, returns any cached vectors, embeds only misses, and restores the input order.
+4. The native service loads its model lazily, off the async runtime, then encodes the input.
+   BERT-family models use batch encoding; Qwen currently encodes the missing inputs one at a
+   time so its model-local cache can participate.
+5. Store or compare the returned vectors only with vectors produced under the same model,
+   active dimension, and retrieval role policy.
 
-1. Continue serving queries against the existing (legacy) embeddings.
-2. Route new document embeddings appropriately (dual-write during `InProgress`, or
-   target-only once cutover is safe).
-3. Backfill old documents with the new model's embeddings in batches
-   (`BackfillCoordinator` computes batch sizes from progress).
-4. Switch queries to the new model once coverage crosses `target_query_threshold`.
+For cache identity, the wrapper hashes the already-prompted text with the model identity,
+model key version, active dimension, and `EmbeddingRole`. Role is deliberately separate from
+the prompted text: a query and a passage can otherwise be confused for models whose text is
+unchanged on one side. `embed` retains the `Generic` role for compatibility with existing
+generic cache entries. See [service.md](service.md#cachedembeddingservice) for the exact
+lookup-and-fill sequence.
 
-This separation keeps the state machine (`migration`) reusable for any two-phase model
-swap, while the routing policy (`backfill`) stays specific to the embedding read/write
-paths.
+## Model and inference boundary
+
+`EmbeddingModel` is the portable selection value. `ModelConfig` pairs it with an optional MRL
+truncation dimension and validates that a model supports the requested output dimension. The
+native service owns one such configuration for its lifetime; it rejects a request selecting a
+different model rather than switching models under active callers.
+
+The native implementation routes encoder families and decoder families differently:
+
+- BGE, multilingual E5, and the MiniLM variants load as BERT-family encoders. BGE is configured
+  for CLS pooling; E5 and MiniLM use masked mean pooling.
+- Qwen3 embedding variants load from a model directory, receive the configured output
+  dimension, and can load/save their model-local embedding cache.
+- A variant that is not locally supported fails through `EmbedError` instead of selecting a
+  remote service implicitly.
+
+Instruction prompts are a service concern because they encode query/document semantics, while
+pooling and output dimensions are inference configuration. The complete prompt and model table
+is in [model.md](model.md); service-level behavior is in [service.md](service.md#retrieval-roles-and-prompts).
+
+## Caching layers
+
+The crate has two different caches that should not be conflated:
+
+1. **`EmbeddingCache`** is the process-local, sharded LRU used by
+   `CachedEmbeddingService`. Its capacity is measured in vectors; a capacity of zero disables
+   it and causes the wrapper to call the inner service without hashing or locking. It is the
+   layer that preserves an application's request order across a mix of hits and misses.
+2. **The Qwen model cache** belongs to `QwenModel`, not to `EmbeddingCache`. When a Qwen model
+   loads, the native service attempts to load a persistent cache whose file name includes the
+   model identifier and current vector dimension. `save_cache` persists that cache only for a
+   loaded Qwen model. A failed integrity check is logged and ignored so future inference can
+   regenerate entries; it is not treated as a successful cache hit.
+
+The distinction matters during MRL use and model migration. The LRU key includes the active
+dimension, and Qwen persistence uses it in the file name, so 1,024-dimensional and native-size
+vectors do not share cached values. Those values still need separate vector-index namespaces
+when a migration is in progress.
+
+## SIMD and index boundary
+
+`simd` contains the computation kernels used to compare or normalize embedding vectors. It
+selects AVX-512/AVX2/FMA on supported x86_64 hosts, NEON on aarch64, SIMD128 when it was
+compiled into a wasm artifact, and scalar fallback elsewhere. The runtime dispatch configuration
+is initialized once and exposed as `SimdConfig`.
+
+The service layer does not require a particular SIMD capability: every supported path has a
+scalar fallback. SIMD remains independent of model loading, cache policy, and migration state;
+this keeps it usable by ANN consumers that already have vectors. Numeric rules such as
+zero/NaN handling, quantization tiers, and the squared-L2 ordering invariant are part of the
+operation contract and live in [simd.md](simd.md) and the public Rust API docs.
+
+## Migration and backfill boundary
+
+Changing an embedding model is a data migration, not a service hot swap. Existing vectors and
+new vectors occupy different spaces, even where their dimensions happen to match. The crate
+separates the state of that migration from the policy used to serve traffic:
+
+- `MigrationController` represents one `MigrationPlan` and records lifecycle transitions and
+  progress without deciding which model should serve any request.
+- `BackfillCoordinator` wraps that state machine and derives document-write, existing-document,
+  and query routes. It also controls backfill batch progression, dual writes, the target query
+  threshold, and the rollback window.
+
+The intended operational progression is to keep searching the legacy index, begin dual-writing
+new documents where configured, backfill old documents into the target index, and move query
+traffic only when the configured coverage condition is met. The target remains a separate index
+until the application considers cutover complete. The state-machine details and routing tables
+are in [migration.md](migration.md) and [backfill.md](backfill.md).
+
+## WebAssembly bindings
+
+The `wasm` module is compiled only when both the `wasm` feature and the `wasm32` target are
+active. The dual gate is intentional: the binding dependencies live in the wasm32 target
+dependency table, so enabling the feature for a native target must leave the module absent
+rather than trying to resolve `wasm-bindgen` there.
+
+`wasm32-unknown-unknown` does not offer the filesystem/memory-map path used by native model
+loading. In particular, a `memmap2` wasm fallback may compile but memory-map calls fail at
+runtime. The browser API consequently accepts raw `model.safetensors`, `config.json`, and
+`tokenizer.json` bytes in `LatticeEmbedder::new`; the JavaScript host is responsible for fetching
+and retaining those bytes. Loading, embedding, and error conversion run synchronously in memory.
+There is no native download, disk cache, or `spawn_blocking` lifecycle in this path.
+
+The browser embedder supports BERT-family models. It starts with mean pooling, which is suitable
+for E5 and MiniLM; a BGE caller must invoke `useClsPooling` before embedding. Invalid UTF-8 in
+the JSON inputs, model parsing failures, and unsupported BERT configuration become JavaScript
+exceptions through `wasm-bindgen`.
+
+The module also exports dot product, squared Euclidean distance, cosine similarity, and
+in-place normalization. These call the Rust SIMD API rather than a separate JavaScript loop.
+SIMD128 is a compile-time property on wasm, not a runtime CPU probe. The
+`simdSimd128Dispatch` binding deliberately reports the same `SimdConfig` decision used by the
+kernels, allowing callers to verify that a SIMD128 build is exercising the intended path rather
+than silently measuring scalar fallback.

--- a/crates/embed/docs/migration.md
+++ b/crates/embed/docs/migration.md
@@ -1,0 +1,212 @@
+# Embedding migration controller
+
+## Scope
+
+The migration module is the bookkeeping layer for a transition from one embedding model
+version to another. A plan names a source model and a target model, and a controller tracks
+the lifecycle and work budget for that one transition.
+
+It deliberately does not embed text, write vectors, create an index, validate that the two
+models are distinct, route reads or writes, or persist itself. The backfill coordinator uses
+this controller to implement model routing; an application owns durable work cursors,
+storage namespaces, retry policy, and deployment-level cutover actions.
+
+This boundary matters because vector spaces are versioned data. A model swap can change
+semantic geometry as well as vector dimension, so source and target embeddings must not be
+mixed in an index merely because they describe the same documents. The controller records
+that a transition exists; it cannot make an application's index layout safe by itself.
+
+## Public data model
+
+### Migration plan
+
+<code>MigrationPlan</code> is the immutable input used to construct a controller:
+
+| Field | Meaning |
+| --- | --- |
+| <code>id</code> | Caller-provided migration identifier. No uniqueness check is performed. |
+| <code>source_model</code> | The model version being replaced. |
+| <code>target_model</code> | The model version being introduced. |
+| <code>total_embeddings</code> | Initial historical-work budget. |
+| <code>batch_size</code> | Descriptive preferred processing batch size. The controller does not schedule batches. |
+| <code>created_at</code> | Caller-supplied ISO 8601 timestamp string. It is stored without parsing or validation. |
+
+The plan does not prove that source and target differ, that their dimensions are compatible
+with any existing index, or that total_embeddings matches a live dataset. Perform those
+checks before constructing the controller.
+
+### Lifecycle state
+
+<code>MigrationState</code> is serializable and non-exhaustive. Downstream code must include
+a wildcard case when matching it so future states can be added without making integrations
+invalid.
+
+| State | Stored information | Interpretation |
+| --- | --- | --- |
+| <code>Planned</code> | none | Created but not started. |
+| <code>InProgress</code> | processed, total, skipped | Active work budget. |
+| <code>Paused</code> | processed, total, skipped, reason | Stopped intentionally; may resume. |
+| <code>Failed</code> | processed, total, skipped, error | Stopped due to a failure; may resume. |
+| <code>Completed</code> | processed, skipped, duration_secs | Work was reported complete. |
+| <code>Cancelled</code> | processed, total, skipped | Abandoned by the caller. |
+
+<code>Completed</code> and <code>Cancelled</code> are terminal according to
+<code>is_terminal()</code>. A failure is not terminal: <code>is_resumable()</code> is true
+for both paused and failed states. Only <code>InProgress</code> is active.
+
+### Skips and progress reports
+
+<code>SkipReason</code> records a permanent reason not to embed one entry:
+
+- content exceeded its maximum allowed byte size;
+- text used an invalid or unsupported encoding;
+- the source content was deleted;
+- an embedding API returned a non-retryable error; or
+- a caller intentionally skipped the item.
+
+<code>MigrationProgress</code> is a snapshot, not a mutable checkpoint. It includes the
+migration identifier, cloned lifecycle state, skipped count, effective total and coverage,
+active throughput, optional estimated remaining seconds, and a count of non-fatal errors.
+<code>record_error</code> only increments that error count; it does not change lifecycle
+state or retain an error message.
+
+<code>MigrationError</code> currently reports an attempted invalid state transition, with
+debug-formatted source and destination descriptions. It is also non-exhaustive, so callers
+must not assume this is the only possible error category.
+
+## State machine
+
+The controller accepts only these lifecycle operations:
+
+~~~text
+Planned ── start ──> InProgress ── progress reaches effective total ──> Completed
+   │                       │  │
+   │ cancel                │  └── fail ──> Failed ── resume ─┐
+   ▼                       │                                  │
+Cancelled <── cancel ──────┼── pause ──> Paused ── resume ────┘
+                           │
+                           └── cancel ──> Cancelled
+~~~
+
+The allowed calls are:
+
+| Method | Accepted source state | Result |
+| --- | --- | --- |
+| <code>start</code> | Planned | InProgress with zero processed and skipped counts. |
+| <code>record_progress</code> | InProgress | Updates processed count or completes the migration. |
+| <code>record_skip</code> | InProgress | Adds one permanent skip when capacity remains. |
+| <code>pause</code> | InProgress | Paused, retaining all counts and a reason. |
+| <code>fail</code> | InProgress | Failed, retaining all counts and an error string. |
+| <code>resume</code> | Paused or Failed | InProgress, retaining all counts. |
+| <code>cancel</code> | Planned, InProgress, Paused, or Failed | Cancelled, retaining counts available in that state. |
+
+Starting twice, progressing while inactive, pausing an inactive migration, resuming planned
+or terminal work, and cancelling a completed or already cancelled migration all return an
+invalid-transition error. There is no transition out of <code>Completed</code> or
+<code>Cancelled</code>.
+
+## Work accounting
+
+### Raw progress
+
+For planned state, <code>progress()</code> returns 0.0. For completed state it returns 1.0.
+For active, paused, failed, and cancelled states it calculates:
+
+    processed / total
+
+When total is zero, it returns 1.0 rather than dividing by zero. The controller preserves an
+overshoot supplied to <code>record_progress</code>; it does not clamp processed to total.
+Consequently, raw progress in a non-completed state can exceed 1.0 if a caller reports more
+work than its original budget. Callers should keep their external work cursor consistent
+with the plan instead of relying on this type to normalize counts.
+
+### Effective total and coverage
+
+Permanent skips reduce the number of entries that actually require an embedding:
+
+    effective_total = saturating_sub(total, skipped)
+    effective_coverage = processed / effective_total
+
+Effective coverage is 1.0 when effective total is zero. Like raw progress, it retains an
+overshoot rather than clamping the numerator. This measure is useful for worker accounting,
+but it has a representation caveat: the completed state does not store the original total.
+Its <code>total()</code> therefore returns zero, and a progress snapshot produced after
+completion reports an effective total of zero. Preserve the plan separately if a completed
+report must display the original or effective work budget.
+
+### Completion rule
+
+<code>record_progress(newly_processed)</code> updates:
+
+    new_processed = processed + newly_processed
+
+It completes when <code>new_processed >= total - skipped</code>. Completion stores the
+reported processed count, skipped count, and elapsed duration. Reporting an oversized final
+batch is therefore accepted and retains the oversized processed value.
+
+<code>record_skip</code> never completes a migration by itself. It is accepted only while:
+
+    processed + skipped < total
+
+This guard prevents a duplicate or retried skip from exceeding the budget. If skips reduce
+effective total to zero, call <code>record_progress(0)</code> to trigger the normal
+completion rule. This is intentional: only the progress operation turns active work into
+the completed state.
+
+## Timing, throughput, and ETA
+
+<code>start</code> records a process-local <code>Instant</code>. While the state is active,
+throughput is:
+
+    processed / elapsed_seconds_since_start
+
+The estimated remaining time is calculated only when throughput is positive:
+
+    (total - skipped - processed) / throughput
+
+All subtractions used for remaining work saturate at zero. Paused, failed, completed,
+cancelled, and planned snapshots report zero throughput and no ETA.
+
+The timer is not paused when a migration enters <code>Paused</code> or <code>Failed</code>.
+On resume, the original start time remains when one exists. The resulting rate is elapsed
+wall time across the whole controller lifetime, including interruptions, rather than pure
+active-worker time. Because <code>Instant</code> is in-memory, timing information cannot be
+reconstructed from a serialized state alone.
+
+## Serialization and version evolution
+
+<code>MigrationState</code> uses snake-case variant names when serialized. Its state variants
+also accept their former PascalCase names as deserialization aliases. This allows persisted
+state written before the naming change to remain readable.
+
+The <code>skipped</code> field defaults to zero when it is absent from serialized
+in-progress, paused, failed, completed, or cancelled states. The skip-related fields on
+<code>MigrationProgress</code> also have serde defaults, so older progress payloads may
+deserialize without them. An absent value means zero at deserialization time; it does not
+recover information that was never persisted.
+
+The controller itself is not serializable. It owns an <code>Instant</code>, non-fatal error
+count, and in-memory vector of skip reasons in addition to its plan and state. An application
+that needs restart recovery must define how it persists the plan, state, work cursor, and any
+skip audit data, then construct and drive a controller consistently with that external
+checkpoint.
+
+## Relationship to backfill routing
+
+The controller knows nothing about source versus target index aliases. It can reach
+<code>Completed</code> without changing which model handles a request. The backfill
+coordinator is the layer that:
+
+1. dual-writes newly created documents while historical records receive target embeddings;
+2. chooses a target query route at a configured coverage threshold;
+3. records a cutover moment when it observes completion; and
+4. keeps source writes alive during a post-cutover rollback window.
+
+This division prevents migration accounting from being coupled to one storage topology, but
+it also means a successful controller state alone is not proof that target data is queryable.
+Before using completion as a serving cutover, an application should verify target-index
+coverage, model and dimension compatibility, durable persistence of processed work, and the
+desired handling of permanently skipped entries.
+
+See [backfill.md](backfill.md) for the embedding-specific routing and batch policy built on
+top of this state machine.

--- a/crates/embed/docs/model.md
+++ b/crates/embed/docs/model.md
@@ -1,0 +1,335 @@
+# Embedding models and cache
+
+`lattice-embed` separates the choice of an embedding model from the runtime
+configuration of its output space. That distinction is important: changing a
+model, its revision family, its retrieval role, or its active output dimension
+changes the meaning of an embedding. Such vectors must not be mixed in one
+index or cache entry.
+
+This document covers the model registry, prompt and pooling wiring, output
+dimension configuration, provenance, vector-space identifiers, and the
+in-memory embedding cache.
+
+## Model wiring
+
+`EmbeddingModel` is the stable, non-exhaustive registry of supported model
+variants. It is serialised with snake-case variant names and accepts the
+corresponding PascalCase names as Serde aliases. Its default is
+`BgeSmallEnV15`.
+
+The registry provides the facts that the rest of the embedding stack needs:
+
+- the provider model identifier used to locate the model;
+- native output width and conservative input limit;
+- whether inference runs locally or through a remote API;
+- the query and document prefixes required for retrieval;
+- the BERT pooling mode when native BERT-family inference is enabled; and
+- the embedding-key revision used to distinguish incompatible model families.
+
+The usual relationship is:
+
+```text
+EmbeddingModel
+    │ model-specific limits, prompts, pooling, key version
+    ▼
+ModelConfig
+    │ active output dimension
+    ├──────────────► embedding invocation
+    └──────────────► cache key and vector-index namespace
+```
+
+`EmbeddingModel::dimensions()` always returns the native width. It does not
+account for an optional Matryoshka Representation Learning (MRL) truncation;
+use `ModelConfig::dimensions()` when allocating output buffers, defining an
+index, or constructing an embedding cache key.
+
+### Supported variants
+
+| Variant | Model identifier | Native dimensions | Conservative maximum input tokens | Execution | Native BERT pooling |
+| --- | --- | ---: | ---: | --- | --- |
+| `BgeSmallEnV15` | `BAAI/bge-small-en-v1.5` | 384 | 512 | Local | CLS |
+| `BgeBaseEnV15` | `BAAI/bge-base-en-v1.5` | 768 | 512 | Local | CLS |
+| `BgeLargeEnV15` | `BAAI/bge-large-en-v1.5` | 1,024 | 512 | Local | CLS |
+| `MultilingualE5Small` | `intfloat/multilingual-e5-small` | 384 | 512 | Local | Mean |
+| `MultilingualE5Base` | `intfloat/multilingual-e5-base` | 768 | 512 | Local | Mean |
+| `AllMiniLmL6V2` | `sentence-transformers/all-MiniLM-L6-v2` | 384 | 256 | Local | Mean |
+| `ParaphraseMultilingualMiniLmL12V2` | `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` | 384 | 128 | Local | Mean |
+| `Qwen3Embedding0_6B` | `Qwen/Qwen3-Embedding-0.6B` | 1,024 | 8,192 | Local | Not a BERT path |
+| `Qwen3Embedding4B` | `Qwen/Qwen3-Embedding-4B` | 2,560 | 8,192 | Local | Not a BERT path |
+| `TextEmbedding3Small` | `text-embedding-3-small` | 1,536 | 8,191 | Remote | Not a BERT path |
+
+The limits are intended for chunking and truncation. They leave room for
+special tokens. In particular, Qwen3-Embedding is capped at 8,192 tokens for
+practical use even though the underlying model supports a longer context.
+
+`is_local()` is true for every variant except `TextEmbedding3Small`;
+`is_remote()` is true only for `TextEmbedding3Small`. Native BERT pooling is
+available only with the `native` feature. BGE v1.5 uses the first-token (CLS)
+representation, whereas E5 and MiniLM variants use masked mean pooling. Qwen3
+and the remote model follow their own embedding paths and therefore return no
+BERT pooling choice.
+
+### Retrieval prompting is part of the embedding space
+
+Asymmetric retrieval models are trained to receive different input forms for
+queries and documents. Apply the prefix returned by `query_instruction()` or
+`document_instruction()` immediately before embedding the original text. The
+prefix is not display-only metadata: omitting it changes retrieval quality and
+creates vectors that are not comparable to correctly prepared vectors.
+
+| Family | Query input | Document input | Why it matters |
+| --- | --- | --- | --- |
+| E5 | `query: {query}` | `passage: {document}` | E5 was trained with these asymmetric prefixes. |
+| BGE v1.5 | `Represent this sentence for searching relevant passages: {query}` | Raw document text | The query instruction is required; BGE passages remain unprefixed. |
+| Qwen3-Embedding | `Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: {query}` | Raw document text | The task instruction aligns query embeddings with passages. |
+| MiniLM variants | Raw query text | Raw document text | These models use symmetric raw-text inputs. |
+| Remote text-embedding model | Raw query text | Raw document text | The registry supplies no instruction prefix. |
+
+For example, a retrieval caller can make the role explicit before asking an
+embedding service to embed the text:
+
+```rust
+let model = EmbeddingModel::MultilingualE5Small;
+let query = format!("{}{}", model.query_instruction().unwrap_or(""), "rust lru cache");
+let passage = format!(
+    "{}{}",
+    model.document_instruction().unwrap_or(""),
+    "An LRU cache evicts the least recently used entry."
+);
+```
+
+Do not use a query vector and a document vector as if their roles were
+interchangeable for an asymmetric model. The cache also records the embedding
+role in its key so that identical raw text embedded through query, passage, or
+generic entry points cannot be reused across roles.
+
+### Parsing and naming
+
+`Display` produces a lower-case canonical model name, such as
+`bge-small-en-v1.5` or `qwen3-embedding-4b`. `FromStr` accepts a case-insensitive
+input after trimming whitespace and converting underscores to hyphens. It also
+accepts common short names and selected full provider identifiers. For example,
+`small`, `bge-small`, and `BAAI/bge-small-en-v1.5` select BGE small; `e5-base`
+selects multilingual E5 base; `qwen3` selects the 0.6B Qwen3 variant; and
+`openai` selects `TextEmbedding3Small`.
+
+Parsing is deliberately convenient for configuration and command-line input,
+but persisted model identity should use the registry value and its key version,
+not a user-provided alias.
+
+## Runtime output dimensions
+
+`ModelConfig` pairs an `EmbeddingModel` with an optional output dimension. With
+`output_dim: None`, its active dimension is the model's native width. An
+explicit value requests MRL truncation and is valid only for the two
+Qwen3-Embedding variants.
+
+`ModelConfig::try_new(model, output_dim)` validates the requested space:
+
+1. A model without MRL support rejects any explicit output dimension.
+2. The requested dimension must be at least `MIN_MRL_OUTPUT_DIM` (32).
+3. It must not exceed the model's native dimension.
+
+`ModelConfig::new(model)` creates the no-truncation configuration, and
+`validate()` is available when a configuration was deserialised or otherwise
+assembled before use. The fields are public, so callers that construct a
+configuration directly should validate it before selecting an output space.
+
+Different active dimensions are different embedding spaces, even when they
+come from the same Qwen model. Keep them in separate vector-index namespaces.
+The embedding cache preserves this boundary by including the active dimension
+in every key.
+
+## Load provenance
+
+`ModelProvenance` records which registry variant was loaded, the source
+identifier, the loading time, and a convenience RFC 3339 timestamp. Its `hash`
+is a 64-character BLAKE3 hexadecimal digest of:
+
+```text
+{model_id}:{loaded_at_iso}:{model_debug_representation}
+```
+
+This gives each load event a lightweight metadata identifier. It is not a hash
+of model weights and must not be treated as a model-integrity verification.
+Weight verification belongs to the inference layer's checksum facilities.
+`dimensions()` forwards to the loaded model's native dimensions, and
+`matches_model()` compares the recorded variant with an expected one.
+
+## Embedding-space identity
+
+The types in `types.rs` describe a vector space independently of the
+in-memory cache. They are appropriate for selecting vector-store collections,
+routing migrations, and producing deterministic identifiers for a complete
+embedding-space description.
+
+### Component encodings
+
+The enum discriminants are part of `EmbeddingKey::canonical_bytes()`:
+
+| Descriptor | Variant | Byte | Additional meaning |
+| --- | --- | ---: | --- |
+| `DistanceMetric` | `Cosine` | 1 | Cosine similarity / distance convention |
+|  | `Dot` | 2 | Inner product |
+|  | `L2` | 3 | Euclidean distance |
+| `VectorDType` | `F32` | 1 | Four bytes per element |
+|  | `F16` | 2 | Two bytes per element |
+|  | `I8` | 3 | One byte per element |
+| `VectorNorm` | `None` | 0 | No normalisation applied |
+|  | `Unit` | 1 | L2 norm equals one |
+
+`DistanceMetric::from_byte()` returns `None` for an unknown discriminant.
+`VectorDType::size_bytes()` reports the storage width. All three types use
+snake-case Serde representation and are non-exhaustive, so consumers should
+avoid assuming that their current variants are exhaustive.
+
+### Canonical `EmbeddingKey` format
+
+An `EmbeddingKey` contains the provider/model name, its revision, dimensions,
+distance metric, storage data type, and normalisation state. Its
+`canonical_bytes()` method emits this exact deterministic sequence:
+
+```text
+model UTF-8 byte length       4-byte unsigned big-endian integer
+model                         UTF-8 bytes
+revision UTF-8 byte length    4-byte unsigned big-endian integer
+revision                      UTF-8 bytes
+dims                          4-byte unsigned big-endian integer
+metric                        1 byte
+dtype                         1 byte
+norm                          1 byte
+```
+
+Length prefixes make the variable-length strings unambiguous. The resulting
+bytes are suitable as the input to a deterministic hash for deduplication.
+They should not be confused with `CacheKey`: the latter is a 32-byte in-memory
+BLAKE3 digest with a cache-specific construction described below.
+
+## Embedding cache
+
+`EmbeddingCache` is an in-memory, thread-safe LRU cache for already computed
+embeddings. It avoids repeating inference for equivalent inputs while keeping
+the returned vector cheap to share: stored `Vec<f32>` values become
+`Arc<[f32]>`, and a cache hit clones only the reference-counted handle rather
+than the vector contents.
+
+The cache is an internal, unstable mechanism. Its key scheme, shard count,
+return type, and metric shapes may change. Do not persist `CacheKey` values or
+assume they remain valid between process versions or sessions.
+
+### Key construction
+
+`CacheKey` is a 32-byte array: the BLAKE3 digest of the following byte stream:
+
+```text
+UTF-8 bytes of text
+UTF-8 bytes of "{model_display}:{model_key_version}:{active_dimensions}:{role_cache_tag}"
+```
+
+`model_display` is the canonical `Display` name, `model_key_version` comes
+from `EmbeddingModel::key_version()`, `active_dimensions` comes from
+`ModelConfig::dimensions()`, and `role_cache_tag` is supplied by
+`EmbeddingRole`. The role is included even for identical raw text so that a
+query embedding cannot satisfy a passage or generic embedding lookup.
+
+The model version values currently divide the registry into these families:
+
+| Key version | Models |
+| --- | --- |
+| `v1.5` | BGE and multilingual E5 variants |
+| `v2` | Both MiniLM variants |
+| `v3` | Both Qwen3-Embedding variants and `TextEmbedding3Small` |
+
+Including the model, version, active dimensions, and role prevents the cache
+from crossing known embedding-space boundaries. `compute_key()` is public and
+always performs this hash when called; disabling the cache bypasses lookup and
+storage, not explicit key construction by its caller.
+
+### Sharding and locking
+
+The cache has 16 fixed shards. The shard is selected from the first byte of a
+BLAKE3 key:
+
+```text
+shard = key[0] & 15
+```
+
+BLAKE3 output is uniformly distributed for this purpose, so the mask spreads
+keys across the shards. The shard count must remain a power of two because the
+implementation uses a bit mask rather than a general modulo operation.
+
+Each shard owns an `LruCache` behind its own `RwLock` plus its own atomic
+hit/miss counters. A lookup takes the write lock, not a read lock, because a
+hit changes LRU recency. This is why sharding is important: independent keys
+usually contend only with work that lands in the same shard rather than with
+all cache traffic.
+
+Counters use relaxed atomics on the hot path and are summed when statistics
+are requested. Under concurrent traffic, aggregate statistics are monitoring
+data rather than a single globally synchronised snapshot.
+
+### Capacity and eviction
+
+`EmbeddingCache::new(capacity)` accepts a requested total entry capacity. The
+default is 4,000 entries, approximately 6 MB for 384-dimensional `f32`
+embeddings before allocator and cache overhead.
+
+For a nonzero requested capacity `C`, every shard receives:
+
+```text
+per_shard_capacity = ceil(C / 16), with a minimum of 1
+```
+
+This has two consequences worth accounting for when setting a memory budget:
+
+1. Each shard evicts independently. A full shard may evict an old entry while
+   another shard still has unused slots.
+2. The physical maximum is `16 * ceil(C / 16)`, which can exceed the requested
+   capacity. For example, a capacity of 10 creates 16 shards with one slot
+   each, so up to 16 entries can be retained. `CacheStats::capacity` still
+   reports the requested value (10), not the rounded physical maximum.
+
+Insertion into a full shard evicts that shard's least-recently-used entry.
+Successful `get()` calls refresh recency, so a recently accessed entry survives
+an insertion ahead of an older entry in the same shard. There is no global LRU
+order across shards.
+
+Passing a capacity of zero disables the cache. `get()` returns `None`; `put()`,
+`put_many()`, and `clear()` do nothing; and `get_many()` returns `None` for
+each requested key. These paths avoid shard locking and do not change the
+per-shard counters. The object still contains dummy shard allocations, but no
+embedding is stored.
+
+### Operations and lifecycle
+
+- `get(key)` returns `Option<Arc<[f32]>>`, records one hit or miss when enabled,
+  and refreshes recency on a hit.
+- `put(key, embedding)` converts its vector to `Arc<[f32]>` and inserts it into
+  the selected shard.
+- `get_many(keys)` preserves input order and performs the same lookup semantics
+  for every key. Each hit shares its vector without copying it.
+- `put_many(entries)` applies the same storage rule to every `(key, vector)`
+  pair.
+- `stats()` sums all shard lengths and counters. With a disabled cache, it
+  reports a size and capacity of zero.
+- `per_shard_stats()` exposes the size, hits, and misses for each of the 16
+  shards, which is useful when diagnosing uneven key distribution.
+- `clear()` drops cached entries from every shard. It does not reset hit or miss
+  counters, so cache lifetime metrics survive a manual eviction.
+
+Both `CacheStats` and `ShardStats` calculate `hit_rate` as `hits / (hits +
+misses)`. When no lookups have occurred, the result is `0.0` rather than an
+undefined value.
+
+### Choosing a safe cache boundary
+
+Use one cache only for work that shares the same semantic configuration. In
+particular, keep model changes and output-dimension changes isolated, and
+always distinguish retrieval roles. `compute_key()` encodes those dimensions
+for the built-in cache, but application-level collection or index naming must
+enforce the same boundary for persisted vectors.
+
+The cache stores only embedding values and never owns the model or its weights.
+Clearing it releases the entries, not the model that produced them. A process
+restart creates an empty cache; cache keys and contents are not an on-disk
+format.

--- a/crates/embed/docs/service.md
+++ b/crates/embed/docs/service.md
@@ -1,0 +1,258 @@
+# Embedding services
+
+`EmbeddingService` is the async boundary between an application and an embedding producer. It
+defines how batches of text become batches of `Vec<f32>` while allowing callers to choose a
+generic, query, or document/passage semantic role. Native builds provide two implementations:
+`NativeEmbeddingService`, which owns a lazily loaded local model, and
+`CachedEmbeddingService`, which wraps any service with a process-local LRU.
+
+The trait is the stable integration surface. Constructors and cache-management APIs on the
+native implementations are marked unstable and may change independently of the trait.
+
+## Service topology
+
+```text
+                         +------------------------+
+texts + model ---------->| EmbeddingService        |
+                         | embed / query / passage |
+                         +-----------+------------+
+                                     |
+                      optional       | native
+                 +-------------------+-------------------+
+                 |                                       |
+                 v                                       v
+  CachedEmbeddingService                      NativeEmbeddingService
+  validate -> lookup -> fill                 validate -> lazy load -> encode
+                 |                                       |
+                 v                                       v
+       EmbeddingCache (sharded LRU)          BERT batch or Qwen item encoding
+```
+
+Both implementations satisfy `Send + Sync`. The trait is declared with `async_trait`, so
+callers can use a concrete service, an `Arc`, or a suitable trait object without deciding how
+the producer performs its work internally.
+
+## Trait contract
+
+### Generic batches and the single-item helper
+
+`embed(&[String], EmbeddingModel)` is the fundamental method. A successful result contains one
+embedding for each input text in the same order. It represents the `Generic` role: no
+role-specific instruction is prepended. Implementations are responsible for returning a typed
+error rather than an incomplete batch.
+
+`embed_one(&str, EmbeddingModel)` is a default helper that allocates a one-element string batch,
+calls `embed`, and returns its only vector. If an implementation incorrectly returns no vectors,
+the helper reports `EmbedError::Internal` instead of inventing an empty embedding.
+
+Use `embed_one` for generic text only. Query and passage operations accept batches so the caller
+can select their semantic role explicitly.
+
+```rust,no_run
+use lattice_embed::{EmbeddingModel, EmbeddingService, NativeEmbeddingService};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let service = NativeEmbeddingService::with_model(EmbeddingModel::MultilingualE5Small);
+    let queries = vec!["what is a vector database?".to_owned()];
+    let vectors = service
+        .embed_query(&queries, EmbeddingModel::MultilingualE5Small)
+        .await?;
+    assert_eq!(vectors.len(), queries.len());
+    Ok(())
+}
+```
+
+`supports_model` allows a caller to ask whether a service can handle a model before submitting a
+request, and `name` provides a static implementation label. `model_config` defaults to the
+native-size configuration for a model. An implementation with a configured output dimension can
+override it so cache keys use the actual vector space.
+
+### Retrieval roles and prompts
+
+`embed_query` and `embed_passage` are default trait methods. Each gets the corresponding prefix
+from `EmbeddingModel`, prepends it to every supplied text when present, then delegates to
+`embed`. They are not interchangeable with generic `embed`: a model trained for asymmetric
+retrieval expects its query and document vectors to be placed correctly in the shared space.
+
+| Model family | `embed_query` prefix | `embed_passage` prefix | Pooling on native BERT path |
+| --- | --- | --- | --- |
+| BGE v1.5 | `Represent this sentence for searching relevant passages: ` | none | CLS |
+| Multilingual E5 | `query: ` | `passage: ` | masked mean |
+| Qwen3-Embedding | retrieval instruction followed by `Query: ` | none | not a BERT path |
+| MiniLM variants | none | none | masked mean |
+
+The Qwen query instruction currently reads: `Instruct: Given a web search query, retrieve
+relevant passages that answer the query\nQuery: `. The library's model API owns these values; use
+the role methods rather than duplicating prompt strings in an application.
+
+The caching wrapper overrides the two role methods instead of relying only on the trait defaults.
+It applies the same prefix but records `Query` or `Passage` in the cache key. This prevents
+`embed_query("text")`, `embed_passage("text")`, and `embed("text")` from sharing a cache entry
+solely because their raw input happens to match.
+
+## Request validation
+
+The native service and cache wrapper enforce the same request limits before inference or cache
+lookup:
+
+| Rule | Failure |
+| --- | --- |
+| Batch must contain at least one text | `EmbedError::InvalidInput` |
+| Batch may contain at most `DEFAULT_MAX_BATCH_SIZE` (1,000) texts | `EmbedError::InvalidInput` |
+| Each text must be at most `MAX_TEXT_CHARS` (32,768) according to the implementation's `String::len()` check | `EmbedError::TextTooLong` |
+| Native request model must equal that service's configured model | `EmbedError::InvalidInput` |
+
+`String::len()` measures UTF-8 bytes, so the present implementation can reject fewer than
+32,768 non-ASCII characters. Prefixes are applied before validation in role-specific calls, so
+the prefix bytes count too. A caller that needs a character-based product limit should enforce
+that separately before calling the service.
+
+The cache performs validation even for an all-hit request. This makes failure behavior stable:
+a request that is invalid cannot start succeeding merely because an older result happens to be
+cached.
+
+## NativeEmbeddingService
+
+`NativeEmbeddingService` is available with the `native` feature, which is enabled by default. It
+uses `lattice-inference` directly, with SIMD-capable local kernels and safetensors model loading;
+there is no ONNX runtime, C++ FFI, or external embedding process.
+
+### Construction and configuration
+
+| Constructor | Configuration |
+| --- | --- |
+| `new` / `default` | The crate's default embedding model at its native dimension |
+| `with_model` | One selected `EmbeddingModel` at its native dimension |
+| `with_model_config` | A model plus validated optional MRL output dimension |
+| `with_model_from_env` | A selected model with `LATTICE_EMBED_DIM` parsed as its optional output dimension |
+
+An absent or blank `LATTICE_EMBED_DIM` means native dimension. A nonnumeric environment value or
+a dimension rejected by `ModelConfig::validate` becomes `EmbedError::InvalidInput`. Configuring
+MRL does not make an arbitrary model dimension-adjustable; only models that support it can use a
+non-native output dimension. See [model.md](model.md) for that capability and its index-space
+implications.
+
+One native service is intentionally single-model. `embed` first compares the requested model
+with the service configuration and rejects a mismatch. Applications that serve several models
+should construct separate services (and separate compatible vector-index namespaces) rather
+than relying on an implicit concurrent model switch. `supports_model` reports this same
+single-model condition.
+
+### Lazy, cancellation-safe loading
+
+Construction does not load model weights. The first `embed` or `ensure_loaded` request follows
+this sequence:
+
+1. Check the `OnceLock` for a completed load result.
+2. When absent, clone the shared lock and start the synchronous loader with
+   `tokio::task::spawn_blocking`.
+3. The blocking worker runs `OnceLock::get_or_init`; concurrent callers wait for the same
+   initializer instead of starting independent loads.
+4. Read the stored success or initialization failure from the lock and proceed or return the
+   corresponding `EmbedError`.
+
+The use of `std::sync::OnceLock` is deliberate. A caller may drop its async future while waiting
+for a download or load, but that does not cancel the blocking initializer or clear the result.
+The model load continues to completion and the service will reuse the stored outcome for its
+remaining lifetime. Conversely, a load failure is also stored in the lock; retrying the same
+service returns that initialization failure rather than silently starting a fresh load.
+
+`ensure_loaded` is the explicit preload hook. It performs the same lazy initialization as the
+first embedding request without an encoding pass. For BERT-family variants, the loader delegates
+to the inference crate's pretrained-model path. Qwen variants require a local model directory:
+`LATTICE_QWEN_MODEL_DIR` takes precedence, otherwise the service looks below
+`$HOME/.lattice/models` using the variant's Qwen directory name. Missing Qwen files produce
+`EmbedError::ModelInitialization` with download guidance.
+
+### Architecture-specific encode paths
+
+The loader routes supported BGE, E5, and MiniLM variants to `BertModel`. It applies the selected
+pooling configuration before sharing that model through an `Arc`; BGE uses CLS pooling while E5
+and MiniLM use masked mean pooling.
+
+Qwen3-Embedding variants load as `QwenModel`, validate any requested output dimension, and set
+that dimension before use. The service calls BERT's `encode_batch` once for a BERT batch. Qwen
+instead calls `encode` for each item in order so Qwen's model-local cache participates. Both
+paths return embeddings in the validated input order.
+
+The native `name` is currently the static string `"native-bert"` for all its supported local
+models, including Qwen. It is an implementation label, not a reliable model-family identifier;
+the configured `ModelConfig` is the source of that identity.
+
+### Qwen persistent cache
+
+`save_cache` and `cache_size` concern only the cache held by a loaded `QwenModel`:
+
+- Before a successful model load, `save_cache` returns `0` and `cache_size` is `0`.
+- BERT-family models do not use this persistent cache through the service, so both operations
+  likewise report `0`.
+- Qwen persistence normally uses a file named `embed_{model}_{dimension}d.bin` below
+  `$HOME/.lattice/cache`; the cache-path helper falls back to `/tmp` when `HOME` is absent.
+  Including model and active dimension prevents different output spaces from sharing a file.
+- A Qwen load attempts to restore that cache. An integrity-check failure is logged and ignored;
+  inference proceeds and a later save can regenerate the cache.
+
+This is distinct from `CachedEmbeddingService`'s in-memory LRU. The two can be used together:
+the outer LRU avoids service calls for repeated application requests, while Qwen can reuse
+model-local work for calls that do reach the native service.
+
+## CachedEmbeddingService
+
+`CachedEmbeddingService<S>` wraps an `Arc<S>` where `S: EmbeddingService`. It owns an
+`EmbeddingCache` with a chosen capacity, or the cache module's default capacity through
+`with_default_cache`. `cache_stats` observes its LRU and `clear_cache` removes its entries; both
+are management APIs rather than a promise of distributed or persistent caching.
+
+### Lookup and fill algorithm
+
+For every generic, query, or passage request, the wrapper does the following:
+
+1. Apply the role prefix, if any. Generic calls remain raw text with the `Generic` role.
+2. Validate the full, prompted batch before looking at the cache.
+3. If capacity is zero, bypass hash computation and locks and delegate the prompted batch to the
+   inner service.
+4. Ask the inner service for the effective `ModelConfig`, then hash each prompted text with the
+   model identifier, its key revision, active dimension, and role tag.
+5. Look up all keys in the sharded LRU. Hits are returned from cache storage as shared slices and
+   copied into the caller-owned result vectors; misses are remembered with their original input
+   positions.
+6. If misses exist, send only those texts to the inner service. It must return exactly one vector
+   for each miss. A count mismatch becomes `EmbedError::InferenceFailed` rather than allowing a
+   `zip` operation to drop positions silently.
+7. Insert new vectors, fill the missing result positions, and return every vector in the order
+   supplied by the caller.
+
+The wrapper avoids mixing role-specific data in two ways: text has already been prompted when a
+role needs a prefix, and the cache key additionally contains the `EmbeddingRole` tag. The latter
+protects behavior as prompt policies evolve and preserves the backward-compatible generic key
+form for `embed`.
+
+The cache is a reuse optimization, not a single-flight coordinator. Concurrent cache misses for
+the same text may each call the inner service before either request inserts its result. Callers
+that need cross-request work de-duplication must provide it outside this wrapper.
+
+## Error boundaries
+
+All service methods use `crate::Result<T>`, an alias for `Result<T, EmbedError>`. The error enum
+also serves model configuration and prepared SIMD APIs, so not every variant originates in a
+native embedding call.
+
+| Error | Meaning at this boundary | Typical caller action |
+| --- | --- | --- |
+| `ModelNotLoaded` | A service requires initialization before use | Initialize/preload the service or surface the configuration issue |
+| `WrongModelLoaded` | The loaded model differs from the expected model during a concurrent switch | Retry with backoff after coordinating the model selection |
+| `ModelInitialization` | Model discovery, download/load, or blocking initialization failed | Inspect model configuration/files; construct a fresh service after correcting it |
+| `InferenceFailed` | The inference backend failed, including a cache-wrapper result-count violation | Surface the backend failure; do not accept a partial batch |
+| `TaskFailed` | A background task was cancelled or panicked | Treat the current call as failed and check service state before retrying |
+| `InvalidInput` | Empty/oversized batch, wrong model, invalid configuration, or other invalid request | Correct the request without retrying unchanged input |
+| `TextTooLong` | A text exceeded the service's length check | Chunk or shorten the prompted input |
+| `DimensionMismatch` | An operation received vectors of different expected and actual dimensions | Keep model/config/index namespaces consistent |
+| `UnsupportedModel` | The selected service cannot provide that model | Select a capable service or model |
+| `Internal` | An invariant failed, such as a missing single-item result | Treat as a bug report; do not synthesize a vector |
+| `TierMismatch` | Prepared SIMD quantization data used a different tier than the operation expects | Reprepare/query with matching quantization metadata |
+
+Errors are descriptive but not a transaction protocol: if a batch fails after an inner service
+has done work, a caller should assume no usable batch result was returned and decide whether its
+own retry policy is safe. In particular, cache insertion happens only after the wrapper has
+received the expected number of new vectors.

--- a/crates/embed/docs/simd.md
+++ b/crates/embed/docs/simd.md
@@ -1,0 +1,365 @@
+# SIMD kernels and quantized-vector paths
+
+`lattice-embed` exposes vector operations through `lattice_embed::simd` and
+selects the best supported implementation for the running target. The public
+operations cover float dot products, cosine similarity, Euclidean distance,
+in-place normalization, and approximate operations over INT8, INT4, and binary
+vectors. Scalar implementations are always available as the fallback.
+
+The SIMD-facing API is marked unstable. Use the higher-level `utils` wrappers
+where a stable API is required; use this module when the lower-level return
+semantics, prepared-query paths, or allocation behaviour matter to a search
+implementation.
+
+## Dispatch model
+
+Feature detection is performed once per process and cached in `SimdConfig`.
+Float dot-product and cosine dispatchers, batch-four dot-product dispatch, and
+INT8 dot-product dispatch also cache their chosen function pointers. This keeps
+feature checks and `OnceLock` initialization out of inner batch loops. Distance
+and normalization reuse the cached configuration when they choose a kernel.
+
+| Operation family | x86_64 priority | aarch64 priority | wasm32 | fallback |
+| --- | --- | --- | --- | --- |
+| Float dot, cosine, squared L2, normalize | AVX-512F, then AVX2 + FMA | NEON | SIMD128 when compiled in | scalar |
+| Batch-four float dot | AVX2 + FMA | NEON | none | scalar |
+| INT8 dot | AVX-512 VNNI + BW when the `avx512` feature is built, then AVX2 | NEON only with FEAT_DotProd | none | scalar |
+| Binary Hamming | none | NEON `vcnt` | none | scalar |
+| INT4 dot | none | NEON | none | scalar |
+
+On `wasm32`, SIMD128 is a build property rather than a runtime capability. A
+module compiled with `-C target-feature=+simd128` contains the SIMD kernels;
+one built without it does not. `SimdConfig::simd128_enabled()` mirrors that
+compile-time setting, so constructing a different `SimdConfig` cannot disable
+SIMD inside an already-SIMD128-enabled artifact.
+
+The dispatch order is deliberately per operation. For example, the float
+batch-four kernel is implemented for AVX2 and NEON, while the single-vector
+float kernel can use AVX-512F. INT8 on Arm additionally requires FEAT_DotProd:
+baseline AArch64 NEON alone is not enough to execute `SDOT`.
+
+## Float reductions
+
+### Dot product
+
+`dot_product(a, b)` computes `Σ a[i] * b[i]` for equal-length `f32` slices.
+It returns `0.0` for a length mismatch. For unit-normalized vectors, this is
+cosine similarity, and squared L2 distance is `2 * (1 - dot)`. That makes the
+operation useful for inner-product and cosine-oriented ANN search.
+
+The single-vector implementations load vector chunks, multiply them, keep
+several partial sums, reduce those partial sums horizontally, and finish with a
+vector tail followed by a scalar tail. AVX-512F uses 16-float registers and
+four-way unrolling; AVX2 uses 8-float registers and eight independent
+accumulators; NEON and wasm SIMD128 use 4-float registers and four
+accumulators. AVX2 has a 384-dimension specialization: 384 is exactly 48
+AVX2 registers, so its six 64-element chunks need no remainder path.
+
+The batch-four API computes one query against four candidates at once:
+
+```text
+(q, c0, c1, c2, c3) -> [dot(q, c0), dot(q, c1), dot(q, c2), dot(q, c3)]
+```
+
+It returns four zeros if any candidate length differs from the query length.
+The AVX2 and NEON implementations reuse each query load across all four
+candidates, with two accumulators per candidate. `batch_dot_product` uses this
+kernel only for consecutive groups of four whose query slices have the same
+pointer and length; mixed groups and a final short group use the ordinary
+per-pair kernel. This pointer check avoids treating merely equal-valued queries
+as the same borrowed query.
+
+### Cosine similarity
+
+Cosine similarity is computed as:
+
+```text
+dot(a, b) / (sqrt(dot(a, a)) * sqrt(dot(b, b)))
+```
+
+The SIMD kernels calculate the dot product and both squared norms in one pass.
+They maintain independent accumulators for all three reductions, combine them,
+add the remainder, take two square roots, and return `0.0` if either norm is
+zero. `cosine_similarity` returns `0.0` for empty input or a length mismatch.
+
+`cosine_similarity_fused` makes the one-pass property explicit. The ordinary
+SIMD cosine dispatcher is already fused, while the scalar reference named
+`cosine_similarity_scalar` performs separate reductions. For normalized input,
+prefer the cheaper dot-product operation instead of either cosine function.
+
+`batch_cosine_similarity` resolves the cosine kernel once before iterating.
+It deliberately does not scan each pair to discover unit normalization: an
+`O(pair_count * dimensions)` pre-scan would cost as much as the computation.
+Callers that know their vectors are normalized should use batch dot products or
+the prepared-query APIs with explicit normalization metadata.
+
+For one query and many candidates, `batch_cosine_one_vs_many` calculates the
+query norm once. Each candidate still requires a dot product and its own norm;
+dimension-mismatched candidates contribute `0.0` in their original order.
+
+### Euclidean distance
+
+Squared Euclidean distance is reduced in the same chunk/tail shape as a dot
+product, using `Σ (a[i] - b[i])²`. `euclidean_distance` is the square root of
+that result. Both APIs return `f32::MAX` for a length mismatch.
+
+When only ranking is required, use `squared_euclidean_distance`. Squaring is
+monotonic for non-negative distances, so it preserves the ordering of true L2
+distance while avoiding a square root per graph comparison. Apply `.sqrt()` at
+the output boundary only when callers need the actual distance.
+
+### Normalization
+
+`normalize(&mut vector)` performs two passes: it first reduces the squared L2
+norm, then multiplies every element by its reciprocal. A zero-norm vector is
+left unchanged. A vector that produces a NaN norm is also left unchanged so the
+SIMD and scalar paths do not turn its contents into NaNs through scaling.
+
+AVX-512F, AVX2, and wasm SIMD128 calculate the inverse norm from a scalar
+square root. The NEON implementation uses `vrsqrteq_f32` followed by two
+Newton-Raphson refinements, then falls back to the scalar reciprocal-square-root
+calculation if the estimate is non-finite for a positive subnormal squared norm.
+That fallback keeps the Arm result compatible with the scalar and x86 paths.
+
+## Floating-point behaviour and kernel boundaries
+
+SIMD reductions are mathematically equivalent to their scalar counterparts but
+do not promise bit-identical output. Lanes and independent accumulators change
+the summation order; FMA-capable targets may also round differently from a
+separate multiply and add. Near-tied squared-L2 comparisons therefore must not
+depend on reproducing an exact scalar ordering. The supported invariant is that
+squared L2 and L2 have the same mathematical ordering, not that every backend
+emits the same bit pattern.
+
+The low-level kernel comments carry the exact safety requirements for lane
+widths, unaligned loads, tails, target features, and numeric tolerances. In
+particular, the kernels use unaligned load/store intrinsics and calculate chunk
+counts with floor division before doing pointer arithmetic; the final tail is
+handled without reading beyond a slice. Those source-local requirements are
+part of the safety boundary for changes to the kernels.
+
+## Quantization tiers and storage policy
+
+`QuantizationTier` selects a storage/accuracy trade-off. `storage_bytes(dims)`
+uses ceiling division for packed formats, so it is authoritative for odd
+dimensions.
+
+| Tier | Representation | Bytes per dimension | Compression vs. `f32` | Typical role |
+| --- | --- | ---: | ---: | --- |
+| `Full` | `Vec<f32>` | 4 | 1x | Hot data and exact search |
+| `Int8` | signed byte plus parameters | 1 | 4x | Warm data and HNSW search |
+| `Int4` | two unsigned nibbles per byte | 0.5 | 8x | Cool data and pre-filtering |
+| `Binary` | one sign bit per dimension | 0.125 | 32x | Cold data and coarse filtering |
+
+`QuantizationTier::from_age_seconds` is a simple recency heuristic, not a
+measurement of vector quality: under one hour selects `Full`; one hour through
+under one day selects `Int8`; one day through under one week selects `Int4`;
+one week or older selects `Binary`. Applications can select tiers directly when
+their retention or recall policy differs.
+
+`QuantizedData` holds any tier behind one enum. Promoting or demoting it always
+dequantizes to `f32` and quantizes into the destination tier. Promotion does not
+recover information discarded by a previous lower-precision representation.
+
+### Prepared queries and tier matching
+
+Quantizing a query inside every candidate comparison repeats work and can
+allocate. `PreparedQuery` quantizes once at the candidate tier, then is reused
+against a homogeneous list. The prepared and stored tiers must match:
+
+| Prepared query and stored data | Cosine-distance path | Dot-product path |
+| --- | --- | --- |
+| `Full` / `Full` | `1 - cosine_similarity` | float dot product |
+| `Int8` / `Int8` | `1 - cosine_similarity_i8_trusted` | trusted INT8 dot product |
+| `Int4` / `Int4` | INT4 cosine distance | INT4 dequantized dot product |
+| `Binary` / `Binary` | Hamming-derived approximation | no meaningful prepared dot product |
+
+The prepared distance and dot-product APIs return `EmbedError::TierMismatch`
+for a mixed tier. A prepared binary dot product returns `EmbedError::Internal`;
+binary vectors provide a cosine-distance approximation instead. The legacy
+`try_approximate_*_prepared` names are aliases of the corresponding non-`try_`
+functions and return the same `Result`.
+
+The non-prepared `approximate_cosine_distance` takes an `f32` query and
+quantizes it on each call for INT8, INT4, or binary stored data. It is convenient
+but not the hot-loop choice. `approximate_dot_product` follows the same pattern;
+for binary data it dequantizes to signed float values before using the float dot
+product.
+
+`approximate_cosine_distance` requires its float query to have the same
+dimensionality as the stored value. This is a caller precondition, enforced with
+a debug assertion rather than an error return; construct queries from the same
+embedding model and tiered index schema as the stored vectors.
+
+Batch prepared APIs exist both as allocating and buffer-reusing variants. The
+`*_into` forms clear the caller buffer first and leave it cleared on an error,
+so they never publish a partial result set. Tier-specific INT8 and INT4 batch
+APIs similarly avoid per-candidate query quantization.
+
+`PreparedQueryWithMeta` adds a `NormalizationHint`. With `Unit` hints for both
+the query and stored `Full` vector, the metadata-aware cosine-distance function
+uses `1 - clamp(dot(query, stored), -1, 1)` and skips norm division. The hints
+are caller assertions; callers that need to establish the property can use
+`is_unit_norm`, whose squared-norm tolerance is `1e-4`. This shortcut applies
+only to the `Full` tier; all other combinations use the normal prepared
+distance dispatch.
+
+## INT8 vectors
+
+### Encoding and error model
+
+INT8 quantization is symmetric. The parameter builder examines only finite
+input elements, finds `max_abs = max(abs(min), abs(max))`, and chooses:
+
+```text
+scale = 127 / max_abs, if max_abs > 1e-10
+scale = 1,             otherwise
+q[i] = clamp(round(v[i] * scale), -127, 127)
+```
+
+Non-finite input values quantize as zero. The stored L2 norm is calculated from
+the finite source values, not from the integers. Dequantization is `q / scale`;
+an invalid or zero stored scale falls back to one. The format has a zero point of
+zero even though `QuantizationParams` retains the field for its current public
+layout.
+
+Mapping `[-max_abs, max_abs]` to `[-127, 127]` gives a step size of
+`max_abs / 127` and a maximum round-trip error of half a step,
+`max_abs / 254`. The error and the resulting approximate cosine similarity must
+be acceptable for the tier selected by the caller; use `Full` or `Int8` instead
+of lower-precision tiers when recall needs more fidelity.
+
+### Dot product and dispatch
+
+The raw integer reduction is dequantized by dividing by the product of the two
+scales. INT8 cosine similarity divides that result by the product of the stored
+source norms. The normal public API accepts `QuantizedVector` values, while
+`dot_product_i8_raw` takes slices and returns the unscaled integer-domain dot
+product as `f32`; its caller owns scale handling and avoids constructing vector
+wrappers.
+
+Every INT8 SIMD input must be in `[-127, 127]`. `i8::MIN` is excluded because
+the x86 sign-handling technique negates an operand; two's-complement negation
+of `-128` remains `-128` rather than producing `+128`, which yields a silent
+wrong numerical result. Constructor-owned vectors clamp into the valid range.
+The raw-slice entry point checks this only with `debug_assert!`, so external
+quantizers must clamp `-128` to `-127` before release-mode hot-path calls.
+
+On Arm, the INT8 kernel is dispatched only after runtime confirmation of
+FEAT_DotProd and uses `SDOT` on 16-byte vectors. On x86, AVX-512 VNNI can use
+`dpbusd` after rewriting signed-times-signed multiplication as absolute values
+times a sign-adjusted operand; AVX2 uses the analogous `maddubs`/`madd`
+sequence. Both implementations unroll their loops and issue a guarded software
+prefetch for a future chunk. Scalar accumulation uses `i32` products and sums.
+
+The trusted internal INT8 functions exist for prepared-query paths whose data
+comes from the constructor. They skip a release-mode invariant scan while
+retaining debug assertions; do not use that optimization for untrusted raw
+bytes.
+
+## INT4 vectors
+
+### Packed format
+
+INT4 uses unsigned symmetric quantization. For finite input values:
+
+```text
+max_abs = max(abs(v[i]))
+scale   = 15 / (2 * max_abs), if max_abs > 1e-10; otherwise 1
+q[i]    = clamp(round((v[i] + max_abs) * scale), 0, 15)
+v[i]    = q[i] / scale - max_abs
+```
+
+Two values share one byte: the even-indexed dimension is bits 7 through 4 and
+the odd-indexed dimension is bits 3 through 0. Storage is `ceil(dimensions / 2)`
+bytes. For an odd-dimensional vector, only the final byte's high nibble is a
+real dimension; the low nibble is padding and is ignored by dequantization and
+dot-product accumulation. Non-finite source values are treated as zero, and
+the L2 norm records the finite source values.
+
+The 16 quantization levels have step size `2 * max_abs / 15`, so the maximum
+per-element round-trip error is `max_abs / 15`. This is a storage-oriented
+approximation: for correlated 384-dimensional vectors, the expected relative
+dot-product error is on the order of the documented 15% bound rather than the
+tighter error expected from INT8.
+
+### Corrected dot product
+
+Because the packed values are offset unsigned integers, a raw dot product alone
+is not the float dot product. The implementation accumulates three integers:
+
+```text
+raw_dot = Σ qa[i] * qb[i]
+sum_a   = Σ qa[i]
+sum_b   = Σ qb[i]
+```
+
+It then applies the offset correction:
+
+```text
+raw_dot / (scale_a * scale_b)
+    - max_abs_b * sum_a / scale_a
+    - max_abs_a * sum_b / scale_b
+    + dimensions * max_abs_a * max_abs_b
+```
+
+This is the expanded product of `(qa / scale_a - max_abs_a)` and
+`(qb / scale_b - max_abs_b)`. It ensures scalar and NEON paths implement the
+same dequantized result without allocating temporary float vectors.
+
+The Arm kernel processes full packed bytes only, splits high and low nibbles,
+and reduces the raw and marginal sums in parallel. It leaves both the byte tail
+and an odd final high nibble to the scalar path so padding can never contribute
+as data. Dimension mismatches, invalid scales, and too-short packed buffers
+return `0.0`; malformed buffers dequantize to an empty vector.
+
+## Binary vectors
+
+Binary quantization stores a sign/threshold decision per dimension. For the
+default threshold of zero, `v >= 0` maps to one and `v < 0` maps to zero.
+`from_f32_with_threshold` generalizes that comparison. Non-finite values become
+zero before comparison, so their output bit depends on the selected threshold.
+
+Bits are packed most-significant first: dimension zero is bit 7 of byte zero,
+dimension one is bit 6, and so on. The storage size is
+`ceil(dimensions / 8)` bytes. Dequantization maps one to `+1.0` and zero to
+`-1.0`; it is intentionally lossy and returns an empty vector if public fields
+describe a buffer shorter than the required packed length.
+
+Hamming distance is the population count of the XOR of two packed buffers. The
+scalar implementation counts full 64-bit groups and remaining bytes; the NEON
+implementation applies `vcnt` to 16-byte vectors and widens before summing.
+The final partial byte needs special treatment: its valid dimensions occupy the
+high `dimensions % 8` bits, so the low padding bits are masked out before their
+popcount. This is necessary for odd dimension counts to produce the same result
+as an unpacked sign comparison.
+
+`hamming_distance_binary` returns `u32::MAX` for different dimensions or a
+malformed packed buffer. A valid binary cosine approximation is:
+
+```text
+cosine_similarity_approx = 1 - 2 * hamming / dimensions
+cosine_distance_approx   = 2 * hamming / dimensions
+```
+
+The cosine-distance method returns `0.0` for a zero-dimensional receiver.
+Callers must reject a mismatch sentinel before treating the approximation as a
+distance.
+
+## Choosing an operation
+
+Use the operation that matches the data and search stage:
+
+| Situation | Recommended operation |
+| --- | --- |
+| Unit-normalized float embeddings | `dot_product` or `batch_dot_product` |
+| Float embeddings with unknown norms | `cosine_similarity_fused` or `cosine_similarity` |
+| ANN ranking where only L2 ordering matters | `squared_euclidean_distance` |
+| One query against many same-tier compressed candidates | prepare once, then use a prepared batch API |
+| Coarse candidate filter with maximum compression | binary Hamming/cosine approximation, followed by a higher-fidelity rerank |
+| Reusing a caller-owned result buffer | a `*_into` prepared batch API |
+
+Do not compare float SIMD output for bit equality with the scalar reference, do
+not feed `i8::MIN` to an INT8 SIMD raw path, and do not count padding bits in
+packed INT4 or binary vectors. Those are correctness requirements rather than
+performance suggestions.

--- a/crates/embed/src/backfill/coordinator.rs
+++ b/crates/embed/src/backfill/coordinator.rs
@@ -1,37 +1,9 @@
-//! Backfill coordinator: orchestrates embedding migration with routing logic. See
-//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/embed/docs/design.md)
-//! for the four-stage migration workflow this coordinates. The [`BackfillCoordinator`]
-//! wraps a [`MigrationController`] and adds routing logic and batch management on top of
-//! the state machine.
+//! Coordinates an embedding backfill above the migration state machine.
 //!
-//! # Example
+//! It selects model routes, accounts for batches, and maintains the post-cutover
+//! rollback window; it does not perform embedding work or persistence itself.
 //!
-//! ```rust
-//! use lattice_embed::backfill::{BackfillCoordinator, BackfillConfig, EmbeddingRoute};
-//! use lattice_embed::migration::MigrationPlan;
-//! use lattice_embed::EmbeddingModel;
-//!
-//! let plan = MigrationPlan {
-//!     id: "mig-001".to_string(),
-//!     source_model: EmbeddingModel::BgeSmallEnV15,
-//!     target_model: EmbeddingModel::BgeBaseEnV15,
-//!     total_embeddings: 1000,
-//!     batch_size: 100,
-//!     created_at: "2026-01-27T00:00:00Z".to_string(),
-//! };
-//!
-//! let mut coord = BackfillCoordinator::with_defaults(plan);
-//!
-//! // Before starting, all requests go to legacy
-//! assert_eq!(coord.route_request(true), EmbeddingRoute::Legacy);
-//!
-//! coord.start().unwrap();
-//!
-//! // During migration, new documents get dual-written
-//! assert_eq!(coord.route_request(true), EmbeddingRoute::DualWrite);
-//! // Existing documents still use legacy
-//! assert_eq!(coord.route_request(false), EmbeddingRoute::Legacy);
-//! ```
+//! See [docs/backfill.md](../../docs/backfill.md) for the routing and batching design.
 
 use std::time::{Duration, Instant};
 
@@ -44,32 +16,15 @@ use super::types::{BackfillConfig, EmbeddingRoute, EmbeddingRoutingConfig, Routi
 
 /// Coordinates the backfill process during embedding migration.
 ///
-/// Wraps a [`MigrationController`] and adds:
-/// - **Request routing**: decides which model handles new embedding requests
-/// - **Query routing**: decides which model's embeddings to search
-/// - **Batch management**: tracks backfill progress and computes next batch sizes
+/// It layers request/query routing, batch sizing, and rollback timing over the migration
+/// controller; callers perform the actual embedding and index updates.
 ///
-/// # State Machine
-///
-/// The coordinator delegates all state transitions to [`MigrationController`]
-/// and layers routing logic on top:
-///
-/// | State       | New Doc Route | Existing Doc Route | Query Route         |
-/// |-------------|---------------|--------------------|---------------------|
-/// | Planned     | Legacy        | Legacy             | Legacy              |
-/// | InProgress  | DualWrite*    | Legacy             | Legacy or Target**  |
-/// | Paused      | Legacy        | Legacy             | Legacy              |
-/// | Completed   | Target        | Target             | Target              |
-/// | Failed      | Legacy        | Legacy             | Legacy              |
-/// | Cancelled   | Legacy        | Legacy             | Legacy              |
-///
-/// \* Only if `dual_write` is enabled in config.
-/// \*\* Switches to Target when progress >= `target_query_threshold`.
+/// See [docs/backfill.md](../../docs/backfill.md) for the lifecycle and routing tables.
 #[derive(Debug)]
 pub struct BackfillCoordinator {
     pub(super) config: BackfillConfig,
     pub(super) controller: MigrationController,
-    /// Count of items successfully backfilled.
+    /// Count accumulated by `record_batch` calls.
     backfilled_count: usize,
     /// Timestamp when cutover occurred (for rollback window tracking).
     pub(super) cutover_at: Option<Instant>,
@@ -241,9 +196,8 @@ impl BackfillCoordinator {
 
     /// Check if we are currently in the post-cutover rollback window.
     ///
-    /// Returns `true` if the migration has completed and we are still within
-    /// the rollback window duration. During this period, queries use the
-    /// target model but writes continue to both models.
+    /// Returns `true` only after this coordinator observed completion and before its
+    /// configured rollback duration has elapsed.
     #[inline]
     pub fn in_rollback_window(&self) -> bool {
         self.cutover_at
@@ -253,19 +207,8 @@ impl BackfillCoordinator {
 
     /// Get the routing configuration for the current state.
     ///
-    /// Returns an [`EmbeddingRoutingConfig`] that separates query routing
-    /// from write routing. This enables true rollback during the post-cutover
-    /// window by continuing to dual-write while queries use the new model.
-    ///
-    /// # Routing Logic
-    ///
-    /// | State               | Query Model | Write Models        | Phase         |
-    /// |---------------------|-------------|---------------------|---------------|
-    /// | Planned             | source      | `[source]`          | Stable        |
-    /// | InProgress          | source      | `[source, target]`  | Migrating     |
-    /// | Completed (window)  | target      | `[source, target]`  | RollbackWindow|
-    /// | Completed (stable)  | target      | `[target]`          | Stable        |
-    /// | Paused/Failed/etc   | source      | `[source]`          | Stable        |
+    /// The post-cutover rollback window selects target queries and both write models.
+    /// See [docs/backfill.md](../../docs/backfill.md) for the complete routing contract.
     pub fn routing_config(&self) -> EmbeddingRoutingConfig {
         match self.controller.state() {
             MigrationState::Planned => EmbeddingRoutingConfig {
@@ -321,7 +264,7 @@ impl BackfillCoordinator {
         &self.config
     }
 
-    /// Get the total count of items successfully backfilled.
+    /// Get the total count accumulated by `record_batch` calls.
     #[inline]
     pub fn backfilled_count(&self) -> usize {
         self.backfilled_count

--- a/crates/embed/src/backfill/mod.rs
+++ b/crates/embed/src/backfill/mod.rs
@@ -1,37 +1,9 @@
-//! Backfill coordinator for embedding migration: routes new requests to the target model
-//! while backfilling old embeddings in batches. See
-//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/embed/docs/design.md)
-//! for the four-stage migration workflow and how [`BackfillCoordinator`] layers routing on
-//! top of [`crate::migration::MigrationController`].
+//! Public API for model-migration backfills.
 //!
-//! # Example
+//! The coordinator layers read/write routing and batch sizing over the migration
+//! controller while callers execute the actual embedding and index updates.
 //!
-//! ```rust
-//! use lattice_embed::backfill::{BackfillCoordinator, BackfillConfig, EmbeddingRoute};
-//! use lattice_embed::migration::MigrationPlan;
-//! use lattice_embed::EmbeddingModel;
-//!
-//! let plan = MigrationPlan {
-//!     id: "mig-001".to_string(),
-//!     source_model: EmbeddingModel::BgeSmallEnV15,
-//!     target_model: EmbeddingModel::BgeBaseEnV15,
-//!     total_embeddings: 1000,
-//!     batch_size: 100,
-//!     created_at: "2026-01-27T00:00:00Z".to_string(),
-//! };
-//!
-//! let mut coord = BackfillCoordinator::with_defaults(plan);
-//!
-//! // Before starting, all requests go to legacy
-//! assert_eq!(coord.route_request(true), EmbeddingRoute::Legacy);
-//!
-//! coord.start().unwrap();
-//!
-//! // During migration, new documents get dual-written
-//! assert_eq!(coord.route_request(true), EmbeddingRoute::DualWrite);
-//! // Existing documents still use legacy
-//! assert_eq!(coord.route_request(false), EmbeddingRoute::Legacy);
-//! ```
+//! See [docs/backfill.md](../../docs/backfill.md) for the complete operational model.
 
 mod coordinator;
 mod types;

--- a/crates/embed/src/backfill/types.rs
+++ b/crates/embed/src/backfill/types.rs
@@ -1,4 +1,9 @@
-//! Backfill types: routing decisions, phases, and configuration.
+//! Defines migration-time routing decisions and backfill configuration.
+//!
+//! The routing configuration separates query and write model selection so a completed
+//! cutover can retain source writes during its rollback window.
+//!
+//! See [docs/backfill.md](../../docs/backfill.md) for the routing contract and defaults.
 
 use serde::{Deserialize, Serialize};
 
@@ -43,26 +48,8 @@ pub enum RoutingPhase {
 
 /// Configuration for embedding request routing.
 ///
-/// Separates query routing from write routing to enable true rollback.
-/// During the rollback window after cutover, queries use the new model
-/// but writes continue to both models, ensuring atoms created after
-/// cutover are present in both indexes.
-///
-/// # Example
-///
-/// ```rust
-/// use lattice_embed::backfill::{EmbeddingRoutingConfig, RoutingPhase};
-/// use lattice_embed::EmbeddingModel;
-///
-/// let config = EmbeddingRoutingConfig {
-///     query_model: EmbeddingModel::BgeBaseEnV15,
-///     write_models: vec![EmbeddingModel::BgeSmallEnV15, EmbeddingModel::BgeBaseEnV15],
-///     phase: RoutingPhase::RollbackWindow,
-///     migration_id: Some("mig-001".to_string()),
-/// };
-///
-/// assert!(config.write_models.len() > 1); // dual-write active
-/// ```
+/// Query and write selections are separate so a rollback window can preserve source writes.
+/// See [docs/backfill.md](../../docs/backfill.md) for how each phase is represented.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingRoutingConfig {
     /// Which model to query against.
@@ -77,24 +64,8 @@ pub struct EmbeddingRoutingConfig {
 
 /// Configuration for the backfill coordinator.
 ///
-/// Controls batch sizing, concurrency, dual-write behavior, and the
-/// threshold at which queries switch to the target model.
-///
-/// # Example
-///
-/// ```rust
-/// use lattice_embed::backfill::BackfillConfig;
-///
-/// let config = BackfillConfig {
-///     batch_size: 200,
-///     max_concurrent: 8,
-///     dual_write: true,
-///     target_query_threshold: 0.9,
-///     rollback_window_secs: 3600, // 1 hour
-/// };
-///
-/// assert_eq!(config.batch_size, 200);
-/// ```
+/// Controls batch sizing, caller-managed concurrency, routing, and rollback timing.
+/// See [docs/backfill.md](../../docs/backfill.md) for default values and policy semantics.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackfillConfig {
     /// Batch size for backfill operations.
@@ -103,19 +74,9 @@ pub struct BackfillConfig {
     pub max_concurrent: usize,
     /// Whether new documents should be dual-written during migration.
     pub dual_write: bool,
-    /// Minimum progress fraction before allowing target-only queries `[0.0, 1.0]`.
-    ///
-    /// When the migration progress reaches this threshold, query routing
-    /// switches from legacy to target embeddings.
+    /// Raw progress threshold at which query routing may choose the target model.
     pub target_query_threshold: f64,
-    /// Duration in seconds to continue dual-writing after cutover.
-    ///
-    /// During the rollback window, queries use the new target model but
-    /// writes continue to both models. This ensures atoms created after
-    /// cutover exist in both indexes, enabling instant rollback without
-    /// data loss.
-    ///
-    /// Default: 86400 seconds (24 hours).
+    /// Seconds to retain both write models after a completed cutover.
     pub rollback_window_secs: u64,
 }
 

--- a/crates/embed/src/cache.rs
+++ b/crates/embed/src/cache.rs
@@ -1,20 +1,11 @@
-//! Sharded embedding cache with LRU eviction.
+//! In-memory embedding cache with sharded LRU eviction.
 //!
-//! Caches embeddings to avoid re-computing for identical texts. Uses 16 independent
-//! shards to reduce write-lock contention — each `get()` on an LRU cache requires a
-//! write lock (to update access order), so a single `RwLock<LruCache>` serializes all
-//! reads under high QPS. Sharding reduces contention by a factor of `NUM_SHARDS`.
+//! A key selects one of 16 independent shards. Cache hits refresh LRU order and therefore
+//! take that shard's write lock; hit/miss counters stay local to the shard. A zero-capacity
+//! cache bypasses storage operations and locking. The power-of-two shard count is required
+//! by the masking-based shard selection.
 //!
-//! # Design
-//!
-//! - **Shard selection**: First byte of the Blake3 cache key, masked to `NUM_SHARDS - 1`.
-//!   Blake3 output is uniformly distributed, so shard load is balanced.
-//! - **Per-shard capacity**: `total_capacity / NUM_SHARDS`. Each shard independently
-//!   evicts its own LRU entries.
-//! - **Per-shard statistics**: Hit/miss counters are per-shard `AtomicU64`s, aggregated
-//!   in `stats()`. This eliminates cross-shard atomic contention on the hot path.
-//! - **Zero-capacity**: `capacity=0` disables caching entirely — all operations become
-//!   no-ops with no locking or hashing work.
+//! See docs/model.md for key construction, capacity semantics, and lifecycle details.
 
 use crate::model::ModelConfig;
 use crate::service::EmbeddingRole;

--- a/crates/embed/src/error.rs
+++ b/crates/embed/src/error.rs
@@ -1,4 +1,6 @@
-//! Error types for embedding operations.
+//! Errors returned by embedding, model configuration, and prepared SIMD-dispatch operations.
+//!
+//! See `docs/service.md` for error boundaries and caller recovery guidance.
 
 use thiserror::Error;
 

--- a/crates/embed/src/lib.rs
+++ b/crates/embed/src/lib.rs
@@ -1,46 +1,16 @@
-//! **Stability tier: Unstable.** The SIMD dispatch layer (`simd/`) and model-loading API
-//! are actively evolving; platform consumers should use this crate via `lattice-engine`,
-//! not directly.
-//!
-//! **Exception — stable khive ANN consumer contract:**
-//! `simd::{squared_euclidean_distance, euclidean_distance, dot_product, cosine_similarity}`
-//! are a stable consumer contract for khive's ANN indexes (`khive-hnsw`, `khive-vamana`;
-//! ADR-012): their `(&[f32], &[f32]) -> f32` signatures and documented degenerate-input
-//! behaviour are guaranteed across the 0.4.x line, as is the squared-L2 ordering invariant
-//! relative to this crate's Euclidean wrapper (SIMD is not bit-identical to scalar and
-//! promises no exact ordering of near-ties). The rest of `simd/` remains unstable. The 25
-//! `unsafe` blocks in the crate are gated SIMD intrinsic calls: 21 on the AVX-512/AVX2/NEON
-//! paths plus 4 wasm32 SIMD128 dispatch sites.
-//!
 //! # lattice-embed
 //!
-//! Vector embedding generation with SIMD-accelerated operations for the lattice-runtime
-//! substrate: pure-Rust local inference (no ONNX, no Python) over the BGE and multilingual
-//! E5/Qwen3 model families, an async API, and an in-process migration/backfill workflow for
-//! moving stored embeddings between model versions. See
-//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/embed/docs/design.md)
-//! for the module map and the migration/backfill architecture.
+//! Pure-Rust local embedding generation, caching, SIMD vector operations, and model migration.
+//! Most of the crate, including model loading and SIMD dispatch, is **Unstable**; consumers
+//! should normally use it through `lattice-engine`.
 //!
-//! # Example
+//! The exception is the stable 0.4.x ANN contract in `simd`: squared/ordinary L2 distance,
+//! dot product, and cosine similarity retain their `(&[f32], &[f32]) -> f32` APIs and
+//! documented degenerate-input behavior. SIMD is not bit-identical to scalar, so near-tie
+//! ordering is not guaranteed.
 //!
-//! ```rust,no_run
-//! use lattice_embed::{EmbeddingService, EmbeddingModel, NativeEmbeddingService};
-//!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let service = NativeEmbeddingService::default();
-//!
-//!     let embedding = service.embed_one(
-//!         "The quick brown fox jumps over the lazy dog",
-//!         EmbeddingModel::default(),
-//!     ).await?;
-//!
-//!     println!("Embedding dimension: {}", embedding.len());
-//!     // Output: Embedding dimension: 384
-//!
-//!     Ok(())
-//! }
-//! ```
+//! See `docs/design.md` for the architecture, service lifecycle, cache identity, and migration
+//! boundaries; use `docs/INDEX.md` to find subsystem references.
 
 #![warn(missing_docs)]
 #![allow(clippy::clone_on_copy)]

--- a/crates/embed/src/migration/controller.rs
+++ b/crates/embed/src/migration/controller.rs
@@ -1,4 +1,9 @@
-//! Migration controller: state machine executor.
+//! Executes lifecycle transitions and progress accounting for one migration.
+//!
+//! This layer tracks a plan and its work budget only; query/write routing belongs to the
+//! backfill coordinator.
+//!
+//! See [docs/migration.md](../../docs/migration.md) for the state machine and accounting rules.
 
 use std::time::Instant;
 
@@ -6,29 +11,8 @@ use super::types::{MigrationError, MigrationPlan, MigrationProgress, MigrationSt
 
 /// Manages the state machine for a single migration.
 ///
-/// # Example
-///
-/// ```rust
-/// use lattice_embed::migration::{MigrationController, MigrationPlan};
-/// use lattice_embed::EmbeddingModel;
-///
-/// let plan = MigrationPlan {
-///     id: "mig-001".to_string(),
-///     source_model: EmbeddingModel::BgeSmallEnV15,
-///     target_model: EmbeddingModel::BgeBaseEnV15,
-///     total_embeddings: 100,
-///     batch_size: 50,
-///     created_at: "2026-01-27T00:00:00Z".to_string(),
-/// };
-///
-/// let mut ctrl = MigrationController::new(plan);
-/// ctrl.start().unwrap();
-/// ctrl.record_progress(50).unwrap();
-///
-/// let report = ctrl.progress();
-/// assert!(report.state.is_active());
-/// assert_eq!(report.state.processed(), 50);
-/// ```
+/// It owns lifecycle transitions, progress, skips, and diagnostics but not model routing.
+/// See [docs/migration.md](../../docs/migration.md) for its transition and accounting rules.
 #[derive(Debug)]
 pub struct MigrationController {
     pub(super) plan: MigrationPlan,
@@ -112,26 +96,8 @@ impl MigrationController {
 
     /// Record an item that will be permanently skipped.
     ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use lattice_embed::migration::{MigrationController, MigrationPlan, SkipReason};
-    /// use lattice_embed::EmbeddingModel;
-    ///
-    /// let plan = MigrationPlan {
-    ///     id: "mig-001".to_string(),
-    ///     source_model: EmbeddingModel::BgeSmallEnV15,
-    ///     target_model: EmbeddingModel::BgeBaseEnV15,
-    ///     total_embeddings: 100,
-    ///     batch_size: 50,
-    ///     created_at: "2026-01-27T00:00:00Z".to_string(),
-    /// };
-    ///
-    /// let mut ctrl = MigrationController::new(plan);
-    /// ctrl.start().unwrap();
-    /// ctrl.record_skip(SkipReason::ContentTooLarge { size: 50000, max: 8192 }).unwrap();
-    /// assert_eq!(ctrl.state().skipped(), 1);
-    /// ```
+    /// Skips reduce the effective completion total but require a later progress call to
+    /// transition to completed. See [docs/migration.md](../../docs/migration.md).
     pub fn record_skip(&mut self, reason: SkipReason) -> Result<(), MigrationError> {
         match &self.state {
             MigrationState::InProgress {
@@ -171,7 +137,7 @@ impl MigrationController {
         &self.skip_reasons
     }
 
-    /// Returns the effective coverage fraction (0.0–1.0) of the migration.
+    /// Returns processed-to-effective-total coverage; a zero effective total returns 1.0.
     pub fn effective_coverage(&self) -> f64 {
         self.state.effective_coverage()
     }

--- a/crates/embed/src/migration/mod.rs
+++ b/crates/embed/src/migration/mod.rs
@@ -1,30 +1,9 @@
-//! Migration module: state machine for embedding model migration. Provides the
-//! [`MigrationController`] state machine, migration plan types, and progress tracking. See
-//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/embed/docs/design.md)
-//! for how this fits into the wider [`crate::backfill`] workflow.
+//! Public API for the embedding-model migration state machine.
 //!
-//! # Quick Start
+//! It exposes plans, serializable lifecycle state, progress accounting, permanent skips,
+//! and transition errors without choosing application routing policy.
 //!
-//! ```rust
-//! use lattice_embed::migration::{MigrationController, MigrationPlan};
-//! use lattice_embed::EmbeddingModel;
-//!
-//! let plan = MigrationPlan {
-//!     id: "mig-001".to_string(),
-//!     source_model: EmbeddingModel::BgeSmallEnV15,
-//!     target_model: EmbeddingModel::BgeBaseEnV15,
-//!     total_embeddings: 10_000,
-//!     batch_size: 256,
-//!     created_at: "2026-01-27T00:00:00Z".to_string(),
-//! };
-//!
-//! let mut ctrl = MigrationController::new(plan);
-//! ctrl.start().unwrap();
-//! ctrl.record_progress(256).unwrap();
-//!
-//! let report = ctrl.progress();
-//! assert!(report.state.is_active());
-//! ```
+//! See [docs/migration.md](../../docs/migration.md) for the complete transition model.
 
 mod controller;
 mod types;

--- a/crates/embed/src/migration/types.rs
+++ b/crates/embed/src/migration/types.rs
@@ -1,4 +1,9 @@
-//! Migration types: states, plans, progress snapshots, and errors.
+//! Defines migration plans, states, progress snapshots, skip reasons, and errors.
+//!
+//! These serializable values describe a model-version transition; the controller supplies
+//! the lifecycle and accounting rules that give their fields meaning.
+//!
+//! See [docs/migration.md](../../docs/migration.md) for state, format, and coverage details.
 
 use serde::{Deserialize, Serialize};
 
@@ -135,7 +140,7 @@ impl MigrationState {
         matches!(self, MigrationState::InProgress { .. })
     }
 
-    /// Returns the progress as a fraction in [0.0, 1.0], or `None` if not applicable.
+    /// Returns raw processed-to-total progress; a zero total returns 1.0.
     pub fn progress(&self) -> Option<f64> {
         match self {
             MigrationState::Planned => Some(0.0),
@@ -201,7 +206,7 @@ impl MigrationState {
         self.total().saturating_sub(self.skipped())
     }
 
-    /// Returns the fraction of effective_total that has been processed (0.0 to 1.0).
+    /// Returns processed-to-effective-total coverage; a zero effective total returns 1.0.
     pub fn effective_coverage(&self) -> f64 {
         let eff = self.effective_total();
         if eff == 0 {
@@ -214,23 +219,7 @@ impl MigrationState {
 
 /// Describes an embedding migration operation.
 ///
-/// # Example
-///
-/// ```rust
-/// use lattice_embed::migration::MigrationPlan;
-/// use lattice_embed::EmbeddingModel;
-///
-/// let plan = MigrationPlan {
-///     id: "mig-001".to_string(),
-///     source_model: EmbeddingModel::BgeSmallEnV15,
-///     target_model: EmbeddingModel::BgeBaseEnV15,
-///     total_embeddings: 10_000,
-///     batch_size: 256,
-///     created_at: "2026-01-27T00:00:00Z".to_string(),
-/// };
-///
-/// assert_eq!(plan.total_embeddings, 10_000);
-/// ```
+/// See [docs/migration.md](../../docs/migration.md) for plan fields and transition scope.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MigrationPlan {
     /// Unique migration identifier.
@@ -260,7 +249,7 @@ pub struct MigrationProgress {
     /// Total minus skipped -- the number of embeddings that actually need processing.
     #[serde(default)]
     pub effective_total: usize,
-    /// Fraction of effective_total that has been processed (0.0 to 1.0).
+    /// Processed-to-effective-total coverage.
     #[serde(default)]
     pub effective_coverage: f64,
     /// Embeddings processed per second.

--- a/crates/embed/src/model.rs
+++ b/crates/embed/src/model.rs
@@ -1,6 +1,9 @@
-//! Embedding model definitions.
+//! Embedding model selection, runtime dimensions, and load provenance.
 //!
-//! Provides `EmbeddingModel` enum for local model selection.
+//! `EmbeddingModel` defines model-specific limits, prompting, and inference wiring.
+//! `ModelConfig` validates optional Matryoshka output truncation for supported models.
+//!
+//! See docs/model.md for the model and cache design.
 
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;

--- a/crates/embed/src/service/cached.rs
+++ b/crates/embed/src/service/cached.rs
@@ -1,4 +1,7 @@
-//! Caching wrapper for embedding services.
+//! Native-only LRU wrapper for an [`EmbeddingService`].
+//!
+//! It preserves caller order across partial cache hits and uses role-aware keys for asymmetric
+//! retrieval. See `docs/service.md` for the lookup and fill algorithm.
 
 use super::{DEFAULT_MAX_BATCH_SIZE, EmbeddingRole, EmbeddingService, MAX_TEXT_CHARS};
 use crate::error::Result;

--- a/crates/embed/src/service/mod.rs
+++ b/crates/embed/src/service/mod.rs
@@ -1,4 +1,8 @@
-//! Embedding service trait and implementations.
+//! Async embedding-service contract and native implementations.
+//!
+//! The trait defines generic, query, and passage embedding; native builds additionally expose
+//! a lazy local-inference service and an LRU caching wrapper. See `docs/service.md` for the
+//! lifecycle, prompt handling, validation rules, and cache behavior.
 
 #[cfg(feature = "native")]
 mod cached;

--- a/crates/embed/src/service/native.rs
+++ b/crates/embed/src/service/native.rs
@@ -1,4 +1,7 @@
-//! Native embedding service using lattice-inference (pure Rust, no C++ FFI).
+//! Native, pure-Rust embedding service backed by `lattice-inference`.
+//!
+//! Model loading is lazy and cancellation-safe; BERT-family and Qwen models take different
+//! loading and batching paths. See `docs/service.md` for lifecycle and persistence details.
 
 use super::{DEFAULT_MAX_BATCH_SIZE, EmbeddingService, MAX_TEXT_CHARS};
 use crate::error::{EmbedError, Result};

--- a/crates/embed/src/simd/binary.rs
+++ b/crates/embed/src/simd/binary.rs
@@ -1,19 +1,8 @@
-//! Binary quantization for ultra-fast pre-filtering.
+//! Binary sign quantization and Hamming-distance operations.
 //!
-//! Sign-bit quantization: 1 bit per dimension (32x compression vs f32).
-//! Distance via Hamming distance using hardware popcount.
+//! Packed format and partial-byte handling remain part of the API contract.
 //!
-//! ## Format
-//!
-//! `b[i] = 1 if v[i] >= 0 else 0`. Pack 8 dimensions into one byte
-//! (bit 7 = dimension 0, bit 6 = dimension 1, etc.).
-//! For D dimensions, storage is `ceil(D / 8)` bytes.
-//!
-//! ## Distance
-//!
-//! Hamming distance counts differing bits between two binary vectors.
-//! Approximate cosine distance: `1.0 - (1.0 - 2.0 * hamming / dims)`
-//! i.e. `2.0 * hamming / dims`.
+//! See docs/simd.md for the format and cosine approximation.
 
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;

--- a/crates/embed/src/simd/cosine.rs
+++ b/crates/embed/src/simd/cosine.rs
@@ -1,4 +1,6 @@
-//! SIMD-accelerated cosine similarity operations.
+//! SIMD cosine-similarity kernels and batch variants.
+//!
+//! See docs/simd.md for fused reductions and query-reuse behaviour.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -545,13 +547,7 @@ unsafe fn cosine_similarity_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
     }
 }
 
-/// **Unstable**: SIMD batch dispatch; use `lattice_embed::utils::batch_cosine_similarity` for stable wrapper.
-///
-/// Resolves the SIMD cosine kernel once to hoist OnceLock dispatch out of the per-pair loop.
-/// For unit-normalized inputs, callers should use `batch_dot_product` directly (or the
-/// PreparedQuery/HNSW APIs which accept explicit normalization hints). Auto-detecting
-/// unit-normalization here would require an O(N×dim) pre-scan costing as much as the
-/// computation itself, so detection is left to the caller.
+/// **Unstable**: batched cosine dispatch; callers supply normalization knowledge.
 pub fn batch_cosine_similarity(pairs: &[(&[f32], &[f32])]) -> Vec<f32> {
     let kernel = cosine_kernel();
     pairs
@@ -566,17 +562,9 @@ pub fn batch_cosine_similarity(pairs: &[(&[f32], &[f32])]) -> Vec<f32> {
         .collect()
 }
 
-/// **Unstable**: Fused single-pass cosine similarity; same SIMD path as `cosine_similarity`.
+/// **Unstable**: fused single-pass cosine similarity.
 ///
-/// Computes dot(a,b), norm(a), and norm(b) in a single pass over memory using three
-/// simultaneous SIMD accumulators. This is 3x more memory-efficient than computing
-/// each quantity in a separate pass (3x fewer cache-line loads).
-///
-/// The SIMD kernels (AVX-512, AVX2, NEON) already fuse all three reductions internally.
-/// The scalar fallback is also fused here, unlike `cosine_similarity_scalar` which
-/// makes three separate passes.
-///
-/// For pre-normalized vectors, callers should use `dot_product` directly.
+/// For pre-normalized vectors, use `dot_product` directly.
 #[inline]
 pub fn cosine_similarity_fused(a: &[f32], b: &[f32]) -> f32 {
     if a.len() != b.len() || a.is_empty() {
@@ -587,18 +575,9 @@ pub fn cosine_similarity_fused(a: &[f32], b: &[f32]) -> f32 {
     cosine_kernel()(a, b)
 }
 
-/// **Unstable**: One-vs-many cosine similarity, pre-computing the query norm once.
+/// **Unstable**: one-query/many-candidate cosine similarity.
 ///
-/// When comparing a single query vector against many stored vectors, the query's
-/// L2 norm is constant across all comparisons. This function computes `|query|`
-/// once and reuses it, saving `candidates.len()` square-root operations.
-///
-/// Each dot(query, candidate) and |candidate| are still computed per-pair via
-/// the SIMD kernel (fused with the candidate norm). The per-pair computation
-/// is 2-accumulator fused (dot_qc and norm_c) after the query norm is factored out.
-///
-/// Returns a `Vec<f32>` of cosine similarities in `[-1, 1]`, in the same order
-/// as `candidates`. Returns 0.0 for any candidate whose length differs from the query.
+/// Results retain candidate order and use `0.0` for dimensional mismatches.
 pub fn batch_cosine_one_vs_many(query: &[f32], candidates: &[&[f32]]) -> Vec<f32> {
     if query.is_empty() || candidates.is_empty() {
         return vec![0.0_f32; candidates.len()];

--- a/crates/embed/src/simd/distance.rs
+++ b/crates/embed/src/simd/distance.rs
@@ -1,4 +1,6 @@
-//! SIMD-accelerated distance operations.
+//! SIMD Euclidean and squared-Euclidean distance kernels.
+//!
+//! See docs/simd.md for distance semantics and ranking guidance.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;

--- a/crates/embed/src/simd/dot_product.rs
+++ b/crates/embed/src/simd/dot_product.rs
@@ -1,4 +1,8 @@
-//! SIMD-accelerated dot product operations.
+//! SIMD float dot-product kernels, including a one-query/four-candidate path.
+//!
+//! The public operations return zero for dimensional mismatches.
+//!
+//! See docs/simd.md for dispatch and batch-kernel design.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -993,11 +997,7 @@ fn same_query_batch4(chunk: &[(&[f32], &[f32])]) -> bool {
             .all(|(q, c)| q.as_ptr() == q_ptr && q.len() == q_len && c.len() == q_len)
 }
 
-/// **Unstable**: SIMD batch dispatch; use `lattice_embed::utils::batch_dot_product` for stable wrapper.
-///
-/// Uses the batch-4 SIMD kernel for consecutive same-query chunks (e.g., query-vs-N
-/// search pattern where the left-hand slice is the same borrowed reference for every pair).
-/// Falls back to the per-pair kernel for mixed or remainder inputs.
+/// **Unstable**: batched dot-product dispatch with a same-query fast path.
 pub fn batch_dot_product(pairs: &[(&[f32], &[f32])]) -> Vec<f32> {
     let pair_kernel = resolved_dot_product_kernel();
     let batch4_kernel = resolved_dot_product_batch4_kernel();

--- a/crates/embed/src/simd/int4.rs
+++ b/crates/embed/src/simd/int4.rs
@@ -1,17 +1,8 @@
-//! INT4 quantization for ultra-compact embedding storage.
+//! INT4 packed-vector quantization and approximate dot products.
 //!
-//! Two 4-bit values packed per byte (8x compression vs f32).
-//! Uses symmetric unsigned quantization: maps [-max_abs, max_abs] to [0, 15].
+//! Nibble layout and offset correction are shared by scalar and NEON paths.
 //!
-//! ## Packing format
-//!
-//! High nibble = even index, low nibble = odd index.
-//! For D dimensions, storage is `ceil(D / 2)` bytes.
-//!
-//! ## Dot product
-//!
-//! Dot products dequantize before accumulation so the unsigned INT4 offset is
-//! handled identically on every target.
+//! See docs/simd.md for the packed format and corrected dot-product derivation.
 
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -184,12 +175,7 @@ impl Int4Vector {
     }
 }
 
-/// **Unstable**: SIMD INT4 dot product; NEON/scalar dispatch may change.
-///
-/// Unpacks nibbles, computes dot product of quantized values, then applies
-/// dequantization scaling: `result = (raw_dot / (scale_a * scale_b)) - correction`
-///
-/// The correction accounts for the unsigned offset in the quantization formula.
+/// **Unstable**: dequantized INT4 dot product; dispatch may change.
 #[inline]
 pub fn dot_product_int4(a: &Int4Vector, b: &Int4Vector) -> f32 {
     if a.dims != b.dims {

--- a/crates/embed/src/simd/mod.rs
+++ b/crates/embed/src/simd/mod.rs
@@ -1,20 +1,9 @@
-//! SIMD-accelerated vector operations for embedding similarity.
+//! SIMD vector operations for embedding similarity and compressed-vector search.
 //!
-//! Provides optimized implementations with automatic fallback:
-//! - **x86_64 (float32)**: AVX-512F > AVX2 + FMA > scalar
-//! - **x86_64 (int8)**: AVX-512 VNNI > AVX2 > scalar
-//! - **aarch64**: ARM NEON with multiple accumulators and loop unrolling
-//! - **wasm32**: SIMD128 with multiple accumulators and loop unrolling, gated at
-//!   compile time via `target-feature=+simd128` (wasm has no runtime feature
-//!   detection, unlike x86_64/aarch64 — see [`SimdConfig::simd128_enabled`])
-//! - **Other**: Scalar fallback
+//! Dispatch uses the best supported target kernel with scalar fallbacks; WASM
+//! SIMD128 is selected at compile time. The public SIMD surface is unstable.
 //!
-//! ## Optimizations
-//!
-//! - **Multiple accumulators**: 4 parallel accumulators to break dependency chains
-//! - **Loop unrolling**: Process 16/32/64 elements per iteration depending on ISA
-//! - **AVX-512F**: Wide float32 kernels for dot, cosine, normalize, and distance
-//! - **AVX-512 VNNI**: Integer VNNI instructions when available (quantized int8 path)
+//! See docs/simd.md for the kernel family, dispatch, and quantization design.
 
 mod binary;
 mod cosine;
@@ -151,28 +140,10 @@ impl SimdConfig {
         }
     }
 
-    /// **Unstable**: wasm32 SIMD128 support available.
+    /// **Unstable**: reports compile-time wasm32 SIMD128 availability.
     ///
-    /// Unlike the x86_64/aarch64 fields, this is a **compile-time**, not
-    /// runtime, signal: wasm has no runtime CPU feature detection (a given
-    /// `.wasm` binary either was or wasn't compiled with `-C
-    /// target-feature=+simd128`; there is no dispatching between two
-    /// codepaths inside one binary). Mirrors `cfg!(target_feature =
-    /// "simd128")` and is always false on non-wasm32 targets. A method rather
-    /// than a field so existing `SimdConfig` struct literals keep compiling.
-    ///
-    /// Because this ignores `self` entirely, no `SimdConfig` value -- not
-    /// `SimdConfig::scalar_only` (the existing test-only force-scalar
-    /// helper), not a hypothetical future runtime override -- can flip it
-    /// back to `false` on a simd128-compiled wasm artifact: it always
-    /// re-derives the same compile-time `cfg!` regardless of which instance
-    /// calls it. The four dispatch resolvers that gate on
-    /// this method (`resolve_dot_product_kernel` in `dot_product.rs`,
-    /// `resolve_cosine_kernel` in `cosine.rs`, `dispatch_squared` in
-    /// `distance.rs`, and `normalize`'s inline dispatch in `normalize.rs`)
-    /// inherit the same property. The only way to get scalar dispatch on
-    /// wasm32 is to build without the `simd128` target feature in the first
-    /// place; there is no runtime escape hatch.
+    /// This mirrors the build's `target-feature=+simd128` setting; no
+    /// `SimdConfig` instance can override it at runtime. See docs/simd.md.
     #[inline]
     pub fn simd128_enabled(&self) -> bool {
         cfg!(all(target_arch = "wasm32", target_feature = "simd128"))

--- a/crates/embed/src/simd/normalize.rs
+++ b/crates/embed/src/simd/normalize.rs
@@ -1,4 +1,6 @@
-//! SIMD-accelerated vector normalization.
+//! SIMD in-place L2 normalization kernels.
+//!
+//! See docs/simd.md for the two-pass algorithm and backend differences.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -409,11 +411,6 @@ unsafe fn normalize_neon_unrolled(vector: &mut [f32]) {
 }
 
 /// wasm32 SIMD128-accelerated normalization with 4x unrolling.
-///
-/// Mirrors `normalize_avx2_unrolled` above (plain `sqrt` + scalar reciprocal,
-/// not the NEON kernel's `vrsqrteq_f32`+Newton-Raphson estimate -- wasm's
-/// `f32x4_sqrt` is already a single instruction, so there is no equivalent
-/// estimate-and-refine trick to apply here).
 ///
 /// # Safety
 ///

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -1,6 +1,8 @@
-//! INT8 quantization for efficient embedding storage and similarity computation.
+//! INT8 vector quantization and approximate similarity kernels.
 //!
-//! Quantized vectors provide ~3x speedup and 4x memory reduction with 99%+ accuracy.
+//! Constructor-owned values preserve the SIMD range invariant.
+//!
+//! See docs/simd.md for the encoding, error model, and dispatch strategy.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -569,10 +571,7 @@ pub type I8DotKernel = fn(&[i8], &[i8]) -> f32;
 
 static I8_DOT_KERNEL: OnceLock<I8DotKernel> = OnceLock::new();
 
-/// Return the cached INT8 dot-product kernel.
-///
-/// Callers that invoke INT8 dot product in a tight loop can hoist this call
-/// outside the loop so the OnceLock check runs once, not per-iteration.
+/// Return the cached INT8 dot-product kernel for tight loops.
 #[inline]
 pub fn resolved_i8_dot_kernel() -> I8DotKernel {
     *I8_DOT_KERNEL.get_or_init(resolve_i8_dot_kernel)
@@ -635,41 +634,15 @@ fn dot_product_i8_scalar_kernel(a: &[i8], b: &[i8]) -> f32 {
         .sum::<i32>() as f32
 }
 
-/// **Unstable**: raw SIMD INT8 hot path; signature and scaling semantics may change.
-///
-/// This is the hot-path function for HNSW quantized search. Unlike `dot_product_i8`,
-/// it takes raw `&[i8]` slices and does NOT divide by scale factors -- the caller
-/// handles scaling. This avoids allocating `QuantizedVector` wrappers.
-///
-/// Returns 0.0 if slices have different lengths.
-///
-/// # Invariant
-///
-/// Both slices must satisfy the `[-127, 127]` range invariant. The value `-128`
-/// causes silent corruption on the AVX2 and AVX-512-VNNI paths, which apply an
-/// operand's sign by negating a byte (`_mm256_sign_epi8` / a `0 - b` emulation):
-/// negating `-128` wraps back to `-128` in two's complement instead of `+128`,
-/// so the kernel accumulates the wrong sign. The invariant is enforced with a
-/// **`debug_assert!`** (debug builds only); callers MUST guarantee it. The
-/// `QuantizedVector::from_f32` constructor satisfies it by clamping to `[-127, 127]`.
-/// Promoting this to a release `assert!` would add an O(n) scan to a documented hot
-/// path and is intentionally avoided.
-///
-/// # Performance
-///
+/// Dispatch a validated raw INT8 dot product.
 #[inline]
 fn dot_product_i8_dispatch(a: &[i8], b: &[i8]) -> f32 {
     resolved_i8_dot_kernel()(a, b)
 }
 
-/// **Unstable**: raw INT8 dot product on slices; SIMD strategy may change.
+/// **Unstable**: unscaled INT8 dot product over raw slices.
 ///
-/// Uses the same SIMD paths as `dot_product_i8`:
-/// - aarch64: NEON with 4x unrolling + tail SIMD chunks
-/// - x86_64: AVX-512 VNNI > AVX2 > scalar
-///
-/// The key difference is zero allocation overhead: no `Vec<i8>`, no
-/// `QuantizedVector`, no `QuantizationParams`. Just raw slices in, f32 out.
+/// The caller owns scaling; returns `0.0` for a length mismatch.
 ///
 /// # Invariant (caller-guaranteed)
 ///
@@ -678,7 +651,7 @@ fn dot_product_i8_dispatch(a: &[i8], b: &[i8]) -> f32 {
 /// an operand's sign by negating a byte (`_mm256_sign_epi8` / a `0 - b`
 /// emulation); negating `-128` wraps back to `-128` in two's complement instead
 /// of `+128`, so the kernel silently accumulates the wrong sign and the dispatch
-/// returns a wrong distance with no panic. The precondition is checked only by
+/// returns a wrong dot product with no panic. The precondition is checked only by
 /// `debug_assert!`, which is compiled out in release builds, so a release caller
 /// gets no diagnostic. `-128` is memory-safe (no UB), only numerically
 /// out-of-contract.

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -1,17 +1,9 @@
-//! Quantization tier management and unified distance dispatch.
+//! Quantization tiers, prepared queries, and unified distance dispatch.
 //!
-//! Provides a `QuantizationTier` enum for selecting precision levels and
-//! a `QuantizedData` enum for storing vectors at any tier with unified
-//! distance computation.
+//! Tiers trade storage for fidelity; prepared queries avoid repeated
+//! quantization in homogeneous candidate searches.
 //!
-//! ## Tier hierarchy
-//!
-//! | Tier   | Precision | Bytes/dim | Compression | Use case                |
-//! |--------|-----------|-----------|-------------|-------------------------|
-//! | Full   | f32       | 4.0       | 1x          | Hot data, exact search   |
-//! | Int8   | 8-bit     | 1.0       | 4x          | Warm data, HNSW search   |
-//! | Int4   | 4-bit     | 0.5       | 8x          | Cool data, pre-filtering |
-//! | Binary | 1-bit     | 0.125     | 32x         | Cold data, coarse filter |
+//! See docs/simd.md for tier selection and dispatch semantics.
 
 use super::binary::BinaryVector;
 use super::int4::Int4Vector;
@@ -72,12 +64,7 @@ impl QuantizationTier {
         }
     }
 
-    /// **Unstable**: age-based tier heuristic; boundaries (HOUR/DAY/WEEK) may be tuned.
-    ///
-    /// - Hot (accessed in last hour): Full
-    /// - Warm (accessed in last day): Int8
-    /// - Cool (accessed in last week): Int4
-    /// - Cold (accessed in last month+): Binary
+    /// **Unstable**: maps recency to a storage tier; boundaries may be tuned.
     pub fn from_age_seconds(age_secs: u64) -> Self {
         const HOUR: u64 = 3600;
         const DAY: u64 = 86400;
@@ -162,12 +149,7 @@ impl QuantizedData {
         }
     }
 
-    /// **Unstable**: tier promotion; re-quantizes via f32; may be rethought.
-    ///
-    /// Dequantizes to f32 then re-quantizes at the target tier.
-    /// Note: this does NOT recover lost information -- it merely changes
-    /// the storage format. INT4 -> INT8 promotion fills in new bits
-    /// based on the dequantized approximation.
+    /// **Unstable**: re-quantizes through `f32`; lost information is not recovered.
     pub fn promote(&self, target: QuantizationTier) -> Self {
         let f32_data = self.to_f32();
         Self::from_f32(&f32_data, target)
@@ -179,10 +161,7 @@ impl QuantizedData {
     }
 }
 
-/// **Unstable**: pre-quantized query for repeated distance computation.
-///
-/// Quantize a query vector once and reuse it against a homogeneous candidate list,
-/// eliminating per-call `from_f32` overhead. The query tier must match the stored data tier.
+/// **Unstable**: pre-quantized query for repeated same-tier distance computation.
 #[derive(Debug, Clone)]
 pub enum PreparedQuery {
     /// Full f32 query.
@@ -236,11 +215,7 @@ pub fn prepare_query(query_f32: &[f32], tier: QuantizationTier) -> PreparedQuery
     PreparedQuery::from_f32(query_f32, tier)
 }
 
-/// A prepared query annotated with a normalization hint for fast-path dispatch.
-///
-/// When `norm == NormalizationHint::Unit` and the stored vector is also unit-normalized,
-/// `approximate_cosine_distance_prepared_with_meta` skips the norm division and uses
-/// `1.0 - dot_product(q, s)` directly — recovering ~26% at 384d on the Full tier.
+/// A prepared query with caller-provided normalization metadata.
 #[derive(Debug, Clone)]
 pub struct PreparedQueryWithMeta {
     /// The quantized query (owns the data).
@@ -317,11 +292,7 @@ pub fn approximate_cosine_distance_prepared(
     }
 }
 
-/// Alias for [`approximate_cosine_distance_prepared`], retained for API compatibility.
-///
-/// As of the tier-mismatch hardening fix (issue #210), the non-`try_` variant no
-/// longer panics and returns the same `Result` as this function. Prefer the
-/// non-`try_` name in new code.
+/// Alias for [`approximate_cosine_distance_prepared`] retained for compatibility.
 #[inline]
 pub fn try_approximate_cosine_distance_prepared(
     query: &PreparedQuery,
@@ -330,11 +301,7 @@ pub fn try_approximate_cosine_distance_prepared(
     approximate_cosine_distance_prepared(query, stored)
 }
 
-/// Alias for [`approximate_dot_product_prepared`], retained for API compatibility.
-///
-/// As of the tier-mismatch hardening fix (issue #210), the non-`try_` variant no
-/// longer panics and returns the same `Result` as this function. Prefer the
-/// non-`try_` name in new code.
+/// Alias for [`approximate_dot_product_prepared`] retained for compatibility.
 #[inline]
 pub fn try_approximate_dot_product_prepared(
     query: &PreparedQuery,
@@ -343,16 +310,10 @@ pub fn try_approximate_dot_product_prepared(
     approximate_dot_product_prepared(query, stored)
 }
 
-/// Cosine distance with unit-norm fast path.
+/// Cosine distance with a caller-asserted unit-norm fast path.
 ///
-/// When `meta.norm == NormalizationHint::Unit` and `stored` is a `QuantizedData::Full`
-/// vector whose squared norm is ≈ 1, skips the norm division and returns
-/// `1.0 - clamp(dot(q, s), -1, 1)`. For all other tier/norm combinations, falls
-/// back to `approximate_cosine_distance_prepared`.
-///
-/// The stored vector's unit claim is verified lazily via [`is_unit_norm`]; callers
-/// that batch many lookups against a fixed stored set should pre-check once and
-/// use the cheaper overload directly.
+/// Matching `Unit` hints on `Full` vectors use `1.0 - clamp(dot(q, s), -1, 1)`;
+/// all other combinations use [`approximate_cosine_distance_prepared`].
 ///
 /// # Errors
 ///
@@ -561,12 +522,7 @@ pub fn approximate_int4_batch_prepared_into(
     Ok(())
 }
 
-/// **Unstable**: tiered distance dispatch; tier mix and formula may change.
-///
-/// This is the primary distance function for HNSW search with tiered storage.
-/// The query is always f32; the stored data may be at any tier.
-///
-/// Returns a value in [0, 2] where 0 = identical, 2 = opposite.
+/// **Unstable**: approximate tiered cosine distance from an `f32` query.
 ///
 /// # Precondition
 ///
@@ -603,7 +559,7 @@ pub fn approximate_cosine_distance(query_f32: &[f32], stored: &QuantizedData) ->
     }
 }
 
-/// **Unstable**: tiered dot product dispatch; tier mix and formula may change.
+/// **Unstable**: approximate tiered dot-product dispatch.
 pub fn approximate_dot_product(query_f32: &[f32], stored: &QuantizedData) -> f32 {
     match stored {
         QuantizedData::Full(v) => dot_product(query_f32, v),

--- a/crates/embed/src/types.rs
+++ b/crates/embed/src/types.rs
@@ -1,8 +1,9 @@
-//! ML-domain vector types local to lattice-embed.
+//! Vector-space identity and storage-format descriptors for `lattice-embed`.
 //!
-//! These types are defined here because the new lattice-types foundation crate
-//! only contains identity/policy/capability primitives and does not include
-//! vector configuration types. These are ML-domain concerns.
+//! These ML-domain types identify compatible vector spaces and define their canonical
+//! byte representation for deterministic hashing.
+//!
+//! See docs/model.md for the embedding-space format and cache-key relationship.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/embed/src/wasm.rs
+++ b/crates/embed/src/wasm.rs
@@ -1,19 +1,8 @@
-//! wasm-bindgen JS bindings for browser-hosted embedding generation.
+//! Browser `wasm-bindgen` bindings for in-memory BERT embeddings and vector utilities.
 //!
-//! Exposes a minimal surface: construct a [`LatticeEmbedder`] from in-memory
-//! model bytes (no filesystem, no network access: the caller fetches or
-//! otherwise holds the bytes on the JS side), then call [`LatticeEmbedder::embed`]
-//! to get an L2-normalized embedding vector for a string.
-//!
-//! This wraps `lattice_inference::BertModel::from_bytes`, which itself avoids
-//! `std::fs`/`mmap` entirely. That is required, not incidental:
-//! `wasm32-unknown-unknown` has no real filesystem, and `memmap2`'s wasm
-//! fallback compiles but every `Mmap::map` call returns
-//! `io::ErrorKind::Unsupported` at runtime (see `SafetensorsFile::from_bytes`'s
-//! doc comment in `lattice-inference`). Everything in this module runs
-//! synchronously in memory: there is no `spawn_blocking`, disk cache, or
-//! download path here; those belong to `NativeEmbeddingService` and stay
-//! native-only.
+//! On `wasm32-unknown-unknown`, filesystem-backed loading and `mmap` are unsupported at
+//! runtime: callers must provide model bytes in memory, and native download/cache paths do not
+//! apply. This module runs synchronously. See `docs/design.md` for the WebAssembly boundary.
 
 use lattice_inference::{BertModel, BertPooling};
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
Follow-up to #948. The first pass was a lib.rs-only summary — too shallow. This pass transposes the full substance of the crate's long inline `//!` narrative into properly-written topic docs.

## What

- New `docs/simd.md`, `docs/service.md`, `docs/model.md`, `docs/migration.md`, `docs/backfill.md` carry the deep material (SIMD tier detection + quantized/int4/binary kernels; native + cached embedding service; model loading; migration controller; backfill coordinator).
- `docs/design.md` is the crate architecture overview; `docs/INDEX.md` indexes every topic doc.
- Source `//!` blocks condensed to a summary + pointer. Load-bearing invariants, SIMD-tier gotchas, and safety notes kept inline.

## Verification

- `cargo fmt -p lattice-embed --check` — clean.
- Docs-only: no source logic changed (only `//!`/`///` comment volume + new markdown). Doc-build (`-D warnings -D rustdoc::broken_intra_doc_links`) is gated by CI; local run deferred under disk pressure this session.
