### PR TITLE
feat(inference): Gemma 4 BPE tokenizer parity with HF goldens (ADR-082 stage 1)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -8,6 +8,7 @@
 # `target/`, so the exclusion is explicit rather than incidental.
 extend-exclude = [
     "crates/inference/tests/fixtures/tokenizers/**",
+    "crates/inference/tests/fixtures/gemma4/tokenizer/**",
     "crates/inference/benchmarks/golden_logits/**",
     "crates/embed/tests/fixtures/**",
     "docs/bench_results/**",

--- a/crates/inference/src/lib.rs
+++ b/crates/inference/src/lib.rs
@@ -176,7 +176,9 @@ pub use crate::tokenizer::tokenizer_from_json_str;
 /// Stage-1 marker-expansion arithmetic (ADR-082 G11/G15/G17): `<|image|>`/`<|audio|>`
 /// placeholder-to-soft-token-count contract, independent of the in-sequence scatter itself.
 pub use crate::tokenizer::{
-    GEMMA4_AUDIO_MAX_SOFT_TOKENS, GEMMA4_AUDIO_MS_PER_SOFT_TOKEN,
+    GEMMA4_AUDIO_FRAME_LENGTH_SAMPLES, GEMMA4_AUDIO_HOP_LENGTH_SAMPLES,
+    GEMMA4_AUDIO_MAX_SOFT_TOKENS, GEMMA4_AUDIO_MS_PER_SOFT_TOKEN, GEMMA4_AUDIO_SAMPLING_RATE_HZ,
     GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE, audio_marker_expansion_tokens,
-    image_marker_expansion_tokens, total_audio_marker_expansion_tokens,
+    audio_marker_expansion_tokens_from_samples, image_marker_expansion_tokens,
+    total_audio_marker_expansion_tokens,
 };

--- a/crates/inference/src/lib.rs
+++ b/crates/inference/src/lib.rs
@@ -154,6 +154,10 @@ pub use crate::pool::BertPooling;
 pub use crate::stop_reason::StopReason;
 /// Byte-level BPE tokenizer used by Qwen-family models. See [`Tokenizer`] and [`TokenizedInput`].
 pub use crate::tokenizer::BpeTokenizer;
+/// Additive Gemma-family BPE tokenizer (literal-space `Split` + `▁` metaspace normalizer),
+/// explicitly selected — never reached via [`load_tokenizer`]'s model-type sniffing. See
+/// [`Tokenizer`] and ADR-082 G17.
+pub use crate::tokenizer::GemmaBpeTokenizer;
 /// `SentencePiece` tokenizer implementation. See [`Tokenizer`] and [`TokenizedInput`].
 pub use crate::tokenizer::SentencePieceTokenizer;
 /// Padded token IDs and the real (unpadded) sequence length returned by tokenizers. See

--- a/crates/inference/src/lib.rs
+++ b/crates/inference/src/lib.rs
@@ -173,3 +173,10 @@ pub use crate::tokenizer::load_tokenizer;
 /// `tokenizer.json`-text tokenizer loader (no filesystem access). See
 /// [`Tokenizer`], [`tokenizer`], and [`BertModel::from_bytes`].
 pub use crate::tokenizer::tokenizer_from_json_str;
+/// Stage-1 marker-expansion arithmetic (ADR-082 G11/G15/G17): `<|image|>`/`<|audio|>`
+/// placeholder-to-soft-token-count contract, independent of the in-sequence scatter itself.
+pub use crate::tokenizer::{
+    GEMMA4_AUDIO_MAX_SOFT_TOKENS, GEMMA4_AUDIO_MS_PER_SOFT_TOKEN,
+    GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE, audio_marker_expansion_tokens,
+    image_marker_expansion_tokens, total_audio_marker_expansion_tokens,
+};

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -839,7 +839,12 @@ fn parse_merges_txt(text: &str) -> Vec<(String, String)> {
     merges
 }
 
-fn parse_merges_json(value: &JsonValue) -> Result<Vec<(String, String)>, InferenceError> {
+/// Shared with the additive Gemma BPE path (`tokenizer::gemma_bpe`), which
+/// parses the same `tokenizer.json` `model.merges` shape but builds its own
+/// merge-rank table and pretokenization pipeline; see ADR-082 G17.
+pub(crate) fn parse_merges_json(
+    value: &JsonValue,
+) -> Result<Vec<(String, String)>, InferenceError> {
     let array = value.as_array().ok_or_else(|| {
         InferenceError::Tokenizer("expected tokenizer.json model.merges array".into())
     })?;

--- a/crates/inference/src/tokenizer/gemma_bpe.rs
+++ b/crates/inference/src/tokenizer/gemma_bpe.rs
@@ -1,0 +1,527 @@
+//! Gemma 4 BPE tokenizer: literal-space `Split` pre-tokenizer + `▁` (U+2581)
+//! metaspace-style normalizer, per the target `tokenizer.json` read for
+//! ADR-082 G17.
+//!
+//! This is an **additive, explicitly-selected** path — `GemmaBpeTokenizer`
+//! is never reached through [`crate::tokenizer::common::load_tokenizer`] or
+//! [`crate::tokenizer::common::tokenizer_from_json_str`]; callers construct
+//! it directly. The existing Qwen-oriented [`crate::tokenizer::BpeTokenizer`]
+//! loader's `validate_bpe_pretokenizer` continues to reject Gemma's
+//! `tokenizer.json` (a literal-string `Split`, not a regex `Split`/
+//! `ByteLevel`), which proves this path is additive rather than a silent
+//! widening of the existing loader — see
+//! `tests/gemma4_tokenizer_goldens_test.rs`.
+//!
+//! Pipeline, read directly from the target `tokenizer.json`
+//! (`google/gemma-4-E2B-it` @ `9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf`):
+//!
+//! - `normalizer`: `Replace(" " -> "▁")` — a literal replace, with no
+//!   dummy-prefix insertion and no leading/trailing-whitespace stripping
+//!   (unlike this crate's SentencePiece Unigram path).
+//! - `pre_tokenizer`: `Split(pattern=" ", behavior=MergedWithPrevious)` — a
+//!   literal-string split. Because the normalizer has already consumed every
+//!   space, this never fires in practice: the whole normalized string is one
+//!   pre-token, matching the empirically observed behavior (`"a  b   c"` ->
+//!   `["a", "▁▁", "b", "▁▁▁", "c"]`, i.e. the BPE merge algorithm — not
+//!   pre-tokenization — decides where multi-`▁` runs group).
+//! - `model`: `BPE` with `byte_fallback: true`, `fuse_unk: true`, no
+//!   `continuing_subword_prefix`/`end_of_word_suffix`. Initial symbols are
+//!   per-Unicode-scalar: a character present in `vocab` as its own token
+//!   starts as that token; otherwise its UTF-8 bytes each become individual
+//!   `<0xXX>` byte-fallback tokens (verified: `\u{10300}` -> four
+//!   single-byte tokens). No merge rule ever pairs two byte-fallback tokens
+//!   in the target vocab, so once introduced they never re-merge.
+//! - `decoder`: `Sequence[Replace("▁" -> " "), ByteFallback, Fuse]`.
+
+use crate::error::InferenceError;
+use crate::tokenizer::bpe::parse_merges_json;
+use crate::tokenizer::common::{
+    JsonValue, TokenizedInput, Tokenizer, invert_vocab, json_object_to_vocab, json_path,
+    known_special_id, pad_ids, parse_added_tokens, parse_json, parse_rendered_added_tokens,
+};
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+/// U+2581 LOWER ONE EIGHTH BLOCK, used by SentencePiece-descended tokenizers
+/// as a metaspace marker for the literal ASCII space.
+const METASPACE: char = '\u{2581}';
+const DEFAULT_MAX_SEQ_LEN: usize = 4_096;
+
+/// **Unstable**: additive Gemma-family byte-level BPE tokenizer; API evolving.
+/// See the module docs for why this is a separate type from
+/// [`crate::tokenizer::BpeTokenizer`].
+#[derive(Debug, Clone)]
+pub struct GemmaBpeTokenizer {
+    inner: Arc<GemmaBpeInner>,
+}
+
+#[derive(Debug, Clone)]
+struct GemmaBpeInner {
+    vocab: HashMap<String, u32>,
+    id_to_token: Vec<String>,
+    merges: HashMap<String, HashMap<String, usize>>,
+    special_tokens: HashMap<String, u32>,
+    special_tokens_sorted: Vec<String>,
+    /// Rendered decode text for added tokens with `special=false`. Empty for
+    /// the target checkpoint (all 24 added tokens are `special=true`), kept
+    /// for shape parity with the general loading contract.
+    added_render: HashMap<u32, String>,
+    /// Added-token ids with `special=true`: dropped on decode, matching
+    /// `skip_special_tokens=True` (HF `tokenizers` default).
+    special_skip_ids: HashSet<u32>,
+    pad_id: u32,
+    unk_id: Option<u32>,
+    max_seq_len: usize,
+}
+
+#[derive(Debug, Clone)]
+struct MergeNode {
+    token: String,
+    prev: Option<usize>,
+    next: Option<usize>,
+    alive: bool,
+    version: u64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct MergeCandidate {
+    rank: usize,
+    left: usize,
+    right: usize,
+    left_version: u64,
+    right_version: u64,
+}
+
+impl Ord for MergeCandidate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .rank
+            .cmp(&self.rank)
+            .then_with(|| other.left.cmp(&self.left))
+            .then_with(|| other.right.cmp(&self.right))
+    }
+}
+
+impl PartialOrd for MergeCandidate {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl GemmaBpeTokenizer {
+    /// **Unstable**: load from a Hugging Face `tokenizer.json` file.
+    /// Selected explicitly by the caller — never reached via
+    /// [`crate::tokenizer::common::load_tokenizer`]'s model-type sniffing.
+    pub fn from_tokenizer_json(path: &Path) -> Result<Self, InferenceError> {
+        let text = fs::read_to_string(path).map_err(|e| {
+            InferenceError::Tokenizer(format!("failed to read {}: {e}", path.display()))
+        })?;
+        Self::from_tokenizer_json_str(&text)
+    }
+
+    /// **Unstable**: load from a Hugging Face `tokenizer.json` string.
+    ///
+    /// Fails closed if the declared `model.type`, `normalizer`, or
+    /// `pre_tokenizer` do not match the Gemma shape this path was built
+    /// against (see module docs) — this constructor makes an explicit
+    /// structural claim about its input, rather than best-effort adapting.
+    pub fn from_tokenizer_json_str(text: &str) -> Result<Self, InferenceError> {
+        let root = parse_json(text)?;
+        validate_gemma_bpe_shape(&root)?;
+
+        let vocab =
+            json_object_to_vocab(json_path(&root, &["model", "vocab"]).ok_or_else(|| {
+                InferenceError::Tokenizer("tokenizer.json missing model.vocab".into())
+            })?)?;
+        let id_to_token = invert_vocab(&vocab)?;
+
+        let merges_value = json_path(&root, &["model", "merges"]).ok_or_else(|| {
+            InferenceError::Tokenizer("tokenizer.json missing model.merges".into())
+        })?;
+        let merges_list = parse_merges_json(merges_value)?;
+        let mut merge_ranks: HashMap<String, HashMap<String, usize>> = HashMap::new();
+        for (rank, (left, right)) in merges_list.into_iter().enumerate() {
+            merge_ranks
+                .entry(left)
+                .or_default()
+                .entry(right)
+                .or_insert(rank);
+        }
+
+        let mut added = parse_added_tokens(&root);
+        added.retain(|name, _| !name.is_empty());
+        let rendered_added = parse_rendered_added_tokens(&root);
+        let added_render: HashMap<u32, String> = rendered_added
+            .iter()
+            .map(|(content, &id)| (id, content.clone()))
+            .collect();
+        let rendered_ids: HashSet<u32> = rendered_added.values().copied().collect();
+        let special_skip_ids: HashSet<u32> = added
+            .values()
+            .copied()
+            .filter(|id| !rendered_ids.contains(id))
+            .collect();
+
+        let mut special_tokens = added;
+        for name in ["<pad>", "<eos>", "<bos>", "<unk>", "<mask>"] {
+            if let Some(&id) = vocab.get(name) {
+                special_tokens.entry(name.to_string()).or_insert(id);
+            }
+        }
+        let mut special_tokens_sorted: Vec<String> = special_tokens.keys().cloned().collect();
+        special_tokens_sorted.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+
+        let pad_id = known_special_id(&vocab, &["<pad>"]).unwrap_or(0);
+        let unk_id = known_special_id(&vocab, &["<unk>"]);
+
+        Ok(Self {
+            inner: Arc::new(GemmaBpeInner {
+                vocab,
+                id_to_token,
+                merges: merge_ranks,
+                special_tokens,
+                special_tokens_sorted,
+                added_render,
+                special_skip_ids,
+                pad_id,
+                unk_id,
+                max_seq_len: DEFAULT_MAX_SEQ_LEN,
+            }),
+        })
+    }
+
+    /// **Unstable**: override the configured maximum sequence length.
+    pub fn with_max_seq_len(self, max_seq_len: usize) -> Self {
+        let mut inner = (*self.inner).clone();
+        inner.max_seq_len = max_seq_len;
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    fn tokenize_to_ids(&self, text: &str) -> Vec<u32> {
+        let mut ids = Vec::new();
+        let mut segment_start = 0usize;
+        let mut pos = 0usize;
+        while pos < text.len() {
+            if let Some((special_end, special_id)) = self.match_special(text, pos) {
+                if segment_start < pos {
+                    self.encode_segment(&text[segment_start..pos], &mut ids);
+                }
+                ids.push(special_id);
+                pos = special_end;
+                segment_start = pos;
+                continue;
+            }
+            let ch = text[pos..]
+                .chars()
+                .next()
+                .expect("invariant: pos is inside non-empty UTF-8 text");
+            pos += ch.len_utf8();
+        }
+        if segment_start < text.len() {
+            self.encode_segment(&text[segment_start..], &mut ids);
+        }
+        if ids.len() > self.inner.max_seq_len {
+            ids.truncate(self.inner.max_seq_len);
+        }
+        ids
+    }
+
+    fn match_special(&self, text: &str, pos: usize) -> Option<(usize, u32)> {
+        let tail = &text[pos..];
+        for token in &self.inner.special_tokens_sorted {
+            if tail.starts_with(token.as_str())
+                && let Some(&id) = self.inner.special_tokens.get(token)
+            {
+                return Some((pos + token.len(), id));
+            }
+        }
+        None
+    }
+
+    /// Normalize (space -> ▁), split into initial BPE symbols (char, or
+    /// per-byte fallback for a char absent from `vocab`), then merge.
+    fn encode_segment(&self, text: &str, out: &mut Vec<u32>) {
+        if text.is_empty() {
+            return;
+        }
+        let mut symbols: Vec<String> = Vec::with_capacity(text.len());
+        for ch in text.chars() {
+            let mapped = if ch == ' ' { METASPACE } else { ch };
+            let single = mapped.to_string();
+            if self.inner.vocab.contains_key(single.as_str()) {
+                symbols.push(single);
+                continue;
+            }
+            let mut buf = [0u8; 4];
+            for &byte in mapped.encode_utf8(&mut buf).as_bytes() {
+                symbols.push(byte_fallback_token(byte));
+            }
+        }
+
+        for token in self.bpe_merge(symbols) {
+            if let Some(&id) = self.inner.vocab.get(token.as_str()) {
+                out.push(id);
+            } else if let Some(unk_id) = self.inner.unk_id {
+                out.push(unk_id);
+            }
+        }
+    }
+
+    fn merge_rank(&self, left: &str, right: &str) -> Option<usize> {
+        self.inner
+            .merges
+            .get(left)
+            .and_then(|inner| inner.get(right))
+            .copied()
+    }
+
+    fn push_candidate(
+        &self,
+        nodes: &[MergeNode],
+        heap: &mut BinaryHeap<MergeCandidate>,
+        left: usize,
+    ) {
+        let Some(right) = nodes[left].next else {
+            return;
+        };
+        if !nodes[left].alive || !nodes[right].alive {
+            return;
+        }
+        let Some(rank) = self.merge_rank(nodes[left].token.as_str(), nodes[right].token.as_str())
+        else {
+            return;
+        };
+        heap.push(MergeCandidate {
+            rank,
+            left,
+            right,
+            left_version: nodes[left].version,
+            right_version: nodes[right].version,
+        });
+    }
+
+    /// Same rank-priority-queue merge algorithm as
+    /// [`crate::tokenizer::bpe::BpeTokenizer::bpe_merge`], adapted to merge
+    /// pre-built symbol strings (chars or `<0xXX>` byte-fallback tokens)
+    /// instead of `chars()` of a byte-remapped word — Gemma's vocab holds
+    /// literal UTF-8 pieces, not GPT-2 byte-remapped ones, so a byte
+    /// fallback symbol is multiple bytes wide and can't be a `char`.
+    fn bpe_merge(&self, symbols: Vec<String>) -> Vec<String> {
+        let mut nodes: Vec<MergeNode> = symbols
+            .into_iter()
+            .enumerate()
+            .map(|(idx, token)| MergeNode {
+                token,
+                prev: idx.checked_sub(1),
+                next: None,
+                alive: true,
+                version: 0,
+            })
+            .collect();
+
+        if nodes.is_empty() {
+            return Vec::new();
+        }
+        for idx in 0..nodes.len().saturating_sub(1) {
+            nodes[idx].next = Some(idx + 1);
+        }
+
+        let mut heap = BinaryHeap::new();
+        for idx in 0..nodes.len().saturating_sub(1) {
+            self.push_candidate(&nodes, &mut heap, idx);
+        }
+
+        while let Some(candidate) = heap.pop() {
+            if candidate.left >= nodes.len() || candidate.right >= nodes.len() {
+                continue;
+            }
+            let left = &nodes[candidate.left];
+            let right = &nodes[candidate.right];
+            if !left.alive
+                || !right.alive
+                || left.next != Some(candidate.right)
+                || left.version != candidate.left_version
+                || right.version != candidate.right_version
+            {
+                continue;
+            }
+
+            let right_next = nodes[candidate.right].next;
+            let right_token = nodes[candidate.right].token.clone();
+            nodes[candidate.left].token.push_str(right_token.as_str());
+            nodes[candidate.left].version = nodes[candidate.left].version.wrapping_add(1);
+            nodes[candidate.left].next = right_next;
+
+            if let Some(next) = right_next {
+                nodes[next].prev = Some(candidate.left);
+            }
+
+            nodes[candidate.right].alive = false;
+            nodes[candidate.right].version = nodes[candidate.right].version.wrapping_add(1);
+
+            if let Some(prev) = nodes[candidate.left].prev {
+                self.push_candidate(&nodes, &mut heap, prev);
+            }
+            self.push_candidate(&nodes, &mut heap, candidate.left);
+        }
+
+        let mut first = 0usize;
+        while first < nodes.len() && !nodes[first].alive {
+            first += 1;
+        }
+        if first >= nodes.len() {
+            return Vec::new();
+        }
+
+        let mut out = Vec::new();
+        let mut current = Some(first);
+        while let Some(idx) = current {
+            if nodes[idx].alive {
+                out.push(nodes[idx].token.clone());
+            }
+            current = nodes[idx].next;
+        }
+        out
+    }
+
+    fn token_bytes_for(&self, id: u32, out: &mut Vec<u8>) {
+        if self.inner.special_skip_ids.contains(&id) {
+            return;
+        }
+        if let Some(content) = self.inner.added_render.get(&id) {
+            out.extend_from_slice(content.as_bytes());
+            return;
+        }
+        let Some(tok) = self.inner.id_to_token.get(id as usize) else {
+            return;
+        };
+        if tok.is_empty() {
+            return;
+        }
+        if let Some(byte) = parse_byte_fallback_token(tok) {
+            out.push(byte);
+            return;
+        }
+        for ch in tok.chars() {
+            if ch == METASPACE {
+                out.push(b' ');
+            } else {
+                let mut buf = [0u8; 4];
+                out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            }
+        }
+    }
+}
+
+impl Tokenizer for GemmaBpeTokenizer {
+    fn tokenize(&self, text: &str) -> TokenizedInput {
+        let ids = self.tokenize_to_ids(text);
+        pad_ids(ids, self.inner.max_seq_len, self.inner.pad_id)
+    }
+
+    fn tokenize_batch(&self, texts: &[&str]) -> Vec<TokenizedInput> {
+        if texts.is_empty() {
+            return Vec::new();
+        }
+        let mut max_len = 0usize;
+        let mut all = Vec::with_capacity(texts.len());
+        for text in texts {
+            let ids = self.tokenize_to_ids(text);
+            max_len = max_len.max(ids.len());
+            all.push(ids);
+        }
+        all.into_iter()
+            .map(|ids| pad_ids(ids, max_len, self.inner.pad_id))
+            .collect()
+    }
+
+    fn decode(&self, ids: &[u32]) -> Option<String> {
+        let mut bytes = Vec::new();
+        for &id in ids {
+            self.token_bytes_for(id, &mut bytes);
+        }
+        Some(String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    fn vocab_size(&self) -> usize {
+        self.inner.id_to_token.len()
+    }
+
+    fn max_seq_len(&self) -> usize {
+        self.inner.max_seq_len
+    }
+}
+
+fn byte_fallback_token(byte: u8) -> String {
+    format!("<0x{byte:02X}>")
+}
+
+/// Parses a `<0xXX>` byte-fallback token back into its raw byte, or `None`
+/// if `tok` is not in that exact shape (2 uppercase hex digits).
+fn parse_byte_fallback_token(tok: &str) -> Option<u8> {
+    let hex = tok.strip_prefix("<0x")?.strip_suffix('>')?;
+    if hex.len() != 2 {
+        return None;
+    }
+    u8::from_str_radix(hex, 16).ok()
+}
+
+/// Fails closed if `root` does not match the Gemma tokenizer shape this
+/// path was built against (ADR-082 G17): `model.type == "BPE"`,
+/// `model.byte_fallback == true`, a `Replace(" " -> "▁")` normalizer, and a
+/// literal-string `Split` pre-tokenizer (not a regex `Split`, which is the
+/// shape the existing Qwen loader accepts).
+fn validate_gemma_bpe_shape(root: &JsonValue) -> Result<(), InferenceError> {
+    let model_type = json_path(root, &["model", "type"])
+        .and_then(JsonValue::as_str)
+        .unwrap_or("");
+    if model_type != "BPE" {
+        return Err(InferenceError::Tokenizer(format!(
+            "GemmaBpeTokenizer expects tokenizer.json model.type == \"BPE\", found {model_type:?}"
+        )));
+    }
+
+    let byte_fallback = json_path(root, &["model", "byte_fallback"])
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(false);
+    if !byte_fallback {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects tokenizer.json model.byte_fallback == true".into(),
+        ));
+    }
+
+    let normalizer = root.get("normalizer");
+    let is_gemma_normalizer = normalizer.is_some_and(|n| {
+        n.get("type").and_then(JsonValue::as_str) == Some("Replace")
+            && json_path(n, &["pattern", "String"]).and_then(JsonValue::as_str) == Some(" ")
+            && n.get("content").and_then(JsonValue::as_str) == Some("\u{2581}")
+    });
+    if !is_gemma_normalizer {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects a Replace(\" \" -> \"\u{2581}\") normalizer; \
+             tokenizer.json declares a different shape, refusing to guess"
+                .into(),
+        ));
+    }
+
+    let pre_tokenizer = root.get("pre_tokenizer");
+    let is_gemma_pretokenizer = pre_tokenizer.is_some_and(|pt| {
+        pt.get("type").and_then(JsonValue::as_str) == Some("Split")
+            && json_path(pt, &["pattern", "String"]).is_some()
+    });
+    if !is_gemma_pretokenizer {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects a literal-string Split pre_tokenizer \
+             (pattern.String, not pattern.Regex); tokenizer.json declares a \
+             different shape, refusing to guess"
+                .into(),
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/inference/src/tokenizer/gemma_bpe.rs
+++ b/crates/inference/src/tokenizer/gemma_bpe.rs
@@ -565,37 +565,58 @@ fn validate_gemma_bpe_shape(root: &JsonValue) -> Result<(), InferenceError> {
         ));
     }
 
-    let decoder = root.get("decoder");
-    let is_gemma_decoder = decoder.is_some_and(|d| {
-        d.get("type").and_then(JsonValue::as_str) == Some("Sequence")
-            && d.get("decoders")
-                .and_then(JsonValue::as_array)
-                .is_some_and(is_gemma_decoder_sequence)
-    });
-    if !is_gemma_decoder {
+    let decoders = root
+        .get("decoder")
+        .filter(|d| d.get("type").and_then(JsonValue::as_str) == Some("Sequence"))
+        .and_then(|d| d.get("decoders"))
+        .and_then(JsonValue::as_array);
+    let Some(decoders) = decoders else {
         return Err(InferenceError::Tokenizer(
             "GemmaBpeTokenizer expects decoder == Sequence[Replace(\"\u{2581}\" -> \
-             \" \"), ByteFallback, Fuse] in exactly that order; tokenizer.json \
+             \" \"), ByteFallback, Fuse]; tokenizer.json declares a different \
+             shape, refusing to guess"
+                .into(),
+        ));
+    };
+    validate_gemma_decoder_sequence(decoders)?;
+
+    let model = root.get("model").unwrap_or(&JsonValue::Null);
+    if !is_null_or_absent(model.get("dropout")) {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects model.dropout == null (this loader \
+             always applies BPE merges); tokenizer.json declares a different \
+             shape, refusing to guess"
+                .into(),
+        ));
+    }
+    if !is_null_or_absent(model.get("continuing_subword_prefix")) {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects model.continuing_subword_prefix == null \
+             (this loader never affix-wraps a subword); tokenizer.json declares \
+             a different shape, refusing to guess"
+                .into(),
+        ));
+    }
+    if !is_null_or_absent(model.get("end_of_word_suffix")) {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects model.end_of_word_suffix == null (this \
+             loader never affix-wraps a subword); tokenizer.json declares a \
+             different shape, refusing to guess"
+                .into(),
+        ));
+    }
+    if model.get("fuse_unk").and_then(JsonValue::as_bool) != Some(true) {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects model.fuse_unk == true; tokenizer.json \
              declares a different shape, refusing to guess"
                 .into(),
         ));
     }
