### PR TITLE
docs(bench): separate measured, reported, gated, and enforced in the bench comments

### DIFF
--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -56,13 +56,15 @@
 # further, so a filtered --full run classifies only the selected groups of
 # those two.
 #
-# Automation: bench-update.yml does run those targets at full resolution on
-# main weekly, but only to collect baselines. It neither compares against a
-# prior baseline nor invokes perf-bench-gate.py nor takes any
-# regression-specific fail or alert action; its ordinary job steps can of
-# course still fail on their own errors. No automated full-mode regression
-# gate exists yet (#1105 tracks it), so a demoted target's full-resolution
-# regression coverage today comes from manual runs.
+# Automation: bench-update.yml runs those targets at full resolution on main
+# — on every push touching the perf paths (which include embed's simd source
+# and bench) and weekly by cron — and saves the baselines. It does not invoke
+# perf-bench-gate.py and takes no regression-specific fail or alert action;
+# its ordinary job steps can of course still fail on their own errors. It is
+# not silent about regressions either: its README generator compares each
+# snapshot against its predecessor and publishes a "Worst step-regression"
+# headline. So full-resolution automation today is regression REPORTING, and
+# what is missing is ENFORCEMENT (#1105 tracks that lane).
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -27,18 +27,25 @@
 # scripts/perf-bench-gate.py --selftest); their groups are still fully
 # measured and rendered — the informational section plus the
 # all-measurements table record every number — but excluded from the
-# FAIL/WARN gate and exit code. Every non-demoted target (all of
-# lattice-inference) gates normally in --quick.
+# FAIL/WARN gate and exit code. Every non-demoted target this script benches
+# (the lattice-inference one) gates normally in --quick.
 #
-# --full evaluates EVERY group of every target at full resolution, simd
-# included: quick mode is a PR-side direction/magnitude screen, and a --full
-# run resolves simd tightly enough to gate. That full-resolution path is
-# available on demand — `make bench-gate` (this HEAD vs the perf-baselines
-# branch) and `bench-compare.sh --full` (an A/B) both run it. What does NOT
-# exist yet is an automated job that runs it on main and alerts on a
-# regression; until #1105 lands that detection lane, the quick-mode demotion
-# is covered only by manual/local full-mode runs, not by CI. Do not read
-# this comment as a claim that an automated lane already catches simd.
+# --full applies no informational demotion: every group it benches gates,
+# simd included, because full resolution is tight enough to gate simd on.
+# Two caveats keep that from meaning "everything is covered".
+#
+# Scope: this script benches two targets, not the workspace's full bench set
+# — lattice-inference:$BENCHES_INFERENCE (default elementwise_cpu_bench) and
+# lattice-embed:simd. The optional BENCH_GROUPS_* filters above narrow it
+# further, so a filtered --full run gates only the selected groups of those
+# two. `make bench-gate` runs the same two targets unfiltered against the
+# perf-baselines branch.
+#
+# Automation: bench-update.yml does run those targets at full resolution on
+# main weekly, but only to COLLECT baselines — it never compares against a
+# prior baseline, never invokes perf-bench-gate.py, and never fails or
+# alerts. No automated full-mode GATE exists yet (#1105 tracks it), so a
+# demoted target's full-resolution coverage today comes from manual runs.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -30,10 +30,15 @@
 # FAIL/WARN gate and exit code. Every non-demoted target (all of
 # lattice-inference) gates normally in --quick.
 #
-# --full remains the gate for EVERY group of every target: quick mode is a
-# PR-side direction/magnitude screen, and full-resolution simd gating rides
-# the scheduled nightly perf lane (a --full run on current main), so the
-# demotion is a resolution split, not a coverage hole.
+# --full evaluates EVERY group of every target at full resolution, simd
+# included: quick mode is a PR-side direction/magnitude screen, and a --full
+# run resolves simd tightly enough to gate. That full-resolution path is
+# available on demand — `make bench-gate` (this HEAD vs the perf-baselines
+# branch) and `bench-compare.sh --full` (an A/B) both run it. What does NOT
+# exist yet is an automated job that runs it on main and alerts on a
+# regression; until #1105 lands that detection lane, the quick-mode demotion
+# is covered only by manual/local full-mode runs, not by CI. Do not read
+# this comment as a claim that an automated lane already catches simd.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -16,6 +16,15 @@
 #   lattice-embed: simd
 # Uses a git worktree for the base ref so your working tree stays untouched.
 #
