### PR TITLE
refactor(bench): demote embed simd bench target to quick-mode informational via one validated manifest

### DIFF
--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -16,14 +16,16 @@
 #   lattice-embed: simd
 # Uses a git worktree for the base ref so your working tree stays untouched.
 #
-# lattice#714: five of the lattice-embed bench targets' groups
+# lattice#714: nine of the lattice-embed bench targets' groups
 # (simd_dot_product, simd_cosine_similarity, int8_batch_cosine,
-# int4_cosine_distance, simd_batch_cosine_non_normalized_query) are confirmed
+# int4_cosine_distance, simd_batch_cosine_non_normalized_query,
+# simd_normalized_cosine_fast_path, int8_raw_dot_product,
+# simd_batch_cosine_normalized_query, int8_vs_float32_cosine) are confirmed
 # noise-dominated in --quick mode by same-toolchain A/A reproductions on
 # identical refs (the original pair: FAIL/WARN sign flipped across dozens of
-# entries run to run; the 2026-07-13 additions: confirmed-CI FAIL rows inside
-# exclusive bench windows with DISJOINT failing groups across two same-commit
-# runs). In --quick mode (the default), only those named groups are
+# entries run to run; the 2026-07-13 and 2026-07-19 additions: confirmed-CI
+# FAIL rows inside exclusive bench windows with DISJOINT failing groups
+# across two same-commit runs each). In --quick mode (the default), only those named groups are
 # measured and reported but excluded from the FAIL/WARN gate and exit code —
 # see the "informational" section of the report and INFO_GROUPS_ALLOWLIST
 # below. Every other group in the target, including any added later, gates

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -16,20 +16,24 @@
 #   lattice-embed: simd
 # Uses a git worktree for the base ref so your working tree stays untouched.
 #
-# lattice#714: nine of the lattice-embed bench targets' groups
-# (simd_dot_product, simd_cosine_similarity, int8_batch_cosine,
-# int4_cosine_distance, simd_batch_cosine_non_normalized_query,
-# simd_normalized_cosine_fast_path, int8_raw_dot_product,
-# simd_batch_cosine_normalized_query, int8_vs_float32_cosine) are confirmed
-# noise-dominated in --quick mode by same-toolchain A/A reproductions on
-# identical refs (the original pair: FAIL/WARN sign flipped across dozens of
-# entries run to run; the 2026-07-13 and 2026-07-19 additions: confirmed-CI
-# FAIL rows inside exclusive bench windows with DISJOINT failing groups
-# across two same-commit runs each). In --quick mode (the default), only those named groups are
-# measured and reported but excluded from the FAIL/WARN gate and exit code —
-# see the "informational" section of the report and INFO_GROUPS_ALLOWLIST
-# below. Every other group in the target, including any added later, gates
-# normally. --full mode gates every group normally regardless.
+# lattice#714 / lattice#1060: the lattice-embed `simd` bench TARGET is
+# informational in --quick mode (the default). Same-toolchain, same-commit
+# A/A reproductions in exclusive bench windows repeatedly produced
+# confirmed-CI FAIL rows (+8% to +17%, 95% CIs) on identical binaries with
+# DISJOINT failing groups across runs — machine-level noise above
+# quick-mode resolution, so per-group exemptions were a treadmill. Demoted
+# targets are named in ONE validated manifest,
+# scripts/lib/bench-quick-informational-targets.txt (validated by
+# scripts/perf-bench-gate.py --selftest); their groups are still fully
+# measured and rendered — the informational section plus the
+# all-measurements table record every number — but excluded from the
+# FAIL/WARN gate and exit code. Every non-demoted target (all of
+# lattice-inference) gates normally in --quick.
+#
+# --full remains the gate for EVERY group of every target: quick mode is a
+# PR-side direction/magnitude screen, and full-resolution simd gating rides
+# the scheduled nightly perf lane (a --full run on current main), so the
+# demotion is a resolution split, not a coverage hole.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
@@ -123,38 +127,36 @@ fi
   cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:|change:" || true
 )
 
