### PR TITLE
test(inference): promote resolved grammar probes

### DIFF
--- a/crates/inference/tests/grammar_tbv_probe.rs
+++ b/crates/inference/tests/grammar_tbv_probe.rs
@@ -1,7 +1,7 @@
 //! Regression harness for GitHub issue #310 (grammar-constrained decoding, ADR-046).
 //!
 //! Status per finding:
-//!   f1 (object optional-member separators)     — FIXED by #380
+//!   f1 (object optional-member separators)     — pins PDA consumed-frame guard
 //!   f2 (array cardinality minItems/maxItems)   — FIXED by #321
 //!   f3 (prefixItems tuple arrays)              — FIXED by #321
 //!   f4 (string enum rule-name collision)       — FIXED by #311

--- a/crates/inference/tests/grammar_tbv_probe.rs
+++ b/crates/inference/tests/grammar_tbv_probe.rs
@@ -1,13 +1,14 @@
 //! Regression harness for GitHub issue #310 (grammar-constrained decoding, ADR-046).
 //!
 //! Status per finding:
-//!   f1 (object optional-member separators)     — DEFERRED, marked #[ignore]
-//!   f2 (array cardinality minItems/maxItems)   — FIXED in this session
-//!   f3 (prefixItems tuple arrays)              — FIXED in this session
-//!   f4 (string enum rule-name collision)       — previously fixed upstream
-//!   f5 (single-stack PDA common-prefix)        — needs architectural redesign, marked #[ignore]
-//!   f6 (leading-zero integer rejection)        — previously fixed upstream
-//!   f7 (enum/const string escaping)            — FIXED in this session
+//!   f1 (object optional-member separators)     — FIXED by #380
+//!   f2 (array cardinality minItems/maxItems)   — FIXED by #321
+//!   f3 (prefixItems tuple arrays)              — FIXED by #321
+//!   f4 (string enum rule-name collision)       — FIXED by #311
+//!   f5 (JSON-Schema string-enum common prefix) — FIXED by #471
+//!   f5 (arbitrary PDA common-prefix)            — needs architectural redesign, marked #[ignore]
+//!   f6 (leading-zero integer rejection)        — FIXED by #311
+//!   f7 (enum/const string escaping)            — FIXED by #321
 
 use lattice_inference::grammar::json_schema::compile_json_schema;
 use lattice_inference::grammar::pda::{
@@ -43,7 +44,6 @@ fn f5_common_prefix_raw() {
 }
 
 #[test]
-#[ignore = "issue #310 finding #5 (single-stack PDA cannot backtrack common prefixes) — needs architectural redesign"]
 fn f5_common_prefix_enum() {
     let g = compile_json_schema(&serde_json::json!({"type":"string","enum":["apple","apricot"]}))
         .unwrap();
@@ -54,7 +54,6 @@ fn f5_common_prefix_enum() {
 }
 
 #[test]
-#[ignore = "issue #310 finding #1 (object optional-member separators) — deferred follow-up"]
 fn f1_trailing_comma() {
     let g = compile_json_schema(&serde_json::json!({"type":"object",
         "properties":{"a":{"type":"string"},"b":{"type":"string"}},"required":["a"]}))


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Promote the #310 object-separator probe to the regular test suite now that #380 fixes both required-only acceptance and trailing-comma rejection.
- Promote the JSON-Schema shared-prefix string-enum probe now that #471 trie-compiles those literals.
- Refresh every finding's provenance in the harness status block (#311, #321, #380, #471).
- Keep the generic raw-PDA common-prefix probe ignored: `root ::= "ab" | "ac"` still rejects `ac`, so this PR deliberately does not claim to close #310 or to change runtime behavior.

## Validation

- `cargo test -p lattice-inference --test grammar_tbv_probe -- --test-threads=1` — 15 passed, exactly 1 intentionally ignored.
- Forced `f5_common_prefix_raw` with `--ignored --exact` — fails on `ac` as expected, proving the remaining ignore is live rather than stale.
- Existing anyOf-of-const shared-prefix regression — PASS.
- Pre-commit hook — PASS (workspace clippy, Rust formatting, recursive Markdown lint/self-test, capability-matrix fixture check).
- Two independent diff reviews — APPROVE, 0 findings.

## bench-compare disposition

Not run. This changes only an integration-test source file that is not compiled into benchmark binaries; effective benchmark code is unchanged.

Refs #310.