### PR TITLE
fix(scripts): stop the doc-lint self-test writing the real git index

### DIFF
--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -87,6 +87,13 @@
 # is what makes a confirmed regression stop something.
 set -euo pipefail
 
+# A caller may hand us an inherited git environment (git exports GIT_INDEX_FILE to
+# hooks as a RELATIVE path, and GIT_DIR/GIT_WORK_TREE arrive empty). The worktree
+# add/remove calls below write a git index, so an inherited relative GIT_INDEX_FILE
+# would resolve against our cwd and hit the caller's real index instead. Nothing in
+# this script needs the caller's index state.
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE
+
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 QUICK_FLAGS="--quick"  # ~10 samples, ~2 min total
 

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 set -e
 
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE
+
 script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 script_path="$script_dir/lint-docs.sh"
 mode=${1:-}
 
 run_discovery_selftest() {
+    index_count_before=$(git ls-files | wc -l | tr -d '[:space:]')
     sandbox=$(mktemp -d "${TMPDIR:-/tmp}/lattice-lint-docs.XXXXXX")
     case "$sandbox" in
         "${TMPDIR:-/tmp}"/lattice-lint-docs.*) ;;
@@ -75,6 +78,11 @@ EOF
     fi
     if ! cmp -s "$expected" "$capture.lint"; then
         echo "lint-docs selftest: linter did not receive the exact tracked Markdown set" >&2
+        exit 1
+    fi
+    index_count_after=$(git ls-files | wc -l | tr -d '[:space:]')
+    if [ "$index_count_after" -ne "$index_count_before" ]; then
+        echo "lint-docs selftest: real index entry count changed: $index_count_before -> $index_count_after" >&2
         exit 1
     fi
     echo "lint-docs: recursive tracked-Markdown selftest OK"

--- a/tests/test_bench_compare_measurement.py
+++ b/tests/test_bench_compare_measurement.py
@@ -31,6 +31,9 @@ STUB_CARGO = """#!/usr/bin/env bash
 exit 0
 """
 
+# Test helpers invoking real Git must disable repository hooks.
+GIT = ("git", "-c", "core.hooksPath=/dev/null")
+
 
 def _run(extra_args):
     """Run the shipping bench-compare.sh in a throwaway repo with a stub cargo."""
@@ -42,11 +45,11 @@ def _run(extra_args):
 
         env_git = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
                    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
-        subprocess.run(["git", "init", "-q", "-b", "main", str(root)], check=True)
+        subprocess.run([*GIT, "init", "-q", "-b", "main", str(root)], check=True)
         for i in range(2):
             (root / f"f{i}.txt").write_text(str(i))