-# --- Quick-mode informational-groups (lattice#714) ---
-# Fixed, reviewed allowlist of the issue-evidenced noisy groups only — NOT a
-# target-wide dump. Every entry carries same-toolchain A/A evidence on
-# identical refs in --quick mode (lattice#714's original reproduction for
-# the first two; isolated bench-window A/A runs for the 2026-07-13
-# additions); no other group in that target has that evidence, so no other
-# group is exempted here. The
-# allowlist itself and the intersection-with-the-real-listing logic live in
-# scripts/lib/bench-informational-groups.sh, invoked below — kept in its own
-# file (rather than inline here) so scripts/perf-bench-gate.py --selftest can
-# run the exact same shell code against a controlled listing and catch a
-# shell-only regression, not just a Python-classifier one.
-# This list is embed-`simd`-specific: names are matched against the Criterion
-# top-level group name only (scripts/perf-bench-gate.py), so it must never be
-# extended with a name that could collide with a `lattice-inference` group —
-# if that ever becomes a concern, namespace by target (e.g. "embed:<group>")
-# on both sides of the handoff instead of trusting name uniqueness. Adding a
-# group requires the same kind of same-toolchain A/A quantitative evidence
-# that justified every current entry, reviewed in a PR — never derived
-# automatically from `--list`, which would silently exempt every future
-# group added to the target.
+# --- Quick-mode informational demotion (lattice#714 / lattice#1060) ---
+# Target-level policy: the demoted-target set lives in ONE validated
+# manifest, scripts/lib/bench-quick-informational-targets.txt. For each
+# bench target this script ran, the helper below is given the target key
+# (`<crate>:<bench-target>`) and that target's Criterion `--list` output;
+# it prints every top-level group of a demoted target and nothing for any
+# other target. Deriving the group set from the listing is deliberate
+# under target semantics — the demotion covers the target, so a group
+# added to a demoted target later is informational by policy, while every
+# non-demoted target stays gated because its key is absent from the
+# manifest. The helper lives in its own file (rather than inline here) so
+# scripts/perf-bench-gate.py --selftest can run the exact same shell code
+# against a controlled listing and catch a shell-only regression, not
+# just a Python-classifier one. --full skips this block entirely: every
+# group of every target gates at full resolution.
 INFO_GROUPS_FILE="$REPO/.cache/bench-compare-informational-groups.txt"
 rm -f "$INFO_GROUPS_FILE"
-if [ -n "$QUICK_FLAGS" ] && [ "$BENCHES_EMBED" = "simd" ]; then
+if [ -n "$QUICK_FLAGS" ]; then
   (
     cd "$HEAD_DIR"
-    # --list reflects both the built binary and any BENCH_GROUPS_EMBED filter
-    # already applied; the helper intersects it against the fixed allowlist
-    # so a stale or renamed allowlist entry fails closed (never gates) rather
-    # than silently no-op'ing into "everything is informational."
-    cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --list 2>/dev/null \
-      | "$REPO/scripts/lib/bench-informational-groups.sh" > "$INFO_GROUPS_FILE"
+    # --list reflects both the built binary and any BENCH_GROUPS_* filter
+    # already applied. Both targets consult the same manifest through the
+    # same helper call, so demoting another target someday is a manifest
+    # edit (plus the selftest expectation), not a change here.
+    {
+      cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --list 2>/dev/null \
+        | "$REPO/scripts/lib/bench-informational-groups.sh" "lattice-embed:$BENCHES_EMBED" || true
+      cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --list 2>/dev/null \
+        | "$REPO/scripts/lib/bench-informational-groups.sh" "lattice-inference:$BENCHES_INFERENCE" || true
+    } > "$INFO_GROUPS_FILE"
   )
 fi
 

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -1,65 +1,45 @@
 #!/usr/bin/env bash
-# bench-informational-groups.sh — the shell-side half of lattice#714's
-# quick-mode informational-groups contract.
+# bench-informational-groups.sh — shell side of the quick-mode informational
+# demotion (lattice#714; target-level policy per lattice#1060, 2026-07-19).
 #
