### PR TITLE
fix(inference): shape-validate dense FFN, full-attention, and GDN tensors on load

### DIFF
--- a/crates/inference/src/attention/gdn.rs
+++ b/crates/inference/src/attention/gdn.rs
@@ -50,7 +50,9 @@ pub struct GatedDeltaNetWeights {
     pub conv_dim: usize,
     pub kernel_size: usize,
 
-    /// Output gated RMSNorm gamma: `[output_dim]`
+    /// Output gated RMSNorm gamma: `[linear_value_head_dim]`, one per-head-dim gamma
+    /// shared across all value heads and applied identically to each (see the
+    /// gated-RMSNorm loop over `value_heads` in `gated_delta_net_step`).
     pub norm_weight: Vec<f32>,
 
     /// Output projection: [hidden_size, output_dim]

--- a/crates/inference/src/model/qwen35/loading.rs
+++ b/crates/inference/src/model/qwen35/loading.rs
@@ -86,6 +86,19 @@ fn load_owned_tensor_checked<T: TensorSource + ?Sized>(
     name: &str,
     expected: &[usize],
 ) -> Result<Vec<f32>, InferenceError> {
+    // Preflight against the declared (metadata-only) shape before materializing the
+    // tensor: get_f32_tensor_owned decodes and finiteness-scans the full tensor, so a
+    // checkpoint declaring a large finite tensor with an incompatible shape must be
+    // rejected here, before that work runs, not after.
+    if let Some(declared_shape) = source.tensor_shape(name)?
+        && declared_shape != expected
+    {
+        return Err(InferenceError::ShapeMismatch {
+            name: name.to_string(),
+            expected: expected.to_vec(),
+            actual: declared_shape,
+        });
+    }
     let (data, shape) = source.get_f32_tensor_owned(name)?;
     if shape != expected {
         return Err(InferenceError::ShapeMismatch {
@@ -95,6 +108,79 @@ fn load_owned_tensor_checked<T: TensorSource + ?Sized>(
         });
     }
     Ok(data)
+}
+
+/// Doubles `value`, returning a typed error instead of panicking (debug) or wrapping
+/// (release) when the config-derived dimension is too large for `usize`.
+fn checked_double(value: usize, what: &str) -> Result<usize, InferenceError> {
+    value
+        .checked_mul(2)
+        .ok_or_else(|| InferenceError::InvalidInput(format!("{what} overflows usize: 2 * {value}")))
+}
+
+/// Full-attention Q projection row count (`num_attention_heads * head_dim`), computed
+/// with checked arithmetic so an attacker-controlled config.json cannot overflow it.
+fn checked_full_q_dim(cfg: &Qwen35Config) -> Result<usize, InferenceError> {
+    cfg.num_attention_heads
+        .checked_mul(cfg.head_dim)
+        .ok_or_else(|| {
+            InferenceError::InvalidInput(format!(
+                "full attention q_dim overflows usize: num_attention_heads({}) * head_dim({})",
+                cfg.num_attention_heads, cfg.head_dim
+            ))
+        })
+}
+
+/// Full-attention KV projection row count (`num_key_value_heads * head_dim`), checked.
+fn checked_full_kv_dim(cfg: &Qwen35Config) -> Result<usize, InferenceError> {
+    cfg.num_key_value_heads
+        .checked_mul(cfg.head_dim)
+        .ok_or_else(|| {
+            InferenceError::InvalidInput(format!(
+                "full attention kv_dim overflows usize: num_key_value_heads({}) * head_dim({})",
+                cfg.num_key_value_heads, cfg.head_dim
+            ))
+        })
+}
+
+/// GatedDeltaNet combined QKV projection row count (`Q + K + V`), checked. Mirrors
+/// `Qwen35Config::linear_qkv_dim`'s formula but rejects overflow with a typed error
+/// instead of panicking (debug) or wrapping (release).
+fn checked_linear_qkv_dim(cfg: &Qwen35Config) -> Result<usize, InferenceError> {
+    let k = cfg
+        .linear_num_key_heads
+        .checked_mul(cfg.linear_key_head_dim)
+        .ok_or_else(|| {
+            InferenceError::InvalidInput(format!(
+                "linear attention k dim overflows usize: linear_num_key_heads({}) * linear_key_head_dim({})",
+                cfg.linear_num_key_heads, cfg.linear_key_head_dim
+            ))
+        })?;
+    let value_heads = cfg.linear_num_value_heads();
+    let v = value_heads.checked_mul(cfg.linear_value_head_dim).ok_or_else(|| {
+        InferenceError::InvalidInput(format!(
+            "linear attention v dim overflows usize: linear_num_value_heads({}) * linear_value_head_dim({})",
+            value_heads, cfg.linear_value_head_dim
+        ))
+    })?;
+    k.checked_add(k)
+        .and_then(|qk| qk.checked_add(v))
+        .ok_or_else(|| {
+            InferenceError::InvalidInput(format!(
+                "linear attention qkv_dim overflows usize: q({k}) + k({k}) + v({v})"
+            ))
+        })
+}
+
+/// GatedDeltaNet output projection row count (`linear_num_value_heads * linear_value_head_dim`), checked.
+fn checked_linear_output_dim(cfg: &Qwen35Config) -> Result<usize, InferenceError> {
+    let value_heads = cfg.linear_num_value_heads();
+    value_heads.checked_mul(cfg.linear_value_head_dim).ok_or_else(|| {
+        InferenceError::InvalidInput(format!(
+            "linear attention output_dim overflows usize: linear_num_value_heads({}) * linear_value_head_dim({})",
+            value_heads, cfg.linear_value_head_dim
+        ))
+    })
 }
 
 fn load_moe_ffn_weights<T: TensorSource + ?Sized>(
@@ -111,6 +197,10 @@ fn load_moe_ffn_weights<T: TensorSource + ?Sized>(
     })?;
     let moe_inter = cfg.moe_intermediate_size();
     let shared_inter = cfg.shared_expert_intermediate_size();
+    let doubled_moe_inter = checked_double(
+        moe_inter,
+        "MoE gate_up_proj row count (2 * moe_intermediate_size)",
+    )?;
 
     let router = MoeRouter::new(
         load_owned_tensor_checked(
@@ -127,7 +217,7 @@ fn load_moe_ffn_weights<T: TensorSource + ?Sized>(
         load_owned_tensor_checked(
             source,
             &format!("{prefix}.mlp.experts.gate_up_proj"),
-            &[num_experts, 2 * moe_inter, hidden],
+            &[num_experts, doubled_moe_inter, hidden],
         )?,
         load_owned_tensor_checked(
             source,
@@ -207,13 +297,17 @@ fn load_full_attention_weights<T: TensorSource + ?Sized>(
 ) -> Result<AttentionWeights, InferenceError> {
     // q_proj carries a fused sigmoid gate alongside Q, doubling its output rows
     // relative to k_proj/v_proj (see FullAttentionLayerWeights / project_qkv).
-    let q_dim = cfg.full_q_dim();
-    let kv_dim = cfg.full_kv_dim();
+    let q_dim = checked_full_q_dim(cfg)?;
+    let kv_dim = checked_full_kv_dim(cfg)?;
     let head_dim = cfg.head_dim;
+    let doubled_q_dim = checked_double(
+        q_dim,
+        "full attention q_proj row count (2 * q_dim, fused sigmoid gate)",
+    )?;
     let qw = load_owned_tensor_checked(
         source,
         &format!("{prefix}.self_attn.q_proj.weight"),
-        &[2 * q_dim, hidden],
+        &[doubled_q_dim, hidden],
     )?;
     let kw = load_owned_tensor_checked(
         source,
@@ -346,8 +440,8 @@ pub(super) fn load_weights<T: TensorSource + ?Sized>(
 ) -> Result<ModelWeights, InferenceError> {
     let hidden = cfg.hidden_size;
     let num_heads = cfg.linear_num_key_heads;
-    let qkv_dim = cfg.linear_qkv_dim();
-    let output_dim = cfg.linear_output_dim();
+    let qkv_dim = checked_linear_qkv_dim(cfg)?;
+    let output_dim = checked_linear_output_dim(cfg)?;
     let kernel_size = cfg.linear_conv_kernel_dim;
 
     let embed_tokens = load_owned_tensor_checked(
@@ -595,11 +689,11 @@ mod tests {
     // to match so the tensor stays finite and self-consistent), and asserts that
     // `load_weights` returns `Err(InferenceError::ShapeMismatch)` naming that tensor.
     //
-    // Mutation check: reverting the checked-loader routing in `load_dense_ffn_weights`,
-    // `load_full_attention_weights`, or `load_linear_attention_weights` back to the
-    // unchecked `load_owned_tensor` makes the corresponding test below fail (the
-    // undersized tensor loads successfully and `load_weights` returns `Ok`, or a later
-    // out-of-bounds read panics instead of returning a typed error).
+    // Mutation check: removing the shape comparisons from `load_owned_tensor_checked`
+    // (the single loader every call site in this module routes through) makes the
+    // corresponding test below fail (the undersized tensor loads successfully and
+    // `load_weights` returns `Ok`, or a later out-of-bounds read panics instead of
+    // returning a typed error).
 
     /// Minimal single-layer config with tiny dimensions, so the tensors constructed for
     /// these tests stay small. `layer_type` controls whether the one layer is full
@@ -827,6 +921,159 @@ mod tests {
             Err(InferenceError::ShapeMismatch { name: got_name, .. }) => assert_eq!(got_name, name),
             Err(e) => panic!("expected ShapeMismatch, got a different error: {e}"),
             Ok(_) => panic!("expected Err for undersized GDN tensor, got Ok"),
+        }
+    }
+
+    // ── Preflight-before-materialization (declared-shape check precedes decode) ────────
+
+    /// A `TensorSource` whose declared shape (`tensor_shape`) is available cheaply but
+    /// whose `get_f32_tensor_owned` panics if ever called — standing in for a checkpoint
+    /// tensor so large that materializing it would exhaust memory. Used to prove the
+    /// shape check runs before materialization, not just that it eventually returns an
+    /// error.
+    struct PanicsOnMaterializeTensorSource {
+        declared_shape: Vec<usize>,
+    }
+
+    impl TensorSource for PanicsOnMaterializeTensorSource {
+        fn has_tensor(&mut self, _name: &str) -> Result<bool, InferenceError> {
+            Ok(true)
+        }
+        fn tensor_shape(&mut self, _name: &str) -> Result<Option<Vec<usize>>, InferenceError> {
+            Ok(Some(self.declared_shape.clone()))
+        }
+        fn get_f32_tensor_owned(
+            &mut self,
+            name: &str,
+        ) -> Result<(Vec<f32>, Vec<usize>), InferenceError> {
+            panic!(
+                "get_f32_tensor_owned must not be called when the declared shape already \
+                 mismatches the expected shape (tensor: {name})"
+            );
+        }
+    }
+
+    /// Mutation check: routing `load_owned_tensor_checked` back to comparing shapes only
+    /// after calling `get_f32_tensor_owned` (i.e. dropping the `tensor_shape` preflight)
+    /// makes this test panic — `PanicsOnMaterializeTensorSource::get_f32_tensor_owned`
+    /// would run. With the preflight in place, the mismatch is caught from `tensor_shape`
+    /// alone and materialization never happens.
+    #[test]
+    fn shape_mismatch_preflight_skips_materialization() {
+        let mut src = PanicsOnMaterializeTensorSource {
+            declared_shape: vec![3, 3],
+        };
+
+        match load_owned_tensor_checked(&mut src, "huge.declared.tensor", &[4, 4]) {
+            Err(InferenceError::ShapeMismatch {
+                name,
+                expected,
+                actual,
+            }) => {
+                assert_eq!(name, "huge.declared.tensor");
+                assert_eq!(expected, vec![4, 4]);
+                assert_eq!(actual, vec![3, 3]);
+            }
+            Err(e) => panic!("expected ShapeMismatch, got a different error: {e}"),
+            Ok(_) => panic!("expected Err for mismatched declared shape, got Ok"),
+        }
+    }
+
+    // ── Checked config-derived dimension arithmetic (no panic/wrap on overflow) ────────
+
+    #[test]
+    fn full_attention_head_dim_overflow_returns_typed_error() {
+        let mut cfg = tiny_config(LayerType::FullAttention);
+        cfg.num_attention_heads = usize::MAX;
+        cfg.head_dim = 2;
+
+        match checked_full_q_dim(&cfg) {
+            Err(InferenceError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("num_attention_heads") && msg.contains("head_dim"),
+                    "message should name the overflowing fields: {msg}"
+                );
+            }
+            Err(e) => panic!("expected InvalidInput, got a different error: {e}"),
+            Ok(v) => panic!(
+                "expected num_attention_heads * head_dim overflow to be rejected, got Ok({v})"
+            ),
+        }
+    }
+
+    #[test]
+    fn full_attention_kv_head_dim_overflow_returns_typed_error() {
+        let mut cfg = tiny_config(LayerType::FullAttention);
+        cfg.num_key_value_heads = usize::MAX;
+        cfg.head_dim = 2;
+
+        match checked_full_kv_dim(&cfg) {
+            Err(InferenceError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("num_key_value_heads") && msg.contains("head_dim"),
+                    "message should name the overflowing fields: {msg}"
+                );
+            }
+            Err(e) => panic!("expected InvalidInput, got a different error: {e}"),
+            Ok(v) => panic!(
+                "expected num_key_value_heads * head_dim overflow to be rejected, got Ok({v})"
+            ),
+        }
+    }
+
+    #[test]
+    fn linear_qkv_dim_overflow_returns_typed_error() {
+        let mut cfg = tiny_config(LayerType::LinearAttention);
+        cfg.linear_num_key_heads = usize::MAX;
+        cfg.linear_key_head_dim = 2;
+
+        match checked_linear_qkv_dim(&cfg) {
+            Err(InferenceError::InvalidInput(_)) => {}
+            Err(e) => panic!("expected InvalidInput, got a different error: {e}"),
+            Ok(v) => panic!("expected linear qkv_dim overflow to be rejected, got Ok({v})"),
+        }
+    }
+
+    #[test]
+    fn moe_gate_up_proj_row_count_overflow_returns_typed_error() {
+        match checked_double(
+            usize::MAX,
+            "MoE gate_up_proj row count (2 * moe_intermediate_size)",
+        ) {
+            Err(InferenceError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("moe_intermediate_size"),
+                    "message should name the overflowing dimension: {msg}"
+                );
+            }
+            Err(e) => panic!("expected InvalidInput, got a different error: {e}"),
+            Ok(v) => {
+                panic!("expected 2 * moe_intermediate_size overflow to be rejected, got Ok({v})")
+            }
+        }
+    }
+
+    /// A full-config `moe_intermediate_size` that overflows when doubled must be rejected
+    /// by `load_moe_ffn_weights` with a typed error, not a panic — and rejected before any
+    /// tensor is touched (`NullTensorSource` would return `MissingTensor` for every name,
+    /// so an `InvalidInput` here proves the overflow check ran first).
+    #[test]
+    fn load_moe_ffn_weights_rejects_overflowing_moe_intermediate_size() {
+        let mut cfg = tiny_config(LayerType::FullAttention);
+        cfg.num_experts = Some(2);
+        cfg.num_experts_per_tok = Some(1);
+        cfg.moe_intermediate_size = Some(usize::MAX / 2 + 1);
+        let mut src = NullTensorSource;
+
+        match load_moe_ffn_weights(&mut src, &cfg, "layers.0", cfg.hidden_size) {
+            Err(InferenceError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("moe_intermediate_size"),
+                    "message should name the overflowing dimension: {msg}"
+                );
+            }
+            Err(e) => panic!("expected InvalidInput, got a different error: {e}"),
+            Ok(_) => panic!("expected Err for overflowing moe_intermediate_size, got Ok"),
         }
     }
 }

--- a/crates/inference/src/model/qwen35/loading.rs
+++ b/crates/inference/src/model/qwen35/loading.rs
@@ -1,4 +1,13 @@
-//! Qwen3.5 tensor-name requirements, validation, owned tensor loaders, layer-specific weight loaders, and `load_weights`.
+//! Qwen3.5 tensor-name requirements, validation, owned tensor loaders, layer-specific weight
+//! loaders, and `load_weights`.
+//!
+//! Every tensor `load_weights` reads is loaded through [`load_owned_tensor_checked`], which
+//! compares the checkpoint's declared shape against a config-derived expected shape and returns
+//! [`InferenceError::ShapeMismatch`] on mismatch. safetensors metadata describes each tensor's
+//! own shape, not the consuming model's shape contract, so an unchecked load would accept a
+//! finite but undersized tensor and only fail later, inside a forward-pass matmul. Routing every
+//! tensor through the checked loader means a shape-incompatible checkpoint is rejected during
+//! loading, before any forward pass runs.
 use super::weights::{
     AttentionWeights, CommonLayerWeights, DenseFfnWeights, FeedForwardWeights,
     FullAttentionLayerWeights, ModelWeights, MoeLayerWeights, MoeRouter, RoutedExperts,
@@ -70,14 +79,6 @@ pub(super) fn validate_required_tensor_names<T: TensorSource + ?Sized>(
         }
     }
     Ok(())
-}
-
-fn load_owned_tensor<T: TensorSource + ?Sized>(
-    source: &mut T,
-    name: &str,
-) -> Result<Vec<f32>, InferenceError> {
-    let (data, _) = source.get_f32_tensor_owned(name)?;
-    Ok(data)
 }
 
 fn load_owned_tensor_checked<T: TensorSource + ?Sized>(
@@ -173,10 +174,24 @@ fn load_moe_ffn_weights<T: TensorSource + ?Sized>(
 fn load_dense_ffn_weights<T: TensorSource + ?Sized>(
     source: &mut T,
     prefix: &str,
+    hidden: usize,
+    intermediate: usize,
 ) -> Result<FeedForwardWeights, InferenceError> {
-    let gp = load_owned_tensor(source, &format!("{prefix}.mlp.gate_proj.weight"))?;
-    let up = load_owned_tensor(source, &format!("{prefix}.mlp.up_proj.weight"))?;
-    let dp = load_owned_tensor(source, &format!("{prefix}.mlp.down_proj.weight"))?;
+    let gp = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.mlp.gate_proj.weight"),
+        &[intermediate, hidden],
+    )?;
+    let up = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.mlp.up_proj.weight"),
+        &[intermediate, hidden],
+    )?;
+    let dp = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.mlp.down_proj.weight"),
+        &[hidden, intermediate],
+    )?;
     Ok(FeedForwardWeights::Dense(DenseFfnWeights {
         gate_proj: gp,
         up_proj: up,
@@ -186,14 +201,45 @@ fn load_dense_ffn_weights<T: TensorSource + ?Sized>(
 
 fn load_full_attention_weights<T: TensorSource + ?Sized>(
     source: &mut T,
+    cfg: &Qwen35Config,
     prefix: &str,
+    hidden: usize,
 ) -> Result<AttentionWeights, InferenceError> {
-    let qw = load_owned_tensor(source, &format!("{prefix}.self_attn.q_proj.weight"))?;
-    let kw = load_owned_tensor(source, &format!("{prefix}.self_attn.k_proj.weight"))?;
-    let vw = load_owned_tensor(source, &format!("{prefix}.self_attn.v_proj.weight"))?;
-    let ow = load_owned_tensor(source, &format!("{prefix}.self_attn.o_proj.weight"))?;
-    let qn = load_owned_tensor(source, &format!("{prefix}.self_attn.q_norm.weight"))?;
-    let kn = load_owned_tensor(source, &format!("{prefix}.self_attn.k_norm.weight"))?;
+    // q_proj carries a fused sigmoid gate alongside Q, doubling its output rows
+    // relative to k_proj/v_proj (see FullAttentionLayerWeights / project_qkv).
+    let q_dim = cfg.full_q_dim();
+    let kv_dim = cfg.full_kv_dim();
+    let head_dim = cfg.head_dim;
+    let qw = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.self_attn.q_proj.weight"),
+        &[2 * q_dim, hidden],
+    )?;
+    let kw = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.self_attn.k_proj.weight"),
+        &[kv_dim, hidden],
+    )?;
+    let vw = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.self_attn.v_proj.weight"),
+        &[kv_dim, hidden],
+    )?;
+    let ow = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.self_attn.o_proj.weight"),
+        &[hidden, q_dim],
+    )?;
+    let qn = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.self_attn.q_norm.weight"),
+        &[head_dim],
+    )?;
+    let kn = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.self_attn.k_norm.weight"),
+        &[head_dim],
+    )?;
     Ok(AttentionWeights::Full(FullAttentionLayerWeights {
         q_proj: qw,
         k_proj: kw,
@@ -215,8 +261,16 @@ fn load_linear_attention_weights<T: TensorSource + ?Sized>(
     kernel_size: usize,
 ) -> Result<AttentionWeights, InferenceError> {
     let value_heads = cfg.linear_num_value_heads();
-    let qkv = load_owned_tensor(source, &format!("{prefix}.linear_attn.in_proj_qkv.weight"))?;
-    let z = load_owned_tensor(source, &format!("{prefix}.linear_attn.in_proj_z.weight"))?;
+    let qkv = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.linear_attn.in_proj_qkv.weight"),
+        &[qkv_dim, hidden],
+    )?;
+    let z = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.linear_attn.in_proj_z.weight"),
+        &[output_dim, hidden],
+    )?;
     let b = load_owned_tensor_checked(
         source,
         &format!("{prefix}.linear_attn.in_proj_b.weight"),
@@ -237,9 +291,24 @@ fn load_linear_attention_weights<T: TensorSource + ?Sized>(
         &format!("{prefix}.linear_attn.dt_bias"),
         &[value_heads],
     )?;
-    let cw = load_owned_tensor(source, &format!("{prefix}.linear_attn.conv1d.weight"))?;
-    let nw = load_owned_tensor(source, &format!("{prefix}.linear_attn.norm.weight"))?;
-    let op = load_owned_tensor(source, &format!("{prefix}.linear_attn.out_proj.weight"))?;
+    let cw = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.linear_attn.conv1d.weight"),
+        &[qkv_dim, 1, kernel_size],
+    )?;
+    // norm.weight is a single per-head-dim RMSNorm gamma shared across all value heads
+    // (gdn.rs applies weights.norm_weight[..value_dim] identically to every head), so its
+    // checkpoint shape is [linear_value_head_dim], not the full [output_dim].
+    let nw = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.linear_attn.norm.weight"),
+        &[cfg.linear_value_head_dim],
+    )?;
+    let op = load_owned_tensor_checked(
+        source,
+        &format!("{prefix}.linear_attn.out_proj.weight"),
+        &[hidden, output_dim],
+    )?;
 
     // conv1d.weight is [conv_dim, 1, kernel_size] — reshape to [conv_dim, kernel_size]
     Ok(AttentionWeights::Linear(GatedDeltaNetWeights {
@@ -267,6 +336,10 @@ fn load_linear_attention_weights<T: TensorSource + ?Sized>(
     }))
 }
 
+/// Assemble every required weight tensor for `cfg`. Each tensor is validated against a
+/// config-derived expected shape as it is loaded (see the module docs); a checkpoint with a
+/// finite but shape-incompatible tensor returns `Err(InferenceError::ShapeMismatch)` here
+/// rather than constructing a model that panics during the forward pass.
 pub(super) fn load_weights<T: TensorSource + ?Sized>(
     source: &mut T,
     cfg: &Qwen35Config,
@@ -301,13 +374,21 @@ pub(super) fn load_weights<T: TensorSource + ?Sized>(
     for i in 0..cfg.num_hidden_layers {
         let prefix = format!("model.language_model.layers.{i}");
 
-        let iln = load_owned_tensor(source, &format!("{prefix}.input_layernorm.weight"))?;
-        let paln = load_owned_tensor(source, &format!("{prefix}.post_attention_layernorm.weight"))?;
+        let iln = load_owned_tensor_checked(
+            source,
+            &format!("{prefix}.input_layernorm.weight"),
+            &[hidden],
+        )?;
+        let paln = load_owned_tensor_checked(
+            source,
+            &format!("{prefix}.post_attention_layernorm.weight"),
+            &[hidden],
+        )?;
 
         let ffn = if cfg.is_moe() {
             load_moe_ffn_weights(source, cfg, &prefix, hidden)?
         } else {
-            load_dense_ffn_weights(source, &prefix)?
+            load_dense_ffn_weights(source, &prefix, hidden, cfg.intermediate_size)?
         };
 
         let common = CommonLayerWeights {
@@ -317,7 +398,7 @@ pub(super) fn load_weights<T: TensorSource + ?Sized>(
         };
 
         let attn = if cfg.is_full_attention(i) {
-            load_full_attention_weights(source, &prefix)?
+            load_full_attention_weights(source, cfg, &prefix, hidden)?
         } else {
             load_linear_attention_weights(
                 source,
@@ -345,7 +426,7 @@ pub(super) fn load_weights<T: TensorSource + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::qwen35_config::Qwen35Config;
+    use crate::model::qwen35_config::{LayerType, Qwen35Config};
 
     struct NullTensorSource;
 
@@ -409,14 +490,15 @@ mod tests {
         let prefix = "layers.0";
         let mut src = MockTensorSource {
             tensors: [
-                // qkv and z are loaded with unchecked load_owned_tensor — any data passes
+                // qkv and z must be correctly shaped so the in_proj_b mismatch below is what
+                // trips first.
                 (
                     format!("{prefix}.linear_attn.in_proj_qkv.weight"),
-                    (vec![0.0f32; 1], vec![1]),
+                    (vec![0.0f32; qkv_dim * hidden], vec![qkv_dim, hidden]),
                 ),
                 (
                     format!("{prefix}.linear_attn.in_proj_z.weight"),
-                    (vec![0.0f32; 1], vec![1]),
+                    (vec![0.0f32; output_dim * hidden], vec![output_dim, hidden]),
                 ),
                 // in_proj_b is key-head-shaped ([16, hidden]) instead of value-head-shaped
                 // ([32, hidden]) — this should be caught by load_owned_tensor_checked
@@ -501,6 +583,250 @@ mod tests {
             }
             Err(e) => panic!("expected InvalidInput, got a different error: {e}"),
             Ok(_) => panic!("expected Err, got Ok"),
+        }
+    }
+
+    // ── Undersized-checkpoint rejection through `load_weights` (#1035) ─────────────────
+    //
+    // A finite but undersized safetensors tensor must be rejected by shape validation
+    // during model assembly, not accepted and left to panic later in a forward-pass
+    // matmul. Each test below builds a complete, correctly-shaped single-layer tensor
+    // set, corrupts exactly one tensor's shape (row count reduced by one, data resized
+    // to match so the tensor stays finite and self-consistent), and asserts that
+    // `load_weights` returns `Err(InferenceError::ShapeMismatch)` naming that tensor.
+    //
+    // Mutation check: reverting the checked-loader routing in `load_dense_ffn_weights`,
+    // `load_full_attention_weights`, or `load_linear_attention_weights` back to the
+    // unchecked `load_owned_tensor` makes the corresponding test below fail (the
+    // undersized tensor loads successfully and `load_weights` returns `Ok`, or a later
+    // out-of-bounds read panics instead of returning a typed error).
+
+    /// Minimal single-layer config with tiny dimensions, so the tensors constructed for
+    /// these tests stay small. `layer_type` controls whether the one layer is full
+    /// (GQA) or linear (GatedDeltaNet) attention; the FFN is always dense (`is_moe()`
+    /// is false for every field here).
+    fn tiny_config(layer_type: LayerType) -> Qwen35Config {
+        Qwen35Config {
+            hidden_size: 8,
+            num_hidden_layers: 1,
+            vocab_size: 4,
+            intermediate_size: 16,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: 2,
+            num_key_value_heads: 2,
+            head_dim: 4,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 1.0,
+            rope_parameters: None,
+            linear_num_key_heads: 2,
+            linear_num_value_heads: Some(2),
+            linear_key_head_dim: 4,
+            linear_value_head_dim: 4,
+            linear_conv_kernel_dim: 4,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 1,
+            layer_types: vec![layer_type],
+            layer_mask: vec![true],
+            eos_token_id: 0,
+            max_position_embeddings: 128,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+            vision_config: None,
+            image_token_id: None,
+            video_token_id: None,
+            vision_start_token_id: None,
+            vision_end_token_id: None,
+        }
+    }
+
+    /// Every required tensor for `tiny_config`'s single layer, each correctly shaped.
+    fn full_valid_tensor_map(
+        cfg: &Qwen35Config,
+    ) -> std::collections::HashMap<String, (Vec<f32>, Vec<usize>)> {
+        let hidden = cfg.hidden_size;
+        let inter = cfg.intermediate_size;
+        let prefix = "model.language_model.layers.0";
+        let mut m = std::collections::HashMap::new();
+
+        m.insert(
+            "model.language_model.embed_tokens.weight".to_string(),
+            (
+                vec![0.0f32; cfg.vocab_size * hidden],
+                vec![cfg.vocab_size, hidden],
+            ),
+        );
+        m.insert(
+            "model.language_model.norm.weight".to_string(),
+            (vec![0.0f32; hidden], vec![hidden]),
+        );
+        m.insert(
+            format!("{prefix}.input_layernorm.weight"),
+            (vec![0.0f32; hidden], vec![hidden]),
+        );
+        m.insert(
+            format!("{prefix}.post_attention_layernorm.weight"),
+            (vec![0.0f32; hidden], vec![hidden]),
+        );
+        m.insert(
+            format!("{prefix}.mlp.gate_proj.weight"),
+            (vec![0.0f32; inter * hidden], vec![inter, hidden]),
+        );
+        m.insert(
+            format!("{prefix}.mlp.up_proj.weight"),
+            (vec![0.0f32; inter * hidden], vec![inter, hidden]),
+        );
+        m.insert(
+            format!("{prefix}.mlp.down_proj.weight"),
+            (vec![0.0f32; hidden * inter], vec![hidden, inter]),
+        );
+
+        if cfg.is_full_attention(0) {
+            let q_dim = cfg.full_q_dim();
+            let kv_dim = cfg.full_kv_dim();
+            let head_dim = cfg.head_dim;
+            m.insert(
+                format!("{prefix}.self_attn.q_proj.weight"),
+                (vec![0.0f32; 2 * q_dim * hidden], vec![2 * q_dim, hidden]),
+            );
+            m.insert(
+                format!("{prefix}.self_attn.k_proj.weight"),
+                (vec![0.0f32; kv_dim * hidden], vec![kv_dim, hidden]),
+            );
+            m.insert(
+                format!("{prefix}.self_attn.v_proj.weight"),
+                (vec![0.0f32; kv_dim * hidden], vec![kv_dim, hidden]),
+            );
+            m.insert(
+                format!("{prefix}.self_attn.o_proj.weight"),
+                (vec![0.0f32; hidden * q_dim], vec![hidden, q_dim]),
+            );
+            m.insert(
+                format!("{prefix}.self_attn.q_norm.weight"),
+                (vec![0.0f32; head_dim], vec![head_dim]),
+            );
+            m.insert(
+                format!("{prefix}.self_attn.k_norm.weight"),
+                (vec![0.0f32; head_dim], vec![head_dim]),
+            );
+        } else {
+            let qkv_dim = cfg.linear_qkv_dim();
+            let output_dim = cfg.linear_output_dim();
+            let value_heads = cfg.linear_num_value_heads();
+            let kernel_size = cfg.linear_conv_kernel_dim;
+            let value_dim = cfg.linear_value_head_dim;
+            m.insert(
+                format!("{prefix}.linear_attn.in_proj_qkv.weight"),
+                (vec![0.0f32; qkv_dim * hidden], vec![qkv_dim, hidden]),
+            );
+            m.insert(
+                format!("{prefix}.linear_attn.in_proj_z.weight"),
+                (vec![0.0f32; output_dim * hidden], vec![output_dim, hidden]),
+            );
+            m.insert(
+                format!("{prefix}.linear_attn.in_proj_b.weight"),
+                (
+                    vec![0.0f32; value_heads * hidden],
+                    vec![value_heads, hidden],
+                ),
+            );
+            m.insert(
+                format!("{prefix}.linear_attn.in_proj_a.weight"),
+                (
+                    vec![0.0f32; value_heads * hidden],
+                    vec![value_heads, hidden],
+                ),
+            );
+            m.insert(
+                format!("{prefix}.linear_attn.A_log"),
+                (vec![0.0f32; value_heads], vec![value_heads]),
+            );
+            m.insert(
+                format!("{prefix}.linear_attn.dt_bias"),
+                (vec![0.0f32; value_heads], vec![value_heads]),
+            );
+            m.insert(
+                format!("{prefix}.linear_attn.conv1d.weight"),
+                (
+                    vec![0.0f32; qkv_dim * kernel_size],
+                    vec![qkv_dim, 1, kernel_size],
+                ),
+            );
+            m.insert(
+                format!("{prefix}.linear_attn.norm.weight"),
+                (vec![0.0f32; value_dim], vec![value_dim]),
+            );
+            m.insert(
+                format!("{prefix}.linear_attn.out_proj.weight"),
+                (vec![0.0f32; hidden * output_dim], vec![hidden, output_dim]),
+            );
+        }
+
+        m
+    }
+
+    /// Shrink tensor `name`'s leading dimension by one row, keeping the data length
+    /// consistent with the new (still finite) shape — an undersized-but-well-formed
+    /// checkpoint tensor, not a corrupt/NaN one.
+    fn shrink_first_dim(
+        tensors: &mut std::collections::HashMap<String, (Vec<f32>, Vec<usize>)>,
+        name: &str,
+    ) {
+        let (data, shape) = tensors.get_mut(name).expect("tensor must be present");
+        assert!(shape[0] > 0, "cannot shrink a zero-sized dimension");
+        let row_len: usize = shape[1..].iter().product();
+        shape[0] -= 1;
+        data.truncate(data.len() - row_len);
+    }
+
+    #[test]
+    fn dense_ffn_undersized_tensor_rejected() {
+        let cfg = tiny_config(LayerType::LinearAttention);
+        let mut tensors = full_valid_tensor_map(&cfg);
+        let name = "model.language_model.layers.0.mlp.down_proj.weight";
+        shrink_first_dim(&mut tensors, name);
+        let mut src = MockTensorSource { tensors };
+
+        match load_weights(&mut src, &cfg) {
+            Err(InferenceError::ShapeMismatch { name: got_name, .. }) => assert_eq!(got_name, name),
+            Err(e) => panic!("expected ShapeMismatch, got a different error: {e}"),
+            Ok(_) => panic!("expected Err for undersized dense-FFN tensor, got Ok"),
+        }
+    }
+
+    #[test]
+    fn full_attention_undersized_tensor_rejected() {
+        let cfg = tiny_config(LayerType::FullAttention);
+        let mut tensors = full_valid_tensor_map(&cfg);
+        let name = "model.language_model.layers.0.self_attn.q_proj.weight";
+        shrink_first_dim(&mut tensors, name);
+        let mut src = MockTensorSource { tensors };
+
+        match load_weights(&mut src, &cfg) {
+            Err(InferenceError::ShapeMismatch { name: got_name, .. }) => assert_eq!(got_name, name),
+            Err(e) => panic!("expected ShapeMismatch, got a different error: {e}"),
+            Ok(_) => panic!("expected Err for undersized attention tensor, got Ok"),
+        }
+    }
+
+    #[test]
+    fn gdn_undersized_tensor_rejected() {
+        let cfg = tiny_config(LayerType::LinearAttention);
+        let mut tensors = full_valid_tensor_map(&cfg);
+        let name = "model.language_model.layers.0.linear_attn.in_proj_qkv.weight";
+        shrink_first_dim(&mut tensors, name);
+        let mut src = MockTensorSource { tensors };
+
+        match load_weights(&mut src, &cfg) {
+            Err(InferenceError::ShapeMismatch { name: got_name, .. }) => assert_eq!(got_name, name),
+            Err(e) => panic!("expected ShapeMismatch, got a different error: {e}"),
+            Ok(_) => panic!("expected Err for undersized GDN tensor, got Ok"),
         }
     }
 }

--- a/crates/inference/src/model/qwen35/model.rs
+++ b/crates/inference/src/model/qwen35/model.rs
@@ -20,6 +20,12 @@ pub struct Qwen35Model {
 
 impl Qwen35Model {
     /// **Unstable**: load Qwen3.5-2B or Qwen3.6 from a local safetensors directory.
+    ///
+    /// Every required tensor is shape-validated against a shape derived from `config.json`
+    /// during assembly (embeddings, output head, norms, attention, FFN, and GDN/linear-attention
+    /// projections alike): a checkpoint whose declared tensor shapes don't match what the config
+    /// requires returns `Err(InferenceError::ShapeMismatch)` from this call, rather than loading
+    /// successfully and later panicking inside a forward-pass matmul.
     pub fn from_safetensors(path: &Path) -> Result<Self, InferenceError> {
         let model_path = path.join("model.safetensors");
         let index_path = path.join("model.safetensors.index.json");


### PR DESCRIPTION
Closes #1035.

The Qwen3.5 safetensors loader already shape-validated embeddings, the output head, norms, and MoE FFN tensors via `load_owned_tensor_checked`, but the dense FFN (`mlp.{gate,up,down}_proj.weight`), full-attention (`self_attn.{q,k,v,o}_proj.weight`, `q_norm`/`k_norm`), and GDN/linear-attention (`in_proj_{qkv,z}`, `conv1d.weight`, `norm.weight`, `out_proj.weight`) tensors, plus the per-layer `input_layernorm`/`post_attention_layernorm`, went through the unchecked `load_owned_tensor`. A finite but undersized tensor for any of those loaded successfully and only failed later, inside a release-active GEMM bounds assertion during the forward pass — a panic instead of a clean load error. This PR routes every remaining call through `load_owned_tensor_checked` with a config-derived expected shape (verified against a real qwen3.5-0.8b checkpoint's declared tensor shapes) and removes the now-unused unchecked loader. Adds three mutation-sensitive regression tests (dense FFN, full attention, GDN) plus a fix to the existing GDN asymmetric-head-shape test, all built on a synthetic in-memory `TensorSource`.

Bench disposition: this change is in the safetensors load path (`model/qwen35/loading.rs`), not compiled into the Criterion bench targets (`elementwise_cpu_bench`, `simd`) — structural-unreachability carve-out per ADR-058. The added checks are O(1) shape comparisons at load time, not hot-path.