### PR TITLE
fix(grammar): stop terminal grammar states cleanly

### DIFF
--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -310,6 +310,26 @@ impl GrammarEngine {
         true
     }
 
+    /// Return whether `state` is accepting and no non-empty vocabulary token
+    /// can legally advance it.
+    pub(crate) fn is_complete_without_continuation(&self, state: &GrammarState) -> bool {
+        if !state.is_complete() {
+            return false;
+        }
+
+        let has_continuation = match self.find_state_id(state) {
+            Some(state_id) => self.partition.any_allowed_token(state_id, |token_id| {
+                simulate_token(state, &self.grammar, &self.vocab_bytes[token_id]).0
+                    == SimResult::Accept
+            }),
+            None => self.vocab_bytes.iter().any(|token_bytes| {
+                !token_bytes.is_empty()
+                    && simulate_token(state, &self.grammar, token_bytes).0 == SimResult::Accept
+            }),
+        };
+        !has_continuation
+    }
+
     /// Find the partition state id for `state` by matching stack configuration.
     ///
     /// Returns `None` when no matching precomputed state exists. This happens
@@ -559,6 +579,30 @@ mod tests {
         let engine = GrammarEngine::new(&spec, vocab).unwrap();
         let state = engine.initial_state();
         assert!(!state.is_complete(), "initial state should not be complete");
+    }
+
+    #[test]
+    fn complete_state_without_continuation_is_terminal() {
+        let vocab = vec![b"a".to_vec()];
+        let spec = GrammarSpec::Gbnf("root ::= \"a\"\n".to_string());
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+        let mut state = engine.initial_state();
+
+        assert!(engine.advance(&mut state, 0));
+        assert!(engine.is_complete_without_continuation(&state));
+    }
+
+    #[test]
+    fn complete_state_with_continuation_is_not_terminal() {
+        let vocab = vec![b"a".to_vec()];
+        let spec = GrammarSpec::Gbnf("root ::= \"a\"+\n".to_string());
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+        let mut state = engine.initial_state();
+
+        assert!(engine.advance(&mut state, 0));
+        assert!(state.is_complete());
+        assert!(!engine.is_complete_without_continuation(&state));
+        assert!(engine.advance(&mut state, 0));
     }
 
     #[test]

