### PR TITLE
fix(bench): fail loud when Metal bench targets cannot measure

### DIFF
--- a/crates/inference/benches/decode_attn_bench.rs
+++ b/crates/inference/benches/decode_attn_bench.rs
@@ -408,8 +408,11 @@ fn bench_reference_decode(c: &mut Criterion) {
         const HEAD_DIM: u32 = 256;
 
         let Some(device) = Device::system_default() else {
-            eprintln!("[decode_attn_bench] No Metal device — skipping reference benchmarks");
-            return;
+            eprintln!(
+                "[decode_attn_bench] FATAL: no Metal device — this bench cannot measure \
+                 anything on this machine; failing instead of producing an empty run"
+            );
+            std::process::exit(1);
         };
         let queue = device.new_command_queue();
 
@@ -515,7 +518,7 @@ fn bench_reference_decode(c: &mut Criterion) {
     }
 
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
-    let _ = c;
+    fail_wrong_build(c);
 }
 
 fn bench_flash_decode(c: &mut Criterion) {
@@ -528,8 +531,11 @@ fn bench_flash_decode(c: &mut Criterion) {
         const DIRECT_THRESHOLD: u32 = 512;
 
         let Some(device) = Device::system_default() else {
-            eprintln!("[decode_attn_bench] No Metal device — skipping flash benchmarks");
-            return;
+            eprintln!(
+                "[decode_attn_bench] FATAL: no Metal device — this bench cannot measure \
+                 anything on this machine; failing instead of producing an empty run"
+            );
+            std::process::exit(1);
         };
         let queue = device.new_command_queue();
 
@@ -692,7 +698,20 @@ fn bench_flash_decode(c: &mut Criterion) {
     }
 
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
-    let _ = c;
+    fail_wrong_build(c);
+}
+
+/// This bench binary is Metal-only: on a build without `metal-gpu` every group
+/// is compiled out and the run exits green having measured nothing, which
+/// silently corrupts A/B comparisons that point at it. Fail instead.
+#[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+fn fail_wrong_build(_c: &mut Criterion) {
+    eprintln!(
+        "[decode_attn_bench] FATAL: built without macOS + `metal-gpu`, so no benchmark \
+         in this binary can run. Rebuild with: cargo bench -p lattice-inference \
+         --bench decode_attn_bench --features f16,metal-gpu"
+    );
+    std::process::exit(1);
 }
 
 criterion_group!(benches, bench_reference_decode, bench_flash_decode);

--- a/crates/inference/benches/topk_readback.rs
+++ b/crates/inference/benches/topk_readback.rs
@@ -758,7 +758,7 @@ fn bench_full_logit_readback_metal(c: &mut Criterion) {
     }
 
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
-    let _ = c;
+    skip_metal_gated(c);
 }
 
 // ---------------------------------------------------------------------------
@@ -815,7 +815,7 @@ fn bench_compact_readback_metal(c: &mut Criterion) {
     }
 
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
-    let _ = c;
+    skip_metal_gated(c);
 }
 
 // ---------------------------------------------------------------------------
@@ -860,7 +860,7 @@ fn bench_noop_command_buffer(c: &mut Criterion) {
     }
 
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
-    let _ = c;
+    skip_metal_gated(c);
 }
 
 // ---------------------------------------------------------------------------
@@ -1252,7 +1252,7 @@ fn bench_metal_topk_dispatch_only(c: &mut Criterion) {
     }
 
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
-    let _ = c;
+    skip_metal_gated(c);
 }
 
 // ---------------------------------------------------------------------------
@@ -1549,7 +1549,7 @@ fn bench_metal_topk_plus_readback(c: &mut Criterion) {
     }
 
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
-    let _ = c;
+    skip_metal_gated(c);
 }
 
 // ---------------------------------------------------------------------------
@@ -2107,7 +2107,20 @@ fn bench_topk_parity(c: &mut Criterion) {
     }
 
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
-    let _ = c;
+    skip_metal_gated(c);
+}
+
+/// Metal-gated groups in this otherwise-CPU bench binary cannot run on a build
+/// without `metal-gpu`. Say so loudly instead of vanishing from the report:
+/// an absent group in an A/B table reads as "no change" when it is actually
+/// "not measured". (Not a hard failure — the CPU groups above must stay
+/// runnable on default builds.)
+#[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+fn skip_metal_gated(_c: &mut Criterion) {
+    eprintln!(
+        "[topk_readback] SKIP: Metal-gated benchmark group compiled out (needs macOS + \
+         --features metal-gpu); its results are MISSING from this run, not unchanged"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Bench binaries that cannot measure must say so, loudly, instead of exiting green and empty.

- **`decode_attn_bench`** (Metal-only binary, `required-features = ["f16"]`): built with `f16` but without `metal-gpu`, both benchmark functions were compiled down to `let _ = c;` and the binary exited 0 having registered zero benchmarks. Same for a `metal-gpu` build on a machine with no Metal device. Both conditions now print a FATAL message and `exit(1)`.
- **`topk_readback`** (mixed CPU/Metal binary): its six Metal-gated functions were silent no-ops on default builds. They now print a SKIP line stating the group is *missing from this run, not unchanged*. Kept exit-0 deliberately: the CPU groups in this binary must stay runnable on default builds.

## Why

A silently empty bench run is how false A/B verdicts happen: a harness pointing at a compiled-out bench records "no change" when the truth is "not measured" (the structural-unreachability failure mode documented in this repo's bench-integrity notes). Explicit target selection without `f16` already fails loudly at the cargo level via `required-features`; the `f16`-without-`metal-gpu` build was the remaining silent case.

## Verification (7-step pipeline, all green)

1. `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings` — clean.
2. Clippy of the non-metal arms (`--bench decode_attn_bench --features f16`; `--bench topk_readback` default) — clean.
3. Both binaries compile in their non-metal configurations.
4. **Mutation-sensitivity**: wrong-build `decode_attn_bench` (`--features f16`, no `metal-gpu`) now exits nonzero; the pre-fix binary exited 0.
5. Default-build `topk_readback` passes `criterion --test` with rc=0 and exactly 6 SKIP lines.
6. Both binaries compile under `f16,metal-gpu`.
7. Metal `decode_attn_bench` smoke (`criterion --test`, exclusive GPU lock): every reference and flash group runs Success.

## bench-compare disposition

No library or kernel code changes; the diff is confined to the two bench source files. In the measured (`f16,metal-gpu`) configuration the benchmark loops are byte-identical; the only behavioral changes execute before any measurement begins (device-acquisition guard) or in build configurations that cannot measure at all. Structural no-op for A/B purposes.
