### PR TITLE
feat(inference): os_signpost instrumentation of Metal decode path

### DIFF
--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -38,6 +38,11 @@ mixture = ["dep:lattice-fann"]
 # GDN state-traffic byte counters (issue #422, measure-first for ADR-058).
 # Opt-in only: the default decode path stays byte-identical when this is off.
 gdn-state-counters = []
+# os_signpost instrumentation of the Metal decode path (W1.0), for capturing
+# a Metal System Trace of command-buffer/dispatch/wait structure in
+# Instruments. Opt-in only: every call site is a zero-sized no-op guard when
+# this is off, so the default decode path stays byte-identical.
+signpost = []
 # Exposes test-only fixture constructors (currently: a tiny all-zero-weight
 # Qwen35Model, ADR-080 C2) as `pub` library API, gated so they never
 # ship in a normal build. Needed because bin targets (lattice.rs,

--- a/crates/inference/METAL_TRACE.md
+++ b/crates/inference/METAL_TRACE.md
@@ -1,0 +1,30 @@
+# lattice-inference — METAL_TRACE.md
+
+`os_signpost` instrumentation of the Metal decode path, gated behind the `signpost` cargo feature (default OFF). It exists so a Metal System Trace captured in Instruments can show the per-decode-step launch and synchronization structure — command-buffer commits, interior `waitUntilCompleted` waits, host-side reads of GPU results — instead of a single opaque GPU busy span.
+
+## Capturing a trace
+
+1. Build a decode binary (e.g. `chat_metal` or `lattice_serve`) with the feature on:
+   ```bash
+   cargo build --release -p lattice-inference --features f16,metal-gpu,signpost --bin chat_metal
+   ```
+2. Open Instruments (`xcrun xctrace` or the Instruments app), choose the **Metal System Trace** template, and add the **os_signpost** instrument (or use the `os_signpost` points-of-interest track that Metal System Trace already includes).
+3. Launch the built binary as the trace target and run a decode workload.
+4. In the trace timeline, filter the signpost track to subsystem `ai.lattice.inference`, category `decode`. Each labeled interval below appears as its own row, aligned against the Metal command-buffer/GPU-schedule tracks Instruments already shows.
+
+The feature is opt-in and adds no code to a default build: every call site is a zero-sized guard that only becomes a real `os_signpost` interval when built with `--features signpost` on macOS.
+
+## Label glossary
+
+| Label | Scope | Meaning |
+|---|---|---|
+| `decode.step` | one call to the per-token forward pass | Wall-clock span of a single decode step: embedding lookup through logits/top-k readback. |
+| `decode.cb_commit` | one `MTLCommandBuffer::commit()` call | Time to submit the step's command buffer to the GPU queue. |
+| `decode.cb_wait` | one `waitUntilCompleted()` call | Interior wait for the GPU to finish the step's command buffer — the launch+sync cost the W1 speculation-lane promotion rule measures against. |
+| `decode.host_scalar_read` | one host-side buffer read | CPU read of a `StorageModeShared` GPU buffer after the step's wait (logits, top-k candidates, or the pre-final hidden state used by MTP). |
+| `decode.grammar_mask` | one grammar-engine logit mask | CPU-side grammar constraint applied to a step's logits before sampling. |
+| `decode.sample` | one token-sampling call | CPU-side sampling (greedy, top-k/top-p, or compact-candidate) that picks the step's next token. |
+
+## Scope
+
+This instruments the existing autoregressive decode path only (`MetalQwen35State::forward_step` and its callers in `generate`/`generate_streaming*`). It adds no new engine behavior — no speculative decode, no verify step — that is future, separately-gated work.

--- a/crates/inference/METAL_TRACE.md
+++ b/crates/inference/METAL_TRACE.md
@@ -2,6 +2,8 @@
 
 `os_signpost` instrumentation of the Metal decode path, gated behind the `signpost` cargo feature (default OFF). It exists so a Metal System Trace captured in Instruments can show the per-decode-step launch and synchronization structure — command-buffer commits, interior `waitUntilCompleted` waits, host-side reads of GPU results — instead of a single opaque GPU busy span.
 
+Source: `crates/inference/src/forward/signpost.rs` (interval guard + label statics) and its call sites in `crates/inference/src/forward/metal_qwen35.rs`.
+
 ## Capturing a trace
 
 1. Build a decode binary (e.g. `chat_metal` or `lattice_serve`) with the feature on:

