### PR TITLE
docs(tune): deep-extract inline narrative into docs/, condense rustdoc

### DIFF
--- a/crates/tune/docs/INDEX.md
+++ b/crates/tune/docs/INDEX.md
@@ -1,10 +1,50 @@
-# lattice-tune — extended docs
+# lattice-tune documentation
 
-Deeper documentation for the crate, kept alongside the source so it stays current
-as the code changes. The crate-level rustdoc (`src/lib.rs`) and `README.md` hold
-the summary and public API surface; the files here hold the longer-form narrative.
+These guides hold the longer-form design and format references for
+`lattice-tune`. Source rustdoc stays focused on public API contracts and
+load-bearing invariants; start here when you need the wider subsystem context.
 
-- [design.md](design.md) — the distillation/training/registry pipeline, walkthroughs
-  for each stage, the `inference-hook` bridge, and the `Checkpoint` JSON schema.
-- `adr/`, `ADR-*.md` — accepted architecture decisions for this crate (unchanged by
-  this index; see each ADR for the alternatives considered and why).
+## Architecture and topic guides
+
+| Guide | Scope |
+| --- | --- |
+| [design.md](design.md) | Crate architecture, subsystem boundaries, lifecycle hand-offs, features, error boundary, and exact-gradient CLI workflow |
+| [data.md](data.md) | `TrainingExample` format, six-label order, metadata, filtering, batching, statistics, and splitting |
+| [distill.md](distill.md) | Teacher configuration, endpoint policy, prompt construction, pipeline behavior, accounting, and label-to-example conversion |
+| [lora-core.md](lora-core.md) | Core adapter representation, low-rank application, and training mechanics |
+| [lora-router.md](lora-router.md) | Adapter selection, router behavior, and online updates |
+| [lora-io.md](lora-io.md) | PEFT safetensors, manifests, loading, saving, and adapter artifact governance |
+| [train.md](train.md) | Training configuration, loop execution, callbacks, checkpoints, and GPU behavior |
+| [registry.md](registry.md) | Model records, storage, lineage, live deployment, shadow evaluation, and rollback |
+
+### Suggested reading paths
+
+- **Prepare teacher-labeled data:** [distill.md](distill.md) →
+  [data.md](data.md) → [train.md](train.md).
+- **Fine-tune or serve an adapter:** [lora-core.md](lora-core.md) →
+  [lora-io.md](lora-io.md) → [lora-router.md](lora-router.md), when routing
+  applies.
+- **Promote a trained model:** [train.md](train.md) →
+  [registry.md](registry.md).
+- **Understand how the pieces fit:** start with [design.md](design.md), then
+  follow the relevant topic links.
+
+## Architecture decisions
+
+The following records are part of this documentation set. Do not move or edit
+the retired crate-local ADR pointers; each identifies the maintained
+repository-wide decision record.
+
+| Decision | Current location |
+| --- | --- |
+| Multi-provider teacher strategy | [ADR-001-teacher-providers.md](ADR-001-teacher-providers.md) |
+| Model registry with lineage | [ADR-002-model-registry.md](ADR-002-model-registry.md) |
+| Fine-tuning pipeline | [crate-local pointer](adr/ADR-001-finetuning-pipeline.md) → [maintained ADR-027](../../../docs/adr/ADR-027-finetuning-pipeline.md) |
+| Knowledge distillation pipeline | [crate-local pointer](adr/ADR-003-knowledge-distillation.md) → [maintained ADR-030](../../../docs/adr/ADR-030-knowledge-distillation.md) |
+| LoRA adapter management | [crate-local pointer](adr/ADR-004-lora-adapter-management.md) → [maintained ADR-031](../../../docs/adr/ADR-031-lora-adapter-management.md) |
+| Training callbacks | [crate-local pointer](adr/ADR-005-training-callbacks.md) → [maintained ADR-032](../../../docs/adr/ADR-032-training-callbacks.md) |
+| JIT adaptation | [crate-local pointer](adr/ADR-006-jit-adaptation.md) → [maintained ADR-033](../../../docs/adr/ADR-033-jit-adaptation.md) |
+| Dataset pipeline | [crate-local pointer](adr/ADR-007-dataset-pipeline.md) → [maintained ADR-034](../../../docs/adr/ADR-034-dataset-pipeline.md) |
+
+Use an ADR to understand an accepted design choice and rejected alternatives;
+use the topic guides to implement against the current code.

--- a/crates/tune/docs/data.md
+++ b/crates/tune/docs/data.md
@@ -1,0 +1,275 @@
+# Training data
+
+The `data` module defines the in-memory contract between distillation or other
+data producers and the training APIs. It does not embed text, fetch records
+from disk, or serialize a dataset by itself. Its job is narrower:
+
+- represent one embedding-based classification example;
+- preserve enough source and teacher metadata for traceability;
+- enforce the structural checks that are available locally; and
+- group examples into cloned batches for one in-memory epoch at a time.
+
+The dataset-pipeline decision is recorded in the retired crate-local
+[ADR-007](adr/ADR-007-dataset-pipeline.md), which links to the maintained
+repository-wide ADR. This guide describes the current API behavior rather than
+restating that decision.
+
+## The example contract
+
+A `TrainingExample` contains one current-message embedding, a chronological
+window of context embeddings, six soft intent labels, and metadata:
+
+```rust
+pub struct TrainingExample {
+    pub id: Uuid,
+    pub context_embeddings: Vec<Vec<f32>>,
+    pub message_embedding: Vec<f32>,
+    pub labels: IntentLabels,
+    pub metadata: ExampleMetadata,
+}
+```
+
+The inner vectors in `context_embeddings` each represent one earlier message,
+ordered oldest to newest. `message_embedding` represents the message to
+classify. A new example receives a UUID and default metadata; `with_id` accepts
+a caller-provided stable ID; `with_metadata` replaces the default metadata.
+
+### Structural validation
+
+`TrainingExample::validate` performs these checks:
+
+1. The current message embedding must be nonempty.
+2. Every context embedding must have exactly the same dimension as the current
+   message embedding.
+3. Each of the six label values must be in the closed interval `[0, 1]`.
+
+It does **not** require a nonempty context window, a fixed global embedding
+dimension, finite embedding values, or labels that sum to one. It also does
+not validate metadata. Producers that need those stronger guarantees must
+enforce them before adding examples to a dataset.
+
+`embedding_dim()` reports the current-message vector length, and
+`context_size()` reports the number of context vectors. The latter is what
+dataset filtering uses; it does not inspect the embedding contents.
+
+## Soft intent labels
+
+`IntentLabels` is a six-field record. Its vector representation and class
+order are fixed:
+
+| Index | Field | Class name | Meaning |
+| ---: | --- | --- | --- |
+| 0 | `continuation` | `continuation` | Natural conversational continuation |
+| 1 | `topic_shift` | `topic_shift` | A change of subject |
+| 2 | `explicit_query` | `explicit_query` | Direct request or question |
+| 3 | `person_lookup` | `person_lookup` | Looking up a person or contact |
+| 4 | `health_check` | `health_check` | Health or wellness inquiry |
+| 5 | `task_status` | `task_status` | Checking a task or todo status |
+
+This order is used by `from_vec`, `to_vec`, `class_names`, batch label
+matrices, distillation statistics, and dataset statistics. It is a
+cross-module data invariant: do not reorder it or reinterpret a serialized
+vector position without changing every producer and consumer.
+
+The named constructors set just one field and leave the other five at zero:
+`continuation(prob)`, `topic_shift(prob)`, `explicit_query(prob)`,
+`person_lookup(prob)`, `health_check(prob)`, and `task_status(prob)`.
+`from_vec` accepts any slice and fills unavailable positions with zero; values
+after the sixth position are ignored.
+
+### Validation, dominant class, and normalization
+
+`validate()` rejects values outside `[0, 1]`, including non-finite values. It
+does not require a normalized distribution. `dominant()` uses
+`f32::total_cmp` over the vector and returns the winning class name and value;
+`TrainingExample::dominant_intent()` delegates to it.
+
+`softmax_normalize()` treats the six stored values as scores, not as already
+normalized probabilities. It:
+
+1. rejects any non-finite input;
+2. subtracts the largest score for numerical stability;
+3. exponentiates the shifted scores; and
+4. divides each exponent by the total.
+
+The resulting values are finite probabilities that sum approximately to one
+for finite inputs. Calling it on values that already look like probabilities
+changes their relative distribution; use it only when a score-to-distribution
+conversion is intended. The distillation pipeline enables it by default; see
+[distill.md](distill.md).
+
+## Traceability metadata
+
+`ExampleMetadata` is optional provenance attached to an example:
+
+| Field | Meaning |
+| --- | --- |
+| `source_id` | Source conversation or session identifier |
+| `timestamp` | UTC time of the original message |
+| `teacher_model` | Teacher display name that generated labels |
+| `labeled_at` | UTC time at which labeling occurred |
+| `teacher_confidence` | Teacher confidence, conventionally 0–1 |
+| `extra` | Additional application metadata |
+
+With `serde` enabled, `extra` is `Option<serde_json::Value>`; without it,
+`extra` is `Option<String>`. The constructors are intentionally additive:
+`with_source` creates metadata with only a source ID, and the `teacher`,
+`timestamp`, `labeled_at`, and `confidence` builders set their respective
+fields.
+
+The distillation conversion path uses the labeling result UUID as `source_id`,
+records `TeacherConfig::display_name()`, records the current UTC time, and
+carries the returned confidence. An application that needs the original raw
+source ID should preserve it in its own metadata flow before conversion.
+
+## Dataset configuration
+
+`DatasetConfig` controls selection and iteration:
+
+| Field | Default | Effect |
+| --- | ---: | --- |
+| `batch_size` | 32 | Number of examples in a full batch; must be nonzero. |
+| `shuffle` | true | Whether `reset_epoch` permutes example indices. |
+| `seed` | none | Fixed seed for a repeatable permutation; absent uses current system time when available. |
+| `drop_last` | false | Whether a final partial batch is discarded. |
+| `min_context_size` | 1 | Minimum number of context vectors accepted by `with_config`. |
+| `max_context_size` | none | Maximum number accepted by `with_config`. |
+
+Despite the field comment's shorthand, `max_context_size` does **not** truncate
+a longer context sequence. `Dataset::with_config` filters out examples outside
+the inclusive `min_context_size..=max_context_size` range. Configuration
+validation rejects a zero batch size and a maximum lower than the minimum.
+
+`DatasetConfig::with_batch_size` starts from defaults. The `shuffle`, `seed`,
+and `drop_last` builders replace their corresponding values. There are no
+builders for the two context-size limits, so configure them through public
+fields before creating the dataset.
+
+### When filtering happens
+
+`Dataset::with_config(examples, config)` validates the configuration once and
+filters the supplied vector by context size. It does not call
+`TrainingExample::validate`. In contrast:
+
+- `Dataset::new()` creates an empty dataset with default configuration;
+- `Dataset::from_examples(...)` keeps every supplied example without filtering;
+- `Dataset::add(...)` appends an example without validation or filtering; and
+- `Dataset::set_config(...)` validates and replaces the stored configuration,
+  but does not retroactively filter existing examples or reset iteration.
+
+Configure and validate producer data before construction when you need the
+dataset itself to be an eligibility gate.
+
+## Batching and epoch state
+
+`Dataset` owns the example vector plus an index permutation and a cursor. It
+does not implement the standard `IntoIterator` contract; use `batches()` for a
+fresh epoch or `next_batch()` to advance the current one manually.
+
+```rust,ignore
+use lattice_tune::data::{Dataset, DatasetConfig};
+
+let mut dataset = Dataset::with_config(examples, DatasetConfig::with_batch_size(32))?;
+
+for batch in dataset.batches() {
+    // batch.examples owns cloned TrainingExample values
+    consume(batch.message_embeddings(), batch.labels());
+}
+```
+
+### Reset and shuffle
+
+`reset_epoch()` sets the cursor to zero, rebuilds the index list as
+`0..examples.len()`, and optionally shuffles it. `batches()` always calls
+`reset_epoch()` before returning `BatchIterator`, so a new `batches()` call
+abandons any partially consumed manual epoch.
+
+The shuffle is Fisher–Yates driven by a simple linear congruential generator.
+With `seed: Some(value)`, every reset starts from the same seed and therefore
+produces the same order for unchanged examples. Without a seed, the current
+UNIX-epoch nanoseconds seed the generator; if the system clock cannot be read,
+the fallback is `42`. This is deterministic sampling machinery, not a
+cryptographic randomizer.
+
+### Batch boundaries
+
+`num_batches()` returns:
+
+```text
+0                                  when the dataset is empty
+floor(n / batch_size)              when drop_last is true
+ceil(n / batch_size)               otherwise
+```
+
+`next_batch()` takes the next slice of permutation indices and clones the
+corresponding examples. If `drop_last` is true and the remaining slice is
+short, it advances the cursor to the end and returns `None`. Otherwise it
+returns a `Batch` with a zero-based `batch_idx` and the epoch's
+`total_batches`.
+
+A `Batch` is an owned collection:
+
+| Member or method | Behavior |
+| --- | --- |
+| `examples` | Cloned `TrainingExample` values selected for that batch |
+| `batch_idx` / `total_batches` | Position and expected count within the epoch |
+| `len()` / `is_empty()` | Inspect the owned example vector |
+| `message_embeddings()` | Allocates a matrix of cloned message vectors |
+| `labels()` | Allocates a matrix of six-element label vectors |
+
+`Batch::from_examples` is a convenience constructor for a standalone batch. It
+sets `total_batches` to one; an epoch-produced batch gets its actual epoch
+total from `Dataset::next_batch`.
+
+## Dataset inspection and partitioning
+
+`len()`, `is_empty()`, `get(id)`, `get_idx(index)`, and `examples()` provide
+read access. `examples_mut()` exposes the backing vector directly; callers
+that change it are responsible for preserving valid examples and for resetting
+the epoch before relying on a fresh index permutation.
+
+### Statistics
+
+`stats()` returns all-zero `DatasetStats` for an empty dataset. Otherwise it
+uses the first example's message dimension as `embedding_dim`, calculates
+minimum, maximum, and arithmetic mean context size, and produces six
+`label_distribution` counters.
+
+Each label-distribution counter represents the number of examples whose
+dominant class is that index; it is not a sum or average of soft label values.
+`stats()` does not validate examples first, so inconsistent dimensions can
+yield a reported first dimension even when the collection is not fit for a
+downstream training routine.
+
+### Train/validation split
+
+`split(train_ratio)` accepts an inclusive ratio in `0.0..=1.0`. It computes
+the boundary as:
+
+```text
+split_index = (number_of_examples as f32 * train_ratio) as usize
+```
+
+and returns the prefix as training data and the suffix as validation data.
+The split preserves current storage order: it does not shuffle or stratify by
+label, context size, or metadata. Both returned datasets are constructed with
+`Dataset::from_examples` and therefore have default configuration, fresh
+indices, and cloned examples. Set configuration explicitly on each partition
+when batch sizing, shuffling, or dropping partial batches matters.
+
+## Producer checklist
+
+Before training, a producer should:
+
+1. create or preserve stable example IDs;
+2. create every context and current-message embedding in the same dimension;
+3. use the fixed `IntentLabels` vector order;
+4. validate each `TrainingExample` if the data source is not already trusted;
+5. choose context eligibility during `Dataset::with_config` construction;
+6. pick a fixed `seed` if repeatable epoch order is needed; and
+7. perform a deliberate, preferably shuffled or stratified, train/validation
+   split before relying on validation metrics.
+
+For teacher-generated labels and the conversion step that supplies these
+examples, see [distill.md](distill.md). For the training loop that consumes
+batches, see [train.md](train.md).

--- a/crates/tune/docs/design.md
+++ b/crates/tune/docs/design.md
@@ -1,221 +1,336 @@
 # lattice-tune design
 
-`lattice-tune` is the training side of Lattice: a knowledge-distillation pipeline that
-turns teacher-model (Claude, GPT, Gemini) responses into a compact student network, plus
-the training loop, LoRA adapters, and a model registry that tracks what got trained and
-why.
+`lattice-tune` owns the training-side lifecycle around Lattice models. It
+keeps data preparation, teacher labeling, training orchestration, adapter
+work, and model registration as separate subsystems with explicit hand-offs
+rather than one all-purpose pipeline.
 
-## Pipeline
+This page is the map of that composition. Follow the linked topic guides for
+formats, algorithms, and operational rules; follow the ADRs for the
+alternatives that led to a boundary.
+
+## Crate map
 
 ```text
-Raw Data → Teacher (LLM) → Soft Labels → Dataset → Training → Model → Registry
-                                                        ↓
-                                                   Deployment
+                         raw text / external records
+                                     │
+                       ┌─────────────▼─────────────┐
+                       │          distill          │
+                       │ teacher policy + labels   │
+                       └─────────────┬─────────────┘
+                                     │ labels
+                   embeddings supplied by application
+                                     │
+                       ┌─────────────▼─────────────┐
+                       │            data           │
+                       │ examples, datasets, batch │
+                       └─────────────┬─────────────┘
+                                     │ batches
+                       ┌─────────────▼─────────────┐
+                       │           train            │
+                       │ loop, configuration, state │
+                       └─────────────┬─────────────┘
+                                     │ trained parameters / metrics
+           ┌─────────────────────────┴──────────────────────────┐
+           ▼                                                    ▼
+┌──────────────────────┐                            ┌──────────────────────┐
+│         lora         │                            │       registry       │
+│ adapter train, I/O,  │                            │ versions, storage,   │
+│ routing, inference   │                            │ shadow, rollback     │
+└──────────┬───────────┘                            └──────────────────────┘
+           │
+           ▼
+ lattice-inference (only through optional feature bridge)
 ```
 
-- **`data`** — `TrainingExample`, `Dataset`, and `Batch`: the labeled-example format and
-  batching used throughout the rest of the crate.
-- **`distill`** — pipelines a teacher model (Claude/GPT/Gemini) over raw text into soft
-  labels, producing `TrainingExample`s.
-- **`train`** — the training loop, optimizer, LR schedule, early stopping, checkpointing,
-  and (behind the `gpu` feature) GPU-accelerated forward/backward.
-- **`registry`** — versions and stores trained models with training-config and metric
-  provenance, plus shadow-deployment and rollback support.
+The diagram has two related but independent paths:
 
-## Design principles
+- The **student-model path** turns examples into batches, trains a model, and
+  records a versioned artifact and its provenance.
+- The **adapter path** creates or loads a LoRA adapter, optionally trains its
+  low-rank parameters, persists it through the LoRA I/O surface, and can
+  attach it to `lattice-inference` when the appropriate feature is enabled.
 
-1. **Data-first** — a well-defined training-example format with full traceability from
-   raw input through to the trained model.
-2. **Modular** — distillation, training, and registry are separate concerns that compose
-   through the shared `data` types.
-3. **Extensible** — teacher providers (Claude, GPT, Gemini) are pluggable via
-   `TeacherConfig`/`TeacherProvider`.
-4. **Traceable** — every registered model carries its version, training config, and
-   metrics.
+The registry is not an implicit last step for either path: callers explicitly
+register a model and its bytes. Likewise, data creation does not implicitly
+invoke a teacher or an embedding service.
 
-## Distillation walkthrough
+## Module ownership and hand-offs
 
-```ignore
-use lattice_tune::distill::{TeacherConfig, DistillationPipeline, RawExample};
+| Module | Owns | Receives | Produces | Guide |
+| --- | --- | --- | --- | --- |
+| `data` | `TrainingExample`, labels, metadata, in-memory datasets, batches | Embeddings and labels from a caller | Filtered datasets and cloned batches | [data.md](data.md) |
+| `distill` | Teacher configuration, endpoint policy, raw prompt handling, labeling result accounting | Raw conversational text | Results; training examples only after caller supplies embeddings | [distill.md](distill.md) |
+| `train` | Generic training config, loop state, callbacks, checkpointing, and optional GPU surface | `Dataset` batches | Metrics, checkpoints, and trained model state | [train.md](train.md) |
+| `lora` | Low-rank adapter representation, application, persistence, online/router work, and optional backward utilities | Base-projection context and adapter inputs | Adapter weights or inference-time deltas | [lora-core.md](lora-core.md), [lora-router.md](lora-router.md), [lora-io.md](lora-io.md) |
+| `registry` | Registered model records, storage/query interfaces, live swaps, shadow evaluation, and rollback | Model metadata and weight artifacts | Versioned, deployable model records | [registry.md](registry.md) |
+| `error` | `TuneError` and `Result` | Failures from every subsystem | A common, domain-specific error vocabulary | This page |
 
-// Configure teacher model
-let teacher = TeacherConfig::claude_sonnet();
+Each subsystem has a deliberately small data boundary:
 
-// Create distillation pipeline
-let mut pipeline = DistillationPipeline::with_teacher(teacher)?;
+- `distill` does not generate embeddings or invoke training;
+- `data` does not fetch or persist records;
+- `train` consumes batches and does not choose a teacher or deployment target;
+- `lora` is an adapter concern, not a dependency of the generic data model;
+- `registry` records and serves artifacts but does not retrain them; and
+- `error` standardizes failure reporting without becoming a control plane.
 
-// Create raw examples (text, not embeddings)
-let raw = RawExample::new(
-    vec!["Hello".to_string(), "How are you?".to_string()],
-    "What's the weather like?",
-);
+## Lifecycle 1: teacher-labeled classification data
 
-// Label with teacher
-let result = pipeline.label_single(&raw)?;
-println!("Labeled with confidence: {}", result.confidence);
+```text
+conversation history + current message
+                  │
+                  ▼
+        RawExample::to_prompt()
+                  │
+                  ▼
+    teacher result / LabelingResult
+                  │
+        caller aligns embeddings
+                  │
+                  ▼
+        TrainingExample + metadata
+                  │
+                  ▼
+     Dataset::with_config(...) ──► batches()
+                  │
+                  ▼
+             TrainingLoop
+                  │
+                  ▼
+       metrics + registered artifact
 ```
 
-## Training walkthrough
+The important boundary in this route is between text and vectors. A
+`RawExample` contains text; a `TrainingExample` contains vectors. The
+distillation pipeline does not own an embedding model, so the caller must
+produce context and message embeddings in the same order as its labeling
+results. [distill.md](distill.md) defines result conversion; [data.md](data.md)
+defines the vector and six-label contract.
 
-```ignore
-use lattice_tune::train::{TrainingConfig, TrainingLoop};
-use lattice_tune::data::Dataset;
+At present `DistillationPipeline` is a placeholder teacher integration. It
+formats and bounds a prompt, creates simulated labels, and maintains
+statistics; it makes no HTTP request and does not read an API-key environment
+variable. A deployment should supply a real provider client before relying on
+this route to generate labels.
 
-// Configure training
-let config = TrainingConfig::default()
-    .epochs(100)
-    .batch_size(32)
-    .learning_rate(0.001);
+## Lifecycle 2: train and register a model
 
-// Train
-let mut trainer = TrainingLoop::new(config)?;
-let metrics = trainer.train(&mut dataset)?;
+The generic training route starts at `Dataset`:
 
-println!("Final loss: {:.4}", metrics.final_train_loss);
+1. Construct or receive valid `TrainingExample` values.
+2. Choose eligibility and batch policy with `DatasetConfig`.
+3. Iterate the dataset by epoch, allowing the training loop to consume
+   `Batch` values.
+4. Keep the training configuration, metrics, and checkpoint state with the
+   trained artifact.
+5. Explicitly create a registry record with its metadata and weights.
+6. Use registry shadow or rollback facilities as an explicit deployment
+   workflow when appropriate.
+
+The training guide owns optimizer, callback, checkpoint, early-stopping, and
+GPU details. The registry guide owns status transitions, storage behavior,
+integrity, shadow traffic, and rollback details. This separation prevents
+training mechanics from defining deployment policy.
+
+The [model-registry ADR](ADR-002-model-registry.md) records why the registry
+keeps versioning and lineage. The retired crate-local
+[fine-tuning](adr/ADR-001-finetuning-pipeline.md),
+[callbacks](adr/ADR-005-training-callbacks.md), and
+[JIT adaptation](adr/ADR-006-jit-adaptation.md) ADR pointers lead to their
+maintained repository-wide counterparts.
+
+## Lifecycle 3: LoRA adapters
+
+LoRA adapters are a second training output, distinct from a generic registered
+student model:
+
+```text
+base model projections
+        │
+        ▼
+LoraConfig + LoraLayer / LoraAdapter
+        │
+        ├──► apply a low-rank delta during an inference projection
+        │
+        ├──► serialize or load adapter artifacts
+        │
+        └──► optional backward and online/router update paths
 ```
 
-### GPU training
+The core adapter representation and projection application live in
+[lora-core.md](lora-core.md). The router and online-update path is documented
+in [lora-router.md](lora-router.md); the safetensors, manifests, and artifact
+formats belong in [lora-io.md](lora-io.md). These documents should be read
+together when adding a target module or adapter format.
 
-With the `gpu` feature enabled, forward/backward passes and validation run on the GPU:
+The `inference-hook` feature is the narrow dependency bridge to
+`lattice-inference`: it enables the implementation of
+`lattice_inference::lora_hook::LoraHook` for `LoraAdapter`. Without that
+feature, the adapter remains a training-side type and `lattice-tune` does not
+need the inference crate for this path.
 