--- a/crates/inference/src/grammar/vocab_partition.rs
+++ b/crates/inference/src/grammar/vocab_partition.rs
@@ -187,6 +187,32 @@ impl VocabPartition {
     pub fn grammar_state(&self, state_id: usize) -> Option<&GrammarState> {
         self.states.get(state_id)
     }
+
+    /// Return whether any token allowed by the precomputed mask satisfies
+    /// `predicate`.
+    pub(crate) fn any_allowed_token(
+        &self,
+        state_id: usize,
+        mut predicate: impl FnMut(usize) -> bool,
+    ) -> bool {
+        if state_id >= self.states.len().min(MAX_GRAMMAR_STATES) {
+            return false;
+        }
+
+        let mask_base = state_id * self.mask_stride;
+        for word_idx in 0..self.mask_stride {
+            let mut mask_word = self.masks[mask_base + word_idx];
+            while mask_word != 0 {
+                let bit = mask_word.trailing_zeros() as usize;
+                let token_id = word_idx * 64 + bit;
+                if token_id < self.vocab_size && predicate(token_id) {
+                    return true;
+                }
+                mask_word &= mask_word - 1;
+            }
+        }
+        false
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -183,8 +183,12 @@ impl Qwen35Model {
         if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
             engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
             // If the grammar blocked every token the sampler's non-finite-max
-            // short-circuit would silently return token 0. Fail closed instead.
+            // short-circuit would silently return token 0. An accepting state
+            // terminates normally; an incomplete state remains a hard error.
             if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
+                if engine.is_complete_without_continuation(gs) {
+                    return Ok(grammar_output(String::new(), &[], prompt_len, true, vec![]));
+                }
                 return Err(InferenceError::InvalidInput(
                     "grammar constraint blocked every token at step 0; \
                      no legal first token exists in the current grammar state"
@@ -204,19 +208,21 @@ impl Qwen35Model {
         // grammar has no valid continuation for the selected token, signalling the
         // end of grammar-constrained generation. Mirror the same early-return used
         // in crate::generate::generate for parity.
-        if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state)
-            && !engine.advance(gs, next_id)
-        {
-            return Ok(GenerateOutput {
-                text: String::new(),
-                token_ids: vec![],
-                prompt_tokens: prompt_len,
-                generated_tokens: 0,
-                stopped: false,
-                stop_reason: Some(StopReason::Grammar),
-                token_logprobs: vec![],
-            });
-        }
+        let grammar_complete =
+            if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                if !engine.advance(gs, next_id) {
+                    return Ok(grammar_output(
+                        String::new(),
+                        &[],
+                        prompt_len,
+                        false,
+                        vec![],
+                    ));
+                }
+                engine.is_complete_without_continuation(gs)
+            } else {
+                false
+            };
 
         if should_stop_token(cfg, gen_cfg, next_id) {
             return Ok(GenerateOutput {
@@ -262,6 +268,15 @@ impl Qwen35Model {
         if gen_cfg.stop_strings.is_empty() {
             // Fast path: no string-level stops. Behaviour byte-for-byte identical
             // to before this feature was added; the e2e-parity CI gate pins this.
+            if grammar_complete {
+                return Ok(grammar_output(
+                    decode_tokens(&self.tokenizer, &generated_ids),
+                    &generated_ids,
+                    prompt_len,
+                    true,
+                    token_logprobs,
+                ));
+            }
             let (stopped, loop_stop_reason) = decode_loop(
                 self,
                 gen_cfg,
@@ -328,6 +343,20 @@ impl Qwen35Model {
                     stop_reason: Some(StopReason::Eos),
                     token_logprobs,
                 });
+            }
+
+            if grammar_complete {
+                let tail = detok.finish();
+                if !tail.is_empty() {
+                    full.push_str(&tail);
+                }
+                return Ok(grammar_output(
+                    full,
+                    &generated_ids,
+                    prompt_len,
+                    true,
+                    token_logprobs,
+                ));
             }
 
             let (stopped, loop_stop_reason) = decode_loop_with_stops(
@@ -608,6 +637,9 @@ impl Qwen35Model {
         if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
             engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
             if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
+                if engine.is_complete_without_continuation(gs) {
+                    return Ok(grammar_output(String::new(), &[], prompt_len, true, vec![]));
+                }
                 return Err(InferenceError::InvalidInput(
                     "grammar constraint blocked every token at step 0; \
                      no legal first token exists in the current grammar state"
@@ -638,19 +670,21 @@ impl Qwen35Model {
         );
 
         // Grammar advance after sampling the first token, mirroring generate().
-        if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state)
-            && !engine.advance(gs, next_id)
-        {
-            return Ok(GenerateOutput {
-                text: String::new(),
-                token_ids: vec![],
-                prompt_tokens: prompt_len,
-                generated_tokens: 0,
-                stopped: false,
-                stop_reason: Some(StopReason::Grammar),
-                token_logprobs: vec![],
-            });
-        }
+        let grammar_complete =
+            if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                if !engine.advance(gs, next_id) {
+                    return Ok(grammar_output(
+                        String::new(),
+                        &[],
+                        prompt_len,
+                        false,
+                        vec![],
+                    ));
+                }
+                engine.is_complete_without_continuation(gs)
+            } else {
+                false
+            };
 
         if should_stop_token(cfg, gen_cfg, next_id) {
             return Ok(GenerateOutput {
@@ -734,6 +768,16 @@ impl Qwen35Model {
                 });
             }
 
+            if grammar_complete {
+                return Ok(grammar_output(
+                    text,
+                    &generated_ids,
+                    prompt_len,
+                    true,
+                    token_logprobs,
+                ));
+            }
+
             let mut stopped = false;
             let mut stopped_by_caller = false;
             let mut stop_reason = StopReason::Length;
@@ -768,6 +812,11 @@ impl Qwen35Model {
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
                     engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
                     if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
+                        if engine.is_complete_without_continuation(gs) {
+                            stopped = true;
+                            stop_reason = StopReason::Grammar;
+                            break;
+                        }
                         return Err(InferenceError::InvalidInput(
                             "grammar constraint blocked every token; \
                              no legal continuation exists in the current grammar state"
@@ -852,7 +901,14 @@ impl Qwen35Model {
                     StepOutcome::Emitted {
                         answer_budget_exhausted,
                         ..
-                    } => answer_budget_exhausted,
+                    } => {
+                        if grammar_complete_without_continuation(gen_cfg, &grammar_state) {
+                            stopped = true;
+                            stop_reason = StopReason::Grammar;
+                            break;
+                        }
+                        answer_budget_exhausted
+                    }
                 };
 
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
@@ -921,6 +977,17 @@ impl Qwen35Model {
                     token_logprobs,
                 });
             }
+            if grammar_complete {
+                let tail = detok.finish();
+                policy.finish_stop(&mut text, &tail, |s| on_token(s));
+                return Ok(grammar_output(
+                    text,
+                    &generated_ids,
+                    prompt_len,
+                    true,
+                    token_logprobs,
+                ));
+            }
 
             let mut stopped = false;
             let mut stopped_by_caller = false;
@@ -953,6 +1020,11 @@ impl Qwen35Model {
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
                     engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
                     if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
+                        if engine.is_complete_without_continuation(gs) {
+                            stopped = true;
+                            stop_reason = StopReason::Grammar;
+                            break;
+                        }
                         return Err(InferenceError::InvalidInput(
                             "grammar constraint blocked every token; \
                              no legal continuation exists in the current grammar state"
@@ -1032,7 +1104,14 @@ impl Qwen35Model {
                     StepOutcome::Emitted {
                         answer_budget_exhausted,
                         ..
-                    } => answer_budget_exhausted,
+                    } => {
+                        if grammar_complete_without_continuation(gen_cfg, &grammar_state) {
+                            stopped = true;
+                            stop_reason = StopReason::Grammar;
+                            break;
+                        }
+                        answer_budget_exhausted
+                    }
                 };
 
                 // Answer-budget break: stop once max_new_tokens answer tokens follow </think>.
@@ -1723,6 +1802,34 @@ fn has_finite_logit(logits: &[f32]) -> bool {
     logits.iter().any(|&l| l > f32::NEG_INFINITY)
 }
 
+fn grammar_complete_without_continuation(
+    gen_cfg: &GenerateConfig,
+    grammar_state: &Option<GrammarState>,
+) -> bool {
+    match (&gen_cfg.grammar, grammar_state) {
+        (Some(engine), Some(state)) => engine.is_complete_without_continuation(state),
+        _ => false,
+    }
+}
+
+fn grammar_output(
+    text: String,
+    generated_ids: &[u32],
+    prompt_tokens: usize,
+    stopped: bool,
+    token_logprobs: Vec<TokenLogprob>,
+) -> GenerateOutput {
+    GenerateOutput {
+        text,
+        token_ids: generated_ids.to_vec(),
+        prompt_tokens,
+        generated_tokens: generated_ids.len(),
+        stopped,
+        stop_reason: Some(StopReason::Grammar),
+        token_logprobs,
+    }
+}
+
 fn initial_rng_state(seed: Option<u64>) -> u64 {
     match seed {
         Some(s) => {
@@ -1800,6 +1907,9 @@ fn decode_loop(
         if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut *grammar_state) {
             engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
             if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
+                if engine.is_complete_without_continuation(gs) {
+                    return Ok((true, StopReason::Grammar));
+                }
                 return Err(InferenceError::InvalidInput(
                     "grammar constraint blocked every token; \
                      no legal continuation exists in the current grammar state"
@@ -1867,6 +1977,9 @@ fn decode_loop(
                 answer_budget_exhausted,
                 ..
             } => {
+                if grammar_complete_without_continuation(gen_cfg, grammar_state) {
+                    return Ok((true, StopReason::Grammar));
+                }
                 // Answer-budget break: stop once max_new_tokens answer tokens
                 // follow </think>.
                 if answer_budget_exhausted {
@@ -1922,6 +2035,11 @@ fn decode_loop_with_stops(
         if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut *grammar_state) {
             engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
             if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
+                if engine.is_complete_without_continuation(gs) {
+                    stopped = true;
+                    stop_reason = StopReason::Grammar;
+                    break;
+                }
                 return Err(InferenceError::InvalidInput(
                     "grammar constraint blocked every token; \
                      no legal continuation exists in the current grammar state"
@@ -2001,7 +2119,14 @@ fn decode_loop_with_stops(
             StepOutcome::Emitted {
                 token_id,
                 answer_budget_exhausted,
-            } => (token_id, answer_budget_exhausted),
+            } => {
+                if grammar_complete_without_continuation(gen_cfg, grammar_state) {
+                    stopped = true;
+                    stop_reason = StopReason::Grammar;
+                    break;
+                }
+                (token_id, answer_budget_exhausted)
+            }
         };
 
         // Answer-budget break: stop once max_new_tokens answer tokens follow
@@ -2955,6 +3080,121 @@ mod tests {
             tokenizer,
             rope,
             lora: Box::new(NoopLoraHook),
+        }
+    }
+
+    const A_FIRST_TINY_TOK_JSON: &str = r#"{
+  "version":"1.0","truncation":null,"padding":null,"added_tokens":[],
+  "normalizer":null,
+  "pre_tokenizer":{"type":"ByteLevel","add_prefix_space":false,"trim_offsets":true,"use_regex":true},
+  "post_processor":null,
+  "decoder":{"type":"ByteLevel","add_prefix_space":true,"trim_offsets":true,"use_regex":true},
+  "model":{"type":"BPE","dropout":null,"unk_token":"<unk>","continuing_subword_prefix":null,
+    "end_of_word_suffix":null,"fuse_unk":false,"byte_fallback":false,"ignore_merges":false,
+    "vocab":{"a":0,"<unk>":1,"b":2,"c":3,"d":4,"e":5," ":6},"merges":[]}
+}"#;
+
+    fn build_a_first_zero_model() -> Qwen35Model {
+        build_tiny_zero_model_tok(A_FIRST_TINY_TOK_JSON)
+    }
+
+    fn a_token_grammar(gbnf: &str) -> std::sync::Arc<crate::grammar::GrammarEngine> {
+        use crate::grammar::{GrammarEngine, GrammarSpec};
+
+        let mut vocab_bytes = vec![Vec::new(); 97];
+        vocab_bytes[0] = b"a".to_vec();
+        std::sync::Arc::new(
+            GrammarEngine::new(&GrammarSpec::Gbnf(gbnf.to_string()), vocab_bytes)
+                .expect("test grammar compiles"),
+        )
+    }
+
+    fn grammar_config(gbnf: &str) -> GenerateConfig {
+        GenerateConfig {
+            max_new_tokens: 4,
+            temperature: 0.0,
+            grammar: Some(a_token_grammar(gbnf)),
+            stop_token_ids: vec![],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn completed_grammar_stops_before_remaining_budget_errors() {
+        let model = build_a_first_zero_model();
+        let result = model
+            .generate("b", &grammar_config("root ::= \"a\"\n"))
+            .expect("a completed grammar must stop successfully");
+
+        assert_eq!(result.text, "a");
+        assert_eq!(result.token_ids, vec![0]);
+        assert_eq!(result.generated_tokens, 1);
+        assert!(result.stopped);
+        assert_eq!(result.stop_reason, Some(StopReason::Grammar));
+    }
+
+    #[test]
+    fn shared_prefix_complete_state_stops_when_pda_has_no_continuation() {
+        let model = build_a_first_zero_model();
+        // The current no-rewind PDA commits to the first shared-prefix
+        // alternative after consuming "a", so "aa" is no longer viable from
+        // this accepting state. This pins a no-continuation stop, not a general
+        // stop-at-first-accepting-state policy.
+        let result = model
+            .generate("b", &grammar_config("root ::= \"a\" | \"aa\"\n"))
+            .expect("the accepting state must terminate without an all-masked error");
+
+        assert_eq!(result.text, "a");
+        assert_eq!(result.token_ids, vec![0]);
+        assert!(result.stopped);
+        assert_eq!(result.stop_reason, Some(StopReason::Grammar));
+    }
+
+    #[test]
+    fn completed_grammar_streaming_matches_nonstreaming() {
+        let model = build_a_first_zero_model();
+        let gen_cfg = grammar_config("root ::= \"a\"\n");
+        let nonstreaming = model
+            .generate("b", &gen_cfg)
+            .expect("non-streaming completion succeeds");
+        let mut streamed_text = String::new();
+        let streaming = model
+            .generate_streaming("b", &gen_cfg, |delta| streamed_text.push_str(delta))
+            .expect("streaming completion succeeds");
+
+        assert_eq!(streaming.text, streamed_text);
+        assert_eq!(streaming.text, nonstreaming.text);
+        assert_eq!(streaming.token_ids, nonstreaming.token_ids);
+        assert_eq!(streaming.generated_tokens, nonstreaming.generated_tokens);
+        assert_eq!(streaming.stopped, nonstreaming.stopped);
+        assert_eq!(streaming.stop_reason, nonstreaming.stop_reason);
+        assert_eq!(streaming.stop_reason, Some(StopReason::Grammar));
+    }
+
+    #[test]
+    fn grammar_completion_after_decode_step_covers_all_loop_siblings() {
+        let model = build_a_first_zero_model();
+
+        for stop_strings in [vec![], vec!["never".to_string()]] {
+            let mut gen_cfg = grammar_config("root ::= \"aa\"\n");
+            gen_cfg.stop_strings = stop_strings;
+
+            let nonstreaming = model
+                .generate("b", &gen_cfg)
+                .expect("non-streaming loop must stop on grammar completion");
+            let mut streamed_text = String::new();
+            let streaming = model
+                .generate_streaming("b", &gen_cfg, |delta| streamed_text.push_str(delta))
+                .expect("streaming loop must stop on grammar completion");
+
+            for result in [&nonstreaming, &streaming] {
+                assert_eq!(result.text, "aa");
+                assert_eq!(result.token_ids, vec![0, 0]);
+                assert_eq!(result.generated_tokens, 2);
+                assert!(result.stopped);
+                assert_eq!(result.stop_reason, Some(StopReason::Grammar));
+            }
+            assert_eq!(streaming.text, streamed_text);
         }
     }
 


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

Closes #930.

## Defect

When grammar-constrained generation reached a PDA state that was accepting and had no legal non-empty continuation in the effective tokenizer vocabulary, the next decode step masked every token and returned `InvalidInput` instead of finishing with `StopReason::Grammar`.

## Fix contract

- Stop with `StopReason::Grammar` only when the PDA is accepting and no legal non-empty vocabulary token can advance it.
- Keep accepting states live when at least one effective-vocabulary token remains legal.
- Preserve the fail-closed `InvalidInput` result for every all-masked incomplete state.
- Preserve the current no-rewind PDA semantics for shared-prefix alternatives such as `root ::= "a" | "aa"`.

The grammar engine now tests exact token viability using the precomputed vocabulary mask, with the existing simulation fallback for unenumerated states. Empty vocabulary entries are not continuations.

## Decode sibling sweep

| Path | Before an all-masked error | After an accepted advance |
| --- | --- | --- |
| `generate` first-token path | completion verdict retained | completion verdict retained |
| `generate_streaming_with_observer` first-token path | completion verdict retained | completion verdict retained |
| streaming inline fast loop | completion verdict retained | completion verdict retained |
| streaming inline stop-string loop | completion verdict retained | completion verdict retained |
| `decode_loop` | completion verdict retained | completion verdict retained |
| `decode_loop_with_stops` | completion verdict retained | completion verdict retained |

The prompt-plus-decode context admission checks from #940 remain before decode-state allocation in both CPU entry points, and the Metal preflight remains unchanged.

## Verification

- `cargo fmt --all -- --check`: pass.
- `cargo clippy --workspace --all-targets -- -D warnings`: pass.
- `cargo test -p lattice-inference`: pass; the library leg reported 1,820 passed and 18 ignored, and all remaining binary, integration, and doctest legs passed.
- `completed_grammar_stops_before_remaining_budget_errors`: pass.
- `completed_grammar_streaming_matches_nonstreaming`: pass.
- `shared_prefix_complete_state_stops_when_pda_has_no_continuation`: pass.
- `grammar_completion_after_decode_step_covers_all_loop_siblings`: pass.
- `grammar_wiring_mask_logits_called_in_generate`: pass, preserving the incomplete all-masked error contract.

Mutation check: forcing `GrammarEngine::is_complete_without_continuation` to return false for the accepting/no-continuation state made `completed_grammar_stops_before_remaining_budget_errors` fail with `InvalidInput("grammar constraint blocked every token; no legal continuation exists in the current grammar state")`. Restoring the completion verdict made the test pass again.

ADR-058 bench: N/A — the grammar decode path is not in the Criterion suite (elementwise_cpu_bench + embed simd), which does not instantiate the grammar engine; no bench run.
