### PR TITLE
refactor(inference): remove duplicate generation wrapper

### DIFF
--- a/crates/inference/src/forward/batch_prefill.rs
+++ b/crates/inference/src/forward/batch_prefill.rs
@@ -1,18 +1,10 @@
-//! Batched prompt prefill for Qwen3.5 hybrid attention.
+//! Shared batched prompt-prefill core for Qwen3.5 hybrid attention.
 //!
-//! This file is written to be included as a child module of `qwen35_model.rs`
-//! (for example `mod batch_prefill;` near the bottom of that file), because the
-//! provided ground-truth implementation keeps several model internals private.
-//! If you instead wire it from `lib.rs`, the same code works after promoting the
-//! touched internals to `pub(crate)`.
-//!
-//! This module's `Qwen35Model::prefill_tokens_batched_for_generate` batched-prefill
-//! core is what the canonical `Qwen35Model::generate` / `generate_streaming`
-//! (`crates/inference/src/model/qwen35/generation.rs`) delegate their own prefill phase
-//! to (PR #680). [`Qwen35Model::generate_with_batch_prefill`] predates that delegation:
-//! it is a standalone, now-redundant decode loop built directly on the same core and is
-//! **deprecated** as of 0.5.1 (issue #807) — new callers should use the canonical
-//! `generate` / `generate_streaming` methods instead.
+//! The canonical [`Qwen35Model::generate`] and [`Qwen35Model::generate_streaming`]
+//! methods delegate their prompt phase to
+//! [`Qwen35Model::prefill_tokens_batched_for_generate`]. The core advances the
+//! full-attention KV cache and GatedDeltaNet recurrent states for the whole prompt
+//! before returning the final prompt position's logits.
 //!
 //! LoRA adapters are applied per-token in all projection steps, matching the
 //! decode path. Each `matmul_bt` over the `[seq_len, dim]` batch is followed by
@@ -27,13 +19,9 @@ use crate::error::InferenceError;
 use crate::forward::cpu::{elementwise_mul, matmul_bt, silu_inplace};
 use crate::model::qwen35::{
     AttentionWeights, CommonLayerWeights, DenseFfnWeights, FeedForwardWeights, ForwardScratch,
-    FullAttentionLayerWeights, KvCache, Qwen35Model, check_grammar_not_set, check_logprobs_not_set,
-    check_reasoning_budget_not_set, check_stop_strings_not_set, decode_tokens, qwen35_rms_norm,
-    resize, sample_token, should_stop_token,
+    FullAttentionLayerWeights, KvCache, Qwen35Model, qwen35_rms_norm, resize,
 };
-use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
-use crate::stop_reason::StopReason;
-use crate::tokenizer::common::Tokenizer;
+use crate::model::qwen35_config::Qwen35Config;
 
 /// Scratch buffers reused across batched prompt prefill.
 ///
@@ -361,200 +349,6 @@ impl Qwen35Model {
             &mut scratch,
             self.lora.as_ref(),
         )
-    }
-
-    /// **Unstable**: batched prefill generate.
-    ///
-    /// A standalone generate body that uses `prefill_prompt()` for the prompt
-    /// phase and then falls back to the existing single-token decode loop.
-    ///
-    /// This method predates the canonical [`Qwen35Model::generate`] /
-    /// [`Qwen35Model::generate_streaming`] delegating their own prefill phase to
-    /// `Self::prefill_tokens_batched_for_generate` (the same batched-prefill core
-    /// this method calls internally, see `crates/inference/src/model/qwen35/generation.rs`
-    /// around line 153). That delegation, wired in PR #680, made this method's
-    /// independent decode loop redundant; it has no production caller (issue #807).
-    #[deprecated(
-        since = "0.5.1",
-        note = "generate_with_batch_prefill is repository-dead and duplicates the canonical \
-                Qwen3.5 decode loop (Qwen35Model::generate / generate_streaming, which already \
-                delegate their prefill phase to the same batched-prefill core this method calls). \
-                Migrate to Qwen35Model::generate / generate_streaming. \
-                Scheduled for removal in 0.6.0."
-    )]
-    #[allow(dead_code)] // TODO(#1958): roadmap — remove in 0.6.0 (tracked by issue #807's follow-up removal PR)
-    pub fn generate_with_batch_prefill(
-        &self,
-        prompt: &str,
-        gen_cfg: &GenerateConfig,
-    ) -> Result<GenerateOutput, InferenceError> {
-        let cfg = &self.config;
-
-        if cfg.is_moe() {
-            return Err(InferenceError::UnsupportedModel(
-                "MoE batch prefill is not yet implemented".into(),
-            ));
-        }
-
-        // Initialize RNG.
-        let mut rng_state = match gen_cfg.seed {
-            Some(s) => {
-                if s == 0 {
-                    1
-                } else {
-                    s
-                }
-            }
-            None => {
-                use std::time::SystemTime;
-                let t = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .map(|d| d.as_nanos() as u64)
-                    .unwrap_or(0x12345678_9abcdef0);
-                if t == 0 { 1 } else { t }
-            }
-        };
-
-        // Tokenize prompt.
-        let input = self.tokenizer.tokenize(prompt);
-        let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
-        let prompt_len = prompt_ids.len();
-
-        if prompt_len == 0 {
-            return Err(InferenceError::Inference("empty prompt".into()));
-        }
-
-        // max_new_tokens == 0 means "generate nothing": return before sampling so
-        // we never emit a token the caller did not ask for. Mirrors the guard in
-        // Qwen35Model::generate (crates/inference/src/model/qwen35/generation.rs).
-        if gen_cfg.max_new_tokens == 0 {
-            return Ok(GenerateOutput {
-                text: String::new(),
-                token_ids: vec![],
-                prompt_tokens: prompt_len,
-                generated_tokens: 0,
-                stopped: false,
-                stop_reason: Some(StopReason::Length),
-                token_logprobs: vec![],
-            });
-        }
-
-        // Grammar-constrained decoding is not wired into the batch-prefill path; reject
-        // grammar configs before any sampling to avoid silently producing unconstrained
-        // output when a caller sets gen_cfg.grammar (#397/#398).
-        check_grammar_not_set(gen_cfg)?;
-        // Same rationale for logprobs capture, which is also not wired into this
-        // generate loop (#585).
-        check_logprobs_not_set(gen_cfg)?;
-        // Same rationale for stop_strings matching and reasoning-budget forcing,
-        // neither of which is wired into this generate loop (ADR-080 C3, #783).
-        check_stop_strings_not_set(gen_cfg)?;
-        check_reasoning_budget_not_set(gen_cfg)?;
-        // Context preflight. apply_partial_rope indexes the precomputed cos/sin table
-        // without bounds checks, so a position at or past max_context() is an out-of-bounds
-        // slice access — a release panic, not a clean error. Mirror the same total-token
-        // policy as generate() and the HTTP server: prompt_len + max_new_tokens <= max_context.
-        let max_context = self.max_context();
-        if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
-            return Err(InferenceError::Inference(format!(
-                "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
-                 model context window ({max_context})",
-                gen_cfg.max_new_tokens
-            )));
-        }
-
-        // Initialize states.
-        let num_linear = cfg.num_linear_attention_layers();
-        let num_full = cfg.num_full_attention_layers();
-        let mut gdn_states: Vec<GatedDeltaNetState> = (0..num_linear)
-            .map(|_| GatedDeltaNetState::new(cfg))
-            .collect();
-        let mut kv_cache = KvCache::new(num_full);
-
-        // Pre-reserve KV storage for prompt prefill.
-        let kv_dim = cfg.full_kv_dim();
-        for i in 0..num_full {
-            kv_cache.k[i].reserve(prompt_len * kv_dim);
-            kv_cache.v[i].reserve(prompt_len * kv_dim);
-        }
-
-        let mut scratch = PrefillScratch::new(cfg);
-
-        let mut generated_ids: Vec<u32> = Vec::with_capacity(gen_cfg.max_new_tokens);
-        let mut all_ids = prompt_ids.clone();
-
-        let logits = self.prefill_prompt(
-            &prompt_ids,
-            &mut gdn_states,
-            &mut kv_cache,
-            &mut scratch,
-            self.lora.as_ref(),
-        )?;
-
-        // Sample from the final prefill logits.
-        let next_id = sample_token(&logits[..cfg.vocab_size], gen_cfg, &all_ids, &mut rng_state);
-
-        if should_stop_token(cfg, gen_cfg, next_id) {
-            return Ok(GenerateOutput {
-                text: String::new(),
-                token_ids: vec![],
-                prompt_tokens: prompt_len,
-                generated_tokens: 0,
-                stopped: true,
-                stop_reason: Some(StopReason::Eos),
-                token_logprobs: vec![],
-            });
-        }
-
-        generated_ids.push(next_id);
-        all_ids.push(next_id);
-
-        let mut stopped = false;
-        let mut stop_reason = StopReason::Length;
-        // Autoregressive decode is unchanged.
-        for _ in 1..gen_cfg.max_new_tokens {
-            let pos = kv_cache.seq_len;
-            let last_token = *all_ids
-                .last()
-                .expect("invariant: prompt or previous sample populated all_ids");
-
-            self.forward_step(
-                last_token,
-                pos,
-                &mut gdn_states,
-                &mut kv_cache,
-                &mut scratch.decode_scratch,
-            );
-            kv_cache.seq_len += 1;
-
-            let next_id = sample_token(
-                &scratch.decode_scratch.logits[..cfg.vocab_size],
-                gen_cfg,
-                &all_ids,
-                &mut rng_state,
-            );
-
-            if should_stop_token(cfg, gen_cfg, next_id) {
-                stopped = true;
-                stop_reason = StopReason::Eos;
-                break;
-            }
-
-            generated_ids.push(next_id);
-            all_ids.push(next_id);
-        }
-
-        let text = decode_tokens(&self.tokenizer, &generated_ids);
-
-        Ok(GenerateOutput {
-            text,
-            token_ids: generated_ids.clone(),
-            prompt_tokens: prompt_len,
-            generated_tokens: generated_ids.len(),
-            stopped,
-            stop_reason: Some(stop_reason),
-            token_logprobs: vec![],
-        })
     }
 
     /// Run one full-attention layer over the whole prompt at once.
