### PR TITLE
ci(perf): add the post-merge full-mode detection lane (#1105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -622,6 +622,12 @@ jobs:
       # "nothing measured" as "nothing regressed"), and runs no benchmark.
       - name: python3 scripts/perf-bench-gate.py --selftest
         run: python3 scripts/perf-bench-gate.py --selftest
+      # bench-compare.sh's measurement-integrity guard. Drives the shipping
+      # script in a disposable repo against a stub cargo, so it exercises the
+      # real parser-to-guard path; no benchmark runs and no real cargo is
+      # invoked, which keeps it in the same harness-plumbing scope as above.
+      - name: python3 tests/test_bench_compare_measurement.py
+        run: python3 tests/test_bench_compare_measurement.py -v
 
   # cargo-semver-checks against the latest published crates.io release for
   # every internal path-dependency crate, so a breaking public API change is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,6 +616,12 @@ jobs:
         run: bash scripts/ensure-noindex-marker-selftest.sh
       - name: python3 tests/test_bench_disposition.py
         run: python3 tests/test_bench_disposition.py -v
+      # perf-bench-gate's own fixture self-test. Same "harness plumbing only"
+      # scope: it fabricates Criterion trees and asserts the gate's exit codes
+      # (including the refusals that keep an automated lane from reading
+      # "nothing measured" as "nothing regressed"), and runs no benchmark.
+      - name: python3 scripts/perf-bench-gate.py --selftest
+        run: python3 scripts/perf-bench-gate.py --selftest
 
   # cargo-semver-checks against the latest published crates.io release for
   # every internal path-dependency crate, so a breaking public API change is

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -45,9 +45,10 @@ on:
       - 'crates/embed/benches/simd.rs'
       - 'crates/embed/Cargo.toml'
       - 'Cargo.lock'
-      # Root Cargo.toml carries [profile.bench]; .cargo/ can carry rustflags.
-      # Either can change codegen for both bench targets without touching a
-      # single line of crate source, so both must trigger this lane.
+      # Root Cargo.toml can carry [profile.bench] (it does not today) and
+      # .cargo/ can carry rustflags. Either can change codegen for both bench
+      # targets without touching a single line of crate source, so both must
+      # trigger this lane.
       - 'Cargo.toml'
       - '.cargo/**'
       - 'scripts/bench-compare.sh'
@@ -188,28 +189,43 @@ jobs:
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Full-mode A/B, failing on a confirmed regression
+        id: ab
         env:
           BASE: ${{ steps.refs.outputs.base }}
           HEAD: ${{ steps.refs.outputs.head }}
         run: |
-          scripts/bench-compare.sh --full --fail-on-regression "$BASE" "$HEAD"
+          # Record the gate's OWN exit code before re-raising it. The summary
+          # below has to tell "confirmed regression" from "refused to certify",
+          # and job.status cannot: it only ever holds success/failure/cancelled,
+          # so every earlier failure (checkout, toolchain, endpoint resolution)
+          # would otherwise be reported to the reader as one of those two gate
+          # verdicts and point them at a revert for a run that never benched.
+          rc=0
+          scripts/bench-compare.sh --full --fail-on-regression "$BASE" "$HEAD" || rc=$?
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          exit "$rc"
 
       - name: Record the outcome honestly
         if: always()
         env:
           JOB_STATUS: ${{ job.status }}
+          AB_RC: ${{ steps.ab.outputs.rc }}
         run: |
           {
             if [ "$JOB_STATUS" = "success" ]; then
               echo "No gross regression detected (see ceiling above)."
+            elif [ "$AB_RC" = "1" ]; then
+              echo "FAILED, exit 1 — a confirmed regression. Check the flagged groups"
+              echo "are reachable from the merged diff, then revert or justify."
+            elif [ "$AB_RC" = "2" ]; then
+              echo "FAILED, exit 2 — the gate refused to certify this run: no"
+              echo "comparison data, a partial A/B, or nothing gating among the"
+              echo "results. Nothing was proven about performance either way."
+              echo "Fix the measurement and re-run; do NOT revert on this alone."
             else
-              echo "FAILED. Two different causes share this exit, and they call for"
-              echo "opposite responses, so read the step log before acting:"
-              echo
-              echo "- exit 1 — a confirmed regression. Check the flagged groups are"
-              echo "  reachable from the merged diff, then revert or justify."
-              echo "- exit 2 — the gate refused to certify: no comparison data, or"
-              echo "  nothing gating among the results. Nothing was proven about"
-              echo "  performance. Fix the measurement and re-run; do NOT revert."
+              echo "FAILED before or during the A/B, with no gate verdict recorded"
+              echo "(\`rc=$AB_RC\`). The benchmark comparison did not reach a"
+              echo "conclusion, so this says nothing about performance. Inspect the"
+              echo "failing step above; do NOT revert on this alone."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -45,10 +45,18 @@ on:
       - 'crates/embed/benches/simd.rs'
       - 'crates/embed/Cargo.toml'
       - 'Cargo.lock'
+      # Root Cargo.toml carries [profile.bench]; .cargo/ can carry rustflags.
+      # Either can change codegen for both bench targets without touching a
+      # single line of crate source, so both must trigger this lane.
+      - 'Cargo.toml'
+      - '.cargo/**'
       - 'scripts/bench-compare.sh'
       - 'scripts/perf-bench-gate.py'
+      # Helpers bench-compare.sh invokes: a change in them changes the run.
       - 'scripts/lib/bench-informational-groups.sh'
       - 'scripts/lib/bench-quick-informational-targets.txt'
+      - 'scripts/lib/resolve-informational-groups.sh'
+      - 'scripts/lib/ensure-noindex-marker.sh'
       - '.github/workflows/perf-postmerge-gate.yml'
   workflow_dispatch:
     inputs:
@@ -65,9 +73,20 @@ permissions:
   contents: read
 
 concurrency:
-  # One post-merge A/B at a time per arch. Timing runs must not overlap each
-  # other on a shared runner pool, and a superseded run's numbers are of no
-  # interest once a newer commit has landed.
+  # One post-merge A/B run at a time for this ref. The group is ref-scoped, NOT
+  # arch-scoped: the two matrix legs belong to the same run and use different
+  # runner pools, so they are free to proceed together.
+  #
+  # KNOWN GAP, stated rather than hidden: GitHub keeps only ONE pending run per
+  # concurrency group. If commits B and C land while a run is in flight, B's
+  # pending run is replaced by C's, and C compares against B (github.event.before),
+  # so a regression introduced by B sits in both arms of C's A/B and is invisible.
+  # Rapid-fire merges to main can therefore skip a commit's measurement entirely.
+  # Closing this needs a queue that retains runs, or comparing against the last
+  # SUCCESSFULLY MEASURED commit rather than the immediate parent; either is a
+  # follow-up. Until then, treat a quiet lane during a merge burst as unproven,
+  # not as evidence of no regression, and use workflow_dispatch with explicit
+  # base_ref/head_ref to measure a commit that was skipped.
   group: perf-postmerge-${{ github.ref }}
   cancel-in-progress: false
 
@@ -177,11 +196,20 @@ jobs:
 
       - name: Record the outcome honestly
         if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
         run: |
-          if [ "${{ job.status }}" = "success" ]; then
-            echo "No gross regression detected (see ceiling above)." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "FAILED: a confirmed regression, or the A/B did not produce measurements." >> "$GITHUB_STEP_SUMMARY"
-            echo "Read the gate report in the step log before reverting: confirm the" >> "$GITHUB_STEP_SUMMARY"
-            echo "flagged groups are reachable from the merged diff." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          {
+            if [ "$JOB_STATUS" = "success" ]; then
+              echo "No gross regression detected (see ceiling above)."
+            else
+              echo "FAILED. Two different causes share this exit, and they call for"
+              echo "opposite responses, so read the step log before acting:"
+              echo
+              echo "- exit 1 — a confirmed regression. Check the flagged groups are"
+              echo "  reachable from the merged diff, then revert or justify."
+              echo "- exit 2 — the gate refused to certify: no comparison data, or"
+              echo "  nothing gating among the results. Nothing was proven about"
+              echo "  performance. Fix the measurement and re-run; do NOT revert."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -151,9 +151,13 @@ jobs:
           {
             echo "### perf post-merge A/B (${{ matrix.arch }})"
             echo
-            echo "\`$BASE\` -> \`$HEAD\`, full-mode Criterion, every group of every"
-            echo "target gated (the quick-mode informational demotion does not apply"
-            echo "in full mode)."
+            echo "\`$BASE\` -> \`$HEAD\`, full-mode Criterion."
+            echo
+            echo "**Coverage.** Every group of the two benched targets"
+            echo "(\`lattice-inference:elementwise_cpu_bench\`, \`lattice-embed:simd\`)"
+            echo "gates: the quick-mode informational demotion does not apply in full"
+            echo "mode, and this job sets no \`BENCH_GROUPS_*\` filter. The workspace's"
+            echo "other bench targets are not run here."
             echo
             echo "**Scope.** This lane DETECTS post-merge; it cannot gate the merge"
             echo "that introduced a regression, and it is not a required check."

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -1,0 +1,183 @@
+name: perf post-merge detection (informational)
+#
+# WHAT THIS IS, AND WHAT IT IS NOT (lattice#1105).
+#
+# Quick-mode PR benching demotes `lattice-embed:simd` to informational, because
+# repeated same-commit A/A runs produced confirmed-CI FAIL rows on identical
+# binaries: machine noise above quick-mode resolution, not signal. That demotion
+# is correct, but for a while three source comments claimed a "scheduled nightly
+# perf lane" covered the demoted groups at full resolution. No such job existed,
+# so those groups were gated in NEITHER mode. This workflow is that missing lane.
+#
+# It DETECTS, it does not GATE a merge. It runs AFTER a commit lands on main, so
+# by construction it cannot block the merge that introduced a regression. The
+# alert is the failed run. Do NOT add this to branch protection's required
+# checks: a post-merge job can never be satisfied pre-merge, and adding it would
+# wedge the merge queue rather than protect it.
+#
+# RESOLUTION CEILING, stated up front so this is not mistaken for fine-grained
+# coverage: GitHub-hosted runners are shared and noisy. This lane reliably
+# catches GROSS regressions (roughly the >=15% class, the magnitude that
+# motivated ADR-058's workflow in the first place). It does NOT resolve
+# sub-few-percent changes — the same noise floor that made quick-mode simd
+# unreliable applies here. A green run means "no gross regression detected", not
+# "performance is unchanged". Tightening this to sub-few-percent resolution
+# requires a dedicated quiet runner and is tracked separately; do not read the
+# absence of a FAIL as evidence of a small change's absence.
+#
+# WHY AN A/B AGAINST THE PARENT rather than against the perf-baselines branch:
+# bench-update.yml rewrites perf-baselines on every perf-path push to main, so a
+# regression can be absorbed into the baseline before any scheduled job compares
+# against it. Benching the merged commit against its own parent, both built and
+# run in the same job on the same runner, compares before that ratchet and
+# removes cross-run baseline drift. Merges are squashed, so the parent is the
+# previous main tip and the diff under test is exactly one PR.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/inference/src/forward/cpu/**'
+      - 'crates/inference/src/attention/**'
+      - 'crates/inference/benches/elementwise_cpu_bench.rs'
+      - 'crates/inference/Cargo.toml'
+      - 'crates/embed/src/simd/**'
+      - 'crates/embed/benches/simd.rs'
+      - 'crates/embed/Cargo.toml'
+      - 'Cargo.lock'
+      - 'scripts/bench-compare.sh'
+      - 'scripts/perf-bench-gate.py'
+      - 'scripts/lib/bench-informational-groups.sh'
+      - 'scripts/lib/bench-quick-informational-targets.txt'
+      - '.github/workflows/perf-postmerge-gate.yml'
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Base ref for the A/B (default: the parent commit)'
+        required: false
+        default: ''
+      head_ref:
+        description: 'Head ref for the A/B (default: HEAD)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  # One post-merge A/B at a time per arch. Timing runs must not overlap each
+  # other on a shared runner pool, and a superseded run's numbers are of no
+  # interest once a newer commit has landed.
+  group: perf-postmerge-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+
+jobs:
+  postmerge-ab:
+    name: post-merge A/B (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            arch: aarch64-linux
+    steps:
+      - name: Checkout with history
+        uses: actions/checkout@v4
+        with:
+          # bench-compare.sh creates a detached worktree at the base ref, so the
+          # base commit must actually be present. A shallow clone silently has
+          # no parent and the resolve step below would fail closed.
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: perf-postmerge-${{ matrix.arch }}
+
+      - name: Resolve the A/B endpoints
+        id: refs
+        env:
+          IN_BASE: ${{ github.event.inputs.base_ref }}
+          IN_HEAD: ${{ github.event.inputs.head_ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          HEAD_REF="${IN_HEAD:-HEAD}"
+          HEAD_SHA=$(git rev-parse "$HEAD_REF")
+
+          if [ -n "$IN_BASE" ]; then
+            BASE_SHA=$(git rev-parse "$IN_BASE")
+          elif [ -n "${EVENT_BEFORE:-}" ] \
+               && [ "$EVENT_BEFORE" != "0000000000000000000000000000000000000000" ] \
+               && git cat-file -e "${EVENT_BEFORE}^{commit}" 2>/dev/null; then
+            BASE_SHA=$(git rev-parse "$EVENT_BEFORE")
+          else
+            # Force-push, branch creation, or an unavailable before-SHA. Fall
+            # back to the first parent, which for a squashed merge is the
+            # previous main tip.
+            BASE_SHA=$(git rev-parse "${HEAD_SHA}^")
+          fi
+
+          # Fail closed on a degenerate pair rather than measuring a commit
+          # against itself and reporting the resulting silence as a pass.
+          if [ "$BASE_SHA" = "$HEAD_SHA" ]; then
+            echo "base and head resolve to the same commit ($BASE_SHA); nothing to compare" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"; then
+            echo "base $BASE_SHA is not an ancestor of head $HEAD_SHA" >&2
+            exit 1
+          fi
+
+          echo "base=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "A/B endpoints: $BASE_SHA -> $HEAD_SHA"
+
+      - name: Declare scope and resolution ceiling
+        env:
+          BASE: ${{ steps.refs.outputs.base }}
+          HEAD: ${{ steps.refs.outputs.head }}
+        run: |
+          {
+            echo "### perf post-merge A/B (${{ matrix.arch }})"
+            echo
+            echo "\`$BASE\` -> \`$HEAD\`, full-mode Criterion, every group of every"
+            echo "target gated (the quick-mode informational demotion does not apply"
+            echo "in full mode)."
+            echo
+            echo "**Scope.** This lane DETECTS post-merge; it cannot gate the merge"
+            echo "that introduced a regression, and it is not a required check."
+            echo
+            echo "**Resolution ceiling.** Hosted runners are shared and noisy. This"
+            echo "reliably catches gross regressions (roughly the >=15% class). It"
+            echo "does NOT resolve sub-few-percent changes. A green run means \"no"
+            echo "gross regression detected\", NOT \"performance is unchanged\"."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Full-mode A/B, failing on a confirmed regression
+        env:
+          BASE: ${{ steps.refs.outputs.base }}
+          HEAD: ${{ steps.refs.outputs.head }}
+        run: |
+          scripts/bench-compare.sh --full --fail-on-regression "$BASE" "$HEAD"
+
+      - name: Record the outcome honestly
+        if: always()
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "No gross regression detected (see ceiling above)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "FAILED: a confirmed regression, or the A/B did not produce measurements." >> "$GITHUB_STEP_SUMMARY"
+            echo "Read the gate report in the step log before reverting: confirm the" >> "$GITHUB_STEP_SUMMARY"
+            echo "flagged groups are reachable from the merged diff." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -132,11 +132,28 @@ jobs:
           EVENT_BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
+          # --verify --end-of-options on the two FREE-FORM inputs only.
+          # workflow_dispatch hands these straight from the user, and git accepts
+          # refnames beginning with a dash, so without the terminator a valid ref
+          # like `-perf-baseline-refresh` is read as an option.
+          #
+          # --verify is load-bearing, not decoration: `git rev-parse
+          # --end-of-options <ref>` ECHOES the literal string `--end-of-options`
+          # as an output line alongside the SHA, so command substitution would
+          # capture a two-line value and hand a corrupted ref downstream. Verified
+          # against a real dash-led branch. --verify selects the single-object
+          # output mode (as --short does in bench-compare.sh) and additionally
+          # fails closed on an unresolvable input instead of echoing it back.
+          #
+          # The two rev-parse calls below consume a github-supplied SHA and a
+          # derived SHA, which cannot take that shape, so they are deliberately
+          # left alone. bench-compare.sh protects its own four ref-consuming call
+          # sites; this step resolves these inputs before reaching the script.
           HEAD_REF="${IN_HEAD:-HEAD}"
-          HEAD_SHA=$(git rev-parse "$HEAD_REF")
+          HEAD_SHA=$(git rev-parse --verify --end-of-options "$HEAD_REF")
 
           if [ -n "$IN_BASE" ]; then
-            BASE_SHA=$(git rev-parse "$IN_BASE")
+            BASE_SHA=$(git rev-parse --verify --end-of-options "$IN_BASE")
           elif [ -n "${EVENT_BEFORE:-}" ] \
                && [ "$EVENT_BEFORE" != "0000000000000000000000000000000000000000" ] \
                && git cat-file -e "${EVENT_BEFORE}^{commit}" 2>/dev/null; then

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -39,8 +39,12 @@ set -euo pipefail
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 QUICK_FLAGS="--quick"  # ~10 samples, ~2 min total
 
-# Parse flags. Both are optional and order-independent; the first non-flag
-# argument begins the positional BASE/HEAD pair.
+# Parse flags. Both are optional and may appear in either order, but they must
+# precede the positional BASE/HEAD pair: the first non-flag argument ends flag
+# parsing. A flag written AFTER a ref is rejected rather than silently taken as
+# a ref — `bench-compare.sh HEAD~1 --full` used to resolve "--full" as HEAD_REF
+# and bench against nonsense. Use `--` to pass a ref that legitimately begins
+# with a dash.
 #
 # --fail-on-regression exists because this script is a REPORTER by default: the
 # gate invocation at the bottom ends in `|| true`, so a confirmed regression is
@@ -77,6 +81,25 @@ done
 
 BASE_REF="${1:-origin/main}"
 HEAD_REF="${2:-HEAD}"
+
+# Reject dash-led leftovers. Without this a misplaced flag becomes a ref and the
+# script benches against garbage, which is worse than refusing: it produces a
+# confident-looking A/B nobody asked for. `--` above opts out for real refs.
+for arg in "$@"; do
+  case "$arg" in
+    -*)
+      echo "bench-compare.sh: '$arg' looks like a flag but follows a positional" \
+           "argument; flags must precede BASE/HEAD (use -- for a literal ref)" >&2
+      echo "usage: bench-compare.sh [--full] [--fail-on-regression] [BASE_REF] [HEAD_REF]" >&2
+      exit 2
+      ;;
+  esac
+done
+if [ "$#" -gt 2 ]; then
+  echo "bench-compare.sh: too many positional arguments ($#); expected at most" \
+       "BASE_REF and HEAD_REF" >&2
+  exit 2
+fi
 
 # Resolve to short SHAs for display
 BASE_SHA=$(git -C "$REPO" rev-parse --short "$BASE_REF" 2>/dev/null || echo "$BASE_REF")
@@ -241,27 +264,35 @@ GATE_ARGS=(--baseline-name compare-base)
 if [ -s "$INFO_GROUPS_FILE" ]; then
   GATE_ARGS+=(--informational-groups-file "$INFO_GROUPS_FILE")
 fi
+if [ "$FAIL_ON_REGRESSION" = "1" ]; then
+  # Ask the gate to distinguish "nothing regressed" from "nothing was
+  # measured". It is the only party that can: it parses the comparisons and
+  # knows how many were judgeable. Testing for the criterion DIRECTORY here
+  # cannot work — this script creates that directory itself before benching.
+  GATE_ARGS+=(--require-measurements)
+fi
+
 GATE_RC=0
-GATE_RAN=0
 if [ -d "$HEAD_DIR/target/criterion" ]; then
-  GATE_RAN=1
   python3 "$REPO/scripts/perf-bench-gate.py" "$HEAD_DIR/target/criterion" "local-compare" "${GATE_ARGS[@]}" 2>&1 || GATE_RC=$?
+else
+  # Cannot happen via the normal path (the directory is created above), but a
+  # missing root must not read as a pass under --fail-on-regression.
+  GATE_RC=2
 fi
 
 echo ""
 echo "Done. Base=$BASE_REF ($BASE_SHA), Head=$HEAD_REF ($HEAD_SHA)"
 
-if [ "$FAIL_ON_REGRESSION" = "1" ]; then
-  # Absence of criterion output is a broken measurement, not a pass. Reporting
-  # success here would be the same defect this flag exists to remove: a green
-  # exit standing in for evidence that was never produced.
-  if [ "$GATE_RAN" = "0" ]; then
-    echo "bench-compare: --fail-on-regression set but no criterion output at" \
-         "$HEAD_DIR/target/criterion — the A/B did not produce measurements." >&2
-    exit 1
-  fi
-  if [ "$GATE_RC" -ne 0 ]; then
+if [ "$FAIL_ON_REGRESSION" = "1" ] && [ "$GATE_RC" -ne 0 ]; then
+  # Exit 1 is a confirmed regression; exit 2 is the gate refusing to certify a
+  # run it could not judge (no comparison data, or nothing gating). Both must
+  # fail the caller: a green exit standing in for evidence that was never
+  # produced is the exact defect this flag exists to remove.
+  if [ "$GATE_RC" = "2" ]; then
+    echo "bench-compare: gate could not judge this run — no usable measurements." >&2
+  else
     echo "bench-compare: gate reported a confirmed regression (exit $GATE_RC)." >&2
-    exit "$GATE_RC"
   fi
+  exit "$GATE_RC"
 fi

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -156,11 +156,26 @@ BENCH_GROUPS_EMBED="${BENCH_GROUPS_EMBED:-}"
 # exactly like a bench that produced no matching lines, and the A/B continued
 # with half its measurements missing. Verified: after `p | grep x || true`,
 # ${PIPESTATUS[0]} reads 0 even when p exited 7.
+#
+# Cargo's exit status is necessary and not sufficient. A bench invocation whose
+# Criterion filter matches no benchmark exits 0 having measured nothing, and a
+# target that emits no Criterion output contributes no comparison for the gate
+# to reconcile — absence leaves no artifact to be found missing. So each
+# invocation also reports how many measurement lines it actually printed:
+# that is the only per-target evidence available at the point where the run's
+# INTENT is known. Downstream, `perf-bench-gate.py` sees a directory tree and
+# cannot know a second target was ever supposed to be in it.
 BENCH_RC=0
+BENCH_LINES=0
 run_bench() {
   local filter="$1"; shift
   BENCH_RC=0
-  { "$@" 2>&1 | grep -E "$filter"; BENCH_RC=${PIPESTATUS[0]}; } || true
+  BENCH_LINES=0
+  local matched
+  matched="$(mktemp)"
+  { "$@" 2>&1 | grep -E "$filter" | tee "$matched"; BENCH_RC=${PIPESTATUS[0]}; } || true
+  BENCH_LINES="$(wc -l < "$matched" | tr -d ' ')"
+  rm -f "$matched"
 }
 
 # A partial A/B is not weaker evidence that nothing regressed, it is no
@@ -168,9 +183,22 @@ run_bench() {
 # (measurement broken) rather than 1 (confirmed regression) because the two ask
 # the reader for opposite responses. The reporter keeps its tolerant behavior.
 require_measured() {
-  local what="$1" rc="$2"
-  if [ "$FAIL_ON_REGRESSION" = "1" ] && [ "$rc" -ne 0 ]; then
+  local what="$1" rc="$2" lines="${3:-}"
+  if [ "$FAIL_ON_REGRESSION" != "1" ]; then
+    return 0
+  fi
+  if [ "$rc" -ne 0 ]; then
     echo "bench-compare: $what failed (exit $rc) — refusing to certify a partial A/B." >&2
+    exit 2
+  fi
+  # An invocation that exits 0 having printed no measurement line ran no
+  # benchmark (a filter that matches nothing is the ordinary way to get here).
+  # Its target then produces no Criterion comparison at all, and a gate that
+  # reconciles comparisons found against comparisons judged cannot see it:
+  # there is nothing on disk to be missing. Caught here, where the target is
+  # still named, or not at all.
+  if [ -n "$lines" ] && [ "$lines" -eq 0 ]; then
+    echo "bench-compare: $what exited 0 but produced no measurements — refusing to certify a partial A/B." >&2
     exit 2
   fi
 }
@@ -187,13 +215,13 @@ BASE_PHASE_RC=0
   # same channel and one of them silently deletes half the comparison.
   if cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} --no-run 2>/dev/null; then
     run_bench "time:" cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --save-baseline compare-base --noplot $QUICK_FLAGS
-    require_measured "base lattice-inference:$BENCHES_INFERENCE" "$BENCH_RC"
+    require_measured "base lattice-inference:$BENCHES_INFERENCE" "$BENCH_RC" "$BENCH_LINES"
   else
     require_measured "base lattice-inference:$BENCHES_INFERENCE build (--no-run)" 1
     echo "  ($BENCHES_INFERENCE not present on $BASE_SHA — skipping)"
   fi
   run_bench "time:" cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --save-baseline compare-base --noplot $QUICK_FLAGS
-  require_measured "base lattice-embed:$BENCHES_EMBED" "$BENCH_RC"
+  require_measured "base lattice-embed:$BENCHES_EMBED" "$BENCH_RC" "$BENCH_LINES"
 ) || BASE_PHASE_RC=$?
 # `exit` inside `( ... )` leaves the SUBSHELL, so the status has to be caught
 # and re-raised here or the refusal above is itself swallowed.
@@ -231,13 +259,13 @@ HEAD_PHASE_RC=0
   cd "$HEAD_DIR"
   if cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} --no-run 2>/dev/null; then
     run_bench "time:|change:" cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --baseline compare-base --noplot $QUICK_FLAGS
-    require_measured "head lattice-inference:$BENCHES_INFERENCE" "$BENCH_RC"
+    require_measured "head lattice-inference:$BENCHES_INFERENCE" "$BENCH_RC" "$BENCH_LINES"
   else
     require_measured "head lattice-inference:$BENCHES_INFERENCE build (--no-run)" 1
     echo "  ($BENCHES_INFERENCE not present on $HEAD_SHA — skipping)"
   fi
   run_bench "time:|change:" cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --baseline compare-base --noplot $QUICK_FLAGS
-  require_measured "head lattice-embed:$BENCHES_EMBED" "$BENCH_RC"
+  require_measured "head lattice-embed:$BENCHES_EMBED" "$BENCH_RC" "$BENCH_LINES"
 ) || HEAD_PHASE_RC=$?
 if [ "$HEAD_PHASE_RC" -ne 0 ]; then exit "$HEAD_PHASE_RC"; fi
 

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -39,11 +39,41 @@ set -euo pipefail
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 QUICK_FLAGS="--quick"  # ~10 samples, ~2 min total
 
-# Parse --full flag
-if [ "${1:-}" = "--full" ]; then
-  QUICK_FLAGS=""  # 100 samples, ~15 min total
-  shift
-fi
+# Parse flags. Both are optional and order-independent; the first non-flag
+# argument begins the positional BASE/HEAD pair.
+#
+# --fail-on-regression exists because this script is a REPORTER by default: the
+# gate invocation at the bottom ends in `|| true`, so a confirmed regression is
+# rendered in the report while the script still exits 0. That is correct for a
+# human reading an A/B, and completely wrong for an automated lane, where a
+# green exit beside a printed FAIL means the job passes on a real regression.
+# Opt in to propagate the gate's exit code instead. Default behavior is
+# unchanged so existing callers keep their current semantics.
+FAIL_ON_REGRESSION=0
+while [ $# -gt 0 ]; do
+  case "${1:-}" in
+    --full)
+      QUICK_FLAGS=""  # 100 samples, ~15 min total
+      shift
+      ;;
+    --fail-on-regression)
+      FAIL_ON_REGRESSION=1
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "bench-compare.sh: unknown flag '$1'" >&2
+      echo "usage: bench-compare.sh [--full] [--fail-on-regression] [BASE_REF] [HEAD_REF]" >&2
+      exit 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 BASE_REF="${1:-origin/main}"
 HEAD_REF="${2:-HEAD}"
@@ -211,9 +241,27 @@ GATE_ARGS=(--baseline-name compare-base)
 if [ -s "$INFO_GROUPS_FILE" ]; then
   GATE_ARGS+=(--informational-groups-file "$INFO_GROUPS_FILE")
 fi
+GATE_RC=0
+GATE_RAN=0
 if [ -d "$HEAD_DIR/target/criterion" ]; then
-  python3 "$REPO/scripts/perf-bench-gate.py" "$HEAD_DIR/target/criterion" "local-compare" "${GATE_ARGS[@]}" 2>&1 || true
+  GATE_RAN=1
+  python3 "$REPO/scripts/perf-bench-gate.py" "$HEAD_DIR/target/criterion" "local-compare" "${GATE_ARGS[@]}" 2>&1 || GATE_RC=$?
 fi
 
 echo ""
 echo "Done. Base=$BASE_REF ($BASE_SHA), Head=$HEAD_REF ($HEAD_SHA)"
+
+if [ "$FAIL_ON_REGRESSION" = "1" ]; then
+  # Absence of criterion output is a broken measurement, not a pass. Reporting
+  # success here would be the same defect this flag exists to remove: a green
+  # exit standing in for evidence that was never produced.
+  if [ "$GATE_RAN" = "0" ]; then
+    echo "bench-compare: --fail-on-regression set but no criterion output at" \
+         "$HEAD_DIR/target/criterion — the A/B did not produce measurements." >&2
+    exit 1
+  fi
+  if [ "$GATE_RC" -ne 0 ]; then
+    echo "bench-compare: gate reported a confirmed regression (exit $GATE_RC)." >&2
+    exit "$GATE_RC"
+  fi
+fi

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -54,6 +54,7 @@ QUICK_FLAGS="--quick"  # ~10 samples, ~2 min total
 # Opt in to propagate the gate's exit code instead. Default behavior is
 # unchanged so existing callers keep their current semantics.
 FAIL_ON_REGRESSION=0
+AFTER_DDASH=0
 while [ $# -gt 0 ]; do
   case "${1:-}" in
     --full)
@@ -65,6 +66,7 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     --)
+      AFTER_DDASH=1
       shift
       break
       ;;
@@ -84,17 +86,25 @@ HEAD_REF="${2:-HEAD}"
 
 # Reject dash-led leftovers. Without this a misplaced flag becomes a ref and the
 # script benches against garbage, which is worse than refusing: it produces a
-# confident-looking A/B nobody asked for. `--` above opts out for real refs.
-for arg in "$@"; do
-  case "$arg" in
-    -*)
-      echo "bench-compare.sh: '$arg' looks like a flag but follows a positional" \
-           "argument; flags must precede BASE/HEAD (use -- for a literal ref)" >&2
-      echo "usage: bench-compare.sh [--full] [--fail-on-regression] [BASE_REF] [HEAD_REF]" >&2
-      exit 2
-      ;;
-  esac
-done
+# confident-looking A/B nobody asked for.
+#
+# `--` opts out, and that opt-out has to be honored HERE, not just in the parser
+# above: the parser only shifts `--` away, so without this guard the very
+# arguments `--` was meant to protect land back in "$@" and are rejected by the
+# loop below. Advertising an escape hatch that the next ten lines then close is
+# worse than having none, because the diagnostic names it as the remedy.
+if [ "$AFTER_DDASH" = "0" ]; then
+  for arg in "$@"; do
+    case "$arg" in
+      -*)
+        echo "bench-compare.sh: '$arg' looks like a flag but follows a positional" \
+             "argument; flags must precede BASE/HEAD (use -- for a literal ref)" >&2
+        echo "usage: bench-compare.sh [--full] [--fail-on-regression] [BASE_REF] [HEAD_REF]" >&2
+        exit 2
+        ;;
+    esac
+  done
+fi
 if [ "$#" -gt 2 ]; then
   echo "bench-compare.sh: too many positional arguments ($#); expected at most" \
        "BASE_REF and HEAD_REF" >&2
