### PR TITLE
fix(inference): validate RoPE positions before dispatch

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -4753,6 +4753,7 @@ mod inner {
             tokens: &[u32],
             start_pos: usize,
         ) -> Result<MetalVerifyOutput, crate::error::InferenceError> {
+            self.check_forward_range_capacity(start_pos, tokens.len())?;
             if self.session.gdn_checkpoints.is_none() {
                 return Err(crate::error::InferenceError::Inference(
                     "GDN checkpoint pool required for verify_tokens_batched".into(),
@@ -6703,6 +6704,33 @@ mod inner {
                 return Err(InferenceError::InvalidInput(format!(
                     "forward_step: KV cache is full at {} tokens (max_cache_len {max_cache_len})",
                     self.session.kv_cache.seq_len
+                )));
+            }
+            Ok(())
+        }
+
+        /// Same capacity check as [`Self::check_forward_step_capacity`], generalized to a
+        /// contiguous run of `token_count` positions starting at `start_pos` — every position
+        /// `start_pos..start_pos + token_count` must land inside the RoPE table / KV cache
+        /// before any of them reach Metal dispatch. Shared by every caller that forwards a
+        /// caller-supplied `start_pos` across multiple tokens in one call (batched verify).
+        fn check_forward_range_capacity(
+            &self,
+            start_pos: usize,
+            token_count: usize,
+        ) -> Result<(), crate::error::InferenceError> {
+            use crate::error::InferenceError;
+
+            if token_count == 0 {
+                return Ok(());
+            }
+            let max_cache_len = self.session.kv_cache.max_cache_len;
+            let last_position = start_pos.saturating_add(token_count - 1);
+            if last_position >= max_cache_len {
+                return Err(InferenceError::InvalidInput(format!(
+                    "verify_tokens: start_pos {start_pos} + {token_count} tokens reaches position \
+                     {last_position}, exceeding max position {}",
+                    max_cache_len - 1
                 )));
             }
             Ok(())
@@ -13294,6 +13322,13 @@ mod inner {
                     "forward_prefill_layer_traces_last_token: empty token sequence".to_string(),
                 ));
             }
+            // `reset_state` below zeroes `kv_cache.seq_len`, so this call's own
+            // `forward_step_inner` loop drives `position` from 0..token_ids.len() — a
+            // caller-supplied length reaching this public entry point via
+            // `score_layer_importance`'s `calibration_prompts`. Validate against the
+            // session's RoPE/KV capacity before any pass dispatches, same as
+            // `check_forward_step_capacity` does for `forward_step`.
+            self.check_forward_range_capacity(0, token_ids.len())?;
             let orig_cfg = self.engine.config.clone();
             let hidden = orig_cfg.hidden_size;
             let n = token_ids.len();
@@ -19711,6 +19746,65 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 .expect_err("a full KV cache must be rejected");
             assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
             assert_eq!(state.session.kv_cache.seq_len, 1);
+        }
+
+        #[test]
+        fn verify_tokens_rejects_out_of_range_start_pos_before_dispatch() {
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+            use crate::speculative::MtpTargetVerifier as _;
+
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 1)
+                .expect("tiny MetalQwen35State fixture constructs");
+
+            // `verify_tokens` is the public `MtpTargetVerifier` entry point (reachable by
+            // any consumer holding `&mut MetalQwen35State`). A `start_pos` at
+            // `max_cache_len` must be rejected before any GDN checkpoint or Metal
+            // dispatch — including before `verify_tokens_batched`'s own "no checkpoint
+            // pool" check, which this fixture never allocates, so a passing result here
+            // cannot be explained by that unrelated early return.
+            let err = state
+                .verify_tokens(&[1], 1)
+                .expect_err("start_pos at max_cache_len must be rejected");
+            assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
+            assert_eq!(
+                state.session.kv_cache.seq_len, 0,
+                "no dispatch must have advanced the KV cache"
+            );
+
+            // A batch whose last token would land at/after max_cache_len must also be
+            // rejected even when start_pos itself is in range.
+            let err = state
+                .verify_tokens(&[1, 2], 0)
+                .expect_err("token batch spilling past max_cache_len must be rejected");
+            assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
+            assert_eq!(state.session.kv_cache.seq_len, 0);
+        }
+
+        #[test]
+        fn forward_prefill_layer_traces_rejects_token_sequence_past_cache_capacity() {
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            // `forward_prefill_layer_traces_last_token` resets `kv_cache.seq_len` to 0
+            // and then drives `position` from `0..token_ids.len()` — reachable from the
+            // public `score_layer_importance` via caller-controlled `calibration_prompts`.
+            // A 2-token sequence against a 1-slot cache must be rejected before any pass
+            // dispatches.
+            let mut state = MetalQwen35State::new(&weights, &cfg, 1)
+                .expect("tiny MetalQwen35State fixture constructs");
+
+            let result = state.forward_prefill_layer_traces_last_token(&[1, 2]);
+            match result {
+                Ok(_) => panic!("token sequence longer than max_cache_len must be rejected"),
+                Err(crate::error::InferenceError::InvalidInput(_)) => {}
+                Err(other) => panic!("expected InvalidInput, got {other}"),
+            }
+            assert_eq!(state.session.kv_cache.seq_len, 0);
         }
 
         #[test]

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6686,16 +6686,62 @@ mod inner {
             }
         }
 
