### PR TITLE
docs(macos): reconcile README/INSTALL/DISTRIBUTION/INSTRUMENT_SCOPE with current app behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ the `lattice` binary for interactive chat and an OpenAI-compatible HTTP server.
 
 **Lattice Studio: a native macOS app.** A SwiftUI instrument panel that drives the Rust engine
 via CLI subprocesses. Train LoRA adapters with a live loss oscilloscope, quantize models with
-a before/after comparison, hot-swap adapters in chat with zero reload, and manage your model
-library from a single window. To build and install it, follow the step-by-step guide in
+a before/after comparison, run multi-turn chat with persistent GPU model residency, and manage your
+model library from a single window. To build and install it, follow the step-by-step guide in
 [`apps/macos/INSTALL.md`](apps/macos/INSTALL.md).
 
 ---
@@ -40,8 +40,8 @@ library from a single window. To build and install it, follow the step-by-step g
 | Generation models      | Qwen3.5-0.8B / 2B via `lattice chat`/`serve`. Qwen3.6-27B via `lattice chat`/`serve` from a native Q4 checkpoint (requires the Metal GPU build, `--features "f16 metal-gpu"`); safetensors 27B is loader-level only. Qwen3.6-35B-A3B (MoE): config + weight loader support. Hybrid GatedDeltaNet + GQA architecture. |
 | Embedding models       | 9 models: BGE, E5, MiniLM, Qwen3-Embedding families. Auto-download for 7 BERT-family variants.                                                                                                                                                                                                                       |
 | Three tokenizers       | WordPiece, SentencePiece, BPE. No Hugging Face tokenizers C extension.                                                                                                                                                                                                                                               |
-| Quantization           | Q8, Q4, and QuaRot (rotation-based 4-bit). No other engine runs Q4 + LoRA hot-swap on Qwen3.5.                                                                                                                                                                                                                       |
-| LoRA                   | Inference hook, hot-swap with no reload, PEFT safetensors format, training via `lattice-tune`.                                                                                                                                                                                                                       |
+| Quantization           | Q8, Q4, and QuaRot (rotation-based 4-bit), including Q4 + LoRA inference on Qwen3.5.                                                                                                                                                                                                                                |
+| LoRA                   | Inference hooks, load-time adapter selection, PEFT safetensors format, training via `lattice-tune`.                                                                                                                                                                                                                  |
 | HTTP API               | OpenAI-compatible `/v1/chat/completions` via `lattice serve`.                                                                                                                                                                                                                                                        |
 | Safetensors native     | Memory-mapped weight loading. Single-file and sharded checkpoints.                                                                                                                                                                                                                                                   |
 | KV cache               | Incremental decoding with key-value caching.                                                                                                                                                                                                                                                                         |
@@ -98,7 +98,7 @@ provide for this model family:
 | Capability                          | Lattice | MLX | Ollama |
 | ----------------------------------- | ------- | --- | ------ |
 | QuaRot 4-bit (rotation-based quant) | yes     | no  | no     |
-| Q4 + LoRA hot-swap (no reload)      | yes     | no  | no     |
+| Q4 + LoRA inference                 | yes     | no  | no     |
 | Pure Rust, zero Python or framework | yes     | no  | no     |
 
 PPL benchmark (wikitext-2, from `docs/bench_results/perplexity.tsv`): Lattice q4 19.27, q4-QuaRot 19.95 (2048 tokens); MLX q8 15.82, q4 18.18 (2041 tokens). Reproduce:
@@ -327,7 +327,7 @@ curl http://127.0.0.1:8080/v1/chat/completions \
 
 Lattice Studio is a native SwiftUI app for macOS 14+. It wraps the Rust engine in an
 instrument-panel interface: live loss curves, before/after quantization comparisons,
-LoRA hot-swap in chat, and a model library manager.
+multi-turn chat, and a model library manager.
 
 > New to the app? [`apps/macos/INSTALL.md`](apps/macos/INSTALL.md) is a step-by-step
 > install, get-a-model, and first-chat guide. The reference below covers building the
