### PR TITLE
docs(embed): correct ADR-016/017 + README/CONFIG to shipped embedding behavior

### DIFF
--- a/crates/embed/CONFIG.md
+++ b/crates/embed/CONFIG.md
@@ -25,9 +25,9 @@ Runtime configuration pairing a model with an optional MRL truncation dimension.
 
 **What it does**: Selects which embedding model to load and run.
 
-**Why `BgeSmallEnV15` as the code default**: It's the lightest local model (384 dims, 33M params), suitable for fast testing and development. In production, the actual model is typically set via application configuration to `multilingual-e5-small` (same dimensions but multilingual). The enum default is rarely used directly — `EmbeddedConfig::memory()` and `EmbeddedConfig::file()` constructors set the model from config.
+**Why `BgeSmallEnV15` as the code default**: It's the lightest local model (384 dims, 33M params), suitable for fast testing and development. `ModelConfig::default()` and `NativeEmbeddingService::new()` use this enum default; applications select another model with `NativeEmbeddingService::with_model()`, `with_model_config()`, or `with_model_from_env()`.
 
-**Important**: The **production default is `multilingual-e5-small`, NOT `bge-small-en-v1.5`**. Configure the active model via your application's config. The `EmbeddingModel` enum `#[default]` is for code that doesn't go through an application config path.
+**Important**: The crate has no separate production default. The active model is the model configured on each `NativeEmbeddingService` instance.
 
 #### `output_dim` — default `None`
 
@@ -58,31 +58,31 @@ Runtime configuration pairing a model with an optional MRL truncation dimension.
 
 ### Supported Models
 
-| Variant                        | Display Name             | HuggingFace ID                   | Native Dims | Max Tokens | Local?       | MRL? | Architecture  |
-| ------------------------------ | ------------------------ | -------------------------------- | ----------- | ---------- | ------------ | ---- | ------------- |
-| `BgeSmallEnV15` (code default) | `bge-small-en-v1.5`      | `BAAI/bge-small-en-v1.5`         | 384         | 512        | yes          | no   | BERT encoder  |
-| `BgeBaseEnV15`                 | `bge-base-en-v1.5`       | `BAAI/bge-base-en-v1.5`          | 768         | 512        | yes          | no   | BERT encoder  |
-| `BgeLargeEnV15`                | `bge-large-en-v1.5`      | `BAAI/bge-large-en-v1.5`         | 1024        | 512        | yes          | no   | BERT encoder  |
-| `MultilingualE5Small`          | `multilingual-e5-small`  | `intfloat/multilingual-e5-small` | 384         | 512        | yes          | no   | BERT encoder  |
-| `MultilingualE5Base`           | `multilingual-e5-base`   | `intfloat/multilingual-e5-base`  | 768         | 512        | yes          | no   | BERT encoder  |
-| `Qwen3Embedding0_6B`           | `qwen3-embedding-0.6b`   | `Qwen/Qwen3-Embedding-0.6B`      | 1024        | 8192       | yes          | yes  | Qwen3 decoder |
-| `Qwen3Embedding4B`             | `qwen3-embedding-4b`     | `Qwen/Qwen3-Embedding-4B`        | 2560        | 8192       | yes          | yes  | Qwen3 decoder |
-| `TextEmbedding3Small`          | `text-embedding-3-small` | `text-embedding-3-small`         | 1536        | 8191       | **no** (API) | —    | OpenAI remote |
+| Variant                        | Display Name             | HuggingFace ID                   | Native Dims | Max Tokens | Local? | MRL? | Architecture                           |
+| ------------------------------ | ------------------------ | -------------------------------- | ----------- | ---------- | ------ | ---- | -------------------------------------- |
+| `BgeSmallEnV15` (code default) | `bge-small-en-v1.5`      | `BAAI/bge-small-en-v1.5`         | 384         | 512        | yes    | no   | BERT encoder                           |
+| `BgeBaseEnV15`                 | `bge-base-en-v1.5`       | `BAAI/bge-base-en-v1.5`          | 768         | 512        | yes    | no   | BERT encoder                           |
+| `BgeLargeEnV15`                | `bge-large-en-v1.5`      | `BAAI/bge-large-en-v1.5`         | 1024        | 512        | yes    | no   | BERT encoder                           |
+| `MultilingualE5Small`          | `multilingual-e5-small`  | `intfloat/multilingual-e5-small` | 384         | 512        | yes    | no   | BERT encoder                           |
+| `MultilingualE5Base`           | `multilingual-e5-base`   | `intfloat/multilingual-e5-base`  | 768         | 512        | yes    | no   | BERT encoder                           |
+| `Qwen3Embedding0_6B`           | `qwen3-embedding-0.6b`   | `Qwen/Qwen3-Embedding-0.6B`      | 1024        | 8192       | yes    | yes  | Qwen3 decoder                          |
+| `Qwen3Embedding4B`             | `qwen3-embedding-4b`     | `Qwen/Qwen3-Embedding-4B`        | 2560        | 8192       | yes    | yes  | Qwen3 decoder                          |
+| `TextEmbedding3Small`          | `text-embedding-3-small` | `text-embedding-3-small`         | 1536        | 8191       | **no** | —    | Remote identifier; no provider service |
 
 ### Key Methods
 
