### PR TITLE
fix(ci): stop the bench-compare gate rejecting long PR descriptions

### DIFF
--- a/scripts/bench_disposition_check.sh
+++ b/scripts/bench_disposition_check.sh
@@ -15,9 +15,9 @@ set -euo pipefail
 
 BODY=$(cat)
 
-# Every read of the description below goes through a herestring or pure parameter
-# expansion, never `printf ... | reader`. Under `set -o pipefail` that pipeline
-# shape turns a LARGE description into a false rejection:
+# Every read of the description below goes through a herestring, never
+# `printf ... | reader`. Under `set -o pipefail` that pipeline shape turns a
+# LARGE description into a false rejection:
 #
 #   `grep -q` and this file's `awk` both exit as soon as they have their answer.
 #   Once the reader is gone, the writing `printf` takes SIGPIPE/EPIPE and exits
@@ -35,7 +35,15 @@ BODY=$(cat)
 # A herestring makes the reader's stdin a temp file with no writer to signal, so
 # an early exit is just an early exit. Fail-closed direction is preserved: a read
 # error still surfaces, it just can no longer be manufactured by input size.
-if [[ -z "${BODY//[[:space:]]/}" ]]; then
+#
+# The readers themselves are unchanged from the pipeline version. Doing the same
+# work in the shell instead (`[[ -z "${BODY//[[:space:]]/}" ]]`) removes a
+# subprocess but is quadratic-ish on bash 3.2, which is what macOS ships as
+# /bin/bash and what the local usage line above invokes: a valid 16KB
+# description took 3.2s that way versus 0.11s under bash 5, and a 65KB one did
+# not finish inside half a minute. The defect being fixed here is the pipe, so
+# the pipe is the only thing that changes.
+if ! grep -q '[^[:space:]]' <<< "$BODY"; then
   echo "empty description; a bench-compare disposition is required" >&2
   exit 1
 fi
