### PR TITLE
ci(e2e): relocate portable wasm + embed-drift gates to ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -350,11 +350,11 @@ jobs:
   # Embedding-drift gate: re-embeds the 5 frozen BGE-small corpus texts and
   # asserts max per-vector (1 - cosine) < 1e-3 vs the committed baseline.
   #
-  # Runs on macos-latest (arm64) to exercise the NEON normalise path that
-  # crates/embed/src/simd/ dispatches on aarch64.  A geometry regression on
-  # AVX2/x86_64 would also be caught here on the runner's scalar fallback, but
-  # the primary reason for macOS is to match the NEON path that production
-  # lattice deployments use.
+  # Runs on ubuntu-24.04-arm (aarch64) to exercise the NEON normalise path that
+  # crates/embed/src/simd/ dispatches on aarch64, the same ISA path that
+  # production lattice deployments use. Relocated from macos-latest (also
+  # aarch64) to cut the shared macOS-runner queue tax; NEON coverage is
+  # identical on aarch64 Linux.
   #
   # Model provisioning: the bge-small-en-v1.5 weights (~130 MB) are downloaded
   # via `cargo run ... --bin embed -- --download-only`, then cached per-run by
@@ -374,7 +374,7 @@ jobs:
     name: embed drift gate
     needs: changes
     if: needs.changes.outputs.engine == 'true'
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -421,7 +421,7 @@ jobs:
     name: wasm embedding parity gate
     needs: changes
     if: needs.changes.outputs.engine == 'true'
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -500,7 +500,7 @@ jobs:
     name: wasm SIMD128 kernel parity gate
     needs: changes
     if: needs.changes.outputs.engine == 'true'
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Relocates three portable jobs in `e2e-parity.yml` from `macos-latest` to `ubuntu-24.04-arm`:

- `wasm-parity` (wasm embedding parity gate)
- `wasm-simd128-parity` (wasm SIMD128 kernel parity gate)
- `embed-drift` (embedding-drift gate)

## Why

CI throughput. The shared `macos-latest` pool carries a real queue tax (measured median ~5 min, p90 ~20 min per job) that `ubuntu-24.04-arm` does not (large pool, effectively no wait). These three jobs need only **aarch64**, not macOS-the-platform:

- The two wasm jobs compile to `wasm32-unknown-unknown` and run under node. That is a VM target, host-agnostic.
- `embed-drift` exercises the NEON normalise path in `crates/embed/src/simd/`; `ubuntu-24.04-arm` is aarch64/NEON, the same ISA production uses. The drift tolerance (max per-vector `1 - cosine < 1e-3`) absorbs libm transcendental differences between macOS-aarch64 and linux-aarch64.

`ubuntu-24.04-arm` is already proven in this repo by the `CI (ubuntu-24.04-arm)` matrix leg.

## How this PR tests itself

The `changes` job's engine-change filter includes `^\.github/workflows/e2e-parity\.yml$`, so this workflow-only PR sets `engine=true` and the three moved jobs run on this PR's own CI on `ubuntu-24.04-arm`. A green run here is the arm-linux proof. Both wasm drivers fail **closed** under their `*_ENFORCE=1` env (missing node, wasm-bindgen, cargo, or the wasm32 target becomes `exit 1`), so a provisioning gap on the new runner cannot masquerade as a green skip.

## Gate integrity

Every moved job stays wired into `parity-gate` unchanged. The relocation changes only where a job runs, never whether its result is consumed. No gate is loosened or dropped.

## Scope held back

- `parity` (the e2e greedy-token gate) is a **monitored cutover**, not part of this PR: greedy token IDs are argmax and platform-robust, but the plan is to confirm identical tokens on linux-aarch64 alongside the macOS leg for one run before repointing `parity-gate`.
- `layer23-golden` stays on macOS: numeric-golden portability from macOS-aarch64 to linux-aarch64 is unproven, and it is usually skipped (tune-only).
- All Metal-pinned jobs (`metal-parity`, `q4-composed`, `vision-s3-gate`, `q4-ppl-quality`) stay on macOS. Metal exists only there.

This is L1 of the CI-throughput plan (L2 is a self-hosted Apple-Silicon runner for the Metal jobs, L3 is moving the compute-bound Q4 golden post-merge).
