### PR TITLE
fix(embed): validate caller text before applying the retrieval instruction

### DIFF
--- a/crates/embed/CHANGELOG.md
+++ b/crates/embed/CHANGELOG.md
@@ -10,7 +10,45 @@ and this project adheres to
 
 ### Added
 
+- `EmbeddingModel::max_instruction_bytes` returns the byte length of the model's
+  longest retrieval instruction, and zero for symmetric models that take no
+  prefix. A length guard that runs on already-prepared text sizes itself with
+  this; a guard on caller text uses `MAX_TEXT_BYTES` unchanged.
+- `EmbeddingService::embed_with_role` is the single entry point for role-aware
+  embedding. It has a default body, so existing implementations of the trait
+  continue to compile and behave as before without being edited.
+
 ### Changed
+
+- The published text-length cap is now checked against the text the caller
+  supplied, before the retrieval instruction is prepended. Previously a caller
+  submitting text at exactly `MAX_TEXT_BYTES` could be rejected for bytes the
+  service itself added. `embed_query` and `embed_passage` are now thin wrappers
+  over `embed_with_role`, so all three role paths share one ordering decision.
+- `CachedEmbeddingService` keys the caller's text together with the role tag
+  rather than keying prepared text. This is equivalent, because the instruction
+  is a function of the role and model configuration already present in the key.
+- `TextTooLong` now reports the bound that actually rejected the input, so the
+  reported maximum is one the caller can relate to their own input.
+
+#### Compatibility note for external implementors
+
+The default `embed_with_role` reaches the backend by calling `embed`, and the
+text it passes there is the prepared text, longer than the caller's by up to
+`EmbeddingModel::max_instruction_bytes`. An external implementation that
+enforces the exact `MAX_TEXT_BYTES` cap inside its own `embed` will therefore
+still reject caller text at the cap.
+
+This behavior is not new. `embed_query` and `embed_passage` have always applied
+the instruction and then called `embed`, so such an implementation received
+lengthened text in prior releases too, and nothing about that path changes here.
+What changes is that the situation is now nameable and fixable: size the guard
+with `max_instruction_bytes`, or override `embed_with_role` to reach the backend
+directly. Both implementations in this crate override it.
+
+Keeping `embed` the sole abstract method is a deliberate backward-compatibility
+choice. Making `embed_with_role` abstract would deliver the cap unconditionally
+but would break every existing implementor at compile time.
 
 ### Deprecated
 

--- a/crates/embed/docs/service.md
+++ b/crates/embed/docs/service.md
@@ -212,24 +212,29 @@ are management APIs rather than a promise of distributed or persistent caching.
 
 For every generic, query, or passage request, the wrapper does the following:
 
-1. Apply the role prefix, if any. Generic calls remain raw text with the `Generic` role.
-2. Validate only the wrapper-owned empty-batch, batch-size, and text-length bounds before lookup.
-3. If capacity is zero, bypass hash computation and locks and delegate the prompted batch to the
-   inner service.
-4. Ask the inner service for the effective `ModelConfig`, then hash each prompted text with the
+1. Keep the caller's text as-is and record the request's `EmbeddingRole` (`Generic` for a plain
+   `embed` call). The wrapper does not apply the role instruction; the wrapped service does.
+2. Validate only the wrapper-owned empty-batch, batch-size, and text-length bounds, against the
+   caller's text, before lookup. Checking caller text keeps the published cap describing what the
+   caller passed rather than what the instruction adds.
+3. If capacity is zero, bypass hash computation and locks and delegate the caller text to the
+   inner service through `embed_with_role`, which applies the instruction for the role.
+4. Ask the inner service for the effective `ModelConfig`, then hash each caller text with the
    model identifier, its key revision, active dimension, and role tag.
 5. Look up all keys in the sharded LRU. Hits are returned from cache storage as shared slices and
    copied into the caller-owned result vectors; misses are remembered with their original input
    positions.
-6. If misses exist, send only those texts to the inner service. It must return exactly one vector
-   for each miss. A count mismatch becomes `EmbedError::InferenceFailed` rather than allowing a
-   `zip` operation to drop positions silently.
+6. If misses exist, send only those caller texts to the inner service through `embed_with_role`.
+   It must return exactly one vector for each miss. A count mismatch becomes
+   `EmbedError::InferenceFailed` rather than allowing a `zip` operation to drop positions silently.
 7. Insert new vectors, fill the missing result positions, and return every vector in the order
    supplied by the caller.
 
-The wrapper avoids mixing role-specific data in two ways: text has already been prompted when a
-role needs a prefix, and the cache key additionally contains the `EmbeddingRole` tag. The latter
-keeps generic, query, and passage requests in distinct cache namespaces as prompt policies evolve.
+The wrapper avoids mixing role-specific data by keying caller text together with the
+`EmbeddingRole` tag, which keeps generic, query, and passage requests in distinct cache namespaces
+as prompt policies evolve. Keying caller text is equivalent to keying prepared text because the
+instruction is a function of the role and model configuration already in the key, so no two
+distinct prepared strings can collide under one key.
 
 The cache is a reuse optimization, not a single-flight coordinator. Concurrent cache misses for
 the same text may each call the inner service before either request inserts its result. Callers
