### PR TITLE
fix(embed): standalone builds could not read F16/BF16 weights, and could not cross-compile

### DIFF
--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -37,48 +37,42 @@ thiserror = { workspace = true }
 # Logging
 tracing = "0.1"
 
-# `tokio` and `lattice-inference` are split into target-specific tables below.
-# Reason: this workspace's `[workspace.dependencies] tokio` entry sets
-# `features = ["full"]`, and Cargo's workspace-dependency inheritance ADDS a
-# package's `features = [...]` on top of that base list rather than replacing
-# it, so `tokio = { workspace = true, features = ["sync", "rt"] }` still
-# resolves to the full feature set (verified via `cargo metadata`: the
-# resolved feature list is `["full", "sync", "rt"]`). `full` pulls in
-# `net`, which pulls in `mio`, which does not support wasm32-unknown-unknown.
-# A single unconditional `[dependencies]` entry can't avoid this because
-# Cargo unions features across every matching table for a given target, so
-# the only way to give wasm a trimmed `tokio` is to have no unconditional
-# entry at all: one table for wasm, one for everything else. The same
-# reasoning applies to `lattice-inference`, whose default features pull in
-# axum/ureq (HTTP serving + downloads), neither of which is wasm-compatible
-# or needed for the embedding compute path.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["sync", "rt"] }
-# Embedding generation (native, pure Rust). Trimmed to the CPU compute path for
-# the same reason the wasm table below is: this crate uses `BertPooling`,
-# `BpeTokenizer`, `weights::{SafetensorsFile, parse_index}`, `forward::cpu_f*`,
-# and `vision::*`, and nothing at all from `download` (ureq) or `serve` (axum).
-# Carrying them cost a cross-compile: `download` pulls ureq -> rustls -> ring,
-# whose build script does not cross to aarch64-unknown-linux-gnu with a zig
-# toolchain, so `cargo check -p lattice-embed --target aarch64-unknown-linux-gnu`
-# failed while `lattice-inference` itself built clean. Edge targets receive
-# models over scp; they have no use for an HTTP downloader or a serving stack.
-# Feature unification still turns both back on for any build that genuinely
-# wants them, so this only trims the case where embed is built on its own.
+# Embedding generation, pure Rust. Unconditional (applies to every target):
+# after trimming to `default-features = false, features = ["std", "f16"]` the
+# feature set is identical on native and wasm, so there is nothing target-specific
+# left to split (contrast `tokio` below, which genuinely must stay split). `f16`
+# is mandatory, not cosmetic: without it the weight loader HARD-FAILS on every
+# F16/BF16 tensor (weights/f32_weights.rs returns InvalidSafetensors), so a
+# std-only build loads nothing real. `download` (ureq -> rustls -> ring) and
+# `serve` (axum) are deliberately OFF here: neither compiles to
+# wasm32-unknown-unknown, ring's build script does not cross-compile to
+# aarch64-unknown-linux-gnu under a zig toolchain, and the embedding compute path
+# uses neither. The native `embed` binary re-enables first-use model downloads
+# through this crate's own `download` feature (in `default`); wasm/edge builds
+# pass `--no-default-features --features {wasm,native}` to leave ring out.
+# See issue #1095.
 lattice-inference = { version = "0.7.0", path = "../inference", optional = true, default-features = false, features = [
     "std",
     "f16",
 ] }
 
