### PR TITLE
docs(inference): state durable rationale in code comments

### DIFF
--- a/crates/inference/src/attention/flash.rs
+++ b/crates/inference/src/attention/flash.rs
@@ -354,8 +354,7 @@ fn write_head_to_interleaved(
 /// the full-layer V-transpose buffer (`v_all_t`) added by #674/#673: it is
 /// *not* the field set from before those changes. `estimate_matches_actual_attention_buffer_lengths`
 /// below cross-checks this estimate against `AttentionBuffers::new`'s real
-/// field lengths so this can't silently rot again the way it did across #678
-/// review finding 3.
+/// field lengths so this can't silently rot again the way it did in #678.
 pub fn estimate_materialized_attention_buffer_bytes(
     max_seq_len: usize,
     hidden_size: usize,
@@ -847,7 +846,7 @@ mod tests {
     use crate::weights::{Tensor1D, Tensor2D, TransformerLayerWeights};
 
     /// Keeps `estimate_materialized_attention_buffer_bytes` honest against the
-    /// real `AttentionBuffers` field set (#678 review finding 3): the helper's
+    /// real `AttentionBuffers` field set (#678): the helper's
     /// formula is hand-maintained and previously drifted (it kept counting a
     /// removed `context`/per-head `v_head_t` allocation and omitted the newer
     /// `qkv` and full-layer `v_all_t` scratch). Covers the concrete BGE-small

--- a/crates/inference/src/attention/gdn_fused.rs
+++ b/crates/inference/src/attention/gdn_fused.rs
@@ -556,7 +556,7 @@ pub fn gated_delta_net_step_fused(
 
     // 8. Gated RMSNorm + output projection
     // norm_weight is [value_dim] per-head, applied to each head independently.
-    // Fail fast if weight dimension doesn't match (reviewer fix: no silent fallback).
+    // Fail fast if weight dimension doesn't match: no silent fallback.
     let gamma = &weights.norm_weight[..value_dim];
     debug_assert_eq!(gamma.len(), value_dim);
 

--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -69,7 +69,7 @@ impl AttentionBuffers {
     /// Sum of every scratch buffer's element count. Used by
     /// `crate::attention::flash::estimate_materialized_attention_buffer_bytes`'s
     /// own test to keep that estimate honest against this struct's actual
-    /// field set (see PR #678 review finding 3).
+    /// field set (see PR #678).
     #[cfg(test)]
     pub(crate) fn total_scratch_len(&self) -> usize {
         self.q.len()

--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -5655,9 +5655,8 @@ mod serve {
             /// this asserts the frame's actual JSON payload shape: real code
             /// path yields `finish_reason: null` + a string `delta.content`;
             /// the mutated path yields a non-null `finish_reason` and no
-            /// `content`, and the second `assert!` fails. Verified by
-            /// reverting that exact line and re-running: see the PR body's
-            /// mutation log.
+            /// `content`, and the second `assert!` fails, so this test fails
+            /// if the disconnect-stops-generation behavior regresses.
             #[tokio::test]
             async fn chat_completions_streaming_disconnect_stops_generation() {
                 let req = ChatCompletionRequest {

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -235,8 +235,8 @@ mod imp {
             message: String,
             code: &'static str,
         },
-        /// A server-side malfunction discovered during admission (round-1
-        /// review medium finding 4a: e.g. the grammar cache's own lock/slot
+        /// A server-side malfunction discovered during admission (e.g. the
+        /// grammar cache's own lock/slot
         /// invariants broke) -- never the caller's fault, so it must not be
         /// reported as the 400 every other `RequestError` is.
         ServerError {
@@ -3792,10 +3792,10 @@ mod imp {
             assert_eq!(value["choices"][0]["message"]["content"], r#"{"ok":true}"#);
         }
 
-        /// Sign-off Q4: a `WorkerEvent::ConstraintBlocked` event must surface
+        /// A `WorkerEvent::ConstraintBlocked` event must surface
         /// as HTTP 500 with the `blocked_constraint` machine code for a
-        /// structured request, never a 200 with partial/absent JSON. Round-1
-        /// review medium finding 2: replies via the raw `WorkerJob::reply`
+        /// structured request, never a 200 with partial/absent JSON. Replies
+        /// via the raw `WorkerJob::reply`
         /// seam (not `spawn_fake`'s `Result<_, String>` closure, which can
         /// only ever produce a generic `WorkerEvent::Failed`) so this test
         /// exercises the real production classification -- a distinct
@@ -4127,9 +4127,9 @@ mod imp {
             }
         }
 
-        /// Round-2 review medium finding 1: the `catch_unwind` single-flight
-        /// recovery path (`get_or_compile`'s `Action::Compile` arm) had no
-        /// test exercising an actual owner-closure panic. `compile` is an
+        /// Exercises the `catch_unwind` single-flight
+        /// recovery path (`get_or_compile`'s `Action::Compile` arm) against
+        /// an actual owner-closure panic. `compile` is an
         /// injectable `FnOnce` argument to `get_or_compile` already -- no
         /// extra test-only seam is needed, since single-flight semantics
         /// mean only the one thread that wins `Action::Compile` ever
@@ -4431,10 +4431,8 @@ mod imp {
         /// key on its own. If `enum` is removed from
         /// `V0_REJECTED_KEYWORDS`, this schema still gets rejected -- by the
         /// allowlist layer instead -- but with a DIFFERENT message, so this
-        /// test (unlike a bare `.is_err()` check) fails as intended. See
-        /// the stage-1 report's mutation transcript for the revert/restore
-        /// procedure this test guards, and this session's report for the
-        /// re-run transcript.
+        /// test (unlike a bare `.is_err()` check) fails if the denylist
+        /// layer's rejection of `enum` regresses.
         #[test]
         fn admit_v0_schema_mutation_sensitive_to_enum_admission() {
             let schema = serde_json::json!({"type": "string", "enum": ["a", "b"]});
@@ -4540,7 +4538,7 @@ mod imp {
             assert!(!v0_validate_json("18446744073709551616", &schema));
         }
 
-        /// End-to-end shape from the review's suggested test: a large
+        /// End-to-end shape: a large
         /// integer nested inside an admitted object schema.
         #[test]
         fn v0_validate_json_accepts_large_integer_nested_in_object() {
@@ -4553,7 +4551,7 @@ mod imp {
             assert!(v0_validate_json(r#"{"n": 18446744073709551616}"#, &schema));
         }
 
-        /// Round-2 review major finding 1: a valid UTF-16 surrogate pair
+        /// A valid UTF-16 surrogate pair
         /// (the G-clef character, U+1D11E) spelled as its two `\uXXXX`
         /// escape halves must validate under a string schema -- it is a
         /// grammar-conforming strict completion, and rejecting it turned
@@ -4592,7 +4590,7 @@ mod imp {
             assert!(v0_validate_json(r#""\uDD1E""#, &schema));
         }
 
-        /// Round-2 review major finding 1, second half: RFC 8259 §7
+        /// RFC 8259 §7
         /// requires U+0000-U+001F to be escaped, and the compiled grammar
         /// rejects them raw too (json_schema.rs
         /// `string_rejects_raw_control_byte`). A literal BEL (0x07) byte
@@ -4920,7 +4918,7 @@ mod imp {
             );
         }
 
-        /// Reviewer finding (b): a mid-stream `WorkerEvent::Failed` (or
+        /// A mid-stream `WorkerEvent::Failed` (or
         /// `Rejected`/worker-gone) emits a client-facing SSE error event
         /// (asserted above) but, before this fix, the terminal `Phase::End`
         /// still recorded the request in `/metrics` as a plain 200 with no
@@ -5012,8 +5010,8 @@ mod imp {
         /// discovering `WorkerEvent::Rejected` only inside `Phase::Body`)
         /// makes this fail -- the response status would be 200 with an SSE body
         /// carrying a `finish_reason: "length"` terminal chunk instead of a
-        /// 400 error envelope. Verified by reverting the preflight and
-        /// re-running: see the PR body's mutation log.
+        /// 400 error envelope, so this test fails if the preflight
+        /// regresses.
         #[cfg(all(feature = "metal-gpu", feature = "test-utils"))]
         #[tokio::test]
         async fn chat_completions_streaming_context_overflow_returns_400_before_committing_sse() {

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -1992,7 +1992,7 @@ mod imp {
         let mut cfg = build_cfg(&validated);
         // Wire the compiled grammar into the worker config (design note
         // §"End-to-end execution", step 4) and force `enable_thinking` off
-        // for strict requests regardless of server defaults (sign-off Q5):
+        // for strict requests regardless of server defaults:
         // the grammar masks from the first decode token, so thinking
         // tokens are unsampleable under it and a think-then-constrain flow
         // is out of scope for v0.
@@ -2410,7 +2410,7 @@ mod imp {
                         .into_response();
                     }
                     WorkerEvent::ConstraintBlocked(message) => {
-                        // Structured-output v0 (design note, sign-off Q4): a
+                        // Structured-output v0 (design note): a
                         // strict request's generation failure is reported
                         // with the `blocked_constraint` machine code instead
                         // of the generic `internal_error`. This used to be
@@ -3717,7 +3717,7 @@ mod imp {
 
         /// Route test (design note §"Serve and backend integration", item
         /// 1): an admitted strict request's worker job carries
-        /// `grammar.is_some()`, `enable_thinking == false` (sign-off Q5),
+        /// `grammar.is_some()`, `enable_thinking == false`,
         /// and the successful response carries `constraint_applied` --
         /// asserted from a real, compiled `GrammarEngine`, not a stub, so a
         /// route that merely returns schema-shaped JSON without actually
@@ -3883,7 +3883,7 @@ mod imp {
             assert_eq!(code, "internal_error");
         }
 
-        /// Sign-off Q4: `stopped == false` (length/KV-window exhaustion)
+        /// `stopped == false` (length/KV-window exhaustion)
         /// on a structured request must surface as HTTP 500
         /// `length_limit`, never HTTP 200 with truncated JSON.
         #[cfg(all(feature = "metal-gpu", feature = "test-utils"))]

--- a/crates/inference/src/error.rs
+++ b/crates/inference/src/error.rs
@@ -36,7 +36,7 @@ pub enum InferenceError {
     /// caller-input problems) so downstream consumers -- e.g. the serve
     /// binaries' `blocked_constraint` HTTP machine code -- can classify this
     /// specific condition by type instead of pattern-matching the message
-    /// text (round-1 structured-output-v0 review, medium finding 2).
+    /// text.
     GrammarConstraintBlocked(String),
 }
 

--- a/crates/inference/src/forward/metal.rs
+++ b/crates/inference/src/forward/metal.rs
@@ -1313,8 +1313,7 @@ kernel void rms_norm_pre_854_oracle(
         ///
         /// Mutation-sensitive: reverting the fix in flash_attention.metal back to
         /// `O4[out_base4] = o_frag * inv_l;` makes this test fail (160/160 NaN
-        /// elements instead of 0), confirmed at PR time (round 1) and reconfirmed
-        /// after the fix-round refactor (round 2).
+        /// elements instead of 0).
         #[test]
         fn fused_attention_fails_closed_on_nan_q_lane() {
             let Some(metal_out) = run_fused_attention_with_corrupted_q_lane(

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1224,7 +1224,7 @@ mod inner {
         ///
         /// Mirrors `Q4WeightBuf::from_buffer` for API-shape parity; unused
         /// until a non-mmap Q3 construction path (e.g. concatenated MoE-style
-        /// upload) exists — see w3_stage2_report.md "what shipped" for scope.
+        /// upload) exists.
         #[allow(dead_code)]
         fn from_buffer(buffer: Buffer) -> Self {
             Q3WeightBuf {
@@ -1237,8 +1237,7 @@ mod inner {
         /// Wrap a no-copy Metal buffer backed by `mmap` with a non-zero payload offset.
         ///
         /// Exercised today only by [`mmap_q3_weight`] and its tests; live
-        /// checkpoint loading does not yet route MLP tensors through it (see
-        /// w3_stage2_report.md "what shipped" for the scope decision).
+        /// checkpoint loading does not yet route MLP tensors through it.
         #[allow(dead_code)]
         fn from_mmap(buffer: Buffer, payload_offset: u64, mmap: memmap2::Mmap) -> Self {
             Q3WeightBuf {
@@ -1264,8 +1263,7 @@ mod inner {
     /// The mmap is read-only (`MAP_PRIVATE`) and the model files must not be
     /// modified while the process is running.
     ///
-    /// Not yet called from live checkpoint loading — see w3_stage2_report.md
-    /// "what shipped" for the scope decision (proven end-to-end by this
+    /// Not yet called from live checkpoint loading (proven end-to-end by this
     /// module's `mmap_q3_weight_*` tests instead).
     #[cfg(feature = "metal-gpu")]
     #[allow(dead_code)]
@@ -12558,7 +12556,7 @@ mod inner {
         /// # Panics
         /// Panics if `k` is zero or not a multiple of 32 (a caller
         /// programming error, not a runtime/capability condition).
-        #[allow(dead_code)] // wired to real MLP dispatch is deferred past Stage 2 — see w3_stage2_report.md
+        #[allow(dead_code)] // wiring to real MLP dispatch is deferred past Stage 2
         fn dispatch_gemm_q3(
             &self,
             enc: &ComputeCommandEncoderRef,
@@ -14156,8 +14154,8 @@ mod inner {
     /// per-step token pick: opens the `decode.sample` interval, then routes
     /// to the compact-candidate or full-logits sampler.
     ///
-    /// Centralizes what was five independent copy-pasted call sites (round-3
-    /// review finding: two of the five -- the multimodal decode loops --
+    /// Centralizes what was five independent copy-pasted call sites: two of
+    /// the five -- the multimodal decode loops --
     /// had already drifted to call `sample_token` directly, with neither the
     /// interval nor the compact-route policy the other three loops apply).
     /// `compact` is `Some(candidates)` for the GPU-top-k route (mirrors the
@@ -17952,7 +17950,7 @@ mod inner {
         };
         use crate::model::qwen35_config::LayerType;
 
-        // Mutation-sensitive regression for round-4 finding 1: five decode
+        // Mutation-sensitive: five decode
         // loops used to copy-paste their own `decode.sample` interval +
         // compact/full-logits routing, and two of the five (the multimodal
         // decode loops) had already drifted to call `sample_token` directly
@@ -17960,7 +17958,7 @@ mod inner {
         // shared call site; these two source-level checks guard both halves
         // of that invariant without depending on a live Instruments/xctrace
         // tool session (which real FFI emission would require to observe).
-        // See fix-round-4 report for the mutation run against this pair.
+        // Each check fails if the shared call site regresses.
         #[test]
         fn sample_decode_traced_opens_the_decode_sample_interval() {
             let src = include_str!("metal_qwen35.rs");
@@ -17993,8 +17991,7 @@ mod inner {
                 .find("    mod tests {")
                 .expect("mod tests must exist in this file");
             let production_src = &src[..production_end];
-            // One definition + five call sites (round-4 finding-1 table: the
-            // fix-round-4 report enumerates each by function and line).
+            // One definition + five call sites, each enumerable by function and line.
             let count = production_src.matches("sample_decode_traced(").count();
             assert_eq!(
                 count, 6,
@@ -21082,8 +21079,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             // Shape E: M=16,N=1024,K=3584 — Qwen3.5-0.8B's down-projection
             //   depth (`intermediate_size=3584`, dispatch uses
             //   `K=intermediate` — metal_qwen35.rs:5112), 112 `BK=32`
-            //   iterations — the deepest Q3-eligible production MLP shape,
-            //   round-2 review finding 2.
+            //   iterations — the deepest Q3-eligible production MLP shape.
             //
             // `max_abs_diff` is the same NaN-honest helper used by the Q4 twin
             // below (`gemm_q4_tiled_vs_naive_numeric_differential`) — a
@@ -21151,11 +21147,10 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 envelope.push((m, n, k, max_diff));
             }
 
-            // Bound derived from the measured envelope above (see
-            // w3_fix_r2_report.md for the full table), not a hand-waved
+            // Bound derived from the measured envelope above, not a hand-waved
             // constant: the largest observed shape (M=16 N=1024 K=3584, the
-            // Qwen3.5-0.8B down-projection depth — 112 `BK=32` iterations,
-            // round-2 review finding 2) measured max|gpu-ref| ~= 1.946e-2;
+            // Qwen3.5-0.8B down-projection depth — 112 `BK=32` iterations)
+            // measured max|gpu-ref| ~= 1.946e-2;
             // 0.037 is ~1.9x that. The headroom covers cross-device variation
             // (different Apple Silicon generations accumulate the f16
             // X/W-staging + f32-reduction residual slightly differently) and
@@ -21176,8 +21171,8 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             }
         }
 
-        /// Mutation-sensitivity test for the differential comparison itself
-        /// (round-1 review finding 2): corrupt a packed block's `scale` field
+        /// Mutation-sensitivity test for the differential comparison itself:
+        /// corrupt a packed block's `scale` field
         /// to an IEEE-754 f16 NaN bit pattern so the GPU kernel's dequantized
         /// weight — and therefore its GEMM output — is NaN, then prove the
         /// NaN-honest comparison fails loudly instead of silently reading as
@@ -21186,7 +21181,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// mutation-sensitive, the same way the pack/unpack mutation tests
         /// prove the kernel is.
         ///
-        /// Round-2 review finding 1: `#[should_panic(expected = "is not
+        /// `#[should_panic(expected = "is not
         /// finite")]` could not distinguish "the Apple7 dispatch ran and the
         /// NaN-honest comparison caught it" from "no Apple7 device, so this
         /// branch panicked with an unrelated message that happened to also
@@ -22187,7 +22182,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// disarmed, and the collector must stay disarmed rather than
         /// silently self-arming on first use.
         ///
-        /// Mutation check (documented for the reviewer to exercise, not
+        /// Mutation check (documented as a manual check, not
         /// compiled in): replacing `encode_moe_ffn`'s `if let Some(trace) =
         /// c.borrow_mut().as_mut() { trace.push(..) }` guard with an
         /// unconditional `c.borrow_mut().get_or_insert_with(Vec::new).push(..)`
@@ -22249,7 +22244,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// through `encode_mlp_block` into `encode_moe_ffn`. Also exercises
         /// `dump_moe_routing_trace_jsonl`'s round-trip.
         ///
-        /// Mutation check (documented for the reviewer to exercise, not
+        /// Mutation check (documented as a manual check, not
         /// compiled in): commenting out the `trace.push(MoeRoutingTraceRecord
         /// { .. })` call inside `encode_moe_ffn`'s `MOE_ROUTING_TRACE.with(..)`
         /// block makes this test fail — `take_moe_routing_trace()` returns an
@@ -22936,7 +22931,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             );
         }
 
-        /// Ordering proof (adversarial-review Finding 1): `encode_moe_ffn`'s
+        /// Ordering proof: `encode_moe_ffn`'s
         /// routed-expert dequant work must genuinely overlap Step 2's
         /// shared-expert GEMV encoding, not just fan out across rayon
         /// before Step 2 starts and then block in front of it. Proven
@@ -23029,7 +23024,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             );
         }
 
-        /// Failure-isolation proof (adversarial-review Finding 2): a dequant
+        /// Failure-isolation proof: a dequant
         /// task panicking after `plan_prefetch` already committed its
         /// slot's ownership bookkeeping must not let a later token read
         /// stale/never-written bytes out of that slot.
@@ -23217,8 +23212,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             }
         }
 
-        /// Direct Stage-1-equivalence regression (adversarial-review
-        /// Finding 3): the `plan_prefetch` + dequant + `apply_prefetch_results`
+        /// Direct Stage-1-equivalence regression: the `plan_prefetch` + dequant + `apply_prefetch_results`
         /// path must leave a cache in EXACTLY the same bookkeeping state
         /// (`slot_owner`, `expert_to_slot`, `slot_touched`, `slot_ready`,
         /// LRU order, hit/miss/eviction counters) as calling `resolve()`
@@ -25755,11 +25749,8 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         }
 
         // ===================================================================
-        // Tester suite (issue #171): mutation-sensitive correctness tests for
-        // the lm_head two-stage block-top-k path. See
-        // ../architect/design_spec.md (Test Plan) and
-        // ../implementer/impl_notes.md. Results + mutation-sensitivity
-        // evidence: ../tester/test_report.md.
+        // Mutation-sensitive correctness tests for
+        // the lm_head two-stage block-top-k path (issue #171).
         // ===================================================================
 
         /// Pure unit test for the route gate (no GPU). Design-spec "Routing
@@ -25895,7 +25886,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             idx
         }
 
-        /// Adversarial distribution from `design_spec.md` Test Plan §3: every
+        /// Adversarial distribution: every
         /// global top-K token clusters inside ONE Stage-1 tile. Proves Stage 1
         /// emits a true per-tile top-`local_k`, not merely a per-tile argmax
         /// or an approximate/truncated local ranking — a distribution where
@@ -26036,16 +26027,15 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             );
         }
 
-        /// Bypass-sensitive production-path test (design_spec.md Test Plan
-        /// §6): poisons the persistent logits buffer with a sentinel bit
+        /// Bypass-sensitive production-path test: poisons the persistent
+        /// logits buffer with a sentinel bit
         /// pattern, runs the compact greedy route, and asserts the sentinel
         /// survives untouched — proving the full `[vocab_size]` GEMV never
         /// wrote to it, i.e. Stage 1/Stage 2 actually ran instead of the
         /// full-logit path silently computing everything and discarding the
         /// extra values.
         ///
-        /// MUTATION-SENSITIVE: see test_report.md for the reverse-apply
-        /// proof — disabling the Stage-1/2 early return in
+        /// MUTATION-SENSITIVE: disabling the Stage-1/2 early return in
         /// `encode_final_head` (forcing every route through the full-logit
         /// GEMV) flips both the sentinel-buffer assertion below AND the
         /// `out.is_empty()` assertion.
@@ -26287,8 +26277,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             }
         }
 
-        /// Acceptance test #1 (task order item 7 / design_spec.md Test Plan
-        /// §4): greedy token agreement 100% vs. the full-logit path on
+        /// Acceptance test: greedy token agreement 100% vs. the full-logit path on
         /// \>=10,000 positions using the real Qwen3.5-0.8B checkpoint.
         /// Overridable via `LATTICE_TEST_GREEDY_POSITIONS` for fast local
         /// iteration; defaults to 10,000 to satisfy the acceptance gate. KV
@@ -27527,8 +27516,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             );
         }
 
-        /// Acceptance test #2 (task order item 7 / design_spec.md Test Plan
-        /// §5): top-k SET agreement 100% for K in {8,16,40,64} vs. the
+        /// Acceptance test: top-k SET agreement 100% for K in {8,16,40,64} vs. the
         /// full-logit CPU oracle, on real checkpoint positions (the
         /// clustered-tile adversarial case is covered separately by
         /// `lm_head_block_topk_clustered_single_tile_set_agreement`).
@@ -29767,7 +29755,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// old `Ok` shape would additionally have `stop_reason: None`, the
         /// invariant-violating result #856 fixes).
         ///
-        /// PR #915 review feedback (fix 4): honors
+        /// Honors
         /// `LATTICE_METAL_TEST_ENFORCE` like the prefix-cache empty-prompt
         /// test, so a required Metal CI leg fails loud on a missing device
         /// instead of silently passing without ever exercising the guard.
@@ -29920,7 +29908,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// through prefill and sampling instead of erroring, so
         /// `result.is_err()` fails.
         ///
-        /// PR #915 review feedback (fix 4): honors
+        /// Honors
         /// `LATTICE_METAL_TEST_ENFORCE` like the prefix-cache empty-prompt
         /// test, so a required Metal CI leg fails loud on a missing device
         /// instead of silently passing without ever exercising the guard.
@@ -34639,7 +34627,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// (`generate_streaming_with_prefix_cache_and_cancel`), before
         /// `_inner` is ever called.
         ///
-        /// PR #915 review feedback (fix 3): a fresh-state / `entry ==
+        /// A fresh-state / `entry ==
         /// None` assertion alone does not exercise the property that
         /// motivated putting the guard in the wrapper rather than
         /// `_inner` -- a *warmed* slot survives the rejection, because the
@@ -34650,10 +34638,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// assert both the exact error and that the pre-existing entry is
         /// unchanged afterward.
         ///
-        /// PR #915 review, second pass: the first version of this
-        /// test only compared `generic.token_ids` while claiming
+        /// Comparing only `generic.token_ids` does not prove
         /// "byte-identical" survival; `MetalCrossTurnPrefixEntry` also
-        /// carries `gdn_snapshot` and sparse `checkpoints`. This version
+        /// carries `gdn_snapshot` and sparse `checkpoints`. This test
         /// compares every field: `generic` (`kv_cache::CrossTurnPrefixEntry`,
         /// which derives `PartialEq`/`Eq` over `slot_id`, `metadata`,
         /// `token_ids`, `represented_len`, the `kv` handle -- itself a
@@ -37640,7 +37627,7 @@ impl MetalQwen35State {
 
     /// **Unstable**: Metal generate stub; always errors without metal-gpu feature.
     ///
-    /// #856 follow-up (PR #915 review, first pass): this used to
+    /// #856 follow-up: this used to
     /// return an unconditional `Ok(GenerateOutput { .. })` with empty
     /// text/tokens for *every* prompt, including non-empty ones. Because
     /// `MetalQwen35State` is a public unit struct on this cfg (directly

--- a/crates/inference/src/forward/signpost.rs
+++ b/crates/inference/src/forward/signpost.rs
@@ -318,7 +318,7 @@ mod imp {
     mod tests {
         use super::*;
 
-        // Regression for finding 4 (round-4 review): the two documented
+        // The two documented
         // capture paths need opposite `os_signpost_enabled` defaults, and
         // both are observable in-process with no Instruments/xctrace tool
         // attached — no external tooling needed to guard this. Constructs
@@ -470,7 +470,8 @@ mod tests {
     // "always" opts into the ordinary category the xctrace CLI path needs.
     // Deliberately does not touch `std::env` — see the in-process
     // `os_signpost_enabled` regression tests in `imp::tests` (macOS +
-    // `signpost` feature only) for the category-behavior half of finding 4.
+    // `signpost` feature only) for the category-behavior half of this
+    // guard.
     #[test]
     fn signpost_mode_from_env_value() {
         assert_eq!(SignpostMode::from_env_value(None), SignpostMode::Auto);
@@ -496,9 +497,8 @@ mod tests {
     // Mutation-sensitive: the mode -> category string mapping `decode_log()`
     // relies on. Also platform/feature independent (`category()` compiles
     // under every combination; only its callers are macOS+signpost-gated).
-    // Breaking this mapping (e.g. always returning "DynamicTracing") is
-    // exactly the round-4 finding-4 regression -- see fix-round-4 report
-    // for the mutation run.
+    // Breaking this mapping (e.g. always returning "DynamicTracing") makes
+    // this test fail.
     #[test]
     fn signpost_mode_category_mapping() {
         assert_eq!(SignpostMode::Auto.category(), "DynamicTracing");
@@ -543,11 +543,11 @@ mod tests {
 
     // Mutation-sensitive: pairing regression for `Label::DecodeSample`, the
     // exact label `sample_decode_traced` in `metal_qwen35.rs` opens --
-    // finding 1's round-4 fix made that one call site the *only* place any
+    // that call site is the *only* place any
     // of the five decode loops open a `decode.sample` interval (previously
     // five independent copies, two of which had already drifted with no
-    // interval at all). See fix-round-4 report for the mutation run
-    // breaking `RecordingInterval::begin` and observing this test fail.
+    // interval at all). This test fails if `RecordingInterval::begin`
+    // stops emitting the paired begin/end events.
     #[test]
     fn decode_sample_label_records_begin_end_pair() {
         super::recorder::clear();
@@ -569,7 +569,7 @@ mod tests {
     // record zero events; `Scope::Decode` must record the full begin/end
     // pair. Reverting the discriminator (emitting unconditionally, as the
     // shared helper did before this fix) makes the `NotDecode` assertion
-    // fail — see fix-round-3 report for the mutation run.
+    // fail.
     #[test]
     fn scope_discriminator_silences_non_decode_and_records_decode() {
         super::recorder::clear();

--- a/crates/inference/src/model/gemma4_config.rs
+++ b/crates/inference/src/model/gemma4_config.rs
@@ -187,7 +187,7 @@ struct HfGemma4TextConfig {
 
 /// Raw `text_config.rope_parameters`: two nested per-attention-type RoPE
 /// records, as the target `config.json` actually nests them (ADR-082
-/// Amendment 1 / review finding 1) -- not the flat `rope_theta` /
+/// Amendment 1) -- not the flat `rope_theta` /
 /// `rope_local_base_freq` shape this loader previously (incorrectly)
 /// expected at the top level of `text_config`.
 #[derive(Debug, serde::Deserialize)]
@@ -428,7 +428,7 @@ impl Gemma4Config {
                 self.num_kv_shared_layers, self.num_hidden_layers
             )));
         }
-        // Amendment 1 / review finding 1: use_double_wide_mlp must not be a
+        // ADR-082 Amendment 1: use_double_wide_mlp must not be a
         // tautological function of is_kv_shared_layer. The raw checkpoint
         // flag is required to agree with the derived KV-shared set: the
         // reference runtime sets it identically (Amendment 1, "G2/G7

--- a/crates/inference/src/model/gemma4_preflight.rs
+++ b/crates/inference/src/model/gemma4_preflight.rs
@@ -238,7 +238,7 @@ pub fn preflight_check(
         }
     }
 
-    // Exhaustiveness (ADR-082 Amendment 1 / review finding 3): every
+    // Exhaustiveness (ADR-082 Amendment 1): every
     // supplied language-model tensor must have been consumed above, either
     // by loading or by the shared-KV tolerate-and-skip category. A name
     // that matches neither -- an extra, misspelled, or otherwise unexpected

--- a/crates/inference/src/model/qwen35/detokenize.rs
+++ b/crates/inference/src/model/qwen35/detokenize.rs
@@ -307,8 +307,7 @@ mod tests {
         assert!(detok.retained_byte_capacity() <= DETOK_RETAINED_BYTE_CAPACITY);
     }
 
-    /// Companion regression for issue #324 (review finding on the retention-bound
-    /// PR): the test above only ever pushes 1-byte ASCII tokens, so `pending`'s
+    /// Companion regression for issue #324: the test above only ever pushes 1-byte ASCII tokens, so `pending`'s
     /// `Vec` never grows past its initial `with_capacity(DETOK_RETAINED_BYTE_CAPACITY)`
     /// allocation — deleting the `compact_pending_capacity()` call (or its call
     /// site) would still pass it, since there is never anything to compact.

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -3790,7 +3790,7 @@ mod tests {
              the prefill-derived first token -- not merely before the RawToken callback, \
              which a PrefillEnd emitted after sampling (but before the RawToken push) would \
              also satisfy while silently including sampling time in the reported prefill \
-             interval (codex round-2 medium, PR #882)"
+             interval (#882)"
         );
     }
 

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -3493,8 +3493,6 @@ mod tests {
     /// masking/sampling) lets generation fall through to sampling the first
     /// token, producing `generated_tokens > 0`, non-empty `text`, and at
     /// least one `on_token` callback -- failing all three assertions below.
-    /// Verified by reverting that exact guard and re-running: see the PR
-    /// body's mutation log.
     #[test]
     fn generate_streaming_with_cancel_true_after_prefill_returns_interrupt() {
         let model = build_tiny_zero_model();
@@ -3698,8 +3696,7 @@ mod tests {
     /// Removing any of the three `on_raw_event(RawGenEvent::RawToken { .. })`
     /// call sites (pre-loop first token, fast-path decode loop, stop-string
     /// decode loop) drops an index from the collected sequence, failing the
-    /// monotonic-range assertion. Verified by reverting the fix and
-    /// re-running: see the PR body's mutation log.
+    /// monotonic-range assertion.
     #[test]
     fn raw_observer_prefill_end_precedes_first_raw_token_monotonic_index() {
         let model = build_tiny_zero_model();

--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -723,8 +723,8 @@ impl Qwen35Config {
                  positive multiple of linear_num_key_heads ({key_heads})"
             )));
         }
-        // A present `vision_config` must be structurally valid (ADR-069 S1/S2 review
-        // feedback): a present-but-malformed object (e.g. `depth: 0`) is syntactically
+        // A present `vision_config` must be structurally valid (ADR-069):
+        // a present-but-malformed object (e.g. `depth: 0`) is syntactically
         // valid JSON and would otherwise silently load a truncated subset of
         // `model.visual.*` tensors instead of failing closed.
         if let Some(vision_cfg) = &cfg.vision_config {

--- a/crates/inference/src/moe_admission.rs
+++ b/crates/inference/src/moe_admission.rs
@@ -1111,9 +1111,8 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // BLOCKER regression (review round 1, finding 1): ArcPolicy must not
-    // evict an id resolved earlier in the SAME token. Replays the exact
-    // three-token scenario from the review verdict.
+    // ArcPolicy must not evict an id resolved earlier in the SAME token.
+    // Replays the exact three-token scenario that regressed this invariant.
     // -----------------------------------------------------------------
 
     #[test]
@@ -1413,8 +1412,7 @@ mod tests {
 
     #[test]
     fn run_simulation_rejects_zero_num_slots_and_top_k_together() {
-        // The exact failure scenario from the review verdict: a one-record
-        // trace with `selected_ids: []` and `--num-slots 0 --top-k 0`.
+        // A one-record trace with `selected_ids: []` and `--num-slots 0 --top-k 0`.
         let layers = vec![(0usize, vec![record(0, 0, &[])])];
         let cfg = SimConfig {
             num_slots: 0,

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -1604,7 +1604,7 @@ mod tests {
     // Path-layout refuses
     // ------------------------------------------------------------------
 
-    /// Major 1: when input and output paths resolve to the same canonical
+    /// When input and output paths resolve to the same canonical
     /// path, the converter must refuse before any write would corrupt
     /// the source `config.json`.
     #[test]
@@ -1631,7 +1631,7 @@ mod tests {
         );
     }
 
-    /// Major 1 sibling: even when the two paths differ literally (e.g.,
+    /// Sibling case: even when the two paths differ literally (e.g.,
     /// trailing slash, symlink), canonicalization must still catch the
     /// equivalence.
     #[test]
@@ -1648,7 +1648,7 @@ mod tests {
         assert!(msg.contains("same path"), "unexpected error: {msg}");
     }
 
-    /// Major 2: a pre-existing non-empty output directory must trigger
+    /// A pre-existing non-empty output directory must trigger
     /// refusal before any conversion work, so a previously-written `.q4`
     /// artifact cannot survive a gate failure and be picked up by the
     /// runtime loader.

--- a/crates/inference/src/quant/quarot/forward_equivalence.rs
+++ b/crates/inference/src/quant/quarot/forward_equivalence.rs
@@ -1425,7 +1425,7 @@ mod tests {
     /// Per-tensor coverage helper: run the full pipeline correctly, then
     /// scale `victim_name` by `factor` in the rotated working set and
     /// assert the gate refuses. Covers the chain-probe-skipped planned
-    /// tensors that were flagged in review.
+    /// tensors.
     fn assert_corrupting_planned_tensor_refuses(victim_name: &str, factor: f64, seed: u64) {
         let cfg = tied_tiny_test_cfg();
         let original = build_working_set(&cfg, seed);
@@ -1481,7 +1481,7 @@ mod tests {
     /// Per-tensor coverage: corrupting `k_proj` is invisible to the chain
     /// probe (probe shortcuts through `q_proj` → `o_proj`) but must be
     /// caught by the per-tensor algebraic check. This regression case is
-    /// the specific gap flagged in the PR #28 review.
+    /// the specific gap the chain probe alone leaves in PR #28.
     #[test]
     fn per_tensor_check_catches_corrupted_k_proj() {
         assert_corrupting_planned_tensor_refuses(
@@ -1576,8 +1576,8 @@ mod tests {
         );
     }
 
-    /// Matrix-equivalence vs single-vector: further review demonstrated
-    /// that the single-probe-vector implementation would miss a row
+    /// Matrix-equivalence vs single-vector: the
+    /// single-probe-vector implementation would miss a row
     /// perturbation orthogonal to the probe direction. The current
     /// matrix-equivalence implementation compares every stored element,
     /// so any non-zero element-level perturbation is caught. This test

--- a/crates/inference/src/serve/metal_worker.rs
+++ b/crates/inference/src/serve/metal_worker.rs
@@ -115,9 +115,8 @@ pub enum WorkerEvent {
     /// candidate token (#611), distinct from [`WorkerEvent::Failed`] at the
     /// type level so a caller offering structured-output admission can
     /// report its dedicated `blocked_constraint` HTTP machine code without
-    /// pattern-matching the message text (round-1 structured-output-v0
-    /// review, medium finding 2: a backend wording change must not be able
-    /// to silently degrade that code to `internal_error`). Carries the
+    /// pattern-matching the message text (a backend wording change must not
+    /// be able to silently degrade that code to `internal_error`). Carries the
     /// underlying error message for server-side logging only.
     ConstraintBlocked(String),
     /// The job was skipped before any prompt work started because the

--- a/crates/inference/src/stop_token_contract.rs
+++ b/crates/inference/src/stop_token_contract.rs
@@ -44,7 +44,7 @@
 //!
 //! Entry 11 (`generate_multimodal`) has its own independent sampling loop —
 //! it does not call `generate`/`generate_streaming` internally — and was
-//! missing from this manifest until the PR #632 review flagged it as
+//! missing from this manifest until PR #632 added it as
 //! an unguarded sibling-invocation path (#613's own warning pattern). Its
 //! loop already used the EXCLUDE contract (checks `is_stop` before pushing
 //! at every termination point: first-token sample, KV-full break, and the

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -1344,8 +1344,8 @@ mod tests {
     /// always splits on word boundaries, so "a" and " b" land in different
     /// pieces and the cross-space merge can never fire, giving `[0, 1]`
     /// (the "a" and "Ġb" ids from separate pieces) instead. This is a
-    /// direct id-level proxy for the silent-wrong-ids failure mode a
-    /// review flagged for explicit `use_regex:false` metadata that fell
+    /// direct id-level proxy for the silent-wrong-ids failure mode when
+    /// explicit `use_regex:false` metadata falls
     /// through to the `Gpt4Regex` default unchecked.
     fn cross_space_merge_json(pre_tokenizer: &str) -> String {
         format!(

--- a/crates/inference/src/tokenizer/sentencepiece.rs
+++ b/crates/inference/src/tokenizer/sentencepiece.rs
@@ -219,7 +219,7 @@ impl SentencePieceTokenizer {
         // signal when the flag is true or absent (HF byte-fallback models set
         // it true; some recovery paths omit it). Only an explicit `false`
         // suppresses inference — so a model that genuinely declares no byte
-        // fallback keeps a literal `<0xNN>` text token as Normal (#255 review).
+        // fallback keeps a literal `<0xNN>` text token as Normal (#255).
         let byte_fallback_enabled = json_path(&root, &["model", "byte_fallback"])
             .and_then(JsonValue::as_bool)
             != Some(false);
@@ -1131,7 +1131,7 @@ mod tests {
     fn test_json_loader_respects_explicit_byte_fallback_false() {
         // When the model explicitly declares no byte fallback, a literal
         // `<0xNN>`-shaped piece must stay Normal (trie-resolvable), not be
-        // misrouted to byte_fallback_ids by shape inference (#255 review edge).
+        // misrouted to byte_fallback_ids by shape inference (#255 edge case).
         let json = r#"{"model":{"type":"Unigram","unk_id":0,"byte_fallback":false,"vocab":[["<unk>",0.0],["<0x41>",-5.0]]}}"#;
         let tok = SentencePieceTokenizer::from_tokenizer_json_str(json).unwrap();
         assert_eq!(tok.inner.byte_fallback_ids[0x41], None);

--- a/crates/inference/src/vision/checkpoint.rs
+++ b/crates/inference/src/vision/checkpoint.rs
@@ -483,8 +483,7 @@ mod tests {
     fn q4_full_inventory_with_depth_zero_is_rejected() {
         // A checkpoint that genuinely carries the full 153-tensor real inventory, paired
         // with a (malformed) vision_config claiming depth: 0, must error rather than
-        // silently returning a nine-tensor `Qwen35VisionWeights` (the S1/S2 review's
-        // exact failure scenario).
+        // silently returning a nine-tensor `Qwen35VisionWeights`.
         let tmp = tempfile::tempdir().unwrap();
         let full_cfg = real_vision_cfg();
         let entries: Vec<String> = tensor_names(&full_cfg)

--- a/crates/inference/src/vision/qwen35_vit_metal.rs
+++ b/crates/inference/src/vision/qwen35_vit_metal.rs
@@ -52,7 +52,7 @@ mod gpu {
     #[cfg(feature = "test-utils")]
     use std::sync::atomic::{AtomicU64, Ordering};
 
-    /// Test-only diagnostic (issue: S3b gate review — cosine parity alone
+    /// Test-only diagnostic: cosine parity alone
     /// can't distinguish "every GEMM ran on Metal" from "every GEMM silently
     /// fell back to the CPU loop below", since the fallback is exact). Counts
     /// GEMM calls that actually dispatched to the GPU (`metal_matmul`/

--- a/crates/inference/src/weights/q3_weights.rs
+++ b/crates/inference/src/weights/q3_weights.rs
@@ -637,8 +637,7 @@ pub fn read_q3_header(
 /// or if `file_len` is smaller than `payload_offset + n_blocks * 16`.
 ///
 /// Only called from `mmap_q3_weight` (crates/inference/src/forward/metal_qwen35.rs)
-/// today, which live checkpoint loading does not yet reach — see
-/// w3_stage2_report.md "what shipped" for the scope decision.
+/// today, which live checkpoint loading does not yet reach.
 #[allow(dead_code)]
 pub(crate) fn validate_q3_header_payload_bounds(
     header: &Q3FileHeader,
@@ -1086,8 +1085,7 @@ mod tests {
     fn mlp_role_rejects_near_miss_suffixes() {
         // Exact-suffix contract: `.contains()` on the role substring would
         // wrongly accept these — a LoRA adapter branch, a renamed sibling
-        // tensor, and a trailing extra suffix after `.weight`. Table-driven
-        // per the round-1 review (codex_1014_r1_verdict.md finding 1).
+        // tensor, and a trailing extra suffix after `.weight`.
         for name in [
             "model.layers.3.mlp.gate_proj.lora_A.weight",
             "model.layers.3.mlp.up_proj_backup.weight",

--- a/crates/inference/tests/gemma4_e2e_forward_test.rs
+++ b/crates/inference/tests/gemma4_e2e_forward_test.rs
@@ -43,7 +43,7 @@ struct Top8 {
     values: Vec<f32>,
 }
 
-/// Sliding-window boundary coverage (review finding 3): each case is a
+/// Sliding-window boundary coverage: each case is a
 /// synthetic prompt of exactly `length` tokens, built by cycling the main
 /// golden's own (tokenizer-verified) prompt ids -- see
 /// `scripts/gemma4_stage5_e2e_golden.py`'s `BOUNDARY_LENGTHS` docs for why
@@ -341,7 +341,7 @@ fn boundary_golden_fixture_is_valid() {
     }
 }
 
-/// ADR-082 stage 5 review finding 3: real-checkpoint sliding-window
+/// ADR-082 stage 5: real-checkpoint sliding-window
 /// boundary coverage at prompt lengths 511/512/513, plus a decode step past
 /// the boundary (`greedy_tokens` in the fixture covers 2 new tokens).
 /// Same fail-closed contract as

--- a/crates/inference/tests/grammar_json_schema_regression.rs
+++ b/crates/inference/tests/grammar_json_schema_regression.rs
@@ -65,7 +65,7 @@ fn enum_helper_names_do_not_collide() {
     );
 }
 
-// Finding #4 ($defs sub-case, raised in review): a generated
+// A generated
 // `str_enum_N` helper rule must not overwrite a user `$defs` rule that
 // happens to share the same name. Here `a` references a def literally named
 // `str_enum_0` (an integer), and `b`'s enum helper would otherwise reserve
@@ -92,7 +92,7 @@ fn enum_helper_does_not_clobber_user_defs_rule() {
     );
 }
 
-// Finding #4 (reverse $defs sub-case, raised in re-review): when an enum
+// Reverse $defs case: when an enum
 // property compiles BEFORE a `$ref` to a def of a colliding name, the `$ref`
 // must resolve to the DEF, not alias to the enum helper. Here `a` (enum, first)
 // would claim `str_enum_0`; `b` then references a def named `str_enum_0` that is

--- a/crates/inference/tests/vision_s3b_vit_metal_gate_test.rs
+++ b/crates/inference/tests/vision_s3b_vit_metal_gate_test.rs
@@ -233,8 +233,8 @@ mod gated {
     }
 
     /// Dispatch-count accounting is only compiled into the library under the
-    /// non-default `test-utils` feature (review follow-up: the counter must
-    /// not run in a normal production `metal-gpu` build). These helpers make
+    /// non-default `test-utils` feature: the counter must
+    /// not run in a normal production `metal-gpu` build. These helpers make
     /// that opt-in a no-op here too, so `cargo test --features f16,metal-gpu`
     /// (without `test-utils`) still compiles and runs the cosine gate below,
     /// just without the dispatch-count proof.


### PR DESCRIPTION
## Summary

Rewrites source comments across `crates/inference` that recorded transient authoring
history into the durable technical properties they document. Issue, ADR and RFC
references, type and function names, and all measured values are preserved. Only the
process framing is removed.

Comment-only: no executable code, no signature, and no test assertion changed. A single
`assert_eq!` failure *message* was also reworded (the descriptive text shown on failure,
not the assertion itself).

## Test plan

- `cargo fmt -p lattice-inference` — no changes
- `cargo check -p lattice-inference --all-targets --features f16,metal-gpu` — pass
- `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings` — pass, zero warnings
- `cargo doc -p lattice-inference --no-deps --features f16,metal-gpu` — pass

Every changed line was programmatically verified to be a comment. The one line that mixes
code and comment (`#[allow(dead_code)] // ...`) was confirmed byte-identical in its
attribute text, with only the trailing comment altered.

## bench-compare disposition

No hot-path call sites touched. Comments do not affect generated code, so there is no
behavioral delta to measure and an A/B comparison is structurally inapplicable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