@@ -340,9 +340,9 @@ LoRA hot-swap in chat, and a model library manager.
 ./apps/macos/scripts/package-app.sh
 ```
 
-This builds the Swift frontend, compiles all Rust engine binaries in release mode, and
-assembles a self-contained `LatticeStudio.app` bundle at `apps/macos/dist/`. A `.dmg`
-and `.zip` are also produced. The packaged app needs no Rust toolchain on the recipient
+This builds the Swift frontend, compiles all ten Rust engine binaries in release mode, and
+assembles a self-contained `Lattice.app` bundle at `apps/macos/dist/`. `Lattice.dmg` and
+`Lattice.zip` are also produced. The packaged app needs no Rust toolchain on the recipient
 machine.
 
 ```bash
@@ -355,14 +355,14 @@ machine.
 
 ### Install
 
-Drag `LatticeStudio.app` from the `.dmg` to `/Applications`.
+Drag `Lattice.app` from the `.dmg` to `/Applications`.
 
 The app is ad-hoc signed. On first launch, right-click and choose "Open" to bypass
 Gatekeeper, then click "Open" in the dialog. macOS remembers the exception for subsequent
 launches. Alternatively:
 
 ```bash
-xattr -dr com.apple.quarantine /Applications/LatticeStudio.app
+xattr -dr com.apple.quarantine /Applications/Lattice.app
 ```
 
 ### What is in Lattice Studio
@@ -379,9 +379,10 @@ ticks digit-by-digit as the run progresses. Scrub the loss curve to freeze all m
 bits, and estimated PPL before and after. True-scale bars animate to show the compression
 ratio. A gate pill states the result: PASS, WARN, or FAIL.
 
-**Chat (cmd-4).** Side-by-side base vs. base+adapter columns streaming the same prompt in
-parallel. The adapter selector is a console fader: slide it and the engine swaps the adapter
-with no reload. A "0 ms reload" stamp confirms it. Each column shows live tok/s and time-to-first-token.
+**Chat (cmd-4).** A single streaming transcript replays completed turns into each prompt. The GPU
+path reuses a persistent `chat_metal --serve` process so the selected model stays resident between
+turns; the CPU path launches `generate_lora` once per turn. The shipped Chat screen does not yet
+expose adapter selection or parallel base-vs.-adapter comparison.
 
 **Data (cmd-5).** Paste raw text or load files. Preview the derived `{prompt, completion}` pairs
 as a JSONL table, validate token counts (using the same tokenizer the engine uses), and export

--- a/apps/macos/DESIGN.md
+++ b/apps/macos/DESIGN.md
@@ -4,6 +4,7 @@
 > **Target:** macOS 26, SwiftUI, `swift build`. Toolchain verified: Apple Swift 6.3.2 / `arm64-apple-macosx26.0`.
 > **Backend:** the `lattice` pure-Rust engine, driven via CLI subprocesses (line-delimited JSON event stream).
 > **Brand law (governs both directions):** *measure first, the number is the truth.* Bold is spent on the **numbers**, not on chrome. Adaptive light + dark from day one.
+> **Current implementation status:** The shipped app forces `.preferredColorScheme(.dark)`; light mode remains deferred relative to this decision.
 
 ---
 
@@ -45,7 +46,9 @@ The README is explicit that MLX is faster; lattice's edge is **capabilities + ho
 
 ### Palette
 
-Adaptive via semantic `Color` assets in the asset catalog (`Color(.panel)`, `Color(.ink)`, `Color(.signal)`…). Dark is the home key; light is a true first-class peer reading like a lab instrument under daylight — same hairline-and-well skeleton, value-inverted.
+This design specifies dark and light semantic color tokens. The shipped app currently locks
+`preferredColorScheme(.dark)`, so dark is the only active appearance and light implementation is
+deferred. The table below retains the intended paired values.
 
 | Token | Dark hex | Light hex | Usage |
 |---|---|---|---|