+# VOCABULARY, because these four are separate and get conflated. A group is
+# MEASURED if the bench ran and produced numbers; REPORTED if those numbers
+# appear in the report; CLASSIFIED GATING (vs informational) if a regression
+# in it contributes to the report's FAIL verdict; and ENFORCED only if that
+# FAIL verdict reaches the caller as a non-zero exit status. Classification
+# is not enforcement: this script computes a verdict and then discards its
+# exit status, so it is REPORT-ONLY in both modes. `make bench-gate` is the
+# path that enforces. Use these words literally below.
+#
 # lattice#714 / lattice#1060: the lattice-embed `simd` bench TARGET is
 # informational in --quick mode (the default). Same-toolchain, same-commit
 # A/A reproductions in exclusive bench windows repeatedly produced
@@ -26,26 +35,34 @@
 # scripts/lib/bench-quick-informational-targets.txt (validated by
 # scripts/perf-bench-gate.py --selftest); their groups are still fully
 # measured and rendered — the informational section plus the
-# all-measurements table record every number — but excluded from the
-# FAIL/WARN gate and exit code. Every non-demoted target this script benches
-# (the lattice-inference one) gates normally in --quick.
+# all-measurements table record every number — but classified informational,
+# so they cannot produce a FAIL verdict. Every non-demoted target this script
+# benches (the lattice-inference one) is classified gating in --quick.
 #
-# --full applies no informational demotion: every group it benches gates,
-# simd included, because full resolution is tight enough to gate simd on.
-# Two caveats keep that from meaning "everything is covered".
+# --full applies no informational demotion: every group it benches is
+# classified gating, simd included, because full resolution is tight enough
+# to distinguish a real simd regression from machine noise. Three caveats
+# keep that from meaning "a regression cannot get past this".
+#
+# Enforcement: neither mode enforces. This script ends its gate invocation
+# with `|| true`, so a FAIL verdict is printed and then discarded, and the
+# script exits 0 either way. `make bench-gate` is the enforcing path: it runs
+# the same two default targets unfiltered against the perf-baselines branch
+# and returns perf-bench-gate.py's status directly.
 #
 # Scope: this script benches two targets, not the workspace's full bench set
 # — lattice-inference:$BENCHES_INFERENCE (default elementwise_cpu_bench) and
 # lattice-embed:simd. The optional BENCH_GROUPS_* filters above narrow it
-# further, so a filtered --full run gates only the selected groups of those
-# two. `make bench-gate` runs the same two targets unfiltered against the
-# perf-baselines branch.
+# further, so a filtered --full run classifies only the selected groups of
+# those two.
 #
 # Automation: bench-update.yml does run those targets at full resolution on
-# main weekly, but only to COLLECT baselines — it never compares against a
-# prior baseline, never invokes perf-bench-gate.py, and never fails or
-# alerts. No automated full-mode GATE exists yet (#1105 tracks it), so a
-# demoted target's full-resolution coverage today comes from manual runs.
+# main weekly, but only to collect baselines. It neither compares against a
+# prior baseline nor invokes perf-bench-gate.py nor takes any
+# regression-specific fail or alert action; its ordinary job steps can of
+# course still fail on their own errors. No automated full-mode regression
+# gate exists yet (#1105 tracks it), so a demoted target's full-resolution
+# regression coverage today comes from manual runs.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -21,9 +21,11 @@
 # appear in the report; CLASSIFIED GATING (vs informational) if a regression
 # in it contributes to the report's FAIL verdict; and ENFORCED only if that
 # FAIL verdict reaches the caller as a non-zero exit status. Classification
