### PR TITLE
fix(kv-cache): require pristine state for prefix restore

### DIFF
--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -855,14 +855,15 @@ impl PagedKVCache {
     /// **Unstable**: restore a cached prefix into owned `PagePool` pages.
     ///
     /// Returns `Ok(Some(prefix_len))` on hit and `Ok(None)` when prefix sharing
-    /// is disabled or the key is absent. The cache must be empty (`seq_len == 0`)
-    /// because restore fast-forwards the sequence before the first append.
+    /// is disabled or the key is absent. The cache must be pristine
+    /// (`seq_len == 0` and `num_pages == 0`) because restore fast-forwards the
+    /// sequence before the first append.
     pub fn restore_prefix(
         &mut self,
         adapter_id: AdapterId,
         token_ids: &[u32],
     ) -> Result<Option<usize>, InferenceError> {
-        if self.seq_len() != 0 {
+        if self.seq_len() != 0 || self.num_pages() != 0 {
             return Err(InferenceError::PrefixCache(
                 "restore_prefix requires an empty PagedKVCache".into(),
             ));
@@ -1367,6 +1368,24 @@ mod tests {
 
         assert_eq!(cache.seq_len(), 1);
         assert_eq!(cache.num_pages(), 1);
+    }
+
+    #[test]
+    fn restore_prefix_rejects_append_before_advance() {
+        let config = make_config(4);
+        let kv_dim = config.kv_dim();
+        let mut cache = PagedKVCache::new(config);
+        cache.append_kv_layer(0, &vec![1.0; kv_dim], &vec![2.0; kv_dim]);
+
+        assert_eq!(cache.seq_len(), 0);
+        assert_eq!(cache.num_pages(), 1);
+        let err = cache
+            .restore_prefix(AdapterId::BASE, &[1, 2, 3])
+            .expect_err("partially initialized cache must be rejected");
+        assert!(
+            matches!(err, InferenceError::PrefixCache(_)),
+            "expected PrefixCache error, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Defect

`PagedKVCache::append_kv_layer` allocates and writes the first physical page at position zero before `advance()` publishes the logical sequence length. `restore_prefix` checked only `seq_len()`, so it admitted this partially initialized state and could restore prefix pages alongside the stray populated page.

## Fix

Require both `seq_len() == 0` and `num_pages() == 0` before prefix lookup or restore. The API documentation now states that restore requires a pristine logical and physical cache. A regression test appends one layer at position zero without advancing, proves the cache has one page at sequence length zero, and requires `restore_prefix` to return `PrefixCache`.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p lattice-inference kv_cache::paged::tests --lib` — 30 passed
- `cargo test -p lattice-inference kv_cache::paged::tests::restore_prefix_rejects_append_before_advance --lib -- --exact --nocapture` — 1 passed

Mutation check: removed only `|| self.num_pages() != 0`, retained the regression test, synchronized and touched the source, and reran the exact test. It failed with `partially initialized cache must be rejected: None` (`0 passed; 1 failed`). Restoring the guard and touching the source made the same test pass (`1 passed; 0 failed`).

## Sibling sweep

Searched the KV-cache modules plus Gemma and Metal restore paths. `FlatKVCache` and `Gemma4KvCache` have no prefix restore; `PrefixPageCache` retains immutable shared snapshots rather than a live page table; Metal cross-turn restore deliberately consumes an owned entry and truncates or resets already-live state instead of assuming pristine storage. No sibling path has the same append-before-advance emptiness contract.

## Bench-compare disposition

No A/B benchmark was run. The changed predicate is in `PagedKVCache::restore_prefix`, a cold setup/control path that runs before the first append; it does not change the benchmarked `append_kv_layer`, `advance`, or gather loops.

Closes #1082