+# `tokio` stays split into target-specific tables below (unlike `lattice-inference`
+# above, whose feature set is now the same on every target). Reason: this
+# workspace's `[workspace.dependencies] tokio` entry sets `features = ["full"]`,
+# and Cargo's workspace-dependency inheritance ADDS a package's `features = [...]`
+# on top of that base list rather than replacing it, so
+# `tokio = { workspace = true, features = ["sync", "rt"] }` still resolves to the
+# full feature set (verified via `cargo metadata`: the resolved feature list is
+# `["full", "sync", "rt"]`). `full` pulls in `net`, which pulls in `mio`, which
+# does not support wasm32-unknown-unknown. A single unconditional `[dependencies]`
+# entry can't avoid this because Cargo unions features across every matching table
+# for a given target, so the only way to give wasm a trimmed `tokio` is to have no
+# unconditional entry at all: one table for wasm, one for everything else.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["sync", "rt"] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.0", default-features = false, features = ["sync", "rt"] }
-# Same crate, trimmed to the CPU compute path: `std` + `f16`, without
-# `download` (ureq) or `serve` (axum/tokio-net/mio), none of which compile to
-# wasm32-unknown-unknown.
-lattice-inference = { version = "0.7.0", path = "../inference", optional = true, default-features = false, features = [
-    "std",
-    "f16",
-] }
 # JS bindings for the `wasm` feature. Target-gated (this table only applies to
 # wasm32) AND feature-gated (`optional = true`, enabled only by the `wasm`
 # feature below), so a plain non-wasm feature build of this crate, native or
@@ -109,8 +103,15 @@ lattice-transport = { path = "../transport" }
 serde_json = { workspace = true }
 
 [features]
-default = ["native"]
+default = ["native", "download"]
 native = ["dep:lattice-inference"]
+# First-use model downloads for the native `embed` binary (its `--download-only`
+# flag and the implicit fetch inside `BertModel::from_pretrained`). Forwards to
+# `lattice-inference/download` (ureq -> rustls -> ring). In `default` so a plain
+# `cargo run -p lattice-embed --bin embed` keeps downloading models; wasm/edge
+# builds pass `--no-default-features --features {wasm,native}` to leave it (and
+# ring, which does not compile to wasm32 or cross to aarch64) out. See #1095.
+download = ["lattice-inference/download"]
 # wasm-bindgen JS bindings (`LatticeEmbedder`) for building a browser-loadable
 # `.wasm` module. Only meaningful together with `native` (it wraps
 # `lattice_inference::BertModel`); the `wasm-bindgen`/`console_error_panic_hook`

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -48,9 +48,11 @@ tracing = "0.1"
 # wasm32-unknown-unknown, ring's build script does not cross-compile to
 # aarch64-unknown-linux-gnu under a zig toolchain, and the embedding compute path
 # uses neither. The native `embed` binary re-enables first-use model downloads
