### PR TITLE
fix(inference): validate QuaRot tensor ingress

### DIFF
--- a/crates/inference/src/bin/quantize_q4.rs
+++ b/crates/inference/src/bin/quantize_q4.rs
@@ -17,8 +17,11 @@ use lattice_inference::quant::quarot::QuarotTensorReader;
 use lattice_inference::weights::q4_weights::{Q4_BLOCK_BYTES, quantize_f32_to_q4, save_q4_file};
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
+
+#[path = "../weights/f16_encode.rs"]
+mod f16_encode;
 
 // ---------------------------------------------------------------------------
 // Tensor classification: should_quantize
@@ -77,91 +80,6 @@ fn should_quantize(name: &str) -> bool {
 
     // Default: quantize unknown weight matrices.
     true
-}
-
-// ---------------------------------------------------------------------------
-// F32 → F16 helper (for non-quantized tensors written as f16)
-// ---------------------------------------------------------------------------
-
-/// Convert f32 to IEEE-754 f16 bit pattern with round-to-nearest-even.
-#[inline]
-fn f32_to_f16(v: f32) -> u16 {
-    let bits = v.to_bits();
-    let sign = ((bits >> 16) & 0x8000) as u16;
-    let exp = ((bits >> 23) & 0xff) as i32;
-    let frac = bits & 0x007f_ffff;
-
-    if exp == 0xff {
-        if frac == 0 {
-            return sign | 0x7c00;
-        }
-        let mut payload = ((frac >> 13) as u16) & 0x03ff;
-        if payload == 0 {
-            payload = 1;
-        }
-        return sign | 0x7c00 | payload | 0x0200;
-    }
-    if exp == 0 {
-        return sign;
-    }
-
-    let exp32 = exp - 127;
-    if exp32 > 15 {
-        return sign | 0x7c00;
-    }
-
-    if exp32 >= -14 {
-        let frac16_raw = (frac >> 13) as u16;
-        let round_bit = ((frac >> 12) & 1) as u16;
-        let sticky = (frac & 0x0fff) != 0;
-        let frac16 = frac16_raw
-            + if round_bit == 1 && (sticky || (frac16_raw & 1) == 1) {
-                1
-            } else {
-                0
-            };
-        let mut exp16 = (exp32 + 15) as u16;
-        let mut frac16_final = frac16 & 0x03ff;
-        if frac16 == 0x0400 {
-            frac16_final = 0;
-            exp16 += 1;
-            if exp16 >= 0x1f {
-                return sign | 0x7c00;
-            }
-        }
-        return sign | (exp16 << 10) | frac16_final;
-    }
-
-    // exp32 < -14: the f32 value is normal-range but smaller than the
-    // smallest f16 normal. F16 still represents 2^-24..2^-14 as subnormals,
-    // and a source-F16 subnormal reaches this point after widening through
-    // f64 and narrowing back to f32 (both exact), so flushing to zero here
-    // would silently destroy a value f16 can represent exactly. Encode it
-    // as an f16 subnormal instead, using the same round-to-nearest-even
-    // shape as the normal-range path above.
-    let sig = 0x0080_0000u32 | frac;
-    let shift = (-exp32 - 1) as u32;
-
-    // Beyond this shift the discarded bits can never reach halfway to the
-    // smallest subnormal (2^-24), so the correctly rounded result is zero.
-    if shift >= 25 {
-        return sign;
-    }
-
-    let frac16_raw = (sig >> shift) as u16;
-    let round_bit = ((sig >> (shift - 1)) & 1) as u16;
-    let sticky = (sig & ((1u32 << (shift - 1)) - 1)) != 0;
-    let frac16 = frac16_raw
-        + if round_bit == 1 && (sticky || (frac16_raw & 1) == 1) {
-            1
-        } else {
-            0
-        };
-
-    // frac16 == 0x0400 means rounding overflowed the largest subnormal into
-    // the smallest normal f16 (exponent field 0x01, fraction 0) — that bit
-    // pattern is exactly `sign | 0x0400`, so no separate branch is needed.
-    sign | frac16
 }
 
 // ---------------------------------------------------------------------------
@@ -244,8 +162,16 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         print_usage_and_exit();
     });
 
