### PR TITLE
docs(scripts): correct where the missing-CV guard actually lives

### DIFF
--- a/scripts/bench_evidence/pr882/POLICY_SHA_TRANSITIONS.md
+++ b/scripts/bench_evidence/pr882/POLICY_SHA_TRANSITIONS.md
@@ -1,0 +1,59 @@
+# Policy-sha transitions affecting the reports in this directory
+
+`report_ctx512.json` and `report_ctx1024.json` pin
+`provenance.policy_sha = 17c4f9ef52c647aeb32642c065af135607d03ccc329d6245482ff899abf1de3c`.
+
+`bench_gate_math.policy_sha` hashes the raw bytes of `scripts/perf-policy.toml`, so
+any edit to that file moves the sha, including an edit that changes no gating
+value. When `validate_run_record` is given `current_policy_sha`, a record whose
+pinned sha no longer matches is rejected as a post-run threshold change. That is
+the correct default: the check exists so a gate result cannot be re-interpreted
+under thresholds that moved after the run.
+
+It cannot, however, tell a threshold change apart from a prose correction, and
+this file records the one transition where the difference matters.
+
+| From | To | Semantic delta |
+|---|---|---|
+| `17c4f9ef52c647ae…` | `9d5a3a3776e50610…` | none — three `note` strings rewritten |
+
+## Why that row is a claim you can check rather than one you have to trust
+
+Parse both versions, drop the prose keys (`note`, `other_rule`), and compare
+what remains. Everything the gate reads is identical:
+
+```
+keys whose VALUE changed: ['.cv_bands[0].note', '.cv_bands[1].note', '.cv_bands[2].note']
+gating values identical (notes/prose excluded): True
+control (tampered max_cv detected): True
+```
+
+The control line matters as much as the result: the comparator was re-run
+against a copy with `cv_bands[0].max_cv` set to `0.999` and reported a
+difference, so "identical" here is a measurement rather than an instrument that
+returns True for everything.
+
+Band values before and after, read back through `parse_cv_bands`:
+`[(0.015, 7, 1.0), (0.05, 25, 1.0), (1.0, 25, 2.0)]` in both.
+
+## What the edit corrected
+
+The band notes described each band by the CV the power curves were calibrated
+at (`~1%`, `~3%`, `>=8%`) while the lookup tests the registered `max_cv`
+(`0.015`, `0.05`, `1.0`). A reader with a measured 2% CV would predict the n=7
+band from the notes; the lookup returns n=25. A reader with 6% would predict the
+1.0 fail-margin multiplier; the lookup returns 2.0. The notes now state the
+boundary first and label the calibration point as such.
+
+## The open design question this exposed
+
+Correcting a misleading comment in the policy file costs exactly what changing a
+kill-point costs: every recorded run record pinning the old sha stops
+revalidating. That prices honesty at the same rate as a threshold move, which is
+part of why the wrong notes survived as long as they did.
+
+A sha computed over the canonicalized *parsed* values, with prose keys excluded,
+would still fail closed on any band, threshold, or noise-class change while
+staying quiet for a comment fix. That is a change to what a gate identity means,
+so it belongs in its own change with its own review rather than riding along
+with a documentation correction. Filed rather than fixed here.

--- a/scripts/bench_gate_math.py
+++ b/scripts/bench_gate_math.py
@@ -12,21 +12,48 @@ dependency the gate can't audit.
 Three of this module's gate-math choices were adversarially checked against
 an independent Monte-Carlo simulation (power curves for the paired gate at
 several CV levels, bootstrap tail behavior at small n, and exact binomial
-bounds for promotion evidence) before the module was written.
-All three corrections are encoded as executable functions,
-not just prose, so the validator in `bench_decode_harness.py` can enforce
-them instead of merely documenting them:
+bounds for promotion evidence) before the module was written. That
+simulation is NOT in this repository, and only one of the three checks left
+an artifact here that re-derives its number: the exact binomial bound is
+recomputed by `clopper_pearson_upper` and asserted in the unit tests. The
+power percentages quoted below and in `perf-policy.toml` are carried over
+from the external simulation. Nothing in this tree computes them, so treat
+them as the recorded rationale for the registered bands, not as a result an
+evaluator can reproduce from this checkout.
+
+The corrections are encoded as executable functions, not just prose, so the
+validator in `bench_decode_harness.py` can enforce them instead of merely
+documenting them:
 
   1. `required_n` — minimum `n` is a function of the MEASURED same-session
      residual CV, not a fixed constant. At cv~=1% n=7 already has ~99%
      power against a true 10% regression (Class-A decode family, FAIL=7%).