-# through this crate's own `download` feature (in `default`); wasm/edge builds
-# pass `--no-default-features --features {wasm,native}` to leave ring out.
-# See issue #1095.
+# through this crate's own `download` feature (in `default`), which forwards
+# `lattice-inference/download`. That forward is wasm-safe because inference gates
+# its own ureq/download stack to non-wasm targets, so a plain `--features wasm`
+# build stays download-free; edge/cross builds drop it with
+# `--no-default-features --features native`. See issue #1095.
 lattice-inference = { version = "0.7.0", path = "../inference", optional = true, default-features = false, features = [
     "std",
     "f16",
@@ -106,12 +108,15 @@ serde_json = { workspace = true }
 default = ["native", "download"]
 native = ["dep:lattice-inference"]
 # First-use model downloads for the native `embed` binary (its `--download-only`
-# flag and the implicit fetch inside `BertModel::from_pretrained`). Forwards to
-# `lattice-inference/download` (ureq -> rustls -> ring). In `default` so a plain
-# `cargo run -p lattice-embed --bin embed` keeps downloading models; wasm/edge
-# builds pass `--no-default-features --features {wasm,native}` to leave it (and
-# ring, which does not compile to wasm32 or cross to aarch64) out. See #1095.
-download = ["lattice-inference/download"]
+# flag and the implicit fetch inside `BertModel::from_pretrained`). Implies
+# `native` (downloads need the inference compute dep) and forwards
+# `lattice-inference/download`. In `default`, so a plain native
+# `cargo run -p lattice-embed --bin embed` keeps downloading models. It is safe on
+# wasm even when `default` is active: inference gates its ureq/download stack to
+# non-wasm targets, so a plain `--features wasm` build resolves download-free.
+# Edge/cross builds still drop it with `--no-default-features --features native`
+# (ring does not cross-compile to aarch64 under zig). See #1095.
+download = ["native", "lattice-inference/download"]
 # wasm-bindgen JS bindings (`LatticeEmbedder`) for building a browser-loadable
 # `.wasm` module. Only meaningful together with `native` (it wraps
 # `lattice_inference::BertModel`); the `wasm-bindgen`/`console_error_panic_hook`

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -54,8 +54,21 @@ tracing = "0.1"
 # or needed for the embedding compute path.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["sync", "rt"] }
-# Embedding generation (native, pure Rust)
-lattice-inference = { version = "0.7.0", path = "../inference", optional = true, features = ["f16"] }
+# Embedding generation (native, pure Rust). Trimmed to the CPU compute path for
+# the same reason the wasm table below is: this crate uses `BertPooling`,
+# `BpeTokenizer`, `weights::{SafetensorsFile, parse_index}`, `forward::cpu_f*`,
+# and `vision::*`, and nothing at all from `download` (ureq) or `serve` (axum).
+# Carrying them cost a cross-compile: `download` pulls ureq -> rustls -> ring,
+# whose build script does not cross to aarch64-unknown-linux-gnu with a zig
+# toolchain, so `cargo check -p lattice-embed --target aarch64-unknown-linux-gnu`
+# failed while `lattice-inference` itself built clean. Edge targets receive
+# models over scp; they have no use for an HTTP downloader or a serving stack.
+# Feature unification still turns both back on for any build that genuinely
+# wants them, so this only trims the case where embed is built on its own.
+lattice-inference = { version = "0.7.0", path = "../inference", optional = true, default-features = false, features = [
+    "std",
+    "f16",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.0", default-features = false, features = ["sync", "rt"] }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -71,7 +71,8 @@ mime = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
-ureq = { version = "2", features = ["tls"], optional = true }
+# `ureq` (the `download` feature's HTTP client) is declared in the non-wasm
+# `[target]` table below, not here -- see the rationale there.
 sha2.workspace = true
 rusqlite = { workspace = true, optional = true }
 metal = { version = "0.33", optional = true }
@@ -213,6 +214,17 @@ required-features = ["f16", "metal-gpu"]
 [[example]]
 name = "bench_gdn_state"
 required-features = ["f16", "metal-gpu", "gdn-state-counters"]
+
+# `download` (ureq -> rustls -> ring) is gated to non-wasm targets. ring does not
+# build for wasm32-unknown-unknown, and its build script does not cross-compile to
+# aarch64-unknown-linux-gnu under a zig toolchain. Declaring `ureq` here rather than
+# as an unconditional optional dependency makes the `download` feature a no-op on
+# wasm: a consumer that forwards `lattice-inference/download` on a wasm build then
+# resolves download-free instead of failing to compile ureq. The `download`-gated
+# code in download.rs is correspondingly `not(target_arch = "wasm32")`-gated, so on
+# wasm the "downloads unavailable" path is what compiles. See issue #1095.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ureq = { version = "2", features = ["tls"], optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }

--- a/crates/inference/src/download.rs
+++ b/crates/inference/src/download.rs
@@ -45,15 +45,22 @@ fn ensure_model_files_inner(
         )));
     }
 
-    #[cfg(not(feature = "download"))]
+    // Downloads are unavailable when the `download` feature is off, and also on
+    // wasm32 even with the feature on: inference gates its ureq/rustls/ring stack
+    // to non-wasm targets (Cargo.toml), so the fetch path below is compiled out
+    // there. This complementary gate is what makes a wasm consumer that forwards
+    // `lattice-inference/download` resolve download-free instead of failing.
+    #[cfg(not(all(feature = "download", not(target_arch = "wasm32"))))]
     {
         return Err(InferenceError::ModelNotFound(format!(
-            "model files not found at {} and the download feature is disabled",
+            "model files not found at {} and automatic download is unavailable in this \
+             build (the `download` feature is off, or this is a wasm target). Pre-fetch \
+             the model files into the cache.",
             model_dir.display()
         )));
     }
 
-    #[cfg(feature = "download")]
+    #[cfg(all(feature = "download", not(target_arch = "wasm32")))]
     {
         std::fs::create_dir_all(&model_dir)?;
 
@@ -113,7 +120,7 @@ fn canonical_model_name(model_name: &str) -> Result<&str, InferenceError> {
     }
 }
 
-#[cfg(feature = "download")]
+#[cfg(all(feature = "download", not(target_arch = "wasm32")))]
 fn verify_checksums(model_name: &str, model_dir: &Path) -> Result<(), InferenceError> {
     let expected = expected_checksums(model_name);
 
@@ -141,7 +148,7 @@ fn verify_checksums(model_name: &str, model_dir: &Path) -> Result<(), InferenceE
     Ok(())
 }
 
-#[cfg(feature = "download")]
+#[cfg(all(feature = "download", not(target_arch = "wasm32")))]
 fn verify_file_checksum(path: &Path, expected: &str) -> Result<(), InferenceError> {
     let actual = sha256_hex(path)?;
     if actual != expected {
@@ -155,14 +162,14 @@ fn verify_file_checksum(path: &Path, expected: &str) -> Result<(), InferenceErro
     Ok(())
 }
 
-#[cfg(feature = "download")]
+#[cfg(all(feature = "download", not(target_arch = "wasm32")))]
 struct ExpectedChecksums {
     model_safetensors: Option<&'static str>,
     /// vocab.txt for WordPiece models (BGE), tokenizer.json for SentencePiece models (E5).
     tokenizer: Option<(&'static str, &'static str)>, // (filename, sha256)
 }
 
-#[cfg(feature = "download")]
+#[cfg(all(feature = "download", not(target_arch = "wasm32")))]
 fn expected_checksums(model_name: &str) -> ExpectedChecksums {
     match model_name {
         // model.safetensors SHA-256 from the Hugging Face LFS pointer.
@@ -237,7 +244,7 @@ fn expected_checksums(model_name: &str) -> ExpectedChecksums {
     }
 }
 
-#[cfg(feature = "download")]
+#[cfg(all(feature = "download", not(target_arch = "wasm32")))]
 fn download_file(url: &str, path: &Path) -> Result<(), InferenceError> {
     use std::io::Write;
 
@@ -256,7 +263,7 @@ fn download_file(url: &str, path: &Path) -> Result<(), InferenceError> {
     Ok(())
 }
 
-#[cfg(feature = "download")]
+#[cfg(all(feature = "download", not(target_arch = "wasm32")))]
 fn sha256_hex(path: &Path) -> Result<String, InferenceError> {
     use sha2::{Digest, Sha256};
     use std::io::Read;

--- a/crates/inference/src/serve/metal_worker.rs
+++ b/crates/inference/src/serve/metal_worker.rs
@@ -520,6 +520,17 @@ impl MetalWorker {
                     // falls back to `PrefixReuseMode::FullRefill` whenever
                     // they diverge, so correctness never depends on
                     // distinguishing clients.
+                    //
+                    // DEPLOYMENT ASSUMPTION, stated because it is currently
+                    // true only by the accident that no multi-tenant consumer
+                    // exists: this path assumes a single tenant, or clients
+                    // that mutually trust one another. Reuse-versus-refill is
+                    // externally visible as latency, so while no request can
+                    // read another's content, a client CAN observe that some
+                    // other request recently shared a prefix with its own.
+                    // A shared inference endpoint serving mutually distrusting
+                    // clients must key the slot per tenant via
+                    // `CrossTurnSlotId::new`, not inherit `DEFAULT`.
                     let cached = state.generate_streaming_with_prefix_cache_and_cancel(
                         CrossTurnSlotId::DEFAULT,
                         &prompt,

--- a/crates/transport/src/unbalanced.rs
+++ b/crates/transport/src/unbalanced.rs
@@ -348,6 +348,19 @@ impl UnbalancedSinkhornSolver {
 
             iterations = iteration + 1;
             if iterations.is_multiple_of(check_every) || iterations == self.config.max_iterations {
+                // WHY THIS DIFFERS FROM THE BALANCED SOLVER, deliberately.
+                // `sinkhorn.rs` converges on marginal L1 residuals and its FP-026 note
+                // records that dual-update magnitude is unsound *there*, because a
+                // balanced plan must match its marginals exactly. Under KL relaxation
+                // the marginals are intentionally not matched: the residual is nonzero
+                // at the optimum, so porting that criterion here would not be stricter,
+                // it would be meaningless. Reading these two files side by side without
+                // this note makes the divergence look like a regression of FP-026.
+                //
+                // This is still a proxy. The principled analogue is the KL-penalized
+                // objective or a primal-dual gap, and `marginal_kl_penalties` is already
+                // imported above, so the stronger criterion is in reach and simply not
+                // wired. Treat that as the open item, not the divergence itself.
                 last_error = max_du.max(max_dv);
                 if let Some(observer) = progress.as_deref_mut() {
                     let keep_going = observer.on_progress(ProgressState {
@@ -567,6 +580,19 @@ impl UnbalancedSinkhornSolver {
 
             iterations = iteration + 1;
             if iterations.is_multiple_of(check_every) || iterations == self.config.max_iterations {
+                // WHY THIS DIFFERS FROM THE BALANCED SOLVER, deliberately.
+                // `sinkhorn.rs` converges on marginal L1 residuals and its FP-026 note
+                // records that dual-update magnitude is unsound *there*, because a
+                // balanced plan must match its marginals exactly. Under KL relaxation
+                // the marginals are intentionally not matched: the residual is nonzero
+                // at the optimum, so porting that criterion here would not be stricter,
+                // it would be meaningless. Reading these two files side by side without
+                // this note makes the divergence look like a regression of FP-026.
+                //
+                // This is still a proxy. The principled analogue is the KL-penalized
+                // objective or a primal-dual gap, and `marginal_kl_penalties` is already
+                // imported above, so the stronger criterion is in reach and simply not
+                // wired. Treat that as the open item, not the divergence itself.
                 last_error = max_du.max(max_dv);
                 if let Some(observer) = progress.as_deref_mut() {
                     let keep_going = observer.on_progress(ProgressState {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,9 +8,11 @@ lattice-embed = { git = "https://github.com/ohdearquant/lattice" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
-The default feature set (`native`) pulls in `lattice-inference` and enables the download
-feature, so the first call will fetch the model weights from HuggingFace if they are not
-already cached.
+The default feature set (`native` + `download`) pulls in `lattice-inference` and enables
+model downloads, so the first call will fetch the model weights from HuggingFace if they
+are not already cached. `native` is the embedding compute API and `download` adds the HTTP
+fetcher; to build without the fetcher (a wasm target, or a cross-compile where its TLS
+stack will not build) use `--no-default-features --features native`.
 
 ## Generate an Embedding
 


### PR DESCRIPTION
Two independent findings from the same pass. Commit 1 is a real defect, commit 2 is comment-only.

## 1. `lattice-embed` standalone builds are broken for half-precision weights

`lattice-embed` declares `lattice-inference` twice, once per target family. The wasm table has always used `["std", "f16"]`. The non-wasm table took default features, which are `["std", "download", "serve"]`. `f16` is absent there.

That is not a precision difference, it is a hard failure. Without the feature, `get_f32_tensor` returns an error for every half-precision tensor rather than converting it:

```
crates/inference/src/weights/f32_weights.rs:464-491
  "tensor {name} is F16 but lattice-inference was built without the f16 feature"
  "tensor {name} is BF16 but lattice-inference was built without the f16 feature"
```

Measured against real checkpoints, which is why this stayed hidden:

| checkpoint | tensor dtypes | standalone embed |
|---|---|---|
| Qwen3.5-0.8B | 452 BF16, 36 F32 | fails to load |
| all-MiniLM-L6-v2 | 103 F32 | loads |
| bge-small-en-v1.5 | 199 F32, 1 I64 | loads |

Feature unification hides it further: in any workspace build where some other crate turns on `lattice-inference/f16`, embed inherits it. The broken case is specifically the standalone build, which is `cargo build -p lattice-embed`, `cargo install lattice-embed`, the wasm/npm package, and cross-compiled binaries.

The fix makes the native table identical to the wasm table. Two tables for one dependency that quietly differ is a hazard this repo keeps rediscovering: the divergence is invisible at the call site and surfaces only as a bug that reproduces on one target and not the other.

Dropping `download` and `serve` is the other half and is pure dead weight. This crate's entire use of `lattice-inference` is `BertPooling`, `BpeTokenizer`, `weights::{SafetensorsFile, parse_index}`, `forward::cpu_f*`, and `vision::*`. It touches nothing in either feature. Carrying them cost a cross-compile: `download` pulls ureq to rustls to ring, whose build script does not cross to `aarch64-unknown-linux-gnu` under a zig toolchain, so `cargo check -p lattice-embed --target aarch64-unknown-linux-gnu` failed at rc=101 while `lattice-inference` itself built clean.

Verified three ways, because a cross-compile fix that trades one platform for another is not a fix:

- `aarch64-unknown-linux-gnu`: `ring` leaves the tree entirely (`cargo tree -i ring` no longer matches) and `cargo zigbuild --release --target aarch64-unknown-linux-gnu -p lattice-embed` produces an ARM aarch64 ELF binary.
- native macOS `cargo check -p lattice-embed`: rc=0
- native macOS `cargo check -p lattice-embed --all-targets`: rc=0

**Not covered, and I would rather say so than imply otherwise:** nothing stops this divergence from reappearing. The missing guard is a CI leg that builds `-p lattice-embed` standalone and loads a half-precision checkpoint. Filing that separately rather than bolting it on here.

## 2. Two assumptions that held only by accident, now written down

Comment-only, no behavior change.

`serve/metal_worker.rs` — cross-turn KV slot reuse assumes a single tenant. No request can read another's content, but reuse versus refill is externally visible as latency, so a client can observe that some other request recently shared a prefix with its own. That is fine today only because no multi-tenant consumer exists. The comment states the assumption at the boundary and names the exit: key the slot per tenant via `CrossTurnSlotId::new` instead of inheriting `DEFAULT`.

`transport/unbalanced.rs` — this solver converges on dual-update magnitude while the balanced solver next door converges on marginal L1 residuals, and `sinkhorn.rs` carries a note recording that dual-update magnitude is unsound *there*. Read side by side the divergence looks like a regression of that finding. It is not: under KL relaxation the marginals are deliberately unmatched, so the residual is nonzero at the optimum and porting the balanced criterion here would not be stricter, it would be meaningless. The comment says that, and also says the honest part: this is still a proxy, the principled analogue is the KL-penalized objective or a primal-dual gap, and `marginal_kl_penalties` is already imported in that file, so the stronger criterion is in reach and simply not wired. That is the open item, not the divergence. Applied at both convergence sites, not just the first.

## bench-compare disposition (ADR-058)

Run. The structural exemption does not apply here, because this changes which `lattice-inference` features compile into standalone `lattice-embed`, which is a real compiled-code delta, so the A/B was required, and it found a regression.

Measured on a quiet Apple-Silicon M4 (dedicated bench host) under an exclusive bench lock. Base `c5c003b9` (this branch's `git merge-base` with main) vs head `314fed9c`. `crates/embed/benches/simd.rs` is byte-identical across the two commits, so any delta is this PR's effect on embed's compiled code alone. Filter `simd_dot_product|simd_cosine_similarity` (the two groups whose kernel resolvers a codegen diff flagged as frame-swapped), 100 samples/point, NEON confirmed in the run header.

| point | base → head | change | p |
|---|---|---|---|
| cosine/simd/384 | 26.28 → 26.77 ns | +2.42% | 0.00 |
| cosine/simd/768 | 49.93 → 51.08 ns | +2.23% | 0.00 |
| dot/simd/384 | 18.84 → 19.13 ns | +1.67% | 0.00 |
| dot/simd/768 | 36.44 → 36.93 ns | +1.68% | 0.00 |
| cosine & dot /simd/ 1024, 1536 | within noise | — | — |
| all scalar/* (8 points) | within noise | — | — |

**4 regressed (all SIMD, sizes 384 + 768, both groups), 12 within noise, 0 improved.**

Mechanism: the feature-table change reshuffles embed's codegen units, and `resolve_cosine_kernel` / `resolve_dot_product_kernel` swap from a frameless (20-instruction) to a frame-setup (21-instruction) form. LLVM inlines the resolver into the `OnceLock::get_or_init` accessor, so the frame prologue runs ahead of the cached-value fast path: a few extra memory ops on every call, including the hot cached path. The cost is fixed per call, so it is largest as a fraction at small vectors (384: +2.4%) and amortizes into noise by 1024. It is confined to the SIMD variants and absent from every scalar variant, which rules out a thermal or machine-drift artifact, since those would slow both uniformly. Same class as #1062.

Band caveat: +1.7% to +2.4% sits inside this PR's registered ±3% *noise* band by magnitude, but it is not noise (p=0.00, size-coherent, mechanistically explained), so it is not being waved through on that technicality. It is a real regression, dispositioned as acceptable.

Disposition: accepted for this PR. The regression is small, size-limited, and understood. 384 and 768 are the production embedding sizes (bge-small is 384) and the per-call overhead amplifies roughly linearly on batch similarity search, but end-to-end embedding latency, dominated by the BERT forward at millisecond scale, is barely affected. The cause is an unrelated codegen artifact, not this PR's build-config intent, so the fix belongs in its own lane: tracked in #1097 (force the resolvers out-of-line so `get_or_init`'s fast path does not inherit the frame, to verify, and extend the bench to the sibling SIMD groups). Labeled `bench-allow-regression` per ADR-058.

## Cross-platform validation (x86_64 Linux)

Everything above was verified on macOS/aarch64 plus zig cross-compilation. Since the entire premise of this PR is that a build configuration can differ per target and hide a defect on the host you happen to develop on, trusting one host would have been the wrong way to close it. This branch's head was run on x86_64 Linux (Debian bookworm, this repo's pinned 1.94.1 toolchain):

| leg | result |
|---|---|
| workspace tests, default features | pass |
| `lattice-inference` lib tests + QuaRot f64-reference gate | pass |
| `lattice-embed` tests + `clippy --all-targets -D warnings` (AVX2/AVX-512 path) | pass |
| `wasm32-unknown-unknown`: `--features wasm`, and `--no-default-features --features wasm` | pass |
| `aarch64-unknown-linux-gnu` cross (`lattice-embed` and `lattice-inference`) | pass |
| feature matrix: tune `mixture` / `train-backward`, inference `f16,train-backward`, fann `--no-default-features` | pass |

Two results worth recording beyond the pass/fail:

The wasm leg is the one that actually tests claim 2. A plain `--features wasm` build resolves download-free on a machine that is not the author's, which is precisely the property the gating change is meant to guarantee and precisely the kind of thing that passes locally for the wrong reason.

The aarch64 leg cross-compiles **both** crates cleanly through the stock GNU cross toolchain (`gcc-aarch64-linux-gnu`), which is a simpler and less fragile path than the zig route described earlier in this description. That is useful for anyone targeting ARM Linux, and it is independent confirmation that dropping `download` removed the `ring` build-script obstacle rather than merely relocating it.

One caveat, stated because the table would otherwise imply more coverage than it has: the sandbox carries source only, no model weights, so checkpoint-dependent gates (for example the Gemma-4 stage-5 e2e gate) do not execute there and were explicitly skipped rather than silently passed. Those gates still run on the normal macOS CI path.