-```ignore
-use lattice_tune::train::{GpuTrainer, GpuTrainerBuilder, TrainingConfig};
-use lattice_fann::Activation;
+The LoRA representation decision is documented by the retired
+[ADR-004 pointer](adr/ADR-004-lora-adapter-management.md), which directs
+readers to the maintained root ADR.
 
-// Build GPU trainer
-let mut trainer = GpuTrainerBuilder::new(768, 6)
-    .hidden(64, Activation::ReLU)
-    .hidden(32, Activation::ReLU)
-    .config(TrainingConfig::default())
-    .build()?;
+## Features and dependency direction
 
-// Train batches
-for batch in dataset.batches() {
-    let loss = trainer.train_batch(&batch)?;
+`lattice-fann` is the required lower-level training dependency. The inference
+crate is optional and only enters through feature-gated adapter injection or
+backward training. That direction matters: training may consume inference
+capabilities, while inference remains usable without `lattice-tune`.
+
+| Feature | Adds or enables | Boundary it affects |
+| --- | --- | --- |
+| `std` | Standard-library support; enabled by default | Base crate |
+| `serde` | Serialization derives and JSON support | Data, config, checkpoints, metadata |
+| `safetensors` | Safe adapter/artifact serialization support | LoRA I/O |
+| `sqlite` | SQLite-backed registry storage; enabled by default | Registry |
+| `gpu` | WGPU-backed GPU training surface | Train |
+| `gpu-tests` | Hardware-dependent GPU tests | Train testing |
+| `inference-hook` | `LoraHook` implementation for `LoraAdapter` | LoRA → inference bridge |
+| `train-backward` | Inference backward/f16 support plus safetensors and serde | Exact-gradient LoRA binaries |
+| `mixture` | Experimental online adapter-selector refit | LoRA routing |
+
+Feature gates select integrations; they do not erase the ownership
+boundaries above. For example, enabling `safetensors` enables an artifact
+format but does not automatically register a saved adapter, and enabling
+`inference-hook` does not automatically attach an adapter to a running model.
+
+## Error boundary
+
+Every public subsystem can return the crate alias
+`Result<T> = std::result::Result<T, TuneError>`. `TuneError` keeps failures
+classified by the boundary that detected them:
+
+| Family | Examples |
+| --- | --- |
+| Data | Dataset errors, missing examples, invalid batches, dimensions |
+| Teacher | Provider failures and request timeouts |
+| Training | Training errors and non-convergence |
+| Configuration and validation | Invalid configuration or user/input validation |
+| Registry and storage | Missing/duplicate models and backing storage failures |
+| Artifact integrity | Serialization, I/O, weight checksum, and memory-budget failures |
+
+Callers should add context while preserving the variant whenever possible.
+This lets a UI or orchestration layer distinguish an invalid local data record
+from a teacher failure or a model-registry problem.
+
+## Exact-gradient LoRA command-line workflow
+
+The `train_grad`, `train_grad_layer23`, and `train_grad_full` executables are
+private training tools compiled only with `train-backward`. They share a
+minimal `train_common` module for JSONL loading, argument lookup, default
+paths, and an explicit trust-but-verify (TBV) gate. Their typed option parsing
+and usage strings remain intentionally local because their supported flags and
+defaults differ.
+
+### Shared JSONL samples
+
+The loader accepts one JSON object per nonempty line with string `prompt` and
+`completion` fields. It concatenates them, tokenizes the prompt and full text
+separately, and records the number of prompt tokens as `completion_start`:
+
+```text
+Sample {
+  tokens: tokenize(prompt + completion),
+  completion_start: tokenize(prompt).real_length,
 }
 ```
 
-`GpuTrainer::train_batch` currently returns `Err` for every optimizer choice — the
-GPU weight-update gap documented on `lattice_tune::train`'s module docs
-(<https://github.com/ohdearquant/lattice/issues/797>) — while `GpuTrainer::validate`
-(forward-only) works today.
+Rows with an empty or missing field, fewer than two full tokens, a full token
+length above `--seq-len`, an empty tokenized prompt, or no completion tokens
+after tokenization are skipped. Malformed nonempty JSON or I/O failures are
+returned as errors. Collection stops once `--max-train` or `--max-valid`
+accepted rows have been reached.
 
-## Registry walkthrough
+The default model directory is
+`$HOME/.lattice/models/qwen3.5-0.8b` (or `./.lattice/models/qwen3.5-0.8b` if
+`HOME` is absent). The default data directory is `data/lora-train`.
 
-```rust
-use lattice_tune::registry::{ModelRegistry, RegisteredModel, ModelMetadata};
+`ArgView` deliberately preserves the original permissive lookup behavior:
+the first matching value flag wins; a dangling or missing value returns
+`None`; presence flags are presence-only; and unknown flags are ignored. Each
+binary decides how to parse or reject the returned text.
 
-// Create a registry
-let registry = ModelRegistry::in_memory();
+### Trust but verify is fail-closed
 
-// Register a model
-let metadata = ModelMetadata::classifier(768, 6, 10000);
-let model = RegisteredModel::new("intent_classifier", "1.0.0")
-    .with_metadata(metadata)
-    .with_description("Intent classification model");
+Before a gradient binary trusts an assembled or cached chain, `verify_tbv`
+compares its masked negative log likelihood to the real model's
+`compute_token_nlls` result. The absolute difference must be at most
+`TBV_MAX_ABS_DIFF = 1e-2`. A non-finite reference, candidate, or difference,
+or a larger difference, returns an error; it is not merely a diagnostic.
 
-let weights = vec![0u8; 1000]; // Model weights
-let id = registry.register(model, &weights).unwrap();
+This gate is deliberately independent of local gradient checks. It catches a
+wrong forward assembly—such as a missing residual, norm convention, or layer
+handoff—before optimization can make its output appear plausible.
 
-// Retrieve the model
-let loaded = registry.get("intent_classifier", "1.0.0").unwrap();
-println!("Loaded: {}", loaded.full_name());
+### `train_grad_full` tape
+
+`train_grad_full` is the multi-layer exact reverse-mode LoRA trainer for
+Qwen3.5. It materializes the inclusive layer range
+`first_layer..=TOP_LAYER`, where `TOP_LAYER` is 23 and the default first layer
+is 19. The default range therefore covers a GQA LoRA layer at 19, frozen-base
+GatedDeltaNet layers at 20–22, and a GQA LoRA layer at 23. GDN base weights
+remain frozen while the command can maintain GDN LoRA slots.
+
+For each sample, it captures the frozen prefix output entering `first_layer`
+and caches RoPE tables. The materialized tape then follows:
+
+```text
+h = frozen prefix output
+for each materialized layer:
+    pre = rms_norm(h, pre_norm)
+    mixed = GQA(pre; LoRA) or GDN(pre; frozen base plus adapter slot)
+    h_mid = h + mixed
+    h = h_mid + swiglu(rms_norm(h_mid, post_norm))
+logits = lm_head · rms_norm(h, final_norm)
+loss = cross entropy over completion positions
 ```
 
-## Consuming the `inference-hook` bridge
+The loss gradient propagates backward through the head, every materialized
+FFN, mixer, residual, and norm. This is essential for a lower GQA layer: its
+adapter gradient is only meaningful if the reverse path crosses the
+intervening frozen GDN layers correctly.
 
-To inject a trained `LoraAdapter` into a running `lattice-inference` forward pass, enable
-the `inference-hook` feature. It pulls in `lattice-inference` and implements
-`lattice_inference::lora_hook::LoraHook` for `LoraAdapter`, so an adapter can be handed to
-the engine as a `Box<dyn LoraHook>`:
+Qwen3.5 layer and final RMSNorm are shifted:
+`x * inverse_rms * (1 + gamma)`. The command precomputes `1 + gamma` for
+those norms because the tape helpers accept plain gamma-like weights. GQA
+q/k-normalization stays raw because the GQA forward path applies its own
+shift internally.
 
-```toml
-[dependencies]
-lattice-tune = { version = "0.4.2", features = ["inference-hook"] }
-lattice-inference = "0.4.2" # provides the LoraHook trait
-```
+The command performs a zero-adapter TBV check before it trains or checks
+gradients. It also refuses a cache whose logits allocation would exceed 2 GiB,
+and uses `valid.jsonl` only for held-out evaluation when requested.
 
-```ignore
-use lattice_tune::lora::LoraAdapter;
-use lattice_inference::lora_hook::LoraHook;
+### Gradient validation
 
-let adapter: LoraAdapter = /* load via LoraAdapter::load_peft_safetensors(...) */;
-let hook: Box<dyn LoraHook> = Box::new(adapter);
-// hand `hook` to the inference engine; on each projection it calls
-// hook.apply(layer_idx, module, x, output)
-```
+`--gradcheck` uses nonzero random initialization for both A and B adapter
+matrices so the A gradient and GDN gate paths cannot pass vacuously. It probes
+both the largest-magnitude analytical gradients and deterministic strided
+indices that a top-k selection could overlook. Each selected entry is compared
+to central finite differences at `0.25×`, `0.5×`, `1×`, and `2×` of
+`--fd-eps`; it keeps the best relative difference to avoid judging a deep
+`f32` chain by a single roundoff- or truncation-dominated step. The default
+center is `4e-3` because the chain's observed roundoff makes much smaller
+central-difference steps unreliable.
 
-The trait path is `lattice_inference::lora_hook::LoraHook` (it is not re-exported at the
-inference crate root). Without the `inference-hook` feature, `LoraAdapter` is a pure
-training type and carries no dependency on `lattice-inference`.
+Normal training initializes A with small random values and B with zeros, so
+the initial delta reproduces the base model and B receives the first
+nonzero update. The command's usage text is the authority for exact option
+defaults, including model/data paths, layer range, steps, rank, alpha, sample
+limits, validation, saving, probes, and finite-difference epsilon.
 
-## Checkpoint serialization format
+## Reading order
 
-`Checkpoint` serializes to JSON when the `serde` feature is enabled:
+For a new implementation or integration:
 
-```json
-{
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "epoch": 10,
-  "global_step": 5000,
-  "metrics": {
-    "final_train_loss": 0.05,
-    "final_val_loss": 0.06,
-    "epochs_completed": 10,
-    "total_steps": 5000,
-    "best_epoch": 8,
-    "best_val_loss": 0.055
-  },
-  "created_at": "2024-01-15T10:30:00Z",
-  "weights": "<base64-encoded bytes>",
-  "optimizer_state": "<base64-encoded bytes>"
-}
-```
-
-| Field             | Type            | Description                                      |
-| ----------------- | ---------------- | ------------------------------------------------ |
-| `id`              | UUID v4          | Unique identifier for this checkpoint            |
-| `epoch`           | usize            | Training epoch when created (0-indexed)          |
-| `global_step`     | usize            | Total batches processed                          |
-| `metrics`         | TrainingMetrics  | Training statistics at checkpoint time           |
-| `created_at`      | ISO 8601         | UTC timestamp of creation                        |
-| `weights`         | bytes            | Serialized model parameters (byte layout below)  |
-| `optimizer_state` | bytes            | Serialized optimizer momentum/state (below)      |
-
-The byte-level layout of `weights` and `optimizer_state` is the load-bearing part of this
-format and stays on `Checkpoint` itself in `src/train/loop/checkpoint.rs`, so a consumer
-parsing the raw bytes has it without a docs/ round-trip:
-
-- `weights`: little-endian `f32` values, concatenated layer-by-layer (each layer's weight
-  matrix in row-major order, then its biases; input-to-output order across layers). For a
-  network with layers `[4->8, 8->2]`: `[layer0_weights: 32 floats][layer0_biases: 8
-  floats][layer1_weights: 16 floats][layer1_biases: 2 floats]`.
-- `optimizer_state`: SGD-with-momentum stores one velocity vector per parameter; Adam
-  stores first (`m`) and second (`v`) moment vectors per parameter.
-
-### Loading a checkpoint
-
-```ignore
-use lattice_tune::Checkpoint;
-
-// Load from JSON file
-let json = std::fs::read_to_string("checkpoint_epoch_10.json")?;
-let checkpoint: Checkpoint = serde_json::from_str(&json)?;
-
-// Restore model weights
-model.load_weights(&checkpoint.weights);
-optimizer.load_state(&checkpoint.optimizer_state);
-```
-
-### Naming convention
-
-Recommended file naming: `checkpoint_epoch_{epoch:04d}_step_{step:08d}.json` — for
-example, `checkpoint_epoch_0010_step_00005000.json`.
-
-## Feature flags
-
-- `std` (default): standard library support.
-- `serde`: serialization support for all types, including `Checkpoint`.
-- `gpu`: GPU-accelerated training via `GpuTrainer`.
-- `inference-hook`: implements `lattice_inference::lora_hook::LoraHook` for `LoraAdapter`,
-  so a trained adapter can be handed straight to `lattice-inference` as a `Box<dyn LoraHook>`.
+1. Start with [data.md](data.md) for the cross-subsystem record contract.
+2. Read [distill.md](distill.md) if labels come from a teacher.
+3. Read [train.md](train.md) for generic training execution and checkpoints.
+4. Choose the appropriate LoRA guide for adapters and inference integration.
+5. Read [registry.md](registry.md) before persisting or deploying a trained
+   model.
+6. Consult the linked ADRs when changing a boundary or revisiting an accepted
+   design decision.

--- a/crates/tune/docs/distill.md
+++ b/crates/tune/docs/distill.md
@@ -1,0 +1,340 @@
+# Distillation
+
+The `distill` module is the boundary between conversational source material and
+the embedding-based `TrainingExample` values used by the rest of
+`lattice-tune`. It has three responsibilities:
+
+1. describe a teacher and the endpoint policy that constrains it;
+2. turn a `RawExample` into a bounded, sanitized prompt and record a labeling
+   result; and
+3. join successful labels with embeddings supplied by the caller.
+
+The module intentionally does not create embeddings. It also does **not**
+currently issue HTTP requests: `DistillationPipeline::label_single` formats a
+prompt but then returns a simulated label distribution. The configuration and
+result types define the intended integration boundary; callers must not treat
+the current pipeline as a live teacher client.
+
+For the provider-selection decision and its alternatives, see
+[ADR-001: Multi-Provider Teacher Strategy](ADR-001-teacher-providers.md). The
+retired crate-local distillation ADR points to its maintained counterpart in
+the repository-wide ADR series.
+
+## End-to-end flow
+
+```text
+Raw text
+  │
+  ▼
+RawExample ──sanitize + format──► teacher prompt
+  │                                  │
+  │                                  └── current implementation: simulated result
+  ▼
+LabelingResult ──successful only──► caller-provided embeddings
+                                         │
+                                         ▼
+                                  TrainingExample
+                                         │
+                                         ▼
+                                      Dataset / train
+```
+
+A `RawExample` has an ID, chronological context strings, one current message,
+and optional metadata. A labeling result preserves the raw ID, so the caller
+can align label results with its independently generated context and message
+embeddings. `to_training_examples` constructs the training records only after
+that alignment has been supplied.
+
+## Teacher configuration
+
+`TeacherConfig` makes the teacher selection, request policy, prompt, and
+endpoint controls explicit. It derives serialization only with the `serde`
+feature.
+
+| Field | Meaning | Validation or behavior |
+| --- | --- | --- |
+| `provider` | `Claude`, `OpenAI`, `Gemini`, `Local`, or `Custom(String)` | Controls default endpoint and display name. |
+| `model_id` | Provider-specific model identifier | Must not be empty. |
+| `endpoint` | Optional custom base endpoint | When absent, `get_endpoint` chooses a provider default. A custom endpoint is checked by `validate`. |
+| `api_key_env` | Environment-variable name for credentials | Configuration only; the current pipeline never reads it. |
+| `temperature` | Generation temperature | Must lie in `0.0..=2.0`. |
+| `max_tokens` | Response-token budget | Must be nonzero. |
+| `timeout_ms` | Per-request timeout | Must be nonzero. |
+| `max_retries` / `retry_delay_ms` | Retry policy | Stored for a future client; currently not executed. |
+| `system_prompt` | Optional classification instruction | Presets use the built-in intent-classification prompt; the builder can replace or clear it. |
+| `security` | `EndpointSecurity` policy | Validates a custom endpoint during `validate`. |
+
+### Provider defaults and presets
+
+The default configuration is `TeacherConfig::claude_sonnet()`. The convenience
+constructors select the following values:
+
+| Constructor | Provider | Model ID | Endpoint | Key variable | Timeout | Retries / delay |
+| --- | --- | --- | --- | --- | ---: | --- |
+| `claude_sonnet()` | Claude | `claude-sonnet-4-20250514` | Claude default | `ANTHROPIC_API_KEY` | 30 s | 3 / 1 s |
+| `claude_haiku()` | Claude | `claude-3-5-haiku-20241022` | Claude default | `ANTHROPIC_API_KEY` | 15 s | 3 / 500 ms |
+| `gpt4()` | OpenAI | `gpt-4-turbo-preview` | OpenAI default | `OPENAI_API_KEY` | 30 s | 3 / 1 s |
+| `gemini_pro()` | Gemini | `gemini-pro` | Gemini default | `GOOGLE_API_KEY` | 30 s | 3 / 1 s |
+| `local(model, endpoint)` | Local | Caller supplied | Caller supplied | empty | 60 s | 2 / 500 ms |
+
+All presets use temperature `0.3`, a 1,024-token response budget, the default
+system prompt, and a security preset appropriate to a remote or local
+endpoint. The endpoint defaults returned by `get_endpoint` are:
+
+| Provider | Default endpoint |
+| --- | --- |
+| Claude | `https://api.anthropic.com/v1` |
+| OpenAI | `https://api.openai.com/v1` |
+| Gemini | `https://generativelanguage.googleapis.com/v1` |
+| Local | `http://localhost:11434` |
+| Custom | empty string |
+
+`TeacherProvider` displays as `claude`, `openai`, `gemini`, `local`, or
+`custom:<name>`. `TeacherConfig::display_name` combines that display form with
+the model ID as `provider:model_id`; the pipeline saves this value in example
+metadata.
+
+### The builder
+
+`TeacherConfig::builder()` starts from the Sonnet preset. Its setters replace
+individual fields and `build()` returns the resulting configuration without
+validating it. Validate before creating a connection or pass the value to
+`DistillationPipeline::new`, which validates it itself.
+
+```rust,ignore
+use lattice_tune::distill::{
+    DistillationConfig, DistillationPipeline, EndpointSecurity, TeacherConfig,
+    TeacherProvider,
+};
+
+let teacher = TeacherConfig::builder()
+    .provider(TeacherProvider::Local)
+    .model_id("my-local-teacher")
+    .endpoint("http://localhost:11434")
+    .security(EndpointSecurity::for_local())
+    .max_tokens(1_024)
+    .build();
+
+teacher.validate()?;
+let pipeline = DistillationPipeline::new(teacher, DistillationConfig::default())?;
+```
+
+The default system prompt asks for a JSON object with six intent scores:
+`continuation`, `topic_shift`, `explicit_query`, `person_lookup`,
+`health_check`, and `task_status`. It asks scores to sum approximately to one
+and asks the teacher to return JSON only. There is no response parser yet, so
+this is a contract for a future teacher-client implementation rather than a
+live parsing guarantee.
+
+## Endpoint security policy
+
+`EndpointSecurity` expresses endpoint policy independently of a concrete HTTP
+client:
+
+| Control | Purpose | What the current code checks |
+| --- | --- | --- |
+| `require_tls` | Disallow non-HTTPS remote endpoints | `verify_endpoint` rejects endpoints whose lowercased string does not start with `https://`. |
+| `allowed_domains` | Host allowlist | The extracted host must exactly equal one configured domain. |
+| `expected_cert_fingerprint` | Expected SHA-256 certificate fingerprint | `validate_cert_fingerprint` checks only that the configured value has 64 ASCII-hex characters. |
+| `model_checksum` | Expected checksum for local weights | `verify_model_checksum` compares an actual checksum provided by its caller. |
+
+`EndpointSecurity::default_secure()` requires TLS and allows only
+`api.anthropic.com`, `api.openai.com`, and
+`generativelanguage.googleapis.com`. `EndpointSecurity::for_local()` does not
+require TLS and allows only `localhost` and `127.0.0.1`. `allow_domain` appends
+to the allowlist, while `with_cert_fingerprint` and `with_model_checksum` set
+the corresponding optional expectations.
+
+### What verification does and does not do
+
+`TeacherConfig::validate` checks model ID, temperature, response budget, and
+timeout. It applies `security.verify_endpoint` only when an explicit custom
+endpoint is present. `TeacherConfig::verify_endpoint` resolves either a custom
+or provider-default endpoint, applies the endpoint policy, and validates the
+*format* of a configured certificate fingerprint.
+
+Neither method opens a network connection. In particular, certificate
+fingerprint comparison must happen in the future HTTP/TLS client after it has
+the peer certificate; the empty value passed by `verify_endpoint` is not an
+actual certificate fingerprint. Similarly, local weight checking occurs only
+when an integration calls `verify_model_checksum` with a computed value.
+Creating a `DistillationPipeline` calls `validate`, not
+`verify_endpoint`.
+
+The current host extraction is deliberately simple: it removes a lowercase
+`http://` or `https://` prefix, takes the text before the next slash, then
+drops a port. It is policy input validation, not a general URL parser. Supply
+a lowercase scheme and canonical lowercase endpoint host when using an
+allowlist.
+
+## Raw examples and prompt bounds
+
+`RawExample` is the pre-embedding input:
+
+```rust
+pub struct RawExample {
+    pub id: Uuid,
+    pub context: Vec<String>,      // oldest to newest
+    pub message: String,           // item to classify
+    pub metadata: Option<ExampleMetadata>,
+}
+```
+
+`new` assigns a fresh UUID; `with_id` preserves a caller-controlled one; and
+`with_metadata` attaches optional source information. The pipeline uses the ID
+for result correlation but does not currently copy `RawExample::metadata` into
+the resulting training example.
+
+### Prompt layout
+
+For nonempty context, `to_prompt` emits:
+
+```text
+Context (previous messages):
+1. <oldest sanitized message>
+2. <next sanitized message>
+
+Current message to classify:
+<sanitized current message>
+```
+
+The formatter applies the same sanitization to each context item and to the
+current message:
+
+1. It limits an individual input to `MAX_MESSAGE_LENGTH` (10,000 bytes),
+   stopping at a UTF-8 character boundary.
+2. It removes control characters except newline, tab, and carriage return.
+3. After assembling the labeled prompt, it truncates the content to
+   `MAX_PROMPT_LENGTH` (50,000 bytes) and appends `\n[truncated]` when the
+   limit was exceeded. The marker is appended after truncation, so the final
+   output includes the marker in addition to the capped content.
+
+The limits prevent unbounded prompt construction before an eventual network
+request. They do not interpret user text or provide a semantic defense against
+prompt injection; the context and current message remain teacher-visible
+content. Treat the resulting text as untrusted data when implementing a
+provider client.
+
+## Pipeline configuration
+
+`DistillationConfig` controls the labeling policy. Its default is a batch size
+of 10, concurrency of 5, softmax normalization enabled, no confidence
+threshold, no intermediate persistence, and a progress interval of 100.
+
+| Field | Default | Current use |
+| --- | ---: | --- |
+| `batch_size` | 10 | Validated nonzero; not used to schedule the synchronous loop. |
+| `concurrency` | 5 | Validated nonzero; not used to run parallel requests yet. |
+| `normalize_labels` | true | Applies `IntentLabels::softmax_normalize` to the simulated scores. |
+| `min_confidence` | none | Rejects a result whose confidence is below the threshold. |
+| `save_intermediate` | false | Stored only. |
+| `output_dir` | none | `output_dir(...)` sets this and enables `save_intermediate`; no files are written yet. |
+| `progress_interval` | 100 | Stored only. |
+
+`fast()` selects a 20-item batch, concurrency 10, and progress every 50
+examples. `quality()` selects a 5-item batch, concurrency 3, a `0.5` minimum
+confidence, intermediate persistence enabled, and progress every 20 examples.
+Both keep normalization enabled. Validation requires nonzero batch size and
+concurrency; when present, the confidence threshold must lie in `0.0..=1.0`.
+
+## Labeling behavior and accounting
+
+### A single item
+
+`DistillationPipeline::new` validates both the teacher and pipeline
+configuration, then starts with empty `DistillationStats`. `with_teacher` uses
+the default pipeline configuration. `label_single`:
+
+1. starts a latency timer and formats the raw prompt;
+2. currently creates fixed scores
+   `[0.4, 0.1, 0.3, 0.1, 0.05, 0.05]` instead of invoking a provider;
+3. applies softmax if requested;
+4. assigns a simulated confidence of `0.85`;
+5. rejects scores below `min_confidence`, when configured; otherwise records
+   a successful `LabelingResult` and updates statistics.
+
+Therefore, a threshold above `0.85` causes the current placeholder to return
+`TuneError::Validation`. On that direct error path the pipeline increments
+`stats.skipped` but does not increment `total_processed`; `label_batch` turns
+the error into a failed result and supplies that second accounting update.
+
+### A batch
+
+`label_batch` processes inputs synchronously in input order. It returns one
+`LabelingResult` per raw input, including failures. An error from
+`label_single` becomes `LabelingResult::failure(raw.id, error, 0)` and is
+included in the statistics. Failed results carry default all-zero labels,
+zero confidence, no raw response, and the error string. The optional raw
+response is currently populated only if code constructs a result with
+`with_raw_response`.
+
+### Statistics
+
+`DistillationStats::update` is the one normal result-accounting path:
+
+- It increments `total_processed` and adds latency for every result.
+- Success increments `successful` and updates average confidence using only
+  successful items.
+- Failure increments `failed`.
+- Average latency is total latency divided by every processed item, including
+  failures.
+- On the first success, `label_distribution` becomes six zero counters. Each
+  successful result increments the counter for its dominant intent; it is not
+  a sum of soft probabilities.
+
+`success_rate()` is `successful / total_processed` and returns `0.0` for an
+empty statistics value. `reset_stats()` discards all accumulated counts and
+averages. `skipped` is a separate counter for confidence-threshold rejects;
+when a reject flows through `label_batch` it is also represented as a failure.
+
+## Converting labels to training data
+
+`to_training_examples` accepts parallel slices of results, context embedding
+matrices, and current-message embeddings. All three slices must have the same
+length. The method checks results against each embedding slice, but the
+dimension-mismatch error reports the context slice's length even when the
+message slice is the mismatched input.
+
+For each successful result it constructs:
+
+```text
+TrainingExample {
+  id: result.example_id,
+  context_embeddings: caller-provided context_embeddings[i],
+  message_embedding: caller-provided message_embeddings[i],
+  labels: result.labels,
+  metadata: {
+    source_id: result.example_id as text,
+    teacher_model: teacher.display_name(),
+    labeled_at: current UTC time,
+    teacher_confidence: result.confidence,
+  },
+}
+```
+
+Failures are skipped, so output length can be smaller than input length. The
+method does not validate embedding shapes or label ranges; validate the
+resulting `TrainingExample` values before handing them to a training consumer
+that requires those guarantees. See [data.md](data.md) for that format and
+validation contract.
+
+## Implementing a live teacher client
+
+A provider implementation should preserve the public contracts above while
+filling in the missing network step:
+
+1. validate the configuration and resolve the effective endpoint;
+2. enforce endpoint policy before connection, then perform real TLS
+   verification and any configured certificate pin comparison in the client;
+3. obtain credentials from the configured environment variable without
+   including their value in results, errors, or logs;
+4. send the system prompt and bounded `RawExample::to_prompt` output;
+5. apply timeout and retry settings with provider-specific error handling;
+6. parse the teacher response into the fixed `IntentLabels` order, reject
+   malformed or non-finite scores, and preserve an optional raw response only
+   when its retention is appropriate; and
+7. route every terminal outcome through the established statistics rules.
+
+The provider client should remain an implementation detail of `distill`. The
+embedding and student-training concerns stay outside this module, connected
+only through the data types documented here and in [data.md](data.md).

