### PR TITLE
perf(ci): offload portable parity work to ARM

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -632,10 +632,10 @@ jobs:
   # own f64 forward-equivalence check (quant/quarot/forward_equivalence.rs) gates
   # the rotation-fusion math PRE-quantization; nothing previously exercised the
   # runtime consumer of a QuaRot+Q4 artifact — MetalQwen35State::from_q4_dir
-  # followed by greedy decode. This job regenerates an EPHEMERAL QuaRot+Q4
-  # artifact from the real Qwen3.5-0.8B weights, then asserts exact first-8
-  # greedy token IDs per prompt against the committed frozen lattice-self golden
-  # (crates/inference/tests/fixtures/quarot_q4_composed_v1/).
+  # followed by greedy decode. This workflow regenerates an EPHEMERAL QuaRot+Q4
+  # artifact from the real Qwen3.5-0.8B weights, hands it to macOS, then asserts
+  # exact first-8 greedy token IDs per prompt against the committed frozen
+  # lattice-self golden (crates/inference/tests/fixtures/quarot_q4_composed_v1/).
   #
   # Tolerance is exact token-ID agreement, NOT a logit tolerance: the golden is
   # generated FROM the Q4 artifact, so quantization error is already baked in and
@@ -678,25 +678,189 @@ jobs:
   # to overwrite without --update-golden). Updating it is a reviewable source
   # change that must carry rationale + mutation evidence.
   #
+  # ADR-069 S3a/S4 are portable CPU-reference gates. They used to run inside the
+  # macOS q4 job below even though their command enables only `f16`. Keep the
+  # exact fail-closed invocation and proof markers, but run it concurrently on
+  # hosted ARM Linux, whose runner pool has materially lower queue latency.
+  # S5b deliberately stays on macOS below: its f16 matmul backend is
+  # platform-specific, so Linux ARM would add coverage rather than preserve it.
+  vision-cpu-gates:
+    name: vision S3a + S4 CPU gates (ARM Linux)
+    needs: changes
+    if: needs.changes.outputs.engine == 'true' && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Cache Python packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pip
+          key: vision-cpu-pip-${{ runner.os }}-${{ runner.arch }}-py311-v1
+
+      - name: Cache HF model weights
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
+          key: hf-qwen35-0.8b-${{ hashFiles('.github/actions/provision-qwen35-0-8b/action.yml') }}
+
+      - name: Install Python deps
+        run: pip install "huggingface_hub==1.20.1"
+
+      - name: Provision Qwen3.5-0.8B
+        id: provision
+        uses: ./.github/actions/provision-qwen35-0-8b
+
+      - name: Setup lattice model dir
+        run: |
+          mkdir -p ~/.lattice/models
+          ln -sf "${{ steps.provision.outputs.model-dir }}" ~/.lattice/models/qwen3.5-0.8b
+
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: vision-cpu-gates
+
+      - name: Run S3a + S4 CPU gates (fail-closed)
+        env:
+          LATTICE_VISION_S3_MODEL_DIR: ~/.lattice/models/qwen3.5-0.8b
+          LATTICE_VISION_S3_GATE_ENFORCE: '1'
+        run: |
+          ARCH=$(uname -m)
+          echo "LATTICE_VISION_CPU_RUNNER arch=$ARCH"
+          test "$ARCH" = "aarch64"
+          # Capture to a file, then always print it while preserving cargo's
+          # status. A pipeline would let the reporter mask a gating failure.
+          if cargo test --release -p lattice-inference --features f16 \
+            --test vision_s3_vit_forward_test \
+            --test vision_s4_merger_test -- --nocapture > vision-s3-gate.log 2>&1
+          then
+            cat vision-s3-gate.log
+          else
+            status=$?
+            cat vision-s3-gate.log
+            exit "$status"
+          fi
+          grep -q 'LATTICE_VISION_S3_COSINE' vision-s3-gate.log
+          grep -q 'LATTICE_VISION_S3_MUTATION_COSINE' vision-s3-gate.log
+          grep -q 'LATTICE_VISION_S4_COSINE' vision-s3-gate.log
+          grep -q 'LATTICE_VISION_S4_MUTATION_COSINE' vision-s3-gate.log
+          grep -q 'LATTICE_VISION_S4_E2E_COSINE' vision-s3-gate.log
+          grep -q 'LATTICE_VISION_S4_E2E_MUTATION_COSINE' vision-s3-gate.log
+
+  # The QuaRot converter and its refuse-on-fail forward-equivalence check are
+  # pure f64 CPU work. Generating the 0.62 GB artifact on the macOS runner held
+  # the scarce pool for 14-18 minutes before any Metal assertion ran. Generate
+  # it on hosted ARM Linux, preserve it byte-for-byte in an uncompressed tar,
+  # and checksum the handoff. The macOS job remains the acceptance point: it
+  # loads this exact artifact through the production Metal Q4 path and compares
+  # exact greedy tokens against the frozen golden.
+  quarot-artifact:
+    name: QuaRot Q4 artifact (ARM Linux)
+    needs: changes
+    if: needs.changes.outputs.engine == 'true' && github.event.pull_request.draft != true
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Cache Python packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pip
+          key: quarot-artifact-pip-${{ runner.os }}-${{ runner.arch }}-py311-v1
+
+      - name: Cache HF model weights
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B
+          key: hf-qwen35-0.8b-${{ hashFiles('.github/actions/provision-qwen35-0-8b/action.yml') }}
+
+      - name: Install Python deps
+        run: pip install "huggingface_hub==1.20.1"
+
+      - name: Provision Qwen3.5-0.8B
+        id: provision
+        uses: ./.github/actions/provision-qwen35-0-8b
+
+      - name: Setup lattice model dir
+        run: |
+          mkdir -p ~/.lattice/models
+          ln -sf "${{ steps.provision.outputs.model-dir }}" ~/.lattice/models/qwen3.5-0.8b
+
+      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: quarot-artifact
+
+      - name: Build QuaRot converter
+        run: cargo build --release -p lattice-inference --bin quantize_quarot --features f16
+
+      - name: Generate and verify QuaRot Q4 artifact
+        run: |
+          ARCH=$(uname -m)
+          echo "LATTICE_QUAROT_ARTIFACT_RUNNER arch=$ARCH"
+          test "$ARCH" = "aarch64"
+          if target/release/quantize_quarot \
+            --model-dir ~/.lattice/models/qwen3.5-0.8b \
+            --output-dir "$RUNNER_TEMP/qwen3.5-0.8b-quarot-q4" \
+            --seed 0xCAFE_BABE_DEAD_BEEF \
+            --num-probe-tokens 4 > quarot-convert.log 2>&1
+          then
+            cat quarot-convert.log
+          else
+            status=$?
+            cat quarot-convert.log
+            exit "$status"
+          fi
+          grep -q '^Forward-equiv:' quarot-convert.log
+          test -s "$RUNNER_TEMP/qwen3.5-0.8b-quarot-q4/quantize_index.json"
+          test -s "$RUNNER_TEMP/qwen3.5-0.8b-quarot-q4/config.json"
+          echo "LATTICE_QUAROT_ARTIFACT_READY"
+
+      - name: Package checksummed handoff
+        run: |
+          tar -C "$RUNNER_TEMP/qwen3.5-0.8b-quarot-q4" \
+            -cf "$RUNNER_TEMP/quarot-q4.tar" .
+          (
+            cd "$RUNNER_TEMP"
+            shasum -a 256 quarot-q4.tar > quarot-q4.tar.sha256
+          )
+          test -s "$RUNNER_TEMP/quarot-q4.tar"
+          test -s "$RUNNER_TEMP/quarot-q4.tar.sha256"
+
+      - name: Upload QuaRot handoff
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: quarot-q4-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/quarot-q4.tar
+            ${{ runner.temp }}/quarot-q4.tar.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
   # NOTE: once this job has gone green on CI once, add "q4-composed" to the
   # repository's required status checks alongside embed-drift. That
   # governance step is intentionally not automated here.
