### PR TITLE
ci: defer the macOS matrix legs while a PR is a draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,26 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `ready_for_review` is load-bearing, not decorative. The macOS legs of
+    # `ci` and `feature-matrix` are dropped from the matrix while a PR is a
+    # draft (see the `oslist` step in `changes`), and the DEFAULT type set is
+    # [opened, synchronize, reopened] — it contains no event for the
+    # draft-to-ready transition. Without this line, a PR marked ready that
+    # never pushes again would keep its draft-shaped run forever and could
+    # never report macOS coverage, wedging the PR.
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
     branches: [main]
     types: [checks_requested]
 
 # Cancel a PR's own superseded runs so they stop occupying the shared
-# macOS runner pool (~5 concurrent, account-wide) while a newer push on the
-# same PR waits behind them. Never cancel a push to main: main has no "next
+# macOS runner pool while a newer push on the same PR waits behind them.
+# An earlier revision of this comment put the pool at "~5 concurrent,
+# account-wide". That figure was inherited and never measured. Measured
+# instead over a 39.6 h window on this repo: median macOS queue 0.0 min,
+# p90 32.5 min, max 87.8 min, against an ubuntu control at p90 5.7 min.
+# Contention is bursty rather than a fixed slot cap, so the reason to cancel
+# superseded runs is the tail, not a slot count. Never cancel a push to main: main has no "next
 # push" to fall back on if a run is killed mid-flight. The event_name segment
 # keeps a push run and a workflow_dispatch run on the same ref out of each
 # other's queue: GitHub cancels a PENDING run whenever another run enters its
