### PR TITLE
fix(bench): report head execution mode

### DIFF
--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -261,7 +261,23 @@ fi
 BASE_SHA=$(git -C "$REPO" rev-parse --short --end-of-options "$BASE_REF" 2>/dev/null || echo "$BASE_REF")
 HEAD_SHA=$(git -C "$REPO" rev-parse --short --end-of-options "$HEAD_REF" 2>/dev/null || echo "$HEAD_REF")
 
+HEAD_WT="$REPO/.cache/bench-compare-head"
+if [ "$HEAD_REF" = "HEAD" ]; then
+  HEAD_MODE="in-place"
+  HEAD_DIR="$REPO"
+else
+  HEAD_MODE="detached worktree"
+  HEAD_DIR="$HEAD_WT"
+fi
+GATE_SCRIPT="$REPO/scripts/perf-bench-gate.py"
+
+print_execution_provenance() {
+  echo "  head arm: $HEAD_MODE at $HEAD_DIR"
+  echo "  gate: $GATE_SCRIPT"
+}
+
 echo "=== bench-compare: $BASE_REF ($BASE_SHA) vs $HEAD_REF ($HEAD_SHA) ==="
+print_execution_provenance
 quiet_gate "before base"
 
 # --- Keep Spotlight out of the bench worktrees ---
@@ -380,16 +396,11 @@ quiet_gate "between phases"
 echo ""
 echo "--- Building + benching HEAD ($HEAD_SHA) ---"
 
-# Determine head working dir — if HEAD_REF is HEAD, use $REPO directly
-if [ "$HEAD_REF" = "HEAD" ]; then
-  HEAD_DIR="$REPO"
-else
-  HEAD_WT="$REPO/.cache/bench-compare-head"
+if [ "$HEAD_MODE" = "detached worktree" ]; then
   if [ -d "$HEAD_WT" ]; then
     git -C "$REPO" worktree remove --force "$HEAD_WT" 2>/dev/null || rm -rf "$HEAD_WT"
   fi
   git -C "$REPO" worktree add --detach --end-of-options "$HEAD_WT" "$HEAD_REF" 2>&1 | tail -1
-  HEAD_DIR="$HEAD_WT"
   # Update cleanup to also remove head worktree
   trap 'git -C "$REPO" worktree remove --force "$HEAD_WT" 2>/dev/null || true; cleanup' EXIT
 fi
@@ -497,6 +508,7 @@ fi
 echo ""
 echo "=== Run conditions ==="
 echo "  base: $BASE_REF ($BASE_SHA)   head: $HEAD_REF ($HEAD_SHA)"
+print_execution_provenance
 echo "  resolution: ${QUICK_FLAGS:---full}"
 echo "  targets: lattice-inference:$BENCHES_INFERENCE, lattice-embed:$BENCHES_EMBED"
 echo "  inference features: ${CARGO_FEATURES_INFERENCE:-<none>}"
@@ -523,7 +535,7 @@ fi
 
 GATE_RC=0
 if [ -d "$HEAD_DIR/target/criterion" ]; then
-  python3 "$REPO/scripts/perf-bench-gate.py" "$HEAD_DIR/target/criterion" "local-compare" "${GATE_ARGS[@]}" 2>&1 || GATE_RC=$?
+  python3 "$GATE_SCRIPT" "$HEAD_DIR/target/criterion" "local-compare" "${GATE_ARGS[@]}" 2>&1 || GATE_RC=$?
 else
   # Cannot happen via the normal path (the directory is created above), but a
   # missing root must not read as a pass under --fail-on-regression.

--- a/tests/test_bench_locks.py
+++ b/tests/test_bench_locks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Regression tests for the bench-compare locking and ambient-load gates.
+"""Regression tests for bench-compare isolation and execution provenance.
 
-Two properties are pinned here, and both are about refusing rather than about
+The locking and ambient-load properties are about refusing rather than about
 measuring.
 
 The body refuses to measure unless the PID recorded in the lock status is one of
@@ -23,6 +23,11 @@ The ambient-load gate REFUSES. A lock excludes peers on this machine; it says
 nothing about how busy the machine is. A warning printed on a bench report is
 read by nobody at the moment it matters, which is weeks later when someone
 quotes the number.
+
+The execution-provenance checks pin which source tree supplies the head arm and
+which invoking-checkout gate grades it. Those facts differ when the positional
+head ref changes, so both the early log and the pasted run-conditions block must
+carry them.
 """
 import importlib.util
 import os
@@ -84,9 +89,9 @@ class _Sandbox:
         self._tmp.cleanup()
         return False
 