@@ -102,8 +112,8 @@ if [ "$#" -gt 2 ]; then
 fi
 
 # Resolve to short SHAs for display
-BASE_SHA=$(git -C "$REPO" rev-parse --short "$BASE_REF" 2>/dev/null || echo "$BASE_REF")
-HEAD_SHA=$(git -C "$REPO" rev-parse --short "$HEAD_REF" 2>/dev/null || echo "$HEAD_REF")
+BASE_SHA=$(git -C "$REPO" rev-parse --short --end-of-options "$BASE_REF" 2>/dev/null || echo "$BASE_REF")
+HEAD_SHA=$(git -C "$REPO" rev-parse --short --end-of-options "$HEAD_REF" 2>/dev/null || echo "$HEAD_REF")
 
 echo "=== bench-compare: $BASE_REF ($BASE_SHA) vs $HEAD_REF ($HEAD_SHA) ==="
 
@@ -122,7 +132,7 @@ WT="$REPO/.cache/bench-compare-base"
 if [ -d "$WT" ]; then
   git -C "$REPO" worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"
 fi
-git -C "$REPO" worktree add --detach "$WT" "$BASE_REF" 2>&1 | tail -1
+git -C "$REPO" worktree add --detach --end-of-options "$WT" "$BASE_REF" 2>&1 | tail -1
 
 cleanup() {
   git -C "$REPO" worktree remove --force "$WT" 2>/dev/null || true
@@ -139,19 +149,55 @@ BENCHES_EMBED="simd"
 BENCH_GROUPS_INFERENCE="${BENCH_GROUPS_INFERENCE:-}"
 BENCH_GROUPS_EMBED="${BENCH_GROUPS_EMBED:-}"
 
+# --- Measurement-integrity helpers (only bite under --fail-on-regression) ---
+# `cargo bench ... | grep -E "time:" || true` discards cargo's status TWICE: a
+# pipeline reports its LAST command (grep), and `|| true` then resets
+# PIPESTATUS to 0. So a bench that failed to build or died mid-run looked
+# exactly like a bench that produced no matching lines, and the A/B continued
+# with half its measurements missing. Verified: after `p | grep x || true`,
+# ${PIPESTATUS[0]} reads 0 even when p exited 7.
+BENCH_RC=0
+run_bench() {
+  local filter="$1"; shift
+  BENCH_RC=0
+  { "$@" 2>&1 | grep -E "$filter"; BENCH_RC=${PIPESTATUS[0]}; } || true
+}
+
+# A partial A/B is not weaker evidence that nothing regressed, it is no
+# evidence: the target that failed is precisely the one nobody measured. Exit 2
+# (measurement broken) rather than 1 (confirmed regression) because the two ask
+# the reader for opposite responses. The reporter keeps its tolerant behavior.
+require_measured() {
+  local what="$1" rc="$2"
+  if [ "$FAIL_ON_REGRESSION" = "1" ] && [ "$rc" -ne 0 ]; then
+    echo "bench-compare: $what failed (exit $rc) — refusing to certify a partial A/B." >&2
+    exit 2
+  fi
+}
+
 # --- Build + bench base ---
 echo ""
 echo "--- Building + benching BASE ($BASE_SHA) ---"
+BASE_PHASE_RC=0
 (
   cd "$WT"
-  # Only bench what exists — some benches may not exist on older refs
+  # Only bench what exists — some benches may not exist on older refs. That
+  # tolerance is right for a human comparing against an old ref and wrong for
+  # the enforcing lane, where "absent" and "failed to compile" arrive on the
+  # same channel and one of them silently deletes half the comparison.
   if cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} --no-run 2>/dev/null; then
-    cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --save-baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:" || true
+    run_bench "time:" cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --save-baseline compare-base --noplot $QUICK_FLAGS
+    require_measured "base lattice-inference:$BENCHES_INFERENCE" "$BENCH_RC"
   else
+    require_measured "base lattice-inference:$BENCHES_INFERENCE build (--no-run)" 1
     echo "  ($BENCHES_INFERENCE not present on $BASE_SHA — skipping)"
   fi
-  cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --save-baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:" || true
-)
+  run_bench "time:" cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --save-baseline compare-base --noplot $QUICK_FLAGS
+  require_measured "base lattice-embed:$BENCHES_EMBED" "$BENCH_RC"
+) || BASE_PHASE_RC=$?
+# `exit` inside `( ... )` leaves the SUBSHELL, so the status has to be caught
+# and re-raised here or the refusal above is itself swallowed.
+if [ "$BASE_PHASE_RC" -ne 0 ]; then exit "$BASE_PHASE_RC"; fi
 
 # --- Copy base criterion data to HEAD's target ---
 echo ""
