### PR TITLE
fix(inference): validate LoRA adapter geometry in Qwen35Model::set_lora

### DIFF
--- a/crates/inference/src/lora_hook.rs
+++ b/crates/inference/src/lora_hook.rs
@@ -6,6 +6,8 @@
 //!
 //! The default `NoopLoraHook` does nothing — zero overhead when no adapter is loaded.
 
+use crate::model::qwen35_config::Qwen35Config;
+
 /// **Unstable**: trait for LoRA adapter injection into linear projections.
 ///
 /// The inference forward pass calls `apply()` after each `matmul_bt`.
@@ -24,6 +26,19 @@ pub trait LoraHook: Send + Sync {
     /// * `x` - Input activation (the same input that was passed to the base projection)
     /// * `output` - Base projection output to modify in-place
     fn apply(&self, layer_idx: usize, module: &str, x: &[f32], output: &mut [f32]);
+
+    /// **Unstable**: self-check this hook's declared rank/shape against a
+    /// Qwen3.5 model's geometry before it is installed.
+    ///
+    /// [`crate::model::qwen35::Qwen35Model::set_lora`] calls this before
+    /// swapping the hook in, so a mismatched adapter is rejected instead of
+    /// silently corrupting a projection's output prefix (or panicking past a
+    /// `debug_assert` in a release build). Default: no-op (trusts the
+    /// caller) — real adapters with known geometry (e.g.
+    /// `lattice_tune::lora::LoraAdapter`) override it.
+    fn validate_against(&self, _config: &Qwen35Config) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 /// No-op implementation. Used when no adapter is loaded.

--- a/crates/inference/src/model/qwen35/model.rs
+++ b/crates/inference/src/model/qwen35/model.rs
@@ -61,8 +61,27 @@ impl Qwen35Model {
     }
 
     /// **Unstable**: attach a LoRA adapter hook; hook trait API may change.
-    pub fn set_lora(&mut self, hook: Box<dyn crate::lora_hook::LoraHook>) {
+    ///
+    /// Calls [`LoraHook::validate_against`](crate::lora_hook::LoraHook::validate_against)
+    /// against this model's own config before installing the hook, so a
+    /// rank/dimension-mismatched adapter is rejected up front instead of
+    /// silently corrupting projection outputs (or panicking past a
+    /// `debug_assert` in a release build). The previously-installed hook
+    /// stays active if validation fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` (via [`InferenceError::InvalidInput`]) when the hook's
+    /// own `validate_against` reports a rank, dimension, or layer-index
+    /// mismatch against this model's geometry.
+    pub fn set_lora(
+        &mut self,
+        hook: Box<dyn crate::lora_hook::LoraHook>,
+    ) -> Result<(), InferenceError> {
+        hook.validate_against(&self.config)
+            .map_err(InferenceError::InvalidInput)?;
         self.lora = hook;
+        Ok(())
     }
 
     /// **Unstable**: access raw model weights.

--- a/crates/inference/src/model/qwen35/tests.rs
+++ b/crates/inference/src/model/qwen35/tests.rs
@@ -617,9 +617,11 @@ mod lora_serving {
         let mut model = build_model(cfg.clone(), 0xA11C_E5ED);
 
         let calls = Arc::new(Mutex::new(Vec::new()));
-        model.set_lora(Box::new(SpyHook {
-            calls: Arc::clone(&calls),
-        }));
+        model
+            .set_lora(Box::new(SpyHook {
+                calls: Arc::clone(&calls),
+            }))
+            .expect("SpyHook has no shape declaration; default validate_against always passes");
 
         let (mut gdn, mut kv, mut scratch) = fresh_state(&cfg);
         model.forward_step(1, 0, &mut gdn, &mut kv, &mut scratch);
@@ -698,7 +700,9 @@ mod lora_serving {
 
         // Two NoopLoraHook runs must be bit-identical — this establishes that any
         // difference below is provably caused by the adapter, not nondeterminism.
-        model.set_lora(Box::new(NoopLoraHook));
+        model
+            .set_lora(Box::new(NoopLoraHook))
+            .expect("NoopLoraHook always validates");
         let baseline_a = run(&model);
         let baseline_b = run(&model);
         assert_eq!(
@@ -707,11 +711,13 @@ mod lora_serving {
         );
 
         // An adapter targeting a real projection must move the logits.
-        model.set_lora(Box::new(DeltaHook {
-            layer: 3,
-            module: "q_proj",
-            delta: 0.5,
-        }));
+        model
+            .set_lora(Box::new(DeltaHook {
+                layer: 3,
+                module: "q_proj",
+                delta: 0.5,
+            }))
+            .expect("DeltaHook has no shape declaration; default validate_against always passes");
         let adapted = run(&model);
         assert_ne!(
             adapted, baseline_a,
@@ -720,16 +726,59 @@ mod lora_serving {
 
         // An adapter keyed to a non-existent (layer, module) must be a no-op —
         // confirms forward_step only dispatches the hook to real projections.
-        model.set_lora(Box::new(DeltaHook {
-            layer: 999,
-            module: "q_proj",
-            delta: 0.5,
-        }));
+        model
+            .set_lora(Box::new(DeltaHook {
+                layer: 999,
+                module: "q_proj",
+                delta: 0.5,
+            }))
+            .expect("DeltaHook has no shape declaration; default validate_against always passes");
         let unmatched = run(&model);
         assert_eq!(
             unmatched, baseline_a,
             "an adapter keyed to a non-existent layer must not affect output"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // set_lora shape/rank validation (issue #753)
+    // ---------------------------------------------------------------------------
+
+    /// A hook whose `validate_against` always fails, and whose `apply` panics
+    /// if it is ever invoked — standing in for a real adapter whose declared
+    /// rank/shape doesn't match the model.
+    struct RejectingHook;
+    impl LoraHook for RejectingHook {
+        fn apply(&self, _layer_idx: usize, _module: &str, _x: &[f32], _output: &mut [f32]) {
+            panic!(
+                "RejectingHook::apply must never run — set_lora should have \
+                 rejected this hook via validate_against before installing it"
+            );
+        }
+        fn validate_against(&self, _config: &Qwen35Config) -> Result<(), String> {
+            Err("synthetic shape mismatch".to_string())
+        }
+    }
+
+    /// `set_lora` must call the hook's `validate_against` before installing
+    /// it: a hook that fails validation must be rejected (`Err`) and must
+    /// never become the active hook, so it can never have `apply` called on
+    /// it during a later `forward_step`.
+    #[test]
+    fn set_lora_rejects_hook_that_fails_validation() {
+        let cfg = test_config();
+        let mut model = build_model(cfg.clone(), 0x5EED_0753);
+
+        let result = model.set_lora(Box::new(RejectingHook));
+        assert!(
+            result.is_err(),
+            "set_lora must reject a hook whose validate_against fails"
+        );
+
+        // If RejectingHook had been installed anyway, this would panic inside
+        // its `apply` — proving the rejected hook never becomes active.
+        let (mut gdn, mut kv, mut scratch) = fresh_state(&cfg);
+        model.forward_step(1, 0, &mut gdn, &mut kv, &mut scratch);
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/tune/src/bin/generate_lora.rs
+++ b/crates/tune/src/bin/generate_lora.rs
@@ -123,7 +123,10 @@ fn main() {
                     adapter.config().scale(),
                     adapter.num_parameters()
                 );
-                model.set_lora(Box::new(adapter));
+                if let Err(e) = model.set_lora(Box::new(adapter)) {
+                    eprintln!("LoRA adapter incompatible with loaded model: {e}");
+                    std::process::exit(1);
+                }
                 println!(
                     "  LoRA active (loaded in {}ms)",
                     t_lora.elapsed().as_millis()

--- a/crates/tune/src/lora/blend.rs
+++ b/crates/tune/src/lora/blend.rs
@@ -463,15 +463,18 @@ mod tests {
                 rank,
             },
         );
-        let adapter = LoraAdapter::new(
-            LoraConfig {
+        // Bypasses `LoraAdapter::new` (which now itself rejects this exact
+        // shape) via a direct struct literal — privacy allows it since this
+        // module is a descendant of `lora` — to exercise blend's own
+        // defense-in-depth check on a malformed adapter.
+        let adapter = LoraAdapter {
+            config: LoraConfig {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        )
-        .expect("valid adapter config");
+        };
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
         assert!(
             result.is_err(),
@@ -501,15 +504,16 @@ mod tests {
                 rank,
             },
         );
-        let adapter = LoraAdapter::new(
-            LoraConfig {
+        // Bypasses `LoraAdapter::new` (see the mirrored A-length test above)
+        // to exercise blend's own defense-in-depth check.
+        let adapter = LoraAdapter {
+            config: LoraConfig {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        )
-        .expect("valid adapter config");
+        };
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
         assert!(
             result.is_err(),
@@ -649,15 +653,16 @@ mod tests {
                 rank,
             },
         );
-        let adapter = LoraAdapter::new(
-            LoraConfig {
+        // Bypasses `LoraAdapter::new` (see the mismatched-length tests above)
+        // to exercise blend's own overflow guard on a malformed adapter.
+        let adapter = LoraAdapter {
+            config: LoraConfig {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        )
-        .expect("valid adapter config");
+        };
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
         // The pre-pass catches the overflow in rank_total*(d_in+d_out); the
         // per-entry checked_mul is defense-in-depth for the same class.
@@ -729,15 +734,17 @@ mod tests {
                 },
             );
         }
-        let adapter = LoraAdapter::new(
-            LoraConfig {
+        // Bypasses `LoraAdapter::new` (see the mismatched-length tests above)
+        // to exercise blend's own aggregate-budget guard on an adapter whose
+        // declared shapes alone (no real buffers) would blow the budget.
+        let adapter = LoraAdapter {
+            config: LoraConfig {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["q_proj".into()],
             },
             layers,
-        )
-        .expect("valid adapter config");
+        };
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
         assert!(result.is_err(), "aggregate budget exceeded must return Err");
         let msg = result.unwrap_err().to_string();

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -145,14 +145,66 @@ impl LoraAdapter {
     /// Construct an adapter from pre-built components (for testing or
     /// when loading from a custom format).
     ///
+    /// Every non-empty layer's `a`/`b` buffers must be sized exactly
+    /// `rank * d_in` and `d_out * rank` (the layout `apply_lora` indexes
+    /// into); a layer with an empty `a` or `b` is an untrained/placeholder
+    /// module and is exempt (mirrors `save_peft_safetensors`, which skips
+    /// the same layers). This is the single construction chokepoint
+    /// (safetensors loading, blending, and training all route through it),
+    /// so downstream code — including
+    /// [`validate_against`](Self::validate_against) and `apply` — can rely
+    /// on the invariant without re-checking it.
+    ///
     /// # Errors
     ///
-    /// Returns an error when the adapter configuration is invalid.
+    /// Returns an error when the adapter configuration is invalid, or when
+    /// any non-empty layer's `a`/`b` buffer length doesn't match its own
+    /// declared `rank`/`d_in`/`d_out`.
     pub fn new(
         config: LoraConfig,
         layers: HashMap<(usize, String), LoraLayer>,
     ) -> crate::error::Result<Self> {
         config.validate()?;
+        for ((layer_idx, module), layer) in &layers {
+            // An empty `a` or `b` denotes an untrained/not-yet-populated
+            // module (see `save_peft_safetensors`, which skips these the
+            // same way) and is exempt from the buffer/rank check below.
+            if layer.a.is_empty() || layer.b.is_empty() {
+                continue;
+            }
+            let expected_a = layer.rank.checked_mul(layer.d_in).ok_or_else(|| {
+                crate::error::TuneError::Validation(format!(
+                    "LoRA layer {layer_idx} module '{module}': rank*d_in overflowed usize \
+                     (rank={}, d_in={})",
+                    layer.rank, layer.d_in
+                ))
+            })?;
+            if layer.a.len() != expected_a {
+                return Err(crate::error::TuneError::Validation(format!(
+                    "LoRA layer {layer_idx} module '{module}': A buffer length {} does not \
+                     match rank*d_in={expected_a} (rank={}, d_in={})",
+                    layer.a.len(),
+                    layer.rank,
+                    layer.d_in
+                )));
+            }
+            let expected_b = layer.d_out.checked_mul(layer.rank).ok_or_else(|| {
+                crate::error::TuneError::Validation(format!(
+                    "LoRA layer {layer_idx} module '{module}': d_out*rank overflowed usize \
+                     (d_out={}, rank={})",
+                    layer.d_out, layer.rank
+                ))
+            })?;
+            if layer.b.len() != expected_b {
+                return Err(crate::error::TuneError::Validation(format!(
+                    "LoRA layer {layer_idx} module '{module}': B buffer length {} does not \
+                     match d_out*rank={expected_b} (d_out={}, rank={})",
+                    layer.b.len(),
+                    layer.d_out,
+                    layer.rank
+                )));
+            }
+        }
         Ok(Self { config, layers })
     }
 
@@ -216,6 +268,11 @@ impl LoraAdapter {
     /// Call it after loading and before
     /// [`set_lora`](lattice_inference::model::qwen35::Qwen35Model::set_lora).
     /// See [`docs/lora-core.md`](../../docs/lora-core.md#adapter-validation) for projection shape rules.
+    ///
+    /// Per-layer `a`/`b` buffer lengths are not re-checked here: [`Self::new`]
+    /// already rejects any layer whose buffers don't match its own
+    /// `rank`/`d_in`/`d_out`, and it's the only way to construct a
+    /// `LoraAdapter`, so every instance already satisfies that invariant.
     pub fn validate_against(
         &self,
         config: &lattice_inference::model::qwen35_config::Qwen35Config,
@@ -473,6 +530,57 @@ mod tests {
         assert!(unknown.is_empty());
     }
 
+    /// Regression for the #972 follow-up finding: a layer with *correct*
+    /// `d_in`/`d_out` (what `validate_against` checked before this fix) but
+    /// a short `a` buffer must still be rejected at construction, not admitted
+    /// to later panic (slice-out-of-bounds) inside `apply_lora`.
+    #[test]
+    fn test_new_rejects_a_buffer_shorter_than_rank_times_d_in() {
+        let config = LoraConfig {
+            rank: 4,
+            alpha: 4.0,
+            target_modules: vec!["q_proj".into()],
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![0.0; 4 * 8 - 1], // one element short of rank(4) * d_in(8)
+                b: vec![0.0; 8 * 4],
+                d_in: 8,
+                d_out: 8,
+                rank: 4,
+            },
+        );
+        let err = LoraAdapter::new(config, layers)
+            .expect_err("A buffer shorter than rank*d_in must be rejected");
+        assert!(err.to_string().contains("A buffer length"));
+    }
+
+    /// Same as above for `b`, the other operand `apply_lora` slices by rank.
+    #[test]
+    fn test_new_rejects_b_buffer_longer_than_d_out_times_rank() {
+        let config = LoraConfig {
+            rank: 4,
+            alpha: 4.0,
+            target_modules: vec!["q_proj".into()],
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![0.0; 4 * 8],
+                b: vec![0.0; 8 * 4 + 3], // padded beyond d_out(8) * rank(4)
+                d_in: 8,
+                d_out: 8,
+                rank: 4,
+            },
+        );
+        let err = LoraAdapter::new(config, layers)
+            .expect_err("B buffer longer than d_out*rank must be rejected");
+        assert!(err.to_string().contains("B buffer length"));
+    }
+
     #[cfg(feature = "inference-hook")]
     mod validate_against_tests {
         use super::*;
@@ -671,6 +779,51 @@ mod tests {
                 LoraHook::validate_against(&matching, &cfg).is_ok(),
                 "the LoraHook trait method must accept an adapter with correct dims"
             );
+        }
+
+        /// Regression for the #972 follow-up finding: a layer whose
+        /// projection dims exactly match a real Qwen3.5 model's `q_proj`
+        /// (the only thing `validate_against` checked before this fix) but
+        /// whose `a` buffer is short must be rejected before it can ever
+        /// reach `validate_against` (and hence `Qwen35Model::set_lora`,
+        /// which calls it — see `test_lora_hook_trait_validate_against_delegates_to_inherent_method`
+        /// above). `LoraAdapter::new` is the sole construction path, so
+        /// rejecting it there is equivalent to rejecting it at the
+        /// `set_lora` gate: the malformed adapter never becomes an
+        /// installable `LoraAdapter` value at all.
+        #[test]
+        fn test_new_rejects_malformed_buffer_matching_real_model_projection_dims() {
+            // Layer 3 is full-attention in `Qwen35Config::qwen35_0_8b()`;
+            // q_proj there expects d_in=hidden=1024, d_out=2*full_q_dim=4096
+            // (see `test_validate_against_correct_dims_passes` above).
+            let (layer_idx, module, d_in, d_out) = (3usize, "q_proj", 1024usize, 4096usize);
+            let rank = 4;
+
+            let config = LoraConfig {
+                rank,
+                alpha: rank as f32,
+                target_modules: vec![module.to_string()],
+            };
+            let mut layers = HashMap::new();
+            layers.insert(
+                (layer_idx, module.to_string()),
+                LoraLayer {
+                    a: vec![0.0; rank * d_in - 1], // one short of rank*d_in
+                    b: vec![0.0; d_out * rank],
+                    d_in,
+                    d_out,
+                    rank,
+                },
+            );
+
+            let err = LoraAdapter::new(config, layers).expect_err(
+                "a malformed A buffer must be rejected at construction, even when \
+                 d_in/d_out exactly match a real model's projection shape",
+            );
+            assert!(err.to_string().contains("A buffer length"));
+
+            // No `LoraAdapter` value exists to pass to `validate_against` or
+            // `set_lora` — construction itself is the gate here.
         }
     }
 }

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -270,6 +270,13 @@ impl lattice_inference::lora_hook::LoraHook for LoraAdapter {
         // Delegate to the existing apply method
         LoraAdapter::apply(self, layer_idx, module, x, output);
     }
+
+    fn validate_against(
+        &self,
+        config: &lattice_inference::model::qwen35_config::Qwen35Config,
+    ) -> Result<(), String> {
+        LoraAdapter::validate_against(self, config).map_err(|e| e.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -631,6 +638,38 @@ mod tests {
             assert!(
                 bad_a.validate_against(&cfg).is_err(),
                 "in_proj_a with key-head dim (16) must fail on a 16-key/48-value config"
+            );
+        }
+
+        /// Regression for #753: `Qwen35Model::set_lora` rejects a mismatched
+        /// adapter by calling through `dyn LoraHook::validate_against`, not
+        /// the inherent `LoraAdapter::validate_against`. This confirms the
+        /// trait-object glue (`impl LoraHook for LoraAdapter`) actually
+        /// delegates to the inherent method instead of defaulting to the
+        /// trait's no-op `Ok(())`, for both a mismatched and a matching
+        /// adapter.
+        #[test]
+        fn test_lora_hook_trait_validate_against_delegates_to_inherent_method() {
+            use lattice_inference::lora_hook::LoraHook;
+
+            let cfg = Qwen35Config::qwen35_0_8b();
+
+            // Same mismatch as `test_validate_against_dim_mismatch`: 2b dims
+            // supplied against the 0.8b config's expected q_proj shape.
+            // Fully-qualified syntax forces dispatch through the trait method
+            // (not `LoraAdapter`'s own inherent `validate_against`, which dot
+            // syntax would otherwise prefer).
+            let mismatched = make_adapter_for_layer(3, "q_proj", 2048, 8192);
+            assert!(
+                LoraHook::validate_against(&mismatched, &cfg).is_err(),
+                "the LoraHook trait method must surface the same dim mismatch as \
+                 the inherent LoraAdapter::validate_against"
+            );
+
+            let matching = make_adapter_for_layer(3, "q_proj", 1024, 4096);
+            assert!(
+                LoraHook::validate_against(&matching, &cfg).is_ok(),
+                "the LoraHook trait method must accept an adapter with correct dims"
             );
         }
     }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Defect (#753)
`Qwen35Model::set_lora` stored any `dyn LoraHook` with zero rank/dim/layer-index validation, so a mismatched adapter silently corrupted a projection output prefix (or panicked past a `debug_assert` in release). Metal's attach path and the manifest loader already hard-check geometry; the CPU setter did not.

## Fix
- Add a **default-noop** `LoraHook::validate_against(&Qwen35Config) -> Result<(), String>` to the trait — backward compatible; existing hooks trust the caller unchanged.
- `set_lora` now calls it before swapping the hook in, returns `Result<(), InferenceError>`, and **keeps the previously-installed hook** if validation fails.
- `LoraAdapter` overrides `validate_against` to delegate to its existing inherent method.

## Sibling call sites (breaking signature change — all handled)
Grepped every `.set_lora(` in the repo: 1 binary caller (`generate_lora` — now `eprintln!` + `exit(1)` on mismatch) + 4 test call sites (updated to handle the `Result`). No unhandled caller remains.

## Mutation-sensitivity
The regression test uses fully-qualified `LoraHook::validate_against(&adapter, &cfg)` to force dispatch through the **trait** method. If the `impl LoraHook for LoraAdapter` delegation glue is removed, dispatch falls back to the trait's no-op default `Ok(())` and the `is_err()` assertion fails.

## Gates
Local pre-commit ran a full `cargo check` over the workspace (compiled clean, 3m18s), doc-lint, and capability-matrix — all passed. Not a decode/prefill/GEMM hot path, so no `bench-compare` required. Draft — do not merge until CI green.

Closes #753