### PR TITLE
docs(tune): mark placeholder examples + amend ADR-027/029 to implemented contracts

### DIFF
--- a/crates/tune/README.md
+++ b/crates/tune/README.md
@@ -9,6 +9,16 @@ Knowledge distillation and training infrastructure for lattice neural models.
 - **Model Registry**: Semver versioning with lineage tracking
 - **Endpoint Security**: TLS enforcement, domain whitelisting, checksum verification
 
+## Current Implementation Status
+
+`DistillationPipeline` and the CPU `TrainingLoop` currently provide orchestration
+placeholders, not end-to-end training. `DistillationPipeline::label_single` does
+not contact a teacher API; it returns a simulated label distribution and
+confidence. `TrainingLoop::train` drives batching, callbacks, metrics, early
+stopping, and in-memory checkpoints, but its loss and accuracy are simulated and
+it does not update model weights. Do not treat either result as evidence of live
+teacher labeling or trained parameters.
+
 ## Pipeline Overview
 
 ```text
@@ -152,10 +162,12 @@ let mut dataset = Dataset::from_examples(examples);
 // Configure batching
 let config = DatasetConfig::with_batch_size(32)
     .shuffle(true)
-    .seed(42)
-    .validation_split(0.2);
+    .seed(42);
 
 dataset.set_config(config)?;
+
+// Split explicitly: 80% training, 20% validation
+let (train, validation) = dataset.split(0.8)?;
 
 let stats = dataset.stats();
 println!("Examples: {}", stats.num_examples);
@@ -165,15 +177,17 @@ println!("Embedding dim: {}", stats.embedding_dim);
 ### Validation Split
 
 ```rust
-use lattice_tune::data::{Dataset, DatasetConfig};
+use lattice_tune::data::Dataset;
 
-let config = DatasetConfig::with_batch_size(32)
-    .validation_split(0.2);  // 20% for validation
-
-// Dataset automatically handles train/validation split
+let dataset = Dataset::from_examples(examples);
+let (train, validation) = dataset.split(0.8)?; // 20% for validation
 ```
 
 ## Distillation Pipeline
+
+This example exercises the current simulated response path. It validates the
+teacher configuration and formats the prompt, but it makes no HTTP request and
+does not read an API key.
 
 ```rust
 use lattice_tune::distill::{TeacherConfig, DistillationPipeline, RawExample};
@@ -190,9 +204,9 @@ let raw = RawExample::new(
     "What's the weather like?",
 );
 
-// Label with teacher
+// Produce the placeholder's simulated labels
 let result = pipeline.label_single(&raw)?;
-println!("Labeled with confidence: {}", result.confidence);
+println!("Simulated confidence: {}", result.confidence);
 
 // Check statistics
 let stats = pipeline.stats();
@@ -230,6 +244,9 @@ config.validate()?;
 
 ### Training Loop
 
+The CPU loop below reports simulated metrics and does not forward through or
+update a neural network.
+
 ```rust
 use lattice_tune::train::{TrainingConfig, TrainingLoop};
 use lattice_tune::data::Dataset;
@@ -238,22 +255,21 @@ let config = TrainingConfig::quick();  // Fast training preset
 let mut trainer = TrainingLoop::new(config)?;
 
 let metrics = trainer.train(&mut dataset)?;
-println!("Final loss: {:.4}", metrics.final_train_loss);
+println!("Simulated final loss: {:.4}", metrics.final_train_loss);
 println!("Epochs completed: {}", metrics.epochs_completed);
 ```
 
 ### Checkpointing
 
+`Checkpoint` is an in-memory record. The training loop sends periodic records to
+`TrainingCallback::on_checkpoint`; it does not write `checkpoint_dir`, and
+`Checkpoint` has no file `save`, `load`, or `into_network` methods. Callers own
+any serialization and persistence. Resuming restores only loop epoch, global
+step, and metrics—not model weights or optimizer state.
+
 ```rust
-use lattice_tune::train::Checkpoint;
-
-// Save checkpoint
-let checkpoint = Checkpoint::new(&network, &training_state);
-checkpoint.save("checkpoints/epoch_50.ckpt")?;
-
-// Load checkpoint
-let loaded = Checkpoint::load("checkpoints/epoch_50.ckpt")?;
-let network = loaded.into_network();
+let checkpoint = trainer.checkpoint();
+trainer.resume_from(&checkpoint);
 ```
 
 ## Model Registry
@@ -264,7 +280,7 @@ let network = loaded.into_network();
 use lattice_tune::registry::{ModelRegistry, RegisteredModel, ModelMetadata};
 
 // Create in-memory registry