-| Method                   | Returns        | Notes                                                                    |
-| ------------------------ | -------------- | ------------------------------------------------------------------------ |
-| `native_dimensions()`    | `usize`        | Full output dimension (ignoring MRL) — `model.rs:143`                    |
-| `dimensions()`           | `usize`        | Same as `native_dimensions()` (MRL is on `ModelConfig`) — `model.rs:165` |
-| `is_local()`             | `bool`         | All except `TextEmbedding3Small` — `model.rs:171`                        |
-| `is_remote()`            | `bool`         | Only `TextEmbedding3Small` — `model.rs:186`                              |
-| `max_input_tokens()`     | `usize`        | Token limit for chunking/truncation — `model.rs:200`                     |
-| `supports_output_dim()`  | `bool`         | Only Qwen3 variants — `model.rs:263`                                     |
-| `query_instruction()`    | `Option<&str>` | Query prefix for asymmetric retrieval; BGE/E5/Qwen3 `Some`, MiniLM `None` — `model.rs:227`                       |
-| `document_instruction()` | `Option<&str>` | E5 `"passage: "`; `None` for others — `model.rs:242`                                |
-| `model_id()`             | `&str`         | HuggingFace ID — `model.rs:248`                                          |
-| `key_version()`          | `&str`         | `"v3"` for Qwen3/OpenAI, `"v1.5"` for BGE/E5 — `model.rs:272`            |
+| Method                   | Returns        | Notes                                                                                      |
+| ------------------------ | -------------- | ------------------------------------------------------------------------------------------ |
+| `native_dimensions()`    | `usize`        | Full output dimension (ignoring MRL) — `model.rs:143`                                      |
+| `dimensions()`           | `usize`        | Same as `native_dimensions()` (MRL is on `ModelConfig`) — `model.rs:165`                   |
+| `is_local()`             | `bool`         | All except `TextEmbedding3Small` — `model.rs:171`                                          |
+| `is_remote()`            | `bool`         | Only `TextEmbedding3Small`; classification only, no provider service — `model.rs:186`      |
+| `max_input_tokens()`     | `usize`        | Token limit for chunking/truncation — `model.rs:200`                                       |
+| `supports_output_dim()`  | `bool`         | Only Qwen3 variants — `model.rs:263`                                                       |
+| `query_instruction()`    | `Option<&str>` | Query prefix for asymmetric retrieval; BGE/E5/Qwen3 `Some`, MiniLM `None` — `model.rs:227` |
+| `document_instruction()` | `Option<&str>` | E5 `"passage: "`; `None` for others — `model.rs:242`                                       |
+| `model_id()`             | `&str`         | HuggingFace ID — `model.rs:248`                                                            |
+| `key_version()`          | `&str`         | `"v3"` for Qwen3/OpenAI, `"v1.5"` for BGE/E5 — `model.rs:272`                              |
 
 ### String Parsing
 
@@ -206,16 +206,16 @@ Runtime SIMD feature detection determines which vector kernel is used for dot pr
 
 ---
 
-## Production Model Selection
+## Service Model Selection
 
-The **production default is `multilingual-e5-small`**, configured at the application level.
+The crate default is `BgeSmallEnV15`. Select a different model when constructing a service.
 
 ### How to Change the Active Model
 
-1. Set via `EmbeddedConfig` in code:
+1. Set via `ModelConfig` and `NativeEmbeddingService` in code:
    ```rust
-   let config = EmbeddedConfig::file("/path/to/db")
-       .with_embedding_model("qwen3-embedding-0.6b", 1024);
+   let config = ModelConfig::try_new(EmbeddingModel::Qwen3Embedding0_6B, Some(1024))?;
+   let service = NativeEmbeddingService::with_model_config(config)?;
    ```
 
 2. After changing models, existing embeddings are **incompatible** — check a model hash on startup and block if it mismatches. Re-embed existing data or start with a fresh database.
@@ -267,13 +267,16 @@ Or via env var:
 LATTICE_EMBED_DIM=1024 your-app --embed-query "query"
 ```
 
-### Remote (OpenAI)
+### Reserved Remote Model Identifier
 
 ```rust
 let config = ModelConfig::new(EmbeddingModel::TextEmbedding3Small);
