### PR TITLE
perf(inference): trie-accelerated grammar mask for over-cap states (#734)

### DIFF
--- a/crates/inference/src/bin/gramperf_profile.rs
+++ b/crates/inference/src/bin/gramperf_profile.rs
@@ -203,7 +203,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
              precomputed_ns_per_step={} context_recheck_calls={} context_recheck_ns={} \
              context_recheck_ns_per_step={} fallback_calls={} fallback_ns={} \
              fallback_ns_per_step={} advance_calls={} advance_ns={} advance_ns_per_step={} \
-             residual_ns_per_step={} stop_reason={:?}",
+             residual_ns_per_step={} stop_reason={:?} trie_build_ns={}",
             output.generated_tokens,
             wall_ns / steps,
             mp.precomputed_calls,
@@ -226,6 +226,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             mp.advance_ns / steps,
             residual_ns / steps,
             output.stop_reason,
+            engine.trie_build_ns(),
         );
         if i == 0 {
             grammar_token_ids = output.token_ids.clone();
@@ -260,6 +261,101 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
              wall_ns_per_step={}",
             output.generated_tokens,
             wall_ns / steps,
+        );
+    }
+
+    // (e) Multi-request cross-request state-revisit measurement. Gates the
+    // GrammarEngine-lifetime memoized-mask decision from the profiling
+    // report's ranked fix #2 (measurement only — no memo is implemented
+    // here). M=5 sequential generations share the SAME `engine` Arc (the
+    // production caching unit: one compiled schema reused across many
+    // requests), each with different prompt wording so content-dependent
+    // states (which enum member, which digits) can plausibly diverge
+    // across requests while schema-literal scaffold states (JSON
+    // punctuation, property-name keys) should still recur. A
+    // `(stack, complete)` visit map persists across all M runs — a hit
+    // means a later request landed on a state some earlier request already
+    // visited, which a per-engine (not per-request) memoized mask cache
+    // could have served from cache.
+    {
+        let multi_prompts = [
+            "Generate a JSON object describing a record with a deeply \
+             nested configuration, some tags and numeric items, and a \
+             handful of categorical flags.",
+            "Produce a JSON object for a different record with its own \
+             nested configuration, different tags, different numeric \
+             items, and different categorical flags.",
+            "Emit a JSON object representing yet another record: nested \
+             configuration, a fresh set of tags, fresh numeric items, and \
+             fresh categorical flags.",
+            "Return a JSON object for a new record instance with a \
+             distinct nested configuration, distinct tags, distinct \
+             numeric items, and distinct categorical flags.",
+            "Write a JSON object capturing one more record: its own \
+             nested configuration, its own tags, its own numeric items, \
+             and its own categorical flags.",
+        ];
+        let m = multi_prompts.len();
+        let mut cross_request_visits: HashMap<(Vec<StackFrame>, bool), u32> = HashMap::new();
+        let mut total_steps = 0u64;
+        let mut cross_request_hits = 0u64;
+
+        for (run_idx, p) in multi_prompts.iter().enumerate() {
+            metal.reset_state();
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: max_tokens,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(42),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: None,
+                grammar: Some(Arc::clone(&engine)),
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: None,
+            };
+            let output = metal.generate(p, &tokenizer, &gen_cfg)?;
+
+            // Replay this run's token sequence through the SAME engine
+            // (fresh GrammarState per run — one request = one decode
+            // sequence — but `cross_request_visits` persists across runs)
+            // to count revisits against states seen in EARLIER runs.
+            let mut state = engine.initial_state();
+            let mut new_states_this_run = 0u64;
+            for &token_id in &output.token_ids {
+                let key: (Vec<StackFrame>, bool) = (state.stack.clone(), state.complete);
+                if cross_request_visits.contains_key(&key) {
+                    cross_request_hits += 1;
+                } else {
+                    new_states_this_run += 1;
+                }
+                *cross_request_visits.entry(key).or_insert(0) += 1;
+                total_steps += 1;
+                if !engine.advance(&mut state, token_id) {
+                    break;
+                }
+            }
+            println!(
+                "RESULT kind=multi_request_run run={run_idx} generated_tokens={} \
+                 new_states={new_states_this_run}",
+                output.generated_tokens,
+            );
+        }
+
+        let hit_rate = if total_steps > 0 {
+            cross_request_hits as f64 / total_steps as f64
+        } else {
+            0.0
+        };
+        println!(
+            "RESULT kind=multi_request_summary requests={m} total_steps={total_steps} \
+             cross_request_hits={cross_request_hits} cross_request_hit_rate={hit_rate:.4} \
+             distinct_states_total={} trie_build_ns={}",
+            cross_request_visits.len(),
+            engine.trie_build_ns(),
         );
     }
 