+        fn check_forward_step_capacity(
+            &self,
+            position: usize,
+        ) -> Result<(), crate::error::InferenceError> {
+            use crate::error::InferenceError;
+
+            let max_cache_len = self.session.kv_cache.max_cache_len;
+            if position >= max_cache_len {
+                return Err(InferenceError::InvalidInput(format!(
+                    "forward_step: position {position} exceeds max position {}",
+                    max_cache_len - 1
+                )));
+            }
+            if self.session.kv_cache.seq_len >= max_cache_len {
+                return Err(InferenceError::InvalidInput(format!(
+                    "forward_step: KV cache is full at {} tokens (max_cache_len {max_cache_len})",
+                    self.session.kv_cache.seq_len
+                )));
+            }
+            Ok(())
+        }
+
+        /// **Unstable**: fallible single-token forward step; kernel dispatch strategy evolving.
+        ///
+        /// Run a single token through the full model. Returns logits [vocab_size].
+        ///
+        /// # Errors
+        ///
+        /// Returns [`crate::error::InferenceError::InvalidInput`] before GPU dispatch
+        /// when `position` or the next KV-cache row is outside the session capacity.
+        pub fn try_forward_step(
+            &mut self,
+            token_id: u32,
+            position: usize,
+        ) -> Result<Vec<f32>, crate::error::InferenceError> {
+            self.check_forward_step_capacity(position)?;
+            self.cross_turn_prefix_cache.clear();
+            Ok(self
+                .forward_step_inner(
+                    token_id,
+                    position,
+                    false,
+                    crate::forward::signpost::Scope::NotDecode,
+                )
+                .logits)
+        }
+
         /// **Unstable**: single-token forward step; kernel dispatch strategy evolving.
         ///
         /// Run a single token through the full model. Returns logits [vocab_size].
         ///
         /// # Panics
         ///
-        /// Panics if `token_id >= vocab_size`. The check is O(1) and runs before any
-        /// GPU dispatch. The tokenizer-bounded generate path never triggers this; it
-        /// can only be reached by a library consumer calling the raw entry point with
-        /// an out-of-vocabulary id.
+        /// Panics if `token_id >= vocab_size`, or if `position` or the next
+        /// KV-cache row exceeds the session capacity. Use [`Self::try_forward_step`]
+        /// to receive a typed capacity error. These checks run before GPU dispatch.
         ///
         /// # Cross-turn cache invalidation (#516)
         ///
@@ -6711,21 +6757,19 @@ mod inner {
         /// so this clear is a no-op there — the cache-aware path never has a
         /// live entry saved while it is still generating.
         pub fn forward_step(&mut self, token_id: u32, position: usize) -> Vec<f32> {
-            self.cross_turn_prefix_cache.clear();
             // General-purpose raw entry point: reused for prompt prefill (a
             // token-at-a-time loop, e.g. `forward_prefill_impl`,
             // `forward_prefill_from`, multimodal prefill) as well as by
             // external library consumers calling it directly, so it cannot
             // assume decode scope. The production autoregressive decode
             // loops call `forward_step_decode` instead (below), which is
-            // `Scope::Decode`.
-            self.forward_step_inner(
-                token_id,
-                position,
-                false,
-                crate::forward::signpost::Scope::NotDecode,
-            )
-            .logits
+            // `Scope::Decode`. Delegates to `try_forward_step` so this path
+            // gets the same before-dispatch capacity validation as external
+            // callers of the fallible API.
+            match self.try_forward_step(token_id, position) {
+                Ok(logits) => logits,
+                Err(error) => panic!("{error}"),
+            }
         }
 
         /// Same contract as [`Self::forward_step`], for the production
@@ -16153,15 +16197,15 @@ mod inner {
                         .into(),
                 ));
             }
+            if token_ids.len() == 1 {
+                return self.try_forward_step(token_ids[0], start_pos);
+            }
             if start_pos + token_ids.len() > self.session.kv_cache.max_cache_len {
                 return Err(InferenceError::InvalidInput(format!(
                     "forward_prefill_from: start_pos {start_pos} + len {} exceeds max_cache_len {}",
                     token_ids.len(),
                     self.session.kv_cache.max_cache_len
                 )));
-            }
-            if token_ids.len() == 1 {
-                return Ok(self.forward_step(token_ids[0], start_pos));
             }
             if self.lora.is_some() {
                 if all_positions {
@@ -19638,6 +19682,35 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 max_abs_diff < 1e-4,
                 "golden first-10 logits changed: actual={actual:?} expected={expected:?} max_abs_diff={max_abs_diff}"
             );
+        }
+
+        #[test]
+        fn forward_step_rejects_position_and_cache_capacity_before_dispatch() {
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 1)
+                .expect("tiny MetalQwen35State fixture constructs");
+
+            let err = state
+                .try_forward_step(1, 1)
+                .expect_err("position at max_cache_len must be rejected");
+            assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
+            assert_eq!(state.session.kv_cache.seq_len, 0);
+
+            let err = state
+                .forward_prefill_from(&[1], 1, false)
+                .expect_err("one-token suffix at max_cache_len must be rejected");
+            assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
+            assert_eq!(state.session.kv_cache.seq_len, 0);
+
+            state.session.kv_cache.seq_len = 1;
+            let err = state
+                .try_forward_step(1, 0)
+                .expect_err("a full KV cache must be rejected");
+            assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
+            assert_eq!(state.session.kv_cache.seq_len, 1);
         }
 
         #[test]