@@ -165,7 +211,7 @@ else
   if [ -d "$HEAD_WT" ]; then
     git -C "$REPO" worktree remove --force "$HEAD_WT" 2>/dev/null || rm -rf "$HEAD_WT"
   fi
-  git -C "$REPO" worktree add --detach "$HEAD_WT" "$HEAD_REF" 2>&1 | tail -1
+  git -C "$REPO" worktree add --detach --end-of-options "$HEAD_WT" "$HEAD_REF" 2>&1 | tail -1
   HEAD_DIR="$HEAD_WT"
   # Update cleanup to also remove head worktree
   trap 'git -C "$REPO" worktree remove --force "$HEAD_WT" 2>/dev/null || true; cleanup' EXIT
@@ -180,15 +226,20 @@ if [ -d "$WT/target/criterion" ]; then
   rsync -a "$WT/target/criterion/" "$HEAD_DIR/target/criterion/" 2>/dev/null || true
 fi
 
+HEAD_PHASE_RC=0
 (
   cd "$HEAD_DIR"
   if cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} --no-run 2>/dev/null; then
-    cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:|change:" || true
+    run_bench "time:|change:" cargo bench -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --baseline compare-base --noplot $QUICK_FLAGS
+    require_measured "head lattice-inference:$BENCHES_INFERENCE" "$BENCH_RC"
   else
