### PR TITLE
ci: route Rust setup action through parity canary (superseded)

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -29,6 +29,7 @@ on:
       - 'crates/tune/src/**'
       - 'crates/tune/tests/**'
       - 'crates/tune/Cargo.toml'
+      - '.github/actions/rust-setup/**'
       - '.github/workflows/e2e-parity.yml'
       - 'scripts/ci-changed-files.sh'
   schedule:
@@ -94,7 +95,7 @@ jobs:
           # patterns: tests/fixtures/vision/, crates/embed/tests/wasm/,
           # crates/inference/tests/fixtures/{quarot_q4_composed_v1,ppl_gate_v1}/,
           # crates/embed/tests/fixtures/{embed_parity_v1,embed_drift_baseline_v1}/,
-          # .github/actions/provision-qwen35-0-8b/ and crates/*/src/. A prefix
+          # .github/actions/{provision-qwen35-0-8b,rust-setup}/ and crates/*/src/. A prefix
           # matches ANY file placed under it, so a README inside a fixture
           # directory classifies a documentation change as an engine change.
           # That is not hypothetical: PR #1159 touched 50 files, ZERO of them
@@ -133,7 +134,7 @@ jobs:
           # still triggers wasm-parity. Without them, engine stays false and the
           # required parity-gate could pass green without the wasm path ever
           # running, a fail-open on the gate itself.
-          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/(ci-changed-files\.sh|e2e_parity_check\.py)$|^\.github/workflows/e2e-parity\.yml$|^\.github/actions/provision-qwen35-0-8b/|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^scripts/wasm-simd128-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$|^scripts/ppl_gate_check\.py$|^scripts/ppl_gate_check_selftest\.sh$|^crates/inference/tests/fixtures/ppl_gate_v1/|^crates/inference/src/bin/eval_perplexity\.rs$|^crates/inference/src/bin/quantize_q4\.rs$|^docs/bench_results/wiki\.test\.raw$|^crates/inference/tests/vision_s3_vit_forward_test\.rs$|^crates/inference/tests/vision_s4_merger_test\.rs$|^crates/inference/tests/vision_s5b_e2e_gate_test\.rs$|^tests/fixtures/vision/|^scripts/vision_goldens_qwen35\.py$|^crates/embed/tests/embed_drift_baseline\.rs$|^crates/embed/tests/fixtures/embed_drift_baseline_v1/' <<<"$CHANGED" >/dev/null; then
+          if grep -E '^crates/(inference|embed)/src/|^crates/(inference|embed)/Cargo\.toml$|^Cargo\.lock$|^scripts/(ci-changed-files\.sh|e2e_parity_check\.py)$|^\.github/workflows/e2e-parity\.yml$|^\.github/actions/(provision-qwen35-0-8b|rust-setup)/|^crates/inference/tests/quarot_q4_composed_golden\.rs$|^crates/inference/tests/fixtures/quarot_q4_composed_v1/|^scripts/gen_quarot_q4_composed_golden\.py$|^scripts/wasm-parity\.sh$|^scripts/wasm-simd128-parity\.sh$|^crates/embed/tests/wasm/|^crates/embed/tests/fixtures/embed_parity_v1/|^crates/embed/examples/dump_parity_embeddings\.rs$|^scripts/ppl_gate_check\.py$|^scripts/ppl_gate_check_selftest\.sh$|^crates/inference/tests/fixtures/ppl_gate_v1/|^crates/inference/src/bin/eval_perplexity\.rs$|^crates/inference/src/bin/quantize_q4\.rs$|^docs/bench_results/wiki\.test\.raw$|^crates/inference/tests/vision_s3_vit_forward_test\.rs$|^crates/inference/tests/vision_s4_merger_test\.rs$|^crates/inference/tests/vision_s5b_e2e_gate_test\.rs$|^tests/fixtures/vision/|^scripts/vision_goldens_qwen35\.py$|^crates/embed/tests/embed_drift_baseline\.rs$|^crates/embed/tests/fixtures/embed_drift_baseline_v1/' <<<"$CHANGED" >/dev/null; then
             echo "engine=true" >> "$GITHUB_OUTPUT"
             echo "→ engine surface changed: parity REQUIRED"
           else

--- a/scripts/ci-engine-filter-selftest.sh
+++ b/scripts/ci-engine-filter-selftest.sh
@@ -83,6 +83,17 @@ check "embed source -> engine" true \
   "$(classify "$ENGINE_RE" <<<'crates/embed/src/simd/mod.rs')"
 check "Cargo.lock -> engine" true \
   "$(classify "$ENGINE_RE" <<<'Cargo.lock')"
+check "shared Rust setup action -> engine" true \
+  "$(classify "$ENGINE_RE" <<<'.github/actions/rust-setup/action.yml')"
+
+# A push to main is filtered before the classifier job exists, so the action
+# path must also be present in the workflow trigger. Keeping this assertion in
+# the same owning test makes either half of the routing contract fail closed.
+PUSH_ROUTES_RUST_SETUP=false
+sed -n '1,45p' "$WF" \
+  | grep -qF "      - '.github/actions/rust-setup/**'" \
+  && PUSH_ROUTES_RUST_SETUP=true
+check "shared Rust setup action -> push workflow" true "$PUSH_ROUTES_RUST_SETUP"
 
 # ── the over-exclusion guard ────────────────────────────────────────────────
 # Stripping .md must not stop fixture DATA under the same directory from firing.


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

Closed as superseded by the already-open draft #1191, which implements #812's same first-stage parity-routing canary with an owning source-contract test. No review or merge is requested for this duplicate.

## bench-compare disposition

Not run. The closed branch only changed workflow routing and its deterministic self-test.