### PR TITLE
ci: promote the Metal e2e leg to a required parity ratchet (#239, #535 waived)

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -180,11 +180,14 @@ jobs:
   # for the long-prefill prompt, where Metal deterministically diverges from
   # HF at the first token (open issue #535). What this required job certifies
   # is therefore: Metal dispatch path-proof, binary health, and greedy token
-  # parity on every prompt EXCEPT the #535-waived one. Any NEW divergence on
-  # any prompt still fails closed. The waiver self-reports: if the waived
-  # prompt starts passing, the run prints XPASS and the entry gets deleted
-  # (see the METAL_EXPECTED_DIVERGENCE comment in the script). Do not read
-  # this gate as full Metal parity until #535 is fixed and the waiver removed.
+  # parity on every prompt EXCEPT the #535-waived one. Any divergence on any
+  # NON-WAIVED prompt fails closed; the waiver is keyed by prompt content, so
+  # the entire waived prompt — including a different or new divergence on it —
+  # stays green while the entry exists. The waiver self-reports: if the waived
+  # prompt starts passing, the run prints XPASS and instructs a maintainer to
+  # delete the entry (advisory — nothing removes it automatically; see the
+  # METAL_EXPECTED_DIVERGENCE comment in the script). Do not read this gate
+  # as full Metal parity until #535 is fixed and the waiver removed.
   #
   # e2e-parity
   # only ever exercised the CPU (qwen35_generate) path above; this job exists

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -171,9 +171,22 @@ jobs:
           header: e2e-parity
           path: parity-report.md
 
-  # REQUIRED Metal attention/KV-cache parity leg (issue #239, promoted per
-  # ADR-066 F2 after a 2-week clean streak: 89/89 executed main-branch runs
-  # green, 2026-07-04 through 2026-07-15, zero reds of any kind). e2e-parity
+  # REQUIRED Metal parity RATCHET leg (issue #239, promoted per ADR-066 F2
+  # after a 2-week clean streak: 89/89 executed main-branch runs green,
+  # 2026-07-04 through 2026-07-15, zero reds of any kind).
+  #
+  # RATCHET, not full-parity certification: scripts/e2e_parity_check.py
+  # carries a deliberate, content-anchored waiver (METAL_EXPECTED_DIVERGENCE)
+  # for the long-prefill prompt, where Metal deterministically diverges from
+  # HF at the first token (open issue #535). What this required job certifies
+  # is therefore: Metal dispatch path-proof, binary health, and greedy token
+  # parity on every prompt EXCEPT the #535-waived one. Any NEW divergence on
+  # any prompt still fails closed. The waiver self-reports: if the waived
+  # prompt starts passing, the run prints XPASS and the entry gets deleted
+  # (see the METAL_EXPECTED_DIVERGENCE comment in the script). Do not read
+  # this gate as full Metal parity until #535 is fixed and the waiver removed.
+  #
+  # e2e-parity
   # only ever exercised the CPU (qwen35_generate) path above; this job exists
   # to prove the Metal attention/KV dispatch helpers actually ran, not just
   # that a Metal device was present.
@@ -198,7 +211,7 @@ jobs:
   # enforcement point, and the gate explicitly accepts skipped-on-merge-group
   # (and only that) as non-failing.
   metal-parity:
-    name: metal attention parity
+    name: metal parity ratchet (#535 waived)
     needs: changes
     if: (needs.changes.outputs.engine == 'true' && github.event_name != 'merge_group') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: macos-latest
@@ -786,10 +799,11 @@ jobs:
   # did not change (nothing to verify); mirrors the parity, embed-drift,
   # wasm-parity, wasm-simd128-parity, q4-composed, vision-s3-gate,
   # ppl-gate-selftest, q4-ppl-quality, and metal-parity verdicts when it did.
-  # Fails closed if change-detection itself errored. metal-parity is required
-  # on PR runs (promoted per ADR-066 F2, issue #239); on merge-group events it
-  # is skipped by design and the gate accepts exactly that skip — see its
-  # comment above. q4-ppl-quality is now armed
+  # Fails closed if change-detection itself errored. metal-parity (the metal
+  # parity RATCHET — #535 is deliberately waived in the script; see the job
+  # comment above) is required on PR runs (promoted per ADR-066 F2, issue
+  # #239); on merge-group events it is skipped by design and the gate accepts
+  # exactly that skip. q4-ppl-quality is now armed
   # (golden captured on run 28841919096) and gates the shipping Q4 tier for
   # regressions.
   parity-gate:
@@ -869,7 +883,7 @@ jobs:
             if [ "$EVENT_NAME" = "merge_group" ] && [ "$METAL_RESULT" = "skipped" ]; then
               echo "metal-parity skipped on merge_group by design — its enforcement point is the PR run."
             else
-              echo "::error::Engine changed and metal attention parity did not succeed (result=$METAL_RESULT)."
+              echo "::error::Engine changed and the metal parity ratchet did not succeed (result=$METAL_RESULT)."
               exit 1
             fi
           fi

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -171,7 +171,9 @@ jobs:
           header: e2e-parity
           path: parity-report.md
 
-  # Non-required Metal attention/KV-cache parity leg (issue #239). e2e-parity
+  # REQUIRED Metal attention/KV-cache parity leg (issue #239, promoted per
+  # ADR-066 F2 after a 2-week clean streak: 89/89 executed main-branch runs
+  # green, 2026-07-04 through 2026-07-15, zero reds of any kind). e2e-parity
   # only ever exercised the CPU (qwen35_generate) path above; this job exists
   # to prove the Metal attention/KV dispatch helpers actually ran, not just
   # that a Metal device was present.
@@ -190,13 +192,13 @@ jobs:
   # kernels despite this, switch only `runs-on` to
   # `[self-hosted, macOS, ARM64, metal]` and document why.
   #
-  # Deliberately NOT added to parity-gate.needs below: this is an informational
-  # signal only. Making it required is a maintainer decision (repo branch
-  # protection), out of scope for this change. It is also skipped on merge-group
-  # events so this non-required macOS work cannot delay the required queue jobs;
-  # the PR run remains its observation point.
+  # Wired into parity-gate.needs below: on engine-change PR runs the gate
+  # fails unless this job succeeded. It remains skipped on merge-group events
+  # so the macOS leg cannot delay the required queue jobs — the PR run is its
+  # enforcement point, and the gate explicitly accepts skipped-on-merge-group
+  # (and only that) as non-failing.
   metal-parity:
-    name: metal attention parity (informational)
+    name: metal attention parity
     needs: changes
     if: (needs.changes.outputs.engine == 'true' && github.event_name != 'merge_group') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: macos-latest
@@ -783,9 +785,11 @@ jobs:
   # REQUIRED status check. Always runs, always reports. Passes when the engine
   # did not change (nothing to verify); mirrors the parity, embed-drift,
   # wasm-parity, wasm-simd128-parity, q4-composed, vision-s3-gate,
-  # ppl-gate-selftest, and q4-ppl-quality verdicts when it did. Fails closed
-  # if change-detection itself errored. metal-parity is deliberately excluded
-  # (informational — see its comment above). q4-ppl-quality is now armed
+  # ppl-gate-selftest, q4-ppl-quality, and metal-parity verdicts when it did.
+  # Fails closed if change-detection itself errored. metal-parity is required
+  # on PR runs (promoted per ADR-066 F2, issue #239); on merge-group events it
+  # is skipped by design and the gate accepts exactly that skip — see its
+  # comment above. q4-ppl-quality is now armed
   # (golden captured on run 28841919096) and gates the shipping Q4 tier for
   # regressions.
   parity-gate:
@@ -801,6 +805,7 @@ jobs:
         vision-s3-gate,
         ppl-gate-selftest,
         q4-ppl-quality,
+        metal-parity,
       ]
     if: always()
     runs-on: ubuntu-latest
@@ -817,7 +822,9 @@ jobs:
           VISION_S3_RESULT="${{ needs.vision-s3-gate.result }}"
           PPL_SELFTEST_RESULT="${{ needs.ppl-gate-selftest.result }}"
           Q4PPL_RESULT="${{ needs.q4-ppl-quality.result }}"
-          echo "changes=$CHANGES_RESULT engine=$ENGINE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT wasm-simd128-parity=$WASM_SIMD128_RESULT q4-composed=$Q4_RESULT vision-s3-gate=$VISION_S3_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT q4-ppl-quality=$Q4PPL_RESULT"
+          METAL_RESULT="${{ needs.metal-parity.result }}"
+          EVENT_NAME="${{ github.event_name }}"
+          echo "changes=$CHANGES_RESULT engine=$ENGINE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT wasm-simd128-parity=$WASM_SIMD128_RESULT q4-composed=$Q4_RESULT vision-s3-gate=$VISION_S3_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT q4-ppl-quality=$Q4PPL_RESULT metal-parity=$METAL_RESULT event=$EVENT_NAME"
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::change-detection did not succeed — failing closed."
             exit 1
@@ -858,5 +865,13 @@ jobs:
             echo "::error::Engine changed and q4-ppl-quality regression gate did not succeed (result=$Q4PPL_RESULT)."
             exit 1
           fi
-          echo "Engine changed; parity, embed-drift, wasm-parity, wasm-simd128-parity, q4-composed, vision-s3-gate, ppl-gate-selftest, and q4-ppl-quality all PASSED."
+          if [ "$METAL_RESULT" != "success" ]; then
+            if [ "$EVENT_NAME" = "merge_group" ] && [ "$METAL_RESULT" = "skipped" ]; then
+              echo "metal-parity skipped on merge_group by design — its enforcement point is the PR run."
+            else
+              echo "::error::Engine changed and metal attention parity did not succeed (result=$METAL_RESULT)."
+              exit 1
+            fi
+          fi
+          echo "Engine changed; parity, embed-drift, wasm-parity, wasm-simd128-parity, q4-composed, vision-s3-gate, ppl-gate-selftest, q4-ppl-quality, and metal-parity all PASSED."
           exit 0

--- a/scripts/e2e_parity_check.py
+++ b/scripts/e2e_parity_check.py
@@ -193,10 +193,12 @@ PROMPTS: list[tuple[str, int]] = [
 # and GDN prefill mode both excluded as causes; the CPU leg passes the same
 # prompt and still gates on it).
 #
-# The metal parity job is informational (deliberately not a required check),
-# but a plain FAIL turns the whole workflow run red on every engine PR,
-# burying new signal in known noise. Marking the prompt expected-divergent
-# keeps the job green while #535 is open WITHOUT weakening anything else:
+# The metal parity job is a required RATCHET gate (promoted per ADR-066 F2,
+# issue #239) precisely BECAUSE this waiver is here: what it certifies is
+# Metal path-proof, binary health, and token parity on every prompt except
+# this #535-waived one — not full Metal parity. Its CI display name says so.
+# Marking the prompt expected-divergent keeps the job green while #535 is
+# open WITHOUT weakening anything else:
 # missing path-proof, binary failures, and divergence on any other prompt
 # still fail closed, and the report still prints the divergence in full.
 # If the prompt starts PASSING on Metal, the run reports XPASS (still green)


### PR DESCRIPTION
## Summary

Promotes the Metal e2e leg (#239) from informational to a **required regression ratchet**, per the ADR-066 F2 two-week clean-streak policy.

## What the required gate certifies (and what it does not)

This is a **ratchet, not full-parity certification**. `scripts/e2e_parity_check.py` carries a deliberate, content-anchored waiver (`METAL_EXPECTED_DIVERGENCE`) for the long-prefill prompt, where Metal deterministically diverges from HF at the first generated token — open issue #535 (repetition penalty and GDN prefill mode both excluded as causes; the CPU leg passes and still gates on the same prompt).

The promoted job therefore gates, on every engine-change PR:

- **Metal dispatch path-proof** — the runtime `LATTICE_METAL_PATH_PROOF` marker must be present with nonzero counters (fails closed, never skip-as-green);
- **binary health** — any harness/binary failure fails the job;
- **greedy token parity on every non-waived prompt** — any divergence on any prompt other than the waived one fails closed. The waiver is keyed by prompt content, so the entire #535 prompt — including any different or new divergence on it — stays green while the waiver entry exists.

The waiver self-reports: if the waived prompt starts passing, the run prints **XPASS** and instructs a maintainer to delete the entry. This is advisory — nothing removes the entry automatically, so acting on an XPASS report is a maintainer responsibility. The job's CI display name — `metal parity ratchet (#535 waived)` — states the scope so the required gate is never misread as full Metal parity. #535 root-cause is a named, tracked follow-up.

## Evidence

Main-branch history for the leg over 2026-07-04 → 2026-07-15 (last 100 e2e-parity runs):

- 89/89 runs that executed the job concluded **success** — zero reds of any kind (no numeric failures, no infra failures).
- The remaining 11 runs did not execute the job because change detection classified them engine=false (docs/CI-only merges), which is the intended skip path, not a gap.

## Mechanics

- `metal-parity` joins `parity-gate.needs`; on engine-change PR runs the required `parity-gate` check now fails unless the Metal leg succeeded.
- The job keeps its deliberate merge-group skip (it never delays the queue); the gate accepts exactly `skipped` on `merge_group` events and nothing else. The PR run remains the enforcement point, matching how the leg has been observed for the full streak.
- The required status check name (`parity-gate`) is unchanged, so no branch-protection edit is needed.

## Not promoted

The sibling `q4 composed golden` leg (#320) is deliberately **not** promoted in this PR: it produced an unexplained numeric flake on 2026-07-15 (#1000, max_abs_error 15.8 vs 1e-5 tolerance, green on rerun of identical code). It re-checkpoints after a clean week once #1000 is root-caused.

ADR-058: workflow + comment-only change, no engine code touched; bench-compare not applicable.
