### PR TITLE
feat(serve): add /metrics Prometheus endpoint to lattice_serve

### DIFF
--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -23,6 +23,10 @@
 //! - `POST /v1/chat/completions` — streaming (SSE) and non-streaming, OpenAI shape
 //! - `GET  /v1/models`           — advertises the single loaded model
 //! - `GET  /health`              — liveness probe (`ok`)
+//! - `GET  /metrics`             — Prometheus text-format metrics (issue #583):
+//!   request count + latency histogram by route/status, prompt/completion
+//!   token counters, error count by code, queue-depth/in-flight gauge, all
+//!   labeled with the loaded model id
 //!
 //! # Design
 //!
@@ -79,6 +83,7 @@ mod imp {
         ContextWindowPolicy, MetalWorker, MetalWorkerClient, StartupError, WorkerEvent,
         WorkerMetadata,
     };
+    use lattice_inference::serve::metrics::ServeMetrics;
     /// Only used by the test module's `.tokenize(..)` calls on a real (tiny)
     /// tokenizer; production code never tokenizes outside the shared worker
     /// (`lattice_inference::serve::metal_worker`), hence the test feature gate.
@@ -152,6 +157,15 @@ mod imp {
         /// exact KV cache length `load_model` allocated, never a hard-coded
         /// constant. See `model_context_from_config` and `build_cfg`.
         model_max_context: usize,
+        /// The shared worker's outstanding-job admission cap (issue #932),
+        /// needed alongside `jobs.available_permits()` to compute the
+        /// `/metrics` (#583) queue-depth/in-flight gauge as `max_pending -
+        /// available_permits()`.
+        max_pending: usize,
+        /// Process-wide Prometheus metrics registry (#583), `Arc`-shared so
+        /// every clone of `AppState` (one per request) records into the same
+        /// counters.
+        metrics: Arc<ServeMetrics>,
     }
 
     // ─── OpenAI request shapes ───────────────────────────────────────────────
@@ -1025,31 +1039,37 @@ mod imp {
 
     // ─── HTTP handlers ───────────────────────────────────────────────────────
 
-    async fn health() -> &'static str {
+    async fn health(State(s): State<AppState>) -> &'static str {
         let t = Instant::now();
         emit_serve_event(
+            &s.metrics,
             "GET",
             "/health",
             200,
             None,
+            None,
             t.elapsed().as_secs_f64() * 1000.0,
             false,
+            None,
         );
         "ok"
     }
 
-    async fn root() -> Json<Value> {
+    async fn root(State(s): State<AppState>) -> Json<Value> {
         let t = Instant::now();
         // ADR-080 C2: shared with lattice.rs's equivalent route so
         // both binaries advertise the same engine-identity document.
         let body = lattice_inference::serve::root_body();
         emit_serve_event(
+            &s.metrics,
             "GET",
             "/",
             200,
             None,
+            None,
             t.elapsed().as_secs_f64() * 1000.0,
             false,
+            None,
         );
         Json(body)
     }
@@ -1060,36 +1080,63 @@ mod imp {
         // binaries advertise the single loaded model in byte-identical shape.
         let body = lattice_inference::serve::models_list_body(s.model_id.as_ref(), unix_secs());
         emit_serve_event(
+            &s.metrics,
             "GET",
             "/v1/models",
             200,
             None,
+            None,
             t.elapsed().as_secs_f64() * 1000.0,
             false,
+            None,
         );
         Json(body)
     }
 
+    /// `GET /metrics` (issue #583): Prometheus text-exposition-format
+    /// metrics for this server -- request counts/latency by route+status,
+    /// prompt/completion token counters, error counts by code (all labeled
+    /// with the loaded model id), and a live queue-depth/in-flight gauge
+    /// read directly off the shared worker's admission semaphore (issue
+    /// #932's cap), not a separately-tracked counter that could drift from
+    /// the real admission state.
+    async fn metrics_handler(State(s): State<AppState>) -> impl IntoResponse {
+        let in_flight = s.max_pending.saturating_sub(s.jobs.available_permits());
+        let body = s.metrics.render(s.model_id.as_ref(), in_flight);
+        (
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "text/plain; version=0.0.4; charset=utf-8",
+            )],
+            body,
+        )
+    }
+
     /// Phase machine for the SSE token stream.
