### PR TITLE
fix(docs): isolate lint self-test index

### DIFF
--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -108,6 +108,8 @@ run_index_isolation_selftest() (
     after_index="$sandbox/after-index"
     tracked_files="$sandbox/tracked-files"
     committed_files="$sandbox/committed-files"
+    hook_marker="$sandbox/hook-ran"
+    global_config="$sandbox/global-config"
     mkdir -p "$repo/sentinel"
     printf '%s\n' '# outer repository' >"$repo/README.md"
     printf '%s\n' 'keep one' >"$repo/sentinel/one.txt"
@@ -115,22 +117,31 @@ run_index_isolation_selftest() (
     git -C "$repo" init -q
     git -C "$repo" add README.md sentinel
     git -C "$repo" ls-files --stage -z >"$before_index"
+    git config --file "$global_config" core.hooksPath /dev/null
 
     cat >"$repo/.git/hooks/pre-commit" <<'EOF'
 #!/bin/sh
 set -e
 LATTICE_LINT_DOCS_INDEX_PROBE=1 \
     "${LATTICE_LINT_DOCS_SELFTEST_SCRIPT:?}" --selftest
+: >"${LATTICE_LINT_DOCS_HOOK_MARKER:?}"
 EOF
     chmod +x "$repo/.git/hooks/pre-commit"
     (
         cd "$repo"
         LATTICE_LINT_DOCS_SELFTEST_SCRIPT="$script_path" \
+            LATTICE_LINT_DOCS_HOOK_MARKER="$hook_marker" \
+            GIT_CONFIG_GLOBAL="$global_config" \
             GIT_INDEX_FILE="$repo/.git/index" \
-            git -c user.name=selftest -c user.email=selftest@example.invalid \
+            git -c core.hooksPath="$repo/.git/hooks" \
+            -c user.name=selftest -c user.email=selftest@example.invalid \
             commit -qm "lint-docs hook index isolation probe"
     )
 
+    if [ ! -f "$hook_marker" ]; then
+        echo "lint-docs index selftest: synthetic pre-commit hook did not complete" >&2
+        exit 1
+    fi
     git -C "$repo" ls-files --stage -z >"$after_index"
     if ! cmp -s "$before_index" "$after_index"; then
         echo "lint-docs index selftest: staged entries changed under hook context" >&2

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -5,7 +5,17 @@ script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 script_path="$script_dir/lint-docs.sh"
 mode=${1:-}
 
-run_discovery_selftest() {
+clear_local_git_environment() {
+    git_local_env_names=$(git rev-parse --local-env-vars)
+    if [ -n "$git_local_env_names" ]; then
+        # Git emits only variable names; word splitting supplies them to unset.
+        unset $git_local_env_names
+    fi
+}
+
+run_discovery_selftest() (
+    clear_local_git_environment
+
     sandbox=$(mktemp -d "${TMPDIR:-/tmp}/lattice-lint-docs.XXXXXX")
     case "$sandbox" in
         "${TMPDIR:-/tmp}"/lattice-lint-docs.*) ;;
@@ -78,11 +88,70 @@ EOF
         exit 1
     fi
     echo "lint-docs: recursive tracked-Markdown selftest OK"
-}
+)
+
+run_index_isolation_selftest() (
+    clear_local_git_environment
+
+    sandbox=$(mktemp -d "${TMPDIR:-/tmp}/lattice-lint-docs-index.XXXXXX")
+    case "$sandbox" in
+        "${TMPDIR:-/tmp}"/lattice-lint-docs-index.*) ;;
+        *)
+            echo "lint-docs index selftest: unexpected sandbox path: $sandbox" >&2
+            exit 1
+            ;;
+    esac
+    trap 'rm -rf "$sandbox"' 0 1 2 3 15
+
+    repo="$sandbox/repo"
+    before_index="$sandbox/before-index"
+    after_index="$sandbox/after-index"
+    tracked_files="$sandbox/tracked-files"
+    committed_files="$sandbox/committed-files"
+    mkdir -p "$repo/sentinel"
+    printf '%s\n' '# outer repository' >"$repo/README.md"
+    printf '%s\n' 'keep one' >"$repo/sentinel/one.txt"
+    printf '%s\n' 'keep two' >"$repo/sentinel/two.md"
+    git -C "$repo" init -q
+    git -C "$repo" add README.md sentinel
+    git -C "$repo" ls-files --stage -z >"$before_index"
+
+    cat >"$repo/.git/hooks/pre-commit" <<'EOF'
+#!/bin/sh
+set -e
+LATTICE_LINT_DOCS_INDEX_PROBE=1 \
+    "${LATTICE_LINT_DOCS_SELFTEST_SCRIPT:?}" --selftest
+EOF
+    chmod +x "$repo/.git/hooks/pre-commit"
+    (
+        cd "$repo"
+        LATTICE_LINT_DOCS_SELFTEST_SCRIPT="$script_path" \
+            GIT_INDEX_FILE="$repo/.git/index" \
+            git -c user.name=selftest -c user.email=selftest@example.invalid \
+            commit -qm "lint-docs hook index isolation probe"
+    )
+
+    git -C "$repo" ls-files --stage -z >"$after_index"
+    if ! cmp -s "$before_index" "$after_index"; then
+        echo "lint-docs index selftest: staged entries changed under hook context" >&2
+        exit 1
+    fi
+    git -C "$repo" ls-files -z >"$tracked_files"
+    git -C "$repo" ls-tree -r --name-only -z HEAD >"$committed_files"
+    if ! cmp -s "$tracked_files" "$committed_files"; then
+        echo "lint-docs index selftest: committed files differ from the index" >&2
+        exit 1
+    fi
+    echo "lint-docs: hook-index isolation selftest OK"
+)
 
 case "$mode" in
     --selftest)
