### PR TITLE
docs(inference): reconcile ADR-001/004/010/035/049/062 + CONFIG.md + speculative comment with shipped code

### DIFF
--- a/crates/inference/CONFIG.md
+++ b/crates/inference/CONFIG.md
@@ -1,26 +1,28 @@
 # lattice-inference — CONFIG.md
 
-Complete configuration reference for the lattice-inference pure-Rust transformer inference engine.
+Configuration reference for the lattice-inference pure-Rust transformer inference engine.
 
 ---
 
 ## ModelInferenceConfig
 
-**Source**: `src/model/qwen.rs:244`
+**Source**: `src/model/qwen.rs` (`ModelInferenceConfig`)
 
 Per-model runtime configuration, loaded from `inference_config.json` in the model directory. Defaults preserve exact Qwen3-Embedding-0.6B behavior — a model with no `inference_config.json` works out of the box.
 
-**Loading** (`qwen.rs:276`): `ModelInferenceConfig::load(model_dir)` reads `{model_dir}/inference_config.json`. Missing file → defaults. Malformed JSON → warning logged, defaults used. Non-Qwen models that lack `config.json` will error earlier at `parse_qwen_config`, so this struct only matters for Qwen variants.
+**Loading**: `ModelInferenceConfig::load(model_dir)` reads `{model_dir}/inference_config.json`. Missing file → defaults. Malformed JSON → warning logged, defaults used. Non-Qwen models that lack `config.json` will error earlier at `parse_qwen_config`, so this struct only matters for Qwen variants.
 
 ### Fields
 
-| Field                    | Type    | Default  | Source of Default                                   |
-| ------------------------ | ------- | -------- | --------------------------------------------------- |
-| `eos_token_id`           | `u32`   | `151643` | `default_eos_token_id()` at `qwen.rs:255`           |
-| `rope_table_max_seq_len` | `usize` | `8192`   | `default_rope_table_max_seq_len()` at `qwen.rs:258` |
-| `gpu_max_seq_len`        | `usize` | `2048`   | `default_gpu_max_seq_len()` at `qwen.rs:261`        |
+| Field                    | Type     | Default                | Source of Default                                   |
+| ------------------------ | -------- | ---------------------- | --------------------------------------------------- |
+| `eos_token_id`           | `u32`    | `151643`               | `default_eos_token_id()` at `qwen.rs:283`           |
+| `rope_table_max_seq_len` | `usize`  | `8192`                 | `default_rope_table_max_seq_len()` at `qwen.rs:286` |
+| `gpu_max_seq_len`        | `usize`  | `2048`                 | `default_gpu_max_seq_len()` at `qwen.rs:289`        |
+| `base_model_rev`         | `String` | `"none"`, then derived | `default_cache_compat_rev()` at `qwen.rs:292`       |
+| `tokenizer_rev`          | `String` | `"none"`, then derived | `default_cache_compat_rev()` at `qwen.rs:292`       |
 
-**Default impl** at `qwen.rs:265` calls each `default_*` function.
+**Default impl** calls each `default_*` function.
 
 ### Field Details
 
@@ -46,7 +48,19 @@ Per-model runtime configuration, loaded from `inference_config.json` in the mode
 
 **Why `2048`**: Embedding inputs are typically <512 tokens; 2048 provides 4× headroom without excessive GPU memory usage. For the 4B model with wider hidden dimensions (2560 vs 1024), the per-token buffer cost is 2.5× higher — reduce to 1024 if GPU memory is tight. For generation workloads, increase up to `rope_table_max_seq_len`.
 
