### PR TITLE
fix(inference): accept sharded checkpoints in dev-run pre-check helpers (9 sibling sites)

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -28250,6 +28250,25 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             best
         }
 
+        /// Mirror `Qwen35Model::from_safetensors`: weights are present in
+        /// EITHER the single-file layout (`model.safetensors`) or the
+        /// sharded layout (`model.safetensors.index.json`) — an HF
+        /// `snapshot_download` of this model ships only the sharded form.
+        fn qwen35_checkpoint_weights_present(model_dir: &std::path::Path) -> bool {
+            model_dir.join("model.safetensors").exists()
+                || model_dir.join("model.safetensors.index.json").exists()
+        }
+
+        #[test]
+        fn qwen35_checkpoint_weights_present_accepts_sharded_layout() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            assert!(!qwen35_checkpoint_weights_present(dir.path()));
+
+            std::fs::write(dir.path().join("model.safetensors.index.json"), "{}")
+                .expect("write index");
+            assert!(qwen35_checkpoint_weights_present(dir.path()));
+        }
+
         #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
         #[test]
         fn metal_qwen35_chunked_prefill_long_prompt_matches_step_loop() {
@@ -28260,7 +28279,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             let model_dir =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".lattice/models/qwen3.5-0.8b");
-            if !model_dir.join("model.safetensors").exists()
+            if !qwen35_checkpoint_weights_present(&model_dir)
                 || !model_dir.join("config.json").exists()
                 || !model_dir.join("tokenizer.json").exists()
             {
@@ -28367,7 +28386,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             let model_dir =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".lattice/models/qwen3.5-0.8b");
-            if !model_dir.join("model.safetensors").exists()
+            if !qwen35_checkpoint_weights_present(&model_dir)
                 || !model_dir.join("config.json").exists()
                 || !model_dir.join("tokenizer.json").exists()
             {
@@ -28469,7 +28488,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             let model_dir =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".lattice/models/qwen3.5-0.8b");
-            if !model_dir.join("model.safetensors").exists()
+            if !qwen35_checkpoint_weights_present(&model_dir)
                 || !model_dir.join("config.json").exists()
                 || !model_dir.join("tokenizer.json").exists()
             {
@@ -28554,7 +28573,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             let model_dir =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".lattice/models/qwen3.5-0.8b");
-            if !model_dir.join("model.safetensors").exists()
+            if !qwen35_checkpoint_weights_present(&model_dir)
                 || !model_dir.join("config.json").exists()
                 || !model_dir.join("tokenizer.json").exists()
             {
@@ -28797,7 +28816,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             let model_dir =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".lattice/models/qwen3.5-0.8b");
-            if !model_dir.join("model.safetensors").exists() {
+            if !qwen35_checkpoint_weights_present(&model_dir) {
                 eprintln!("skipping: model missing");
                 return;
             }
@@ -28850,7 +28869,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             let model_dir =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".lattice/models/qwen3.5-0.8b");
-            if !model_dir.join("model.safetensors").exists() {
+            if !qwen35_checkpoint_weights_present(&model_dir) {
                 eprintln!("skipping: model missing");
                 return;
             }
@@ -28979,7 +28998,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             let model_dir =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".lattice/models/qwen3.5-0.8b");
-            if !model_dir.join("model.safetensors").exists() {
+            if !qwen35_checkpoint_weights_present(&model_dir) {
                 eprintln!(
                     "skipping gdn_chunked_prefill_vs_serial_prefill_logit_parity: model missing"
                 );
@@ -29169,7 +29188,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             let model_dir =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".lattice/models/qwen3.5-0.8b");
-            if !model_dir.join("model.safetensors").exists() {
+            if !qwen35_checkpoint_weights_present(&model_dir) {
                 eprintln!("skipping gdn175_s1b_chunkwise_oracle_real_activations: model missing");
                 return;
             }
@@ -29472,7 +29491,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             let model_dir =
                 std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
                     .join(".lattice/models/qwen3.5-0.8b");
-            if !model_dir.join("model.safetensors").exists() {
+            if !qwen35_checkpoint_weights_present(&model_dir) {
                 eprintln!("skipping: model missing");
                 return;
             }


### PR DESCRIPTION
Nine dev-run test helpers in `metal_qwen35.rs` independently duplicated the single-file-only checkpoint pre-check that 3fe22ee691 already fixed in the CI-gated copy: they required a monolithic `model.safetensors`, failing closed on sharded checkpoints (`model.safetensors.index.json`) — the only form an HF `snapshot_download` of Qwen3.5-0.8B ships — even though `Qwen35Model::from_safetensors` accepts both layouts.

Classic sibling-invocation-path batch: the fix's own shape was the grep query (`model_dir.join("model.safetensors").exists()`), which found exactly 9 sites in two structural variants (4 multi-condition OR chains, 5 single-condition guards).

**Fix shape**: one shared helper, `qwen35_checkpoint_weights_present(&Path) -> bool` (single-file OR sharded index), swapped into all 9 sites as one-line changes. Every site's own surrounding structure (additional `config.json`/`tokenizer.json` checks, skip messages) is untouched. The already-fixed CI-gated site was deliberately left as-is — mirroring the fix, not unifying with it, keeps the diff surgical.

**Tests**: new unit test `qwen35_checkpoint_weights_present_accepts_sharded_layout` (temp dir with index manifest and no monolithic file). Mutation-verified: reverting the helper to the single-file-only body fails the test; restored, it passes. (The locally cached checkpoint has both layouts present, so a temp-dir unit test is the honest demonstration — a live run against it would not have exercised the sharded-only path.)

Diff: 1 file, +28/−9 (helper + test + 9 one-line call-site swaps). `cargo clippy --workspace -- -D warnings` clean; `cargo clippy -p lattice-inference --features metal-gpu,f16 --all-targets -- -D warnings` clean; `cargo fmt --all` no drift; metal-gpu,f16 lib test target compiles; new test green.

bench-compare (ADR-058): diff is confined to `#[cfg(test)]` helpers inside the `metal-gpu`-gated module — compiled out of default-feature bench builds entirely; base and head bench binaries are identical effective source, so no A/B can attribute a delta to this diff.

Refs 3fe22ee691 (the CI-gated original fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