--- a/crates/tune/docs/lora-core.md
+++ b/crates/tune/docs/lora-core.md
@@ -1,0 +1,442 @@
+# LoRA Training Core
+
+`lattice-tune` represents a LoRA adapter as a set of small, per-projection
+weight updates. The same representation supports three different operations:
+
+- applying an adapter during inference;
+- fitting an adapter with the exact CPU backward tape or a one-event SGD refit;
+- combining adapters or admitting them through a governed manifest.
+
+This document describes the core behavior implemented by `lora/mod.rs`,
+`train_core.rs`, `train.rs`, `optimizer.rs`, `blend.rs`, `online.rs`, and
+`manifest.rs`. Safetensors parsing and manifest loading are separate modules,
+but their externally visible validation rules are included where they define
+the core contract.
+
+## Adapter representation and inference
+
+For a base linear projection with input width `d_in` and output width `d_out`,
+a `LoraLayer` stores two row-major `f32` matrices:
+
+| Matrix | Logical shape | Flat storage | Role |
+| --- | --- | --- | --- |
+| `A` | `(rank, d_in)` | `rank * d_in` values | Projects the activation into the low-rank space. |
+| `B` | `(d_out, rank)` | `d_out * rank` values | Projects the low-rank activation back to output width. |
+
+With adapter configuration `(rank, alpha)`, inference adds the following
+update to the base projection output:
+
+```text
+scale = alpha / rank
+h     = A @ x
+output += scale * (B @ h)
+```
+
+The update is additive: the base projection remains responsible for producing
+`output`, and LoRA only adds its correction. `LoraAdapter::apply` identifies a
+layer by `(transformer_layer_index, module_name)`. A missing key is a no-op,
+which allows a partial adapter to coexist with a model that has many more
+projections.
+
+`LoraConfig::scale()` deliberately returns `0.0` when `rank == 0`, and also
+returns `0.0` for non-finite alpha or derived scale. Construction through
+`LoraAdapter::new` validates that alpha and its effective scale are finite.
+The micro trainer is stricter and rejects rank zero before allocating or
+running the tape.
+
+The adapter layer itself is intentionally model-neutral. Typical target names
+are:
+
+| Model family | Attention targets | Feed-forward targets |
+| --- | --- | --- |
+| Qwen-style transformer | `q_proj`, `k_proj`, `v_proj`, `o_proj` | `gate_proj`, `up_proj`, `down_proj` |
+| BERT or cross-encoder | `query`, `key`, `value`, `attn_output` | `ffn_intermediate`, `ffn_output` |
+
+When the `inference-hook` feature is available, `validate_against` checks a
+Qwen3.5 adapter before installation. It verifies every layer index and each
+adapted projection's input and output width. This is the point to reject a
+model/adapter shape mismatch before generation, rather than discovering it in
+a projection call.
+
+## Exact micro-LoRA training
+
+The `train-backward` feature exposes `train_micro_lora`, a compact CPU trainer
+for tokenized prompt/completion pairs. It is intended for a bounded suffix of a
+Qwen3.5 model, not for the crate's general dataset and training facilities.
+
+### Input contract
+
+A `TrainingPair` contains the complete token sequence and the index where the
+completion begins. For a pair of length `L`, supervised next-token positions
+are:
+
+```text
+completion_start - 1 ..= L - 2
+```
+
+At position `t`, the model predicts `tokens[t + 1]`. This makes the prompt's
+last token the context for the first completion token.
+
+`MicroLoraConfig` has these defaults:
+
+| Field | Default | Meaning |
+| --- | ---: | --- |
+| `rank` | `4` | Low-rank dimension for each trained projection. |
+| `alpha` | `8.0` | LoRA alpha; execution scale is `alpha / rank`. |
+| `first_layer` | `19` | First model layer included in the materialized suffix. |
+| `steps` | `25` | Number of Adam updates. |
+| `learning_rate` | `1e-3` | Adam learning rate. |
+| `max_seq_len` | `64` | Per-pair sequence length ceiling. |
+
+The trainer fails before model access when any caller-controlled condition
+would make tape indexing or allocation unsafe:
+
+- there must be at least one pair, and every pair needs at least two tokens;
+- every pair must fit `max_seq_len`, and every token ID must be below the
+  model vocabulary size;
+- `completion_start` must be in `1..tokens.len()`;
+- rank must be in `1..=512`;
+- steps must be at most `100_000`, and `max_seq_len` at most `8_192`;
+- `first_layer` must not exceed `TOP_LAYER` (`23`), and the model must contain
+  at least 24 layers because the loop indexes the inclusive range through 23.
+
+The rank, step, and sequence caps are allocation and runtime safety bounds,
+not recommendations for model quality. The model's own context window remains
+an independent limit.
+
+### Materialized suffix and slot layout
+
+The model runs the prefix before `first_layer` through its normal frozen
+forward path. For each pair, the trainer captures the hidden state entering
+`first_layer` and obtains the RoPE cosine and sine tables for that sequence.
+It then materializes layers `first_layer..=23` as a tape.
+
+Each materialized layer is classified as one of two mixer kinds:
+
+- **GQA** layers receive a LoRA slot in the public micro-training path. The
+  resulting adapter contains `q_proj` and `v_proj` layers for every such slot.
+- **GatedDeltaNet (GDN)** layers are included in the forward and backward path
+  so their derivatives reach earlier GQA layers, but `train_micro_lora` gives
+  them no LoRA slots. They are frozen in this public helper.
+
+The tape uses an explicit GQA-slot and GDN-slot layout rather than assuming a
+slot number equals a model layer number. `TrainCtx::try_new` rejects duplicate
+slot entries, indices outside the model, a GQA slot placed on a GDN layer, a
+GDN slot placed on a GQA layer, and a layer claimed by both layouts. This keeps
+the weight vectors, cache selection, and optimizer keys aligned.
+
+### Initialization
+
+Every GQA slot contains parameters for both `q_proj` and `v_proj`:
+
+| Projection | A shape | B shape |
+| --- | --- | --- |
+| `q_proj` | `(rank, hidden)` | `(2 * q_dim, rank)` |
+| `v_proj` | `(rank, hidden)` | `(kv_dim, rank)` |
+
+The trainer initializes A with a deterministic uniform sample in
+`[-1 / sqrt(hidden), +1 / sqrt(hidden)]` and initializes B to zero. Zero B
+makes the initial adapter contribution exactly zero, preserving the frozen
+model's forward behavior at the first step. Consequently the first update can
+move B while A's gradient is initially zero; later steps update both factors.
+
+All rank-by-dimension products are checked before the parameter vectors are
+allocated. The same checked arithmetic is used by the tape's gradient buffers.
+
+### Forward pass
+
+For each materialized layer, the tape records the intermediates required by
+reverse mode:
+
+```text
+h_layer_in = h
+normed_pre, inv_pre = RMSNorm(h_layer_in, pre_shift)
+mixer_out, mixer_cache = GQA-or-GDN mixer(normed_pre, optional LoRA)
+h_mid = h_layer_in + mixer_out
+normed_ffn, inv_ffn = RMSNorm(h_mid, post_shift)
+ffn_out, gate_pre, up_pre = SwiGLU(normed_ffn)
+h = h_mid + ffn_out
+```
+
+For GQA, the mixer receives A/B for Q and V together with the rank and
+`alpha / rank` scale. For a GDN layer without a LoRA slot, the same saved
+forward path is used with no LoRA matrices and a rank/scale of zero. Thus the
+backward tape always has the mixer state it needs, irrespective of whether the
+mixer itself is being adapted.
+
+At every supervised position, the tape applies final RMSNorm, computes logits
+with the language-model head, and stores the logits, target token, position,
+and final normalization inverse. `eval_chain_nll` reports mean NLL across all
+supervised positions in a cache set. `nll_and_grads` returns the summed NLL and
+the count of supervised positions, while normalizing each logit derivative by
+the number of positions in that sequence.
+
+### Reverse pass
+
+For one target token, the loss is negative log likelihood. The logit derivative
+is the usual softmax probability minus the one-hot target, divided by the
+number of supervised positions. The tape then propagates through the language
+model head and final RMSNorm into the final hidden state.
+
+Layers are processed in reverse order. At each layer, the derivative first
+passes through the SwiGLU feed-forward branch and post-mixer RMSNorm, then
+through the saved GQA or GDN mixer, and finally through pre-mixer RMSNorm. The
+residual derivative is added at both residual joins. GQA mixer backpropagation
+fills the slot's Q/V LoRA gradients; a GDN slot, when used by a lower-level
+caller, yields gradients for all five of its LoRA projections.
+
+The optional GDN parameter container has ten arrays per slot:
+
+| Projection | A shape | B shape |
+| --- | --- | --- |
+| `in_proj_qkv` | `(rank, hidden)` | `(qkv_dim, rank)` |
+| `in_proj_z` | `(rank, hidden)` | `(output_dim, rank)` |
+| `in_proj_b` (beta) | `(rank, hidden)` | `(value_heads, rank)` |
+| `in_proj_a` (alpha) | `(rank, hidden)` | `(value_heads, rank)` |
+| `out_proj` | `(rank, output_dim)` | `(hidden, rank)` |
+
+The beta and alpha B matrices are indexed by **value heads**, not key heads.
+That shape must agree with the shipping GDN forward implementation and its
+weight loader; using `num_kh` is incorrect for models whose key and value head
+counts differ.
+
+### Validated tape context
+
+`TrainCtx` is the immutable agreement shared by forward, evaluation, reverse,
+and optimizer entry points. It owns references to geometry and slot layout plus
+the derived execution values and Adam policy; it does not own weights, caches,
+gradients, LoRA vectors, or optimizer state.
+
+Its constructor accepts `alpha` but stores only `rank` and the derived
+`alpha / rank` scale. It rejects zero rank and non-finite alpha, learning rate,
+beta values, epsilon, RMSNorm epsilon, or GDN attention scale. It also checks
+that every `Dims` and `GdnDims` field was derived from the same model
+configuration, including RMSNorm epsilon and the GDN scale. This avoids a
+seemingly valid tape whose flattened dimensions describe a different model.
+
+## Adam updates
+
+`AdamState` stores first moments `m`, second moments `v`, and an update counter
+`t` in maps keyed by parameter name. A key is expected to identify one stable
+parameter tensor and shape for its lifetime. The training tape names GQA arrays
+by model layer and factor (`l{layer}_a_q`, `l{layer}_b_q`, `l{layer}_a_v`, and
+`l{layer}_b_v`); GDN arrays use analogous projection-specific names.
+
+The update for an element uses:
+
+```text
+m_t = beta1 * m_(t-1) + (1 - beta1) * g_t
+v_t = beta2 * v_(t-1) + (1 - beta2) * g_t^2
+m_hat = m_t / (1 - beta1^t)
+v_hat = v_t / (1 - beta2^t)
+theta -= learning_rate * m_hat / (sqrt(v_hat) + epsilon)
+```
+
+The timestep is per key, not global. One logical LoRA optimization round calls
+`step` for several A and B tensors; a global counter would cause tensors later
+in that round to use a larger bias-correction exponent than their actual number
+of updates. With decoupled weight decay selected, the implementation first
+applies `theta -= learning_rate * weight_decay * theta`, then takes the Adam
+gradient step. Otherwise it performs standard Adam and ignores `weight_decay`.
+
+The micro trainer uses Adam with beta values `0.9` and `0.999`, epsilon `1e-8`,
+zero weight decay, and no decoupling. It cycles deterministically through the
+provided pairs: training step `s` uses pair `(s - 1) % pairs.len()`.
+
+## Single-event online refit
+
+`adapt_step` is the smaller alternative to the full token-level tape. It fits
+one existing `LoraLayer` to a desired output correction for a single input
+activation. It is useful only when the caller already has an activation and a
+target LoRA delta for one projection; it does not run the transformer.
+
+With `scale = alpha / rank`, it minimizes the unnormalized squared error:
+
+```text
+h        = A @ input
+delta    = scale * B @ h
+residual = delta - target_delta
+loss     = sum(residual^2)
+```
+
+The exact derivatives are:
+
+```text
+dL/dB[i, r] = 2 * scale * residual[i] * h[r]
+dL/dA[r, j] = 2 * scale * (B^T @ residual)[r] * input[j]
+```
+
+`adapt_step` computes both gradient matrices, reports the loss and the
+Euclidean norm of their concatenation, and applies in-place SGD updates to B
+and A. `compute_lora_gradients` performs the same arithmetic but returns the
+raw `LoraGradients` without mutating the adapter, which makes it suitable for
+inspection or for a different optimizer.
+
+Both entry points reject a missing `(layer_idx, module)` as `TuneError::Training`
+and reject input or target slices whose lengths differ from `d_in` or `d_out`.
+The local APIs do not impose a policy on learning rate or activation values;
+callers that require finite-value or step-size checks must apply that policy
+before calling them.
+
+## Exact adapter blending
+
+Some inference paths consume one adapter slot. `blend_lora_adapters` converts a
+weighted collection of adapters into a standard single adapter on the CPU, so
+the consumer need not dispatch one kernel per source adapter.
+
+For source adapter `e`, let `s_e = alpha_e / rank_e` and let `w_e` be its
+mixture weight. Its contribution is:
+
+```text
+Delta_e(x) = s_e * B_e @ (A_e @ x)
+```
+
+For a particular `(layer_idx, module)` group, the blend is exact, not a
+low-rank approximation of the weighted sum:
+
+```text
+A_blend = vertical_concat(A_1, ..., A_N)
+B_blend = horizontal_concat((w_1 * s_1) * B_1, ..., (w_N * s_N) * B_N)
+
+B_blend @ (A_blend @ x) = sum_e w_e * Delta_e(x)
+```
+
+The result's A shape is `(sum_e rank_e, d_in)` and its B shape is
+`(d_out, sum_e rank_e)`. The mixture coefficient and each source scale are
+folded into B exactly once. The returned adapter uses `alpha == rank` and
+therefore a configuration scale of one.
+
+Grouping happens independently for every projection key in the union of source
+keys. A source that lacks a key contributes nothing to that group. As a result,
+different groups can have different layer ranks. The adapter-level `rank` is
+the largest blended layer rank, but its matching alpha keeps the common adapter
+scale at one for every group. A zero mixture weight is allowed; it still takes
+part in the concatenation and consumes rank and allocation budget.
+
+Before allocating, blending rejects:
+
+- an empty adapter collection or a non-finite mixture weight;
+- adapters that share a projection but disagree on `d_in` or `d_out`;
+- a source A/B buffer that does not match its declared row-major shape;
+- integer overflow in rank or size arithmetic;
+- a summed rank above `MAX_BLEND_RANK_TOTAL` (`4096`) for one projection; or
+- total planned elements above `MAX_BLEND_TOTAL_ELEMENTS` (`1 << 30`, about
+  4 GiB of `f32` storage) across all projection groups.
+
+The aggregate limit matters independently of the per-projection rank cap: a
+large adapter can have many individually permitted projections whose combined
+allocation is not acceptable.
+
+## Manifest schema and governed loading
+
+The serde-gated `LoraManifest` is a JSON document with a `version` and an
+unordered list of adapter entries. `LoraManifest::new()` creates version 1.
+Deserialization preserves the supplied `version` rather than enforcing it, so
+callers that need a strict schema-version gate should check the field after
+parsing.
+
+Each `ManifestEntry` requires these fields:
+
+| Field | Meaning | Enforced by governed load? |
+| --- | --- | --- |
+| `id` | Opaque adapter ID; a UUID is conventional. | Yes, if the safetensors header has `adapter_id`. |
+| `name` | Human-readable identifier. | Provenance only. |
+| `owner` | Responsible team or person. | Provenance only. |
+| `uri` | Relative path to the adapter file. | Yes; must remain under the supplied base directory. |
+| `integrity_sha256` | SHA-256 of the complete adapter file. | Yes. |
+| `base_model_rev` | Base model revision used for training, or `"none"`. | Yes when running revisions are supplied. |
+| `tokenizer_rev` | Tokenizer revision used for training, or `"none"`. | Yes when running revisions are supplied. |
+| `rank` | Adapter's LoRA rank. | Yes; must equal the parsed adapter rank. |
+| `alpha` | Adapter's LoRA alpha. | Yes; compared with `1e-4` tolerance. |
+| `target_modules` | Declared module allow-list. | Yes; actual adapter modules must be a subset. |
+| `dtype` | Training/save dtype label. | Provenance only; tensor parsing validates real data separately. |
+| `status` | `approved`, `quarantined`, or `revoked`. | Yes; only `approved` is allowed. |
+
+For example:
+
+```json
+{
+  "version": 1,
+  "adapters": [
+    {
+      "id": "support-v1",
+      "name": "Support terminology",
+      "owner": "search-team",
+      "uri": "adapters/support-v1.safetensors",
+      "integrity_sha256": "<sha256 of complete file>",
+      "base_model_rev": "abc123",
+      "tokenizer_rev": "def456",
+      "rank": 8,
+      "alpha": 16.0,
+      "target_modules": ["q_proj", "v_proj"],
+      "dtype": "f32",
+      "status": "approved"
+    }
+  ]
+}
+```
+
+`status` is intentionally the only approval field. `approved` is represented
+by `status == "approved"`; a parallel boolean could disagree with the richer
+`quarantined` and `revoked` states. Serde uses these lowercase snake-case
+strings and rejects an unknown status value.
+
+### Manifest I/O boundary
+
+Manifest JSON is expected to be small. `LoraManifest::load` caps its on-disk
+size at 64 MiB: it first rejects an oversized metadata length, then reads at
+most 64 MiB plus one sentinel byte so a file that grows after the metadata
+check also fails. It rejects non-UTF-8 content before JSON parsing. This avoids
+materializing an attacker-controlled multi-gigabyte document merely to learn
+that it is not a manifest.
+
+`to_json` emits pretty JSON and `save` writes that UTF-8 representation. A
+parse or serialization error is reported as a serialization error; filesystem
+and bounded-read failures are I/O or validation errors as appropriate.
+
+### Fail-closed admission sequence
+
+The manifest-driven loader accepts a vector only if every entry passes every
+applicable check. It has no partial-success or silent-skip path. Before opening
+any adapter file, it pre-scans all entries: one `quarantined` or `revoked`
+entry rejects the entire request and prevents file I/O for otherwise approved
+entries.
+
+For every approved entry, the loader then performs these ordered checks:
+
+1. Recheck that the status is approved.
+2. Resolve `uri` below the caller's base directory. Absolute paths and `..`
+   components are rejected, and canonical base and target paths prove that a
+   symlink cannot escape the base directory.
+3. Require the target to exist and be readable as part of canonicalization and
+   the bounded file read.
+4. Read the bounded adapter bytes and require their SHA-256 to equal
+   `integrity_sha256`.
+5. Parse those bytes as a valid PEFT LoRA adapter.
+6. Require the parsed rank to equal manifest `rank`.
+7. Require parsed alpha to equal manifest `alpha` within `1e-4`; this also
+   catches a missing file alpha that falls back to rank when the manifest
+   declares a different value.
+8. Require every actual target module to appear in the manifest's
+   `target_modules` list.
+9. When `inference-hook` is active and a model configuration is supplied,
+   require adapter dimension validation against that model.
+10. If the safetensors header contains `adapter_id`, require it to equal `id`.
+11. When running revisions are supplied, require base-model and tokenizer
+    revisions to match unless an explicit permissive override is in effect.
+
+The whole-file integrity digest belongs in the manifest rather than in the
+safetensors header: putting a file's complete digest inside that same file
+would change the bytes being hashed. Header provenance fields are therefore
+advisory metadata, while the manifest remains the authority for whole-file
+integrity and admission status.
+
+`RunningRevisions::strict` is the normal serving mode. It treats the literal
+`"none"` as a real value, not a wildcard, so both sides must use `"none"` for
+an untracked revision. `RunningRevisions::permissive` allows a mismatch only
+for controlled migration work and marks the returned `LoadedAdapter` with
+`rev_mismatch_overridden = true`; callers should make that override visible.
+Passing no running revision context skips revision enforcement, and passing no
+model configuration skips model-dimension validation. Those modes are useful
+for offline inspection but are weaker admission checks than live serving.
+

