### PR TITLE
ci: pin actions to SHAs, stop trusting remote model code, and fix miscited rationale

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/adr064-gpu-decode-nightly.yml
+++ b/.github/workflows/adr064-gpu-decode-nightly.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: main
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload current JSON + gate report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: adr064-gpu-decode-nightly-${{ github.run_id }}
           path: |

--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       bins: ${{ steps.filter.outputs.bins }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - id: filter
@@ -96,9 +96,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: app-binaries
       - name: Build all app-shipped binaries (required-features included)

--- a/.github/workflows/bench-evidence.yml
+++ b/.github/workflows/bench-evidence.yml
@@ -55,7 +55,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         # Pinned to a full commit SHA: this is a pull_request_target job, so a
         # moved or compromised tag would run in the trusted context before the
-        # checker does. SHA is actions/checkoutd5960a326750d5838078e36cf38b85af677262 # v4 v4 (the v4 tag as of 2026-07-20).
+        # checker does. SHA is actions/checkout v4 (the v4 tag as of 2026-07-20).
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/bench-evidence.yml
+++ b/.github/workflows/bench-evidence.yml
@@ -55,7 +55,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         # Pinned to a full commit SHA: this is a pull_request_target job, so a
         # moved or compromised tag would run in the trusted context before the
-        # checker does. SHA is actions/checkout v4 (the v4 tag as of 2026-07-20).
+        # checker does. SHA is actions/checkoutd5960a326750d5838078e36cf38b85af677262 # v4 v4 (the v4 tag as of 2026-07-20).
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/bench-update.yml
+++ b/.github/workflows/bench-update.yml
@@ -46,13 +46,13 @@ jobs:
             arch: aarch64-linux
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0  # need history for commit SHA + dates
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           shared-key: bench-${{ matrix.arch }}
@@ -77,7 +77,7 @@ jobs:
             --out artifacts/snapshot.json
 
       - name: Upload baseline + snapshot
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bench-data-${{ matrix.arch }}
           path: |
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main (for scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -124,7 +124,7 @@ jobs:
           fi
 
       - name: Download all bench artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: bench-artifacts/
 

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -62,7 +62,7 @@ jobs:
     outputs:
       deps: ${{ steps.filter.outputs.deps }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - id: filter
@@ -101,12 +101,12 @@ jobs:
     if: needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
       - name: Pin the real toolchain bin on PATH
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
       - name: Cache cargo-audit binary
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-bin-${{ runner.os }}-v0.22.2
@@ -124,12 +124,12 @@ jobs:
     if: needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
       - name: Pin the real toolchain bin on PATH
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
       - name: Cache cargo-audit binary
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-bin-${{ runner.os }}-v0.22.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - id: filter
@@ -111,8 +111,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
         with:
           components: rustfmt, clippy
       - name: Pin the real toolchain bin on PATH
@@ -123,7 +123,7 @@ jobs:
         # later step (cache, clean, ci.sh) gets a working cargo. No-op on healthy
         # images and on Linux.
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
       - name: Clean lattice crates (force rebuild, keep dep cache)
@@ -152,13 +152,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
         with:
           components: clippy
       - name: Pin the real toolchain bin on PATH
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: feature-matrix
           cache-on-failure: true
@@ -188,6 +188,20 @@ jobs:
         run: cargo build -p lattice-inference --features wgpu-gpu
       - name: fann — no default features
         run: cargo build -p lattice-fann --no-default-features
+      # `-p lattice-embed` is the only invocation that resolves lattice-embed's
+      # `lattice-inference` dependency features in isolation. Any --workspace
+      # command (including this job's own sibling steps and scripts/ci.sh's
+      # `cargo test --workspace`) also builds lattice-tune, whose Cargo.toml
+      # requests `lattice-inference/f16` unconditionally — feature unification
+      # then grants lattice-embed f16 for free regardless of what
+      # crates/embed/Cargo.toml itself declares. That is how the native/wasm
+      # dependency tables drifted apart silently before (#1094): every green
+      # --workspace run was testing a configuration the standalone crate never
+      # gets. Run this test target alone so it actually resolves the table a
+      # standalone `cargo build -p lattice-embed` (or `cargo install
+      # lattice-embed`, or the wasm/npm build) would get. See #1095.
+      - name: embed — f16 native dependency load guard (standalone, no workspace unification)
+        run: cargo test -p lattice-embed --test f16_feature_load_guard
       # Metal kernels only exist on macOS; gate so Linux does not try to build them.
       - name: inference — metal-gpu (macOS only)
         if: runner.os == 'macOS'
@@ -428,11 +442,11 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
       - name: Pin the real toolchain bin on PATH
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: bench-compile
           cache-on-failure: true
@@ -464,11 +478,11 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: "1.93.1"
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.93.1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@683cb613d4ff7d29ceb2fe421b81294b4319512a # 1.93.1
       - name: Pin the real toolchain bin on PATH
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: msrv
           cache-on-failure: true
@@ -485,13 +499,13 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: licenses + bans + sources (required)
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
         with:
           command: check licenses bans sources
       - name: advisories (informational)
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
         continue-on-error: true
         with:
           command: check advisories
@@ -506,11 +520,11 @@ jobs:
     name: rustdoc-lint (informational)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
       - name: Pin the real toolchain bin on PATH
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: rustdoc-lint
           cache-on-failure: true
@@ -534,13 +548,13 @@ jobs:
     name: unwrap-in-lib-lint (informational)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
         with:
           components: clippy
       - name: Pin the real toolchain bin on PATH
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: unwrap-in-lib-lint
           cache-on-failure: true
@@ -555,8 +569,8 @@ jobs:
     name: typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.48.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
 
   # Cheap ubuntu workflow/config lint. Catches malformed expressions, unknown
   # contexts/inputs, shellcheck-level issues, and changed-file range regressions
@@ -566,8 +580,8 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: raven-actions/actionlint@v2.2.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
         with:
           version: '1.7.12'
       - name: merge-queue config tests
@@ -595,8 +609,8 @@ jobs:
     name: decode-harness-unit-tests (no engine)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - name: python3 tests/test_bench_decode_harness.py
@@ -641,15 +655,15 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: semver-checks
       # metal-gpu does not compile on Linux and must stay off; default-features
       # keeps the check to each crate's own `[features] default = [...]` set
       # rather than the action's heuristic all-features-ish default, which
       # would otherwise try to turn on optional platform-gated features.
-      - uses: obi1kenobi/cargo-semver-checks-action@v2
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
         with:
           package: lattice-fann,lattice-transport,lattice-inference,lattice-embed,lattice-tune
           feature-group: default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,18 +188,21 @@ jobs:
         run: cargo build -p lattice-inference --features wgpu-gpu
       - name: fann — no default features
         run: cargo build -p lattice-fann --no-default-features
-      # `-p lattice-embed` is the only invocation that resolves lattice-embed's
-      # `lattice-inference` dependency features in isolation. Any --workspace
-      # command (including this job's own sibling steps and scripts/ci.sh's
-      # `cargo test --workspace`) also builds lattice-tune, whose Cargo.toml
-      # requests `lattice-inference/f16` unconditionally — feature unification
-      # then grants lattice-embed f16 for free regardless of what
-      # crates/embed/Cargo.toml itself declares. That is how the native/wasm
-      # dependency tables drifted apart silently before (#1094): every green
-      # --workspace run was testing a configuration the standalone crate never
-      # gets. Run this test target alone so it actually resolves the table a
-      # standalone `cargo build -p lattice-embed` (or `cargo install
-      # lattice-embed`, or the wasm/npm build) would get. See #1095.
+      # Run this target alone. `-p lattice-embed` resolves lattice-embed's own
+      # `lattice-inference` feature table in isolation, which is the configuration
+      # a standalone `cargo build -p lattice-embed`, `cargo install lattice-embed`,
+      # or the wasm/npm build actually gets — and the one that drifted in #1094.
+      #
+      # Two things keep this out of the workspace-wide runs. The failure is
+      # runtime-only: `SafetensorsFile` returns `InvalidSafetensors` for a
+      # half-precision tensor rather than failing to build, so the `--no-run`
+      # steps above cannot observe it. And lattice-tune's optional
+      # `lattice-inference` dependency carries `features = ["f16"]`, so any
+      # invocation that activates tune's `inference-hook` or `train-backward`
+      # alongside lattice-embed unifies that `f16` into embed for free and the
+      # regression reads green. Neither tune feature is in its defaults today, so
+      # `cargo test --workspace` does not do this — but nothing enforces that,
+      # which is why the guard runs on the isolated resolve instead. See #1095.
       - name: embed — f16 native dependency load guard (standalone, no workspace unification)
         run: cargo test -p lattice-embed --test f16_feature_load_guard
       # Metal kernels only exist on macOS; gate so Linux does not try to build them.

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -61,7 +61,7 @@ jobs:
       engine: ${{ steps.filter.outputs.engine }}
       tune: ${{ steps.filter.outputs.tune }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - id: filter
@@ -109,20 +109,20 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Cache Python packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/Library/Caches/pip
           key: layer23-golden-pip-${{ runner.os }}-py311-v1
 
       - name: Cache HF model weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
           # Derived from the provisioning action so the cache cannot outlive the
@@ -144,8 +144,8 @@ jobs:
           mkdir -p "$RUNNER_TEMP/lattice-models"
           ln -sf "${{ steps.provision.outputs.model-dir }}" "$RUNNER_TEMP/lattice-models/qwen3.5-0.8b"
 
-      - uses: dtolnay/rust-toolchain@1.94.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: layer23-golden
 
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload layer-23 bridge report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: layer23-golden-${{ github.sha }}
           path: ${{ runner.temp }}/layer23-golden-report.txt
@@ -180,20 +180,20 @@ jobs:
     # the slow tail of the runner pool.
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Cache Python packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/Library/Caches/pip
           key: e2e-pip-${{ runner.os }}-py311-v1
 
       - name: Cache HF model weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
           # Derived from the provisioning action so the cache cannot outlive the
@@ -225,8 +225,8 @@ jobs:
           ln -sf "${{ steps.provision.outputs.model-dir }}" ~/.lattice/models/qwen3.5-0.8b
 
       # Step 4: build lattice
-      - uses: dtolnay/rust-toolchain@1.94.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: e2e-parity
 
@@ -247,7 +247,7 @@ jobs:
       # Step 6: post results as PR comment
       - name: Post parity report
         if: github.event_name == 'pull_request' && always()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: e2e-parity
           path: parity-report.md
@@ -301,20 +301,20 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Cache Python packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/Library/Caches/pip
           key: e2e-pip-${{ runner.os }}-py311-v1
 
       - name: Cache HF model weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
           # Derived from the provisioning action so the cache cannot outlive the
@@ -336,9 +336,9 @@ jobs:
           mkdir -p ~/.lattice/models
           ln -sf "${{ steps.provision.outputs.model-dir }}" ~/.lattice/models/qwen3.5-0.8b
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: e2e-metal-parity
 
@@ -364,7 +364,7 @@ jobs:
 
       - name: Post Metal parity report
         if: github.event_name == 'pull_request' && always()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: e2e-metal-parity
           path: metal-parity-report.md
@@ -399,16 +399,16 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: embed-drift
 
       - name: Cache BGE-small weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.lattice/models/bge-small-en-v1.5
           key: bge-small-en-v1.5-v1
@@ -446,18 +446,18 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: wasm-parity
 
       - name: Cache wasm-bindgen-cli
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/wasm-bindgen
           key: wasm-bindgen-cli-0.2.105-${{ runner.os }}
@@ -475,13 +475,13 @@ jobs:
           fi
 
       - name: Cache bge-small-en-v1.5 weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.lattice/models/bge-small-en-v1.5
           key: bge-small-en-v1.5-wasm-v1
 
       - name: Cache all-minilm-l6-v2 weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.lattice/models/all-minilm-l6-v2
           key: all-minilm-l6-v2-wasm-v1
@@ -525,18 +525,18 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: wasm-simd128-parity
 
       - name: Cache wasm-bindgen-cli
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/wasm-bindgen
           key: wasm-bindgen-cli-0.2.105-${{ runner.os }}
@@ -622,20 +622,20 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Cache Python packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/Library/Caches/pip
           key: q4-composed-pip-${{ runner.os }}-py311-v1
 
       - name: Cache HF model weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
           # Derived from the provisioning action so the cache cannot outlive the
@@ -659,8 +659,8 @@ jobs:
           mkdir -p ~/.lattice/models
           ln -sf "${{ steps.provision.outputs.model-dir }}" ~/.lattice/models/qwen3.5-0.8b
 
-      - uses: dtolnay/rust-toolchain@1.94.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: q4-composed
 
@@ -725,20 +725,20 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Cache Python packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/Library/Caches/pip
           key: e2e-pip-${{ runner.os }}-py311-v1
 
       - name: Cache HF model weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
           # Derived from the provisioning action so the cache cannot outlive the
@@ -760,8 +760,8 @@ jobs:
           mkdir -p ~/.lattice/models
           ln -sf "${{ steps.provision.outputs.model-dir }}" ~/.lattice/models/qwen3.5-0.8b
 
-      - uses: dtolnay/rust-toolchain@1.94.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: vision-s3-gate
 
@@ -845,8 +845,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - name: Run ppl-gate control-flow self-test
@@ -885,20 +885,20 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Cache Python packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/Library/Caches/pip
           key: q4-composed-pip-${{ runner.os }}-py311-v1
 
       - name: Cache HF model weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
           # Derived from the provisioning action so the cache cannot outlive the
@@ -920,8 +920,8 @@ jobs:
           mkdir -p ~/.lattice/models
           ln -sf "${{ steps.provision.outputs.model-dir }}" ~/.lattice/models/qwen3.5-0.8b
 
-      - uses: dtolnay/rust-toolchain@1.94.1
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: q4-ppl-quality
 
@@ -961,7 +961,7 @@ jobs:
 
       - name: Post PPL gate report
         if: github.event_name == 'pull_request' && always()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: q4-ppl-gate
           path: ppl-gate-report.md

--- a/.github/workflows/embed-parity-release.yml
+++ b/.github/workflows/embed-parity-release.yml
@@ -41,36 +41,36 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: embed-parity-release
 
       # Weights are immutable, so the cache keys never need to change unless a
       # model revision is bumped (then bump the matching key suffix).
       - name: Cache bge-small-en-v1.5 weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.lattice/models/bge-small-en-v1.5
           key: bge-small-en-v1.5-v1
 
       - name: Cache multilingual-e5-small weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.lattice/models/multilingual-e5-small
           key: multilingual-e5-small-v1
 
       - name: Cache all-minilm-l6-v2 weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.lattice/models/all-minilm-l6-v2
           key: all-minilm-l6-v2-v1
 
       - name: Cache paraphrase-multilingual-minilm-l12-v2 weights
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.lattice/models/paraphrase-multilingual-minilm-l12-v2
           key: paraphrase-multilingual-minilm-l12-v2-v1

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -110,16 +110,16 @@ jobs:
             arch: aarch64-linux
     steps:
       - name: Checkout with history
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # bench-compare.sh creates a detached worktree at the base ref, so the
           # base commit must actually be present. A shallow clone silently has
           # no parent and the resolve step below would fail closed.
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           shared-key: perf-postmerge-${{ matrix.arch }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -49,18 +49,18 @@ jobs:
             target: aarch64-unknown-linux-gnu
             features: f16
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
 
       - name: Pin the real toolchain bin on PATH
         # See ci.yml: some macos-latest images ship a rustup-init shim as
         # ~/.cargo/bin/cargo rather than the rustup proxy.
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-binaries-${{ matrix.target }}
 

--- a/crates/embed/benches/simd.rs
+++ b/crates/embed/benches/simd.rs
@@ -750,15 +750,17 @@ fn bench_int8_prepared_dot_product(c: &mut Criterion) {
 }
 
 // ============================================================================
-// ROUND 3: NORMALIZED COSINE FAST PATH BENCHMARKS (H1 baseline)
+// NORMALIZED-COSINE FAST-PATH HEADROOM
 // ============================================================================
 
-/// Baseline for normalized-cosine fast path (Round 3, Hypothesis 1).
-///
-/// Compares full cosine (two norm ops + division) vs dot product on pre-normalized
-/// unit vectors at [384, 768, 1024] dims. Shows the theoretical speedup available.
-/// After i2 adds `approximate_cosine_distance_prepared_with_meta`, it should
-/// approach dot-product speed on the same unit corpus.
+/// Cosine similarity between two already-unit-normalized vectors reduces to a
+/// bare dot product — no norm computation or division needed. `cosine_full`
+/// still pays for the general two-norm-and-divide path; `dot_product` is the
+/// floor a unit-aware fast path could reach on the same corpus. The gap
+/// between the two groups at [384, 768, 1024] dims is the headroom a
+/// unit-normalization hint has to recover, which is what
+/// `approximate_cosine_distance_prepared_with_meta`'s `NormalizationHint::Unit`
+/// path (benchmarked below in `bench_prepared_query_normalized_cosine`) exists to close.
 fn bench_normalized_cosine_fast_path(c: &mut Criterion) {
     const BENCH_DIMS: [usize; 3] = [384, 768, 1024];
     let mut group = c.benchmark_group("simd_normalized_cosine_fast_path");
@@ -782,14 +784,14 @@ fn bench_normalized_cosine_fast_path(c: &mut Criterion) {
 }
 
 // ============================================================================
-// ROUND 3: SQUARED EUCLIDEAN FAST PATH BENCHMARKS (H3 baseline)
+// SQUARED-EUCLIDEAN FAST-PATH HEADROOM
 // ============================================================================
 
-/// Baseline for squared-L2 fast path (Round 3, Hypothesis 3).
-///
-/// Measures `euclidean_distance` (with final sqrt) at [384, 768, 1024] dims.
-/// After i2 adds `simd::squared_euclidean_distance`, this becomes a before/after
-/// comparison: squared variant skips the sqrt and is used for HNSW internal ordering.
+/// `euclidean_distance` computes squared distance then takes a final `sqrt`;
+/// `squared_euclidean_distance` skips it. HNSW's internal candidate ordering
+/// only needs relative distance, so it uses the squared variant — the
+/// `squared_euclidean` group here is that same computation, and the gap to
+/// `euclidean_full` is the cost of the `sqrt` per comparison.
 fn bench_squared_euclidean_fast_path(c: &mut Criterion) {
     const BENCH_DIMS: [usize; 3] = [384, 768, 1024];
     let mut group = c.benchmark_group("simd_squared_euclidean_fast_path");

--- a/crates/embed/tests/f16_feature_load_guard.rs
+++ b/crates/embed/tests/f16_feature_load_guard.rs
@@ -1,0 +1,81 @@
+//! Guards against the `lattice-embed` native `lattice-inference` dependency
+//! table losing the `f16` feature (#1095).
+//!
+//! `crates/embed/Cargo.toml` declares `lattice-inference` once now (the
+//! native/wasm split that used to carry two independently-editable feature
+//! lists was collapsed by #1094), but a standalone `cargo build -p
+//! lattice-embed` is still the only invocation that resolves `lattice-embed`'s
+//! `lattice-inference` feature set in isolation. Any `--workspace` build also
+//! compiles `lattice-tune`, whose own `Cargo.toml` requests
+//! `lattice-inference/f16` unconditionally — Cargo's workspace feature
+//! unification then grants `lattice-embed` an `f16`-enabled build for free,
+//! even if `crates/embed/Cargo.toml` itself no longer asks for it. That is
+//! exactly how the dependency table drifted silently before (#1094): every
+//! green `--workspace` run was testing a configuration the standalone crate
+//! never actually gets.
+//!
+//! This test never resolves through `--workspace`. It builds a half-precision
+//! (BF16) tensor in memory and round-trips it through
+//! `lattice_inference::weights::SafetensorsFile`, the same load path real
+//! model weights go through (`weights/f32_weights.rs`). Without the `f16`
+//! feature that load returns `InvalidSafetensors` instead of a tensor —
+//! a compile-time-invisible, runtime-only failure, so a build-only check
+//! would stay green on the very regression this test exists to catch.
+//!
+//! Run standalone to reproduce the isolation the guard depends on:
+//!   `cargo test -p lattice-embed --test f16_feature_load_guard`
+
+use lattice_inference::weights::SafetensorsFile;
+
+/// Builds a minimal safetensors byte buffer containing a single BF16 tensor
+/// named `weight` with two elements. Real model checkpoints carry BF16/F16
+/// tensors identically shaped at the container level; only the byte width
+/// and dtype tag matter to the load path under test, so a synthetic 4-byte
+/// payload exercises the exact branch a real checkpoint would hit.
+fn minimal_bf16_safetensors() -> Vec<u8> {
+    // bf16 bit patterns for 1.0 and 2.0 (sign:1 exp:8 mantissa:7, top 16 bits
+    // of the equivalent f32), little-endian on the wire like every other
+    // safetensors dtype.
+    let tensor_bytes: [u8; 4] = [0x80, 0x3f, 0x00, 0x40]; // [1.0_bf16, 2.0_bf16]
+
+    let header = format!(
+        r#"{{"weight":{{"dtype":"BF16","shape":[2],"data_offsets":[0,{}]}}}}"#,
+        tensor_bytes.len()
+    );
+    let header_bytes = header.into_bytes();
+
+    let mut buf = Vec::with_capacity(8 + header_bytes.len() + tensor_bytes.len());
+    buf.extend_from_slice(&(header_bytes.len() as u64).to_le_bytes());
+    buf.extend_from_slice(&header_bytes);
+    buf.extend_from_slice(&tensor_bytes);
+    buf
+}
+
+#[test]
+fn bf16_tensor_loads_through_lattice_embeds_native_dependency() {
+    let bytes = minimal_bf16_safetensors();
+    let file = SafetensorsFile::from_bytes(bytes).expect(
+        "safetensors container with a BF16 tensor must parse regardless of the f16 feature",
+    );
+
+    let (values, shape) = file.get_f32_tensor("weight").unwrap_or_else(|e| {
+        panic!(
+            "lattice-embed's native lattice-inference dependency was built \
+             without the f16 feature, so a BF16 tensor hard-fails at load \
+             instead of decoding to f32 (this is the #1094/#1095 regression \
+             this guard exists to catch): {e}"
+        )
+    });
+
+    assert_eq!(shape, [2]);
+    assert!(
+        (values[0] - 1.0).abs() < 1e-2,
+        "bf16 1.0 decoded as {}",
+        values[0]
+    );
+    assert!(
+        (values[1] - 2.0).abs() < 1e-2,
+        "bf16 2.0 decoded as {}",
+        values[1]
+    );
+}

--- a/crates/embed/tests/f16_feature_load_guard.rs
+++ b/crates/embed/tests/f16_feature_load_guard.rs
@@ -3,16 +3,19 @@
 //!
 //! `crates/embed/Cargo.toml` declares `lattice-inference` once now (the
 //! native/wasm split that used to carry two independently-editable feature
-//! lists was collapsed by #1094), but a standalone `cargo build -p
-//! lattice-embed` is still the only invocation that resolves `lattice-embed`'s
-//! `lattice-inference` feature set in isolation. Any `--workspace` build also
-//! compiles `lattice-tune`, whose own `Cargo.toml` requests
-//! `lattice-inference/f16` unconditionally — Cargo's workspace feature
-//! unification then grants `lattice-embed` an `f16`-enabled build for free,
-//! even if `crates/embed/Cargo.toml` itself no longer asks for it. That is
-//! exactly how the dependency table drifted silently before (#1094): every
-//! green `--workspace` run was testing a configuration the standalone crate
-//! never actually gets.
+//! lists was collapsed by #1094), and a standalone `cargo build -p
+//! lattice-embed` resolves that one feature set in isolation — the same
+//! resolve `cargo install lattice-embed` and the wasm/npm build get.
+//!
+//! Running the guard on that isolated resolve, rather than inside a
+//! `--workspace` run, is deliberate. `lattice-tune`'s `lattice-inference`
+//! dependency is optional but carries `features = ["f16"]`, so any invocation
+//! that activates tune's `inference-hook` or `train-backward` alongside
+//! `lattice-embed` lets Cargo's feature unification grant `lattice-embed` an
+//! `f16`-enabled build for free, whatever `crates/embed/Cargo.toml` itself
+//! asks for. Neither tune feature is in its defaults today, so a plain
+//! `cargo test --workspace` does not currently mask anything; nothing enforces
+//! that, and the isolated resolve does not depend on it staying true.
 //!
 //! This test never resolves through `--workspace`. It builds a half-precision
 //! (BF16) tensor in memory and round-trips it through

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -27741,11 +27741,20 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// across BOTH test threads in this process and any other process on the
         /// machine.
         ///
-        /// In-process half: concurrent GPU execution amplifies the pre-existing
-        /// ADR-065 attention race, which perturbs the *serial* GDN reference that
-        /// the cross-algorithm parity tests compare against — producing
-        /// false-positive failures under `cargo test`'s default multi-threading.
-        /// The chunked scan itself is deterministic (see
+        /// In-process half: the Metal batched/decode attention kernels carry a
+        /// runtime-only nondeterminism that perturbs logit values by small
+        /// magnitudes on roughly 1-in-N runs. Static analysis of
+        /// `gdn_recurrence_fused` and `decode_attention` found both barrier-correct
+        /// (no uninitialized threadgroup reads, no intra-dispatch cross-threadgroup
+        /// device race, no untracked buffers), so the hazard has not been
+        /// root-caused — it is only observable via GPU frame capture (Xcode Metal
+        /// debugger), which no run here has done yet. Concurrent GPU execution
+        /// amplifies it, and it perturbs the *serial* GDN reference that the
+        /// cross-algorithm parity tests compare against — producing false-positive
+        /// failures under `cargo test`'s default multi-threading. Argmax stays
+        /// stable across the perturbation; only logit values drift (see the
+        /// chunked-prefill parity test below for the magnitude evidence). The
+        /// chunked scan itself is deterministic (see
         /// `gdn_chunked_b_vs_b_self_consistency`); serializing device access keeps
         /// the serial reference clean run-to-run.
         ///
@@ -30185,8 +30194,11 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             // debugger). The argmax is STABLE across hundreds of runs, so generated tokens
             // are unaffected; only logit *values* drift. The hard guarantee this test
             // enforces is therefore argmax equality; the logit-value bound is a loose
-            // regression guard, not a strict-parity assertion. See RACE_FIX_NOTES.md /
-            // ADR-065 for the full diagnosis and the GPU-capture path to a true fix.
+            // regression guard, not a strict-parity assertion. Root cause is unconfirmed:
+            // a GPU frame capture of a divergent run is the diagnostic that could show the
+            // actual dispatch-level ordering hazard, and nothing in this tree has done that
+            // capture yet (see `gpu_test_lock`'s doc comment for what static analysis has
+            // and hasn't ruled out).
             assert!(
                 max_abs_diff < 0.5,
                 "chunked prefill logits diverged from step loop beyond the known-issue \
@@ -30876,7 +30888,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             // The chunked GDN scan is itself deterministic — gdn_chunked_b_vs_b_self_consistency and
             // the race-localization probe both show chunked-vs-chunked state diff = 0.0 across many
             // runs.  The only remaining nondeterminism is the pre-existing batched/decode attention
-            // race (ADR-065), which perturbs the residual stream on ~1-in-N runs.  GPU access is
+            // race (root cause unconfirmed; see `gpu_test_lock`'s doc comment for what static
+            // analysis has and hasn't ruled out), which perturbs the residual stream on
+            // ~1-in-N runs.  GPU access is
             // serialized via gpu_test_lock() so that race is not amplified by device contention, but
             // it can still occasionally perturb the *serial* forward_step reference by ~1e-3.
             //
@@ -30937,7 +30951,8 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         ///
         /// Both paths are selected via `state.use_gdn_chunked` (no process-env mutation), so there
         /// are no setenv races. GPU access is additionally serialized via `gpu_test_lock()` so the
-        /// pre-existing ADR-065 attention race is not amplified by concurrent device contention,
+        /// pre-existing batched/decode attention race (root cause unconfirmed; see
+        /// `gpu_test_lock`'s doc comment) is not amplified by concurrent device contention,
         /// and the deterministic chunked logits are computed once per length while only the serial
         /// reference is retried — a flaky chunked attempt cannot be masked by best-of-N.
         ///
@@ -30983,7 +30998,8 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
 
             // The chunked scan is deterministic (gdn_chunked_b_vs_b_self_consistency), but
             // chunked-vs-serial all-position value drift grows with prompt length even after
-            // best-of-N discards the ADR-065 serial-race outliers: best-of-5 max_abs_diff
+            // best-of-N discards the batched/decode attention race's serial-reference outliers
+            // (root cause unconfirmed; see `gpu_test_lock`'s doc comment): best-of-5 max_abs_diff
             // reaches ~4.8e-2 at n=1009 and crosses the old 1e-2 bound at n=511/512/513
             // (#534). The value bound below is a drift sentinel, not the correctness gate —
             // the argmax-flip assertion after the sweep is the hard safety check. Tighten
@@ -31019,7 +31035,8 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     "chunked all_logits len mismatch at n={n}"
                 );
 
-                // Best-of-N: the serial reference is perturbed by the ADR-065 race on a minority
+                // Best-of-N: the serial reference is perturbed by the batched/decode attention
+                // race (root cause unconfirmed; see `gpu_test_lock`'s doc comment) on a minority
                 // of runs.  Keep the attempt with the smallest max_abs (and its flip count); a
                 // single clean comparison proves the chunked algorithm correct, so stop early once
                 // one attempt is within bound and flip-free.  Mirrors

--- a/scripts/compare_logits.py
+++ b/scripts/compare_logits.py
@@ -54,7 +54,13 @@ def tokenize_corpus_bpe(corpus_path: Path, model_dir: Path, n: int) -> list[int]
     We use mlx_lm's tokenizer here — it loads the same tokenizer.json file.
     """
     from transformers import AutoTokenizer  # type: ignore
-    tok = AutoTokenizer.from_pretrained(str(model_dir), trust_remote_code=True)
+    # Qwen3.5's tokenizer is a stock Qwen2Tokenizer/tokenizer.json — no custom
+    # tokenization class ships with the snapshot, so no remote code is needed
+    # to load it, and running arbitrary code from a caller-supplied directory
+    # is not a trade this script should make on their behalf.
+    tok = AutoTokenizer.from_pretrained(
+        str(model_dir), trust_remote_code=False, local_files_only=True
+    )
     text = corpus_path.read_text(encoding="utf-8")[:8192]  # first ~8K chars
     ids = tok.encode(text, add_special_tokens=False)
     return ids[:n]

--- a/scripts/gemma4_stage5_e2e_golden.py
+++ b/scripts/gemma4_stage5_e2e_golden.py
@@ -72,7 +72,7 @@ def main() -> None:
         cfg_dict = json.load(f)
     cfg = Gemma4Config(**cfg_dict)
 
-    tok = AutoTokenizer.from_pretrained(MODEL_DIR)
+    tok = AutoTokenizer.from_pretrained(MODEL_DIR, trust_remote_code=False, local_files_only=True)
     bos_id = cfg.text_config.bos_token_id
     prompt_ids = tok(PROMPT, add_special_tokens=False)["input_ids"]
     input_ids_list = [bos_id] + prompt_ids
@@ -80,7 +80,12 @@ def main() -> None:
 
     print("loading model (CPU f32, text-only)...", file=sys.stderr)
     model = Gemma4ForConditionalGeneration.from_pretrained(
-        MODEL_DIR, config=cfg, dtype=torch.float32, low_cpu_mem_usage=True
+        MODEL_DIR,
+        config=cfg,
+        dtype=torch.float32,
+        low_cpu_mem_usage=True,
+        trust_remote_code=False,
+        local_files_only=True,
     )
     model.eval()
 

--- a/scripts/gen_embed_parity_goldens.py
+++ b/scripts/gen_embed_parity_goldens.py
@@ -58,6 +58,9 @@ def l2_normalize(vec: np.ndarray) -> np.ndarray:
     return vec / norm
 
 
+BGE_SMALL_EN_V15_REVISION = "5c38ec7c405ec4b44b94cc5a9bb96e735b38267a"
+
+
 def generate_bge_small_goldens() -> list[dict]:
     """
     BAAI/bge-small-en-v1.5: CLS-token pooling + L2 normalize, no prompt prefix.
@@ -66,10 +69,11 @@ def generate_bge_small_goldens() -> list[dict]:
     "Use the CLS token embedding and normalize to unit length."
     """
     model_id = "BAAI/bge-small-en-v1.5"
-    print(f"Loading {model_id} from HF hub...")
+    revision = BGE_SMALL_EN_V15_REVISION
+    print(f"Loading {model_id}@{revision} from HF hub...")
 
-    tokenizer = AutoTokenizer.from_pretrained(model_id)
-    model = AutoModel.from_pretrained(model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id, revision=revision)
+    model = AutoModel.from_pretrained(model_id, revision=revision)
     model.eval()
 
     print(f"  model type: {type(model).__name__}, hidden_size: {model.config.hidden_size}")
@@ -85,6 +89,7 @@ def generate_bge_small_goldens() -> list[dict]:
 
         goldens.append({
             "model_id": model_id,
+            "source_revision": revision,
             "pooling": "cls",
             "prompt_prefix": "",
             "input": text,
@@ -113,7 +118,8 @@ def generate_e5_small_goldens() -> list[dict]:
         sys.exit(1)
 
     model_id = "intfloat/multilingual-e5-small"
-    print(f"Loading {model_id} from {model_path}...")
+    revision = source_revision_of(model_path)
+    print(f"Loading {model_id} from {model_path} (source_revision={revision})...")
 
     tokenizer = AutoTokenizer.from_pretrained(str(model_path))
     model = AutoModel.from_pretrained(str(model_path))
@@ -138,6 +144,7 @@ def generate_e5_small_goldens() -> list[dict]:
 
         goldens.append({
             "model_id": model_id,
+            "source_revision": revision,
             "pooling": "mean",
             "prompt_prefix": prompt_prefix,
             "input": text,
@@ -163,6 +170,20 @@ def find_hf_cache_snapshot(model_id: str) -> Path | None:
     return None
 
 
+def source_revision_of(model_path: Path) -> str:
+    """Best-effort provenance for a golden's `source_revision` field.
+
+    HF cache snapshot dirs are named after the exact commit they were
+    resolved from (`snapshots/<sha>/`), so that directory name doubles as a
+    revision pin. `.lattice/models/<slug>/` snapshots carry no such marker —
+    lattice's own downloader resolves against a mutable ref by design (see
+    issue #1100) — so record that plainly rather than inventing a revision.
+    """
+    if model_path.parent.name == "snapshots" and len(model_path.name) == 40:
+        return model_path.name
+    return f"unpinned:{model_path}"
+
+
 def generate_all_minilm_l6_v2_goldens() -> list[dict]:
     """
     sentence-transformers/all-MiniLM-L6-v2: mean pooling + L2 normalize, no prompt prefix.
@@ -181,7 +202,8 @@ def generate_all_minilm_l6_v2_goldens() -> list[dict]:
             print(f"ERROR: all-MiniLM-L6-v2 not found in HF cache or .lattice/models/")
             sys.exit(1)
 
-    print(f"Loading {model_id} from {model_path}...")
+    revision = source_revision_of(model_path)
+    print(f"Loading {model_id} from {model_path} (source_revision={revision})...")
 
     tokenizer = AutoTokenizer.from_pretrained(str(model_path))
     model = AutoModel.from_pretrained(str(model_path))
@@ -205,6 +227,7 @@ def generate_all_minilm_l6_v2_goldens() -> list[dict]:
 
         goldens.append({
             "model_id": model_id,
+            "source_revision": revision,
             "pooling": "mean",
             "prompt_prefix": prompt_prefix,
             "input": text,
@@ -235,7 +258,8 @@ def generate_paraphrase_multilingual_minilm_l12_v2_goldens() -> list[dict]:
             print(f"ERROR: paraphrase-multilingual-MiniLM-L12-v2 not found in HF cache or .lattice/models/")
             sys.exit(1)
 
-    print(f"Loading {model_id} from {model_path}...")
+    revision = source_revision_of(model_path)
+    print(f"Loading {model_id} from {model_path} (source_revision={revision})...")
 
     tokenizer = AutoTokenizer.from_pretrained(str(model_path))
     model = AutoModel.from_pretrained(str(model_path))
@@ -259,6 +283,7 @@ def generate_paraphrase_multilingual_minilm_l12_v2_goldens() -> list[dict]:
 
         goldens.append({
             "model_id": model_id,
+            "source_revision": revision,
             "pooling": "mean",
             "prompt_prefix": prompt_prefix,
             "input": text,
@@ -288,7 +313,8 @@ def generate_qwen_goldens() -> list[dict]:
         sys.exit(1)
 
     model_id = "Qwen/Qwen3-Embedding-0.6B"
-    print(f"Loading {model_id} from {model_path}...")
+    revision = source_revision_of(model_path)
+    print(f"Loading {model_id} from {model_path} (source_revision={revision})...")
 
     tokenizer = AutoTokenizer.from_pretrained(str(model_path))
     model = AutoModel.from_pretrained(str(model_path))
@@ -312,6 +338,7 @@ def generate_qwen_goldens() -> list[dict]:
 
         goldens.append({
             "model_id": model_id,
+            "source_revision": revision,
             "pooling": "last_token",
             "prompt_prefix": prompt_prefix,
             "input": text,

--- a/scripts/vision_goldens_qwen35.py
+++ b/scripts/vision_goldens_qwen35.py
@@ -326,8 +326,12 @@ def run(model_dir: Path, out_dir: Path) -> None:
         merged_dir = Path(tmp) / "model_merged"
         build_merged_dir(model_dir, merged_dir)
 
-        processor = AutoProcessor.from_pretrained(str(merged_dir))
-        model = AutoModelForImageTextToText.from_pretrained(str(merged_dir), dtype=torch.float32)
+        processor = AutoProcessor.from_pretrained(
+            str(merged_dir), trust_remote_code=False, local_files_only=True
+        )
+        model = AutoModelForImageTextToText.from_pretrained(
+            str(merged_dir), dtype=torch.float32, trust_remote_code=False, local_files_only=True
+        )
         model.eval()
 
         img = Image.open(image_path).convert("RGB")


### PR DESCRIPTION
Five independent supply-chain and documentation-integrity fixes.

## Pin third-party actions to commit SHAs (#1113)

A mutable tag such as `@v4` resolves to whatever the action's owner points it at, so a compromised or simply retagged release executes new code in CI with CI's permissions.

Coverage: all 10 workflow files, 127 `uses:` references — 121 now SHA-pinned, 6 are local composite actions (`./`) needing no pin, 0 left on a mutable ref. Each of the 13 distinct pins was checked against upstream and resolves to the commit its trailing version comment names (10 via release tags; 3 via version branches, which is how `dtolnay/rust-toolchain` and `sticky-pull-request-comment` publish versions). A Dependabot `github-actions` entry keeps them refreshed rather than frozen.

## Stop trusting remote model code, pin reference revisions (#1100)

One script passed `trust_remote_code=True`, which executes arbitrary Python from a downloaded model repository. That is now `False` everywhere, with `local_files_only=True` where the model is expected on disk. The BGE reference revision is pinned so golden regeneration is reproducible, and goldens record the source revision they came from. Local snapshot directories carry no revision marker, so that case records the absence rather than inventing a value.

## Guard the native f16 dependency against silent drift (#1095)

`lattice-embed`'s native `lattice-inference` table took that crate's default features, which are `["std", "download", "serve"]` and do not include `f16`, while the wasm table beside it did (#1094). Standalone native consumers got a build where BF16 weights hard-fail at load. No run went red over it, and not because feature resolution hid it: nothing in the suite exercised a half-precision load on any invocation. The gap was coverage.

The new test round-trips a BF16 safetensors tensor through the real load path. It has to execute rather than merely build, because without the feature the failure is a runtime `Err` and not a compile error, so the `--no-run` steps beside it cannot observe it.

It runs standalone via `cargo test -p lattice-embed --test f16_feature_load_guard` rather than inside a `--workspace` command. `lattice-tune`'s `lattice-inference` dependency is optional but carries `features = ["f16"]`, so any invocation that activates tune's `inference-hook` or `train-backward` alongside `lattice-embed` would unify that `f16` into embed and mask exactly this regression. Neither feature is in tune's defaults, so `cargo test --workspace` does not do that today; running the guard on the isolated resolve means it never has to stay true.

Mutation check on this branch. With `"f16"` removed from `crates/embed/Cargo.toml`:

```
test bf16_tensor_loads_through_lattice_embeds_native_dependency ... FAILED

thread 'bf16_tensor_loads_through_lattice_embeds_native_dependency' panicked at
crates/embed/tests/f16_feature_load_guard.rs:65:9:
lattice-embed's native lattice-inference dependency was built without the f16 feature,
so a BF16 tensor hard-fails at load instead of decoding to f32 (this is the #1094/#1095
regression this guard exists to catch): Invalid safetensors file: tensor weight is BF16
but lattice-inference was built without the f16 feature

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

Restoring the feature returns it to `ok`.

## State the attention-race rationale instead of citing an ADR (#1093)

Five comments attributed the Metal batched/decode attention nondeterminism to ADR-065, which is about feature promotion gates and does not describe this race. No ADR documents it, so there is no correct number to substitute and citing a different one would compound the error. Each site now states the situation directly: what the hazard perturbs, what static analysis has and has not ruled out, that the root cause is unconfirmed, and that a GPU frame capture is the diagnostic nobody has run. A dangling reference to a notes file absent from this repository goes with it.

## Replace bench process narration with durable rationale (#1088)

Two bench group comments in `crates/embed/benches/simd.rs` described the work that produced them, referencing a round and hypothesis numbering meaningless to a later reader and describing a follow-up as pending after it shipped. They now state what each pair of groups compares and why the gap between them is the quantity of interest.

Closes #1113
Closes #1100
Closes #1095
Closes #1093
Closes #1088

## bench-compare disposition

No A/B was run, and no A/B could attribute anything to this diff: base and head bench binaries are built from identical effective source.

Every changed line in the two Rust source files this branch touches under `crates/` is a comment — `crates/inference/src/forward/metal_qwen35.rs` (39 changed lines, 0 non-comment) and `crates/embed/benches/simd.rs` (28 changed lines, 0 non-comment). The only other `crates/` change is a new file under `crates/embed/tests/`, which is a separate Cargo target from `benches/` and is not linked into any bench binary. No `Cargo.toml`, no build script, and no compiled source line differs, so `elementwise_cpu_bench` and `simd` compile to the same instructions on both sides.

The remaining changes are workflow YAML, a Dependabot config, and Python scripts, none of which is compiled at all.

