### PR TITLE
fix(quant): reject non-finite QuaRot equivalence errors

### DIFF
--- a/crates/inference/src/quant/quarot/forward_equivalence.rs
+++ b/crates/inference/src/quant/quarot/forward_equivalence.rs
@@ -251,8 +251,9 @@ pub struct ForwardEquivalenceReport {
 /// - `rotation.dim() != cfg.hidden_size`.
 /// - Any planned tensor is missing from either working set, or has the
 ///   wrong shape or data length.
-/// - Either the chain probe or the per-tensor check exceeds tolerance —
-///   the refuse-on-fail case. The error message names which check tripped.
+/// - Either the chain probe or the per-tensor check produces a non-finite
+///   error or exceeds tolerance — the refuse-on-fail case. The error
+///   message names which check tripped.
 pub fn assert_forward_equivalence_qwen35(
     original: &HashMap<String, TensorEntry>,
     rotated: &HashMap<String, TensorEntry>,
@@ -314,8 +315,15 @@ pub fn assert_forward_equivalence_qwen35(
                 logits_rot.len()
             )));
         }
-        for (a, b) in logits_orig.iter().zip(logits_rot.iter()) {
+        for (logit_index, (a, b)) in logits_orig.iter().zip(logits_rot.iter()).enumerate() {
             let d = (a - b).abs();
+            if !d.is_finite() {
+                return Err(InferenceError::Inference(format!(
+                    "forward-equivalence refused: chain probe non-finite error \
+                     (token={token}, logit_index={logit_index}, original={a}, rotated={b}, \
+                     abs_error={d}). Do NOT write conversion artifacts."
+                )));
+            }
             if d > chain_max_abs {
                 chain_max_abs = d;
             }
@@ -556,11 +564,23 @@ fn check_per_tensor_rotation_equivalence(
             }
         }
 
-        let delta = expected_rot
-            .iter()
-            .zip(actual.data.iter())
-            .map(|(a, b)| (a - b).abs())
-            .fold(0.0_f64, f64::max);
+        let mut delta = 0.0_f64;
+        for (element_index, (expected, actual)) in
+            expected_rot.iter().zip(actual.data.iter()).enumerate()
+        {
+            let element_delta = (expected - actual).abs();
+            if !element_delta.is_finite() {
+                return Err(InferenceError::Inference(format!(
+                    "forward-equivalence refused: per-tensor non-finite error \
+                     (tensor={expected_name}, element_index={element_index}, \
+                     expected={expected}, actual={actual}, abs_error={element_delta}). \
+                     Do NOT write conversion artifacts."
+                )));
+            }
+            if element_delta > delta {
+                delta = element_delta;
+            }
+        }
         if delta > max_abs {
             max_abs = delta;
         }
@@ -1141,6 +1161,72 @@ mod tests {
             msg.contains("forward-equivalence refused"),
             "unexpected error: {msg}"
         );
+    }
+
+    /// The poisoned rotated norm is consumed only by the chain probe, so
+    /// removing the chain's non-finite guard lets this conversion pass.
+    #[test]
+    fn forward_equivalence_refuses_non_finite_chain_probe_error() {
+        let cfg = tied_tiny_test_cfg();
+        let original = build_working_set(&cfg, 32);
+        let mut rotated = original.clone();
+
+        materialize_lm_head_for_qwen35(&mut rotated, &cfg).unwrap();
+        let (fusion, rot_plan) = full_pipeline_plans(&cfg);
+        fuse_rmsnorms(&mut rotated, &fusion).unwrap();
+        let rotation = RandomizedHadamard::new(0xCA11_0BAD, cfg.hidden_size).unwrap();
+        absorb_rotations(&mut rotated, &rot_plan, &rotation).unwrap();
+
+        rotated.get_mut(QWEN35_FINAL_NORM_NAME).unwrap().data[0] = f64::NAN;
+
+        let err = assert_forward_equivalence_qwen35(
+            &original,
+            &rotated,
+            &cfg,
+            &rotation,
+            &ForwardEquivalenceConfig::default(),
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("chain probe non-finite error"),
+            "unexpected error: {msg}"
+        );
+        assert!(msg.contains("abs_error=NaN"), "unexpected error: {msg}");
+    }
+
+    /// `k_proj` is excluded from the chain probe, so removing the
+    /// per-tensor non-finite guard lets this conversion pass.
+    #[test]
+    fn forward_equivalence_refuses_non_finite_per_tensor_error() {
+        let cfg = tied_tiny_test_cfg();
+        let original = build_working_set(&cfg, 33);
+        let mut rotated = original.clone();
+
+        materialize_lm_head_for_qwen35(&mut rotated, &cfg).unwrap();
+        let (fusion, rot_plan) = full_pipeline_plans(&cfg);
+        fuse_rmsnorms(&mut rotated, &fusion).unwrap();
+        let rotation = RandomizedHadamard::new(0xFACE_FEED, cfg.hidden_size).unwrap();
+        absorb_rotations(&mut rotated, &rot_plan, &rotation).unwrap();
+
+        let k_name = "model.language_model.layers.1.self_attn.k_proj.weight";
+        rotated.get_mut(k_name).unwrap().data[0] = f64::NAN;
+
+        let err = assert_forward_equivalence_qwen35(
+            &original,
+            &rotated,
+            &cfg,
+            &rotation,
+            &ForwardEquivalenceConfig::default(),
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("per-tensor non-finite error"),
+            "unexpected error: {msg}"
+        );
+        assert!(msg.contains(k_name), "unexpected error: {msg}");
+        assert!(msg.contains("abs_error=NaN"), "unexpected error: {msg}");
     }
 
     /// Refuse: rotate without fusing per-layer norms first. Rotation


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