--- a/apps/macos/DISTRIBUTION.md
+++ b/apps/macos/DISTRIBUTION.md
@@ -11,17 +11,19 @@ cd lattice/
 
 This will:
 1. Run `swift build -c release` to produce the Swift instrument panel.
-2. Build all 6 Rust engine binaries with `cargo build --release`.
-3. Assemble `apps/macos/dist/LatticeStudio.app` with the engine binaries inside
+2. Build all 10 Rust engine binaries with `cargo build --release`: `quantize_q4`,
+   `quantize_quarot`, `lattice`, `qwen35_generate`, `train_grad_full`, `generate_lora`,
+   `eval_perplexity`, `embed`, `chat_metal`, and `lattice_serve`.
+3. Assemble `apps/macos/dist/Lattice.app` with the engine binaries inside
    `Contents/Resources/bin/` so the app is fully self-contained.
 4. Write `Contents/Info.plist` with bundle ID `ai.khive.lattice.studio`.
 5. Ad-hoc codesign the bundle.
-6. Produce `apps/macos/dist/LatticeStudio.dmg` and `LatticeStudio.zip`.
+6. Produce `apps/macos/dist/Lattice.dmg` and `Lattice.zip`.
 
 Options:
 
 ```bash
-# Skip Swift rebuild (use existing .build/release/LatticeStudio)
+# Skip Swift rebuild (use existing .build/release/Lattice)
 ./apps/macos/scripts/package-app.sh --skip-build
 
 # Skip Cargo rebuild (use existing target/release/ binaries)
@@ -33,7 +35,7 @@ Options:
 
 ## Installing
 
-Drag `LatticeStudio.app` from the DMG to `/Applications`.
+Drag `Lattice.app` from the DMG to `/Applications`.
 
 Requires macOS 14.0 (Sonoma) or later. The app is self-contained — no source
 checkout, no Cargo, no Rust toolchain needed on the recipient machine.
@@ -44,13 +46,13 @@ The app is ad-hoc signed, which means macOS Gatekeeper will quarantine it on
 first launch because it lacks a Developer ID certificate. Recipients must:
 
 **Option 1 — right-click → Open:**
-1. Right-click (or Ctrl-click) `LatticeStudio.app` in Finder.
+1. Right-click (or Ctrl-click) `Lattice.app` in Finder.
 2. Choose "Open" from the context menu.
 3. Click "Open" in the dialog. macOS remembers the exception.
 
 **Option 2 — remove the quarantine xattr:**
 ```bash
-xattr -dr com.apple.quarantine /Applications/LatticeStudio.app
+xattr -dr com.apple.quarantine /Applications/Lattice.app
 ```
 
 This is a one-time step. The app will open normally on subsequent launches.

--- a/apps/macos/INSTALL.md
+++ b/apps/macos/INSTALL.md
@@ -38,13 +38,13 @@ installed, run:
 ./apps/macos/scripts/package-app.sh
 ```
 
-This compiles the Swift app and all engine binaries in release mode and assembles
-`apps/macos/dist/LatticeStudio.app`, along with a `.dmg` and a `.zip`. Any of these
+This compiles the Swift app and all ten engine binaries in release mode and assembles
+`apps/macos/dist/Lattice.app`, along with `Lattice.dmg` and `Lattice.zip`. Any of these
 can be copied to another Mac and will run there without a toolchain.
 
 ### Install a `.dmg` someone built
 
