### PR TITLE
fix(tune): gate simulated distillation labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,12 @@ jobs:
       # buffer bounds). Build AND run them here so the feature cannot rot silently.
       - name: tune — mixture (online router-refit, build + run tests)
         run: cargo test -p lattice-tune --features mixture --lib
+      # simulated-teacher gates the deterministic fixed-label test/example path
+      # (label_single_simulated, label_batch_simulated). Off by default, so the
+      # required `ci` job never compiles or runs it. Build AND run here so the
+      # opt-in API cannot rot silently.
+      - name: tune — simulated-teacher (build + run tests)
+        run: cargo test -p lattice-tune --features simulated-teacher --lib
       - name: inference — f16 + train-backward
         run: cargo build -p lattice-inference --features f16,train-backward
       # wgpu-gpu is excluded from default builds and was silently broken under

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -28,6 +28,8 @@ sqlite = ["dep:rusqlite", "serde"]
 # Online adapter-selector refit from preference feedback (experimental, bench-gated).
 # Pulls in the lattice-fann training primitives (RLOO / EWC++) for gate updates.
 mixture = ["lattice-fann/online-router"]
+# Fixed labels for tests and examples. Never enables the default labeling path.
+simulated-teacher = []
 
 [dependencies]
 lattice-fann = { version = "0.7.0", path = "../fann" }

--- a/crates/tune/README.md
+++ b/crates/tune/README.md
@@ -13,8 +13,9 @@ Knowledge distillation and training infrastructure for lattice neural models.
 
 `DistillationPipeline` and the CPU `TrainingLoop` currently provide orchestration
 placeholders, not end-to-end training. `DistillationPipeline::label_single` does
-not contact a teacher API; it returns a simulated label distribution and
-confidence. `TrainingLoop::train` drives batching, callbacks, metrics, early
+not contact a teacher API and fails closed with `TuneError::TeacherApi`. Fixed
+labels are available only through the non-default `simulated-teacher` feature and
+explicitly named simulation methods. `TrainingLoop::train` drives batching, callbacks, metrics, early
 stopping, and in-memory checkpoints, but its loss and accuracy are simulated and
 it does not update model weights. Do not treat either result as evidence of live
 teacher labeling or trained parameters.
@@ -185,9 +186,9 @@ let (train, validation) = dataset.split(0.8)?; // 20% for validation
 
 ## Distillation Pipeline
 
-This example exercises the current simulated response path. It validates the
-teacher configuration and formats the prompt, but it makes no HTTP request and
-does not read an API key.
+This example shows the default fail-closed behavior. The pipeline validates the
+teacher configuration, but it does not fabricate labels when live transport is
+unavailable.
 
 ```rust
 use lattice_tune::distill::{TeacherConfig, DistillationPipeline, RawExample};
@@ -204,15 +205,19 @@ let raw = RawExample::new(
     "What's the weather like?",
 );
 
-// Produce the placeholder's simulated labels
-let result = pipeline.label_single(&raw)?;
-println!("Simulated confidence: {}", result.confidence);
+let error = pipeline.label_single(&raw).unwrap_err();
+assert!(error.to_string().contains("not configured"));
 
 // Check statistics
 let stats = pipeline.stats();
-println!("Successful: {}", stats.successful);
+println!("Successful: {}", stats.successful); // 0
 println!("Failed: {}", stats.failed);
 ```
+
+Tests and examples that deliberately need fixed output can enable the
+`simulated-teacher` feature and call `label_single_simulated` or
+`label_batch_simulated`. These methods remain separate from the default live
+labeling methods even when the feature is enabled.
 
 ## Training
 