@@ -1223,7 +1017,6 @@ fn softplus_prefill(x: f32) -> f32 {
 }
 
 #[cfg(test)]
-#[allow(deprecated)] // exercises generate_with_batch_prefill itself during its deprecation window (issue #807)
 mod tests {
     use super::*;
     use crate::lora_hook::LoraHook;
@@ -1302,47 +1095,21 @@ mod tests {
         cfg.shared_expert_intermediate_size = Some(32);
         assert!(cfg.is_moe());
 
+        let mut gdn_states: Vec<GatedDeltaNetState> = (0..cfg.num_linear_attention_layers())
+            .map(|_| GatedDeltaNetState::new(&cfg))
+            .collect();
+        let mut kv_cache = KvCache::new(cfg.num_full_attention_layers());
         let model = build_random_model(cfg, 0xfeed_face_cafe_beef);
         let err = model
-            .generate_with_batch_prefill("hello", &GenerateConfig::default())
+            .prefill_tokens_batched_for_generate(&[1], &mut gdn_states, &mut kv_cache)
             .expect_err("MoE batch prefill should return UnsupportedModel");
 
         assert!(
             matches!(err, InferenceError::UnsupportedModel(msg) if msg == "MoE batch prefill is not yet implemented")
         );
-    }
-
-    // ── Issue #403 preflight regression test ───────────────────────────────────
-    //
-    // Mutation contract: removing the `if prompt_len.saturating_add(gen_cfg.max_new_tokens)
-    // > max_context` guard added for #403 lets this test run a forward pass. Without the
-    // guard the call fails either by returning Ok — when generation stops before the RoPE
-    // boundary, tripping the `expect_err` below — or by an out-of-bounds RoPE panic if
-    // decode reaches the boundary. Either outcome changes the test result from PASS to FAIL.
-
-    #[test]
-    fn test_generate_with_batch_prefill_rejects_over_context_request() {
-        // Mutation contract: deleting the context preflight added for #403 makes this
-        // test fail either by returning Ok (generation stops before the RoPE boundary,
-        // so the `expect_err` below trips) or by an out-of-bounds RoPE panic if decode
-        // reaches the boundary. Either outcome changes the test result from PASS to FAIL.
-        let cfg = tiny_test_config();
-        let model = build_random_model(cfg, 0xC0D0_0403);
-        let max_context = model.max_context(); // 1024 from tiny_test_config()
-
-        // Single-token prompt ("a") plus max_new_tokens that overflows the window.
-        let gen_cfg = GenerateConfig {
-            max_new_tokens: max_context, // 1 + 1024 = 1025 > 1024
-            ..GenerateConfig::default()
-        };
-        let err = model
-            .generate_with_batch_prefill("a", &gen_cfg)
-            .expect_err("prompt_len + max_new_tokens > max_context must return Err, not panic");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("context window") && msg.contains(&format!("{max_context}")),
-            "error must name the context window limit; got: {msg}"
-        );
+        assert_eq!(kv_cache.seq_len, 0);
+        assert!(kv_cache.k.iter().all(Vec::is_empty));
+        assert!(kv_cache.v.iter().all(Vec::is_empty));
     }
 
     /// A non-trivial LoRA hook that adds a fixed delta to a specific (layer, module) pair.
@@ -1882,158 +1649,6 @@ mod tests {
         (x >> 32) as u32
     }
 
