### PR TITLE
ci: defer macOS parity jobs while a pull request is a draft

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -14,6 +14,13 @@ name: e2e-parity
 on:
   pull_request:
     branches: [main]
+    # `ready_for_review` is NOT in the default type set, and it is load-bearing
+    # here: the macOS jobs below skip while a PR is a draft, so the flip out of
+    # draft is the only event that can run them. Without this type the flip
+    # fires nothing, the gate never re-reports, and the PR wedges. The other
+    # three are the defaults, restated because naming `types` at all replaces
+    # them.
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
     paths:
@@ -102,10 +109,26 @@ jobs:
             echo "→ no tune training change: layer-23 golden not required"
           fi
 
+  # The macOS jobs from here down carry `github.event.pull_request.draft != true`.
+  # The macOS runner pool is ~5 concurrent account-wide and these are the long
+  # jobs (model fetch, HF reference run, then lattice), so a draft under active
+  # iteration otherwise occupies the same pool that ready-to-merge PRs queue on.
+  #
+  # `!= true` rather than `== false` is deliberate: on merge_group, schedule,
+  # workflow_dispatch and push there is no `pull_request` object at all, so the
+  # expression resolves to null. `null != true` runs the job, which is the arm
+  # that must not be skipped; `null == false` would be false and would silently
+  # disable these gates everywhere except pull requests.
+  #
+  # This is not a loosened gate. parity-gate below requires each arm to be
+  # literally "success", so a skipped job fails it — a draft therefore shows an
+  # honest red gate meaning "parity unverified", never a green one. The gate can
+  # only go green after the ready flip actually runs these jobs, which is what
+  # the `ready_for_review` trigger above exists to guarantee.
   layer23-golden:
     name: layer-23 golden bridge
     needs: changes
-    if: needs.changes.outputs.tune == 'true'
+    if: needs.changes.outputs.tune == 'true' && github.event.pull_request.draft != true
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -171,7 +194,7 @@ jobs:
   parity:
     name: e2e parity
     needs: changes
-    if: needs.changes.outputs.engine == 'true'
+    if: needs.changes.outputs.engine == 'true' && github.event.pull_request.draft != true
     runs-on: macos-latest
     # 25 min, not 15: typical runtime is ~12.5 min but shared-runner speed
     # variance exceeds the old ~17% headroom — two consecutive timeout
@@ -297,7 +320,7 @@ jobs:
   metal-parity:
     name: metal parity ratchet (#535 waived)
     needs: changes
-    if: (needs.changes.outputs.engine == 'true' && github.event_name != 'merge_group') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: (needs.changes.outputs.engine == 'true' && github.event_name != 'merge_group' && github.event.pull_request.draft != true) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: macos-latest
     timeout-minutes: 25
     steps:
@@ -618,7 +641,7 @@ jobs:
   q4-composed:
     name: q4 composed golden
     needs: changes
-    if: needs.changes.outputs.engine == 'true'
+    if: needs.changes.outputs.engine == 'true' && github.event.pull_request.draft != true
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -721,7 +744,7 @@ jobs:
   vision-s3-gate:
     name: vision S3a+S4 cosine gate
     needs: changes
-    if: needs.changes.outputs.engine == 'true'
+    if: needs.changes.outputs.engine == 'true' && github.event.pull_request.draft != true
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
@@ -881,7 +904,7 @@ jobs:
   q4-ppl-quality:
     name: q4 ppl regression gate
     needs: changes
-    if: needs.changes.outputs.engine == 'true'
+    if: needs.changes.outputs.engine == 'true' && github.event.pull_request.draft != true
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -1019,9 +1042,23 @@ jobs:
           METAL_RESULT="${{ needs.metal-parity.result }}"
           LAYER23_RESULT="${{ needs.layer23-golden.result }}"
           EVENT_NAME="${{ github.event_name }}"
+          # Empty on every non-pull_request event, which is what we want: the
+          # draft branch below must never fire on merge_group, push, schedule,
+          # or workflow_dispatch.
+          DRAFT="${{ github.event.pull_request.draft }}"
           echo "changes=$CHANGES_RESULT engine=$ENGINE tune=$TUNE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT wasm-simd128-parity=$WASM_SIMD128_RESULT q4-composed=$Q4_RESULT vision-s3-gate=$VISION_S3_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT q4-ppl-quality=$Q4PPL_RESULT metal-parity=$METAL_RESULT layer23-golden=$LAYER23_RESULT event=$EVENT_NAME"
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::change-detection did not succeed — failing closed."
+            exit 1
+          fi
+          # Drafts skip the macOS parity jobs to keep the ~5-concurrent runner
+          # pool available to PRs that are ready to merge. Those skips reach the
+          # arm checks below as result=skipped, which is correctly not "success",
+          # so this gate would fail anyway. It short-circuits here only so the
+          # failure explains itself instead of reading as a parity regression.
+          # This stays a FAILURE on purpose: a green gate has to mean parity ran.
+          if [ "$DRAFT" = "true" ] && { [ "$ENGINE" = "true" ] || [ "$TUNE" = "true" ]; }; then
+            echo "::error::Draft PR: macOS parity jobs are deferred while this PR is a draft, so parity is UNVERIFIED and this gate fails by design. Mark the PR ready for review and these jobs run automatically on the ready_for_review event."
             exit 1
           fi
           if [ "$TUNE" = "true" ] && [ "$LAYER23_RESULT" != "success" ]; then


### PR DESCRIPTION
## What

Draft pull requests no longer run the six macOS jobs in `e2e-parity.yml`, and `ready_for_review` is added to the `pull_request` trigger types so the flip out of draft runs them.

## Why

The macOS runner pool is roughly five concurrent, account-wide, and these are the long jobs: model fetch, reference run, then lattice. Drafts under active iteration currently hold that pool on every push, queued ahead of pull requests that are ready to merge.

## Both halves are required

`ready_for_review` is not in the default trigger type set (`opened`, `synchronize`, `reopened`). Adding the draft skip without it would mean the ready flip fires nothing, the gate never re-reports, and the pull request wedges. The other three types are restated because naming `types` at all replaces the defaults rather than extending them.

## Why `!= true` and not `== false`

`merge_group`, `push`, `schedule` and `workflow_dispatch` carry no `pull_request` object, so `github.event.pull_request.draft` resolves to null on those events. `null != true` keeps the jobs running, which is the arm that must not be skipped. `null == false` would be false and would silently disable these gates everywhere except pull requests.

## This does not weaken the gate

`parity-gate` requires each arm to be literally `"success"`, so a skipped job fails it. A draft therefore reports a red gate meaning parity is unverified, never a green one, and the gate can only go green after the ready flip actually runs the jobs. `parity-gate` short-circuits on the draft case solely so that failure explains itself instead of reading as a parity regression.

Expect open drafts to show a red `parity-gate` after this lands. That is the intended and accurate state.

## Verification

- YAML parses; all six macOS jobs carry the draft condition; no Ubuntu job was gated; `ready_for_review` present.
- The checker was re-run against a deliberately un-gated job to confirm it reports the defect rather than passing silently.
- `actionlint` clean.

## Bench-compare disposition

Not applicable: no file under `crates/inference/` or `crates/embed/` is touched. The diff is confined to `.github/workflows/e2e-parity.yml`.