--- a/crates/inference/src/bin/gramperf_profile.rs
+++ b/crates/inference/src/bin/gramperf_profile.rs
@@ -1,0 +1,328 @@
+//! Profiling harness for issue #734 (grammar-constrained decode ~4.5x
+//! slower per token when a schema exceeds `MAX_GRAMMAR_STATES`).
+//!
+//! PROFILING ONLY — no optimization landed here. This binary measures four
+//! things over a real greedy generation on Qwen3.5-0.8B-Q4 (Metal):
+//!
+//!   a. per-decode-step wall time split: forward pass (residual) vs grammar
+//!      masking (precomputed-hit / `mask_by_simulation` fallback / the
+//!      context-dependent recheck loop) vs PDA `advance`.
+//!   b. state revisit rate: distinct grammar states visited vs total decode
+//!      steps, and the hit rate a lazy memoized mask cache would have had.
+//!   c. compile-time breakdown: BFS state enumeration vs eager
+//!      `VocabPartition::build`, and reachable states found vs the 256 cap.
+//!   d. mask density: how many of the ~250K vocab tokens are masked per step.
+//!
+//! Env:
+//!   LATTICE_MODEL_DIR      Q4 model dir (default ~/.lattice/models/_fresh616_q4)
+//!   LATTICE_TOKENIZER_DIR  tokenizer dir (default ~/.lattice/models/qwen3.5-0.8b)
+//!   GRAMPERF_RUNS          grammar-constrained generation runs (default 3)
+//!   GRAMPERF_MAX_TOKENS    max_new_tokens per run (default 150)
+//!   GRAMPERF_PROBE_CAP     uncapped BFS probe ceiling (default 1024; bounded
+//!                          because probe cost scales ~linearly with states)
+//!
+//! Output: machine-readable `RESULT key=value ...` lines to stdout, one
+//! block per measurement, consumed by hand for the profiling report (this is
+//! a diagnostic tool, not a bench-gate harness).
+
+fn main() {
+    #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+    {
+        eprintln!("Requires macOS + metal-gpu feature.");
+        std::process::exit(1);
+    }
+
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    {
+        if let Err(e) = run() {
+            eprintln!("gramperf_profile failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    use lattice_inference::forward::metal_qwen35::MetalQwen35State;
+    use lattice_inference::grammar::engine::{
+        enable_mask_profiling, last_build_profile, probe_reachable_states, take_mask_profile,
+    };
+    use lattice_inference::grammar::pda::StackFrame;
+    use lattice_inference::grammar::{GrammarEngine, GrammarSpec};
+    use lattice_inference::model::qwen35_config::{GenerateConfig, Qwen35Config};
+    use lattice_inference::tokenizer::BpeTokenizer;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    let home = std::env::var("HOME")?;
+    let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
+        .unwrap_or_else(|_| format!("{home}/.lattice/models/_fresh616_q4"));
+    let dir = std::path::Path::new(&model_dir_str);
+    let tokenizer_dir_str = std::env::var("LATTICE_TOKENIZER_DIR")
+        .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.5-0.8b"));
+    let tokenizer_dir = std::path::Path::new(&tokenizer_dir_str);
+
+    let runs: usize = std::env::var("GRAMPERF_RUNS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+    let max_tokens: usize = std::env::var("GRAMPERF_MAX_TOKENS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(150);
+    let probe_cap: usize = std::env::var("GRAMPERF_PROBE_CAP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1024);
+
+    eprintln!("[gramperf] loading {model_dir_str} (Q4) / tokenizer {tokenizer_dir_str}");
+    let cfg = Qwen35Config::from_model_dir(dir).map_err(|e| format!("config.json load: {e}"))?;
+    let mut metal =
+        MetalQwen35State::from_q4_dir(dir, &tokenizer_dir.join("tokenizer.json"), &cfg, 4096)
+            .map_err(|e| format!("Metal Q4 init: {e}"))?;
+    let tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_dir.join("tokenizer.json"))?;
+
+    // #734-shape schema, reconstructed (the exact schema is not in the repo
+    // or the issue text): 4 levels of nested objects (level1..level4), 3
+    // array fields (tags, items, flags), 6 string-enum fields (6 members
+    // each: status, category, priority, region, mode, role).
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "level1": {
+                "type": "object",
+                "properties": {
+                    "level2": {
+                        "type": "object",
+                        "properties": {
+                            "level3": {
+                                "type": "object",
+                                "properties": {
+                                    "level4": {
+                                        "type": "object",
+                                        "properties": {
+                                            "status": {"type": "string", "enum": ["active", "inactive", "pending", "archived", "deleted", "draft"]},
+                                            "value": {"type": "integer"}
+                                        },
+                                        "required": ["status", "value"]
+                                    }
+                                },
+                                "required": ["level4"]
+                            },
+                            "category": {"type": "string", "enum": ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"]}
+                        },
+                        "required": ["level3", "category"]
+                    },
+                    "tags": {"type": "array", "items": {"type": "string"}}
+                },
+                "required": ["level2", "tags"]
+            },
+            "items": {"type": "array", "items": {"type": "integer"}},
+            "flags": {"type": "array", "items": {"type": "boolean"}},
+            "priority": {"type": "string", "enum": ["low", "medium", "high", "urgent", "critical", "none"]},
+            "region": {"type": "string", "enum": ["us", "eu", "apac", "latam", "mea", "other"]},
+            "mode": {"type": "string", "enum": ["sync", "async", "batch", "stream", "manual", "auto"]},
+            "role": {"type": "string", "enum": ["admin", "user", "guest", "owner", "viewer", "editor"]}
+        },
+        "required": ["level1", "items", "flags", "priority", "region", "mode", "role"]
+    });
+    let spec = GrammarSpec::JsonSchema(schema);
+
+    eprintln!("[gramperf] tokenizer vocab_size={}", cfg.vocab_size);
+    let vocab_bytes = tokenizer.vocab_bytes(cfg.vocab_size)?;
+
+    // (c) compile-time breakdown: capped (production) build.
+    let compile_t0 = Instant::now();
+    let engine = GrammarEngine::new(&spec, vocab_bytes.clone())?;
+    let compile_total_ns = compile_t0.elapsed().as_nanos() as u64;
+    let build_profile = last_build_profile();
+    println!(
+        "RESULT kind=compile compile_total_ns={} bfs_ns={} partition_build_ns={} \
+         reachable_states_capped={} state_cap={} exceeds_state_budget={}",
+        compile_total_ns,
+        build_profile.bfs_ns,
+        build_profile.partition_build_ns,
+        build_profile.reachable_states,
+        build_profile.capped_states,
+        engine.exceeds_state_budget(),
+    );
+
+    // (c) uncapped-ish BFS probe: how many states does the schema actually
+    // reach past the 256 cap? Bounded at `probe_cap` — probe cost scales
+    // ~linearly with states explored, so this is a lower bound if the true
+    // count exceeds `probe_cap`.
+    let probe_t0 = Instant::now();
+    let probed_states = probe_reachable_states(&spec, &vocab_bytes, probe_cap)?;
+    let probe_ns = probe_t0.elapsed().as_nanos() as u64;
+    let probe_truncated = probed_states >= probe_cap;
+    println!(
+        "RESULT kind=probe probe_cap={probe_cap} probed_states={probed_states} \
+         probe_truncated={probe_truncated} probe_ns={probe_ns}"
+    );
+
+    let engine = Arc::new(engine);
+
+    let prompt = "Generate a JSON object describing a record with a deeply \
+                  nested configuration, some tags and numeric items, and a \
+                  handful of categorical flags.";
+
+    // (a) grammar-constrained runs: real forward pass + real mask_logits +
+    // real advance, with mask profiling enabled to attribute decode-step
+    // cost to precomputed-hit / recheck / fallback / advance / residual
+    // (forward pass + sampling).
+    let mut grammar_token_ids: Vec<u32> = Vec::new();
+    for i in 0..runs {
+        metal.reset_state();
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: max_tokens,
+            temperature: 0.0,
+            top_k: 1,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            seed: Some(42),
+            stop_token_ids: vec![],
+            enable_thinking: false,
+            enable_mtp: None,
+            grammar: Some(Arc::clone(&engine)),
+            stop_strings: vec![],
+            reasoning_budget: None,
+            logprobs: None,
+        };
+        enable_mask_profiling();
+        let t0 = Instant::now();
+        let output = metal.generate(prompt, &tokenizer, &gen_cfg)?;
+        let wall_ns = t0.elapsed().as_nanos() as u64;
+        let mp = take_mask_profile();
+        let steps = output.generated_tokens.max(1) as u64;
+        let mask_ns = mp.precomputed_ns + mp.context_recheck_ns + mp.fallback_ns;
+        let residual_ns = wall_ns.saturating_sub(mask_ns + mp.advance_ns);
+        println!(
+            "RESULT kind=grammar_run run={i} generated_tokens={} wall_ns={wall_ns} \
+             wall_ns_per_step={} precomputed_calls={} precomputed_ns={} \
+             precomputed_ns_per_step={} context_recheck_calls={} context_recheck_ns={} \
+             context_recheck_ns_per_step={} fallback_calls={} fallback_ns={} \
+             fallback_ns_per_step={} advance_calls={} advance_ns={} advance_ns_per_step={} \
+             residual_ns_per_step={} stop_reason={:?}",
+            output.generated_tokens,
+            wall_ns / steps,
+            mp.precomputed_calls,
+            mp.precomputed_ns,
+            mp.precomputed_ns
+                .checked_div(mp.precomputed_calls.max(1))
+                .unwrap_or(0),
+            mp.context_recheck_calls,
+            mp.context_recheck_ns,
+            mp.context_recheck_ns
+                .checked_div(mp.context_recheck_calls.max(1))
+                .unwrap_or(0),
+            mp.fallback_calls,
+            mp.fallback_ns,
+            mp.fallback_ns
+                .checked_div(mp.fallback_calls.max(1))
+                .unwrap_or(0),
+            mp.advance_calls,
+            mp.advance_ns,
+            mp.advance_ns / steps,
+            residual_ns / steps,
+            output.stop_reason,
+        );
+        if i == 0 {
+            grammar_token_ids = output.token_ids.clone();
+        }
+    }
+
+    // Unconstrained baseline (context, not the primary measurement): same
+    // prompt, no grammar, greedy.
+    {
+        metal.reset_state();
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: max_tokens,
+            temperature: 0.0,
+            top_k: 1,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            seed: Some(42),
+            stop_token_ids: vec![],
+            enable_thinking: false,
+            enable_mtp: None,
+            grammar: None,
+            stop_strings: vec![],
+            reasoning_budget: None,
+            logprobs: None,
+        };
+        let t0 = Instant::now();
+        let output = metal.generate(prompt, &tokenizer, &gen_cfg)?;
+        let wall_ns = t0.elapsed().as_nanos() as u64;
+        let steps = output.generated_tokens.max(1) as u64;
+        println!(
+            "RESULT kind=baseline_unconstrained generated_tokens={} wall_ns={wall_ns} \
+             wall_ns_per_step={}",
+            output.generated_tokens,
+            wall_ns / steps,
+        );
+    }
+
+    // (b) + (d): replay the exact token sequence from grammar run 0 through
+    // the same engine (no GPU needed) to get state-revisit / memoization-hit
+    // and mask-density stats faithfully, without perturbing the timed runs
+    // above with density-counting overhead.
+    {
+        let mut state = engine.initial_state();
+        let mut visits: HashMap<(Vec<StackFrame>, bool), u32> = HashMap::new();
+        let mut steps = 0u64;
+        let mut cache_hits = 0u64;
+        let mut density_sum = 0f64;
+        let mut density_min = f64::MAX;
+        let mut density_max = f64::MIN;
+        let vocab_size = cfg.vocab_size;
+        let mut dummy_logits = vec![0.0f32; vocab_size];
+
+        for &token_id in &grammar_token_ids {
+            let key: (Vec<StackFrame>, bool) = (state.stack.clone(), state.complete);
+            let seen_before = visits.contains_key(&key);
+            *visits.entry(key).or_insert(0) += 1;
+            if seen_before {
+                cache_hits += 1;
+            }
+
+            for l in dummy_logits.iter_mut() {
+                *l = 0.0;
+            }
+            engine.mask_logits(&mut state, &mut dummy_logits);
+            let masked = dummy_logits
+                .iter()
+                .filter(|&&l| l == f32::NEG_INFINITY)
+                .count();
+            let density = masked as f64 / vocab_size as f64;
+            density_sum += density;
+            density_min = density_min.min(density);
+            density_max = density_max.max(density);
+            steps += 1;
+
+            if !engine.advance(&mut state, token_id) {
+                break;
+            }
+        }
+
+        let distinct_states = visits.len() as u64;
+        let hit_rate = if steps > 0 {
+            cache_hits as f64 / steps as f64
+        } else {
+            0.0
+        };
+        let density_mean = if steps > 0 {
+            density_sum / steps as f64
+        } else {
+            0.0
+        };
+        println!(
+            "RESULT kind=replay steps={steps} distinct_states={distinct_states} \
+             cache_hits={cache_hits} would_be_hit_rate={hit_rate:.4} \
+             mask_density_mean={density_mean:.4} mask_density_min={density_min:.4} \
+             mask_density_max={density_max:.4} vocab_size={vocab_size}"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -1262,4 +1262,136 @@ mod tests {
             "mask_logits on an over-cap state must match the oracle mask exactly"
         );
     }
+
+    /// Same differential as `trie_mask_byte_identical_to_oracle_over_corpus` /
+    /// `trie_mask_never_over_accepts_vs_oracle`, but over the REAL model
+    /// tokenizer vocabulary instead of the synthetic `trie_diff_vocab`. The
+    /// synthetic vocab (256 single bytes + ~50 fragments) is a stand-in that
+    /// exercises trie branching and prefix sharing but is roughly three
+    /// orders of magnitude smaller than a real ~248K-token vocab, so it
+    /// cannot rule out a size- or content-dependent trie bug that only
+    /// surfaces at production scale. `#[ignore]`d because it loads a real
+    /// tokenizer and simulates the oracle over the full vocab (slow, and
+    /// requires a model checkout on disk); run explicitly with a `real_vocab`
+    /// test filter.
+    #[test]
+    #[ignore = "loads a real tokenizer + full vocab oracle simulation; run with `real_vocab` filter"]
+    fn trie_mask_byte_identical_to_oracle_real_vocab() {
+        let home = std::env::var("HOME").expect("HOME must be set");
+        let tokenizer_dir_str = std::env::var("LATTICE_TOKENIZER_DIR")
+            .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.5-0.8b"));
+        let tokenizer_dir = std::path::Path::new(&tokenizer_dir_str);
+        let config_path = tokenizer_dir.join("config.json");
+        let tokenizer_path = tokenizer_dir.join("tokenizer.json");
+        if !config_path.exists() || !tokenizer_path.exists() {
+            panic!(
+                "real-vocab differential test skipped: no model checkout at \
+                 {tokenizer_dir_str} (expected config.json + tokenizer.json); \
+                 set LATTICE_TOKENIZER_DIR to point at one"
+            );
+        }
+
+        let cfg = crate::model::qwen35_config::Qwen35Config::from_model_dir(tokenizer_dir)
+            .expect("config.json load");
+        let tokenizer = crate::tokenizer::BpeTokenizer::from_tokenizer_json(&tokenizer_path)
+            .expect("tokenizer.json load");
+        let vocab = tokenizer
+            .vocab_bytes(cfg.vocab_size)
+            .expect("vocab_bytes over real tokenizer");
+        assert!(
+            vocab.len() > 100_000,
+            "expected a production-scale vocab (~248K tokens for Qwen3.5), got {}",
+            vocab.len()
+        );
+
+        let spec = GrammarSpec::JsonSchema(trie_diff_schema());
+        let engine = GrammarEngine::new(&spec, vocab.clone()).unwrap();
+        assert!(
+            engine.exceeds_state_budget(),
+            "fixture must exceed the state cap for this differential to exercise \
+             the fallback path (the point of this test) — got a real vocab of {} \
+             tokens",
+            vocab.len()
+        );
+
+        let corpus = harvest_trajectory_states(&engine);
+        assert!(
+            corpus.len() >= 20,
+            "need at least 20 distinct harvested states, got {}",
+            corpus.len()
+        );
+
+        let mut over_cap_states = 0usize;
+        let mut mismatches: Vec<(usize, usize)> = Vec::new();
+        let mut over_accepts: Vec<(usize, usize)> = Vec::new();
+        for (i, state) in corpus.iter().enumerate() {
+            let mut oracle_logits = vec![0.0f32; vocab.len()];
+            let mut trie_logits = vec![0.0f32; vocab.len()];
+            engine.mask_by_simulation(state, &mut oracle_logits);
+            engine.mask_by_trie(state, &mut trie_logits);
+            if engine.find_state_id(state).is_none() {
+                over_cap_states += 1;
+            }
+            for tok in 0..vocab.len() {
+                if trie_logits[tok] != oracle_logits[tok] {
+                    mismatches.push((i, tok));
+                }
+                let oracle_blocked = oracle_logits[tok] == f32::NEG_INFINITY;
+                let trie_allowed = trie_logits[tok] != f32::NEG_INFINITY;
+                if oracle_blocked && trie_allowed {
+                    over_accepts.push((i, tok));
+                }
+            }
+        }
+
+        assert!(
+            over_cap_states >= 10,
+            "corpus should mostly cover the over-cap fallback path; got \
+             {over_cap_states}/{}",
+            corpus.len()
+        );
+
+        // Reported separately from the byte-identical check below so a
+        // prune-logic regression that only over-accepts (P0 soundness) is
+        // distinguishable from a broader mismatch (which could also include
+        // under-accepts).
+        assert!(
+            over_accepts.is_empty(),
+            "trie over-accepted {} token(s) the oracle rejects on the real \
+             vocab (P0 soundness violation): {:?}",
+            over_accepts.len(),
+            over_accepts
+                .iter()
+                .take(5)
+                .map(|(state_idx, tok)| (
+                    state_idx,
+                    tok,
+                    String::from_utf8_lossy(&vocab[*tok]).to_string()
+                ))
+                .collect::<Vec<_>>()
+        );
+
+        assert!(
+            mismatches.is_empty(),
+            "trie mask diverged from oracle mask on {} (state, token) pair(s) \
+             over the real vocab: {:?}",
+            mismatches.len(),
+            mismatches
+                .iter()
+                .take(5)
+                .map(|(state_idx, tok)| (
+                    state_idx,
+                    tok,
+                    String::from_utf8_lossy(&vocab[*tok]).to_string()
+                ))
+                .collect::<Vec<_>>()
+        );
+
+        eprintln!(
+            "real_vocab differential: vocab_size={} corpus_states={} \
+             over_cap_states={over_cap_states} over_accepts=0 mismatches=0",
+            vocab.len(),
+            corpus.len(),
+        );
+    }
 }

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -39,8 +39,11 @@ use crate::grammar::pda::{
     CompiledGrammar, GrammarState, SimResult, StepResult, advance_byte, simulate_token,
 };
 use crate::grammar::spec::GrammarSpec;