-            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
-            subprocess.run(["git", "-C", str(root), "commit", "-qm", f"c{i}"],
+            subprocess.run([*GIT, "-C", str(root), "add", "-A"], check=True)
+            subprocess.run([*GIT, "-C", str(root), "commit", "-qm", f"c{i}"],
                            check=True, env=env_git)
 
         # Redirect the machine-wide lock and pending-marker paths inside the

--- a/tests/test_bench_locks.py
+++ b/tests/test_bench_locks.py
@@ -47,6 +47,9 @@ STUB_CARGO = """#!/usr/bin/env bash
 exit 0
 """
 
+# Test helpers invoking real Git must disable repository hooks.
+GIT = ("git", "-c", "core.hooksPath=/dev/null")
+
 
 class _Sandbox:
     """A throwaway repo holding the shipping scripts, with locks redirected."""
@@ -63,11 +66,11 @@ class _Sandbox:
 
         env_git = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
                    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
-        subprocess.run(["git", "init", "-q", "-b", "main", str(self.root)], check=True)
+        subprocess.run([*GIT, "init", "-q", "-b", "main", str(self.root)], check=True)
         for i in range(2):
             (self.root / f"f{i}.txt").write_text(str(i))
-            subprocess.run(["git", "-C", str(self.root), "add", "-A"], check=True)
-            subprocess.run(["git", "-C", str(self.root), "commit", "-qm", f"c{i}"],
+            subprocess.run([*GIT, "-C", str(self.root), "add", "-A"], check=True)
+            subprocess.run([*GIT, "-C", str(self.root), "commit", "-qm", f"c{i}"],
                            check=True, env=env_git)
 
         locks = self.root / "scripts" / "lib" / "bench-locks.py"

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -13,6 +13,7 @@ from pathlib import Path
 _SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "ci-changed-files.sh"
 _ROOT = _SCRIPT.parent.parent
 _ZERO_SHA = "0" * 40
+_GIT = ("git", "-c", "core.hooksPath=/dev/null")
 _REQUIRED_WORKFLOWS = (
     ".github/workflows/app-binaries.yml",
     ".github/workflows/cargo-audit.yml",
@@ -65,8 +66,9 @@ class ChangedFilesTests(unittest.TestCase):
         self._tempdir.cleanup()
 
     def _git(self, *args: str) -> str:
+        # Test helpers invoking real Git must disable repository hooks.
         result = subprocess.run(
-            ["git", *args],
+            [*_GIT, *args],
             cwd=self.repo,
             check=True,
             capture_output=True,

--- a/tests/test_lint_docs.py
+++ b/tests/test_lint_docs.py
@@ -1,0 +1,43 @@
+"""Regression tests for scripts/lint-docs.sh."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "lint-docs.sh"
+_GIT = ("git", "-c", "core.hooksPath=/dev/null")
+
+
+class LintDocsTests(unittest.TestCase):
+    def test_selftest_does_not_mutate_callers_relative_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            # Test helpers invoking real Git must disable repository hooks.
+            subprocess.run([*_GIT, "init", "-q"], cwd=repo, check=True)
+            for name in ("README.md", "keep.txt"):
+                (repo / name).write_text(f"{name}\n", encoding="utf-8")
+            subprocess.run([*_GIT, "add", "."], cwd=repo, check=True)
+
+            before = self._index_count(repo)
+            env = os.environ.copy()
+            env["TMPDIR"] = str(repo)
+            env["GIT_INDEX_FILE"] = "../../.git/index"
+            subprocess.run([str(_SCRIPT), "--selftest"], cwd=repo, env=env, check=True)
+
+            self.assertEqual(self._index_count(repo), before)
+
+    @staticmethod
+    def _index_count(repo: Path) -> int:
+        result = subprocess.run(
+            [*_GIT, "ls-files"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return len(result.stdout.splitlines())


### PR DESCRIPTION
Fixes #1213.

## The defect

`scripts/lint-docs.sh` builds a throwaway git sandbox in `run_discovery_selftest()` and calls
`git -C "$sandbox" init` / `git -C "$sandbox" add` while the shell's cwd is still the real
worktree root.

Git exports `GIT_INDEX_FILE` to a `pre-commit` hook as a **relative** path (`.git/index`), and
`GIT_DIR` / `GIT_WORK_TREE` arrive empty. Inside the hook, that inherited relative path resolves
against the caller's cwd, and an inherited ambient git environment variable takes precedence over
`git -C`. The sandbox's staging therefore wrote the **real** repository index.

Observed on a two-line commit: the resulting tree held **213 files against the repository's 898**,
with `crates/embed` and `crates/fann` absent entirely and three doc-lint sandbox fixtures committed
as real files. The hook printed `Pre-commit checks passed` and exited 0.

Latent since the self-test was introduced. It stayed invisible because `--no-verify` commits are
unaffected, and running `scripts/lint-docs.sh` directly does not reproduce it — the hook-supplied
environment is required.

## The fix

Three layers, because no single one of them is sufficient.

1. **Environment neutralisation.** `unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE` at the top of
   `scripts/lint-docs.sh`, before any git call. A subshell that `cd`s into the sandbox first would
   also be correct, but that is cwd discipline and one refactor away from breaking; unsetting the
   inherited environment does not depend on control flow.

2. **Self-proof.** The self-test records the repository's index entry count before and after its
   sandbox work and fails loudly if it changed, so the script demonstrates its own harmlessness on
   every run rather than being trusted to be harmless. Note the honest limit of this layer: it
   reads the index through the same environment it is testing, so it cannot detect the
   environment-mediated corruption itself. It guards against future sandbox-write regressions that
   are not environment-mediated. The regression test below is what guards this class.

3. **Test hermeticity.** Test helpers that shell out to real git now pin
   `git -c core.hooksPath=/dev/null`, so a suite invoking git can never pick up repository hooks.
   Hook exemptions for test paths were deliberately not added — that would invert the defence.

The same environment neutralisation is applied to `scripts/lib/bench-compare-impl.sh`, which
performs `git worktree add` / `worktree remove` against the repository. It is not reachable from
the hook today, so this is prophylactic rather than a second live bug, but it is the same class and
a one-line defence.

## Verification

**The regression test is mutation-sensitive.** With the `unset` line removed and nothing else
changed, `tests/test_lint_docs.py` fails with `AssertionError: 6 != 2` — the real index grew by
exactly the corruption class. Restored, it passes. The test drives the script with a relative
`GIT_INDEX_FILE`, reproducing the hook environment rather than a proxy for it.

- Full test suite: 546 tests, all passing.
- `scripts/lint-docs.sh` passes both directly and in `--selftest` mode.
- Both modified shell scripts pass a syntax check.
- **End-to-end**: the commit adding the `bench-compare-impl.sh` change was made through the fixed
  hook with no bypass. Tree entry count after that commit is 897, matching `git ls-files`, with
  zero unexpected dirty files. The same commit on the unfixed hook produces a 213-file tree.

## Sibling sweep

Swept all of `scripts/` and `.githooks/` for index-affecting git verbs (`init`, `add`, `commit`,
`worktree`, `checkout`, `reset`, `stash`, `rm`), using an absolute `grep` path with a
known-positive control in the same invocation, since the shell's `grep` prunes ignored paths and a
bare negative sweep would not be evidence of absence.

Results: `scripts/lint-docs.sh` (fixed), `scripts/lib/bench-compare-impl.sh` (fixed),
`scripts/ci-changed-files.sh` (read-only `cat-file`, no index write), `scripts/bench_quality.sh`
(read-only `rev-parse`). `.githooks/` contains exactly one hook.

`.githooks/pre-commit` itself was deliberately **not** given the unset. The hook is the legitimate
owner of that environment, and neutralising it there would silently change the meaning of any
future staged-content check such as `git diff --cached`. The defence belongs in the leaf scripts
that build sandboxes.

## Bench-compare disposition

Not applicable: this change touches `scripts/` and `tests/` only, with no modification under
`crates/inference/` or `crates/embed/`.