--- a/crates/tune/docs/lora-io.md
+++ b/crates/tune/docs/lora-io.md
@@ -1,0 +1,230 @@
+# LoRA Safetensors and Governed Loading
+
+The LoRA I/O path has two layers. `lora::safetensors` translates PEFT and MLX
+weight files into `LoraAdapter` values and writes PEFT-compatible files.
+`lora::loader` adds a manifest-controlled admission gate for serving. The
+format parser establishes that the tensors form an adapter; the manifest loader
+establishes that this particular file is approved, confined, intact, and
+compatible with the requested serving context.
+
+## LoRA factor layout
+
+A LoRA update for one linear projection is:
+
+```text
+dW = B @ A
+output += (alpha / rank) * B @ (A @ input)
+```
+
+The in-memory `LoraLayer` stores both matrices as row-major `f32` values:
+
+| Factor | Shape | Purpose |
+| --- | --- | --- |
+| A | `(rank, d_in)` | Projects the base input down to the low-rank space |
+| B | `(d_out, rank)` | Projects low-rank values up to the base output dimension |
+
+Each pair is identified by `(layer_idx, module)`, where `layer_idx` is
+zero-based and `module` is the final key segment such as `q_proj`, `v_proj`,
+or `gate_proj`. An adapter's `LoraConfig` has one common rank, an `alpha`, and
+the sorted set of target module names observed in its tensor keys. The runtime
+scale is `alpha / rank`; invalid or non-finite scale data is rejected when a
+`LoraAdapter` is constructed or saved.
+
+## Accepted tensor keys
+
+The parser recognizes PEFT uppercase suffixes and MLX lowercase suffixes. It
+does not require one fixed leading prefix: it finds the `.layers.{index}.`
+segment and uses the final preceding key component as the module name.
+
+| Producer | A key | B key | Stored shape before normalization |
+| --- | --- | --- | --- |
+| PEFT | `...layers.{i}.self_attn.{module}.lora_A.weight` | `...layers.{i}.self_attn.{module}.lora_B.weight` | A `(rank, d_in)`, B `(d_out, rank)` |
+| PEFT MLP | `...layers.{i}.mlp.{module}.lora_A.weight` | `...layers.{i}.mlp.{module}.lora_B.weight` | A `(rank, d_in)`, B `(d_out, rank)` |
+| MLX | `...layers.{i}.{block}.{module}.lora_a` | `...layers.{i}.{block}.{module}.lora_b` | A `(d_in, rank)`, B `(rank, d_out)` |
+
+The trailing `.weight` is optional. Non-LoRA tensors and keys that do not fit
+this grammar are ignored; a file with no recognized `lora_A` or `lora_B`
+tensors is rejected. MLX factors are transposed into the PEFT/in-memory layout
+before pairing, but only after verifying that the source is two-dimensional
+and that its stated element count does not overflow or disagree with its byte
+data.
+
+The writer emits the PEFT spelling with the full
+`base_model.model.model.layers.{i}` prefix. It uses `self_attn` for
+`q_proj`, `k_proj`, `v_proj`, and `o_proj`, and `mlp` for `gate_proj`,
+`up_proj`, and `down_proj`. Unknown module names are written under
+`self_attn`; the module name itself remains part of the key.
+
+## Numeric representation and parser checks
+
+Input tensors may be `F32`, `F16`, or `BF16`. Their data is decoded to
+in-memory `f32` using little-endian elements; F16 and BF16 are converted
+before any factor validation. Other safetensors dtypes are rejected. The
+parser also rejects a byte length not divisible by the dtype width and rejects
+any decoded NaN or infinity.
+
+For every `(layer_idx, module)` key, loading is fail-closed:
+
+1. Both an A and a B tensor must exist; an orphan of either kind is an error.
+2. Both tensors must be two-dimensional.
+3. Their rank axes must agree: `A.shape[0] == B.shape[1]` after any MLX
+   transpose.
+4. That rank must match the first factor pair's rank. Mixed-rank adapters are
+   rejected.
+5. `rank * d_in` and `d_out * rank` must not overflow `usize`, and each
+   product must equal the decoded element count.
+6. The completed configuration must pass `LoraAdapter::new`, including its
+   finite-alpha and finite-effective-scale checks.
+
+This means a successful parse represents complete, consistently shaped,
+finite factor pairs. It does not by itself prove that the factors belong to a
+particular base model; when the `inference-hook` feature is available, the
+governed loader can additionally validate every layer index and projection
+dimension against the active model configuration.
+
+## Header metadata and export
+
+The writer serializes F32 factor tensors and includes these normal adapter
+metadata entries in the safetensors header:
+
+| Key | Value |
+| --- | --- |
+| `rank` | `LoraConfig::rank` as text |
+| `alpha` | `LoraConfig::alpha` as text |
+| `target_modules` | Comma-joined target-module list |
+
+The loader uses `alpha` if it is present. It must parse as a finite `f32`.
+When absent, it uses `rank` as alpha, giving the neutral scale `1.0`. The
+header's `rank` and `target_modules` are informational to this parser: the
+authoritative rank and module set are derived from validated factors.
+
+`save_peft_safetensors` may also receive `AdapterGovernance`, which writes all
+six provenance fields together:
+
+```text
+gov_name
+gov_owner
+gov_base_model_rev
+gov_tokenizer_rev
+gov_dtype
+gov_status
+```
+
+They describe an adapter but are not a substitute for the governed manifest.
+In particular, the writer never embeds `integrity_sha256`: an integrity digest
+is defined over the complete safetensors file, including the header. Writing
+such a digest into that header changes the file and therefore changes the
+digest. The manifest is the only authority for whole-file integrity.
+
+An optional header `adapter_id` is read by the manifest loader. If it exists,
+it must equal the manifest entry identifier. Its absence is allowed, which
+keeps compatibility with PEFT exports that do not include it. Reading optional
+governance metadata is advisory; missing or malformed optional header metadata
+does not substitute for a manifest decision.
+
+The exporter skips a layer whose A or B buffer is empty. Such a layer denotes a
+module that was not trained; emitting a non-zero shaped tensor with no data
+would create an invalid safetensors tensor view.
+
+## Bounded file reads
+
+All paths that materialize adapter bytes use a common 10 GiB maximum. The
+limit protects the full-buffer parser from an oversized-file allocation attack
+and has two checks:
+
+1. Read file metadata first and reject a known-oversized file before opening
+   it for content.
+2. Open the file and read through `take(max_bytes + 1)`. The one-byte sentinel
+   rejects a file that grew after the metadata check while allowing a file
+   exactly at the limit.
+
+The second check closes the metadata-to-open size race. Both the plain
+path-based loader and the manifest loader use this guarded reader, so the
+manifest path cannot bypass the memory bound.
+
+## Manifest admission
+
+`load_adapters_from_manifest` accepts a parsed `LoraManifest`, a base directory
+for relative paths, an optional active-model configuration when
+`inference-hook` is enabled, and optional `RunningRevisions`. It returns
+`Ok(Vec<LoadedAdapter>)` only when every entry succeeds. Any anomaly returns
+an error and discards the accumulated output; there is no partial result and
+no silent skip.
+
+Before opening any file, the loader scans the whole manifest. Every entry must
+be `Approved`; a `Quarantined` or `Revoked` entry rejects the entire call. This
+pre-scan prevents a later disallowed entry from allowing earlier files to be
+read first. The per-entry status check is repeated as defense in depth.
+
+For each approved entry, these checks run in order:
+
+| Check | Requirement |
+| ---: | --- |
+| 1 | Status is `Approved`. |
+| 2 | `uri` is relative, contains no `..` component, canonicalizes successfully, and its canonical target remains under the canonical base directory. This rejects absolute paths and symlink escapes. |
+| 3–4 | The proven in-base file can be read under the 10 GiB cap, and the SHA-256 of those exact bytes equals `integrity_sha256`. Existence is folded into this guarded read to avoid a separate check/open race. |
+| 5 | The bytes parse as a complete PEFT or normalized MLX LoRA adapter. |
+| 6 | Parsed rank equals manifest `rank`. |
+| 7 | Parsed alpha and manifest alpha are finite and differ by at most `1e-4`. If the file omits alpha, its synthesized `rank` value is still compared. |
+| 8 | Every parsed target module is listed in manifest `target_modules`; the parser's set must be a subset of the manifest declaration. |
+| 9 | When `inference-hook` is active and a model configuration is supplied, the adapter dimensions and layer indices validate against that model. |
+| 10 | If a safetensors header has `adapter_id`, it equals the manifest `id`. |
+| 11 | When running revisions are supplied, both base-model and tokenizer revisions exactly match unless the caller explicitly allows a mismatch. |
+
+Canonicalization is a proof step, not a convenience. A target that cannot be
+canonicalized is refused rather than read lexically, because the loader has not
+proved it remains under the base directory. There remains a final-component
+replacement window between canonicalization and open; whole-file SHA-256
+verification rejects a substituted file whose bytes do not match the manifest.
+
+## Revision enforcement
+
+`RunningRevisions::strict(base_model_rev, tokenizer_rev)` is the normal
+serving context. It compares both strings exactly with the manifest fields and
+rejects either mismatch. The literal `"none"` is not a wildcard: legacy
+entries using that sentinel require the running side to supply `"none"` too.
+
+`RunningRevisions::permissive(...)` is an explicit migration escape hatch.
+It permits mismatched revisions but marks the returned
+`LoadedAdapter::rev_mismatch_overridden` as `true`. Callers should surface that
+condition because the adapter can load and execute while producing degraded
+results against a different base-model or tokenizer revision. Passing no
+running revisions skips this check, which is appropriate only when there is no
+live serving context, such as offline manifest validation.
+
+## Serving pattern
+
+```rust,no_run
+use std::path::Path;
+use lattice_tune::lora::{LoraManifest, RunningRevisions};
+use lattice_tune::lora::loader::load_adapters_from_manifest;
+
+let manifest = LoraManifest::load(Path::new("adapters/manifest.json"))?;
+let revisions = RunningRevisions::strict("base-weights-revision", "tokenizer-revision");
+
+#[cfg(not(feature = "inference-hook"))]
+let loaded = load_adapters_from_manifest(
+    &manifest,
+    Path::new("adapters"),
+    Some(&revisions),
+)?;
+
+#[cfg(feature = "inference-hook")]
+let loaded = load_adapters_from_manifest(
+    &manifest,
+    Path::new("adapters"),
+    Some(&model_config),
+    Some(&revisions),
+)?;
+
+for adapter in &loaded {
+    assert!(!adapter.rev_mismatch_overridden);
+}
+# Ok::<(), lattice_tune::TuneError>(())
+```
+
+For a simple local import without manifest governance, use
+`load_peft_safetensors(path)` or `LoraAdapter::from_safetensors(path)`. That
+path retains the bounded read and tensor-format validation, but it deliberately
+does not establish status, approved location, whole-file integrity, manifest
+claims, or serving-revision compatibility.

--- a/crates/tune/docs/lora-router.md
+++ b/crates/tune/docs/lora-router.md
@@ -1,0 +1,228 @@
+# LoRA Router Refit
+
+`lora::router_update` updates the small gate that selects an adapter for a
+request. It accepts completed-request feedback rather than a supervised label
+set: a caller supplies the same context vector that was routed, the adapter
+index the feedback concerns, and a preference signal. The result is a complete
+FANN gate binary, ready to replace the previous gate on the next call.
+
+This module is available only with the `mixture` feature.
+
+## State and inputs
+
+`update_router` operates on four persistent inputs plus a feedback batch:
+
+| Input | Role | Mutated by refit? |
+| --- | --- | --- |
+| `gate_bytes` | Current FANN gate, serialized by `Network::to_bytes()` | No; decoded into a working gate |
+| `events` | Non-empty current feedback batch | No |
+| `ReplayBuffer` | Bounded FIFO history of known-good routes | Yes |
+| `DiagonalFisher` | Per-parameter importance EMA and parameter anchor | Yes |
+| `RouterUpdateConfig` | RLOO, replay, and EWC settings | No |
+
+The returned `RouterDelta::network_bytes` is a full `Network::to_bytes()`
+payload, not a parameter diff. It can be passed back as `gate_bytes` to a later
+refit or restored with `Network::from_bytes()`. `events_consumed` is always the
+current batch length. `replay_accuracy` is the post-refit top-1 accuracy on the
+entire, updated replay buffer, or `None` when that buffer is empty.
+
+An event's `adapter_id` is retained for audit and tracing; gradient computation
+uses only its context, adapter index, and signal. The context must be the
+vector supplied to the gate when the request was made. Reconstructing a
+different context at feedback time trains the router against a different
+decision than the one being judged.
+
+## Feedback polarity and RLOO
+
+`PreferenceSignal` maps to a fixed signed reward:
+
+| Signal | Reward | Meaning for the named adapter |
+| --- | ---: | --- |
+| `Positive` | `+1.0` | Strong evidence it should be selected |
+| `ImplicitPositive` | `+0.5` | Weak evidence it should be selected |
+| `ImplicitNegative` | `-0.5` | Weak evidence it should be selected less often |
+| `Negative` | `-1.0` | Strong evidence it should be selected less often |
+
+The reward sign is the only polarity mechanism. Every event calls
+`RlooTrainer::step(gate, context, action_idx, reward)`; there is no separate
+negative-feedback branch. In the single-sample RLOO (`M = 1`) policy-gradient
+update, the relevant logit gradient has the form:
+
+```text
+reward * (p - onehot(action))
+```
+
+Consequently, a positive reward increases the named adapter's routing
+probability and a negative reward decreases it. Splitting positive and
+negative events into separate update logic would risk reversing that invariant
+or treating a negative signal as an alternative preferred adapter.
+
+The RLOO trainer also receives the configured auxiliary load-balancing loss and
+router z-loss. The former discourages all requests from collapsing onto one
+adapter; the latter discourages unbounded router logits. Both coefficients may
+be zero to disable their respective auxiliary term.
+
+## Configuration defaults and bounds
+
+`RouterUpdateConfig::default()` is intended as a conservative starting point:
+
+| Setting | Default | Accepted values | Effect |
+| --- | ---: | --- | --- |
+| `learning_rate` | `1e-3` | Finite and `> 0` | SGD step magnitude |
+| `aux_loss_coeff` | `0.01` | Finite and `>= 0` | Load-balancing penalty weight |
+| `z_loss_coeff` | `0.001` | Finite and `>= 0` | Logit-growth penalty weight |
+| `epochs` | `5` | Integer `> 0` | Complete passes over new plus sampled replay data |
+| `ewc_lambda` | `0.1` | Finite and `>= 0` | Reserved anchor-penalty coefficient; inactive in v1 |
+| `replay_mix_fraction` | `0.5` | Finite in `[0, 1]` | Fraction of stored replay entries sampled per refit |
+
+The replay fraction is converted to a count with `ceil`, so any positive
+fraction selects at least one entry when the buffer is non-empty. A fraction of
+zero disables replay and a fraction of one selects the full buffer.
+
+## Refit algorithm
+
+The refit is deliberately ordered so invalid caller state is rejected before
+the feedback loop mutates the gate, replay buffer, or Fisher state.
+
+1. Reject an empty feedback batch, then deserialize the FANN gate.
+2. Read the gate input dimension, output count, and flattened parameter count.
+3. Validate every event as a batch: its context length must equal the gate's
+   input dimension, its adapter index must be smaller than the output count,
+   and every context value must be finite. One bad event rejects the complete
+   batch.
+4. Validate the configuration and the Fisher state. An empty Fisher is
+   initialized with zero-valued importance and anchor vectors sized to the
+   gate. A non-empty Fisher must already match the gate parameter count and
+   contain valid values.
+5. Construct `RlooTrainer` from the learning rate, auxiliary-loss coefficient,
+   and z-loss coefficient.
+6. Take a replay sample before changing the replay buffer. The sample size is
+   `ceil(replay.len() * replay_mix_fraction)`, and entries are spaced through
+   the buffer rather than taken only from its oldest end.
+7. For each epoch, update first on every new event with its signed reward,
+   then on every sampled replay entry with reward `+1.0`.
+8. Snapshot the final parameters into the Fisher anchor.
+9. Append only newly positive events to replay, evicting the oldest entry if
+   capacity has been reached.
+10. Measure top-1 replay accuracy with the updated gate, serialize it, and
+    return the `RouterDelta`.
+
+The replay sample is cloned before training so the buffer can be updated after
+the epochs without invalidating borrowed entries. Its deterministic sampler
+uses `ceil(len / n)` as an iteration stride, takes at most `n` entries, and
+therefore spreads a small sample across the buffer's history. A zero requested
+sample or an empty buffer produces no replay steps.
+
+## One gradient step and Fisher projection
+
+Each event or replay entry is processed with the following transaction:
+
+1. Flatten the gate parameters in forward layer order: row-major weights,
+   followed by biases, for each layer.
+2. Let the RLOO trainer perform its ordinary SGD step.
+3. Flatten the new parameters and calculate the raw update
+   `delta = after - before`.
+4. Approximate the gradient as `-delta / learning_rate`. The implementation
+   uses `max(abs(learning_rate), 1e-10)` as the denominator guard; public
+   validation still requires a finite, strictly positive learning rate.
+5. Feed that gradient to the diagonal Fisher EMA. Each importance entry is a
+   squared-gradient moving average:
+
+   ```text
+   F_i <- decay * F_i + (1 - decay) * gradient_i^2
+   ```
+
+6. Call `DiagonalFisher::project_delta` on the raw update. High-importance
+   parameters have their updates damped toward zero; parameters whose Fisher
+   importance is near zero pass through with little damping.
+7. Restore the gate as `before + projected_delta`.
+
+This is the v1 anti-forgetting mechanism. It protects parameters that the
+recent Fisher history identifies as important while leaving lower-importance
+degrees of freedom available to learn new routing feedback.
+
+The parameter anchor is updated after the whole refit, but the projection path
+does not use it. `RouterUpdateConfig::ewc_lambda` is validated and retained for
+the alternative anchor-pullback EWC penalty (`penalty_gradient`), but it has no
+effect on v1 gate bytes. Changing `ewc_lambda` alone must therefore not change
+the result of an otherwise identical v1 refit.
+
+## Replay semantics
+
+Replay stores only positive signals. A positive event tells the system which
+adapter should be selected, so it can safely reappear as a `+1.0` training
+example. A negative event only says that one adapter should be selected less
+often; it does not identify a replacement and is therefore never placed in
+replay.
+
+`ReplayBuffer` is a FIFO with a caller-supplied maximum size. Pushing when it
+is full removes the oldest entry first. A zero-capacity buffer intentionally
+accepts no entries. Refit adds new positive events only after all training
+epochs finish, so current feedback is not replayed multiple extra times within
+the same call.
+
+Replay accuracy is an operational indicator, not a new optimization target.
+For each stored positive route, the gate is run and its largest output index is
+compared with the stored adapter index. A forward failure or an output that
+cannot produce a comparable maximum counts as incorrect rather than aborting
+the metric calculation.
+
+## Validation contract
+
+All of the following reject the call with `TuneError::Validation` before the
+training loop begins:
+
+| Value | Required condition |
+| --- | --- |
+| `events` | Non-empty |
+| Event context | Exactly the gate input length; every value finite |
+| Event adapter index | Less than the gate output count |
+| `learning_rate` | Finite and `> 0` |
+| `aux_loss_coeff`, `z_loss_coeff`, `ewc_lambda` | Finite and `>= 0` |
+| `replay_mix_fraction` | Finite and in `[0, 1]` |
+| `epochs` | Greater than zero |
+| Fisher decay | Finite and strictly in `(0, 1)` |
+| Empty Fisher | Auto-initialized to the gate parameter count |
+| Non-empty Fisher | Importance and anchor lengths equal parameter count; importance entries finite and non-negative; anchor entries finite |
+
+Gate deserialization, RLOO stepping, Fisher observation, and anchor updates
+that fail are surfaced as `TuneError::Training`. The validation boundary is
+important because non-finite inputs or invalid Fisher state would otherwise
+contaminate the gate and the persisted online-learning state.
+
+## Example lifecycle
+
+```rust,no_run
+use lattice_fann::{Network, training::DiagonalFisher};
+use lattice_tune::lora::router_update::{
+    update_router, FeedbackEvent, PreferenceSignal, ReplayBuffer,
+    RouterUpdateConfig,
+};
+
+let initial_gate: Network = /* construct a gate */ unimplemented!();
+let mut gate_bytes = initial_gate.to_bytes();
+let mut replay = ReplayBuffer::new(1_024);
+let mut fisher = DiagonalFisher::new(0, 0.99)?; // Empty state auto-initializes.
+
+let events = vec![FeedbackEvent {
+    context_vector: vec![/* exact routing context */],
+    preferred_adapter_idx: 2,
+    adapter_id: "legal-domain".to_owned(),
+    signal: PreferenceSignal::Positive,
+}];
+
+let delta = update_router(
+    &gate_bytes,
+    &events,
+    &mut replay,
+    &mut fisher,
+    &RouterUpdateConfig::default(),
+)?;
+gate_bytes = delta.network_bytes;
+# Ok::<(), lattice_tune::TuneError>(())
+```
+
+Persist `gate_bytes`, replay state, and Fisher state together when continuity
+across process restarts matters. Restoring only the gate discards the
+anti-forgetting history; restoring only the Fisher state with a different gate
+will fail its parameter-count validation.