-# is not enforcement: this script computes a verdict and then discards its
-# exit status, so it is REPORT-ONLY in both modes. `make bench-gate` is the
-# path that enforces. Use these words literally below.
+# is not enforcement: by default this script computes a verdict and then
+# discards its exit status, so --quick and --full are both REPORT-ONLY.
+# Enforcement is opt-in per invocation via --fail-on-regression, which
+# propagates the gate's status instead; `make bench-gate` also enforces.
+# Use these words literally below.
 #
 # lattice#714 / lattice#1060: the lattice-embed `simd` bench TARGET is
 # informational in --quick mode (the default). Same-toolchain, same-commit
@@ -44,11 +46,14 @@
 # to distinguish a real simd regression from machine noise. Three caveats
 # keep that from meaning "a regression cannot get past this".
 #
-# Enforcement: neither mode enforces. This script ends its gate invocation
-# with `|| true`, so a FAIL verdict is printed and then discarded, and the
-# script exits 0 either way. `make bench-gate` is the enforcing path: it runs
-# the same two default targets unfiltered against the perf-baselines branch
-# and returns perf-bench-gate.py's status directly.
+# Enforcement: neither mode enforces BY DEFAULT. This script ends its gate
+# invocation with `|| true`, so a FAIL verdict is printed and then discarded,
+# and the script exits 0 either way — which is why the demotion below is a
+# resolution split rather than a coverage hole in the default path. Two
+# callers do enforce: --fail-on-regression propagates the gate's status (exit
+# 1 confirmed regression, exit 2 the measurement itself is broken), and
+# `make bench-gate` runs the same two default targets unfiltered against the
+# perf-baselines branch and returns perf-bench-gate.py's status directly.
 #
 # Scope: this script benches two targets, not the workspace's full bench set
 # — lattice-inference:$BENCHES_INFERENCE (default elementwise_cpu_bench) and
@@ -63,8 +68,14 @@
 # its ordinary job steps can of course still fail on their own errors. It is
 # not silent about regressions either: its README generator compares each
 # snapshot against its predecessor and publishes a "Worst step-regression"
-# headline. So full-resolution automation today is regression REPORTING, and
-# what is missing is ENFORCEMENT (#1105 tracks that lane).
+# headline. So bench-update.yml itself is regression REPORTING.
+#
+# Enforcement at full resolution is a separate workflow, perf-postmerge-gate
+# .yml: it runs this script with --full --fail-on-regression on perf-path
+# merges to main, benching the merged commit against its own parent, and
+# fails the job when the gate confirms a regression. Read the two together —
+# bench-update.yml maintains the baselines and the trend, the post-merge gate
+# is what makes a confirmed regression stop something.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -23,9 +23,12 @@
 # probes; production never sets it.
 #
 # FULL mode (`bench-compare.sh --full`, or `make bench-gate`) ignores this
-# mechanism entirely and evaluates every group of every target. Those paths
-# are run manually/locally today; no automated CI lane runs full mode on main
-# yet (#1105 tracks it).
+# mechanism entirely: every group those paths bench gates, with no demotion.
+# Both bench the same two targets rather than the workspace's full bench set,
+# and --full additionally honors bench-compare.sh's BENCH_GROUPS_* filters.
+# Both are manual/local today. bench-update.yml is the one automated
+# full-resolution job on main, and it collects baselines without comparing,
+# gating, or alerting (#1105 tracks the missing gate lane).
 set -euo pipefail
 
 MANIFEST="${INFO_TARGETS_MANIFEST:-$(dirname "$0")/bench-quick-informational-targets.txt}"

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -25,15 +25,19 @@
 # FULL mode (`bench-compare.sh --full`, or `make bench-gate`) ignores this
 # mechanism entirely: every group those paths bench is classified gating,
 # with no demotion. Classification is not enforcement — `bench-compare.sh`
