### PR TITLE
fix(grammar): initialize nullable grammar state

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -34842,6 +34842,166 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             );
         }
 
+        // -----------------------------------------------------------------------
+        // Grammar terminal-at-step-zero integration tests (#1153)
+        //
+        // The all-blocking tests above prove the incomplete/dead-end half of
+        // each post-prefill branch. An epsilon grammar reaches the same
+        // all-NEG_INFINITY mask from an accepting state: no token may extend
+        // the empty document, so that result is a clean Grammar stop rather
+        // than GrammarConstraintBlocked. The fixture asserts both
+        // preconditions before any GPU work so a parser or vocabulary change
+        // cannot make these tests pass through a different branch.
+
+        fn terminal_step_zero_grammar_cfg() -> GenerateConfig {
+            use crate::grammar::{GrammarEngine, GrammarSpec};
+            use std::sync::Arc;
+
+            let engine = Arc::new(
+                GrammarEngine::new(
+                    &GrammarSpec::Gbnf("root ::= \"\"\n".to_string()),
+                    single_char_vocab_bytes(),
+                )
+                .expect("epsilon grammar builds over single-char vocab"),
+            );
+            let mut grammar_state = engine.initial_state();
+            assert!(
+                engine.is_complete_without_continuation(&grammar_state),
+                "epsilon grammar must start complete with no legal continuation"
+            );
+            let mut logits = vec![0.0; 32];
+            engine.mask_logits(&mut grammar_state, &mut logits);
+            assert!(
+                !crate::forward::metal_qwen35::has_finite_logit(&logits),
+                "terminal epsilon grammar must mask every continuation"
+            );
+
+            GenerateConfig {
+                max_new_tokens: 1,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(1),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: Some(engine),
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: None,
+            }
+        }
+
+        fn assert_terminal_step_zero_output(output: &GenerateOutput) {
+            assert_eq!(output.text, "");
+            assert!(output.token_ids.is_empty());
+            assert_eq!(output.generated_tokens, 0);
+            assert!(output.stopped, "terminal grammar is a successful stop");
+            assert_eq!(output.stop_reason, Some(StopReason::Grammar));
+            assert!(output.token_logprobs.is_empty());
+        }
+
+        /// #1153: `generate` must distinguish an initially terminal grammar
+        /// from the incomplete all-blocking grammar covered above.
+        #[test]
+        fn generate_terminal_grammar_at_step_zero_is_success() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+
+            let output = state
+                .generate("a", &tokenizer, &terminal_step_zero_grammar_cfg())
+                .expect("an initially terminal grammar is a successful stop");
+            assert_terminal_step_zero_output(&output);
+        }
+
+        /// #1153: the shared streaming implementation must make the same
+        /// terminal-versus-dead-end distinction without emitting a token.
+        #[test]
+        fn generate_streaming_terminal_grammar_at_step_zero_is_success() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let mut on_token_calls = 0usize;
+
+            let output = state
+                .generate_streaming(
+                    "a",
+                    &tokenizer,
+                    &terminal_step_zero_grammar_cfg(),
+                    |_, _| {
+                        on_token_calls += 1;
+                        true
+                    },
+                )
+                .expect("an initially terminal grammar is a successful streaming stop");
+            assert_terminal_step_zero_output(&output);
+            assert_eq!(
+                on_token_calls, 0,
+                "step-zero completion must stop before any token reaches on_token"
+            );
+        }
+
+        /// #1153: the prefix-cache Metal path must also return a clean
+        /// terminal stop rather than entering its destructive error recovery.
+        #[test]
+        fn generate_streaming_with_prefix_cache_terminal_grammar_at_step_zero_is_success() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut on_token_calls = 0usize;
+
+            let result = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "a",
+                    &tokenizer,
+                    &terminal_step_zero_grammar_cfg(),
+                    |_, _| {
+                        on_token_calls += 1;
+                        true
+                    },
+                )
+                .expect("an initially terminal grammar is a successful cached streaming stop");
+            assert_terminal_step_zero_output(&result.output);
+            assert_eq!(
+                on_token_calls, 0,
+                "step-zero completion must stop before any token reaches on_token"
+            );
+        }
+
         /// `generate_streaming_with_prefix_cache` must reject an empty
         /// prompt with a typed `Err(Inference("empty prompt"))` (#856),
         /// unifying it with all three CPU forward paths instead of the

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -36,7 +36,8 @@
 use crate::grammar::gbnf::parse_gbnf;
 use crate::grammar::json_schema::compile;
 use crate::grammar::pda::{
-    CompiledGrammar, GrammarState, SimResult, StepResult, advance_byte, simulate_token,
+    CompiledGrammar, GrammarState, SimResult, StepResult, advance_byte, initial_grammar_state,
+    simulate_token,
 };
 use crate::grammar::spec::GrammarSpec;
 use crate::grammar::trie::ByteTrie;