-# Given Criterion `--list` output (a file path as $1, or stdin when no arg is
-# given), print the intersection of the fixed, reviewed allowlist below with
-# the top-level group names actually present in that listing — one name per
-# line, sorted.
+# The set of demoted bench targets lives in ONE validated manifest:
+# scripts/lib/bench-quick-informational-targets.txt. Given a target key
+# (`<crate>:<bench-target>`) and that target's Criterion `--list` output (a
+# file path as $2, or stdin), this script prints the group names to treat
+# as informational in QUICK mode: ALL of the listing's top-level groups
+# when the target is in the manifest, nothing otherwise. Deriving the
+# group set from the listing is deliberate under target-level semantics —
+# the demotion covers the target, so a group added to a demoted target
+# later is informational by policy, while every other target stays gated
+# because its key is absent from the manifest.
 #
-# scripts/bench-compare.sh invokes this file for the real run so the exact
-# same array and intersection logic feeds the gate. scripts/perf-bench-gate.py
-# --selftest invokes this script two ways: with --print-allowlist (dump the
-# raw array, no listing) so the Python-side expected set is compared against
-# the ACTUAL array — a name added only here, or only there, fails the
-# selftest — and as the intersection subprocess against a controlled listing
-# so the production code path is exercised end-to-end. An earlier fixture
-# kept its own hardcoded copy of this list in Python and never exercised
-# this file at all; extracting the logic here closed that.
+# scripts/bench-compare.sh invokes this file for production runs.
+# scripts/perf-bench-gate.py --selftest invokes the same file three ways:
+# `--print-targets` (compare the manifest against the reviewed
+# expectation, so a manifest-only or expectation-only edit fails), a
+# demoted-target probe (all listing groups emitted), and a
+# non-demoted-target probe (nothing emitted — the cross-target guarantee).
+# INFO_TARGETS_MANIFEST overrides the manifest path for those controlled
+# probes; production never sets it.
 #
-# Adding a group to the allowlist requires the same kind of same-toolchain
-# A/A quantitative evidence that justified every current entry (see scripts/
-# bench-compare.sh's "Quick-mode informational-groups" comment), reviewed in
-# a PR — never derived automatically from `--list`, which would silently
-# exempt every future group added to the target.
+# FULL mode (`bench-compare.sh --full`, nightly perf lane) ignores this
+# mechanism entirely and gates every group of every target.
 set -euo pipefail
 
-INFO_GROUPS_ALLOWLIST=(
-  "simd_dot_product"
-  "simd_cosine_similarity"
-  # Added 2026-07-13: two same-commit A/A runs, each inside an exclusive
-  # machine-wide bench window (/tmp/lion-bench-window.lock), still produced
-  # confirmed-CI FAIL rows (>7%) in these embed micro-groups — with DISJOINT
-  # failing groups across the two runs, the signature of a noise floor above
-  # the quick-mode gate rather than a regression. Evidence tables in the PR
-  # that added these entries.
-  "int8_batch_cosine"
-  "int4_cosine_distance"
-  "simd_batch_cosine_non_normalized_query"
-  # Added 2026-07-19: two further same-commit A/A runs on origin/main
-  # (e1000d3108), quick mode, each inside an exclusive bench window on an
-  # otherwise idle machine, produced confirmed-CI gating FAIL rows
-  # (+8.4% to +11.5%) in these four groups — again with DISJOINT failing
-  # groups across the two runs (run 1: the first three; run 2:
-  # int8_vs_float32_cosine alone), while every inference group and every
-  # non-listed embed group stayed clean. Evidence tables in the PR that
-  # added these entries.
-  "simd_normalized_cosine_fast_path"
-  "int8_raw_dot_product"
-  "simd_batch_cosine_normalized_query"
-  "int8_vs_float32_cosine"
-)
+MANIFEST="${INFO_TARGETS_MANIFEST:-$(dirname "$0")/bench-quick-informational-targets.txt}"
 
-if [ "${1:-}" = "--print-allowlist" ]; then
-  printf '%s\n' "${INFO_GROUPS_ALLOWLIST[@]}" | sort
+manifest_targets() {
+  sed 's/#.*//' "$MANIFEST" | awk 'NF { print $1 }' | sort
+}
+
+if [ "${1:-}" = "--print-targets" ]; then
+  manifest_targets
   exit 0
 fi
 
-input="${1:-/dev/stdin}"
-listed_groups=$(awk -F/ '/: benchmark$/{print $1}' "$input" | sort -u)
+target="${1:?usage: bench-informational-groups.sh <crate>:<bench-target> [listing-file] (or --print-targets)}"
+input="${2:-/dev/stdin}"
 
