### PR TITLE
docs(transport): condense inline comments, extract background to crate docs

### DIFF
--- a/crates/transport/docs/INDEX.md
+++ b/crates/transport/docs/INDEX.md
@@ -6,3 +6,5 @@ the summary and public API surface; the files here hold the longer-form narrativ
 
 - [design.md](design.md) — architecture layers, the log-domain invariant and why it
   matters, workspace preallocation, and the no-external-linear-algebra constraint.
+- [algorithms.md](algorithms.md) — operational background for divergence, sparse
+  plans, barycenters, unbalanced transport, and online drift.

--- a/crates/transport/docs/algorithms.md
+++ b/crates/transport/docs/algorithms.md
@@ -1,0 +1,29 @@
+# lattice-transport algorithms
+
+This page collects operational background for transport APIs whose source-level
+documentation is deliberately brief.
+
+## Debiased divergence
+
+Entropy regularization gives optimal transport a non-zero self-cost. Sinkhorn
+divergence removes that bias by subtracting half of each self-interaction from
+the cross cost: `S(a, b) = W_eps(a, b) - 0.5 W_eps(a, a) - 0.5 W_eps(b, b)`.
+
+## Sparse plans
+
+The solver retains dual variables rather than a dense coupling. Sparse-plan
+extraction reconstructs only entries above a caller-selected mass threshold for
+inspection and per-record drift reporting.
+
+## Barycenters and unbalanced transport
+
+Fixed-support barycenters optimize weights over a common support; the
+free-support routine also relocates support points. Unbalanced Sinkhorn relaxes
+the marginal constraints with KL penalties when corpus weights need not match.
+
+## Online drift
+
+`OnlineDriftDetector` freezes its first full window as the reference, slides a
+current window over later observations, and evaluates divergence at the chosen
+sample interval. Its window-size cap limits the three square solver workspaces
+allocated for each detector.

--- a/crates/transport/src/barycenter.rs
+++ b/crates/transport/src/barycenter.rs
@@ -1,12 +1,6 @@
-//! Wasserstein barycenters.
+//! Wasserstein barycenters with fixed or Euclidean free support.
 //!
-//! The fixed-support solver is the workhorse for model-drift analysis across
-//! multiple embedding versions. The support points are fixed, only the
-//! barycenter weights are optimized. The optional free-support routine
-//! alternates between fixed-support weight updates and Euclidean support
-//! relocation.
-//!
-//! See: Cuturi & Doucet, "Fast Computation of Wasserstein Barycenters", ICML 2014.
+//! Extended background: <https://github.com/ohdearquant/lattice/blob/main/crates/transport/docs/algorithms.md>.
 
 use super::cost::{CostMatrix, DenseCostMatrix, SquaredEuclidean};
 use super::logsumexp::{OnlineLogSumExp, max_abs_diff, normalize_log_weights, safe_exp};
@@ -17,8 +11,6 @@ use super::sinkhorn::{
 };
 
 /// Configuration for barycenter computation.
-///
-/// **Unstable**: barycenter API is less mature; inner/outer iteration structure may change.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BarycenterConfig {
     /// Inner Sinkhorn solver configuration.
@@ -40,8 +32,6 @@ impl Default for BarycenterConfig {
 }
 
 /// A single source measure and the cost to the common barycenter support.
-///
-/// **Unstable**: input type for `fixed_support_barycenter`; may grow fields as multi-source API matures.
 pub struct BarycenterProblem<'a> {
     /// Cost matrix from this source to the barycenter support.
     pub cost: &'a dyn CostMatrix,
@@ -50,8 +40,6 @@ pub struct BarycenterProblem<'a> {
 }
 
 /// Workspace for fixed-support barycenter computation.