-  # FOLDED JOB. q4-composed, vision-s3-gate and q4-ppl-quality were three
-  # separate macOS jobs whose 9-step preambles were byte-identical: checkout,
-  # python, pip cache, HF weight cache, deps, Qwen3.5-0.8B provision, model dir,
-  # toolchain, rust-cache. Each also kept its OWN rust-cache shared-key, so the
-  # same crate was built and cached three separate times. They are one job now:
-  # one model provision, one dep install, one cache, and the crate compiled
-  # twice instead of six times.
+  # FOLDED MAC JOB. q4-composed and q4-ppl-quality retain one macOS model
+  # provision, one dependency install and one cache. Portable S3a/S4 and the
+  # f64 QuaRot conversion run on ARM Linux above; S5b, the composed golden and
+  # the Metal injection/PPL gates remain here because their exercised backends
+  # are macOS-specific.
   #
-  # Twice, not once, and the reason is deliberate: the QuaRot converter is built
-  # f16-only while the other gates need f16,metal-gpu. STEP ORDER IS THEREFORE
-  # LOAD-BEARING -- the f16-only build comes first and the f16,metal-gpu build
-  # adds the feature on top; reversing them makes cargo compile a third time.
-  # The converter's feature set is NOT unified to metal-gpu on purpose. It
-  # produces the ephemeral artifact the frozen golden was generated from, so
-  # changing how it is built could change the artifact and silently move what
-  # the golden proves.
+  # STEP ORDER IS LOAD-BEARING: S5b builds f16 first, then the composed golden
+  # adds metal-gpu. Reversing them makes cargo compile a third feature set.
   #
   # metal-parity is deliberately NOT folded in: it carries a merge_group
   # exclusion the other three do not, and folding it would push that condition
@@ -707,13 +871,29 @@ jobs:
   # the fold would hide every gate after the first red one and an agent would
   # fix them one slow round-trip at a time.
   q4-vision-gates:
-    name: q4 + vision gates
-    needs: changes
+    name: q4 + macOS vision gates
+    needs: [changes, quarot-artifact]
     if: needs.changes.outputs.engine == 'true' && github.event.pull_request.draft != true
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download QuaRot handoff
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: quarot-q4-${{ github.run_id }}
+          path: ${{ runner.temp }}/quarot-handoff
+
+      - name: Verify and extract QuaRot handoff
+        run: |
+          cd "$RUNNER_TEMP/quarot-handoff"
+          shasum -a 256 -c quarot-q4.tar.sha256
+          mkdir -p "$RUNNER_TEMP/qwen3.5-0.8b-quarot-q4"
+          tar -xf quarot-q4.tar -C "$RUNNER_TEMP/qwen3.5-0.8b-quarot-q4"
+          test -s "$RUNNER_TEMP/qwen3.5-0.8b-quarot-q4/quantize_index.json"
+          test -s "$RUNNER_TEMP/qwen3.5-0.8b-quarot-q4/config.json"
+          echo "LATTICE_QUAROT_ARTIFACT_CONSUMED"
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -755,20 +935,25 @@ jobs:
         with:
           shared-key: q4-vision-gates
 
-
-      - name: Build QuaRot converter
-        run: cargo build --release -p lattice-inference --bin quantize_quarot --features f16
-
-      # Regenerate the ephemeral QuaRot+Q4 artifact (NOT committed). The frozen
-      # golden the test asserts against WAS produced from this exact conversion
-      # (same seed), so a green run proves the runtime composed path still matches.
-      - name: Generate ephemeral QuaRot Q4 artifact
+      # Keep S5b on macOS. `generate_multimodal_f16` reaches the Accelerate/AMX
+      # f16 matmul backend here, while Linux aarch64 dispatches to its scalar
+      # fallback; moving it would silently replace existing backend coverage.
+      - name: Run S5b macOS f16 gate (fail-closed)
+        if: ${{ !cancelled() }}
+        env:
+          LATTICE_VISION_S3_MODEL_DIR: ~/.lattice/models/qwen3.5-0.8b
+          LATTICE_VISION_S3_GATE_ENFORCE: '1'
         run: |
-          target/release/quantize_quarot \
-            --model-dir ~/.lattice/models/qwen3.5-0.8b \
-            --output-dir "$RUNNER_TEMP/qwen3.5-0.8b-quarot-q4" \
-            --seed 0xCAFE_BABE_DEAD_BEEF \
-            --num-probe-tokens 4
+          if cargo test --release -p lattice-inference --features f16 \
+            --test vision_s5b_e2e_gate_test -- --nocapture > vision-s5b-gate.log 2>&1
+          then
+            cat vision-s5b-gate.log
+          else
+            status=$?
+            cat vision-s5b-gate.log
+            exit "$status"
+          fi
+          grep -q 'LATTICE_VISION_S5B_GREEDY_TOKENS' vision-s5b-gate.log
 
       - name: Run QuaRot Q4 composed golden gate
         if: ${{ !cancelled() }}
@@ -781,68 +966,6 @@ jobs:
             --test quarot_q4_composed_golden \
             --features "f16,metal-gpu" \
             -- --nocapture
-
-  # ADR-069 S3a + S4 required gate: real Qwen3.5-0.8B ViT forward (CPU
-  # reference) and patch-merger/projection vs the committed HF differential
-  # goldens (cosine > 0.999 each). Closes the gap a static review found: the
-  # checkpoint-gated test only ran locally, never in CI, so a
-  # patch-fold/RoPE/normalization/activation regression could land while
-  # every required check stayed green (skip-as-green gate failure).
-  # LATTICE_VISION_S3_GATE_ENFORCE=1 makes both tests panic (not skip) if the
-  # model dir is missing or invalid — same fail-closed shape as embed-drift
-  # and q4-composed. The gating `cargo test` writes directly to a log file
-  # (no pipeline), so its own non-zero exit aborts the `bash -e` step before
-  # the log is printed; the grep assertions below additionally prove the
-  # real numerical path executed for both stages (not just that the process
-  # exited 0), so a future control-flow change that turns either computation
-  # into an early return cannot silently pass this job.
-  #
-  # S4 shares this job with S3a (same checkpoint, same env, one extra
-  # `--test` binary) rather than a separate job: it reuses the checkpoint
-  # this job already downloads, so a second full checkout+download job would
-  # only add ~2 min of duplicated setup for a step that runs in seconds.
-  #
-  # S3a/S4 are the CPU-reference stages; S3b (Metal port vs the S3a CPU
-  # reference under the GPU lock) is a separate fast-follow gate. S5b
-  # (decoder injection + M-RoPE, `vision_s5b_e2e_gate_test`) shares this same
-  # job/checkpoint/env below rather than a separate job, for the same reason
-  # S4 does.
-  #
-  # NOTE: once this job has gone green on CI once, add "vision-s3-gate" to
-  # the repository's required status checks alongside embed-drift and
-  # q4-composed. That governance step is intentionally not automated here.
-
-      - name: Run S3a + S4 cosine gates (fail-closed)
-        if: ${{ !cancelled() }}
-        env:
-          LATTICE_VISION_S3_MODEL_DIR: ~/.lattice/models/qwen3.5-0.8b
-          LATTICE_VISION_S3_GATE_ENFORCE: '1'
-        run: |
-          # Capture to a file, then always print it — but preserve cargo's exit
-          # status so a test failure fails the step. A `... | tee` pipeline would
-          # NOT work here: this step sets no `shell:`, so it runs under GitHub's
-          # default `bash -e {0}` (no `pipefail`), where the pipeline takes tee's
-          # zero exit and the failure is masked. The old `> file` + bare `cat`
-          # was the opposite bug: `-e` aborted before the `cat`, hiding the
-          # output. This if/else does both — visible output AND fail-closed.
-          if cargo test --release -p lattice-inference --features f16 \
-            --test vision_s3_vit_forward_test \
-            --test vision_s4_merger_test \
-            --test vision_s5b_e2e_gate_test -- --nocapture > vision-s3-gate.log 2>&1
-          then
-            cat vision-s3-gate.log
-          else
-            status=$?
-            cat vision-s3-gate.log
-            exit "$status"
-          fi
-          grep -q 'LATTICE_VISION_S3_COSINE' vision-s3-gate.log
-          grep -q 'LATTICE_VISION_S3_MUTATION_COSINE' vision-s3-gate.log
-          grep -q 'LATTICE_VISION_S4_COSINE' vision-s3-gate.log
-          grep -q 'LATTICE_VISION_S4_MUTATION_COSINE' vision-s3-gate.log
-          grep -q 'LATTICE_VISION_S4_E2E_COSINE' vision-s3-gate.log
-          grep -q 'LATTICE_VISION_S4_E2E_MUTATION_COSINE' vision-s3-gate.log
-          grep -q 'LATTICE_VISION_S5B_GREEDY_TOKENS' vision-s3-gate.log
 
       # MP2+MP3 Metal injection gate: `forward_step_injected_logits_differ_by_row_content`,
       # `generate_multimodal_vision_injection_is_mutation_sensitive`,