-    /// Build a zero-layer Qwen35Model for generate_with_batch_prefill unit tests.
-    ///
-    /// All-zero embed_tokens → logits all 0 → greedy picks token 0.
-    /// eos_token_id=96 (vocab-1) so token 0 is NOT eos, making stop_token_ids=[0]
-    /// detectable as a distinct stop path.
-    fn zero_layer_batch_prefill_fixture() -> Qwen35Model {
-        let cfg = make_test_config(64, 128, 97, 0);
-        // make_test_config sets eos_token_id = vocab_size-1 = 96 ≠ 0 ✓
-
-        let rope_dim = cfg.rope_dim();
-        let rope_max = cfg.max_position_embeddings.min(8192);
-        let rope = RopeTable::new(rope_dim, rope_max, cfg.rope_theta);
-
-        Qwen35Model {
-            config: cfg.clone(),
-            weights: ModelWeights {
-                // All zeros → logits all 0 → greedy always picks token 0.
-                embed_tokens: vec![0.0f32; cfg.vocab_size * cfg.hidden_size],
-                lm_head: None,
-                final_norm: vec![0.0f32; cfg.hidden_size],
-                layers: vec![],
-            },
-            tokenizer: dummy_tokenizer(),
-            rope,
-            lora: Box::new(crate::lora_hook::NoopLoraHook),
-        }
-    }
-
-    /// Build a 0-layer model where the greedy sequence is: token 1 → 2 → 3 (stop).
-    ///
-    /// embed_tokens uses standard basis vectors: embed[i][i] = 1.0 for i in 1..4 so
-    /// that each token lives in its own orthogonal direction. embed[0] and embed[4..]
-    /// are all zeros.
-    ///
-    /// lm_head is untied (ModelWeights::lm_head = Some(...)). It is a forward-shift
-    /// by one index in the basis:
-    ///   row 2 has col-1 = 1.0  → logit[2] wins from the embed[1] direction
-    ///   row 3 has col-2 = 1.0  → logit[3] wins from the embed[2] direction
-    ///
-    /// Greedy sequence from prompt "a" (→ token 1, eos_token_id=6):
-    ///   post-prefill: RMSNorm(embed[1]) = [0, 4, 0, …] → logit[2] = 4 wins → token 2
-    ///   decode step 1: RMSNorm(embed[2]) = [0, 0, 4, …] → logit[3] = 4 wins → stop(3)
-    fn rotation_model_fixture() -> Qwen35Model {
-        let cfg = make_test_config(16, 16, 7, 0);
-        let rope_dim = cfg.rope_dim();
-        let rope_max = cfg.max_position_embeddings.min(8192);
-        let rope = RopeTable::new(rope_dim, rope_max, cfg.rope_theta);
-        let hidden = cfg.hidden_size; // 16
-        let vocab = cfg.vocab_size; // 7
-
-        // Standard basis: each active token lives in its own orthogonal dimension.
-        let mut embed = vec![0.0f32; vocab * hidden];
-        embed[hidden + 1] = 1.0; // token 1 → e_1
-        embed[2 * hidden + 2] = 1.0; // token 2 → e_2
-        embed[3 * hidden + 3] = 1.0; // token 3 → e_3 (stop)
-
-        // Forward-shift lm_head: e_1 direction wins token 2; e_2 direction wins token 3.
-        // With RMSNorm(gamma=0), hidden = 4 * e_i for token i (inv_rms = 4.0 at hidden=16).
-        let mut lm_head = vec![0.0f32; vocab * hidden];
-        lm_head[2 * hidden + 1] = 1.0; // logit[2] = 4 * 1 = 4 from token 1
-        lm_head[3 * hidden + 2] = 1.0; // logit[3] = 4 * 1 = 4 from token 2
-
-        Qwen35Model {
-            config: cfg.clone(),
-            weights: ModelWeights {
-                embed_tokens: embed,
-                lm_head: Some(lm_head),
-                final_norm: vec![0.0f32; hidden],
-                layers: vec![],
-            },
-            tokenizer: dummy_tokenizer(),
-            rope,
-            lora: Box::new(crate::lora_hook::NoopLoraHook),
-        }
-    }
-
-    /// `generate_with_batch_prefill` must stop on a token in `stop_token_ids`
-    /// even when that token differs from `eos_token_id`.
-    ///
-    /// Setup: all-zero weights → greedy sampling always picks token 0.
-    /// Config has eos_token_id=96 (not 0) and stop_token_ids=[0].
-    /// With the fix the first sampled token (0) hits the stop list and the
-    /// function returns 0 generated tokens.
-    ///
-    /// Mutation check: reverting `should_stop_token` back to
-    /// `next_id == cfg.eos_token_id` in either check causes `0 == 96` to be false,
-    /// so token 0 is pushed to output and `generated_tokens` becomes ≥ 1.
-    #[test]
-    fn test_generate_with_batch_prefill_honors_stop_token_ids() {
-        let model = zero_layer_batch_prefill_fixture();
-
-        let gen_cfg = GenerateConfig {
-            max_new_tokens: 4,
-            stop_token_ids: vec![0], // token 0 is the stop signal, NOT eos (96)
-            temperature: 0.0,        // greedy: all-zero logits always yield token 0
-            ..Default::default()
-        };
-
-        let out = model
-            .generate_with_batch_prefill("a", &gen_cfg)
-            .expect("generate_with_batch_prefill must succeed with valid stop_token_ids");
-
-        assert_eq!(
-            out.generated_tokens, 0,
-            "generate_with_batch_prefill must stop immediately when the first \
-             greedy token (0) is in stop_token_ids — got {} generated tokens instead",
-            out.generated_tokens
-        );
-    }
-
-    /// `generate_with_batch_prefill` must also stop when the stop token first
-    /// appears in the **decode loop**, not only at the post-prefill check.
-    ///
-    /// Fixture: rotation_model_fixture(). Greedy sequence from prompt "a" (token 1):
-    ///   post-prefill  → token 2  (not stop=3)
-    ///   decode step 1 → token 3  (stop) → decode-loop fires
-    ///
-    /// Mutation proof: reverting ONLY the decode-loop `should_stop_token` check
-    /// (line 444 at time of writing) to `next_id == cfg.eos_token_id` leaves
-    /// token 3 uncaught (3 ≠ eos=6), the sequence continues, and generated_tokens
-    /// becomes ≥ 2 — failing the assertion below.
-    #[test]
-    fn test_generate_with_batch_prefill_honors_stop_token_ids_decode_loop() {
-        let model = rotation_model_fixture();
-
-        let gen_cfg = GenerateConfig {
-            max_new_tokens: 10,
-            stop_token_ids: vec![3], // stop on token 3 mid-decode-loop; eos_token_id=6≠3
-            temperature: 0.0,        // greedy: deterministic forward-shift sequence
-            ..Default::default()
-        };
-
-        // Prompt "a" → token 1.
-        // Post-prefill generates token 2 (not stop).
-        // Decode step 1 generates token 3 → decode-loop stop fires.
-        let out = model
-            .generate_with_batch_prefill("a", &gen_cfg)
-            .expect("generate_with_batch_prefill must succeed");
-
-        assert_eq!(
-            out.generated_tokens, 1,
-            "generate_with_batch_prefill must stop at decode-loop step 1 when token 3 \
-             is in stop_token_ids — got {} tokens; reverting only the decode-loop check \
-             lets token 3 through and produces ≥ 2 tokens",
-            out.generated_tokens
-        );
-        assert!(
-            out.stopped,
-            "generate_with_batch_prefill must set stopped=true when the decode-loop stop fires"
-        );
-    }
-
     /// Minimal byte-level BPE tokenizer parsed from a string — no temp file, no
     /// cross-test races.
     fn dummy_tokenizer() -> BpeTokenizer {
@@ -2060,134 +1675,6 @@ mod tests {
   }
 }"#;
         BpeTokenizer::from_tokenizer_json_str(json).expect("test tokenizer parses")
