### PR TITLE
docs(embed): condense inline comments, extract background to crate docs

### DIFF
--- a/crates/embed/src/backfill/coordinator.rs
+++ b/crates/embed/src/backfill/coordinator.rs
@@ -122,7 +122,6 @@ impl BackfillCoordinator {
         self.backfilled_count += count;
         self.controller.record_progress(count)?;
 
-        // Track cutover time when transitioning to Completed
         if was_in_progress && matches!(self.controller.state(), MigrationState::Completed { .. }) {
             self.cutover_at = Some(Instant::now());
         }
@@ -226,7 +225,6 @@ impl BackfillCoordinator {
                 }
             }
             MigrationState::Completed { .. } => {
-                // During rollback window, still dual-write
                 if self.in_rollback_window() {
                     EmbeddingRoutingConfig {
                         query_model: self.target_model(), // query new
@@ -243,7 +241,6 @@ impl BackfillCoordinator {
                     }
                 }
             }
-            // Paused, Failed, Cancelled: fall back to source-only
             _ => EmbeddingRoutingConfig {
                 query_model: self.source_model(),
                 write_models: vec![self.source_model()],

--- a/crates/embed/src/backfill/tests.rs
+++ b/crates/embed/src/backfill/tests.rs
@@ -46,7 +46,6 @@ fn test_route_request_no_dual_write_when_disabled() {
     };
     let mut coord = BackfillCoordinator::new(test_plan(), config);
     coord.start().unwrap();
-    // Even new docs go to Legacy when dual_write is disabled
     assert_eq!(coord.route_request(true), EmbeddingRoute::Legacy);
 }
 
@@ -135,7 +134,6 @@ fn test_record_batch_updates_progress() {
 fn test_next_batch_size_normal() {
     let mut coord = BackfillCoordinator::with_defaults(test_plan());
     coord.start().unwrap();
-    // 1000 remaining, batch_size = 100 -> next = 100
     assert_eq!(coord.next_batch_size(), 100);
 }
 
@@ -144,7 +142,6 @@ fn test_next_batch_size_less_than_batch() {
     let mut coord = BackfillCoordinator::with_defaults(test_plan());
     coord.start().unwrap();
     coord.record_batch(950).unwrap();
-    // 50 remaining < batch_size 100 -> next = 50
     assert_eq!(coord.next_batch_size(), 50);
 }
 
@@ -166,35 +163,29 @@ fn test_next_batch_size_zero_after_completion() {
 fn test_full_lifecycle() {
     let mut coord = BackfillCoordinator::with_defaults(test_plan());
 
-    // Phase 1: Before start
     assert_eq!(*coord.state(), MigrationState::Planned);
     assert_eq!(coord.route_request(true), EmbeddingRoute::Legacy);
     assert_eq!(coord.route_query(), EmbeddingRoute::Legacy);
     assert_eq!(coord.next_batch_size(), 0);
 
-    // Phase 2: Start migration
     coord.start().unwrap();
     assert!(coord.state().is_active());
     assert_eq!(coord.route_request(true), EmbeddingRoute::DualWrite);
     assert_eq!(coord.route_query(), EmbeddingRoute::Legacy);
     assert_eq!(coord.next_batch_size(), 100);
 
-    // Phase 3: Process some batches
     coord.record_batch(100).unwrap();
     coord.record_batch(100).unwrap();
     coord.record_batch(100).unwrap();
     assert_eq!(coord.backfilled_count(), 300);
     assert_eq!(coord.state().processed(), 300);
-    // 30% < 80% threshold -> still legacy for queries
     assert_eq!(coord.route_query(), EmbeddingRoute::Legacy);
 
-    // Phase 4: Cross threshold
     coord.record_batch(500).unwrap(); // 800/1000 = 80%
     assert_eq!(coord.route_query(), EmbeddingRoute::Target);
     assert_eq!(coord.route_request(true), EmbeddingRoute::DualWrite);
     assert_eq!(coord.next_batch_size(), 100); // 200 remaining
 
-    // Phase 5: Complete
     coord.record_batch(200).unwrap();
     assert!(coord.state().is_terminal());
     assert_eq!(coord.route_request(true), EmbeddingRoute::Target);
@@ -210,13 +201,11 @@ fn test_pause_and_resume_lifecycle() {
     coord.start().unwrap();
     coord.record_batch(500).unwrap();
 
-    // Pause
     coord.pause("resource contention").unwrap();
     assert_eq!(coord.route_request(true), EmbeddingRoute::Legacy);
     assert_eq!(coord.route_query(), EmbeddingRoute::Legacy);
     assert_eq!(coord.next_batch_size(), 0);
 
-    // Resume
     coord.resume().unwrap();
     assert!(coord.state().is_active());
     assert_eq!(coord.route_request(true), EmbeddingRoute::DualWrite);
@@ -294,21 +283,17 @@ fn test_zero_total_embeddings() {
     };
     let mut coord = BackfillCoordinator::with_defaults(plan);
     coord.start().unwrap();
-    // total=0 with 0 processed: progress = 1.0 (vacuously complete)
-    // So query routing should go to Target
     assert_eq!(coord.route_query(), EmbeddingRoute::Target);
 }
 
 #[test]
 fn test_embedding_route_traits() {
-    // Verify Copy, Clone, Debug, PartialEq, Eq, Hash
     let route = EmbeddingRoute::DualWrite;
     let route2 = route; // Copy
     let route3 = route.clone(); // Clone
     assert_eq!(route2, route3); // PartialEq + Eq
     assert_eq!(format!("{route:?}"), "DualWrite"); // Debug
 
-    // Hash
     use std::collections::HashSet;
     let mut set = HashSet::new();
     set.insert(EmbeddingRoute::Legacy);
@@ -316,8 +301,6 @@ fn test_embedding_route_traits() {
     set.insert(EmbeddingRoute::DualWrite);
     assert_eq!(set.len(), 3);
 }
-
-// ========== Routing Configuration Tests ==========
 
 #[test]
 fn test_routing_phase_serialization() {
@@ -351,7 +334,6 @@ fn test_routing_config_during_migration() {
     coord.start().unwrap();
     let config = coord.routing_config();
 
-    // During migration: query legacy, dual-write
     assert_eq!(config.query_model, EmbeddingModel::BgeSmallEnV15);
     assert_eq!(
         config.write_models,
@@ -371,14 +353,12 @@ fn test_routing_config_during_migration_no_dual_write() {
     coord.start().unwrap();
     let routing = coord.routing_config();
 
-    // With dual_write disabled, only source model in write_models
     assert_eq!(routing.write_models, vec![EmbeddingModel::BgeSmallEnV15]);
     assert_eq!(routing.phase, RoutingPhase::Migrating);
 }
 
 #[test]
 fn test_routing_config_after_completion_in_rollback_window() {
-    // Use a very long rollback window so we're definitely still in it
     let config = BackfillConfig {
         rollback_window_secs: 86400 * 365, // 1 year
         ..BackfillConfig::default()
@@ -389,9 +369,6 @@ fn test_routing_config_after_completion_in_rollback_window() {
 
     let routing = coord.routing_config();
 
-    // After cutover but in rollback window:
-    // - Query the new model
-    // - Still dual-write for safe rollback
     assert_eq!(routing.query_model, EmbeddingModel::BgeBaseEnV15);
     assert_eq!(
         routing.write_models,
@@ -403,7 +380,6 @@ fn test_routing_config_after_completion_in_rollback_window() {
 
 #[test]
 fn test_routing_config_after_rollback_window_expires() {
-    // Use a zero rollback window so it expires immediately
     let config = BackfillConfig {
         rollback_window_secs: 0,
         ..BackfillConfig::default()
@@ -412,7 +388,6 @@ fn test_routing_config_after_rollback_window_expires() {
     coord.start().unwrap();
     coord.record_batch(1000).unwrap();
 
-    // Window is 0 seconds, so it's already expired
     let routing = coord.routing_config();
 
     assert_eq!(routing.query_model, EmbeddingModel::BgeBaseEnV15);
@@ -429,7 +404,6 @@ fn test_routing_config_when_paused() {
 
     let routing = coord.routing_config();
 
-    // When paused, fall back to stable source-only
     assert_eq!(routing.query_model, EmbeddingModel::BgeSmallEnV15);
     assert_eq!(routing.write_models, vec![EmbeddingModel::BgeSmallEnV15]);
     assert_eq!(routing.phase, RoutingPhase::Stable);
@@ -443,7 +417,6 @@ fn test_routing_config_when_cancelled() {
 
     let routing = coord.routing_config();
 
-    // When cancelled, fall back to stable source-only
     assert_eq!(routing.query_model, EmbeddingModel::BgeSmallEnV15);
     assert_eq!(routing.write_models, vec![EmbeddingModel::BgeSmallEnV15]);
     assert_eq!(routing.phase, RoutingPhase::Stable);
@@ -469,7 +442,6 @@ fn test_in_rollback_window_true_immediately_after_cutover() {
     coord.start().unwrap();
     coord.record_batch(1000).unwrap(); // completes migration
 
-    // Immediately after cutover, should be in rollback window
     assert!(coord.in_rollback_window());
 }
 
@@ -483,7 +455,6 @@ fn test_in_rollback_window_false_after_window_expires() {
     coord.start().unwrap();
     coord.record_batch(1000).unwrap();
 
-    // Window is 0 seconds, so it should already be expired
     assert!(!coord.in_rollback_window());
 }
 
@@ -491,16 +462,13 @@ fn test_in_rollback_window_false_after_window_expires() {
 fn test_cutover_at_set_on_completion() {
     let mut coord = BackfillCoordinator::with_defaults(test_plan());
 
-    // Before starting, cutover_at should be None
     assert!(coord.cutover_at.is_none());
 
     coord.start().unwrap();
     coord.record_batch(500).unwrap();
-    // Still in progress, cutover_at should be None
     assert!(coord.cutover_at.is_none());
 
     coord.record_batch(500).unwrap(); // completes
-    // After completion, cutover_at should be set
     assert!(coord.cutover_at.is_some());
 }
 
@@ -524,27 +492,23 @@ fn test_embedding_routing_config_serialization() {
 
 #[test]
 fn test_routing_config_lifecycle_full() {
-    // Test the full routing config lifecycle through all phases
     let config = BackfillConfig {
         rollback_window_secs: 86400 * 365, // Long window for testing
         ..BackfillConfig::default()
     };
     let mut coord = BackfillCoordinator::new(test_plan(), config);
 
-    // Phase 1: Planned -> Stable, source only
     let routing = coord.routing_config();
     assert_eq!(routing.phase, RoutingPhase::Stable);
     assert_eq!(routing.write_models.len(), 1);
     assert!(routing.migration_id.is_none());
 
-    // Phase 2: InProgress -> Migrating, dual write
     coord.start().unwrap();
     let routing = coord.routing_config();
     assert_eq!(routing.phase, RoutingPhase::Migrating);
     assert_eq!(routing.write_models.len(), 2);
     assert!(routing.migration_id.is_some());
 
-    // Phase 3: Completed -> RollbackWindow, query new, dual write
     coord.record_batch(1000).unwrap();
     let routing = coord.routing_config();
     assert_eq!(routing.phase, RoutingPhase::RollbackWindow);
@@ -570,7 +534,6 @@ fn test_next_batch_size_accounts_for_skipped() {
     let mut coord = BackfillCoordinator::new(plan, config);
     coord.start().unwrap();
 
-    // Skip 3 items; processed = 0.
     for _ in 0..3 {
         coord
             .controller
@@ -578,10 +541,8 @@ fn test_next_batch_size_accounts_for_skipped() {
             .unwrap();
     }
 
-    // Effective remaining = 10 - 0 - 3 = 7; batch_size = 50 -> 7.
     assert_eq!(coord.next_batch_size(), 7);
 
-    // Process the remaining 7 effective items; migration should complete.
     coord.record_batch(7).unwrap();
     assert!(
         coord.state().is_terminal(),
@@ -589,6 +550,5 @@ fn test_next_batch_size_accounts_for_skipped() {
         coord.state()
     );
 
-    // After completion, next_batch_size must be 0.
     assert_eq!(coord.next_batch_size(), 0);
 }

--- a/crates/embed/src/bin/embed.rs
+++ b/crates/embed/src/bin/embed.rs
@@ -113,8 +113,6 @@ options:
 
         let service = NativeEmbeddingService::with_model(model);
 
-        // --download-only: ensure the model is present (downloading + checksum-verifying if
-        // needed) and loadable, then exit without running any encode pass.
         if download_only {
             match service.ensure_loaded().await {
                 Ok(()) => {
@@ -163,7 +161,6 @@ options:
         let dims = embeddings[0].len();
         let count = embeddings.len();
 
-        // Build NxN pairwise cosine matrix.
         let mut cosine: Vec<Vec<f32>> = Vec::with_capacity(count);
         for i in 0..count {
             let mut row = Vec::with_capacity(count);
@@ -174,7 +171,6 @@ options:
             cosine.push(row);
         }
 
-        // Build preview: first 8 dims of each vector.
         let preview_len = dims.min(8);
         let preview: Vec<Vec<f32>> = embeddings
             .iter()
@@ -214,8 +210,6 @@ fn main() -> std::process::ExitCode {
     cli::main()
 }
 
-// wasm32 has no terminal environment for this CLI to run in (see module doc
-// comment above); the crate's wasm-facing surface is the `wasm` feature's
-// wasm-bindgen bindings instead. This no-op keeps the bin target linkable.
+// `wasm32` still builds this target, but cannot run the native CLI.
 #[cfg(target_arch = "wasm32")]
 fn main() {}

--- a/crates/embed/src/cache.rs
+++ b/crates/embed/src/cache.rs
@@ -31,7 +31,7 @@ const NUM_SHARDS: usize = 16;
 /// Mask for shard index computation: `key[0] as usize & SHARD_MASK`.
 const SHARD_MASK: usize = NUM_SHARDS - 1;
 
-// Compile-time assertion that NUM_SHARDS is a power of 2.
+// Masking shard selection requires a power-of-two count.
 const _: () = assert!(
     NUM_SHARDS.is_power_of_two(),
     "NUM_SHARDS must be a power of 2"
@@ -153,7 +153,6 @@ impl EmbeddingCache {
     ) -> CacheKey {
         let mut hasher = blake3::Hasher::new();
         hasher.update(text.as_bytes());
-        // Deterministic model/role namespace for this cache key.
         let model_key = format!(
             "{}:{}:{}:{}",
             model_config.model,
@@ -370,28 +369,19 @@ mod tests {
             EmbeddingRole::Generic,
         );
 
-        // Miss
         assert!(cache.get(&key).is_none());
 
-        // Put
         let embedding = vec![0.1, 0.2, 0.3];
         cache.put(key, embedding.clone());
 
-        // Hit — returns Arc<[f32]>
         let cached = cache.get(&key).unwrap();
         assert_eq!(&*cached, &embedding[..]);
     }
 
     #[test]
     fn test_cache_eviction() {
-        // With 16 shards, a capacity of 16 gives 1 entry per shard.
-        // To test eviction, we need keys that hash to the same shard.
-        // Use a larger capacity and fill it up.
         let cache = EmbeddingCache::new(16);
 
-        // Insert 32 entries — each shard has capacity 1, so each shard
-        // can only hold 1 entry. Inserting 2 entries to the same shard
-        // will evict the first.
         let mut keys = Vec::new();
         for i in 0..32u32 {
             let text = format!("text_{i}");
@@ -404,21 +394,17 @@ mod tests {
             cache.put(key, vec![i as f32]);
         }
 
-        // Total size should not exceed capacity (16)
         let stats = cache.stats();
         assert!(stats.size <= 16, "size {} exceeds capacity 16", stats.size);
     }
 
     #[test]
     fn test_cache_lru_eviction_within_shard() {
-        // Create cache with capacity 32 (2 per shard).
         let cache = EmbeddingCache::new(32);
 
-        // Find 3 keys that land in the same shard.
         let mut same_shard_keys = Vec::new();
         let mut i = 0u32;
 
-        // Find the first key's shard and collect 3 keys for it.
         let first_key = cache.compute_key(
             "probe_0",
             ModelConfig::new(EmbeddingModel::BgeSmallEnV15),
@@ -445,14 +431,11 @@ mod tests {
         let (k2, v2) = same_shard_keys[1];
         let (k3, v3) = same_shard_keys[2];
 
-        // Insert k1 and k2 (shard capacity is 2).
         cache.put(k1, vec![v1 as f32]);
         cache.put(k2, vec![v2 as f32]);
 
-        // Access k1 to make it recently used.
         assert!(cache.get(&k1).is_some());
 
-        // Insert k3 — should evict k2 (least recently used in this shard).
         cache.put(k3, vec![v3 as f32]);
 
         assert!(
@@ -478,7 +461,6 @@ mod tests {
             EmbeddingRole::Generic,
         );
 
-        // Same text, different models = different keys
         assert_ne!(key_small, key_base);
     }
 
@@ -504,7 +486,6 @@ mod tests {
 
     #[test]
     fn test_cache_get_many() {
-        // Use capacity large enough that no shard evicts.
         let cache = EmbeddingCache::new(100);
 
         let key1 = cache.compute_key(
@@ -535,7 +516,6 @@ mod tests {
 
     #[test]
     fn test_cache_put_many() {
-        // Use capacity large enough that no shard evicts (ceil(100/16) = 7 per shard).
         let cache = EmbeddingCache::new(100);
 
         let key1 = cache.compute_key(
@@ -602,17 +582,13 @@ mod tests {
     fn test_concurrent_access() {
         use std::thread;
 
-        // Use large capacity so no eviction occurs (800 entries across 16 shards).
-        // Per-shard capacity = ceil(4000/16) = 250, so 800 entries fit easily.
         let cache = Arc::new(EmbeddingCache::new(4000));
         let mut handles = Vec::new();
 
-        // Spawn 8 threads, each doing 100 put+get operations.
         for t in 0..8 {
             let cache = Arc::clone(&cache);
             handles.push(thread::spawn(move || {
                 for i in 0..100 {
-                    // Each thread uses unique keys to avoid contention on same entry.
                     let text = format!("thread_{t}_item_{i}");
                     let key = cache.compute_key(
                         &text,
@@ -633,7 +609,6 @@ mod tests {
             h.join().expect("thread panicked");
         }
 
-        // All 800 entries should be in cache (capacity 4000 >> 800).
         let stats = cache.stats();
         assert_eq!(stats.size, 800);
         assert!(stats.hits >= 800, "at least 800 hits expected");
@@ -641,8 +616,6 @@ mod tests {
 
     #[test]
     fn test_shard_distribution() {
-        // Use generous capacity to avoid eviction from uneven distribution.
-        // 4000 total → 250/shard. We insert 800 entries → ~50/shard on average.
         let cache = EmbeddingCache::new(4000);
 
         let n = 800;
@@ -658,7 +631,6 @@ mod tests {
         let shard_stats = cache.per_shard_stats();
         assert_eq!(shard_stats.len(), NUM_SHARDS);
 
-        // Each shard should have entries. With uniform hash, each shard gets ~50.
         for ss in &shard_stats {
             assert!(
                 ss.size > 0,
@@ -667,11 +639,9 @@ mod tests {
             );
         }
 
-        // No eviction since 800 << 4000. Total should be exactly 800.
         let total: usize = shard_stats.iter().map(|s| s.size).sum();
         assert_eq!(total, n);
 
-        // Check distribution is reasonably uniform: no shard has >3x the average.
         let avg = n / NUM_SHARDS; // 50
         for ss in &shard_stats {
             assert!(
@@ -688,7 +658,6 @@ mod tests {
     fn test_per_shard_stats_hit_tracking() {
         let cache = EmbeddingCache::new(100);
 
-        // Insert a few entries and access them.
         let key1 = cache.compute_key(
             "hello",
             ModelConfig::new(EmbeddingModel::BgeSmallEnV15),
@@ -703,7 +672,6 @@ mod tests {
         cache.put(key1, vec![1.0]);
         cache.put(key2, vec![2.0]);
 
-        // Access key1 three times, key2 once.
         cache.get(&key1);
         cache.get(&key1);
         cache.get(&key1);
@@ -720,7 +688,6 @@ mod tests {
 
     #[test]
     fn test_small_capacity_rounds_up() {
-        // Capacity smaller than NUM_SHARDS: each shard gets at least 1.
         let cache = EmbeddingCache::new(3);
         assert!(cache.is_enabled());
 
@@ -732,10 +699,6 @@ mod tests {
         cache.put(key, vec![42.0]);
         assert!(cache.get(&key).is_some());
     }
-
-    // -------------------------------------------------------------------------
-    // Role-aware cache key tests (P0-E2)
-    // -------------------------------------------------------------------------
 
     /// Query and passage roles must produce different cache keys for the same raw text
     /// so that embed_query("hello") and embed_passage("hello") are stored separately.
@@ -774,16 +737,13 @@ mod tests {
         let key_query = cache.compute_key("embed me", model, EmbeddingRole::Query);
         let key_passage = cache.compute_key("embed me", model, EmbeddingRole::Passage);
 
-        // Store under Query role.
         cache.put(key_query, vec![1.0, 2.0]);
 
-        // Passage role key must still be a miss.
         assert!(
             cache.get(&key_passage).is_none(),
             "passage key must miss after storing under query key"
         );
 
-        // Query role key must hit.
         assert!(
             cache.get(&key_query).is_some(),
             "query key must hit after storing under query key"

--- a/crates/embed/src/migration/controller.rs
+++ b/crates/embed/src/migration/controller.rs
@@ -105,7 +105,6 @@ impl MigrationController {
                 total,
                 skipped,
             } => {
-                // Accept skips only while their combined work count is strictly below total.
                 if *processed + *skipped >= *total {
                     return Err(MigrationError::InvalidTransition {
                         from: format!("{:?}", self.state),

--- a/crates/embed/src/migration/tests.rs
+++ b/crates/embed/src/migration/tests.rs
@@ -128,19 +128,14 @@ fn test_cancel_from_failed() {
 fn test_invalid_transitions() {
     let mut ctrl = MigrationController::new(test_plan());
 
-    // Cannot pause before starting
     assert!(ctrl.pause("oops").is_err());
-    // Cannot record progress before starting
     assert!(ctrl.record_progress(10).is_err());
-    // Cannot resume from Planned
     assert!(ctrl.resume().is_err());
 
     ctrl.start().unwrap();
     ctrl.record_progress(1000).unwrap(); // auto-completes
 
-    // Cannot cancel a completed migration
     assert!(ctrl.cancel().is_err());
-    // Cannot start a completed migration
     assert!(ctrl.start().is_err());
 }
 
@@ -216,9 +211,7 @@ fn test_zero_total_progress() {
     };
     let mut ctrl = MigrationController::new(plan);
     ctrl.start().unwrap();
-    // total=0, so any progress completes
     assert!(ctrl.state().is_active());
-    // Verify progress shows 1.0 for zero-total when in-progress
     let state = &MigrationState::InProgress {
         processed: 0,
         total: 0,
@@ -314,8 +307,6 @@ fn test_full_lifecycle() {
     assert_eq!(report.error_count, 1);
     assert_eq!(report.migration_id, "test-migration-001");
 }
-
-// ==================== Skip Handling Tests ====================
 
 #[test]
 fn test_skip_reason_display() {
@@ -520,7 +511,6 @@ fn test_lifecycle_with_skips() {
     ctrl.resume().unwrap();
 
     ctrl.record_progress(496).unwrap();
-    // 996 < 998 (effective_total = 1000 - 2 = 998), not complete yet
     assert!(!ctrl.state().is_terminal());
 
     ctrl.record_progress(2).unwrap();
@@ -541,12 +531,10 @@ fn test_record_skip_rejects_exceeding_total() {
     let mut ctrl = MigrationController::new(plan);
     ctrl.start().unwrap();
 
-    // First two skips exhaust the budget (processed=0, so 0+0<2, 0+1<2).
     assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_ok());
     assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_ok());
     assert_eq!(ctrl.state().skipped(), 2);
 
-    // Third skip must be rejected (0+2 >= 2); skipped count must not change.
     assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_err());
     assert_eq!(ctrl.state().skipped(), 2);
 }
@@ -564,11 +552,9 @@ fn test_all_skipped_still_completes() {
     let mut ctrl = MigrationController::new(plan);
     ctrl.start().unwrap();
 
-    // Skipping all items is legitimate: effective_total becomes 0.
     assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_ok());
     assert!(ctrl.record_skip(SkipReason::ContentDeleted).is_ok());
 
-    // record_progress(0) should complete because effective_total == 0.
     ctrl.record_progress(0).unwrap();
 
     assert!(

--- a/crates/embed/src/migration/types.rs
+++ b/crates/embed/src/migration/types.rs
@@ -51,7 +51,7 @@ impl std::fmt::Display for SkipReason {
 #[non_exhaustive]
 pub enum MigrationState {
     /// Migration is planned but has not started.
-    // FP-036: alias allows deserializing data stored before rename_all = "snake_case" was applied.
+    // Accept the pre-snake-case serialized form.
     #[serde(alias = "Planned")]
     Planned,
     /// Migration is actively processing embeddings.

--- a/crates/embed/src/model.rs
+++ b/crates/embed/src/model.rs
@@ -36,7 +36,6 @@ impl ModelProvenance {
             dt.to_rfc3339()
         };
 
-        // Create a lightweight hash from model metadata
         let hash_input = format!("{model_id}:{loaded_at_iso}:{model:?}");
         let hash = blake3::hash(hash_input.as_bytes()).to_hex().to_string();
 
@@ -174,7 +173,6 @@ impl EmbeddingModel {
             EmbeddingModel::MultilingualE5Base => 512,
             EmbeddingModel::AllMiniLmL6V2 => 256,
             EmbeddingModel::ParaphraseMultilingualMiniLmL12V2 => 128,
-            // Conservative cap; see docs/model.md.
             EmbeddingModel::Qwen3Embedding0_6B => 8192,
             EmbeddingModel::Qwen3Embedding4B => 8192,
             EmbeddingModel::TextEmbedding3Small => 8191,
@@ -351,10 +349,6 @@ impl std::str::FromStr for EmbeddingModel {
     }
 }
 
-// ============================================================================
-// ModelConfig — runtime MRL dimension configuration
-// ============================================================================
-
 /// Minimum allowed MRL output dimension.
 pub const MIN_MRL_OUTPUT_DIM: usize = 32;
 
@@ -458,7 +452,6 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(10)); // Ensure different timestamp
         let p2 = ModelProvenance::new(EmbeddingModel::BgeSmallEnV15, "model1".into());
 
-        // Different timestamps should produce different hashes
         assert_ne!(p1.hash, p2.hash);
     }
 
@@ -488,8 +481,7 @@ mod tests {
         let provenance = ModelProvenance::new(EmbeddingModel::BgeSmallEnV15, "test-model".into());
 
         let json = serde_json::to_string(&provenance).unwrap();
-        // FP-037: EmbeddingModel has #[serde(rename_all = "snake_case")] so
-        // BgeSmallEnV15 serializes as "bge_small_en_v15", not "BgeSmallEnV15".
+        // The enum's snake-case serde form is part of the persisted format.
         assert!(json.contains("bge_small_en_v15"), "json={json}");
         assert!(json.contains("test-model"));
         assert!(json.contains(&provenance.hash));
@@ -638,10 +630,6 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("unknown embedding model"));
     }
-
-    // -------------------------------------------------------------------------
-    // bert_pooling() routing tests (P1-E3) — require `native` feature
-    // -------------------------------------------------------------------------
 
     /// BGE small/base/large must use CLS pooling per their HF model cards.
     #[cfg(feature = "native")]

--- a/crates/embed/src/service/cached.rs
+++ b/crates/embed/src/service/cached.rs
@@ -57,7 +57,6 @@ impl<S: EmbeddingService> CachedEmbeddingService<S> {
 #[async_trait]
 impl<S: EmbeddingService + 'static> EmbeddingService for CachedEmbeddingService<S> {
     async fn embed(&self, texts: &[String], model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
-        // Generic has its own role tag — see docs/service.md.
         self.embed_with_role(texts, model, EmbeddingRole::Generic)
             .await
     }
@@ -104,7 +103,6 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
     ) -> Result<Vec<Vec<f32>>> {
         use crate::error::EmbedError;
 
-        // Validate wrapper-owned request bounds before cache interaction.
         if texts.is_empty() {
             return Err(EmbedError::InvalidInput("no texts provided".into()));
         }
@@ -124,22 +122,18 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
             }
         }
 
-        // Fast path: bypass cache entirely when disabled (no key computation, no locking)
         if !self.cache.is_enabled() {
             return self.inner.embed(texts, model).await;
         }
 
-        // Compute cache keys — include the active dimension (for MRL models) and role.
         let model_config = self.inner.model_config(model);
         let keys: Vec<_> = texts
             .iter()
             .map(|t| self.cache.compute_key(t, model_config, role))
             .collect();
 
-        // Check cache for all texts — returns Arc<[f32]> refs (O(1) per hit)
         let cached = self.cache.get_many(&keys);
 
-        // Identify which texts need embedding
         let mut to_embed: Vec<(usize, &String)> = Vec::new();
         let mut results: Vec<Option<Vec<f32>>> = vec![None; texts.len()];
 
@@ -151,11 +145,9 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
             }
         }
 
-        // If all cached, return immediately
         if to_embed.is_empty() {
             debug!("all {} texts found in cache", texts.len());
-            // SAFETY: All slots are Some because we only reach here when to_embed is empty,
-            // meaning every text was found in cache and had results[i] = Some(...) assigned.
+            // SAFETY: An empty miss list means every result slot was populated.
             return Ok(results.into_iter().flatten().collect());
         }
 
@@ -165,12 +157,10 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
             to_embed.len()
         );
 
-        // Embed missing texts (after prompt is already applied in texts)
         let texts_to_embed: Vec<String> = to_embed.iter().map(|(_, t)| (*t).clone()).collect();
         let new_embeddings = self.inner.embed(&texts_to_embed, model).await?;
 
-        // FP-035: validate count before zipping — a count mismatch would silently
-        // drop slots via zip() and return fewer embeddings than requested.
+        // Reject count mismatches before `zip` can silently omit results.
         if new_embeddings.len() != to_embed.len() {
             return Err(EmbedError::InferenceFailed(format!(
                 "embedding service returned {} vectors for {} inputs",
@@ -179,7 +169,6 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
             )));
         }
 
-        // Store in cache and populate results
         let mut cache_entries = Vec::with_capacity(to_embed.len());
         for ((i, _), embedding) in to_embed.into_iter().zip(new_embeddings.into_iter()) {
             cache_entries.push((keys[i], embedding.clone()));
@@ -187,15 +176,11 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
         }
         self.cache.put_many(cache_entries);
 
-        // Return all results
-        // SAFETY: All slots are guaranteed to be Some at this point:
-        // - Cached items were assigned via results[i] = Some(arc.to_vec())
-        // - Non-cached items were assigned via results[i] = Some(embedding) in the loop above
+        // SAFETY: Cache hits and validated fresh results populate every slot.
         Ok(results.into_iter().flatten().collect())
     }
 }
 
-// Suppress dead code warnings for constants that are used by other modules
 const _: () = {
     let _ = DEFAULT_MAX_BATCH_SIZE;
     let _ = MAX_TEXT_CHARS;

--- a/crates/embed/src/service/mod.rs
+++ b/crates/embed/src/service/mod.rs
@@ -16,7 +16,6 @@ use crate::error::{EmbedError, Result};
 use crate::model::{EmbeddingModel, ModelConfig};
 use async_trait::async_trait;
 
-// Re-exports
 #[cfg(feature = "native")]
 pub use cached::CachedEmbeddingService;
 #[cfg(feature = "native")]

--- a/crates/embed/src/service/native.rs
+++ b/crates/embed/src/service/native.rs
@@ -17,7 +17,7 @@ enum LoadedModel {
     Qwen(Arc<QwenModel>),
 }
 
-// Wrapped model types provide the required thread-safety — see docs/service.md.
+// Wrapped model types provide the required thread safety.
 
 impl LoadedModel {
     fn encode_batch(&self, texts: &[&str]) -> std::result::Result<Vec<Vec<f32>>, String> {
@@ -152,7 +152,6 @@ impl NativeEmbeddingService {
     ///
     /// See [`docs/service.md`](../../docs/service.md#nativeembeddingservice-implementation-notes) for the cancellation invariant.
     async fn ensure_model(&self) -> Result<&LoadedModel> {
-        // Fast path: already loaded.
         if let Some(result) = self.model.get() {
             return result
                 .as_ref()
@@ -202,8 +201,7 @@ fn load_model_sync(model_config: ModelConfig) -> std::result::Result<LoadedModel
             };
             info!(model = model_name, "loading native BERT embedding model");
             let mut bert = BertModel::from_pretrained(model_name).map_err(|e| e.to_string())?;
-            // Route each model family through its correct pooling strategy.
-            // BGE uses CLS pooling; E5 and MiniLM use mean pooling.
+            // Pooling depends on the model family.
             if let Some(pooling) = model_config.model.bert_pooling() {
                 bert.set_pooling(pooling);
             }
@@ -256,7 +254,6 @@ fn embedding_cache_path(model: &str, dim: usize) -> std::path::PathBuf {
 
 /// Locate Qwen3-Embedding model directory for the given model variant.
 fn qwen_model_dir(model_type: EmbeddingModel) -> Result<std::path::PathBuf> {
-    // Check env override first — applies to whichever Qwen model is loaded.
     if let Ok(dir) = std::env::var("LATTICE_QWEN_MODEL_DIR") {
         return Ok(std::path::PathBuf::from(dir));
     }

--- a/crates/embed/src/service/tests.rs
+++ b/crates/embed/src/service/tests.rs
@@ -23,7 +23,6 @@ mod native_tests {
     fn test_native_service_supports_only_loaded_model() {
         let service = NativeEmbeddingService::default();
         assert!(service.supports_model(EmbeddingModel::BgeSmallEnV15));
-        // All other models must be rejected even if they are local.
         assert!(!service.supports_model(EmbeddingModel::BgeBaseEnV15));
         assert!(!service.supports_model(EmbeddingModel::BgeLargeEnV15));
         assert!(!service.supports_model(EmbeddingModel::MultilingualE5Small));
@@ -59,7 +58,6 @@ mod native_tests {
     #[test]
     fn test_native_service_with_model_config_invalid_dim_rejected() {
         use crate::model::ModelConfig;
-        // BgeSmallEnV15 does not support MRL — output_dim must be rejected at construction.
         let cfg = ModelConfig {
             model: EmbeddingModel::BgeSmallEnV15,
             output_dim: Some(128),
@@ -84,7 +82,7 @@ mod native_tests {
         assert_eq!(returned.dimensions(), 768);
     }
 
-    // Mutex to serialize all tests that read or write LATTICE_EMBED_DIM.
+    // Serializes environment-variable mutation in this test binary.
     static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// LATTICE_EMBED_DIM absent → with_model_from_env returns native dim (2560 for 4B).
@@ -190,7 +188,6 @@ mod native_tests {
     async fn test_native_service_embed_wrong_model_returns_error() {
         let service = NativeEmbeddingService::default(); // loads BgeSmallEnV15
         let texts = vec!["hello".to_string()];
-        // Requesting a different local model should fail before any IO.
         let result = service.embed(&texts, EmbeddingModel::BgeBaseEnV15).await;
         assert!(result.is_err(), "expected error for wrong model");
         let err = result.unwrap_err().to_string();
@@ -200,10 +197,6 @@ mod native_tests {
         );
     }
 }
-
-// ---------------------------------------------------------------------------
-// Role-aware prompt tests (P0-E2)
-// ---------------------------------------------------------------------------
 
 /// E5 query_instruction returns "query: ", document_instruction returns "passage: ".
 #[test]

--- a/crates/embed/src/simd/binary.rs
+++ b/crates/embed/src/simd/binary.rs
@@ -35,7 +35,6 @@ impl BinaryVector {
     pub fn from_f32_with_threshold(vector: &[f32], threshold: f32) -> Self {
         let dims = vector.len();
 
-        // Compute norm
         let mut norm_sq = 0.0f32;
         for &v in vector {
             if v.is_finite() {
@@ -128,10 +127,7 @@ pub fn hamming_distance_binary(a: &BinaryVector, b: &BinaryVector) -> u32 {
     #[cfg(target_arch = "aarch64")]
     {
         if config.neon_enabled {
-            // SAFETY: NEON is available on aarch64. Both slices have been verified above
-            // to contain at least `required_bytes` elements, which is the exact packed
-            // length for `dims` bits. The callee uses unaligned loads and chunk/remainder
-            // bounds strictly within those slices; no out-of-bounds read is possible.
+            // SAFETY: AArch64 guarantees NEON and the checked packed slices cover `dims`.
             return unsafe {
                 hamming_distance_neon(&a.data[..required_bytes], &b.data[..required_bytes], a.dims)
             };
@@ -152,11 +148,9 @@ pub fn hamming_distance_binary(a: &BinaryVector, b: &BinaryVector) -> u32 {
 fn hamming_distance_scalar(a: &[u8], b: &[u8], dims: usize) -> u32 {
     let mut total: u32 = 0;
 
-    // Number of fully-populated 8-byte chunks (all bits valid).
     let full_bytes = dims / 8; // bytes where every bit is a real dimension
     let chunks = full_bytes / 8;
 
-    // Process 8 bytes at a time as u64
     for c in 0..chunks {
         let offset = c * 8;
         let a_u64 = u64::from_ne_bytes([
@@ -182,14 +176,12 @@ fn hamming_distance_scalar(a: &[u8], b: &[u8], dims: usize) -> u32 {
         total += (a_u64 ^ b_u64).count_ones();
     }
 
-    // Handle the remaining full bytes (between the last u64 chunk and the partial byte)
     let remainder_start = chunks * 8;
     for i in remainder_start..full_bytes {
         total += (a[i] ^ b[i]).count_ones();
     }
 
-    // Handle the single partial byte (if dims is not a multiple of 8).
-    // The `r` valid bits occupy the top `r` bits of the byte (MSB = dim 0 within byte).
+    // Partial bytes store valid dimensions in their high bits.
     let r = dims % 8;
     if r != 0 {
         let mask = 0xFFu8 << (8 - r); // top `r` bits set, bottom `(8-r)` clear
@@ -207,7 +199,7 @@ fn hamming_distance_scalar(a: &[u8], b: &[u8], dims: usize) -> u32 {
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn hamming_distance_neon(a: &[u8], b: &[u8], dims: usize) -> u32 {
-    // SA-163/164: verify equal-length backing slices before the SIMD loop.
+    // Validate packed lengths before SIMD loads.
     debug_assert_eq!(
         a.len(),
         b.len(),
@@ -216,14 +208,12 @@ unsafe fn hamming_distance_neon(a: &[u8], b: &[u8], dims: usize) -> u32 {
         b.len()
     );
 
-    // Only full bytes (where every bit is a real dimension) go through the SIMD loop.
+    // Keep the partial byte out of SIMD so padding cannot contribute.
     let full_bytes = dims / 8;
     const SIMD_WIDTH: usize = 16;
     let chunks = full_bytes / SIMD_WIDTH;
 
-    // Accumulate popcount bytes into u16 to avoid overflow
-    // (max 8 bits per byte, 16 bytes per register = 128 per chunk, fits u8 for ~1 chunk)
-    // Use vpaddlq to widen: u8 -> u16 -> u32 -> u64
+    // Widen popcounts before accumulation to avoid byte overflow.
     let mut sum_u64 = vdupq_n_u64(0);
 
     for c in 0..chunks {
@@ -231,30 +221,24 @@ unsafe fn hamming_distance_neon(a: &[u8], b: &[u8], dims: usize) -> u32 {
         let va = vld1q_u8(a.as_ptr().add(base));
         let vb = vld1q_u8(b.as_ptr().add(base));
 
-        // XOR to find differing bits
         let xor = veorq_u8(va, vb);
 
-        // Population count per byte
         let popcnt = vcntq_u8(xor);
 
-        // Widen and accumulate: u8 -> u16 -> u32 -> u64
         let sum_u16 = vpaddlq_u8(popcnt);
         let sum_u32 = vpaddlq_u16(sum_u16);
         sum_u64 = vaddq_u64(sum_u64, vpaddlq_u32(sum_u32));
     }
 
-    // Extract final sum
     let total = vgetq_lane_u64(sum_u64, 0) + vgetq_lane_u64(sum_u64, 1);
     let mut result = total as u32;
 
-    // Handle remaining full bytes (between last SIMD chunk and the partial byte)
     let remainder_start = chunks * SIMD_WIDTH;
     for i in remainder_start..full_bytes {
         result += (a[i] ^ b[i]).count_ones();
     }
 
-    // Handle the single partial byte (if dims is not a multiple of 8).
-    // Top `r` bits are real dimensions; bottom `(8 - r)` bits are padding.
+    // Mask low padding bits from the final partial byte.
     let r = dims % 8;
     if r != 0 {
         let mask = 0xFFu8 << (8 - r); // top `r` bits set, bottom `(8-r)` clear
@@ -289,7 +273,6 @@ mod tests {
         assert_eq!(bv.data.len(), 1); // 8 dims -> 1 byte
         assert_eq!(bv.dims, 8);
 
-        // Expected bits (MSB first): 1, 0, 1, 0, 1, 1, 0, 1 = 0b10101101 = 0xAD
         assert_eq!(bv.data[0], 0xAD, "packed bits: {:08b}", bv.data[0]);
     }
 
@@ -299,24 +282,18 @@ mod tests {
         let bv = BinaryVector::from_f32(&v);
         let deq = bv.to_f32();
 
-        // Binary: positive -> +1.0, negative -> -1.0
         assert_eq!(deq, vec![1.0, -1.0, 1.0, -1.0, 1.0, 1.0, -1.0, 1.0]);
     }
 
     #[test]
     fn test_binary_hamming_distance() {
-        // Same vector should have 0 Hamming distance
         let v = generate_vector(384, 42);
         let bv = BinaryVector::from_f32(&v);
         assert_eq!(bv.hamming_distance(&bv), 0);
 
-        // Opposite sign vector should have max Hamming distance
         let neg_v: Vec<f32> = v.iter().map(|x| -x).collect();
         let neg_bv = BinaryVector::from_f32(&neg_v);
-        // Some values might be exactly 0.0, which maps to +1 in both cases
-        // So Hamming may not be exactly 384
         let hamming = bv.hamming_distance(&neg_bv);
-        // But it should be close to 384 for random vectors
         assert!(hamming > 350, "hamming={hamming}, expected close to 384");
     }
 
@@ -336,7 +313,6 @@ mod tests {
         let a = generate_vector(384, 101);
         let b = generate_vector(384, 202);
 
-        // f32 reference cosine
         let dot: f32 = a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum();
         let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
         let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -346,7 +322,6 @@ mod tests {
         let bb = BinaryVector::from_f32(&b);
         let bin_cos = ba.cosine_similarity_approx(&bb);
 
-        // Binary is a rough approximation -- within 0.3 is acceptable for pre-filtering
         assert!(
             (f32_cos - bin_cos).abs() < 0.35,
             "Binary cosine too far from f32: f32={f32_cos}, binary={bin_cos}"
@@ -358,20 +333,16 @@ mod tests {
         let v = generate_vector(384, 999);
         let bv = BinaryVector::from_f32(&v);
 
-        // f32: 384 * 4 = 1536 bytes
-        // Binary: ceil(384/8) = 48 bytes = 32x compression
         assert_eq!(bv.data.len(), 48);
     }
 
     #[test]
     fn test_binary_non_multiple_of_8_dims() {
-        // 385 dims -> ceil(385/8) = 49 bytes
         let v = generate_vector(385, 77);
         let bv = BinaryVector::from_f32(&v);
         assert_eq!(bv.data.len(), 49);
         assert_eq!(bv.dims, 385);
 
-        // Roundtrip should preserve all 385 values
         let deq = bv.to_f32();
         assert_eq!(deq.len(), 385);
     }
@@ -379,10 +350,8 @@ mod tests {
     #[test]
     fn test_binary_with_threshold() {
         let v = vec![0.5, 0.3, 0.1, -0.1, -0.3, -0.5, 0.7, 0.2];
-        // With threshold 0.25, only values >= 0.25 map to 1
         let bv = BinaryVector::from_f32_with_threshold(&v, 0.25);
         let deq = bv.to_f32();
-        // Expected: 1, 1, -1, -1, -1, -1, 1, -1
         assert_eq!(deq, vec![1.0, 1.0, -1.0, -1.0, -1.0, -1.0, 1.0, -1.0]);
     }
 
@@ -408,7 +377,6 @@ mod tests {
 
     #[test]
     fn test_hamming_scalar_vs_neon_parity() {
-        // Generate two distinct binary vectors and verify both paths give same result
         let a = generate_vector(384, 111);
         let b = generate_vector(384, 222);
         let ba = BinaryVector::from_f32(&a);
@@ -423,11 +391,8 @@ mod tests {
         );
     }
 
-    // --- Issue #211 regression tests -------------------------------------------------
-
     #[test]
     fn test_hamming_short_data_returns_max() {
-        // dims=128 requires 16 bytes; supply only 4 — must return u32::MAX, not OOB.
         let a = BinaryVector {
             dims: 128,
             data: vec![0xFFu8; 4],
@@ -447,7 +412,6 @@ mod tests {
 
     #[test]
     fn test_hamming_one_side_short_returns_max() {
-        // a is correct length, b is too short.
         let a = BinaryVector {
             dims: 128,
             data: vec![0xFFu8; 16],
@@ -463,7 +427,6 @@ mod tests {
 
     #[test]
     fn test_hamming_correct_data_still_works() {
-        // Verify the guard does not break the normal path.
         let v = generate_vector(128, 42);
         let bv = BinaryVector::from_f32(&v);
         assert_eq!(bv.hamming_distance(&bv), 0);
@@ -471,7 +434,6 @@ mod tests {
 
     #[test]
     fn test_binary_to_f32_short_data_returns_empty() {
-        // dims=128 requires 16 bytes; supply only 4.
         let bv = BinaryVector {
             dims: 128,
             data: vec![0xFFu8; 4],
@@ -486,14 +448,11 @@ mod tests {
 
     #[test]
     fn test_binary_to_f32_exact_length_works() {
-        // Exactly the right number of bytes — must succeed.
         let v = generate_vector(128, 7);
         let bv = BinaryVector::from_f32(&v);
         let deq = bv.to_f32();
         assert_eq!(deq.len(), 128);
     }
-
-    // --- Issue #249 regression: padding-bit masking in Hamming distance -------------
 
     /// Vectors with 12 dimensions use 2 bytes, with 4 padding bits in byte 1 (the low
     /// nibble). Two vectors that agree on all 12 real dimensions but differ in their
@@ -504,22 +463,17 @@ mod tests {
     /// the low nibble before counting, giving the correct answer.
     #[test]
     fn test_hamming_ignores_padding_bits() {
-        // 12 dims → 2 bytes; the last 4 bits of byte 1 are padding.
-        // Build via pub fields so we can inject arbitrary padding.
         let clean = BinaryVector {
             dims: 12,
-            // byte 1: top nibble = 4 valid dims, low nibble = 0 (zero padding)
             data: vec![0b10101010u8, 0b11110000u8],
             norm: 1.0,
         };
         let dirty = BinaryVector {
             dims: 12,
-            // same valid bits in top nibble of byte 1, non-zero garbage in low-nibble padding
             data: vec![0b10101010u8, 0b11111111u8],
             norm: 1.0,
         };
 
-        // Both vectors agree on all 12 real dimensions; Hamming distance must be 0.
         assert_eq!(
             hamming_distance_scalar(&clean.data, &dirty.data, 12),
             0,
@@ -531,7 +485,6 @@ mod tests {
             "dispatch: padding bits must not be counted"
         );
 
-        // Cosine distance approximation must also be 0.0 for identical valid bits.
         assert_eq!(
             clean.cosine_distance_approx(&dirty),
             0.0,

--- a/crates/embed/src/simd/cosine.rs
+++ b/crates/embed/src/simd/cosine.rs
@@ -86,8 +86,7 @@ fn cosine_neon_kernel(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 #[inline]
 fn cosine_simd128_kernel(a: &[f32], b: &[f32]) -> f32 {
-    // SAFETY: only stored in COSINE_KERNEL when compiled with the wasm32
-    // `simd128` target feature (compile-time gate, see `SimdConfig::simd128_enabled`).
+    // SAFETY: Stored only when the wasm32 `simd128` target feature is compiled in.
     unsafe { cosine_similarity_simd128_unrolled(a, b) }
 }
 
@@ -134,7 +133,6 @@ unsafe fn cosine_similarity_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
     debug_assert!(n > 0);
     let chunks = n / CHUNK_SIZE;
 
-    // 4 accumulators for each of 3 sums (dot, norm_a, norm_b)
     let mut dot0 = _mm512_setzero_ps();
     let mut dot1 = _mm512_setzero_ps();
     let mut dot2 = _mm512_setzero_ps();
@@ -178,12 +176,10 @@ unsafe fn cosine_similarity_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
         nb3 = _mm512_fmadd_ps(b3, b3, nb3);
     }
 
-    // Combine accumulators
     let dot_vec = _mm512_add_ps(_mm512_add_ps(dot0, dot1), _mm512_add_ps(dot2, dot3));
     let na_vec = _mm512_add_ps(_mm512_add_ps(na0, na1), _mm512_add_ps(na2, na3));
     let nb_vec = _mm512_add_ps(_mm512_add_ps(nb0, nb1), _mm512_add_ps(nb2, nb3));
 
-    // Handle remainder with single-register AVX-512F loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -206,7 +202,6 @@ unsafe fn cosine_similarity_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut norm_a = horizontal_sum_avx512(na_vec) + horizontal_sum_avx512(na_remainder);
     let mut norm_b = horizontal_sum_avx512(nb_vec) + horizontal_sum_avx512(nb_remainder);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         let av = a[i];
@@ -242,7 +237,6 @@ unsafe fn cosine_similarity_avx2_unrolled(a: &[f32], b: &[f32]) -> f32 {
     debug_assert!(n > 0);
     let chunks = n / CHUNK_SIZE;
 
-    // 4 accumulators for each of 3 sums (dot, norm_a, norm_b)
     let mut dot0 = _mm256_setzero_ps();
     let mut dot1 = _mm256_setzero_ps();
     let mut dot2 = _mm256_setzero_ps();
@@ -261,28 +255,24 @@ unsafe fn cosine_similarity_avx2_unrolled(a: &[f32], b: &[f32]) -> f32 {
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
-        // Unroll 0
         let a0 = _mm256_loadu_ps(a.as_ptr().add(base));
         let b0 = _mm256_loadu_ps(b.as_ptr().add(base));
         dot0 = _mm256_fmadd_ps(a0, b0, dot0);
         na0 = _mm256_fmadd_ps(a0, a0, na0);
         nb0 = _mm256_fmadd_ps(b0, b0, nb0);
 
-        // Unroll 1
         let a1 = _mm256_loadu_ps(a.as_ptr().add(base + SIMD_WIDTH));
         let b1 = _mm256_loadu_ps(b.as_ptr().add(base + SIMD_WIDTH));
         dot1 = _mm256_fmadd_ps(a1, b1, dot1);
         na1 = _mm256_fmadd_ps(a1, a1, na1);
         nb1 = _mm256_fmadd_ps(b1, b1, nb1);
 
-        // Unroll 2
         let a2 = _mm256_loadu_ps(a.as_ptr().add(base + SIMD_WIDTH * 2));
         let b2 = _mm256_loadu_ps(b.as_ptr().add(base + SIMD_WIDTH * 2));
         dot2 = _mm256_fmadd_ps(a2, b2, dot2);
         na2 = _mm256_fmadd_ps(a2, a2, na2);
         nb2 = _mm256_fmadd_ps(b2, b2, nb2);
 
-        // Unroll 3
         let a3 = _mm256_loadu_ps(a.as_ptr().add(base + SIMD_WIDTH * 3));
         let b3 = _mm256_loadu_ps(b.as_ptr().add(base + SIMD_WIDTH * 3));
         dot3 = _mm256_fmadd_ps(a3, b3, dot3);
@@ -290,7 +280,6 @@ unsafe fn cosine_similarity_avx2_unrolled(a: &[f32], b: &[f32]) -> f32 {
         nb3 = _mm256_fmadd_ps(b3, b3, nb3);
     }
 
-    // Combine accumulators
     let dot_vec = _mm256_add_ps(_mm256_add_ps(dot0, dot1), _mm256_add_ps(dot2, dot3));
     let na_vec = _mm256_add_ps(_mm256_add_ps(na0, na1), _mm256_add_ps(na2, na3));
     let nb_vec = _mm256_add_ps(_mm256_add_ps(nb0, nb1), _mm256_add_ps(nb2, nb3));
@@ -299,7 +288,6 @@ unsafe fn cosine_similarity_avx2_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut norm_a = horizontal_sum_avx2(na_vec);
     let mut norm_b = horizontal_sum_avx2(nb_vec);
 
-    // Handle remainder
     let remainder_start = chunks * CHUNK_SIZE;
     for i in remainder_start..n {
         let av = a[i];
@@ -335,7 +323,6 @@ unsafe fn cosine_similarity_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
     debug_assert!(n > 0);
     let chunks = n / CHUNK_SIZE;
 
-    // 4 accumulators for each sum
     let mut dot0 = vdupq_n_f32(0.0);
     let mut dot1 = vdupq_n_f32(0.0);
     let mut dot2 = vdupq_n_f32(0.0);
@@ -379,7 +366,6 @@ unsafe fn cosine_similarity_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
         nb3 = vfmaq_f32(nb3, b3, b3);
     }
 
-    // Combine accumulators
     let dot_vec = vaddq_f32(vaddq_f32(dot0, dot1), vaddq_f32(dot2, dot3));
     let na_vec = vaddq_f32(vaddq_f32(na0, na1), vaddq_f32(na2, na3));
     let nb_vec = vaddq_f32(vaddq_f32(nb0, nb1), vaddq_f32(nb2, nb3));
@@ -388,7 +374,6 @@ unsafe fn cosine_similarity_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut norm_a = horizontal_sum_neon(na_vec);
     let mut norm_b = horizontal_sum_neon(nb_vec);
 
-    // Handle remainder
     let remainder_start = chunks * CHUNK_SIZE;
     for i in remainder_start..n {
         let av = a[i];
@@ -424,7 +409,6 @@ unsafe fn cosine_similarity_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
     debug_assert!(n > 0);
     let chunks = n / CHUNK_SIZE;
 
-    // 4 accumulators for each of 3 sums (dot, norm_a, norm_b)
     let mut dot0 = f32x4_splat(0.0);
     let mut dot1 = f32x4_splat(0.0);
     let mut dot2 = f32x4_splat(0.0);
@@ -468,7 +452,6 @@ unsafe fn cosine_similarity_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
         nb3 = f32x4_add(nb3, f32x4_mul(b3, b3));
     }
 
-    // Combine accumulators
     let dot_vec = f32x4_add(f32x4_add(dot0, dot1), f32x4_add(dot2, dot3));
     let na_vec = f32x4_add(f32x4_add(na0, na1), f32x4_add(na2, na3));
     let nb_vec = f32x4_add(f32x4_add(nb0, nb1), f32x4_add(nb2, nb3));
@@ -477,7 +460,6 @@ unsafe fn cosine_similarity_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut norm_a = horizontal_sum_simd128(na_vec);
     let mut norm_b = horizontal_sum_simd128(nb_vec);
 
-    // Handle remainder
     let remainder_start = chunks * CHUNK_SIZE;
     for i in remainder_start..n {
         let av = a[i];
@@ -520,8 +502,6 @@ pub fn cosine_similarity_fused(a: &[f32], b: &[f32]) -> f32 {
     if a.len() != b.len() || a.is_empty() {
         return 0.0;
     }
-    // All SIMD backends already perform a fused single-pass computation.
-    // This entry point makes the guarantee explicit in the public API.
     cosine_kernel()(a, b)
 }
 

--- a/crates/embed/src/simd/distance.rs
+++ b/crates/embed/src/simd/distance.rs
@@ -143,7 +143,6 @@ unsafe fn squared_euclidean_distance_avx512_unrolled(a: &[f32], b: &[f32]) -> f3
     let sum_vec = _mm512_add_ps(_mm512_add_ps(sum0, sum1), _mm512_add_ps(sum2, sum3));
     let main_sum = horizontal_sum_avx512(sum_vec);
 
-    // Handle remainder with single-register AVX-512F loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -159,7 +158,6 @@ unsafe fn squared_euclidean_distance_avx512_unrolled(a: &[f32], b: &[f32]) -> f3
 
     let mut sum = main_sum + horizontal_sum_avx512(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         let diff = a[i] - b[i];
@@ -216,7 +214,6 @@ unsafe fn squared_euclidean_distance_avx2_unrolled(a: &[f32], b: &[f32]) -> f32 
     let sum_vec = _mm256_add_ps(_mm256_add_ps(sum0, sum1), _mm256_add_ps(sum2, sum3));
     let mut sum = horizontal_sum_avx2(sum_vec);
 
-    // Handle remainder
     for i in (chunks * CHUNK_SIZE)..n {
         let diff = a[i] - b[i];
         sum += diff * diff;
@@ -272,7 +269,6 @@ unsafe fn squared_euclidean_distance_neon_unrolled(a: &[f32], b: &[f32]) -> f32 
     let sum_vec = vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3));
     let mut sum = horizontal_sum_neon(sum_vec);
 
-    // Handle remainder
     for i in (chunks * CHUNK_SIZE)..n {
         let diff = a[i] - b[i];
         sum += diff * diff;
@@ -328,7 +324,6 @@ unsafe fn squared_euclidean_distance_simd128_unrolled(a: &[f32], b: &[f32]) -> f
     let sum_vec = f32x4_add(f32x4_add(sum0, sum1), f32x4_add(sum2, sum3));
     let mut sum = horizontal_sum_simd128(sum_vec);
 
-    // Handle remainder
     for i in (chunks * CHUNK_SIZE)..n {
         let diff = a[i] - b[i];
         sum += diff * diff;

--- a/crates/embed/src/simd/dot_product.rs
+++ b/crates/embed/src/simd/dot_product.rs
@@ -60,10 +60,6 @@ fn resolve_dot_product_kernel() -> DotKernel {
     dot_product_scalar
 }
 
-// ---------------------------------------------------------------------------
-// Batch-4 dot product kernel (query vs. 4 candidates simultaneously)
-// ---------------------------------------------------------------------------
-
 /// SIMD kernel type for batch-4 f32 dot product.
 ///
 /// Signature: (query, c0, c1, c2, c3) → [dot(q,c0), dot(q,c1), dot(q,c2), dot(q,c3)].
@@ -177,9 +173,7 @@ fn dot_product_neon_kernel(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 #[inline]
 fn dot_product_simd128_kernel(a: &[f32], b: &[f32]) -> f32 {
-    // SAFETY: only stored in DOT_PRODUCT_KERNEL when compiled with the wasm32
-    // `simd128` target feature (the `#[cfg(target_feature = "simd128")]` gate
-    // above is compile-time, not runtime -- see `SimdConfig::simd128_enabled`).
+    // SAFETY: Stored only when the wasm32 `simd128` target feature is compiled in.
     unsafe { dot_product_simd128_unrolled(a, b) }
 }
 
@@ -188,7 +182,7 @@ fn dot_product_simd128_kernel(a: &[f32], b: &[f32]) -> f32 {
 /// See [`docs/simd.md`](../../docs/simd.md#public-api-contracts) for ANN and normalization semantics.
 #[inline]
 pub fn dot_product(a: &[f32], b: &[f32]) -> f32 {
-    // Runtime length check to prevent UB in release builds
+    // Reject mismatched slices before raw-pointer loads.
     if a.len() != b.len() {
         return 0.0;
     }
@@ -218,7 +212,6 @@ unsafe fn dot_product_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(n, b.len());
     let chunks = n / CHUNK_SIZE;
 
-    // 4 independent accumulators to break dependency chains
     let mut sum0 = _mm512_setzero_ps();
     let mut sum1 = _mm512_setzero_ps();
     let mut sum2 = _mm512_setzero_ps();
@@ -244,14 +237,12 @@ unsafe fn dot_product_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
         sum3 = _mm512_fmadd_ps(a3, b3, sum3);
     }
 
-    // Combine accumulators (dependencies are introduced only once at the end)
     let sum01 = _mm512_add_ps(sum0, sum1);
     let sum23 = _mm512_add_ps(sum2, sum3);
     let sum_vec = _mm512_add_ps(sum01, sum23);
 
     let main_sum = horizontal_sum_avx512(sum_vec);
 
-    // Handle remainder with single-register loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -266,7 +257,6 @@ unsafe fn dot_product_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
 
     let mut total = main_sum + horizontal_sum_avx512(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         total += a[i] * b[i];
@@ -302,7 +292,6 @@ unsafe fn dot_product_avx2_8acc(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(n, b.len());
     let chunks = n / CHUNK_SIZE;
 
-    // 8 independent accumulators to break dependency chains
     let mut sum0 = _mm256_setzero_ps();
     let mut sum1 = _mm256_setzero_ps();
     let mut sum2 = _mm256_setzero_ps();
@@ -348,7 +337,6 @@ unsafe fn dot_product_avx2_8acc(a: &[f32], b: &[f32]) -> f32 {
         sum7 = _mm256_fmadd_ps(a7, b7, sum7);
     }
 
-    // Combine accumulators pairwise to reduce dependency chain depth
     let sum01 = _mm256_add_ps(sum0, sum1);
     let sum23 = _mm256_add_ps(sum2, sum3);
     let sum45 = _mm256_add_ps(sum4, sum5);
@@ -359,7 +347,6 @@ unsafe fn dot_product_avx2_8acc(a: &[f32], b: &[f32]) -> f32 {
 
     let sum = horizontal_sum_avx2(sum_vec);
 
-    // Handle remainder with single-vector loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -374,7 +361,6 @@ unsafe fn dot_product_avx2_8acc(a: &[f32], b: &[f32]) -> f32 {
 
     let mut total = sum + horizontal_sum_avx2(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         total += a[i] * b[i];
@@ -392,7 +378,6 @@ unsafe fn dot_product_avx2_8acc(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "avx2", enable = "fma")]
 unsafe fn dot_product_384_avx2(a: &[f32], b: &[f32]) -> f32 {
     const SIMD_WIDTH: usize = 8;
-    // 384 / 8 = 48 iterations, processed as 6 groups of 8 for accumulator reuse
     const UNROLL: usize = 8;
     const CHUNK_SIZE: usize = SIMD_WIDTH * UNROLL; // 64 floats per iteration
     const CHUNKS: usize = 384 / CHUNK_SIZE; // 6 full chunks
@@ -402,7 +387,6 @@ unsafe fn dot_product_384_avx2(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(b.len(), 384);
     debug_assert_eq!(CHUNKS * CHUNK_SIZE + TAIL_ITERS * SIMD_WIDTH, 384);
 
-    // 8 independent accumulators
     let mut sum0 = _mm256_setzero_ps();
     let mut sum1 = _mm256_setzero_ps();
     let mut sum2 = _mm256_setzero_ps();
@@ -412,7 +396,6 @@ unsafe fn dot_product_384_avx2(a: &[f32], b: &[f32]) -> f32 {
     let mut sum6 = _mm256_setzero_ps();
     let mut sum7 = _mm256_setzero_ps();
 
-    // 6 full chunks of 64 elements = 384 elements total
     for i in 0..CHUNKS {
         let base = i * CHUNK_SIZE;
 
@@ -449,7 +432,6 @@ unsafe fn dot_product_384_avx2(a: &[f32], b: &[f32]) -> f32 {
         sum7 = _mm256_fmadd_ps(a7, b7, sum7);
     }
 
-    // Combine accumulators pairwise
     let sum01 = _mm256_add_ps(sum0, sum1);
     let sum23 = _mm256_add_ps(sum2, sum3);
     let sum45 = _mm256_add_ps(sum4, sum5);
@@ -470,12 +452,10 @@ unsafe fn dot_product_384_avx2(a: &[f32], b: &[f32]) -> f32 {
 #[target_feature(enable = "avx2")]
 #[inline]
 pub(crate) unsafe fn horizontal_sum_avx2(v: __m256) -> f32 {
-    // Sum high and low 128-bit lanes
     let high = _mm256_extractf128_ps(v, 1);
     let low = _mm256_castps256_ps128(v);
     let sum128 = _mm_add_ps(high, low);
 
-    // Horizontal add within 128-bit
     let shuf = _mm_movehdup_ps(sum128); // [1,1,3,3]
     let sums = _mm_add_ps(sum128, shuf); // [0+1,1+1,2+3,3+3]
     let shuf2 = _mm_movehl_ps(sums, sums); // [2+3,3+3,2+3,3+3]
@@ -635,7 +615,6 @@ unsafe fn dot_product_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(n, b.len());
     let chunks = n / CHUNK_SIZE;
 
-    // 4 independent accumulators
     let mut sum0 = vdupq_n_f32(0.0);
     let mut sum1 = vdupq_n_f32(0.0);
     let mut sum2 = vdupq_n_f32(0.0);
@@ -661,14 +640,12 @@ unsafe fn dot_product_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
         sum3 = vfmaq_f32(sum3, a3, b3);
     }
 
-    // Combine accumulators
     let sum01 = vaddq_f32(sum0, sum1);
     let sum23 = vaddq_f32(sum2, sum3);
     let sum_vec = vaddq_f32(sum01, sum23);
 
     let mut sum = horizontal_sum_neon(sum_vec);
 
-    // Handle remainder with single-vector loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -683,7 +660,6 @@ unsafe fn dot_product_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
 
     sum += horizontal_sum_neon(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         sum += a[i] * b[i];
@@ -719,7 +695,6 @@ unsafe fn dot_product_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(n, b.len());
     let chunks = n / CHUNK_SIZE;
 
-    // 4 independent accumulators to break dependency chains
     let mut sum0 = f32x4_splat(0.0);
     let mut sum1 = f32x4_splat(0.0);
     let mut sum2 = f32x4_splat(0.0);
@@ -745,14 +720,12 @@ unsafe fn dot_product_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
         sum3 = f32x4_add(sum3, f32x4_mul(a3, b3));
     }
 
-    // Combine accumulators (dependencies are introduced only once at the end)
     let sum01 = f32x4_add(sum0, sum1);
     let sum23 = f32x4_add(sum2, sum3);
     let sum_vec = f32x4_add(sum01, sum23);
 
     let mut total = horizontal_sum_simd128(sum_vec);
 
-    // Handle remainder with single-vector loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -767,7 +740,6 @@ unsafe fn dot_product_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
 
     total += horizontal_sum_simd128(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         total += a[i] * b[i];

--- a/crates/embed/src/simd/int4.rs
+++ b/crates/embed/src/simd/int4.rs
@@ -34,7 +34,6 @@ impl Int4Params {
             }
         }
 
-        // Epsilon guard: avoid division by near-zero
         let scale = if max_abs > 1e-10 {
             15.0 / (2.0 * max_abs)
         } else {
@@ -70,7 +69,6 @@ impl Int4Vector {
         let params = Int4Params::from_vector(vector);
         let dims = vector.len();
 
-        // Compute L2 norm
         let mut norm_sq = 0.0f32;
         for &v in vector {
             if v.is_finite() {
@@ -79,23 +77,19 @@ impl Int4Vector {
         }
         let norm = norm_sq.sqrt();
 
-        // Quantize each value to [0, 15] and pack pairs into bytes
         let packed_len = dims.div_ceil(2);
         let mut data = vec![0u8; packed_len];
 
         for (i, &elem) in vector[..dims].iter().enumerate() {
             let v = if elem.is_finite() { elem } else { 0.0 };
-            // Map [-max_abs, max_abs] -> [0, 15]
             let q = ((v + params.max_abs) * params.scale)
                 .round()
                 .clamp(0.0, 15.0) as u8;
 
             let byte_idx = i / 2;
             if i % 2 == 0 {
-                // Even index -> high nibble
                 data[byte_idx] |= q << 4;
             } else {
-                // Odd index -> low nibble
                 data[byte_idx] |= q;
             }
         }
@@ -183,9 +177,7 @@ pub fn dot_product_int4(a: &Int4Vector, b: &Int4Vector) -> f32 {
     {
         let config = simd_config();
         if config.neon_enabled {
-            // SAFETY: aarch64 NEON is available by config, the packed data length guard
-            // above prevents out-of-bounds loads, and the callee handles odd dimensions
-            // without reading the padding nibble as a real dimension.
+            // SAFETY: AArch64 NEON and checked packed lengths keep loads in bounds.
             let (raw_dot, sum_a, sum_b) =
                 unsafe { dot_product_int4_neon_unrolled(&a.data, &b.data, a.dims) };
             return finish_int4_dot(raw_dot, sum_a, sum_b, a, b);
@@ -253,9 +245,7 @@ unsafe fn dot_product_int4_neon_unrolled(a: &[u8], b: &[u8], dims: usize) -> (i3
     const UNROLL: usize = 4;
     const CHUNK_BYTES: usize = BLOCK_BYTES * UNROLL;
 
-    // Only bytes containing two valid dimensions are processed in SIMD.
-    // If dims is odd, the final high nibble is handled separately and the low
-    // padding nibble is ignored to preserve current to_f32 semantics.
+    // Process odd final nibbles separately so padding never contributes.
     let full_bytes = dims / 2;
     let chunks = full_bytes / CHUNK_BYTES;
 
@@ -365,8 +355,6 @@ mod tests {
 
         assert_eq!(dequantized.len(), original.len());
 
-        // INT4 has only 16 levels, so error is larger than INT8.
-        // Max error should be within 1/15 of the range.
         let max_abs = original
             .iter()
             .filter(|v| v.is_finite())
@@ -385,23 +373,19 @@ mod tests {
 
     #[test]
     fn test_int4_packing_correctness() {
-        // Verify nibble packing: even index -> high nibble, odd -> low
         let v = vec![0.5, -0.5, 0.0, 1.0]; // 4 values -> 2 packed bytes
         let q = Int4Vector::from_f32(&v);
         assert_eq!(q.data.len(), 2);
         assert_eq!(q.dims, 4);
 
-        // Verify roundtrip preserves approximate values
         let deq = q.to_f32();
         assert_eq!(deq.len(), 4);
-        // 0.5 should map to roughly the right region
         assert!((deq[0] - 0.5).abs() < 0.15, "deq[0]={}", deq[0]);
         assert!((deq[1] - (-0.5)).abs() < 0.15, "deq[1]={}", deq[1]);
     }
 
     #[test]
     fn test_int4_odd_dimensions() {
-        // Odd number of dimensions: last nibble has a padding zero
         let v = generate_vector(383, 77);
         let q = Int4Vector::from_f32(&v);
         assert_eq!(q.data.len(), 192); // ceil(383/2) = 192
@@ -426,9 +410,7 @@ mod tests {
 
     #[test]
     fn test_int4_dot_product_vs_f32() {
-        // Use correlated vectors so the true dot product is large relative to noise.
-        // For uncorrelated random vectors, the expected dot product is ~0 while
-        // quantization noise is O(dims * step^2), so relative error is unbounded.
+        // Correlated vectors avoid unbounded relative error near a zero dot product.
         let a = generate_vector(384, 101);
         let b: Vec<f32> = a
             .iter()
@@ -436,15 +418,12 @@ mod tests {
             .map(|(i, &x)| x + 0.2 * (i as f32 * 0.3).sin())
             .collect();
 
-        // f32 reference
         let f32_dot: f32 = a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum();
 
         let qa = Int4Vector::from_f32(&a);
         let qb = Int4Vector::from_f32(&b);
         let int4_dot = qa.dot_product(&qb);
 
-        // INT4 has 16 levels; for correlated vectors the relative error should be
-        // within ~15% (quantization step = 2*max_abs/15 per component).
         let rel_error = (f32_dot - int4_dot).abs() / f32_dot.abs().max(1.0);
         assert!(
             rel_error < 0.15,
@@ -455,10 +434,7 @@ mod tests {
     #[cfg(target_arch = "aarch64")]
     #[test]
     fn test_packed_scalar_matches_neon_exact() {
-        // Directly compare dot_product_int4_packed_scalar against
-        // dot_product_int4_neon_unrolled on integer tuples. Both return
-        // (raw_dot, sum_a, sum_b) as i32 — integer domain, exact equality expected.
-        // This is the executing parity proof for the non-aarch64 fallback kernel.
+        // Integer-domain parity is exact for packed scalar and NEON paths.
         for dim in [1usize, 3, 31, 127, 383, 384] {
             let a_f32 = generate_vector(dim, 500 + dim as u64);
             let b_f32 = generate_vector(dim, 600 + dim as u64);
@@ -466,8 +442,7 @@ mod tests {
             let qb = Int4Vector::from_f32(&b_f32);
 
             let scalar_result = dot_product_int4_packed_scalar(&qa.data, &qb.data, dim);
-            // SAFETY: aarch64 always has NEON; data slices are correctly sized by
-            // Int4Vector::from_f32 (len = dims.div_ceil(2)).
+            // SAFETY: AArch64 guarantees NEON and `from_f32` sizes packed slices.
             let neon_result = unsafe { dot_product_int4_neon_unrolled(&qa.data, &qb.data, dim) };
 
             assert_eq!(
@@ -507,7 +482,6 @@ mod tests {
         let qb = Int4Vector::from_f32(&b);
         let int4_cos = qa.cosine_similarity(&qb);
 
-        // Compute f32 reference cosine
         let dot: f32 = a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum();
         let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
         let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -524,8 +498,6 @@ mod tests {
         let v = generate_vector(384, 999);
         let q = Int4Vector::from_f32(&v);
 
-        // f32: 384 * 4 = 1536 bytes
-        // INT4: ceil(384/2) = 192 bytes = 8x compression
         assert_eq!(q.data.len(), 192);
         assert_eq!(v.len() * 4, 1536);
     }
@@ -545,19 +517,13 @@ mod tests {
         let q = Int4Vector::from_f32(&v);
         let deq = q.to_f32();
         assert_eq!(deq.len(), 8);
-        // NaN and Inf should be treated as 0
-        // The dequantized value for the "0" slot should be near -max_abs + something,
-        // but the key invariant is no panics and finite output.
         for &val in &deq {
             assert!(val.is_finite(), "Dequantized value should be finite");
         }
     }
 
-    // --- Issue #211 regression tests -------------------------------------------------
-
     #[test]
     fn test_int4_to_f32_short_data_returns_empty() {
-        // dims=128 requires 64 bytes; supply only 4.
         let q = Int4Vector {
             dims: 128,
             data: vec![0xFFu8; 4],
@@ -576,7 +542,6 @@ mod tests {
 
     #[test]
     fn test_int4_to_f32_exact_length_works() {
-        // Exactly the right number of bytes — must succeed and not index OOB.
         let v: Vec<f32> = (0..128).map(|i| (i as f32) / 64.0 - 1.0).collect();
         let q = Int4Vector::from_f32(&v);
         let deq = q.to_f32();

--- a/crates/embed/src/simd/mod.rs
+++ b/crates/embed/src/simd/mod.rs
@@ -17,7 +17,6 @@ mod tier;
 #[cfg(test)]
 mod tests;
 
-// Re-export public API
 pub use binary::BinaryVector;
 pub use cosine::{
     batch_cosine_one_vs_many, batch_cosine_similarity, cosine_similarity, cosine_similarity_fused,
@@ -94,9 +93,7 @@ impl SimdConfig {
         }
         #[cfg(target_arch = "aarch64")]
         {
-            // NEON is mandatory on aarch64, always available.
-            // FEAT_DotProd (dotprod) is optional: required on Armv8.4+,
-            // optional on Armv8.2/v8.3. Detect at runtime.
+            // NEON is mandatory; optional FEAT_DotProd needs runtime detection.
             Self {
                 avx512f_enabled: false,
                 avx2_enabled: false,
@@ -108,11 +105,7 @@ impl SimdConfig {
         }
         #[cfg(target_arch = "wasm32")]
         {
-            // No runtime detection on wasm32: `simd128` is either compiled in
-            // for the whole module (via `-C target-feature=+simd128`) or not.
-            // `cfg!` reads the same compile-time flag the `#[cfg(...)]` gates
-            // on the SIMD kernel functions themselves key off, so this stays
-            // consistent with which kernels actually exist in the binary.
+            // WASM SIMD availability is a compile-time target-feature choice.
             Self {
                 avx512f_enabled: false,
                 avx2_enabled: false,
@@ -171,7 +164,7 @@ impl SimdConfig {
     }
 }
 
-// Process-wide SIMD configuration (detected once).
+// Process-wide configuration is detected once.
 static SIMD_CONFIG: OnceLock<SimdConfig> = OnceLock::new();
 
 /// **Unstable**: SIMD dispatch internal; shape may change as new backends are added.

--- a/crates/embed/src/simd/normalize.rs
+++ b/crates/embed/src/simd/normalize.rs
@@ -30,15 +30,11 @@ pub fn normalize(vector: &mut [f32]) {
     #[cfg(target_arch = "x86_64")]
     {
         if config.avx512f_enabled {
-            // SAFETY: Runtime feature detection verified AVX-512F. The mutable
-            // slice is valid for the call lifetime; the callee uses unaligned
-            // loads/stores and chunk/remainder bounds that stay inside the slice.
+            // SAFETY: AVX-512F was detected; bounded unaligned accesses stay in the slice.
             return unsafe { normalize_avx512_unrolled(vector) };
         }
         if config.avx2_enabled && config.fma_enabled {
-            // SAFETY: Runtime feature detection verified AVX2+FMA. The mutable
-            // slice is valid for the call lifetime; the callee uses unaligned
-            // loads/stores and chunk/remainder bounds that stay inside the slice.
+            // SAFETY: AVX2+FMA were detected; bounded unaligned accesses stay in the slice.
             return unsafe { normalize_avx2_unrolled(vector) };
         }
     }
@@ -46,9 +42,7 @@ pub fn normalize(vector: &mut [f32]) {
     #[cfg(target_arch = "aarch64")]
     {
         if config.neon_enabled {
-            // SAFETY: NEON is available on aarch64. The mutable slice is valid
-            // for the call lifetime; the callee uses unaligned loads/stores and
-            // bounded chunk/remainder loops that stay inside the slice.
+            // SAFETY: AArch64 guarantees NEON; bounded unaligned accesses stay in the slice.
             return unsafe { normalize_neon_unrolled(vector) };
         }
     }
@@ -56,10 +50,7 @@ pub fn normalize(vector: &mut [f32]) {
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     {
         if config.simd128_enabled() {
-            // SAFETY: compiled with wasm32 simd128 (compile-time gate, see
-            // `SimdConfig::simd128_enabled`). The mutable slice is valid for
-            // the call lifetime; the callee uses alignment-free loads/stores
-            // and bounded chunk/remainder loops that stay inside the slice.
+            // SAFETY: This target was compiled with SIMD128; bounded accesses stay in the slice.
             return unsafe { normalize_simd128_unrolled(vector) };
         }
     }
@@ -94,7 +85,6 @@ unsafe fn normalize_avx512_unrolled(vector: &mut [f32]) {
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
 
-    // First pass: compute L2 norm with 4 accumulators
     let mut norm0 = _mm512_setzero_ps();
     let mut norm1 = _mm512_setzero_ps();
     let mut norm2 = _mm512_setzero_ps();
@@ -118,7 +108,6 @@ unsafe fn normalize_avx512_unrolled(vector: &mut [f32]) {
 
     let norm_vec = _mm512_add_ps(_mm512_add_ps(norm0, norm1), _mm512_add_ps(norm2, norm3));
 
-    // Remainder for norm calculation with single-register AVX-512F loop
     let mut norm_remainder = _mm512_setzero_ps();
     for i in 0..remaining_chunks {
         let offset = main_processed + i * SIMD_WIDTH;
@@ -128,16 +117,12 @@ unsafe fn normalize_avx512_unrolled(vector: &mut [f32]) {
 
     let mut norm_sq = horizontal_sum_avx512(norm_vec) + horizontal_sum_avx512(norm_remainder);
 
-    // Scalar tail for norm (recomputed inline to avoid cross-pass variable dependency)
     for i in (main_processed + remaining_chunks * SIMD_WIDTH)..n {
         norm_sq += vector[i] * vector[i];
     }
 
     let norm = norm_sq.sqrt();
-    // Match `normalize_scalar`, which only scales when `norm > 0.0`. Rejecting
-    // NaN here too (a NaN element makes `norm` NaN) leaves the vector
-    // byte-identical to the scalar path instead of scaling by a NaN inv_norm.
-    // `is_nan() || <= 0.0` is the lint-clean equivalent of `!(norm > 0.0)`.
+    // Preserve scalar behavior: leave zero- and NaN-norm vectors unchanged.
     if norm.is_nan() || norm <= 0.0 {
         return;
     }
@@ -145,7 +130,6 @@ unsafe fn normalize_avx512_unrolled(vector: &mut [f32]) {
     let inv_norm = 1.0 / norm;
     let inv_norm_vec = _mm512_set1_ps(inv_norm);
 
-    // Second pass: scale by inverse norm with 4x unrolling
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
@@ -174,7 +158,6 @@ unsafe fn normalize_avx512_unrolled(vector: &mut [f32]) {
         );
     }
 
-    // Remainder for scaling with single-register AVX-512F loop
     for i in 0..remaining_chunks {
         let offset = main_processed + i * SIMD_WIDTH;
         let v = _mm512_loadu_ps(vector.as_ptr().add(offset));
@@ -184,7 +167,6 @@ unsafe fn normalize_avx512_unrolled(vector: &mut [f32]) {
         );
     }
 
-    // Final scalar remainder (recomputed inline to avoid cross-pass variable dependency)
     for i in (main_processed + remaining_chunks * SIMD_WIDTH)..n {
         vector[i] *= inv_norm;
     }
@@ -204,7 +186,6 @@ unsafe fn normalize_avx2_unrolled(vector: &mut [f32]) {
     let n = vector.len();
     let chunks = n / CHUNK_SIZE;
 
-    // First pass: compute L2 norm with 4 accumulators
     let mut norm0 = _mm256_setzero_ps();
     let mut norm1 = _mm256_setzero_ps();
     let mut norm2 = _mm256_setzero_ps();
@@ -229,15 +210,12 @@ unsafe fn normalize_avx2_unrolled(vector: &mut [f32]) {
     let norm_vec = _mm256_add_ps(_mm256_add_ps(norm0, norm1), _mm256_add_ps(norm2, norm3));
     let mut norm_sq = horizontal_sum_avx2(norm_vec);
 
-    // Remainder for norm calculation
     for i in (chunks * CHUNK_SIZE)..n {
         norm_sq += vector[i] * vector[i];
     }
 
     let norm = norm_sq.sqrt();
-    // Match `normalize_scalar`: reject 0.0 and NaN alike so a NaN-containing
-    // vector is left unchanged rather than scaled by NaN. `is_nan() || <= 0.0`
-    // is the lint-clean equivalent of `!(norm > 0.0)`.
+    // Preserve scalar behavior: leave zero- and NaN-norm vectors unchanged.
     if norm.is_nan() || norm <= 0.0 {
         return;
     }
@@ -245,7 +223,6 @@ unsafe fn normalize_avx2_unrolled(vector: &mut [f32]) {
     let inv_norm = 1.0 / norm;
     let inv_norm_vec = _mm256_set1_ps(inv_norm);
 
-    // Second pass: divide by norm with 4x unrolling
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
@@ -274,7 +251,6 @@ unsafe fn normalize_avx2_unrolled(vector: &mut [f32]) {
         );
     }
 
-    // Remainder for scaling
     for i in (chunks * CHUNK_SIZE)..n {
         vector[i] *= inv_norm;
     }
@@ -294,7 +270,6 @@ unsafe fn normalize_neon_unrolled(vector: &mut [f32]) {
     let n = vector.len();
     let chunks = n / CHUNK_SIZE;
 
-    // First pass: compute L2 norm with 4 accumulators
     let mut norm0 = vdupq_n_f32(0.0);
     let mut norm1 = vdupq_n_f32(0.0);
     let mut norm2 = vdupq_n_f32(0.0);
@@ -323,34 +298,24 @@ unsafe fn normalize_neon_unrolled(vector: &mut [f32]) {
         norm_sq += val * val;
     }
 
-    // Match `normalize_scalar`: reject 0.0 and NaN alike. A subnormal-but-positive
-    // norm_sq still passes here and is handled by the finite-fallback below; only
-    // zero/NaN short-circuit to leave the vector unchanged, keeping NEON
-    // byte-consistent with the scalar path. `is_nan() || <= 0.0` is the lint-clean
-    // equivalent of `!(norm_sq > 0.0)`.
+    // Preserve scalar behavior; positive subnormals use the finite fallback below.
     if norm_sq.is_nan() || norm_sq <= 0.0 {
         return;
     }
 
-    // vrsqrteq_f32 gives ~8-bit estimate; two Newton–Raphson steps reach full f32
-    // precision (~23 bits), eliminating any residual above the 1e-5 accuracy gate.
-    // vrsqrtsq_f32(a, b) = (3 - a*b) / 2  →  y' = y * vrsqrtsq_f32(x, y*y)
+    // Two Newton-Raphson refinements bring the reciprocal-square-root to f32 precision.
     let norm_sq_v = vdupq_n_f32(norm_sq);
     let y0 = vrsqrteq_f32(norm_sq_v);
     let y1 = vmulq_f32(y0, vrsqrtsq_f32(norm_sq_v, vmulq_f32(y0, y0)));
     let y2 = vmulq_f32(y1, vrsqrtsq_f32(norm_sq_v, vmulq_f32(y1, y1)));
-    // SAFETY: y2 has 4 identical lanes (norm_sq_v is a broadcast), so lane 0 is the
-    // scalar inv_norm used for both the NEON broadcast and the 1-3 element tail.
+    // SAFETY: A broadcast input yields identical lanes; lane 0 also scales the tail.
     let mut inv_norm = vgetq_lane_f32(y2, 0);
-    // vrsqrte/Newton overflow to inf for a subnormal-but-nonzero norm_sq (‖v‖ ≲ 7e-20),
-    // where the AVX2/scalar lanes stay finite via 1.0/sqrt; fall back to keep NEON
-    // byte-consistent with them rather than scaling the vector to inf/NaN.
+    // Subnormal norms can overflow the estimate; use the scalar reciprocal square root.
     if !inv_norm.is_finite() {
         inv_norm = 1.0 / norm_sq.sqrt();
     }
     let inv_norm_vec = vdupq_n_f32(inv_norm);
 
-    // Second pass: scale by inverse norm with 4x unrolling
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
@@ -376,7 +341,6 @@ unsafe fn normalize_neon_unrolled(vector: &mut [f32]) {
         );
     }
 
-    // Remainder for scaling
     for val in vector.iter_mut().skip(chunks * CHUNK_SIZE) {
         *val *= inv_norm;
     }
@@ -396,7 +360,6 @@ unsafe fn normalize_simd128_unrolled(vector: &mut [f32]) {
     let n = vector.len();
     let chunks = n / CHUNK_SIZE;
 
-    // First pass: compute L2 norm with 4 accumulators
     let mut norm0 = f32x4_splat(0.0);
     let mut norm1 = f32x4_splat(0.0);
     let mut norm2 = f32x4_splat(0.0);
@@ -421,15 +384,12 @@ unsafe fn normalize_simd128_unrolled(vector: &mut [f32]) {
     let norm_vec = f32x4_add(f32x4_add(norm0, norm1), f32x4_add(norm2, norm3));
     let mut norm_sq = horizontal_sum_simd128(norm_vec);
 
-    // Remainder for norm calculation
     for i in (chunks * CHUNK_SIZE)..n {
         norm_sq += vector[i] * vector[i];
     }
 
     let norm = norm_sq.sqrt();
-    // Match `normalize_scalar`: reject 0.0 and NaN alike so a NaN-containing
-    // vector is left unchanged rather than scaled by NaN. `is_nan() || <= 0.0`
-    // is the lint-clean equivalent of `!(norm > 0.0)`.
+    // Preserve scalar behavior: leave zero- and NaN-norm vectors unchanged.
     if norm.is_nan() || norm <= 0.0 {
         return;
     }
@@ -437,7 +397,6 @@ unsafe fn normalize_simd128_unrolled(vector: &mut [f32]) {
     let inv_norm = 1.0 / norm;
     let inv_norm_vec = f32x4_splat(inv_norm);
 
-    // Second pass: divide by norm with 4x unrolling
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
@@ -466,7 +425,6 @@ unsafe fn normalize_simd128_unrolled(vector: &mut [f32]) {
         );
     }
 
-    // Remainder for scaling
     for i in (chunks * CHUNK_SIZE)..n {
         vector[i] *= inv_norm;
     }

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -34,7 +34,6 @@ impl QuantizationParams {
     ///
     /// Handles edge cases: empty vectors, NaN, Inf, near-zero vectors.
     pub fn from_vector(vector: &[f32]) -> Self {
-        // Single pass over finite values to handle NaN/Inf gracefully.
         let mut min_val = f32::INFINITY;
         let mut max_val = f32::NEG_INFINITY;
 
@@ -45,16 +44,13 @@ impl QuantizationParams {
             }
         }
 
-        // Handle edge case: empty or all non-finite.
         if !min_val.is_finite() || !max_val.is_finite() {
             min_val = 0.0;
             max_val = 0.0;
         }
 
-        // Symmetric quantization: map [-max_abs, max_abs] to [-127, 127]
         let max_abs = min_val.abs().max(max_val.abs());
 
-        // Epsilon guard to avoid division by near-zero
         let scale = if max_abs > 1e-10 {
             127.0 / max_abs
         } else {
@@ -109,12 +105,10 @@ impl QuantizedVector {
     pub fn from_f32(vector: &[f32]) -> Self {
         let mut params = QuantizationParams::from_vector(vector);
 
-        // Defensive guard: avoid NaN/Inf/zero scale.
         if !params.scale.is_finite() || params.scale == 0.0 {
             params.scale = 1.0;
         }
 
-        // Compute L2 norm of finite values (NaN/Inf are treated as 0.0).
         let mut norm_sq = 0.0f32;
         for &v in vector {
             if v.is_finite() {
@@ -247,7 +241,7 @@ unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
     let mut sum2 = vdupq_n_s32(0);
     let mut sum3 = vdupq_n_s32(0);
 
-    // SDOT is selected only after runtime FEAT_DotProd detection — see docs/simd.md.
+    // SDOT requires runtime FEAT_DotProd detection.
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
@@ -299,7 +293,6 @@ unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
     let sum23 = vaddq_s32(sum2, sum3);
     let mut sum_vec = vaddq_s32(sum01, sum23);
 
-    // Tail: remaining full 16-byte vectors using sdot
     let tail_start = chunks * CHUNK_SIZE;
     let tail_chunks = (n - tail_start) / SIMD_WIDTH;
     for j in 0..tail_chunks {
@@ -317,7 +310,6 @@ unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
 
     let sum = vaddvq_s32(sum_vec);
 
-    // Scalar tail: only the final < SIMD_WIDTH elements
     let remainder_start = tail_start + tail_chunks * SIMD_WIDTH;
     let remainder: i32 = a[remainder_start..]
         .iter()
@@ -340,13 +332,9 @@ unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
 unsafe fn mm512_sign_epi8(b: __m512i, a: __m512i) -> __m512i {
     let zero = _mm512_setzero_si512();
     let neg_b = _mm512_sub_epi8(zero, b);
-    // mask where a < 0
     let mask_neg = _mm512_cmplt_epi8_mask(a, zero);
-    // mask where a == 0
     let mask_zero = _mm512_cmpeq_epi8_mask(a, zero);
-    // Start with b, replace with -b where a < 0
     let result = _mm512_mask_blend_epi8(mask_neg, b, neg_b);
-    // Replace with 0 where a == 0
     _mm512_mask_blend_epi8(mask_zero, result, zero)
 }
 
@@ -367,7 +355,6 @@ unsafe fn dot_product_i8_avx512vnni(a: &[i8], b: &[i8]) -> f32 {
     debug_assert!(b.iter().all(|&v| v != i8::MIN));
     let chunks = n / CHUNK_SIZE;
 
-    // 4 independent int32 accumulators (16 int32s each)
     let mut sum0 = _mm512_setzero_si512();
     let mut sum1 = _mm512_setzero_si512();
     let mut sum2 = _mm512_setzero_si512();
@@ -376,8 +363,7 @@ unsafe fn dot_product_i8_avx512vnni(a: &[i8], b: &[i8]) -> f32 {
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
-        // VNNI: dpbusd computes sum += a[unsigned] * b[signed]
-        // For signed * signed, we use: abs(a) * sign(b, a)
+        // Map signed products through VNNI's unsigned-by-signed operation.
         let a0 = _mm512_loadu_si512(a.as_ptr().add(base) as *const __m512i);
         let b0 = _mm512_loadu_si512(b.as_ptr().add(base) as *const __m512i);
         let a0_abs = _mm512_abs_epi8(a0);
@@ -403,15 +389,12 @@ unsafe fn dot_product_i8_avx512vnni(a: &[i8], b: &[i8]) -> f32 {
         sum3 = _mm512_dpbusd_epi32(sum3, a3_abs, b3_signed);
     }
 
-    // Combine accumulators
     let sum01 = _mm512_add_epi32(sum0, sum1);
     let sum23 = _mm512_add_epi32(sum2, sum3);
     let sum_vec = _mm512_add_epi32(sum01, sum23);
 
-    // Horizontal sum of 16 int32s
     let sum = _mm512_reduce_add_epi32(sum_vec);
 
-    // Handle remainder with scalar
     let remainder_start = chunks * CHUNK_SIZE;
     let remainder: i32 = a[remainder_start..]
         .iter()
@@ -433,7 +416,6 @@ unsafe fn dot_product_i8_avx2_unrolled(a: &[i8], b: &[i8]) -> f32 {
     const SIMD_WIDTH: usize = 32;
     const UNROLL: usize = 4;
     const CHUNK_SIZE: usize = SIMD_WIDTH * UNROLL;
-    // Prefetch one full chunk ahead for both input arrays.
     const PREFETCH_DISTANCE: usize = CHUNK_SIZE;
     let n = a.len();
     debug_assert_eq!(n, b.len());
@@ -441,7 +423,6 @@ unsafe fn dot_product_i8_avx2_unrolled(a: &[i8], b: &[i8]) -> f32 {
     debug_assert!(b.iter().all(|&v| v != i8::MIN));
     let chunks = n / CHUNK_SIZE;
 
-    // 4 independent int32 accumulators
     let mut sum0 = _mm256_setzero_si256();
     let mut sum1 = _mm256_setzero_si256();
     let mut sum2 = _mm256_setzero_si256();
@@ -452,35 +433,30 @@ unsafe fn dot_product_i8_avx2_unrolled(a: &[i8], b: &[i8]) -> f32 {
     for i in 0..chunks {
         let base = i * CHUNK_SIZE;
 
-        // Software prefetch for the next chunk.
         let next_base = base + PREFETCH_DISTANCE;
         if next_base + CHUNK_SIZE <= n {
             _mm_prefetch(a.as_ptr().add(next_base), _MM_HINT_T0);
             _mm_prefetch(b.as_ptr().add(next_base), _MM_HINT_T0);
         }
 
-        // Unroll 0
         let a0 = _mm256_loadu_si256(a.as_ptr().add(base) as *const __m256i);
         let b0 = _mm256_loadu_si256(b.as_ptr().add(base) as *const __m256i);
         let prod0 = _mm256_maddubs_epi16(_mm256_abs_epi8(a0), _mm256_sign_epi8(b0, a0));
         let prod0_32 = _mm256_madd_epi16(prod0, ones);
         sum0 = _mm256_add_epi32(sum0, prod0_32);
 
-        // Unroll 1
         let a1 = _mm256_loadu_si256(a.as_ptr().add(base + SIMD_WIDTH) as *const __m256i);
         let b1 = _mm256_loadu_si256(b.as_ptr().add(base + SIMD_WIDTH) as *const __m256i);
         let prod1 = _mm256_maddubs_epi16(_mm256_abs_epi8(a1), _mm256_sign_epi8(b1, a1));
         let prod1_32 = _mm256_madd_epi16(prod1, ones);
         sum1 = _mm256_add_epi32(sum1, prod1_32);
 
-        // Unroll 2
         let a2 = _mm256_loadu_si256(a.as_ptr().add(base + SIMD_WIDTH * 2) as *const __m256i);
         let b2 = _mm256_loadu_si256(b.as_ptr().add(base + SIMD_WIDTH * 2) as *const __m256i);
         let prod2 = _mm256_maddubs_epi16(_mm256_abs_epi8(a2), _mm256_sign_epi8(b2, a2));
         let prod2_32 = _mm256_madd_epi16(prod2, ones);
         sum2 = _mm256_add_epi32(sum2, prod2_32);
 
-        // Unroll 3
         let a3 = _mm256_loadu_si256(a.as_ptr().add(base + SIMD_WIDTH * 3) as *const __m256i);
         let b3 = _mm256_loadu_si256(b.as_ptr().add(base + SIMD_WIDTH * 3) as *const __m256i);
         let prod3 = _mm256_maddubs_epi16(_mm256_abs_epi8(a3), _mm256_sign_epi8(b3, a3));
@@ -488,12 +464,10 @@ unsafe fn dot_product_i8_avx2_unrolled(a: &[i8], b: &[i8]) -> f32 {
         sum3 = _mm256_add_epi32(sum3, prod3_32);
     }
 
-    // Combine accumulators
     let sum01 = _mm256_add_epi32(sum0, sum1);
     let sum23 = _mm256_add_epi32(sum2, sum3);
     let sum_vec = _mm256_add_epi32(sum01, sum23);
 
-    // Horizontal sum
     let sum128_lo = _mm256_castsi256_si128(sum_vec);
     let sum128_hi = _mm256_extracti128_si256(sum_vec, 1);
     let sum128 = _mm_add_epi32(sum128_lo, sum128_hi);
@@ -501,7 +475,6 @@ unsafe fn dot_product_i8_avx2_unrolled(a: &[i8], b: &[i8]) -> f32 {
     let sum32 = _mm_add_epi32(sum64, _mm_srli_si128(sum64, 4));
     let sum = _mm_cvtsi128_si32(sum32);
 
-    // Handle remainder
     let remainder_start = chunks * CHUNK_SIZE;
     let remainder: i32 = a[remainder_start..]
         .iter()
@@ -511,10 +484,6 @@ unsafe fn dot_product_i8_avx2_unrolled(a: &[i8], b: &[i8]) -> f32 {
 
     (sum + remainder) as f32
 }
-
-// ============================================================================
-// INT8 kernel dispatch cache (mirrors f32 DotKernel pattern in dot_product.rs)
-// ============================================================================
 
 /// INT8 dot-product kernel function pointer type.
 pub type I8DotKernel = fn(&[i8], &[i8]) -> f32;
@@ -532,8 +501,7 @@ fn resolve_i8_dot_kernel() -> I8DotKernel {
 
     #[cfg(target_arch = "aarch64")]
     {
-        // The NEON kernel uses SDOT (ARMv8.2 FEAT_DotProd), which is optional on
-        // Armv8.2/v8.3. Only dispatch when dotprod_enabled is confirmed at runtime.
+        // SDOT is optional on older Arm versions, so require runtime detection.
         if config.neon_enabled && config.dotprod_enabled {
             return dot_product_i8_neon_kernel;
         }
@@ -628,8 +596,7 @@ mod simd_parity_tests {
             .collect()
     }
 
-    // FP-034: NEON SDOT vs scalar parity for INT8 dot product.
-    // Gated on dotprod: SDOT is FEAT_DotProd, not baseline NEON.
+    // SDOT is FEAT_DotProd, not baseline NEON.
     #[test]
     fn test_i8_neon_scalar_parity() {
         #[cfg(target_arch = "aarch64")]
@@ -661,7 +628,6 @@ mod simd_parity_tests {
         }
     }
 
-    // FP-034: AVX2 vs scalar parity for INT8 dot product.
     #[test]
     fn test_i8_avx2_scalar_parity() {
         #[cfg(target_arch = "x86_64")]

--- a/crates/embed/src/simd/tests.rs
+++ b/crates/embed/src/simd/tests.rs
@@ -357,10 +357,8 @@ fn test_avx512_euclidean_distance_dimensions() {
 /// 4. **Degenerate-input behaviour** — the documented length-mismatch returns.
 #[test]
 fn test_simd_distance_consumer_contract() {
-    // The `(&[f32], &[f32]) -> f32` shape khive ANN indexes bind to.
     type DistFn = fn(&[f32], &[f32]) -> f32;
 
-    // (1) Signature gate: fails to compile if any signature drifts.
     let _contract: [DistFn; 4] = [
         squared_euclidean_distance,
         euclidean_distance,
@@ -368,7 +366,6 @@ fn test_simd_distance_consumer_contract() {
         cosine_similarity,
     ];
 
-    // (2) squared_euclidean_distance == scalar reference, within FP tolerance.
     for dim in AVX512_TEST_DIMS {
         let a = generate_random_vector_seeded(dim, 911);
         let b = generate_random_vector_seeded(dim, 1013);
@@ -385,7 +382,6 @@ fn test_simd_distance_consumer_contract() {
         );
     }
 
-    // (3) Ordering invariant: sorting by squared-L2 matches sorting by true L2.
     let query = generate_random_vector_seeded(384, 1);
     let candidates: Vec<Vec<f32>> = (0..16)
         .map(|i| generate_random_vector_seeded(384, 100 + i as u64))
@@ -405,7 +401,6 @@ fn test_simd_distance_consumer_contract() {
         "squared_euclidean_distance must preserve true-L2 ordering (ANN invariant)"
     );
 
-    // (4) Documented degenerate-input behaviour is part of the contract.
     let a4 = [1.0_f32, 2.0, 3.0, 4.0];
     let b3 = [1.0_f32, 2.0, 3.0];
     assert_eq!(squared_euclidean_distance(&a4, &b3), f32::MAX);
@@ -413,7 +408,6 @@ fn test_simd_distance_consumer_contract() {
     assert_eq!(dot_product(&a4, &b3), 0.0);
     assert_eq!(cosine_similarity(&a4, &b3), 0.0);
 
-    // cosine_similarity additionally documents empty-input → 0.0 (explicit guard).
     assert_eq!(cosine_similarity(&[], &[]), 0.0);
 }
 
@@ -448,7 +442,6 @@ fn test_avx512f_config_detection() {
 #[test]
 fn test_simd_config_detection() {
     let config = SimdConfig::detect();
-    // Just verify it doesn't panic and show capabilities
     println!(
         "AVX512F: {}, AVX2: {}, FMA: {}, AVX512-VNNI: {}, NEON: {}",
         config.avx512f_enabled,
@@ -463,7 +456,6 @@ fn test_simd_config_detection() {
         assert!(config.avx512f_enabled, "AVX512-VNNI requires AVX512F");
     }
 
-    // On aarch64 (Apple Silicon, Graviton, etc.), NEON should be enabled
     #[cfg(target_arch = "aarch64")]
     assert!(config.neon_enabled, "NEON should be available on aarch64");
 }
@@ -487,7 +479,6 @@ fn test_batch_operations() {
     let results = batch_cosine_similarity(&pair_refs);
     assert_eq!(results.len(), 10);
 
-    // Verify each result is in valid range
     for sim in results {
         assert!((-1.0..=1.0).contains(&sim));
     }
@@ -495,7 +486,6 @@ fn test_batch_operations() {
 
 #[test]
 fn test_non_multiple_of_8() {
-    // Test with dimensions that aren't multiples of 8 or 16.
     for dim in [7, 15, 100, 383, 385] {
         let a = generate_random_vector_seeded(dim, 23);
         let b = generate_random_vector_seeded(dim, 47);
@@ -513,17 +503,12 @@ fn test_non_multiple_of_8() {
     }
 }
 
-// ========================================================================
-// INT8 QUANTIZATION TESTS
-// ========================================================================
-
 #[test]
 fn test_quantization_roundtrip() {
     let original = generate_random_vector(384);
     let quantized = QuantizedVector::from_f32(&original);
     let dequantized = quantized.to_f32();
 
-    // Check approximate equality (quantization introduces some error)
     for (orig, deq) in original.iter().zip(dequantized.iter()) {
         assert!(
             (orig - deq).abs() < 0.02,
@@ -561,7 +546,6 @@ fn test_i8_cosine_similarity_accuracy() {
     let b_q = QuantizedVector::from_f32(&b);
     let i8_result = cosine_similarity_i8(&a_q, &b_q);
 
-    // int8 cosine similarity should be very close to float32
     assert!(
         (float_result - i8_result).abs() < 0.02,
         "int8 cosine similarity error too large: float={float_result}, i8={i8_result}"
@@ -573,24 +557,12 @@ fn test_i8_memory_savings() {
     let v = generate_random_vector(384);
     let q = QuantizedVector::from_f32(&v);
 
-    // float32: 384 * 4 = 1536 bytes
-    // int8: 384 * 1 = 384 bytes
     assert_eq!(v.len() * 4, 1536, "float32 should be 1536 bytes");
     assert_eq!(q.len(), 384, "int8 should be 384 bytes");
-    // 4x memory reduction
 }
-
-// ============================================================================
-// PROPTEST - Property-based tests for embedding dimension invariants (#451)
-// ============================================================================
-
-// ========================================================================
-// BATCH-4 KERNEL PARITY TESTS
-// ========================================================================
 
 #[test]
 fn test_batch4_dot_matches_per_pair_basic() {
-    // Small known vectors so correctness is obvious.
     let q = vec![1.0_f32, 0.5, -0.5, 0.25, 0.0, -1.0, 0.75, 0.1];
     let c0 = vec![1.0_f32, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0];
     let c1 = vec![0.0_f32, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
@@ -645,7 +617,6 @@ fn test_batch4_dot_matches_per_pair_384dim() {
 
 #[test]
 fn test_batch4_dot_matches_per_pair_odd_dims() {
-    // 100 is not a multiple of 8; exercises the scalar tail.
     let q = generate_random_vector_seeded(100, 7777);
     let c0 = generate_random_vector_seeded(100, 7778);
     let c1 = generate_random_vector_seeded(100, 7779);
@@ -673,15 +644,11 @@ fn test_batch4_dot_matches_per_pair_odd_dims() {
 
 #[test]
 fn test_batch_dot_product_same_query_matches_per_pair() {
-    // Constructs a same-query batch (N=16 candidates, all with the same query).
-    // batch_dot_product should take the batch-4 SIMD path for chunks of 4
-    // and produce the same values as per-pair calls.
     let query = generate_random_vector_seeded(384, 9001);
     let candidates: Vec<Vec<f32>> = (0..16)
         .map(|i| generate_random_vector_seeded(384, 9100 + i as u64))
         .collect();
 
-    // Build pairs where every left-hand side is the same query borrow.
     let pairs: Vec<(&[f32], &[f32])> = candidates
         .iter()
         .map(|c| (query.as_slice(), c.as_slice()))
@@ -705,9 +672,6 @@ fn test_batch_dot_product_same_query_matches_per_pair() {
 
 #[test]
 fn test_batch_dot_product_unit_vectors_equals_cosine() {
-    // For unit-normalized vectors, dot product == cosine similarity.
-    // This validates the fast path that routes normalized cosine similarity
-    // through a plain dot product.
     let mut q = generate_random_vector_seeded(384, 42);
     let mut c = generate_random_vector_seeded(384, 43);
     normalize(&mut q);
@@ -730,13 +694,11 @@ mod proptests {
     /// Strategy for generating embedding dimensions (common model sizes + edge cases)
     fn embedding_dimension_strategy() -> impl Strategy<Value = usize> {
         prop_oneof![
-            // Common embedding model dimensions
             Just(128),
             Just(384),  // bge-small-en-v1.5
             Just(768),  // bge-base-en-v1.5
             Just(1024), // bge-large-en-v1.5
             Just(1536),
-            // Edge cases for SIMD alignment
             Just(1),    // Minimum
             Just(7),    // Non-aligned small
             Just(8),    // AVX alignment
@@ -749,7 +711,6 @@ mod proptests {
             Just(383),  // Off-by-one small
             Just(385),  // Off-by-one large
             Just(1023), // Off-by-one 1024
-            // Random dimensions
             (1usize..2048usize),
         ]
     }
@@ -769,7 +730,6 @@ mod proptests {
         #[test]
         fn prop_cosine_identical_is_one(dim in embedding_dimension_strategy()) {
             let v: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.1).cos()).collect();
-            // Skip zero vectors
             let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
             prop_assume!(norm > 1e-6);
 
@@ -891,7 +851,6 @@ mod proptests {
         /// Property: int8 quantization preserves relative similarity ordering
         #[test]
         fn prop_i8_quantization_preserves_similarity_order(dim in 32usize..512usize) {
-            // Generate 3 vectors where a is more similar to b than to c
             let a: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.1).sin()).collect();
             let b: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.1).sin() + 0.1 * (i as f32 * 0.3).cos()).collect();
             let c: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.5).cos()).collect();
@@ -899,7 +858,6 @@ mod proptests {
             let sim_ab_float = cosine_similarity(&a, &b);
             let sim_ac_float = cosine_similarity(&a, &c);
 
-            // Only test if there's meaningful difference
             prop_assume!((sim_ab_float - sim_ac_float).abs() > 0.1);
 
             let a_q = QuantizedVector::from_f32(&a);
@@ -909,7 +867,6 @@ mod proptests {
             let sim_ab_i8 = cosine_similarity_i8(&a_q, &b_q);
             let sim_ac_i8 = cosine_similarity_i8(&a_q, &c_q);
 
-            // Relative ordering should be preserved
             if sim_ab_float > sim_ac_float {
                 prop_assert!(sim_ab_i8 > sim_ac_i8 - 0.1,
                     "i8 should preserve order: ab={} > ac={} but i8: ab={}, ac={}",
@@ -918,10 +875,6 @@ mod proptests {
         }
     }
 }
-
-// ============================================================================
-// OPTIMIZATION CORRECTNESS TESTS (added with perf(embed) optimizations)
-// ============================================================================
 
 /// Verify that `cosine_similarity_fused` produces the same result as `cosine_similarity`.
 ///
@@ -947,11 +900,9 @@ fn test_cosine_fused_matches_separate() {
 /// Edge cases for `cosine_similarity_fused`: zero vectors, mismatched lengths, identical vectors.
 #[test]
 fn test_cosine_fused_edge_cases() {
-    // Empty input
     let result = cosine_similarity_fused(&[], &[]);
     assert_eq!(result, 0.0, "fused: empty slices should return 0.0");
 
-    // Length mismatch
     let a = vec![1.0_f32, 2.0, 3.0];
     let b = vec![1.0_f32, 2.0];
     assert_eq!(
@@ -960,7 +911,6 @@ fn test_cosine_fused_edge_cases() {
         "fused: length mismatch should return 0.0"
     );
 
-    // Identical non-zero vector -> similarity 1.0
     let v = vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let sim = cosine_similarity_fused(&v, &v);
     assert!(
@@ -1004,12 +954,10 @@ fn test_batch_cosine_one_vs_many_dim_mismatch() {
 
     let results = batch_cosine_one_vs_many(&query, &refs);
     assert_eq!(results.len(), 2);
-    // good candidate should produce a valid similarity
     assert!(
         results[0].is_finite(),
         "good candidate should produce finite similarity"
     );
-    // bad candidate (dim mismatch) should return 0.0
     assert_eq!(results[1], 0.0, "dim-mismatch candidate should return 0.0");
 }
 
@@ -1024,7 +972,6 @@ fn test_i8_dot_unrolled_matches_original() {
         let a_q = QuantizedVector::from_f32(&a_f32);
         let b_q = QuantizedVector::from_f32(&b_f32);
 
-        // Scalar reference: direct i32 accumulation over raw i8 slices.
         let scalar: f32 = a_q
             .data()
             .iter()
@@ -1032,7 +979,6 @@ fn test_i8_dot_unrolled_matches_original() {
             .map(|(&x, &y)| x as i32 * y as i32)
             .sum::<i32>() as f32;
 
-        // SIMD path (with prefetch via dot_product_i8_raw).
         let simd = dot_product_i8_raw(a_q.data(), b_q.data());
 
         let diff = (simd - scalar).abs();

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -497,21 +497,17 @@ pub fn approximate_cosine_distance(query_f32: &[f32], stored: &QuantizedData) ->
     );
     match stored {
         QuantizedData::Full(v) => {
-            // Exact cosine distance
             1.0 - cosine_similarity(query_f32, v)
         }
         QuantizedData::Int8(q) => {
-            // Quantize query to INT8, compute via INT8 path
             let query_q = QuantizedVector::from_f32(query_f32);
             1.0 - q.cosine_similarity(&query_q)
         }
         QuantizedData::Int4(q) => {
-            // Quantize query to INT4, compute via INT4 path
             let query_q = Int4Vector::from_f32(query_f32);
             q.cosine_distance(&query_q)
         }
         QuantizedData::Binary(q) => {
-            // Quantize query to binary, compute Hamming-based approx
             let query_q = BinaryVector::from_f32(query_f32);
             q.cosine_distance_approx(&query_q)
         }
@@ -531,7 +527,6 @@ pub fn approximate_dot_product(query_f32: &[f32], stored: &QuantizedData) -> f32
             q.dot_product(&query_q)
         }
         QuantizedData::Binary(_q) => {
-            // Binary doesn't have a meaningful dot product; fall back to dequantize
             let stored_f32 = _q.to_f32();
             dot_product(query_f32, &stored_f32)
         }
@@ -618,7 +613,6 @@ mod tests {
             assert_eq!(data.tier(), tier, "tier mismatch for {tier:?}");
             assert_eq!(data.dims(), 384, "dims mismatch for {tier:?}");
 
-            // Verify storage bytes match expected
             let expected_bytes = tier.storage_bytes(384);
             assert_eq!(
                 data.storage_bytes(),
@@ -630,15 +624,12 @@ mod tests {
 
     #[test]
     fn test_approximate_cosine_distance_ordering() {
-        // Vectors a and b should be "closer" than a and c.
         let a = generate_vector(384, 1);
-        // b = a + small noise
         let b: Vec<f32> = a
             .iter()
             .enumerate()
             .map(|(i, &x)| x + 0.05 * (i as f32 * 0.3).sin())
             .collect();
-        // c = random, uncorrelated
         let c = generate_vector(384, 999);
 
         for tier in [
@@ -653,7 +644,6 @@ mod tests {
             let dist_ab = approximate_cosine_distance(&a, &stored_b);
             let dist_ac = approximate_cosine_distance(&a, &stored_c);
 
-            // a should be closer to b than to c at all tiers
             assert!(
                 dist_ab < dist_ac,
                 "{tier:?}: dist(a,b)={dist_ab} should be < dist(a,c)={dist_ac}"
@@ -666,7 +656,6 @@ mod tests {
         let v = generate_vector(384, 42);
         let binary = QuantizedData::from_f32(&v, QuantizationTier::Binary);
 
-        // Promote Binary -> Int4 -> Int8 -> Full
         let int4 = binary.promote(QuantizationTier::Int4);
         assert_eq!(int4.tier(), QuantizationTier::Int4);
 
@@ -730,10 +719,6 @@ mod tests {
 
     #[test]
     fn test_int4_batch_prepared_api_dispatch_parity() {
-        // Verify that approximate_int4_batch_prepared produces the same cosine distance
-        // as approximate_cosine_distance_prepared for each candidate. On aarch64 both
-        // sides dispatch to NEON; on other targets both use the packed scalar fallback.
-        // For direct scalar-vs-NEON integer parity, see int4::tests::test_packed_scalar_matches_neon_exact.
         for dim in [1usize, 3, 31, 127, 383, 384] {
             let query = generate_vector(dim, 700 + dim as u64);
             let candidate = generate_vector(dim, 800 + dim as u64);
@@ -758,18 +743,12 @@ mod tests {
     fn test_quantized_data_to_f32_roundtrip() {
         let v = generate_vector(384, 55);
 
-        // Full tier should be lossless
         let full_data = QuantizedData::from_f32(&v, QuantizationTier::Full);
         let full_rt = full_data.to_f32();
         for (a, b) in v.iter().zip(full_rt.iter()) {
             assert!((a - b).abs() < 1e-10, "Full tier should be lossless");
         }
     }
-
-    // ------------------------------------------------------------------
-    // Regression tests for issue #210: tier-mismatch in prepared SIMD
-    // dispatch must return a typed error, not panic.
-    // ------------------------------------------------------------------
 
     #[test]
     fn test_cosine_distance_prepared_tier_mismatch_returns_typed_error() {
@@ -791,7 +770,6 @@ mod tests {
             other => panic!("expected TierMismatch, got {other:?}"),
         }
 
-        // try_ alias must agree.
         assert!(try_approximate_cosine_distance_prepared(&query, &stored).is_err());
     }
 

--- a/crates/embed/src/types.rs
+++ b/crates/embed/src/types.rs
@@ -7,10 +7,6 @@
 
 use serde::{Deserialize, Serialize};
 
-// ============================================================================
-// DistanceMetric
-// ============================================================================
-
 /// Distance metric used for vector similarity search.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -45,10 +41,6 @@ impl DistanceMetric {
     }
 }
 
-// ============================================================================
-// VectorDType
-// ============================================================================
-
 /// Element data type for stored vectors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -82,10 +74,6 @@ impl VectorDType {
     }
 }
 
-// ============================================================================
-// VectorNorm
-// ============================================================================
-
 /// Normalization state of stored vectors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -106,10 +94,6 @@ impl VectorNorm {
         self as u8
     }
 }
-
-// ============================================================================
-// EmbeddingKey
-// ============================================================================
 
 /// Identifies an embedding space (model + revision + dims + metric + dtype + norm).
 ///

--- a/crates/embed/src/wasm.rs
+++ b/crates/embed/src/wasm.rs
@@ -67,7 +67,7 @@ impl LatticeEmbedder {
     }
 }
 
-// Expose the stable SIMD consumer contract to JavaScript — see docs/design.md.
+// Expose the stable SIMD contract to JavaScript.
 
 /// Dot product of two equal-length vectors via `simd::dot_product`.
 ///


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Implements Ocean's 2026-07-10 comment-hygiene directive for `crates/embed/src` only. This is comment/doc-only, with zero behavior change.

## Comment counts

- Source comment lines: 1,700 -> 1,268.
- Non-doc inline comments: 499 -> 67.
- Public/module documentation: 1,201 -> 1,201.

## Hygiene changes

- Deleted 432 lines of next-line narration, separator banners, test walkthroughs, reviewer/history labels, and comments that repeated the following code.
- Condensed retained ambiguity-reducing comments to one line: safety justifications, raw-pointer preconditions, SIMD dispatch constraints, packed-vector padding, numerical fallback behavior, and persistence compatibility.
- Extracted background: no new extraction was needed; the existing crate guides already hold the long-form rationale removed from source.

## Crate docs

- New `crates/embed/docs/` files: none.
- Existing guides retained as the background references: `design.md`, `simd.md`, `model.md`, `service.md`, `migration.md`, and `backfill.md`.

## ADR candidates

- Fixed power-of-two cache sharding and rounding policy: `crates/embed/docs/design.md` (`EmbeddingCache`); consider an ADR if shard-count configurability becomes a product decision.
- Architecture-specific SIMD dispatch and numerical fallback policy: `crates/embed/docs/simd.md`; consider an ADR if backend guarantees or public precision semantics change.

No ADR was authored.

## Validation

- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p lattice-embed` (with build lock) ✅
- `cargo clippy -p lattice-embed --all-targets -- -D warnings` (with build lock) ✅
- `cargo test -p lattice-embed` (with build lock) ✅

The source-diff audit confirms comment changes and blank-line churn only.
