### PR TITLE
fix(tune): fail closed on placeholder train steps + derive eligible LoRA indices

### DIFF
--- a/crates/inference/src/bin/bench_lora_mixture.rs
+++ b/crates/inference/src/bin/bench_lora_mixture.rs
@@ -11,12 +11,12 @@
 //! # Output
 //!
 //! ```text
-//! BLEND_BENCH r=1 k=1 layers=28 blend_us=<f>
-//! BLEND_BENCH r=1 k=4 layers=28 blend_us=<f>
-//! BLEND_BENCH r=1 k=8 layers=28 blend_us=<f>
-//! BLEND_BENCH r=2 k=1 layers=28 blend_us=<f>
-//! BLEND_BENCH r=2 k=4 layers=28 blend_us=<f>
-//! BLEND_BENCH r=2 k=8 layers=28 blend_us=<f>
+//! BLEND_BENCH r=1 k=1 layers=12 blend_us=<f>
+//! BLEND_BENCH r=1 k=4 layers=12 blend_us=<f>
+//! BLEND_BENCH r=1 k=8 layers=12 blend_us=<f>
+//! BLEND_BENCH r=2 k=1 layers=12 blend_us=<f>
+//! BLEND_BENCH r=2 k=4 layers=12 blend_us=<f>
+//! BLEND_BENCH r=2 k=8 layers=12 blend_us=<f>
 //! ```
 //!
 //! When a model is available:
@@ -49,9 +49,25 @@ fn main() {
     }
 }
 
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+fn full_attention_layer_indices(
+    cfg: &lattice_inference::model::qwen35_config::Qwen35Config,
+) -> Vec<usize> {
+    use lattice_inference::model::qwen35_config::LayerType;
+
+    cfg.layer_types
+        .iter()
+        .enumerate()
+        .filter_map(|(layer_idx, layer_type)| {
+            (*layer_type == LayerType::FullAttention).then_some(layer_idx)
+        })
+        .collect()
+}
+
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     use lattice_inference::forward::metal_qwen35::{LoraLayerData, blend_lora_layer_data};
+    use lattice_inference::model::qwen35_config::Qwen35Config;
     use std::time::Instant;
 
     let warmup: usize = std::env::var("BENCH_WARMUP")
@@ -67,20 +83,21 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(32);
 