@@ -60,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      oslist: ${{ steps.oslist.outputs.oslist }}
+      featureoslist: ${{ steps.oslist.outputs.featureoslist }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -100,6 +115,42 @@ jobs:
             echo "code=false" >> "$GITHUB_OUTPUT"
             echo "→ docs-only change: full matrix skipped"
           fi
+      # Measured on a real run: `CI (macos-latest)` takes 9.5 min and
+      # `feature-matrix (macos-latest)` 6.6 min, so each run of this workflow
+      # spends 16.1 minutes on the macOS pool. Every other leg is Linux and
+      # finishes in a fraction of that. A draft PR cannot merge, so paying
+      # those 16.1 minutes on every draft push buys nothing the ready-flip does
+      # not buy again, while the runs that CAN merge queue behind them.
+      #
+      # The matrix is computed here rather than guarded with a job-level `if`
+      # because `jobs.<id>.if` is evaluated BEFORE matrix expansion and cannot
+      # see `matrix.os`. A job-level condition would therefore skip the whole
+      # matrix, taking the Linux legs with it — and those must keep running on
+      # drafts, since they are what catches ordinary compile breakage early.
+      #
+      # Dropping a combination is safe for branch protection because the
+      # required context is `ci-gate`, not the matrix-expanded names; see the
+      # rollout note at the top of this file. `ci-gate` fails closed on drafts
+      # so a draft is never reported as fully verified.
+      #
+      # `= "true"` against an empty default rather than a `== false`
+      # comparison: on push, merge_group and workflow_dispatch there is no
+      # pull_request object at all, so the value arrives empty and the full
+      # matrix must run. Empty is the arm that must not be skipped.
+      - id: oslist
+        env:
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo 'oslist=["ubuntu-latest","ubuntu-24.04-arm"]' >> "$GITHUB_OUTPUT"
+            echo 'featureoslist=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+            echo "→ draft PR: macOS legs deferred until ready for review"
+          else
+            echo 'oslist=["ubuntu-latest","macos-latest","ubuntu-24.04-arm"]' >> "$GITHUB_OUTPUT"
+            echo 'featureoslist=["ubuntu-latest","macos-latest"]' >> "$GITHUB_OUTPUT"
+            echo "→ full matrix including macOS"
+          fi
 
   ci:
     name: CI
@@ -109,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
+        os: ${{ fromJSON(needs.changes.outputs.oslist) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
@@ -162,7 +213,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: ${{ fromJSON(needs.changes.outputs.featureoslist) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
@@ -717,6 +768,16 @@ jobs:
           if [ "$CODE" != "true" ]; then
             echo "Docs-only change, heavy compile jobs not required. PASS."
             exit 0
+          fi
+          # Fail closed on drafts. The macOS legs are dropped from the matrix
+          # while a PR is a draft, so `ci` and `feature-matrix` report success
+          # off their Linux legs alone. Without this branch the gate would read
+          # green while macOS was never compiled — a pass in the shape of a
+          # verdict, which is the failure mode this gate exists to prevent.
+          DRAFT="${{ github.event.pull_request.draft }}"
+          if [ "$DRAFT" = "true" ]; then
+            echo "::error::Draft PR: the macOS legs of ci and feature-matrix are deferred while this PR is a draft, so macOS coverage is UNVERIFIED and this gate fails by design. Mark the PR ready for review and they run automatically on the ready_for_review event."
+            exit 1
           fi
           if [ "$CI_RESULT" != "success" ]; then
             echo "::error::ci did not succeed (result=$CI_RESULT)."


### PR DESCRIPTION
## Measured problem

Per-job durations from a real run of this workflow:

| job | runner | time |
|---|---|---|
| `CI (macos-latest)` | macOS | **9.5 min** |
| `feature-matrix (macos-latest)` | macOS | **6.6 min** |
| `CI (ubuntu-24.04-arm)` | Linux | 6.1 min |
| `CI (ubuntu-latest)` | Linux | 4.9 min |
| `feature-matrix (ubuntu-latest)` | Linux | 1.8 min |
| remaining 11 jobs | Linux | under 1.2 min each |

Every run of this workflow spends **16.1 minutes on the macOS pool**. This workflow had no draft handling at all, so that was paid on every push to every draft PR. A draft cannot merge, so the work is repeated in full at the ready-flip, while the runs that can merge queue behind it.

Observed while preparing this change: 15 queued runs of `CI` against 2 of `e2e-parity`, across 16 branches, with the macOS jobs of a ready PR queued for over half an hour. Queue measurements over a 39.6 h window: macOS median 0.0 min, p90 32.5 min, max 87.8 min; ubuntu control p90 5.7 min.

## Approach

The OS matrix is computed in the `changes` job instead of being a literal, and the macOS entries are dropped while `github.event.pull_request.draft` is `true`.

A job-level `if` cannot express this. `jobs.<id>.if` is evaluated **before** matrix expansion and cannot see `matrix.os`, so it would skip the entire matrix and take the Linux legs with it. Those must keep running on drafts, since they are what catches ordinary compile breakage early.

Dropping a matrix combination is safe for branch protection because the required context is `ci-gate`, not the matrix-expanded names — see the rollout note at the top of the file.

## Fail-closed, not fail-open

`ci-gate` now fails on drafts. Without that branch it would report success off the Linux legs alone while macOS was never compiled: a pass in the shape of a verdict, which is the exact failure this gate exists to prevent. The draft check sits **after** the docs-only early exit so docs-only drafts are unaffected.

`pull_request` gains an explicit `types` list including `ready_for_review`. The default set is `[opened, synchronize, reopened]` and contains no event for the draft-to-ready transition, so without it a PR marked ready that never pushes again would keep its draft-shaped run and could never report macOS coverage. This line is what stops the change from wedging PRs.

`= "true"` against an empty default rather than `== false`: on push, merge_group and workflow_dispatch there is no `pull_request` object, the value arrives empty, and the full matrix must run. Empty is the arm that must not be skipped.

## Not in scope

- `msrv` also runs on `macos-latest` and is deliberately untouched. It takes 1 min and exists to prove the Apple-only NEON and Metal surfaces compile at the declared MSRV.
- `app-binaries.yml` has a `macos-latest` job and no draft guard either. Its duration did not appear in the last 25 runs, so it is recorded here as **unmeasured, not zero**, and left for a separate change once measured.

## Verification

- `actionlint` clean.
- Assertions over the parsed YAML: `ready_for_review` present alongside all three default types; both matrices resolve through `fromJSON`; the `changes` job declares both outputs; the `oslist` step emits both keys on both branches; every runner label is one GitHub actually offers; the draft arm requests no macOS; **the non-draft arms are set-equal to the original literals**, so nothing is lost outside drafts; neither draft arm is empty, since an empty matrix list makes a job vanish rather than shrink.
- Four injected-defect controls, each confirmed to fire: dropped branch, deleted macOS coverage, typo'd runner label, empty matrix. A clean reading is therefore a measurement rather than a blind pass.

## Comment correction

The concurrency comment put the macOS pool at "~5 concurrent, account-wide". That figure was inherited and never measured; the measured numbers above replace it. Contention is bursty rather than a fixed slot cap.

## bench-compare disposition

Not applicable. This diff touches `.github/workflows/ci.yml` only. No file under `crates/inference/` or `crates/embed/` is modified, so no code compiled into any bench binary changes.
