### PR TITLE
perf(embed): make quantization explicitly SIMD

### DIFF
--- a/crates/embed/docs/simd.md
+++ b/crates/embed/docs/simd.md
@@ -24,6 +24,7 @@ and normalization reuse the cached configuration when they choose a kernel.
 | Float dot, cosine, squared L2, normalize | AVX-512F, then AVX2 + FMA                                       | NEON                        | SIMD128 when compiled in | scalar   |
 | Batch-four float dot                     | AVX2 + FMA                                                      | NEON                        | none                     | scalar   |
 | INT8 dot                                 | AVX-512 VNNI + BW when the `avx512` feature is built, then AVX2 | NEON only with FEAT_DotProd | none                     | scalar   |
+| INT8, INT4, and binary quantization      | AVX2                                                            | NEON                        | none                     | scalar   |
 | Binary Hamming                           | none                                                            | NEON `vcnt`                 | none                     | scalar   |
 | INT4 dot                                 | none                                                            | NEON                        | none                     | scalar   |
 
@@ -229,6 +230,11 @@ Mapping `[-max_abs, max_abs]` to `[-127, 127]` gives a step size of
 be acceptable for the tier selected by the caller; use `Full` or `Int8` instead
 of lower-precision tiers when recall needs more fidelity.
 
+The finite min/max scan and integer conversion use explicit AVX2 or NEON
+kernels, with a scalar fallback. Conversion keeps round-half-away-from-zero
+semantics and finishes lengths shorter than a full vector in the scalar tail.
+The source L2 norm remains a scalar-ordered reduction.
+
 ### Dot product and dispatch
 
 The raw integer reduction is dequantized by dividing by the product of the two
@@ -276,6 +282,10 @@ bytes. For an odd-dimensional vector, only the final byte's high nibble is a
 real dimension; the low nibble is padding and is ignored by dequantization and
 dot-product accumulation. Non-finite source values are treated as zero, and
 the L2 norm records the finite source values.
+
+Finite max-absolute reduction and nibble conversion use explicit AVX2 or NEON
+kernels. Both leave incomplete chunks to the scalar implementation, including
+an odd final high nibble. The source L2 norm remains scalar-ordered.
 
 The 16 quantization levels have step size `2 * max_abs / 15`, so the maximum
 per-element round-trip error is `max_abs / 15`. This is a storage-oriented
@@ -325,6 +335,10 @@ dimension one is bit 6, and so on. The storage size is
 `ceil(dimensions / 8)` bytes. Dequantization maps one to `+1.0` and zero to
 `-1.0`; it is intentionally lossy and returns an empty vector if public fields
 describe a buffer shorter than the required packed length.
+
+Threshold conversion uses explicit AVX2 or NEON kernels for full eight-value
+groups and a scalar tail for the final partial byte. The kernels preserve the
+same finite-value substitution and most-significant-bit-first layout.
 
 Hamming distance is the population count of the XOR of two packed buffers. The
 scalar implementation counts full 64-bit groups and remaining bytes; the NEON

--- a/crates/embed/src/simd/binary.rs
+++ b/crates/embed/src/simd/binary.rs
@@ -7,6 +7,9 @@
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
 use super::simd_config;
 
 /// **Unstable**: binary quantization format and struct layout are under active design.
@@ -45,16 +48,7 @@ impl BinaryVector {
         let norm = norm_sq.sqrt();
 
         let packed_len = dims.div_ceil(8);
-        let mut data = vec![0u8; packed_len];
-
-        for (i, &v) in vector.iter().enumerate() {
-            let val = if v.is_finite() { v } else { 0.0 };
-            if val >= threshold {
-                let byte_idx = i / 8;
-                let bit_idx = 7 - (i % 8); // bit 7 = first dimension in byte
-                data[byte_idx] |= 1 << bit_idx;
-            }
-        }
+        let data = quantize_binary(vector, threshold, packed_len);
 
         Self { data, dims, norm }
     }
