### PR TITLE
docs(bench): name the real exit-status mechanism, not a bare discard

### DIFF
--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -21,8 +21,9 @@
 # appear in the report; CLASSIFIED GATING (vs informational) if a regression
 # in it contributes to the report's FAIL verdict; and ENFORCED only if that
 # FAIL verdict reaches the caller as a non-zero exit status. Classification
-# is not enforcement: by default this script computes a verdict and then
-# discards its exit status, so --quick and --full are both REPORT-ONLY.
+# is not enforcement: by default this script computes a verdict, captures the
+# gate's exit status, and does not act on it, so --quick and --full are both
+# REPORT-ONLY.
 # Enforcement is opt-in per invocation via --fail-on-regression, which
 # propagates the gate's status instead; `make bench-gate` also enforces.
 # Use these words literally below.
@@ -46,10 +47,11 @@
 # to distinguish a real simd regression from machine noise. Three caveats
 # keep that from meaning "a regression cannot get past this".
 #
-# Enforcement: neither mode enforces BY DEFAULT. This script ends its gate
-# invocation with `|| true`, so a FAIL verdict is printed and then discarded,
-# and the script exits 0 either way — which is why the demotion below is a
-# resolution split rather than a coverage hole in the default path. Two
+# Enforcement: neither mode enforces BY DEFAULT. The gate's exit status is
+# captured into GATE_RC at the bottom and re-raised only under
+# --fail-on-regression, so by default a FAIL verdict is printed and the script
+# still exits 0 — which is why the demotion below is a resolution split rather
+# than a coverage hole in the default path. Two
 # callers do enforce: --fail-on-regression propagates the gate's status (exit
 # 1 confirmed regression, exit 2 the measurement itself is broken), and
 # `make bench-gate` runs the same two default targets unfiltered against the
@@ -89,8 +91,9 @@ QUICK_FLAGS="--quick"  # ~10 samples, ~2 min total
 # with a dash.
 #
 # --fail-on-regression exists because this script is a REPORTER by default: the
-# gate invocation at the bottom ends in `|| true`, so a confirmed regression is
-# rendered in the report while the script still exits 0. That is correct for a
+# gate invocation at the bottom captures its status into GATE_RC and re-raises
+# it only under this flag, so a confirmed regression is rendered in the report
+# while the script still exits 0. That is correct for a
 # human reading an A/B, and completely wrong for an automated lane, where a
 # green exit beside a printed FAIL means the job passes on a real regression.
 # Opt in to propagate the gate's exit code instead. Default behavior is


### PR DESCRIPTION
## What

Three sentences in `scripts/bench-compare.sh`'s header described the default report-only behavior as the gate invocation "ending in `` `|| true` ``". That construct is not there. The gate's status is captured into `GATE_RC` and re-raised only under `--fail-on-regression`, so the discard is conditional rather than unconditional.

The conclusion those sentences draw is unchanged and still correct: both modes are report-only by default. Only the cited mechanism was stale, left over from before the exit handling changed underneath it.

## Why it is worth a PR rather than a note

The wording does not merely fail to inform, it misdirects. A reader who searches this file for `` `|| true` `` on the strength of those sentences lands on the bench-run pipeline, where the construct is deliberately paired with a `PIPESTATUS` capture so the status is **preserved**, and which carries its own comment block existing solely to prevent that misreading. Aiming a reader at a construct whose meaning is the inverse of the one being illustrated is worse than saying nothing, in a file whose header exists to make exactly that distinction precise.

## Scope

Three occurrences, not two: the enforcement paragraph, the `--fail-on-regression` rationale, and one more in the vocabulary block that describes the same behavior without using the phrase. The conditional statements in `scripts/lib/bench-informational-groups.sh` and `scripts/lib/bench-quick-informational-targets.txt` are accurate as written and are left alone.

## Verification

- `bash -n scripts/bench-compare.sh`: clean.
- `python3 scripts/perf-bench-gate.py --selftest`: PASS.
- `python3 tests/test_bench_compare_measurement.py`: PASS.
- No remaining prose in `scripts/` or `.github/` cites a bare discard of the gate's status.

Comments only: no changed line falls outside a comment, so there is no behavioral delta, and no crate source is touched, so no bench-compare disposition applies.

Follows #1111.
