### PR TITLE
fix(inference): handle grammar masking errors in tests

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -35015,7 +35015,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 "epsilon grammar must start complete with no legal continuation"
             );
             let mut logits = vec![0.0; 32];
-            engine.mask_logits(&mut grammar_state, &mut logits);
+            engine
+                .mask_logits(&mut grammar_state, &mut logits)
+                .expect("local epsilon engine and full vocabulary logits must mask");
             assert!(
                 !crate::forward::metal_qwen35::has_finite_logit(&logits),
                 "terminal epsilon grammar must mask every continuation"

--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -875,7 +875,9 @@ mod tests {
 
         let mut logits = vec![0.0];
         enable_mask_profiling();
-        engine.mask_logits(&mut state, &mut logits);
+        engine
+            .mask_logits(&mut state, &mut logits)
+            .expect("locally constructed engine and matching logits length must mask");
         let profile = take_mask_profile();
         assert_eq!(logits, vec![f32::NEG_INFINITY]);
         assert_eq!(profile.precomputed_calls, 1);
@@ -894,7 +896,9 @@ mod tests {
 
         let mut logits = vec![0.0];
         enable_mask_profiling();
-        engine.mask_logits(&mut state, &mut logits);
+        engine
+            .mask_logits(&mut state, &mut logits)
+            .expect("locally constructed engine and matching logits length must mask");
         let profile = take_mask_profile();
         assert_eq!(logits, vec![0.0]);
         assert_eq!(profile.precomputed_calls, 1);


### PR DESCRIPTION
`GrammarEngine::mask_logits` returns a `Result`. Three call sites in test code
ignored it, so `-D warnings` fails the `lattice-inference` lib-test target and
the macOS metal-gpu clippy step does not compile.

Each site now handles the result with `.expect(...)` naming why an error is
impossible there. `let _ = ...` would be wrong: all three tests exist to assert
that masking happened — the two `nullable_initial_state_*` tests assert the
resulting logits, and the epsilon-grammar test asserts every continuation was
masked — so discarding an `Err` would let a masking failure pass silently in the
code written to catch it.

Completeness: 28 executable `mask_logits` call sites exist in `crates/`; 3
needed a change. Verified by compilation rather than by reading, across default,
`f16`, `metal-gpu`, and `f16,metal-gpu` feature sets.

`cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings`
— the exact failing step at `.github/workflows/ci.yml:300` — passes.
`cargo test -p lattice-inference nullable_initial_state_` runs 2 tests, both
pass. The three tests sharing the changed Metal fixture need a Metal device and
were not run; no claim is made about their runtime behaviour.

## bench-compare disposition

Structural exception (ADR-058). All three changed lines are `#[cfg(test)]`-gated,
which the compiler itself attests: every error was reported against the
`lattice-inference (lib test)` target and none against the lib. Criterion bench
binaries are built from the non-test lib with the default bench feature set, so
base and head bench binaries have identical effective source and no A/B can
attribute any delta to this diff.