@@ -312,13 +317,14 @@ wrapper's LRU.
 
 ## CachedEmbeddingService cache-hit behavior
 
-The wrapper applies an optional role prefix, performs its local request-bound checks, and then
-either bypasses a disabled cache or computes keys from the prompted text, effective model
+The wrapper keeps the caller's text, performs its local request-bound checks against that text,
+and then either bypasses a disabled cache or computes keys from the caller text, effective model
 configuration, and role. It gathers every LRU hit before deciding whether to call the inner
 service. A full hit returns immediately and never invokes the inner service.
 
 Consequently, the wrapper cannot enforce an inner service's model selection, authorization, or
 other service-specific validation on a full hit. With at least one miss it delegates only the
-misses, and `NativeEmbeddingService::embed` performs its configured-model check before loading or
-encoding them. The wrapper rejects a mismatched number of returned vectors before insertion, which
-prevents a partial `zip` from losing original result positions.
+misses through `inner.embed_with_role`; the wrapped service applies the role instruction and
+performs its configured-model check before loading or encoding them. The wrapper rejects a
+mismatched number of returned vectors before insertion, which prevents a partial `zip` from losing
+original result positions.

--- a/crates/embed/docs/service.md
+++ b/crates/embed/docs/service.md
@@ -267,11 +267,23 @@ order and represents the `Generic` role. `embed_one` is a one-item convenience c
 an internal error if an implementation violates that cardinality contract rather than fabricating
 an empty vector.
 
-`embed_query` and `embed_passage` obtain a model instruction, prefix every text when one exists,
-then delegate to `embed`. The defaults cannot create role-separated cache entries by themselves:
-that behavior comes from `CachedEmbeddingService` overriding those methods and supplying its
-`Query` or `Passage` role tag. `EmbeddingRole::Generic` also has its own tag, so all three wrapper
-entry points receive distinct cache keys even when their resulting text is identical.
+`embed_with_role` is the single role entry point: it validates the caller's text against the
+published cap first, then prepends the model instruction, then delegates to `embed`. Validating
+before preparation is deliberate. The cap describes what the caller may submit, so charging the
+caller for the instruction bytes the service itself adds would reject text that is within the
+documented limit. `embed_query` and `embed_passage` are thin wrappers that call `embed_with_role`
+with the `Query` or `Passage` role, so all three role paths share one ordering decision instead of
+repeating it.
+
+That default cannot preserve the caller-text cap for an external implementation that enforces the
+exact cap inside its own `embed`: the prepared string reaches that `embed` already lengthened.
+Keeping `embed` the sole abstract method is a backward-compatibility choice on a published crate;
+an implementor that caps text should size that guard for the prepared length or override
+`embed_with_role` to reach its backend directly. Both in-crate implementors override it. The
+default also cannot create role-separated cache entries by itself: that behavior comes from
+`CachedEmbeddingService` supplying its role tag on the key. `EmbeddingRole::Generic` also has its
+own tag, so all three role paths receive distinct cache keys even when their resulting text is
+identical.
 
 `model_config` defaults to the model's native dimension. A service that has selected an MRL
 dimension overrides it so a caching wrapper hashes the actual output space, not merely the model

--- a/crates/embed/docs/service.md
+++ b/crates/embed/docs/service.md
@@ -254,7 +254,7 @@ native embedding call.
 | `InferenceFailed`     | The inference backend failed, including a cache-wrapper result-count violation      | Surface the backend failure; do not accept a partial batch                       |
 | `TaskFailed`          | A background task was cancelled or panicked                                         | Treat the current call as failed and check service state before retrying         |
 | `InvalidInput`        | Empty/oversized batch, wrong model, invalid configuration, or other invalid request | Correct the request without retrying unchanged input                             |
-| `TextTooLong`         | A text exceeded the service's length check                                          | Chunk or shorten the prompted input                                              |
+| `TextTooLong`         | A text exceeded the service's length check                                          | Chunk or shorten the caller-supplied input                                       |
 | `DimensionMismatch`   | An operation received vectors of different expected and actual dimensions           | Keep model/config/index namespaces consistent                                    |
 | `UnsupportedModel`    | The selected service cannot provide that model                                      | Select a capable service or model                                                |
 | `Internal`            | An invariant failed, such as a missing single-item result                           | Treat as a bug report; do not synthesize a vector                                |
@@ -273,8 +273,11 @@ an internal error if an implementation violates that cardinality contract rather
 an empty vector.
 
 `embed_with_role` is the single role entry point: it validates the caller's text against the
-published cap first, then prepends the model instruction, then delegates to `embed`. Validating
-before preparation is deliberate. The cap describes what the caller may submit, so charging the
+published cap first, then prepends the model instruction, then hands the prepared text to the
+backend. The trait default reaches the backend by calling `embed`; both implementations in this
+crate override the method and go straight to their own backend entry point, precisely so the
+prepared text is not re-checked against a cap that describes caller input. Validating before
+preparation is deliberate. The cap describes what the caller may submit, so charging the
 caller for the instruction bytes the service itself adds would reject text that is within the
 documented limit. `embed_query` and `embed_passage` are thin wrappers that call `embed_with_role`
 with the `Query` or `Passage` role, so all three role paths share one ordering decision instead of