+    require_measured "head lattice-inference:$BENCHES_INFERENCE build (--no-run)" 1
     echo "  ($BENCHES_INFERENCE not present on $HEAD_SHA — skipping)"
   fi
-  cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --baseline compare-base --noplot $QUICK_FLAGS 2>&1 | grep -E "time:|change:" || true
-)
+  run_bench "time:|change:" cargo bench -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --baseline compare-base --noplot $QUICK_FLAGS
+  require_measured "head lattice-embed:$BENCHES_EMBED" "$BENCH_RC"
+) || HEAD_PHASE_RC=$?
+if [ "$HEAD_PHASE_RC" -ne 0 ]; then exit "$HEAD_PHASE_RC"; fi
 
 # --- Quick-mode informational demotion (lattice#714 / lattice#1060) ---
 # Target-level policy: the demoted-target set lives in ONE validated

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -19,7 +19,10 @@ Exit codes:
       Criterion's two-sided 95% CI as a one-sided cutoff — see the
       WARN_PCT/FAIL_PCT note below for the actual one-sided confidence
       level this implies, which is tighter than "95%")
-  2 — parse error / bad input
+  2 — parse error / bad input, or (with --require-measurements) the gate
+      refusing to certify a run it could not judge: no comparison data, or
+      no gating comparison among the parsed results. An automated lane must
+      not read "nothing was measured" as "nothing regressed".
 
 --informational-groups-file (lattice#714): quick-mode Criterion runs on
 sub-microsecond micro-benches (lattice-embed's `simd` bench target) are
@@ -614,6 +617,48 @@ def run_selftest() -> int:
                     "informational status — resolver over-suppressed"
                 )
 
+    # --require-measurements: the lane must not read "nothing measured" as
+    # "nothing regressed" (#1105 review). bench-compare.sh creates the criterion
+    # directory itself before benching, and the cargo pipelines swallow bench
+    # failures, so an EMPTY-but-present root is the realistic failure shape.
+    with tempfile.TemporaryDirectory() as td:
+        gate = Path(__file__).resolve()
+        empty_root = Path(td) / "empty" / "criterion"
+        empty_root.mkdir(parents=True)
+
+        def _run(root: Path, *extra: str) -> subprocess.CompletedProcess:
+            return subprocess.run(
+                [sys.executable, str(gate), str(root), "selftest-arch", *extra],
+                capture_output=True, text=True, timeout=60,
+            )
+
+        # Without the flag, an absent baseline stays a pass (first-run semantics).
+        if _run(empty_root).returncode != 0:
+            failures.append("require-measurements: empty root without the flag "
+                            "must still exit 0 (first-run semantics changed)")
+        # With it, the same empty root must refuse to certify.
+        if _run(empty_root, "--require-measurements").returncode != 2:
+            failures.append("require-measurements: empty criterion root exited "
+                            "0 with the flag set — the lane can go green having "
+                            "measured nothing (the #1105 fail-open)")
+
+        # A real gating comparison must still pass, or the flag is just a brake.
+        ok_root = Path(td) / "ok" / "criterion"
+        _fabricate_bench(ok_root / "grp_ok" / "bench_ok", "compare-base")
+        if _run(ok_root, "--require-measurements").returncode != 0:
+            failures.append("require-measurements: a parsed gating comparison "
+                            "was rejected — the flag over-fails")
+
+        # All-informational is measured-but-unjudgeable: nothing could FAIL.
+        info_file = Path(td) / "informational.txt"
+        info_file.write_text("grp_info\n")
+        info_root = Path(td) / "info" / "criterion"
+        _fabricate_bench(info_root / "grp_info" / "bench_info", "compare-base")
+        if _run(info_root, "--require-measurements",
+                "--informational-groups-file", str(info_file)).returncode != 2:
+            failures.append("require-measurements: an all-informational run was "
+                            "certified — no gating comparison was judged")
+
     for f in failures:
         print(f"FAIL: {f}", file=sys.stderr)
     if failures:
@@ -621,7 +666,7 @@ def run_selftest() -> int:
         return 1
     print("SELFTEST: PASS — base/, compare-base/, orphan-warn, named-wins-over-stale-base, "
           "multi-sibling-refusal, manifest-handoff (demoted target informational, "
-          "non-demoted target gated), and composed-path collision-guard all correct")
+          "non-demoted target gated), and composed-path collision-guard, and require-measurements (empty root, gating pass, all-informational refusal) all correct")
     return 0
 
 