@@ -932,7 +1055,7 @@ jobs:
 
   # REQUIRED status check. Always runs, always reports. Passes when the engine
   # did not change (nothing to verify); mirrors the parity, embed-drift,
-  # wasm-parity, wasm-simd128-parity, q4-composed, vision-s3-gate,
+  # wasm-parity, wasm-simd128-parity, q4-composed, S3a/S4 CPU gates,
   # ppl-gate-selftest, q4-ppl-quality, and metal-parity verdicts when it did.
   # Fails closed if change-detection itself errored. metal-parity (the metal
   # parity RATCHET — #535 is deliberately waived in the script; see the job
@@ -997,6 +1120,8 @@ jobs:
         embed-drift,
         wasm-parity,
         wasm-simd128-parity,
+        vision-cpu-gates,
+        quarot-artifact,
         q4-vision-gates,
         ppl-gate-selftest,
         metal-parity,
@@ -1014,12 +1139,10 @@ jobs:
           DRIFT_RESULT="${{ needs.embed-drift.result }}"
           WASM_RESULT="${{ needs.wasm-parity.result }}"
           WASM_SIMD128_RESULT="${{ needs.wasm-simd128-parity.result }}"
-          # One variable where there were three: the QuaRot golden, the vision
-          # S3a/S4 cosine gates and the Q4 PPL regression gate now run as steps
-          # of a single job, so they report one result. Granularity is not lost
-          # in practice — each step still names itself in the job log, and the
-          # steps carry an if-not-cancelled guard so a red one does not mask the
-          # others.
+          VISION_CPU_RESULT="${{ needs.vision-cpu-gates.result }}"
+          QUAROT_ARTIFACT_RESULT="${{ needs.quarot-artifact.result }}"
+          # The QuaRot golden, S5b, Metal injection gate and Q4 PPL regression
+          # gate remain steps of one macOS job and report one result.
           Q4VISION_RESULT="${{ needs.q4-vision-gates.result }}"
           PPL_SELFTEST_RESULT="${{ needs.ppl-gate-selftest.result }}"
           METAL_RESULT="${{ needs.metal-parity.result }}"
@@ -1029,19 +1152,19 @@ jobs:
           # draft branch below must never fire on merge_group, push, schedule,
           # or workflow_dispatch.
           DRAFT="${{ github.event.pull_request.draft }}"
-          echo "changes=$CHANGES_RESULT engine=$ENGINE tune=$TUNE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT wasm-simd128-parity=$WASM_SIMD128_RESULT q4-vision-gates=$Q4VISION_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT metal-parity=$METAL_RESULT layer23-golden=$LAYER23_RESULT event=$EVENT_NAME"
+          echo "changes=$CHANGES_RESULT engine=$ENGINE tune=$TUNE parity=$PARITY_RESULT embed-drift=$DRIFT_RESULT wasm-parity=$WASM_RESULT wasm-simd128-parity=$WASM_SIMD128_RESULT vision-cpu-gates=$VISION_CPU_RESULT quarot-artifact=$QUAROT_ARTIFACT_RESULT q4-vision-gates=$Q4VISION_RESULT ppl-gate-selftest=$PPL_SELFTEST_RESULT metal-parity=$METAL_RESULT layer23-golden=$LAYER23_RESULT event=$EVENT_NAME"
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::change-detection did not succeed — failing closed."
             exit 1
           fi