-for grp in "${INFO_GROUPS_ALLOWLIST[@]}"; do
-  if grep -qxF "$grp" <<< "$listed_groups"; then
-    echo "$grp"
-  fi
-done
+if manifest_targets | grep -qxF "$target"; then
+  awk -F/ '/: benchmark$/{print $1}' "$input" | sort -u
+fi

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -36,6 +36,18 @@ INFO_GROUPS_ALLOWLIST=(
   "int8_batch_cosine"
   "int4_cosine_distance"
   "simd_batch_cosine_non_normalized_query"
+  # Added 2026-07-19: two further same-commit A/A runs on origin/main
+  # (e1000d3108), quick mode, each inside an exclusive bench window on an
+  # otherwise idle machine, produced confirmed-CI gating FAIL rows
+  # (+8.4% to +11.5%) in these four groups — again with DISJOINT failing
+  # groups across the two runs (run 1: the first three; run 2:
+  # int8_vs_float32_cosine alone), while every inference group and every
+  # non-listed embed group stayed clean. Evidence tables in the PR that
+  # added these entries.
+  "simd_normalized_cosine_fast_path"
+  "int8_raw_dot_product"
+  "simd_batch_cosine_normalized_query"
+  "int8_vs_float32_cosine"
 )
 
 if [ "${1:-}" = "--print-allowlist" ]; then

--- a/scripts/lib/bench-quick-informational-targets.txt
+++ b/scripts/lib/bench-quick-informational-targets.txt
@@ -1,0 +1,30 @@
+# bench-quick-informational-targets.txt — the single validated manifest for
+# quick-mode informational demotion (lattice#714; target-level policy per
+# lattice#1060, 2026-07-19).
+#
+# Format: one `<crate>:<bench-target>` key per line; `#` starts a comment.
+# scripts/lib/bench-informational-groups.sh (the production shell path) and
+# scripts/perf-bench-gate.py --selftest (the validator) both read THIS file.
+# There is no other copy of the demoted-target set anywhere.
+#
+# Semantics: in QUICK mode, every Criterion group of a listed target is
+# reported informationally — fully measured, rendered in the report's
+# informational section and the all-measurements table, excluded only from
+# the gating verdict and exit code. FULL mode (`scripts/bench-compare.sh
+# --full`, nightly perf lane) gates every group of every target regardless
+# of this manifest. Targets not listed here gate normally in both modes.
+#
+# Demoting a target requires same-toolchain, same-commit A/A evidence in an
+# exclusive bench window, reviewed in a PR that edits this file.
+#
+# lattice-embed:simd — demoted 2026-07-19. Evidence: repeated same-commit
+# A/A quick-mode runs in exclusive machine-wide bench windows (2026-07-13
+# idle-machine calibration; 2026-07-19 twice on origin/main e1000d3108)
+# produced confirmed-CI FAIL rows (+8% to +17%, 95% CIs) on identical
+# binaries, with DISJOINT failing groups across runs — machine-level noise
+# above quick-mode resolution, not signal. 9 of the target's ~23 groups had
+# individually accumulated that evidence before the target-level decision;
+# per-group allowlisting was converging on the whole target one PR at a
+# time while implying the unlisted groups were reliable at quick
+# resolution, which the disjoint-failure signature disproves.
+lattice-embed:simd

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -416,141 +416,133 @@ def run_selftest() -> int:
         if "ℹ️" not in report or "grp_f/noisy_fail" not in report:
             failures.append("informational-groups: noisy FAIL not shown in informational section")
 
