### PR TITLE
docs(embed): condense verbose comments

### DIFF
--- a/crates/embed/src/cache.rs
+++ b/crates/embed/src/cache.rs
@@ -370,14 +370,11 @@ mod tests {
             EmbeddingRole::Generic,
         );
 
-        // Miss
         assert!(cache.get(&key).is_none());
 
-        // Put
         let embedding = vec![0.1, 0.2, 0.3];
         cache.put(key, embedding.clone());
 
-        // Hit — returns Arc<[f32]>
         let cached = cache.get(&key).unwrap();
         assert_eq!(&*cached, &embedding[..]);
     }

--- a/crates/embed/src/model.rs
+++ b/crates/embed/src/model.rs
@@ -36,7 +36,6 @@ impl ModelProvenance {
             dt.to_rfc3339()
         };
 
-        // Create a lightweight hash from model metadata
         let hash_input = format!("{model_id}:{loaded_at_iso}:{model:?}");
         let hash = blake3::hash(hash_input.as_bytes()).to_hex().to_string();
 

--- a/crates/embed/src/service/cached.rs
+++ b/crates/embed/src/service/cached.rs
@@ -139,7 +139,6 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
         // Check cache for all texts — returns Arc<[f32]> refs (O(1) per hit)
         let cached = self.cache.get_many(&keys);
 
-        // Identify which texts need embedding
         let mut to_embed: Vec<(usize, &String)> = Vec::new();
         let mut results: Vec<Option<Vec<f32>>> = vec![None; texts.len()];
 
@@ -179,7 +178,6 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
             )));
         }
 
-        // Store in cache and populate results
         let mut cache_entries = Vec::with_capacity(to_embed.len());
         for ((i, _), embedding) in to_embed.into_iter().zip(new_embeddings.into_iter()) {
             cache_entries.push((keys[i], embedding.clone()));
@@ -187,7 +185,6 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
         }
         self.cache.put_many(cache_entries);
 
-        // Return all results
         // SAFETY: All slots are guaranteed to be Some at this point:
         // - Cached items were assigned via results[i] = Some(arc.to_vec())
         // - Non-cached items were assigned via results[i] = Some(embedding) in the loop above

--- a/crates/embed/src/simd/cosine.rs
+++ b/crates/embed/src/simd/cosine.rs
@@ -178,12 +178,10 @@ unsafe fn cosine_similarity_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
         nb3 = _mm512_fmadd_ps(b3, b3, nb3);
     }
 
-    // Combine accumulators
     let dot_vec = _mm512_add_ps(_mm512_add_ps(dot0, dot1), _mm512_add_ps(dot2, dot3));
     let na_vec = _mm512_add_ps(_mm512_add_ps(na0, na1), _mm512_add_ps(na2, na3));
     let nb_vec = _mm512_add_ps(_mm512_add_ps(nb0, nb1), _mm512_add_ps(nb2, nb3));
 
-    // Handle remainder with single-register AVX-512F loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -206,7 +204,6 @@ unsafe fn cosine_similarity_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut norm_a = horizontal_sum_avx512(na_vec) + horizontal_sum_avx512(na_remainder);
     let mut norm_b = horizontal_sum_avx512(nb_vec) + horizontal_sum_avx512(nb_remainder);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         let av = a[i];
@@ -290,7 +287,6 @@ unsafe fn cosine_similarity_avx2_unrolled(a: &[f32], b: &[f32]) -> f32 {
         nb3 = _mm256_fmadd_ps(b3, b3, nb3);
     }
 
-    // Combine accumulators
     let dot_vec = _mm256_add_ps(_mm256_add_ps(dot0, dot1), _mm256_add_ps(dot2, dot3));
     let na_vec = _mm256_add_ps(_mm256_add_ps(na0, na1), _mm256_add_ps(na2, na3));
     let nb_vec = _mm256_add_ps(_mm256_add_ps(nb0, nb1), _mm256_add_ps(nb2, nb3));
@@ -299,7 +295,6 @@ unsafe fn cosine_similarity_avx2_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut norm_a = horizontal_sum_avx2(na_vec);
     let mut norm_b = horizontal_sum_avx2(nb_vec);
 
