### PR TITLE
fix(inference): harden batch, BitNet, and grammar inputs

### DIFF
--- a/crates/inference/src/batch/worker.rs
+++ b/crates/inference/src/batch/worker.rs
@@ -62,6 +62,19 @@ impl GdnStatePool {
     /// sizes for the full model (all GDN layers combined):
     /// - `s_floats_per_slot` = Σ_layers (num_heads × key_dim × value_dim)
     /// - `conv_floats_per_slot` = Σ_layers (conv_dim × (kernel_size - 1))
+    ///
+    /// # Deprecated
+    ///
+    /// This constructor performs no geometry checking, so an overflowing
+    /// `capacity × floats_per_slot` product reaches `Vec` and panics inside the
+    /// allocator instead of returning an error. [`GdnStatePool::try_new`]
+    /// performs the same construction with the products checked. Retained only
+    /// so the 0.7.x line stays source-compatible; scheduled for removal in
+    /// 0.8.0.
+    #[deprecated(
+        since = "0.7.1",
+        note = "unchecked geometry: panics in the allocator on overflow. Use `GdnStatePool::try_new`, which returns `InferenceError::InvalidInput`. Removed in 0.8.0."
+    )]
     pub fn new(capacity: usize, s_floats_per_slot: usize, conv_floats_per_slot: usize) -> Self {
         let s_matrices = (0..capacity)
             .map(|_| vec![0.0f32; s_floats_per_slot])
@@ -131,6 +144,9 @@ impl GdnStatePool {
                 "capacity ({capacity}) outer-vector allocation ({outer_bytes} bytes) exceeds isize::MAX"
             )));
         }
+        // The geometry is fully checked above; `new` is the unchecked body this
+        // constructor exists to wrap, so calling it here is the intended path.
+        #[allow(deprecated)]
         Ok(Self::new(capacity, s_floats_per_slot, conv_floats_per_slot))
     }
 
