### PR TITLE
fix(inference): validate Q8 and NEON prompt token ids

### DIFF
--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -921,18 +921,7 @@ pub fn generate_f16(
     // `check_prompt_not_empty` (model::qwen35::generation).
     crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
 
-    // Sibling of `generate_multimodal_f16`'s input-id guard: tokenizer
-    // output is bounded by the tokenizer's own vocabulary, but this driver accepts
-    // `cfg` and `tokenizer` as independent parameters, so a mismatched pair can still
-    // produce a prompt id at or past `cfg.vocab_size` and panic in `forward_step_f16`'s
-    // embedding-table slice. Fail closed here, once, before any decoder state is
-    // allocated.
-    if let Some(&bad_id) = prompt_ids.iter().find(|&&id| id as usize >= cfg.vocab_size) {
-        return Err(crate::error::InferenceError::InvalidInput(format!(
-            "prompt contains out-of-vocabulary token id {bad_id} (vocab_size={})",
-            cfg.vocab_size
-        )));
-    }
+    crate::model::qwen35::check_prompt_ids_in_vocab(&prompt_ids, cfg.vocab_size)?;
 
     // max_new_tokens == 0 means "generate nothing": return before sampling so
     // we never emit a token the caller did not ask for. Mirrors the guard in

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -719,6 +719,7 @@ pub fn generate_q8(
     // used to accept an empty prompt and return an empty Ok) — see
     // `check_prompt_not_empty` (model::qwen35::generation).
     crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
+    crate::model::qwen35::check_prompt_ids_in_vocab(&prompt_ids, cfg.vocab_size)?;
 
     // max_new_tokens == 0 is a valid request: "score this prompt, return no tokens".
     // Guard here so the decode loop (`for _ in 1..0`) never accidentally samples one
@@ -1603,6 +1604,38 @@ mod tests {
             matches!(result, Err(InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
             "generate_q8 must reject an empty prompt with Err(Inference(\"empty \
              prompt\")) (#856); got {result:?}"
+        );
+    }
+
+    /// A standalone Q8 driver can receive a tokenizer whose vocabulary is
+    /// larger than the supplied model config. The boundary ID `vocab_size`
+    /// must be rejected before `forward_step_q8` slices the embedding table.
+    ///
+    /// Mutation sensitivity: removing only the Q8 call to
+    /// `check_prompt_ids_in_vocab` lets this request reach the unchecked
+    /// embedding slice and panic instead of returning `InvalidInput`.
+    #[test]
+    fn generate_q8_rejects_out_of_vocab_prompt_id() {
+        use std::collections::HashMap;
+
+        let (cfg, weights, rope, _tokenizer) = zero_layer_q8_fixture();
+        let mut vocab_map: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o", "w", "r", "d", "!"].iter().enumerate() {
+            vocab_map.insert((*c).to_string(), i as u32);
+        }
+        vocab_map.insert("z".to_string(), cfg.vocab_size as u32);
+        let mismatched_tokenizer = BpeTokenizer::from_vocab_and_merges(vocab_map, vec![])
+            .expect("tokenizer with an OOV vocab entry still constructs");
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            ..Default::default()
+        };
+
+        let err = generate_q8(&weights, &cfg, &mismatched_tokenizer, &rope, "z", &gen_cfg)
+            .expect_err("an out-of-vocabulary prompt token id must be rejected, not panic");
+        assert!(
+            matches!(err, crate::error::InferenceError::InvalidInput(_)),
+            "expected InvalidInput, got {err:?}"
         );
     }
 

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -983,6 +983,7 @@ pub fn generate_q8_neon(
     // used to accept an empty prompt and return an empty Ok) — see
     // `check_prompt_not_empty` (model::qwen35::generation).
     crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
+    crate::model::qwen35::check_prompt_ids_in_vocab(&prompt_ids, cfg.vocab_size)?;
 
     // max_new_tokens == 0 means "generate nothing": return before sampling so
     // we never emit a token the caller did not ask for. Mirrors the guard in
@@ -3139,6 +3140,87 @@ mod tests {
             matches!(result, Err(InferenceError::Inference(ref msg)) if msg.contains("empty prompt")),
             "generate_q8_neon must reject an empty prompt with Err(Inference(\"empty \
              prompt\")) (#856); got {result:?}"
+        );
+    }
+
+    /// A standalone NEON driver can receive a tokenizer whose vocabulary is
+    /// larger than the supplied model config. The boundary ID `vocab_size`
+    /// must be rejected before `forward_step_q8_neon` slices the embedding
+    /// table.
+    ///
+    /// Mutation sensitivity: removing only the NEON call to
+    /// `check_prompt_ids_in_vocab` lets this request reach the unchecked
+    /// embedding slice and panic instead of returning `InvalidInput`.
+    #[test]
+    fn generate_q8_neon_rejects_out_of_vocab_prompt_id() {
+        use std::collections::HashMap;
+
+        let hidden = 32usize;
+        let vocab = 8usize;
+        let cfg = Qwen35Config {
+            hidden_size: hidden,
+            num_hidden_layers: 0,
+            vocab_size: vocab,
+            intermediate_size: 32,
+            rms_norm_eps: 1e-6,
+            num_attention_heads: 1,
+            num_key_value_heads: 1,
+            head_dim: 32,
+            rope_theta: 10_000.0,
+            partial_rotary_factor: 0.5,
+            rope_parameters: None,
+            linear_num_key_heads: 1,
+            linear_num_value_heads: Some(1),
+            linear_key_head_dim: 32,
+            linear_value_head_dim: 32,
+            linear_conv_kernel_dim: 32,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
+            shared_expert_intermediate_size: None,
+            output_router_logits: false,
+            router_aux_loss_coef: None,
+            tie_word_embeddings: true,
+            full_attention_interval: 2,
+            layer_types: vec![],
+            layer_mask: vec![],
+            eos_token_id: 5,
+            max_position_embeddings: 512,
+            mtp_num_hidden_layers: 0,
+            mtp_use_dedicated_embeddings: false,
+            quarot_rotation_seed: None,
+            vision_config: None,
+            image_token_id: None,
+            video_token_id: None,
+            vision_start_token_id: None,
+            vision_end_token_id: None,
+        };
+        let model = Q8NeonModel {
+            embed_tokens: vec![0.0f32; vocab * hidden],
+            final_norm: vec![0.0f32; hidden],
+            lm_head_packed: zero_packed(vocab, hidden),
+            lm_head_rows: vocab,
+            lm_head_cols: hidden,
+            layers: vec![],
+        };
+        let rope = RopeTable::new(16, 64, 10_000.0);
+        let mut vocab_map: HashMap<String, u32> = HashMap::new();
+        for (i, c) in ["h", "e", "l", "o", "w", "r", "d", "!"].iter().enumerate() {
+            vocab_map.insert((*c).to_string(), i as u32);
+        }
+        vocab_map.insert("z".to_string(), cfg.vocab_size as u32);
+        let mismatched_tokenizer = BpeTokenizer::from_vocab_and_merges(vocab_map, vec![])
+            .expect("tokenizer with an OOV vocab entry still constructs");
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            ..Default::default()
+        };
+
+        let err = generate_q8_neon(&model, &cfg, &mismatched_tokenizer, &rope, "z", &gen_cfg)
+            .expect_err("an out-of-vocabulary prompt token id must be rejected, not panic");
+        assert!(
+            matches!(err, crate::error::InferenceError::InvalidInput(_)),
+            "expected InvalidInput, got {err:?}"
         );
     }
 

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -2364,6 +2364,24 @@ pub(crate) fn check_prompt_not_empty(prompt_len: usize) -> Result<(), InferenceE
     Ok(())
 }
 