-    def run(self, argv, **env):
+    def run(self, argv, *, base_ref="HEAD~1", head_ref="HEAD", **env):
         return subprocess.run(
-            ["bash", *argv, "HEAD~1", "HEAD"],
+            ["bash", *argv, base_ref, head_ref],
             capture_output=True, text=True, env={**self.env, **env}, timeout=300)
 
     @property
@@ -198,6 +203,48 @@ class LockPrecondition(unittest.TestCase):
             r = sb.run([sb.entry], BENCH_IDLE_FLOOR="0")
             self.assertIn("Run conditions", r.stdout, f"stdout:\n{r.stdout}")
             self.assertIn("bench-window", r.stdout)
+
+
+class HeadModeReporting(unittest.TestCase):
+    """The log and pasted run-conditions block identify the resolved head arm."""
+
+    def assert_provenance_in_header_and_report(self, stdout, head_line, gate_line):
+        header, separator, report = stdout.partition("=== Run conditions ===")
+        self.assertTrue(separator, stdout)
+        for section in (header, report):
+            self.assertIn(head_line, section)
+            self.assertIn(gate_line, section)
+
+    def test_head_ref_uses_and_reports_the_invoking_checkout(self):
+        """Mutation-sensitive: removing either provenance emission leaves one
+        half of this header/report assertion without the in-place mode."""
+        with _Sandbox() as sb:
+            r = sb.run([sb.entry], BENCH_IDLE_FLOOR="0")
+            self.assertEqual(r.returncode, 0, f"stderr:\n{r.stderr}")
+            self.assert_provenance_in_header_and_report(
+                r.stdout,
+                f"  head arm: in-place at {sb.root}",
+                f"  gate: {sb.root}/scripts/perf-bench-gate.py",
+            )
+            self.assertNotIn("head arm: detached worktree", r.stdout)
+
+    def test_explicit_head_ref_uses_and_reports_a_detached_worktree(self):
+        """Mutation-sensitive: collapsing the mode selection to in-place makes
+        the expected worktree provenance disappear from both report locations."""
+        with _Sandbox() as sb:
+            r = sb.run(
+                [sb.entry],
+                base_ref="HEAD~1",
+                head_ref="HEAD~1",
+                BENCH_IDLE_FLOOR="0",
+            )
+            self.assertEqual(r.returncode, 0, f"stderr:\n{r.stderr}")
+            self.assert_provenance_in_header_and_report(
+                r.stdout,
+                f"  head arm: detached worktree at {sb.root}/.cache/bench-compare-head",
+                f"  gate: {sb.root}/scripts/perf-bench-gate.py",
+            )
+            self.assertNotIn("head arm: in-place", r.stdout)
 
 
 class ContentionDiagnostics(unittest.TestCase):


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

`bench-compare` silently selected two different head-arm source modes: a literal `HEAD` used the invoking checkout in place, while any other head ref used a detached worktree. The report named the refs but not that source distinction, even though the gate policy always came from the invoking checkout.

Resolve the head mode, source directory, and gate script once, then emit the same provenance lines in both the early run header and the final `Run conditions` block:

- `head arm: in-place at ...` or `head arm: detached worktree at ...`
- `gate: .../scripts/perf-bench-gate.py`

The resolved variables now also drive worktree creation and the gate invocation, preventing the reported paths from drifting from the paths actually used.

## Regression coverage

The existing disposable-repository harness now exercises both argument shapes with stubbed Cargo:

- literal `HEAD` must report the invoking checkout in both output locations
- an explicit head ref must report `.cache/bench-compare-head` in both output locations
- both modes must report the invoking checkout's gate script

Mutation proof: removing both production provenance emissions made both `HeadModeReporting` tests fail on the missing exact `head arm` lines. Restoring the emissions made both tests pass.

Sibling-path sweep: the Makefile target and post-merge workflow both route through the same locking entry point and implementation. The implementation contains the only head-mode decision and local-compare gate invocation. `make bench-gate` is a separate single-arm baseline comparison and has no head-source mode to report.

## Validation

- `bash -n scripts/bench-compare.sh scripts/lib/bench-compare-impl.sh`
- `python3 tests/test_bench_locks.py -v` (16 passed; real scripts in disposable repos, stubbed Cargo)
- `python3 tests/test_bench_compare_measurement.py -v` (2 passed)
- `bash scripts/ensure-noindex-marker-selftest.sh` (16 passed)
- `python3 scripts/perf-bench-gate.py --selftest`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `git diff --check`

Closes #1091

## bench-compare disposition

N/A — this changes benchmark-harness provenance reporting and its stubbed regression tests only. It changes no measured code, benchmark target, or gate threshold; a benchmark run would not add coverage beyond the exercised reporting paths.