-# discards its gate's exit status in both modes, so only `make bench-gate`
-# turns a FAIL verdict into a non-zero exit. Both bench the same two targets
-# rather than the workspace's full bench set, and --full additionally honors
-# bench-compare.sh's BENCH_GROUPS_* filters. Both are manual/local today.
-# bench-update.yml is the automated full-resolution job on main: it saves
-# baselines and publishes historical trend comparisons, including a "Worst
-# step-regression" headline. It does not invoke perf-bench-gate.py and takes
-# no regression-specific fail action, so it reports rather than enforces
-# (#1105 tracks the missing enforcement lane).
+# discards its gate's exit status unless the caller passes
+# --fail-on-regression, so a FAIL verdict becomes a non-zero exit only under
+# that flag or via `make bench-gate`. Both bench the same two targets rather
+# than the workspace's full bench set, and --full additionally honors
+# bench-compare.sh's BENCH_GROUPS_* filters.
+#
+# Two automated full-resolution jobs run on main, and they do different
+# things. bench-update.yml saves baselines and publishes historical trend
+# comparisons, including a "Worst step-regression" headline; it does not
+# invoke perf-bench-gate.py and takes no regression-specific fail action, so
+# it reports rather than enforces. perf-postmerge-gate.yml is the enforcing
+# one: it runs `bench-compare.sh --full --fail-on-regression` against the
+# merged commit's own parent and fails on a confirmed regression.
 set -euo pipefail
 
 MANIFEST="${INFO_TARGETS_MANIFEST:-$(dirname "$0")/bench-quick-informational-targets.txt}"

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -23,12 +23,15 @@
 # probes; production never sets it.
 #
 # FULL mode (`bench-compare.sh --full`, or `make bench-gate`) ignores this
-# mechanism entirely: every group those paths bench gates, with no demotion.
-# Both bench the same two targets rather than the workspace's full bench set,
-# and --full additionally honors bench-compare.sh's BENCH_GROUPS_* filters.
-# Both are manual/local today. bench-update.yml is the one automated
-# full-resolution job on main, and it collects baselines without comparing,
-# gating, or alerting (#1105 tracks the missing gate lane).
+# mechanism entirely: every group those paths bench is classified gating,
+# with no demotion. Classification is not enforcement — `bench-compare.sh`
+# discards its gate's exit status in both modes, so only `make bench-gate`
+# turns a FAIL verdict into a non-zero exit. Both bench the same two targets
+# rather than the workspace's full bench set, and --full additionally honors
+# bench-compare.sh's BENCH_GROUPS_* filters. Both are manual/local today.
+# bench-update.yml is the one automated full-resolution job on main; it
+# collects baselines without comparing against a prior one and takes no
+# regression-specific fail or alert action (#1105 tracks the missing lane).
 set -euo pipefail
 
 MANIFEST="${INFO_TARGETS_MANIFEST:-$(dirname "$0")/bench-quick-informational-targets.txt}"

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -22,8 +22,10 @@
 # INFO_TARGETS_MANIFEST overrides the manifest path for those controlled
 # probes; production never sets it.
 #
-# FULL mode (`bench-compare.sh --full`, nightly perf lane) ignores this
-# mechanism entirely and gates every group of every target.
+# FULL mode (`bench-compare.sh --full`, or `make bench-gate`) ignores this
+# mechanism entirely and evaluates every group of every target. Those paths
+# are run manually/locally today; no automated CI lane runs full mode on main
+# yet (#1105 tracks it).
 set -euo pipefail
 
 MANIFEST="${INFO_TARGETS_MANIFEST:-$(dirname "$0")/bench-quick-informational-targets.txt}"

--- a/scripts/lib/bench-informational-groups.sh
+++ b/scripts/lib/bench-informational-groups.sh
@@ -29,9 +29,11 @@
 # turns a FAIL verdict into a non-zero exit. Both bench the same two targets
 # rather than the workspace's full bench set, and --full additionally honors
 # bench-compare.sh's BENCH_GROUPS_* filters. Both are manual/local today.