-        # lattice#714: the shell-side allowlist handoff, exercised end-to-
-        # end. An earlier fixture kept its own hardcoded `shell_allowlist`
-        # set instead of reading it from the actual shell code — a
-        # regression that added a group only to bench-compare.sh's array
-        # (e.g. simd_normalize) stayed invisible. Two probes against the
-        # real helper (scripts/lib/bench-informational-groups.sh, the same
-        # file bench-compare.sh invokes for production runs): first dump
-        # the raw array (--print-allowlist) and require it to equal the
-        # reviewed expectation set — this is what catches an array-only
-        # addition — then run the intersection against a controlled
-        # Criterion `--list`-shaped listing, feed its emitted file into
-        # the Python classifier, and assert the full
-        # pipeline: only the approved names come out of the shell step,
-        # and an unapproved embed group, an inference group, and a
-        # similarly-prefixed-but-distinct embed group all still gate.
+        # lattice#714 / lattice#1060: the shell-side manifest handoff,
+        # exercised end-to-end against the real helper and the real
+        # manifest (scripts/lib/bench-quick-informational-targets.txt) —
+        # the same files bench-compare.sh uses in production. Three
+        # probes: (1) --print-targets must equal the reviewed expectation
+        # set below, so a manifest-only or expectation-only edit fails
+        # the selftest; (2) a demoted target key must emit every group of
+        # a controlled listing (target-level semantics — including groups
+        # the old per-group allowlist never contained); (3) a non-demoted
+        # target key against the same listing must emit nothing — the
+        # cross-target guarantee that keeps inference gating intact.
+        # Probe 2's output then drives the Python classifier to prove
+        # embed FAILs land informational while an inference FAIL gates.
         helper = Path(__file__).resolve().parent / "lib" / "bench-informational-groups.sh"
-        # The reviewed allowlist, duplicated here on purpose: the selftest
-        # compares this set against the shell array itself (via
-        # --print-allowlist below), so a name added to only ONE side —
-        # shell array or this expectation — fails the selftest. The
-        # listing-intersection test alone cannot catch an array-only
-        # addition (a fixed listing never contains the new name, so the
-        # intersection output is unchanged).
-        approved_allowlist = frozenset({
-            "simd_dot_product",
-            "simd_cosine_similarity",
-            "int8_batch_cosine",
-            "int4_cosine_distance",
-            "simd_batch_cosine_non_normalized_query",
-            "simd_normalized_cosine_fast_path",
-            "int8_raw_dot_product",
-            "simd_batch_cosine_normalized_query",
-            "int8_vs_float32_cosine",
-        })
+        # The reviewed demoted-target set, duplicated here on purpose:
+        # the selftest compares this against the manifest itself (via
+        # --print-targets), so a target added to only ONE side —
+        # manifest or this expectation — fails the selftest.
+        approved_targets = frozenset({"lattice-embed:simd"})
         if not helper.exists():
-            failures.append(f"allowlist-handoff: shell helper missing at {helper}")
+            failures.append(f"manifest-handoff: shell helper missing at {helper}")
         else:
             raw_proc = subprocess.run(
-                ["bash", str(helper), "--print-allowlist"],
+                ["bash", str(helper), "--print-targets"],
                 capture_output=True, text=True, timeout=30,
             )