-    }
-
-    /// `generate_with_batch_prefill` must reject a `GenerateConfig` that sets `grammar`
-    /// with a typed `InvalidInput` error before sampling any token (#397/#398).
-    ///
-    /// Before the fix, grammar was silently ignored and unconstrained output was produced.
-    /// The guard fires before any weight access or state allocation, so a real (tiny) model
-    /// with valid weights is sufficient — the guard short-circuits before the prefill call.
-    ///
-    /// Mutation sensitivity: removing `check_grammar_not_set` causes the function to proceed
-    /// through the full prefill + decode path with the tiny weights, returning `Ok(...)`.
-    /// The `matches!(result, Err(InferenceError::InvalidInput(_)))` assert then fails.
-    #[test]
-    fn generate_with_batch_prefill_rejects_grammar_config_before_sampling() {
-        use crate::error::InferenceError;
-        use crate::grammar::{GrammarEngine, GrammarSpec};
-        use std::sync::Arc;
-
-        let cfg = tiny_test_config();
-        let model = build_random_model(cfg, 0x1234_5678_abcd_ef01);
-
-        let spec = GrammarSpec::Gbnf("root ::= \"a\" | \"b\"\n".to_string());
-        let grammar_vocab = vec![b"a".to_vec(), b"b".to_vec()];
-        let engine =
-            GrammarEngine::new(&spec, grammar_vocab).expect("trivial grammar must compile");
-
-        let gen_cfg = GenerateConfig {
-            grammar: Some(Arc::new(engine)),
-            ..Default::default()
-        };
-
-        let result = model.generate_with_batch_prefill("a b c", &gen_cfg);
-        assert!(
-            matches!(result, Err(InferenceError::InvalidInput(_))),
-            "generate_with_batch_prefill must fail closed with InvalidInput when grammar is \
-             set (#397/#398); got {result:?}"
-        );
-    }
-
-    /// `generate_with_batch_prefill` must reject a `GenerateConfig` that sets
-    /// `stop_strings` with a typed `InvalidInput` error before sampling any token
-    /// (ADR-080 C3, #783).
-    ///
-    /// Mutation sensitivity: removing `check_stop_strings_not_set` causes the
-    /// function to proceed through the full prefill + decode path with the tiny
-    /// weights, returning `Ok(...)`. The `matches!` assert then fails.
-    #[test]
-    fn generate_with_batch_prefill_rejects_stop_strings_config_before_sampling() {
-        use crate::error::InferenceError;
-
-        let cfg = tiny_test_config();
-        let model = build_random_model(cfg, 0x1234_5678_abcd_ef01);
-
-        let gen_cfg = GenerateConfig {
-            stop_strings: vec!["</s>".to_string()],
-            ..Default::default()
-        };
-
-        let result = model.generate_with_batch_prefill("a b c", &gen_cfg);
-        assert!(
-            matches!(result, Err(InferenceError::InvalidInput(_))),
-            "generate_with_batch_prefill must fail closed with InvalidInput when \
-             stop_strings is set (ADR-080 C3, #783); got {result:?}"
-        );
-    }
-
-    /// `generate_with_batch_prefill` must reject a `GenerateConfig` that sets
-    /// `reasoning_budget` with a typed `InvalidInput` error before sampling any
-    /// token (ADR-080 C3, #783).
-    ///
-    /// Mutation sensitivity: removing `check_reasoning_budget_not_set` causes the
-    /// function to proceed through the full prefill + decode path with the tiny
-    /// weights, returning `Ok(...)`. The `matches!` assert then fails.
-    #[test]
-    fn generate_with_batch_prefill_rejects_reasoning_budget_config_before_sampling() {
-        use crate::error::InferenceError;
-
-        let cfg = tiny_test_config();
-        let model = build_random_model(cfg, 0x1234_5678_abcd_ef01);
-
-        let gen_cfg = GenerateConfig {
-            reasoning_budget: Some(16),
-            ..Default::default()
-        };
-
-        let result = model.generate_with_batch_prefill("a b c", &gen_cfg);
-        assert!(
-            matches!(result, Err(InferenceError::InvalidInput(_))),
-            "generate_with_batch_prefill must fail closed with InvalidInput when \
-             reasoning_budget is set (ADR-080 C3, #783); got {result:?}"
-        );
-    }
-
-    /// `generate_with_batch_prefill` with `max_new_tokens == 0` must return zero
-    /// generated tokens without running prefill or sampling anything (#612, 3rd
-    /// recurrence of the #226/#456 bug class).
-    ///
-    /// Mutation sensitivity: removing the `max_new_tokens == 0` early return
-    /// causes the function to run `prefill_prompt` and sample one token from the
-    /// final logits, so `generated_tokens` becomes 1 instead of 0 and the
-    /// assertion below fails.
-    #[test]
-    fn generate_with_batch_prefill_max_new_tokens_zero_returns_empty() {
-        let cfg = tiny_test_config();
-        let model = build_random_model(cfg, 0x1234_5678_abcd_ef01);
-
-        let gen_cfg = GenerateConfig {
-            max_new_tokens: 0,
-            ..Default::default()
-        };
-
-        let out = model
-            .generate_with_batch_prefill("a b c", &gen_cfg)
-            .expect("max_new_tokens=0 must succeed, not error");
-
-        assert_eq!(
-            out.generated_tokens, 0,
-            "max_new_tokens=0 must produce zero generated tokens"
-        );
-        assert!(
-            out.token_ids.is_empty(),
-            "max_new_tokens=0 must produce an empty token list"
-        );
-        assert_eq!(
-            out.stop_reason,
-            Some(StopReason::Length),
-            "max_new_tokens=0 must report stop_reason=Length"
-        );
     }
 
     /// ADR-080 C1 (#780): RED before the fix, `running_sum.max(f32::MIN_POSITIVE)`

