### PR TITLE
perf(embed): avoid duplicate cached validation

### DIFF
--- a/crates/embed/benches/simd.rs
+++ b/crates/embed/benches/simd.rs
@@ -6,6 +6,8 @@
 //! scalar fallbacks to measure the speedup.
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use lattice_embed::EmbeddingModel;
+use lattice_embed::service::{CachedEmbeddingService, EmbeddingService, NativeEmbeddingService};
 use lattice_embed::simd::{
     self, BinaryVector, Int4Vector, NormalizationHint, PreparedQuery, PreparedQueryWithMeta,
     QuantizationTier, QuantizedData, QuantizedVector, SimdConfig, approximate_cosine_distance,
@@ -15,6 +17,7 @@ use lattice_embed::simd::{
 };
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
 /// Embedding dimensions to test.
 const DIMENSIONS: [usize; 4] = [384, 768, 1024, 1536];
@@ -35,6 +38,32 @@ fn generate_normalized_vector(dim: usize, seed: u64) -> Vec<f32> {
     let mut v = generate_vector(dim, seed);
     simd::normalize(&mut v);
     v
+}
+
+fn bench_cached_embedding_delegation(c: &mut Criterion) {
+    const BATCH_SIZE: usize = 64;
+    const TEXT_BYTES: usize = 4096;
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("benchmark runtime");
+    let service = CachedEmbeddingService::new(Arc::new(NativeEmbeddingService::default()), 0);
+    let texts = vec!["x".repeat(TEXT_BYTES); BATCH_SIZE];
+    let wrong_model = EmbeddingModel::BgeBaseEnV15;
+
+    let mut group = c.benchmark_group("cached_embedding_delegate");
+    group.throughput(Throughput::Bytes((BATCH_SIZE * TEXT_BYTES) as u64));
+    group.bench_function("native_wrong_model_disabled_64x4096", |bench| {
+        bench.to_async(&runtime).iter(|| async {
+            black_box(
+                service
+                    .embed(black_box(&texts), wrong_model)
+                    .await
+                    .expect_err("wrong model must fail before model loading"),
+            )
+        });
+    });
+    group.finish();
 }
 
 // ============================================================================
@@ -1222,6 +1251,7 @@ criterion_group!(
     bench_batch_cosine_normalized_query,
     bench_batch_cosine_non_normalized_query,
     bench_prepared_batch_sizes,
+    bench_cached_embedding_delegation,
 );
 
 criterion_main!(simd_benches);

--- a/crates/embed/docs/service.md
+++ b/crates/embed/docs/service.md
@@ -93,9 +93,11 @@ solely because their raw input happens to match.
 
 ## Request validation
 
-The cache wrapper validates empty batches, batch size, and text length before any lookup. The
-native service enforces those same limits when it is called and additionally verifies that the
-requested model matches its configured model:
+The cache wrapper validates empty batches, batch size, and text length before any lookup. A direct
+native-service call enforces those same limits and additionally verifies that the requested model
+matches its configured model. When the wrapper delegates, an opaque internal capability proves the
+caller bounds were already checked; the native service skips only that identical scan and retains
+its configured-model check and prepared-text memory backstop.
 
 | Rule                                                                                                        | Failure                    |
 | ----------------------------------------------------------------------------------------------------------- | -------------------------- |
@@ -105,9 +107,10 @@ requested model matches its configured model:
 | Native request model must equal that service's configured model                                             | `EmbedError::InvalidInput` |
 
 `String::len()` measures UTF-8 bytes, so the present implementation can reject fewer than
-32,768 non-ASCII characters. Prefixes are applied before validation in role-specific calls, so
-the prefix bytes count too. A caller that needs a character-based product limit should enforce
-that separately before calling the service.
+32,768 non-ASCII characters. Role-specific calls validate caller text before adding an instruction.
+The prepared-text backstop admits the caller allowance plus the model's longest instruction, so
+service-added prefix bytes do not reduce the published caller limit. A caller that needs a
+character-based product limit should enforce that separately before calling the service.
 
 The wrapper performs its own three request-bound checks even for an all-hit request. It does
 not call `inner.embed` merely to validate a cache hit, so an inner service's model-specific
@@ -217,15 +220,18 @@ For every generic, query, or passage request, the wrapper does the following:
 2. Validate only the wrapper-owned empty-batch, batch-size, and text-length bounds, against the
    caller's text, before lookup. Checking caller text keeps the published cap describing what the
    caller passed rather than what the instruction adds.
-3. If capacity is zero, bypass hash computation and locks and delegate the caller text to the
-   inner service through `embed_with_role`, which applies the instruction for the role.
+3. If capacity is zero, bypass hash computation and locks and delegate the validated caller text
+   through the internal prevalidated role hook. Built-in services consume its validation proof
+   directly; the compatibility default reaches an unknown service's existing public role override.
 4. Ask the inner service for the effective `ModelConfig`, then hash each caller text with the
    model identifier, its key revision, active dimension, and role tag.
 5. Look up all keys in the sharded LRU. Hits are returned from cache storage as shared slices and
-   copied into the caller-owned result vectors; misses are remembered with their original input
-   positions.
-6. If misses exist, send only those caller texts to the inner service through `embed_with_role`.
-   It must return exactly one vector for each miss. A count mismatch becomes
+   copied into the caller-owned result vectors; misses are remembered by original input position.
+6. If misses exist, send borrowed views of only those already-validated caller texts through the
+   internal prevalidated role hook. Native and nested cache services consume those views directly,
+   avoiding a cloned `Vec<String>` for delegation. The compatibility default materializes raw text
+   once before calling an unknown service's public role override. The inner service must return
+   exactly one vector for each miss. A count mismatch becomes
    `EmbedError::InferenceFailed` rather than allowing a `zip` operation to drop positions silently.
 7. Insert new vectors, fill the missing result positions, and return every vector in the order
    supplied by the caller.
@@ -283,6 +289,16 @@ documented limit. `embed_query` and `embed_passage` are thin wrappers that call 
 with the `Query` or `Passage` role, so all three role paths share one ordering decision instead of
 repeating it.
 
+`embed_with_role_prevalidated` is a hidden implementation hook used only by compositional wrappers.
+Its `ValidatedTextBatch` argument has no public constructor, so an external caller cannot use the
+hook to bypass the stable methods' request bounds. The default hook keeps external implementors
+behaviorally compatible by calling their existing `embed_with_role` override; for a sparse miss
+batch it first materializes the raw texts required by that public slice type. Such an unknown
+implementation may repeat caller-bound validation. The native service overrides the hook to
+consume borrowed text views directly when no instruction is required. A nested
+`CachedEmbeddingService` also overrides it, preserving one caller-bound validation across
+arbitrarily composed cache wrappers.
+
 That default cannot preserve the caller-text cap for an external implementation that enforces the
 exact cap inside its own `embed`: the prepared string reaches that `embed` already lengthened.
 Keeping `embed` the sole abstract method is a backward-compatibility choice on a published crate;
@@ -327,7 +343,10 @@ service. A full hit returns immediately and never invokes the inner service.
 
 Consequently, the wrapper cannot enforce an inner service's model selection, authorization, or
 other service-specific validation on a full hit. With at least one miss it delegates only the
-misses through `inner.embed_with_role`; the wrapped service applies the role instruction and
-performs its configured-model check before loading or encoding them. The wrapper rejects a
+misses through the prevalidated role hook; the wrapped service applies the role instruction and
+performs service-specific checks, such as the native configured-model check, before loading or
+encoding them. Native and nested cache services do not repeat the caller-bound validation the
+wrapper already completed. An unknown implementation reaches its existing public role method
+instead, preserving custom behavior even when that method repeats validation. The wrapper rejects a
 mismatched number of returned vectors before insertion, which prevents a partial `zip` from losing
 original result positions.

--- a/crates/embed/src/service/cached.rs
+++ b/crates/embed/src/service/cached.rs
@@ -3,7 +3,7 @@
 //! It preserves caller order across partial cache hits and uses role-aware keys for asymmetric
 //! retrieval. See `docs/service.md` for the lookup and fill algorithm.
 
-use super::{EmbeddingRole, EmbeddingService};
+use super::{EmbeddingRole, EmbeddingService, ValidatedTextBatch};
 use crate::error::Result;
 use crate::model::EmbeddingModel;
 use async_trait::async_trait;
@@ -58,6 +58,7 @@ impl<S: EmbeddingService> CachedEmbeddingService<S> {
 impl<S: EmbeddingService + 'static> EmbeddingService for CachedEmbeddingService<S> {
     async fn embed(&self, texts: &[String], model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
         // Generic has its own role tag — see docs/service.md.
+        let texts = ValidatedTextBatch::new(texts)?;
         self.cache_and_embed(texts, model, EmbeddingRole::Generic)
             .await
     }
@@ -69,6 +70,16 @@ impl<S: EmbeddingService + 'static> EmbeddingService for CachedEmbeddingService<
     async fn embed_with_role(
         &self,
         texts: &[String],
+        model: EmbeddingModel,
+        role: EmbeddingRole,
+    ) -> Result<Vec<Vec<f32>>> {
+        let texts = ValidatedTextBatch::new(texts)?;
+        self.cache_and_embed(texts, model, role).await
+    }
+
+    async fn embed_with_role_prevalidated(
+        &self,
+        texts: ValidatedTextBatch<'_>,
         model: EmbeddingModel,
         role: EmbeddingRole,
     ) -> Result<Vec<Vec<f32>>> {
@@ -96,38 +107,37 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
     /// in the key.
     async fn cache_and_embed(
         &self,
-        texts: &[String],
+        texts: ValidatedTextBatch<'_>,
         model: EmbeddingModel,
         role: EmbeddingRole,
     ) -> Result<Vec<Vec<f32>>> {
         use crate::error::EmbedError;
 
-        // Validate wrapper-owned request bounds before cache interaction.
-        super::validate_texts(texts)?;
-
         // Fast path: bypass cache entirely when disabled (no key computation, no locking)
         if !self.cache.is_enabled() {
-            return self.inner.embed_with_role(texts, model, role).await;
+            return self
+                .inner
+                .embed_with_role_prevalidated(texts, model, role)
+                .await;
         }
 
         // Compute cache keys — include the active dimension (for MRL models) and role.
         let model_config = self.inner.model_config(model);
-        let keys: Vec<_> = texts
-            .iter()
-            .map(|t| self.cache.compute_key(t, model_config, role))
+        let keys: Vec<_> = (0..texts.len())
+            .map(|index| self.cache.compute_key(texts.get(index), model_config, role))
             .collect();
 
         // Check cache for all texts — returns Arc<[f32]> refs (O(1) per hit)
         let cached = self.cache.get_many(&keys);
 
-        let mut to_embed: Vec<(usize, &String)> = Vec::new();
+        let mut to_embed = Vec::new();
         let mut results: Vec<Option<Vec<f32>>> = vec![None; texts.len()];
 
-        for (i, (text, cached_emb)) in texts.iter().zip(cached.into_iter()).enumerate() {
+        for (i, cached_emb) in cached.into_iter().enumerate() {
             if let Some(arc) = cached_emb {
                 results[i] = Some(arc.to_vec());
             } else {
-                to_embed.push((i, text));
+                to_embed.push(i);
             }
         }
 
@@ -146,10 +156,10 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
         );
 
         // Embed missing texts; the wrapped service applies the role instruction.
-        let texts_to_embed: Vec<String> = to_embed.iter().map(|(_, t)| (*t).clone()).collect();
+        let texts_to_embed: Vec<&str> = to_embed.iter().map(|&index| texts.get(index)).collect();
         let new_embeddings = self
             .inner
-            .embed_with_role(&texts_to_embed, model, role)
+            .embed_with_role_prevalidated(texts.borrowed_subset(&texts_to_embed), model, role)
             .await?;
 
         // FP-035: validate count before zipping — a count mismatch would silently
@@ -163,7 +173,7 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
         }
 
         let mut cache_entries = Vec::with_capacity(to_embed.len());
-        for ((i, _), embedding) in to_embed.into_iter().zip(new_embeddings.into_iter()) {
+        for (i, embedding) in to_embed.into_iter().zip(new_embeddings.into_iter()) {
             cache_entries.push((keys[i], embedding.clone()));
             results[i] = Some(embedding);
         }
@@ -173,5 +183,259 @@ impl<S: EmbeddingService + 'static> CachedEmbeddingService<S> {
         // - Cached items were assigned via results[i] = Some(arc.to_vec())
         // - Non-cached items were assigned via results[i] = Some(embedding) in the loop above
         Ok(results.into_iter().flatten().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::EmbedError;
+    use crate::service::{
+        MAX_TEXT_BYTES, NativeEmbeddingService, reset_validate_texts_calls, validate_texts_calls,
+    };
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct ProbeService {
+        calls: AtomicUsize,
+        requests: Mutex<Vec<Vec<String>>>,
+        fail: bool,
+    }
+
+    impl ProbeService {
+        fn failing() -> Self {
+            Self {
+                fail: true,
+                ..Self::default()
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+
+        fn requests(&self) -> Vec<Vec<String>> {
+            self.requests.lock().unwrap().clone()
+        }
+
+        fn record(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.requests.lock().unwrap().push(texts.to_vec());
+            if self.fail {
+                return Err(EmbedError::InferenceFailed("probe failure".into()));
+            }
+            Ok(texts.iter().map(|text| vec![text.len() as f32]).collect())
+        }
+    }
+
+    #[async_trait]
+    impl EmbeddingService for ProbeService {
+        async fn embed(&self, texts: &[String], _model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
+            self.record(texts)
+        }
+
+        async fn embed_with_role_prevalidated(
+            &self,
+            texts: ValidatedTextBatch<'_>,
+            model: EmbeddingModel,
+            role: EmbeddingRole,
+        ) -> Result<Vec<Vec<f32>>> {
+            let prepared = texts.to_owned_with_prefix(role.instruction(model));
+            self.record(&prepared)
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "cache-probe"
+        }
+    }
+
+    #[derive(Default)]
+    struct BorrowProbe {
+        saw_borrowed: AtomicBool,
+    }
+
+    #[async_trait]
+    impl EmbeddingService for BorrowProbe {
+        async fn embed(&self, _texts: &[String], _model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
+            panic!("cache delegation must use the prevalidated hook")
+        }
+
+        async fn embed_with_role_prevalidated(
+            &self,
+            texts: ValidatedTextBatch<'_>,
+            _model: EmbeddingModel,
+            _role: EmbeddingRole,
+        ) -> Result<Vec<Vec<f32>>> {
+            self.saw_borrowed
+                .store(texts.borrowed().is_some(), Ordering::Relaxed);
+            Ok((0..texts.len())
+                .map(|index| vec![texts.get(index).len() as f32])
+                .collect())
+        }
+
+        fn supports_model(&self, _model: EmbeddingModel) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            "borrow-probe"
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn disabled_delegate_validates_once_and_preserves_role_preparation() {
+        let inner = Arc::new(ProbeService::default());
+        let service = CachedEmbeddingService::new(inner.clone(), 0);
+        let texts = vec!["hello".to_string()];
+        let model = EmbeddingModel::BgeSmallEnV15;
+
+        reset_validate_texts_calls();
+        let result = service.embed_query(&texts, model).await.unwrap();
+
+        assert_eq!(validate_texts_calls(), 1);
+        assert_eq!(inner.calls(), 1);
+        let requests = inner.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0][0],
+            format!("{}hello", model.query_instruction().unwrap())
+        );
+        assert_eq!(result, vec![vec![requests[0][0].len() as f32]]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn miss_validates_once_and_delegates_only_uncached_texts() {
+        let inner = Arc::new(ProbeService::default());
+        let service = CachedEmbeddingService::new(inner.clone(), 128);
+        let model = EmbeddingModel::AllMiniLmL6V2;
+
+        reset_validate_texts_calls();
+        service.embed(&["cached".to_string()], model).await.unwrap();
+        assert_eq!(validate_texts_calls(), 1);
+
+        let calls_before = inner.calls();
+        reset_validate_texts_calls();
+        let result = service
+            .embed(&["cached".to_string(), "missing".to_string()], model)
+            .await
+            .unwrap();
+
+        assert_eq!(validate_texts_calls(), 1);
+        assert_eq!(inner.calls(), calls_before + 1);
+        assert_eq!(
+            inner.requests().last().unwrap(),
+            &vec!["missing".to_string()]
+        );
+        assert_eq!(result, vec![vec![6.0], vec![7.0]]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn miss_delegates_borrowed_text_views_after_one_validation() {
+        let inner = Arc::new(BorrowProbe::default());
+        let service = CachedEmbeddingService::new(inner.clone(), 128);
+
+        reset_validate_texts_calls();
+        let result = service
+            .embed(&["uncached".to_string()], EmbeddingModel::AllMiniLmL6V2)
+            .await
+            .unwrap();
+
+        assert_eq!(validate_texts_calls(), 1);
+        assert!(inner.saw_borrowed.load(Ordering::Relaxed));
+        assert_eq!(result, vec![vec![8.0]]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn all_hit_validates_once_without_delegating() {
+        let inner = Arc::new(ProbeService::default());
+        let service = CachedEmbeddingService::new(inner.clone(), 128);
+        let texts = vec!["cached".to_string()];
+        let model = EmbeddingModel::AllMiniLmL6V2;
+
+        service.embed(&texts, model).await.unwrap();
+        let calls_before = inner.calls();
+
+        reset_validate_texts_calls();
+        let result = service.embed(&texts, model).await.unwrap();
+
+        assert_eq!(validate_texts_calls(), 1);
+        assert_eq!(inner.calls(), calls_before);
+        assert_eq!(result, vec![vec![6.0]]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn invalid_input_validates_once_without_delegating() {
+        let inner = Arc::new(ProbeService::default());
+        let service = CachedEmbeddingService::new(inner.clone(), 128);
+        let texts = vec!["x".repeat(MAX_TEXT_BYTES + 1)];
+
+        reset_validate_texts_calls();
+        let error = service
+            .embed(&texts, EmbeddingModel::AllMiniLmL6V2)
+            .await
+            .unwrap_err();
+
+        assert_eq!(validate_texts_calls(), 1);
+        assert!(matches!(
+            error,
+            EmbedError::TextTooLong {
+                max: MAX_TEXT_BYTES,
+                ..
+            }
+        ));
+        assert_eq!(inner.calls(), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn delegate_error_still_validates_once() {
+        let inner = Arc::new(ProbeService::failing());
+        let service = CachedEmbeddingService::new(inner.clone(), 0);
+
+        reset_validate_texts_calls();
+        let error = service
+            .embed(&["valid".to_string()], EmbeddingModel::AllMiniLmL6V2)
+            .await
+            .unwrap_err();
+
+        assert_eq!(validate_texts_calls(), 1);
+        assert_eq!(inner.calls(), 1);
+        assert!(matches!(error, EmbedError::InferenceFailed(_)));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn nested_cache_delegate_preserves_single_validation() {
+        let probe = Arc::new(ProbeService::default());
+        let inner = Arc::new(CachedEmbeddingService::new(probe.clone(), 0));
+        let service = CachedEmbeddingService::new(inner, 0);
+
+        reset_validate_texts_calls();
+        let result = service
+            .embed_passage(&["nested".to_string()], EmbeddingModel::AllMiniLmL6V2)
+            .await
+            .unwrap();
+
+        assert_eq!(validate_texts_calls(), 1);
+        assert_eq!(probe.calls(), 1);
+        assert_eq!(result, vec![vec![6.0]]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn native_delegate_preserves_model_validation_without_rescanning_caller_text() {
+        let inner = Arc::new(NativeEmbeddingService::default());
+        let service = CachedEmbeddingService::new(inner, 0);
+
+        reset_validate_texts_calls();
+        let error = service
+            .embed(&["valid".to_string()], EmbeddingModel::BgeBaseEnV15)
+            .await
+            .unwrap_err();
+
+        assert_eq!(validate_texts_calls(), 1);
+        assert!(matches!(error, EmbedError::InvalidInput(_)));
     }
 }

--- a/crates/embed/src/service/mod.rs
+++ b/crates/embed/src/service/mod.rs
@@ -16,6 +16,11 @@ use crate::error::{EmbedError, Result};
 use crate::model::{EmbeddingModel, ModelConfig};
 use async_trait::async_trait;
 
+#[cfg(test)]
+std::thread_local! {
+    static VALIDATE_TEXTS_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 // Re-exports
 #[cfg(feature = "native")]
 pub use cached::CachedEmbeddingService;
@@ -88,7 +93,19 @@ impl EmbeddingRole {
 /// preparation are memory backstops and size themselves with
 /// [`EmbeddingModel::max_instruction_bytes`]; they are not this check.
 pub(crate) fn validate_texts(texts: &[String]) -> Result<()> {
+    #[cfg(test)]
+    VALIDATE_TEXTS_CALLS.set(VALIDATE_TEXTS_CALLS.get() + 1);
     validate_texts_bounded(texts, MAX_TEXT_BYTES)
+}
+
+#[cfg(test)]
+pub(crate) fn reset_validate_texts_calls() {
+    VALIDATE_TEXTS_CALLS.set(0);
+}
+
+#[cfg(test)]
+pub(crate) fn validate_texts_calls() -> usize {
+    VALIDATE_TEXTS_CALLS.get()
 }
 
 /// Shared body of the caller-text contract check and the prepared-text backstop.
@@ -97,7 +114,7 @@ pub(crate) fn validate_texts(texts: &[String]) -> Result<()> {
 /// model's longest instruction on text that has already been prepared. The
 /// reported `max` is `max_bytes` so an error names the bound that actually
 /// rejected the input rather than a constant the caller cannot relate to.
-pub(crate) fn validate_texts_bounded(texts: &[String], max_bytes: usize) -> Result<()> {
+pub(crate) fn validate_texts_bounded<T: AsRef<str>>(texts: &[T], max_bytes: usize) -> Result<()> {
     if texts.is_empty() {
         return Err(EmbedError::InvalidInput("no texts provided".into()));
     }
@@ -109,6 +126,7 @@ pub(crate) fn validate_texts_bounded(texts: &[String], max_bytes: usize) -> Resu
         )));
     }
     for text in texts {
+        let text = text.as_ref();
         if text.len() > max_bytes {
             return Err(EmbedError::TextTooLong {
                 length: text.len(),
@@ -117,6 +135,83 @@ pub(crate) fn validate_texts_bounded(texts: &[String], max_bytes: usize) -> Resu
         }
     }
     Ok(())
+}
+
+enum ValidatedTextBatchInner<'a> {
+    Contiguous(&'a [String]),
+    Borrowed(&'a [&'a str]),
+}
+
+/// Internal capability proving the caller-text request bounds were checked.
+///
+/// The constructors are crate-private, so external callers cannot manufacture
+/// this capability to bypass [`EmbeddingService`] input validation.
+#[doc(hidden)]
+pub struct ValidatedTextBatch<'a> {
+    inner: ValidatedTextBatchInner<'a>,
+}
+
+impl<'a> ValidatedTextBatch<'a> {
+    pub(in crate::service) fn new(texts: &'a [String]) -> Result<Self> {
+        validate_texts(texts)?;
+        Ok(Self {
+            inner: ValidatedTextBatchInner::Contiguous(texts),
+        })
+    }
+
+    pub(in crate::service) fn borrowed_subset<'b>(
+        &'b self,
+        texts: &'b [&'b str],
+    ) -> ValidatedTextBatch<'b> {
+        ValidatedTextBatch {
+            inner: ValidatedTextBatchInner::Borrowed(texts),
+        }
+    }
+
+    pub(in crate::service) fn len(&self) -> usize {
+        match self.inner {
+            ValidatedTextBatchInner::Contiguous(texts) => texts.len(),
+            ValidatedTextBatchInner::Borrowed(texts) => texts.len(),
+        }
+    }
+
+    pub(in crate::service) fn get(&self, index: usize) -> &str {
+        match self.inner {
+            ValidatedTextBatchInner::Contiguous(texts) => texts[index].as_str(),
+            ValidatedTextBatchInner::Borrowed(texts) => texts[index],
+        }
+    }
+
+    fn contiguous(&self) -> Option<&'a [String]> {
+        match self.inner {
+            ValidatedTextBatchInner::Contiguous(texts) => Some(texts),
+            ValidatedTextBatchInner::Borrowed(_) => None,
+        }
+    }
+
+    pub(in crate::service) fn borrowed(&self) -> Option<&'a [&'a str]> {
+        match self.inner {
+            ValidatedTextBatchInner::Contiguous(_) => None,
+            ValidatedTextBatchInner::Borrowed(texts) => Some(texts),
+        }
+    }
+
+    pub(in crate::service) fn to_owned_with_prefix(&self, prefix: Option<&str>) -> Vec<String> {
+        (0..self.len())
+            .map(|index| {
+                let text = self.get(index);
+                match prefix {
+                    None => text.to_owned(),
+                    Some(prefix) => {
+                        let mut prepared = String::with_capacity(prefix.len() + text.len());
+                        prepared.push_str(prefix);
+                        prepared.push_str(text);
+                        prepared
+                    }
+                }
+            })
+            .collect()
+    }
 }
 
 /// **Stable**: external consumers may depend on this; breaking changes require a SemVer bump.
@@ -167,6 +262,25 @@ pub trait EmbeddingService: Send + Sync {
         validate_texts(texts)?;
         let prepared = apply_prefix(texts, role.instruction(model));
         self.embed(&prepared, model).await
+    }
+
+    /// Internal delegation hook for caller text already checked against the public bounds.
+    ///
+    /// External callers cannot construct [`ValidatedTextBatch`]. The default
+    /// preserves external implementors' role overrides by delegating through
+    /// [`EmbeddingService::embed_with_role`].
+    #[doc(hidden)]
+    async fn embed_with_role_prevalidated(
+        &self,
+        texts: ValidatedTextBatch<'_>,
+        model: EmbeddingModel,
+        role: EmbeddingRole,
+    ) -> Result<Vec<Vec<f32>>> {
+        if let Some(contiguous) = texts.contiguous() {
+            return self.embed_with_role(contiguous, model, role).await;
+        }
+        let owned = texts.to_owned_with_prefix(None);
+        self.embed_with_role(&owned, model, role).await
     }
 
     /// **Stable**: embed query texts after applying the model's query instruction.

--- a/crates/embed/src/service/native.rs
+++ b/crates/embed/src/service/native.rs
@@ -3,7 +3,7 @@
 //! Model loading is lazy and cancellation-safe; BERT-family and Qwen models take different
 //! loading and batching paths. See `docs/service.md` for lifecycle and persistence details.
 
-use super::{EmbeddingRole, EmbeddingService, MAX_TEXT_BYTES};
+use super::{EmbeddingRole, EmbeddingService, MAX_TEXT_BYTES, ValidatedTextBatch};
 use crate::error::{EmbedError, Result};
 use crate::model::{EmbeddingModel, ModelConfig};
 use async_trait::async_trait;
@@ -185,7 +185,7 @@ impl NativeEmbeddingService {
     /// prepends, which is zero bytes for symmetric models.
     async fn encode_prepared(
         &self,
-        texts: &[String],
+        texts: &[&str],
         model: EmbeddingModel,
     ) -> Result<Vec<Vec<f32>>> {
         if model != self.model_config.model {
@@ -200,10 +200,34 @@ impl NativeEmbeddingService {
         )?;
 
         let loaded = self.ensure_model().await?;
-        let text_refs = texts.iter().map(String::as_str).collect::<Vec<_>>();
         loaded
-            .encode_batch(&text_refs)
+            .encode_batch(texts)
             .map_err(EmbedError::InferenceFailed)
+    }
+
+    async fn encode_prevalidated_with_role(
+        &self,
+        texts: ValidatedTextBatch<'_>,
+        model: EmbeddingModel,
+        role: EmbeddingRole,
+    ) -> Result<Vec<Vec<f32>>> {
+        let prefix = role.instruction(model);
+        if prefix.is_none()
+            && let Some(borrowed) = texts.borrowed()
+        {
+            return self.encode_prepared(borrowed, model).await;
+        }
+
+        if prefix.is_none() {
+            let borrowed = (0..texts.len())
+                .map(|index| texts.get(index))
+                .collect::<Vec<_>>();
+            return self.encode_prepared(&borrowed, model).await;
+        }
+
+        let prepared = texts.to_owned_with_prefix(prefix);
+        let borrowed = prepared.iter().map(String::as_str).collect::<Vec<_>>();
+        self.encode_prepared(&borrowed, model).await
     }
 }
 
@@ -321,9 +345,9 @@ fn qwen_model_dir(model_type: EmbeddingModel) -> Result<std::path::PathBuf> {
 #[async_trait]
 impl EmbeddingService for NativeEmbeddingService {
     async fn embed(&self, texts: &[String], model: EmbeddingModel) -> Result<Vec<Vec<f32>>> {
-        // Caller text, so the published cap applies exactly.
-        super::validate_texts(texts)?;
-        self.encode_prepared(texts, model).await
+        let texts = ValidatedTextBatch::new(texts)?;
+        self.encode_prevalidated_with_role(texts, model, EmbeddingRole::Generic)
+            .await
     }
 
     async fn embed_with_role(
@@ -332,12 +356,17 @@ impl EmbeddingService for NativeEmbeddingService {
         model: EmbeddingModel,
         role: EmbeddingRole,
     ) -> Result<Vec<Vec<f32>>> {
-        // Validate what the caller passed, then prepare. Routing the prepared
-        // text back through `embed` would re-check it against the caller-text
-        // cap and reject input the caller kept within the documented limit.
-        super::validate_texts(texts)?;
-        let prepared = super::apply_prefix(texts, role.instruction(model));
-        self.encode_prepared(&prepared, model).await
+        let texts = ValidatedTextBatch::new(texts)?;
+        self.encode_prevalidated_with_role(texts, model, role).await
+    }
+
+    async fn embed_with_role_prevalidated(
+        &self,
+        texts: ValidatedTextBatch<'_>,
+        model: EmbeddingModel,
+        role: EmbeddingRole,
+    ) -> Result<Vec<Vec<f32>>> {
+        self.encode_prevalidated_with_role(texts, model, role).await
     }
 
     fn model_config(&self, model: EmbeddingModel) -> ModelConfig {

--- a/crates/embed/src/service/tests.rs
+++ b/crates/embed/src/service/tests.rs
@@ -480,6 +480,21 @@ mod external_impl_contract {
         assert_eq!(out.len(), 1, "one embedding per input");
     }
 
+    #[cfg(feature = "native")]
+    #[tokio::test]
+    async fn cached_wrapper_preserves_external_role_override() {
+        use crate::service::CachedEmbeddingService;
+        use std::sync::Arc;
+
+        let text = "a".repeat(MAX_TEXT_BYTES);
+        let service = CachedEmbeddingService::new(Arc::new(ExactCapWithOverride), 128);
+        let out = service
+            .embed_query(&[text], EmbeddingModel::BgeSmallEnV15)
+            .await
+            .expect("cached miss must preserve the inner role override");
+        assert_eq!(out.len(), 1, "one embedding per input");
+    }
+
     /// Over-cap caller text is rejected on both external shapes, and the error
     /// reports the published cap rather than any wider internal bound.
     #[tokio::test]

--- a/docs/adr/ADR-014-embedding-service.md
+++ b/docs/adr/ADR-014-embedding-service.md
@@ -25,6 +25,20 @@ pub trait EmbeddingService: Send + Sync {
 `CachedEmbeddingService` wraps any `EmbeddingService` with an LRU cache
 (sharded by text hash, configurable capacity).
 
+### Compositional validation capability (2026-07-28)
+
+`CachedEmbeddingService` validates caller text before any cache access. Delegating a disabled-cache
+request or a miss through the public role method would make a built-in inner service repeat the
+same caller-bound scan. The trait therefore has a doc-hidden `embed_with_role_prevalidated` hook
+whose opaque `ValidatedTextBatch` argument has no public constructor.
+
+The compatibility default calls the implementor's existing public `embed_with_role` method. This
+preserves arbitrary out-of-tree role overrides, even though an unknown implementation may validate
+again. `NativeEmbeddingService` consumes the proof directly while retaining its model check and
+prepared-text memory backstop. `CachedEmbeddingService` also consumes it directly, so nested cache
+wrappers validate the caller once. A cache miss is represented as borrowed views into the validated
+batch for those built-in paths rather than a cloned `Vec<String>`.
+
 ### Supported models
 
 | Model               | Dims | Use case                        |
@@ -75,4 +89,6 @@ a future step.
 - `ml/embed` is the only crate that imports `ml/inference`.
 - Verbs and the DB layer call `embed.embed_one()` — they never touch inference directly.
 - The cache prevents redundant model calls for repeated text.
+- Built-in cache delegation preserves validation-before-lookup while avoiding a repeated
+  caller-bound scan; unknown trait implementations retain their existing role-method behavior.
 - Drift detection is available but opt-in — no cost when unused.


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

Closes #1143

## Summary

- add an opaque, doc-hidden validated-text capability for compositional `EmbeddingService` delegation
- let Native and nested Cached services consume that proof directly, while the compatibility default still calls an unknown implementation's existing public role override
- delegate cache-miss subsets as borrowed text views on built-in paths instead of cloning every missing `String`
- retain validation before every cache lookup, Native's configured-model check, the prepared-text memory backstop, role preparation, ordering, and returned-count validation
- record the contract in ADR-014 and service documentation

The cache-owned embedding copy is unchanged. With the stable `Vec<Vec<f32>>` return type and `Arc<[f32]>` cache storage, the returned vector and retained cache entry require distinct ownership; removing that copy needs a separate storage/return-representation change rather than moving the same copy elsewhere.

## Validation

- `cargo test -p lattice-embed` — 293 unit tests passed; integration, drift, tokenizer, SIMD, and HF parity suites passed; the existing Qwen3 embedding parity test remains ignored under #103
- `cargo clippy -p lattice-embed --all-targets -- -D warnings` — passed
- Apple Silicon: `cargo test -p lattice-embed` — same complete result
- Apple Silicon: `cargo clippy --workspace -- -D warnings` — passed
- pre-commit formatting, Rust check, documentation lint, and capability-matrix fixture check — passed

Mutation proof: routing disabled-cache and miss delegation back through the old public methods and rebuilding owned miss strings made six focused tests fail. Validation counters increased from 1 to 2 on disabled, miss, delegated-error, and Native paths; nested caches increased to 3; the borrowed-view probe panicked. Restoring the prevalidated hook returned all eight focused cache tests to green. A separate regression test confirms a cached miss still reaches an out-of-tree service's custom `embed_with_role` override.

## bench-compare disposition

Command:

```text
make bench-compare \
  BASE=b7af26f05b871aa2fa2e4b72eaa377d987ff8339 \
  HEAD=93bc36938dd61cc7fa89caa2568de8b2f1ed583d \
  BENCH_GROUPS_INFERENCE=rms_norm \
  BENCH_GROUPS_EMBED=cached_embedding_delegate
```

The benchmark-only base commit contains the identical focused benchmark on both sides. It measures a disabled `CachedEmbeddingService<NativeEmbeddingService>` request with 64 texts × 4,096 bytes and a wrong model, so Native rejects before model loading or inference while still exercising the delegation and validation path.

```text
=== Run conditions ===
  base: b7af26f05b871aa2fa2e4b72eaa377d987ff8339 (b7af26f05b)   head: 93bc36938dd61cc7fa89caa2568de8b2f1ed583d (93bc36938d)
  resolution: --quick
  targets: lattice-inference:elementwise_cpu_bench, lattice-embed:simd
  inference features: <none>
  filters: inference='rms_norm' embed='cached_embedding_delegate'
  enforcement: report-only (gate status printed, exit 0)
  locks:
  bench-window (/tmp/lion-bench-window.lock): acquired immediately (uncontended)
  Metal GPU (/tmp/lion-metal-gpu-test.lock): acquired immediately (uncontended)
  ambient load:
    [quiet] before base: idle 96.7% (floor 70.0%) ok | top: WallpaperAerialsExtension 8.3%, WindowServer 1.8%, VTDecoderXPCService 1.5%, com.apple.DriverKit-AppleBCMWLAN 0.4%
    [quiet] between phases: idle 96.7% (floor 70.0%) ok | top: WallpaperAerialsExtension 7.8%, WindowServer 1.8%, VTDecoderXPCService 1.6%, com.apple.DriverKit-AppleBCMWLAN 1.0%
    [quiet] after head: idle 97.1% (floor 70.0%) ok | top: WallpaperAerialsExtension 7.2%, WindowServer 1.7%, VTDecoderXPCService 1.3%, com.apple.DriverKit-AppleBCMWLAN 0.4%
```

| Bench | Base | Head | Point delta | 95% CI | Classification |
|---|---:|---:|---:|---:|---|
| `cached_embedding_delegate/native_wrong_model_disabled_64x4096` | 6,718.8 ns | 157.6 ns | -97.65% | [-97.66%, -97.65%] | quick-mode informational |
| `rms_norm/4096` | control | control | +0.02% | [-0.02%, +0.07%] | gated; within noise |
| `rms_norm/896` | control | control | +0.08% | [+0.05%, +0.12%] | gated; within noise |

The focused embed row is informational because the `lattice-embed:simd` target is demoted below quick-mode gating resolution (#714), and Criterion printed `p = 0.07 > 0.05`. The result is reported as direction-and-magnitude evidence, not as a gated statistical-significance claim. The two unchanged inference controls were within the ±3% gate noise band.