-    // Handle remainder
     let remainder_start = chunks * CHUNK_SIZE;
     for i in remainder_start..n {
         let av = a[i];
@@ -379,7 +374,6 @@ unsafe fn cosine_similarity_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
         nb3 = vfmaq_f32(nb3, b3, b3);
     }
 
-    // Combine accumulators
     let dot_vec = vaddq_f32(vaddq_f32(dot0, dot1), vaddq_f32(dot2, dot3));
     let na_vec = vaddq_f32(vaddq_f32(na0, na1), vaddq_f32(na2, na3));
     let nb_vec = vaddq_f32(vaddq_f32(nb0, nb1), vaddq_f32(nb2, nb3));
@@ -388,7 +382,6 @@ unsafe fn cosine_similarity_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut norm_a = horizontal_sum_neon(na_vec);
     let mut norm_b = horizontal_sum_neon(nb_vec);
 
-    // Handle remainder
     let remainder_start = chunks * CHUNK_SIZE;
     for i in remainder_start..n {
         let av = a[i];
@@ -468,7 +461,6 @@ unsafe fn cosine_similarity_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
         nb3 = f32x4_add(nb3, f32x4_mul(b3, b3));
     }
 
-    // Combine accumulators
     let dot_vec = f32x4_add(f32x4_add(dot0, dot1), f32x4_add(dot2, dot3));
     let na_vec = f32x4_add(f32x4_add(na0, na1), f32x4_add(na2, na3));
     let nb_vec = f32x4_add(f32x4_add(nb0, nb1), f32x4_add(nb2, nb3));
@@ -477,7 +469,6 @@ unsafe fn cosine_similarity_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
     let mut norm_a = horizontal_sum_simd128(na_vec);
     let mut norm_b = horizontal_sum_simd128(nb_vec);
 
