### PR TITLE
feat(inference): Metal decode kernels for Q3 MLP weight format (ADR-072 P1, #420 Stage 2)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1090,6 +1090,12 @@ mod inner {
 
     const MSL_Q4_TILED_SOURCE: &str = include_str!("shaders/gemm_q4_tiled.metal");
 
+    /// MSL source for the Q3 simdgroup-matrix tiled GEMM kernel (ADR-072 P1,
+    /// W3 MLP-only weight format, #420 Stage 2). Mirrors [`MSL_Q4_TILED_SOURCE`]
+    /// with the 16-byte plane-split 2+1 Q3 block payload substituted for Q4's
+    /// 20-byte asymmetric block. See `weights::q3_weights` for the on-disk format.
+    const MSL_Q3_TILED_SOURCE: &str = include_str!("shaders/gemm_q3_tiled.metal");
+
     /// MSL source for the Q8_0 simdgroup-matrix tiled GEMM kernel.
     ///
     /// Block layout: each Q8_0 block is 34 bytes — 2-byte f16 scale (little-endian)
@@ -1195,6 +1201,106 @@ mod inner {
         buf.set_label(label);
 
         Ok(Q4WeightBuf::from_mmap(buf, header.payload_offset, mmap))
+    }
+
+    /// A Q3-quantized weight buffer (ADR-072 P1, #420 Stage 2), paired with the
+    /// byte offset within `buffer` where the Q3 block payload starts.
+    ///
+    /// Restricted to MLP gate/up/down projections — see
+    /// [`crate::weights::q3_weights::validate_q3_mlp_role`]. Mirrors
+    /// [`Q4WeightBuf`]'s buffer/offset/mmap-lifetime structure exactly; kept as
+    /// a separate type (not a third `Q4WeightBuf` variant) so the MLP-only
+    /// role restriction is enforced at construction, not by convention.
+    pub(crate) struct Q3WeightBuf {
+        buffer: Buffer,
+        /// Byte offset of the Q3 payload within `buffer`.
+        payload_offset: u64,
+        // Keeps the mmap alive as long as the Metal buffer needs the memory.
+        _mmap: Option<memmap2::Mmap>,
+    }
+
+    impl Q3WeightBuf {
+        /// Wrap a normally-allocated Metal buffer (payload at offset 0).
+        ///
+        /// Mirrors `Q4WeightBuf::from_buffer` for API-shape parity; unused
+        /// until a non-mmap Q3 construction path (e.g. concatenated MoE-style
+        /// upload) exists — see w3_stage2_report.md "what shipped" for scope.
+        #[allow(dead_code)]
+        fn from_buffer(buffer: Buffer) -> Self {
+            Q3WeightBuf {
+                buffer,
+                payload_offset: 0,
+                _mmap: None,
+            }
+        }
+
+        /// Wrap a no-copy Metal buffer backed by `mmap` with a non-zero payload offset.
+        ///
+        /// Exercised today only by [`mmap_q3_weight`] and its tests; live
+        /// checkpoint loading does not yet route MLP tensors through it (see
+        /// w3_stage2_report.md "what shipped" for the scope decision).
+        #[allow(dead_code)]
+        fn from_mmap(buffer: Buffer, payload_offset: u64, mmap: memmap2::Mmap) -> Self {
+            Q3WeightBuf {
+                buffer,
+                payload_offset,
+                _mmap: Some(mmap),
+            }
+        }
+    }
+
+    /// Open `path`, mmap the whole file, and register it as a Metal no-copy
+    /// `StorageModeShared` buffer holding a Q3 tensor — mirrors [`mmap_q4_weight`].
+    ///
+    /// Fails closed on two independent conditions before the mmap ever reaches
+    /// the GPU: `tensor_name` must name an MLP gate/up/down projection (see
+    /// [`crate::weights::q3_weights::validate_q3_mlp_role`]), and the file's
+    /// declared header must not claim a payload larger than the file actually
+    /// holds (see `validate_q3_header_payload_bounds`) — the same truncation
+    /// hazard `mmap_q4_weight` guards against, since this path never reads the
+    /// payload bytes itself.
+    ///
+    /// # Safety invariant
+    /// The mmap is read-only (`MAP_PRIVATE`) and the model files must not be
+    /// modified while the process is running.
+    ///
+    /// Not yet called from live checkpoint loading — see w3_stage2_report.md
+    /// "what shipped" for the scope decision (proven end-to-end by this
+    /// module's `mmap_q3_weight_*` tests instead).
+    #[cfg(feature = "metal-gpu")]
+    #[allow(dead_code)]
+    fn mmap_q3_weight(
+        device: &Device,
+        path: &std::path::Path,
+        tensor_name: &str,
+        label: &str,
+    ) -> Result<Q3WeightBuf, String> {
+        use crate::weights::q3_weights::validate_q3_mlp_role;
+
+        validate_q3_mlp_role(tensor_name).map_err(|e| e.to_string())?;
+
+        let mut file = std::fs::File::open(path)
+            .map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+        let header = crate::weights::q3_weights::read_q3_header(&mut file)
+            .map_err(|e| format!("failed to parse Q3 header {}: {e}", path.display()))?;
+        let file_len = file
+            .metadata()
+            .map_err(|e| format!("failed to stat {}: {e}", path.display()))?
+            .len();
+        crate::weights::q3_weights::validate_q3_header_payload_bounds(&header, file_len, path)
+            .map_err(|e| format!("failed to validate Q3 payload {}: {e}", path.display()))?;
+        let mmap = unsafe { memmap2::MmapOptions::new().map(&file) }
+            .map_err(|e| format!("failed to mmap {}: {e}", path.display()))?;
+
+        let buf = device.new_buffer_with_bytes_no_copy(
+            mmap.as_ptr().cast(),
+            mmap.len() as u64,
+            MTLResourceOptions::StorageModeShared,
+            None,
+        );
+        buf.set_label(label);
+
+        Ok(Q3WeightBuf::from_mmap(buf, header.payload_offset, mmap))
     }
 
     /// Weights for a GatedDeltaNet (linear attention) layer on GPU.
@@ -1611,6 +1717,8 @@ mod inner {
         gemv_q4: ComputePipelineState,
         gemm_q4: ComputePipelineState,
         gemm_q4_tiled: Option<ComputePipelineState>,
+        gemv_q3: ComputePipelineState,
+        gemm_q3_tiled: Option<ComputePipelineState>,
         conv1d_silu: ComputePipelineState,
         gdn_recurrence: ComputePipelineState,
         gdn_chunk_materialize_c32: ComputePipelineState,
@@ -3081,6 +3189,21 @@ mod inner {
                 device.new_compute_pipeline_state_with_function(&func).ok()
             };
 
+            let make_optional_gemm_q3_tiled = || -> Option<ComputePipelineState> {
+                // Same Apple7 simdgroup-matrix gate as Q4/Q8; falls back to the
+                // gemv_q3_decode-only (M=1) path on any device/compile failure.
+                if !device.supports_family(MTLGPUFamily::Apple7) {
+                    return None;
+                }
+                let tiled_opts = CompileOptions::new();
+                tiled_opts.set_language_version(MTLLanguageVersion::V3_0);
+                let lib = device
+                    .new_library_with_source(MSL_Q3_TILED_SOURCE, &tiled_opts)
+                    .ok()?;
+                let func = lib.get_function("gemm_q3_tiled", None).ok()?;
+                device.new_compute_pipeline_state_with_function(&func).ok()
+            };
+
             let make_optional_gemm_q8_tiled = || -> Option<ComputePipelineState> {
                 // Q8_0 simdgroup-matrix tiled GEMM: same Apple7 gate as Q4.
                 if !device.supports_family(MTLGPUFamily::Apple7) {
@@ -3102,6 +3225,8 @@ mod inner {
                 gemv_q4: make_pipeline("gemv_q4_decode")?,
                 gemm_q4: make_pipeline("gemm_q4")?,
                 gemm_q4_tiled: make_optional_gemm_q4_tiled(),
+                gemv_q3: make_pipeline("gemv_q3_decode")?,
+                gemm_q3_tiled: make_optional_gemm_q3_tiled(),
                 rms_norm: make_pipeline("rms_norm_qwen35")?,
                 partial_rope: make_pipeline("partial_rope_interleaved")?,
                 per_head_rms_norm: make_pipeline("per_head_rms_norm")?,
@@ -11975,6 +12100,72 @@ mod inner {
             }
         }
 
+        /// Dispatch a Q3 GEMV/GEMM (ADR-072 P1, #420 Stage 2), mirroring
+        /// `dispatch_gemm_q4` exactly: `gemv_q3_decode` for M=1 (the decode-path
+        /// kernel that matters — decode is weight-bandwidth-bound), the tiled
+        /// simdgroup-matrix `gemm_q3_tiled` for M>1.
+        ///
+        /// Unlike Q4/Q8, there is no naive fallback GEMM for M>1 — Stage 2 scope
+        /// is `gemv_q3_decode` + `gemm_q3_tiled` only (see #420 design note §3),
+        /// so `gemm_q3_tiled` must be present (Apple7+) whenever this is called
+        /// with M>1. Callers that need to support non-Apple7 prefill would need
+        /// a naive `gemm_q3` kernel, out of Stage 2 scope.
+        ///
+        /// # Panics
+        /// Panics if `k` is zero or not a multiple of 32, or if `m > 1` and
+        /// `gemm_q3_tiled` is unavailable (device is not Apple7+).
+        #[allow(dead_code)] // wired to real MLP dispatch is deferred past Stage 2 — see w3_stage2_report.md
+        fn dispatch_gemm_q3(
+            &self,
+            enc: &ComputeCommandEncoderRef,
+            x: &Buffer,
+            x_offset: u64,
+            qw: &Q3WeightBuf,
+            y: &Buffer,
+            y_offset: u64,
+            m: u32,
+            n: u32,
+            k: u32,
+        ) {
+            if m == 0 || n == 0 {
+                return;
+            }
+            assert!(
+                k > 0 && k.is_multiple_of(32),
+                "dispatch_gemm_q3 requires K to be non-zero and divisible by 32, got {k}"
+            );
+
+            if m == 1 {
+                enc.set_compute_pipeline_state(&self.engine.pipelines.gemv_q3);
+                enc.set_buffer(0, Some(x), x_offset);
+                enc.set_buffer(1, Some(&qw.buffer), qw.payload_offset);
+                enc.set_buffer(2, Some(y), y_offset);
+                enc.set_bytes(3, 4, &n as *const u32 as *const _);
+                enc.set_bytes(4, 4, &k as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(n.div_ceil(2) as u64, 1, 1),
+                    MTLSize::new(32, 4, 1),
+                );
+            } else {
+                let tiled = self.engine.pipelines.gemm_q3_tiled.as_ref().expect(
+                    "dispatch_gemm_q3 called with M>1 but gemm_q3_tiled is unavailable \
+                     (device is not Apple7+, or the tiled kernel failed to compile); \
+                     Stage 2 has no naive Q3 GEMM fallback",
+                );
+                enc.set_compute_pipeline_state(tiled);
+                enc.set_buffer(0, Some(&qw.buffer), qw.payload_offset);
+                enc.set_buffer(1, Some(x), x_offset);
+                enc.set_buffer(2, Some(y), y_offset);
+                enc.set_bytes(3, 4, &m as *const u32 as *const _);
+                enc.set_bytes(4, 4, &n as *const u32 as *const _);
+                enc.set_bytes(5, 4, &k as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new(n.div_ceil(32) as u64, m.div_ceil(64) as u64, 1),
+                    MTLSize::new(32, 4, 1),
+                );
+            }
+        }
+
         // -----------------------------------------------------------------------
         // GDN chunked-scan helpers (default ON; LATTICE_GDN_CHUNKED=0 opts out)
         // -----------------------------------------------------------------------
@@ -14792,6 +14983,21 @@ mod inner {
                 device.new_compute_pipeline_state_with_function(&func).ok()
             };
 
+            let make_optional_gemm_q3_tiled = || -> Option<ComputePipelineState> {
+                // Same Apple7 simdgroup-matrix gate as Q4/Q8; falls back to the
+                // gemv_q3_decode-only (M=1) path on any device/compile failure.
+                if !device.supports_family(MTLGPUFamily::Apple7) {
+                    return None;
+                }
+                let tiled_opts = CompileOptions::new();
+                tiled_opts.set_language_version(MTLLanguageVersion::V3_0);
+                let lib = device
+                    .new_library_with_source(MSL_Q3_TILED_SOURCE, &tiled_opts)
+                    .ok()?;
+                let func = lib.get_function("gemm_q3_tiled", None).ok()?;
+                device.new_compute_pipeline_state_with_function(&func).ok()
+            };
+
             let make_optional_gemm_q8_tiled = || -> Option<ComputePipelineState> {
                 // Q8_0 simdgroup-matrix tiled GEMM: same Apple7 gate as Q4.
                 if !device.supports_family(MTLGPUFamily::Apple7) {
@@ -14813,6 +15019,8 @@ mod inner {
                 gemv_q4: make_pipeline("gemv_q4_decode")?,
                 gemm_q4: make_pipeline("gemm_q4")?,
                 gemm_q4_tiled: make_optional_gemm_q4_tiled(),
+                gemv_q3: make_pipeline("gemv_q3_decode")?,
+                gemm_q3_tiled: make_optional_gemm_q3_tiled(),
                 rms_norm: make_pipeline("rms_norm_qwen35")?,
                 partial_rope: make_pipeline("partial_rope_interleaved")?,
                 per_head_rms_norm: make_pipeline("per_head_rms_norm")?,
@@ -19957,6 +20165,379 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 result.is_ok(),
                 "mmap_q4_weight must accept a fully populated payload: {:?}",
                 result.err()
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Q3 MLP-only weight format (ADR-072 P1, #420 Stage 2): loader
+        // fail-closed gates for `mmap_q3_weight`.
+        // -------------------------------------------------------------------
+
+        #[test]
+        fn mmap_q3_weight_rejects_non_mlp_tensor_role() {
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let path = tmp.path().join("attn.q3");
+            let tensor = crate::weights::q3_weights::Q3Tensor {
+                blocks: vec![
+                    crate::weights::q3_weights::Q3Block {
+                        scale: 0,
+                        bias: 0,
+                        packed: [0u8; 12]
+                    };
+                    2
+                ],
+                shape: vec![64],
+                original_len: 64,
+            };
+            crate::weights::q3_weights::save_q3_file(&path, &tensor)
+                .expect("save well-formed q3 file");
+
+            let result = mmap_q3_weight(
+                &device,
+                &path,
+                "model.layers.0.self_attn.q_proj.weight",
+                "attn-role-rejected",
+            );
+            assert!(
+                result.is_err(),
+                "mmap_q3_weight must reject a non-MLP tensor role even with a well-formed payload"
+            );
+        }
+
+        #[test]
+        fn mmap_q3_weight_rejects_truncated_block_payload_before_dispatch() {
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let path = tmp.path().join("truncated_payload.q3");
+            let mut file = std::fs::File::create(&path).expect("create truncated q3");
+            use std::io::Write;
+            file.write_all(b"KHQ3").expect("write magic");
+            file.write_all(&1_u32.to_le_bytes()).expect("write version");
+            file.write_all(&1_u32.to_le_bytes()).expect("write ndim");
+            file.write_all(&64_u64.to_le_bytes()).expect("write shape");
+            file.write_all(&64_u64.to_le_bytes())
+                .expect("write original_len");
+            file.flush().expect("flush q3 header");
+            // original_len=64 -> 2 blocks -> 32 required payload bytes; file
+            // ends right at payload_offset, so the payload is entirely missing.
+
+            let result = mmap_q3_weight(
+                &device,
+                &path,
+                "model.layers.0.mlp.gate_proj.weight",
+                "truncated-payload-proof",
+            );
+            assert!(
+                result.is_err(),
+                "mmap_q3_weight must reject a KHQ3 header whose original_len requires \
+                 32 payload bytes but whose file ends at payload_offset"
+            );
+        }
+
+        #[test]
+        fn mmap_q3_weight_accepts_fully_populated_mlp_payload() {
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let path = tmp.path().join("full_payload.q3");
+            let tensor = crate::weights::q3_weights::Q3Tensor {
+                blocks: vec![
+                    crate::weights::q3_weights::Q3Block {
+                        scale: 0,
+                        bias: 0,
+                        packed: [0u8; 12]
+                    };
+                    2
+                ],
+                shape: vec![64],
+                original_len: 64,
+            };
+            crate::weights::q3_weights::save_q3_file(&path, &tensor)
+                .expect("save well-formed q3 file");
+
+            let result = mmap_q3_weight(
+                &device,
+                &path,
+                "model.layers.0.mlp.down_proj.weight",
+                "full-payload-accept",
+            );
+            assert!(
+                result.is_ok(),
+                "mmap_q3_weight must accept a well-formed MLP-role payload: {:?}",
+                result.err()
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Q3 Metal kernel parity (ADR-072 P1, #420 Stage 2): `gemv_q3_decode`
+        // and `gemm_q3_tiled` dequantize plane-split 2+1 Q3 blocks to f16 in
+        // -kernel and must match the CPU `gemv_q3_reference` / `gemm_q3_reference`
+        // oracle (`weights::q3_weights`) within an f16-accumulation-driven bound.
+        // -------------------------------------------------------------------
+
+        /// Build a Q3 weight buffer (row-major `[N, K]`, one row of packed
+        /// blocks per output neuron — matches `gemv_q3_decode`/`gemm_q3_tiled`'s
+        /// `QW[row * row_bytes + ...]` indexing) and its packed-bytes copy for
+        /// the CPU reference oracle. Deterministic LCG so runs are reproducible.
+        fn make_q3_weight_ref(device: &Device, seed: u64, n: usize, k: usize) -> (Buffer, Vec<u8>) {
+            assert_eq!(k % 32, 0, "K must be divisible by 32 for Q3 GEMV/GEMM");
+            let mut rng = seed;
+            let mut next = || -> f32 {
+                rng = rng
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                ((rng >> 11) as u32 as f32 / u32::MAX as f32) * 2.0 - 1.0
+            };
+            let weights_f32: Vec<f32> = (0..n * k).map(|_| next()).collect();
+            use crate::weights::q3_weights::quantize_row_q3_0;
+            let mut packed_bytes = Vec::with_capacity(n * (k / 32) * 16);
+            for row in weights_f32.chunks_exact(k) {
+                packed_bytes.extend_from_slice(&quantize_row_q3_0(row).unwrap());
+            }
+            let buf = device.new_buffer_with_data(
+                packed_bytes.as_ptr() as *const _,
+                packed_bytes.len() as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+            buf.set_label("test_qw_q3");
+            (buf, packed_bytes)
+        }
+
+        /// Deterministic activation RNG shared by the Q3 GEMV/GEMM parity tests.
+        fn q3_test_activation(seed: u64, len: usize) -> Vec<f32> {
+            let mut rng = seed;
+            let mut next = || -> f32 {
+                rng = rng
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                ((rng >> 11) as u32 as f32 / u32::MAX as f32) * 2.0 - 1.0
+            };
+            (0..len).map(|_| next()).collect()
+        }
+
+        #[test]
+        fn gemv_q3_decode_matches_cpu_reference_across_shapes() {
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let _guard = gpu_test_lock();
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let state =
+                MetalQwen35State::new(&weights, &cfg, 4).expect("tiny MetalQwen35State fixture");
+            let pipeline = &state.engine.pipelines.gemv_q3;
+            let queue = &state.engine.queue;
+
+            use crate::weights::q3_weights::gemv_q3_reference;
+
+            // Shapes exercising tile-adjacent geometry: N=1 (single output row),
+            // N=5 (odd, not a multiple of NR=2), N=33 with a 3-block K.
+            for &(n, k, seed) in &[
+                (1usize, 32usize, 0x1111_u64),
+                (5usize, 64usize, 0x2222_u64),
+                (33usize, 96usize, 0x3333_u64),
+            ] {
+                let (qw_buf, packed) = make_q3_weight_ref(&device, seed, n, k);
+                let x = q3_test_activation(seed ^ 0xABCD, k);
+                let x_buf = device.new_buffer_with_data(
+                    x.as_ptr() as *const _,
+                    (x.len() * 4) as u64,
+                    MTLResourceOptions::StorageModeShared,
+                );
+                let y_buf =
+                    device.new_buffer((n * 4) as u64, MTLResourceOptions::StorageModeShared);
+
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(pipeline);
+                enc.set_buffer(0, Some(&x_buf), 0);
+                enc.set_buffer(1, Some(&qw_buf), 0);
+                enc.set_buffer(2, Some(&y_buf), 0);
+                enc.set_bytes(3, 4, &(n as u32) as *const u32 as *const _);
+                enc.set_bytes(4, 4, &(k as u32) as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new((n as u64).div_ceil(2), 1, 1),
+                    MTLSize::new(32, 4, 1),
+                );
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+
+                let y_gpu: &[f32] =
+                    unsafe { std::slice::from_raw_parts(y_buf.contents().cast::<f32>(), n) };
+                let y_ref = gemv_q3_reference(&x, &packed, n, k);
+
+                for i in 0..n {
+                    let diff = (y_gpu[i] - y_ref[i]).abs();
+                    assert!(
+                        diff < 5e-3,
+                        "shape N={n} K={k}: row {i}: gpu={} ref={} diff={diff}",
+                        y_gpu[i],
+                        y_ref[i]
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn gemm_q3_tiled_matches_cpu_reference_at_tile_boundaries() {
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            if !device.supports_family(MTLGPUFamily::Apple7) {
+                return;
+            }
+            let _guard = gpu_test_lock();
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let state =
+                MetalQwen35State::new(&weights, &cfg, 4).expect("tiny MetalQwen35State fixture");
+            // On Apple7+ the tiled pipeline MUST exist — a missing pipeline here
+            // is the exact regression this gate guards against, so fail loudly
+            // rather than `return` (mirrors `gemm_q4_tiled_vs_naive_numeric_differential`).
+            let tiled_pipeline = state.engine.pipelines.gemm_q3_tiled.as_ref().expect(
+                "gemm_q3_tiled must be present on Apple7+ (else this gate passes vacuously)",
+            );
+            let queue = &state.engine.queue;
+
+            use crate::weights::q3_weights::gemm_q3_reference;
+
+            // Shape A: M=64,N=64,K=64 exact tile multiples (BM=64, BN=32, BK=32).
+            // Shape B: M=72,N=48,K=64 non-multiple of BM/BN — exercises the
+            //   `gm<M`/`gn<N` boundary zero-pad guards in the tiled kernel.
+            // Shape C: M=5,N=9,K=96 small odd M/N with a 3-block K depth.
+            for &(m, n, k, seed) in &[
+                (64usize, 64usize, 64usize, 0xAAAA_u64),
+                (72usize, 48usize, 64usize, 0xBBBB_u64),
+                (5usize, 9usize, 96usize, 0xCCCC_u64),
+            ] {
+                let (qw_buf, packed) = make_q3_weight_ref(&device, seed, n, k);
+                let x = q3_test_activation(seed ^ 0xDEAD, m * k);
+                let x_buf = device.new_buffer_with_data(
+                    x.as_ptr() as *const _,
+                    (x.len() * 4) as u64,
+                    MTLResourceOptions::StorageModeShared,
+                );
+                let y_buf =
+                    device.new_buffer((m * n * 4) as u64, MTLResourceOptions::StorageModeShared);
+
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(tiled_pipeline);
+                enc.set_buffer(0, Some(&qw_buf), 0);
+                enc.set_buffer(1, Some(&x_buf), 0);
+                enc.set_buffer(2, Some(&y_buf), 0);
+                enc.set_bytes(3, 4, &(m as u32) as *const u32 as *const _);
+                enc.set_bytes(4, 4, &(n as u32) as *const u32 as *const _);
+                enc.set_bytes(5, 4, &(k as u32) as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new((n as u64).div_ceil(32), (m as u64).div_ceil(64), 1),
+                    MTLSize::new(32, 4, 1),
+                );
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+
+                let y_gpu: &[f32] =
+                    unsafe { std::slice::from_raw_parts(y_buf.contents().cast::<f32>(), m * n) };
+                let y_ref = gemm_q3_reference(&x, &packed, m, n, k);
+
+                let mut max_diff = 0.0f32;
+                for i in 0..m * n {
+                    let d = (y_gpu[i] - y_ref[i]).abs();
+                    if d > max_diff {
+                        max_diff = d;
+                    }
+                }
+                // Tiled kernel stages X/W in half precision, same as
+                // gemm_q4_tiled (documented ~2.9e-3 half-staging error on top
+                // of quant error there); bound generously at ~15x that headroom
+                // since Q3's coarser 8-level quantization widens the per-weight
+                // step size relative to Q4's 16 levels.
+                assert!(
+                    max_diff < 0.05,
+                    "shape M={m} N={n} K={k}: max|gpu-ref| = {max_diff} exceeds bound"
+                );
+            }
+        }
+
+        #[test]
+        fn gemv_q3_decode_mutation_sensitive_high_plane_bit() {
+            // Guards the Metal kernel's high-plane read: if `gemv_q3_decode`
+            // had a bug that dropped the high-1-bit plane (silently truncating
+            // every dequant to the 0..=3 range), flipping a high-plane bit in
+            // the packed weight buffer would NOT change the kernel's output.
+            // This proves the kernel actually consumes `packed[8..12]`, not
+            // just `packed[0..8]` — the same bug class the Stage-1
+            // `plane_split_mutation_sensitive_high_bit` test guards at the
+            // pack/unpack level (weights/q3_weights.rs), now proven through the
+            // real GPU dispatch path this Stage adds.
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let _guard = gpu_test_lock();
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let state =
+                MetalQwen35State::new(&weights, &cfg, 4).expect("tiny MetalQwen35State fixture");
+            let pipeline = &state.engine.pipelines.gemv_q3;
+            let queue = &state.engine.queue;
+
+            let (n, k) = (2usize, 32usize);
+            let (_qw_buf, packed) = make_q3_weight_ref(&device, 0x9999_u64, n, k);
+            let mut corrupted = packed.clone();
+            // Row 0's block occupies packed[0..16); its high-plane byte 0
+            // (values 0..8) is packed[12] (offset 4 header + 8 low-plane bytes).
+            corrupted[12] ^= 0x01;
+
+            let x = q3_test_activation(0x9999_u64 ^ 0x5A5A, k);
+            let x_buf = device.new_buffer_with_data(
+                x.as_ptr() as *const _,
+                (x.len() * 4) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+
+            let run = |packed_bytes: &[u8]| -> Vec<f32> {
+                let qw_buf = device.new_buffer_with_data(
+                    packed_bytes.as_ptr() as *const _,
+                    packed_bytes.len() as u64,
+                    MTLResourceOptions::StorageModeShared,
+                );
+                let y_buf =
+                    device.new_buffer((n * 4) as u64, MTLResourceOptions::StorageModeShared);
+                let cmd = queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                enc.set_compute_pipeline_state(pipeline);
+                enc.set_buffer(0, Some(&x_buf), 0);
+                enc.set_buffer(1, Some(&qw_buf), 0);
+                enc.set_buffer(2, Some(&y_buf), 0);
+                enc.set_bytes(3, 4, &(n as u32) as *const u32 as *const _);
+                enc.set_bytes(4, 4, &(k as u32) as *const u32 as *const _);
+                enc.dispatch_thread_groups(
+                    MTLSize::new((n as u64).div_ceil(2), 1, 1),
+                    MTLSize::new(32, 4, 1),
+                );
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                unsafe { std::slice::from_raw_parts(y_buf.contents().cast::<f32>(), n) }.to_vec()
+            };
+
+            let y_correct = run(&packed);
+            let y_corrupted = run(&corrupted);
+
+            assert_ne!(
+                y_correct[0], y_corrupted[0],
+                "flipping a high-plane bit in row 0's block must change gemv_q3_decode's \
+                 output for row 0 — if it doesn't, the kernel is not reading the \
+                 high-1-bit plane (packed[8..12])"
+            );
+            assert_eq!(
+                y_correct[1], y_corrupted[1],
+                "corrupting row 0's block must not affect row 1's output"
             );
         }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1289,6 +1289,11 @@ mod inner {
             .len();
         crate::weights::q3_weights::validate_q3_header_payload_bounds(&header, file_len, path)
             .map_err(|e| format!("failed to validate Q3 payload {}: {e}", path.display()))?;
+        // SAFETY: `mmap`'s read-only-mmap invariant is documented above
+        // (`# Safety invariant`): the file is opened read-only and mapped
+        // `MAP_PRIVATE`, and the caller must not mutate the on-disk file
+        // while this process runs — the same invariant `mmap_q4_weight`
+        // relies on for its no-copy Metal buffer.
         let mmap = unsafe { memmap2::MmapOptions::new().map(&file) }
             .map_err(|e| format!("failed to mmap {}: {e}", path.display()))?;
 
@@ -12111,9 +12116,16 @@ mod inner {
         /// with M>1. Callers that need to support non-Apple7 prefill would need
         /// a naive `gemm_q3` kernel, out of Stage 2 scope.
         ///
+        /// # Errors
+        /// Returns `Err` if `m > 1` and `gemm_q3_tiled` is unavailable (device
+        /// is not Apple7+, or the tiled kernel failed to compile) — Stage 2
+        /// has no naive Q3 GEMM fallback to fall back to (mirrors how
+        /// `mmap_q3_weight` propagates its fail-closed checks as `Result`
+        /// rather than panicking).
+        ///
         /// # Panics
-        /// Panics if `k` is zero or not a multiple of 32, or if `m > 1` and
-        /// `gemm_q3_tiled` is unavailable (device is not Apple7+).
+        /// Panics if `k` is zero or not a multiple of 32 (a caller
+        /// programming error, not a runtime/capability condition).
         #[allow(dead_code)] // wired to real MLP dispatch is deferred past Stage 2 — see w3_stage2_report.md
         fn dispatch_gemm_q3(
             &self,
@@ -12126,9 +12138,9 @@ mod inner {
             m: u32,
             n: u32,
             k: u32,
-        ) {
+        ) -> Result<(), String> {
             if m == 0 || n == 0 {
-                return;
+                return Ok(());
             }
             assert!(
                 k > 0 && k.is_multiple_of(32),
@@ -12147,11 +12159,17 @@ mod inner {
                     MTLSize::new(32, 4, 1),
                 );
             } else {
-                let tiled = self.engine.pipelines.gemm_q3_tiled.as_ref().expect(
-                    "dispatch_gemm_q3 called with M>1 but gemm_q3_tiled is unavailable \
+                let tiled = self
+                    .engine
+                    .pipelines
+                    .gemm_q3_tiled
+                    .as_ref()
+                    .ok_or_else(|| {
+                        "dispatch_gemm_q3 called with M>1 but gemm_q3_tiled is unavailable \
                      (device is not Apple7+, or the tiled kernel failed to compile); \
-                     Stage 2 has no naive Q3 GEMM fallback",
-                );
+                     Stage 2 has no naive Q3 GEMM fallback"
+                            .to_string()
+                    })?;
                 enc.set_compute_pipeline_state(tiled);
                 enc.set_buffer(0, Some(&qw.buffer), qw.payload_offset);
                 enc.set_buffer(1, Some(x), x_offset);
@@ -12164,6 +12182,7 @@ mod inner {
                     MTLSize::new(32, 4, 1),
                 );
             }
+            Ok(())
         }
 
         // -----------------------------------------------------------------------
@@ -20368,6 +20387,11 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 cmd.commit();
                 cmd.wait_until_completed();
 
+                // SAFETY: `cmd.wait_until_completed()` above blocks until the
+                // GPU has finished writing `y_buf`, and `y_buf` is a
+                // `StorageModeShared` buffer sized `n * 4` bytes — the CPU
+                // read of `n` f32s below is in-bounds and happens-after the
+                // GPU write.
                 let y_gpu: &[f32] =
                     unsafe { std::slice::from_raw_parts(y_buf.contents().cast::<f32>(), n) };
                 let y_ref = gemv_q3_reference(&x, &packed, n, k);
@@ -20410,10 +20434,27 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             // Shape B: M=72,N=48,K=64 non-multiple of BM/BN — exercises the
             //   `gm<M`/`gn<N` boundary zero-pad guards in the tiled kernel.
             // Shape C: M=5,N=9,K=96 small odd M/N with a 3-block K depth.
+            // Shape D: M=16,N=32,K=1024 — representative production MLP
+            //   intermediate-dim depth (Qwen3.5's `hidden_size`/`intermediate_size`
+            //   K-depths are multiples of 1024), so the envelope below is not
+            //   just extrapolated from tiny shapes.
+            //
+            // `max_abs_diff` is the same NaN-honest helper used by the Q4 twin
+            // below (`gemm_q4_tiled_vs_naive_numeric_differential`) — a
+            // `.fold(0.0, f32::max)`-style comparison silently drops a NaN/Inf
+            // operand (IEEE maxNum semantics keep the non-NaN side), so a
+            // corrupted GPU tile that produces NaN would read as a perfect
+            // match. Both operands here read the *same* already-quantized Q3
+            // bytes, so source quantization error cancels between GPU and CPU
+            // reference; the residual is f16 X/W staging plus f32 reduction
+            // order, not quant step size — see the measured envelope below,
+            // which replaces the prior hand-waved 0.05 bound.
+            let mut envelope: Vec<(usize, usize, usize, f32)> = Vec::new();
             for &(m, n, k, seed) in &[
                 (64usize, 64usize, 64usize, 0xAAAA_u64),
                 (72usize, 48usize, 64usize, 0xBBBB_u64),
                 (5usize, 9usize, 96usize, 0xCCCC_u64),
+                (16usize, 32usize, 1024usize, 0xEEEE_u64),
             ] {
                 let (qw_buf, packed) = make_q3_weight_ref(&device, seed, n, k);
                 let x = q3_test_activation(seed ^ 0xDEAD, m * k);
@@ -20442,27 +20483,144 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 cmd.commit();
                 cmd.wait_until_completed();
 
+                // SAFETY: completed GPU work (`wait_until_completed` above)
+                // makes this `StorageModeShared` buffer's `m * n` f32s visible
+                // to the CPU; the slice length matches the buffer's
+                // allocated size (`m * n * 4` bytes) from its construction
+                // above.
                 let y_gpu: &[f32] =
                     unsafe { std::slice::from_raw_parts(y_buf.contents().cast::<f32>(), m * n) };
                 let y_ref = gemm_q3_reference(&x, &packed, m, n, k);
 
-                let mut max_diff = 0.0f32;
-                for i in 0..m * n {
-                    let d = (y_gpu[i] - y_ref[i]).abs();
-                    if d > max_diff {
-                        max_diff = d;
-                    }
-                }
-                // Tiled kernel stages X/W in half precision, same as
-                // gemm_q4_tiled (documented ~2.9e-3 half-staging error on top
-                // of quant error there); bound generously at ~15x that headroom
-                // since Q3's coarser 8-level quantization widens the per-weight
-                // step size relative to Q4's 16 levels.
+                let max_diff = max_abs_diff(y_gpu, &y_ref);
                 assert!(
-                    max_diff < 0.05,
-                    "shape M={m} N={n} K={k}: max|gpu-ref| = {max_diff} exceeds bound"
+                    max_diff.is_finite(),
+                    "shape M={m} N={n} K={k}: max|gpu-ref| is not finite (max_diff={max_diff}) \
+                     — the GPU tiled kernel produced a NaN/Inf output that a \
+                     `.fold(0.0, f32::max)`-style comparison would have silently \
+                     dropped as a false match"
+                );
+                println!("gemm_q3_tiled envelope: M={m} N={n} K={k} max|gpu-ref|={max_diff:.3e}");
+                envelope.push((m, n, k, max_diff));
+            }
+
+            // Bound derived from the measured envelope above (see
+            // w3_fix_r1_report.md for the full table), not a hand-waved
+            // constant: the largest observed shape (M=16 N=32 K=1024,
+            // production intermediate-dim depth) measured max|gpu-ref| ~=
+            // 1.055e-2; 0.02 is ~1.9x that, absorbing run-to-run
+            // f16-staging/reduction-order jitter while still catching a real
+            // regression (e.g. the NaN and packed-high-plane mutation tests
+            // below, which corrupt the GPU-visible bytes and must fail this
+            // same bound).
+            const MEASURED_ENVELOPE_TOL: f32 = 0.02;
+            for &(m, n, k, d) in &envelope {
+                assert!(
+                    d < MEASURED_ENVELOPE_TOL,
+                    "shape M={m} N={n} K={k}: max|gpu-ref| = {d} exceeds the \
+                     measured-envelope bound {MEASURED_ENVELOPE_TOL}"
                 );
             }
+        }
+
+        /// Mutation-sensitivity test for the differential comparison itself
+        /// (round-1 review finding 2): corrupt a packed block's `scale` field
+        /// to an IEEE-754 f16 NaN bit pattern so the GPU kernel's dequantized
+        /// weight — and therefore its GEMM output — is NaN, then prove the
+        /// NaN-honest comparison fails loudly instead of silently reading as
+        /// a perfect match. This is deliberately the inverse of the test
+        /// above: it proves the comparison mechanism itself is
+        /// mutation-sensitive, the same way the pack/unpack mutation tests
+        /// prove the kernel is.
+        #[test]
+        #[should_panic(expected = "is not finite")]
+        fn gemm_q3_tiled_differential_fails_closed_on_nan_scale() {
+            let Some(device) = Device::system_default() else {
+                // No GPU available: nothing to corrupt or dispatch, so the
+                // `should_panic` expectation cannot be exercised. Panic with
+                // the same expected substring so this test is still honest
+                // about not having proven anything on this host, rather than
+                // vacuously "passing" via `return` under `should_panic`.
+                panic!("is not finite: no Metal device available to run this test");
+            };
+            if !device.supports_family(MTLGPUFamily::Apple7) {
+                panic!("is not finite: host GPU is not Apple7+, gemm_q3_tiled is unavailable");
+            }
+            let _guard = gpu_test_lock();
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let state =
+                MetalQwen35State::new(&weights, &cfg, 4).expect("tiny MetalQwen35State fixture");
+            let tiled_pipeline = state
+                .engine
+                .pipelines
+                .gemm_q3_tiled
+                .as_ref()
+                .expect("gemm_q3_tiled must be present on Apple7+");
+            let queue = &state.engine.queue;
+
+            use crate::weights::q3_weights::gemm_q3_reference;
+
+            let (m, n, k) = (5usize, 9usize, 96usize);
+            let (_qw_buf, packed) = make_q3_weight_ref(&device, 0xF00D_u64, n, k);
+
+            // Corrupt row 0's first block: `scale` occupies packed[0..2] as an
+            // IEEE-754 f16 bit pattern (little-endian). 0x7C01 is a quiet-ish
+            // NaN encoding (exponent all-ones, nonzero mantissa) — every
+            // weight in that block dequantizes to NaN, and the GEMM row that
+            // reads it becomes NaN in the GPU output.
+            let mut corrupted = packed.clone();
+            corrupted[0] = 0x01;
+            corrupted[1] = 0x7C;
+            let qw_buf = device.new_buffer_with_data(
+                corrupted.as_ptr() as *const _,
+                corrupted.len() as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+
+            let x = q3_test_activation(0xF00D_u64 ^ 0xDEAD, m * k);
+            let x_buf = device.new_buffer_with_data(
+                x.as_ptr() as *const _,
+                (x.len() * 4) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+            let y_buf =
+                device.new_buffer((m * n * 4) as u64, MTLResourceOptions::StorageModeShared);
+
+            let cmd = queue.new_command_buffer();
+            let enc = cmd.new_compute_command_encoder();
+            enc.set_compute_pipeline_state(tiled_pipeline);
+            enc.set_buffer(0, Some(&qw_buf), 0);
+            enc.set_buffer(1, Some(&x_buf), 0);
+            enc.set_buffer(2, Some(&y_buf), 0);
+            enc.set_bytes(3, 4, &(m as u32) as *const u32 as *const _);
+            enc.set_bytes(4, 4, &(n as u32) as *const u32 as *const _);
+            enc.set_bytes(5, 4, &(k as u32) as *const u32 as *const _);
+            enc.dispatch_thread_groups(
+                MTLSize::new((n as u64).div_ceil(32), (m as u64).div_ceil(64), 1),
+                MTLSize::new(32, 4, 1),
+            );
+            enc.end_encoding();
+            cmd.commit();
+            cmd.wait_until_completed();
+
+            // SAFETY: completed GPU work (`wait_until_completed` above) makes
+            // this `StorageModeShared` buffer's `m * n` f32s visible to the
+            // CPU; the slice length matches the buffer's allocated size
+            // (`m * n * 4` bytes) from its construction above.
+            let y_gpu: &[f32] =
+                unsafe { std::slice::from_raw_parts(y_buf.contents().cast::<f32>(), m * n) };
+            // Reference computed from the ORIGINAL, uncorrupted bytes: the
+            // GPU side alone is corrupted, so any NaN in `y_gpu` is a genuine
+            // divergence the comparison must surface, not an artifact of a
+            // NaN also present on the reference side.
+            let y_ref = gemm_q3_reference(&x, &packed, m, n, k);
+
+            let max_diff = max_abs_diff(y_gpu, &y_ref);
+            assert!(
+                max_diff.is_finite(),
+                "max|gpu-ref| is not finite (max_diff={max_diff}) — NaN-scale mutation \
+                 correctly detected by the comparison"
+            );
         }
 
         #[test]
@@ -20523,6 +20681,10 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 enc.end_encoding();
                 cmd.commit();
                 cmd.wait_until_completed();
+                // SAFETY: completed GPU work (`wait_until_completed` above)
+                // makes this `StorageModeShared` buffer's `n` f32s visible to
+                // the CPU; the slice length matches the buffer's allocated
+                // size (`n * 4` bytes) from its construction above.
                 unsafe { std::slice::from_raw_parts(y_buf.contents().cast::<f32>(), n) }.to_vec()
             };
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -20434,10 +20434,15 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             // Shape B: M=72,N=48,K=64 non-multiple of BM/BN — exercises the
             //   `gm<M`/`gn<N` boundary zero-pad guards in the tiled kernel.
             // Shape C: M=5,N=9,K=96 small odd M/N with a 3-block K depth.
-            // Shape D: M=16,N=32,K=1024 — representative production MLP
-            //   intermediate-dim depth (Qwen3.5's `hidden_size`/`intermediate_size`
-            //   K-depths are multiples of 1024), so the envelope below is not
-            //   just extrapolated from tiny shapes.
+            // Shape D: M=16,N=32,K=1024 — Qwen3.5-0.8B's dense gate/up
+            //   projection input depth (`hidden_size=1024`, dispatch uses
+            //   `K=hidden` — metal_qwen35.rs:5086), a production K-depth but
+            //   not the deepest Q3-eligible one.
+            // Shape E: M=16,N=1024,K=3584 — Qwen3.5-0.8B's down-projection
+            //   depth (`intermediate_size=3584`, dispatch uses
+            //   `K=intermediate` — metal_qwen35.rs:5112), 112 `BK=32`
+            //   iterations — the deepest Q3-eligible production MLP shape,
+            //   round-2 review finding 2.
             //
             // `max_abs_diff` is the same NaN-honest helper used by the Q4 twin
             // below (`gemm_q4_tiled_vs_naive_numeric_differential`) — a
@@ -20455,6 +20460,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 (72usize, 48usize, 64usize, 0xBBBB_u64),
                 (5usize, 9usize, 96usize, 0xCCCC_u64),
                 (16usize, 32usize, 1024usize, 0xEEEE_u64),
+                (16usize, 1024usize, 3584usize, 0xFEED_u64),
             ] {
                 let (qw_buf, packed) = make_q3_weight_ref(&device, seed, n, k);
                 let x = q3_test_activation(seed ^ 0xDEAD, m * k);
@@ -20505,15 +20511,21 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             }
 
             // Bound derived from the measured envelope above (see
-            // w3_fix_r1_report.md for the full table), not a hand-waved
-            // constant: the largest observed shape (M=16 N=32 K=1024,
-            // production intermediate-dim depth) measured max|gpu-ref| ~=
-            // 1.055e-2; 0.02 is ~1.9x that, absorbing run-to-run
-            // f16-staging/reduction-order jitter while still catching a real
-            // regression (e.g. the NaN and packed-high-plane mutation tests
-            // below, which corrupt the GPU-visible bytes and must fail this
-            // same bound).
-            const MEASURED_ENVELOPE_TOL: f32 = 0.02;
+            // w3_fix_r2_report.md for the full table), not a hand-waved
+            // constant: the largest observed shape (M=16 N=1024 K=3584, the
+            // Qwen3.5-0.8B down-projection depth — 112 `BK=32` iterations,
+            // round-2 review finding 2) measured max|gpu-ref| ~= 1.946e-2;
+            // 0.037 is ~1.9x that. The headroom covers cross-device variation
+            // (different Apple Silicon generations accumulate the f16
+            // X/W-staging + f32-reduction residual slightly differently) and
+            // future kernel-scheduling changes (e.g. a different tile
+            // traversal order), not run-to-run jitter — the seeds and
+            // dispatch are deterministic, so a rerun on the same host
+            // reproduces the same value, and this bound is not measuring
+            // that. It must still catch a real regression (e.g. the NaN and
+            // packed-high-plane mutation tests below, which corrupt the
+            // GPU-visible bytes and must fail this same bound).
+            const MEASURED_ENVELOPE_TOL: f32 = 0.037;
             for &(m, n, k, d) in &envelope {
                 assert!(
                     d < MEASURED_ENVELOPE_TOL,
@@ -20532,19 +20544,42 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// above: it proves the comparison mechanism itself is
         /// mutation-sensitive, the same way the pack/unpack mutation tests
         /// prove the kernel is.
+        ///
+        /// Round-2 review finding 1: `#[should_panic(expected = "is not
+        /// finite")]` could not distinguish "the Apple7 dispatch ran and the
+        /// NaN-honest comparison caught it" from "no Apple7 device, so this
+        /// branch panicked with an unrelated message that happened to also
+        /// contain the substring" — both read as green under
+        /// `should_panic(expected = ...)`. This test instead dispatches
+        /// unconditionally past the device gate, then wraps only the
+        /// comparison in `catch_unwind` and asserts on the caught panic's
+        /// message, so a panic from the wrong place (or no panic at all)
+        /// fails the test instead of silently passing it.
+        ///
+        /// Consequence: on a host with a Metal device but no Apple7 GPU
+        /// (e.g. GitHub's `macos-latest` paravirtual runner), this test
+        /// still returns early rather than failing — mirroring
+        /// `gemm_q3_tiled_matches_cpu_reference_at_tile_boundaries` and
+        /// `gemm_q4_tiled_enabled_on_apple7_plus` above, and the reasoning
+        /// `e2e-parity.yml`'s MP2 injection gate documents: Apple7's
+        /// `simdgroup_matrix` requirement is real hardware, not something
+        /// `LATTICE_METAL_TEST_ENFORCE` can force on a paravirtual GPU. No CI
+        /// workflow currently selects this test by name (its module path
+        /// does not match any existing `--lib` filter), so
+        /// `LATTICE_METAL_TEST_ENFORCE` below only covers the device-absent
+        /// branch, consistent with every other Apple7-gated test in this file.
         #[test]
-        #[should_panic(expected = "is not finite")]
         fn gemm_q3_tiled_differential_fails_closed_on_nan_scale() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
             let Some(device) = Device::system_default() else {
-                // No GPU available: nothing to corrupt or dispatch, so the
-                // `should_panic` expectation cannot be exercised. Panic with
-                // the same expected substring so this test is still honest
-                // about not having proven anything on this host, rather than
-                // vacuously "passing" via `return` under `should_panic`.
-                panic!("is not finite: no Metal device available to run this test");
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
             };
             if !device.supports_family(MTLGPUFamily::Apple7) {
-                panic!("is not finite: host GPU is not Apple7+, gemm_q3_tiled is unavailable");
+                return;
             }
             let _guard = gpu_test_lock();
             let (cfg, weights) = tiny_metal_qwen35_fixture();
@@ -20615,11 +20650,31 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             // NaN also present on the reference side.
             let y_ref = gemm_q3_reference(&x, &packed, m, n, k);
 
-            let max_diff = max_abs_diff(y_gpu, &y_ref);
+            // Wrapped in `catch_unwind` (round-2 fix) rather than
+            // `#[should_panic]` on the whole test: everything above this
+            // point (the device/Apple7 gate, the real dispatch) has already
+            // run unconditionally, so a caught "is not finite" panic here
+            // proves the dispatch executed and the comparison caught the
+            // corruption — not that the test skipped before doing anything.
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let max_diff = max_abs_diff(y_gpu, &y_ref);
+                assert!(
+                    max_diff.is_finite(),
+                    "max|gpu-ref| is not finite (max_diff={max_diff}) — NaN-scale mutation \
+                     correctly detected by the comparison"
+                );
+            }));
+            let payload = result.expect_err(
+                "expected the NaN-scale mutation to make the differential comparison panic",
+            );
+            let msg = payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| payload.downcast_ref::<&str>().copied())
+                .unwrap_or("<non-string panic payload>");
             assert!(
-                max_diff.is_finite(),
-                "max|gpu-ref| is not finite (max_diff={max_diff}) — NaN-scale mutation \
-                 correctly detected by the comparison"
+                msg.contains("is not finite"),
+                "expected the caught panic message to contain \"is not finite\", got: {msg}"
             );
         }
 

--- a/crates/inference/src/forward/shaders/gemm_q3_tiled.metal
+++ b/crates/inference/src/forward/shaders/gemm_q3_tiled.metal
@@ -1,0 +1,109 @@
+#include <metal_stdlib>
+#if defined(__METAL_VERSION__) && (__METAL_VERSION__ >= 300)
+#include <metal_simdgroup_matrix>
+using namespace metal;
+// ===== Q3 GEMM tiled: 3-bit plane-split (2+1) x float32, simdgroup-matrix MMA =====
+// Q3 block: [f16 scale (2B)][f16 bias/min (2B)][12 bytes packed 2+1 plane-split] = 16 bytes / 32 weights.
+// Plane-split layout (see weights/q3_weights.rs module docs):
+//   packed[0..8]  low-2-bit plane, 4 values/byte
+//   packed[8..12] high-1-bit plane, 8 values/byte
+//   dequant: q[i] = low2(i) | (hi(i) << 2); weight = q * scale + bias
+// Mirrors gemm_q4_tiled's BM=64 x BN=32 x BK=32 tiling (PR #270/#283 occupancy
+// structure) with the Q3 16-byte block payload substituted for Q4's 20-byte one.
+kernel void gemm_q3_tiled(
+    device const uchar* QW [[buffer(0)]],
+    device const float* X  [[buffer(1)]],
+    device float* Y        [[buffer(2)]],
+    constant uint& M       [[buffer(3)]],
+    constant uint& N       [[buffer(4)]],
+    constant uint& K       [[buffer(5)]],
+    uint3 tg               [[threadgroup_position_in_grid]],
+    uint tid               [[thread_index_in_threadgroup]],
+    uint lane              [[thread_index_in_simdgroup]],
+    uint sg                [[simdgroup_index_in_threadgroup]])
+{
+    constexpr uint BM = 64;
+    constexpr uint BN = 32;
+    constexpr uint BK = 32;
+    constexpr uint BN_PAD = 40;
+    constexpr uint Q3_BYTES = 16;
+    constexpr uint THREADS = 128;
+    const uint m0 = tg.y * BM;
+    const uint n0 = tg.x * BN;
+    const uint nb = K / 32;
+    const uint row_bytes = nb * Q3_BYTES;
+    threadgroup half Xtg[64][32];
+    threadgroup uchar Qraw[32][Q3_BYTES];
+    threadgroup half Wtg[32][40];
+    threadgroup float Ytg[32][16];
+    threadgroup float Zero[8][8];
+    if (tid < 64) { Zero[tid / 8][tid % 8] = 0.0f; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const uint sg_m_base = (sg / 2) * 32;
+    const uint sg_n_base = (sg % 2) * 16;
+    simdgroup_float8x8 acc00,acc01,acc10,acc11,acc20,acc21,acc30,acc31;
+    simdgroup_load(acc00,&Zero[0][0],8); simdgroup_load(acc01,&Zero[0][0],8);
+    simdgroup_load(acc10,&Zero[0][0],8); simdgroup_load(acc11,&Zero[0][0],8);
+    simdgroup_load(acc20,&Zero[0][0],8); simdgroup_load(acc21,&Zero[0][0],8);
+    simdgroup_load(acc30,&Zero[0][0],8); simdgroup_load(acc31,&Zero[0][0],8);
+    for (uint k0 = 0; k0 < K; k0 += BK) {
+        const uint kb = k0 / 32;
+        for (uint j = tid; j < BM*(BK/4); j += THREADS) {
+            uint mi=j/(BK/4); uint kb4=j%(BK/4); uint gm=m0+mi; uint gk4=k0+kb4*4;
+            float4 v=(gm<M)?*((device const float4*)(X+gm*K+gk4)):float4(0.0f);
+            Xtg[mi][kb4*4+0]=half(v.x); Xtg[mi][kb4*4+1]=half(v.y);
+            Xtg[mi][kb4*4+2]=half(v.z); Xtg[mi][kb4*4+3]=half(v.w); }
+        for (uint i = tid; i < BN*Q3_BYTES; i += THREADS) {
+            uint ni=i/Q3_BYTES; uint off=i%Q3_BYTES; uint gn=n0+ni; uchar v=0;
+            if(gn<N){v=QW[gn*row_bytes+kb*Q3_BYTES+off];} Qraw[ni][off]=v; }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        // One thread per (column, value-in-block) pair — 32 values/block, unlike
+        // Q4's 2-values-per-byte loop, since 3-bit values aren't byte-aligned.
+        for (uint i = tid; i < BN*32; i += THREADS) {
+            uint ni=i/32; uint vi=i%32;
+            ushort sb=ushort(Qraw[ni][0])|(ushort(Qraw[ni][1])<<8);
+            ushort bb=ushort(Qraw[ni][2])|(ushort(Qraw[ni][3])<<8);
+            float d=float(as_type<half>(sb));
+            float b=float(as_type<half>(bb));
+            uchar low2 = (Qraw[ni][4 + vi/4] >> ((vi%4)*2)) & 0x3;
+            uchar hi   = (Qraw[ni][4 + 8 + vi/8] >> (vi%8)) & 0x1;
+            uchar q = low2 | (hi << 2);
+            Wtg[vi][ni] = half(float(q)*d + b); }
+        for (uint i = tid; i < BK*8; i += THREADS) {
+            uint kk=i/8; uint pn=BN+(i%8); Wtg[kk][pn]=half(0.0f); }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        [[unroll]]
+        for (uint kk = 0; kk < BK; kk += 8) {
+            simdgroup_half8x8 a0,a1,a2,a3,b0,b1;
+            simdgroup_load(a0,&Xtg[sg_m_base+ 0][kk],BK);
+            simdgroup_load(a1,&Xtg[sg_m_base+ 8][kk],BK);
+            simdgroup_load(a2,&Xtg[sg_m_base+16][kk],BK);
+            simdgroup_load(a3,&Xtg[sg_m_base+24][kk],BK);
+            simdgroup_load(b0,&Wtg[kk][sg_n_base+0],BN_PAD);
+            simdgroup_load(b1,&Wtg[kk][sg_n_base+8],BN_PAD);
+            simdgroup_multiply_accumulate(acc00,a0,b0,acc00);
+            simdgroup_multiply_accumulate(acc01,a0,b1,acc01);
+            simdgroup_multiply_accumulate(acc10,a1,b0,acc10);
+            simdgroup_multiply_accumulate(acc11,a1,b1,acc11);
+            simdgroup_multiply_accumulate(acc20,a2,b0,acc20);
+            simdgroup_multiply_accumulate(acc21,a2,b1,acc21);
+            simdgroup_multiply_accumulate(acc30,a3,b0,acc30);
+            simdgroup_multiply_accumulate(acc31,a3,b1,acc31); }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    for (uint ssg = 0; ssg < 4; ssg++) {
+        if (sg == ssg) {
+            simdgroup_store(acc00,&Ytg[ 0][0],16); simdgroup_store(acc01,&Ytg[ 0][8],16);
+            simdgroup_store(acc10,&Ytg[ 8][0],16); simdgroup_store(acc11,&Ytg[ 8][8],16);
+            simdgroup_store(acc20,&Ytg[16][0],16); simdgroup_store(acc21,&Ytg[16][8],16);
+            simdgroup_store(acc30,&Ytg[24][0],16); simdgroup_store(acc31,&Ytg[24][8],16); }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        uint smb=(ssg/2)*32; uint snb=(ssg%2)*16;
+        for (uint i = tid; i < 512; i += THREADS) {
+            uint lm=i/16; uint ln=i%16;
+            uint gm=m0+smb+lm; uint gn=n0+snb+ln;
+            if(gm<M&&gn<N){Y[gm*N+gn]=Ytg[lm][ln];} }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+}
+#endif

--- a/crates/inference/src/forward/shaders/qwen35.metal
+++ b/crates/inference/src/forward/shaders/qwen35.metal
@@ -876,6 +876,85 @@ kernel void gemv_q4_decode(
     }
 }
 
+// ===== Q3 GEMV Decode: 3-bit plane-split (2+1) x float32 with simd_sum reduction =====
+// Q3 block: [f16 scale (2B)][f16 bias/min (2B)][12 bytes packed 2+1 plane-split] = 16 bytes per 32 weights.
+// Plane-split layout (see weights/q3_weights.rs module docs):
+//   packed[0..8]  low-2-bit plane, 4 values/byte; packed[8..12] high-1-bit plane, 8 values/byte.
+//   dequant: q[i] = low2(i) | (hi(i) << 2); real_value = q * scale + bias.
+// NR=2 output rows per threadgroup, 4 simdgroups of 32 = 128 threads — same dispatch
+// geometry as gemv_q4_decode (mirrored, not reinvented): TG count = ceil(N/2).
+// Dispatch: threadgroups=(ceil(N/2), 1, 1), threads=(32, 4, 1)
+kernel void gemv_q3_decode(
+    device const float* x        [[buffer(0)]],
+    device const char*  qweight  [[buffer(1)]],
+    device float*       y        [[buffer(2)]],
+    constant uint& N             [[buffer(3)]],
+    constant uint& K             [[buffer(4)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint  tiisg [[thread_index_in_simdgroup]],
+    uint  sgitg [[simdgroup_index_in_threadgroup]])
+{
+    const uint NR = 2;
+    const uint NSG = 4;
+    const uint nb = K / 32;           // number of Q3 blocks per row
+    const uint row_bytes = nb * 16;   // 16 bytes per block (2 scale + 2 bias + 12 plane-split packed)
+    const uint first_row = tgpig.x * NR;
+    const uint ix = tiisg / 4;        // block sub-index (0..7)
+    const uint il = tiisg % 4;        // lane within block (0..3); each lane owns 8 of the 32 weights
+
+    float sumf[NR] = {0.0f};
+    const uint ib_start = sgitg * 8 + ix;
+    const uint ib_stride = NSG * 8;
+
+    // Each lane handles the 8 weights at global indices [il*8, il*8+8) within
+    // the block — the high-plane byte for that range is a single aligned byte
+    // (packed[8+il]), the low-plane spans two aligned bytes (packed[2*il..2*il+2]).
+    device const float* yb = x + ib_start * 32 + il * 8;
+
+    for (uint ib = ib_start; ib < nb; ib += ib_stride) {
+        float yl[8];
+        float yl_sum = 0.0f;
+        for (uint i = 0; i < 8; i++) { yl[i] = yb[i]; yl_sum += yb[i]; }
+        yb += ib_stride * 32;
+
+        for (uint row = 0; row < NR; row++) {
+            uint r = first_row + row;
+            if (r >= N) continue;
+            device const uchar* base = (device const uchar*)(qweight + r * row_bytes + ib * 16);
+            float d = float(*((device const half*)base));         // scale
+            float b = float(*((device const half*)(base + 2)));   // bias (min)
+            device const uchar* low2_bytes = base + 4 + il * 2;   // 2 bytes: low-2-bit plane for this lane's 8 values
+            uchar hi_byte = *(base + 4 + 8 + il);                  // 1 byte: high-1-bit plane for this lane's 8 values
+
+            // Asymmetric dequant: w = q * d + b, q = low2 | (hi << 2).
+            float sumq_dot = 0.0f;
+            for (uint k = 0; k < 8; k++) {
+                uchar low2 = (low2_bytes[k / 4] >> ((k % 4) * 2)) & 0x3;
+                uchar hi = (hi_byte >> k) & 0x1;
+                uchar q = low2 | (hi << 2);
+                sumq_dot += float(q) * yl[k];
+            }
+            sumf[row] += sumq_dot * d + b * yl_sum;
+        }
+    }
+
+    for (uint row = 0; row < NR; row++) sumf[row] = simd_sum(sumf[row]);
+
+    threadgroup float shared[NR][4];
+    if (tiisg == 0) {
+        for (uint row = 0; row < NR; row++) shared[row][sgitg] = sumf[row];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (sgitg == 0 && tiisg == 0) {
+        for (uint row = 0; row < NR; row++) {
+            uint r = first_row + row;
+            if (r < N) {
+                y[r] = shared[row][0] + shared[row][1] + shared[row][2] + shared[row][3];
+            }
+        }
+    }
+}
+
 // ===== GDN: Depthwise conv1d + SiLU =====
 // conv_buf: [conv_dim * buf_len] persistent shift register (buf_len = kernel_size - 1)
 // One thread per channel.

--- a/crates/inference/src/weights/q3_weights.rs
+++ b/crates/inference/src/weights/q3_weights.rs
@@ -488,6 +488,34 @@ pub fn save_q3_file(path: &std::path::Path, tensor: &Q3Tensor) -> std::io::Resul
     f.write_all(block_bytes)
 }
 
+/// Restrict Q3 loading to MLP gate/up/down projections (ADR-072 P1 scope).
+///
+/// The W3 format is a decode-bandwidth play for the MLP GEMM group only —
+/// attention and GDN stay Q4/Q8 (role-aware precision, #423). Any tensor name
+/// outside the MLP projection set is rejected closed rather than silently
+/// accepted, so a mixed checkpoint can never route an attention/GDN weight
+/// through the 3-bit path by mistake.
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] if `tensor_name` does not name an
+/// MLP `gate_proj` / `up_proj` / `down_proj` / fused `gate_up_proj` tensor.
+pub fn validate_q3_mlp_role(tensor_name: &str) -> Result<(), InferenceError> {
+    let is_mlp_proj = tensor_name.contains(".mlp.gate_proj")
+        || tensor_name.contains(".mlp.up_proj")
+        || tensor_name.contains(".mlp.down_proj")
+        || tensor_name.contains(".mlp.gate_up_proj");
+    if is_mlp_proj {
+        Ok(())
+    } else {
+        Err(InferenceError::InvalidInput(format!(
+            "Q3 weight format is restricted to MLP gate/up/down projections \
+             (ADR-072 P1); tensor '{tensor_name}' is outside that set and must \
+             not be loaded as Q3"
+        )))
+    }
+}
+
 /// Header metadata returned by [`read_q3_header`] without allocating blocks.
 pub struct Q3FileHeader {
     /// Tensor shape.
@@ -582,6 +610,62 @@ pub fn read_q3_header(
     })
 }
 
+/// Validate a [`Q3FileHeader`] against the file's actual byte length before the
+/// payload is handed to a no-copy mmap buffer (the Metal loader never reads the
+/// payload itself, so a missing bounds check here would let a truncated
+/// on-disk checkpoint reach GPU dispatch and read past the mapped region).
+///
+/// Mirrors `q4_weights::validate_q4_header_payload_bounds` with the 16-byte
+/// Q3 block size in place of Q4's 20.
+///
+/// # Errors
+///
+/// Returns an error if `shape.iter().product()` disagrees with `original_len`,
+/// or if `file_len` is smaller than `payload_offset + n_blocks * 16`.
+///
+/// Only called from `mmap_q3_weight` (crates/inference/src/forward/metal_qwen35.rs)
+/// today, which live checkpoint loading does not yet reach — see
+/// w3_stage2_report.md "what shipped" for the scope decision.
+#[allow(dead_code)]
+pub(crate) fn validate_q3_header_payload_bounds(
+    header: &Q3FileHeader,
+    file_len: u64,
+    path: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let shape_product = header
+        .shape
+        .iter()
+        .try_fold(1_usize, |acc, &d| acc.checked_mul(d))
+        .ok_or("shape dims overflow usize")?;
+    if shape_product != header.original_len {
+        return Err(format!(
+            "{}: shape product {shape_product} (shape={:?}) != original_len {}",
+            path.display(),
+            header.shape,
+            header.original_len
+        )
+        .into());
+    }
+
+    let payload_bytes = header
+        .original_len
+        .div_ceil(32)
+        .checked_mul(Q3_BLOCK_BYTES)
+        .ok_or("Q3 block payload byte count overflows usize")? as u64;
+    let required_len = header
+        .payload_offset
+        .checked_add(payload_bytes)
+        .ok_or("Q3 payload end offset overflows u64")?;
+    if file_len < required_len {
+        return Err(format!(
+            "{}: file truncated below Q3 block payload ({file_len} bytes < required {required_len})",
+            path.display()
+        )
+        .into());
+    }
+    Ok(())
+}
+
 /// Load a [`Q3Tensor`] from a `.q3` file written by [`save_q3_file`].
 ///
 /// # Errors
@@ -654,6 +738,75 @@ pub fn load_q3_file(path: &std::path::Path) -> Result<Q3Tensor, Box<dyn std::err
         shape,
         original_len,
     })
+}
+
+// ---------------------------------------------------------------------------
+// CPU reference GEMV / GEMM — parity oracle for the Metal Q3 kernels
+// ---------------------------------------------------------------------------
+
+/// CPU reference GEMV: `y[n] = sum_k x[k] * dequant(qweight)[n, k]`.
+///
+/// `qweight` is `N` rows of packed Q3 blocks in the same row-major-per-row
+/// layout the Metal kernels read (`row_bytes = (K/32) * 16` per row, produced
+/// by calling [`quantize_row_q3_0`] once per output row). This is the
+/// straight-line f32 dequant-then-dot reference the Metal `gemv_q3_decode`
+/// kernel is checked against; it does no tiling and no reduced precision.
+///
+/// # Panics
+///
+/// Panics if `K` is not a multiple of 32, or if `qweight.len()` does not equal
+/// `N * (K / 32) * Q3_BLOCK_BYTES`.
+pub fn gemv_q3_reference(x: &[f32], qweight: &[u8], n: usize, k: usize) -> Vec<f32> {
+    assert_eq!(k % 32, 0, "K must be divisible by 32 for Q3 GEMV");
+    let row_bytes = (k / 32) * Q3_BLOCK_BYTES;
+    assert_eq!(
+        qweight.len(),
+        n * row_bytes,
+        "qweight length does not match N * (K/32) * Q3_BLOCK_BYTES"
+    );
+    let mut y = vec![0.0f32; n];
+    for (row_idx, row_bytes_slice) in qweight.chunks_exact(row_bytes).enumerate() {
+        let w = dequantize_row_q3_0(row_bytes_slice, k);
+        y[row_idx] = x.iter().zip(w.iter()).map(|(&xv, &wv)| xv * wv).sum();
+    }
+    y
+}
+
+/// CPU reference GEMM: `Y[m, n] = sum_k X[m, k] * dequant(qweight)[n, k]`.
+///
+/// `X` is row-major `[M, K]`, `qweight` is `N` rows of packed Q3 blocks (same
+/// per-row layout as [`gemv_q3_reference`]), `Y` is row-major `[M, N]`. The
+/// parity oracle for the Metal `gemm_q3_tiled` kernel.
+///
+/// # Panics
+///
+/// Panics if `K` is not a multiple of 32, or if `qweight.len()` does not equal
+/// `N * (K / 32) * Q3_BLOCK_BYTES`, or if `x.len()` does not equal `M * K`.
+pub fn gemm_q3_reference(x: &[f32], qweight: &[u8], m: usize, n: usize, k: usize) -> Vec<f32> {
+    assert_eq!(k % 32, 0, "K must be divisible by 32 for Q3 GEMM");
+    assert_eq!(x.len(), m * k, "x length does not match M * K");
+    let row_bytes = (k / 32) * Q3_BLOCK_BYTES;
+    assert_eq!(
+        qweight.len(),
+        n * row_bytes,
+        "qweight length does not match N * (K/32) * Q3_BLOCK_BYTES"
+    );
+    let w_deq: Vec<Vec<f32>> = qweight
+        .chunks_exact(row_bytes)
+        .map(|row| dequantize_row_q3_0(row, k))
+        .collect();
+    let mut y = vec![0.0f32; m * n];
+    for mi in 0..m {
+        let xrow = &x[mi * k..(mi + 1) * k];
+        for ni in 0..n {
+            y[mi * n + ni] = xrow
+                .iter()
+                .zip(w_deq[ni].iter())
+                .map(|(&xv, &wv)| xv * wv)
+                .sum();
+        }
+    }
+    y
 }
 
 #[cfg(test)]
@@ -881,5 +1034,155 @@ mod tests {
         // 32 weights in 16 bytes = 4.0 bits per weight (the ADR-072 W3 target).
         let bits_per_weight = (Q3_BLOCK_BYTES * 8) as f32 / 32.0;
         assert_eq!(bits_per_weight, 4.0);
+    }
+
+    // -----------------------------------------------------------------------
+    // MLP-role fail-closed loader gate
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mlp_role_accepts_gate_up_down_and_fused() {
+        assert!(validate_q3_mlp_role("model.layers.3.mlp.gate_proj.weight").is_ok());
+        assert!(validate_q3_mlp_role("model.layers.3.mlp.up_proj.weight").is_ok());
+        assert!(validate_q3_mlp_role("model.layers.3.mlp.down_proj.weight").is_ok());
+        assert!(validate_q3_mlp_role("model.layers.3.mlp.gate_up_proj.weight").is_ok());
+    }
+
+    #[test]
+    fn mlp_role_rejects_attention_and_gdn_tensors() {
+        // Attention and GDN weights must stay Q4/Q8 (ADR-072 P1 scope) — any Q3
+        // claim on these tensor names must fail closed, not silently load.
+        for name in [
+            "model.layers.0.self_attn.q_proj.weight",
+            "model.layers.0.self_attn.k_proj.weight",
+            "model.layers.0.self_attn.v_proj.weight",
+            "model.layers.0.self_attn.o_proj.weight",
+            "model.layers.0.linear_attn.in_proj_qkv.weight",
+            "model.layers.0.mlp.experts.gate_up_proj", // MoE routed experts, not the dense MLP path
+            "lm_head.weight",
+            "model.embed_tokens.weight",
+        ] {
+            assert!(
+                validate_q3_mlp_role(name).is_err(),
+                "expected '{name}' to be rejected as outside the Q3 MLP role set"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Header payload-bounds fail-closed gate
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn header_bounds_rejects_truncated_payload() {
+        let header = Q3FileHeader {
+            shape: vec![64],
+            original_len: 64, // 2 blocks * 16 bytes = 32 bytes required
+            payload_offset: 20,
+        };
+        // File is one byte short of the required 20 + 32 = 52 bytes.
+        let err = validate_q3_header_payload_bounds(&header, 51, std::path::Path::new("t.q3"));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn header_bounds_accepts_exact_payload() {
+        let header = Q3FileHeader {
+            shape: vec![64],
+            original_len: 64,
+            payload_offset: 20,
+        };
+        assert!(
+            validate_q3_header_payload_bounds(&header, 52, std::path::Path::new("t.q3")).is_ok()
+        );
+    }
+
+    #[test]
+    fn header_bounds_rejects_shape_mismatch() {
+        let header = Q3FileHeader {
+            shape: vec![63], // disagrees with original_len
+            original_len: 64,
+            payload_offset: 20,
+        };
+        assert!(
+            validate_q3_header_payload_bounds(&header, 1_000, std::path::Path::new("t.q3"))
+                .is_err()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // CPU reference GEMV/GEMM — parity oracle sanity + mutation sensitivity
+    // -----------------------------------------------------------------------
+
+    fn synth_q3_weight_matrix(seed: u64, n: usize, k: usize) -> (Vec<u8>, Vec<f32>) {
+        let mut rng = seed;
+        let mut next = || -> f32 {
+            rng = rng
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((rng >> 11) as u32 as f32 / u32::MAX as f32) * 2.0 - 1.0
+        };
+        let weights_f32: Vec<f32> = (0..n * k).map(|_| next()).collect();
+        let mut packed = Vec::with_capacity(n * (k / 32) * Q3_BLOCK_BYTES);
+        let mut deq = Vec::with_capacity(n * k);
+        for row in weights_f32.chunks_exact(k) {
+            let row_packed = quantize_row_q3_0(row).unwrap();
+            deq.extend_from_slice(&dequantize_row_q3_0(&row_packed, k));
+            packed.extend_from_slice(&row_packed);
+        }
+        (packed, deq)
+    }
+
+    #[test]
+    fn gemv_reference_matches_naive_dequant_dot_product() {
+        let (n, k) = (17usize, 64usize);
+        let (packed, deq) = synth_q3_weight_matrix(0x1234_5678, n, k);
+        let x: Vec<f32> = (0..k).map(|i| (i as f32) * 0.01 - 0.32).collect();
+        let y = gemv_q3_reference(&x, &packed, n, k);
+        for (ni, &yv) in y.iter().enumerate() {
+            let expect: f32 = x
+                .iter()
+                .zip(&deq[ni * k..(ni + 1) * k])
+                .map(|(&xv, &wv)| xv * wv)
+                .sum();
+            assert!((yv - expect).abs() < 1e-3, "row {ni}: {yv} vs {expect}");
+        }
+    }
+
+    #[test]
+    fn gemm_reference_matches_gemv_reference_per_row() {
+        // GEMM with M=1 must reduce to GEMV — cross-checks the two oracles
+        // against each other in addition to the naive-dot check above.
+        let (n, k) = (9usize, 96usize);
+        let (packed, _deq) = synth_q3_weight_matrix(0xC0FF_EE11, n, k);
+        let x: Vec<f32> = (0..k).map(|i| ((i * 7) % 13) as f32 * 0.05 - 0.3).collect();
+        let y_gemv = gemv_q3_reference(&x, &packed, n, k);
+        let y_gemm = gemm_q3_reference(&x, &packed, 1, n, k);
+        assert_eq!(y_gemv, y_gemm);
+    }
+
+    #[test]
+    fn gemv_reference_mutation_sensitive_high_plane_bit() {
+        // Flip one high-plane bit in the packed weight buffer (the same class
+        // of bug the Stage-1 `plane_split_mutation_sensitive_high_bit` test
+        // guards at the pack/unpack level) and assert the GEMV parity oracle's
+        // output changes — this is the oracle the Metal kernel differential
+        // test compares against, so it must itself be sensitive to packing
+        // corruption or a corrupted kernel could pass parity vacuously.
+        let (n, k) = (4usize, 32usize);
+        let (mut packed, _deq) = synth_q3_weight_matrix(0xFEED_FACE, n, k);
+        let x: Vec<f32> = (0..k).map(|i| (i as f32) * 0.02 - 0.3).collect();
+        let y_before = gemv_q3_reference(&x, &packed, n, k);
+
+        // Row 0's block: bytes [0..16) = [scale(2) bias(2) low2(8) hi(4)].
+        // Flip a bit in the high-plane byte at packed offset 4+8+0 = 12.
+        packed[12] ^= 0x01;
+
+        let y_after = gemv_q3_reference(&x, &packed, n, k);
+        assert_ne!(
+            y_before[0], y_after[0],
+            "flipping a high-plane bit must change the dequantized GEMV output \
+             for the row whose block it belongs to"
+        );
     }
 }

--- a/crates/inference/src/weights/q3_weights.rs
+++ b/crates/inference/src/weights/q3_weights.rs
@@ -501,10 +501,23 @@ pub fn save_q3_file(path: &std::path::Path, tensor: &Q3Tensor) -> std::io::Resul
 /// Returns [`InferenceError::InvalidInput`] if `tensor_name` does not name an
 /// MLP `gate_proj` / `up_proj` / `down_proj` / fused `gate_up_proj` tensor.
 pub fn validate_q3_mlp_role(tensor_name: &str) -> Result<(), InferenceError> {
-    let is_mlp_proj = tensor_name.contains(".mlp.gate_proj")
-        || tensor_name.contains(".mlp.up_proj")
-        || tensor_name.contains(".mlp.down_proj")
-        || tensor_name.contains(".mlp.gate_up_proj");
+    const MLP_PROJ_SUFFIXES: [&str; 4] = [
+        ".mlp.gate_proj",
+        ".mlp.up_proj",
+        ".mlp.down_proj",
+        ".mlp.gate_up_proj",
+    ];
+    // Real checkpoints (safetensors index + the Q4 loader's call sites, e.g.
+    // `{prefix}.mlp.gate_proj.weight`) always carry a terminal `.weight`; a
+    // name without it — a LoRA adapter (`...gate_proj.lora_A.weight`), a
+    // renamed backup (`...up_proj_backup`), or a trailing-suffix typo
+    // (`...down_proj.weight.extra`) — must fail closed rather than match on
+    // substring alone.
+    let is_mlp_proj = tensor_name.strip_suffix(".weight").is_some_and(|stem| {
+        MLP_PROJ_SUFFIXES
+            .iter()
+            .any(|suffix| stem.ends_with(suffix))
+    });
     if is_mlp_proj {
         Ok(())
     } else {
@@ -1065,6 +1078,44 @@ mod tests {
             assert!(
                 validate_q3_mlp_role(name).is_err(),
                 "expected '{name}' to be rejected as outside the Q3 MLP role set"
+            );
+        }
+    }
+
+    #[test]
+    fn mlp_role_rejects_near_miss_suffixes() {
+        // Exact-suffix contract: `.contains()` on the role substring would
+        // wrongly accept these — a LoRA adapter branch, a renamed sibling
+        // tensor, and a trailing extra suffix after `.weight`. Table-driven
+        // per the round-1 review (codex_1014_r1_verdict.md finding 1).
+        for name in [
+            "model.layers.3.mlp.gate_proj.lora_A.weight",
+            "model.layers.3.mlp.up_proj_backup.weight",
+            "model.layers.3.mlp.up_proj_backup",
+            "model.layers.3.mlp.down_proj.weight.extra",
+        ] {
+            assert!(
+                validate_q3_mlp_role(name).is_err(),
+                "expected near-miss '{name}' to be rejected by the exact-suffix gate"
+            );
+        }
+    }
+
+    #[test]
+    fn mlp_role_requires_terminal_weight_suffix() {
+        // Real checkpoints always name dense MLP projections with a terminal
+        // `.weight` (see the Q4 loader's `{prefix}.mlp.gate_proj.weight` call
+        // sites in metal_qwen35.rs); a role-correct name missing it is not a
+        // real tensor name and must fail closed.
+        for name in [
+            "model.layers.3.mlp.gate_proj",
+            "model.layers.3.mlp.up_proj",
+            "model.layers.3.mlp.down_proj",
+            "model.layers.3.mlp.gate_up_proj",
+        ] {
+            assert!(
+                validate_q3_mlp_role(name).is_err(),
+                "expected '{name}' (missing '.weight') to be rejected"
             );
         }
     }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

Stage 2 of the 3-bit MLP weight format (ADR-072 P1, #420), building on the merged Stage-1 CPU format (#978, `Q3Block` plane-split 2+1, group-32, 16 B/block = 4.0 bpw). Adds the Metal kernels, loader building blocks, and the CPU parity oracle — mirroring the shipped Q4 architecture at every point rather than inventing a new pattern.

- **`gemv_q3_decode`** (`shaders/qwen35.metal`): decode-path GEMV, same dispatch geometry as `gemv_q4_decode` (NR=2 rows/threadgroup, 128 threads, `threadgroups = (ceil(N/2), 1, 1)`). The plane-split layout means each lane's 8 values are two aligned low-plane bytes + one aligned high-plane byte — no cross-byte straddle in the inner dequant loop.
- **`gemm_q3_tiled`** (`shaders/gemm_q3_tiled.metal`, new): prefill-path tiled GEMM, same BM=64×BN=32×BK=32 simdgroup-matrix tiling as `gemm_q4_tiled`, Apple7-gated. Inner unpack loop iterates one thread per (column, value-in-block) pair since plane-split has no fixed byte-to-value ratio.
- **Loader building blocks**: `Q3WeightBuf`/`mmap_q3_weight` mirror the Q4 pair (mmap → no-copy `StorageModeShared` buffer). Two fail-closed gates run before any bytes reach the GPU: `validate_q3_mlp_role` (MLP-only tensor names, per P1 scope — attention/GDN stay Q4/Q8) and `validate_q3_header_payload_bounds` (truncation guard).
- **CPU reference oracle**: `gemv_q3_reference`/`gemm_q3_reference`, straight-line f32 dequant-then-dot over the same packed layout.
- **`dispatch_gemm_q3`**: M=1 → GEMV, M>1 → tiled GEMM, mirroring `dispatch_gemm_q4`.

**Explicit scope gap (not hidden):** the new pieces are `#[allow(dead_code)]` and NOT wired into live checkpoint routing — `MetalFfnWeights::Dense` still carries only `Q4WeightBuf` for MLP tensors, and the checkpoint-level "detect `.q3` files, mix Q3 MLP with Q4/Q8 everything else" path touches ~10 call sites on the load-bearing dispatch path. That wiring is a follow-up stage so it can be verified without risking the working Q4/Q8 decode path. The kernels themselves are exercised end-to-end on a real GPU by the differential tests below.

**Tests** (32/32 green, `--features metal-gpu,f16`, real Apple-series GPU — not skip-passed):
- `gemv_q3_decode_matches_cpu_reference_across_shapes`: N∈{1,5,33} × K∈{32,64,96}, tolerance <5e-3 (f32-throughout kernel; bound dominated by Q3's 8-level quantization step).
- `gemm_q3_tiled_matches_cpu_reference_at_tile_boundaries`: exact tile multiples, non-multiple M/N (zero-pad boundary guards), small odd shapes, plus the Qwen3.5-0.8B dense gate/up depth (K=1024) and down-projection depth (K=3584, 112 `BK=32` iterations) — the measured envelope (max 1.946e-2 at K=3584) derives the `0.037` tolerance bound (~1.9x headroom for cross-device variation and future kernel-scheduling changes).
- `gemm_q3_tiled_differential_fails_closed_on_nan_scale`: proves the NaN-honest comparison itself fails loudly on a corrupted GPU output. Dispatches unconditionally past the device/Apple7 gate (mirroring the other Apple7-gated tests' skip-on-absent convention) then wraps only the comparison in `catch_unwind` (the dispatch completes before the catch begins, so a pre-comparison failure is an ordinary test failure, not a matched panic), asserting on the caught panic's message — so a skip can no longer be mistaken for a verified run the way a whole-test `#[should_panic(expected = "is not finite")]` could.
- Mutation-sensitive coverage on both sides of the parity oracle: `gemv_q3_decode_mutation_sensitive_high_plane_bit` (corrupts post-encode packed bytes fed to the real GPU kernel) and `gemv_reference_mutation_sensitive_high_plane_bit` (same for the CPU oracle) — these corrupt the packed bytes directly because a pack-side mutation corrupts both oracle inputs identically and cannot show up as a GPU-vs-CPU disagreement by construction.
- Loader fail-closed tests: non-MLP role rejection, truncated-payload rejection, bad magic, shape mismatch.

`cargo clippy --workspace -- -D warnings` clean; `cargo clippy -p lattice-inference --features metal-gpu,f16 --all-targets -- -D warnings` clean; `cargo fmt --all` no drift.

bench-compare (ADR-058): measured A/B, quick mode, base `origin/main` (07f5d854) vs head (f45dd66f), run in a quiet window. Result: **0 FAIL, 2 WARN** (both in the 3–7% non-gating band), 60 informational — `simd_batch_cosine/simd_batch/100` +7.11% and `simd_query_batch_dot_product/simd_batch/128d_256c` +4.87%, both `lattice-embed` SIMD micro-benches. Attribution analysis: every new symbol in this PR is `#[allow(dead_code)]` or test-only and unreachable from any bench group (the Metal module is additionally `cfg`-gated out of default-feature bench builds), so the only possible mechanism is code-layout shift from the compiled-but-uncalled `q3_weights` module; the same embed groups swung on an unrelated sibling PR's A/B the same night (one direction there +4.47% on the identical `simd_batch_cosine/simd_batch/100` group), which points at the known #714 micro-bench sensitivity rather than this diff. Warns do not gate (>7% CI-confirmed fails do). Stage 3 (PPL gate + A/B on a real Q3-quantized checkpoint) runs when live routing lands.

Refs #420, ADR-072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


