### PR TITLE
fix(inference): validate QuaRot quantizer ingress

### DIFF
--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -54,6 +54,9 @@ test-utils = []
 [dependencies]
 half.workspace = true
 memmap2 = "0.9"
+# Unix directory-fd binding (openat/O_NOFOLLOW) for the QuaRot/Q4 offline
+# quantizer's staging-directory writes (path-race hardening, ADR-058).
+libc = "0.2"
 indexmap = "2"
 rustc-hash = "2"
 rayon = { workspace = true }

--- a/crates/inference/src/bin/quantize_q4.rs
+++ b/crates/inference/src/bin/quantize_q4.rs
@@ -275,12 +275,11 @@ impl TempPublishDir {
                 output_dir.display()
             )
         })?;
-        // Restore the parent-creation behavior `fs::create_dir_all(output_dir)`
-        // used to provide before `TempPublishDir` replaced it: a valid
-        // `--output-dir` whose parent doesn't exist yet must still succeed
-        // (the adjacent temp dir and the final rename target both resolve
-        // once the parent exists). The refuse-non-empty-output check above
-        // already ran, so this can't paper over a stale non-empty target.
+        // A valid `--output-dir` whose parent doesn't exist yet must still
+        // succeed (the adjacent temp dir and the final rename target both
+        // resolve once the parent exists). The refuse-non-empty-output check
+        // above already ran, so this can't paper over a stale non-empty
+        // target.
         fs::create_dir_all(parent).map_err(|e| {
             format!(
                 "failed to create output directory parent {}: {e}",
@@ -964,11 +963,9 @@ mod tests {
         // `config.json` planted as a symlink to a file outside the model
         // directory — standing in for a hostile or concurrently-swapped
         // checkpoint trying to exfiltrate arbitrary readable bytes into the
-        // quantizer's output. reverting
-        // `read_file_at_nofollow` to a path-based `fs::read` (which follows
-        // the final symlink) makes this test fail — the secret contents
-        // would be copied into the staging directory instead of the read
-        // being refused.
+        // quantizer's output. `read_file_at_nofollow` refuses to follow the
+        // final symlink, so the secret contents are never copied into the
+        // staging directory.
         let tmp = tempfile::tempdir().unwrap();
         let input = tmp.path().join("input");
         let output = tmp.path().join("output");
@@ -998,14 +995,12 @@ mod tests {
     // -----------------------------------------------------------------------
     // Atomic publish + refuse-non-empty-output-dir.
     //
-    // Reverting `TempPublishDir` so writes land directly
-    // in `output_dir` makes
-    // `atomic_publish_leaves_output_dir_untouched_on_mid_conversion_failure`
-    // fail (a partial `.q4`/`config.json` would appear in `output`), and
-    // dropping the up-front `fs::read_dir` non-empty check makes both
-    // `quantize_model_refuses_preexisting_nonempty_output_dir` and
-    // `quantize_model_refuses_output_dir_containing_planted_symlink` fail
-    // (the stray file / symlink would silently coexist with fresh output).
+    // `TempPublishDir` stages writes outside `output_dir` and only publishes
+    // on success, so a mid-conversion failure leaves `output_dir` untouched
+    // with no partial `.q4`/`config.json` present. The up-front
+    // `fs::read_dir` non-empty check refuses to run against a preexisting
+    // output directory, including one containing a planted symlink, instead
+    // of letting stray content silently coexist with fresh output.
     // -----------------------------------------------------------------------
 
     #[test]
@@ -1113,15 +1108,10 @@ mod tests {
         // `renameat(parent_fd, temp_name, parent_fd, output_name)` anchors
         // both the source and destination name to the parent-directory fd
         // `create()` opened — never a re-resolved `output_dir`/`temp_dir`
-        // full path. A `fs::rename(temp_dir, output_dir)` on reconstructed
-        // paths instead re-walks every ancestor of both paths at publish
-        // time, so swapping the shared parent directory between `create()`
-        // and `publish()` would redirect (or break) the final rename
-        // relative to the substituted parent. Reverting `publish()` to
-        // path-based `fs::rename` makes this test fail — the rename either
-        // errors (source path no longer resolves under the swapped parent)
-        // or lands under the wrong parent, instead of publishing under the
-        // parent whose fd was actually held.
+        // full path. Swapping the shared parent directory between
+        // `create()` and `publish()` therefore cannot redirect the final
+        // rename: it always lands under the parent whose fd was actually
+        // held, regardless of what the path currently resolves to.
         let tmp = tempfile::tempdir().unwrap();
         let real_parent = tmp.path().join("real_parent");
         fs::create_dir(&real_parent).unwrap();
@@ -1212,13 +1202,10 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Fold: Drop-ordering — a failed `publish()` must leave the staging
-    // handle in `self` so `Drop` can still clean it up.
-    //
-    // reverting `publish()` to `.take()` `self.temp` (and
-    // `self.dir_fd`) up front makes this test fail — the
-    // staging directory would survive (leaked) after a failed rename,
-    // because `Drop` would find `self.temp == None` and do nothing.
+    // Drop-ordering — a failed `publish()` must leave the staging handle in
+    // `self` so `Drop` can still clean it up: `self.temp` and `self.dir_fd`
+    // stay populated until the rename actually succeeds, so a failed rename
+    // still gets removed by `Drop` instead of being leaked.
     // -----------------------------------------------------------------------
     #[test]
     fn publish_failure_still_lets_drop_clean_up_the_staging_dir() {
@@ -1266,11 +1253,10 @@ mod tests {
         // no-publish / early-error path) rather than `publish()`: the
         // staging path is replaced with a fresh, unrelated directory that
         // holds attacker-planted content, then the guard drops without
-        // calling `publish`. Reverting `Drop` to a bare
-        // `fs::remove_dir_all(temp_dir)` (no inode check against the held
-        // `dir_fd`) makes this test fail — the substituted directory (and
-        // the attacker's file inside it) would be recursively deleted even
-        // though this run never created it.
+        // calling `publish`. `Drop` checks the substituted directory's
+        // inode against the held `dir_fd` before deleting anything, so the
+        // substituted directory (and the attacker's file inside it) is left
+        // untouched rather than recursively deleted.
         let tmp = tempfile::tempdir().unwrap();
         let output = tmp.path().join("output");
 
@@ -1298,11 +1284,10 @@ mod tests {
     // -----------------------------------------------------------------------
     // fd-bind the staging directory (path race).
     //
-    // reverting `TempPublishDir::create_file` to a
-    // the previous path-based `File::create(self.write_dir().join(filename))` makes `create_file_writes_land_in_original_dirfd_inode_not_a_
-    // post_create_symlink_swap` fail — the write would follow the attacker's
-    // symlink into `attacker_dir` instead of landing in the original staging
-    // inode, so the "attacker dir stays empty" assertion trips.
+    // `TempPublishDir::create_file` opens each file relative to the held
+    // directory fd rather than through a reconstructed path, so a symlink
+    // planted at the staging path after creation cannot redirect the write
+    // into the attacker's directory.
     // -----------------------------------------------------------------------
     #[test]
     #[cfg(unix)]
@@ -1354,14 +1339,10 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // dry-run must validate f16 representability identically to
-    // the real run.
-    //
-    // hoisting the `encode_f16_payload` call back inside
-    // the `if !dry_run` block makes
-    // `dry_run_rejects_f16_overflow_that_the_real_run_would_also_reject`
-    // pass silently through dry-run (no error), diverging from the real-run
-    // sibling assertion below it.
+    // dry-run must validate f16 representability identically to the real
+    // run: `encode_f16_payload` runs unconditionally, not only inside an
+    // `if !dry_run` block, so a value that overflows f16 narrowing errors in
+    // dry-run the same way it would in the real run.
     // -----------------------------------------------------------------------
     #[test]
     fn dry_run_rejects_f16_overflow_that_the_real_run_would_also_reject() {
@@ -1396,13 +1377,11 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // restore missing-parent-directory creation.
+    // Missing parent directory creation.
     //
-    // removing the `fs::create_dir_all(parent)` call
-    // added to `TempPublishDir::create` makes
-    // `quantize_model_creates_missing_output_parent_directories` fail with
-    // "failed to create staging directory" (no such file or directory),
-    // while the non-empty-output-dir refusal sibling stays green throughout.
+    // `TempPublishDir::create` creates any missing ancestor directories of
+    // `output_dir` before staging writes there, so an output path whose
+    // parent does not exist yet still succeeds.
     // -----------------------------------------------------------------------
     #[test]
     fn quantize_model_creates_missing_output_parent_directories() {
@@ -1434,11 +1413,10 @@ mod tests {
     // -----------------------------------------------------------------------
     // MoE routed-expert tensors (issue #874 regression coverage).
     //
-    // these tensor names have no `.weight` suffix, so the
-    // pre-fix gate (`if !name.ends_with(".weight") ... return false`) rejects
-    // them before reaching any of the quantize-candidate checks. Reverting
-    // the `.experts.gate_up_proj` / `.experts.down_proj` special-case added
-    // in this fix makes every assertion below fail.
+    // These tensor names have no `.weight` suffix, so `should_quantize`
+    // special-cases the `.experts.gate_up_proj` / `.experts.down_proj`
+    // suffixes to accept them alongside the ordinary `.weight`-suffixed
+    // candidates.
     // -----------------------------------------------------------------------
 
     #[test]
@@ -1500,9 +1478,9 @@ mod tests {
 
     #[test]
     fn should_quantize_accepts_shared_expert_weights() {
-        // The shared (always-on) expert and its gate already carry a
-        // `.weight` suffix and were already quantized correctly pre-fix;
-        // this pins that they remain quantized post-fix.
+        // The shared (always-on) expert and its gate carry a `.weight`
+        // suffix, so the ordinary `.weight`-suffix rule alone quantizes
+        // them correctly.
         for name in [
             "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight",
             "model.language_model.layers.0.mlp.shared_expert.up_proj.weight",

--- a/crates/inference/src/bin/quantize_q4.rs
+++ b/crates/inference/src/bin/quantize_q4.rs
@@ -14,10 +14,14 @@
 //! alongside its `f32` downcast and Q4 output.
 
 use lattice_inference::quant::quarot::QuarotTensorReader;
-use lattice_inference::weights::q4_weights::{Q4_BLOCK_BYTES, quantize_f32_to_q4, save_q4_file};
+use lattice_inference::quant::quarot::convert::encode_f16_payload;
+use lattice_inference::weights::q4_weights::{Q4_BLOCK_BYTES, q4_file_bytes, quantize_f32_to_q4};
+use std::ffi::CString;
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 // ---------------------------------------------------------------------------
@@ -77,91 +81,6 @@ fn should_quantize(name: &str) -> bool {
 
     // Default: quantize unknown weight matrices.
     true
-}
-
-// ---------------------------------------------------------------------------
-// F32 → F16 helper (for non-quantized tensors written as f16)
-// ---------------------------------------------------------------------------
-
-/// Convert f32 to IEEE-754 f16 bit pattern with round-to-nearest-even.
-#[inline]
-fn f32_to_f16(v: f32) -> u16 {
-    let bits = v.to_bits();
-    let sign = ((bits >> 16) & 0x8000) as u16;
-    let exp = ((bits >> 23) & 0xff) as i32;
-    let frac = bits & 0x007f_ffff;
-
-    if exp == 0xff {
-        if frac == 0 {
-            return sign | 0x7c00;
-        }
-        let mut payload = ((frac >> 13) as u16) & 0x03ff;
-        if payload == 0 {
-            payload = 1;
-        }
-        return sign | 0x7c00 | payload | 0x0200;
-    }
-    if exp == 0 {
-        return sign;
-    }
-
-    let exp32 = exp - 127;
-    if exp32 > 15 {
-        return sign | 0x7c00;
-    }
-
-    if exp32 >= -14 {
-        let frac16_raw = (frac >> 13) as u16;
-        let round_bit = ((frac >> 12) & 1) as u16;
-        let sticky = (frac & 0x0fff) != 0;
-        let frac16 = frac16_raw
-            + if round_bit == 1 && (sticky || (frac16_raw & 1) == 1) {
-                1
-            } else {
-                0
-            };
-        let mut exp16 = (exp32 + 15) as u16;
-        let mut frac16_final = frac16 & 0x03ff;
-        if frac16 == 0x0400 {
-            frac16_final = 0;
-            exp16 += 1;
-            if exp16 >= 0x1f {
-                return sign | 0x7c00;
-            }
-        }
-        return sign | (exp16 << 10) | frac16_final;
-    }
-
-    // exp32 < -14: the f32 value is normal-range but smaller than the
-    // smallest f16 normal. F16 still represents 2^-24..2^-14 as subnormals,
-    // and a source-F16 subnormal reaches this point after widening through
-    // f64 and narrowing back to f32 (both exact), so flushing to zero here
-    // would silently destroy a value f16 can represent exactly. Encode it
-    // as an f16 subnormal instead, using the same round-to-nearest-even
-    // shape as the normal-range path above.
-    let sig = 0x0080_0000u32 | frac;
-    let shift = (-exp32 - 1) as u32;
-
-    // Beyond this shift the discarded bits can never reach halfway to the
-    // smallest subnormal (2^-24), so the correctly rounded result is zero.
-    if shift >= 25 {
-        return sign;
-    }
-
-    let frac16_raw = (sig >> shift) as u16;
-    let round_bit = ((sig >> (shift - 1)) & 1) as u16;
-    let sticky = (sig & ((1u32 << (shift - 1)) - 1)) != 0;
-    let frac16 = frac16_raw
-        + if round_bit == 1 && (sticky || (frac16_raw & 1) == 1) {
-            1
-        } else {
-            0
-        };
-
-    // frac16 == 0x0400 means rounding overflowed the largest subnormal into
-    // the smallest normal f16 (exponent field 0x01, fraction 0) — that bit
-    // pattern is exactly `sign | 0x0400`, so no separate branch is needed.
-    sign | frac16
 }
 
 // ---------------------------------------------------------------------------
@@ -244,20 +163,326 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         print_usage_and_exit();
     });
 
-    if !dry_run {
-        fs::create_dir_all(&output_dir)?;
-        let source_config = model_dir.join("config.json");
-        let output_config = output_dir.join("config.json");
-        fs::copy(&source_config, &output_config).map_err(|e| {
+    quantize_model(&model_dir, &output_dir, dry_run)
+}
+
+/// Open `dir` as a directory fd bound to that exact inode, refusing to
+/// follow a symlink.
+///
+/// This is the fd-bind primitive every staging-directory write in this file
+/// routes through: a `Path` re-resolves at the moment of each syscall, so an
+/// attacker who can replace `dir` (or a child within it) between `mkdir` and
+/// a later path-based write redirects that write to wherever the path now
+/// points. A directory fd, once opened, is bound to the inode — later
+/// `openat` calls against this fd always land inside the directory that was
+/// actually created, regardless of what the path currently resolves to.
+/// `O_NOFOLLOW` additionally rejects the open outright if `dir` was swapped
+/// for a symlink between `mkdir` and this call.
+fn open_dir_nofollow(dir: &Path) -> Result<OwnedFd, Box<dyn std::error::Error>> {
+    let cpath = CString::new(dir.as_os_str().as_bytes()).map_err(|e| {
+        format!(
+            "staging directory path {} contains an interior NUL byte: {e}",
+            dir.display()
+        )
+    })?;
+    // SAFETY: `cpath` is a valid NUL-terminated C string owned for the
+    // duration of this call. `libc::open` returns either a valid owned fd
+    // (>= 0) or -1 with errno set; the -1 case is checked immediately below
+    // before any use of `raw`.
+    let raw = unsafe {
+        libc::open(
+            cpath.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return Err(format!(
+            "failed to open staging directory {} (O_DIRECTORY|O_NOFOLLOW): {}",
+            dir.display(),
+            std::io::Error::last_os_error()
+        )
+        .into());
+    }
+    // SAFETY: `raw` was just returned by `libc::open` above, checked
+    // non-negative, and is not owned or closed anywhere else — `OwnedFd`
+    // becomes its sole owner and will close it on drop.
+    Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+/// Publish directory for a conversion run: a fresh temp dir on success (`dry_run`
+/// leaves `output_dir` itself as the target, since nothing is ever written), or
+/// `output_dir` directly when there is nothing to atomically publish.
+///
+/// The `Drop` impl removes the temp dir unless [`TempPublishDir::publish`] has
+/// consumed it — so any early return via `?` between creation and publish
+/// discards the partially-written temp dir and leaves `output_dir` untouched.
+struct TempPublishDir {
+    /// `Some(temp_path)` when writes are staged in a temp dir pending an
+    /// atomic rename; `None` for dry runs, where there is nothing to publish.
+    temp: Option<PathBuf>,
+    /// Directory fd for `temp`, opened `O_DIRECTORY|O_NOFOLLOW` immediately
+    /// after `mkdir` and held for the lifetime of the conversion. Every
+    /// staging-directory write in [`quantize_model`] goes through
+    /// [`TempPublishDir::create_file`] against this fd — never a path-based
+    /// `File::create`/`fs::write` — so the write always lands in the
+    /// directory that was actually created, not wherever the staging path
+    /// resolves to at write time. `None` for dry runs (nothing is staged).
+    dir_fd: Option<OwnedFd>,
+    output_dir: PathBuf,
+}
+
+impl TempPublishDir {
+    /// Refuse a pre-existing non-empty `output_dir` (fail before any write),
+    /// then create a fresh temp dir adjacent to it (same parent => same
+    /// filesystem, so the final rename is atomic). A fresh dir has no
+    /// pre-planted symlinks. Immediately opens a directory fd bound to that
+    /// staging dir (`open_dir_nofollow`) — held for the rest of the run so
+    /// every subsequent write can bind to the fd instead of re-resolving
+    /// the staging path.
+    fn create(output_dir: &Path, dry_run: bool) -> Result<Self, Box<dyn std::error::Error>> {
+        if dry_run {
+            return Ok(Self {
+                temp: None,
+                dir_fd: None,
+                output_dir: output_dir.to_path_buf(),
+            });
+        }
+
+        if let Ok(mut entries) = fs::read_dir(output_dir)
+            && entries.next().is_some()
+        {
+            return Err(format!(
+                "output directory {} already exists and is not empty; \
+                 refusing to overwrite (remove it first if this is intentional)",
+                output_dir.display()
+            )
+            .into());
+        }
+
+        let parent = output_dir.parent().ok_or_else(|| {
             format!(
-                "failed to copy {} to {}: {e}",
-                source_config.display(),
+                "output directory {} has no parent to stage a temp dir in",
+                output_dir.display()
+            )
+        })?;
+        // Restore the parent-creation behavior `fs::create_dir_all(output_dir)`
+        // used to provide before `TempPublishDir` replaced it: a valid
+        // `--output-dir` whose parent doesn't exist yet must still succeed
+        // (the adjacent temp dir and the final rename target both resolve
+        // once the parent exists). The refuse-non-empty-output check above
+        // already ran, so this can't paper over a stale non-empty target.
+        fs::create_dir_all(parent).map_err(|e| {
+            format!(
+                "failed to create output directory parent {}: {e}",
+                parent.display()
+            )
+        })?;
+        let dir_name = output_dir
+            .file_name()
+            .ok_or_else(|| format!("output directory {} has no file name", output_dir.display()))?
+            .to_string_lossy();
+        let temp_dir = parent.join(format!(".{dir_name}.quantize-tmp-{}", std::process::id()));
+        fs::create_dir(&temp_dir).map_err(|e| {
+            format!(
+                "failed to create staging directory {}: {e}",
+                temp_dir.display()
+            )
+        })?;
+        let dir_fd = open_dir_nofollow(&temp_dir)?;
+
+        Ok(Self {
+            temp: Some(temp_dir),
+            dir_fd: Some(dir_fd),
+            output_dir: output_dir.to_path_buf(),
+        })
+    }
+
+    /// Directory that writes should target: the temp dir when staging, or
+    /// `output_dir` directly for a dry run. Used only for path *display* and
+    /// bookkeeping now — actual writes go through [`TempPublishDir::create_file`],
+    /// bound to `dir_fd`, never through this path.
+    fn write_dir(&self) -> &Path {
+        self.temp.as_deref().unwrap_or(&self.output_dir)
+    }
+
+    /// Create (and open for writing) a new file directly inside the staging
+    /// directory via `openat` against the held `dir_fd` — never a path-based
+    /// `File::create`. `filename` must be a plain file name (no separators);
+    /// every call site passes a literal or a sanitized tensor-name stem.
+    ///
+    /// `O_EXCL` refuses a pre-existing entry (including one an attacker
+    /// planted after `mkdir` but before this call); `O_NOFOLLOW` refuses to
+    /// follow it even if it is a symlink. Mode `0o600`: staging artifacts
+    /// are private to the invoking user until the final rename publishes
+    /// them under `output_dir`.
+    fn create_file(&self, filename: &str) -> Result<fs::File, Box<dyn std::error::Error>> {
+        let dir_fd = self.dir_fd.as_ref().ok_or_else(|| {
+            format!(
+                "staging directory {} has no open directory fd (dry run?)",
+                self.write_dir().display()
+            )
+        })?;
+        let cname = CString::new(filename)
+            .map_err(|e| format!("file name {filename} contains an interior NUL byte: {e}"))?;
+        // SAFETY: `dir_fd` is a valid open directory fd held for the
+        // lifetime of `self`; `cname` is a valid NUL-terminated C string
+        // owned for the duration of this call. `openat` returns either a
+        // valid owned fd (>= 0) or -1 with errno set; the -1 case is
+        // checked immediately below before any use of `raw`.
+        let raw = unsafe {
+            libc::openat(
+                dir_fd.as_raw_fd(),
+                cname.as_ptr(),
+                libc::O_CREAT | libc::O_EXCL | libc::O_WRONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                0o600,
+            )
+        };
+        if raw < 0 {
+            return Err(format!(
+                "failed to create {filename} in staging directory {}: {}",
+                self.write_dir().display(),
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
+        // SAFETY: `raw` was just returned by `libc::openat` above, checked
+        // non-negative, and is not owned or closed anywhere else —
+        // `OwnedFd`/`File` becomes its sole owner and will close it on drop.
+        let owned = unsafe { OwnedFd::from_raw_fd(raw) };
+        Ok(fs::File::from(owned))
+    }
+
+    /// fsync every held file handle written during this run, fsync the
+    /// staging directory itself (via the held `dir_fd`, not a path-based
+    /// reopen), then atomically rename the temp dir onto `output_dir`.
+    /// No-op for a dry run (nothing was staged).
+    ///
+    /// Consumes `written_files` (path + open file handle pairs, for fsync
+    /// and error-message display) rather than reopening each path — the
+    /// files were already opened bound to `dir_fd` by
+    /// [`TempPublishDir::create_file`], so fsyncing the held handle keeps
+    /// the whole write+durability path fd-bound end to end.
+    ///
+    /// Ownership of the staging dir/fd is released (`self.temp`/`self.dir_fd`
+    /// set to `None`) only *after* the rename succeeds — an earlier `?`
+    /// return (fsync failure) leaves them populated so `Drop` still cleans
+    /// up the orphaned staging directory instead of leaking it.
+    fn publish(
+        mut self,
+        written_files: Vec<(PathBuf, fs::File)>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let Some(temp_dir) = self.temp.clone() else {
+            return Ok(());
+        };
+        for (path, file) in &written_files {
+            file.sync_all()
+                .map_err(|e| format!("failed to fsync {}: {e}", path.display()))?;
+        }
+        let dir_fd = self.dir_fd.as_ref().ok_or_else(|| {
+            format!(
+                "staging directory {} has no open directory fd to fsync",
+                temp_dir.display()
+            )
+        })?;
+        // SAFETY: `dir_fd` is a valid open fd held for the lifetime of
+        // `self`. `libc::fsync` returns 0 on success or -1 with errno set.
+        if unsafe { libc::fsync(dir_fd.as_raw_fd()) } != 0 {
+            return Err(format!(
+                "failed to fsync staging directory {}: {}",
+                temp_dir.display(),
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
+        // `fs::rename` below is necessarily path-based (POSIX has no
+        // "rename this fd" call) — but `dir_fd` was bound to the inode
+        // `mkdir` actually created, so it is the one piece of ground truth
+        // an attacker cannot redirect. Compare it against a fresh stat of
+        // `temp_dir` immediately before the rename: if the path was swapped
+        // for a different directory (a plain directory substitution passes
+        // `O_NOFOLLOW`, which only rejects a symlink) between the last
+        // write and this call, the inode numbers diverge and the rename is
+        // refused instead of publishing the attacker's substituted
+        // directory as `output_dir`.
+        let mut fd_stat: libc::stat = unsafe { std::mem::zeroed() };
+        // SAFETY: `dir_fd` is a valid open fd for the lifetime of `self`;
+        // `fd_stat` is a valid, fully-initialized (zeroed) `libc::stat` the
+        // kernel writes into. `fstat` returns 0 on success or -1 with errno
+        // set, checked immediately below.
+        if unsafe { libc::fstat(dir_fd.as_raw_fd(), &raw mut fd_stat) } != 0 {
+            return Err(format!(
+                "failed to fstat staging directory {}: {}",
+                temp_dir.display(),
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
+        let path_meta = fs::symlink_metadata(&temp_dir).map_err(|e| {
+            format!(
+                "failed to stat staging directory {} before publish: {e}",
+                temp_dir.display()
+            )
+        })?;
+        use std::os::unix::fs::MetadataExt;
+        if path_meta.dev() != fd_stat.st_dev as u64 || path_meta.ino() != fd_stat.st_ino {
+            return Err(format!(
+                "staging directory {} was replaced before publish (inode mismatch: \
+                 held fd is dev={} ino={}, path now resolves to dev={} ino={}); \
+                 refusing to publish a substituted directory",
+                temp_dir.display(),
+                fd_stat.st_dev,
+                fd_stat.st_ino,
+                path_meta.dev(),
+                path_meta.ino(),
+            )
+            .into());
+        }
+        fs::rename(&temp_dir, &self.output_dir).map_err(|e| {
+            format!(
+                "failed to publish {} to {}: {e}",
+                temp_dir.display(),
+                self.output_dir.display()
+            )
+        })?;
+        self.temp = None;
+        self.dir_fd = None;
+        Ok(())
+    }
+}
+
+impl Drop for TempPublishDir {
+    fn drop(&mut self) {
+        if let Some(temp_dir) = self.temp.take() {
+            let _ = fs::remove_dir_all(temp_dir);
+        }
+    }
+}
+
+fn quantize_model(
+    model_dir: &Path,
+    output_dir: &Path,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let publish_dir = TempPublishDir::create(output_dir, dry_run)?;
+    let write_dir = publish_dir.write_dir().to_path_buf();
+    let mut written_files: Vec<(PathBuf, fs::File)> = Vec::new();
+
+    if !dry_run {
+        let source_config = model_dir.join("config.json");
+        let output_config = write_dir.join("config.json");
+        let config_bytes = fs::read(&source_config)
+            .map_err(|e| format!("failed to read {}: {e}", source_config.display()))?;
+        let mut f = publish_dir.create_file("config.json")?;
+        f.write_all(&config_bytes).map_err(|e| {
+            format!(
+                "failed to write {} to staging directory: {e}",
                 output_config.display()
             )
         })?;
+        written_files.push((output_config, f));
     }
 
-    let reader = QuarotTensorReader::open(&model_dir)?;
+    let reader = QuarotTensorReader::open(model_dir)?;
     let mut tensor_names = reader.tensor_names();
     tensor_names.sort();
     let n_tensors = tensor_names.len();
@@ -298,9 +523,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             .into());
         }
 
-        // Reader decodes to f64; the Q4 quantizer works in f32 (ADR-044 step 3c).
-        let data_f32: Vec<f32> = data_f64.iter().map(|&v| v as f32).collect();
-        let numel = data_f32.len();
+        let numel = data_f64.len();
         total_bytes_in += bytes_in;
 
         let sanitized: String = tensor_name
@@ -315,16 +538,22 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             .collect();
 
         if should_quantize(tensor_name) {
+            // Reader decodes to f64; the Q4 quantizer works in f32 (ADR-044 step
+            // 3c). Only quantized tensors need this widening pass — kept
+            // tensors write directly from `data_f64` below.
+            let data_f32: Vec<f32> = data_f64.iter().map(|&v| v as f32).collect();
             let q4 = quantize_f32_to_q4(&data_f32, &shape)?;
             let bytes_out = (q4.blocks.len() * Q4_BLOCK_BYTES) as u64;
             total_bytes_out += bytes_out;
 
             let out_filename = format!("{sanitized}.q4");
-            let out_path = output_dir.join(&out_filename);
+            let out_path = write_dir.join(&out_filename);
 
             if !dry_run {
-                save_q4_file(&out_path, &q4)
+                let mut f = publish_dir.create_file(&out_filename)?;
+                f.write_all(&q4_file_bytes(&q4))
                     .map_err(|e| format!("failed to write {}: {e}", out_path.display()))?;
+                written_files.push((out_path, f));
             }
 
             let elapsed = tensor_start.elapsed();
@@ -348,29 +577,29 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             // Kept tensor: reader already decoded to numeric values, so the
             // common path is decoded-value → f16 for every source dtype.
-            let f16_data: Vec<u8> = data_f32
-                .iter()
-                .flat_map(|&v| f32_to_f16(v).to_le_bytes())
-                .collect();
-
-            let bytes_out = f16_data.len() as u64;
+            let bytes_out = (numel * 2) as u64;
             total_bytes_out += bytes_out;
 
             let out_filename = format!("{sanitized}.f16");
-            let out_path = output_dir.join(&out_filename);
+            let out_path = write_dir.join(&out_filename);
+
+            // Validate f16 representability unconditionally: a dry run must
+            // reject exactly what the real write below
+            // would reject — a finite kept value that overflows f16
+            // narrowing (e.g. `f32::MAX`) errors here regardless of
+            // `dry_run`, instead of only surfacing on the next real run.
+            let framed = encode_f16_payload(
+                &out_path.display().to_string(),
+                tensor_name,
+                &data_f64,
+                &shape,
+            )?;
 
             if !dry_run {
-                let mut f = fs::File::create(&out_path)
-                    .map_err(|e| format!("failed to create {}: {e}", out_path.display()))?;
-                // Minimal header: magic "KHF1" + version u32 + ndim u32 + shape[i] u64 + numel u64 + data
-                f.write_all(b"KHF1")?;
-                f.write_all(&1u32.to_le_bytes())?;
-                f.write_all(&(shape.len() as u32).to_le_bytes())?;
-                for &dim in &shape {
-                    f.write_all(&(dim as u64).to_le_bytes())?;
-                }
-                f.write_all(&(numel as u64).to_le_bytes())?;
-                f.write_all(&f16_data)?;
+                let mut f = publish_dir.create_file(&out_filename)?;
+                f.write_all(&framed)
+                    .map_err(|e| format!("failed to write {}: {e}", out_path.display()))?;
+                written_files.push((out_path, f));
             }
 
             let elapsed = tensor_start.elapsed();
@@ -396,14 +625,21 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         total_tensors += 1;
     }
 
-    // Write the quantization index.
+    // Write the quantization index, then atomically publish the whole run.
     if !dry_run {
-        let index_path = output_dir.join("quantize_index.json");
+        let index_path = write_dir.join("quantize_index.json");
         let index_json = serde_json::to_string_pretty(&index_entries)
             .map_err(|e| format!("failed to serialize index: {e}"))?;
-        fs::write(&index_path, index_json)
+        let mut f = publish_dir.create_file("quantize_index.json")?;
+        f.write_all(index_json.as_bytes())
             .map_err(|e| format!("failed to write {}: {e}", index_path.display()))?;
-        eprintln!("Index written: {}", index_path.display());
+        written_files.push((index_path, f));
+        eprintln!(
+            "Index written: {}",
+            output_dir.join("quantize_index.json").display()
+        );
+
+        publish_dir.publish(written_files)?;
     }
 
     let total_elapsed = global_start.elapsed();
@@ -442,7 +678,402 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod tests {
-    use super::should_quantize;
+    use super::{quantize_model, should_quantize};
+    use std::fs;
+    use std::io::Write;
+    use std::path::Path;
+
+    fn write_single_f32_tensor(path: &Path, name: &str, values: &[f32]) {
+        let payload: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let header = serde_json::json!({
+            name: {
+                "dtype": "F32",
+                "shape": [values.len()],
+                "data_offsets": [0, payload.len()],
+            }
+        });
+        let header = serde_json::to_vec(&header).unwrap();
+        let mut file = fs::File::create(path).unwrap();
+        file.write_all(&(header.len() as u64).to_le_bytes())
+            .unwrap();
+        file.write_all(&header).unwrap();
+        file.write_all(&payload).unwrap();
+    }
+
+    #[test]
+    fn invalid_source_tensor_is_not_published() {
+        for (name, extension) in [("invalid.weight", "q4"), ("invalid.norm.weight", "f16")] {
+            let tmp = tempfile::tempdir().unwrap();
+            let input = tmp.path().join("input");
+            let output = tmp.path().join("output");
+            fs::create_dir(&input).unwrap();
+            fs::write(input.join("config.json"), b"{}").unwrap();
+            write_single_f32_tensor(
+                &input.join("model.safetensors"),
+                name,
+                &[1.0, f32::NAN, 3.0],
+            );
+
+            let err = quantize_model(&input, &output, false)
+                .expect_err("offline quantizer must reject a non-finite source tensor");
+            let sanitized = name.replace('.', "_");
+            assert!(err.to_string().contains(name), "unexpected error: {err}");
+            assert!(
+                !output.join(format!("{sanitized}.{extension}")).exists(),
+                "invalid tensor must not have a completed output artifact"
+            );
+            assert!(!output.join("quantize_index.json").exists());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Atomic publish + refuse-non-empty-output-dir.
+    //
+    // Mutation-sensitive: reverting `TempPublishDir` so writes land directly
+    // in `output_dir` (as before this fix) makes
+    // `atomic_publish_leaves_output_dir_untouched_on_mid_conversion_failure`
+    // fail (a partial `.q4`/`config.json` would appear in `output`), and
+    // dropping the up-front `fs::read_dir` non-empty check makes both
+    // `quantize_model_refuses_preexisting_nonempty_output_dir` and
+    // `quantize_model_refuses_output_dir_containing_planted_symlink` fail
+    // (the stray file / symlink would silently coexist with fresh output).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn quantize_model_publishes_successful_run_atomically() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("input");
+        let output = tmp.path().join("output");
+        fs::create_dir(&input).unwrap();
+        fs::write(input.join("config.json"), b"{}").unwrap();
+        write_single_f32_tensor(
+            &input.join("model.safetensors"),
+            "model.layers.0.input_layernorm.weight",
+            &[1.0, 2.0, 3.0],
+        );
+
+        quantize_model(&input, &output, false).unwrap();
+
+        assert!(output.join("config.json").exists());
+        assert!(output.join("quantize_index.json").exists());
+        // No leftover staging directory beside the published output.
+        let siblings: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(
+            siblings
+                .iter()
+                .filter(|n| *n != "input" && *n != "output")
+                .count(),
+            0,
+            "no temp staging directory should survive a successful run: {siblings:?}"
+        );
+    }
+
+    #[test]
+    fn atomic_publish_leaves_output_dir_untouched_on_mid_conversion_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("input");
+        let output = tmp.path().join("output");
+        fs::create_dir(&input).unwrap();
+        fs::write(input.join("config.json"), b"{}").unwrap();
+        write_single_f32_tensor(
+            &input.join("model.safetensors"),
+            "invalid.norm.weight",
+            &[1.0, f32::NAN, 3.0],
+        );
+
+        quantize_model(&input, &output, false)
+            .expect_err("non-finite source tensor must fail the conversion");
+
+        assert!(
+            !output.exists(),
+            "a failed conversion must leave output_dir absent, not partially populated"
+        );
+        // No orphaned staging directory left behind either.
+        let siblings: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(
+            siblings.iter().filter(|n| *n != "input").count(),
+            0,
+            "a failed conversion must not leave a temp staging directory: {siblings:?}"
+        );
+    }
+
+    #[test]
+    fn publish_refuses_staging_dir_substituted_with_different_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let output = tmp.path().join("output");
+
+        let staging = super::TempPublishDir::create(&output, false).unwrap();
+        let temp_path = staging.write_dir().to_path_buf();
+        staging
+            .create_file("real.q4")
+            .unwrap()
+            .write_all(b"legit")
+            .unwrap();
+
+        // Substitute the staging directory: remove the one `create()` made
+        // and `mkdir` a fresh plain directory at the same path. This is not
+        // a symlink, so `O_NOFOLLOW` on the held `dir_fd` (opened against
+        // the original inode) does not reject it — only an inode check
+        // right before the path-based `rename` can catch the swap.
+        fs::remove_dir_all(&temp_path).unwrap();
+        fs::create_dir(&temp_path).unwrap();
+        fs::write(temp_path.join("attacker-planted.txt"), b"evil").unwrap();
+
+        let err = staging
+            .publish(Vec::new())
+            .expect_err("publish must refuse a staging directory substituted after creation");
+        assert!(
+            err.to_string().contains("inode mismatch"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            !output.exists(),
+            "a substituted staging directory must not be published as output_dir"
+        );
+    }
+
+    #[test]
+    fn quantize_model_refuses_preexisting_nonempty_output_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("input");
+        let output = tmp.path().join("output");
+        fs::create_dir(&input).unwrap();
+        fs::write(input.join("config.json"), b"{}").unwrap();
+        write_single_f32_tensor(
+            &input.join("model.safetensors"),
+            "model.layers.0.input_layernorm.weight",
+            &[1.0, 2.0, 3.0],
+        );
+        fs::create_dir(&output).unwrap();
+        fs::write(output.join("stray.txt"), b"pre-existing").unwrap();
+
+        let err = quantize_model(&input, &output, false)
+            .expect_err("a non-empty pre-existing output_dir must be refused");
+        assert!(
+            err.to_string().contains("already exists and is not empty"),
+            "unexpected error: {err}"
+        );
+        assert!(output.join("stray.txt").exists());
+        assert!(!output.join("quantize_index.json").exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn quantize_model_refuses_output_dir_containing_planted_symlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("input");
+        let output = tmp.path().join("output");
+        fs::create_dir(&input).unwrap();
+        fs::write(input.join("config.json"), b"{}").unwrap();
+        write_single_f32_tensor(
+            &input.join("model.safetensors"),
+            "model.layers.0.input_layernorm.weight",
+            &[1.0, 2.0, 3.0],
+        );
+
+        let escape_target = tmp.path().join("outside_target");
+        fs::create_dir(&escape_target).unwrap();
+        fs::create_dir(&output).unwrap();
+        std::os::unix::fs::symlink(&escape_target, output.join("config.json")).unwrap();
+
+        let err = quantize_model(&input, &output, false)
+            .expect_err("an output_dir containing a planted symlink must be refused");
+        assert!(
+            err.to_string().contains("already exists and is not empty"),
+            "unexpected error: {err}"
+        );
+        // The attacker's symlink target must never have been written into.
+        assert_eq!(fs::read_dir(&escape_target).unwrap().count(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Fold: Drop-ordering — a failed `publish()` must leave the staging
+    // handle in `self` so `Drop` can still clean it up.
+    //
+    // Mutation-sensitive: reverting `publish()` to `.take()` `self.temp` (and
+    // `self.dir_fd`) up front makes this test fail — the
+    // staging directory would survive (leaked) after a failed rename,
+    // because `Drop` would find `self.temp == None` and do nothing.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn publish_failure_still_lets_drop_clean_up_the_staging_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let output = tmp.path().join("output");
+        // Pre-create `output` as a regular FILE (not a directory): the
+        // non-empty-dir refusal in `create()` only triggers for an existing
+        // *directory*, so `create()` succeeds, but the final
+        // `fs::rename(temp_dir, output)` in `publish()` fails (renaming a
+        // directory onto an existing non-directory is always rejected).
+        fs::write(&output, b"not a directory").unwrap();
+
+        let publish_dir = super::TempPublishDir::create(&output, false).unwrap();
+        let staging_path = publish_dir.write_dir().to_path_buf();
+        assert!(staging_path.is_dir());
+
+        let mut f = publish_dir.create_file("artifact.q4").unwrap();
+        f.write_all(b"data").unwrap();
+
+        // `publish` takes `self` by value, so `publish_dir` is dropped
+        // inside this call before the `Err` reaches the assertion below —
+        // whatever `Drop` does (or fails to do) has already happened by
+        // the time `.expect_err` runs.
+        let err = publish_dir
+            .publish(vec![(staging_path.join("artifact.q4"), f)])
+            .expect_err("renaming the staging dir onto an existing file must fail");
+        assert!(
+            err.to_string().contains("failed to publish"),
+            "unexpected error: {err}"
+        );
+
+        assert!(
+            !staging_path.exists(),
+            "a failed publish must not leak the staging directory — Drop must \
+             still own cleanup because `self.temp`/`self.dir_fd` stayed \
+             populated until the rename actually succeeded"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // fd-bind the staging directory (path race).
+    //
+    // Mutation-sensitive: reverting `TempPublishDir::create_file` to a
+    // the previous path-based `File::create(self.write_dir().join(filename))` makes `create_file_writes_land_in_original_dirfd_inode_not_a_
+    // post_create_symlink_swap` fail — the write would follow the attacker's
+    // symlink into `attacker_dir` instead of landing in the original staging
+    // inode, so the "attacker dir stays empty" assertion trips.
+    // -----------------------------------------------------------------------
+    #[test]
+    #[cfg(unix)]
+    fn create_file_writes_land_in_original_dirfd_inode_not_a_post_create_symlink_swap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let output = tmp.path().join("output");
+        let publish_dir = super::TempPublishDir::create(&output, false).unwrap();
+        let staging_path = publish_dir.write_dir().to_path_buf();
+        assert!(
+            staging_path.is_dir(),
+            "staging dir must exist right after TempPublishDir::create"
+        );
+
+        // Attacker replaces the staging PATH with a symlink to a directory
+        // they control, after the dir (and its fd) were already created.
+        // The original directory is preserved (moved aside via `rename`,
+        // which never touches inodes or open fds — only the still-open
+        // `dir_fd` keeps pointing at it) rather than `rmdir`'d: an already
+        // fully-unlinked (0-link) directory refuses further `openat` calls
+        // outright (verified on this platform), which would make the test
+        // pass for the wrong reason (ENOENT, not fd-binding) instead of
+        // proving the write actually lands in the original inode.
+        let attacker_dir = tmp.path().join("attacker_dir");
+        let moved_aside = tmp.path().join("staging_moved_aside");
+        fs::create_dir(&attacker_dir).unwrap();
+        fs::rename(&staging_path, &moved_aside).unwrap();
+        std::os::unix::fs::symlink(&attacker_dir, &staging_path).unwrap();
+
+        // Drive a child write through the dirfd-bound API.
+        let mut f = publish_dir.create_file("child.q4").unwrap();
+        f.write_all(b"trusted-payload").unwrap();
+        drop(f);
+
+        // The attacker's directory must never have been written into: a
+        // path-based write would have followed the swapped symlink here.
+        assert_eq!(
+            fs::read_dir(&attacker_dir).unwrap().count(),
+            0,
+            "attacker-controlled directory must stay empty; a path-based \
+             write would have redirected the child write here"
+        );
+
+        // Affirmative check: the write landed in the ORIGINAL staging
+        // inode — reachable at `moved_aside` (where the directory now
+        // lives) — not wherever `staging_path` currently resolves.
+        let landed = fs::read(moved_aside.join("child.q4"))
+            .expect("child write must land in the original (moved-aside) staging directory");
+        assert_eq!(landed, b"trusted-payload");
+    }
+
+    // -----------------------------------------------------------------------
+    // dry-run must validate f16 representability identically to
+    // the real run.
+    //
+    // Mutation-sensitive: hoisting the `encode_f16_payload` call back inside
+    // the `if !dry_run` block makes
+    // `dry_run_rejects_f16_overflow_that_the_real_run_would_also_reject`
+    // pass silently through dry-run (no error), diverging from the real-run
+    // sibling assertion below it.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn dry_run_rejects_f16_overflow_that_the_real_run_would_also_reject() {
+        for dry_run in [true, false] {
+            let tmp = tempfile::tempdir().unwrap();
+            let input = tmp.path().join("input");
+            let output = tmp.path().join("output");
+            fs::create_dir(&input).unwrap();
+            fs::write(input.join("config.json"), b"{}").unwrap();
+            // A finite kept (non-quantized) tensor whose value overflows f16
+            // narrowing to +inf: `f32::MAX` is finite in f32/f64 but has no
+            // finite f16 representation.
+            write_single_f32_tensor(
+                &input.join("model.safetensors"),
+                "model.layers.0.input_layernorm.weight",
+                &[f32::MAX, 1.0, 2.0],
+            );
+
+            let err = quantize_model(&input, &output, dry_run).expect_err(&format!(
+                "a kept tensor with an f16-unrepresentable value must be rejected \
+                 (dry_run={dry_run})"
+            ));
+            assert!(
+                err.to_string().contains("non-finite"),
+                "unexpected error (dry_run={dry_run}): {err}"
+            );
+            assert!(
+                !output.exists(),
+                "a rejected conversion must not create output_dir (dry_run={dry_run})"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // restore missing-parent-directory creation.
+    //
+    // Mutation-sensitive: removing the `fs::create_dir_all(parent)` call
+    // added to `TempPublishDir::create` makes
+    // `quantize_model_creates_missing_output_parent_directories` fail with
+    // "failed to create staging directory" (no such file or directory),
+    // while the non-empty-output-dir refusal sibling stays green throughout.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn quantize_model_creates_missing_output_parent_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("input");
+        // `output`'s parent ("nested/does/not/exist") does not exist yet.
+        let output = tmp
+            .path()
+            .join("nested")
+            .join("does")
+            .join("not")
+            .join("exist")
+            .join("out");
+        fs::create_dir(&input).unwrap();
+        fs::write(input.join("config.json"), b"{}").unwrap();
+        write_single_f32_tensor(
+            &input.join("model.safetensors"),
+            "model.layers.0.input_layernorm.weight",
+            &[1.0, 2.0, 3.0],
+        );
+
+        quantize_model(&input, &output, false)
+            .expect("a valid output path with a missing parent directory must succeed");
+
+        assert!(output.join("config.json").exists());
+        assert!(output.join("quantize_index.json").exists());
+    }
 
     // -----------------------------------------------------------------------
     // MoE routed-expert tensors (issue #874 regression coverage).

--- a/crates/inference/src/bin/quantize_q4.rs
+++ b/crates/inference/src/bin/quantize_q4.rs
@@ -16,9 +16,9 @@
 use lattice_inference::quant::quarot::QuarotTensorReader;
 use lattice_inference::quant::quarot::convert::encode_f16_payload;
 use lattice_inference::weights::q4_weights::{Q4_BLOCK_BYTES, q4_file_bytes, quantize_f32_to_q4};
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::fs;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
@@ -209,42 +209,6 @@ fn open_dir_nofollow(dir: &Path) -> Result<OwnedFd, Box<dyn std::error::Error>> 
     Ok(unsafe { OwnedFd::from_raw_fd(raw) })
 }
 
-/// Read `name` (a plain file name) from the directory bound to `dirfd` via
-/// `openat(..., O_NOFOLLOW)`, never a path-based `fs::read`. `fs::read`
-/// follows a symlink at the final path component; a hostile or
-/// concurrently-swapped model directory could plant one at `config.json`
-/// pointing at an arbitrary readable file, which `fs::read` would then copy
-/// into the output directory.
-fn read_file_at_nofollow(dirfd: RawFd, name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let cname = CString::new(name)
-        .map_err(|e| format!("file name {name} contains an interior NUL byte: {e}"))?;
-    // SAFETY: `dirfd` is a valid open directory fd borrowed for the
-    // duration of this call; `cname` is a valid NUL-terminated C string.
-    // `openat` returns either a valid fd (>= 0) or -1 with errno set,
-    // checked immediately below.
-    let raw = unsafe {
-        libc::openat(
-            dirfd,
-            cname.as_ptr(),
-            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-        )
-    };
-    if raw < 0 {
-        return Err(format!(
-            "failed to open {name} (O_NOFOLLOW): {}",
-            std::io::Error::last_os_error()
-        )
-        .into());
-    }
-    // SAFETY: `raw` was just returned by `libc::openat` above, checked
-    // non-negative, and is not owned or closed anywhere else.
-    let mut file = unsafe { fs::File::from(OwnedFd::from_raw_fd(raw)) };
-    let mut buf = Vec::new();
-    file.read_to_end(&mut buf)
-        .map_err(|e| format!("failed to read {name}: {e}"))?;
-    Ok(buf)
-}
-
 /// Publish directory for a conversion run: a fresh temp dir on success (`dry_run`
 /// leaves `output_dir` itself as the target, since nothing is ever written), or
 /// `output_dir` directly when there is nothing to atomically publish.
@@ -264,6 +228,15 @@ struct TempPublishDir {
     /// directory that was actually created, not wherever the staging path
     /// resolves to at write time. `None` for dry runs (nothing is staged).
     dir_fd: Option<OwnedFd>,
+    /// Directory fd for `temp`'s parent (== `output_dir`'s parent — both are
+    /// created as direct children of it), opened once alongside `dir_fd`.
+    /// [`TempPublishDir::publish`] and `Drop` use this, together with the
+    /// bare file-name components, to reach both the temp dir and the final
+    /// `output_dir` name via `renameat`/`unlinkat` rather than re-resolving
+    /// either as a full path — an ancestor of `output_dir`'s parent being
+    /// swapped after this fd is opened cannot redirect the eventual publish
+    /// or cleanup. `None` for dry runs.
+    parent_fd: Option<OwnedFd>,
     output_dir: PathBuf,
 }
 
@@ -280,6 +253,7 @@ impl TempPublishDir {
             return Ok(Self {
                 temp: None,
                 dir_fd: None,
+                parent_fd: None,
                 output_dir: output_dir.to_path_buf(),
             });
         }
@@ -325,10 +299,12 @@ impl TempPublishDir {
             )
         })?;
         let dir_fd = open_dir_nofollow(&temp_dir)?;
+        let parent_fd = open_dir_nofollow(parent)?;
 
         Ok(Self {
             temp: Some(temp_dir),
             dir_fd: Some(dir_fd),
+            parent_fd: Some(parent_fd),
             output_dir: output_dir.to_path_buf(),
         })
     }
@@ -430,16 +406,24 @@ impl TempPublishDir {
             )
             .into());
         }
-        // `fs::rename` below is necessarily path-based (POSIX has no
-        // "rename this fd" call) — but `dir_fd` was bound to the inode
-        // `mkdir` actually created, so it is the one piece of ground truth
-        // an attacker cannot redirect. Compare it against a fresh stat of
-        // `temp_dir` immediately before the rename: if the path was swapped
-        // for a different directory (a plain directory substitution passes
-        // `O_NOFOLLOW`, which only rejects a symlink) between the last
-        // write and this call, the inode numbers diverge and the rename is
-        // refused instead of publishing the attacker's substituted
-        // directory as `output_dir`.
+        let parent_fd = self.parent_fd.as_ref().ok_or_else(|| {
+            format!(
+                "staging directory {} has no open parent directory fd to publish through",
+                temp_dir.display()
+            )
+        })?;
+        let temp_name = file_name_cstring(&temp_dir)?;
+        let output_name = file_name_cstring(&self.output_dir)?;
+
+        // `dir_fd` was bound to the inode `mkdir` actually created, so it is
+        // the one piece of ground truth an attacker cannot redirect. Compare
+        // it against a fresh `fstatat` of the CURRENT entry named
+        // `temp_name` inside `parent_fd` (never a full-path re-resolution):
+        // if that name now refers to a different directory (a plain
+        // directory substitution passes `O_NOFOLLOW`, which only rejects a
+        // symlink) between the last write and this call, the inode numbers
+        // diverge and the publish is refused instead of renaming the
+        // attacker's substituted directory into place.
         let mut fd_stat: libc::stat = unsafe { std::mem::zeroed() };
         // SAFETY: `dir_fd` is a valid open fd for the lifetime of `self`;
         // `fd_stat` is a valid, fully-initialized (zeroed) `libc::stat` the
@@ -453,78 +437,243 @@ impl TempPublishDir {
             )
             .into());
         }
-        let path_meta = fs::symlink_metadata(&temp_dir).map_err(|e| {
+        let entry_stat = fstatat_nofollow(parent_fd.as_raw_fd(), &temp_name).map_err(|e| {
             format!(
-                "failed to stat staging directory {} before publish: {e}",
+                "failed to stat staging directory entry {} before publish: {e}",
                 temp_dir.display()
             )
         })?;
-        use std::os::unix::fs::MetadataExt;
-        if path_meta.dev() != fd_stat.st_dev as u64 || path_meta.ino() != fd_stat.st_ino {
+        if entry_stat.st_dev != fd_stat.st_dev || entry_stat.st_ino != fd_stat.st_ino {
             return Err(format!(
                 "staging directory {} was replaced before publish (inode mismatch: \
-                 held fd is dev={} ino={}, path now resolves to dev={} ino={}); \
+                 held fd is dev={} ino={}, entry now resolves to dev={} ino={}); \
                  refusing to publish a substituted directory",
                 temp_dir.display(),
                 fd_stat.st_dev,
                 fd_stat.st_ino,
-                path_meta.dev(),
-                path_meta.ino(),
+                entry_stat.st_dev,
+                entry_stat.st_ino,
             )
             .into());
         }
-        fs::rename(&temp_dir, &self.output_dir).map_err(|e| {
-            format!(
-                "failed to publish {} to {}: {e}",
-                temp_dir.display(),
-                self.output_dir.display()
+        // `renameat` anchors BOTH the source and destination name to
+        // `parent_fd`, which is bound to the inode `create()` opened — an
+        // ancestor of that parent being swapped after this fd was opened
+        // cannot redirect either resolution, unlike `fs::rename` on
+        // reconstructed full paths.
+        //
+        // SAFETY: `parent_fd` is a valid open fd held for the lifetime of
+        // `self`; `temp_name`/`output_name` are valid NUL-terminated C
+        // strings owned for the duration of this call. `renameat` returns 0
+        // on success or -1 with errno set, checked immediately below.
+        if unsafe {
+            libc::renameat(
+                parent_fd.as_raw_fd(),
+                temp_name.as_ptr(),
+                parent_fd.as_raw_fd(),
+                output_name.as_ptr(),
             )
-        })?;
+        } != 0
+        {
+            return Err(format!(
+                "failed to publish {} to {}: {}",
+                temp_dir.display(),
+                self.output_dir.display(),
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
         self.temp = None;
         self.dir_fd = None;
+        self.parent_fd = None;
         Ok(())
     }
 }
 
+/// Extract the final path component of `path` as an owned `CString`, for use
+/// with `openat`/`renameat`/`unlinkat`-family calls against a held directory
+/// fd. Purely in-memory string manipulation — never touches the filesystem,
+/// so it does not re-resolve any part of `path`.
+fn file_name_cstring(path: &Path) -> Result<CString, Box<dyn std::error::Error>> {
+    let name = path
+        .file_name()
+        .ok_or_else(|| format!("path {} has no file name", path.display()))?;
+    CString::new(name.as_bytes())
+        .map_err(|e| format!("file name {name:?} contains an interior NUL byte: {e}").into())
+}
+
+/// `fstatat(dirfd, name, AT_SYMLINK_NOFOLLOW)` — stat the entry named `name`
+/// inside the directory bound to `dirfd`, without following a symlink and
+/// without re-resolving any path component above `dirfd`.
+fn fstatat_nofollow(dirfd: RawFd, name: &CString) -> std::io::Result<libc::stat> {
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: `dirfd` is a valid open directory fd borrowed for the
+    // duration of this call; `name` is a valid NUL-terminated C string;
+    // `st` is a valid, fully-initialized (zeroed) `libc::stat` the kernel
+    // writes into. `fstatat` returns 0 on success or -1 with errno set,
+    // checked immediately below.
+    let rc = unsafe { libc::fstatat(dirfd, name.as_ptr(), &raw mut st, libc::AT_SYMLINK_NOFOLLOW) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(st)
+}
+
+/// Recursively delete everything bound to `dirfd`, never re-resolving a
+/// path: each descent opens a child via `openat(dirfd, name,
+/// O_DIRECTORY|O_NOFOLLOW)` and each removal is `unlinkat(dirfd, name, ...)`
+/// against the fd of its ACTUAL parent, so there is no pathname an attacker
+/// can substitute between the scan and the removal.
+fn remove_dir_all_at(dirfd: RawFd) -> std::io::Result<()> {
+    // SAFETY: `dirfd` is a valid, open, borrowed-for-this-call directory fd.
+    // `dup` returns either a new independent fd (>= 0) or -1 with errno
+    // set, checked immediately below.
+    let dup_fd = unsafe { libc::dup(dirfd) };
+    if dup_fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `dup_fd` was just returned by `libc::dup` above, checked
+    // non-negative. `fdopendir` takes ownership of it on success; on
+    // failure `dup_fd` is still open and is closed explicitly below.
+    let dirp = unsafe { libc::fdopendir(dup_fd) };
+    if dirp.is_null() {
+        let err = std::io::Error::last_os_error();
+        // SAFETY: `dup_fd` is still owned by us — `fdopendir` failed to
+        // take it — and open.
+        unsafe {
+            libc::close(dup_fd);
+        }
+        return Err(err);
+    }
+    let result = (|| -> std::io::Result<()> {
+        loop {
+            // SAFETY: `dirp` is a valid, non-null `DIR*` for the duration
+            // of this loop, owned solely by this function. `readdir`
+            // returns either a pointer into storage owned by `dirp` (valid
+            // until the next `readdir`/`closedir` call on `dirp`) or null
+            // at end-of-stream or on error; either null case stops the
+            // scan here.
+            let entry = unsafe { libc::readdir(dirp) };
+            if entry.is_null() {
+                return Ok(());
+            }
+            // SAFETY: `entry` was just checked non-null and points at a
+            // `dirent` owned by `dirp`, valid for this statement's
+            // duration. `d_name` is NUL-terminated per the `readdir`
+            // contract.
+            let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
+            if name.to_bytes() == b"." || name.to_bytes() == b".." {
+                continue;
+            }
+            // SAFETY: `entry` is valid for this statement's duration, as
+            // above.
+            let d_type = unsafe { (*entry).d_type };
+            let is_dir = if d_type == libc::DT_DIR {
+                true
+            } else if d_type == libc::DT_UNKNOWN {
+                fstatat_nofollow(dirfd, &name.to_owned())
+                    .map(|st| st.st_mode & libc::S_IFMT == libc::S_IFDIR)
+                    .unwrap_or(false)
+            } else {
+                false
+            };
+            if is_dir {
+                // SAFETY: `dirfd` is a valid open directory fd borrowed for
+                // the duration of this call; `name` is a valid
+                // NUL-terminated C string from `readdir` above. `openat`
+                // returns either a valid fd (>= 0) or -1 with errno set,
+                // checked immediately below.
+                let raw = unsafe {
+                    libc::openat(
+                        dirfd,
+                        name.as_ptr(),
+                        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                    )
+                };
+                if raw < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                // SAFETY: `raw` was just returned by `libc::openat` above,
+                // checked non-negative, and is not owned or closed
+                // anywhere else.
+                let child_fd = unsafe { OwnedFd::from_raw_fd(raw) };
+                remove_dir_all_at(child_fd.as_raw_fd())?;
+                // SAFETY: `dirfd` is valid for the duration of this call;
+                // `name` is a valid NUL-terminated C string.
+                if unsafe { libc::unlinkat(dirfd, name.as_ptr(), libc::AT_REMOVEDIR) } != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            } else {
+                // SAFETY: `dirfd` is valid for the duration of this call;
+                // `name` is a valid NUL-terminated C string.
+                if unsafe { libc::unlinkat(dirfd, name.as_ptr(), 0) } != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+        }
+    })();
+    // SAFETY: `dirp` was returned non-null by `fdopendir` above and has not
+    // been closed anywhere else.
+    unsafe {
+        libc::closedir(dirp);
+    }
+    result
+}
+
 impl Drop for TempPublishDir {
-    /// Recursively deletes `temp_dir` only after proving, via the fd `mkdir`
-    /// bound at creation, that the path still resolves to the same inode
-    /// this run actually created. `fs::remove_dir_all` is necessarily
-    /// path-based (POSIX has no "delete relative to this fd" call for a
-    /// whole subtree), so without this check an attacker who replaces
-    /// `temp_dir` with a directory or symlink after the last write (a
-    /// failed conversion, a panic mid-run) makes a bare `remove_dir_all`
-    /// recursively delete a directory this process never created. On
-    /// identity mismatch, the staging directory is deliberately leaked
-    /// rather than deleted — reported to stderr for manual cleanup.
+    /// Deletes the staging directory entirely through the fds `create()`
+    /// bound: contents are walked and unlinked via [`remove_dir_all_at`]
+    /// against `dir_fd` (bound to the inode `mkdir` actually created), then
+    /// the now-empty directory entry itself is removed via
+    /// `unlinkat(parent_fd, name, AT_REMOVEDIR)` — bound to `parent_fd`,
+    /// never a re-resolved full path. `AT_REMOVEDIR` only succeeds against
+    /// an empty directory, so even if the entry named `temp_dir`'s file name
+    /// was substituted for something else between the last write and this
+    /// call, the worst case is a failed (or no-op) removal, never a
+    /// recursive delete of attacker-supplied content: nothing this
+    /// function deletes is ever reached by re-resolving `temp_dir` as a
+    /// path.
     fn drop(&mut self) {
         let Some(temp_dir) = self.temp.take() else {
             return;
         };
-        let identity_confirmed = self.dir_fd.as_ref().is_some_and(|dir_fd| {
-            let mut fd_stat: libc::stat = unsafe { std::mem::zeroed() };
-            // SAFETY: `dir_fd` is a valid open fd held for the lifetime of
-            // `self`; `fd_stat` is a valid, fully-initialized (zeroed)
-            // `libc::stat`. `fstat` returns 0 on success or -1 with errno
-            // set, checked immediately below.
-            if unsafe { libc::fstat(dir_fd.as_raw_fd(), &raw mut fd_stat) } != 0 {
-                return false;
-            }
-            let Ok(path_meta) = fs::symlink_metadata(&temp_dir) else {
-                return false;
-            };
-            use std::os::unix::fs::MetadataExt;
-            path_meta.dev() == fd_stat.st_dev as u64 && path_meta.ino() == fd_stat.st_ino
-        });
-        if identity_confirmed {
-            let _ = fs::remove_dir_all(&temp_dir);
-        } else {
+        let (Some(dir_fd), Some(parent_fd)) = (self.dir_fd.take(), self.parent_fd.take()) else {
+            return;
+        };
+        if let Err(e) = remove_dir_all_at(dir_fd.as_raw_fd()) {
             eprintln!(
-                "quantize_q4: staging directory {} was replaced before cleanup \
-                 could run (inode identity check failed); leaving it in place \
-                 instead of recursively deleting a directory this run may not \
-                 have created — remove it manually if it is safe to do so",
+                "quantize_q4: failed to clean up contents of staging directory {} \
+                 (fd-relative walk): {e} — remove it manually if it is safe to do so",
                 temp_dir.display()
+            );
+            return;
+        }
+        drop(dir_fd);
+        let Ok(temp_name) = file_name_cstring(&temp_dir) else {
+            eprintln!(
+                "quantize_q4: staging directory {} has no file name; \
+                 its contents were removed but the directory entry itself \
+                 was left in place — remove it manually if it is safe to do so",
+                temp_dir.display()
+            );
+            return;
+        };
+        // SAFETY: `parent_fd` is a valid open fd owned by this call;
+        // `temp_name` is a valid NUL-terminated C string.
+        if unsafe {
+            libc::unlinkat(
+                parent_fd.as_raw_fd(),
+                temp_name.as_ptr(),
+                libc::AT_REMOVEDIR,
+            )
+        } != 0
+        {
+            eprintln!(
+                "quantize_q4: staging directory {} contents were removed but the \
+                 directory entry itself could not be (entry was substituted or \
+                 already gone): {} — remove it manually if it is safe to do so",
+                temp_dir.display(),
+                std::io::Error::last_os_error()
             );
         }
     }
@@ -550,8 +699,14 @@ fn quantize_model(
     let n_tensors = tensor_names.len();
 
     if !dry_run {
-        let model_dir_fd = open_dir_nofollow(model_dir)?;
-        let config_bytes = read_file_at_nofollow(model_dir_fd.as_raw_fd(), "config.json")
+        // Read through `reader`'s already-held model-directory fd — never a
+        // fresh `open_dir_nofollow(model_dir)` — so the checkpoint that was
+        // just validated above and the `config.json` read here resolve
+        // through the exact same directory fd. Reopening `model_dir` by
+        // path here would give an ancestor swap between the two opens a
+        // second window to substitute a different directory's config.json.
+        let config_bytes = reader
+            .read_file("config.json")
             .map_err(|e| format!("failed to read {}/config.json: {e}", model_dir.display()))?;
         let output_config = write_dir.join("config.json");
         let mut f = publish_dir.create_file("config.json")?;
@@ -809,7 +964,7 @@ mod tests {
         // `config.json` planted as a symlink to a file outside the model
         // directory — standing in for a hostile or concurrently-swapped
         // checkpoint trying to exfiltrate arbitrary readable bytes into the
-        // quantizer's output. Mutation-sensitive: reverting
+        // quantizer's output. reverting
         // `read_file_at_nofollow` to a path-based `fs::read` (which follows
         // the final symlink) makes this test fail — the secret contents
         // would be copied into the staging directory instead of the read
@@ -843,8 +998,8 @@ mod tests {
     // -----------------------------------------------------------------------
     // Atomic publish + refuse-non-empty-output-dir.
     //
-    // Mutation-sensitive: reverting `TempPublishDir` so writes land directly
-    // in `output_dir` (as before this fix) makes
+    // Reverting `TempPublishDir` so writes land directly
+    // in `output_dir` makes
     // `atomic_publish_leaves_output_dir_untouched_on_mid_conversion_failure`
     // fail (a partial `.q4`/`config.json` would appear in `output`), and
     // dropping the up-front `fs::read_dir` non-empty check makes both
@@ -953,6 +1108,56 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn publish_targets_original_parent_despite_a_parent_directory_swap() {
+        // `renameat(parent_fd, temp_name, parent_fd, output_name)` anchors
+        // both the source and destination name to the parent-directory fd
+        // `create()` opened — never a re-resolved `output_dir`/`temp_dir`
+        // full path. A `fs::rename(temp_dir, output_dir)` on reconstructed
+        // paths instead re-walks every ancestor of both paths at publish
+        // time, so swapping the shared parent directory between `create()`
+        // and `publish()` would redirect (or break) the final rename
+        // relative to the substituted parent. Reverting `publish()` to
+        // path-based `fs::rename` makes this test fail — the rename either
+        // errors (source path no longer resolves under the swapped parent)
+        // or lands under the wrong parent, instead of publishing under the
+        // parent whose fd was actually held.
+        let tmp = tempfile::tempdir().unwrap();
+        let real_parent = tmp.path().join("real_parent");
+        fs::create_dir(&real_parent).unwrap();
+        let output = real_parent.join("output");
+
+        let staging = super::TempPublishDir::create(&output, false).unwrap();
+        staging
+            .create_file("real.q4")
+            .unwrap()
+            .write_all(b"legit")
+            .unwrap();
+
+        // Swap the parent directory itself: move it aside (open fds stay
+        // bound to the original inode regardless) and plant a fresh, empty
+        // directory at the original parent path.
+        let moved_aside_parent = tmp.path().join("real_parent_moved_aside");
+        fs::rename(&real_parent, &moved_aside_parent).unwrap();
+        fs::create_dir(&real_parent).unwrap();
+
+        staging
+            .publish(Vec::new())
+            .expect("publish must succeed via the held parent fd despite the path-level swap");
+
+        assert_eq!(
+            fs::read_dir(&real_parent).unwrap().count(),
+            0,
+            "the substituted parent directory must receive no published output"
+        );
+        assert!(
+            moved_aside_parent.join("output").join("real.q4").exists(),
+            "the published output must land under the parent directory whose \
+             fd was bound at create() time, wherever it now lives"
+        );
+    }
+
+    #[test]
     fn quantize_model_refuses_preexisting_nonempty_output_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let input = tmp.path().join("input");
@@ -1010,7 +1215,7 @@ mod tests {
     // Fold: Drop-ordering — a failed `publish()` must leave the staging
     // handle in `self` so `Drop` can still clean it up.
     //
-    // Mutation-sensitive: reverting `publish()` to `.take()` `self.temp` (and
+    // reverting `publish()` to `.take()` `self.temp` (and
     // `self.dir_fd`) up front makes this test fail — the
     // staging directory would survive (leaked) after a failed rename,
     // because `Drop` would find `self.temp == None` and do nothing.
@@ -1061,7 +1266,7 @@ mod tests {
         // no-publish / early-error path) rather than `publish()`: the
         // staging path is replaced with a fresh, unrelated directory that
         // holds attacker-planted content, then the guard drops without
-        // calling `publish`. Mutation-sensitive: reverting `Drop` to a bare
+        // calling `publish`. Reverting `Drop` to a bare
         // `fs::remove_dir_all(temp_dir)` (no inode check against the held
         // `dir_fd`) makes this test fail — the substituted directory (and
         // the attacker's file inside it) would be recursively deleted even
@@ -1093,7 +1298,7 @@ mod tests {
     // -----------------------------------------------------------------------
     // fd-bind the staging directory (path race).
     //
-    // Mutation-sensitive: reverting `TempPublishDir::create_file` to a
+    // reverting `TempPublishDir::create_file` to a
     // the previous path-based `File::create(self.write_dir().join(filename))` makes `create_file_writes_land_in_original_dirfd_inode_not_a_
     // post_create_symlink_swap` fail — the write would follow the attacker's
     // symlink into `attacker_dir` instead of landing in the original staging
@@ -1152,7 +1357,7 @@ mod tests {
     // dry-run must validate f16 representability identically to
     // the real run.
     //
-    // Mutation-sensitive: hoisting the `encode_f16_payload` call back inside
+    // hoisting the `encode_f16_payload` call back inside
     // the `if !dry_run` block makes
     // `dry_run_rejects_f16_overflow_that_the_real_run_would_also_reject`
     // pass silently through dry-run (no error), diverging from the real-run
@@ -1193,7 +1398,7 @@ mod tests {
     // -----------------------------------------------------------------------
     // restore missing-parent-directory creation.
     //
-    // Mutation-sensitive: removing the `fs::create_dir_all(parent)` call
+    // removing the `fs::create_dir_all(parent)` call
     // added to `TempPublishDir::create` makes
     // `quantize_model_creates_missing_output_parent_directories` fail with
     // "failed to create staging directory" (no such file or directory),
@@ -1229,7 +1434,7 @@ mod tests {
     // -----------------------------------------------------------------------
     // MoE routed-expert tensors (issue #874 regression coverage).
     //
-    // Mutation-sensitive: these tensor names have no `.weight` suffix, so the
+    // these tensor names have no `.weight` suffix, so the
     // pre-fix gate (`if !name.ends_with(".weight") ... return false`) rejects
     // them before reaching any of the quantize-candidate checks. Reverting
     // the `.experts.gate_up_proj` / `.experts.down_proj` special-case added

--- a/crates/inference/src/bin/quantize_q4.rs
+++ b/crates/inference/src/bin/quantize_q4.rs
@@ -18,8 +18,8 @@ use lattice_inference::quant::quarot::convert::encode_f16_payload;
 use lattice_inference::weights::q4_weights::{Q4_BLOCK_BYTES, q4_file_bytes, quantize_f32_to_q4};
 use std::ffi::CString;
 use std::fs;
-use std::io::Write;
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -207,6 +207,42 @@ fn open_dir_nofollow(dir: &Path) -> Result<OwnedFd, Box<dyn std::error::Error>> 
     // non-negative, and is not owned or closed anywhere else — `OwnedFd`
     // becomes its sole owner and will close it on drop.
     Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+/// Read `name` (a plain file name) from the directory bound to `dirfd` via
+/// `openat(..., O_NOFOLLOW)`, never a path-based `fs::read`. `fs::read`
+/// follows a symlink at the final path component; a hostile or
+/// concurrently-swapped model directory could plant one at `config.json`
+/// pointing at an arbitrary readable file, which `fs::read` would then copy
+/// into the output directory.
+fn read_file_at_nofollow(dirfd: RawFd, name: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let cname = CString::new(name)
+        .map_err(|e| format!("file name {name} contains an interior NUL byte: {e}"))?;
+    // SAFETY: `dirfd` is a valid open directory fd borrowed for the
+    // duration of this call; `cname` is a valid NUL-terminated C string.
+    // `openat` returns either a valid fd (>= 0) or -1 with errno set,
+    // checked immediately below.
+    let raw = unsafe {
+        libc::openat(
+            dirfd,
+            cname.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return Err(format!(
+            "failed to open {name} (O_NOFOLLOW): {}",
+            std::io::Error::last_os_error()
+        )
+        .into());
+    }
+    // SAFETY: `raw` was just returned by `libc::openat` above, checked
+    // non-negative, and is not owned or closed anywhere else.
+    let mut file = unsafe { fs::File::from(OwnedFd::from_raw_fd(raw)) };
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)
+        .map_err(|e| format!("failed to read {name}: {e}"))?;
+    Ok(buf)
 }
 
 /// Publish directory for a conversion run: a fresh temp dir on success (`dry_run`
@@ -451,9 +487,45 @@ impl TempPublishDir {
 }
 
 impl Drop for TempPublishDir {
+    /// Recursively deletes `temp_dir` only after proving, via the fd `mkdir`
+    /// bound at creation, that the path still resolves to the same inode
+    /// this run actually created. `fs::remove_dir_all` is necessarily
+    /// path-based (POSIX has no "delete relative to this fd" call for a
+    /// whole subtree), so without this check an attacker who replaces
+    /// `temp_dir` with a directory or symlink after the last write (a
+    /// failed conversion, a panic mid-run) makes a bare `remove_dir_all`
+    /// recursively delete a directory this process never created. On
+    /// identity mismatch, the staging directory is deliberately leaked
+    /// rather than deleted — reported to stderr for manual cleanup.
     fn drop(&mut self) {
-        if let Some(temp_dir) = self.temp.take() {
-            let _ = fs::remove_dir_all(temp_dir);
+        let Some(temp_dir) = self.temp.take() else {
+            return;
+        };
+        let identity_confirmed = self.dir_fd.as_ref().is_some_and(|dir_fd| {
+            let mut fd_stat: libc::stat = unsafe { std::mem::zeroed() };
+            // SAFETY: `dir_fd` is a valid open fd held for the lifetime of
+            // `self`; `fd_stat` is a valid, fully-initialized (zeroed)
+            // `libc::stat`. `fstat` returns 0 on success or -1 with errno
+            // set, checked immediately below.
+            if unsafe { libc::fstat(dir_fd.as_raw_fd(), &raw mut fd_stat) } != 0 {
+                return false;
+            }
+            let Ok(path_meta) = fs::symlink_metadata(&temp_dir) else {
+                return false;
+            };
+            use std::os::unix::fs::MetadataExt;
+            path_meta.dev() == fd_stat.st_dev as u64 && path_meta.ino() == fd_stat.st_ino
+        });
+        if identity_confirmed {
+            let _ = fs::remove_dir_all(&temp_dir);
+        } else {
+            eprintln!(
+                "quantize_q4: staging directory {} was replaced before cleanup \
+                 could run (inode identity check failed); leaving it in place \
+                 instead of recursively deleting a directory this run may not \
+                 have created — remove it manually if it is safe to do so",
+                temp_dir.display()
+            );
         }
     }
 }
@@ -467,11 +539,21 @@ fn quantize_model(
     let write_dir = publish_dir.write_dir().to_path_buf();
     let mut written_files: Vec<(PathBuf, fs::File)> = Vec::new();
 
+    // Checkpoint validation (`QuarotTensorReader::open` parses and validates
+    // every SafeTensors header) runs BEFORE config.json is ever read or
+    // copied. Copying config.json first would let a hostile or
+    // concurrently-swapped model directory exfiltrate an arbitrary readable
+    // file into the output before the checkpoint is known to be valid.
+    let reader = QuarotTensorReader::open(model_dir)?;
+    let mut tensor_names = reader.tensor_names();
+    tensor_names.sort();
+    let n_tensors = tensor_names.len();
+
     if !dry_run {
-        let source_config = model_dir.join("config.json");
+        let model_dir_fd = open_dir_nofollow(model_dir)?;
+        let config_bytes = read_file_at_nofollow(model_dir_fd.as_raw_fd(), "config.json")
+            .map_err(|e| format!("failed to read {}/config.json: {e}", model_dir.display()))?;
         let output_config = write_dir.join("config.json");
-        let config_bytes = fs::read(&source_config)
-            .map_err(|e| format!("failed to read {}: {e}", source_config.display()))?;
         let mut f = publish_dir.create_file("config.json")?;
         f.write_all(&config_bytes).map_err(|e| {
             format!(
@@ -481,11 +563,6 @@ fn quantize_model(
         })?;
         written_files.push((output_config, f));
     }
-
-    let reader = QuarotTensorReader::open(model_dir)?;
-    let mut tensor_names = reader.tensor_names();
-    tensor_names.sort();
-    let n_tensors = tensor_names.len();
 
     eprintln!("=== quantize_q4: SafeTensors → Q4_0 ===");
     eprintln!("Model dir:  {}", model_dir.display());
@@ -726,6 +803,43 @@ mod tests {
         }
     }
 
+    #[test]
+    #[cfg(unix)]
+    fn config_json_symlink_is_rejected_not_followed() {
+        // `config.json` planted as a symlink to a file outside the model
+        // directory — standing in for a hostile or concurrently-swapped
+        // checkpoint trying to exfiltrate arbitrary readable bytes into the
+        // quantizer's output. Mutation-sensitive: reverting
+        // `read_file_at_nofollow` to a path-based `fs::read` (which follows
+        // the final symlink) makes this test fail — the secret contents
+        // would be copied into the staging directory instead of the read
+        // being refused.
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("input");
+        let output = tmp.path().join("output");
+        fs::create_dir(&input).unwrap();
+        write_single_f32_tensor(
+            &input.join("model.safetensors"),
+            "model.layers.0.input_layernorm.weight",
+            &[1.0, 2.0, 3.0],
+        );
+
+        let secret = tmp.path().join("secret.txt");
+        fs::write(&secret, b"do-not-exfiltrate").unwrap();
+        std::os::unix::fs::symlink(&secret, input.join("config.json")).unwrap();
+
+        let err = quantize_model(&input, &output, false)
+            .expect_err("a symlinked config.json must be refused, not followed");
+        assert!(
+            err.to_string().contains("config.json"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            !output.exists() || fs::read_dir(&output).unwrap().next().is_none(),
+            "no output artifact may exist after a refused config.json read"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Atomic publish + refuse-non-empty-output-dir.
     //
@@ -936,6 +1050,43 @@ mod tests {
             "a failed publish must not leak the staging directory — Drop must \
              still own cleanup because `self.temp`/`self.dir_fd` stayed \
              populated until the rename actually succeeded"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn drop_refuses_to_delete_a_staging_dir_substituted_with_a_different_directory() {
+        // Same substitution as `publish_refuses_staging_dir_substituted_
+        // with_different_directory`, but exercised through `Drop` (the
+        // no-publish / early-error path) rather than `publish()`: the
+        // staging path is replaced with a fresh, unrelated directory that
+        // holds attacker-planted content, then the guard drops without
+        // calling `publish`. Mutation-sensitive: reverting `Drop` to a bare
+        // `fs::remove_dir_all(temp_dir)` (no inode check against the held
+        // `dir_fd`) makes this test fail — the substituted directory (and
+        // the attacker's file inside it) would be recursively deleted even
+        // though this run never created it.
+        let tmp = tempfile::tempdir().unwrap();
+        let output = tmp.path().join("output");
+
+        let staging = super::TempPublishDir::create(&output, false).unwrap();
+        let temp_path = staging.write_dir().to_path_buf();
+
+        fs::remove_dir_all(&temp_path).unwrap();
+        fs::create_dir(&temp_path).unwrap();
+        let planted = temp_path.join("attacker-planted.txt");
+        fs::write(&planted, b"evil").unwrap();
+
+        drop(staging);
+
+        assert!(
+            temp_path.exists(),
+            "a substituted staging directory must be leaked, not deleted"
+        );
+        assert_eq!(
+            fs::read(&planted).unwrap(),
+            b"evil",
+            "the attacker's substituted directory contents must be untouched"
         );
     }
 

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -7,7 +7,7 @@
 //! writes the converted model to `output_dir`:
 //!
 //! - Planned (rotated) tensors → `<sanitized>.q4` via
-//!   [`save_q4_file`].
+//!   [`write_q4_tensor`] against an fd-bound exclusive no-follow file.
 //! - Other required weights (norms, `A_log`, `dt_bias`, `conv1d.weight`,
 //!   etc.) → `<sanitized>.f16` with a `KHF1` header matching
 //!   `bin/quantize_q4`'s convention.
@@ -45,7 +45,7 @@ use crate::quant::quarot::pipeline::{
 };
 use crate::quant::quarot::plan::RotationPlan;
 use crate::quant::quarot::rmsnorm_fusion::qwen35_per_layer_fusion_plan;
-use crate::weights::q4_weights::{q4_f32_to_f16, quantize_f64_to_q4, save_q4_file};
+use crate::weights::q4_weights::{create_output_file, quantize_f64_to_q4, write_q4_tensor};
 
 /// CLI / library options for [`convert_quarot_qwen35`].
 #[derive(Debug, Clone)]
@@ -273,9 +273,20 @@ fn write_mtp_weights_quarot(
         // Byte accounting uses the pure formula: same result as write_f16_file
         // would return, derived from shape and numel without any I/O.
         *total_bytes_out += f16_file_byte_count(data.len(), shape.len());
+        // Validate representability unconditionally: a
+        // dry run must reject exactly what the real write below would
+        // reject, not silently accept a value that later overflows f16.
+        let framed = encode_f16_payload(&file_name, name, &data, &shape)?;
         if !dry_run {
             let out_path = output_dir.join(&file_name);
-            write_f16_file(&out_path, &data, &shape)?;
+            create_output_file(&out_path)
+                .and_then(|mut f| f.write_all(&framed))
+                .map_err(|e| {
+                    InferenceError::Inference(format!(
+                        "write_mtp_weights_quarot: failed to write {}: {e}",
+                        out_path.display()
+                    ))
+                })?;
         }
         *kept_f16 += 1;
         index_entries.push(IndexEntry {
@@ -489,16 +500,25 @@ pub fn convert_quarot_qwen35(
             let header_bytes = (4 + 4 + 4 + 8 * entry.shape.len() + 8) as u64;
             let n_blocks = entry.data.len().div_ceil(32) as u64;
             total_bytes_out += header_bytes + n_blocks.saturating_mul(20);
+            // Validate Q4 representability unconditionally: quantize_f64_to_q4
+            // runs the same
+            // encode_finite_q4_metadata scale+bias underflow guard that the
+            // real write below depends on, so a dry run rejects exactly what
+            // the real run would reject (e.g. a constant block whose bias
+            // underflows to f16 zero) instead of only surfacing on the next
+            // real run. Only the file write is gated on `!opts.dry_run`.
+            let q4 = quantize_f64_to_q4(&entry.data, &entry.shape)?;
+            let file_name = format!("{sanitized}.q4");
             if !opts.dry_run {
-                let q4 = quantize_f64_to_q4(&entry.data, &entry.shape)?;
-                let file_name = format!("{sanitized}.q4");
                 let out_path = output_dir.join(&file_name);
-                save_q4_file(&out_path, &q4).map_err(|e| {
-                    InferenceError::Inference(format!(
-                        "convert_quarot_qwen35: failed to write {}: {e}",
-                        out_path.display()
-                    ))
-                })?;
+                create_output_file(&out_path)
+                    .and_then(|mut f| write_q4_tensor(&mut f, &q4))
+                    .map_err(|e| {
+                        InferenceError::Inference(format!(
+                            "convert_quarot_qwen35: failed to write {}: {e}",
+                            out_path.display()
+                        ))
+                    })?;
                 index_entries.push(IndexEntry {
                     name: name.clone(),
                     file: file_name,
@@ -511,10 +531,23 @@ pub fn convert_quarot_qwen35(
         } else {
             // f16 file footprint computed from shape and numel without writing.
             total_bytes_out += f16_file_byte_count(entry.data.len(), entry.shape.len());
+            let file_name = format!("{sanitized}.f16");
+            // Validate representability unconditionally:
+            // dry-run must reject exactly what the real write below would
+            // reject (e.g. a finite kept value that overflows f16 narrowing),
+            // not silently accept it and let the real run discover the
+            // rejection later.
+            let framed = encode_f16_payload(&file_name, name, &entry.data, &entry.shape)?;
             if !opts.dry_run {
-                let file_name = format!("{sanitized}.f16");
                 let out_path = output_dir.join(&file_name);
-                write_f16_file(&out_path, &entry.data, &entry.shape)?;
+                create_output_file(&out_path)
+                    .and_then(|mut f| f.write_all(&framed))
+                    .map_err(|e| {
+                        InferenceError::Inference(format!(
+                            "convert_quarot_qwen35: failed to write {}: {e}",
+                            out_path.display()
+                        ))
+                    })?;
                 index_entries.push(IndexEntry {
                     name: name.clone(),
                     file: file_name,
@@ -550,22 +583,26 @@ pub fn convert_quarot_qwen35(
                 "convert_quarot_qwen35: failed to serialize quantize_index.json: {e}"
             ))
         })?;
-        fs::write(&index_path, index_json).map_err(|e| {
-            InferenceError::Inference(format!(
-                "convert_quarot_qwen35: failed to write {}: {e}",
-                index_path.display()
-            ))
-        })?;
+        create_output_file(&index_path)
+            .and_then(|mut f| f.write_all(index_json.as_bytes()))
+            .map_err(|e| {
+                InferenceError::Inference(format!(
+                    "convert_quarot_qwen35: failed to write {}: {e}",
+                    index_path.display()
+                ))
+            })?;
 
         let mut output_config_json = untie_word_embeddings_in_config_json(&config_json)?;
         output_config_json = inject_quarot_seed(&output_config_json, opts.rotation_seed)?;
         let out_config_path = output_dir.join("config.json");
-        fs::write(&out_config_path, &output_config_json).map_err(|e| {
-            InferenceError::Inference(format!(
-                "convert_quarot_qwen35: failed to write {}: {e}",
-                out_config_path.display()
-            ))
-        })?;
+        create_output_file(&out_config_path)
+            .and_then(|mut f| f.write_all(output_config_json.as_bytes()))
+            .map_err(|e| {
+                InferenceError::Inference(format!(
+                    "convert_quarot_qwen35: failed to write {}: {e}",
+                    out_config_path.display()
+                ))
+            })?;
     }
 
     Ok(ConversionReport {
@@ -654,8 +691,8 @@ fn sanitize_tensor_name(name: &str) -> String {
         .collect()
 }
 
-/// Write a `KHF1`-headed `.f16` file matching the convention used by
-/// `bin/quantize_q4` for non-quantized weights.
+/// Validate and encode one tensor's `KHF1`-framed `.f16` payload entirely in
+/// memory, without touching the filesystem.
 ///
 /// Layout:
 /// ```text
@@ -667,56 +704,88 @@ fn sanitize_tensor_name(name: &str) -> String {
 ///   payload    = numel × u16 (IEEE-754 f16, little-endian)
 /// ```
 ///
-/// Returns the total number of bytes written. f64 → f16 goes through
-/// f32 to share the existing converter (rounding-aware) — sufficient
-/// for the runtime's f16 fast path.
-fn write_f16_file(path: &Path, data: &[f64], shape: &[usize]) -> Result<usize, InferenceError> {
-    let mut file = fs::File::create(path).map_err(|e| {
+/// [`write_f16_file`] (the real-write path) and every dry-run byte-accounting
+/// path call this same function, so a dry run rejects exactly what a real
+/// write would reject — a finite kept tensor that overflows f16 narrowing
+/// (e.g. `f32::MAX`) errors here regardless of `dry_run`, instead of only
+/// surfacing on the next real run (dry-run/real-run representability
+/// parity).
+///
+/// `source` labels the origin in error messages (a destination path for a
+/// real write, or a synthetic label — e.g. the tensor name — when called
+/// from a dry-run path with no output path yet). `tensor_name` is always the
+/// original source tensor name (not derived from `source`), so a validation
+/// failure traces back to the source tensor even when the output filename
+/// has been sanitized.
+///
+/// # Errors
+///
+/// Returns an error when the tensor shape is inconsistent, a value is
+/// non-finite before or after f16 encoding, or numel/shape overflow `usize`.
+pub fn encode_f16_payload(
+    source: &str,
+    tensor_name: &str,
+    data: &[f64],
+    shape: &[usize],
+) -> Result<Vec<u8>, InferenceError> {
+    let mut payload = Vec::new();
+    crate::weights::ingress::validate_ingested_tensor(
+        crate::weights::ingress::IngestedTensor::encode_f16(
+            source,
+            tensor_name,
+            shape,
+            data,
+            &mut payload,
+        ),
+    )?;
+
+    let mut framed = Vec::with_capacity(4 + 4 + 4 + 8 * shape.len() + 8 + payload.len());
+    framed.extend_from_slice(b"KHF1");
+    framed.extend_from_slice(&1u32.to_le_bytes());
+    framed.extend_from_slice(&(shape.len() as u32).to_le_bytes());
+    for &dim in shape {
+        framed.extend_from_slice(&(dim as u64).to_le_bytes());
+    }
+    framed.extend_from_slice(&(data.len() as u64).to_le_bytes());
+    framed.extend_from_slice(&payload);
+    Ok(framed)
+}
+
+/// Write a `KHF1`-headed `.f16` file matching the convention used by
+/// `bin/quantize_q4` for non-quantized weights.
+///
+/// Returns the total number of bytes written. Validation and f64 → f16
+/// conversion (via [`encode_f16_payload`]) finish before the destination is
+/// created, so an invalid tensor cannot appear as a completed output
+/// artifact.
+///
+/// # Errors
+///
+/// Returns an error when the tensor shape is inconsistent, a value is
+/// non-finite before or after f16 encoding, or the output cannot be written.
+pub fn write_f16_file(
+    path: &Path,
+    tensor_name: &str,
+    data: &[f64],
+    shape: &[usize],
+) -> Result<usize, InferenceError> {
+    let source = path.display().to_string();
+    let framed = encode_f16_payload(&source, tensor_name, data, shape)?;
+
+    let mut file = create_output_file(path).map_err(|e| {
         InferenceError::Inference(format!(
             "write_f16_file: failed to create {}: {e}",
             path.display()
         ))
     })?;
-    let mut bytes_written: usize = 0;
+    file.write_all(&framed).map_err(|e| {
+        InferenceError::Inference(format!(
+            "write_f16_file: write failure on {}: {e}",
+            path.display()
+        ))
+    })?;
 
-    let mut write_all = |buf: &[u8]| -> Result<(), InferenceError> {
-        file.write_all(buf).map_err(|e| {
-            InferenceError::Inference(format!(
-                "write_f16_file: write failure on {}: {e}",
-                path.display()
-            ))
-        })
-    };
-
-    write_all(b"KHF1")?;
-    bytes_written += 4;
-    write_all(&1u32.to_le_bytes())?;
-    bytes_written += 4;
-    write_all(&(shape.len() as u32).to_le_bytes())?;
-    bytes_written += 4;
-    for &dim in shape {
-        write_all(&(dim as u64).to_le_bytes())?;
-        bytes_written += 8;
-    }
-    write_all(&(data.len() as u64).to_le_bytes())?;
-    bytes_written += 8;
-
-    let mut payload = Vec::with_capacity(data.len() * 2);
-    for &v in data {
-        // Use the subnormal-aware helper from `weights::q4_weights`. The
-        // hand-rolled flush-to-zero variant in `bin/quantize_q4.rs`
-        // silently rounds f16-subnormal-but-f32-normal values
-        // (~1e-7 range) to zero — relevant here because every kept
-        // tensor (norms, A_log, dt_bias, conv1d, etc.) passes through
-        // this path. `q4_f32_to_f16` round-trips through the f16
-        // subnormal range correctly.
-        let h = q4_f32_to_f16(v as f32);
-        payload.extend_from_slice(&h.to_le_bytes());
-    }
-    write_all(&payload)?;
-    bytes_written += payload.len();
-
-    Ok(bytes_written)
+    Ok(framed.len())
 }
 
 #[cfg(test)]
@@ -911,6 +980,19 @@ mod tests {
 
     /// Write every required tensor for `cfg` to a single safetensors file.
     fn write_required_tensors_for(cfg: &Qwen35Config, path: &Path, seed: u64) {
+        write_required_tensors_for_with_override(cfg, path, seed, None);
+    }
+
+    /// Like [`write_required_tensors_for`], but replaces the data of the
+    /// tensor named `override_entry.0` with `override_entry.1` before
+    /// writing. Used to force a specific planned (rotated) tensor to a
+    /// controlled magnitude for representability-boundary tests.
+    fn write_required_tensors_for_with_override(
+        cfg: &Qwen35Config,
+        path: &Path,
+        seed: u64,
+        override_entry: Option<(&str, Vec<f64>)>,
+    ) {
         let hidden = cfg.hidden_size;
         let vocab = cfg.vocab_size;
         let intermediate = cfg.intermediate_size;
@@ -1057,6 +1139,19 @@ mod tests {
             ));
         }
 
+        if let Some((name, data)) = &override_entry {
+            let entry = entries
+                .iter_mut()
+                .find(|(n, _, _)| n == name)
+                .unwrap_or_else(|| panic!("override target tensor `{name}` not found in fixture"));
+            assert_eq!(
+                entry.2.len(),
+                data.len(),
+                "override data length must match fixture tensor `{name}`'s numel"
+            );
+            entry.2 = data.clone();
+        }
+
         let borrowed: Vec<(&str, Vec<usize>, &[f64])> = entries
             .iter()
             .map(|(n, s, d)| (n.as_str(), s.clone(), d.as_slice()))
@@ -1070,9 +1165,61 @@ mod tests {
         write_required_tensors_for(cfg, &dir.join("model.safetensors"), seed);
     }
 
+    /// Like [`write_input_dir`], but overrides one required tensor's data
+    /// before writing — see [`write_required_tensors_for_with_override`].
+    fn write_input_dir_with_override(
+        cfg: &Qwen35Config,
+        dir: &Path,
+        seed: u64,
+        override_entry: (&str, Vec<f64>),
+    ) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("config.json"), tiny_config_json(cfg)).unwrap();
+        write_required_tensors_for_with_override(
+            cfg,
+            &dir.join("model.safetensors"),
+            seed,
+            Some(override_entry),
+        );
+    }
+
     // ------------------------------------------------------------------
     // Happy path
     // ------------------------------------------------------------------
+
+    #[test]
+    #[cfg(unix)]
+    fn create_output_file_refuses_a_preexisting_symlink() {
+        // Every converter output write (`write_f16_file`, the Q4 write in
+        // `convert_quarot_qwen35`, `quantize_index.json`, `config.json`)
+        // routes through `create_output_file`. `validate_output_dir_layout`
+        // only checks emptiness at the very start of the run, but the real
+        // writes happen much later — after loading every tensor and running
+        // the forward-equivalence gate — so a concurrent actor has a wide
+        // window to plant a symlink at a fixed output filename pointing at
+        // an external victim file. Mutation-sensitive: reverting
+        // `create_output_file` to a plain `fs::File::create` makes this
+        // test fail — the victim file would be truncated instead of the
+        // open being refused.
+        let tmp = tempfile::tempdir().unwrap();
+        let victim = tmp.path().join("victim.txt");
+        fs::write(&victim, b"do-not-touch").unwrap();
+        let planted = tmp.path().join("config.json");
+        std::os::unix::fs::symlink(&victim, &planted).unwrap();
+
+        let err = create_output_file(&planted)
+            .expect_err("a pre-existing symlink at the output path must be refused");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::AlreadyExists,
+            "unexpected error kind: {err}"
+        );
+        assert_eq!(
+            fs::read(&victim).unwrap(),
+            b"do-not-touch",
+            "victim file reached through the planted symlink must be untouched"
+        );
+    }
 
     #[test]
     fn convert_quarot_qwen35_tied_end_to_end() {
@@ -1204,6 +1351,103 @@ mod tests {
             !output.exists(),
             "dry-run must not create the output directory"
         );
+    }
+
+    /// The Q4 quantized-tensor branch: the
+    /// real-write path (`quantize_f64_to_q4` → `create_output_file` +
+    /// `write_q4_tensor`) validates Q4
+    /// representability via `encode_finite_q4_metadata`'s two-sided
+    /// scale+bias underflow guard, but that call used to be gated behind
+    /// `if !opts.dry_run`, so dry-run silently skipped it. A planned tensor
+    /// whose post-rotation magnitude underflows Q4's symmetric-mode
+    /// scale/bias to f16 zero (B4's constant-block repro, scaled to a whole
+    /// tensor here since Hadamard rotation mixes every element along a
+    /// planned tensor's rotated axis) must be rejected identically in
+    /// dry-run and the real run.
+    ///
+    /// Mutation-sensitive: re-gating `quantize_f64_to_q4` behind `if
+    /// !opts.dry_run` (the pre-fix state) makes the `dry_run: true`
+    /// iteration of this test pass silently through validation, diverging
+    /// from the `dry_run: false` iteration's `Err`.
+    #[test]
+    fn dry_run_rejects_q4_bias_underflow_that_the_real_run_would_also_reject() {
+        let cfg = tiny_cfg(true);
+        let hidden = cfg.hidden_size;
+        let intermediate = cfg.intermediate_size;
+        let tensor_name = "model.language_model.layers.0.mlp.down_proj.weight";
+
+        for dry_run in [true, false] {
+            let tmp = tempfile::tempdir().unwrap();
+            let input = tmp.path().join("input");
+            let output = tmp.path().join("output");
+            // A uniformly tiny planned tensor: Hadamard rotation is
+            // orthogonal (norm-preserving) along the rotated axis, so a
+            // uniform 1e-9 input stays bounded within a small constant
+            // factor of 1e-9 after rotation — well under the ~5.96e-8 f16
+            // subnormal floor that `encode_finite_q4_metadata` guards
+            // (symmetric-mode scale = abs_max/7, bias = -8*scale; both
+            // derive from the same tiny abs_max and underflow together).
+            let tiny = vec![1e-9_f64; hidden * intermediate];
+            write_input_dir_with_override(&cfg, &input, 200, (tensor_name, tiny));
+
+            let err = convert_quarot_qwen35(
+                &input,
+                &output,
+                &ConversionOptions {
+                    rotation_seed: 0xC0FFEE,
+                    tolerance: 1e-5,
+                    num_probe_tokens: 2,
+                    dry_run,
+                },
+            )
+            .expect_err(&format!(
+                "a Q4 block whose scale/bias underflows to f16 zero must be rejected \
+                 (dry_run={dry_run})"
+            ));
+            assert!(
+                err.to_string().contains("underflows to f16 zero"),
+                "unexpected error (dry_run={dry_run}): {err}"
+            );
+            if dry_run {
+                // Dry-run performs no writes at all (`opts.dry_run` gates
+                // every `fs::create_dir_all`/write in the function), so the
+                // output directory must never come into existence.
+                assert!(
+                    !output.exists(),
+                    "a dry-run rejection must not create output_dir"
+                );
+            }
+            // For the real run, `output_dir` is created before the
+            // per-tensor loop runs (so earlier-sorted tensors can stream
+            // their writes), so a mid-loop rejection can leave it created
+            // (possibly holding earlier tensors' output) — that pre-existing
+            // real-run behavior is orthogonal to the dry-run/real-run
+            // representability *parity* this test guards, which is: both
+            // must reject the SAME input with the SAME error.
+        }
+
+        // A representable planned tensor passes both dry-run and the real run.
+        for dry_run in [true, false] {
+            let tmp = tempfile::tempdir().unwrap();
+            let input = tmp.path().join("input");
+            let output = tmp.path().join("output");
+            write_input_dir(&cfg, &input, 201);
+
+            let report = convert_quarot_qwen35(
+                &input,
+                &output,
+                &ConversionOptions {
+                    rotation_seed: 0xC0FFEE,
+                    tolerance: 1e-5,
+                    num_probe_tokens: 2,
+                    dry_run,
+                },
+            )
+            .unwrap_or_else(|e| {
+                panic!("representable tensor must be accepted (dry_run={dry_run}): {e}")
+            });
+            assert!(report.planned_quantized > 0);
+        }
     }
 
     /// Refuse-on-fail: tolerance set absurdly tight forces the gate to
@@ -1443,7 +1687,7 @@ mod tests {
         let p = tmp.path().join("test.f16");
         let data = vec![1.5_f64, -2.5, 0.25, -0.125];
         let shape = vec![2_usize, 2];
-        let bytes_written = write_f16_file(&p, &data, &shape).unwrap();
+        let bytes_written = write_f16_file(&p, "test-tensor", &data, &shape).unwrap();
         let raw = fs::read(&p).unwrap();
         assert_eq!(&raw[0..4], b"KHF1");
         assert_eq!(u32::from_le_bytes(raw[4..8].try_into().unwrap()), 1);
@@ -1456,30 +1700,45 @@ mod tests {
         assert_eq!(bytes_written, raw.len());
     }
 
-    /// Smoke check on `q4_f32_to_f16` (used by `write_f16_file`).
-    /// Includes an f16-subnormal regression, since fixed: the old local
-    /// helper flushed every value below f16's smallest
-    /// normal to zero, silently corrupting small-magnitude weights in
-    /// kept tensors (e.g., `A_log`, `dt_bias`, GDN `linear_attn.norm`).
     #[test]
-    fn q4_f32_to_f16_canonical_and_subnormal_values() {
-        assert_eq!(q4_f32_to_f16(0.0), 0x0000);
-        assert_eq!(q4_f32_to_f16(-0.0), 0x8000);
-        assert_eq!(q4_f32_to_f16(1.0), 0x3c00);
-        assert_eq!(q4_f32_to_f16(-1.0), 0xbc00);
-        assert_eq!(q4_f32_to_f16(f32::INFINITY), 0x7c00);
-        assert_eq!(q4_f32_to_f16(f32::NEG_INFINITY), 0xfc00);
-        // f16 smallest positive normal is 2^-14 ≈ 6.103515625e-5; values
-        // below that but above the f16 subnormal floor (2^-24) must NOT
-        // flush to zero — they should encode as f16 subnormals.
-        let h = q4_f32_to_f16(1e-7_f32);
-        assert_ne!(
-            h, 0,
-            "1e-7 (an f16 subnormal range value) must not flush to zero"
-        );
-        // f32 subnormals (well below f16's subnormal range) DO round to zero
-        // because there's no f16 representation for them.
-        assert_eq!(q4_f32_to_f16(1e-40_f32), 0);
+    fn f16_file_rejects_invalid_encoded_values_before_creation() {
+        for (case, value) in [
+            ("nan", f64::NAN),
+            ("positive-infinity", f64::INFINITY),
+            ("negative-infinity", f64::NEG_INFINITY),
+            ("finite-f16-overflow", f32::MAX as f64),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let path = tmp.path().join(format!("{case}.f16"));
+            let err = write_f16_file(&path, "test-tensor", &[value], &[1])
+                .expect_err("invalid f16 output must be rejected");
+            assert!(
+                err.to_string().contains("non-finite"),
+                "unexpected {case} error: {err}"
+            );
+            assert!(
+                !path.exists(),
+                "validation must finish before publishing {case} output"
+            );
+        }
+    }
+
+    /// The shared KHF1 encoder preserves signed zero and f16 subnormals.
+    #[test]
+    fn f16_file_preserves_signed_zero_and_subnormal_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("edge-values.f16");
+        write_f16_file(&path, "test-tensor", &[0.0, -0.0, 1e-7, 1e-40], &[4]).unwrap();
+        let raw = fs::read(path).unwrap();
+        let payload = &raw[28..];
+        let bits: Vec<u16> = payload
+            .chunks_exact(2)
+            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect();
+        assert_eq!(bits[0], 0x0000);
+        assert_eq!(bits[1], 0x8000);
+        assert_ne!(bits[2], 0, "f16 subnormal must not flush to zero");
+        assert_eq!(bits[3], 0);
     }
 
     /// f32_to_bf16_bits helper smoke check (used by the test fixture

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -1312,10 +1312,9 @@ mod tests {
         // writes happen much later — after loading every tensor and running
         // the forward-equivalence gate — so a concurrent actor has a wide
         // window to plant a symlink at a fixed output filename pointing at
-        // an external victim file. reverting
-        // `create_output_file` to a plain `fs::File::create` makes this
-        // test fail — the victim file would be truncated instead of the
-        // open being refused.
+        // an external victim file. `create_output_file` refuses to open a
+        // path that already resolves through a symlink, so the victim file
+        // is never truncated.
         let tmp = tempfile::tempdir().unwrap();
         let victim = tmp.path().join("victim.txt");
         fs::write(&victim, b"do-not-touch").unwrap();
@@ -1344,10 +1343,9 @@ mod tests {
         // by scanning the fd itself, that nothing was planted in the gap
         // between `create_dir_all` and `open_dir_nofollow` (a race, or a
         // plain-directory substitution that `O_NOFOLLOW` alone does not
-        // reject). Reverting the check to unconditionally report "empty"
-        // makes this test fail — planted content in the directory the fd
-        // is bound to would go undetected and the write session would
-        // proceed into it.
+        // reject). `dir_fd_is_nonempty` scans the fd's directory entries
+        // directly, so content planted in the directory the fd is bound to
+        // is detected regardless of how it got there.
         let tmp = tempfile::tempdir().unwrap();
         let empty_dir = tmp.path().join("empty");
         fs::create_dir(&empty_dir).unwrap();
@@ -1549,22 +1547,15 @@ mod tests {
         );
     }
 
-    /// The Q4 quantized-tensor branch: the
-    /// real-write path (`quantize_f64_to_q4` → `create_output_file` +
-    /// `write_q4_tensor`) validates Q4
-    /// representability via `encode_finite_q4_metadata`'s two-sided
-    /// scale+bias underflow guard, but that call used to be gated behind
-    /// `if !opts.dry_run`, so dry-run silently skipped it. A planned tensor
-    /// whose post-rotation magnitude underflows Q4's symmetric-mode
-    /// scale/bias to f16 zero (B4's constant-block repro, scaled to a whole
-    /// tensor here since Hadamard rotation mixes every element along a
-    /// planned tensor's rotated axis) must be rejected identically in
-    /// dry-run and the real run.
-    ///
-    /// re-gating `quantize_f64_to_q4` behind `if
-    /// !opts.dry_run` (the pre-fix state) makes the `dry_run: true`
-    /// iteration of this test pass silently through validation, diverging
-    /// from the `dry_run: false` iteration's `Err`.
+    /// The Q4 quantized-tensor branch: the real-write path
+    /// (`quantize_f64_to_q4` → `create_output_file` + `write_q4_tensor`)
+    /// validates Q4 representability via `encode_finite_q4_metadata`'s
+    /// two-sided scale+bias underflow guard, and dry-run runs the same
+    /// validation rather than skipping it. A planned tensor whose
+    /// post-rotation magnitude underflows Q4's symmetric-mode scale/bias to
+    /// f16 zero (a constant-block underflow, scaled to a whole tensor here
+    /// since Hadamard rotation mixes every element along a planned tensor's
+    /// rotated axis) is rejected identically in dry-run and the real run.
     #[test]
     fn dry_run_rejects_q4_bias_underflow_that_the_real_run_would_also_reject() {
         let cfg = tiny_cfg(true);
@@ -2741,10 +2732,10 @@ mod tests {
     fn read_quarot_seed_from_index_bare_array_is_none() {
         // `quantize_q4` (plain, non-rotated Q4 checkpoints) writes
         // `quantize_index.json` as a bare top-level tensor array, not the
-        // `{quarot_seed, tensors}` object `quantize_quarot` produces. This
-        // must be recognized as "no seed", not rejected as malformed —
-        // reverting the array-shape check makes serde misparse the first
-        // array element as the `quarot_seed: Option<u64>` field and error.
+        // `{quarot_seed, tensors}` object `quantize_quarot` produces. The
+        // array-shape check recognizes this as "no seed" before serde would
+        // otherwise try to parse the first array element as the
+        // `quarot_seed: Option<u64>` field and error.
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("quantize_index.json"),
@@ -2776,10 +2767,10 @@ mod tests {
     #[test]
     fn read_quarot_seed_from_index_rejects_malformed_json() {
         // #504 remaining slice 2: a *present* file that fails to parse must
-        // be a hard error, not a silent None — the pre-fix behavior treated
-        // corruption/truncation identically to "legitimately absent",
-        // which would silently apply the wrong (or no) QuaRot rotation to
-        // a checkpoint that actually needed one.
+        // be a hard error, not a silent None, so corruption/truncation is
+        // never treated identically to "legitimately absent" — that
+        // distinction matters because a silent None would apply the wrong
+        // (or no) QuaRot rotation to a checkpoint that actually needed one.
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("quantize_index.json"), "not json").unwrap();
         let err = read_quarot_seed_from_index(tmp.path())

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -26,6 +26,7 @@
 
 use std::fs;
 use std::io::Write;
+use std::os::fd::AsRawFd;
 use std::path::Path;
 
 use crate::error::InferenceError;
@@ -45,7 +46,9 @@ use crate::quant::quarot::pipeline::{
 };
 use crate::quant::quarot::plan::RotationPlan;
 use crate::quant::quarot::rmsnorm_fusion::qwen35_per_layer_fusion_plan;
-use crate::weights::q4_weights::{create_output_file, quantize_f64_to_q4, write_q4_tensor};
+use crate::weights::q4_weights::{
+    create_file_at, create_output_file, open_dir_nofollow, quantize_f64_to_q4, write_q4_tensor,
+};
 
 /// CLI / library options for [`convert_quarot_qwen35`].
 #[derive(Debug, Clone)]
@@ -230,6 +233,7 @@ fn f16_file_byte_count(data_len: usize, shape_len: usize) -> u64 {
 fn write_mtp_weights_quarot(
     reader: &QuarotTensorReader,
     output_dir: &Path,
+    output_dir_fd: Option<&std::os::fd::OwnedFd>,
     dry_run: bool,
     index_entries: &mut Vec<IndexEntry>,
     kept_f16: &mut usize,
@@ -278,13 +282,19 @@ fn write_mtp_weights_quarot(
         // reject, not silently accept a value that later overflows f16.
         let framed = encode_f16_payload(&file_name, name, &data, &shape)?;
         if !dry_run {
-            let out_path = output_dir.join(&file_name);
-            create_output_file(&out_path)
+            let dirfd = output_dir_fd.ok_or_else(|| {
+                InferenceError::Inference(
+                    "write_mtp_weights_quarot: missing output directory fd for a non-dry-run write"
+                        .to_string(),
+                )
+            })?;
+            create_file_at(dirfd.as_raw_fd(), &file_name)
                 .and_then(|mut f| f.write_all(&framed))
                 .map_err(|e| {
                     InferenceError::Inference(format!(
-                        "write_mtp_weights_quarot: failed to write {}: {e}",
-                        out_path.display()
+                        "write_mtp_weights_quarot: failed to write {} in {}: {e}",
+                        file_name,
+                        output_dir.display()
                     ))
                 })?;
         }
@@ -462,14 +472,26 @@ pub fn convert_quarot_qwen35(
         },
     )?;
 
-    if !opts.dry_run {
+    // Opened once, right after creation, and held for every write below:
+    // binding the whole write session to one fd means an ancestor or
+    // output-dir swap after this point cannot redirect any later write,
+    // unlike re-joining and reopening `output_dir` by path for each file.
+    let output_dir_fd = if !opts.dry_run {
         fs::create_dir_all(output_dir).map_err(|e| {
             InferenceError::Inference(format!(
                 "convert_quarot_qwen35: failed to create output directory {}: {e}",
                 output_dir.display()
             ))
         })?;
-    }
+        Some(open_dir_nofollow(output_dir).map_err(|e| {
+            InferenceError::Inference(format!(
+                "convert_quarot_qwen35: failed to open output directory {}: {e}",
+                output_dir.display()
+            ))
+        })?)
+    } else {
+        None
+    };
 
     let mut names: Vec<String> = working_set.keys().cloned().collect();
     names.sort();
@@ -510,13 +532,18 @@ pub fn convert_quarot_qwen35(
             let q4 = quantize_f64_to_q4(&entry.data, &entry.shape)?;
             let file_name = format!("{sanitized}.q4");
             if !opts.dry_run {
-                let out_path = output_dir.join(&file_name);
-                create_output_file(&out_path)
+                let dirfd = output_dir_fd.as_ref().ok_or_else(|| {
+                    InferenceError::Inference(
+                        "convert_quarot_qwen35: missing output directory fd for a non-dry-run write"
+                            .to_string(),
+                    )
+                })?;
+                create_file_at(dirfd.as_raw_fd(), &file_name)
                     .and_then(|mut f| write_q4_tensor(&mut f, &q4))
                     .map_err(|e| {
                         InferenceError::Inference(format!(
-                            "convert_quarot_qwen35: failed to write {}: {e}",
-                            out_path.display()
+                            "convert_quarot_qwen35: failed to write {file_name} in {}: {e}",
+                            output_dir.display()
                         ))
                     })?;
                 index_entries.push(IndexEntry {
@@ -539,13 +566,18 @@ pub fn convert_quarot_qwen35(
             // rejection later.
             let framed = encode_f16_payload(&file_name, name, &entry.data, &entry.shape)?;
             if !opts.dry_run {
-                let out_path = output_dir.join(&file_name);
-                create_output_file(&out_path)
+                let dirfd = output_dir_fd.as_ref().ok_or_else(|| {
+                    InferenceError::Inference(
+                        "convert_quarot_qwen35: missing output directory fd for a non-dry-run write"
+                            .to_string(),
+                    )
+                })?;
+                create_file_at(dirfd.as_raw_fd(), &file_name)
                     .and_then(|mut f| f.write_all(&framed))
                     .map_err(|e| {
                         InferenceError::Inference(format!(
-                            "convert_quarot_qwen35: failed to write {}: {e}",
-                            out_path.display()
+                            "convert_quarot_qwen35: failed to write {file_name} in {}: {e}",
+                            output_dir.display()
                         ))
                     })?;
                 index_entries.push(IndexEntry {
@@ -564,6 +596,7 @@ pub fn convert_quarot_qwen35(
         write_mtp_weights_quarot(
             &reader,
             output_dir,
+            output_dir_fd.as_ref(),
             opts.dry_run,
             &mut index_entries,
             &mut kept_f16,
@@ -573,7 +606,13 @@ pub fn convert_quarot_qwen35(
     }
 
     if !opts.dry_run {
-        let index_path = output_dir.join("quantize_index.json");
+        let dirfd = output_dir_fd.as_ref().ok_or_else(|| {
+            InferenceError::Inference(
+                "convert_quarot_qwen35: missing output directory fd for a non-dry-run write"
+                    .to_string(),
+            )
+        })?;
+
         let index_record = QuantizeIndex {
             quarot_seed: Some(opts.rotation_seed),
             tensors: index_entries,
@@ -583,24 +622,23 @@ pub fn convert_quarot_qwen35(
                 "convert_quarot_qwen35: failed to serialize quantize_index.json: {e}"
             ))
         })?;
-        create_output_file(&index_path)
+        create_file_at(dirfd.as_raw_fd(), "quantize_index.json")
             .and_then(|mut f| f.write_all(index_json.as_bytes()))
             .map_err(|e| {
                 InferenceError::Inference(format!(
-                    "convert_quarot_qwen35: failed to write {}: {e}",
-                    index_path.display()
+                    "convert_quarot_qwen35: failed to write quantize_index.json in {}: {e}",
+                    output_dir.display()
                 ))
             })?;
 
         let mut output_config_json = untie_word_embeddings_in_config_json(&config_json)?;
         output_config_json = inject_quarot_seed(&output_config_json, opts.rotation_seed)?;
-        let out_config_path = output_dir.join("config.json");
-        create_output_file(&out_config_path)
+        create_file_at(dirfd.as_raw_fd(), "config.json")
             .and_then(|mut f| f.write_all(output_config_json.as_bytes()))
             .map_err(|e| {
                 InferenceError::Inference(format!(
-                    "convert_quarot_qwen35: failed to write {}: {e}",
-                    out_config_path.display()
+                    "convert_quarot_qwen35: failed to write config.json in {}: {e}",
+                    output_dir.display()
                 ))
             })?;
     }
@@ -1751,12 +1789,12 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Path-layout refuses (review findings, Majors 1 + 2)
+    // Path-layout refuses
     // ------------------------------------------------------------------
 
-    /// Major 1: when input and output paths resolve to the same canonical
-    /// path, the converter must refuse before any write would corrupt
-    /// the source `config.json`.
+    /// When input and output paths resolve to the same canonical path, the
+    /// converter must refuse before any write would corrupt the source
+    /// `config.json`.
     #[test]
     fn convert_quarot_qwen35_rejects_same_input_output_dir() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1781,9 +1819,8 @@ mod tests {
         );
     }
 
-    /// Major 1 sibling: even when the two paths differ literally (e.g.,
-    /// trailing slash, symlink), canonicalization must still catch the
-    /// equivalence.
+    /// Even when the two paths differ literally (e.g., trailing slash,
+    /// symlink), canonicalization must still catch the equivalence.
     #[test]
     fn convert_quarot_qwen35_rejects_same_input_output_dir_via_trailing_slash() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1798,10 +1835,10 @@ mod tests {
         assert!(msg.contains("same path"), "unexpected error: {msg}");
     }
 
-    /// Major 2: a pre-existing non-empty output directory must trigger
-    /// refusal before any conversion work, so a previously-written `.q4`
-    /// artifact cannot survive a gate failure and be picked up by the
-    /// runtime loader.
+    /// A pre-existing non-empty output directory must trigger refusal
+    /// before any conversion work, so a previously-written `.q4` artifact
+    /// cannot survive a gate failure and be picked up by the runtime
+    /// loader.
     #[test]
     fn convert_quarot_qwen35_rejects_non_empty_output_dir() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -364,6 +364,15 @@ pub fn convert_quarot_qwen35(
     // happens, so the footguns cannot fire — callers may legitimately
     // dry-run against an existing populated output location or a
     // placeholder that happens to equal the input directory.
+    //
+    // This check is not the security boundary by itself: it is a plain path-based stat, re-resolved
+    // fresh and far in time from the directory fd this function actually
+    // writes through (acquired much later, right before the write loop,
+    // via `dir_fd_is_nonempty` below re-validating ON THE FD). A refused
+    // conversion (bad config, non-power-of-2 hidden size, MoE, or a
+    // forward-equivalence tolerance miss) must leave `output_dir`
+    // untouched, so the directory cannot be created until every one of
+    // those checks has already passed.
     if !opts.dry_run {
         validate_output_dir_layout(input_dir, output_dir)?;
     }
@@ -472,10 +481,16 @@ pub fn convert_quarot_qwen35(
         },
     )?;
 
-    // Opened once, right after creation, and held for every write below:
-    // binding the whole write session to one fd means an ancestor or
-    // output-dir swap after this point cannot redirect any later write,
-    // unlike re-joining and reopening `output_dir` by path for each file.
+    // The directory fd is acquired here — right before the write loop,
+    // with `dir_fd_is_nonempty` validating it immediately, back-to-back,
+    // with no intervening work — and held for every write below. The
+    // early `validate_output_dir_layout` call above is not the security
+    // boundary by itself (a path resolved there is not the path this
+    // `openat` resolves); the
+    // real security boundary is this fd plus the check on it: once held,
+    // nothing downstream may re-resolve `output_dir` as a path again, and
+    // `dir_fd_is_nonempty` proves — on the fd itself, not by re-reading
+    // the path — that nothing was planted between `mkdir` and `open`.
     let output_dir_fd = if !opts.dry_run {
         fs::create_dir_all(output_dir).map_err(|e| {
             InferenceError::Inference(format!(
@@ -483,12 +498,20 @@ pub fn convert_quarot_qwen35(
                 output_dir.display()
             ))
         })?;
-        Some(open_dir_nofollow(output_dir).map_err(|e| {
+        let fd = open_dir_nofollow(output_dir).map_err(|e| {
             InferenceError::Inference(format!(
                 "convert_quarot_qwen35: failed to open output directory {}: {e}",
                 output_dir.display()
             ))
-        })?)
+        })?;
+        if dir_fd_is_nonempty(fd.as_raw_fd())? {
+            return Err(InferenceError::Inference(format!(
+                "convert_quarot_qwen35: output directory {} became non-empty between \
+                 creation and opening its directory fd; refusing to write into it",
+                output_dir.display()
+            )));
+        }
+        Some(fd)
     } else {
         None
     };
@@ -715,6 +738,60 @@ fn validate_output_dir_layout(input_dir: &Path, output_dir: &Path) -> Result<(),
         )));
     }
     Ok(())
+}
+
+/// Whether the directory bound to `dirfd` contains any entry other than `.`
+/// / `..`, checked by scanning the fd itself (`fdopendir`/`readdir`) rather
+/// than re-reading the directory by path — the fd is the only thing an
+/// attacker cannot redirect once it is held.
+fn dir_fd_is_nonempty(dirfd: std::os::fd::RawFd) -> Result<bool, InferenceError> {
+    // SAFETY: `dirfd` is a valid, open, borrowed-for-this-call directory fd.
+    // `dup` returns either a new fd (>= 0, independent lifetime from
+    // `dirfd`) or -1 with errno set, checked immediately below.
+    let dup_fd = unsafe { libc::dup(dirfd) };
+    if dup_fd < 0 {
+        return Err(InferenceError::Io(std::io::Error::last_os_error()));
+    }
+    // SAFETY: `dup_fd` was just returned by `libc::dup` above, checked
+    // non-negative. `fdopendir` takes ownership of it on success; on
+    // failure `dup_fd` is still open and closed explicitly below.
+    let dirp = unsafe { libc::fdopendir(dup_fd) };
+    if dirp.is_null() {
+        let err = std::io::Error::last_os_error();
+        // SAFETY: `dup_fd` is still owned by us (fdopendir failed to take
+        // it) and open.
+        unsafe {
+            libc::close(dup_fd);
+        }
+        return Err(InferenceError::Io(err));
+    }
+    let mut found_entry = false;
+    loop {
+        // SAFETY: `dirp` is a valid, non-null `DIR*` for the duration of
+        // this loop, owned by this function and not shared with any other
+        // thread. `readdir` returns either a pointer into storage owned by
+        // `dirp` (valid until the next `readdir`/`closedir` call on `dirp`)
+        // or null at end-of-stream or on error; either null case is
+        // treated the same way here (stop scanning).
+        let entry = unsafe { libc::readdir(dirp) };
+        if entry.is_null() {
+            break;
+        }
+        // SAFETY: `entry` was just checked non-null above and points at a
+        // `dirent` owned by `dirp`, valid for this statement's duration.
+        // `d_name` is NUL-terminated per the `readdir` contract.
+        let name = unsafe { std::ffi::CStr::from_ptr((*entry).d_name.as_ptr()) };
+        if name.to_bytes() != b"." && name.to_bytes() != b".." {
+            found_entry = true;
+            break;
+        }
+    }
+    // SAFETY: `dirp` was returned non-null by `fdopendir` above and has not
+    // been closed anywhere else.
+    unsafe {
+        libc::closedir(dirp);
+    }
+    Ok(found_entry)
 }
 
 fn sanitize_tensor_name(name: &str) -> String {
@@ -1235,7 +1312,7 @@ mod tests {
         // writes happen much later — after loading every tensor and running
         // the forward-equivalence gate — so a concurrent actor has a wide
         // window to plant a symlink at a fixed output filename pointing at
-        // an external victim file. Mutation-sensitive: reverting
+        // an external victim file. reverting
         // `create_output_file` to a plain `fs::File::create` makes this
         // test fail — the victim file would be truncated instead of the
         // open being refused.
@@ -1257,6 +1334,87 @@ mod tests {
             b"do-not-touch",
             "victim file reached through the planted symlink must be untouched"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn dir_fd_is_nonempty_detects_content_planted_between_mkdir_and_open() {
+        // `convert_quarot_qwen35` treats a freshly `mkdir`'d output
+        // directory as safe to write into only after this check confirms,
+        // by scanning the fd itself, that nothing was planted in the gap
+        // between `create_dir_all` and `open_dir_nofollow` (a race, or a
+        // plain-directory substitution that `O_NOFOLLOW` alone does not
+        // reject). Reverting the check to unconditionally report "empty"
+        // makes this test fail — planted content in the directory the fd
+        // is bound to would go undetected and the write session would
+        // proceed into it.
+        let tmp = tempfile::tempdir().unwrap();
+        let empty_dir = tmp.path().join("empty");
+        fs::create_dir(&empty_dir).unwrap();
+        let fd = open_dir_nofollow(&empty_dir).unwrap();
+        assert!(!dir_fd_is_nonempty(fd.as_raw_fd()).unwrap());
+
+        let planted_dir = tmp.path().join("planted");
+        fs::create_dir(&planted_dir).unwrap();
+        fs::write(planted_dir.join("attacker.txt"), b"evil").unwrap();
+        let fd2 = open_dir_nofollow(&planted_dir).unwrap();
+        assert!(dir_fd_is_nonempty(fd2.as_raw_fd()).unwrap());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn convert_quarot_qwen35_output_dir_fd_survives_a_mid_run_directory_swap() {
+        // Every write goes through the ONE directory fd opened for this run
+        // — never a re-resolved `output_dir` path. A concurrent actor that
+        // replaces `output` with a fresh real directory (passing
+        // `O_NOFOLLOW`, which only rejects a symlink) after that fd was
+        // opened must not redirect any subsequent write into the
+        // substitute. A background thread swaps `output` for a fresh
+        // directory shortly after the run starts; artifacts must only ever
+        // appear in the directory whose fd was live at the moment each
+        // write happened — never in whatever directory currently occupies
+        // the `output` path.
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("input");
+        let output = tmp.path().join("output");
+        let cfg = tiny_cfg(true);
+        write_input_dir(&cfg, &input, 1);
+        fs::create_dir(&output).unwrap();
+
+        let moved_aside = tmp.path().join("output_original");
+        let output_for_thread = output.clone();
+        let moved_aside_for_thread = moved_aside.clone();
+        let swapper = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            std::fs::rename(&output_for_thread, &moved_aside_for_thread).unwrap();
+            std::fs::create_dir(&output_for_thread).unwrap();
+        });
+
+        let report = convert_quarot_qwen35(
+            &input,
+            &output,
+            &ConversionOptions {
+                rotation_seed: 0xC0FFEE,
+                tolerance: 1e-5,
+                num_probe_tokens: 2,
+                dry_run: false,
+            },
+        )
+        .unwrap();
+        swapper.join().unwrap();
+
+        assert_eq!(
+            fs::read_dir(&output).unwrap().count(),
+            0,
+            "the directory now occupying the original output path must receive no artifacts"
+        );
+        assert!(
+            moved_aside.join("quantize_index.json").exists(),
+            "artifacts must land in the directory whose fd was bound at run start, \
+             wherever it now lives, not whatever directory currently sits at the \
+             output path"
+        );
+        assert!(report.planned_quantized > 0);
     }
 
     #[test]
@@ -1403,7 +1561,7 @@ mod tests {
     /// planned tensor's rotated axis) must be rejected identically in
     /// dry-run and the real run.
     ///
-    /// Mutation-sensitive: re-gating `quantize_f64_to_q4` behind `if
+    /// re-gating `quantize_f64_to_q4` behind `if
     /// !opts.dry_run` (the pre-fix state) makes the `dry_run: true`
     /// iteration of this test pass silently through validation, diverging
     /// from the `dry_run: false` iteration's `Err`.

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -40,14 +40,45 @@
 //! [ADR-044]: ../../../../../docs/adr/ADR-044-quarot-rotated-quantization.md
 
 use std::collections::HashMap;
-use std::fs::File;
 use std::path::Path;
 
 use memmap2::Mmap;
 use serde_json::Value;
 
+use std::path::PathBuf;
+
 use crate::error::InferenceError;
 use crate::weights::f32_weights::parse_index;
+
+/// Resolve a manifest-declared shard filename against `model_root`, rejecting
+/// absolute paths and any resolution that escapes the model directory.
+///
+/// Mirrors `f32_weights::contain_manifest_path` from PR #1053 (not yet merged
+/// as of this writing) verbatim, so that once #1053 lands a follow-up rebase
+/// can drop this local copy and call the shared helper instead. Canonicalizing
+/// the candidate (rather than only the parent) is correct here because the
+/// shard file is expected to exist on disk at read time.
+pub(crate) fn contain_manifest_path(
+    model_root: &Path,
+    entry_name: &str,
+) -> Result<PathBuf, InferenceError> {
+    if Path::new(entry_name).is_absolute() {
+        return Err(InferenceError::Inference(format!(
+            "manifest entry {entry_name:?} must be a path relative to the model directory, not absolute"
+        )));
+    }
+    let candidate = model_root.join(entry_name);
+    let canon_root = model_root.canonicalize().map_err(InferenceError::Io)?;
+    let canon_candidate = candidate.canonicalize().map_err(InferenceError::Io)?;
+    if !canon_candidate.starts_with(&canon_root) {
+        return Err(InferenceError::Inference(format!(
+            "manifest entry {entry_name:?} escapes model root {} (resolved to {})",
+            model_root.display(),
+            canon_candidate.display()
+        )));
+    }
+    Ok(canon_candidate)
+}
 
 /// On-disk storage dtype of a tensor.
 ///
@@ -93,6 +124,7 @@ struct TensorHeader {
 
 #[derive(Debug)]
 struct Shard {
+    source: String,
     mmap: Mmap,
     /// Absolute file offset where the data section begins
     /// (`8 + header_len`).
@@ -162,10 +194,29 @@ fn safetensors_bits_per_elem(dtype_str: &str) -> Option<usize> {
 }
 
 impl Shard {
+    /// Open `path` for mmap, refusing to follow a symlink at the final path
+    /// component (`O_NOFOLLOW`).
+    ///
+    /// For manifest-referenced shards, `contain_manifest_path` validates
+    /// containment before this call, but that canonicalize-then-open
+    /// sequence is not atomic: an attacker could replace `path` with a
+    /// symlink pointing outside the model root after the check and before
+    /// this open. `O_NOFOLLOW` means that swap makes the open fail outright
+    /// (`ELOOP`) instead of silently following the symlink and mapping bytes
+    /// from outside the model directory, regardless of the timing of the
+    /// swap.
     fn open(path: &Path) -> Result<Self, InferenceError> {
-        let file = File::open(path).map_err(|e| {
-            InferenceError::InvalidSafetensors(format!("failed to open {}: {e}", path.display()))
-        })?;
+        use std::os::unix::fs::OpenOptionsExt;
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+            .map_err(|e| {
+                InferenceError::InvalidSafetensors(format!(
+                    "failed to open {}: {e}",
+                    path.display()
+                ))
+            })?;
         // SAFETY: the file is opened read-only; the returned Mmap owns the
         // mapping. The File handle can be dropped immediately after — the OS
         // keeps the fd alive through the map. Standard memmap2 usage.
@@ -381,6 +432,7 @@ impl Shard {
         }
 
         Ok(Shard {
+            source: path.display().to_string(),
             mmap,
             data_offset,
             headers,
@@ -478,7 +530,8 @@ impl QuarotTensorReader {
                 if shards.contains_key(shard_file) {
                     continue;
                 }
-                let shard = Shard::open(&model_dir.join(shard_file))?;
+                let shard_path = contain_manifest_path(model_dir, shard_file)?;
+                let shard = Shard::open(&shard_path)?;
                 shards.insert(shard_file.clone(), shard);
             }
             Ok(Self {
@@ -583,7 +636,7 @@ impl QuarotTensorReader {
             .ok_or_else(|| InferenceError::MissingTensor(name.to_string()))?
             .clone();
         let bytes = shard.tensor_bytes(name)?;
-        let data = decode_bytes_to_f64(bytes, header.dtype)?;
+        let data = decode_bytes_to_f64(&shard.source, name, bytes, header.dtype, &header.shape)?;
         Ok((data, header.shape))
     }
 
@@ -613,51 +666,31 @@ impl QuarotTensorReader {
     }
 }
 
-fn decode_bytes_to_f64(bytes: &[u8], dtype: SourceDType) -> Result<Vec<f64>, InferenceError> {
-    match dtype {
-        SourceDType::F32 => {
-            if !bytes.len().is_multiple_of(4) {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "F32 tensor byte length {} not divisible by 4",
-                    bytes.len()
-                )));
-            }
-            Ok(bytes
-                .chunks_exact(4)
-                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]) as f64)
-                .collect())
-        }
-        SourceDType::BF16 => {
-            if !bytes.len().is_multiple_of(2) {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "BF16 tensor byte length {} not divisible by 2",
-                    bytes.len()
-                )));
-            }
-            Ok(bytes
-                .chunks_exact(2)
-                .map(|b| {
-                    crate::weights::half_bits::bf16_bits_to_f32(u16::from_le_bytes([b[0], b[1]]))
-                        as f64
-                })
-                .collect())
-        }
-        SourceDType::F16 => {
-            if !bytes.len().is_multiple_of(2) {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "F16 tensor byte length {} not divisible by 2",
-                    bytes.len()
-                )));
-            }
-            Ok(bytes
-                .chunks_exact(2)
-                .map(|b| {
-                    crate::weights::half_bits::f16_bits_to_f32(u16::from_le_bytes([b[0], b[1]]))
-                        as f64
-                })
-                .collect())
-        }
-    }
+fn decode_bytes_to_f64(
+    source: &str,
+    tensor_name: &str,
+    bytes: &[u8],
+    dtype: SourceDType,
+    shape: &[usize],
+) -> Result<Vec<f64>, InferenceError> {
+    let raw_dtype = match dtype {
+        SourceDType::F32 => crate::weights::ingress::RawDType::F32,
+        SourceDType::F16 => crate::weights::ingress::RawDType::F16,
+        SourceDType::BF16 => crate::weights::ingress::RawDType::Bf16,
+    };
+    let mut values = Vec::new();
+    crate::weights::ingress::validate_ingested_tensor(
+        crate::weights::ingress::IngestedTensor::decode_f64(
+            source,
+            tensor_name,
+            shape,
+            dtype.name(),
+            bytes,
+            raw_dtype,
+            &mut values,
+        ),
+    )?;
+    Ok(values)
 }
 
 #[cfg(test)]
@@ -667,7 +700,7 @@ mod tests {
     use std::io::Write;
 
     /// On-disk dtype for synthetic test fixtures.
-    #[derive(Copy, Clone)]
+    #[derive(Debug, Copy, Clone)]
     enum FixtureDType {
         F32,
         F16,
@@ -840,6 +873,40 @@ mod tests {
     }
 
     #[test]
+    fn read_tensor_f64_rejects_non_finite_values_with_provenance() {
+        for dtype in [FixtureDType::F32, FixtureDType::F16, FixtureDType::BF16] {
+            for (case, bad) in [
+                ("nan", f32::NAN),
+                ("positive-infinity", f32::INFINITY),
+                ("negative-infinity", f32::NEG_INFINITY),
+            ] {
+                let dir = tempfile::tempdir().unwrap();
+                let path = dir.path().join("model.safetensors");
+                let values = [1.0, bad, 3.0];
+                write_safetensors(&path, &[("invalid.weight", dtype, vec![3], &values)]);
+
+                let reader = QuarotTensorReader::open(dir.path()).unwrap();
+                let err = reader
+                    .read_tensor_f64("invalid.weight")
+                    .expect_err("non-finite source value must be rejected");
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("invalid.weight"),
+                    "{case} {dtype:?} error must name the tensor: {msg}"
+                );
+                assert!(
+                    msg.contains(path.to_string_lossy().as_ref()),
+                    "{case} {dtype:?} error must name the source path: {msg}"
+                );
+                assert!(
+                    msg.contains("element index 1"),
+                    "{case} {dtype:?} error must locate the bad value: {msg}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn sharded_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let shard_a = "model-00001-of-00002.safetensors";
@@ -891,6 +958,105 @@ mod tests {
         // Re-reading the same tensor exercises the cached-shard path.
         let (a_again, _) = reader.read_tensor_f64("a.weight").unwrap();
         assert_eq!(a_again, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    // -------------------------------------------------------------------
+    // Shard-path containment (mirrors PR #1053's `contain_manifest_path`).
+    //
+    // Mutation-sensitive: with `contain_manifest_path` bypassed (shard join
+    // reverted to a bare `model_dir.join(shard_file)`), both tests below
+    // would instead succeed in opening the reader and reading the escaped
+    // tensor's real contents from outside the model directory.
+    // -------------------------------------------------------------------
+
+    #[test]
+    #[cfg(unix)]
+    fn shard_open_refuses_a_symlink() {
+        // `contain_manifest_path` canonicalizes (and thus resolves) any
+        // symlink present at call time, so a symlink planted before that
+        // check runs is already caught there. The gap this guards is a
+        // symlink planted *after* the containment check passes and *before*
+        // `Shard::open`'s `File::open` — not reproducible end-to-end in a
+        // single-threaded test, so this exercises `Shard::open` directly
+        // with a symlink standing in for that later swap.
+        //
+        // Mutation-sensitive: reverting `Shard::open` to a plain
+        // `File::open` (dropping `O_NOFOLLOW`) makes this test fail — the
+        // open would succeed and follow the symlink.
+        let root = tempfile::tempdir().unwrap();
+        let real = root.path().join("real.safetensors");
+        write_safetensors(
+            &real,
+            &[("secret.weight", FixtureDType::F32, vec![1], &[42.0])],
+        );
+        let link = root.path().join("linked.safetensors");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let err = Shard::open(&link).expect_err("Shard::open must refuse a symlink, not follow it");
+        assert!(
+            err.to_string().contains("failed to open"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn sharded_index_rejects_path_traversal_shard_entry() {
+        let root = tempfile::tempdir().unwrap();
+        let model_dir = root.path().join("model_root");
+        std::fs::create_dir(&model_dir).unwrap();
+
+        // A file OUTSIDE model_dir that a hostile index.json tries to reach.
+        write_safetensors(
+            &root.path().join("secret.safetensors"),
+            &[("secret.weight", FixtureDType::F32, vec![1], &[42.0])],
+        );
+
+        let index = serde_json::json!({
+            "metadata": {"total_size": 4usize},
+            "weight_map": {"secret.weight": "../secret.safetensors"},
+        });
+        std::fs::write(
+            model_dir.join("model.safetensors.index.json"),
+            serde_json::to_string(&index).unwrap(),
+        )
+        .unwrap();
+
+        let err = QuarotTensorReader::open(&model_dir)
+            .expect_err("a shard entry escaping model_dir via ../ must be rejected");
+        assert!(
+            err.to_string().contains("escapes model root"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn sharded_index_rejects_absolute_shard_entry() {
+        let root = tempfile::tempdir().unwrap();
+        let model_dir = root.path().join("model_root");
+        std::fs::create_dir(&model_dir).unwrap();
+
+        write_safetensors(
+            &root.path().join("secret.safetensors"),
+            &[("secret.weight", FixtureDType::F32, vec![1], &[42.0])],
+        );
+
+        let absolute_target = root.path().join("secret.safetensors");
+        let index = serde_json::json!({
+            "metadata": {"total_size": 4usize},
+            "weight_map": {"secret.weight": absolute_target.to_str().unwrap()},
+        });
+        std::fs::write(
+            model_dir.join("model.safetensors.index.json"),
+            serde_json::to_string(&index).unwrap(),
+        )
+        .unwrap();
+
+        let err = QuarotTensorReader::open(&model_dir)
+            .expect_err("an absolute shard entry must be rejected");
+        assert!(
+            err.to_string().contains("must be a path relative"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -1145,10 +1145,9 @@ mod tests {
     // after `QuarotTensorReader::open`'s initial `open_dir_nofollow` cannot
     // redirect any later read.
     //
-    // with `open_manifest_entry` bypassed (shard
-    // resolution reverted to a bare `model_dir.join(shard_file)` reopened by
-    // path), every test below would instead succeed in reading the escaped
-    // tensor's real contents from outside the model directory.
+    // `open_manifest_entry` is the only path any shard read goes through,
+    // so a shard entry that resolves outside the model directory is
+    // refused rather than opened by a reconstructed path.
     // -------------------------------------------------------------------
 
     #[test]
@@ -1156,9 +1155,8 @@ mod tests {
     fn shard_entry_rejects_a_symlinked_final_component() {
         // A symlink planted at the shard's final path component — standing
         // in for a swap that lands between the initial `open_dir_nofollow`
-        // and the later per-shard `openat`. dropping
-        // `O_NOFOLLOW` from `openat_file_nofollow` makes this test fail —
-        // the open would succeed and follow the symlink.
+        // and the later per-shard `openat`. `openat_file_nofollow` refuses
+        // to follow it.
         let root = tempfile::tempdir().unwrap();
         let model_dir = root.path().join("model_root");
         std::fs::create_dir(&model_dir).unwrap();
@@ -1186,11 +1184,9 @@ mod tests {
         // The shard entry's intermediate directory component ("subdir") is a
         // symlink to a directory outside model_root. `O_NOFOLLOW` only
         // protects the *final* path component in a plain `open`, so this
-        // guards the hop-by-hop `openat_dir_nofollow` walk specifically.
-        // dropping `O_NOFOLLOW` from
-        // `openat_dir_nofollow` makes this test fail — the walk would
-        // follow the symlink into the outside directory and read the
-        // escaped tensor.
+        // guards the hop-by-hop `openat_dir_nofollow` walk specifically:
+        // each hop refuses to follow a symlink, so the walk cannot escape
+        // into the outside directory and read the escaped tensor.
         let root = tempfile::tempdir().unwrap();
         let model_dir = root.path().join("model_root");
         std::fs::create_dir(&model_dir).unwrap();

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -40,44 +40,143 @@
 //! [ADR-044]: ../../../../../docs/adr/ADR-044-quarot-rotated-quantization.md
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::ffi::CString;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path};
 
 use memmap2::Mmap;
 use serde_json::Value;
 
-use std::path::PathBuf;
-
 use crate::error::InferenceError;
 use crate::weights::f32_weights::parse_index;
 
-/// Resolve a manifest-declared shard filename against `model_root`, rejecting
-/// absolute paths and any resolution that escapes the model directory.
+/// Open `path` as a directory fd, refusing to follow a symlink at the final
+/// component (`O_NOFOLLOW|O_DIRECTORY`). Held for the lifetime of a
+/// [`QuarotTensorReader`] and used as the sole anchor for every subsequent
+/// `openat` in this module — no path string derived from `path` is ever
+/// re-resolved after this call returns.
+fn open_dir_nofollow(path: &Path) -> Result<OwnedFd, InferenceError> {
+    let cpath = CString::new(path.as_os_str().as_bytes()).map_err(|e| {
+        InferenceError::Inference(format!("path {path:?} contains an interior NUL: {e}"))
+    })?;
+    // SAFETY: `cpath` is a valid NUL-terminated C string owned for the
+    // duration of this call. `open` returns either a valid fd (>= 0) or -1
+    // with errno set; the -1 case is checked immediately below.
+    let raw = unsafe {
+        libc::open(
+            cpath.as_ptr(),
+            libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return Err(InferenceError::Io(std::io::Error::last_os_error()));
+    }
+    // SAFETY: `raw` was just returned by `libc::open` above, checked
+    // non-negative, and is not owned or closed anywhere else.
+    Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+/// `openat(dirfd, name, O_DIRECTORY|O_NOFOLLOW)` — one traversal hop bound to
+/// an already-held directory fd rather than a re-resolved path.
+fn openat_dir_nofollow(dirfd: RawFd, name: &std::ffi::OsStr) -> Result<OwnedFd, InferenceError> {
+    let cname = CString::new(name.as_bytes()).map_err(|e| {
+        InferenceError::Inference(format!(
+            "path component {name:?} contains an interior NUL: {e}"
+        ))
+    })?;
+    // SAFETY: `dirfd` is a valid open directory fd borrowed for the duration
+    // of this call; `cname` is a valid NUL-terminated C string. `openat`
+    // returns either a valid fd (>= 0) or -1 with errno set, checked below.
+    let raw = unsafe {
+        libc::openat(
+            dirfd,
+            cname.as_ptr(),
+            libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return Err(InferenceError::Io(std::io::Error::last_os_error()));
+    }
+    // SAFETY: see `open_dir_nofollow`.
+    Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+/// `openat(dirfd, name, O_RDONLY|O_NOFOLLOW)` — open the final path
+/// component as a file bound to an already-held directory fd.
+fn openat_file_nofollow(
+    dirfd: RawFd,
+    name: &std::ffi::OsStr,
+) -> Result<std::fs::File, InferenceError> {
+    let cname = CString::new(name.as_bytes()).map_err(|e| {
+        InferenceError::Inference(format!(
+            "path component {name:?} contains an interior NUL: {e}"
+        ))
+    })?;
+    // SAFETY: see `openat_dir_nofollow`.
+    let raw = unsafe {
+        libc::openat(
+            dirfd,
+            cname.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return Err(InferenceError::Io(std::io::Error::last_os_error()));
+    }
+    // SAFETY: see `open_dir_nofollow`.
+    Ok(unsafe { std::fs::File::from(OwnedFd::from_raw_fd(raw)) })
+}
+
+/// Resolve a manifest-declared shard filename against a held `model_root`
+/// directory fd (`root_fd`) by walking every path component with its own
+/// `openat(..., O_NOFOLLOW)`, rather than canonicalizing the joined path and
+/// reopening it by string.
 ///
-/// Mirrors `f32_weights::contain_manifest_path` from PR #1053 (not yet merged
-/// as of this writing) verbatim, so that once #1053 lands a follow-up rebase
-/// can drop this local copy and call the shared helper instead. Canonicalizing
-/// the candidate (rather than only the parent) is correct here because the
-/// shard file is expected to exist on disk at read time.
-pub(crate) fn contain_manifest_path(
-    model_root: &Path,
+/// A canonicalize-then-open sequence is a snapshot: it stops being true the
+/// instant `canonicalize` returns, so an attacker who can replace an
+/// ancestor directory (or the model root itself) between the check and the
+/// later open can redirect a "contained" shard outside `model_root` even
+/// though the check passed. Walking component-by-component with `O_NOFOLLOW`
+/// on every hop makes containment a structural property of the traversal:
+/// each hop is bound to the fd opened for the *previous* hop, never to a
+/// re-resolved path string, and any component that is `..`, absolute, or a
+/// symlink is rejected outright.
+fn open_manifest_entry(
+    root_fd: &OwnedFd,
     entry_name: &str,
-) -> Result<PathBuf, InferenceError> {
-    if Path::new(entry_name).is_absolute() {
-        return Err(InferenceError::Inference(format!(
-            "manifest entry {entry_name:?} must be a path relative to the model directory, not absolute"
-        )));
+) -> Result<std::fs::File, InferenceError> {
+    let rel = Path::new(entry_name);
+    let mut components = Vec::new();
+    for component in rel.components() {
+        match component {
+            Component::Normal(part) => components.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(InferenceError::Inference(format!(
+                    "manifest entry {entry_name:?} must be a plain relative path with no `..` \
+                     or root component"
+                )));
+            }
+        }
     }
-    let candidate = model_root.join(entry_name);
-    let canon_root = model_root.canonicalize().map_err(InferenceError::Io)?;
-    let canon_candidate = candidate.canonicalize().map_err(InferenceError::Io)?;
-    if !canon_candidate.starts_with(&canon_root) {
+    let Some((&last, dirs)) = components.split_last() else {
         return Err(InferenceError::Inference(format!(
-            "manifest entry {entry_name:?} escapes model root {} (resolved to {})",
-            model_root.display(),
-            canon_candidate.display()
+            "manifest entry {entry_name:?} resolves to an empty path"
         )));
+    };
+
+    let mut held_dir: Option<OwnedFd> = None;
+    for name in dirs {
+        let base_fd = held_dir
+            .as_ref()
+            .map_or(root_fd.as_raw_fd(), AsRawFd::as_raw_fd);
+        held_dir = Some(openat_dir_nofollow(base_fd, name)?);
     }
-    Ok(canon_candidate)
+    let base_fd = held_dir
+        .as_ref()
+        .map_or(root_fd.as_raw_fd(), AsRawFd::as_raw_fd);
+    openat_file_nofollow(base_fd, last)
 }
 
 /// On-disk storage dtype of a tensor.
@@ -194,40 +293,28 @@ fn safetensors_bits_per_elem(dtype_str: &str) -> Option<usize> {
 }
 
 impl Shard {
-    /// Open `path` for mmap, refusing to follow a symlink at the final path
-    /// component (`O_NOFOLLOW`).
-    ///
-    /// For manifest-referenced shards, `contain_manifest_path` validates
-    /// containment before this call, but that canonicalize-then-open
-    /// sequence is not atomic: an attacker could replace `path` with a
-    /// symlink pointing outside the model root after the check and before
-    /// this open. `O_NOFOLLOW` means that swap makes the open fail outright
-    /// (`ELOOP`) instead of silently following the symlink and mapping bytes
-    /// from outside the model directory, regardless of the timing of the
-    /// swap.
-    fn open(path: &Path) -> Result<Self, InferenceError> {
-        use std::os::unix::fs::OpenOptionsExt;
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_NOFOLLOW)
-            .open(path)
-            .map_err(|e| {
-                InferenceError::InvalidSafetensors(format!(
-                    "failed to open {}: {e}",
-                    path.display()
-                ))
-            })?;
+    /// Wrap an already-opened `file` for mmap. `file` must have been opened
+    /// descriptor-relative to a trusted directory anchor (`open_dir_nofollow`
+    /// together with `openat_file_nofollow`, or `open_manifest_entry`) with
+    /// `O_NOFOLLOW` on every path component — never reopened by a full path
+    /// string, which would re-resolve ancestor components an attacker could
+    /// have swapped after an earlier containment check. `display_path` is
+    /// used only for error messages.
+    fn open(file: std::fs::File, display_path: &Path) -> Result<Self, InferenceError> {
         // SAFETY: the file is opened read-only; the returned Mmap owns the
         // mapping. The File handle can be dropped immediately after — the OS
         // keeps the fd alive through the map. Standard memmap2 usage.
         let mmap = unsafe { Mmap::map(&file) }.map_err(|e| {
-            InferenceError::InvalidSafetensors(format!("failed to mmap {}: {e}", path.display()))
+            InferenceError::InvalidSafetensors(format!(
+                "failed to mmap {}: {e}",
+                display_path.display()
+            ))
         })?;
 
         if mmap.len() < 8 {
             return Err(InferenceError::InvalidSafetensors(format!(
                 "{}: file too small to contain a safetensors header",
-                path.display()
+                display_path.display()
             )));
         }
 
@@ -241,7 +328,7 @@ impl Shard {
         if data_offset > mmap.len() {
             return Err(InferenceError::InvalidSafetensors(format!(
                 "{}: header extends past end of file (header_end={}, file_len={})",
-                path.display(),
+                display_path.display(),
                 data_offset,
                 mmap.len()
             )));
@@ -250,19 +337,19 @@ impl Shard {
         let header_str = std::str::from_utf8(&mmap[8..data_offset]).map_err(|e| {
             InferenceError::InvalidSafetensors(format!(
                 "{}: header is not valid UTF-8: {e}",
-                path.display()
+                display_path.display()
             ))
         })?;
         let root: Value = serde_json::from_str(header_str).map_err(|e| {
             InferenceError::InvalidSafetensors(format!(
                 "{}: header is not valid JSON: {e}",
-                path.display()
+                display_path.display()
             ))
         })?;
         let obj = root.as_object().ok_or_else(|| {
             InferenceError::InvalidSafetensors(format!(
                 "{}: header root is not a JSON object",
-                path.display()
+                display_path.display()
             ))
         })?;
 
@@ -405,7 +492,7 @@ impl Shard {
                 return Err(InferenceError::InvalidSafetensors(format!(
                     "{}: data_offsets non-contiguous at tensor {}: \
                      expected start={prev_end}, got [{}, {})",
-                    path.display(),
+                    display_path.display(),
                     p.name,
                     p.start,
                     p.end,
@@ -417,7 +504,7 @@ impl Shard {
             return Err(InferenceError::InvalidSafetensors(format!(
                 "{}: data section is {data_len} bytes but tensors cover {prev_end} bytes \
                  (trailing or missing payload)",
-                path.display(),
+                display_path.display(),
             )));
         }
 
@@ -432,7 +519,7 @@ impl Shard {
         }
 
         Ok(Shard {
-            source: path.display().to_string(),
+            source: display_path.display().to_string(),
             mmap,
             data_offset,
             headers,
@@ -515,37 +602,61 @@ impl QuarotTensorReader {
     /// forward-equivalence assertion would compare against a different
     /// model than the one Lattice actually serves from that directory.
     pub fn open(model_dir: &Path) -> Result<Self, InferenceError> {
-        let single_path = model_dir.join("model.safetensors");
-        let index_path = model_dir.join("model.safetensors.index.json");
-
-        if single_path.exists() {
-            let shard = Shard::open(&single_path)?;
-            Ok(Self {
-                backing: Backing::Single { shard },
-            })
-        } else if index_path.exists() {
-            let index = parse_index(model_dir)?;
-            let mut shards: HashMap<String, Shard> = HashMap::new();
-            for shard_file in index.weight_map.values() {
-                if shards.contains_key(shard_file) {
-                    continue;
-                }
-                let shard_path = contain_manifest_path(model_dir, shard_file)?;
-                let shard = Shard::open(&shard_path)?;
-                shards.insert(shard_file.clone(), shard);
-            }
-            Ok(Self {
-                backing: Backing::Sharded {
-                    weight_map: index.weight_map,
-                    shards,
-                },
-            })
-        } else {
-            Err(InferenceError::InvalidSafetensors(format!(
-                "{}: missing both model.safetensors and \
-                 model.safetensors.index.json",
+        // `model_dir` is opened exactly once and held as `root_fd` for the
+        // rest of this call. Every subsequent open (the single-file
+        // checkpoint, the index, and every shard) is `openat`-relative to
+        // this fd, so an ancestor swap after this line cannot redirect any
+        // later read — see `open_manifest_entry`.
+        let root_fd = open_dir_nofollow(model_dir).map_err(|e| {
+            InferenceError::InvalidSafetensors(format!(
+                "failed to open model directory {}: {e}",
                 model_dir.display()
-            )))
+            ))
+        })?;
+
+        match openat_file_nofollow(
+            root_fd.as_raw_fd(),
+            std::ffi::OsStr::new("model.safetensors"),
+        ) {
+            Ok(file) => {
+                let shard = Shard::open(file, &model_dir.join("model.safetensors"))?;
+                Ok(Self {
+                    backing: Backing::Single { shard },
+                })
+            }
+            Err(InferenceError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                openat_file_nofollow(
+                    root_fd.as_raw_fd(),
+                    std::ffi::OsStr::new("model.safetensors.index.json"),
+                )
+                .map_err(|_| {
+                    InferenceError::InvalidSafetensors(format!(
+                        "{}: missing both model.safetensors and \
+                         model.safetensors.index.json",
+                        model_dir.display()
+                    ))
+                })?;
+                let index = parse_index(model_dir)?;
+                let mut shards: HashMap<String, Shard> = HashMap::new();
+                for shard_file in index.weight_map.values() {
+                    if shards.contains_key(shard_file) {
+                        continue;
+                    }
+                    let file = open_manifest_entry(&root_fd, shard_file)?;
+                    let shard = Shard::open(file, &model_dir.join(shard_file))?;
+                    shards.insert(shard_file.clone(), shard);
+                }
+                Ok(Self {
+                    backing: Backing::Sharded {
+                        weight_map: index.weight_map,
+                        shards,
+                    },
+                })
+            }
+            Err(e) => Err(InferenceError::InvalidSafetensors(format!(
+                "failed to open {}: {e}",
+                model_dir.join("model.safetensors").display()
+            ))),
         }
     }
 
@@ -961,40 +1072,78 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
-    // Shard-path containment (mirrors PR #1053's `contain_manifest_path`).
+    // Shard-path containment via descriptor-relative traversal
+    // (`open_manifest_entry`). Containment is a structural property of the
+    // walk here, not a canonicalize-then-open string comparison: each hop
+    // opens relative to the fd from the previous hop, so an ancestor swap
+    // after `QuarotTensorReader::open`'s initial `open_dir_nofollow` cannot
+    // redirect any later read.
     //
-    // Mutation-sensitive: with `contain_manifest_path` bypassed (shard join
-    // reverted to a bare `model_dir.join(shard_file)`), both tests below
-    // would instead succeed in opening the reader and reading the escaped
+    // Mutation-sensitive: with `open_manifest_entry` bypassed (shard
+    // resolution reverted to a bare `model_dir.join(shard_file)` reopened by
+    // path), every test below would instead succeed in reading the escaped
     // tensor's real contents from outside the model directory.
     // -------------------------------------------------------------------
 
     #[test]
     #[cfg(unix)]
-    fn shard_open_refuses_a_symlink() {
-        // `contain_manifest_path` canonicalizes (and thus resolves) any
-        // symlink present at call time, so a symlink planted before that
-        // check runs is already caught there. The gap this guards is a
-        // symlink planted *after* the containment check passes and *before*
-        // `Shard::open`'s `File::open` — not reproducible end-to-end in a
-        // single-threaded test, so this exercises `Shard::open` directly
-        // with a symlink standing in for that later swap.
-        //
-        // Mutation-sensitive: reverting `Shard::open` to a plain
-        // `File::open` (dropping `O_NOFOLLOW`) makes this test fail — the
-        // open would succeed and follow the symlink.
+    fn shard_entry_rejects_a_symlinked_final_component() {
+        // A symlink planted at the shard's final path component — standing
+        // in for a swap that lands between the initial `open_dir_nofollow`
+        // and the later per-shard `openat`. Mutation-sensitive: dropping
+        // `O_NOFOLLOW` from `openat_file_nofollow` makes this test fail —
+        // the open would succeed and follow the symlink.
         let root = tempfile::tempdir().unwrap();
+        let model_dir = root.path().join("model_root");
+        std::fs::create_dir(&model_dir).unwrap();
+
         let real = root.path().join("real.safetensors");
         write_safetensors(
             &real,
             &[("secret.weight", FixtureDType::F32, vec![1], &[42.0])],
         );
-        let link = root.path().join("linked.safetensors");
+        let link = model_dir.join("linked.safetensors");
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
-        let err = Shard::open(&link).expect_err("Shard::open must refuse a symlink, not follow it");
+        let root_fd = open_dir_nofollow(&model_dir).unwrap();
+        let err = open_manifest_entry(&root_fd, "linked.safetensors")
+            .expect_err("a symlinked shard entry must be refused, not followed");
         assert!(
-            err.to_string().contains("failed to open"),
+            matches!(err, InferenceError::Io(_)),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn shard_entry_rejects_a_symlinked_intermediate_directory() {
+        // The shard entry's intermediate directory component ("subdir") is a
+        // symlink to a directory outside model_root. `O_NOFOLLOW` only
+        // protects the *final* path component in a plain `open`, so this
+        // guards the hop-by-hop `openat_dir_nofollow` walk specifically.
+        // Mutation-sensitive: dropping `O_NOFOLLOW` from
+        // `openat_dir_nofollow` makes this test fail — the walk would
+        // follow the symlink into the outside directory and read the
+        // escaped tensor.
+        let root = tempfile::tempdir().unwrap();
+        let model_dir = root.path().join("model_root");
+        std::fs::create_dir(&model_dir).unwrap();
+
+        let outside_dir = root.path().join("outside");
+        std::fs::create_dir(&outside_dir).unwrap();
+        write_safetensors(
+            &outside_dir.join("shard.safetensors"),
+            &[("secret.weight", FixtureDType::F32, vec![1], &[42.0])],
+        );
+
+        let subdir_link = model_dir.join("subdir");
+        std::os::unix::fs::symlink(&outside_dir, &subdir_link).unwrap();
+
+        let root_fd = open_dir_nofollow(&model_dir).unwrap();
+        let err = open_manifest_entry(&root_fd, "subdir/shard.safetensors")
+            .expect_err("a symlinked intermediate directory must be refused");
+        assert!(
+            matches!(err, InferenceError::Io(_)),
             "unexpected error: {err}"
         );
     }
@@ -1024,7 +1173,7 @@ mod tests {
         let err = QuarotTensorReader::open(&model_dir)
             .expect_err("a shard entry escaping model_dir via ../ must be rejected");
         assert!(
-            err.to_string().contains("escapes model root"),
+            err.to_string().contains("no `..` or root component"),
             "unexpected error: {err}"
         );
     }
@@ -1054,7 +1203,7 @@ mod tests {
         let err = QuarotTensorReader::open(&model_dir)
             .expect_err("an absolute shard entry must be rejected");
         assert!(
-            err.to_string().contains("must be a path relative"),
+            err.to_string().contains("no `..` or root component"),
             "unexpected error: {err}"
         );
     }

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -584,6 +584,14 @@ impl Backing {
 #[derive(Debug)]
 pub struct QuarotTensorReader {
     backing: Backing,
+    /// The model-directory fd opened once at [`QuarotTensorReader::open`]
+    /// and held for the reader's lifetime. [`QuarotTensorReader::read_file`]
+    /// resolves every name against this fd — a caller that already went
+    /// through `open()` to validate the checkpoint must never reopen the
+    /// model directory by path afterward to read a sibling file (e.g.
+    /// `config.json`): that second path resolution is a fresh TOCTOU window
+    /// an ancestor swap between the two opens can exploit.
+    root_fd: std::os::fd::OwnedFd,
 }
 
 impl QuarotTensorReader {
@@ -622,6 +630,7 @@ impl QuarotTensorReader {
                 let shard = Shard::open(file, &model_dir.join("model.safetensors"))?;
                 Ok(Self {
                     backing: Backing::Single { shard },
+                    root_fd,
                 })
             }
             Err(InferenceError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -651,6 +660,7 @@ impl QuarotTensorReader {
                         weight_map: index.weight_map,
                         shards,
                     },
+                    root_fd,
                 })
             }
             Err(e) => Err(InferenceError::InvalidSafetensors(format!(
@@ -658,6 +668,24 @@ impl QuarotTensorReader {
                 model_dir.join("model.safetensors").display()
             ))),
         }
+    }
+
+    /// Read `name` (a plain file name, no separators — e.g. `config.json`)
+    /// from the model directory this reader was opened against, via
+    /// `openat` against the held `root_fd`.
+    ///
+    /// A caller that has already validated the checkpoint through
+    /// [`QuarotTensorReader::open`] must read any other file from the same
+    /// model directory (such as `config.json`) through this method rather
+    /// than reopening the directory by path — a fresh path resolution is a
+    /// new TOCTOU window an ancestor swap between the two opens can use to
+    /// substitute a different directory for the second read.
+    pub fn read_file(&self, name: &str) -> Result<Vec<u8>, InferenceError> {
+        use std::io::Read;
+        let mut file = openat_file_nofollow(self.root_fd.as_raw_fd(), std::ffi::OsStr::new(name))?;
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).map_err(InferenceError::Io)?;
+        Ok(buf)
     }
 
     /// All readable supported tensor names.
@@ -807,6 +835,7 @@ fn decode_bytes_to_f64(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::fs::File;
     use std::io::Write;
 
@@ -941,6 +970,43 @@ mod tests {
         for (g, &v) in got.iter().zip(values.iter()) {
             assert_eq!(*g, v as f64);
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn read_file_uses_the_fd_open_already_bound_not_a_fresh_path_resolution() {
+        // A caller that reads a sibling file (e.g. `config.json`) after
+        // `open()` has already validated the checkpoint must never
+        // re-resolve the model directory by path to do it — that second
+        // resolution is a fresh window an ancestor swap between the two
+        // opens can use to substitute a different directory's file.
+        // `read_file` instead resolves `name` against the same `root_fd`
+        // `open()` already holds. Swap the model directory for a different
+        // one (same path, fresh content) after `open()` returns, then
+        // confirm `read_file` still reaches the ORIGINAL directory's file,
+        // not the substituted one.
+        let dir = tempfile::tempdir().unwrap();
+        let model_dir = dir.path().join("model");
+        fs::create_dir(&model_dir).unwrap();
+        fs::write(model_dir.join("config.json"), b"REAL-CONFIG").unwrap();
+        write_safetensors(
+            &model_dir.join("model.safetensors"),
+            &[("w", FixtureDType::F32, vec![1], &[1.0])],
+        );
+
+        let reader = QuarotTensorReader::open(&model_dir).unwrap();
+
+        let moved_aside = dir.path().join("model_moved_aside");
+        fs::rename(&model_dir, &moved_aside).unwrap();
+        fs::create_dir(&model_dir).unwrap();
+        fs::write(model_dir.join("config.json"), b"FAKE-CONFIG").unwrap();
+
+        let bytes = reader.read_file("config.json").unwrap();
+        assert_eq!(
+            bytes, b"REAL-CONFIG",
+            "read_file must reach the directory validated at open(), not \
+             whatever directory currently occupies the model_dir path"
+        );
     }
 
     #[test]
@@ -1079,7 +1145,7 @@ mod tests {
     // after `QuarotTensorReader::open`'s initial `open_dir_nofollow` cannot
     // redirect any later read.
     //
-    // Mutation-sensitive: with `open_manifest_entry` bypassed (shard
+    // with `open_manifest_entry` bypassed (shard
     // resolution reverted to a bare `model_dir.join(shard_file)` reopened by
     // path), every test below would instead succeed in reading the escaped
     // tensor's real contents from outside the model directory.
@@ -1090,7 +1156,7 @@ mod tests {
     fn shard_entry_rejects_a_symlinked_final_component() {
         // A symlink planted at the shard's final path component — standing
         // in for a swap that lands between the initial `open_dir_nofollow`
-        // and the later per-shard `openat`. Mutation-sensitive: dropping
+        // and the later per-shard `openat`. dropping
         // `O_NOFOLLOW` from `openat_file_nofollow` makes this test fail —
         // the open would succeed and follow the symlink.
         let root = tempfile::tempdir().unwrap();
@@ -1121,7 +1187,7 @@ mod tests {
         // symlink to a directory outside model_root. `O_NOFOLLOW` only
         // protects the *final* path component in a plain `open`, so this
         // guards the hop-by-hop `openat_dir_nofollow` walk specifically.
-        // Mutation-sensitive: dropping `O_NOFOLLOW` from
+        // dropping `O_NOFOLLOW` from
         // `openat_dir_nofollow` makes this test fail — the walk would
         // follow the symlink into the outside directory and read the
         // escaped tensor.

--- a/crates/inference/src/weights/half_bits.rs
+++ b/crates/inference/src/weights/half_bits.rs
@@ -144,6 +144,18 @@ pub(crate) fn f32_to_f16_bits(v: f32) -> u16 {
     sign | frac16
 }
 
+/// Test whether an IEEE-754 binary16 (f16) bit pattern encodes a finite
+/// value (not infinity, not NaN), without widening to `f32`.
+///
+/// An f16 bit pattern is infinity or NaN exactly when its 5-bit exponent
+/// field (bits 10..15) is all-ones (`0x1f`); every other exponent value is
+/// finite (zero, subnormal, or normal). Checking the exponent field directly
+/// avoids a widen-then-`is_finite()` round trip through `f32`.
+#[inline]
+pub(crate) fn f16_bits_is_finite(bits: u16) -> bool {
+    ((bits >> 10) & 0x1f) != 0x1f
+}
+
 /// Widen a bfloat16 bit pattern to `f32`.
 ///
 /// BF16 shares f32's sign+exponent layout truncated to a 7-bit mantissa, so
@@ -448,6 +460,18 @@ mod tests {
         assert_eq!(bf16_bits_to_f32(0x7f80), f32::INFINITY);
         assert_eq!(bf16_bits_to_f32(0xff80), f32::NEG_INFINITY);
         assert!(bf16_bits_to_f32(0x7fc0).is_nan());
+    }
+
+    #[test]
+    fn f16_bits_is_finite_matches_widen_is_finite_across_full_space() {
+        for bits in 0u32..=0xffff {
+            let bits = bits as u16;
+            assert_eq!(
+                f16_bits_is_finite(bits),
+                f16_bits_to_f32(bits).is_finite(),
+                "f16_bits_is_finite({bits:#06x}) diverges from widen-then-is_finite"
+            );
+        }
     }
 
     #[test]

--- a/crates/inference/src/weights/half_bits.rs
+++ b/crates/inference/src/weights/half_bits.rs
@@ -199,10 +199,8 @@ mod tests {
         // NOT prove either function matches IEEE-754 or an external decoder,
         // because both sides of the comparison come from this module. A
         // decode bug that is exactly undone by a matching encode bug (or
-        // vice versa) passes this test silently: a wrong infinity decode
-        // constant and ties-away-from-zero rounding were both injected as
-        // test mutations and left this test green. Independent
-        // verification against a third-party decoder lives in
+        // vice versa) passes this test silently. Independent verification
+        // against a third-party decoder lives in
         // `f16_bits_to_f32_matches_independent_half_crate_oracle` and
         // `f16_bits_to_f32_signaling_nan_is_lossless_widen_independent_of_decoder`
         // below; do not treat this test alone as a correctness guarantee.

--- a/crates/inference/src/weights/ingress.rs
+++ b/crates/inference/src/weights/ingress.rs
@@ -350,11 +350,9 @@ mod tests {
         assert!(err.to_string().contains("does not match"));
     }
 
-    /// Mutation sensitivity: with the `!v.is_finite()` scan removed (or
-    /// replaced by an always-`Ok` stub), this test's NaN input would pass
-    /// validation. Verified by temporarily deleting the scan and confirming
-    /// `rejects_nan` above goes red before restoring it (see PR description
-    /// for the revert/touch/restore cycle).
+    /// The finiteness scan checks every element, not just the first — a
+    /// NaN placed at the last index of a 64-element tensor is still caught
+    /// and reported at its actual index.
     #[test]
     fn all_of_a_finite_tensor_is_scanned_not_just_the_first_element() {
         let mut values = vec![1.0f32; 64];

--- a/crates/inference/src/weights/ingress.rs
+++ b/crates/inference/src/weights/ingress.rs
@@ -9,28 +9,43 @@
 //! route through immediately before a tensor view escapes to a caller, so
 //! the same class of gap cannot silently reopen at the next loader.
 //!
-//! Scope note: this issue wires up the "decoded F32" payload form only —
-//! safetensors F32/F16/BF16 all normalize to `f32` by the time they reach
-//! this seam (`SafetensorsFile::get_f32_tensor` widens F16/BF16 before
-//! returning). The other payload forms named in lattice#800 — raw
-//! safetensors F32/F16/BF16 bytes, decoded F64, native Q4 blocks/bytes, and
-//! Q8 data+scales — are added by the companion issues in this cluster
-//! (QuaRot/offline-quantizer routing, native Q4/KHF1 validation
-//! unification, Q8 routing) as those loaders start calling into this seam.
+//! Safetensors runtime loads arrive as decoded `f32` slices. QuaRot reads
+//! arrive as raw F32/F16/BF16 bytes and are decoded directly into their
+//! one-tensor `Vec<f64>` here, so finiteness is checked during the existing
+//! materialization pass. KHF1 output uses the same seam while narrowing to
+//! f16, which prevents a finite source value that overflows f16 from being
+//! published as non-finite output.
 
 use crate::error::InferenceError;
 
 /// Sealed carrier for one tensor's ingested payload plus its provenance.
 ///
-/// Construction only happens through [`IngestedTensor::decoded_f32`], so a
-/// call site cannot fabricate an already-"validated" value and skip
-/// [`validate_ingested_tensor`].
+/// Construction happens through [`IngestedTensor::decoded_f32`] (already
+/// f32-widened data), [`IngestedTensor::decode_f64`] (raw on-disk bytes
+/// decoded to f64), or [`IngestedTensor::encode_f16`] (f64 encoded down to
+/// f16 output bytes) — a call site cannot fabricate an already-"validated"
+/// value and skip [`validate_ingested_tensor`].
 #[derive(Debug)]
 pub(crate) struct IngestedTensor<'a> {
     source: &'a str,
     tensor_name: &'a str,
     shape: &'a [usize],
     payload: IngestPayload<'a>,
+}
+
+/// On-disk raw float dtype for [`IngestedTensor::decode_f64`].
+///
+/// Matched exactly once per call in [`validate_ingested_tensor`], which then
+/// runs a per-dtype tight decode loop with the conversion inlined at the
+/// call site. The previous design stored a `fn(&[u8]) -> f64` pointer
+/// selected by a match and invoked it per element; release LLVM IR showed
+/// that lowering to a per-element indirect `tail call`, defeating inlining
+/// for a hot per-tensor loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RawDType {
+    F32,
+    F16,
+    Bf16,
 }
 
 #[derive(Debug)]
@@ -41,6 +56,16 @@ enum IngestPayload<'a> {
     DecodedF32 {
         values: &'a [f32],
         dtype_label: &'static str,
+    },
+    DecodeF64 {
+        bytes: &'a [u8],
+        dtype: RawDType,
+        values: &'a mut Vec<f64>,
+        dtype_label: &'static str,
+    },
+    EncodeF16 {
+        values: &'a [f64],
+        bytes: &'a mut Vec<u8>,
     },
 }
 
@@ -63,13 +88,53 @@ impl<'a> IngestedTensor<'a> {
             },
         }
     }
+
+    /// Wrap raw floating-point bytes for checked one-pass f64 decoding.
+    pub(crate) fn decode_f64(
+        source: &'a str,
+        tensor_name: &'a str,
+        shape: &'a [usize],
+        dtype_label: &'static str,
+        bytes: &'a [u8],
+        dtype: RawDType,
+        values: &'a mut Vec<f64>,
+    ) -> Self {
+        Self {
+            source,
+            tensor_name,
+            shape,
+            payload: IngestPayload::DecodeF64 {
+                bytes,
+                dtype,
+                values,
+                dtype_label,
+            },
+        }
+    }
+
+    /// Wrap f64 values for checked one-pass f16 output encoding.
+    pub(crate) fn encode_f16(
+        source: &'a str,
+        tensor_name: &'a str,
+        shape: &'a [usize],
+        values: &'a [f64],
+        bytes: &'a mut Vec<u8>,
+    ) -> Self {
+        Self {
+            source,
+            tensor_name,
+            shape,
+            payload: IngestPayload::EncodeF16 { values, bytes },
+        }
+    }
 }
 
 /// Validate one ingested tensor at the exact point its bytes become trusted
 /// tensor data: the declared shape's element count must not overflow, the
-/// payload's element count must exactly match that shape, and every element
-/// must be finite (NaN and either infinity are rejected; signed zero and
-/// subnormals are accepted).
+/// payload's element count must exactly match that shape, and every trusted
+/// element must be finite (NaN and either infinity are rejected; signed zero
+/// and subnormals are accepted). Raw-to-f64 decode and f64-to-f16 encode are
+/// validated while their output vectors are built, without a second scan.
 ///
 /// Errors are `InferenceError::InvalidSafetensors` — no new public error
 /// variant is added — and carry source label, tensor name, dtype, shape,
@@ -107,6 +172,120 @@ pub(crate) fn validate_ingested_tensor(tensor: IngestedTensor<'_>) -> Result<(),
                      {idx} of {numel} (shape {:?})",
                     tensor.source, tensor.tensor_name, tensor.shape,
                 )));
+            }
+            Ok(())
+        }
+        IngestPayload::DecodeF64 {
+            bytes,
+            dtype,
+            values,
+            dtype_label,
+        } => {
+            let bytes_per_element = match dtype {
+                RawDType::F32 => 4,
+                RawDType::F16 | RawDType::Bf16 => 2,
+            };
+            let expected_bytes = numel.checked_mul(bytes_per_element).ok_or_else(|| {
+                InferenceError::InvalidSafetensors(format!(
+                    "{}: tensor {} ({dtype_label}) byte length overflows usize for shape {:?}",
+                    tensor.source, tensor.tensor_name, tensor.shape,
+                ))
+            })?;
+            if bytes.len() != expected_bytes {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "{}: tensor {} ({dtype_label}) byte length {} does not match shape {:?} \
+                     (expected {expected_bytes})",
+                    tensor.source,
+                    tensor.tensor_name,
+                    bytes.len(),
+                    tensor.shape,
+                )));
+            }
+
+            values.clear();
+            values.reserve_exact(numel);
+
+            // `dtype` is matched exactly once here; each arm is a tight loop
+            // with its decode statically known at the call site (no stored
+            // fn-pointer indirection — see `RawDType` doc comment).
+            macro_rules! decode_loop {
+                ($chunk_len:expr, $decode:expr) => {
+                    for (idx, chunk) in bytes.chunks_exact($chunk_len).enumerate() {
+                        let value: f64 = $decode(chunk);
+                        if !value.is_finite() {
+                            return Err(InferenceError::InvalidSafetensors(format!(
+                                "{}: tensor {} ({dtype_label}) has non-finite value {value} at \
+                                 element index {idx} of {numel} (shape {:?})",
+                                tensor.source, tensor.tensor_name, tensor.shape,
+                            )));
+                        }
+                        values.push(value);
+                    }
+                };
+            }
+
+            match dtype {
+                RawDType::F32 => decode_loop!(4, |chunk: &[u8]| f32::from_le_bytes([
+                    chunk[0], chunk[1], chunk[2], chunk[3]
+                ]) as f64),
+                RawDType::F16 => {
+                    decode_loop!(
+                        2,
+                        |chunk: &[u8]| crate::weights::half_bits::f16_bits_to_f32(
+                            u16::from_le_bytes([chunk[0], chunk[1]])
+                        ) as f64
+                    )
+                }
+                RawDType::Bf16 => {
+                    decode_loop!(
+                        2,
+                        |chunk: &[u8]| crate::weights::half_bits::bf16_bits_to_f32(
+                            u16::from_le_bytes([chunk[0], chunk[1]])
+                        ) as f64
+                    )
+                }
+            }
+            Ok(())
+        }
+        IngestPayload::EncodeF16 { values, bytes } => {
+            if values.len() != numel {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "{}: tensor {} (F16) source element count {} does not match shape {:?} \
+                     (expected {numel})",
+                    tensor.source,
+                    tensor.tensor_name,
+                    values.len(),
+                    tensor.shape,
+                )));
+            }
+
+            let encoded_len = numel.checked_mul(2).ok_or_else(|| {
+                InferenceError::InvalidSafetensors(format!(
+                    "{}: tensor {} (F16) encoded byte length overflows usize for shape {:?}",
+                    tensor.source, tensor.tensor_name, tensor.shape,
+                ))
+            })?;
+            bytes.clear();
+            bytes.reserve_exact(encoded_len);
+            for (idx, &value) in values.iter().enumerate() {
+                if !value.is_finite() {
+                    return Err(InferenceError::InvalidSafetensors(format!(
+                        "{}: tensor {} (F16) has non-finite source value {value} at element \
+                         index {idx} of {numel} (shape {:?})",
+                        tensor.source, tensor.tensor_name, tensor.shape,
+                    )));
+                }
+                let narrowed = value as f32;
+                let bits = crate::weights::half_bits::f32_to_f16_bits(narrowed);
+                if !crate::weights::half_bits::f16_bits_is_finite(bits) {
+                    return Err(InferenceError::InvalidSafetensors(format!(
+                        "{}: tensor {} (F16) encodes finite source value {value} as a \
+                         non-finite f16 bit pattern at element index {idx} of {numel} \
+                         (shape {:?})",
+                        tensor.source, tensor.tensor_name, tensor.shape,
+                    )));
+                }
+                bytes.extend_from_slice(&bits.to_le_bytes());
             }
             Ok(())
         }

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -50,6 +50,27 @@
 
 use crate::error::InferenceError;
 
+/// Create `path` for writing with fd-bound exclusive no-follow semantics:
+/// `create_new` refuses a pre-existing entry (including a stale file left by
+/// an earlier run) and `O_NOFOLLOW` refuses to follow a symlink planted at
+/// `path`, so a concurrent actor that plants a symlink at an output filename
+/// after an earlier existence check cannot redirect the write to overwrite
+/// an arbitrary target. Shared by every offline-conversion output writer
+/// (`.q4`, `.f16`, `quantize_index.json`, `config.json`).
+///
+/// # Errors
+///
+/// Returns an error if `path` already exists (including as a symlink) or
+/// cannot be created.
+pub(crate) fn create_output_file(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+}
+
 /// One Q4_0 quantization block: 32 weights packed as 4-bit unsigned integers.
 ///
 /// `scale` is stored as a raw IEEE-754 f16 bit pattern in a `u16` — the `half` crate
@@ -122,6 +143,57 @@ pub(crate) fn q4_f16_to_f32(bits: u16) -> f32 {
     crate::weights::half_bits::f16_bits_to_f32(bits)
 }
 
+/// Which Q4 block metadata field is being encoded — selects the field-specific
+/// underflow-guard wording below. A typed enum (rather than a free-form
+/// `field: &str`) means a typo can no longer silently bypass the guard for
+/// one field while claiming to check the other (the exact risk class the
+/// two-sided guard below exists to close).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Q4MetadataField {
+    Scale,
+    Bias,
+}
+
+impl Q4MetadataField {
+    fn label(self) -> &'static str {
+        match self {
+            Q4MetadataField::Scale => "scale",
+            Q4MetadataField::Bias => "bias",
+        }
+    }
+}
+
+/// Encode one Q4 block metadata value (`scale` or `bias`) to its f16 bit
+/// pattern, rejecting non-finite inputs/outputs and — for either field — a
+/// non-zero value that underflows to f16 zero.
+///
+/// Both fields are gated identically (two-sided): a non-zero `scale` that
+/// underflows collapses every dequantized value in the block to the bias
+/// (multiplicative term zeroed); a non-zero `bias` that underflows silently
+/// drops the block's zero-point offset, which is the same class of silent
+/// value destruction on the additive term instead of the multiplicative one
+/// (e.g. a constant block `[1e-9; 32]`: `scale = 1.0` legitimately, but the
+/// bias `1e-9` underflows to f16 zero and the whole block dequantizes to
+/// zero instead of `1e-9`). A genuinely zero-valued field (exact `0.0`) is
+/// not an underflow and still encodes successfully.
+fn encode_finite_q4_metadata(value: f32, field: Q4MetadataField) -> Result<u16, InferenceError> {
+    let bits = q4_f32_to_f16(value);
+    let label = field.label();
+    if !value.is_finite() || !crate::weights::half_bits::f16_bits_is_finite(bits) {
+        return Err(InferenceError::InvalidInput(format!(
+            "Q4 {label} value {value} encodes as a non-finite f16 value"
+        )));
+    }
+    if value != 0.0 && q4_f16_to_f32(bits) == 0.0 {
+        return Err(InferenceError::InvalidInput(format!(
+            "Q4 {label} value {value} underflows to f16 zero, which would silently \
+             destroy this block's {label} contribution to every dequantized value; \
+             refusing to quantize a block with a degenerate {label}"
+        )));
+    }
+    Ok(bits)
+}
+
 /// Convert a BF16 bit pattern (`u16`) to `f32`.
 ///
 /// BF16 has identical sign+exponent layout to f32; zero-extending the mantissa
@@ -180,7 +252,16 @@ fn quantize_block_with_mode_len(
         let scale = if abs_max == 0.0 {
             1.0f32
         } else {
-            abs_max / 7.0
+            let s = abs_max / 7.0;
+            if s == 0.0 {
+                return Err(InferenceError::InvalidInput(format!(
+                    "Q4 weight block has nonzero abs_max {abs_max} but abs_max/7.0 \
+                     underflows to f32 zero, which would silently collapse this \
+                     block's scale to zero; refusing to quantize a block with a \
+                     degenerate scale"
+                )));
+            }
+            s
         };
         let inv_scale = 1.0 / scale;
         let bias = -8.0 * scale;
@@ -191,8 +272,8 @@ fn quantize_block_with_mode_len(
             packed[b] = (q1 << 4) | (q0 & 0x0f);
         }
         Ok(Q4Block {
-            scale: q4_f32_to_f16(scale),
-            bias: q4_f32_to_f16(bias),
+            scale: encode_finite_q4_metadata(scale, Q4MetadataField::Scale)?,
+            bias: encode_finite_q4_metadata(bias, Q4MetadataField::Bias)?,
             packed,
         })
     } else {
@@ -200,7 +281,20 @@ fn quantize_block_with_mode_len(
         let min_val = real.iter().copied().fold(f32::INFINITY, f32::min);
         let max_val = real.iter().copied().fold(f32::NEG_INFINITY, f32::max);
         let range = max_val - min_val;
-        let scale = if range == 0.0 { 1.0f32 } else { range / 15.0 };
+        let scale = if range == 0.0 {
+            1.0f32
+        } else {
+            let s = range / 15.0;
+            if s == 0.0 {
+                return Err(InferenceError::InvalidInput(format!(
+                    "Q4 weight block has nonzero range {range} but range/15.0 \
+                     underflows to f32 zero, which would silently collapse this \
+                     block's scale to zero; refusing to quantize a block with a \
+                     degenerate scale"
+                )));
+            }
+            s
+        };
         let inv_scale = 1.0 / scale;
         let mut packed = [0u8; 16];
         for b in 0..16 {
@@ -209,8 +303,8 @@ fn quantize_block_with_mode_len(
             packed[b] = (q1 << 4) | (q0 & 0x0f);
         }
         Ok(Q4Block {
-            scale: q4_f32_to_f16(scale),
-            bias: q4_f32_to_f16(min_val),
+            scale: encode_finite_q4_metadata(scale, Q4MetadataField::Scale)?,
+            bias: encode_finite_q4_metadata(min_val, Q4MetadataField::Bias)?,
             packed,
         })
     }
@@ -229,7 +323,10 @@ fn quantize_block_with_mode_len(
 ///
 /// # Errors
 ///
-/// Returns [`InferenceError::InvalidInput`] if any value in `src` is non-finite.
+/// Returns [`InferenceError::InvalidInput`] if any value in `src` is
+/// non-finite, or if a non-constant block's computed scale underflows to
+/// f16 zero (which would silently collapse every dequantized value in that
+/// block to the bias).
 pub fn quantize_row_q4_0(src: &[f32]) -> Result<Vec<u8>, InferenceError> {
     let n_blocks = src.len().div_ceil(32);
     let mut out = Vec::with_capacity(n_blocks * 20);
@@ -280,7 +377,10 @@ pub fn dequantize_row_q4_0(data: &[u8], n_weights: usize) -> Vec<f32> {
 ///
 /// # Errors
 ///
-/// Returns [`InferenceError::InvalidInput`] if any value in `src` is non-finite.
+/// Returns [`InferenceError::InvalidInput`] if any value in `src` is
+/// non-finite, or if a non-constant block's computed scale underflows to
+/// f16 zero (which would silently collapse every dequantized value in that
+/// block to the bias).
 pub fn quantize_tensor_q4_0(
     src: &[f32],
     rows: usize,
@@ -304,7 +404,7 @@ pub fn quantize_tensor_q4_0(
 // BF16-input quantization API (for streaming model shards)
 // ---------------------------------------------------------------------------
 
-/// Assert that `shape.iter().product()` equals `data_len`.
+/// Validate that `shape.iter().product()` equals `data_len`.
 ///
 /// SafeTensors' own `TensorView::new` rejects shape/data-size mismatches
 /// (returns `InvalidTensorView`). The Q4 entry points keep the same
@@ -313,32 +413,33 @@ pub fn quantize_tensor_q4_0(
 /// `save_q4_file` will then write the inconsistent metadata into a `.q4`
 /// header that downstream loaders (`write_merged_qkvz`, the Metal
 /// runtime path) trust without re-verification. Uses `checked_mul` so
-/// `usize` overflow on a malformed shape surfaces as a panic at
-/// construction, not as a wraparound that aliases a valid length.
-#[track_caller]
-fn assert_shape_matches_data_len(shape: &[usize], data_len: usize) {
+/// `usize` overflow on a malformed shape returns an error instead of
+/// wrapping to a valid length.
+fn validate_shape_matches_data_len(shape: &[usize], data_len: usize) -> Result<(), InferenceError> {
     let numel = shape
         .iter()
         .try_fold(1_usize, |acc, &d| acc.checked_mul(d))
-        .unwrap_or_else(|| {
-            panic!("shape product overflowed usize: shape={shape:?}");
-        });
-    assert_eq!(
-        numel, data_len,
-        "shape product {numel} (shape={shape:?}) must equal data length {data_len}"
-    );
+        .ok_or_else(|| {
+            InferenceError::InvalidInput(format!("shape product overflows usize: shape={shape:?}"))
+        })?;
+    if numel != data_len {
+        return Err(InferenceError::InvalidInput(format!(
+            "shape product {numel} (shape={shape:?}) must equal data length {data_len}"
+        )));
+    }
+    Ok(())
 }
 
 /// Quantize a BF16 tensor (raw `u16` slice) into a [`Q4Tensor`].
 ///
-/// Panics if `shape.iter().product()` does not equal `data.len()`.
-///
 /// # Errors
 ///
-/// Returns [`InferenceError::InvalidInput`] if any BF16 value decodes to a
-/// non-finite f32 (NaN or ±inf).
+/// Returns [`InferenceError::InvalidInput`] if shape metadata is inconsistent,
+/// any BF16 value decodes to a non-finite f32 (NaN or ±inf), or a
+/// non-constant block's computed scale underflows to f16 zero (which would
+/// silently collapse every dequantized value in that block to the bias).
 pub fn quantize_bf16_to_q4(data: &[u16], shape: &[usize]) -> Result<Q4Tensor, InferenceError> {
-    assert_shape_matches_data_len(shape, data.len());
+    validate_shape_matches_data_len(shape, data.len())?;
     let original_len = data.len();
     let n_blocks = original_len.div_ceil(32);
     let mut blocks = Vec::with_capacity(n_blocks);
@@ -375,13 +476,12 @@ pub fn quantize_bf16_to_q4(data: &[u16], shape: &[usize]) -> Result<Q4Tensor, In
 /// side of a Q4 bin boundary or shift `abs_max` for the block. The f32 path
 /// avoids that truncation.
 ///
-/// Panics if `shape.iter().product()` does not equal `data.len()`.
-///
 /// # Errors
 ///
-/// Returns [`InferenceError::InvalidInput`] if any value in `data` is non-finite.
+/// Returns [`InferenceError::InvalidInput`] if shape metadata is inconsistent,
+/// any value in `data` is non-finite, or Q4 metadata is not finite in f16.
 pub fn quantize_f32_to_q4(data: &[f32], shape: &[usize]) -> Result<Q4Tensor, InferenceError> {
-    assert_shape_matches_data_len(shape, data.len());
+    validate_shape_matches_data_len(shape, data.len())?;
     let original_len = data.len();
     let n_blocks = original_len.div_ceil(32);
     let mut blocks = Vec::with_capacity(n_blocks);
@@ -420,12 +520,11 @@ pub fn quantize_f32_to_q4(data: &[f32], shape: &[usize]) -> Result<Q4Tensor, Inf
 /// at exact-midpoint values and rotated activations rarely sit on bin
 /// boundaries.
 ///
-/// Panics if `shape.iter().product()` does not equal `data.len()`.
-///
 /// # Errors
 ///
-/// Returns [`InferenceError::InvalidInput`] if any f64 value is non-finite (NaN
-/// or ±inf), or if the f32 downcast produces a non-finite value.
+/// Returns [`InferenceError::InvalidInput`] if shape metadata is inconsistent,
+/// any f64 value is non-finite (NaN or ±inf), the f32 downcast is non-finite,
+/// or Q4 metadata is not finite in f16.
 pub fn quantize_f64_to_q4(data: &[f64], shape: &[usize]) -> Result<Q4Tensor, InferenceError> {
     quantize_f64_to_q4_mode(data, shape, true) // symmetric — QuaRot-rotated weights are zero-mean
 }
@@ -440,13 +539,14 @@ pub fn quantize_f64_to_q4(data: &[f64], shape: &[usize]) -> Result<Q4Tensor, Inf
 ///
 /// # Errors
 ///
-/// Returns [`InferenceError::InvalidInput`] if any value in `data` is non-finite.
+/// Returns [`InferenceError::InvalidInput`] if shape metadata is inconsistent,
+/// any value in `data` is non-finite, or Q4 metadata is not finite in f16.
 pub fn quantize_f64_to_q4_mode(
     data: &[f64],
     shape: &[usize],
     symmetric: bool,
 ) -> Result<Q4Tensor, InferenceError> {
-    assert_shape_matches_data_len(shape, data.len());
+    validate_shape_matches_data_len(shape, data.len())?;
     let original_len = data.len();
     let n_blocks = original_len.div_ceil(32);
     let mut blocks = Vec::with_capacity(n_blocks);
@@ -523,7 +623,11 @@ pub fn stream_quantize_shard(
 // File I/O
 // ---------------------------------------------------------------------------
 
-/// Write a [`Q4Tensor`] to a `.q4` file.
+/// Serialize a [`Q4Tensor`] to its on-disk `.q4` byte layout entirely in
+/// memory, without touching the filesystem. Shared by [`save_q4_file`] and
+/// any caller (e.g. the offline quantizer's fd-bound staging writer) that
+/// needs the exact on-disk bytes to write through an already-open file
+/// handle instead of a path.
 ///
 /// File format:
 /// ```text
@@ -534,28 +638,65 @@ pub fn stream_quantize_shard(
 /// original_len u64 LE    8 bytes
 /// blocks       [Q4Block; n]  n × 20 bytes
 /// ```
-pub fn save_q4_file(path: &std::path::Path, tensor: &Q4Tensor) -> std::io::Result<()> {
-    use std::io::Write;
-    let mut f = std::fs::File::create(path)?;
-    f.write_all(b"KHQ4")?;
-    f.write_all(&2u32.to_le_bytes())?;
-    f.write_all(&(tensor.shape.len() as u32).to_le_bytes())?;
-    for &dim in &tensor.shape {
-        f.write_all(&(dim as u64).to_le_bytes())?;
-    }
-    f.write_all(&(tensor.original_len as u64).to_le_bytes())?;
+pub fn q4_file_bytes(tensor: &Q4Tensor) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(
+        4 + 4 + 4 + 8 * tensor.shape.len() + 8 + tensor.blocks.len() * Q4_BLOCK_BYTES,
+    );
+    write_q4_tensor(&mut buf, tensor).expect("Vec<u8> writer never fails");
+    buf
+}
+
+/// Borrowed view of a [`Q4Tensor`]'s packed blocks as raw bytes, with no
+/// copy — the returned slice aliases `tensor.blocks` directly.
+fn q4_block_bytes(tensor: &Q4Tensor) -> &[u8] {
     // SAFETY: Q4Block is #[repr(C)] with size 20; its alignment is 2 (the
     // alignment of the leading `scale: u16` per the Rust Reference's repr(C)
     // rule). Casting to a `&[u8]` is valid because the target element type is
     // `u8` (alignment 1 ≤ source alignment 2). The resulting slice has length
     // `blocks.len() * 20` matching the source contiguous storage.
-    let block_bytes: &[u8] = unsafe {
+    unsafe {
         std::slice::from_raw_parts(
             tensor.blocks.as_ptr().cast::<u8>(),
-            tensor.blocks.len() * 20,
+            tensor.blocks.len() * Q4_BLOCK_BYTES,
         )
-    };
-    f.write_all(block_bytes)
+    }
+}
+
+/// Stream a [`Q4Tensor`] to `writer` as the header followed by the borrowed
+/// packed-block bytes, with no output-sized duplicate buffer — unlike
+/// [`q4_file_bytes`], which allocates and copies the full byte image before
+/// any write happens. `writer` is written in two `write_all` calls: header,
+/// then block bytes aliasing `tensor.blocks` directly.
+pub fn write_q4_tensor<W: std::io::Write>(
+    writer: &mut W,
+    tensor: &Q4Tensor,
+) -> std::io::Result<()> {
+    let mut header = Vec::with_capacity(4 + 4 + 4 + 8 * tensor.shape.len() + 8);
+    header.extend_from_slice(b"KHQ4");
+    header.extend_from_slice(&2u32.to_le_bytes());
+    header.extend_from_slice(&(tensor.shape.len() as u32).to_le_bytes());
+    for &dim in &tensor.shape {
+        header.extend_from_slice(&(dim as u64).to_le_bytes());
+    }
+    header.extend_from_slice(&(tensor.original_len as u64).to_le_bytes());
+    writer.write_all(&header)?;
+    writer.write_all(q4_block_bytes(tensor))
+}
+
+/// Write a [`Q4Tensor`] to a `.q4` file at `path`, creating or truncating it.
+/// See [`q4_file_bytes`] for the on-disk layout.
+///
+/// General-purpose library entry point — callers that need fd-bound
+/// exclusive no-follow creation against untrusted output paths (the QuaRot
+/// offline converter) use [`create_output_file`] plus [`write_q4_tensor`]
+/// directly instead of this function.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be created or the write fails.
+pub fn save_q4_file(path: &std::path::Path, tensor: &Q4Tensor) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write_q4_tensor(&mut file, tensor)
 }
 
 /// Header metadata returned by [`read_q4_header`] without allocating blocks.
@@ -741,7 +882,7 @@ pub fn load_q4_file(path: &std::path::Path) -> Result<Q4Tensor, Box<dyn std::err
 
     // Fail closed on a header whose shape disagrees with its element count.
     // The quantize paths enforce `shape.product() == data.len()` via
-    // `assert_shape_matches_data_len`; the loader must reject the same
+    // `validate_shape_matches_data_len`; the loader must reject the same
     // inconsistency rather than return a tensor whose `shape` overstates the
     // block payload (downstream matmuls would read stale, out-of-range data).
     let shape_product = shape
@@ -1131,6 +1272,138 @@ mod tests {
             packed_off, 4,
             "packed field must start at byte offset 4 (after scale + bias, no padding)"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Non-constant-block scale underflow.
+    //
+    // Mutation-sensitive: with the `value != 0.0 && encoded == 0.0` guard
+    // removed from `encode_finite_q4_metadata`, the first test below would
+    // instead succeed and silently collapse every dequantized value in the
+    // block to the bias.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn non_constant_block_with_underflowing_scale_is_rejected() {
+        // 31 zeros + one value 1e-9 above them: genuinely non-constant
+        // (max != min), but range/15 underflows to f16 zero.
+        let mut vals = vec![0.0f32; 32];
+        vals[0] = 1e-9;
+        let err = quantize_row_q4_0(&vals)
+            .expect_err("a non-constant block whose scale underflows to f16 zero must error");
+        assert!(
+            err.to_string().contains("underflows to f16 zero"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn constant_block_still_succeeds_and_round_trips_the_constant() {
+        // max == min: scale is legitimately forced to 1.0 (not derived from
+        // range), so it must NOT be rejected by the underflow guard above.
+        let vals = vec![3.5f32; 32];
+        let encoded =
+            quantize_row_q4_0(&vals).expect("a genuinely constant block must still quantize");
+        let decoded = dequantize_row_q4_0(&encoded, 32);
+        assert_eq!(decoded.len(), 32);
+        for v in decoded {
+            assert!((v - 3.5).abs() < 1e-6, "expected ~3.5, got {v}");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Constant-block BIAS underflow (two-sided with scale).
+    //
+    // Mutation-sensitive: reverting the two-sided guard to gate only
+    // `Q4MetadataField::Scale` makes
+    // `constant_block_with_underflowing_bias_is_rejected` fail — the block's
+    // scale=1.0 never underflows, so only the new bias-side check catches
+    // this. Restoring the two-sided guard makes it error again; the
+    // zero-bias sibling below stays green throughout since `value == 0.0`
+    // is never gated.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn constant_block_with_underflowing_bias_is_rejected() {
+        // A genuinely constant block: scale is legitimately forced to 1.0
+        // (not derived from range, so it never underflows), but the bias
+        // (== the constant value itself, 1e-9) underflows to f16 zero,
+        // which would silently dequantize the whole block to 0.0 instead
+        // of 1e-9 — the same silent-value-destruction class the guard above
+        // targets, on the bias field instead of the scale field.
+        let vals = vec![1e-9f32; 32];
+        let err = quantize_row_q4_0(&vals)
+            .expect_err("a constant block whose bias underflows to f16 zero must error");
+        assert!(
+            err.to_string().contains("underflows to f16 zero"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // f32-division scale underflow (distinct from the f16-encoding underflow
+    // above): `range` (asymmetric) or `abs_max` (symmetric) is nonzero but so
+    // close to the smallest positive f32 subnormal that dividing it by 15.0
+    // / 7.0 flushes to *exactly* 0.0f32 before `encode_finite_q4_metadata`
+    // ever runs. Since the divide-by-zero guards above only special-case an
+    // exact-zero *input* (`range == 0.0` / `abs_max == 0.0`), the computed
+    // scale reaching exact zero here previously passed through as a
+    // "genuinely zero" field and silently zeroed the whole block.
+    //
+    // Mutation-sensitive: reverting the `s == 0.0` checks in
+    // `quantize_block_with_mode_len` makes both tests below fail (the calls
+    // succeed with a corrupted all-zero block instead of erroring).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn asymmetric_scale_underflow_from_subnormal_range_is_rejected() {
+        // min=0.0, max=the smallest positive f32 subnormal: range is
+        // nonzero, but range/15.0 underflows to exact 0.0f32.
+        let subnormal = f32::from_bits(1);
+        assert_ne!(subnormal, 0.0);
+        assert_eq!(
+            subnormal / 15.0,
+            0.0,
+            "test premise: division must underflow"
+        );
+        let mut vals = vec![0.0f32; 32];
+        vals[0] = subnormal;
+        let err = quantize_row_q4_0(&vals).expect_err(
+            "a nonzero-range block whose f32 scale computation underflows to zero must error",
+        );
+        assert!(
+            err.to_string().contains("underflows to f32 zero"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn symmetric_scale_underflow_from_subnormal_abs_max_is_rejected() {
+        let subnormal = f32::from_bits(1);
+        assert_eq!(
+            subnormal / 7.0,
+            0.0,
+            "test premise: division must underflow"
+        );
+        let mut vals = vec![0.0f64; 32];
+        vals[0] = subnormal as f64;
+        let err = quantize_f64_to_q4(&vals, &[32]).expect_err(
+            "a nonzero-abs_max block whose f32 scale computation underflows to zero must error",
+        );
+        assert!(
+            err.to_string().contains("underflows to f32 zero"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn constant_zero_block_still_accepts() {
+        // A genuinely-zero bias (constant-zero block) must not be flagged
+        // as an underflow — `value == 0.0` is the legitimate, non-degenerate
+        // case the guard explicitly excludes.
+        let vals = vec![0.0f32; 32];
+        let encoded = quantize_row_q4_0(&vals).expect("a constant-zero block must still quantize");
+        let decoded = dequantize_row_q4_0(&encoded, 32);
+        for v in decoded {
+            assert!(v.abs() < 1e-6, "expected ~0, got {v}");
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1965,40 +2238,56 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "shape product")]
     fn quantize_f32_to_q4_rejects_shape_data_mismatch() {
         let data = synthetic_f32_uniform(64, 41);
-        // shape claims 96 elements; data has 64 → must panic.
-        let _ = quantize_f32_to_q4(&data, &[3, 32]);
+        let err = quantize_f32_to_q4(&data, &[3, 32])
+            .expect_err("shape claims 96 elements but data has 64");
+        assert!(err.to_string().contains("shape product 96"));
     }
 
     #[test]
-    #[should_panic(expected = "shape product")]
     fn quantize_f64_to_q4_rejects_shape_data_mismatch() {
         let data: Vec<f64> = synthetic_f32_uniform(64, 43)
             .into_iter()
             .map(f64::from)
             .collect();
-        let _ = quantize_f64_to_q4(&data, &[3, 32]);
+        let err = quantize_f64_to_q4(&data, &[3, 32])
+            .expect_err("shape claims 96 elements but data has 64");
+        assert!(err.to_string().contains("shape product 96"));
     }
 
     #[test]
-    #[should_panic(expected = "shape product")]
     fn quantize_bf16_to_q4_rejects_shape_data_mismatch() {
         // Lock the same contract on the pre-existing BF16 entry point — the
         // SafeTensors source format rejects shape/data mismatches and the Q4
         // bridge must not silently weaken that invariant.
         let data: Vec<u16> = (0..64).map(|i| i as u16).collect();
-        let _ = quantize_bf16_to_q4(&data, &[3, 32]);
+        let err = quantize_bf16_to_q4(&data, &[3, 32])
+            .expect_err("shape claims 96 elements but data has 64");
+        assert!(err.to_string().contains("shape product 96"));
     }
 
     #[test]
-    #[should_panic(expected = "overflowed usize")]
     fn quantize_f32_to_q4_rejects_shape_product_overflow() {
         let data = vec![0.0_f32; 32];
         // usize::MAX * 2 overflows; checked_mul must catch it before the
         // length comparison aliases to a valid length by wraparound.
-        let _ = quantize_f32_to_q4(&data, &[usize::MAX, 2]);
+        let err = quantize_f32_to_q4(&data, &[usize::MAX, 2])
+            .expect_err("overflowing shape must return an error");
+        assert!(err.to_string().contains("overflows usize"));
+    }
+
+    #[test]
+    fn quantize_q4_rejects_non_finite_half_metadata() {
+        let f32_data = vec![f32::MAX; 32];
+        let f32_err = quantize_f32_to_q4(&f32_data, &[32])
+            .expect_err("finite f32 values that overflow f16 bias must be rejected");
+        assert!(f32_err.to_string().contains("non-finite"));
+
+        let f64_data = vec![f32::MAX as f64; 32];
+        let f64_err = quantize_f64_to_q4(&f64_data, &[32])
+            .expect_err("finite f64 values that overflow f16 scale must be rejected");
+        assert!(f64_err.to_string().contains("non-finite"));
     }
 
     #[test]
@@ -2154,7 +2443,7 @@ mod tests {
     fn test_q4_rejects_shape_product_mismatch() {
         // shape product (4*16=64) disagrees with original_len (32): the header
         // claims twice as many elements as the block payload covers. The
-        // quantize paths reject this via assert_shape_matches_data_len; the
+        // quantize paths reject this via validate_shape_matches_data_len; the
         // loader must too, with a clean Err rather than a Q4Tensor whose shape
         // overstates its data (downstream matmuls would read stale elements).
         let mut buf = Vec::new();

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -1342,7 +1342,7 @@ mod tests {
         // that was open at session start, regardless of what the path
         // currently resolves to.
         //
-        // Mutation-sensitive: reverting `create_file_at` to
+        // reverting `create_file_at` to
         // `create_output_file(&dir_path.join(filename))` (path-based) makes
         // this test fail — the write would land in the attacker's
         // substituted directory instead of the original.
@@ -1402,7 +1402,7 @@ mod tests {
     // -----------------------------------------------------------------------
     // Non-constant-block scale underflow.
     //
-    // Mutation-sensitive: with the `value != 0.0 && encoded == 0.0` guard
+    // with the `value != 0.0 && encoded == 0.0` guard
     // removed from `encode_finite_q4_metadata`, the first test below would
     // instead succeed and silently collapse every dequantized value in the
     // block to the bias.
@@ -1438,7 +1438,7 @@ mod tests {
     // -----------------------------------------------------------------------
     // Constant-block BIAS underflow (two-sided with scale).
     //
-    // Mutation-sensitive: reverting the two-sided guard to gate only
+    // reverting the two-sided guard to gate only
     // `Q4MetadataField::Scale` makes
     // `constant_block_with_underflowing_bias_is_rejected` fail — the block's
     // scale=1.0 never underflows, so only the new bias-side check catches
@@ -1473,7 +1473,7 @@ mod tests {
     // scale reaching exact zero here previously passed through as a
     // "genuinely zero" field and silently zeroed the whole block.
     //
-    // Mutation-sensitive: reverting the `s == 0.0` checks in
+    // reverting the `s == 0.0` checks in
     // `quantize_block_with_mode_len` makes both tests below fail (the calls
     // succeed with a corrupted all-zero block instead of erroring).
     // -----------------------------------------------------------------------
@@ -2016,7 +2016,7 @@ mod tests {
 
     #[test]
     fn quantize_f32_to_q4_partial_block_uses_real_tail_min_max() {
-        // Mutation-sensitive: a tail block of [5, 6, 7] zero-padded to 32
+        // a tail block of [5, 6, 7] zero-padded to 32
         // slots would (pre-fix) fold min/max over the padded zeros too,
         // yielding min=0/max=7 instead of the real min=5/max=7. This test
         // fails if the asymmetric path reverts to computing stats over the
@@ -2170,7 +2170,7 @@ mod tests {
     // Exercises the full composition: absorb_rotations (offline rotation
     // absorption) → quantize_f64_to_q4 → dequantize_q4_to_f32 → matmul,
     // and asserts correctness against an independent f64 reference that
-    // manually mirrors each step. Mutation-sensitive: perturbing the rotation
+    // manually mirrors each step. Perturbing the rotation
     // dispatch (pipeline.rs:226-230), absorption helpers (rotation.rs:161-164
     // or rotation.rs:184-192), Q4 symmetric scale (q4_weights.rs:277 or :280),
     // or Q4 symmetric mode flag (q4_weights.rs:523) must cause failure.
@@ -2827,7 +2827,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Non-finite input guard — mutation-sensitive tests
+    // Non-finite input guard tests
     //
     // IEEE-754: `NaN > x` and `NaN < x` are always false, so a plain
     // `f32::max` / `f32::min` fold over a block that contains NaN silently

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -288,9 +288,8 @@ fn bf16_to_f32(v: u16) -> f32 {
 /// a full block would (padding zeros must never widen the range). Symmetric
 /// mode folds `abs_max` over the full padded array unconditionally: zero
 /// padding can never exceed a non-empty real element's absolute value, so the
-/// result is bit-identical to folding over the real elements alone, and doing
-/// it this way keeps the symmetric path source-identical to the pre-fix
-/// version (see `quantize_f64_to_q4_symmetric_partial_block_is_bit_identical_to_padded_block`).
+/// result is bit-identical to folding over the real elements alone (see
+/// `quantize_f64_to_q4_symmetric_partial_block_is_bit_identical_to_padded_block`).
 ///
 /// # Errors
 ///
@@ -1341,11 +1340,6 @@ mod tests {
         // the fd closes that window: writes always land in the directory
         // that was open at session start, regardless of what the path
         // currently resolves to.
-        //
-        // reverting `create_file_at` to
-        // `create_output_file(&dir_path.join(filename))` (path-based) makes
-        // this test fail — the write would land in the attacker's
-        // substituted directory instead of the original.
         use std::os::fd::AsRawFd;
 
         let tmp = tempfile::tempdir().unwrap();
@@ -1402,10 +1396,9 @@ mod tests {
     // -----------------------------------------------------------------------
     // Non-constant-block scale underflow.
     //
-    // with the `value != 0.0 && encoded == 0.0` guard
-    // removed from `encode_finite_q4_metadata`, the first test below would
-    // instead succeed and silently collapse every dequantized value in the
-    // block to the bias.
+    // `encode_finite_q4_metadata` rejects a nonzero field that encodes to
+    // f16 zero, so a non-constant block whose scale underflows errors
+    // instead of silently collapsing every dequantized value to the bias.
     // -----------------------------------------------------------------------
     #[test]
     fn non_constant_block_with_underflowing_scale_is_rejected() {
@@ -1438,12 +1431,10 @@ mod tests {
     // -----------------------------------------------------------------------
     // Constant-block BIAS underflow (two-sided with scale).
     //
-    // reverting the two-sided guard to gate only
-    // `Q4MetadataField::Scale` makes
-    // `constant_block_with_underflowing_bias_is_rejected` fail — the block's
-    // scale=1.0 never underflows, so only the new bias-side check catches
-    // this. Restoring the two-sided guard makes it error again; the
-    // zero-bias sibling below stays green throughout since `value == 0.0`
+    // The underflow guard gates both `Q4MetadataField::Scale` and
+    // `Q4MetadataField::Bias`: a constant block's scale is forced to 1.0 and
+    // never underflows, so only the bias-side check catches an underflowing
+    // bias. The zero-bias sibling below is unaffected since `value == 0.0`
     // is never gated.
     // -----------------------------------------------------------------------
     #[test]
@@ -1473,9 +1464,9 @@ mod tests {
     // scale reaching exact zero here previously passed through as a
     // "genuinely zero" field and silently zeroed the whole block.
     //
-    // reverting the `s == 0.0` checks in
-    // `quantize_block_with_mode_len` makes both tests below fail (the calls
-    // succeed with a corrupted all-zero block instead of erroring).
+    // `quantize_block_with_mode_len` checks the computed scale itself for
+    // exact zero, not just the input it was derived from, so both cases
+    // below error instead of returning a corrupted all-zero block.
     // -----------------------------------------------------------------------
     #[test]
     fn asymmetric_scale_underflow_from_subnormal_range_is_rejected() {
@@ -2016,11 +2007,10 @@ mod tests {
 
     #[test]
     fn quantize_f32_to_q4_partial_block_uses_real_tail_min_max() {
-        // a tail block of [5, 6, 7] zero-padded to 32
-        // slots would (pre-fix) fold min/max over the padded zeros too,
-        // yielding min=0/max=7 instead of the real min=5/max=7. This test
-        // fails if the asymmetric path reverts to computing stats over the
-        // padded [f32; 32] array instead of the real `chunk.len()` elements.
+        // A tail block of [5, 6, 7] zero-padded to 32 slots: the asymmetric
+        // path computes min/max over the real `chunk.len()` elements, not
+        // the padded [f32; 32] array, so the range is min=5/max=7 rather
+        // than min=0/max=7.
         let src = [5.0f32, 6.0, 7.0];
         let q = quantize_f32_to_q4(&src, &[3]).unwrap();
         assert_eq!(q.original_len, 3);
@@ -2170,10 +2160,10 @@ mod tests {
     // Exercises the full composition: absorb_rotations (offline rotation
     // absorption) → quantize_f64_to_q4 → dequantize_q4_to_f32 → matmul,
     // and asserts correctness against an independent f64 reference that
-    // manually mirrors each step. Perturbing the rotation
-    // dispatch (pipeline.rs:226-230), absorption helpers (rotation.rs:161-164
-    // or rotation.rs:184-192), Q4 symmetric scale (q4_weights.rs:277 or :280),
-    // or Q4 symmetric mode flag (q4_weights.rs:523) must cause failure.
+    // mirrors each step, covering the rotation dispatch (pipeline.rs:226-230),
+    // absorption helpers (rotation.rs:161-164 and rotation.rs:184-192), Q4
+    // symmetric scale (q4_weights.rs:277 and :280), and Q4 symmetric mode
+    // flag (q4_weights.rs:523).
     // -----------------------------------------------------------------------
     #[test]
     fn quarot_rotated_q4_forward_matches_f64_reference() {
@@ -2436,9 +2426,9 @@ mod tests {
     // Tests for dequantize_row_q4_0 robustness (issue #263)
     //
     // These tests verify that dequantize_row_q4_0 does NOT panic on
-    // misaligned or undersized inputs. The function uses chunks_exact(20)
-    // which silently ignores trailing bytes, so removing the assert_eq!
-    // alignment check makes the behaviour well-defined on any input.
+    // misaligned or undersized inputs: it uses chunks_exact(20), which
+    // silently ignores trailing bytes, so behaviour is well-defined on any
+    // input length.
     // -----------------------------------------------------------------------
 
     /// Misaligned input (25 bytes = 1 complete block + 5 remainder bytes) must not panic.
@@ -2485,8 +2475,8 @@ mod tests {
         );
     }
 
-    /// Clean 2-block (40-byte) input with n_weights=64 still returns 64 correct values.
-    /// This is a regression guard: removing the assert must not break the happy path.
+    /// Clean 2-block (40-byte) input with n_weights=64 still returns 64 correct values —
+    /// the alignment guard for misaligned input above must not affect this happy path.
     #[test]
     fn dequantize_row_q4_0_exact_blocks_unchanged() {
         let src: Vec<f32> = (0..64).map(|i| (i as f32 - 32.0) / 10.0).collect();
@@ -2734,11 +2724,8 @@ mod tests {
         // reaches the block-payload guard (not the earlier shape-mismatch
         // guard). n_blocks*20 does not itself overflow u64 at this
         // magnitude, so this exercises the file_len-bound branch of
-        // checked_alloc_bytes: it must return a clean Err, never panic or
-        // attempt a multi-exabyte allocation. Removing the `checked_mul`
-        // guard (reverting to `n_blocks * 20`) does not panic here either
-        // since the multiply itself doesn't overflow — this test instead
-        // proves the *file_len bound* check is load-bearing on its own.
+        // checked_alloc_bytes on its own: it must return a clean Err, never
+        // panic or attempt a multi-exabyte allocation.
         let huge = usize::MAX - 3;
         let mut buf = Vec::new();
         buf.extend_from_slice(b"KHQ4");
@@ -2762,10 +2749,9 @@ mod tests {
     fn test_f16_rejects_numel_whose_byte_count_exceeds_file_len() {
         // numel = usize::MAX / 4: numel*2 does NOT overflow (≈ 2^62), so the
         // checked_mul branch passes and rejection can only come from the
-        // file_len-bound branch of checked_alloc_bytes. This pins that branch
-        // for the f16 loader specifically — the assertion below must not
-        // accept "overflows usize", or a deleted file_len check would go
-        // unnoticed (the overflow branch is pinned separately by
+        // file_len-bound branch of checked_alloc_bytes. The assertion below
+        // requires that specific branch's message rather than "overflows
+        // usize" (the overflow branch is covered separately by
         // test_f16_rejects_numel_that_wraps_to_small_value_on_overflow).
         let huge = usize::MAX / 4;
         let mut buf = Vec::new();
@@ -2789,13 +2775,13 @@ mod tests {
     #[test]
     fn test_f16_rejects_numel_that_wraps_to_small_value_on_overflow() {
         // numel = usize::MAX/2 + 5: numel*2 overflows u64 and wraps to a
-        // *small* residual (10, mod 2^64) that would sail past the
-        // file_len-bound check if `checked_mul` were replaced by a plain
-        // wrapping multiply — a silent-corruption bug (an ~empty read
-        // reported as success with the wrong shape/numel) rather than the
-        // OOM/panic the near-usize::MAX test above guards against. This is
-        // the scenario `checked_mul` uniquely defends: the bound check alone
-        // cannot catch it because the wrapped byte count looks small.
+        // *small* residual (10, mod 2^64) that a plain wrapping multiply
+        // would let sail past the file_len-bound check — a silent-corruption
+        // bug (an ~empty read reported as success with the wrong
+        // shape/numel) rather than the OOM/panic the near-usize::MAX test
+        // above guards against. `checked_mul` is what catches this case,
+        // since the bound check alone cannot: the wrapped byte count looks
+        // small.
         let huge = usize::MAX / 2 + 5;
         let mut buf = Vec::new();
         buf.extend_from_slice(b"KHF1");
@@ -2803,10 +2789,9 @@ mod tests {
         buf.extend_from_slice(&1u32.to_le_bytes()); // ndim
         buf.extend_from_slice(&(huge as u64).to_le_bytes()); // shape[0]
         buf.extend_from_slice(&(huge as u64).to_le_bytes()); // numel
-        // Trailing filler: `huge * 2` wraps to a small residue (10 bytes) if
-        // `checked_mul` is bypassed, so pad enough real bytes that a buggy
-        // wrapping multiply would successfully `read_exact` a plausible
-        // (wrong) buffer instead of also failing on a short read — isolating
+        // Trailing filler: `huge * 2` wraps to a small residue (10 bytes), so
+        // pad enough real bytes that a wrapping multiply's `read_exact`
+        // would succeed against a plausible (wrong) buffer size — isolating
         // the assertion to the overflow guard itself, not an incidental
         // short-file error.
         buf.extend_from_slice(&[0xABu8; 64]);
@@ -2837,9 +2822,9 @@ mod tests {
     // with a silently wrong entry. The guard at the top of
     // `quantize_block_with_mode` must catch this before the fold.
     //
-    // Mutation sensitivity: removing the `if !v.is_finite()` guard converts
-    // both `Err` returns below to `Ok`, turning `result.is_err()` → false
-    // and failing the assertion.
+    // The `if !v.is_finite()` guard at the top of `quantize_block_with_mode`
+    // is what makes both blocks below return `Err` rather than a
+    // plausible-looking but silently wrong `Q4Block`.
     // -----------------------------------------------------------------------
 
     #[test]
@@ -2873,16 +2858,13 @@ mod tests {
     // (#504 remaining slice: "Merged-Q4 cache: compatibility check is
     // size-only — no content integrity on the merged artifact.")
     //
-    // Mutation sensitivity: `merged_qkvz_cache_is_valid`'s size check alone
-    // (the pre-fix behavior) would accept a same-size tampered/stale merged
-    // file. `test_merged_qkvz_cache_rejects_same_size_corrupted_payload` and
-    // `test_merged_qkvz_cache_rejects_same_size_stale_source` are the
-    // discriminating tests: reverting the fingerprint comparison back to a
-    // bare `metadata.len() == expected_size` check makes both pass
-    // incorrectly (`is_valid` would wrongly return `true`), so they fail
-    // under the reverted code. Verified manually per the task's mutation-test
-    // protocol — see the session report for the reverse-apply/touch/restore
-    // proof.
+    // `merged_qkvz_cache_is_valid` compares a content fingerprint, not just
+    // `metadata.len() == expected_size`, so a same-size tampered or stale
+    // merged file is rejected rather than accepted on size alone.
+    // `test_merged_qkvz_cache_rejects_same_size_corrupted_payload` and
+    // `test_merged_qkvz_cache_rejects_same_size_stale_source` are the tests
+    // that specifically discriminate a size-only check from a fingerprint
+    // check.
     // -----------------------------------------------------------------------
 
     /// Write a minimal valid 2-D `.q4` source file (`shape = [rows, cols]`,
@@ -3053,9 +3035,9 @@ mod tests {
 
     #[test]
     fn test_merged_qkvz_cache_rejects_same_size_corrupted_payload() {
-        // Same-size bit flip inside the merged payload — the pre-fix
-        // size-only check would accept this file unchanged. This is the
-        // mutation-sensitive case for the content-integrity fix itself.
+        // Same-size bit flip inside the merged payload — a size-only check
+        // would accept this file unchanged, so this pins the
+        // content-integrity check specifically.
         let (qkv_p, z_p, merged_p) = merge_test_paths("corrupted");
         write_test_q4_source(&qkv_p, 4, 8, 1.0);
         write_test_q4_source(&z_p, 4, 8, 5.0);

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -71,6 +71,78 @@ pub(crate) fn create_output_file(path: &std::path::Path) -> std::io::Result<std:
         .open(path)
 }
 
+/// Open `path` as a directory fd, refusing to follow a symlink at the final
+/// component (`O_DIRECTORY|O_NOFOLLOW`). A conversion run holds this fd for
+/// its whole writing session and creates every output file `openat`-relative
+/// to it via [`create_file_at`] rather than re-joining and reopening
+/// `path` for each write — a canonicalize-or-create-dir-all-then-reopen
+/// sequence is a snapshot that stops being true the instant it returns, so a
+/// long-running multi-file write session gives an attacker repeated windows
+/// to swap the directory between writes. Binding every write to one fd
+/// opened before the session starts closes that window structurally.
+///
+/// # Errors
+///
+/// Returns an error if `path` does not exist, is not a directory, is a
+/// symlink, or cannot be opened.
+pub(crate) fn open_dir_nofollow(path: &std::path::Path) -> std::io::Result<std::os::fd::OwnedFd> {
+    use std::os::fd::FromRawFd;
+    use std::os::unix::ffi::OsStrExt;
+    let cpath = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+    // SAFETY: `cpath` is a valid NUL-terminated C string owned for the
+    // duration of this call. `open` returns either a valid fd (>= 0) or -1
+    // with errno set, checked immediately below.
+    let raw = unsafe {
+        libc::open(
+            cpath.as_ptr(),
+            libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `raw` was just returned by `libc::open` above, checked
+    // non-negative, and is not owned or closed anywhere else.
+    Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(raw) })
+}
+
+/// Create `filename` (a plain file name — no separators, never a full path)
+/// for writing inside the directory bound to `dirfd`, with the same
+/// exclusive/no-follow semantics as [`create_output_file`] but resolved via
+/// `openat` against the held fd instead of a re-resolved path string.
+///
+/// # Errors
+///
+/// Returns an error if `filename` already exists under `dirfd` (including as
+/// a symlink) or cannot be created.
+pub(crate) fn create_file_at(
+    dirfd: std::os::fd::RawFd,
+    filename: &str,
+) -> std::io::Result<std::fs::File> {
+    use std::os::fd::FromRawFd;
+    let cname = std::ffi::CString::new(filename)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+    // SAFETY: `dirfd` is a valid open directory fd borrowed for the duration
+    // of this call (owned by the caller for the writing session); `cname` is
+    // a valid NUL-terminated C string. `openat` returns either a valid fd
+    // (>= 0) or -1 with errno set, checked immediately below.
+    let raw = unsafe {
+        libc::openat(
+            dirfd,
+            cname.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0o644,
+        )
+    };
+    if raw < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `raw` was just returned by `libc::openat` above, checked
+    // non-negative, and is not owned or closed anywhere else.
+    Ok(unsafe { std::fs::File::from(std::os::fd::OwnedFd::from_raw_fd(raw)) })
+}
+
 /// One Q4_0 quantization block: 32 weights packed as 4-bit unsigned integers.
 ///
 /// `scale` is stored as a raw IEEE-754 f16 bit pattern in a `u16` — the `half` crate
@@ -1254,6 +1326,59 @@ pub(crate) fn write_merged_qkvz(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn create_file_at_writes_land_in_original_dirfd_not_a_post_open_directory_swap() {
+        // `open_dir_nofollow` binds a directory fd to the inode `mkdir`
+        // created; a long-running multi-file write session then creates
+        // every output artifact `openat`-relative to that fd via
+        // `create_file_at`. A path-based `output_dir.join(name)` +
+        // `create_output_file` sequence would instead re-resolve
+        // `output_dir` on every write, so an attacker who swaps the
+        // directory after the fd was opened (but before a later write)
+        // redirects that write into the substituted directory. Binding to
+        // the fd closes that window: writes always land in the directory
+        // that was open at session start, regardless of what the path
+        // currently resolves to.
+        //
+        // Mutation-sensitive: reverting `create_file_at` to
+        // `create_output_file(&dir_path.join(filename))` (path-based) makes
+        // this test fail — the write would land in the attacker's
+        // substituted directory instead of the original.
+        use std::os::fd::AsRawFd;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let real_dir = tmp.path().join("real_output");
+        std::fs::create_dir(&real_dir).unwrap();
+
+        let dirfd = open_dir_nofollow(&real_dir).unwrap();
+
+        // Swap `real_output` for a fresh, unrelated directory after the fd
+        // was opened: move the original directory aside (same inode, new
+        // path — `dirfd` still refers to it) and plant an attacker
+        // directory at the original path.
+        let moved_aside = tmp.path().join("real_output_moved_aside");
+        std::fs::rename(&real_dir, &moved_aside).unwrap();
+        std::fs::create_dir(&real_dir).unwrap();
+
+        let mut f = create_file_at(dirfd.as_raw_fd(), "artifact.q4").unwrap();
+        use std::io::Write;
+        f.write_all(b"legit-bytes").unwrap();
+        drop(f);
+
+        assert_eq!(
+            std::fs::read_dir(&real_dir).unwrap().count(),
+            0,
+            "the substituted directory (now at the original path) must not receive the write"
+        );
+        assert_eq!(
+            std::fs::read(moved_aside.join("artifact.q4")).unwrap(),
+            b"legit-bytes",
+            "the write must land in the directory `dirfd` was opened against, \
+             wherever it now lives, not the directory currently at that path"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // Test 1: Q4Block is exactly 20 bytes (scale + bias + 16 nibble bytes).
@@ -2702,7 +2827,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Non-finite input guard — mutation-sensitive tests (Finding 1, PR #452)
+    // Non-finite input guard — mutation-sensitive tests
     //
     // IEEE-754: `NaN > x` and `NaN < x` are always false, so a plain
     // `f32::max` / `f32::min` fold over a block that contains NaN silently

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,0 +1,6 @@
+# Implementation Notes
+
+- Extended the private weight-ingress seam to decode QuaRot F32/F16/BF16 bytes into `f64` while checking finiteness in the same materialization pass.
+- Routed both offline quantizers through one checked KHF1 writer, removing the plain quantizer's local half encoder and validating f16 output before file creation.
+- Rejected Q4 scale or bias metadata that becomes non-finite in f16, and changed Q4 shape mismatches from panics to `InferenceError::InvalidInput` results.
+- Added regression coverage for NaN and both infinities across all supported QuaRot source dtypes, invalid-output publication, f16 overflow, Q4 metadata overflow, and shape errors.

--- a/implementation_notes.md
+++ b/implementation_notes.md
@@ -1,6 +1,0 @@
-# Implementation Notes
-
-- Extended the private weight-ingress seam to decode QuaRot F32/F16/BF16 bytes into `f64` while checking finiteness in the same materialization pass.
-- Routed both offline quantizers through one checked KHF1 writer, removing the plain quantizer's local half encoder and validating f16 output before file creation.
-- Rejected Q4 scale or bias metadata that becomes non-finite in f16, and changed Q4 shape mismatches from panics to `InferenceError::InvalidInput` results.
-- Added regression coverage for NaN and both infinities across all supported QuaRot source dtypes, invalid-output publication, f16 overflow, Q4 metadata overflow, and shape errors.


### PR DESCRIPTION
## Summary

Hardens QuaRot/Q4 offline-quantization filesystem ingress so every checked path is also the path actually used — closing check-then-use gaps where an earlier validation and the later read/write/rename/delete were two independent path resolutions:

- `convert_quarot_qwen35`: the output-directory fd is opened once, immediately before the write session begins, and re-validated on the fd itself (scanning its contents via `fdopendir`/`readdir`) rather than trusting an earlier, separately-resolved path check. Every write in the session goes through that one fd.
- `quantize_q4`'s `TempPublishDir::publish` anchors both the staging directory and the final `output_dir` name to a single held parent-directory fd via `renameat`, instead of re-resolving both as full paths.
- `TempPublishDir`'s `Drop` cleanup walks and removes the staging directory's contents entirely through the held directory fd (`fdopendir`/`readdir`/`unlinkat`), then removes the now-empty directory entry itself via `unlinkat(parent_fd, name, AT_REMOVEDIR)` — never a path-based recursive delete.
- `quantize_model` reads `config.json` through the same model-directory fd already used to validate the checkpoint, instead of reopening the model directory by a fresh path for that second read.
- Descriptor-relative shard traversal and final-component `config.json` symlink rejection from the prior round are unchanged.

## Test plan

```
cargo test -p lattice-inference --lib quant::quarot
cargo test -p lattice-inference --lib q4_weights
cargo test -p lattice-inference --bin quantize_q4
cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings
cargo fmt -p lattice-inference -- --check
```

All green (192 + 71 + 21 tests). New regression tests were each verified against the fix reverted (fail) and restored (pass) before landing.

## bench-compare disposition

Offline filesystem ingress for the QuaRot/Q4 conversion CLIs — not a decode or prefill hot path, and not reachable from any benchmarked call site. No hot-path call sites; A/B in a quiet window pending before ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