-///
-/// **Unstable**: internal buffer management type; field layout may change if warm-starting is added.
 #[derive(Debug, Clone)]
 pub struct FixedSupportBarycenterWorkspace {
     source_workspaces: Vec<SinkhornWorkspace>,
@@ -64,7 +52,6 @@ pub struct FixedSupportBarycenterWorkspace {
 impl FixedSupportBarycenterWorkspace {
     /// Create workspace for the given problems and support size.
     ///
-    /// **Unstable**: constructor matches struct stability.
     pub fn new(problems: &[BarycenterProblem<'_>], support_size: usize) -> Self {
         let mut source_workspaces = Vec::with_capacity(problems.len());
         let mut ku_logs = Vec::with_capacity(problems.len());
@@ -83,8 +70,6 @@ impl FixedSupportBarycenterWorkspace {
 }
 
 /// Result of a fixed-support barycenter computation.
-///
-/// **Unstable**: output type for `fixed_support_barycenter`; `source_results` field may be made optional for memory efficiency.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FixedSupportBarycenter {
     /// Barycenter weights on the support.
@@ -104,8 +89,6 @@ pub struct FixedSupportBarycenter {
 }
 
 /// Compute a fixed-support Wasserstein barycenter.
-///
-/// **Unstable**: core barycenter algorithm; `initial_weights` parameter may become a typed enum.
 pub fn fixed_support_barycenter(
     problems: &[BarycenterProblem<'_>],
     combination_weights: &[f32],
@@ -243,8 +226,6 @@ pub fn fixed_support_barycenter(
 }
 
 /// Owned measure used by the free-support routine.
-///
-/// **Unstable**: input type for `free_support_barycenter`; may be replaced by a borrowed view when lifetimes are cleaner.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OwnedPointMeasure {
     /// Points in the measure.
@@ -254,8 +235,6 @@ pub struct OwnedPointMeasure {
 }
 
 /// Configuration for free-support barycenter.
-///
-/// **Unstable**: heuristic free-support iteration config; support-update strategy is exploratory.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FreeSupportConfig {
     /// Inner fixed-support barycenter configuration.
@@ -277,8 +256,6 @@ impl Default for FreeSupportConfig {
 }
 
 /// Result of a free-support barycenter computation.
-///
-/// **Unstable**: output of the heuristic free-support routine; shape tied to current relocation algorithm.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FreeSupportBarycenter {
     /// Barycenter support points.
@@ -294,12 +271,6 @@ pub struct FreeSupportBarycenter {
 }
 
 /// Heuristic free-support barycenter for squared Euclidean geometry.
-///
-/// Alternates between fixed-support weight updates and Euclidean support
-/// relocation. Useful for exploratory analysis; production drift scoring
-/// usually only needs fixed-support barycenters or pairwise OT.
-///
-/// **Unstable**: heuristic algorithm; convergence guarantees and parameter defaults are subject to tuning.
 pub fn free_support_barycenter(
     measures: &[OwnedPointMeasure],
     combination_weights: &[f32],

--- a/crates/transport/src/cost.rs
+++ b/crates/transport/src/cost.rs
@@ -1,17 +1,10 @@
-//! Cost matrix abstractions.
-//!
-//! The central engineering choice is to separate **how** transport cost is
-//! computed from **how** Sinkhorn uses it. This keeps the solver generic over
-//! dense matrices, on-the-fly pairwise distances, and custom callback-based
-//! costs without changing the numerical kernel.
+//! Cost matrices and point-distance abstractions for Sinkhorn solvers.
 
 use core::fmt;
 
 use super::math::sqrt;
 
 /// Errors that arise while constructing or validating cost structures.
-///
-/// **Stable** (provisional): error type paired with the `Stable` cost API; changes only if the cost trait surface changes.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CostError {
     /// Point set has no elements.
@@ -68,8 +61,6 @@ impl fmt::Display for CostError {
 }
 
 /// Common interface for accessing points without committing to a storage layout.
-///
-/// **Stable** (provisional): core cost abstraction; signature frozen pending second consumer.
 pub trait PointSet {
     /// Number of points in the set.
     fn len(&self) -> usize;
@@ -111,12 +102,7 @@ impl<'a> PointSet for [&'a [f32]] {
     }
 }
 
-/// Contiguous row-major storage for point clouds.
-///
-/// Convenient when embeddings already live in a flat buffer from a BLAS,
-/// database page, or GPU staging area.
-///
-/// **Stable** (provisional): lightweight view type; layout unlikely to change.
+/// Contiguous row-major point-cloud storage.
 #[derive(Debug, Clone, Copy)]
 pub struct ContiguousPoints<'a> {
     data: &'a [f32],
@@ -126,7 +112,6 @@ pub struct ContiguousPoints<'a> {
 impl<'a> ContiguousPoints<'a> {
     /// Create from a flat buffer with the given dimension per point.
     ///
-    /// **Stable** (provisional): constructor matches struct stability.
     pub fn new(data: &'a [f32], dim: usize) -> Result<Self, CostError> {
         if dim == 0 || data.is_empty() {
             return Err(CostError::EmptyPointSet);
@@ -158,8 +143,6 @@ impl PointSet for ContiguousPoints<'_> {
 }
 
 /// Distance function between two points.
-///
-/// **Stable** (provisional): `Copy` bound and two-method signature are stable; custom metrics implement this.
 pub trait PointMetric: Copy {
     /// Compute the distance (cost) between two points.
     fn distance(&self, lhs: &[f32], rhs: &[f32]) -> f32;
@@ -170,8 +153,6 @@ pub trait PointMetric: Copy {
 }
 
 /// Squared Euclidean cost `||x - y||^2`, appropriate for Wasserstein-2.
-///
-/// **Stable** (provisional): standard metric; no breaking change anticipated.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SquaredEuclidean;
 
@@ -194,12 +175,7 @@ impl PointMetric for SquaredEuclidean {
     }
 }
 
-/// Cosine distance `1 - cos(theta)`.
-///
-/// If embeddings are already unit-normalized, set `assume_unit_norm = true` to
-/// avoid recomputing norms for every pair.
-///
-/// **Stable** (provisional): standard metric; `norm_floor` field may gain a default-constructor helper but struct shape is stable.
+/// Cosine distance `1 - cos(theta)`; skip norms for unit-normalized embeddings.
 #[derive(Debug, Clone, Copy)]
 pub struct CosineDistance {
     /// Skip norm computation for pre-normalized vectors.
@@ -250,8 +226,6 @@ impl PointMetric for CosineDistance {
 }
 
 /// Generic cost matrix interface.
-///
-/// **Stable** (provisional): three-method trait; the core abstraction boundary between geometry and solver.
 pub trait CostMatrix {
     /// Number of source entries (rows).
     fn rows(&self) -> usize;
@@ -262,8 +236,6 @@ pub trait CostMatrix {
 }
 
 /// Dense row-major cost matrix.
-///
-/// **Stable** (provisional): primary cost matrix type used throughout the crate.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DenseCostMatrix {
     rows: usize,
@@ -272,16 +244,11 @@ pub struct DenseCostMatrix {
 }
 
 impl DenseCostMatrix {
-    /// Create from pre-computed data.
+    /// Create from pre-computed data, panicking on an invalid matrix shape.
     ///
-    /// Panics if `rows × cols` overflows `usize` or does not equal `data.len()`.
-    ///
-    /// **Stable** (provisional): constructor matches struct stability.
     pub fn new(rows: usize, cols: usize, data: Vec<f32>) -> Self {
-        // FP-030: validate shape in release builds too — a caller-provided
-        // dimension mismatch corrupts every subsequent cost() lookup.
-        // checked_mul guards rows × cols against silently wrapping in release,
-        // which could otherwise let a corrupt (rows, cols) pass the length check.
+        // Validate in release: invalid dimensions corrupt every `cost` lookup.
+        // `checked_mul` rejects overflowing dimensions.
         let Some(expected) = rows.checked_mul(cols) else {
             panic!("DenseCostMatrix: dimensions {rows}×{cols} overflow usize");
         };
@@ -296,7 +263,6 @@ impl DenseCostMatrix {
 
     /// Build a cost matrix by evaluating a closure for each (row, col) pair.
     ///
-    /// **Stable** (provisional): convenience constructor; signature stable.
     pub fn from_fn<F>(rows: usize, cols: usize, mut f: F) -> Self
     where
         F: FnMut(usize, usize) -> f32,
@@ -312,7 +278,6 @@ impl DenseCostMatrix {
 
     /// Build from two point sets and a distance metric.
     ///
-    /// **Stable** (provisional): primary way to turn point cloud pairs into a cost matrix.
     pub fn from_point_sets<X, Y, M>(source: &X, target: &Y, metric: M) -> Result<Self, CostError>
     where
         X: PointSet + ?Sized,
@@ -328,7 +293,6 @@ impl DenseCostMatrix {
 
     /// Access the underlying flat data.
     ///
-    /// **Stable** (provisional): zero-copy accessor; no breaking change anticipated.
     #[inline]
     pub fn as_slice(&self) -> &[f32] {
         &self.data
@@ -336,7 +300,6 @@ impl DenseCostMatrix {
 
     /// Compute the flat index for (row, col).
     ///
-    /// **Unstable**: layout-specific helper; may be removed if storage changes.
     #[inline]
     pub fn index(&self, row: usize, col: usize) -> usize {
         row * self.cols + col
@@ -358,8 +321,6 @@ impl CostMatrix for DenseCostMatrix {
 }
 
 /// Pairwise cost computed lazily from two point clouds and a metric.
-///
-/// **Stable** (provisional): lazy cost view; avoids materializing a dense matrix for large problems.
 #[derive(Debug, Clone, Copy)]
 pub struct PairwiseCostMatrix<'a, X: ?Sized, Y: ?Sized, M> {
     /// Source point set.
@@ -373,7 +334,6 @@ pub struct PairwiseCostMatrix<'a, X: ?Sized, Y: ?Sized, M> {
 impl<'a, X: ?Sized, Y: ?Sized, M> PairwiseCostMatrix<'a, X, Y, M> {
     /// Create a lazy pairwise cost matrix.
     ///
-    /// **Stable** (provisional): constructor matches struct stability.
     pub fn new(source: &'a X, target: &'a Y, metric: M) -> Self {
         Self {
             source,
@@ -404,11 +364,6 @@ where
 }
 
 /// Arbitrary callback-backed cost matrix.
-///
-/// Useful for non-Euclidean domain-specific penalties, for example
-/// hybrid symbolic/neural costs or graph-aware memory migration penalties.
-///
-/// **Stable** (provisional): escape hatch for custom cost functions; closure type is generic so the public shape won't change.
 #[derive(Clone, Copy)]
 pub struct ClosureCostMatrix<F> {
     rows: usize,
@@ -428,7 +383,6 @@ impl<F> fmt::Debug for ClosureCostMatrix<F> {
 impl<F> ClosureCostMatrix<F> {
     /// Create a closure-backed cost matrix.
     ///
-    /// **Stable** (provisional): constructor matches struct stability.
     pub fn new(rows: usize, cols: usize, f: F) -> Self {
         Self { rows, cols, f }
     }
@@ -453,8 +407,6 @@ where
 
 /// Validates that a point set is non-empty, has constant dimension, and does
 /// not contain NaNs or infinities.
-///
-/// **Unstable**: internal validation helper; may be inlined or split as the API evolves.
 pub fn validate_point_set<P>(points: &P) -> Result<(), CostError>
 where
     P: PointSet + ?Sized,

--- a/crates/transport/src/divergence.rs
+++ b/crates/transport/src/divergence.rs
@@ -1,21 +1,14 @@
 //! Debiased Sinkhorn divergence.
 //!
-//! See: Genevay et al., "Learning Generative Models with Sinkhorn Divergences", AISTATS 2018.
-//!
-//! The regularized OT cost is not zero on identical distributions because the
-//! entropy term introduces a positive self-cost. The Sinkhorn divergence removes
-//! that bias by subtracting half of each self-interaction term:
-//!
-//! ```text
-//! S(a, b) = W_eps(a, b) - 0.5 * W_eps(a, a) - 0.5 * W_eps(b, b)
-//! ```
+//! Removes the entropy-induced self-cost of regularized transport. Extended
+//! background: <https://github.com/ohdearquant/lattice/blob/main/crates/transport/docs/algorithms.md>.
 
 use super::cost::{
     CostError, CostMatrix, DenseCostMatrix, PairwiseCostMatrix, PointMetric, PointSet,
 };
 use super::sinkhorn::{SinkhornError, SinkhornResult, SinkhornSolver, SinkhornWorkspace};
 
-/// Materialize cost matrices up to this combined byte limit.
+/// Combined limit for materialized cost matrices.
 const DENSE_COST_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 
 fn cost_error_to_sinkhorn(e: CostError) -> SinkhornError {
@@ -30,8 +23,6 @@ fn cost_error_to_sinkhorn(e: CostError) -> SinkhornError {
 }
 
 /// Result of a Sinkhorn divergence computation.
-///
-/// **Stable** (provisional): debiased divergence output; three nested `SinkhornResult` fields for cross and self terms.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SinkhornDivergence {
     /// Debiased divergence value.
@@ -45,8 +36,6 @@ pub struct SinkhornDivergence {
 }
 
 /// Compute Sinkhorn divergence from three pre-built cost matrices.
-///
-/// **Stable** (provisional): lower-level API when cost matrices are already materialized.
 #[allow(clippy::too_many_arguments)]
 pub fn sinkhorn_divergence<Cxy, Cxx, Cyy>(
     solver: &SinkhornSolver,
@@ -67,9 +56,7 @@ where
     let cross = solver.solve(cost_xy, source, target, workspace_xy)?;
     let self_source = solver.solve(cost_xx, source, source, workspace_xx)?;
     let self_target = solver.solve(cost_yy, target, target, workspace_yy)?;
-    // FP-023: Sinkhorn divergence must use the regularized OT cost
-    // (transport_cost − ε·entropy), not the raw primal transport cost.
-    // Using raw transport cost breaks symmetry and positive semi-definiteness.
+    // Use regularized cost: raw primal cost breaks divergence symmetry.
     let value = cross.regularized_cost
         - 0.5 * self_source.regularized_cost
         - 0.5 * self_target.regularized_cost;
@@ -81,14 +68,7 @@ where
     })
 }
 
-/// Compute Sinkhorn divergence directly from point sets.
-///
-/// When the combined cost matrices fit within 16 MiB, point-pair distances are
-/// precomputed once into dense matrices so the solver inner loops access O(1)
-/// lookups instead of recomputing 384-d distances on every iteration. For very
-/// large inputs the function falls back to lazy pairwise computation.
-///
-/// **Stable** (provisional): convenience API that builds cost matrices internally; preferred entry point for most callers.
+/// Compute Sinkhorn divergence from point sets, materializing costs below 16 MiB.
 #[allow(clippy::too_many_arguments)]
 pub fn point_set_sinkhorn_divergence<X, Y, M>(
     solver: &SinkhornSolver,
@@ -108,7 +88,6 @@ where
 {
     let n_src = source_points.len();
     let n_tgt = target_points.len();
-    // Three matrices: cross (n_src×n_tgt), self-source (n_src²), self-target (n_tgt²).
     let total_bytes = (n_src.saturating_mul(n_tgt))
         .saturating_add(n_src.saturating_mul(n_src))
         .saturating_add(n_tgt.saturating_mul(n_tgt))

--- a/crates/transport/src/drift.rs
+++ b/crates/transport/src/drift.rs
@@ -1,8 +1,4 @@
-//! High-level embedding drift API.
-//!
-//! Translates raw OT outputs into the quantities a memory subsystem actually
-//! needs: a scalar drift magnitude, sparse correspondences, expected per-entry
-//! displacement, and summary statistics suitable for thresholding.
+//! High-level embedding drift analysis from optimal-transport outputs.
 
 use std::borrow::ToOwned;
 
@@ -17,8 +13,6 @@ use super::transport_plan::{SparseTransportPlan, extract_sparse_plan};
 use super::unbalanced::{UnbalancedConfig, UnbalancedSinkhornSolver};
 
 /// Lightweight embedding record accepted by the drift API.
-///
-/// **Stable** (provisional): input record for `detect_drift_records`; field set is minimal by design.
 #[derive(Debug, Clone)]
 pub struct EmbeddingRecord<'a, Id> {
     /// Identifier for this record.
@@ -34,7 +28,6 @@ pub struct EmbeddingRecord<'a, Id> {
 impl<'a, Id> EmbeddingRecord<'a, Id> {
     /// Create a record with uniform weight.
     ///
-    /// **Stable** (provisional): convenience constructor; equivalent to setting `weight = 1.0` and `model = None`.
     pub fn uniform(id: Id, embedding: &'a [f32]) -> Self {
         Self {
             id,
@@ -46,37 +39,29 @@ impl<'a, Id> EmbeddingRecord<'a, Id> {
 }
 
 /// Adapter trait for application-level memory structs.
-///
-/// **Stable** (provisional): bridge between application memory types and the OT drift pipeline; four-method contract is stable.
 pub trait MemoryLike {
     /// Identifier type for memories.
     type Id: Clone;
 
     /// Get the memory's identifier.
     ///
-    /// **Stable** (provisional): required method; part of the trait contract.
     fn memory_id(&self) -> Self::Id;
     /// Get the embedding, if present.
     ///
-    /// **Stable** (provisional): required method; `None` records are filtered before the OT solve.
     fn embedding(&self) -> Option<&[f32]>;
     /// Get the importance weight (defaults to 1.0).
     ///
-    /// **Stable** (provisional): optional method with provided default.
     fn importance(&self) -> f32 {
         1.0
     }
     /// Get the embedding model identifier.
     ///
-    /// **Stable** (provisional): optional method with provided default; used for model-change audit logging.
     fn embed_model(&self) -> Option<&str> {
         None
     }
 }
 
 /// How to weight entries in drift computation.
-///
-/// **Stable** (provisional): two-variant enum; a `Custom` variant may be added but existing variants are stable.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DriftWeighting {
@@ -87,8 +72,6 @@ pub enum DriftWeighting {
 }
 
 /// Distance metric for drift computation.
-///
-/// **Stable** (provisional): two standard metrics; new entries (e.g., L1) would be additive.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DriftMetricKind {
@@ -99,8 +82,6 @@ pub enum DriftMetricKind {
 }
 
 /// Solver variant for drift computation.
-///
-/// **Stable** (provisional): `Balanced` and `Unbalanced` cover the primary use cases; existing variants are stable.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DriftSolverMode {
@@ -116,8 +97,6 @@ pub enum DriftSolverMode {
 }
 
 /// Configuration for drift detection.
-///
-/// **Stable** (provisional): aggregate config for the high-level drift API; new fields would be additive with `Default`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DriftConfig {
     /// Weighting strategy.
@@ -151,8 +130,6 @@ impl Default for DriftConfig {
 }
 
 /// Per-entry displacement in the transport plan.
-///
-/// **Stable** (provisional): per-source-entry diagnostic included in `DriftReport`; field set is stable.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PerEntryDisplacement<Id> {
     /// Record identifier.
@@ -172,8 +149,6 @@ pub struct PerEntryDisplacement<Id> {
 }
 
 /// Summary statistics for drift displacements.
-///
-/// **Stable** (provisional): five scalar statistics; new statistics would be additive.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DriftSummary {
     /// Mean displacement across all source entries.
@@ -189,8 +164,6 @@ pub struct DriftSummary {
 }
 
 /// Complete drift analysis report.
-///
-/// **Stable** (provisional): primary output type of the drift API; all fields are documented outputs.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DriftReport<Id> {
     /// Wasserstein distance (scalar drift magnitude).
@@ -214,8 +187,6 @@ pub struct DriftReport<Id> {
 }
 
 /// Detect drift from application-level memory objects.
-///
-/// **Stable** (provisional): primary entry point for `MemoryLike`-typed corpora; filters None embeddings internally.
 pub fn detect_drift_memories<M>(
     source: &[M],
     target: &[M],
@@ -258,8 +229,6 @@ where
 }
 
 /// Detect drift from embedding records.
-///
-/// **Stable** (provisional): lower-level entry point; caller constructs `EmbeddingRecord` slices directly.
 pub fn detect_drift_records<Id>(
     source: &[EmbeddingRecord<'_, Id>],
     target: &[EmbeddingRecord<'_, Id>],

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,23 +1,10 @@
-//! Sinkhorn optimal transport for embedding distribution drift detection.
+//! Log-domain Sinkhorn optimal transport for embedding distribution drift.
 //!
-//! **Stability tier: Unstable.** The Sinkhorn API is functional but currently
-//! consumed by only one crate; its shape may still change.
+//! The solver never materializes `exp(-C/epsilon)` and reuses
+//! [`SinkhornWorkspace`] buffers. Extended background: [design] and [algorithms].
 //!
-//! This crate implements entropy-regularized optimal transport (the Sinkhorn-Knopp
-//! algorithm) in the log domain, for quantifying how much embedding geometry shifts
-//! between model versions (for example, BGE-small to mE5-small). The load-bearing
-//! numerical invariant is that the solvers stay in log space throughout and never
-//! materialize the Gibbs kernel `exp(-C/epsilon)`, which prevents underflow at small
-//! regularization epsilon. The crate is a leaf with no intra-workspace dependencies:
-//! pure-Rust math with no BLAS/LAPACK, and [`SinkhornWorkspace`] preallocates the
-//! inner-loop buffers so callers allocate once and reuse.
-//!
-//! The layers run from the numerical foundation ([`logsumexp`]) up through the
-//! [`cost`] abstraction, the core solvers ([`sinkhorn`], [`sinkhorn_log`],
-//! [`unbalanced`]), post-processing ([`transport_plan`], [`divergence`]), and the
-//! high-level [`drift`] and [`barycenter`] APIs. See
-//! [`docs/design.md`](https://github.com/ohdearquant/lattice/blob/main/crates/transport/docs/design.md)
-//! for the architecture and design rationale in full.
+//! [design]: https://github.com/ohdearquant/lattice/blob/main/crates/transport/docs/design.md
+//! [algorithms]: https://github.com/ohdearquant/lattice/blob/main/crates/transport/docs/algorithms.md
 //!
 //! # Example
 //!
@@ -56,47 +43,38 @@ mod reference_cases;
 #[cfg(test)]
 mod tests;
 
-// Core solver types
 pub use sinkhorn::{
     BatchSolveResult, MarginalPair, ProgressObserver, ProgressState, SinkhornConfig, SinkhornError,
     SinkhornResult, SinkhornSolver, SinkhornWorkspace, normalize_weights, uniform_weights,
 };
 
-// Cost abstractions
 pub use cost::{
     ClosureCostMatrix, ContiguousPoints, CosineDistance, CostError, CostMatrix, DenseCostMatrix,
     PairwiseCostMatrix, PointMetric, PointSet, SquaredEuclidean,
 };
 
-// Log-domain solver with epsilon scaling
 pub use sinkhorn_log::{
     EpsilonScalingSchedule, EpsilonStageSummary, LogDomainSinkhornConfig, LogDomainSinkhornResult,
     LogDomainSinkhornSolver,
 };
 
-// Transport plan extraction
 pub use transport_plan::{
     SparseTransportEntry, SparseTransportPlan, extract_sparse_plan, log_gamma,
 };
 
-// Sinkhorn divergence (debiased)
 pub use divergence::{SinkhornDivergence, point_set_sinkhorn_divergence, sinkhorn_divergence};
 
-// Unbalanced OT
 pub use unbalanced::{UnbalancedConfig, UnbalancedResult, UnbalancedSinkhornSolver};
 
-// Barycenter computation
 pub use barycenter::{
     BarycenterConfig, BarycenterProblem, FixedSupportBarycenter, FixedSupportBarycenterWorkspace,
     FreeSupportBarycenter, FreeSupportConfig, OwnedPointMeasure, fixed_support_barycenter,
     free_support_barycenter,
 };
 
-// Drift detection API
 pub use drift::{
     DriftConfig, DriftMetricKind, DriftReport, DriftSolverMode, DriftSummary, DriftWeighting,
     EmbeddingRecord, MemoryLike, PerEntryDisplacement, detect_drift_memories, detect_drift_records,
 };
 
-// Online streaming drift detection
 pub use online_drift::{OnlineDriftConfig, OnlineDriftDetector, OnlineDriftSignal};

--- a/crates/transport/src/logsumexp.rs
+++ b/crates/transport/src/logsumexp.rs
@@ -1,34 +1,16 @@
 //! Numerically stable helpers for log-domain Sinkhorn updates.
 //!
-//! The core design rule in this crate is simple: never materialize the Gibbs
-//! kernel `K = exp(-C / epsilon)` directly. Instead we keep all scaling vectors
-//! in log space and only exponentiate when we intentionally recover transport
-//! mass. These helpers centralize the handful of stable transforms that the
-//! rest of the module relies on.
+//! Scaling vectors stay in log space; exponentiation only recovers transport mass.
 
 use super::math::{abs, exp, ln, log1p, sqrt as math_sqrt};
 
 /// Sentinel representing `log(0)`.
-///
-/// **Unstable**: numerical internal; value is mathematically fixed but export path may change.
 pub const LOG_ZERO: f32 = f32::NEG_INFINITY;
 
-/// Conservative cutoff before `expf` underflows in `f32`.
-///
-/// `exp(-87.0)` is ~1.6e-38, still a representable positive `f32`. Actual
-/// underflow is near the smallest subnormal value.
-///
-/// **Unstable**: tuning constant; value could change if benchmarking reveals a better cutoff.
+/// Conservative `f32` exponential underflow cutoff.
 pub const EXP_UNDERFLOW_CUTOFF: f32 = -103.97208;
 
-/// Safe natural logarithm that clamps the input away from zero.
-///
-/// In balanced OT the marginals should be strictly positive. In production,
-/// however, users often pass weights with zeros after filtering or importance
-/// truncation. Clamping to a tiny floor makes the algorithm robust while keeping
-/// the perturbation controlled and explicit.
-///
-/// **Unstable**: numerical internal; signature or clamping semantics may be adjusted.
+/// Natural logarithm with a caller-provided positive floor.
 #[inline]
 pub fn safe_ln(value: f32, floor: f32) -> f32 {
     let clamped = if value.is_finite() {
@@ -41,8 +23,6 @@ pub fn safe_ln(value: f32, floor: f32) -> f32 {
 
 /// Safe exponential used only when recovering transport mass or converting a
 /// normalized log probability back to probability space.
-///
-/// **Unstable**: numerical internal; underflow cutoff value may be tuned.
 #[inline]
 pub fn safe_exp(log_value: f32) -> f32 {
     if log_value < EXP_UNDERFLOW_CUTOFF {
@@ -53,8 +33,6 @@ pub fn safe_exp(log_value: f32) -> f32 {
 }
 
 /// Stable `log(exp(a) + exp(b))`.
-///
-/// **Unstable**: core Sinkhorn arithmetic primitive; always correct but module placement may change.
 #[inline]
 pub fn logaddexp(a: f32, b: f32) -> f32 {
     if a == LOG_ZERO {
@@ -67,14 +45,7 @@ pub fn logaddexp(a: f32, b: f32) -> f32 {
     hi + log1p(exp(lo - hi))
 }
 
-/// One-pass online log-sum-exp accumulator.
-///
-/// Tracks `(max, sum_of_exp_offsets)` and finalizes as `max + ln(sum)`.
-/// Compared with chaining `logaddexp`, this avoids one `log1p` call per term
-/// (only one `ln` at the end), reducing transcendental pressure in inner Sinkhorn
-/// loops by roughly 1×exp per element.
-///
-/// **Unstable**: internal optimization primitive used by solver inner loops.
+/// One-pass log-sum-exp accumulator.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct OnlineLogSumExp {
     max: f32,
@@ -114,8 +85,6 @@ impl OnlineLogSumExp {
 }
 
 /// Stable log-sum-exp over a slice.
-///
-/// **Unstable**: numerical internal; may be replaced by the iterator-based variant.
 pub fn logsumexp(values: &[f32]) -> f32 {
     let mut acc = LOG_ZERO;
     for &value in values {
@@ -124,12 +93,7 @@ pub fn logsumexp(values: &[f32]) -> f32 {
     acc
 }
 
-/// Stable log-sum-exp over an implicit iterator `0..len`.
-///
-/// This is particularly useful when the values are generated on the fly from a
-/// cost matrix and we do not want to allocate a temporary buffer.
-///
-/// **Unstable**: convenience variant; may be unified with `logsumexp` via an `impl Iterator` parameter.
+/// Stable log-sum-exp over values generated for `0..len`.
 pub fn logsumexp_by<F>(len: usize, mut f: F) -> f32
 where
     F: FnMut(usize) -> f32,
@@ -143,8 +107,6 @@ where
 
 /// Subtracts `logsumexp(log_weights)` in place so that the exponentiated values
 /// sum to one. Returns the removed normalizer.
-///
-/// **Unstable**: barycenter internal; in-place mutation signature may be revised.
 pub fn normalize_log_weights(log_weights: &mut [f32]) -> f32 {
     let normalizer = logsumexp(log_weights);
     if normalizer.is_finite() {
@@ -155,15 +117,7 @@ pub fn normalize_log_weights(log_weights: &mut [f32]) -> f32 {
     normalizer
 }
 
-/// Maximum absolute difference between two same-length slices.
-///
-/// **Unstable**: barycenter convergence helper; may be inlined.
-///
-/// Fails closed on a non-finite difference: a NaN or Inf `delta` compares
-/// `false` against every running max under plain `>`, so a naive
-/// accumulate-the-max loop silently reports the non-finite input as `0.0`.
-/// This returns the first non-finite `delta` immediately instead, so a
-/// catastrophically wrong input can never read back as a clean small value.
+/// Maximum absolute difference, returning the first non-finite delta.
 pub fn max_abs_diff(lhs: &[f32], rhs: &[f32]) -> f32 {
     let mut max_delta = 0.0;
     for (&left, &right) in lhs.iter().zip(rhs.iter()) {
@@ -179,16 +133,12 @@ pub fn max_abs_diff(lhs: &[f32], rhs: &[f32]) -> f32 {
 }
 
 /// Converts log-probabilities to a freshly allocated probability vector.
-///
-/// **Unstable**: convenience converter; allocates — may be replaced with an iterator adapter.
 pub fn exp_normalized(log_weights: &[f32]) -> Vec<f32> {
     log_weights.iter().map(|&value| safe_exp(value)).collect()
 }
 
 /// Mean and standard deviation in one pass using Welford's online algorithm.
 /// Drift diagnostics use this for outlier detection.
-///
-/// **Unstable**: drift summary internal; may be moved to a dedicated stats module.
 pub fn mean_std(values: &[f32]) -> (f32, f32) {
     if values.is_empty() {
         return (0.0, 0.0);
@@ -212,8 +162,6 @@ pub fn mean_std(values: &[f32]) -> (f32, f32) {
 
 /// Median computed by sorting a scratch copy. Used only in high-level
 /// drift summaries, so the extra allocation is acceptable.
-///
-/// **Unstable**: drift summary internal; sorting allocation may be avoided with a selection algorithm.
 pub fn median(values: &[f32]) -> f32 {
     if values.is_empty() {
         return 0.0;
@@ -233,32 +181,24 @@ pub fn median(values: &[f32]) -> f32 {
 }
 
 /// Square root wrapper.
-///
-/// **Unstable**: thin shim over `f32::sqrt`; may be removed if callers use `f32::sqrt` directly.
 #[inline]
 pub fn sqrt(value: f32) -> f32 {
     math_sqrt(value)
 }
 
 /// Sum of a slice.
-///
-/// **Unstable**: convenience wrapper; may be removed in favor of iterator `.sum()` at call sites.
 #[inline]
 pub fn sum(values: &[f32]) -> f32 {
     values.iter().copied().sum()
 }
 
 /// Checks whether all values are finite.
-///
-/// **Unstable**: validation helper used in problem setup; may be inlined.
 #[inline]
 pub fn all_finite(values: &[f32]) -> bool {
     values.iter().all(|value| value.is_finite())
 }
 
 /// Stable `x * ln(x / y) - x + y`, with the usual `0 ln 0 = 0` convention.
-///
-/// **Unstable**: KL-divergence term used only by `UnbalancedSinkhornSolver`; may move to `unbalanced.rs`.
 pub fn kl_term(x: f32, y: f32, floor: f32) -> f32 {
     if x <= 0.0 {
         return y.max(0.0);
@@ -272,12 +212,7 @@ pub fn kl_term(x: f32, y: f32, floor: f32) -> f32 {
 mod tests {
     use super::*;
 
-    /// Mutation-sensitivity proof: a plain accumulate-the-max loop with no
-    /// finiteness check silently reports `0.0` for a NaN or Inf difference, so
-    /// a catastrophically wrong input would read as a clean small value and
-    /// pass a tolerance gate. This asserts the fixed helper surfaces the
-    /// non-finite value instead; if this ever fails, the gate is decoration
-    /// again.
+    /// Non-finite deltas must not appear converged.
     #[test]
     fn max_abs_diff_is_nan_and_inf_honest() {
         let clean = [1.0f32, 2.0, 3.0];

--- a/crates/transport/src/math.rs
+++ b/crates/transport/src/math.rs
@@ -1,7 +1,4 @@
-//! Small math shim for transport module.
-//!
-//! Delegates to platform `std` implementations. Kept as a thin wrapper to
-//! centralize all floating-point operations used by the Sinkhorn solvers.
+//! Small math shim for transport floating-point operations.
 
 #[inline]
 pub fn abs(x: f32) -> f32 {

--- a/crates/transport/src/online_drift.rs
+++ b/crates/transport/src/online_drift.rs
@@ -1,11 +1,6 @@
-//! Streaming online drift detection via Sinkhorn divergence.
+//! Streaming, sliding-window drift detection via Sinkhorn divergence.
 //!
-//! Implements `OnlineDriftDetector` as a sample-count sliding-window drift sensor
-//! that calls `point_set_sinkhorn_divergence` every `check_interval` observations.
-//! The first `window_size` samples populate a frozen reference distribution; all
-//! subsequent samples slide through `current_window`.
-//!
-//! See ADR-055 for design rationale and crate-boundary rules.
+//! Extended background: <https://github.com/ohdearquant/lattice/blob/main/crates/transport/docs/algorithms.md>.
 
 use std::collections::VecDeque;
 
@@ -17,17 +12,10 @@ use crate::{
 /// Minimum `window_size` enforced by `OnlineDriftConfig::normalized`.
 pub const MIN_ONLINE_DRIFT_WINDOW_SIZE: usize = 128;
 
-/// Maximum `window_size` enforced by `OnlineDriftConfig::normalized`.
-///
-/// Each drift check builds three `W×W` Sinkhorn workspaces, so memory scales as
-/// O(W²). This cap bounds one detector's workspace footprint to roughly
-/// 3 × 4096² × 4 bytes ≈ 192 MB, preventing a deserialized config with an
-/// oversized window from exhausting memory.
+/// Maximum window size, bounding three O(W²) workspaces to about 192 MiB.
 pub const MAX_ONLINE_DRIFT_WINDOW_SIZE: usize = 4096;
 
 /// Configuration for streaming Sinkhorn drift detection.
-///
-/// **Stable** (provisional): aggregate config for the online drift API; new fields would be additive with `Default`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OnlineDriftConfig {
     /// Sliding window size W. Clamped to `[128, 4096]` by `normalized` (O(W²) cost per check).
@@ -63,8 +51,6 @@ impl OnlineDriftConfig {
 }
 
 /// Per-sample online drift status returned by [`OnlineDriftDetector::observe`].
-///
-/// **Stable** (provisional): four-variant status enum; new variants would be additive.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OnlineDriftSignal {
@@ -98,13 +84,7 @@ pub enum OnlineDriftSignal {
     },
 }
 
-/// Streaming Sinkhorn drift detector.
-///
-/// The first `window_size` samples auto-fit a frozen reference distribution.
-/// Subsequent samples slide through `current_window`; every `check_interval`
-/// observations `observe` computes S(reference, current) and emits a signal.
-///
-/// **Stable** (provisional): `new` + `observe` + `reset_reference` are the stable surface.
+/// Streaming Sinkhorn drift detector with frozen-reference and sliding windows.
 #[derive(Debug, Clone)]
 pub struct OnlineDriftDetector {
     config: OnlineDriftConfig,
@@ -142,10 +122,7 @@ impl OnlineDriftDetector {
         }
     }
 
-    /// Observe one embedding sample and return the current drift status.
-    ///
-    /// Returns `Err(SinkhornError)` only on solver failure; status signals are
-    /// encoded in the `Ok` variants.
+    /// Observe one sample; solver failures are `Err` and statuses are `Ok`.
     pub fn observe(&mut self, embedding: Vec<f32>) -> Result<OnlineDriftSignal, SinkhornError> {
         self.samples_seen += 1;
 
@@ -190,7 +167,7 @@ impl OnlineDriftDetector {
             &mut self.workspace_yy,
         )?;
 
-        // Clamp tiny negative floating-point noise; debiased divergence is non-negative by definition.
+        // Clamp roundoff: the debiased divergence is non-negative.
         let value = divergence.value.max(0.0);
         self.last_divergence = Some(value);
 
@@ -207,10 +184,7 @@ impl OnlineDriftDetector {
         }
     }
 
-    /// Promote the current window to the frozen reference distribution.
-    ///
-    /// Call after an adapter or router refresh to reset the baseline. `samples_seen`
-    /// is preserved so `window_pos` in future signals remains monotonically increasing.
+    /// Promote the current window to the reference while preserving `samples_seen`.
     pub fn reset_reference(&mut self) {
         self.reference_window = self.current_window.clone();
         self.workspace_xy.reset();
@@ -287,11 +261,10 @@ mod tests {
                 .state
                 .wrapping_mul(6_364_136_223_846_793_005)
                 .wrapping_add(1_442_695_040_888_963_407);
-            // Map high 32 bits to [0, 1).
             (self.state >> 32) as f32 / u32::MAX as f32
         }
 
-        // Sample from approximate N(mean, 1) using Box-Muller (two uniforms -> one normal).
+        // Box-Muller sample from approximately N(mean, 1).
         fn next_normal(&mut self, mean: f32) -> f32 {
             let u1 = self.next_f32().max(1e-10);
             let u2 = self.next_f32();
@@ -333,8 +306,6 @@ mod tests {
 
     #[test]
     fn online_drift_computes_when_window_fills() {
-        // With check_interval=1 and a high threshold, sample 128 fills both windows
-        // with identical data, which should yield near-zero divergence.
         let config = OnlineDriftConfig {
             window_size: 128,
             check_interval: 1,
@@ -376,15 +347,11 @@ mod tests {
         let mut detector = OnlineDriftDetector::new(config);
         let mut rng = Lcg::new(7);
 
-        // Feed 128 samples — fills both windows; sample 128 is divisible by 8 so it
-        // triggers a compute. Sample 129 is not divisible by 8 so it must be Skipped.
         for _ in 0..128 {
             detector.observe(make_vector(&mut rng, 4, 0.0)).unwrap();
         }
         let at_128 = detector.observe(make_vector(&mut rng, 4, 0.0)).unwrap();
-        // sample 129 (not on interval 8)
         let at_129 = at_128; // we already consumed it; redo:
-        // Reset and replay carefully.
         let mut detector2 = OnlineDriftDetector::new(OnlineDriftConfig {
             window_size: 128,
             check_interval: 8,
@@ -395,7 +362,6 @@ mod tests {
         for _ in 0..128 {
             detector2.observe(make_vector(&mut rng2, 4, 0.0)).unwrap();
         }
-        // sample 129 — check_interval=8, 129 % 8 = 1 ≠ 0 → Skipped
         let sig_129 = detector2.observe(make_vector(&mut rng2, 4, 0.0)).unwrap();
         assert!(
             matches!(
@@ -407,7 +373,6 @@ mod tests {
             ),
             "expected Skipped at 129 with next_check_in=7, got {sig_129:?}"
         );
-        // Verify sample 128 was Stable or Drift (not Warming or Skipped).
         let mut detector3 = OnlineDriftDetector::new(OnlineDriftConfig {
             window_size: 128,
             check_interval: 8,
@@ -418,7 +383,6 @@ mod tests {
         for _ in 0..127 {
             detector3.observe(make_vector(&mut rng3, 4, 0.0)).unwrap();
         }
-        // sample 128 — 128 % 8 == 0 → compute
         let sig_128 = detector3.observe(make_vector(&mut rng3, 4, 0.0)).unwrap();
         assert!(
             matches!(
@@ -432,8 +396,6 @@ mod tests {
 
     #[test]
     fn online_drift_detects_gaussian_shift() {
-        // Feed 128 reference samples near 0.0, then 128 shifted samples near 4.0.
-        // With a low threshold, a Drift signal must appear after the shift.
         let config = OnlineDriftConfig {
             window_size: 128,
             check_interval: 1,
@@ -443,14 +405,11 @@ mod tests {
         let mut detector = OnlineDriftDetector::new(config);
         let mut rng = Lcg::new(2025);
 
-        // Warm up with reference near 0.
         for _ in 0..128 {
             let sig = detector.observe(make_vector(&mut rng, 8, 0.0)).unwrap();
-            // These may be Warming or Stable; no assertion needed during warm-up.
             let _ = sig;
         }
 
-        // Feed shifted samples; at least one Drift should appear.
         let mut found_drift = false;
         for _ in 0..128 {
             let sig = detector.observe(make_vector(&mut rng, 8, 4.0)).unwrap();
@@ -460,8 +419,6 @@ mod tests {
             } = sig
             {
                 assert!(divergence > 0.1, "drift divergence should exceed threshold");
-                // window_pos is samples_seen at detection time; must be > 128 since windows
-                // need to be full first, and we're in the shifted batch.
                 assert!(
                     window_pos > 128,
                     "window_pos must be after warm-up: got {window_pos}"
@@ -478,7 +435,6 @@ mod tests {
 
     #[test]
     fn online_drift_zero_divergence_identical_distributions() {
-        // After reset_reference, feeding the same sequence should give near-zero divergence.
         let config = OnlineDriftConfig {
             window_size: 128,
             check_interval: 1,
@@ -488,15 +444,12 @@ mod tests {
         let mut detector = OnlineDriftDetector::new(config);
         let mut rng = Lcg::new(55);
 
-        // Collect 128 fixed vectors.
         let vecs: Vec<Vec<f32>> = (0..128).map(|_| make_vector(&mut rng, 4, 0.0)).collect();
 
-        // Fill detector with the fixed sequence.
         for v in &vecs {
             detector.observe(v.clone()).unwrap();
         }
 
-        // Promote current window to reference, then replay identical sequence.
         detector.reset_reference();
 
         let mut last_signal = None;
@@ -517,7 +470,6 @@ mod tests {
 
     #[test]
     fn online_drift_reproducible_with_fixed_sequence() {
-        // Two detectors with identical config and same input sequence must produce identical signals.
         let config = OnlineDriftConfig {
             window_size: 128,
             check_interval: 8,

--- a/crates/transport/src/reference_cases.rs
+++ b/crates/transport/src/reference_cases.rs
@@ -1,7 +1,4 @@
-//! Reference datasets and comparison helpers (test-only).
-//!
-//! Provides deterministic toy cases for correctness checks and a structured
-//! place for cross-library comparisons.
+//! Test-only reference datasets and comparison helpers.
 
 use super::cost::{CostMatrix, DenseCostMatrix};
 use super::math::abs;

--- a/crates/transport/src/sinkhorn.rs
+++ b/crates/transport/src/sinkhorn.rs
@@ -1,10 +1,4 @@
-//! Core balanced Sinkhorn solver.
-//!
-//! Implements a numerically stable, log-domain Sinkhorn iteration with
-//! preallocated work buffers, configurable convergence checks, progress
-//! callbacks, and batch solving against a shared cost matrix.
-//!
-//! See: Cuturi, "Sinkhorn Distances: Lightspeed Computation of Optimal Transport", NeurIPS 2013.
+//! Core balanced, log-domain Sinkhorn solver with reusable workspaces.
 
 use core::fmt;
 use core::mem;
@@ -27,15 +21,9 @@ fn use_parallel_sinkhorn(rows: usize, cols: usize) -> bool {
 }
 
 /// Solver configuration for balanced entropic OT.
-///
-/// **Stable** (provisional): all fields are semantically stable; a new field would be additive.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SinkhornConfig {
-    /// Entropy regularization strength.
-    ///
-    /// Smaller values better approximate exact OT but require more iterations.
-    /// Recommend scaling the cost matrix first and choosing epsilon relative
-    /// to a characteristic cost scale.
+    /// Entropy regularization strength; scale costs before choosing it.
     pub epsilon: f32,
     /// Hard iteration cap.
     pub max_iterations: usize,
@@ -64,8 +52,6 @@ impl Default for SinkhornConfig {
 }
 
 /// Work buffers reused across solves to avoid heap allocation in the hot loop.
-///
-/// **Stable** (provisional): allocate once, solve many; the allocation pattern is part of the documented usage contract.
 #[derive(Debug, Clone)]
 pub struct SinkhornWorkspace {
     pub(crate) log_u: Vec<f32>,
@@ -78,7 +64,6 @@ pub struct SinkhornWorkspace {
 impl SinkhornWorkspace {
     /// Create workspace for a problem of the given dimensions.
     ///
-    /// **Stable** (provisional): constructor matches struct stability.
     pub fn new(rows: usize, cols: usize) -> Self {
         Self {
             log_u: vec![0.0; rows],
@@ -91,7 +76,6 @@ impl SinkhornWorkspace {
 
     /// Resize buffers, resetting initialization state.
     ///
-    /// **Stable** (provisional): needed when problem size changes between batch solves.
     pub fn resize(&mut self, rows: usize, cols: usize) {
         self.log_u.resize(rows, 0.0);
         self.log_v.resize(cols, 0.0);
@@ -102,7 +86,6 @@ impl SinkhornWorkspace {
 
     /// Zero all buffers and mark as initialized (for warm-start).
     ///
-    /// **Stable** (provisional): warm-start support is a documented feature.
     pub fn reset(&mut self) {
         self.log_u.fill(0.0);
         self.log_v.fill(0.0);
@@ -122,7 +105,6 @@ impl SinkhornWorkspace {
 
     /// Number of source entries.
     ///
-    /// **Stable** (provisional): dimension accessor.
     #[inline]
     pub fn rows(&self) -> usize {
         self.log_u.len()
@@ -130,7 +112,6 @@ impl SinkhornWorkspace {
 
     /// Number of target entries.
     ///
-    /// **Stable** (provisional): dimension accessor.
     #[inline]
     pub fn cols(&self) -> usize {
         self.log_v.len()
@@ -138,8 +119,6 @@ impl SinkhornWorkspace {
 }
 
 /// Errors produced by the solver.
-///
-/// **Stable** (provisional): error variants reflect the documented failure modes; new variants would be additive.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SinkhornError {
     /// The problem has zero rows or columns.
@@ -250,8 +229,6 @@ impl fmt::Display for SinkhornError {
 }
 
 /// Lightweight progress snapshot emitted every `check_convergence_every` iterations.
-///
-/// **Stable** (provisional): all fields are pure read-only diagnostics; new fields would be additive.
 #[derive(Debug, Clone, Copy)]
 pub struct ProgressState {
     /// Index within a batch solve (0 for single solves).
@@ -269,12 +246,9 @@ pub struct ProgressState {
 }
 
 /// Observer interface used by long-running solves.
-///
-/// **Stable** (provisional): single-method trait; the `FnMut` blanket impl means closures work without a named type.
 pub trait ProgressObserver {
     /// Called periodically during iteration. Return `false` to cancel the solve.
     ///
-    /// **Stable** (provisional): signature matches struct stability.
     fn on_progress(&mut self, state: ProgressState) -> bool;
 }
 
@@ -288,8 +262,6 @@ where
 }
 
 /// Input pair for batch solving.
-///
-/// **Stable** (provisional): two-field view into source/target marginals; used by `solve_batch`.
 #[derive(Debug, Clone, Copy)]
 pub struct MarginalPair<'a> {
     /// Source marginal weights (sum to 1).
@@ -299,8 +271,6 @@ pub struct MarginalPair<'a> {
 }
 
 /// Returned by `solve_batch`.
-///
-/// **Stable** (provisional): simple wrapper over `Vec<SinkhornResult>`; shape stable.
 #[derive(Debug, Clone)]
 pub struct BatchSolveResult {
     /// One result per problem in the batch.
@@ -308,8 +278,6 @@ pub struct BatchSolveResult {
 }
 
 /// Solver output containing dual variables and primal statistics.
-///
-/// **Stable** (provisional): primary result type; all fields are documented outputs of the solve.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SinkhornResult {
     /// Epsilon used for this solve.
@@ -341,7 +309,6 @@ pub struct SinkhornResult {
 impl SinkhornResult {
     /// Returns the log-mass of a single coupling entry `gamma[row, col]`.
     ///
-    /// **Stable** (provisional): used by `extract_sparse_plan` and audit tooling.
     #[inline]
     pub fn log_gamma<C>(&self, cost: &C, row: usize, col: usize) -> Result<f32, SinkhornError>
     where
@@ -364,8 +331,6 @@ impl SinkhornResult {
 }
 
 /// Balanced Sinkhorn solver.
-///
-/// **Stable** (provisional): the main solver type; `Default` produces production-ready configuration.
 #[derive(Debug, Clone, Default)]
 pub struct SinkhornSolver {
     /// Solver configuration.
@@ -375,14 +340,12 @@ pub struct SinkhornSolver {
 impl SinkhornSolver {
     /// Create a solver with the given configuration.
     ///
-    /// **Stable** (provisional): constructor matches struct stability.
     pub fn new(config: SinkhornConfig) -> Self {
         Self { config }
     }
 
     /// Solve a single balanced OT problem.
     ///
-    /// **Stable** (provisional): primary entry point; signature stable.
     pub fn solve<C>(
         &self,
         cost: &C,
@@ -398,7 +361,6 @@ impl SinkhornSolver {
 
     /// Solve with a progress observer for cancellation and monitoring.
     ///
-    /// **Stable** (provisional): progress/cancellation support is a documented feature.
     pub fn solve_with_progress<C>(
         &self,
         cost: &C,
@@ -413,12 +375,8 @@ impl SinkhornSolver {
         self.solve_internal(cost, source, target, workspace, progress, false, 0, 1)
     }
 
-    /// Solve with warm-starting from previous dual variables.
+    /// Solve with warm-started dual variables for related problems.
     ///
-    /// Mainly intended for epsilon-scaling and repeated solves with slowly
-    /// changing marginals.
-    ///
-    /// **Stable** (provisional): warm-start is a documented performance feature.
     pub fn solve_warm_start<C>(
         &self,
         cost: &C,
@@ -435,7 +393,6 @@ impl SinkhornSolver {
 
     /// Solve multiple problems sharing the same cost matrix structure.
     ///
-    /// **Stable** (provisional): batch API reuses a single workspace across problems for efficiency.
     pub fn solve_batch<C>(
         &self,
         cost: &C,
@@ -476,11 +433,8 @@ impl SinkhornSolver {
         Ok(BatchSolveResult { results })
     }
 
-    /// Dense-matrix solve with gated Rayon-parallel row/column updates for n ≥ 500.
+    /// Dense-matrix solve that enables internal parallel updates.
     ///
-    /// Same semantics as `solve`; concrete `DenseCostMatrix` type enables internal parallelism.
-    ///
-    /// **Stable** (provisional): matches `solve` stability.
     pub fn solve_dense(
         &self,
         cost: &DenseCostMatrix,
@@ -522,7 +476,6 @@ impl SinkhornSolver {
         let use_par = use_parallel_sinkhorn(rows, cols);
 
         for iteration in 0..self.config.max_iterations {
-            // Update log_u (row scaling)
             if use_par {
                 let log_v = workspace.log_v.as_slice();
                 source
@@ -571,7 +524,6 @@ impl SinkhornSolver {
             }
             mem::swap(&mut workspace.log_u, &mut workspace.next_log_u);
 
-            // Update log_v (column scaling)
             if use_par {
                 let log_u = workspace.log_u.as_slice();
                 workspace
@@ -722,7 +674,6 @@ impl SinkhornSolver {
         let mut iterations = 0usize;
 
         for iteration in 0..self.config.max_iterations {
-            // Update log_u (row scaling)
             let mut max_du = 0.0f32;
             for (row, (&src, next_u)) in source
                 .iter()
@@ -750,7 +701,6 @@ impl SinkhornSolver {
             }
             mem::swap(&mut workspace.log_u, &mut workspace.next_log_u);
 
-            // Update log_v (column scaling)
             let mut max_dv = 0.0f32;
             for (col, (&tgt, next_v)) in target
                 .iter()
@@ -780,10 +730,7 @@ impl SinkhornSolver {
 
             iterations = iteration + 1;
             if iterations.is_multiple_of(check_every) || iterations == self.config.max_iterations {
-                // FP-026: convergence criterion is marginal constraint satisfaction
-                // (L1 residuals), not dual-variable update size. Dual updates are a
-                // proxy that can declare convergence while marginal constraints are
-                // still substantially violated.
+                // Use L1 marginal residuals; small dual updates need not satisfy constraints.
                 let (row_res, col_res) = marginal_residuals(
                     cost,
                     epsilon,
@@ -852,8 +799,6 @@ impl SinkhornSolver {
 }
 
 /// Creates a uniform probability vector.
-///
-/// **Stable** (provisional): convenience helper; commonly used in tests and examples.
 pub fn uniform_weights(len: usize) -> Vec<f32> {
     if len == 0 {
         return Vec::new();
@@ -863,8 +808,6 @@ pub fn uniform_weights(len: usize) -> Vec<f32> {
 }
 
 /// Normalizes a non-negative weight vector to sum to one.
-///
-/// **Stable** (provisional): utility needed by `detect_drift_records` and barycenter code.
 pub fn normalize_weights(weights: &[f32], floor: f32) -> Result<Vec<f32>, SinkhornError> {
     if weights.is_empty() {
         return Err(SinkhornError::EmptyProblem);
@@ -919,9 +862,7 @@ where
             got_cols: target.len(),
         });
     }
-    // FP-024: reject zero-mass and non-positive entries explicitly. Previously
-    // safe_ln would silently clamp zeros to min_marginal, injecting phantom mass
-    // and producing incorrect transport plans.
+    // Reject non-positive marginals: `safe_ln` would inject phantom mass.
     for (index, &value) in source.iter().enumerate() {
         if !value.is_finite() || value <= 0.0 {
             return Err(SinkhornError::InvalidMarginal {
@@ -942,8 +883,7 @@ where
     }
     let source_sum = sum(source);
     let target_sum = sum(target);
-    // FP-025: explicitly reject zero-total distributions. If both sums are zero
-    // they satisfy the mass-balance check below but the problem is degenerate.
+    // Equal zero totals are degenerate, not balanced.
     if source_sum <= 0.0 || !source_sum.is_finite() {
         return Err(SinkhornError::InvalidMarginal {
             axis: "source",

--- a/crates/transport/src/sinkhorn_log.rs
+++ b/crates/transport/src/sinkhorn_log.rs
@@ -1,11 +1,6 @@
-//! Log-domain stabilized variants beyond the plain fixed-epsilon solver.
+//! Epsilon-scaling acceleration for the log-domain Sinkhorn solver.
 //!
-//! The base solver in `sinkhorn.rs` is already fully log-domain. This module
-//! adds epsilon-scaling acceleration (Schmitzer-style): solve a sequence of
-//! easier problems with larger `epsilon`, warm-starting the dual variables
-//! at each stage.
-//!
-//! See: Schmitzer, "Stabilized Sparse Scaling Algorithms for Entropy Regularized Transport Problems", SIAM J. Sci. Comput. 2019.
+//! Each stage warm-starts the next lower-epsilon solve.
 
 use super::cost::CostMatrix;
 use super::math::abs;
@@ -17,8 +12,6 @@ use super::sinkhorn::{
 const MAX_EPSILON_STAGES: usize = 10_000;
 
 /// Geometric epsilon schedule from `start` down to `target`.
-///
-/// **Unstable**: epsilon-scaling acceleration; schedule representation may change to support non-geometric sequences.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EpsilonScalingSchedule {
     /// Initial (large) epsilon.
@@ -34,7 +27,6 @@ pub struct EpsilonScalingSchedule {
 impl EpsilonScalingSchedule {
     /// Generate the geometric sequence of epsilon values.
     ///
-    /// **Unstable**: schedule generation detail; return type may become an iterator.
     pub fn geometric_values(&self) -> Vec<f32> {
         self.try_geometric_values().unwrap_or_default()
     }
@@ -106,8 +98,6 @@ impl EpsilonScalingSchedule {
 }
 
 /// Full configuration for the staged solver.
-///
-/// **Unstable**: wraps `SinkhornConfig` with an optional scaling schedule; field set may grow.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 pub struct LogDomainSinkhornConfig {
     /// Base solver configuration (epsilon here is used only when no scaling schedule is set).
@@ -117,8 +107,6 @@ pub struct LogDomainSinkhornConfig {
 }
 
 /// Summary of a single epsilon-scaling stage.
-///
-/// **Unstable**: per-stage diagnostic; field set mirrors `SinkhornResult` subset and may change.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EpsilonStageSummary {
     /// Stage index (0-based).
@@ -136,8 +124,6 @@ pub struct EpsilonStageSummary {
 }
 
 /// Result of a multi-stage log-domain solve.
-///
-/// **Unstable**: aggregates per-stage summaries with the final `SinkhornResult`; structure may be simplified.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LogDomainSinkhornResult {
     /// Result from the final stage.
@@ -149,8 +135,6 @@ pub struct LogDomainSinkhornResult {
 }
 
 /// Warm-started log-domain Sinkhorn with optional epsilon scaling.
-///
-/// **Unstable**: acceleration layer on top of `SinkhornSolver`; may be absorbed into the main solver via a schedule option.
 #[derive(Debug, Clone, Default)]
 pub struct LogDomainSinkhornSolver {
     /// Solver configuration.
@@ -160,14 +144,12 @@ pub struct LogDomainSinkhornSolver {
 impl LogDomainSinkhornSolver {
     /// Create a solver with the given configuration.
     ///
-    /// **Unstable**: constructor matches struct stability.
     pub fn new(config: LogDomainSinkhornConfig) -> Self {
         Self { config }
     }
 
     /// Solve with optional epsilon scaling.
     ///
-    /// **Unstable**: primary entry point; rejects invalid epsilon schedules.
     pub fn solve<C>(
         &self,
         cost: &C,

--- a/crates/transport/src/tests.rs
+++ b/crates/transport/src/tests.rs
@@ -2,9 +2,6 @@
 
 use super::*;
 
-/// Test 1: Uniform marginals on a symmetric cost matrix.
-/// The optimal transport for identical uniform distributions on a diagonal cost
-/// is to not move any mass. Transport cost should be near zero.
 #[test]
 fn uniform_marginals_identity_cost() {
     let cost = DenseCostMatrix::new(3, 3, vec![0.0, 1.0, 2.0, 1.0, 0.0, 1.0, 2.0, 1.0, 0.0]);
@@ -21,9 +18,6 @@ fn uniform_marginals_identity_cost() {
         .unwrap();
 
     assert!(result.converged, "Sinkhorn should converge");
-    // With identical source/target, exact OT cost is 0. Regularized version
-    // will be slightly positive due to entropy, but transport_cost should be
-    // very small relative to epsilon.
     assert!(
         result.transport_cost < 0.1,
         "transport cost should be small for identical distributions, got {}",
@@ -36,11 +30,8 @@ fn uniform_marginals_identity_cost() {
     );
 }
 
-/// Test 2: Epsilon convergence -- smaller epsilon should give tighter approximation
-/// to exact OT.
 #[test]
 fn epsilon_convergence() {
-    // 1x1 problem where exact OT cost = 5.0.
     let cost = DenseCostMatrix::new(1, 1, vec![5.0]);
     let source = vec![1.0];
     let target = vec![1.0];
@@ -60,7 +51,6 @@ fn epsilon_convergence() {
         costs_at_eps.push((eps, result.transport_cost));
     }
 
-    // All should be close to 5.0 (for 1x1 problem, exact solution is trivial)
     for &(eps, cost_val) in &costs_at_eps {
         assert!(
             (cost_val - 5.0).abs() < eps + 0.01,
@@ -71,8 +61,6 @@ fn epsilon_convergence() {
     }
 }
 
-/// Test 3: Sinkhorn divergence symmetry.
-/// S(a, b) and S(b, a) should be approximately equal (divergence is symmetric).
 #[test]
 fn sinkhorn_divergence_symmetry() {
     let points_a: Vec<Vec<f32>> = vec![vec![0.0, 0.0], vec![1.0, 0.0]];
@@ -86,7 +74,6 @@ fn sinkhorn_divergence_symmetry() {
         ..SinkhornConfig::default()
     });
 
-    // S(a, b)
     let mut ws_ab = SinkhornWorkspace::new(2, 2);
     let mut ws_aa = SinkhornWorkspace::new(2, 2);
     let mut ws_bb = SinkhornWorkspace::new(2, 2);
@@ -103,7 +90,6 @@ fn sinkhorn_divergence_symmetry() {
     )
     .unwrap();
 
-    // S(b, a)
     let mut ws_ba = SinkhornWorkspace::new(2, 2);
     let mut ws_bb2 = SinkhornWorkspace::new(2, 2);
     let mut ws_aa2 = SinkhornWorkspace::new(2, 2);
@@ -130,9 +116,6 @@ fn sinkhorn_divergence_symmetry() {
     );
 }
 
-/// Test 4: Transport plan validity.
-/// The sparse transport plan entries should have non-negative mass and their total
-/// should be close to 1.0 for uniform distributions.
 #[test]
 fn transport_plan_validity() {
     let cost = DenseCostMatrix::new(3, 3, vec![0.0, 1.0, 4.0, 1.0, 0.0, 1.0, 4.0, 1.0, 0.0]);
@@ -145,7 +128,6 @@ fn transport_plan_validity() {
 
     let plan = extract_sparse_plan(&result, &cost, 1e-8).unwrap();
 
-    // All entries should have non-negative mass
     for entry in &plan.entries {
         assert!(
             entry.mass >= 0.0,
@@ -158,7 +140,6 @@ fn transport_plan_validity() {
         );
     }
 
-    // Total retained + dropped mass should be close to 1.0
     let total = plan.retained_mass + plan.dropped_mass;
     assert!(
         (total - 1.0).abs() < 0.05,
@@ -167,13 +148,8 @@ fn transport_plan_validity() {
     );
 }
 
-/// Test 5: Drift metric with known displacement.
-/// Two point clouds that are a known distance apart should produce a corresponding
-/// Wasserstein distance.
 #[test]
 fn drift_metric_known_displacement() {
-    // Source: two points at (0, 0) and (1, 0)
-    // Target: two points at (2, 0) and (3, 0) -- shifted right by 2 units
     let source_emb: Vec<Vec<f32>> = vec![vec![0.0, 0.0], vec![1.0, 0.0]];
     let target_emb: Vec<Vec<f32>> = vec![vec![2.0, 0.0], vec![3.0, 0.0]];
 
@@ -201,15 +177,12 @@ fn drift_metric_known_displacement() {
 
     let report = detect_drift_records(&source_records, &target_records, &config).unwrap();
 
-    // Each point moves by 2 units, so squared distance = 4 per point.
-    // Wasserstein-2 distance = sqrt(average squared cost) = sqrt(4) = 2.
     assert!(
         (report.wasserstein_distance - 2.0).abs() < 0.2,
         "Wasserstein distance should be near 2.0, got {}",
         report.wasserstein_distance
     );
 
-    // Per-entry displacements should each be near 2.0
     for entry in &report.per_entry {
         assert!(
             (entry.expected_distance - 2.0).abs() < 0.5,
@@ -219,11 +192,9 @@ fn drift_metric_known_displacement() {
     }
 }
 
-/// Test 6: Unbalanced solver allows mass mismatch.
 #[test]
 fn unbalanced_solver_mass_mismatch() {
     let cost = DenseCostMatrix::new(2, 3, vec![0.0, 1.0, 4.0, 1.0, 0.0, 1.0]);
-    // Different sizes, different total mass
     let source = vec![0.5, 0.5];
     let target = vec![0.3, 0.3, 0.4];
 
@@ -248,7 +219,6 @@ fn unbalanced_solver_mass_mismatch() {
     assert!(result.transported_mass > 0.0, "Should transport some mass");
 }
 
-/// Test 7: Reference case correctness.
 #[test]
 fn reference_cases_pass() {
     let solver = SinkhornSolver::new(SinkhornConfig {
@@ -284,7 +254,6 @@ fn reference_cases_pass() {
     }
 }
 
-/// Test 8: Epsilon scaling solver converges.
 #[test]
 fn epsilon_scaling_converges() {
     let cost = DenseCostMatrix::new(3, 3, vec![0.0, 1.0, 4.0, 1.0, 0.0, 1.0, 4.0, 1.0, 0.0]);
@@ -319,7 +288,6 @@ fn epsilon_scaling_converges() {
     );
 }
 
-/// Test 9: Cost matrix from point sets.
 #[test]
 fn cost_matrix_from_points() {
     let points_a = [vec![0.0, 0.0], vec![1.0, 0.0]];
@@ -331,22 +299,16 @@ fn cost_matrix_from_points() {
     assert_eq!(cost.rows(), 2);
     assert_eq!(cost.cols(), 2);
 
-    // (0,0) -> (0,1): squared distance = 1.0
     assert!((cost.cost(0, 0) - 1.0).abs() < 1e-6);
-    // (0,0) -> (1,1): squared distance = 2.0
     assert!((cost.cost(0, 1) - 2.0).abs() < 1e-6);
-    // (1,0) -> (0,1): squared distance = 2.0
     assert!((cost.cost(1, 0) - 2.0).abs() < 1e-6);
-    // (1,0) -> (1,1): squared distance = 1.0
     assert!((cost.cost(1, 1) - 1.0).abs() < 1e-6);
 }
 
-/// Test 10: Cosine distance metric.
 #[test]
 fn cosine_distance_metric() {
     let metric = CosineDistance::default();
 
-    // Same direction: cosine distance = 0
     let a = vec![1.0, 0.0, 0.0];
     let b = vec![2.0, 0.0, 0.0];
     let d = metric.distance(&a, &b);
@@ -356,7 +318,6 @@ fn cosine_distance_metric() {
         d
     );
 
-    // Orthogonal: cosine distance = 1
     let c = vec![0.0, 1.0, 0.0];
     let d_val = metric.distance(&a, &c);
     assert!(
@@ -366,7 +327,6 @@ fn cosine_distance_metric() {
     );
 }
 
-/// Test 11: Contiguous points layout.
 #[test]
 fn contiguous_points_access() {
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
@@ -378,7 +338,6 @@ fn contiguous_points_access() {
     assert_eq!(points.point(1), &[4.0, 5.0, 6.0]);
 }
 
-/// Test 12: Error on empty problem.
 #[test]
 fn error_on_empty_problem() {
     let cost = DenseCostMatrix::new(0, 0, vec![]);
@@ -405,7 +364,6 @@ fn balanced_solver_rejects_zero_marginal_entries() {
     ));
 }
 
-/// Test 13: Error on non-positive epsilon.
 #[test]
 fn error_on_non_positive_epsilon() {
     let cost = DenseCostMatrix::new(2, 2, vec![0.0, 1.0, 1.0, 0.0]);
@@ -546,15 +504,12 @@ fn safe_exp_preserves_representable_positive_values() {
     assert_eq!(logsumexp::safe_exp(-104.0), 0.0);
 }
 
-/// Test 14: logsumexp numerical stability.
 #[test]
 fn logsumexp_stability() {
     use super::logsumexp::logsumexp;
 
-    // Large values that would overflow naive exp
     let values = vec![100.0, 101.0, 102.0];
     let result = logsumexp(&values);
-    // Should be close to 102 + ln(1 + exp(-1) + exp(-2))
     assert!(result.is_finite(), "logsumexp should not overflow");
     assert!(
         (result - 102.408).abs() < 0.01,
@@ -562,7 +517,6 @@ fn logsumexp_stability() {
         result
     );
 
-    // Very negative values
     let neg_values = vec![-100.0, -101.0, -102.0];
     let neg_result = logsumexp(&neg_values);
     assert!(

--- a/crates/transport/src/transport_plan.rs
+++ b/crates/transport/src/transport_plan.rs
@@ -1,17 +1,12 @@
-//! Sparse transport plan extraction.
+//! Sparse transport-plan extraction from Sinkhorn dual variables.
 //!
-//! The solver itself keeps only dual variables because storing the dense coupling
-//! is infeasible for large problems. This module reconstructs only the entries
-//! above a user-specified threshold, which is typically what downstream drift
-//! analysis and audit tooling needs.
+//! Extended background: <https://github.com/ohdearquant/lattice/blob/main/crates/transport/docs/algorithms.md>.
 
 use super::cost::CostMatrix;
 use super::logsumexp::{safe_exp, safe_ln};
 use super::sinkhorn::{SinkhornError, SinkhornResult};
 
 /// A single entry in the sparse transport plan.
-///
-/// **Stable** (provisional): output record type; all fields represent documented plan attributes.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SparseTransportEntry {
     /// Source index.
@@ -27,8 +22,6 @@ pub struct SparseTransportEntry {
 }
 
 /// Sparse representation of the optimal coupling.
-///
-/// **Stable** (provisional): output from `extract_sparse_plan`; embedded in `DriftReport`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SparseTransportPlan {
     /// Number of source entries.
@@ -46,8 +39,6 @@ pub struct SparseTransportPlan {
 }
 
 /// Compute log-gamma for a single (row, col) entry.
-///
-/// **Stable** (provisional): thin delegation to `SinkhornResult::log_gamma`; re-exported for convenience.
 #[inline]
 pub fn log_gamma<C>(
     result: &SinkhornResult,
@@ -62,8 +53,6 @@ where
 }
 
 /// Extract entries of the transport plan above a mass threshold.
-///
-/// **Stable** (provisional): primary plan extraction function used by `DriftReport` construction.
 pub fn extract_sparse_plan<C>(
     result: &SinkhornResult,
     cost: &C,

--- a/crates/transport/src/unbalanced.rs
+++ b/crates/transport/src/unbalanced.rs
@@ -1,11 +1,6 @@
 //! Unbalanced Sinkhorn with KL-relaxed marginals.
 //!
-//! See: Chizat et al., "Scaling Algorithms for Unbalanced Optimal Transport Problems", Math. Comp. 2018.
-//!
-//! This variant is preferable when the two embedding corpora do not represent
-//! exactly the same total mass: entries may have been added, deleted, or had
-//! their importance reweighted. Instead of forcing equality with dummy nodes,
-//! the KL penalty softly charges mass creation and destruction.
+//! Extended background: <https://github.com/ohdearquant/lattice/blob/main/crates/transport/docs/algorithms.md>.
 
 use core::mem;
 
@@ -31,8 +26,6 @@ fn use_parallel_sinkhorn(rows: usize, cols: usize) -> bool {
 }
 
 /// Configuration for KL-relaxed Sinkhorn.
-///
-/// **Unstable**: unbalanced OT API is secondary to the balanced solver; tau parameters may be restructured.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UnbalancedConfig {
     /// Entropy regularization strength.
@@ -66,8 +59,6 @@ impl Default for UnbalancedConfig {
 }
 
 /// Result of an unbalanced Sinkhorn solve.
-///
-/// **Unstable**: field set mirrors `SinkhornResult` but adds KL penalty fields; may be unified in a future refactor.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UnbalancedResult {
     /// Epsilon used.
@@ -101,8 +92,6 @@ pub struct UnbalancedResult {
 }
 
 /// Unbalanced Sinkhorn solver with KL-relaxed marginal constraints.
-///
-/// **Unstable**: solver for mass-imbalanced distributions; API may be unified with `SinkhornSolver` via a mode enum.
 #[derive(Debug, Clone, Default)]
 pub struct UnbalancedSinkhornSolver {
     /// Solver configuration.
@@ -112,16 +101,11 @@ pub struct UnbalancedSinkhornSolver {
 impl UnbalancedSinkhornSolver {
     /// Create a solver with the given configuration.
     ///
-    /// **Unstable**: constructor matches struct stability.
     pub fn new(config: UnbalancedConfig) -> Self {
         Self { config }
     }
 
-    /// Dense-matrix solve with gated Rayon-parallel row/column updates for n ≥ 500.
-    ///
-    /// Same semantics as `solve`; concrete `DenseCostMatrix` type enables internal parallelism.
-    ///
-    /// **Unstable**: matches `solve` stability.
+    /// Dense-matrix solve that enables internal parallel updates.
     pub fn solve_dense(
         &self,
         cost: &DenseCostMatrix,
@@ -220,7 +204,6 @@ impl UnbalancedSinkhornSolver {
         let use_par = use_parallel_sinkhorn(rows, cols);
 
         for iteration in 0..self.config.max_iterations {
-            // Row update (log_u)
             let max_du = if use_par {
                 let log_v = workspace.log_v.as_slice();
                 let old_log_u = workspace.log_u.as_slice();
@@ -280,7 +263,6 @@ impl UnbalancedSinkhornSolver {
             };
             mem::swap(&mut workspace.log_u, &mut workspace.next_log_u);
 
-            // Column update (log_v)
             let max_dv = if use_par {
                 let log_u = workspace.log_u.as_slice();
                 let old_log_v = workspace.log_v.as_slice();
@@ -424,7 +406,6 @@ impl UnbalancedSinkhornSolver {
 
     /// Solve an unbalanced OT problem.
     ///
-    /// **Unstable**: primary entry point; signature may change when unified with balanced solver.
     pub fn solve<C>(
         &self,
         cost: &C,


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Implements Ocean's 2026-07-10 fleet-wide comment-hygiene directive for `crates/transport/src` only. This is comment/doc-only, with zero behavior change.

## Counts

- Source comment/doc-comment lines: 855 before → 431 after (424 fewer).
- Source diff: 49 concise comment/doc lines added or condensed; 473 verbose, redundant, or stale lines removed.

## What changed

- Condensed module, public-API, and numerical-helper prose to contracts and invariants the code cannot state alone.
- Deleted repeated provisional-stability boilerplate, next-line narration, and test comments that restated assertions.
- Extracted operational background from module rustdoc into `crates/transport/docs/algorithms.md` and linked it from the crate index and relevant module docs.

## New docs

- `crates/transport/docs/algorithms.md`

## ADR candidates

- Divergence must use regularized cost, rather than raw primal cost, to preserve symmetry (`src/divergence.rs`).
- Balanced solves reject non-positive and zero-total marginals instead of allowing log-floor clamping to create phantom mass (`src/sinkhorn.rs`).
- Convergence uses L1 marginal residuals rather than dual-update size (`src/sinkhorn.rs`).
- The 16 MiB materialization threshold for point-set divergence is an explicit performance/memory policy (`src/divergence.rs`).
- The 4096 online-drift window cap bounds three O(W²) workspaces (`src/online_drift.rs`).

All required gates are green: `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p lattice-transport`, `cargo clippy -p lattice-transport --all-targets -- -D warnings`, and `cargo test -p lattice-transport`.