--- a/crates/tune/docs/registry.md
+++ b/crates/tune/docs/registry.md
@@ -1,0 +1,479 @@
+# Model and adapter registry
+
+`lattice-tune`'s registry is an in-process catalog of versioned models and their
+weight artifacts. It separates a model's descriptive record from bytes held by a
+storage backend, supports lock-free catalog reads, and provides helpers for
+shadow evaluation, rollback audit records, and atomic live-record replacement.
+
+The registry does not load or execute a model. A `RegisteredModel` is metadata,
+and `LiveModel` atomically replaces that metadata record. An application that
+keeps instantiated inference models must coordinate its own model loading with a
+registry update.
+
+For the original choice of an in-process, lineage-aware registry and its
+rejected alternatives, see [ADR-002](ADR-002-model-registry.md).
+
+## Components and boundaries
+
+```text
+training output
+      |
+      v
+RegisteredModel + weight bytes
+      |
+      v
+ModelRegistry -----> StorageBackend
+      |                    |
+      |                    +-- in memory / filesystem / SQLite
+      |
+      +-- ShadowSession       (compare candidate with production)
+      +-- RollbackController  (record a rollback)
+      +-- LiveModel           (atomically replace a record)
+```
+
+`ModelRegistry` is the catalog and consistency boundary for the process in
+which it is created. A storage backend persists artifacts, but constructing a
+new registry does not hydrate its indexes from that backend. In particular,
+creating a registry over an existing directory or SQLite database does not make
+pre-existing rows or files visible through `get`, `list_*`, or checksum loading
+until they have been registered in that registry instance.
+
+The deployment helpers are deliberately separate:
+
+- A `ShadowSession` collects and evaluates comparison observations. It never
+  promotes a candidate.
+- A `RollbackController` records a rollback decision. It never changes a
+  `ModelRegistry` or a `LiveModel`.
+- A `LiveModel` changes one `RegisteredModel` pointer. It neither persists the
+  change nor updates registry status.
+
+An application normally evaluates a candidate, promotes the chosen registry
+record, swaps its serving record or loaded model, and records any rollback as
+separate, explicit actions.
+
+## The model record
+
+### Identity, versioning, and lineage
+
+Each `RegisteredModel` has a UUID `id` and a human-facing `(name, version)`
+identity. The registry's duplicate key is the string `"{name}:{version}"`;
+registration rejects an existing key while holding the writer lock. Validation
+only requires both strings to be non-empty. A caller that uses filesystem or
+SQLite storage must also supply path-safe names and versions, because those
+backends make them directory components.
+
+`version_tuple()` recognizes only exactly three dot-separated unsigned integer
+components. It returns `None` for prefixes, suffixes, pre-release identifiers,
+or any other non-`MAJOR.MINOR.PATCH` form. `get_latest` orders parseable
+versions by that tuple and treats an unparsable version as `(0, 0, 0)`. Use
+strict numeric three-part versions whenever automated latest-version selection
+matters.
+
+`parent_id` records the immediate source of a fine-tuned model and `children`
+holds descendant IDs. The registry does not validate that a parent exists,
+populate a parent's `children`, or cascade deletion. Applications that use
+lineage must maintain those relations and account for orphaned references
+themselves.
+
+### Metadata and status
+
+`ModelMetadata` records architecture, input and output dimensions, parameter
+count, optional configuration and dataset identifiers, example count, training
+metrics, validation and test accuracy, tags, and an extensible `extra` value.
+With `serde`, `extra` is JSON; without it, it is a string. The `classifier`
+constructor fills architecture and dimension/count fields, and builder methods
+set architecture, dataset, metrics, and tags.
+
+`training_metrics` retains the supplied metrics and sets `validation_accuracy`
+only when `final_val_loss` is present; it then uses the most recent history
+entry's validation accuracy, falling back to `0.0` if that entry has none.
+Callers that need a different metric summary should set the public metadata
+fields explicitly.
+
+The status vocabulary is:
+
+| Status | Meaning |
+| --- | --- |
+| `Pending` | Registered but not yet validated. |
+| `Validated` | Validation has passed. |
+| `Staged` | Prepared for deployment. |
+| `Production` | The selected production version. |
+| `Archived` | Superseded or retained for history. |
+| `Deprecated` | Not for further use. |
+
+The conventional lifecycle is `Pending -> Validated -> Staged -> Production`,
+with old versions later archived or deprecated. This is convention, not a
+state-machine enforcement layer: the status helper methods and `update_status`
+can set any status, and `promote_to_production` does not first require the
+target to be deployable. `is_deployable` reports true for `Validated`,
+`Staged`, and `Production`; `is_active` reports false only for `Archived` and
+`Deprecated`.
+
+`RegisteredModel` also carries its registration and update timestamps, optional
+registrant and description, and optional weight path, byte size, and SHA-256
+hash. Builder methods that alter model content update `updated_at`; setting the
+registrant does not. A model created with `new` starts as `Pending` with a new
+UUID and both timestamps set to creation time.
+
+## Registry operations and concurrency
+
+`ModelRegistry` owns two immutable `ArcSwap` indexes:
+
+- `UUID -> RegisteredModel` for direct lookup and enumeration.
+- `"name:version" -> UUID` for lookup by model identity.
+
+Read methods take snapshots without the writer lock and return owned cloned
+records. A reader therefore never borrows internal map storage and may keep a
+record after a writer publishes a newer map. `get_by_id`, `get`, `get_latest`,
+`get_production`, the `list_*` methods, `len`, and `is_empty` are all lock-free
+at the registry level.
+
+Writes take one `write_lock`, clone the affected index map, modify the clone,
+and atomically store the new `Arc`. The storage backend itself is behind a mutex
+because saving and deletion require mutable backend access. This serializes
+registry writers and prevents two writers from publishing updates derived from
+the same old map; it does not make backend persistence and index publication a
+cross-resource transaction.
+
+### Registration and deletion ordering
+
+`register(model, weights)` follows this order:
+
+1. Validate the non-empty name and version.
+2. Acquire the writer lock and reject a duplicate full name.
+3. Ask the backend to save the bytes.
+4. Compute the SHA-256 over those exact input bytes and attach the backend's
+   returned relative path, size, and hash to the model record.
+5. Publish the enriched record in both in-memory indexes.
+
+If backend saving fails, neither index is changed. `register_metadata` follows
+the same duplicate and index rules but creates no artifact or weight metadata.
+The model passed to a backend is the pre-enrichment record; a backend that
+persists metadata receives it before the outer registry attaches the returned
+path, size, and checksum.
+
+`delete(id)` first removes the record from a cloned map, then asks the backend
+to delete its weight path (when one exists), and publishes the changed indexes
+only after that operation succeeds. Thus a backend deletion error leaves the
+in-memory indexes intact. The method only asks the backend to remove weights;
+backend-specific side files and cross-resource cleanup have the behavior
+described below.
+
+`promote_to_production(id)` finds the selected record's name, changes every
+production record with that name to `Staged`, changes the requested record to
+`Production`, timestamps all changed records with the same `Utc::now()`, and
+publishes one new model map. Models with other names are unaffected. This
+creates one production status per name in the published registry snapshot, but
+does not update a `LiveModel`, validate weights, or persist status changes
+through the storage backend.
+
+`update_status` similarly changes only the in-memory catalog. If a durable
+deployment workflow needs status history, it must persist it outside the
+registry or use backend-specific facilities.
+
+### Checksum-bound weight loading
+
+`register` records a SHA-256 checksum for its input weight bytes.
+`load_weights` resolves the supplied model ID against the registry's canonical
+snapshot before touching storage. It rejects a caller-provided clone whose
+`weights_path` or `weights_hash` differs from the canonical record, preventing a
+mutable public DTO from redirecting a load or selecting a replacement hash.
+
+If the canonical record has a checksum, the loaded bytes must match it or the
+method returns `TuneError::WeightIntegrityError`. If it has no hash, such as a
+metadata-only or legacy record, `load_weights` returns the bytes without a
+checksum comparison. That is the only unverified path and is explicit in the
+canonical record.
+
+Use `load_weights_verified` when verification is a caller requirement. It
+rejects a model with no canonical `weights_hash`, then delegates to the same
+canonical-record and SHA-256 checks. Both methods return `ModelNotFound` for a
+record absent from the in-memory index and a storage error when no weight path
+is recorded.
+
+> **Integrity invariant:** never treat a hash on a caller-owned
+> `RegisteredModel` clone as authority. The registry verifies against its own
+> canonical snapshot, and a checksum mismatch is an error rather than a
+> best-effort warning.
+
+### Querying
+
+`ModelQuery` starts from `list_all`, so it operates on owned snapshots rather
+than a live cursor. It can require an exact name or status, a minimum validation
+accuracy, every requested tag, and a result limit. A minimum-accuracy query
+excludes records with no validation accuracy. Results keep the registry's map
+iteration order; the builder does not sort them before applying `limit`.
+
+## Shadow evaluation
+
+Shadow evaluation compares a candidate UUID with a production UUID using
+application-supplied observations. It is a decision aid for real traffic; the
+registry does not run model inference, choose sampled requests, or verify that
+either UUID currently denotes a registry record.
+
+### Configuration
+
+`ShadowConfig` contains four acceptance inputs:
+
+| Field | Interpretation | Default | `quick()` | `strict()` |
+| --- | --- | ---: | ---: | ---: |
+| `sample_rate` | Fraction of traffic the caller intends to sample. | 0.10 | 0.20 | 0.10 |
+| `min_samples` | Observations required before a terminal evaluation. | 1,000 | 100 | 10,000 |
+| `min_agreement` | Minimum agreeing-output fraction. | 0.95 | 0.90 | 0.99 |
+| `max_latency_increase_ms` | Largest allowed mean candidate-minus-production latency. | 50.0 | 100.0 | 20.0 |
+
+`validate` requires `sample_rate` and `min_agreement` to lie in `[0, 1]`,
+requires a nonzero sample count, and rejects a negative latency allowance.
+`ShadowSession::new` does not call `validate`, and `sample_rate` is not applied
+internally. Validate the configuration and make the traffic-sampling decision
+before calling `record_sample`.
+
+### State machine and calculation
+
+Creating a session records its IDs and enters `Running` with zero samples.
+While it is running, `record_sample(agreed, latency_diff_ms)` appends one
+observation; positive latency means the candidate was slower. The session keeps
+the raw `(bool, f64)` observations in memory. It neither caps their count nor
+validates their latency values, so callers should provide meaningful finite
+measurements.
+
+At any point, `current_comparison` computes:
+
+```text
+agreement_rate = agreeing_observations / total_observations
+latency_diff_ms = sum(candidate_latency - production_latency) / total_observations
+```
+
+An empty session reports zero for all three comparison fields. `progress` is
+`sample_count / min_samples`, capped at one.
+
+`evaluate` changes state only if the session is `Running` and it has at least
+`min_samples` observations. It passes exactly at or above the agreement
+threshold and exactly at or below the latency threshold. Otherwise it moves to
+`Failed`, preserving the final comparison and producing one or both
+human-readable reasons. Before the sample minimum, it returns `Running` and
+makes no decision.
+
+```text
+Running -- enough samples and both criteria pass --> Passed
+Running -- enough samples and either criterion fails -> Failed
+Running -- cancel(reason) ------------------------> Cancelled
+```
+
+After `Passed`, `Failed`, or `Cancelled`, `record_sample` ignores subsequent
+observations and `evaluate` leaves the terminal state untouched. `cancel` itself
+sets `Cancelled` unconditionally, so it can replace an earlier terminal state.
+`ShadowSession` is mutated through `&mut self`; synchronize it externally if
+multiple tasks or threads feed observations.
+
+Promotion remains a separate step:
+
+```rust,no_run
+use lattice_tune::registry::{ModelRegistry, ShadowSession};
+
+fn promote_if_shadow_passes(
+    registry: &ModelRegistry,
+    session: &mut ShadowSession,
+) -> lattice_tune::Result<()> {
+    if session.passed() {
+        registry.promote_to_production(&session.candidate_model_id)?;
+    }
+    Ok(())
+}
+```
+
+The calling service is responsible for making the promotion decision durable,
+putting the production artifact into service, and handling the behavior of
+in-flight requests.
+
+## Rollback records
+
+`RollbackController` is a bounded, in-memory audit log. A `RollbackRecord`
+stores its own UUID, the prior production model ID, the new production model
+ID, a required reason, optional initiator, and a UTC timestamp.
+`record_rollback` appends the record and returns a clone of it.
+
+Records are oldest first. When appending would exceed `max_history`, the
+controller removes exactly the oldest entry. A controller configured with zero
+keeps no records: each appended record is immediately removed, although the
+call still returns it. The default capacity is 100.
+
+The controller exposes the whole ordered history, its most recent record, and
+filters for records involving, from, or targeting a particular model. It does
+not perform a registry promotion, weight swap, status update, or persistence.
+Serialize records externally if audit history must survive a restart.
+
+> **Lifecycle invariant:** recording a rollback is not the rollback itself.
+> Coordinate the registry status change, serving-model change, and durable
+> audit write in the application, and protect a shared controller with a
+> `Mutex` or `RwLock` when it is mutated concurrently.
+
+## Live-model replacement
+
+`LiveModel` wraps one `ArcSwap<RegisteredModel>`. `load` returns an `Arc` to a
+consistent current record without taking a lock. `swap` atomically publishes a
+new `RegisteredModel` and returns an `Arc` to the old one. A snapshot obtained
+before a swap stays valid and continues to expose the old record; snapshots
+obtained after the swap see the new record.
+
+This makes the handle useful for a serving layer that needs non-blocking
+metadata selection during a hot reload. It does not deserialize weights,
+coordinate a two-phase rollout, validate status, or ensure that an application
+has replaced its separately held executable model. Readers that need several
+fields from one version should call `load` once and read them from that single
+snapshot rather than call `model_id` and `version` independently across a
+possible swap.
+
+```rust
+use lattice_tune::registry::{LiveModel, RegisteredModel};
+
+let live = LiveModel::new(RegisteredModel::new("classifier", "1.0.0"));
+let before = live.load();
+let replaced = live.swap(RegisteredModel::new("classifier", "2.0.0"));
+
+assert_eq!(before.version, "1.0.0");
+assert_eq!(replaced.version, "1.0.0");
+assert_eq!(live.load().version, "2.0.0");
+```
+
+## Storage backends
+
+`StorageBackend` has mutable `save` and `delete` operations plus read-only
+`load`, `exists`, and `list`. It is `Send + Sync`, allowing a registry to hold a
+boxed implementation behind its backend mutex. A custom backend receives a
+`RegisteredModel` and a byte slice on save and must define its own persistence,
+durability, and recovery guarantees.
+
+### In-memory backend
+
+`InMemoryStorage` keeps a `HashMap<String, Vec<u8>>` keyed by
+`name/version/weights.bin`. It is intended for tests and process-local use.
+Saving replaces any existing bytes at the same computed key, `load` clones the
+stored bytes, deleting an absent key succeeds, and `list` returns map keys in
+unspecified order. Unlike path-backed stores, it does not validate model names
+or versions because the key is not a filesystem path.
+
+### Filesystem backend
+
+`FileSystemStorage::new(root)` creates the root directory. A save validates the
+model name and version, then writes weights at:
+
+```text
+<root>/<name>/<version>/weights.bin
+```
+
+When the `serde` feature is enabled, it also writes a pretty JSON serialization
+of the supplied model to `metadata.json` in the same directory. It returns the
+relative `name/version/weights.bin` path, never the absolute path.
+
+Loads and deletes reject null bytes, absolute paths, and any `..` component;
+`exists` returns `false` rather than an error for such paths. `list` walks the
+two-level name/version layout and returns only paths for a present `weights.bin`.
+It tolerates unreadable entries by skipping them. Deletion removes the weight
+file first and only attempts to remove its immediate parent if empty. A
+`metadata.json` side file can therefore keep that directory in place after a
+delete; the stale metadata is ignored by `list` because the weight file is gone.
+
+### SQLite backend
+
+With the `sqlite` feature, `SqliteStorage` stores registry fields in a SQLite
+`models` table and writes artifact bytes beside the database under:
+
+```text
+<database-parent>/weights/<name>/<version>/weights.bin
+```
+
+The table has the model ID, name and version (unique as a pair), status,
+metadata JSON, registration and update timestamps as epoch microseconds,
+registrant and description, weight path/size/hash, and parent ID. It has name
+and status indexes. The implementation serializes access to its SQLite
+connection with a mutex.
+
+Saving validates path components, writes the file, serializes the supplied
+metadata, then inserts the row. If the insert fails, it removes the newly
+written weight file before returning an error. The outer registry computes its
+checksum after a backend save returns, so a backend row is built from the
+pre-enrichment record supplied to `save`; applications that need durable
+metadata should account for that ordering.
+
+Deletion orders file removal before deleting the SQLite row. A file-removal
+failure therefore preserves the row, but the two resources are not one
+transaction: a later database deletion failure can leave a row for a file that
+has already been removed. `exists` requires both a matching row and a present
+file, while `list` reads non-null weight paths from SQLite. Reconcile partial
+failures at the application level.
+
+`SqliteStorage::in_memory` creates an in-memory database and a unique temporary
+weights directory for tests. It constructs the table directly and does not run
+the on-disk upgrade migrations or create the two indexes used by the on-disk
+constructor.
+
+### SQLite schema upgrades
+
+The on-disk constructor creates the current table and indexes if needed, then
+runs two fail-closed, idempotent migrations before exposing the storage:
+
+1. It queries `PRAGMA table_info(models)` for a legacy `metadata_json` column.
+   If it exists, `ALTER TABLE` renames it to `metadata`; if it is already absent
+   the migration does nothing. Unexpected SQLite errors stop initialization.
+2. It inspects the declared type of `registered_at`. If it is `INTEGER` (or the
+   table is absent), timestamp migration is a no-op. Otherwise it runs a
+   `BEGIN IMMEDIATE` batch that creates a correctly typed backup table, copies
+   rows, drops the old table, renames the backup, recreates both indexes, and
+   commits. Initialization returns an error rather than ignoring a migration
+   failure.
+
+The timestamp copy handles three legacy representations for both timestamp
+columns:
+
+| Stored value | Detection | Result |
+| --- | --- | --- |
+| Native integer | `typeof(value) = 'integer'` | Preserve it unchanged. |
+| Parseable RFC 3339 / ISO 8601 text | `datetime(value) IS NOT NULL` | Convert `strftime('%s', value)` to microseconds by multiplying by 1,000,000. |
+| Numeric text | Neither condition | Cast directly to `INTEGER`. |
+
+The third case matters because SQLite's old `TEXT` affinity could convert
+integer microseconds into digit strings. RFC 3339 conversion is based on epoch
+seconds, so it discards any sub-second component in those legacy strings. The
+backup-and-rename work is deliberately performed under the immediate SQLite
+transaction; do not replace it with piecemeal schema changes that can expose a
+half-converted table.
+
+## Safetensors weight exchange
+
+When the `safetensors` feature is enabled, `safetensors_io` reads and writes
+flat `f32` tensors using the safetensors data format. The library format begins
+with an eight-byte little-endian header length, followed by JSON tensor metadata
+and the raw tensor-data region. It is a data-only format: parsing does not
+deserialize executable objects. Format validation and bounds checking come from
+the safetensors parser, while registry SHA-256 verification answers the separate
+question of whether the expected artifact bytes were loaded.
+
+`save_weights(weights, name)` produces one named, one-dimensional `F32` tensor
+whose shape is `[weights.len()]`. It converts every value to little-endian
+bytes. `load_weights(data, name)` requires that exact tensor name and `F32`
+dtype, rejects byte lengths not divisible by four, and reconstructs a vector
+from four-byte little-endian chunks.
+
+The multi-tensor functions use the same one-dimensional representation for every
+map entry:
+
+- `save_tensors` serializes each `HashMap<String, Vec<f32>>` entry as a named
+  `F32` vector.
+- `load_tensors` iterates all names, skips tensors with a non-`F32` dtype, and
+  rejects an `F32` tensor whose byte length is not divisible by four or whose
+  byte-derived element count disagrees with the product of its declared shape.
+- `validate` only deserializes the container. It establishes that the payload is
+  well-formed but does not require a tensor name, dtype, shape, or registry
+  checksum.
+
+Use a single named tensor where a flat model-weight vector is the intended
+contract. Use multiple tensors only when consumers agree that each tensor is a
+flat `f32` vector; these helpers do not preserve arbitrary multidimensional
+shapes in their returned `Vec<f32>` values.
+
+> **Format invariant:** safetensors parsing prevents executable-payload
+> deserialization, but it does not replace registry identity or SHA-256 checks.
+> Validate the container before accepting external bytes and use
+> `load_weights_verified` when a recorded artifact checksum is required.
+

--- a/crates/tune/docs/train.md
+++ b/crates/tune/docs/train.md
@@ -1,0 +1,409 @@
+# Training pipeline
+
+`lattice-tune` exposes configuration, run orchestration, metrics, checkpoints, a
+WGPU-backed trainer, and just-in-time (JIT) adaptation helpers. This document
+describes their current behavior, including the boundaries that make a
+configuration valid but do not yet make it an executable optimization run.
+
+## Current implementation status
+
+The public interfaces distinguish five relevant execution paths:
+
+| Path | What works now | What it does not do |
+| --- | --- | --- |
+| `TrainingLoop` | Validates configuration, splits and batches data, invokes callbacks, records metrics, applies early stopping, and produces checkpoint metadata. | It simulates loss and accuracy and never forwards through or updates a network. |
+| `GpuTrainer::validate` | Runs the WGPU network forward, checks outputs for NaN/Infinity, computes loss, and reports top-class accuracy. | It is evaluation only and does not update weights. |
+| `GpuTrainer::train_batch` | Runs forward, finite-value checks, loss calculation, and placeholder backward preparation. | It always returns `TuneError::Training` at the optimizer update. No optimizer choice changes weights. |
+| `JitAdapter::adapt_cpu` | Batches examples, observes its timeout and patience rules, and returns a loss history. | Its per-step loss is simulated; it does not adapt a model. |
+| `JitAdapter::adapt_gpu` | Uses the same batching and stop rules, when the `gpu` feature is enabled. | It delegates to `GpuTrainer::train_batch`, so it currently fails at the optimizer update. |
+
+Treat these boundaries as part of the API contract. In particular, callers must
+not interpret a successful forward-only validation result, a CPU-loop metric, or
+a JIT CPU result as evidence that model parameters were trained.
+
+## Training configuration
+
+`TrainingConfig` is the root configuration passed to `TrainingLoop` and
+`GpuTrainer`. Its builder methods replace the matching field and return the
+updated configuration. Trainer constructors validate it before constructing a
+trainer.
+
+### Defaults and presets
+
+| Setting | `TrainingConfig::default()` | `quick()` | `thorough()` |
+| --- | --- | --- | --- |
+| Epochs | 100 | 10 | 200 |
+| Batch size | 32 | 64 | 32 |
+| Optimizer | default AdamW | default AdamW | AdamW, LR `0.0001`, decay `0.01` |
+| Schedule | cosine warmup: 100 steps, floor `1e-6`, period 100 epochs | same as default | cosine warmup: 500 steps, floor `1e-7`, period 200 epochs |
+| Regularization | default | default | `strong()` |
+| Validation split | 0.1 | 0.0 | 0.15 |
+| Early stopping | default validation-loss monitor | disabled | validation-loss monitor, patience 20 |
+| Checkpoint interval | 10 epochs | 5 epochs | 5 epochs |
+| Logging interval | 100 steps | 100 steps | 50 steps |
+| Mixed precision | disabled | disabled | enabled |
+| Seed | 42 | 42 | 42 |
+
+The default optimizer is AdamW with learning rate `0.001`, momentum `0.9`,
+Adam coefficients `beta1 = 0.9` and `beta2 = 0.999`, epsilon `1e-8`, and
+weight decay `0.01`. The supported selection is SGD, SGD with momentum, Adam,
+AdamW, or RMSprop. Optimizer configuration requires a finite positive learning
+rate and epsilon; finite momentum in `[0, 1]`; finite Adam coefficients in
+`[0, 1)`; and finite, non-negative weight decay.
+
+Configuration validity also requires:
+
+| Field | Requirement |
+| --- | --- |
+| `epochs` | Greater than zero. |
+| `batch_size` | In `1..=8192`; the upper bound prevents excessive allocation. |
+| `val_split` | In the closed interval `[0, 1]`. |
+| `accumulation_steps` | Greater than zero. |
+| Optimizer, regularization, schedule | Each nested configuration must validate. |
+
+The effective batch size reported by `effective_batch_size()` is
+`batch_size.saturating_mul(accumulation_steps)`. It is a configuration-derived
+value: neither current trainer consumes `accumulation_steps` to defer an
+optimizer update.
+
+`mixed_precision`, `log_interval`, and `checkpoint_dir` are stored in the
+configuration. The current `TrainingLoop` does not implement mixed precision or
+use `log_interval` itself; logging is callback-defined. A checkpoint directory
+only enables periodic checkpoint callbacks—it does not create a file.
+
+### Memory budgeting
+
+`estimate_memory_mb(model_params, embedding_dim)` is a conservative planning
+estimate, not an allocator reservation. It uses checked integer arithmetic and
+returns `InvalidConfig` on overflow. Let `P` be the parameter count, `B` the
+configured batch size, and `D` the embedding dimension. Its byte estimate is:
+
+```text
+model       = 4P
+gradients   = 4P
+optimizer   = 8P for Adam or AdamW
+              4P for RMSprop or SGD with momentum
+              0  for SGD
+batch data  = 8BD
+activations = 2 × batch data
+total MB    = ceil(1.20 × total bytes / 1,048,576)
+```
+
+`check_memory_budget(required_mb)` returns
+`TuneError::MemoryBudgetExceeded` only when `memory_budget_mb` is set and the
+requested amount is greater than the budget. No trainer calls the estimate or
+budget check automatically, so applications that require an admission check
+must call both before construction or execution.
+
+### Regularization
+
+`RegularizationConfig` contains independent settings. The validation range does
+not imply that every setting is applied by every path.
+
+| Setting | Default | Validation | Current use |
+| --- | ---: | --- | --- |
+| `dropout` | 0.1 | Must be within `[0, 1]`. | Stored only in the training configuration. |
+| `label_smoothing` | 0.1 | Must be within `[0, 1]`. | Used by `GpuTrainer` loss calculation. |
+| `gradient_clip` | `Some(1.0)` | If set, must be greater than zero. | Available through `apply_gradient_clip`; no current trainer calls it. |
+| `mixup_alpha` | `None` | If set, must be greater than zero. | Stored only in the training configuration. |
+
+The presets are `none()` (no dropout, no smoothing, no clipping, no mixup),
+`light()` (dropout 0.05, smoothing 0.05, clipping 1.0), and `strong()`
+(dropout 0.3, smoothing 0.2, clipping 0.5, mixup alpha 0.2).
+
+Gradient clipping is global L2-norm clipping. For gradient vector `g`, it
+computes `norm = sqrt(sum(g_i²))`, returns that original norm, and behaves as
+follows:
+
+```text
+if norm > max_norm and norm > 0:
+    g ← g × (max_norm / norm)
+otherwise:
+    g is unchanged
+```
+
+This preserves direction and makes the resulting norm exactly `max_norm` in the
+clipping case. An empty or all-zero vector remains unchanged and returns zero.
+`apply_gradient_clip` returns `None` when clipping is disabled and
+`Some(original_norm)` when it is enabled, whether or not rescaling occurred.
+
+### Learning-rate schedules
+
+`LRSchedule::get_lr(base_lr, step, epoch)` evaluates from the immutable base
+optimizer rate. Schedules do not mutate optimizer configuration. Let `b` be
+`base_lr`, `s` be `step`, and `e` be `epoch`.
+
+| Schedule | Result |
+| --- | --- |
+| `Constant` | `b` |
+| `LinearWarmup { warmup_steps: W }` | `b × s / W` while `s < W`; otherwise `b` |
+| `StepDecay { step_size: K, gamma: γ }` | `b × γ^(floor(e / K))` |
+| `ExponentialDecay { gamma: γ }` | `b × γ^e` |
+| `CosineAnnealing { min_lr: m, t_max: T }` | `m + (b - m) × (1 + cos(π × ((e mod T) / T))) / 2` |
+| `CosineAnnealingWarmup { W, m, T }` | Linear warmup while `s < W`; otherwise the cosine formula above, using `e mod T` |
+| `OneCycle { max_lr: M, pct_start: p, total_steps: N }` | Rise linearly from `b` to `M` for `s/N < p`; then linearly descend from `M` to `0.01b` over the remaining fraction. |
+
+The default is `CosineAnnealingWarmup { warmup_steps: 100, min_lr: 1e-6,
+t_max: 100 }`. Warmup starts at zero when `step` is zero; the cosine phase uses
+absolute epoch modulo `t_max`, not an epoch count offset by the warmup.
+
+Validation prevents a zero warmup length where a warmup schedule needs one, a
+zero decay period, or a zero OneCycle length. Decay factors must be finite and
+positive; cosine floors must be finite and non-negative; OneCycle maximum rate
+must be finite and positive; and its start fraction must be finite and strictly
+inside `(0, 1)`. `get_lr` defensively returns the base rate for zero periods
+even though validation rejects them. It does not clamp `step` to `total_steps`
+for OneCycle, so callers should keep `step` inside the configured cycle when
+they need the stated terminal rate.
+
+### Early stopping
+
+`EarlyStopping` monitors one of the metric names accepted by
+`EpochMetrics::get_metric`: `train_loss`, `val_loss`, `train_accuracy`, or
+`val_accuracy`. Its defaults monitor `val_loss` with patience 10, minimum delta
+`1e-4`, and minimization. The helpers choose validation loss (minimize) or
+validation accuracy (maximize).
+
+For a minimization monitor, an epoch improves only when
+`current < best - min_delta`; for maximization, it must satisfy
+`current > best + min_delta`. An unknown monitor yields no metric and therefore
+does not advance or reset the loop's patience counter.
+
+The current `TrainingState` starts `best_metric` at positive infinity. That is
+appropriate for a minimizing monitor, but a maximizing monitor never improves
+against the initial value; `val_accuracy` monitoring will therefore exhaust
+patience unless state is initialized or restored differently. This is a current
+behavior to account for when selecting the monitor.
+
+## CPU training-loop lifecycle
+
+`TrainingLoop::new` validates its configuration, sets the state learning rate
+to the optimizer base rate, creates empty metrics and callbacks, and clones the
+optional early-stopping configuration. `train` rejects an empty dataset.
+
+For a nonzero validation split, it calls `dataset.split(1.0 - val_split)` and
+uses the returned training and validation datasets. With a zero split it clones
+the original dataset as the training data and has no validation data. The
+training dataset is configured with the selected batch size, shuffling enabled,
+and either the configured seed or 42 when no seed is provided.
+
+The lifecycle is:
+
+1. Invoke `on_train_start(config)` on callbacks.
+2. For each epoch, record the zero-based epoch in state, reset that epoch's
+   step/loss/correct/total counters, then invoke `on_epoch_start(epoch)`.
+3. For every batch, invoke `on_batch_start(batch_idx)`, run the simulated batch
+   operation, then invoke `on_batch_end(batch_idx, loss)`.
+4. When validation exists, calculate the simulated validation loss and
+   accuracy. Build and append `EpochMetrics`, then invoke
+   `on_epoch_end(epoch, metrics)`.
+5. Evaluate early stopping. A stop breaks the epoch loop before that epoch's
+   learning-rate update and periodic checkpoint callback.
+6. Set the next learning rate from the schedule using the base optimizer rate,
+   current global step, and current epoch.
+7. If checkpointing is enabled and the epoch count is an interval multiple,
+   construct an in-memory checkpoint and invoke `on_checkpoint`.
+8. Invoke `on_train_end(metrics)` and return a clone of the aggregate metrics.
+
+The simulated batch implementation increments both per-epoch and global step,
+adds the batch size to examples seen, and uses the following synthetic values:
+
+```text
+loss          = 0.5 × exp(-0.01 × global_step) + 0.1
+accuracy rate = 0.6 + 0.35 × (1 - exp(-0.005 × global_step))
+correct       = trunc(batch_size × accuracy rate)
+```
+
+Validation returns 110% of epoch training loss and 95% of epoch training
+accuracy. These values exercise reporting and stopping behavior only; neither
+is produced from model predictions.
+
+`checkpoint_interval` is not validated. When both a checkpoint directory is
+configured and the interval is zero, the periodic modulo check panics. Use a
+positive interval whenever checkpointing is enabled. Supplying a directory does
+not write a checkpoint: only callbacks receive the object.
+
+### Metrics and callbacks
+
+`EpochMetrics` contains the zero-based epoch, train and optional validation
+loss and accuracy, the learning rate recorded before the end-of-epoch schedule
+update, duration, and examples seen in that epoch. Metric lookup recognizes the
+four names used by early stopping.
+
+`TrainingMetrics::add_epoch` appends history and updates:
+
+- `best_val_loss` and `best_epoch` only for an epoch that has validation loss;
+- final training and optional validation loss from the appended epoch;
+- accumulated duration and `epochs_completed = epoch + 1`.
+
+`train_loss_history` preserves one value per epoch. `val_loss_history` omits
+epochs without validation. `is_overfitting(window)` needs at least two full
+history windows and compares mean training losses and validation losses across
+the earlier and most-recent windows. Its validation sums are still divided by
+`window` even when individual epochs lack validation, so use it only with
+validation metrics available for every epoch in the compared range.
+
+Callbacks are mutable `Send + Sync` trait objects. The no-op callback accepts
+every lifecycle event. `LoggingCallback` prints a summary at epoch end and a
+batch loss when `batch_idx % log_interval == 0`. Its constructor accepts zero,
+which makes the modulo expression panic on the first batch; use a positive
+logging interval.
+
+## Checkpoints and resumption
+
+`Checkpoint::new(epoch, global_step, metrics)` constructs an in-memory record
+with a UUID v4 identifier and current UTC timestamp. Its `weights` and
+`optimizer_state` vectors start empty. Neither `Checkpoint` nor `TrainingLoop`
+performs file creation, serialization, deserialization, or buffer restoration.
+
+With the `serde` feature, the struct serializes as JSON. Applications that
+populate and consume its byte vectors must preserve this byte-level contract:
+
+| Field | Required byte layout |
+| --- | --- |
+| `weights` | Little-endian `f32` values, layer by layer; for each layer, its row-major weight matrix then its biases; layers proceed input to output. |
+| `optimizer_state` | Optimizer-specific vectors per parameter: one velocity vector for momentum SGD; first (`m`) and second (`v`) moment vectors for Adam. |
+
+`TrainingLoop::checkpoint()` captures only the current epoch, global step, and
+cloned metrics in that record. `resume_from` restores exactly those three
+values. It does not restore weights, optimizer bytes, learning rate,
+early-stopping best metric, patience counter, callbacks, or the dataset
+position. Moreover, a subsequent `train()` starts its `for epoch in
+0..config.epochs` loop at zero and overwrites the restored current epoch.
+A resumed loop therefore needs external model/optimizer restoration and is not
+a continuation mechanism for epoch position or early-stopping state.
+
+## GPU path
+
+`GpuTrainer::new` creates a blocking `GpuContext`, wraps a `lattice_fann`
+network in `GpuNetwork`, and allocates state for each network layer.
+`with_context` uses an existing shared context instead. Both validate
+`TrainingConfig` first and initialize the current learning rate to the optimizer
+base rate.
+
+For each layer with `W` weights and `B` biases, initialization creates storage
+and copy-destination buffers for `W` weight gradients and `B` bias gradients.
+It also allocates three optimizer-state buffers—Adam first moment, Adam second
+moment, and SGD velocity—each sized for `W + B` `f32` values, regardless of the
+optimizer selected. The state timestep starts at zero.
+
+### Forward input, loss, and validation
+
+Each training example becomes one network input. If it has context embeddings,
+the trainer averages those vectors elementwise and then appends the message
+embedding. This requires all context embeddings to have the first context
+embedding's dimensionality; the current preparation code does not validate that
+invariant before indexing.
+
+The trainer calls synchronous GPU forward for every example and records only
+the input and output as its placeholder activation set. It rejects any NaN or
+infinite output before computing loss or accuracy.
+
+For output values `p`, target values `y`, smoothing amount `a`, and
+`C = output.len()`, the GPU loss calculation uses:
+
+```text
+y_smooth = (1 - a) × y + a / C
+sample loss = -Σ y_smooth × ln(max(p, 1e-7))
+batch loss = mean(sample loss)
+```
+
+The `1e-7` lower clamp applies only inside the logarithm. It prevents a
+logarithm of zero but does not alter the output vector used for accuracy or the
+placeholder backward derivative. `validate` accumulates each batch loss
+weighted by batch length, divides by the number of examples, and computes
+accuracy by comparing the index of the largest output to the index of the
+largest target. Empty validation data returns `(0.0, 0.0)`.
+
+### Backward and optimizer status
+
+The current backward preparation first forms `output - target` using the
+*unsmoothed* target. It then ignores those values: the CPU fallback uploads the
+constant gradient `0.01 / batch_size` for every weight and bias of every layer.
+Consequently, even before optimizer dispatch, this is placeholder work rather
+than an implementation of backpropagation for the loss above.
+
+All optimizer selections deliberately fail:
+
+| Optimizer | Current result |
+| --- | --- |
+| Adam | Returns `TuneError::Training`; shader buffer bindings are absent. |
+| AdamW | Returns the same error. |
+| SGD with momentum | Returns the same error. |
+| SGD | Returns `TuneError::Training`; there is neither real gradient plumbing nor mutable network weight write-back. |
+| RMSprop | Returns `TuneError::Training`; it does not substitute a different algorithm. |
+
+The failure is intentional. A previous no-op or substitute update would have
+made a training call look successful while leaving weights unchanged. Since the
+optimizer returns before its post-update bookkeeping, optimizer timesteps are
+not incremented and weights are not synchronized. `GpuTrainer::train_batch`
+only increments its global step and evaluates the next learning rate after a
+fully successful update, so failed calls cannot inflate step or schedule state.
+
+Until this status changes, use `GpuTrainer::validate` only for forward
+evaluation and handle `train_batch` errors as an expected capability boundary.
+
+## JIT adaptation
+
+`JitConfig` describes a short adaptation run. Its default is the
+`LastNLayers(2)` strategy, 100 steps, learning rate `0.001`, frozen-layer
+multiplier `0.1`, batch size 16, GPU requested, a 10-second timeout, patience
+10, minimum improvement `1e-4`, and seed 42.
+
+| Preset | Strategy | Steps | LR | Batch | Timeout | Patience |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `fast()` | head only | 50 | 0.01 | 32 | 5 s | 5 |
+| `thorough()` | last 3 layers | 200 | 0.001 | 16 | 10 s | 20 |
+| `few_shot()` | head only | 30 | 0.005 | 4 | 3 s | 5 |
+
+Validation requires positive `steps`, learning rate, batch size, and timeout.
+It does not validate strategy parameters, `frozen_lr_multiplier`, `patience`,
+or `min_delta`; callers must choose meaningful values for those fields.
+`use_gpu` is also stored but not consulted to select a method: callers choose
+explicitly between `adapt_cpu` and the feature-gated `adapt_gpu`.
+
+### Strategies and helper output
+
+The `freeze` helpers use `true` to mean a frozen layer and order layers from
+input to output.
+
+| Strategy | `get_frozen_layers` | `get_lr_multipliers` |
+| --- | --- | --- |
+| `LastNLayers(n)` | Freeze all except the final `min(n, total_layers)` layers. | Frozen layers get `frozen_lr_multiplier`; final layers get 1.0. |
+| `HeadOnly` | Freeze all except the final layer; an empty model remains empty. | Frozen layers get the multiplier; the head gets 1.0. |
+| `GradualUnfreeze` | All layers are marked trainable. | Linear interpolation from the frozen multiplier on layer 0 to 1.0 on the last layer. |
+| `LowRank { rank }` | Every original layer is frozen. | Every layer gets the frozen multiplier. |
+| `Full` | No layers are frozen. | Every layer gets 1.0. |
+
+The helpers describe selection only. In particular, the JIT adapter does not
+construct low-rank matrices, apply per-layer multipliers, or otherwise connect
+these strategy values to a model update path.
+
+### Adaptation loop and result
+
+Both CPU and GPU adaptation reject an empty example vector, create a dataset
+with the configured batch size, shuffle it, and use the configured seed or 42.
+When a batch iterator reaches the end, the adapter resets the dataset epoch and
+continues with the next batch.
+
+At the start of each requested step it checks `elapsed > timeout`; equality
+does not stop the run. It records a completed step's loss, then resets patience
+only when `loss < best_loss - min_delta`. Any other loss increments the counter;
+when it reaches `patience`, the result is early-stopped. A zero patience value
+therefore stops on the first non-improving completed step.
+
+CPU adaptation uses the synthetic loss:
+
+```text
+1 / (1 + 0.1 × step) + abs(sin(0.1 × step) × 0.1)
+```
+
+GPU adaptation invokes `GpuTrainer::train_batch` and then, if a run could
+finish, validates the same adaptation dataset to obtain final accuracy. The
+current GPU optimizer limitation prevents it from reaching that point.
+
+`JitResult` returns final loss (or positive infinity when no step completed),
+optional final accuracy, completed-step count, elapsed seconds, early-stop and
+timeout flags, and the complete loss history. `is_success()` means only that
+the run did not time out and its final loss is finite; an early-stopped result
+can be successful. `avg_loss()` returns zero for an empty history.