-# bench-update.yml is the one automated full-resolution job on main; it
-# collects baselines without comparing against a prior one and takes no
-# regression-specific fail or alert action (#1105 tracks the missing lane).
+# bench-update.yml is the automated full-resolution job on main: it saves
+# baselines and publishes historical trend comparisons, including a "Worst
+# step-regression" headline. It does not invoke perf-bench-gate.py and takes
+# no regression-specific fail action, so it reports rather than enforces
+# (#1105 tracks the missing enforcement lane).
 set -euo pipefail
 
 MANIFEST="${INFO_TARGETS_MANIFEST:-$(dirname "$0")/bench-quick-informational-targets.txt}"

--- a/scripts/lib/bench-quick-informational-targets.txt
+++ b/scripts/lib/bench-quick-informational-targets.txt
@@ -11,8 +11,12 @@
 # reported informationally — fully measured, rendered in the report's
 # informational section and the all-measurements table, excluded only from
 # the gating verdict and exit code. FULL mode (`scripts/bench-compare.sh
-# --full`, nightly perf lane) gates every group of every target regardless
-# of this manifest. Targets not listed here gate normally in both modes.
+# --full`, or `make bench-gate` against the perf-baselines branch) evaluates
+# every group of every target at full resolution regardless of this manifest.
+# Those full-mode paths are manual/local today; no automated CI job runs them
+# on main to alert on a regression, so a demoted target's only full-resolution
+# coverage is a manual run until #1105 lands the detection lane. Targets not
+# listed here gate normally in quick mode.
 #
 # Demoting a target requires same-toolchain, same-commit A/A evidence in an
 # exclusive bench window, reviewed in a PR that edits this file.

--- a/scripts/lib/bench-quick-informational-targets.txt
+++ b/scripts/lib/bench-quick-informational-targets.txt
@@ -11,12 +11,15 @@
 # reported informationally — fully measured, rendered in the report's
 # informational section and the all-measurements table, excluded only from
 # the gating verdict and exit code. FULL mode (`scripts/bench-compare.sh
-# --full`, or `make bench-gate` against the perf-baselines branch) evaluates
-# every group of every target at full resolution regardless of this manifest.
-# Those full-mode paths are manual/local today; no automated CI job runs them
-# on main to alert on a regression, so a demoted target's only full-resolution
-# coverage is a manual run until #1105 lands the detection lane. Targets not
-# listed here gate normally in quick mode.
+# --full`, or `make bench-gate` against the perf-baselines branch) ignores
+# this manifest: every group those paths bench gates at full resolution
+# (--full also honors bench-compare.sh's BENCH_GROUPS_* filters, and neither
+# path covers the workspace's full bench set). Both are manual/local today.
+# bench-update.yml does run the same targets at full resolution on main
+# weekly, but only to collect baselines — it never compares, gates, or
+# alerts, so a demoted target's full-resolution regression coverage is a
+# manual run until #1105 lands the gate lane. Targets not listed here gate
+# normally in quick mode.
 #
 # Demoting a target requires same-toolchain, same-commit A/A evidence in an
 # exclusive bench window, reviewed in a PR that edits this file.

--- a/scripts/lib/bench-quick-informational-targets.txt
+++ b/scripts/lib/bench-quick-informational-targets.txt
@@ -18,11 +18,12 @@
 # gating is not the same as being enforced: bench-compare.sh discards its
 # gate's exit status, so `make bench-gate` is the only path whose FAIL
 # verdict becomes a non-zero exit. Both are manual/local today.
-# bench-update.yml does run the same targets at full resolution on main
-# weekly, but only to collect baselines — it makes no prior-baseline
-# comparison and takes no regression-specific fail or alert action, so a
-# demoted target's full-resolution regression coverage is a manual run until
-# #1105 lands the gate lane. Targets not listed here are classified gating in
+# bench-update.yml runs the same targets at full resolution on main, on
+# perf-path pushes and weekly, and saves the baselines. It publishes
+# historical trend comparisons including a "Worst step-regression" headline,
+# but does not invoke perf-bench-gate.py or fail on a regression. So a demoted
+# target has automated full-resolution REPORTING; what it lacks until #1105
+# lands is enforcement. Targets not listed here are classified gating in
 # quick mode.
 #
 # Demoting a target requires same-toolchain, same-commit A/A evidence in an

