### PR TITLE
fix(bench): exclude in-place measurement targets from Spotlight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,7 +638,7 @@ jobs:
         run: python3 tests/test_bench_decode_adapters_agentic.py -v
       # bench-compare's Spotlight-exclusion guard. Same "harness plumbing only"
       # scope as the steps above: it asserts the guard's exit codes and the
-      # bench-compare.sh call site, and runs no benchmark.
+      # benchmark measurement call sites, and runs no benchmark.
       - name: bash scripts/ensure-noindex-marker-selftest.sh
         run: bash scripts/ensure-noindex-marker-selftest.sh
       - name: python3 tests/test_bench_disposition.py

--- a/scripts/bench_decode_slopefit.sh
+++ b/scripts/bench_decode_slopefit.sh
@@ -29,6 +29,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# The scheduled macOS measurement builds in this checkout. Reapply the marker
+# before every build because cleaning target removes the protection with it.
+"$REPO/scripts/lib/ensure-noindex-marker.sh" "$REPO/target"
+
 # Build before benchmarking; cargo incremental prevents stale release binaries.
 >&2 echo "[slopefit] building bench_decode_slopefit (release)..."
 cargo build --release -p lattice-inference --bin bench_decode_slopefit \

--- a/scripts/ensure-noindex-marker-selftest.sh
+++ b/scripts/ensure-noindex-marker-selftest.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Self-test for scripts/lib/ensure-noindex-marker.sh.
 #
-# The marker suppresses Spotlight indexing of the bench worktrees. Indexing
-# churn lands asymmetrically across a base-then-head A/B and reads as a code
-# delta, so a silently absent marker does not fail the run: it corrupts the
-# numbers while they still look trustworthy. That makes the guard fail-closed
-# infrastructure, and this proves each branch's exit code in a sandbox:
+# The marker suppresses Spotlight indexing of benchmark worktrees and in-place
+# target directories. Indexing churn can overlap a timing phase and read as a
+# code delta, so a silently absent marker does not fail the run: it corrupts
+# the numbers while they still look trustworthy. That makes the guard
+# fail-closed infrastructure, and this proves each branch's exit code in a
+# sandbox:
 #   bash scripts/ensure-noindex-marker-selftest.sh
 #
 # The invariant under test, stated once: WHEN THE GUARD EXITS 0, A REGULAR
@@ -16,15 +17,17 @@ set -uo pipefail
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 SRC="$REPO/scripts/lib/ensure-noindex-marker.sh"
 # The measurement body, not the entry point: scripts/bench-compare.sh only
-# takes the machine-wide locks and execs this. Naming a file by path is how a
-# check like this goes stale, so the existence assertion below is what turns a
-# future move into a loud failure instead of a silently-skipped call-site test.
-CALLER="$REPO/scripts/lib/bench-compare-impl.sh"
-if [ ! -f "$CALLER" ]; then
-  echo "FATAL: expected caller $CALLER does not exist — the call-site assertions" >&2
-  echo "  below would vacuously pass against a moved or renamed file." >&2
-  exit 1
-fi
+# takes the machine-wide locks and execs this. The slopefit driver is the build
+# path used by the scheduled macOS measurement workflow.
+COMPARE_CALLER="$REPO/scripts/lib/bench-compare-impl.sh"
+SLOPEFIT_CALLER="$REPO/scripts/bench_decode_slopefit.sh"
+for caller in "$COMPARE_CALLER" "$SLOPEFIT_CALLER"; do
+  if [ ! -f "$caller" ]; then
+    echo "FATAL: expected caller $caller does not exist — the call-site assertions" >&2
+    echo "  below would vacuously pass against a moved or renamed file." >&2
+    exit 1
+  fi
+done
 SB="$(mktemp -d)"
 trap 'chmod -R u+w "$SB" 2>/dev/null; rm -rf "$SB"' EXIT
 
@@ -72,7 +75,20 @@ else
   echo "  FAIL:   -> existing marker was truncated"; fail=$((fail+1))
 fi
 