-// Requires OPENAI_API_KEY env var
-// 1536 dimensions, no MRL support
 ```
+
+`TextEmbedding3Small` is a type-level remote model identifier. `lattice-embed` does not implement
+an OpenAI provider service and does not read `OPENAI_API_KEY`; `NativeEmbeddingService` rejects
+this model when loading. Constructing this `ModelConfig` alone does not provide a runnable remote
+embedding path.
 
 ---
 

--- a/crates/embed/README.md
+++ b/crates/embed/README.md
@@ -18,7 +18,8 @@ similarity matching.
 | `BgeBaseEnV15`  | 768        | Balanced quality/speed          | BAAI/bge-base-en-v1.5  |
 | `BgeLargeEnV15` | 1024       | Highest quality                 | BAAI/bge-large-en-v1.5 |
 
-All models have a 512 token input limit.
+The BGE models listed above have a 512-token input limit. See the
+[supported-model reference](../../docs/models.md) for every variant's limit and availability.
 
 ## Services
 
@@ -57,14 +58,14 @@ scalar fallback. On aarch64 the f32 kernels always use NEON (mandatory on that
 architecture, no runtime check), while the int8 kernel runtime-detects SDOT. On wasm32
 the SIMD choice is fixed at compile time and covers the f32 kernels only (see below).
 
-| Platform       | Instructions                                       |
-| -------------- | -------------------------------------------------- |
-| x86_64 (f32)   | AVX-512F > AVX2 + FMA > scalar                     |
-| x86_64 (int8)  | AVX-512 VNNI (`avx512` feature) > AVX2 > scalar    |
-| aarch64 (f32)  | ARM NEON (mandatory, always on)                    |
-| aarch64 (int8) | NEON SDOT (runtime-detected) > scalar              |
-| wasm32         | SIMD128 (compile-time, f32 kernels only) > scalar  |
-| Other          | Scalar fallback                                    |
+| Platform       | Instructions                                      |
+| -------------- | ------------------------------------------------- |
+| x86_64 (f32)   | AVX-512F > AVX2 + FMA > scalar                    |
+| x86_64 (int8)  | AVX-512 VNNI (`avx512` feature) > AVX2 > scalar   |
+| aarch64 (f32)  | ARM NEON (mandatory, always on)                   |
+| aarch64 (int8) | NEON SDOT (runtime-detected) > scalar             |
+| wasm32         | SIMD128 (compile-time, f32 kernels only) > scalar |
+| Other          | Scalar fallback                                   |
 
 ### wasm32 (SIMD128)
 
@@ -126,11 +127,15 @@ Blake3-based hashing with LRU eviction. Default capacity: 4000 entries (~6MB for
 vectors).
 
 ```rust
-use lattice_embed::{EmbeddingCache, EmbeddingModel};
+use lattice_embed::{EmbeddingCache, EmbeddingModel, EmbeddingRole, ModelConfig};
 
 let cache = EmbeddingCache::new(1000);
 
-let key = cache.compute_key("text", EmbeddingModel::BgeSmallEnV15);
+let key = cache.compute_key(
+    "text",
+    ModelConfig::new(EmbeddingModel::BgeSmallEnV15),
+    EmbeddingRole::Generic,
+);
 cache.put(key, vec![0.1, 0.2, 0.3]);
 
 let stats = cache.stats();

--- a/docs/adr/ADR-016-model-variants.md
+++ b/docs/adr/ADR-016-model-variants.md
@@ -49,15 +49,17 @@ The trade-off is that adding a new model requires touching the source.
 
 **Asymmetric retrieval instruction prefixes**
 
-Two model families require instruction prefixes that must be prepended at inference time:
+Three model families require instruction prefixes that must be prepended at inference time:
 
 - E5 models (`MultilingualE5Small`, `MultilingualE5Base`): `query_instruction()` returns `Some("query: ")`.
-  These models were fine-tuned with `"query: "` / `"passage: "` asymmetric prefixes; omitting them
-  degrades retrieval quality substantially. `document_instruction()` returns `None` — documents
-  are embedded with no prefix (by design in the original fine-tuning).
+  `document_instruction()` returns `Some("passage: ")`; `embed_query()` and `embed_passage()` apply
+  the corresponding asymmetric prefix before embedding.
 - Qwen3 models: `query_instruction()` returns the long instruction prompt `"Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: "`.
-  Decoder-based embedding models require an explicit task description to orient the pooled representation.
-- BGE and MiniLM families: both return `None` — trained on raw contrastive pairs without prefixes.
+  Decoder-based embedding models require an explicit task description to orient the pooled representation;
+  `document_instruction()` returns `None`.
+- BGE models: `query_instruction()` returns `Some("Represent this sentence for searching relevant passages: ")`;
+  `document_instruction()` returns `None`.
+- MiniLM models: both instruction methods return `None`.
 
 **MRL (Matryoshka Representation Learning) for Qwen3 only**
 

