### PR TITLE
fix(inference): unify safetensors reader validation

### DIFF
--- a/crates/embed/src/vision.rs
+++ b/crates/embed/src/vision.rs
@@ -629,13 +629,17 @@ mod tests {
     #[test]
     fn resolve_single_shard_rejects_parent_traversal_shard_name() {
         let tmp = tempfile::tempdir().expect("tempdir");
+        let outside = tmp.path().parent().expect("temp dir has a parent");
+        let outside_file = outside.join("lattice_embed_vision_traversal_outside.safetensors");
+        std::fs::write(&outside_file, b"secret").expect("write outside file");
+
         let index_path = tmp.path().join("model.safetensors.index.json");
         // A mixed quantized/FP16 manifest can name an escaping FP16 shard;
         // without the shared containment helper this join would resolve
         // outside `tmp` instead of erroring.
         std::fs::write(
             &index_path,
-            r#"{"metadata":{},"weight_map":{"a":"../outside/decoder.safetensors"}}"#,
+            r#"{"metadata":{},"weight_map":{"a":"../lattice_embed_vision_traversal_outside.safetensors"}}"#,
         )
         .expect("write index");
 
@@ -643,9 +647,11 @@ mod tests {
             .expect_err("a shard name with a parent-directory component must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains("parent-directory"),
+            msg.contains("escapes the checkpoint directory"),
             "expected the shared containment error, got: {msg}"
         );
+
+        std::fs::remove_file(&outside_file).ok();
     }
 
     #[test]
@@ -667,7 +673,7 @@ mod tests {
             resolve_single_shard(tmp.path()).expect_err("an absolute shard name must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains("absolute"),
+            msg.contains("escapes the checkpoint directory"),
             "expected the shared containment error, got: {msg}"
         );
     }

--- a/crates/embed/src/vision.rs
+++ b/crates/embed/src/vision.rs
@@ -24,8 +24,8 @@ use lattice_inference::model::qwen35_config::Qwen35Config;
 use lattice_inference::tokenizer::bpe::BpeTokenizer;
 use lattice_inference::vision::checkpoint::{Qwen35VisionWeights, load_qwen35_vision_weights};
 use lattice_inference::vision::embed_image_from_bytes_f16;
-use lattice_inference::weights::SafetensorsFile;
 use lattice_inference::weights::f16_weights::{F16ModelWeights, load_f16_weights};
+use lattice_inference::weights::{SafetensorsFile, resolve_shard_path};
 use std::path::Path;
 
 pub use lattice_inference::forward::cpu_f16::PoolingStrategy;
@@ -202,7 +202,12 @@ fn resolve_single_shard(model_dir: &Path) -> Result<std::path::PathBuf> {
     shards.sort_unstable();
     shards.dedup();
     match shards.as_slice() {
-        [one] => Ok(model_dir.join(one)),
+        [one] => resolve_shard_path(model_dir, one).map_err(|e| {
+            EmbedError::ModelInitialization(format!(
+                "invalid shard filename in {}: {e}",
+                model_dir.join("model.safetensors.index.json").display()
+            ))
+        }),
         [] => Err(EmbedError::ModelInitialization(format!(
             "empty weight_map in {}",
             model_dir.join("model.safetensors.index.json").display()
@@ -619,6 +624,52 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let err = resolve_single_shard(tmp.path()).expect_err("missing manifest must be rejected");
         assert!(matches!(err, EmbedError::ModelInitialization(_)));
+    }
+
+    #[test]
+    fn resolve_single_shard_rejects_parent_traversal_shard_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let index_path = tmp.path().join("model.safetensors.index.json");
+        // A mixed quantized/FP16 manifest can name an escaping FP16 shard;
+        // without the shared containment helper this join would resolve
+        // outside `tmp` instead of erroring.
+        std::fs::write(
+            &index_path,
+            r#"{"metadata":{},"weight_map":{"a":"../outside/decoder.safetensors"}}"#,
+        )
+        .expect("write index");
+
+        let err = resolve_single_shard(tmp.path())
+            .expect_err("a shard name with a parent-directory component must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parent-directory"),
+            "expected the shared containment error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_single_shard_rejects_absolute_shard_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_file = outside.path().join("decoder.safetensors");
+        std::fs::write(&outside_file, b"secret").expect("write outside file");
+
+        let index_path = tmp.path().join("model.safetensors.index.json");
+        let abs = outside_file.to_string_lossy().replace('\\', "\\\\");
+        std::fs::write(
+            &index_path,
+            format!(r#"{{"metadata":{{}},"weight_map":{{"a":"{abs}"}}}}"#),
+        )
+        .expect("write index");
+
+        let err =
+            resolve_single_shard(tmp.path()).expect_err("an absolute shard name must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("absolute"),
+            "expected the shared containment error, got: {msg}"
+        );
     }
 
     /// `from_directory`'s documented contract requires an index/quantize

--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -749,8 +749,9 @@ mod doctor {
             let mut present_names: BTreeSet<String> = BTreeSet::new();
             let mut has_mtp_tensors = false;
             for entry in &entries {
-                let file_path = dir.join(&entry.file);
-                match std::fs::metadata(&file_path) {
+                let resolved = lattice_inference::weights::resolve_shard_path(dir, &entry.file)
+                    .and_then(|file_path| std::fs::metadata(&file_path).map_err(Into::into));
+                match resolved {
                     Ok(meta) => {
                         total_bytes +=
                             q4_resident_bytes(&entry.name, meta.len(), cfg.tie_word_embeddings);

--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -542,7 +542,13 @@ mod doctor {
             }
             let mut merged = HashMap::new();
             for shard_name in shard_names {
-                let shard_path = dir.join(&shard_name);
+                let shard_path = lattice_inference::weights::resolve_shard_path(dir, &shard_name)
+                    .map_err(|e| {
+                    format!(
+                        "shard '{shard_name}' referenced by {} is invalid: {e}",
+                        index_path.display()
+                    )
+                })?;
                 if !shard_path.exists() {
                     return Err(format!(
                         "shard '{shard_name}' referenced by {} not found in {}",

--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -11,6 +11,7 @@ use crate::forward::metal::MetalForwardPass;
 use crate::pool::{l2_normalize, last_token_pool};
 use crate::rope::RopeTable;
 use crate::tokenizer::common::{Tokenizer, load_tokenizer};
+use crate::weights::f32_weights::validate_shard_relative_path;
 use crate::weights::{QwenWeights, SafetensorsFile, ShardedQwenBacking, ShardedSafetensors};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -372,9 +373,17 @@ const WEIGHT_FINGERPRINT_INLINE_CAP: u64 = 2 * 1024 * 1024; // 2 MiB
 /// `model.safetensors.index.json` if present (its `weight_map` values,
 /// deduplicated and lexically sorted so the fingerprint is stable regardless
 /// of key iteration order), else no weight files (config-only derivation).
-fn resolve_weight_fingerprint_files(dir: &Path) -> Vec<String> {
+///
+/// Every `weight_map` value is untrusted checkpoint content, so each one is
+/// validated with [`validate_shard_relative_path`] before it is returned —
+/// this must happen before any caller joins the name onto `dir` and opens
+/// it. An escaping entry (absolute or containing `..`) fails the whole
+/// derivation closed rather than returning the other, valid entries: the
+/// caller must not open *any* weight file for a checkpoint whose index is
+/// malformed.
+fn resolve_weight_fingerprint_files(dir: &Path) -> Result<Vec<String>, InferenceError> {
     if dir.join("model.safetensors").is_file() {
-        return vec!["model.safetensors".to_string()];
+        return Ok(vec!["model.safetensors".to_string()]);
     }
     let index_path = dir.join("model.safetensors.index.json");
     if let Ok(index_bytes) = std::fs::read(&index_path)
@@ -385,11 +394,14 @@ fn resolve_weight_fingerprint_files(dir: &Path) -> Vec<String> {
             .values()
             .filter_map(|v| v.as_str().map(str::to_string))
             .collect();
+        for file in &files {
+            validate_shard_relative_path(file)?;
+        }
         if !files.is_empty() {
-            return files.into_iter().collect();
+            return Ok(files.into_iter().collect());
         }
     }
-    Vec::new()
+    Ok(Vec::new())
 }
 
 /// Fold one weight shard's filename, byte length, and boundary-sampled
@@ -453,14 +465,19 @@ fn fold_weight_file_into_hasher(
 /// Returns `None` only when `config.json` itself is missing or unreadable
 /// (mirroring `derive_cache_compat_rev`), in which case the caller leaves
 /// `base_model_rev` at its existing sentinel. A read failure partway
-/// through a weight file degrades gracefully to the config-only derivation
+/// through a weight file, or a `weight_map` entry that fails shard-path
+/// validation, degrades gracefully to the config-only derivation
 /// (`derive_cache_compat_rev`) rather than failing `ModelInferenceConfig`
-/// construction.
+/// construction — in the validation-failure case this also means no weight
+/// file is ever opened, since `resolve_weight_fingerprint_files` rejects the
+/// whole file list before any of it reaches `fold_weight_file_into_hasher`.
 fn derive_base_model_rev(dir: &Path) -> Option<String> {
     let config_path = dir.join("config.json");
     let config_bytes = std::fs::read(&config_path).ok()?;
 
-    let weight_files = resolve_weight_fingerprint_files(dir);
+    let Ok(weight_files) = resolve_weight_fingerprint_files(dir) else {
+        return derive_cache_compat_rev(&config_path);
+    };
 
     let mut hasher = Sha256::new();
     hasher.update(&config_bytes);
@@ -2808,6 +2825,70 @@ mod tests {
             "flipping a byte in the second (non-first-mentioned) shard must change the rev"
         );
 
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn derive_base_model_rev_rejects_parent_traversal_weight_map_entry() {
+        let tmp = std::env::temp_dir().join("lattice_test_derive_base_rev_traversal");
+        let outside_dir =
+            std::env::temp_dir().join("lattice_test_derive_base_rev_traversal_outside");
+        std::fs::remove_dir_all(&tmp).ok();
+        std::fs::remove_dir_all(&outside_dir).ok();
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        std::fs::write(tmp.join("config.json"), b"{\"hidden_size\":1024}").unwrap();
+
+        let outside_file = outside_dir.join("secret.safetensors");
+        write_pattern_bytes(&outside_file, 4096);
+
+        // Without shard-path validation ahead of the fold, this would open
+        // and hash `outside_file` via a `../` join instead of failing closed.
+        let index_json = format!(
+            r#"{{"weight_map": {{"a.weight": "../{}/secret.safetensors"}}}}"#,
+            outside_dir.file_name().unwrap().to_string_lossy()
+        );
+        std::fs::write(tmp.join("model.safetensors.index.json"), &index_json).unwrap();
+
+        let rev = derive_base_model_rev(&tmp);
+        let config_only = derive_cache_compat_rev(&tmp.join("config.json"));
+        assert_eq!(
+            rev, config_only,
+            "an escaping weight_map entry must fail closed to the config-only revision, \
+             not open a file outside the model directory"
+        );
+
+        std::fs::remove_dir_all(&outside_dir).ok();
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn derive_base_model_rev_rejects_absolute_weight_map_entry() {
+        let tmp = std::env::temp_dir().join("lattice_test_derive_base_rev_absolute");
+        let outside_dir =
+            std::env::temp_dir().join("lattice_test_derive_base_rev_absolute_outside");
+        std::fs::remove_dir_all(&tmp).ok();
+        std::fs::remove_dir_all(&outside_dir).ok();
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        std::fs::write(tmp.join("config.json"), b"{\"hidden_size\":1024}").unwrap();
+
+        let outside_file = outside_dir.join("secret.safetensors");
+        write_pattern_bytes(&outside_file, 4096);
+
+        let abs = outside_file.to_string_lossy().replace('\\', "\\\\");
+        let index_json = format!(r#"{{"weight_map": {{"a.weight": "{abs}"}}}}"#);
+        std::fs::write(tmp.join("model.safetensors.index.json"), &index_json).unwrap();
+
+        let rev = derive_base_model_rev(&tmp);
+        let config_only = derive_cache_compat_rev(&tmp.join("config.json"));
+        assert_eq!(
+            rev, config_only,
+            "an absolute weight_map entry must fail closed to the config-only revision, \
+             not open a file outside the model directory"
+        );
+
+        std::fs::remove_dir_all(&outside_dir).ok();
         std::fs::remove_dir_all(&tmp).ok();
     }
 

--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -11,7 +11,7 @@ use crate::forward::metal::MetalForwardPass;
 use crate::pool::{l2_normalize, last_token_pool};
 use crate::rope::RopeTable;
 use crate::tokenizer::common::{Tokenizer, load_tokenizer};
-use crate::weights::f32_weights::validate_shard_relative_path;
+use crate::weights::f32_weights::{parse_index, validate_shard_relative_path};
 use crate::weights::{QwenWeights, SafetensorsFile, ShardedQwenBacking, ShardedSafetensors};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -385,23 +385,19 @@ fn resolve_weight_fingerprint_files(dir: &Path) -> Result<Vec<String>, Inference
     if dir.join("model.safetensors").is_file() {
         return Ok(vec!["model.safetensors".to_string()]);
     }
-    let index_path = dir.join("model.safetensors.index.json");
-    if let Ok(index_bytes) = std::fs::read(&index_path)
-        && let Ok(index_json) = serde_json::from_slice::<serde_json::Value>(&index_bytes)
-        && let Some(weight_map) = index_json.get("weight_map").and_then(|v| v.as_object())
-    {
-        let files: std::collections::BTreeSet<String> = weight_map
-            .values()
-            .filter_map(|v| v.as_str().map(str::to_string))
-            .collect();
-        for file in &files {
-            validate_shard_relative_path(file)?;
-        }
-        if !files.is_empty() {
-            return Ok(files.into_iter().collect());
-        }
+    // Reuse the strict index parser the runtime loaders use, rather than a
+    // separate ad hoc `serde_json::Value` walk that could silently drop a
+    // non-string shard value or collapse a duplicate tensor-name key --
+    // either of those would let this fingerprint diverge from what
+    // `QwenModel::from_directory` actually loads.
+    let Ok(index) = parse_index(dir) else {
+        return Ok(Vec::new());
+    };
+    let files: std::collections::BTreeSet<String> = index.weight_map.into_values().collect();
+    for file in &files {
+        validate_shard_relative_path(file)?;
     }
-    Ok(Vec::new())
+    Ok(files.into_iter().collect())
 }
 
 /// Fold one weight shard's filename, byte length, and boundary-sampled
@@ -414,10 +410,10 @@ fn fold_weight_file_into_hasher(
     hasher: &mut Sha256,
     dir: &Path,
     file_name: &str,
-) -> std::io::Result<()> {
+) -> Result<(), InferenceError> {
     use std::io::{Read, Seek, SeekFrom};
 
-    let path = dir.join(file_name);
+    let path = crate::weights::f32_weights::resolve_contained_path(dir, file_name)?;
     let mut file = std::io::BufReader::new(std::fs::File::open(&path)?);
     let len = file.get_ref().metadata()?.len();
 

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -48,7 +48,7 @@ use serde_json::Value;
 
 use crate::error::InferenceError;
 use crate::weights::f32_weights::{
-    SafetensorsTensorLayout, parse_index, validate_safetensors_layout, validate_shard_relative_path,
+    SafetensorsTensorLayout, parse_index, resolve_contained_path, validate_safetensors_layout,
 };
 
 /// On-disk storage dtype of a tensor.
@@ -395,8 +395,8 @@ impl QuarotTensorReader {
                 if shards.contains_key(shard_file) {
                     continue;
                 }
-                validate_shard_relative_path(shard_file)?;
-                let shard = Shard::open(&model_dir.join(shard_file))?;
+                let shard_path = resolve_contained_path(model_dir, shard_file)?;
+                let shard = Shard::open(&shard_path)?;
                 shards.insert(shard_file.clone(), shard);
             }
             Ok(Self {
@@ -841,7 +841,7 @@ mod tests {
         let err = QuarotTensorReader::open(dir.path())
             .expect_err("shard filename with a parent-directory component must be rejected");
         assert!(
-            err.to_string().contains("parent-directory"),
+            err.to_string().contains("escapes the checkpoint directory"),
             "unexpected error: {err}"
         );
     }
@@ -869,7 +869,7 @@ mod tests {
         let err = QuarotTensorReader::open(dir.path())
             .expect_err("an absolute shard path must be rejected");
         assert!(
-            err.to_string().contains("absolute"),
+            err.to_string().contains("escapes the checkpoint directory"),
             "unexpected error: {err}"
         );
     }

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -47,7 +47,9 @@ use memmap2::Mmap;
 use serde_json::Value;
 
 use crate::error::InferenceError;
-use crate::weights::f32_weights::parse_index;
+use crate::weights::f32_weights::{
+    SafetensorsTensorLayout, parse_index, validate_safetensors_layout,
+};
 
 /// On-disk storage dtype of a tensor.
 ///
@@ -110,55 +112,11 @@ struct Shard {
 /// per-tensor validation alone would miss.
 struct ParsedEntry {
     name: String,
+    dtype: String,
+    shape: Vec<usize>,
     start: usize,
     end: usize,
-    /// `Some` for F32/F16/BF16; `None` for any other SafeTensors dtype.
-    /// `None` entries are still kept in the contiguity check but never
-    /// appear in `Shard::headers`.
-    header: Option<TensorHeader>,
-}
-
-/// Bits per element for every standard SafeTensors dtype name. The
-/// bit-size variant (rather than bytes) is required because the format
-/// admits sub-byte dtypes: `F4` stores 4 bits per element, and
-/// `F6_E2M3` / `F6_E3M2` store 6 bits.
-///
-/// Returns `None` for any unrecognized dtype string. The caller MUST
-/// reject unknown dtypes rather than treat them as opaque, since they
-/// indicate either a newer SafeTensors revision the reader has not yet
-/// been updated for or a corrupted header.
-///
-/// Strictness note: the official `safetensors` Rust crate rejects
-/// unknown/invalid dtype metadata outright, and this reader follows
-/// that strict contract. Lattice's runtime weights parser
-/// ([`crate::weights::f32_weights::SafetensorsFile`]'s `parse_tensor_meta`)
-/// was more permissive prior to lattice#800 — it mapped unknown dtypes to
-/// `Ok(None)` and silently skipped the entry. As of lattice#800 it also
-/// rejects a genuinely unrecognized dtype string at parse time and tracks
-/// known-but-unsupported whole-byte dtypes (I64, BOOL, ...) structurally
-/// instead of dropping them, matching this reader's strictness for those
-/// cases. The two parsers still diverge on sub-byte dtypes (`F4`,
-/// `F6_E2M3`, `F6_E3M2`): this reader's bit-size table represents them
-/// exactly, while the runtime parser's whole-byte extent model treats them
-/// as unrecognized. Unifying the two parsers (not just their strictness) is
-/// a separate concern, tracked by the native Q4/KHF1 validation-unification
-/// and QuaRot/offline-quantizer routing issues in the lattice#800 cluster.
-///
-/// Table mirrors `Dtype::bitsize()` in the official `safetensors` Rust
-/// crate. Kept inline rather than depending on `safetensors` to match
-/// the hand-roll pattern of [`crate::weights::f32_weights`] (which also
-/// parses safetensors headers directly). When upstream adds a dtype,
-/// add it here and to the dtype-coverage regression tests.
-fn safetensors_bits_per_elem(dtype_str: &str) -> Option<usize> {
-    match dtype_str {
-        "F4" => Some(4),
-        "F6_E2M3" | "F6_E3M2" => Some(6),
-        "BOOL" | "U8" | "I8" | "F8_E4M3" | "F8_E5M2" | "F8_E8M0" => Some(8),
-        "I16" | "U16" | "F16" | "BF16" => Some(16),
-        "I32" | "U32" | "F32" => Some(32),
-        "I64" | "U64" | "F64" | "C64" => Some(64),
-        _ => None,
-    }
+    source_dtype: Option<SourceDType>,
 }
 
 impl Shard {
@@ -246,13 +204,16 @@ impl Shard {
                 })?
                 .iter()
                 .map(|v| {
-                    v.as_u64()
-                        .ok_or_else(|| {
-                            InferenceError::InvalidSafetensors(format!(
-                                "tensor {name}: shape dim is not u64"
-                            ))
-                        })
-                        .map(|x| x as usize)
+                    let dim = v.as_u64().ok_or_else(|| {
+                        InferenceError::InvalidSafetensors(format!(
+                            "tensor {name}: shape dim is not u64"
+                        ))
+                    })?;
+                    usize::try_from(dim).map_err(|_| {
+                        InferenceError::InvalidSafetensors(format!(
+                            "tensor {name}: shape dim {dim} exceeds usize"
+                        ))
+                    })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
@@ -274,109 +235,65 @@ impl Shard {
                 InferenceError::InvalidSafetensors(format!(
                     "tensor {name}: data_offsets[0] is not u64"
                 ))
-            })? as usize;
+            })?;
+            let start = usize::try_from(start).map_err(|_| {
+                InferenceError::InvalidSafetensors(format!(
+                    "tensor {name}: data_offsets[0] exceeds usize"
+                ))
+            })?;
             let end = offsets[1].as_u64().ok_or_else(|| {
                 InferenceError::InvalidSafetensors(format!(
                     "tensor {name}: data_offsets[1] is not u64"
                 ))
-            })? as usize;
-
-            if start > end {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "tensor {name}: invalid data_offsets [{start}, {end})"
-                )));
-            }
-            if end > data_len {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "tensor {name}: data_offsets end={end} past data_len={data_len}"
-                )));
-            }
-
-            let numel = shape.iter().try_fold(1usize, |acc, &dim| {
-                acc.checked_mul(dim).ok_or_else(|| {
-                    InferenceError::InvalidSafetensors(format!(
-                        "tensor {name}: shape {shape:?} overflows usize"
-                    ))
-                })
             })?;
-            let bits = safetensors_bits_per_elem(dtype_str).ok_or_else(|| {
+            let end = usize::try_from(end).map_err(|_| {
                 InferenceError::InvalidSafetensors(format!(
-                    "tensor {name}: unrecognized SafeTensors dtype {dtype_str:?}"
+                    "tensor {name}: data_offsets[1] exceeds usize"
                 ))
             })?;
-            let total_bits = numel.checked_mul(bits).ok_or_else(|| {
-                InferenceError::InvalidSafetensors(format!(
-                    "tensor {name}: bit length overflows usize"
-                ))
-            })?;
-            if total_bits % 8 != 0 {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "tensor {name}: sub-byte dtype {dtype_str} with shape {shape:?} \
-                     produces {total_bits} bits, which is not byte-aligned"
-                )));
-            }
-            let expected = total_bits / 8;
-            let actual = end - start;
-            if actual != expected {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "tensor {name}: byte length mismatch for {dtype_str} {shape:?}: \
-                     expected {expected}, got {actual}"
-                )));
-            }
-
-            let header = SourceDType::from_header_str(dtype_str).map(|dtype| TensorHeader {
-                dtype,
-                shape,
-                start,
-                end,
-            });
 
             parsed.push(ParsedEntry {
                 name: name.clone(),
+                dtype: dtype_str.to_string(),
+                shape,
                 start,
                 end,
-                header,
+                source_dtype: SourceDType::from_header_str(dtype_str),
             });
         }
 
-        // Phase 2: validate that all tensor byte ranges are sorted,
-        // disjoint, contiguous from offset 0, and exhaust the data
-        // section. This mirrors the official `safetensors` crate
-        // validation rules — without it, a corrupted checkpoint could
-        // silently alias two tensor names to the same byte range (e.g.
-        // both `a` and `b` pointing at `[0, 4)`), or hide leading /
-        // trailing padding, and the converter would rotate or quantize
-        // bytes that the runtime would never load.
-        parsed.sort_by_key(|p| (p.start, p.end));
-        let mut prev_end = 0usize;
-        for p in &parsed {
-            if p.start != prev_end {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "{}: data_offsets non-contiguous at tensor {}: \
-                     expected start={prev_end}, got [{}, {})",
-                    path.display(),
-                    p.name,
-                    p.start,
-                    p.end,
-                )));
+        validate_safetensors_layout(
+            parsed.iter().map(|entry| SafetensorsTensorLayout {
+                name: &entry.name,
+                dtype: &entry.dtype,
+                shape: &entry.shape,
+                start: entry.start,
+                end: entry.end,
+            }),
+            data_len,
+        )
+        .map_err(|error| match error {
+            InferenceError::InvalidSafetensors(message) => {
+                InferenceError::InvalidSafetensors(format!("{}: {message}", path.display()))
             }
-            prev_end = p.end;
-        }
-        if prev_end != data_len {
-            return Err(InferenceError::InvalidSafetensors(format!(
-                "{}: data section is {data_len} bytes but tensors cover {prev_end} bytes \
-                 (trailing or missing payload)",
-                path.display(),
-            )));
-        }
+            other => other,
+        })?;
 
-        // Phase 3: expose only supported-dtype tensors via the read API.
+        // Phase 2: expose only supported-dtype tensors via the read API.
         // Unsupported entries already had their offsets validated above
         // and their bytes accounted for in the contiguity check.
         let mut headers = HashMap::with_capacity(parsed.len());
         for p in parsed {
-            if let Some(header) = p.header {
-                headers.insert(p.name, header);
+            if let Some(dtype) = p.source_dtype {
+                headers.insert(
+                    p.name,
+                    TensorHeader {
+                        dtype,
+                        shape: p.shape,
+                        start: p.start,
+                        end: p.end,
+                    },
+                );
             }
         }
 

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -48,7 +48,7 @@ use serde_json::Value;
 
 use crate::error::InferenceError;
 use crate::weights::f32_weights::{
-    SafetensorsTensorLayout, parse_index, validate_safetensors_layout,
+    SafetensorsTensorLayout, parse_index, validate_safetensors_layout, validate_shard_relative_path,
 };
 
 /// On-disk storage dtype of a tensor.
@@ -395,6 +395,7 @@ impl QuarotTensorReader {
                 if shards.contains_key(shard_file) {
                     continue;
                 }
+                validate_shard_relative_path(shard_file)?;
                 let shard = Shard::open(&model_dir.join(shard_file))?;
                 shards.insert(shard_file.clone(), shard);
             }
@@ -808,6 +809,69 @@ mod tests {
         // Re-reading the same tensor exercises the cached-shard path.
         let (a_again, _) = reader.read_tensor_f64("a.weight").unwrap();
         assert_eq!(a_again, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn sharded_open_rejects_parent_traversal_shard_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_vals: Vec<f32> = vec![42.0];
+        write_safetensors(
+            &outside.path().join("secret.safetensors"),
+            &[("secret", FixtureDType::F32, vec![1], &outside_vals)],
+        );
+
+        let outside_name = outside
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let traversal_shard = format!("../{outside_name}/secret.safetensors");
+
+        let index = serde_json::json!({
+            "weight_map": { "a.weight": traversal_shard },
+        });
+        std::fs::write(
+            dir.path().join("model.safetensors.index.json"),
+            serde_json::to_string(&index).unwrap(),
+        )
+        .unwrap();
+
+        let err = QuarotTensorReader::open(dir.path())
+            .expect_err("shard filename with a parent-directory component must be rejected");
+        assert!(
+            err.to_string().contains("parent-directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn sharded_open_rejects_absolute_shard_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_vals: Vec<f32> = vec![42.0];
+        let outside_file = outside.path().join("secret.safetensors");
+        write_safetensors(
+            &outside_file,
+            &[("secret", FixtureDType::F32, vec![1], &outside_vals)],
+        );
+
+        let index = serde_json::json!({
+            "weight_map": { "a.weight": outside_file.to_string_lossy() },
+        });
+        std::fs::write(
+            dir.path().join("model.safetensors.index.json"),
+            serde_json::to_string(&index).unwrap(),
+        )
+        .unwrap();
+
+        let err = QuarotTensorReader::open(dir.path())
+            .expect_err("an absolute shard path must be rejected");
+        assert!(
+            err.to_string().contains("absolute"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/inference/src/vision/checkpoint.rs
+++ b/crates/inference/src/vision/checkpoint.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use crate::error::InferenceError;
 use crate::model::qwen35_config::VisionModelConfig;
 use crate::quant::q4_manifest;
-use crate::weights::f32_weights::{ShardedSafetensors, TensorSource};
+use crate::weights::f32_weights::{ShardedSafetensors, TensorSource, resolve_contained_path};
 use crate::weights::q4_weights::{dequantize_q4_to_f32, load_f16_tensor_file, load_q4_file};
 
 /// One ViT transformer block's real tensors (`model.visual.blocks.{i}.*`).
@@ -241,7 +241,13 @@ fn load_from_q4_dir(
                 entry.name,
             )));
         }
-        let file_path = model_dir.join(&entry.file);
+        let file_path = resolve_contained_path(model_dir, &entry.file).map_err(|e| {
+            InferenceError::InvalidSafetensors(format!(
+                "quantize_index.json entry {} in {}: {e}",
+                entry.name,
+                model_dir.display()
+            ))
+        })?;
         let (data, shape) = if entry.quantized.unwrap_or(false) {
             let q4 = load_q4_file(&file_path).map_err(|e| {
                 InferenceError::InvalidSafetensors(format!(
@@ -790,6 +796,129 @@ mod tests {
             }
             other => panic!("expected InferenceError::Inference, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn q4_manifest_rejects_absolute_entry_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = outside.path().join("secret.q4");
+        let data: Vec<f64> = vec![0.25_f64; 4];
+        let q4 =
+            crate::weights::q4_weights::quantize_f64_to_q4(&data, &[4]).expect("quantize succeeds");
+        crate::weights::q4_weights::save_q4_file(&outside_file, &q4)
+            .expect("test setup: write outside q4 file");
+
+        let abs = outside_file.to_string_lossy().replace('\\', "\\\\");
+        std::fs::write(
+            tmp.path().join("quantize_index.json"),
+            format!(r#"[{{"name":"model.visual.test","file":"{abs}","quantized":true}}]"#),
+        )
+        .expect("test setup: write manifest");
+
+        let cfg = tiny_vision_cfg();
+        // Without containment on `entry.file`, this join would discard `model_dir`
+        // and load `outside_file` directly instead of erroring.
+        let err = load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect_err("an absolute quantize_index.json entry.file must be rejected");
+        assert!(
+            err.to_string().contains("escapes the checkpoint directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn q4_manifest_rejects_parent_traversal_entry_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside_dir = tmp.path().parent().expect("temp dir has a parent");
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("invariant: system time is after UNIX_EPOCH")
+            .as_nanos();
+        let outside_name = format!("lattice_q4_traversal_outside_{unique}.q4");
+        let outside_file = outside_dir.join(&outside_name);
+        let data: Vec<f64> = vec![0.25_f64; 4];
+        let q4 =
+            crate::weights::q4_weights::quantize_f64_to_q4(&data, &[4]).expect("quantize succeeds");
+        crate::weights::q4_weights::save_q4_file(&outside_file, &q4)
+            .expect("test setup: write outside q4 file");
+
+        std::fs::write(
+            tmp.path().join("quantize_index.json"),
+            format!(
+                r#"[{{"name":"model.visual.test","file":"../{outside_name}","quantized":true}}]"#
+            ),
+        )
+        .expect("test setup: write manifest");
+
+        let cfg = tiny_vision_cfg();
+        let err = load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect_err("a parent-traversal quantize_index.json entry.file must be rejected");
+        assert!(
+            err.to_string().contains("escapes the checkpoint directory"),
+            "unexpected error: {err}"
+        );
+
+        std::fs::remove_file(&outside_file).ok();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn q4_manifest_rejects_symlink_entry_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = outside.path().join("secret.q4");
+        let data: Vec<f64> = vec![0.25_f64; 4];
+        let q4 =
+            crate::weights::q4_weights::quantize_f64_to_q4(&data, &[4]).expect("quantize succeeds");
+        crate::weights::q4_weights::save_q4_file(&outside_file, &q4)
+            .expect("test setup: write outside q4 file");
+
+        let link_name = "linked.q4";
+        std::os::unix::fs::symlink(&outside_file, tmp.path().join(link_name))
+            .expect("test setup: create symlink entry");
+
+        std::fs::write(
+            tmp.path().join("quantize_index.json"),
+            format!(r#"[{{"name":"model.visual.test","file":"{link_name}","quantized":true}}]"#),
+        )
+        .expect("test setup: write manifest");
+
+        let cfg = tiny_vision_cfg();
+        // A lexically valid `entry.file` that is a symlink escaping `model_dir`
+        // must be rejected the same way an absolute or `..` path is.
+        let err = load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect_err("a symlink quantize_index.json entry.file must be rejected");
+        assert!(
+            err.to_string().contains("escapes the checkpoint directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn q4_manifest_accepts_legitimate_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let shapes = tiny_expected_shapes();
+
+        let mut manifest_entries = Vec::new();
+        for (i, (name, shape)) in shapes.iter().enumerate() {
+            let numel: usize = shape.iter().product();
+            let values = vec![0.5f32; numel];
+            let file_name = format!("t{i}.f16");
+            write_khf1_f16_file(&tmp.path().join(&file_name), shape, &values);
+            manifest_entries.push(format!(
+                r#"{{"name":"{name}","file":"{file_name}","quantized":false}}"#
+            ));
+        }
+        std::fs::write(
+            tmp.path().join("quantize_index.json"),
+            format!("[{}]", manifest_entries.join(",")),
+        )
+        .expect("test setup: write manifest");
+
+        load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect("a manifest of legitimate in-directory entries must load");
     }
 
     #[test]

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -149,6 +149,41 @@ pub(crate) fn validate_safetensors_layout<'a>(
     Ok(())
 }
 
+/// Reject a shard filename that would escape the model directory when
+/// joined onto it.
+///
+/// Shard filenames come from `model.safetensors.index.json`'s `weight_map`,
+/// which is untrusted checkpoint content, not a value this crate controls.
+/// Joining an unchecked value onto the model directory lets an absolute
+/// path or a `..` component redirect the reader to any file the process
+/// can read, outside the checkpoint. Every call site that joins an
+/// index-derived shard name onto a directory must validate it with this
+/// function first.
+pub(crate) fn validate_shard_relative_path(name: &str) -> Result<(), InferenceError> {
+    let path = Path::new(name);
+    if path.is_absolute() {
+        return Err(InferenceError::InvalidSafetensors(format!(
+            "shard filename {name:?} is absolute; must be relative to the checkpoint directory"
+        )));
+    }
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "shard filename {name:?} contains a parent-directory (..) component"
+                )));
+            }
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "shard filename {name:?} contains a root or prefix component"
+                )));
+            }
+            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+        }
+    }
+    Ok(())
+}
+
 /// Resolve a safetensors header `dtype` string to a [`DType`], including
 /// non-float dtypes (tracked via `DType::Other` so extent validation still
 /// covers them). Returns `None` only for a string this crate has never
@@ -1071,9 +1106,15 @@ impl TensorSource for SafetensorsFile {
     }
 }
 
-/// Lazy-opening reader for sharded safetensors checkpoints.
+/// Reader for sharded safetensors checkpoints.
 ///
-/// Opens shard files on demand (first access) to avoid mapping 26 files upfront.
+/// `open_index` maps and format-validates every unique shard's header up
+/// front — matching `QuarotTensorReader`'s eager contract so a malformed
+/// shard is rejected at open time even if none of its tensors are ever
+/// requested. This only touches header bytes (mmap + JSON parse); tensor
+/// *data* stays lazily materialized on first `get_f32_tensor_owned` access,
+/// so the memory profile for large checkpoints (e.g. 26-shard Qwen3.6) is
+/// unchanged from the previous lazy-shard design.
 #[derive(Debug)]
 pub struct ShardedSafetensors {
     root: PathBuf,
@@ -1121,6 +1162,7 @@ pub fn load_sharded(model_dir: &Path) -> Result<HashMap<String, Tensor>, Inferen
 
     let mut tensors = HashMap::with_capacity(index.weight_map.len());
     for (shard_file, tensor_names) in by_shard {
+        validate_shard_relative_path(&shard_file)?;
         let shard_path = model_dir.join(&shard_file);
         let shard = SafetensorsFile::open(&shard_path)?;
         for tensor_name in tensor_names {
@@ -1139,17 +1181,30 @@ pub fn load_sharded(model_dir: &Path) -> Result<HashMap<String, Tensor>, Inferen
 }
 
 impl ShardedSafetensors {
-    /// Parse `model.safetensors.index.json` and set up the lazy shard reader.
+    /// Parse `model.safetensors.index.json` and eagerly format-validate
+    /// every unique shard it references.
     pub fn open_index(index_path: &Path) -> Result<Self, InferenceError> {
         let root = index_path
             .parent()
             .unwrap_or_else(|| Path::new("."))
             .to_path_buf();
         let index = parse_index(&root)?;
+
+        let mut shards: HashMap<String, SafetensorsFile> = HashMap::new();
+        for shard_file in index.weight_map.values() {
+            if shards.contains_key(shard_file) {
+                continue;
+            }
+            validate_shard_relative_path(shard_file)?;
+            let shard_path = root.join(shard_file);
+            let shard = SafetensorsFile::open(&shard_path)?;
+            shards.insert(shard_file.clone(), shard);
+        }
+
         Ok(Self {
             root,
             index,
-            shards: HashMap::new(),
+            shards,
         })
     }
 
@@ -1165,6 +1220,7 @@ impl ShardedSafetensors {
             .weight_map
             .get(tensor_name)
             .ok_or_else(|| InferenceError::MissingTensor(tensor_name.to_string()))?;
+        validate_shard_relative_path(shard_file)?;
         Ok((self.root.join(shard_file), tensor_name.to_string()))
     }
 
@@ -1178,6 +1234,7 @@ impl ShardedSafetensors {
 
     fn open_shard(&mut self, shard_file: &str) -> Result<&SafetensorsFile, InferenceError> {
         if !self.shards.contains_key(shard_file) {
+            validate_shard_relative_path(shard_file)?;
             let shard_path = self.root.join(shard_file);
             let shard = SafetensorsFile::open(&shard_path)?;
             self.shards.insert(shard_file.to_string(), shard);
@@ -2660,6 +2717,105 @@ mod tests {
         assert!(
             result.is_err(),
             "load_sharded must return Err when indexed shard file is absent"
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_load_sharded_rejects_parent_traversal_shard_name() {
+        let dir = temp_dir("lattice_shard_traversal_test");
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("invariant: system time is after UNIX_EPOCH")
+            .as_nanos();
+        let outside_name = format!("lattice_shard_traversal_outside_{unique}.safetensors");
+        let outside = dir
+            .parent()
+            .expect("temp dir has a parent")
+            .join(&outside_name);
+        write_single_f32_tensor(&outside, "secret", &[9.0]);
+
+        let index_path = dir.join("model.safetensors.index.json");
+        fs::write(
+            &index_path,
+            format!(r#"{{"weight_map":{{"tensor.a":"../{outside_name}"}}}}"#),
+        )
+        .expect("test setup: write index");
+
+        // Without the shard-path guard this join would resolve outside
+        // `dir` and open `outside` successfully instead of erroring.
+        let err = load_sharded(&dir)
+            .expect_err("shard filename with a parent-directory component must be rejected");
+        assert!(
+            err.to_string().contains("parent-directory"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&outside).ok();
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_load_sharded_rejects_absolute_shard_path() {
+        let dir = temp_dir("lattice_shard_absolute_test");
+        let outside_dir = temp_dir("lattice_shard_absolute_outside");
+        let outside_file = outside_dir.join("model-00001-of-00001.safetensors");
+        write_single_f32_tensor(&outside_file, "secret", &[9.0]);
+
+        let index_path = dir.join("model.safetensors.index.json");
+        let abs = outside_file.to_string_lossy().replace('\\', "\\\\");
+        fs::write(
+            &index_path,
+            format!(r#"{{"weight_map":{{"tensor.a":"{abs}"}}}}"#),
+        )
+        .expect("test setup: write index");
+
+        // Without the shard-path guard this join would discard `dir` and
+        // open `outside_file` directly instead of erroring.
+        let err = load_sharded(&dir).expect_err("an absolute shard path must be rejected");
+        assert!(
+            err.to_string().contains("absolute"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_dir_all(&outside_dir).ok();
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_sharded_safetensors_open_index_rejects_malformed_unaccessed_shard() {
+        let dir = temp_dir("lattice_malformed_shard_test");
+        let shard_a = dir.join("model-00001-of-00002.safetensors");
+        let shard_b = dir.join("model-00002-of-00002.safetensors");
+        write_single_f32_tensor(&shard_a, "tensor.a", &[1.0, 2.0]);
+
+        // Shard b's header declares tensor.b as 3 f32 (12 bytes) but the
+        // data_offsets only span 8 bytes — a malformed layout that
+        // `validate_safetensors_layout` rejects. `tensor.b` is never
+        // requested by this test.
+        let header = r#"{"tensor.b":{"dtype":"F32","shape":[3],"data_offsets":[0,8]}}"#;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&[0u8; 8]);
+        fs::write(&shard_b, &bytes).expect("test setup: write malformed shard b");
+
+        let index_path = dir.join("model.safetensors.index.json");
+        fs::write(
+            &index_path,
+            r#"{"weight_map":{"tensor.a":"model-00001-of-00002.safetensors","tensor.b":"model-00002-of-00002.safetensors"}}"#,
+        )
+        .expect("test setup: write index");
+
+        // Before the fix, `open_index` left shards unopened and this call
+        // would succeed even though shard_b is malformed, because nothing
+        // here ever calls `get_f32_tensor_owned("tensor.b")`.
+        let result = ShardedSafetensors::open_index(&index_path);
+        assert!(
+            result.is_err(),
+            "open_index must eagerly reject a malformed shard even when none of its \
+             tensors are ever requested, matching the QuaRot reader's eager contract"
         );
 
         fs::remove_dir_all(&dir).ok();

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -3,7 +3,7 @@ use crate::error::InferenceError;
 use memmap2::Mmap;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -182,6 +182,53 @@ pub(crate) fn validate_shard_relative_path(name: &str) -> Result<(), InferenceEr
         }
     }
     Ok(())
+}
+
+/// Resolve an untrusted, checkpoint-supplied relative path onto `model_dir`
+/// and require the result to stay inside it, defeating symlink escapes in
+/// addition to the lexical `..`/absolute-path escapes
+/// [`validate_shard_relative_path`] already rejects.
+///
+/// Lexical validation alone is not sufficient: a shard name can pass every
+/// lexical check (no `..`, not absolute) yet still be a symlink that
+/// resolves outside the model directory, letting `File::open` disclose any
+/// file the process can read. This function canonicalizes both the model
+/// directory and the joined candidate — which follows symlinks and resolves
+/// `..` components — and requires the canonical candidate to be contained in
+/// the canonical root via [`Path::starts_with`] (a component-wise check, not
+/// a string prefix, so `/model` cannot match a sibling `/model-evil`).
+/// Canonicalizing both sides also normalizes platform path aliasing (e.g.
+/// macOS's `/tmp` → `/private/tmp` symlink).
+///
+/// An absolute `untrusted` value replaces `model_dir` entirely under
+/// `Path::join`'s semantics; canonicalizing the result and checking
+/// containment rejects it the same way as a symlink or `..` escape, so one
+/// check covers all three attack shapes.
+///
+/// If the candidate does not exist, this returns the same
+/// [`InferenceError::InvalidSafetensors`] "failed to open" shape that
+/// [`SafetensorsFile::open`] already returns for a missing shard, so callers
+/// do not observe a new error shape for the ordinary missing-file case.
+pub(crate) fn resolve_contained_path(
+    model_dir: &Path,
+    untrusted: &str,
+) -> Result<PathBuf, InferenceError> {
+    let candidate = model_dir.join(untrusted);
+    let canonical_root = fs::canonicalize(model_dir).map_err(|e| {
+        InferenceError::InvalidSafetensors(format!(
+            "failed to canonicalize model directory {}: {e}",
+            model_dir.display()
+        ))
+    })?;
+    let canonical_candidate = fs::canonicalize(&candidate).map_err(|e| {
+        InferenceError::InvalidSafetensors(format!("failed to open {}: {e}", candidate.display()))
+    })?;
+    if !canonical_candidate.starts_with(&canonical_root) {
+        return Err(InferenceError::InvalidSafetensors(format!(
+            "path {untrusted:?} escapes the checkpoint directory"
+        )));
+    }
+    Ok(canonical_candidate)
 }
 
 /// Resolve a safetensors header `dtype` string to a [`DType`], including
@@ -1143,19 +1190,19 @@ pub fn resolve_shard(
     Ok(PathBuf::from(shard_file))
 }
 
-/// Validate an index-derived shard filename and join it onto `root`.
+/// Validate an index-derived shard filename and resolve it onto `root`,
+/// rejecting the result if it escapes `root` once symlinks and `..`
+/// components are resolved.
 ///
 /// This is the crate-public entry point for the containment policy
-/// enforced by [`validate_shard_relative_path`], for callers outside
+/// enforced by [`resolve_contained_path`], for callers outside
 /// `lattice-inference` (e.g. `lattice-embed`) that need to resolve a
 /// `weight_map` value onto a model directory. Every caller that joins a
 /// `weight_map`/shard-index-derived filename onto a directory — in this
 /// crate or a downstream one — must go through this function (or
-/// `validate_shard_relative_path` directly, in-crate) before the join, not
-/// after.
+/// `resolve_contained_path` directly, in-crate) before the join, not after.
 pub fn resolve_shard_path(root: &Path, shard_file: &str) -> Result<PathBuf, InferenceError> {
-    validate_shard_relative_path(shard_file)?;
-    Ok(root.join(shard_file))
+    resolve_contained_path(root, shard_file)
 }
 
 /// Eagerly load all tensors from a sharded checkpoint into an owned map.
@@ -1177,8 +1224,7 @@ pub fn load_sharded(model_dir: &Path) -> Result<HashMap<String, Tensor>, Inferen
 
     let mut tensors = HashMap::with_capacity(index.weight_map.len());
     for (shard_file, tensor_names) in by_shard {
-        validate_shard_relative_path(&shard_file)?;
-        let shard_path = model_dir.join(&shard_file);
+        let shard_path = resolve_contained_path(model_dir, &shard_file)?;
         let shard = SafetensorsFile::open(&shard_path)?;
         for tensor_name in tensor_names {
             let (data, shape) = shard.get_f32_tensor(&tensor_name)?;
@@ -1195,6 +1241,21 @@ pub fn load_sharded(model_dir: &Path) -> Result<HashMap<String, Tensor>, Inferen
     Ok(tensors)
 }
 
+/// Cap on the number of distinct shard files a single manifest may name in
+/// [`ShardedSafetensors::open_index`].
+///
+/// `open_index` eagerly mmaps every unique shard the index names so
+/// `has_tensor`/`tensor_shape` never need a subsequent disk hit. That means
+/// the number of live mmaps at construction time is entirely
+/// manifest-controlled: a crafted `model.safetensors.index.json` naming many
+/// distinct, individually valid (containment-checked) shard filenames can
+/// exhaust address space or file descriptors purely at init, before any
+/// tensor is requested. The largest known real-world sharded checkpoints
+/// split into low hundreds of shards; this cap sits an order of magnitude
+/// above that so no legitimate checkpoint is affected while bounding the
+/// worst case.
+const MAX_SHARDED_MANIFEST_SHARDS: usize = 4096;
+
 impl ShardedSafetensors {
     /// Parse `model.safetensors.index.json` and eagerly format-validate
     /// every unique shard it references.
@@ -1205,13 +1266,20 @@ impl ShardedSafetensors {
             .to_path_buf();
         let index = parse_index(&root)?;
 
+        let unique_shards: std::collections::BTreeSet<&String> =
+            index.weight_map.values().collect();
+        if unique_shards.len() > MAX_SHARDED_MANIFEST_SHARDS {
+            return Err(InferenceError::InvalidSafetensors(format!(
+                "model.safetensors.index.json in {} names {} distinct shards, exceeding the \
+                 {MAX_SHARDED_MANIFEST_SHARDS}-shard cap enforced at load time",
+                root.display(),
+                unique_shards.len(),
+            )));
+        }
+
         let mut shards: HashMap<String, SafetensorsFile> = HashMap::new();
-        for shard_file in index.weight_map.values() {
-            if shards.contains_key(shard_file) {
-                continue;
-            }
-            validate_shard_relative_path(shard_file)?;
-            let shard_path = root.join(shard_file);
+        for shard_file in unique_shards {
+            let shard_path = resolve_contained_path(&root, shard_file)?;
             let shard = SafetensorsFile::open(&shard_path)?;
             shards.insert(shard_file.clone(), shard);
         }
@@ -1235,8 +1303,8 @@ impl ShardedSafetensors {
             .weight_map
             .get(tensor_name)
             .ok_or_else(|| InferenceError::MissingTensor(tensor_name.to_string()))?;
-        validate_shard_relative_path(shard_file)?;
-        Ok((self.root.join(shard_file), tensor_name.to_string()))
+        let shard_path = resolve_contained_path(&self.root, shard_file)?;
+        Ok((shard_path, tensor_name.to_string()))
     }
 
     fn shard_file_for(&self, name: &str) -> Result<String, InferenceError> {
@@ -1247,10 +1315,13 @@ impl ShardedSafetensors {
             .ok_or_else(|| InferenceError::MissingTensor(name.to_string()))
     }
 
+    // `open_index` eagerly resolves and opens every distinct shard the
+    // manifest names, so by the time `self` exists every key `shard_file_for`
+    // can return is already present in `self.shards` — the lazy-open branch
+    // below is unreachable in practice but kept as a defensive fallback.
     fn open_shard(&mut self, shard_file: &str) -> Result<&SafetensorsFile, InferenceError> {
         if !self.shards.contains_key(shard_file) {
-            validate_shard_relative_path(shard_file)?;
-            let shard_path = self.root.join(shard_file);
+            let shard_path = resolve_contained_path(&self.root, shard_file)?;
             let shard = SafetensorsFile::open(&shard_path)?;
             self.shards.insert(shard_file.to_string(), shard);
         }
@@ -2763,7 +2834,7 @@ mod tests {
         let err = load_sharded(&dir)
             .expect_err("shard filename with a parent-directory component must be rejected");
         assert!(
-            err.to_string().contains("parent-directory"),
+            err.to_string().contains("escapes the checkpoint directory"),
             "unexpected error: {err}"
         );
 
@@ -2790,11 +2861,76 @@ mod tests {
         // open `outside_file` directly instead of erroring.
         let err = load_sharded(&dir).expect_err("an absolute shard path must be rejected");
         assert!(
-            err.to_string().contains("absolute"),
+            err.to_string().contains("escapes the checkpoint directory"),
             "unexpected error: {err}"
         );
 
         fs::remove_dir_all(&outside_dir).ok();
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_load_sharded_rejects_symlink_shard_escape() {
+        let dir = temp_dir("lattice_shard_symlink_test");
+        let outside_dir = temp_dir("lattice_shard_symlink_outside");
+        let outside_file = outside_dir.join("secret.safetensors");
+        write_single_f32_tensor(&outside_file, "secret", &[9.0]);
+
+        // A shard filename that is lexically valid (no `..`, not absolute)
+        // but is actually a symlink resolving outside `dir`.
+        let symlink_name = "model-00001-of-00001.safetensors";
+        std::os::unix::fs::symlink(&outside_file, dir.join(symlink_name))
+            .expect("test setup: create symlink shard");
+
+        let index_path = dir.join("model.safetensors.index.json");
+        fs::write(
+            &index_path,
+            format!(r#"{{"weight_map":{{"tensor.a":"{symlink_name}"}}}}"#),
+        )
+        .expect("test setup: write index");
+
+        // Lexical validation alone would accept `symlink_name` (no `..`, not
+        // absolute) and `File::open` would happily follow the symlink,
+        // disclosing `outside_file`'s contents. Containment must reject it.
+        let err = load_sharded(&dir).expect_err(
+            "a shard filename that is a symlink escaping the model dir must be rejected",
+        );
+        assert!(
+            err.to_string().contains("escapes the checkpoint directory"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_dir_all(&outside_dir).ok();
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_open_index_rejects_manifest_exceeding_shard_cap() {
+        let dir = temp_dir("lattice_shard_cap_test");
+        let mut weight_map = String::from("{");
+        for i in 0..=MAX_SHARDED_MANIFEST_SHARDS {
+            if i > 0 {
+                weight_map.push(',');
+            }
+            weight_map.push_str(&format!(r#""tensor.{i}":"shard-{i}.safetensors""#));
+        }
+        weight_map.push('}');
+
+        let index_path = dir.join("model.safetensors.index.json");
+        fs::write(&index_path, format!(r#"{{"weight_map":{weight_map}}}"#))
+            .expect("test setup: write index");
+
+        // None of the `MAX_SHARDED_MANIFEST_SHARDS + 1` shard files are
+        // ever created on disk: the cap must reject the manifest before
+        // `open_index` attempts to resolve or mmap a single one of them.
+        let err = ShardedSafetensors::open_index(&index_path)
+            .expect_err("a manifest naming more than the shard cap must be rejected");
+        assert!(
+            err.to_string().contains("exceeding"),
+            "unexpected error: {err}"
+        );
+
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -1143,6 +1143,21 @@ pub fn resolve_shard(
     Ok(PathBuf::from(shard_file))
 }
 
+/// Validate an index-derived shard filename and join it onto `root`.
+///
+/// This is the crate-public entry point for the containment policy
+/// enforced by [`validate_shard_relative_path`], for callers outside
+/// `lattice-inference` (e.g. `lattice-embed`) that need to resolve a
+/// `weight_map` value onto a model directory. Every caller that joins a
+/// `weight_map`/shard-index-derived filename onto a directory — in this
+/// crate or a downstream one — must go through this function (or
+/// `validate_shard_relative_path` directly, in-crate) before the join, not
+/// after.
+pub fn resolve_shard_path(root: &Path, shard_file: &str) -> Result<PathBuf, InferenceError> {
+    validate_shard_relative_path(shard_file)?;
+    Ok(root.join(shard_file))
+}
+
 /// Eagerly load all tensors from a sharded checkpoint into an owned map.
 ///
 /// Groups tensor names by shard file to open each shard file exactly once.

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -19,19 +19,10 @@ enum DType {
     /// via `get_f32_tensor` (lattice#800).
     Other {
         label: &'static str,
-        size_bytes: usize,
     },
 }
 
 impl DType {
-    fn size_bytes(self) -> usize {
-        match self {
-            Self::F32 => 4,
-            Self::F16 | Self::BF16 => 2,
-            Self::Other { size_bytes, .. } => size_bytes,
-        }
-    }
-
     fn name(self) -> &'static str {
         match self {
             Self::F32 => "F32",
@@ -42,6 +33,122 @@ impl DType {
     }
 }
 
+pub(crate) struct SafetensorsTensorLayout<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) dtype: &'a str,
+    pub(crate) shape: &'a [usize],
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+}
+
+fn safetensors_dtype(dtype: &str) -> Option<(&'static str, usize)> {
+    Some(match dtype {
+        "F4" => ("F4", 4),
+        "F6_E2M3" => ("F6_E2M3", 6),
+        "F6_E3M2" => ("F6_E3M2", 6),
+        "BOOL" => ("BOOL", 8),
+        "U8" => ("U8", 8),
+        "I8" => ("I8", 8),
+        "F8_E4M3" => ("F8_E4M3", 8),
+        "F8_E5M2" => ("F8_E5M2", 8),
+        "F8_E8M0" => ("F8_E8M0", 8),
+        "F8_E4M3FNUZ" => ("F8_E4M3FNUZ", 8),
+        "F8_E5M2FNUZ" => ("F8_E5M2FNUZ", 8),
+        "I16" => ("I16", 16),
+        "U16" => ("U16", 16),
+        "F16" => ("F16", 16),
+        "BF16" => ("BF16", 16),
+        "I32" => ("I32", 32),
+        "U32" => ("U32", 32),
+        "F32" => ("F32", 32),
+        "I64" => ("I64", 64),
+        "U64" => ("U64", 64),
+        "F64" => ("F64", 64),
+        "C64" => ("C64", 64),
+        _ => return None,
+    })
+}
+
+pub(crate) fn validate_safetensors_layout<'a>(
+    tensors: impl IntoIterator<Item = SafetensorsTensorLayout<'a>>,
+    data_len: usize,
+) -> Result<(), InferenceError> {
+    let mut ranges = Vec::new();
+    for tensor in tensors {
+        if tensor.start > tensor.end {
+            return Err(InferenceError::InvalidSafetensors(format!(
+                "tensor {} has invalid offsets [{}, {})",
+                tensor.name, tensor.start, tensor.end
+            )));
+        }
+        if tensor.end > data_len {
+            return Err(InferenceError::InvalidSafetensors(format!(
+                "tensor {} points past data section: end={}, data_len={data_len}",
+                tensor.name, tensor.end
+            )));
+        }
+
+        let numel = tensor.shape.iter().try_fold(1usize, |acc, &dim| {
+            acc.checked_mul(dim).ok_or_else(|| {
+                InferenceError::InvalidSafetensors(format!(
+                    "tensor {} shape {:?} overflows usize",
+                    tensor.name, tensor.shape
+                ))
+            })
+        })?;
+        let (_, bits_per_elem) = safetensors_dtype(tensor.dtype).ok_or_else(|| {
+            InferenceError::InvalidSafetensors(format!(
+                "tensor {} has unrecognized SafeTensors dtype {:?}",
+                tensor.name, tensor.dtype
+            ))
+        })?;
+        let total_bits = numel.checked_mul(bits_per_elem).ok_or_else(|| {
+            InferenceError::InvalidSafetensors(format!(
+                "tensor {} bit length overflows usize",
+                tensor.name
+            ))
+        })?;
+        if total_bits % 8 != 0 {
+            return Err(InferenceError::InvalidSafetensors(format!(
+                "tensor {} sub-byte dtype {} with shape {:?} produces {total_bits} bits, which is \
+                 not byte-aligned",
+                tensor.name, tensor.dtype, tensor.shape
+            )));
+        }
+        let expected = total_bits / 8;
+        let actual = tensor.end - tensor.start;
+        if actual != expected {
+            return Err(InferenceError::InvalidSafetensors(format!(
+                "tensor {} byte length mismatch for dtype {} and shape {:?}: expected \
+                 {expected}, got {actual}",
+                tensor.name, tensor.dtype, tensor.shape
+            )));
+        }
+
+        ranges.push((tensor.start, tensor.end, tensor.name));
+    }
+
+    ranges.sort_unstable();
+    let mut previous_end = 0usize;
+    for (start, end, name) in ranges {
+        if start != previous_end {
+            return Err(InferenceError::InvalidSafetensors(format!(
+                "tensor {name} has non-contiguous data offsets: expected start={previous_end}, \
+                 got [{start}, {end})"
+            )));
+        }
+        previous_end = end;
+    }
+    if previous_end != data_len {
+        return Err(InferenceError::InvalidSafetensors(format!(
+            "data section is {data_len} bytes but tensors cover {previous_end} bytes (trailing or \
+             missing payload)"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Resolve a safetensors header `dtype` string to a [`DType`], including
 /// non-float dtypes (tracked via `DType::Other` so extent validation still
 /// covers them). Returns `None` only for a string this crate has never
@@ -49,73 +156,12 @@ impl DType {
 /// unrecognized dtype's byte width is unknowable and extent validation
 /// cannot proceed (lattice#800).
 fn dtype_from_str(s: &str) -> Option<DType> {
-    Some(match s {
+    let (label, _) = safetensors_dtype(s)?;
+    Some(match label {
         "F32" => DType::F32,
         "F16" => DType::F16,
         "BF16" => DType::BF16,
-        "F64" => DType::Other {
-            label: "F64",
-            size_bytes: 8,
-        },
-        "I64" => DType::Other {
-            label: "I64",
-            size_bytes: 8,
-        },
-        "U64" => DType::Other {
-            label: "U64",
-            size_bytes: 8,
-        },
-        "I32" => DType::Other {
-            label: "I32",
-            size_bytes: 4,
-        },
-        "U32" => DType::Other {
-            label: "U32",
-            size_bytes: 4,
-        },
-        "I16" => DType::Other {
-            label: "I16",
-            size_bytes: 2,
-        },
-        "U16" => DType::Other {
-            label: "U16",
-            size_bytes: 2,
-        },
-        "I8" => DType::Other {
-            label: "I8",
-            size_bytes: 1,
-        },
-        "U8" => DType::Other {
-            label: "U8",
-            size_bytes: 1,
-        },
-        "BOOL" => DType::Other {
-            label: "BOOL",
-            size_bytes: 1,
-        },
-        "F8_E4M3" => DType::Other {
-            label: "F8_E4M3",
-            size_bytes: 1,
-        },
-        "F8_E5M2" => DType::Other {
-            label: "F8_E5M2",
-            size_bytes: 1,
-        },
-        "F8_E8M0" => DType::Other {
-            label: "F8_E8M0",
-            size_bytes: 1,
-        },
-        "C64" => DType::Other {
-            label: "C64",
-            size_bytes: 8,
-        },
-        // Sub-byte dtypes (F4: 4 bits/elem, F6_E2M3 / F6_E3M2: 6 bits/elem)
-        // do not fit this crate's whole-byte-per-element extent model and
-        // are treated as unrecognized here; see
-        // `crate::quant::quarot::io::safetensors_bits_per_elem` for the
-        // bit-level table used by the QuaRot converter, which does support
-        // sub-byte dtypes.
-        _ => return None,
+        _ => DType::Other { label },
     })
 }
 
@@ -325,63 +371,16 @@ impl SafetensorsFile {
         let tensors = parse_safetensors_header(header)?;
 
         let data_len = bytes.len() - data_offset;
-        for (name, meta) in &tensors {
-            if meta.start > meta.end {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "tensor {name} has invalid offsets [{}, {})",
-                    meta.start, meta.end
-                )));
-            }
-            if meta.end > data_len {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "tensor {name} points past data section: end={}, data_len={}",
-                    meta.end, data_len
-                )));
-            }
-            let numel = meta.shape.iter().try_fold(1usize, |acc, &dim| {
-                acc.checked_mul(dim).ok_or_else(|| {
-                    InferenceError::InvalidSafetensors(format!(
-                        "tensor {name} shape {:?} overflows usize",
-                        meta.shape
-                    ))
-                })
-            })?;
-            let expected = numel.checked_mul(meta.dtype.size_bytes()).ok_or_else(|| {
-                InferenceError::InvalidSafetensors(format!(
-                    "tensor {name} byte length overflows usize"
-                ))
-            })?;
-            let actual = meta.end - meta.start;
-            if actual != expected {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "tensor {name} byte length mismatch for dtype {} and shape {:?}: \
-                     expected {expected}, got {actual}",
-                    meta.dtype.name(),
-                    meta.shape
-                )));
-            }
-        }
-
-        let mut ranges: Vec<_> = tensors
-            .iter()
-            .map(|(name, meta)| (meta.start, meta.end, name.as_str()))
-            .collect();
-        ranges.sort_unstable();
-        let mut previous_end = 0usize;
-        for &(start, end, name) in &ranges {
-            if start != previous_end {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "tensor {name} has non-contiguous data offsets: expected start={previous_end}, \
-                     got [{start}, {end})"
-                )));
-            }
-            previous_end = end;
-        }
-        if previous_end != data_len {
-            return Err(InferenceError::InvalidSafetensors(format!(
-                "data section is {data_len} bytes but tensors cover {previous_end} bytes"
-            )));
-        }
+        validate_safetensors_layout(
+            tensors.iter().map(|(name, meta)| SafetensorsTensorLayout {
+                name,
+                dtype: meta.dtype.name(),
+                shape: &meta.shape,
+                start: meta.start,
+                end: meta.end,
+            }),
+            data_len,
+        )?;
 
         Ok(Self {
             data,
@@ -1972,6 +1971,27 @@ mod tests {
         ))
     }
 
+    fn write_raw_safetensors(path: &Path, header: &str, data: &[u8]) {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(data);
+        let mut file = File::create(path).expect("test setup: create safetensors file");
+        file.write_all(&bytes)
+            .expect("test setup: write safetensors bytes");
+    }
+
+    fn assert_raw_open_error(name: &str, header: &str, data: &[u8], expected: &str) {
+        let path = temp_path(name);
+        write_raw_safetensors(&path, header, data);
+        let err = SafetensorsFile::open(&path).expect_err("invalid layout must fail at open");
+        assert!(
+            err.to_string().contains(expected),
+            "expected {expected:?} in error, got: {err}"
+        );
+        fs::remove_file(path).ok();
+    }
+
     #[test]
     fn test_parse_small_safetensors_file() {
         let path = temp_path("lattice_weights_test");
@@ -2099,6 +2119,112 @@ mod tests {
         );
 
         fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_rejects_leading_data_hole() {
+        assert_raw_open_error(
+            "lattice_weights_leading_hole",
+            r#"{"w":{"dtype":"F32","shape":[1],"data_offsets":[4,8]}}"#,
+            &[0; 8],
+            "non-contiguous",
+        );
+    }
+
+    #[test]
+    fn test_rejects_internal_data_hole() {
+        assert_raw_open_error(
+            "lattice_weights_internal_hole",
+            r#"{"a":{"dtype":"F32","shape":[1],"data_offsets":[0,4]},"b":{"dtype":"F32","shape":[1],"data_offsets":[8,12]}}"#,
+            &[0; 12],
+            "non-contiguous",
+        );
+    }
+
+    #[test]
+    fn test_rejects_trailing_payload() {
+        assert_raw_open_error(
+            "lattice_weights_trailing_payload",
+            r#"{"w":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#,
+            &[0; 8],
+            "data section",
+        );
+    }
+
+    #[test]
+    fn test_unsupported_dtype_still_participates_in_layout_validation() {
+        assert_raw_open_error(
+            "lattice_weights_unsupported_dtype_hole",
+            r#"{"w":{"dtype":"I64","shape":[1],"data_offsets":[4,12]}}"#,
+            &[0; 12],
+            "non-contiguous",
+        );
+    }
+
+    #[test]
+    fn test_rejects_f8_byte_length_mismatch() {
+        assert_raw_open_error(
+            "lattice_weights_f8_bad_length",
+            r#"{"w":{"dtype":"F8_E8M0","shape":[2],"data_offsets":[0,1]}}"#,
+            &[0],
+            "byte length mismatch",
+        );
+    }
+
+    #[test]
+    fn test_rejects_c64_byte_length_mismatch() {
+        assert_raw_open_error(
+            "lattice_weights_c64_bad_length",
+            r#"{"w":{"dtype":"C64","shape":[1],"data_offsets":[0,4]}}"#,
+            &[0; 4],
+            "byte length mismatch",
+        );
+    }
+
+    #[test]
+    fn test_rejects_non_byte_aligned_sub_byte_tensor() {
+        assert_raw_open_error(
+            "lattice_weights_f4_unaligned",
+            r#"{"w":{"dtype":"F4","shape":[3],"data_offsets":[0,2]}}"#,
+            &[0; 2],
+            "not byte-aligned",
+        );
+    }
+
+    #[test]
+    fn test_rejects_f6_byte_length_mismatch() {
+        assert_raw_open_error(
+            "lattice_weights_f6_bad_length",
+            r#"{"w":{"dtype":"F6_E2M3","shape":[4],"data_offsets":[0,2]}}"#,
+            &[0; 2],
+            "byte length mismatch",
+        );
+    }
+
+    #[test]
+    fn test_accepts_byte_aligned_sub_byte_tensors() {
+        let path = temp_path("lattice_weights_sub_byte_valid");
+        let header = r#"{"f4":{"dtype":"F4","shape":[2],"data_offsets":[0,1]},"f6":{"dtype":"F6_E3M2","shape":[4],"data_offsets":[1,4]}}"#;
+        write_raw_safetensors(&path, header, &[0; 4]);
+
+        let file = SafetensorsFile::open(&path).expect("valid sub-byte layout must open");
+        assert!(file.has_tensor("f4"));
+        assert!(file.has_tensor("f6"));
+
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn test_accepts_fnuz_f8_tensors() {
+        let path = temp_path("lattice_weights_fnuz_f8_valid");
+        let header = r#"{"e4":{"dtype":"F8_E4M3FNUZ","shape":[1],"data_offsets":[0,1]},"e5":{"dtype":"F8_E5M2FNUZ","shape":[1],"data_offsets":[1,2]}}"#;
+        write_raw_safetensors(&path, header, &[0; 2]);
+
+        let file = SafetensorsFile::open(&path).expect("valid FNUZ F8 layout must open");
+        assert!(file.has_tensor("e4"));
+        assert!(file.has_tensor("e5"));
+
+        fs::remove_file(path).ok();
     }
 
     /// Write a single raw tensor entry (arbitrary dtype/bytes) to a fresh

--- a/crates/inference/tests/vision_s5b_e2e_gate_test.rs
+++ b/crates/inference/tests/vision_s5b_e2e_gate_test.rs
@@ -233,7 +233,21 @@ fn resolve_safetensors_path(model_dir: &Path) -> PathBuf {
     shards.sort_unstable();
     shards.dedup();
     match shards.as_slice() {
-        [one] => model_dir.join(one),
+        // Route through the same containment policy production loading uses
+        // (`lattice_inference::weights::resolve_shard_path`), not a raw
+        // `model_dir.join(one)` -- otherwise an index value like
+        // `../outside/model.safetensors` would make this gate read outside
+        // the checkpoint while production correctly rejects it, so the gate
+        // could report parity against different weights than production
+        // ever loads.
+        [one] => {
+            lattice_inference::weights::resolve_shard_path(model_dir, one).unwrap_or_else(|e| {
+                panic!(
+                    "shard '{one}' referenced by {} is invalid: {e}",
+                    model_dir.join("model.safetensors.index.json").display()
+                )
+            })
+        }
         [] => panic!(
             "empty weight_map in {}",
             model_dir.join("model.safetensors.index.json").display()
@@ -321,8 +335,15 @@ mod resolver_strictness_tests {
             &dir,
             r#"{"weight_map":{"a":"only.safetensors","b":"only.safetensors"}}"#,
         );
+        // `resolve_safetensors_path` now resolves through the same
+        // containment policy as production (`resolve_shard_path`), which
+        // canonicalizes the candidate and therefore requires it to exist —
+        // so the shard file itself, not just the index entry naming it,
+        // must be present for the accept case.
+        std::fs::write(dir.join("only.safetensors"), b"stub").expect("write shard stub");
         let p = resolve_safetensors_path(&dir);
-        let expected = dir.join("only.safetensors");
+        let expected = std::fs::canonicalize(dir.join("only.safetensors"))
+            .expect("canonicalize expected shard path");
         std::fs::remove_dir_all(&dir).ok();
         assert_eq!(p, expected);
     }


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

Closes #22.

SafetensorsFile and QuarotTensorReader now share one strict layout and dtype validator.
The runtime accepts standard byte-aligned packed dtypes and rejects the same malformed offsets, shapes, and dtype extents as the converter.

This revision adds a shared shard-relative-path guard (rejects absolute paths and `..` traversal in index-derived shard filenames) and makes sharded runtime checkpoint opening validate every shard's header up front instead of on first access, matching the QuaRot reader's existing eager contract.

A follow-up revision closes two remaining gaps where an index-derived shard path could reach the filesystem without going through that guard: the Qwen cache-revision fingerprint (`crates/inference/src/model/qwen.rs`, `resolve_weight_fingerprint_files`/`derive_base_model_rev`) now validates every `weight_map` value before opening or hashing any shard, and the vision embedding loader's single-shard resolver (`crates/embed/src/vision.rs`, `resolve_single_shard`) now routes through a new crate-public `resolve_shard_path` helper (`crates/inference/src/weights/f32_weights.rs`) instead of joining the index-provided shard name directly.

## bench-compare disposition (ADR-058)

This revision (on top of the prior shard-path-guard revision described above) hardens shard-path containment to a filesystem-safe check and bounds sharded-manifest construction:

- `resolve_contained_path(model_dir, untrusted)` (new, `crates/inference/src/weights/f32_weights.rs`) canonicalizes both the model directory and the joined candidate and requires containment via `Path::starts_with`, defeating symlink escapes in addition to the existing lexical `..`/absolute-path checks. Routed through everywhere a shard/manifest path is resolved: `resolve_shard_path`, `load_sharded`, `ShardedSafetensors::open_index`/`open_shard`/`resolve_weight`, the QuaRot reader's sharded open loop (`crates/inference/src/quant/quarot/io.rs`), the Q4 vision loader's `quantize_index.json` `entry.file` (`crates/inference/src/vision/checkpoint.rs`), the Qwen weight-fingerprint hasher's shard open (`crates/inference/src/model/qwen.rs`), and the `lattice` CLI's Q4 inventory scan (`crates/inference/src/bin/lattice.rs`).
- `MAX_SHARDED_MANIFEST_SHARDS` (new constant, 4096) caps the number of distinct shards `ShardedSafetensors::open_index` will resolve and mmap from a single manifest, bounding worst-case address-space/fd use at construction time.
- `resolve_weight_fingerprint_files` now parses the index via the shared strict `parse_index` instead of a separate ad hoc `serde_json::Value` walk.

All of this remains cold-path SafeTensors reader/loader/manifest validation, not on the decode/prefill hot path. It is **compiled into the default build** (none of it is behind a `cfg` feature gate), so it is a compiled-in cold model-load path, not compiled-out code — distinct from the cfg-gated-module carve-out (e.g. a `#[cfg(metal-gpu)]` module).

`make bench-compare`'s default targets are `lattice-inference`'s `elementwise_cpu_bench` and `lattice-embed`'s `simd` bench. Grepping both bench sources for the changed symbols returns no matches (grep-0):

```
grep -n "resolve_contained_path|open_index|open_shard|canonicalize|model_dir|loading" crates/inference/benches/elementwise_cpu_bench.rs crates/embed/benches/simd.rs
# (no output)
```

Per grep-0, this is a compiled-in cold model-load path, not in the measured call graph of either default bench target. The A/B run is deferred to a maintainer quiet-window run rather than claimed as structurally unreachable.

