### PR TITLE
fix(fann): preserve extreme sigmoid and tanh inputs (#774)

### DIFF
--- a/crates/fann/src/gpu/shader_manager.rs
+++ b/crates/fann/src/gpu/shader_manager.rs
@@ -240,7 +240,7 @@ mod tests {
                 .source()
                 .contains("@compute")
         );
-        assert!(ShaderType::Sigmoid.source().contains("clamp"));
+        assert!(ShaderType::Sigmoid.source().contains("if (x >= 0.0)"));
     }
 
     #[test]

--- a/crates/fann/src/gpu/shaders.rs
+++ b/crates/fann/src/gpu/shaders.rs
@@ -152,7 +152,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
 /// Sigmoid activation with numerical stability
 ///
-/// Uses clamping to prevent exp() overflow
+/// Uses sign-dependent formulas to keep the exponent non-positive
 pub const SIGMOID_SHADER: &str = r#"
 struct Uniforms {
     size: u32,
@@ -171,10 +171,13 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         return;
     }
 
-    // Clamp to [-10, 10] to prevent exp() overflow
-    // exp(88) overflows f32, exp(10) = 22026 is safe
-    let x = clamp(data[idx], -10.0, 10.0);
-    data[idx] = 1.0 / (1.0 + exp(-x));
+    let x = data[idx];
+    if (x >= 0.0) {
+        data[idx] = 1.0 / (1.0 + exp(-x));
+    } else {
+        let ex = exp(x);
+        data[idx] = ex / (1.0 + ex);
+    }
 }
 "#;
 
@@ -197,8 +200,6 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         return;
     }
 
-    // Clamp to [-5, 5] - tanh saturates faster than sigmoid
-    let x = clamp(data[idx], -5.0, 5.0);
-    data[idx] = tanh(x);
+    data[idx] = tanh(data[idx]);
 }
 "#;

--- a/crates/fann/tests/cpu_gpu_parity.rs
+++ b/crates/fann/tests/cpu_gpu_parity.rs
@@ -11,12 +11,14 @@
 
 #![cfg(feature = "gpu")]
 
-use lattice_fann::gpu::{GpuContext, GpuNetwork, is_gpu_available};
+use lattice_fann::gpu::{GpuContext, GpuNetwork, is_gpu_available, should_use_gpu};
 use lattice_fann::{Activation, NetworkBuilder};
 use std::sync::Arc;
 
 /// Maximum acceptable difference between CPU and GPU outputs
 const TOLERANCE: f32 = 1e-4;