-    /// `Body`, `Done`, and `End` carry the completion token count so failure
-    /// paths preserve the deltas emitted before the worker failed.
+    /// `Body`, `Done`, and `End` carry the (completion_tokens, prompt_tokens)
+    /// pair so failure paths preserve the deltas emitted before the worker
+    /// failed, and `/metrics` (issue #583) gets prompt-token counts even for
+    /// streaming responses.
     enum Phase {
         Start,
         Body(usize),
-        Done(usize), // holds completion_tokens from worker
-        End(usize),  // holds completion_tokens; emits telemetry then stream ends
+        Done(usize, usize), // completion_tokens, prompt_tokens
+        End(usize, usize),  // completion_tokens, prompt_tokens; emits telemetry then stream ends
     }
 
     async fn chat_completions(State(s): State<AppState>, body: Body) -> Response {
         let timer = Instant::now();
         let Ok(body) = to_bytes(body, REQUEST_BODY_LIMIT_BYTES).await else {
             emit_serve_event(
+                &s.metrics,
                 "POST",
                 "/v1/chat/completions",
                 413,
                 None,
+                None,
                 timer.elapsed().as_secs_f64() * 1000.0,
                 false,
+                Some("request_body_too_large"),
             );
             // ADR-080 C2: previously mapped to
             // HTTP 400 + generic "invalid_request", diverging from
@@ -1105,24 +1152,30 @@ mod imp {
             Ok(req) => req,
             Err(err) => {
                 emit_serve_event(
+                    &s.metrics,
                     "POST",
                     "/v1/chat/completions",
                     400,
                     None,
+                    None,
                     timer.elapsed().as_secs_f64() * 1000.0,
                     false,
+                    Some(err.code()),
                 );
                 return err_response(StatusCode::BAD_REQUEST, err.message(), err.code());
             }
         };
         if let Err(err) = reject_unsupported(&req) {
             emit_serve_event(
+                &s.metrics,
                 "POST",
                 "/v1/chat/completions",
                 400,
                 None,
+                None,
                 timer.elapsed().as_secs_f64() * 1000.0,
                 false,
+                Some(err.code()),
             );
             return err_response(StatusCode::BAD_REQUEST, err.message(), err.code());
         }
@@ -1130,12 +1183,15 @@ mod imp {
             && requested_model != s.model_id.as_ref()
         {
             emit_serve_event(
+                &s.metrics,
                 "POST",
                 "/v1/chat/completions",
                 400,
                 None,
+                None,
                 timer.elapsed().as_secs_f64() * 1000.0,
                 false,
+                Some("model_not_found"),
             );
             return err_response(
                 StatusCode::BAD_REQUEST,
@@ -1148,12 +1204,15 @@ mod imp {
         }
         if req.messages.is_empty() {
             emit_serve_event(
+                &s.metrics,
                 "POST",
                 "/v1/chat/completions",
                 400,
                 None,
+                None,
                 timer.elapsed().as_secs_f64() * 1000.0,
                 false,
+                Some("invalid_messages"),
             );
             // Matches lattice.rs's `validate_chat_request` code for the
             // identical empty-messages condition (ADR-080 C2).
@@ -1168,12 +1227,15 @@ mod imp {
             Ok(messages) => messages,
             Err(err) => {
                 emit_serve_event(
+                    &s.metrics,
                     "POST",
                     "/v1/chat/completions",
                     400,
                     None,
+                    None,
                     timer.elapsed().as_secs_f64() * 1000.0,
                     false,
+                    Some(err.code()),
                 );
                 return err_response(StatusCode::BAD_REQUEST, err.message(), err.code());
             }
@@ -1182,12 +1244,15 @@ mod imp {
             Ok(cfg) => cfg,
             Err(err) => {
                 emit_serve_event(
+                    &s.metrics,
                     "POST",
                     "/v1/chat/completions",
                     400,
                     None,
+                    None,
                     timer.elapsed().as_secs_f64() * 1000.0,
                     false,
+                    Some(err.code()),
                 );
                 // ADR-080 C2: `build_cfg` already
                 // returns the shared `lattice_inference::serve::ApiError`
@@ -1217,12 +1282,15 @@ mod imp {
             Ok(rx) => rx,
             Err(api_err) => {
                 emit_serve_event(
+                    &s.metrics,
                     "POST",
                     "/v1/chat/completions",
                     503,
                     None,
+                    None,
                     timer.elapsed().as_secs_f64() * 1000.0,
                     false,
+                    Some(api_err.code()),
                 );
                 return api_err.into_response();
             }
@@ -1251,12 +1319,15 @@ mod imp {
             // state machine (`pending`) so it isn't silently dropped.
             let Some(first_ev) = rx.recv().await.map(normalize_cancelled) else {
                 emit_serve_event(
+                    &s.metrics,
                     "POST",
                     "/v1/chat/completions",
                     500,
                     None,
+                    None,
                     timer.elapsed().as_secs_f64() * 1000.0,
                     true,
+                    Some("internal_error"),
                 );
                 return err_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -1267,24 +1338,30 @@ mod imp {
             let first_ev = match first_ev {
                 WorkerEvent::Rejected(api_err) => {
                     emit_serve_event(
+                        &s.metrics,
                         "POST",
                         "/v1/chat/completions",
                         400,
                         None,
+                        None,
                         timer.elapsed().as_secs_f64() * 1000.0,
                         true,
+                        Some(api_err.code()),
                     );
                     return api_err.into_response();
                 }
                 WorkerEvent::Failed(message) => {
                     eprintln!("generation error (streaming): {message}");
                     emit_serve_event(
+                        &s.metrics,
                         "POST",
                         "/v1/chat/completions",
                         500,
                         None,
+                        None,
                         timer.elapsed().as_secs_f64() * 1000.0,
                         true,
+                        Some("internal_error"),
                     );
                     return err_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
@@ -1297,9 +1374,10 @@ mod imp {
                     unreachable!("normalize_cancelled already rewrote Cancelled into Complete")
                 }
             };
+            let metrics = s.metrics.clone();
             let stream = futures::stream::unfold(
-                (rx, Phase::Start, cancel_guard, Some(first_ev)),
-                move |(mut rx, phase, cancel_guard, mut pending)| {
+                (rx, Phase::Start, cancel_guard, Some(first_ev), metrics),
+                move |(mut rx, phase, cancel_guard, mut pending, metrics)| {
                     let id = id.clone();
                     let model = model_id.clone();
                     async move {
@@ -1314,7 +1392,7 @@ mod imp {
                                     Ok::<Event, std::convert::Infallible>(
                                         Event::default().data(chunk.to_string()),
                                     ),
-                                    (rx, Phase::Body(0), cancel_guard, pending),
+                                    (rx, Phase::Body(0), cancel_guard, pending, metrics),
                                 ))
                             }
                             Phase::Body(completion_tokens) => match match pending.take() {
@@ -1336,6 +1414,7 @@ mod imp {
                                             Phase::Body(completion_tokens.saturating_add(1)),
                                             cancel_guard,
                                             None,
+                                            metrics,
                                         ),
                                     ))
                                 }
@@ -1357,9 +1436,13 @@ mod imp {
                                         Ok(Event::default().data(chunk.to_string())),
                                         (
                                             rx,
-                                            Phase::Done(output.generated_tokens),
+                                            Phase::Done(
+                                                output.generated_tokens,
+                                                output.prompt_tokens,
+                                            ),
                                             cancel_guard,
                                             None,
+                                            metrics,
                                         ),
                                     ))
                                 }
@@ -1383,7 +1466,13 @@ mod imp {
                                     });
                                     Some((
                                         Ok(Event::default().data(error.to_string())),
-                                        (rx, Phase::Done(completion_tokens), cancel_guard, None),
+                                        (
+                                            rx,
+                                            Phase::Done(completion_tokens, 0),
+                                            cancel_guard,
+                                            None,
+                                            metrics,
+                                        ),
                                     ))
                                 }
                                 Some(WorkerEvent::Rejected(api_err)) => {
@@ -1412,7 +1501,13 @@ mod imp {
                                     });
                                     Some((
                                         Ok(Event::default().data(error.to_string())),
-                                        (rx, Phase::Done(completion_tokens), cancel_guard, None),
+                                        (
+                                            rx,
+                                            Phase::Done(completion_tokens, 0),
+                                            cancel_guard,
+                                            None,
+                                            metrics,
+                                        ),
                                     ))
                                 }
                                 Some(WorkerEvent::Cancelled) => unreachable!(
@@ -1429,22 +1524,31 @@ mod imp {
                                     });
                                     Some((
                                         Ok(Event::default().data(error.to_string())),
-                                        (rx, Phase::Done(completion_tokens), cancel_guard, None),
+                                        (
+                                            rx,
+                                            Phase::Done(completion_tokens, 0),
+                                            cancel_guard,
+                                            None,
+                                            metrics,
+                                        ),
                                     ))
                                 }
                             },
-                            Phase::Done(ct) => Some((
+                            Phase::Done(ct, pt) => Some((
                                 Ok(Event::default().data("[DONE]")),
-                                (rx, Phase::End(ct), cancel_guard, None),
+                                (rx, Phase::End(ct, pt), cancel_guard, None, metrics),
                             )),
-                            Phase::End(ct) => {
+                            Phase::End(ct, pt) => {
                                 emit_serve_event(
+                                    &metrics,
                                     "POST",
                                     "/v1/chat/completions",
                                     200,
+                                    Some(pt),
                                     Some(ct),
                                     timer.elapsed().as_secs_f64() * 1000.0,
                                     true,
+                                    None,
                                 );
                                 None
                             }
@@ -1469,12 +1573,15 @@ mod imp {
             // 500 this binary has always returned for that condition.
             let Some(first_ev) = rx.recv().await.map(normalize_cancelled) else {
                 emit_serve_event(
+                    &s.metrics,
                     "POST",
                     "/v1/chat/completions",
                     500,
                     None,
+                    None,
                     timer.elapsed().as_secs_f64() * 1000.0,
                     false,
+                    Some("internal_error"),
                 );
                 return err_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -1507,12 +1614,15 @@ mod imp {
                         // contract the CPU/Metal handlers in `lattice.rs` use.
                         eprintln!("generation error: {message}");
                         emit_serve_event(
+                            &s.metrics,
                             "POST",
                             "/v1/chat/completions",
                             500,
                             None,
+                            None,
                             timer.elapsed().as_secs_f64() * 1000.0,
                             false,
+                            Some("internal_error"),
                         );
                         return err_response(
                             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1528,12 +1638,15 @@ mod imp {
                         // committed yet, so this surfaces as a real 400 with
                         // the specific reason, not a generic 500.
                         emit_serve_event(
+                            &s.metrics,
                             "POST",
                             "/v1/chat/completions",
                             400,
                             None,
+                            None,
                             timer.elapsed().as_secs_f64() * 1000.0,
                             false,
+                            Some(api_err.code()),
                         );
                         // Matches lattice.rs's `check_context_window` code
                         // for the analogous prompt-plus-budget-exceeds-window
@@ -1564,12 +1677,15 @@ mod imp {
                 },
             });
             emit_serve_event(
+                &s.metrics,
                 "POST",
                 "/v1/chat/completions",
                 200,
+                Some(prompt_tokens),
                 Some(completion_tokens),
                 timer.elapsed().as_secs_f64() * 1000.0,
                 false,
+                None,
             );
             Json(body).into_response()
         }
@@ -1610,15 +1726,29 @@ mod imp {
         api_err.into_response()
     }
 
-    /// Print a structured telemetry line to stdout for the app bridge to parse.
+    /// Prints a structured telemetry line to stdout for the app bridge to
+    /// parse, AND records the same observation into the process's
+    /// `/metrics` registry (issue #583) -- the single call site both
+    /// consumers (the stdout bridge, the Prometheus scrape endpoint) share,
+    /// so they can never observe a different request count for the same
+    /// traffic.
+    #[allow(clippy::too_many_arguments)]
     fn emit_serve_event(
+        metrics: &ServeMetrics,
         method: &str,
         route: &str,
         status: u16,
-        tokens: Option<usize>,
+        prompt_tokens: Option<usize>,
+        completion_tokens: Option<usize>,
         dur_ms: f64,
         stream: bool,
+        error_code: Option<&str>,
     ) {
+        metrics.record_request(method, route, status, dur_ms / 1000.0);
+        metrics.record_tokens(prompt_tokens.unwrap_or(0), completion_tokens.unwrap_or(0));
+        if let Some(code) = error_code {
+            metrics.record_error(code);
+        }
         println!(
             "@@lattice {}",
             json!({
@@ -1626,7 +1756,8 @@ mod imp {
                 "method": method,
                 "route": route,
                 "status": status,
-                "tokens": tokens,
+                "tokens": completion_tokens,
+                "prompt_tokens": prompt_tokens,
                 "dur_ms": dur_ms,
                 "stream": stream,
             })
@@ -1720,6 +1851,7 @@ mod imp {
             .route("/health", get(health))
             .route("/v1/models", get(list_models))
             .route("/v1/chat/completions", post(chat_completions))
+            .route("/metrics", get(metrics_handler))
             .with_state(state)
     }
 
@@ -1856,6 +1988,8 @@ mod imp {
             model_id,
             defaults,
             model_max_context,
+            max_pending,
+            metrics: Arc::new(ServeMetrics::default()),
         };
 
         let rt = tokio::runtime::Builder::new_multi_thread()
@@ -1868,7 +2002,9 @@ mod imp {
                 .await
                 .map_err(|e| format!("bind {addr} failed: {e}"))?;
             eprintln!("[lattice_serve] OpenAI-compatible API on http://{addr}/v1");
-            eprintln!("[lattice_serve]   POST /v1/chat/completions   GET /v1/models   GET /health");
+            eprintln!(
+                "[lattice_serve]   POST /v1/chat/completions   GET /v1/models   GET /health   GET /metrics"
+            );
             println!("@@lattice {}", json!({"ev": "ready", "port": port}));
             axum::serve(listener, app)
                 .await
@@ -1941,6 +2077,8 @@ mod imp {
                         reasoning_budget: None,
                     },
                     model_max_context: 4096,
+                    max_pending: 1_000_000,
+                    metrics: Arc::new(ServeMetrics::default()),
                 }
             }
             let (jobs, _rx) = test_client_and_jobs();
@@ -2215,6 +2353,8 @@ mod imp {
                     reasoning_budget: None,
                 },
                 model_max_context: 4096,
+                max_pending: 1_000_000,
+                metrics: Arc::new(ServeMetrics::default()),
             }
         }
 
@@ -2450,6 +2590,8 @@ mod imp {
                     reasoning_budget: None,
                 },
                 model_max_context: 4096,
+                max_pending: 1_000_000,
+                metrics: Arc::new(ServeMetrics::default()),
             };
             (state, jobs_rx)
         }
@@ -2503,6 +2645,75 @@ mod imp {
             // length-capped or cancelled completion was misreported as an
             // explicit stop condition (#746).
             assert_eq!(non_streaming_finish_reason_for(false).await, "length");
+        }
+
+        /// #583: `GET /metrics` must reflect REAL traffic recorded through
+        /// `emit_serve_event`, not a static template -- mutation check: if
+        /// `emit_serve_event` stops forwarding into `ServeMetrics` (or
+        /// `metrics_handler` stops rendering it), every assertion below
+        /// regresses to "0"/absent while the route itself would still
+        /// return 200, so this would NOT be caught by a route-existence
+        /// check alone.
+        #[cfg(all(feature = "metal-gpu", feature = "test-utils"))]
+        #[tokio::test]
+        async fn metrics_endpoint_reports_requests_tokens_and_errors() {
+            let (state, mut jobs_rx) = test_app_state_with_jobs();
+            tokio::spawn(async move {
+                if let Some(job) = jobs_rx.recv().await {
+                    let _ = job.reply(WorkerEvent::Complete(GenerateOutput {
+                        text: "hi".to_string(),
+                        token_ids: vec![0],
+                        prompt_tokens: 3,
+                        generated_tokens: 2,
+                        stopped: true,
+                        stop_reason: None,
+                        token_logprobs: vec![],
+                    }));
+                }
+            });
+            let ok_body =
+                Body::from(r#"{"messages":[{"role":"user","content":"hi"}]}"#.to_string());
+            let ok_response = chat_completions(State(state.clone()), ok_body).await;
+            assert_eq!(ok_response.status(), StatusCode::OK);
+
+            let bad_body = Body::from(r#"{"messages":[]}"#.to_string());
+            let bad_response = chat_completions(State(state.clone()), bad_body).await;
+            assert_eq!(bad_response.status(), StatusCode::BAD_REQUEST);
+
+            let _ = health(State(state.clone())).await;
+
+            let metrics_response = metrics_handler(State(state.clone())).await.into_response();
+            let bytes = axum::body::to_bytes(metrics_response.into_body(), usize::MAX)
+                .await
+                .expect("metrics body must be readable");
+            let body = String::from_utf8(bytes.to_vec()).expect("metrics body must be UTF-8");
+
+            assert!(
+                body.contains(
+                    "lattice_http_requests_total{method=\"POST\",route=\"/v1/chat/completions\",status=\"200\",model=\"test-model\"} 1"
+                ),
+                "missing successful chat_completions counter:\n{body}"
+            );
+            assert!(
+                body.contains(
+                    "lattice_http_requests_total{method=\"GET\",route=\"/health\",status=\"200\",model=\"test-model\"} 1"
+                ),
+                "missing health counter:\n{body}"
+            );
+            assert!(
+                body.contains("lattice_prompt_tokens_total{model=\"test-model\"} 3"),
+                "missing prompt token count:\n{body}"
+            );
+            assert!(
+                body.contains("lattice_completion_tokens_total{model=\"test-model\"} 2"),
+                "missing completion token count:\n{body}"
+            );
+            assert!(
+                body.contains(
+                    "lattice_errors_total{code=\"invalid_messages\",model=\"test-model\"} 1"
+                ),
+                "missing invalid_messages error count:\n{body}"
+            );
         }
 
         /// Same round-trip as above, but through the SSE streaming path
@@ -2756,6 +2967,8 @@ mod imp {
                         reasoning_budget: None,
                     },
                     model_max_context,
+                    max_pending: 1_000_000,
+                    metrics: Arc::new(ServeMetrics::default()),
                 }
             }
 
@@ -2858,6 +3071,8 @@ mod imp {
                         reasoning_budget: None,
                     },
                     model_max_context: 4096,
+                    max_pending: 1_000_000,
+                    metrics: Arc::new(ServeMetrics::default()),
                 };
                 (state, unblock_tx, started_rx)
             }
@@ -3091,6 +3306,8 @@ mod imp {
                         reasoning_budget: None,
                     },
                     model_max_context,
+                    max_pending: 1_000_000,
+                    metrics: Arc::new(ServeMetrics::default()),
                 }
             }
 
@@ -3281,6 +3498,8 @@ mod imp {
                         reasoning_budget: None,
                     },
                     model_max_context,
+                    max_pending: 1_000_000,
+                    metrics: Arc::new(ServeMetrics::default()),
                 };
                 let body = Body::from(
                     r#"{"messages":[{"role":"user","content":"hi there"}],"temperature":1.3,"top_p":0.55,"seed":7,"max_tokens":9}"#

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -1100,6 +1100,16 @@ mod imp {
     /// read directly off the shared worker's admission semaphore (issue
     /// #932's cap), not a separately-tracked counter that could drift from
     /// the real admission state.
+    ///
+    /// **Deployment boundary**: this endpoint has no authentication or
+    /// opt-in guard, matching every other route on this server (see
+    /// "Auth, rate limiting, and concurrency" in `docs/serve-http-api.md`).
+    /// Accepted as-is for the current local-first deployment model (this
+    /// server binds `127.0.0.1` by default), but `--host` can bind a
+    /// non-loopback address -- doing that exposes `/metrics` (request
+    /// volume/latency/error-rate shape) to anyone who can reach the
+    /// listening address. Do not bind `--host` to a non-loopback address
+    /// without an external auth layer (reverse proxy, firewall) in front.
     async fn metrics_handler(State(s): State<AppState>) -> impl IntoResponse {
         let in_flight = s.max_pending.saturating_sub(s.jobs.available_permits());
         let body = s.metrics.render(s.model_id.as_ref(), in_flight);
@@ -1116,12 +1126,20 @@ mod imp {
     /// `Body`, `Done`, and `End` carry the (completion_tokens, prompt_tokens)
     /// pair so failure paths preserve the deltas emitted before the worker
     /// failed, and `/metrics` (issue #583) gets prompt-token counts even for
-    /// streaming responses.
+    /// streaming responses. `Done`/`End` also carry an `error outcome`:
+    /// `None` for a clean `Complete`, `Some((status, code))` for a mid-stream
+    /// `Failed`/`Rejected`/worker-gone event -- the on-the-wire HTTP status
+    /// was already committed to 200 before streaming started and can't
+    /// change, but `Phase::End`'s `emit_serve_event` call uses this to
+    /// record the *true* logical status/error code, mirroring exactly what
+    /// the non-streaming branch below records for the same failure classes.
+    /// Without this, every failed stream was recorded as a successful 200
+    /// with no error code, so `lattice_errors_total` never counted them.
     enum Phase {
         Start,
         Body(usize),
-        Done(usize, usize), // completion_tokens, prompt_tokens
-        End(usize, usize),  // completion_tokens, prompt_tokens; emits telemetry then stream ends
+        Done(usize, usize, Option<(u16, &'static str)>), // completion_tokens, prompt_tokens, error outcome
+        End(usize, usize, Option<(u16, &'static str)>),  // same; emits telemetry then stream ends
     }
 
     async fn chat_completions(State(s): State<AppState>, body: Body) -> Response {
@@ -1439,6 +1457,7 @@ mod imp {
                                             Phase::Done(
                                                 output.generated_tokens,
                                                 output.prompt_tokens,
+                                                None,
                                             ),
                                             cancel_guard,
                                             None,
@@ -1468,7 +1487,13 @@ mod imp {
                                         Ok(Event::default().data(error.to_string())),
                                         (
                                             rx,
-                                            Phase::Done(completion_tokens, 0),
+                                            // Mirrors the non-streaming `Failed` arm's
+                                            // 500 + "internal_error" recording below.
+                                            Phase::Done(
+                                                completion_tokens,
+                                                0,
+                                                Some((500, "internal_error")),
+                                            ),
                                             cancel_guard,
                                             None,
                                             metrics,
@@ -1499,11 +1524,14 @@ mod imp {
                                             "param": null,
                                         }
                                     });
+                                    // Mirrors the non-streaming `Rejected` arm's
+                                    // 400 + `api_err.code()` recording below.
+                                    let error_outcome = Some((400, api_err.code()));
                                     Some((
                                         Ok(Event::default().data(error.to_string())),
                                         (
                                             rx,
-                                            Phase::Done(completion_tokens, 0),
+                                            Phase::Done(completion_tokens, 0, error_outcome),
                                             cancel_guard,
                                             None,
                                             metrics,
@@ -1522,11 +1550,18 @@ mod imp {
                                             "param": null,
                                         }
                                     });
+                                    // Mirrors this same file's non-streaming
+                                    // worker-unavailable preflight, which
+                                    // records 500 + "internal_error".
                                     Some((
                                         Ok(Event::default().data(error.to_string())),
                                         (
                                             rx,
-                                            Phase::Done(completion_tokens, 0),
+                                            Phase::Done(
+                                                completion_tokens,
+                                                0,
+                                                Some((500, "internal_error")),
+                                            ),
                                             cancel_guard,
                                             None,
                                             metrics,
@@ -1534,21 +1569,34 @@ mod imp {
                                     ))
                                 }
                             },
-                            Phase::Done(ct, pt) => Some((
+                            Phase::Done(ct, pt, outcome) => Some((
                                 Ok(Event::default().data("[DONE]")),
-                                (rx, Phase::End(ct, pt), cancel_guard, None, metrics),
+                                (rx, Phase::End(ct, pt, outcome), cancel_guard, None, metrics),
                             )),
-                            Phase::End(ct, pt) => {
+                            Phase::End(ct, pt, outcome) => {
+                                // `outcome` is the true logical result of the
+                                // stream: `None` for a clean `Complete`,
+                                // `Some((status, code))` when one of the
+                                // failure arms above ran. The wire status was
+                                // already committed to 200 SSE and cannot
+                                // change, but the RECORDED metric must
+                                // reflect what actually happened so
+                                // `lattice_errors_total` and the request
+                                // counter aren't lying about a failed stream.
+                                let (status, error_code) = match outcome {
+                                    Some((status, code)) => (status, Some(code)),
+                                    None => (200, None),
+                                };
                                 emit_serve_event(
                                     &metrics,
                                     "POST",
                                     "/v1/chat/completions",
-                                    200,
+                                    status,
                                     Some(pt),
                                     Some(ct),
                                     timer.elapsed().as_secs_f64() * 1000.0,
                                     true,
-                                    None,
+                                    error_code,
                                 );
                                 None
                             }
@@ -1871,6 +1919,18 @@ mod imp {
             .unwrap_or_else(|| model_dir.join("tokenizer.json"));
 
         let host = parse_arg(&args, "--host").unwrap_or_else(|| "127.0.0.1".to_string());
+        // `/metrics` (and every other route on this server) has no
+        // authentication -- fine for the local-first default (`127.0.0.1`),
+        // but a non-loopback `--host` exposes it to the network. Warn once
+        // at startup rather than silently doing so; see the deployment-
+        // boundary note on `metrics_handler` and `docs/serve-http-api.md`.
+        if host != "127.0.0.1" && host != "localhost" && host != "::1" {
+            eprintln!(
+                "[lattice_serve] WARNING: --host {host} is not loopback; /metrics and every \
+                 other route are unauthenticated -- do not expose this to an untrusted network \
+                 without an external auth layer (reverse proxy, firewall)."
+            );
+        }
         let port: u16 = parse_arg(&args, "--port")
             .and_then(|s| s.parse().ok())
             .or_else(|| {
@@ -2803,6 +2863,64 @@ mod imp {
             assert!(
                 !text.contains("\"finish_reason\":\"stop\""),
                 "generation failure must not masquerade as a clean stop; got: {text}"
+            );
+        }
+
+        /// Reviewer finding (b): a mid-stream `WorkerEvent::Failed` (or
+        /// `Rejected`/worker-gone) emits a client-facing SSE error event
+        /// (asserted above) but, before this fix, the terminal `Phase::End`
+        /// still recorded the request in `/metrics` as a plain 200 with no
+        /// error code -- `lattice_errors_total` never incremented for a
+        /// failed stream. Mutation-sensitive: reverting the `Phase::Done`/
+        /// `Phase::End` error-outcome threading (while keeping this test)
+        /// makes this fail, because the recorded counter reverts to
+        /// `status="200"` and `lattice_errors_total{code="internal_error"}`
+        /// stays absent.
+        #[cfg(all(feature = "metal-gpu", feature = "test-utils"))]
+        #[tokio::test]
+        async fn chat_completions_streaming_failure_records_failed_metric() {
+            let (state, mut jobs_rx) = test_app_state_with_jobs();
+            tokio::spawn(async move {
+                if let Some(job) = jobs_rx.recv().await {
+                    let _ = job.reply(WorkerEvent::Delta("partial".to_string()));
+                    let _ = job.reply(WorkerEvent::Failed("blocked by grammar".to_string()));
+                }
+            });
+            let body = Body::from(
+                r#"{"messages":[{"role":"user","content":"hi"}],"stream":true}"#.to_string(),
+            );
+            let response = chat_completions(State(state.clone()), body).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            // Drain the full SSE body so the stream runs to `Phase::End`,
+            // which is where the metric gets recorded.
+            let _ = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("SSE response body must be readable");
+
+            let metrics_response = metrics_handler(State(state.clone())).await.into_response();
+            let bytes = axum::body::to_bytes(metrics_response.into_body(), usize::MAX)
+                .await
+                .expect("metrics body must be readable");
+            let text = String::from_utf8(bytes.to_vec()).expect("metrics body must be UTF-8");
+
+            assert!(
+                !text.contains(
+                    "lattice_http_requests_total{method=\"POST\",route=\"/v1/chat/completions\",status=\"200\""
+                ),
+                "a failed stream must NOT be recorded as a 200; got:\n{text}"
+            );
+            assert!(
+                text.contains(
+                    "lattice_http_requests_total{method=\"POST\",route=\"/v1/chat/completions\",status=\"500\",model=\"test-model\"} 1"
+                ),
+                "failed stream must be recorded with the same 500 status the non-streaming \
+                 `Failed` arm records; got:\n{text}"
+            );
+            assert!(
+                text.contains(
+                    "lattice_errors_total{code=\"internal_error\",model=\"test-model\"} 1"
+                ),
+                "lattice_errors_total must increment for a failed stream; got:\n{text}"
             );
         }
 

--- a/crates/inference/src/serve/metal_worker.rs
+++ b/crates/inference/src/serve/metal_worker.rs
@@ -262,6 +262,17 @@ impl MetalWorkerClient {
         let _ = self.jobs.send(job);
         Ok(rx)
     }
+
+    /// Live snapshot of the admission semaphore's free slots (issue #932's
+    /// cap). `/metrics` (issue #583) computes queue depth / in-flight jobs
+    /// as `max_pending - available_permits()`: a permit is held from
+    /// `submit` until `run_worker_loop` is fully done with the job (see this
+    /// type's own doc comment above), so this reflects real outstanding
+    /// work rather than a separately-tracked counter that could drift from
+    /// the actual admission state.
+    pub fn available_permits(&self) -> usize {
+        self.admission.available_permits()
+    }
 }
 
 /// Adapter-selected KV-window invariant for Metal jobs (#656).

--- a/crates/inference/src/serve/metrics.rs
+++ b/crates/inference/src/serve/metrics.rs
@@ -1,0 +1,300 @@
+//! Minimal in-process Prometheus text-exposition-format metrics registry
+//! (issue #583). Deliberately dependency-free: `lattice_serve`'s HTTP
+//! surface exposes O(10) distinct series at a scrape interval measured in
+//! seconds, so a hand-rolled `HashMap<label-tuple, count>` behind a
+//! `std::sync::Mutex` is simpler to audit than pulling in the `prometheus`
+//! crate for this scope, and keeps this leaf-adjacent module free of a new
+//! external dependency.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Latency histogram bucket upper bounds, in seconds. Mirrors the default
+/// buckets most Prometheus client libraries ship, covering sub-millisecond
+/// health checks up to a generous worst-case generation request.
+const LATENCY_BUCKETS_SECONDS: [f64; 13] = [
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+];
+
+/// Per-route latency accumulator. `bucket_counts[i]` holds the number of
+/// observations that fell in `(LATENCY_BUCKETS_SECONDS[i - 1],
+/// LATENCY_BUCKETS_SECONDS[i]]` (or `(0, LATENCY_BUCKETS_SECONDS[0]]` for
+/// `i == 0`) -- NOT yet cumulative; [`ServeMetrics::render`] computes the
+/// running total Prometheus's `le` bucket semantics require. An observation
+/// exceeding every finite bucket bound increments no `bucket_counts` slot but
+/// still counts toward `count`/`sum_seconds`, which is exactly what the
+/// implicit `le="+Inf"` bucket must report.
+#[derive(Default)]
+struct RouteLatency {
+    bucket_counts: [u64; LATENCY_BUCKETS_SECONDS.len()],
+    sum_seconds: f64,
+    count: u64,
+}
+
+impl RouteLatency {
+    fn observe(&mut self, seconds: f64) {
+        self.sum_seconds += seconds;
+        self.count += 1;
+        for (i, bound) in LATENCY_BUCKETS_SECONDS.iter().enumerate() {
+            if seconds <= *bound {
+                self.bucket_counts[i] += 1;
+                break;
+            }
+        }
+    }
+}
+
+/// Process-wide metrics registry for one `lattice_serve` instance. Cheap to
+/// share: every field is a `Mutex`/atomic behind a shared reference, so
+/// callers hold this behind an `Arc` (see `AppState::metrics` in
+/// `lattice_serve.rs`) and every clone observes the same counters.
+#[derive(Default)]
+pub struct ServeMetrics {
+    /// (method, route, status) -> request count.
+    requests_total: Mutex<HashMap<(String, String, u16), u64>>,
+    /// route -> latency histogram.
+    route_latency: Mutex<HashMap<String, RouteLatency>>,
+    prompt_tokens_total: AtomicU64,
+    completion_tokens_total: AtomicU64,
+    /// OpenAI-style error code -> count.
+    errors_total: Mutex<HashMap<String, u64>>,
+}
+
+impl ServeMetrics {
+    /// Records one completed HTTP request: increments the (method, route,
+    /// status) counter and observes `dur_seconds` into that route's latency
+    /// histogram.
+    pub fn record_request(&self, method: &str, route: &str, status: u16, dur_seconds: f64) {
+        let mut requests = self
+            .requests_total
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *requests
+            .entry((method.to_string(), route.to_string(), status))
+            .or_insert(0) += 1;
+        drop(requests);
+
+        let mut latencies = self
+            .route_latency
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        latencies
+            .entry(route.to_string())
+            .or_default()
+            .observe(dur_seconds);
+    }
+
+    /// Adds to the prompt/completion token counters. A no-op call with both
+    /// zero (the common case for non-generation routes) is harmless.
+    pub fn record_tokens(&self, prompt_tokens: usize, completion_tokens: usize) {
+        if prompt_tokens > 0 {
+            self.prompt_tokens_total
+                .fetch_add(prompt_tokens as u64, Ordering::Relaxed);
+        }
+        if completion_tokens > 0 {
+            self.completion_tokens_total
+                .fetch_add(completion_tokens as u64, Ordering::Relaxed);
+        }
+    }
+
+    /// Increments the error counter for one OpenAI-style error `code`
+    /// (e.g. `"invalid_request"`, `"model_not_found"`, `"internal_error"`).
+    pub fn record_error(&self, code: &str) {
+        let mut errors = self
+            .errors_total
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *errors.entry(code.to_string()).or_insert(0) += 1;
+    }
+
+    /// Renders the full registry as Prometheus text-exposition format
+    /// (version 0.0.4), labeling every series with `model="<model_id>"` --
+    /// `lattice_serve` serves exactly one model per process, so a per-series
+    /// model label (rather than a metric-name suffix) keeps the series names
+    /// stable across model swaps and matches how most Prometheus exporters
+    /// attach instance-identifying labels. `in_flight` is a live snapshot
+    /// the caller computes from the shared worker's admission semaphore
+    /// (`MetalWorkerClient::available_permits`), not state owned by this
+    /// registry.
+    pub fn render(&self, model_id: &str, in_flight: usize) -> String {
+        let model = escape_label(model_id);
+        let mut out = String::new();
+
+        out.push_str(
+            "# HELP lattice_http_requests_total Total HTTP requests processed.\n\
+             # TYPE lattice_http_requests_total counter\n",
+        );
+        {
+            let requests = self
+                .requests_total
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut rows: Vec<_> = requests.iter().collect();
+            rows.sort();
+            for ((method, route, status), count) in rows {
+                out.push_str(&format!(
+                    "lattice_http_requests_total{{method=\"{}\",route=\"{}\",status=\"{status}\",model=\"{model}\"}} {count}\n",
+                    escape_label(method),
+                    escape_label(route),
+                ));
+            }
+        }
+
+        out.push_str(
+            "# HELP lattice_http_request_duration_seconds HTTP request latency in seconds.\n\
+             # TYPE lattice_http_request_duration_seconds histogram\n",
+        );
+        {
+            let latencies = self
+                .route_latency
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut rows: Vec<_> = latencies.iter().collect();
+            rows.sort_by(|a, b| a.0.cmp(b.0));
+            for (route, hist) in rows {
+                let route = escape_label(route);
+                let mut cumulative = 0u64;
+                for (bound, bucket_count) in LATENCY_BUCKETS_SECONDS.iter().zip(hist.bucket_counts)
+                {
+                    cumulative += bucket_count;
+                    out.push_str(&format!(
+                        "lattice_http_request_duration_seconds_bucket{{route=\"{route}\",model=\"{model}\",le=\"{bound}\"}} {cumulative}\n"
+                    ));
+                }
+                out.push_str(&format!(
+                    "lattice_http_request_duration_seconds_bucket{{route=\"{route}\",model=\"{model}\",le=\"+Inf\"}} {}\n",
+                    hist.count
+                ));
+                out.push_str(&format!(
+                    "lattice_http_request_duration_seconds_sum{{route=\"{route}\",model=\"{model}\"}} {}\n",
+                    hist.sum_seconds
+                ));
+                out.push_str(&format!(
+                    "lattice_http_request_duration_seconds_count{{route=\"{route}\",model=\"{model}\"}} {}\n",
+                    hist.count
+                ));
+            }
+        }
+
+        out.push_str(&format!(
+            "# HELP lattice_prompt_tokens_total Total prompt tokens processed.\n\
+             # TYPE lattice_prompt_tokens_total counter\n\
+             lattice_prompt_tokens_total{{model=\"{model}\"}} {}\n",
+            self.prompt_tokens_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(&format!(
+            "# HELP lattice_completion_tokens_total Total completion tokens generated.\n\
+             # TYPE lattice_completion_tokens_total counter\n\
+             lattice_completion_tokens_total{{model=\"{model}\"}} {}\n",
+            self.completion_tokens_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(&format!(
+            "# HELP lattice_inflight_requests Outstanding (queued + in-flight) requests on the shared worker.\n\
+             # TYPE lattice_inflight_requests gauge\n\
+             lattice_inflight_requests{{model=\"{model}\"}} {in_flight}\n"
+        ));
+
+        out.push_str(
+            "# HELP lattice_errors_total Total error responses, labeled by error code.\n\
+             # TYPE lattice_errors_total counter\n",
+        );
+        {
+            let errors = self
+                .errors_total
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut rows: Vec<_> = errors.iter().collect();
+            rows.sort();
+            for (code, count) in rows {
+                out.push_str(&format!(
+                    "lattice_errors_total{{code=\"{}\",model=\"{model}\"}} {count}\n",
+                    escape_label(code),
+                ));
+            }
+        }
+
+        out
+    }
+}
+
+/// Escapes a Prometheus label value per the text-exposition format: a
+/// backslash becomes `\\`, a double quote becomes `\"`, a newline becomes
+/// `\n`. Order matters -- backslash must be escaped first, or the
+/// backslashes this function inserts for `"`/`\n` would themselves be
+/// re-escaped.
+fn escape_label(raw: &str) -> String {
+    raw.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_request_increments_count_and_histogram() {
+        let metrics = ServeMetrics::default();
+        metrics.record_request("GET", "/health", 200, 0.001);
+        metrics.record_request("GET", "/health", 200, 0.002);
+        let body = metrics.render("test-model", 0);
+        assert!(body.contains(
+            "lattice_http_requests_total{method=\"GET\",route=\"/health\",status=\"200\",model=\"test-model\"} 2\n"
+        ));
+        assert!(body.contains(
+            "lattice_http_request_duration_seconds_count{route=\"/health\",model=\"test-model\"} 2\n"
+        ));
+    }
+
+    #[test]
+    fn record_tokens_accumulates_across_calls() {
+        let metrics = ServeMetrics::default();
+        metrics.record_tokens(10, 5);
+        metrics.record_tokens(3, 7);
+        let body = metrics.render("m", 0);
+        assert!(body.contains("lattice_prompt_tokens_total{model=\"m\"} 13\n"));
+        assert!(body.contains("lattice_completion_tokens_total{model=\"m\"} 12\n"));
+    }
+
+    #[test]
+    fn record_error_counts_by_code() {
+        let metrics = ServeMetrics::default();
+        metrics.record_error("invalid_request");
+        metrics.record_error("invalid_request");
+        metrics.record_error("internal_error");
+        let body = metrics.render("m", 0);
+        assert!(body.contains("lattice_errors_total{code=\"internal_error\",model=\"m\"} 1\n"));
+        assert!(body.contains("lattice_errors_total{code=\"invalid_request\",model=\"m\"} 2\n"));
+    }
+
+    #[test]
+    fn in_flight_gauge_reflects_caller_supplied_snapshot() {
+        let metrics = ServeMetrics::default();
+        let body = metrics.render("m", 3);
+        assert!(body.contains("lattice_inflight_requests{model=\"m\"} 3\n"));
+    }
+
+    #[test]
+    fn latency_bucket_cumulative_counts_are_monotonic() {
+        let metrics = ServeMetrics::default();
+        metrics.record_request("POST", "/v1/chat/completions", 200, 0.01);
+        metrics.record_request("POST", "/v1/chat/completions", 200, 5.0);
+        let body = metrics.render("m", 0);
+        // Bucket le="0.025" (>= the 0.01 observation, < the 5.0 one) must
+        // read 1; le="+Inf" (== total count) must read 2.
+        assert!(body.contains(
+            "lattice_http_request_duration_seconds_bucket{route=\"/v1/chat/completions\",model=\"m\",le=\"0.025\"} 1\n"
+        ));
+        assert!(body.contains(
+            "lattice_http_request_duration_seconds_bucket{route=\"/v1/chat/completions\",model=\"m\",le=\"+Inf\"} 2\n"
+        ));
+    }
+
+    #[test]
+    fn label_escaping_handles_special_characters() {
+        assert_eq!(escape_label("a\"b\\c\nd"), "a\\\"b\\\\c\\nd");
+    }
+}

--- a/crates/inference/src/serve/mod.rs
+++ b/crates/inference/src/serve/mod.rs
@@ -32,6 +32,12 @@ use crate::model::qwen35_config::GenerateConfig;
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub mod metal_worker;
 
+/// In-process Prometheus text-format metrics registry (issue #583), shared
+/// by any binary that calls [`metrics::ServeMetrics`]'s recording methods
+/// from its own request-completion hook (currently `lattice_serve.rs`'s
+/// `emit_serve_event`).
+pub mod metrics;
+
 /// Request body size cap shared by both HTTP servers: 1 MiB. Both binaries
 /// already enforced this exact limit independently (`lattice.rs` via
 /// `DefaultBodyLimit::max`, `lattice_serve.rs` via `to_bytes(body, LIMIT)`);
@@ -92,6 +98,20 @@ impl ApiError {
             ApiError::PayloadTooLarge { message } => message,
             ApiError::Internal { message } => message,
             ApiError::ServiceUnavailable { message } => message,
+        }
+    }
+
+    /// The OpenAI-style error code, regardless of variant -- mirrors exactly
+    /// the string each variant's `IntoResponse` impl below serializes as
+    /// `error.code`, so a caller recording metrics from this accessor (issue
+    /// #583's `/metrics` error-count-by-code series) always matches what the
+    /// client actually observed in the response body.
+    pub fn code(&self) -> &'static str {
+        match self {
+            ApiError::BadRequest { code, .. } => code,
+            ApiError::PayloadTooLarge { .. } => "request_body_too_large",
+            ApiError::Internal { .. } => "internal_error",
+            ApiError::ServiceUnavailable { .. } => "server_busy",
         }
     }
 }

--- a/docs/serve-http-api.md
+++ b/docs/serve-http-api.md
@@ -19,10 +19,15 @@ This codebase has **two** separately built HTTP servers with confusingly similar
 - **`lattice_serve`** — a separate, standalone binary
   (`crates/inference/src/bin/lattice_serve.rs`), purpose-built as the internal HTTP daemon the
   macOS Lattice Studio app spawns and talks to (introduced in PR #435). It has its own, narrower
-  route set (`GET /`, `GET /health`, `GET /v1/models`, `POST /v1/chat/completions`) and its own
-  disconnect-cancellation behavior (PR #552/#606) that `lattice serve` does not have (see
-  "Streaming" below). It is not what the README's HTTP API section documents, and it is out of
-  scope for this document.
+  route set (`GET /`, `GET /health`, `GET /v1/models`, `POST /v1/chat/completions`, `GET /metrics`)
+  and its own disconnect-cancellation behavior (PR #552/#606) that `lattice serve` does not have
+  (see "Streaming" below). It is not what the README's HTTP API section documents, and it is out
+  of scope for this document -- with one exception worth flagging here: `lattice_serve`'s
+  `GET /metrics` (issue #583) carries the same "no authentication" posture described below for
+  `lattice serve`'s routes, and it is bound by the same `--host`/loopback-default rule. Do not
+  point `--host` at a non-loopback address for either binary without an external auth layer
+  (reverse proxy, firewall) in front -- `/metrics` exposes request volume/latency/error-rate shape
+  to anyone who can reach the listening address.
 
 If you arrived here from an issue or note that points at `lattice_serve.rs` specifically: the
 README's actual HTTP API example — the thing that issue was asking to be expanded — targets


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Defect / gap

`lattice_serve` advertised only `POST /v1/chat/completions`, `GET /v1/models`, and `GET /health` (endpoint list at `lattice_serve.rs:21-25`, router at `lattice_serve.rs:1846-1852`). Per-request telemetry existed via `emit_serve_event`, but it only printed a `@@lattice {...}` JSON line to stdout for the app bridge — there was no way to scrape throughput/latency/error data into a metrics backend for anyone running `lattice_serve` beyond an interactive session.

## Fix

- New `lattice_inference::serve::metrics::ServeMetrics` registry (dependency-free: a `HashMap<label, count>` behind `std::sync::Mutex` + a couple of atomics — this server exposes O(10) series scraped every few seconds, so it didn't need the `prometheus` crate). Renders Prometheus text-exposition format:
  - `lattice_http_requests_total{method,route,status,model}` — counter
  - `lattice_http_request_duration_seconds{route,model}` — histogram (standard-ish buckets, 5ms–60s)
  - `lattice_prompt_tokens_total{model}` / `lattice_completion_tokens_total{model}` — counters
  - `lattice_errors_total{code,model}` — counter, keyed by the same OpenAI-style error code the client sees in the response body
  - `lattice_inflight_requests{model}` — gauge
- `emit_serve_event` (the single per-request telemetry call site, already threaded through every response path in `chat_completions`/`health`/`root`/`list_models`) now forwards each observation into `ServeMetrics` in addition to printing the existing `@@lattice` stdout line, so the two consumers can never observe a different request count for the same traffic.
- The in-flight/queue-depth gauge is a **live read of the shared worker's admission semaphore** (`MetalWorkerClient::available_permits`, new method) computed as `max_pending - available_permits()` at scrape time — not a separately-tracked counter that could drift from the real admission state (the semaphore permit is already held from `submit` until `run_worker_loop` is fully done with the job, so this reflects genuinely outstanding work).
- Streaming responses previously only tracked `completion_tokens` through the SSE `Phase` state machine (`Phase::Done`/`Phase::End` carried one `usize`). Extended both variants to carry `(completion_tokens, prompt_tokens)` so `/metrics` gets prompt-token counts for streaming requests too, matching the non-streaming path.
- `ApiError` gained a `code()` accessor mirroring exactly the string each variant's `IntoResponse` impl already serializes as `error.code`, so error codes can be recorded without duplicating the per-variant mapping.
- `GET /metrics` documented in the binary's module doc comment (`# Endpoints`) and the startup banner.

## Sibling paths checked

`lattice.rs` (the other OpenAI-compatible server binary) has no `emit_serve_event` equivalent at all and is not mentioned in issue #583 (titled specifically for `lattice_serve`), so no sibling fix applies there. Grepped the crate for any other `println!("@@lattice"` telemetry call sites — `emit_serve_event` is the only one.

## Regression test

`metrics_endpoint_reports_requests_tokens_and_errors` (in `lattice_serve.rs`) drives a successful `chat_completions`, a 400 (empty `messages`), and a `health` check through the real handlers, then asserts the `/metrics` body reflects each: request counters by (method, route, status), prompt/completion token totals, and the `invalid_messages` error count.

**Verified mutation-sensitive**: commented out `emit_serve_event`'s three `metrics.record_*()` calls, `touch`ed the file to force a rebuild, and reran — the test failed (`missing successful chat_completions counter`) while the route itself still returned 200/400 as before, confirming the test actually exercises the metrics-recording wiring and not just route existence. Restored the calls and reran — 44/44 tests pass.

## Verification

```
cargo test -p lattice-inference --features f16,metal-gpu,serve,test-utils --bin lattice_serve
  → test result: ok. 44 passed; 0 failed
cargo clippy -p lattice-inference --features f16,metal-gpu,serve,test-utils -- -D warnings
  → clean
cargo fmt -p lattice-inference -- --check
  → clean
```

No GPU/Metal touched — this is HTTP-layer instrumentation only (no decode/prefill/GEMM path changed), so no `make bench-compare` is required.

Closes #583