--- a/scripts/lib/bench-quick-informational-targets.txt
+++ b/scripts/lib/bench-quick-informational-targets.txt
@@ -16,15 +16,20 @@
 # resolution (--full also honors bench-compare.sh's BENCH_GROUPS_* filters,
 # and neither path covers the workspace's full bench set). Being classified
 # gating is not the same as being enforced: bench-compare.sh discards its
-# gate's exit status, so `make bench-gate` is the only path whose FAIL
-# verdict becomes a non-zero exit. Both are manual/local today.
-# bench-update.yml runs the same targets at full resolution on main, on
-# perf-path pushes and weekly, and saves the baselines. It publishes
-# historical trend comparisons including a "Worst step-regression" headline,
-# but does not invoke perf-bench-gate.py or fail on a regression. So a demoted
-# target has automated full-resolution REPORTING; what it lacks until #1105
-# lands is enforcement. Targets not listed here are classified gating in
-# quick mode.
+# gate's exit status unless the caller passes --fail-on-regression, so a FAIL
+# verdict becomes a non-zero exit only under that flag or via
+# `make bench-gate`.
+#
+# Two automated jobs bench these targets at full resolution on main.
+# bench-update.yml runs on perf-path pushes and weekly and saves the
+# baselines; it publishes historical trend comparisons including a "Worst
+# step-regression" headline, but does not invoke perf-bench-gate.py or fail
+# on a regression, so it REPORTS. perf-postmerge-gate.yml runs
+# `bench-compare.sh --full --fail-on-regression` on perf-path merges,
+# against the merged commit's own parent, and fails on a confirmed
+# regression, so it ENFORCES. A demoted target is therefore reported AND
+# enforced at full resolution; the demotion only removes it from the quick
+# mode gate. Targets not listed here are classified gating in quick mode.
 #
 # Demoting a target requires same-toolchain, same-commit A/A evidence in an
 # exclusive bench window, reviewed in a PR that edits this file.

--- a/scripts/lib/bench-quick-informational-targets.txt
+++ b/scripts/lib/bench-quick-informational-targets.txt
@@ -12,14 +12,18 @@
 # informational section and the all-measurements table, excluded only from
 # the gating verdict and exit code. FULL mode (`scripts/bench-compare.sh
 # --full`, or `make bench-gate` against the perf-baselines branch) ignores
-# this manifest: every group those paths bench gates at full resolution
-# (--full also honors bench-compare.sh's BENCH_GROUPS_* filters, and neither
-# path covers the workspace's full bench set). Both are manual/local today.
+# this manifest: every group those paths bench is classified gating at full
+# resolution (--full also honors bench-compare.sh's BENCH_GROUPS_* filters,
+# and neither path covers the workspace's full bench set). Being classified
+# gating is not the same as being enforced: bench-compare.sh discards its
+# gate's exit status, so `make bench-gate` is the only path whose FAIL
+# verdict becomes a non-zero exit. Both are manual/local today.
 # bench-update.yml does run the same targets at full resolution on main
-# weekly, but only to collect baselines — it never compares, gates, or
-# alerts, so a demoted target's full-resolution regression coverage is a
-# manual run until #1105 lands the gate lane. Targets not listed here gate
-# normally in quick mode.
+# weekly, but only to collect baselines — it makes no prior-baseline
+# comparison and takes no regression-specific fail or alert action, so a
+# demoted target's full-resolution regression coverage is a manual run until
+# #1105 lands the gate lane. Targets not listed here are classified gating in
+# quick mode.
 #
 # Demoting a target requires same-toolchain, same-commit A/A evidence in an
 # exclusive bench window, reviewed in a PR that edits this file.


### PR DESCRIPTION
## What

Three source comments described the quick-mode `lattice-embed:simd` demotion as covered by a "scheduled nightly perf lane (a `--full` run on current main)". No such job existed when those comments were written, so the demoted groups were gated in neither mode. `bench-update.yml` did run both targets at full resolution and did publish historical regression reports, but it never invoked `perf-bench-gate.py` and never failed on the result, so the compensating control the comments claimed — full-resolution *gating* for the demoted target — was not there.