@@ -275,6 +291,20 @@ impl BatchWorker {
     /// * `s_floats_per_slot` — GDN s_matrix floats per concurrent sequence.
     /// * `conv_floats_per_slot` — GDN conv buffer floats per concurrent sequence.
     /// * `eos_token_id` — Token ID that signals end-of-sequence, if any.
+    ///
+    /// # Deprecated
+    ///
+    /// This constructor skips [`BatchConfig::validate`] and builds its pools
+    /// through the unchecked `PagePool::new` / `GdnStatePool::new` path, so an
+    /// invalid config or an overflowing page geometry is accepted here and
+    /// surfaces later as an allocator panic or a wrong-sized pool.
+    /// [`BatchWorker::try_new`] takes the same arguments and returns
+    /// `InferenceError::InvalidInput` instead. Retained only so the 0.7.x line
+    /// stays source-compatible; scheduled for removal in 0.8.0.
+    #[deprecated(
+        since = "0.7.1",
+        note = "skips BatchConfig::validate and unchecked page geometry. Use `BatchWorker::try_new`, which returns `InferenceError::InvalidInput`. Removed in 0.8.0."
+    )]
     pub fn new(
         config: BatchConfig,
         kv_pool_config: PagedKVCacheConfig,
@@ -283,7 +313,9 @@ impl BatchWorker {
         eos_token_id: Option<u32>,
     ) -> Self {
         let floats_per_page = kv_pool_config.floats_per_page_pub();
+        #[allow(deprecated)]
         let kv_pool = PagePool::new(kv_pool_config.max_pages, floats_per_page);
+        #[allow(deprecated)]
         let gdn_pool = GdnStatePool::new(
             config.max_batch_size,
             s_floats_per_slot,
@@ -675,7 +707,7 @@ mod tests {
 
     #[test]
     fn gdn_pool_alloc_and_free() {
-        let mut pool = GdnStatePool::new(2, 4, 2);
+        let mut pool = GdnStatePool::try_new(2, 4, 2).expect("valid pool geometry");
         assert_eq!(pool.free_count(), 2);
         let s0 = pool.alloc(SeqId(0));
         assert!(s0.is_some());
@@ -692,7 +724,7 @@ mod tests {
 
     #[test]
     fn gdn_pool_free_zeroes_buffers() {
-        let mut pool = GdnStatePool::new(1, 4, 2);
+        let mut pool = GdnStatePool::try_new(1, 4, 2).expect("valid pool geometry");
         let slot = pool.alloc(SeqId(0)).unwrap();
         pool.s_matrix_mut(slot).fill(1.0);
         pool.conv_buffer_mut(slot).fill(2.0);
@@ -706,7 +738,7 @@ mod tests {
 
     #[test]
     fn gdn_pool_slot_of() {
-        let mut pool = GdnStatePool::new(2, 4, 2);
+        let mut pool = GdnStatePool::try_new(2, 4, 2).expect("valid pool geometry");
         pool.alloc(SeqId(5)).unwrap();
         assert!(pool.slot_of(SeqId(5)).is_some());
         assert!(pool.slot_of(SeqId(99)).is_none());

--- a/crates/inference/src/batch/worker.rs
+++ b/crates/inference/src/batch/worker.rs
@@ -302,8 +302,8 @@ impl BatchWorker {
         }
     }
 
-    /// Fallible constructor — returns `InvalidInput` on overflow rather than
-    /// panicking or silently allocating a wrong-sized pool.
+    /// Fallible constructor — validates the batch configuration and returns
+    /// `InvalidInput` on invalid geometry or overflow.
     pub fn try_new(
         config: BatchConfig,
         kv_pool_config: PagedKVCacheConfig,
@@ -311,6 +311,7 @@ impl BatchWorker {
         conv_floats_per_slot: usize,
         eos_token_id: Option<u32>,
     ) -> Result<Self, InferenceError> {
+        config.validate().map_err(InferenceError::InvalidInput)?;
         let floats_per_page = kv_pool_config.try_floats_per_page_pub()?;
         let kv_pool = PagePool::try_new(kv_pool_config.max_pages, floats_per_page)?;
         let gdn_pool = GdnStatePool::try_new(
@@ -1022,6 +1023,51 @@ mod tests {
             matches!(r, Err(InferenceError::InvalidInput(_))),
             "expected InvalidInput on worker PagePool capacity overflow"
         );
+    }
+
+    #[test]
+    fn batch_worker_try_new_rejects_invalid_batch_config() {
+        let invalid_configs = [
+            (
+                "max_batch_size",
+                BatchConfig {
+                    max_batch_size: 0,
+                    ..BatchConfig::default()
+                },
+            ),
+            (
+                "max_seq_len",
+                BatchConfig {
+                    max_seq_len: 0,
+                    ..BatchConfig::default()
+                },
+            ),
+            (
+                "chunk_size",
+                BatchConfig {
+                    chunk_size: 0,
+                    ..BatchConfig::default()
+                },
+            ),
+            (
+                "chunk_size",
+                BatchConfig {
+                    chunk_size: 513,
+                    ..BatchConfig::default()
+                },
+            ),
+        ];
+
+        for (field, config) in invalid_configs {
+            let result = BatchWorker::try_new(config, test_kv_config(), 1, 1, None);
+            let Err(InferenceError::InvalidInput(message)) = result else {
+                panic!("expected InvalidInput for invalid {field}");
+            };
+            assert!(
+                message.contains(field),
+                "error for invalid {field} must identify the field, got: {message}"
+            );
+        }
     }
 
     // --- GdnStatePool isize::MAX boundary test (Fix 2) ---

--- a/crates/inference/src/bin/gramperf_profile.rs
+++ b/crates/inference/src/bin/gramperf_profile.rs
@@ -385,7 +385,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             for l in dummy_logits.iter_mut() {
                 *l = 0.0;
             }
-            engine.mask_logits(&mut state, &mut dummy_logits);
+            engine.mask_logits(&mut state, &mut dummy_logits)?;
             let masked = dummy_logits
                 .iter()
                 .filter(|&&l| l == f32::NEG_INFINITY)

--- a/crates/inference/src/forward/bitnet_kernel.rs
+++ b/crates/inference/src/forward/bitnet_kernel.rs
@@ -38,6 +38,8 @@
 //!
 //! The final output is: `y = alpha * gamma * dot(x_q, w_ternary)`
 
+use crate::error::InferenceError;
+
 // ---------------------------------------------------------------------------
 // I2_S weight encoding
 // ---------------------------------------------------------------------------
@@ -86,7 +88,13 @@ pub fn packed_row_bytes(k: usize) -> usize {
 ///   w_ternary = RoundClip(w / alpha, -1, 1)
 ///
 /// Returns `(packed_bytes, alpha)` where `alpha` is the per-row scale factor.
-fn pack_row(row: &[f32]) -> (Vec<u8>, f32) {
+fn pack_row(row: &[f32]) -> Result<(Vec<u8>, f32), InferenceError> {
+    if let Some((index, value)) = row.iter().enumerate().find(|(_, value)| !value.is_finite()) {
+        return Err(InferenceError::InvalidInput(format!(
+            "BitNet weight row contains non-finite value {value} at index {index}"
+        )));
+    }
+
     // Compute alpha = mean(|w|)
     let abs_sum: f32 = row.iter().map(|v| v.abs()).sum();
     let alpha = if row.is_empty() {
@@ -110,7 +118,7 @@ fn pack_row(row: &[f32]) -> (Vec<u8>, f32) {
         }
     }
 
-    (packed, alpha)
+    Ok((packed, alpha))
 }
 
 /// **Unstable**: pack float weights into I2_S ternary format; packing convention may change.
@@ -120,21 +128,43 @@ fn pack_row(row: &[f32]) -> (Vec<u8>, f32) {
 /// Returns `(packed_bytes, alphas)` where:
 /// - `packed_bytes`: length `n * packed_row_bytes(k)`, rows stored contiguously
 /// - `alphas`: per-row scale factors, length `n`
-pub fn pack_ternary(weights: &[f32], n: usize, k: usize) -> (Vec<u8>, Vec<f32>) {
-    assert_eq!(weights.len(), n * k, "weights length must be n*k");
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidInput`] when the matrix geometry does not
+/// match `weights` or any weight is non-finite.
+pub fn pack_ternary(
+    weights: &[f32],
+    n: usize,
+    k: usize,
+) -> Result<(Vec<u8>, Vec<f32>), InferenceError> {
+    let expected_len = n.checked_mul(k).ok_or_else(|| {
+        InferenceError::InvalidInput(format!("BitNet weight geometry overflows: n={n}, k={k}"))
+    })?;
+    if weights.len() != expected_len {
+        return Err(InferenceError::InvalidInput(format!(
+            "BitNet weights length {} does not match n*k ({n}*{k}={expected_len})",
+            weights.len()
+        )));
+    }
 
     let row_bytes = packed_row_bytes(k);
-    let mut packed = vec![0u8; n * row_bytes];
+    let packed_len = n.checked_mul(row_bytes).ok_or_else(|| {
+        InferenceError::InvalidInput(format!(
+            "BitNet packed geometry overflows: n={n}, row_bytes={row_bytes}"
+        ))
+    })?;
+    let mut packed = vec![0u8; packed_len];
     let mut alphas = vec![0.0f32; n];
 
     for row_idx in 0..n {
         let row = &weights[row_idx * k..(row_idx + 1) * k];
-        let (row_packed, alpha) = pack_row(row);
+        let (row_packed, alpha) = pack_row(row)?;
         packed[row_idx * row_bytes..(row_idx + 1) * row_bytes].copy_from_slice(&row_packed);
         alphas[row_idx] = alpha;
     }
 
-    (packed, alphas)
+    Ok((packed, alphas))
 }
 
 /// **Unstable**: unpack a single I2_S ternary weight; for debugging and testing only.
@@ -516,7 +546,7 @@ mod tests {
             weights[k + i] = t as f32 * alpha;
         }
 
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
         // Alpha should be close to the mean absolute value.
         // Row 0: 6 nonzero * alpha / 8 = 0.375
@@ -554,7 +584,7 @@ mod tests {
         let n = 1;
         // All +1 weights.
         let weights = vec![1.0f32; k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
         assert!(alphas[0] > 0.0);
         assert_eq!(packed.len(), packed_row_bytes(k)); // ceil(7/4) = 2 bytes
@@ -562,6 +592,26 @@ mod tests {
         for j in 0..k {
             assert_eq!(unpack_weight(&packed, k, 0, j), 1, "col={j}");
         }
+    }
+
+    #[test]
+    fn pack_ternary_rejects_non_finite_weights() {
+        for non_finite in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let result = pack_ternary(&[0.25, non_finite, -0.5, 1.0], 1, 4);
+            assert!(
+                matches!(result, Err(InferenceError::InvalidInput(_))),
+                "non-finite weight {non_finite} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn pack_ternary_rejects_mismatched_geometry() {
+        let result = pack_ternary(&[0.25, -0.5, 1.0], 1, 4);
+        assert!(
+            matches!(result, Err(InferenceError::InvalidInput(_))),
+            "weights whose length differs from n*k must be rejected"
+        );
     }
 
     // -------------------------------------------------------------------
@@ -639,7 +689,7 @@ mod tests {
         let n = 2;
         let k = 4;
         let weights = vec![1.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
         // Activation: [1.0, 2.0, 3.0, 4.0]
         let x = vec![1.0, 2.0, 3.0, 4.0];
@@ -675,7 +725,7 @@ mod tests {
         for i in 0..n {
             weights[i * k + i] = 1.0;
         }
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
         let x = vec![10.0, 20.0, 30.0, 40.0];
         let (x_q, gamma) = quantize_activation(&x);
@@ -713,7 +763,7 @@ mod tests {
         let n = 3;
         let k = 8;
         let weights = vec![0.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
         let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let (x_q, gamma) = quantize_activation(&x);
@@ -732,7 +782,7 @@ mod tests {
         let n = 1;
         let k = 8;
         let weights = vec![-1.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
         let x = vec![1.0; k]; // sum = 8.0
         let (x_q, gamma) = quantize_activation(&x);
@@ -777,11 +827,11 @@ mod tests {
         let ternary_output = matmul_ternary(
             &x,
             &{
-                let (p, _) = pack_ternary(&weights, n, k);
+                let (p, _) = pack_ternary(&weights, n, k).expect("finite test weights");
                 p
             },
             &{
-                let (_, a) = pack_ternary(&weights, n, k);
+                let (_, a) = pack_ternary(&weights, n, k).expect("finite test weights");
                 a
             },
             n,
@@ -810,7 +860,7 @@ mod tests {
         let n = 2;
         let k = 7;
         let weights = vec![1.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
         let x: Vec<f32> = (0..k).map(|i| (i + 1) as f32).collect(); // [1..7]
         let (x_q, gamma) = quantize_activation(&x);
@@ -849,7 +899,7 @@ mod tests {
                     _ => 0.0,
                 };
             }
-            let (packed, alphas) = pack_ternary(&weights, n, k);
+            let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
             let x: Vec<f32> = (0..k).map(|i| (i as f32 - 16.0) * 0.1).collect();
             let (x_q, gamma) = quantize_activation(&x);
@@ -891,7 +941,7 @@ mod tests {
                     _ => 0.0,
                 };
             }
-            let (packed, alphas) = pack_ternary(&weights, n, k);
+            let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
             let x: Vec<f32> = (0..k)
                 .map(|i| ((i * 13 % 100) as f32 - 50.0) * 0.01)
@@ -932,7 +982,7 @@ mod tests {
                     _ => 0.4,
                 })
                 .collect();
-            let (packed, alphas) = pack_ternary(&weights, n, k);
+            let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
             let x: Vec<f32> = (0..k).map(|i| (i as f32 * 0.01) - 0.5).collect();
             let (x_q, gamma) = quantize_activation(&x);
@@ -968,7 +1018,7 @@ mod tests {
             let n = 2;
             let k = 32;
             let weights = vec![1.0f32; n * k];
-            let (packed, alphas) = pack_ternary(&weights, n, k);
+            let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
             let x_q = vec![1i8; k - 1]; // too short
             let mut output = vec![0.0f32; n];
             // SAFETY: never reached — the validator panics before any `get_unchecked` read.
@@ -982,7 +1032,7 @@ mod tests {
             let n = 2;
             let k = 64;
             let weights = vec![0.0f32; n * k];
-            let (packed, alphas) = pack_ternary(&weights, n, k);
+            let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
             let x = vec![5.0f32; k];
             let (x_q, gamma) = quantize_activation(&x);
@@ -1004,7 +1054,7 @@ mod tests {
             let n = 1;
             let k = 64;
             let weights = vec![1.0f32; n * k]; // all +1
-            let (packed, alphas) = pack_ternary(&weights, n, k);
+            let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
             let x = vec![1.0f32; k]; // sum = 64
             let (x_q, gamma) = quantize_activation(&x);
@@ -1033,7 +1083,7 @@ mod tests {
         let n = 4;
         let k = 32;
         let weights = vec![1.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
 
         let x = vec![1.0f32; k];
         let output = matmul_ternary(&x, &packed, &alphas, n, k);
@@ -1062,7 +1112,7 @@ mod tests {
         let n = 2;
         let k = 32;
         let weights = vec![1.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
         let x = vec![1.0f32; k - 1]; // too short
         let _ = matmul_ternary(&x, &packed, &alphas, n, k);
     }
@@ -1073,7 +1123,7 @@ mod tests {
         let n = 2;
         let k = 32;
         let weights = vec![1.0f32; n * k];
-        let (packed, _alphas) = pack_ternary(&weights, n, k);
+        let (packed, _alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
         let x = vec![1.0f32; k];
         let short_alphas = vec![1.0f32; n - 1];
         let _ = matmul_ternary(&x, &packed, &short_alphas, n, k);
@@ -1085,7 +1135,7 @@ mod tests {
         let n = 2;
         let k = 32;
         let weights = vec![1.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
         let short_packed = &packed[..packed.len() - 1];
         let x = vec![1.0f32; k];
         let _ = matmul_ternary(&x, short_packed, &alphas, n, k);
@@ -1097,7 +1147,7 @@ mod tests {
         let n = 2;
         let k = 32;
         let weights = vec![1.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
         let x_q = vec![1i8; k - 1]; // too short
         let mut output = vec![0.0f32; n];
         matvec_ternary_scalar(&x_q, 1.0, &packed, &alphas, n, k, &mut output);
@@ -1116,7 +1166,7 @@ mod tests {
         let n = 2;
         let k = 5;
         let weights = vec![1.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
         let x_q = vec![1i8; k - 1]; // too short, ends inside the remainder range
         let mut output = vec![0.0f32; n];
         matvec_ternary_scalar(&x_q, 1.0, &packed, &alphas, n, k, &mut output);
@@ -1127,7 +1177,7 @@ mod tests {
         let n = 2;
         let k = 32;
         let weights = vec![1.0f32; n * k];
-        let (packed, alphas) = pack_ternary(&weights, n, k);
+        let (packed, alphas) = pack_ternary(&weights, n, k).expect("finite test weights");
         let x_q = vec![1i8; k + 4]; // oversized
         let mut output = vec![0.0f32; n + 4]; // oversized
         matvec_ternary_scalar(&x_q, 1.0, &packed, &alphas, n, k, &mut output);

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -8912,7 +8912,7 @@ mod inner {
 
             // Apply grammar masking to prefill logits before sampling.
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                engine.mask_logits(gs, &mut prefill_logits);
+                engine.mask_logits(gs, &mut prefill_logits)?;
                 // If the grammar blocked every token the sampler's non-finite-max
                 // short-circuit would silently return the first candidate's token
                 // id. An accepting state with no legal continuation is a completed
@@ -9110,7 +9110,7 @@ mod inner {
                         let _signpost_grammar = crate::forward::signpost::interval(
                             crate::forward::signpost::Label::DecodeGrammarMask,
                         );
-                        engine.mask_logits(gs, &mut step_logits);
+                        engine.mask_logits(gs, &mut step_logits)?;
                         // Fail closed if the grammar blocked every continuation,
                         // matching the CPU contract (#611).
                         if !super::has_finite_logit(&step_logits) {
@@ -13951,7 +13951,7 @@ mod inner {
 
             // Apply grammar masking to prefill logits before sampling.
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                engine.mask_logits(gs, &mut prefill_logits);
+                engine.mask_logits(gs, &mut prefill_logits)?;
                 // If the grammar blocked every token the sampler's non-finite-max
                 // short-circuit would silently return the first candidate's token
                 // id. An accepting state with no legal continuation is a completed
@@ -14160,7 +14160,7 @@ mod inner {
                     let _signpost_grammar = crate::forward::signpost::interval(
                         crate::forward::signpost::Label::DecodeGrammarMask,
                     );
-                    engine.mask_logits(gs, &mut step_logits);
+                    engine.mask_logits(gs, &mut step_logits)?;
                     // Fail closed if the grammar blocked every continuation,
                     // matching the CPU contract (#611).
                     if !super::has_finite_logit(&step_logits) {
@@ -16949,7 +16949,7 @@ mod inner {
             }
 
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                engine.mask_logits(gs, &mut prefill_logits);
+                engine.mask_logits(gs, &mut prefill_logits)?;
                 // If the grammar blocked every token the sampler's non-finite-max
                 // short-circuit would silently return the first candidate's token
                 // id. An accepting state with no legal continuation is a completed
@@ -17208,7 +17208,7 @@ mod inner {
                     let _signpost_grammar = crate::forward::signpost::interval(
                         crate::forward::signpost::Label::DecodeGrammarMask,
                     );
-                    engine.mask_logits(gs, &mut step_logits);
+                    engine.mask_logits(gs, &mut step_logits)?;
                     // Fail closed if the grammar blocked every continuation,
                     // matching the CPU contract (#611).
                     if !super::has_finite_logit(&step_logits) {

--- a/crates/inference/src/generate.rs
+++ b/crates/inference/src/generate.rs
@@ -564,7 +564,7 @@ pub fn generate(
 
     // Apply grammar masking on the logit buffer in-place before sampling.
     if let (Some(engine), Some(gs)) = (&config.grammar, &mut grammar_state) {
-        engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+        engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size])?;
         // If the grammar blocked every token the sampler's non-finite-max
         // short-circuit would silently return token 0 (the lowest id after
         // sorting an all-NEG_INFINITY candidate set). Fail closed instead (#398).
@@ -636,7 +636,7 @@ pub fn generate(
 
             // Apply grammar masking before sampling.
             if let (Some(engine), Some(gs)) = (&config.grammar, &mut grammar_state) {
-                engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+                engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size])?;
                 // Same empty-mask guard as the first-token path: an all-NEG_INFINITY
                 // logit buffer would cause the sampler to silently emit token 0 (#398).
                 if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -17,7 +17,7 @@
 //!     ↓
 //! loop {
 //!     forward_pass(input) → logits
-//!     engine.mask_logits(&mut state, logits) — apply grammar constraint
+//!     engine.mask_logits(&mut state, logits)? — apply grammar constraint
 //!     token = sampler.sample(logits)
 //!     engine.advance(&mut state, token_id)  — update grammar state
 //! }
@@ -178,6 +178,12 @@ impl fmt::Display for GrammarError {
     }
 }
 impl std::error::Error for GrammarError {}
+
+impl From<GrammarError> for crate::error::InferenceError {
+    fn from(error: GrammarError) -> Self {
+        Self::InvalidInput(error.0)
+    }
+}
 
 impl From<crate::grammar::json_schema::SchemaError> for GrammarError {
     fn from(e: crate::grammar::json_schema::SchemaError) -> Self {
@@ -376,19 +382,23 @@ impl GrammarEngine {
     /// been created by `initial_state()` and advanced via `advance()` after
     /// each sampled token.
     ///
+    /// # Errors
+    ///
+    /// Returns [`GrammarError`] when `logits` is shorter than the engine's
+    /// vocabulary.
+    ///
     /// # Performance
     ///
     /// The hot path is a bitmask scan over `vocab_size / 64` words (~3,880
     /// iterations for Qwen3's 248,320 tokens), taking under 40 µs on modern
     /// Apple Silicon.  Context-dependent tokens add O(k × stack_depth)
     /// overhead (k ≈ 1% of vocab).
-    pub fn mask_logits(&self, state: &mut GrammarState, logits: &mut [f32]) {
-        assert!(
-            logits.len() >= self.vocab_size,
-            "logits length {} < vocab_size {}",
-            logits.len(),
-            self.vocab_size
-        );
+    pub fn mask_logits(
+        &self,
+        state: &mut GrammarState,
+        logits: &mut [f32],
+    ) -> Result<(), GrammarError> {
+        self.validate_logits_len(logits)?;
 
         let profiling = mask_profiling_enabled();
         let find_t0 = profiling.then(std::time::Instant::now);
@@ -472,6 +482,18 @@ impl GrammarEngine {
                 }
             }
         }
+        Ok(())
+    }
+
+    fn validate_logits_len(&self, logits: &[f32]) -> Result<(), GrammarError> {
+        if logits.len() < self.vocab_size {
+            return Err(GrammarError(format!(
+                "logits length {} is shorter than vocabulary size {}",
+                logits.len(),
+                self.vocab_size
+            )));
+        }
+        Ok(())
     }
 
     /// Compute the grammar mask for `state` directly by simulating every token.
@@ -483,7 +505,17 @@ impl GrammarEngine {
     /// `MAX_GRAMMAR_STATES`). It defines the mask contract `mask_by_trie`
     /// must reproduce exactly and stays public as the oracle for the
     /// differential tests below and as a slow-path manual escape hatch.
-    pub fn mask_by_simulation(&self, state: &GrammarState, logits: &mut [f32]) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GrammarError`] when `logits` is shorter than the engine's
+    /// vocabulary.
+    pub fn mask_by_simulation(
+        &self,
+        state: &GrammarState,
+        logits: &mut [f32],
+    ) -> Result<(), GrammarError> {
+        self.validate_logits_len(logits)?;
         for token_id in 0..self.vocab_size {
             if logits[token_id] == f32::NEG_INFINITY {
                 continue;
@@ -498,6 +530,7 @@ impl GrammarEngine {
                 logits[token_id] = f32::NEG_INFINITY;
             }
         }
+        Ok(())
     }
 
     /// Compute the grammar mask for `state` via the byte trie.
@@ -778,7 +811,9 @@ mod tests {
 
         let mut state = engine.initial_state();
         let mut logits = vec![1.0f32, 2.0f32, 3.0f32];
-        engine.mask_logits(&mut state, &mut logits);
+        engine
+            .mask_logits(&mut state, &mut logits)
+            .expect("matching vocab length");
 
         // "other" should be blocked.
         assert_eq!(
@@ -858,17 +893,23 @@ mod tests {
     }
 
     #[test]
-    fn mask_logits_logits_shorter_panics() {
+    fn mask_logits_logits_shorter_returns_error() {
         let vocab = vec![b"a".to_vec(), b"b".to_vec()];
         let spec = GrammarSpec::JsonSchema(serde_json::json!({"type": "null"}));
         let engine = GrammarEngine::new(&spec, vocab).unwrap();
         let mut state = engine.initial_state();
-        // Panic if logits slice is shorter than vocab_size.
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let mut logits = vec![0.0f32]; // shorter than vocab_size=2
-            engine.mask_logits(&mut state, &mut logits);
-        }));
-        assert!(result.is_err(), "should panic when logits too short");
+        let mut logits = vec![0.0f32];
+        let error = engine
+            .mask_logits(&mut state, &mut logits)
+            .expect_err("logits shorter than vocab_size must return an error");
+        assert!(error.0.contains("logits length 1"));
+        assert!(error.0.contains("vocabulary size 2"));
+
+        let simulation_error = engine
+            .mask_by_simulation(&state, &mut logits)
+            .expect_err("the public simulation path must reject the same mismatch");
+        assert!(simulation_error.0.contains("logits length 1"));
+        assert!(simulation_error.0.contains("vocabulary size 2"));
     }
 
     #[test]
@@ -931,7 +972,9 @@ mod tests {
         );
 
         let mut logits = vec![1.0f32, 1.0f32];
-        engine.mask_logits(&mut state, &mut logits);
+        engine
+            .mask_logits(&mut state, &mut logits)
+            .expect("matching vocab length");
 
         assert!(
             logits[1] > f32::NEG_INFINITY,
@@ -958,7 +1001,9 @@ mod tests {
 
         let mut state = engine.initial_state();
         let mut logits = vec![1.0f32; 130];
-        engine.mask_logits(&mut state, &mut logits);
+        engine
+            .mask_logits(&mut state, &mut logits)
+            .expect("matching vocab length");
 
         // At least tokens 0 and 1 should be allowed.
         assert!(
@@ -1170,7 +1215,9 @@ mod tests {
         for (i, state) in corpus.iter().enumerate() {
             let mut oracle_logits = vec![0.0f32; vocab.len()];
             let mut trie_logits = vec![0.0f32; vocab.len()];
-            engine.mask_by_simulation(state, &mut oracle_logits);
+            engine
+                .mask_by_simulation(state, &mut oracle_logits)
+                .expect("matching vocab length");
             engine.mask_by_trie(state, &mut trie_logits);
             if engine.find_state_id(state).is_none() {
                 over_cap_states += 1;
@@ -1211,7 +1258,9 @@ mod tests {
         for state in &corpus {
             let mut oracle_logits = vec![0.0f32; vocab.len()];
             let mut trie_logits = vec![0.0f32; vocab.len()];
-            engine.mask_by_simulation(state, &mut oracle_logits);
+            engine
+                .mask_by_simulation(state, &mut oracle_logits)
+                .expect("matching vocab length");
             engine.mask_by_trie(state, &mut trie_logits);
             for tok in 0..vocab.len() {
                 let oracle_blocked = oracle_logits[tok] == f32::NEG_INFINITY;
@@ -1254,8 +1303,12 @@ mod tests {
         let mut via_mask_logits = vec![0.0f32; vocab.len()];
         let mut oracle_logits = vec![0.0f32; vocab.len()];
         let mut state_for_public_call = deep_state.clone();
-        engine.mask_logits(&mut state_for_public_call, &mut via_mask_logits);
-        engine.mask_by_simulation(deep_state, &mut oracle_logits);
+        engine
+            .mask_logits(&mut state_for_public_call, &mut via_mask_logits)
+            .expect("matching vocab length");
+        engine
+            .mask_by_simulation(deep_state, &mut oracle_logits)
+            .expect("matching vocab length");
 
         assert_eq!(
             via_mask_logits, oracle_logits,
@@ -1327,7 +1380,9 @@ mod tests {
         for (i, state) in corpus.iter().enumerate() {
             let mut oracle_logits = vec![0.0f32; vocab.len()];
             let mut trie_logits = vec![0.0f32; vocab.len()];
-            engine.mask_by_simulation(state, &mut oracle_logits);
+            engine
+                .mask_by_simulation(state, &mut oracle_logits)
+                .expect("matching vocab length");
             engine.mask_by_trie(state, &mut trie_logits);
             if engine.find_state_id(state).is_none() {
                 over_cap_states += 1;

--- a/crates/inference/src/grammar/mod.rs
+++ b/crates/inference/src/grammar/mod.rs
@@ -13,7 +13,7 @@
 //!                          GrammarEngine::new()
 //!                                    │
 //!                              generate loop:
-//!                      engine.mask_logits(state, logits)
+//!                      engine.mask_logits(state, logits)?
 //!                      token = sampler.sample(logits)
 //!                      engine.advance(state, token_id)
 //! ```

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -181,7 +181,7 @@ impl Qwen35Model {
         // sample. mask_logits sets every disallowed token to NEG_INFINITY in-place,
         // so the sampler only sees the grammar-permitted candidate set.
         if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-            engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+            engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size])?;
             // If the grammar blocked every token the sampler's non-finite-max
             // short-circuit would silently return token 0. An accepting state
             // terminates normally; an incomplete state remains a hard error.
@@ -635,7 +635,7 @@ impl Qwen35Model {
 
         // Grammar mask on the post-prefill logits, identical to the generate() path.
         if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-            engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+            engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size])?;
             if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
                 if engine.is_complete_without_continuation(gs) {
                     return Ok(grammar_output(String::new(), &[], prompt_len, true, vec![]));
@@ -810,7 +810,7 @@ impl Qwen35Model {
 
                 // Grammar mask before sampling; fail closed on an all-blocked step.
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                    engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+                    engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size])?;
                     if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
                         if engine.is_complete_without_continuation(gs) {
                             stopped = true;
@@ -1018,7 +1018,7 @@ impl Qwen35Model {
 
                 // Grammar mask before sampling; fail closed on an all-blocked step.
                 if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
-                    engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+                    engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size])?;
                     if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
                         if engine.is_complete_without_continuation(gs) {
                             stopped = true;
@@ -1905,7 +1905,7 @@ fn decode_loop(
 
         // Grammar mask before sampling; fail closed when every token is blocked.
         if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut *grammar_state) {
-            engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+            engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size])?;
             if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
                 if engine.is_complete_without_continuation(gs) {
                     return Ok((true, StopReason::Grammar));
@@ -2033,7 +2033,7 @@ fn decode_loop_with_stops(
 
         // Grammar mask before sampling; fail closed when every token is blocked.
         if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut *grammar_state) {
-            engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size]);
+            engine.mask_logits(gs, &mut scratch.logits[..cfg.vocab_size])?;
             if !has_finite_logit(&scratch.logits[..cfg.vocab_size]) {
                 if engine.is_complete_without_continuation(gs) {
                     stopped = true;
@@ -2448,7 +2448,9 @@ mod tests {
         // Set logits so the forbidden token (index 2) has the highest value.
         // Without masking, greedy sampling would return 2.
         let mut logits = vec![1.0_f32, 2.0_f32, 1000.0_f32];
-        engine.mask_logits(&mut state, &mut logits);
+        engine
+            .mask_logits(&mut state, &mut logits)
+            .expect("matching vocab length");
 
         // The forbidden token must be blocked.
         assert_eq!(

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -1587,7 +1587,9 @@ mod tests {
         let mut state = engine.initial_state();
         for token_id in 0..3u32 {
             let mut logits = vec![0.0; 3];
-            engine.mask_logits(&mut state, &mut logits);
+            engine
+                .mask_logits(&mut state, &mut logits)
+                .expect("matching vocab length");
             assert!(
                 logits[token_id as usize].is_finite(),
                 "split UTF-8 token {token_id} must remain grammar-legal"
@@ -1617,7 +1619,9 @@ mod tests {
         let engine = GrammarEngine::new(&spec, vocab_bytes).unwrap();
         let mut state = engine.initial_state();
         let mut logits = vec![0.0; 101];
-        engine.mask_logits(&mut state, &mut logits);
+        engine
+            .mask_logits(&mut state, &mut logits)
+            .expect("matching vocab length");
         assert_eq!(logits[99], f32::NEG_INFINITY);
         assert_eq!(logits[100], f32::NEG_INFINITY);
     }
@@ -1653,7 +1657,9 @@ mod tests {
         let mut state = engine.initial_state();
         let mut logits = vec![0.0; cfg.vocab_size];
 
-        engine.mask_logits(&mut state, &mut logits);
+        engine
+            .mask_logits(&mut state, &mut logits)
+            .expect("matching vocab length");
 
         assert!(
             logits[248_070..]
@@ -1679,7 +1685,9 @@ mod tests {
         let engine = GrammarEngine::new(&spec, vocab_bytes).unwrap();
         let mut state = engine.initial_state();
         let mut logits = vec![0.0; 102];
-        engine.mask_logits(&mut state, &mut logits);
+        engine
+            .mask_logits(&mut state, &mut logits)
+            .expect("matching vocab length");
         assert!(logits[100].is_finite());
         assert!(logits[101].is_finite());
     }

--- a/docs/adr/ADR-084-fallible-inference-validation-helpers.md
+++ b/docs/adr/ADR-084-fallible-inference-validation-helpers.md
@@ -1,0 +1,65 @@
+# ADR-084: Fallible Validation for Unstable Inference Helpers
+
+**Status**: Accepted
+**Date**: 2026-07-28
+**Crate**: lattice-inference
+
+## Context
+
+Two public helpers in the unstable inference surface could not report invalid caller input
+without panicking or returning unusable numeric state:
+
+- `GrammarEngine::mask_logits` asserted when the logits slice was shorter than the engine
+  vocabulary.
+- `pack_ternary` had an infallible return type even though a non-finite weight makes its row
+  scale non-finite.
+
+Both conditions can originate at model or tokenizer integration boundaries. Treating them as
+process invariants makes ordinary input disagreement fatal and prevents callers from attaching
+the failure to the request or checkpoint that caused it.
+
+## Decision
+
+The helpers return typed errors:
+
+- `GrammarEngine::mask_logits` and its public simulation sibling return
+  `Result<(), GrammarError>`. Generation entry points propagate that result through
+  `InferenceError::InvalidInput`.
+- `pack_ternary` returns `Result<(Vec<u8>, Vec<f32>), InferenceError>` and rejects non-finite
+  weights and invalid matrix geometry before packing.
+
+The success path for grammar masking retains the existing length comparison. Error allocation
+and formatting occur only when validation fails.
+
+### Alternatives Considered
+
+| Alternative                                                        | Pros                 | Cons                                                                   | Why Not                                              |
+| ------------------------------------------------------------------ | -------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------- |
+| Keep panics as programmer errors                                   | No signature changes | A model/tokenizer mismatch terminates the process                      | These are caller-visible integration boundaries      |
+| Add new `try_*` helpers and retain the infallible methods          | Source compatible    | Leaves the unsafe entry points available and easy to call accidentally | Validation must be enforced at the existing boundary |
+| Return empty packed buffers or mask every token on malformed input | Infallible API       | Converts invalid input into ambiguous downstream behavior              | Callers need an explicit, attributable failure       |
+
+## Consequences
+
+### Positive
+
+- Malformed grammar and BitNet inputs fail through typed error channels.
+- Generation callers can preserve service availability and classify the request failure.
+- Non-finite weight rows cannot seed downstream kernels with non-finite scales.
+
+### Negative
+
+- Direct callers of these unstable helpers must handle a `Result`.
+- Grammar generation call sites carry an additional fallible return edge.
+
+### Risks
+
+- A future direct grammar-mask caller could discard the `Result`; linting and
+  `Result`'s `must_use` annotation make that visible.
+- Lower-level masking primitives still rely on the validated `GrammarEngine` entry point and
+  must not be exposed as request boundaries without equivalent validation.
+
+## References
+
+- [Issue #1085](https://github.com/ohdearquant/lattice/issues/1085)
+- [ADR-046: Structured Output](ADR-046-structured-output.md)

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -92,33 +92,34 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 
 ## architecture / research (ADR-059 onward)
 
-| ADR                                                    | Title                                                                                                        | Status   | Depends on                      |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------- |
-| [059](ADR-059-composable-layer-architecture.md)        | Composable Layer Architecture                                                                                | Proposed | ADR-010                         |
-| [060](ADR-060-pruning-toolbox.md)                      | Pruning Toolbox                                                                                              | Proposed | ADR-044, 059                    |
-| [061](ADR-061-inference-metrics-infrastructure.md)     | Inference Metrics & Experiment Runner                                                                        | Proposed | ADR-059                         |
-| [062](ADR-062-metal-fa2-prefill.md)                    | Metal FA2 Prefill + KV Cache Quantization                                                                    | Proposed | ADR-047                         |
-| [063](ADR-063-serving-architecture.md)                 | Serving Architecture — CLI, HTTP, API Compat                                                                 | Proposed | ADR-048, 046                    |
-| [064](ADR-064-ci-gate-taxonomy.md)                     | CI Gate Taxonomy and Promotion Policy                                                                        | Proposed | ADR-058                         |
-| [065](ADR-065-feature-promotion-gates.md)              | Feature promotion gates: merge measured primitives, not ideas                                                | Proposed | ADR-064                         |
-| [066](ADR-066-output-correctness-gate-architecture.md) | Output-correctness gate architecture                                                                         | Accepted | ADR-064, ADR-065                |
-| [067](ADR-067-gpu-decode-perf-regression-gates.md)     | GPU/Decode Performance Regression Gate System (Self-Hosted M2 Max)                                           | Proposed | ADR-058, 061, 064               |
-| [068](ADR-068-grammar-wire-contract.md)                | Pluggable Custom-Grammar Wire Contract for the OpenAI-Compatible Serving Surface                             | Proposed | ADR-046, 063                    |
-| [069](ADR-069-vision-encoder-qwen35-recalibration.md)  | Vision Encoder Recalibration for Qwen3.5-0.8B                                                                | Proposed | none                            |
-| [070](ADR-070-cpu-embedding-batched-encode.md)         | CPU Embedding Performance: Fused Batched Encode and the ONNX Parity Gate                                     | Proposed | ADR-058                         |
-| [071](ADR-071-gdn-state-object-priority.md)            | GDN Recurrent State as a First-Class Serveable Object — Priority and Scope                                   | Proposed | none                            |
-| [072](ADR-072-weight-quantization-priority.md)         | Weight Quantization Priority (Metal)                                                                         | Proposed | ADR-044, 051                    |
-| [073](ADR-073-kv-cache-quantization-priority.md)       | KV-Cache Quantization Priority (Metal)                                                                       | Proposed | ADR-048, 062, 072               |
-| [074](ADR-074-mtp-speculative-decoding-priority.md)    | MTP / Speculative-Decoding Priority (Metal)                                                                  | Proposed | ADR-006, 050, 051, 073          |
-| [075](ADR-075-moe-expert-offload-priority.md)          | MoE Expert-Offload Priority (Metal)                                                                          | Proposed | ADR-053, 072, 073, 074          |
-| [076](ADR-076-adaptive-reasoning-priority.md)          | Adaptive Reasoning-Budget Priority (Metal + CPU)                                                             | Proposed | ADR-073, 074                    |
-| [077](ADR-077-pruning-distill-priority.md)             | Pruning + Distillation Priority (Metal + CPU)                                                                | Proposed | ADR-060, 073, 076               |
-| [078](ADR-078-multimodal-serving-deferral-priority.md) | Multimodal / Vision Serving Priority (Deferral)                                                              | Proposed | ADR-049, 069, 071               |
-| [079](ADR-079-adaptive-micro-lora-brain.md)            | Adaptive Micro-LoRA Brain — Composed Train→Govern→Compose→Route→Consume Loop                                 | Proposed | ADR-008/031/043/045/054/056/057 |
-| [080](ADR-080-consolidation-duplicated-contracts.md)   | Consolidation of Duplicated Numeric-Contract Helpers (Softmax, HTTP Serving, Decode Policy, GEMM Validation) | Accepted | ADR-058, ADR-064, ADR-066       |
-| [081](ADR-081-prefill-gemm-optimization-priority.md)   | Prefill GEMM Optimization Priority (Metal)                                                                   | Proposed | none                            |
-| [082](ADR-082-gemma4-e2b-support.md)                   | Gemma 4 E2B Support — Staged Multimodal Ladder (Vision + Audio)                                              | Accepted | ADR-069                         |
-| [083](ADR-083-backward-simd-dispatch.md)               | Backward SIMD Dispatch Contract                                                                              | Accepted | ADR-002, ADR-058                |
+| ADR                                                     | Title                                                                                                        | Status   | Depends on                      |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------- |
+| [059](ADR-059-composable-layer-architecture.md)         | Composable Layer Architecture                                                                                | Proposed | ADR-010                         |
+| [060](ADR-060-pruning-toolbox.md)                       | Pruning Toolbox                                                                                              | Proposed | ADR-044, 059                    |
+| [061](ADR-061-inference-metrics-infrastructure.md)      | Inference Metrics & Experiment Runner                                                                        | Proposed | ADR-059                         |
+| [062](ADR-062-metal-fa2-prefill.md)                     | Metal FA2 Prefill + KV Cache Quantization                                                                    | Proposed | ADR-047                         |
+| [063](ADR-063-serving-architecture.md)                  | Serving Architecture — CLI, HTTP, API Compat                                                                 | Proposed | ADR-048, 046                    |
+| [064](ADR-064-ci-gate-taxonomy.md)                      | CI Gate Taxonomy and Promotion Policy                                                                        | Proposed | ADR-058                         |
+| [065](ADR-065-feature-promotion-gates.md)               | Feature promotion gates: merge measured primitives, not ideas                                                | Proposed | ADR-064                         |
+| [066](ADR-066-output-correctness-gate-architecture.md)  | Output-correctness gate architecture                                                                         | Accepted | ADR-064, ADR-065                |
+| [067](ADR-067-gpu-decode-perf-regression-gates.md)      | GPU/Decode Performance Regression Gate System (Self-Hosted M2 Max)                                           | Proposed | ADR-058, 061, 064               |
+| [068](ADR-068-grammar-wire-contract.md)                 | Pluggable Custom-Grammar Wire Contract for the OpenAI-Compatible Serving Surface                             | Proposed | ADR-046, 063                    |
+| [069](ADR-069-vision-encoder-qwen35-recalibration.md)   | Vision Encoder Recalibration for Qwen3.5-0.8B                                                                | Proposed | none                            |
+| [070](ADR-070-cpu-embedding-batched-encode.md)          | CPU Embedding Performance: Fused Batched Encode and the ONNX Parity Gate                                     | Proposed | ADR-058                         |
+| [071](ADR-071-gdn-state-object-priority.md)             | GDN Recurrent State as a First-Class Serveable Object — Priority and Scope                                   | Proposed | none                            |
+| [072](ADR-072-weight-quantization-priority.md)          | Weight Quantization Priority (Metal)                                                                         | Proposed | ADR-044, 051                    |
+| [073](ADR-073-kv-cache-quantization-priority.md)        | KV-Cache Quantization Priority (Metal)                                                                       | Proposed | ADR-048, 062, 072               |
+| [074](ADR-074-mtp-speculative-decoding-priority.md)     | MTP / Speculative-Decoding Priority (Metal)                                                                  | Proposed | ADR-006, 050, 051, 073          |
+| [075](ADR-075-moe-expert-offload-priority.md)           | MoE Expert-Offload Priority (Metal)                                                                          | Proposed | ADR-053, 072, 073, 074          |
+| [076](ADR-076-adaptive-reasoning-priority.md)           | Adaptive Reasoning-Budget Priority (Metal + CPU)                                                             | Proposed | ADR-073, 074                    |
+| [077](ADR-077-pruning-distill-priority.md)              | Pruning + Distillation Priority (Metal + CPU)                                                                | Proposed | ADR-060, 073, 076               |
+| [078](ADR-078-multimodal-serving-deferral-priority.md)  | Multimodal / Vision Serving Priority (Deferral)                                                              | Proposed | ADR-049, 069, 071               |
+| [079](ADR-079-adaptive-micro-lora-brain.md)             | Adaptive Micro-LoRA Brain — Composed Train→Govern→Compose→Route→Consume Loop                                 | Proposed | ADR-008/031/043/045/054/056/057 |
+| [080](ADR-080-consolidation-duplicated-contracts.md)    | Consolidation of Duplicated Numeric-Contract Helpers (Softmax, HTTP Serving, Decode Policy, GEMM Validation) | Accepted | ADR-058, ADR-064, ADR-066       |
+| [081](ADR-081-prefill-gemm-optimization-priority.md)    | Prefill GEMM Optimization Priority (Metal)                                                                   | Proposed | none                            |
+| [082](ADR-082-gemma4-e2b-support.md)                    | Gemma 4 E2B Support — Staged Multimodal Ladder (Vision + Audio)                                              | Accepted | ADR-069                         |
+| [083](ADR-083-backward-simd-dispatch.md)                | Backward SIMD Dispatch Contract                                                                              | Accepted | ADR-002, ADR-058                |
+| [084](ADR-084-fallible-inference-validation-helpers.md) | Fallible Validation for Unstable Inference Helpers                                                           | Accepted | ADR-046                         |
 
 ## informational
 


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

Close three fail-open or panic-prone input-validation gaps in inference construction and preprocessing.

### Batch worker configuration

- validate `BatchConfig` before `BatchWorker::try_new` constructs its pools;
- preserve the existing `InferenceError::InvalidInput` error channel;
- cover every rejected configuration field, including oversized chunks.

### BitNet packing

- reject NaN and infinite row weights before computing their scale;
- make the unstable `pack_ternary` helper return `Result`;
- replace its public geometry assertion with typed length and overflow errors.

### Grammar masking

- return `GrammarError` when logits are shorter than the grammar vocabulary;
- apply the same validation to the simulation sibling;
- propagate the typed error through CPU and Metal generation call sites.

ADR-084 records the two public helper signature changes.

## Mutation-sensitive regressions

| Guard removed or reverted | Observed failure |
| --- | --- |
| `BatchWorker::try_new` config validation removed | `expected InvalidInput for invalid max_batch_size` |
| BitNet finite-value guard removed | `non-finite weight NaN must be rejected` |
| Grammar typed error restored to the former assertion | panic: `logits length 1 < vocab_size 2` |

The fixed tree passed before and after each byte-identical restoration.

## Sibling sweep

- Repository construction paths use `BatchWorker::try_new`; the legacy infallible `BatchWorker::new` has no in-repository callers and remains unchanged.
- BitNet has no other production `pack_ternary` caller; sibling load-time quantizers already reject non-finite values.
- Every `mask_logits` caller now propagates the result, `mask_by_simulation` shares the length guard, and production `VocabPartition::apply_mask` calls remain behind engine validation.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- batch worker suite: 21 passed
- BitNet suite: 30 passed
- grammar engine suite: 22 passed, 1 ignored (real-vocabulary fixture)
- `scripts/lint-docs.sh`
- explicit Deno formatting checks for ADR-084 and the ADR index

## bench-compare disposition

No A/B benchmark was run. Batch validation and BitNet packing execute only during construction or loading. Grammar masking retains the same successful-path length branch and masking algorithm; this change replaces only its failure arm and propagates the resulting typed error. No kernel or steady-state compute path changed.

Closes #1085