@@ -193,7 +201,7 @@ SECTION=$(awk '
 
 # This awk exits early at the section's closing heading, so it is the same
 # early-exiting reader as the greps; see the note at the top.
-if [[ -z "${SECTION//[[:space:]]/}" ]]; then
+if ! grep -q '[^[:space:]]' <<< "$SECTION"; then
   echo "no bench-compare disposition heading found in the description" >&2
   echo "put the numbers under a heading, e.g.  ## bench-compare disposition" >&2
   exit 1
@@ -204,7 +212,7 @@ fi
 # marker matching (markers like "no change" contain spaces) and a stripped
 # copy for the length floor.
 BODYTEXT=$(tail -n +2 <<< "$SECTION")
-CONTENT="${BODYTEXT//[[:space:]]/}"
+CONTENT=$(tr -d '[:space:]' <<< "$BODYTEXT")
 
 # The blessed minimal dispositions are legitimately terse and fall well
 # under a raw length floor: the no-change one-liner CLAUDE.md blesses

--- a/scripts/bench_disposition_check.sh
+++ b/scripts/bench_disposition_check.sh
@@ -15,7 +15,27 @@ set -euo pipefail
 
 BODY=$(cat)
 
-if ! printf '%s' "$BODY" | grep -q '[^[:space:]]'; then
+# Every read of the description below goes through a herestring or pure parameter
+# expansion, never `printf ... | reader`. Under `set -o pipefail` that pipeline
+# shape turns a LARGE description into a false rejection:
+#
+#   `grep -q` and this file's `awk` both exit as soon as they have their answer.
+#   Once the reader is gone, the writing `printf` takes SIGPIPE/EPIPE and exits
+#   non-zero, `pipefail` promotes that to the pipeline's status, and the gate
+#   reports whatever its failure branch says. A short description never trips it,
+#   because printf's whole write fits in the pipe buffer and completes before the
+#   reader exits; past roughly the buffer size printf blocks and the race is lost
+#   every time.
+#
+# So the gate's outcome depended on the description's LENGTH, and the failure was
+# silent about that: a compliant PR with a long body was told "empty description",
+# which sends the author to rewrite a body that was already correct. Observed on a
+# PR whose body carried six bench-compare sections in 65KB.
+#
+# A herestring makes the reader's stdin a temp file with no writer to signal, so
+# an early exit is just an early exit. Fail-closed direction is preserved: a read
+# error still surfaces, it just can no longer be manufactured by input size.
+if [[ -z "${BODY//[[:space:]]/}" ]]; then
   echo "empty description; a bench-compare disposition is required" >&2
   exit 1
 fi
@@ -75,7 +95,7 @@ fi
 # that opens AFTER a visible bench-compare heading still counts as section
 # content, because a real bench table is often fenced; masking suppresses heading
 # detection, not membership in an already-open section.
-SECTION=$(printf '%s' "$BODY" | awk '
+SECTION=$(awk '
   function level(s,   m) {
     if (match(s, /^#{1,6}([ \t]|$)/)) {
       m = substr(s, 1, RLENGTH); sub(/[ \t]*$/, "", m); return length(m)
@@ -169,9 +189,11 @@ SECTION=$(printf '%s' "$BODY" | awk '
     if (!found && lv > 0 && tolower(line) ~ /bench-?compare/) { found = 1; start_lv = lv }
     if (found) print line
   }
-')
+' <<< "$BODY")
 
-if ! printf '%s' "$SECTION" | grep -q '[^[:space:]]'; then
+# This awk exits early at the section's closing heading, so it is the same
+# early-exiting reader as the greps; see the note at the top.
+if [[ -z "${SECTION//[[:space:]]/}" ]]; then
   echo "no bench-compare disposition heading found in the description" >&2
   echo "put the numbers under a heading, e.g.  ## bench-compare disposition" >&2
   exit 1
@@ -181,8 +203,8 @@ fi
 # with nothing beneath it cannot satisfy the gate. Keep a spaced copy for
 # marker matching (markers like "no change" contain spaces) and a stripped
 # copy for the length floor.
-BODYTEXT=$(printf '%s' "$SECTION" | tail -n +2)
-CONTENT=$(printf '%s' "$BODYTEXT" | tr -d '[:space:]')
+BODYTEXT=$(tail -n +2 <<< "$SECTION")
+CONTENT="${BODYTEXT//[[:space:]]/}"
 
 # The blessed minimal dispositions are legitimately terse and fall well
 # under a raw length floor: the no-change one-liner CLAUDE.md blesses
@@ -200,7 +222,7 @@ CONTENT=$(printf '%s' "$BODYTEXT" | tr -d '[:space:]')
 # pre-PR run on macOS); grep -qi tests presence only, so consuming a boundary
 # char is harmless.
 MARKERS='(^|[^[:alnum:]_])(n/a|not required|not applicable|no( measurable)? change|no perf(ormance)? change|compiled out|identical effective source)($|[^[:alnum:]_])'
-if printf '%s' "$BODYTEXT" | grep -qiE "$MARKERS"; then
+if grep -qiE "$MARKERS" <<< "$BODYTEXT"; then
   echo "bench-compare disposition present (explicit disposition marker; ${#CONTENT} chars)"
   exit 0
 fi

--- a/tests/test_bench_disposition.py
+++ b/tests/test_bench_disposition.py
@@ -465,6 +465,40 @@ class BenchDispositionCheck(unittest.TestCase):
         )
         self.assertTrue(has_disposition(body))
 
+    def test_long_body_with_valid_disposition_passes(self):
+        # A compliant description must not be rejected for being LONG. The gate
+        # used to pipe the body into readers that exit early (`grep -q`, and the
+        # section `awk`); once the reader exited, the writing `printf` took EPIPE
+        # and `set -o pipefail` promoted that to the gate's result. Short bodies
+        # never tripped it because the whole write fits in the pipe buffer and
+        # completes before the reader leaves, so the outcome depended on size and
+        # on scheduling: the same description passed locally and failed in CI.
+        #
+        # The padding here is well past a 64KiB pipe buffer so the pre-fix failure
+        # is deterministic rather than marginal. The disposition is a blessed
+        # one-liner, so nothing but length distinguishes this from
+        # test_real_heading_with_content_passes.
+        body = (
+            "## bench-compare disposition\n"
+            "bench-compare showed no change (p > 0.05 on all groups).\n\n"
+            + "".join(
+                f"padding line {i} standing in for the prose a long PR body carries\n"
+                for i in range(2000)
+            )
+        )
+        self.assertGreater(len(body), 64 * 1024)
+        self.assertTrue(has_disposition(body))
+
+    def test_long_body_without_disposition_still_fails(self):
+        # The companion to the case above: the length fix must not turn into a
+        # blanket pass for big bodies. Same size, no disposition heading.
+        body = "".join(
+            f"unrelated prose line {i} that says nothing about the gate\n"
+            for i in range(2000)
+        )
+        self.assertGreater(len(body), 64 * 1024)
+        self.assertFalse(has_disposition(body))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_bench_disposition.py
+++ b/tests/test_bench_disposition.py
@@ -499,6 +499,37 @@ class BenchDispositionCheck(unittest.TestCase):
         self.assertGreater(len(body), 64 * 1024)
         self.assertFalse(has_disposition(body))
 
+    def test_long_body_is_fast_under_system_bash(self):
+        # Guards the OTHER way to get the pipe out of the reads: doing the
+        # whitespace work in the shell (`"${BODY//[[:space:]]/}"`) instead of
+        # handing it to grep/tr. That removes a subprocess but is quadratic-ish
+        # on bash 3.2, which is what macOS ships as /bin/bash and what the
+        # script's own local usage line invokes. Measured on this repo's
+        # host: a valid 16KB body took 3.2s that way versus 0.06s through
+        # grep, and a 64KB body did not finish inside 30s.
+        #
+        # Read the discriminating power honestly: on macOS /bin/bash is 3.2 and
+        # this case catches that shape outright. On a Linux runner /bin/bash is
+        # 5.x, where the shell form is fast and this case cannot fail. It is a
+        # real guard locally and a no-op in CI, which is the reverse of the
+        # usual arrangement and worth knowing before trusting a green run.
+        system_bash = Path("/bin/bash")
+        if not system_bash.exists():
+            self.skipTest("no /bin/bash on this platform")
+        body = (
+            "## bench-compare disposition\n"
+            "bench-compare showed no change (p > 0.05 on all groups).\n\n"
+            + "x" * (64 * 1024)
+        )
+        result = subprocess.run(
+            [str(system_bash), str(SCRIPT)],
+            input=body,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The bench-compare disposition gate rejects compliant PRs when the description is
long, and tells the author the description is empty.

`scripts/bench_disposition_check.sh` read the description by piping it into readers
that stop as soon as they have an answer: `grep -q` exits on its first match, and
the section `awk` exits at the closing heading. Once the reader is gone the writing
`printf` takes EPIPE and exits non-zero, and under `set -o pipefail` that becomes
the pipeline's status. Each site's failure branch then fires on input it had just
successfully matched.

A short description never trips it, because the whole write fits in the pipe buffer
and completes before the reader leaves. Past roughly the buffer size `printf` blocks
and loses the race every time.

## Why this is worse than a size limit

Near the buffer boundary the outcome depends on scheduling, so the same description
can pass locally and fail on a runner. The script's own usage note tells authors to
run it locally before opening a PR, which is exactly the check that gives the wrong
answer.

The reported reason also misdirects. Site one says `empty description` for a 65KB
body containing six bench-compare sections, sending the author to rewrite a
description that was already correct. Fixing only site one moves the failure to
site three, which then says `no bench-compare disposition heading found` about a
body whose first line is that heading.

## Reproduction

Same disposition content, only the length differs:

```
$ printf '## bench-compare disposition\nbench-compare showed no change (p > 0.05 on all groups).\n' \
    | bash scripts/bench_disposition_check.sh
bench-compare disposition present (explicit disposition marker; 55 chars)    # rc=0

$ bash scripts/bench_disposition_check.sh < 64kb-body.txt
empty description; a bench-compare disposition is required                   # rc=1
```

## Fix

Every read of the description goes through a herestring. A reader's stdin becomes a
temp file with no writer to signal, so an early exit is just an early exit. The
readers themselves are unchanged, and so is every accept/reject decision.

Doing the whitespace tests in the shell instead (`"${BODY//[[:space:]]/}"`) also
removes the pipe, and the first version of this PR did that. It is quadratic-ish on
bash 3.2, which is what macOS ships as `/bin/bash` and what the usage line above
invokes: a valid 16KB body took 3.2s that way against 0.06s through `grep`, and a
64KB body did not finish inside 30s. The defect here is the pipe, so the pipe is the
only thing that changes.

## Which checkout runs this script

`bench-evidence.yml` runs as `pull_request_target` and checks out
`github.event.pull_request.base.sha`, so the gate always executes the checker from
the base branch, never from the PR's tree. That is deliberate (a PR must not be able
to edit the script that judges it), and it means this PR's own gate run is scored by
main's current, unfixed script. This description is deliberately short enough to fit
the pipe buffer, so it passes under both the old and the new script and the check
result here does not depend on which version ran.

## Behaviour preserved

Verified at both small and large sizes: empty, whitespace-only, no-heading,
heading-with-no-content, and prose-mention-without-heading all still fail. The 35
existing cases pass unchanged; 38 total after this PR.

## Test plan

- `pytest tests/test_bench_disposition.py` — 38 passed.
- `test_long_body_with_valid_disposition_passes` fails against the previous script
  and passes after, so it is sensitive to the fix rather than decoration. Checked by
  pointing the suite at the base version: exactly one failure, that case.
- `test_long_body_without_disposition_still_fails` is its negative twin, pinning that
  the length fix did not become a blanket pass for large bodies.
- `test_long_body_is_fast_under_system_bash` runs a 64KB valid body through
  `/bin/bash` under a timeout. Reintroducing the shell-expansion form makes it fail
  with a timeout. Its power is platform-dependent and the test says so: on macOS
  `/bin/bash` is 3.2 and it catches that shape outright, while on a Linux runner
  `/bin/bash` is 5.x, where it cannot fail.

## bench-compare disposition (ADR-058)

N/A. This PR changes only `scripts/bench_disposition_check.sh` and its test file.
No file under `crates/inference/` or `crates/embed/` is touched, so no code enters
any bench binary and there is nothing for an A/B to measure.