-          # Drafts skip the macOS parity jobs to keep the ~5-concurrent runner
-          # pool available to PRs that are ready to merge. Those skips reach the
-          # arm checks below as result=skipped, which is correctly not "success",
+          # Drafts skip the resource-intensive parity jobs to keep hosted runner
+          # capacity available to PRs that are ready to merge. Those skips reach
+          # the arm checks below as result=skipped, which is correctly not "success",
           # so this gate would fail anyway. It short-circuits here only so the
           # failure explains itself instead of reading as a parity regression.
           # This stays a FAILURE on purpose: a green gate has to mean parity ran.
           if [ "$DRAFT" = "true" ] && { [ "$ENGINE" = "true" ] || [ "$TUNE" = "true" ]; }; then
-            echo "::error::Draft PR: macOS parity jobs are deferred while this PR is a draft, so parity is UNVERIFIED and this gate fails by design. Mark the PR ready for review and these jobs run automatically on the ready_for_review event."
+            echo "::error::Draft PR: resource-intensive parity jobs are deferred while this PR is a draft, so parity is UNVERIFIED and this gate fails by design. Mark the PR ready for review and these jobs run automatically on the ready_for_review event."
             exit 1
           fi
           if [ "$TUNE" = "true" ] && [ "$LAYER23_RESULT" != "success" ]; then
@@ -1068,8 +1191,16 @@ jobs:
             echo "::error::Engine changed and wasm-simd128-parity gate did not succeed (result=$WASM_SIMD128_RESULT)."
             exit 1
           fi
+          if [ "$VISION_CPU_RESULT" != "success" ]; then
+            echo "::error::Engine changed and the ARM Linux S3a/S4 CPU gates did not succeed (result=$VISION_CPU_RESULT)."
+            exit 1
+          fi
+          if [ "$QUAROT_ARTIFACT_RESULT" != "success" ]; then
+            echo "::error::Engine changed and the ARM Linux QuaRot artifact job did not succeed (result=$QUAROT_ARTIFACT_RESULT)."
+            exit 1
+          fi
           if [ "$Q4VISION_RESULT" != "success" ]; then
-            echo "::error::Engine changed and the q4 + vision gates job did not succeed (result=$Q4VISION_RESULT). This one result covers the QuaRot composed golden, the vision S3a/S4 cosine gates and the Q4 PPL regression gate; open the job log to see which step failed."
+            echo "::error::Engine changed and the q4 + macOS vision gates job did not succeed (result=$Q4VISION_RESULT). This one result covers the QuaRot composed golden, S5b, Metal injection gate and Q4 PPL regression gate; open the job log to see which step failed."
             exit 1
           fi
           if [ "$PPL_SELFTEST_RESULT" != "success" ]; then
@@ -1084,5 +1215,5 @@ jobs:
               exit 1
             fi
           fi
-          echo "Engine changed; parity, embed-drift, wasm-parity, wasm-simd128-parity, q4-vision-gates, ppl-gate-selftest, and metal-parity all PASSED."
+          echo "Engine changed; parity, embed-drift, wasm-parity, wasm-simd128-parity, vision-cpu-gates, quarot-artifact, q4-vision-gates, ppl-gate-selftest, and metal-parity all PASSED."
           exit 0

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import tempfile
 import unittest
@@ -18,6 +19,38 @@ _REQUIRED_WORKFLOWS = (
     ".github/workflows/ci.yml",
     ".github/workflows/e2e-parity.yml",
 )
+
+
+def _workflow_job(contents: str, job_id: str) -> str:
+    start_match = re.search(rf"^  {re.escape(job_id)}:\n", contents, re.MULTILINE)
+    if start_match is None:
+        raise AssertionError(f"workflow job {job_id!r} is missing")
+    next_match = re.search(
+        r"^  [a-z0-9][a-z0-9-]*:\n",
+        contents[start_match.end() :],
+        re.MULTILINE,
+    )
+    end = (
+        len(contents)
+        if next_match is None
+        else start_match.end() + next_match.start()
+    )
+    return contents[start_match.start() : end]
+
+
+def _workflow_step(job: str, step_name: str) -> str:
+    marker = f"      - name: {step_name}\n"
+    start = job.find(marker)
+    if start < 0:
+        raise AssertionError(f"workflow step {step_name!r} is missing")
+    body_start = start + len(marker)
+    next_match = re.search(
+        r"^      - (?:name:|uses:)",
+        job[body_start:],
+        re.MULTILINE,
+    )
+    end = len(job) if next_match is None else body_start + next_match.start()
+    return job[start:end]
 
 
 class ChangedFilesTests(unittest.TestCase):
@@ -204,6 +237,280 @@ class MergeQueueWorkflowTests(unittest.TestCase):
             with self.subTest(workflow=relative_path):
                 contents = (_ROOT / relative_path).read_text(encoding="utf-8")
                 self.assertIn(trigger, contents)