-**Where used**: Metal forward pass buffer allocation (`forward/metal.rs` `MetalForwardPass`), KV cache sizing (`kv_cache.rs` `FlatKVCacheConfig`).
+**Where used**: Metal forward pass buffer allocation (`forward/metal.rs` `MetalForwardPass`), KV cache sizing (`kv_cache/flat.rs` `FlatKVCacheConfig`).
+
+#### `base_model_rev` — default `"none"`, derived on load
+
+**What it does**: Identifies the model revision recorded in embedding-cache manifests. `cache_load()` rejects a cache whose revision differs, before loading any entries.
+
+**Precedence**: An explicit non-`"none"` value in `inference_config.json` wins. Otherwise `ModelInferenceConfig::load()` derives `sha256:<16 hex chars>` from `config.json` plus the weight-file names, lengths, and boundary samples. If `config.json` is missing or unreadable, the value remains `"none"`.
+
+#### `tokenizer_rev` — default `"none"`, derived on load
+
+**What it does**: Identifies the tokenizer revision recorded in embedding-cache manifests. `cache_load()` rejects a cache whose tokenizer revision differs.
+
+**Precedence**: An explicit non-`"none"` value wins. Otherwise `ModelInferenceConfig::load()` derives `sha256:<16 hex chars>` from the complete `tokenizer.json` contents. If that file is missing or unreadable, the value remains `"none"`.
 
 ### Example: `inference_config.json`
 
@@ -54,7 +68,9 @@ Per-model runtime configuration, loaded from `inference_config.json` in the mode
 {
   "eos_token_id": 151643,
   "rope_table_max_seq_len": 8192,
-  "gpu_max_seq_len": 2048
+  "gpu_max_seq_len": 2048,
+  "base_model_rev": "qwen3-embedding-0.6b-rev1",
+  "tokenizer_rev": "qwen3-tokenizer-rev1"
 }
 ```
 
@@ -64,16 +80,20 @@ Omit any field to use the default. An empty `{}` is valid and equivalent to all 
 
 ## GenerateConfig
 
-**Source**: `src/generate.rs:25`
+**Source**: `src/generate.rs` (`GenerateConfig`)
 
-Text generation configuration for decoder-only models.
+Legacy text generation configuration for decoder-only models. This `crate::generate::GenerateConfig` type is deprecated since 0.5.1 but remains functional during its compatibility window; the canonical Qwen3.5 configuration is `crate::model::GenerateConfig` in `src/model/qwen35_config.rs`.
 
-| Field            | Type             | Default   | Source                             | Why                                                                                           |
-| ---------------- | ---------------- | --------- | ---------------------------------- | --------------------------------------------------------------------------------------------- |
-| `max_new_tokens` | `usize`          | `256`     | `Default` impl at `generate.rs:37` | Practical limit for chat-style responses. Increase for long-form generation                   |
-| `sampling`       | `SamplingConfig` | see below | `SamplingConfig::default()`        | Balanced temperature+nucleus sampling                                                         |
-| `eos_token_id`   | `Option<u32>`    | `None`    | `Default` impl                     | When `None`, generation runs to `max_new_tokens`. Set to model's EOS to enable early stopping |
-| `include_prompt` | `bool`           | `false`   | `Default` impl                     | Whether output includes the original prompt text                                              |
+| Field               | Type                         | Default   | Source                              | Why                                                                                           |
+| ------------------- | ---------------------------- | --------- | ----------------------------------- | --------------------------------------------------------------------------------------------- |
+| `max_new_tokens`    | `usize`                      | `256`     | `Default` impl at `generate.rs:126` | Practical limit for chat-style responses. Increase for long-form generation                   |
+| `sampling`          | `SamplingConfig`             | see below | `SamplingConfig::default()`         | Balanced temperature+nucleus sampling                                                         |
+| `eos_token_id`      | `Option<u32>`                | `None`    | `Default` impl                      | When `None`, generation runs to `max_new_tokens`. Set to model's EOS to enable early stopping |
+| `include_prompt`    | `bool`                       | `false`   | `Default` impl                      | Whether output includes the original prompt text                                              |
+| `grammar`           | `Option<Arc<GrammarEngine>>` | `None`    | `Default` impl                      | Masks logits and advances grammar state at every generated token                              |
+| `kv_cache_capacity` | `Option<usize>`              | `None`    | `Default` impl                      | Optional per-request cap on KV allocation and effective generation length                     |
+
+When `grammar` masks every token, generation fails closed with `InferenceError::InvalidInput`; a token rejected while advancing the grammar stops with `StopReason::Grammar`. `kv_cache_capacity` is clamped to `[1, prompt_len + max_new_tokens]`; a cap smaller than the prompt is rejected, and generation stops with `StopReason::KvFull` when the cache reaches the effective cap.
 
 ---
 
@@ -96,44 +116,43 @@ Token sampling parameters for text generation.
 
 ## Metal GPU Shape Constraints
 
-**Source**: `src/forward/metal.rs:1014-1043`
+**Source**: `src/forward/metal.rs` (`validate_fused_kernel_shape`, `msl_source_for`)
 
-The Metal fused attention shader has **compile-time MSL constants** that cannot be changed at runtime. A Rust-side guard (`validate_fused_kernel_shape` at `metal.rs:1017`) validates the model config before any GPU buffer allocation.
+The Metal fused attention shader uses **model-specific compile-time MSL constants**. `MetalForwardPass::new` validates structural requirements, then `msl_source_for` injects the model's head dimension and GQA group count before compiling the shader library.
 
 ### Constants
 
-| MSL Constant       | Rust Constant            | Value | Purpose                                                                                   |
-| ------------------ | ------------------------ | ----- | ----------------------------------------------------------------------------------------- |
-| `FA_HEAD_DIM`      | `METAL_FUSED_HEAD_DIM`   | `128` | Fused attention tile dimension. Model requires `hidden_size / num_attention_heads == 128` |
-| `FA_GQA_GROUPS`    | `METAL_FUSED_GQA_GROUPS` | `2`   | GQA group count. Model requires `num_attention_heads / num_key_value_heads == 2`          |
-| `FUSED_C_HEAD_DIM` | (same as above)          | `128` | Used in fused QK-norm + RoPE kernel at `metal.rs:886`                                     |
-| `FUSED_C_HALF_DIM` | (derived)                | `64`  | `HEAD_DIM / 2` for RoPE frequency pairs                                                   |
+| MSL Constant       | Injected value                              | Purpose                               |
+| ------------------ | ------------------------------------------- | ------------------------------------- |
+| `FA_HEAD_DIM`      | `config.head_dim`                           | Fused attention dimension             |
+| `FA_GQA_GROUPS`    | `num_attention_heads / num_key_value_heads` | Query heads served by each KV head    |
+| `FUSED_C_HEAD_DIM` | `config.head_dim`                           | Fused QK-norm + RoPE dimension        |
+| `FUSED_C_HALF_DIM` | `config.head_dim / 2`                       | RoPE frequency-pair count             |
+| `FUSED_C_THREADS`  | `config.head_dim / 2`                       | Fused QK-norm + RoPE threadgroup size |
 
 ### Validation Logic
 
 ```
 validate_fused_kernel_shape(config: &QwenConfig):
