### PR TITLE
docs(fann): reconcile ADR-021/024/025/026 + README with shared-weight/builder/GPU contracts

### DIFF
--- a/crates/fann/README.md
+++ b/crates/fann/README.md
@@ -273,14 +273,26 @@ Enable the `gpu` feature for wgpu-based GPU acceleration.
 
 ```rust
 #[cfg(feature = "gpu")]
-use lattice_fann::gpu::{GpuContext, GpuNetwork};
+use lattice_fann::{
+    Activation, NetworkBuilder,
+    gpu::{GpuContext, GpuNetwork},
+};
+#[cfg(feature = "gpu")]
+use std::sync::Arc;
 
 #[cfg(feature = "gpu")]
 async fn gpu_inference() -> Result<(), Box<dyn std::error::Error>> {
-    let ctx = GpuContext::new().await?;
-    let network = GpuNetwork::from_cpu(&ctx, cpu_network)?;
+    let cpu_network = NetworkBuilder::new()
+        .input(4)
+        .hidden(8, Activation::ReLU)
+        .output(2, Activation::Softmax)
+        .build()?;
+    let ctx = Arc::new(GpuContext::new().await?);
+    let mut network = GpuNetwork::new(ctx, cpu_network)?;
+    let input = [0.1, 0.2, 0.3, 0.4];
 
     let output = network.forward(&input).await?;
+    println!("{output:?}");
     Ok(())
 }
 ```

--- a/crates/fann/src/gpu/mod.rs
+++ b/crates/fann/src/gpu/mod.rs
@@ -1,9 +1,9 @@
 //! GPU compute backend: contexts, pooled memory, WGSL pipelines, and dense inference.
 //!
 //! CPU selection uses a 10,000 effective-element threshold; activation policy uses 1,000.
-//! Keep each dispatch at or below 100,000 elements to retain 1.5 ms headroom beneath Metal's
-//! 2 ms watchdog. Apple Silicon uses 256-byte pool-buffer alignment and 32-thread matmul /
-//! 256-thread element-wise workgroups. See ADR-025 and `docs/gpu.md`.
+//! Layers above the static 100,000-element dispatch heuristic fall back to CPU; dispatch time
+//! is not measured at runtime. Apple Silicon uses 256-byte pool-buffer alignment and 32-thread
+//! matmul / 256-thread element-wise workgroups. See ADR-025 and `docs/gpu.md`.
 
 mod buffer;
 mod circuit_breaker;
@@ -28,9 +28,9 @@ pub mod thresholds {
     pub const BATCH_MIN_SIZE: usize = 100;
     /// Minimum elements for GPU activation function benefit
     pub const ACTIVATION_MIN_ELEMENTS: usize = 1_000;
-    /// Max elements per dispatch to avoid Metal watchdog (2ms limit)
+    /// Static element cap that triggers CPU fallback for oversized layers
     pub const MAX_ELEMENTS_PER_DISPATCH: usize = 100_000;
-    /// Metal dispatch time headroom (stay under 2ms watchdog)
+    /// Documentation target only; dispatch time is not measured at runtime
     pub const MAX_DISPATCH_TIME_MS: f32 = 1.5;
 }
 