-let mut registry = ModelRegistry::in_memory();
+let registry = ModelRegistry::in_memory();
 
 // Create model with metadata
 let metadata = ModelMetadata::classifier(768, 6, 10000)
@@ -279,11 +295,16 @@ let weights = vec![0u8; 1000];
 let id = registry.register(model, &weights)?;
 
 // Retrieve the model
-let loaded = registry.get("intent_classifier", "1.0.0")?;
-println!("Loaded: {}", loaded.full_name());
+if let Some(loaded) = registry.get("intent_classifier", "1.0.0") {
+    println!("Loaded: {}", loaded.full_name());
+}
 ```
 
 ### Model Status Lifecycle
+
+This is the conventional lifecycle, not an enforced transition graph.
+`update_status` can assign any status, and `promote_to_production` does not
+require a validated or staged target. Callers must enforce deployment gates.
 
 ```text
 Pending -> Validated -> Staged -> Production
@@ -317,36 +338,40 @@ let metadata = ModelMetadata::classifier(768, 6, 15000);
 
 let finetuned = RegisteredModel::new("intent_classifier", "1.1.0")
     .with_metadata(metadata)
-    .with_parent(base_id);  // Track lineage
+    .with_parent(base_id);  // Store the caller-supplied parent reference
 ```
+
+Registration does not validate `parent_id` or append the fine-tuned model's ID
+to the parent's `children` field. Applications that need reverse lineage must
+maintain both sides themselves.
 
 ## Feature Flags
 
-| Feature          | Default | Description                                                  |
-| ---------------- | ------- | ------------------------------------------------------------ |
-| `std`            | Yes     | Standard library support                                     |
-| `serde`          | No      | Serialization (propagates to lattice-fann)                   |
+| Feature          | Default | Description                                                             |
+| ---------------- | ------- | ----------------------------------------------------------------------- |
+| `std`            | Yes     | Standard library support                                                |
+| `serde`          | No      | Serialization (propagates to lattice-fann)                              |
 | `gpu`            | No      | GPU-accelerated forward/backward passes and validation[^gpu-limitation] |
-| `gpu-tests`      | No      | GPU tests requiring hardware                                 |
-| `safetensors`    | No      | Safe checkpoint serialization                                |
-| `inference-hook` | No      | `impl LoraHook for LoraAdapter` (pulls in `lattice-inference`) |
-| `train-backward` | No      | Backward/gradient training surface (pulls in `lattice-inference`) |
+| `gpu-tests`      | No      | GPU tests requiring hardware                                            |
+| `safetensors`    | No      | PEFT-compatible LoRA adapter serialization                              |
+| `inference-hook` | No      | `impl LoraHook for LoraAdapter` (pulls in `lattice-inference`)          |
+| `train-backward` | No      | Backward/gradient training surface (pulls in `lattice-inference`)       |
 
 [^gpu-limitation]: **Current limitation**: `GpuTrainer::train_batch` returns
-`Err` for every optimizer choice (Adam, AdamW, SGD-momentum, plain SGD,
-RMSprop) — the GPU-shader optimizer dispatch has no buffer bindings wired to
-the network's weight/gradient buffers, and the CPU-side plain-SGD arm has
-neither real gradient plumbing nor a mutable weight write-back path. Forward
-pass and loss computation work correctly; only the weight-update step is
-unimplemented. See [issue #797](https://github.com/ohdearquant/lattice/issues/797).
-This note will be removed once that wiring lands.
+    `Err` for every optimizer choice (Adam, AdamW, SGD-momentum, plain SGD,
+    RMSprop) — the GPU-shader optimizer dispatch has no buffer bindings wired to
+    the network's weight/gradient buffers, and the CPU-side plain-SGD arm has
+    neither real gradient plumbing nor a mutable weight write-back path. Forward
+    pass and loss computation work correctly; only the weight-update step is
+    unimplemented. See [issue #797](https://github.com/ohdearquant/lattice/issues/797).
+    This note will be removed once that wiring lands.
 
 ```toml
 [dependencies]
 lattice-tune = { version = "0.4.2" }                           # Default
 lattice-tune = { version = "0.4.2", features = ["serde"] }     # With serialization
 lattice-tune = { version = "0.4.2", features = ["gpu"] }       # GPU training
-lattice-tune = { version = "0.4.2", features = ["safetensors"] } # Safe checkpoints
+lattice-tune = { version = "0.4.2", features = ["safetensors"] } # LoRA adapter I/O
 ```
 
 ### Injecting an adapter into `lattice-inference`
@@ -357,15 +382,16 @@ as a `Box<dyn LoraHook>`:
 
 ```toml
 [dependencies]
