### PR TITLE
test(inference): resize cross-turn chat fixture

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -33118,27 +33118,36 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             };
             let _gpu_guard = gpu_test_lock();
 
+            const LEGACY_FIXTURE_CONTEXT: usize = 128;
+            const CHAT_FIXTURE_CONTEXT: usize = 192;
+
             let tokenizer = single_char_vocab_tokenizer();
             let (mut cfg, weights) = tiny_hybrid_fixture();
             // Keep EOS unreachable so every turn generates its full budget,
             // guaranteeing the history keeps growing turn over turn (mirrors the
             // raw-prompt sibling test above).
             cfg.eos_token_id = u32::MAX;
+            cfg.max_position_embeddings = CHAT_FIXTURE_CONTEXT;
 
             let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
-            // max_cache_len=128 = this fixture's max_position_embeddings ceiling;
-            // four short turns of ChatML-formatted history (role words + content)
-            // stay well under it (~70 tokens at the last turn).
-            let mut cached_state =
-                MetalQwen35State::new(&weights, &cfg, 128).expect("tiny hybrid fixture");
+            let mut cached_state = MetalQwen35State::new(&weights, &cfg, CHAT_FIXTURE_CONTEXT)
+                .expect("tiny hybrid fixture");
 
             let user_turns = ["a", "bc", "d", "ef"];
             let mut history: Vec<ChatMessage> = vec![ChatMessage::system("")];
             let mut saw_exact_append = false;
+            let mut prompt_lengths = Vec::with_capacity(user_turns.len());
 
             for (turn_idx, user_text) in user_turns.iter().enumerate() {
                 history.push(ChatMessage::user(*user_text));
                 let gen_cfg = cross_turn_test_gen_cfg(42, 2);
+                let rendered_prompt = format_chat_template(&history);
+                let prompt_len = tokenizer.tokenize(&rendered_prompt).real_length;
+                prompt_lengths.push(prompt_len);
+                assert!(
+                    prompt_len + gen_cfg.max_new_tokens <= CHAT_FIXTURE_CONTEXT,
+                    "turn {turn_idx}: fixture context must cover the rendered prompt and decode cap"
+                );
 
                 let cached_out = cached_state
                     .chat_completion_streaming_with_prefix_cache(
@@ -33155,7 +33164,8 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 // history — exactly chat_metal's pre-#462 behavior (reset_state +
                 // full re-prefill of the whole ChatML-formatted history every turn).
                 let mut reference_state =
-                    MetalQwen35State::new(&weights, &cfg, 128).expect("tiny hybrid fixture");
+                    MetalQwen35State::new(&weights, &cfg, CHAT_FIXTURE_CONTEXT)
+                        .expect("tiny hybrid fixture");
                 let reference_gen_cfg = cross_turn_test_gen_cfg(42, 2);
                 let reference_out = reference_state
                     .chat_completion_streaming(
@@ -33196,6 +33206,18 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 history.push(cached_out.output.message.clone());
             }
 
+            assert_eq!(
+                prompt_lengths,
+                [51, 92, 132, 173],
+                "record the four-turn ChatML footprint so template growth cannot silently \
+                 invalidate this cache-parity fixture"
+            );
+            assert!(
+                prompt_lengths
+                    .iter()
+                    .any(|&len| len + 2 > LEGACY_FIXTURE_CONTEXT),
+                "the fixture must exercise history beyond the obsolete 128-token window"
+            );
             assert!(
                 saw_exact_append,
                 "at least one later turn must actually exercise ExactAppend reuse through the \


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- resize the four-turn ChatML cache-parity fixture from 128 to 192 tokens
- record the rendered prompt footprint for every turn
- fail at the fixture boundary before a future template change can invalidate the GPU assertion

Closes #1076.

## Root cause

The production context-budget check is correct. The stale test fixture was exposed when #940 added that check to the Metal entry points:

| Revision | Result |
|---|---|
| `709d1098b4` (parent of #940) | passes |
| `604f911964` (#940) | fails at 132 prompt tokens plus a 2-token decode cap against the 128-token fixture |
| current `main` | fails with the same admission error |

The single-character test tokenizer renders the four prompts at 51, 92, 132, and 173 tokens. The old “about 70 tokens” estimate therefore stopped describing the test before the correct admission guard made the mismatch visible.

## Regression coverage

The test now sets both `max_position_embeddings` and the two Metal states to a 192-token fixture context. Before each generation it renders and tokenizes the actual history, then asserts that prompt plus decode cap fits that context.

It also asserts the complete `[51, 92, 132, 173]` footprint and proves that at least one turn exceeds the obsolete 128-token window. This retains the intended four-turn exact-append coverage instead of shortening the conversation until it happens to pass.

Mutation check: changing only `CHAT_FIXTURE_CONTEXT` back to 128 makes the test fail on the third request with:

```text
turn 2: fixture context must cover the rendered prompt and decode cap
```

Restoring 192 returns the test and its sibling sweep to green.

## Validation

- targeted failing test on current `main` — reproduced the 132 + 2 > 128 admission error
- targeted test at `709d1098b4` — passed
- targeted test at `604f911964` — reproduced the first failing revision
- `cross_turn_cache_` Metal test sweep — 16 passed
- `cargo clippy -p lattice-inference --features metal-gpu --lib -- -D warnings`
- pre-commit formatting, workspace all-target Clippy, and documentation lint

## Sibling-path sweep

All 16 `cross_turn_cache_` tests passed, covering raw-prompt parity, ChatML parity, mismatch fallback, slot isolation, explicit clearing, LoRA/GDN invalidation, interleaving, and cancellation. Only the ChatML wrapper accumulates enough rendered framing to require the larger fixture; the raw-prompt siblings retain their smaller purpose-built windows.

## bench-compare disposition

Not run. The diff changes only code inside the Metal `#[cfg(test)]` module; production libraries and benchmark binaries cannot compile or execute this fixture. There is no timed path to compare.