-            raw_array = frozenset(
+            raw_targets = frozenset(
                 ln.strip() for ln in raw_proc.stdout.splitlines() if ln.strip()
             )
             if raw_proc.returncode != 0:
                 failures.append(
-                    f"allowlist-handoff: --print-allowlist exited "
+                    f"manifest-handoff: --print-targets exited "
                     f"{raw_proc.returncode}: {raw_proc.stderr}"
                 )
-            elif raw_array != approved_allowlist:
+            elif raw_targets != approved_targets:
                 failures.append(
-                    "allowlist-handoff: shell array and selftest expectation "
-                    f"disagree — array-only: {sorted(raw_array - approved_allowlist)}, "
-                    f"expectation-only: {sorted(approved_allowlist - raw_array)}. "
-                    "Every allowlist change must update both sides in one PR."
+                    "manifest-handoff: manifest and selftest expectation "
+                    f"disagree — manifest-only: {sorted(raw_targets - approved_targets)}, "
+                    f"expectation-only: {sorted(approved_targets - raw_targets)}. "
+                    "Every demotion change must update both sides in one PR."
                 )
-            listing_dir = root / "allowlist-listing"
+            listing_dir = root / "manifest-listing"
             listing_dir.mkdir(parents=True, exist_ok=True)
             listing_file = listing_dir / "list.txt"
             listing_file.write_text(
                 "simd_dot_product/scalar/384: benchmark\n"
                 "simd_dot_product/simd/384: benchmark\n"
                 "simd_cosine_similarity/scalar/384: benchmark\n"
-                "simd_cosine_similarity/simd/384: benchmark\n"
                 "simd_normalize/scalar/384: benchmark\n"
                 "simd_dot_product_extra/scalar/384: benchmark\n"
-                "rms_norm/4096: benchmark\n"
-                "int8_batch_cosine/float32_simd/100: benchmark\n"
-                "int4_cosine_distance/int4/768: benchmark\n"
-                "simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c: benchmark\n"
-                "simd_normalized_cosine_fast_path/cosine_full/768: benchmark\n"
                 "int8_raw_dot_product/dot_product_i8_raw/128: benchmark\n"
-                "simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c: benchmark\n"
-                "int8_vs_float32_cosine/float32_simd/1024: benchmark\n"
             )
-            proc = subprocess.run(
-                ["bash", str(helper), str(listing_file)],
+            expected_groups = frozenset({
+                "simd_dot_product", "simd_cosine_similarity", "simd_normalize",
+                "simd_dot_product_extra", "int8_raw_dot_product",
+            })
+            demoted_proc = subprocess.run(
+                ["bash", str(helper), "lattice-embed:simd", str(listing_file)],
                 capture_output=True, text=True, timeout=30,
             )
             shell_emitted = frozenset(
-                ln.strip() for ln in proc.stdout.splitlines() if ln.strip()
+                ln.strip() for ln in demoted_proc.stdout.splitlines() if ln.strip()
             )
-            if proc.returncode != 0:
+            gated_proc = subprocess.run(
+                ["bash", str(helper), "lattice-inference:elementwise_cpu_bench",
+                 str(listing_file)],
+                capture_output=True, text=True, timeout=30,
+            )
+            gated_emitted = [ln for ln in gated_proc.stdout.splitlines() if ln.strip()]
+            if demoted_proc.returncode != 0:
                 failures.append(
-                    f"allowlist-handoff: shell helper exited {proc.returncode}: {proc.stderr}"
+                    f"manifest-handoff: demoted-target probe exited "
+                    f"{demoted_proc.returncode}: {demoted_proc.stderr}"
                 )
-            elif shell_emitted != approved_allowlist:
+            elif shell_emitted != expected_groups:
                 failures.append(
-                    "allowlist-handoff: shell helper emitted "
-                    f"{sorted(shell_emitted)}, expected the approved "
-                    "allowlist groups"
+                    "manifest-handoff: demoted target emitted "
+                    f"{sorted(shell_emitted)}, expected every listing group "
+                    f"{sorted(expected_groups)}"
+                )
+            elif gated_proc.returncode != 0:
+                failures.append(
+                    f"manifest-handoff: non-demoted-target probe exited "
+                    f"{gated_proc.returncode}: {gated_proc.stderr}"
+                )
+            elif gated_emitted:
+                failures.append(
+                    "manifest-handoff: non-demoted target emitted "
+                    f"{gated_emitted} — cross-target exemption leak"
                 )
             else:
-                allowlist_dir = root / "allowlist"
-                approved_a = allowlist_dir / "simd_dot_product" / "384"
-                _fabricate_bench(approved_a, "compare-base", point=0.10, ci_low=0.10, ci_high=0.20)
-                approved_b = allowlist_dir / "simd_cosine_similarity" / "384"
-                _fabricate_bench(approved_b, "compare-base", point=0.10, ci_low=0.10, ci_high=0.20)
-                unapproved_embed = allowlist_dir / "simd_normalize" / "384"
-                _fabricate_bench(unapproved_embed, "compare-base", point=0.10, ci_low=0.10, ci_high=0.20)
-                unapproved_extra = allowlist_dir / "simd_dot_product_extra" / "384"
-                _fabricate_bench(unapproved_extra, "compare-base", point=0.10, ci_low=0.10, ci_high=0.20)
-                unapproved_inference = allowlist_dir / "rms_norm" / "4096"
-                _fabricate_bench(unapproved_inference, "compare-base", point=0.10, ci_low=0.10, ci_high=0.20)
+                manifest_dir = root / "manifest"
+                emb_a = manifest_dir / "simd_dot_product" / "384"
+                _fabricate_bench(emb_a, "compare-base", point=0.10, ci_low=0.10, ci_high=0.20)
+                emb_b = manifest_dir / "simd_normalize" / "384"
+                _fabricate_bench(emb_b, "compare-base", point=0.10, ci_low=0.10, ci_high=0.20)
+                inf_c = manifest_dir / "rms_norm" / "4096"
+                _fabricate_bench(inf_c, "compare-base", point=0.10, ci_low=0.10, ci_high=0.20)
 
-                allowlist_results: dict[str, BenchResult] = {}
-                for cf in find_change_files(allowlist_dir):
-                    r = parse_bench(cf, allowlist_dir, baseline_name="compare-base")
+                manifest_results: dict[str, BenchResult] = {}
+                for cf in find_change_files(manifest_dir):
+                    r = parse_bench(cf, manifest_dir, baseline_name="compare-base")
                     if r is not None:
-                        allowlist_results[r.name] = r
+                        manifest_results[r.name] = r
 
-                needed = {
-                    "simd_dot_product/384", "simd_cosine_similarity/384",
-                    "simd_normalize/384", "simd_dot_product_extra/384", "rms_norm/4096",
-                }
-                if not needed.issubset(allowlist_results):
-                    failures.append("allowlist-handoff fixture: not all benches parsed")
+                needed = {"simd_dot_product/384", "simd_normalize/384", "rms_norm/4096"}
+                if not needed.issubset(manifest_results):
+                    failures.append("manifest-handoff fixture: not all benches parsed")
                 else:
-                    allowlist_gated_fails = {
-                        r.name for r in allowlist_results.values()
+                    manifest_gated_fails = {
+                        r.name for r in manifest_results.values()
                         if r.verdict() == "FAIL" and not r.is_informational(shell_emitted)
                     }
-                    if "simd_dot_product/384" in allowlist_gated_fails:
-                        failures.append("allowlist-handoff: approved simd_dot_product leaked into gated fails")
-                    if "simd_cosine_similarity/384" in allowlist_gated_fails:
-                        failures.append("allowlist-handoff: approved simd_cosine_similarity leaked into gated fails")
-                    if "simd_normalize/384" not in allowlist_gated_fails:
-                        failures.append("allowlist-handoff: unapproved embed group simd_normalize did not gate")
-                    if "simd_dot_product_extra/384" not in allowlist_gated_fails:
+                    if "simd_dot_product/384" in manifest_gated_fails:
                         failures.append(
-                            "allowlist-handoff: unapproved simd_dot_product_extra "
-                            "did not gate (prefix/substring exemption leak)"
+                            "manifest-handoff: demoted simd_dot_product "
+                            "leaked into gated fails"
                         )
-                    if "rms_norm/4096" not in allowlist_gated_fails:
-                        failures.append("allowlist-handoff: inference group rms_norm did not gate")
+                    if "simd_normalize/384" in manifest_gated_fails:
+                        failures.append(
+                            "manifest-handoff: simd_normalize gated despite "
+                            "target-level demotion (listing-derivation broken)"
+                        )
+                    if "rms_norm/4096" not in manifest_gated_fails:
+                        failures.append(
+                            "manifest-handoff: inference group rms_norm did not gate"
+                        )
 
     for f in failures:
         print(f"FAIL: {f}", file=sys.stderr)
@@ -558,7 +550,8 @@ def run_selftest() -> int:
         print(f"SELFTEST: FAIL ({len(failures)} failure(s))")
         return 1
     print("SELFTEST: PASS — base/, compare-base/, orphan-warn, named-wins-over-stale-base, "
-          "and multi-sibling-refusal all correct")
+          "multi-sibling-refusal, and manifest-handoff (demoted target informational, "
+          "non-demoted target gated) all correct")
     return 0
 
 

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -445,6 +445,10 @@ def run_selftest() -> int:
             "int8_batch_cosine",
             "int4_cosine_distance",
             "simd_batch_cosine_non_normalized_query",
+            "simd_normalized_cosine_fast_path",
+            "int8_raw_dot_product",
+            "simd_batch_cosine_normalized_query",
+            "int8_vs_float32_cosine",
         })
         if not helper.exists():
             failures.append(f"allowlist-handoff: shell helper missing at {helper}")
