### PR TITLE
docs(transport): correct ADR-036/038/039/055 to observe/Result API + actual solver paths

### DIFF
--- a/docs/adr/ADR-036-log-domain-stability.md
+++ b/docs/adr/ADR-036-log-domain-stability.md
@@ -69,11 +69,12 @@ pub fn safe_exp(log_value: f32) -> f32 {
 }
 ```
 
-`exp(-104)` ≈ `1.2e-45` which is below f32's smallest subnormal (`~1.4e-45`), producing
-0.0 in round-to-nearest mode. Subnormal numbers incur a performance penalty on some CPUs
-(x87 "denormal assist"). The cutoff is set conservatively at `-103.97208` (≈ `ln(f32::MIN_POSITIVE)`)
-to ensure clean zero rather than a subnormal. `safe_exp` is only called when recovering
-transport mass for statistics — it is not in the inner Sinkhorn loop.
+`exp(-104)` ≈ `1.2e-45` which is below f32's smallest subnormal (`2^-149` ≈ `1.4e-45`),
+producing 0.0 in round-to-nearest mode. Subnormal numbers incur a performance penalty on
+some CPUs (x87 "denormal assist"). The cutoff `-103.97208` is approximately `ln(2^-150)`,
+the rounding boundary below the minimum f32 subnormal, so smaller values become clean zero
+rather than a subnormal. `safe_exp` is only called when recovering transport mass for
+statistics — it is not in the inner Sinkhorn loop.
 
 **`logaddexp(a, b)` — stable log(exp(a) + exp(b))**
 

--- a/docs/adr/ADR-038-barycenters.md
+++ b/docs/adr/ADR-038-barycenters.md
@@ -116,7 +116,9 @@ outer iteration (points move), so only owned data structures are appropriate.
 
 ### Positive
 
-- Fixed-support barycenter re-uses the full `SinkhornSolver` machinery including Rayon parallelism (for large support sizes) and convergence checking.
+- Fixed-support barycenter reuses `SinkhornSolver` convergence checking and warm-started dual
+  variables. Its erased `dyn CostMatrix` inputs call the sequential `solve_warm_start` path,
+  not the Rayon-enabled `solve_dense` path.
 - The workspace pattern eliminates allocations in the outer loop after the first iteration.
 - `FixedSupportBarycenter.source_results` returns the per-source Sinkhorn results from the final outer iteration, enabling diagnosis of which source was furthest from the barycenter.
 

--- a/docs/adr/ADR-039-divergence-measures.md
+++ b/docs/adr/ADR-039-divergence-measures.md
@@ -48,9 +48,10 @@ and `regularized_cost = transport_cost - ε * entropy`. Using `regularized_cost`
 
 `sinkhorn_divergence` accepts three `SinkhornWorkspace` parameters (`workspace_xy`,
 `workspace_xx`, `workspace_yy`). Reusing a single workspace would require resizing it
-between the cross-term solve (n×m) and self-term solves (n×n and m×m), destroying
-warm-start state. Three workspaces allow each solve to warm-start independently across
-repeated divergence computations with slowly-changing distributions.
+between the cross-term solve (n×m) and self-term solves (n×n and m×m). Three workspaces
+preserve independently sized buffers across repeated divergence computations. Each term
+uses `SinkhornSolver::solve`, which resets its workspace's dual variables before solving;
+the current divergence API reuses buffer capacity but does not warm-start between calls.
 
 **Three separate cost matrices**
 
@@ -122,7 +123,8 @@ important for debugging cases where one of the three solves failed to converge.
 ### Positive
 
 - `S(a, a) ≈ 0` for any distribution `a` when the correct `regularized_cost` formula is used (FP-023 fix). This enables a single threshold parameter for drift detection regardless of distribution shape.
-- The three-workspace design enables warm-starting across repeated drift checks with slowly-changing distributions (e.g., streaming window drift detection where the reference window advances by one sample at a time).
+- The three-workspace design reuses independently sized buffers across repeated drift checks,
+  avoiding allocation when the cross and self problem dimensions remain unchanged.
 - The lower-level API `sinkhorn_divergence` is testable with synthetic `ClosureCostMatrix` inputs without needing real embedding data.
 
 ### Negative

--- a/docs/adr/ADR-055-online-drift-detection.md
+++ b/docs/adr/ADR-055-online-drift-detection.md
@@ -38,7 +38,7 @@ applies symmetrically to both mechanisms. This ADR formalizes the dual-use desig
 ## Decision
 
 Add an `OnlineDriftDetector` to `lattice-transport` that computes Sinkhorn divergence over
-a sliding window of hidden-state samples. Expose an `OnlineDriftSignal` event type that
+a sliding window of hidden-state samples. Expose an `OnlineDriftSignal` per-sample status enum that
 `lattice-inference` subscribes to for triggering adapter and router staleness checks.
 
 **Existing drift API**: `crates/transport/src/drift.rs` already provides `DriftConfig`,
@@ -86,13 +86,15 @@ No new crates. No Metal kernel changes. No changes to serving hot path.
 pub struct OnlineDriftConfig {
     pub window_size: usize,     // W; minimum 128. O(W²) per divergence call.
     pub check_interval: usize,  // compute divergence every N new samples (amortizes cost)
-    pub threshold: f32,         // S(ref, current) > threshold → emit OnlineDriftSignal
+    pub threshold: f32,         // S(ref, current) > threshold → return Drift
     pub epsilon: f32,           // Sinkhorn regularization (inherited from SinkhornConfig)
 }
 
-pub struct OnlineDriftSignal {
-    pub divergence: f32,        // S(reference, current) value at detection
-    pub window_pos: usize,      // total samples seen when signal fired
+pub enum OnlineDriftSignal {
+    Warming { samples_seen: usize, window_size: usize },
+    Skipped { samples_seen: usize, next_check_in: usize },
+    Stable { divergence: f32, window_pos: usize },
+    Drift { divergence: f32, window_pos: usize },
 }
 
 pub struct OnlineDriftDetector {
@@ -100,21 +102,24 @@ pub struct OnlineDriftDetector {
     reference_window: VecDeque<Vec<f32>>,   // first W samples; frozen as reference
     current_window: VecDeque<Vec<f32>>,     // sliding window of last W samples
     samples_seen: usize,
-    // Three workspaces for warm-start across repeated divergence calls (ADR-039 pattern)
+    // Three independently sized, reusable workspaces; divergence solves reset dual variables
     workspace_xy: SinkhornWorkspace,
     workspace_xx: SinkhornWorkspace,
     workspace_yy: SinkhornWorkspace,
 }
 
 impl OnlineDriftDetector {
-    pub fn push(&mut self, sample: Vec<f32>) -> Option<OnlineDriftSignal>;
+    pub fn observe(&mut self, sample: Vec<f32>)
+        -> Result<OnlineDriftSignal, SinkhornError>;
     pub fn reset_reference(&mut self);  // call after adapter/router refresh
 }
 ```
 
