### PR TITLE
refactor(inference): share CPU generation setup

### DIFF
--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -14,8 +14,8 @@ use crate::attention::gdn_fused::{
 };
 use crate::forward::cpu::{elementwise_mul, silu_inplace};
 use crate::model::qwen35::{
-    ForwardScratch, KvCache, decode_tokens, qwen35_rms_norm, resize, sample_token,
-    should_stop_token,
+    ForwardScratch, GenerationEntryContract, GenerationPlan, GenerationPreparation, KvCache,
+    decode_tokens, prepare_generation, qwen35_rms_norm, resize, sample_token, should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::rope::RopeTable;
@@ -892,79 +892,23 @@ pub fn generate_f16(
     prompt: &str,
     gen_cfg: &GenerateConfig,
 ) -> Result<GenerateOutput, crate::error::InferenceError> {
-    // Initialize RNG
-    let mut rng_state = match gen_cfg.seed {
-        Some(s) => {
-            if s == 0 {
-                1
-            } else {
-                s
-            }
-        }
-        None => {
-            use std::time::SystemTime;
-            let t = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as u64)
-                .unwrap_or(0x12345678_9abcdef0);
-            if t == 0 { 1 } else { t }
-        }
+    let plan = match prepare_generation(
+        tokenizer,
+        prompt,
+        gen_cfg,
+        cfg.vocab_size,
+        rope.max_positions(),
+        GenerationEntryContract::StandaloneCpu,
+    )? {
+        GenerationPreparation::Ready(plan) => plan,
+        GenerationPreparation::Complete(output) => return Ok(output),
     };
-
-    // Tokenize prompt
-    let input = tokenizer.tokenize(prompt);
-    let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
-    let prompt_len = prompt_ids.len();
-
-    // #856: single shared preflight, unified with the Metal paths (which
-    // used to accept an empty prompt and return an empty Ok) — see
-    // `check_prompt_not_empty` (model::qwen35::generation).
-    crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
-
-    crate::model::qwen35::check_prompt_ids_in_vocab(&prompt_ids, cfg.vocab_size)?;
-
-    // max_new_tokens == 0 means "generate nothing": return before sampling so
-    // we never emit a token the caller did not ask for. Mirrors the guard in
-    // Qwen35Model::generate (crates/inference/src/model/qwen35/generation.rs).
-    if gen_cfg.max_new_tokens == 0 {
-        return Ok(GenerateOutput {
-            text: String::new(),
-            token_ids: vec![],
-            prompt_tokens: prompt_len,
-            generated_tokens: 0,
-            stopped: false,
-            stop_reason: Some(StopReason::Length),
-            token_logprobs: vec![],
-        });
-    }
-
-    // Reject grammar configs before allocating any state. Grammar masking
-    // (`mask_logits` + `advance`) is not wired into this generate loop; without
-    // the guard the grammar field would be silently ignored, producing
-    // unconstrained output despite a grammar being set (#397/#398).
-    crate::model::qwen35::check_grammar_not_set(gen_cfg)?;
-    // Same rationale for logprobs capture, which is also not wired into this
-    // generate loop (#585).
-    crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
-    // Same rationale for stop_strings matching and reasoning-budget forcing,
-    // neither of which is wired into this generate loop (ADR-080 C3, #783).
-    crate::model::qwen35::check_stop_strings_not_set(gen_cfg)?;
-    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
-
-    // Context preflight. The RoPE cos/sin tables are indexed unchecked in
-    // forward_step_f16 (`rope.cos_at(base + i)`), so a position at or past the
-    // table capacity is an out-of-bounds slice access — a release panic, not a
-    // clean error. Mirror Qwen35Model::generate's total-token policy
-    // (prompt_len + max_new_tokens <= max_context) so direct and HTTP generation
-    // agree on when a request is too long.
-    let max_context = rope.max_positions();
-    if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
-        return Err(crate::error::InferenceError::Inference(format!(
-            "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
-             model context window ({max_context})",
-            gen_cfg.max_new_tokens
-        )));
-    }
+    let GenerationPlan {
+        mut rng_state,
+        prompt_ids,
+        prompt_len,
+        ..
+    } = plan;
 
     // Initialize states
     let num_linear = cfg.num_linear_attention_layers();
@@ -2601,8 +2545,8 @@ mod tests {
     /// are sufficient (mirrors `generate_f16_rejects_grammar_config_before_sampling`
     /// below).
     ///
-    /// Mutation sensitivity: reverting the `check_prompt_not_empty` call at
-    /// this call site makes the function proceed past the guard with a
+    /// Mutation sensitivity: bypassing the shared preparation at this entry
+    /// point makes the function proceed past the guard with a
     /// zero-length prompt, either panicking in the prefill/decode loop
     /// (`all_ids.last()` on an empty vec) or producing a non-`Inference`
     /// error — this assert fails either way.

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -16,14 +16,13 @@ use crate::attention::gdn_fused::{
 use crate::forward::cpu::{elementwise_mul, matmul_bt, silu_inplace};
 use crate::model::qwen35::Qwen35Model;
 use crate::model::qwen35::{
-    ForwardScratch, KvCache, decode_tokens, qwen35_rms_norm, resize, sample_token,
-    should_stop_token,
+    ForwardScratch, GenerationEntryContract, GenerationPlan, GenerationPreparation, KvCache,
+    decode_tokens, prepare_generation, qwen35_rms_norm, resize, sample_token, should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::rope::RopeTable;
 use crate::stop_reason::StopReason;
 use crate::tokenizer::bpe::BpeTokenizer;
-use crate::tokenizer::common::Tokenizer;
 use crate::weights::q8_weights::{
     Q8AttentionWeights, Q8CommonLayerWeights, Q8FullAttentionLayerWeights, Q8GatedDeltaNetWeights,
     Q8ModelWeights, matmul_bt_q8,
@@ -691,77 +690,23 @@ pub fn generate_q8(
     prompt: &str,
     gen_cfg: &GenerateConfig,
 ) -> Result<GenerateOutput, crate::error::InferenceError> {
-    // Initialize RNG
-    let mut rng_state = match gen_cfg.seed {
-        Some(s) => {
-            if s == 0 {
-                1
-            } else {
-                s
-            }
-        }
-        None => {
-            use std::time::SystemTime;
-            let t = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as u64)
-                .unwrap_or(0x12345678_9abcdef0);
-            if t == 0 { 1 } else { t }
-        }
+    let plan = match prepare_generation(
+        tokenizer,
+        prompt,
+        gen_cfg,
+        cfg.vocab_size,
+        rope.max_positions(),
+        GenerationEntryContract::StandaloneCpu,
+    )? {
+        GenerationPreparation::Ready(plan) => plan,
+        GenerationPreparation::Complete(output) => return Ok(output),
     };
-
-    // Tokenize prompt
-    let input = tokenizer.tokenize(prompt);
-    let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
-    let prompt_len = prompt_ids.len();
-
-    // #856: single shared preflight, unified with the Metal paths (which
-    // used to accept an empty prompt and return an empty Ok) — see
-    // `check_prompt_not_empty` (model::qwen35::generation).
-    crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
-    crate::model::qwen35::check_prompt_ids_in_vocab(&prompt_ids, cfg.vocab_size)?;
-
-    // max_new_tokens == 0 is a valid request: "score this prompt, return no tokens".
-    // Guard here so the decode loop (`for _ in 1..0`) never accidentally samples one
-    // token from the prefill logits before realising the budget is exhausted.
-    if gen_cfg.max_new_tokens == 0 {
-        return Ok(GenerateOutput {
-            text: String::new(),
-            token_ids: vec![],
-            prompt_tokens: prompt_len,
-            generated_tokens: 0,
-            stopped: false,
-            stop_reason: Some(StopReason::Length),
-            token_logprobs: vec![],
-        });
-    }
-    // Reject grammar configs before allocating any state. Grammar masking
-    // (`mask_logits` + `advance`) is not wired into this generate loop; without
-    // the guard the grammar field would be silently ignored, producing
-    // unconstrained output despite a grammar being set (#397/#398).
-    crate::model::qwen35::check_grammar_not_set(gen_cfg)?;
-    // Same rationale for logprobs capture, which is also not wired into this
-    // generate loop (#585).
-    crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
-    // Same rationale for stop_strings matching and reasoning-budget forcing,
-    // neither of which is wired into this generate loop (ADR-080 C3, #783).
-    crate::model::qwen35::check_stop_strings_not_set(gen_cfg)?;
-    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
-
-    // Context preflight. The RoPE cos/sin tables are indexed unchecked in
-    // full_attention_step_q8 (`rope.cos_at(position * half + i)`), so a position
-    // at or past the table capacity is an out-of-bounds slice access — a release
-    // panic, not a clean error. Mirror Qwen35Model::generate's total-token policy
-    // (prompt_len + max_new_tokens <= max_context) so direct and HTTP generation
-    // agree on when a request is too long.
-    let max_context = rope.max_positions();
-    if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
-        return Err(crate::error::InferenceError::Inference(format!(
-            "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
-             model context window ({max_context})",
-            gen_cfg.max_new_tokens
-        )));
-    }
+    let GenerationPlan {
+        mut rng_state,
+        prompt_ids,
+        prompt_len,
+        ..
+    } = plan;
 
     // Initialize states
     let num_linear = cfg.num_linear_attention_layers();
@@ -1571,8 +1516,8 @@ mod tests {
     /// Metal paths, which used to silently accept an empty prompt and
     /// return an empty `Ok`. See docs/generation-entrypoint-matrix.md row 2.
     ///
-    /// Mutation sensitivity: reverting the `check_prompt_not_empty` call at
-    /// this call site makes the function proceed past the guard with a
+    /// Mutation sensitivity: bypassing the shared preparation at this entry
+    /// point makes the function proceed past the guard with a
     /// zero-length prompt, either panicking in the prefill/decode loop or
     /// producing a non-`Inference` error — this assert fails either way.
     #[test]
@@ -1611,8 +1556,8 @@ mod tests {
     /// larger than the supplied model config. The boundary ID `vocab_size`
     /// must be rejected before `forward_step_q8` slices the embedding table.
     ///
-    /// Mutation sensitivity: removing only the Q8 call to
-    /// `check_prompt_ids_in_vocab` lets this request reach the unchecked
+    /// Mutation sensitivity: removing the shared setup's
+    /// `check_prompt_ids_in_vocab` call lets this request reach the unchecked
     /// embedding slice and panic instead of returning `InvalidInput`.
     #[test]
     fn generate_q8_rejects_out_of_vocab_prompt_id() {

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -23,14 +23,14 @@ use crate::forward::cpu::{elementwise_mul, silu_inplace};
 use crate::forward::neon::{matmul_q8_neon_into, pack_weights_q8};
 use crate::model::qwen35::{
     AttentionWeights, CommonLayerWeights, FeedForwardWeights, ForwardScratch,
-    FullAttentionLayerWeights, KvCache, ModelWeights, decode_tokens, qwen35_rms_norm, resize,
+    FullAttentionLayerWeights, GenerationEntryContract, GenerationPlan, GenerationPreparation,
+    KvCache, ModelWeights, decode_tokens, prepare_generation, qwen35_rms_norm, resize,
     sample_token, should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::rope::RopeTable;
 use crate::stop_reason::StopReason;
 use crate::tokenizer::bpe::BpeTokenizer;
-use crate::tokenizer::common::Tokenizer;
 use crate::weights::ingress::{IngestedTensor, validate_ingested_tensor};
 use crate::weights::q8_weights::{validate_cfg_len, validate_gdn_shapes};
 
@@ -955,75 +955,23 @@ pub fn generate_q8_neon(
     prompt: &str,
     gen_cfg: &GenerateConfig,
 ) -> Result<GenerateOutput, crate::error::InferenceError> {
-    // Initialize RNG
-    let mut rng_state = match gen_cfg.seed {
-        Some(s) => {
-            if s == 0 {
-                1
-            } else {
-                s
-            }
-        }
-        None => {
-            use std::time::SystemTime;
-            let t = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as u64)
-                .unwrap_or(0x12345678_9abcdef0);
-            if t == 0 { 1 } else { t }
-        }
+    let plan = match prepare_generation(
+        tokenizer,
+        prompt,
+        gen_cfg,
+        cfg.vocab_size,
+        rope.max_positions(),
+        GenerationEntryContract::StandaloneCpu,
+    )? {
+        GenerationPreparation::Ready(plan) => plan,
+        GenerationPreparation::Complete(output) => return Ok(output),
     };
-
-    // Tokenize prompt
-    let input = tokenizer.tokenize(prompt);
-    let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
-    let prompt_len = prompt_ids.len();
-
-    // #856: single shared preflight, unified with the Metal paths (which
-    // used to accept an empty prompt and return an empty Ok) — see
-    // `check_prompt_not_empty` (model::qwen35::generation).
-    crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
-    crate::model::qwen35::check_prompt_ids_in_vocab(&prompt_ids, cfg.vocab_size)?;
-
-    // max_new_tokens == 0 means "generate nothing": return before sampling so
-    // we never emit a token the caller did not ask for. Mirrors the guard in
-    // Qwen35Model::generate (crates/inference/src/model/qwen35/generation.rs).
-    if gen_cfg.max_new_tokens == 0 {
-        return Ok(GenerateOutput {
-            text: String::new(),
-            token_ids: vec![],
-            prompt_tokens: prompt_len,
-            generated_tokens: 0,
-            stopped: false,
-            stop_reason: Some(StopReason::Length),
-            token_logprobs: vec![],
-        });
-    }
-
-    // Reject grammar configs before allocating any state. Grammar masking
-    // (`mask_logits` + `advance`) is not wired into this generate loop; without
-    // the guard the grammar field would be silently ignored, producing
-    // unconstrained output despite a grammar being set (#397/#398).
-    crate::model::qwen35::check_grammar_not_set(gen_cfg)?;
-    // Same rationale for logprobs capture, which is also not wired into this
-    // generate loop (#585).
-    crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
-    // Same rationale for stop_strings matching and reasoning-budget forcing,
-    // neither of which is wired into this generate loop (ADR-080 C3, #783).
-    crate::model::qwen35::check_stop_strings_not_set(gen_cfg)?;
-    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
-
-    // Reject requests whose total token budget exceeds the RoPE table's
-    // position capacity before allocating caches or dereferencing weights.
-    // Mirrors Qwen35Model::generate and forward::cpu_q8::generate_q8.
-    let max_context = rope.max_positions();
-    if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
-        return Err(crate::error::InferenceError::Inference(format!(
-            "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
-             model context window ({max_context})",
-            gen_cfg.max_new_tokens
-        )));
-    }
+    let GenerationPlan {
+        mut rng_state,
+        prompt_ids,
+        prompt_len,
+        required_capacity: max_seq_len,
+    } = plan;
 
     // Initialize states
     let num_linear = cfg.num_linear_attention_layers();
@@ -1033,10 +981,6 @@ pub fn generate_q8_neon(
         .collect();
     let mut kv_cache = KvCache::new(num_full);
     let mut scratch = ForwardScratch::new();
-    let max_seq_len = prompt_len
-        .saturating_add(gen_cfg.max_new_tokens)
-        .saturating_add(1);
-
     kv_cache.reserve(max_seq_len, cfg.full_kv_dim());
     scratch.ensure_capacity(cfg, max_seq_len);
 
@@ -3104,8 +3048,8 @@ mod tests {
     /// Metal paths, which used to silently accept an empty prompt and
     /// return an empty `Ok`. See docs/generation-entrypoint-matrix.md row 2.
     ///
-    /// Mutation sensitivity: reverting the `check_prompt_not_empty` call at
-    /// this call site makes the function proceed past the guard with a
+    /// Mutation sensitivity: bypassing the shared preparation at this entry
+    /// point makes the function proceed past the guard with a
     /// zero-length prompt, either panicking in the prefill/decode loop or
     /// producing a non-`Inference` error — this assert fails either way.
     #[test]
@@ -3148,8 +3092,8 @@ mod tests {
     /// must be rejected before `forward_step_q8_neon` slices the embedding
     /// table.
     ///
-    /// Mutation sensitivity: removing only the NEON call to
-    /// `check_prompt_ids_in_vocab` lets this request reach the unchecked
+    /// Mutation sensitivity: removing the shared setup's
+    /// `check_prompt_ids_in_vocab` call lets this request reach the unchecked
     /// embedding slice and panic instead of returning `InvalidInput`.
     #[test]
     fn generate_q8_neon_rejects_out_of_vocab_prompt_id() {

--- a/crates/inference/src/model/qwen35/generation_setup.rs
+++ b/crates/inference/src/model/qwen35/generation_setup.rs
@@ -1,0 +1,292 @@
+use super::generation::{
+    check_grammar_not_set, check_logprobs_not_set, check_prompt_ids_in_vocab,
+    check_prompt_not_empty, check_reasoning_budget_not_set, check_stop_strings_not_set,
+};
+use crate::error::InferenceError;
+use crate::model::qwen35_config::{GenerateConfig, GenerateOutput};
+use crate::stop_reason::StopReason;
+use crate::tokenizer::bpe::BpeTokenizer;
+use crate::tokenizer::common::Tokenizer;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GenerationEntryContract {
+    StandaloneCpu,
+}
+
+impl GenerationEntryContract {
+    fn validate(self, gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
+        match self {
+            Self::StandaloneCpu => {
+                check_grammar_not_set(gen_cfg)?;
+                check_logprobs_not_set(gen_cfg)?;
+                check_stop_strings_not_set(gen_cfg)?;
+                check_reasoning_budget_not_set(gen_cfg)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct GenerationPlan {
+    pub(crate) rng_state: u64,
+    pub(crate) prompt_ids: Vec<u32>,
+    pub(crate) prompt_len: usize,
+    pub(crate) required_capacity: usize,
+}
+
+#[derive(Debug)]
+pub(crate) enum GenerationPreparation {
+    Ready(GenerationPlan),
+    Complete(GenerateOutput),
+}
+
+pub(crate) fn prepare_generation(
+    tokenizer: &BpeTokenizer,
+    prompt: &str,
+    gen_cfg: &GenerateConfig,
+    vocab_size: usize,
+    max_context: usize,
+    contract: GenerationEntryContract,
+) -> Result<GenerationPreparation, InferenceError> {
+    let rng_state = normalize_seed(gen_cfg.seed, system_seed);
+
+    let input = tokenizer.tokenize(prompt);
+    let prompt_ids = input.input_ids[..input.real_length].to_vec();
+    let prompt_len = prompt_ids.len();
+
+    check_prompt_not_empty(prompt_len)?;
+    check_prompt_ids_in_vocab(&prompt_ids, vocab_size)?;
+
+    if gen_cfg.max_new_tokens == 0 {
+        return Ok(GenerationPreparation::Complete(GenerateOutput {
+            text: String::new(),
+            token_ids: Vec::new(),
+            prompt_tokens: prompt_len,
+            generated_tokens: 0,
+            stopped: false,
+            stop_reason: Some(StopReason::Length),
+            token_logprobs: Vec::new(),
+        }));
+    }
+
+    contract.validate(gen_cfg)?;
+
+    if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
+        return Err(InferenceError::Inference(format!(
+            "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
+             model context window ({max_context})",
+            gen_cfg.max_new_tokens
+        )));
+    }
+
+    Ok(GenerationPreparation::Ready(GenerationPlan {
+        rng_state,
+        prompt_ids,
+        prompt_len,
+        required_capacity: prompt_len
+            .saturating_add(gen_cfg.max_new_tokens)
+            .saturating_add(1),
+    }))
+}
+
+fn normalize_seed(seed: Option<u64>, fallback: impl FnOnce() -> u64) -> u64 {
+    let seed = seed.unwrap_or_else(fallback);
+    if seed == 0 { 1 } else { seed }
+}
+
+fn system_seed() -> u64 {
+    use std::time::SystemTime;
+
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos() as u64)
+        .unwrap_or(0x12345678_9abcdef0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grammar::{GrammarEngine, GrammarSpec};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn tokenizer(entries: &[(&str, u32)]) -> BpeTokenizer {
+        let vocab = entries
+            .iter()
+            .map(|(token, id)| ((*token).to_string(), *id))
+            .collect::<HashMap<_, _>>();
+        BpeTokenizer::from_vocab_and_merges(vocab, Vec::new()).expect("test tokenizer constructs")
+    }
+
+    fn prepare(
+        tokenizer: &BpeTokenizer,
+        prompt: &str,
+        gen_cfg: &GenerateConfig,
+        vocab_size: usize,
+        max_context: usize,
+    ) -> Result<GenerationPreparation, InferenceError> {
+        prepare_generation(
+            tokenizer,
+            prompt,
+            gen_cfg,
+            vocab_size,
+            max_context,
+            GenerationEntryContract::StandaloneCpu,
+        )
+    }
+
+    #[test]
+    fn seed_normalization_preserves_nonzero_and_repairs_zero() {
+        assert_eq!(
+            normalize_seed(Some(7), || panic!("fallback must not run")),
+            7
+        );
+        assert_eq!(
+            normalize_seed(Some(0), || panic!("fallback must not run")),
+            1
+        );
+        assert_eq!(normalize_seed(None, || 0), 1);
+        assert_eq!(normalize_seed(None, || 9), 9);
+    }
+
+    #[test]
+    fn preparation_applies_seed_normalization_to_the_returned_plan() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            seed: Some(0),
+            ..Default::default()
+        };
+        let result = prepare(&tokenizer, "a", &gen_cfg, 1, 2).expect("preparation succeeds");
+        let GenerationPreparation::Ready(plan) = result else {
+            panic!("nonzero budget must return a ready plan");
+        };
+
+        assert_eq!(plan.rng_state, 1);
+    }
+
+    #[test]
+    fn ready_plan_owns_prompt_seed_and_capacity_and_preserves_mtp_contract() {
+        let tokenizer = tokenizer(&[("a", 0), ("b", 1)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 3,
+            seed: Some(17),
+            enable_mtp: Some(true),
+            ..Default::default()
+        };
+        let result = prepare(&tokenizer, "ab", &gen_cfg, 2, 5).expect("preparation succeeds");
+        let GenerationPreparation::Ready(plan) = result else {
+            panic!("nonzero budget must return a ready plan");
+        };
+
+        assert_eq!(plan.rng_state, 17);
+        assert_eq!(plan.prompt_ids, vec![0, 1]);
+        assert_eq!(plan.prompt_len, 2);
+        assert_eq!(plan.required_capacity, 6);
+    }
+
+    #[test]
+    fn empty_prompt_precedes_zero_budget_and_capability_checks() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            stop_strings: vec!["stop".to_string()],
+            ..Default::default()
+        };
+        let err = prepare(&tokenizer, "", &gen_cfg, 1, 0)
+            .expect_err("empty prompt must reject before every later branch");
+
+        assert!(matches!(
+            err,
+            InferenceError::Inference(ref message) if message == "empty prompt"
+        ));
+    }
+
+    #[test]
+    fn prompt_id_admission_precedes_zero_budget() {
+        let tokenizer = tokenizer(&[("z", 2)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            ..Default::default()
+        };
+        let err = prepare(&tokenizer, "z", &gen_cfg, 2, usize::MAX)
+            .expect_err("out-of-vocabulary prompt must reject before zero-budget completion");
+
+        assert!(matches!(err, InferenceError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn zero_budget_precedes_capabilities_and_context() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            stop_strings: vec!["stop".to_string()],
+            ..Default::default()
+        };
+        let result = prepare(&tokenizer, "a", &gen_cfg, 1, 0)
+            .expect("zero budget must complete before unsupported features and context");
+        let GenerationPreparation::Complete(output) = result else {
+            panic!("zero budget must return an early completion");
+        };
+
+        assert!(output.text.is_empty());
+        assert!(output.token_ids.is_empty());
+        assert_eq!(output.prompt_tokens, 1);
+        assert_eq!(output.generated_tokens, 0);
+        assert!(!output.stopped);
+        assert_eq!(output.stop_reason, Some(StopReason::Length));
+        assert!(output.token_logprobs.is_empty());
+    }
+
+    #[test]
+    fn standalone_cpu_contract_rejects_every_unwired_feature() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let grammar = GrammarEngine::new(
+            &GrammarSpec::Gbnf("root ::= \"a\"\n".to_string()),
+            vec![b"a".to_vec()],
+        )
+        .expect("test grammar compiles");
+        let configs = [
+            GenerateConfig {
+                grammar: Some(Arc::new(grammar)),
+                ..Default::default()
+            },
+            GenerateConfig {
+                logprobs: Some(0),
+                ..Default::default()
+            },
+            GenerateConfig {
+                stop_strings: vec!["stop".to_string()],
+                ..Default::default()
+            },
+            GenerateConfig {
+                reasoning_budget: Some(1),
+                ..Default::default()
+            },
+        ];
+
+        for gen_cfg in &configs {
+            let err = prepare(&tokenizer, "a", gen_cfg, 1, 0)
+                .expect_err("standalone CPU contract must reject unwired features");
+            assert!(matches!(err, InferenceError::InvalidInput(_)));
+        }
+    }
+
+    #[test]
+    fn context_preflight_preserves_the_standalone_cpu_error() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 2,
+            ..Default::default()
+        };
+        let err = prepare(&tokenizer, "a", &gen_cfg, 1, 2)
+            .expect_err("prompt plus decode budget must fit the context");
+
+        assert!(matches!(
+            err,
+            InferenceError::Inference(ref message)
+                if message
+                    == "prompt (1 tokens) plus max_new_tokens (2) exceeds model context window (2)"
+        ));
+    }
+}

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod detokenize;
 mod eval;
 mod forward;
 mod generation;
+mod generation_setup;
 mod loading;
 mod model;
 mod moe;
@@ -56,23 +57,22 @@ pub(crate) use generation::check_logprobs_not_set;
 // Sibling guards for `stop_strings` / `reasoning_budget` on the same unwired
 // paths (ADR-080 C3, #783).
 pub(crate) use generation::{check_reasoning_budget_not_set, check_stop_strings_not_set};
+pub(crate) use generation_setup::{
+    GenerationEntryContract, GenerationPlan, GenerationPreparation, prepare_generation,
+};
 // Shared empty-prompt preflight (#856): every CPU forward path (cpu_q8,
 // cpu_f16, neon_forward) and every Metal generation entry point
 // (forward::metal_qwen35) calls this instead of its own inline
 // `if prompt_len == 0` copy, unifying the CPU/Metal empty-prompt contract.
 pub(crate) use generation::check_prompt_not_empty;
-// Shared prompt-token admission guard for standalone CPU drivers whose
-// tokenizer and model config are supplied independently (#1083).
-pub(crate) use generation::check_prompt_ids_in_vocab;
 // Shared total-context admission bound (#922): every Metal generation entry
 // point (forward::metal_qwen35) calls this after check_prompt_not_empty to
 // mirror the CPU `generate`/`generate_streaming` total bound
 // (prompt_len + decode budget <= max_context), instead of only bounding the
 // prompt alone. Only the Metal (`mod inner`, gated identically) consumer
-// needs the re-export; the CPU forward paths (cpu_f16, cpu_q8, neon_forward)
-// already enforce this same bound with their own inline check and
-// `generation.rs` itself uses `check_context_budget` directly within its own
-// module.
+// needs the re-export; the standalone CPU paths (cpu_f16, cpu_q8,
+// neon_forward) enforce the same bound through `prepare_generation`, and
+// `generation.rs` uses `check_context_budget` directly within its own module.
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub(crate) use generation::check_context_budget;
 // Shared backend-neutral decode-policy struct (reasoning-budget accounting +


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Add a crate-private, typed `prepare_generation` contract that owns seed normalization, BPE prompt ownership, prompt admission, zero-budget completion, unsupported-feature guards, and context preflight.
- Migrate exactly `generate_f16`, `generate_q8`, and `generate_q8_neon`; keep backend-specific state construction, prefill, decode loops, canonical generation, multimodal, Metal, and batch-prefill paths unchanged.
- Preserve the post-#1158 order (`seed → tokenize → empty → OOV → zero budget → capability guards → context`), exact errors/output fields, ignored standalone-CPU `enable_mtp` behavior, and NEON `prompt + budget + 1` capacity.

Fixes #823

## Validation

- `cargo test -p lattice-inference --lib` — 2421 passed, 20 ignored, 0 failed (post-rebase).
- `cargo clippy --workspace --all-targets -- -D warnings` — passed (post-rebase).
- `cargo fmt --all -- --check` and `git diff --check origin/main...HEAD` — passed.
- Repository pre-commit hook — passed, including doc lint and capability-matrix fixture check.
- Helper tests — 8 passed; existing f16 caller tests — 10 passed; existing q8/NEON caller tests — 19 passed.
- Mutation proof: moving context admission ahead of capability guards made `standalone_cpu_contract_rejects_every_unwired_feature` fail; moving OOV admission after zero-budget completion made `prompt_id_admission_precedes_zero_budget` fail. Both mutations were reverted and the final suite passed.
- Three independent read-only review passes: APPROVE, no blockers.
- `e2e-parity.yml` is intentionally left to the required macOS PR gate because it needs the HF/model-backed environment.

## bench-compare disposition

A/B run, quick resolution, on an otherwise idle dedicated macOS arm64 host (Apple M4, 10 cores).

```
base: origin/main (0f86f5125a)   head: a58db7d15b
resolution: --quick
targets: lattice-inference:elementwise_cpu_bench, lattice-embed:simd
inference features: <none>   filters: inference='<all>' embed='<all>'
harness: pinned to origin/main (the bench script and gate run from the invoking checkout)
locks: bench-window acquired; Metal GPU acquired (uncontended)
ambient idle: before base 94.2%  between phases 96.4%  after head 96.8%   (floor 70.0%)   spread 2.6pp
```

The three ambient samples are read as a series and not only against the floor, because a per-sample
threshold cannot see a load that sat on one phase and not the other.

### Gate verdict

The repository's target-qualified gate report for the gating target
`lattice-inference:elementwise_cpu_bench` records **no regression and one confirmed improvement**
across 17 groups. Nothing warned and nothing failed.

| Bench | Δ point | 95% CI | verdict |
| --- | ---: | --- | --- |
| `layer_norm/4096` | -11.12% | [-11.57%, -10.66%] | improvement |

This is the largest single-group excursion measured on this host today and it is **not claimed as a
win**. The diff mentions `layer_norm` nowhere, and -11.12% is 4.7x the maximum excursion the
byte-identical control produced, so it is not dismissible as that control's noise either.

The controls below matter to how this row is read, and they cut in its favour. The run as a whole
floated positive: its gated median is +1.32%, with 13 of 17 groups positive. `layer_norm/4096` read
-11.12% against that whole-run offset, and -11.12% is 4.7x the maximum excursion the byte-identical
control produced on any gated group. So the row is neither the run's own offset nor that control's
noise. What is not established is the offset's magnitude for this particular group, so the size of
the underlying effect is bounded loosely rather than pinned.

The plausible mechanism is a codegen effect: the change moves 238 lines out of `cpu_f16.rs`,
`cpu_q8.rs` and `neon_forward.rs` into a shared `generation_setup.rs`, which can shift inlining and
codegen-unit partitioning in translation units that do contain those kernels. That mechanism is
unverified here, and verifying it is not a merge blocker, because the direction is an improvement and
no group regressed.

An earlier revision of this description said no performance conclusion was claimed because the
fail-closed quiet gate rejected the A/B and the bench host was unreachable. Both were true at the
time; both are resolved, and the run above certified on its first attempt. That revision also quoted a
different SHA pair, which no longer describes this branch.

### The controls, and what the flagged rows actually mean

**Correction to an earlier revision of this description.** An earlier revision attributed the
flagged warn-band rows to measurement arm order, stating that the arm measured second is the
slower one whichever tree occupies it, and supported that with a count of warn rows by sign.
Both statements are withdrawn. The paragraphs below are what the controls actually establish.

**The sign count carried no information.** The gate defines WARN as a confidence-interval lower
bound above the warn threshold, so a WARN row is positive by construction. A tally of warn rows
by sign is therefore true of any dataset and says nothing about this one.

**Arm order is refuted by measurement.** A base-versus-base control on byte-identical source
(`base_sha == head_sha == 0f86f5125a`, ambient idle 96.3 / 96.5 / 96.9, spread 0.6pp) returns
**134 positive and 127 negative across 264 groups, at a median of +0.01%**. Arm order predicts a
one-sided result on that control and does not produce one. A forward run in this PR family also
lands negative at its gated median (-0.94%, 6 positive / 11 negative), which arm order predicts
cannot happen while the branch occupies the head arm.

**What the controls do support.** Each quick-resolution run carries a coherent offset shared
across its groups, and the sign of that offset differs between runs: gated medians measured on
this host in this session range from -0.94% to +3.00%, with both all-positive and
majority-negative runs appearing. Criterion computes its confidence intervals within a single
run, so they are narrower than the run-to-run spread and can be confidently wrong about it. On
the byte-identical control the per-group spread is 1.90pp standard deviation over a -6.07% to
+9.55% range.

**The practical consequence, which is what the earlier revision got right.** A warn-band row at
quick resolution is not evidence about the diff. Applying the gate's own thresholds to the
byte-identical control yields 10 would-be WARN and 3 would-be FAIL rows on source that cannot
differ; all of them land on `lattice-embed:simd`, which quick mode already reports
informationally rather than gating. The 17 gated groups stayed inside the 3% band on that
control, with a maximum excursion of +2.38% on `layer_norm/896`, and no gating group approached
the >7% FAIL threshold in either direction.

Two things follow that are worth stating plainly. A clean gated verdict at quick resolution
currently rests on which groups sit in the gated set rather than on the numeric value of the
threshold, so moving a group into that set calls for re-deriving the threshold rather than
inheriting it. And a real code effect inside the 3-5% range cannot be resolved at this
resolution at all: separating one needs `--full`, or a harness that interleaves the two arms
rather than running them in blocks.

### `lattice-embed:simd`

`lattice-embed:simd` is the sole entry in `scripts/lib/bench-quick-informational-targets.txt`, so
quick mode measures it and reports it but excludes it from the regression verdict, which is why its
gate report reads "All 0 gated benches". Today's runs show why the manifest lists it: across PRs that
change none of its source, its `simd_normalize` group swung between -14% and +33% at this resolution.

It also cannot serve as a source-identical control for a `crates/inference` change.
`crates/embed/Cargo.toml` compiles `lattice-inference` with `["std", "f16"]` under its default
`native` feature, and the dependency runs embed to inference and not the reverse, so an inference diff
changes embed's bench binary too.

### Base equivalence across the interim merge

Main advanced from `0f86f5125a` to `ab48dee49b` while these runs were in flight. `git diff --stat`
over that range is one file, `docs/benchmarks.md | 20 ++++`, with zero `.rs`, `.toml`, `.yml` or
`.yaml` files in it, so the bench binaries at the two shas are built from identical effective source
and the A/B above remains valid against current main. Verified as a diff rather than asserted.