-# 4. THE REVIEWED DEFECT (#1089 round 1). A dangling marker symlink is the case
+# 4. Build-tree cleanup removes the marker with the guarded resource. A caller
+#    that reapplies the helper before every build must recreate both.
+D="$SB/recreated/target"
+run "$D"; first_rc=$?
+rm -rf "$D"
+run "$D"; second_rc=$?
+if [ "$first_rc" -eq 0 ] && [ "$second_rc" -eq 0 ]; then
+  echo "  PASS: marker is recreated after target cleanup"; pass=$((pass+1))
+else
+  echo "  FAIL: marker recreation failed (first=$first_rc second=$second_rc)"; fail=$((fail+1))
+fi
+check_marker "  -> recreated marker is a regular file" "$D" file
+
+# 5. THE REVIEWED DEFECT (#1089 round 1). A dangling marker symlink is the case
 #    the fail-open form got wrong: `test -e` is FALSE for a dangling link, the
 #    redirect then followed it to an uncreatable target and failed, and the
 #    trailing `|| true` reported success anyway — so the A/B ran unprotected.
@@ -84,18 +100,18 @@ ln -s "$SB/dangling/no-such-dir/target" "$D/.metadata_never_index"
 run "$D"; check "dangling marker symlink is repaired" 0 $?
 check_marker "  -> replaced by a regular file" "$D" file
 
-# 5. Symlink pointing at an existing file elsewhere: still not a real marker in
+# 6. Symlink pointing at an existing file elsewhere: still not a real marker in
 #    this directory (Spotlight reads the directory), so it is replaced.
 D="$SB/livelink/.cache"; mkdir -p "$D"; : > "$SB/livelink/elsewhere"
 ln -s "$SB/livelink/elsewhere" "$D/.metadata_never_index"
 run "$D"; check "live marker symlink is replaced" 0 $?
 check_marker "  -> replaced by a regular file" "$D" file
 
-# 6. Marker path occupied by a directory: cannot become a file, must not proceed.
+# 7. Marker path occupied by a directory: cannot become a file, must not proceed.
 D="$SB/isdir/.cache"; mkdir -p "$D/.metadata_never_index/occupied"
 run "$D"; check "non-empty dir at marker path fails closed" 1 $?
 
-# 7. FAIL-CLOSED PROOF. An unwritable .cache cannot hold a marker at all, so the
+# 8. FAIL-CLOSED PROOF. An unwritable .cache cannot hold a marker at all, so the
 #    guard must refuse rather than let an unprotected A/B proceed. This is the
 #    case that fails if the trailing `|| true` ever comes back.
 if [ "$(id -u)" -eq 0 ]; then
@@ -111,21 +127,53 @@ else
   chmod u+w "$D"
 fi
 
-# 8. CALL-SITE ASSERTION. Testing the helper in isolation would still pass if
-#    the measurement body stopped calling it, so assert the wiring too.
-if grep -q 'scripts/lib/ensure-noindex-marker.sh' "$CALLER"; then
-  echo "  PASS: the measurement body invokes the guard"; pass=$((pass+1))
+# 9. CALL-SITE ASSERTIONS. Testing the helper in isolation would still pass if
+#    a measurement body stopped calling it, so pin the exact protected trees.
+cache_call="\"\$REPO/scripts/lib/ensure-noindex-marker.sh\" \"\$REPO/.cache\""
+target_call="\"\$REPO/scripts/lib/ensure-noindex-marker.sh\" \"\$REPO/target\""
+
+if grep -qF "$cache_call" "$COMPARE_CALLER"; then
+  echo "  PASS: bench-compare protects its worktree parent"; pass=$((pass+1))
 else
-  echo "  FAIL: the measurement body no longer invokes the guard"; fail=$((fail+1))
+  echo "  FAIL: bench-compare no longer protects its worktree parent"; fail=$((fail+1))
 fi
 
-# 9. The guard must run BEFORE the worktrees it protects are created.
-guard_ln=$(grep -n 'ensure-noindex-marker.sh' "$CALLER" | head -1 | cut -d: -f1)
-wt_ln=$(grep -n 'worktree add' "$CALLER" | head -1 | cut -d: -f1)
-if [ -n "$guard_ln" ] && [ -n "$wt_ln" ] && [ "$guard_ln" -lt "$wt_ln" ]; then
-  echo "  PASS: guard precedes worktree creation (line $guard_ln < $wt_ln)"; pass=$((pass+1))
+if grep -qF "$target_call" "$COMPARE_CALLER"; then
+  echo "  PASS: bench-compare protects its in-place target"; pass=$((pass+1))
 else
