### PR TITLE
fix(bench): remove inert label override promise

### DIFF
--- a/docs/adr/ADR-058-cpu-perf-regression-ci.md
+++ b/docs/adr/ADR-058-cpu-perf-regression-ci.md
@@ -112,7 +112,7 @@ For each `(arch, bench, test)` triple, Criterion reports `change.estimates.mean.
 | > +7%                                  | Fail the check, block merge                                                        |
 | Point estimate < −3% AND CI-upper < 0% | Pass with celebratory PR comment ("🚀 confirmed improvement: ...")                 |
 
-PRs may bypass the >7% fail by applying the label `bench-allow-regression`. The PR comment must then quote the rationale (e.g. "intentional: layer_norm two-pass revert for numerical stability, see ADR-058 context"). The label is intentionally awkward to apply — protects against accidental bypass.
+The gate has no per-PR label override. A confirmed regression above 7% remains a hard failure.
 
 **Why 7% on CI-lower-bound**: a naive 7% threshold on the raw point estimate would produce unacceptable flake — shared-runner variance puts the P95 of single-bench point-estimate noise around ±7%, so with ~25 measurements per workflow run the per-PR false-positive rate would approach 70%. Using the _lower bound of Criterion's own 95% CI_ requires the run to be statistically confident the regression is real before it can cross the threshold, which collapses noise-driven flakes back to <2% per PR while preserving 7% sensitivity to genuine kernel slowdowns. If observed false-positive rate is still >5% after the 7-day shadow period (D2/Rollout step 3), tighten the CI-confidence threshold from 95% → 99% rather than weakening the 7% sensitivity.
 
@@ -198,7 +198,7 @@ A `make bench-ci` target builds and runs the exact same matrix locally on the de
 ### Negative
 
 - **2x bench wall time per PR** (build baseline + build current). Mitigation: `Swatinem/rust-cache` for deps; Criterion bench builds themselves are seconds, not minutes.
-- **Noise tolerance is real.** Even with a 10% threshold, ~5% of bench runs may flake-warn. The `bench-allow-regression` label and the warning band (5-10%) give an honest escape valve without weakening the hard gate.
+- **Noise tolerance is real.** Even with a 7% failure threshold, bench runs may warn because of noise. The 3-7% warning band makes that uncertainty visible without weakening the hard gate.
 - **No Apple Silicon coverage in CI.** Metal GPU regressions and M-series-specific NEON behavior remain caught only by local `bench_decode_harness.py` runs on the `apples_precise` profile. This ADR explicitly does not solve the Apple Silicon CI problem — see Alternatives Considered §A3.
 - **Bench shape is now part of the contract.** Renaming a Criterion bench group requires updating `perf-baselines` (it'll appear as a "new bench, no baseline" rather than a regression). Document this in `perf-baselines/README.md`.
 
@@ -261,7 +261,7 @@ A subsequent adversarial statistical review of this design found the confidence-
 path (D3 "Why 7% on CI-lower-bound" and Rollout step 5: on persistent false positives,
 tighten the CI confidence from 95% to 99% "rather than weakening the 7% sensitivity")
 to be backwards. At a fixed threshold, requiring higher confidence widens the margin the
-lower bound must clear before tripping, which *reduces* power against genuine regressions;
+lower bound must clear before tripping, which _reduces_ power against genuine regressions;
 it does not preserve sensitivity. If observed flake is high, the honest levers are more
 samples per run, better runner isolation, or an explicitly raised threshold.
 

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -269,7 +269,7 @@ def render_report(results: list[BenchResult], arch: str,
     lines.append("\n</details>\n")
     lines.append(
         f"_Rule: CI-lower of change ≤{WARN_PCT}% passes silently; "
-        f"({WARN_PCT}%, {FAIL_PCT}%] warns; >{FAIL_PCT}% fails. Override via PR label `bench-allow-regression`._"
+        f"({WARN_PCT}%, {FAIL_PCT}%] warns; >{FAIL_PCT}% fails._"
     )
     if informational_groups:
         lines.append(
@@ -424,6 +424,8 @@ def run_selftest() -> int:
             failures.append("informational-groups: real FAIL missing from rendered report")
         if "ℹ️" not in report or "grp_f/noisy_fail" not in report:
             failures.append("informational-groups: noisy FAIL not shown in informational section")
+        if "bench-allow-regression" in report:
+            failures.append("rendered report advertises an unsupported label override")
 
         # lattice#714 / lattice#1060: the shell-side manifest handoff,
         # exercised end-to-end against the real helper and the real


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

Remove the documented `bench-allow-regression` escape hatch because no label-reading or override path exists and the benchmark gate intentionally fails closed.

The ADR and generated report now state the actual contract: a confirmed regression above 7% is a hard failure. The ADR's stale 10% failure and 5-10% warning thresholds are corrected to the implemented 7% and 3-7% bands.

Closes #1108.

## Defect

ADR-058 and every generated benchmark report told maintainers that applying `bench-allow-regression` would bypass a confirmed regression. The gate never reads labels, so following that documented recovery path had no effect and offered no explanation.

The implementation itself remained fail closed. The defect was the public contract promising an inert bypass.

## Implementation

- remove the unsupported override from ADR-058;
- remove it from the report footer;
- make the no-override, hard-failure behavior explicit;
- align the ADR's consequences section with the implemented 7% failure and 3-7% warning thresholds;
- add a self-test assertion that the generated report cannot advertise the unsupported label again.

## Regression and mutation proof

Production-only mutation: restoring the old footer sentence while leaving the self-test unchanged failed with:

```text
FAIL: rendered report advertises an unsupported label override
SELFTEST: FAIL (1 failure(s))
```

Restoring the corrected footer made the complete gate self-test pass.

## Validation

```text
python3 scripts/perf-bench-gate.py --selftest
SELFTEST: PASS

deno fmt --check docs/adr/ADR-058-cpu-perf-regression-ci.md scripts/perf-bench-gate.py
Checked 1 file

scripts/lint-docs.sh
Doc Lint Passed

cargo fmt --all -- --check
passed

cargo clippy --workspace -- -D warnings
passed

git diff --check
passed
```

## Sibling sweep

- No workflow, action, or script reads `bench-allow-regression`.
- The only remaining occurrence is the self-test's negative assertion.
- The generated-report path and both ADR references now agree with the gate's fail-closed behavior.

## bench-compare disposition

No benchmark was run. This changes benchmark-report wording, ADR text, and a self-test assertion only; it does not change benchmark execution, measurement, thresholds, or product hot paths.
