### PR TITLE
docs: bench A/B quiet-window rule (zero disk activity; reachability check before rerun)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,12 @@ Paste the output in the PR description. If nothing changed, say "bench-compare s
 
 This process caught a 15% decode throughput regression (157 → 130 tok/s) that had been attributed to "GPU contention noise" for days. The f32 dot_product unrolling that caused it was identified in under 2 minutes via A/B comparison.
 
+### Keep the Machine Quiet During A/B Runs — Quiet Means Zero Disk Activity, Not Just Zero Builds
+
+A bench window means no concurrent builds AND no git checkouts, worktree adds, large file copies, or downloads. Filesystem indexing churn (Spotlight `mdworker`, `fseventsd`) from a repository checkout lands asymmetrically in whichever measurement phase it overlaps, and base-then-head runs make that asymmetry read as a code regression. Two consecutive A/B runs were corrupted this way — worktree checkouts overlapping the head phase produced swings up to +250% in groups the diff could not reach.
+
+Before re-running a corrupted A/B, check structural reachability first: is the changed code even compiled into the bench binaries? A diff confined to a `cfg`-gated module (e.g. `#[cfg(all(target_os = "macos", feature = "metal-gpu"))]`) is compiled out of a default-feature bench build entirely — base and head binaries are then built from identical effective source, no rerun can attribute any delta to the diff, and stating that proof in the PR beats a ritual rerun.
+
 ### Bench by Group, Not All at Once
 
 The full Criterion suite takes 15-30 min. Never run it all. Filter to the groups your PR touches:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,9 @@ This process caught a 15% decode throughput regression (157 → 130 tok/s) that 
 
 A bench window means no concurrent builds AND no git checkouts, worktree adds, large file copies, or downloads. Filesystem indexing churn (Spotlight `mdworker`, `fseventsd`) from a repository checkout lands asymmetrically in whichever measurement phase it overlaps, and base-then-head runs make that asymmetry read as a code regression. Two consecutive A/B runs were corrupted this way — worktree checkouts overlapping the head phase produced swings up to +250% in groups the diff could not reach.
 
-Before re-running a corrupted A/B, check structural reachability first: is the changed code even compiled into the bench binaries? A diff confined to a `cfg`-gated module (e.g. `#[cfg(all(target_os = "macos", feature = "metal-gpu"))]`) is compiled out of a default-feature bench build entirely — base and head binaries are then built from identical effective source, no rerun can attribute any delta to the diff, and stating that proof in the PR beats a ritual rerun.
+Before re-running a corrupted A/B, check structural reachability first: is the changed code even compiled into the bench binaries? A diff confined to a `cfg`-gated module (e.g. `#[cfg(all(target_os = "macos", feature = "metal-gpu"))]`) is compiled out of a default-feature bench build entirely — base and head binaries are then built from identical effective source, and no rerun can attribute any delta to the diff.
+
+To be precise about how this interacts with the "no exceptions" rule above: the bench-compare disposition section of the PR is still mandatory for every `crates/inference/` or `crates/embed/` PR. The compiled-out proof is the one narrow case where that section may contain the structural argument (name the `cfg` gate, name the bench build's feature set, state that base and head bench binaries have identical effective source) instead of an A/B table. If any changed line is compiled into the bench binaries — even an additive field or a cold-path function — the proof does not apply and you run the A/B, in a quiet window, like always.
 
 ### Bench by Group, Not All at Once
 


### PR DESCRIPTION
Codifies a measurement lesson from two consecutive corrupted bench-compare A/B runs (2026-07-16): repository checkouts overlapping the head measurement phase produced swings up to +250% in bench groups the diff structurally could not reach. Two rules added to the Development Process section:

1. A bench window means zero disk activity — no builds, and also no git checkouts/worktree adds/large copies (filesystem indexing churn lands asymmetrically in one measurement phase and reads as a code regression).
2. Before re-running a corrupted A/B, check structural reachability: a diff confined to a cfg-gated module is compiled out of a default-feature bench build, making base and head binaries identical effective source — the proof belongs in the PR instead of a ritual rerun (applied on #1011).

Docs-only, 2 paragraphs. bench-compare (ADR-058): not applicable — CLAUDE.md is not compiled into anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)