Corrected in:

- `scripts/bench-compare.sh`
- `scripts/lib/bench-quick-informational-targets.txt`
- `scripts/lib/bench-informational-groups.sh`

The missing lane has since been built (#1105, implemented in #1112) and this branch has merged it in, so the comments here describe shipped behavior rather than an absence.

## Four words that were doing one job

The replacement text for a false claim is itself a claim, and this one was wrong three times before it settled, every time in the same direction: a stronger statement than the code supported.

- "No automated CI lane runs full mode on main" was false. `bench-update.yml` runs both bench targets without `--quick`.
- "weekly" and "collects baselines without comparing against a prior one" were both false. It triggers on every push to main touching its perf paths — which include `crates/embed/src/simd/**` and `crates/embed/benches/simd.rs`, the demoted target's own source — as well as weekly by cron. And it does compare: it invokes `scripts/perf-baselines-readme.py`, which walks the snapshot history, computes each snapshot's delta against its predecessor, and publishes a "Worst step-regression" headline naming the bench and commit.
- "every group of every target" overstated both halves. The script benches two targets out of the workspace's declared bench set, and `--full` still honors the optional `BENCH_GROUPS_*` filters.

Rather than patch sentences a fourth time, the header now defines four terms once and the three comments use them literally:

- **measured** — the group ran and produced Criterion output
- **reported** — it appears in the report and the all-measurements table
- **classified gating** — a regression in it contributes to the report's FAIL verdict
- **enforced** — that verdict reaches the caller as a non-zero exit status

Separating "reported" from "enforced" is what made the last error findable: once they are different words, "collects baselines without comparing" reads as the category error it was.

## What the comments now say, and where each claim lives

- `scripts/bench-compare.sh` is report-only by default in both quick and full mode: the gate result is captured in `GATE_RC` and not returned. Passing `--fail-on-regression` propagates it — exit 1 for a confirmed gated regression, exit 2 when the comparison cannot be certified (`scripts/bench-compare.sh:388-418`, `scripts/perf-bench-gate.py`).
- `make bench-gate` is a separate path: it restores the local architecture's `perf-baselines` data, runs the two default targets, and returns `perf-bench-gate.py`'s status directly (`Makefile:57-73`).
- `perf-postmerge-gate.yml` runs `bench-compare.sh --full --fail-on-regression` on perf-path pushes to `main`, against the merged commit's own parent, and fails the job on a confirmed regression. For an ordinary push it uses `github.event.before`; when that SHA is unusable it falls back to the head commit's first parent, which for a squashed merge is the previous main tip.
- `bench-update.yml` saves baseline snapshots and publishes historical step-regression trends. It does not invoke the gate and has no regression-specific failure path, so it reports.
- Quick-mode demotion removes a target from the quick-mode gate only. Full-mode runs ignore the manifest, so every group they measure is classified gating — and, under the post-merge lane's flag, enforced.

## Why this is separate from the lane itself

The demotion decision is sound: repeated same-commit A/A quick-mode runs produced disjoint confirmed-CI FAIL rows on identical binaries, which is noise above quick-mode resolution. What was missing was the compensating control the comments named. A comment that cites infrastructure as justification is a claim, and that claim was false. Removing it was correct independently of what the eventual lane looked like, which is why it ships on its own.

## Verification

- `bash -n` on the changed shell files: clean.
- `python3 scripts/perf-bench-gate.py --selftest`: PASS (it reads the edited manifest).
- `python3 tests/test_bench_compare_measurement.py`: PASS.
- `actionlint` on `perf-postmerge-gate.yml` and `bench-update.yml`: clean.
- Manifest data line `lattice-embed:simd` intact; `bench-informational-groups.sh --print-targets` still emits it.
- Every claim above was read against source at this head.
- Comments and text only: no changed line falls outside a comment, so there is no behavioral delta, and no crate source is touched, so no bench-compare disposition applies.