-  echo "  FAIL: guard does not precede worktree creation (guard=$guard_ln wt=$wt_ln)"; fail=$((fail+1))
+  echo "  FAIL: bench-compare no longer protects its in-place target"; fail=$((fail+1))
+fi
+
+if grep -qF "$target_call" "$SLOPEFIT_CALLER"; then
+  echo "  PASS: slopefit protects its in-place target"; pass=$((pass+1))
+else
+  echo "  FAIL: slopefit no longer protects its in-place target"; fail=$((fail+1))
+fi
+
+# 10. Each marker must exist before the operation that creates or builds the
+#     protected resource. These ordering checks fail if a call drifts too late.
+cache_guard_ln=$(grep -nF "$cache_call" "$COMPARE_CALLER" | head -1 | cut -d: -f1)
+wt_ln=$(grep -n 'worktree add' "$COMPARE_CALLER" | head -1 | cut -d: -f1)
+if [ -n "$cache_guard_ln" ] && [ -n "$wt_ln" ] && [ "$cache_guard_ln" -lt "$wt_ln" ]; then
+  echo "  PASS: cache guard precedes worktree creation (line $cache_guard_ln < $wt_ln)"; pass=$((pass+1))
+else
+  echo "  FAIL: cache guard does not precede worktree creation (guard=$cache_guard_ln wt=$wt_ln)"; fail=$((fail+1))
+fi
+
+target_guard_ln=$(grep -nF "$target_call" "$COMPARE_CALLER" | head -1 | cut -d: -f1)
+compare_build_ln=$(grep -nE '^[[:space:]]*(if[[:space:]]+)?cargo bench[[:space:]]' "$COMPARE_CALLER" | head -1 | cut -d: -f1)
+if [ -n "$target_guard_ln" ] && [ -n "$compare_build_ln" ] && [ "$target_guard_ln" -lt "$compare_build_ln" ]; then
+  echo "  PASS: target guard precedes bench-compare build (line $target_guard_ln < $compare_build_ln)"; pass=$((pass+1))
+else
+  echo "  FAIL: target guard does not precede bench-compare build (guard=$target_guard_ln build=$compare_build_ln)"; fail=$((fail+1))
+fi
+
+slopefit_guard_ln=$(grep -nF "$target_call" "$SLOPEFIT_CALLER" | head -1 | cut -d: -f1)
+slopefit_build_ln=$(grep -n '^cargo build' "$SLOPEFIT_CALLER" | head -1 | cut -d: -f1)
+if [ -n "$slopefit_guard_ln" ] && [ -n "$slopefit_build_ln" ] && [ "$slopefit_guard_ln" -lt "$slopefit_build_ln" ]; then
+  echo "  PASS: target guard precedes slopefit build (line $slopefit_guard_ln < $slopefit_build_ln)"; pass=$((pass+1))
+else
+  echo "  FAIL: target guard does not precede slopefit build (guard=$slopefit_guard_ln build=$slopefit_build_ln)"; fail=$((fail+1))
 fi
 
 echo "=== $pass passed, $fail failed ==="