+    quantize_model(&model_dir, &output_dir, dry_run)
+}
+
+fn quantize_model(
+    model_dir: &Path,
+    output_dir: &Path,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     if !dry_run {
-        fs::create_dir_all(&output_dir)?;
+        fs::create_dir_all(output_dir)?;
         let source_config = model_dir.join("config.json");
         let output_config = output_dir.join("config.json");
         fs::copy(&source_config, &output_config).map_err(|e| {
@@ -257,7 +183,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         })?;
     }
 
-    let reader = QuarotTensorReader::open(&model_dir)?;
+    let reader = QuarotTensorReader::open(model_dir)?;
     let mut tensor_names = reader.tensor_names();
     tensor_names.sort();
     let n_tensors = tensor_names.len();
@@ -315,7 +241,12 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             .collect();
 
         if should_quantize(tensor_name) {
-            let q4 = quantize_f32_to_q4(&data_f32, &shape)?;
+            let q4 = quantize_f32_to_q4(&data_f32, &shape).map_err(|error| {
+                format!(
+                    "{}: tensor {tensor_name} failed Q4 encoding: {error}",
+                    model_dir.display(),
+                )
+            })?;
             let bytes_out = (q4.blocks.len() * Q4_BLOCK_BYTES) as u64;
             total_bytes_out += bytes_out;
 
@@ -348,10 +279,17 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             // Kept tensor: reader already decoded to numeric values, so the
             // common path is decoded-value → f16 for every source dtype.
-            let f16_data: Vec<u8> = data_f32
-                .iter()
-                .flat_map(|&v| f32_to_f16(v).to_le_bytes())
-                .collect();
+            let mut f16_data = Vec::with_capacity(data_f32.len() * 2);
+            for (index, &value) in data_f32.iter().enumerate() {
+                let bits = f16_encode::f32_to_finite_f16_bits(value).map_err(|bits| {
+                    format!(
+                        "{}: tensor {tensor_name} cannot encode value {value} at element \
+                         index {index} as finite F16 (encoded bits {bits:#06x})",
+                        model_dir.display(),
+                    )
+                })?;
+                f16_data.extend_from_slice(&bits.to_le_bytes());
+            }
 
             let bytes_out = f16_data.len() as u64;
             total_bytes_out += bytes_out;
@@ -442,7 +380,125 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod tests {
-    use super::should_quantize;
+    use super::{quantize_model, should_quantize};
+
+    fn write_f32_tensor_model(
+        model_dir: &std::path::Path,
+        tensors: &[(&str, &[f32])],
+    ) -> std::path::PathBuf {
+        std::fs::create_dir_all(model_dir).unwrap();
+        std::fs::write(model_dir.join("config.json"), b"{}").unwrap();
+        let mut header = serde_json::Map::new();
+        let mut payload = Vec::new();
+        for (tensor_name, values) in tensors {
+            let start = payload.len();
+            for value in *values {
+                payload.extend_from_slice(&value.to_le_bytes());
+            }
+            let end = payload.len();
+            header.insert(
+                (*tensor_name).to_string(),
+                serde_json::json!({
+                    "dtype": "F32",
+                    "shape": [values.len()],
+                    "data_offsets": [start, end],
+                }),
+            );
+        }
+        let header = serde_json::to_vec(&header).unwrap();
+        let mut safetensors = Vec::new();
+        safetensors.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        safetensors.extend_from_slice(&header);
+        safetensors.extend_from_slice(&payload);
+        let source_path = model_dir.join("model.safetensors");
+        std::fs::write(&source_path, safetensors).unwrap();
+        source_path
+    }
+
+    #[test]
+    fn later_invalid_source_tensor_is_not_published_after_valid_tensor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let model_dir = tmp.path().join("model");
+        let output_dir = tmp.path().join("output");
+        let valid_name = "a_valid.norm.weight";
+        let invalid_name = "z_invalid.norm.weight";
+        let source_path = write_f32_tensor_model(
+            &model_dir,
+            &[(valid_name, &[1.0]), (invalid_name, &[1.0, f32::NAN])],
+        );
+
+        let err = quantize_model(&model_dir, &output_dir, false).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains(&source_path.display().to_string()),
+            "{message}"
+        );
+        assert!(message.contains(invalid_name), "{message}");
+        assert!(message.contains("non-finite value"), "{message}");
+
+        assert!(
+            output_dir.join("a_valid_norm_weight.f16").exists(),
+            "an earlier independently valid tensor may remain published"
+        );
+        assert!(
+            !output_dir.join("z_invalid_norm_weight.f16").exists(),
+            "the tensor that failed validation must not be published"
+        );
+        assert!(
+            !output_dir.join("quantize_index.json").exists(),
+            "failed conversion must not publish an index"
+        );
+    }
+
+    #[test]
+    fn finite_f32_that_overflows_f16_is_not_published() {
+        let tmp = tempfile::tempdir().unwrap();
+        let model_dir = tmp.path().join("model");
+        let output_dir = tmp.path().join("output");
+        let tensor_name = "model.language_model.norm.weight";
+        write_f32_tensor_model(&model_dir, &[(tensor_name, &[100_000.0])]);
+
+        let err = quantize_model(&model_dir, &output_dir, false).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains(&model_dir.display().to_string()),
+            "{message}"
+        );
+        assert!(message.contains(tensor_name), "{message}");
+        assert!(message.contains("cannot encode value"), "{message}");
+        assert!(message.contains("as finite F16"), "{message}");
+        assert!(
+            std::fs::read_dir(&output_dir)
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .all(|path| path.extension().is_none_or(|extension| extension != "f16")),
+            "overflowed F16 payload must not be published"
+        );
+    }
+
+    #[test]
+    fn finite_extreme_quantized_tensor_is_not_published() {
+        let tmp = tempfile::tempdir().unwrap();
+        let model_dir = tmp.path().join("model");
+        let output_dir = tmp.path().join("output");
+        let tensor_name = "model.layers.0.mlp.gate_proj.weight";
+        let values = [f32::MAX; 32];
+        write_f32_tensor_model(&model_dir, &[(tensor_name, &values)]);
+
+        let err = quantize_model(&model_dir, &output_dir, false).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains(&model_dir.display().to_string()),
+            "{message}"
+        );
+        assert!(message.contains(tensor_name), "{message}");
+        assert!(
+            !output_dir
+                .join("model_layers_0_mlp_gate_proj_weight.q4")
+                .exists()
+        );
+        assert!(!output_dir.join("quantize_index.json").exists());
+    }
 
     // -----------------------------------------------------------------------
     // MoE routed-expert tensors (issue #874 regression coverage).

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -45,7 +45,8 @@ use crate::quant::quarot::pipeline::{
 };
 use crate::quant::quarot::plan::RotationPlan;
 use crate::quant::quarot::rmsnorm_fusion::qwen35_per_layer_fusion_plan;
-use crate::weights::q4_weights::{q4_f32_to_f16, quantize_f64_to_q4, save_q4_file};
+use crate::weights::ingress::DecodedTensorValidator;
+use crate::weights::q4_weights::{q4_f32_to_finite_f16, quantize_f64_to_q4, save_q4_file};
 
 /// Upper bound on `hidden_size` accepted by [`convert_quarot_qwen35`], well above any
 /// real Qwen3.5 checkpoint, guarding `RandomizedHadamard::new`'s config-sized allocation
