### PR TITLE
test(embed): add AVX-512 VNNI int8 dot-product scalar-parity test

### DIFF
--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -740,4 +740,37 @@ mod simd_parity_tests {
             }
         }
     }
+
+    // FP-034: AVX-512 VNNI vs scalar parity for INT8 dot product.
+    // Gated on the `avx512` build feature: the VNNI kernel only compiles then.
+    // Runs only when the host advertises AVX-512F+BW+VNNI, matching the kernel's
+    // safety contract and SimdConfig::avx512vnni_enabled.
+    #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+    #[test]
+    fn test_i8_avx512vnni_scalar_parity() {
+        if std::arch::is_x86_feature_detected!("avx512f")
+            && std::arch::is_x86_feature_detected!("avx512bw")
+            && std::arch::is_x86_feature_detected!("avx512vnni")
+        {
+            for dim in [7usize, 16, 64, 128, 384, 768] {
+                let a_q = QuantizedVector::from_f32(&gen_vec(dim, 600 + dim as u64));
+                let b_q = QuantizedVector::from_f32(&gen_vec(dim, 700 + dim as u64));
+
+                // SAFETY: AVX-512F+BW+VNNI verified above; slices have equal length from from_f32.
+                let vnni = unsafe { dot_product_i8_avx512vnni(&a_q.data, &b_q.data) };
+                let scalar: f32 = a_q
+                    .data
+                    .iter()
+                    .zip(b_q.data.iter())
+                    .map(|(&x, &y)| x as i32 * y as i32)
+                    .sum::<i32>() as f32;
+
+                let diff = (vnni - scalar).abs();
+                assert!(
+                    diff <= 1.0,
+                    "VNNI vs scalar i8 dot product dim={dim}: vnni={vnni} scalar={scalar} diff={diff}"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds `test_i8_avx512vnni_scalar_parity`, closing a coverage gap: the raw AVX-512 VNNI INT8 dot-product kernel (`dot_product_i8_avx512vnni`) had no parity test, while its NEON and AVX2 siblings both did (`test_i8_neon_scalar_parity`, `test_i8_avx2_scalar_parity`). The gap was structural: the kernel sits behind `#[cfg(feature = "avx512")]`, which is not in the default or CI feature set, so it was compiled out of every CI build and could not be exercised there.

The new test mirrors the AVX2 sibling: it quantizes deterministic vectors across dims `[7, 16, 64, 128, 384, 768]`, computes the VNNI dot product, and asserts equality with an independent scalar reference (`|diff| <= 1.0`, allowing INT8 rounding). It is gated on `#[cfg(all(target_arch = "x86_64", feature = "avx512"))]` and guarded at runtime by `is_x86_feature_detected!` for avx512f/bw/vnni, matching the kernel's safety contract and `SimdConfig::avx512vnni_enabled`.

## Validation

Validated on real hardware (AMD Zen4 EPYC with avx512vnni present), built with `--features avx512`: the test ran and passed across all dims (`1 passed; 0 failed; 257 filtered out`, rustc 1.94.1). rustfmt-clean locally. The avx512 path cannot be compiled or run on an arm64 host (cfg'd out), so on-hardware execution is the validation for the kernel body.

The test stays dormant in default CI (avx512 is not in the CI feature set, matching the kernel it guards); it activates for any build with `--features avx512` on avx512vnni hardware. Wiring avx512 into a CI job needs a runner that exposes avx512vnni and is tracked separately.

## bench-compare disposition

Test-only change: adds a `#[cfg(all(target_arch = "x86_64", feature = "avx512"))]` parity test and nothing else. The `simd` bench target (`cargo bench -p lattice-embed --bench simd`) builds with default features (avx512 off), so the added test is compiled out of every bench build. Base and head bench binaries have identical effective source; no A/B measurement applies.