@@ -482,6 +486,10 @@ def run_selftest() -> int:
                 "int8_batch_cosine/float32_simd/100: benchmark\n"
                 "int4_cosine_distance/int4/768: benchmark\n"
                 "simd_batch_cosine_non_normalized_query/pair_loop/1024d_64c: benchmark\n"
+                "simd_normalized_cosine_fast_path/cosine_full/768: benchmark\n"
+                "int8_raw_dot_product/dot_product_i8_raw/128: benchmark\n"
+                "simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c: benchmark\n"
+                "int8_vs_float32_cosine/float32_simd/1024: benchmark\n"
             )
             proc = subprocess.run(
                 ["bash", str(helper), str(listing_file)],


### PR DESCRIPTION
## What

Demotes the `lattice-embed` `simd` bench TARGET to informational in `--quick` mode, replacing the per-group allowlist this PR originally extended (#714, #1060). The structural alternative flagged in the original body ("per-group allowlisting is trending toward covering the whole target") is now the design.

The demoted-target set lives in one validated manifest, `scripts/lib/bench-quick-informational-targets.txt` (sole entry: `lattice-embed:simd`). `scripts/lib/bench-informational-groups.sh` derives a demoted target's group set from that target's own Criterion `--list` output, so coverage tracks the target as groups are added or renamed; every non-demoted target emits nothing and gates normally. `scripts/bench-compare.sh` keys the helper by `<crate>:<bench-target>` for both bench targets it runs, so demoting another target later is a manifest edit (plus the selftest expectation), not a script edit.

## Nothing goes unmeasured

Demoted groups are still fully measured and fully rendered: every number lands in the report's informational section and the all-measurements table. Only the FAIL/WARN gate verdict and the exit code exclude them. The gate's runtime interface (`--informational-groups-file`) is unchanged.

## Evidence

Two A/A null runs of `bench-compare` on `origin/main` (e1000d3108) vs itself, quick mode, each inside an exclusive machine-wide bench window on an otherwise idle machine (both runs rc=0). Both sides of a same-commit comparison run identical binaries, so every FAIL is a false positive by construction.

Run 1 gating FAILs (3):

| group | Δ | 95% CI |
|---|---|---|
| `simd_normalized_cosine_fast_path/cosine_full/768` | +11.47% | [+10.92%, +12.02%] |
| `int8_raw_dot_product/dot_product_i8_raw/128` | +9.00% | [+8.83%, +9.18%] |
| `simd_batch_cosine_normalized_query/pair_loop_dot/1024d_64c` | +8.39% | [+8.18%, +8.59%] |

Run 2 gating FAILs (1):

| group | Δ | 95% CI |
|---|---|---|
| `int8_vs_float32_cosine/float32_simd/1024` | +9.75% | [+9.63%, +9.88%] |

The failing groups are disjoint across the two runs. Combined with the 2026-07-13 calibration evidence that seeded the original allowlist, 9 of the target's ~23 groups had individually accumulated confirmed-CI false-FAIL evidence under clean conditions, with disjoint failing groups across runs. That signature is a machine noise floor above the 7% quick-mode gate sitting over the whole target, not a property of any fixed subset — per-group allowlisting was converging on the whole target one PR at a time while implying the unlisted groups were reliable at quick resolution, which the disjoint failures disprove. Every `lattice-inference` group was clean in both runs and remains fully gated.

## `--full` cadence

`--full` remains the gate for every group of every target; quick mode is a PR-side direction/magnitude screen. No scheduled `--full` run exists today, so this PR proposes one: a nightly `--full` bench-compare run on current main as part of the scheduled nightly perf workflow, giving full-resolution `simd` gating a standing cadence. The demotion is then a resolution split, not a coverage hole.

## Validation

- `scripts/perf-bench-gate.py --selftest` passes. The manifest-handoff leg runs the real helper against the real manifest three ways: `--print-targets` must equal the reviewed in-selftest expectation (an edit to only one side fails), a demoted target key must emit every group of a controlled listing (including names the old allowlist never contained), and a non-demoted target key against the same listing must emit nothing — the cross-target guarantee. The demoted probe's output then drives the Python classifier end-to-end: demoted embed FAILs land informational while an inference FAIL still gates.
- Helper verified on both input shapes: stdin (production pipe from `cargo bench --list`) and file argument (selftest probes).
- `bash -n` clean on both shell scripts.

## Bench disposition

Tooling/gate configuration only; no `crates/` source touched; no bench A/B applicable.