@@ -639,6 +684,11 @@ def main() -> int:
                     help="Path to a file listing Criterion top-level group names (one per "
                          "line) to measure+report but exclude from gating/exit-code — quick-"
                          "mode noise-floor groups (lattice#714). Omit for full-mode runs.")
+    ap.add_argument("--require-measurements", action="store_true",
+                    help="Fail (exit 2) instead of passing when the run produced no gating "
+                         "comparison to judge. Without this, an absent baseline exits 0, which "
+                         "is right for a first run but wrong for an automated lane: it cannot "
+                         "tell 'nothing regressed' from 'nothing was measured'.")
     ap.add_argument("--selftest", action="store_true",
                     help="Run the fixture self-test (no criterion_root/arch needed) and exit")
     args = ap.parse_args()
@@ -657,6 +707,11 @@ def main() -> int:
     if not change_files:
         print(f"warn: no change/estimates.json under {args.criterion_root}; baseline missing?",
               file=sys.stderr)
+        if args.require_measurements:
+            print(f"error: --require-measurements set but no change/estimates.json under "
+                  f"{args.criterion_root}: the run produced no comparison, so it is not "
+                  f"evidence that nothing regressed.", file=sys.stderr)
+            return 2
         # Treat missing baseline as pass — first run on a bench has no comparison.
         if args.out:
             args.out.write_text(f"### `{args.arch}` — no baseline to compare\n\n"
@@ -680,10 +735,17 @@ def main() -> int:
     if args.out:
         args.out.write_text(report)
 
-    fails = sum(
-        1 for r in results
-        if r.verdict() == "FAIL" and not r.is_informational(informational_groups)
-    )
+    gating = [r for r in results if not r.is_informational(informational_groups)]
+
+    # Parsed results are not automatically judgeable results. If every parsed
+    # result is informational, nothing in this run could have produced a FAIL,
+    # so a zero exit says only that no gating comparison existed.
+    if args.require_measurements and not gating:
+        print(f"error: --require-measurements set but all {len(results)} parsed result(s) are "
+              f"informational: no gating comparison was judged.", file=sys.stderr)
+        return 2
+
+    fails = sum(1 for r in gating if r.verdict() == "FAIL")
     return 1 if fails > 0 else 0
 
 

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -618,7 +618,7 @@ def run_selftest() -> int:
                 )
 
     # --require-measurements: the lane must not read "nothing measured" as
