### PR TITLE
docs(tune): condense inline comments, extract background to crate docs

### DIFF
--- a/crates/tune/src/data/dataset.rs
+++ b/crates/tune/src/data/dataset.rs
@@ -205,7 +205,6 @@ impl Dataset {
     pub fn with_config(examples: Vec<TrainingExample>, config: DatasetConfig) -> Result<Self> {
         config.validate()?;
 
-        // Filter examples based on context size requirements
         let filtered: Vec<TrainingExample> = examples
             .into_iter()
             .filter(|e| {
@@ -302,7 +301,7 @@ impl Dataset {
 
     /// Shuffle indices using simple Fisher-Yates
     fn shuffle_indices(&mut self) {
-        // Simple LCG for deterministic shuffling when seed is provided
+        // The LCG keeps seeded shuffles reproducible without an RNG dependency.
         let mut state = self.config.seed.unwrap_or_else(|| {
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -311,7 +310,6 @@ impl Dataset {
         });
 
         for i in (1..self.indices.len()).rev() {
-            // LCG: state = (a * state + c) mod m
             state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
             let j = (state as usize) % (i + 1);
             self.indices.swap(i, j);
@@ -327,7 +325,6 @@ impl Dataset {
         let batch_size = self.config.batch_size;
         let end_idx = (self.current_idx + batch_size).min(self.examples.len());
 
-        // Skip incomplete final batch if drop_last is true
         if self.config.drop_last && (end_idx - self.current_idx) < batch_size {
             self.current_idx = self.examples.len();
             return None;
@@ -374,7 +371,6 @@ impl Dataset {
         let min_context_size = *context_sizes.iter().min().unwrap_or(&0);
         let max_context_size = *context_sizes.iter().max().unwrap_or(&0);
 
-        // Count dominant labels
         let mut label_distribution = vec![0usize; 6];
         for example in &self.examples {
             let probs = example.labels.to_vec();
@@ -505,7 +501,6 @@ mod tests {
             .set_config(DatasetConfig::with_batch_size(10).seed(42))
             .unwrap();
 
-        // Same seed should produce same shuffle
         let batches1: Vec<Batch> = dataset1.batches().collect();
         let batches2: Vec<Batch> = dataset2.batches().collect();
 

--- a/crates/tune/src/distill/pipeline/distill.rs
+++ b/crates/tune/src/distill/pipeline/distill.rs
@@ -13,8 +13,7 @@ use chrono::Utc;
 
 /// Distillation pipeline that orchestrates labeling from teacher models
 ///
-/// This is a placeholder implementation. The actual API calls would need
-/// to be implemented with a proper HTTP client like `reqwest`.
+/// Formats prompts and records simulated labels; it does not call a teacher API.
 pub struct DistillationPipeline {
     /// Teacher model configuration
     teacher: TeacherConfig,
@@ -70,11 +69,8 @@ impl DistillationPipeline {
     pub fn label_single(&mut self, raw: &RawExample) -> Result<LabelingResult> {
         let start = std::time::Instant::now();
 
-        // The simulated result preserves the future client boundary — see docs/distill.md.
-
         let _prompt = raw.to_prompt();
 
-        // Simulate labels (in production, these come from teacher)
         let mut labels = IntentLabels {
             continuation: 0.4,
             topic_shift: 0.1,
@@ -93,7 +89,6 @@ impl DistillationPipeline {
         let confidence = 0.85; // Would come from teacher response
         let latency_ms = start.elapsed().as_millis() as u64;
 
-        // Check confidence threshold
         if let Some(min_conf) = self.config.min_confidence
             && confidence < min_conf
         {
@@ -160,7 +155,6 @@ impl DistillationPipeline {
                 result.labels.clone(),
             );
 
-            // Add metadata about the labeling
             let metadata = ExampleMetadata::with_source(result.example_id.to_string())
                 .teacher(self.teacher.display_name())
                 .labeled_at(Utc::now())

--- a/crates/tune/src/distill/pipeline/tests.rs
+++ b/crates/tune/src/distill/pipeline/tests.rs
@@ -103,12 +103,10 @@ fn test_pipeline_label_batch() {
 
 #[test]
 fn test_sanitize_strips_control_chars() {
-    // Create input with control characters
     let input_with_control = "Hello\x00World\x07Test";
     let raw = RawExample::new(vec![], input_with_control);
     let prompt = raw.to_prompt();
 
-    // Control chars should be stripped
     assert!(!prompt.contains('\x00'));
     assert!(!prompt.contains('\x07'));
     assert!(prompt.contains("HelloWorldTest"));
@@ -120,7 +118,6 @@ fn test_sanitize_preserves_newlines() {
     let raw = RawExample::new(vec![], input);
     let prompt = raw.to_prompt();
 
-    // Newlines, tabs, and carriage returns should be preserved
     assert!(prompt.contains('\n'));
     assert!(prompt.contains('\t'));
     assert!(prompt.contains('\r'));
@@ -132,20 +129,17 @@ fn test_sanitize_truncates_long_message() {
     let raw = RawExample::new(vec![], long_message.clone());
     let prompt = raw.to_prompt();
 
-    // Should be truncated to MAX_MESSAGE_LENGTH
     assert!(prompt.len() <= MAX_PROMPT_LENGTH + 20); // +20 for formatting
 }
 
 #[test]
 fn test_sanitize_truncates_long_prompt() {
-    // Create enough context to exceed MAX_PROMPT_LENGTH
     let long_context: Vec<String> = (0..1000)
         .map(|i| format!("Context message {i} with some content"))
         .collect();
     let raw = RawExample::new(long_context, "Final message");
     let prompt = raw.to_prompt();
 
-    // Should be truncated with marker
     assert!(prompt.len() <= MAX_PROMPT_LENGTH + 20);
     assert!(prompt.contains("[truncated]") || prompt.len() <= MAX_PROMPT_LENGTH);
 }

--- a/crates/tune/src/distill/pipeline/types.rs
+++ b/crates/tune/src/distill/pipeline/types.rs
@@ -124,7 +124,6 @@ impl DistillationStats {
                 + result.confidence)
                 / self.successful as f32;
 
-            // Update label distribution
             if self.label_distribution.is_empty() {
                 self.label_distribution = vec![0; IntentLabels::NUM_CLASSES];
             }
@@ -215,7 +214,6 @@ impl RawExample {
             "Current message to classify:\n{sanitized_message}"
         ));
 
-        // Truncate total prompt if needed
         if prompt.len() > MAX_PROMPT_LENGTH {
             prompt.truncate(MAX_PROMPT_LENGTH);
             prompt.push_str("\n[truncated]");
@@ -229,7 +227,6 @@ impl RawExample {
     /// - Strips control characters (except \n, \t, \r)
     /// - Truncates to [`MAX_MESSAGE_LENGTH`]
     fn sanitize_input(input: &str) -> String {
-        // Truncate first to avoid processing huge strings
         let truncated = if input.len() > MAX_MESSAGE_LENGTH {
             let boundary = input
                 .char_indices()
@@ -242,7 +239,6 @@ impl RawExample {
             input
         };
 
-        // Remove control characters except newlines, tabs, carriage returns
         truncated
             .chars()
             .filter(|c| !c.is_control() || *c == '\n' || *c == '\t' || *c == '\r')

--- a/crates/tune/src/distill/teacher/config.rs
+++ b/crates/tune/src/distill/teacher/config.rs
@@ -185,7 +185,6 @@ Respond ONLY with the JSON object, no other text."#.to_string()
             return Err("timeout_ms must be > 0".to_string());
         }
 
-        // Validate endpoint security if custom endpoint is provided
         if let Some(ref endpoint) = self.endpoint {
             self.security.verify_endpoint(endpoint)?;
         }
@@ -198,7 +197,7 @@ Respond ONLY with the JSON object, no other text."#.to_string()
     /// This performs no network I/O and only validates the format of a configured
     /// certificate fingerprint. See [`docs/distill.md`](../../../docs/distill.md#teacherconfigverify_endpoint) for the client-side checks that remain.
     pub fn verify_endpoint(&self) -> Result<(), String> {
-        // Resolve the provider default before applying local policy.
+        // Apply policy to the resolved provider default as well as custom endpoints.
         let endpoint = self.get_endpoint();
         self.security.verify_endpoint(&endpoint)?;
 

--- a/crates/tune/src/distill/teacher/security.rs
+++ b/crates/tune/src/distill/teacher/security.rs
@@ -14,16 +14,13 @@ pub struct EndpointSecurity {
     /// Require TLS for remote connections
     pub require_tls: bool,
 
-    /// Expected SHA-256 certificate fingerprint (hex string)
-    /// If set, validates the server certificate fingerprint
+    /// Expected SHA-256 certificate fingerprint in hexadecimal.
     pub expected_cert_fingerprint: Option<String>,
 
-    /// Allowed endpoint domains (whitelist)
-    /// If set, only these domains are permitted
+    /// Endpoint host allowlist.
     pub allowed_domains: Option<Vec<String>>,
 
-    /// Model weight checksum (SHA-256 hex) for local models
-    /// Used to verify model integrity
+    /// Expected SHA-256 checksum for local model weights.
     pub model_checksum: Option<String>,
 }
 
@@ -75,17 +72,14 @@ impl EndpointSecurity {
     ///
     /// Returns Ok(()) if the endpoint passes all checks, Err with reason otherwise.
     pub fn verify_endpoint(&self, endpoint: &str) -> Result<(), String> {
-        // Parse the URL
         let endpoint_lower = endpoint.to_lowercase();
 
-        // Check TLS requirement
         if self.require_tls && !endpoint_lower.starts_with("https://") {
             return Err(format!(
                 "TLS required but endpoint uses insecure protocol: {endpoint}"
             ));
         }
 
-        // Check domain whitelist
         if let Some(ref allowed) = self.allowed_domains {
             let domain = Self::extract_domain(endpoint);
             if !allowed.iter().any(|d| domain == d.as_str()) {
@@ -110,8 +104,7 @@ impl EndpointSecurity {
             .unwrap_or(url)
     }
 
-    /// Validate certificate fingerprint (placeholder - actual implementation
-    /// would need TLS library integration)
+    /// Validate the configured certificate fingerprint's format.
     pub fn validate_cert_fingerprint(&self, _actual_fingerprint: &str) -> Result<(), String> {
         if let Some(ref expected) = self.expected_cert_fingerprint {
             // A live client must compare the format-validated value to its peer certificate.

--- a/crates/tune/src/distill/teacher/tests.rs
+++ b/crates/tune/src/distill/teacher/tests.rs
@@ -26,15 +26,12 @@ fn test_teacher_config_builder() {
 fn test_teacher_config_validation() {
     let mut config = TeacherConfig::default();
 
-    // Valid config
     assert!(config.validate().is_ok());
 
-    // Invalid temperature
     config.temperature = 3.0;
     assert!(config.validate().is_err());
     config.temperature = 0.3;
 
-    // Invalid model_id
     config.model_id = String::new();
     assert!(config.validate().is_err());
 }
@@ -64,8 +61,6 @@ fn test_preset_configs() {
     assert!(gemini.validate().is_ok());
 }
 
-// Endpoint Security Tests
-
 #[test]
 fn test_endpoint_security_default_secure() {
     let security = EndpointSecurity::default_secure();
@@ -93,10 +88,8 @@ fn test_endpoint_verification_tls_required() {
         ..Default::default()
     };
 
-    // HTTPS should pass
     assert!(security.verify_endpoint("https://api.example.com").is_ok());
 
-    // HTTP should fail
     assert!(security.verify_endpoint("http://api.example.com").is_err());
 }
 
@@ -111,7 +104,6 @@ fn test_endpoint_verification_domain_whitelist() {
         ..Default::default()
     };
 
-    // Allowed domains should pass
     assert!(
         security
             .verify_endpoint("https://api.anthropic.com/v1")
@@ -123,7 +115,6 @@ fn test_endpoint_verification_domain_whitelist() {
             .is_ok()
     );
 
-    // Disallowed domains should fail
     assert!(
         security
             .verify_endpoint("https://evil.example.com/v1")
@@ -139,23 +130,19 @@ fn test_endpoint_verification_no_restrictions() {
         ..Default::default()
     };
 
-    // Any endpoint should pass
     assert!(security.verify_endpoint("http://any.example.com").is_ok());
     assert!(security.verify_endpoint("https://any.example.com").is_ok());
 }
 
 #[test]
 fn test_cert_fingerprint_validation() {
-    // Valid 64-char hex fingerprint
     let security = EndpointSecurity::default()
         .with_cert_fingerprint("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3a94a8fe5ccb19ba61c4c0873");
     assert!(security.validate_cert_fingerprint("").is_ok());
 
-    // Invalid length
     let security = EndpointSecurity::default().with_cert_fingerprint("tooshort");
     assert!(security.validate_cert_fingerprint("").is_err());
 
-    // Invalid characters
     let security = EndpointSecurity::default()
         .with_cert_fingerprint("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz");
     assert!(security.validate_cert_fingerprint("").is_err());
@@ -166,10 +153,8 @@ fn test_model_checksum_verification() {
     let expected = "abc123def456";
     let security = EndpointSecurity::default().with_model_checksum(expected);
 
-    // Matching checksum should pass
     assert!(security.verify_model_checksum(expected).is_ok());
 
-    // Mismatched checksum should fail
     assert!(security.verify_model_checksum("wrong_checksum").is_err());
 }
 
@@ -180,7 +165,6 @@ fn test_teacher_config_with_invalid_custom_endpoint() {
         .security(EndpointSecurity::default_secure())
         .build();
 
-    // Should fail validation because TLS is required but endpoint is HTTP
     assert!(config.validate().is_err());
 }
 
@@ -193,7 +177,6 @@ fn test_teacher_config_with_valid_custom_endpoint() {
         .security(security)
         .build();
 
-    // Should pass validation
     assert!(config.validate().is_ok());
 }
 
@@ -201,7 +184,6 @@ fn test_teacher_config_with_valid_custom_endpoint() {
 fn test_local_config_security() {
     let config = TeacherConfig::local("llama2", "http://localhost:11434");
 
-    // Local config should allow HTTP localhost
     assert!(config.validate().is_ok());
 }
 

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -24,39 +24,32 @@ pub mod lora;
 pub mod registry;
 pub mod train;
 
-// Re-exports for convenience
 pub use error::{Result, TuneError};
 
-// Data re-exports
 pub use data::{
     Batch, Dataset, DatasetConfig, DatasetStats, ExampleMetadata, IntentLabels, TrainingExample,
 };
 
-// Distill re-exports
 pub use distill::{
     DistillationConfig, DistillationPipeline, DistillationStats, EndpointSecurity, LabelingResult,
     TeacherConfig, TeacherConfigBuilder, TeacherProvider,
 };
 
-// Train re-exports
 pub use train::{
     Checkpoint, EarlyStopping, EpochMetrics, JitAdapter, JitConfig, JitResult, JitStrategy,
     LRSchedule, LoggingCallback, NoOpCallback, Optimizer, OptimizerConfig, RegularizationConfig,
     TrainingCallback, TrainingConfig, TrainingLoop, TrainingMetrics, TrainingState, freeze,
 };
 
-// GPU training re-exports (when feature enabled)
 #[cfg(feature = "gpu")]
 pub use train::{GpuTrainer, GpuTrainerBuilder};
 
-// LoRA re-exports
 #[cfg(all(feature = "safetensors", feature = "serde"))]
 pub use lora::LoadedAdapter;
 #[cfg(feature = "serde")]
 pub use lora::{AdapterId, LoraManifest, ManifestEntry};
 pub use lora::{LoraAdapter, LoraConfig, LoraLayer, blend_lora_adapters};
 
-// Registry re-exports
 pub use registry::{
     LiveModel, ModelMetadata, ModelQuery, ModelRegistry, ModelStatus, RegisteredModel,
     RollbackController, RollbackRecord, ShadowComparison, ShadowConfig, ShadowSession, ShadowState,
@@ -94,7 +87,6 @@ mod tests {
 
     #[test]
     fn test_end_to_end_workflow() {
-        // 1. Create training examples
         let examples: Vec<TrainingExample> = (0..100)
             .map(|i| {
                 let label = match i % 6 {
@@ -113,7 +105,6 @@ mod tests {
             })
             .collect();
 
-        // 2. Create dataset
         let mut dataset = Dataset::from_examples(examples);
         let config = DatasetConfig::with_batch_size(16).shuffle(true).seed(42);
         dataset.set_config(config).unwrap();
@@ -122,14 +113,12 @@ mod tests {
         assert_eq!(stats.num_examples, 100);
         assert_eq!(stats.embedding_dim, 3);
 
-        // 3. Configure training
         let train_config = TrainingConfig::quick();
         assert!(train_config.validate().is_ok());
 
-        // 4. Create training loop
         let mut trainer = TrainingLoop::new(train_config).unwrap();
 
-        // 5. The placeholder loop must fail instead of fabricating metrics
+        // The placeholder loop must fail instead of fabricating metrics.
         let error = trainer.train(&mut dataset).unwrap_err();
         assert!(matches!(
             error,
@@ -137,7 +126,6 @@ mod tests {
         ));
         let metrics = TrainingMetrics::default();
 
-        // 6. Create model for registry
         let metadata = ModelMetadata::classifier(3, 6, 1000)
             .dataset("test_dataset", 100)
             .training_metrics(metrics);
@@ -146,12 +134,10 @@ mod tests {
             .with_metadata(metadata)
             .with_description("Test model from end-to-end workflow");
 
-        // 7. Register in registry
         let registry = ModelRegistry::in_memory();
         let weights = vec![0u8; 1000];
         let id = registry.register(model, &weights).unwrap();
 
-        // 8. Verify registration
         let loaded = registry.get("intent_classifier", "0.1.0").unwrap();
         assert_eq!(loaded.id, id);
         assert_eq!(loaded.metadata.num_training_examples, 100);
@@ -159,30 +145,24 @@ mod tests {
 
     #[test]
     fn test_distillation_workflow() {
-        // 1. Create raw examples
         let raw = distill::RawExample::new(
             vec!["Hello".to_string(), "How are you?".to_string()],
             "What's the weather like?",
         );
 
-        // 2. Verify prompt generation
         let prompt = raw.to_prompt();
         assert!(prompt.contains("Context"));
         assert!(prompt.contains("weather"));
 
-        // 3. Create teacher config
         let teacher = TeacherConfig::claude_sonnet();
         assert!(teacher.validate().is_ok());
 
-        // 4. Create pipeline
         let mut pipeline = DistillationPipeline::with_teacher(teacher).unwrap();
 
-        // 5. Label (placeholder)
         let result = pipeline.label_single(&raw).unwrap();
         assert!(result.is_success());
         assert!(result.confidence > 0.0);
 
-        // 6. Check stats
         let stats = pipeline.stats();
         assert_eq!(stats.successful, 1);
     }

--- a/crates/tune/src/lora/apply.rs
+++ b/crates/tune/src/lora/apply.rs
@@ -24,8 +24,7 @@ pub fn apply_lora(lora: &LoraLayer, scale: f32, x: &[f32], output: &mut [f32]) {
     debug_assert_eq!(x.len(), lora.d_in, "x length must equal d_in");
     debug_assert!(output.len() >= lora.d_out, "output length must be >= d_out");
 
-    // Step 1: intermediate = A @ x  -> shape (rank,)
-    // A is row-major (rank, d_in), so row r dot x gives intermediate[r].
+    // `A` is row-major `(rank, d_in)`.
     let rank = lora.rank;
     let d_in = lora.d_in;
     let d_out = lora.d_out;
@@ -37,8 +36,7 @@ pub fn apply_lora(lora: &LoraLayer, scale: f32, x: &[f32], output: &mut [f32]) {
         *inter = acc;
     }
 
-    // Step 2: output += scale * B @ intermediate  -> accumulate into (d_out,)
-    // B is row-major (d_out, rank), so row r dot intermediate gives the contribution.
+    // `B` is row-major `(d_out, rank)`.
     for (r, out) in output[..d_out].iter_mut().enumerate() {
         let row = &lora.b[r * rank..(r + 1) * rank];
         let acc: f32 = row
@@ -56,13 +54,6 @@ mod tests {
 
     #[test]
     fn test_apply_lora_identity_like() {
-        // rank=1, d_in=3, d_out=2
-        // A = [[1, 0, 0]]  (1x3)
-        // B = [[1], [0]]    (2x1)
-        // x = [5, 3, 1]
-        // A @ x = [5]
-        // B @ [5] = [5, 0]
-        // scale = 2.0 => output += [10, 0]
         let lora = LoraLayer {
             a: vec![1.0, 0.0, 0.0],
             b: vec![1.0, 0.0],
@@ -81,13 +72,6 @@ mod tests {
 
     #[test]
     fn test_apply_lora_rank2() {
-        // rank=2, d_in=2, d_out=2
-        // A = [[1, 0], [0, 1]]  (2x2, identity)
-        // B = [[1, 2], [3, 4]]  (2x2)
-        // x = [1, 1]
-        // A @ x = [1, 1]
-        // B @ [1, 1] = [3, 7]
-        // scale = 0.5 => output += [1.5, 3.5]
         let lora = LoraLayer {
             a: vec![1.0, 0.0, 0.0, 1.0],
             b: vec![1.0, 2.0, 3.0, 4.0],
@@ -118,7 +102,6 @@ mod tests {
         let mut output = [10.0, 20.0];
         apply_lora(&lora, 0.0, &x, &mut output);
 
-        // Output should be unchanged
         assert!((output[0] - 10.0).abs() < 1e-6);
         assert!((output[1] - 20.0).abs() < 1e-6);
     }

--- a/crates/tune/src/lora/blend.rs
+++ b/crates/tune/src/lora/blend.rs
@@ -36,7 +36,6 @@ pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapt
         }
     }
 
-    // Group the union of projection keys with their folded source scales.
     let mut grouped: HashMap<(usize, String), Vec<(&LoraLayer, f32)>> = HashMap::new();
     for (adapter, weight) in adapters {
         let s_e = adapter.config().scale();
@@ -49,7 +48,7 @@ pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapt
         }
     }
 
-    // Reject aggregate allocation overflow or budget excess before allocating.
+    // Check aggregate allocation before creating blend buffers.
     let mut planned_elems: usize = 0;
     for ((layer_idx, module), entries) in &grouped {
         let (first, _) = entries[0]; // each key was inserted with >=1 layer
@@ -84,14 +83,13 @@ pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapt
         )));
     }
 
-    // Blend each (layer_idx, module) group independently.
     let mut blended_layers: HashMap<(usize, String), LoraLayer> = HashMap::new();
     for ((layer_idx, module), entries) in &grouped {
         let blended = blend_layer_entries(entries, &(layer_idx, module))?;
         blended_layers.insert((*layer_idx, module.clone()), blended);
     }
 
-    // Set alpha = rank so the returned adapter's scale is one.
+    // Folding source scales lets the returned adapter use scale one.
     let total_rank: usize = blended_layers.values().map(|l| l.rank).max().unwrap_or(0);
     let target_modules: Vec<String> = {
         let mut mods: Vec<String> = grouped
@@ -124,7 +122,6 @@ fn blend_layer_entries(
     let d_in = first_layer.d_in;
     let d_out = first_layer.d_out;
 
-    // Validate that all entries share the same projection shape.
     for (idx, (layer, _)) in entries.iter().enumerate() {
         if layer.d_in != d_in || layer.d_out != d_out {
             return Err(TuneError::Validation(format!(
@@ -135,7 +132,7 @@ fn blend_layer_entries(
         }
     }
 
-    // Accumulate rank_total with overflow protection and a hard cap.
+    // Bound the combined rank before allocating.
     let mut rank_total: usize = 0;
     for (layer, _) in entries {
         rank_total = rank_total.checked_add(layer.rank).ok_or_else(|| {
@@ -149,7 +146,6 @@ fn blend_layer_entries(
         )));
     }
 
-    // Validate source buffers before copying their declared row-major shapes.
     for (idx, (layer, _)) in entries.iter().enumerate() {
         let expected_a = layer.rank.checked_mul(d_in).ok_or_else(|| {
             TuneError::Validation("blend_layer_entries: rank*d_in overflowed usize".into())
@@ -184,13 +180,11 @@ fn blend_layer_entries(
         TuneError::Validation("blend_layer_entries: d_out * rank_total overflowed usize".into())
     })?;
 
-    // Stack A blocks vertically in source order.
     let mut a_blend = Vec::with_capacity(a_buf_len);
     for (layer, _) in entries {
         a_blend.extend_from_slice(&layer.a);
     }
 
-    // Concatenate scaled B blocks horizontally in each row.
     let mut b_blend = vec![0.0f32; b_buf_len];
     let mut col_offset = 0usize;
     for (layer, eff_weight) in entries {
@@ -293,10 +287,6 @@ mod tests {
         delta
     }
 
-    // -----------------------------------------------------------------------
-    // Required assertion 1: single adapter at weight 1.0 is numerically
-    // identical to that adapter (max-diff 0.0 or < 1e-6).
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_single_adapter_identity() {
         let rank = 2;
@@ -306,11 +296,9 @@ mod tests {
 
         let blended = blend_lora_adapters(&[(&adapter, 1.0)]).unwrap();
 
-        // Generate a test input vector.
         let x: Vec<f32> = (0..d_in).map(|i| (i + 1) as f32).collect();
 
         let delta_orig = lora_delta(&adapter, &x);
-        // Blended adapter has scale=1.0 (alpha=rank_total).
         let blended_layer = blended.layers().get(&(0, "q_proj".to_string())).unwrap();
         let delta_blend = layer_delta(blended_layer, blended.config().scale(), &x);
 
@@ -326,10 +314,6 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Required assertion 2: blend of two adapters equals explicit sum.
-    // w1·Δ1(x) + w2·Δ2(x) matches the blended adapter's output (max-diff < 1e-5).
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_two_adapters_equals_sum() {
         let rank = 3;
@@ -347,7 +331,6 @@ mod tests {
 
         let d1 = lora_delta(&adapter1, &x);
         let d2 = lora_delta(&adapter2, &x);
-        // Expected: w1*Δ1 + w2*Δ2
         let expected: Vec<f32> = d1.iter().zip(&d2).map(|(a, b)| w1 * a + w2 * b).collect();
 
         let blended_layer = blended.layers().get(&(0, "q_proj".to_string())).unwrap();
@@ -365,9 +348,6 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Required assertion 3: rank of blended adapter equals Σr_e.
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_rank_equals_sum_of_ranks() {
         let adapter1 = make_adapter(1, 4, 4, 0.0);
@@ -383,18 +363,12 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Edge-case: empty adapters slice returns an error.
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_empty_returns_error() {
         let result: Result<LoraAdapter> = blend_lora_adapters(&[]);
         assert!(result.is_err(), "empty adapters should return an error");
     }
 
-    // -----------------------------------------------------------------------
-    // Edge-case: non-finite weight returns an error.
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_non_finite_weight_returns_error() {
         let adapter = make_adapter(1, 4, 4, 0.0);
@@ -402,13 +376,9 @@ mod tests {
         assert!(result.is_err(), "NaN weight should return an error");
     }
 
-    // -----------------------------------------------------------------------
-    // Summed rank exceeding MAX_BLEND_RANK_TOTAL returns an error.
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_rank_exceeds_cap_returns_error() {
         use super::MAX_BLEND_RANK_TOTAL;
-        // rank = cap + 1; d_in=1, d_out=1 → A and B are tiny (~32 KB total).
         let rank = MAX_BLEND_RANK_TOTAL + 1;
         let d_in = 1;
         let d_out = 1;
@@ -441,15 +411,11 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Mismatched A slice length returns an error.
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_mismatched_a_length_returns_error() {
         let rank = 2;
         let d_in = 4;
         let d_out = 4;
-        // A is one element short of the required rank * d_in.
         let a: Vec<f32> = vec![0.0f32; rank * d_in - 1];
         let b: Vec<f32> = vec![0.0f32; d_out * rank];
         let mut layers = HashMap::new();
@@ -479,16 +445,12 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Mismatched B slice length returns an error.
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_mismatched_b_length_returns_error() {
         let rank = 2;
         let d_in = 4;
         let d_out = 4;
         let a: Vec<f32> = vec![0.0f32; rank * d_in];
-        // B is one element short of the required d_out * rank.
         let b: Vec<f32> = vec![0.0f32; d_out * rank - 1];
         let mut layers = HashMap::new();
         layers.insert(
@@ -517,12 +479,6 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // alpha != rank causes scale() to be folded exactly once into B.
-    //
-    // With alpha=4, rank=2 → scale=2.0.  Blending a single adapter at
-    // mixture weight w should produce: w * scale * B @ (A @ x).
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_folds_alpha_rank_scale_once() {
         let rank = 2usize;
@@ -560,7 +516,6 @@ mod tests {
         let x: Vec<f32> = (0..d_in).map(|i| (i + 1) as f32).collect();
         let scale = alpha / rank as f32; // = 2.0
 
-        // Reference: w * scale * B @ (A @ x) — scale folded exactly once.
         let mut inter = vec![0.0f32; rank];
         for r in 0..rank {
             inter[r] = (0..d_in).map(|c| a[r * d_in + c] * x[c]).sum();
@@ -569,7 +524,6 @@ mod tests {
             .map(|row| w * scale * (0..rank).map(|c| b[row * rank + c] * inter[c]).sum::<f32>())
             .collect();
 
-        // Blended adapter has alpha=rank_total so scale()=1.0; use layer_delta directly.
         let actual = layer_delta(blended_layer, blended.config().scale(), &x);
 
         let max_diff = expected
@@ -584,9 +538,6 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Edge-case: adapters with different ranks blend correctly.
-    // -----------------------------------------------------------------------
     #[test]
     fn blend_asymmetric_ranks() {
         let r1 = 1;
@@ -624,15 +575,7 @@ mod tests {
         assert!(max_diff < 1e-5, "asymmetric-rank blend max-diff={max_diff}");
     }
 
-    // -----------------------------------------------------------------------
-    // Contract: a malformed huge dimension returns Err, never panics.
-    //
-    // rank=2, d_in=usize::MAX/2+1, d_out=1 with empty a and b=[0.0;2].
-    // Through the public entry the aggregate pre-pass catches it first
-    // (rank_total*(d_in+d_out) overflows usize via checked_mul → Err); the
-    // per-entry checked_mul is defense-in-depth for the same overflow class,
-    // isolated directly by blend_layer_entries_per_entry_product_overflow.
-    // -----------------------------------------------------------------------
+    // Malformed huge dimensions must return an error without allocating.
     #[test]
     fn blend_malformed_huge_dim_returns_err_not_panic() {
         let rank = 2usize;
@@ -659,24 +602,13 @@ mod tests {
         )
         .expect("valid adapter config");
         let result = blend_lora_adapters(&[(&adapter, 1.0)]);
-        // The pre-pass catches the overflow in rank_total*(d_in+d_out); the
-        // per-entry checked_mul is defense-in-depth for the same class.
         assert!(
             result.is_err(),
             "malformed huge dim must return Err, not panic"
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Isolates the per-entry rank*d_in checked_mul directly. Through the public
-    // blend_lora_adapters the aggregate pre-pass catches this overflow class
-    // first; calling the per-group helper with a single malformed entry
-    // (rank_total below the per-projection cap, no aggregate stage) reaches the
-    // per-entry guard as the first and only overflow check. Pinning the error
-    // message makes it mutation-sensitive: reverting the checked_mul makes the
-    // overflow either panic (debug) or surface via a different guard (release),
-    // both of which fail this assertion.
-    // -----------------------------------------------------------------------
+    // Exercise the per-entry overflow guard without the aggregate pre-pass.
     #[test]
     fn blend_layer_entries_per_entry_product_overflow_returns_err() {
         let rank = 2usize;
@@ -702,14 +634,7 @@ mod tests {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Contract: an aggregate element budget overrun returns Err before alloc.
-    //
-    // 65 layers each with rank=4096, d_in=2048, d_out=2048, empty a/b so the
-    // test allocates nothing. Per-group: rank_total=4096 == cap (passes the
-    // per-projection check). Aggregate: 4096*(2048+2048)*65 = 1,090,519,040
-    // > MAX_BLEND_TOTAL_ELEMENTS (1<<30 = 1,073,741,824).
-    // -----------------------------------------------------------------------
+    // Aggregate allocation limits must reject before any layer buffer exists.
     #[test]
     fn blend_aggregate_budget_exceeded_returns_err() {
         use super::MAX_BLEND_TOTAL_ELEMENTS;

--- a/crates/tune/src/lora/loader.rs
+++ b/crates/tune/src/lora/loader.rs
@@ -69,10 +69,8 @@ impl<'a> RunningRevisions<'a> {
         }
     }
 
-    /// Permissive revision context: mismatches are recorded on the loaded
-    /// adapter (`rev_mismatch_overridden`) but do not fail the load. Intended
-    /// for controlled migrations/backfills only — this reopens the silent
-    /// quality-loss gap Check 11 exists to close.
+    /// Permit revision mismatches for controlled migrations or backfills.
+    /// The loaded adapter records that this bypassed the usual rejection.
     pub fn permissive(base_model_rev: &'a str, tokenizer_rev: &'a str) -> Self {
         Self {
             base_model_rev,
@@ -93,7 +91,7 @@ pub fn load_adapters_from_manifest(
     >,
     running: Option<&RunningRevisions<'_>>,
 ) -> Result<Vec<LoadedAdapter>> {
-    // Reject a disallowed manifest before any adapter I/O — see docs/lora-io.md.
+    // Reject unapproved entries before any adapter I/O.
     for entry in &manifest.adapters {
         match entry.status {
             AdapterStatus::Quarantined => {
@@ -112,12 +110,10 @@ pub fn load_adapters_from_manifest(
         }
     }
 
-    // Allocate only after the admission pre-scan.
     let mut out = Vec::with_capacity(manifest.adapters.len());
 
     for entry in &manifest.adapters {
-        // Check 1: Status — defence-in-depth after the prescan above; can only
-        // fire if the manifest is mutated between the prescan and this loop.
+        // Recheck status in case the manifest changes after the pre-scan.
         match entry.status {
             AdapterStatus::Quarantined => {
                 return Err(TuneError::Validation(format!(
@@ -134,7 +130,7 @@ pub fn load_adapters_from_manifest(
             AdapterStatus::Approved => {}
         }
 
-        // Check 2: canonicalization must prove an untrusted URI remains in `base_dir`.
+        // Canonicalization must prove an untrusted URI remains in `base_dir`.
         let full_path = {
             let p = Path::new(&entry.uri);
             if p.is_absolute() {
@@ -152,7 +148,6 @@ pub fn load_adapters_from_manifest(
                 }
             }
             let joined = base_dir.join(p);
-            // Prove both endpoints before reading — see docs/lora-io.md.
             let canonical_base = std::fs::canonicalize(base_dir).map_err(|e| {
                 TuneError::Io(std::io::Error::new(
                     e.kind(),
@@ -176,7 +171,6 @@ pub fn load_adapters_from_manifest(
                     canonical_joined
                 }
                 Err(e) => {
-                    // Never fall back to an unproven lexical path.
                     return Err(TuneError::Io(std::io::Error::new(
                         e.kind(),
                         format!(
@@ -189,7 +183,7 @@ pub fn load_adapters_from_manifest(
             }
         };
 
-        // Checks 3–4: read the proven path once; bounded I/O and SHA-256 backstop races.
+        // Bound the verified-path read, then verify its checksum.
         let bytes = crate::lora::safetensors::read_lora_file_bounded(
             &full_path,
             crate::lora::safetensors::MAX_LORA_SIZE,
@@ -204,7 +198,6 @@ pub fn load_adapters_from_manifest(
             )));
         }
 
-        // Check 5: Parse safetensors bytes into a LoraAdapter.
         let adapter =
             crate::lora::safetensors::load_peft_safetensors_bytes(&bytes).map_err(|e| {
                 TuneError::Validation(format!(
@@ -213,7 +206,6 @@ pub fn load_adapters_from_manifest(
                 ))
             })?;
 
-        // Check 6: Rank must match the manifest entry.
         if adapter.config().rank != entry.rank {
             return Err(TuneError::Validation(format!(
                 "rank mismatch for '{}': manifest says {}, file has {}",
@@ -223,10 +215,9 @@ pub fn load_adapters_from_manifest(
             )));
         }
 
-        // Check 7: synthesized alpha also must match; omission cannot bypass the claim.
+        // Synthesized alpha must also match the manifest claim.
         validate_manifest_alpha(adapter.config().alpha, entry)?;
 
-        // Check 8: target_modules in adapter must be a subset of entry's list.
         for module in &adapter.config().target_modules {
             if !entry.target_modules.contains(module) {
                 return Err(TuneError::Validation(format!(
@@ -237,7 +228,6 @@ pub fn load_adapters_from_manifest(
             }
         }
 
-        // Check 9: Dimension validation against model config (inference-hook only).
         #[cfg(feature = "inference-hook")]
         if let Some(cfg) = model_config {
             adapter.validate_against(cfg).map_err(|e| {
@@ -248,7 +238,6 @@ pub fn load_adapters_from_manifest(
             })?;
         }
 
-        // Check 10: If safetensors header carries `adapter_id`, it must equal entry.id.
         let header_id = crate::lora::safetensors::read_peft_header_adapter_id(&bytes);
         if let Some(ref hid) = header_id
             && hid != &entry.id
@@ -259,7 +248,7 @@ pub fn load_adapters_from_manifest(
             )));
         }
 
-        // Check 11: reject silent serving-quality loss from revision drift — see docs/lora-io.md.
+        // Revision drift can silently degrade serving quality.
         let mut rev_mismatch_overridden = false;
         if let Some(running) = running {
             let mut mismatches = Vec::new();
@@ -468,7 +457,6 @@ mod tests {
         manifest.adapters.push(make_entry(
             "sha-mismatch-adapter",
             "adapter.safetensors",
-            // deliberately wrong hash
             "0000000000000000000000000000000000000000000000000000000000000000",
             4,
             8.0,
@@ -522,13 +510,11 @@ mod tests {
     fn loader_rejects_rank_mismatch() {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("adapter.safetensors");
-        // File has rank=4
         write_test_adapter(&file_path, 4, 8.0, &["q_proj"], None);
         let bytes = std::fs::read(&file_path).unwrap();
         let sha = sha256_hash(&bytes);
 
         let mut manifest = LoraManifest::new();
-        // Manifest says rank=8 — mismatch
         manifest.adapters.push(make_entry(
             "rank-mismatch-adapter",
             "adapter.safetensors",
@@ -557,13 +543,11 @@ mod tests {
     fn loader_rejects_id_mismatch() {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("adapter.safetensors");
-        // Write adapter with adapter_id = "file-id" in the safetensors header
         write_test_adapter(&file_path, 4, 8.0, &["q_proj"], Some("file-id"));
         let bytes = std::fs::read(&file_path).unwrap();
         let sha = sha256_hash(&bytes);
 
         let mut manifest = LoraManifest::new();
-        // Manifest entry has a different id — check 10 must reject this
         manifest.adapters.push(make_entry(
             "manifest-id",
             "adapter.safetensors",
@@ -628,7 +612,6 @@ mod tests {
     fn loader_ok_with_matching_header_id() {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("adapter.safetensors");
-        // Header id matches entry id
         write_test_adapter(&file_path, 4, 8.0, &["q_proj"], Some("matching-id"));
         let bytes = std::fs::read(&file_path).unwrap();
         let sha = sha256_hash(&bytes);
@@ -672,19 +655,13 @@ mod tests {
         assert!(result.unwrap().is_empty());
     }
 
-    /// FIX-2 mutation-sensitive: a revoked entry that appears AFTER an approved
-    /// entry must cause rejection WITHOUT reading the approved entry's file.
-    /// The approved entry's URI points at a path that does not exist, so if the
-    /// prescan were removed the loader would attempt to read it and return a
-    /// different (IO/NotFound) error. The prescan fires first — the error must
-    /// contain "revoked", not "not found" or "does not exist".
+    /// A later revoked entry must reject the manifest before earlier adapter I/O.
     #[test]
     fn loader_prescan_rejects_revoked_without_reading_approved_file() {
         let dir = tempdir().unwrap();
         let mut manifest = LoraManifest::new();
 
-        // approved-A: file intentionally missing — if reached, the error would
-        // say "does not exist", not "revoked".
+        // This missing file proves the pre-scan runs before adapter I/O.
         manifest.adapters.push(make_entry(
             "approved-a",
             "approved_a_does_not_exist.safetensors",
@@ -694,7 +671,6 @@ mod tests {
             AdapterStatus::Approved,
             vec!["q_proj".to_string()],
         ));
-        // revoked-B appears after approved-A; prescan must reject before IO.
         manifest.adapters.push(make_entry(
             "revoked-b",
             "revoked_b.safetensors",
@@ -782,20 +758,13 @@ mod tests {
         );
     }
 
-    /// D4 (alpha synthesis): an adapter whose header omits alpha metadata
-    /// synthesises alpha = rank. The governed loader must reject it when the
-    /// manifest declares a different alpha. This test proves the alpha-agreement
-    /// check in Check 7 is not bypassed by the synthesis fallback.
-    ///
-    /// Mutation-sensitive: removing the Check 7 alpha comparison makes this test
-    /// pass (wrong), so the test fails when the guard is absent.
+    /// Manifest alpha must match the rank-derived fallback for omitted metadata.
     #[test]
     fn loader_alpha_synthesis_mismatch_is_rejected() {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("no_alpha_meta.safetensors");
 
-        // Write an adapter with rank=16 but NO `alpha` key in the header.
-        // The loader's safetensors parser will synthesise alpha = rank = 16.
+        // Omitted metadata makes the parser synthesize `alpha = rank`.
         use safetensors::Dtype;
         use safetensors::tensor::{TensorView, serialize};
         use std::collections::HashMap;
@@ -814,7 +783,6 @@ mod tests {
             "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight".to_string(),
             TensorView::new(Dtype::F32, vec![d_out, rank], &b_bytes).unwrap(),
         );
-        // Deliberately omit `alpha` from metadata so synthesis fires.
         let mut meta: HashMap<String, String> = HashMap::new();
         meta.insert("rank".to_string(), rank.to_string());
         meta.insert("target_modules".to_string(), "q_proj".to_string());
@@ -823,7 +791,6 @@ mod tests {
 
         let sha = sha256_hash(&file_bytes);
 
-        // Manifest declares alpha=64, but the file synthesises alpha=16 — mismatch.
         let mut manifest = LoraManifest::new();
         manifest.adapters.push(make_entry(
             "alpha-mismatch",
@@ -866,23 +833,15 @@ mod tests {
         assert!(err.to_string().contains("alpha mismatch"));
     }
 
-    /// FIX-3 (round 2), mutation-sensitive: a symlink inside base_dir that points
-    /// to a real file OUTSIDE base_dir must not let an adapter escape confinement.
-    /// The canonicalized path resolves outside base, so the loader rejects it
-    /// rather than reading through the symlink. Removing the `starts_with`
-    /// confinement check makes this load the outside file (then fail later on the
-    /// "dummy" hash) — a different error — so this test fails when the guard is
-    /// absent.
+    /// A symlink within `base_dir` must not escape its canonicalized boundary.
     #[cfg(unix)]
     #[test]
     fn loader_rejects_symlink_escape() {
         use std::os::unix::fs::symlink;
         let base = tempdir().unwrap();
         let outside = tempdir().unwrap();
-        // A real adapter sits OUTSIDE base_dir.
         let secret = outside.path().join("secret.safetensors");
         write_test_adapter(&secret, 4, 8.0, &["q_proj"], None);
-        // base_dir/link.safetensors -> outside/secret.safetensors
         let link = base.path().join("link.safetensors");
         symlink(&secret, &link).unwrap();
 
@@ -914,15 +873,7 @@ mod tests {
         );
     }
 
-    /// Check 11, mutation-sensitive: an adapter stamped with a `base_model_rev`
-    /// that does not match the running context must be rejected, even though
-    /// every other check (status/path/hash/rank/alpha/modules/id) passes.
-    ///
-    /// Mutation-sensitive: removing the Check 11 block makes `running` inert
-    /// (the parameter is simply never consulted), so this load would return
-    /// `Ok` instead — the `result.is_err()` assertion fails when the guard is
-    /// absent. Verified by reverting the Check 11 addition and re-running:
-    /// this test fails (`Ok` returned) without the fix, passes with it.
+    /// A base-model revision mismatch must reject an otherwise valid adapter.
     #[test]
     fn loader_rejects_base_model_rev_mismatch() {
         let dir = tempdir().unwrap();
@@ -945,7 +896,6 @@ mod tests {
         entry.tokenizer_rev = "tok-rev-a".to_string();
         manifest.adapters.push(entry);
 
-        // Tokenizer rev matches; base_model_rev does not.
         let running = RunningRevisions::strict("running-rev-b", "tok-rev-a");
         let result = load_adapters_from_manifest(
             &manifest,
@@ -962,8 +912,7 @@ mod tests {
         );
     }
 
-    /// Symmetric to the base-rev test above: a `tokenizer_rev` mismatch alone
-    /// must also be rejected.
+    /// A tokenizer revision mismatch must also reject the adapter.
     #[test]
     fn loader_rejects_tokenizer_rev_mismatch() {
         let dir = tempdir().unwrap();
@@ -986,7 +935,6 @@ mod tests {
         entry.tokenizer_rev = "tok-rev-a".to_string();
         manifest.adapters.push(entry);
 
-        // base_model_rev matches; tokenizer_rev does not.
         let running = RunningRevisions::strict("trained-rev-a", "tok-rev-mismatch");
         let result = load_adapters_from_manifest(
             &manifest,
@@ -1003,8 +951,7 @@ mod tests {
         );
     }
 
-    /// Complement to the rejection tests: matching revisions must load fine —
-    /// Check 11 is a comparison, not an unconditional reject.
+    /// Matching revisions remain admissible.
     #[test]
     fn loader_accepts_matching_revs() {
         let dir = tempdir().unwrap();

--- a/crates/tune/src/lora/manifest.rs
+++ b/crates/tune/src/lora/manifest.rs
@@ -118,7 +118,7 @@ impl LoraManifest {
     /// allocation-DoS from an attacker-supplied or symlinked giant path.
     pub fn load(path: &Path) -> Result<Self> {
         use std::io::Read;
-        // Fast-path: stat before open (cheap; avoids opening a known-huge file).
+        // Check size before opening an untrusted path.
         let file_size = std::fs::metadata(path).map_err(TuneError::Io)?.len();
         if file_size > MAX_MANIFEST_SIZE {
             return Err(TuneError::Io(std::io::Error::new(
@@ -128,7 +128,7 @@ impl LoraManifest {
                 ),
             )));
         }
-        // Bounded read: +1 sentinel detects a file that grew after the stat.
+        // The extra byte detects growth after the metadata check.
         let f = std::fs::File::open(path).map_err(TuneError::Io)?;
         let mut buf = Vec::new();
         f.take(MAX_MANIFEST_SIZE + 1)
@@ -205,9 +205,7 @@ mod tests {
 
     #[test]
     fn rejects_missing_required_field() {
-        // `id` is omitted — serde must reject this. `owner`/`dtype` are
-        // filled in (even though they're also required) so `id` remains the
-        // *sole* deliberately-missing field, matching this test's name.
+        // Populate every other required field so only `id` is missing.
         let json = r#"{
             "version": 1,
             "adapters": [{
@@ -247,9 +245,7 @@ mod tests {
             (AdapterStatus::Revoked, "revoked"),
         ] {
             assert_eq!(status.as_str(), expected);
-            // `as_str()` must never drift from the serde wire format, since
-            // callers (e.g. the safetensors header writer) use it as a
-            // stand-in for JSON serialization.
+            // `as_str()` is used as the safetensors wire-format value.
             assert_eq!(
                 serde_json::to_string(&status).unwrap(),
                 format!("\"{expected}\"")
@@ -259,8 +255,7 @@ mod tests {
 
     #[test]
     fn rejects_unknown_status() {
-        // `owner`/`dtype` are filled in so the failure is unambiguously
-        // about the bad `status` value, not an incidental missing field.
+        // Populate other fields so this rejects only the bad status.
         let json = r#"{
             "id": "x", "name": "n", "owner": "team-test", "uri": "u",
             "integrity_sha256": "h",
@@ -310,10 +305,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("big_manifest.json");
 
-        // Produce a file whose stat length is MAX_MANIFEST_SIZE + 1 without
-        // writing 64 MiB: seek past the cap and write one byte. On every major
-        // filesystem this yields a sparse file (one real disk sector) whose
-        // reported length crosses the cap, exercising the guard cheaply.
+        // A sparse file crosses the cap without allocating its full length.
         {
             let mut f = std::fs::File::create(&path).unwrap();
             use std::io::Seek;

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -263,11 +263,9 @@ impl LoraAdapter {
     }
 }
 
-// Delegate inference hooks to the adapter's application path.
 #[cfg(feature = "inference-hook")]
 impl lattice_inference::lora_hook::LoraHook for LoraAdapter {
     fn apply(&self, layer_idx: usize, module: &str, x: &[f32], output: &mut [f32]) {
-        // Delegate to the existing apply method
         LoraAdapter::apply(self, layer_idx, module, x, output);
     }
 }
@@ -285,8 +283,6 @@ mod tests {
 
         let mut layers = HashMap::new();
 
-        // Layer 0, q_proj: rank=2, d_in=4, d_out=4
-        // A = identity-like (first 2 components), B = scale
         layers.insert(
             (0, "q_proj".into()),
             LoraLayer {
@@ -362,11 +358,6 @@ mod tests {
     fn test_adapter_apply() {
         let adapter = make_test_adapter();
 
-        // x = [1, 2, 3, 4], base = [0, 0, 0, 0]
-        // A @ x = [1, 2] (picks first 2 components)
-        // B @ [1, 2] = [1, 2, 0, 0]
-        // scale = 2.0
-        // output = [0, 0, 0, 0] + 2.0 * [1, 2, 0, 0] = [2, 4, 0, 0]
         let x = [1.0, 2.0, 3.0, 4.0];
         let mut output = [0.0f32; 4];
         adapter.apply(0, "q_proj", &x, &mut output);
@@ -383,7 +374,6 @@ mod tests {
 
         let x = [1.0, 2.0, 3.0, 4.0];
         let mut output = [10.0, 20.0, 30.0, 40.0];
-        // v_proj at layer 0 has no adapter -> should be a no-op
         adapter.apply(0, "v_proj", &x, &mut output);
 
         assert!((output[0] - 10.0).abs() < 1e-6);
@@ -396,7 +386,6 @@ mod tests {
 
         let x = [1.0, 2.0, 3.0, 4.0];
         let mut output = [10.0, 20.0, 30.0, 40.0];
-        // layer 1 has no adapter -> should be a no-op
         adapter.apply(1, "q_proj", &x, &mut output);
 
         assert!((output[0] - 10.0).abs() < 1e-6);
@@ -413,7 +402,6 @@ mod tests {
     #[test]
     fn test_num_parameters() {
         let adapter = make_test_adapter();
-        // A: 2*4 = 8, B: 4*2 = 8 => total 16
         assert_eq!(adapter.num_parameters(), 16);
     }
 
@@ -503,7 +491,6 @@ mod tests {
         #[test]
         fn test_validate_against_layer_out_of_bounds() {
             let cfg = Qwen35Config::qwen35_0_8b();
-            // layer 999 does not exist
             let adapter = make_adapter_for_layer(999, "q_proj", 1024, 4096);
             assert!(adapter.validate_against(&cfg).is_err());
         }
@@ -511,9 +498,6 @@ mod tests {
         #[test]
         fn test_validate_against_dim_mismatch() {
             let cfg = Qwen35Config::qwen35_0_8b();
-            // 0.8b: hidden=1024, full_q_dim=8*256=2048 → q_proj expects (1024, 4096)
-            // Supply 2b dims (hidden=2048, full_q_dim=4096 → d_out=8192) — wrong for 0.8b.
-            // Layer 3 is full-attention in the 24-layer 0.8b config.
             let adapter = make_adapter_for_layer(3, "q_proj", 2048, 8192);
             assert!(adapter.validate_against(&cfg).is_err());
         }
@@ -521,7 +505,6 @@ mod tests {
         #[test]
         fn test_validate_against_correct_dims_passes() {
             let cfg = Qwen35Config::qwen35_0_8b();
-            // Layer 3 is full-attention; q_proj: d_in=hidden=1024, d_out=2*full_q_dim=4096.
             let adapter = make_adapter_for_layer(3, "q_proj", 1024, 4096);
             assert!(adapter.validate_against(&cfg).is_ok());
         }
@@ -529,7 +512,6 @@ mod tests {
         #[test]
         fn test_validate_against_mlp_correct() {
             let cfg = Qwen35Config::qwen35_0_8b();
-            // gate_proj on any layer: d_in=hidden=1024, d_out=intermediate=3584.
             let adapter = make_adapter_for_layer(0, "gate_proj", 1024, 3584);
             assert!(adapter.validate_against(&cfg).is_ok());
         }
@@ -544,11 +526,7 @@ mod tests {
 
         #[test]
         fn test_validate_against_gdn_all_modules_pass() {
-            // Regression: train_grad_full --save emits all five GDN LoRA modules
-            // (in_proj_qkv/z/b/a, out_proj). The forward applies every one of them
-            // (gdn_fused.rs), so validate_against must accept each with the dims the
-            // loader and trainer use. Dims are derived from the config, not hardcoded,
-            // so this stays correct if the reference dims change.
+            // All GDN LoRA dimensions must come from the model configuration.
             let cfg = Qwen35Config::qwen35_0_8b();
             let gdn_layer = (0..cfg.num_hidden_layers)
                 .find(|&i| !cfg.is_full_attention(i))
@@ -586,13 +564,11 @@ mod tests {
                 .expect("config has linear-attention layers");
             let h = cfg.hidden_size;
 
-            // Correct dims (value_heads=32) must validate.
             let ok_b = make_adapter_for_layer(gdn_layer, "in_proj_b", h, 32);
             assert!(ok_b.validate_against(&cfg).is_ok());
             let ok_a = make_adapter_for_layer(gdn_layer, "in_proj_a", h, 32);
             assert!(ok_a.validate_against(&cfg).is_ok());
 
-            // The old (wrong) key-head dim (16) must be rejected.
             let bad_b = make_adapter_for_layer(gdn_layer, "in_proj_b", h, 16);
             assert!(
                 bad_b.validate_against(&cfg).is_err(),
@@ -615,13 +591,11 @@ mod tests {
                 .expect("config has linear-attention layers");
             let h = cfg.hidden_size;
 
-            // Correct dims (value_heads=48) must validate.
             let ok_b = make_adapter_for_layer(gdn_layer, "in_proj_b", h, 48);
             assert!(ok_b.validate_against(&cfg).is_ok());
             let ok_a = make_adapter_for_layer(gdn_layer, "in_proj_a", h, 48);
             assert!(ok_a.validate_against(&cfg).is_ok());
 
-            // The old (wrong) key-head dim (16) must be rejected.
             let bad_b = make_adapter_for_layer(gdn_layer, "in_proj_b", h, 16);
             assert!(
                 bad_b.validate_against(&cfg).is_err(),

--- a/crates/tune/src/lora/online.rs
+++ b/crates/tune/src/lora/online.rs
@@ -45,7 +45,6 @@ pub fn adapt_step(
     target_delta: &[f32],
     learning_rate: f32,
 ) -> Result<AdaptStepResult, TuneError> {
-    // Extract scale before any mutable borrow of adapter layers.
     let scale = adapter.config().scale();
 
     let lora = adapter
@@ -70,16 +69,12 @@ pub fn adapt_step(
         });
     }
 
-    // Forward: intermediate = A @ input,  shape (rank,)
-    // A is row-major (rank, d_in): intermediate[r] = sum_j A[r*d_in + j] * input[j]
     let mut intermediate = vec![0.0f32; rank];
     for r in 0..rank {
         let row = &lora.a[r * d_in..(r + 1) * d_in];
         intermediate[r] = row.iter().zip(input.iter()).map(|(a, x)| a * x).sum();
     }
 
-    // Forward: delta = scale * B @ intermediate,  shape (d_out,)
-    // B is row-major (d_out, rank): delta[i] = scale * sum_r B[i*rank + r] * intermediate[r]
     let mut delta = vec![0.0f32; d_out];
     for i in 0..d_out {
         let row = &lora.b[i * rank..(i + 1) * rank];
@@ -91,7 +86,6 @@ pub fn adapt_step(
         delta[i] = scale * acc;
     }
 
-    // Residual and loss
     let residual: Vec<f32> = delta
         .iter()
         .zip(target_delta.iter())
@@ -99,7 +93,6 @@ pub fn adapt_step(
         .collect();
     let loss: f32 = residual.iter().map(|r| r * r).sum();
 
-    // dL/dB[i*rank + r] = 2 * scale * residual[i] * intermediate[r]
     let mut db = vec![0.0f32; d_out * rank];
     for i in 0..d_out {
         for r in 0..rank {
@@ -107,13 +100,11 @@ pub fn adapt_step(
         }
     }
 
-    // bt_residual[r] = sum_i B[i*rank + r] * residual[i]  (B^T @ residual)
     let mut bt_residual = vec![0.0f32; rank];
     for r in 0..rank {
         bt_residual[r] = (0..d_out).map(|i| lora.b[i * rank + r] * residual[i]).sum();
     }
 
-    // dL/dA[r*d_in + j] = 2 * scale * bt_residual[r] * input[j]
     let mut da = vec![0.0f32; rank * d_in];
     for r in 0..rank {
         for j in 0..d_in {
@@ -126,7 +117,6 @@ pub fn adapt_step(
         sq.sqrt()
     };
 
-    // SGD in-place update
     for (b_val, db_val) in lora.b.iter_mut().zip(db.iter()) {
         *b_val -= learning_rate * db_val;
     }
@@ -221,7 +211,6 @@ mod tests {
     fn test_adapt_step_dimension_mismatch() {
         let mut adapter = make_small_adapter();
 
-        // input too short (d_in=3, passing 2)
         let err = adapt_step(&mut adapter, 0, "q_proj", &[1.0, 2.0], &[1.0, 1.0], 0.01)
             .expect_err("wrong input length must return Err");
         assert!(
@@ -229,7 +218,6 @@ mod tests {
             "expected DimensionMismatch, got {err:?}"
         );
 
-        // target_delta wrong length (d_out=2, passing 3)
         let err = adapt_step(
             &mut adapter,
             0,

--- a/crates/tune/src/lora/optimizer.rs
+++ b/crates/tune/src/lora/optimizer.rs
@@ -60,7 +60,6 @@ impl AdamState {
         );
         let n = params.len();
 
-        // Lazily initialise moment vectors to zero.
         let m = self
             .m
             .entry(key.to_string())
@@ -70,35 +69,30 @@ impl AdamState {
             .entry(key.to_string())
             .or_insert_with(|| vec![0.0f32; n]);
 
-        // Advance only this tensor's timestep for correct bias correction.
+        // Bias correction uses a timestep per tensor, never a shared counter.
         let t = {
             let c = self.t.entry(key.to_string()).or_insert(0);
             *c += 1;
             *c
         };
 
-        // Bias-correction denominators (this key's own t).
         let bc1 = 1.0 - beta1.powi(t as i32);
         let bc2 = 1.0 - beta2.powi(t as i32);
 
         for i in 0..n {
             let g = grads[i];
 
-            // Update biased first moment: m = β₁·m + (1-β₁)·g
             m[i] = beta1 * m[i] + (1.0 - beta1) * g;
-            // Update biased second moment: v = β₂·v + (1-β₂)·g²
             v[i] = beta2 * v[i] + (1.0 - beta2) * g * g;
 
-            // Bias-corrected estimates.
             let m_hat = m[i] / bc1;
             let v_hat = v[i] / bc2;
 
-            // AdamW: decoupled weight decay applied before the gradient step.
+            // AdamW decouples weight decay from the gradient update.
             if decoupled && weight_decay != 0.0 {
                 params[i] -= lr * weight_decay * params[i];
             }
 
-            // θ -= lr · m̂ / (√v̂ + ε)
             params[i] -= lr * m_hat / (v_hat.sqrt() + eps);
         }
     }
@@ -109,8 +103,6 @@ impl Default for AdamState {
         Self::new()
     }
 }
-
-// ─── Gradient computation ────────────────────────────────────────────────────
 
 /// Gradients of the LoRA MSE loss with respect to a single layer's A and B matrices.
 #[derive(Debug)]
@@ -159,14 +151,12 @@ pub fn compute_lora_gradients(
         });
     }
 
-    // Forward: intermediate = A @ input  (rank,)
     let mut intermediate = vec![0.0f32; rank];
     for r in 0..rank {
         let row = &lora.a[r * d_in..(r + 1) * d_in];
         intermediate[r] = row.iter().zip(input.iter()).map(|(a, x)| a * x).sum();
     }
 
-    // Forward: delta = scale * B @ intermediate  (d_out,)
     let mut delta = vec![0.0f32; d_out];
     for i in 0..d_out {
         let row = &lora.b[i * rank..(i + 1) * rank];
@@ -178,7 +168,6 @@ pub fn compute_lora_gradients(
         delta[i] = scale * acc;
     }
 
-    // Residual and loss (sum of squared errors, matching adapt_step).
     let error: Vec<f32> = delta
         .iter()
         .zip(target_delta.iter())
@@ -186,7 +175,6 @@ pub fn compute_lora_gradients(
         .collect();
     let loss: f32 = error.iter().map(|e| e * e).sum();
 
-    // dL/dB[i*rank + r] = 2 * scale * error[i] * intermediate[r]
     let mut grad_b = vec![0.0f32; d_out * rank];
     for i in 0..d_out {
         for r in 0..rank {
@@ -194,13 +182,11 @@ pub fn compute_lora_gradients(
         }
     }
 
-    // bt_error[r] = Σ_i B[i*rank + r] * error[i]
     let mut bt_error = vec![0.0f32; rank];
     for r in 0..rank {
         bt_error[r] = (0..d_out).map(|i| lora.b[i * rank + r] * error[i]).sum();
     }
 
-    // dL/dA[r*d_in + j] = 2 * scale * bt_error[r] * input[j]
     let mut grad_a = vec![0.0f32; rank * d_in];
     for r in 0..rank {
         for j in 0..d_in {
@@ -248,8 +234,6 @@ mod tests {
         LoraAdapter::new(config, layers).expect("valid adapter config")
     }
 
-    // ─── gradient computation tests ────────────────────────────────────────
-
     #[test]
     fn test_gradient_computation() {
         let adapter = make_small_adapter();
@@ -259,17 +243,13 @@ mod tests {
         let grads = compute_lora_gradients(&adapter, 0, "q_proj", &input, &target_delta)
             .expect("compute_lora_gradients must succeed");
 
-        // grad_b shape: d_out * rank = 2 * 2 = 4
         assert_eq!(
             grads.grad_b.len(),
             4,
             "grad_b must have d_out*rank elements"
         );
-        // grad_a shape: rank * d_in = 2 * 3 = 6
         assert_eq!(grads.grad_a.len(), 6, "grad_a must have rank*d_in elements");
-        // Loss must be positive because delta != target.
         assert!(grads.loss > 0.0, "loss must be positive");
-        // At least one gradient element must be non-zero.
         assert!(
             grads.grad_b.iter().any(|&g| g.abs() > 1e-9)
                 || grads.grad_a.iter().any(|&g| g.abs() > 1e-9),
@@ -291,7 +271,6 @@ mod tests {
     #[test]
     fn test_gradient_computation_dimension_mismatch() {
         let adapter = make_small_adapter();
-        // input too short (d_in=3, passing 2)
         let err = compute_lora_gradients(&adapter, 0, "q_proj", &[1.0, 2.0], &[1.0, 1.0])
             .expect_err("wrong input length must return Err");
         assert!(
@@ -299,8 +278,6 @@ mod tests {
             "expected DimensionMismatch, got {err:?}"
         );
     }
-
-    // ─── Adam state tests ───────────────────────────────────────────────────
 
     #[test]
     fn test_adam_step_updates_params() {
@@ -345,7 +322,6 @@ mod tests {
         let mut pc = vec![3.0f32, 3.0];
         let mut pd = vec![4.0f32, 4.0];
 
-        // Step each key once.
         for (key, params) in [
             ("a", &mut pa),
             ("b", &mut pb),
@@ -360,7 +336,6 @@ mod tests {
         assert_eq!(state.t["c"], 1, "key 'c' must be at t=1 after one step");
         assert_eq!(state.t["d"], 1, "key 'd' must be at t=1 after one step");
 
-        // Step only "a" a second time.
         state.step("a", &mut pa, &grads, 0.01, 0.9, 0.999, 1e-8, 0.0, false);
 
         assert_eq!(
@@ -380,7 +355,4 @@ mod tests {
             "key 'd' must not advance when only 'a' is stepped"
         );
     }
-
-    // Integration tests for AdamW weight decay and Adam-vs-SGD convergence
-    // require the train_lora loop (issue #88). They will land alongside that.
 }

--- a/crates/tune/src/lora/safetensors.rs
+++ b/crates/tune/src/lora/safetensors.rs
@@ -34,10 +34,8 @@ enum LoraMatrix {
 
 /// Parse a recognized PEFT or MLX LoRA tensor key, ignoring non-factor keys.
 fn parse_peft_key(key: &str) -> Option<PeftKey> {
-    // Strip the trailing `.weight` if present
     let key = key.strip_suffix(".weight").unwrap_or(key);
 
-    // Determine A or B (handles both PEFT uppercase and MLX lowercase)
     let (key, matrix, is_mlx) = if let Some(k) = key.strip_suffix(".lora_A") {
         (k, LoraMatrix::A, false)
     } else if let Some(k) = key.strip_suffix(".lora_B") {
@@ -50,19 +48,14 @@ fn parse_peft_key(key: &str) -> Option<PeftKey> {
         return None;
     };
 
-    // Find "layers.{i}" segment and extract what follows
     let layers_marker = ".layers.";
     let layers_pos = key.find(layers_marker)?;
     let after_layers = &key[layers_pos + layers_marker.len()..];
 
-    // Split: "{i}.{rest}" where rest is like "self_attn.q_proj" or "mlp.gate_proj"
     let dot_pos = after_layers.find('.')?;
     let layer_idx: usize = after_layers[..dot_pos].parse().ok()?;
     let rest = &after_layers[dot_pos + 1..];
 
-    // Extract the module name (last segment after the block qualifier).
-    // "self_attn.q_proj" -> "q_proj"
-    // "mlp.gate_proj" -> "gate_proj"
     let module = rest.rsplit('.').next()?.to_string();
     if module.is_empty() {
         return None;
@@ -158,22 +151,18 @@ fn f16_to_f32(bits: u16) -> f32 {
 
     if exp == 0 {
         if frac == 0 {
-            // Zero
             f32::from_bits(sign << 31)
         } else {
-            // Subnormal: value = (-1)^sign * 2^(-14) * (frac / 1024)
             let val = (frac as f32) / 1024.0 * (2.0f32).powi(-14);
             if sign == 1 { -val } else { val }
         }
     } else if exp == 31 {
-        // Inf or NaN
         if frac == 0 {
             f32::from_bits((sign << 31) | (0xff << 23))
         } else {
             f32::from_bits((sign << 31) | (0xff << 23) | (frac << 13))
         }
     } else {
-        // Normalized: re-bias exponent from 15 to 127
         let f32_exp = exp + 127 - 15;
         f32::from_bits((sign << 31) | (f32_exp << 23) | (frac << 13))
     }
@@ -191,7 +180,6 @@ pub(crate) fn load_peft_safetensors_bytes(bytes: &[u8]) -> Result<LoraAdapter, T
     let tensors = SafeTensors::deserialize(bytes)
         .map_err(|e| TuneError::Serialization(format!("failed to parse safetensors: {e}")))?;
 
-    // Collect all parsed LoRA keys
     let names: Vec<String> = tensors.names().into_iter().map(String::from).collect();
     let mut a_tensors: HashMap<(usize, String), (Vec<f32>, Vec<usize>)> = HashMap::new();
     let mut b_tensors: HashMap<(usize, String), (Vec<f32>, Vec<usize>)> = HashMap::new();
@@ -203,8 +191,7 @@ pub(crate) fn load_peft_safetensors_bytes(bytes: &[u8]) -> Result<LoraAdapter, T
             let (data, shape) = read_tensor_f32(&tensors, name)?;
             target_modules.insert(peft_key.module.clone());
 
-            // MLX format stores transposed: A=(d_in, rank), B=(rank, d_out)
-            // PEFT format (what we expect): A=(rank, d_in), B=(d_out, rank)
+            // MLX stores factors transposed relative to PEFT.
             let (data, shape) = if peft_key.transposed && shape.len() == 2 {
                 let (rows, cols) = (shape[0], shape[1]);
                 let expected = rows.checked_mul(cols).ok_or_else(|| {
@@ -451,7 +438,6 @@ pub(crate) const MAX_LORA_SIZE: u64 = 10 * 1024 * 1024 * 1024;
 /// Returns I/O errors for metadata, over-limit, open, or read failures.
 /// See [`docs/lora-io.md`](../../docs/lora-io.md#read_lora_file_bounded) for the two-stage bound.
 pub(crate) fn read_lora_file_bounded(path: &Path, max_bytes: u64) -> Result<Vec<u8>, TuneError> {
-    // Reject a known-oversized file before allocation.
     let file_size = std::fs::metadata(path)
         .map_err(|e| {
             TuneError::Io(std::io::Error::new(
@@ -469,7 +455,6 @@ pub(crate) fn read_lora_file_bounded(path: &Path, max_bytes: u64) -> Result<Vec<
             ),
         )));
     }
-    // The one-byte sentinel catches growth after the metadata check.
     use std::io::Read;
     let f = std::fs::File::open(path).map_err(|e| {
         TuneError::Io(std::io::Error::new(
@@ -514,7 +499,6 @@ pub fn save_peft_safetensors(
 ) -> Result<(), TuneError> {
     adapter.config().validate()?;
 
-    // Collect owned byte buffers first; TensorView borrows from these.
     let mut byte_data: Vec<(String, Vec<usize>, Vec<u8>)> = Vec::new();
 
     for ((layer_idx, module), layer) in adapter.layers() {

--- a/crates/tune/src/registry/storage/tests.rs
+++ b/crates/tune/src/registry/storage/tests.rs
@@ -104,12 +104,6 @@ fn test_registry_delete() {
     assert!(registry.is_empty());
 }
 
-// ------------------------------------------------------------------
-// load_weights / load_weights_verified integrity (#504 remaining slice 3:
-// close the registry raw-load bypass — `load_weights` no longer silently
-// skips the checksum check when a hash is on record).
-// ------------------------------------------------------------------
-
 #[test]
 fn test_load_weights_verifies_when_hash_present() {
     let registry = ModelRegistry::in_memory();
@@ -123,7 +117,6 @@ fn test_load_weights_verifies_when_hash_present() {
         "register() must always record a weights_hash"
     );
 
-    // Untampered load succeeds via both entry points.
     assert_eq!(registry.load_weights(&registered).unwrap(), weights);
     assert_eq!(
         registry.load_weights_verified(&registered).unwrap(),
@@ -133,11 +126,7 @@ fn test_load_weights_verifies_when_hash_present() {
 
 #[test]
 fn test_load_weights_rejects_tampered_bytes_on_disk() {
-    // #504 remaining slice 3: previously `load_weights` was a pure raw
-    // read with zero checksum check — a byte flipped on disk (or a
-    // truncated file, or a full swap) would load silently. It must now
-    // be rejected via the SAME entry point a naive caller reaches for,
-    // not only via `load_weights_verified`.
+    // `load_weights` must verify a recorded checksum, not just the stricter API.
     let tmp = tempfile::tempdir().unwrap();
     let registry = ModelRegistry::with_path(tmp.path()).unwrap();
     let model = RegisteredModel::new("test", "1.0.0");
@@ -146,8 +135,6 @@ fn test_load_weights_rejects_tampered_bytes_on_disk() {
     let id = registry.register(model, &weights).unwrap();
     let registered = registry.get_by_id(&id).unwrap();
 
-    // Tamper with the on-disk weights file directly (flip one byte,
-    // same length — the size-only-adjacent failure mode).
     let weights_path = tmp.path().join("test/1.0.0/weights.bin");
     let mut tampered = weights.clone();
     tampered[3] ^= 0xFF;
@@ -161,7 +148,6 @@ fn test_load_weights_rejects_tampered_bytes_on_disk() {
         "expected WeightIntegrityError, got: {err:?}"
     );
 
-    // load_weights_verified must reject the same tampered artifact too.
     let err = registry
         .load_weights_verified(&registered)
         .expect_err("load_weights_verified must reject tampered bytes");
@@ -173,12 +159,7 @@ fn test_load_weights_rejects_tampered_bytes_on_disk() {
 
 #[test]
 fn test_load_weights_rejects_mutated_clone_hash() {
-    // `RegisteredModel` is a cloned DTO with public `weights_path`/
-    // `weights_hash` fields. If verification trusted the CALLER's value, a
-    // caller could tamper weights.bin on disk, set its clone's hash to
-    // sha256(tampered bytes), and have both entry points "verify" the
-    // tampered artifact. Verification must anchor to the canonical
-    // registry record and reject a disagreeing argument outright.
+    // Verification must use the canonical record, never caller-mutated fields.
     let tmp = tempfile::tempdir().unwrap();
     let registry = ModelRegistry::with_path(tmp.path()).unwrap();
     let model = RegisteredModel::new("test", "1.0.0");
@@ -186,8 +167,6 @@ fn test_load_weights_rejects_mutated_clone_hash() {
 
     let id = registry.register(model, &weights).unwrap();
 
-    // Tamper the on-disk artifact, then forge the clone's hash to match
-    // the tampered bytes.
     let weights_path = tmp.path().join("test/1.0.0/weights.bin");
     let mut tampered = weights.clone();
     tampered[0] ^= 0xFF;
@@ -211,8 +190,6 @@ fn test_load_weights_rejects_mutated_clone_hash() {
         "expected canonical-record disagreement rejection, got: {err:?}"
     );
 
-    // Blanking the clone's hash must not re-open the pre-#504 raw-load
-    // path either — the canonical record still carries a hash.
     let mut hashless = registry.get_by_id(&id).unwrap();
     hashless.weights_hash = None;
     let err = registry
@@ -230,8 +207,6 @@ fn test_load_weights_rejects_mutated_clone_hash() {
         "expected canonical-record disagreement rejection, got: {err:?}"
     );
 
-    // The honest canonical record still rejects the tampered disk bytes
-    // via the checksum itself.
     let canonical = registry.get_by_id(&id).unwrap();
     let err = registry
         .load_weights(&canonical)
@@ -244,11 +219,7 @@ fn test_load_weights_rejects_mutated_clone_hash() {
 
 #[test]
 fn test_load_weights_rejects_mutated_clone_path() {
-    // Path half of the canonical-record disagreement guard. The redirected
-    // file holds byte-identical content and the clone's hash is left
-    // canonical, so if the `weights_path` predicate were removed the load
-    // would wrongly SUCCEED (canonical path + canonical hash still line
-    // up) — the hash comparison cannot mask this test.
+    // A path mismatch must reject even when bytes and hash match.
     let tmp = tempfile::tempdir().unwrap();
     let registry = ModelRegistry::with_path(tmp.path()).unwrap();
     let model = RegisteredModel::new("test", "1.0.0");
@@ -280,8 +251,7 @@ fn test_load_weights_rejects_mutated_clone_path() {
 
 #[test]
 fn test_load_weights_rejects_unregistered_model() {
-    // A RegisteredModel value that was never registered (or was deleted)
-    // has no canonical record to verify against — it must not load at all.
+    // A missing canonical record must never load.
     let registry = ModelRegistry::in_memory();
     let mut ghost = RegisteredModel::new("ghost", "1.0.0");
     ghost.weights_path = Some("ghost/1.0.0/weights.bin".to_string());
@@ -326,13 +296,7 @@ fn test_load_weights_rejects_truncated_file_on_disk() {
 
 #[test]
 fn test_load_weights_verified_rejects_missing_hash() {
-    // A model with weights on disk but no recorded hash at all (e.g.
-    // registered via `register_metadata` and given a weights_path
-    // out-of-band, or a legacy pre-hash record) has nothing to verify
-    // against. `load_weights` still loads it (there is no check to
-    // perform), but `load_weights_verified` — the entry point that
-    // promises verification — must refuse rather than silently return
-    // an unverified load.
+    // The verified API must reject records with no checksum.
     let registry = ModelRegistry::in_memory();
     let mut model = RegisteredModel::new("test", "1.0.0");
     model.weights_path = Some("test/1.0.0/weights.bin".to_string());
@@ -567,22 +531,11 @@ mod sqlite_tests {
         assert!(storage.load("../evil/path").is_err());
     }
 
-    // ========================================================================
-    // #1392: Upgrade regression test — models.metadata_json → metadata
-    //
-    // Verifies that an existing DB whose `models` table was created with the
-    // OLD `metadata_json` column name is transparently upgraded on open, so
-    // that rows inserted under the old name are readable via the new column.
-    // Also verifies idempotency (reopening an already-migrated DB succeeds).
-    // ========================================================================
-
     #[test]
     fn upgrade_from_old_schema_renames_models_metadata_json_to_metadata() {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("old_schema.db");
 
-        // Phase 1: Manually create a DB with the OLD column name `metadata_json`.
-        // This simulates a production DB created before the column was renamed.
         {
             let conn = rusqlite::Connection::open(&db_path).unwrap();
             conn.execute_batch(
@@ -622,17 +575,11 @@ mod sqlite_tests {
             .unwrap();
         }
 
-        // Phase 2: Open the DB via SqliteStorage::new() — this must trigger the
-        // migrate_models_metadata_json_to_metadata() migration transparently.
         let _storage = SqliteStorage::new(&db_path).unwrap();
 
-        // Phase 3: Verify via a separate raw connection that the column was renamed
-        // and data survived.  SqliteStorage wraps the connection privately, so we
-        // open a second connection directly for introspection.
         {
             let verify_conn = rusqlite::Connection::open(&db_path).unwrap();
 
-            // New column must be present and hold the original data.
             let metadata: String = verify_conn
                 .query_row(
                     "SELECT metadata FROM models WHERE id = 'test-id-001'",
@@ -645,7 +592,6 @@ mod sqlite_tests {
                 "metadata content must survive upgrade, got: {metadata}"
             );
 
-            // Old column must no longer exist.
             let old_col_result = verify_conn.query_row(
                 "SELECT metadata_json FROM models WHERE id = 'test-id-001'",
                 [],
@@ -657,32 +603,15 @@ mod sqlite_tests {
             );
         }
 
-        // Phase 4: Idempotency — reopening the already-migrated DB must succeed.
-        // SqliteStorage::new() will call migrate_models_metadata_json_to_metadata()
-        // again, which must be a no-op (not an error).
         let _storage2 =
             SqliteStorage::new(&db_path).expect("reopening already-migrated DB must not fail");
     }
-
-    // ========================================================================
-    // #1389: Upgrade regression test — models.registered_at / updated_at
-    //        TEXT (RFC 3339) → INTEGER (epoch microseconds)
-    //
-    // Verifies that an existing DB whose `models` table was created with the
-    // OLD TEXT column types for timestamps is transparently upgraded on open,
-    // so rows inserted under the old schema remain accessible and the column
-    // types are corrected.  Also verifies idempotency (reopening an already-
-    // migrated DB succeeds without error).
-    // ========================================================================
 
     #[test]
     fn upgrade_from_old_schema_converts_timestamps_text_to_integer() {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("old_timestamps.db");
 
-        // Phase 1: Manually create a DB with the OLD TEXT timestamp columns.
-        // This simulates a production DB created before the column types were
-        // corrected.
         {
             let conn = rusqlite::Connection::open(&db_path).unwrap();
             conn.execute_batch(
@@ -705,7 +634,6 @@ mod sqlite_tests {
             )
             .unwrap();
 
-            // Insert a row with RFC 3339 TEXT timestamps (old format).
             conn.execute(
                 "INSERT INTO models
                  (id, name, version, status, metadata, registered_at, updated_at)
@@ -723,14 +651,8 @@ mod sqlite_tests {
             .unwrap();
         }
 
-        // Phase 2: Open the DB via SqliteStorage::new() — this must trigger the
-        // migrate_models_timestamps_text_to_integer() migration transparently.
         let _storage = SqliteStorage::new(&db_path).unwrap();
 
-        // Phase 3: Verify via a raw connection that:
-        //   a) The row is still present.
-        //   b) registered_at and updated_at are now INTEGER (epoch microseconds).
-        //   c) The values are in the correct ballpark (non-zero, positive).
         {
             let verify_conn = rusqlite::Connection::open(&db_path).unwrap();
 
@@ -742,21 +664,16 @@ mod sqlite_tests {
                 )
                 .expect("row must be readable after timestamp migration");
 
-            // 2024-01-15T10:30:00Z in epoch seconds is 1705314600.
-            // In epoch microseconds: 1705314600 * 1_000_000 = 1_705_314_600_000_000.
             assert_eq!(
                 reg_at, 1_705_314_600_000_000_i64,
                 "registered_at must be epoch microseconds, got: {reg_at}"
             );
 
-            // 2024-01-16T08:00:00Z in epoch seconds is 1705392000.
-            // In epoch microseconds: 1705392000 * 1_000_000 = 1_705_392_000_000_000.
             assert_eq!(
                 upd_at, 1_705_392_000_000_000_i64,
                 "updated_at must be epoch microseconds, got: {upd_at}"
             );
 
-            // Verify declared column type is now INTEGER via PRAGMA table_info.
             let col_types: Vec<(String, String)> = verify_conn
                 .prepare("PRAGMA table_info(models)")
                 .unwrap()
@@ -776,13 +693,9 @@ mod sqlite_tests {
             }
         }
 
-        // Phase 4: Idempotency — reopening the already-migrated DB must succeed
-        // without error.  The migration inspects column type and exits early
-        // when it sees INTEGER.
         let _storage2 =
             SqliteStorage::new(&db_path).expect("reopening already-migrated DB must not fail");
 
-        // Phase 5: Writing a new model after migration must succeed (INTEGER path).
         {
             let mut storage3 = SqliteStorage::new(&db_path).unwrap();
             let model = RegisteredModel::new("post_migration_model", "2.0.0");
@@ -794,15 +707,12 @@ mod sqlite_tests {
 
     #[test]
     fn upgrade_timestamps_handles_mixed_integer_rows_safely() {
-        // Verifies the per-row typeof() guard: a DB can have some rows already
-        // storing INTEGER values (if partially migrated or written by new code
-        // before migration ran) alongside TEXT rows without corruption.
+        // A mixed old/new timestamp column must preserve integer rows.
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("mixed_timestamps.db");
 
         {
             let conn = rusqlite::Connection::open(&db_path).unwrap();
-            // Create table with TEXT column type (old schema).
             conn.execute_batch(
                 "CREATE TABLE models (
                     id TEXT PRIMARY KEY,
@@ -823,7 +733,6 @@ mod sqlite_tests {
             )
             .unwrap();
 
-            // Row A: TEXT RFC 3339 timestamps.
             conn.execute(
                 "INSERT INTO models
                  (id, name, version, status, metadata, registered_at, updated_at)
@@ -833,8 +742,6 @@ mod sqlite_tests {
             )
             .unwrap();
 
-            // Row B: INTEGER timestamps stored despite TEXT column type
-            // (SQLite dynamic typing permits this).
             conn.execute(
                 "INSERT INTO models
                  (id, name, version, status, metadata, registered_at, updated_at)
@@ -845,14 +752,11 @@ mod sqlite_tests {
             .unwrap();
         }
 
-        // Open via SqliteStorage — migration must handle both rows safely.
         let _storage = SqliteStorage::new(&db_path).unwrap();
 
         {
             let verify_conn = rusqlite::Connection::open(&db_path).unwrap();
 
-            // Row A was TEXT: expect epoch-micro conversion.
-            // 2024-03-01T00:00:00Z = 1709251200 seconds → 1_709_251_200_000_000 µs.
             let (ra_reg, ra_upd): (i64, i64) = verify_conn
                 .query_row(
                     "SELECT registered_at, updated_at FROM models WHERE id = 'row-a'",
@@ -863,7 +767,6 @@ mod sqlite_tests {
             assert_eq!(ra_reg, 1_709_251_200_000_000_i64, "row-a registered_at");
             assert_eq!(ra_upd, 1_709_251_200_000_000_i64, "row-a updated_at");
 
-            // Row B was already INTEGER: must pass through unchanged.
             let (rb_reg, rb_upd): (i64, i64) = verify_conn
                 .query_row(
                     "SELECT registered_at, updated_at FROM models WHERE id = 'row-b'",


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

Implements Ocean's 2026-07-10 comment-hygiene directive for `crates/tune/src` only. Comment/doc-only, zero behavior change.

## Counts

- Comment/doc lines: 2,783 → 2,393 (390 fewer)
- Inline comment lines: 919 → 563 (356 fewer)
- Doc-comment lines: 1,864 → 1,830 (34 fewer)

## Sweep

- Deleted next-line narration, numbered test steps, section dividers, and redundant arithmetic walkthroughs.
- Condensed retained constraints for deterministic shuffling, allocation bounds, checksum/canonical-record integrity, path confinement, revision compatibility, and SQLite migration safety.
- Retained public-item contracts and load-bearing invariants; simplified public docs where they repeated the code.
- No new extraction was needed: the existing `crates/tune/docs/` guides (`data.md`, `distill.md`, `lora-core.md`, `lora-io.md`, and `registry.md`) already contain the relevant long-form background.

## New crate docs

None; existing topic guides remained the canonical home for long-form rationale.

## ADR candidates

None. The retained rationale is implementation-level or already covered by the existing crate guides and accepted ADRs.

## Validation

All three required gates are green:

- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p lattice-tune`
- `cargo clippy -p lattice-tune --all-targets -- -D warnings`
- `cargo test -p lattice-tune` (241 tests passed)