-    // Handle remainder
     let remainder_start = chunks * CHUNK_SIZE;
     for i in remainder_start..n {
         let av = a[i];

--- a/crates/embed/src/simd/distance.rs
+++ b/crates/embed/src/simd/distance.rs
@@ -143,7 +143,6 @@ unsafe fn squared_euclidean_distance_avx512_unrolled(a: &[f32], b: &[f32]) -> f3
     let sum_vec = _mm512_add_ps(_mm512_add_ps(sum0, sum1), _mm512_add_ps(sum2, sum3));
     let main_sum = horizontal_sum_avx512(sum_vec);
 
-    // Handle remainder with single-register AVX-512F loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -159,7 +158,6 @@ unsafe fn squared_euclidean_distance_avx512_unrolled(a: &[f32], b: &[f32]) -> f3
 
     let mut sum = main_sum + horizontal_sum_avx512(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         let diff = a[i] - b[i];
@@ -216,7 +214,6 @@ unsafe fn squared_euclidean_distance_avx2_unrolled(a: &[f32], b: &[f32]) -> f32 
     let sum_vec = _mm256_add_ps(_mm256_add_ps(sum0, sum1), _mm256_add_ps(sum2, sum3));
     let mut sum = horizontal_sum_avx2(sum_vec);
 
-    // Handle remainder
     for i in (chunks * CHUNK_SIZE)..n {
         let diff = a[i] - b[i];
         sum += diff * diff;
@@ -272,7 +269,6 @@ unsafe fn squared_euclidean_distance_neon_unrolled(a: &[f32], b: &[f32]) -> f32 
     let sum_vec = vaddq_f32(vaddq_f32(sum0, sum1), vaddq_f32(sum2, sum3));
     let mut sum = horizontal_sum_neon(sum_vec);
 
-    // Handle remainder
     for i in (chunks * CHUNK_SIZE)..n {
         let diff = a[i] - b[i];
         sum += diff * diff;
@@ -328,7 +324,6 @@ unsafe fn squared_euclidean_distance_simd128_unrolled(a: &[f32], b: &[f32]) -> f
     let sum_vec = f32x4_add(f32x4_add(sum0, sum1), f32x4_add(sum2, sum3));
     let mut sum = horizontal_sum_simd128(sum_vec);
 
-    // Handle remainder
     for i in (chunks * CHUNK_SIZE)..n {
         let diff = a[i] - b[i];
         sum += diff * diff;

--- a/crates/embed/src/simd/dot_product.rs
+++ b/crates/embed/src/simd/dot_product.rs
@@ -251,7 +251,6 @@ unsafe fn dot_product_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
 
     let main_sum = horizontal_sum_avx512(sum_vec);
 
-    // Handle remainder with single-register loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -266,7 +265,6 @@ unsafe fn dot_product_avx512_unrolled(a: &[f32], b: &[f32]) -> f32 {
 
     let mut total = main_sum + horizontal_sum_avx512(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         total += a[i] * b[i];
@@ -359,7 +357,6 @@ unsafe fn dot_product_avx2_8acc(a: &[f32], b: &[f32]) -> f32 {
 
     let sum = horizontal_sum_avx2(sum_vec);
 
-    // Handle remainder with single-vector loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -374,7 +371,6 @@ unsafe fn dot_product_avx2_8acc(a: &[f32], b: &[f32]) -> f32 {
 
     let mut total = sum + horizontal_sum_avx2(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         total += a[i] * b[i];
@@ -668,7 +664,6 @@ unsafe fn dot_product_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
 
     let mut sum = horizontal_sum_neon(sum_vec);
 
-    // Handle remainder with single-vector loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -683,7 +678,6 @@ unsafe fn dot_product_neon_unrolled(a: &[f32], b: &[f32]) -> f32 {
 
     sum += horizontal_sum_neon(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         sum += a[i] * b[i];
@@ -752,7 +746,6 @@ unsafe fn dot_product_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
 
     let mut total = horizontal_sum_simd128(sum_vec);
 
-    // Handle remainder with single-vector loop
     let main_processed = chunks * CHUNK_SIZE;
     let remaining = n - main_processed;
     let remaining_chunks = remaining / SIMD_WIDTH;
@@ -767,7 +760,6 @@ unsafe fn dot_product_simd128_unrolled(a: &[f32], b: &[f32]) -> f32 {
 
     total += horizontal_sum_simd128(remainder_sum);
 
-    // Final scalar remainder
     let scalar_start = main_processed + remaining_chunks * SIMD_WIDTH;
     for i in scalar_start..n {
         total += a[i] * b[i];

--- a/crates/embed/src/simd/mod.rs
+++ b/crates/embed/src/simd/mod.rs
@@ -17,7 +17,6 @@ mod tier;
 #[cfg(test)]
 mod tests;
 
-// Re-export public API
 pub use binary::BinaryVector;
 pub use cosine::{
     batch_cosine_one_vs_many, batch_cosine_similarity, cosine_similarity, cosine_similarity_fused,

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -501,17 +501,14 @@ pub fn approximate_cosine_distance(query_f32: &[f32], stored: &QuantizedData) ->
             1.0 - cosine_similarity(query_f32, v)
         }
         QuantizedData::Int8(q) => {
-            // Quantize query to INT8, compute via INT8 path
             let query_q = QuantizedVector::from_f32(query_f32);
             1.0 - q.cosine_similarity(&query_q)
         }
         QuantizedData::Int4(q) => {
-            // Quantize query to INT4, compute via INT4 path
             let query_q = Int4Vector::from_f32(query_f32);
             q.cosine_distance(&query_q)
         }
         QuantizedData::Binary(q) => {
-            // Quantize query to binary, compute Hamming-based approx
             let query_q = BinaryVector::from_f32(query_f32);
             q.cosine_distance_approx(&query_q)
         }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Self-check

- Doc-comment lines removed: 0 of 1,201 (0%).
- SAFETY lines removed: 0.
- Non-comment source lines changed: 0.

## Comment changes

- Condensed: none.
- Extracted: none.
- Deleted -- pure code-restating narration only:
  - crates/embed/src/cache.rs: 3 test-operation labels.
  - crates/embed/src/model.rs: 1 hash-creation label.
  - crates/embed/src/service/cached.rs: 3 result-workflow labels.
  - crates/embed/src/simd/cosine.rs: 9 repeated accumulator and remainder labels.
  - crates/embed/src/simd/distance.rs: 5 repeated remainder labels.
  - crates/embed/src/simd/dot_product.rs: 8 repeated remainder labels.
  - crates/embed/src/simd/mod.rs: 1 public re-export label.
  - crates/embed/src/simd/tier.rs: 3 tier-dispatch labels.

## New docs files

- None.

## Gates

- GREEN: RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p lattice-embed.
- GREEN: cargo clippy -p lattice-embed --all-targets -- -D warnings.
- GREEN: cargo test -p lattice-embed.