--- a/crates/embed/src/model.rs
+++ b/crates/embed/src/model.rs
@@ -214,6 +214,29 @@ impl EmbeddingModel {
         }
     }
 
+    /// **Stable**: byte length of this model's longest retrieval instruction.
+    ///
+    /// Zero for symmetric models, which take no prefix at all.
+    ///
+    /// Callers apply an instruction to caller-supplied text, so text that has
+    /// already been prepared is longer than what the caller passed by at most
+    /// this many bytes. Length guards that run on prepared text size themselves
+    /// with this; guards that run on caller text use [`MAX_TEXT_BYTES`] exactly.
+    ///
+    /// [`MAX_TEXT_BYTES`]: crate::service::MAX_TEXT_BYTES
+    #[inline]
+    pub const fn max_instruction_bytes(&self) -> usize {
+        let q = match self.query_instruction() {
+            Some(s) => s.len(),
+            None => 0,
+        };
+        let d = match self.document_instruction() {
+            Some(s) => s.len(),
+            None => 0,
+        };
+        if q > d { q } else { d }
+    }
+
     /// **Stable**: get the model identifier (HuggingFace ID or provider/model).
     #[inline]
     pub const fn model_id(&self) -> &'static str {

--- a/crates/embed/src/service/cached.rs
+++ b/crates/embed/src/service/cached.rs
@@ -3,7 +3,7 @@
 //! It preserves caller order across partial cache hits and uses role-aware keys for asymmetric
 //! retrieval. See `docs/service.md` for the lookup and fill algorithm.
 
-use super::{DEFAULT_MAX_BATCH_SIZE, EmbeddingRole, EmbeddingService, MAX_TEXT_BYTES};
+use super::{EmbeddingRole, EmbeddingService};
 use crate::error::Result;
 use crate::model::EmbeddingModel;
 use async_trait::async_trait;
@@ -58,28 +58,21 @@ impl<S: EmbeddingService> CachedEmbeddingService<S> {
 impl<S: EmbeddingService + 'static> EmbeddingService for CachedEmbeddingService<S> {
     async fn embed(&self, texts: &[String], model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
         // Generic has its own role tag — see docs/service.md.
-        self.embed_with_role(texts, model, EmbeddingRole::Generic)
+        self.cache_and_embed(texts, model, EmbeddingRole::Generic)
             .await
     }
 
-    /// Override: apply query prompt then cache with `Query` role key.
-    async fn embed_query(&self, texts: &[String], model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
-        let prefix = model.query_instruction();
-        let prompted = super::apply_prefix(texts, prefix);
-        self.embed_with_role(&prompted, model, EmbeddingRole::Query)
-            .await
-    }
-
-    /// Override: apply passage prompt then cache with `Passage` role key.
-    async fn embed_passage(
+    /// Override: cache under the role key rather than prefixing here.
+    ///
+    /// `embed_query` and `embed_passage` reach this through their trait defaults,
+    /// so all three role paths share one cache-aware implementation.
+    async fn embed_with_role(
         &self,
         texts: &[String],
         model: EmbeddingModel,
+        role: EmbeddingRole,
     ) -> Result<Vec<Vec<f32>>> {
-        let prefix = model.document_instruction();
-        let prompted = super::apply_prefix(texts, prefix);
-        self.embed_with_role(&prompted, model, EmbeddingRole::Passage)
-            .await
+        self.cache_and_embed(texts, model, role).await
     }
 
     fn supports_model(&self, model: EmbeddingModel) -> bool {
@@ -92,11 +85,16 @@ impl<S: EmbeddingService + 'static> EmbeddingService for CachedEmbeddingService<
 }
 
 impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
-    /// Core cache-and-embed implementation shared by `embed`, `embed_query`, and
-    /// `embed_passage`.  `texts` must already have the prompt prefix applied; `role`
-    /// is used only as part of the cache key so that different roles produce separate
-    /// cache entries for the same raw text.
-    async fn embed_with_role(
+    /// Core cache-and-embed implementation shared by every entry point.
+    ///
+    /// `texts` is caller text. The retrieval instruction is applied by the wrapped
+    /// service rather than here, so the published cap is checked against what the
+    /// caller actually passed. `role` selects that instruction downstream and
+    /// namespaces the cache key, so the same raw text under two roles never shares
+    /// an entry; keying on caller text is equivalent to keying on prepared text
+    /// because the instruction is a function of the role and model config already
+    /// in the key.
+    async fn cache_and_embed(
         &self,
         texts: &[String],
         model: EmbeddingModel,
@@ -105,28 +103,11 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
         use crate::error::EmbedError;
 
         // Validate wrapper-owned request bounds before cache interaction.
-        if texts.is_empty() {
-            return Err(EmbedError::InvalidInput("no texts provided".into()));
-        }
-        if texts.len() > DEFAULT_MAX_BATCH_SIZE {
-            return Err(EmbedError::InvalidInput(format!(
-                "batch size {} exceeds maximum {}",
-                texts.len(),
-                DEFAULT_MAX_BATCH_SIZE
-            )));
-        }
-        for text in texts {
-            if text.len() > MAX_TEXT_BYTES {
-                return Err(EmbedError::TextTooLong {
-                    length: text.len(),
-                    max: MAX_TEXT_BYTES,
-                });
-            }
-        }
+        super::validate_texts(texts)?;
 
         // Fast path: bypass cache entirely when disabled (no key computation, no locking)
         if !self.cache.is_enabled() {
-            return self.inner.embed(texts, model).await;
+            return self.inner.embed_with_role(texts, model, role).await;
         }
 
         // Compute cache keys — include the active dimension (for MRL models) and role.
@@ -164,9 +145,12 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
             to_embed.len()
         );
 
-        // Embed missing texts (after prompt is already applied in texts)
+        // Embed missing texts; the wrapped service applies the role instruction.
         let texts_to_embed: Vec<String> = to_embed.iter().map(|(_, t)| (*t).clone()).collect();
-        let new_embeddings = self.inner.embed(&texts_to_embed, model).await?;
+        let new_embeddings = self
+            .inner
+            .embed_with_role(&texts_to_embed, model, role)
+            .await?;
 
         // FP-035: validate count before zipping — a count mismatch would silently
         // drop slots via zip() and return fewer embeddings than requested.
@@ -191,9 +175,3 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
         Ok(results.into_iter().flatten().collect())
     }
 }
-
-// Suppress dead code warnings for constants that are used by other modules
-const _: () = {
-    let _ = DEFAULT_MAX_BATCH_SIZE;
-    let _ = MAX_TEXT_BYTES;
-};

--- a/crates/embed/src/service/mod.rs
+++ b/crates/embed/src/service/mod.rs
@@ -69,6 +69,54 @@ impl EmbeddingRole {
             EmbeddingRole::Generic => "role:generic",
         }
     }