+use crate::grammar::trie::ByteTrie;
 use crate::grammar::vocab_partition::VocabPartition;
 use std::fmt;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 // ---------------------------------------------------------------------------
 // Profiling instrumentation (issue #734 diagnostics)
@@ -262,9 +265,18 @@ pub struct GrammarEngine {
     vocab_bytes: Vec<Vec<u8>>,
     /// Set when state enumeration in `new` hit `MAX_GRAMMAR_STATES` before
     /// exhausting the reachable state graph: some runtime states then have
-    /// no precomputed mask and fall back to `mask_by_simulation` (a
-    /// full-vocab scan per token). See `exceeds_state_budget`.
+    /// no precomputed mask and fall back to `mask_by_trie`. See
+    /// `exceeds_state_budget`.
     state_limit_exceeded: bool,
+    /// Byte trie over `vocab_bytes`, used by `mask_by_trie` for states with
+    /// no precomputed mask. Built lazily on first use (`OnceLock`) so
+    /// grammars that never exceed `MAX_GRAMMAR_STATES` — the common case —
+    /// never pay the build cost.
+    trie: OnceLock<ByteTrie>,
+    /// Nanoseconds spent building `trie`, captured the one time
+    /// `trie.get_or_init` actually runs the builder. Zero until the trie
+    /// has been built at least once.
+    trie_build_ns: AtomicU64,
 }
 
 impl GrammarEngine {
@@ -326,7 +338,17 @@ impl GrammarEngine {
             vocab_size,
             vocab_bytes,
             state_limit_exceeded,
+            trie: OnceLock::new(),
+            trie_build_ns: AtomicU64::new(0),
         })
+    }
+
+    /// Nanoseconds spent building the byte trie used by `mask_by_trie`, or 0
+    /// if the trie has not been built yet (grammar never hit an over-cap
+    /// state, or none has been masked yet). Diagnostic accessor for
+    /// self-measurement harnesses.
+    pub fn trie_build_ns(&self) -> u64 {
+        self.trie_build_ns.load(Ordering::Relaxed)
     }
 
     /// True when state enumeration hit `MAX_GRAMMAR_STATES` (256) before