--- a/docs/adr/ADR-017-native-embedding-service.md
+++ b/docs/adr/ADR-017-native-embedding-service.md
@@ -8,7 +8,7 @@
 
 The embedding service must:
 
-1. Load a transformer model once per process (model weights are 100-400 MB; reloading is too slow).
+1. Load a transformer model once per service instance (model weights are 100-400 MB; reloading is too slow).
 2. Be cancellation-safe: if an async client disconnects during model loading (e.g., MCP timeout), the loading must not be abandoned and then restarted on the next request.
 3. Support both BERT encoder and Qwen3 decoder architectures with a single code path.
 4. Allow the output dimension to be configured via environment variable for MRL models.
@@ -19,8 +19,9 @@ blocking thread pool.
 
 ## Decision
 
-`NativeEmbeddingService` uses `std::sync::OnceLock<Result<LoadedModel, String>>` wrapped in
-`Arc` to guarantee once-and-only-once model loading that is safe under async cancellation.
+`NativeEmbeddingService` uses an instance-owned `std::sync::OnceLock<Result<LoadedModel, String>>`
+wrapped in `Arc` to guarantee once-and-only-once model loading per service instance that is safe
+under async cancellation. Separately constructed services own independent locks and models.
 
 ### Key Design Choices
 
@@ -33,8 +34,8 @@ continuous load attempts under flaky connectivity.
 
 `std::sync::OnceLock` runs its initializer to completion inside `spawn_blocking`. Even if
 the outer async future is cancelled and dropped, the `spawn_blocking` task continues
-running. The model is set in the `OnceLock` exactly once regardless of how many callers
-cancelled while waiting. The `OnceLock` is in an `Arc` so the `spawn_blocking` closure
+running. The model is set in the `OnceLock` exactly once regardless of how many callers on that
+service instance cancelled while waiting. The `OnceLock` is in an `Arc` so the `spawn_blocking` closure
 can own a reference to it and store the result after the original `NativeEmbeddingService`
 reference may have been dropped.
 
@@ -82,8 +83,9 @@ different MRL configurations never share a cache file. This is separate from the
 
 **Model mismatch is a hard error**
 
-`NativeEmbeddingService` is single-model: it loads exactly one model at construction time.
-`embed()` rejects requests for a different model with `EmbedError::InvalidInput`. Callers
+`NativeEmbeddingService` is single-model: it is configured for exactly one model at construction
+time and lazily loads that model. `embed()` rejects requests for a different model with
+`EmbedError::InvalidInput`. Callers
 that need multiple models should instantiate one `NativeEmbeddingService` per model and
 multiplex through a higher-level router.
 
@@ -108,7 +110,7 @@ multiplex through a higher-level router.
 ### Negative
 
 - First-call latency is high (~1-10 seconds for Qwen3-4B). Callers that need guaranteed sub-second response time must warm the service before accepting traffic.
-- Error from model loading is permanent within a process lifetime: once `OnceLock` stores `Err(...)`, subsequent calls always return that error without retry. Process restart is required to attempt a fresh load.
+- Error from model loading is permanent within that service instance's lifetime: once its `OnceLock` stores `Err(...)`, subsequent calls on the instance always return that error without retry. A fresh service instance is required to attempt a fresh load.
 - `NativeEmbeddingService` does not implement `Clone` — only `Arc<NativeEmbeddingService>` can be shared.
 
 ### Risks


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Correct ADR-016 to document the shipped E5 passage prefix and BGE query prefix.
- Scope ADR-017's `OnceLock` guarantee to one `NativeEmbeddingService` instance and clarify lazy loading and retry lifetime.
- Update the embed README cache-key example with `ModelConfig` and `EmbeddingRole`, and scope the 512-token statement to the listed BGE models.
- Mark `TextEmbedding3Small` in CONFIG as a type-level remote identifier without an implemented provider, and replace absent `EmbeddedConfig` examples with the shipped service API.

## Verification

- Compared the documentation with `EmbeddingModel::{query_instruction,document_instruction,max_input_tokens}`, `EmbeddingService::{embed_query,embed_passage}`, every `NativeEmbeddingService` constructor and its native loading branch, and `EmbeddingCache::compute_key` on current `main`.
- Ran `deno fmt --check` on all four edited Markdown files.
- Ran `./scripts/lint-docs.sh` successfully.
- Did not run Cargo build, check, test, Clippy, bench, or GPU commands because this is a documentation-only consistency fix.

Closes #758
Closes #760
Closes #767