+
+
+class E2eRunnerSpecializationWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = (
+            _ROOT / ".github/workflows/e2e-parity.yml"
+        ).read_text(encoding="utf-8")
+
+    def _assert_split_is_fail_closed(self, workflow: str) -> None:
+        cpu = _workflow_job(workflow, "vision-cpu-gates")
+        artifact = _workflow_job(workflow, "quarot-artifact")
+        q4_metal = _workflow_job(workflow, "q4-vision-gates")
+        gate = _workflow_job(workflow, "parity-gate")
+        s5b_step = _workflow_step(
+            q4_metal, "Run S5b macOS f16 gate (fail-closed)"
+        )
+        cpu_code = "\n".join(
+            line for line in cpu.splitlines() if not line.lstrip().startswith("#")
+        )
+        artifact_code = "\n".join(
+            line
+            for line in artifact.splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        q4_metal_code = "\n".join(
+            line
+            for line in q4_metal.splitlines()
+            if not line.lstrip().startswith("#")
+        )
+
+        condition = (
+            "if: needs.changes.outputs.engine == 'true' && "
+            "github.event.pull_request.draft != true"
+        )
+        self.assertIn(condition, cpu_code)
+        self.assertIn(condition, artifact_code)
+        self.assertIn(condition, q4_metal_code)
+        self.assertIn("runs-on: ubuntu-24.04-arm", cpu_code)
+        self.assertIn('test "$ARCH" = "aarch64"', cpu_code)
+        self.assertIn("LATTICE_VISION_CPU_RUNNER", cpu_code)
+        self.assertIn("LATTICE_VISION_S3_GATE_ENFORCE: '1'", cpu_code)
+        self.assertIn("--features f16 \\", cpu_code)
+        self.assertIn("status=$?", cpu_code)
+        self.assertIn('exit "$status"', cpu_code)
+        self.assertNotIn("metal-gpu", cpu_code)
+        self.assertNotIn("LATTICE_METAL_TEST_ENFORCE", cpu_code)
+        self.assertNotIn("quantize_", cpu_code)
+
+        test_targets = (
+            "vision_s3_vit_forward_test",
+            "vision_s4_merger_test",
+        )
+        proof_markers = (
+            "LATTICE_VISION_S3_COSINE",
+            "LATTICE_VISION_S3_MUTATION_COSINE",
+            "LATTICE_VISION_S4_COSINE",
+            "LATTICE_VISION_S4_MUTATION_COSINE",
+            "LATTICE_VISION_S4_E2E_COSINE",
+            "LATTICE_VISION_S4_E2E_MUTATION_COSINE",
+        )
+        for target in test_targets:
+            self.assertEqual(cpu_code.count(f"--test {target}"), 1)
+            self.assertNotIn(target, q4_metal_code)
+        for marker in proof_markers:
+            self.assertEqual(cpu_code.count(f"grep -q '{marker}'"), 1)
+        self.assertNotIn("vision_s5b_e2e_gate_test", cpu_code)
+        self.assertNotIn("LATTICE_VISION_S5B_GREEDY_TOKENS", cpu_code)
+
+        self.assertIn("runs-on: ubuntu-24.04-arm", artifact_code)
+        self.assertIn('test "$ARCH" = "aarch64"', artifact_code)
+        self.assertIn("LATTICE_QUAROT_ARTIFACT_RUNNER", artifact_code)
+        self.assertIn(
+            "cargo build --release -p lattice-inference "
+            "--bin quantize_quarot --features f16",
+            artifact_code,
+        )
+        self.assertIn("target/release/quantize_quarot", artifact_code)
+        self.assertIn("--seed 0xCAFE_BABE_DEAD_BEEF", artifact_code)
+        self.assertIn("--num-probe-tokens 4", artifact_code)
+        self.assertIn("status=$?", artifact_code)
+        self.assertIn('exit "$status"', artifact_code)
+        self.assertIn("grep -q '^Forward-equiv:'", artifact_code)
+        self.assertIn("quantize_index.json", artifact_code)
+        self.assertIn("config.json", artifact_code)
+        self.assertIn("LATTICE_QUAROT_ARTIFACT_READY", artifact_code)
+        self.assertIn('-cf "$RUNNER_TEMP/quarot-q4.tar" .', artifact_code)
+        self.assertIn("shasum -a 256 quarot-q4.tar", artifact_code)
+        self.assertIn(
+            "actions/upload-artifact@"
+            "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+            artifact_code,
+        )
+        self.assertIn(
+            "name: quarot-q4-${{ github.run_id }}\n",
+            artifact_code,
+        )
+        self.assertNotIn("github.run_attempt", artifact_code)
+        self.assertIn("if-no-files-found: error", artifact_code)
+        self.assertIn("retention-days: 1", artifact_code)
+        self.assertIn("compression-level: 0", artifact_code)
+        self.assertIn("overwrite: true", artifact_code)
+        self.assertNotIn("metal-gpu", artifact_code)
+
+        self.assertIn("runs-on: macos-latest", q4_metal_code)
+        self.assertIn("needs: [changes, quarot-artifact]", q4_metal_code)
+        self.assertIn(
+            "actions/download-artifact@"
+            "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+            q4_metal_code,
+        )
+        self.assertIn(
+            "name: quarot-q4-${{ github.run_id }}\n",
+            q4_metal_code,
+        )
+        self.assertNotIn("github.run_attempt", q4_metal_code)
+        self.assertIn("shasum -a 256 -c quarot-q4.tar.sha256", q4_metal_code)
+        self.assertIn("-xf quarot-q4.tar", q4_metal_code)
+        self.assertIn("LATTICE_QUAROT_ARTIFACT_CONSUMED", q4_metal_code)
+        self.assertNotIn("--bin quantize_quarot", q4_metal_code)
+        for metal_gate_anchor in (
+            "--test quarot_q4_composed_golden",
+            '--features "f16,metal-gpu"',
+            "LATTICE_METAL_TEST_ENFORCE: '1'",
+            "--lib inject -- --nocapture --test-threads=1",
+            "--test vision_s5b_e2e_gate_test",
+            "LATTICE_VISION_S5B_GREEDY_TOKENS",
+            "--bin eval_perplexity --bin quantize_q4",
+            "LATTICE_PPL_GATE_REQUIRE_ARMED: \"1\"",
+        ):
+            self.assertIn(metal_gate_anchor, q4_metal_code)
+        self.assertIn("status=$?", s5b_step)
+        self.assertIn('exit "$status"', s5b_step)
+
+        needs = gate.split("    needs:\n", 1)[1].split("    if:", 1)[0]
+        self.assertIn("        vision-cpu-gates,\n", needs)
+        self.assertIn("        quarot-artifact,\n", needs)
+        self.assertIn(
+            'VISION_CPU_RESULT="${{ needs.vision-cpu-gates.result }}"',
+            gate,
+        )
+        self.assertIn(
+            'if [ "$VISION_CPU_RESULT" != "success" ]; then',
+            gate,
+        )
+        self.assertIn(
+            'QUAROT_ARTIFACT_RESULT="${{ needs.quarot-artifact.result }}"',
+            gate,
+        )
+        self.assertIn(
+            'if [ "$QUAROT_ARTIFACT_RESULT" != "success" ]; then',
+            gate,
+        )
+
+    def test_portable_gates_are_arm_only_and_required(self) -> None:
+        self._assert_split_is_fail_closed(self.workflow)
+
+    def test_contract_rejects_runner_coverage_and_gate_mutations(self) -> None:
+        def mutate_job(job_id: str, old: str, new: str) -> str:
+            job = _workflow_job(self.workflow, job_id)
+            self.assertIn(old, job)
+            return self.workflow.replace(job, job.replace(old, new, 1), 1)
+
+        def mutate_step(
+            job_id: str,
+            step_name: str,
+            old: str,
+            new: str,
+        ) -> str:
+            job = _workflow_job(self.workflow, job_id)
+            step = _workflow_step(job, step_name)
+            self.assertIn(old, step)
+            mutated_step = step.replace(old, new, 1)
+            mutated_job = job.replace(step, mutated_step, 1)
+            return self.workflow.replace(job, mutated_job, 1)
+
+        mutations = {
+            "runner moved back to macOS": mutate_job(
+                "vision-cpu-gates",
+                "runs-on: ubuntu-24.04-arm",
+                "runs-on: macos-latest",
+            ),
+            "real-path marker removed": mutate_job(
+                "vision-cpu-gates",
+                "grep -q 'LATTICE_VISION_S4_E2E_MUTATION_COSINE'",
+                "true # marker removed",
+            ),
+            "Metal feature added to CPU job": mutate_job(
+                "vision-cpu-gates",
+                "--features f16 \\",
+                "--features f16,metal-gpu \\",
+            ),
+            "cargo failure propagation removed": mutate_job(
+                "vision-cpu-gates",
+                'exit "$status"',
+                "true # cargo status discarded",
+            ),
+            "S5b cargo failure propagation removed": mutate_step(
+                "q4-vision-gates",
+                "Run S5b macOS f16 gate (fail-closed)",
+                'exit "$status"',
+                "true # cargo status discarded",
+            ),
+            "artifact runner moved to macOS": mutate_job(
+                "quarot-artifact",
+                "runs-on: ubuntu-24.04-arm",
+                "runs-on: macos-latest",
+            ),
+            "artifact converter failure propagation removed": mutate_step(
+                "quarot-artifact",
+                "Generate and verify QuaRot Q4 artifact",
+                'exit "$status"',
+                "true # converter status discarded",
+            ),
+            "artifact equivalence proof removed": mutate_job(
+                "quarot-artifact",
+                "grep -q '^Forward-equiv:'",
+                "true # equivalence proof removed",
+            ),
+            "artifact ready marker removed": mutate_job(
+                "quarot-artifact",
+                'echo "LATTICE_QUAROT_ARTIFACT_READY"',
+                "true # artifact marker removed",
+            ),
+            "artifact producer made attempt-dependent": mutate_job(
+                "quarot-artifact",
+                "name: quarot-q4-${{ github.run_id }}",
+                "name: quarot-q4-${{ github.run_id }}-"
+                "${{ github.run_attempt }}",
+            ),
+            "artifact overwrite disabled": mutate_job(
+                "quarot-artifact",
+                "overwrite: true",
+                "overwrite: false",
+            ),
+            "artifact consumer made attempt-dependent": mutate_job(
+                "q4-vision-gates",
+                "name: quarot-q4-${{ github.run_id }}",
+                "name: quarot-q4-${{ github.run_id }}-"
+                "${{ github.run_attempt }}",
+            ),
+            "artifact checksum verification removed": mutate_job(
+                "q4-vision-gates",
+                "shasum -a 256 -c quarot-q4.tar.sha256",
+                "true # checksum discarded",
+            ),
+            "macOS artifact dependency removed": mutate_job(
+                "q4-vision-gates",
+                "needs: [changes, quarot-artifact]",
+                "needs: changes",
+            ),
+            "CPU required needs edge removed": mutate_job(
+                "parity-gate",
+                "        vision-cpu-gates,\n",
+                "",
+            ),
+            "artifact required needs edge removed": mutate_job(
+                "parity-gate",
+                "        quarot-artifact,\n",
+                "",
+            ),
+            "CPU required result check disabled": mutate_job(
+                "parity-gate",
+                'if [ "$VISION_CPU_RESULT" != "success" ]; then',
+                "if false; then",
+            ),
+            "artifact required result check disabled": mutate_job(
+                "parity-gate",
+                'if [ "$QUAROT_ARTIFACT_RESULT" != "success" ]; then',
+                "if false; then",
+            ),
+        }
+        for name, mutated in mutations.items():
+            with self.subTest(mutation=name), self.assertRaises(AssertionError):
+                self._assert_split_is_fail_closed(mutated)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Generate and forward-verify the 0.62 GB QuaRot Q4 handoff on hosted ARM Linux instead of occupying a macOS runner.
- Run the portable ADR-069 S3a/S4 CPU reference gates concurrently on hosted ARM Linux.
- Keep S5b, the composed Q4 golden, Metal injection, and Q4 perplexity on macOS so the existing Accelerate/AMX and Metal coverage is preserved.
- Require both new ARM jobs and the shortened macOS consumer in `parity-gate`.

## Throughput rationale

The latest full engine run before this change ([run 30461355379](https://github.com/ohdearquant/lattice/actions/runs/30461355379)) spent 31m19s in `q4 + vision gates` with no queue delay:

- QuaRot converter build: 44s
- QuaRot generation plus forward-equivalence check: 17m52s
- Combined S3a/S4/S5b step: 4m06s

That job was the required workflow's critical path. A separate 53-run sample found macOS queue p90 at 24.42m versus 0.07m for `ubuntu-24.04-arm`. This change removes the 18m36s converter phase plus S3a/S4 from scarce macOS occupancy. The converter still runs and remains fail-closed; the work moves to the much less contended ARM pool, and the macOS job consumes its checksummed output.

This is primarily a shared-runner throughput improvement: the macOS consumer intentionally waits for a verified artifact rather than reserving a macOS runner while portable work executes elsewhere.

## Fail-closed guarantees

- Both portable jobs assert `uname -m == aarch64`.
- The converter runs with the unchanged seed, probe count, feature set, and default `1e-5` equivalence tolerance.
- The producer requires the `Forward-equiv:` proof marker plus non-empty index/config files before upload.
- The uncompressed tar is SHA-256 checked before macOS extracts it.
- The artifact name is stable across partial reruns; full reruns overwrite the same run-scoped artifact.
- S3a/S4 retain all six numerical and mutation-sensitivity markers.
- S5b remains on macOS with independent exit-status and proof-marker checks.
- `parity-gate` checks literal success results for the producer, portable vision gate, and macOS consumer.

## Validation

- `actionlint .github/workflows/e2e-parity.yml`
- `python3 tests/test_ci_changed_files.py -v` — 15 tests pass
- 18 mutation controls cover runner drift, feature/backend drift, discarded command status, missing proof markers, retry-unstable artifact naming, disabled overwrite/checksum, and missing required-gate dependency/result checks
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --target-dir /Users/lion/khive-work/target -- -D warnings`
- `./scripts/lint-docs.sh`
- `git diff --check`
- [Live branch workflow dispatch 30464827135](https://github.com/ohdearquant/lattice/actions/runs/30464827135) — all jobs and the required `parity-gate` passed
  - ARM QuaRot producer: 4m10s total; converter generation 2m11s; `max_abs=7.461e-14`, `mean_abs=1.061e-14`; 671,191,392-byte artifact uploaded
  - ARM S3a/S4 gates: 2m47s; all six real-path/mutation markers present
  - macOS q4 consumer: 14m11s active time after a 9m30s queue; checksum/extraction, S5b, composed Q4 golden, MP2, and PPL all passed
  - Immediate main baseline: 31m19s macOS q4 job; this run reduced scarce macOS occupancy by 17m08s (54.7%)

## bench-compare disposition

Not run. This changes workflow topology and a Python source-contract test only; no benchmark or shipped Rust binary changes. GitHub Actions job/step timing is the relevant performance evidence.

## Sibling-change sweep

- #1192 changes frozen HF reference provisioning, not these jobs.
- #1197 changes app-binary draft gating, not e2e parity.
- #1162 and #1021 touch adjacent e2e workflow areas and may need a normal rebase after this lands; neither implements this runner/artifact split.