-    # "nothing regressed" (#1105 review). bench-compare.sh creates the criterion
+    # "nothing regressed" (#1105). bench-compare.sh creates the criterion
     # directory itself before benching, and the cargo pipelines swallow bench
     # failures, so an EMPTY-but-present root is the realistic failure shape.
     with tempfile.TemporaryDirectory() as td:

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -659,6 +659,35 @@ def run_selftest() -> int:
             failures.append("require-measurements: an all-informational run was "
                             "certified — no gating comparison was judged")
 
+        # PARTIAL is the shape the first fix missed: asking whether ANY judgeable
+        # comparison exists passes a run where one target compared cleanly and the
+        # other produced an unresolvable baseline. The unmeasured target is exactly
+        # the one a green exit would be vouching for.
+        mixed_root = Path(td) / "mixed" / "criterion"
+        _fabricate_bench(mixed_root / "grp_ok" / "bench_ok", "compare-base")
+        mixed_orphan = mixed_root / "grp_bad" / "bench_orphan"
+        (mixed_orphan / "new").mkdir(parents=True)
+        (mixed_orphan / "new" / "estimates.json").write_text(
+            json.dumps({"mean": {"point_estimate": 100.0}}))
+        (mixed_orphan / "change").mkdir(parents=True)
+        (mixed_orphan / "change" / "estimates.json").write_text(json.dumps({
+            "mean": {"point_estimate": 0.10,
+                     "confidence_interval": {"lower_bound": 0.05, "upper_bound": 0.15}}
+        }))
+        mixed = _run(mixed_root, "--require-measurements")
+        if mixed.returncode != 2:
+            failures.append("require-measurements: a run with one judgeable and one "
+                            "unresolvable comparison exited "
+                            f"{mixed.returncode} — a partial A/B was certified")
+        if "bench_orphan" not in mixed.stderr:
+            failures.append("require-measurements: the partial-run refusal did not "
+                            "name the unjudged bench")
+        # Without the flag the same mixed root stays a pass: the reporter is
+        # allowed to render what it has.
+        if _run(mixed_root).returncode != 0:
+            failures.append("require-measurements: the mixed root without the flag "
+                            "must still exit 0 (reporter behavior changed)")
+
     for f in failures:
         print(f"FAIL: {f}", file=sys.stderr)
     if failures:
@@ -666,7 +695,7 @@ def run_selftest() -> int:
         return 1
     print("SELFTEST: PASS — base/, compare-base/, orphan-warn, named-wins-over-stale-base, "
           "multi-sibling-refusal, manifest-handoff (demoted target informational, "
-          "non-demoted target gated), and composed-path collision-guard, and require-measurements (empty root, gating pass, all-informational refusal) all correct")
+          "non-demoted target gated), and composed-path collision-guard, and require-measurements (empty root, gating pass, all-informational refusal, partial-run refusal) all correct")
     return 0
 
 
