### PR TITLE
fix(inference): weight-loader validation guards (aliased ranges, q4 shape, config copy)

### DIFF
--- a/crates/inference/src/bin/quantize_q4.rs
+++ b/crates/inference/src/bin/quantize_q4.rs
@@ -246,6 +246,15 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     if !dry_run {
         fs::create_dir_all(&output_dir)?;
+        let source_config = model_dir.join("config.json");
+        let output_config = output_dir.join("config.json");
+        fs::copy(&source_config, &output_config).map_err(|e| {
+            format!(
+                "failed to copy {} to {}: {e}",
+                source_config.display(),
+                output_config.display()
+            )
+        })?;
     }
 
     let reader = QuarotTensorReader::open(&model_dir)?;

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -362,6 +362,27 @@ impl SafetensorsFile {
             }
         }
 
+        let mut ranges: Vec<_> = tensors
+            .iter()
+            .map(|(name, meta)| (meta.start, meta.end, name.as_str()))
+            .collect();
+        ranges.sort_unstable();
+        let mut previous_end = 0usize;
+        for &(start, end, name) in &ranges {
+            if start != previous_end {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "tensor {name} has non-contiguous data offsets: expected start={previous_end}, \
+                     got [{start}, {end})"
+                )));
+            }
+            previous_end = end;
+        }
+        if previous_end != data_len {
+            return Err(InferenceError::InvalidSafetensors(format!(
+                "data section is {data_len} bytes but tensors cover {previous_end} bytes"
+            )));
+        }
+
         Ok(Self {
             data,
             data_offset,
@@ -1981,6 +2002,35 @@ mod tests {
             .expect_err("one-byte-extra payload should be rejected at open");
         assert!(
             err.to_string().contains("byte length mismatch"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_rejects_aliased_tensor_ranges() {
+        let path = temp_path("lattice_weights_aliased_ranges");
+        let header = r#"{
+            "key": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]},
+            "value": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}
+        }"#
+        .replace(['\n', ' '], "");
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+        let mut file = File::create(&path).expect("test setup: create safetensors file");
+        file.write_all(&bytes)
+            .expect("test setup: write safetensors bytes");
+        drop(file);
+
+        let err = SafetensorsFile::open(&path)
+            .expect_err("aliased tensor byte ranges must be rejected at open");
+        assert!(
+            err.to_string().contains("non-contiguous"),
             "unexpected error: {err}"
         );
 

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -791,7 +791,8 @@ pub fn load_q4_file(path: &std::path::Path) -> Result<Q4Tensor, Box<dyn std::err
 ///
 /// # Errors
 ///
-/// Returns an error on I/O failure, unrecognized magic bytes, or unsupported version.
+/// Returns an error on I/O failure, malformed dimensions, unrecognized magic bytes, or
+/// unsupported version.
 pub fn load_f16_tensor_file(
     path: &std::path::Path,
 ) -> Result<(Vec<f32>, Vec<usize>), Box<dyn std::error::Error>> {
@@ -828,6 +829,16 @@ pub fn load_f16_tensor_file(
 
     f.read_exact(&mut b8)?;
     let numel = u64::from_le_bytes(b8) as usize;
+
+    let shape_product = shape
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or("shape dims overflow usize")?;
+    if shape_product != numel {
+        return Err(
+            format!("shape product {shape_product} (shape={shape:?}) != numel {numel}").into(),
+        );
+    }
 
     let raw_len = checked_alloc_bytes(numel, 2, file_len, "f16 data")?;
     let mut raw = vec![0u8; raw_len];
@@ -2253,7 +2264,7 @@ mod tests {
         buf.extend_from_slice(b"KHF1");
         buf.extend_from_slice(&1u32.to_le_bytes());
         buf.extend_from_slice(&1u32.to_le_bytes()); // ndim
-        buf.extend_from_slice(&4u64.to_le_bytes()); // shape[0]
+        buf.extend_from_slice(&(1u64 << 63).to_le_bytes()); // shape[0]
         buf.extend_from_slice(&(1u64 << 63).to_le_bytes()); // numel
         let path = std::path::PathBuf::from("/tmp/test_f16_huge_numel.f16");
         std::fs::write(&path, &buf).unwrap();
@@ -2262,6 +2273,27 @@ mod tests {
         assert!(
             r.is_err(),
             "2^63 numel must be rejected, not silently truncated to empty"
+        );
+    }
+
+    #[test]
+    fn test_f16_rejects_shape_numel_mismatch() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"KHF1");
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.extend_from_slice(&2u32.to_le_bytes()); // ndim
+        buf.extend_from_slice(&2u64.to_le_bytes()); // shape[0]
+        buf.extend_from_slice(&2u64.to_le_bytes()); // shape[1]
+        buf.extend_from_slice(&1u64.to_le_bytes()); // numel
+        buf.extend_from_slice(&0u16.to_le_bytes()); // one valid f16 payload value
+        let path = std::path::PathBuf::from("/tmp/test_f16_shape_numel_mismatch.f16");
+        std::fs::write(&path, &buf).unwrap();
+        let r = load_f16_tensor_file(&path);
+        std::fs::remove_file(&path).ok();
+        let err = r.expect_err("shape product != numel must be rejected");
+        assert!(
+            err.to_string().contains("shape product"),
+            "unexpected error: {err}"
         );
     }
 
@@ -2326,7 +2358,7 @@ mod tests {
         buf.extend_from_slice(b"KHF1");
         buf.extend_from_slice(&1u32.to_le_bytes());
         buf.extend_from_slice(&1u32.to_le_bytes()); // ndim
-        buf.extend_from_slice(&4u64.to_le_bytes()); // shape[0]
+        buf.extend_from_slice(&(huge as u64).to_le_bytes()); // shape[0]
         buf.extend_from_slice(&(huge as u64).to_le_bytes()); // numel
         let path = std::path::PathBuf::from("/tmp/test_f16_numel_exceeds_file_len.f16");
         std::fs::write(&path, &buf).unwrap();
@@ -2355,7 +2387,7 @@ mod tests {
         buf.extend_from_slice(b"KHF1");
         buf.extend_from_slice(&1u32.to_le_bytes());
         buf.extend_from_slice(&1u32.to_le_bytes()); // ndim
-        buf.extend_from_slice(&4u64.to_le_bytes()); // shape[0]
+        buf.extend_from_slice(&(huge as u64).to_le_bytes()); // shape[0]
         buf.extend_from_slice(&(huge as u64).to_le_bytes()); // numel
         // Trailing filler: `huge * 2` wraps to a small residue (10 bytes) if
         // `checked_mul` is bypassed, so pad enough real bytes that a buggy

--- a/crates/inference/tests/quantize_q4_reader_refactor.rs
+++ b/crates/inference/tests/quantize_q4_reader_refactor.rs
@@ -20,6 +20,7 @@ const GATE_PROJ_GOLDEN: &[u8] =
     include_bytes!("fixtures/quantize_q4_reader_refactor/gate_proj_golden.q4");
 const K_PROJ_GOLDEN: &[u8] =
     include_bytes!("fixtures/quantize_q4_reader_refactor/k_proj_golden.q4");
+const CONFIG_JSON: &str = "{\n  \"model_type\": \"fixture\"\n}\n";
 
 /// BF16 bit pattern for an arbitrary finite `f32`: truncate to the top 16
 /// bits, matching `QuarotTensorReader`'s BF16 decode (`f32::from_bits((bits
@@ -134,6 +135,7 @@ fn fixture_tensors() -> Vec<(&'static str, Vec<usize>, Vec<f32>)> {
 
 fn write_sharded_fixture(model_dir: &Path) {
     std::fs::create_dir_all(model_dir).expect("create model dir");
+    std::fs::write(model_dir.join("config.json"), CONFIG_JSON).expect("write config");
     let shard_name = "model-00001-of-00001.safetensors";
     write_safetensors(&model_dir.join(shard_name), &fixture_tensors());
 
@@ -159,6 +161,7 @@ fn write_sharded_fixture(model_dir: &Path) {
 
 fn write_single_file_fixture(model_dir: &Path) {
     std::fs::create_dir_all(model_dir).expect("create model dir");
+    std::fs::write(model_dir.join("config.json"), CONFIG_JSON).expect("write config");
     write_safetensors(&model_dir.join("model.safetensors"), &fixture_tensors());
 }
 
@@ -230,6 +233,20 @@ fn single_file_fixture_matches_same_q4_golden() {
     assert_q4_matches_golden(&output_dir);
 }
 
+#[test]
+fn output_includes_source_config_json_verbatim() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let model_dir = dir.path().join("model");
+    let output_dir = dir.path().join("out");
+    write_single_file_fixture(&model_dir);
+
+    run_quantize_q4(&model_dir, &output_dir);
+
+    let output_config = std::fs::read_to_string(output_dir.join("config.json"))
+        .expect("quantized artifact includes config.json");
+    assert_eq!(output_config, CONFIG_JSON);
+}
+
 /// Parses the kept-tensor `.f16` output format `quantize_q4` writes: magic
 /// `KHF1` + version `u32` + ndim `u32` + shape dims (`u64` each) + numel
 /// (`u64`) + raw little-endian f16 bit patterns — returns the bit patterns.
@@ -259,6 +276,7 @@ fn f16_source_subnormals_survive_kept_tensor_round_trip() {
     let model_dir = dir.path().join("model");
     let output_dir = dir.path().join("out");
     std::fs::create_dir_all(&model_dir).expect("create model dir");
+    std::fs::write(model_dir.join("config.json"), CONFIG_JSON).expect("write config");
 
     let values: Vec<u16> = vec![
         0x0001, // smallest positive subnormal


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Defects

- `quantize_q4` produced `.q4`, `.f16`, and `quantize_index.json` files without the source `config.json`, so a fresh output directory was not directly loadable.
- The KHF1 F16 loader trusted `shape` and `numel` independently, allowing a declared shape to overstate the actual payload.
- `SafetensorsFile` validated tensor extents individually but did not reject overlapping, aliased, gapped, or incompletely covered data ranges.

## Fix

- Copy the source `config.json` into non-dry-run `quantize_q4` output directories.
- Compute the KHF1 shape product with checked multiplication and require it to equal `numel` before payload allocation and decoding.
- Sort all Safetensors tensor ranges and require contiguous coverage from offset zero through the entire data section.

## Sibling paths checked

- `quantize_quarot` already writes its transformed `config.json`; no additional converter path needed a change.
- Every runtime KHF1 consumer in `metal_qwen35.rs` routes through `load_f16_tensor_file`, so the loader-boundary guard covers the MTP and main Q4-directory F16 paths.
- `SafetensorsFile::open`, `SafetensorsFile::from_bytes`, and lazy sharded loads all route through the guarded `from_backing` path. The separate QuaRot Safetensors reader already enforces sorted contiguous full coverage.

## Regression sensitivity

- Reverting the config copy makes `output_includes_source_config_json_verbatim` fail because the output file is missing.
- Reverting the KHF1 guard makes `test_f16_rejects_shape_numel_mismatch` return `Ok` for a `[2, 2]` tensor with one declared element.
- Reverting the Safetensors layout guard makes `test_rejects_aliased_tensor_ranges` accept two names backed by the same `[0, 4)` bytes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lattice-inference`
- `cargo clippy -p lattice-inference -- -D warnings`
- Pre-commit workspace clippy/all-targets and documentation lint

No GPU bench is required: these changes are confined to offline artifact generation and load-time validation, not decode, prefill, or GEMM hot paths.

Closes #706
Closes #735
Closes #752