+
+    /// Returns the instruction this role prepends for `model`, if any.
+    #[inline]
+    pub(crate) const fn instruction(self, model: EmbeddingModel) -> Option<&'static str> {
+        match self {
+            EmbeddingRole::Query => model.query_instruction(),
+            EmbeddingRole::Passage => model.document_instruction(),
+            EmbeddingRole::Generic => None,
+        }
+    }
+}
+
+/// Enforces the published request bounds against caller-supplied text.
+///
+/// This is the contract check, so it runs on what the caller actually passed
+/// and before any instruction is prepended. Guards that run downstream of
+/// preparation are memory backstops and size themselves with
+/// [`EmbeddingModel::max_instruction_bytes`]; they are not this check.
+pub(crate) fn validate_texts(texts: &[String]) -> Result<()> {
+    validate_texts_bounded(texts, MAX_TEXT_BYTES)
+}
+
+/// Shared body of the caller-text contract check and the prepared-text backstop.
+///
+/// `max_bytes` is [`MAX_TEXT_BYTES`] on caller text, and that value plus the
+/// model's longest instruction on text that has already been prepared. The
+/// reported `max` is `max_bytes` so an error names the bound that actually
+/// rejected the input rather than a constant the caller cannot relate to.
+pub(crate) fn validate_texts_bounded(texts: &[String], max_bytes: usize) -> Result<()> {
+    if texts.is_empty() {
+        return Err(EmbedError::InvalidInput("no texts provided".into()));
+    }
+    if texts.len() > DEFAULT_MAX_BATCH_SIZE {
+        return Err(EmbedError::InvalidInput(format!(
+            "batch size {} exceeds maximum {}",
+            texts.len(),
+            DEFAULT_MAX_BATCH_SIZE
+        )));
+    }
+    for text in texts {
+        if text.len() > max_bytes {
+            return Err(EmbedError::TextTooLong {
+                length: text.len(),
+                max: max_bytes,
+            });
+        }
+    }
+    Ok(())
 }
 
 /// **Stable**: external consumers may depend on this; breaking changes require a SemVer bump.
@@ -97,13 +145,36 @@ pub trait EmbeddingService: Send + Sync {
             .ok_or_else(|| EmbedError::Internal("no embedding generated".into()))
     }
 
+    /// **Stable**: embed texts under a retrieval role, applying that role's instruction.
+    ///
+    /// The published length cap applies to the text the caller supplies, so this
+    /// validates first and prepends the instruction second. Doing it the other
+    /// way round charges the caller for bytes the service itself added, which
+    /// rejects text that is within the documented limit.
+    ///
+    /// Implementors that enforce a text-length cap inside [`EmbeddingService::embed`]
+    /// receive prepared text here, which is longer than the caller's by up to
+    /// [`EmbeddingModel::max_instruction_bytes`]. Size that guard accordingly, or
+    /// override this method to reach the backend without passing through it.
+    ///
+    /// See [`docs/service.md`](../../docs/service.md#trait-api-details) for role and cache behavior.
+    async fn embed_with_role(
+        &self,
+        texts: &[String],
+        model: EmbeddingModel,
+        role: EmbeddingRole,
+    ) -> Result<Vec<Vec<f32>>> {
+        validate_texts(texts)?;
+        let prepared = apply_prefix(texts, role.instruction(model));
+        self.embed(&prepared, model).await
+    }
+
     /// **Stable**: embed query texts after applying the model's query instruction.
     ///
     /// See [`docs/service.md`](../../docs/service.md#trait-api-details) for role and cache behavior.
     async fn embed_query(&self, texts: &[String], model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
-        let prefix = model.query_instruction();
-        let prompted = apply_prefix(texts, prefix);
-        self.embed(&prompted, model).await
+        self.embed_with_role(texts, model, EmbeddingRole::Query)
+            .await
     }
 
     /// **Stable**: embed passages after applying the model's document instruction.