-`push()` appends to `current_window`, evicts oldest entry if full. Every `check_interval`
-samples, calls `point_set_sinkhorn_divergence` (ADR-039) between `reference_window` and
-`current_window`. If `divergence > threshold`, returns `Some(OnlineDriftSignal)`.
+`observe()` appends to `current_window` and evicts the oldest entry if full. It returns
+`Warming` while the windows fill and `Skipped` between checks. Every `check_interval`
+samples, it calls `point_set_sinkhorn_divergence` (ADR-039) between `reference_window` and
+`current_window`, returning `Stable` or `Drift` according to the threshold. Solver failures
+are returned as `Err(SinkhornError)`.
 
 The reference window is frozen at construction from the first W samples. After an adapter
 refresh, `reset_reference()` promotes `current_window` to `reference_window`, restarting
@@ -175,8 +180,9 @@ use, and `rate_of_divergence` is empirically estimated from the drift signal tim
 
 In practice, `threshold` in `OnlineDriftConfig` is a Sinkhorn divergence value calibrated from a
 validation set: compute `S(training_dist, held_out_dist)` at known excess NLL levels and pick
-the divergence that corresponds to acceptable degradation. The `OnlineDriftSignal.divergence` value
-lets the reactor apply graduated responses (warn vs. force-refresh vs. fallback to base model).
+the divergence that corresponds to acceptable degradation. The `divergence` value carried by the
+`Stable` and `Drift` variants lets the reactor apply graduated responses (warn vs. force-refresh
+vs. fallback to base model).
 
 ---
 
@@ -224,7 +230,7 @@ receives `Vec<f32>` values. Enforcement: `crates/transport/Cargo.toml` must neve
 
 - ADR-035: Sinkhorn-Knopp Solver — sliding window builds on this primitive
 - ADR-036: Log-Domain Stability — numerical robustness inherited
-- ADR-039: Sinkhorn Divergence — `point_set_sinkhorn_divergence`, three-workspace warm-start
+- ADR-039: Sinkhorn Divergence — `point_set_sinkhorn_divergence`, three reusable workspaces
 - ADR-040: Gated Attention (MoE router) — router staleness context
 - ADR-043: LoRA Serving Verification — adapter serving context
 - Genevay, Peyré, Cuturi, "Learning Generative Models with Sinkhorn Divergences", AISTATS 2018


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Correct ADR-036 to derive the exponential cutoff from the f32 subnormal rounding boundary rather than `f32::MIN_POSITIVE`.
- Document that fixed-support barycenters use the sequential erased-cost `solve_warm_start` path, not the Rayon-enabled dense path.
- Clarify that divergence workspaces reuse independently sized buffers while ordinary `SinkhornSolver::solve` calls reset dual variables.
- Update ADR-055 from the removed `push() -> Option<_>` contract to `observe() -> Result<OnlineDriftSignal, SinkhornError>` and its four per-sample status variants.

## Verification

Compared each ADR directly with the shipped implementations in `logsumexp.rs`, `barycenter.rs`, `divergence.rs`, `sinkhorn.rs`, and `online_drift.rs`. Ran `./scripts/lint-docs.sh` and `git diff --check`; both passed. Cargo checks were intentionally not run because this is a documentation-only consistency fix.

Closes #770