-If a developer hands you a `LatticeStudio.dmg` (or you built one with the command
+If a developer hands you a `Lattice.dmg` (or you built one with the command
 above), you do not need any developer tools to install it. Open the `.dmg` and go
 to step 2.
 
@@ -56,17 +56,17 @@ to step 2.
 
 ## 2. Install and open it
 
-1. Drag **LatticeStudio** from the `.dmg` into your **Applications** folder.
+1. Drag **Lattice** from the `.dmg` into your **Applications** folder.
 2. The app is signed with a free ad-hoc certificate, not a paid Apple Developer ID,
    so the first launch needs one extra step. **Right-click** (or Control-click)
-   **LatticeStudio** in Applications, choose **Open**, then click **Open** in the
+   **Lattice** in Applications, choose **Open**, then click **Open** in the
    dialog. macOS remembers this, so every launch after the first is a normal
    double-click.
 
    The terminal equivalent of that one-time step is:
 
    ```bash
-   xattr -dr com.apple.quarantine /Applications/LatticeStudio.app
+   xattr -dr com.apple.quarantine /Applications/Lattice.app
    ```
 
 ---

--- a/apps/macos/docs/INSTRUMENT_SCOPE.md
+++ b/apps/macos/docs/INSTRUMENT_SCOPE.md
@@ -39,7 +39,7 @@ processes, parses their output, and renders live readouts.
 | Screens/ | TrainScreen.swift | LoRA fine-tune config + live oscilloscope + control strip | EXISTS |
 | Screens/ | QuantizeScreen.swift | Q4 / QuaRot config + layer progress + mass comparison | EXISTS |
 | Screens/ | ModelsScreen.swift | Model DataTable + inspector + action row (Train/Quantize/Chat→) | EXISTS |
-| Screens/ | ChatScreen.swift | Config strip + single-variant transcript + generate_lora subprocess | PARTIAL |
+| Screens/ | ChatScreen.swift | Model/backend config + multi-turn transcript; persistent GPU chat, one-shot CPU chat | PARTIAL |
 | Screens/ | DataScreen.swift | Source dir scan, .jsonl inspector, builder-script copy buttons | EXISTS |
 | Screens/ | RunsScreen.swift | Run archive DataTable + live banner + inspector | EXISTS |
 | Screens/ | ScreenScaffold.swift | Shared header chrome (index / title / subtitle / trailing slot) | EXISTS |
@@ -47,7 +47,7 @@ processes, parses their output, and renders live readouts.
 | Components/ | StripChart.swift | Swift Charts oscilloscope: LineMark + AreaMark + scrub-to-freeze | EXISTS |
 | Components/ | HeroNumber.swift | 56pt tabular-mono hero with .contentTransition(.numericText()) | EXISTS |
 | Components/ | GatePill.swift | PASS/WARN/FAIL/RUN verdict pill, 6px radius, animated pulse on RUN | EXISTS |
-| Components/ | FaderToggle.swift | Console spring-fader for binary mode choices (Q4↔QuaRot, BASE↔+ADAPTER) | EXISTS |
+| Components/ | FaderToggle.swift | Unwired BASE↔+ADAPTER console fader; instantiated only by its SwiftUI preview | PARTIAL |
 | Components/ | ReadoutWell.swift | 15pt tabular-mono well: label + value + unit + delta caret | EXISTS |
 | Components/ | OpaquePanel.swift | Instrument panel surface (opaque, 1px hairline, 0px radius) + well surface | EXISTS |
 | Components/ | ParamRow.swift | Config param row variants used in TrainScreen/QuantizeScreen | EXISTS |
@@ -64,14 +64,15 @@ AppStore (@Observable @MainActor)
   ├── selection: Screen                    current nav screen
   ├── models: [ModelInfo]                  discovered on disk
   ├── runs: [RunRecord]                    JSON-persisted archive
-  ├── liveRun: LiveRun?                    the one active subprocess run
+  ├── liveRun: LiveRun?                    the one active logical run
   ├── workingModel: ModelInfo?             explicit cross-screen target
-  ├── handle: RunHandle?                   the one live Process wrapper
+  ├── handle: RunHandle?                   one-shot Process wrapper
+  ├── chatSessionHandle: RunHandle?        persistent GPU chat_metal --serve process
   └── binariesReady: Bool                  prebuilt .lattice binary present
 ```
 
-Only one subprocess runs at a time. `AppStore.launch()` calls `prior.stop()` before starting
-a new one (AppStore.swift line 108).
+`AppStore.launch()` replaces the prior one-shot process. GPU chat uses a separate persistent
+`chat_metal --json --serve` handle so the selected model can remain resident between turns.
 
 ### 2.3 What Works Today
 
@@ -85,7 +86,9 @@ a new one (AppStore.swift line 108).
 - DataScreen: .jsonl scan, summary stats, 5-example preview, builder-script copy buttons.
 - RunsScreen: persistent run archive (Application Support/LatticeStudio/runs.json), live banner.
 - CommandBar: ⌘K palette with 7 commands, fuzzy match.
-- ChatScreen config strip and transcript: functional for single-variant generation.
+- ChatScreen model/backend config and multi-turn transcript: functional for single-variant
+  generation. Completed turns are replayed in each prompt; GPU chat keeps the model resident,
+  while CPU chat launches a fresh process per turn.
 
 ---
 
@@ -112,6 +115,10 @@ AppStore.launch(bin, args)
 
 `Source: LatticeBridge.swift (RunHandle class) + AppStore.swift lines 96-120`
 
+CPU chat follows this one-shot launch path through `generate_lora`. GPU chat instead starts or
+reuses a `chat_metal --json --serve` process and writes one JSON request per turn to its stdin;
+the model remains resident, but the request still contains the full replayed conversation prompt.
+
 ### 3.2 Binary Path Resolution
 
 Resolution order (LatticeBridge.swift `launchSpec`):
@@ -123,7 +130,7 @@ Resolution order (LatticeBridge.swift `launchSpec`):
 
 `Source: LatticeBridge.swift + apps/macos/DISTRIBUTION.md`
 
-### 3.3 Bundled Binaries (6)
+### 3.3 Bundled Binaries (10)
 
 Defined in `apps/macos/scripts/package-app.sh`:
 
@@ -135,6 +142,10 @@ Defined in `apps/macos/scripts/package-app.sh`:
 | `qwen35_generate` | lattice-inference | (none) | Qwen3.5 generation |
 | `train_grad_full` | lattice-tune | `train-backward` | LoRA fine-tune |
 | `generate_lora` | lattice-tune | `safetensors,inference-hook` | LoRA chat generation |
+| `eval_perplexity` | lattice-inference | `f16,metal-gpu` | CPU BF16 and Metal Q4/QuaRot perplexity evaluation |
+| `embed` | lattice-embed | default | embedding CLI |
+| `chat_metal` | lattice-inference | `f16,metal-gpu` | persistent Metal chat session |
+| `lattice_serve` | lattice-inference | `f16,metal-gpu` | OpenAI-format HTTP daemon |
 
 ### 3.4 Event Protocol
 
@@ -207,14 +218,17 @@ the current binary (train_grad_full.rs line 743).
 --model-dir <PATH>
 --output-dir <PATH>
 --dry-run               (Q4 and QuaRot)
---seed <U64>            (QuaRot only, default 0xC0FFEE)
+--seed <U64>            (QuaRot only; required by the binary)
 ```
+
+The macOS `QuantConfig` wrapper always supplies this required flag, inserting `0xC0FFEE` when
+the UI leaves the seed unset. Direct `quantize_quarot` callers must choose and pass a seed.
 
 ### 3.6 ASCII Architecture Diagram
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│                 LatticeStudio.app                   │
+│                    Lattice.app                      │
 │                                                     │
 │  ┌──────────┐    ┌───────────┐    ┌─────────────┐  │
 │  │ AppStore │←─→ │ LiveRun   │←── │ SwiftUI     │  │
@@ -247,6 +261,10 @@ the current binary (train_grad_full.rs line 743).
 │  quantize_quarot   (lattice-inference)           │
 │  lattice           (lattice-inference)           │
 │  qwen35_generate   (lattice-inference)           │
+│  eval_perplexity   (lattice-inference +Metal)    │
+│  embed             (lattice-embed)               │
+│  chat_metal        (lattice-inference +Metal)    │
+│  lattice_serve     (lattice-inference +Metal)    │
 └──────────────────────────────────────────────────┘
 ```
 
@@ -309,15 +327,16 @@ the current binary (train_grad_full.rs line 743).
 
 | Feature | State | Notes |
 |---------|-------|-------|
-| Config strip (model + adapter pickers) | EXISTS | |
-| FaderToggle BASE↔+ADAPTER | EXISTS | changes adapterPath in next GenConfig only |
+| Config strip (model + CPU/GPU picker) | EXISTS | |
+| Adapter picker / FaderToggle | MISSING | `FaderToggle` is preview-only; live `GenConfig.adapterPath` is nil |
 | Sampling params (temperature, max-tokens, seed) | EXISTS | |
-| Single-variant transcript | EXISTS | ChatTurn model; streaming via genText accumulation |
-| generate_lora subprocess + `--json` | EXISTS | GenConfig → AppStore.runGenerate() |
+| Single-variant multi-turn transcript | EXISTS | `renderChatML` replays completed `ChatTurn` pairs into each prompt |
+| GPU `chat_metal --json --serve` session | EXISTS | one persistent process keeps the selected model resident |
+| CPU `generate_lora --json` subprocess | EXISTS | one fresh process per turn via `AppStore.runGenerate()` |
 | Streaming gen_token events | EXISTS | onChange on store.liveRun?.genText accumulates deltas |
 | Non-streaming fallback | EXISTS | filters log lines for non-"$ " prefix |
-| True A/B lockstep streaming | MISSING | FaderToggle flip is manual; two parallel subprocesses never run; "0 ms reload" text is hardcoded UI label (FaderToggle.swift line 137) |
-| Conversation history (multi-turn) | MISSING | each submission is a fresh subprocess invocation; no history passed |
+| True A/B lockstep streaming | MISSING | each send dispatches one backend run; no production adapter control is wired |
+| Conversation history (multi-turn) | EXISTS | completed turns are prompt-replayed; there is no cross-turn KV prefix cache |
 | Adapter hot-swap mid-conversation | MISSING | DESIGN.md arc_swap/LiveModel references are aspirational; no engine API exists |
 
 ---
@@ -326,11 +345,9 @@ the current binary (train_grad_full.rs line 743).
 
 ### G1 — No true A/B side-by-side (MISSING, HIGH)
 
-`ChatScreen.swift` comment: "We do NOT auto-run both variants — manual flip+resend is the v1
-A/B story." The FaderToggle label "0 ms reload" is hardcoded text (FaderToggle.swift line 137),
-not a live measurement. Running base and adapter in parallel requires two simultaneous `RunHandle`
-instances and a side-by-side transcript view. AppStore currently enforces one active run at a
-time (AppStore.swift line 108: `prior.stop()`).
+`ChatScreen` does not instantiate `FaderToggle`; its warm/send `GenConfig` construction sites pass
+a nil adapter path, and each send dispatches exactly one backend run. Running base and adapter in
+parallel still requires two independently tracked runs and a side-by-side transcript view.
 
 ### G2 — quantize bins have no `--json` (STRUCTURAL, HIGH)
 
@@ -347,11 +364,11 @@ parser silently degrades to `.status` passthrough.
 adapter file size and name only. Users cannot distinguish a rank-4 from a rank-64 adapter in
 the UI without inspecting the file manually.
 
-### G4 — Multi-turn conversation not supported (MISSING, MEDIUM)
+### G4 — Conversation history is prompt-replayed, not KV-cached (LIMITATION, MEDIUM)
 
-Each chat generation is a fresh subprocess invocation with a single `--prompt` string. There is
-no mechanism to pass prior turns to `generate_lora`. The binary interface has no `--history`
-flag.
+`ChatScreen.renderChatML` serializes completed user/assistant turns into every new prompt. GPU chat
+keeps a `chat_metal --serve` model process resident, while CPU chat starts `generate_lora` once per
+turn. Neither path retains a cross-turn KV prefix cache, so prior context is re-prefilled.
 
 ### G5 — Token count is approximate (MEDIUM)
 
@@ -413,10 +430,9 @@ Files: `LatticeBridge.swift` (`discoverAdapters` function only).
 Lift the single-run constraint for the Chat surface. Add `handle2: RunHandle?` and
 `liveRun2: LiveRun?` to AppStore (or introduce a `ChatSession` model that holds two
 `(RunHandle, LiveRun)` pairs). ChatScreen renders an HSplitView with two transcript columns.
-The FaderToggle becomes a "run both" trigger. The "0 ms reload" hardcoded label in
-FaderToggle.swift line 137 becomes a real measurement from the time between the two
-`gen_token done` events. This requires the binary to support a stable `--json` streaming
-interface (already true for generate_lora).
+Wire the currently preview-only `FaderToggle` as a "run both" trigger and report a real timing
+measurement from the two `gen_token done` events. This requires the binary to support a stable
+`--json` streaming interface (already true for `generate_lora`).
 
 Files: `AppStore.swift`, `ChatScreen.swift`, `FaderToggle.swift`, `DomainModels.swift`.
 

--- a/apps/macos/scripts/package-app.sh
+++ b/apps/macos/scripts/package-app.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-# package-app.sh — Build and package LatticeStudio.app + .dmg + .zip
+# package-app.sh — Build and package Lattice.app + .dmg + .zip
 #
 # Usage:
 #   ./scripts/package-app.sh [--out <dir>] [--skip-build] [--skip-cargo]
 #
 # Options:
 #   --out <dir>       Output directory (default: apps/macos/dist/)
-#   --skip-build      Skip `swift build -c release` (use existing .build/release/LatticeStudio)
+#   --skip-build      Skip `swift build -c release` (use existing .build/release/Lattice)
 #   --skip-cargo      Skip cargo builds (use existing target/release/ binaries)
 #
 # Idempotent: re-running overwrites dist/ cleanly.
 #
 # Signing: ad-hoc codesign only (no Developer ID required).
-# Recipients must right-click → Open, or: xattr -dr com.apple.quarantine LatticeStudio.app
+# Recipients must right-click → Open, or: xattr -dr com.apple.quarantine Lattice.app
 # See DISTRIBUTION.md for the Developer ID upgrade path.
 
 set -euo pipefail


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Rename documented package outputs from `LatticeStudio.app`/`.dmg`/`.zip` to the `Lattice` artifacts produced by `package-app.sh`, and update the bundled payload from six to ten binaries.
- Replace README claims of live adapter hot-swap and parallel base-versus-adapter Chat with the shipped single-transcript flow.
- Refresh `INSTRUMENT_SCOPE.md` to describe prompt-replayed multi-turn history, persistent GPU `chat_metal --serve`, one-shot CPU `generate_lora`, and the still-missing production adapter/A/B controls.
- Record forced dark appearance as the current implementation status without changing the adaptive light/dark design decision.
- Distinguish the required `quantize_quarot --seed` flag from the macOS wrapper fallback of `0xC0FFEE`.

## Verification

- Verified bundle names and the ten-binary payload against the `APP_NAME`, validation/copy loops, and DMG/ZIP paths in `apps/macos/scripts/package-app.sh`.
- Verified Chat behavior against `ChatScreen.renderChatML`, nil adapter construction, single backend dispatch, `AppStore.runChatGPU`, and the persistent `--json --serve` session setup.
- Verified theme and QuaRot wording against `.preferredColorScheme(.dark)`, the binary required-seed guard, and the Swift wrapper fallback.
- Ran `./scripts/lint-docs.sh` and `git diff --check`; both passed. Per task instructions, no Cargo, Swift, GPU, benchmark, build, clippy, or test command was run.

Closes #756
Closes #757
Closes #765