@@ -114,9 +185,8 @@ pub trait EmbeddingService: Send + Sync {
         texts: &[String],
         model: EmbeddingModel,
     ) -> Result<Vec<Vec<f32>>> {
-        let prefix = model.document_instruction();
-        let prompted = apply_prefix(texts, prefix);
-        self.embed(&prompted, model).await
+        self.embed_with_role(texts, model, EmbeddingRole::Passage)
+            .await
     }
 
     /// **Unstable**: returns the effective configuration used for this model's cache keys.

--- a/crates/embed/src/service/native.rs
+++ b/crates/embed/src/service/native.rs
@@ -3,7 +3,7 @@
 //! Model loading is lazy and cancellation-safe; BERT-family and Qwen models take different
 //! loading and batching paths. See `docs/service.md` for lifecycle and persistence details.
 
-use super::{DEFAULT_MAX_BATCH_SIZE, EmbeddingService, MAX_TEXT_BYTES};
+use super::{EmbeddingRole, EmbeddingService, MAX_TEXT_BYTES};
 use crate::error::{EmbedError, Result};
 use crate::model::{EmbeddingModel, ModelConfig};
 use async_trait::async_trait;
@@ -176,6 +176,35 @@ impl NativeEmbeddingService {
             .as_ref()
             .map_err(|e| EmbedError::ModelInitialization(e.clone()))
     }
+
+    /// Encodes text that has already been prepared, meaning any retrieval
+    /// instruction is applied and the caller-facing contract is checked.
+    ///
+    /// The length bound here is a memory backstop, not the published cap: it
+    /// admits the caller's allowance plus whatever instruction this model
+    /// prepends, which is zero bytes for symmetric models.
+    async fn encode_prepared(
+        &self,
+        texts: &[String],
+        model: EmbeddingModel,
+    ) -> Result<Vec<Vec<f32>>> {
+        if model != self.model_config.model {
+            return Err(EmbedError::InvalidInput(format!(
+                "requested model {:?} but this service is loaded with {:?}",
+                model, self.model_config.model
+            )));
+        }
+        super::validate_texts_bounded(
+            texts,
+            MAX_TEXT_BYTES.saturating_add(model.max_instruction_bytes()),
+        )?;
+
+        let loaded = self.ensure_model().await?;
+        let text_refs = texts.iter().map(String::as_str).collect::<Vec<_>>();
+        loaded
+            .encode_batch(&text_refs)
+            .map_err(EmbedError::InferenceFailed)
+    }
 }
 
 /// Synchronous model loading (runs on blocking thread pool).