+/// Rejects tokenizer output that cannot index the configured embedding table.
+///
+/// Standalone CPU generation drivers accept their tokenizer and model config
+/// independently, so tokenizer validity alone does not prove that every prompt
+/// ID is below `vocab_size`. Perform one cold ingress scan before any decoder
+/// state allocation instead of branching inside the per-token forward path.
+pub(crate) fn check_prompt_ids_in_vocab(
+    prompt_ids: &[u32],
+    vocab_size: usize,
+) -> Result<(), InferenceError> {
+    if let Some(&bad_id) = prompt_ids.iter().find(|&&id| id as usize >= vocab_size) {
+        return Err(InferenceError::InvalidInput(format!(
+            "prompt contains out-of-vocabulary token id {bad_id} (vocab_size={vocab_size})"
+        )));
+    }
+    Ok(())
+}
+
 /// Shared total-context admission bound (#922): rejects a request whose
 /// prompt fits the window alone but whose prompt plus decode budget does
 /// not, closing exactly the gap between "will prefill" and "will actually

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -61,6 +61,9 @@ pub(crate) use generation::{check_reasoning_budget_not_set, check_stop_strings_n
 // (forward::metal_qwen35) calls this instead of its own inline
 // `if prompt_len == 0` copy, unifying the CPU/Metal empty-prompt contract.
 pub(crate) use generation::check_prompt_not_empty;
+// Shared prompt-token admission guard for standalone CPU drivers whose
+// tokenizer and model config are supplied independently (#1083).
+pub(crate) use generation::check_prompt_ids_in_vocab;
 // Shared total-context admission bound (#922): every Metal generation entry
 // point (forward::metal_qwen35) calls this after check_prompt_not_empty to
 // mirror the CPU `generate`/`generate_streaming` total bound


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

Closes #1083.

## Defect

The standalone Q8 and Q8 NEON generation drivers accept a tokenizer and model config independently but did not verify that tokenized prompt IDs fit the configured embedding vocabulary. A mismatched pair could therefore reach the direct embedding-table slice with `id >= vocab_size` and panic.

## Fix

- Factor the existing f16 prompt-ID preflight into `check_prompt_ids_in_vocab` in the shared Qwen generation-validation module.
- Apply that cold ingress scan to `generate_f16`, `generate_q8`, and `generate_q8_neon` before zero-budget returns, decoder allocation, or embedding lookup.
- Add separate Q8 and NEON boundary regressions using `id == vocab_size`; both require a typed `InvalidInput` error.

The inner forward steps remain branch-free.

## Mutation-test evidence

- Q8: removing only the `generate_q8` helper call makes `generate_q8_rejects_out_of_vocab_prompt_id` panic at `cpu_q8.rs:570` with `range end index 36 out of range for slice of length 32`. Restoring the call makes the exact test pass.
- NEON: removing only the `generate_q8_neon` helper call makes `generate_q8_neon_rejects_out_of_vocab_prompt_id` panic at `neon_forward.rs:852` with `range end index 288 out of range for slice of length 256`. Restoring the call makes the exact test pass.

## Sibling-path sweep

Searched every Qwen embedding-lookup sibling. The standard model-owned CPU paths bind the tokenizer and config in one model; generic CPU/GPU and Metal raw-ID entry points already validate IDs or assert at their internal boundary; multimodal and prefill f16 callers already reject invalid caller-supplied IDs. The independent-tokenizer f16/Q8/NEON drivers are the complete affected set, and all three now share the same preflight.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lattice-inference --lib rejects_out_of_vocab_prompt_id -- --nocapture` (3 passed)
- `cargo clippy --workspace -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `./scripts/lint-docs.sh`

## Bench-compare disposition

No A/B benchmark was run. The changed production code is a single cold prompt-admission scan in `generate_f16`, `generate_q8`, and `generate_q8_neon`, executed once before decoder-state allocation. No embedding math, prefill loop, decode loop, SIMD kernel, or benchmarked hot path changed.