--- a/crates/tune/src/bin/train_common/mod.rs
+++ b/crates/tune/src/bin/train_common/mod.rs
@@ -1,13 +1,8 @@
-//! Binary-private support shared by `train_grad`, `train_grad_full`, and
-//! `train_grad_layer23` (issue #845): the loader, the CLI arg-lookup
-//! semantics, and the fail-closed TBV (trust-but-verify) check.
+//! Binary-private support shared by the gradient-training executables.
 //!
-//! Deliberately narrow. Each bin keeps its own typed config and usage text —
-//! defaults and supported flags genuinely differ between bins (see the flag
-//! table in issue #845) — so this module holds only the pieces that were
-//! byte-identical across all three: `Sample`/`load_jsonl`, the
-//! `parse_arg`/`parse_flag` lookup semantics (as `ArgView`), the shared
-//! path defaults, and `verify_tbv`.
+//! It owns JSONL sample loading, raw argument lookup, path defaults, and the
+//! fail-closed trust-but-verify comparison. Each binary owns its typed options
+//! and usage contract. See `docs/design.md` for the CLI data and TBV flow.
 
 use std::io::BufRead;
 use std::path::{Path, PathBuf};

--- a/crates/tune/src/bin/train_grad_full.rs
+++ b/crates/tune/src/bin/train_grad_full.rs
@@ -1,37 +1,10 @@
-// Multi-layer reverse-mode (exact) gradient LoRA trainer for Qwen3.5-0.8B.
+// Exact reverse-mode LoRA trainer for a Qwen3.5 layer range ending at layer 23.
 //
-// Generalises train_grad_layer23 from a single GQA layer to a layer RANGE
-// [first_layer ..= 23], dispatching per layer kind and propagating dx through
-// the frozen GatedDeltaNet layers via gdn_backward. This is the full-depth
-// backward tape: gradient from the CE loss flows back through the head, through
-// every materialised layer's FFN + mixer + norms, accumulating LoRA grads at the
-// GQA layers and threading dx through the frozen GDN layers in between.
-//
-//   h_in (frozen prefix 0..first_layer)  ── captured once per sample
-//   for L in first_layer ..= 23:
-//     normed_pre = rms_norm(h, pre_norm[L])
-//     mixer_out  = GQA(normed_pre; LoRA)  | GDN(normed_pre)   (frozen if GDN)
-//     h_mid      = h + mixer_out
-//     ffn_out    = swiglu(rms_norm(h_mid, post_norm[L]))
-//     h          = h_mid + ffn_out
-//   logits = lm_head · rms_norm(h, final_norm)
-//   loss   = CE(logits, next_token) over completion positions
-//
-// Default first_layer = 19, so the materialised stack is
-//   19 (GQA+LoRA) → 20,21,22 (GDN, frozen) → 23 (GQA+LoRA).
-// Layer-19's LoRA gradient is only correct if dx propagated correctly back
-// through the three frozen GDN layers, so the finite-difference gradcheck on
-// layer-19's params is the integration test for gdn_backward + the assembled
-// residual/norm chain — exactly the gap the per-block self-consistent
-// gradchecks cannot see.
-//
-// Qwen3.5 RMSNorm is SHIFTED (x·inv·(1+gamma)); rms_norm_forward/rmsnorm_backward
-// take plain gamma, so layer/final norms get (1+gamma) precomputed weights.
-// q_norm/k_norm are shifted inside gqa_forward_with_cache, so they stay raw.
-//
-// Usage: train_grad_full --model-dir <path> --data-dir <path> [--first-layer 19]
-//        [--steps 25] [--lr 1e-3] [--rank 8] [--alpha 16] [--max-train 3]
-//        [--seq-len 64] [--gradcheck]
+// It caches the frozen prefix, backpropagates through materialized GQA and
+// frozen GDN layers, and uses trust-but-verify before training or gradcheck.
+// Shifted RMSNorm weights are prepared for layer and final norms; GQA q/k
+// normalization remains owned by the GQA forward path. See docs/design.md for
+// the tape, JSONL contract, validation strategy, and command-line workflow.
 
 use std::path::PathBuf;
 use std::time::Instant;

--- a/crates/tune/src/data/dataset.rs
+++ b/crates/tune/src/data/dataset.rs
@@ -1,4 +1,8 @@
-//! Dataset loading and batching
+//! In-memory dataset filtering, batching, splitting, and statistics.
+//!
+//! Dataset configuration controls eligibility and epoch iteration; batches own
+//! cloned examples. See `docs/data.md` for filtering, shuffle, and split
+//! semantics.
 
 use super::TrainingExample;
 use crate::error::{Result, TuneError};
@@ -26,7 +30,7 @@ pub struct DatasetConfig {
     /// Minimum context size required (filter out shorter examples)
     pub min_context_size: usize,
 
-    /// Maximum context size (truncate longer sequences)
+    /// Maximum context size accepted when filtering at construction
     pub max_context_size: Option<usize>,
 }
 

--- a/crates/tune/src/data/example.rs
+++ b/crates/tune/src/data/example.rs
@@ -1,4 +1,8 @@
-//! Training example types
+//! Training examples, soft intent labels, and traceability metadata.
+//!
+//! Examples combine chronological embedding context with a fixed six-class
+//! label vector. See `docs/data.md` for the data contract and normalization
+//! rules.
 
 use uuid::Uuid;
 

--- a/crates/tune/src/data/mod.rs
+++ b/crates/tune/src/data/mod.rs
@@ -1,26 +1,8 @@
-//! Training data types and utilities
+//! Data contracts and in-memory batching for training.
 //!
-//! This module provides the core data structures for training:
-//! - [`TrainingExample`]: Individual training examples with embeddings and labels
-//! - [`IntentLabels`]: Soft labels from teacher models
-//! - [`Dataset`]: Collection of examples with batching support
-//!
-//! # Example
-//!
-//! ```
-//! use lattice_tune::data::{TrainingExample, IntentLabels, Dataset, DatasetConfig};
-//!
-//! // Create a dataset from examples
-//! let examples = vec![
-//!     TrainingExample::new(
-//!         vec![vec![0.1, 0.2, 0.3]],  // context embeddings
-//!         vec![0.4, 0.5, 0.6],        // message embedding
-//!         IntentLabels::continuation(0.8),
-//!     ),
-//! ];
-//!
-//! let dataset = Dataset::from_examples(examples);
-//! ```
+//! `TrainingExample` carries embeddings and soft labels, while `Dataset` turns
+//! examples into epoch batches. See `docs/data.md` for the full format,
+//! validation rules, and iteration behavior.
 
 mod dataset;
 mod example;

--- a/crates/tune/src/distill/mod.rs
+++ b/crates/tune/src/distill/mod.rs
@@ -1,30 +1,9 @@
-//! Knowledge distillation module
+//! Knowledge-distillation interfaces for producing soft intent labels.
 //!
-//! This module provides infrastructure for distilling knowledge from
-//! large teacher models (Claude, GPT, Gemini) into smaller student models.
-//!
-//! # Architecture
-//!
-//! ```text
-//! Raw Data → Teacher (LLM) → Soft Labels → Dataset → Student Training
-//! ```
-//!
-//! # Example
-//!
-//! ```ignore
-//! use lattice_tune::distill::{TeacherConfig, DistillationPipeline, DistillationConfig};
-//!
-//! // Configure the teacher model
-//! let teacher = TeacherConfig::claude_sonnet()
-//!     .temperature(0.3)
-//!     .build();
-//!
-//! // Create distillation pipeline
-//! let pipeline = DistillationPipeline::new(teacher, DistillationConfig::default());
-//!
-//! // Label raw examples
-//! let labeled = pipeline.label_batch(&raw_examples).await?;
-//! ```
+//! It configures a teacher, sanitizes raw conversational input, records label
+//! outcomes, and converts successful results after embeddings are supplied.
+//! See `docs/distill.md` for the full data flow, security policy, and current
+//! placeholder boundary.
 
 mod pipeline;
 mod teacher;

--- a/crates/tune/src/distill/pipeline/distill.rs
+++ b/crates/tune/src/distill/pipeline/distill.rs
@@ -1,4 +1,8 @@
-//! Distillation pipeline orchestration.
+//! Orchestration from raw prompts to labeled examples.
+//!
+//! This implementation validates configuration, formats prompts, and records
+//! results; its teacher response is currently simulated rather than fetched.
+//! See `docs/distill.md` for the execution path and integration boundaries.
 
 use super::DistillationConfig;
 use super::types::{DistillationStats, LabelingResult, RawExample};

--- a/crates/tune/src/distill/pipeline/types.rs
+++ b/crates/tune/src/distill/pipeline/types.rs
@@ -1,4 +1,8 @@
-//! Pipeline types: labeling results, statistics, and raw examples.
+//! Inputs, outputs, and accounting for the distillation pipeline.
+//!
+//! `RawExample` sanitizes and formats teacher input; `LabelingResult` carries
+//! one outcome, and `DistillationStats` aggregates outcomes. See
+//! `docs/distill.md` for prompt limits, result semantics, and statistics rules.
 
 use crate::data::{ExampleMetadata, IntentLabels};
 use uuid::Uuid;
@@ -192,12 +196,12 @@ impl RawExample {
         self
     }
 
-    /// Format for teacher prompt with input sanitization.
+    /// Format a bounded, control-character-sanitized teacher prompt.
     ///
     /// Applies the following sanitization:
     /// - Strips control characters (except newlines and tabs)
     /// - Truncates individual messages to `MAX_MESSAGE_LENGTH`
