### PR TITLE
fix(ci): stop documentation changes from requiring the engine parity battery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,6 +691,14 @@ jobs:
       # bench-compare.sh call site, and runs no benchmark.
       - name: bash scripts/ensure-noindex-marker-selftest.sh
         run: bash scripts/ensure-noindex-marker-selftest.sh
+      # e2e-parity's engine/tune change classifier. Same "harness plumbing only"
+      # scope: it extracts the live regexes out of e2e-parity.yml and asserts
+      # their verdicts on fixture path lists, running no parity job. It belongs
+      # in THIS workflow rather than e2e-parity's own, because the classification
+      # it grades is what decides whether e2e-parity's jobs run at all — a test
+      # gated on the decision it is testing cannot observe the false-negative.
+      - name: bash scripts/ci-engine-filter-selftest.sh
+        run: bash scripts/ci-engine-filter-selftest.sh
       - name: python3 tests/test_bench_disposition.py
         run: python3 tests/test_bench_disposition.py -v
       # perf-bench-gate's own fixture self-test. Same "harness plumbing only"

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -89,6 +89,42 @@ jobs:
           CHANGED=$(./scripts/ci-changed-files.sh)
           echo "Changed files:"
           echo "$CHANGED"
+          # Markdown is stripped BEFORE classification, and the reason is that
+          # several alternations below are DIRECTORY PREFIXES rather than file
+          # patterns: tests/fixtures/vision/, crates/embed/tests/wasm/,
+          # crates/inference/tests/fixtures/{quarot_q4_composed_v1,ppl_gate_v1}/,
+          # crates/embed/tests/fixtures/{embed_parity_v1,embed_drift_baseline_v1}/,
+          # .github/actions/provision-qwen35-0-8b/ and crates/*/src/. A prefix
+          # matches ANY file placed under it, so a README inside a fixture
+          # directory classifies a documentation change as an engine change.
+          # That is not hypothetical: PR #1159 touched 50 files, ZERO of them
+          # under crates/*/src, and was classified engine=true by exactly one
+          # path — tests/fixtures/vision/README.md. It then sat BLOCKED behind
+          # the full macOS parity battery (parity, wasm, wasm-simd128, q4+vision,
+          # ppl self-test, metal ratchet) that its diff could not reach.
+          # Safe because documentation carries no compiled behaviour: no test
+          # consumes a .md as data (zero include_str! of any .md across crates/,
+          # against a control confirming include_str! is live in 9 files), and
+          # the only .md under any fixture directory is that vision README,
+          # referenced from comments rather than read.
+          # `|| true` because grep -v exits 1 when a docs-ONLY diff leaves no
+          # lines, which under `set -e` would abort the job instead of correctly
+          # classifying it as no-engine-change.
+          # Both the engine and tune classifiers read $CHANGED below, so this one
+          # reassignment covers both; crates/tune/(src|tests)/ is a directory
+          # prefix with the identical exposure.
+          DOCS_ONLY=$(grep '\.md$' <<<"$CHANGED" || true)
+          CHANGED=$(grep -v '\.md$' <<<"$CHANGED" || true)
+          # Disclose the exclusion. Without this the log prints the FULL changed
+          # list and then reports engine=false, and a reader diagnosing a skipped
+          # gate would see a fixture path in the list with no indication it was
+          # never classified.
+          if [ -n "$DOCS_ONLY" ]; then
+            echo "Excluded from classification (documentation, no compiled behaviour):"
+            echo "$DOCS_ONLY"
+          fi
+          echo "Classified against:"
+          echo "${CHANGED:-(nothing — documentation-only diff)}"
           # here-string, not `echo | grep -q`: -q exits at first match, echo gets
           # SIGPIPE, and under pipefail the pipeline reports 141 → the else branch
           # would silently skip the gate on large diffs (fail-open).