--- a/crates/fann/src/network/builder.rs
+++ b/crates/fann/src/network/builder.rs
@@ -45,7 +45,8 @@ impl NetworkBuilder {
 
     /// Set the input size for the network
     ///
-    /// This must be called before adding any layers.
+    /// This must be called before `build` or `build_with_seed`; call order is otherwise
+    /// unconstrained.
     pub fn input(mut self, size: usize) -> Self {
         self.input_size = Some(size);
         self

--- a/crates/fann/src/training/backprop.rs
+++ b/crates/fann/src/training/backprop.rs
@@ -36,9 +36,9 @@ impl BackpropTrainer {
 
     /// Compute gradients for a single training sample using backpropagation.
     ///
-    /// After the forward pass, references weights and activations directly from
-    /// the network (no per-sample cloning). The forward pass is the only mutation;
-    /// all subsequent reads use immutable borrows.
+    /// After the forward pass, copies the final output so weights and activations can be
+    /// borrowed directly from the network. Delta vectors are allocated per sample; layer
+    /// weights and activation buffers are not cloned.
     fn compute_gradients(
         &self,
         network: &mut Network,

--- a/docs/adr/ADR-021-zero-alloc.md
+++ b/docs/adr/ADR-021-zero-alloc.md
@@ -71,15 +71,17 @@ pub fn forward(&mut self, input: &[f32]) -> FannResult<&[f32]> {
 
 - **Memory committed upfront**: Network reserves memory for maximum activation sizes at
   construction, even if never used
-- **No concurrent inference on same Network**: `&mut self` requirement prevents parallel
-  forward passes on a single instance; callers must clone for parallelism
+- **Single-input forward requires exclusive access**: `forward(&mut self, ...)` prevents
+  concurrent calls to that method on one instance. With the `parallel` feature,
+  `forward_batch(&self, ...)` instead shares the immutable layer parameters across workers
 - **Fixed topology**: Buffer sizes are locked at construction; dynamic layer addition
   would require reallocation
 
 ### Neutral
 
-- **Batch inference requires cloning**: `forward_batch()` clones the network per thread
-  when using Rayon parallelism; acceptable for typical batch sizes
+- **Batch inference allocates activation buffers**: `forward_batch()` shares weight matrices
+  rather than cloning the network, but allocates independent layer-activation buffers for each
+  input in the Rayon iterator
 
 ## Alternatives Considered
 

--- a/docs/adr/ADR-024-network-builder.md
+++ b/docs/adr/ADR-024-network-builder.md
@@ -18,7 +18,7 @@ A fluent `NetworkBuilder` struct with consuming builder methods. The build step 
 
 #### Fluent API with Consuming Methods
 
-All builder methods take and return `Self` by value. This enables method chaining without holding a mutable reference and makes partial builders inexpressible at runtime (an `input(...)` call must precede any `hidden`/`output` call, enforced by the `input_size: Option<usize>` field).
+All builder methods take and return `Self` by value. This enables method chaining without holding a mutable reference. Partial builders remain representable: `hidden()` and `output()` may be called before `input()` because they append to the layer list independently of `input_size`. The `build()` and `build_with_seed()` methods require an input size and at least one layer, regardless of the order in which those values were supplied.
 
 ```
 NetworkBuilder::new()

--- a/docs/adr/ADR-025-gpu-backend.md
+++ b/docs/adr/ADR-025-gpu-backend.md
@@ -25,11 +25,11 @@ All thresholds are constants in `gpu::thresholds`:
 | Matrix-vector | >10,000 elements | GPU launch overhead dominates below this |
 | Batch matmul  | batch_size > 100 | Amortize kernel launch cost              |
 | Activation    | >1,000 elements  | Element-wise is memory-bound             |
-| Max dispatch  | 100,000 elements | Stay under Metal 2ms watchdog            |
+| Max dispatch  | 100,000 elements | Static heuristic for CPU fallback        |
 
 `GpuNetwork::new` evaluates `should_use_gpu(total_params, 1)` at construction time. If the network is too small, `use_gpu = false` and all `forward()` calls delegate to the CPU network immediately, incurring no GPU overhead.
 
-The watchdog check (`elements > MAX_ELEMENTS_PER_DISPATCH`) inside `forward_gpu` provides a second safety net: if a single layer would exceed the Metal 2ms dispatch limit, the entire forward pass falls back to CPU rather than risking a GPU timeout.
+The element-count check (`elements > MAX_ELEMENTS_PER_DISPATCH`) inside `forward_gpu` provides a second fallback heuristic: if a single layer exceeds the cap, the entire forward pass falls back to CPU. It does not measure GPU execution time or enforce a 2ms boundary; `MAX_DISPATCH_TIME_MS` is not read by the dispatch logic.
 
 #### Shader Types and Compilation
 
@@ -106,8 +106,8 @@ After CPU-side training updates weights, `GpuNetwork::sync_weights()` calls `que
 
 ### Risks
 
-- The fallback to CPU inside `forward_gpu` (watchdog check) returns from the entire forward pass using the CPU network, losing any GPU work done on previous layers. This is correct but potentially surprising — partial GPU acceleration is not attempted.
-- The Metal 2ms watchdog is empirically set; different GPU generations may have different thresholds. `MAX_DISPATCH_TIME_MS = 1.5` is a conservative headroom.
+- The fallback to CPU inside `forward_gpu` (element-count check) returns from the entire forward pass using the CPU network, losing any GPU work done on previous layers. This is correct but potentially surprising — partial GPU acceleration is not attempted.
+- The 100,000-element cap is a fixed heuristic and may not correlate with dispatch duration across GPU generations. `MAX_DISPATCH_TIME_MS = 1.5` records a documentation target only; the code does not measure elapsed dispatch time.
 
 ## References
 

--- a/docs/adr/ADR-026-training-loop.md
+++ b/docs/adr/ADR-026-training-loop.md
@@ -63,11 +63,11 @@ Each epoch computes the average error across all batches. If `avg_error < config
 
 `TrainingConfig::seed: Option<u64>` controls the shuffle RNG. If `Some(seed)`, `SmallRng::seed_from_u64(seed)` is used; if `None`, `SmallRng::from_entropy()`. The RNG is created once before the epoch loop (not per-epoch) to ensure the full shuffle sequence is deterministic across epochs when a seed is provided.
 
-#### No Allocation in Hot Path
+#### Hot-Path Allocation Profile
 
 Gradient buffers (`weight_grads`, `bias_grads`) and the index vector (`indices`) are allocated once before the epoch loop. Inside each epoch, gradient buffers are zeroed with `fill(0.0)`. The velocity buffers are allocated once in `init_velocities` and reused across all epochs.
 
-The `compute_gradients` method calls `network.forward(input)` for the forward pass (which uses pre-allocated activation buffers), then reads layer weights and activations via `&[f32]` references — no per-sample cloning.
+The `compute_gradients` method calls `network.forward(input)` for the forward pass, which uses pre-allocated activation buffers. It then copies the final output into a new `Vec<f32>` and allocates the outer deltas vector plus one delta vector per layer for each sample. Layer weights and stored activation buffers are subsequently read through slice references rather than cloned.
 
 #### `Trainer` Trait
 
@@ -78,7 +78,7 @@ pub trait Trainer {
 }
 ```
 
-`lattice-tune`'s `GpuTrainer` can implement this trait to provide GPU-accelerated training as a drop-in replacement. The separation ensures `lattice-fann`'s core stays sync and allocation-free.
+`lattice-tune`'s `GpuTrainer` can implement this trait to provide GPU-accelerated training as a drop-in replacement. The separation keeps `lattice-fann`'s core training API synchronous and independent of the GPU runtime.
 
 ### Alternatives Considered
 
@@ -100,7 +100,7 @@ pub trait Trainer {
 
 ### Negative
 
-- `BackpropTrainer::compute_gradients` allocates `deltas: Vec<Vec<f32>>` per training sample. This is the most expensive allocation in the training hot path. A pre-allocated deltas buffer (similar to how gradient buffers are pre-allocated) would eliminate it.
+- `BackpropTrainer::compute_gradients` copies the final output and allocates `deltas: Vec<Vec<f32>>` per training sample. These are the per-sample allocations in the training hot path. Pre-allocated output and deltas buffers (similar to the gradient buffers) would eliminate them.
 - `Trainer` trait is synchronous only — async training requires a different interface, which is why `lattice-tune` implements its own `GpuTrainer`.
 
 ### Risks


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Reconcile ADR-021 with `forward_batch`: Rayon workers share immutable layer parameters and allocate per-input activation buffers instead of cloning the network.
- Correct ADR-024 and `NetworkBuilder::input` documentation so input is required at build time but need not precede layer methods.
- Document ADR-026's shipped per-sample output copy and delta-vector allocations.
- Replace the stale GPU README example with the current `Arc<GpuContext>`, `GpuNetwork::new`, and mutable-forward API.
- Clarify in ADR-025 and GPU comments that the 100,000-element cap is a static CPU-fallback heuristic and elapsed dispatch time is not measured.

## Verification

- Compared each ADR/comment claim with the current implementations in `network/mod.rs`, `network/builder.rs`, `training/backprop.rs`, `gpu/network.rs`, and `gpu/mod.rs`.
- Confirmed `MAX_DISPATCH_TIME_MS` has no runtime consumer and that oversized layers fall back through the `MAX_ELEMENTS_PER_DISPATCH` element-count check.
- Ran `git diff --check`; no build, test, benchmark, or Clippy command was run for these documentation/comment-only changes.

Closes #768