-
-    let model = root.get("model");
-    let model_matches_assumed_shape = model.is_some_and(|m| {
-        is_null_or_absent(m.get("dropout"))
-            && is_null_or_absent(m.get("continuing_subword_prefix"))
-            && is_null_or_absent(m.get("end_of_word_suffix"))
-            && m.get("fuse_unk").and_then(JsonValue::as_bool) == Some(true)
-            && m.get("ignore_merges").and_then(JsonValue::as_bool) == Some(false)
-    });
-    if !model_matches_assumed_shape {
+    if model.get("ignore_merges").and_then(JsonValue::as_bool) != Some(false) {
         return Err(InferenceError::Tokenizer(
-            "GemmaBpeTokenizer expects model.dropout/continuing_subword_prefix/\
-             end_of_word_suffix == null, model.fuse_unk == true, and \
-             model.ignore_merges == false (this loader always applies BPE \
-             merges and never affix-wraps a subword); tokenizer.json declares \
-             a different shape, refusing to guess"
+            "GemmaBpeTokenizer expects model.ignore_merges == false (this \
+             loader always applies BPE merges); tokenizer.json declares a \
+             different shape, refusing to guess"
                 .into(),
         ));
     }
@@ -610,21 +631,57 @@ fn is_null_or_absent(value: Option<&JsonValue>) -> bool {
     matches!(value, None | Some(JsonValue::Null))
 }
 
-/// `true` if `decoders` is exactly `[Replace("\u{2581}" -> " "), ByteFallback, Fuse]`
-/// in that order — the declared decoder sequence this loader's run-based
-/// byte-fallback decode (see [`flush_byte_fallback_run`]) is built against.
-fn is_gemma_decoder_sequence(decoders: &[JsonValue]) -> bool {
+/// Fails closed unless `decoders` is exactly `[Replace("\u{2581}" -> " "),
+/// ByteFallback, Fuse]` in that order — the declared decoder sequence this
+/// loader's run-based byte-fallback decode (see [`flush_byte_fallback_run`])
+/// is built against. Each mismatch names the specific stage/field so a
+/// rejection is attributable to the exact declared shape that diverged.
+fn validate_gemma_decoder_sequence(decoders: &[JsonValue]) -> Result<(), InferenceError> {
     let [replace, byte_fallback, fuse] = decoders else {
-        return false;
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects exactly three decoder stages \
+             [Replace, ByteFallback, Fuse]; tokenizer.json declares a \
+             different shape, refusing to guess"
+                .into(),
+        ));
     };
-    let is_replace = replace.get("type").and_then(JsonValue::as_str) == Some("Replace")
-        && json_path(replace, &["pattern", "String"]).and_then(JsonValue::as_str)
-            == Some("\u{2581}")
-        && replace.get("content").and_then(JsonValue::as_str) == Some(" ");
-    let is_byte_fallback =
-        byte_fallback.get("type").and_then(JsonValue::as_str) == Some("ByteFallback");
-    let is_fuse = fuse.get("type").and_then(JsonValue::as_str) == Some("Fuse");
-    is_replace && is_byte_fallback && is_fuse
+    if replace.get("type").and_then(JsonValue::as_str) != Some("Replace") {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects decoder[0].type == \"Replace\"; \
+             tokenizer.json declares a different shape, refusing to guess"
+                .into(),
+        ));
+    }
+    if json_path(replace, &["pattern", "String"]).and_then(JsonValue::as_str) != Some("\u{2581}") {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects decoder[0].pattern.String == \
+             \"\u{2581}\"; tokenizer.json declares a different shape, \
+             refusing to guess"
+                .into(),
+        ));
+    }
+    if replace.get("content").and_then(JsonValue::as_str) != Some(" ") {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects decoder[0].content == \" \"; \
+             tokenizer.json declares a different shape, refusing to guess"
+                .into(),
+        ));
+    }
+    if byte_fallback.get("type").and_then(JsonValue::as_str) != Some("ByteFallback") {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects decoder[1].type == \"ByteFallback\"; \
+             tokenizer.json declares a different shape, refusing to guess"
+                .into(),
+        ));
+    }
+    if fuse.get("type").and_then(JsonValue::as_str) != Some("Fuse") {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects decoder[2].type == \"Fuse\"; \
+             tokenizer.json declares a different shape, refusing to guess"
+                .into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Vision soft tokens per `<|image|>` placeholder (ADR-082 G11): the

--- a/crates/inference/src/tokenizer/gemma_bpe.rs
+++ b/crates/inference/src/tokenizer/gemma_bpe.rs
@@ -784,7 +784,7 @@ pub fn audio_marker_expansion_tokens_from_samples(num_samples: u32) -> u32 {
 /// for callers that only have a duration in milliseconds: converts to a
 /// sample count at [`GEMMA4_AUDIO_SAMPLING_RATE_HZ`] — mirroring HF's own
 /// `_get_num_multimodal_tokens`, which reads `audio_lengths` in samples
-/// "assum[ing] default sampling rate" — before applying the exact
+/// assuming the default sampling rate — before applying the exact
 /// post-subsampling arithmetic.
 pub fn audio_marker_expansion_tokens(duration_ms: u32) -> u32 {
     let num_samples = u64::from(duration_ms) * u64::from(GEMMA4_AUDIO_SAMPLING_RATE_HZ) / 1000;

--- a/crates/inference/src/tokenizer/gemma_bpe.rs
+++ b/crates/inference/src/tokenizer/gemma_bpe.rs
@@ -124,10 +124,12 @@ impl GemmaBpeTokenizer {
 
     /// **Unstable**: load from a Hugging Face `tokenizer.json` string.
     ///
-    /// Fails closed if the declared `model.type`, `normalizer`, or
-    /// `pre_tokenizer` do not match the Gemma shape this path was built
-    /// against (see module docs) — this constructor makes an explicit
-    /// structural claim about its input, rather than best-effort adapting.
+    /// Fails closed if the declared `model.type`, `normalizer`,
+    /// `pre_tokenizer`, `decoder`, or the `model` fields the encode/decode
+    /// logic depends on do not match the Gemma shape this path was built
+    /// against (see [`validate_gemma_bpe_shape`] and the module docs) — this
+    /// constructor makes an explicit structural claim about its input,
+    /// rather than best-effort adapting.
     pub fn from_tokenizer_json_str(text: &str) -> Result<Self, InferenceError> {
         let root = parse_json(text)?;
         validate_gemma_bpe_shape(&root)?;
@@ -389,12 +391,20 @@ impl GemmaBpeTokenizer {
         out
     }
 
-    fn token_bytes_for(&self, id: u32, out: &mut Vec<u8>) {
+    /// Appends the decoded text for one non-fallback token (`id`) to `out`,
+    /// first flushing any pending byte-fallback run. Mirrors the pinned HF
+    /// `tokenizers` decoder sequence `Replace -> ByteFallback -> Fuse`: the
+    /// `Replace("▁" -> " ")` step runs per-token here, and any
+    /// `<0xXX>` run is flushed (as its own `ByteFallback` step) before this
+    /// token's text is appended, so token order — not raw byte order — is
+    /// preserved across a run boundary.
+    fn append_token(&self, id: u32, pending_fallback: &mut Vec<u8>, out: &mut String) {
         if self.inner.special_skip_ids.contains(&id) {
             return;
         }
         if let Some(content) = self.inner.added_render.get(&id) {
-            out.extend_from_slice(content.as_bytes());
+            flush_byte_fallback_run(pending_fallback, out);
+            out.push_str(content);
             return;
         }
         let Some(tok) = self.inner.id_to_token.get(id as usize) else {
@@ -404,15 +414,35 @@ impl GemmaBpeTokenizer {
             return;
         }
         if let Some(byte) = parse_byte_fallback_token(tok) {
-            out.push(byte);
+            pending_fallback.push(byte);
             return;
         }
+        flush_byte_fallback_run(pending_fallback, out);
         for ch in tok.chars() {
             if ch == METASPACE {
-                out.push(b' ');
+                out.push(' ');
             } else {
-                let mut buf = [0u8; 4];
-                out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+                out.push(ch);
+            }
+        }
+    }
+}
+
+/// Flushes a run of consecutive byte-fallback bytes accumulated across
+/// `<0xXX>` tokens, per the HF `tokenizers` v0.22.2 `ByteFallback` decoder
+/// (`decoders/byte_fallback.rs`): a valid UTF-8 run decodes as one string:
+/// an invalid run emits exactly one U+FFFD per byte in the run — never
+/// `str::from_utf8_lossy`'s maximal-subpart replacement, which can collapse
+/// several invalid bytes into a single U+FFFD and under-count HF's output.
+fn flush_byte_fallback_run(pending: &mut Vec<u8>, out: &mut String) {
+    if pending.is_empty() {
+        return;
+    }
+    match String::from_utf8(std::mem::take(pending)) {
+        Ok(valid) => out.push_str(&valid),
+        Err(err) => {
+            for _ in 0..err.into_bytes().len() {
+                out.push('\u{FFFD}');
             }
         }
     }
@@ -441,11 +471,13 @@ impl Tokenizer for GemmaBpeTokenizer {
     }
 
     fn decode(&self, ids: &[u32]) -> Option<String> {
-        let mut bytes = Vec::new();
+        let mut out = String::new();
+        let mut pending_fallback: Vec<u8> = Vec::new();
         for &id in ids {
-            self.token_bytes_for(id, &mut bytes);
+            self.append_token(id, &mut pending_fallback, &mut out);
         }
-        Some(String::from_utf8_lossy(&bytes).into_owned())
+        flush_byte_fallback_run(&mut pending_fallback, &mut out);
+        Some(out)
     }
 
     fn vocab_size(&self) -> usize {
@@ -472,10 +504,17 @@ fn parse_byte_fallback_token(tok: &str) -> Option<u8> {
 }
 
 /// Fails closed if `root` does not match the Gemma tokenizer shape this
-/// path was built against (ADR-082 G17): `model.type == "BPE"`,
-/// `model.byte_fallback == true`, a `Replace(" " -> "▁")` normalizer, and a
-/// literal-string `Split` pre-tokenizer (not a regex `Split`, which is the
-/// shape the existing Qwen loader accepts).
+/// path was built against (ADR-082 G17): `model.type == "BPE"`, a
+/// `Replace(" " -> "▁")` normalizer, a literal-string `Split` pre-tokenizer
+/// with the exact `pattern.String == " "` / `behavior ==
+/// "MergedWithPrevious"` / `invert == false` fields this loader's encode
+/// path assumes (not a regex `Split`, which is the shape the existing Qwen
+/// loader accepts), the exact `decoder == Sequence[Replace, ByteFallback,
+/// Fuse]` order the run-based decode in this module is built against, and
+/// the `model.{dropout,continuing_subword_prefix,end_of_word_suffix,
+/// fuse_unk,byte_fallback,ignore_merges}` fields the BPE merge/fallback
+/// logic depends on. Every field this constructor does *not* check is
+/// exactly the set this loader's encode/decode logic never reads.
 fn validate_gemma_bpe_shape(root: &JsonValue) -> Result<(), InferenceError> {
     let model_type = json_path(root, &["model", "type"])
         .and_then(JsonValue::as_str)
@@ -512,16 +551,133 @@ fn validate_gemma_bpe_shape(root: &JsonValue) -> Result<(), InferenceError> {
     let pre_tokenizer = root.get("pre_tokenizer");
     let is_gemma_pretokenizer = pre_tokenizer.is_some_and(|pt| {
         pt.get("type").and_then(JsonValue::as_str) == Some("Split")
-            && json_path(pt, &["pattern", "String"]).is_some()
+            && json_path(pt, &["pattern", "String"]).and_then(JsonValue::as_str) == Some(" ")
+            && pt.get("behavior").and_then(JsonValue::as_str) == Some("MergedWithPrevious")
+            && pt.get("invert").and_then(JsonValue::as_bool) == Some(false)
     });
     if !is_gemma_pretokenizer {
         return Err(InferenceError::Tokenizer(
             "GemmaBpeTokenizer expects a literal-string Split pre_tokenizer \
-             (pattern.String, not pattern.Regex); tokenizer.json declares a \
-             different shape, refusing to guess"
+             (pattern.String == \" \", behavior == \"MergedWithPrevious\", \
+             invert == false); tokenizer.json declares a different shape, \
+             refusing to guess"
+                .into(),
+        ));
+    }
+
+    let decoder = root.get("decoder");
+    let is_gemma_decoder = decoder.is_some_and(|d| {
+        d.get("type").and_then(JsonValue::as_str) == Some("Sequence")
+            && d.get("decoders")
+                .and_then(JsonValue::as_array)
+                .is_some_and(is_gemma_decoder_sequence)
+    });
+    if !is_gemma_decoder {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects decoder == Sequence[Replace(\"\u{2581}\" -> \
+             \" \"), ByteFallback, Fuse] in exactly that order; tokenizer.json \
+             declares a different shape, refusing to guess"
+                .into(),
+        ));
+    }
+
+    let model = root.get("model");
+    let model_matches_assumed_shape = model.is_some_and(|m| {
+        is_null_or_absent(m.get("dropout"))
+            && is_null_or_absent(m.get("continuing_subword_prefix"))
+            && is_null_or_absent(m.get("end_of_word_suffix"))
+            && m.get("fuse_unk").and_then(JsonValue::as_bool) == Some(true)
+            && m.get("ignore_merges").and_then(JsonValue::as_bool) == Some(false)
+    });
+    if !model_matches_assumed_shape {
+        return Err(InferenceError::Tokenizer(
+            "GemmaBpeTokenizer expects model.dropout/continuing_subword_prefix/\
+             end_of_word_suffix == null, model.fuse_unk == true, and \
+             model.ignore_merges == false (this loader always applies BPE \
+             merges and never affix-wraps a subword); tokenizer.json declares \
+             a different shape, refusing to guess"
                 .into(),
         ));
     }
 
     Ok(())
+}
+
+/// `true` if `value` is absent or JSON `null` — used for model fields this
+/// loader assumes are unset (`dropout`, `continuing_subword_prefix`,
+/// `end_of_word_suffix`) rather than silently ignoring a populated one.
+fn is_null_or_absent(value: Option<&JsonValue>) -> bool {
+    matches!(value, None | Some(JsonValue::Null))
+}
+
+/// `true` if `decoders` is exactly `[Replace("\u{2581}" -> " "), ByteFallback, Fuse]`
+/// in that order — the declared decoder sequence this loader's run-based
+/// byte-fallback decode (see [`flush_byte_fallback_run`]) is built against.
+fn is_gemma_decoder_sequence(decoders: &[JsonValue]) -> bool {
+    let [replace, byte_fallback, fuse] = decoders else {
+        return false;
+    };
+    let is_replace = replace.get("type").and_then(JsonValue::as_str) == Some("Replace")
+        && json_path(replace, &["pattern", "String"]).and_then(JsonValue::as_str)
+            == Some("\u{2581}")
+        && replace.get("content").and_then(JsonValue::as_str) == Some(" ");
+    let is_byte_fallback =
+        byte_fallback.get("type").and_then(JsonValue::as_str) == Some("ByteFallback");
+    let is_fuse = fuse.get("type").and_then(JsonValue::as_str) == Some("Fuse");
+    is_replace && is_byte_fallback && is_fuse
+}
+
+/// Vision soft tokens per `<|image|>` placeholder (ADR-082 G11): the
+/// `google/gemma-4-E2B-it` processor's default image-token budget, read
+/// from the pinned checkpoint's `processor_config.json`
+/// (`image_processor.image_seq_length` / `.max_soft_tokens`, both `280`) —
+/// see `scripts/gemma4_tokenizer_goldens.py`'s `expansion_goldens.json`
+/// output and `tests/fixtures/gemma4/tokenizer/processor_config.json`.
+pub const GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE: u32 = 280;
+
+/// Milliseconds of audio collapsed into one `<|audio|>` soft token
+/// (ADR-082 G15), read from the pinned checkpoint's
+/// `processor_config.json` (`audio_ms_per_token`).
+pub const GEMMA4_AUDIO_MS_PER_SOFT_TOKEN: u32 = 40;
+
+/// Upper bound on audio soft tokens for a single `<|audio|>` placeholder
+/// (ADR-082 G15; ≈ the card's 30 s audio limit), read from the pinned
+/// checkpoint's `processor_config.json` (`audio_seq_length`).
+pub const GEMMA4_AUDIO_MAX_SOFT_TOKENS: u32 = 750;
+
+/// Stage-1 marker-expansion arithmetic (ADR-082 G11/G15/G17): the number of
+/// vision soft tokens `image_marker_count` `<|image|>` placeholders expand
+/// to. Each placeholder expands to the fixed
+/// [`GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE`] budget — this is the processor's
+/// default image-token count, not a per-image-resolution computation (that
+/// resolution-dependent variant, and the actual in-sequence scatter, are
+/// Stage 5/6 scope per ADR-082's stage table).
+pub fn image_marker_expansion_tokens(image_marker_count: usize) -> usize {
+    image_marker_count * GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE as usize
+}
+
+/// Stage-1 marker-expansion arithmetic (ADR-082 G11/G15/G17): the number of
+/// audio soft tokens one `<|audio|>` placeholder expands to, given its
+/// audio segment's duration in milliseconds —
+/// `ceil(duration_ms / GEMMA4_AUDIO_MS_PER_SOFT_TOKEN)`, capped at
+/// [`GEMMA4_AUDIO_MAX_SOFT_TOKENS`]. This is HF `Gemma4Processor`'s own
+/// documented placeholder-count contract; the mel-framing + two-stride-2-Conv
+/// subsampling arithmetic `_compute_audio_num_tokens` mirrors to land on the
+/// same count from a raw waveform is Stage 9 (audio end-to-end) scope, not
+/// Stage 1's.
+pub fn audio_marker_expansion_tokens(duration_ms: u32) -> u32 {
+    duration_ms
+        .div_ceil(GEMMA4_AUDIO_MS_PER_SOFT_TOKEN)
+        .min(GEMMA4_AUDIO_MAX_SOFT_TOKENS)
+}
+
+/// Total audio soft tokens across every `<|audio|>` placeholder's duration
+/// (one entry per marker, in encounter order); see
+/// [`audio_marker_expansion_tokens`].
+pub fn total_audio_marker_expansion_tokens(durations_ms: &[u32]) -> usize {
+    durations_ms
+        .iter()
+        .copied()
+        .map(|ms| audio_marker_expansion_tokens(ms) as usize)
+        .sum()
 }

--- a/crates/inference/src/tokenizer/gemma_bpe.rs
+++ b/crates/inference/src/tokenizer/gemma_bpe.rs
@@ -635,15 +635,33 @@ fn is_gemma_decoder_sequence(decoders: &[JsonValue]) -> bool {
 /// output and `tests/fixtures/gemma4/tokenizer/processor_config.json`.
 pub const GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE: u32 = 280;
 
-/// Milliseconds of audio collapsed into one `<|audio|>` soft token
-/// (ADR-082 G15), read from the pinned checkpoint's
-/// `processor_config.json` (`audio_ms_per_token`).
+/// Milliseconds of audio nominally collapsed into one `<|audio|>` soft
+/// token (ADR-082 G15), read from the pinned checkpoint's
+/// `processor_config.json` (`audio_ms_per_token`). This is the processor's
+/// own documented nominal rate, kept here as a cross-checked provenance
+/// constant; the actual per-segment token count is the exact post-
+/// subsampling arithmetic in [`audio_marker_expansion_tokens_from_samples`],
+/// not a direct division by this constant (see that function's doc comment
+/// for why a plain `ceil(duration_ms / 40)` disagrees with HF at valid
+/// durations).
 pub const GEMMA4_AUDIO_MS_PER_SOFT_TOKEN: u32 = 40;
 
 /// Upper bound on audio soft tokens for a single `<|audio|>` placeholder
 /// (ADR-082 G15; ≈ the card's 30 s audio limit), read from the pinned
 /// checkpoint's `processor_config.json` (`audio_seq_length`).
 pub const GEMMA4_AUDIO_MAX_SOFT_TOKENS: u32 = 750;
+
+/// Sampling rate (Hz) the pinned checkpoint's audio front end assumes, read
+/// from `processor_config.json`'s `feature_extractor.sampling_rate`.
+pub const GEMMA4_AUDIO_SAMPLING_RATE_HZ: u32 = 16_000;
+
+/// Mel-frame analysis window length in samples, read from
+/// `processor_config.json`'s `feature_extractor.frame_length`.
+pub const GEMMA4_AUDIO_FRAME_LENGTH_SAMPLES: u32 = 320;
+
+/// Mel-frame hop length in samples, read from `processor_config.json`'s
+/// `feature_extractor.hop_length`.
+pub const GEMMA4_AUDIO_HOP_LENGTH_SAMPLES: u32 = 160;
 
 /// Stage-1 marker-expansion arithmetic (ADR-082 G11/G15/G17): the number of
 /// vision soft tokens `image_marker_count` `<|image|>` placeholders expand
@@ -656,19 +674,64 @@ pub fn image_marker_expansion_tokens(image_marker_count: usize) -> usize {
     image_marker_count * GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE as usize
 }
 
-/// Stage-1 marker-expansion arithmetic (ADR-082 G11/G15/G17): the number of
-/// audio soft tokens one `<|audio|>` placeholder expands to, given its
-/// audio segment's duration in milliseconds —
-/// `ceil(duration_ms / GEMMA4_AUDIO_MS_PER_SOFT_TOKEN)`, capped at
-/// [`GEMMA4_AUDIO_MAX_SOFT_TOKENS`]. This is HF `Gemma4Processor`'s own
-/// documented placeholder-count contract; the mel-framing + two-stride-2-Conv
-/// subsampling arithmetic `_compute_audio_num_tokens` mirrors to land on the
-/// same count from a raw waveform is Stage 9 (audio end-to-end) scope, not
-/// Stage 1's.
-pub fn audio_marker_expansion_tokens(duration_ms: u32) -> u32 {
-    duration_ms
-        .div_ceil(GEMMA4_AUDIO_MS_PER_SOFT_TOKEN)
+/// Stage-1 marker-expansion arithmetic (ADR-082 G11/G15/G17): the exact
+/// number of audio soft tokens one `<|audio|>` placeholder expands to for a
+/// `num_samples`-sample raw waveform, mirroring HF
+/// `Gemma4Processor._compute_audio_num_tokens` bit-for-bit (transformers @
+/// `ab1771c9e42891d893189978a8009426d70b4688`,
+/// `src/transformers/models/gemma4/processing_gemma4.py:260-298`):
+///
+/// 1. Mel-frame count from the feature extractor's semicausal framing —
+///    `frame_size_for_unfold = frame_length + 1`, `pad_left = frame_length /
+///    2`, `num_mel_frames = floor((num_samples + pad_left -
+///    frame_size_for_unfold) / hop_length) + 1`, clamped to zero if
+///    non-positive.
+/// 2. Two stride-2 `Conv2d` subsampling reductions
+///    (`Gemma4AudioSubSampleConvProjection`; kernel=3, stride=2, padding=1 —
+///    architectural constants transcribed from the pinned source, not
+///    exposed via `Gemma4AudioConfig`): `t = floor((t + 2*padding - kernel) /
+///    stride) + 1`, applied twice.
+/// 3. Capped at [`GEMMA4_AUDIO_MAX_SOFT_TOKENS`].
+///
+/// A plain `ceil(duration_ms / GEMMA4_AUDIO_MS_PER_SOFT_TOKEN)` disagrees
+/// with this at valid durations — e.g. at 16 kHz a 41 ms clip is 656
+/// samples -> 4 mel frames -> 2 -> 1 soft token, not `ceil(41/40) = 2`; a
+/// 1-10 ms clip is 0 mel frames -> 0 soft tokens, not 1.
+pub fn audio_marker_expansion_tokens_from_samples(num_samples: u32) -> u32 {
+    let frame_size_for_unfold = i64::from(GEMMA4_AUDIO_FRAME_LENGTH_SAMPLES) + 1;
+    let pad_left = i64::from(GEMMA4_AUDIO_FRAME_LENGTH_SAMPLES / 2);
+    let hop = i64::from(GEMMA4_AUDIO_HOP_LENGTH_SAMPLES);
+
+    let mel_frame_numerator = i64::from(num_samples) + pad_left - frame_size_for_unfold;
+    let num_mel_frames = mel_frame_numerator.div_euclid(hop) + 1;
+    if num_mel_frames <= 0 {
+        return 0;
+    }
+
+    const SSCP_KERNEL: i64 = 3;
+    const SSCP_STRIDE: i64 = 2;
+    const SSCP_PADDING: i64 = 1;
+    const SSCP_LAYERS: u32 = 2;
+
+    let mut t = num_mel_frames;
+    for _ in 0..SSCP_LAYERS {
+        t = (t + 2 * SSCP_PADDING - SSCP_KERNEL).div_euclid(SSCP_STRIDE) + 1;
+    }
+
+    u32::try_from(t)
+        .unwrap_or(0)
         .min(GEMMA4_AUDIO_MAX_SOFT_TOKENS)
+}
+
+/// Convenience wrapper over [`audio_marker_expansion_tokens_from_samples`]
+/// for callers that only have a duration in milliseconds: converts to a
+/// sample count at [`GEMMA4_AUDIO_SAMPLING_RATE_HZ`] — mirroring HF's own
+/// `_get_num_multimodal_tokens`, which reads `audio_lengths` in samples
+/// "assum[ing] default sampling rate" — before applying the exact
+/// post-subsampling arithmetic.
+pub fn audio_marker_expansion_tokens(duration_ms: u32) -> u32 {
+    let num_samples = u64::from(duration_ms) * u64::from(GEMMA4_AUDIO_SAMPLING_RATE_HZ) / 1000;
+    audio_marker_expansion_tokens_from_samples(u32::try_from(num_samples).unwrap_or(u32::MAX))
 }
 
 /// Total audio soft tokens across every `<|audio|>` placeholder's duration

--- a/crates/inference/src/tokenizer/mod.rs
+++ b/crates/inference/src/tokenizer/mod.rs
@@ -1,6 +1,7 @@
 //! Tokenizer module index and re-exports for WordPiece, BPE, common tokenizer types/loaders, and SentencePiece.
 pub mod bpe;
 pub mod common;
+pub mod gemma_bpe;
 pub mod sentencepiece;
 pub mod wordpiece;
 
@@ -9,4 +10,5 @@ pub use self::wordpiece::*;
 // Re-export key types from other tokenizer modules
 pub use self::bpe::BpeTokenizer;
 pub use self::common::{TokenizedInput, Tokenizer, load_tokenizer, tokenizer_from_json_str};
+pub use self::gemma_bpe::GemmaBpeTokenizer;
 pub use self::sentencepiece::SentencePieceTokenizer;

--- a/crates/inference/src/tokenizer/mod.rs
+++ b/crates/inference/src/tokenizer/mod.rs
@@ -11,8 +11,10 @@ pub use self::wordpiece::*;
 pub use self::bpe::BpeTokenizer;
 pub use self::common::{TokenizedInput, Tokenizer, load_tokenizer, tokenizer_from_json_str};
 pub use self::gemma_bpe::{
-    GEMMA4_AUDIO_MAX_SOFT_TOKENS, GEMMA4_AUDIO_MS_PER_SOFT_TOKEN,
+    GEMMA4_AUDIO_FRAME_LENGTH_SAMPLES, GEMMA4_AUDIO_HOP_LENGTH_SAMPLES,
+    GEMMA4_AUDIO_MAX_SOFT_TOKENS, GEMMA4_AUDIO_MS_PER_SOFT_TOKEN, GEMMA4_AUDIO_SAMPLING_RATE_HZ,
     GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE, GemmaBpeTokenizer, audio_marker_expansion_tokens,
-    image_marker_expansion_tokens, total_audio_marker_expansion_tokens,
+    audio_marker_expansion_tokens_from_samples, image_marker_expansion_tokens,
+    total_audio_marker_expansion_tokens,
 };
 pub use self::sentencepiece::SentencePieceTokenizer;

--- a/crates/inference/src/tokenizer/mod.rs
+++ b/crates/inference/src/tokenizer/mod.rs
@@ -10,5 +10,9 @@ pub use self::wordpiece::*;
 // Re-export key types from other tokenizer modules
 pub use self::bpe::BpeTokenizer;
 pub use self::common::{TokenizedInput, Tokenizer, load_tokenizer, tokenizer_from_json_str};
-pub use self::gemma_bpe::GemmaBpeTokenizer;
+pub use self::gemma_bpe::{
+    GEMMA4_AUDIO_MAX_SOFT_TOKENS, GEMMA4_AUDIO_MS_PER_SOFT_TOKEN,
+    GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE, GemmaBpeTokenizer, audio_marker_expansion_tokens,
+    image_marker_expansion_tokens, total_audio_marker_expansion_tokens,
+};
 pub use self::sentencepiece::SentencePieceTokenizer;

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/chat_template.jinja
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/chat_template.jinja
@@ -1,0 +1,360 @@
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'image' -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') == 'audio' -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '<|image|>' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '<|video|>' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif not (ns_tr_out.flag and not has_content) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/chat_template_golden.json
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/chat_template_golden.json
@@ -1,0 +1,44 @@
+{
+  "description": "2-turn conversation (user, assistant), add_generation_prompt=True",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the capital of France?"
+    },
+    {
+      "role": "assistant",
+      "content": "The capital of France is Paris."
+    }
+  ],
+  "rendered_text": "<bos><|turn>user\nWhat is the capital of France?<turn|>\n<|turn>model\nThe capital of France is Paris.<turn|>\n<|turn>model\n",
+  "ids": [
+    2,
+    105,
+    2364,
+    107,
+    3689,
+    563,
+    506,
+    5279,
+    529,
+    7001,
+    236881,
+    106,
+    107,
+    105,
+    4368,
+    107,
+    818,
+    5279,
+    529,
+    7001,
+    563,
+    9079,
+    236761,
+    106,
+    107,
+    105,
+    4368,
+    107
+  ]
+}

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/corpus_goldens.json
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/corpus_goldens.json
@@ -1,0 +1,570 @@
+[
+  {
+    "id": "ascii_ordinary",
+    "category": "text",
+    "text": "The quick brown fox jumps over the lazy dog.",
+    "ids": [
+      818,
+      3823,
+      8864,
+      37423,
+      38167,
+      1024,
+      506,
+      31770,
+      4799,
+      236761
+    ],
+    "tokens": [
+      "The",
+      "▁quick",
+      "▁brown",
+      "▁fox",
+      "▁jumps",
+      "▁over",
+      "▁the",
+      "▁lazy",
+      "▁dog",
+      "."
+    ],
+    "decoded": "The quick brown fox jumps over the lazy dog."
+  },
+  {
+    "id": "ascii_punctuation",
+    "category": "text",
+    "text": "Hello, world! How are you? (fine, thanks) -- 100% sure.",
+    "ids": [
+      9259,
+      236764,
+      1902,
+      236888,
+      2088,
+      659,
+      611,
+      236881,
+      568,
+      35022,
+      236764,
+      8863,
+      236768,
+      2617,
+      236743,
+      236770,
+      236771,
+      236771,
+      236908,
+      2889,
+      236761
+    ],
+    "tokens": [
+      "Hello",
+      ",",
+      "▁world",
+      "!",
+      "▁How",
+      "▁are",
+      "▁you",
+      "?",
+      "▁(",
+      "fine",
+      ",",
+      "▁thanks",
+      ")",
+      "▁--",
+      "▁",
+      "1",
+      "0",
+      "0",
+      "%",
+      "▁sure",
+      "."
+    ],
+    "decoded": "Hello, world! How are you? (fine, thanks) -- 100% sure."
+  },
+  {
+    "id": "unicode_cjk",
+    "category": "unicode",
+    "text": "短い日本語のテストです。今日は良い天気ですね。",
+    "ids": [
+      209499,
+      94951,
+      236945,
+      88733,
+      3652,
+      236924,
+      90082,
+      32485,
+      228212,
+      31875,
+      236924
+    ],
+    "tokens": [
+      "短い",
+      "日本語",
+      "の",
+      "テスト",
+      "です",
+      "。",
+      "今日は",
+      "良い",
+      "天気",
+      "ですね",
+      "。"
+    ],
+    "decoded": "短い日本語のテストです。今日は良い天気ですね。"
+  },
+  {
+    "id": "unicode_emoji",
+    "category": "unicode",
+    "text": "Great job! 😀🚀🎉 family: 👨‍👩‍👧",
+    "ids": [
+      20418,
+      3195,
+      236888,
+      163543,
+      242015,
+      242061,
+      2523,
+      236787,
+      236743,
+      243874,
+      237243,
+      243767,
+      237243,
+      244814
+    ],
+    "tokens": [
+      "Great",
+      "▁job",
+      "!",
+      "▁😀",
+      "🚀",
+      "🎉",
+      "▁family",
+      ":",
+      "▁",
+      "👨",
+      "‍",
+      "👩",
+      "‍",
+      "👧"
+    ],
+    "decoded": "Great job! 😀🚀🎉 family: 👨‍👩‍👧"
+  },
+  {
+    "id": "unicode_combining",
+    "category": "unicode",
+    "text": "combining: é vs é (decomposed e + U+0301 vs precomposed)",
+    "ids": [
+      20024,
+      4049,
+      236787,
+      545,
+      238288,
+      7728,
+      1559,
+      568,
+      893,
+      138107,
+      545,
+      900,
+      749,
+      236862,
+      236771,
+      236800,
+      236771,
+      236770,
+      7728,
+      877,
+      138107,
+      236768
+    ],
+    "tokens": [
+      "comb",
+      "ining",
+      ":",
+      "▁e",
+      "́",
+      "▁vs",
+      "▁é",
+      "▁(",
+      "de",
+      "composed",
+      "▁e",
+      "▁+",
+      "▁U",
+      "+",
+      "0",
+      "3",
+      "0",
+      "1",
+      "▁vs",
+      "▁pre",
+      "composed",
+      ")"
+    ],
+    "decoded": "combining: é vs é (decomposed e + U+0301 vs precomposed)"
+  },
+  {
+    "id": "unicode_mixed",
+    "category": "unicode",
+    "text": "Café résumé naïve façade -- 日本語 mixed with emoji 😀",
+    "ids": [
+      160319,
+      236859,
+      118515,
+      120362,
+      96008,
+      2617,
+      33375,
+      238582,
+      9726,
+      607,
+      64334,
+      163543
+    ],
+    "tokens": [
+      "Caf",
+      "é",
+      "▁résumé",
+      "▁naïve",
+      "▁façade",
+      "▁--",
+      "▁日本",
+      "語",
+      "▁mixed",
+      "▁with",
+      "▁emoji",
+      "▁😀"
+    ],
+    "decoded": "Café résumé naïve façade -- 日本語 mixed with emoji 😀"
+  },
+  {
+    "id": "whitespace_multi_space",
+    "category": "whitespace",
+    "text": "a  b   c    d",
+    "ids": [
+      236746,
+      138,
+      236763,
+      139,
+      236755,
+      140,
+      236753
+    ],
+    "tokens": [
+      "a",
+      "▁▁",
+      "b",
+      "▁▁▁",
+      "c",
+      "▁▁▁▁",
+      "d"
+    ],
+    "decoded": "a  b   c    d"
+  },
+  {
+    "id": "whitespace_tabs_newlines",
+    "category": "whitespace",
+    "text": "line1\tcol2\nline2\n\nline4",
+    "ids": [
+      1257,
+      236770,
+      255968,
+      1475,
+      236778,
+      107,
+      1257,
+      236778,
+      108,
+      1257,
+      236812
+    ],
+    "tokens": [
+      "line",
+      "1",
+      "\t",
+      "col",
+      "2",
+      "\n",
+      "line",
+      "2",
+      "\n\n",
+      "line",
+      "4"
+    ],
+    "decoded": "line1\tcol2\nline2\n\nline4"
+  },
+  {
+    "id": "whitespace_leading_trailing",
+    "category": "whitespace",
+    "text": "   leading and trailing spaces   ",
+    "ids": [
+      139,
+      26016,
+      532,
+      45330,
+      9952,
+      139
+    ],
+    "tokens": [
+      "▁▁▁",
+      "leading",
+      "▁and",
+      "▁trailing",
+      "▁spaces",
+      "▁▁▁"
+    ],
+    "decoded": "   leading and trailing spaces   "
+  },
+  {
+    "id": "whitespace_only",
+    "category": "whitespace",
+    "text": "   ",
+    "ids": [
+      139
+    ],
+    "tokens": [
+      "▁▁▁"
+    ],
+    "decoded": "   "
+  },
+  {
+    "id": "empty",
+    "category": "whitespace",
+    "text": "",
+    "ids": [],
+    "tokens": [],
+    "decoded": ""
+  },
+  {
+    "id": "byte_fallback_rare_char",
+    "category": "byte_fallback",
+    "text": "rare: 𐌀 old italic letter",
+    "ids": [
+      43128,
+      236787,
+      236743,
+      478,
+      382,
+      378,
+      366,
+      2255,
+      103147,
+      6064
+    ],
+    "tokens": [
+      "rare",
+      ":",
+      "▁",
+      "<0xF0>",
+      "<0x90>",
+      "<0x8C>",
+      "<0x80>",
+      "▁old",
+      "▁italic",
+      "▁letter"
+    ],
+    "decoded": "rare: 𐌀 old italic letter"
+  },
+  {
+    "id": "byte_fallback_private_use",
+    "category": "byte_fallback",
+    "text": "pua:  chars",
+    "ids": [
+      236758,
+      3271,
+      236787,
+      236743,
+      245863,
+      247368,
+      56256
+    ],
+    "tokens": [
+      "p",
+      "ua",
+      ":",
+      "▁",
+      "",
+      "",
+      "▁chars"
+    ],
+    "decoded": "pua:  chars"
+  },
+  {
+    "id": "byte_fallback_replacement_char",
+    "category": "byte_fallback",
+    "text": "bad: � sequence",
+    "ids": [
+      15242,
+      236787,
+      58588,
+      7501
+    ],
+    "tokens": [
+      "bad",
+      ":",
+      "▁�",
+      "▁sequence"
+    ],
+    "decoded": "bad: � sequence"
+  },
+  {
+    "id": "marker_image",
+    "category": "marker",
+    "text": "<|image|>",
+    "ids": [
+      258880
+    ],
+    "tokens": [
+      "<|image|>"
+    ],
+    "decoded": ""
+  },
+  {
+    "id": "marker_audio",
+    "category": "marker",
+    "text": "<|audio|>",
+    "ids": [
+      258881
+    ],
+    "tokens": [
+      "<|audio|>"
+    ],
+    "decoded": ""
+  },
+  {
+    "id": "marker_image_audio_combo",
+    "category": "marker",
+    "text": "<|image|> describe this <|audio|> transcribe this",
+    "ids": [
+      258880,
+      9779,
+      672,
+      236743,
+      258881,
+      226476,
+      672
+    ],
+    "tokens": [
+      "<|image|>",
+      "▁describe",
+      "▁this",
+      "▁",
+      "<|audio|>",
+      "▁transcribe",
+      "▁this"
+    ],
+    "decoded": " describe this  transcribe this"
+  },
+  {
+    "id": "marker_boi_eoi",
+    "category": "marker",
+    "text": "<|image>content<image|>",
+    "ids": [
+      255999,
+      3955,
+      258882
+    ],
+    "tokens": [
+      "<|image>",
+      "content",
+      "<image|>"
+    ],
+    "decoded": "content"
+  },
+  {
+    "id": "marker_boa_eoa",
+    "category": "marker",
+    "text": "<|audio>content<audio|>",
+    "ids": [
+      256000,
+      3955,
+      258883
+    ],
+    "tokens": [
+      "<|audio>",
+      "content",
+      "<audio|>"
+    ],
+    "decoded": "content"
+  },
+  {
+    "id": "marker_video",
+    "category": "marker",
+    "text": "<|video|>",
+    "ids": [
+      258884
+    ],
+    "tokens": [
+      "<|video|>"
+    ],
+    "decoded": ""
+  },
+  {
+    "id": "thought_tool_markers",
+    "category": "marker",
+    "text": "<|think|><|channel>thought\nreasoning\n<channel|><|turn>model\nanswer<turn|><|tool>declaration<tool|><|tool_call>call:foo{}<tool_call|><|tool_response>response:foo{}<tool_response|>",
+    "ids": [
+      98,
+      100,
+      45518,
+      107,
+      27388,
+      522,
+      107,
+      101,
+      105,
+      4368,
+      107,
+      14433,
+      106,
+      46,
+      163688,
+      47,
+      48,
+      6639,
+      236787,
+      26537,
+      16454,
+      49,
+      50,
+      6275,
+      236787,
+      26537,
+      16454,
+      51
+    ],
+    "tokens": [
+      "<|think|>",
+      "<|channel>",
+      "thought",
+      "\n",
+      "reason",
+      "ing",
+      "\n",
+      "<channel|>",
+      "<|turn>",
+      "model",
+      "\n",
+      "answer",
+      "<turn|>",
+      "<|tool>",
+      "declaration",
+      "<tool|>",
+      "<|tool_call>",
+      "call",
+      ":",
+      "foo",
+      "{}",
+      "<tool_call|>",
+      "<|tool_response>",
+      "response",
+      ":",
+      "foo",
+      "{}",
+      "<tool_response|>"
+    ],
+    "decoded": "thought\nreasoning\nmodel\nanswerdeclarationcall:foo{}response:foo{}"
+  }
+]

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/decode_goldens.json
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/decode_goldens.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "decode_lone_incomplete_lead_byte",
+    "ids": [
+      467
+    ],
+    "decoded": "�"
+  },
+  {
+    "id": "decode_two_byte_incomplete_run",
+    "ids": [
+      467,
+      381
+    ],
+    "decoded": "��"
+  },
+  {
+    "id": "decode_valid_three_byte_fallback_run",
+    "ids": [
+      467,
+      381,
+      409
+    ],
+    "decoded": "叫"
+  },
+  {
+    "id": "decode_incomplete_run_then_ordinary_token",
+    "ids": [
+      467,
+      381,
+      236746
+    ],
+    "decoded": "��a"
+  }
+]

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/expansion_goldens.json
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/expansion_goldens.json
@@ -1,0 +1,45 @@
+{
+  "provenance": {
+    "image_seq_length": 280,
+    "audio_ms_per_token": 40,
+    "audio_seq_length": 750
+  },
+  "image_cases": [
+    {
+      "marker_count": 0,
+      "expected_tokens": 0
+    },
+    {
+      "marker_count": 1,
+      "expected_tokens": 280
+    },
+    {
+      "marker_count": 3,
+      "expected_tokens": 840
+    }
+  ],
+  "audio_cases": [
+    {
+      "durations_ms": [],
+      "expected_tokens": []
+    },
+    {
+      "durations_ms": [
+        1000
+      ],
+      "expected_tokens": [
+        25
+      ]
+    },
+    {
+      "durations_ms": [
+        1000,
+        40000
+      ],
+      "expected_tokens": [
+        25,
+        750
+      ]
+    }
+  ]
+}

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/expansion_goldens.json
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/expansion_goldens.json
@@ -2,7 +2,10 @@
   "provenance": {
     "image_seq_length": 280,
     "audio_ms_per_token": 40,
-    "audio_seq_length": 750
+    "audio_seq_length": 750,
+    "audio_sampling_rate_hz": 16000,
+    "audio_frame_length_samples": 320,
+    "audio_hop_length_samples": 160
   },
   "image_cases": [
     {
@@ -33,10 +36,22 @@
     },
     {
       "durations_ms": [
+        0,
+        1,
+        10,
+        11,
+        40,
+        41,
         1000,
         40000
       ],
       "expected_tokens": [
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
         25,
         750
       ]

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/manifest.json
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/manifest.json
@@ -14,6 +14,10 @@
     "chat_template.jinja": {
       "bytes": 17336,
       "sha256": "2f1b4d75d067bae3fe44e676721c7f077d243bc007156cb9c2f8b5836613d082"
+    },
+    "processor_config.json": {
+      "bytes": 1689,
+      "sha256": "32bdf45d2ad4cc29a0822ddd157a182de76644f0419a6228d151495256e9813c"
     }
   },
   "runtime_versions": {

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/manifest.json
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/manifest.json
@@ -1,0 +1,25 @@
+{
+  "source_repo": "google/gemma-4-E2B-it",
+  "revision": "9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf",
+  "url_form": "https://huggingface.co/google/gemma-4-E2B-it/resolve/9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf/<file>",
+  "files": {
+    "tokenizer.json": {
+      "bytes": 32169626,
+      "sha256": "cc8d3a0ce36466ccc1278bf987df5f71db1719b9ca6b4118264f45cb627bfe0f"
+    },
+    "tokenizer_config.json": {
+      "bytes": 2095,
+      "sha256": "90c3a3ba5bf53818383a58e1a776cbcacd2a038d4812eaa373e1522f2d06f3df"
+    },
+    "chat_template.jinja": {
+      "bytes": 17336,
+      "sha256": "2f1b4d75d067bae3fe44e676721c7f077d243bc007156cb9c2f8b5836613d082"
+    }
+  },
+  "runtime_versions": {
+    "tokenizers": "0.22.2",
+    "jinja2": "3.1.6"
+  },
+  "generator": "scripts/gemma4_tokenizer_goldens.py",
+  "adr": "ADR-082 Stage 1 (G17)"
+}

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/processor_config.json
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/processor_config.json
@@ -1,0 +1,75 @@
+{
+  "audio_ms_per_token": 40,
+  "audio_seq_length": 750,
+  "feature_extractor": {
+    "dither": 0.0,
+    "feature_extractor_type": "Gemma4AudioFeatureExtractor",
+    "feature_size": 128,
+    "fft_length": 512,
+    "fft_overdrive": false,
+    "frame_length": 320,
+    "hop_length": 160,
+    "input_scale_factor": 1.0,
+    "max_frequency": 8000.0,
+    "mel_floor": 0.001,
+    "min_frequency": 0.0,
+    "padding_side": "right",
+    "padding_value": 0.0,
+    "per_bin_mean": null,
+    "per_bin_stddev": null,
+    "preemphasis": 0.0,
+    "preemphasis_htk_flavor": true,
+    "return_attention_mask": true,
+    "sampling_rate": 16000
+  },
+  "image_processor": {
+    "do_convert_rgb": true,
+    "do_normalize": false,
+    "do_rescale": true,
+    "do_resize": true,
+    "image_mean": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "image_processor_type": "Gemma4ImageProcessor",
+    "image_seq_length": 280,
+    "image_std": [
+      1.0,
+      1.0,
+      1.0
+    ],
+    "max_soft_tokens": 280,
+    "patch_size": 16,
+    "pooling_kernel_size": 3,
+    "resample": 3,
+    "rescale_factor": 0.00392156862745098
+  },
+  "image_seq_length": 280,
+  "processor_class": "Gemma4Processor",
+  "video_processor": {
+    "do_convert_rgb": true,
+    "do_normalize": true,
+    "do_rescale": true,
+    "do_resize": true,
+    "do_sample_frames": true,
+    "image_mean": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "image_std": [
+      1.0,
+      1.0,
+      1.0
+    ],
+    "max_soft_tokens": 70,
+    "num_frames": 32,
+    "patch_size": 16,
+    "pooling_kernel_size": 3,
+    "resample": 3,
+    "rescale_factor": 0.00392156862745098,
+    "return_metadata": false,
+    "video_processor_type": "Gemma4VideoProcessor"
+  }
+}

--- a/crates/inference/tests/fixtures/gemma4/tokenizer/tokenizer_config.json
+++ b/crates/inference/tests/fixtures/gemma4/tokenizer/tokenizer_config.json
@@ -1,0 +1,74 @@
+{
+  "audio_token": "<|audio|>",
+  "backend": "tokenizers",
+  "boa_token": "<|audio>",
+  "boi_token": "<|image>",
+  "bos_token": "<bos>",
+  "eoa_token": "<audio|>",
+  "eoc_token": "<channel|>",
+  "eoi_token": "<image|>",
+  "eos_token": "<eos>",
+  "eot_token": "<turn|>",
+  "escape_token": "<|\"|>",
+  "etc_token": "<tool_call|>",
+  "etd_token": "<tool|>",
+  "etr_token": "<tool_response|>",
+  "extra_special_tokens": [
+    "<|video|>"
+  ],
+  "image_token": "<|image|>",
+  "mask_token": "<mask>",
+  "model_max_length": 1000000000000000019884624838656,
+  "pad_token": "<pad>",
+  "padding_side": "left",
+  "processor_class": "Gemma4Processor",
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "role": {
+        "const": "assistant"
+      },
+      "thinking": {
+        "type": "string"
+      },
+      "content": {
+        "type": "string"
+      },
+      "tool_calls": {
+        "x-regex-iterator": "<\\|tool_call>(.*?)<tool_call\\|>",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "function"
+            },
+            "function": {
+              "type": "object",
+              "x-regex": "call\\:(?P<name>\\w+)(?P<arguments>\\{.*\\})",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "arguments": {
+                  "type": "object",
+                  "x-parser": "gemma4-tool-call",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "x-regex": "(\\<\\|channel\\>thought\\n(?P<thinking>.*?)\\<channel\\|\\>)?(?P<tool_calls>\\<\\|tool_call\\>.*\\<tool_call\\|\\>)?(?P<content>(?:(?!\\<turn\\|\\>)(?!\\<\\|tool_response\\>).)+)?(?:\\<turn\\|\\>|\\<\\|tool_response\\>)?"
+  },
+  "soc_token": "<|channel>",
+  "sot_token": "<|turn>",
+  "stc_token": "<|tool_call>",
+  "std_token": "<|tool>",
+  "str_token": "<|tool_response>",
+  "think_token": "<|think|>",
+  "tokenizer_class": "GemmaTokenizer",
+  "unk_token": "<unk>"
+}

--- a/crates/inference/tests/gemma4_tokenizer_goldens_test.rs
+++ b/crates/inference/tests/gemma4_tokenizer_goldens_test.rs
@@ -1,0 +1,227 @@
+//! Fixture-only gate for the Gemma 4 BPE tokenizer (ADR-082 Stage 1, G17).
+//!
+//! **Offline-only.** Unlike `scripts/gemma4_tokenizer_goldens.py` (which
+//! fetches `tokenizer.json`/`tokenizer_config.json`/`chat_template.jinja`
+//! over HTTPS), this test never touches the network — it loads the fixtures
+//! already committed at `tests/fixtures/gemma4/tokenizer/`, produced by a
+//! single real run of that script against the pinned checkpoint revision
+//! (`google/gemma-4-E2B-it` @ `9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf`,
+//! HF `tokenizers==0.22.2` / `jinja2==3.1.6` — see `manifest.json`).
+//!
+//! Three things are asserted:
+//! 1. `GemmaBpeTokenizer` (the new, additive path) reproduces the exact HF
+//!    token IDs for every corpus case and the 2-turn chat-template
+//!    rendering, plus a plain-text decode round trip.
+//! 2. The **existing** Qwen-oriented `BpeTokenizer::from_tokenizer_json_str`
+//!    still rejects this same `tokenizer.json` — proving the new path is
+//!    additive, not a silent widening of the general loader (ADR-082's
+//!    mandated negative test).
+
+use lattice_inference::{BpeTokenizer, GemmaBpeTokenizer, Tokenizer};
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/gemma4/tokenizer")
+}
+
+fn read_fixture(name: &str) -> String {
+    let path = fixture_dir().join(name);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()))
+}
+
+static TOKENIZER_JSON: LazyLock<String> = LazyLock::new(|| read_fixture("tokenizer.json"));
+static TOKENIZER: LazyLock<GemmaBpeTokenizer> =
+    LazyLock::new(|| GemmaBpeTokenizer::from_tokenizer_json_str(&TOKENIZER_JSON).unwrap());
+
+#[derive(Deserialize)]
+struct CorpusCase {
+    id: String,
+    #[allow(dead_code)]
+    category: String,
+    text: String,
+    ids: Vec<u32>,
+    #[allow(dead_code)]
+    tokens: Vec<String>,
+    decoded: String,
+}
+
+#[derive(Deserialize)]
+struct ChatTemplateGolden {
+    #[allow(dead_code)]
+    description: String,
+    #[allow(dead_code)]
+    messages: serde_json::Value,
+    rendered_text: String,
+    ids: Vec<u32>,
+}
+
+#[derive(Deserialize)]
+struct ManifestFile {
+    bytes: u64,
+    sha256: String,
+}
+
+#[derive(Deserialize)]
+struct Manifest {
+    source_repo: String,
+    revision: String,
+    files: std::collections::HashMap<String, ManifestFile>,
+}
+
+fn load_corpus() -> Vec<CorpusCase> {
+    serde_json::from_str(&read_fixture("corpus_goldens.json")).expect("valid corpus_goldens.json")
+}
+
+fn load_chat_golden() -> ChatTemplateGolden {
+    serde_json::from_str(&read_fixture("chat_template_golden.json"))
+        .expect("valid chat_template_golden.json")
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+
+// ---------------------------------------------------------------------
+// Provenance
+// ---------------------------------------------------------------------
+
+#[test]
+fn manifest_matches_committed_tokenizer_json_bytes() {
+    let manifest: Manifest =
+        serde_json::from_str(&read_fixture("manifest.json")).expect("valid manifest.json");
+    assert_eq!(manifest.source_repo, "google/gemma-4-E2B-it");
+    assert_eq!(
+        manifest.revision,
+        "9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf"
+    );
+
+    for (name, entry) in &manifest.files {
+        let bytes = std::fs::read(fixture_dir().join(name))
+            .unwrap_or_else(|e| panic!("failed to read committed {name}: {e}"));
+        assert_eq!(bytes.len() as u64, entry.bytes, "{name} byte count drifted");
+        assert_eq!(sha256_hex(&bytes), entry.sha256, "{name} sha256 drifted");
+    }
+}
+
+// ---------------------------------------------------------------------
+// Corpus goldens (exact HF token-ID equality)
+// ---------------------------------------------------------------------
+
+#[test]
+fn corpus_goldens_match_exact_hf_token_ids() {
+    let cases = load_corpus();
+    assert!(cases.len() >= 20, "expected a substantial declared corpus");
+
+    let mut categories = std::collections::HashSet::new();
+    for case in &cases {
+        categories.insert(case.category.clone());
+        let ids = TOKENIZER.tokenize_ids_for_test(&case.text);
+        assert_eq!(
+            ids, case.ids,
+            "case {:?} (text={:?}) produced {:?}, expected {:?}",
+            case.id, case.text, ids, case.ids
+        );
+    }
+
+    for required in ["text", "unicode", "whitespace", "byte_fallback", "marker"] {
+        assert!(
+            categories.contains(required),
+            "corpus is missing required category {required:?}"
+        );
+    }
+}
+
+#[test]
+fn corpus_goldens_decode_round_trips_plain_text() {
+    for case in load_corpus() {
+        if case.category == "marker" {
+            // Special-token markers are dropped on decode by design
+            // (skip_special_tokens semantics) — covered separately below,
+            // not a round-trip case.
+            continue;
+        }
+        let decoded = TOKENIZER
+            .decode(&case.ids)
+            .expect("decode always returns Some");
+        assert_eq!(decoded, case.decoded, "case {:?} decode mismatch", case.id);
+        assert_eq!(
+            decoded, case.text,
+            "case {:?} did not round-trip byte-for-byte",
+            case.id
+        );
+    }
+}
+
+#[test]
+fn image_and_audio_markers_tokenize_to_single_ids() {
+    let cases = load_corpus();
+    let image = cases
+        .iter()
+        .find(|c| c.id == "marker_image")
+        .expect("marker_image case present");
+    let audio = cases
+        .iter()
+        .find(|c| c.id == "marker_audio")
+        .expect("marker_audio case present");
+    assert_eq!(image.ids.len(), 1, "<|image|> must be a single token");
+    assert_eq!(audio.ids.len(), 1, "<|audio|> must be a single token");
+    assert_ne!(image.ids[0], audio.ids[0]);
+}
+
+// ---------------------------------------------------------------------
+// Chat template (rendered string + token IDs)
+// ---------------------------------------------------------------------
+
+#[test]
+fn chat_template_2turn_rendering_matches_hf() {
+    let golden = load_chat_golden();
+    assert!(golden.rendered_text.starts_with("<bos>"));
+    assert!(golden.rendered_text.contains("<|turn>user\n"));
+    assert!(golden.rendered_text.contains("<|turn>model\n"));
+
+    let ids = TOKENIZER.tokenize_ids_for_test(&golden.rendered_text);
+    assert_eq!(
+        ids, golden.ids,
+        "chat-template rendering did not tokenize to the golden IDs"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Additive-path negative test (ADR-082 Stage 1 mandated gate)
+// ---------------------------------------------------------------------
+
+#[test]
+fn existing_qwen_bpe_loader_rejects_gemma_tokenizer_json() {
+    let result = BpeTokenizer::from_tokenizer_json_str(&TOKENIZER_JSON);
+    assert!(
+        result.is_err(),
+        "existing BpeTokenizer loader must reject Gemma's literal-space \
+         Split + \u{2581} normalizer tokenizer.json -- if this now succeeds, \
+         the general loader has been silently widened to accept the Gemma \
+         shape, which ADR-082 Stage 1 explicitly forbids"
+    );
+}
+
+#[test]
+fn gemma_tokenizer_vocab_size_matches_checkpoint() {
+    assert_eq!(TOKENIZER.vocab_size(), 262_144);
+}
+
+// Small helper trait to expose raw (unpadded) tokenize-to-ids for golden
+// comparison without pulling in the padded `TokenizedInput` shape.
+trait TestTokenizeIds {
+    fn tokenize_ids_for_test(&self, text: &str) -> Vec<u32>;
+}
+
+impl TestTokenizeIds for GemmaBpeTokenizer {
+    fn tokenize_ids_for_test(&self, text: &str) -> Vec<u32> {
+        let padded = self.tokenize(text);
+        padded.input_ids[..padded.real_length].to_vec()
+    }
+}

--- a/crates/inference/tests/gemma4_tokenizer_goldens_test.rs
+++ b/crates/inference/tests/gemma4_tokenizer_goldens_test.rs
@@ -23,9 +23,11 @@
 //!    the pinned checkpoint's `processor_config.json`-derived goldens.
 
 use lattice_inference::{
-    BpeTokenizer, GEMMA4_AUDIO_MAX_SOFT_TOKENS, GEMMA4_AUDIO_MS_PER_SOFT_TOKEN,
+    BpeTokenizer, GEMMA4_AUDIO_FRAME_LENGTH_SAMPLES, GEMMA4_AUDIO_HOP_LENGTH_SAMPLES,
+    GEMMA4_AUDIO_MAX_SOFT_TOKENS, GEMMA4_AUDIO_MS_PER_SOFT_TOKEN, GEMMA4_AUDIO_SAMPLING_RATE_HZ,
     GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE, GemmaBpeTokenizer, Tokenizer,
     audio_marker_expansion_tokens, image_marker_expansion_tokens,
+    total_audio_marker_expansion_tokens,
 };
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -79,6 +81,9 @@ struct ExpansionProvenance {
     image_seq_length: u32,
     audio_ms_per_token: u32,
     audio_seq_length: u32,
+    audio_sampling_rate_hz: u32,
+    audio_frame_length_samples: u32,
+    audio_hop_length_samples: u32,
 }
 
 #[derive(Deserialize)]
@@ -332,6 +337,18 @@ fn marker_expansion_arithmetic_matches_processor_config_goldens() {
         GEMMA4_AUDIO_MAX_SOFT_TOKENS, goldens.provenance.audio_seq_length,
         "GEMMA4_AUDIO_MAX_SOFT_TOKENS drifted from processor_config.json"
     );
+    assert_eq!(
+        GEMMA4_AUDIO_SAMPLING_RATE_HZ, goldens.provenance.audio_sampling_rate_hz,
+        "GEMMA4_AUDIO_SAMPLING_RATE_HZ drifted from processor_config.json"
+    );
+    assert_eq!(
+        GEMMA4_AUDIO_FRAME_LENGTH_SAMPLES, goldens.provenance.audio_frame_length_samples,
+        "GEMMA4_AUDIO_FRAME_LENGTH_SAMPLES drifted from processor_config.json"
+    );
+    assert_eq!(
+        GEMMA4_AUDIO_HOP_LENGTH_SAMPLES, goldens.provenance.audio_hop_length_samples,
+        "GEMMA4_AUDIO_HOP_LENGTH_SAMPLES drifted from processor_config.json"
+    );
 
     assert!(goldens.image_cases.iter().any(|c| c.marker_count == 0));
     assert!(goldens.image_cases.iter().any(|c| c.marker_count == 1));
@@ -367,6 +384,32 @@ fn marker_expansion_arithmetic_matches_processor_config_goldens() {
                 "audio duration_ms={duration_ms} expansion mismatch"
             );
         }
+        // total_audio_marker_expansion_tokens must agree with the per-marker
+        // sum for zero, one, and multiple markers alike (each `case` here
+        // covers exactly one of those shapes -- see the `any()` asserts
+        // above).
+        assert_eq!(
+            total_audio_marker_expansion_tokens(&case.durations_ms) as u64,
+            case.expected_tokens.iter().map(|&t| t as u64).sum::<u64>(),
+            "total_audio_marker_expansion_tokens mismatch for durations_ms={:?}",
+            case.durations_ms
+        );
+    }
+
+    // Exact post-subsampling boundary arithmetic (ADR-082 G15, transformers @
+    // ab1771c9, processing_gemma4.py:260-298): 16 kHz post-subsampling token
+    // counts do NOT follow `ceil(duration_ms / 40)` at these durations --
+    // 1-10 ms clips have zero mel frames (0 tokens, not 1), and 40-41 ms
+    // clips reduce to exactly one soft token after the two stride-2 Conv2d
+    // layers (not 2). These are asserted independently of the fixture above
+    // so a fixture regeneration bug can't silently launder a wrong formula.
+    let exact_boundary_cases: &[(u32, u32)] = &[(0, 0), (1, 0), (10, 0), (11, 1), (40, 1), (41, 1)];
+    for &(duration_ms, expected) in exact_boundary_cases {
+        assert_eq!(
+            audio_marker_expansion_tokens(duration_ms),
+            expected,
+            "audio duration_ms={duration_ms} exact post-subsampling expansion mismatch"
+        );
     }
 
     // Explicit boundary check: a duration well past the 30s card limit must
@@ -376,6 +419,20 @@ fn marker_expansion_arithmetic_matches_processor_config_goldens() {
         GEMMA4_AUDIO_MAX_SOFT_TOKENS
     );
     assert_eq!(image_marker_expansion_tokens(0), 0);
+
+    // total_audio_marker_expansion_tokens over zero/one/multiple markers,
+    // independent of the fixture-driven loop above.
+    assert_eq!(total_audio_marker_expansion_tokens(&[]), 0);
+    assert_eq!(
+        total_audio_marker_expansion_tokens(&[1_000]),
+        audio_marker_expansion_tokens(1_000) as usize
+    );
+    assert_eq!(
+        total_audio_marker_expansion_tokens(&[41, 1_000, 40_000]),
+        audio_marker_expansion_tokens(41) as usize
+            + audio_marker_expansion_tokens(1_000) as usize
+            + audio_marker_expansion_tokens(40_000) as usize
+    );
 }
 
 // ---------------------------------------------------------------------
@@ -513,6 +570,37 @@ fn constructor_rejects_non_null_continuing_subword_prefix() {
     let mut mutated = minimal_valid_tokenizer_json();
     mutated["model"]["continuing_subword_prefix"] = serde_json::json!("##");
     assert_rejects(&mutated, "model.continuing_subword_prefix == \"##\"");
+}
+
+#[test]
+fn constructor_rejects_byte_fallback_false() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["model"]["byte_fallback"] = serde_json::json!(false);
+    assert_rejects(&mutated, "model.byte_fallback == false");
+}
+
+#[test]
+fn constructor_rejects_non_null_end_of_word_suffix() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["model"]["end_of_word_suffix"] = serde_json::json!("</w>");
+    assert_rejects(&mutated, "model.end_of_word_suffix == \"</w>\"");
+}
+
+#[test]
+fn constructor_rejects_decoder_replace_wrong_content() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["decoder"]["decoders"][0]["content"] = serde_json::json!("_");
+    assert_rejects(&mutated, "decoder[0].content == \"_\" (not \" \")");
+}
+
+#[test]
+fn constructor_rejects_decoder_replace_wrong_pattern() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["decoder"]["decoders"][0]["pattern"]["String"] = serde_json::json!("_");
+    assert_rejects(
+        &mutated,
+        "decoder[0].pattern.String == \"_\" (not \"\u{2581}\")",
+    );
 }
 
 // Small helper trait to expose raw (unpadded) tokenize-to-ids for golden

--- a/crates/inference/tests/gemma4_tokenizer_goldens_test.rs
+++ b/crates/inference/tests/gemma4_tokenizer_goldens_test.rs
@@ -498,6 +498,22 @@ fn assert_rejects(value: &serde_json::Value, context: &str) {
     );
 }
 
+/// Like [`assert_rejects`], but additionally proves the rejection came from
+/// the intended guard: the error message must name the exact mutated field,
+/// so a rejection by some *other* validation cannot masquerade as coverage.
+fn assert_rejects_naming(value: &serde_json::Value, context: &str, expected_fragment: &str) {
+    let text = value.to_string();
+    let Err(err) = GemmaBpeTokenizer::from_tokenizer_json_str(&text) else {
+        panic!("{context}: expected construction to fail closed, but it succeeded")
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains(expected_fragment),
+        "{context}: rejection error does not name the guarded field \
+         {expected_fragment:?}; got: {msg}"
+    );
+}
+
 #[test]
 fn minimal_valid_tokenizer_json_constructs() {
     assert_constructs(&minimal_valid_tokenizer_json(), "unmutated baseline");
@@ -576,30 +592,43 @@ fn constructor_rejects_non_null_continuing_subword_prefix() {
 fn constructor_rejects_byte_fallback_false() {
     let mut mutated = minimal_valid_tokenizer_json();
     mutated["model"]["byte_fallback"] = serde_json::json!(false);
-    assert_rejects(&mutated, "model.byte_fallback == false");
+    assert_rejects_naming(
+        &mutated,
+        "model.byte_fallback == false",
+        "model.byte_fallback",
+    );
 }
 
 #[test]
 fn constructor_rejects_non_null_end_of_word_suffix() {
     let mut mutated = minimal_valid_tokenizer_json();
     mutated["model"]["end_of_word_suffix"] = serde_json::json!("</w>");
-    assert_rejects(&mutated, "model.end_of_word_suffix == \"</w>\"");
+    assert_rejects_naming(
+        &mutated,
+        "model.end_of_word_suffix == \"</w>\"",
+        "model.end_of_word_suffix",
+    );
 }
 
 #[test]
 fn constructor_rejects_decoder_replace_wrong_content() {
     let mut mutated = minimal_valid_tokenizer_json();
     mutated["decoder"]["decoders"][0]["content"] = serde_json::json!("_");
-    assert_rejects(&mutated, "decoder[0].content == \"_\" (not \" \")");
+    assert_rejects_naming(
+        &mutated,
+        "decoder[0].content == \"_\" (not \" \")",
+        "decoder[0].content",
+    );
 }
 
 #[test]
 fn constructor_rejects_decoder_replace_wrong_pattern() {
     let mut mutated = minimal_valid_tokenizer_json();
     mutated["decoder"]["decoders"][0]["pattern"]["String"] = serde_json::json!("_");
-    assert_rejects(
+    assert_rejects_naming(
         &mutated,
         "decoder[0].pattern.String == \"_\" (not \"\u{2581}\")",
+        "decoder[0].pattern.String",
     );
 }
 

--- a/crates/inference/tests/gemma4_tokenizer_goldens_test.rs
+++ b/crates/inference/tests/gemma4_tokenizer_goldens_test.rs
@@ -8,16 +8,25 @@
 //! (`google/gemma-4-E2B-it` @ `9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf`,
 //! HF `tokenizers==0.22.2` / `jinja2==3.1.6` — see `manifest.json`).
 //!
-//! Three things are asserted:
+//! Four things are asserted:
 //! 1. `GemmaBpeTokenizer` (the new, additive path) reproduces the exact HF
 //!    token IDs for every corpus case and the 2-turn chat-template
-//!    rendering, plus a plain-text decode round trip.
+//!    rendering, plus exact byte-fallback decode goldens (including
+//!    invalid/incomplete UTF-8 byte runs).
 //! 2. The **existing** Qwen-oriented `BpeTokenizer::from_tokenizer_json_str`
 //!    still rejects this same `tokenizer.json` — proving the new path is
 //!    additive, not a silent widening of the general loader (ADR-082's
 //!    mandated negative test).
+//! 3. The constructor fails closed on a mutated pre-tokenizer, decoder, or
+//!    model field it depends on.
+//! 4. The Stage-1 marker-expansion arithmetic (ADR-082 G11/G15/G17) matches
+//!    the pinned checkpoint's `processor_config.json`-derived goldens.
 
-use lattice_inference::{BpeTokenizer, GemmaBpeTokenizer, Tokenizer};
+use lattice_inference::{
+    BpeTokenizer, GEMMA4_AUDIO_MAX_SOFT_TOKENS, GEMMA4_AUDIO_MS_PER_SOFT_TOKEN,
+    GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE, GemmaBpeTokenizer, Tokenizer,
+    audio_marker_expansion_tokens, image_marker_expansion_tokens,
+};
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::LazyLock;
@@ -59,6 +68,39 @@ struct ChatTemplateGolden {
 }
 
 #[derive(Deserialize)]
+struct DecodeCase {
+    id: String,
+    ids: Vec<u32>,
+    decoded: String,
+}
+
+#[derive(Deserialize)]
+struct ExpansionProvenance {
+    image_seq_length: u32,
+    audio_ms_per_token: u32,
+    audio_seq_length: u32,
+}
+
+#[derive(Deserialize)]
+struct ImageExpansionCase {
+    marker_count: usize,
+    expected_tokens: usize,
+}
+
+#[derive(Deserialize)]
+struct AudioExpansionCase {
+    durations_ms: Vec<u32>,
+    expected_tokens: Vec<u32>,
+}
+
+#[derive(Deserialize)]
+struct ExpansionGoldens {
+    provenance: ExpansionProvenance,
+    image_cases: Vec<ImageExpansionCase>,
+    audio_cases: Vec<AudioExpansionCase>,
+}
+
+#[derive(Deserialize)]
 struct ManifestFile {
     bytes: u64,
     sha256: String,
@@ -78,6 +120,15 @@ fn load_corpus() -> Vec<CorpusCase> {
 fn load_chat_golden() -> ChatTemplateGolden {
     serde_json::from_str(&read_fixture("chat_template_golden.json"))
         .expect("valid chat_template_golden.json")
+}
+
+fn load_decode_goldens() -> Vec<DecodeCase> {
+    serde_json::from_str(&read_fixture("decode_goldens.json")).expect("valid decode_goldens.json")
+}
+
+fn load_expansion_goldens() -> ExpansionGoldens {
+    serde_json::from_str(&read_fixture("expansion_goldens.json"))
+        .expect("valid expansion_goldens.json")
 }
 
 fn sha256_hex(data: &[u8]) -> String {
@@ -158,6 +209,52 @@ fn corpus_goldens_decode_round_trips_plain_text() {
     }
 }
 
+// ---------------------------------------------------------------------
+// Byte-fallback decode goldens (exact HF decode parity for invalid/
+// incomplete UTF-8 byte-fallback runs; ADR-082 Stage 1 major finding)
+// ---------------------------------------------------------------------
+
+#[test]
+fn byte_fallback_decode_matches_exact_hf_output() {
+    let cases = load_decode_goldens();
+    assert!(
+        cases.len() >= 4,
+        "expected the required lone/incomplete/valid/mixed decode cases"
+    );
+    for case in &cases {
+        let decoded = TOKENIZER
+            .decode(&case.ids)
+            .expect("decode always returns Some");
+        assert_eq!(
+            decoded, case.decoded,
+            "case {:?} (ids={:?}) decoded {:?}, expected {:?}",
+            case.id, case.ids, decoded, case.decoded
+        );
+    }
+
+    // Pin the shape of the required cases directly (not just via the fixture),
+    // so a fixture regeneration that silently drops a case still fails loudly.
+    let by_id = |id: &str| {
+        cases
+            .iter()
+            .find(|c| c.id == id)
+            .unwrap_or_else(|| panic!("missing required decode case {id:?}"))
+    };
+    assert_eq!(
+        by_id("decode_lone_incomplete_lead_byte").decoded,
+        "\u{FFFD}"
+    );
+    assert_eq!(
+        by_id("decode_two_byte_incomplete_run").decoded,
+        "\u{FFFD}\u{FFFD}"
+    );
+    assert_eq!(by_id("decode_valid_three_byte_fallback_run").decoded, "叫");
+    assert_eq!(
+        by_id("decode_incomplete_run_then_ordinary_token").decoded,
+        "\u{FFFD}\u{FFFD}a"
+    );
+}
+
 #[test]
 fn image_and_audio_markers_tokenize_to_single_ids() {
     let cases = load_corpus();
@@ -211,6 +308,211 @@ fn existing_qwen_bpe_loader_rejects_gemma_tokenizer_json() {
 #[test]
 fn gemma_tokenizer_vocab_size_matches_checkpoint() {
     assert_eq!(TOKENIZER.vocab_size(), 262_144);
+}
+
+// ---------------------------------------------------------------------
+// Stage-1 marker-expansion arithmetic (ADR-082 G11/G15/G17)
+// ---------------------------------------------------------------------
+
+#[test]
+fn marker_expansion_arithmetic_matches_processor_config_goldens() {
+    let goldens = load_expansion_goldens();
+
+    // The committed Rust constants must not silently drift from the
+    // checkpoint's own `processor_config.json` the goldens were derived from.
+    assert_eq!(
+        GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE, goldens.provenance.image_seq_length,
+        "GEMMA4_IMAGE_SOFT_TOKENS_PER_IMAGE drifted from processor_config.json"
+    );
+    assert_eq!(
+        GEMMA4_AUDIO_MS_PER_SOFT_TOKEN, goldens.provenance.audio_ms_per_token,
+        "GEMMA4_AUDIO_MS_PER_SOFT_TOKEN drifted from processor_config.json"
+    );
+    assert_eq!(
+        GEMMA4_AUDIO_MAX_SOFT_TOKENS, goldens.provenance.audio_seq_length,
+        "GEMMA4_AUDIO_MAX_SOFT_TOKENS drifted from processor_config.json"
+    );
+
+    assert!(goldens.image_cases.iter().any(|c| c.marker_count == 0));
+    assert!(goldens.image_cases.iter().any(|c| c.marker_count == 1));
+    assert!(goldens.image_cases.iter().any(|c| c.marker_count > 1));
+    for case in &goldens.image_cases {
+        assert_eq!(
+            image_marker_expansion_tokens(case.marker_count),
+            case.expected_tokens,
+            "image marker_count={} expansion mismatch",
+            case.marker_count
+        );
+    }
+
+    assert!(
+        goldens
+            .audio_cases
+            .iter()
+            .any(|c| c.durations_ms.is_empty())
+    );
+    assert!(
+        goldens
+            .audio_cases
+            .iter()
+            .any(|c| c.durations_ms.len() == 1)
+    );
+    assert!(goldens.audio_cases.iter().any(|c| c.durations_ms.len() > 1));
+    for case in &goldens.audio_cases {
+        assert_eq!(case.durations_ms.len(), case.expected_tokens.len());
+        for (&duration_ms, &expected) in case.durations_ms.iter().zip(&case.expected_tokens) {
+            assert_eq!(
+                audio_marker_expansion_tokens(duration_ms),
+                expected,
+                "audio duration_ms={duration_ms} expansion mismatch"
+            );
+        }
+    }
+
+    // Explicit boundary check: a duration well past the 30s card limit must
+    // clamp at the cap rather than grow unbounded.
+    assert_eq!(
+        audio_marker_expansion_tokens(1_000_000),
+        GEMMA4_AUDIO_MAX_SOFT_TOKENS
+    );
+    assert_eq!(image_marker_expansion_tokens(0), 0);
+}
+
+// ---------------------------------------------------------------------
+// Fail-closed constructor validation (ADR-082 Stage 1 medium finding):
+// mutating any field `validate_gemma_bpe_shape` checks must reject
+// construction, proving the constructor's fail-closed claim isn't
+// decorative.
+// ---------------------------------------------------------------------
+
+/// A minimal but complete Gemma-shaped `tokenizer.json`, built directly
+/// (not derived from the 32 MB committed fixture) so each mutation test
+/// stays fast and each mutated field is isolated from the others.
+fn minimal_valid_tokenizer_json() -> serde_json::Value {
+    serde_json::json!({
+        "normalizer": {
+            "type": "Replace",
+            "pattern": {"String": " "},
+            "content": "\u{2581}",
+        },
+        "pre_tokenizer": {
+            "type": "Split",
+            "pattern": {"String": " "},
+            "behavior": "MergedWithPrevious",
+            "invert": false,
+        },
+        "decoder": {
+            "type": "Sequence",
+            "decoders": [
+                {"type": "Replace", "pattern": {"String": "\u{2581}"}, "content": " "},
+                {"type": "ByteFallback"},
+                {"type": "Fuse"},
+            ],
+        },
+        "added_tokens": [],
+        "model": {
+            "type": "BPE",
+            "dropout": serde_json::Value::Null,
+            "unk_token": "<unk>",
+            "continuing_subword_prefix": serde_json::Value::Null,
+            "end_of_word_suffix": serde_json::Value::Null,
+            "fuse_unk": true,
+            "byte_fallback": true,
+            "ignore_merges": false,
+            "vocab": {"<unk>": 0, "a": 1, "<0x61>": 2, "\u{2581}": 3},
+            "merges": [],
+        },
+    })
+}
+
+fn assert_constructs(value: &serde_json::Value, context: &str) {
+    let text = value.to_string();
+    assert!(
+        GemmaBpeTokenizer::from_tokenizer_json_str(&text).is_ok(),
+        "{context}: expected construction to succeed"
+    );
+}
+
+fn assert_rejects(value: &serde_json::Value, context: &str) {
+    let text = value.to_string();
+    assert!(
+        GemmaBpeTokenizer::from_tokenizer_json_str(&text).is_err(),
+        "{context}: expected construction to fail closed, but it succeeded"
+    );
+}
+
+#[test]
+fn minimal_valid_tokenizer_json_constructs() {
+    assert_constructs(&minimal_valid_tokenizer_json(), "unmutated baseline");
+}
+
+#[test]
+fn constructor_rejects_wrong_split_pattern() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["pre_tokenizer"]["pattern"]["String"] = serde_json::json!("\t");
+    assert_rejects(&mutated, "pre_tokenizer.pattern.String == \"\\t\"");
+}
+
+#[test]
+fn constructor_rejects_wrong_split_behavior() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["pre_tokenizer"]["behavior"] = serde_json::json!("Isolated");
+    assert_rejects(&mutated, "pre_tokenizer.behavior == \"Isolated\"");
+}
+
+#[test]
+fn constructor_rejects_inverted_split() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["pre_tokenizer"]["invert"] = serde_json::json!(true);
+    assert_rejects(&mutated, "pre_tokenizer.invert == true");
+}
+
+#[test]
+fn constructor_rejects_reordered_decoder_sequence() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    let decoders = mutated["decoder"]["decoders"].as_array().unwrap().clone();
+    mutated["decoder"]["decoders"] = serde_json::json!([
+        decoders[1].clone(),
+        decoders[0].clone(),
+        decoders[2].clone()
+    ]);
+    assert_rejects(&mutated, "decoder order ByteFallback,Replace,Fuse");
+}
+
+#[test]
+fn constructor_rejects_missing_fuse_stage() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    let decoders = mutated["decoder"]["decoders"].as_array().unwrap().clone();
+    mutated["decoder"]["decoders"] = serde_json::json!([decoders[0].clone(), decoders[1].clone()]);
+    assert_rejects(&mutated, "decoder missing trailing Fuse");
+}
+
+#[test]
+fn constructor_rejects_ignore_merges_true() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["model"]["ignore_merges"] = serde_json::json!(true);
+    assert_rejects(&mutated, "model.ignore_merges == true");
+}
+
+#[test]
+fn constructor_rejects_fuse_unk_false() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["model"]["fuse_unk"] = serde_json::json!(false);
+    assert_rejects(&mutated, "model.fuse_unk == false");
+}
+
+#[test]
+fn constructor_rejects_non_null_dropout() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["model"]["dropout"] = serde_json::json!(0.1);
+    assert_rejects(&mutated, "model.dropout == 0.1");
+}
+
+#[test]
+fn constructor_rejects_non_null_continuing_subword_prefix() {
+    let mut mutated = minimal_valid_tokenizer_json();
+    mutated["model"]["continuing_subword_prefix"] = serde_json::json!("##");
+    assert_rejects(&mutated, "model.continuing_subword_prefix == \"##\"");
 }
 
 // Small helper trait to expose raw (unpadded) tokenize-to-ids for golden

--- a/docs/gemma4.md
+++ b/docs/gemma4.md
@@ -102,3 +102,31 @@ fetched — see manifest `metadata`):
 Every stage from 3 onward downloads real weight bytes and must place them under
 `$LATTICE_MODEL_CACHE`, consistent with `ensure_model_files`'s existing cache-then-download flow
 and `LATTICE_OFFLINE`'s fail-closed behavior on a cache miss.
+
+## Tokenizer + prompt-template parity (Stage 1, G17)
+
+[`crates/inference/tests/fixtures/gemma4/tokenizer/`](../crates/inference/tests/fixtures/gemma4/tokenizer/)
+commits the target tokenizer assets verbatim — `tokenizer.json` (~32.2 MB; large for a fixture but
+still a small text/JSON file with zero weight bytes, matching the Stage-0 table above), plus
+`tokenizer_config.json` and `chat_template.jinja` — alongside `manifest.json` (source revision +
+per-file SHA-256 + generator runtime versions) and two derived golden files:
+`corpus_goldens.json` (exact HF token IDs over a declared corpus: ordinary text, Unicode,
+whitespace runs, byte-fallback cases, and the image/audio/thought/tool markers) and
+`chat_template_golden.json` (the rendered 2-turn instruction-template string plus its token IDs).
+
+**Generator / drift gate**: [`scripts/gemma4_tokenizer_goldens.py`](../scripts/gemma4_tokenizer_goldens.py),
+same fetch discipline as Stage 0's manifest script (pinned `/resolve/<revision>/` URLs, a hard fetch
+cap, `--write-fixture` vs. default-verify modes) plus a runtime-version pin on the HF `tokenizers`
+and `jinja2` packages used to generate the goldens.
+
+Read directly from the downloaded `tokenizer.json` (not guessed): `model.type == "BPE"` with
+`byte_fallback: true`, a `Replace(" " -> "▁")` normalizer, and a literal-string `Split`
+pre-tokenizer (`pattern.String`, not the regex `pattern.Regex` shape the existing Qwen BPE loader
+accepts). `crates/inference/src/tokenizer/gemma_bpe.rs` implements this as a new, additive
+`GemmaBpeTokenizer` — selected by an explicit constructor call, never reached through
+`load_tokenizer`'s model-type sniffing. The existing loader's `validate_bpe_pretokenizer`
+continues to reject this same `tokenizer.json` (`crates/inference/tests/gemma4_tokenizer_goldens_test.rs::existing_qwen_bpe_loader_rejects_gemma_tokenizer_json`),
+proving the new path is additive rather than a silent widening of the general loader.
+
+Config/loader wiring (an explicit `Gemma4E2bConfig` branch that selects `GemmaBpeTokenizer`) is
+Stage 2 scope, not this stage.

