### PR TITLE
test(inference): cover checked-loader routing for Qwen3.5 dense-FFN tensors

### DIFF
--- a/crates/inference/src/model/qwen35/loading.rs
+++ b/crates/inference/src/model/qwen35/loading.rs
@@ -924,6 +924,38 @@ mod tests {
         load_weights(&mut src, &cfg).expect("correctly shaped layernorms must load");
     }
 
+    /// Regression for #1035: a finite, undersized dense-FFN tensor must cause
+    /// `load_weights` — the routine `Qwen35Model::from_safetensors` uses to assemble a
+    /// model — to return `Err`, not reach the forward pass and panic in the release-active
+    /// GEMM bounds guard.
+    #[test]
+    fn load_weights_rejects_undersized_dense_ffn_tensor() {
+        let cfg = tiny_linear_layer_cfg();
+        let hidden = cfg.hidden_size;
+        let inter = cfg.intermediate_size;
+        let mut src = tiny_linear_layer_tensors(&cfg, hidden, hidden);
+        // down_proj declared as [hidden, inter - 1] instead of [hidden, inter] --
+        // finite, just smaller than the config requires.
+        src.tensors.insert(
+            "model.language_model.layers.0.mlp.down_proj.weight".to_string(),
+            (vec![0.0f32; hidden * (inter - 1)], vec![hidden, inter - 1]),
+        );
+
+        match load_weights(&mut src, &cfg) {
+            Err(InferenceError::ShapeMismatch { name, .. }) => {
+                assert!(
+                    name.contains("down_proj"),
+                    "error must name down_proj, got: {name}"
+                );
+            }
+            Err(e) => panic!("expected ShapeMismatch, got a different error: {e}"),
+            Ok(_) => panic!(
+                "expected Err for undersized down_proj, got Ok (an undersized tensor would \
+                 reach the forward pass and panic in the GEMM bounds guard)"
+            ),
+        }
+    }
+
     /// A config with `num_attention_heads = 2^63` and `head_dim = 2` overflows
     /// `full_q_dim()`/`full_kv_dim()` in release builds. `load_full_attention_weights`
     /// must reject this via the checked accessors before deriving a wrapped, undersized

--- a/crates/inference/src/model/qwen35/model.rs
+++ b/crates/inference/src/model/qwen35/model.rs
@@ -27,19 +27,14 @@ impl Qwen35Model {
     /// weights are assembled; a failure there drops the local assembly state
     /// and returns an error without exposing a partially built model.
     ///
-    /// That ingress check validates a tensor's own metadata — that its
-    /// decoded element count matches its declared shape and every value is
-    /// finite — not that the shape is *compatible with this model's config*.
-    /// Embeddings, the LM head, the final norm, the MoE router/expert/
-    /// shared-expert tensors, and the GDN decay tensors (`in_proj_b`,
-    /// `in_proj_a`, `a_log`, `dt_bias`) are additionally checked against a
-    /// config-derived expected shape at assembly. Dense FFN weights, full
-    /// attention Q/K/V/O and their norms, per-layer input/post-attention
-    /// norms, and the remaining GDN projection tensors are not yet checked
-    /// against config-derived shapes, so a finite but undersized tensor at
-    /// one of those names can still reach a forward pass built for a larger
-    /// shape. Closing that gap for every required tensor is tracked in
-    /// #1035.
+    /// Every required tensor — embeddings, the LM head, the final norm,
+    /// per-layer input/post-attention norms, dense FFN weights, full
+    /// attention Q/K/V/O and their norms, the GDN projection and decay
+    /// tensors, and the MoE router/expert/shared-expert tensors — is also
+    /// checked against a config-derived expected shape at assembly
+    /// (`load_owned_tensor_checked`), so a finite but undersized or
+    /// otherwise config-incompatible tensor is rejected here rather than
+    /// reaching a forward pass built for a different shape.
     pub fn from_safetensors(path: &Path) -> Result<Self, InferenceError> {
         let model_path = path.join("model.safetensors");
         let index_path = path.join("model.safetensors.index.json");


### PR DESCRIPTION
## Summary

Closes #1035.

Every required tensor in the Qwen3.5 safetensors loader is already routed through
`load_owned_tensor_checked`, which validates each tensor against its config-derived
expected shape at assembly. A finite but config-incompatible tensor is therefore
rejected during `load_weights` with a `ShapeMismatch` error, rather than reaching the
forward pass and panicking in the release-active GEMM bounds guard.

Two gaps remained, both closed here:

- `Qwen35Model::from_safetensors`' doc comment still described dense FFN weights, full
  attention Q/K/V/O and their norms, per-layer input/post-attention norms, and the
  remaining GDN projection tensors as unchecked. It now states that every required
  tensor is checked against a config-derived shape at assembly, matching the loader.
- There was no end-to-end regression covering this path. Added
  `load_weights_rejects_undersized_dense_ffn_tensor`: a finite, undersized `down_proj`
  tensor must make `load_weights` return `Err(ShapeMismatch)` naming `down_proj`.

## Mutation sensitivity

Disabling both shape gates inside `load_owned_tensor_checked` makes the new test fail
at the `Ok(_)` branch — "expected Err for undersized down_proj, got Ok" — confirming
the checked loader is the sole guard and that the test fails for the stated reason, not
incidentally. Restoring the gates returns it to green.

`cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings`: clean.

## bench-compare disposition

Not applicable. The diff adds a `#[cfg(test)]` regression test and rewrites a doc
comment; there are no non-test, non-doc line changes. Base and head bench binaries
build from identical effective source, so an A/B comparison cannot attribute any delta
to this change.