--- a/crates/inference/METAL_TRACE.md
+++ b/crates/inference/METAL_TRACE.md
@@ -10,11 +10,33 @@ Source: `crates/inference/src/forward/signpost.rs` (interval guard + label stati
    ```bash
    cargo build --release -p lattice-inference --features f16,metal-gpu,signpost --bin chat_metal
    ```
-2. Open Instruments (`xcrun xctrace` or the Instruments app), choose the **Metal System Trace** template, and add the **os_signpost** instrument (or use the `os_signpost` points-of-interest track that Metal System Trace already includes).
-3. Launch the built binary as the trace target and run a decode workload.
-4. In the trace timeline, filter the signpost track to subsystem `ai.lattice.inference`, category `decode`. Each labeled interval below appears as its own row, aligned against the Metal command-buffer/GPU-schedule tracks Instruments already shows.
+2. Choose a capture path and category based on which tool you're using — the two differ (see "Runtime signpost mode" below):
+
+   **Instruments.app (GUI)** — works with the default mode, no environment variable needed:
+   - Open Instruments, choose the **Metal System Trace** template, and add the **os_signpost** instrument (or use the `os_signpost` points-of-interest track Metal System Trace already includes).
+   - Launch the built binary as the trace target and run a decode workload.
+   - In the trace timeline, filter the signpost track to subsystem `ai.lattice.inference`, category `DynamicTracing`. Each labeled interval below appears as its own row, aligned against the Metal command-buffer/GPU-schedule tracks Instruments already shows.
+
+   **`xcrun xctrace` (CLI)** — requires `LATTICE_SIGNPOST_MODE=always` (see below), or the capture is silently empty:
+   ```bash
+   LATTICE_SIGNPOST_MODE=always xcrun xctrace record \
+     --template 'Metal System Trace' --instrument os_signpost \
+     --output trace.trace --launch -- ./target/release/chat_metal
+   ```
+   Filter the signpost track to subsystem `ai.lattice.inference`, category `decode` (not `DynamicTracing` — mode `always` uses the ordinary category, see below).
 
 The feature is opt-in and adds no code to a default build: every call site is a zero-sized guard that only becomes a real `os_signpost` interval when built with `--features signpost` on macOS.
+
+### Runtime signpost mode
+
+The `signpost` feature's `os_log` category is chosen at runtime from the `LATTICE_SIGNPOST_MODE` environment variable, read once at first use:
+
+| `LATTICE_SIGNPOST_MODE` | Category | `os_signpost_enabled` default | Use with |
+|---|---|---|---|
+| unset or `auto` (default) | `DynamicTracing` | `false` until an Instruments-style tool session attaches (idle-inert) | Instruments.app (GUI) |
+| `always` | `decode` | `true` unconditionally, whether or not any tool is attached | `xcrun xctrace` (CLI) |
+
+Both paths exist because the two tools drive `os_signpost_enabled` differently on macOS. `DynamicTracing` (`OS_LOG_CATEGORY_DYNAMIC_TRACING` in `<os/signpost.h>`) is disabled by default and only becomes enabled while a performance tool like Instruments.app is actively recording — that's what keeps the feature idle-inert (no signpost overhead) in a `--features signpost` build with nothing attached. Instruments.app's GUI recording session satisfies that contract. The `xcrun xctrace` CLI's `os_signpost` instrument, however, was observed on this project's macOS 26 development machine to **not** enable `DynamicTracing`-category signposts under `xctrace record --template 'Metal System Trace' --instrument os_signpost`: a direct `os_signpost_enabled` probe reported `DynamicTracing=0` while an ordinary category reported `decode=1` in the same process, under the same invocation. So the CLI path needs the ordinary `decode` category (`LATTICE_SIGNPOST_MODE=always`) to observe anything at all — trading idle-inertness for CLI-capture compatibility, which is fine for the duration of a deliberate trace-capture run.
 
 ## Label glossary
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1621,6 +1621,14 @@ mod inner {
     struct MetalStepOutput {
         logits: Vec<f32>,
         pre_final_hidden: Vec<f32>,
+        // Kept alive by binding the returned struct (not discarding it),
+        // rather than dropping at the end of `forward_step_inner_impl`'s
+        // body — the zero-copy greedy path needs `decode.step` to span
+        // through its post-return logits scan (see
+        // `forward_step_greedy_argmax`); every other caller either drops
+        // this immediately (`.logits`, same timing as before) or holds a
+        // `Scope::NotDecode` no-op guard, which is a no-op to drop late.
+        _signpost_step: crate::forward::signpost::Interval,
     }
 
     struct MetalMtpForwardOutput {
@@ -4714,7 +4722,12 @@ mod inner {
                     GdnStateTrafficScope::MtpVerify,
                 );
                 #[cfg(not(feature = "gdn-state-counters"))]
-                let repair_out = self.forward_step_inner(repair_token, repair_pos, true);
+                let repair_out = self.forward_step_inner(
+                    repair_token,
+                    repair_pos,
+                    true,
+                    crate::forward::signpost::Scope::NotDecode,
+                );
                 self.session.last_pre_final_hidden = repair_out.pre_final_hidden;
                 self.session.kv_cache.seq_len = seq_len;
             } else {
@@ -4763,7 +4776,12 @@ mod inner {
                     GdnStateTrafficScope::MtpVerify,
                 );
                 #[cfg(not(feature = "gdn-state-counters"))]
-                let out = self.forward_step_inner(token, start_pos + i, true);
+                let out = self.forward_step_inner(
+                    token,
+                    start_pos + i,
+                    true,
+                    crate::forward::signpost::Scope::NotDecode,
+                );
                 self.checkpoint_gdn_to_slot(i + 1, GdnStateTrafficScope::MtpVerify)?;
                 all_logits.push(out.logits);
                 final_hidden = out.pre_final_hidden;
@@ -5977,6 +5995,7 @@ mod inner {
             token_id: u32,
             position: usize,
             capture_hidden: bool,
+            signpost_scope: crate::forward::signpost::Scope,
         ) -> MetalStepOutput {
             self.forward_step_inner_impl(
                 token_id,
@@ -5986,6 +6005,7 @@ mod inner {
                 GdnStateTrafficScope::Decode,
                 None,
                 None,
+                signpost_scope,
             )
         }
 
@@ -6001,6 +6021,8 @@ mod inner {
             capture_hidden: bool,
             scope: GdnStateTrafficScope,
         ) -> MetalStepOutput {
+            // Both callers (repair replay, batched verifier) are MTP-verify
+            // work, never autoregressive decode — always `NotDecode`.
             self.forward_step_inner_impl(
                 token_id,
                 position,
@@ -6009,6 +6031,7 @@ mod inner {
                 scope,
                 None,
                 None,
+                crate::forward::signpost::Scope::NotDecode,
             )
         }
 
@@ -6031,6 +6054,7 @@ mod inner {
         #[allow(dead_code)] // exercised by injection-only unit tests, see doc comment
         fn forward_step_injected(&mut self, embedding: &[f32], position: usize) -> Vec<f32> {
             self.cross_turn_prefix_cache.clear();
+            // Never reached on a production path (see doc comment) — always `NotDecode`.
             self.forward_step_inner_impl(
                 0,
                 position,
@@ -6039,6 +6063,7 @@ mod inner {
                 GdnStateTrafficScope::Decode,
                 Some(embedding),
                 None,
+                crate::forward::signpost::Scope::NotDecode,
             )
             .logits
         }
@@ -6054,6 +6079,7 @@ mod inner {
             embedding: &[f32],
             position: usize,
             mrope_cos_sin: Option<(&[f32], &[f32])>,
+            signpost_scope: crate::forward::signpost::Scope,
         ) -> Vec<f32> {
             self.cross_turn_prefix_cache.clear();
             self.forward_step_inner_impl(
@@ -6064,6 +6090,7 @@ mod inner {
                 GdnStateTrafficScope::Decode,
                 Some(embedding),
                 mrope_cos_sin,
+                signpost_scope,
             )
             .logits
         }
@@ -6079,6 +6106,7 @@ mod inner {
             token_id: u32,
             position: usize,
             mrope_cos_sin: Option<(&[f32], &[f32])>,
+            signpost_scope: crate::forward::signpost::Scope,
         ) -> Vec<f32> {
             self.cross_turn_prefix_cache.clear();
             self.forward_step_inner_impl(
@@ -6089,6 +6117,7 @@ mod inner {
                 GdnStateTrafficScope::Decode,
                 None,
                 mrope_cos_sin,
+                signpost_scope,
             )
             .logits
         }
@@ -6109,9 +6138,12 @@ mod inner {
             _traffic_scope: GdnStateTrafficScope,
             injected_embedding: Option<&[f32]>,
             mrope_cos_sin: Option<(&[f32], &[f32])>,
+            signpost_scope: crate::forward::signpost::Scope,
         ) -> MetalStepOutput {
-            let _signpost_step =
-                crate::forward::signpost::interval(crate::forward::signpost::Label::DecodeStep);
+            let _signpost_step = crate::forward::signpost::interval_in(
+                signpost_scope,
+                crate::forward::signpost::Label::DecodeStep,
+            );
             let cfg = self.engine.config.clone();
             let hidden = cfg.hidden_size;
 
@@ -6234,8 +6266,20 @@ mod inner {
                         linear_idx += 1;
                         layer_enc.end_encoding();
                         let t_mixer = std::time::Instant::now();
-                        layer_cmd.commit();
-                        layer_cmd.wait_until_completed();
+                        {
+                            let _signpost_commit = crate::forward::signpost::interval_in(
+                                signpost_scope,
+                                crate::forward::signpost::Label::DecodeCbCommit,
+                            );
+                            layer_cmd.commit();
+                        }
+                        {
+                            let _signpost_wait = crate::forward::signpost::interval_in(
+                                signpost_scope,
+                                crate::forward::signpost::Label::DecodeCbWait,
+                            );
+                            layer_cmd.wait_until_completed();
+                        }
                         prof.gpu_gdn_mixer_us += t_mixer.elapsed().as_micros();
                         // MLP-only command buffer for this GDN layer.
                         let mlp_cmd = unsafe {
@@ -6254,8 +6298,20 @@ mod inner {
                         );
                         mlp_enc.end_encoding();
                         let t_mlp = std::time::Instant::now();
-                        mlp_cmd.commit();
-                        mlp_cmd.wait_until_completed();
+                        {
+                            let _signpost_commit = crate::forward::signpost::interval_in(
+                                signpost_scope,
+                                crate::forward::signpost::Label::DecodeCbCommit,
+                            );
+                            mlp_cmd.commit();
+                        }
+                        {
+                            let _signpost_wait = crate::forward::signpost::interval_in(
+                                signpost_scope,
+                                crate::forward::signpost::Label::DecodeCbWait,
+                            );
+                            mlp_cmd.wait_until_completed();
+                        }
                         prof.gpu_mlp_us += t_mlp.elapsed().as_micros();
                     } else {
                         // Attn-only (no MLP): measures pure GQA attention cost.
@@ -6275,8 +6331,20 @@ mod inner {
                         full_idx += 1;
                         layer_enc.end_encoding();
                         let t_attn = std::time::Instant::now();
-                        layer_cmd.commit();
-                        layer_cmd.wait_until_completed();
+                        {
+                            let _signpost_commit = crate::forward::signpost::interval_in(
+                                signpost_scope,
+                                crate::forward::signpost::Label::DecodeCbCommit,
+                            );
+                            layer_cmd.commit();
+                        }
+                        {
+                            let _signpost_wait = crate::forward::signpost::interval_in(
+                                signpost_scope,
+                                crate::forward::signpost::Label::DecodeCbWait,
+                            );
+                            layer_cmd.wait_until_completed();
+                        }
                         prof.gpu_gqa_attn_us += t_attn.elapsed().as_micros();
                         // MLP-only command buffer for this GQA layer.
                         let mlp_cmd = unsafe {
@@ -6295,8 +6363,20 @@ mod inner {
                         );
                         mlp_enc.end_encoding();
                         let t_mlp = std::time::Instant::now();
-                        mlp_cmd.commit();
-                        mlp_cmd.wait_until_completed();
+                        {
+                            let _signpost_commit = crate::forward::signpost::interval_in(
+                                signpost_scope,
+                                crate::forward::signpost::Label::DecodeCbCommit,
+                            );
+                            mlp_cmd.commit();
+                        }
+                        {
+                            let _signpost_wait = crate::forward::signpost::interval_in(
+                                signpost_scope,
+                                crate::forward::signpost::Label::DecodeCbWait,
+                            );
+                            mlp_cmd.wait_until_completed();
+                        }
                         prof.gpu_mlp_us += t_mlp.elapsed().as_micros();
                     }
                     // Keep legacy aggregates for backward compat with existing tooling.
@@ -6312,8 +6392,20 @@ mod inner {
                     self.encode_final_head(head_enc, &cfg, capture_hidden, &mut prof, profiling);
                 head_enc.end_encoding();
                 let t_gpu = std::time::Instant::now();
-                head_cmd.commit();
-                head_cmd.wait_until_completed();
+                {
+                    let _signpost_commit = crate::forward::signpost::interval_in(
+                        signpost_scope,
+                        crate::forward::signpost::Label::DecodeCbCommit,
+                    );
+                    head_cmd.commit();
+                }
+                {
+                    let _signpost_wait = crate::forward::signpost::interval_in(
+                        signpost_scope,
+                        crate::forward::signpost::Label::DecodeCbWait,
+                    );
+                    head_cmd.wait_until_completed();
+                }
                 prof.gpu_lm_head_us += t_gpu.elapsed().as_micros();
 
                 let total_gpu_us = prof.gpu_gdn_mixer_us
@@ -6386,6 +6478,10 @@ mod inner {
 
                 // SAFETY: GPU completed (wait_until_completed called above for head_cmd).
                 let pre_final_hidden = if capture_hidden || self.session.mtp.is_some() {
+                    let _signpost_host_read = crate::forward::signpost::interval_in(
+                        signpost_scope,
+                        crate::forward::signpost::Label::DecodeHostScalarRead,
+                    );
                     let h =
                         unsafe { read_buffer(&self.session.activations.pre_final_hidden, hidden) };
                     self.session.last_pre_final_hidden = h.clone();
@@ -6397,11 +6493,19 @@ mod inner {
                 let logits = if skip_logits_readback {
                     vec![]
                 } else if let Some(which) = topk_which_inner {
+                    let _signpost_host_read = crate::forward::signpost::interval_in(
+                        signpost_scope,
+                        crate::forward::signpost::Label::DecodeHostScalarRead,
+                    );
                     let k = self.session.compact_topk;
                     let candidates = unsafe { self.read_topk_candidates(which, k) };
                     self.session.compact_result = candidates;
                     vec![]
                 } else {
+                    let _signpost_host_read = crate::forward::signpost::interval_in(
+                        signpost_scope,
+                        crate::forward::signpost::Label::DecodeHostScalarRead,
+                    );
                     unsafe { read_buffer(&self.session.activations.logits, cfg.vocab_size) }
                 };
                 self.session.kv_cache.seq_len += 1;
@@ -6409,6 +6513,7 @@ mod inner {
                 return MetalStepOutput {
                     logits,
                     pre_final_hidden,
+                    _signpost_step,
                 };
             }
 
@@ -6472,13 +6577,15 @@ mod inner {
             // Single submit for entire forward pass + optional top-k.
             enc.end_encoding();
             {
-                let _signpost_commit = crate::forward::signpost::interval(
+                let _signpost_commit = crate::forward::signpost::interval_in(
+                    signpost_scope,
                     crate::forward::signpost::Label::DecodeCbCommit,
                 );
                 cmd.commit();
             }
             {
-                let _signpost_wait = crate::forward::signpost::interval(
+                let _signpost_wait = crate::forward::signpost::interval_in(
+                    signpost_scope,
                     crate::forward::signpost::Label::DecodeCbWait,
                 );
                 cmd.wait_until_completed();
@@ -6539,7 +6646,8 @@ mod inner {
             // Read back pre-final hidden when requested (for MTP input).
             // SAFETY: GPU completed, pre_final_hidden is StorageModeShared.
             let pre_final_hidden = if capture_hidden || self.session.mtp.is_some() {
-                let _signpost_host_read = crate::forward::signpost::interval(
+                let _signpost_host_read = crate::forward::signpost::interval_in(
+                    signpost_scope,
                     crate::forward::signpost::Label::DecodeHostScalarRead,
                 );
                 let h = unsafe { read_buffer(&self.session.activations.pre_final_hidden, hidden) };
@@ -6554,7 +6662,8 @@ mod inner {
             } else if let Some(which) = topk_which {
                 // Compact path: read k*(f32+u32)=k*8 bytes instead of vocab*4 bytes.
                 // SAFETY: GPU completed, buffers are StorageModeShared.
-                let _signpost_host_read = crate::forward::signpost::interval(
+                let _signpost_host_read = crate::forward::signpost::interval_in(
+                    signpost_scope,
                     crate::forward::signpost::Label::DecodeHostScalarRead,
                 );
                 let k = self.session.compact_topk;
@@ -6564,7 +6673,8 @@ mod inner {
             } else {
                 // Full path: read vocab_size f32 logits back to host.
                 // SAFETY: GPU completed, buffer is StorageModeShared.
-                let _signpost_host_read = crate::forward::signpost::interval(
+                let _signpost_host_read = crate::forward::signpost::interval_in(
+                    signpost_scope,
                     crate::forward::signpost::Label::DecodeHostScalarRead,
                 );
                 unsafe { read_buffer(&self.session.activations.logits, cfg.vocab_size) }
@@ -6574,6 +6684,7 @@ mod inner {
             MetalStepOutput {
                 logits,
                 pre_final_hidden,
+                _signpost_step,
             }
         }
 
@@ -6603,14 +6714,49 @@ mod inner {
         /// live entry saved while it is still generating.
         pub fn forward_step(&mut self, token_id: u32, position: usize) -> Vec<f32> {
             self.cross_turn_prefix_cache.clear();
-            self.forward_step_inner(token_id, position, false).logits
+            // General-purpose raw entry point: reused for prompt prefill (a
+            // token-at-a-time loop, e.g. `forward_prefill_impl`,
+            // `forward_prefill_from`, multimodal prefill) as well as by
+            // external library consumers calling it directly, so it cannot
+            // assume decode scope. The production autoregressive decode
+            // loops call `forward_step_decode` instead (below), which is
+            // `Scope::Decode`.
+            self.forward_step_inner(
+                token_id,
+                position,
+                false,
+                crate::forward::signpost::Scope::NotDecode,
+            )
+            .logits
+        }
+
+        /// Same contract as [`Self::forward_step`], for the production
+        /// autoregressive decode loops (`generate`, `generate_streaming*`,
+        /// `generate_streaming_with_prefix_cache*`) only — marks the
+        /// `decode.*` signpost interval `Scope::Decode` so it is not silent.
+        /// Not `pub`: external consumers get the general-purpose
+        /// `forward_step`, which stays `Scope::NotDecode` since it cannot
+        /// know whether the caller is decoding or prefilling.
+        fn forward_step_decode(&mut self, token_id: u32, position: usize) -> Vec<f32> {
+            self.cross_turn_prefix_cache.clear();
+            self.forward_step_inner(
+                token_id,
+                position,
+                false,
+                crate::forward::signpost::Scope::Decode,
+            )
+            .logits
         }
 
         /// Zero-copy greedy argmax: run forward pass then scan GPU shared buffer
         /// directly for the argmax token ID, avoiding 993KB allocation+copy.
         fn forward_step_greedy_argmax(&mut self, token_id: u32, position: usize) -> u32 {
             let cfg = self.engine.config.clone();
-            self.forward_step_inner_impl(
+            // Binding (not discarding) the returned guard keeps `decode.step`
+            // alive through the host-read/argmax scan below, matching its
+            // documented span (through logits/top-k readback) — the scan is
+            // logically part of this step, not a separate one.
+            let _step_guard = self.forward_step_inner_impl(
                 token_id,
                 position,
                 false,
@@ -6618,6 +6764,7 @@ mod inner {
                 GdnStateTrafficScope::Decode,
                 None,
                 None,
+                crate::forward::signpost::Scope::Decode,
             );
 
             // Fused host read + greedy sample: this scan both reads the
@@ -8910,7 +9057,14 @@ mod inner {
                 }
                 if self.session.gdn_checkpoints.is_none() {
                     // Checkpoint pool not allocated — fall through to single-token decode.
-                    let logits = self.forward_step_inner(pending_token, pos, false).logits;
+                    let logits = self
+                        .forward_step_inner(
+                            pending_token,
+                            pos,
+                            false,
+                            crate::forward::signpost::Scope::Decode,
+                        )
+                        .logits;
                     let next = argmax_logits(&logits);
                     generated_ids.push(pending_token);
                     // Stop-token contract (#613): `next` is never appended when it is
@@ -8939,7 +9093,14 @@ mod inner {
                     .checkpoint_gdn_to_slot(0, GdnStateTrafficScope::Decode)
                     .is_err()
                 {
-                    let logits = self.forward_step_inner(pending_token, pos, false).logits;
+                    let logits = self
+                        .forward_step_inner(
+                            pending_token,
+                            pos,
+                            false,
+                            crate::forward::signpost::Scope::Decode,
+                        )
+                        .logits;
                     let next = argmax_logits(&logits);
                     generated_ids.push(pending_token);
                     // Stop-token contract (#613): `next` is never appended when it is
@@ -9428,7 +9589,7 @@ mod inner {
                 let next_id = if greedy_fast {
                     self.forward_step_greedy_argmax(last_token, pos)
                 } else {
-                    let mut step_logits = self.forward_step(last_token, pos);
+                    let mut step_logits = self.forward_step_decode(last_token, pos);
 
                     // Apply grammar masking before sampling (ADR-046).
                     if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
@@ -9793,7 +9954,7 @@ mod inner {
                     stop_reason = StopReason::Eos;
                     break;
                 }
-                let step_logits = self.forward_step(last_token, pos);
+                let step_logits = self.forward_step_decode(last_token, pos);
                 pos += 1;
                 let next_id = sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state);
                 if is_stop(next_id) {
@@ -10040,9 +10201,19 @@ mod inner {
                         )));
                     }
                     visual_row += 1;
-                    last_logits = self.forward_step_injected_mrope(row, pos, cos_sin);
+                    last_logits = self.forward_step_injected_mrope(
+                        row,
+                        pos,
+                        cos_sin,
+                        crate::forward::signpost::Scope::NotDecode,
+                    );
                 } else {
-                    last_logits = self.forward_step_mrope(token_id, pos, cos_sin);
+                    last_logits = self.forward_step_mrope(
+                        token_id,
+                        pos,
+                        cos_sin,
+                        crate::forward::signpost::Scope::NotDecode,
+                    );
                 }
             }
 
@@ -10121,7 +10292,12 @@ mod inner {
                     None
                 };
 
-                let step_logits = self.forward_step_mrope(last_token, physical_pos, mrope_cos_sin);
+                let step_logits = self.forward_step_mrope(
+                    last_token,
+                    physical_pos,
+                    mrope_cos_sin,
+                    crate::forward::signpost::Scope::Decode,
+                );
                 if let Some(probe) = decode_logits_probe.as_deref_mut() {
                     probe.push(step_logits.clone());
                 }
@@ -13744,7 +13920,12 @@ mod inner {
                 // Process all tokens; capture pre-final hidden for the last one.
                 for (pos, &id) in token_ids.iter().enumerate() {
                     let is_last = pos == n - 1;
-                    let _ = self.forward_step_inner(id, pos, is_last);
+                    let _ = self.forward_step_inner(
+                        id,
+                        pos,
+                        is_last,
+                        crate::forward::signpost::Scope::NotDecode,
+                    );
                 }
 
                 // last_pre_final_hidden = post-last-active-layer hidden for the last token.
@@ -14380,7 +14561,7 @@ mod inner {
                 let last_token = *all_ids
                     .last()
                     .expect("invariant: prompt or previous sample populated all_ids");
-                let mut step_logits = self.forward_step(last_token, pos);
+                let mut step_logits = self.forward_step_decode(last_token, pos);
 
                 // Apply grammar masking before sampling (ADR-046).
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
@@ -17327,7 +17508,7 @@ mod inner {
                 let last_token = *all_ids
                     .last()
                     .expect("invariant: prompt or previous sample populated all_ids");
-                let mut step_logits = self.forward_step(last_token, pos);
+                let mut step_logits = self.forward_step_decode(last_token, pos);
 
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
                     let _signpost_grammar = crate::forward::signpost::interval(
@@ -17474,7 +17655,7 @@ mod inner {
                 if !generated_ids.is_empty() && !stopped && !stopped_by_caller {
                     let seq_len = self.session.kv_cache.seq_len;
                     if seq_len < self.session.kv_cache.max_cache_len {
-                        let _ = self.forward_step(last_pushed_id, seq_len);
+                        let _ = self.forward_step_decode(last_pushed_id, seq_len);
                     }
                     // else: KV is already full; the cache boundary stays one
                     // token short of `generated_ids` — still consistent, since
@@ -26341,6 +26522,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     GdnStateTrafficScope::Decode,
                     Some(&row),
                     None,
+                    crate::forward::signpost::Scope::NotDecode,
                 )
                 .logits;
 
@@ -26355,6 +26537,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     GdnStateTrafficScope::Decode,
                     Some(&row),
                     None,
+                    crate::forward::signpost::Scope::NotDecode,
                 )
                 .logits;
 
@@ -26463,9 +26646,19 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             };
 
             prime(&mut state);
-            let logits_a = state.forward_step_injected_mrope(&row, 2, Some((&cos_a, &sin_a)));
+            let logits_a = state.forward_step_injected_mrope(
+                &row,
+                2,
+                Some((&cos_a, &sin_a)),
+                crate::forward::signpost::Scope::NotDecode,
+            );
             prime(&mut state);
-            let logits_b = state.forward_step_injected_mrope(&row, 2, Some((&cos_b, &sin_b)));
+            let logits_b = state.forward_step_injected_mrope(
+                &row,
+                2,
+                Some((&cos_b, &sin_b)),
+                crate::forward::signpost::Scope::NotDecode,
+            );
 
             let max_abs_diff = logits_a
                 .iter()
@@ -26527,9 +26720,19 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     let end = start + request.decoder_hidden_size;
                     let row = &request.post_merger_rows[start..end];
                     visual_row += 1;
-                    last_logits_real = state_real.forward_step_injected_mrope(row, pos, cos_sin);
+                    last_logits_real = state_real.forward_step_injected_mrope(
+                        row,
+                        pos,
+                        cos_sin,
+                        crate::forward::signpost::Scope::NotDecode,
+                    );
                 } else {
-                    last_logits_real = state_real.forward_step_mrope(token_id, pos, cos_sin);
+                    last_logits_real = state_real.forward_step_mrope(
+                        token_id,
+                        pos,
+                        cos_sin,
+                        crate::forward::signpost::Scope::NotDecode,
+                    );
                 }
             }
 
@@ -26674,7 +26877,12 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
 
             let mut bits_last = Vec::new();
             for (pos, &token_id) in input_ids.iter().enumerate() {
-                let a = state_mrope_none.forward_step_mrope(token_id, pos, None);
+                let a = state_mrope_none.forward_step_mrope(
+                    token_id,
+                    pos,
+                    None,
+                    crate::forward::signpost::Scope::NotDecode,
+                );
                 let b = state_plain_bits.forward_step(token_id, pos);
                 assert_bits_equal(&a, &b, pos);
                 bits_last = a;
@@ -26689,7 +26897,12 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     physical_pos, state_plain_bits.session.kv_cache.seq_len,
                     "physical KV positions diverged before decode step {step}"
                 );
-                let a = state_mrope_none.forward_step_mrope(next_id, physical_pos, None);
+                let a = state_mrope_none.forward_step_mrope(
+                    next_id,
+                    physical_pos,
+                    None,
+                    crate::forward::signpost::Scope::NotDecode,
+                );
                 let b = state_plain_bits.forward_step(next_id, physical_pos);
                 assert_bits_equal(&a, &b, input_ids.len() + step);
                 bits_last = a;
@@ -26840,9 +27053,19 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                         let end = start + request.decoder_hidden_size;
                         let row = &request.post_merger_rows[start..end];
                         visual_row += 1;
-                        last_logits = state.forward_step_injected_mrope(row, pos, cos_sin);
+                        last_logits = state.forward_step_injected_mrope(
+                            row,
+                            pos,
+                            cos_sin,
+                            crate::forward::signpost::Scope::NotDecode,
+                        );
                     } else {
-                        last_logits = state.forward_step_mrope(token_id, pos, cos_sin);
+                        last_logits = state.forward_step_mrope(
+                            token_id,
+                            pos,
+                            cos_sin,
+                            crate::forward::signpost::Scope::NotDecode,
+                        );
                     }
                 }
                 let mut all_ids = request.input_ids.clone();
@@ -26868,7 +27091,12 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 } else {
                     None
                 };
-                state.forward_step_mrope(first_id, physical_pos, cos_sin)
+                state.forward_step_mrope(
+                    first_id,
+                    physical_pos,
+                    cos_sin,
+                    crate::forward::signpost::Scope::NotDecode,
+                )
             };
 
             let logits_correct = manual_decode_logits(true);

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -9608,19 +9608,13 @@ mod inner {
                         }
                     }
 
-                    let _signpost_sample = crate::forward::signpost::interval(
-                        crate::forward::signpost::Label::DecodeSample,
-                    );
-                    if use_compact {
-                        sample_from_candidates(
-                            &self.session.compact_result,
-                            gen_cfg,
-                            &all_ids,
-                            &mut rng_state,
-                        )
-                    } else {
-                        sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
-                    }
+                    sample_decode_traced(
+                        use_compact.then_some(self.session.compact_result.as_slice()),
+                        &step_logits,
+                        gen_cfg,
+                        &all_ids,
+                        &mut rng_state,
+                    )
                 };
 
                 // Advance grammar state after sampling.
@@ -9956,7 +9950,8 @@ mod inner {
                 }
                 let step_logits = self.forward_step_decode(last_token, pos);
                 pos += 1;
-                let next_id = sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state);
+                let next_id =
+                    sample_decode_traced(None, &step_logits, gen_cfg, &all_ids, &mut rng_state);
                 if is_stop(next_id) {
                     stopped = true;
                     stop_reason = StopReason::Eos;
@@ -10301,7 +10296,8 @@ mod inner {
                 if let Some(probe) = decode_logits_probe.as_deref_mut() {
                     probe.push(step_logits.clone());
                 }
-                let next_id = sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state);
+                let next_id =
+                    sample_decode_traced(None, &step_logits, gen_cfg, &all_ids, &mut rng_state);
                 if is_stop(next_id) {
                     stopped = true;
                     stop_reason = StopReason::Eos;
@@ -14110,6 +14106,34 @@ mod inner {
         crate::sampling::sample_full_logits(logits, cfg, previous_ids, rng_state)
     }
 
+    /// Signpost-traced sampling shared by every autoregressive decode loop's
+    /// per-step token pick: opens the `decode.sample` interval, then routes
+    /// to the compact-candidate or full-logits sampler.
+    ///
+    /// Centralizes what was five independent copy-pasted call sites (round-3
+    /// review finding: two of the five -- the multimodal decode loops --
+    /// had already drifted to call `sample_token` directly, with neither the
+    /// interval nor the compact-route policy the other three loops apply).
+    /// `compact` is `Some(candidates)` for the GPU-top-k route (mirrors the
+    /// `use_compact` branch every call site used to inline) and `None` for
+    /// callers with no compact route, which is the multimodal decode loops'
+    /// only case -- they gain `decode.sample` instrumentation as a side
+    /// effect of routing through here instead of `sample_token` directly.
+    fn sample_decode_traced(
+        compact: Option<&[crate::sampling::Candidate]>,
+        step_logits: &[f32],
+        cfg: &GenerateConfig,
+        previous_ids: &[u32],
+        rng_state: &mut u64,
+    ) -> u32 {
+        let _signpost_sample =
+            crate::forward::signpost::interval(crate::forward::signpost::Label::DecodeSample);
+        match compact {
+            Some(candidates) => sample_from_candidates(candidates, cfg, previous_ids, rng_state),
+            None => sample_token(step_logits, cfg, previous_ids, rng_state),
+        }
+    }
+
     fn decode_tokens(tokenizer: &BpeTokenizer, ids: &[u32]) -> String {
         crate::model::qwen35::detokenize::decode_tokens(tokenizer, ids)
     }
@@ -14581,19 +14605,13 @@ mod inner {
                 }
 
                 let sampled_id = {
-                    let _signpost_sample = crate::forward::signpost::interval(
-                        crate::forward::signpost::Label::DecodeSample,
-                    );
-                    if use_compact {
-                        sample_from_candidates(
-                            &self.session.compact_result,
-                            gen_cfg,
-                            &all_ids,
-                            &mut rng_state,
-                        )
-                    } else {
-                        sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
-                    }
+                    sample_decode_traced(
+                        use_compact.then_some(self.session.compact_result.as_slice()),
+                        &step_logits,
+                        gen_cfg,
+                        &all_ids,
+                        &mut rng_state,
+                    )
                 };
 
                 // One atomic per-step transition (ADR-080 C3, PR #787) --
@@ -17527,19 +17545,13 @@ mod inner {
                 }
 
                 let sampled_id = {
-                    let _signpost_sample = crate::forward::signpost::interval(
-                        crate::forward::signpost::Label::DecodeSample,
-                    );
-                    if use_compact {
-                        sample_from_candidates(
-                            &self.session.compact_result,
-                            gen_cfg,
-                            &all_ids,
-                            &mut rng_state,
-                        )
-                    } else {
-                        sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
-                    }
+                    sample_decode_traced(
+                        use_compact.then_some(self.session.compact_result.as_slice()),
+                        &step_logits,
+                        gen_cfg,
+                        &all_ids,
+                        &mut rng_state,
+                    )
                 };
 
                 // `policy.stop_mode` (fixed to `StopMode::Streaming` or
@@ -17787,6 +17799,59 @@ mod inner {
             CommonLayerWeights, DenseFfnWeights, FeedForwardWeights, FullAttentionLayerWeights,
         };
         use crate::model::qwen35_config::LayerType;
+
+        // Mutation-sensitive regression for round-4 finding 1: five decode
+        // loops used to copy-paste their own `decode.sample` interval +
+        // compact/full-logits routing, and two of the five (the multimodal
+        // decode loops) had already drifted to call `sample_token` directly
+        // with no interval at all. `sample_decode_traced` is now the single
+        // shared call site; these two source-level checks guard both halves
+        // of that invariant without depending on a live Instruments/xctrace
+        // tool session (which real FFI emission would require to observe).
+        // See fix-round-4 report for the mutation run against this pair.
+        #[test]
+        fn sample_decode_traced_opens_the_decode_sample_interval() {
+            let src = include_str!("metal_qwen35.rs");
+            let start = src
+                .find("fn sample_decode_traced(")
+                .expect("sample_decode_traced must exist in this file");
+            let body_end = src[start..]
+                .find("\n    }\n")
+                .expect("sample_decode_traced's body must close with `\\n    }\\n`");
+            let body = &src[start..start + body_end];
+            assert!(
+                body.contains(
+                    "crate::forward::signpost::interval(crate::forward::signpost::Label::DecodeSample)"
+                ),
+                "sample_decode_traced must open the decode.sample interval -- it is the \
+                 single call site all five decode loops now share; silently dropping this \
+                 line removes decode.sample instrumentation from every decode loop at once"
+            );
+        }
+
+        #[test]
+        fn all_five_decode_loops_call_sample_decode_traced() {
+            let src = include_str!("metal_qwen35.rs");
+            // Scope the search to production code, excluding `mod tests`
+            // itself -- this test's own source text contains the literal
+            // string `sample_decode_traced(` several times over (the
+            // `include_str!` search string, this function's name, etc.),
+            // which would otherwise self-count.
+            let production_end = src
+                .find("    mod tests {")
+                .expect("mod tests must exist in this file");
+            let production_src = &src[..production_end];
+            // One definition + five call sites (round-4 finding-1 table: the
+            // fix-round-4 report enumerates each by function and line).
+            let count = production_src.matches("sample_decode_traced(").count();
+            assert_eq!(
+                count, 6,
+                "expected sample_decode_traced's definition plus exactly 5 decode-loop \
+                 call sites; got {count} instead -- a decode loop likely reverted to \
+                 calling sample_token/sample_from_candidates directly, the exact drift \
+                 round 3's review caught in the two multimodal decode loops"
+            );
+        }
 
         /// #854: guards against a reintroduced manual copy of the RMS-norm
         /// reduction tree across qwen35.metal's seven RMS-norm-family kernels

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6110,7 +6110,8 @@ mod inner {
             injected_embedding: Option<&[f32]>,
             mrope_cos_sin: Option<(&[f32], &[f32])>,
         ) -> MetalStepOutput {
-            let _signpost_step = crate::forward::signpost::interval("decode.step");
+            let _signpost_step =
+                crate::forward::signpost::interval(crate::forward::signpost::Label::DecodeStep);
             let cfg = self.engine.config.clone();
             let hidden = cfg.hidden_size;
 
@@ -6471,11 +6472,15 @@ mod inner {
             // Single submit for entire forward pass + optional top-k.
             enc.end_encoding();
             {
-                let _signpost_commit = crate::forward::signpost::interval("decode.cb_commit");
+                let _signpost_commit = crate::forward::signpost::interval(
+                    crate::forward::signpost::Label::DecodeCbCommit,
+                );
                 cmd.commit();
             }
             {
-                let _signpost_wait = crate::forward::signpost::interval("decode.cb_wait");
+                let _signpost_wait = crate::forward::signpost::interval(
+                    crate::forward::signpost::Label::DecodeCbWait,
+                );
                 cmd.wait_until_completed();
             }
 
@@ -6534,8 +6539,9 @@ mod inner {
             // Read back pre-final hidden when requested (for MTP input).
             // SAFETY: GPU completed, pre_final_hidden is StorageModeShared.
             let pre_final_hidden = if capture_hidden || self.session.mtp.is_some() {
-                let _signpost_host_read =
-                    crate::forward::signpost::interval("decode.host_scalar_read");
+                let _signpost_host_read = crate::forward::signpost::interval(
+                    crate::forward::signpost::Label::DecodeHostScalarRead,
+                );
                 let h = unsafe { read_buffer(&self.session.activations.pre_final_hidden, hidden) };
                 self.session.last_pre_final_hidden = h.clone();
                 h
@@ -6548,8 +6554,9 @@ mod inner {
             } else if let Some(which) = topk_which {
                 // Compact path: read k*(f32+u32)=k*8 bytes instead of vocab*4 bytes.
                 // SAFETY: GPU completed, buffers are StorageModeShared.
-                let _signpost_host_read =
-                    crate::forward::signpost::interval("decode.host_scalar_read");
+                let _signpost_host_read = crate::forward::signpost::interval(
+                    crate::forward::signpost::Label::DecodeHostScalarRead,
+                );
                 let k = self.session.compact_topk;
                 let candidates = unsafe { self.read_topk_candidates(which, k) };
                 self.session.compact_result = candidates;
@@ -6557,8 +6564,9 @@ mod inner {
             } else {
                 // Full path: read vocab_size f32 logits back to host.
                 // SAFETY: GPU completed, buffer is StorageModeShared.
-                let _signpost_host_read =
-                    crate::forward::signpost::interval("decode.host_scalar_read");
+                let _signpost_host_read = crate::forward::signpost::interval(
+                    crate::forward::signpost::Label::DecodeHostScalarRead,
+                );
                 unsafe { read_buffer(&self.session.activations.logits, cfg.vocab_size) }
             };
             self.session.kv_cache.seq_len += 1;
@@ -6612,6 +6620,15 @@ mod inner {
                 None,
             );
 
+            // Fused host read + greedy sample: this scan both reads the
+            // shared logits buffer off the GPU and picks the argmax token in
+            // the same pass (the whole point of the zero-copy path), so it
+            // carries both signpost labels for the span it covers.
+            let _signpost_host_read = crate::forward::signpost::interval(
+                crate::forward::signpost::Label::DecodeHostScalarRead,
+            );
+            let _signpost_sample =
+                crate::forward::signpost::interval(crate::forward::signpost::Label::DecodeSample);
             // SAFETY: GPU completed (wait_until_completed called in forward_step_inner).
             // logits buffer is StorageModeShared — CPU can read it directly.
             unsafe {
@@ -9415,8 +9432,9 @@ mod inner {
 
                     // Apply grammar masking before sampling (ADR-046).
                     if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                        let _signpost_grammar =
-                            crate::forward::signpost::interval("decode.grammar_mask");
+                        let _signpost_grammar = crate::forward::signpost::interval(
+                            crate::forward::signpost::Label::DecodeGrammarMask,
+                        );
                         engine.mask_logits(gs, &mut step_logits);
                         // Fail closed if the grammar blocked every continuation,
                         // matching the CPU contract (#611).
@@ -9429,7 +9447,9 @@ mod inner {
                         }
                     }
 
-                    let _signpost_sample = crate::forward::signpost::interval("decode.sample");
+                    let _signpost_sample = crate::forward::signpost::interval(
+                        crate::forward::signpost::Label::DecodeSample,
+                    );
                     if use_compact {
                         sample_from_candidates(
                             &self.session.compact_result,
@@ -14364,6 +14384,9 @@ mod inner {
 
                 // Apply grammar masking before sampling (ADR-046).
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                    let _signpost_grammar = crate::forward::signpost::interval(
+                        crate::forward::signpost::Label::DecodeGrammarMask,
+                    );
                     engine.mask_logits(gs, &mut step_logits);
                     // Fail closed if the grammar blocked every continuation,
                     // matching the CPU contract (#611).
@@ -14376,15 +14399,20 @@ mod inner {
                     }
                 }
 
-                let sampled_id = if use_compact {
-                    sample_from_candidates(
-                        &self.session.compact_result,
-                        gen_cfg,
-                        &all_ids,
-                        &mut rng_state,
-                    )
-                } else {
-                    sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
+                let sampled_id = {
+                    let _signpost_sample = crate::forward::signpost::interval(
+                        crate::forward::signpost::Label::DecodeSample,
+                    );
+                    if use_compact {
+                        sample_from_candidates(
+                            &self.session.compact_result,
+                            gen_cfg,
+                            &all_ids,
+                            &mut rng_state,
+                        )
+                    } else {
+                        sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
+                    }
                 };
 
                 // One atomic per-step transition (ADR-080 C3, PR #787) --
@@ -17302,8 +17330,9 @@ mod inner {
                 let mut step_logits = self.forward_step(last_token, pos);
 
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                    let _signpost_grammar =
-                        crate::forward::signpost::interval("decode.grammar_mask");
+                    let _signpost_grammar = crate::forward::signpost::interval(
+                        crate::forward::signpost::Label::DecodeGrammarMask,
+                    );
                     engine.mask_logits(gs, &mut step_logits);
                     // Fail closed if the grammar blocked every continuation,
                     // matching the CPU contract (#611).
@@ -17317,7 +17346,9 @@ mod inner {
                 }
 
                 let sampled_id = {
-                    let _signpost_sample = crate::forward::signpost::interval("decode.sample");
+                    let _signpost_sample = crate::forward::signpost::interval(
+                        crate::forward::signpost::Label::DecodeSample,
+                    );
                     if use_compact {
                         sample_from_candidates(
                             &self.session.compact_result,

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6110,6 +6110,7 @@ mod inner {
             injected_embedding: Option<&[f32]>,
             mrope_cos_sin: Option<(&[f32], &[f32])>,
         ) -> MetalStepOutput {
+            let _signpost_step = crate::forward::signpost::interval("decode.step");
             let cfg = self.engine.config.clone();
             let hidden = cfg.hidden_size;
 
@@ -6469,8 +6470,14 @@ mod inner {
 
             // Single submit for entire forward pass + optional top-k.
             enc.end_encoding();
-            cmd.commit();
-            cmd.wait_until_completed();
+            {
+                let _signpost_commit = crate::forward::signpost::interval("decode.cb_commit");
+                cmd.commit();
+            }
+            {
+                let _signpost_wait = crate::forward::signpost::interval("decode.cb_wait");
+                cmd.wait_until_completed();
+            }
 
             // Diagnostic: dump post-final-norm hidden state magnitudes for
             // divergence analysis vs MLX. Set LATTICE_HIDDEN_DUMP=path to enable.
@@ -6527,6 +6534,8 @@ mod inner {
             // Read back pre-final hidden when requested (for MTP input).
             // SAFETY: GPU completed, pre_final_hidden is StorageModeShared.
             let pre_final_hidden = if capture_hidden || self.session.mtp.is_some() {
+                let _signpost_host_read =
+                    crate::forward::signpost::interval("decode.host_scalar_read");
                 let h = unsafe { read_buffer(&self.session.activations.pre_final_hidden, hidden) };
                 self.session.last_pre_final_hidden = h.clone();
                 h
@@ -6539,6 +6548,8 @@ mod inner {
             } else if let Some(which) = topk_which {
                 // Compact path: read k*(f32+u32)=k*8 bytes instead of vocab*4 bytes.
                 // SAFETY: GPU completed, buffers are StorageModeShared.
+                let _signpost_host_read =
+                    crate::forward::signpost::interval("decode.host_scalar_read");
                 let k = self.session.compact_topk;
                 let candidates = unsafe { self.read_topk_candidates(which, k) };
                 self.session.compact_result = candidates;
@@ -6546,6 +6557,8 @@ mod inner {
             } else {
                 // Full path: read vocab_size f32 logits back to host.
                 // SAFETY: GPU completed, buffer is StorageModeShared.
+                let _signpost_host_read =
+                    crate::forward::signpost::interval("decode.host_scalar_read");
                 unsafe { read_buffer(&self.session.activations.logits, cfg.vocab_size) }
             };
             self.session.kv_cache.seq_len += 1;
@@ -9402,6 +9415,8 @@ mod inner {
 
                     // Apply grammar masking before sampling (ADR-046).
                     if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                        let _signpost_grammar =
+                            crate::forward::signpost::interval("decode.grammar_mask");
                         engine.mask_logits(gs, &mut step_logits);
                         // Fail closed if the grammar blocked every continuation,
                         // matching the CPU contract (#611).
@@ -9414,6 +9429,7 @@ mod inner {
                         }
                     }
 
+                    let _signpost_sample = crate::forward::signpost::interval("decode.sample");
                     if use_compact {
                         sample_from_candidates(
                             &self.session.compact_result,
@@ -17286,6 +17302,8 @@ mod inner {
                 let mut step_logits = self.forward_step(last_token, pos);
 
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
+                    let _signpost_grammar =
+                        crate::forward::signpost::interval("decode.grammar_mask");
                     engine.mask_logits(gs, &mut step_logits);
                     // Fail closed if the grammar blocked every continuation,
                     // matching the CPU contract (#611).
@@ -17298,15 +17316,18 @@ mod inner {
                     }
                 }
 
-                let sampled_id = if use_compact {
-                    sample_from_candidates(
-                        &self.session.compact_result,
-                        gen_cfg,
-                        &all_ids,
-                        &mut rng_state,
-                    )
-                } else {
-                    sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
+                let sampled_id = {
+                    let _signpost_sample = crate::forward::signpost::interval("decode.sample");
+                    if use_compact {
+                        sample_from_candidates(
+                            &self.session.compact_result,
+                            gen_cfg,
+                            &all_ids,
+                            &mut rng_state,
+                        )
+                    } else {
+                        sample_token(&step_logits, gen_cfg, &all_ids, &mut rng_state)
+                    }
                 };
 
                 // `policy.stop_mode` (fixed to `StopMode::Streaming` or

--- a/crates/inference/src/forward/mod.rs
+++ b/crates/inference/src/forward/mod.rs
@@ -16,11 +16,11 @@ pub mod metal_qwen35;
 pub mod moe_expert_cache;
 pub mod neon;
 pub mod neon_forward;
-// Every call site lives inside `metal_qwen35`'s `metal-gpu`-gated Metal
-// decode implementation; with that feature off, nothing in this crate
-// constructs a `Label`/`Interval`, which is otherwise flagged as dead code
-// now that the module is `pub(crate)` rather than a public API surface.
-#[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
+// Every call site lives inside `metal_qwen35::inner`, gated the same way
+// (`target_os = "macos"` + `metal-gpu`) — mirror that gate here instead of
+// compiling the module everywhere and suppressing the resulting dead-code
+// lint. Smaller surface, nothing to keep in sync with `mod inner`'s own gate.
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub(crate) mod signpost;
 
 // Re-export from cpu for backward compat (was `layers`)

--- a/crates/inference/src/forward/mod.rs
+++ b/crates/inference/src/forward/mod.rs
@@ -16,6 +16,7 @@ pub mod metal_qwen35;
 pub mod moe_expert_cache;
 pub mod neon;
 pub mod neon_forward;
+pub mod signpost;
 
 // Re-export from cpu for backward compat (was `layers`)
 pub use self::cpu::*;

--- a/crates/inference/src/forward/mod.rs
+++ b/crates/inference/src/forward/mod.rs
@@ -16,7 +16,12 @@ pub mod metal_qwen35;
 pub mod moe_expert_cache;
 pub mod neon;
 pub mod neon_forward;
-pub mod signpost;
+// Every call site lives inside `metal_qwen35`'s `metal-gpu`-gated Metal
+// decode implementation; with that feature off, nothing in this crate
+// constructs a `Label`/`Interval`, which is otherwise flagged as dead code
+// now that the module is `pub(crate)` rather than a public API surface.
+#[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
+pub(crate) mod signpost;
 
 // Re-export from cpu for backward compat (was `layers`)
 pub use self::cpu::*;

--- a/crates/inference/src/forward/signpost.rs
+++ b/crates/inference/src/forward/signpost.rs
@@ -127,11 +127,33 @@ mod imp {
         }
     }
 
+    /// The category string is `<os/signpost.h>`'s `OS_LOG_CATEGORY_DYNAMIC_TRACING`:
+    /// ```c
+    /// #define OS_LOG_CATEGORY_DYNAMIC_TRACING "DynamicTracing"
+    /// ```
+    /// (`/Library/Developer/CommandLineTools/SDKs/MacOSX26.2.sdk/usr/include/os/signpost.h:332`,
+    /// under the header's own `@const OS_LOG_CATEGORY_DYNAMIC_TRACING` doc comment:
+    /// "signposts emitted to the resulting log handle should be disabled by
+    /// default, reducing the runtime overhead. os_signpost_enabled calls on the
+    /// resulting log handle will only return 'true' when a performance tool
+    /// like Instruments.app is recording.") A plain `"decode"` category (the
+    /// prior value) has no such contract — `os_signpost_enabled` on it can be
+    /// `true` with no tool attached, so every decode interval paid ID
+    /// generation plus begin/end FFI even in an idle signpost-enabled build.
+    /// This category name is not one of `Label`'s `__TEXT,__oslogstring`
+    /// statics: it is passed to `os_log_create`, not to
+    /// `_os_signpost_emit_with_name_impl`'s `name`/`format` parameters, so it
+    /// does not need compiler-string-table placement — only those two
+    /// parameters are read from `__TEXT,__oslogstring` by the trace decoder.
+    /// A heap `CString`, one-time-allocated and `OnceLock`-cached below (not
+    /// a per-interval cost), is the same category-string mechanism the
+    /// subsystem string already used before this fix.
     fn decode_log() -> os_log_t {
         static LOG: OnceLock<usize> = OnceLock::new();
         let ptr = *LOG.get_or_init(|| {
             let subsystem = CString::new("ai.lattice.inference").expect("static subsystem string");
-            let category = CString::new("decode").expect("static category string");
+            let category =
+                CString::new("DynamicTracing").expect("static dynamic-tracing category string");
             // SAFETY: both CStrings outlive this call; os_log_create copies
             // what it needs internally per Apple's os_log contract. This is a
             // one-time (OnceLock-cached) allocation, not a per-interval cost;
@@ -196,6 +218,15 @@ mod imp {
                 state: Some((log, spid, label)),
             }
         }
+
+        /// Same zero-FFI-cost `state: None` guard `begin` returns when
+        /// `os_signpost_enabled` observed false — used for a label that is
+        /// suppressed for the current [`super::Scope`] rather than for the
+        /// tracing-off case. No `decode_log()`/FFI call at all: the caller
+        /// already knows this scope must stay silent.
+        pub fn not_recording() -> Self {
+            Interval { state: None }
+        }
     }
 
     impl Drop for Interval {
@@ -220,10 +251,27 @@ mod imp {
         pub fn begin(_label: Label) -> Self {
             Interval
         }
+
+        #[inline(always)]
+        pub fn not_recording() -> Self {
+            Interval
+        }
     }
 }
 
 pub(crate) use imp::Interval;
+
+/// Discriminates which decode-path invocations of the shared per-token
+/// forward helper are in the documented autoregressive-decode scope. Only
+/// `Scope::Decode` call sites emit `decode.*` signposts; MTP verification,
+/// prompt-prefill (multimodal or plain), and diagnostic replays pass
+/// `Scope::NotDecode` and stay silent — the same shared helper otherwise
+/// reports their work as decode, contradicting the label glossary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Scope {
+    Decode,
+    NotDecode,
+}
 
 /// Begin a signpost interval for `label`, ending it when the returned guard
 /// drops. No-op (zero-sized, inlined away) unless built with `--features
@@ -233,12 +281,23 @@ pub(crate) fn interval(label: Label) -> Interval {
     Interval::begin(label)
 }
 
+/// Same as [`interval`], but only for `Scope::Decode`; `Scope::NotDecode`
+/// returns the same zero-FFI-cost guard a disabled/not-recording build
+/// returns, without touching `decode_log()` or any FFI call.
+#[inline(always)]
+pub(crate) fn interval_in(scope: Scope, label: Label) -> Interval {
+    match scope {
+        Scope::Decode => Interval::begin(label),
+        Scope::NotDecode => Interval::not_recording(),
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod recorder {
     //! Emission-recording seam for tests: records begin/end pairing without
     //! touching the real macOS FFI path, so pairing can be asserted on every
     //! platform/feature combination `cargo test` runs under.
-    use super::Label;
+    use super::{Label, Scope};
     use std::cell::RefCell;
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -259,18 +318,30 @@ pub(crate) mod recorder {
         LOG.with(|log| log.borrow().clone())
     }
 
-    pub(crate) struct RecordingInterval(Label);
+    pub(crate) struct RecordingInterval(Option<Label>);
 
     impl RecordingInterval {
         pub(crate) fn begin(label: Label) -> Self {
             LOG.with(|log| log.borrow_mut().push(Event::Begin(label)));
-            RecordingInterval(label)
+            RecordingInterval(Some(label))
+        }
+
+        /// Mirrors [`super::interval_in`]'s scope gating: `Scope::NotDecode`
+        /// records nothing at begin or drop, exactly like the real FFI path's
+        /// `Interval::not_recording()`.
+        pub(crate) fn begin_in(scope: Scope, label: Label) -> Self {
+            match scope {
+                Scope::Decode => Self::begin(label),
+                Scope::NotDecode => RecordingInterval(None),
+            }
         }
     }
 
     impl Drop for RecordingInterval {
         fn drop(&mut self) {
-            LOG.with(|log| log.borrow_mut().push(Event::End(self.0)));
+            if let Some(label) = self.0 {
+                LOG.with(|log| log.borrow_mut().push(Event::End(label)));
+            }
         }
     }
 }
@@ -278,6 +349,7 @@ pub(crate) mod recorder {
 #[cfg(test)]
 mod tests {
     use super::Label;
+    use super::Scope;
     use super::interval;
     use super::recorder::{Event, RecordingInterval};
 
@@ -314,6 +386,39 @@ mod tests {
                 Event::End(Label::DecodeCbCommit),
                 Event::End(Label::DecodeStep),
             ]
+        );
+    }
+
+    // Mutation-sensitive: drives the `Scope` discriminator both ways through
+    // the exact `RecordingInterval::begin_in` seam `interval_in` mirrors.
+    // `Scope::NotDecode` (MTP verify / prefill / diagnostic call sites) must
+    // record zero events; `Scope::Decode` must record the full begin/end
+    // pair. Reverting the discriminator (emitting unconditionally, as the
+    // shared helper did before this fix) makes the `NotDecode` assertion
+    // fail — see fix-round-3 report for the mutation run.
+    #[test]
+    fn scope_discriminator_silences_non_decode_and_records_decode() {
+        super::recorder::clear();
+        {
+            let _not_decode = RecordingInterval::begin_in(Scope::NotDecode, Label::DecodeStep);
+        }
+        assert_eq!(
+            super::recorder::events(),
+            vec![],
+            "Scope::NotDecode must record nothing"
+        );
+
+        super::recorder::clear();
+        {
+            let _decode = RecordingInterval::begin_in(Scope::Decode, Label::DecodeStep);
+        }
+        assert_eq!(
+            super::recorder::events(),
+            vec![
+                Event::Begin(Label::DecodeStep),
+                Event::End(Label::DecodeStep)
+            ],
+            "Scope::Decode must record the begin/end pair"
         );
     }
 }

--- a/crates/inference/src/forward/signpost.rs
+++ b/crates/inference/src/forward/signpost.rs
@@ -1,17 +1,39 @@
 //! `os_signpost` instrumentation for the Metal decode path (feature `signpost`,
 //! default OFF).
 //!
-//! Every call site is an RAII interval guard: `signpost::interval("label")`
+//! Every call site is an RAII interval guard: `signpost::interval(Label::X)`
 //! begins an `os_signpost` interval and ends it when the guard drops. When the
 //! `signpost` feature is disabled, or the target isn't macOS, [`interval`]
 //! returns a zero-sized no-op type and the call compiles to nothing — the
 //! call sites in the decode path never need a `#[cfg(...)]` of their own.
 //!
-//! See `docs/metal-trace.md` for how to capture a Metal System Trace with
-//! these signposts and the label glossary.
+//! The label set is closed (see [`Label`]) and each variant is backed by a
+//! `static` byte string placed in the binary's `__TEXT,__oslogstring`
+//! section — the same section Clang places `os_signpost_interval_begin`'s
+//! string-literal `name`/`format` arguments into. Apple's underscored
+//! `_os_signpost_emit_with_name_impl` entry point (what the public macros
+//! expand to) requires its `name`/`format` pointers to live there; a heap
+//! `CString` does not qualify and is recorded as an empty name in Instruments.
+//!
+//! See `crates/inference/METAL_TRACE.md` for how to capture a Metal System
+//! Trace with these signposts and the label glossary.
+
+/// Closed set of decode-path signpost interval labels. Adding a new call site
+/// means adding a variant here (and its backing static in `imp`, macOS-only).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)] // "Decode" mirrors the decode.* signpost namespace, not redundant noise
+pub(crate) enum Label {
+    DecodeStep,
+    DecodeCbCommit,
+    DecodeCbWait,
+    DecodeHostScalarRead,
+    DecodeGrammarMask,
+    DecodeSample,
+}
 
 #[cfg(all(feature = "signpost", target_os = "macos"))]
 mod imp {
+    use super::Label;
     use std::ffi::{CString, c_char, c_void};
     use std::sync::OnceLock;
 
@@ -31,10 +53,16 @@ mod imp {
 
         // The public `os_signpost_interval_begin`/`_end` macros in
         // <os/signpost.h> are Clang-only (they rely on `__builtin_os_log_format`
-        // to build the log's argument buffer at compile time). Called from
-        // Rust, the equivalent is the underscored-but-exported libsystem_trace
-        // entry point those macros expand to for a static, no-format-argument
-        // name — the same technique other non-Clang os_signpost bindings use.
+        // to build the log's argument buffer at compile time, and require
+        // `name`/`format` to be string literals placed by the compiler into
+        // the `__TEXT,__oslogstring` section). Called from Rust, the
+        // equivalent is the underscored-but-exported libsystem_trace entry
+        // point those macros expand to for a static, no-format-argument name
+        // — the same technique other non-Clang os_signpost bindings use. We
+        // supply `name`/`format` pointers into statics placed in that same
+        // section ourselves (see the `oslogstring!` statics below) so this
+        // satisfies the same compiled-in-binary-string-table contract Clang's
+        // macro expansion satisfies; a heap `CString` does not.
         fn _os_signpost_emit_with_name_impl(
             dso: *const c_void,
             log: os_log_t,
@@ -47,37 +75,96 @@ mod imp {
         );
     }
 
+    /// Declares a `static` NUL-terminated byte array placed in the
+    /// `__TEXT,__oslogstring,cstring_literals` Mach-O section — verified
+    /// against this machine's Xcode/CommandLineTools SDK to be the same
+    /// section Clang places `os_log`/`os_signpost` string-literal name and
+    /// format arguments into (confirmed via `clang -S -emit-llvm` on a
+    /// minimal `os_signpost_interval_begin` call: both the name and the
+    /// empty-format constant land in a `section "__TEXT,__oslogstring,cstring_literals"`
+    /// global). `#[used]` keeps the linker from discarding it as dead data;
+    /// only its address (not a load of its contents through normal Rust
+    /// code) is ever taken.
+    macro_rules! oslogstring {
+        ($name:ident, $s:literal) => {
+            #[used]
+            #[unsafe(link_section = "__TEXT,__oslogstring,cstring_literals")]
+            static $name: [u8; $s.len() + 1] = {
+                let src = $s.as_bytes();
+                let mut buf = [0u8; $s.len() + 1];
+                let mut i = 0;
+                while i < src.len() {
+                    buf[i] = src[i];
+                    i += 1;
+                }
+                buf
+            };
+        };
+    }
+
+    oslogstring!(NAME_DECODE_STEP, "decode.step");
+    oslogstring!(NAME_DECODE_CB_COMMIT, "decode.cb_commit");
+    oslogstring!(NAME_DECODE_CB_WAIT, "decode.cb_wait");
+    oslogstring!(NAME_DECODE_HOST_SCALAR_READ, "decode.host_scalar_read");
+    oslogstring!(NAME_DECODE_GRAMMAR_MASK, "decode.grammar_mask");
+    oslogstring!(NAME_DECODE_SAMPLE, "decode.sample");
+    // Zero-argument log payload: empty format string + a 2-byte header
+    // {flags=0, argc=0}, matching what Clang's macro emits when there are no
+    // dynamic values to log.
+    oslogstring!(EMPTY_FORMAT, "");
+
+    impl Label {
+        fn name_ptr(self) -> *const c_char {
+            let bytes: &'static [u8] = match self {
+                Label::DecodeStep => &NAME_DECODE_STEP,
+                Label::DecodeCbCommit => &NAME_DECODE_CB_COMMIT,
+                Label::DecodeCbWait => &NAME_DECODE_CB_WAIT,
+                Label::DecodeHostScalarRead => &NAME_DECODE_HOST_SCALAR_READ,
+                Label::DecodeGrammarMask => &NAME_DECODE_GRAMMAR_MASK,
+                Label::DecodeSample => &NAME_DECODE_SAMPLE,
+            };
+            bytes.as_ptr().cast()
+        }
+    }
+
     fn decode_log() -> os_log_t {
         static LOG: OnceLock<usize> = OnceLock::new();
         let ptr = *LOG.get_or_init(|| {
             let subsystem = CString::new("ai.lattice.inference").expect("static subsystem string");
             let category = CString::new("decode").expect("static category string");
             // SAFETY: both CStrings outlive this call; os_log_create copies
-            // what it needs internally per Apple's os_log contract.
+            // what it needs internally per Apple's os_log contract. This is a
+            // one-time (OnceLock-cached) allocation, not a per-interval cost;
+            // subsystem/category are not the compile-time-provenance strings
+            // the emit-impl's name/format arguments must be.
             unsafe { os_log_create(subsystem.as_ptr(), category.as_ptr()) as usize }
         });
         ptr as os_log_t
     }
 
-    fn emit(log: os_log_t, signpost_type: u8, spid: os_signpost_id_t, name: &CString) {
-        // SAFETY: `log` is a live os_log_t from `decode_log()`; `name` is a
-        // valid NUL-terminated C string held on the stack for this call;
-        // `format`/`buf` describe a zero-argument log payload (empty format
-        // string, 2-byte header {flags=0, argc=0}), matching what Clang's
-        // macro emits when there are no dynamic values to log.
+    /// Emits without re-checking `os_signpost_enabled` — callers must already
+    /// know signposts are enabled (only reached from a live [`Interval`]
+    /// whose `begin` observed `os_signpost_enabled(log) == true`).
+    fn emit_unchecked(
+        log: os_log_t,
+        signpost_type: u8,
+        spid: os_signpost_id_t,
+        name: *const c_char,
+    ) {
+        let buf: [u8; 2] = [0, 0];
+        // SAFETY: `log` is a live os_log_t from `decode_log()`; `name` and
+        // the format pointer are `'static` addresses into the
+        // `__TEXT,__oslogstring` section; `buf` describes a zero-argument
+        // log payload matching what Clang's macro emits with no dynamic
+        // values.
         unsafe {
-            if !os_signpost_enabled(log) {
-                return;
-            }
-            let format = c"";
-            let buf: [u8; 2] = [0, 0];
             _os_signpost_emit_with_name_impl(
                 &__dso_handle as *const c_void,
                 log,
                 signpost_type,
                 spid,
-                name.as_ptr(),
-                format.as_ptr(),
+                name,
+                EMPTY_FORMAT.as_ptr().cast(),
                 buf.as_ptr(),
                 buf.len() as u32,
             );
@@ -85,58 +172,114 @@ mod imp {
     }
 
     pub struct Interval {
-        log: os_log_t,
-        spid: os_signpost_id_t,
-        name: CString,
+        // `None` when `os_signpost_enabled` was false at `begin` time (the
+        // common case with tracing off) — `Drop` then does no FFI work at
+        // all, rather than repeating the enabled check.
+        state: Option<(os_log_t, os_signpost_id_t, Label)>,
     }
 
     impl Interval {
-        pub fn begin(label: &str) -> Self {
+        pub fn begin(label: Label) -> Self {
             let log = decode_log();
-            let name = CString::new(label).unwrap_or_else(|_| {
-                CString::new("invalid-signpost-label").expect("static fallback string")
-            });
+            // First operation: the enabled check. Only on true do we pay for
+            // ID generation and emission — statics mean the label lookup
+            // itself is always zero-allocation, but we still skip the FFI
+            // calls entirely when nothing is recording.
+            // SAFETY: `log` is a live os_log_t from `decode_log()`.
+            if !unsafe { os_signpost_enabled(log) } {
+                return Interval { state: None };
+            }
             // SAFETY: `log` is a live os_log_t from `decode_log()`.
             let spid = unsafe { os_signpost_id_generate(log) };
-            emit(log, OS_SIGNPOST_INTERVAL_BEGIN, spid, &name);
-            Interval { log, spid, name }
+            emit_unchecked(log, OS_SIGNPOST_INTERVAL_BEGIN, spid, label.name_ptr());
+            Interval {
+                state: Some((log, spid, label)),
+            }
         }
     }
 
     impl Drop for Interval {
         fn drop(&mut self) {
-            emit(self.log, OS_SIGNPOST_INTERVAL_END, self.spid, &self.name);
+            if let Some((log, spid, label)) = self.state {
+                emit_unchecked(log, OS_SIGNPOST_INTERVAL_END, spid, label.name_ptr());
+            }
         }
     }
 }
 
 #[cfg(not(all(feature = "signpost", target_os = "macos")))]
 mod imp {
+    use super::Label;
+
     /// Zero-sized no-op: optimizes away entirely so the default build (feature
     /// off, or non-macOS) is byte-identical to a build with no signpost calls.
     pub struct Interval;
 
     impl Interval {
         #[inline(always)]
-        pub fn begin(_label: &str) -> Self {
+        pub fn begin(_label: Label) -> Self {
             Interval
         }
     }
 }
 
-pub use imp::Interval;
+pub(crate) use imp::Interval;
 
-/// Begin a signpost interval named `label`, ending it when the returned guard
+/// Begin a signpost interval for `label`, ending it when the returned guard
 /// drops. No-op (zero-sized, inlined away) unless built with `--features
 /// signpost` on macOS.
 #[inline(always)]
-pub fn interval(label: &str) -> Interval {
+pub(crate) fn interval(label: Label) -> Interval {
     Interval::begin(label)
 }
 
 #[cfg(test)]
+pub(crate) mod recorder {
+    //! Emission-recording seam for tests: records begin/end pairing without
+    //! touching the real macOS FFI path, so pairing can be asserted on every
+    //! platform/feature combination `cargo test` runs under.
+    use super::Label;
+    use std::cell::RefCell;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) enum Event {
+        Begin(Label),
+        End(Label),
+    }
+
+    thread_local! {
+        static LOG: RefCell<Vec<Event>> = const { RefCell::new(Vec::new()) };
+    }
+
+    pub(crate) fn clear() {
+        LOG.with(|log| log.borrow_mut().clear());
+    }
+
+    pub(crate) fn events() -> Vec<Event> {
+        LOG.with(|log| log.borrow().clone())
+    }
+
+    pub(crate) struct RecordingInterval(Label);
+
+    impl RecordingInterval {
+        pub(crate) fn begin(label: Label) -> Self {
+            LOG.with(|log| log.borrow_mut().push(Event::Begin(label)));
+            RecordingInterval(label)
+        }
+    }
+
+    impl Drop for RecordingInterval {
+        fn drop(&mut self) {
+            LOG.with(|log| log.borrow_mut().push(Event::End(self.0)));
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use super::Label;
     use super::interval;
+    use super::recorder::{Event, RecordingInterval};
 
     // Exercises the exact call-site shape used in the decode path (bind a
     // guard, let it drop at end of scope). Compiles and runs identically
@@ -145,9 +288,32 @@ mod tests {
     // separate call-site variant to test per configuration.
     #[test]
     fn interval_guard_compiles_and_drops_cleanly() {
-        let _guard = interval("decode.step");
+        let _guard = interval(Label::DecodeStep);
         {
-            let _nested = interval("decode.cb_commit");
+            let _nested = interval(Label::DecodeCbCommit);
         }
+    }
+
+    // Mutation-sensitive: asserts the actual begin/end emission order for a
+    // nested two-interval scope via the recording seam, independent of the
+    // real (macOS-only) FFI path exercised by the smoke test above.
+    #[test]
+    fn nested_intervals_emit_begin_end_in_order() {
+        super::recorder::clear();
+        {
+            let _outer = RecordingInterval::begin(Label::DecodeStep);
+            {
+                let _inner = RecordingInterval::begin(Label::DecodeCbCommit);
+            }
+        }
+        assert_eq!(
+            super::recorder::events(),
+            vec![
+                Event::Begin(Label::DecodeStep),
+                Event::Begin(Label::DecodeCbCommit),
+                Event::End(Label::DecodeCbCommit),
+                Event::End(Label::DecodeStep),
+            ]
+        );
     }
 }

--- a/crates/inference/src/forward/signpost.rs
+++ b/crates/inference/src/forward/signpost.rs
@@ -1,0 +1,153 @@
+//! `os_signpost` instrumentation for the Metal decode path (feature `signpost`,
+//! default OFF).
+//!
+//! Every call site is an RAII interval guard: `signpost::interval("label")`
+//! begins an `os_signpost` interval and ends it when the guard drops. When the
+//! `signpost` feature is disabled, or the target isn't macOS, [`interval`]
+//! returns a zero-sized no-op type and the call compiles to nothing — the
+//! call sites in the decode path never need a `#[cfg(...)]` of their own.
+//!
+//! See `docs/metal-trace.md` for how to capture a Metal System Trace with
+//! these signposts and the label glossary.
+
+#[cfg(all(feature = "signpost", target_os = "macos"))]
+mod imp {
+    use std::ffi::{CString, c_char, c_void};
+    use std::sync::OnceLock;
+
+    #[allow(non_camel_case_types)]
+    type os_log_t = *mut c_void;
+    #[allow(non_camel_case_types)]
+    type os_signpost_id_t = u64;
+
+    const OS_SIGNPOST_INTERVAL_BEGIN: u8 = 1;
+    const OS_SIGNPOST_INTERVAL_END: u8 = 2;
+
+    unsafe extern "C" {
+        fn os_log_create(subsystem: *const c_char, category: *const c_char) -> os_log_t;
+        fn os_signpost_id_generate(log: os_log_t) -> os_signpost_id_t;
+        fn os_signpost_enabled(log: os_log_t) -> bool;
+        static __dso_handle: c_void;
+
+        // The public `os_signpost_interval_begin`/`_end` macros in
+        // <os/signpost.h> are Clang-only (they rely on `__builtin_os_log_format`
+        // to build the log's argument buffer at compile time). Called from
+        // Rust, the equivalent is the underscored-but-exported libsystem_trace
+        // entry point those macros expand to for a static, no-format-argument
+        // name — the same technique other non-Clang os_signpost bindings use.
+        fn _os_signpost_emit_with_name_impl(
+            dso: *const c_void,
+            log: os_log_t,
+            signpost_type: u8,
+            spid: os_signpost_id_t,
+            name: *const c_char,
+            format: *const c_char,
+            buf: *const u8,
+            size: u32,
+        );
+    }
+
+    fn decode_log() -> os_log_t {
+        static LOG: OnceLock<usize> = OnceLock::new();
+        let ptr = *LOG.get_or_init(|| {
+            let subsystem = CString::new("ai.lattice.inference").expect("static subsystem string");
+            let category = CString::new("decode").expect("static category string");
+            // SAFETY: both CStrings outlive this call; os_log_create copies
+            // what it needs internally per Apple's os_log contract.
+            unsafe { os_log_create(subsystem.as_ptr(), category.as_ptr()) as usize }
+        });
+        ptr as os_log_t
+    }
+
+    fn emit(log: os_log_t, signpost_type: u8, spid: os_signpost_id_t, name: &CString) {
+        // SAFETY: `log` is a live os_log_t from `decode_log()`; `name` is a
+        // valid NUL-terminated C string held on the stack for this call;
+        // `format`/`buf` describe a zero-argument log payload (empty format
+        // string, 2-byte header {flags=0, argc=0}), matching what Clang's
+        // macro emits when there are no dynamic values to log.
+        unsafe {
+            if !os_signpost_enabled(log) {
+                return;
+            }
+            let format = c"";
+            let buf: [u8; 2] = [0, 0];
+            _os_signpost_emit_with_name_impl(
+                &__dso_handle as *const c_void,
+                log,
+                signpost_type,
+                spid,
+                name.as_ptr(),
+                format.as_ptr(),
+                buf.as_ptr(),
+                buf.len() as u32,
+            );
+        }
+    }
+
+    pub struct Interval {
+        log: os_log_t,
+        spid: os_signpost_id_t,
+        name: CString,
+    }
+
+    impl Interval {
+        pub fn begin(label: &str) -> Self {
+            let log = decode_log();
+            let name = CString::new(label).unwrap_or_else(|_| {
+                CString::new("invalid-signpost-label").expect("static fallback string")
+            });
+            // SAFETY: `log` is a live os_log_t from `decode_log()`.
+            let spid = unsafe { os_signpost_id_generate(log) };
+            emit(log, OS_SIGNPOST_INTERVAL_BEGIN, spid, &name);
+            Interval { log, spid, name }
+        }
+    }
+
+    impl Drop for Interval {
+        fn drop(&mut self) {
+            emit(self.log, OS_SIGNPOST_INTERVAL_END, self.spid, &self.name);
+        }
+    }
+}
+
+#[cfg(not(all(feature = "signpost", target_os = "macos")))]
+mod imp {
+    /// Zero-sized no-op: optimizes away entirely so the default build (feature
+    /// off, or non-macOS) is byte-identical to a build with no signpost calls.
+    pub struct Interval;
+
+    impl Interval {
+        #[inline(always)]
+        pub fn begin(_label: &str) -> Self {
+            Interval
+        }
+    }
+}
+
+pub use imp::Interval;
+
+/// Begin a signpost interval named `label`, ending it when the returned guard
+/// drops. No-op (zero-sized, inlined away) unless built with `--features
+/// signpost` on macOS.
+#[inline(always)]
+pub fn interval(label: &str) -> Interval {
+    Interval::begin(label)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::interval;
+
+    // Exercises the exact call-site shape used in the decode path (bind a
+    // guard, let it drop at end of scope). Compiles and runs identically
+    // whether this crate is built with `--features signpost` (a real
+    // interval on macOS) or without it (the no-op fallback) -- there is no
+    // separate call-site variant to test per configuration.
+    #[test]
+    fn interval_guard_compiles_and_drops_cleanly() {
+        let _guard = interval("decode.step");
+        {
+            let _nested = interval("decode.cb_commit");
+        }
+    }
+}

--- a/crates/inference/src/forward/signpost.rs
+++ b/crates/inference/src/forward/signpost.rs
@@ -31,6 +31,67 @@ pub(crate) enum Label {
     DecodeSample,
 }
 
+/// Runtime selector for the `os_log` category `decode_log()` creates its
+/// handle with, read once from `LATTICE_SIGNPOST_MODE` at first use.
+///
+/// The two documented capture paths need opposite `os_signpost_enabled`
+/// defaults: Instruments.app (GUI) attaches as an Instruments-style tool
+/// session, so `DynamicTracing` sees it and stays idle-inert the rest of the
+/// time. `xcrun xctrace record --instrument os_signpost` (CLI) does not —
+/// on this machine's macOS 26, a direct `os_signpost_enabled` probe under
+/// that exact invocation reported `DynamicTracing=0` while an ordinary
+/// category reported `decode=1`, so the CLI path needs the ordinary
+/// category to observe anything at all. One process cannot satisfy both
+/// defaults with a compile-time-fixed category, hence the runtime switch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SignpostMode {
+    /// `DynamicTracing` category (`OS_LOG_CATEGORY_DYNAMIC_TRACING`):
+    /// idle-inert, `os_signpost_enabled` is only true while an
+    /// Instruments-style tool session is attached. Default (unset or
+    /// `"auto"`), preserves round 3's idle-inertness fix.
+    Auto,
+    /// Ordinary `"decode"` category: `os_signpost_enabled` is true whenever
+    /// any collector could observe it, including the `xcrun xctrace` CLI
+    /// capture path. Opt-in via `LATTICE_SIGNPOST_MODE=always`.
+    Always,
+}
+
+impl SignpostMode {
+    pub(crate) const ENV_VAR: &'static str = "LATTICE_SIGNPOST_MODE";
+
+    /// Pure parsing, independent of the actual process environment so it can
+    /// be unit-tested without mutating global env state: `"always"` selects
+    /// [`SignpostMode::Always`]; unset, `"auto"`, or anything else defaults
+    /// to [`SignpostMode::Auto`] (fail-safe toward the idle-inert default).
+    pub(crate) fn from_env_value(value: Option<&str>) -> Self {
+        match value {
+            Some("always") => SignpostMode::Always,
+            _ => SignpostMode::Auto,
+        }
+    }
+
+    #[cfg_attr(not(all(feature = "signpost", target_os = "macos")), allow(dead_code))]
+    fn from_process_env() -> Self {
+        let value = std::env::var(Self::ENV_VAR).ok();
+        Self::from_env_value(value.as_deref())
+    }
+
+    /// The `os_log_create` category string for this mode. `Auto` is
+    /// `<os/signpost.h>`'s `OS_LOG_CATEGORY_DYNAMIC_TRACING`
+    /// (`/Library/Developer/CommandLineTools/SDKs/MacOSX26.2.sdk/usr/include/os/signpost.h:332`):
+    /// "signposts emitted to the resulting log handle should be disabled by
+    /// default... will only return 'true' when a performance tool like
+    /// Instruments.app is recording." `Always` is a plain category with no
+    /// such contract, matching what the `xcrun xctrace` CLI workflow needs.
+    #[cfg_attr(not(all(feature = "signpost", target_os = "macos")), allow(dead_code))]
+    fn category(self) -> &'static str {
+        match self {
+            SignpostMode::Auto => "DynamicTracing",
+            SignpostMode::Always => "decode",
+        }
+    }
+}
+
 #[cfg(all(feature = "signpost", target_os = "macos"))]
 mod imp {
     use super::Label;
@@ -63,6 +124,16 @@ mod imp {
         // section ourselves (see the `oslogstring!` statics below) so this
         // satisfies the same compiled-in-binary-string-table contract Clang's
         // macro expansion satisfies; a heap `CString` does not.
+        // SDK header (`os/signpost.h:378-380`, all installed CommandLineTools
+        // SDKs incl. MacOSX26.2): `void _os_signpost_emit_with_name_impl(void
+        // *dso, os_log_t log, os_signpost_type_t type, os_signpost_id_t spid,
+        // const char *name, const char *format, uint8_t *buf, uint32_t
+        // size);` — `buf` is a writable `uint8_t *`, not `const`. The prior
+        // Rust declaration typed it `*const u8` and passed a pointer derived
+        // from an immutable `static`/stack array; if the OS implementation
+        // ever writes through `buf` (its own log-packet buffer), that was UB
+        // over immutable memory. `buf` is declared `*mut u8` here and every
+        // call site passes a mutable stack scratch buffer instead.
         fn _os_signpost_emit_with_name_impl(
             dso: *const c_void,
             log: os_log_t,
@@ -70,7 +141,7 @@ mod imp {
             spid: os_signpost_id_t,
             name: *const c_char,
             format: *const c_char,
-            buf: *const u8,
+            buf: *mut u8,
             size: u32,
         );
     }
@@ -127,40 +198,40 @@ mod imp {
         }
     }
 
-    /// The category string is `<os/signpost.h>`'s `OS_LOG_CATEGORY_DYNAMIC_TRACING`:
-    /// ```c
-    /// #define OS_LOG_CATEGORY_DYNAMIC_TRACING "DynamicTracing"
-    /// ```
-    /// (`/Library/Developer/CommandLineTools/SDKs/MacOSX26.2.sdk/usr/include/os/signpost.h:332`,
-    /// under the header's own `@const OS_LOG_CATEGORY_DYNAMIC_TRACING` doc comment:
-    /// "signposts emitted to the resulting log handle should be disabled by
-    /// default, reducing the runtime overhead. os_signpost_enabled calls on the
-    /// resulting log handle will only return 'true' when a performance tool
-    /// like Instruments.app is recording.") A plain `"decode"` category (the
-    /// prior value) has no such contract — `os_signpost_enabled` on it can be
-    /// `true` with no tool attached, so every decode interval paid ID
-    /// generation plus begin/end FFI even in an idle signpost-enabled build.
+    /// Creates the `os_log_t` handle for an explicit category string. Kept
+    /// separate from [`decode_log`] so tests can construct a log for each
+    /// `SignpostMode` category directly and assert on `os_signpost_enabled`
+    /// without touching process-global environment state (the mode→category
+    /// mapping is instead tested in isolation via
+    /// `SignpostMode::from_env_value`, which takes an `Option<&str>`).
+    ///
     /// This category name is not one of `Label`'s `__TEXT,__oslogstring`
     /// statics: it is passed to `os_log_create`, not to
     /// `_os_signpost_emit_with_name_impl`'s `name`/`format` parameters, so it
     /// does not need compiler-string-table placement — only those two
     /// parameters are read from `__TEXT,__oslogstring` by the trace decoder.
-    /// A heap `CString`, one-time-allocated and `OnceLock`-cached below (not
-    /// a per-interval cost), is the same category-string mechanism the
-    /// subsystem string already used before this fix.
+    /// A heap `CString`, one-time-allocated per call, is the same
+    /// category-string mechanism the subsystem string already used.
+    fn create_log(category: &str) -> usize {
+        let subsystem = CString::new("ai.lattice.inference").expect("static subsystem string");
+        let category = CString::new(category).expect("signpost category string has no NUL byte");
+        // SAFETY: both CStrings outlive this call; os_log_create copies what
+        // it needs internally per Apple's os_log contract.
+        unsafe { os_log_create(subsystem.as_ptr(), category.as_ptr()) as usize }
+    }
+
+    /// `os_signpost_enabled`'s default for the resulting log handle depends
+    /// on the category `SignpostMode` selects (see [`super::SignpostMode`]):
+    /// `DynamicTracing` (mode `Auto`, default) is idle-inert until an
+    /// Instruments-style tool session attaches; the ordinary `"decode"`
+    /// category (mode `Always`, opt-in via `LATTICE_SIGNPOST_MODE=always`)
+    /// is enabled whenever any collector could observe it, including the
+    /// `xcrun xctrace` CLI capture path. Read once and `OnceLock`-cached —
+    /// not a per-interval cost.
     fn decode_log() -> os_log_t {
         static LOG: OnceLock<usize> = OnceLock::new();
-        let ptr = *LOG.get_or_init(|| {
-            let subsystem = CString::new("ai.lattice.inference").expect("static subsystem string");
-            let category =
-                CString::new("DynamicTracing").expect("static dynamic-tracing category string");
-            // SAFETY: both CStrings outlive this call; os_log_create copies
-            // what it needs internally per Apple's os_log contract. This is a
-            // one-time (OnceLock-cached) allocation, not a per-interval cost;
-            // subsystem/category are not the compile-time-provenance strings
-            // the emit-impl's name/format arguments must be.
-            unsafe { os_log_create(subsystem.as_ptr(), category.as_ptr()) as usize }
-        });
+        let ptr =
+            *LOG.get_or_init(|| create_log(super::SignpostMode::from_process_env().category()));
         ptr as os_log_t
     }
 
@@ -173,12 +244,18 @@ mod imp {
         spid: os_signpost_id_t,
         name: *const c_char,
     ) {
-        let buf: [u8; 2] = [0, 0];
+        // Mutable stack scratch buffer, not a `&'static`/immutable source:
+        // the header types `buf` as writable `uint8_t *` (see the SAFETY
+        // note above the extern block), so a pointer derived from immutable
+        // memory would be UB if the OS implementation ever wrote through it.
+        // Zero-argument payload semantics (empty format, 2-byte {flags=0,
+        // argc=0} header) are unchanged.
+        let mut buf: [u8; 2] = [0, 0];
         // SAFETY: `log` is a live os_log_t from `decode_log()`; `name` and
         // the format pointer are `'static` addresses into the
-        // `__TEXT,__oslogstring` section; `buf` describes a zero-argument
-        // log payload matching what Clang's macro emits with no dynamic
-        // values.
+        // `__TEXT,__oslogstring` section; `buf` is a live mutable stack
+        // buffer describing a zero-argument log payload matching what
+        // Clang's macro emits with no dynamic values.
         unsafe {
             _os_signpost_emit_with_name_impl(
                 &__dso_handle as *const c_void,
@@ -187,7 +264,7 @@ mod imp {
                 spid,
                 name,
                 EMPTY_FORMAT.as_ptr().cast(),
-                buf.as_ptr(),
+                buf.as_mut_ptr(),
                 buf.len() as u32,
             );
         }
@@ -234,6 +311,39 @@ mod imp {
             if let Some((log, spid, label)) = self.state {
                 emit_unchecked(log, OS_SIGNPOST_INTERVAL_END, spid, label.name_ptr());
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        // Regression for finding 4 (round-4 review): the two documented
+        // capture paths need opposite `os_signpost_enabled` defaults, and
+        // both are observable in-process with no Instruments/xctrace tool
+        // attached — no external tooling needed to guard this. Constructs
+        // logs from an explicit category string (never touches process env)
+        // so it can run concurrently with other tests without env races;
+        // the env->mode parsing itself is tested separately in the outer
+        // `mod tests` via `SignpostMode::from_env_value`.
+        #[test]
+        fn always_mode_category_is_enabled_with_no_tool_attached() {
+            let log = create_log("decode") as os_log_t;
+            assert!(
+                unsafe { os_signpost_enabled(log) },
+                "ordinary category must report enabled even with no tool attached \
+                 (mode=always exists precisely so the xcrun xctrace CLI path observes it)"
+            );
+        }
+
+        #[test]
+        fn auto_mode_category_is_idle_inert_with_no_tool_attached() {
+            let log = create_log("DynamicTracing") as os_log_t;
+            assert!(
+                !unsafe { os_signpost_enabled(log) },
+                "DynamicTracing category must report disabled with no tool attached \
+                 (round 3's idle-inertness property, preserved as the default mode)"
+            );
         }
     }
 }
@@ -350,8 +460,50 @@ pub(crate) mod recorder {
 mod tests {
     use super::Label;
     use super::Scope;
+    use super::SignpostMode;
     use super::interval;
     use super::recorder::{Event, RecordingInterval};
+
+    // Pure parsing, platform- and feature-independent (runs under every
+    // `cargo test` combination the gates use): unset/"auto"/anything
+    // unrecognized default to the idle-inert mode; only the literal string
+    // "always" opts into the ordinary category the xctrace CLI path needs.
+    // Deliberately does not touch `std::env` — see the in-process
+    // `os_signpost_enabled` regression tests in `imp::tests` (macOS +
+    // `signpost` feature only) for the category-behavior half of finding 4.
+    #[test]
+    fn signpost_mode_from_env_value() {
+        assert_eq!(SignpostMode::from_env_value(None), SignpostMode::Auto);
+        assert_eq!(SignpostMode::from_env_value(Some("")), SignpostMode::Auto);
+        assert_eq!(
+            SignpostMode::from_env_value(Some("auto")),
+            SignpostMode::Auto
+        );
+        assert_eq!(
+            SignpostMode::from_env_value(Some("Always")),
+            SignpostMode::Auto
+        );
+        assert_eq!(
+            SignpostMode::from_env_value(Some("bogus")),
+            SignpostMode::Auto
+        );
+        assert_eq!(
+            SignpostMode::from_env_value(Some("always")),
+            SignpostMode::Always
+        );
+    }
+
+    // Mutation-sensitive: the mode -> category string mapping `decode_log()`
+    // relies on. Also platform/feature independent (`category()` compiles
+    // under every combination; only its callers are macOS+signpost-gated).
+    // Breaking this mapping (e.g. always returning "DynamicTracing") is
+    // exactly the round-4 finding-4 regression -- see fix-round-4 report
+    // for the mutation run.
+    #[test]
+    fn signpost_mode_category_mapping() {
+        assert_eq!(SignpostMode::Auto.category(), "DynamicTracing");
+        assert_eq!(SignpostMode::Always.category(), "decode");
+    }
 
     // Exercises the exact call-site shape used in the decode path (bind a
     // guard, let it drop at end of scope). Compiles and runs identically
@@ -385,6 +537,28 @@ mod tests {
                 Event::Begin(Label::DecodeCbCommit),
                 Event::End(Label::DecodeCbCommit),
                 Event::End(Label::DecodeStep),
+            ]
+        );
+    }
+
+    // Mutation-sensitive: pairing regression for `Label::DecodeSample`, the
+    // exact label `sample_decode_traced` in `metal_qwen35.rs` opens --
+    // finding 1's round-4 fix made that one call site the *only* place any
+    // of the five decode loops open a `decode.sample` interval (previously
+    // five independent copies, two of which had already drifted with no
+    // interval at all). See fix-round-4 report for the mutation run
+    // breaking `RecordingInterval::begin` and observing this test fail.
+    #[test]
+    fn decode_sample_label_records_begin_end_pair() {
+        super::recorder::clear();
+        {
+            let _guard = RecordingInterval::begin(Label::DecodeSample);
+        }
+        assert_eq!(
+            super::recorder::events(),
+            vec![
+                Event::Begin(Label::DecodeSample),
+                Event::End(Label::DecodeSample)
             ]
         );
     }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

Adds `os_signpost` instrumentation over the existing Metal decode path (`MetalQwen35State::forward_step` and its callers), gated behind a new `signpost` cargo feature (default OFF). This lets a Metal System Trace captured in Instruments show per-decode-step launch and synchronization structure — command-buffer commit, interior `waitUntilCompleted` wait, host-side scalar reads, grammar masking, and sampling — instead of one opaque GPU-busy span.

- New module `crates/inference/src/forward/signpost.rs`: an RAII interval guard (`signpost::interval(label)`) backed by a minimal `extern "C"` shim over libsystem_trace's `os_signpost`/`os_log` entry points on macOS. No new external dependency — it reuses the same "link a macOS framework directly" idiom the crate already uses for Metal/objc.
- Off the `signpost` feature (or on non-macOS), the guard is a zero-sized no-op type with an `#[inline(always)]` constructor, so call sites don't need their own `#[cfg(...)]`.
- Instrumented labels: `decode.step`, `decode.cb_commit`, `decode.cb_wait`, `decode.host_scalar_read`, `decode.grammar_mask`, `decode.sample`.
- New doc: `crates/inference/METAL_TRACE.md` — how to capture a trace in Instruments, plus the label glossary.

No behavior change to the decode path itself; this is instrumentation only.

## bench-compare disposition

The `signpost` feature is default-OFF, and its *implementation* (the real `os_signpost` FFI calls) lives entirely behind `#[cfg(all(feature = "signpost", target_os = "macos"))]` in `signpost.rs`, so that code is compiled out of any default-feature bench build.

However, the call sites added in `metal_qwen35.rs` (`signpost::interval("decode.step")` etc.) are **not** themselves behind `#[cfg(feature = "signpost")]` — they are unconditional calls into a zero-sized no-op guard type when the feature is off. That means these lines *do* reach the default bench build's source, even though they're designed to optimize away to nothing (an inlined constructor for a zero-sized type, immediately dropped). Per this repo's bench-compare carve-out, that's a materially different claim than "compiled out entirely," so I'm not self-certifying via the structural argument here — flagging it instead of asserting no-op-by-construction is enough.

`make bench-compare` was not run in this session. Recommend a quick `--quick` A/B on the decode/elementwise groups before merge to confirm the no-op call sites carry no measurable cost in the default build.

## Test plan

- [x] `cargo check -p lattice-inference --features f16,metal-gpu,test-utils` (signpost off) — clean
- [x] `cargo check -p lattice-inference --features f16,metal-gpu,test-utils,signpost` — clean
- [x] `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu,test-utils -- -D warnings` — clean
- [x] `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu,test-utils,signpost -- -D warnings` — clean
- [x] `cargo test -p lattice-inference --lib --features f16,metal-gpu,test-utils signpost::` — passes (no-op fallback)
- [x] `cargo test -p lattice-inference --lib --features f16,metal-gpu,test-utils,signpost signpost::` — passes (real os_signpost path, runs without crashing)
- [ ] `make bench-compare` — not run this session, see disposition above
- [ ] Capture an actual Metal System Trace in Instruments and confirm the labeled intervals show up (needs a local Instruments session)