### PR TITLE
ci: defer the macOS msrv job while a PR is a draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,7 +515,12 @@ jobs:
   msrv:
     name: msrv (1.93, f16+metal-gpu)
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # This job is macOS and is NOT matrix-driven, so the oslist selector that
+    # defers `ci` and `feature-matrix` on drafts does not reach it. It carries
+    # the draft condition directly, matching the form the parity workflow uses
+    # on its own single-runner macOS jobs. ci-gate's draft branch exits before
+    # it reads this job's result, so skipping here cannot produce a false green.
+    if: needs.changes.outputs.code == 'true' && github.event.pull_request.draft != true
     runs-on: macos-latest
     # RUSTUP_TOOLCHAIN pins every rustup-mediated invocation in this job to 1.93.1.
     # Without it, rustup's checked-in rust-toolchain.toml (1.94.1, repo dev/CI pin)
@@ -776,7 +781,7 @@ jobs:
           # verdict, which is the failure mode this gate exists to prevent.
           DRAFT="${{ github.event.pull_request.draft }}"
           if [ "$DRAFT" = "true" ]; then
-            echo "::error::Draft PR: the macOS legs of ci and feature-matrix are deferred while this PR is a draft, so macOS coverage is UNVERIFIED and this gate fails by design. Mark the PR ready for review and they run automatically on the ready_for_review event."
+            echo "::error::Draft PR: the macOS legs of ci and feature-matrix, and the macOS msrv job, are deferred while this PR is a draft, so macOS coverage is UNVERIFIED and this gate fails by design. Mark the PR ready for review and they run automatically on the ready_for_review event."
             exit 1
           fi
           if [ "$CI_RESULT" != "success" ]; then


### PR DESCRIPTION
## What

`msrv (1.93, f16+metal-gpu)` runs on `macos-latest` and is a standalone job, not
a matrix entry. The `oslist` selector that defers the macOS legs of `ci` and
`feature-matrix` on drafts therefore never reached it, so every draft push still
ran one full macOS job.

This carries the draft condition on the job itself, matching the form the parity
workflow already uses for its single-runner macOS jobs.

## Measured

With the selector live on `main` and no other change, freshly triggered draft
runs show `macOS jobs = 1, Linux jobs = 10` across three sampled draft PRs. The
one remaining macOS job is `msrv`. The Linux count is the control confirming the
run had expanded when sampled.

After this change the expected count is `macOS jobs = 0` on a draft.

## Runner accounting

Enumerated from the file rather than by inspection:

- `runs-on` occurrences: 12
- hardcoded `macos-latest`: 1 (this job, now guarded)
- matrix-driven (`${{ matrix.os }}`): 2, both fed by the `oslist` selector
- remaining 9: `ubuntu-latest`

## Gate safety

`ci-gate` evaluates its draft branch and exits non-zero *before* it reads
`needs.msrv.result`, so skipping this job on a draft cannot produce a green gate
without macOS coverage. A code-changing draft still ends red by design. The
gate's draft message is updated to name this job alongside the matrix legs.

## Validation

`actionlint` clean. Pre-commit doc lint and capability-matrix fixture check pass.

## bench-compare disposition

No file under `crates/inference/` or `crates/embed/` is modified. The diff is a
single workflow YAML file, which is compiled into no bench binary, so base and
head bench binaries have identical effective source and no A/B table applies.