### PR TITLE
fix(inference): return typed error for LoRA all-logits prefill

### DIFF
--- a/crates/inference/src/bin/bench_logit_dump.rs
+++ b/crates/inference/src/bin/bench_logit_dump.rs
@@ -83,7 +83,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     eprintln!("[bench_logit_dump] running forward_prefill_all_logits...");
-    let logits_flat = metal.forward_prefill_all_logits(&tokens);
+    let logits_flat = metal.forward_prefill_all_logits(&tokens)?;
 
     let vocab = cfg.vocab_size;
     let n_pos = tokens.len();

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -7064,13 +7064,29 @@ mod inner {
         ///
         /// Panics if any `token_ids[i] >= vocab_size`. See [`forward_prefill`] for details.
         ///
+        /// # Errors
+        ///
+        /// Returns an error when more than one position is requested while a
+        /// LoRA adapter is active, because the batched all-position path does
+        /// not apply LoRA projections.
+        ///
         /// # Cross-turn cache invalidation (#516)
         ///
         /// Public raw-forward entry point — see [`Self::forward_step`]'s doc
         /// comment for the invariant this enforces.
-        pub fn forward_prefill_all_logits(&mut self, token_ids: &[u32]) -> Vec<f32> {
+        pub fn forward_prefill_all_logits(
+            &mut self,
+            token_ids: &[u32],
+        ) -> Result<Vec<f32>, crate::error::InferenceError> {
+            if token_ids.len() > 1 && self.lora.is_some() {
+                return Err(crate::error::InferenceError::Inference(
+                    "forward_prefill_all_logits: all-position prefill does not apply LoRA \
+                     adapters; unload the adapter before requesting all-position logits"
+                        .into(),
+                ));
+            }
             self.cross_turn_prefix_cache.clear();
-            self.forward_prefill_impl(token_ids, true)
+            Ok(self.forward_prefill_impl(token_ids, true))
         }
 
         fn forward_prefill_impl(&mut self, token_ids: &[u32], all_positions: bool) -> Vec<f32> {
@@ -7097,12 +7113,6 @@ mod inner {
             }
             if self.lora.is_some() {
                 // Batched helper does not apply LoRA adapters; stay on sequential path.
-                if all_positions {
-                    panic!(
-                        "forward_prefill_all_logits: LoRA active — \
-                         batch/all-position prefill does not apply LoRA"
-                    );
-                }
                 let mut last_logits = Vec::new();
                 for (pos, &id) in token_ids.iter().enumerate() {
                     last_logits = self.forward_step(id, pos);
@@ -15946,8 +15956,8 @@ mod inner {
         /// softmax runs over the full vocabulary at decode step `i`.
         ///
         /// Errors if `tokens.len() < 2`, if `tokens.len() > self.max_context()`
-        /// (the KV cache would overflow during the walk), or if any
-        /// `token_id >= cfg.vocab_size`.
+        /// (the KV cache would overflow during the walk), if any
+        /// `token_id >= cfg.vocab_size`, or if a LoRA adapter is active.
         pub fn compute_token_nlls(
             &mut self,
             tokens: &[u32],
@@ -15985,7 +15995,7 @@ mod inner {
             // Sequential forward_step from pos=0 with reset_state does NOT
             // produce usable next-token distributions and is not used here.
             self.reset_state();
-            let flat = self.forward_prefill_all_logits(tokens);
+            let flat = self.forward_prefill_all_logits(tokens)?;
             debug_assert_eq!(flat.len(), tokens.len() * vocab_size);
             let mut nlls = Vec::with_capacity(tokens.len() - 1);
             for i in 0..tokens.len() - 1 {
@@ -24761,6 +24771,52 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         }
 
         #[test]
+        fn lora_all_position_prefill_and_nll_return_typed_errors() {
+            let _gpu = gpu_test_lock();
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let mut state =
+                MetalQwen35State::new(&weights, &cfg, 4).expect("tiny fixture constructs");
+            state
+                .load_lora_adapter(vec![make_valid_layer(cfg.hidden_size, 1)], 1.0, None)
+                .expect("valid LoRA adapter loads");
+
+            let direct_outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                state.forward_prefill_all_logits(&[1, 2])
+            }));
+            let direct_result =
+                direct_outcome.expect("LoRA all-position prefill must return Err, not panic");
+            let direct_error = direct_result.expect_err("active LoRA must reject all-position");
+            assert!(
+                matches!(
+                    &direct_error,
+                    crate::error::InferenceError::Inference(message)
+                        if message.contains("all-position prefill")
+                            && message.contains("LoRA adapters")
+                ),
+                "unexpected all-position error: {direct_error}"
+            );
+
+            let nll_outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                state.compute_token_nlls(&[1, 2])
+            }));
+            let nll_result =
+                nll_outcome.expect("LoRA compute_token_nlls must return Err, not panic");
+            let nll_error = nll_result.expect_err("active LoRA must reject per-token NLLs");
+            assert!(
+                matches!(
+                    &nll_error,
+                    crate::error::InferenceError::Inference(message)
+                        if message.contains("all-position prefill")
+                            && message.contains("LoRA adapters")
+                ),
+                "unexpected NLL error: {nll_error}"
+            );
+        }
+
+        #[test]
         fn load_lora_adapter_rejects_short_a() {
             let Some(_dev) = metal::Device::system_default() else {
                 return;
@@ -30804,7 +30860,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             // the emit_logits gate) — its final-position row is what an unskipped last
             // chunk would have produced.
             state.reset_state();
-            let all_logits = state.forward_prefill_all_logits(&tokens);
+            let all_logits = state
+                .forward_prefill_all_logits(&tokens)
+                .expect("LoRA-inactive all-position prefill succeeds");
             assert_eq!(
                 all_logits.len(),
                 tokens.len() * vocab,
@@ -30879,7 +30937,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
 
             // Must not panic; returns n * vocab_size f32 values.
             state.reset_state();
-            let flat = state.forward_prefill_all_logits(&tokens);
+            let flat = state
+                .forward_prefill_all_logits(&tokens)
+                .expect("LoRA-inactive all-position prefill succeeds");
             assert_eq!(
                 flat.len(),
                 tokens.len() * model.config().vocab_size,
@@ -31468,7 +31528,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 // fail the gate, never get masked by a lucky retry.
                 state.use_gdn_chunked = true;
                 state.reset_state();
-                let chunked_all = state.forward_prefill_all_logits(&tokens);
+                let chunked_all = state
+                    .forward_prefill_all_logits(&tokens)
+                    .expect("LoRA-inactive chunked all-position prefill succeeds");
                 assert_eq!(
                     chunked_all.len(),
                     n * vocab,
@@ -31487,7 +31549,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     // Serial path (chunked OFF): per-position logits via all_logits.
                     state.use_gdn_chunked = false;
                     state.reset_state();
-                    let serial_all = state.forward_prefill_all_logits(&tokens);
+                    let serial_all = state
+                        .forward_prefill_all_logits(&tokens)
+                        .expect("LoRA-inactive serial all-position prefill succeeds");
                     assert_eq!(
                         serial_all.len(),
                         n * vocab,


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

Closes #1084.

## Defect

`MetalQwen35State::forward_prefill_all_logits` panicked when more than one position was requested with an active LoRA adapter. `compute_token_nlls` and `compute_perplexity` reach that all-position path, so an ordinary adapter-plus-perplexity request could terminate the process instead of returning through the existing inference error channel.

## Fix

- Change the unstable all-logits method to return `Result<Vec<f32>, InferenceError>`.
- Return a typed `InferenceError::Inference` before dispatch when multi-position all-logits prefill is requested with active LoRA.
- Preserve the existing zero- and one-position paths, where no unsupported batched LoRA operation is needed.
- Propagate the result through `compute_token_nlls` (and therefore `compute_perplexity`) and update every direct caller, including `bench_logit_dump`.

## Regression test and mutation evidence

`lora_all_position_prefill_and_nll_return_typed_errors` loads a valid LoRA adapter and checks both the direct all-logits entry point and `compute_token_nlls`. Each call is wrapped with `catch_unwind`, so the test specifically requires `Err(InferenceError::Inference(..))` and distinguishes it from a panic. The test acquires the repository's machine-wide Metal GPU lock.

- Fix present: the exact Metal test passed.
- Mutation: replaced only the typed-error guard with the former `panic!`, left the test intact, touched `metal_qwen35.rs`, and reran the exact test. It failed with `forward_prefill_all_logits: LoRA active — batch/all-position prefill does not apply LoRA`, followed by `LoRA all-position prefill must return Err, not panic: Any { .. }`.
- Restored: restored the saved production source byte-for-byte, touched it, and the exact test passed again.

## Sibling-path sweep

Searched all `lora.is_some()`, `all_positions`, and `forward_prefill_all_logits` paths and call sites. The cross-turn suffix sibling `forward_prefill_from(..., all_positions)` already returns a typed `InferenceError::PrefixCache` for active LoRA plus all-position output. Last-logit prefill intentionally remains on its sequential LoRA-aware path. `compute_perplexity` delegates to `compute_token_nlls` and now propagates the same typed error. No other LoRA/all-position sibling was found.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p lattice-inference --features "f16 metal-gpu" --lib --bin bench_logit_dump -- -D warnings`
- `cargo test -p lattice-inference --features metal-gpu --lib forward::metal_qwen35::inner::tests::lora_all_position_prefill_and_nll_return_typed_errors -- --exact --nocapture --test-threads=1`
- `./scripts/lint-docs.sh`

## bench-compare disposition

No A/B benchmark was run. The changed production method and its callers in `metal_qwen35.rs` are compiled only under `cfg(all(target_os = "macos", feature = "metal-gpu"))`; the default `bench-compare` inference target (`elementwise_cpu_bench`) builds without `metal-gpu`, so its base and head binaries have identical effective source. The only other production caller change is in `bench_logit_dump`, a standalone binary gated on `f16` plus `metal-gpu` and not a Criterion benchmark target. The remaining changes are tests and documentation.