-        run_discovery_selftest
+        if [ "${LATTICE_LINT_DOCS_INDEX_PROBE:-}" = "1" ]; then
+            run_discovery_selftest
+        else
+            run_index_isolation_selftest
+        fi
         exit 0
         ;;
     "" | --format | --markdown-only) ;;


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- clear every Git repository-local environment variable before the Markdown discovery self-test operates on its sandbox repository
- run the discovery probe in a subshell so its environment and cleanup trap cannot leak back to the caller
- exercise the real pre-commit hook context and prove the hook completes even when an adversarial global `core.hooksPath` points elsewhere
- require both an explicit hook marker and unchanged staged/committed file sets

The regression probe supplies a foreign `GIT_INDEX_FILE` to an actual temporary-repository commit. The nested discovery test must operate only on its own repository; any inherited-index write makes the hook or the post-commit identity checks fail.

Fixes #1213

## Validation

- `sh -n scripts/lint-docs.sh` — passed
- `./scripts/lint-docs.sh --selftest` — recursive discovery, forced-hook execution, and hook-index isolation passed
- `./scripts/lint-docs.sh` — all 179 tracked Markdown files, discovery self-test, and capability-matrix checks passed
- `git diff --check` — passed

## Mutation proof

Removing the repository-local environment clearing caused the synthetic pre-commit to rewrite the outer index. Removing either the forced hook path or the hook-completion marker made the self-test fail closed instead of silently skipping the regression probe. Restoring all guards returned the exact staged-entry and committed-tree checks to green.

## Sibling sweep

The discovery self-test is the only path in `lint-docs.sh` that creates and stages a foreign Git repository. It clears the complete set reported by `git rev-parse --local-env-vars`, covering index, worktree, object-store, shallow, replacement-ref, and repository overrides rather than singling out one current hook variable.

## bench-compare disposition

Not run. This changes only the documentation-lint shell harness and its self-test; it does not alter Rust code, benchmark binaries, or timed execution paths.