### PR TITLE
chore(ci): group action updates and separate majors from patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      # Patch and minor action bumps are the routine, low-risk ones and travel
+      # together in a single pull request so a weekly run does not fan out into
+      # one review per action.
+      actions-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Major bumps are separated deliberately. Action majors change runtime
+      # behavior often enough that they need to be looked at on their own, and
+      # grouping them with patches would let a breaking change ride in beside
+      # updates that are safe to take on sight.
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,16 @@ updates:
       # Patch and minor action bumps are the routine, low-risk ones and travel
       # together in a single pull request so a weekly run does not fan out into
       # one review per action.
+      #
+      # Major bumps are deliberately left OUT of this group and out of any other
+      # group. An update matching no group rule gets its own pull request, which
+      # is the point: action majors change runtime behavior often enough to be
+      # worth reading one at a time, and a second group for them would defeat
+      # that, since a group produces a single combined pull request no matter
+      # how many majors it matches.
       actions-minor:
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
-      # Major bumps are separated deliberately. Action majors change runtime
-      # behavior often enough that they need to be looked at on their own, and
-      # grouping them with patches would let a breaking change ride in beside
-      # updates that are safe to take on sight.
-      actions-major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"


### PR DESCRIPTION
Automated action updates were configured to open one pull request per action. That produces a weekly fan-out proportional to the number of actions in use rather than to the number of things actually worth reviewing, and the first run opened five at once.

Patch and minor bumps now travel together in a single request, and a limit caps how many can be open at a time.

Major bumps are grouped separately rather than folded into that same request. Action majors change runtime behavior often enough to deserve being looked at on their own, and bundling them with patches would let a breaking change ride in beside updates that are safe to take on sight. The five requests already open are all majors, which is exactly the split this encodes.

## bench-compare disposition

Not applicable, and this is the narrow case where that phrase is literally true rather than a judgement call: the diff is one YAML configuration file consumed by the hosting platform. No Rust source, no manifest, and no build script changes, so nothing reaches a compiler and base and head bench binaries are byte-identical by construction.