@@ -107,6 +101,108 @@ impl BinaryVector {
     pub fn cosine_similarity_approx(&self, other: &BinaryVector) -> f32 {
         1.0 - self.cosine_distance_approx(other)
     }
+}
+
+fn quantize_binary(vector: &[f32], threshold: f32, packed_len: usize) -> Vec<u8> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if simd_config().avx2_enabled {
+            // SAFETY: AVX2 was detected at runtime; the kernel bounds every load and store.
+            return unsafe { quantize_binary_avx2(vector, threshold, packed_len) };
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        if simd_config().neon_enabled {
+            // SAFETY: NEON was detected at runtime; the kernel bounds every load and store.
+            return unsafe { quantize_binary_neon(vector, threshold, packed_len) };
+        }
+    }
+    quantize_binary_scalar(vector, threshold, packed_len)
+}
+
+fn quantize_binary_scalar(vector: &[f32], threshold: f32, packed_len: usize) -> Vec<u8> {
+    let mut data = vec![0u8; packed_len];
+    quantize_binary_scalar_tail(vector, threshold, &mut data, 0);
+    data
+}
+
+fn quantize_binary_scalar_tail(vector: &[f32], threshold: f32, data: &mut [u8], start: usize) {
+    for (i, &value) in vector.iter().enumerate().skip(start) {
+        let finite_value = if value.is_finite() { value } else { 0.0 };
+        if finite_value >= threshold {
+            data[i / 8] |= 1 << (7 - i % 8);
+        }
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    static BINARY_QUANTIZE_SIMD_HITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn quantize_binary_avx2(vector: &[f32], threshold: f32, packed_len: usize) -> Vec<u8> {
+    #[cfg(test)]
+    BINARY_QUANTIZE_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
+    let mut data = vec![0u8; packed_len];
+    let chunks = vector.len() / 8;
+    let threshold_scalar = threshold;
+    let sign = _mm256_set1_ps(-0.0);
+    let inf = _mm256_set1_ps(f32::INFINITY);
+    let threshold = _mm256_set1_ps(threshold_scalar);
+
+    for i in 0..chunks {
+        let input = _mm256_loadu_ps(vector.as_ptr().add(i * 8));
+        let abs = _mm256_andnot_ps(sign, input);
+        let finite = _mm256_cmp_ps(abs, inf, _CMP_LT_OQ);
+        let values = _mm256_and_ps(input, finite);
+        let above_threshold = _mm256_cmp_ps(values, threshold, _CMP_GE_OQ);
+        data[i] = (_mm256_movemask_ps(above_threshold) as u8).reverse_bits();
+    }
+
+    quantize_binary_scalar_tail(vector, threshold_scalar, &mut data, chunks * 8);
+    data
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn quantize_binary_neon(vector: &[f32], threshold: f32, packed_len: usize) -> Vec<u8> {
+    #[cfg(test)]
+    BINARY_QUANTIZE_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
+    let mut data = vec![0u8; packed_len];
+    let chunks = vector.len() / 8;
+    let inf = vdupq_n_f32(f32::INFINITY);
+    let zero = vdupq_n_f32(0.0);
+    let threshold_vector = vdupq_n_f32(threshold);
+
+    for i in 0..chunks {
+        let base = i * 8;
+        let first = vld1q_f32(vector.as_ptr().add(base));
+        let second = vld1q_f32(vector.as_ptr().add(base + 4));
+        let first_values = vbslq_f32(vcaltq_f32(first, inf), first, zero);
+        let second_values = vbslq_f32(vcaltq_f32(second, inf), second, zero);
+        let first_mask = vcgeq_f32(first_values, threshold_vector);
+        let second_mask = vcgeq_f32(second_values, threshold_vector);
+        let mut first_lanes = [0u32; 4];
+        let mut second_lanes = [0u32; 4];
+        vst1q_u32(first_lanes.as_mut_ptr(), first_mask);
+        vst1q_u32(second_lanes.as_mut_ptr(), second_mask);
+
+        let mut packed = 0u8;
+        for (lane, mask) in first_lanes.into_iter().chain(second_lanes).enumerate() {
+            if mask != 0 {
+                packed |= 1 << (7 - lane);
+            }
+        }
+        data[i] = packed;
+    }
+
+    quantize_binary_scalar_tail(vector, threshold, &mut data, chunks * 8);
+    data
 }
 
 /// **Unstable**: returns packed-bit Hamming distance or `u32::MAX` for invalid inputs.
@@ -280,6 +376,57 @@ mod tests {
                 unit * 2.0 - 1.0
             })
             .collect()
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[test]
+    fn test_binary_quantize_explicit_simd_matches_scalar_and_is_dispatched() {
+        #[cfg(target_arch = "x86_64")]
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        for threshold in [0.0, 0.25, f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            for dim in [0usize, 1, 3, 4, 7, 8, 9, 31, 32, 33, 383, 384, 385] {
+                let mut input = generate_vector(dim, 900 + dim as u64);
+                if dim > 0 {
+                    input[0] = f32::NAN;
+                }
+                if dim > 1 {
+                    input[1] = f32::INFINITY;
+                }
+                if dim > 2 {
+                    input[2] = f32::NEG_INFINITY;
+                }
+
+                let packed_len = dim.div_ceil(8);
+                let scalar = quantize_binary_scalar(&input, threshold, packed_len);
+                #[cfg(target_arch = "aarch64")]
+                // SAFETY: baseline aarch64 provides NEON; the kernel bounds every access.
+                let simd = unsafe { quantize_binary_neon(&input, threshold, packed_len) };
+                #[cfg(target_arch = "x86_64")]
+                // SAFETY: AVX2 was detected above; the kernel bounds every access.
+                let simd = unsafe { quantize_binary_avx2(&input, threshold, packed_len) };
+                assert_eq!(
+                    simd, scalar,
+                    "explicit SIMD mismatch at dim={dim}, threshold={threshold}"
+                );
+            }
+        }
+
+        let input = generate_vector(385, 1_063);
+        let before = BINARY_QUANTIZE_SIMD_HITS.with(std::cell::Cell::get);
+        let quantized = BinaryVector::from_f32(&input);
+        let after = BINARY_QUANTIZE_SIMD_HITS.with(std::cell::Cell::get);
+        assert_eq!(
+            after,
+            before + 1,
+            "BinaryVector::from_f32 did not execute its explicit SIMD quantizer"
+        );
+        assert_eq!(
+            quantized.data,
+            quantize_binary_scalar(&input, 0.0, input.len().div_ceil(8))
+        );
     }
 
     #[test]

--- a/crates/embed/src/simd/int4.rs
+++ b/crates/embed/src/simd/int4.rs
@@ -7,7 +7,10 @@
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 use super::simd_config;
 
 /// **Unstable**: INT4 quantization internals; scale/bias scheme may change.
@@ -27,12 +30,7 @@ pub struct Int4Params {
 impl Int4Params {
     /// **Unstable**: quantization parameter computation; may be folded into `Int4Vector::from_f32`.
     pub fn from_vector(vector: &[f32]) -> Self {
-        let mut max_abs: f32 = 0.0;
-        for &v in vector {
-            if v.is_finite() {
-                max_abs = max_abs.max(v.abs());
-            }
-        }
+        let max_abs = max_abs_finite(vector);
 
         // Epsilon guard: avoid division by near-zero
         let scale = if max_abs > 1e-10 {
@@ -43,6 +41,93 @@ impl Int4Params {
 
         Self { scale, max_abs }
     }
+}
+
+fn max_abs_finite(vector: &[f32]) -> f32 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if simd_config().avx2_enabled {
+            // SAFETY: AVX2 was detected at runtime; the kernel bounds every load.
+            return unsafe { max_abs_finite_avx2(vector) };
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        if simd_config().neon_enabled {
+            // SAFETY: NEON was detected at runtime; the kernel bounds every load.
+            return unsafe { max_abs_finite_neon(vector) };
+        }
+    }
+    max_abs_finite_scalar(vector)
+}
+
+fn max_abs_finite_scalar(vector: &[f32]) -> f32 {
+    vector
+        .iter()
+        .filter(|value| value.is_finite())
+        .map(|value| value.abs())
+        .fold(0.0, f32::max)
+}
+
+#[cfg(test)]
+thread_local! {
+    static INT4_MAX_ABS_SIMD_HITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn max_abs_finite_avx2(vector: &[f32]) -> f32 {
+    #[cfg(test)]
+    INT4_MAX_ABS_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
+    let chunks = vector.len() / 8;
+    let sign = _mm256_set1_ps(-0.0);
+    let inf = _mm256_set1_ps(f32::INFINITY);
+    let mut maximum = _mm256_setzero_ps();
+
+    for i in 0..chunks {
+        let input = _mm256_loadu_ps(vector.as_ptr().add(i * 8));
+        let abs = _mm256_andnot_ps(sign, input);
+        let finite = _mm256_cmp_ps(abs, inf, _CMP_LT_OQ);
+        maximum = _mm256_max_ps(maximum, _mm256_and_ps(abs, finite));
+    }
+
+    let mut lanes = [0.0f32; 8];
+    _mm256_storeu_ps(lanes.as_mut_ptr(), maximum);
+    let mut max_abs = lanes.into_iter().fold(0.0f32, f32::max);
+    for &value in &vector[chunks * 8..] {
+        if value.is_finite() {
+            max_abs = max_abs.max(value.abs());
+        }
+    }
+    max_abs
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn max_abs_finite_neon(vector: &[f32]) -> f32 {
+    #[cfg(test)]
+    INT4_MAX_ABS_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
+    let chunks = vector.len() / 4;
+    let inf = vdupq_n_f32(f32::INFINITY);
+    let zero = vdupq_n_f32(0.0);
+    let mut maximum = zero;
+
+    for i in 0..chunks {
+        let input = vld1q_f32(vector.as_ptr().add(i * 4));
+        let abs = vabsq_f32(input);
+        let finite = vcltq_f32(abs, inf);
+        maximum = vmaxq_f32(maximum, vbslq_f32(finite, abs, zero));
+    }
+
+    let mut max_abs = vmaxvq_f32(maximum);
+    for &value in &vector[chunks * 4..] {
+        if value.is_finite() {
+            max_abs = max_abs.max(value.abs());
+        }
+    }
+    max_abs
 }
 
 /// **Unstable**: INT4 quantization format is under active design; struct layout may change.
@@ -79,26 +164,7 @@ impl Int4Vector {
         }
         let norm = norm_sq.sqrt();
 
-        // Quantize each value to [0, 15] and pack pairs into bytes
-        let packed_len = dims.div_ceil(2);
-        let mut data = vec![0u8; packed_len];
-
-        for (i, &elem) in vector[..dims].iter().enumerate() {
-            let v = if elem.is_finite() { elem } else { 0.0 };
-            // Map [-max_abs, max_abs] -> [0, 15]
-            let q = ((v + params.max_abs) * params.scale)
-                .round()
-                .clamp(0.0, 15.0) as u8;
-
-            let byte_idx = i / 2;
-            if i % 2 == 0 {
-                // Even index -> high nibble
-                data[byte_idx] |= q << 4;
-            } else {
-                // Odd index -> low nibble
-                data[byte_idx] |= q;
-            }
-        }
+        let data = quantize_int4(vector, params);
 
         Self {
             data,
@@ -159,6 +225,126 @@ impl Int4Vector {
     pub fn cosine_distance(&self, other: &Int4Vector) -> f32 {
         1.0 - self.cosine_similarity(other)
     }
+}
+
+fn quantize_int4(vector: &[f32], params: Int4Params) -> Vec<u8> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if simd_config().avx2_enabled {
+            // SAFETY: AVX2 was detected at runtime; the kernel bounds every load and store.
+            return unsafe { quantize_int4_avx2(vector, params) };
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        if simd_config().neon_enabled {
+            // SAFETY: NEON was detected at runtime; the kernel bounds every load and store.
+            return unsafe { quantize_int4_neon(vector, params) };
+        }
+    }
+    quantize_int4_scalar(vector, params)
+}
+
+fn quantize_int4_scalar(vector: &[f32], params: Int4Params) -> Vec<u8> {
+    let mut data = vec![0u8; vector.len().div_ceil(2)];
+    quantize_int4_scalar_tail(vector, params, &mut data, 0);
+    data
+}
+
+fn quantize_int4_scalar_tail(vector: &[f32], params: Int4Params, data: &mut [u8], start: usize) {
+    for (i, &value) in vector.iter().enumerate().skip(start) {
+        let quantized = quantize_int4_value(value, params);
+        if i % 2 == 0 {
+            data[i / 2] |= quantized << 4;
+        } else {
+            data[i / 2] |= quantized;
+        }
+    }
+}
+
+#[inline]
+fn quantize_int4_value(value: f32, params: Int4Params) -> u8 {
+    let finite_value = if value.is_finite() { value } else { 0.0 };
+    ((finite_value + params.max_abs) * params.scale)
+        .round()
+        .clamp(0.0, 15.0) as u8
+}
+
+#[cfg(test)]
+thread_local! {
+    static INT4_QUANTIZE_SIMD_HITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn quantize_int4_avx2(vector: &[f32], params: Int4Params) -> Vec<u8> {
+    #[cfg(test)]
+    INT4_QUANTIZE_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
+    let mut data = vec![0u8; vector.len().div_ceil(2)];
+    let chunks = vector.len() / 8;
+    let sign = _mm256_set1_ps(-0.0);
+    let inf = _mm256_set1_ps(f32::INFINITY);
+    let max_abs = _mm256_set1_ps(params.max_abs);
+    let scale = _mm256_set1_ps(params.scale);
+    let zero = _mm256_setzero_ps();
+    let high = _mm256_set1_ps(15.0);
+    let half = _mm256_set1_ps(0.5);
+    let one = _mm256_set1_epi32(1);
+
+    for i in 0..chunks {
+        let base = i * 8;
+        let input = _mm256_loadu_ps(vector.as_ptr().add(base));
+        let abs = _mm256_andnot_ps(sign, input);
+        let finite = _mm256_cmp_ps(abs, inf, _CMP_LT_OQ);
+        let values = _mm256_and_ps(input, finite);
+        let scaled = _mm256_mul_ps(_mm256_add_ps(values, max_abs), scale);
+        let clamped = _mm256_min_ps(_mm256_max_ps(scaled, zero), high);
+        let truncated = _mm256_cvttps_epi32(clamped);
+        let fraction = _mm256_sub_ps(clamped, _mm256_cvtepi32_ps(truncated));
+        let round_up = _mm256_castps_si256(_mm256_cmp_ps(fraction, half, _CMP_GE_OQ));
+        let rounded = _mm256_add_epi32(truncated, _mm256_and_si256(round_up, one));
+        let mut lanes = [0i32; 8];
+        _mm256_storeu_si256(lanes.as_mut_ptr().cast::<__m256i>(), rounded);
+        for pair in 0..4 {
+            data[base / 2 + pair] = ((lanes[pair * 2] as u8) << 4) | lanes[pair * 2 + 1] as u8;
+        }
+    }
+
+    quantize_int4_scalar_tail(vector, params, &mut data, chunks * 8);
+    data
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn quantize_int4_neon(vector: &[f32], params: Int4Params) -> Vec<u8> {
+    #[cfg(test)]
+    INT4_QUANTIZE_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
+    let mut data = vec![0u8; vector.len().div_ceil(2)];
+    let chunks = vector.len() / 4;
+    let inf = vdupq_n_f32(f32::INFINITY);
+    let zero = vdupq_n_f32(0.0);
+    let max_abs = vdupq_n_f32(params.max_abs);
+    let scale = vdupq_n_f32(params.scale);
+    let high = vdupq_n_f32(15.0);
+
+    for i in 0..chunks {
+        let base = i * 4;
+        let input = vld1q_f32(vector.as_ptr().add(base));
+        let finite = vcaltq_f32(input, inf);
+        let values = vbslq_f32(finite, input, zero);
+        let scaled = vmulq_f32(vaddq_f32(values, max_abs), scale);
+        let clamped = vminq_f32(vmaxq_f32(scaled, zero), high);
+        let rounded = vcvtaq_s32_f32(clamped);
+        let mut lanes = [0i32; 4];
+        vst1q_s32(lanes.as_mut_ptr(), rounded);
+        data[base / 2] = ((lanes[0] as u8) << 4) | lanes[1] as u8;
+        data[base / 2 + 1] = ((lanes[2] as u8) << 4) | lanes[3] as u8;
+    }
+
+    quantize_int4_scalar_tail(vector, params, &mut data, chunks * 4);
+    data
 }
 
 /// **Unstable**: dequantized INT4 dot product; dispatch may change.
@@ -355,6 +541,123 @@ mod tests {
                 unit * 2.0 - 1.0
             })
             .collect()
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[test]
+    fn test_int4_quantize_explicit_simd_matches_scalar_and_is_dispatched() {
+        #[cfg(target_arch = "x86_64")]
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        let params = Int4Params {
+            scale: 7.5,
+            max_abs: 1.0,
+        };
+        let tie_params = Int4Params {
+            scale: 1.0,
+            max_abs: 7.5,
+        };
+        let tie_input = [-7.5, -1.0, 1.0, 7.5, -1.0, 1.0, 0.0, -0.0];
+        let scalar_ties = quantize_int4_scalar(&tie_input, tie_params);
+        assert_eq!(scalar_ties, [0x07, 0x9f, 0x79, 0x88]);
+        #[cfg(target_arch = "aarch64")]
+        // SAFETY: baseline aarch64 provides NEON; the kernel bounds every access.
+        let simd_ties = unsafe { quantize_int4_neon(&tie_input, tie_params) };
+        #[cfg(target_arch = "x86_64")]
+        // SAFETY: AVX2 was detected above; the kernel bounds every access.
+        let simd_ties = unsafe { quantize_int4_avx2(&tie_input, tie_params) };
+        assert_eq!(
+            simd_ties, scalar_ties,
+            "explicit SIMD must preserve ties-away rounding"
+        );
+
+        for dim in [0usize, 1, 3, 4, 7, 8, 9, 31, 32, 33, 383, 384, 385] {
+            let mut input = generate_vector(dim, 900 + dim as u64);
+            if dim > 0 {
+                input[0] = f32::NAN;
+            }
+            if dim > 1 {
+                input[1] = f32::INFINITY;
+            }
+            if dim > 2 {
+                input[2] = f32::NEG_INFINITY;
+            }
+            if dim > 3 {
+                let boundary = -1.0 + 0.5 / params.scale;
+                input[3] = f32::from_bits(boundary.to_bits() - 1);
+            }
+            if dim > 4 {
+                let boundary = -1.0 + 0.5 / params.scale;
+                input[4] = f32::from_bits(boundary.to_bits() + 1);
+            }
+
+            let scalar = quantize_int4_scalar(&input, params);
+            #[cfg(target_arch = "aarch64")]
+            // SAFETY: baseline aarch64 provides NEON; the kernel bounds every access.
+            let simd = unsafe { quantize_int4_neon(&input, params) };
+            #[cfg(target_arch = "x86_64")]
+            // SAFETY: AVX2 was detected above; the kernel bounds every access.
+            let simd = unsafe { quantize_int4_avx2(&input, params) };
+            assert_eq!(simd, scalar, "explicit SIMD mismatch at dim={dim}");
+        }
+
+        let input = generate_vector(385, 1_063);
+        let before = INT4_QUANTIZE_SIMD_HITS.with(std::cell::Cell::get);
+        let quantized = Int4Vector::from_f32(&input);
+        let after = INT4_QUANTIZE_SIMD_HITS.with(std::cell::Cell::get);
+        assert_eq!(
+            after,
+            before + 1,
+            "Int4Vector::from_f32 did not execute its explicit SIMD quantizer"
+        );
+        assert_eq!(
+            quantized.data,
+            quantize_int4_scalar(&input, quantized.params)
+        );
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[test]
+    fn test_int4_max_abs_explicit_simd_matches_scalar() {
+        #[cfg(target_arch = "x86_64")]
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        for dim in [0usize, 1, 3, 4, 7, 8, 9, 31, 32, 33, 383, 384, 385] {
+            let mut input = generate_vector(dim, 1_100 + dim as u64);
+            if dim > 0 {
+                input[0] = f32::NAN;
+            }
+            if dim > 1 {
+                input[1] = f32::INFINITY;
+            }
+            if dim > 2 {
+                input[2] = f32::NEG_INFINITY;
+            }
+
+            let scalar = max_abs_finite_scalar(&input);
+            #[cfg(target_arch = "aarch64")]
+            // SAFETY: baseline aarch64 provides NEON; the kernel bounds every access.
+            let simd = unsafe { max_abs_finite_neon(&input) };
+            #[cfg(target_arch = "x86_64")]
+            // SAFETY: AVX2 was detected above; the kernel bounds every access.
+            let simd = unsafe { max_abs_finite_avx2(&input) };
+            assert_eq!(simd, scalar, "finite max-abs mismatch at dim={dim}");
+        }
+
+        let input = generate_vector(385, 1_063);
+        let before = INT4_MAX_ABS_SIMD_HITS.with(std::cell::Cell::get);
+        let params = Int4Params::from_vector(&input);
+        let after = INT4_MAX_ABS_SIMD_HITS.with(std::cell::Cell::get);
+        assert_eq!(
+            after,
+            before + 1,
+            "Int4Params::from_vector did not execute its explicit SIMD reducer"
+        );
+        assert_eq!(params.max_abs, max_abs_finite_scalar(&input));
     }
 
     #[test]

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -90,6 +90,42 @@ fn minmax_finite(v: &[f32]) -> (f32, f32) {
     minmax_finite_scalar(v)
 }
 
+/// Resolves the sign of a zero-valued min/max so every kernel agrees bit-for-bit.
+///
+/// `f32::min`/`f32::max`, NEON's `vminvq_f32`/`vmaxvq_f32`, and AVX2's
+/// `_mm256_min_ps`/`_mm256_max_ps` each return an unspecified one of their operands
+/// when the operands compare equal, so a `-0.0`/`+0.0` tie is broken differently per
+/// kernel and per codegen. Applying IEEE 754-2019 `minimum`/`maximum` ordering
+/// (`-0.0 < +0.0`) to the finished pair makes the choice a stated contract instead of
+/// an artifact: the min takes `-0.0` and the max takes `+0.0` whenever that sign is
+/// present in the input.
+///
+/// The sign scan runs only when a bound is exactly zero, so the cost on a typical
+/// vector is the two comparisons in the guard.
+#[inline]
+fn pin_zero_signs(v: &[f32], min_val: f32, max_val: f32) -> (f32, f32) {
+    if min_val != 0.0 && max_val != 0.0 {
+        return (min_val, max_val);
+    }
+    let mut has_negative_zero = false;
+    let mut has_positive_zero = false;
+    for &value in v {
+        has_negative_zero |= value.to_bits() == (-0.0f32).to_bits();
+        has_positive_zero |= value.to_bits() == 0.0f32.to_bits();
+    }
+    let min_val = if min_val == 0.0 {
+        if has_negative_zero { -0.0 } else { 0.0 }
+    } else {
+        min_val
+    };
+    let max_val = if max_val == 0.0 {
+        if has_positive_zero { 0.0 } else { -0.0 }
+    } else {
+        max_val
+    };
+    (min_val, max_val)
+}
+
 fn minmax_finite_scalar(v: &[f32]) -> (f32, f32) {
     let mut min_val = f32::INFINITY;
     let mut max_val = f32::NEG_INFINITY;
@@ -99,7 +135,7 @@ fn minmax_finite_scalar(v: &[f32]) -> (f32, f32) {
             max_val = max_val.max(x);
         }
     }
-    (min_val, max_val)
+    pin_zero_signs(v, min_val, max_val)
 }
 
 #[cfg(test)]
@@ -141,21 +177,7 @@ unsafe fn minmax_finite_avx2(v: &[f32]) -> (f32, f32) {
             max_val = max_val.max(x);
         }
     }
-    if min_val == 0.0 || max_val == 0.0 {
-        let mut has_negative_zero = false;
-        let mut has_positive_zero = false;
-        for &value in v {
-            has_negative_zero |= value.to_bits() == (-0.0f32).to_bits();
-            has_positive_zero |= value.to_bits() == 0.0f32.to_bits();
-        }
-        if min_val == 0.0 {
-            min_val = if has_negative_zero { -0.0 } else { 0.0 };
-        }
-        if max_val == 0.0 {
-            max_val = if has_positive_zero { 0.0 } else { -0.0 };
-        }
-    }
-    (min_val, max_val)
+    pin_zero_signs(v, min_val, max_val)
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -186,7 +208,7 @@ unsafe fn minmax_finite_neon(v: &[f32]) -> (f32, f32) {
             max_val = max_val.max(x);
         }
     }
-    (min_val, max_val)
+    pin_zero_signs(v, min_val, max_val)
 }
 
 /// **Unstable**: INT8 quantized vector; struct layout and invariants may change.
@@ -991,6 +1013,66 @@ mod simd_parity_tests {
         assert_eq!(
             (params.min_val.to_bits(), params.max_val.to_bits()),
             (scalar.0.to_bits(), scalar.1.to_bits())
+        );
+    }
+
+    /// The signed-zero tie-break is a contract, not whatever the reduction happened to
+    /// pick. Parity tests can only compare kernels against each other, so they pass on
+    /// any architecture whose kernels agree by accident; this pins the value itself and
+    /// runs everywhere, including targets with no explicit SIMD path at all.
+    ///
+    /// The first block drives `pin_zero_signs` directly with bounds carrying the wrong
+    /// sign. That matters: on aarch64 the scalar fold already returns the contracted
+    /// signs, so assertions routed through `minmax_finite_scalar` alone still pass with
+    /// the sign pass deleted. Only x86-64 breaks the tie the other way, and a guard that
+    /// can be removed without any local test noticing is not a guard.
+    #[test]
+    fn test_minmax_finite_pins_zero_signs() {
+        let both_signs = [-0.0f32, 0.0, -1.0];
+        assert_eq!(
+            pin_zero_signs(&both_signs, -1.0, -0.0).1.to_bits(),
+            0.0f32.to_bits(),
+            "a max of -0.0 must be rewritten to +0.0 when +0.0 is present"
+        );
+        assert_eq!(
+            pin_zero_signs(&both_signs, 0.0, -1.0).0.to_bits(),
+            (-0.0f32).to_bits(),
+            "a min of +0.0 must be rewritten to -0.0 when -0.0 is present"
+        );
+
+        let max_ties = [-0.0f32, 0.0, -1.0];
+        let (_, max_val) = minmax_finite_scalar(&max_ties);
+        assert_eq!(
+            max_val.to_bits(),
+            0.0f32.to_bits(),
+            "max must take +0.0 when both zero signs are present"
+        );
+
+        let min_ties = [0.0f32, -0.0, 1.0];
+        let (min_val, _) = minmax_finite_scalar(&min_ties);
+        assert_eq!(
+            min_val.to_bits(),
+            (-0.0f32).to_bits(),
+            "min must take -0.0 when both zero signs are present"
+        );
+
+        // A bound that is zero with only one sign available keeps that sign.
+        let (only_neg_min, only_neg_max) = minmax_finite_scalar(&[-0.0f32, -1.0]);
+        assert_eq!(only_neg_max.to_bits(), (-0.0f32).to_bits());
+        assert_eq!(only_neg_min.to_bits(), (-1.0f32).to_bits());
+        let (only_pos_min, only_pos_max) = minmax_finite_scalar(&[0.0f32, 1.0]);
+        assert_eq!(only_pos_min.to_bits(), 0.0f32.to_bits());
+        assert_eq!(only_pos_max.to_bits(), 1.0f32.to_bits());
+
+        // Non-zero bounds are returned untouched, and an all-nonfinite input keeps the
+        // identity pair rather than being rewritten by the sign pass.
+        assert_eq!(
+            minmax_finite_scalar(&[]),
+            (f32::INFINITY, f32::NEG_INFINITY)
+        );
+        assert_eq!(
+            minmax_finite_scalar(&[f32::NAN, f32::INFINITY]),
+            (f32::INFINITY, f32::NEG_INFINITY)
         );
     }
 

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -73,6 +73,13 @@ impl QuantizationParams {
 /// quantization at 1024 dims), so the hot path must not depend on the
 /// auto-vectorizer's mood.
 fn minmax_finite(v: &[f32]) -> (f32, f32) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if simd_config().avx2_enabled {
+            // SAFETY: AVX2 was detected at runtime; the kernel bounds every load.
+            return unsafe { minmax_finite_avx2(v) };
+        }
+    }
     #[cfg(target_arch = "aarch64")]
     {
         if simd_config().neon_enabled {
@@ -95,8 +102,67 @@ fn minmax_finite_scalar(v: &[f32]) -> (f32, f32) {
     (min_val, max_val)
 }
 
+#[cfg(test)]
+thread_local! {
+    static I8_MINMAX_SIMD_HITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn minmax_finite_avx2(v: &[f32]) -> (f32, f32) {
+    #[cfg(test)]
+    I8_MINMAX_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
+    let chunks = v.len() / 8;
+    let inf = _mm256_set1_ps(f32::INFINITY);
+    let neg_inf = _mm256_set1_ps(f32::NEG_INFINITY);
+    let sign = _mm256_set1_ps(-0.0);
+    let mut vmin = inf;
+    let mut vmax = neg_inf;
+
+    for i in 0..chunks {
+        let x = _mm256_loadu_ps(v.as_ptr().add(i * 8));
+        let abs = _mm256_andnot_ps(sign, x);
+        let finite = _mm256_cmp_ps(abs, inf, _CMP_LT_OQ);
+        vmin = _mm256_min_ps(vmin, _mm256_blendv_ps(inf, x, finite));
+        vmax = _mm256_max_ps(vmax, _mm256_blendv_ps(neg_inf, x, finite));
+    }
+
+    let mut min_lanes = [0.0f32; 8];
+    let mut max_lanes = [0.0f32; 8];
+    _mm256_storeu_ps(min_lanes.as_mut_ptr(), vmin);
+    _mm256_storeu_ps(max_lanes.as_mut_ptr(), vmax);
+
+    let mut min_val = min_lanes.into_iter().fold(f32::INFINITY, f32::min);
+    let mut max_val = max_lanes.into_iter().fold(f32::NEG_INFINITY, f32::max);
+    for &x in &v[chunks * 8..] {
+        if x.is_finite() {
+            min_val = min_val.min(x);
+            max_val = max_val.max(x);
+        }
+    }
+    if min_val == 0.0 || max_val == 0.0 {
+        let mut has_negative_zero = false;
+        let mut has_positive_zero = false;
+        for &value in v {
+            has_negative_zero |= value.to_bits() == (-0.0f32).to_bits();
+            has_positive_zero |= value.to_bits() == 0.0f32.to_bits();
+        }
+        if min_val == 0.0 {
+            min_val = if has_negative_zero { -0.0 } else { 0.0 };
+        }
+        if max_val == 0.0 {
+            max_val = if has_positive_zero { 0.0 } else { -0.0 };
+        }
+    }
+    (min_val, max_val)
+}
+
 #[cfg(target_arch = "aarch64")]
 unsafe fn minmax_finite_neon(v: &[f32]) -> (f32, f32) {
+    #[cfg(test)]
+    I8_MINMAX_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
     let chunks = v.len() / 4;
     let inf = unsafe { vdupq_n_f32(f32::INFINITY) };
     let neg_inf = unsafe { vdupq_n_f32(f32::NEG_INFINITY) };
@@ -176,16 +242,7 @@ impl QuantizedVector {
         }
         let norm = norm_sq.sqrt();
 
-        let data: Vec<i8> = vector
-            .iter()
-            .map(|&v| {
-                if !v.is_finite() {
-                    0
-                } else {
-                    (v * params.scale).round().clamp(-127.0, 127.0) as i8
-                }
-            })
-            .collect();
+        let data = quantize_i8(vector, params.scale);
 
         Self { data, params, norm }
     }
@@ -214,6 +271,128 @@ impl QuantizedVector {
     pub fn cosine_similarity(&self, other: &QuantizedVector) -> f32 {
         cosine_similarity_i8(self, other)
     }
+}
+
+fn quantize_i8(vector: &[f32], scale: f32) -> Vec<i8> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if simd_config().avx2_enabled {
+            // SAFETY: AVX2 was detected at runtime; the kernel bounds every load and store.
+            return unsafe { quantize_i8_avx2(vector, scale) };
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        if simd_config().neon_enabled {
+            // SAFETY: NEON was detected at runtime; the kernel bounds every load and store.
+            return unsafe { quantize_i8_neon(vector, scale) };
+        }
+    }
+    quantize_i8_scalar(vector, scale)
+}
+
+fn quantize_i8_scalar(vector: &[f32], scale: f32) -> Vec<i8> {
+    vector
+        .iter()
+        .map(|&v| quantize_i8_value(v, scale))
+        .collect()
+}
+
+#[inline]
+fn quantize_i8_value(value: f32, scale: f32) -> i8 {
+    if value.is_finite() {
+        (value * scale).round().clamp(-127.0, 127.0) as i8
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    static I8_QUANTIZE_SIMD_HITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn quantize_i8_avx2(vector: &[f32], scale: f32) -> Vec<i8> {
+    #[cfg(test)]
+    I8_QUANTIZE_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
+    let mut data = vec![0i8; vector.len()];
+    let chunks = vector.len() / 8;
+    let scale_scalar = scale;
+    let scale = _mm256_set1_ps(scale_scalar);
+    let inf = _mm256_set1_ps(f32::INFINITY);
+    let sign = _mm256_set1_ps(-0.0);
+    let low = _mm256_set1_ps(-127.0);
+    let high = _mm256_set1_ps(127.0);
+    let half = _mm256_set1_ps(0.5);
+    let negative_half = _mm256_set1_ps(-0.5);
+    let one = _mm256_set1_epi32(1);
+    let negative_one = _mm256_set1_epi32(-1);
+
+    for i in 0..chunks {
+        let base = i * 8;
+        let input = _mm256_loadu_ps(vector.as_ptr().add(base));
+        let abs = _mm256_andnot_ps(sign, input);
+        let finite = _mm256_cmp_ps(abs, inf, _CMP_LT_OQ);
+        let values = _mm256_and_ps(input, finite);
+        let scaled = _mm256_mul_ps(values, scale);
+        let clamped = _mm256_min_ps(_mm256_max_ps(scaled, low), high);
+        let truncated = _mm256_cvttps_epi32(clamped);
+        let fraction = _mm256_sub_ps(clamped, _mm256_cvtepi32_ps(truncated));
+        let round_up = _mm256_castps_si256(_mm256_cmp_ps(fraction, half, _CMP_GE_OQ));
+        let round_down = _mm256_castps_si256(_mm256_cmp_ps(fraction, negative_half, _CMP_LE_OQ));
+        let rounded = _mm256_add_epi32(
+            _mm256_add_epi32(truncated, _mm256_and_si256(round_up, one)),
+            _mm256_and_si256(round_down, negative_one),
+        );
+        let mut lanes = [0i32; 8];
+        _mm256_storeu_si256(lanes.as_mut_ptr().cast::<__m256i>(), rounded);
+        for (offset, lane) in lanes.into_iter().enumerate() {
+            data[base + offset] = lane as i8;
+        }
+    }
+
+    for i in chunks * 8..vector.len() {
+        data[i] = quantize_i8_value(vector[i], scale_scalar);
+    }
+    data
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn quantize_i8_neon(vector: &[f32], scale: f32) -> Vec<i8> {
+    #[cfg(test)]
+    I8_QUANTIZE_SIMD_HITS.with(|hits| hits.set(hits.get() + 1));
+
+    let mut data = vec![0i8; vector.len()];
+    let chunks = vector.len() / 4;
+    let scale_vector = vdupq_n_f32(scale);
+    let inf = vdupq_n_f32(f32::INFINITY);
+    let zero = vdupq_n_f32(0.0);
+    let low = vdupq_n_f32(-127.0);
+    let high = vdupq_n_f32(127.0);
+
+    for i in 0..chunks {
+        let base = i * 4;
+        let input = vld1q_f32(vector.as_ptr().add(base));
+        let finite = vcaltq_f32(input, inf);
+        let values = vbslq_f32(finite, input, zero);
+        let scaled = vmulq_f32(values, scale_vector);
+        let clamped = vminq_f32(vmaxq_f32(scaled, low), high);
+        let rounded = vcvtaq_s32_f32(clamped);
+        let mut lanes = [0i32; 4];
+        vst1q_s32(lanes.as_mut_ptr(), rounded);
+        for (offset, lane) in lanes.into_iter().enumerate() {
+            data[base + offset] = lane as i8;
+        }
+    }
+
+    for i in chunks * 4..vector.len() {
+        data[i] = quantize_i8_value(vector[i], scale);
+    }
+    data
 }
 
 /// **Unstable**: computes an approximate float dot product, returning `0.0` for a mismatch.
@@ -679,6 +858,140 @@ mod simd_parity_tests {
                 unit * 2.0 - 1.0
             })
             .collect()
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[test]
+    fn test_i8_quantize_explicit_simd_matches_scalar_and_is_dispatched() {
+        #[cfg(target_arch = "x86_64")]
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        for dim in [0usize, 1, 3, 4, 7, 8, 9, 31, 32, 33, 383, 384, 385] {
+            let mut input = gen_vec(dim, 900 + dim as u64);
+            if dim > 0 {
+                input[0] = f32::NAN;
+            }
+            if dim > 1 {
+                input[1] = f32::INFINITY;
+            }
+            if dim > 2 {
+                input[2] = f32::NEG_INFINITY;
+            }
+            if dim > 3 {
+                input[3] = 0.25;
+            }
+            if dim > 4 {
+                input[4] = -0.25;
+            }
+            if dim > 5 {
+                input[5] = f32::from_bits(0.25f32.to_bits() - 1);
+            }
+            if dim > 6 {
+                input[6] = f32::from_bits(0.25f32.to_bits() + 1);
+            }
+
+            let scalar = quantize_i8_scalar(&input, 2.0);
+            #[cfg(target_arch = "aarch64")]
+            // SAFETY: baseline aarch64 provides NEON; the kernel bounds every access.
+            let simd = unsafe { quantize_i8_neon(&input, 2.0) };
+            #[cfg(target_arch = "x86_64")]
+            // SAFETY: AVX2 was detected above; the kernel bounds every access.
+            let simd = unsafe { quantize_i8_avx2(&input, 2.0) };
+            assert_eq!(simd, scalar, "explicit SIMD mismatch at dim={dim}");
+        }
+
+        let input = gen_vec(385, 1_063);
+        let before = I8_QUANTIZE_SIMD_HITS.with(std::cell::Cell::get);
+        let quantized = QuantizedVector::from_f32(&input);
+        let after = I8_QUANTIZE_SIMD_HITS.with(std::cell::Cell::get);
+        assert_eq!(
+            after,
+            before + 1,
+            "QuantizedVector::from_f32 did not execute its explicit SIMD quantizer"
+        );
+        assert_eq!(
+            quantized.data,
+            quantize_i8_scalar(&input, quantized.params.scale)
+        );
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[test]
+    fn test_finite_minmax_explicit_simd_matches_scalar() {
+        #[cfg(target_arch = "x86_64")]
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        for dim in [0usize, 1, 3, 4, 7, 8, 9, 31, 32, 33, 383, 384, 385] {
+            let mut input = gen_vec(dim, 1_100 + dim as u64);
+            if dim > 0 {
+                input[0] = f32::NAN;
+            }
+            if dim > 1 {
+                input[1] = f32::INFINITY;
+            }
+            if dim > 2 {
+                input[2] = f32::NEG_INFINITY;
+            }
+            if dim > 3 {
+                input[3] = -0.0;
+            }
+            if dim > 4 {
+                input[4] = 0.0;
+            }
+
+            let scalar = minmax_finite_scalar(&input);
+            #[cfg(target_arch = "aarch64")]
+            // SAFETY: baseline aarch64 provides NEON; the kernel bounds every access.
+            let simd = unsafe { minmax_finite_neon(&input) };
+            #[cfg(target_arch = "x86_64")]
+            // SAFETY: AVX2 was detected above; the kernel bounds every access.
+            let simd = unsafe { minmax_finite_avx2(&input) };
+            assert_eq!(
+                (simd.0.to_bits(), simd.1.to_bits()),
+                (scalar.0.to_bits(), scalar.1.to_bits()),
+                "finite min/max mismatch at dim={dim}"
+            );
+        }
+
+        let mut min_zero_input = vec![1.0f32; 16];
+        min_zero_input[0] = -0.0;
+        min_zero_input[8] = 0.0;
+        let mut max_zero_input = vec![-1.0f32; 16];
+        max_zero_input[0] = 0.0;
+        max_zero_input[8] = -0.0;
+        for input in [&min_zero_input, &max_zero_input] {
+            let scalar = minmax_finite_scalar(input);
+            #[cfg(target_arch = "aarch64")]
+            // SAFETY: baseline aarch64 provides NEON; the kernel bounds every access.
+            let simd = unsafe { minmax_finite_neon(input) };
+            #[cfg(target_arch = "x86_64")]
+            // SAFETY: AVX2 was detected above; the kernel bounds every access.
+            let simd = unsafe { minmax_finite_avx2(input) };
+            assert_eq!(
+                (simd.0.to_bits(), simd.1.to_bits()),
+                (scalar.0.to_bits(), scalar.1.to_bits()),
+                "finite min/max signed-zero mismatch"
+            );
+        }
+
+        let input = gen_vec(385, 1_063);
+        let before = I8_MINMAX_SIMD_HITS.with(std::cell::Cell::get);
+        let params = QuantizationParams::from_vector(&input);
+        let after = I8_MINMAX_SIMD_HITS.with(std::cell::Cell::get);
+        assert_eq!(
+            after,
+            before + 1,
+            "QuantizationParams::from_vector did not execute its explicit SIMD reducer"
+        );
+        let scalar = minmax_finite_scalar(&input);
+        assert_eq!(
+            (params.min_val.to_bits(), params.max_val.to_bits()),
+            (scalar.0.to_bits(), scalar.1.to_bits())
+        );
     }
 
     // FP-034: NEON SDOT vs scalar parity for INT8 dot product.

--- a/docs/adr/ADR-085-explicit-quantization-simd.md
+++ b/docs/adr/ADR-085-explicit-quantization-simd.md
@@ -1,0 +1,65 @@
+# ADR-085: Explicit Quantization SIMD Dispatch
+
+**Status**: Accepted
+**Date**: 2026-07-28
+**Crate**: lattice-embed
+
+## Context
+
+The finite-value reduction in `QuantizationParams::from_vector` previously
+depended on LLVM auto-vectorizing a guarded loop. An unrelated codegen-unit
+change demoted that loop to scalar instructions and regressed per-call INT8
+quantization by 47.6%. The repair in #1062 added an explicit NEON reduction, but
+the guarded conversion loops in INT8, INT4, and binary quantization retained the
+same compiler sensitivity. The x86_64 reduction also remained scalar and
+unmeasured.
+
+The L2 norm loops in these constructors are different. Their scalar accumulation
+order is part of the numerical behavior; vectorizing them would reassociate
+floating-point addition.
+
+## Decision
+
+INT8, INT4, and binary constructors dispatch their guarded conversion loops to
+explicit NEON kernels on aarch64 and AVX2 kernels on x86_64. INT8 finite min/max
+and INT4 finite max-absolute reductions use the same architecture coverage.
+Targets without the selected feature retain scalar fallbacks.
+
+The kernels preserve the existing format:
+
+- non-finite source lanes are replaced with zero before conversion;
+- INT8 and INT4 use round-half-away-from-zero and their existing clamps;
+- INT4 remains high-nibble-first and binary remains most-significant-bit-first;
+- vector chunks use bounded unaligned loads, with safe scalar tails;
+- L2 norm accumulation remains scalar-ordered.
+
+Architecture-specific tests compare every SIMD result with the scalar reference
+across boundary lengths, non-finite values, rounding boundaries, and binary
+thresholds. Test-only thread-local counters prove each constructor executes its
+applicable SIMD reduction and conversion kernels on capable hardware.
+
+### Alternatives Considered
+
+| Alternative                                 | Why not                                                                              |
+| ------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Continue relying on LLVM auto-vectorization | Prior codegen-unit changes caused a silent 47.6% regression without a source change. |
+| Add only disassembly checks                 | They detect demotion but leave throughput dependent on compiler heuristics.          |
+| Vectorize L2 norm accumulation too          | Reassociation changes floating-point results and is outside this decision.           |
+| Require AVX2 or NEON                        | CPU-first support requires a scalar fallback for older x86_64 and other targets.     |
+
+## Consequences
+
+Quantization no longer depends on guarded-loop auto-vectorization on supported
+desktop architectures, and AVX2 closes the previously silent x86_64 gap. The
+implementation adds unsafe intrinsic code that requires manual review, scalar
+equivalence tests, and architecture-specific compilation.
+
+The draft must receive uncontended A/B measurements before merge. Correctness
+validation alone does not establish that the extra packing work around each
+vector chunk improves end-to-end constructor throughput.
+
+## References
+
+- [Issue #1063](https://github.com/ohdearquant/lattice/issues/1063)
+- [Issue #1062](https://github.com/ohdearquant/lattice/issues/1062)
+- [ADR-058](ADR-058-cpu-perf-regression-ci.md)

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -119,6 +119,7 @@ Global ADR index for the Lattice project. Numbered sequentially, grouped by crat
 | [081](ADR-081-prefill-gemm-optimization-priority.md)   | Prefill GEMM Optimization Priority (Metal)                                                                   | Proposed | none                            |
 | [082](ADR-082-gemma4-e2b-support.md)                   | Gemma 4 E2B Support — Staged Multimodal Ladder (Vision + Audio)                                              | Accepted | ADR-069                         |
 | [083](ADR-083-backward-simd-dispatch.md)               | Backward SIMD Dispatch Contract                                                                              | Accepted | ADR-002, ADR-058                |
+| [085](ADR-085-explicit-quantization-simd.md)           | Explicit Quantization SIMD Dispatch                                                                          | Accepted | ADR-058                         |
 
 ## informational
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -15,7 +15,7 @@ Counts are recorded in each crate's top-level `lib.rs` comment and updated on ea
 | Crate               | `unsafe` blocks | Reason                                                                                   |
 | ------------------- | --------------- | ---------------------------------------------------------------------------------------- |
 | `lattice-inference` | 153             | SIMD matmul/attention kernels (AVX2, NEON, Metal FFI), mmap tensor slices, f16 bit-casts |
-| `lattice-embed`     | 21              | SIMD intrinsic calls (AVX-512, AVX2, NEON) in distance and normalize kernels             |
+| `lattice-embed`     | 30              | SIMD intrinsic calls (AVX-512, AVX2, NEON), including quantization kernels               |
 | `lattice-fann`      | 0               | No unsafe — all operations are safe Rust                                                 |
 | `lattice-transport` | 0               | No unsafe — pure safe Rust math                                                          |
 | `lattice-tune`      | 0               | No unsafe                                                                                |
@@ -81,7 +81,7 @@ safety invariant is documented at the call site.
 
 | Flag                           | Effect                                                     |
 | ------------------------------ | ---------------------------------------------------------- |
-| Default (`native`, no GPU)     | 21 unsafe blocks in `embed` (SIMD only)                    |
+| Default (`native`, no GPU)     | 30 unsafe blocks in `embed` (SIMD only)                    |
 | Disable `native` feature       | 0 unsafe blocks in `embed` (no inference, remote API only) |
 | No `metal-gpu`                 | Removes Metal FFI unsafe blocks in `inference`             |
 | No `f16`                       | Removes f16 bit-cast unsafe in `inference`                 |


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

Replace compiler-dependent guarded quantization loops with explicit SIMD dispatch:

- INT8 finite min/max reduction and float-to-INT8 conversion;
- INT4 finite max-absolute reduction and packed-nibble conversion;
- binary threshold conversion and bit packing.

Each path now has NEON and AVX2 kernels plus the existing scalar behavior as a fallback. L2 norm accumulation remains scalar-ordered.

Closes #1063.

## Defect

These hot loops mixed finiteness guards, conversion, and packing. Their performance therefore depended on LLVM continuing to auto-vectorize the exact source shape across codegen-unit and compiler changes. INT8 reduction had already demonstrated a silent 47.6% regression after such a change; the conversion loops and x86 reducers retained the same failure mode.

## Implementation

- dispatch once through the cached SIMD capability configuration;
- process bounded full vectors with unaligned NEON or AVX2 loads;
- substitute zero for non-finite source lanes;
- preserve round-half-away-from-zero for INT8 and INT4;
- preserve INT4 high-nibble-first and binary most-significant-bit-first layouts;
- leave incomplete vectors and final partial packed bytes to scalar tails;
- retain scalar fallbacks for targets without the selected feature.

ADR-085 records the dispatch and numerical contracts. The unsafe-code inventory is updated for the nine new production dispatch blocks.

## Regression and mutation proof

Architecture tests compare SIMD and scalar results across empty, tail, and vector-boundary lengths; NaN and infinities; signed zero; exact rounding ties; and binary thresholds including NaN and infinities. Test-only hit counters prove the public constructors dispatch both applicable reducers and converters.

Three production-only mutations were exercised with the tests unchanged:

```text
Bypass all three constructor conversion dispatches:
QuantizedVector::from_f32 ... left: 13, right: 14
Int4Vector::from_f32 ... left: 13, right: 14
BinaryVector::from_f32 ... left: 65, right: 66

Change INT4 NEON ties-away conversion to ties-even:
left:  [6, 143, 104, 136]
right: [7, 159, 121, 136]

Bypass both constructor reduction dispatches:
Int4Params::from_vector ... left: 13, right: 14
QuantizationParams::from_vector ... left: 15, right: 16
```

Restoring each production path made the five explicit-SIMD regressions pass.

## Validation

```text
cargo test -p lattice-embed
289 unit tests passed; all integration tests passed; 4 HF parity tests passed, 1 ignored

cargo test -p lattice-embed --lib explicit_simd
5 passed

cargo clippy --workspace --all-targets -- -D warnings
passed

cargo fmt --all -- --check
passed

scripts/lint-docs.sh
passed

cargo test --target x86_64-apple-darwin -p lattice-embed --no-run
all test binaries built

cargo check --target wasm32-unknown-unknown -p lattice-embed --lib
passed
```

Native aarch64 execution covered the NEON paths. The x86_64 test build and scalar tests passed under Rosetta, but that environment reports AVX2 unavailable, so it did not execute the AVX2 regressions. Release assembly contains the named AVX2 kernels and vector conversion/packing instructions, but execution on real AVX2 hardware and manual intrinsic verification remain required before merge.

## Sibling sweep

- INT8: both the finite min/max reducer and integer conversion now dispatch explicitly.
- INT4: both the finite max-absolute reducer and packed conversion now dispatch explicitly.
- Binary: threshold conversion and bit packing now dispatch explicitly.
- Constructor L2 norms intentionally remain scalar because SIMD reassociation would change floating-point accumulation order.
- Other targets retain scalar fallbacks; no additional guarded quantization or packing sibling remained in these modules.

## Signed-zero tie-break across the three minmax kernels

The finite min/max reduction had its signed-zero normalization in exactly one of three
kernels. AVX2 normalized the result; NEON and the scalar reference folded bare
`f32::min`/`f32::max`, which return an unspecified one of their operands when the operands
compare equal. The scalar-vs-SIMD parity test then asserted bit equality across kernels, i.e.
against a tie-break nothing specifies. aarch64 agreed by coincidence and x86-64 did not, so
`test_finite_minmax_explicit_simd_matches_scalar` failed on `ubuntu-latest` at `dim=7`
(`+0.0` vs `-0.0`) while both aarch64 legs passed.

The normalization is now one `pin_zero_signs` helper applied in all three kernels, making
IEEE 754-2019 `minimum`/`maximum` ordering (`-0.0 < +0.0`) a stated contract rather than a
property of codegen: the min takes `-0.0` and the max takes `+0.0` when that sign is present.
The sign scan runs only when a bound is exactly zero, so the cost on a typical vector is the
two comparisons in the guard.

`test_minmax_finite_pins_zero_signs` pins the contract directly. It drives `pin_zero_signs`
with wrong-signed bounds rather than routing through the scalar fold, because on aarch64 the
fold already returns the contracted signs — assertions routed through it still pass with the
sign pass deleted, so the direct form is what makes the guard fail on every target when the
contract is removed.

## bench-compare disposition

`make bench-compare`, quick mode, base `94c473d7bd` vs head `453946918f`, embed filter
`int8_|int4_|binary_`, 93 measurements. The inference target was left at its default
deliberately: this PR does not touch `crates/inference`, so those groups act as an in-run
control on unchanged source.

This re-runs an earlier A/B measured at `07a64d2e06`. The head has since gained
`pin_zero_signs` on the scalar and NEON `minmax_finite` paths, which are on the embed hot
path, so the earlier numbers no longer described the head that would merge. They are replaced
rather than caveated.

**Run conditions**

```
resolution: --quick
targets: lattice-inference:elementwise_cpu_bench, lattice-embed:simd
filters: inference='<all>' embed='int8_|int4_|binary_'
enforcement: report-only (gate status printed, exit 0)
locks: bench-window acquired immediately (uncontended)
       Metal GPU  acquired immediately (uncontended)
       heavy lane held exclusively (all 3 slots)
ambient load: [quiet] before base    idle 86.1% (floor 70.0%) ok
              [quiet] between phases idle 82.6% (floor 70.0%) ok
              [quiet] after head     idle 87.9% (floor 70.0%) ok
```

`BENCH_IDLE_FLOOR` left at its default and not lowered at any point. An earlier attempt was
refused by the harness at 56.7% idle and was not overridden.

**Result: one effect, reproduced and scale-invariant; the rest is not attributable.**

| Benchmark | Δ | 95% CI | base ns | new ns |
|---|---:|---|---:|---:|
| `tier_prepared_batch_sizes/int4_query_per_call/1000` | **−54.19%** | [−54.72%, −53.65%] | 1,652,382.8 | 756,974.0 |
| `tier_prepared_batch_sizes/int4_query_per_call/100` | **−52.98%** | [−53.40%, −52.57%] | 160,352.6 | 75,392.4 |
| `tier_prepared_batch_sizes/int4_query_per_call/10` | **−52.98%** | [−53.09%, −52.87%] | 15,934.7 | 7,492.5 |
| `tier_prepared_query/int4_query_per_call_1000` | **−52.88%** | [−53.20%, −52.56%] | 1,622,778.7 | 764,581.2 |

Roughly a 2.1× speedup on the int4 query-per-call path, holding across three input scales and
reproducing across two independent runs at two different heads (−52.79% at `07a64d2e06`,
−52.88% here for the common benchmark). Its A/A control row is **+0.59%**, so the effect is
about 90× its own control and about 4× the largest excursion anywhere in the A/A.

**Everything else is not attributed, and the report itself shows why.** The gate printed
"3 confirmed improvement". All three are in `crates/inference`, which is byte-identical
across both arms:

| Benchmark (unchanged source) | Δ | 95% CI | gate verdict |
|---|---:|---|---|
| `residual_add_layer_norm/unfused/hidden384_seq128` | −7.15% | [−8.24%, −6.04%] | WIN |
| `gelu/4096` | −4.58% | [−7.64%, −1.39%] | WIN |
| `rms_norm/896` | −4.30% | [−6.05%, −2.50%] | WIN |

A gate declaring three wins on code that did not change is the disposition for every sub-10%
row in this report. The embed rows in that band — `int8_batch_cosine/float32_simd/1000`
+5.45%, `int8_prepared_dot_product/per_call/129` +5.34%, and a cluster of −3% to −7%
"WIN (informational)" rows — are claimed in neither direction.

**A/A control, both arms `94c473d7bd`, same filter and mode.** On byte-identical source the
lane produced two gate failures and a −13%…+14% spread:

| Benchmark (identical source) | change | 95% CI | verdict |
|---|---|---|---|
| `binary_cosine_distance/binary/384` | +14.28% | [+13.68%, +14.89%] | FAIL |
| `int4_cosine_distance/float32_simd/384` | −12.91% | [−14.68%, −11.13%] | WIN |
| `binary_cosine_distance/float32_simd/768` | −10.19% | [−11.94%, −8.38%] | WIN |
| `int8_raw_dot_product/dot_product_i8_raw/128` | +8.74% | [+7.69%, +9.80%] | FAIL |

The control was not re-run at this head. It bounds the lane rather than the diff, and neither
the machine nor the filter changed, so the earlier run still applies — stated explicitly
because reusing a control is itself a claim.

**On the exit code:** enforcement was report-only, and all nine filtered groups are excluded
from gating as quick-mode informational-only (#714). A zero exit here means the harness ran,
not that anything passed. Narrow Criterion intervals are also not reassurance: the interval
is a within-run dispersion estimate and says nothing about between-arm bias, so a biased lane
reports a tight interval around the wrong number.

**Disclosed confound:** the quiet samples record Python and sqlite3 consumers at up to 55.7%.
All three samples cleared the 70% floor and the floor was not lowered, but the machine was not
idle and the load was not symmetric across phases. That is a further reason the sub-10% rows
are left unclaimed.

`--full` was deliberately not run. More samples do not correct between-arm bias, so the A/A
control was the right instrument rather than a longer A/B.

Still outstanding, unchanged by this measurement: manual SIMD intrinsic verification and AVX2
execution on capable hardware.