@@ -432,13 +454,14 @@ impl GrammarEngine {
                 // be unsound: tokens valid only at position 0 (e.g. an opening
                 // quote) would be left allowed at a deep state, and single-byte
                 // tokens are not in the context-dependent recheck set, so nothing
-                // would correct them. Compute the exact mask by simulating every
-                // token against the actual state instead. This is the universal
-                // algorithm the precomputed table caches; it is sound and live
-                // (a fully fail-closed "block everything" fallback would be sound
-                // but would stall generation by leaving no legal token).
+                // would correct them. Compute the exact mask via the byte trie
+                // instead — same contract as `mask_by_simulation` (only cheaper:
+                // a rejected byte prunes every token sharing that prefix in one
+                // step instead of re-walking each one independently).
+                // `mask_by_simulation` stays available as the oracle for the
+                // differential tests below and as a manual fallback.
                 let t0 = profiling.then(std::time::Instant::now);
-                self.mask_by_simulation(state, logits);
+                self.mask_by_trie(state, logits);
                 if let Some(t0) = t0 {
                     let ns = find_ns + t0.elapsed().as_nanos() as u64;
                     MASK_PROFILE.with(|p| {
@@ -453,12 +476,14 @@ impl GrammarEngine {
 
     /// Compute the grammar mask for `state` directly by simulating every token.
     ///
-    /// Used as the exact fallback for runtime states that are not present in the
-    /// precomputed partition (grammars exceeding `MAX_GRAMMAR_STATES`). Blocks
-    /// every token whose byte sequence does not fully advance the PDA from
-    /// `state`. Cost: O(vocab_size × token_len); only invoked on the unknown-state
-    /// path, never for grammars within the state cap.
-    fn mask_by_simulation(&self, state: &GrammarState, logits: &mut [f32]) {
+    /// This was the over-cap fallback in `mask_logits` before the byte-trie
+    /// path (`mask_by_trie`) replaced it on the hot path (issue #734: this
+    /// full-vocab independent simulation is O(vocab_size × token_len) and
+    /// dominates decode-step wall time for schemas that exceed
+    /// `MAX_GRAMMAR_STATES`). It defines the mask contract `mask_by_trie`
+    /// must reproduce exactly and stays public as the oracle for the
+    /// differential tests below and as a slow-path manual escape hatch.
+    pub fn mask_by_simulation(&self, state: &GrammarState, logits: &mut [f32]) {
         for token_id in 0..self.vocab_size {
             if logits[token_id] == f32::NEG_INFINITY {
                 continue;
@@ -473,6 +498,23 @@ impl GrammarEngine {
                 logits[token_id] = f32::NEG_INFINITY;
             }
         }
+    }
+
+    /// Compute the grammar mask for `state` via the byte trie.
+    ///
+    /// Same contract as `mask_by_simulation` (see [`crate::grammar::trie`]),
+    /// used as the over-cap fallback in `mask_logits` in place of the
+    /// full-vocab independent simulation. Builds the trie on first use and
+    /// reuses it for every subsequent call against this engine.
+    fn mask_by_trie(&self, state: &GrammarState, logits: &mut [f32]) {
+        let trie = self.trie.get_or_init(|| {
+            let t0 = std::time::Instant::now();
+            let built = ByteTrie::build(&self.vocab_bytes);
+            self.trie_build_ns
+                .store(t0.elapsed().as_nanos() as u64, Ordering::Relaxed);
+            built
+        });
+        trie.mask(state, &self.grammar, self.vocab_size, logits);
     }
 
     /// Advance the grammar state by one token.
@@ -931,5 +973,293 @@ mod tests {
         for i in 2..130 {
             assert_eq!(logits[i], f32::NEG_INFINITY, "token {i} should be blocked");
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Trie-mask differential tests (issue #734 fix)
+    //
+    // `mask_by_trie` must reproduce `mask_by_simulation`'s mask bit for
+    // bit. These tests harvest a corpus of real grammar states from a
+    // generation trajectory against the exact schema shape
+    // `gramperf_profile` profiles (crates/inference/src/bin/
+    // gramperf_profile.rs), then compare the two algorithms directly.
+    // -----------------------------------------------------------------
+
+    /// The #734-shape schema from `gramperf_profile`: 4 nested object
+    /// levels, 3 array fields, 6 six-member string enums. Reused verbatim
+    /// (not approximated) so this corpus exercises the same structural
+    /// over-cap behavior the profiling report measured.
+    fn trie_diff_schema() -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "level1": {
+                    "type": "object",
+                    "properties": {
+                        "level2": {
+                            "type": "object",
+                            "properties": {
+                                "level3": {
+                                    "type": "object",
+                                    "properties": {
+                                        "level4": {
+                                            "type": "object",
+                                            "properties": {
+                                                "status": {"type": "string", "enum": ["active", "inactive", "pending", "archived", "deleted", "draft"]},
+                                                "value": {"type": "integer"}
+                                            },
+                                            "required": ["status", "value"]
+                                        }
+                                    },
+                                    "required": ["level4"]
+                                },
+                                "category": {"type": "string", "enum": ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"]}
+                            },
+                            "required": ["level3", "category"]
+                        },
+                        "tags": {"type": "array", "items": {"type": "string"}}
+                    },
+                    "required": ["level2", "tags"]
+                },
+                "items": {"type": "array", "items": {"type": "integer"}},
+                "flags": {"type": "array", "items": {"type": "boolean"}},
+                "priority": {"type": "string", "enum": ["low", "medium", "high", "urgent", "critical", "none"]},
+                "region": {"type": "string", "enum": ["us", "eu", "apac", "latam", "mea", "other"]},
+                "mode": {"type": "string", "enum": ["sync", "async", "batch", "stream", "manual", "auto"]},
+                "role": {"type": "string", "enum": ["admin", "user", "guest", "owner", "viewer", "editor"]}
+            },
+            "required": ["level1", "items", "flags", "priority", "region", "mode", "role"]
+        })
+    }
+
+    /// Synthetic vocabulary sized for fast unit tests (not the real 248K
+    /// tokenizer vocab): every single byte (so the trie branches fully at
+    /// every depth, matching the real vocab's near-total root fan-out)
+    /// plus multi-byte literal fragments drawn from the schema's property
+    /// names, enum members, and JSON keywords, so the trie also exercises
+    /// prefix-shared, straight-line multi-byte runs.
+    fn trie_diff_vocab() -> Vec<Vec<u8>> {
+        let mut vocab: Vec<Vec<u8>> = (0u16..256).map(|b| vec![b as u8]).collect();
+        let fragments: &[&str] = &[
+            "\"level1\"",
+            "\"level2\"",
+            "\"level3\"",
+            "\"level4\"",
+            "\"status\"",
+            "\"value\"",
+            "\"category\"",
+            "\"tags\"",
+            "\"items\"",
+            "\"flags\"",
+            "\"priority\"",
+            "\"region\"",
+            "\"mode\"",
+            "\"role\"",
+            "\"active\"",
+            "\"inactive\"",
+            "\"pending\"",
+            "\"archived\"",
+            "\"deleted\"",
+            "\"draft\"",
+            "\"alpha\"",
+            "\"beta\"",
+            "\"gamma\"",
+            "\"delta\"",
+            "\"epsilon\"",
+            "\"zeta\"",
+            "\"low\"",
+            "\"medium\"",
+            "\"high\"",
+            "\"urgent\"",
+            "\"critical\"",
+            "\"none\"",
+            "\"us\"",
+            "\"eu\"",
+            "\"apac\"",
+            "\"latam\"",
+            "\"mea\"",
+            "\"other\"",
+            "\"sync\"",
+            "\"async\"",
+            "\"batch\"",
+            "\"stream\"",
+            "\"manual\"",
+            "\"auto\"",
+            "\"admin\"",
+            "\"user\"",
+            "\"guest\"",
+            "\"owner\"",
+            "\"viewer\"",
+            "\"editor\"",
+            "true",
+            "false",
+            "null",
+        ];
+        for f in fragments {
+            vocab.push(f.as_bytes().to_vec());
+        }
+        vocab
+    }
+
+    /// A minified, schema-valid JSON instance. `serde_json::Value::Object`
+    /// is a `BTreeMap` in this workspace (no `preserve_order` feature), so
+    /// `compile_object`'s property order — and therefore the required-key
+    /// order the PDA enforces — is alphabetical-by-key, not `properties`
+    /// declaration order or `required`-array order; this instance's key
+    /// order at every nesting level is alphabetical to match (top:
+    /// flags, items, level1, mode, priority, region, role; level2:
+    /// category, level3 — note `category` sorts before `level3`). Walking
+    /// this byte-by-byte through the PDA is the "generation trajectory"
+    /// the corpus is harvested from: its byte positions span the initial
+    /// state (byte 0), deep nesting (into level1/level2/level3/level4),
+    /// inside-string (mid `"active`), inside-enum-literal (mid `"alpha`,
+    /// `"low`, `"sync`, ...), post-number (right after `42`, `1`, `2`,
+    /// `3`), and near-complete (the last few closing-brace bytes) — the
+    /// edge-state categories the correctness bar requires, without needing
+    /// a separate hand-built state per category.
+    const TRIE_DIFF_INSTANCE: &str = r#"{"flags":[true,false],"items":[1,2,3],"level1":{"level2":{"category":"alpha","level3":{"level4":{"status":"active","value":42}}},"tags":["x","y"]},"mode":"sync","priority":"low","region":"us","role":"admin"}"#;
+
+    /// Harvest a corpus of distinct grammar states by advancing `engine`
+    /// byte-by-byte through [`TRIE_DIFF_INSTANCE`], deduping by PDA
+    /// identity (`states_equal`, same identity `find_state_id` uses).
+    /// Panics with the failing byte position if the instance is rejected —
+    /// a silent partial trajectory would silently shrink the corpus
+    /// instead of failing the test that depends on its size.
+    fn harvest_trajectory_states(engine: &GrammarEngine) -> Vec<GrammarState> {
+        let mut state = engine.initial_state();
+        let mut corpus = vec![state.clone()];
+        for (i, &b) in TRIE_DIFF_INSTANCE.as_bytes().iter().enumerate() {
+            let step = advance_byte(&mut state, &engine.grammar, b);
+            assert_eq!(
+                step,
+                StepResult::Accepted,
+                "trajectory instance rejected at byte {i} ({:?}); fixture is out of \
+                 sync with the schema",
+                b as char
+            );
+            if !corpus.iter().any(|s| states_equal(s, &state)) {
+                corpus.push(state.clone());
+            }
+        }
+        assert!(
+            state.is_complete(),
+            "trajectory instance must fully complete the grammar"
+        );
+        corpus
+    }
+
+    #[test]
+    fn trie_mask_byte_identical_to_oracle_over_corpus() {
+        let vocab = trie_diff_vocab();
+        let spec = GrammarSpec::JsonSchema(trie_diff_schema());
+        let engine = GrammarEngine::new(&spec, vocab.clone()).unwrap();
+        assert!(
+            engine.exceeds_state_budget(),
+            "fixture must exceed the state cap for this differential to exercise \
+             the fallback path (the point of this test)"
+        );
+
+        let corpus = harvest_trajectory_states(&engine);
+        assert!(
+            corpus.len() >= 20,
+            "need at least 20 distinct harvested states, got {}",
+            corpus.len()
+        );
+
+        let mut over_cap_states = 0usize;
+        for (i, state) in corpus.iter().enumerate() {
+            let mut oracle_logits = vec![0.0f32; vocab.len()];
+            let mut trie_logits = vec![0.0f32; vocab.len()];
+            engine.mask_by_simulation(state, &mut oracle_logits);
+            engine.mask_by_trie(state, &mut trie_logits);
+            if engine.find_state_id(state).is_none() {
+                over_cap_states += 1;
+            }
+            for tok in 0..vocab.len() {
+                assert_eq!(
+                    trie_logits[tok],
+                    oracle_logits[tok],
+                    "state #{i}: token {tok} ({:?}) mismatch — trie={} oracle={}",
+                    String::from_utf8_lossy(&vocab[tok]),
+                    trie_logits[tok],
+                    oracle_logits[tok]
+                );
+            }
+        }
+        assert!(
+            over_cap_states >= 15,
+            "corpus should mostly cover the over-cap fallback path (the profiling \
+             report measured a 98% fallback rate on this schema shape); got \
+             {over_cap_states}/{}",
+            corpus.len()
+        );
+    }
+
+    #[test]
+    fn trie_mask_never_over_accepts_vs_oracle() {
+        // P0, reported separately from the byte-identical test above: this
+        // isolates the over-accept direction (trie allows a token the
+        // oracle rejects) so a prune-logic regression that only
+        // over-accepts is caught and reported distinctly from an
+        // under-accept regression.
+        let vocab = trie_diff_vocab();
+        let spec = GrammarSpec::JsonSchema(trie_diff_schema());
+        let engine = GrammarEngine::new(&spec, vocab.clone()).unwrap();
+        let corpus = harvest_trajectory_states(&engine);
+
+        let mut over_accepts: Vec<(usize, Vec<u8>)> = Vec::new();
+        for state in &corpus {
+            let mut oracle_logits = vec![0.0f32; vocab.len()];
+            let mut trie_logits = vec![0.0f32; vocab.len()];
+            engine.mask_by_simulation(state, &mut oracle_logits);
+            engine.mask_by_trie(state, &mut trie_logits);
+            for tok in 0..vocab.len() {
+                let oracle_blocked = oracle_logits[tok] == f32::NEG_INFINITY;
+                let trie_allowed = trie_logits[tok] != f32::NEG_INFINITY;
+                if oracle_blocked && trie_allowed {
+                    over_accepts.push((tok, vocab[tok].clone()));
+                }
+            }
+        }
+        assert!(
+            over_accepts.is_empty(),
+            "trie over-accepted {} token(s) the oracle rejects (P0 soundness \
+             violation): {:?}",
+            over_accepts.len(),
+            over_accepts
+                .iter()
+                .take(5)
+                .map(|(id, bytes)| (id, String::from_utf8_lossy(bytes).to_string()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn trie_routes_over_cap_states_through_mask_logits() {
+        // End-to-end wiring check: the public `mask_logits` entry point
+        // (not the private helpers) must actually route over-cap states
+        // through the trie and produce the same result as calling the
+        // oracle directly — guards against the routing edit in
+        // `mask_logits` silently going stale if the fallback call site
+        // changes again.
+        let vocab = trie_diff_vocab();
+        let spec = GrammarSpec::JsonSchema(trie_diff_schema());
+        let engine = GrammarEngine::new(&spec, vocab.clone()).unwrap();
+        let corpus = harvest_trajectory_states(&engine);
+        let deep_state = corpus
+            .iter()
+            .find(|s| engine.find_state_id(s).is_none())
+            .expect("corpus must contain at least one over-cap state");
+
+        let mut via_mask_logits = vec![0.0f32; vocab.len()];
+        let mut oracle_logits = vec![0.0f32; vocab.len()];
+        let mut state_for_public_call = deep_state.clone();
+        engine.mask_logits(&mut state_for_public_call, &mut via_mask_logits);
+        engine.mask_by_simulation(deep_state, &mut oracle_logits);
+
+        assert_eq!(
+            via_mask_logits, oracle_logits,
+            "mask_logits on an over-cap state must match the oracle mask exactly"
+        );
     }
 }

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -42,6 +42,129 @@ use crate::grammar::spec::GrammarSpec;
 use crate::grammar::vocab_partition::VocabPartition;
 use std::fmt;
 
+// ---------------------------------------------------------------------------
+// Profiling instrumentation (issue #734 diagnostics)
+// ---------------------------------------------------------------------------
+//
+// Thread-local, opt-in counters used by `gramperf_profile` (crates/inference/
+// src/bin/gramperf_profile.rs) to break decode-step cost down into the
+// precomputed-bitmask path, the context-dependent recheck loop, and the
+// `mask_by_simulation` fallback, without touching any call site outside this
+// file. Disabled by default (`mask_profiling_enabled()` short-circuits on a
+// single `Cell<bool>` read), so production decode pays no cost beyond that
+// one branch when profiling is off.
+
+thread_local! {
+    static MASK_PROFILING_ENABLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static MASK_PROFILE: std::cell::RefCell<MaskProfile> =
+        const { std::cell::RefCell::new(MaskProfile::new()) };
+    static BUILD_PROFILE: std::cell::RefCell<BuildProfile> =
+        const { std::cell::RefCell::new(BuildProfile::new()) };
+}
+
+/// Aggregated per-decode-step grammar-masking cost, accumulated across every
+/// `mask_logits`/`advance` call since the last [`enable_mask_profiling`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MaskProfile {
+    /// Precomputed-bitmask path: `find_state_id` (hit) + `VocabPartition::apply_mask`.
+    pub precomputed_calls: u64,
+    pub precomputed_ns: u64,
+    /// Context-dependent token recheck loop (runs only on the precomputed-hit path).
+    pub context_recheck_calls: u64,
+    pub context_recheck_ns: u64,
+    /// `mask_by_simulation` fallback: `find_state_id` (miss) + full-vocab simulation.
+    pub fallback_calls: u64,
+    pub fallback_ns: u64,
+    /// `GrammarEngine::advance` (PDA byte-stepping), tracked separately so it
+    /// is not misattributed to either masking path in the report.
+    pub advance_calls: u64,
+    pub advance_ns: u64,
+}
+
+impl MaskProfile {
+    const fn new() -> Self {
+        Self {
+            precomputed_calls: 0,
+            precomputed_ns: 0,
+            context_recheck_calls: 0,
+            context_recheck_ns: 0,
+            fallback_calls: 0,
+            fallback_ns: 0,
+            advance_calls: 0,
+            advance_ns: 0,
+        }
+    }
+}
+
+/// One-time `GrammarEngine::new` cost breakdown, overwritten on every call
+/// (unconditional — construction is a once-per-schema event, so the two
+/// extra `Instant::now()` calls are immaterial next to the multi-second
+/// build itself).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BuildProfile {
+    pub bfs_ns: u64,
+    pub partition_build_ns: u64,
+    /// `enumerate_grammar_states`'s returned state count, which is *itself*
+    /// capped at the `max_states` argument passed to it — see
+    /// `probe_reachable_states` for the uncapped count.
+    pub reachable_states: usize,
+    pub capped_states: usize,
+}
+
+impl BuildProfile {
+    const fn new() -> Self {
+        Self {
+            bfs_ns: 0,
+            partition_build_ns: 0,
+            reachable_states: 0,
+            capped_states: 0,
+        }
+    }
+}
+
+/// Enable per-decode-step mask profiling on the current thread and reset the
+/// accumulator. Call [`take_mask_profile`] after the measured run(s).
+pub fn enable_mask_profiling() {
+    MASK_PROFILING_ENABLED.with(|e| e.set(true));
+    MASK_PROFILE.with(|p| *p.borrow_mut() = MaskProfile::new());
+}
+
+/// Disable mask profiling and return the accumulated [`MaskProfile`].
+pub fn take_mask_profile() -> MaskProfile {
+    MASK_PROFILING_ENABLED.with(|e| e.set(false));
+    MASK_PROFILE.with(|p| *p.borrow())
+}
+
+fn mask_profiling_enabled() -> bool {
+    MASK_PROFILING_ENABLED.with(std::cell::Cell::get)
+}
+
+/// Return the [`BuildProfile`] captured by the most recent `GrammarEngine::new`
+/// call on this thread.
+pub fn last_build_profile() -> BuildProfile {
+    BUILD_PROFILE.with(|p| *p.borrow())
+}
+
+/// Profiling-only probe: run `enumerate_grammar_states` with an arbitrary
+/// `max_states` ceiling (independent of `MAX_GRAMMAR_STATES`) and return how
+/// many states it found. Because `enumerate_grammar_states` stops growing
+/// `visited` once it reaches `max_states`, `GrammarEngine::new`'s own BFS
+/// output is *already* capped when a grammar exceeds the production limit —
+/// this is the only way to see the true reachable-state count past the cap.
+/// Never called from production code paths; used solely by
+/// `gramperf_profile` (issue #734).
+pub fn probe_reachable_states(
+    spec: &GrammarSpec,
+    vocab_bytes: &[Vec<u8>],
+    max_states: usize,
+) -> Result<usize, GrammarError> {
+    let grammar = match spec {
+        GrammarSpec::JsonSchema(schema) => compile(schema)?,
+        GrammarSpec::Gbnf(gbnf) => parse_gbnf(gbnf)?,
+    };
+    Ok(enumerate_grammar_states(&grammar, vocab_bytes, max_states).len())
+}
+
 /// Error from `GrammarEngine::new`.
 #[derive(Debug, Clone)]
 pub struct GrammarError(pub String);
@@ -165,11 +288,13 @@ impl GrammarEngine {
 
         // Enumerate grammar states reachable from the initial state.
         // We limit to MAX_GRAMMAR_STATES to bound memory usage.
+        let bfs_t0 = std::time::Instant::now();
         let states = enumerate_grammar_states(
             &grammar,
             &vocab_bytes,
             crate::grammar::vocab_partition::MAX_GRAMMAR_STATES,
         );
+        let bfs_ns = bfs_t0.elapsed().as_nanos() as u64;
 
         let state_limit_exceeded =
             states.len() >= crate::grammar::vocab_partition::MAX_GRAMMAR_STATES;
@@ -179,9 +304,21 @@ impl GrammarEngine {
                 crate::grammar::vocab_partition::MAX_GRAMMAR_STATES
             );
         }
+        let reachable_states = states.len();
 
         // Build the vocabulary partition.
+        let partition_t0 = std::time::Instant::now();
         let partition = VocabPartition::build(&grammar, states, &vocab_bytes);
+        let partition_build_ns = partition_t0.elapsed().as_nanos() as u64;
+
+        BUILD_PROFILE.with(|p| {
+            *p.borrow_mut() = BuildProfile {
+                bfs_ns,
+                partition_build_ns,
+                reachable_states,
+                capped_states: crate::grammar::vocab_partition::MAX_GRAMMAR_STATES,
+            }
+        });
 
         Ok(Self {
             grammar,
@@ -231,13 +368,28 @@ impl GrammarEngine {
             self.vocab_size
         );
 
+        let profiling = mask_profiling_enabled();
+        let find_t0 = profiling.then(std::time::Instant::now);
+        let found = self.find_state_id(state);
+        let find_ns = find_t0.map(|t| t.elapsed().as_nanos() as u64).unwrap_or(0);
+
         // Find the state id in the partition.
-        match self.find_state_id(state) {
+        match found {
             Some(state_id) => {
                 // Apply the precomputed bitmask.
+                let t0 = profiling.then(std::time::Instant::now);
                 self.partition.apply_mask(state_id, logits);
+                if let Some(t0) = t0 {
+                    let ns = find_ns + t0.elapsed().as_nanos() as u64;
+                    MASK_PROFILE.with(|p| {
+                        let mut p = p.borrow_mut();
+                        p.precomputed_calls += 1;
+                        p.precomputed_ns += ns;
+                    });
+                }
 
                 // Re-check context-dependent tokens at runtime.
+                let t1 = profiling.then(std::time::Instant::now);
                 for &token_id in self.partition.context_dependent_ids() {
                     if token_id >= self.vocab_size {
                         continue;
@@ -264,6 +416,14 @@ impl GrammarEngine {
                         SimResult::Accept => {}
                     }
                 }
+                if let Some(t1) = t1 {
+                    let ns = t1.elapsed().as_nanos() as u64;
+                    MASK_PROFILE.with(|p| {
+                        let mut p = p.borrow_mut();
+                        p.context_recheck_calls += 1;
+                        p.context_recheck_ns += ns;
+                    });
+                }
             }
             None => {
                 // The grammar exceeded `MAX_GRAMMAR_STATES`, so the BFS state
@@ -277,7 +437,16 @@ impl GrammarEngine {
                 // algorithm the precomputed table caches; it is sound and live
                 // (a fully fail-closed "block everything" fallback would be sound
                 // but would stall generation by leaving no legal token).
+                let t0 = profiling.then(std::time::Instant::now);
                 self.mask_by_simulation(state, logits);
+                if let Some(t0) = t0 {
+                    let ns = find_ns + t0.elapsed().as_nanos() as u64;
+                    MASK_PROFILE.with(|p| {
+                        let mut p = p.borrow_mut();
+                        p.fallback_calls += 1;
+                        p.fallback_ns += ns;
+                    });
+                }
             }
         }
     }
@@ -313,6 +482,21 @@ impl GrammarEngine {
     /// the grammar rejected it (caller should treat this as an error and stop
     /// generation).
     pub fn advance(&self, state: &mut GrammarState, token_id: u32) -> bool {
+        let profiling = mask_profiling_enabled();
+        let t0 = profiling.then(std::time::Instant::now);
+        let result = self.advance_inner(state, token_id);
+        if let Some(t0) = t0 {
+            let ns = t0.elapsed().as_nanos() as u64;
+            MASK_PROFILE.with(|p| {
+                let mut p = p.borrow_mut();
+                p.advance_calls += 1;
+                p.advance_ns += ns;
+            });
+        }
+        result
+    }
+
+    fn advance_inner(&self, state: &mut GrammarState, token_id: u32) -> bool {
         let token_id = token_id as usize;
         if token_id >= self.vocab_size {
             return false;

--- a/crates/inference/src/grammar/mod.rs
+++ b/crates/inference/src/grammar/mod.rs
@@ -69,6 +69,7 @@ pub mod gbnf;
 pub mod json_schema;
 pub mod pda;
 pub mod spec;
+pub mod trie;
 pub mod vocab_partition;
 
 // Re-exports for the primary public API.

--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -107,7 +107,13 @@ impl CompiledGrammar {
 }
 
 /// One frame on the PDA execution stack.
-#[derive(Debug, Clone, PartialEq)]
+///
+/// `Eq + Hash` (added alongside `PartialEq`, structurally over the same
+/// fields) let a `GrammarState`'s `(stack, complete)` pair — the same
+/// identity `states_equal` in `engine.rs` already compares by — key a
+/// `HashMap` for state-revisit / memoization profiling without changing any
+/// existing comparison semantics.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StackFrame {
     /// Index into `CompiledGrammar::rules`.
     pub rule_id: usize,

--- a/crates/inference/src/grammar/trie.rs
+++ b/crates/inference/src/grammar/trie.rs
@@ -1,0 +1,249 @@
+//! Trie-accelerated vocabulary masking for grammar states outside the
+//! precomputed `VocabPartition` (issue #734).
+//!
+//! # Motivation
+//!
+//! `GrammarEngine::mask_by_simulation` computes the mask for a runtime state
+//! that has no precomputed bitmask by running `simulate_token` independently
+//! for every vocabulary token: O(vocab_size × token_len) byte-walks, almost
+//! all of which reject on the very first byte. A byte trie built once over
+//! `vocab_bytes` lets the PDA walk the *shared prefix structure* of the
+//! vocabulary instead: a single rejected byte transition at a trie node
+//! prunes every token beneath it in one step, since they all share that
+//! prefix and would reject identically.
+//!
+//! # Mask contract
+//!
+//! [`ByteTrie::mask`] reproduces `mask_by_simulation`'s contract bit for bit:
+//! a token is allowed iff `simulate_token(state, grammar, token_bytes)`
+//! would return `SimResult::Accept` — i.e. every byte of the token is
+//! accepted by the PDA in order, with no rejection at any position. Both
+//! `SimResult::Reject` (first-byte rejection) and `SimResult::ContextDependent`
+//! (rejection after a partial prefix) block the token identically: a DFS
+//! walk that fails to reach a token's terminal trie node covers both cases
+//! without needing to distinguish them.
+//!
+//! # DFS state handling
+//!
+//! Trie construction is independent of any grammar (it depends only on
+//! `vocab_bytes`), so the same trie is reused across every over-cap
+//! `mask_logits` call for a given engine. Masking DFS-walks the trie
+//! carrying a live `GrammarState`, calling `advance_byte` once per trie
+//! edge:
+//!
+//! - A rejected edge prunes the whole subtree below it (no recursion).
+//! - An accepted edge whose destination node has terminal token ids marks
+//!   those tokens allowed (the path from root to that node — and therefore
+//!   every byte of that token — was accepted).
+//!
+//! `GrammarState` clones are O(stack depth) (pda.rs), typically 2-8 frames,
+//! but a naive "clone before every child" DFS would pay that cost at every
+//! trie edge, including long straight-line runs (nodes with exactly one
+//! child) where no other branch needs the pre-advance state. The DFS here
+//! clones only when a node has more than one child (clone for every child
+//! but the last; the last child reuses the caller's owned state by move),
+//! so straight-line chains — the common case for byte-level BPE tokens
+//! after the first few branching bytes — advance in place with zero clones.
+
+use crate::grammar::pda::{CompiledGrammar, GrammarState, StepResult, advance_byte};
+
+/// One node in the byte trie. Children are kept as a small sorted-free
+/// association list rather than a fixed 256-entry table: vocab tries are
+/// deep and sparse (most nodes have very few children), so a `Vec` avoids
+/// paying 256 pointers per node.
+struct TrieNode {
+    /// `(byte, child_node_index)`, insertion order (not sorted — node
+    /// fan-out is small enough that a linear scan beats maintaining order).
+    children: Vec<(u8, u32)>,
+    /// Token ids whose full byte sequence ends exactly at this node.
+    /// Almost always empty or length 1; multiple ids only when the
+    /// vocabulary contains duplicate byte sequences under different ids.
+    terminals: Vec<u32>,
+}
+
+/// A byte trie over a model vocabulary, built once and reused for every
+/// masking call against that vocabulary.
+pub struct ByteTrie {
+    /// Arena of nodes; index 0 is always the root (zero bytes consumed).
+    nodes: Vec<TrieNode>,
+}
+
+impl ByteTrie {
+    /// Build a trie over `vocab_bytes`. Empty-byte tokens are not inserted
+    /// (they are unconditionally blocked, matching `mask_by_simulation`'s
+    /// explicit empty-token handling) — they simply never get a set mask
+    /// bit, which is the correct "blocked" default.
+    pub fn build(vocab_bytes: &[Vec<u8>]) -> Self {
+        let mut nodes = vec![TrieNode {
+            children: Vec::new(),
+            terminals: Vec::new(),
+        }];
+
+        for (token_id, bytes) in vocab_bytes.iter().enumerate() {
+            if bytes.is_empty() {
+                continue;
+            }
+            let mut cur = 0u32;
+            for &b in bytes {
+                cur = match nodes[cur as usize]
+                    .children
+                    .iter()
+                    .find(|&&(cb, _)| cb == b)
+                {
+                    Some(&(_, child)) => child,
+                    None => {
+                        let new_idx = nodes.len() as u32;
+                        nodes.push(TrieNode {
+                            children: Vec::new(),
+                            terminals: Vec::new(),
+                        });
+                        nodes[cur as usize].children.push((b, new_idx));
+                        new_idx
+                    }
+                };
+            }
+            nodes[cur as usize].terminals.push(token_id as u32);
+        }
+
+        Self { nodes }
+    }
+
+    /// Compute the grammar mask for `state` by DFS-walking the trie, and
+    /// apply it to `logits` in place (same contract as
+    /// `GrammarEngine::mask_by_simulation`: sets disallowed positions to
+    /// `f32::NEG_INFINITY`, leaves allowed positions' original values
+    /// untouched).
+    pub fn mask(
+        &self,
+        state: &GrammarState,
+        grammar: &CompiledGrammar,
+        vocab_size: usize,
+        logits: &mut [f32],
+    ) {
+        let mask_stride = vocab_size.div_ceil(64);
+        let mut allowed = vec![0u64; mask_stride];
+        mark_allowed(&self.nodes, 0, state.clone(), grammar, &mut allowed);
+        apply_allowed_mask(&allowed, vocab_size, logits);
+    }
+}
+
+/// DFS from `node_idx` carrying an owned live `state`. Marks every
+/// terminal token reachable via an all-accepted byte path as allowed in
+/// `allowed`.
+fn mark_allowed(
+    nodes: &[TrieNode],
+    node_idx: u32,
+    state: GrammarState,
+    grammar: &CompiledGrammar,
+    allowed: &mut [u64],
+) {
+    let node = &nodes[node_idx as usize];
+    for &token_id in &node.terminals {
+        let idx = token_id as usize;
+        allowed[idx / 64] |= 1u64 << (idx % 64);
+    }
+
+    let children = &node.children;
+    let Some((&last, rest)) = children.split_last() else {
+        return;
+    };
+
+    // Every non-last child needs its own state: cloning here (rather than
+    // unconditionally on every recursive call) is what keeps straight-line
+    // single-child runs — the common case past the first few bytes of a
+    // token — clone-free.
+    for &(byte, child_idx) in rest {
+        let mut child_state = state.clone();
+        if advance_byte(&mut child_state, grammar, byte) == StepResult::Accepted {
+            mark_allowed(nodes, child_idx, child_state, grammar, allowed);
+        }
+    }
+
+    // Last child reuses (moves) the caller's owned state — no clone.
+    let (byte, child_idx) = last;
+    let mut last_state = state;
+    if advance_byte(&mut last_state, grammar, byte) == StepResult::Accepted {
+        mark_allowed(nodes, child_idx, last_state, grammar, allowed);
+    }
+}
+
+/// Apply a bitmask (1 = allowed) to `logits`, blocking every position whose
+/// bit is unset. Word-scanning structure mirrors
+/// `VocabPartition::apply_mask` (skip all-allowed words, fast-fill
+/// all-blocked words).
+fn apply_allowed_mask(allowed: &[u64], vocab_size: usize, logits: &mut [f32]) {
+    let mask_stride = allowed.len();
+    for word_idx in 0..mask_stride {
+        let word = allowed[word_idx];
+        let base_token = word_idx * 64;
+        if word == u64::MAX {
+            continue;
+        }
+        if word == 0 {
+            let end = (base_token + 64).min(vocab_size);
+            for l in logits[base_token..end].iter_mut() {
+                *l = f32::NEG_INFINITY;
+            }
+            continue;
+        }
+        for bit in 0..64u32 {
+            let token_idx = base_token + bit as usize;
+            if token_idx >= vocab_size {
+                break;
+            }
+            if word & (1u64 << bit) == 0 {
+                logits[token_idx] = f32::NEG_INFINITY;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grammar::pda::{GrammarBuilder, Symbol};
+
+    /// Grammar: root = 'a' | 'b'
+    fn or_grammar() -> CompiledGrammar {
+        let mut b = GrammarBuilder::new();
+        b.add_rule(
+            "root",
+            vec![vec![Symbol::Terminal(b'a')], vec![Symbol::Terminal(b'b')]],
+        );
+        b.build()
+    }
+
+    #[test]
+    fn trie_build_shares_prefixes() {
+        let vocab = vec![b"ab".to_vec(), b"ac".to_vec(), b"b".to_vec()];
+        let trie = ByteTrie::build(&vocab);
+        // root -> 'a' -> {'b','c'} ; root -> 'b'. Node count: root, a, ab,
+        // ac, b(root's) = 5.
+        assert_eq!(trie.nodes.len(), 5);
+    }
+
+    #[test]
+    fn trie_mask_matches_simple_grammar() {
+        let vocab = vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()];
+        let grammar = or_grammar();
+        let trie = ByteTrie::build(&vocab);
+        let state = GrammarState::initial();
+        let mut logits = vec![1.0f32, 2.0f32, 3.0f32];
+        trie.mask(&state, &grammar, vocab.len(), &mut logits);
+        assert!(logits[0] > f32::NEG_INFINITY, "'a' allowed");
+        assert!(logits[1] > f32::NEG_INFINITY, "'b' allowed");
+        assert_eq!(logits[2], f32::NEG_INFINITY, "'c' blocked");
+    }
+
+    #[test]
+    fn trie_mask_empty_token_blocked() {
+        let vocab = vec![b"a".to_vec(), vec![]];
+        let grammar = or_grammar();
+        let trie = ByteTrie::build(&vocab);
+        let state = GrammarState::initial();
+        let mut logits = vec![1.0f32, 1.0f32];
+        trie.mask(&state, &grammar, vocab.len(), &mut logits);
+        assert!(logits[0] > f32::NEG_INFINITY);
+        assert_eq!(logits[1], f32::NEG_INFINITY, "empty token always blocked");
+    }
+}

--- a/crates/inference/src/grammar/trie.rs
+++ b/crates/inference/src/grammar/trie.rs
@@ -44,8 +44,31 @@
 //! but the last; the last child reuses the caller's owned state by move),
 //! so straight-line chains — the common case for byte-level BPE tokens
 //! after the first few branching bytes — advance in place with zero clones.
+//!
+//! That O(stack depth) bound depends on the walk starting from a state
+//! whose `partial_token_bytes` is empty, not a clone of the live decode
+//! state's. `advance_byte` unconditionally appends to that field, and the
+//! live state passed into `mask` has one entry per byte generated so far
+//! in the whole decode — cloning it as the walk root would make every
+//! DFS clone O(stack depth + bytes generated so far) instead. See
+//! [`walk_root_state`] for the fix.
 
 use crate::grammar::pda::{CompiledGrammar, GrammarState, StepResult, advance_byte};
+
+// Reused across every `ByteTrie::mask` call on this thread so the hot
+// over-cap path doesn't heap-allocate a fresh `vocab_size / 64`-word bitvec
+// every time (issue #734 follow-up: this buffer was previously a
+// `vec![0u64; stride]` per call, ~31KB of allocator traffic at 248K-token
+// vocab). `ByteTrie::mask` takes `&self`, so a `RefCell` field can't hand
+// out a mutably-borrowed buffer across calls without risking a
+// double-borrow if `mask` were ever re-entered on the same thread; it
+// isn't (the DFS never calls back into `mask`), so a plain thread-local
+// scratch buffer is sound and avoids that hazard entirely — concurrent
+// callers on other threads each get their own buffer, so there's no data
+// race to reason about either.
+thread_local! {
+    static MASK_SCRATCH: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
+}
 
 /// One node in the byte trie. Children are kept as a small sorted-free
 /// association list rather than a fixed 256-entry table: vocab tries are
@@ -121,9 +144,40 @@ impl ByteTrie {
         logits: &mut [f32],
     ) {
         let mask_stride = vocab_size.div_ceil(64);
-        let mut allowed = vec![0u64; mask_stride];
-        mark_allowed(&self.nodes, 0, state.clone(), grammar, &mut allowed);
-        apply_allowed_mask(&allowed, vocab_size, logits);
+        MASK_SCRATCH.with(|scratch| {
+            let mut allowed = scratch.borrow_mut();
+            allowed.clear();
+            allowed.resize(mask_stride, 0u64);
+            mark_allowed(
+                &self.nodes,
+                0,
+                walk_root_state(state),
+                grammar,
+                &mut allowed,
+            );
+            apply_allowed_mask(&allowed, vocab_size, logits);
+        });
+    }
+}
+
+/// Build the DFS walk's root state from the live decode-step `state`.
+///
+/// Carries a clone of `stack` and `complete` (the only fields `advance_byte`
+/// and `is_accepting` ever read) but starts `partial_token_bytes` empty
+/// instead of cloning the live state's history. `advance_byte` (pda.rs)
+/// unconditionally *appends* to `partial_token_bytes` and nothing in PDA
+/// matching ever reads it — it exists only for external context-dependent
+/// inspection of a state returned to a caller, which the trie walk's
+/// throwaway internal states are not. Cloning the live field here would
+/// make every non-last-child DFS clone (`mark_allowed`) pay for the entire
+/// generated-so-far byte history instead of O(stack depth), since
+/// `partial_token_bytes` grows once per accepted byte for the whole
+/// decode, not just within one trie walk.
+fn walk_root_state(state: &GrammarState) -> GrammarState {
+    GrammarState {
+        stack: state.stack.clone(),
+        partial_token_bytes: Vec::new(),
+        complete: state.complete,
     }
 }
 
@@ -245,5 +299,70 @@ mod tests {
         trie.mask(&state, &grammar, vocab.len(), &mut logits);
         assert!(logits[0] > f32::NEG_INFINITY);
         assert_eq!(logits[1], f32::NEG_INFINITY, "empty token always blocked");
+    }
+
+    /// Regression test for the over-cap trie-mask hot path (issue #734
+    /// follow-up): `mark_allowed`'s DFS clones must never carry the live
+    /// decode state's `partial_token_bytes` history. `advance_byte`
+    /// (pda.rs) appends to that field on every accepted byte for the
+    /// *whole* decode, and nothing in PDA matching (`try_advance_stack`,
+    /// `is_accepting`) ever reads it back. If the walk root cloned it,
+    /// every non-last-child DFS clone in `mark_allowed` would copy the
+    /// entire generated-so-far history instead of paying only for the
+    /// stack.
+    ///
+    /// Mutation-sensitive: reverting `walk_root_state` to `state.clone()`
+    /// makes this fail immediately, since `root.partial_token_bytes` would
+    /// equal the 64KB history instead of being empty. Verified by hand:
+    /// temporarily replacing the body with `state.clone()` and re-running
+    /// this test fails on the `is_empty()` assertion; restoring the fix
+    /// makes it pass again.
+    #[test]
+    fn trie_walk_root_state_drops_partial_token_bytes() {
+        let mut state = GrammarState::initial();
+        // Representative of a long-running decode: `partial_token_bytes`
+        // grows by one entry per accepted byte across the whole
+        // generation, not just within one trie walk.
+        state.partial_token_bytes = vec![b'x'; 64 * 1024];
+
+        let root = walk_root_state(&state);
+
+        assert!(
+            root.partial_token_bytes.is_empty(),
+            "walk root must start with empty partial_token_bytes regardless \
+             of the live state's history length (got {} bytes) — a full \
+             state.clone() here reintroduces O(generation-so-far) DFS clones",
+            root.partial_token_bytes.len()
+        );
+        assert_eq!(root.stack, state.stack, "walk root must preserve stack");
+        assert_eq!(
+            root.complete, state.complete,
+            "walk root must preserve the complete flag"
+        );
+    }
+
+    /// End-to-end companion to the unit test above: the mask output must
+    /// not depend on how much byte history the live state carries in
+    /// `partial_token_bytes`, since the trie walk never reads that field
+    /// through a cloned live state.
+    #[test]
+    fn trie_mask_byte_identical_regardless_of_partial_token_bytes_history() {
+        let vocab = vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()];
+        let grammar = or_grammar();
+        let trie = ByteTrie::build(&vocab);
+
+        let clean_state = GrammarState::initial();
+        let mut clean_logits = vec![1.0f32, 2.0f32, 3.0f32];
+        trie.mask(&clean_state, &grammar, vocab.len(), &mut clean_logits);
+
+        let mut heavy_state = GrammarState::initial();
+        heavy_state.partial_token_bytes = vec![b'x'; 64 * 1024];
+        let mut heavy_logits = vec![1.0f32, 2.0f32, 3.0f32];
+        trie.mask(&heavy_state, &grammar, vocab.len(), &mut heavy_logits);
+
+        assert_eq!(
+            clean_logits, heavy_logits,
+            "mask output must be independent of partial_token_bytes history"
+        );
     }
 }


### PR DESCRIPTION
## Problem (#734)

Grammar-constrained decode on schemas whose compiled PDA exceeds `MAX_GRAMMAR_STATES` (256) was ~15x slower than unconstrained decode. Profiling (committed harness, `gramperf_profile`) on a 4-level-nested JSON schema measured the mechanism precisely:

- 147 of 150 decode steps (98%) missed the precomputed `VocabPartition` table and fell back to `mask_by_simulation`
- that fallback ran an independent `simulate_token` byte-walk for every one of the 248,320 vocab tokens, every step: **114.11 ms/step, 91.1% of the 125.25 ms/step wall time**
- 99.83%+ of the vocab is blocked per step, and almost all rejections happen on the first byte or two

## Fix

`ByteTrie` (new `crates/inference/src/grammar/trie.rs`): a byte trie over `vocab_bytes`, built lazily once per engine (`OnceLock`, first over-cap `mask_logits` call) and reused. The mask is computed by DFS-walking the trie with a live PDA state: a rejected byte edge prunes every token sharing that prefix in one step, instead of re-walking each token independently. Clone-on-branch state handling: only nodes with >1 child clone the PDA state (O(stack depth)); straight-line runs — the common case past the first bytes of a BPE token — advance in place with zero clones.

`mask_logits`'s over-cap fallback now routes to `mask_by_trie`. The precomputed-table path for in-cap states is untouched. `mask_by_simulation` stays (now `pub`) as the reference oracle.

Semantics are identical by construction: `simulate_token` returns `Accept` iff every `advance_byte` accepts, and reaching a trie terminal requires exactly that same all-accepted byte path. Both `Reject` and `ContextDependent` (a rejected byte at position 0 vs >0) block a token identically in the oracle, and both are covered by the same pruned-edge condition in the trie walk.

## Correctness evidence

- **Differential tests vs the oracle** (`engine.rs` tests): byte-identical mask comparison (`mask_by_trie` vs `mask_by_simulation`) over a corpus of ≥20 distinct PDA states harvested from a schema-valid trajectory on the #734-shape schema (29 states, ≥15 over-cap asserted), plus a **dedicated over-accept test** reported separately (a token allowed by the trie but rejected by the oracle is a soundness bug, strictly worse than a slow mask).
- **Real-vocabulary differential** (`#[ignore]`-gated, needs a local model checkout): same comparison over the full real Qwen3.5 tokenizer vocab — 248,320 tokens, 208 harvested states (204 over-cap): **0 mismatches, 0 over-accepts**. Run:
  `cargo test -p lattice-inference --release --features "f16,metal-gpu" --lib real_vocab -- --ignored --nocapture`
- **Mutation-sensitivity** (verified, not committed): disabling the subtree-prune check → over-accept test fails (62,937 over-accepts); inverting the mask apply-bit → all trie tests fail. Both mutations restored; re-verified independently after commit.
- **End-to-end routing test** via public `mask_logits`, so a future fallback-call-site edit that silently stops routing to the trie fails a test.
- All pre-existing grammar tests green (200 lib + integration), clippy `-D warnings` clean, fmt clean.

## Measured results

Harness: `gramperf_profile` (committed), Qwen3.5-0.8B Q4 on Metal (M2 Max), greedy (`temperature=0.0, top_k=1, seed=42`), 150 tokens/generation, 3 runs, exclusive GPU lock held, machine otherwise quiet. Replay:

```
GRAMPERF_RUNS=3 GRAMPERF_MAX_TOKENS=150 GRAMPERF_PROBE_CAP=1024 \
  target/release/gramperf_profile
```

| metric | before | after | change |
|---|---|---|---|
| wall/step (grammar-constrained) | 125.25 ms | 7.92 ms (runs: 8.18 / 6.83 / 8.76) | **~15.8x** |
| over-cap fallback cost | 114.11 ms/step (91.1% of wall) | 1.037 ms/call (13.1% of wall) | **~110x** |
| throughput on this schema | ~8.0 tok/s | ~126 tok/s | |
| trie build (one-time, lazy) | — | 64.2 ms | first over-cap call only |
| grammar compile (`GrammarEngine::new`) | 16.94 s | 17.53 s | unchanged (untouched path; machine variance) |

Fallback call counts are identical before/after (147/150 steps) — the fix changes what the fallback costs, not how often it runs. Known noise disclosed: this run's single unconstrained-baseline sample (10.32 ms/step) is noisier than the profiling round's (6.08 ms/step); the headline fallback numbers come from direct per-call counters, not baseline subtraction, and are unaffected.

## bench-compare (ADR-058)

Full-suite quick A/B, base `205f2176` (origin/main) vs head `f65e0819`, run under the exclusive machine bench window.

The first full-suite run flagged 4 confirmed regressions >7%, all in `lattice-embed` SIMD cosine groups (`simd_batch_cosine/simd_batch/1000` +16.3%; three `simd_batch_cosine_normalized_query` benches +9.7–10.6%), alongside equally large nominal improvements in untouched groups (`softmax_attention` −30%, `simd_throughput_384` −12 to −20%). A targeted identical-refs re-run of exactly the flagged groups (`BENCH_GROUPS_EMBED="simd_batch_cosine"`, same base/head SHAs, same machine, immediately after) reproduced **none** of the 4: the same benchmarks swung to −9% to −45% (e.g. `pair_loop_cosine/768d_4c`: +9.77% FAIL in run 1 → −43.65% in run 2), while a different, previously-clean bench (`scalar_loop/10`) spiked +11.5% instead.

Bidirectional ±45% swings between two runs of identical code are machine noise, not a code effect. Structurally, the diff cannot reach these benchmarks: it is confined to the grammar module and a profiling binary in `lattice-inference` (5 files); `lattice-embed`'s dependency on `lattice-inference` is optional and feature-gated, and the flagged SIMD kernels execute no grammar code on any path.

**Disposition: no change attributable to this diff.** The genuinely-affected path (grammar-constrained decode) is measured directly by the committed `gramperf_profile` harness above (~15.8× improvement).

## Scope

No change to: in-cap precomputed masking, grammar compilation, PDA semantics, sampling, or any non-grammar code path. The eager-compile cost (~17 s on this schema) is deliberately out of scope — separate issue to follow.