-    // Qwen3.5-0.8b has 28 transformer layers; use q_proj for the projection.
-    // For a realistic mix we cover all 28 layers × 2 modules (q_proj + v_proj).
-    const NUM_LAYERS: usize = 28;
+    let cfg = Qwen35Config::qwen35_0_8b();
+    let layer_indices = full_attention_layer_indices(&cfg);
     const D_IN: usize = 1024;
     const D_OUT: usize = 4096;
 
     for &rank in &[1usize, 2] {
         for &k in &[1usize, 4, 8] {
-            // Build k synthetic adapters, each covering NUM_LAYERS layers.
+            // GDN layers have no q_proj or v_proj and are rejected by the runtime.
             let adapters: Vec<Vec<LoraLayerData>> = (0..k)
                 .map(|adapter_idx| {
-                    (0..NUM_LAYERS)
+                    layer_indices
+                        .iter()
+                        .copied()
                         .flat_map(|layer_idx| {
-                            let seed = (adapter_idx * NUM_LAYERS + layer_idx) as f32;
+                            let seed = (adapter_idx * cfg.num_hidden_layers + layer_idx) as f32;
                             // q_proj
                             let layer_q = LoraLayerData {
                                 layer_idx,
@@ -135,7 +152,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             let elapsed = start.elapsed();
             let blend_us = elapsed.as_micros() as f64 / iters as f64;
 
-            let layers_count = NUM_LAYERS * 2; // q_proj + v_proj
+            let layers_count = layer_indices.len() * 2; // q_proj + v_proj
             println!("BLEND_BENCH r={rank} k={k} layers={layers_count} blend_us={blend_us:.1}");
         }
     }
@@ -187,13 +204,16 @@ fn run_gpu_decode_bench(
     const D_IN: usize = 1024;
     const D_OUT: usize = 4096;
     let num_layers = cfg.num_hidden_layers;
+    let layer_indices = full_attention_layer_indices(&cfg);
     let prompt = "Hello";
 
     for &rank in &[1usize, 2] {
         for &k in &[1usize, 4, 8] {
             let adapters: Vec<Vec<LoraLayerData>> = (0..k)
                 .map(|adapter_idx| {
-                    (0..num_layers)
+                    layer_indices
+                        .iter()
+                        .copied()
                         .map(|layer_idx| {
                             let seed = (adapter_idx * num_layers + layer_idx) as f32;
                             LoraLayerData {
@@ -238,4 +258,20 @@ fn run_gpu_decode_bench(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lattice_inference::model::qwen35_config::Qwen35Config;
+
+    #[test]
+    fn qwen35_0_8b_lora_layers_are_full_attention_only() {
+        let cfg = Qwen35Config::qwen35_0_8b();
+
+        assert_eq!(
+            full_attention_layer_indices(&cfg),
+            vec![3, 7, 11, 15, 19, 23]
+        );
+    }
 }

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -129,9 +129,13 @@ mod tests {
         // 4. Create training loop
         let mut trainer = TrainingLoop::new(train_config).unwrap();
 
-        // 5. Train (using placeholder implementation)
-        let metrics = trainer.train(&mut dataset).unwrap();
-        assert!(metrics.epochs_completed > 0);
+        // 5. The placeholder loop must fail instead of fabricating metrics
+        let error = trainer.train(&mut dataset).unwrap_err();
+        assert!(matches!(
+            error,
+            TuneError::Training(message) if message.contains("not implemented")
+        ));
+        let metrics = TrainingMetrics::default();
 
         // 6. Create model for registry
         let metadata = ModelMetadata::classifier(3, 6, 1000)

--- a/crates/tune/src/train/jit.rs
+++ b/crates/tune/src/train/jit.rs
@@ -1,8 +1,8 @@
 //! Just-in-time adaptation configuration, control flow, and layer-selection helpers.
 //!
-//! CPU adaptation currently reports simulated loss; GPU adaptation delegates to
-//! the GPU trainer and therefore cannot complete a weight update yet. See
-//! `docs/train.md` for strategies, stopping rules, and current limitations.
+//! CPU adaptation currently fails at its unwired training step; GPU adaptation
+//! delegates to the GPU trainer and therefore cannot complete a weight update
+//! yet. See `docs/train.md` for strategies, stopping rules, and limitations.
 
 use crate::data::{Dataset, TrainingExample};
 use crate::error::{Result, TuneError};
@@ -248,7 +248,6 @@ impl JitAdapter {
                 break;
             }
 
-            // Simulate training step (placeholder)
             let loss = self.train_step_cpu(&mut dataset, step)?;
             loss_history.push(loss);
             steps_completed = step + 1;
@@ -365,23 +364,11 @@ impl JitAdapter {
         })
     }
 
-    /// Placeholder CPU training step
-    fn train_step_cpu(&self, dataset: &mut Dataset, step: usize) -> Result<f32> {
-        // Get batch (cycle through dataset)
-        let _batch = match dataset.next_batch() {
-            Some(b) => b,
-            None => {
-                dataset.reset_epoch();
-                dataset
-                    .next_batch()
-                    .ok_or_else(|| TuneError::Training("Dataset is empty".into()))?
-            }
-        };
-
-        // Simulate decreasing loss
-        let base_loss = 1.0 / (1.0 + step as f32 * 0.1);
-        let noise = (step as f32 * 0.1).sin() * 0.1;
-        Ok(base_loss + noise.abs())
+    /// Return an error until CPU adaptation has a real gradient update path.
+    fn train_step_cpu(&self, _dataset: &mut Dataset, _step: usize) -> Result<f32> {
+        Err(TuneError::Training(
+            "JIT CPU adaptation is not implemented; use train_grad_full for LoRA SFT".into(),
+        ))
     }
 }
 
@@ -498,8 +485,9 @@ mod tests {
     }
 
     #[test]
-    fn test_jit_adapt_cpu() {
+    fn test_jit_low_rank_adapt_cpu_fails_closed() {
         let adapter = JitAdapter::with_config(JitConfig {
+            strategy: JitStrategy::LowRank { rank: 4 },
             steps: 10,
             timeout_secs: 1.0,
             ..JitConfig::fast()
@@ -507,13 +495,12 @@ mod tests {
         .unwrap();
 
         let examples = make_examples(20);
-        let result = adapter.adapt_cpu(examples);
+        let error = adapter.adapt_cpu(examples).unwrap_err();
 
-        assert!(result.is_ok());
-        let result = result.unwrap();
-        assert!(result.is_success());
-        assert!(result.steps_completed > 0);
-        assert!(result.time_secs < 1.0);
+        assert!(matches!(
+            error,
+            TuneError::Training(message) if message.contains("not implemented")
+        ));
     }
 
     #[test]

--- a/crates/tune/src/train/loop/mod.rs
+++ b/crates/tune/src/train/loop/mod.rs
@@ -1,8 +1,8 @@
 //! Training-loop orchestration, callbacks, metrics, and checkpoints.
 //!
-//! The current CPU loop validates and drives the run lifecycle but simulates
-//! loss and accuracy rather than optimizing network weights. See `docs/train.md`
-//! for lifecycle order, metric semantics, and checkpoint limitations.
+//! The current CPU loop validates and drives the run lifecycle but fails when
+//! training reaches the unwired optimizer step. See `docs/train.md` for
+//! lifecycle order, metric semantics, and checkpoint limitations.
 
 mod callbacks;
 mod checkpoint;
@@ -20,8 +20,9 @@ use crate::error::{Result, TuneError};
 
 /// CPU training-loop orchestrator.
 ///
-/// This implementation simulates batch loss and accuracy; it does not update a
-/// neural network. See `docs/train.md` for the lifecycle and current contract.
+/// This implementation does not update a neural network and returns a training
+/// error when a batch reaches the unwired optimizer step. See `docs/train.md`
+/// for the lifecycle and current contract.
 pub struct TrainingLoop {
     /// Training configuration
     config: TrainingConfig,
@@ -77,8 +78,8 @@ impl TrainingLoop {
 
     /// Train on a dataset
     ///
-    /// This is a placeholder that simulates training. Real implementation
-    /// would use lattice-fann for actual neural network operations.
+    /// This returns a training error because CPU optimizer integration is not
+    /// implemented. Use the `train_grad_full` binary for LoRA SFT.
     pub fn train(&mut self, dataset: &mut Dataset) -> Result<TrainingMetrics> {
         if dataset.is_empty() {
             return Err(TuneError::Dataset("Dataset is empty".to_string()));
@@ -206,29 +207,11 @@ impl TrainingLoop {
 
     /// Train one batch
     ///
-    /// Placeholder: returns simulated loss. Real implementation would:
-    /// 1. Forward pass
-    /// 2. Compute loss
-    /// 3. Backward pass
-    /// 4. Update weights
-    fn train_batch(&mut self, batch: &Batch) -> Result<f32> {
-        self.state.step += 1;
-        self.state.global_step += 1;
-
-        // Simulate training
-        let batch_size = batch.len();
-        self.state.running_total += batch_size;
-
-        // Simulated loss (decreases over training)
-        let loss = 0.5 * (-0.01 * self.state.global_step as f32).exp() + 0.1;
-        self.state.running_loss += loss;
-
-        // Simulated accuracy (increases over training)
-        let accuracy_rate = 0.6 + 0.35 * (1.0 - (-0.005 * self.state.global_step as f32).exp());
-        let correct = (batch_size as f32 * accuracy_rate) as usize;
-        self.state.running_correct += correct;
-
-        Ok(loss)
+    /// Returns an error until the forward, backward, and optimizer steps are wired.
+    fn train_batch(&mut self, _batch: &Batch) -> Result<f32> {
+        Err(TuneError::Training(
+            "TrainingLoop CPU training is not implemented; use train_grad_full for LoRA SFT".into(),
+        ))
     }
 
     /// Validate on a dataset
@@ -285,27 +268,29 @@ mod tests {
     }
 
     #[test]
-    fn test_training_loop_train() {
+    fn test_training_loop_train_fails_closed() {
         let config = TrainingConfig::quick();
         let mut trainer = TrainingLoop::new(config).unwrap();
         let mut dataset = make_dataset(100);
 
-        let metrics = trainer.train(&mut dataset);
-        assert!(metrics.is_ok());
-
-        let metrics = metrics.unwrap();
-        assert!(metrics.epochs_completed > 0);
-        assert!(metrics.final_train_loss > 0.0);
+        let error = trainer.train(&mut dataset).unwrap_err();
+        assert!(matches!(
+            error,
+            TuneError::Training(message) if message.contains("not implemented")
+        ));
+        assert_eq!(trainer.state().global_step, 0);
+        assert!(trainer.metrics().history.is_empty());
     }
 
     #[test]
     fn test_training_with_validation() {
         let config = TrainingConfig::quick().val_split(0.2);
-        let mut trainer = TrainingLoop::new(config).unwrap();
-        let mut dataset = make_dataset(100);
+        let trainer = TrainingLoop::new(config).unwrap();
+        let dataset = make_dataset(100);
 
-        let metrics = trainer.train(&mut dataset).unwrap();
-        assert!(metrics.final_val_loss.is_some());
+        let (loss, accuracy) = trainer.validate(&dataset).unwrap();
+        assert_eq!(loss, 0.0);
+        assert_eq!(accuracy, 0.0);
     }
 
     #[test]

--- a/crates/tune/tests/training_pipeline.rs
+++ b/crates/tune/tests/training_pipeline.rs
@@ -13,7 +13,7 @@
 use lattice_tune::{
     Checkpoint, Dataset, DatasetConfig, EarlyStopping, EpochMetrics, IntentLabels, LRSchedule,
     LoggingCallback, OptimizerConfig, RegularizationConfig, TrainingCallback, TrainingConfig,
-    TrainingExample, TrainingLoop, TrainingMetrics, TrainingState,
+    TrainingExample, TrainingLoop, TrainingMetrics, TrainingState, TuneError,
 };
 
 // ============================================================================
@@ -54,6 +54,13 @@ fn make_diverse_dataset(num_examples: usize, embedding_dim: usize) -> Dataset {
         })
         .collect();
     Dataset::from_examples(examples)
+}
+
+fn assert_training_unimplemented(result: lattice_tune::Result<TrainingMetrics>) {
+    assert!(matches!(
+        result,
+        Err(TuneError::Training(message)) if message.contains("not implemented")
+    ));
 }
 
 // ============================================================================
@@ -108,17 +115,13 @@ fn test_training_loop_creation_invalid_batch_size() {
 // ============================================================================
 
 #[test]
-fn test_training_basic_execution() {
+fn test_training_basic_execution_fails_closed() {
     let config = TrainingConfig::quick().epochs(5);
     let mut trainer = TrainingLoop::new(config).unwrap();
     let mut dataset = make_dataset(100, 3, 64);
 
-    let metrics = trainer.train(&mut dataset);
-    assert!(metrics.is_ok());
-
-    let metrics = metrics.unwrap();
-    assert_eq!(metrics.epochs_completed, 5);
-    assert!(metrics.final_train_loss > 0.0);
+    assert_training_unimplemented(trainer.train(&mut dataset));
+    assert_eq!(trainer.state().global_step, 0);
 }
 
 #[test]
@@ -132,46 +135,39 @@ fn test_training_empty_dataset_fails() {
 }
 
 #[test]
-fn test_training_with_validation_split() {
+fn test_training_with_validation_split_fails_closed() {
     let config = TrainingConfig::quick().epochs(3).val_split(0.2);
     let mut trainer = TrainingLoop::new(config).unwrap();
     let mut dataset = make_dataset(100, 3, 64);
 
-    let metrics = trainer.train(&mut dataset).unwrap();
-
-    assert!(metrics.final_val_loss.is_some());
-    assert!(metrics.best_val_loss.is_some());
+    assert_training_unimplemented(trainer.train(&mut dataset));
 }
 
 #[test]
-fn test_training_diverse_labels() {
+fn test_training_diverse_labels_fail_closed() {
     let config = TrainingConfig::quick().epochs(3);
     let mut trainer = TrainingLoop::new(config).unwrap();
     let mut dataset = make_diverse_dataset(120, 64);
 
-    let metrics = trainer.train(&mut dataset).unwrap();
-    assert!(metrics.epochs_completed > 0);
+    assert_training_unimplemented(trainer.train(&mut dataset));
 }
 
 #[test]
-fn test_training_single_example() {
+fn test_training_single_example_fails_closed() {
     let config = TrainingConfig::quick().epochs(2).batch_size(1);
     let mut trainer = TrainingLoop::new(config).unwrap();
     let mut dataset = make_dataset(1, 3, 64);
 
-    let metrics = trainer.train(&mut dataset).unwrap();
-    assert!(metrics.epochs_completed > 0);
+    assert_training_unimplemented(trainer.train(&mut dataset));
 }
 
 #[test]
-fn test_training_large_batch_size() {
+fn test_training_large_batch_size_fails_closed() {
     let config = TrainingConfig::quick().epochs(2).batch_size(64);
     let mut trainer = TrainingLoop::new(config).unwrap();
     let mut dataset = make_dataset(50, 3, 64);
 
-    // Batch size larger than dataset should still work
-    let metrics = trainer.train(&mut dataset).unwrap();
-    assert!(metrics.epochs_completed > 0);
+    assert_training_unimplemented(trainer.train(&mut dataset));
 }
 
 // ============================================================================
@@ -185,27 +181,13 @@ fn test_early_stopping_on_val_loss() {
         .val_split(0.2)
         .early_stopping(EarlyStopping::val_loss(2)); // Very short patience
 
-    let mut trainer = TrainingLoop::new(config).unwrap();
-    let mut dataset = make_dataset(100, 3, 64);
-
-    let metrics = trainer.train(&mut dataset).unwrap();
-
-    // Should stop before 100 epochs (simulated loss decreases slowly)
-    // Note: With placeholder implementation, early stopping may or may not trigger
-    assert!(metrics.epochs_completed > 0);
+    assert!(config.early_stopping.is_some());
 }
 
 #[test]
 fn test_early_stopping_disabled() {
     let config = TrainingConfig::quick().epochs(5).no_early_stopping();
-
-    let mut trainer = TrainingLoop::new(config).unwrap();
-    let mut dataset = make_dataset(100, 3, 64);
-
-    let metrics = trainer.train(&mut dataset).unwrap();
-
-    assert!(!metrics.early_stopped);
-    assert_eq!(metrics.epochs_completed, 5);
+    assert!(config.early_stopping.is_none());
 }
 
 #[test]
@@ -325,23 +307,16 @@ fn test_checkpoint_creation() {
 #[test]
 fn test_checkpoint_from_trainer() {
     let config = TrainingConfig::quick().epochs(3);
-    let mut trainer = TrainingLoop::new(config).unwrap();
-    let mut dataset = make_dataset(50, 3, 64);
-
-    trainer.train(&mut dataset).unwrap();
+    let trainer = TrainingLoop::new(config).unwrap();
 
     let checkpoint = trainer.checkpoint();
-    assert_eq!(checkpoint.epoch, 2); // 0-indexed, after 3 epochs
+    assert_eq!(checkpoint.epoch, 0);
+    assert_eq!(checkpoint.global_step, 0);
 }
 
 #[test]
 fn test_checkpoint_resume() {
-    let config = TrainingConfig::quick().epochs(2);
-    let mut trainer = TrainingLoop::new(config).unwrap();
-    let mut dataset = make_dataset(50, 3, 64);
-
-    trainer.train(&mut dataset).unwrap();
-    let checkpoint = trainer.checkpoint();
+    let checkpoint = Checkpoint::new(1, 7, TrainingMetrics::default());
 
     // Create new trainer and resume
     let config2 = TrainingConfig::quick().epochs(5);
@@ -414,7 +389,7 @@ fn test_callback_invocation() {
     trainer.add_callback(callback);
 
     let mut dataset = make_dataset(30, 3, 64);
-    trainer.train(&mut dataset).unwrap();
+    assert_training_unimplemented(trainer.train(&mut dataset));
 
     // Verify callbacks were called (we can't access internal state,
     // but this verifies no panics during callback invocation)
@@ -646,7 +621,7 @@ fn test_training_state_epoch_loss() {
 // ============================================================================
 
 #[test]
-fn test_training_with_custom_dataset_config() {
+fn test_training_with_custom_dataset_config_fails_closed() {
     let config = TrainingConfig::quick().epochs(2).batch_size(16);
     let mut trainer = TrainingLoop::new(config).unwrap();
 
@@ -657,12 +632,11 @@ fn test_training_with_custom_dataset_config() {
     )
     .unwrap();
 
-    let metrics = trainer.train(&mut dataset).unwrap();
-    assert!(metrics.epochs_completed > 0);
+    assert_training_unimplemented(trainer.train(&mut dataset));
 }
 
 #[test]
-fn test_training_reproducibility_with_seed() {
+fn test_training_reproducibility_with_seed_fails_closed() {
     let config1 = TrainingConfig::quick().epochs(3).seed(12345);
     let config2 = TrainingConfig::quick().epochs(3).seed(12345);
 
@@ -672,12 +646,9 @@ fn test_training_reproducibility_with_seed() {
     let mut dataset1 = make_dataset(50, 3, 64);
     let mut dataset2 = make_dataset(50, 3, 64);
 
-    let metrics1 = trainer1.train(&mut dataset1).unwrap();
-    let metrics2 = trainer2.train(&mut dataset2).unwrap();
-
-    // With same seed, training should produce similar results
-    // (Note: exact match depends on implementation details)
-    assert_eq!(metrics1.epochs_completed, metrics2.epochs_completed);
+    assert_training_unimplemented(trainer1.train(&mut dataset1));
+    assert_training_unimplemented(trainer2.train(&mut dataset2));
+    assert_eq!(trainer1.state().global_step, trainer2.state().global_step);
 }
 
 // ============================================================================
@@ -685,7 +656,7 @@ fn test_training_reproducibility_with_seed() {
 // ============================================================================
 
 #[test]
-fn test_full_training_pipeline() {
+fn test_full_training_pipeline_fails_closed() {
     // 1. Create diverse dataset
     let mut dataset = make_diverse_dataset(200, 32);
 
@@ -708,26 +679,18 @@ fn test_full_training_pipeline() {
     // 3. Create trainer
     let mut trainer = TrainingLoop::new(config).unwrap();
 
-    // 4. Train
-    let metrics = trainer.train(&mut dataset).unwrap();
+    // 4. Training must fail until the CPU optimizer is wired
+    assert_training_unimplemented(trainer.train(&mut dataset));
 
-    // 5. Verify results
-    assert!(metrics.epochs_completed > 0);
-    assert!(metrics.final_train_loss > 0.0);
-    assert!(metrics.final_val_loss.is_some());
-    assert!(!metrics.history.is_empty());
-
-    // 6. Create checkpoint
+    // 5. A failed step must not fabricate checkpoint metrics
     let checkpoint = trainer.checkpoint();
     assert!(!checkpoint.id.is_nil());
-    assert_eq!(
-        checkpoint.metrics.epochs_completed,
-        metrics.epochs_completed
-    );
+    assert_eq!(checkpoint.global_step, 0);
+    assert!(checkpoint.metrics.history.is_empty());
 }
 
 #[test]
-fn test_training_with_all_lr_schedules() {
+fn test_training_with_all_lr_schedules_fails_closed() {
     let schedules = vec![
         LRSchedule::Constant,
         LRSchedule::LinearWarmup { warmup_steps: 10 },
@@ -749,16 +712,12 @@ fn test_training_with_all_lr_schedules() {
         let mut trainer = TrainingLoop::new(config).unwrap();
         let mut dataset = make_dataset(50, 3, 32);
 
-        let result = trainer.train(&mut dataset);
-        assert!(
-            result.is_ok(),
-            "Training failed with schedule: {schedule:?}"
-        );
+        assert_training_unimplemented(trainer.train(&mut dataset));
     }
 }
 
 #[test]
-fn test_training_with_different_batch_sizes() {
+fn test_training_with_different_batch_sizes_fails_closed() {
     let batch_sizes = vec![1, 8, 32, 64, 128];
 
     for batch_size in batch_sizes {
@@ -766,11 +725,7 @@ fn test_training_with_different_batch_sizes() {
         let mut trainer = TrainingLoop::new(config).unwrap();
         let mut dataset = make_dataset(150, 3, 32);
 
-        let result = trainer.train(&mut dataset);
-        assert!(
-            result.is_ok(),
-            "Training failed with batch_size: {batch_size}"
-        );
+        assert_training_unimplemented(trainer.train(&mut dataset));
     }
 }
 


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Defect

`TrainingLoop::train_batch` and `JitAdapter::train_step_cpu` returned plausible synthetic losses without updating any weights. The LoRA mixture benchmark also constructed `q_proj` adapters for every Qwen3.5 layer, including GDN layers where that projection is invalid, and its CPU blend setup assumed 28 layers for the 24-layer 0.8B model.

## Fix

- Return `TuneError::Training` from both unwired CPU training steps before they can fabricate metrics or advance training state.
- Derive full-attention layer indices from `Qwen35Config::layer_types` and use them for both the GPU decode adapters and the sibling CPU blend adapters.
- Derive the CPU benchmark's layer count from the selected full-attention projections instead of the stale hardcoded model-layer count.

## Sibling paths checked

The same-file CPU blend constructor also emitted `q_proj`/`v_proj` entries for every layer, so it now uses the identical full-attention index selection. `GpuTrainer::train_batch` already returns a training error for its unwired optimizer path. The remaining `LoraLayerData` constructors in `metal_qwen35.rs` are focused validation and blend tests, not production benchmark setup.

## Regression coverage

The tune regressions assert that the public training loop and low-rank JIT CPU adaptation return an explicit not-implemented training error; the training-loop test also pins `global_step == 0` and an empty metric history. Before the fix, both tests failed because the old code returned `Ok` synthetic metrics/loss. The benchmark regression pins the Qwen3.5-0.8B eligible indices to `[3, 7, 11, 15, 19, 23]`, so restoring all-layer selection fails the guard.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p lattice-tune` — 184 unit, 7 property, and 50 integration tests passed
- `cargo test -p lattice-inference --features f16,metal-gpu --bin bench_lora_mixture qwen35_0_8b_lora_layers_are_full_attention_only` — passed without initializing a GPU
- `cargo clippy -p lattice-tune -- -D warnings`
- `cargo clippy -p lattice-inference --features f16,metal-gpu --bin bench_lora_mixture -- -D warnings`
- repository pre-commit checks — workspace clippy and documentation lint passed

No GPU benchmark is required: this changes benchmark input construction and fail-closed CPU guards, not a decode, prefill, or GEMM hot path.

Closes #10
Closes #637
Closes #738
