### PR TITLE
refactor(transport): rename bench module to reference_cases

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -52,7 +52,7 @@ pub mod transport_plan;
 pub mod unbalanced;
 
 #[cfg(test)]
-mod bench;
+mod reference_cases;
 #[cfg(test)]
 mod tests;
 

--- a/crates/transport/src/reference_cases.rs
+++ b/crates/transport/src/reference_cases.rs
@@ -17,7 +17,6 @@ pub struct ReferenceCase {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct ReferenceComparison {
     pub name: &'static str,
     pub expected_exact_cost: f32,

--- a/crates/transport/src/tests.rs
+++ b/crates/transport/src/tests.rs
@@ -257,14 +257,27 @@ fn reference_cases_pass() {
         convergence_threshold: 1e-7,
         ..SinkhornConfig::default()
     });
-    let comparisons = super::bench::compare_against_reference(&solver).unwrap();
+    let comparisons = super::reference_cases::compare_against_reference(&solver).unwrap();
 
     for comp in &comparisons {
+        assert!(
+            comp.result.converged,
+            "Reference case '{}' should converge",
+            comp.name,
+        );
         assert!(
             comp.absolute_error < 0.1,
             "Reference case '{}': absolute error {} is too large (expected ~{}, got {})",
             comp.name,
             comp.absolute_error,
+            comp.expected_exact_cost,
+            comp.sinkhorn_cost,
+        );
+        assert!(
+            comp.relative_error < 0.1,
+            "Reference case '{}': relative error {} is too large (expected ~{}, got {})",
+            comp.name,
+            comp.relative_error,
             comp.expected_exact_cost,
             comp.sinkhorn_cost,
         );


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Defect

The live test-only Sinkhorn reference helper was named `bench.rs`, which made it look like vestigial benchmark code, and `ReferenceComparison` carried a blanket `#[allow(dead_code)]` because two diagnostic fields were not read.

## Fix

- Renamed the test-only module to `reference_cases.rs` and updated its declaration and only caller.
- Removed the blanket dead-code allow.
- Extended the existing reference-case test to assert convergence and relative error, consuming both previously unread diagnostic fields without changing solver behavior or public API.

## Sibling paths checked

Searched all of `crates/transport` for `compare_against_reference`, `ReferenceComparison`, `mod bench`, and `bench::`. The existing `reference_cases_pass` unit test was the only invocation path, so no sibling callers required changes.

## Regression sensitivity

The test was changed first to call `super::reference_cases`; before the module rename, the focused test build failed with E0433 because `reference_cases` did not exist. Reverting the implementation rename therefore fails the regression at compile time. The added assertions also exercise `result` and `relative_error` directly.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p lattice-transport` (30 unit tests, 3 integration tests, 1 doctest)
- `cargo clippy -p lattice-transport -- -D warnings`

This is test-harness-only and does not touch a decode, prefill, or GEMM hot path; no GPU benchmark is required.

Closes #805