### PR TITLE
docs(fann): fix ewc penalty-gradient anchor slug (double hyphen)

### DIFF
--- a/crates/fann/src/training/ewc.rs
+++ b/crates/fann/src/training/ewc.rs
@@ -81,7 +81,7 @@ impl DiagonalFisher {
     /// Adds the EWC penalty gradient for `params` into `out`.
     ///
     /// Returns [`FannError::InputSizeMismatch`] unless both slices match the Fisher length.
-    /// See [`docs/training.md`](../../docs/training.md#anchor-penalty-gradient) for the formula and descent integration.
+    /// See [`docs/training.md`](../../docs/training.md#anchor--penalty-gradient) for the formula and descent integration.
     pub fn penalty_gradient(&self, params: &[f32], lambda: f32, out: &mut [f32]) -> FannResult<()> {
         let n = self.values.len();
         if params.len() != n {


### PR DESCRIPTION
## Summary

One-character intra-doc anchor fix, follow-up to #952.

`crates/fann/src/training/ewc.rs:84` links `docs/training.md#anchor-penalty-gradient`, but the heading `### Anchor + penalty gradient` GitHub-slugs to `#anchor--penalty-gradient` — GitHub strips the `+`, leaving two adjacent spaces that collapse to a **double** hyphen. The link used a single hyphen, so it resolved to nothing.

#952's body claimed "all anchors verified, 0 broken"; this anchor was the one miss (the sibling `#backprop--momentum` for `## Backprop + momentum` was already correct). This lands the fix so the claim holds.

## Verification
- Only reference to this anchor across the crate (grepped; no sibling invocation paths).
- Slug hand-derived: `Anchor + penalty gradient` -> lowercase -> strip `+` -> two spaces -> spaces-to-hyphens -> `anchor--penalty-gradient`.

Docs-only; no code logic or public signature change.