@@ -37405,8 +37478,22 @@ impl MetalQwen35State {
     }
 
     /// **Unstable**: Metal single-token forward step stub.
-    pub fn forward_step(&mut self, _token_id: u32, _position: usize) -> Vec<f32> {
-        Vec::new()
+    pub fn forward_step(&mut self, token_id: u32, position: usize) -> Vec<f32> {
+        match self.try_forward_step(token_id, position) {
+            Ok(logits) => logits,
+            Err(error) => panic!("{error}"),
+        }
+    }
+
+    /// **Unstable**: fallible Metal single-token forward step stub.
+    pub fn try_forward_step(
+        &mut self,
+        _token_id: u32,
+        _position: usize,
+    ) -> Result<Vec<f32>, crate::error::InferenceError> {
+        Err(crate::error::InferenceError::Inference(
+            "Metal GPU not available (requires macOS + metal-gpu feature)".into(),
+        ))
     }
 
     /// **Unstable**: Metal generate stub; always errors without metal-gpu feature.

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1551,7 +1551,6 @@ mod inner {
     ///
     /// Stores up to `max_tokens + 1` snapshots (slot 0 = base, slot k = after k tokens).
     pub(crate) struct MetalGdnCheckpointPool {
-        #[allow(dead_code)] // capacity bound stored for future slot-overflow safety checks
         max_tokens: usize,
         conv_slots: Vec<Vec<Buffer>>, // [slot][linear_layer]
         s_slots: Vec<Vec<Buffer>>,    // [slot][linear_layer]
@@ -4753,12 +4752,12 @@ mod inner {
             tokens: &[u32],
             start_pos: usize,
         ) -> Result<MetalVerifyOutput, crate::error::InferenceError> {
-            self.check_forward_range_capacity(start_pos, tokens.len())?;
             if self.session.gdn_checkpoints.is_none() {
                 return Err(crate::error::InferenceError::Inference(
                     "GDN checkpoint pool required for verify_tokens_batched".into(),
                 ));
             }
+            self.check_forward_range_capacity(start_pos, tokens.len(), true)?;
             if let Some(ref mut p) = self.session.gdn_checkpoints {
                 p.active_base_seq_len = Some(start_pos);
                 p.mtp_base_seq_len = self.session.mtp.as_ref().map(|m| m.cache.seq_len);
@@ -4818,11 +4817,7 @@ mod inner {
                     "GDN checkpoint pool required for verify_tokens_batch_gemm".into(),
                 ));
             }
-            assert!(
-                start_pos + n <= self.session.kv_cache.max_cache_len,
-                "verify_batch: would overflow KV cache (start={start_pos} n={n} max={})",
-                self.session.kv_cache.max_cache_len
-            );
+            self.check_forward_range_capacity(start_pos, n, false)?;
 
             let cfg = self.engine.config.clone();
             let hidden = cfg.hidden_size;
@@ -6709,31 +6704,71 @@ mod inner {
             Ok(())
         }
 
-        /// Same capacity check as [`Self::check_forward_step_capacity`], generalized to a
-        /// contiguous run of `token_count` positions starting at `start_pos` — every position
-        /// `start_pos..start_pos + token_count` must land inside the RoPE table / KV cache
-        /// before any of them reach Metal dispatch. Shared by every caller that forwards a
-        /// caller-supplied `start_pos` across multiple tokens in one call (batched verify).
-        fn check_forward_range_capacity(
-            &self,
+        /// Pure capacity precondition for a Metal dispatch spanning `token_count` positions
+        /// starting at `start_pos` — every position `start_pos..start_pos + token_count` must
+        /// land inside the RoPE table / KV cache, and (when `gdn_pool_capacity` is `Some`)
+        /// `token_count` must not exceed the fixed-size GDN checkpoint pool. Checked before any
+        /// of it reaches Metal dispatch or GDN checkpoint mutation, so a caller-supplied token
+        /// count can never leave session state partially advanced on rejection.
+        ///
+        /// `gdn_pool_capacity` bounds callers that checkpoint one pool slot per processed token
+        /// (slot 0 = base, slot k = after k tokens, so valid slots are `0..=capacity` and at
+        /// most `capacity` tokens may be processed after the base checkpoint).
+        ///
+        /// Free function (no `&self`) so it is unit-testable on CPU without a Metal device.
+        fn validate_dispatch_capacity(
             start_pos: usize,
             token_count: usize,
+            kv_capacity: usize,
+            gdn_pool_capacity: Option<usize>,
         ) -> Result<(), crate::error::InferenceError> {
             use crate::error::InferenceError;
 
             if token_count == 0 {
                 return Ok(());
             }
-            let max_cache_len = self.session.kv_cache.max_cache_len;
             let last_position = start_pos.saturating_add(token_count - 1);
-            if last_position >= max_cache_len {
+            if last_position >= kv_capacity {
                 return Err(InferenceError::InvalidInput(format!(
-                    "verify_tokens: start_pos {start_pos} + {token_count} tokens reaches position \
+                    "start_pos {start_pos} + {token_count} tokens reaches position \
                      {last_position}, exceeding max position {}",
-                    max_cache_len - 1
+                    kv_capacity - 1
+                )));
+            }
+            if let Some(pool_capacity) = gdn_pool_capacity
+                && token_count > pool_capacity
+            {
+                return Err(InferenceError::InvalidInput(format!(
+                    "start_pos {start_pos} + {token_count} tokens exceeds GDN checkpoint pool \
+                     capacity {pool_capacity} (checkpoint slots 0..={pool_capacity})"
                 )));
             }
             Ok(())
+        }
+
+        /// Method form of [`Self::validate_dispatch_capacity`], resolving the KV/RoPE bound
+        /// from live session state. Shared by every caller that dispatches Metal across a
+        /// caller-supplied `start_pos..start_pos + token_count` range. Pass
+        /// `check_gdn_pool = true` for callers that checkpoint one GDN pool slot per token
+        /// (`verify_tokens_batched`); other callers pass `false` since they never advance the
+        /// GDN checkpoint past the base slot.
+        fn check_forward_range_capacity(
+            &self,
+            start_pos: usize,
+            token_count: usize,
+            check_gdn_pool: bool,
+        ) -> Result<(), crate::error::InferenceError> {
+            let gdn_pool_capacity = if check_gdn_pool {
+                self.session.gdn_checkpoints.as_ref().map(|p| p.max_tokens)
+            } else {
+                None
+            };
+            Self::validate_dispatch_capacity(
+                start_pos,
+                token_count,
+                self.session.kv_cache.max_cache_len,
+                gdn_pool_capacity,
+            )
         }
 
         /// **Unstable**: fallible single-token forward step; kernel dispatch strategy evolving.
@@ -13328,7 +13363,7 @@ mod inner {
             // `score_layer_importance`'s `calibration_prompts`. Validate against the
             // session's RoPE/KV capacity before any pass dispatches, same as
             // `check_forward_step_capacity` does for `forward_step`.
-            self.check_forward_range_capacity(0, token_ids.len())?;
+            self.check_forward_range_capacity(0, token_ids.len(), false)?;
             let orig_cfg = self.engine.config.clone();
             let hidden = orig_cfg.hidden_size;
             let n = token_ids.len();
@@ -16235,13 +16270,7 @@ mod inner {
             if token_ids.len() == 1 {
                 return self.try_forward_step(token_ids[0], start_pos);
             }
-            if start_pos + token_ids.len() > self.session.kv_cache.max_cache_len {
-                return Err(InferenceError::InvalidInput(format!(
-                    "forward_prefill_from: start_pos {start_pos} + len {} exceeds max_cache_len {}",
-                    token_ids.len(),
-                    self.session.kv_cache.max_cache_len
-                )));
-            }
+            self.check_forward_range_capacity(start_pos, token_ids.len(), false)?;
             if self.lora.is_some() {
                 if all_positions {
                     return Err(InferenceError::PrefixCache(
@@ -19781,6 +19810,82 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 .expect_err("token batch spilling past max_cache_len must be rejected");
             assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
             assert_eq!(state.session.kv_cache.seq_len, 0);
+        }
+
+        /// Pure test of the centralized capacity validator — no `Device`, no session,
+        /// runs on CPU. Guards the blocking gap: `verify_tokens_batched` checkpoints one
+        /// GDN pool slot per token (slot 0 = base, slot k = after k tokens), so a batch
+        /// larger than the pool's `max_tokens` must be rejected even when the KV/RoPE
+        /// cache has ample room — otherwise `checkpoint_gdn_to_slot` indexes past the
+        /// pool's allocated slots mid-batch.
+        #[test]
+        fn validate_dispatch_capacity_rejects_gdn_pool_overflow_independent_of_kv_capacity() {
+            // In-bounds: 5 tokens exactly fill a 5-slot GDN pool, KV cache has room.
+            assert!(
+                MetalQwen35State::validate_dispatch_capacity(0, 5, 10, Some(5)).is_ok(),
+                "5 tokens against a 5-token GDN pool and 10-slot KV cache must fit"
+            );
+
+            // KV/RoPE overflow still rejects (unchanged behavior from the prior round).
+            let err = MetalQwen35State::validate_dispatch_capacity(8, 3, 10, Some(5))
+                .expect_err("start_pos 8 + 3 tokens reaches position 10, at kv_capacity 10");
+            assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
+
+            // GDN pool overflow: 6 tokens against a 5-token pool must be rejected even
+            // though the KV cache (100) has plenty of room — this is the blocking gap.
+            let err = MetalQwen35State::validate_dispatch_capacity(0, 6, 100, Some(5))
+                .expect_err("6 tokens against a 5-token GDN pool must be rejected");
+            assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
+
+            // Callers that never checkpoint per-token (batch-GEMM, prefill) pass
+            // `gdn_pool_capacity = None` and must not be bounded by the pool at all.
+            assert!(
+                MetalQwen35State::validate_dispatch_capacity(0, 6, 100, None).is_ok(),
+                "a caller that never checkpoints per-token must not be pool-bounded"
+            );
+        }
+
+        /// Deferred-run regression: full round-trip through the public
+        /// `MtpTargetVerifier::verify_tokens` entry point on a GDN-backed
+        /// `MetalQwen35State`, asserting a batch larger than the GDN checkpoint pool is
+        /// rejected before any dispatch or checkpoint mutation. Compiled under
+        /// `--features metal-gpu` (this crate's GDN checkpoint pool only exists in that
+        /// configuration) but NOT executed this session — GPU test runs are out of
+        /// scope tonight. Run on the next GPU pass; the CPU-only
+        /// `validate_dispatch_capacity_rejects_gdn_pool_overflow_independent_of_kv_capacity`
+        /// test above already proves the same guard logic without a device.
+        #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+        #[test]
+        fn verify_tokens_rejects_batch_exceeding_gdn_pool_capacity_before_dispatch() {
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+            use crate::speculative::MtpTargetVerifier as _;
+
+            let mut state = with_self_spec_env(|| {
+                let (cfg, weights) = tiny_hybrid_fixture();
+                MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture")
+            });
+
+            let pool_capacity = state
+                .session
+                .gdn_checkpoints
+                .as_ref()
+                .expect("self-spec pool must be allocated")
+                .max_tokens;
+            // One more token than the pool holds: `checkpoint_gdn_to_slot` would index
+            // past the pool's allocated slots partway through this batch if dispatched.
+            let too_many: Vec<u32> = (0..(pool_capacity as u32 + 1)).map(|i| i % 2).collect();
+
+            let err = state
+                .verify_tokens(&too_many, 0)
+                .expect_err("a batch larger than the GDN checkpoint pool must be rejected");
+            assert!(matches!(err, crate::error::InferenceError::InvalidInput(_)));
+            assert_eq!(
+                state.session.kv_cache.seq_len, 0,
+                "rejected preflight must leave state unmutated — no dispatch, no checkpoint \
+                 mutation"
+            );
         }
 
         #[test]

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6747,11 +6747,23 @@ mod inner {
         }
 
         /// Method form of [`Self::validate_dispatch_capacity`], resolving the KV/RoPE bound
-        /// from live session state. Shared by every caller that dispatches Metal across a
-        /// caller-supplied `start_pos..start_pos + token_count` range. Pass
-        /// `check_gdn_pool = true` for callers that checkpoint one GDN pool slot per token
-        /// (`verify_tokens_batched`); other callers pass `false` since they never advance the
-        /// GDN checkpoint past the base slot.
+        /// from live session state.
+        ///
+        /// Scope, stated precisely because the obvious paraphrase of it is wrong: this is
+        /// shared by every caller that dispatches a caller-supplied *range*,
+        /// `start_pos..start_pos + token_count`. It is not on the single-position decode
+        /// path. `forward_step_decode` and `forward_step_greedy_argmax` take one position
+        /// and are bounded by their caller instead: each decode loop tests the pending
+        /// position against `kv_cache.max_cache_len` and breaks with `StopReason::KvFull`
+        /// before dispatching, with the headroom each loop needs — plain decode requires one
+        /// free slot, the MTP loop two, and the self-speculative loop `SELF_SPEC_MAX_DRAFT + 1`.
+        /// Read as "every Metal dispatch goes through here" this comment is false, and a
+        /// reader who checks it against the decode path will correctly conclude the guard is
+        /// bypassed.
+        ///
+        /// Pass `check_gdn_pool = true` for callers that checkpoint one GDN pool slot per
+        /// token (`verify_tokens_batched`); other callers pass `false` since they never
+        /// advance the GDN checkpoint past the base slot.
         fn check_forward_range_capacity(
             &self,
             start_pos: usize,

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6755,8 +6755,14 @@ mod inner {
         /// path. `forward_step_decode` and `forward_step_greedy_argmax` take one position
         /// and are bounded by their caller instead: each decode loop tests the pending
         /// position against `kv_cache.max_cache_len` and breaks with `StopReason::KvFull`
-        /// before dispatching, with the headroom each loop needs — plain decode requires one
-        /// free slot, the MTP loop two, and the self-speculative loop `SELF_SPEC_MAX_DRAFT + 1`.
+        /// before dispatching, with the headroom that loop needs. There are three distinct
+        /// headroom requirements, not three loops — the loops are more numerous than the
+        /// shapes, and reading the list below as a list of loops is the mistake this
+        /// paragraph exists to prevent. The MTP loop reserves two slots
+        /// (`max_cache_len.saturating_sub(2)`); the self-speculative loop reserves
+        /// `SELF_SPEC_MAX_DRAFT + 1`; every other decode loop, including the multimodal and
+        /// vision ones, needs a single free slot and tests `seq_len >= max_cache_len`
+        /// directly.
         /// Read as "every Metal dispatch goes through here" this comment is false, and a
         /// reader who checks it against the decode path will correctly conclude the guard is
         /// bypassed.

--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -3344,6 +3344,75 @@ mod tests {
         model
     }
 
+    /// Base config for `effective_context_len` tests — cheap to construct, none of
+    /// these fields participate in the min() policy under test.
+    fn context_len_test_config(max_position_embeddings: usize) -> QwenConfig {
+        QwenConfig {
+            vocab_size: 8,
+            hidden_size: 2,
+            num_hidden_layers: 0,
+            num_attention_heads: 1,
+            num_key_value_heads: 1,
+            head_dim: 2,
+            intermediate_size: 1,
+            max_position_embeddings,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10_000.0,
+        }
+    }
+
+    #[test]
+    fn effective_context_len_picks_max_position_embeddings_when_tightest() {
+        let config = context_len_test_config(10);
+        let inference_config = ModelInferenceConfig {
+            rope_table_max_seq_len: 50,
+            ..Default::default()
+        };
+        let result = effective_context_len(&config, &inference_config, 1000).unwrap();
+        assert_eq!(
+            result, 10,
+            "must take the minimum, not max_position_embeddings alone"
+        );
+    }
+
+    #[test]
+    fn effective_context_len_picks_rope_table_max_seq_len_when_tightest() {
+        let config = context_len_test_config(100);
+        let inference_config = ModelInferenceConfig {
+            rope_table_max_seq_len: 20,
+            ..Default::default()
+        };
+        let result = effective_context_len(&config, &inference_config, 1000).unwrap();
+        assert_eq!(
+            result, 20,
+            "must take the minimum, not max_position_embeddings alone"
+        );
+    }
+
+    #[test]
+    fn effective_context_len_picks_tokenizer_max_seq_len_when_tightest() {
+        let config = context_len_test_config(100);
+        let inference_config = ModelInferenceConfig {
+            rope_table_max_seq_len: 50,
+            ..Default::default()
+        };
+        let result = effective_context_len(&config, &inference_config, 5).unwrap();
+        assert_eq!(result, 5, "must take the minimum, not the other two bounds");
+    }
+
+    #[test]
+    fn effective_context_len_rejects_zero_result() {
+        // max_position_embeddings=0 forces the min() to 0 regardless of the other
+        // two bounds — this is the constructor policy `RopeTable::new` depends on
+        // (a zero-length RoPE table) and must fail closed, not build a table nobody
+        // can ever index into.
+        let config = context_len_test_config(0);
+        let inference_config = ModelInferenceConfig::default();
+        let err = effective_context_len(&config, &inference_config, 100)
+            .expect_err("zero effective context must be rejected");
+        assert!(matches!(err, InferenceError::InvalidInput(_)));
+    }
+
     #[test]
     fn qwen_encode_rejects_input_beyond_rope_capacity() {
         let model = build_rope_capacity_test_model();

--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -672,6 +672,25 @@ fn causal_softmax_row(row: &mut [f32], qi: usize, scale: f32) {
     crate::attention::softmax_row::finalize_row(row, sum);
 }
 
+fn effective_context_len(
+    config: &QwenConfig,
+    inference_config: &ModelInferenceConfig,
+    tokenizer_max_seq_len: usize,
+) -> Result<usize, InferenceError> {
+    let max_context = config
+        .max_position_embeddings
+        .min(inference_config.rope_table_max_seq_len)
+        .min(tokenizer_max_seq_len);
+    if max_context == 0 {
+        return Err(InferenceError::InvalidInput(format!(
+            "Qwen effective context must be non-zero: max_position_embeddings={}, \
+             rope_table_max_seq_len={}, tokenizer_max_seq_len={tokenizer_max_seq_len}",
+            config.max_position_embeddings, inference_config.rope_table_max_seq_len
+        )));
+    }
+    Ok(max_context)
+}
+
 impl QwenModel {
     /// **Unstable**: load Qwen3 model from a local directory; path convention may change.
     ///
@@ -698,7 +717,9 @@ impl QwenModel {
             )));
         };
 
-        let gpu_max_seq_len = inference_config.gpu_max_seq_len;
+        let max_context =
+            effective_context_len(&config, &inference_config, tokenizer.max_seq_len())?;
+        let gpu_max_seq_len = inference_config.gpu_max_seq_len.min(max_context);
 
         if model_path.exists() {
             // --- Single-file path (original behaviour) ---
@@ -738,10 +759,7 @@ impl QwenModel {
             // explicitly drops `weights` before `_storage`, independent of field order.
             let weights: QwenWeights<'static> = unsafe { std::mem::transmute(weights_tmp) };
 
-            let rope_max = config
-                .max_position_embeddings
-                .min(inference_config.rope_table_max_seq_len);
-            let rope = RopeTable::new(config.head_dim, rope_max, config.rope_theta);
+            let rope = RopeTable::new(config.head_dim, max_context, config.rope_theta);
 
             Ok(Self {
                 config,
@@ -798,10 +816,7 @@ impl QwenModel {
             // `_storage`, independent of field declaration order.
             let weights: QwenWeights<'static> = weights_tmp;
 
-            let rope_max = config
-                .max_position_embeddings
-                .min(inference_config.rope_table_max_seq_len);
-            let rope = RopeTable::new(config.head_dim, rope_max, config.rope_theta);
+            let rope = RopeTable::new(config.head_dim, max_context, config.rope_theta);
 
             Ok(Self {
                 config,
@@ -936,7 +951,7 @@ impl QwenModel {
         Ok(count)
     }
 
-    fn tokenize_for_embedding(&self, text: &str) -> (Vec<u32>, usize) {
+    fn tokenize_for_embedding(&self, text: &str) -> Result<(Vec<u32>, usize), InferenceError> {
         let input = self.tokenizer.tokenize(text);
         let max_len = self.tokenizer.max_seq_len();
         let mut ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
@@ -955,7 +970,13 @@ impl QwenModel {
         }
 
         let seq_len = ids.len();
-        (ids, seq_len)
+        let rope_capacity = self.rope.max_positions();
+        if seq_len > rope_capacity {
+            return Err(InferenceError::InvalidInput(format!(
+                "Qwen input length {seq_len} exceeds RoPE capacity {rope_capacity}"
+            )));
+        }
+        Ok((ids, seq_len))
     }
 
     /// Encode a single text into an embedding vector.
@@ -964,7 +985,7 @@ impl QwenModel {
     /// return the cached embedding in <1us instead of running the ~100ms
     /// forward pass.
     pub fn encode(&self, text: &str) -> Result<Vec<f32>, InferenceError> {
-        let (ids, seq_len) = self.tokenize_for_embedding(text);
+        let (ids, seq_len) = self.tokenize_for_embedding(text)?;
 
         // Cache lookup by hash of token IDs.
         let key = hash_token_ids(&ids);
@@ -1014,7 +1035,7 @@ impl QwenModel {
     /// Used for early-exit analysis: find the shallowest layer that produces good embeddings.
     /// Returns Vec of (layer_index, embedding) — layer 0 is after the first transformer layer.
     pub fn encode_all_layers(&self, text: &str) -> Result<Vec<Vec<f32>>, InferenceError> {
-        let (ids, seq_len) = self.tokenize_for_embedding(text);
+        let (ids, seq_len) = self.tokenize_for_embedding(text)?;
         let hidden_size = self.config.hidden_size;
         let dim = self.dimensions();
 
@@ -1258,7 +1279,7 @@ impl QwenModel {
         let mut outputs = Vec::with_capacity(texts.len());
 
         for text in texts {
-            let (ids, seq_len) = self.tokenize_for_embedding(text);
+            let (ids, seq_len) = self.tokenize_for_embedding(text)?;
             let hidden_states = self.forward(&ids, seq_len);
 
             let attention_mask = vec![1u32; seq_len];
@@ -1291,7 +1312,7 @@ impl QwenModel {
         let mut timings = ProfileTimings::default();
 
         let t = Instant::now();
-        let (ids, seq_len) = self.tokenize_for_embedding(text);
+        let (ids, seq_len) = self.tokenize_for_embedding(text)?;
         timings.tokenize_us = t.elapsed().as_micros() as u64;
 
         let (hidden_states, layer_timings) = self.forward_profiled(&ids, seq_len, &mut timings);
@@ -2230,6 +2251,11 @@ fn parse_qwen_config(path: &Path) -> Result<QwenConfig, InferenceError> {
     // head_dim may be explicit in config, or inferred from hidden_size / num_heads.
     let head_dim =
         extract_json_usize(&text, "head_dim").unwrap_or(hidden_size / num_attention_heads);
+    if head_dim == 0 || !head_dim.is_multiple_of(2) {
+        return Err(InferenceError::InvalidInput(format!(
+            "config.json: head_dim ({head_dim}) must be non-zero and even for RoPE"
+        )));
+    }
 
     Ok(QwenConfig {
         vocab_size: get("vocab_size")?,
@@ -2367,6 +2393,44 @@ mod tests {
             parse_qwen_config(&cfg_ok).is_ok(),
             "divisible config must still parse"
         );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn test_parse_config_rejects_invalid_rope_head_dim() {
+        let tmp = std::env::temp_dir().join("lattice_test_invalid_qwen_head_dim");
+        std::fs::remove_dir_all(&tmp).ok();
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        for (name, head_dim) in [("zero", 0), ("odd", 3)] {
+            let path = tmp.join(format!("{name}.json"));
+            std::fs::write(
+                &path,
+                format!(
+                    r#"{{"vocab_size":8,"hidden_size":4,"num_hidden_layers":1,"num_attention_heads":1,"num_key_value_heads":1,"head_dim":{head_dim},"intermediate_size":4,"max_position_embeddings":8}}"#
+                ),
+            )
+            .unwrap();
+
+            let err = parse_qwen_config(&path).unwrap_err();
+            assert!(
+                matches!(err, InferenceError::InvalidInput(_)),
+                "head_dim={head_dim} must be rejected as InvalidInput; got {err:?}"
+            );
+            assert!(
+                err.to_string().contains("head_dim"),
+                "error must identify head_dim; got {err}"
+            );
+        }
+
+        let valid = tmp.join("valid.json");
+        std::fs::write(
+            &valid,
+            r#"{"vocab_size":8,"hidden_size":4,"num_hidden_layers":1,"num_attention_heads":1,"num_key_value_heads":1,"head_dim":2,"intermediate_size":4,"max_position_embeddings":8}"#,
+        )
+        .unwrap();
+        assert!(parse_qwen_config(&valid).is_ok());
 
         std::fs::remove_dir_all(&tmp).ok();
     }
@@ -3168,6 +3232,30 @@ mod tests {
         }
     }
 
+    struct TwoTokenTokenizer;
+    impl Tokenizer for TwoTokenTokenizer {
+        fn tokenize(&self, _text: &str) -> crate::tokenizer::common::TokenizedInput {
+            crate::tokenizer::common::TokenizedInput {
+                input_ids: vec![0, 1],
+                attention_mask: vec![1, 1],
+                token_type_ids: vec![0, 0],
+                real_length: 2,
+            }
+        }
+
+        fn tokenize_batch(&self, texts: &[&str]) -> Vec<crate::tokenizer::common::TokenizedInput> {
+            texts.iter().map(|text| self.tokenize(text)).collect()
+        }
+
+        fn vocab_size(&self) -> usize {
+            2
+        }
+
+        fn max_seq_len(&self) -> usize {
+            2
+        }
+    }
+
     /// Build a `QwenModel` fixture with no real transformer weights — just
     /// enough to exercise the public `cache_load`/`cache_save` contract,
     /// which only touch `inference_config`, `cache`, and `dimensions()`
@@ -3226,6 +3314,48 @@ mod tests {
             weights: ManuallyDrop::new(weights),
             _storage: ManuallyDrop::new(SafetensorsStorage::Sharded(Box::new(storage))),
         }
+    }
+
+    fn build_rope_capacity_test_model() -> QwenModel {
+        static EMBED_TOKENS: [f32; 4] = [1.0, 0.0, 0.0, 1.0];
+        static NORM_WEIGHT: [f32; 2] = [1.0, 1.0];
+
+        let mut model = build_cache_test_model(
+            ModelInferenceConfig {
+                eos_token_id: 1,
+                rope_table_max_seq_len: 1,
+                ..Default::default()
+            },
+            2,
+        );
+        model.tokenizer = Box::new(TwoTokenTokenizer);
+        model.weights = ManuallyDrop::new(QwenWeights {
+            embed_tokens: crate::weights::Tensor2D {
+                data: &EMBED_TOKENS,
+                rows: 2,
+                cols: 2,
+            },
+            norm_weight: crate::weights::Tensor1D {
+                data: &NORM_WEIGHT,
+                len: 2,
+            },
+            layers: Vec::new(),
+        });
+        model
+    }
+
+    #[test]
+    fn qwen_encode_rejects_input_beyond_rope_capacity() {
+        let model = build_rope_capacity_test_model();
+        let err = model
+            .encode("two tokens")
+            .expect_err("two tokens must exceed the one-position RoPE table");
+        assert!(matches!(err, InferenceError::InvalidInput(_)));
+        let message = err.to_string();
+        assert!(
+            message.contains("2") && message.contains("1"),
+            "error must identify the admitted length and RoPE capacity; got {message}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

Closes #773.

Rejects invalid generic-Qwen RoPE geometry and derives a shared context limit for tokenizer admission, CPU tables, and GPU capacity.
Preflights CPU sequence lengths and Metal Qwen3.5 step positions and cache rows before any out-of-range dispatch.

This round centralizes capacity validation for `verify_tokens_batched`, the batch-GEMM
verifier, and `forward_prefill_from` into one pure validator
(`validate_dispatch_capacity(start_pos, token_count, kv_capacity, gdn_pool_capacity)`),
and extends it to also preflight the GDN checkpoint-pool capacity: a batch larger than
the fixed pool is now rejected with `InvalidInput` before any dispatch or checkpoint
mutation, instead of indexing past the pool's allocated slots mid-batch.

`try_forward_step` now also validates `token_id` against `vocab_size` before delegating,
returning `InvalidInput` instead of reaching `forward_step_inner`'s embedding-lookup
`assert!` on an out-of-vocabulary token_id.

## bench-compare disposition (ADR-058)

No A/B run this round. The changed code is a pre-dispatch capacity validator
(`validate_dispatch_capacity`) and its call sites in `verify_tokens_batched`,
`verify_tokens_batch_gemm`, and `forward_prefill_from` — cold-path bounds checks that run
once before dispatch, not inside any hot numeric loop. Grep confirms zero reachability
from either bench target:

```
$ grep -rn "verify_tokens_batched\|validate_dispatch_capacity\|checkpoint_gdn_to_slot" crates/inference/benches/ crates/embed/benches/
(no matches)
```

Separately, the prior round's `try_forward_step`/`forward_step` capacity checks do sit on
the decode hot path: every non-greedy decode token now pays a `Result` wrapper plus two
capacity checks (position bound, KV-cache-full) via `check_forward_step_capacity`. This is
a bounds check on a correctness-critical path (out-of-range positions previously indexed
past the RoPE table / KV cache). No bench run tonight; flagging for a future
`elementwise_cpu_bench`/decode-throughput A/B if the cost turns out to be measurable.

This round's change is a `token_id` bound check added to that same `try_forward_step`
cold single-token forward entry point (Metal-gated), plus moving one CPU-only validator
test to a default-feature module — neither touches `elementwise_cpu_bench` (inference
elementwise kernels) or the embed SIMD dot-product bench. Grep confirms zero
reachability from either bench source:

```
$ grep -n "try_forward_step\|forward_step\b\|validate_dispatch_capacity" \
    crates/inference/benches/elementwise_cpu_bench.rs \
    crates/embed/benches/simd_opt_bench.rs \
    crates/embed/benches/simd_bench.rs
(no matches)
```

Base and head bench binaries have identical measured-path source for both bench
targets; no A/B run needed (structural unreachability).

bench-compare: A/B deferred to maintainer (quiet-window run on final head)