-     At cv~=3%, n=7 has only ~47-63% power; n~=23-25 restores ~80-84%. At
+     At cv~=3%, n=7 has only ~47-63% power; n=25 restores ~80-84%. At
      cv>=8%, even n=30 only reaches ~31% power against the same true
      regression — inflating n further is not cost-effective, so that band
      widens the FAIL margin instead (see `perf-policy.toml` `[[cv_bands]]`
-     `fail_margin_multiplier`). Bands are DATA in `perf-policy.toml`; this
-     module only looks them up and refuses to guess a required n for a
-     cell with no measured CV on record.
+     `fail_margin_multiplier`). Those CV figures name the calibration
+     points the power curves were computed at; they are NOT the band
+     boundaries. The boundaries are the registered `max_cv` values, and
+     they are what a lookup actually tests against — read them from
+     `perf-policy.toml` before reasoning about a specific CV, because a
+     measured 2% lands in the n=25 band and a measured 6% already carries
+     the widened FAIL margin.
+
+     Bands are DATA in `perf-policy.toml`; this module only looks them up.
+     It does NOT refuse a cell with no measured CV, and cannot: `required_n`
+     takes a float, so a missing CV arrives here either as a bare `TypeError`
+     or, if a caller substitutes 0.0, as a silent lookup into the CHEAPEST
+     band. The fail-closed behaviour lives in the CALLERS —
+     `bench_decode_harness.validate_run_record` raises
+     `RunRecordValidationError` ("INFRA-FAIL: ... has no measured_cv on
+     record") for any cell whose verdict is not `unsupported`, and
+     `bench_cpu_flagship_supervisor` demotes an un-CV'd cell to shadow
+     rather than defaulting it. A NEW CALL SITE INHERITS THE OBLIGATION,
+     NOT THE GUARD: if you call `required_n` from somewhere else, you must
+     refuse the missing-CV case yourself before calling, because nothing in
+     this module will do it for you and nothing here will fail if you skip
+     it.
 
   2. `order_stratified_bootstrap_means` bootstraps the MEAN of paired
      log-slowdowns, never the median. At n=7 the bootstrap distribution of

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -215,9 +215,15 @@ def render_report(results: list[BenchResult], arch: str,
 
     lines = [f"### `{arch}` — perf regression report\n"]
     if fails:
-        lines.append(f"**❌ {len(fails)} FAIL** (regression >{FAIL_PCT}% confirmed by 95% CI)")
+        lines.append(
+            f"**❌ {len(fails)} FAIL** (regression >{FAIL_PCT}% — lower bound of Criterion's "
+            "two-sided 95% CI, i.e. about a 97.5% one-sided level, not a calibrated one-sided 95% test)"
+        )
     if warns:
-        lines.append(f"**⚠ {len(warns)} WARN** (regression {WARN_PCT}-{FAIL_PCT}% confirmed)")
+        lines.append(
+            f"**⚠ {len(warns)} WARN** (regression {WARN_PCT}-{FAIL_PCT}% by the same "
+            "two-sided-95%-CI lower bound)"
+        )
     if wins:
         lines.append(f"**🚀 {len(wins)} confirmed improvement**")
     if not (fails or warns or wins):

--- a/scripts/perf-policy.toml
+++ b/scripts/perf-policy.toml
@@ -31,34 +31,41 @@ policy_version = 1
 # (100%) so no measured CV can fall through uncovered — enforced by
 # `bench_gate_math.parse_cv_bands`.
 #
-# Evidence (cross-checked by an independent Monte-Carlo power simulation,
-# summarized here so the policy is self-explaining without it): at cv~=1%
-# n=7 already has ~99% power
-# against a true 10% regression (class A, decode family, FAIL=7%). At
-# cv~=3%, n=7 only has ~47-63% power; n~=23-25 restores ~80-84%. At
-# cv>=8%, even n=30 caps out near ~31% power — inflating n further stops
-# being cost-effective, so that band widens the FAIL margin instead
-# (`fail_margin_multiplier`) rather than chasing an ever-larger n.
+# Evidence (cross-checked by an independent Monte-Carlo power simulation
+# that is NOT in this repository — nothing in the tree recomputes these
+# percentages, so they are the recorded rationale for the bands rather than
+# a reproducible result): at cv~=1% n=7 already has ~99% power against a
+# true 10% regression (class A, decode family, FAIL=7%). At cv~=3%, n=7
+# only has ~47-63% power; n=25 restores ~80-84%. At cv>=8%, even n=30 caps
+# out near ~31% power — inflating n further stops being cost-effective, so
+# that band widens the FAIL margin instead (`fail_margin_multiplier`)
+# rather than chasing an ever-larger n.
+#
+# Those CV percentages are the CALIBRATION POINTS the power curves were
+# computed at. They are NOT the band boundaries, and the note on each band
+# below names both so the two are never read as the same number: the
+# lookup tests `max_cv`, so a measured 2% is already in the n=25 band and a
+# measured 6% already carries the 2.0 FAIL-margin multiplier.
 [[cv_bands]]
 max_cv = 0.015
 required_n_class_a = 7
 required_n_class_b = 9
 fail_margin_multiplier = 1.0
-note = "measured CV ~1%: n=7/9 as originally registered; ~99% power vs a true 10% regression."
+note = "applies to measured_cv <= 0.015. Calibration point cv~=1%: n=7/9 as originally registered, ~99% power vs a true 10% regression."
 
 [[cv_bands]]
 max_cv = 0.05
 required_n_class_a = 25
 required_n_class_b = 25
 fail_margin_multiplier = 1.0
-note = "measured CV ~3%: n=7 has only ~47-63% power vs a true 10% regression; n=25 restores ~80-84%."
+note = "applies to 0.015 < measured_cv <= 0.05, so a measured 2% lands here, not in the n=7 band. Calibration point cv~=3%: n=7 has only ~47-63% power vs a true 10% regression, n=25 restores ~80-84%."
 
 [[cv_bands]]
 max_cv = 1.0
 required_n_class_a = 25
 required_n_class_b = 25
 fail_margin_multiplier = 2.0
-note = "measured CV >=8%: even n=30 only reaches ~31% power vs a true 10% regression -- widen the FAIL margin for this band instead of chasing n. A cell with no measured_cv record can never be assumed to land in the cheapest band; the validator refuses promotion of any such cell (correction 1's fail-closed requirement)."
+note = "catch-all: applies to any measured_cv > 0.05, so a measured 6% already carries this band's widened FAIL margin. Calibration point cv>=8%: even n=30 only reaches ~31% power vs a true 10% regression -- widen the FAIL margin for this band instead of chasing n. A cell with no measured_cv record can never be assumed to land in the cheapest band; the validator refuses promotion of any such cell (correction 1's fail-closed requirement)."
 
 # ---------------------------------------------------------------------------
 # Gate-math method (Correction 2, mandatory): bootstrap the MEAN of paired

--- a/tests/test_bench_gate_math.py
+++ b/tests/test_bench_gate_math.py
@@ -330,6 +330,39 @@ class CvBandsTest(unittest.TestCase):
         with self.assertRaises(gm.PolicyConfigError):
             gm.parse_cv_bands([{"max_cv": 1.0, "required_n_class_a": 7, "required_n_class_b": 9}])
 
+    def test_module_does_not_itself_refuse_an_absent_cv(self):
+        """Pin where the missing-CV guard actually lives, because the module
+        header used to claim it lived here.
+
+        `required_n` is typed to take a float. An absent CV therefore reaches
+        it either as a bare `TypeError` or, if a caller substitutes 0.0, as a
+        silent lookup that returns the CHEAPEST band -- the most permissive
+        answer available, from the function a reader would expect to refuse.
+        The refusal is the caller's:
+        `bench_decode_harness.validate_run_record` raises
+        `RunRecordValidationError` for a non-`unsupported` cell with no
+        `measured_cv` (covered by
+        `test_bench_run_record.test_missing_measured_cv_fails_closed`).
+
+        This test asserts the absence of a guard, which is unusual, and it is
+        deliberate: a safety property documented at a module but enforced by
+        its callers reads as fail-closed in isolation, so a new call site
+        inherits the belief without inheriting the guard. Pinning the real
+        locus keeps the header from drifting back.
+        """
+        bands = self._bands()
+        self.assertEqual(gm.required_n(0.0, bands, "A"), (7, 1.0))
+        with self.assertRaises(TypeError):
+            gm.required_n(None, bands, "A")  # type: ignore[arg-type]
+
+    def test_band_boundaries_not_the_calibration_points(self):
+        """The notes quote calibration points (~1%, ~3%, >=8%); the lookup
+        tests `max_cv`. A reader who confuses the two mis-predicts every CV
+        between a calibration point and its boundary, so pin the gap."""
+        bands = self._bands()
+        self.assertEqual(gm.required_n(0.02, bands, "A"), (25, 1.0))
+        self.assertEqual(gm.required_n(0.06, bands, "A"), (25, 2.0))
+
 
 # --------------------------------------------------------------------------
 # perf-policy.toml load (real, shipped file)


### PR DESCRIPTION
Documentation corrections to the bench gate math, plus the two tests that keep them from
drifting back. No gating value changes.

## The load-bearing one

The `bench_gate_math` module header claimed the module "refuses to guess a required n for a cell
with no measured CV on record". It does not, and structurally cannot: `required_n` takes a
float, so an absent CV reaches it either as a bare `TypeError` or, when a caller substitutes
`0.0`, as a silent lookup returning the **cheapest** band.

```
required_n(0.0,  bands, "A") -> (7, 1.0)      # cheapest band
required_n(None, bands, "A") -> TypeError     # not GateMathError
required_n(-0.1, bands, "A") -> GateMathError # control: the function can refuse
```

The refusal is real and the system is fail-closed end to end, but it is enforced by the
**callers**: `bench_decode_harness.validate_run_record` raises `RunRecordValidationError` for a
non-`unsupported` cell with no `measured_cv`, and `bench_cpu_flagship_supervisor` demotes an
un-CV'd cell to shadow rather than defaulting it. The docstring on `required_n` itself already
said this; the module header said the opposite, and the header is what someone adding a fourth
call site reads.

This is a shape worth naming: a safety property documented at a module but enforced by its
callers reads as fail-closed in isolation, so a new caller inherits the belief without
inheriting the guard, and nothing in the module fails when the guard is omitted. The header now
names the enforcing callers and says plainly that a new call site inherits the obligation rather
than the guard.

## The band notes described the wrong numbers

The `[[cv_bands]]` notes named the CV each band's power curves were calibrated at (`~1%`, `~3%`,
`>=8%`). The lookup tests the registered `max_cv` (`0.015`, `0.05`, `1.0`). The gap is not
cosmetic:

| measured CV | notes suggest | `required_n` returns |
|---|---|---|
| 2% | `n=7` band | `(25, 1.0)` |
| 6% | `1.0` fail margin | `(25, 2.0)` |

Each note now leads with its boundary and labels the calibration point as such. Also drops
`n~=23-25` for the registered `25`.

## Power figures are external

The power percentages come from a Monte-Carlo simulation that is not in this repository. Nothing
here computes them and no test asserts one — the three mentions are all prose. They are now
labelled as the recorded rationale for the registered bands rather than something an evaluator
can reproduce from a checkout.

The adjacent Clopper-Pearson bound is **not** in that category and is unchanged:
`clopper_pearson_upper` recomputes it and the tests assert `0.1391`.

## Gate report wording

`perf-bench-gate.py` printed `confirmed by 95% CI` for a FAIL, while comments in the same file
fifteen lines above already conceded that using `ci_low` as a one-sided cutoff sits near a 97.5%
one-sided level. The error is conservative (it can only suppress true FAILs, never manufacture
one), so this is a wording fix, but it was wrong in the sentence a reader quotes.

## Tests

- `test_module_does_not_itself_refuse_an_absent_cv` — asserts the **absence** of a guard in
  `required_n` and points at the caller-side test that covers the real refusal
  (`test_missing_measured_cv_fails_closed`). Deliberately unusual; pinning the real locus is
  what stops the header drifting back.
- `test_band_boundaries_not_the_calibration_points` — pins the 2% and 6% rows above.

150 tests pass across `test_bench_gate_math.py` and `test_bench_run_record.py`; the module
selftest still exits 0.

## Policy sha

`policy_sha` hashes the file's bytes, so this comment-only edit moves it from
`17c4f9ef52c647ae…` to `9d5a3a3776e50610…` and invalidates the recorded reports under
`scripts/bench_evidence/pr882/`, which pinned the former exactly. The edit is semantically empty
— parsing both versions and dropping prose keys leaves only the three `note` strings different,
confirmed against a tampered-`max_cv` control — and `POLICY_SHA_TRANSITIONS.md` records that so
the reports are not silently non-revalidatable.

The underlying problem (a byte-sha cannot tell a comment fix from a threshold change, which
prices the honest correction at the cost of a policy change) is #1138 rather than something to
fix here.

## bench-compare disposition (ADR-058)

Not applicable, and the structural argument rather than an A/B table: this change touches
`scripts/` and `tests/` only. No file under `crates/inference/` or `crates/embed/` is modified,
so no changed line is compiled into any bench binary, and base and head bench binaries have
identical effective source.