+const EXTREME_ACTIVATION_TOLERANCE: f32 = 1e-6;
+const GPU_ACTIVATION_WIDTH: usize = 100;
 
 /// Helper to skip tests if no GPU is available
 fn require_gpu() -> bool {
@@ -37,6 +39,10 @@ fn try_create_context() -> Option<Arc<GpuContext>> {
 
 /// Compare two slices within tolerance
 fn assert_outputs_close(cpu: &[f32], gpu: &[f32], test_name: &str) {
+    assert_outputs_close_with_tolerance(cpu, gpu, test_name, TOLERANCE);
+}
+
+fn assert_outputs_close_with_tolerance(cpu: &[f32], gpu: &[f32], test_name: &str, tolerance: f32) {
     assert_eq!(
         cpu.len(),
         gpu.len(),
@@ -48,10 +54,31 @@ fn assert_outputs_close(cpu: &[f32], gpu: &[f32], test_name: &str) {
     for (i, (c, g)) in cpu.iter().zip(gpu.iter()).enumerate() {
         let diff = (c - g).abs();
         assert!(
-            diff < TOLERANCE,
+            diff < tolerance,
             "{test_name}: index {i} mismatch - CPU: {c}, GPU: {g}, diff: {diff}"
         );
     }
+}
+
+fn identity_activation_network(activation: Activation) -> lattice_fann::Network {
+    let mut network = NetworkBuilder::new()
+        .input(GPU_ACTIVATION_WIDTH)
+        .output(GPU_ACTIVATION_WIDTH, activation)
+        .build_with_seed(0)
+        .unwrap();
+
+    let layer = network.layer_mut(0).unwrap();
+    layer.weights_mut().fill(0.0);
+    layer.biases_mut().fill(0.0);
+    for index in 0..GPU_ACTIVATION_WIDTH {
+        assert!(layer.set_weight(index, index, 1.0));
+    }
+
+    assert!(
+        should_use_gpu(network.total_params(), 1),
+        "extreme activation parity must exercise the GPU path"
+    );
+    network
 }
 
 // ============================================================================
@@ -257,69 +284,47 @@ fn test_parity_wide_network() {
 #[test]
 #[cfg_attr(not(feature = "gpu-tests"), ignore = "requires GPU hardware")]
 fn test_parity_sigmoid_activation() {
-    if !require_gpu() {
-        return;
-    }
-
-    let ctx = try_create_context().expect("GPU context");
-    let seed = 111;
-
-    let mut cpu_network = NetworkBuilder::new()
-        .input(4)
-        .hidden(8, Activation::Sigmoid)
-        .output(2, Activation::Linear)
-        .build_with_seed(seed)
-        .unwrap();
-
-    let gpu_cpu_network = NetworkBuilder::new()
-        .input(4)
-        .hidden(8, Activation::Sigmoid)
-        .output(2, Activation::Linear)
-        .build_with_seed(seed)
-        .unwrap();
+    let ctx = Arc::new(GpuContext::new_blocking().expect("gpu-tests requires a real GPU"));
+    let mut cpu_network = identity_activation_network(Activation::Sigmoid);
+    let gpu_cpu_network = cpu_network.clone();
 
     let mut gpu_network = GpuNetwork::new(ctx, gpu_cpu_network).unwrap();
-
-    let input = vec![0.5f32, -0.5, 1.0, -1.0];
+    let input: Vec<f32> = (0..GPU_ACTIVATION_WIDTH)
+        .map(|index| if index % 2 == 0 { -100.0 } else { 100.0 })
+        .collect();
 
     let cpu_output = cpu_network.forward(&input).unwrap().to_vec();
     let gpu_output = gpu_network.forward_sync(&input).unwrap();
 
-    assert_outputs_close(&cpu_output, &gpu_output, "sigmoid_activation");
+    assert_outputs_close_with_tolerance(
+        &cpu_output,
+        &gpu_output,
+        "sigmoid_activation_extremes",
+        EXTREME_ACTIVATION_TOLERANCE,
+    );
 }
 
 #[test]
 #[cfg_attr(not(feature = "gpu-tests"), ignore = "requires GPU hardware")]
 fn test_parity_tanh_activation() {
-    if !require_gpu() {
-        return;
-    }
-
-    let ctx = try_create_context().expect("GPU context");
-    let seed = 222;
-
-    let mut cpu_network = NetworkBuilder::new()
-        .input(4)
-        .hidden(8, Activation::Tanh)
-        .output(2, Activation::Linear)
-        .build_with_seed(seed)
-        .unwrap();
-
-    let gpu_cpu_network = NetworkBuilder::new()
-        .input(4)
-        .hidden(8, Activation::Tanh)
-        .output(2, Activation::Linear)
-        .build_with_seed(seed)
-        .unwrap();
+    let ctx = Arc::new(GpuContext::new_blocking().expect("gpu-tests requires a real GPU"));
+    let mut cpu_network = identity_activation_network(Activation::Tanh);
+    let gpu_cpu_network = cpu_network.clone();
 
     let mut gpu_network = GpuNetwork::new(ctx, gpu_cpu_network).unwrap();
-
-    let input = vec![0.3f32, -0.7, 0.9, -0.2];
+    let input: Vec<f32> = (0..GPU_ACTIVATION_WIDTH)
+        .map(|index| if index % 2 == 0 { -10.0 } else { 10.0 })
+        .collect();
 
     let cpu_output = cpu_network.forward(&input).unwrap().to_vec();
     let gpu_output = gpu_network.forward_sync(&input).unwrap();
 
-    assert_outputs_close(&cpu_output, &gpu_output, "tanh_activation");
+    assert_outputs_close_with_tolerance(
+        &cpu_output,
+        &gpu_output,
+        "tanh_activation_extremes",
+        EXTREME_ACTIVATION_TOLERANCE,
+    );
 }
 
 #[test]

--- a/crates/fann/tests/shader_validation.rs
+++ b/crates/fann/tests/shader_validation.rs
@@ -121,8 +121,11 @@ fn test_sigmoid_shader_valid() {
     let shader = &rest[shader_start..shader_start + shader_end];
 
     validate_wgsl(shader).expect("SIGMOID_SHADER should be valid WGSL");
-    // Check for numerical stability clamping
-    check_shader_patterns(shader, &["@compute", "clamp", "exp"]);
+    check_shader_patterns(shader, &["@compute", "if (x >= 0.0)", "exp(-x)", "exp(x)"]);
+    assert!(
+        !shader.contains("clamp("),
+        "Sigmoid must preserve extreme inputs"
+    );
 }
 
 #[test]
@@ -135,7 +138,11 @@ fn test_tanh_shader_valid() {
     let shader = &rest[shader_start..shader_start + shader_end];
 
     validate_wgsl(shader).expect("TANH_SHADER should be valid WGSL");
-    check_shader_patterns(shader, &["@compute", "clamp", "tanh"]);
+    check_shader_patterns(shader, &["@compute", "tanh(data[idx])"]);
+    assert!(
+        !shader.contains("clamp("),
+        "Tanh must preserve extreme inputs"
+    );
 }
 
 // ============================================================================
@@ -143,19 +150,16 @@ fn test_tanh_shader_valid() {
 // ============================================================================
 
 #[test]
-fn test_shader_numerical_stability_patterns() {
+fn test_activation_shaders_preserve_extreme_inputs() {
     let source = include_str!("../src/gpu/shaders.rs");
 
-    // Sigmoid should clamp inputs to prevent exp() overflow
     assert!(
-        source.contains("clamp(data[idx], -10.0, 10.0)"),
-        "Sigmoid should clamp inputs for numerical stability"
+        source.contains("if (x >= 0.0)"),
+        "Sigmoid should use a sign-stable branch"
     );
-
-    // Tanh should clamp inputs
     assert!(
-        source.contains("clamp(data[idx], -5.0, 5.0)"),
-        "Tanh should clamp inputs for numerical stability"
+        source.contains("data[idx] = tanh(data[idx]);"),
+        "Tanh should evaluate the original input"
     );
 }
 


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Defect

The FANN WGSL Sigmoid shader clamped inputs to `[-10, 10]`, and the Tanh shader clamped inputs to `[-5, 5]`. Those GPU-only clamps changed activation values for extreme inputs relative to the CPU implementations.

## Fix

- Evaluate Sigmoid with sign-dependent formulas so every exponent is non-positive without clipping the input.
- Evaluate native WGSL `tanh` on the original input.
- Strengthen the existing Sigmoid and Tanh parity cases with identity weights, extreme inputs, a tighter tolerance, and an assertion that the constructed network crosses the GPU dispatch threshold. When `gpu-tests` is enabled, absence of a real GPU now fails these cases instead of silently returning.
- Update CPU-only shader validation to reject clipping and verify the stable Sigmoid branch plus direct Tanh input.

## Sibling paths checked

The existing Sigmoid and Tanh parity tests were the sibling construction paths for this activation dispatch; both now use the same GPU-forcing identity-network helper. The stale `ShaderManager` Sigmoid source assertion was updated as well. No other GPU Sigmoid/Tanh shader definitions or clipping sites were found in `lattice-fann`.

## Regression sensitivity

Before the shader fix, `test_activation_shaders_preserve_extreme_inputs` failed with `Sigmoid should use a sign-stable branch`. Restoring either old clamp makes the CPU-only shader validation fail. On hardware, the parity cases compare Sigmoid at ±100 and Tanh at ±10 with `1e-6` tolerance; the old clamps introduce roughly `4.5e-5` and `9.1e-5` errors respectively.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lattice-fann`
- `cargo test -p lattice-fann --features gpu --lib test_shader_type_source`
- `cargo test -p lattice-fann --features gpu --test cpu_gpu_parity --no-run`
- `cargo clippy -p lattice-fann -- -D warnings`

No GPU workload was executed on the shared machine. This is an element-wise activation correctness fix, not a decode/prefill/GEMM hot-path change, so `make bench-compare` is not required before merge.

Closes #774
