### PR TITLE
ci: defer the macOS app-binary build while a PR is a draft

### DIFF
--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -18,6 +18,14 @@ name: app-binaries
 on:
   pull_request:
     branches: [main]
+    # `ready_for_review` is load-bearing, not decorative. `build-app-bins` is
+    # skipped while a PR is a draft, and the DEFAULT type set is
+    # [opened, synchronize, reopened] — it contains no event for the
+    # draft-to-ready transition. Without this line, a PR marked ready that
+    # never pushes again would keep its draft-shaped run forever and could
+    # never report an app-binary build, wedging the PR on a gate that fails
+    # closed for drafts.
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
     paths:
@@ -34,8 +42,15 @@ on:
     types: [checks_requested]
 
 # Cancel a PR's own superseded runs so they stop occupying the shared macOS
-# runner pool (~5 concurrent, account-wide) while a newer push on the same PR
-# waits behind them. Never cancel a push to main or a manual dispatch: neither
+# runner pool while a newer push on the same PR waits behind them. An earlier
+# revision of this comment put the pool at "~5 concurrent, account-wide". That
+# figure was inherited and never measured; ci.yml and e2e-parity.yml already
+# retracted it and this was the last copy still asserting it as fact. Measured
+# instead over a 39.6 h window on this repo: median macOS queue 0.0 min, p90
+# 32.5 min, max 87.8 min, against an ubuntu control at p90 5.7 min. Contention
+# is bursty rather than a fixed slot cap, so the reason to cancel superseded
+# runs is the tail, not a slot count.
+# Never cancel a push to main or a manual dispatch: neither
 # has a "next run" to fall back on if killed mid-flight. The event_name segment
 # keeps a push run and a workflow_dispatch run on the same ref out of each
 # other's queue: GitHub cancels a PENDING run whenever another run enters its
@@ -89,10 +104,17 @@ jobs:
             echo "→ no app-binary change: build skipped, gate passes"
           fi
 
+  # Deferred while a PR is a draft, matching the macOS legs of `ci` and
+  # `feature-matrix` and every macOS job in `e2e-parity`. A draft
+  # cannot merge, so a 45-minute macOS build on every draft push buys nothing
+  # the ready-flip does not buy later, while occupying a runner pool whose
+  # measured p90 queue is 32.5 min against an ubuntu control at 5.7 min.
+  # `app-binaries-gate` fails closed on drafts so a draft is never reported as
+  # having a verified app-binary build.
   build-app-bins:
     name: build app-shipped binaries
     needs: changes
-    if: needs.changes.outputs.bins == 'true'
+    if: needs.changes.outputs.bins == 'true' && github.event.pull_request.draft != true
     runs-on: macos-latest
     timeout-minutes: 45
     steps:
@@ -125,6 +147,19 @@ jobs:
           if [ "$BINS" != "true" ]; then
             echo "No app-binary change — build not required. PASS."
             exit 0
+          fi
+          # Fail closed on drafts, and only after the no-change PASS above: a
+          # docs-only draft defers nothing, so it must still pass. When the
+          # app-binary surface HAS changed, `build-app-bins` is skipped while
+          # the PR is a draft, and a skipped build must not read as a verified
+          # one — a pass in the shape of a verdict is the failure mode this
+          # gate exists to prevent. On merge_group, push, and workflow_dispatch
+          # there is no pull_request payload, so DRAFT is empty and this branch
+          # cannot fire.
+          DRAFT="${{ github.event.pull_request.draft }}"
+          if [ "$DRAFT" = "true" ]; then
+            echo "::error::Draft PR: the macOS app-binary build is deferred while this PR is a draft, so the app-binary surface is UNVERIFIED and this gate fails by design. Mark the PR ready for review and it runs automatically on the ready_for_review event."
+            exit 1
           fi
           if [ "$BUILD_RESULT" != "success" ]; then
             echo "::error::App-binary surface changed and build did not succeed (result=$BUILD_RESULT)."

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -39,6 +39,8 @@ name: cargo audit
 on:
   pull_request:
     branches: [main]
+    # A required check must also report after a draft-to-ready transition.
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
     branches: [main]
     types: [checks_requested]


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

### Summary

This change closes the draft-to-ready trigger gap for the two workflows that produce the required `app-binaries-gate` and `cargo-audit-gate` status contexts.

A required status context that cannot re-report after a draft pull request becomes ready makes every merge decision depend on that gate's draft semantics. If the workflow does not run on `ready_for_review`, a ready flip with no later push creates no post-flip check run at all, leaving the required context waiting to be reported.

### App binaries

`app-binaries.yml` defers its 45-minute macOS build while a pull request is a draft and makes `app-binaries-gate` fail closed in that state. Its draft semantics were read directly, and the change is deliberately conservative:

- dependency-irrelevant changes still pass;
- drafts with relevant changes report that the build is deferred rather than verified;
- non-pull-request events retain their existing behavior;
- `ready_for_review` starts the deferred build without requiring another push.

The workflow's concurrency comment is also corrected to remove an inherited, unverified fixed-capacity claim.

### Cargo audit

`cargo-audit.yml` now declares the same explicit pull-request activity types, including `ready_for_review`.

The original work did not assess this workflow's draft semantics, and this extension makes no claim about them. The change is confined to the trigger declaration: no jobs, draft conditions, gate logic, or change-detection behavior are modified.

### Why the explicit type list is required

GitHub's default `pull_request` activity types are `opened`, `synchronize`, and `reopened`; naming `types` replaces that default rather than extending it. Both workflows therefore state all three defaults plus `ready_for_review`.

### Acceptance test

After merge, flip one draft pull request to ready without pushing another commit and observe that all seven required contexts report:

- `actionlint`
- `app-binaries-gate`
- `cargo-audit-gate`
- `cargo-deny`
- `ci-gate`
- `parity-gate`
- `typos`

The pre-fix control is the measured state in which eight ready pull requests were blocked because `app-binaries-gate` and `cargo-audit-gate` had no post-flip check run.

### Bench-compare disposition

No file under `crates/inference/src/` or `crates/embed/src/` is modified. The changes are confined to GitHub Actions workflow configuration, so no benchmark binary changes and no A/B table applies.

### Verification

- `actionlint` passes for both changed workflows.
- Parsed YAML places `ready_for_review` under each workflow's `pull_request.types`.
- `cargo-audit.yml` retains its original `merge_group` trigger unchanged.
- `git diff --check` passes.
