### PR TITLE
test: gate wall-clock-threshold assertions behind non-CI to de-flake (#977)

### DIFF
--- a/crates/embed/tests/integration.rs
+++ b/crates/embed/tests/integration.rs
@@ -218,12 +218,16 @@ fn test_simd_config_cached() {
     }
     let elapsed = start.elapsed();
 
-    // Should be very fast (cached)
-    assert!(
-        elapsed.as_micros() < 1000, // Less than 1ms for 10k calls
-        "simd_config() should be cached, took {:?}",
-        elapsed
-    );
+    // Should be very fast (cached). Wall-clock timing flakes under shared-CI
+    // load; assert only on a quiet non-CI machine (CI runners set the CI env
+    // var). The 10k calls above still run in CI as a smoke check.
+    if std::env::var_os("CI").is_none() {
+        assert!(
+            elapsed.as_micros() < 1000, // Less than 1ms for 10k calls
+            "simd_config() should be cached, took {:?}",
+            elapsed
+        );
+    }
 }
 
 // ============================================================================
@@ -417,12 +421,17 @@ fn test_batch_faster_than_sequential() {
 
     println!("Batch: {:?}, Sequential: {:?}", batch_time, sequential_time);
 
-    // Both should complete quickly (< 10ms for 99 pairs of 384-dim vectors)
-    assert!(
-        batch_time.as_millis() < 100,
-        "Batch operation too slow: {:?}",
-        batch_time
-    );
+    // Both should complete quickly (< 10ms for 99 pairs of 384-dim vectors).
+    // Wall-clock timing flakes under shared-CI load; assert only on a quiet
+    // non-CI machine (CI runners set the CI env var). The batch and sequential
+    // runs above still execute in CI as a smoke check.
+    if std::env::var_os("CI").is_none() {
+        assert!(
+            batch_time.as_millis() < 100,
+            "Batch operation too slow: {:?}",
+            batch_time
+        );
+    }
 }
 
 #[test]
@@ -450,10 +459,14 @@ fn test_large_batch_dot_product() {
     assert_eq!(results.len(), 1000);
     println!("1000 dot products in {:?}", elapsed);
 
-    // Should complete in < 10ms with SIMD
-    assert!(
-        elapsed.as_millis() < 100,
-        "Large batch too slow: {:?}",
-        elapsed
-    );
+    // Should complete in < 10ms with SIMD. Wall-clock timing flakes under
+    // shared-CI load; assert only on a quiet non-CI machine (CI runners set the
+    // CI env var). The results.len() correctness assert above always runs.
+    if std::env::var_os("CI").is_none() {
+        assert!(
+            elapsed.as_millis() < 100,
+            "Large batch too slow: {:?}",
+            elapsed
+        );
+    }
 }

--- a/crates/fann/src/lib.rs
+++ b/crates/fann/src/lib.rs
@@ -98,8 +98,13 @@ mod tests {
         let avg_us = elapsed.as_micros() as f64 / iterations as f64;
         println!("Average inference time: {avg_us:.2} us");
 
-        // Should be well under 5ms (5000us)
-        assert!(avg_us < 5000.0, "Inference too slow: {avg_us} us");
+        // Wall-clock timing flakes under shared-CI load, so assert the bound only
+        // on a quiet non-CI machine (CI runners set the CI env var). The forward
+        // passes above still run in CI as a smoke check that inference does not
+        // panic or hang; perf regressions are tracked by the Criterion benches.
+        if std::env::var_os("CI").is_none() {
+            assert!(avg_us < 5000.0, "Inference too slow: {avg_us} us");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem (#977)

Several unit/integration tests assert **absolute wall-clock bounds**. Absolute timing does not belong in a correctness gate: under shared-CI load these assertions flake, and a contended runner can inflate a microsecond operation past a millisecond bound with no code regression behind it.

## Fix — gate the timing assertion behind non-CI (issue preference #1)

Each wall-clock assertion is wrapped in `if std::env::var_os("CI").is_none()`. The operations above the assertion still run in CI as **smoke coverage** (they must not panic or hang); the flaky wall-clock bound is asserted only on a quiet non-CI machine. Criterion benches (`make bench-compare`) remain the perf-regression home. Correctness assertions (e.g. `results.len() == 1000`) stay unconditional.

## The whole family (enumerated)

| # | test | file:line | assertion | disposition |
|---|------|-----------|-----------|-------------|
| 1 | `test_inference_speed` | `crates/fann/src/lib.rs:102` | `avg_us < 5000.0` (1000 fwd passes) | gated behind non-CI |
| 2 | `test_simd_config_cached` | `crates/embed/tests/integration.rs:222` | `elapsed.as_micros() < 1000` (10k cached calls) | gated behind non-CI |
| 3 | `test_batch_faster_than_sequential` | `crates/embed/tests/integration.rs:422` | `batch_time.as_millis() < 100` | gated behind non-CI |
| 4 | `test_large_batch_dot_product` | `crates/embed/tests/integration.rs:455` | `elapsed.as_millis() < 100` (`results.len()==1000` kept) | gated behind non-CI |
| 5 | `microbench_sample_full_logits_default_issue_config` | `crates/inference/src/sampling.rs:2595` | `after_elapsed < before_elapsed` | **already `#[ignore]`'d** (perf microbench, does not run in default `cargo test`) — left as-is |

The family was enumerated by sweeping all `crates/*/src` + `crates/*/tests` for `Instant::now()` timing tests and duration-threshold comparisons. Production timeout/duration **logic** (rollback-window, circuit-breaker recovery, JIT timeout, division guards) is not a test gate and is untouched.

## Verification

- Gate proven **mutation-sensitive** on the fann instance: with an impossible threshold (`avg_us < 0.0`), the test **FAILS** in non-CI mode (assert is reached: "Inference too slow: 717.592 us") and **PASSES** under `CI=1` (assert gated out) — confirming the guard runs iff CI is unset. Threshold restored byte-identical.
- `cargo test -p lattice-fann --lib test_inference_speed` — ok in both `CI` unset and `CI=1`.
- `cargo test -p lattice-embed --test integration` — 15 passed, 0 failed, in both `CI` unset and `CI=1` (no sibling breakage).
- `cargo fmt` clean; `cargo clippy -p lattice-fann -p lattice-embed --all-targets -- -D warnings` clean (rc=0).

## Bench / parity disposition

Test-only change: the gated assertions live in `#[cfg(test)]` (`fann/src/lib.rs`) and in the `tests/` integration target (`embed/tests/integration.rs`). No library or bench source is touched — the changed lines are compiled only into test binaries and are unreachable from any bench target (`elementwise_cpu_bench`, `simd`); base and head bench binaries have identical effective source, so no A/B run applies. No `crates/inference/src/` or `crates/embed/src/` change, so `e2e-parity.yml` is not triggered.
