### PR TITLE
feat(inference): Metal ViT forward gated vs S3a CPU reference (ADR-069 S3b)

### DIFF
--- a/crates/inference/src/forward/metal_gemm.rs
+++ b/crates/inference/src/forward/metal_gemm.rs
@@ -191,7 +191,7 @@ mod gpu {
 }
 
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
-pub use gpu::{metal_matmul, metal_matmul_bt};
+pub use gpu::{is_available, metal_matmul, metal_matmul_bt};
 
 // Stubs for non-macOS or non-metal builds.
 /// **Unstable**: Metal matmul B^T stub; returns false when metal-gpu feature is disabled.

--- a/crates/inference/src/vision/mod.rs
+++ b/crates/inference/src/vision/mod.rs
@@ -2,18 +2,19 @@
 //! not share weights, config, or forward-pass code, and nothing in the tree
 //! bridges between them.
 //!
-//! ## The real path: Qwen3.5-0.8B (ADR-069, S1-S3a shipped)
+//! ## The real path: Qwen3.5-0.8B (ADR-069, S1-S3b shipped)
 //!
 //! [`checkpoint::load_qwen35_vision_weights`] loads the real
 //! `model.visual.*` tensors (S1/S2); [`qwen35_vit::qwen35_vit_forward`] runs
 //! the depth-12/hidden-768 forward pass over them, producing pre-merger
 //! hidden states `[num_patches, hidden_size]` (S3a — CPU reference, gated at
 //! cosine > 0.999 vs a committed HF differential golden in
-//! `tests/vision_s3_vit_forward_test.rs`, wired as a required CI job). S3b
-//! (a Metal port verified against this CPU reference under the GPU lock) is
-//! the next fast-follow. S4 (spatial-merger + image-token expansion) and S5
-//! (decoder injection + M-RoPE) are unimplemented — **this is the path
-//! future vision work should build on.**
+//! `tests/vision_s3_vit_forward_test.rs`, wired as a required CI job).
+//! [`qwen35_vit_metal::qwen35_vit_forward_metal`] is the Metal port (S3b),
+//! gated against the S3a CPU reference under the machine GPU lock in
+//! `tests/vision_s3b_vit_metal_gate_test.rs`. S4 (spatial-merger +
+//! image-token expansion) and S5 (decoder injection + M-RoPE) are
+//! unimplemented — **this is the path future vision work should build on.**
 //!
 //! ```text
 //! image bytes → preprocess_qwen35_image → qwen35_vit_forward
@@ -72,6 +73,7 @@ pub mod merger;
 pub mod multimodal;
 pub mod preprocess;
 pub mod qwen35_vit;
+pub mod qwen35_vit_metal;
 pub mod vit;
 
 pub use config::VisionConfig;

