### PR TITLE
chore(ci): stop automated updates for the toolchain-selecting action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,25 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    ignore:
+      # dtolnay/rust-toolchain is not an action whose version should be kept
+      # current. Its ref selects the Rust toolchain the action installs, so the
+      # pinned revision is a version selector owned by rust-toolchain.toml and
+      # by the workspace rust-version, and it has to move in lockstep with them
+      # rather than on a weekly schedule.
+      #
+      # The concrete hazard is the MSRV job in ci.yml, whose pin is deliberately
+      # held one release behind every other pin in the repository because that
+      # job exists to prove the workspace still compiles at the declared
+      # rust-version. An automated bump moves that pin to the newer toolchain
+      # while the trailing version comment keeps claiming the older one, leaving
+      # the file stating a toolchain it no longer selects.
+      #
+      # That bump does not announce itself. The job pins RUSTUP_TOOLCHAIN and
+      # asserts the compiler version, so it stays green while the pin quietly
+      # stops matching its stated intent — and the comment is the only thing
+      # telling a later reader why that one line differs from the others.
+      - dependency-name: "dtolnay/rust-toolchain"
     groups:
       # Patch and minor action bumps are the routine, low-risk ones and travel
       # together in a single pull request so a weekly run does not fan out into

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,10 @@ jobs:
       RUSTUP_TOOLCHAIN: "1.93.1"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      # Held one release behind every other rust-toolchain pin in this repository
+      # on purpose: this ref selects the MSRV compiler, so it tracks rust-version
+      # rather than the newest action revision. Automated updates for this action
+      # are turned off in .github/dependabot.yml for that reason.
       - uses: dtolnay/rust-toolchain@683cb613d4ff7d29ceb2fe421b81294b4319512a # 1.93.1
       - name: Pin the real toolchain bin on PATH
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,9 +483,13 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       # Held one release behind every other rust-toolchain pin in this repository
-      # on purpose: this ref selects the MSRV compiler, so it tracks rust-version
-      # rather than the newest action revision. Automated updates for this action
-      # are turned off in .github/dependabot.yml for that reason.
+      # on purpose: this ref installs the MSRV compiler, which RUSTUP_TOOLCHAIN
+      # above then selects. The ref tracks rust-version rather than the newest
+      # action revision, so automated updates for this action are turned off in
+      # .github/dependabot.yml. Installing is not selecting: dropping
+      # RUSTUP_TOOLCHAIN while keeping this ref would let rust-toolchain.toml
+      # outrank the action's `rustup default`, which is the regression the
+      # comment above describes.
       - uses: dtolnay/rust-toolchain@683cb613d4ff7d29ceb2fe421b81294b4319512a # 1.93.1
       - name: Pin the real toolchain bin on PATH
         run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"


### PR DESCRIPTION
`dtolnay/rust-toolchain` is not an action whose version should be kept current. Its ref selects the
Rust toolchain the action installs, so the pinned revision is a version selector owned by
`rust-toolchain.toml` and the workspace `rust-version`, and it has to move in lockstep with those
rather than on a weekly schedule.

The concrete hazard is the MSRV job in `ci.yml`, whose pin is deliberately held one release behind
every other pin in the repository because that job exists to prove the workspace still compiles at
the declared `rust-version = "1.93"`. An automated bump moves that pin to the 1.94 revision while
the trailing comment keeps reading `# 1.93.1`, leaving the file stating a toolchain it no longer
selects.

That bump does not announce itself, which is why this is a configuration change rather than
something to catch in review. The job sets `RUSTUP_TOOLCHAIN: "1.93.1"` and asserts
`rustc --version | grep -F 1.93.1`, so it stays green while the pin quietly stops matching its
stated intent. Green is the expected outcome there, not the reassuring one, and that trailing
comment is the only thing telling a later reader why one line differs from the other twenty-one.

The MSRV pin itself is unchanged. The added note at that line records why it lags and points at the
configuration that keeps it there.

## Verification

Both pins resolved against the upstream repository rather than format-checked:

| revision | resolves to | comment | agreement |
|---|---|---|---|
| `683cb613…` (current MSRV pin) | branches `1.93`, `1.93.1` | `# 1.93.1` | agrees |
| `e43eeffd…` (proposed by the update) | branches `1.94`, `1.94.1` | would remain `# 1.93.1` | disagrees |

`rust-version = "1.93"` in the workspace manifest; `rust-toolchain.toml` channel `1.94.1`; the other
twenty-one pins of this action are `e43eeffd…` and correctly commented `# 1.94.1`.

`dependabot.yml` parses and the existing grouping and pull-request limit are preserved; `ci.yml`
parses and the MSRV job's pin and `RUSTUP_TOOLCHAIN` are asserted unchanged.

No `crates/` code is touched, so the bench-compare requirement does not apply.
