### PR TITLE
fix(embed): verify unit-norm assumption in cosine fast path

### DIFF
--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -319,6 +319,7 @@ pub fn approximate_cosine_distance_prepared_with_meta(
     if meta.norm == NormalizationHint::Unit
         && stored_norm == NormalizationHint::Unit
         && let (PreparedQuery::Full(q), QuantizedData::Full(s)) = (&meta.query, stored)
+        && is_unit_norm(s)
     {
         let dot = dot_product(q, s);
         return Ok(1.0 - dot.clamp(-1.0, 1.0));
@@ -842,6 +843,27 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, EmbedError::TierMismatch { .. }));
+    }
+
+    #[test]
+    fn test_cosine_distance_prepared_with_meta_validates_stored_unit_norm() {
+        let query = vec![std::f32::consts::FRAC_1_SQRT_2; 2];
+        let meta = PreparedQueryWithMeta::from_f32(
+            &query,
+            QuantizationTier::Full,
+            NormalizationHint::Unit,
+        );
+        let stored = QuantizedData::Full(vec![2.0, 0.0]);
+
+        let got =
+            approximate_cosine_distance_prepared_with_meta(&meta, &stored, NormalizationHint::Unit)
+                .unwrap();
+        let expected = approximate_cosine_distance_prepared(&meta.query, &stored).unwrap();
+
+        assert!(
+            (got - expected).abs() < 1e-6,
+            "got={got}, expected={expected}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Defect

`approximate_cosine_distance_prepared_with_meta` trusted the stored `NormalizationHint::Unit` metadata without inspecting the stored vector. A non-unit `Full` vector mislabeled as unit therefore took the `1 - clamp(dot)` shortcut and returned a non-cosine distance.

## Fix

Require `is_unit_norm` to validate the stored `Full` vector before entering the dot-product shortcut. A false stored-unit claim now falls back to the existing full cosine-distance dispatch.

## Sibling paths checked

Searched `lattice-embed` for `NormalizationHint`, `PreparedQueryWithMeta`, `prepare_query_with_norm`, and `approximate_cosine_distance_prepared_with_meta`. There is no sibling implementation of the metadata-aware shortcut to update; the existing Criterion benchmark is the only non-test external caller.

## Regression test

Added `test_cosine_distance_prepared_with_meta_validates_stored_unit_norm`, using a unit query and stored `[2.0, 0.0]` vector mislabeled as unit. With the guard reverted, the shortcut returns `0`; the full cosine path returns `0.29289317`, so the test fails.

## Validation

- `cargo fmt --check`
- `cargo test -p lattice-embed`: 338 passed, 1 existing ignored
- `cargo clippy -p lattice-embed -- -D warnings`
- `cargo llvm-cov -p lattice-embed --summary-only`: passed; filtered `lattice-embed` library report is 91.45% line coverage, with `simd/tier.rs` at 87.85%
- `cargo bench -p lattice-embed --bench simd -- prepared_meta_unit` on NEON, 1,000 stored vectors per sample:
  - 384d: 373.72 us median, 2.6758 Melem/s
  - 768d: 751.08 us median, 1.3314 Melem/s
  - 1024d: 1.0896 ms median, 917.80 Kelem/s

This is a CPU-only validation guard, not a decode, prefill, or GEMM hot-path change. No GPU benchmark is required.

Closes #759
