### PR TITLE
chore(ci): name the mocked decode-harness checks for what they prove

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,8 +580,14 @@ jobs:
   # any CI job before this issue's step-2 migrations landed; this closes
   # that gap for all of them at once rather than repeating the same
   # omission per migrated script.)
-  bench-decode-harness-tests:
-    name: bench-decode-harness-tests
+  # The job/check name says "unit-tests (no engine)" on purpose: a green
+  # check here proves harness plumbing and parameter transcription ONLY.
+  # No benchmark runs, no engine binary executes, no throughput number is
+  # produced or validated by this job — reading it as bench evidence is
+  # exactly the misread its old name ("bench-decode-harness-tests")
+  # invited on the #813 migration PRs.
+  decode-harness-unit-tests:
+    name: decode-harness-unit-tests (no engine)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/tests/test_bench_decode_adapters_apples_precise.py
+++ b/tests/test_bench_decode_adapters_apples_precise.py
@@ -5,7 +5,7 @@ decode-bench harness).
 No engine binary or network access is required: real adapters are
 exercised only through their pure parsing helpers
 (`parse_lattice_result_line`, `ollama_response_to_result`); the profile ->
-call-schedule equivalence is checked with the harness's own deterministic
+call-schedule contract is checked against the harness's own deterministic
 fake adapters, matching
 tests/test_bench_decode_adapters_apples_to_apples.py's convention.
 
@@ -66,7 +66,7 @@ class _FakeAdapter:
         )
 
 
-class ProfileParameterEquivalenceTest(unittest.TestCase):
+class ProfileParameterTranscriptionTest(unittest.TestCase):
     """bench_apples_precise.sh: N1=64, N2=512, TOTAL_RUNS=15, WARMUP=2 (so
     13 measured), trimmed mean dropping top/bottom 2, every engine warms
     identically (unlike apples_to_apples's mlx-only warmup)."""
@@ -113,7 +113,7 @@ class ProfileParameterEquivalenceTest(unittest.TestCase):
             self.assertEqual(group.quantization, "q8", group.name)
 
 
-class CallScheduleEquivalenceTest(unittest.TestCase):
+class CallScheduleContractTest(unittest.TestCase):
     """Proves the produced call schedule matches bench_apples_precise.sh's
     loop structure: every engine gets 2 warmup calls at N2=512, then N1 x13,
     then N2 x13."""

--- a/tests/test_bench_decode_adapters_apples_to_apples.py
+++ b/tests/test_bench_decode_adapters_apples_to_apples.py
@@ -5,7 +5,7 @@ decode-bench harness).
 No engine binary or network access is required to run this file: real
 adapters are exercised only through their pure parsing helpers
 (`parse_lattice_result_line`, `ollama_response_to_result`); the profile ->
-call-schedule equivalence is checked with the harness's own deterministic
+call-schedule contract is checked against the harness's own deterministic
 `_FakeAdapter`, matching `tests/test_bench_decode_harness.py`'s convention
 and the issue #813 gate: "Deterministic fake-adapter tests and raw-schema
 validation pass without any engine binary present."
@@ -75,12 +75,12 @@ class _FakeAdapter:
 
 
 # --------------------------------------------------------------------------
-# Profile parameter equivalence (the issue #813 gate: byte-for-byte
+# Profile parameter transcription (the issue #813 gate: byte-for-byte
 # equivalent window/repeats/warmup parameters vs the legacy script)
 # --------------------------------------------------------------------------
 
 
-class ProfileParameterEquivalenceTest(unittest.TestCase):
+class ProfileParameterTranscriptionTest(unittest.TestCase):
     """bench_apples_to_apples.sh: N1=32, N2=256, RUNS=5, no lattice/ollama
     warmup, mlx warms up once at 8 tokens -- see the script's own
     N1/N2/RUNS constants and its single pre-loop `generate(..., max_tokens=8,
@@ -156,11 +156,11 @@ class ProfileParameterEquivalenceTest(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
-# Call-schedule equivalence via fake adapters (no engine binary needed)
+# Call-schedule contract via fake adapters (no engine binary needed)
 # --------------------------------------------------------------------------
 
 
-class CallScheduleEquivalenceTest(unittest.TestCase):
+class CallScheduleContractTest(unittest.TestCase):
     """Runs the REAL shipped profiles through harness.run_profile with fake
     adapters, proving the produced call schedule matches
     bench_apples_to_apples.sh's loop structure exactly: lattice/ollama get