@@ -720,10 +749,17 @@ def main() -> int:
         return 0
 
     results = []
+    unjudged = []
     for cf in change_files:
         r = parse_bench(cf, args.criterion_root, args.baseline_name)
         if r is not None:
             results.append(r)
+        else:
+            # parse_bench warns and returns None for both malformed data and an
+            # unresolvable baseline. Keep the file, not just the warning: the
+            # count of comparisons the run INTENDED is the only thing that makes
+            # a missing one visible downstream.
+            unjudged.append(cf)
 
     if not results:
         print("error: change files found but all failed to parse", file=sys.stderr)
@@ -736,6 +772,22 @@ def main() -> int:
         args.out.write_text(report)
 
     gating = [r for r in results if not r.is_informational(informational_groups)]
+
+    # Completeness, not existence. The first version of this guard asked whether
+    # ANY judgeable comparison existed, which passes a run where one target built
+    # a clean comparison and the other produced an unresolvable or malformed one:
+    # the failed target is exactly the one nobody measured, so a green exit is a
+    # claim about code that was never benched. Reconcile what the run intended
+    # (change files on disk) against what was actually judged.
+    if args.require_measurements and unjudged:
+        listed = ", ".join(str(cf.parent.parent.relative_to(args.criterion_root))
+                           for cf in unjudged[:5])
+        more = f" (+{len(unjudged) - 5} more)" if len(unjudged) > 5 else ""
+        print(f"error: --require-measurements set but {len(unjudged)} of "
+              f"{len(change_files)} comparison(s) could not be judged "
+              f"(unresolvable baseline or malformed data): {listed}{more}. A partial "
+              f"A/B is not evidence that nothing regressed.", file=sys.stderr)
+        return 2
 
     # Parsed results are not automatically judgeable results. If every parsed
     # result is informational, nothing in this run could have produced a FAIL,