@@ -208,7 +209,7 @@ fn enumerate_grammar_states(
     vocab_bytes: &[Vec<u8>],
     max_states: usize,
 ) -> Vec<GrammarState> {
-    let initial = GrammarState::initial();
+    let initial = initial_grammar_state(grammar);
     let mut queue: Vec<GrammarState> = vec![initial.clone()];
     let mut visited: Vec<GrammarState> = vec![initial];
     let mut head = 0;
@@ -365,7 +366,7 @@ impl GrammarEngine {
 
     /// Create the initial `GrammarState` for a new decode sequence.
     pub fn initial_state(&self) -> GrammarState {
-        GrammarState::initial()
+        initial_grammar_state(&self.grammar)
     }
 
     /// Apply grammar constraints to `logits` in-place.
@@ -825,6 +826,44 @@ mod tests {
         let engine = GrammarEngine::new(&spec, vocab).unwrap();
         let state = engine.initial_state();
         assert!(!state.is_complete(), "initial state should not be complete");
+    }
+
+    #[test]
+    fn nullable_initial_state_is_complete_without_continuation() {
+        let vocab = vec![b"a".to_vec()];
+        let spec = GrammarSpec::Gbnf("root ::= \"\"\n".to_string());
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+        let mut state = engine.initial_state();
+
+        assert!(state.is_complete());
+        assert!(engine.is_complete_without_continuation(&state));
+
+        let mut logits = vec![0.0];
+        enable_mask_profiling();
+        engine.mask_logits(&mut state, &mut logits);
+        let profile = take_mask_profile();
+        assert_eq!(logits, vec![f32::NEG_INFINITY]);
+        assert_eq!(profile.precomputed_calls, 1);
+        assert_eq!(profile.fallback_calls, 0);
+    }
+
+    #[test]
+    fn nullable_initial_state_with_continuation_is_not_terminal() {
+        let vocab = vec![b"a".to_vec()];
+        let spec = GrammarSpec::Gbnf("root ::= \"a\"?\n".to_string());
+        let engine = GrammarEngine::new(&spec, vocab).unwrap();
+        let mut state = engine.initial_state();
+
+        assert!(state.is_complete());
+        assert!(!engine.is_complete_without_continuation(&state));
+
+        let mut logits = vec![0.0];
+        enable_mask_profiling();
+        engine.mask_logits(&mut state, &mut logits);
+        let profile = take_mask_profile();
+        assert_eq!(logits, vec![0.0]);
+        assert_eq!(profile.precomputed_calls, 1);
+        assert_eq!(profile.fallback_calls, 0);
     }
 
     #[test]

--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -179,6 +179,12 @@ impl GrammarState {
     }
 }
 
+pub(crate) fn initial_grammar_state(grammar: &CompiledGrammar) -> GrammarState {
+    let mut state = GrammarState::initial();
+    state.complete = is_accepting(&state, grammar);
+    state
+}
+
 // ---------------------------------------------------------------------------
 // PDA execution engine
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- normalize a nullable grammar's initial runtime state as complete when it already accepts the empty input
- use the same normalized initializer while enumerating precomputed grammar masks
- cover step-zero terminal success in all three Metal generation entry points

Closes #1153.

## Defect

The post-prefill branches added in #1087 distinguish a successfully complete grammar from a genuinely blocked constraint, but `GrammarEngine::initial_state()` always returned `complete = false`. A terminal epsilon grammar therefore made all tokens illegal while remaining non-complete, so the supposedly successful step-zero branch was unreachable and returned `GrammarConstraintBlocked`.

The existing tests covered completion and dead ends after consuming a token. They did not exercise the distinct initial-state case.

## Implementation

`initial_grammar_state` now derives the initial `complete` bit from the grammar's accepting-state predicate. Both the runtime engine and its BFS precomputation use that helper, preventing their state identities from disagreeing.

The controls also prove that nullable does not imply terminal: an optional grammar begins complete but still exposes its legal continuation.

## Regression and mutation evidence

- each of the three post-prefill completion checks was independently mutated to make the successful branch unreachable; the corresponding `generate`, streaming, and prefix-cache test then failed with `GrammarConstraintBlocked`
- reverting only `GrammarEngine::initial_state()` to the raw state made both nullable-state tests fail at `state.is_complete()`
- reverting only BFS enumeration to the raw state made both nullable-state tests fail because the precomputed-mask counter remained zero
- after every mutation was reverted, the focused tests and the full grammar suite passed again

## Validation

- `cargo test -p lattice-inference --features metal-gpu --lib grammar -- --nocapture --test-threads=1` — 240 passed, 1 ignored
- the three new Metal terminal-at-step-zero integration tests — 3 passed
- `cargo clippy -p lattice-inference --features metal-gpu --lib -- -D warnings`
- `cargo clippy --workspace -- -D warnings`
- pre-commit formatting, workspace all-target Clippy, and documentation lint

## Sibling-path sweep

- covered `generate`, `generate_streaming`, and `generate_streaming_with_prefix_cache`
- retained the existing post-token terminal and genuine-dead-end coverage in all three entry points
- exercised both the runtime state and precomputed-mask state through one initializer
- added a nullable grammar with a legal continuation as the nonterminal control

## bench-compare disposition

Ran the default quick A/B under the repository's machine-wide benchmark and GPU locks:

```text
make bench-compare BASE=origin/main HEAD=origin/fix/nullable-grammar-initial-state
base 34e369c6d9
head 0ca1a78e72
resolution quick
targets lattice-inference:elementwise_cpu_bench, lattice-embed:simd
filters <all>
ambient CPU idle 97.1% before base, 97.5% between phases, and the after-head probe passed the 70% floor
```

All 17 gated benchmarks remained within the ±3% noise band. The quick run also reported 246 informational embedding measurements; their drift is not attributable to this inference-only grammar-state change, and those targets remain informational by repository policy.