@@ -415,6 +420,10 @@ impl DistillationPipeline {
     pub fn with_teacher(config: TeacherConfig) -> Result<Self>;
     pub fn label_single(&mut self, example: &RawExample) -> Result<LabelingResult>;
     pub fn label_batch(&mut self, examples: &[RawExample]) -> Vec<LabelingResult>;
+    #[cfg(feature = "simulated-teacher")]
+    pub fn label_single_simulated(&mut self, example: &RawExample) -> Result<LabelingResult>;
+    #[cfg(feature = "simulated-teacher")]
+    pub fn label_batch_simulated(&mut self, examples: &[RawExample]) -> Vec<LabelingResult>;
     pub fn stats(&self) -> &DistillationStats;
 }
 ```

--- a/crates/tune/docs/design.md
+++ b/crates/tune/docs/design.md
@@ -109,10 +109,13 @@ results. [distill.md](distill.md) defines result conversion; [data.md](data.md)
 defines the vector and six-label contract.
 
 At present `DistillationPipeline` is a placeholder teacher integration. It
-formats and bounds a prompt, creates simulated labels, and maintains
-statistics; it makes no HTTP request and does not read an API-key environment
-variable. A deployment should supply a real provider client before relying on
-this route to generate labels.
+fails closed when live teacher transport is unavailable; deterministic fixed
+labels require the non-default `simulated-teacher` feature and explicitly named
+simulation methods. Those methods do not format or bound a prompt — they never
+inspect the example's content at all — and maintain statistics; the pipeline
+makes no HTTP request and does not read an API-key environment variable. A
+deployment should supply a real provider client before relying on this route
+to generate labels.
 
 ## Lifecycle 2: train and register a model
 

--- a/crates/tune/docs/distill.md
+++ b/crates/tune/docs/distill.md
@@ -10,10 +10,10 @@ the embedding-based `TrainingExample` values used by the rest of
 3. join successful labels with embeddings supplied by the caller.
 
 The module intentionally does not create embeddings. It also does **not**
-currently issue HTTP requests: `DistillationPipeline::label_single` formats a
-prompt but then returns a simulated label distribution. The configuration and
-result types define the intended integration boundary; callers must not treat
-the current pipeline as a live teacher client.
+currently issue HTTP requests: `DistillationPipeline::label_single` returns
+`TuneError::TeacherApi` instead of fabricating labels. Deterministic fixed labels
+are available only through the non-default `simulated-teacher` feature and the
+explicit `label_single_simulated` and `label_batch_simulated` methods.
 
 For the provider-selection decision and its alternatives, see
 [ADR-001: Multi-Provider Teacher Strategy](ADR-001-teacher-providers.md). The
@@ -26,9 +26,10 @@ the repository-wide ADR series.
 Raw text
   │
   ▼
-RawExample ──sanitize + format──► teacher prompt
-  │                                  │
-  │                                  └── current implementation: simulated result
+RawExample ──label_single────────► TeacherApi error (no live transport)
+  │
+  └──label_single_simulated─────► bounded prompt ──► fixed test labels
+         (`simulated-teacher` feature only)
   ▼
 LabelingResult ──successful only──► caller-provided embeddings
                                          │
@@ -225,7 +226,7 @@ threshold, no intermediate persistence, and a progress interval of 100.
 | ------------------- | ------: | -------------------------------------------------------------------------------------- |
 | `batch_size`        |      10 | Validated nonzero; not used to schedule the synchronous loop.                          |
 | `concurrency`       |       5 | Validated nonzero; not used to run parallel requests yet.                              |
-| `normalize_labels`  |    true | Applies `IntentLabels::softmax_normalize` to the simulated scores.                     |
+| `normalize_labels`  |    true | Applies `IntentLabels::softmax_normalize` to explicit simulated scores.                |
 | `min_confidence`    |    none | Rejects a result whose confidence is below the threshold.                              |
 | `save_intermediate` |   false | Stored only.                                                                           |
 | `output_dir`        |    none | `output_dir(...)` sets this and enables `save_intermediate`; no files are written yet. |
@@ -243,30 +244,25 @@ concurrency; when present, the confidence threshold must lie in `0.0..=1.0`.
 
 `DistillationPipeline::new` validates both the teacher and pipeline
 configuration, then starts with empty `DistillationStats`. `with_teacher` uses
-the default pipeline configuration. `label_single`:
+the default pipeline configuration. Because no live transport is configured,
+`label_single` returns `TuneError::TeacherApi` without creating labels or
+updating statistics.
 
-1. starts a latency timer and formats the raw prompt;
-2. currently creates fixed scores
-   `[0.4, 0.1, 0.3, 0.1, 0.05, 0.05]` instead of invoking a provider;
-3. applies softmax if requested;
-4. assigns a simulated confidence of `0.85`;
-5. rejects scores below `min_confidence`, when configured; otherwise records
-   a successful `LabelingResult` and updates statistics.
-
-Therefore, a threshold above `0.85` causes the current placeholder to return
-`TuneError::Validation`. On that direct error path the pipeline increments
-`stats.skipped` but does not increment `total_processed`; `label_batch` turns
-the error into a failed result and supplies that second accounting update.
+With the non-default `simulated-teacher` feature,
+`label_single_simulated` does not format a prompt or otherwise inspect the
+example's content — it creates fixed scores `[0.4, 0.1, 0.3, 0.1, 0.05,
+0.05]` independent of `raw`, optionally applies softmax, and assigns
+confidence `0.85`. A configured threshold above `0.85` returns
+`TuneError::Validation` and increments `stats.skipped`.
 
 ### A batch
 
-`label_batch` processes inputs synchronously in input order. It returns one
-`LabelingResult` per raw input, including failures. An error from
-`label_single` becomes `LabelingResult::failure(raw.id, error, 0)` and is
-included in the statistics. Failed results carry default all-zero labels,
-zero confidence, no raw response, and the error string. The optional raw
-response is currently populated only if code constructs a result with
-`with_raw_response`.
+`label_batch` processes inputs synchronously in input order. With no live
+transport configured, every item becomes `LabelingResult::failure(raw.id,
+error, 0)` and is included in the statistics. Failed results carry default
+all-zero labels, zero confidence, no raw response, and the error string.
+`label_batch_simulated`, when compiled, has the same accounting behavior but
+routes each input through `label_single_simulated`.
 
 ### Statistics
 
@@ -369,13 +365,11 @@ checksum to `verify_model_checksum`.
 
 ## DistillationPipeline::label_single
 
-`label_single` is deliberately a provider-shaped placeholder. It starts timing
-and materializes the bounded prompt, but it does not send the prompt, read the
-configured API-key environment variable, retry, or parse a response. Instead,
-it emits its fixed score vector, optionally softmax-normalizes it, assigns
-confidence `0.85`, and applies the configured confidence threshold.
+`label_single` is the live-provider boundary. Until provider transport is
+implemented, it fails closed with `TuneError::TeacherApi`; it does not send the
+prompt, read the configured API-key environment variable, retry, parse a
+response, or fall back to fixed labels.
 
-This preserves the eventual client boundary: a real implementation should
-replace only the simulated result with provider I/O and response validation,
-while retaining the prompt limits, label order, threshold behavior, and result
-accounting described above.
+The `simulated-teacher` feature is intended only for deterministic tests and
+examples. It exposes separately named methods so fixed output cannot be
+mistaken for a live teacher response.

--- a/crates/tune/src/distill/mod.rs
+++ b/crates/tune/src/distill/mod.rs
@@ -9,6 +9,7 @@ mod pipeline;
 mod teacher;
 
 pub use pipeline::{
-    DistillationConfig, DistillationPipeline, DistillationStats, LabelingResult, RawExample,
+    DistillationConfig, DistillationPipeline, DistillationStats, LabelSource, LabelingResult,
+    RawExample, TeacherAuth,
 };
 pub use teacher::{EndpointSecurity, TeacherConfig, TeacherConfigBuilder, TeacherProvider};

--- a/crates/tune/src/distill/pipeline/distill.rs
+++ b/crates/tune/src/distill/pipeline/distill.rs
@@ -1,20 +1,22 @@
 //! Orchestration from raw prompts to labeled examples.
 //!
-//! This implementation validates configuration, formats prompts, and records
-//! results; its teacher response is currently simulated rather than fetched.
-//! See `docs/distill.md` for the execution path and integration boundaries.
+//! This implementation validates configuration and records results. Live
+//! teacher transport is not yet configured, so normal labeling fails closed.
+//! A fixed-label path is available only through the `simulated-teacher` feature.
 
 use super::DistillationConfig;
-use super::types::{DistillationStats, LabelingResult, RawExample};
-use crate::data::{ExampleMetadata, IntentLabels, TrainingExample};
+use super::types::{DistillationStats, LabelSource, LabelingResult, RawExample};
+#[cfg(feature = "simulated-teacher")]
+use crate::data::IntentLabels;
+use crate::data::{ExampleMetadata, TrainingExample};
 use crate::distill::teacher::TeacherConfig;
 use crate::error::{Result, TuneError};
 use chrono::Utc;
 
-/// Distillation pipeline that orchestrates labeling from teacher models
+/// Distillation pipeline that orchestrates labeling from teacher models.
 ///
-/// This is a placeholder implementation. The actual API calls would need
-/// to be implemented with a proper HTTP client like `reqwest`.
+/// Live provider transport is not configured yet. [`Self::label_single`] and
+/// [`Self::label_batch`] fail closed instead of producing fabricated labels.
 pub struct DistillationPipeline {
     /// Teacher model configuration
     teacher: TeacherConfig,
@@ -64,17 +66,40 @@ impl DistillationPipeline {
         self.stats = DistillationStats::default();
     }
 
-    /// Label a single raw example
+    /// Label a single raw example using a live teacher.
     ///
-    /// This is a placeholder - actual implementation would call the teacher API.
-    pub fn label_single(&mut self, raw: &RawExample) -> Result<LabelingResult> {
+    /// Returns [`TuneError::TeacherApi`] until a live provider transport is
+    /// configured. It never falls back to simulated labels.
+    pub fn label_single(&mut self, _raw: &RawExample) -> Result<LabelingResult> {
+        Err(TuneError::TeacherApi(
+            "live teacher transport is not configured".to_string(),
+        ))
+    }
+
+    /// Label a single raw example with deterministic simulated output.
+    ///
+    /// Produces a fixed label distribution independent of `raw`'s content —
+    /// it does not call [`RawExample::to_prompt`] or otherwise inspect the
+    /// message/context. This explicit test-only path is available with the
+    /// non-default `simulated-teacher` feature and never affects
+    /// [`Self::label_single`].
+    #[cfg(feature = "simulated-teacher")]
+    pub fn label_single_simulated(&mut self, raw: &RawExample) -> Result<LabelingResult> {
+        let result = self.simulate_single(raw)?;
+        self.stats.update(&result);
+        Ok(result)
+    }
+
+    /// Core simulated-labeling computation shared by
+    /// [`Self::label_single_simulated`] and [`Self::label_batch_simulated`]
+    /// (via [`Self::label_batch_with`]). Does not update `self.stats` for a
+    /// successful result — the caller owns that accounting, so a result is
+    /// counted exactly once whether it comes from the single-item API or a
+    /// batch.
+    #[cfg(feature = "simulated-teacher")]
+    fn simulate_single(&mut self, raw: &RawExample) -> Result<LabelingResult> {
         let start = std::time::Instant::now();
 
-        // The simulated result preserves the future client boundary — see docs/distill.md.
-
-        let _prompt = raw.to_prompt();
-
-        // Simulate labels (in production, these come from teacher)
         let mut labels = IntentLabels {
             continuation: 0.4,
             topic_shift: 0.1,
@@ -90,7 +115,7 @@ impl DistillationPipeline {
                 .map_err(TuneError::InvalidConfig)?;
         }
 
-        let confidence = 0.85; // Would come from teacher response
+        let confidence = 0.85;
         let latency_ms = start.elapsed().as_millis() as u64;
 
         // Check confidence threshold
@@ -103,31 +128,49 @@ impl DistillationPipeline {
             )));
         }
 
-        let result = LabelingResult::success(raw.id, labels, confidence, latency_ms);
-        self.stats.update(&result);
-
-        Ok(result)
+        Ok(LabelingResult::simulated(
+            raw.id, labels, confidence, latency_ms,
+        ))
     }
 
     /// Label a batch of raw examples
     ///
     /// Returns results for all examples, including failures.
     pub fn label_batch(&mut self, raws: &[RawExample]) -> Vec<LabelingResult> {
+        self.label_batch_with(raws, Self::label_single)
+    }
+
+    /// Shared batch loop: labels each example with `label_one`, converting
+    /// errors into failed [`LabelingResult`]s. Owns statistics accounting for
+    /// both branches — every result, success or failure, is counted exactly
+    /// once here, so a new `label_one` implementation can never under-count
+    /// or double-count by forgetting to touch `self.stats` itself.
+    fn label_batch_with(
+        &mut self,
+        raws: &[RawExample],
+        mut label_one: impl FnMut(&mut Self, &RawExample) -> Result<LabelingResult>,
+    ) -> Vec<LabelingResult> {
         let mut results = Vec::with_capacity(raws.len());
 
         for raw in raws {
-            let result = match self.label_single(raw) {
+            let result = match label_one(self, raw) {
                 Ok(r) => r,
-                Err(e) => {
-                    let r = LabelingResult::failure(raw.id, e.to_string(), 0);
-                    self.stats.update(&r);
-                    r
-                }
+                Err(e) => LabelingResult::failure(raw.id, e.to_string(), 0),
             };
+            self.stats.update(&result);
             results.push(result);
         }
 
         results
+    }
+
+    /// Label a batch with deterministic simulated output.
+    ///
+    /// This explicit test-only path is available with the non-default
+    /// `simulated-teacher` feature and never affects [`Self::label_batch`].
+    #[cfg(feature = "simulated-teacher")]
+    pub fn label_batch_simulated(&mut self, raws: &[RawExample]) -> Vec<LabelingResult> {
+        self.label_batch_with(raws, Self::simulate_single)
     }
 
     /// Convert labeled results to training examples
@@ -146,10 +189,20 @@ impl DistillationPipeline {
             });
         }
 
-        let mut examples = Vec::with_capacity(results.len());
+        let eligible = results
+            .iter()
+            .filter(|result| result.is_success() && result.source() != LabelSource::Simulated)
+            .count();
+        let mut examples = Vec::with_capacity(eligible);
 
         for (i, result) in results.iter().enumerate() {
             if !result.is_success() {
+                continue;
+            }
+            // Simulated labels must never be attributed to the configured
+            // teacher in a training dataset — reject them here rather than
+            // stamp `self.teacher.display_name()` on fabricated output.
+            if result.source() == LabelSource::Simulated {
                 continue;
             }
 
@@ -157,14 +210,14 @@ impl DistillationPipeline {
                 result.example_id,
                 context_embeddings[i].clone(),
                 message_embeddings[i].clone(),
-                result.labels.clone(),
+                result.labels().clone(),
             );
 
             // Add metadata about the labeling
             let metadata = ExampleMetadata::with_source(result.example_id.to_string())
                 .teacher(self.teacher.display_name())
                 .labeled_at(Utc::now())
-                .confidence(result.confidence);
+                .confidence(result.confidence());
 
             example = example.with_metadata(metadata);
             examples.push(example);

--- a/crates/tune/src/distill/pipeline/mod.rs
+++ b/crates/tune/src/distill/pipeline/mod.rs
@@ -4,7 +4,7 @@ mod distill;
 mod types;
 
 pub use distill::DistillationPipeline;
-pub use types::{DistillationStats, LabelingResult, RawExample};
+pub use types::{DistillationStats, LabelSource, LabelingResult, RawExample, TeacherAuth};
 
 use crate::error::{Result, TuneError};
 

--- a/crates/tune/src/distill/pipeline/tests.rs
+++ b/crates/tune/src/distill/pipeline/tests.rs
@@ -39,19 +39,24 @@ fn test_raw_example_prompt() {
 #[test]
 fn test_labeling_result() {
     let labels = IntentLabels::explicit_query(0.9);
-    let result = LabelingResult::success(Uuid::new_v4(), labels, 0.85, 150);
+    let result = LabelingResult::success(Uuid::new_v4(), labels, 0.85, 150, TeacherAuth::new());
 
     assert!(result.is_success());
-    assert_eq!(result.confidence, 0.85);
-    assert_eq!(result.latency_ms, 150);
+    assert_eq!(result.confidence(), 0.85);
+    assert_eq!(result.latency_ms(), 150);
 }
 
 #[test]
 fn test_distillation_stats() {
     let mut stats = DistillationStats::default();
 
-    let result1 =
-        LabelingResult::success(Uuid::new_v4(), IntentLabels::continuation(0.8), 0.9, 100);
+    let result1 = LabelingResult::success(
+        Uuid::new_v4(),
+        IntentLabels::continuation(0.8),
+        0.9,
+        100,
+        TeacherAuth::new(),
+    );
     stats.update(&result1);
 
     let result2 = LabelingResult::failure(Uuid::new_v4(), "API error", 50);
@@ -73,21 +78,21 @@ fn test_pipeline_creation() {
 }
 
 #[test]
-fn test_pipeline_label_single() {
+fn label_single_fails_closed_without_a_live_teacher() {
     let teacher = TeacherConfig::claude_sonnet();
     let config = DistillationConfig::default();
     let mut pipeline = DistillationPipeline::new(teacher, config).unwrap();
 
     let raw = RawExample::new(vec!["Hi".to_string()], "What time is it?");
-    let result = pipeline.label_single(&raw);
+    let error = pipeline.label_single(&raw).unwrap_err();
 
-    assert!(result.is_ok());
-    let result = result.unwrap();
-    assert!(result.is_success());
+    assert!(matches!(error, crate::error::TuneError::TeacherApi(_)));
+    assert!(error.to_string().contains("not configured"));
+    assert_eq!(pipeline.stats().total_processed, 0);
 }
 
 #[test]
-fn test_pipeline_label_batch() {
+fn label_batch_reports_missing_live_teacher_as_failures() {
     let teacher = TeacherConfig::claude_sonnet();
     let config = DistillationConfig::default();
     let mut pipeline = DistillationPipeline::new(teacher, config).unwrap();
@@ -98,7 +103,43 @@ fn test_pipeline_label_batch() {
 
     let results = pipeline.label_batch(&raws);
     assert_eq!(results.len(), 5);
-    assert!(results.iter().all(super::types::LabelingResult::is_success));
+    assert!(results.iter().all(|result| !result.is_success()));
+    assert!(results.iter().all(|result| {
+        result
+            .error()
+            .is_some_and(|error| error.contains("not configured"))
+    }));
+    assert_eq!(pipeline.stats().failed, 5);
+}
+
+#[cfg(feature = "simulated-teacher")]
+#[test]
+fn simulated_labeling_requires_explicit_method() {
+    let teacher = TeacherConfig::claude_sonnet();
+    let config = DistillationConfig::default();
+    let mut pipeline = DistillationPipeline::new(teacher, config).unwrap();
+    let raw = RawExample::new(vec!["Hi".to_string()], "What time is it?");
+
+    let result = pipeline.label_single_simulated(&raw).unwrap();
+
+    assert!(result.is_success());
+    assert_eq!(result.confidence(), 0.85);
+    assert_eq!(pipeline.stats().successful, 1);
+    assert_eq!(
+        result.source(),
+        LabelSource::Simulated,
+        "the simulated path must stamp Simulated provenance, not Teacher"
+    );
+
+    let results = pipeline.label_batch_simulated(&[raw]);
+    assert_eq!(results.len(), 1);
+    assert!(results[0].is_success());
+    assert_eq!(pipeline.stats().successful, 2);
+    assert_eq!(
+        results[0].source(),
+        LabelSource::Simulated,
+        "the simulated batch path must stamp Simulated provenance, not Teacher"
+    );
 }
 
 #[test]
@@ -148,4 +189,198 @@ fn test_sanitize_truncates_long_prompt() {
     // Should be truncated with marker
     assert!(prompt.len() <= MAX_PROMPT_LENGTH + 20);
     assert!(prompt.contains("[truncated]") || prompt.len() <= MAX_PROMPT_LENGTH);
+}
+
+#[test]
+fn label_source_reflects_construction_path() {
+    let teacher_result = LabelingResult::success(
+        Uuid::new_v4(),
+        IntentLabels::continuation(0.8),
+        0.9,
+        10,
+        TeacherAuth::new(),
+    );
+    assert_eq!(teacher_result.source(), LabelSource::Teacher);
+
+    let simulated_result =
+        LabelingResult::simulated(Uuid::new_v4(), IntentLabels::continuation(0.8), 0.85, 5);
+    assert_eq!(simulated_result.source(), LabelSource::Simulated);
+
+    // Provenance is compile-enforced, not just constructor-enforced: `source`
+    // is `pub(super)` on `LabelingResult`, so it cannot be set in a struct
+    // literal or reassigned from outside `pipeline` — there is no path from
+    // either result above to the other's provenance short of editing this
+    // module.
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn teacher_result_serializes_but_has_no_deserialize_path_back() {
+    // A legitimate, in-process Teacher result.
+    let result = LabelingResult::success(
+        Uuid::new_v4(),
+        IntentLabels::explicit_query(0.9),
+        0.85,
+        150,
+        TeacherAuth::new(),
+    );
+    assert_eq!(result.source(), LabelSource::Teacher);
+
+    // It serializes fine — `Serialize` is still derived, so the data isn't
+    // lost or hidden.
+    let json = serde_json::to_string(&result).expect("Teacher result must serialize");
+    assert!(json.contains("\"source\":\"Teacher\""));
+
+    // But there is no way back: `LabelingResult` does not implement
+    // `Deserialize`, so `serde_json::from_str::<LabelingResult>(&json)` does
+    // not type-check (see the `compile_fail` doctests on `LabelingResult`).
+    // A result can only ever be reconstructed by calling `success`,
+    // `simulated`, or `failure` again, in-process — never by round-tripping
+    // through storage. This is a compile-time guarantee, not a runtime
+    // discard: there is no silent path from serialized bytes back to a
+    // convertible `LabelingResult`, forged or genuine.
+    let _ = json;
+}
+
+#[test]
+fn to_training_examples_converts_a_genuine_teacher_result() {
+    let teacher = TeacherConfig::claude_sonnet();
+    let config = DistillationConfig::default();
+    let pipeline = DistillationPipeline::new(teacher, config).unwrap();
+
+    let teacher_result = LabelingResult::success(
+        Uuid::new_v4(),
+        IntentLabels::explicit_query(0.9),
+        0.85,
+        150,
+        TeacherAuth::new(),
+    );
+
+    let context_embeddings = vec![vec![vec![0.0_f32; 4]]];
+    let message_embeddings = vec![vec![0.0_f32; 4]];
+
+    let examples = pipeline
+        .to_training_examples(&[teacher_result], &context_embeddings, &message_embeddings)
+        .unwrap();
+
+    assert_eq!(
+        examples.len(),
+        1,
+        "a genuinely-constructed Teacher result must convert to a training example"
+    );
+}
+
+#[test]
+fn failed_result_cannot_be_promoted_to_success_via_public_api() {
+    let result = LabelingResult::failure(Uuid::new_v4(), "boom", 5);
+
+    assert!(!result.is_success());
+    assert_eq!(result.error(), Some("boom"));
+
+    // There is no public setter for `error`, `labels`, or `source`: the only
+    // way to reach a `LabelingResult` with `is_success() == true` is through
+    // `LabelingResult::success` or `LabelingResult::simulated`. See the
+    // `compile_fail` doctest on `LabelingResult` for the structural proof
+    // that `result.error = None` does not compile.
+}
+
+#[test]
+fn label_batch_accounts_failures_from_the_shared_helper() {
+    // `label_batch` routes every item through `label_batch_with`, which must
+    // own failure accounting itself — `label_single` never touches
+    // `self.stats`.
+    let teacher = TeacherConfig::claude_sonnet();
+    let config = DistillationConfig::default();
+    let mut pipeline = DistillationPipeline::new(teacher, config).unwrap();
+
+    let raws: Vec<RawExample> = (0..3)
+        .map(|i| RawExample::new(vec!["context".to_string()], format!("message {i}")))
+        .collect();
+
+    let results = pipeline.label_batch(&raws);
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(pipeline.stats().total_processed, 3);
+    assert_eq!(pipeline.stats().failed, 3);
+    assert_eq!(pipeline.stats().successful, 0);
+}
+
+#[cfg(feature = "simulated-teacher")]
+#[test]
+fn mixed_batch_reports_correct_success_and_failure_counts_from_the_helper() {
+    // Two batches on one pipeline, one that always fails (no live teacher)
+    // and one that always succeeds (simulated), combine into stats neither
+    // batch's callback updates on its own — `label_batch_with` is the only
+    // place that calls `self.stats.update`, for both branches, so the
+    // combined counts prove it owns both, not just failures.
+    let teacher = TeacherConfig::claude_sonnet();
+    let config = DistillationConfig::default();
+    let mut pipeline = DistillationPipeline::new(teacher, config).unwrap();
+
+    let failing_raws: Vec<RawExample> = (0..2)
+        .map(|i| RawExample::new(vec!["context".to_string()], format!("fail {i}")))
+        .collect();
+    let succeeding_raws: Vec<RawExample> = (0..3)
+        .map(|i| RawExample::new(vec!["context".to_string()], format!("ok {i}")))
+        .collect();
+
+    let failed_results = pipeline.label_batch(&failing_raws);
+    let succeeded_results = pipeline.label_batch_simulated(&succeeding_raws);
+
+    assert_eq!(failed_results.len(), 2);
+    assert_eq!(succeeded_results.len(), 3);
+    assert!(failed_results.iter().all(|r| !r.is_success()));
+    assert!(succeeded_results.iter().all(LabelingResult::is_success));
+
+    assert_eq!(pipeline.stats().total_processed, 5);
+    assert_eq!(pipeline.stats().failed, 2);
+    assert_eq!(pipeline.stats().successful, 3);
+}
+
+#[test]
+fn to_training_examples_rejects_simulated_provenance() {
+    let teacher = TeacherConfig::claude_sonnet();
+    let config = DistillationConfig::default();
+    let pipeline = DistillationPipeline::new(teacher, config).unwrap();
+
+    let simulated =
+        LabelingResult::simulated(Uuid::new_v4(), IntentLabels::continuation(0.8), 0.85, 5);
+
+    let context_embeddings = vec![vec![vec![0.0_f32; 4]]];
+    let message_embeddings = vec![vec![0.0_f32; 4]];
+
+    let examples = pipeline
+        .to_training_examples(&[simulated], &context_embeddings, &message_embeddings)
+        .unwrap();
+
+    assert!(
+        examples.is_empty(),
+        "a simulated label must never be converted into a training example \
+         attributed to the configured real teacher"
+    );
+}
+
+#[test]
+fn to_training_examples_does_not_over_reserve_for_an_all_skipped_batch() {
+    let teacher = TeacherConfig::claude_sonnet();
+    let config = DistillationConfig::default();
+    let pipeline = DistillationPipeline::new(teacher, config).unwrap();
+
+    let failures: Vec<LabelingResult> = (0..64)
+        .map(|i| LabelingResult::failure(Uuid::new_v4(), format!("error {i}"), 0))
+        .collect();
+    let context_embeddings: Vec<Vec<Vec<f32>>> = vec![vec![]; failures.len()];
+    let message_embeddings: Vec<Vec<f32>> = vec![vec![]; failures.len()];
+
+    let examples = pipeline
+        .to_training_examples(&failures, &context_embeddings, &message_embeddings)
+        .unwrap();
+
+    assert!(examples.is_empty());
+    assert_eq!(
+        examples.capacity(),
+        0,
+        "the returned Vec must be sized to the eligible (kept) count, not the input count, \
+         so a large all-skipped batch does not hold unused reserved memory"
+    );
 }

--- a/crates/tune/src/distill/pipeline/types.rs
+++ b/crates/tune/src/distill/pipeline/types.rs
@@ -10,36 +10,124 @@ use uuid::Uuid;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Result of labeling a single example
-#[derive(Debug, Clone)]
+/// Provenance of a labeling result: did it come from the configured teacher,
+/// or from the opt-in deterministic simulation path?
+///
+/// [`DistillationPipeline::to_training_examples`](super::DistillationPipeline::to_training_examples)
+/// uses this to keep simulated labels from being attributed to the real teacher.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum LabelSource {
+    /// Produced by the configured teacher.
+    #[default]
+    Teacher,
+    /// Produced by the deterministic `simulated-teacher` path. Never a real
+    /// teacher's output.
+    Simulated,
+}
+
+/// Capability proving a [`LabelingResult`] was produced by this crate's own
+/// teacher-provider path, not fabricated by an external caller.
+///
+/// `TeacherAuth` has a private field and no public constructor, so code
+/// outside `lattice_tune` can never obtain one — and [`LabelingResult::success`]
+/// requires one to construct a `Teacher`-sourced result. This closes the gap
+/// a private `source` field alone leaves open: without an unforgeable token
+/// gating the constructor itself, any caller could still mint a `Teacher`
+/// result through the public API with arbitrary labels and confidence.
+#[derive(Debug, Clone, Copy)]
+pub struct TeacherAuth(());
+
+impl TeacherAuth {
+    /// Mint a new capability. Only reachable from within this crate — the
+    /// live teacher-provider path is the intended (future) caller. Unused in
+    /// production code today because [`DistillationPipeline::label_single`](super::DistillationPipeline::label_single)
+    /// fails closed rather than calling a live teacher; tests exercise it in
+    /// the meantime.
+    #[allow(dead_code)]
+    pub(crate) fn new() -> Self {
+        Self(())
+    }
+}
+
+/// Result of labeling a single example.
+///
+/// Every field that [`Self::is_success`], [`Self::source`], or
+/// [`super::DistillationPipeline::to_training_examples`] reads is private:
+/// the only ways to reach a value are [`Self::success`], [`Self::simulated`],
+/// and [`Self::failure`]. There is no public setter, so a caller cannot
+/// mutate a failed result into an accepted one (clearing `error` and
+/// swapping in `labels`) or otherwise disagree with the state a constructor
+/// established:
+///
+/// ```compile_fail
+/// # use lattice_tune::LabelingResult;
+/// # use uuid::Uuid;
+/// let mut result = LabelingResult::failure(Uuid::new_v4(), "boom", 0);
+/// result.error = None; // private field — does not compile
+/// ```
+///
+/// `LabelingResult` implements `Serialize` but deliberately never
+/// `Deserialize`. A deserialized payload cannot be authenticated as having
+/// come from the configured teacher, so there is no path — silent or
+/// otherwise — from untrusted bytes back to this type; the only route is to
+/// call [`Self::success`], [`Self::simulated`], or [`Self::failure`] again,
+/// in-process:
+///
+/// ```compile_fail
+/// # use lattice_tune::LabelingResult;
+/// let _: LabelingResult = serde_json::from_str("{}").unwrap();
+/// ```
+///
+/// A caller outside this crate also cannot mint a `Teacher`-sourced result
+/// at all: [`Self::success`] requires a [`TeacherAuth`] token, and
+/// `TeacherAuth` has no public constructor. There is no `TeacherAuth` value
+/// an external caller can pass, so the call site itself does not compile:
+///
+/// ```compile_fail
+/// # use lattice_tune::{IntentLabels, LabelingResult};
+/// # use uuid::Uuid;
+/// let _ = LabelingResult::success(Uuid::new_v4(), IntentLabels::default(), 0.99, 0);
+/// ```
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct LabelingResult {
     /// Original example ID
     pub example_id: Uuid,
 
     /// Generated labels
-    pub labels: IntentLabels,
+    labels: IntentLabels,
 
-    /// Confidence score from teacher
-    pub confidence: f32,
+    /// Confidence score, from either the teacher or the simulated path —
+    /// see [`Self::source`] for which one produced this result.
+    confidence: f32,
 
-    /// Raw response from teacher (for debugging)
-    pub raw_response: Option<String>,
+    /// Raw response, for debugging — populated for teacher results; absent
+    /// for simulated results, which never call the teacher.
+    raw_response: Option<String>,
 
     /// Error message if labeling failed
-    pub error: Option<String>,
+    error: Option<String>,
 
     /// Latency in milliseconds
-    pub latency_ms: u64,
+    latency_ms: u64,
+
+    /// Where this result's labels came from.
+    ///
+    /// Visibility is intentionally narrower than the other fields: provenance
+    /// must only ever be set by [`LabelingResult::success`] or
+    /// [`LabelingResult::simulated`] at construction time, never mutated
+    /// afterward. Read it via [`Self::source`].
+    pub(super) source: LabelSource,
 }
 
 impl LabelingResult {
-    /// Create a successful result
-    pub fn success(
+    fn new_success(
         example_id: Uuid,
         labels: IntentLabels,
         confidence: f32,
         latency_ms: u64,
+        source: LabelSource,
     ) -> Self {
         Self {
             example_id,
@@ -48,7 +136,47 @@ impl LabelingResult {
             raw_response: None,
             error: None,
             latency_ms,
+            source,
         }
+    }
+
+    /// Create a successful result attributed to the configured teacher.
+    ///
+    /// Requires a [`TeacherAuth`] token, which only this crate's own
+    /// teacher-provider path can construct — an external caller cannot
+    /// obtain one, so this constructor cannot be used to fabricate
+    /// `Teacher`-sourced labels.
+    pub fn success(
+        example_id: Uuid,
+        labels: IntentLabels,
+        confidence: f32,
+        latency_ms: u64,
+        _auth: TeacherAuth,
+    ) -> Self {
+        Self::new_success(
+            example_id,
+            labels,
+            confidence,
+            latency_ms,
+            LabelSource::Teacher,
+        )
+    }
+
+    /// Create a successful result from the deterministic simulation path.
+    /// Never attributable to the configured teacher.
+    pub fn simulated(
+        example_id: Uuid,
+        labels: IntentLabels,
+        confidence: f32,
+        latency_ms: u64,
+    ) -> Self {
+        Self::new_success(
+            example_id,
+            labels,
+            confidence,
+            latency_ms,
+            LabelSource::Simulated,
+        )
     }
 
     /// Create a failed result
@@ -60,12 +188,47 @@ impl LabelingResult {
             raw_response: None,
             error: Some(error.into()),
             latency_ms,
+            source: LabelSource::Teacher,
         }
     }
 
     /// Check if labeling succeeded
     pub fn is_success(&self) -> bool {
         self.error.is_none()
+    }
+
+    /// Where this result's labels came from. `source` itself is not settable
+    /// from outside this module — provenance is fixed at construction by
+    /// [`Self::success`] or [`Self::simulated`].
+    pub fn source(&self) -> LabelSource {
+        self.source
+    }
+
+    /// Generated labels.
+    pub fn labels(&self) -> &IntentLabels {
+        &self.labels
+    }
+
+    /// Confidence score, from either the teacher or the simulated path —
+    /// see [`Self::source`] for which one produced this result.
+    pub fn confidence(&self) -> f32 {
+        self.confidence
+    }
+
+    /// Raw response, for debugging — populated for teacher results; absent
+    /// for simulated results, which never call the teacher.
+    pub fn raw_response(&self) -> Option<&str> {
+        self.raw_response.as_deref()
+    }
+
+    /// Error message if labeling failed.
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    /// Latency in milliseconds.
+    pub fn latency_ms(&self) -> u64 {
+        self.latency_ms
     }
 
     /// Set raw response

--- a/crates/tune/src/lib.rs
+++ b/crates/tune/src/lib.rs
@@ -34,8 +34,8 @@ pub use data::{
 
 // Distill re-exports
 pub use distill::{
-    DistillationConfig, DistillationPipeline, DistillationStats, EndpointSecurity, LabelingResult,
-    TeacherConfig, TeacherConfigBuilder, TeacherProvider,
+    DistillationConfig, DistillationPipeline, DistillationStats, EndpointSecurity, LabelSource,
+    LabelingResult, TeacherAuth, TeacherConfig, TeacherConfigBuilder, TeacherProvider,
 };
 
 // Train re-exports
@@ -69,7 +69,7 @@ pub mod prelude {
         Batch, Dataset, DatasetConfig, DatasetStats, ExampleMetadata, IntentLabels, TrainingExample,
     };
     pub use crate::distill::{
-        DistillationConfig, DistillationPipeline, DistillationStats, EndpointSecurity,
+        DistillationConfig, DistillationPipeline, DistillationStats, EndpointSecurity, LabelSource,
         LabelingResult, TeacherConfig, TeacherProvider,
     };
     pub use crate::error::{Result, TuneError};
@@ -177,13 +177,12 @@ mod tests {
         // 4. Create pipeline
         let mut pipeline = DistillationPipeline::with_teacher(teacher).unwrap();
 
-        // 5. Label (placeholder)
-        let result = pipeline.label_single(&raw).unwrap();
-        assert!(result.is_success());
-        assert!(result.confidence > 0.0);
+        // 5. Labeling fails closed until a live teacher is configured
+        let error = pipeline.label_single(&raw).unwrap_err();
+        assert!(matches!(error, TuneError::TeacherApi(_)));
 
         // 6. Check stats
         let stats = pipeline.stats();
-        assert_eq!(stats.successful, 1);
+        assert_eq!(stats.successful, 0);
     }
 }

--- a/docs/adr/ADR-027-finetuning-pipeline.md
+++ b/docs/adr/ADR-027-finetuning-pipeline.md
@@ -33,9 +33,13 @@ at inference time. The neural network primitives live in `lattice-fann`.
 The three capabilities above define the accepted subsystem boundaries; they do
 not imply that every stage is implemented end to end. In the shipped code:
 
-- `DistillationPipeline::label_single` is synchronous. It formats the prompt but
-  returns a simulated label distribution and confidence without issuing an HTTP
-  request or reading an API key.
+- `DistillationPipeline::label_single` fails closed with a `TeacherApi` error
+  instead of issuing an HTTP request or returning fabricated labels. A
+  deterministic simulated-label path (`label_single_simulated` /
+  `label_batch_simulated`) exists only behind the non-default
+  `simulated-teacher` feature; its results are marked with `LabelSource::Simulated`
+  and `to_training_examples` rejects them rather than attributing them to the
+  configured teacher.
 - The CPU `TrainingLoop` validates configuration, batches data, invokes
   callbacks, records metrics, and emits in-memory checkpoint records. Its loss
   and accuracy are simulated, and it neither forwards through nor updates a

--- a/docs/adr/ADR-030-knowledge-distillation.md
+++ b/docs/adr/ADR-030-knowledge-distillation.md
@@ -82,7 +82,7 @@ The method pairs them by index (returns `TuneError::DimensionMismatch` on length
 
 ### Negative
 
-- The actual HTTP client (`reqwest`) is not wired — `label_single` is a placeholder that returns simulated labels. The interface contract is fully defined but the implementation awaits the async HTTP layer.
+- The actual HTTP client (`reqwest`) is not wired — `label_single` fails closed with a `TeacherApi` error rather than returning fabricated labels. The interface contract is fully defined but the implementation awaits the async HTTP layer. A deterministic simulated-label path exists only behind the non-default `simulated-teacher` feature, is marked with `LabelSource::Simulated`, and is rejected by `to_training_examples` rather than attributed to the configured teacher.
 - Confidence score is a single `f32` — no per-class breakdown, no calibration information
 - `label_batch` is sequential (no parallelism). Large batches against rate-limited teacher APIs will be slow.
 
@@ -95,10 +95,13 @@ The method pairs them by index (returns `TuneError::DimensionMismatch` on length
 
 The data contract (`LabelingResult`, `TrainingExample`, `DistillationStats`) and the
 `DistillationPipeline` struct are fully defined and tested. Actual HTTP teacher calls remain
-placeholder: `crates/tune/src/distill/pipeline/distill.rs:65` comments "This is a placeholder
-— actual implementation would call the teacher API." No `reqwest` HTTP requests are made; the
-`label_single` and `label_batch` methods do not hit any external endpoint. The pipeline struct
-and config presets are ready for wiring once a real HTTP client is added.
+unimplemented: no `reqwest` HTTP requests are made, and `label_single` / `label_batch` fail
+closed with a `TeacherApi` error instead of hitting any external endpoint or fabricating output.
+A deterministic simulated-label path (`label_single_simulated` / `label_batch_simulated`) is
+available only behind the non-default `simulated-teacher` feature; `LabelingResult::source`
+marks its output as `LabelSource::Simulated`, and `to_training_examples` rejects simulated
+results rather than attributing them to the configured teacher. The pipeline struct and config
+presets are ready for wiring once a real HTTP client is added.
 
 ## References
 


### PR DESCRIPTION
Closes #11.

## Summary

Gates simulated distillation labels so they can never be mistaken for real teacher output:

- `DistillationPipeline::label_single`/`label_batch` fail closed with `TuneError::TeacherApi` until a live teacher transport is configured, instead of returning fabricated labels.
- Deterministic fixed-label output is available only behind the non-default `simulated-teacher` feature, through explicitly named methods (`label_single_simulated`, `label_batch_simulated`).
- `LabelingResult` tracks provenance (`LabelSource::Teacher` / `Simulated`) as a private field, readable only via `source()`. It implements `Serialize` but not `Deserialize`, so there is no path from untrusted bytes back to a `LabelingResult`.
- `LabelingResult::success` (the `Teacher`-provenance constructor) now requires a `TeacherAuth` capability token that has no public constructor — only code inside `lattice-tune` can mint one. External callers can no longer forge a `Teacher`-sourced result through the public API, closing a training-data-poisoning gap where arbitrary labels could be attributed to the configured teacher.
- `DistillationPipeline::to_training_examples` rejects `Simulated`-sourced results and right-sizes its output allocation to the number of eligible (kept) results rather than the full input count, so a large all-skipped batch doesn't hold unused reserved memory.

**API note:** this is a semver-major change to `lattice-tune`. External code constructing `LabelingResult` via a struct literal, reading/writing `.source` directly, or calling `LabelingResult::success` needs to switch to the constructors and the new `source()` accessor; `success` additionally now requires an in-crate `TeacherAuth` token. Version bump and release handling are left to the maintainer.

## Test plan

- `cargo test -p lattice-tune --features serde,simulated-teacher` — 195 unit + 7/50 integration + 3 doc tests, all passing.
- `cargo clippy -p lattice-tune --all-targets --features serde,simulated-teacher -- -D warnings` — clean.
- `cargo fmt -p lattice-tune -- --check` — clean.
- Mutation-tested: reverting the `TeacherAuth` gate on `success` makes the corresponding `compile_fail` doctest compile (and thus fail); reverting the allocation right-sizing makes `to_training_examples_does_not_over_reserve_for_an_all_skipped_batch` fail on the capacity assertion. Both verified locally, then restored.

## bench-compare disposition (ADR-058)

This PR only touches `crates/tune`, which is not a dependency of `lattice-inference` or `lattice-embed` (the two ADR-058 bench-target crates). No changed symbol (`LabelingResult`, `LabelSource`, `TeacherAuth`, `to_training_examples`) appears in either bench source, and neither crate's `Cargo.toml` depends on `lattice-tune`. Base and head bench binaries have identical effective source for this change — structural unreachability, not a cold path. No A/B run performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