--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -264,15 +264,15 @@ HEAD_SHA=$(git -C "$REPO" rev-parse --short --end-of-options "$HEAD_REF" 2>/dev/
 echo "=== bench-compare: $BASE_REF ($BASE_SHA) vs $HEAD_REF ($HEAD_SHA) ==="
 quiet_gate "before base"
 
-# --- Keep Spotlight out of the bench worktrees ---
-# The worktrees created below are full repository checkouts. Indexing them
-# produces filesystem churn that lands asymmetrically in whichever measurement
-# phase it overlaps, and a base-then-head run turns that asymmetry into an
-# apparent code delta. The marker suppresses indexing for the whole directory.
-# Recreated every run so a wiped .cache does not silently lose the protection.
+# --- Keep Spotlight out of the benchmark build trees ---
+# .cache protects the detached base/head worktrees. The separate target marker
+# protects the default in-place HEAD arm: without it the base is excluded while
+# the head build dirties thousands of indexed files immediately before timing.
+# Recreate both every run because deleting either tree deletes its own marker.
 # Inert on non-macOS. Fail-closed: refuse to measure without the protection
 # rather than emit numbers that look trustworthy and are not.
 "$REPO/scripts/lib/ensure-noindex-marker.sh" "$REPO/.cache"
+"$REPO/scripts/lib/ensure-noindex-marker.sh" "$REPO/target"
 
 # --- Worktree for base ref ---
 WT="$REPO/.cache/bench-compare-base"

--- a/scripts/lib/ensure-noindex-marker.sh
+++ b/scripts/lib/ensure-noindex-marker.sh
@@ -4,10 +4,9 @@
 #   scripts/lib/ensure-noindex-marker.sh <dir>
 #
 # Creates <dir>/.metadata_never_index so macOS does not index the directory.
-# bench-compare.sh calls this before creating its base/head worktrees: indexing
-# full repository checkouts produces filesystem churn that lands asymmetrically
-# across the base and head measurement phases, and a base-then-head A/B turns
-# that asymmetry into an apparent code delta.
+# Benchmark entry points call this before creating or building their measurement
+# trees. Indexing the resulting filesystem churn can overlap a timing phase, and
+# a base-then-head A/B turns asymmetric overlap into an apparent code delta.
 #
 # FAIL-CLOSED BY DESIGN. This guards measurement integrity, so it must never
 # report success without the marker actually being in place. A silently absent
@@ -31,8 +30,8 @@ fi
 # Idempotent: an existing regular marker is left untouched, not re-truncated.
 if [ ! -f "$MARKER" ] && ! : > "$MARKER"; then
   echo "[noindex] FATAL: cannot create $MARKER" >&2
-  echo "[noindex] Without it Spotlight indexes this directory. For bench worktrees that" >&2
-  echo "[noindex] churn lands asymmetrically across the base/head phases and reads as a" >&2
+  echo "[noindex] Without it Spotlight indexes this directory. Its build churn can" >&2
+  echo "[noindex] land asymmetrically across timing phases and read as a" >&2
   echo "[noindex] code delta. Refusing to continue rather than measure unprotected." >&2
   exit 1
 fi


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Reapply the fail-closed Spotlight marker to the repository `target/` on every `bench-compare` invocation, making the default in-place HEAD arm symmetric with the `.cache/`-protected base arm.
- Reapply the same marker before every scheduled slopefit build so `cargo clean`, disk-pressure cleanup, and fresh checkouts self-heal before measurement.
- Extend the existing CI self-test to cover target deletion/recreation and the exact guard call sites and ordering for both measurement paths.

## Test plan

- [x] `bash -n scripts/lib/ensure-noindex-marker.sh scripts/lib/bench-compare-impl.sh scripts/bench_decode_slopefit.sh scripts/ensure-noindex-marker-selftest.sh`
- [x] `bash scripts/ensure-noindex-marker-selftest.sh` — 22 passed, 0 failed
- [x] Mutation proof: deleting the new `bench-compare` target guard produced 2 expected self-test failures and exit 1; deleting the slopefit target guard independently produced 2 expected failures and exit 1; both calls were restored and the suite returned green.
- [x] `shellcheck -e SC2001 scripts/lib/bench-compare-impl.sh scripts/lib/ensure-noindex-marker.sh scripts/bench_decode_slopefit.sh scripts/ensure-noindex-marker-selftest.sh`
- [x] `actionlint .github/workflows/ci.yml`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Repository pre-commit hook (format, all-target Clippy, and doc lint)

The exhaustive `cargo test --workspace` run passed the 2,401-test inference library and the subsequent completed binaries/integration suites, then was stopped while one unrelated real-checkpoint Gemma golden remained long-running after 14 minutes. No Rust code changed; the complete behavior gate for this scripts-only change is the mutation-sensitive shell suite above.

## bench-compare disposition

N/A — this changes measurement-harness guard plumbing, not code compiled into either benchmark binary or a timed operation. Running the A/B would measure identical binaries and would not validate the call-site ordering. No benchmark was run; the mutation-sensitive self-test validates the affected behavior directly.

## ADR

n/a — small measurement-integrity fix; no public API or architecture change.

## Out of scope

- Evicting entries already present in Spotlight's index; this fix establishes the marker before future build churn.
- Adding contention sampling or quiescence policy beyond the existing harness checks.
- Marking the nightly workflow's `perf-baselines` worktree: the repository-wide sweep found that checkout is read-only measurement input and nothing is built inside it.

Closes #1092
