### PR TITLE
fix(fann): enforce hidden-Softmax placement invariant in Network::new

### DIFF
--- a/crates/fann/src/network/builder.rs
+++ b/crates/fann/src/network/builder.rs
@@ -19,24 +19,6 @@ pub struct NetworkBuilder {
     layers: Vec<(usize, Activation)>,
 }
 
-/// Reject Softmax before the final layer: its derivative here is only diagonal (see ADR-023).
-fn validate_no_hidden_softmax(layers: &[(usize, Activation)]) -> FannResult<()> {
-    if layers.len() < 2 {
-        return Ok(());
-    }
-    let last_hidden = layers.len() - 1;
-    for (_, activation) in &layers[..last_hidden] {
-        if activation.is_softmax() {
-            return Err(FannError::InvalidBuilder(
-                "Softmax is only valid as the output-layer activation; \
-                 hidden layers must use a pointwise activation"
-                    .into(),
-            ));
-        }
-    }
-    Ok(())
-}
-
 impl NetworkBuilder {
     /// Create a new network builder
     pub fn new() -> Self {
@@ -87,8 +69,6 @@ impl NetworkBuilder {
             return Err(FannError::InvalidBuilder("Input size cannot be 0".into()));
         }
 
-        validate_no_hidden_softmax(&self.layers)?;
-
         let mut layers = Vec::with_capacity(self.layers.len());
         let mut prev_size = input_size;
 
@@ -122,8 +102,6 @@ impl NetworkBuilder {
         if input_size == 0 {
             return Err(FannError::InvalidBuilder("Input size cannot be 0".into()));
         }
-
-        validate_no_hidden_softmax(&self.layers)?;
 
         let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
         let mut layers = Vec::with_capacity(self.layers.len());

--- a/crates/fann/src/network/mod.rs
+++ b/crates/fann/src/network/mod.rs
@@ -89,10 +89,23 @@ impl TryFrom<NetworkData> for Network {
 impl Network {
     /// Create a network from a list of layers
     ///
-    /// Validates that layer dimensions are compatible.
+    /// Validates that layer dimensions are compatible and Softmax appears only
+    /// on the output layer.
     pub fn new(layers: Vec<Layer>) -> FannResult<Self> {
         if layers.is_empty() {
             return Err(FannError::EmptyNetwork);
+        }
+
+        // Reject Softmax before the final layer: its derivative here is only diagonal (see ADR-023).
+        if layers[..layers.len() - 1]
+            .iter()
+            .any(|layer| layer.activation().is_softmax())
+        {
+            return Err(FannError::InvalidBuilder(
+                "Softmax is only valid as the output-layer activation; \
+                 hidden layers must use a pointwise activation"
+                    .into(),
+            ));
         }
 
         // Validate layer compatibility
@@ -295,6 +308,19 @@ mod tests {
             result,
             Err(FannError::NumericInstability(message)) if message.contains("NaN")
         ));
+    }
+
+    #[test]
+    fn network_new_rejects_hidden_softmax() {
+        let hidden = Layer::new(2, 4, Activation::Softmax).unwrap();
+        let output = Layer::new(4, 1, Activation::Linear).unwrap();
+
+        let result = Network::new(vec![hidden, output]);
+
+        assert!(
+            matches!(result, Err(FannError::InvalidBuilder(_))),
+            "expected InvalidBuilder, got {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Defect

`Network::new` accepted Softmax on a non-final layer even though the builders rejected that topology. Direct construction, serde deserialization, and binary deserialization could therefore bypass the invariant.

## Fix

Centralize the hidden-Softmax placement check in `Network::new` and remove the redundant builder-level checks so both builder entry points delegate to the constructor invariant. Output-layer Softmax remains valid.

## Sibling paths checked

- `NetworkBuilder::build` and `NetworkBuilder::build_with_seed` both finish through `Network::new`.
- `TryFrom<NetworkData>` for serde and `Network::from_bytes` already finish through `Network::new`; no duplicate checks were needed.
- The GPU fail-loud path is explicitly split into separate work in the issue comment and is not changed here.

## Regression test

`network_new_rejects_hidden_softmax` constructs compatible layers with hidden Softmax and calls `Network::new` directly. Reverting the constructor guard makes the call return `Ok(Network)`, so the test fails. The test was observed failing before the fix and passing after it.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p lattice-fann` (80 unit tests plus integration, property, and shader validation tests)
- `cargo test -p lattice-fann --features serde serde_validation_tests`
- `cargo clippy -p lattice-fann -- -D warnings`
- Repository pre-commit checks

No GPU bench is required because this is a construction-time validation change, not a decode, prefill, or GEMM hot-path change.

Closes #742