@@ -338,6 +339,7 @@ fn f16_file_byte_count(data_len: usize, shape_len: usize) -> u64 {
 
 fn write_mtp_weights_quarot(
     reader: &QuarotTensorReader,
+    source: &str,
     output_dir: &Path,
     dry_run: bool,
     index_entries: &mut Vec<IndexEntry>,
@@ -384,7 +386,7 @@ fn write_mtp_weights_quarot(
         *total_bytes_out += f16_file_byte_count(data.len(), shape.len());
         if !dry_run {
             let out_path = output_dir.join(&file_name);
-            write_f16_file(&out_path, &data, &shape)?;
+            write_f16_file(&out_path, source, name, &data, &shape)?;
         }
         *kept_f16 += 1;
         index_entries.push(IndexEntry {
@@ -496,6 +498,7 @@ pub fn convert_quarot_qwen35(
     }
 
     let reader = QuarotTensorReader::open(input_dir)?;
+    let input_source = input_dir.display().to_string();
     let required_names = qwen_required_tensor_names(&cfg);
     // Measure the on-disk footprint of the language-model tensors the pipeline
     // reads and writes, using SafeTensors header byte spans
@@ -638,7 +641,7 @@ pub fn convert_quarot_qwen35(
             if !opts.dry_run {
                 let file_name = format!("{sanitized}.f16");
                 let out_path = output_dir.join(&file_name);
-                write_f16_file(&out_path, &entry.data, &entry.shape)?;
+                write_f16_file(&out_path, &input_source, name, &entry.data, &entry.shape)?;
                 index_entries.push(IndexEntry {
                     name: name.clone(),
                     file: file_name,
@@ -654,6 +657,7 @@ pub fn convert_quarot_qwen35(
     if cfg.mtp_num_hidden_layers > 0 {
         write_mtp_weights_quarot(
             &reader,
+            &input_source,
             output_dir,
             opts.dry_run,
             &mut index_entries,
@@ -799,7 +803,26 @@ fn sanitize_tensor_name(name: &str) -> String {
 /// Returns the total number of bytes written. f64 → f16 goes through
 /// f32 to share the existing converter (rounding-aware) — sufficient
 /// for the runtime's f16 fast path.
-fn write_f16_file(path: &Path, data: &[f64], shape: &[usize]) -> Result<usize, InferenceError> {
+fn write_f16_file(
+    path: &Path,
+    source: &str,
+    tensor_name: &str,
+    data: &[f64],
+    shape: &[usize],
+) -> Result<usize, InferenceError> {
+    // Delay file creation until narrowing is proven finite so a rejected
+    // tensor cannot look like a completed KHF1 artifact.
+    let mut validator =
+        DecodedTensorValidator::decoded_input(source, tensor_name, shape, "F16", data.len())?;
+    let mut payload = Vec::with_capacity(data.len() * 2);
+    for &value in data {
+        let bits =
+            q4_f32_to_finite_f16(value as f32).map_err(|bits| validator.reject_f16_bits(bits))?;
+        validator.observe_finite();
+        payload.extend_from_slice(&bits.to_le_bytes());
+    }
+    validator.finish()?;
+
     let mut file = fs::File::create(path).map_err(|e| {
         InferenceError::Inference(format!(
             "write_f16_file: failed to create {}: {e}",
@@ -830,18 +853,6 @@ fn write_f16_file(path: &Path, data: &[f64], shape: &[usize]) -> Result<usize, I
     write_all(&(data.len() as u64).to_le_bytes())?;
     bytes_written += 8;
 
-    let mut payload = Vec::with_capacity(data.len() * 2);
-    for &v in data {
-        // Use the subnormal-aware helper from `weights::q4_weights`. The
-        // hand-rolled flush-to-zero variant in `bin/quantize_q4.rs`
-        // silently rounds f16-subnormal-but-f32-normal values
-        // (~1e-7 range) to zero — relevant here because every kept
-        // tensor (norms, A_log, dt_bias, conv1d, etc.) passes through
-        // this path. `q4_f32_to_f16` round-trips through the f16
-        // subnormal range correctly.
-        let h = q4_f32_to_f16(v as f32);
-        payload.extend_from_slice(&h.to_le_bytes());
-    }
     write_all(&payload)?;
     bytes_written += payload.len();
 
@@ -852,6 +863,7 @@ fn write_f16_file(path: &Path, data: &[f64], shape: &[usize]) -> Result<usize, I
 mod tests {
     use super::*;
     use crate::model::qwen35_config::{LayerType, compute_layer_types};
+    use crate::weights::q4_weights::q4_f32_to_f16;
     use serde_json::Value;
     use std::path::PathBuf;
 
@@ -1606,7 +1618,8 @@ mod tests {
         let p = tmp.path().join("test.f16");
         let data = vec![1.5_f64, -2.5, 0.25, -0.125];
         let shape = vec![2_usize, 2];
-        let bytes_written = write_f16_file(&p, &data, &shape).unwrap();
+        let bytes_written =
+            write_f16_file(&p, "fixture.safetensors", "fixture.weight", &data, &shape).unwrap();
         let raw = fs::read(&p).unwrap();
         assert_eq!(&raw[0..4], b"KHF1");
         assert_eq!(u32::from_le_bytes(raw[4..8].try_into().unwrap()), 1);
@@ -1619,7 +1632,43 @@ mod tests {
         assert_eq!(bytes_written, raw.len());
     }
 
-    /// Smoke check on `q4_f32_to_f16` (used by `write_f16_file`).
+    /// Mutation-sensitive lattice#801 output gate: accepting every encoded
+    /// bit pattern makes each case create a KHF1 file and return Ok.
+    #[test]
+    fn f16_writer_rejects_non_finite_or_overflowed_encoding_before_create() {
+        let tmp = tempfile::tempdir().unwrap();
+        for (label, value) in [
+            ("nan", f64::NAN),
+            ("positive-infinity", f64::INFINITY),
+            ("negative-infinity", f64::NEG_INFINITY),
+            ("f32-overflow", f64::MAX),
+            ("f16-overflow", 100_000.0_f64),
+        ] {
+            let path = tmp.path().join(format!("{label}.f16"));
+            let err = write_f16_file(
+                &path,
+                "fixture.safetensors",
+                "fixture.weight",
+                &[value],
+                &[1],
+            )
+            .unwrap_err();
+            let message = err.to_string();
+            assert!(
+                matches!(err, InferenceError::InvalidInput(_)),
+                "{label}: got {err:?}"
+            );
+            assert!(message.contains("non-finite value"), "{label}: got {err}");
+            assert!(message.contains("fixture.safetensors"));
+            assert!(message.contains("fixture.weight"));
+            assert!(
+                !path.exists(),
+                "{label}: invalid f16 encoding must be rejected before file creation"
+            );
+        }
+    }
+
+    /// Smoke check on the canonical encoder underlying `write_f16_file`.
     /// Includes an f16-subnormal regression, since fixed: the old local
     /// helper flushed every value below f16's smallest
     /// normal to zero, silently corrupting small-magnitude weights in

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -50,6 +50,7 @@ use crate::error::InferenceError;
 use crate::model::qwen35::qwen_layer_tensor_prefix;
 use crate::model::qwen35_config::Qwen35Config;
 use crate::quant::quarot::plan::{OnlineRotationSpec, OnlineTransformSite};
+use crate::weights::ingress::DecodedTensorValidator;
 use crate::weights::safetensors_layout::{
     SafetensorsLayoutEntry, safetensors_dtype, validate_safetensors_layout,
 };
@@ -100,6 +101,7 @@ struct TensorHeader {
 #[derive(Debug)]
 struct Shard {
     mmap: Mmap,
+    source: String,
     /// Absolute file offset where the data section begins
     /// (`8 + header_len`).
     data_offset: usize,
@@ -291,6 +293,7 @@ impl Shard {
 
         Ok(Shard {
             mmap,
+            source: path.display().to_string(),
             data_offset,
             headers,
         })
@@ -861,7 +864,7 @@ impl QuarotTensorReader {
             .ok_or_else(|| InferenceError::MissingTensor(name.to_string()))?
             .clone();
         let bytes = shard.tensor_bytes(name)?;
-        let data = decode_bytes_to_f64(bytes, header.dtype)?;
+        let data = decode_bytes_to_f64(bytes, header.dtype, &shard.source, name, &header.shape)?;
         Ok((data, header.shape))
     }
 
@@ -891,51 +894,153 @@ impl QuarotTensorReader {
     }
 }
 
-fn decode_bytes_to_f64(bytes: &[u8], dtype: SourceDType) -> Result<Vec<f64>, InferenceError> {
+const VALIDATED_DECODE_LANES: usize = 16;
+
+fn decode_bytes_to_f64(
+    bytes: &[u8],
+    dtype: SourceDType,
+    source: &str,
+    tensor_name: &str,
+    shape: &[usize],
+) -> Result<Vec<f64>, InferenceError> {
+    let element_width = match dtype {
+        SourceDType::F32 => 4,
+        SourceDType::F16 | SourceDType::BF16 => 2,
+    };
+    if !bytes.len().is_multiple_of(element_width) {
+        return Err(InferenceError::InvalidSafetensors(format!(
+            "{source}: tensor {tensor_name} ({}) byte length {} not divisible by \
+             element width {element_width}",
+            dtype.name(),
+            bytes.len(),
+        )));
+    }
+
+    let decoded_len = bytes.len() / element_width;
+    let validator =
+        DecodedTensorValidator::safetensors(source, tensor_name, shape, dtype.name(), decoded_len)?;
+    let mut data = Vec::with_capacity(decoded_len);
+    let mut non_finite_lanes = [false; VALIDATED_DECODE_LANES];
+
     match dtype {
         SourceDType::F32 => {
-            if !bytes.len().is_multiple_of(4) {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "F32 tensor byte length {} not divisible by 4",
-                    bytes.len()
-                )));
+            let mut groups = bytes.chunks_exact(VALIDATED_DECODE_LANES * 4);
+            for group in &mut groups {
+                let mut decoded = [0.0_f64; VALIDATED_DECODE_LANES];
+                macro_rules! decode_lane {
+                    ($lane:literal) => {{
+                        let offset = $lane * 4;
+                        let bits = u32::from_le_bytes([
+                            group[offset],
+                            group[offset + 1],
+                            group[offset + 2],
+                            group[offset + 3],
+                        ]);
+                        non_finite_lanes[$lane] |= bits & 0x7f80_0000 == 0x7f80_0000;
+                        decoded[$lane] = f32::from_bits(bits) as f64;
+                    }};
+                }
+                decode_lane!(0);
+                decode_lane!(1);
+                decode_lane!(2);
+                decode_lane!(3);
+                decode_lane!(4);
+                decode_lane!(5);
+                decode_lane!(6);
+                decode_lane!(7);
+                decode_lane!(8);
+                decode_lane!(9);
+                decode_lane!(10);
+                decode_lane!(11);
+                decode_lane!(12);
+                decode_lane!(13);
+                decode_lane!(14);
+                decode_lane!(15);
+                data.extend_from_slice(&decoded);
             }
-            Ok(bytes
-                .chunks_exact(4)
-                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]) as f64)
-                .collect())
+            for bytes in groups.remainder().chunks_exact(4) {
+                let bits = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                non_finite_lanes[0] |= bits & 0x7f80_0000 == 0x7f80_0000;
+                data.push(f32::from_bits(bits) as f64);
+            }
         }
         SourceDType::BF16 => {
-            if !bytes.len().is_multiple_of(2) {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "BF16 tensor byte length {} not divisible by 2",
-                    bytes.len()
-                )));
+            let mut groups = bytes.chunks_exact(VALIDATED_DECODE_LANES * 2);
+            for group in &mut groups {
+                let mut decoded = [0.0_f64; VALIDATED_DECODE_LANES];
+                macro_rules! decode_lane {
+                    ($lane:literal) => {{
+                        let offset = $lane * 2;
+                        let bits = u16::from_le_bytes([group[offset], group[offset + 1]]);
+                        non_finite_lanes[$lane] |= bits & 0x7f80 == 0x7f80;
+                        decoded[$lane] = crate::weights::half_bits::bf16_bits_to_f32(bits) as f64;
+                    }};
+                }
+                decode_lane!(0);
+                decode_lane!(1);
+                decode_lane!(2);
+                decode_lane!(3);
+                decode_lane!(4);
+                decode_lane!(5);
+                decode_lane!(6);
+                decode_lane!(7);
+                decode_lane!(8);
+                decode_lane!(9);
+                decode_lane!(10);
+                decode_lane!(11);
+                decode_lane!(12);
+                decode_lane!(13);
+                decode_lane!(14);
+                decode_lane!(15);
+                data.extend_from_slice(&decoded);
             }
-            Ok(bytes
-                .chunks_exact(2)
-                .map(|b| {
-                    crate::weights::half_bits::bf16_bits_to_f32(u16::from_le_bytes([b[0], b[1]]))
-                        as f64
-                })
-                .collect())
+            for bytes in groups.remainder().chunks_exact(2) {
+                let bits = u16::from_le_bytes([bytes[0], bytes[1]]);
+                non_finite_lanes[0] |= bits & 0x7f80 == 0x7f80;
+                data.push(crate::weights::half_bits::bf16_bits_to_f32(bits) as f64);
+            }
         }
         SourceDType::F16 => {
-            if !bytes.len().is_multiple_of(2) {
-                return Err(InferenceError::InvalidSafetensors(format!(
-                    "F16 tensor byte length {} not divisible by 2",
-                    bytes.len()
-                )));
+            let mut groups = bytes.chunks_exact(VALIDATED_DECODE_LANES * 2);
+            for group in &mut groups {
+                let mut decoded = [0.0_f64; VALIDATED_DECODE_LANES];
+                macro_rules! decode_lane {
+                    ($lane:literal) => {{
+                        let offset = $lane * 2;
+                        let bits = u16::from_le_bytes([group[offset], group[offset + 1]]);
+                        non_finite_lanes[$lane] |= bits & 0x7c00 == 0x7c00;
+                        decoded[$lane] = crate::weights::half_bits::f16_bits_to_f32(bits) as f64;
+                    }};
+                }
+                decode_lane!(0);
+                decode_lane!(1);
+                decode_lane!(2);
+                decode_lane!(3);
+                decode_lane!(4);
+                decode_lane!(5);
+                decode_lane!(6);
+                decode_lane!(7);
+                decode_lane!(8);
+                decode_lane!(9);
+                decode_lane!(10);
+                decode_lane!(11);
+                decode_lane!(12);
+                decode_lane!(13);
+                decode_lane!(14);
+                decode_lane!(15);
+                data.extend_from_slice(&decoded);
             }
-            Ok(bytes
-                .chunks_exact(2)
-                .map(|b| {
-                    crate::weights::half_bits::f16_bits_to_f32(u16::from_le_bytes([b[0], b[1]]))
-                        as f64
-                })
-                .collect())
+            for bytes in groups.remainder().chunks_exact(2) {
+                let bits = u16::from_le_bytes([bytes[0], bytes[1]]);
+                non_finite_lanes[0] |= bits & 0x7c00 == 0x7c00;
+                data.push(crate::weights::half_bits::f16_bits_to_f32(bits) as f64);
+            }
         }
     }
+
+    let has_non_finite = non_finite_lanes.into_iter().any(|found| found);
+    validator.finish_f64_materialization(&data, has_non_finite)?;
+    Ok(data)
 }
 
 #[cfg(test)]
@@ -1053,6 +1158,32 @@ mod tests {
         file.write_all(&payload).unwrap();
     }
 
+    fn write_raw_safetensor(
+        path: &Path,
+        tensor_name: &str,
+        dtype: FixtureDType,
+        shape: &[usize],
+        payload: &[u8],
+    ) {
+        assert_eq!(
+            payload.len(),
+            shape.iter().product::<usize>() * bytes_per_elem(dtype)
+        );
+        let header = serde_json::json!({
+            (tensor_name): {
+                "dtype": dtype_name(dtype),
+                "shape": shape,
+                "data_offsets": [0, payload.len()],
+            }
+        });
+        let header = serde_json::to_vec(&header).unwrap();
+        let mut file = File::create(path).unwrap();
+        file.write_all(&(header.len() as u64).to_le_bytes())
+            .unwrap();
+        file.write_all(&header).unwrap();
+        file.write_all(payload).unwrap();
+    }
+
     fn approx_eq(a: f64, b: f64, eps: f64) -> bool {
         (a - b).abs() <= eps
     }
@@ -1115,6 +1246,99 @@ mod tests {
         for (g, &v) in got.iter().zip(values.iter()) {
             let tol = (v.abs() as f64) * (1.0 / 1024.0) + 1e-6;
             assert!(approx_eq(*g, v as f64, tol), "got {g} expected ~{v}");
+        }
+    }
+
+    /// Mutation-sensitive lattice#801 gate: removing a raw exponent-marker
+    /// reduction makes that dtype's NaN/Inf cases return `Ok`.
+    #[test]
+    fn read_tensor_f64_rejects_non_finite_values_for_every_supported_dtype() {
+        for dtype in [FixtureDType::F32, FixtureDType::F16, FixtureDType::BF16] {
+            for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+                for bad_index in [5, 17] {
+                    let dir = tempfile::tempdir().unwrap();
+                    let path = dir.path().join("model.safetensors");
+                    let mut values = vec![1.0; 18];
+                    values[bad_index] = bad;
+                    write_safetensors(&path, &[("bad.weight", dtype, vec![18], &values)]);
+
+                    let reader = QuarotTensorReader::open(dir.path()).unwrap();
+                    let err = reader.read_tensor_f64("bad.weight").unwrap_err();
+                    match err {
+                        InferenceError::InvalidSafetensors(message) => {
+                            assert!(message.contains(&path.display().to_string()), "{message}");
+                            assert!(message.contains("bad.weight"), "{message}");
+                            assert!(message.contains(dtype_name(dtype)), "{message}");
+                            assert!(message.contains("non-finite value"), "{message}");
+                            assert!(
+                                message.contains(&format!("element index {bad_index}")),
+                                "{message}"
+                            );
+                        }
+                        other => panic!("expected InvalidSafetensors, got {other:?}"),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn read_tensor_f64_accepts_signed_zero_and_smallest_subnormal_for_every_dtype() {
+        let mut f32_bits = vec![1.0_f32.to_bits(); 18];
+        f32_bits[0] = 0;
+        f32_bits[1] = 0x8000_0000;
+        f32_bits[2] = 1;
+        f32_bits[16] = 0x8000_0000;
+        f32_bits[17] = 1;
+        let f32_payload = f32_bits
+            .into_iter()
+            .flat_map(u32::to_le_bytes)
+            .collect::<Vec<_>>();
+
+        let mut f16_bits = vec![0x3c00_u16; 18];
+        f16_bits[0] = 0;
+        f16_bits[1] = 0x8000;
+        f16_bits[2] = 1;
+        f16_bits[16] = 0x8000;
+        f16_bits[17] = 1;
+        let f16_payload = f16_bits
+            .into_iter()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>();
+
+        let mut bf16_bits = vec![0x3f80_u16; 18];
+        bf16_bits[0] = 0;
+        bf16_bits[1] = 0x8000;
+        bf16_bits[2] = 1;
+        bf16_bits[16] = 0x8000;
+        bf16_bits[17] = 1;
+        let bf16_payload = bf16_bits
+            .into_iter()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>();
+
+        for (dtype, payload, smallest_subnormal) in [
+            (FixtureDType::F32, f32_payload, 2.0_f64.powi(-149)),
+            (FixtureDType::F16, f16_payload, 2.0_f64.powi(-24)),
+            (FixtureDType::BF16, bf16_payload, 2.0_f64.powi(-133)),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            write_raw_safetensor(
+                &dir.path().join("model.safetensors"),
+                "finite.weight",
+                dtype,
+                &[18],
+                &payload,
+            );
+
+            let reader = QuarotTensorReader::open(dir.path()).unwrap();
+            let (decoded, shape) = reader.read_tensor_f64("finite.weight").unwrap();
+            assert_eq!(shape, vec![18]);
+            assert_eq!(decoded[0].to_bits(), 0.0_f64.to_bits());
+            assert_eq!(decoded[1].to_bits(), (-0.0_f64).to_bits());
+            assert_eq!(decoded[2], smallest_subnormal, "{}", dtype_name(dtype));
+            assert_eq!(decoded[16].to_bits(), (-0.0_f64).to_bits());
+            assert_eq!(decoded[17], smallest_subnormal, "{}", dtype_name(dtype));
         }
     }
 

--- a/crates/inference/src/weights/f16_encode.rs
+++ b/crates/inference/src/weights/f16_encode.rs
@@ -1,0 +1,97 @@
+//! Scalar IEEE-754 f32-to-f16 bit-pattern conversion shared by the library
+//! and package-local offline quantizer binary.
+
+#[inline]
+fn round_shift_right_even(value: u32, shift: u32) -> u32 {
+    if shift == 0 {
+        return value;
+    }
+    if shift >= 32 {
+        return 0;
+    }
+
+    let base = value >> shift;
+    let mask = (1u32 << shift) - 1;
+    let remainder = value & mask;
+    let half = 1u32 << (shift - 1);
+
+    if remainder > half || (remainder == half && (base & 1) != 0) {
+        base + 1
+    } else {
+        base
+    }
+}
+
+/// Convert `f32` to an IEEE-754 binary16 bit pattern using
+/// round-to-nearest-even.
+#[inline]
+pub(crate) fn f32_to_f16_bits(v: f32) -> u16 {
+    let bits = v.to_bits();
+    let sign = ((bits >> 16) as u16) & 0x8000;
+    let exp = ((bits >> 23) & 0xff) as i32;
+    let frac = bits & 0x007f_ffff;
+
+    if exp == 0xff {
+        if frac == 0 {
+            return sign | 0x7c00;
+        }
+        let mut payload = (frac >> 13) as u16;
+        if payload == 0 {
+            payload = 1;
+        }
+        payload |= 0x0200;
+        return sign | 0x7c00 | (payload & 0x03ff);
+    }
+
+    if exp == 0 {
+        return sign;
+    }
+
+    let exp32 = exp - 127;
+    if exp32 > 15 {
+        return sign | 0x7c00;
+    }
+
+    if exp32 >= -14 {
+        let mut exp16 = (exp32 + 15) as u16;
+        let mut frac16 = round_shift_right_even(frac, 13) as u16;
+
+        if frac16 == 0x0400 {
+            frac16 = 0;
+            exp16 += 1;
+            if exp16 >= 0x1f {
+                return sign | 0x7c00;
+            }
+        }
+
+        return sign | (exp16 << 10) | frac16;
+    }
+
+    let mant = frac | 0x0080_0000;
+    let shift = (-exp32 - 1) as u32;
+    if shift >= 32 {
+        return sign;
+    }
+
+    let frac16 = round_shift_right_even(mant, shift) as u16;
+    if frac16 == 0 {
+        return sign;
+    }
+    if frac16 == 0x0400 {
+        return sign | 0x0400;
+    }
+
+    sign | frac16
+}
+
+/// Convert `f32` to finite f16 bits, returning the non-finite encoding on
+/// NaN, infinity, or narrowing overflow.
+#[inline]
+pub(crate) fn f32_to_finite_f16_bits(v: f32) -> Result<u16, u16> {
+    let bits = f32_to_f16_bits(v);
+    if bits & 0x7c00 == 0x7c00 {
+        Err(bits)
+    } else {
+        Ok(bits)
+    }
+}

--- a/crates/inference/src/weights/half_bits.rs
+++ b/crates/inference/src/weights/half_bits.rs
@@ -14,6 +14,8 @@
 //! F16/BF16 model loading* is gated behind the crate's `f16` feature. Only
 //! the loading permission is feature-gated, never this bit conversion math.
 
+pub(crate) use super::f16_encode::{f32_to_f16_bits, f32_to_finite_f16_bits};
+
 /// Widen an IEEE-754 binary16 (f16) bit pattern to `f32`, exactly.
 ///
 /// Handles signed zero, subnormals, infinities, and NaN (NaN payload is
@@ -48,100 +50,6 @@ pub(crate) fn f16_bits_to_f32(bits: u16) -> f32 {
     };
 
     f32::from_bits(f32_bits)
-}
-
-/// Round-to-nearest-even right shift used for mantissa truncation in the
-/// f32-to-f16 direction.
-#[inline]
-fn round_shift_right_even(value: u32, shift: u32) -> u32 {
-    if shift == 0 {
-        return value;
-    }
-    if shift >= 32 {
-        return 0;
-    }
-
-    let base = value >> shift;
-    let mask = (1u32 << shift) - 1;
-    let remainder = value & mask;
-    let half = 1u32 << (shift - 1);
-
-    if remainder > half || (remainder == half && (base & 1) != 0) {
-        base + 1
-    } else {
-        base
-    }
-}
-
-/// Convert `f32` to an IEEE-754 binary16 (f16) bit pattern using
-/// round-to-nearest-even.
-///
-/// Handles ±0, ±∞, NaN (payload preserved, quiet bit forced set, guaranteed
-/// non-zero mantissa), subnormals, and overflow (rounds up to ±∞).
-#[inline]
-pub(crate) fn f32_to_f16_bits(v: f32) -> u16 {
-    let bits = v.to_bits();
-    let sign = ((bits >> 16) as u16) & 0x8000;
-    let exp = ((bits >> 23) & 0xff) as i32;
-    let frac = bits & 0x007f_ffff;
-
-    // Inf or NaN
-    if exp == 0xff {
-        if frac == 0 {
-            return sign | 0x7c00;
-        }
-        let mut payload = (frac >> 13) as u16;
-        if payload == 0 {
-            payload = 1;
-        }
-        payload |= 0x0200;
-        return sign | 0x7c00 | (payload & 0x03ff);
-    }
-
-    // Zero or f32 subnormal (underflows to f16 zero)
-    if exp == 0 {
-        return sign;
-    }
-
-    let exp32 = exp - 127;
-
-    // Overflow to infinity
-    if exp32 > 15 {
-        return sign | 0x7c00;
-    }
-
-    // Normal f16 range
-    if exp32 >= -14 {
-        let mut exp16 = (exp32 + 15) as u16;
-        let mut frac16 = round_shift_right_even(frac, 13) as u16;
-
-        if frac16 == 0x0400 {
-            frac16 = 0;
-            exp16 += 1;
-            if exp16 >= 0x1f {
-                return sign | 0x7c00;
-            }
-        }
-
-        return sign | (exp16 << 10) | frac16;
-    }
-
-    // Subnormal f16 range
-    let mant = frac | 0x0080_0000;
-    let shift = (-exp32 - 1) as u32;
-    if shift >= 32 {
-        return sign;
-    }
-
-    let frac16 = round_shift_right_even(mant, shift) as u16;
-    if frac16 == 0 {
-        return sign;
-    }
-    if frac16 == 0x0400 {
-        return sign | 0x0400;
-    }
-
-    sign | frac16
 }
 
 /// Widen a bfloat16 bit pattern to `f32`.

--- a/crates/inference/src/weights/ingress.rs
+++ b/crates/inference/src/weights/ingress.rs
@@ -78,6 +78,162 @@ impl IngressErrorKind {
     }
 }
 
+/// Shared provenance, shape, and finite-value validator for one-pass
+/// decoders.
+///
+/// Byte-stream readers reduce raw non-finite markers while materializing
+/// each decode group, then use [`Self::finish_f64_materialization`].
+/// Narrowing writers use the shared finite-f16 encoder, then call
+/// [`Self::observe_finite`] before publishing a completed payload.
+pub(crate) struct DecodedTensorValidator<'a> {
+    source: &'a str,
+    tensor_name: &'a str,
+    shape: &'a [usize],
+    dtype_label: &'static str,
+    error_kind: IngressErrorKind,
+    numel: usize,
+    seen: usize,
+}
+
+impl<'a> DecodedTensorValidator<'a> {
+    fn new(
+        source: &'a str,
+        tensor_name: &'a str,
+        shape: &'a [usize],
+        dtype_label: &'static str,
+        error_kind: IngressErrorKind,
+        numel: usize,
+        decoded_len: usize,
+    ) -> Result<Self, InferenceError> {
+        if decoded_len != numel {
+            return Err(error_kind.error(format!(
+                "{source}: tensor {tensor_name} ({dtype_label}) decoded element count \
+                 {decoded_len} does not match shape {shape:?} (shape product {numel})",
+            )));
+        }
+        Ok(Self {
+            source,
+            tensor_name,
+            shape,
+            dtype_label,
+            error_kind,
+            numel,
+            seen: 0,
+        })
+    }
+
+    /// Construct a validator for one SafeTensors decode.
+    pub(crate) fn safetensors(
+        source: &'a str,
+        tensor_name: &'a str,
+        shape: &'a [usize],
+        dtype_label: &'static str,
+        decoded_len: usize,
+    ) -> Result<Self, InferenceError> {
+        let numel = shape
+            .iter()
+            .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+            .ok_or_else(|| {
+                InferenceError::InvalidSafetensors(format!(
+                    "{source}: tensor {tensor_name} shape {shape:?} overflows usize element count",
+                ))
+            })?;
+        Self::new(
+            source,
+            tensor_name,
+            shape,
+            dtype_label,
+            IngressErrorKind::InvalidSafetensors,
+            numel,
+            decoded_len,
+        )
+    }
+
+    /// Construct a validator for derived values before they are serialized.
+    pub(crate) fn decoded_input(
+        source: &'a str,
+        tensor_name: &'a str,
+        shape: &'a [usize],
+        dtype_label: &'static str,
+        decoded_len: usize,
+    ) -> Result<Self, InferenceError> {
+        let numel = shape
+            .iter()
+            .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+            .ok_or_else(|| {
+                InferenceError::InvalidInput(format!(
+                    "{source}: tensor {tensor_name} shape {shape:?} overflows usize element count",
+                ))
+            })?;
+        Self::new(
+            source,
+            tensor_name,
+            shape,
+            dtype_label,
+            IngressErrorKind::InvalidInput,
+            numel,
+            decoded_len,
+        )
+    }
+
+    #[cold]
+    fn reject_non_finite_at(&self, index: usize, value: f64) -> InferenceError {
+        self.error_kind.error(format!(
+            "{}: tensor {} ({}) has non-finite value {value} at element index \
+             {} of {} (shape {:?})",
+            self.source, self.tensor_name, self.dtype_label, index, self.numel, self.shape,
+        ))
+    }
+
+    #[cold]
+    fn reject_non_finite(&self, value: f64) -> InferenceError {
+        self.reject_non_finite_at(self.seen, value)
+    }
+
+    pub(crate) fn reject_f16_bits(&self, bits: u16) -> InferenceError {
+        let value = crate::weights::half_bits::f16_bits_to_f32(bits);
+        self.reject_non_finite(value as f64)
+    }
+
+    #[inline(always)]
+    pub(crate) fn observe_finite(&mut self) {
+        self.seen += 1;
+    }
+
+    /// Complete a one-pass f64 materialization whose decode loop reduced
+    /// raw non-finite markers without branching. The valid path never
+    /// traverses the materialized tensor again; only an already-invalid
+    /// input is scanned to recover its first offending index for diagnostics.
+    #[inline]
+    pub(crate) fn finish_f64_materialization(
+        self,
+        values: &[f64],
+        has_non_finite: bool,
+    ) -> Result<(), InferenceError> {
+        if has_non_finite
+            && let Some((index, &value)) = values
+                .iter()
+                .enumerate()
+                .find(|(_, value)| !value.is_finite())
+        {
+            return Err(self.reject_non_finite_at(index, value));
+        }
+        Ok(())
+    }
+
+    /// Confirm the decoder observed exactly the declared element count.
+    #[inline]
+    pub(crate) fn finish(self) -> Result<(), InferenceError> {
+        if self.seen != self.numel {
+            return Err(self.error_kind.error(format!(
+                "{}: tensor {} ({}) decoder observed {} elements, expected {} for shape {:?}",
+                self.source, self.tensor_name, self.dtype_label, self.seen, self.numel, self.shape,
+            )));
+        }
+        Ok(())
+    }
+}
+
 impl<'a> IngestedTensor<'a> {
     /// Wrap an already f32-widened tensor slice for validation.
     pub(crate) fn decoded_f32(

--- a/crates/inference/src/weights/mod.rs
+++ b/crates/inference/src/weights/mod.rs
@@ -1,4 +1,5 @@
 //! Weight module index for f16, f32, q3, q4, and q8 weights, with f32 weight re-exports.
+pub(crate) mod f16_encode;
 pub mod f16_weights;
 pub mod f32_weights;
 pub(crate) mod half_bits;

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -124,6 +124,11 @@ pub(crate) fn q4_f32_to_f16(x: f32) -> u16 {
     crate::weights::half_bits::f32_to_f16_bits(x)
 }
 
+#[inline]
+pub(crate) fn q4_f32_to_finite_f16(x: f32) -> Result<u16, u16> {
+    crate::weights::half_bits::f32_to_finite_f16_bits(x)
+}
+
 /// Convert an IEEE-754 f16 bit pattern (`u16`) back to `f32`.
 #[inline]
 pub(crate) fn q4_f16_to_f32(bits: u16) -> f32 {


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- reject NaN and either infinity while the QuaRot reader widens F32, F16, or BF16 source tensors to f64
- use the consolidated half-bit converters and reject non-finite or overflowed F16 encodings before either offline quantizer creates a completed tensor artifact
- preserve one-tensor-at-a-time memory use and validate each source element during the same 16-lane decode traversal
- add reader, converter, and CLI regressions for provenance, signed zero/subnormals, source non-finites, narrowing overflow, and fail-closed publication

This draft is stacked on #1190 because it consumes the shared SafeTensors layout contract introduced there.

## Defect and design

`QuarotTensorReader::read_tensor_f64` validated header layout but widened payload values without enforcing the finite-value ingress contract. The offline QuaRot and Q4 conversion paths could therefore accept source NaN/Inf, and their F16 writers did not reject a finite source value that overflowed during f64→f32→f16 narrowing.

The reader now decodes and reduces raw exponent markers in one unrolled 16-lane traversal through the consolidated half-bit helpers. Independent marker lanes preserve release-mode throughput without a second source or materialized-tensor pass. Only an invalid tensor is searched afterward for its first offending index so the error retains source path, tensor name, dtype, shape, and index attribution.

Both F16 output paths compile the same private `f16_encode.rs` conversion/finite-validation source and finish payload validation before creating the tensor file. The existing per-tensor streaming bound is unchanged, and a failure may still leave earlier independently valid tensor files as documented by the issue; it cannot publish the tensor that failed validation or the final quantization index.

No default public API, `QuarotTensorReader`, shard, or CLI argument signature changes.

## Mutation evidence

- bypassing the reader's reduced non-finite marker made `read_tensor_f64_rejects_non_finite_values_for_every_supported_dtype` fail because `[1.0, NaN]` returned `Ok`
- making the shared finite-F16 encoder accept every bit pattern made the converter's output test return `Ok(30)` and made the standalone CLI publish both an overflowed F16 file and its final index

Each mutation was reverted before the final validation run.

## Sibling-path sweep

- single-file and sharded QuaRot readers both converge on `read_tensor_f64`
- F32, F16, and BF16 decoding all use the same provenance/shape validator and cover NaN, positive infinity, and negative infinity
- raw-bit fixtures preserve positive zero, negative zero, and each source dtype's smallest subnormal independently across F32, F16, and BF16
- the standalone Q4 CLI reads both quantized matrices and kept F16 tensors through the validated reader; its kept-tensor writer also rejects F16 overflow before file creation
- the CLI publication fixture writes an earlier valid tensor, then rejects a later invalid tensor while retaining the valid artifact, omitting the invalid artifact, and withholding the final index
- the offline QuaRot converter's Q4 path retains its existing finite-checking quantizer, while its KHF1 path now validates the actual encoded F16 payload before file creation
- plain SafeTensors runtime loading remains on the ingress seam from #800/#1190 and is unchanged by this stacked patch

## Validation

- exact-head Mini gate: `LATTICE_GEMMA4_GATE_SKIP=1 CARGO_TARGET_DIR=/Users/leo/lattice-ci/target cargo test --workspace --quiet` — passed
- `cargo test -p lattice-inference quant::quarot::io::tests --lib` — 62 passed
- `cargo test -p lattice-inference quant::quarot::convert::tests --lib` — 43 passed
- `cargo test -p lattice-inference --bin quantize_q4` — 11 passed
- `cargo clippy -p lattice-inference --lib --bin quantize_q4 -- -D warnings`
- repository pre-commit checks — formatting, workspace all-target Clippy, documentation lint, and capability-matrix fixture check passed
- merge-tree check with draft #1183, which also edits `quant/quarot/convert.rs` — clean

## bench-compare disposition

`make bench-compare` was not run because this changes offline model ingestion and serialization rather than a timed inference or embedding kernel. A release-mode targeted A/B decoded 1,048,576 F32 values and quantized the result to Q4 in eight alternating rounds per arm. Four independent median comparisons measured validated/reference ratios of 1.026x, 0.996x, 1.029x, and 1.001x, showing no material regression in the actual offline decode-plus-quantize workload.

Closes #801.