--- a/crates/inference/src/forward/batch_prefill.rs
+++ b/crates/inference/src/forward/batch_prefill.rs
@@ -18,7 +18,7 @@ use crate::attention::gdn::{
 use crate::error::InferenceError;
 use crate::forward::cpu::{elementwise_mul, matmul_bt, silu_inplace};
 use crate::model::qwen35::{
-    AttentionWeights, CommonLayerWeights, DenseFfnWeights, FeedForwardWeights, ForwardScratch,
+    AttentionWeights, CommonLayerWeights, DenseFfnWeights, FeedForwardWeights,
     FullAttentionLayerWeights, KvCache, Qwen35Model, qwen35_rms_norm, resize,
 };
 use crate::model::qwen35_config::Qwen35Config;
@@ -71,10 +71,6 @@ struct PrefillScratch {
     /// FFN output after down projection: `[seq_len, hidden_size]`.
     ffn_batch: Vec<f32>,
 
-    // ----- Single-token decode scratch -----
-    /// Reuses the existing single-token decode scratch after prompt prefill.
-    decode_scratch: ForwardScratch,
-
     // ----- Attention tiling config -----
     /// Tiling configuration for full-attention prompt prefill.
     tiled_config: TiledAttentionConfig,
@@ -124,7 +120,6 @@ impl PrefillScratch {
             gate_batch: Vec::new(),
             up_batch: Vec::new(),
             ffn_batch: Vec::new(),
-            decode_scratch: ForwardScratch::new(),
             tiled_config: TiledAttentionConfig::new(
                 cfg.num_attention_heads,
                 cfg.num_key_value_heads,
@@ -175,7 +170,6 @@ impl PrefillScratch {
         resize(&mut self.up_batch, seq_len * inter);
         resize(&mut self.ffn_batch, seq_len * hidden);
 
-        self.decode_scratch.ensure_capacity(cfg, seq_len + 1);
         resize(&mut self.logits, cfg.vocab_size);
 
         resize(&mut self.gdn_conv_token, qkv_dim);
@@ -1020,7 +1014,7 @@ fn softplus_prefill(x: f32) -> f32 {
 mod tests {
     use super::*;
     use crate::lora_hook::LoraHook;
-    use crate::model::qwen35::ModelWeights;
+    use crate::model::qwen35::{ForwardScratch, ModelWeights};
     use crate::model::qwen35_config::LayerType;
     use crate::rope::RopeTable;
     use crate::tokenizer::bpe::BpeTokenizer;

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -2190,9 +2190,9 @@ fn truncate_token_logprobs_to_retained_text(
 
 /// Returns true when `token_id` is EOS or is in the `stop_token_ids` list.
 ///
-/// `pub(crate)` — all callers (Q8, F16, NEON, batch-prefill generate paths) live
-/// within this crate. Keeping the function crate-private avoids leaking a
-/// low-level sampling helper as part of the public API.
+/// `pub(crate)` — all call sites live within this crate. Keeping the function
+/// crate-private avoids leaking a low-level sampling helper as part of the
+/// public API.
 pub(crate) fn should_stop_token(
     cfg: &Qwen35Config,
     gen_cfg: &GenerateConfig,
@@ -2213,7 +2213,6 @@ pub(crate) fn should_stop_token(
 /// - `generate_q8` (`forward/cpu_q8.rs`)
 /// - `generate_f16` (`forward/cpu_f16.rs`)
 /// - `generate_q8_neon` (`forward/neon_forward.rs`)
-/// - `Qwen35Model::generate_with_batch_prefill` (`forward/batch_prefill.rs`)
 /// - `multimodal_generate_preflight` (`forward/metal_qwen35.rs`)
 ///
 /// The base CPU `generate()` / `generate_streaming()` paths in this module wire
@@ -2255,8 +2254,7 @@ pub(crate) fn check_logprobs_not_set(gen_cfg: &GenerateConfig) -> Result<(), Inf
 /// string-level stop matching into its decode loop.
 ///
 /// Callers: `generate_f16` (`forward/cpu_f16.rs`), `generate_q8`
-/// (`forward/cpu_q8.rs`), `generate_q8_neon` (`forward/neon_forward.rs`),
-/// `Qwen35Model::generate_with_batch_prefill` (`forward/batch_prefill.rs`).
+/// (`forward/cpu_q8.rs`), `generate_q8_neon` (`forward/neon_forward.rs`).
 ///
 /// The base CPU `generate()` / `generate_streaming()` paths in this module,
 /// and the Metal `generate()` / `generate_streaming()` / `generate_multimodal`

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -97,7 +97,7 @@ pub(crate) use weights::{MoeLayerWeights, MoeRouter, RoutedExperts, SharedExpert
 
 #[cfg(test)]
 pub use detokenize::bytes_to_unicode;
-// Needed by all generate paths (cpu_q8, cpu_f16, neon_forward, batch_prefill)
+// Needed by all generate paths (cpu_q8, cpu_f16, neon_forward)
 // and by tests. `pub(crate)` keeps it out of the public API surface.
 pub(crate) use generation::should_stop_token;
 // Public raw generation-lifecycle observer event, consumed by

--- a/crates/inference/src/sampling.rs
+++ b/crates/inference/src/sampling.rs
@@ -552,7 +552,7 @@ thread_local! {
     /// no owning struct to hold per-generation buffers: the Metal CPU fallback
     /// (`forward/metal_qwen35.rs`'s private `sample_token`) and the Qwen CPU
     /// decode loops (`model/qwen35/sampling.rs::sample_token`, shared by the
-    /// f16/q8/NEON/batch-prefill forward paths). Kept thread-local instead of
+    /// f16/q8/NEON forward paths). Kept thread-local instead of
     /// per-call so vocab-sized buffers are allocated once per thread and
     /// reused across every decode step, not just within one generation.
     static FULL_LOGIT_SCRATCH: std::cell::RefCell<FullLogitScratch> =

--- a/crates/inference/src/stop_token_contract.rs
+++ b/crates/inference/src/stop_token_contract.rs
@@ -11,13 +11,15 @@
 //! - **EXCLUDE**: the stop token is detected *before* it is pushed, so
 //!   `token_ids`/`text` never contain it (the Qwen3.5 CPU family in
 //!   [`crate::model::qwen35::generation`], [`crate::forward::cpu_f16`],
-//!   [`crate::forward::cpu_q8`], [`crate::forward::neon_forward`],
-//!   [`crate::forward::batch_prefill`], and the Metal plain/streaming/
-//!   prefix-cache paths in [`crate::forward::metal_qwen35`]).
+//!   [`crate::forward::cpu_q8`], [`crate::forward::neon_forward`], and the
+//!   Metal plain/streaming/prefix-cache paths in
+//!   [`crate::forward::metal_qwen35`]).
 //!
-//! **Chosen contract: EXCLUDE.** It was already the majority behaviour (8 of
-//! 10 surveyed call sites), it matches the OpenAI/HF `stop` semantics most
-//! callers expect (the stop marker is a control signal, not content), and it
+//! **Chosen contract: EXCLUDE.** It was already the majority behaviour (9 of
+//! 11 surveyed call sites — the current entry-point manifest below, minus the
+//! two that needed a production change), it matches the OpenAI/HF `stop`
+//! semantics most callers expect (the stop marker is a control signal, not
+//! content), and it
 //! composes correctly with string-level `stop_strings` truncation, which by
 //! construction already drops the matched suffix. `GenerateOutput`'s doc
 //! comment (in [`crate::generate`] and [`crate::model::qwen35_config`]) now
@@ -112,8 +114,7 @@ mod tests {
 
     /// Shared zero-layer config: embed -> final_norm -> lm_head only, no
     /// attention/FFN. Mirrors the established fixture recipe already used by
-    /// `cpu_f16::zero_layer_f16_fixture`, `cpu_q8::zero_layer_q8_fixture`, and
-    /// `batch_prefill::zero_layer_batch_prefill_fixture`.
+    /// `cpu_f16::zero_layer_f16_fixture` and `cpu_q8::zero_layer_q8_fixture`.
     fn zero_layer_config() -> Qwen35Config {
         Qwen35Config {
             hidden_size: HIDDEN,

--- a/crates/inference/src/stop_token_contract.rs
+++ b/crates/inference/src/stop_token_contract.rs
@@ -30,18 +30,17 @@
 //! |---|---|---|
 //! | 1 | `Qwen35Model::generate` (f32) | this file |
 //! | 2 | `Qwen35Model::generate_streaming` (f32) | this file |
-//! | 3 | `Qwen35Model::generate_with_batch_prefill` | this file |
-//! | 4 | `forward::cpu_f16::generate_f16` | this file |
-//! | 5 | `forward::cpu_q8::generate_q8` | this file |
-//! | 6 | `forward::neon_forward::generate_q8_neon` | this file |
-//! | 7 | Metal `generate` (plain, no MTP/self-spec) | `forward::metal_qwen35::inner::tests` |
-//! | 8 | Metal `generate` with `LATTICE_MTP=1` | `forward::metal_qwen35::inner::tests` + `mtp_greedy_round_tests` |
-//! | 9 | Metal `generate` with `LATTICE_SELF_SPEC=1` | `forward::metal_qwen35::inner::tests` + `self_spec_eos_tests` |
-//! | 10 | Metal `generate_streaming` | `forward::metal_qwen35::inner::tests` |
-//! | 11 | Metal `generate_streaming_with_prefix_cache` | `forward::metal_qwen35::inner::tests` |
-//! | 12 | Metal `generate_multimodal` | `forward::metal_qwen35::inner::tests` |
+//! | 3 | `forward::cpu_f16::generate_f16` | this file |
+//! | 4 | `forward::cpu_q8::generate_q8` | this file |
+//! | 5 | `forward::neon_forward::generate_q8_neon` | this file |
+//! | 6 | Metal `generate` (plain, no MTP/self-spec) | `forward::metal_qwen35::inner::tests` |
+//! | 7 | Metal `generate` with `LATTICE_MTP=1` | `forward::metal_qwen35::inner::tests` + `mtp_greedy_round_tests` |
+//! | 8 | Metal `generate` with `LATTICE_SELF_SPEC=1` | `forward::metal_qwen35::inner::tests` + `self_spec_eos_tests` |
+//! | 9 | Metal `generate_streaming` | `forward::metal_qwen35::inner::tests` |
+//! | 10 | Metal `generate_streaming_with_prefix_cache` | `forward::metal_qwen35::inner::tests` |
+//! | 11 | Metal `generate_multimodal` | `forward::metal_qwen35::inner::tests` |
 //!
-//! Entry 12 (`generate_multimodal`) has its own independent sampling loop —
+//! Entry 11 (`generate_multimodal`) has its own independent sampling loop —
 //! it does not call `generate`/`generate_streaming` internally — and was
 //! missing from this manifest until the PR #632 review flagged it as
 //! an unguarded sibling-invocation path (#613's own warning pattern). Its
@@ -50,7 +49,7 @@
 //! autoregressive decode loop), so no production change was needed here —
 //! only manifest + test coverage.
 //!
-//! The Metal-family tests (7-11) live inside `metal_qwen35.rs`'s existing
+//! The Metal-family tests (6-11) live inside `metal_qwen35.rs`'s existing
 //! `mod tests` rather than here because its GPU test fixtures
 //! (`tiny_hybrid_fixture`, `minimal_bpe_tokenizer`, `with_self_spec_env`) are
 //! private to that module and already proven correct by dozens of existing
@@ -82,7 +81,7 @@
 //! `generated_tokens == 0`, `token_ids` and `text` empty, `stopped == true`,
 //! `stop_reason == Some(StopReason::Eos)`.
 //!
-//! Most of the paths tested here (1-6) were already EXCLUDE before this
+//! Most of the paths tested here (1-5) were already EXCLUDE before this
 //! session's fix — they regression-lock behaviour that was already correct.
 //! The two paths whose logic changed (MTP, self-spec) are unit-tested at the
 //! decision-function level in `metal_qwen35.rs`'s `mtp_greedy_round_tests`
@@ -255,16 +254,6 @@ mod tests {
             "generate_streaming must not emit an on_token callback for an \
              excluded stop token, got {deltas:?}"
         );
-    }
-
-    #[test]
-    #[allow(deprecated)] // exercises the deprecated path itself during its deprecation window (issue #807)
-    fn qwen35_model_generate_with_batch_prefill_excludes_stop_token() {
-        let model = zero_layer_qwen35_model();
-        let out = model
-            .generate_with_batch_prefill("h", &stop_gen_cfg())
-            .expect("generate_with_batch_prefill must succeed");
-        assert_excludes_stop_token(&out, "Qwen35Model::generate_with_batch_prefill");
     }
 
     #[test]

--- a/docs/adr/ADR-080-consolidation-duplicated-contracts.md
+++ b/docs/adr/ADR-080-consolidation-duplicated-contracts.md
@@ -56,12 +56,12 @@ defect** — the signature of a missing shared contract, not of intentional back
 
 ### Evidence summary (from the duplication maps)
 
-| cluster | nominal operations mapped | site counts (largest → smallest) | unfiled held findings (post-verification) | filed issues |
-|---|---|---|---|---|
-| attention-softmax | 6 | 6, 6, 4, 4, 3, 3 | 4 (CPU MHA -inf floor, Flash-causal NaN-key, differential/native-sparse hardening, Qwen3 secondary-loop duplication) | #739, #740, #741 |
-| http-serve | 6 | 3, 3, 3, 3, 2, 2 | 1 (unify endpoint/error contracts) | #744, #745, #746 |
-| sampling-decode | 6 | 10, 6, 4, 4, 4, 1 | 2 (canonical greedy-selection sharing; fail-closed generation controls on alternate CPU decode loops) | none |
-| matmul-gemm | 10 | 14, 7, 6, 5, 5, 5, 4, 4, 3, 1 | 5 (scaled-SGEMM FFI validation, standalone WGPU/Metal validation, BitNet release-active checks, SwiGLU short-activation rejection, oversized-input unification) | none |
+| cluster           | nominal operations mapped | site counts (largest → smallest) | unfiled held findings (post-verification)                                                                                                                       | filed issues     |
+| ----------------- | ------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| attention-softmax | 6                         | 6, 6, 4, 4, 3, 3                 | 4 (CPU MHA -inf floor, Flash-causal NaN-key, differential/native-sparse hardening, Qwen3 secondary-loop duplication)                                            | #739, #740, #741 |
+| http-serve        | 6                         | 3, 3, 3, 3, 2, 2                 | 1 (unify endpoint/error contracts)                                                                                                                              | #744, #745, #746 |
+| sampling-decode   | 6                         | 10, 6, 4, 4, 4, 1                | 2 (canonical greedy-selection sharing; fail-closed generation controls on alternate CPU decode loops)                                                           | none             |
+| matmul-gemm       | 10                        | 14, 7, 6, 5, 5, 5, 4, 4, 3, 1    | 5 (scaled-SGEMM FFI validation, standalone WGPU/Metal validation, BitNet release-active checks, SwiGLU short-activation rejection, oversized-input unification) | none             |
 
 12 unfiled held findings plus 6 filed issues (18 total) were confirmed against live source at the
 audited commit and re-checked against a commit 51 revisions later; none was a stale artifact of
@@ -83,15 +83,15 @@ checklists (18 findings total across the four clusters).
 
 **Consolidate within existing crates. Do not create a new crate.** Extract one small, checked,
 module-level helper per cluster inside `lattice-inference` (the crate that owns every site
-*selected for consolidation* in all four clusters). Keep every backend-specific kernel — CPU
+_selected for consolidation_ in all four clusters). Keep every backend-specific kernel — CPU
 scalar, CPU SIMD (NEON/AVX2), Metal, WGPU — as a separate implementation. The scalar/CPU
 implementation in each cluster is named the **numeric reference** ("formula oracle"): it is the
 specification other backends are checked against in parity tests, not itself replaced by a
 cross-backend abstraction.
 
 A new crate is justified only when a helper's canonical dependency-free logic is needed by two or
-more *crates* that do not already share a dependency edge. None of the four clusters meets that
-bar: attention-softmax, sampling-decode, and every matmul-gemm site *selected for consolidation*
+more _crates_ that do not already share a dependency edge. None of the four clusters meets that
+bar: attention-softmax, sampling-decode, and every matmul-gemm site _selected for consolidation_
 are intra-`lattice-inference`; http-serve spans two binaries (`lattice.rs`, `lattice_serve.rs`)
 that already live in the same crate. (The matmul-gemm survey also touched `lattice-fann`'s
 dense-layer GEMM and one delegating call site in `lattice-embed` — those are cross-crate,
@@ -134,7 +134,7 @@ takes row scores and returns the fail-closed normalized row per the contract abo
 variant (f32/f16/Q8/NEON), the Flash-causal tiled and fallback paths, the two Qwen3 secondary loops,
 and the three standalone-attention-variant sites call it instead of reimplementing row reduction.
 Metal and WGPU kernels stay separate GPU code but gain an explicit non-finite-row contract test
-that checks the *kernel output* against the same reference. The unselected legacy Metal
+that checks the _kernel output_ against the same reference. The unselected legacy Metal
 score/softmax kernel is deleted (dead code, not a live divergence to fix).
 
 **Resolves**: the four unfiled held findings for this cluster — exact zero for -inf-masked CPU MHA
@@ -180,12 +180,14 @@ the same "two independently-maintained request/response paths" root cause this c
 
 ### C3: Backend-neutral decode policy (sampling-decode)
 
-**Evidence.** The Qwen autoregressive decode-policy loop recurs across 10 sites:
+**Evidence.** The Qwen autoregressive decode-policy loop recurs across 9 sites:
 `model/qwen35/generation.rs` (both canonical CPU entry points), `forward/cpu_f16.rs`,
-`forward/cpu_q8.rs`, `forward/neon_forward.rs`, `forward/batch_prefill.rs`, and four
-`forward/metal_qwen35.rs` entry points (direct, streaming, MTP, multimodal-adjacent). #657 already
-fixed `stop_strings` propagation on four Metal decode loops (landed 2026-07-04, confirmed in
-re-verification at `0699e60cc`), narrowing but not closing the family.
+`forward/cpu_q8.rs`, `forward/neon_forward.rs`, and four `forward/metal_qwen35.rs` entry points
+(direct, streaming, MTP, multimodal-adjacent). #657 already fixed `stop_strings` propagation on
+four Metal decode loops (landed 2026-07-04, confirmed in re-verification at `0699e60cc`),
+narrowing but not closing the family. `forward/batch_prefill.rs` carried this cluster's only
+decode loop (`generate_with_batch_prefill`); that loop was removed as a dead, redundant
+duplicate (#807), so `batch_prefill.rs` is prefill-only and out of this cluster.
 
 **Divergence.** The two canonical CPU generation entry points apply the full `GenerateConfig`
 policy — `stop_strings` and reasoning-budget — and fail closed on unsupported grammar. The
@@ -308,7 +310,7 @@ benchmark binaries.
 ## What we are NOT doing
 
 - **No new crate.** Every extracted helper lands inside `lattice-inference`, the crate that already
-  owns every site *selected for consolidation* in all four clusters. A new crate would add a publish-order
+  owns every site _selected for consolidation_ in all four clusters. A new crate would add a publish-order
   dependency edge for zero cross-crate consumers.
 - **No cross-crate kernel unification.** `lattice-fann`'s dense-layer GEMM and
   `lattice-inference`'s attention/projection GEMMs stay independent implementations; only
@@ -389,7 +391,7 @@ widest span of call sites and the training/autodiff paths).
    Rejected. The audit explicitly found that CPU/SIMD/Metal/WGPU reduction-order and
    precision-staging differences (e.g. f32 vs half-tile staging in Q4 Metal kernels) are
    intentional performance/precision trade-offs, not defects. Only the argument-validation and
-   fail-closed-row *contracts* are duplicated and drifting; the arithmetic kernels themselves are
+   fail-closed-row _contracts_ are duplicated and drifting; the arithmetic kernels themselves are
    correctly backend-specific and are kept separate.
 
 4. **Do nothing beyond the individually-filed issues, and let periodic audits re-discover the same

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -321,6 +321,7 @@ local safetensors directory -> Qwen35Model::from_safetensors
   -> required tensor validation (validate_required_tensor_names)
   -> load_weights                                    (model/qwen35/loading.rs)
   -> BpeTokenizer::from_tokenizer_json                (tokenizer.json)
+  -> Qwen35Model::generate / generate_streaming       (model/qwen35/generation.rs)
   -> Tokenizer::tokenize(prompt)                      (tokenizer/common.rs)
   -> prefill_tokens_batched_for_generate              (forward/batch_prefill.rs)
        -> prefill_prompt                              (forward/batch_prefill.rs)
@@ -340,11 +341,6 @@ single batched `prefill_prompt` pass over the whole prompt (PR #680) and returns
 prompt position's logits. Both then sample the first token with `sample_token`, and enter a
 decode loop that calls the single-token `forward_step` (`model/qwen35/forward.rs`) and
 `sample_token` once per generated token.
-
-Note: `Qwen35Model::generate_with_batch_prefill` (`forward/batch_prefill.rs`) is a separate,
-**deprecated** (since 0.5.1, issue #807) standalone decode loop that predates the delegation
-above — it calls the same batched-prefill core directly but is not the canonical entry point.
-New callers should use `Qwen35Model::generate` / `generate_streaming`.
 
 Note: the tokenizer trait method is `tokenize`, not `encode` — `encode` is a method on the
 separate `QwenModel` embedding path (`model/qwen.rs`), not on the `Tokenizer` trait used here.

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -167,8 +167,8 @@ implementations:
 
 ## Deprecations
 
-- `crate::generate` (`GenerateConfig`, `GenerateOutput`, `generate`) and
-  `Qwen35Model::generate_with_batch_prefill` are marked `#[deprecated(since = "0.5.1")]`.
+- `crate::generate` (`GenerateConfig`, `GenerateOutput`, `generate`) and the standalone
+  Qwen3.5 batched-prefill generation wrapper are marked `#[deprecated(since = "0.5.1")]`.
   Originally scheduled for removal in 0.6.0 (#865); the removal target slips to
   **0.7.0** (deliberate — give downstream consumers a full extra release to migrate off
   the deprecated paths before this release also lands unrelated breaking changes; see

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -82,10 +82,10 @@ or construct/destructure `ChatCompletionOutput` exhaustively needs no source cha
   keeps smaller-group models under the occupancy cliff. Self-measured (M2 Max,
   Qwen3.5-0.8B-Q4, idle GPU, same session, production dispatch path):
 
-  | prompt tokens | previous (group-8 kernel) | this change (group-4 kernel) | delta |
-  |---:|---:|---:|---:|
-  | 2048 | 1204.3 ms | 1062.3 ms (std 1.9) | -11.8% |
-  | 4096 | 3179.2 ms | 2600.3 ms (std 3.5) | -18.2% |
+  | prompt tokens | previous (group-8 kernel) | this change (group-4 kernel) |  delta |
+  | ------------: | ------------------------: | ---------------------------: | -----: |
+  |          2048 |                 1204.3 ms |          1062.3 ms (std 1.9) | -11.8% |
+  |          4096 |                 3179.2 ms |          2600.3 ms (std 3.5) | -18.2% |
 
   Output is bit-identical per model; this is purely an occupancy/scheduling change.
 - **Skip discarded terminal work on intermediate long-prefill chunks** (#708): chunked
@@ -167,8 +167,8 @@ implementations:
 
 ## Deprecations
 
-- `crate::generate` (`GenerateConfig`, `GenerateOutput`, `generate`) and the standalone
-  Qwen3.5 batched-prefill generation wrapper are marked `#[deprecated(since = "0.5.1")]`.
+- `crate::generate` (`GenerateConfig`, `GenerateOutput`, `generate`) and
+  `Qwen35Model::generate_with_batch_prefill` are marked `#[deprecated(since = "0.5.1")]`.
   Originally scheduled for removal in 0.6.0 (#865); the removal target slips to
   **0.7.0** (deliberate — give downstream consumers a full extra release to migrate off
   the deprecated paths before this release also lands unrelated breaking changes; see

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,5 +1,17 @@
 # lattice v0.7.0
 
+## Breaking changes
+
+- **`Qwen35Model::generate_with_batch_prefill` (`crates/inference/src/forward/batch_prefill.rs`)
+  removed.** It was marked `#[deprecated(since = "0.5.1")]` in v0.6.0 with removal
+  targeted at this release (#807): a standalone decode loop that predated
+  `Qwen35Model::generate` / `generate_streaming` delegating their own prompt phase to
+  the same batched-prefill core (`prefill_tokens_batched_for_generate`), leaving it an
+  unused, redundant duplicate. Migrate to `Qwen35Model::generate` /
+  `Qwen35Model::generate_streaming` (`crates/inference/src/model/qwen35/generation.rs`) —
+  both already take the same `GenerateConfig` and return the same `GenerateOutput`, so
+  the call is a drop-in replacement.
+
 ## Fixes
 
 - The two HTTP serve binaries now emit an SSE error envelope when generation fails mid-stream,

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -7,10 +7,12 @@
   targeted at this release (#807): a standalone decode loop that predated
   `Qwen35Model::generate` / `generate_streaming` delegating their own prompt phase to
   the same batched-prefill core (`prefill_tokens_batched_for_generate`), leaving it an
-  unused, redundant duplicate. Migrate to `Qwen35Model::generate` /
-  `Qwen35Model::generate_streaming` (`crates/inference/src/model/qwen35/generation.rs`) —
-  both already take the same `GenerateConfig` and return the same `GenerateOutput`, so
-  the call is a drop-in replacement.
+  unused, redundant duplicate. Migrate to `Qwen35Model::generate`
+  (`crates/inference/src/model/qwen35/generation.rs`) for a drop-in replacement — it
+  takes the same `GenerateConfig` and returns the same `GenerateOutput`. For streaming
+  output, use `Qwen35Model::generate_streaming` instead, which takes the same
+  `GenerateConfig` and returns the same `GenerateOutput` but additionally requires an
+  `on_token: impl FnMut(&str)` callback invoked as each token is produced.
 
 ## Fixes
 


### PR DESCRIPTION
Closes #810.

Removes the deprecated standalone Qwen3.5 batch-prefill decode loop and its wrapper-specific tests.
Keeps the shared batched-prefill core and routes documentation and contract coverage through the canonical generate and generate_streaming entry points.

## bench-compare disposition (ADR-058)

No A/B run — this change lies outside the measured call graph of both default bench targets.

`make bench-compare`'s default targets are `lattice-inference --bench elementwise_cpu_bench`
and `lattice-embed --bench simd`. `elementwise_cpu_bench` measures elementwise and kernel
primitives directly (`rms_norm`, `layer_norm`, `silu_inplace`, `gelu`, `add_bias_gelu`,
`softmax_attention`, `residual_add_layer_norm`, `elementwise_mul`): it constructs input tensors
and invokes those ops, and never instantiates `Qwen35Model` or any generation path. `simd`
measures SIMD dot-product / int8 / normalize primitives. Neither bench's measured call graph
reaches the generation orchestration layer, directly or transitively.

This PR's only code change is the removal of `Qwen35Model::generate_with_batch_prefill`
(`crates/inference/src/forward/batch_prefill.rs`), a `#[deprecated(since = "0.5.1")]`,
`#[allow(dead_code)]` standalone decode loop with no callers, together with its own tests and
now-stale doc comments; the remaining edits are release notes. The shared batched-prefill core
(`prefill_tokens_batched_for_generate`, `prefill_prompt`) and the elementwise/SIMD kernels the
two bench targets actually execute are byte-unchanged. Base and head therefore have identical
effective source for every path these benches measure, so no A/B delta is expected or
measurable. See ADR-058.

**Update:** this branch also removes the now-dead `PrefillScratch.decode_scratch` field
(`crates/inference/src/forward/batch_prefill.rs`) — its only reader was the removed
`generate_with_batch_prefill` wrapper above — plus doc/comment corrections in
`docs/releases/v0.7.0.md`, `docs/adr/ADR-080-consolidation-duplicated-contracts.md`,
`crates/inference/src/model/qwen35/mod.rs`, and `crates/inference/src/sampling.rs`. Same
disposition applies: `grep -rn 'PrefillScratch\|decode_scratch\|batch_prefill'` over
`crates/inference/benches/` and `crates/embed/benches/` returns zero hits, so this change is
also outside the measured call graph of both default bench targets. No A/B run.

