### PR TITLE
chore(inference): link Metal readback follow-up

### DIFF
--- a/crates/inference/examples/profile_metal.rs
+++ b/crates/inference/examples/profile_metal.rs
@@ -145,7 +145,7 @@ fn main() {
     );
 
     // ── Hidden-readback overhead measurement ─────────────────────────────────
-    // TODO(i2): When MetalQwen35State::forward_step_with_hidden and
+    // TODO(#1186): When MetalQwen35State::forward_step_with_hidden and
     //   forward_prefill_with_hidden are implemented, replace this section with:
     //
     //   let n_measure = 5;


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- file #1186 as the durable tracker for the missing Metal hidden-state forward APIs and profiling measurement
- replace the private `TODO(i2)` milestone in `profile_metal.rs` with the resolvable `TODO(#1186)` reference
- leave the disabled measurement block and its existing status message unchanged until those APIs land

Closes #820.

## Defect

The profiling example described the intended hidden-readback and real-model MTP measurement, but its only ownership reference was an internal `i2` milestone. Repository readers could not resolve that marker to a public specification, acceptance criteria, or implementation status.

No existing open issue tracked the two missing `MetalQwen35State` APIs after a search across issue titles, bodies, and open pull requests.

## Fix

Issue #1186 now records the required step and prefill APIs, cache/logit parity, explicit readback path proof, Apple Silicon profiling verification, and benchmark evidence. The source marker points directly to that issue.

This PR deliberately does not enable or edit the deferred measurement block. That remains coupled to the missing APIs and belongs in #1186.

## Regression and mutation evidence

- `scripts/lint-source-markers.sh --selftest` passes
- restoring `TODO(i2)` in the worktree makes `scripts/lint-source-markers.sh` fail and identify `crates/inference/examples/profile_metal.rs:148`
- restoring `TODO(#1186)` removes that example from the lint findings
- an exact search confirms zero remaining `TODO(i2)` markers in `profile_metal.rs`

The repository-wide source-marker scan still reports the independent `FIXME(FANN-M5)` marker in `crates/fann/src/gpu/network.rs`; this change neither introduces nor claims to resolve that existing finding.

## Sibling and edge-case sweep

- searched open issues and pull requests for the named hidden-returning methods, hidden readback, MTP profiling, and the `i2` milestone before filing #1186
- searched the inference tree for the two proposed methods and confirmed neither currently exists
- confirmed the disabled measurement block and its line-185 status message are byte-for-byte unchanged
- confirmed the only source diff is the marker provenance replacement

## Validation

- `cargo fmt --all -- --check`
- `scripts/lint-source-markers.sh --selftest`
- `cargo check -p lattice-inference --example profile_metal --features f16,metal-gpu`
- `cargo clippy -p lattice-inference --example profile_metal --features f16,metal-gpu -- -D warnings`
- pre-commit checks
- `git diff --check`
- exact-head Apple Silicon rerun of the feature-gated example check and Clippy command

## bench-compare disposition

Not run. The implementation is a comment-only ownership-link change and does not alter executable code, generated artifacts, or a timed path.