### PR TITLE
fix(inference): reject non-RGB vision in_channels at config parse time

### DIFF
--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -3369,7 +3369,7 @@ mod tests {
             out_hidden_size: cfg.hidden_size,
             temporal_patch_size: 1,
             num_position_embeddings: 1,
-            in_channels: 1,
+            in_channels: 3,
             deepstack_visual_indexes: vec![],
             intermediate_size: None,
         });

--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -602,10 +602,25 @@ impl VisionModelConfig {
                 self.num_position_embeddings
             )));
         }
-        if self.in_channels == 0 {
-            return Err(InferenceError::Inference(
-                "invalid vision_config: in_channels must be > 0".to_string(),
-            ));
+        // The preprocessor (`vision::qwen35_vit::preprocess_qwen35_image`) is RGB-only by
+        // construction: it decodes every image to a fixed 3-channel `RgbImage` and then
+        // indexes `pixel[c]` for `c in 0..in_channels`. A shape-consistent checkpoint
+        // declaring `in_channels >= 4` otherwise passes this validation and panics the sole
+        // Metal worker on the first ordinary image request, because `pixel[3]` is out of
+        // bounds for a 3-element `Rgb<u8>`. Fail closed here instead of silently truncating
+        // or padding channels.
+        //
+        // This is a dimension (B) semantic-validity bound and it subsumes both the
+        // `in_channels == 0` and the `in_channels > MAX_VISION_IN_CHANNELS` dimension (A)
+        // allocation bounds on the parse path. The (A) bound below is kept deliberately: it
+        // states the allocation limit independently, so relaxing this check for a future
+        // non-RGB preprocessor cannot silently uncap the allocation.
+        if self.in_channels != 3 {
+            return Err(InferenceError::Inference(format!(
+                "invalid vision_config: in_channels must be 3 (RGB); got {} -- the image \
+                 preprocessor is RGB-only and cannot serve any other channel count",
+                self.in_channels
+            )));
         }
         if self.in_channels > MAX_VISION_IN_CHANNELS {
             return Err(InferenceError::Inference(format!(
@@ -5009,7 +5024,9 @@ mod tests {
         // num_heads itself does not feed any `checked_derived_sizes` product (only
         // hidden_size % num_heads == 0 is checked), so it stays accepted at its own cap as
         // long as hidden_size (here set to a realistic divisible value, not also maxed) keeps
-        // every derived tensor under MAX_VISION_TENSOR_BYTES.
+        // every derived tensor under MAX_VISION_TENSOR_BYTES. `in_channels` is 3 because the
+        // preprocessor is RGB-only and every other value is now rejected outright; this test's
+        // subject is `num_heads`, so the channel count is held at the one servable value.
         let json = config_json_with_vision(&format!(
             r#"{{
                 "depth": 4,
@@ -5020,7 +5037,7 @@ mod tests {
                 "out_hidden_size": 1024,
                 "temporal_patch_size": 1,
                 "num_position_embeddings": 2304,
-                "in_channels": 1
+                "in_channels": 3
             }}"#
         ));
         assert!(
@@ -5551,6 +5568,12 @@ mod tests {
         );
     }
 
+    /// Both `in_channels` boundary cases land on the RGB-only semantic bound rather than the
+    /// `MAX_VISION_IN_CHANNELS` allocation bound, because `preprocess_qwen35_image` indexes a
+    /// fixed 3-element `Rgb<u8>` and any other channel count panics the worker on the first
+    /// image. The allocation constant is still exercised here so the two bounds cannot drift
+    /// apart unnoticed: a value at the allocation limit must be rejected too, and rejected by
+    /// the semantic guard.
     #[test]
     fn parser_rejects_present_vision_config_with_in_channels_over_max() {
         let json = config_json_with_vision(&format!(
@@ -5571,13 +5594,13 @@ mod tests {
             .expect_err("in_channels above MAX_VISION_IN_CHANNELS must be rejected")
             .to_string();
         assert!(
-            err.contains("in_channels") && err.contains("MAX_VISION_IN_CHANNELS"),
+            err.contains("in_channels must be 3"),
             "wrong guard fired: {err}"
         );
     }
 
     #[test]
-    fn parser_accepts_present_vision_config_with_in_channels_at_max() {
+    fn parser_rejects_present_vision_config_with_in_channels_at_max() {
         let json = config_json_with_vision(&format!(
             r#"{{
                 "depth": 4,
@@ -5591,9 +5614,92 @@ mod tests {
                 "in_channels": {MAX_VISION_IN_CHANNELS}
             }}"#
         ));
+        let err = Qwen35Config::from_config_json_str(&json)
+            .expect_err("in_channels == MAX_VISION_IN_CHANNELS is not RGB and must be rejected")
+            .to_string();
         assert!(
-            Qwen35Config::from_config_json_str(&json).is_ok(),
-            "in_channels == MAX_VISION_IN_CHANNELS must be accepted"
+            err.contains("in_channels must be 3"),
+            "wrong guard fired: {err}"
+        );
+    }
+
+    /// The channel count the preprocessor can actually serve. Without this positive case the
+    /// rejection tests above are satisfied by a validator that rejects every `in_channels`.
+    #[test]
+    fn parser_accepts_present_vision_config_with_in_channels_three() {
+        let json = config_json_with_vision(
+            r#"{
+                "depth": 4,
+                "hidden_size": 768,
+                "num_heads": 12,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "out_hidden_size": 1024,
+                "temporal_patch_size": 2,
+                "num_position_embeddings": 2304,
+                "in_channels": 3
+            }"#,
+        );
+        let cfg = Qwen35Config::from_config_json_str(&json)
+            .expect("in_channels: 3 vision_config must parse");
+        assert_eq!(
+            cfg.vision_config
+                .expect("vision_config present")
+                .in_channels,
+            3
+        );
+    }
+
+    /// The panic this guard exists to prevent, pinned at the boundary that matters:
+    /// `in_channels: 4` is shape-consistent everywhere else, so before this validation it
+    /// parsed cleanly and failed only when a request reached `pixel[3]`.
+    #[test]
+    fn parser_rejects_present_vision_config_with_in_channels_four() {
+        let json = config_json_with_vision(
+            r#"{
+                "depth": 4,
+                "hidden_size": 768,
+                "num_heads": 12,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "out_hidden_size": 1024,
+                "temporal_patch_size": 2,
+                "num_position_embeddings": 2304,
+                "in_channels": 4
+            }"#,
+        );
+        let err = Qwen35Config::from_config_json_str(&json)
+            .expect_err("in_channels: 4 vision_config must be rejected at parse time")
+            .to_string();
+        assert!(
+            err.contains("in_channels must be 3"),
+            "wrong guard fired: {err}"
+        );
+    }
+
+    /// `in_channels: 0` was previously rejected by its own `> 0` check; the RGB bound subsumes
+    /// it, and this pins that the zero case is still refused rather than falling through.
+    #[test]
+    fn parser_rejects_present_vision_config_with_in_channels_zero() {
+        let json = config_json_with_vision(
+            r#"{
+                "depth": 4,
+                "hidden_size": 768,
+                "num_heads": 12,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "out_hidden_size": 1024,
+                "temporal_patch_size": 2,
+                "num_position_embeddings": 2304,
+                "in_channels": 0
+            }"#,
+        );
+        let err = Qwen35Config::from_config_json_str(&json)
+            .expect_err("in_channels: 0 vision_config must be rejected at parse time")
+            .to_string();
+        assert!(
+            err.contains("in_channels must be 3"),
+            "wrong guard fired: {err}"
         );
     }
 

--- a/crates/inference/src/model/qwen35_config.rs
+++ b/crates/inference/src/model/qwen35_config.rs
@@ -5650,57 +5650,52 @@ mod tests {
         );
     }
 
-    /// The panic this guard exists to prevent, pinned at the boundary that matters:
-    /// `in_channels: 4` is shape-consistent everywhere else, so before this validation it
-    /// parsed cleanly and failed only when a request reached `pixel[3]`.
+    /// Every rejected value on both sides of 3, so the guard is pinned as an equality rather
+    /// than as a one-sided bound.
+    ///
+    /// The cases matter individually. `4` is the panic this guard exists to prevent: it is
+    /// shape-consistent everywhere else, so before this validation it parsed cleanly and
+    /// failed only when a request reached `pixel[3]`. `0` was previously rejected by its own
+    /// `> 0` check, which the RGB bound subsumes, so it pins that the zero case is still
+    /// refused rather than falling through. `1` and `2` are the interior values that panic
+    /// nothing and are therefore the easiest to lose: `pixel[0]` and `pixel[1]` are in bounds
+    /// for a 3-element `Rgb<u8>`, so an under-wide `in_channels` silently produces a
+    /// channel-truncated tensor that disagrees with the checkpoint's `patch_embed` weights
+    /// instead of failing loudly.
+    ///
+    /// Without `1` and `2` the suite is not mutation-sensitive: rewriting the predicate as
+    /// `self.in_channels == 0 || self.in_channels > 3` passes every other case in this file
+    /// while letting both slip through. That mutation was executed against this tree, not
+    /// reasoned about — it passed 5/5 before these cases existed.
     #[test]
-    fn parser_rejects_present_vision_config_with_in_channels_four() {
-        let json = config_json_with_vision(
-            r#"{
-                "depth": 4,
-                "hidden_size": 768,
-                "num_heads": 12,
-                "patch_size": 16,
-                "spatial_merge_size": 2,
-                "out_hidden_size": 1024,
-                "temporal_patch_size": 2,
-                "num_position_embeddings": 2304,
-                "in_channels": 4
-            }"#,
-        );
-        let err = Qwen35Config::from_config_json_str(&json)
-            .expect_err("in_channels: 4 vision_config must be rejected at parse time")
-            .to_string();
-        assert!(
-            err.contains("in_channels must be 3"),
-            "wrong guard fired: {err}"
-        );
-    }
-
-    /// `in_channels: 0` was previously rejected by its own `> 0` check; the RGB bound subsumes
-    /// it, and this pins that the zero case is still refused rather than falling through.
-    #[test]
-    fn parser_rejects_present_vision_config_with_in_channels_zero() {
-        let json = config_json_with_vision(
-            r#"{
-                "depth": 4,
-                "hidden_size": 768,
-                "num_heads": 12,
-                "patch_size": 16,
-                "spatial_merge_size": 2,
-                "out_hidden_size": 1024,
-                "temporal_patch_size": 2,
-                "num_position_embeddings": 2304,
-                "in_channels": 0
-            }"#,
-        );
-        let err = Qwen35Config::from_config_json_str(&json)
-            .expect_err("in_channels: 0 vision_config must be rejected at parse time")
-            .to_string();
-        assert!(
-            err.contains("in_channels must be 3"),
-            "wrong guard fired: {err}"
-        );
+    fn parser_rejects_present_vision_config_with_any_in_channels_but_three() {
+        for in_channels in [0_usize, 1, 2, 4] {
+            let json = config_json_with_vision(&format!(
+                r#"{{
+                    "depth": 4,
+                    "hidden_size": 768,
+                    "num_heads": 12,
+                    "patch_size": 16,
+                    "spatial_merge_size": 2,
+                    "out_hidden_size": 1024,
+                    "temporal_patch_size": 2,
+                    "num_position_embeddings": 2304,
+                    "in_channels": {in_channels}
+                }}"#
+            ));
+            let err = match Qwen35Config::from_config_json_str(&json) {
+                Ok(_) => {
+                    panic!(
+                        "in_channels: {in_channels} vision_config must be rejected at parse time"
+                    )
+                }
+                Err(e) => e.to_string(),
+            };
+            assert!(
+                err.contains("in_channels must be 3"),
+                "in_channels: {in_channels} -- wrong guard fired: {err}"
+            );
+        }
     }
 
     // ── CLASS A2: aggregate GDN session-buffer budget ───────────────────────────────

--- a/crates/inference/src/vision/checkpoint.rs
+++ b/crates/inference/src/vision/checkpoint.rs
@@ -725,7 +725,7 @@ mod tests {
             out_hidden_size: 4,
             temporal_patch_size: 1,
             num_position_embeddings: 4,
-            in_channels: 1,
+            in_channels: 3,
             deepstack_visual_indexes: vec![],
             intermediate_size: None,
         }
@@ -742,8 +742,9 @@ mod tests {
         let out_hidden = 4;
         let mut v = vec![
             (
+                // [hidden, in_channels, temporal_patch_size, patch_size, patch_size]
                 "model.visual.patch_embed.proj.weight".to_string(),
-                vec![hidden, 1, 1, 2, 2],
+                vec![hidden, 3, 1, 2, 2],
             ),
             (
                 "model.visual.patch_embed.proj.bias".to_string(),

--- a/crates/inference/src/vision/pooled_embed.rs
+++ b/crates/inference/src/vision/pooled_embed.rs
@@ -142,7 +142,7 @@ mod tests {
             out_hidden_size: 8, // must equal decoder hidden_size below
             temporal_patch_size: 1,
             num_position_embeddings: 16,
-            in_channels: 1,
+            in_channels: 3,
             deepstack_visual_indexes: vec![],
             intermediate_size: None,
         }

--- a/crates/inference/src/vision/qwen35_merger.rs
+++ b/crates/inference/src/vision/qwen35_merger.rs
@@ -163,7 +163,7 @@ mod tests {
             out_hidden_size: 6,
             temporal_patch_size: 1,
             num_position_embeddings: 16,
-            in_channels: 1,
+            in_channels: 3,
             deepstack_visual_indexes: vec![],
             intermediate_size: None,
         }

--- a/crates/inference/src/vision/qwen35_vit.rs
+++ b/crates/inference/src/vision/qwen35_vit.rs
@@ -509,7 +509,7 @@ mod tests {
             out_hidden_size: 8,
             temporal_patch_size: 1,
             num_position_embeddings: 16, // side = 4
-            in_channels: 1,
+            in_channels: 3,
             deepstack_visual_indexes: vec![],
             intermediate_size: None,
         }

--- a/crates/inference/src/vision/qwen35_vit_metal.rs
+++ b/crates/inference/src/vision/qwen35_vit_metal.rs
@@ -350,7 +350,7 @@ mod tests {
             out_hidden_size: 8,
             temporal_patch_size: 1,
             num_position_embeddings: 16,
-            in_channels: 1,
+            in_channels: 3,
             deepstack_visual_indexes: vec![],
             intermediate_size: None,
         }


### PR DESCRIPTION
## What this changes

`VisionModelConfig::validate` accepted any `in_channels` from 1 to `MAX_VISION_IN_CHANNELS`
(256). The image preprocessor is RGB-only: it reads pixel channels out of a 3-element
`Rgb<u8>` returned by `image::RgbImage::get_pixel`.

```rust
// crates/inference/src/vision/qwen35_vit.rs
for c in 0..in_channels {
    let pixel = rgb.get_pixel((px + dx) as u32, (py + dy) as u32);
    let raw = pixel[c] as f32 / 255.0;
```

So a config declaring `in_channels: 4` parses successfully and then panics with an index
out of bounds on the first image the vision tower sees. The validation now rejects
anything but 3 at parse time, with a message naming the reason.

`MAX_VISION_IN_CHANNELS` is deliberately kept. It bounds an allocation-driving field
against a hostile config and answers a different question than semantic validity: the
constant asks "could this number make us allocate absurdly", the new check asks "can the
preprocessor actually serve this number". Removing the bound because a stricter check now
subsumes it would drop the allocation guard if the stricter check is ever relaxed.

Six test fixtures carried `in_channels: 1` and were updated to 3. One of them,
`tiny_expected_shapes()` in `vision/checkpoint.rs`, derives the patch-embed tensor shape
independently of production code, so the fixture change did not propagate to it
automatically — its shape literal is corrected in the same commit and the comment now
names the dimension order.

The boundary tests changed shape with the contract they test:
`parser_accepts_present_vision_config_at_max_in_channels` becomes a rejection test,
`parser_rejects_present_vision_config_with_in_channels_over_max` now asserts on the new
message, an acceptance case for 3 was added, and one table-driven case rejects `0`, `1`,
`2` and `4`. Each rejection asserts the specific message rather than merely that an error
occurred, so a different guard firing for a different reason fails the test instead of
passing it.

## bench-compare disposition

`make bench-compare`, quick mode, base `94c473d7bd` (origin/main) vs head `d84aed0cf8`,
no filters, 253 measurements.

The structural compiled-out exception does not apply here and was not claimed: the changed
production code is in `crates/inference/src/model/`, is behind no `cfg` gate, and is
compiled into the inference bench binary. So the A/B was run.

**Run conditions**

```
resolution: --quick
targets: lattice-inference:elementwise_cpu_bench, lattice-embed:simd
inference features: <none>
filters: inference='<all>' embed='<all>'
enforcement: report-only (gate status printed, exit 0)
locks: bench-window acquired immediately (uncontended)
       Metal GPU  acquired immediately (uncontended)
       heavy lane held exclusively (all 3 slots)
ambient load: [quiet] before base    idle 88.3% (floor 70.0%) ok
              [quiet] between phases idle 77.5% (floor 70.0%) ok
              [quiet] after head     idle 87.0% (floor 70.0%) ok
```

`BENCH_IDLE_FLOOR` left at its default and not lowered at any point.

**Prediction registered before the run, in the runner script:** `VisionModelConfig::validate`
is a config-parse function on no bench path, so the expectation was no separable change on
any group. That is what the run shows, and the report carries its own control for saying so.

**The report is half control.** `crates/embed` is untouched by this diff — zero files, so
the embed arm is byte-identical source benched twice on the same machine in the same run.
Those 246 informational rows are therefore an in-run A/A control, and they span **+16.95%
to −7.77%**:

| Benchmark (identical source) | Δ | 95% CI |
|---|---:|---|
| `simd_normalized_cosine_fast_path/cosine_full/384` | +16.95% | [+13.31%, +20.80%] |
| `simd_throughput_384/cosine_similarity` | +16.48% | [+14.58%, +18.41%] |
| `simd_query_batch_dot_product/pair_loop/768d_256c` | +10.51% | [+7.97%, +13.10%] |
| `simd_throughput_384/normalize` | −7.77% | [−9.60%, −5.88%] |

That is wider than the standalone A/A control measured on this lane earlier (+14.28% max),
and it was produced by this very run rather than borrowed from another one.

**The seven gated rows are all on code this diff cannot reach**, FAIL and WIN alike.
`elementwise_cpu_bench` benches `rms_norm`, `layer_norm`, `silu`, `gelu`, `add_bias_gelu`,
`elementwise_mul`, `softmax_attention` and `residual_add_layer_norm`; it constructs no
`VisionModelConfig` and names no vision symbol (checked with a positive control on the same
invocation — the file does contain `gelu`, so the search was working when it found no
vision reference).

| Benchmark (unreachable from the diff) | Δ | 95% CI | gate verdict |
|---|---:|---|---|
| `gelu/896` | +10.25% | [+8.86%, +11.67%] | FAIL |
| `layer_norm/4096` | −4.89% | [−7.13%, −2.63%] | WIN |
| `silu_inplace/896` | −4.47% | [−7.45%, −1.39%] | WIN |
| `softmax_attention/128` | −3.91% | [−5.99%, −1.74%] | WIN |
| `residual_add_layer_norm/unfused/hidden384_seq128` | −3.70% | [−5.77%, −1.59%] | WIN |
| `gelu/4096` | −3.59% | [−5.85%, −1.23%] | WIN |
| `elementwise_mul/4096` | −3.38% | [−6.32%, −0.31%] | WIN |

`gelu/896` at +10.25% and `gelu/4096` at −3.59% are the same kernel moving in opposite
directions in the same run, which is what a lane-noise row looks like and is not what a
regression looks like. Both sit inside the ±17% band the identical-source half of this same
report just established. Six "confirmed improvements" on code that did not change is the
disposition for the FAIL as much as for the wins: **no row in this report is attributed to
this diff, in either direction.**

One mechanism is worth naming rather than leaving implicit. Because `qwen35_config.rs` is
in `lattice-inference`, the crate is genuinely rebuilt between arms, so code layout can
shift for functions the diff never touches. That is a real effect distinct from machine
noise, and it is also not a property of the change's semantics — `validate` runs once at
model load and never during decode.

`--full` was deliberately not run. More samples narrow a within-run dispersion estimate and
do nothing about between-arm bias, so a longer A/B would report a tighter interval around
the same unattributable numbers. The in-run A/A control is the instrument that answers the
question; the exit code is not, since enforcement was report-only.

### Addendum at head `14f0e00320`

The head moved after the A/B above to replace two single-value parser tests with one
table-driven case covering `0`, `1`, `2` and `4`. `1` and `2` were the unpinned values:
they panic nothing, because `pixel[0]` and `pixel[1]` are in bounds for a 3-element
`Rgb<u8>`, so an under-wide `in_channels` silently produces a channel-truncated tensor
that disagrees with the checkpoint's `patch_embed` weights instead of failing.

Without them the suite was not mutation-sensitive. Executed rather than argued: rewriting
the predicate as `self.in_channels == 0 || self.in_channels > 3` passed 5/5 before the
change and fails at `in_channels: 1` after it, and the tree was diffed back to pristine
after each mutation. The narrower `> 3` mutation was already caught by the zero case.

That delta does not get its own A/B, and this is the narrow structural case rather than a
waiver: every changed line sits inside the `#[cfg(test)]` module, which is compiled out of
`cargo bench` builds entirely, so the base and head bench binaries have identical effective
source across it. The A/B above still describes the production diff, which is unchanged.