--- a/scripts/ci-engine-filter-selftest.sh
+++ b/scripts/ci-engine-filter-selftest.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Self-test for the engine/tune change classifier in .github/workflows/e2e-parity.yml.
+#
+# WHY THIS EXISTS. Most alternations in the engine filter are DIRECTORY PREFIXES
+# (tests/fixtures/vision/, crates/embed/tests/wasm/, crates/*/src/, ...). A prefix
+# matches any file placed under it, so a README committed inside a fixture
+# directory classifies a documentation change as an engine change and demands the
+# full macOS parity battery. PR #1159 changed 50 files, none under crates/*/src,
+# and was blocked by exactly one path: tests/fixtures/vision/README.md.
+#
+# WHY IT READS THE WORKFLOW instead of restating the regex. A test carrying its own
+# copy of the pattern proves only that the copy behaves; the two drift and nothing
+# complains. This extracts the live regex from the YAML, so editing the gate is what
+# this test grades.
+#
+#   bash scripts/ci-engine-filter-selftest.sh
+set -uo pipefail
+
+WF="$(cd "$(dirname "$0")/.." && pwd)/.github/workflows/e2e-parity.yml"
+[ -r "$WF" ] || { echo "FAIL: cannot read $WF"; exit 1; }
+
+# Extract the two classifier regexes from their `if grep -E '...'` lines. The
+# engine line is identified by an anchor unique to it, the tune line by its own.
+extract_re() {  # $1 = anchor substring unique to the wanted line
+  grep -E "^ *if grep -E '" "$WF" \
+    | grep -F "$1" \
+    | head -1 \
+    | sed -E "s/^ *if grep -E '//; s/' <<<.*$//"
+}
+
+ENGINE_RE="$(extract_re 'crates/(inference|embed)/src/')"
+TUNE_RE="$(extract_re 'crates/tune/')"
+
+# FAIL CLOSED ON EMPTY. An extraction that resolved nothing would make every
+# assertion below pass vacuously (grep against an empty pattern matches all, or
+# the harness silently degrades) and this file would report a green gate while
+# grading nothing at all.
+[ -n "$ENGINE_RE" ] || { echo "FAIL: could not extract the engine regex from $WF"; exit 1; }
+[ -n "$TUNE_RE" ]   || { echo "FAIL: could not extract the tune regex from $WF";   exit 1; }
+
+# Does the workflow strip documentation before classifying? Read from the file
+# rather than assumed, so removing the fix is what flips this.
+STRIPS_DOCS=0
+grep -qF "grep -v '\\.md\$' <<<\"\$CHANGED\"" "$WF" && STRIPS_DOCS=1
+
+classify() {  # $1 = regex, stdin = newline-separated paths -> prints true|false
+  local re="$1" changed
+  changed="$(cat)"
+  if [ "$STRIPS_DOCS" -eq 1 ]; then
+    changed="$(grep -v '\.md$' <<<"$changed" || true)"
+  fi
+  if grep -E "$re" <<<"$changed" >/dev/null; then echo true; else echo false; fi
+}
+
+FAILED=0
+check() {  # $1 = label, $2 = expected, $3 = actual
+  if [ "$2" = "$3" ]; then
+    printf 'ok    %-58s %s\n' "$1" "$3"
+  else
+    printf 'FAIL  %-58s expected=%s actual=%s\n' "$1" "$2" "$3"
+    FAILED=1
+  fi
+}
+
+# ── the regression this file exists for ──────────────────────────────────────
+# A README inside a fixture directory must NOT demand the parity battery.
+check "vision fixture README alone -> engine" false \
+  "$(classify "$ENGINE_RE" <<<'tests/fixtures/vision/README.md')"
+
+# The real #1159 shape: docs across the tree, plus that README.
+check "docs-only diff (#1159 shape) -> engine" false \
+  "$(classify "$ENGINE_RE" <<<'README.md
+docs/adr/ADR-064-ci-gate-taxonomy.md
+crates/inference/README.md
+crates/inference/METAL_TRACE.md
+tests/fixtures/vision/README.md')"
+
+# ── positive controls: the gate must still fire on real engine surface ───────
+# Without these, deleting the whole regex would make this file pass.
+check "inference source -> engine" true \
+  "$(classify "$ENGINE_RE" <<<'crates/inference/src/rope.rs')"
+check "embed source -> engine" true \
+  "$(classify "$ENGINE_RE" <<<'crates/embed/src/simd/mod.rs')"
+check "Cargo.lock -> engine" true \
+  "$(classify "$ENGINE_RE" <<<'Cargo.lock')"
+
+# ── the over-exclusion guard ────────────────────────────────────────────────
+# Stripping .md must not stop fixture DATA under the same directory from firing.
+check "vision fixture DATA -> engine" true \
+  "$(classify "$ENGINE_RE" <<<'tests/fixtures/vision/goldens_s3a.json')"
+check "ppl fixture DATA -> engine" true \
+  "$(classify "$ENGINE_RE" <<<'crates/inference/tests/fixtures/ppl_gate_v1/golden.json')"
+
+# ── mixed diff: docs must not mask a real engine change ─────────────────────
+check "docs + engine source -> engine" true \
+  "$(classify "$ENGINE_RE" <<<'tests/fixtures/vision/README.md
+crates/inference/src/rope.rs')"
+
+# ── tune classifier carries the identical directory-prefix exposure ──────────
+check "tune tests README alone -> tune" false \
+  "$(classify "$TUNE_RE" <<<'crates/tune/tests/README.md')"
+check "tune source -> tune" true \
+  "$(classify "$TUNE_RE" <<<'crates/tune/src/lora.rs')"
+
+if [ "$FAILED" -eq 0 ]; then
+  echo "PASS: engine/tune change classifier behaves as specified"
+else
+  echo "FAILURES above"
+fi
+exit "$FAILED"