Closes #1081.

## Defect

The QuaRot forward-equivalence gate aggregated absolute errors with ordinary IEEE comparisons. A NaN chain-probe delta made `d > chain_max_abs` false, and the per-tensor `fold(f64::max)` likewise discarded a NaN. Either path could therefore report an in-tolerance maximum and allow a corrupt conversion artifact to proceed.

## Fix

Reject every non-finite element delta before either maximum is updated. Chain-probe diagnostics identify the token and logit index; per-tensor diagnostics identify the tensor and element index. Both errors carry the compared values and preserve the existing refuse-before-write contract.

## Regression and mutation evidence

- `cargo test -p lattice-inference --lib forward_equivalence_refuses_non_finite -- --nocapture`: 2 passed with the fix.
- With only the two production guards removed and both tests retained, the same command failed 2/2. The chain case unexpectedly returned `Ok(ForwardEquivalenceReport { max_abs_error: 0.0, mean_abs_error: NaN, ... })`; the chain-skipped `k_proj` case unexpectedly returned `Ok` with `max_abs_error: 1.1102230246251565e-15`.
- Restoring the guards and rebuilding the touched source returned the filter to 2 passed.
- `cargo test -p lattice-inference --lib quant::quarot::forward_equivalence::tests -- --nocapture`: 26 passed.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy --workspace -- -D warnings`: passed.

## Sibling sweep

Searched the QuaRot implementation for forward-equivalence entry points, tolerance gates, max-absolute-error aggregations, and `f32`/`f64::max` folds. The converter delegates to this single production forward-equivalence gate; its chain and per-tensor aggregators are the only production siblings requiring this fix. The analogous helpers in `pipeline`, `lora`, `rmsnorm_fusion`, and `rotation` are test-only and already return non-finite deltas honestly. Remaining folds in `plan`, `rotation` precision coverage, `hadamard`, and the R3 reference are also test-only assertions.

## bench-compare disposition

No A/B benchmark was run. `assert_forward_equivalence_qwen35` and `check_per_tensor_rotation_equivalence` execute only in the offline QuaRot conversion validation pass before artifact writes; they are outside runtime inference hot paths and Criterion benchmark targets. The change adds fail-closed branches only to that cold validation path.
