### PR TITLE
docs(fann): condense inline comments, extract background to crate docs

### DIFF
--- a/crates/fann/src/activation.rs
+++ b/crates/fann/src/activation.rs
@@ -5,7 +5,7 @@
 //!
 //! See `docs/network.md` for formulas, numerical rules, and derivative limits.
 
-/// Activation function types
+/// Supported activation functions.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
@@ -30,12 +30,10 @@ pub enum Activation {
     Softmax,
 }
 
-// --- SIMD activation function helpers ---
-
 /// NEON-accelerated ReLU: max(0, x) for 4 elements at a time.
 ///
 /// # Safety
-/// NEON must be available (mandatory on aarch64). Slice pointer must be valid.
+/// Must run on AArch64, where NEON is mandatory.
 #[cfg(all(feature = "simd", target_arch = "aarch64"))]
 #[inline]
 unsafe fn simd_relu_neon(values: &mut [f32]) {
@@ -54,7 +52,6 @@ unsafe fn simd_relu_neon(values: &mut [f32]) {
         vst1q_f32(p.add(offset), result);
         offset += 4;
     }
-    // Scalar tail
     for i in offset..n {
         let val = *p.add(i);
         if val < 0.0 {
@@ -66,7 +63,7 @@ unsafe fn simd_relu_neon(values: &mut [f32]) {
 /// AVX2-accelerated ReLU: max(0, x) for 8 elements at a time.
 ///
 /// # Safety
-/// Caller must ensure AVX2 is available. Slice pointer must be valid.
+/// Caller must ensure AVX2 is available.
 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn simd_relu_avx2(values: &mut [f32]) {
@@ -85,7 +82,6 @@ unsafe fn simd_relu_avx2(values: &mut [f32]) {
         _mm256_storeu_ps(p.add(offset), result);
         offset += 8;
     }
-    // Scalar tail
     for i in offset..n {
         let val = *p.add(i);
         if val < 0.0 {
@@ -96,11 +92,10 @@ unsafe fn simd_relu_avx2(values: &mut [f32]) {
 
 /// NEON-accelerated LeakyReLU: x if x > 0, else alpha * x.
 ///
-/// Uses vbslq_f32 (bitwise select) to blend between x and alpha*x based on
-/// whether x >= 0. This avoids branching entirely.
+/// Uses vector selection to avoid per-lane branches.
 ///
 /// # Safety
-/// NEON must be available (mandatory on aarch64). Slice pointer must be valid.
+/// Must run on AArch64, where NEON is mandatory.
 #[cfg(all(feature = "simd", target_arch = "aarch64"))]
 #[inline]
 unsafe fn simd_leaky_relu_neon(values: &mut [f32], alpha: f32) {
@@ -117,14 +112,11 @@ unsafe fn simd_leaky_relu_neon(values: &mut [f32], alpha: f32) {
         // SAFETY: offset + 4 <= n; p is valid for n elements
         let v = vld1q_f32(p.add(offset));
         let scaled = vmulq_f32(v, alpha_v);
-        // mask: all-ones where v >= 0, all-zeros where v < 0
         let mask = vcgeq_f32(v, zero);
-        // Select: where mask is set, pick v; where clear, pick scaled
         let result = vbslq_f32(mask, v, scaled);
         vst1q_f32(p.add(offset), result);
         offset += 4;
     }
-    // Scalar tail
     for i in offset..n {
         let val = *p.add(i);
         if val < 0.0 {
@@ -135,11 +127,10 @@ unsafe fn simd_leaky_relu_neon(values: &mut [f32], alpha: f32) {
 
 /// AVX2-accelerated LeakyReLU: x if x > 0, else alpha * x.
 ///
-/// Uses _mm256_blendv_ps to select between x and alpha*x. The blend uses
-/// the sign bit of x: positive keeps x, negative gets alpha*x.
+/// Uses vector selection to avoid per-lane branches.
 ///
 /// # Safety
-/// Caller must ensure AVX2 is available. Slice pointer must be valid.
+/// Caller must ensure AVX2 is available.
 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn simd_leaky_relu_avx2(values: &mut [f32], alpha: f32) {
@@ -156,14 +147,11 @@ unsafe fn simd_leaky_relu_avx2(values: &mut [f32], alpha: f32) {
         // SAFETY: offset + 8 <= n; p is valid for n elements
         let v = _mm256_loadu_ps(p.add(offset));
         let scaled = _mm256_mul_ps(v, alpha_v);
-        // Compare: mask lanes where v > 0 (all bits set for true lanes)
         let mask = _mm256_cmp_ps(v, zero, _CMP_GT_OQ);
-        // Blend: pick v where mask is set, scaled where not
         let result = _mm256_blendv_ps(scaled, v, mask);
         _mm256_storeu_ps(p.add(offset), result);
         offset += 8;
     }
-    // Scalar tail
     for i in offset..n {
         let val = *p.add(i);
         if val < 0.0 {
@@ -172,11 +160,7 @@ unsafe fn simd_leaky_relu_avx2(values: &mut [f32], alpha: f32) {
     }
 }
 
-/// Numerically stable sigmoid: avoids overflow when x is large and negative.
-///
-/// For x >= 0 uses the standard formula 1/(1+e^-x).
-/// For x < 0 rewrites as e^x/(1+e^x) so the exponent is always non-negative,
-/// preventing the intermediate `-(-x).exp()` from overflowing to +Inf.
+/// Evaluates sigmoid without overflowing for large negative inputs.
 #[inline]
 fn stable_sigmoid(x: f32) -> f32 {
     if x >= 0.0 {
@@ -188,10 +172,10 @@ fn stable_sigmoid(x: f32) -> f32 {
 }
 
 impl Activation {
-    /// Default leaky ReLU alpha value
+    /// Default alpha for leaky ReLU.
     pub const DEFAULT_LEAKY_ALPHA: f32 = 0.01;
 
-    /// Apply activation function to a single value (element-wise)
+    /// Applies this activation to one value.
     ///
     /// Note: For Softmax, use `forward_batch` instead as it requires the full vector.
     #[inline]
@@ -208,7 +192,7 @@ impl Activation {
                     alpha * x
                 }
             }
-            // For single element, softmax is just 1.0
+            // A scalar Softmax is 1.0.
             Activation::Softmax => 1.0,
         }
     }
@@ -234,17 +218,13 @@ impl Activation {
             Activation::ReLU => {
                 #[cfg(all(feature = "simd", target_arch = "aarch64"))]
                 {
-                    // SAFETY: NEON is mandatory on aarch64. We process values
-                    // in chunks of 4 using vld1q/vmaxq/vst1q, then handle
-                    // the scalar tail. All pointer arithmetic stays within the
-                    // slice bounds.
+                    // SAFETY: NEON is mandatory on AArch64; the helper bounds-checks vector loads.
                     unsafe { simd_relu_neon(values) };
                 }
                 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
                 {
                     if is_x86_feature_detected!("avx2") {
-                        // SAFETY: AVX2 verified above; function processes in
-                        // 8-element chunks with scalar tail.
+                        // SAFETY: AVX2 was detected above.
                         unsafe { simd_relu_avx2(values) };
                     } else {
                         for v in values.iter_mut() {
@@ -266,15 +246,13 @@ impl Activation {
                 let a = *alpha;
                 #[cfg(all(feature = "simd", target_arch = "aarch64"))]
                 {
-                    // SAFETY: NEON is mandatory on aarch64. Processes in chunks
-                    // of 4, blending between x and alpha*x based on sign.
+                    // SAFETY: NEON is mandatory on AArch64; the helper bounds-checks vector loads.
                     unsafe { simd_leaky_relu_neon(values, a) };
                 }
                 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
                 {
                     if is_x86_feature_detected!("avx2") {
-                        // SAFETY: AVX2 verified above; processes in 8-element
-                        // chunks with blendv for conditional alpha scaling.
+                        // SAFETY: AVX2 was detected above.
                         unsafe { simd_leaky_relu_avx2(values, a) };
                     } else {
                         for v in values.iter_mut() {
@@ -297,7 +275,7 @@ impl Activation {
                 }
             }
             Activation::Softmax => {
-                // Numerically stable softmax
+                // Subtract the maximum to avoid exponent overflow.
                 let max = values.iter().copied().fold(f32::NEG_INFINITY, f32::max);
                 let mut sum = 0.0;
                 for v in values.iter_mut() {
@@ -337,15 +315,12 @@ impl Activation {
                     *alpha
                 }
             }
-            // Diagonal approximation of the Softmax Jacobian; accepted
-            // limitation, see ADR-023.
+            // The full Jacobian is handled by output-layer backpropagation (ADR-023).
             Activation::Softmax => output * (1.0 - output),
         }
     }
 
-    /// Compute derivatives for a batch of output values (in-place)
-    ///
-    /// Modifies `outputs` to contain the derivatives.
+    /// Replaces each output with its derivative.
     #[inline]
     pub fn derivative_batch(&self, outputs: &mut [f32]) {
         match self {
@@ -376,8 +351,7 @@ impl Activation {
                 }
             }
             Activation::Softmax => {
-                // Simplified: diagonal of Jacobian
-                // Full Jacobian: J[i,j] = s[i](delta[i,j] - s[j])
+                // This exposes only the Softmax Jacobian diagonal.
                 for v in outputs.iter_mut() {
                     *v = *v * (1.0 - *v);
                 }
@@ -385,13 +359,13 @@ impl Activation {
         }
     }
 
-    /// Returns true if this activation is Softmax
+    /// Returns whether this is Softmax.
     #[inline]
     pub fn is_softmax(&self) -> bool {
         matches!(self, Activation::Softmax)
     }
 
-    /// Returns true if this activation has a bounded output range
+    /// Returns whether this activation has a bounded output range.
     #[inline]
     pub fn is_bounded(&self) -> bool {
         matches!(
@@ -425,7 +399,6 @@ mod tests {
         assert!(approx_eq(act.forward(0.0), 0.5));
         assert!(act.forward(10.0) > 0.99);
         assert!(act.forward(-10.0) < 0.01);
-        // Derivative at output 0.5
         assert!(approx_eq(act.derivative(0.5), 0.25));
     }
 
@@ -435,7 +408,6 @@ mod tests {
         assert!(approx_eq(act.forward(0.0), 0.0));
         assert!(act.forward(3.0) > 0.99);
         assert!(act.forward(-3.0) < -0.99);
-        // Derivative at output 0
         assert!(approx_eq(act.derivative(0.0), 1.0));
     }
 
@@ -465,11 +437,9 @@ mod tests {
         let mut values = vec![1.0, 2.0, 3.0];
         act.forward_batch(&mut values);
 
-        // Sum should be 1.0
         let sum: f32 = values.iter().sum();
         assert!(approx_eq(sum, 1.0));
 
-        // Values should be in increasing order (since input was increasing)
         assert!(values[0] < values[1]);
         assert!(values[1] < values[2]);
     }
@@ -477,7 +447,6 @@ mod tests {
     #[test]
     fn test_softmax_numerical_stability() {
         let act = Activation::Softmax;
-        // Large values that would overflow without stability fix
         let mut values = vec![1000.0, 1001.0, 1002.0];
         act.forward_batch(&mut values);
 

--- a/crates/fann/src/error.rs
+++ b/crates/fann/src/error.rs
@@ -5,17 +5,13 @@
 
 use thiserror::Error;
 
-/// Result type for neural network operations
+/// Result type for neural-network operations.
 pub type FannResult<T> = std::result::Result<T, FannError>;
 
-/// Maximum allowed elements in a single tensor allocation.
-/// 100 million elements = ~400MB for f32, a reasonable limit to prevent OOM.
+/// Maximum elements in a single tensor allocation.
 pub const MAX_ALLOWED_ELEMENTS: usize = 100_000_000;
 
-/// Validate that an allocation size is within safe limits.
-///
-/// Returns an error if the requested size exceeds [`MAX_ALLOWED_ELEMENTS`].
-/// This prevents denial-of-service attacks via memory exhaustion.
+/// Validates an allocation size against [`MAX_ALLOWED_ELEMENTS`].
 #[inline]
 pub fn validate_allocation_size(num_elements: usize) -> FannResult<()> {
     if num_elements > MAX_ALLOWED_ELEMENTS {
@@ -27,10 +23,7 @@ pub fn validate_allocation_size(num_elements: usize) -> FannResult<()> {
     Ok(())
 }
 
-/// Validate layer dimensions for safe allocation.
-///
-/// Checks both that dimensions are non-zero and that the total allocation
-/// (num_inputs * num_outputs for weights) doesn't exceed safe limits.
+/// Validates nonzero layer dimensions and their weight allocation size.
 #[inline]
 pub fn validate_layer_dimensions(num_inputs: usize, num_outputs: usize) -> FannResult<()> {
     if num_inputs == 0 || num_outputs == 0 {
@@ -40,7 +33,6 @@ pub fn validate_layer_dimensions(num_inputs: usize, num_outputs: usize) -> FannR
         });
     }
 
-    // Check for overflow and size limit
     let total = num_inputs
         .checked_mul(num_outputs)
         .ok_or(FannError::ShapeTooLarge {
@@ -51,10 +43,10 @@ pub fn validate_layer_dimensions(num_inputs: usize, num_outputs: usize) -> FannR
     validate_allocation_size(total)
 }
 
-/// Errors that can occur in neural network operations
+/// Errors from neural-network operations.
 #[derive(Error, Debug, Clone, PartialEq)]
 pub enum FannError {
-    /// Input size does not match network's expected input size
+    /// Input length differs from the network input width.
     #[error("Input size mismatch: expected {expected}, got {actual}")]
     InputSizeMismatch {
         /// Expected input size
@@ -63,7 +55,7 @@ pub enum FannError {
         actual: usize,
     },
 
-    /// Output size does not match network's expected output size
+    /// Output length differs from the network output width.
     #[error("Output size mismatch: expected {expected}, got {actual}")]
     OutputSizeMismatch {
         /// Expected output size
@@ -72,7 +64,7 @@ pub enum FannError {
         actual: usize,
     },
 
-    /// Weight count does not match expected weight count for layer
+    /// Weight count differs from the layer shape.
     #[error("Weight count mismatch: expected {expected}, got {actual}")]
     WeightCountMismatch {
         /// Expected weight count
@@ -81,7 +73,7 @@ pub enum FannError {
         actual: usize,
     },
 
-    /// Bias count does not match expected bias count for layer
+    /// Bias count differs from the layer output width.
     #[error("Bias count mismatch: expected {expected}, got {actual}")]
     BiasCountMismatch {
         /// Expected bias count
@@ -90,7 +82,7 @@ pub enum FannError {
         actual: usize,
     },
 
-    /// Layer dimensions are invalid
+    /// Layer dimensions are invalid.
     #[error("Invalid layer dimensions: inputs={inputs}, outputs={outputs}")]
     InvalidLayerDimensions {
         /// Number of inputs
@@ -99,7 +91,7 @@ pub enum FannError {
         outputs: usize,
     },
 
-    /// Allocation size exceeds maximum allowed elements (DoS prevention)
+    /// Allocation size exceeds the configured limit.
     #[error("Shape too large: requested {requested} elements, max allowed is {max}")]
     ShapeTooLarge {
         /// Requested number of elements
@@ -108,31 +100,31 @@ pub enum FannError {
         max: usize,
     },
 
-    /// Network has no layers
+    /// Network has no layers.
     #[error("Network has no layers")]
     EmptyNetwork,
 
-    /// Builder configuration is invalid
+    /// Builder configuration is invalid.
     #[error("Invalid builder configuration: {0}")]
     InvalidBuilder(String),
 
-    /// Training error
+    /// Training failed.
     #[error("Training error: {0}")]
     TrainingError(String),
 
-    /// Gradient computation failed
+    /// Gradient computation failed.
     #[error("Gradient computation failed: {0}")]
     GradientError(String),
 
-    /// Numeric instability detected
+    /// Numeric instability was detected.
     #[error("Numeric instability: {0}")]
     NumericInstability(String),
 
-    /// Invalid distribution parameters (e.g., negative std_dev, NaN)
+    /// Distribution parameters are invalid.
     #[error("Invalid distribution parameters: {0}")]
     InvalidDistributionParams(String),
 
-    /// Serialization error
+    /// Serialization failed.
     #[cfg(feature = "serde")]
     #[error("Serialization error: {0}")]
     SerializationError(String),
@@ -238,14 +230,12 @@ mod tests {
 
     #[test]
     fn test_validate_layer_dimensions_too_large() {
-        // 100_001 * 100_001 > MAX_ALLOWED_ELEMENTS (100M)
         let result = validate_layer_dimensions(100_001, 100_001);
         assert!(matches!(result, Err(FannError::ShapeTooLarge { .. })));
     }
 
     #[test]
     fn test_validate_layer_dimensions_overflow() {
-        // usize::MAX * 2 would overflow
         let result = validate_layer_dimensions(usize::MAX, 2);
         assert!(matches!(result, Err(FannError::ShapeTooLarge { .. })));
     }

--- a/crates/fann/src/lib.rs
+++ b/crates/fann/src/lib.rs
@@ -20,7 +20,6 @@ pub mod training;
 #[cfg(feature = "gpu")]
 pub mod gpu;
 
-// Re-exports
 pub use activation::Activation;
 pub use error::{FannError, FannResult};
 pub use layer::Layer;
@@ -32,7 +31,7 @@ pub use training::{
 #[cfg(feature = "gpu")]
 pub use gpu::{GpuContext, GpuNetwork};
 
-/// Prelude for common imports
+/// Common imports.
 pub mod prelude {
     pub use crate::{
         Activation, BackpropTrainer, FannError, FannResult, GradientGuardStrategy, Layer, Network,
@@ -49,7 +48,6 @@ mod tests {
 
     #[test]
     fn test_full_workflow() {
-        // Build network
         let mut network = NetworkBuilder::new()
             .input(4)
             .hidden(8, Activation::ReLU)
@@ -58,16 +56,13 @@ mod tests {
             .build()
             .unwrap();
 
-        // Verify architecture
         assert_eq!(network.num_inputs(), 4);
         assert_eq!(network.num_outputs(), 2);
         assert_eq!(network.num_layers(), 3);
 
-        // Run inference
         let input = [1.0, 2.0, 3.0, 4.0];
         let output = network.forward(&input).unwrap();
 
-        // Softmax output sums to 1
         let sum: f32 = output.iter().sum();
         assert!((sum - 1.0).abs() < 1e-5);
     }
@@ -76,7 +71,6 @@ mod tests {
     fn test_inference_speed() {
         use std::time::Instant;
 
-        // Create a reasonably sized network
         let mut network = NetworkBuilder::new()
             .input(128)
             .hidden(256, Activation::ReLU)
@@ -88,12 +82,10 @@ mod tests {
 
         let input: Vec<f32> = (0..128).map(|i| i as f32 / 128.0).collect();
 
-        // Warm up
         for _ in 0..10 {
             network.forward(&input).unwrap();
         }
 
-        // Benchmark
         let iterations = 1000;
         let start = Instant::now();
         for _ in 0..iterations {
@@ -104,7 +96,6 @@ mod tests {
         let avg_us = elapsed.as_micros() as f64 / iterations as f64;
         println!("Average inference time: {avg_us:.2} us");
 
-        // Should be well under 5ms (5000us)
         assert!(avg_us < 5000.0, "Inference too slow: {avg_us} us");
     }
 
@@ -118,11 +109,9 @@ mod tests {
 
         let input = [1.0, 2.0, 3.0, 4.0];
 
-        // Run multiple times
         let output1 = network.forward(&input).unwrap().to_vec();
         let output2 = network.forward(&input).unwrap().to_vec();
 
-        // Should be deterministic
         for (a, b) in output1.iter().zip(output2.iter()) {
             assert!((a - b).abs() < 1e-6);
         }

--- a/crates/fann/src/network/builder.rs
+++ b/crates/fann/src/network/builder.rs
@@ -11,8 +11,7 @@ use crate::error::{FannError, FannResult};
 use crate::layer::Layer;
 use crate::network::Network;
 
-/// Fluent builder for a dense feedforward network.
-/// See [`docs/network.md`](../../docs/network.md#networkbuilder) for construction examples.
+/// Fluent builder for dense feedforward networks.
 #[derive(Debug, Clone, Default)]
 pub struct NetworkBuilder {
     input_size: Option<usize>,
@@ -20,35 +19,30 @@ pub struct NetworkBuilder {
 }
 
 impl NetworkBuilder {
-    /// Create a new network builder
+    /// Creates a new network builder.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Set the input size for the network
-    ///
-    /// This must be called before `build` or `build_with_seed`; call order is otherwise
-    /// unconstrained.
+    /// Sets the input width.
     pub fn input(mut self, size: usize) -> Self {
         self.input_size = Some(size);
         self
     }
 
-    /// Add a hidden layer with the specified size and activation
+    /// Adds a hidden layer.
     pub fn hidden(mut self, size: usize, activation: Activation) -> Self {
         self.layers.push((size, activation));
         self
     }
 
-    /// Add the output layer with the specified size and activation
-    ///
-    /// This is semantically the same as `hidden` but improves readability.
+    /// Adds the output layer.
     pub fn output(mut self, size: usize, activation: Activation) -> Self {
         self.layers.push((size, activation));
         self
     }
 
-    /// Add a layer with default ReLU activation
+    /// Adds a ReLU layer.
     pub fn dense(self, size: usize) -> Self {
         self.hidden(size, Activation::ReLU)
     }
@@ -88,7 +82,6 @@ impl NetworkBuilder {
     /// Builds the configured network with deterministic initialization from `seed`.
     ///
     /// The same architecture and seed produce identical parameters.
-    /// See [`docs/network.md`](../../docs/network.md#networkbuilder) for reproducibility details.
     pub fn build_with_seed(self, seed: u64) -> FannResult<Network> {
         use rand::SeedableRng;
 
@@ -173,7 +166,6 @@ mod tests {
             .build()
             .unwrap();
 
-        // dense() uses ReLU
         assert_eq!(network.layer(0).unwrap().activation(), Activation::ReLU);
         assert_eq!(network.layer(1).unwrap().activation(), Activation::ReLU);
         assert_eq!(network.layer(2).unwrap().activation(), Activation::Softmax);
@@ -195,7 +187,6 @@ mod tests {
             .build_with_seed(42)
             .unwrap();
 
-        // Same seed should produce identical weights
         for i in 0..network1.num_layers() {
             let layer1 = network1.layer(i).unwrap();
             let layer2 = network2.layer(i).unwrap();
@@ -220,7 +211,6 @@ mod tests {
             .build_with_seed(123)
             .unwrap();
 
-        // Different seeds should produce different weights
         let layer1 = network1.layer(0).unwrap();
         let layer2 = network2.layer(0).unwrap();
         assert_ne!(layer1.weights(), layer2.weights());
@@ -228,7 +218,6 @@ mod tests {
 
     #[test]
     fn test_builder_rejects_hidden_softmax() {
-        // Softmax on a hidden layer should be rejected.
         let result = NetworkBuilder::new()
             .input(2)
             .hidden(4, Activation::Softmax)
@@ -239,7 +228,6 @@ mod tests {
             "expected InvalidBuilder, got {result:?}"
         );
 
-        // build_with_seed must enforce the same rule.
         let result = NetworkBuilder::new()
             .input(2)
             .hidden(4, Activation::Softmax)
@@ -253,7 +241,6 @@ mod tests {
 
     #[test]
     fn test_builder_output_softmax_is_allowed() {
-        // Softmax on the output layer must continue to work.
         let result = NetworkBuilder::new()
             .input(4)
             .hidden(8, Activation::ReLU)

--- a/crates/fann/src/network/mod.rs
+++ b/crates/fann/src/network/mod.rs
@@ -39,11 +39,9 @@ fn forward_into_buffers(
     input: &[f32],
     buffers: &mut [Vec<f32>],
 ) -> FannResult<()> {
-    // First layer takes input directly
     layers[0].forward(input, &mut buffers[0])?;
     check_numeric_stability(&buffers[0], 0)?;
 
-    // Subsequent layers take previous layer's output
     for i in 1..layers.len() {
         let (prev, curr) = buffers.split_at_mut(i);
         layers[i].forward(&prev[i - 1], &mut curr[0])?;
@@ -62,10 +60,7 @@ fn forward_into_buffers(
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "NetworkData"))]
 pub struct Network {
-    /// Network layers
     layers: Vec<Layer>,
-    /// Pre-allocated buffers for intermediate activations
-    /// `buffers[i]` holds the output of layer `i`.
     #[cfg_attr(feature = "serde", serde(skip))]
     buffers: Vec<Vec<f32>>,
 }
@@ -87,16 +82,13 @@ impl TryFrom<NetworkData> for Network {
 }
 
 impl Network {
-    /// Create a network from a list of layers
-    ///
-    /// Validates that layer dimensions are compatible and Softmax appears only
-    /// on the output layer.
+    /// Creates a network from compatible layers with terminal Softmax only.
     pub fn new(layers: Vec<Layer>) -> FannResult<Self> {
         if layers.is_empty() {
             return Err(FannError::EmptyNetwork);
         }
 
-        // Reject Softmax before the final layer: its derivative here is only diagonal (see ADR-023).
+        // Hidden Softmax needs a full Jacobian; this API exposes only its diagonal (ADR-023).
         if layers[..layers.len() - 1]
             .iter()
             .any(|layer| layer.activation().is_softmax())
@@ -108,7 +100,6 @@ impl Network {
             ));
         }
 
-        // Validate layer compatibility
         for i in 1..layers.len() {
             let prev_outputs = layers[i - 1].num_outputs();
             let curr_inputs = layers[i].num_inputs();
@@ -120,7 +111,6 @@ impl Network {
             }
         }
 
-        // Allocate buffers for intermediate activations
         let buffers = layers
             .iter()
             .map(|layer| vec![0.0; layer.num_outputs()])
@@ -152,23 +142,22 @@ impl Network {
     /// Returns an owned copy of the output and propagates `forward` validation errors.
     /// See [`docs/network.md`](../../docs/network.md#networkforward_async) for interface rationale.
     pub async fn forward_async(&mut self, input: &[f32]) -> FannResult<Vec<f32>> {
-        // CPU forward is synchronous, just wrap in async for API consistency
         self.forward(input).map(<[f32]>::to_vec)
     }
 
-    /// Get the number of inputs the network expects
+    /// Returns the expected input width.
     #[inline]
     pub fn num_inputs(&self) -> usize {
         self.layers[0].num_inputs()
     }
 
-    /// Get the number of outputs the network produces
+    /// Returns the output width.
     #[inline]
     pub fn num_outputs(&self) -> usize {
         self.layers[self.layers.len() - 1].num_outputs()
     }
 
-    /// Get the total number of parameters in the network
+    /// Returns the total parameter count.
     #[inline]
     pub fn total_params(&self) -> usize {
         self.layers
@@ -177,43 +166,43 @@ impl Network {
             .sum()
     }
 
-    /// Get the number of layers in the network
+    /// Returns the layer count.
     #[inline]
     pub fn num_layers(&self) -> usize {
         self.layers.len()
     }
 
-    /// Get a reference to a specific layer
+    /// Returns a layer by index.
     #[inline]
     pub fn layer(&self, index: usize) -> Option<&Layer> {
         self.layers.get(index)
     }
 
-    /// Get a mutable reference to a specific layer (for training)
+    /// Returns a mutable layer by index.
     #[inline]
     pub fn layer_mut(&mut self, index: usize) -> Option<&mut Layer> {
         self.layers.get_mut(index)
     }
 
-    /// Get all layers
+    /// Returns all layers.
     #[inline]
     pub fn layers(&self) -> &[Layer] {
         &self.layers
     }
 
-    /// Get all layers mutably (for training)
+    /// Returns all layers mutably.
     #[inline]
     pub fn layers_mut(&mut self) -> &mut [Layer] {
         &mut self.layers
     }
 
-    /// Get intermediate activations buffer for a layer (for debugging/training)
+    /// Returns a layer's latest activation buffer.
     #[inline]
     pub fn activations(&self, layer_index: usize) -> Option<&[f32]> {
         self.buffers.get(layer_index).map(std::vec::Vec::as_slice)
     }
 
-    /// Get network architecture as a string
+    /// Formats the network architecture.
     pub fn architecture(&self) -> String {
         let mut parts = vec![self.num_inputs().to_string()];
         for layer in &self.layers {
@@ -235,7 +224,6 @@ impl Network {
         inputs
             .par_iter()
             .map(|input| {
-                // Allocate only activation buffers — weights are shared via &self
                 let mut buffers: Vec<Vec<f32>> = self
                     .layers
                     .iter()
@@ -279,7 +267,6 @@ mod tests {
         let input = [1.0, 2.0, 3.0, 4.0];
         let output = network.forward(&input).unwrap();
 
-        // Softmax output should sum to 1
         let sum: f32 = output.iter().sum();
         assert!((sum - 1.0).abs() < 1e-5);
     }
@@ -380,7 +367,6 @@ mod tests {
         let input = [1.0, 2.0];
         network.forward(&input).unwrap();
 
-        // Can access intermediate activations
         let hidden_activations = network.activations(0).unwrap();
         assert_eq!(hidden_activations.len(), 4);
 
@@ -402,7 +388,6 @@ mod tests {
         let output1 = network1.forward(&input).unwrap().to_vec();
         let output2 = network2.forward(&input).unwrap().to_vec();
 
-        // Cloned networks should produce same output
         for (a, b) in output1.iter().zip(output2.iter()) {
             assert!((a - b).abs() < 1e-5);
         }
@@ -415,7 +400,6 @@ mod serde_validation_tests {
     use crate::activation::Activation;
 
     fn sample_network() -> Network {
-        // 3 -> 4 (ReLU) -> 2 (Linear): first layer has 3*4 = 12 weights.
         NetworkBuilder::new()
             .input(3)
             .hidden(4, Activation::ReLU)
@@ -428,8 +412,7 @@ mod serde_validation_tests {
     fn roundtrip_rebuilds_skipped_buffers_and_runs_forward() {
         let net = sample_network();
         let json = serde_json::to_string(&net).unwrap();
-        // `buffers` is #[serde(skip)] — a direct field-deserialize would leave it
-        // empty and panic in forward. The TryFrom path must rebuild it.
+        // Deserialization must rebuild skipped activation buffers.
         let mut restored: Network = serde_json::from_str(&json).unwrap();
         let out = restored.forward(&[1.0, 2.0, 3.0]).unwrap();
         assert_eq!(out.len(), 2);
@@ -446,9 +429,6 @@ mod serde_validation_tests {
 
     #[test]
     fn layer_with_short_weights_is_rejected() {
-        // Serialize a valid network, then drop one weight from the first layer
-        // so weights.len() no longer equals num_inputs * num_outputs. Routing
-        // through Value avoids hard-coding the Activation serialization format.
         let net = sample_network();
         let json = serde_json::to_string(&net).unwrap();
         let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/crates/fann/src/network/serialization.rs
+++ b/crates/fann/src/network/serialization.rs
@@ -17,22 +17,16 @@ impl Network {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 
-        // Magic number "FANN"
         bytes.extend_from_slice(b"FANN");
 
-        // Version (1)
         bytes.extend_from_slice(&1u32.to_le_bytes());
 
-        // Number of layers
         bytes.extend_from_slice(&(self.layers().len() as u32).to_le_bytes());
 
-        // Each layer
         for layer in self.layers() {
-            // Dimensions
             bytes.extend_from_slice(&(layer.num_inputs() as u32).to_le_bytes());
             bytes.extend_from_slice(&(layer.num_outputs() as u32).to_le_bytes());
 
-            // Activation type
             match layer.activation() {
                 Activation::Linear => bytes.push(0),
                 Activation::Sigmoid => bytes.push(1),
@@ -45,12 +39,10 @@ impl Network {
                 Activation::Softmax => bytes.push(5),
             }
 
-            // Weights
             for &w in layer.weights() {
                 bytes.extend_from_slice(&w.to_le_bytes());
             }
 
-            // Biases
             for &b in layer.biases() {
                 bytes.extend_from_slice(&b.to_le_bytes());
             }
@@ -66,9 +58,8 @@ impl Network {
     pub fn from_bytes(bytes: &[u8]) -> FannResult<Self> {
         let mut pos = 0;
 
-        // Read only after an overflow-safe remaining-byte check.
         let read_bytes = |pos: &mut usize, n: usize| -> FannResult<&[u8]> {
-            // Subtraction avoids overflow with hostile byte counts — see docs/network.md.
+            // Avoid overflow from untrusted byte counts.
             let available = bytes.len().saturating_sub(*pos);
             if n > available {
                 return Err(FannError::InvalidBuilder(format!(
@@ -81,7 +72,6 @@ impl Network {
             Ok(slice)
         };
 
-        // Read magic number
         let magic = read_bytes(&mut pos, 4)?;
         if magic != b"FANN" {
             return Err(FannError::InvalidBuilder(format!(
@@ -89,7 +79,6 @@ impl Network {
             )));
         }
 
-        // Read version
         let version_bytes: [u8; 4] = read_bytes(&mut pos, 4)?
             .try_into()
             .map_err(|_| FannError::InvalidBuilder("Failed to read version".into()))?;
@@ -100,7 +89,6 @@ impl Network {
             )));
         }
 
-        // Read number of layers
         let num_layers_bytes: [u8; 4] = read_bytes(&mut pos, 4)?
             .try_into()
             .map_err(|_| FannError::InvalidBuilder("Failed to read num_layers".into()))?;
@@ -110,7 +98,7 @@ impl Network {
             return Err(FannError::EmptyNetwork);
         }
 
-        // Every layer needs 9 header bytes; bound counts before allocation — see docs/network.md.
+        // Require every declared layer header before allocating.
         let remaining_for_layers = bytes.len().saturating_sub(pos);
         let max_plausible_layers = remaining_for_layers / 9;
         if num_layers > max_plausible_layers {
@@ -119,13 +107,11 @@ impl Network {
                  bytes can encode (max plausible with 9 bytes/layer: {max_plausible_layers})"
             )));
         }
-        // Apply the general allocation guard as defence in depth.
         validate_allocation_size(num_layers)?;
 
         let mut layers = Vec::with_capacity(num_layers);
 
         for layer_idx in 0..num_layers {
-            // Read dimensions
             let num_inputs_bytes: [u8; 4] = read_bytes(&mut pos, 4)?
                 .try_into()
                 .map_err(|_| FannError::InvalidBuilder("Failed to read num_inputs".into()))?;
@@ -136,10 +122,9 @@ impl Network {
                 .map_err(|_| FannError::InvalidBuilder("Failed to read num_outputs".into()))?;
             let num_outputs = u32::from_le_bytes(num_outputs_bytes) as usize;
 
-            // Validate hostile dimensions before collecting payloads — see docs/network.md.
+            // Validate dimensions before allocating payload vectors.
             validate_layer_dimensions(num_inputs, num_outputs)?;
 
-            // Read activation type
             let activation_type = read_bytes(&mut pos, 1)?[0];
             let activation = match activation_type {
                 0 => Activation::Linear,
@@ -161,7 +146,7 @@ impl Network {
                 }
             };
 
-            // Checked payload sizing rejects hostile dimensions without allocation — see docs/network.md.
+            // Check untrusted payload sizes before reading them.
             let weight_count = num_inputs.checked_mul(num_outputs).ok_or_else(|| {
                 FannError::InvalidBuilder(format!(
                     "layer {layer_idx}: num_inputs ({num_inputs}) * num_outputs \
@@ -177,7 +162,6 @@ impl Network {
             let weights: Vec<f32> = weight_bytes
                 .chunks_exact(4)
                 .map(|chunk| {
-                    // SAFETY: chunks_exact(4) guarantees exactly 4 bytes per chunk
                     let arr: [u8; 4] = chunk
                         .try_into()
                         .expect("chunks_exact(4) guarantees 4 bytes");
@@ -185,7 +169,6 @@ impl Network {
                 })
                 .collect();
 
-            // Bias payload sizing uses the same checked-arithmetic boundary.
             let bias_byte_count = num_outputs.checked_mul(4).ok_or_else(|| {
                 FannError::InvalidBuilder(format!(
                     "layer {layer_idx}: bias byte count overflows ({num_outputs} * 4)"
@@ -195,7 +178,6 @@ impl Network {
             let biases: Vec<f32> = bias_bytes
                 .chunks_exact(4)
                 .map(|chunk| {
-                    // SAFETY: chunks_exact(4) guarantees exactly 4 bytes per chunk
                     let arr: [u8; 4] = chunk
                         .try_into()
                         .expect("chunks_exact(4) guarantees 4 bytes");
@@ -207,7 +189,6 @@ impl Network {
             layers.push(layer);
         }
 
-        // The format is exact-length; trailing bytes are malformed — see docs/network.md.
         if pos != bytes.len() {
             return Err(FannError::InvalidBuilder(format!(
                 "trailing bytes after parsing: consumed {pos} of {} bytes; \
@@ -243,7 +224,6 @@ mod tests {
         assert_eq!(original.num_layers(), restored.num_layers());
         assert_eq!(original.total_params(), restored.total_params());
 
-        // Verify weights match
         for i in 0..original.num_layers() {
             let orig_layer = original.layer(i).unwrap();
             let rest_layer = restored.layer(i).unwrap();
@@ -269,7 +249,6 @@ mod tests {
         let bytes = original.to_bytes();
         let restored = Network::from_bytes(&bytes).unwrap();
 
-        // Verify LeakyReLU alpha is preserved
         assert_eq!(
             original.layer(0).unwrap().activation(),
             Activation::LeakyReLU(alpha)
@@ -296,7 +275,6 @@ mod tests {
 
     #[test]
     fn test_from_bytes_empty_network() {
-        // Valid header with 0 layers
         let bytes = b"FANN\x01\x00\x00\x00\x00\x00\x00\x00";
         let result = Network::from_bytes(bytes);
         assert!(matches!(result, Err(FannError::EmptyNetwork)));
@@ -304,7 +282,6 @@ mod tests {
 
     #[test]
     fn test_serialization_forward_consistency() {
-        // Build with seed for reproducibility
         let mut original = NetworkBuilder::new()
             .input(4)
             .hidden(8, Activation::ReLU)
@@ -315,28 +292,17 @@ mod tests {
         let input = [1.0, 2.0, 3.0, 4.0];
         let original_output = original.forward(&input).unwrap().to_vec();
 
-        // Serialize and deserialize
         let bytes = original.to_bytes();
         let mut restored = Network::from_bytes(&bytes).unwrap();
         let restored_output = restored.forward(&input).unwrap().to_vec();
 
-        // Outputs should be identical
         for (orig, rest) in original_output.iter().zip(restored_output.iter()) {
             assert!((orig - rest).abs() < 1e-6);
         }
     }
 
-    // ── FIX 2: bounds-before-allocation + trailing-bytes tests ──────────────
-
-    /// A header with num_layers = 0xFFFFFFFF and a short buffer must return
-    /// Err(FannError::InvalidBuilder) without attempting any large allocation.
-    ///
-    /// Mutation that defeats this test: remove the remaining-bytes bounds check
-    /// before Vec::with_capacity(num_layers).
     #[test]
     fn from_bytes_large_num_layers_short_buffer_returns_err() {
-        // Only 12 bytes: magic + version + num_layers=0xFFFFFFFF.
-        // remaining_for_layers = 0, max_plausible = 0 < 0xFFFFFFFF → Err.
         let mut bytes = b"FANN".to_vec();
         bytes.extend_from_slice(&1u32.to_le_bytes());
         bytes.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes());
@@ -347,11 +313,6 @@ mod tests {
         );
     }
 
-    /// A valid serialized blob with one extra trailing byte must return
-    /// Err(FannError::InvalidBuilder).
-    ///
-    /// Mutation that defeats this test: remove the trailing-bytes check after
-    /// the layer loop.
     #[test]
     fn from_bytes_trailing_bytes_returns_err() {
         let net = NetworkBuilder::new()
@@ -369,20 +330,6 @@ mod tests {
         );
     }
 
-    /// A header declaring a huge weight count (num_inputs * num_outputs far
-    /// above MAX_ALLOWED_ELEMENTS) must be rejected by the early per-layer size
-    /// cap with Err(FannError::ShapeTooLarge), before any byte-count arithmetic,
-    /// read, or allocation.
-    ///
-    /// With num_inputs=3_000_000_000 and num_outputs=2_000_000_000 the element
-    /// count is 6e18 — a valid usize, but ~6e10x the 100M cap. validate_layer_dimensions
-    /// (run right after the dimensions are read) rejects it via validate_allocation_size.
-    /// The downstream weight_count.checked_mul(4) guard remains as defence in depth
-    /// but is unreachable for these dimensions because the cap fires first.
-    ///
-    /// Mutation that defeats this test: remove the early validate_layer_dimensions
-    /// call — the parser then reaches weight_count.checked_mul(4), which overflows
-    /// (6e18 * 4 = 2.4e19 > usize::MAX) and returns InvalidBuilder instead.
     #[test]
     fn from_bytes_huge_weight_dims_rejected_by_size_cap() {
         let mut bytes = b"FANN".to_vec();
@@ -391,7 +338,6 @@ mod tests {
         bytes.extend_from_slice(&3_000_000_000_u32.to_le_bytes()); // num_inputs
         bytes.extend_from_slice(&2_000_000_000_u32.to_le_bytes()); // num_outputs
         bytes.push(0); // activation=Linear
-        // 21 bytes total; the layer bounds check passes (remaining=9, max=1 layer).
         let result = Network::from_bytes(&bytes);
         assert!(
             matches!(result, Err(FannError::ShapeTooLarge { .. })),
@@ -399,20 +345,6 @@ mod tests {
         );
     }
 
-    /// A header with near-usize::MAX-product dimensions must be rejected cleanly
-    /// (Err, no panic) by the early per-layer size cap. This pins that
-    /// validate_layer_dimensions itself does not overflow/panic on extreme
-    /// dimensions: its internal checked_mul handles the 2^62-1 product, and
-    /// validate_allocation_size then rejects it with ShapeTooLarge.
-    ///
-    /// num_inputs = 2^31-1, num_outputs = 2^31+1 → product = 2^62-1 (a valid
-    /// usize, ~4.6e10x the 100M cap). The cap fires before the weight byte-count
-    /// arithmetic and before read_bytes is asked for the (usize::MAX-3) payload,
-    /// so the overflow-safe read_bytes guard remains as defence in depth here.
-    ///
-    /// Mutation that defeats this test: remove the early validate_layer_dimensions
-    /// call — the parser then reaches read_bytes(pos=21, usize::MAX-3) and returns
-    /// a truncation InvalidBuilder instead of ShapeTooLarge.
     #[test]
     fn from_bytes_near_usize_max_dims_rejected_by_size_cap() {
         let mut bytes = b"FANN".to_vec();
@@ -430,13 +362,6 @@ mod tests {
 
     #[test]
     fn from_bytes_oversized_layer_dims_rejected_before_allocation() {
-        // A hostile header declaring more than MAX_ALLOWED_ELEMENTS weights must
-        // be rejected by the size cap BEFORE from_bytes reads or collects the
-        // weight payload. This buffer carries no weight bytes at all: if the cap
-        // were enforced only inside Layer::with_weights (after collection), the
-        // parser would first attempt the oversized weight read and return a
-        // truncation InvalidBuilder. Reverting the early validate_layer_dimensions
-        // call makes this case return InvalidBuilder instead of ShapeTooLarge.
         let mut bytes = b"FANN".to_vec();
         bytes.extend_from_slice(&1u32.to_le_bytes()); // version=1
         bytes.extend_from_slice(&1u32.to_le_bytes()); // num_layers=1

--- a/crates/fann/src/training/backprop.rs
+++ b/crates/fann/src/training/backprop.rs
@@ -8,21 +8,21 @@ use crate::network::Network;
 use crate::training::gradient::{GradientGuardStrategy, check_gradients_valid, sanitize_gradients};
 use crate::training::{Trainer, TrainingConfig, TrainingResult};
 
-/// Basic backpropagation trainer with momentum
+/// Backpropagation trainer with momentum.
 #[derive(Debug, Default)]
 pub struct BackpropTrainer {
-    /// Velocity buffers for momentum (one per layer)
+    /// Per-layer momentum buffers.
     weight_velocities: Vec<Vec<f32>>,
     bias_velocities: Vec<Vec<f32>>,
 }
 
 impl BackpropTrainer {
-    /// Create a new backpropagation trainer
+    /// Creates a backpropagation trainer.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Initialize velocity buffers for a network
+    /// Initializes momentum buffers for a network.
     fn init_velocities(&mut self, network: &Network) {
         self.weight_velocities.clear();
         self.bias_velocities.clear();
@@ -36,9 +36,7 @@ impl BackpropTrainer {
 
     /// Compute gradients for a single training sample using backpropagation.
     ///
-    /// After the forward pass, copies the final output so weights and activations can be
-    /// borrowed directly from the network. Delta vectors are allocated per sample; layer
-    /// weights and activation buffers are not cloned.
+    /// Copies the output so it can borrow the network for backpropagation.
     fn compute_gradients(
         &self,
         network: &mut Network,
@@ -49,24 +47,18 @@ impl BackpropTrainer {
     ) -> FannResult<f32> {
         let num_layers = network.num_layers();
 
-        // Forward pass (populates activation buffers) — only mutation
         let output: Vec<f32> = network.forward(input)?.to_vec();
         let output_len = output.len();
 
-        // After forward returns, reborrow network immutably.
-        // Reference layers and activations directly — no cloning needed.
         let layers = network.layers();
 
-        // Compute output error (MSE derivative)
         let mut error = 0.0;
         let mut deltas: Vec<Vec<f32>> = Vec::with_capacity(num_layers);
 
-        // Output layer deltas
         let output_activation = layers[num_layers - 1].activation();
         let mut output_deltas = vec![0.0_f32; output_len];
         if matches!(output_activation, crate::activation::Activation::Softmax) {
-            // Full Jacobian for softmax: J[i,j] = s[j]*(delta[i,j] - s[i])
-            // Chain rule with MSE loss: delta[i] = sum_j((output[j]-target[j]) * J[j,i])
+            // Softmax output requires its full Jacobian.
             for i in 0..output_len {
                 let mut delta = 0.0_f32;
                 for j in 0..output_len {
@@ -91,7 +83,6 @@ impl BackpropTrainer {
         }
         deltas.push(output_deltas);
 
-        // Backpropagate deltas through hidden layers
         for layer_idx in (0..num_layers - 1).rev() {
             let layer_activation = layers[layer_idx].activation();
             let layer_num_outputs = layers[layer_idx].num_outputs();
@@ -120,10 +111,8 @@ impl BackpropTrainer {
             deltas.push(layer_deltas);
         }
 
-        // Reverse deltas (now in layer order)
         deltas.reverse();
 
-        // Compute gradients — reference layer dimensions and activations directly
         for (layer_idx, delta) in deltas.iter().enumerate() {
             let num_inputs = layers[layer_idx].num_inputs();
             let num_outputs = layers[layer_idx].num_outputs();
@@ -138,14 +127,12 @@ impl BackpropTrainer {
                 })?
             };
 
-            // Weight gradients: dW[i,j] = delta[i] * input[j]
             for (i, &d) in delta.iter().enumerate().take(num_outputs) {
                 for (j, &inp) in layer_input.iter().enumerate().take(num_inputs) {
                     weight_grads[layer_idx][i * num_inputs + j] += d * inp;
                 }
             }
 
-            // Bias gradients: dB[i] = delta[i]
             for (i, &d) in delta.iter().enumerate().take(num_outputs) {
                 bias_grads[layer_idx][i] += d;
             }
@@ -154,7 +141,7 @@ impl BackpropTrainer {
         Ok(error / output_len as f32)
     }
 
-    /// Apply gradients with momentum and weight decay
+    /// Applies gradients with momentum and weight decay.
     fn apply_gradients(
         &mut self,
         network: &mut Network,
@@ -172,17 +159,14 @@ impl BackpropTrainer {
                 continue;
             };
 
-            // Update weights
             let weights = layer.weights_mut();
             for (i, w) in weights.iter_mut().enumerate() {
-                // Momentum update
                 self.weight_velocities[layer_idx][i] = momentum
                     * self.weight_velocities[layer_idx][i]
                     - lr * (weight_grads[layer_idx][i] + weight_decay * *w);
                 *w += self.weight_velocities[layer_idx][i];
             }
 
-            // Update biases
             let biases = layer.biases_mut();
             for (i, b) in biases.iter_mut().enumerate() {
                 self.bias_velocities[layer_idx][i] =
@@ -219,7 +203,6 @@ impl Trainer for BackpropTrainer {
             )));
         }
 
-        // Validate dimensions
         for (i, (input, target)) in inputs.iter().zip(targets.iter()).enumerate() {
             if input.len() != network.num_inputs() {
                 return Err(FannError::TrainingError(format!(
@@ -239,10 +222,8 @@ impl Trainer for BackpropTrainer {
             }
         }
 
-        // Initialize velocity buffers
         self.init_velocities(network);
 
-        // Allocate gradient buffers
         let mut weight_grads: Vec<Vec<f32>> = network
             .layers()
             .iter()
@@ -257,7 +238,6 @@ impl Trainer for BackpropTrainer {
         let mut error_history = Vec::with_capacity(config.max_epochs);
         let mut indices: Vec<usize> = (0..inputs.len()).collect();
 
-        // Create RNG once before the epoch loop to avoid per-epoch allocation
         use rand::SeedableRng;
         let mut rng = match config.seed {
             Some(seed) => rand::rngs::SmallRng::seed_from_u64(seed),
@@ -265,7 +245,6 @@ impl Trainer for BackpropTrainer {
         };
 
         for epoch in 0..config.max_epochs {
-            // Shuffle if configured
             if config.shuffle {
                 use rand::seq::SliceRandom;
                 indices.shuffle(&mut rng);
@@ -274,7 +253,6 @@ impl Trainer for BackpropTrainer {
             let mut epoch_error = 0.0;
             let mut batch_count = 0;
 
-            // Process batches
             let effective_batch_size = if config.batch_size == 0 {
                 1
             } else {
@@ -284,7 +262,6 @@ impl Trainer for BackpropTrainer {
                 let batch_end = (batch_start + effective_batch_size).min(inputs.len());
                 let actual_batch_size = batch_end - batch_start;
 
-                // Zero gradients
                 for grads in weight_grads.iter_mut() {
                     grads.fill(0.0);
                 }
@@ -292,8 +269,7 @@ impl Trainer for BackpropTrainer {
                     grads.fill(0.0);
                 }
 
-                // Accumulate gradients over batch; keep batch error separate so
-                // SkipBatch can discard it without inflating epoch_error.
+                // Keep skipped batches out of the epoch metric.
                 let mut batch_error = 0.0_f32;
                 for &idx in &indices[batch_start..batch_end] {
                     let error = self.compute_gradients(
@@ -306,7 +282,6 @@ impl Trainer for BackpropTrainer {
                     batch_error += error;
                 }
 
-                // Check for NaN/Inf gradients before applying
                 let gradient_check = check_gradients_valid(&weight_grads, &bias_grads);
                 if let Err(location) = gradient_check {
                     match config.gradient_guard {
@@ -316,8 +291,6 @@ impl Trainer for BackpropTrainer {
                             )));
                         }
                         GradientGuardStrategy::Sanitize => {
-                            // Replace NaN/Inf with zeros and continue; batch is
-                            // still applied (sanitized) so we commit its error.
                             for grads in weight_grads.iter_mut() {
                                 sanitize_gradients(grads);
                             }
@@ -331,8 +304,7 @@ impl Trainer for BackpropTrainer {
                             );
                         }
                         GradientGuardStrategy::SkipBatch => {
-                            // Discard both gradients AND error for this batch so
-                            // epoch_error stays proportional to batch_count.
+                            // Skipped batches contribute neither update nor error.
                             tracing::warn!(
                                 "Epoch {}: skipping batch due to NaN/Inf gradients ({})",
                                 epoch,
@@ -343,7 +315,6 @@ impl Trainer for BackpropTrainer {
                     }
                 }
 
-                // Apply gradients
                 self.apply_gradients(
                     network,
                     &weight_grads,
@@ -352,23 +323,20 @@ impl Trainer for BackpropTrainer {
                     actual_batch_size,
                 );
 
-                // Commit error and sample count only for non-skipped batches.
                 epoch_error += batch_error;
                 batch_count += actual_batch_size;
             }
 
-            // Every batch was skipped — error metric is undefined; fail loudly.
+            // An all-skipped epoch has no defined error metric.
             if batch_count == 0 {
                 return Err(FannError::NumericInstability(
                     "all batches skipped due to NaN/Inf gradients".into(),
                 ));
             }
 
-            // Average error
             let avg_error = epoch_error / batch_count as f32;
             error_history.push(avg_error);
 
-            // Check convergence
             if avg_error < config.target_error {
                 return Ok(TrainingResult {
                     final_error: avg_error,
@@ -378,9 +346,6 @@ impl Trainer for BackpropTrainer {
                 });
             }
 
-            // Catch both NaN and +Inf (the latter arises when every batch skips
-            // but batch_count is somehow non-zero due to partial skips and a
-            // very large accumulated error).
             if avg_error.is_nan() || avg_error.is_infinite() {
                 return Err(FannError::NumericInstability(
                     "non-finite error during training".into(),
@@ -405,7 +370,6 @@ mod tests {
 
     #[test]
     fn test_xor_training() {
-        // XOR problem - classic test for neural network training
         let mut network = NetworkBuilder::new()
             .input(2)
             .hidden(4, Activation::Tanh)
@@ -437,8 +401,6 @@ mod tests {
 
         let result = trainer.train(&mut network, &inputs, &targets, &config);
 
-        // Training should complete without error
-        // Note: XOR convergence is not guaranteed with random initialization
         assert!(result.is_ok());
     }
 
@@ -495,10 +457,6 @@ mod tests {
 
     #[test]
     fn test_skip_batch_all_skipped_returns_error() {
-        // Targets containing NaN propagate into gradients (diff = output - NaN = NaN),
-        // triggering the gradient guard on every batch.  With SkipBatch the whole
-        // epoch completes with batch_count == 0, which must be an Err not an Ok
-        // with a non-finite final_error.
         let mut network = NetworkBuilder::new()
             .input(2)
             .hidden(2, Activation::Tanh)
@@ -507,7 +465,6 @@ mod tests {
             .unwrap();
 
         let inputs = vec![vec![1.0_f32, 0.0], vec![0.0, 1.0]];
-        // NaN targets guarantee NaN in every gradient computation.
         let targets = vec![vec![f32::NAN], vec![f32::NAN]];
 
         let mut trainer = BackpropTrainer::new();
@@ -524,7 +481,6 @@ mod tests {
             matches!(result, Err(FannError::NumericInstability(_))),
             "expected NumericInstability, got {result:?}"
         );
-        // Confirm the error text is informative (not just any instability error).
         if let Err(FannError::NumericInstability(msg)) = result {
             assert!(
                 msg.contains("all batches skipped"),
@@ -535,7 +491,6 @@ mod tests {
 
     #[test]
     fn test_linear_regression() {
-        // Simple linear regression: y = 2x + 1
         let mut network = NetworkBuilder::new()
             .input(1)
             .output(1, Activation::Linear)
@@ -558,7 +513,6 @@ mod tests {
             .train(&mut network, &inputs, &targets, &config)
             .unwrap();
 
-        // Linear regression should converge easily
         assert!(
             result.final_error < 0.1,
             "Error {} too high",

--- a/crates/fann/src/training/ewc.rs
+++ b/crates/fann/src/training/ewc.rs
@@ -8,28 +8,24 @@
 
 use crate::error::{FannError, FannResult, validate_allocation_size};
 
-/// A flat-slice EWC++ diagonal-Fisher forgetting guard.
-///
-/// Tracks EMA importance and a matching parameter anchor for each entry.
-/// See [`docs/training.md`](../../docs/training.md#elastic-weight-consolidation-ewc) for the lifecycle and update formulas.
+/// Flat-slice EWC++ diagonal-Fisher forgetting guard.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DiagonalFisher {
-    /// Diagonal Fisher estimate: EMA of squared gradients, one entry per parameter.
+    /// Per-parameter Fisher estimate.
     pub values: Vec<f32>,
-    /// Anchor (reference) parameter vector captured at the end of a prior task.
+    /// Reference parameters from a prior task.
     pub anchor: Vec<f32>,
-    /// EMA decay factor ∈ (0, 1). Higher values give slower decay and longer memory.
+    /// EMA decay in `(0, 1)`.
     pub decay: f32,
 }
 
 impl DiagonalFisher {
     /// Creates zeroed Fisher and anchor vectors for `num_params` parameters.
     ///
-    /// Returns [`FannError::InvalidDistributionParams`] for non-finite or out-of-range `decay`, or [`FannError::ShapeTooLarge`] for an oversized allocation.
-    /// See [`docs/training.md`](../../docs/training.md#diagonal-fisher-information-as-an-importance-estimate) for the EMA rule and decay rationale.
+    /// Rejects invalid decay or oversized allocations.
     pub fn new(num_params: usize, decay: f32) -> FannResult<Self> {
-        // Decay must retain history and a positive fresh-gradient contribution — see docs/training.md.
+        // The EMA needs both retained and fresh-gradient terms.
         if !decay.is_finite() || decay <= 0.0 || decay >= 1.0 {
             return Err(FannError::InvalidDistributionParams(format!(
                 "EWC decay must be finite and in the open interval (0, 1), got {decay}"
@@ -45,8 +41,7 @@ impl DiagonalFisher {
 
     /// Updates each Fisher entry from the corresponding gradient observation.
     ///
-    /// Returns [`FannError::InputSizeMismatch`] unless `grad` matches the parameter count.
-    /// See [`docs/training.md`](../../docs/training.md#diagonal-fisher-information-as-an-importance-estimate) for the EWC++ EMA rule.
+    /// Rejects a gradient with the wrong parameter count.
     pub fn observe_gradient(&mut self, grad: &[f32]) -> FannResult<()> {
         if grad.len() != self.values.len() {
             return Err(FannError::InputSizeMismatch {
@@ -56,17 +51,12 @@ impl DiagonalFisher {
         }
         let one_minus_decay = 1.0 - self.decay;
         for (f, &g) in self.values.iter_mut().zip(grad.iter()) {
-            // EMA of g² accumulates squared-gradient importance over time.
             *f = self.decay * *f + one_minus_decay * g * g;
         }
         Ok(())
     }
 
-    /// Fix the anchor (reference) parameter vector at a task boundary.
-    ///
-    /// The EWC penalty measures deviation from these anchor parameters, so
-    /// call this once after the prior task finishes training. Returns an
-    /// error if `params.len()` does not match the guard's parameter count.
+    /// Stores reference parameters at a task boundary.
     pub fn set_anchor(&mut self, params: &[f32]) -> FannResult<()> {
         if params.len() != self.anchor.len() {
             return Err(FannError::InputSizeMismatch {
@@ -80,8 +70,7 @@ impl DiagonalFisher {
 
     /// Adds the EWC penalty gradient for `params` into `out`.
     ///
-    /// Returns [`FannError::InputSizeMismatch`] unless both slices match the Fisher length.
-    /// See [`docs/training.md`](../../docs/training.md#anchor--penalty-gradient) for the formula and descent integration.
+    /// Rejects slices that differ from the Fisher length.
     pub fn penalty_gradient(&self, params: &[f32], lambda: f32, out: &mut [f32]) -> FannResult<()> {
         let n = self.values.len();
         if params.len() != n {
@@ -96,7 +85,6 @@ impl DiagonalFisher {
                 actual: out.len(),
             });
         }
-        // self.anchor.len() == n by construction (set_anchor length-checks any update).
         for (((v, anchor), p), out_elem) in self
             .values
             .iter()
@@ -104,7 +92,6 @@ impl DiagonalFisher {
             .zip(params.iter())
             .zip(out.iter_mut())
         {
-            // Gradient of (λ/2)·F_i·(θ_i − θ*_i)² is λ·F_i·(θ_i − θ*_i).
             *out_elem += lambda * v * (p - anchor);
         }
         Ok(())
@@ -112,17 +99,14 @@ impl DiagonalFisher {
 
     /// Damp the common prefix of a raw parameter update by Fisher importance.
     ///
-    /// Leaves `delta` unchanged when the estimate has no importance signal.
-    /// See [`docs/training.md`](../../docs/training.md#null-space-delta-projection) for the scaling rule and trade-offs.
+    /// Leaves `delta` unchanged without an importance signal.
     pub fn project_delta(&self, delta: &mut [f32]) {
         let f_max = self.values.iter().copied().fold(0.0_f32, f32::max);
 
-        // No importance signal has been observed yet — treat as identity.
         if f_max < 1e-8 {
             return;
         }
 
-        // Damp high-Fisher updates while preserving low-Fisher ones — see docs/training.md.
         for (d, &v) in delta.iter_mut().zip(self.values.iter()) {
             *d *= (1.0 - v / f_max).max(0.0);
         }
@@ -135,15 +119,11 @@ mod tests {
 
     use crate::error::MAX_ALLOWED_ELEMENTS;
 
-    /// A degenerate Fisher (all-zero values) must leave delta unchanged.
-    ///
-    /// Verifies the early-return path in project_delta — no projection, no panic.
     #[test]
     fn ewc_degenerate_fisher_is_identity() {
         let fisher = DiagonalFisher::new(4, 0.9).unwrap();
         let mut delta = vec![1.0_f32, -2.0, 3.0, -4.0];
         let original = delta.clone();
-        // values are all zero → f_max < 1e-8 → early return.
         fisher.project_delta(&mut delta);
         assert_eq!(
             delta, original,
@@ -151,23 +131,19 @@ mod tests {
         );
     }
 
-    /// High-Fisher entry blocks its parameter's update; zero-Fisher entry passes.
     #[test]
     fn ewc_high_fisher_blocks() {
         let mut fisher = DiagonalFisher::new(2, 0.9).unwrap();
-        // decay=0.9 → F[0] = 0.9*0 + 0.1*100² = 1000; F[1] = 0.
         fisher.observe_gradient(&[100.0, 0.0]).unwrap();
 
         let mut delta = vec![1.0_f32, 1.0];
         fisher.project_delta(&mut delta);
 
-        // F[0] == f_max → scale = (1 - 1000/1000).max(0) = 0 → blocked.
         assert!(
             delta[0].abs() < 1e-6,
             "high-Fisher entry should be blocked, got {}",
             delta[0]
         );
-        // F[1] == 0 → scale = (1 - 0/1000).max(0) = 1 → passes through.
         assert!(
             (delta[1] - 1.0).abs() < 1e-6,
             "zero-Fisher entry should pass through, got {}",
@@ -175,43 +151,30 @@ mod tests {
         );
     }
 
-    /// With anchor=0, params=[2], Fisher≈1, lambda=1 → out accumulates ≈+2.
-    ///
-    /// Uses decay=f32::EPSILON so (1−decay)≈1 and one unit-gradient observation
-    /// gives F[0]≈1.0; the penalty gradient is thus ≈ lambda·F[0]·(θ−θ*)=2.
-    /// This regression test pins the direction: positive gradient means the
-    /// update (w -= lr·g) pulls θ back toward the anchor, not away from it.
     #[test]
     fn ewc_penalty_gradient_pulls_to_anchor() {
         let mut fisher = DiagonalFisher::new(1, f32::EPSILON).unwrap();
-        // decay≈0 → values[0] ≈ g² = 1.0 after one unit-gradient observation.
         fisher.observe_gradient(&[1.0]).unwrap();
-        // anchor remains at zero (default).
 
         let params = vec![2.0_f32];
         let mut out = vec![0.0_f32];
         fisher.penalty_gradient(&params, 1.0, &mut out).unwrap();
 
-        // Gradient = lambda · F[0] · (theta[0] − anchor[0]) ≈ 1 · 1 · (2 − 0) = +2.
-        // Positive: subtracted in gradient descent → θ moves toward anchor.
         assert!(
             (out[0] - 2.0).abs() < 1e-5,
             "expected penalty gradient ≈+2.0 (toward anchor), got {}",
             out[0]
         );
-        // Direction check: penalty gradient must be strictly positive when θ > anchor.
         assert!(
             out[0] > 0.0,
             "penalty gradient must be positive when theta > anchor (toward anchor)"
         );
     }
 
-    /// Two EMA steps with decay=0.9 and unit gradient must match the closed-form.
     #[test]
     fn ewc_fisher_ema_accumulates() {
         let mut fisher = DiagonalFisher::new(1, 0.9).unwrap();
 
-        // Step 1: F = 0.9 * 0 + 0.1 * 1² = 0.1
         fisher.observe_gradient(&[1.0]).unwrap();
         assert!(
             (fisher.values[0] - 0.1).abs() < 1e-6,
@@ -219,7 +182,6 @@ mod tests {
             fisher.values[0]
         );
 
-        // Step 2: F = 0.9 * 0.1 + 0.1 * 1² = 0.09 + 0.10 = 0.19
         fisher.observe_gradient(&[1.0]).unwrap();
         assert!(
             (fisher.values[0] - 0.19).abs() < 1e-6,
@@ -228,7 +190,6 @@ mod tests {
         );
     }
 
-    /// observe_gradient with a wrong-length slice must return Err, not panic.
     #[test]
     fn ewc_length_mismatch_errors() {
         let mut fisher = DiagonalFisher::new(4, 0.9).unwrap();
@@ -236,11 +197,6 @@ mod tests {
         assert!(result.is_err(), "expected Err on length mismatch, got Ok");
     }
 
-    // ---- Allocation-bound guard tests ---------------------------------------
-
-    /// Constructing with num_params > MAX_ALLOWED_ELEMENTS must return Err, not panic.
-    ///
-    /// Mutation that breaks this: removing the `validate_allocation_size` call.
     #[test]
     fn diagonal_fisher_new_too_large_returns_err() {
         let result = DiagonalFisher::new(MAX_ALLOWED_ELEMENTS + 1, 0.9);
@@ -250,11 +206,6 @@ mod tests {
         );
     }
 
-    // ---- Decay-validation guard tests ---------------------------------------
-
-    /// decay = 0.0 must be rejected (lower bound of the open interval).
-    ///
-    /// Mutation that breaks this: removing or inverting the `decay <= 0.0` check.
     #[test]
     fn diagonal_fisher_new_decay_zero_returns_err() {
         let result = DiagonalFisher::new(4, 0.0);
@@ -264,9 +215,6 @@ mod tests {
         );
     }
 
-    /// decay = 1.0 must be rejected (upper bound of the open interval).
-    ///
-    /// Mutation that breaks this: removing or inverting the `decay >= 1.0` check.
     #[test]
     fn diagonal_fisher_new_decay_one_returns_err() {
         let result = DiagonalFisher::new(4, 1.0);
@@ -276,9 +224,6 @@ mod tests {
         );
     }
 
-    /// decay = -0.5 must be rejected (below zero).
-    ///
-    /// Mutation that breaks this: removing the `decay <= 0.0` check.
     #[test]
     fn diagonal_fisher_new_decay_negative_returns_err() {
         let result = DiagonalFisher::new(4, -0.5);
@@ -288,9 +233,6 @@ mod tests {
         );
     }
 
-    /// decay = NaN must be rejected.
-    ///
-    /// Mutation that breaks this: removing the `is_finite()` check.
     #[test]
     fn diagonal_fisher_new_decay_nan_returns_err() {
         let result = DiagonalFisher::new(4, f32::NAN);
@@ -300,9 +242,6 @@ mod tests {
         );
     }
 
-    /// decay = +Inf must be rejected.
-    ///
-    /// Mutation that breaks this: removing the `is_finite()` check.
     #[test]
     fn diagonal_fisher_new_decay_inf_returns_err() {
         let result = DiagonalFisher::new(4, f32::INFINITY);
@@ -312,7 +251,6 @@ mod tests {
         );
     }
 
-    /// Serialise then deserialise must produce a structurally equal value.
     #[cfg(feature = "serde")]
     #[test]
     fn ewc_fisher_roundtrips() {

--- a/crates/fann/src/training/gradient.rs
+++ b/crates/fann/src/training/gradient.rs
@@ -1,18 +1,13 @@
-//! Gradient utilities for training
+//! Gradient validation and guard strategies.
 //!
-//! Provides utilities for gradient checking, sanitization, and guard strategies.
 
-/// Check if a gradient vector contains NaN or Inf values.
-///
-/// Returns Some(index) of the first bad value, or None if all values are finite.
+/// Returns the index of the first non-finite gradient.
 #[inline]
 pub fn find_nan_or_inf(grads: &[f32]) -> Option<usize> {
     grads.iter().position(|&g| !g.is_finite())
 }
 
-/// Check multiple gradient vectors for NaN/Inf values.
-///
-/// Returns a description of where the bad value was found.
+/// Validates all weight and bias gradients.
 pub fn check_gradients_valid(
     weight_grads: &[Vec<f32>],
     bias_grads: &[Vec<f32>],
@@ -36,9 +31,7 @@ pub fn check_gradients_valid(
     Ok(())
 }
 
-/// Replace NaN/Inf values with zeros (gradient clipping fallback).
-///
-/// Returns the number of values replaced.
+/// Replaces non-finite gradients with zero and returns the count.
 pub fn sanitize_gradients(grads: &mut [f32]) -> usize {
     let mut count = 0;
     for g in grads.iter_mut() {
@@ -50,17 +43,17 @@ pub fn sanitize_gradients(grads: &mut [f32]) -> usize {
     count
 }
 
-/// Strategy for handling NaN/Inf gradients
+/// Response to non-finite gradients.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum GradientGuardStrategy {
-    /// Return an error immediately when NaN/Inf detected
+    /// Returns an error immediately.
     #[default]
     Error,
-    /// Replace NaN/Inf with zero and continue (gradient clipping fallback)
+    /// Replaces non-finite values with zero.
     Sanitize,
-    /// Skip the batch when NaN/Inf detected
+    /// Skips the batch.
     SkipBatch,
 }
 
@@ -70,19 +63,15 @@ mod tests {
 
     #[test]
     fn test_find_nan_or_inf() {
-        // Normal gradients
         let normal = vec![0.1, 0.2, 0.3, -0.5];
         assert!(find_nan_or_inf(&normal).is_none());
 
-        // NaN value
         let with_nan = vec![0.1, f32::NAN, 0.3];
         assert_eq!(find_nan_or_inf(&with_nan), Some(1));
 
-        // Inf value
         let with_inf = vec![0.1, 0.2, f32::INFINITY];
         assert_eq!(find_nan_or_inf(&with_inf), Some(2));
 
-        // Negative Inf
         let with_neg_inf = vec![f32::NEG_INFINITY, 0.2];
         assert_eq!(find_nan_or_inf(&with_neg_inf), Some(0));
     }
@@ -93,13 +82,11 @@ mod tests {
         let bias_grads = vec![vec![0.1], vec![0.2]];
         assert!(check_gradients_valid(&weight_grads, &bias_grads).is_ok());
 
-        // With NaN in weight gradients
         let bad_weight_grads = vec![vec![0.1, f32::NAN], vec![0.3, 0.4]];
         let result = check_gradients_valid(&bad_weight_grads, &bias_grads);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("weight gradient"));
 
-        // With Inf in bias gradients
         let bad_bias_grads = vec![vec![0.1], vec![f32::INFINITY]];
         let result = check_gradients_valid(&weight_grads, &bad_bias_grads);
         assert!(result.is_err());
@@ -116,7 +103,6 @@ mod tests {
 
     #[test]
     fn test_gradient_guard_strategy_default() {
-        // Default should be Error
         let strategy = GradientGuardStrategy::default();
         assert_eq!(strategy, GradientGuardStrategy::Error);
     }

--- a/crates/fann/src/training/mod.rs
+++ b/crates/fann/src/training/mod.rs
@@ -22,27 +22,27 @@ pub use rloo::{RlooConfig, RlooTrainer};
 use crate::error::FannResult;
 use crate::network::Network;
 
-/// Configuration for training
+/// Training configuration.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrainingConfig {
-    /// Learning rate
+    /// Learning rate.
     pub learning_rate: f32,
-    /// Momentum coefficient (0.0 = no momentum)
+    /// Momentum coefficient.
     pub momentum: f32,
-    /// L2 regularization coefficient (weight decay)
+    /// L2 weight-decay coefficient.
     pub weight_decay: f32,
-    /// Maximum number of epochs
+    /// Maximum epochs.
     pub max_epochs: usize,
-    /// Target error threshold for early stopping
+    /// Early-stop error threshold.
     pub target_error: f32,
-    /// Batch size (1 = stochastic gradient descent)
+    /// Batch size; `1` is stochastic gradient descent.
     pub batch_size: usize,
-    /// Whether to shuffle training data each epoch
+    /// Whether to shuffle each epoch.
     pub shuffle: bool,
-    /// Strategy for handling NaN/Inf gradients
+    /// Response to non-finite gradients.
     pub gradient_guard: GradientGuardStrategy,
-    /// Optional RNG seed for reproducible shuffling (None = use entropy)
+    /// Optional seed for reproducible shuffling.
     pub seed: Option<u64>,
 }
 
@@ -63,89 +63,83 @@ impl Default for TrainingConfig {
 }
 
 impl TrainingConfig {
-    /// Create a new training configuration with default values
+    /// Creates the default training configuration.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Set learning rate
+    /// Sets the learning rate.
     pub fn learning_rate(mut self, lr: f32) -> Self {
         self.learning_rate = lr;
         self
     }
 
-    /// Set momentum
+    /// Sets momentum.
     pub fn momentum(mut self, m: f32) -> Self {
         self.momentum = m;
         self
     }
 
-    /// Set weight decay
+    /// Sets weight decay.
     pub fn weight_decay(mut self, wd: f32) -> Self {
         self.weight_decay = wd;
         self
     }
 
-    /// Set maximum epochs
+    /// Sets maximum epochs.
     pub fn max_epochs(mut self, epochs: usize) -> Self {
         self.max_epochs = epochs;
         self
     }
 
-    /// Set target error
+    /// Sets the target error.
     pub fn target_error(mut self, error: f32) -> Self {
         self.target_error = error;
         self
     }
 
-    /// Set batch size
+    /// Sets the batch size.
     pub fn batch_size(mut self, size: usize) -> Self {
         self.batch_size = size;
         self
     }
 
-    /// Set shuffle flag
+    /// Sets epoch shuffling.
     pub fn shuffle(mut self, shuffle: bool) -> Self {
         self.shuffle = shuffle;
         self
     }
 
-    /// Set gradient guard strategy
+    /// Sets the gradient guard strategy.
     pub fn gradient_guard(mut self, strategy: GradientGuardStrategy) -> Self {
         self.gradient_guard = strategy;
         self
     }
 
-    /// Set RNG seed for reproducible training
+    /// Sets the shuffle seed.
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = Some(seed);
         self
     }
 }
 
-/// Training result containing metrics
+/// Training metrics.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrainingResult {
-    /// Final mean squared error
+    /// Final mean squared error.
     pub final_error: f32,
-    /// Number of epochs trained
+    /// Completed epochs.
     pub epochs_trained: usize,
-    /// Error history per epoch
+    /// Error after each epoch.
     pub error_history: Vec<f32>,
-    /// Whether target error was reached
+    /// Whether the target error was reached.
     pub converged: bool,
 }
 
-/// Trait for training algorithms
+/// Training algorithm.
 pub trait Trainer {
-    /// Train the network on the given data
-    ///
-    /// # Arguments
-    /// * `network` - The network to train
-    /// * `inputs` - Training input vectors
-    /// * `targets` - Target output vectors
-    /// * `config` - Training configuration
+    /// Trains `network` on input-target pairs.
     fn train(
         &mut self,
         network: &mut Network,
@@ -155,19 +149,14 @@ pub trait Trainer {
     ) -> FannResult<TrainingResult>;
 }
 
-// Structural reachability test: when online-router is enabled the public types
-// must be importable through the training module path.  Without the feature the
-// entire ewc/rloo sub-modules are absent, so the check is compile-time only.
 #[cfg(all(test, feature = "online-router"))]
 mod online_router_reachability {
     use super::{DiagonalFisher, RlooConfig, RlooTrainer};
 
     #[test]
     fn online_router_types_are_reachable() {
-        // Merely naming the types proves the feature gate exposes them.
         let _: Option<DiagonalFisher> = None;
         let _config = RlooConfig::default();
-        // RlooTrainer::new is non-Copy but constructible — just confirm the path resolves.
         let _trainer = RlooTrainer::new(RlooConfig::default());
     }
 }
@@ -205,7 +194,6 @@ mod tests {
         let config = TrainingConfig::new().gradient_guard(GradientGuardStrategy::SkipBatch);
         assert_eq!(config.gradient_guard, GradientGuardStrategy::SkipBatch);
 
-        // Default should be Error
         let default_config = TrainingConfig::default();
         assert_eq!(default_config.gradient_guard, GradientGuardStrategy::Error);
     }

--- a/crates/fann/src/training/rloo.rs
+++ b/crates/fann/src/training/rloo.rs
@@ -19,9 +19,9 @@ use rand::SeedableRng;
 pub struct RlooConfig {
     /// Step size applied per policy-gradient update.
     pub learning_rate: f32,
-    /// Coefficient for the load-balance auxiliary loss (prevents routing collapse).
+    /// Load-balance auxiliary-loss coefficient.
     pub aux_loss_coeff: f32,
-    /// Coefficient for the router z-loss (discourages logit explosion).
+    /// Router z-loss coefficient.
     pub z_loss_coeff: f32,
 }
 
@@ -35,18 +35,15 @@ impl Default for RlooConfig {
     }
 }
 
-/// A policy-gradient trainer for selector gates with linear logits.
-///
-/// It applies softmax in the loss and leaves EWC composition to the caller.
-/// See [`docs/training.md`](../../docs/training.md#reinforce-with-leave-one-out-rloo) for the gate contract and loss terms.
+/// Policy-gradient trainer for selector gates with linear logits.
 pub struct RlooTrainer {
     config: RlooConfig,
-    /// RNG used for Gumbel-max sampling in the Phase-2 multi-sample path.
+    /// RNG for multi-sample Gumbel-max sampling.
     rng: rand::rngs::SmallRng,
 }
 
 impl RlooTrainer {
-    /// Create a new trainer, seeding the RNG from system entropy.
+    /// Creates a trainer seeded from system entropy.
     pub fn new(config: RlooConfig) -> Self {
         Self {
             config,
@@ -54,9 +51,7 @@ impl RlooTrainer {
         }
     }
 
-    /// Create a new trainer with a fixed RNG seed for deterministic behaviour.
-    ///
-    /// Prefer this constructor in tests to guarantee reproducible results.
+    /// Creates a trainer with a fixed RNG seed.
     pub fn with_seed(config: RlooConfig, seed: u64) -> Self {
         Self {
             config,
@@ -66,9 +61,7 @@ impl RlooTrainer {
 
     /// Applies one REINFORCE update for `action_idx` from a signed reward.
     ///
-    /// The reward sign controls policy direction and its magnitude controls update strength.
     /// Returns the scalar policy loss for logging.
-    /// See [`docs/training.md`](../../docs/training.md#phase-1-single-sample-reinforce-step-the-active-path) for reward semantics and the loss formula.
     pub fn step(
         &mut self,
         gate: &mut Network,
@@ -94,7 +87,7 @@ impl RlooTrainer {
             });
         }
 
-        // Gate output layer must be Linear (raw logits, softmax applied here).
+        // RLOO consumes raw logits and applies Softmax itself.
         {
             let layers = gate.layers();
             if !matches!(layers[num_layers - 1].activation(), Activation::Linear) {
@@ -104,7 +97,6 @@ impl RlooTrainer {
             }
         }
 
-        // Forward pass (populates activation buffers).
         let logits: Vec<f32> = gate.forward(context)?.to_vec();
 
         let probs = softmax(&logits);
@@ -112,10 +104,8 @@ impl RlooTrainer {
 
         let k = num_outputs;
         let sum_p_sq: f32 = probs.iter().map(|&p| p * p).sum();
-        // Scalar used in the load-balance gradient (computed once).
         let c = sum_p_sq - 1.0 / k as f32;
 
-        // Linear output makes this the pre-activation error; preserve reward polarity — see docs/training.md.
         let output_deltas: Vec<f32> = probs
             .iter()
             .enumerate()
@@ -131,16 +121,13 @@ impl RlooTrainer {
 
         self.backprop_and_apply(gate, context, &output_deltas, num_layers)?;
 
-        // Scalar policy loss for caller logging.
         let loss = -reward * probs[action_idx].max(1e-9).ln();
         Ok(loss)
     }
 
     /// Runs a Gumbel-top-`k` RLOO update with a leave-one-out baseline.
     ///
-    /// Pair its positive events with [`Self::step`] negative feedback; a positive-only stream is invalid.
     /// Returns the mean sampled reward or a validation error.
-    /// See [`docs/training.md`](../../docs/training.md#phase-2-multi-sample-rloo-rloo_step-not-the-default-path) for sampling and update details.
     pub fn rloo_step(
         &mut self,
         gate: &mut Network,
@@ -179,7 +166,7 @@ impl RlooTrainer {
             ));
         }
 
-        // Bound both caller-controlled capacities before allocation; checked multiplication prevents overflow.
+        // Bound both caller-controlled allocations.
         validate_allocation_size(m_samples)?;
         let subset_storage = m_samples.checked_mul(k).ok_or_else(|| {
             FannError::TrainingError(format!(
@@ -201,19 +188,17 @@ impl RlooTrainer {
         let probs = softmax(&logits);
         let lse = log_sum_exp(&logits);
 
-        // Draw `m_samples` Gumbel-top-`k` subsets — see docs/training.md.
         let mut rewards: Vec<f32> = Vec::with_capacity(m_samples);
         let mut subsets: Vec<Vec<usize>> = Vec::with_capacity(m_samples);
 
         for _ in 0..m_samples {
-            // Perturb each logit with independent Gumbel(0,1) noise.
             let mut perturbed: Vec<(f32, usize)> = logits
                 .iter()
                 .enumerate()
                 .map(|(i, &s)| {
                     let u: f32 = {
                         let raw: f32 = self.rng.r#gen::<f32>();
-                        // Clamp to open (0,1) to avoid ln(0).
+                        // Keep the Gumbel transform away from `ln(0)`.
                         raw.clamp(1e-38_f32, 1.0 - f32::EPSILON)
                     };
                     let gumbel_noise = -(-u.ln()).ln();
@@ -221,7 +206,6 @@ impl RlooTrainer {
                 })
                 .collect();
 
-            // Select top-k by perturbed logit (descending).
             perturbed.sort_unstable_by(|a, b| {
                 b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
             });
@@ -236,7 +220,6 @@ impl RlooTrainer {
             subsets.push(subset);
         }
 
-        // Build output-layer gradient with leave-one-out baseline.
         let reward_sum: f32 = rewards.iter().sum();
         let ko = num_outputs;
         let sum_p_sq: f32 = probs.iter().map(|&p| p * p).sum();
@@ -245,7 +228,6 @@ impl RlooTrainer {
         let mut output_deltas = vec![0.0_f32; ko];
 
         for (r_m, subset_m) in rewards.iter().zip(subsets.iter()) {
-            // Leave-one-out baseline: (ΣR − R_m) / (M − 1); 0 if M == 1.
             let baseline = if m_samples > 1 {
                 (reward_sum - r_m) / (m_samples - 1) as f32
             } else {
@@ -253,7 +235,6 @@ impl RlooTrainer {
             };
             let advantage = r_m - baseline;
 
-            // g[j] += -(1/M) * advantage * (count(j ∈ subset) − k · p[j])
             for j in 0..ko {
                 let in_subset: f32 = subset_m
                     .iter()
@@ -264,7 +245,6 @@ impl RlooTrainer {
             }
         }
 
-        // Aux and z-loss terms (identical to step).
         for (j, &pj) in probs.iter().enumerate() {
             let aux =
                 self.config.aux_loss_coeff * (2.0 / ko as f32) * pj * (pj - 1.0 / ko as f32 - c);
@@ -277,11 +257,7 @@ impl RlooTrainer {
         Ok(reward_sum / m_samples as f32)
     }
 
-    /// Backpropagate the output-layer delta through hidden layers and apply
-    /// a plain SGD update (no momentum, no weight decay).
-    ///
-    /// Mirrors `backprop.rs::compute_gradients` lines 94–152 (hidden-layer
-    /// backprop) and `apply_gradients` lines 170–191 (simplified, batch_size=1).
+    /// Backpropagates the output delta and applies plain SGD.
     fn backprop_and_apply(
         &self,
         gate: &mut Network,
@@ -289,15 +265,10 @@ impl RlooTrainer {
         output_deltas: &[f32],
         num_layers: usize,
     ) -> FannResult<()> {
-        // --- Phase 1: compute all layer deltas and accumulate gradients ---
-        // Both gate.layers() and gate.activations() are &self borrows and may
-        // coexist simultaneously; they are released before the mutable apply phase.
         let (weight_grads, bias_grads) = {
-            // Start with the output-layer delta (from caller).
             let mut deltas: Vec<Vec<f32>> = Vec::with_capacity(num_layers);
             deltas.push(output_deltas.to_vec());
 
-            // Mirror backprop.rs:94-121: propagate deltas backward through hidden layers.
             let layers = gate.layers(); // shared borrow: released at end of this block
             for layer_idx in (0..num_layers - 1).rev() {
                 let layer_activation = layers[layer_idx].activation();
@@ -310,7 +281,6 @@ impl RlooTrainer {
                     FannError::TrainingError("empty deltas during backpropagation".to_string())
                 })?;
 
-                // gate.activations() is also a &self borrow — OK alongside layers.
                 let layer_activations = gate.activations(layer_idx).ok_or_else(|| {
                     FannError::TrainingError(format!("missing activations for layer {layer_idx}"))
                 })?;
@@ -319,7 +289,6 @@ impl RlooTrainer {
                 for i in 0..layer_num_outputs {
                     let mut sum = 0.0_f32;
                     for j in 0..next_num_outputs {
-                        // Weight layout: row-major, row j, column i.
                         let weight = next_weights[j * next_num_inputs + i];
                         sum += weight * prev_deltas[j];
                     }
@@ -329,10 +298,8 @@ impl RlooTrainer {
 
                 deltas.push(layer_deltas);
             }
-            // Mirror backprop.rs:123-124: reverse to forward layer order.
             deltas.reverse();
 
-            // Allocate gradient buffers (mirror backprop.rs:126-152).
             let mut weight_grads: Vec<Vec<f32>> = layers
                 .iter()
                 .map(|l| vec![0.0_f32; l.weights().len()])
@@ -357,24 +324,20 @@ impl RlooTrainer {
                     })?
                 };
 
-                // dW[i,j] = delta[i] * input[j]
                 for (i, &d) in delta.iter().enumerate().take(num_o) {
                     for (j, &inp) in layer_input.iter().enumerate().take(num_i) {
                         weight_grads[layer_idx][i * num_i + j] += d * inp;
                     }
                 }
 
-                // dB[i] = delta[i]
                 for (i, &d) in delta.iter().enumerate().take(num_o) {
                     bias_grads[layer_idx][i] += d;
                 }
             }
 
             (weight_grads, bias_grads)
-            // `layers` (shared borrow) drops here — gate is free for mutation.
         };
 
-        // --- Phase 2: apply plain SGD (mirror backprop.rs:170-191, no momentum) ---
         let lr = self.config.learning_rate;
         for layer_idx in 0..num_layers {
             let Some(layer) = gate.layer_mut(layer_idx) else {
@@ -396,10 +359,7 @@ impl RlooTrainer {
     }
 }
 
-/// Load-balance auxiliary loss: `(1/K) Σ_i (p_i − 1/K)²`.
-///
-/// Penalises routing collapse where one adapter receives most probability mass.
-/// `probs` should be the softmax of the gate logits.
+/// Computes the load-balance loss for gate probabilities.
 pub fn load_balance_aux_loss(probs: &[f32]) -> f32 {
     if probs.is_empty() {
         return 0.0;
@@ -413,16 +373,11 @@ pub fn load_balance_aux_loss(probs: &[f32]) -> f32 {
         / k
 }
 
-/// Router z-loss: `(log Σ_i exp(s_i))²`.
-///
-/// Discourages logit explosion by penalising large log-sum-exp values.
-/// `logits` should be the raw gate output (pre-softmax).
+/// Computes the router z-loss from raw logits.
 pub fn router_z_loss(logits: &[f32]) -> f32 {
     let lse = log_sum_exp(logits);
     lse * lse
 }
-
-// --- Private helpers ---
 
 /// Numerically stable softmax: subtract max before exp to prevent overflow.
 fn softmax(logits: &[f32]) -> Vec<f32> {
@@ -433,7 +388,6 @@ fn softmax(logits: &[f32]) -> Vec<f32> {
     let exps: Vec<f32> = logits.iter().map(|&s| (s - max_val).exp()).collect();
     let sum: f32 = exps.iter().sum();
     if sum == 0.0 {
-        // Degenerate case: return uniform distribution.
         vec![1.0 / logits.len() as f32; logits.len()]
     } else {
         exps.iter().map(|&e| e / sum).collect()
@@ -457,7 +411,6 @@ mod tests {
     use crate::error::MAX_ALLOWED_ELEMENTS;
     use crate::network::NetworkBuilder;
 
-    /// Build a deterministic 4-input → 8-hidden(ReLU) → 4-output(Linear) gate.
     fn test_gate() -> Network {
         NetworkBuilder::new()
             .input(4)
@@ -469,10 +422,6 @@ mod tests {
 
     const CTX: [f32; 4] = [0.1, -0.2, 0.3, 0.4];
 
-    /// A positive reward on action 2 must increase the logit for action 2.
-    ///
-    /// Mutation that fails this test: setting learning_rate to 0 or zeroing
-    /// the policy gradient term in `step`.
     #[test]
     fn rloo_positive_reward_increases_action_score() {
         let mut gate = test_gate();
@@ -488,11 +437,6 @@ mod tests {
         );
     }
 
-    /// A negative reward on action 1 must DECREASE the logit for action 1.
-    ///
-    /// This is the critical polarity test. Mutation that fails: dropping the
-    /// `reward *` factor (treating −1.0 as +1.0) or routing negative reward
-    /// through a cross-entropy call toward a different preferred index.
     #[test]
     fn rloo_negative_reward_decreases_action_score() {
         let mut gate = test_gate();
@@ -508,10 +452,6 @@ mod tests {
         );
     }
 
-    /// Load-balance loss must be nonzero for a peaked distribution and near
-    /// zero for a uniform distribution.
-    ///
-    /// Mutation that fails: returning 0.0 unconditionally.
     #[test]
     fn load_balance_aux_loss_nonzero_on_skewed() {
         let skewed_logits = [10.0_f32, -10.0, -10.0, -10.0];
@@ -530,9 +470,6 @@ mod tests {
         );
     }
 
-    /// Router z-loss must be strictly larger for large logits than for zero logits.
-    ///
-    /// Mutation that fails: returning 0.0 unconditionally.
     #[test]
     fn router_z_loss_nonzero_on_large_logits() {
         let large = [100.0_f32; 4];
@@ -549,7 +486,6 @@ mod tests {
         );
     }
 
-    /// Wrong context dimension must return Err, not panic.
     #[test]
     fn rloo_wrong_context_dim_errors() {
         let mut gate = test_gate();
@@ -562,10 +498,6 @@ mod tests {
         );
     }
 
-    /// Explicit reward (+1.0) must move the action logit more than implicit (+0.5).
-    ///
-    /// Mutation that fails: computing the gradient without the `reward *` scale
-    /// factor, or treating all rewards as +1.0.
     #[test]
     fn rloo_implicit_weaker_than_explicit() {
         let gate_base = test_gate();
@@ -595,11 +527,6 @@ mod tests {
         );
     }
 
-    // ---- Allocation-bound guard tests ---------------------------------------
-
-    /// rloo_step with m_samples > MAX_ALLOWED_ELEMENTS must return Err, not panic.
-    ///
-    /// Mutation that breaks this: removing the `validate_allocation_size(m_samples)?` call.
     #[test]
     fn rloo_step_m_samples_too_large_returns_err() {
         let mut gate = test_gate();
@@ -611,13 +538,6 @@ mod tests {
         );
     }
 
-    /// A per-call m_samples that is itself within bounds must still be rejected
-    /// when m_samples * k (the aggregate retained-subset storage) exceeds the cap.
-    /// Here m_samples = 30M passes the standalone m_samples guard (< 100M) but
-    /// 30M * 4 = 120M exceeds it, so only the product guard can produce the error.
-    ///
-    /// Mutation that breaks this: removing the `validate_allocation_size(subset_storage)?`
-    /// product check (the standalone m_samples guard alone admits this input).
     #[test]
     fn rloo_step_m_samples_times_k_product_too_large_returns_err() {
         let mut gate = test_gate();


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Comment/doc-only, zero behavior change. Applies Ocean’s 2026-07-10 comment-hygiene directive to `crates/fann/src`.

## Counts

- Source comment/doc lines: 1,126 before → 758 after (368 removed or condensed).

## Changes

- Condensed public API docs and implementation narration to contract-level wording.
- Kept non-obvious numerical, safety, parsing-boundary, and training-accounting invariants inline.
- Deleted redundant test narration, reviewer-oriented mutation notes, and next-line restatements.
- Extracted background: no new extraction was needed; the existing `crates/fann/docs/{design,network,training,gpu}.md` reference set already holds the long-form rationale.

## New crate docs

- None. Existing crate documentation already covered the retained background.

## ADR candidates

- None new. The hidden-Softmax Jacobian limitation remains a short reference to existing ADR-023.

## Validation

- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p lattice-fann` — green
- `cargo clippy -p lattice-fann --all-targets -- -D warnings` — green
- `cargo test -p lattice-fann` — green