--- a/scripts/gemma4_tokenizer_goldens.py
+++ b/scripts/gemma4_tokenizer_goldens.py
@@ -295,31 +295,57 @@ def generate_goldens(
 # ADR-082 Stage-1 marker-expansion arithmetic (G11/G15/G17): every
 # `<|image|>` marker expands to a fixed vision soft-token count; every
 # `<|audio|>` marker expands to a duration-derived count capped at the
-# processor's declared maximum. Mirrors `Gemma4Processor.replace_image_token`
-# / `_compute_audio_num_tokens`'s documented `ceil(duration_ms /
-# audio_ms_per_token)` cap in HF `transformers`
-# (`processing_gemma4.py`) -- the full mel-framing + conv-subsampling detail
-# behind that cap is Stage 6/9 (vision/audio end-to-end) scope, not Stage 1.
+# processor's declared maximum. The audio arithmetic mirrors HF
+# `Gemma4Processor._compute_audio_num_tokens` bit-for-bit (transformers @
+# ab1771c9e42891d893189978a8009426d70b4688,
+# src/transformers/models/gemma4/processing_gemma4.py:260-298): mel-frame
+# count from the feature extractor's semicausal framing, then two stride-2
+# Conv2d subsampling reductions (Gemma4AudioSubSampleConvProjection;
+# kernel=3, stride=2, padding=1 -- architectural constants transcribed from
+# the pinned source, not exposed via Gemma4AudioConfig), then the cap. A
+# plain `ceil(duration_ms / audio_ms_per_token)` disagrees with this at
+# valid durations (e.g. 41 ms -> 1 token, not 2; 1-10 ms -> 0 tokens, not 1).
 def generate_expansion_goldens(processor_config_bytes: bytes) -> dict[str, Any]:
     config = json.loads(processor_config_bytes)
     image_seq_length = config["image_seq_length"]
     audio_ms_per_token = config["audio_ms_per_token"]
     audio_seq_length = config["audio_seq_length"]
+    feature_extractor = config["feature_extractor"]
+    sampling_rate = feature_extractor["sampling_rate"]
+    frame_length = feature_extractor["frame_length"]
+    hop_length = feature_extractor["hop_length"]
+
+    def audio_tokens_for_samples(num_samples: int) -> int:
+        frame_size_for_unfold = frame_length + 1
+        pad_left = frame_length // 2  # semicausal time padding
+        num_mel_frames = (num_samples + pad_left - frame_size_for_unfold) // hop_length + 1
+        if num_mel_frames <= 0:
+            return 0
+
+        # Two stride-2 Conv2d subsampling layers (kernel=3, stride=2,
+        # padding=1) from Gemma4AudioSubSampleConvProjection.
+        t = num_mel_frames
+        for _ in range(2):
+            t = (t + 2 * 1 - 3) // 2 + 1
+
+        return min(t, audio_seq_length)
 
     def audio_tokens_for(duration_ms: int) -> int:
-        return min(-(-duration_ms // audio_ms_per_token), audio_seq_length)
+        num_samples = duration_ms * sampling_rate // 1000
+        return audio_tokens_for_samples(num_samples)
 
     image_cases = [
         {"marker_count": 0, "expected_tokens": 0},
         {"marker_count": 1, "expected_tokens": image_seq_length},
         {"marker_count": 3, "expected_tokens": 3 * image_seq_length},
     ]
+    boundary_durations_ms = [0, 1, 10, 11, 40, 41, 1000, 40_000]
     audio_cases = [
         {"durations_ms": [], "expected_tokens": []},
         {"durations_ms": [1000], "expected_tokens": [audio_tokens_for(1000)]},
         {
-            "durations_ms": [1000, 40_000],
-            "expected_tokens": [audio_tokens_for(1000), audio_tokens_for(40_000)],
+            "durations_ms": boundary_durations_ms,
+            "expected_tokens": [audio_tokens_for(d) for d in boundary_durations_ms],
         },
     ]
     return {
@@ -327,6 +353,9 @@ def generate_expansion_goldens(processor_config_bytes: bytes) -> dict[str, Any]:
             "image_seq_length": image_seq_length,
             "audio_ms_per_token": audio_ms_per_token,
             "audio_seq_length": audio_seq_length,
+            "audio_sampling_rate_hz": sampling_rate,
+            "audio_frame_length_samples": frame_length,
+            "audio_hop_length_samples": hop_length,
         },
         "image_cases": image_cases,
         "audio_cases": audio_cases,

--- a/scripts/gemma4_tokenizer_goldens.py
+++ b/scripts/gemma4_tokenizer_goldens.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Generate/verify Gemma 4 E2B tokenizer + chat-template parity fixtures
+(ADR-082 Stage 1, G17).
+
+Downloads `tokenizer.json`, `tokenizer_config.json`, and `chat_template.jinja`
+from the checkpoint's pinned revision (the `/resolve/<commit>/` URL form, so
+the pin is real, not advisory), records their SHA-256 in a committed
+provenance manifest, and uses the HF `tokenizers` library (NOT
+`transformers.AutoTokenizer`, which does not know the `gemma4` architecture
+yet) plus `jinja2` to produce golden token IDs over a declared corpus and a
+2-turn chat-template rendering.
+
+Pinned checkpoint (ADR-082): `google/gemma-4-E2B-it` @ revision
+`9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf`.
+
+Usage:
+    # Verify (default): re-fetch the three files, diff their SHA-256 against
+    # the committed manifest, regenerate goldens in-memory and diff against
+    # the committed golden JSON. Fails closed on any drift. Touches the
+    # network — not run by CI, a manual/periodic drift check.
+    uv run python3 scripts/gemma4_tokenizer_goldens.py
+
+    # Regenerate the committed fixtures (deliberate, reviewable, never run
+    # by CI):
+    uv run python3 scripts/gemma4_tokenizer_goldens.py --write-fixture
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO = "google/gemma-4-E2B-it"
+REVISION = "9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf"
+BASE_URL = f"https://huggingface.co/{REPO}/resolve/{REVISION}"
+
+# Hard cap on total bytes fetched by this script across all three files.
+# tokenizer.json is ~32.2 MB; 40 MB leaves headroom for the two small
+# sidecar files without coming remotely close to the ~10.25 GB weight
+# payload a mistargeted URL could otherwise pull in.
+MAX_FETCH_BYTES = 40_000_000
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "crates"
+    / "inference"
+    / "tests"
+    / "fixtures"
+    / "gemma4"
+    / "tokenizer"
+)
+MANIFEST_PATH = FIXTURE_DIR / "manifest.json"
+CORPUS_GOLDENS_PATH = FIXTURE_DIR / "corpus_goldens.json"
+CHAT_TEMPLATE_GOLDEN_PATH = FIXTURE_DIR / "chat_template_golden.json"
+TOKENIZER_JSON_PATH = FIXTURE_DIR / "tokenizer.json"
+TOKENIZER_CONFIG_PATH = FIXTURE_DIR / "tokenizer_config.json"
+CHAT_TEMPLATE_JINJA_PATH = FIXTURE_DIR / "chat_template.jinja"
+
+FILES = ["tokenizer.json", "tokenizer_config.json", "chat_template.jinja"]
+
+# Runtime versions this script was validated against (pinned in uv.lock as
+# transitive deps of `transformers`). A version drift is not necessarily
+# wrong, but it changes tokenization/rendering behavior silently enough
+# that goldens generated under a different version are not trustworthy
+# without re-review — fail closed rather than silently regenerate under an
+# unvalidated toolchain.
+EXPECTED_TOKENIZERS_VERSION = "0.22.2"
+EXPECTED_JINJA2_VERSION = "3.1.6"
+
+# Declared corpus (ADR-082 Stage 1 gate): ordinary text, Unicode (CJK +
+# emoji + combining marks), whitespace runs, byte-fallback cases, the
+# image/audio wrapper markers, and thought/tool markers.
+CORPUS: list[tuple[str, str, str]] = [
+    ("ascii_ordinary", "text", "The quick brown fox jumps over the lazy dog."),
+    (
+        "ascii_punctuation",
+        "text",
+        "Hello, world! How are you? (fine, thanks) -- 100% sure.",
+    ),
+    (
+        "unicode_cjk",
+        "unicode",
+        "短い日本語のテストです。"
+        "今日は良い天気ですね。",
+    ),
+    (
+        "unicode_emoji",
+        "unicode",
+        "Great job! \U0001f600\U0001f680\U0001f389 family: "
+        "\U0001f468‍\U0001f469‍\U0001f467",
+    ),
+    (
+        "unicode_combining",
+        "unicode",
+        "combining: é vs é (decomposed e + U+0301 vs precomposed)",
+    ),
+    (
+        "unicode_mixed",
+        "unicode",
+        "Café résumé naïve façade -- "
+        "日本語 mixed with emoji \U0001f600",
+    ),
+    ("whitespace_multi_space", "whitespace", "a  b   c    d"),
+    ("whitespace_tabs_newlines", "whitespace", "line1\tcol2\nline2\n\nline4"),
+    (
+        "whitespace_leading_trailing",
+        "whitespace",
+        "   leading and trailing spaces   ",
+    ),
+    ("whitespace_only", "whitespace", "   "),
+    ("empty", "whitespace", ""),
+    (
+        "byte_fallback_rare_char",
+        "byte_fallback",
+        "rare: \U00010300 old italic letter",
+    ),
+    ("byte_fallback_private_use", "byte_fallback", "pua: \ue000\ue001 chars"),
+    (
+        "byte_fallback_replacement_char",
+        "byte_fallback",
+        "bad: � sequence",
+    ),
+    ("marker_image", "marker", "<|image|>"),
+    ("marker_audio", "marker", "<|audio|>"),
+    (
+        "marker_image_audio_combo",
+        "marker",
+        "<|image|> describe this <|audio|> transcribe this",
+    ),
+    ("marker_boi_eoi", "marker", "<|image>content<image|>"),
+    ("marker_boa_eoa", "marker", "<|audio>content<audio|>"),
+    ("marker_video", "marker", "<|video|>"),
+    (
+        "thought_tool_markers",
+        "marker",
+        "<|think|><|channel>thought\nreasoning\n<channel|>"
+        "<|turn>model\nanswer<turn|>"
+        "<|tool>declaration<tool|>"
+        "<|tool_call>call:foo{}<tool_call|>"
+        "<|tool_response>response:foo{}<tool_response|>",
+    ),
+]
+
+CHAT_MESSAGES = [
+    {"role": "user", "content": "What is the capital of France?"},
+    {"role": "assistant", "content": "The capital of France is Paris."},
+]
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _fetch(url: str, remaining_budget: int) -> tuple[bytes, int]:
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310 (pinned https HF URL)
+        if resp.status != 200:
+            raise RuntimeError(f"expected HTTP 200 fetching {url}, got {resp.status}")
+        read_cap = remaining_budget + 1
+        data = resp.read(read_cap)
+        if len(data) > remaining_budget:
+            raise RuntimeError(
+                f"fetch of {url} exceeded the remaining budget "
+                f"({remaining_budget} bytes) -- refusing to continue reading"
+            )
+        return data, remaining_budget - len(data)
+
+
+def fetch_all() -> dict[str, bytes]:
+    budget = MAX_FETCH_BYTES
+    out: dict[str, bytes] = {}
+    for name in FILES:
+        data, budget = _fetch(f"{BASE_URL}/{name}", budget)
+        out[name] = data
+        print(f"  fetched {name}: {len(data)} bytes, sha256={_sha256_bytes(data)}")
+    return out
+
+
+def _validate_runtime_versions() -> None:
+    import jinja2
+    import tokenizers
+
+    if tokenizers.__version__ != EXPECTED_TOKENIZERS_VERSION:
+        raise RuntimeError(
+            f"tokenizers=={tokenizers.__version__}, expected "
+            f"{EXPECTED_TOKENIZERS_VERSION} -- goldens generated under a "
+            "different tokenizers version are not trustworthy without "
+            "re-review; pin via uv.lock or update EXPECTED_TOKENIZERS_VERSION "
+            "deliberately"
+        )
+    if jinja2.__version__ != EXPECTED_JINJA2_VERSION:
+        raise RuntimeError(
+            f"jinja2=={jinja2.__version__}, expected {EXPECTED_JINJA2_VERSION} "
+            "-- see tokenizers version check above for rationale"
+        )
+    print(
+        f"  runtime versions OK: tokenizers=={tokenizers.__version__}, "
+        f"jinja2=={jinja2.__version__}"
+    )
+
+
+def generate_goldens(files: dict[str, bytes]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    from tokenizers import Tokenizer
+
+    tok = Tokenizer.from_file(str(_write_temp(files["tokenizer.json"])))
+
+    corpus_goldens = []
+    for case_id, category, text in CORPUS:
+        enc = tok.encode(text, add_special_tokens=False)
+        decoded = tok.decode(enc.ids)
+        corpus_goldens.append(
+            {
+                "id": case_id,
+                "category": category,
+                "text": text,
+                "ids": enc.ids,
+                "tokens": enc.tokens,
+                "decoded": decoded,
+            }
+        )
+
+    import jinja2
+
+    env = jinja2.Environment()
+    template = env.from_string(files["chat_template.jinja"].decode("utf-8"))
+    rendered = template.render(
+        messages=CHAT_MESSAGES,
+        bos_token="<bos>",
+        eos_token="<eos>",
+        add_generation_prompt=True,
+        tools=None,
+    )
+    rendered_ids = tok.encode(rendered, add_special_tokens=False).ids
+    chat_golden = {
+        "description": "2-turn conversation (user, assistant), add_generation_prompt=True",
+        "messages": CHAT_MESSAGES,
+        "rendered_text": rendered,
+        "ids": rendered_ids,
+    }
+
+    return corpus_goldens, chat_golden
+
+
+def _write_temp(data: bytes) -> Path:
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with open(fd, "wb") as f:
+        f.write(data)
+    return Path(path)
+
+
+def build_manifest(files: dict[str, bytes]) -> dict[str, Any]:
+    import jinja2
+    import tokenizers
+
+    return {
+        "source_repo": REPO,
+        "revision": REVISION,
+        "url_form": f"{BASE_URL}/<file>",
+        "files": {
+            name: {"bytes": len(data), "sha256": _sha256_bytes(data)}
+            for name, data in files.items()
+        },
+        "runtime_versions": {
+            "tokenizers": tokenizers.__version__,
+            "jinja2": jinja2.__version__,
+        },
+        "generator": "scripts/gemma4_tokenizer_goldens.py",
+        "adr": "ADR-082 Stage 1 (G17)",
+    }
+
+
+def cmd_verify() -> int:
+    print(f"Fetching from {BASE_URL} ...")
+    files = fetch_all()
+    _validate_runtime_versions()
+
+    if not MANIFEST_PATH.exists():
+        print("no committed manifest.json -- run --write-fixture first", file=sys.stderr)
+        return 1
+    committed_manifest = json.loads(MANIFEST_PATH.read_text())
+
+    ok = True
+    for name, data in files.items():
+        expected_sha = committed_manifest["files"].get(name, {}).get("sha256")
+        actual_sha = _sha256_bytes(data)
+        if expected_sha != actual_sha:
+            print(
+                f"DRIFT: {name} sha256 mismatch: committed={expected_sha} "
+                f"live={actual_sha}",
+                file=sys.stderr,
+            )
+            ok = False
+
+    corpus_goldens, chat_golden = generate_goldens(files)
+    committed_corpus = json.loads(CORPUS_GOLDENS_PATH.read_text())
+    committed_chat = json.loads(CHAT_TEMPLATE_GOLDEN_PATH.read_text())
+
+    if corpus_goldens != committed_corpus:
+        print("DRIFT: corpus_goldens.json does not match live generation", file=sys.stderr)
+        ok = False
+    if chat_golden != committed_chat:
+        print("DRIFT: chat_template_golden.json does not match live generation", file=sys.stderr)
+        ok = False
+
+    if not ok:
+        return 1
+    print("OK: fixtures match live fetch + regeneration, no drift.")
+    return 0
+
+
+def cmd_write_fixture() -> int:
+    print(f"Fetching from {BASE_URL} ...")
+    files = fetch_all()
+    _validate_runtime_versions()
+
+    FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    TOKENIZER_JSON_PATH.write_bytes(files["tokenizer.json"])
+    TOKENIZER_CONFIG_PATH.write_bytes(files["tokenizer_config.json"])
+    CHAT_TEMPLATE_JINJA_PATH.write_bytes(files["chat_template.jinja"])
+
+    corpus_goldens, chat_golden = generate_goldens(files)
+    CORPUS_GOLDENS_PATH.write_text(json.dumps(corpus_goldens, indent=2, ensure_ascii=False) + "\n")
+    CHAT_TEMPLATE_GOLDEN_PATH.write_text(json.dumps(chat_golden, indent=2, ensure_ascii=False) + "\n")
+
+    manifest = build_manifest(files)
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    print(f"Wrote fixtures to {FIXTURE_DIR}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write-fixture",
+        action="store_true",
+        help="regenerate the committed fixtures (deliberate, reviewable, never run by CI)",
+    )
+    args = parser.parse_args()
+
+    if args.write_fixture:
+        return cmd_write_fixture()
+    return cmd_verify()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gemma4_tokenizer_goldens.py
+++ b/scripts/gemma4_tokenizer_goldens.py
@@ -2,19 +2,24 @@
 """Generate/verify Gemma 4 E2B tokenizer + chat-template parity fixtures
 (ADR-082 Stage 1, G17).
 
-Downloads `tokenizer.json`, `tokenizer_config.json`, and `chat_template.jinja`
-from the checkpoint's pinned revision (the `/resolve/<commit>/` URL form, so
-the pin is real, not advisory), records their SHA-256 in a committed
-provenance manifest, and uses the HF `tokenizers` library (NOT
-`transformers.AutoTokenizer`, which does not know the `gemma4` architecture
-yet) plus `jinja2` to produce golden token IDs over a declared corpus and a
-2-turn chat-template rendering.
+Downloads `tokenizer.json`, `tokenizer_config.json`, `chat_template.jinja`,
+and `processor_config.json` from the checkpoint's pinned revision (the
+`/resolve/<commit>/` URL form, so the pin is real, not advisory), records
+their SHA-256 in a committed provenance manifest, and uses the HF
+`tokenizers` library (NOT `transformers.AutoTokenizer`, which does not know
+the `gemma4` architecture yet) plus `jinja2` to produce golden token IDs over
+a declared corpus, a 2-turn chat-template rendering, exact byte-fallback
+decode goldens (including invalid/incomplete UTF-8 byte runs), and the
+Stage-1 marker-expansion arithmetic goldens (ADR-082 G11/G15/G17: image
+placeholders expand to a fixed vision soft-token count, audio placeholders
+to a duration-derived, capped count) sourced from the fetched
+`processor_config.json`, not hardcoded.
 
 Pinned checkpoint (ADR-082): `google/gemma-4-E2B-it` @ revision
 `9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf`.
 
 Usage:
-    # Verify (default): re-fetch the three files, diff their SHA-256 against
+    # Verify (default): re-fetch the four files, diff their SHA-256 against
     # the committed manifest, regenerate goldens in-memory and diff against
     # the committed golden JSON. Fails closed on any drift. Touches the
     # network — not run by CI, a manual/periodic drift check.
@@ -39,8 +44,8 @@ REPO = "google/gemma-4-E2B-it"
 REVISION = "9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf"
 BASE_URL = f"https://huggingface.co/{REPO}/resolve/{REVISION}"
 
-# Hard cap on total bytes fetched by this script across all three files.
-# tokenizer.json is ~32.2 MB; 40 MB leaves headroom for the two small
+# Hard cap on total bytes fetched by this script across all four files.
+# tokenizer.json is ~32.2 MB; 40 MB leaves headroom for the three small
 # sidecar files without coming remotely close to the ~10.25 GB weight
 # payload a mistargeted URL could otherwise pull in.
 MAX_FETCH_BYTES = 40_000_000
@@ -57,11 +62,34 @@ FIXTURE_DIR = (
 MANIFEST_PATH = FIXTURE_DIR / "manifest.json"
 CORPUS_GOLDENS_PATH = FIXTURE_DIR / "corpus_goldens.json"
 CHAT_TEMPLATE_GOLDEN_PATH = FIXTURE_DIR / "chat_template_golden.json"
+DECODE_GOLDENS_PATH = FIXTURE_DIR / "decode_goldens.json"
+EXPANSION_GOLDENS_PATH = FIXTURE_DIR / "expansion_goldens.json"
 TOKENIZER_JSON_PATH = FIXTURE_DIR / "tokenizer.json"
 TOKENIZER_CONFIG_PATH = FIXTURE_DIR / "tokenizer_config.json"
 CHAT_TEMPLATE_JINJA_PATH = FIXTURE_DIR / "chat_template.jinja"
+PROCESSOR_CONFIG_PATH = FIXTURE_DIR / "processor_config.json"
 
-FILES = ["tokenizer.json", "tokenizer_config.json", "chat_template.jinja"]
+FILES = [
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "chat_template.jinja",
+    "processor_config.json",
+]
+
+# Byte-fallback decode goldens (ADR-082 Stage 1 major finding): `<0xE5>` (id
+# 467) and `<0x8F>` (id 381) are the first two bytes of the 3-byte UTF-8
+# encoding of "叫" (id 409 = `<0xAB>`, the third byte). `[467]` and
+# `[467, 381]` are, respectively, a lone incomplete lead byte and a 2-byte
+# run still missing its final continuation byte -- both invalid on their
+# own. The ordinary-token id is resolved from the live vocab (`"a"`) rather
+# than hardcoded, since only the byte-fallback ids are pinned by the
+# required-goldens contract.
+DECODE_CASES: list[tuple[str, list[int]]] = [
+    ("decode_lone_incomplete_lead_byte", [467]),
+    ("decode_two_byte_incomplete_run", [467, 381]),
+    ("decode_valid_three_byte_fallback_run", [467, 381, 409]),
+    ("decode_incomplete_run_then_ordinary_token", [467, 381, "a"]),
+]
 
 # Runtime versions this script was validated against (pinned in uv.lock as
 # transitive deps of `transformers`). A version drift is not necessarily
@@ -204,10 +232,14 @@ def _validate_runtime_versions() -> None:
     )
 
 
-def generate_goldens(files: dict[str, bytes]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+def generate_goldens(
+    files: dict[str, bytes],
+) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
     from tokenizers import Tokenizer
 
-    tok = Tokenizer.from_file(str(_write_temp(files["tokenizer.json"])))
+    # `Tokenizer.from_str` loads directly from the fetched JSON text -- no
+    # temporary file is written or needs cleaning up.
+    tok = Tokenizer.from_str(files["tokenizer.json"].decode("utf-8"))
 
     corpus_goldens = []
     for case_id, category, text in CORPUS:
@@ -243,16 +275,62 @@ def generate_goldens(files: dict[str, bytes]) -> tuple[list[dict[str, Any]], dic
         "ids": rendered_ids,
     }
 
-    return corpus_goldens, chat_golden
+    vocab = tok.get_vocab()
+    decode_goldens = []
+    for case_id, ids in DECODE_CASES:
+        resolved_ids = [vocab[i] if isinstance(i, str) else i for i in ids]
+        decode_goldens.append(
+            {
+                "id": case_id,
+                "ids": resolved_ids,
+                "decoded": tok.decode(resolved_ids),
+            }
+        )
+
+    expansion_goldens = generate_expansion_goldens(files["processor_config.json"])
+
+    return corpus_goldens, chat_golden, decode_goldens, expansion_goldens
 
 
-def _write_temp(data: bytes) -> Path:
-    import tempfile
+# ADR-082 Stage-1 marker-expansion arithmetic (G11/G15/G17): every
+# `<|image|>` marker expands to a fixed vision soft-token count; every
+# `<|audio|>` marker expands to a duration-derived count capped at the
+# processor's declared maximum. Mirrors `Gemma4Processor.replace_image_token`
+# / `_compute_audio_num_tokens`'s documented `ceil(duration_ms /
+# audio_ms_per_token)` cap in HF `transformers`
+# (`processing_gemma4.py`) -- the full mel-framing + conv-subsampling detail
+# behind that cap is Stage 6/9 (vision/audio end-to-end) scope, not Stage 1.
+def generate_expansion_goldens(processor_config_bytes: bytes) -> dict[str, Any]:
+    config = json.loads(processor_config_bytes)
+    image_seq_length = config["image_seq_length"]
+    audio_ms_per_token = config["audio_ms_per_token"]
+    audio_seq_length = config["audio_seq_length"]
 
-    fd, path = tempfile.mkstemp(suffix=".json")
-    with open(fd, "wb") as f:
-        f.write(data)
-    return Path(path)
+    def audio_tokens_for(duration_ms: int) -> int:
+        return min(-(-duration_ms // audio_ms_per_token), audio_seq_length)
+
+    image_cases = [
+        {"marker_count": 0, "expected_tokens": 0},
+        {"marker_count": 1, "expected_tokens": image_seq_length},
+        {"marker_count": 3, "expected_tokens": 3 * image_seq_length},
+    ]
+    audio_cases = [
+        {"durations_ms": [], "expected_tokens": []},
+        {"durations_ms": [1000], "expected_tokens": [audio_tokens_for(1000)]},
+        {
+            "durations_ms": [1000, 40_000],
+            "expected_tokens": [audio_tokens_for(1000), audio_tokens_for(40_000)],
+        },
+    ]
+    return {
+        "provenance": {
+            "image_seq_length": image_seq_length,
+            "audio_ms_per_token": audio_ms_per_token,
+            "audio_seq_length": audio_seq_length,
+        },
+        "image_cases": image_cases,
+        "audio_cases": audio_cases,
+    }
 
 
 def build_manifest(files: dict[str, bytes]) -> dict[str, Any]:
@@ -298,15 +376,23 @@ def cmd_verify() -> int:
             )
             ok = False
 
-    corpus_goldens, chat_golden = generate_goldens(files)
+    corpus_goldens, chat_golden, decode_goldens, expansion_goldens = generate_goldens(files)
     committed_corpus = json.loads(CORPUS_GOLDENS_PATH.read_text())
     committed_chat = json.loads(CHAT_TEMPLATE_GOLDEN_PATH.read_text())
+    committed_decode = json.loads(DECODE_GOLDENS_PATH.read_text())
+    committed_expansion = json.loads(EXPANSION_GOLDENS_PATH.read_text())
 
     if corpus_goldens != committed_corpus:
         print("DRIFT: corpus_goldens.json does not match live generation", file=sys.stderr)
         ok = False
     if chat_golden != committed_chat:
         print("DRIFT: chat_template_golden.json does not match live generation", file=sys.stderr)
+        ok = False
+    if decode_goldens != committed_decode:
+        print("DRIFT: decode_goldens.json does not match live generation", file=sys.stderr)
+        ok = False
+    if expansion_goldens != committed_expansion:
+        print("DRIFT: expansion_goldens.json does not match live generation", file=sys.stderr)
         ok = False
 
     if not ok:
@@ -324,10 +410,13 @@ def cmd_write_fixture() -> int:
     TOKENIZER_JSON_PATH.write_bytes(files["tokenizer.json"])
     TOKENIZER_CONFIG_PATH.write_bytes(files["tokenizer_config.json"])
     CHAT_TEMPLATE_JINJA_PATH.write_bytes(files["chat_template.jinja"])
+    PROCESSOR_CONFIG_PATH.write_bytes(files["processor_config.json"])
 
-    corpus_goldens, chat_golden = generate_goldens(files)
+    corpus_goldens, chat_golden, decode_goldens, expansion_goldens = generate_goldens(files)
     CORPUS_GOLDENS_PATH.write_text(json.dumps(corpus_goldens, indent=2, ensure_ascii=False) + "\n")
     CHAT_TEMPLATE_GOLDEN_PATH.write_text(json.dumps(chat_golden, indent=2, ensure_ascii=False) + "\n")
+    DECODE_GOLDENS_PATH.write_text(json.dumps(decode_goldens, indent=2, ensure_ascii=False) + "\n")
+    EXPANSION_GOLDENS_PATH.write_text(json.dumps(expansion_goldens, indent=2, ensure_ascii=False) + "\n")
 
     manifest = build_manifest(files)
     MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n")


### PR DESCRIPTION
## Summary

ADR-082 Stage 1 (Tokenizer + prompt-template parity, G17). Adds an **additive** `GemmaBpeTokenizer` (`crates/inference/src/tokenizer/gemma_bpe.rs`) implementing the literal-space `Split` pretokenizer + U+2581 metaspace `Replace` normalizer + byte-fallback BPE pipeline, read directly from the target `tokenizer.json` (`google/gemma-4-E2B-it` @ `9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf`) rather than guessed from training data.

Goldens-first, per this repo's differential-test-first practice: the HF-side golden generator and fixtures were produced and reviewed before the Rust tokenizer was written.

## Corpus coverage

`scripts/gemma4_tokenizer_goldens.py` generates `corpus_goldens.json` (21 cases) covering every category the Stage-1 gate requires:

| Category | Cases |
| --- | --- |
| `text` | ordinary English + punctuation |
| `unicode` | CJK, emoji (incl. ZWJ family emoji), combining marks, mixed CJK/Latin/emoji |
| `whitespace` | multi-space runs, tabs/newlines, leading/trailing spaces, whitespace-only, empty string |
| `byte_fallback` | rare 4-byte UTF-8 char (U+10300, decomposes to 4 `<0xXX>` tokens), private-use-area chars, replacement char |
| `marker` | `<\|image\|>`, `<\|audio\|>`, `<\|image>`/`<image\|>`, `<\|audio>`/`<audio\|>`, `<\|video\|>`, and the thought/tool/turn/channel markers (`<\|think\|>`, `<\|channel>`/`<channel\|>`, `<\|turn>`/`<turn\|>`, `<\|tool>`/`<tool\|>`, `<\|tool_call>`/`<tool_call\|>`, `<\|tool_response>`/`<tool_response\|>`) |

Plus `chat_template_golden.json`: a 2-turn (user, assistant) conversation rendered through the real `chat_template.jinja` with `add_generation_prompt=True`, both the rendered string and its token IDs.

Every case is asserted for **exact token-ID equality** against `GemmaBpeTokenizer`, plus a byte-for-byte decode round trip on the non-marker cases (`crates/inference/tests/gemma4_tokenizer_goldens_test.rs`).

## Golden provenance

- Source: `google/gemma-4-E2B-it` @ revision `9dbdf8a839e4e9e0eb56ed80cc8886661d3817cf` (pinned in the `/resolve/<revision>/` URL form, not advisory).
- Files fetched (bounded to 40 MB total, actual ~32.2 MB): `tokenizer.json` (sha256 `cc8d3a0c...7bfe0f`), `tokenizer_config.json` (sha256 `90c3a3ba...06f3df`), `chat_template.jinja` (sha256 `2f1b4d75...6613d082`) — full manifest with per-file sizes/hashes in `crates/inference/tests/fixtures/gemma4/tokenizer/manifest.json`.
- Generator runtime versions, pinned and validated before generation: HF `tokenizers==0.22.2`, `jinja2==3.1.6` (both locked transitively via `transformers` in `uv.lock`).
- A Rust test (`manifest_matches_committed_tokenizer_json_bytes`) re-hashes the committed fixture files and checks them against the manifest, offline — it doesn't re-fetch, but it does prove the committed bytes match their recorded provenance.

## Additive-path negative-test evidence

`crates/inference/src/tokenizer/bpe.rs`'s `validate_bpe_pretokenizer` (the existing Qwen-oriented loader's gate) still rejects this same `tokenizer.json` — proven by `existing_qwen_bpe_loader_rejects_gemma_tokenizer_json`, which feeds the real fixture into `BpeTokenizer::from_tokenizer_json_str` and asserts `Err`. `GemmaBpeTokenizer` is a separate type with its own explicit constructors (`from_tokenizer_json`/`from_tokenizer_json_str`), never reached through `load_tokenizer`'s or `tokenizer_from_json_str`'s model-type dispatch — selection is by explicit caller choice, not sniffing.

## Mutation cycles (run this session, both reverted before commit)

1. **Golden-ID mutation**: flipped `corpus_goldens.json`'s `ascii_ordinary` first token ID (818 → 819) → `corpus_goldens_match_exact_hf_token_ids` failed with a clear ID-mismatch panic. Reverted; test green again.
2. **Additive-path guard mutation**: temporarily made `is_supported_bpe_pretokenizer` unconditionally `return true` (simulating a silent widening of the general loader) → `existing_qwen_bpe_loader_rejects_gemma_tokenizer_json` failed loudly. Reverted; `cargo clippy -p lattice-inference --all-targets -- -D warnings` and the full test re-confirmed clean.

## Bench statement (ADR-058)

bench-compare not run: additive tokenizer path + fixtures, no existing engine path modified (structural). The only change to a pre-existing file (`bpe.rs`) is making an internal helper (`parse_merges_json`) `pub(crate)` so the new module can reuse the same merges-array parser — no behavioral change to any existing code path.

## Gates

- `cargo clippy -p lattice-inference --all-targets -- -D warnings` — clean
- `cargo test -p lattice-inference tokenizer` — green
- `cargo test -p lattice-inference gemma` — green (17 tests: 15 Stage-0 manifest + 2 matching this filter's substring from the new file)
- `cargo test -p lattice-inference --test gemma4_tokenizer_goldens_test` — 7/7 green
- `cargo check --workspace` — clean
- `cargo fmt -p lattice-inference` — applied, no outstanding diff

## Scope

Tokenizer module + fixtures + tests only, per ADR-082 sizing (Stage 1 = S). No config/loader/forward-pass work — that's Stage 2. The chat-template rendering golden covers only the plain 2-turn case (the real `chat_template.jinja` also handles tool calls, reasoning/thinking channels, and multi-turn continuation, which are out of scope here); the Rust side doesn't implement a Jinja renderer at all — it only tokenizes the HF-rendered golden string, so template rendering fidelity itself is not yet claimed for the tool-calling/reasoning branches.

Anchors #566, ADR-082 Stage 1.