--- a/tests/test_bench_decode_adapters_context_scaling.py
+++ b/tests/test_bench_decode_adapters_context_scaling.py
@@ -74,7 +74,7 @@ class _SequencedNativeAdapter:
         )
 
 
-class ProfileParameterEquivalenceTest(unittest.TestCase):
+class ProfileParameterTranscriptionTest(unittest.TestCase):
     """bench_context_scaling.sh: N1=8 baseline, default CONTEXTS=(64 128
     256), RUNS=5, only mlx warms (4 tokens, once, before the whole loop)."""
 
@@ -104,7 +104,7 @@ class ProfileParameterEquivalenceTest(unittest.TestCase):
             self.assertEqual(group.quantization, "q8", group.name)
 
 
-class CallScheduleEquivalenceTest(unittest.TestCase):
+class CallScheduleContractTest(unittest.TestCase):
     """Proves the default (no measured_calls override) window-major replay
     of profile.windows reproduces "measure N1=8 once, then measure each
     context length in turn, reusing the N1 baseline for every slope" --

--- a/tests/test_bench_decode_adapters_q4_apples.py
+++ b/tests/test_bench_decode_adapters_q4_apples.py
@@ -57,7 +57,7 @@ class _FakeAdapter:
         )
 
 
-class ProfileParameterEquivalenceTest(unittest.TestCase):
+class ProfileParameterTranscriptionTest(unittest.TestCase):
     """bench_q4_apples.sh: N1=32, N2=256, RUNS=5, no lattice/ollama warmup,
     mlx warms once at 8 tokens (same call shape as apples_to_apples_q4, but
     this is that script's own separate reimplementation, migrated on its
@@ -98,7 +98,7 @@ class ProfileParameterEquivalenceTest(unittest.TestCase):
         self.assertEqual(groups["mlx"].model, "qwen3.5-0.8b")
 
 
-class CallScheduleEquivalenceTest(unittest.TestCase):
+class CallScheduleContractTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         _, cls.profiles = harness.load_profiles_file(DEFAULT_PROFILES_FILE)


### PR DESCRIPTION
## What

Renames the mocked decode-harness CI check and its "equivalence" test classes so their names state exactly what they prove. No test logic changes; all five test files pass unchanged before and after.

## Why

The `bench-decode-harness-tests` check runs deterministic fake-adapter unit tests — no engine binary executes and no throughput number is produced — but its name read as if benchmarks ran, and a green check on the #813 migration PRs could be (and was) mistaken for bench evidence. Same for `ProfileParameterEquivalenceTest` / `CallScheduleEquivalenceTest`: they verify that migrated profiles transcribe the legacy scripts' constants and reproduce the call schedule against fake adapters — parameter transcription and a schedule contract, not output equivalence against the legacy implementation.

## Changes

- `ci.yml`: job/check `bench-decode-harness-tests` → `decode-harness-unit-tests (no engine)`, with a comment stating explicitly what a green check does and does not prove. The check is not in branch protection's required contexts (verified), so the rename has no protection-config impact.
- Four adapter test files: `ProfileParameterEquivalenceTest` → `ProfileParameterTranscriptionTest`, `CallScheduleEquivalenceTest` → `CallScheduleContractTest`, docstrings and section comments reworded to match. Accurate uses of "equivalent" (the parameter-level byte-for-byte claim, which is true) are kept.

## Audit context

This lands alongside a source verification of the four #813 migrations against their pre-migration originals (recovered from the repo's root-commit import): all pinned parameters check out (windows, repeats, prompts, warmup shapes, aggregation semantics including slope-of-medians and trimmed-mean trim=2), and in two cases the migration corrected real bugs in the retired scripts — the context-scaling slope truncation (#1060) and the q4 lattice leg that never actually loaded Q4 weights (disclosed in `bench_decode_profiles.toml`). The tests were honest about what they test; only the names overclaimed.

Docs/CI/test-naming only; no code paths affected; no bench disposition applicable (no `crates/` source touched).
