### PR TITLE
perf(embed): make the int8 quantization min/max scan explicitly SIMD

### DIFF
--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -35,15 +35,7 @@ impl QuantizationParams {
     /// Handles edge cases: empty vectors, NaN, Inf, near-zero vectors.
     pub fn from_vector(vector: &[f32]) -> Self {
         // Single pass over finite values to handle NaN/Inf gracefully.
-        let mut min_val = f32::INFINITY;
-        let mut max_val = f32::NEG_INFINITY;
-
-        for &v in vector {
-            if v.is_finite() {
-                min_val = min_val.min(v);
-                max_val = max_val.max(v);
-            }
-        }
+        let (mut min_val, mut max_val) = minmax_finite(vector);
 
         // Handle edge case: empty or all non-finite.
         if !min_val.is_finite() || !max_val.is_finite() {
@@ -68,6 +60,67 @@ impl QuantizationParams {
             max_val,
         }
     }
+}
+
+/// Minimum and maximum over the finite lanes of `v`, in one pass.
+///
+/// Non-finite lanes are skipped. An empty or all-non-finite input yields
+/// `(+inf, -inf)` so the caller's reset branch fires.
+///
+/// Explicit NEON kernel with a scalar fallback rather than a plain guarded
+/// loop: the auto-vectorized form of this reduction was demoted to scalar
+/// code by an unrelated codegen-unit reshuffle (+48% on per-call int8
+/// quantization at 1024 dims), so the hot path must not depend on the
+/// auto-vectorizer's mood.
+fn minmax_finite(v: &[f32]) -> (f32, f32) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        if simd_config().neon_enabled {
+            // SAFETY: NEON confirmed available at runtime.
+            return unsafe { minmax_finite_neon(v) };
+        }
+    }
+    minmax_finite_scalar(v)
+}
+
+fn minmax_finite_scalar(v: &[f32]) -> (f32, f32) {
+    let mut min_val = f32::INFINITY;
+    let mut max_val = f32::NEG_INFINITY;
+    for &x in v {
+        if x.is_finite() {
+            min_val = min_val.min(x);
+            max_val = max_val.max(x);
+        }
+    }
+    (min_val, max_val)
+}
+
+#[cfg(target_arch = "aarch64")]
+unsafe fn minmax_finite_neon(v: &[f32]) -> (f32, f32) {
+    let chunks = v.len() / 4;
+    let inf = unsafe { vdupq_n_f32(f32::INFINITY) };
+    let neg_inf = unsafe { vdupq_n_f32(f32::NEG_INFINITY) };
+    let mut vmin = inf;
+    let mut vmax = neg_inf;
+    for i in 0..chunks {
+        // SAFETY: `i * 4 + 3 < v.len()` by the chunk bound.
+        let x = unsafe { vld1q_f32(v.as_ptr().add(i * 4)) };
+        unsafe {
+            // `|x| < +inf` holds exactly for finite lanes (false for NaN, ±inf),
+            // so masked lanes contribute identity elements, same as skipping.
+            let finite = vcaltq_f32(x, inf);
+            vmin = vminq_f32(vmin, vbslq_f32(finite, x, inf));
+            vmax = vmaxq_f32(vmax, vbslq_f32(finite, x, neg_inf));
+        }
+    }
+    let (mut min_val, mut max_val) = unsafe { (vminvq_f32(vmin), vmaxvq_f32(vmax)) };
+    for &x in &v[chunks * 4..] {
+        if x.is_finite() {
+            min_val = min_val.min(x);
+            max_val = max_val.max(x);
+        }
+    }
+    (min_val, max_val)
 }
 
 /// **Unstable**: INT8 quantized vector; struct layout and invariants may change.

--- a/crates/embed/src/simd/tests.rs
+++ b/crates/embed/src/simd/tests.rs
@@ -1042,3 +1042,29 @@ fn test_i8_dot_unrolled_matches_original() {
         );
     }
 }
+
+#[test]
+fn test_quantization_params_non_finite_lanes_are_skipped() {
+    // The branchless min/max scan must be exactly equivalent to skipping
+    // non-finite lanes: they contribute identity elements, never values.
+    let mut v = vec![0.5f32, -2.0, 3.0, 1.0];
+    v.push(f32::NAN);
+    v.push(f32::INFINITY);
+    v.push(f32::NEG_INFINITY);
+    let p = QuantizationParams::from_vector(&v);
+    assert_eq!(p.min_val, -2.0);
+    assert_eq!(p.max_val, 3.0);
+    assert_eq!(p.scale, 127.0 / 3.0);
+
+    // All-non-finite still resets to (0, 0) with unit scale.
+    let p = QuantizationParams::from_vector(&[f32::NAN, f32::INFINITY, f32::NEG_INFINITY]);
+    assert_eq!(p.min_val, 0.0);
+    assert_eq!(p.max_val, 0.0);
+    assert_eq!(p.scale, 1.0);
+
+    // Empty input takes the same reset path.
+    let p = QuantizationParams::from_vector(&[]);
+    assert_eq!(p.min_val, 0.0);
+    assert_eq!(p.max_val, 0.0);
+    assert_eq!(p.scale, 1.0);
+}


### PR DESCRIPTION
## Summary

`QuantizationParams::from_vector`'s finite-lane min/max scan relied on LLVM auto-vectorizing a guarded loop. An unrelated module reshuffle changed codegen-unit partitioning and the loop silently went scalar — the compiled `from_f32` dropped from 51 NEON fmin/fmax instructions to 3 — costing **+47.6%** on `tier_prepared_query/int8_query_per_call/1000` (755.6µs → 1116µs at 1024 dims) between 2026-06-23 main and current main. The source was byte-identical across that window; only codegen changed. A branchless rewrite still did not vectorize, so the scan is now an **explicit NEON kernel with a scalar fallback**, following the same dispatch shape as `dot_product_i8` in the same file.

Semantics are exactly preserved: non-finite lanes contribute identity elements (+inf to min, -inf to max), equivalent to skipping them, including the all-non-finite and empty reset cases. A new test pins those semantics (mixed finite/NaN/±inf, all-non-finite, empty).

This path is production-relevant: `QuantizedVector::from_f32` is the int8 ingest quantizer.

## bench-compare disposition

Full-mode A/B (n=100, Apple M2 Max, idle machine, exclusive measurement window, prebuilt binaries) against the 2026-06-23 main baseline:

| Bench | this branch vs 2026-06-23 | current main vs 2026-06-23 |
|---|---:|---:|
| `int8_query_per_call/1000` | **-5.3%** (715.7µs) | +47.6% (1116µs) |
| `int8_query_once/1000` | +8.2% | +8.6% |

The per_call regression is fully recovered and the path is now faster than before the regression (explicit NEON beats the old auto-vectorized code). The residual `once` +8.2% is the pure i8 dot loop (~12ns/candidate), untouched by this diff and tracked separately.

## Test plan

- `cargo test -p lattice-embed --lib simd`: 98 passed.
- `cargo clippy -p lattice-embed --all-targets`: clean.
- Static verification: disassembled `from_f32` in the bench binary shows the NEON mask/min/max sequence (facgt/bsl/fmin/fmax on vector lanes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