-  1. config.head_dim != 128            → Err("head_dim mismatch")
-  2. config.num_key_value_heads == 0    → Err("zero kv_heads")
-  3. num_heads % num_kv_heads != 0      → Err("not divisible")
-  4. num_heads / num_kv_heads != 2      → Err("GQA groups mismatch")
-  All pass                              → Ok(())
+  1. config.head_dim == 0                → Err("nonzero head_dim required")
+  2. config.head_dim % 4 != 0            → Err("head_dim must be divisible by 4")
+  3. config.num_key_value_heads == 0     → Err("nonzero kv_heads required")
+  4. num_heads % num_kv_heads != 0       → Err("not divisible")
+  All pass                               → Ok(num_heads / num_kv_heads)
 ```
 
-**On mismatch**: `QwenModel` sets `self.metal = None`. All forward passes silently fall back to the **CPU NEON path** (`forward/neon_forward.rs`). No error is raised — the model still works, just slower.
+**On mismatch**: `QwenModel` leaves `self.metal` unset. Forward passes use the CPU path instead; no initialization error is raised to the caller.
 
 ### Model Compatibility Matrix
 
-| Model                 | hidden | heads | kv_heads | head_dim | GQA   | Metal GPU? | Why               |
-| --------------------- | ------ | ----- | -------- | -------- | ----- | ---------- | ----------------- |
-| Qwen3-Embedding-0.6B  | 1024   | 16    | 8        | **64**   | 2     | **NO**     | head_dim=64 ≠ 128 |
-| Qwen3-Embedding-4B    | 2560   | 32    | 16       | **80**   | 2     | **NO**     | head_dim=80 ≠ 128 |
-| Qwen3-8B (generation) | 4096   | 32    | 8        | 128      | **4** | **NO**     | gqa=4 ≠ 2         |
-| Qwen3.5-14B           | 5120   | 40    | 8        | 128      | **5** | **NO**     | gqa=5 ≠ 2         |
+| Model                | hidden | heads | kv_heads | head_dim | GQA | Structural gate |
+| -------------------- | ------ | ----- | -------- | -------- | --- | --------------- |
+| Qwen3-Embedding-0.6B | 1024   | 16    | 8        | 64       | 2   | Pass            |
+| Qwen3-Embedding-4B   | 2560   | 32    | 16       | 80       | 2   | Pass            |
 
-**Currently no Qwen3-Embedding model passes the Metal gate.** The GPU kernels were optimized for a Qwen3.5 generation configuration (head_dim=128, GQA=2) that no shipping model matches. All embedding models run on CPU/NEON.
+Both Qwen3 embedding shapes pass the structural gate. Actual GPU activation also requires a Metal device, successful shader compilation, and `LATTICE_NO_GPU` to be unset. Initialization failure leaves `QwenModel::metal` unset and falls back to CPU; a per-call Metal failure also logs a warning and retries that forward pass on CPU.
 
-**To add Metal support for other head_dim values**: Rewrite the MSL shader with parameterized tile dimensions. This is a shader rewrite, not a config change.
+Qwen3.5 generation uses the separate `forward/metal_qwen35.rs` engine and is not governed by this embedding-path validator.
 
 ---
 
@@ -181,7 +200,8 @@ validate_fused_kernel_shape(config: &QwenConfig):
    - `rope_table_max_seq_len`: from `config.json` → `max_position_embeddings`
    - `gpu_max_seq_len`: based on expected workload and GPU memory budget
 
-3. **Check Metal compatibility**: compute `head_dim = hidden_size / num_attention_heads`.
-   If `head_dim != 128` or `gqa_groups != 2` → model runs CPU-only (automatic, no error).
+3. **Check Metal compatibility**: require nonzero `head_dim` divisible by 4, nonzero
+   `num_key_value_heads`, and `num_attention_heads` divisible by `num_key_value_heads`.
+   The resulting head dimension and GQA group count are injected into the MSL source.
 
 4. **Test**: `cargo test -p lattice-inference`, manual embedding generation.

--- a/crates/inference/src/error.rs
+++ b/crates/inference/src/error.rs
@@ -1,8 +1,9 @@
 //! Inference error type, display/error implementations, and I/O error conversion.
 use std::fmt::{Display, Formatter};
 
-/// **Stable**: primary error type consumed by `lattice-embed`; adding new variants
-/// is backward-compatible, but removing or renaming them requires a SemVer bump.
+/// **Stable**: primary error type consumed by `lattice-embed`; because downstream
+/// code can match it exhaustively, adding, removing, or renaming variants is
+/// SemVer-breaking.
 #[derive(Debug)]
 pub enum InferenceError {
     ModelNotFound(String),

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -868,7 +868,7 @@ impl<'a> MtpVerifier<'a> {
             );
         }
 
-        // Partial RoPE (interleaved pairing, first rope_dim dims of each head)
+        // Partial RoPE (stride-half pairing; see mtp_apply_partial_rope)
         for h in 0..num_q_heads {
             let start = h * head_dim;
             mtp_apply_partial_rope(

--- a/docs/adr/ADR-001-pure-rust-transformer-engine.md
+++ b/docs/adr/ADR-001-pure-rust-transformer-engine.md
@@ -22,7 +22,7 @@ The engine implements the full transformer forward pass:
 
 ### Hardware acceleration
 
-- **Metal GPU** (Apple Silicon) — fused attention kernel, head_dim=128, GQA groups=2
+- **Metal GPU** (Apple Silicon) — fused attention kernels compiled with model-specific head dimension and GQA group count; requires a nonzero head dimension divisible by 4 and query-head count divisible by a nonzero KV-head count
 - **NEON** (aarch64 CPU) — fallback when Metal shape constraints don't match
 - **AVX2** (x86_64) — 8-wide f32 SIMD
 - **Scalar** — universal fallback

--- a/docs/adr/ADR-004-kv-cache.md
+++ b/docs/adr/ADR-004-kv-cache.md
@@ -99,7 +99,7 @@ Provide **two complementary KV cache implementations**: `FlatKVCache` for single
    bounds check now produces an `Err` instead of panicking. The allocation-free
    property is preserved.] For embedding workloads where `forward()` is called
    thousands of times per second, this eliminates GC pressure entirely.
-2. **Contiguous layout per layer**: Each layer's K tensor is a single `Vec<f32>` of size `max_seq_len * kv_dim`. The layout `[max_seq_len, kv_dim]` means that reading a full key sequence for attention is a single contiguous memory region — cache-friendly for the GEMM in attention scoring.
+2. **Contiguous layout per layer**: Each layer's K tensor is a single `Vec<f16>` of size `max_seq_len * kv_dim`. The layout `[max_seq_len, kv_dim]` means that reading a full key sequence for attention is a single contiguous memory region; reads dequantize into caller-provided f32 scratch for attention scoring.
 3. **`reset_fast()` vs `reset()`**: The fast reset sets only `seq_len = 0` without zeroing. The caller is responsible for not reading stale data. This is correct because every position up to `seq_len` is written before being read. Saves ~7 ms for a 4096-token cache on M3.
 4. **256-token page granularity in PagedKVCache**: Balances internal fragmentation (larger pages = more waste for short sequences) against management overhead (smaller pages = more entries in the page table and LRU structure). 256 tokens at 128 head_dim × 8 heads × 2 sides × 4 bytes = 2 MB per page — fits one huge page on Linux.
 5. **LRU eviction in PagedKVCache**: Sequences that haven't been accessed recently are evicted. This is correct for multi-user embedding servers where active queries are always in progress and idle sequences can be re-encoded on next request.

--- a/docs/adr/ADR-010-attention-mechanisms.md
+++ b/docs/adr/ADR-010-attention-mechanisms.md
@@ -3,7 +3,9 @@
 **Status**: Accepted (attention taxonomy superseded by ADR-059)\
 **Date**: 2026-05-13\
 **Crate**: `lattice-inference`\
-**Amendment (2026-05-27)**: ADR-059 expands the attention taxonomy from 4 variants (MHA, GQA, Flash, GDN) to 10 modules with a composable `AttentionKind` enum and `AttentionOp` trait. This ADR remains the authoritative reference for the primitive-level API contracts of MHA (`AttentionBuffers`), GQA (`GqaScratch`), Flash (tiled), and GDN (recurrent state). For dispatch/composition and the full taxonomy, see ADR-059.
+**Amendment (2026-05-27; implementation status updated 2026-07-14)**: ADR-059 proposes expanding the attention taxonomy from 4 variants (MHA, GQA, Flash, GDN) to 10 modules. The metadata-only `AttentionKind` enum has landed, but it does not implement an `AttentionOp` trait, allocate state, or dispatch kernels; that execution layer remains proposed P2+ work in ADR-059. This ADR remains the authoritative reference for the primitive-level API contracts of MHA (`AttentionBuffers`), GQA (`GqaScratch`), Flash (tiled), and GDN (recurrent state). For the proposed dispatch/composition architecture and the full taxonomy, see ADR-059.
+
+**Implementation correction (2026-07-14)**: The shipped standard-MHA path masks padding keys with `f32::NEG_INFINITY`, not a finite sentinel. `softmax_attention` zeros an all-masked row through its non-finite row-maximum guard. The old `-10,000.0` sentinel allowed a masked key to become the row maximum when every valid score was lower, leaking masked values into the output (#361). The original finite-sentinel decision is preserved below as historical rationale; it does not describe current behavior.
 
 ---
 
@@ -17,7 +19,7 @@ The crate supports three distinct attention algorithms, each suited to different
 - Bidirectional: no causal mask.
 - Equal Q, K, V head counts.
 - Pre-allocated `AttentionBuffers` (q/k/v/scores/context/concat/ffn_intermediate + per-head reshape buffers).
-- Padding positions masked with `-10,000.0` (not `-inf` to avoid NaN propagation).
+- Original decision: padding positions masked with `-10,000.0`; the implementation correction above documents the shipped `-inf` mask and all-masked-row guard.
 - Matmul convention: `matmul_bt` (computes A @ B^T; B is stored row-major, transposed logically).
 
 **Grouped Query Attention (GQA)** — `src/attention/gqa.rs`:
@@ -63,7 +65,7 @@ Implement **four attention variants** (MHA, GQA, CPU flash/tiled, GatedDeltaNet)
 ## Key Design Choices
 
 1. **Separate modules, not a single configurable attention function**: Each variant has distinct internal state (scratch buffers, stride patterns, normalization style). A unified function with a `mode: AttentionMode` parameter would share nothing meaningful between paths while obscuring which path is taken. Separate modules make each path independently testable and optimizable.
-2. **`-10,000.0` padding mask, not `-inf`**: Negative infinity can produce NaN in softmax when a row is fully masked (exp(-inf) = 0, sum = 0, 0/0 = NaN). A large negative value (-10,000.0) produces exp(-10,000) ≈ 0 without the NaN risk. This follows the HuggingFace BERT implementation convention.
+2. **Original finite-sentinel decision (not shipped)**: Negative infinity can produce NaN in softmax when a row is fully masked (exp(-inf) = 0, sum = 0, 0/0 = NaN). A large negative value (-10,000.0) produces exp(-10,000) ≈ 0 without the NaN risk. This follows the HuggingFace BERT implementation convention. The shipped path instead uses structural `-inf` masking plus an explicit all-masked-row guard, as recorded in the implementation correction above.
 3. **Zero-out causal mask in GQA (not additive before softmax)**: Standard causal masking adds a large negative value before softmax. The GQA path instead zeros the future-position probabilities after softmax scale but before normalization. This is equivalent for valid sequences but avoids the numerical risk of additive -inf.
 4. **`sgemm_bt_strided` on macOS**: Accelerate's BLAS handles strided K access without a copy. K is stored in the KV cache as `[seq_len, kv_dim]`; each KV head's slice is a stride away. On non-macOS, the GQA path copies K to a contiguous buffer before calling the generic BLAS. This is an OS-specific optimization, not a correctness difference.
 5. **48 KB L1 budget constant for flash tiling**: A conservative estimate (48 KB = 75% of the minimum 64 KB L1d on Apple Silicon). The constant is documented with its derivation in the source. Choosing too large a budget causes cache thrashing that nullifies the tiling benefit.
@@ -109,7 +111,7 @@ Implement **four attention variants** (MHA, GQA, CPU flash/tiled, GatedDeltaNet)
 
 ## References
 
-- `src/attention/standard.rs` — `multi_head_attention_in_place()`, `AttentionBuffers`, `-10,000.0` mask
+- `src/attention/standard.rs` — `multi_head_attention_in_place()`, `AttentionBuffers`, structural `f32::NEG_INFINITY` mask
 - `src/attention/gqa.rs` — `apply_gqa_attention()`, `GqaConfig`, `GqaScratch`, `apply_scaled_causal_softmax_fused()`
 - `src/attention/flash.rs` — `TiledAttentionConfig`, `TiledAttentionBuffers`, `optimal_tile_sizes()`, `TILED_SEQ_THRESHOLD`
 - `src/attention/gdn.rs` — `gated_delta_net_step()`, `GatedDeltaNetState`, `GatedDeltaNetScratch`

--- a/docs/adr/ADR-035-sinkhorn-solver.md
+++ b/docs/adr/ADR-035-sinkhorn-solver.md
@@ -14,7 +14,7 @@ embedding drift diagnostics.
 
 Entropic regularization (Cuturi 2013) reduces this to O(n²) iterations via the
 Sinkhorn-Knopp algorithm, at the cost of biased distances that must be corrected via
-Sinkhorn divergence (see ADR-005).
+Sinkhorn divergence (see ADR-039).
 
 ## Decision
 

--- a/docs/adr/ADR-048-continuous-batching.md
+++ b/docs/adr/ADR-048-continuous-batching.md
@@ -5,6 +5,7 @@
 **Crate**: `lattice-inference`
 **Depends on**: ADR-004 (KV Cache), ADR-008 (LoRA Injection), ADR-047 (Paged KV Cache)
 **Amendment (2026-05-27)**: ADR-063 supersedes the "Tokio task owning a dedicated Metal command buffer encoder" Phase 2 wording. GPU work runs on a dedicated OS thread (`std::thread`), not on the tokio runtime, to avoid starving HTTP handlers during 10-100ms GPU steps. The Phase 1 `FifoScheduler`, chunked prefill, and single-resource GPU scheduling remain unchanged and are consumed by ADR-063.
+**Implementation correction (2026-07-14)**: The shipped Phase 1 `InferenceRequest` does not carry a caller-assigned `SeqId` or response channel. `BatchWorker::submit` assigns and returns `Option<SeqId>`, rejecting empty or over-length requests, and `BatchWorker::step` returns the iteration's buffered `Vec<InferenceToken>` events. The original request-lifecycle decision remains otherwise unchanged.
 
 ---
 
@@ -131,17 +132,18 @@ pub struct SeqId(u64);
 
 /// Submitted by the caller; scheduler takes ownership.
 pub struct InferenceRequest {
-    pub id: SeqId,
     pub prompt_ids: Vec<u32>,
     pub sampling: SamplingConfig,
     /// None = base model. Some = adapter key for LoraHook dispatch.
     pub lora_adapter: Option<AdapterKey>,
     /// Maximum tokens to generate (hard cap enforced by scheduler).
     pub max_new_tokens: usize,
-    pub response_tx: tokio::sync::mpsc::Sender<InferenceToken>,
 }
 
-/// Streamed back to caller one token at a time.
+// The worker assigns identity at admission; None means the request was rejected.
+let seq_id: Option<SeqId> = worker.submit(request);
+
+/// Returned from BatchWorker::step for this iteration.
 pub struct InferenceToken {
     pub seq_id: SeqId,
     pub token_id: u32,

--- a/docs/adr/ADR-049-vision-encoder.md
+++ b/docs/adr/ADR-049-vision-encoder.md
@@ -4,6 +4,10 @@
 **Date**: 2026-05-19
 **Crate**: lattice-inference
 
+## Implementation status (2026-07-14)
+
+The shipped `vision` scaffold does not implement the Metal ViT path specified by the original v0 decision below. `vision::vit::ViT::forward` is a CPU reference implementation, and the `vision` module identifies a Metal ViT forward pass as future work. ADR-069 separately proposes an all-Metal vision path, but it remains Proposed. The accepted decision is preserved below as the historical design; this note records the current implementation gap without revising that decision.
+
 ## Context
 
 Lattice currently processes only text: `BpeTokenizer` converts strings to token IDs, and

--- a/docs/adr/ADR-062-metal-fa2-prefill.md
+++ b/docs/adr/ADR-062-metal-fa2-prefill.md
@@ -11,10 +11,12 @@ The prefill bottleneck described in §Context was solved by a different mechanis
 Metal shader proposed here. The shipped solution is chunked batched prefill:
 `forward_prefill_batched_chunk` at `crates/inference/src/forward/metal_qwen35.rs:7878` (PR #228,
 1.78× TTFT improvement). Tiled Q4 GEMM landing on Apple7+ (PRs #265/#270/#283) further reduced
-prefill time. The full Metal FA2 kernel (new shader extraction into `crates/lattice-metal/`) and
-KV-cache quantization chain described in this ADR were not built; `prefix.rs:60` still stores
-`Arc<[f32]>` pages. The ADR remains as the historical design proposal; its KV-quant chain is an
-open future direction.
+prefill time. The full Metal FA2 kernel (new shader extraction into `crates/lattice-metal/`) and the
+int8/int4 KV-cache quantization chain described in this ADR were not built. F16 storage has partially
+shipped: `FlatKVCache` always stores f16, while the Qwen3.5 `MetalKvCache` has an opt-in f16 path
+selected by `LATTICE_KV_F16`. `PagedKVCache` and `PrefixPageCache` still store f32. The ADR remains
+as the historical design proposal; paged/prefix f16 storage and the int8/int4 chain are open future
+work.
 
 ---
 
@@ -52,9 +54,9 @@ Apple GPU Families 7-10 (M1-M4) share a binding constraint: **32 KiB threadgroup
 
 This constrains tile sizes. At f16, `BQ=32 BK=32 D=128` uses approximately 18.5 KiB -- safe. At f32, the same tile needs ~34.5 KiB -- exceeds the limit. Runtime selection via `supportsFamily` and `MTLComputePipelineState.maxTotalThreadsPerThreadgroup` is mandatory.
 
-### Existing KV cache: f32-only
+### Existing KV caches: mixed f16 and f32 storage
 
-Both `FlatKVCache` (flat.rs, 543 lines) and `PagedKVCache` (paged.rs, 1150 lines) store K and V as `Vec<f32>`. The Metal kernel reads f32 from KV buffers at full 32-bit bandwidth. Halving this to f16 is the single cheapest bandwidth win available, and is a prerequisite for the int8/int4 quantization chain.
+`FlatKVCache` stores K and V as `Vec<Vec<f16>>`, converting f32 inputs on write and dequantizing into caller-provided f32 buffers on read. `PagedKVCache` still stores its page pool as `Vec<f32>`. The Qwen3.5 Metal path defaults to f32 KV buffers but supports opt-in f16 buffers when `LATTICE_KV_F16=1` or `true`. Flat-cache f16 and opt-in Metal f16 are therefore shipped; the remaining storage work is paged/prefix f16 plus the proposed int8/int4 chain.
 
 `PrefixPageCache` (prefix.rs, 439 lines) is built and wired into `PagedKVCache` via `restore_prefix` / `promote_to_prefix`, but operates on `Arc<[f32]>` shared pages. The prefix cache design is format-agnostic -- it copies between page layouts at different page sizes -- but currently assumes f32 throughout.
 


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

This reconciles documentation and two in-code comments with the behavior shipped on current `main`:

- corrects the MTP call-site comment to stride-half RoPE pairing;
- records the shipped `-inf` standard-attention mask and all-masked-row guard while preserving ADR-010's original finite-sentinel decision as historical rationale;
- marks ADR-059 execution composition as proposed: only metadata-only `AttentionKind` has landed;
- records that ADR-049's accepted Metal ViT decision is not shipped and the current vision scaffold uses the CPU reference path, without revising the decision;
- corrects FlatKVCache f16 storage, PagedKVCache/PrefixPageCache f32 storage, and the opt-in Qwen3.5 Metal f16 path in ADR-004/062;
- fixes ADR-035's Sinkhorn-divergence cross-reference;
- replaces stale fixed Metal shape gates with the structural validator and model-specific MSL substitution in ADR-001 and CONFIG.md;
- documents the omitted cache-identity, grammar, and KV-capacity controls;
- corrects the SemVer warning on the exhaustively matchable `InferenceError` enum and updates ADR-048's request/worker ownership example.

The ADR index finding in #764 was already resolved on current `main` by commit `307d62cef9`, so this PR intentionally leaves `docs/adr/INDEX.md` unchanged.

## Verification

I read each cited implementation before editing, including `mtp_apply_partial_rope`, standard attention masking plus the fail-closed softmax helper and regression test, the CPU ViT module, flat/paged/prefix and Metal KV storage, the Metal structural validator and MSL substitution, configuration defaults and failure paths, and `BatchWorker::submit`/`step`.

`cargo fmt --all -- --check`, targeted `deno fmt --check`, and `git diff --check` pass for the changed content. ADR-049 retains a pre-existing unformatted table outside this diff rather than adding an unrelated formatting rewrite. Per the issue-leg instructions, no build, test, clippy, GPU, or benchmark command was run.

Closes #754
Closes #755
Closes #761
Closes #764
Closes #769