-    /// - Truncates total prompt to `MAX_PROMPT_LENGTH`
+    /// - Truncates prompt content to `MAX_PROMPT_LENGTH`
     pub fn to_prompt(&self) -> String {
         let mut prompt = String::new();
 
@@ -224,7 +228,7 @@ impl RawExample {
         prompt
     }
 
-    /// Sanitize user input to prevent prompt injection.
+    /// Sanitize user input before embedding it in a prompt.
     ///
     /// - Strips control characters (except \n, \t, \r)
     /// - Truncates to [`MAX_MESSAGE_LENGTH`]

--- a/crates/tune/src/distill/teacher/config.rs
+++ b/crates/tune/src/distill/teacher/config.rs
@@ -1,4 +1,8 @@
-//! Teacher model configuration and builder.
+//! Teacher selection, request policy, and endpoint-security configuration.
+//!
+//! Presets and the builder produce a `TeacherConfig`; validation checks its
+//! local invariants and custom endpoint policy before pipeline construction.
+//! See `docs/distill.md` for provider defaults, validation, and security limits.
 
 use super::TeacherProvider;
 use super::security::EndpointSecurity;
@@ -24,7 +28,7 @@ pub struct TeacherConfig {
     /// API key environment variable name
     pub api_key_env: String,
 
-    /// Temperature for generation (0.0 - 1.0)
+    /// Temperature for generation (0.0 - 2.0)
     pub temperature: f32,
 
     /// Maximum tokens in response

--- a/crates/tune/src/distill/teacher/security.rs
+++ b/crates/tune/src/distill/teacher/security.rs
@@ -1,4 +1,8 @@
-//! Endpoint security configuration for teacher models.
+//! Endpoint policy for teacher-model connections.
+//!
+//! The policy can require TLS, restrict hosts, and carry certificate or local
+//! weight-integrity expectations. See `docs/distill.md` for the exact checks
+//! performed today and the verification that remains the HTTP client's job.
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/tune/src/error.rs
+++ b/crates/tune/src/error.rs
@@ -1,4 +1,8 @@
-//! Error types for lattice-tune
+//! Error vocabulary shared by lattice-tune subsystems.
+//!
+//! `TuneError` preserves the domain that failed—data, teacher, training,
+//! registry, storage, validation, or integrity—while `Result` is the crate
+//! alias. See `docs/design.md` for subsystem ownership and hand-off points.
 
 use thiserror::Error;
 use uuid::Uuid;

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -2,39 +2,18 @@
 #![allow(clippy::needless_borrows_for_generic_args)]
 #![allow(clippy::field_reassign_with_default)]
 
-//! Training infrastructure for Lattice neural models: knowledge distillation, dataset
-//! management, the training loop, LoRA adapters, and a model registry with lineage.
+//! Training infrastructure for Lattice neural models.
 //!
-//! The pipeline runs data -> teacher (LLM) -> soft labels -> dataset -> training -> model
-//! -> registry. [`data`] holds training examples and batching, [`distill`] drives knowledge
-//! distillation from teacher models (Claude, GPT, Gemini), [`train`] is the training loop,
-//! optimizer, and checkpointing, and [`registry`] versions, stores, and tracks deployment of
-//! trained models. [`lora`] adapters can be trained here and, via the `inference-hook`
-//! feature, applied directly to a running `lattice-inference` forward pass.
+//! The crate connects data preparation, teacher-label distillation, training,
+//! LoRA adaptation, and versioned model registration. The public modules
+//! retain those boundaries: [`data`], [`distill`], [`train`], [`lora`], and
+//! [`registry`].
 //!
-//! # Quick start
-//!
-//! ```rust
-//! use lattice_tune::data::{TrainingExample, IntentLabels, Dataset, DatasetConfig};
-//!
-//! // Create training examples
-//! let examples = vec![
-//!     TrainingExample::new(
-//!         vec![vec![0.1, 0.2, 0.3]],  // context embeddings
-//!         vec![0.4, 0.5, 0.6],        // message embedding
-//!         IntentLabels::continuation(0.8),
-//!     ),
-//! ];
-//!
-//! // Create a dataset
-//! let dataset = Dataset::from_examples(examples);
-//! let stats = dataset.stats();
-//! println!("Dataset has {} examples", stats.num_examples);
-//! ```
+//! Optional features add serialization, GPU paths, registry storage, LoRA
+//! inference integration, and backward-training support.
 //!
 //! See [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/tune/docs/design.md)
-//! for the distillation, training, and registry walkthroughs, the `inference-hook` bridge in
-//! full, and the `Checkpoint` JSON schema.
+//! for architecture, lifecycle boundaries, and links to the subsystem guides.
 
 #![warn(missing_docs)]
 

--- a/crates/tune/src/lora/blend.rs
+++ b/crates/tune/src/lora/blend.rs
@@ -1,74 +1,35 @@
-//! Weighted blending of multiple LoRA adapters into a single rank-Σr adapter.
+//! Exact CPU blending of adapters into one higher-rank adapter.
 //!
-//! # Why blend instead of loading multiple adapters
+//! The blend vertically concatenates A blocks and horizontally concatenates B
+//! blocks after folding in each mixture weight and `alpha / rank` scale. Its
+//! returned configuration sets `alpha == rank_total`, so its scale is exactly 1.
 //!
-//! The Metal inference path holds exactly one `Option<MetalLoraAdapter>` slot.
-//! Rather than adding a Metal kernel that dispatches across N adapters,
-//! we pre-blend on the CPU once per request: the result is a standard single
-//! adapter loaded through the existing single-slot path with no kernel changes.
-//!
-//! # Blend math (exact, not approximate)
-//!
-//! For adapter `e` with effective scale `s_e = alpha_e / rank_e` and mixture
-//! weight `w_e`:
-//!
-//! ```text
-//! Δ_e x = s_e · B_e @ (A_e @ x)
-//! blend  = Σ_e  w_e · Δ_e x
-//!        = B_blend @ (A_blend @ x)
-//! ```
-//!
-//! where
-//! - `A_blend = vconcat[A_1; …; A_N]`          shape `(Σr_e) × d_in`
-//! - `B_blend = hconcat[(w_1·s_1)·B_1 | …]`    shape `d_out × (Σr_e)`
-//!
-//! The `w_e · s_e` coefficient is folded into the B column block so the
-//! blended adapter's effective scale is exactly **1.0** (`alpha = rank_total`).
+//! See `docs/lora-core.md` for the derivation, limits, and failure behavior.
 
 use crate::error::{Result, TuneError};
 use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
 use std::collections::HashMap;
 
-/// Maximum total rank allowed across all adapters in a single blend.
-///
-/// The GEMV kernels that consume the blended adapter assume a modest rank budget
-/// (≤ ~64 per adapter in a typical mixture).  This cap allows a generous mixture
-/// while bounding allocations and rejecting adversarially large adapter pools.
+/// Maximum summed rank for one blended projection.
 pub(crate) const MAX_BLEND_RANK_TOTAL: usize = 4096;
 
-/// Aggregate cap on a blended adapter's total element count, summed across
-/// every (layer_idx, module) projection: Σ rank_total·(d_in + d_out). At f32
-/// this bounds the blended-adapter allocation to ~4 GiB. MAX_BLEND_RANK_TOTAL
-/// bounds one projection; this bounds the whole blend, so a full-model adapter
-/// that keeps every projection near the per-group cap cannot drive a multi-GiB
-/// aggregate allocation. A realistic micro-LoRA mixture is far below this; a
-/// large-model mixture at modest summed rank stays within budget, while a
-/// rank-4096-everywhere adapter (tens of GiB) is rejected before any allocation.
+/// Aggregate cap on all blended A and B elements (about 4 GiB of f32 storage).
 pub(crate) const MAX_BLEND_TOTAL_ELEMENTS: usize = 1 << 30; // 1,073,741,824 elements ≈ 4 GiB f32
 
 /// Blend a set of `(adapter, mixture_weight)` pairs into one rank-Σr adapter.
 ///
-/// Each adapter in `adapters` contributes to the blended result with its
-/// corresponding weight `w_e`.  The per-adapter `alpha/rank` scale is folded
-/// into the B column block, so the returned adapter's effective scale is 1.0
-/// (i.e., `LoraConfig { alpha: rank_total, rank: rank_total }`).
-///
-/// # Target-module semantics
-///
-/// For each `(layer_idx, module)` pair that appears in **any** of the input
-/// adapters, a blended layer is produced.  An adapter that does not cover a
-/// given pair contributes zero (it is simply absent from the vertical/horizontal
-/// concatenation for that pair).
+/// Each adapter contributes with its corresponding mixture weight. Its
+/// `alpha/rank` scale is folded into B, and the returned adapter has scale 1.
+/// Every projection present in any input is included; inputs missing that
+/// projection contribute nothing to its blended layer.
 ///
 /// # Errors
 ///
 /// Returns an error if:
 /// - `adapters` is empty
 /// - Any weight is not finite
-/// - Two adapters share a `(layer_idx, module)` pair but disagree on `d_in` or `d_out`
-/// - The summed rank for a single projection exceeds `MAX_BLEND_RANK_TOTAL`
-/// - The aggregate blend size across all projections exceeds `MAX_BLEND_TOTAL_ELEMENTS`
-/// - A layer's A or B buffer length does not match its declared `rank`, `d_in`, or `d_out`
+/// - Shared projections disagree on dimensions or have malformed buffers
+/// - A rank, allocation budget, or size calculation exceeds its limit
 /// - Rank accumulation or a size product overflows `usize`
 pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapter> {
     if adapters.is_empty() {

--- a/crates/tune/src/lora/loader.rs
+++ b/crates/tune/src/lora/loader.rs
@@ -1,8 +1,10 @@
-//! Fail-closed manifest-driven loader for LoRA adapters.
+//! Fail-closed manifest-driven loading for LoRA adapters.
 //!
-//! `load_adapters_from_manifest` validates every approved adapter through
-//! eleven ordered checks, returning `Err` on the first anomaly encountered.
-//! There is no partial success and no silent skip.
+//! Every manifest entry must be approved and pass path, size, integrity,
+//! format, metadata, and optional serving-revision checks before any adapter
+//! list is returned. The loader never silently skips a failed entry or returns
+//! a partial result.
+//! See docs/lora-io.md.
 
 use super::LoraAdapter;
 use super::manifest::{AdapterId, AdapterStatus, LoraManifest, ManifestEntry};

--- a/crates/tune/src/lora/manifest.rs
+++ b/crates/tune/src/lora/manifest.rs
@@ -1,8 +1,9 @@
-//! LoRA adapter manifest — governance and integrity tracking.
+//! Versioned LoRA manifest schema and bounded JSON I/O.
 //!
-//! The manifest is a human-reviewed JSON document that records every adapter
-//! produced by a training run. Loaders consult it to enforce approval status
-//! and integrity before materialising weights.
+//! A manifest records adapter provenance, integrity data, and one authoritative
+//! status. Only approved entries are admissible to the governed loader.
+//!
+//! See `docs/lora-core.md` for schema version 1 and fail-closed loading rules.
 
 use crate::error::{Result, TuneError};
 use serde::{Deserialize, Serialize};
@@ -10,11 +11,7 @@ use std::path::Path;
 
 /// Maximum on-disk size of the manifest JSON file, in bytes (64 MiB).
 ///
-/// A manifest is a small governance document (typically a few kilobytes). The
-/// adapter-file cap is 10 GiB, but that ceiling is inappropriate here: a file
-/// that large would be materialised entirely before parsing — an allocation-DoS
-/// regardless of legitimacy. 64 MiB is orders of magnitude larger than any real
-/// manifest while still blocking a trivially-oversized attacker-supplied path.
+/// This cap is enforced before parsing and again with a bounded read sentinel.
 const MAX_MANIFEST_SIZE: u64 = 64 * 1024 * 1024;
 
 /// Opaque adapter identifier (arbitrary string; a UUID is conventional).
@@ -48,18 +45,9 @@ impl AdapterStatus {
 
 /// Metadata and governance state for one adapter in the manifest.
 ///
-/// Field set intentionally matches the #439 design intent
-/// `{name, owner, uri, base_model_rev, tokenizer_rev, integrity_sha256,
-/// dtype, approved}` (see issue #610), with one reconciliation:
-/// `status: AdapterStatus` is carried instead of a separate `approved: bool`.
-/// `AdapterStatus` is a strict superset of that boolean —
-/// `status == AdapterStatus::Approved` *is* `approved == true`, and the
-/// `Quarantined` / `Revoked` variants add fail-closed distinctions the
-/// loader already gives distinct error messages for (see
-/// `loader::load_adapters_from_manifest` Check 1). Adding a redundant
-/// `approved: bool` alongside `status` would create two sources of truth
-/// for the same governance decision with no defined precedence when they
-/// disagree; recorded in ADR-045.
+/// `status` is the sole approval authority; a separate `approved` boolean
+/// would create conflicting sources of truth. See ADR-045 and
+/// `docs/lora-core.md`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManifestEntry {
     /// Opaque identifier; matched against the `adapter_id` field in the
@@ -98,7 +86,8 @@ pub struct ManifestEntry {
 /// Governed manifest listing admissible adapters.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoraManifest {
-    /// Manifest schema version. Current: 1.
+    /// Manifest schema version. New manifests use 1; parsing preserves the
+    /// supplied value without enforcing a supported-version set.
     pub version: u32,
     /// All adapter entries. The loader iterates this list; order is not significant.
     pub adapters: Vec<ManifestEntry>,

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -1,37 +1,10 @@
-//! LoRA (Low-Rank Adaptation) adapter loading and inference integration.
+//! LoRA adapters, lightweight training helpers, and inference integration.
 //!
-//! This module implements the Rust side of a LoRA fine-tuning pipeline:
-//! **train (Python/PEFT) -> export safetensors -> load in Rust -> apply during inference**.
+//! A layer stores row-major `A: (rank, d_in)` and `B: (d_out, rank)` and adds
+//! `(alpha / rank) * B @ (A @ x)` to a base projection. The adapter constructor
+//! rejects non-finite alpha values; a zero rank has an effective scale of zero.
 //!
-//! LoRA decomposes weight updates into low-rank matrices:
-//! `dW = B @ A` where A is `(rank, d_in)` and B is `(d_out, rank)`.
-//! During inference, the output is modified as:
-//! `output += (alpha / rank) * B @ (A @ x)`
-//!
-//! # Supported target modules
-//!
-//! For Qwen3.5-2B (and similar transformer architectures):
-//! - **Attention**: `q_proj`, `k_proj`, `v_proj`, `o_proj`
-//! - **MLP**: `gate_proj`, `up_proj`, `down_proj`
-//!
-//! For BERT/CrossEncoder models:
-//! - **Attention**: `query`, `key`, `value`, `attn_output`
-//! - **FFN**: `ffn_intermediate`, `ffn_output`
-//!
-//! # Example
-//!
-//! ```ignore
-//! use lattice_tune::lora::LoraAdapter;
-//! use std::path::Path;
-//!
-//! // Load a PEFT-exported adapter
-//! let adapter = LoraAdapter::from_safetensors(Path::new("adapter.safetensors"))?;
-//!
-//! // Apply to a projection output during inference
-//! let x = vec![0.1f32; 2048];         // input activation
-//! let mut output = vec![0.0f32; 2048]; // base projection output
-//! adapter.apply(5, "q_proj", &x, &mut output);
-//! ```
+//! See `docs/lora-core.md` for the training, blending, and manifest design.
 
 mod apply;
 pub mod blend;

--- a/crates/tune/src/lora/online.rs
+++ b/crates/tune/src/lora/online.rs
@@ -1,8 +1,10 @@
-//! Online single-event SGD for LoRA weights (ADR-057 D3).
+//! One-event SGD refitting for a LoRA layer.
 //!
-//! Provides [`adapt_step`] for one gradient descent step given a single
-//! (input, target_delta) pair. The forward pass matches `apply_lora` exactly,
-//! then back-propagates through B and A using the MSE residual.
+//! [`adapt_step`] matches inference arithmetic, then updates A and B from the
+//! squared-error residual for one `(input, target_delta)` observation.
+//!
+//! See ADR-057 for the decision record.
+//! See `docs/lora-core.md` for the objective, gradients, and diagnostics.
 
 use super::LoraAdapter;
 use crate::error::TuneError;

--- a/crates/tune/src/lora/optimizer.rs
+++ b/crates/tune/src/lora/optimizer.rs
@@ -1,8 +1,10 @@
-//! Adam and AdamW optimizers for LoRA weight updates.
+//! Adam/AdamW state and exact single-layer LoRA gradient computation.
 //!
-//! Provides [`AdamState`] for stateful Adam/AdamW updates and
-//! [`compute_lora_gradients`] which mirrors the forward/backward pass of
-//! [`adapt_step`](super::online::adapt_step) without applying the update.
+//! Adam state and bias correction are tracked per parameter key, never with a
+//! global timestep. [`compute_lora_gradients`] uses the same MSE arithmetic as
+//! [`adapt_step`](super::online::adapt_step) without changing adapter weights.
+//!
+//! See `docs/lora-core.md` for the optimizer and local-refit equations.
 
 use std::collections::HashMap;
 
@@ -11,16 +13,10 @@ use crate::error::TuneError;
 
 /// Stateful Adam / AdamW optimizer.
 ///
-/// Tracks per-parameter first and second moment estimates keyed by an
-/// arbitrary string (typically `"{layer_idx}_{module}_{param}"` where
-/// `param` is `"a"` or `"b"`).  Each key advances its OWN Adam timestep, so
-/// bias correction reflects how many updates that tensor has received — not
-/// how many `step` calls occurred across all keys.  (A single shared counter
-/// over-advances `t` whenever one optimiser step updates several tensors, as
-/// LoRA training does — every tensor then bias-corrects with a `t` far larger
-/// than its true update count, inflating m̂/√v̂ and over-stepping early updates,
-/// which defeats Adam's warmup.  Per-key `t` matches MLX/PyTorch, which key the
-/// timestep per parameter.)
+/// Tracks moments and a bias-correction timestep per parameter key.
+///
+/// A key's timestep advances only when that tensor is updated; sharing one
+/// counter across LoRA tensors would bias-correct later tensors incorrectly.
 pub struct AdamState {
     /// First moment estimates (exponential moving average of gradients).
     m: HashMap<String, Vec<f32>>,
@@ -45,7 +41,8 @@ impl AdamState {
     ///
     /// # Arguments
     ///
-    /// * `key` - Unique string key identifying this parameter tensor.
+    /// * `key` - Stable, unique string key identifying this parameter tensor.
+    ///   Reusing a key requires the parameter slice to keep the same length.
     /// * `params` - Parameter slice to update in place.
     /// * `grads` - Gradient slice (same length as `params`).
     /// * `lr` - Learning rate for this step (may be scheduled externally).
@@ -147,31 +144,11 @@ pub struct LoraGradients {
     pub loss: f32,
 }
 
-/// Compute LoRA gradients without applying an update.
+/// Compute local MSE gradients without applying an update.
 ///
-/// Mirrors the forward / backward arithmetic in [`adapt_step`](super::online::adapt_step)
-/// exactly, returning raw gradients instead of performing an SGD step.
-///
-/// # Forward pass
-///
-/// ```text
-/// intermediate = A @ input          (rank,)
-/// delta        = scale * B @ intermediate  (d_out,)
-/// error        = delta - target_delta
-/// loss         = ||error||²
-/// ```
-///
-/// # Backward pass
-///
-/// ```text
-/// dL/dB[i,r] = 2 · scale · error[i] · intermediate[r]
-/// dL/dA[r,j] = 2 · scale · (Bᵀ·error)[r] · input[j]
-/// ```
-///
-/// # Errors
-///
-/// * [`TuneError::Training`]          – layer `(layer_idx, module)` not found.
-/// * [`TuneError::DimensionMismatch`] – `input` or `target_delta` wrong length.
+/// Uses the same forward and backward arithmetic as
+/// [`adapt_step`](super::online::adapt_step). Returns [`TuneError::Training`]
+/// for a missing layer and [`TuneError::DimensionMismatch`] for bad input sizes.
 pub fn compute_lora_gradients(
     adapter: &LoraAdapter,
     layer_idx: usize,

--- a/crates/tune/src/lora/router_update.rs
+++ b/crates/tune/src/lora/router_update.rs
@@ -1,36 +1,11 @@
-//! Online adapter-selector refit from preference feedback signals.
+//! Online refit of an adapter-selection gate from preference feedback.
 //!
-//! Consumes a batch of [`FeedbackEvent`]s, retunes the adapter-selection gate
-//! network with a single-sample policy-gradient update (RLOO / M=1), applies
-//! Fisher null-space damping for anti-forgetting (v1), and returns the updated
-//! gate as a self-contained FANN binary blob.
-//!
-//! # Anti-forgetting mechanism (v1)
-//!
-//! The shipped v1 mechanism is **Fisher null-space damping** via
-//! [`DiagonalFisher::project_delta`]: parameters with a high squared-gradient
-//! EMA (important to prior tasks) have their update scaled toward zero;
-//! parameters with near-zero importance pass through unchanged.  The anchor
-//! parameter vector is updated at the end of each refit call, but it is used
-//! only by the off-by-default penalty path — not by `project_delta`.
-//!
-//! The anchor-pullback penalty ([`DiagonalFisher::penalty_gradient`]) is a
-//! tested Phase-2 path wired to [`RouterUpdateConfig::ewc_lambda`].  It is
-//! **not** active in v1; `ewc_lambda` is validated and stored but not consumed
-//! by the current update loop.
-//!
-//! # Polarity invariant
-//!
-//! The reward carried in each [`FeedbackEvent`] flows through a **single code
-//! path** to [`RlooTrainer::step`].  Positive reward raises the target
-//! adapter's routing probability; negative reward lowers it.  There is no
-//! separate branch for negative feedback — the sign is embedded in the
-//! gradient formula (`reward * (p - onehot(action))`).  See
-//! [`RlooTrainer::step`] for the derivation.
-//!
-//! # Feature gate
-//!
-//! This entire module is compiled only when the `mixture` feature is active.
+//! Each signed reward takes the same RLOO update path: positive feedback raises
+//! the selected adapter's score and negative feedback lowers it. v1 protects
+//! prior routing behavior with Fisher delta projection; `ewc_lambda` is
+//! validated but intentionally inactive until the penalty-gradient path ships.
+//! This module requires the `mixture` feature.
+//! See docs/lora-router.md.
 
 use std::collections::VecDeque;
 

--- a/crates/tune/src/lora/safetensors.rs
+++ b/crates/tune/src/lora/safetensors.rs
@@ -1,15 +1,10 @@
-//! Load PEFT-format LoRA adapters from safetensors files.
+//! PEFT/MLX safetensors import and PEFT-compatible export for LoRA adapters.
 //!
-//! PEFT (Parameter-Efficient Fine-Tuning) saves LoRA weights with keys like:
-//! ```text
-//! base_model.model.model.layers.{i}.self_attn.q_proj.lora_A.weight  -> (rank, d_in)
-//! base_model.model.model.layers.{i}.self_attn.q_proj.lora_B.weight  -> (d_out, rank)
-//! base_model.model.model.layers.{i}.mlp.gate_proj.lora_A.weight     -> (rank, d_in)
-//! base_model.model.model.layers.{i}.mlp.gate_proj.lora_B.weight     -> (d_out, rank)
-//! ```
-//!
-//! This module parses those keys, extracts layer index and module name,
-//! and loads the A/B matrix pairs into [`LoraLayer`] structs.
+//! A factor pair is keyed by transformer layer and projection: A is
+//! `(rank, d_in)` and B is `(d_out, rank)` after MLX normalization. Parsing
+//! rejects incomplete, malformed, non-finite, or rank-inconsistent pairs.
+//! File reads are bounded before parsing.
+//! See docs/lora-io.md.
 
 use super::{LoraAdapter, LoraConfig, LoraLayer};
 use crate::error::TuneError;

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -1,8 +1,10 @@
-//! Micro-LoRA training: CPU backward pass for a configurable layer range.
+//! CPU micro-LoRA training over a bounded Qwen3.5 layer suffix.
 //!
-//! Provides a self-contained training loop over caller-supplied token pairs.
-//! Callers that need full training infrastructure (data loading, gradcheck,
-//! validation) should use the `train_grad_full` binary instead.
+//! The public helper trains GQA `q_proj` and `v_proj` weights with exact
+//! gradients; GatedDeltaNet layers remain frozen while preserving gradient flow.
+//! It validates all caller-controlled shape, range, and sequence bounds first.
+//!
+//! See `docs/lora-core.md` for the tape, loop, and configuration details.
 
 use std::collections::HashMap;
 

--- a/crates/tune/src/lora/train_core.rs
+++ b/crates/tune/src/lora/train_core.rs
@@ -1,5 +1,12 @@
 #![allow(missing_docs)]
 
+//! Private backward tape for micro-LoRA training.
+//!
+//! The tape materializes a Qwen3.5 suffix, preserves mixer and FFN activations,
+//! and uses a validated context to bind geometry, slots, rank/scale, and Adam.
+//!
+//! See `docs/lora-core.md` for the forward/backward walk and shape invariants.
+
 use lattice_inference::attention::gdn::GatedDeltaNetWeights;
 use lattice_inference::attention::gdn_backward::{GdnSaved, gdn_backward, gdn_forward_save};
 use lattice_inference::backward::attention_gqa::{AttnCache, gqa_backward, gqa_forward_with_cache};
@@ -283,22 +290,10 @@ impl AdamConfig {
     }
 }
 
-/// Validated, immutable run context for the training tape's core entry
-/// points (`forward_full`, `eval_chain_nll`, `nll_and_grads`,
-/// `apply_adam_updates`, `apply_gdn_adam_updates`).
+/// Validated, immutable context for the training tape's core entry points.
 ///
-/// `TrainCtx::try_new` is the only constructor: it validates rank and
-/// hyperparameter finiteness, checks that `geometry`'s `Dims`/`GdnDims` agree
-/// with `geometry.model`, and checks that `slots`' GQA/GDN layer indices are
-/// each unique, in-range for `geometry.model`, and never claim the same layer
-/// index for both mixer kinds. A `TrainCtx` cannot exist unless all of that
-/// holds, so callers of the narrowed entry points no longer have to
-/// reconstruct — or get wrong — the positional-argument agreement the old
-/// ten-argument signatures relied on.
-///
-/// Non-goal: `TrainCtx` owns geometry, layout, and optimizer policy only — it
-/// never owns weights, caches, gradients, LoRA vectors, or optimizer state
-/// (see issue #844's Non-goals).
+/// It binds geometry, layer slots, execution scale, and Adam policy, but never
+/// owns weights, caches, gradients, LoRA vectors, or optimizer state.
 pub struct TrainCtx<'a> {
     geometry: TapeGeometry<'a>,
     lora: LoraExecution,

--- a/crates/tune/src/registry/live_model.rs
+++ b/crates/tune/src/registry/live_model.rs
@@ -1,28 +1,9 @@
-//! Live model handle for atomic hot-swap during inference.
+//! Lock-free snapshots and atomic replacement for a live model record.
 //!
-//! [`LiveModel`] wraps a [`RegisteredModel`] in an [`ArcSwap`], enabling
-//! lock-free reads and atomic swaps for model hot-reload scenarios.
+//! A loaded [`RegisteredModel`] remains valid after a swap; a new load sees
+//! the replacement. This handle does not load weights or persist a deployment.
 //!
-//! # Example
-//!
-//! ```
-//! use lattice_tune::registry::{RegisteredModel, LiveModel};
-//!
-//! let model_v1 = RegisteredModel::new("classifier", "1.0.0");
-//! let live = LiveModel::new(model_v1);
-//!
-//! // Read current model (lock-free)
-//! let current = live.load();
-//! assert_eq!(current.version, "1.0.0");
-//!
-//! // Hot-swap to new version
-//! let model_v2 = RegisteredModel::new("classifier", "2.0.0");
-//! let old = live.swap(model_v2);
-//! assert_eq!(old.version, "1.0.0");
-//!
-//! // Readers now see v2
-//! assert_eq!(live.version(), "2.0.0");
-//! ```
+//! See `docs/registry.md` for live-model replacement semantics.
 
 use arc_swap::ArcSwap;
 use std::sync::Arc;
@@ -30,14 +11,10 @@ use uuid::Uuid;
 
 use super::model::RegisteredModel;
 
-/// A handle to a live model that can be atomically swapped.
+/// A handle to a live model record that can be atomically swapped.
 ///
-/// Readers get a consistent snapshot via [`load()`](LiveModel::load) (lock-free);
-/// writers replace the model atomically via [`swap()`](LiveModel::swap).
-///
-/// This is designed for inference hot-reload: an inference server holds a
-/// `LiveModel` and reads the current model on each request. A background
-/// updater swaps in a new model version without blocking readers.
+/// `load` returns a stable, lock-free [`Arc`] snapshot; `swap` replaces the
+/// current record without invalidating prior snapshots.
 pub struct LiveModel {
     current: ArcSwap<RegisteredModel>,
 }

--- a/crates/tune/src/registry/mod.rs
+++ b/crates/tune/src/registry/mod.rs
@@ -1,52 +1,10 @@
-//! Model registry module
+//! Versioned model records, artifact storage, and deployment helpers.
 //!
-//! Provides versioned model storage and retrieval with deployment features.
+//! [`ModelRegistry`] provides lock-free record reads and serialized writes;
+//! [`LiveModel`] atomically swaps a serving record. Shadow evaluation and
+//! rollback recording are explicit workflow helpers, not automatic deployment.
 //!
-//! # Architecture
-//!
-//! ```text
-//! Training → Model → Registry → Shadow → Deployment
-//!                  ↓              ↓           ↓
-//!              Storage     Evaluation    Rollback
-//! ```
-//!
-//! # Concurrency
-//!
-//! [`ModelRegistry`] uses `ArcSwap` for lock-free reads during concurrent
-//! updates. All read methods return owned snapshots; write methods are
-//! serialized internally. See [`LiveModel`] for atomic model hot-swap.
-//!
-//! # Safe Deployment
-//!
-//! The registry includes two features for safe model deployment:
-//!
-//! - **Shadow Evaluation** ([`ShadowSession`]): Run candidate models in parallel
-//!   with production to compare outputs before promotion.
-//! - **Rollback** ([`RollbackController`]): Quickly revert to a previous model
-//!   version when issues are detected, with full audit history.
-//!
-//! # Security
-//!
-//! When the `safetensors` feature is enabled, model weights can be serialized
-//! using the safetensors format which prevents arbitrary code execution attacks.
-//! This is **strongly recommended** for production deployments.
-//!
-//! # Example
-//!
-//! ```ignore
-//! use lattice_tune::registry::{ModelRegistry, RegisteredModel, ModelMetadata};
-//!
-//! // Create a registry
-//! let mut registry = ModelRegistry::new("/path/to/models");
-//!
-//! // Register a model
-//! let model = RegisteredModel::new("intent_classifier", "1.0.0")
-//!     .with_metadata(metadata);
-//! registry.register(model)?;
-//!
-//! // Load a model
-//! let model = registry.get("intent_classifier", "1.0.0")?;
-//! ```
+//! See `docs/registry.md` for the registry design, storage formats, and lifecycle.
 
 mod live_model;
 mod model;

--- a/crates/tune/src/registry/model.rs
+++ b/crates/tune/src/registry/model.rs
@@ -1,4 +1,9 @@
-//! Registered model types
+//! Versioned registry records, metadata, status, and lineage fields.
+//!
+//! Status is descriptive rather than an enforced state machine, and lineage
+//! links are maintained by callers.
+//!
+//! See `docs/registry.md` for identity, versioning, metadata, and lifecycle details.
 
 use crate::train::TrainingMetrics;
 use chrono::{DateTime, Utc};

--- a/crates/tune/src/registry/rollback.rs
+++ b/crates/tune/src/registry/rollback.rs
@@ -1,31 +1,9 @@
-//! Rollback controller for model version management.
+//! Bounded in-memory audit records for model rollbacks.
 //!
-//! Enables safe rollback to previous model versions with history tracking.
-//! When a production model causes issues, operators can roll back to a
-//! known-good version while maintaining an audit trail.
+//! Recording a rollback does not update registry status, swap a live model, or
+//! persist the audit trail. Applications coordinate those operations explicitly.
 //!
-//! # Example
-//!
-//! ```
-//! use lattice_tune::registry::{RollbackController, RollbackRecord};
-//! use uuid::Uuid;
-//!
-//! let mut controller = RollbackController::new(100);
-//!
-//! // Record a rollback operation
-//! let from_id = Uuid::new_v4();
-//! let to_id = Uuid::new_v4();
-//! let record = controller.record_rollback(
-//!     from_id,
-//!     to_id,
-//!     "Performance regression detected",
-//!     Some("ops-team".to_string()),
-//! );
-//!
-//! // Query history
-//! assert_eq!(controller.history().len(), 1);
-//! assert_eq!(controller.last_rollback().unwrap().reason, "Performance regression detected");
-//! ```
+//! See `docs/registry.md` for rollback lifecycle and retention semantics.
 
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
@@ -73,16 +51,10 @@ impl RollbackRecord {
     }
 }
 
-/// Controller for model rollback operations.
+/// Bounded in-memory history of rollback operations.
 ///
-/// Maintains a bounded history of rollback operations for audit and
-/// debugging purposes. The history is stored in memory; for persistence,
-/// serialize the records externally.
-///
-/// # Thread Safety
-///
-/// This type is NOT thread-safe. For concurrent access, wrap in a
-/// `Mutex` or `RwLock`.
+/// The controller does not enact a rollback or persist records. Synchronize
+/// mutable shared access externally with a `Mutex` or `RwLock`.
 pub struct RollbackController {
     /// History of rollback operations (oldest first)
     history: Vec<RollbackRecord>,

--- a/crates/tune/src/registry/safetensors_io.rs
+++ b/crates/tune/src/registry/safetensors_io.rs
@@ -1,35 +1,9 @@
-//! Safe checkpoint serialization using safetensors format.
+//! Safetensors serialization for flat `f32` weight vectors.
 //!
-//! This module provides secure model weight serialization that prevents
-//! arbitrary code execution vulnerabilities found in formats like Python pickle.
+//! Parsing accepts data only and validates the safetensors container, but it
+//! does not replace registry identity or checksum verification.
 //!
-//! # Security Guarantees
-//!
-//! The safetensors format provides:
-//! - **No code execution**: Pure data format, cannot contain executable code
-//! - **Memory safety**: Zero-copy deserialization with bounds checking
-//! - **Integrity**: Header contains tensor shapes and data types
-//!
-//! # Format
-//!
-//! ```text
-//! [8 bytes: header size (little-endian u64)]
-//! [header: JSON metadata + tensor info]
-//! [tensor data: raw bytes, aligned]
-//! ```
-//!
-//! # Example
-//!
-//! ```ignore
-//! use lattice_tune::registry::safetensors_io::{save_weights, load_weights};
-//!
-//! // Save weights securely
-//! let weights: Vec<f32> = vec![0.1, 0.2, 0.3];
-//! let bytes = save_weights(&weights, "layer0.weights")?;
-//!
-//! // Load weights safely (validates format, no code execution)
-//! let loaded: Vec<f32> = load_weights(&bytes, "layer0.weights")?;
-//! ```
+//! See `docs/registry.md` for the format, tensor contract, and security boundary.
 
 use crate::error::{Result, TuneError};
 use safetensors::Dtype;

--- a/crates/tune/src/registry/shadow.rs
+++ b/crates/tune/src/registry/shadow.rs
@@ -1,43 +1,9 @@
-//! Shadow evaluation for safe model deployment.
+//! Candidate-versus-production comparison for deployment decisions.
 //!
-//! Runs candidate models in parallel with production to compare outputs
-//! before promotion. This enables data-driven deployment decisions based
-//! on real traffic rather than synthetic benchmarks.
+//! Callers select traffic, run both models, and record observations. A session
+//! transitions only after its sample minimum; it never promotes a candidate.
 //!
-//! # Workflow
-//!
-//! 1. Create a [`ShadowSession`] with production and candidate model IDs
-//! 2. For each sampled request, run both models and call [`record_sample`]
-//! 3. Call [`evaluate`] periodically to check if criteria are met
-//! 4. If [`passed`] returns true, promote the candidate to production
-//!
-//! # Example
-//!
-//! ```
-//! use lattice_tune::registry::{ShadowSession, ShadowConfig, ShadowState};
-//! use uuid::Uuid;
-//!
-//! let production_id = Uuid::new_v4();
-//! let candidate_id = Uuid::new_v4();
-//!
-//! let config = ShadowConfig {
-//!     sample_rate: 0.1,      // Sample 10% of traffic
-//!     min_samples: 100,      // Need at least 100 samples
-//!     min_agreement: 0.95,   // 95% agreement threshold
-//!     max_latency_increase_ms: 50.0,
-//! };
-//!
-//! let mut session = ShadowSession::new(production_id, candidate_id, config);
-//!
-//! // Record samples (in real usage, from actual inference)
-//! for _ in 0..100 {
-//!     session.record_sample(true, 5.0); // agreed, 5ms slower
-//! }
-//!
-//! // Evaluate
-//! let state = session.evaluate();
-//! assert!(session.passed());
-//! ```
+//! See `docs/registry.md` for shadow configuration, state transitions, and metrics.
 
 use chrono::{DateTime, Utc};
 use uuid::Uuid;

--- a/crates/tune/src/registry/storage/backends.rs
+++ b/crates/tune/src/registry/storage/backends.rs
@@ -1,4 +1,9 @@
-//! Storage backend implementations.
+//! In-memory, filesystem, and optional SQLite artifact storage backends.
+//!
+//! Backends define artifact persistence; the registry maintains its own
+//! in-process indexes and checksum policy.
+//!
+//! See `docs/registry.md` for layouts, failure ordering, and SQLite upgrades.
 
 use super::{StorageBackend, validate_model_identity, validate_path};
 use crate::error::{Result, TuneError};
@@ -66,22 +71,10 @@ pub struct SqliteStorage {
     weights_dir: PathBuf,
 }
 
-/// Rename the `metadata_json` column in the `models` table to `metadata`.
+/// Idempotently rename legacy `metadata_json` to `metadata` when present.
 ///
-/// This is an idempotent upgrade migration (#1392): databases created before
-/// the column was renamed will have `metadata_json`; databases created after
-/// will already have `metadata`.  We attempt the rename and silently succeed
-/// if the old column no longer exists (already migrated or fresh schema).
-///
-/// Idempotency is implemented by checking the actual column list in
-/// `sqlite_master` before attempting the rename, which avoids relying on
-/// error-string matching across SQLite versions.
-///
-/// # Errors
-///
-/// Returns an error if the column exists but the rename fails for any
-/// unexpected reason.  Fail-closed: we never silently swallow unexpected
-/// errors.
+/// The actual column list decides whether a rename is needed; unexpected
+/// SQLite errors abort initialization. See `docs/registry.md` for upgrades.
 // Called from SqliteStorage::new() which is cfg(feature = "sqlite");
 // the compiler cannot trace the call site when checking without that feature.
 #[cfg(feature = "sqlite")]
@@ -103,50 +96,12 @@ fn migrate_models_metadata_json_to_metadata(
     Ok(())
 }
 
-/// Convert `registered_at` and `updated_at` columns from TEXT (RFC 3339) to
-/// INTEGER (epoch microseconds) in the `models` table.
+/// Upgrade legacy text timestamps to INTEGER epoch microseconds.
 ///
-/// This is an idempotent upgrade migration (#1389).  Databases created before
-/// the schema was corrected declare these columns as `TEXT NOT NULL` and store
-/// RFC 3339 strings (e.g. `"2024-01-15T10:30:00Z"`).  Databases created after
-/// the correction declare them as `INTEGER NOT NULL` and store epoch
-/// microseconds (i64).
-///
-/// SQLite does not support `ALTER TABLE … ALTER COLUMN … TYPE`, so the
-/// migration recreates the `models` table with the correct column types and
-/// converts existing rows using per-row `typeof()` guards so the migration is
-/// safe whether rows contain TEXT RFC 3339 values or INTEGER values already.
-///
-/// # Idempotency
-///
-/// The migration inspects `PRAGMA table_info(models)` to detect the declared
-/// type of `registered_at`.  If both columns already declare `INTEGER` the
-/// migration is a no-op and returns immediately.  Re-running it on an already-
-/// migrated database (or a fresh database) is safe.
-///
-/// # Conversion formula (per-row)
-///
-/// SQLite coerces all values to TEXT affinity in the old schema, so `typeof()`
-/// alone cannot distinguish an RFC 3339 string from a numeric string.  The
-/// migration uses a three-way CASE per timestamp column:
-///
-/// 1. `typeof(val) = 'integer'` → native integer (stored without coercion)
-///    → pass through unchanged.
-/// 2. `datetime(val) IS NOT NULL` → valid datetime string (RFC 3339 / ISO 8601)
-///    → convert: `CAST(strftime('%s', val) AS INTEGER) * 1_000_000`
-///    (epoch seconds → epoch microseconds, sub-second component zeroed).
-/// 3. Otherwise → numeric string already holding epoch microseconds
-///    → `CAST(val AS INTEGER)` to strip TEXT affinity.
-///
-/// This handles all real-world states: pure TEXT databases (case 2), databases
-/// where new code wrote integer micros to old TEXT columns (case 3 — the
-/// integer was coerced to a TEXT digit string by SQLite affinity rules), and
-/// fresh INTEGER-schema rows that somehow arrived in a migration path (case 1).
-///
-/// # Errors
-///
-/// Returns an error if the table recreation or data conversion fails for any
-/// unexpected reason.  Fail-closed: we never silently swallow unexpected errors.
+/// The migration is a no-op for an INTEGER schema. Otherwise it performs the
+/// backup/copy/rename sequence under `BEGIN IMMEDIATE`, distinguishes native
+/// integers, date strings, and numeric strings, and fails initialization on an
+/// SQLite error. See `docs/registry.md` for conversion and transaction details.
 // Called from SqliteStorage::new() which is cfg(feature = "sqlite");
 // the compiler cannot trace the call site when checking without that feature.
 #[cfg(feature = "sqlite")]

--- a/crates/tune/src/registry/storage/registry.rs
+++ b/crates/tune/src/registry/storage/registry.rs
@@ -1,8 +1,9 @@
-//! Model registry for storing and retrieving versioned models.
+//! In-process versioned model index with pluggable artifact storage.
 //!
-//! Uses `ArcSwap` for lock-free concurrent reads and a clone-modify-store
-//! pattern for writes. Readers always see a consistent snapshot; writers
-//! are serialized via `write_lock` to prevent lost updates.
+//! Reads use `ArcSwap` snapshots; serialized writers clone, modify, and publish
+//! indexes after the required storage operation succeeds.
+//!
+//! See `docs/registry.md` for registry ordering, concurrency, and integrity rules.
 
 use super::backends::InMemoryStorage;
 use super::{FileSystemStorage, StorageBackend, sha256_hash};
@@ -14,12 +15,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use uuid::Uuid;
 
-/// Model registry for storing and retrieving versioned models.
+/// In-process index for versioned models and their stored weight artifacts.
 ///
-/// All read operations (`get_by_id`, `get`, `list_*`, `len`, `is_empty`)
-/// are lock-free via `ArcSwap` snapshots. Write operations (`register`,
-/// `update_status`, `promote_to_production`, `delete`) use a
-/// clone-modify-store pattern serialized by an internal write lock.
+/// Reads use lock-free snapshots; writers are serialized and publish cloned
+/// indexes atomically after their required storage operation succeeds.
 pub struct ModelRegistry {
     /// Storage backend (behind Mutex for `&mut self` methods)
     storage: parking_lot::Mutex<Box<dyn StorageBackend>>,
@@ -302,30 +301,11 @@ impl ModelRegistry {
         names
     }
 
-    /// Load model weights, verifying the recorded checksum when one is on
-    /// record.
+    /// Load bytes using the canonical registry record for this model ID.
     ///
-    /// #504 remaining slice 3: this used to be a pure raw load with **no**
-    /// checksum check at all — a caller reaching for the "obvious" method
-    /// name silently bypassed the verification `load_weights_verified`
-    /// performed, even though every model registered via [`Self::register`]
-    /// always carries a `weights_hash`. Fail-closed discipline now applies
-    /// here too: a hash mismatch is a hard
-    /// `TuneError::WeightIntegrityError`, not a silent pass-through.
-    ///
-    /// Verification is anchored to the **canonical registry record**
-    /// (resolved by `model.id` from the registry's own snapshot), never to
-    /// the caller-provided value: [`RegisteredModel`] is a plain DTO with
-    /// public `weights_path`/`weights_hash` fields, so a mutated clone
-    /// could otherwise redirect the load to a different path or "verify"
-    /// tampered bytes against a recomputed hash. A caller argument that
-    /// disagrees with the canonical record on either field is rejected
-    /// outright. A model whose *canonical* record has no hash at all
-    /// (e.g. [`Self::register_metadata`] with weights added out-of-band,
-    /// or a legacy pre-hash record) has nothing to check against and loads
-    /// unverified — that is the only remaining "raw" case, and it is
-    /// explicit (a `None` hash on the canonical record), never a silent
-    /// skip of a hash that *is* present.
+    /// A caller clone that disagrees on weight path or hash is rejected. A
+    /// recorded checksum must match; only a canonical record with no hash loads
+    /// unverified. See `docs/registry.md` for the integrity boundary.
     pub fn load_weights(&self, model: &RegisteredModel) -> Result<Vec<u8>> {
         let snap = self.models.load();
         let canonical = snap
@@ -365,25 +345,10 @@ impl ModelRegistry {
         Ok(weights)
     }
 
-    /// Load model weights, **requiring** a recorded checksum to verify
-    /// against.
+    /// Load bytes only when the canonical record has a checksum to verify.
     ///
-    /// This is [`Self::load_weights`] (which already verifies whenever a
-    /// hash is on record) plus one additional guarantee for callers that
-    /// explicitly want verification: a model with **no** recorded
-    /// `weights_hash` is rejected rather than silently loaded unverified.
-    /// Use this entry point wherever the caller's contract requires "this
-    /// load is verified", and [`Self::load_weights`] only when an
-    /// unverified load of a hash-less (metadata-only-registered) model is
-    /// an accepted, understood case.
-    ///
-    /// Returns `TuneError::WeightIntegrityError` if the checksum doesn't
-    /// match, or `TuneError::Storage` if no checksum is on record at all.
-    ///
-    /// Like [`Self::load_weights`], the "is a hash on record" decision is
-    /// made against the canonical registry record, not the caller's clone
-    /// (whose public `weights_hash` field could have been set to `None` or
-    /// to a recomputed hash of tampered bytes).
+    /// A missing hash and a hash mismatch are both errors. Verification uses
+    /// the canonical record, never caller-controlled fields; see `docs/registry.md`.
     pub fn load_weights_verified(&self, model: &RegisteredModel) -> Result<Vec<u8>> {
         let snap = self.models.load();
         let canonical = snap

--- a/crates/tune/src/train/config/lr_schedule.rs
+++ b/crates/tune/src/train/config/lr_schedule.rs
@@ -1,4 +1,7 @@
-//! Learning rate schedule configuration
+//! Learning-rate schedule definitions and evaluation.
+//!
+//! Schedules combine a base optimizer rate with the current step and epoch.
+//! See `docs/train.md` for formulas, validation rules, and edge cases.
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/tune/src/train/config/mod.rs
+++ b/crates/tune/src/train/config/mod.rs
@@ -1,7 +1,8 @@
-//! Training configuration
+//! Training configuration, validation, and memory estimation.
 //!
-//! This module provides configuration for training loops, optimizers,
-//! learning rate schedules, and regularization.
+//! [`TrainingConfig`] combines optimizer, schedule, regularization, validation,
+//! checkpoint, and reproducibility settings for a training run.
+//! See `docs/train.md` for configuration semantics and memory-estimate details.
 
 mod early_stopping;
 mod lr_schedule;

--- a/crates/tune/src/train/config/regularization.rs
+++ b/crates/tune/src/train/config/regularization.rs
@@ -1,4 +1,7 @@
-//! Regularization configuration
+//! Regularization settings and gradient-norm clipping.
+//!
+//! Values are validated before training; clipping rescales an over-limit vector
+//! uniformly and preserves its direction. See `docs/train.md` for usage details.
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -44,29 +47,11 @@ impl RegularizationConfig {
         }
     }
 
-    /// Clip gradients by their L2 norm
+    /// Clip gradients to `max_norm` by their L2 norm, returning the original norm.
     ///
-    /// If the L2 norm of gradients exceeds `max_norm`, scale them down
-    /// proportionally so that the norm equals `max_norm`.
-    ///
-    /// # Arguments
-    /// * `gradients` - Mutable slice of gradient values to clip
-    /// * `max_norm` - Maximum allowed L2 norm
-    ///
-    /// # Returns
-    /// The original gradient norm (before clipping)
-    ///
-    /// # Example
-    /// ```
-    /// use lattice_tune::train::RegularizationConfig;
-    ///
-    /// let mut grads = vec![3.0, 4.0]; // Norm = 5.0
-    /// let original_norm = RegularizationConfig::clip_grad_norm(&mut grads, 1.0);
-    /// assert!((original_norm - 5.0).abs() < 1e-6);
-    /// // After clipping, norm should be 1.0
-    /// let new_norm: f32 = grads.iter().map(|x| x * x).sum::<f32>().sqrt();
-    /// assert!((new_norm - 1.0).abs() < 1e-6);
-    /// ```
+    /// A zero or already-in-range vector is unchanged; otherwise every component
+    /// is scaled by `max_norm / norm`, leaving the gradient direction unchanged.
+    /// See `docs/train.md` for regularization behavior.
     pub fn clip_grad_norm(gradients: &mut [f32], max_norm: f32) -> f32 {
         // Compute L2 norm
         let norm_sq: f32 = gradients.iter().map(|g| g * g).sum();

--- a/crates/tune/src/train/gpu/mod.rs
+++ b/crates/tune/src/train/gpu/mod.rs
@@ -1,6 +1,8 @@
-//! GPU-accelerated training infrastructure
+//! GPU forward, loss, validation, and training-step infrastructure.
 //!
-//! Uses lattice-fann's wgpu-based GPU backend for accelerated training.
+//! The backend uses lattice-fann's WGPU network and rejects non-finite outputs.
+//! Its optimizer update path intentionally fails until buffer binding and weight
+//! write-back are implemented, so validation is forward-only. See `docs/train.md`.
 
 mod builder;
 mod optimizers;
@@ -17,23 +19,11 @@ use lattice_fann::gpu::{GpuContext, GpuNetwork};
 use state::{LayerGradients, OptimizerState};
 use std::sync::Arc;
 
-/// GPU-accelerated trainer
+/// GPU-backed trainer using lattice-fann's WGPU network.
 ///
-/// Provides GPU-accelerated forward/backward passes and weight updates
-/// using lattice-fann's wgpu backend.
-///
-/// # Current limitation
-///
-/// [`Self::train_batch`] returns `Err(TuneError::Training(_))` for every
-/// optimizer choice (Adam, AdamW, SGD-momentum, plain SGD, RMSprop): the
-/// GPU-shader optimizer dispatch has no buffer bindings wired to the
-/// network's weight/gradient buffers, and the CPU-side plain-SGD arm has
-/// neither real gradient plumbing nor a mutable weight write-back path.
-/// Forward pass and loss computation work correctly — [`Self::validate`] is
-/// a forward-only path that does not touch the optimizer. Only the
-/// weight-update step is unimplemented. See
-/// <https://github.com/ohdearquant/lattice/issues/797>. This note will be
-/// removed once that wiring lands.
+/// [`Self::train_batch`] currently returns `TuneError::Training` for every
+/// optimizer instead of reporting a no-effect update. [`Self::validate`] is a
+/// usable forward-only path. See `docs/train.md` for the backend status.
 pub struct GpuTrainer {
     /// GPU context (device, queue, shader manager)
     ctx: Arc<GpuContext>,

--- a/crates/tune/src/train/gpu/optimizers.rs
+++ b/crates/tune/src/train/gpu/optimizers.rs
@@ -1,11 +1,9 @@
-//! GPU optimizer implementations
+//! GPU optimizer dispatch.
 //!
-//! Every `GpuOptimizer` arm (Adam, AdamW, SGD-momentum, plain SGD, RMSprop)
-//! currently fails loudly with `TuneError::Training` rather than performing a
-//! real weight update: the shader-based arms have no buffer bindings wired
-//! to the network's weight/gradient buffers, and the CPU-side plain-SGD arm
-//! has neither real gradient plumbing nor a mutable weight write-back path.
-//! See #797. Wiring the real dispatch/write-back is tracked follow-up work.
+//! All optimizer choices return `TuneError::Training` until real gradient
+//! bindings and a mutable network weight write-back path exist. This is
+//! intentional: a no-effect optimizer step must never report success. See
+//! `docs/train.md` for the current backend contract.
 
 use super::state::LayerGradients;
 use crate::error::{Result, TuneError};
@@ -13,18 +11,14 @@ use crate::train::config::{Optimizer, TrainingConfig};
 use lattice_fann::gpu::GpuContext;
 use std::sync::Arc;
 
-/// Optimizer update methods
+/// GPU optimizer dispatcher.
+///
+/// Every update arm currently returns an error rather than performing a
+/// no-effect update. See `docs/train.md` for implementation status.
 pub struct GpuOptimizer;
 
 impl GpuOptimizer {
-    /// Adam optimizer update using GPU shader
-    ///
-    /// # Errors
-    ///
-    /// Always returns `TuneError::Training`: the GPU dispatch has no buffer
-    /// bindings wired to the network's weight/gradient buffers (#797). Wiring
-    /// the real dispatch is tracked as follow-up work; until then this arm
-    /// fails loudly instead of silently performing a zero-effect update.
+    /// Return an error because GPU Adam buffer bindings are not implemented.
     pub fn update_adam(
         _ctx: &Arc<GpuContext>,
         _layer_gradients: &[LayerGradients],
@@ -38,11 +32,7 @@ impl GpuOptimizer {
         ))
     }
 
-    /// AdamW optimizer update using GPU shader
-    ///
-    /// # Errors
-    ///
-    /// Always returns `TuneError::Training`: see [`Self::update_adam`] (#797).
+    /// Return an error because GPU AdamW buffer bindings are not implemented.
     pub fn update_adamw(
         _ctx: &Arc<GpuContext>,
         _layer_gradients: &[LayerGradients],
@@ -56,11 +46,7 @@ impl GpuOptimizer {
         ))
     }
 
-    /// SGD with momentum update using GPU shader
-    ///
-    /// # Errors
-    ///
-    /// Always returns `TuneError::Training`: see [`Self::update_adam`] (#797).
+    /// Return an error because GPU SGD-momentum bindings are not implemented.
     pub fn update_sgd_momentum(
         _ctx: &Arc<GpuContext>,
         _layer_gradients: &[LayerGradients],
@@ -112,20 +98,7 @@ impl GpuOptimizer {
         Ok(())
     }
 
-    /// Plain SGD update (CPU fallback - no shader for plain SGD)
-    ///
-    /// # Errors
-    ///
-    /// Always returns `TuneError::Training`: this is not real SGD (#797).
-    /// The previous body used a constant placeholder gradient magnitude
-    /// (`grad_scale = 0.01`) instead of the actual per-layer gradients
-    /// accumulated in `LayerGradients`, and had no mutable write-back path
-    /// from `GpuNetwork` (only the immutable `cpu_network()` accessor
-    /// exists) even if it had used real gradients — so the computed values
-    /// were always discarded. A working plain-SGD arm needs both real
-    /// gradient plumbing and a mutable weight-write path on `GpuNetwork`;
-    /// until then it fails loudly like every other arm rather than
-    /// reporting success for a step that changed nothing.
+    /// Return an error because plain SGD has no gradient or weight write-back path.
     fn update_sgd(_network: &lattice_fann::gpu::GpuNetwork, _current_lr: f32) -> Result<()> {
         Err(TuneError::Training(
             "GPU SGD optimizer update not implemented: no real gradient plumbing or mutable \

--- a/crates/tune/src/train/jit.rs
+++ b/crates/tune/src/train/jit.rs
@@ -1,7 +1,8 @@
-//! JIT (Just-In-Time) model adaptation
+//! Just-in-time adaptation configuration, control flow, and layer-selection helpers.
 //!
-//! Fast fine-tuning infrastructure for rapid model adaptation.
-//! Enables 5-10 second adaptation cycles with GPU acceleration.
+//! CPU adaptation currently reports simulated loss; GPU adaptation delegates to
+//! the GPU trainer and therefore cannot complete a weight update yet. See
+//! `docs/train.md` for strategies, stopping rules, and current limitations.
 
 use crate::data::{Dataset, TrainingExample};
 use crate::error::{Result, TuneError};

--- a/crates/tune/src/train/loop/checkpoint.rs
+++ b/crates/tune/src/train/loop/checkpoint.rs
@@ -1,4 +1,8 @@
-//! Checkpoint management
+//! In-memory training checkpoint representation.
+//!
+//! Checkpoints carry metadata, metrics, weights, and optimizer bytes; this
+//! module does not perform persistence. See `docs/train.md` for the format and
+//! resume limitations.
 
 use super::metrics::TrainingMetrics;
 use chrono::{DateTime, Utc};
@@ -9,17 +13,10 @@ use serde::{Deserialize, Serialize};
 
 /// Checkpoint of training state.
 ///
-/// # Serialization format (load-bearing)
-///
-/// With the `serde` feature, checkpoints serialize to JSON. See
-/// [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/tune/docs/design.md)
-/// for the full JSON schema, a loading example, and the file naming convention. Two fields
-/// carry a byte-level contract that is not visible from their `Vec<u8>` type:
-///
-/// - `weights`: little-endian `f32` values, concatenated layer-by-layer (each layer's weight
-///   matrix in row-major order, then its biases; input-to-output order across layers).
-/// - `optimizer_state`: optimizer-specific — SGD-with-momentum stores one velocity vector per
-///   parameter; Adam stores first (`m`) and second (`v`) moment vectors per parameter.
+/// With `serde`, the representation is JSON. `weights` are little-endian `f32`
+/// values ordered layer-by-layer (row-major weights, then biases, input to
+/// output); `optimizer_state` stores momentum or Adam moment vectors per
+/// parameter. See `docs/train.md` for the full format and persistence contract.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Checkpoint {

--- a/crates/tune/src/train/loop/metrics.rs
+++ b/crates/tune/src/train/loop/metrics.rs
@@ -1,4 +1,7 @@
-//! Training metrics
+//! Per-epoch and aggregate training metrics.
+//!
+//! Metrics retain history, best validation loss, final values, and simple trend
+//! queries. See `docs/train.md` for update order and interpretation caveats.
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/tune/src/train/loop/mod.rs
+++ b/crates/tune/src/train/loop/mod.rs
@@ -1,4 +1,8 @@
-//! Training loop implementation
+//! Training-loop orchestration, callbacks, metrics, and checkpoints.
+//!
+//! The current CPU loop validates and drives the run lifecycle but simulates
+//! loss and accuracy rather than optimizing network weights. See `docs/train.md`
+//! for lifecycle order, metric semantics, and checkpoint limitations.
 
 mod callbacks;
 mod checkpoint;
@@ -14,10 +18,10 @@ use super::config::{EarlyStopping, TrainingConfig};
 use crate::data::{Batch, Dataset};
 use crate::error::{Result, TuneError};
 
-/// Training loop orchestrator
+/// CPU training-loop orchestrator.
 ///
-/// This is a placeholder implementation. The actual neural network operations
-/// would be implemented via lattice-fann when it's available.
+/// This implementation simulates batch loss and accuracy; it does not update a
+/// neural network. See `docs/train.md` for the lifecycle and current contract.
 pub struct TrainingLoop {
     /// Training configuration
     config: TrainingConfig,


### PR DESCRIPTION
Follow-up to #946. The first pass was a lib/train/checkpoint summary — too shallow. This pass transposes the full substance of the crate's long inline `//!` narrative into properly-written topic docs.

## What

- New `docs/lora-core.md`, `docs/lora-router.md`, `docs/lora-io.md`, `docs/registry.md`, `docs/train.md`, `docs/distill.md`, `docs/data.md` carry the deep material (LoRA blend/optimizer/online refit; adapter+model registry with shadow deploy + rollback; training pipeline + GPU optimizers + JIT; teacher distillation providers + security; dataset/example formats).
- `docs/design.md` is the architecture overview and references the existing ADRs (ADR-001 teacher providers, ADR-002 model registry) rather than duplicating them; `docs/INDEX.md` indexes all topic docs + ADRs.
- Source `//!` blocks condensed to a summary + pointer. Load-bearing lifecycle/rollback/regularization invariants kept inline.

## Verification

- `cargo fmt -p lattice-tune --check` — clean.
- Docs-only: no source logic changed (only `//!`/`///` comment volume + new markdown). Doc-build (`-D warnings -D rustdoc::broken_intra_doc_links`) is gated by CI; local run deferred under disk pressure this session.