@@ -292,36 +321,23 @@ fn qwen_model_dir(model_type: EmbeddingModel) -> Result<std::path::PathBuf> {
 #[async_trait]
 impl EmbeddingService for NativeEmbeddingService {
     async fn embed(&self, texts: &[String], model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
-        if model != self.model_config.model {
-            return Err(EmbedError::InvalidInput(format!(
-                "requested model {:?} but this service is loaded with {:?}",
-                model, self.model_config.model
-            )));
-        }
-        if texts.is_empty() {
-            return Err(EmbedError::InvalidInput("no texts provided".into()));
-        }
-        if texts.len() > DEFAULT_MAX_BATCH_SIZE {
-            return Err(EmbedError::InvalidInput(format!(
-                "batch size {} exceeds maximum {}",
-                texts.len(),
-                DEFAULT_MAX_BATCH_SIZE
-            )));
-        }
-        for text in texts {
-            if text.len() > MAX_TEXT_BYTES {
-                return Err(EmbedError::TextTooLong {
-                    length: text.len(),
-                    max: MAX_TEXT_BYTES,
-                });
-            }
-        }
+        // Caller text, so the published cap applies exactly.
+        super::validate_texts(texts)?;
+        self.encode_prepared(texts, model).await
+    }
 
-        let loaded = self.ensure_model().await?;
-        let text_refs = texts.iter().map(String::as_str).collect::<Vec<_>>();
-        loaded
-            .encode_batch(&text_refs)
-            .map_err(EmbedError::InferenceFailed)
+    async fn embed_with_role(
+        &self,
+        texts: &[String],
+        model: EmbeddingModel,
+        role: EmbeddingRole,
+    ) -> Result<Vec<Vec<f32>>> {
+        // Validate what the caller passed, then prepare. Routing the prepared
+        // text back through `embed` would re-check it against the caller-text
+        // cap and reject input the caller kept within the documented limit.
+        super::validate_texts(texts)?;
+        let prepared = super::apply_prefix(texts, role.instruction(model));
+        self.encode_prepared(&prepared, model).await
     }
 
     fn model_config(&self, model: EmbeddingModel) -> ModelConfig {

--- a/crates/embed/src/service/tests.rs
+++ b/crates/embed/src/service/tests.rs
@@ -364,6 +364,146 @@ fn test_max_instruction_bytes_matches_the_longest_instruction() {
 }
 
 // ---------------------------------------------------------------------------
+// External-implementor contract for the embed_with_role default (PR #1110)
+// ---------------------------------------------------------------------------
+//
+// The default `embed_with_role` validates caller text, then prepends the role
+// instruction and delegates to `embed`. For an out-of-tree service that enforces
+// the exact `MAX_TEXT_BYTES` cap inside `embed` and does not override the default,
+// that means cap-sized caller text for an instruction-bearing model reaches the
+// backend already lengthened and is rejected. This is a deliberate, documented
+// limitation of keeping `embed` the sole abstract method (backward compatible on
+// a published crate); the escape hatch is overriding `embed_with_role`. Both in-
+// crate implementors take the escape hatch. These tests pin both sides of that
+// contract executably so the choice cannot regress into prose only. They use no
+// model weights, so they run in every feature configuration.
+mod external_impl_contract {
+    use crate::error::{EmbedError, Result};
+    use crate::model::EmbeddingModel;
+    use crate::service::{
+        EmbeddingRole, EmbeddingService, MAX_TEXT_BYTES, apply_prefix, validate_texts,
+    };
+    use async_trait::async_trait;
+
+    /// Shared backend: exact published cap, no weights, one-dim stub vectors.
+    fn exact_cap_embed(texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        for t in texts {
+            if t.len() > MAX_TEXT_BYTES {
+                return Err(EmbedError::TextTooLong {
+                    length: t.len(),
+                    max: MAX_TEXT_BYTES,
+                });
+            }
+        }
+        Ok(texts.iter().map(|_| vec![0.0]).collect())
+    }
+
+    /// External service that inherits the `embed_with_role` default unchanged.
+    struct ExactCapNoOverride;
+
+    #[async_trait]
+    impl EmbeddingService for ExactCapNoOverride {
+        async fn embed(&self, texts: &[String], _model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
+            exact_cap_embed(texts)
+        }
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+        fn name(&self) -> &'static str {
+            "exact-cap-no-override"
+        }
+    }
+
+    /// External service that overrides the role method: validate caller text,
+    /// then reach its own backend with a bound sized for the prepared string.
+    struct ExactCapWithOverride;
+
+    #[async_trait]
+    impl EmbeddingService for ExactCapWithOverride {
+        async fn embed(&self, texts: &[String], _model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
+            exact_cap_embed(texts)
+        }
+        async fn embed_with_role(
+            &self,
+            texts: &[String],
+            model: EmbeddingModel,
+            role: EmbeddingRole,
+        ) -> Result<Vec<Vec<f32>>> {
+            validate_texts(texts)?;
+            let prepared = apply_prefix(texts, role.instruction(model));
+            let backstop = MAX_TEXT_BYTES + model.max_instruction_bytes();
+            for t in &prepared {
+                if t.len() > backstop {
+                    return Err(EmbedError::TextTooLong {
+                        length: t.len(),
+                        max: MAX_TEXT_BYTES,
+                    });
+                }
+            }
+            Ok(prepared.iter().map(|_| vec![0.0]).collect())
+        }
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+        fn name(&self) -> &'static str {
+            "exact-cap-with-override"
+        }
+    }
+
+    /// The documented limitation, made executable: the default forwards prepared
+    /// text through the exact-cap `embed`, so cap-sized caller text is rejected.
+    /// Reverting the default to skip preparation would flip this, so it guards the
+    /// dispatch shape rather than restating it.
+    #[tokio::test]
+    async fn default_role_forwards_prepared_text_to_embed() {
+        let text = "a".repeat(MAX_TEXT_BYTES);
+        assert_eq!(text.len(), MAX_TEXT_BYTES);
+        let err = ExactCapNoOverride
+            .embed_query(&[text], EmbeddingModel::BgeSmallEnV15)
+            .await
+            .expect_err("default forwards the lengthened string through exact-cap embed");
+        assert!(
+            matches!(err, EmbedError::TextTooLong { .. }),
+            "expected the inherited exact-cap embed to reject prepared text, got: {err}"
+        );
+    }
+
+    /// The escape hatch, made executable: overriding `embed_with_role` lets an
+    /// external service enforce the cap on caller text and admit cap-sized input.
+    #[tokio::test]
+    async fn overriding_the_role_method_preserves_the_caller_cap() {
+        let text = "a".repeat(MAX_TEXT_BYTES);
+        let out = ExactCapWithOverride
+            .embed_query(&[text], EmbeddingModel::BgeSmallEnV15)
+            .await
+            .expect("overriding embed_with_role admits cap-sized caller text");
+        assert_eq!(out.len(), 1, "one embedding per input");
+    }
+
+    /// Over-cap caller text is rejected on both external shapes, and the error
+    /// reports the published cap rather than any wider internal bound.
+    #[tokio::test]
+    async fn over_cap_caller_text_reports_published_cap_on_both_shapes() {
+        let text = "a".repeat(MAX_TEXT_BYTES + 1);
+        let one = std::slice::from_ref(&text);
+        for res in [
+            ExactCapNoOverride
+                .embed_query(one, EmbeddingModel::BgeSmallEnV15)
+                .await,
+            ExactCapWithOverride
+                .embed_query(one, EmbeddingModel::BgeSmallEnV15)
+                .await,
+        ] {
+            let err = res.expect_err("over-cap caller text must be rejected");
+            assert!(
+                matches!(err, EmbedError::TextTooLong { max, .. } if max == MAX_TEXT_BYTES),
+                "must report the published cap, got: {err}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Role-aware prompt tests (P0-E2)
 // ---------------------------------------------------------------------------
 

--- a/crates/embed/src/service/tests.rs
+++ b/crates/embed/src/service/tests.rs
@@ -273,6 +273,94 @@ mod native_tests {
         let msg = err.to_string();
         assert!(msg.contains("32846"), "got: {msg}");
     }
+
+    /// #1104: the published cap covers caller text, so text sitting exactly at
+    /// the cap must clear validation on a role path even though the model's
+    /// query instruction makes the prepared string longer than the cap.
+    ///
+    /// Model weights are not present in every environment, so this asserts the
+    /// request got PAST length validation rather than asserting success. That is
+    /// the precise thing that regressed: validating prepared text returned
+    /// `TextTooLong` here and never reached model loading.
+    #[tokio::test]
+    async fn test_role_path_validates_caller_text_not_prepared_text() {
+        let model = EmbeddingModel::BgeSmallEnV15;
+        assert!(
+            model.max_instruction_bytes() > 0,
+            "test needs a model that prepends a query instruction"
+        );
+
+        let text = "a".repeat(MAX_TEXT_BYTES);
+        assert_eq!(text.len(), MAX_TEXT_BYTES);
+
+        let service = NativeEmbeddingService::default();
+        if let Err(e) = service.embed_query(&[text], model).await {
+            assert!(
+                !matches!(e, crate::error::EmbedError::TextTooLong { .. }),
+                "caller text at exactly the cap must not be rejected for length: {e}"
+            );
+        }
+    }
+
+    /// #1104 companion: the cap is still enforced, and the error still reports
+    /// the published cap rather than the wider backstop used on prepared text.
+    #[tokio::test]
+    async fn test_role_path_still_rejects_caller_text_over_the_cap() {
+        let text = "a".repeat(MAX_TEXT_BYTES + 1);
+        let service = NativeEmbeddingService::default();
+        let err = service
+            .embed_query(&[text], EmbeddingModel::BgeSmallEnV15)
+            .await
+            .expect_err("caller text over the cap must be rejected");
+        assert!(
+            matches!(err, crate::error::EmbedError::TextTooLong { max, .. } if max == MAX_TEXT_BYTES),
+            "must report the published cap, got: {err}"
+        );
+    }
+
+    /// Sibling invocation path: the cached wrapper has its own entry point and
+    /// must apply the same caller-text semantics.
+    #[tokio::test]
+    async fn test_cached_role_path_validates_caller_text() {
+        use crate::service::CachedEmbeddingService;
+        use std::sync::Arc;
+
+        let text = "a".repeat(MAX_TEXT_BYTES);
+        let service =
+            CachedEmbeddingService::with_default_cache(Arc::new(NativeEmbeddingService::default()));
+
+        if let Err(e) = service
+            .embed_query(&[text], EmbeddingModel::BgeSmallEnV15)
+            .await
+        {
+            assert!(
+                !matches!(e, crate::error::EmbedError::TextTooLong { .. }),
+                "caller text at exactly the cap must not be rejected for length: {e}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_max_instruction_bytes_matches_the_longest_instruction() {
+    for model in [
+        EmbeddingModel::BgeSmallEnV15,
+        EmbeddingModel::MultilingualE5Small,
+        EmbeddingModel::Qwen3Embedding0_6B,
+        EmbeddingModel::AllMiniLmL6V2,
+    ] {
+        let q = model.query_instruction().map_or(0, str::len);
+        let d = model.document_instruction().map_or(0, str::len);
+        assert_eq!(
+            model.max_instruction_bytes(),
+            q.max(d),
+            "{model:?} reports the wrong instruction bound"
+        );
+    }
+
+    // Symmetric models take no instruction, so prepared text is caller text and
+    // the backstop collapses onto the published cap exactly.
+    assert_eq!(EmbeddingModel::AllMiniLmL6V2.max_instruction_bytes(), 0);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1104.

## The bug

`MAX_TEXT_BYTES` is documented as what a caller may pass. The guard ran on the string *after* the role instruction was prepended, so a caller submitting text at exactly the documented cap was rejected at `cap + prefix_len`. Someone doing exactly what the docs say got an error blaming them for bytes the service itself added.

Reported on both role paths, which is the sibling-path shape: the trait defaults (`embed_query` / `embed_passage` into `NativeEmbeddingService::embed`) and the `CachedEmbeddingService` overrides into its own internal method, four sites in total.

## Why this is not a one-line reorder

The single guard was doing two different jobs:

1. **The published contract**, "your text may be up to `MAX_TEXT_BYTES`". The right place to check this is the public entry, against the caller's own text.
2. **A memory bound** on what actually gets processed. Any sufficient bound satisfies this.

Validating caller text at the role methods fixes the reported symptom, but the downstream check still saw the prepared string and still rejected it, so the downstream bound had to change too. Three options were considered on the issue:

- **A.** Bound the sink at `MAX_TEXT_BYTES + MAX_PROMPT_PREFIX_BYTES` globally. Smallest diff, but a direct `embed` caller who never had a prefix applied gains slack against a cap the docs state exactly. Loosening a published bound to make a check pass is the habit worth avoiding even when the amount is small.
- **B.** Make the sink bound role-aware. Exact, but only reaches the cached path.
- **C.** Prefix after validation instead of before, removing the conflation rather than working around it.

This implements C, with B's exactness where a downstream bound is still needed.

## What changed

`embed_with_role(texts, model, role)` is a new defaulted trait method. It validates caller text, then prepares. `embed_query` and `embed_passage` become thin wrappers over it, so all three role paths share one implementation instead of three copies of the same ordering decision.

The length check downstream of preparation is now explicitly a memory backstop rather than the contract check, and it sizes itself as the cap plus *that model's own longest instruction* via the new `EmbeddingModel::max_instruction_bytes()`. For symmetric models that is zero bytes, so the backstop collapses onto the published cap exactly. There is no global slack constant.

`CachedEmbeddingService` now keeps caller text end to end and delegates prefixing to the wrapped service. Cache keying is unchanged in effect: the instruction is a function of the role and model config that are already part of the key, so keying on caller text and keying on prepared text partition identically.

Errors report the bound that actually rejected the input, so a caller over the published cap still sees `MAX_TEXT_BYTES` rather than the wider internal number.

## Public surface

This adds one defaulted method to the `EmbeddingService` trait. That is backward compatible for existing implementors, and `embed` remains the abstract method, so nothing external is forced to change. Flagging it explicitly because it is public trait surface on a published crate rather than an internal refactor.

The trait default documents the constraint it imposes on implementors: an implementor enforcing a text-length cap inside `embed` receives prepared text through the default path, which is longer than the caller's by up to `max_instruction_bytes()`. Such an implementor should size that guard accordingly or override `embed_with_role` to reach its backend directly. Both in-crate implementors override it.

## Tests

Three tests, on both invocation paths, plus a unit test pinning `max_instruction_bytes()` against the instruction strings.

Mutation-checked rather than assumed: reverting the validation order to prefix-then-validate and rebuilding makes both new role-path tests fail with the original signature, `32825 bytes exceeds maximum 32768`, which is the cap plus the 57-byte query instruction. Restoring the fix returns them to green. Full crate suite is 281 passing, clippy clean under `-D warnings`.

The positive-direction tests assert the request got *past* length validation rather than asserting success, because model weights are not present in every environment. That is the precise behavior that regressed: the old order returned `TextTooLong` and never reached model loading.

## bench-compare disposition

**No measurable performance change.**

`lattice-embed --bench simd`, all groups, quick mode. Base is the merge-base `05291c5d`, head is `de82422e`. Both binaries built from the same toolchain, then run back to back on the same idle machine.

**246 comparisons: 0 regressed, 3 improved, 243 no change.** Point estimates span -13.24% to +9.40%, mean -1.82%, median -1.97%.

Machine state, sampled three times and recorded with the run rather than asserted: 96.78% idle before the base phase, 97.22% between phases, 97.4% after the head phase.

### Reading the three flagged rows

| group | point | 95% CI |
|---|---:|---|
| `simd_dot_product/simd/384` | -6.70% | [-8.98, -4.33] |
| `simd_batch_cosine_non_normalized_query/simd_batch/768d_256c` | -5.60% | [-7.00, -4.19] |
| `int8_raw_dot_product/dot_product_i8/768` | -4.56% | [-6.13, -2.99] |

All three are improvements, all three measure SIMD kernels this diff cannot reach, and none is claimed as a win. This change is confined to service-layer validation ordering and async trait dispatch; it does not touch a SIMD kernel. Larger unflagged swings sit alongside them (`pair_loop_dot/1024d_16c` at -13.24%, `binary_query_per_call/1000` at +9.40%), both reported as no change on CI width, which is the shape of a lane whose resolution is wider than these effects.

The direction also argues against a regression rather than for one. The head arm runs second, and this lane carries a measured order effect where whatever runs second measures slower. Head still came out neutral-to-faster on the mean, so the bias worked against the head arm and found nothing.

Honest scope note: `lattice-embed:simd` is the target currently demoted to informational in quick mode, and same-commit A/A runs on it have produced confirmed-CI FAIL rows with disjoint failing groups. So this lane resolves poorly at this magnitude. That is acceptable for the claim being made here, which is the absence of a regression rather than the presence of a win.