-lattice-tune = { version = "0.4.2", features = ["inference-hook"] }
+lattice-tune = { version = "0.4.2", features = ["inference-hook", "safetensors"] }
 lattice-inference = "0.4.2" # provides the LoraHook trait
 ```
 
 ```rust,ignore
+use std::path::Path;
 use lattice_tune::lora::LoraAdapter;
 use lattice_inference::lora_hook::LoraHook; // not re-exported at the crate root
 
-let adapter: LoraAdapter = /* LoraAdapter::load_peft_safetensors(...) */;
+let adapter = LoraAdapter::from_safetensors(Path::new("adapter.safetensors"))?;
 let hook: Box<dyn LoraHook> = Box::new(adapter);
 // the engine calls hook.apply(layer_idx, module, x, output) on each projection
 ```
@@ -388,8 +414,8 @@ lattice-tune = { version = "0.4.2" }
 impl DistillationPipeline {
     pub fn with_teacher(config: TeacherConfig) -> Result<Self>;
     pub fn label_single(&mut self, example: &RawExample) -> Result<LabelingResult>;
-    pub fn label_batch(&mut self, examples: &[RawExample]) -> Result<Vec<LabelingResult>>;
-    pub fn stats(&self) -> DistillationStats;
+    pub fn label_batch(&mut self, examples: &[RawExample]) -> Vec<LabelingResult>;
+    pub fn stats(&self) -> &DistillationStats;
 }
 ```
 
