### PR TITLE
perf(embed): delegate hinted prepared cosine to the fused path

### DIFF
--- a/crates/embed/benches/simd.rs
+++ b/crates/embed/benches/simd.rs
@@ -825,12 +825,16 @@ fn bench_squared_euclidean_fast_path(c: &mut Criterion) {
 // ROUND 3: PREPARED QUERY NORMALIZED COSINE BENCHMARKS (H1 batch baseline)
 // ============================================================================
 
-/// Baseline for prepared normalized-cosine batch path (Round 3, Hypothesis 1).
+/// Prepared normalized-cosine batch path (Round 3, Hypothesis 1 — REFUTED).
 ///
 /// Measures `approximate_cosine_distance_prepared` on `QuantizedData::Full` unit
-/// vectors at [384, 768, 1024] dims (1000 stored vectors). After i2 adds
-/// `approximate_cosine_distance_prepared_with_meta` with `VectorNorm::Unit`, the
-/// new path should improve by at least 15% for 768/1024 by routing to dot product.
+/// vectors at [384, 768, 1024] dims (1000 stored vectors), against
+/// `approximate_cosine_distance_prepared_with_meta` on the same corpus. The
+/// original hypothesis (a unit-norm hint path routing to bare dot product beats
+/// full cosine by >=15%) is refuted by this bench: verifying the stored norm
+/// costs an extra O(d) pass, while `cosine_similarity` fuses dot and norms in
+/// one pass. `_with_meta` now delegates to the fused path, so these two groups
+/// are expected to measure AT PARITY; a gap between them is a regression.
 fn bench_prepared_query_normalized_cosine(c: &mut Criterion) {
     const BENCH_DIMS: [usize; 3] = [384, 768, 1024];
     const STORED_COUNT: usize = 1000;

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -311,7 +311,15 @@ pub fn try_approximate_dot_product_prepared(
     approximate_dot_product_prepared(query, stored)
 }
 
-/// Computes prepared cosine distance, using the `Full` unit-norm fast path when asserted.
+/// Computes prepared cosine distance; hints are accepted but do not select a
+/// separate code path.
+///
+/// The former `Full` unit-norm "fast path" (skip norm division when both sides
+/// assert unit norm) was measurably slower than the general path it guarded:
+/// verifying the stored side's norm plus the query dot takes two O(d) passes,
+/// while [`cosine_similarity`] computes the dot and both norms in one fused
+/// pass. With the guard it was also a correctness risk, trusting release-time
+/// hints. Delegating unconditionally is both the fastest and the safest shape.
 ///
 /// Returns [`EmbedError::TierMismatch`] for a tier mismatch.
 /// See [`docs/simd.md`](../../docs/simd.md#prepared-queries-and-tier-matching) for hint semantics.
@@ -319,16 +327,8 @@ pub fn try_approximate_dot_product_prepared(
 pub fn approximate_cosine_distance_prepared_with_meta(
     meta: &PreparedQueryWithMeta,
     stored: &QuantizedData,
-    stored_norm: NormalizationHint,
+    _stored_norm: NormalizationHint,
 ) -> Result<f32> {
-    if meta.norm == NormalizationHint::Unit
-        && stored_norm == NormalizationHint::Unit
-        && let (PreparedQuery::Full(q), QuantizedData::Full(s)) = (&meta.query, stored)
-        && is_unit_norm(s)
-    {
-        let dot = dot_product(q, s);
-        return Ok(1.0 - dot.clamp(-1.0, 1.0));
-    }
     approximate_cosine_distance_prepared(&meta.query, stored)
 }
 

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -248,9 +248,14 @@ impl PreparedQueryWithMeta {
 }
 
 /// Returns `true` when the squared norm of `v` is within 1e-4 of 1.0.
+///
+/// Uses the SIMD-dispatched [`dot_product`] for the self-dot rather than a plain
+/// scalar reduction: on a hot per-candidate path this check runs alongside an
+/// already-SIMD `dot_product(q, s)`, and a scalar accumulator here made the guard
+/// several times more expensive than the multiply it was guarding.
 #[inline]
 pub fn is_unit_norm(v: &[f32]) -> bool {
-    let sq: f32 = v.iter().map(|x| x * x).sum();
+    let sq = dot_product(v, v);
     (sq - 1.0).abs() < 1e-4
 }
 

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -250,9 +250,10 @@ impl PreparedQueryWithMeta {
 /// Returns `true` when the squared norm of `v` is within 1e-4 of 1.0.
 ///
 /// Uses the SIMD-dispatched [`dot_product`] for the self-dot rather than a plain
-/// scalar reduction: on a hot per-candidate path this check runs alongside an
-/// already-SIMD `dot_product(q, s)`, and a scalar accumulator here made the guard
-/// several times more expensive than the multiply it was guarding.
+/// scalar reduction. This helper is no longer called on the cosine hot path
+/// (`approximate_cosine_distance_prepared_with_meta` delegates to the fused
+/// path instead of guarding a hint-selected shortcut), but any caller checking
+/// norms per candidate gets the SIMD cost model, not a scalar one.
 #[inline]
 pub fn is_unit_norm(v: &[f32]) -> bool {
     let sq = dot_product(v, v);


### PR DESCRIPTION
## Summary

`approximate_cosine_distance_prepared_with_meta` carried a unit-norm "fast path": when both sides assert `NormalizationHint::Unit`, verify the stored side with `is_unit_norm` and skip the norm division. Two independent defects:

1. **The guard was O(d) scalar.** `is_unit_norm` used a scalar accumulator on the hot per-candidate path, costing 10-12x on `simd_prepared_query_normalized_cosine/prepared_meta_unit` (confirmed by A/B at every dim; also visible in the `perf-baselines` trend on both CI arches since it landed).
2. **The fast path loses to the path it guards even with the guard SIMD-fixed.** Verifying the stored norm plus the query dot is two O(d) passes; `cosine_similarity` computes dot and both norms in one fused pass. Measured with the guard converted to SIMD: the guarded route still ran 1.5-1.9x slower than delegating to the general path.

The function has no production callers (bench and unit tests only), so there is no call site that could justify keeping a hint-selected route. This PR deletes the special case: `_with_meta` now delegates unconditionally to `approximate_cosine_distance_prepared`. The norm hint no longer selects a code path, which also removes the correctness risk of trusting release-time hints. `is_unit_norm` stays public with a SIMD self-dot.

## bench-compare disposition

A/B on Apple M2 Max (idle machine, exclusive measurement window, prebuilt binaries, Criterion `--quick`), `main@e1000d310` vs this branch:

| Bench | Δ point | 95% CI | new ns | base ns |
|---|---:|---|---:|---:|
| `prepared_meta_unit/384` | -90.79% | [-90.82%, -90.75%] | 34,599 | 375,535 |
| `prepared_meta_unit/768` | -91.24% | [-91.29%, -91.19%] | 64,225 | 732,921 |
| `prepared_meta_unit/1024` | -91.60% | [-91.67%, -91.52%] | 82,508 | 981,843 |

Controls in the same group are flat: `prepared_full_cosine` -0.1..+1.1%, `dot_product_loop` -2.2..+1.1%. Post-change, `prepared_meta_unit` measures at parity with `prepared_full_cosine` (82.5µs vs 85.0µs at 1024), which is the expected shape: both now run the same fused path. The bench group's doc comment is updated to state that parity is the contract and a gap between the two groups is a regression.

## Test plan

- `cargo test -p lattice-embed --lib`: 276 passed.
- `cargo clippy -p lattice-embed --all-targets`: clean.
- `test_cosine_distance_prepared_with_meta_validates_stored_unit_norm` now pins `_with_meta` ≡ `approximate_cosine_distance_prepared` on a non-unit stored vector under a unit hint — the delegation contract.
- Tier-mismatch error propagation covered by the existing typed-error test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