### PR DESCRIPTION
## Problem

The `engine` and `tune` change classifiers in `e2e-parity.yml` are built largely from
**directory prefixes** rather than file patterns:

```
crates/(inference|embed)/src/
crates/tune/(src|tests)/
tests/fixtures/vision/
crates/embed/tests/wasm/
crates/inference/tests/fixtures/{quarot_q4_composed_v1,ppl_gate_v1}/
crates/embed/tests/fixtures/{embed_parity_v1,embed_drift_baseline_v1}/
.github/actions/provision-qwen35-0-8b/
```

A prefix matches every file beneath it, so a README committed inside a fixture
directory classifies a documentation change as an engine change.

#1159 changed 50 files, **none** under `crates/*/src`, and was classified
`engine=true` by exactly one path: `tests/fixtures/vision/README.md`. Its run
reported `engine=true ... parity=failure`, and it sat `BLOCKED` pending parity,
wasm, wasm-simd128, q4+vision, the ppl self-test and the metal ratchet, none of
which its diff can reach. That is macOS runner time spent on a diff with no
compiled surface, and a merge blocked on a gate that cannot be informative
about it.

## Fix

Strip markdown before classifying. Both classifiers read the same variable, so
one reassignment covers `engine` and `tune` alike.

Safe because documentation carries no compiled behaviour, checked rather than
assumed: there are zero `include_str!` of any `.md` across `crates/` (against a
control confirming `include_str!` is live in 9 files), and the only `.md` under
any fixture directory is that vision README, referenced from comments rather
than read as data.

The excluded paths are printed. Without that the log would show the full changed
list and then report `engine=false`, and anyone diagnosing a skipped gate would
see a fixture path in the list with no indication it was never classified.

## Test

`scripts/ci-engine-filter-selftest.sh`, wired into `ci.yml` beside the other
harness-plumbing self-tests. It runs no parity job.

It **extracts the live regexes out of the workflow** instead of restating them,
so editing the gate is what it grades; a test carrying its own copy proves only
that the copy behaves. It fails closed if extraction resolves nothing, so a
broken extractor cannot report a green gate while grading nothing.

Assertions: the regression itself; positive controls that keep the gate firing
on real engine surface (`crates/inference/src/`, `crates/embed/src/`,
`Cargo.lock`); an over-exclusion guard proving fixture **data** under the same
directories still triggers; a mixed diff proving docs cannot mask a real engine
change; and the same pair for `tune`.

Mutation-verified: removing the strip line fails three assertions
(vision README, the #1159 shape, and the `tune` README), while the six controls
stay green.

## Scope

No files under `crates/*/src` or `crates/embed/src`, so ADR-058's bench-compare
disposition does not apply. `actionlint` and `shellcheck` clean on all changed
files.