@@ -399,7 +425,8 @@ impl DistillationPipeline {
 impl TrainingLoop {
     pub fn new(config: TrainingConfig) -> Result<Self>;
     pub fn train(&mut self, dataset: &mut Dataset) -> Result<TrainingMetrics>;
-    pub fn train_epoch(&mut self, dataset: &mut Dataset) -> Result<EpochMetrics>;
+    pub fn checkpoint(&self) -> Checkpoint;
+    pub fn resume_from(&mut self, checkpoint: &Checkpoint);
 }
 ```
 
@@ -408,9 +435,9 @@ impl TrainingLoop {
 ```rust
 impl ModelRegistry {
     pub fn in_memory() -> Self;
-    pub fn register(&mut self, model: RegisteredModel, weights: &[u8]) -> Result<Uuid>;
-    pub fn get(&self, name: &str, version: &str) -> Result<RegisteredModel>;
-    pub fn promote(&mut self, id: Uuid, status: ModelStatus) -> Result<()>;
-    pub fn find_latest(&self, name: &str) -> Option<&RegisteredModel>;
+    pub fn register(&self, model: RegisteredModel, weights: &[u8]) -> Result<Uuid>;
+    pub fn get(&self, name: &str, version: &str) -> Option<RegisteredModel>;
+    pub fn promote_to_production(&self, id: &Uuid) -> Result<()>;
+    pub fn get_latest(&self, name: &str) -> Option<RegisteredModel>;
 }
 ```

--- a/docs/adr/ADR-027-finetuning-pipeline.md
+++ b/docs/adr/ADR-027-finetuning-pipeline.md
@@ -28,7 +28,27 @@ This is NOT a general-purpose ML training library. It handles the specific
 workflow: teacher generates → student learns → adapter saved → adapter loaded
 at inference time. The neural network primitives live in `lattice-fann`.
 
+### Current implementation status (amended 2026-07-14)
+
+The three capabilities above define the accepted subsystem boundaries; they do
+not imply that every stage is implemented end to end. In the shipped code:
+
+- `DistillationPipeline::label_single` is synchronous. It formats the prompt but
+  returns a simulated label distribution and confidence without issuing an HTTP
+  request or reading an API key.
+- The CPU `TrainingLoop` validates configuration, batches data, invokes
+  callbacks, records metrics, and emits in-memory checkpoint records. Its loss
+  and accuracy are simulated, and it neither forwards through nor updates a
+  `lattice-fann` network.
+
+The provider configurations and training-loop types therefore describe
+integration contracts for a future live teacher client and student-training
+backend. Their current outputs must not be treated as teacher-generated labels
+or trained model metrics.
+
 ## Consequences
 
-- `lattice-tune` depends on `lattice-fann` for the training loop.
-- Teacher API calls are async — this is the only crate with async.
+- `lattice-tune` depends on `lattice-fann`, although the placeholder CPU
+  `TrainingLoop` does not currently invoke a network.
+- A live teacher integration is expected to require asynchronous I/O. The
+  current distillation path is synchronous and contains no HTTP client.

--- a/docs/adr/ADR-029-model-registry.md
+++ b/docs/adr/ADR-029-model-registry.md
@@ -68,26 +68,41 @@ Pending --> Validated --> Staged --> Production
 **Lineage Tracking**: Fine-tuned models reference `parent_id` pointing to base model.
 Parent models accumulate `children` UUIDs for forward traceability.
 
+### Current implementation status (amended 2026-07-14)
+
+The lifecycle and bidirectional lineage above remain the accepted workflow, but
+the shipped registry stores descriptive records rather than enforcing that
+workflow:
+
+- `update_status` accepts any target status, and `promote_to_production` promotes
+  any existing record without requiring `Validated` or `Staged`. It demotes
+  production records with the same model name to `Staged`.
+- `register` and `register_metadata` validate only that name and version are
+  non-empty. They do not validate `parent_id`, append a child UUID to the parent,
+  or otherwise synchronize the two lineage fields. Callers must maintain both
+  sides, and a caller-supplied parent reference may be dangling.
+
 ## Consequences
 
 ### Positive
 
-- **Full Traceability**: Any production model can be traced to training config, dataset,
-  and parent lineage.
+- **Traceability Fields**: Production records can carry training config, dataset,
+  and caller-maintained parent lineage.
 - **Rollback Capability**: If v1.2.0 degrades, promote v1.1.0 from Archived to
   Production.
-- **Safe Promotion**: Status gates prevent deploying Pending models to production.
+- **Atomic Status Selection**: Promotion publishes one updated registry snapshot and
+  demotes existing Production records with the same name; callers enforce validation gates.
 - **Integrity Checking**: SHA-256 weights hash detects corruption before inference.
-- **Query by Version**: `find_latest(name)` returns highest semver for automated
-  deployments.
+- **Query by Version**: `get_latest(name)` orders versions by their parsed three-part
+  tuple, treating other version strings as `0.0.0`.
 
 ### Negative
 
 - **Storage Overhead**: Each version stores full weights (no delta compression).
 - **In-Memory Limitation**: Default `ModelRegistry::in_memory()` does not persist across
   restarts.
-- **Manual Lineage**: Parent-child relationships require explicit `with_parent()` calls;
-  not auto-detected.
+- **Manual Lineage**: Parent-child relationships are caller-maintained; registration
+  neither validates `parent_id` nor updates `children`.
 - **Orphan Risk**: Deleting a parent does not cascade to children, potentially leaving
   orphaned lineage references.
 
@@ -97,7 +112,8 @@ Parent models accumulate `children` UUIDs for forward traceability.
   (future work).
 - Document lineage workflow in examples to ensure developers set `parent_id` on
   fine-tuned models.
-- Validate `parent_id` exists before registration to prevent orphan references.
+- Callers should validate `parent_id` and maintain the corresponding `children` entry
+  before registration when reverse lineage is required.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## What drifted

The tune README presented simulated teacher labeling and CPU training metrics as operational results, documented checkpoint persistence methods that do not exist, and listed stale dataset, LoRA loading, training-loop, and registry APIs. ADR-027 did not distinguish its accepted subsystem boundaries from the placeholder teacher and CPU training implementations. ADR-029 described enforced status gates and automatically maintained reverse lineage even though the registry stores advisory status and caller-maintained lineage records.

## What changed

- Marked `DistillationPipeline::label_single` and the CPU `TrainingLoop` as simulated placeholders and corrected their examples.
- Replaced stale dataset splitting, checkpoint, LoRA loading, and API-reference examples with shipped signatures and behavior.
- Amended ADR-027 with the current synchronous simulated-label and simulated-metric contracts without changing the accepted decision.
- Amended ADR-029 with the shipped unenforced status lifecycle and caller-maintained lineage contracts without changing the accepted decision.

## Verification

Verified each claim directly against `distill/pipeline/distill.rs`, `train/loop/mod.rs`, `train/loop/checkpoint.rs`, `data/dataset.rs`, `lora/mod.rs`, `registry/model.rs`, and `registry/storage/registry.rs`. The `max_context_size` comment and crate-level LoRA loader documentation reported in #771 were already corrected on current `main` and were re-verified without further edits.

Documentation validation passed with `deno fmt --check`, `scripts/lint-docs.sh`, and `git diff --check`. No Cargo, test, Clippy, build, GPU, or benchmark command was run because this is a documentation-only change.

Closes #762
Closes #763
Closes #771