--- a/crates/inference/src/vision/qwen35_vit.rs
+++ b/crates/inference/src/vision/qwen35_vit.rs
@@ -210,7 +210,12 @@ fn bilinear_pos_embed(
 /// `cos`/`sin` each `[head_dim]` (matches `apply_rotary_pos_emb_vision` in
 /// the HF reference: `x_embed = x * cos + rotate_half(x) * sin`, where
 /// `rotate_half(x) = cat(-x[half:], x[:half])`).
-fn apply_rope_inplace(x: &mut [f32], cos: &[f32], sin: &[f32]) {
+///
+/// `pub(crate)` so the S3b Metal port (`qwen35_vit_metal.rs`) can reuse this
+/// exact function for its own RoPE application rather than re-deriving the
+/// rotate-half convention (ADR-069 S3b's "zero independent convention
+/// decisions" contract).
+pub(crate) fn apply_rope_inplace(x: &mut [f32], cos: &[f32], sin: &[f32]) {
     let half = x.len() / 2;
     let mut rotated = vec![0.0f32; x.len()];
     for i in 0..half {
@@ -220,6 +225,85 @@ fn apply_rope_inplace(x: &mut [f32], cos: &[f32], sin: &[f32]) {
     for i in 0..x.len() {
         x[i] = x[i] * cos[i] + rotated[i] * sin[i];
     }
+}
+
+/// Build the per-patch bilinear-interpolated position-embedding contribution
+/// (`[n * hidden]`, to be added into the patch-embedded hidden states) and
+/// the per-patch 2-axis vision RoPE `cos`/`sin` tables (`[n * head_dim]`
+/// each), from the same block-major (spatial-merge-block-outer) patch order
+/// `preprocess_qwen35_image` produces. Factored out of [`qwen35_vit_forward`]
+/// so the S3b Metal port can reuse this exact CPU setup logic (cheap,
+/// deterministic table construction — not the heavy compute the Metal port
+/// targets) instead of re-deriving the interpolation/RoPE conventions.
+pub(crate) fn build_pos_embed_and_rope_tables(
+    weights: &Qwen35VisionWeights,
+    cfg: &VisionModelConfig,
+    grid: GridThw,
+) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+    let hidden = cfg.hidden_size;
+    let n = grid.num_patches();
+    let side = (cfg.num_position_embeddings as f64).sqrt().round() as usize;
+    let merge = cfg.spatial_merge_size;
+    let head_dim = hidden / cfg.num_heads;
+    let rope_dim = head_dim / 2; // matches Qwen3_5VisionRotaryEmbedding(head_dim // 2)
+    let rope_half = rope_dim / 2; // inv_freq has rope_dim/2 entries (arange(0, rope_dim, 2))
+    let theta = 10_000.0_f32;
+    let inv_freq: Vec<f32> = (0..rope_half)
+        .map(|i| 1.0 / theta.powf((2 * i) as f32 / rope_dim as f32))
+        .collect();
+
+    let mut pos_embed_contrib = vec![0.0f32; n * hidden];
+    let mut cos_table = vec![0.0f32; n * head_dim];
+    let mut sin_table = vec![0.0f32; n * head_dim];
+
+    let blocks_h = grid.h / merge;
+    let blocks_w = grid.w / merge;
+    let mut patch_idx = 0usize;
+    for block_row in 0..blocks_h {
+        for block_col in 0..blocks_w {
+            for sub_row in 0..merge {
+                for sub_col in 0..merge {
+                    let h_idx = block_row * merge + sub_row;
+                    let w_idx = block_col * merge + sub_col;
+
+                    let pos_slice =
+                        &mut pos_embed_contrib[patch_idx * hidden..(patch_idx + 1) * hidden];
+                    bilinear_pos_embed(
+                        &weights.pos_embed,
+                        hidden,
+                        side,
+                        grid.h,
+                        grid.w,
+                        h_idx,
+                        w_idx,
+                        pos_slice,
+                    );
+
+                    // rotary = concat(h*inv_freq, w*inv_freq)  [rope_dim]
+                    // emb = concat(rotary, rotary)             [head_dim]
+                    let mut rotary = vec![0.0f32; rope_dim];
+                    for i in 0..rope_half {
+                        rotary[i] = h_idx as f32 * inv_freq[i];
+                        rotary[rope_half + i] = w_idx as f32 * inv_freq[i];
+                    }
+                    let cos_row = &mut cos_table[patch_idx * head_dim..(patch_idx + 1) * head_dim];
+                    let sin_row = &mut sin_table[patch_idx * head_dim..(patch_idx + 1) * head_dim];
+                    for i in 0..rope_dim {
+                        let (s, c) = rotary[i].sin_cos();
+                        cos_row[i] = c;
+                        cos_row[rope_dim + i] = c;
+                        sin_row[i] = s;
+                        sin_row[rope_dim + i] = s;
+                    }
+
+                    patch_idx += 1;
+                }
+            }
+        }
+    }
+    debug_assert_eq!(patch_idx, n);
+
+    (pos_embed_contrib, cos_table, sin_table)
 }
 
 /// Run the real Qwen3.5 ViT forward pass over one image's preprocessed pixel
@@ -271,65 +355,12 @@ pub fn qwen35_vit_forward(
     // `preprocess_qwen35_image` already produced, so no separate reorder
     // permutation is needed here (unlike the HF reference, which computes
     // patches in plain raster order and permutes afterward). ----
-    let side = (cfg.num_position_embeddings as f64).sqrt().round() as usize;
-    let merge = cfg.spatial_merge_size;
     let head_dim = hidden / cfg.num_heads;
-    let rope_dim = head_dim / 2; // matches Qwen3_5VisionRotaryEmbedding(head_dim // 2)
-    let rope_half = rope_dim / 2; // inv_freq has rope_dim/2 entries (arange(0, rope_dim, 2))
-    let theta = 10_000.0_f32;
-    let inv_freq: Vec<f32> = (0..rope_half)
-        .map(|i| 1.0 / theta.powf((2 * i) as f32 / rope_dim as f32))
-        .collect();
-
-    let mut cos_table = vec![0.0f32; n * head_dim];
-    let mut sin_table = vec![0.0f32; n * head_dim];
-
-    let blocks_h = grid.h / merge;
-    let blocks_w = grid.w / merge;
-    let mut patch_idx = 0usize;
-    for block_row in 0..blocks_h {
-        for block_col in 0..blocks_w {
-            for sub_row in 0..merge {
-                for sub_col in 0..merge {
-                    let h_idx = block_row * merge + sub_row;
-                    let w_idx = block_col * merge + sub_col;
-
-                    let pos_slice =
-                        &mut hidden_states[patch_idx * hidden..(patch_idx + 1) * hidden];
-                    bilinear_pos_embed(
-                        &weights.pos_embed,
-                        hidden,
-                        side,
-                        grid.h,
-                        grid.w,
-                        h_idx,
-                        w_idx,
-                        pos_slice,
-                    );
-
-                    // rotary = concat(h*inv_freq, w*inv_freq)  [rope_dim]
-                    // emb = concat(rotary, rotary)             [head_dim]
-                    let mut rotary = vec![0.0f32; rope_dim];
-                    for i in 0..rope_half {
-                        rotary[i] = h_idx as f32 * inv_freq[i];
-                        rotary[rope_half + i] = w_idx as f32 * inv_freq[i];
-                    }
-                    let cos_row = &mut cos_table[patch_idx * head_dim..(patch_idx + 1) * head_dim];
-                    let sin_row = &mut sin_table[patch_idx * head_dim..(patch_idx + 1) * head_dim];
-                    for i in 0..rope_dim {
-                        let (s, c) = rotary[i].sin_cos();
-                        cos_row[i] = c;
-                        cos_row[rope_dim + i] = c;
-                        sin_row[i] = s;
-                        sin_row[rope_dim + i] = s;
-                    }
-
-                    patch_idx += 1;
-                }
-            }
-        }
+    let (pos_embed_contrib, cos_table, sin_table) =
+        build_pos_embed_and_rope_tables(weights, cfg, grid);
+    for i in 0..n * hidden {
+        hidden_states[i] += pos_embed_contrib[i];
     }
-    debug_assert_eq!(patch_idx, n);
 
     let scale = 1.0_f32 / (head_dim as f32).sqrt();
     let n_heads = cfg.num_heads;

--- a/crates/inference/src/vision/qwen35_vit_metal.rs
+++ b/crates/inference/src/vision/qwen35_vit_metal.rs
@@ -49,6 +49,7 @@ mod gpu {
     use super::super::vit::{gelu, layer_norm, softmax_inplace};
     use crate::forward::metal_gemm::{metal_matmul, metal_matmul_bt};
     use crate::model::qwen35_config::VisionModelConfig;
+    #[cfg(feature = "test-utils")]
     use std::sync::atomic::{AtomicU64, Ordering};
 
     /// Test-only diagnostic (issue: S3b gate review — cosine parity alone
@@ -56,22 +57,29 @@ mod gpu {
     /// fell back to the CPU loop below", since the fallback is exact). Counts
     /// GEMM calls that actually dispatched to the GPU (`metal_matmul`/
     /// `metal_matmul_bt` returned `true`), not calls that took the CPU
-    /// fallback branch. Global by design, mirroring the opt-in
-    /// `PathProofCounters` pattern in `forward/metal_qwen35.rs` (issue #239),
-    /// scoped down to a single atomic since this module has one dispatch
-    /// pair (`gemm_bt`/`gemm_nn`) rather than many distinct kernels. Read via
+    /// fallback branch. Compiled only under the non-default `test-utils`
+    /// feature (see `Cargo.toml`), so the normal production `metal-gpu` build
+    /// carries neither the storage nor the `fetch_add` at each dispatch site
+    /// — unlike the opt-in-flag `PathProofCounters` pattern in
+    /// `forward/metal_qwen35.rs` (issue #239), which stays compiled in and
+    /// gates the atomic op behind a runtime check instead. Read via
     /// [`metal_dispatch_count`] / zeroed via [`reset_metal_dispatch_count`];
     /// see `tests/vision_s3b_vit_metal_gate_test.rs`.
+    #[cfg(feature = "test-utils")]
     static METAL_DISPATCH_COUNT: AtomicU64 = AtomicU64::new(0);
 
     /// Returns the number of Metal GEMM calls dispatched to the GPU (as
     /// opposed to the CPU fallback branch) since the last
-    /// [`reset_metal_dispatch_count`] call. Test-only diagnostic.
+    /// [`reset_metal_dispatch_count`] call. Test-only diagnostic, compiled
+    /// only under the `test-utils` feature.
+    #[cfg(feature = "test-utils")]
     pub fn metal_dispatch_count() -> u64 {
         METAL_DISPATCH_COUNT.load(Ordering::Relaxed)
     }
 
-    /// Resets the Metal GEMM dispatch counter to zero. Test-only diagnostic.
+    /// Resets the Metal GEMM dispatch counter to zero. Test-only diagnostic,
+    /// compiled only under the `test-utils` feature.
+    #[cfg(feature = "test-utils")]
     pub fn reset_metal_dispatch_count() {
         METAL_DISPATCH_COUNT.store(0, Ordering::Relaxed);
     }
@@ -86,6 +94,7 @@ mod gpu {
     fn gemm_bt(a: &[f32], b: &[f32], m: usize, k: usize, n: usize) -> Vec<f32> {
         let mut c = vec![0.0f32; m * n];
         if metal_matmul_bt(a, b, &mut c, m, k, n) {
+            #[cfg(feature = "test-utils")]
             METAL_DISPATCH_COUNT.fetch_add(1, Ordering::Relaxed);
         } else {
             for i in 0..m {
@@ -108,6 +117,7 @@ mod gpu {
     fn gemm_nn(a: &[f32], b: &[f32], m: usize, k: usize, n: usize) -> Vec<f32> {
         let mut c = vec![0.0f32; m * n];
         if metal_matmul(a, b, &mut c, m, k, n) {
+            #[cfg(feature = "test-utils")]
             METAL_DISPATCH_COUNT.fetch_add(1, Ordering::Relaxed);
         } else {
             for i in 0..m {
@@ -303,7 +313,9 @@ mod gpu {
 pub use gpu::qwen35_vit_forward_metal;
 
 /// Test-only diagnostic re-exports — see [`gpu::metal_dispatch_count`] docs.
-#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+/// Gated on `test-utils` in addition to `metal-gpu` so the normal production
+/// build carries neither the counter storage nor its `fetch_add` sites.
+#[cfg(all(target_os = "macos", feature = "metal-gpu", feature = "test-utils"))]
 pub use gpu::{metal_dispatch_count, reset_metal_dispatch_count};
 
 /// Stub for builds without the `metal-gpu` feature (or off macOS): returns a

--- a/crates/inference/src/vision/qwen35_vit_metal.rs
+++ b/crates/inference/src/vision/qwen35_vit_metal.rs
@@ -49,6 +49,32 @@ mod gpu {
     use super::super::vit::{gelu, layer_norm, softmax_inplace};
     use crate::forward::metal_gemm::{metal_matmul, metal_matmul_bt};
     use crate::model::qwen35_config::VisionModelConfig;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Test-only diagnostic (issue: S3b gate review — cosine parity alone
+    /// can't distinguish "every GEMM ran on Metal" from "every GEMM silently
+    /// fell back to the CPU loop below", since the fallback is exact). Counts
+    /// GEMM calls that actually dispatched to the GPU (`metal_matmul`/
+    /// `metal_matmul_bt` returned `true`), not calls that took the CPU
+    /// fallback branch. Global by design, mirroring the opt-in
+    /// `PathProofCounters` pattern in `forward/metal_qwen35.rs` (issue #239),
+    /// scoped down to a single atomic since this module has one dispatch
+    /// pair (`gemm_bt`/`gemm_nn`) rather than many distinct kernels. Read via
+    /// [`metal_dispatch_count`] / zeroed via [`reset_metal_dispatch_count`];
+    /// see `tests/vision_s3b_vit_metal_gate_test.rs`.
+    static METAL_DISPATCH_COUNT: AtomicU64 = AtomicU64::new(0);
+
+    /// Returns the number of Metal GEMM calls dispatched to the GPU (as
+    /// opposed to the CPU fallback branch) since the last
+    /// [`reset_metal_dispatch_count`] call. Test-only diagnostic.
+    pub fn metal_dispatch_count() -> u64 {
+        METAL_DISPATCH_COUNT.load(Ordering::Relaxed)
+    }
+
+    /// Resets the Metal GEMM dispatch counter to zero. Test-only diagnostic.
+    pub fn reset_metal_dispatch_count() {
+        METAL_DISPATCH_COUNT.store(0, Ordering::Relaxed);
+    }
 
     /// `C[m, n] = A[m, k] @ B[n, k]^T`, dispatched to Metal when the codebase's
     /// existing `metal_matmul_bt` accepts the shape (real ViT geometry always
@@ -59,7 +85,9 @@ mod gpu {
     /// `[n, k]` row-major, i.e. PyTorch `nn.Linear` layout).
     fn gemm_bt(a: &[f32], b: &[f32], m: usize, k: usize, n: usize) -> Vec<f32> {
         let mut c = vec![0.0f32; m * n];
-        if !metal_matmul_bt(a, b, &mut c, m, k, n) {
+        if metal_matmul_bt(a, b, &mut c, m, k, n) {
+            METAL_DISPATCH_COUNT.fetch_add(1, Ordering::Relaxed);
+        } else {
             for i in 0..m {
                 let ai = &a[i * k..(i + 1) * k];
                 for j in 0..n {
@@ -76,10 +104,12 @@ mod gpu {
     }
 
     /// `C[m, n] = A[m, k] @ B[k, n]`, dispatched to Metal via `metal_matmul`;
-    /// same CPU-fallback contract as [`gemm_bt`].
+    /// same CPU-fallback contract and dispatch-counting as [`gemm_bt`].
     fn gemm_nn(a: &[f32], b: &[f32], m: usize, k: usize, n: usize) -> Vec<f32> {
         let mut c = vec![0.0f32; m * n];
-        if !metal_matmul(a, b, &mut c, m, k, n) {
+        if metal_matmul(a, b, &mut c, m, k, n) {
+            METAL_DISPATCH_COUNT.fetch_add(1, Ordering::Relaxed);
+        } else {
             for i in 0..m {
                 let ai = &a[i * k..(i + 1) * k];
                 for j in 0..n {
@@ -271,6 +301,10 @@ mod gpu {
 
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub use gpu::qwen35_vit_forward_metal;
+
+/// Test-only diagnostic re-exports — see [`gpu::metal_dispatch_count`] docs.
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+pub use gpu::{metal_dispatch_count, reset_metal_dispatch_count};
 
 /// Stub for builds without the `metal-gpu` feature (or off macOS): returns a
 /// clear error instead of silently running a CPU-only re-implementation, so

--- a/crates/inference/src/vision/qwen35_vit_metal.rs
+++ b/crates/inference/src/vision/qwen35_vit_metal.rs
@@ -1,0 +1,412 @@
+//! Metal port of the Qwen3.5-0.8B ViT forward pass (ADR-069 S3b), gated
+//! against the S3a CPU reference ([`super::qwen35_vit::qwen35_vit_forward`]).
+//!
+//! **Zero independent convention decisions**: every layout/normalization/
+//! activation/RoPE convention here is inherited directly from the CPU
+//! reference — the setup tables (bilinear position-embedding interpolation,
+//! 2-axis vision RoPE `cos`/`sin` construction) are computed by literally
+//! calling [`super::qwen35_vit::build_pos_embed_and_rope_tables`], and the
+//! per-element ops (biased `LayerNorm`, GELU-tanh, RoPE rotate-half
+//! application, fail-closed softmax) reuse the exact CPU reference functions
+//! (`layer_norm`, `gelu`, `apply_rope_inplace`, `softmax_inplace`) rather
+//! than re-deriving them. Only the GEMM-heavy compute — patch embedding,
+//! fused QKV projection, the two attention matmuls (`Q @ K^T` and
+//! `scores @ V`), the output projection, and the MLP `fc1`/`fc2` — is
+//! dispatched to the Metal GPU via [`crate::forward::metal_gemm`]'s existing
+//! `metal_matmul` / `metal_matmul_bt` kernels (reused as-is, not
+//! reimplemented — these already carry the codebase's tiled-GEMM Metal
+//! shader and CPU-availability fallback). Those GEMMs account for well over
+//! 99% of the forward pass's FLOPs at the real depth-12/hidden-768/12-head
+//! geometry; the reused elementwise CPU functions are the strongest form of
+//! convention mirroring available (literally the same code, not a
+//! re-implementation), and their cost is negligible relative to the GEMMs.
+//!
+//! Gate: `tests/vision_s3b_vit_metal_gate_test.rs` — cosine > 0.999 between
+//! this forward and the S3a CPU reference on the same (synthetic,
+//! deterministic) weights and the committed golden fixture image, under the
+//! machine-wide `gpu_test_lock()`.
+
+#[allow(unused_imports)] // only used by the non-metal-gpu stub below
+use super::VisionError;
+#[allow(unused_imports)]
+use super::checkpoint::Qwen35VisionWeights;
+#[allow(unused_imports)]
+use super::qwen35_vit::GridThw;
+#[allow(unused_imports)]
+use crate::model::qwen35_config::VisionModelConfig;
+
+// Real implementation lives behind the same `metal-gpu` feature gating as
+// the rest of the codebase's Metal code (`metal_gemm.rs`'s `mod gpu { .. }`
+// pattern, reused here). A stub below keeps the symbol callable — returning
+// a clear error — from builds where the feature is off, so callers (and the
+// S3b gate test) don't need to sprinkle `cfg` at every call site.
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+mod gpu {
+    use super::super::VisionError;
+    use super::super::checkpoint::Qwen35VisionWeights;
+    use super::super::qwen35_vit::GridThw;
+    use super::super::qwen35_vit::{apply_rope_inplace, build_pos_embed_and_rope_tables};
+    use super::super::vit::{gelu, layer_norm, softmax_inplace};
+    use crate::forward::metal_gemm::{metal_matmul, metal_matmul_bt};
+    use crate::model::qwen35_config::VisionModelConfig;
+
+    /// `C[m, n] = A[m, k] @ B[n, k]^T`, dispatched to Metal when the codebase's
+    /// existing `metal_matmul_bt` accepts the shape (real ViT geometry always
+    /// clears its GPU-dispatch-threshold); falls back to the identical CPU dot
+    /// product otherwise, so the result is correct regardless of GPU
+    /// availability. This is the exact math [`super::qwen35_vit::qwen35_vit`]'s
+    /// `batch_matvec` performs (`A` = activations `[m, k]`, `B` = weight
+    /// `[n, k]` row-major, i.e. PyTorch `nn.Linear` layout).
+    fn gemm_bt(a: &[f32], b: &[f32], m: usize, k: usize, n: usize) -> Vec<f32> {
+        let mut c = vec![0.0f32; m * n];
+        if !metal_matmul_bt(a, b, &mut c, m, k, n) {
+            for i in 0..m {
+                let ai = &a[i * k..(i + 1) * k];
+                for j in 0..n {
+                    let bj = &b[j * k..(j + 1) * k];
+                    let mut acc = 0.0f32;
+                    for t in 0..k {
+                        acc += ai[t] * bj[t];
+                    }
+                    c[i * n + j] = acc;
+                }
+            }
+        }
+        c
+    }
+
+    /// `C[m, n] = A[m, k] @ B[k, n]`, dispatched to Metal via `metal_matmul`;
+    /// same CPU-fallback contract as [`gemm_bt`].
+    fn gemm_nn(a: &[f32], b: &[f32], m: usize, k: usize, n: usize) -> Vec<f32> {
+        let mut c = vec![0.0f32; m * n];
+        if !metal_matmul(a, b, &mut c, m, k, n) {
+            for i in 0..m {
+                let ai = &a[i * k..(i + 1) * k];
+                for j in 0..n {
+                    let mut acc = 0.0f32;
+                    for t in 0..k {
+                        acc += ai[t] * b[t * n + j];
+                    }
+                    c[i * n + j] = acc;
+                }
+            }
+        }
+        c
+    }
+
+    /// Full (unwindowed) self-attention, mirroring
+    /// [`super::qwen35_vit::qwen35_vit`]'s `multihead_attention_full` exactly
+    /// (same per-head Q/K/V extraction, same `scale` application order, same
+    /// fail-closed row softmax reused directly), but with the two `[n, n]`- and
+    /// `[n, head_dim]`-shaped matmuls per head dispatched to Metal.
+    fn multihead_attention_full_metal(
+        qkv: &[f32],
+        n: usize,
+        hidden: usize,
+        n_heads: usize,
+        head_dim: usize,
+        scale: f32,
+    ) -> Vec<f32> {
+        let mut out = vec![0.0f32; n * hidden];
+
+        for h in 0..n_heads {
+            let mut q_h = vec![0.0f32; n * head_dim];
+            let mut k_h = vec![0.0f32; n * head_dim];
+            let mut v_h = vec![0.0f32; n * head_dim];
+            for i in 0..n {
+                let base = i * 3 * hidden;
+                q_h[i * head_dim..(i + 1) * head_dim]
+                    .copy_from_slice(&qkv[base + h * head_dim..base + (h + 1) * head_dim]);
+                k_h[i * head_dim..(i + 1) * head_dim].copy_from_slice(
+                    &qkv[base + hidden + h * head_dim..base + hidden + (h + 1) * head_dim],
+                );
+                v_h[i * head_dim..(i + 1) * head_dim].copy_from_slice(
+                    &qkv[base + 2 * hidden + h * head_dim..base + 2 * hidden + (h + 1) * head_dim],
+                );
+            }
+
+            // scores[n, n] = Q_h @ K_h^T, then scale (same order as the CPU
+            // reference: dot product first, `* scale` applied to the raw dot).
+            let mut scores = gemm_bt(&q_h, &k_h, n, head_dim, n);
+            for s in scores.iter_mut() {
+                *s *= scale;
+            }
+            for i in 0..n {
+                softmax_inplace(&mut scores[i * n..(i + 1) * n]);
+            }
+
+            // out_h[n, head_dim] = scores @ V_h
+            let out_h = gemm_nn(&scores, &v_h, n, n, head_dim);
+            for i in 0..n {
+                out[i * hidden + h * head_dim..i * hidden + (h + 1) * head_dim]
+                    .copy_from_slice(&out_h[i * head_dim..(i + 1) * head_dim]);
+            }
+        }
+
+        out
+    }
+
+    /// Metal port of [`super::qwen35_vit::qwen35_vit_forward`]. Same signature,
+    /// same output contract (`[num_patches, hidden_size]` pre-merger hidden
+    /// states, no post-block normalization). See module docs for the
+    /// GPU/CPU-reuse split.
+    ///
+    /// # Errors
+    ///
+    /// [`VisionError::ShapeMismatch`] if `pixel_values.len()` doesn't match
+    /// `grid.num_patches() * (in_channels * temporal_patch_size * patch_size^2)`.
+    pub fn qwen35_vit_forward_metal(
+        weights: &Qwen35VisionWeights,
+        cfg: &VisionModelConfig,
+        pixel_values: &[f32],
+        grid: GridThw,
+    ) -> Result<Vec<f32>, VisionError> {
+        let hidden = cfg.hidden_size;
+        let n = grid.num_patches();
+        let patch_len = cfg.in_channels * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
+        if pixel_values.len() != n * patch_len {
+            return Err(VisionError::ShapeMismatch {
+                expected: n * patch_len,
+                actual: pixel_values.len(),
+                context: "qwen35_vit_forward_metal: pixel_values length".into(),
+            });
+        }
+
+        // ---- Patch embedding (Metal GEMM). ----
+        let mut hidden_states = gemm_bt(
+            pixel_values,
+            &weights.patch_embed_weight,
+            n,
+            patch_len,
+            hidden,
+        );
+        for i in 0..n {
+            for j in 0..hidden {
+                hidden_states[i * hidden + j] += weights.patch_embed_bias[j];
+            }
+        }
+
+        // ---- Position embedding + RoPE tables: exact CPU-reference setup reuse. ----
+        let head_dim = hidden / cfg.num_heads;
+        let (pos_embed_contrib, cos_table, sin_table) =
+            build_pos_embed_and_rope_tables(weights, cfg, grid);
+        for i in 0..n * hidden {
+            hidden_states[i] += pos_embed_contrib[i];
+        }
+
+        let scale = 1.0_f32 / (head_dim as f32).sqrt();
+        let n_heads = cfg.num_heads;
+
+        for block in &weights.blocks {
+            // -- Attention sub-layer --
+            let residual = hidden_states.clone();
+            let mut normed = hidden_states.clone();
+            for i in 0..n {
+                layer_norm(
+                    &mut normed[i * hidden..(i + 1) * hidden],
+                    &block.norm1_weight,
+                    &block.norm1_bias,
+                    1e-6,
+                );
+            }
+
+            let mut qkv = gemm_bt(&normed, &block.qkv_weight, n, hidden, 3 * hidden);
+            for i in 0..n {
+                for j in 0..3 * hidden {
+                    qkv[i * 3 * hidden + j] += block.qkv_bias[j];
+                }
+            }
+
+            // Apply RoPE to Q and K in place, per head — exact CPU-reference
+            // rotate-half function, reused directly (not re-derived).
+            for i in 0..n {
+                let base = i * 3 * hidden;
+                let cos_row = &cos_table[i * head_dim..(i + 1) * head_dim];
+                let sin_row = &sin_table[i * head_dim..(i + 1) * head_dim];
+                for h in 0..n_heads {
+                    let q = &mut qkv[base + h * head_dim..base + (h + 1) * head_dim];
+                    apply_rope_inplace(q, cos_row, sin_row);
+                    let k_base = base + hidden;
+                    let k = &mut qkv[k_base + h * head_dim..k_base + (h + 1) * head_dim];
+                    apply_rope_inplace(k, cos_row, sin_row);
+                }
+            }
+
+            let attn_out =
+                multihead_attention_full_metal(&qkv, n, hidden, n_heads, head_dim, scale);
+            let proj_out = gemm_bt(&attn_out, &block.proj_weight, n, hidden, hidden);
+            for i in 0..n * hidden {
+                hidden_states[i] = residual[i] + proj_out[i] + block.proj_bias[i % hidden];
+            }
+
+            // -- MLP sub-layer --
+            let residual = hidden_states.clone();
+            let mut normed = hidden_states.clone();
+            for i in 0..n {
+                layer_norm(
+                    &mut normed[i * hidden..(i + 1) * hidden],
+                    &block.norm2_weight,
+                    &block.norm2_bias,
+                    1e-6,
+                );
+            }
+
+            let mlp_dim = block.fc1_bias.len();
+            let mut fc1_out = gemm_bt(&normed, &block.fc1_weight, n, hidden, mlp_dim);
+            for i in 0..n {
+                for j in 0..mlp_dim {
+                    let idx = i * mlp_dim + j;
+                    fc1_out[idx] = gelu(fc1_out[idx] + block.fc1_bias[j]);
+                }
+            }
+            let fc2_out = gemm_bt(&fc1_out, &block.fc2_weight, n, mlp_dim, hidden);
+            for i in 0..n * hidden {
+                hidden_states[i] = residual[i] + fc2_out[i] + block.fc2_bias[i % hidden];
+            }
+        }
+
+        Ok(hidden_states)
+    }
+} // mod gpu
+
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+pub use gpu::qwen35_vit_forward_metal;
+
+/// Stub for builds without the `metal-gpu` feature (or off macOS): returns a
+/// clear error instead of silently running a CPU-only re-implementation, so
+/// callers can tell "Metal unavailable" apart from "Metal ran and matched".
+#[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+pub fn qwen35_vit_forward_metal(
+    _weights: &Qwen35VisionWeights,
+    _cfg: &VisionModelConfig,
+    _pixel_values: &[f32],
+    _grid: GridThw,
+) -> Result<Vec<f32>, VisionError> {
+    Err(VisionError::InvalidConfig(
+        "qwen35_vit_forward_metal requires the `metal-gpu` feature on macOS".into(),
+    ))
+}
+
+#[cfg(all(test, target_os = "macos", feature = "metal-gpu"))]
+mod tests {
+    use super::gpu::qwen35_vit_forward_metal;
+    use super::*;
+    use crate::vision::checkpoint::{VisualBlockWeights, VisualMergerWeights};
+    use crate::vision::qwen35_vit::{preprocess_qwen35_image, qwen35_vit_forward};
+
+    fn tiny_cfg() -> VisionModelConfig {
+        VisionModelConfig {
+            depth: 1,
+            hidden_size: 8,
+            num_heads: 2,
+            patch_size: 2,
+            spatial_merge_size: 2,
+            out_hidden_size: 8,
+            temporal_patch_size: 1,
+            num_position_embeddings: 16,
+            in_channels: 1,
+            deepstack_visual_indexes: vec![],
+        }
+    }
+
+    fn make_test_png(w: u32, h: u32) -> Vec<u8> {
+        use image::RgbImage;
+        let mut img = RgbImage::new(w, h);
+        for y in 0..h {
+            for x in 0..w {
+                let v = ((x + y) % 256) as u8;
+                img.put_pixel(x, y, image::Rgb([v, v, v]));
+            }
+        }
+        let mut buf = Vec::new();
+        img.write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png)
+            .unwrap();
+        buf
+    }
+
+    fn make_test_weights(cfg: &VisionModelConfig) -> Qwen35VisionWeights {
+        let hidden = cfg.hidden_size;
+        let patch_len = cfg.in_channels * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
+        let mlp_dim = 2 * hidden;
+        let merge_in = cfg.spatial_merge_size * cfg.spatial_merge_size * hidden;
+
+        let mut state = 0x1234_5678_u32;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            (state as f32 / u32::MAX as f32) * 0.2 - 0.1
+        };
+        let mut v = |n: usize| (0..n).map(|_| next()).collect::<Vec<f32>>();
+
+        let block = VisualBlockWeights {
+            qkv_weight: v(3 * hidden * hidden),
+            qkv_bias: v(3 * hidden),
+            proj_weight: v(hidden * hidden),
+            proj_bias: v(hidden),
+            fc1_weight: v(mlp_dim * hidden),
+            fc1_bias: v(mlp_dim),
+            fc2_weight: v(hidden * mlp_dim),
+            fc2_bias: v(hidden),
+            norm1_weight: vec![1.0; hidden],
+            norm1_bias: vec![0.0; hidden],
+            norm2_weight: vec![1.0; hidden],
+            norm2_bias: vec![0.0; hidden],
+        };
+
+        Qwen35VisionWeights {
+            patch_embed_weight: v(hidden * patch_len),
+            patch_embed_weight_shape: vec![
+                hidden,
+                cfg.in_channels,
+                cfg.temporal_patch_size,
+                cfg.patch_size,
+                cfg.patch_size,
+            ],
+            patch_embed_bias: v(hidden),
+            pos_embed: v(cfg.num_position_embeddings * hidden),
+            blocks: vec![block],
+            merger: VisualMergerWeights {
+                fc1_weight: v(merge_in * merge_in),
+                fc1_bias: v(merge_in),
+                fc2_weight: v(cfg.out_hidden_size * merge_in),
+                fc2_bias: v(cfg.out_hidden_size),
+                norm_weight: vec![1.0; hidden],
+                norm_bias: vec![0.0; hidden],
+            },
+        }
+    }
+
+    /// Below-GPU-dispatch-threshold shapes exercise the CPU-fallback path in
+    /// `gemm_bt`/`gemm_nn` on every platform (no Metal device required),
+    /// proving the fallback math matches the CPU reference exactly.
+    #[test]
+    fn metal_forward_matches_cpu_reference_small_shapes() {
+        let cfg = tiny_cfg();
+        let weights = make_test_weights(&cfg);
+        let png = make_test_png(8, 8);
+        let (pixel_values, grid) = preprocess_qwen35_image(&png, &cfg).expect("preprocess");
+
+        let cpu_out = qwen35_vit_forward(&weights, &cfg, &pixel_values, grid).expect("cpu forward");
+        let metal_out =
+            qwen35_vit_forward_metal(&weights, &cfg, &pixel_values, grid).expect("metal forward");
+
+        assert_eq!(cpu_out.len(), metal_out.len());
+        for (a, b) in cpu_out.iter().zip(metal_out.iter()) {
+            assert!(
+                (a - b).abs() < 1e-4,
+                "cpu={a} metal={b} diverge beyond fallback-path tolerance"
+            );
+        }
+    }
+
+    #[test]
+    fn metal_forward_rejects_pixel_length_mismatch() {
+        let cfg = tiny_cfg();
+        let weights = make_test_weights(&cfg);
+        let grid = GridThw { t: 1, h: 4, w: 4 };
+        let bad_pixels = vec![0.0f32; 3];
+        let err = qwen35_vit_forward_metal(&weights, &cfg, &bad_pixels, grid).unwrap_err();
+        assert!(matches!(err, VisionError::ShapeMismatch { .. }));
+    }
+}

--- a/crates/inference/tests/vision_s3b_vit_metal_gate_test.rs
+++ b/crates/inference/tests/vision_s3b_vit_metal_gate_test.rs
@@ -28,7 +28,17 @@
 //! `bin/bench_gdn_prefill_ab.rs`) before any Metal work, and runs
 //! `--test-threads=1`-safe (each test acquires its own lock instance).
 //!
-//! Run:
+//! The dispatch-count proof (see `expected_dispatch_count`/
+//! `assert_dispatch_count` below) is only compiled in under the non-default
+//! `test-utils` feature, since the counter it reads is itself feature-gated
+//! out of the production `metal-gpu` library build. Run the full gate
+//! (cosine + dispatch-count) with:
+//! ```bash
+//! cargo test --release -p lattice-inference --features f16,metal-gpu,test-utils \
+//!     --test vision_s3b_vit_metal_gate_test -- --nocapture --test-threads=1
+//! ```
+//! Without `test-utils`, the same command still compiles and runs the cosine
+//! gate, just without the dispatch-count assertion:
 //! ```bash
 //! cargo test --release -p lattice-inference --features f16,metal-gpu \
 //!     --test vision_s3b_vit_metal_gate_test -- --nocapture --test-threads=1
@@ -46,8 +56,10 @@ mod gated {
         Qwen35VisionWeights, VisualBlockWeights, VisualMergerWeights,
     };
     use lattice_inference::vision::qwen35_vit::{preprocess_qwen35_image, qwen35_vit_forward};
+    use lattice_inference::vision::qwen35_vit_metal::qwen35_vit_forward_metal;
+    #[cfg(feature = "test-utils")]
     use lattice_inference::vision::qwen35_vit_metal::{
-        metal_dispatch_count, qwen35_vit_forward_metal, reset_metal_dispatch_count,
+        metal_dispatch_count, reset_metal_dispatch_count,
     };
 
     fn fixture_dir() -> std::path::PathBuf {
@@ -220,6 +232,35 @@ mod gated {
         (1 + cfg.depth * per_block) as u64
     }
 
+    /// Dispatch-count accounting is only compiled into the library under the
+    /// non-default `test-utils` feature (review follow-up: the counter must
+    /// not run in a normal production `metal-gpu` build). These helpers make
+    /// that opt-in a no-op here too, so `cargo test --features f16,metal-gpu`
+    /// (without `test-utils`) still compiles and runs the cosine gate below,
+    /// just without the dispatch-count proof.
+    #[cfg(feature = "test-utils")]
+    fn reset_dispatch_count() {
+        reset_metal_dispatch_count();
+    }
+
+    #[cfg(not(feature = "test-utils"))]
+    fn reset_dispatch_count() {}
+
+    #[cfg(feature = "test-utils")]
+    fn assert_dispatch_count(expected: u64) {
+        let dispatches = metal_dispatch_count();
+        eprintln!("LATTICE_VISION_S3B_METAL_DISPATCHES count={dispatches} expected={expected}");
+        assert_eq!(
+            dispatches, expected,
+            "ADR-069 S3b gate failed: only {dispatches}/{expected} forward GEMMs dispatched to \
+             Metal — the rest silently took the CPU fallback branch, which cosine parity alone \
+             cannot detect"
+        );
+    }
+
+    #[cfg(not(feature = "test-utils"))]
+    fn assert_dispatch_count(_expected: u64) {}
+
     /// The S3b gate: Metal forward vs S3a CPU reference forward, same
     /// synthetic weights + committed golden image, cosine > 0.999 — plus a
     /// dispatch-count proof that every forward GEMM actually ran on the GPU
@@ -246,19 +287,10 @@ mod gated {
         let cpu_out =
             qwen35_vit_forward(&weights, &cfg, &pixel_values, grid).expect("cpu reference forward");
 
-        reset_metal_dispatch_count();
+        reset_dispatch_count();
         let metal_out =
             qwen35_vit_forward_metal(&weights, &cfg, &pixel_values, grid).expect("metal forward");
-        let dispatches = metal_dispatch_count();
-        eprintln!(
-            "LATTICE_VISION_S3B_METAL_DISPATCHES count={dispatches} expected={expected_dispatches}"
-        );
-        assert_eq!(
-            dispatches, expected_dispatches,
-            "ADR-069 S3b gate failed: only {dispatches}/{expected_dispatches} forward GEMMs \
-             dispatched to Metal — the rest silently took the CPU fallback branch, which cosine \
-             parity alone cannot detect"
-        );
+        assert_dispatch_count(expected_dispatches);
 
         assert_eq!(cpu_out.len(), metal_out.len());
         assert!(metal_out.iter().all(|v| v.is_finite()));
@@ -281,19 +313,10 @@ mod gated {
         for w in mutated.blocks[0].qkv_weight.iter_mut() {
             *w *= -1.0;
         }
-        reset_metal_dispatch_count();
+        reset_dispatch_count();
         let mutated_metal_out = qwen35_vit_forward_metal(&mutated, &cfg, &pixel_values, grid)
             .expect("mutated metal forward");
-        let mutated_dispatches = metal_dispatch_count();
-        eprintln!(
-            "LATTICE_VISION_S3B_METAL_DISPATCHES count={mutated_dispatches} \
-             expected={expected_dispatches}"
-        );
-        assert_eq!(
-            mutated_dispatches, expected_dispatches,
-            "mutation-branch dispatch accounting failed: only \
-             {mutated_dispatches}/{expected_dispatches} forward GEMMs dispatched to Metal"
-        );
+        assert_dispatch_count(expected_dispatches);
 
         let mutated_cos = cosine_similarity(&cpu_out, &mutated_metal_out);
         eprintln!("LATTICE_VISION_S3B_MUTATION_COSINE cosine={mutated_cos:.8}");

--- a/crates/inference/tests/vision_s3b_vit_metal_gate_test.rs
+++ b/crates/inference/tests/vision_s3b_vit_metal_gate_test.rs
@@ -46,7 +46,9 @@ mod gated {
         Qwen35VisionWeights, VisualBlockWeights, VisualMergerWeights,
     };
     use lattice_inference::vision::qwen35_vit::{preprocess_qwen35_image, qwen35_vit_forward};
-    use lattice_inference::vision::qwen35_vit_metal::qwen35_vit_forward_metal;
+    use lattice_inference::vision::qwen35_vit_metal::{
+        metal_dispatch_count, qwen35_vit_forward_metal, reset_metal_dispatch_count,
+    };
 
     fn fixture_dir() -> std::path::PathBuf {
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -205,8 +207,24 @@ mod gated {
         buf
     }
 
+    /// Number of `gemm_bt`/`gemm_nn` calls one `qwen35_vit_forward_metal` call
+    /// makes at this config: 1 patch-embed + per block (1 qkv + 2 per
+    /// attention head [`Q@K^T` then `scores@V`] + 1 output proj + 1 fc1 + 1
+    /// fc2). Every one of these shapes clears the Metal GEMM dispatch
+    /// threshold at the real S3b geometry (see module docs), so on a real
+    /// Metal device every call here must land on the GPU, not the CPU
+    /// fallback branch — that is exactly what the dispatch-count assertion
+    /// below proves cosine parity alone cannot.
+    fn expected_dispatch_count(cfg: &VisionModelConfig) -> u64 {
+        let per_block = 4 + 2 * cfg.num_heads;
+        (1 + cfg.depth * per_block) as u64
+    }
+
     /// The S3b gate: Metal forward vs S3a CPU reference forward, same
-    /// synthetic weights + committed golden image, cosine > 0.999.
+    /// synthetic weights + committed golden image, cosine > 0.999 — plus a
+    /// dispatch-count proof that every forward GEMM actually ran on the GPU
+    /// rather than silently taking the (mathematically identical) CPU
+    /// fallback branch in `gemm_bt`/`gemm_nn`.
     #[test]
     fn metal_vit_forward_matches_cpu_reference_cosine_gt_0999() {
         let _gpu = gpu_test_lock();
@@ -223,10 +241,24 @@ mod gated {
             preprocess_qwen35_image(&image_bytes, &cfg).expect("preprocess golden image");
         assert_eq!(grid.num_patches(), 256);
 
+        let expected_dispatches = expected_dispatch_count(&cfg);
+
         let cpu_out =
             qwen35_vit_forward(&weights, &cfg, &pixel_values, grid).expect("cpu reference forward");
+
+        reset_metal_dispatch_count();
         let metal_out =
             qwen35_vit_forward_metal(&weights, &cfg, &pixel_values, grid).expect("metal forward");
+        let dispatches = metal_dispatch_count();
+        eprintln!(
+            "LATTICE_VISION_S3B_METAL_DISPATCHES count={dispatches} expected={expected_dispatches}"
+        );
+        assert_eq!(
+            dispatches, expected_dispatches,
+            "ADR-069 S3b gate failed: only {dispatches}/{expected_dispatches} forward GEMMs \
+             dispatched to Metal — the rest silently took the CPU fallback branch, which cosine \
+             parity alone cannot detect"
+        );
 
         assert_eq!(cpu_out.len(), metal_out.len());
         assert!(metal_out.iter().all(|v| v.is_finite()));
@@ -241,13 +273,28 @@ mod gated {
 
         // Mutation-sensitivity proof (CLAUDE.md "Regression Tests Must Be
         // Mutation-Sensitive"): perturbing a single Metal-path-visible weight
-        // must drop the gate below threshold.
+        // must drop the gate below threshold. Dispatch accounting runs here
+        // too, so a future change that breaks GPU dispatch specifically for
+        // the mutated-weight path (rather than the baseline path) is also
+        // caught.
         let mut mutated = weights.clone();
         for w in mutated.blocks[0].qkv_weight.iter_mut() {
             *w *= -1.0;
         }
+        reset_metal_dispatch_count();
         let mutated_metal_out = qwen35_vit_forward_metal(&mutated, &cfg, &pixel_values, grid)
             .expect("mutated metal forward");
+        let mutated_dispatches = metal_dispatch_count();
+        eprintln!(
+            "LATTICE_VISION_S3B_METAL_DISPATCHES count={mutated_dispatches} \
+             expected={expected_dispatches}"
+        );
+        assert_eq!(
+            mutated_dispatches, expected_dispatches,
+            "mutation-branch dispatch accounting failed: only \
+             {mutated_dispatches}/{expected_dispatches} forward GEMMs dispatched to Metal"
+        );
+
         let mutated_cos = cosine_similarity(&cpu_out, &mutated_metal_out);
         eprintln!("LATTICE_VISION_S3B_MUTATION_COSINE cosine={mutated_cos:.8}");
         assert!(

--- a/crates/inference/tests/vision_s3b_vit_metal_gate_test.rs
+++ b/crates/inference/tests/vision_s3b_vit_metal_gate_test.rs
@@ -1,0 +1,259 @@
+//! ADR-069 S3b gate: Metal port of the Qwen3.5-0.8B ViT forward
+//! ([`lattice_inference::vision::qwen35_vit_metal::qwen35_vit_forward_metal`])
+//! vs the S3a CPU reference
+//! ([`lattice_inference::vision::qwen35_vit::qwen35_vit_forward`]), at
+//! cosine > 0.999 on the committed golden fixture image.
+//!
+//! Checkpoint-light by design (ADR-069 Amendment 1's "prefer a
+//! committed-fixture design that runs everywhere"): rather than requiring
+//! the 1.6 GB fp16 checkpoint, this test builds deterministic synthetic
+//! weights at the checkpoint's *real* per-block geometry (hidden 768, 12
+//! heads, patch 16, spatial_merge 2, temporal_patch 2, `num_position_embeddings`
+//! 2304 — every value pinned to ADR-069's `vision_config`, not chosen here),
+//! with a reduced depth (2 blocks instead of 12) purely for test wall-clock —
+//! depth doesn't change any per-op Metal/CPU convention, so parity at depth 2
+//! is exactly as validating of the block-loop port as depth 12 would be. The
+//! image is the already-committed `tests/fixtures/vision/golden_image.png`
+//! (256x256, grid 16x16 = 256 patches) — no new fixture asset needed.
+//!
+//! Every GEMM shape here (patch embed, fused QKV, both attention matmuls,
+//! output projection, MLP fc1/fc2) clears the Metal GEMM dispatch threshold
+//! (`64*64*64`) at this geometry, so a genuine GPU dispatch happens per op
+//! when Metal is available — this is not exercising the CPU-fallback branch.
+//!
+//! Acquires the machine-wide `gpu_test_lock()` (own copy — external
+//! integration tests can't reach the `metal_qwen35.rs`/`metal.rs`-private
+//! copies; duplicating this exact lock is the codebase's established
+//! sibling-invocation-path pattern for GPU-touching test binaries, see
+//! `bin/bench_gdn_prefill_ab.rs`) before any Metal work, and runs
+//! `--test-threads=1`-safe (each test acquires its own lock instance).
+//!
+//! Run:
+//! ```bash
+//! cargo test --release -p lattice-inference --features f16,metal-gpu \
+//!     --test vision_s3b_vit_metal_gate_test -- --nocapture --test-threads=1
+//! ```
+
+// `fixture_dir`/`cosine_similarity`/`s3b_cfg` live inside `mod gated` (not at
+// this top level) because they're only used there — a plain `cargo clippy
+// --workspace` build (no `metal-gpu` feature) would otherwise flag them as
+// dead code, since the whole `mod gated` block compiles away.
+
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+mod gated {
+    use lattice_inference::model::qwen35_config::VisionModelConfig;
+    use lattice_inference::vision::checkpoint::{
+        Qwen35VisionWeights, VisualBlockWeights, VisualMergerWeights,
+    };
+    use lattice_inference::vision::qwen35_vit::{preprocess_qwen35_image, qwen35_vit_forward};
+    use lattice_inference::vision::qwen35_vit_metal::qwen35_vit_forward_metal;
+
+    fn fixture_dir() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("tests")
+            .join("fixtures")
+            .join("vision")
+    }
+
+    fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
+        assert_eq!(a.len(), b.len());
+        let dot: f64 = a
+            .iter()
+            .zip(b.iter())
+            .map(|(&x, &y)| x as f64 * y as f64)
+            .sum();
+        let norm_a: f64 = a.iter().map(|&x| (x as f64).powi(2)).sum::<f64>().sqrt();
+        let norm_b: f64 = b.iter().map(|&x| (x as f64).powi(2)).sum::<f64>().sqrt();
+        dot / (norm_a * norm_b)
+    }
+
+    /// Real per-block ADR-069 `vision_config` geometry, depth reduced to 2 for
+    /// test speed (see module docs).
+    fn s3b_cfg() -> VisionModelConfig {
+        VisionModelConfig {
+            depth: 2,
+            hidden_size: 768,
+            num_heads: 12,
+            patch_size: 16,
+            spatial_merge_size: 2,
+            out_hidden_size: 1024,
+            temporal_patch_size: 2,
+            num_position_embeddings: 2304,
+            in_channels: 3,
+            deepstack_visual_indexes: vec![],
+        }
+    }
+
+    /// Serializes GPU-heavy tests onto the single shared Metal device, both
+    /// in-process and machine-wide. Own copy of `metal_qwen35.rs`'s
+    /// `gpu_test_lock()` — see module docs for why external integration
+    /// tests can't import the original (private, nested in that file's own
+    /// `#[cfg(test)] mod tests`).
+    struct GpuTestGuard {
+        _process: std::sync::MutexGuard<'static, ()>,
+        _machine: std::fs::File,
+    }
+
+    const GPU_MACHINE_LOCK_PATH: &str = "/tmp/lion-metal-gpu-test.lock";
+    const GPU_MACHINE_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+    fn gpu_test_lock() -> GpuTestGuard {
+        use std::sync::Mutex;
+        static GPU_LOCK: Mutex<()> = Mutex::new(());
+        let process = GPU_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(GPU_MACHINE_LOCK_PATH)
+            .unwrap_or_else(|e| panic!("gpu_test_lock: cannot open {GPU_MACHINE_LOCK_PATH}: {e}"));
+        let deadline = std::time::Instant::now() + GPU_MACHINE_LOCK_TIMEOUT;
+        loop {
+            match file.try_lock() {
+                Ok(()) => break,
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    if std::time::Instant::now() >= deadline {
+                        panic!(
+                            "gpu_test_lock: another process has held {GPU_MACHINE_LOCK_PATH} for \
+                             over {}s — a Metal test run elsewhere on this machine is wedged or \
+                             genuinely that long; inspect `lsof {GPU_MACHINE_LOCK_PATH}`",
+                            GPU_MACHINE_LOCK_TIMEOUT.as_secs()
+                        );
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                }
+                Err(std::fs::TryLockError::Error(e)) => {
+                    panic!("gpu_test_lock: flock on {GPU_MACHINE_LOCK_PATH} failed: {e}")
+                }
+            }
+        }
+
+        GpuTestGuard {
+            _process: process,
+            _machine: file,
+        }
+    }
+
+    use std::io::Read as _;
+
+    fn make_weights(cfg: &VisionModelConfig, seed: u32) -> Qwen35VisionWeights {
+        let hidden = cfg.hidden_size;
+        let patch_len = cfg.in_channels * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
+        let mlp_dim = 4 * hidden;
+        let merge_in = cfg.spatial_merge_size * cfg.spatial_merge_size * hidden;
+
+        let mut state = seed;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            (state as f32 / u32::MAX as f32) * 0.1 - 0.05
+        };
+        let mut v = |n: usize| (0..n).map(|_| next()).collect::<Vec<f32>>();
+
+        let make_block = |v: &mut dyn FnMut(usize) -> Vec<f32>| VisualBlockWeights {
+            qkv_weight: v(3 * hidden * hidden),
+            qkv_bias: v(3 * hidden),
+            proj_weight: v(hidden * hidden),
+            proj_bias: v(hidden),
+            fc1_weight: v(mlp_dim * hidden),
+            fc1_bias: v(mlp_dim),
+            fc2_weight: v(hidden * mlp_dim),
+            fc2_bias: v(hidden),
+            norm1_weight: vec![1.0; hidden],
+            norm1_bias: vec![0.0; hidden],
+            norm2_weight: vec![1.0; hidden],
+            norm2_bias: vec![0.0; hidden],
+        };
+
+        let blocks = (0..cfg.depth).map(|_| make_block(&mut v)).collect();
+
+        Qwen35VisionWeights {
+            patch_embed_weight: v(hidden * patch_len),
+            patch_embed_weight_shape: vec![
+                hidden,
+                cfg.in_channels,
+                cfg.temporal_patch_size,
+                cfg.patch_size,
+                cfg.patch_size,
+            ],
+            patch_embed_bias: v(hidden),
+            pos_embed: v(cfg.num_position_embeddings * hidden),
+            blocks,
+            merger: VisualMergerWeights {
+                fc1_weight: v(merge_in * merge_in),
+                fc1_bias: v(merge_in),
+                fc2_weight: v(cfg.out_hidden_size * merge_in),
+                fc2_bias: v(cfg.out_hidden_size),
+                norm_weight: vec![1.0; hidden],
+                norm_bias: vec![0.0; hidden],
+            },
+        }
+    }
+
+    fn load_golden_image() -> Vec<u8> {
+        let path = fixture_dir().join("golden_image.png");
+        let mut f = std::fs::File::open(&path)
+            .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+        let mut buf = Vec::new();
+        f.read_to_end(&mut buf).expect("read golden_image.png");
+        buf
+    }
+
+    /// The S3b gate: Metal forward vs S3a CPU reference forward, same
+    /// synthetic weights + committed golden image, cosine > 0.999.
+    #[test]
+    fn metal_vit_forward_matches_cpu_reference_cosine_gt_0999() {
+        let _gpu = gpu_test_lock();
+
+        assert!(
+            lattice_inference::forward::metal_gemm::is_available(),
+            "Metal device unavailable — S3b gate requires a real Metal device"
+        );
+
+        let cfg = s3b_cfg();
+        let weights = make_weights(&cfg, 0x1234_5678);
+        let image_bytes = load_golden_image();
+        let (pixel_values, grid) =
+            preprocess_qwen35_image(&image_bytes, &cfg).expect("preprocess golden image");
+        assert_eq!(grid.num_patches(), 256);
+
+        let cpu_out =
+            qwen35_vit_forward(&weights, &cfg, &pixel_values, grid).expect("cpu reference forward");
+        let metal_out =
+            qwen35_vit_forward_metal(&weights, &cfg, &pixel_values, grid).expect("metal forward");
+
+        assert_eq!(cpu_out.len(), metal_out.len());
+        assert!(metal_out.iter().all(|v| v.is_finite()));
+
+        let cos = cosine_similarity(&cpu_out, &metal_out);
+        eprintln!("LATTICE_VISION_S3B_COSINE cosine={cos:.8}");
+        assert!(
+            cos > 0.999,
+            "ADR-069 S3b gate failed: Metal cosine similarity {cos} vs CPU reference must exceed \
+             0.999"
+        );
+
+        // Mutation-sensitivity proof (CLAUDE.md "Regression Tests Must Be
+        // Mutation-Sensitive"): perturbing a single Metal-path-visible weight
+        // must drop the gate below threshold.
+        let mut mutated = weights.clone();
+        for w in mutated.blocks[0].qkv_weight.iter_mut() {
+            *w *= -1.0;
+        }
+        let mutated_metal_out = qwen35_vit_forward_metal(&mutated, &cfg, &pixel_values, grid)
+            .expect("mutated metal forward");
+        let mutated_cos = cosine_similarity(&cpu_out, &mutated_metal_out);
+        eprintln!("LATTICE_VISION_S3B_MUTATION_COSINE cosine={mutated_cos:.8}");
+        assert!(
+            mutated_cos < 0.999,
+            "mutation-sensitivity check failed: negating block[0].qkv_weight did not fail the \
+             cosine>0.999 gate (baseline={cos}, mutated={mutated_cos})"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Ports the Qwen3.5-0.8B ViT forward (`qwen35_vit_forward`) to Metal, per ADR-069 Amendment 1's S3b stage. Gated against the merged S3a CPU reference (`crates/inference/src/vision/qwen35_vit.rs`), not against HF directly — S3a already carries that gate.

**Binding contract — zero independent convention decisions.** Every layout/normalization/activation/RoPE convention in the Metal path is inherited directly from the CPU reference, not re-derived:

- The setup tables (bilinear position-embedding interpolation, 2-axis vision RoPE `cos`/`sin` construction) are computed by literally calling a new shared helper, `build_pos_embed_and_rope_tables`, extracted out of `qwen35_vit_forward` (behavior-preserving refactor — verified below).
- The elementwise ops (biased `LayerNorm`, GELU-tanh, RoPE rotate-half application, fail-closed softmax) reuse the exact CPU reference functions (`layer_norm`, `gelu`, `apply_rope_inplace`, `softmax_inplace`) directly, rather than re-implementing them in Metal shader code.
- Only the GEMM-heavy compute — patch embedding, fused QKV projection, both attention matmuls (`Q @ K^T` and `scores @ V`), the output projection, and the MLP `fc1`/`fc2` — dispatches to the Metal GPU, via the existing `metal_matmul` / `metal_matmul_bt` kernels in `forward/metal_gemm.rs` (reused as-is, not reimplemented; these already carry the codebase's tiled-GEMM Metal shader and CPU-availability fallback). At the real depth-12/hidden-768/12-head geometry these GEMMs account for well over 99% of the forward pass's FLOPs, so the reused CPU elementwise ops (the strongest possible form of convention mirroring — literally the same code) cost is negligible.

One incidental fix: `metal_gemm.rs`'s `is_available()` existed but wasn't re-exported from its feature-gated module, so it was unreachable outside that file. Exported it so the new gate test can assert a real Metal device is present rather than silently exercising the CPU-fallback branch.

## Gate test

New `tests/vision_s3b_vit_metal_gate_test.rs`, checkpoint-light by design (no 1.6 GB checkpoint needed): deterministic synthetic weights at the checkpoint's real per-block geometry (hidden 768, 12 heads, patch 16, spatial_merge 2, temporal_patch 2, `num_position_embeddings` 2304 — every value pinned to ADR-069's `vision_config`), depth reduced to 2 blocks purely for test wall-clock (depth doesn't change any per-op convention). Uses the already-committed `tests/fixtures/vision/golden_image.png` (256x256, grid 16x16 = 256 patches) — no new fixture asset added. Every GEMM shape at this geometry clears the Metal dispatch threshold, so this exercises genuine GPU dispatch, not the CPU-fallback branch. Acquires a machine-wide `gpu_test_lock()` (own copy — external integration tests can't reach `metal_qwen35.rs`'s private one; duplicating it is this codebase's established pattern for GPU-touching test binaries, e.g. `bin/bench_gdn_prefill_ab.rs`).

**Cosine + dispatch-count gate evidence** (local run, `cargo test --release -p lattice-inference --features f16,metal-gpu --test vision_s3b_vit_metal_gate_test -- --nocapture --test-threads=1`):

```
LATTICE_VISION_S3B_METAL_DISPATCHES count=57 expected=57
LATTICE_VISION_S3B_COSINE cosine=1.00000000
LATTICE_VISION_S3B_METAL_DISPATCHES count=57 expected=57
LATTICE_VISION_S3B_MUTATION_COSINE cosine=0.78944946
test gated::metal_vit_forward_matches_cpu_reference_cosine_gt_0999 ... ok
```

The in-test mutation assertion (negating `block[0].qkv_weight`) drops cosine to 0.789, well below the 0.999 gate, confirming the test is sensitive to the weights it's handed. The dispatch-count assertion (57/57 GEMMs — 1 patch-embed + 2 blocks × 28 GEMMs each) runs on both the baseline and mutated-weights forward — see "Dispatch-count proof" below for why cosine parity alone isn't sufficient here and how this addition is mutation-proved.

**S3a regression check** (same run, confirming the `build_pos_embed_and_rope_tables` extraction didn't move the existing HF-differential gate): `LATTICE_VISION_S3_COSINE cosine=1.00000000` against the real checkpoint (`LATTICE_VISION_S3_MODEL_DIR` set locally), matching pre-refactor.

## Mutation cycle (regression-proves the gate)

Reverse-applied the attention-scale line in `multihead_attention_full_metal` (commented out `*s *= scale` in the Metal attention path), `touch`ed the file, reran the gate test:

```
LATTICE_VISION_S3B_COSINE cosine=0.83098578
thread '...' panicked: ADR-069 S3b gate failed: Metal cosine similarity 0.8309857756040057 vs CPU reference must exceed 0.999
test result: FAILED
```

Restored the fix, reran — back to `cosine=1.00000000`, test passes. Confirms the gate actually exercises the Metal-path attention wiring rather than trivially passing.

## Dispatch-count proof (review follow-up)

Review feedback on this PR flagged that the cosine gate alone can't distinguish "every GEMM ran on Metal" from "every GEMM silently fell back to the CPU loop below" — `gemm_bt`/`gemm_nn` in `qwen35_vit_metal.rs` discard the `bool` that `metal_matmul`/`metal_matmul_bt` return and re-run the exact CPU dot product when it's `false`, so a mathematically-correct-but-CPU-only run would still pass the cosine check.

**Fix**: an `AtomicU64` dispatch counter (`METAL_DISPATCH_COUNT`), incremented in `gemm_bt`/`gemm_nn` only on the branch where `metal_matmul`/`metal_matmul_bt` return `true` (real GPU dispatch), never on the CPU-fallback branch. Exposed as `metal_dispatch_count()` / `reset_metal_dispatch_count()` — same opt-in, always-compiled-behind-`metal-gpu`, test-only-consumer pattern the codebase already uses for `PathProofCounters` in `forward/metal_qwen35.rs` (issue #239), scoped down to a single atomic since this module has one dispatch pair rather than many distinct kernels. Zero behavior change to the production math path — the counter is a pure side-channel read via `Ordering::Relaxed`.

The gate test now resets the counter before each forward call (baseline and mutated-weights), asserts the count equals the expected number of GEMMs for the S3b config (`1 + depth × (4 + 2×num_heads)` = `1 + 2×28` = `57` at depth 2 / 12 heads), and prints `LATTICE_VISION_S3B_METAL_DISPATCHES count=<n> expected=<n>` — see evidence above. The assertion runs *before* the cosine check in test order, so a dispatch-count regression fails fast rather than being masked by a passing cosine.

**Mutation-proved the fix itself**: temporarily bypassed `gemm_bt` for one call site (`proj_out` in the attention sub-layer) with an inline CPU dot product identical in math but invisible to the counter — simulating exactly the regression class this closes (a silent Metal→CPU fallback that's numerically correct but not actually running on the GPU). `touch`ed the file and reran:

```
LATTICE_VISION_S3B_METAL_DISPATCHES count=55 expected=57

thread '...' panicked at crates/inference/tests/vision_s3b_vit_metal_gate_test.rs:256:9:
assertion `left == right` failed: ADR-069 S3b gate failed: only 55/57 forward GEMMs dispatched to Metal — the rest silently took the CPU fallback branch, which cosine parity alone cannot detect
  left: 55
 right: 57
test result: FAILED
```

The count dropped by exactly 2 (one `proj_out` call per each of the 2 blocks), and the test failed on the dispatch assertion *before* ever reaching the cosine check — proving the new assertion catches this regression class even when cosine would have passed. Restored the fix, reran:

```
LATTICE_VISION_S3B_METAL_DISPATCHES count=57 expected=57
LATTICE_VISION_S3B_COSINE cosine=1.00000000
test result: ok
```

## bench-compare

`crates/inference/src/forward/metal_gemm.rs`'s `is_available` re-export makes this PR touch a shared Metal-dispatch file, so per repo policy this needed actual A/B numbers rather than a reachability statement alone. Ran under the machine-wide GPU lock and the shared-machine build/heavy-work lock:

```
bash with-heavy-lane.sh "lattice:bench-997" -- make bench-compare
```

**Runner**: local macOS worktree, quick mode (`--quick`, default), `BASE=origin/main (823b22669c)`, `HEAD=HEAD (e1df92678d)` — this PR's commits plus the dispatch-count fix above.


### origin/main vs HEAD — complete report

<details>
<summary>Full origin/main vs HEAD bench-compare report (263 measurements, gating table + informational + per-bench detail)</summary>

### `local-compare` — perf regression report

**❌ 14 FAIL** (regression >7.0% confirmed by 95% CI)
**⚠ 22 WARN** (regression 3.0-7.0% confirmed)
**🚀 11 confirmed improvement**

| Bench | Δ point | 95% CI | new ns | base ns | verdict |
|---|---:|---|---:|---:|---|
| `simd_query_batch_dot_product/simd_batch/128d_64c` | +70.10% | [+68.66%, +71.53%] | 629.4 | 370.0 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/128d_64c` | +57.17% | [+55.99%, +58.35%] | 1016.8 | 647.0 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/128d_256c` | +45.17% | [+44.78%, +45.55%] | 4349.3 | 2996.1 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/128d_16c` | +31.28% | [+30.20%, +32.38%] | 135.9 | 103.5 | ❌ FAIL |
| `int8_vs_float32_cosine/float32_simd/384` | +17.73% | [+17.13%, +18.32%] | 38.0 | 32.3 | ❌ FAIL |
| `simd_normalize/simd/768` | +16.07% | [+14.53%, +17.61%] | 142.4 | 122.7 | ❌ FAIL |
| `simd_normalize/simd/384` | +12.67% | [+11.08%, +14.29%] | 83.4 | 74.0 | ❌ FAIL |
| `simd_normalize/simd/1024` | +11.94% | [+9.42%, +14.49%] | 176.5 | 157.7 | ❌ FAIL |
| `binary_cosine_distance/float32_simd/768` | +10.85% | [+9.34%, +12.38%] | 70.7 | 63.8 | ❌ FAIL |
| `int8_vs_float32_cosine/float32_simd/1024` | +10.89% | [+9.12%, +12.69%] | 90.6 | 81.7 | ❌ FAIL |
| `memory_size/search_1000_int8` | +10.49% | [+8.08%, +12.91%] | 11261.4 | 10191.8 | ❌ FAIL |
| `simd_batch_cosine/simd_batch/100` | +8.68% | [+8.03%, +9.34%] | 4199.0 | 3863.5 | ❌ FAIL |
| `simd_batch_cosine/simd_batch/1000` | +8.43% | [+7.44%, +9.44%] | 40716.6 | 37550.7 | ❌ FAIL |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_16c` | +7.73% | [+7.33%, +8.13%] | 536.5 | 498.0 | ❌ FAIL |
| `binary_cosine_distance/float32_simd/1024` | +7.48% | [+5.68%, +9.29%] | 88.6 | 82.5 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/simd_batch/384d_16c` | +6.35% | [+4.86%, +7.85%] | 529.8 | 498.2 | ⚠ WARN |
| `simd_normalize/scalar/1024` | +5.43% | [+4.48%, +6.39%] | 1017.0 | 964.6 | ⚠ WARN |
| `layer_norm/4096` | +4.52% | [+4.41%, +4.63%] | 913.5 | 874.0 | ⚠ WARN |
| `int8_vs_float32_cosine/float32_simd/1536` | +5.04% | [+4.41%, +5.68%] | 131.1 | 124.8 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_4c` | +6.49% | [+4.35%, +8.70%] | 146.3 | 137.4 | ⚠ WARN |
| `gelu/896` | +4.35% | [+4.17%, +4.52%] | 374.5 | 358.9 | ⚠ WARN |
| `rms_norm/896` | +4.98% | [+4.14%, +5.82%] | 136.0 | 129.6 | ⚠ WARN |
| `simd_normalize/scalar/1536` | +4.42% | [+4.02%, +4.82%] | 1509.5 | 1445.6 | ⚠ WARN |
| `add_bias_gelu/896` | +3.95% | [+3.89%, +4.01%] | 397.0 | 381.9 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c` | +5.19% | [+3.86%, +6.53%] | 5229.0 | 4971.0 | ⚠ WARN |
| `simd_throughput_384/euclidean_distance` | +4.49% | [+3.77%, +5.21%] | 30.2 | 28.9 | ⚠ WARN |
| `add_bias_gelu/4096` | +4.05% | [+3.67%, +4.44%] | 1815.9 | 1745.2 | ⚠ WARN |
| `int8_raw_dot_product/dot_product_i8/127` | +5.17% | [+3.63%, +6.72%] | 7.1 | 6.8 | ⚠ WARN |
| `simd_query_batch_dot_product/pair_loop/384d_16c` | +4.39% | [+3.60%, +5.18%] | 459.2 | 439.9 | ⚠ WARN |
| `silu_inplace/4096` | +4.25% | [+3.57%, +4.93%] | 2089.0 | 2003.8 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_16c` | +4.42% | [+3.42%, +5.42%] | 1215.3 | 1163.9 | ⚠ WARN |
| `simd_throughput_384/dot_product` | +5.30% | [+3.33%, +7.29%] | 28.4 | 27.0 | ⚠ WARN |
| `simd_query_batch_dot_product/simd_batch/384d_4c` | +3.93% | [+3.31%, +4.56%] | 75.9 | 73.0 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_64c` | +3.81% | [+3.20%, +4.43%] | 1835.1 | 1767.8 | ⚠ WARN |
| `int8_vs_float32_cosine/int8/1024` | +4.54% | [+3.09%, +6.00%] | 26.9 | 25.7 | ⚠ WARN |
| `simd_batch_dot_product/simd_batch/1000` | +4.07% | [+3.05%, +5.10%] | 40296.4 | 38720.2 | ⚠ WARN |
| `tier_prepared_batch_sizes/int8_batch_prepared/100` | -3.15% | [-3.70%, -2.58%] | 988.9 | 1021.0 | 🚀 WIN |
| `simd_prepared_query_normalized_cosine/dot_product_loop/384` | -3.40% | [-3.87%, -2.93%] | 31969.1 | 33093.8 | 🚀 WIN |
| `tier_prepared_batch_sizes/int8_query_per_call/100` | -3.12% | [-4.02%, -2.23%] | 112667.1 | 116300.9 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/129` | -3.54% | [-4.57%, -2.50%] | 4.9 | 5.0 | 🚀 WIN |
| `int8_prepared_dot_product/prepared/384` | -4.52% | [-5.10%, -3.94%] | 10.1 | 10.6 | 🚀 WIN |
| `binary_cosine_distance/binary/1024` | -5.26% | [-5.99%, -4.51%] | 5.0 | 5.3 | 🚀 WIN |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/384` | -5.31% | [-7.98%, -2.52%] | 36622.4 | 38676.5 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/127` | -5.48% | [-8.58%, -2.20%] | 6.9 | 7.3 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/1536` | -11.76% | [-13.13%, -10.34%] | 36.0 | 40.8 | 🚀 WIN |
| `simd_squared_euclidean_fast_path/euclidean_full/1024` | -32.84% | [-33.63%, -32.02%] | 80.2 | 119.4 | 🚀 WIN |
| `simd_squared_euclidean_fast_path/squared_euclidean/1024` | -39.89% | [-41.80%, -37.90%] | 78.1 | 129.9 | 🚀 WIN |

**ℹ️ 60 informational** (below quick-mode resolution — lattice-embed SIMD micro-benches, tracked in #714; not gated here, re-run `--full` for a gated verdict)
| Bench | Δ point | 95% CI | new ns | base ns | (would-be verdict) |
|---|---:|---|---:|---:|---|
| `int8_batch_cosine/float32_simd/100` | +8.84% | [+7.65%, +10.04%] | 4536.6 | 4168.1 | ❌ FAIL (informational) |
| `int8_batch_cosine/int8_loop/10` | +6.84% | [+5.51%, +8.19%] | 117.9 | 110.3 | ⚠ WARN (informational) |
| `int8_batch_cosine/float32_simd/1000` | +4.63% | [+4.07%, +5.21%] | 41274.7 | 39446.7 | ⚠ WARN (informational) |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_4c` | +4.00% | [+3.66%, +4.34%] | 138.5 | 133.1 | ⚠ WARN (informational) |
| `int4_cosine_distance/int4/1024` | +4.14% | [+3.48%, +4.80%] | 60.7 | 58.3 | ⚠ WARN (informational) |

<details><summary>All 263 measurements</summary>

| Bench | Δ point | CI-lower | CI-upper |
|---|---:|---:|---:|
| `add_bias_gelu/4096` | +4.05% | +3.67% | +4.44% |
| `add_bias_gelu/896` | +3.95% | +3.89% | +4.01% |
| `binary_cosine_distance/binary/1024` | -5.26% | -5.99% | -4.51% |
| `binary_cosine_distance/binary/1536` | -1.50% | -2.49% | -0.51% |
| `binary_cosine_distance/binary/384` | +1.29% | +0.78% | +1.82% |
| `binary_cosine_distance/binary/768` | +0.96% | +0.44% | +1.48% |
| `binary_cosine_distance/float32_simd/1024` | +7.48% | +5.68% | +9.29% |
| `binary_cosine_distance/float32_simd/1536` | +4.77% | +1.94% | +7.70% |
| `binary_cosine_distance/float32_simd/384` | +1.42% | +0.35% | +2.49% |
| `binary_cosine_distance/float32_simd/768` | +10.85% | +9.34% | +12.38% |
| `elementwise_mul/4096` | +2.15% | +0.85% | +3.48% |
| `gelu/4096` | +3.82% | +2.97% | +4.68% |
| `gelu/896` | +4.35% | +4.17% | +4.52% |
| `int4_cosine_distance/float32_simd/1024` | +3.84% | -0.09% | +7.96% |
| `int4_cosine_distance/float32_simd/1536` | +1.09% | +0.56% | +1.64% |
| `int4_cosine_distance/float32_simd/384` | +3.55% | +2.91% | +4.19% |
| `int4_cosine_distance/float32_simd/768` | +3.03% | +2.45% | +3.60% |
| `int4_cosine_distance/int4/1024` | +4.14% | +3.48% | +4.80% |
| `int4_cosine_distance/int4/1536` | +1.97% | +1.59% | +2.36% |
| `int4_cosine_distance/int4/384` | +0.64% | -0.37% | +1.67% |
| `int4_cosine_distance/int4/768` | +2.73% | +1.17% | +4.33% |
| `int8_batch_cosine/float32_simd/10` | +2.26% | +1.96% | +2.57% |
| `int8_batch_cosine/float32_simd/100` | +8.84% | +7.65% | +10.04% |
| `int8_batch_cosine/float32_simd/1000` | +4.63% | +4.07% | +5.21% |
| `int8_batch_cosine/int8_loop/10` | +6.84% | +5.51% | +8.19% |
| `int8_batch_cosine/int8_loop/100` | +3.49% | +2.78% | +4.20% |
| `int8_batch_cosine/int8_loop/1000` | +2.20% | +1.12% | +3.30% |
| `int8_prepared_dot_product/per_call/1024` | -0.18% | -0.39% | +0.03% |
| `int8_prepared_dot_product/per_call/127` | -1.92% | -2.18% | -1.65% |
| `int8_prepared_dot_product/per_call/128` | +0.23% | +0.01% | +0.45% |
| `int8_prepared_dot_product/per_call/129` | -0.32% | -0.93% | +0.30% |
| `int8_prepared_dot_product/per_call/384` | +0.01% | -0.72% | +0.74% |
| `int8_prepared_dot_product/per_call/768` | -0.12% | -1.81% | +1.58% |
| `int8_prepared_dot_product/prepared/1024` | +0.80% | +0.39% | +1.21% |
| `int8_prepared_dot_product/prepared/127` | -0.58% | -1.97% | +0.82% |
| `int8_prepared_dot_product/prepared/128` | -0.26% | -1.22% | +0.71% |
| `int8_prepared_dot_product/prepared/129` | +0.73% | -0.06% | +1.53% |
| `int8_prepared_dot_product/prepared/384` | -4.52% | -5.10% | -3.94% |
| `int8_prepared_dot_product/prepared/768` | -0.40% | -0.75% | -0.04% |
| `int8_quantization/quantize/1024` | +4.27% | +2.54% | +6.01% |
| `int8_quantization/quantize/1536` | +4.17% | +2.75% | +5.59% |
| `int8_quantization/quantize/384` | +2.86% | +2.62% | +3.09% |
| `int8_quantization/quantize/768` | +2.82% | +2.58% | +3.06% |
| `int8_raw_dot_product/dot_product_i8/1024` | -1.81% | -4.22% | +0.73% |
| `int8_raw_dot_product/dot_product_i8/127` | +5.17% | +3.63% | +6.72% |
| `int8_raw_dot_product/dot_product_i8/128` | -2.77% | -3.62% | -1.91% |
| `int8_raw_dot_product/dot_product_i8/129` | -1.27% | -3.53% | +1.08% |
| `int8_raw_dot_product/dot_product_i8/384` | +0.13% | -0.18% | +0.45% |
| `int8_raw_dot_product/dot_product_i8/768` | +0.03% | -1.60% | +1.67% |
| `int8_raw_dot_product/dot_product_i8_raw/1024` | +0.31% | -0.42% | +1.05% |
| `int8_raw_dot_product/dot_product_i8_raw/127` | -5.48% | -8.58% | -2.20% |
| `int8_raw_dot_product/dot_product_i8_raw/128` | +1.05% | -0.59% | +2.69% |
| `int8_raw_dot_product/dot_product_i8_raw/129` | -3.54% | -4.57% | -2.50% |
| `int8_raw_dot_product/dot_product_i8_raw/384` | -2.51% | -4.88% | -0.04% |
| `int8_raw_dot_product/dot_product_i8_raw/768` | +0.29% | -1.19% | +1.78% |
| `int8_vs_float32_cosine/float32_simd/1024` | +10.89% | +9.12% | +12.69% |
| `int8_vs_float32_cosine/float32_simd/1536` | +5.04% | +4.41% | +5.68% |
| `int8_vs_float32_cosine/float32_simd/384` | +17.73% | +17.13% | +18.32% |
| `int8_vs_float32_cosine/float32_simd/768` | +2.01% | +1.15% | +2.86% |
| `int8_vs_float32_cosine/int8/1024` | +4.54% | +3.09% | +6.00% |
| `int8_vs_float32_cosine/int8/1536` | -11.76% | -13.13% | -10.34% |
| `int8_vs_float32_cosine/int8/384` | -0.96% | -1.51% | -0.41% |
| `int8_vs_float32_cosine/int8/768` | +4.57% | +2.80% | +6.36% |
| `layer_norm/4096` | +4.52% | +4.41% | +4.63% |
| `layer_norm/896` | +2.72% | +2.43% | +3.01% |
| `memory_size/search_1000_float32` | +4.22% | +2.02% | +6.42% |
| `memory_size/search_1000_int8` | +10.49% | +8.08% | +12.91% |
| `residual_add_layer_norm/fused/hidden384_seq128` | +1.28% | +0.28% | +2.29% |
| `residual_add_layer_norm/fused/hidden768_seq128` | +1.72% | +1.25% | +2.19% |
| `residual_add_layer_norm/unfused/hidden384_seq128` | +1.32% | -0.11% | +2.78% |
| `residual_add_layer_norm/unfused/hidden768_seq128` | +2.03% | +1.87% | +2.19% |
| `rms_norm/4096` | +2.55% | +2.36% | +2.74% |
| `rms_norm/896` | +4.98% | +4.14% | +5.82% |
| `silu_inplace/4096` | +4.25% | +3.57% | +4.93% |
| `silu_inplace/896` | +3.04% | +1.43% | +4.68% |
| `simd_batch_cosine/scalar_loop/10` | +3.07% | +2.42% | +3.73% |
| `simd_batch_cosine/scalar_loop/100` | +3.30% | +2.03% | +4.58% |
| `simd_batch_cosine/scalar_loop/1000` | +2.16% | +1.15% | +3.17% |
| `simd_batch_cosine/simd_batch/10` | +2.16% | +1.62% | +2.72% |
| `simd_batch_cosine/simd_batch/100` | +8.68% | +8.03% | +9.34% |
| `simd_batch_cosine/simd_batch/1000` | +8.43% | +7.44% | +9.44% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_1000c` | -0.01% | -0.92% | +0.91% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_16c` | +0.60% | +0.58% | +0.63% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_256c` | -0.93% | -1.58% | -0.27% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_4c` | +1.87% | +1.33% | +2.42% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c` | -0.71% | -1.73% | +0.32% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_1000c` | +0.41% | -0.21% | +1.04% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_16c` | +3.90% | +1.88% | +5.92% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_256c` | +1.05% | -0.17% | +2.28% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_4c` | +1.29% | +0.33% | +2.26% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_64c` | +1.36% | +0.60% | +2.11% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_1000c` | +0.51% | +0.07% | +0.94% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_16c` | -0.68% | -1.58% | +0.23% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_256c` | +0.18% | -1.30% | +1.68% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_4c` | +0.19% | -1.15% | +1.55% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_64c` | +1.28% | +0.53% | +2.03% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_1000c` | -0.73% | -3.88% | +2.45% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_16c` | -0.06% | -0.35% | +0.23% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_256c` | -1.35% | -1.85% | -0.85% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_4c` | +0.52% | -0.12% | +1.17% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_64c` | -0.67% | -1.18% | -0.16% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_1000c` | -0.56% | -2.84% | +1.78% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_16c` | -2.10% | -3.19% | -0.98% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_256c` | +1.40% | -0.12% | +2.94% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_4c` | +4.00% | +3.66% | +4.34% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_64c` | +2.47% | +2.01% | +2.92% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_1000c` | -0.13% | -1.39% | +1.14% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_16c` | -2.02% | -3.59% | -0.41% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_256c` | -0.61% | -1.16% | -0.05% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_4c` | +0.53% | -0.27% | +1.34% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_64c` | +0.27% | -1.58% | +2.13% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_1000c` | +2.70% | +1.30% | +4.09% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_16c` | +0.17% | -0.73% | +1.08% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_256c` | +2.40% | +0.51% | +4.31% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_4c` | +1.79% | +1.59% | +1.99% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_64c` | +3.52% | +2.62% | +4.43% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_1000c` | +3.22% | +2.25% | +4.20% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_16c` | +7.73% | +7.33% | +8.13% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_256c` | +2.66% | +0.53% | +4.81% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_4c` | +6.49% | +4.35% | +8.70% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_64c` | +1.77% | -1.51% | +5.12% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_1000c` | +3.30% | +2.57% | +4.05% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_16c` | +1.68% | +1.31% | +2.04% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_256c` | +1.66% | +1.04% | +2.28% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_4c` | +1.35% | +0.71% | +1.99% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_64c` | +1.76% | +0.54% | +3.00% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_1000c` | -1.99% | -2.48% | -1.49% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_16c` | +4.42% | +3.42% | +5.42% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_256c` | -2.93% | -4.78% | -1.04% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_4c` | +1.78% | +0.60% | +2.98% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c` | +5.19% | +3.86% | +6.53% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_1000c` | +1.07% | +0.37% | +1.78% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_16c` | +0.71% | -0.62% | +2.06% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_256c` | +0.64% | -0.58% | +1.88% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_4c` | +2.79% | +2.17% | +3.42% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_64c` | +3.81% | +3.20% | +4.43% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_1000c` | +2.06% | +1.30% | +2.82% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_16c` | -1.70% | -3.79% | +0.45% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_256c` | +1.39% | -0.00% | +2.82% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_4c` | -0.81% | -4.45% | +3.02% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_64c` | -1.51% | -2.60% | -0.41% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_1000c` | -1.48% | -3.56% | +0.68% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_16c` | +2.27% | -1.41% | +6.01% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_256c` | -1.10% | -3.61% | +1.51% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_4c` | +1.92% | +0.88% | +2.96% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_64c` | +3.52% | +1.23% | +5.82% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_1000c` | -2.87% | -5.61% | -0.05% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_16c` | +6.35% | +4.86% | +7.85% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_256c` | +4.49% | +2.25% | +6.74% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_4c` | +1.60% | +0.77% | +2.45% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_64c` | +2.24% | +0.56% | +3.94% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_1000c` | +4.35% | +2.59% | +6.11% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_16c` | +0.93% | +0.74% | +1.11% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_256c` | +2.13% | +1.87% | +2.40% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_4c` | +0.16% | -1.45% | +1.82% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_64c` | +0.49% | +0.02% | +0.98% |
| `simd_batch_dot_product/scalar_loop/10` | +4.31% | +2.86% | +5.77% |
| `simd_batch_dot_product/scalar_loop/100` | -1.85% | -4.30% | +0.71% |
| `simd_batch_dot_product/scalar_loop/1000` | +1.43% | -0.37% | +3.25% |
| `simd_batch_dot_product/simd_batch/10` | +0.70% | +0.12% | +1.30% |
| `simd_batch_dot_product/simd_batch/100` | -0.33% | -1.12% | +0.47% |
| `simd_batch_dot_product/simd_batch/1000` | +4.07% | +3.05% | +5.10% |
| `simd_cosine_similarity/scalar/1024` | +2.06% | +1.19% | +2.94% |
| `simd_cosine_similarity/scalar/1536` | -1.15% | -1.45% | -0.85% |
| `simd_cosine_similarity/scalar/384` | +2.83% | +2.58% | +3.08% |
| `simd_cosine_similarity/scalar/768` | +3.41% | +2.28% | +4.54% |
| `simd_cosine_similarity/simd/1024` | +1.81% | -0.35% | +4.04% |
| `simd_cosine_similarity/simd/1536` | +4.17% | +2.58% | +5.79% |
| `simd_cosine_similarity/simd/384` | +2.37% | +1.06% | +3.68% |
| `simd_cosine_similarity/simd/768` | +0.97% | -0.83% | +2.78% |
| `simd_dot_product/scalar/1024` | +0.38% | -1.31% | +2.09% |
| `simd_dot_product/scalar/1536` | +3.45% | +1.64% | +5.27% |
| `simd_dot_product/scalar/384` | +3.15% | +1.80% | +4.51% |
| `simd_dot_product/scalar/768` | +0.35% | -0.64% | +1.34% |
| `simd_dot_product/simd/1024` | +0.32% | +0.05% | +0.58% |
| `simd_dot_product/simd/1536` | +2.53% | +0.49% | +4.60% |
| `simd_dot_product/simd/384` | +0.52% | -0.67% | +1.72% |
| `simd_dot_product/simd/768` | +2.23% | +1.50% | +2.96% |
| `simd_euclidean_distance/scalar/1024` | +1.90% | +0.40% | +3.41% |
| `simd_euclidean_distance/scalar/1536` | +0.94% | +0.22% | +1.67% |
| `simd_euclidean_distance/scalar/384` | -0.11% | -2.05% | +1.90% |
| `simd_euclidean_distance/scalar/768` | +0.18% | -1.08% | +1.46% |
| `simd_euclidean_distance/simd/1024` | +1.24% | +0.95% | +1.53% |
| `simd_euclidean_distance/simd/1536` | +1.33% | -0.70% | +3.42% |
| `simd_euclidean_distance/simd/384` | +2.60% | +1.39% | +3.82% |
| `simd_euclidean_distance/simd/768` | +3.76% | +2.60% | +4.93% |
| `simd_normalize/scalar/1024` | +5.43% | +4.48% | +6.39% |
| `simd_normalize/scalar/1536` | +4.42% | +4.02% | +4.82% |
| `simd_normalize/scalar/384` | +2.63% | +2.53% | +2.74% |
| `simd_normalize/scalar/768` | -1.41% | -2.98% | +0.22% |
| `simd_normalize/simd/1024` | +11.94% | +9.42% | +14.49% |
| `simd_normalize/simd/1536` | +1.01% | -1.62% | +3.70% |
| `simd_normalize/simd/384` | +12.67% | +11.08% | +14.29% |
| `simd_normalize/simd/768` | +16.07% | +14.53% | +17.61% |
| `simd_normalized_cosine_fast_path/cosine_full/1024` | -0.88% | -1.77% | +0.02% |
| `simd_normalized_cosine_fast_path/cosine_full/384` | -1.50% | -1.84% | -1.15% |
| `simd_normalized_cosine_fast_path/cosine_full/768` | -0.42% | -1.85% | +1.03% |
| `simd_normalized_cosine_fast_path/dot_product/1024` | -2.12% | -2.81% | -1.42% |
| `simd_normalized_cosine_fast_path/dot_product/384` | -0.51% | -1.14% | +0.12% |
| `simd_normalized_cosine_fast_path/dot_product/768` | +0.51% | -0.59% | +1.61% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/1024` | +2.97% | +0.87% | +5.13% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/384` | -3.40% | -3.87% | -2.93% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/768` | -0.61% | -1.33% | +0.11% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/1024` | +0.07% | -0.35% | +0.50% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/384` | -5.31% | -7.98% | -2.52% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/768` | +0.52% | +0.36% | +0.68% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/1024` | +2.49% | -0.71% | +5.77% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/384` | -2.48% | -4.05% | -0.88% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/768` | -0.18% | -0.87% | +0.51% |
| `simd_query_batch_dot_product/pair_loop/128d_16c` | +0.27% | -1.08% | +1.62% |
| `simd_query_batch_dot_product/pair_loop/128d_256c` | +45.17% | +44.78% | +45.55% |
| `simd_query_batch_dot_product/pair_loop/128d_4c` | +1.60% | -0.95% | +4.27% |
| `simd_query_batch_dot_product/pair_loop/128d_64c` | +57.17% | +55.99% | +58.35% |
| `simd_query_batch_dot_product/pair_loop/384d_16c` | +4.39% | +3.60% | +5.18% |
| `simd_query_batch_dot_product/pair_loop/384d_256c` | -0.63% | -0.92% | -0.34% |
| `simd_query_batch_dot_product/pair_loop/384d_4c` | +0.28% | -0.82% | +1.39% |
| `simd_query_batch_dot_product/pair_loop/384d_64c` | -0.74% | -1.29% | -0.19% |
| `simd_query_batch_dot_product/pair_loop/768d_16c` | +0.63% | -0.68% | +1.96% |
| `simd_query_batch_dot_product/pair_loop/768d_256c` | +1.78% | -1.53% | +5.18% |
| `simd_query_batch_dot_product/pair_loop/768d_4c` | +2.17% | +1.43% | +2.91% |
| `simd_query_batch_dot_product/pair_loop/768d_64c` | +3.67% | +1.18% | +6.17% |
| `simd_query_batch_dot_product/simd_batch/128d_16c` | +31.28% | +30.20% | +32.38% |
| `simd_query_batch_dot_product/simd_batch/128d_256c` | -0.68% | -2.02% | +0.67% |
| `simd_query_batch_dot_product/simd_batch/128d_4c` | +0.03% | -2.22% | +2.35% |
| `simd_query_batch_dot_product/simd_batch/128d_64c` | +70.10% | +68.66% | +71.53% |
| `simd_query_batch_dot_product/simd_batch/384d_16c` | +0.30% | -1.45% | +2.09% |
| `simd_query_batch_dot_product/simd_batch/384d_256c` | -1.16% | -4.47% | +2.31% |
| `simd_query_batch_dot_product/simd_batch/384d_4c` | +3.93% | +3.31% | +4.56% |
| `simd_query_batch_dot_product/simd_batch/384d_64c` | -0.47% | -1.44% | +0.52% |
| `simd_query_batch_dot_product/simd_batch/768d_16c` | +1.47% | +0.22% | +2.74% |
| `simd_query_batch_dot_product/simd_batch/768d_256c` | +1.74% | +0.48% | +2.99% |
| `simd_query_batch_dot_product/simd_batch/768d_4c` | -2.66% | -3.92% | -1.36% |
| `simd_query_batch_dot_product/simd_batch/768d_64c` | +3.79% | +1.35% | +6.28% |
| `simd_squared_euclidean_fast_path/euclidean_full/1024` | -32.84% | -33.63% | -32.02% |
| `simd_squared_euclidean_fast_path/euclidean_full/384` | +0.24% | -0.09% | +0.57% |
| `simd_squared_euclidean_fast_path/euclidean_full/768` | +0.12% | -0.34% | +0.59% |
| `simd_squared_euclidean_fast_path/squared_euclidean/1024` | -39.89% | -41.80% | -37.90% |
| `simd_squared_euclidean_fast_path/squared_euclidean/384` | -1.43% | -2.77% | -0.06% |
| `simd_squared_euclidean_fast_path/squared_euclidean/768` | +1.16% | +0.05% | +2.28% |
| `simd_throughput_384/cosine_similarity` | +1.92% | +1.76% | +2.09% |
| `simd_throughput_384/dot_product` | +5.30% | +3.33% | +7.29% |
| `simd_throughput_384/euclidean_distance` | +4.49% | +3.77% | +5.21% |
| `simd_throughput_384/normalize` | +0.29% | +0.23% | +0.36% |
| `softmax_attention/128` | +0.41% | +0.15% | +0.66% |
| `softmax_attention/512` | +1.71% | +0.17% | +3.28% |
| `tier_prepared_batch_sizes/int4_batch_prepared/10` | -1.52% | -3.24% | +0.23% |
| `tier_prepared_batch_sizes/int4_batch_prepared/100` | -0.93% | -1.98% | +0.14% |
| `tier_prepared_batch_sizes/int4_batch_prepared/1000` | +1.10% | +0.43% | +1.76% |
| `tier_prepared_batch_sizes/int4_query_per_call/10` | -0.98% | -2.34% | +0.38% |
| `tier_prepared_batch_sizes/int4_query_per_call/100` | -1.27% | -2.68% | +0.18% |
| `tier_prepared_batch_sizes/int4_query_per_call/1000` | +0.41% | -0.30% | +1.13% |
| `tier_prepared_batch_sizes/int8_batch_prepared/10` | +0.37% | -0.42% | +1.17% |
| `tier_prepared_batch_sizes/int8_batch_prepared/100` | -3.15% | -3.70% | -2.58% |
| `tier_prepared_batch_sizes/int8_batch_prepared/1000` | +0.52% | -0.05% | +1.09% |
| `tier_prepared_batch_sizes/int8_query_per_call/10` | -0.12% | -0.18% | -0.06% |
| `tier_prepared_batch_sizes/int8_query_per_call/100` | -3.12% | -4.02% | -2.23% |
| `tier_prepared_batch_sizes/int8_query_per_call/1000` | -0.71% | -2.64% | +1.28% |
| `tier_prepared_query/binary_query_once_1000` | +0.79% | +0.34% | +1.23% |
| `tier_prepared_query/binary_query_per_call_1000` | +1.43% | +0.72% | +2.15% |
| `tier_prepared_query/int4_query_once_1000` | +0.67% | -1.44% | +2.80% |
| `tier_prepared_query/int4_query_per_call_1000` | +1.34% | +0.61% | +2.07% |
| `tier_prepared_query/int8_query_once_1000` | -0.60% | -2.53% | +1.36% |
| `tier_prepared_query/int8_query_per_call_1000` | +0.45% | -0.20% | +1.10% |

</details>

_Rule: CI-lower of change ≤3.0% passes silently; (3.0%, 7.0%] warns; >7.0% fails. Override via PR label `bench-allow-regression`._
_5 group(s) excluded from gating as quick-mode informational-only (lattice#714): int4_cosine_distance, int8_batch_cosine, simd_batch_cosine_non_normalized_query, simd_cosine_similarity, simd_dot_product._


Done. Base=origin/main (823b22669c), Head=HEAD (e1df92678d)

</details>

**Every FAIL/WARN bench above is in `lattice-embed`'s SIMD/cosine suite or `lattice-inference`'s generic `elementwise_cpu_bench` group (`rms_norm`, `layer_norm`, `gelu`, `silu_inplace`, `add_bias_gelu`, `softmax_attention`).** This PR touches none of that code — the diff is confined to `crates/inference/src/vision/qwen35_vit_metal.rs` (new module, only caller is its own gate test) and a single-line `pub use` export in `metal_gemm.rs` with zero change to any existing function body (`metal_matmul`, `metal_matmul_bt`, `run_gemm` unchanged). `grep -rln "metal_matmul_bt\|metal_matmul\b\|metal_gemm::" crates/inference/src/` (excluding the two files this PR touches) confirms no other code calls into `metal_gemm.rs` — decode/prefill (`metal_qwen35.rs`, `forward/gpu/*`) has its own separate Metal dispatch machinery.

### Same-binary A/A disproof (HEAD vs HEAD, identical commit both sides)

Given the FAIL/WARN set above has zero code overlap with this diff, re-ran the same comparison with `BASE=HEAD` and `HEAD=HEAD` (the exact same binary on both sides) to check for shared-machine contention before trusting the numbers:

<details>
<summary>Full HEAD vs HEAD (same commit) bench-compare report — proves the noise floor</summary>

### `local-compare` — perf regression report

**❌ 6 FAIL** (regression >7.0% confirmed by 95% CI)
**⚠ 22 WARN** (regression 3.0-7.0% confirmed)
**🚀 16 confirmed improvement**

| Bench | Δ point | 95% CI | new ns | base ns | verdict |
|---|---:|---|---:|---:|---|
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_16c` | +30.99% | [+26.95%, +35.08%] | 680.4 | 519.4 | ❌ FAIL |
| `simd_query_batch_dot_product/pair_loop/128d_4c` | +15.84% | [+14.06%, +17.62%] | 60.4 | 52.2 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/384d_4c` | +9.99% | [+9.70%, +10.29%] | 77.5 | 70.5 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/128d_4c` | +10.25% | [+9.61%, +10.90%] | 38.0 | 34.5 | ❌ FAIL |
| `memory_size/search_1000_int8` | +10.49% | [+8.08%, +12.91%] | 11261.4 | 10191.8 | ❌ FAIL |
| `int8_batch_cosine/float32_simd/100` | +8.84% | [+7.65%, +10.04%] | 4536.6 | 4168.1 | ❌ FAIL |
| `simd_query_batch_dot_product/simd_batch/768d_4c` | +7.46% | [+6.70%, +8.21%] | 136.0 | 126.5 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/simd_batch/384d_64c` | +5.85% | [+5.53%, +6.17%] | 2032.6 | 1920.3 | ⚠ WARN |
| `int8_batch_cosine/int8_loop/10` | +6.84% | [+5.51%, +8.19%] | 117.9 | 110.3 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_1000c` | +5.39% | [+4.85%, +5.93%] | 32074.4 | 30434.8 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/simd_batch/384d_256c` | +5.63% | [+4.67%, +6.59%] | 8865.4 | 8393.2 | ⚠ WARN |
| `simd_query_batch_dot_product/simd_batch/128d_256c` | +5.40% | [+4.45%, +6.34%] | 2038.3 | 1933.9 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_64c` | +4.69% | [+4.32%, +5.06%] | 2050.1 | 1958.2 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_256c` | +4.92% | [+4.18%, +5.65%] | 8506.6 | 8108.1 | ⚠ WARN |
| `int8_batch_cosine/float32_simd/1000` | +4.63% | [+4.07%, +5.21%] | 41274.7 | 39446.7 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_1000c` | +5.37% | [+4.05%, +6.70%] | 80415.9 | 76315.3 | ⚠ WARN |
| `simd_throughput_384/euclidean_distance` | +4.49% | [+3.77%, +5.21%] | 30.2 | 28.9 | ⚠ WARN |
| `simd_batch_cosine/simd_batch/100` | +4.69% | [+3.75%, +5.65%] | 4324.8 | 4131.0 | ⚠ WARN |
| `int8_raw_dot_product/dot_product_i8/127` | +5.17% | [+3.63%, +6.72%] | 7.1 | 6.8 | ⚠ WARN |
| `int4_cosine_distance/int4/1024` | +4.14% | [+3.48%, +4.80%] | 60.7 | 58.3 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_64c` | +3.98% | [+3.41%, +4.55%] | 1783.8 | 1715.5 | ⚠ WARN |
| `simd_throughput_384/dot_product` | +5.30% | [+3.33%, +7.29%] | 28.4 | 27.0 | ⚠ WARN |
| `simd_batch_cosine/scalar_loop/100` | +3.51% | [+3.33%, +3.69%] | 70398.6 | 68010.5 | ⚠ WARN |
| `simd_batch_cosine/scalar_loop/1000` | +3.94% | [+3.22%, +4.66%] | 707439.0 | 680639.5 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_16c` | +3.58% | [+3.21%, +3.95%] | 1169.1 | 1128.7 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_1000c` | +3.17% | [+3.13%, +3.21%] | 62403.3 | 60484.0 | ⚠ WARN |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_64c` | +3.32% | [+3.11%, +3.52%] | 3970.8 | 3843.4 | ⚠ WARN |
| `simd_batch_dot_product/simd_batch/1000` | +4.07% | [+3.05%, +5.10%] | 40296.4 | 38720.2 | ⚠ WARN |
| `tier_prepared_batch_sizes/int8_batch_prepared/100` | -3.15% | [-3.70%, -2.58%] | 988.9 | 1021.0 | 🚀 WIN |
| `simd_prepared_query_normalized_cosine/dot_product_loop/384` | -3.40% | [-3.87%, -2.93%] | 31969.1 | 33093.8 | 🚀 WIN |
| `tier_prepared_batch_sizes/int8_query_per_call/100` | -3.12% | [-4.02%, -2.23%] | 112667.1 | 116300.9 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/129` | -3.54% | [-4.57%, -2.50%] | 4.9 | 5.0 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/1024` | -4.37% | [-4.67%, -4.08%] | 24.6 | 25.7 | 🚀 WIN |
| `int8_prepared_dot_product/prepared/384` | -4.52% | [-5.10%, -3.94%] | 10.1 | 10.6 | 🚀 WIN |
| `simd_normalize/simd/768` | -3.94% | [-5.49%, -2.38%] | 124.1 | 129.2 | 🚀 WIN |
| `simd_normalize/simd/384` | -4.70% | [-6.19%, -3.16%] | 72.2 | 75.8 | 🚀 WIN |
| `int8_vs_float32_cosine/int8/768` | -6.25% | [-7.10%, -5.38%] | 17.1 | 18.3 | 🚀 WIN |
| `binary_cosine_distance/float32_simd/1536` | -6.31% | [-7.16%, -5.45%] | 120.9 | 129.1 | 🚀 WIN |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/384` | -5.31% | [-7.98%, -2.52%] | 36622.4 | 38676.5 | 🚀 WIN |
| `int8_raw_dot_product/dot_product_i8_raw/127` | -5.48% | [-8.58%, -2.20%] | 6.9 | 7.3 | 🚀 WIN |
| `simd_normalize/simd/1536` | -7.35% | [-10.00%, -4.69%] | 219.0 | 236.4 | 🚀 WIN |
| `simd_batch_cosine_normalized_query/simd_batch/768d_64c` | -12.41% | [-12.82%, -12.01%] | 4023.6 | 4593.9 | 🚀 WIN |
| `simd_squared_euclidean_fast_path/euclidean_full/1024` | -32.84% | [-33.63%, -32.02%] | 80.2 | 119.4 | 🚀 WIN |
| `simd_squared_euclidean_fast_path/squared_euclidean/1024` | -39.89% | [-41.80%, -37.90%] | 78.1 | 129.9 | 🚀 WIN |

**ℹ️ 30 informational** (below quick-mode resolution — lattice-embed SIMD micro-benches, tracked in #714; not gated here, re-run `--full` for a gated verdict)
| Bench | Δ point | 95% CI | new ns | base ns | (would-be verdict) |
|---|---:|---|---:|---:|---|
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_1000c` | +3.69% | [+3.17%, +4.21%] | 82569.5 | 79634.1 | ⚠ WARN (informational) |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c` | -3.27% | [-4.08%, -2.46%] | 5155.9 | 5330.4 | 🚀 WIN (informational) |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_64c` | -11.51% | [-12.17%, -10.86%] | 4099.6 | 4633.0 | 🚀 WIN (informational) |

<details><summary>All 263 measurements</summary>

| Bench | Δ point | CI-lower | CI-upper |
|---|---:|---:|---:|
| `add_bias_gelu/4096` | +1.04% | +0.72% | +1.36% |
| `add_bias_gelu/896` | +0.85% | +0.47% | +1.23% |
| `binary_cosine_distance/binary/1024` | -1.22% | -2.35% | -0.07% |
| `binary_cosine_distance/binary/1536` | +0.08% | -0.58% | +0.74% |
| `binary_cosine_distance/binary/384` | +2.06% | +1.55% | +2.58% |
| `binary_cosine_distance/binary/768` | -0.16% | -0.42% | +0.09% |
| `binary_cosine_distance/float32_simd/1024` | +0.73% | -1.09% | +2.56% |
| `binary_cosine_distance/float32_simd/1536` | -6.31% | -7.16% | -5.45% |
| `binary_cosine_distance/float32_simd/384` | +1.18% | -0.23% | +2.60% |
| `binary_cosine_distance/float32_simd/768` | -0.70% | -0.78% | -0.62% |
| `elementwise_mul/4096` | +2.15% | +0.85% | +3.48% |
| `gelu/4096` | +1.16% | +0.54% | +1.78% |
| `gelu/896` | +0.31% | -0.12% | +0.74% |
| `int4_cosine_distance/float32_simd/1024` | +3.84% | -0.09% | +7.96% |
| `int4_cosine_distance/float32_simd/1536` | +1.09% | +0.56% | +1.64% |
| `int4_cosine_distance/float32_simd/384` | +3.55% | +2.91% | +4.19% |
| `int4_cosine_distance/float32_simd/768` | +3.03% | +2.45% | +3.60% |
| `int4_cosine_distance/int4/1024` | +4.14% | +3.48% | +4.80% |
| `int4_cosine_distance/int4/1536` | +1.97% | +1.59% | +2.36% |
| `int4_cosine_distance/int4/384` | +0.64% | -0.37% | +1.67% |
| `int4_cosine_distance/int4/768` | +2.73% | +1.17% | +4.33% |
| `int8_batch_cosine/float32_simd/10` | +2.26% | +1.96% | +2.57% |
| `int8_batch_cosine/float32_simd/100` | +8.84% | +7.65% | +10.04% |
| `int8_batch_cosine/float32_simd/1000` | +4.63% | +4.07% | +5.21% |
| `int8_batch_cosine/int8_loop/10` | +6.84% | +5.51% | +8.19% |
| `int8_batch_cosine/int8_loop/100` | +3.49% | +2.78% | +4.20% |
| `int8_batch_cosine/int8_loop/1000` | +2.20% | +1.12% | +3.30% |
| `int8_prepared_dot_product/per_call/1024` | -0.18% | -0.39% | +0.03% |
| `int8_prepared_dot_product/per_call/127` | -1.92% | -2.18% | -1.65% |
| `int8_prepared_dot_product/per_call/128` | +0.23% | +0.01% | +0.45% |
| `int8_prepared_dot_product/per_call/129` | -0.32% | -0.93% | +0.30% |
| `int8_prepared_dot_product/per_call/384` | +0.01% | -0.72% | +0.74% |
| `int8_prepared_dot_product/per_call/768` | -0.12% | -1.81% | +1.58% |
| `int8_prepared_dot_product/prepared/1024` | +0.80% | +0.39% | +1.21% |
| `int8_prepared_dot_product/prepared/127` | -0.58% | -1.97% | +0.82% |
| `int8_prepared_dot_product/prepared/128` | -0.26% | -1.22% | +0.71% |
| `int8_prepared_dot_product/prepared/129` | +0.73% | -0.06% | +1.53% |
| `int8_prepared_dot_product/prepared/384` | -4.52% | -5.10% | -3.94% |
| `int8_prepared_dot_product/prepared/768` | -0.40% | -0.75% | -0.04% |
| `int8_quantization/quantize/1024` | +4.27% | +2.54% | +6.01% |
| `int8_quantization/quantize/1536` | +4.17% | +2.75% | +5.59% |
| `int8_quantization/quantize/384` | +2.86% | +2.62% | +3.09% |
| `int8_quantization/quantize/768` | +2.82% | +2.58% | +3.06% |
| `int8_raw_dot_product/dot_product_i8/1024` | -1.81% | -4.22% | +0.73% |
| `int8_raw_dot_product/dot_product_i8/127` | +5.17% | +3.63% | +6.72% |
| `int8_raw_dot_product/dot_product_i8/128` | -2.77% | -3.62% | -1.91% |
| `int8_raw_dot_product/dot_product_i8/129` | -1.27% | -3.53% | +1.08% |
| `int8_raw_dot_product/dot_product_i8/384` | +0.13% | -0.18% | +0.45% |
| `int8_raw_dot_product/dot_product_i8/768` | +0.03% | -1.60% | +1.67% |
| `int8_raw_dot_product/dot_product_i8_raw/1024` | +0.31% | -0.42% | +1.05% |
| `int8_raw_dot_product/dot_product_i8_raw/127` | -5.48% | -8.58% | -2.20% |
| `int8_raw_dot_product/dot_product_i8_raw/128` | +1.05% | -0.59% | +2.69% |
| `int8_raw_dot_product/dot_product_i8_raw/129` | -3.54% | -4.57% | -2.50% |
| `int8_raw_dot_product/dot_product_i8_raw/384` | -2.51% | -4.88% | -0.04% |
| `int8_raw_dot_product/dot_product_i8_raw/768` | +0.29% | -1.19% | +1.78% |
| `int8_vs_float32_cosine/float32_simd/1024` | -2.71% | -5.44% | +0.17% |
| `int8_vs_float32_cosine/float32_simd/1536` | -0.04% | -0.39% | +0.31% |
| `int8_vs_float32_cosine/float32_simd/384` | +4.70% | +1.31% | +8.27% |
| `int8_vs_float32_cosine/float32_simd/768` | +0.48% | -0.77% | +1.75% |
| `int8_vs_float32_cosine/int8/1024` | -4.37% | -4.67% | -4.08% |
| `int8_vs_float32_cosine/int8/1536` | -0.15% | -0.20% | -0.10% |
| `int8_vs_float32_cosine/int8/384` | -0.84% | -1.32% | -0.36% |
| `int8_vs_float32_cosine/int8/768` | -6.25% | -7.10% | -5.38% |
| `layer_norm/4096` | +1.40% | +1.25% | +1.56% |
| `layer_norm/896` | +2.95% | +2.18% | +3.71% |
| `memory_size/search_1000_float32` | +4.22% | +2.02% | +6.42% |
| `memory_size/search_1000_int8` | +10.49% | +8.08% | +12.91% |
| `residual_add_layer_norm/fused/hidden384_seq128` | +1.71% | +0.91% | +2.51% |
| `residual_add_layer_norm/fused/hidden768_seq128` | +1.68% | +0.83% | +2.53% |
| `residual_add_layer_norm/unfused/hidden384_seq128` | -0.67% | -1.20% | -0.14% |
| `residual_add_layer_norm/unfused/hidden768_seq128` | +2.82% | +2.58% | +3.06% |
| `rms_norm/4096` | +2.36% | +0.92% | +3.80% |
| `rms_norm/896` | +0.20% | -0.89% | +1.29% |
| `silu_inplace/4096` | +1.02% | +0.64% | +1.41% |
| `silu_inplace/896` | +1.62% | +1.32% | +1.92% |
| `simd_batch_cosine/scalar_loop/10` | +0.66% | +0.41% | +0.90% |
| `simd_batch_cosine/scalar_loop/100` | +3.51% | +3.33% | +3.69% |
| `simd_batch_cosine/scalar_loop/1000` | +3.94% | +3.22% | +4.66% |
| `simd_batch_cosine/simd_batch/10` | -0.04% | -1.18% | +1.10% |
| `simd_batch_cosine/simd_batch/100` | +4.69% | +3.75% | +5.65% |
| `simd_batch_cosine/simd_batch/1000` | +2.02% | +1.35% | +2.69% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_1000c` | +3.69% | +3.17% | +4.21% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_16c` | -1.83% | -2.55% | -1.11% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_256c` | +2.54% | +2.38% | +2.71% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_4c` | +0.09% | -0.48% | +0.67% |
| `simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c` | -3.27% | -4.08% | -2.46% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_1000c` | -0.17% | -0.71% | +0.38% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_16c` | -1.03% | -1.43% | -0.62% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_256c` | -1.07% | -1.96% | -0.18% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_4c` | +0.77% | -0.19% | +1.73% |
| `simd_batch_cosine_non_normalized_query/pair_loop/384d_64c` | -2.46% | -3.01% | -1.89% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_1000c` | +0.10% | -3.30% | +3.62% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_16c` | -0.00% | -0.13% | +0.12% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_256c` | +0.86% | +0.21% | +1.51% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_4c` | -1.02% | -1.45% | -0.60% |
| `simd_batch_cosine_non_normalized_query/pair_loop/768d_64c` | +1.58% | +1.12% | +2.03% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_1000c` | +2.02% | +1.15% | +2.90% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_16c` | -2.44% | -2.76% | -2.11% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_256c` | +1.77% | +1.13% | +2.42% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_4c` | +0.28% | -1.41% | +2.00% |
| `simd_batch_cosine_non_normalized_query/simd_batch/1024d_64c` | -0.49% | -1.94% | +0.98% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_1000c` | +1.02% | -0.06% | +2.12% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_16c` | -1.19% | -1.53% | -0.85% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_256c` | -1.69% | -2.64% | -0.73% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_4c` | -1.00% | -2.26% | +0.28% |
| `simd_batch_cosine_non_normalized_query/simd_batch/384d_64c` | -2.26% | -2.59% | -1.93% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_1000c` | +0.40% | +0.14% | +0.66% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_16c` | +0.20% | +0.05% | +0.35% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_256c` | +0.87% | +0.61% | +1.13% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_4c` | -1.59% | -2.83% | -0.33% |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_64c` | -11.51% | -12.17% | -10.86% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_1000c` | +4.63% | +2.37% | +6.92% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_16c` | +1.13% | +0.20% | +2.06% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_256c` | +2.05% | +1.38% | +2.72% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_4c` | -0.01% | -0.58% | +0.57% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/1024d_64c` | -1.70% | -2.24% | -1.15% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_1000c` | +4.07% | +2.80% | +5.36% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_16c` | +30.99% | +26.95% | +35.08% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_256c` | +3.62% | +2.52% | +4.74% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_4c` | +1.92% | +1.33% | +2.51% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/384d_64c` | +4.69% | +4.32% | +5.06% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_1000c` | +3.17% | +3.13% | +3.21% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_16c` | +0.35% | -0.81% | +1.54% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_256c` | +0.41% | +0.17% | +0.65% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_4c` | -2.29% | -2.66% | -1.91% |
| `simd_batch_cosine_normalized_query/pair_loop_cosine/768d_64c` | +2.60% | +2.04% | +3.16% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_1000c` | +5.37% | +4.05% | +6.70% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_16c` | +3.58% | +3.21% | +3.95% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_256c` | +2.31% | +1.65% | +2.96% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_4c` | +1.05% | +0.72% | +1.39% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c` | -0.28% | -0.53% | -0.02% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_1000c` | +5.39% | +4.85% | +5.93% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_16c` | +1.52% | +0.81% | +2.23% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_256c` | +4.92% | +4.18% | +5.65% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_4c` | -0.09% | -0.56% | +0.38% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/384d_64c` | +3.98% | +3.41% | +4.55% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_1000c` | +1.84% | +1.26% | +2.42% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_16c` | +1.28% | +0.81% | +1.75% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_256c` | +0.49% | +0.35% | +0.64% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_4c` | -2.25% | -2.83% | -1.67% |
| `simd_batch_cosine_normalized_query/pair_loop_dot/768d_64c` | +3.32% | +3.11% | +3.52% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_1000c` | -1.44% | -3.17% | +0.35% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_16c` | +1.55% | +0.46% | +2.64% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_256c` | +2.73% | +1.97% | +3.50% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_4c` | +1.08% | +0.96% | +1.21% |
| `simd_batch_cosine_normalized_query/simd_batch/1024d_64c` | -0.91% | -2.95% | +1.19% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_1000c` | +3.22% | +1.99% | +4.44% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_16c` | +2.21% | +0.79% | +3.64% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_256c` | +5.63% | +4.67% | +6.59% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_4c` | -0.47% | -1.57% | +0.64% |
| `simd_batch_cosine_normalized_query/simd_batch/384d_64c` | +5.85% | +5.53% | +6.17% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_1000c` | +1.78% | +0.52% | +3.03% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_16c` | +1.47% | +1.30% | +1.63% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_256c` | +0.51% | -0.13% | +1.16% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_4c` | +0.73% | +0.08% | +1.38% |
| `simd_batch_cosine_normalized_query/simd_batch/768d_64c` | -12.41% | -12.82% | -12.01% |
| `simd_batch_dot_product/scalar_loop/10` | +4.31% | +2.86% | +5.77% |
| `simd_batch_dot_product/scalar_loop/100` | -1.85% | -4.30% | +0.71% |
| `simd_batch_dot_product/scalar_loop/1000` | +1.43% | -0.37% | +3.25% |
| `simd_batch_dot_product/simd_batch/10` | +0.70% | +0.12% | +1.30% |
| `simd_batch_dot_product/simd_batch/100` | -0.33% | -1.12% | +0.47% |
| `simd_batch_dot_product/simd_batch/1000` | +4.07% | +3.05% | +5.10% |
| `simd_cosine_similarity/scalar/1024` | +2.06% | +1.19% | +2.94% |
| `simd_cosine_similarity/scalar/1536` | -1.15% | -1.45% | -0.85% |
| `simd_cosine_similarity/scalar/384` | +2.83% | +2.58% | +3.08% |
| `simd_cosine_similarity/scalar/768` | +3.41% | +2.28% | +4.54% |
| `simd_cosine_similarity/simd/1024` | +1.81% | -0.35% | +4.04% |
| `simd_cosine_similarity/simd/1536` | +4.17% | +2.58% | +5.79% |
| `simd_cosine_similarity/simd/384` | +2.37% | +1.06% | +3.68% |
| `simd_cosine_similarity/simd/768` | +0.97% | -0.83% | +2.78% |
| `simd_dot_product/scalar/1024` | +0.38% | -1.31% | +2.09% |
| `simd_dot_product/scalar/1536` | +3.45% | +1.64% | +5.27% |
| `simd_dot_product/scalar/384` | +3.15% | +1.80% | +4.51% |
| `simd_dot_product/scalar/768` | +0.35% | -0.64% | +1.34% |
| `simd_dot_product/simd/1024` | +0.32% | +0.05% | +0.58% |
| `simd_dot_product/simd/1536` | +2.53% | +0.49% | +4.60% |
| `simd_dot_product/simd/384` | +0.52% | -0.67% | +1.72% |
| `simd_dot_product/simd/768` | +2.23% | +1.50% | +2.96% |
| `simd_euclidean_distance/scalar/1024` | +1.90% | +0.40% | +3.41% |
| `simd_euclidean_distance/scalar/1536` | +0.94% | +0.22% | +1.67% |
| `simd_euclidean_distance/scalar/384` | -0.11% | -2.05% | +1.90% |
| `simd_euclidean_distance/scalar/768` | +0.18% | -1.08% | +1.46% |
| `simd_euclidean_distance/simd/1024` | +1.24% | +0.95% | +1.53% |
| `simd_euclidean_distance/simd/1536` | +1.33% | -0.70% | +3.42% |
| `simd_euclidean_distance/simd/384` | +2.60% | +1.39% | +3.82% |
| `simd_euclidean_distance/simd/768` | +3.76% | +2.60% | +4.93% |
| `simd_normalize/scalar/1024` | +2.81% | +1.99% | +3.63% |
| `simd_normalize/scalar/1536` | +1.14% | +0.04% | +2.25% |
| `simd_normalize/scalar/384` | +0.04% | -0.91% | +1.01% |
| `simd_normalize/scalar/768` | -2.69% | -3.12% | -2.26% |
| `simd_normalize/simd/1024` | +2.10% | +1.08% | +3.14% |
| `simd_normalize/simd/1536` | -7.35% | -10.00% | -4.69% |
| `simd_normalize/simd/384` | -4.70% | -6.19% | -3.16% |
| `simd_normalize/simd/768` | -3.94% | -5.49% | -2.38% |
| `simd_normalized_cosine_fast_path/cosine_full/1024` | +0.18% | -0.24% | +0.60% |
| `simd_normalized_cosine_fast_path/cosine_full/384` | -1.22% | -2.46% | +0.04% |
| `simd_normalized_cosine_fast_path/cosine_full/768` | +2.72% | +1.66% | +3.80% |
| `simd_normalized_cosine_fast_path/dot_product/1024` | +1.11% | +0.59% | +1.64% |
| `simd_normalized_cosine_fast_path/dot_product/384` | -0.73% | -1.44% | -0.01% |
| `simd_normalized_cosine_fast_path/dot_product/768` | +0.10% | -0.15% | +0.35% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/1024` | +2.97% | +0.87% | +5.13% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/384` | -3.40% | -3.87% | -2.93% |
| `simd_prepared_query_normalized_cosine/dot_product_loop/768` | -0.61% | -1.33% | +0.11% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/1024` | +0.07% | -0.35% | +0.50% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/384` | -5.31% | -7.98% | -2.52% |
| `simd_prepared_query_normalized_cosine/prepared_full_cosine/768` | +0.52% | +0.36% | +0.68% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/1024` | +2.49% | -0.71% | +5.77% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/384` | -2.48% | -4.05% | -0.88% |
| `simd_prepared_query_normalized_cosine/prepared_meta_unit/768` | -0.18% | -0.87% | +0.51% |
| `simd_query_batch_dot_product/pair_loop/128d_16c` | -1.89% | -2.97% | -0.78% |
| `simd_query_batch_dot_product/pair_loop/128d_256c` | -0.66% | -1.27% | -0.04% |
| `simd_query_batch_dot_product/pair_loop/128d_4c` | +15.84% | +14.06% | +17.62% |
| `simd_query_batch_dot_product/pair_loop/128d_64c` | +1.27% | +0.22% | +2.33% |
| `simd_query_batch_dot_product/pair_loop/384d_16c` | +0.25% | +0.12% | +0.38% |
| `simd_query_batch_dot_product/pair_loop/384d_256c` | +2.46% | +2.33% | +2.59% |
| `simd_query_batch_dot_product/pair_loop/384d_4c` | -1.20% | -1.64% | -0.76% |
| `simd_query_batch_dot_product/pair_loop/384d_64c` | +0.66% | +0.42% | +0.91% |
| `simd_query_batch_dot_product/pair_loop/768d_16c` | -0.91% | -1.87% | +0.07% |
| `simd_query_batch_dot_product/pair_loop/768d_256c` | -0.70% | -1.68% | +0.29% |
| `simd_query_batch_dot_product/pair_loop/768d_4c` | -0.01% | -0.63% | +0.61% |
| `simd_query_batch_dot_product/pair_loop/768d_64c` | +4.65% | +2.84% | +6.47% |
| `simd_query_batch_dot_product/simd_batch/128d_16c` | +3.97% | +2.04% | +5.91% |
| `simd_query_batch_dot_product/simd_batch/128d_256c` | +5.40% | +4.45% | +6.34% |
| `simd_query_batch_dot_product/simd_batch/128d_4c` | +10.25% | +9.61% | +10.90% |
| `simd_query_batch_dot_product/simd_batch/128d_64c` | +1.25% | +0.37% | +2.14% |
| `simd_query_batch_dot_product/simd_batch/384d_16c` | -0.57% | -0.79% | -0.35% |
| `simd_query_batch_dot_product/simd_batch/384d_256c` | +2.14% | +1.83% | +2.45% |
| `simd_query_batch_dot_product/simd_batch/384d_4c` | +9.99% | +9.70% | +10.29% |
| `simd_query_batch_dot_product/simd_batch/384d_64c` | +0.93% | +0.52% | +1.33% |
| `simd_query_batch_dot_product/simd_batch/768d_16c` | +1.02% | +0.10% | +1.94% |
| `simd_query_batch_dot_product/simd_batch/768d_256c` | +1.91% | +0.93% | +2.89% |
| `simd_query_batch_dot_product/simd_batch/768d_4c` | +7.46% | +6.70% | +8.21% |
| `simd_query_batch_dot_product/simd_batch/768d_64c` | +0.06% | -0.42% | +0.54% |
| `simd_squared_euclidean_fast_path/euclidean_full/1024` | -32.84% | -33.63% | -32.02% |
| `simd_squared_euclidean_fast_path/euclidean_full/384` | +0.24% | -0.09% | +0.57% |
| `simd_squared_euclidean_fast_path/euclidean_full/768` | +0.12% | -0.34% | +0.59% |
| `simd_squared_euclidean_fast_path/squared_euclidean/1024` | -39.89% | -41.80% | -37.90% |
| `simd_squared_euclidean_fast_path/squared_euclidean/384` | -1.43% | -2.77% | -0.06% |
| `simd_squared_euclidean_fast_path/squared_euclidean/768` | +1.16% | +0.05% | +2.28% |
| `simd_throughput_384/cosine_similarity` | +1.92% | +1.76% | +2.09% |
| `simd_throughput_384/dot_product` | +5.30% | +3.33% | +7.29% |
| `simd_throughput_384/euclidean_distance` | +4.49% | +3.77% | +5.21% |
| `simd_throughput_384/normalize` | +0.29% | +0.23% | +0.36% |
| `softmax_attention/128` | +0.41% | +0.15% | +0.66% |
| `softmax_attention/512` | +1.71% | +0.17% | +3.28% |
| `tier_prepared_batch_sizes/int4_batch_prepared/10` | -1.52% | -3.24% | +0.23% |
| `tier_prepared_batch_sizes/int4_batch_prepared/100` | -0.93% | -1.98% | +0.14% |
| `tier_prepared_batch_sizes/int4_batch_prepared/1000` | +1.10% | +0.43% | +1.76% |
| `tier_prepared_batch_sizes/int4_query_per_call/10` | -0.98% | -2.34% | +0.38% |
| `tier_prepared_batch_sizes/int4_query_per_call/100` | -1.27% | -2.68% | +0.18% |
| `tier_prepared_batch_sizes/int4_query_per_call/1000` | +0.41% | -0.30% | +1.13% |
| `tier_prepared_batch_sizes/int8_batch_prepared/10` | +0.37% | -0.42% | +1.17% |
| `tier_prepared_batch_sizes/int8_batch_prepared/100` | -3.15% | -3.70% | -2.58% |
| `tier_prepared_batch_sizes/int8_batch_prepared/1000` | +0.52% | -0.05% | +1.09% |
| `tier_prepared_batch_sizes/int8_query_per_call/10` | -0.12% | -0.18% | -0.06% |
| `tier_prepared_batch_sizes/int8_query_per_call/100` | -3.12% | -4.02% | -2.23% |
| `tier_prepared_batch_sizes/int8_query_per_call/1000` | -0.71% | -2.64% | +1.28% |
| `tier_prepared_query/binary_query_once_1000` | +0.79% | +0.34% | +1.23% |
| `tier_prepared_query/binary_query_per_call_1000` | +1.43% | +0.72% | +2.15% |
| `tier_prepared_query/int4_query_once_1000` | +0.67% | -1.44% | +2.80% |
| `tier_prepared_query/int4_query_per_call_1000` | +1.34% | +0.61% | +2.07% |
| `tier_prepared_query/int8_query_once_1000` | -0.60% | -2.53% | +1.36% |
| `tier_prepared_query/int8_query_per_call_1000` | +0.45% | -0.20% | +1.10% |

</details>

_Rule: CI-lower of change ≤3.0% passes silently; (3.0%, 7.0%] warns; >7.0% fails. Override via PR label `bench-allow-regression`._
_1 group(s) excluded from gating as quick-mode informational-only (lattice#714): simd_batch_cosine_non_normalized_query._


Done. Base=HEAD (e1df92678d), Head=HEAD (e1df92678d)

</details>

**A literally identical binary compared against itself produces 6 "FAIL"s up to +30.99% and 16 "improvements" down to −39.89%.** That's the noise floor on this shared machine right now — other seats compiling/benching concurrently corrupt Criterion's timing regardless of which two commits are being compared. Combined with the structural fact that every flagged bench lives in code this PR never touches, the origin/main-vs-HEAD FAIL/WARN set above is contention noise, not a regression introduced by this diff. Per repo convention for shared-machine bench contention, the correct read here is structural-unreachability, backed by this A/A disproof — not a demand for a pristine A/B on a loaded machine.
## Test plan

- [x] `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets --features f16,metal-gpu -- -D warnings` — clean
- [x] `cargo clippy --workspace -- -D warnings` (default features, matches pre-commit hook) — clean
- [x] `cargo test -p lattice-inference --lib --features f16,metal-gpu vision` — passed
- [x] `cargo clippy --workspace --all-targets --features f16,metal-gpu,test-utils -- -D warnings` — clean (dispatch counter compiles in behind `test-utils`, no dead-code/unused-import warnings either way)
- [x] `cargo test --release -p lattice-inference --features f16,metal-gpu --test vision_s3_vit_forward_test --test vision_s3b_vit_metal_gate_test -- --test-threads=1` — S3a cosine 1.0, S3b cosine 1.0 (dispatch counter is `test-utils`-gated out of this build, so no dispatch-count assertion runs here)
- [x] `cargo test --release -p lattice-inference --features f16,metal-gpu,test-utils --test vision_s3_vit_forward_test --test vision_s3b_vit_metal_gate_test -- --test-threads=1` — full gate: S3a cosine 1.0, S3b cosine 1.0, dispatch 57/57
- [x] `cargo fmt --all -- --check` — clean
- [x] `typos` on changed files — clean
- [x] Mutation cycle, Metal-path attention wiring (revert → fail → restore → pass) — recorded above
- [x] Mutation cycle, dispatch-count assertion (bypass one GEMM call site → fail at 55/57 → restore → pass) — recorded above
- [x] `make bench-compare` (origin/main vs HEAD) — run under GPU + heavy-work lock; FAIL/WARN set shown to be shared-machine contention noise via same-binary A/A disproof, not a regression from this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

