### PR TITLE
docs(fann): condense verbose comments

### DIFF
--- a/crates/fann/src/activation.rs
+++ b/crates/fann/src/activation.rs
@@ -54,7 +54,6 @@ unsafe fn simd_relu_neon(values: &mut [f32]) {
         vst1q_f32(p.add(offset), result);
         offset += 4;
     }
-    // Scalar tail
     for i in offset..n {
         let val = *p.add(i);
         if val < 0.0 {
@@ -85,7 +84,6 @@ unsafe fn simd_relu_avx2(values: &mut [f32]) {
         _mm256_storeu_ps(p.add(offset), result);
         offset += 8;
     }
-    // Scalar tail
     for i in offset..n {
         let val = *p.add(i);
         if val < 0.0 {
@@ -124,7 +122,6 @@ unsafe fn simd_leaky_relu_neon(values: &mut [f32], alpha: f32) {
         vst1q_f32(p.add(offset), result);
         offset += 4;
     }
-    // Scalar tail
     for i in offset..n {
         let val = *p.add(i);
         if val < 0.0 {
@@ -163,7 +160,6 @@ unsafe fn simd_leaky_relu_avx2(values: &mut [f32], alpha: f32) {
         _mm256_storeu_ps(p.add(offset), result);
         offset += 8;
     }
-    // Scalar tail
     for i in offset..n {
         let val = *p.add(i);
         if val < 0.0 {

--- a/crates/fann/src/gpu/buffer.rs
+++ b/crates/fann/src/gpu/buffer.rs
@@ -225,7 +225,6 @@ impl BufferPool {
         let aligned_size = align_size(size as usize, BUFFER_ALIGNMENT) as u64;
         let category = BufferCategory::from_size(aligned_size as usize);
 
-        // Try to reuse from pool
         if let Some(mut buffer) = self.try_reuse(aligned_size, usage, category) {
             buffer.mark_used();
             self.stats.cache_hits.fetch_add(1, Ordering::Relaxed);
@@ -234,7 +233,6 @@ impl BufferPool {
 
         self.stats.cache_misses.fetch_add(1, Ordering::Relaxed);
 
-        // Allocate new buffer
         let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label,
             size: aligned_size,

--- a/crates/fann/src/gpu/context.rs
+++ b/crates/fann/src/gpu/context.rs
@@ -158,7 +158,6 @@ impl GpuContext {
                 _ => 256,       // Maximize throughput for element-wise
             }
         } else {
-            // Generic defaults
             match operation {
                 "matmul" => 64,
                 _ => 256,
@@ -261,7 +260,6 @@ mod tests {
     #[test]
     #[cfg_attr(not(feature = "gpu-tests"), ignore = "requires GPU hardware")]
     fn test_context_creation() {
-        // Skip if no GPU
         if !super::super::is_gpu_available() {
             println!("Skipping GPU test - no GPU available");
             return;

--- a/crates/fann/src/gpu/shader_manager.rs
+++ b/crates/fann/src/gpu/shader_manager.rs
@@ -115,7 +115,6 @@ impl ShaderManager {
     pub fn with_warmup(device: Arc<wgpu::Device>) -> GpuResult<Self> {
         let manager = Self::new(device);
 
-        // Precompile common inference shaders
         let warmup_shaders = [
             ShaderType::MatrixVectorMultiply,
             ShaderType::MatrixVectorMultiplyRelu,

--- a/crates/fann/src/layer.rs
+++ b/crates/fann/src/layer.rs
@@ -471,7 +471,6 @@ impl Layer {
         // weights is row-major: weights[out_idx * num_inputs + in_idx]
         self.matmul_add(input, output);
 
-        // Apply activation
         self.activation.forward_batch(output);
 
         Ok(())

--- a/crates/fann/src/lib.rs
+++ b/crates/fann/src/lib.rs
@@ -20,7 +20,6 @@ pub mod training;
 #[cfg(feature = "gpu")]
 pub mod gpu;
 
-// Re-exports
 pub use activation::Activation;
 pub use error::{FannError, FannResult};
 pub use layer::Layer;
@@ -49,7 +48,6 @@ mod tests {
 
     #[test]
     fn test_full_workflow() {
-        // Build network
         let mut network = NetworkBuilder::new()
             .input(4)
             .hidden(8, Activation::ReLU)
@@ -58,12 +56,10 @@ mod tests {
             .build()
             .unwrap();
 
-        // Verify architecture
         assert_eq!(network.num_inputs(), 4);
         assert_eq!(network.num_outputs(), 2);
         assert_eq!(network.num_layers(), 3);
 
-        // Run inference
         let input = [1.0, 2.0, 3.0, 4.0];
         let output = network.forward(&input).unwrap();
 
@@ -88,12 +84,10 @@ mod tests {
 
         let input: Vec<f32> = (0..128).map(|i| i as f32 / 128.0).collect();
 
-        // Warm up
         for _ in 0..10 {
             network.forward(&input).unwrap();
         }
 
-        // Benchmark
         let iterations = 1000;
         let start = Instant::now();
         for _ in 0..iterations {
@@ -118,7 +112,6 @@ mod tests {
 
         let input = [1.0, 2.0, 3.0, 4.0];
 
-        // Run multiple times
         let output1 = network.forward(&input).unwrap().to_vec();
         let output2 = network.forward(&input).unwrap().to_vec();
 

--- a/crates/fann/src/network/serialization.rs
+++ b/crates/fann/src/network/serialization.rs
@@ -17,22 +17,16 @@ impl Network {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 
-        // Magic number "FANN"
         bytes.extend_from_slice(b"FANN");
 
-        // Version (1)
         bytes.extend_from_slice(&1u32.to_le_bytes());
 
-        // Number of layers
         bytes.extend_from_slice(&(self.layers().len() as u32).to_le_bytes());
 
-        // Each layer
         for layer in self.layers() {
-            // Dimensions
             bytes.extend_from_slice(&(layer.num_inputs() as u32).to_le_bytes());
             bytes.extend_from_slice(&(layer.num_outputs() as u32).to_le_bytes());
 
-            // Activation type
             match layer.activation() {
                 Activation::Linear => bytes.push(0),
                 Activation::Sigmoid => bytes.push(1),
@@ -45,12 +39,10 @@ impl Network {
                 Activation::Softmax => bytes.push(5),
             }
 
-            // Weights
             for &w in layer.weights() {
                 bytes.extend_from_slice(&w.to_le_bytes());
             }
 
-            // Biases
             for &b in layer.biases() {
                 bytes.extend_from_slice(&b.to_le_bytes());
             }
@@ -325,8 +317,6 @@ mod tests {
             assert!((orig - rest).abs() < 1e-6);
         }
     }
-
-    // ── FIX 2: bounds-before-allocation + trailing-bytes tests ──────────────
 
     /// A header with num_layers = 0xFFFFFFFF and a short buffer must return
     /// Err(FannError::InvalidBuilder) without attempting any large allocation.

--- a/crates/fann/src/training/backprop.rs
+++ b/crates/fann/src/training/backprop.rs
@@ -53,8 +53,7 @@ impl BackpropTrainer {
         let output: Vec<f32> = network.forward(input)?.to_vec();
         let output_len = output.len();
 
-        // After forward returns, reborrow network immutably.
-        // Reference layers and activations directly — no cloning needed.
+        // Reborrow immutably to reference layer data without cloning.
         let layers = network.layers();
 
         // Compute output error (MSE derivative)

--- a/crates/fann/src/training/rloo.rs
+++ b/crates/fann/src/training/rloo.rs
@@ -289,9 +289,7 @@ impl RlooTrainer {
         output_deltas: &[f32],
         num_layers: usize,
     ) -> FannResult<()> {
-        // --- Phase 1: compute all layer deltas and accumulate gradients ---
-        // Both gate.layers() and gate.activations() are &self borrows and may
-        // coexist simultaneously; they are released before the mutable apply phase.
+        // Shared borrows end before the mutable update phase.
         let (weight_grads, bias_grads) = {
             // Start with the output-layer delta (from caller).
             let mut deltas: Vec<Vec<f32>> = Vec::with_capacity(num_layers);


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Self-check:
- Doc-comment lines removed: 0 of 674 (0%).
- Removed `SAFETY` lines: 0.
- Non-comment changed lines: 0.

Comment hygiene:
- Condensed: four borrow-lifetime narration lines into two one-line notes in the training implementations.
- Extracted: none; no remaining background prose justified a new crate docs file.
- Deleted: 26 pure code-restating narration lines and one reviewer/process heading.
- New `docs/` files: none.

Gates green:
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p lattice-fann`
- `cargo clippy -p lattice-fann --all-targets -- -D warnings`
- `cargo test -p lattice-fann` (80 unit, 5 property, and 8 shader tests passed)