### PR TITLE
chore(bench): gitignore .cache and exclude bench worktrees from Spotlight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,11 @@ jobs:
         run: python3 tests/test_bench_decode_adapters_q4_apples.py -v
       - name: python3 tests/test_bench_decode_adapters_context_scaling.py
         run: python3 tests/test_bench_decode_adapters_context_scaling.py -v
+      # bench-compare's Spotlight-exclusion guard. Same "harness plumbing only"
+      # scope as the steps above: it asserts the guard's exit codes and the
+      # bench-compare.sh call site, and runs no benchmark.
+      - name: bash scripts/ensure-noindex-marker-selftest.sh
+        run: bash scripts/ensure-noindex-marker-selftest.sh
 
   # cargo-semver-checks against the latest published crates.io release for
   # every internal path-dependency crate, so a breaking public API change is

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /target
 debug
 
+# bench-compare scratch: full worktree checkouts + their target dirs, multi-GB
+/.cache/
+
 # Cargo
 **/*.rs.bk
 Cargo.lock

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -60,9 +60,9 @@ echo "=== bench-compare: $BASE_REF ($BASE_SHA) vs $HEAD_REF ($HEAD_SHA) ==="
 # phase it overlaps, and a base-then-head run turns that asymmetry into an
 # apparent code delta. The marker suppresses indexing for the whole directory.
 # Recreated every run so a wiped .cache does not silently lose the protection.
-# Inert on non-macOS.
-mkdir -p "$REPO/.cache"
-[ -e "$REPO/.cache/.metadata_never_index" ] || : > "$REPO/.cache/.metadata_never_index" || true
+# Inert on non-macOS. Fail-closed: refuse to measure without the protection
+# rather than emit numbers that look trustworthy and are not.
+"$REPO/scripts/lib/ensure-noindex-marker.sh" "$REPO/.cache"
 
 # --- Worktree for base ref ---
 WT="$REPO/.cache/bench-compare-base"

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -54,6 +54,16 @@ HEAD_SHA=$(git -C "$REPO" rev-parse --short "$HEAD_REF" 2>/dev/null || echo "$HE
 
 echo "=== bench-compare: $BASE_REF ($BASE_SHA) vs $HEAD_REF ($HEAD_SHA) ==="
 
+# --- Keep Spotlight out of the bench worktrees ---
+# The worktrees created below are full repository checkouts. Indexing them
+# produces filesystem churn that lands asymmetrically in whichever measurement
+# phase it overlaps, and a base-then-head run turns that asymmetry into an
+# apparent code delta. The marker suppresses indexing for the whole directory.
+# Recreated every run so a wiped .cache does not silently lose the protection.
+# Inert on non-macOS.
+mkdir -p "$REPO/.cache"
+[ -e "$REPO/.cache/.metadata_never_index" ] || : > "$REPO/.cache/.metadata_never_index" || true
+
 # --- Worktree for base ref ---
 WT="$REPO/.cache/bench-compare-base"
 if [ -d "$WT" ]; then

--- a/scripts/ensure-noindex-marker-selftest.sh
+++ b/scripts/ensure-noindex-marker-selftest.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Self-test for scripts/lib/ensure-noindex-marker.sh.
+#
+# The marker suppresses Spotlight indexing of the bench worktrees. Indexing
+# churn lands asymmetrically across a base-then-head A/B and reads as a code
+# delta, so a silently absent marker does not fail the run: it corrupts the
+# numbers while they still look trustworthy. That makes the guard fail-closed
+# infrastructure, and this proves each branch's exit code in a sandbox:
+#   bash scripts/ensure-noindex-marker-selftest.sh
+#
+# The invariant under test, stated once: WHEN THE GUARD EXITS 0, A REGULAR
+# MARKER FILE EXISTS. When one cannot be established, the guard exits nonzero
+# and the caller never measures. Both halves are asserted on every case.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$REPO/scripts/lib/ensure-noindex-marker.sh"
+CALLER="$REPO/scripts/bench-compare.sh"
+SB="$(mktemp -d)"
+trap 'chmod -R u+w "$SB" 2>/dev/null; rm -rf "$SB"' EXIT
+
+pass=0; fail=0
+check() {  # $1=desc $2=expected_exit $3=actual_exit
+  if [ "$2" = "$3" ]; then
+    echo "  PASS: $1 (exit $3)"; pass=$((pass+1))
+  else
+    echo "  FAIL: $1 — expected exit $2 got $3"
+    echo "        output: $(tr '\n' '|' <<<"$OUT" | tail -c 300)"
+    fail=$((fail+1))
+  fi
+}
+check_marker() {  # $1=desc $2=dir $3=want ("file" or "absent")
+  local m="$2/.metadata_never_index" got="absent"
+  [ -f "$m" ] && got="file"
+  [ -L "$m" ] && got="symlink"
+  [ -d "$m" ] && got="dir"
+  if [ "$got" = "$3" ]; then
+    echo "  PASS: $1 (marker=$got)"; pass=$((pass+1))
+  else
+    echo "  FAIL: $1 — wanted marker=$3 got marker=$got"; fail=$((fail+1))
+  fi
+}
+run() { OUT="$(bash "$SRC" "$1" 2>&1)"; return $?; }
+
+echo "=== ensure-noindex-marker.sh fail-closed self-test ==="
+
+# 1. Absent marker in a fresh dir: created.
+D="$SB/fresh/.cache"
+run "$D"; check "absent marker is created" 0 $?
+check_marker "  -> marker is a regular file" "$D" file
+
+# 2. Parent dir does not exist yet: mkdir -p path still lands protected.
+D="$SB/deep/a/b/.cache"
+run "$D"; check "missing parent dirs are created" 0 $?
+check_marker "  -> marker is a regular file" "$D" file
+
+# 3. Existing regular marker: left untouched, not re-truncated (idempotent).
+D="$SB/existing/.cache"; mkdir -p "$D"; echo "sentinel" > "$D/.metadata_never_index"
+run "$D"; check "existing regular marker is kept" 0 $?
+if [ "$(cat "$D/.metadata_never_index")" = "sentinel" ]; then
+  echo "  PASS:   -> existing content preserved"; pass=$((pass+1))
+else
+  echo "  FAIL:   -> existing marker was truncated"; fail=$((fail+1))
+fi
+
+# 4. THE REVIEWED DEFECT (#1089 round 1). A dangling marker symlink is the case
+#    the fail-open form got wrong: `test -e` is FALSE for a dangling link, the
+#    redirect then followed it to an uncreatable target and failed, and the
+#    trailing `|| true` reported success anyway — so the A/B ran unprotected.
+#    The guard now repairs it instead of merely refusing, which is the stronger
+#    outcome: a stray symlink must not block every bench on the machine when a
+#    real marker can be established in a writable directory.
+D="$SB/dangling/.cache"; mkdir -p "$D"
+ln -s "$SB/dangling/no-such-dir/target" "$D/.metadata_never_index"
+run "$D"; check "dangling marker symlink is repaired" 0 $?
+check_marker "  -> replaced by a regular file" "$D" file
+
+# 5. Symlink pointing at an existing file elsewhere: still not a real marker in
+#    this directory (Spotlight reads the directory), so it is replaced.
+D="$SB/livelink/.cache"; mkdir -p "$D"; : > "$SB/livelink/elsewhere"
+ln -s "$SB/livelink/elsewhere" "$D/.metadata_never_index"
+run "$D"; check "live marker symlink is replaced" 0 $?
+check_marker "  -> replaced by a regular file" "$D" file
+
+# 6. Marker path occupied by a directory: cannot become a file, must not proceed.
+D="$SB/isdir/.cache"; mkdir -p "$D/.metadata_never_index/occupied"
+run "$D"; check "non-empty dir at marker path fails closed" 1 $?
+
+# 7. FAIL-CLOSED PROOF. An unwritable .cache cannot hold a marker at all, so the
+#    guard must refuse rather than let an unprotected A/B proceed. This is the
+#    case that fails if the trailing `|| true` ever comes back.
+if [ "$(id -u)" -eq 0 ]; then
+  echo "  SKIP: unwritable-dir case (running as root bypasses permissions)"
+else
+  D="$SB/readonly/.cache"; mkdir -p "$D"; chmod a-w "$D"
+  run "$D"; check "unwritable dir fails closed" 1 $?
+  check_marker "  -> no marker was created" "$D" absent
+  case "$OUT" in
+    *FATAL*) echo "  PASS:   -> diagnostic names the failure"; pass=$((pass+1)) ;;
+    *) echo "  FAIL:   -> no FATAL diagnostic in output"; fail=$((fail+1)) ;;
+  esac
+  chmod u+w "$D"
+fi
+
+# 8. CALL-SITE ASSERTION. Testing the helper in isolation would still pass if
+#    bench-compare.sh stopped calling it, so assert the wiring too.
+if grep -q 'scripts/lib/ensure-noindex-marker.sh' "$CALLER"; then
+  echo "  PASS: bench-compare.sh invokes the guard"; pass=$((pass+1))
+else
+  echo "  FAIL: bench-compare.sh no longer invokes the guard"; fail=$((fail+1))
+fi
+
+# 9. The guard must run BEFORE the worktrees it protects are created.
+guard_ln=$(grep -n 'ensure-noindex-marker.sh' "$CALLER" | head -1 | cut -d: -f1)
+wt_ln=$(grep -n 'worktree add' "$CALLER" | head -1 | cut -d: -f1)
+if [ -n "$guard_ln" ] && [ -n "$wt_ln" ] && [ "$guard_ln" -lt "$wt_ln" ]; then
+  echo "  PASS: guard precedes worktree creation (line $guard_ln < $wt_ln)"; pass=$((pass+1))
+else
+  echo "  FAIL: guard does not precede worktree creation (guard=$guard_ln wt=$wt_ln)"; fail=$((fail+1))
+fi
+
+echo "=== $pass passed, $fail failed ==="
+[ "$fail" -eq 0 ]

--- a/scripts/lib/ensure-noindex-marker.sh
+++ b/scripts/lib/ensure-noindex-marker.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# ensure-noindex-marker.sh — install the Spotlight exclusion marker in a directory.
+#
+#   scripts/lib/ensure-noindex-marker.sh <dir>
+#
+# Creates <dir>/.metadata_never_index so macOS does not index the directory.
+# bench-compare.sh calls this before creating its base/head worktrees: indexing
+# full repository checkouts produces filesystem churn that lands asymmetrically
+# across the base and head measurement phases, and a base-then-head A/B turns
+# that asymmetry into an apparent code delta.
+#
+# FAIL-CLOSED BY DESIGN. This guards measurement integrity, so it must never
+# report success without the marker actually being in place. A silently absent
+# marker is worse than no protection at all, because the A/B still runs and its
+# numbers still look trustworthy. Every failure path exits non-zero.
+set -euo pipefail
+
+DIR="${1:?usage: ensure-noindex-marker.sh <dir>}"
+MARKER="$DIR/.metadata_never_index"
+
+mkdir -p "$DIR"
+
+# A symlink (or any non-regular entry) here defeats the protection silently:
+# `test -e` is FALSE for a dangling link, so an existence check falls through to
+# a redirect, and the redirect then follows the link to a target that may not be
+# creatable. Replace anything that is not a plain file.
+if [ -L "$MARKER" ] || { [ -e "$MARKER" ] && [ ! -f "$MARKER" ]; }; then
+  rm -f "$MARKER"
+fi
+
+# Idempotent: an existing regular marker is left untouched, not re-truncated.
+if [ ! -f "$MARKER" ] && ! : > "$MARKER"; then
+  echo "[noindex] FATAL: cannot create $MARKER" >&2
+  echo "[noindex] Without it Spotlight indexes this directory. For bench worktrees that" >&2
+  echo "[noindex] churn lands asymmetrically across the base/head phases and reads as a" >&2
+  echo "[noindex] code delta. Refusing to continue rather than measure unprotected." >&2
+  exit 1
+fi
+
+# Post-condition: prove the marker is really there before reporting success.
+[ -f "$MARKER" ] || { echo "[noindex] FATAL: $MARKER missing after creation" >&2; exit 1; }


### PR DESCRIPTION
## Problem

`bench-compare.sh` creates full repository checkouts under `$REPO/.cache`. That directory was unmanaged in two ways.

**1. Neither tracked nor ignored.** `.cache/` showed as untracked in every `git status`, one `git add -A` away from committing multi-GB worktrees and their `target/` dirs.

**2. Indexed by Spotlight.** Indexing those checkouts produces filesystem churn that lands asymmetrically in whichever measurement phase it overlaps. Because `bench-compare` runs base then head, that asymmetry reads as a code delta:

| Load lands in | Effect | Bias in reported Δ |
|---|---|---|
| BASE phase | inflates base | spurious **wins** |
| HEAD phase | inflates head | spurious **regressions** |

Two A/B runs have been corrupted this way. The most recent one had the indexing daemon consuming more CPU than the bench binary itself, during the base phase.

## Change

- `.gitignore`: add `/.cache/`
- `bench-compare.sh`: drop a `.metadata_never_index` marker in `.cache` before creating the worktrees

The marker is recreated on every run, so wiping `.cache` does not silently lose the protection. It is inert on non-macOS.

## Verification

- `bash -n scripts/bench-compare.sh` clean
- Marker creation exercised under `set -euo pipefail` in a temp dir: creates a 0-byte file, and a second run exits 0 (idempotent, does not re-truncate)
- `git check-ignore -v` with a real `.cache/probe/f.txt` present resolves to `.gitignore:6:/.cache/`, and `git status` no longer lists it
- Confirmed live on this machine: `mdfind -onlyin .cache` returns nothing after the marker is placed

## bench-compare disposition

Not applicable. This PR touches only `scripts/` and `.gitignore`; neither is compiled into any bench binary, so base and head bench binaries have identical effective source. No A/B can attribute a delta to this diff.
