### PR TITLE
fix(inference): contain index-declared shard paths beneath the model directory

### DIFF
--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -542,17 +542,18 @@ mod doctor {
             }
             let mut merged = HashMap::new();
             for shard_name in shard_names {
-                if !dir.join(&shard_name).exists() {
+                // Index-declared shard names are untrusted checkpoint content;
+                // resolve once through the shared containment helper, then
+                // report missing files against the resolved path (#1069).
+                let shard_path = lattice_inference::weights::contained_shard_path(dir, &shard_name)
+                    .map_err(|e| e.to_string())?;
+                if !shard_path.exists() {
                     return Err(format!(
                         "shard '{shard_name}' referenced by {} not found in {}",
                         index_path.display(),
                         dir.display()
                     ));
                 }
-                // Index-declared shard names are untrusted checkpoint content;
-                // containment-check before opening (#1069).
-                let shard_path = lattice_inference::weights::contained_shard_path(dir, &shard_name)
-                    .map_err(|e| e.to_string())?;
                 merged.extend(read_safetensors_header(&shard_path)?);
             }
             merged
@@ -746,7 +747,20 @@ mod doctor {
             let mut present_names: BTreeSet<String> = BTreeSet::new();
             let mut has_mtp_tensors = false;
             for entry in &entries {
-                let file_path = dir.join(&entry.file);
+                // Manifest-declared file names are untrusted checkpoint
+                // content; the same lexical containment the loaders apply
+                // gates the doctor's readiness accounting, so an entry the
+                // loader would reject is never counted present (#1069).
+                let Ok(file_path) =
+                    lattice_inference::weights::contained_shard_path(dir, &entry.file)
+                else {
+                    missing_tensors.push(format!(
+                        "{} (listed in quantize_index.json as '{}', \
+                         path escapes the model directory)",
+                        entry.name, entry.file
+                    ));
+                    continue;
+                };
                 match std::fs::metadata(&file_path) {
                     Ok(meta) => {
                         total_bytes +=

--- a/crates/inference/src/bin/lattice.rs
+++ b/crates/inference/src/bin/lattice.rs
@@ -542,14 +542,17 @@ mod doctor {
             }
             let mut merged = HashMap::new();
             for shard_name in shard_names {
-                let shard_path = dir.join(&shard_name);
-                if !shard_path.exists() {
+                if !dir.join(&shard_name).exists() {
                     return Err(format!(
                         "shard '{shard_name}' referenced by {} not found in {}",
                         index_path.display(),
                         dir.display()
                     ));
                 }
+                // Index-declared shard names are untrusted checkpoint content;
+                // containment-check before opening (#1069).
+                let shard_path = lattice_inference::weights::contained_shard_path(dir, &shard_name)
+                    .map_err(|e| e.to_string())?;
                 merged.extend(read_safetensors_header(&shard_path)?);
             }
             merged

--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -408,7 +408,7 @@ fn fold_weight_file_into_hasher(
     // Index-declared shard names are untrusted checkpoint content (#1069);
     // a containment failure degrades to the config-only derivation via this
     // function's existing error path, same as any other unreadable shard.
-    let path = crate::weights::f32_weights::contained_shard_path(dir, file_name)
+    let path = crate::weights::contained_shard_path(dir, file_name)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string()))?;
     let mut file = std::io::BufReader::new(std::fs::File::open(&path)?);
     let len = file.get_ref().metadata()?.len();

--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -405,7 +405,11 @@ fn fold_weight_file_into_hasher(
 ) -> std::io::Result<()> {
     use std::io::{Read, Seek, SeekFrom};
 
-    let path = dir.join(file_name);
+    // Index-declared shard names are untrusted checkpoint content (#1069);
+    // a containment failure degrades to the config-only derivation via this
+    // function's existing error path, same as any other unreadable shard.
+    let path = crate::weights::f32_weights::contained_shard_path(dir, file_name)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string()))?;
     let mut file = std::io::BufReader::new(std::fs::File::open(&path)?);
     let len = file.get_ref().metadata()?.len();
 

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -50,7 +50,7 @@ use crate::error::InferenceError;
 use crate::model::qwen35::qwen_layer_tensor_prefix;
 use crate::model::qwen35_config::Qwen35Config;
 use crate::quant::quarot::plan::{OnlineRotationSpec, OnlineTransformSite};
-use crate::weights::f32_weights::{contained_shard_path, parse_index};
+use crate::weights::{contained_shard_path, parse_index};
 
 /// On-disk storage dtype of a tensor.
 ///
@@ -1697,7 +1697,10 @@ mod tests {
         let err = QuarotTensorReader::open(&model_dir).unwrap_err();
         match err {
             InferenceError::InvalidSafetensors(msg) => {
-                assert!(msg.contains("outside the model directory"), "got: {msg}");
+                assert!(
+                    msg.contains("must stay within the model directory"),
+                    "got: {msg}"
+                );
             }
             other => panic!("expected InvalidSafetensors, got {other:?}"),
         }

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -50,7 +50,7 @@ use crate::error::InferenceError;
 use crate::model::qwen35::qwen_layer_tensor_prefix;
 use crate::model::qwen35_config::Qwen35Config;
 use crate::quant::quarot::plan::{OnlineRotationSpec, OnlineTransformSite};
-use crate::weights::f32_weights::parse_index;
+use crate::weights::f32_weights::{contained_shard_path, parse_index};
 
 /// On-disk storage dtype of a tensor.
 ///
@@ -849,7 +849,9 @@ impl QuarotTensorReader {
                 if shards.contains_key(shard_file) {
                     continue;
                 }
-                let shard = Shard::open(&model_dir.join(shard_file))?;
+                // Index-declared shard names are untrusted checkpoint content;
+                // containment-check before mapping (#1069).
+                let shard = Shard::open(&contained_shard_path(model_dir, shard_file)?)?;
                 shards.insert(shard_file.clone(), shard);
             }
             Ok(Self {
@@ -1668,6 +1670,37 @@ mod tests {
         assert_eq!(reader.tensor_names(), vec!["other.weight".to_string()]);
         let err = reader.read_tensor_f64("required.weight").unwrap_err();
         assert!(matches!(err, InferenceError::MissingTensor(_)));
+    }
+
+    /// #1069: a weight_map entry that escapes the model directory (here via
+    /// `..` traversal to a structurally valid shard outside it) must be
+    /// rejected at open time, before anything is memory-mapped.
+    #[test]
+    fn sharded_index_entry_escaping_model_dir_is_rejected() {
+        let outer = tempfile::tempdir().unwrap();
+        let model_dir = outer.path().join("model");
+        std::fs::create_dir_all(&model_dir).unwrap();
+        write_safetensors(
+            &outer.path().join("evil.safetensors"),
+            &[("t.weight", FixtureDType::F32, vec![1], &[1.0])],
+        );
+        let index = serde_json::json!({
+            "metadata": {"total_size": 4usize},
+            "weight_map": {"t.weight": "../evil.safetensors"},
+        });
+        std::fs::write(
+            model_dir.join("model.safetensors.index.json"),
+            serde_json::to_string(&index).unwrap(),
+        )
+        .unwrap();
+
+        let err = QuarotTensorReader::open(&model_dir).unwrap_err();
+        match err {
+            InferenceError::InvalidSafetensors(msg) => {
+                assert!(msg.contains("outside the model directory"), "got: {msg}");
+            }
+            other => panic!("expected InvalidSafetensors, got {other:?}"),
+        }
     }
 
     /// Index declares `required.weight` in a shard that DOES contain a

--- a/crates/inference/src/vision/checkpoint.rs
+++ b/crates/inference/src/vision/checkpoint.rs
@@ -241,7 +241,9 @@ fn load_from_q4_dir(
                 entry.name,
             )));
         }
-        let file_path = model_dir.join(&entry.file);
+        // Manifest-declared file names are untrusted checkpoint content;
+        // containment-check before reading (#1069).
+        let file_path = crate::weights::contained_shard_path(model_dir, &entry.file)?;
         let (data, shape) = if entry.quantized.unwrap_or(false) {
             let q4 = load_q4_file(&file_path).map_err(|e| {
                 InferenceError::InvalidSafetensors(format!(
@@ -692,6 +694,36 @@ mod tests {
         .expect("test setup: write manifest");
 
         assert_fc2_shape_mismatch(load_qwen35_vision_weights(tmp.path(), &cfg));
+    }
+
+    /// #1069: quantize_index.json file entries are untrusted checkpoint
+    /// content; an entry escaping the model directory must be rejected
+    /// before its file is read.
+    #[test]
+    fn q4_manifest_entry_escaping_model_dir_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let model_dir = tmp.path().join("model");
+        std::fs::create_dir_all(&model_dir).expect("test setup");
+        // A structurally valid q4 file OUTSIDE the model dir — containment,
+        // not file validity, must be what rejects the entry.
+        let data = vec![0.25_f64; 4];
+        let q4 = crate::weights::q4_weights::quantize_f64_to_q4(&data, &[2, 2])
+            .expect("quantize succeeds");
+        crate::weights::q4_weights::save_q4_file(&tmp.path().join("evil.q4"), &q4)
+            .expect("test setup: write q4 file");
+        std::fs::write(
+            model_dir.join("quantize_index.json"),
+            r#"[{"name":"model.visual.evil","file":"../evil.q4","quantized":true}]"#,
+        )
+        .expect("test setup: write manifest");
+
+        let err = load_qwen35_vision_weights(&model_dir, &tiny_vision_cfg())
+            .expect_err("escaping manifest entry must be rejected");
+        assert!(
+            err.to_string()
+                .contains("must stay within the model directory"),
+            "unexpected error: {err}"
+        );
     }
 
     fn write_khf1_f16_file(path: &Path, shape: &[usize], values: &[f32]) {

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -1088,40 +1088,46 @@ pub struct ShardedSafetensors {
 /// Shard names come from checkpoint-controlled JSON (`model.safetensors.
 /// index.json` or a quantized-checkpoint manifest), so they are untrusted
 /// input: an absolute entry replaces `model_dir` entirely in `Path::join`,
-/// and `..` components or a symlinked entry can address files outside the
-/// checkpoint — turning a malicious model directory into an
-/// open-arbitrary-readable-file primitive (#1069). Both sides are
-/// canonicalized (resolving symlinks), the shard must remain beneath the
-/// canonicalized model directory, and the canonicalized path is returned so
-/// callers open exactly the path that was checked.
+/// and `..` components address files outside the checkpoint — turning a
+/// malicious model directory into an open-arbitrary-readable-file
+/// primitive (#1069). The validation is purely lexical — absolute paths
+/// and any parent-directory (or Windows prefix/root) component are
+/// rejected before the join — so an index entry cannot address anything
+/// above the model directory, and no filesystem state is consulted,
+/// leaving no check-to-open window to race.
 ///
-/// Scope: this guards malicious checkpoint *content* on a quiescent
-/// filesystem. It does not defend against a concurrent local attacker
-/// re-pointing directory components between this check and the caller's
-/// open; that threat requires fd-relative resolution the loaders do not
-/// need for static model directories.
+/// Symlinks are deliberately followed at open time, matching peer loaders
+/// (HF transformers, candle, llama.cpp). The HuggingFace hub cache stores
+/// snapshots as symlink farms (`snapshots/<rev>/x.safetensors ->
+/// ../../blobs/<sha>`) and lattice loads those directories directly;
+/// resolving symlinks and requiring the resolved target to stay beneath
+/// the model directory would reject every hub-cache checkpoint.
 pub fn contained_shard_path(model_dir: &Path, shard_file: &str) -> Result<PathBuf, InferenceError> {
-    let dir = model_dir.canonicalize().map_err(|e| {
-        InferenceError::InvalidSafetensors(format!(
-            "cannot canonicalize model directory {}: {e}",
-            model_dir.display()
-        ))
-    })?;
-    let candidate = model_dir.join(shard_file);
-    let resolved = candidate.canonicalize().map_err(|e| {
-        InferenceError::InvalidSafetensors(format!(
-            "shard entry {shard_file:?}: cannot resolve {}: {e}",
-            candidate.display()
-        ))
-    })?;
-    if !resolved.starts_with(&dir) {
+    let rel = Path::new(shard_file);
+    if rel.as_os_str().is_empty() {
+        return Err(InferenceError::InvalidSafetensors(
+            "shard entry is empty; index entries must name a file within the model directory"
+                .to_string(),
+        ));
+    }
+    if rel.is_absolute() {
         return Err(InferenceError::InvalidSafetensors(format!(
-            "shard entry {shard_file:?} resolves to {}, outside the model directory {}",
-            resolved.display(),
-            dir.display()
+            "shard entry {shard_file:?} is an absolute path; \
+             index entries must stay within the model directory"
         )));
     }
-    Ok(resolved)
+    for component in rel.components() {
+        match component {
+            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+            _ => {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "shard entry {shard_file:?} escapes the model directory; \
+                     index entries must stay within the model directory"
+                )));
+            }
+        }
+    }
+    Ok(model_dir.join(rel))
 }
 
 /// Parse `model.safetensors.index.json` from a model directory.
@@ -2558,7 +2564,8 @@ mod tests {
             "unexpected error kind: {err}"
         );
         assert!(
-            err.to_string().contains("outside the model directory"),
+            err.to_string()
+                .contains("must stay within the model directory"),
             "unexpected error: {err}"
         );
 
@@ -2578,7 +2585,8 @@ mod tests {
         let err = contained_shard_path(&dir, "../secret.bin")
             .expect_err("parent traversal must be rejected");
         assert!(
-            err.to_string().contains("outside the model directory"),
+            err.to_string()
+                .contains("must stay within the model directory"),
             "unexpected error: {err}"
         );
         assert!(
@@ -2589,25 +2597,37 @@ mod tests {
         fs::remove_dir_all(&outer).ok();
     }
 
-    /// #1069: a symlink inside the model directory pointing outside it must
-    /// be rejected — canonicalization resolves the link before the
-    /// containment check.
+    /// The HuggingFace hub cache stores snapshots as symlink farms:
+    /// `snapshots/<rev>/model.safetensors -> ../../blobs/<sha>`. Lattice
+    /// loads those directories directly (the e2e workflows point the
+    /// engine at `snapshot_download()` output), so index-entry validation
+    /// must stay lexical — a policy that resolved symlinks and required
+    /// the target beneath the model directory would reject every
+    /// hub-cache checkpoint. This pins the layout end-to-end through
+    /// `load_sharded`.
     #[cfg(unix)]
     #[test]
-    fn contained_shard_path_rejects_symlink_escape() {
-        let outer = temp_dir("lattice_containment_symlink_test");
-        let dir = outer.join("model");
+    fn sharded_loader_follows_hub_cache_snapshot_layout() {
+        let outer = temp_dir("lattice_containment_hub_layout_test");
+        let blobs = outer.join("blobs");
+        let dir = outer.join("snapshots").join("rev");
+        fs::create_dir_all(&blobs).expect("test setup");
         fs::create_dir_all(&dir).expect("test setup");
-        let target = outer.join("outside.safetensors");
-        fs::write(&target, b"x").expect("test setup");
-        std::os::unix::fs::symlink(&target, dir.join("link.safetensors")).expect("test setup");
+        write_single_f32_tensor(&blobs.join("blob-sha"), "tensor.a", &[1.0, 2.0]);
+        std::os::unix::fs::symlink(
+            Path::new("../../blobs/blob-sha"),
+            dir.join("model.safetensors"),
+        )
+        .expect("test setup");
+        fs::write(
+            dir.join("model.safetensors.index.json"),
+            r#"{"metadata": {}, "weight_map": {"tensor.a": "model.safetensors"}}"#,
+        )
+        .expect("test setup: write index");
 
-        let err = contained_shard_path(&dir, "link.safetensors")
-            .expect_err("symlink escaping the model dir must be rejected");
-        assert!(
-            err.to_string().contains("outside the model directory"),
-            "unexpected error: {err}"
-        );
+        let tensors =
+            load_sharded(&dir).expect("hub-cache snapshot layout must load through the symlink");
+        assert_eq!(tensors["tensor.a"].data, vec![1.0, 2.0]);
 
         fs::remove_dir_all(&outer).ok();
     }
@@ -2631,7 +2651,8 @@ mod tests {
 
         let err = load_sharded(&dir).expect_err("load_sharded must reject the escaping entry");
         assert!(
-            err.to_string().contains("outside the model directory"),
+            err.to_string()
+                .contains("must stay within the model directory"),
             "unexpected error: {err}"
         );
 
@@ -2641,14 +2662,16 @@ mod tests {
             .get_f32_tensor_owned("tensor.a")
             .expect_err("lazy loader must reject the escaping entry at access time");
         assert!(
-            err.to_string().contains("outside the model directory"),
+            err.to_string()
+                .contains("must stay within the model directory"),
             "unexpected error: {err}"
         );
         let err = st
             .resolve_weight("tensor.a")
             .expect_err("resolve_weight must reject the escaping entry");
         assert!(
-            err.to_string().contains("outside the model directory"),
+            err.to_string()
+                .contains("must stay within the model directory"),
             "unexpected error: {err}"
         );
 

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -1096,12 +1096,24 @@ pub struct ShardedSafetensors {
 /// above the model directory, and no filesystem state is consulted,
 /// leaving no check-to-open window to race.
 ///
+/// # Threat model
+///
+/// Manifest STRINGS are untrusted; the local FILESYSTEM is trusted.
 /// Symlinks are deliberately followed at open time, matching peer loaders
 /// (HF transformers, candle, llama.cpp). The HuggingFace hub cache stores
 /// snapshots as symlink farms (`snapshots/<rev>/x.safetensors ->
 /// ../../blobs/<sha>`) and lattice loads those directories directly;
 /// resolving symlinks and requiring the resolved target to stay beneath
-/// the model directory would reject every hub-cache checkpoint.
+/// the model directory — or refusing to follow symlinks at all — would
+/// reject every hub-cache checkpoint (pinned by
+/// `sharded_loader_follows_hub_cache_snapshot_layout`, which fails under
+/// exactly such a policy). A symlink planted inside the model directory
+/// is therefore honored by design: an actor who can write the model
+/// directory already controls every byte the loader reads, so blocking
+/// links there defends nothing, and archive-extraction tools are the
+/// correct place to refuse hostile symlinks. Do not "re-harden" this
+/// helper to resolve or reject symlinks without revisiting that decision
+/// trail (#1069, #1072).
 pub fn contained_shard_path(model_dir: &Path, shard_file: &str) -> Result<PathBuf, InferenceError> {
     let rel = Path::new(shard_file);
     if rel.as_os_str().is_empty() {

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -1082,6 +1082,48 @@ pub struct ShardedSafetensors {
     shards: HashMap<String, SafetensorsFile>,
 }
 
+/// Resolve an index-declared shard file name beneath `model_dir`, rejecting
+/// entries that escape the model directory.
+///
+/// Shard names come from checkpoint-controlled JSON (`model.safetensors.
+/// index.json` or a quantized-checkpoint manifest), so they are untrusted
+/// input: an absolute entry replaces `model_dir` entirely in `Path::join`,
+/// and `..` components or a symlinked entry can address files outside the
+/// checkpoint — turning a malicious model directory into an
+/// open-arbitrary-readable-file primitive (#1069). Both sides are
+/// canonicalized (resolving symlinks), the shard must remain beneath the
+/// canonicalized model directory, and the canonicalized path is returned so
+/// callers open exactly the path that was checked.
+///
+/// Scope: this guards malicious checkpoint *content* on a quiescent
+/// filesystem. It does not defend against a concurrent local attacker
+/// re-pointing directory components between this check and the caller's
+/// open; that threat requires fd-relative resolution the loaders do not
+/// need for static model directories.
+pub fn contained_shard_path(model_dir: &Path, shard_file: &str) -> Result<PathBuf, InferenceError> {
+    let dir = model_dir.canonicalize().map_err(|e| {
+        InferenceError::InvalidSafetensors(format!(
+            "cannot canonicalize model directory {}: {e}",
+            model_dir.display()
+        ))
+    })?;
+    let candidate = model_dir.join(shard_file);
+    let resolved = candidate.canonicalize().map_err(|e| {
+        InferenceError::InvalidSafetensors(format!(
+            "shard entry {shard_file:?}: cannot resolve {}: {e}",
+            candidate.display()
+        ))
+    })?;
+    if !resolved.starts_with(&dir) {
+        return Err(InferenceError::InvalidSafetensors(format!(
+            "shard entry {shard_file:?} resolves to {}, outside the model directory {}",
+            resolved.display(),
+            dir.display()
+        )));
+    }
+    Ok(resolved)
+}
+
 /// Parse `model.safetensors.index.json` from a model directory.
 pub fn parse_index(model_dir: &Path) -> Result<SafetensorsIndex, InferenceError> {
     let index_path = model_dir.join("model.safetensors.index.json");
@@ -1122,7 +1164,7 @@ pub fn load_sharded(model_dir: &Path) -> Result<HashMap<String, Tensor>, Inferen
 
     let mut tensors = HashMap::with_capacity(index.weight_map.len());
     for (shard_file, tensor_names) in by_shard {
-        let shard_path = model_dir.join(&shard_file);
+        let shard_path = contained_shard_path(model_dir, &shard_file)?;
         let shard = SafetensorsFile::open(&shard_path)?;
         for tensor_name in tensor_names {
             let (data, shape) = shard.get_f32_tensor(&tensor_name)?;
@@ -1166,7 +1208,10 @@ impl ShardedSafetensors {
             .weight_map
             .get(tensor_name)
             .ok_or_else(|| InferenceError::MissingTensor(tensor_name.to_string()))?;
-        Ok((self.root.join(shard_file), tensor_name.to_string()))
+        Ok((
+            contained_shard_path(&self.root, shard_file)?,
+            tensor_name.to_string(),
+        ))
     }
 
     fn shard_file_for(&self, name: &str) -> Result<String, InferenceError> {
@@ -1179,7 +1224,7 @@ impl ShardedSafetensors {
 
     fn open_shard(&mut self, shard_file: &str) -> Result<&SafetensorsFile, InferenceError> {
         if !self.shards.contains_key(shard_file) {
-            let shard_path = self.root.join(shard_file);
+            let shard_path = contained_shard_path(&self.root, shard_file)?;
             let shard = SafetensorsFile::open(&shard_path)?;
             self.shards.insert(shard_file.to_string(), shard);
         }
@@ -2474,6 +2519,140 @@ mod tests {
         assert_eq!(tb.shape, vec![3]);
 
         fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1069: index-declared shard names are untrusted checkpoint content.
+    /// Plain names and subdirectory names beneath the model directory
+    /// resolve; anything that escapes the directory is rejected.
+    #[test]
+    fn contained_shard_path_accepts_entries_beneath_model_dir() {
+        let dir = temp_dir("lattice_containment_ok_test");
+        fs::write(dir.join("shard.safetensors"), b"x").expect("test setup");
+        fs::create_dir_all(dir.join("sub")).expect("test setup");
+        fs::write(dir.join("sub").join("nested.safetensors"), b"x").expect("test setup");
+
+        let plain = contained_shard_path(&dir, "shard.safetensors").expect("plain name resolves");
+        assert_eq!(
+            plain.file_name().unwrap().to_string_lossy(),
+            "shard.safetensors"
+        );
+        contained_shard_path(&dir, "sub/nested.safetensors")
+            .expect("subdirectory entry beneath the model dir resolves");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1069: an absolute index entry replaces the model directory entirely
+    /// in `Path::join`; it must be rejected even when the target exists.
+    #[test]
+    fn contained_shard_path_rejects_absolute_entry() {
+        let dir = temp_dir("lattice_containment_abs_test");
+        let outside = temp_dir("lattice_containment_abs_outside");
+        let target = outside.join("outside.safetensors");
+        fs::write(&target, b"x").expect("test setup");
+
+        let err = contained_shard_path(&dir, &target.to_string_lossy())
+            .expect_err("absolute entry must be rejected");
+        assert!(
+            matches!(err, InferenceError::InvalidSafetensors(_)),
+            "unexpected error kind: {err}"
+        );
+        assert!(
+            err.to_string().contains("outside the model directory"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_dir_all(&dir).ok();
+        fs::remove_dir_all(&outside).ok();
+    }
+
+    /// #1069: `..` components must not address files outside the model
+    /// directory, whether or not the target exists.
+    #[test]
+    fn contained_shard_path_rejects_parent_traversal() {
+        let outer = temp_dir("lattice_containment_dotdot_test");
+        let dir = outer.join("model");
+        fs::create_dir_all(&dir).expect("test setup");
+        fs::write(outer.join("secret.bin"), b"x").expect("test setup");
+
+        let err = contained_shard_path(&dir, "../secret.bin")
+            .expect_err("parent traversal must be rejected");
+        assert!(
+            err.to_string().contains("outside the model directory"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            contained_shard_path(&dir, "../nonexistent.bin").is_err(),
+            "traversal to a missing target must also fail"
+        );
+
+        fs::remove_dir_all(&outer).ok();
+    }
+
+    /// #1069: a symlink inside the model directory pointing outside it must
+    /// be rejected — canonicalization resolves the link before the
+    /// containment check.
+    #[cfg(unix)]
+    #[test]
+    fn contained_shard_path_rejects_symlink_escape() {
+        let outer = temp_dir("lattice_containment_symlink_test");
+        let dir = outer.join("model");
+        fs::create_dir_all(&dir).expect("test setup");
+        let target = outer.join("outside.safetensors");
+        fs::write(&target, b"x").expect("test setup");
+        std::os::unix::fs::symlink(&target, dir.join("link.safetensors")).expect("test setup");
+
+        let err = contained_shard_path(&dir, "link.safetensors")
+            .expect_err("symlink escaping the model dir must be rejected");
+        assert!(
+            err.to_string().contains("outside the model directory"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_dir_all(&outer).ok();
+    }
+
+    /// #1069 end-to-end: a sharded index whose weight_map entry escapes the
+    /// model directory fails to load through both sharded loaders.
+    #[test]
+    fn sharded_loaders_reject_escaping_index_entry() {
+        let outer = temp_dir("lattice_containment_loader_test");
+        let dir = outer.join("model");
+        fs::create_dir_all(&dir).expect("test setup");
+        // A structurally valid shard OUTSIDE the model dir — containment,
+        // not file validity, must be what rejects it.
+        let evil = outer.join("evil.safetensors");
+        write_single_f32_tensor(&evil, "tensor.a", &[1.0, 2.0]);
+        fs::write(
+            dir.join("model.safetensors.index.json"),
+            r#"{"metadata": {}, "weight_map": {"tensor.a": "../evil.safetensors"}}"#,
+        )
+        .expect("test setup: write index");
+
+        let err = load_sharded(&dir).expect_err("load_sharded must reject the escaping entry");
+        assert!(
+            err.to_string().contains("outside the model directory"),
+            "unexpected error: {err}"
+        );
+
+        let index_path = dir.join("model.safetensors.index.json");
+        let mut st = ShardedSafetensors::open_index(&index_path).expect("index itself parses");
+        let err = st
+            .get_f32_tensor_owned("tensor.a")
+            .expect_err("lazy loader must reject the escaping entry at access time");
+        assert!(
+            err.to_string().contains("outside the model directory"),
+            "unexpected error: {err}"
+        );
+        let err = st
+            .resolve_weight("tensor.a")
+            .expect_err("resolve_weight must reject the escaping entry");
+        assert!(
+            err.to_string().contains("outside the model directory"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_dir_all(&outer).ok();
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes #1069. Shard and tensor file names declared by checkpoint manifests (`model.safetensors.index.json`, `quantize_index.json`) are checkpoint-controlled input, but readers joined them directly onto the model directory and opened the result. An absolute entry replaces the base entirely in `Path::join`, and `..` components address files outside the checkpoint — a malicious model directory becomes an open-arbitrary-readable-file primitive (memory-mapped, in the QuaRot reader's case).

## How

One helper, `weights::contained_shard_path`, applied at every manifest-path consumer. Validation is **purely lexical**: absolute entries and any parent-directory (or Windows prefix/root) component are rejected by string inspection before the join. Two properties follow directly:

- **No check-to-open window.** The check consults no filesystem state, so there is nothing a concurrent writer can re-point between validation and open — the race a resolve-then-compare design would carry is structurally absent.
- **Hub-cache layouts keep loading.** The HuggingFace cache stores snapshots as symlink farms (`snapshots/<rev>/x.safetensors -> ../../blobs/<sha>`), and the e2e workflows feed `snapshot_download()` output to the engine directly (`.github/workflows/e2e-parity.yml`, composed-golden job). A policy that resolved symlinks and required the target beneath the model directory rejects every such checkpoint — verified by a regression test that fails under exactly that policy. Symlinks are therefore followed at open time, matching HF transformers, candle, and llama.cpp; the guard's scope is manifest-entry escapes, which is the vector a hostile checkpoint archive actually controls.

Guarded sites: the QuaRot conversion reader (mmap), eager and lazy f32 sharded loaders (`load_sharded`, `resolve_weight`, `open_shard`), the Q4 vision manifest loader, the doctor's Q4 readiness inventory (an entry the loaders would reject is now reported invalid instead of counted present), the CLI shard-header merge (resolved once through the helper, no raw-join pre-check), and the weight-fingerprint sampler (containment failure degrades to config-only derivation via its existing error path). Call sites use the `crate::weights::` re-export uniformly. The converter's output writes were already safe via `sanitize_tensor_name`.

## Tests

- Helper-level: absolute entries and `..` traversal rejected (existing and missing targets); plain and subdirectory names accepted
- End-to-end escape rejection through `load_sharded`, the lazy loader's access path, `resolve_weight`, `QuarotTensorReader::open`, and the Q4 vision loader (each with a structurally valid target file outside the directory, so containment, not file validity, is what rejects)
- Hub-cache layout regression: a blobs/snapshots fixture with a relative symlink loads end-to-end through `load_sharded`
- Reverting the validation to a raw join makes all five escape tests fail while the hub-layout test still passes; reverting the vision site alone makes its escape test fail; substituting a canonicalize-and-compare policy makes the hub-layout test fail while the escape tests still pass — each verified individually
- Not unit-covered: the doctor and CLI merge sites (binary-only paths, thin wrappers over the same helper) and the fingerprint site (degrades by contract rather than erroring)

## Verification

- `cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings` clean
- `weights::f32_weights` + `quant::quarot::io` + `vision::checkpoint` modules: 101/101 green

## Bench disposition

Load-time only: the validation is a per-manifest-entry string scan (cheaper than the filesystem metadata work a canonicalize-based check would add). No decode/prefill/embed hot-path code is touched; the decode bench targets do not exercise checkpoint loading inside measurement loops.

## Threat model

Manifest strings are untrusted; the local filesystem is trusted; symlinks are followed at open time by design — an actor who can write the model directory already controls every byte the loader reads, so refusing links there defends nothing, and archive-extraction tooling is the correct layer to reject hostile symlinks. The `sharded_loader_follows_hub_cache_snapshot_layout` regression test pins the hub-cache layout that any resolve-or-refuse symlink policy breaks.