--- a/tests/test_bench_compare_measurement.py
+++ b/tests/test_bench_compare_measurement.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/bench-compare.sh's measurement-integrity guard.
+
+The guard exists because cargo's exit status is necessary and not sufficient. A
+bench invocation whose Criterion filter matches nothing exits 0 having measured
+nothing, and the target then contributes no Criterion comparison at all — so a
+downstream gate that reconciles comparisons FOUND against comparisons JUDGED
+cannot see the omission: absence leaves no artifact to be found missing. The
+only place the run's intent is still known is the invocation itself.
+
+These tests drive the real script, not an extracted copy of the helper. The
+script derives its repo root from its own location, so each case builds a
+disposable git repo, copies the shipping script and its lib/ into it, and puts a
+stub `cargo` on PATH that exits 0 and prints no measurement lines — exactly the
+shape that used to pass.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "bench-compare.sh"
+LIB = REPO / "scripts" / "lib"
+
+# Exits 0 for every subcommand and prints nothing a measurement filter matches.
+STUB_CARGO = """#!/usr/bin/env bash
+exit 0
+"""
+
+
+def _run(extra_args):
+    """Run the shipping bench-compare.sh in a throwaway repo with a stub cargo."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "repo"
+        (root / "scripts").mkdir(parents=True)
+        shutil.copy2(SCRIPT, root / "scripts" / SCRIPT.name)
+        shutil.copytree(LIB, root / "scripts" / "lib")
+
+        env_git = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+                   "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+        subprocess.run(["git", "init", "-q", "-b", "main", str(root)], check=True)
+        for i in range(2):
+            (root / f"f{i}.txt").write_text(str(i))
+            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+            subprocess.run(["git", "-C", str(root), "commit", "-qm", f"c{i}"],
+                           check=True, env=env_git)
+
+        bindir = Path(tmp) / "bin"
+        bindir.mkdir()
+        cargo = bindir / "cargo"
+        cargo.write_text(STUB_CARGO)
+        cargo.chmod(0o755)
+
+        env = {**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}"}
+        return subprocess.run(
+            ["bash", str(root / "scripts" / SCRIPT.name), *extra_args, "HEAD~1", "HEAD"],
+            capture_output=True, text=True, env=env, timeout=300)
+
+
+class BenchCompareMeasurementGuard(unittest.TestCase):
+    def test_enforcing_mode_refuses_a_run_that_measured_nothing(self):
+        """A bench that exits 0 having printed no measurement must not certify.
+
+        Mutation-sensitive: drop the line-count argument from the call sites, or
+        the zero-line branch from require_measured, and this run exits 0 instead
+        of 2 -- which is precisely the partial A/B the flag exists to refuse.
+        """
+        result = _run(["--fail-on-regression"])
+        self.assertEqual(
+            result.returncode, 2,
+            f"expected exit 2 (measurement broken), got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertIn("produced no measurements", result.stderr)
+
+    def test_reporter_mode_is_unchanged_by_the_guard(self):
+        """Without the flag the script stays tolerant: the guard must not bite.
+
+        The default caller is a human reading an A/B against an arbitrary ref,
+        where a missing bench target is ordinary. Pinning this stops a later
+        tightening from silently becoming the default.
+        """
+        result = _run([])
+        self.assertNotEqual(
+            result.returncode, 2,
+            f"reporter mode must not exit 2\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}")
+        self.assertNotIn("produced no measurements", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Builds the detection lane tracked in #1105, and fixes the swallow that would have made it decorative.

## The swallow

`scripts/bench-compare.sh` ends its gate invocation with `python3 scripts/perf-bench-gate.py ... || true`. It renders the FAIL section and still exits 0. For a human reading an A/B that is correct. For an automated lane it is the exact defect #1105 is about: a job that prints a red FAIL in its log and reports the step as passed.

This adds an opt-in `--fail-on-regression` that propagates the gate's exit code. Default behavior is unchanged, so every existing caller keeps its current semantics.

## The same swallow, three times more, each one level down

This PR's own guard failed open twice while it was being built, each time in the shape it exists to prevent. Both are worth stating rather than quietly fixing, because the shape is the interesting part.

**First, nothing measured passed.** The guard asked whether `target/criterion` existed. This script creates that directory itself, with `mkdir -p`, before any bench runs. The `cargo bench` pipelines end in `|| true` so a failed or skipped bench is swallowed, and `perf-bench-gate.py` returns 0 for a root containing no `change/estimates.json` — correct by design, because a first run has no baseline to compare against. Every link behaved as designed and the composition let a run that measured nothing exit 0. The guard was reading its own side effect as evidence about the benchmark.

**Then, partially measured passed.** The replacement asked whether *any* judgeable comparison existed. That still certifies a run where one target compared cleanly and the other produced an unresolvable baseline: the failed target is precisely the one nobody measured, and a green exit is a claim about code that was never benched. Existence was standing in for completeness.

**Then, a target that measured nothing passed.** Reconciling comparisons *found* against comparisons *judged* catches a comparison that failed to resolve, and is structurally blind to a target that produced no comparison to find: absence leaves no artifact to be missing. Verified by execution against a Criterion root holding a single valid `simd` comparison and nothing from the inference target — the gate exits 0 and certifies an A/B in which an entire bench target was never measured. Cargo's status does not catch it either, because a bench invocation whose Criterion filter matches nothing exits 0 having run nothing.

The gate is the wrong layer for this one and no amount of patching there fixes it: it is handed a directory tree and cannot know a second target was ever supposed to be in it. So the check moved to the invocation, which is the only point where the run's intent is still known and the target is still named — each bench invocation now reports how many measurement lines it actually printed, and under `--fail-on-regression` a run that exits 0 having printed none is refused with exit 2. Reporter mode is untouched: a missing bench target is ordinary when a human compares against an arbitrary ref.

Its test drives the shipping script in a disposable repo against a stub cargo rather than an extracted copy of the helper, so it exercises the real parser-to-guard path, and CI runs it beside the other harness-plumbing checks.

Both halves were discarding the evidence they needed.

The shell discarded cargo's status twice over. A pipeline reports its *last* command, which is `grep`, and `|| true` then resets `PIPESTATUS`. Verified directly: after `p | grep x || true`, `${PIPESTATUS[0]}` reads 0 even when `p` exited 7. A bench that failed to build was indistinguishable from one that printed no matching lines. Cargo's status is now captured inside the group and re-raised. The `--no-run` guard had the same defect in a different dress: "target absent on an older ref" and "target failed to compile" arrive on one channel, so the reporter may keep tolerating both while the enforcing lane may not.

The gate discarded its own skips. `parse_bench` returns `None` for malformed data and for an unresolvable baseline alike, warns, and the caller dropped it on the floor. It now reconciles comparisons *found* against comparisons *judged*; under `--require-measurements` any unjudged one is exit 2, naming the bench.

`bench-compare.sh` passes that flag only under `--fail-on-regression`, so the first-run "no baseline yet" pass that other callers rely on is untouched. Exit 1 and exit 2 both fail the caller, and the job summary spells out that they call for opposite responses: exit 1 means revert or justify, exit 2 means the measurement is broken and nothing was proven about performance.

## Why an A/B against the parent, not against `perf-baselines`

`make bench-gate` compares against the `perf-baselines` branch, which `bench-update.yml` rewrites on every perf-path push to main. A regression can therefore be absorbed into the baseline before any scheduled job compares against it. Benching the merged commit against its own parent compares before that ratchet. Merges here are squashed, so the parent is the previous main tip and the diff under test is exactly one PR. Both arms also build and run in the same job on the same runner, which removes cross-run baseline drift.

## Scope, stated where it cannot be missed

The lane **detects** post-merge. It cannot gate the merge that introduced a regression, so it must not be added to branch protection's required checks; a post-merge job can never be satisfied pre-merge.

Hosted runners are shared and noisy. This catches gross regressions (roughly the 15%-and-above class, the magnitude ADR-058's workflow was built for) and does **not** resolve sub-few-percent changes, the same noise floor that made quick-mode simd unreliable. A green run means "no gross regression detected", not "performance is unchanged". That ceiling appears in the workflow header and is printed into every run's job summary, so it travels with the result rather than living only in a PR description.

Full mode ignores the quick-mode informational demotion, so `lattice-embed:simd` is included. Every group of the two benched targets (`lattice-inference:elementwise_cpu_bench`, `lattice-embed:simd`) is gated, because this job sets no `BENCH_GROUPS_*` filter. The workspace's other bench targets are not run here.

## Known gap, documented rather than implied away

GitHub keeps only one pending run per concurrency group. If two commits land while a run is in flight, the first one's pending run is replaced, and the survivor compares against it — so a regression introduced by the skipped commit sits in both arms and is invisible. During a rapid merge burst, a quiet lane is unproven, not evidence of no regression. `workflow_dispatch` with explicit `base_ref`/`head_ref` measures a commit that was skipped. Closing this properly needs a queue that retains runs, or comparison against the last successfully measured commit; either is a follow-up.

## Additional hardening in the same area

- **The `--` escape was advertised and did not work.** The parser shifted `--` away and a dash-leftover check ten lines later re-inspected the very arguments `--` existed to protect, so `-- --dash-led-ref` was rejected by the diagnostic that names `--` as the remedy. An escape hatch that the next ten lines close is worse than none. It is honored now, and the four git call sites that consume a ref pass `--end-of-options` so a dash-led ref survives git's own option parsing.
- **The job summary could not tell exit 1 from exit 2.** It read `job.status`, which holds only `success`/`failure`/`cancelled`. A checkout, toolchain, or endpoint-resolution failure was therefore reported to the reader as "confirmed regression — revert or justify" for a run that never benched. The A/B step now records its actual exit code and the summary explains only codes it saw, with a distinct message for "failed before reaching a verdict".
- **`--selftest` now runs in CI.** An earlier revision's commit message said CI re-ran these cases; no workflow invoked it. It is wired into the existing script-validation job alongside the other script self-tests, and is confirmed executing on this branch's runs.

- **The workflow's own ref inputs terminate option parsing.** `bench-compare.sh` protects its four ref-consuming git call sites, but this workflow resolves `base_ref`/`head_ref` *before* it calls the script, and those two `rev-parse` calls had no terminator, so a legal dash-led ref supplied to `workflow_dispatch` was read as an option. `--verify` is load-bearing rather than stylistic there: `git rev-parse --end-of-options <ref>` echoes the literal string `--end-of-options` as an output line beside the SHA, so plain command substitution captures a two-line value and passes a corrupted ref downstream, which is worse than the original failure because it does not fail loudly. `--verify` selects the single-object output mode, the same reason `--short` suffices inside the script.
- Flag parsing rejects a misplaced flag instead of benching garbage. `bench-compare.sh HEAD~1 --full` resolved `--full` as `HEAD_REF` and started a real A/B against a nonsense ref. Confirmed by running it.
- Trigger coverage: root `Cargo.toml` can carry `[profile.bench]` (it does not today) and `.cargo/` can carry rustflags, either of which changes bench codegen without touching crate source. Both added, along with the two helper scripts `bench-compare.sh` invokes.
- Grouped the summary redirects (actionlint SC2129).

Actions are referenced by tag here, matching every other workflow in this repo. Pinning to commit SHAs is worth doing, but as a repo-wide change rather than a one-off in a new file that would imply a policy the repo does not have.

## Merge-order dependency on #1111

These two touch the same file and the same claim, in opposite directions, so the second one to land has work to do.

#1111 adds a vocabulary block to `bench-compare.sh` defining measured / reported / classified gating / enforced, and states that the script is REPORT-ONLY in both modes because it discards its gate's exit status. That is true of `main` today and false the moment this PR lands: `--fail-on-regression` is exactly the mode that enforces.

So whichever merges second must update that wording in the same change, describing the default and opt-in modes separately rather than making one blanket claim. If this PR lands second, that edit belongs in its rebase. Flagging it here because a comment that silently goes stale at merge is the same class of defect both of these PRs exist to remove.

## Verification

What was executed, and by what method:

- **The enforcing path, end to end on the real script.** With an absent inference bench target, `--fail-on-regression` exits 2, names the failed target, produces zero benchmark output lines, and leaves no worktree residue. This exercises the subshell status propagation that an earlier revision lacked, without running a benchmark.
- **The partial-A/B refusal, and its mutation sensitivity.** A fixture with one valid gating comparison and one unresolvable baseline exits 2 and names the unjudged bench. Reverting the refusal makes that self-test case fail with exactly that message; restoring it passes.
- **The no-measurement fail-open, reproduced and then closed.** `perf-bench-gate.py` against an empty criterion root exits 0 before the fix and 2 with `--require-measurements`. Six cases now live in `--selftest`: empty root passes without the flag (first-run semantics preserved) and fails with it; a real gating comparison still passes, so the flag is not merely a brake; an all-informational run is refused; the mixed root is refused with the flag and still passes without it.
- **Gate returns nonzero on a real regression.** A criterion fixture at 20 percent regression with CI-lower above the 7 percent threshold exits 1. Control: the same fixture at half a percent exits 0, so the fixture discriminates rather than always failing.
- **`PIPESTATUS` after `|| true`.** Measured, not assumed: it reads 0 for a command that exited 7, which is why the capture had to move inside the group.
- **Dash-led refs, against a real branch.** In a disposable repository with a branch actually named with a leading dash: the bare form resolves to two lines, the `--verify` form to one line matching the branch tip, and `git worktree add --end-of-options` accepts the same ref. This is why the workflow uses `--verify` and the script's `--short` sites do not need it.
- **Argument handling on the real script.** A flag after a positional, an unknown flag, and surplus positionals each exit 2 with a usage message. `-- --dash-led-ref` now reaches git, which reports `invalid reference` rather than `unknown option` — the discriminator showing the ref survived option parsing.
- `bash -n` clean, both workflows parse, and `actionlint` is clean.

Not claimed: no live end-to-end A/B in which a genuine regression drives the real script to a nonzero exit, and no execution of the default-mode shell path for an absent target, whose only route starts a real benchmark. Calling either verified would be the kind of overclaim this PR exists to remove.

No crate source is touched, so no bench-compare disposition applies.

