### PR TITLE
docs(bench): distinguish gate classification modes

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -8,17 +8,23 @@ this document — hardware varies. Run the benchmarks on your target machine.
 
 ### Regression gate modes
 
-The quick comparison and full-resolution gates deliberately classify targets differently:
+Target classification and enforcement are separate:
 
-| Command                                                              | Comparison                                                                | Classification                                                                                                                    | Enforcement                                                          |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `make bench-compare`                                                 | `origin/main` against `HEAD`, quick resolution                            | Targets listed in `scripts/lib/bench-quick-informational-targets.txt` are reported as informational; every other target is gating | Report-only unless the script is invoked with `--fail-on-regression` |
-| `scripts/bench-compare.sh --full --fail-on-regression <base> <head>` | Two explicit refs, full resolution                                        | Every measured target is gating; the quick informational manifest is ignored                                                      | A confirmed regression exits nonzero                                 |
-| `make bench-gate`                                                    | The current checkout against the `perf-baselines` branch, full resolution | Every measured result is gating; the quick informational manifest is ignored                                                      | A confirmed regression exits nonzero                                 |
+| Command                                                              | Comparison                                                                | Target classification                                                                                                          | Enforcement                                                                                                     |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `make bench-compare`                                                 | `origin/main` against `HEAD`, quick resolution                            | Targets listed in `scripts/lib/bench-quick-informational-targets.txt` are informational; every other measured target is gating | Report-only                                                                                                     |
+| `scripts/bench-compare.sh --full --fail-on-regression <base> <head>` | Two explicit refs, full resolution                                        | Every measured target is gating; the quick informational manifest is ignored                                                   | Propagates the aggregate gate status                                                                            |
+| `make bench-gate`                                                    | The current checkout against the `perf-baselines` branch, full resolution | Every measured result is gating; the quick informational manifest is ignored                                                   | Exits `1` for a missing baseline or regression, `2` when the gate cannot judge, and `0` only for a genuine pass |
 
-Informational classification does not skip measurement or remove results from the report. It only
-excludes a quick-mode target from the regression verdict. Use a full-resolution command when a
-quick-mode informational target must contribute to an enforcing decision.
+Informational classification does not skip measurement or remove results from the report. It
+excludes that quick-mode target from the regression verdict. `scripts/bench-compare.sh` is
+report-only in either resolution unless `--fail-on-regression` is supplied.
+
+Exit `2` outranks not-measurable `3`, reserved for valid ambient samples below the idle floor. The
+gate script allows first-run exit `0` only without `--require-measurements`; `make bench-gate` always
+passes it and never creates a baseline. `make bench-ci` saves one locally, and `bench-update.yml`
+updates `perf-baselines` on `main`. This closes the exact fail-open: expecting a green first run
+makes legitimate exit `2` look like tooling breakage—a lane can then go green having measured nothing.
 
 ### Embedding SIMD operations (no model download required)
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,6 +6,20 @@ this document — hardware varies. Run the benchmarks on your target machine.
 
 ## Running the Benchmarks
 
+### Regression gate modes
+
+The quick comparison and full-resolution gates deliberately classify targets differently:
+
+| Command                                                              | Comparison                                                                | Classification                                                                                                                    | Enforcement                                                          |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `make bench-compare`                                                 | `origin/main` against `HEAD`, quick resolution                            | Targets listed in `scripts/lib/bench-quick-informational-targets.txt` are reported as informational; every other target is gating | Report-only unless the script is invoked with `--fail-on-regression` |
+| `scripts/bench-compare.sh --full --fail-on-regression <base> <head>` | Two explicit refs, full resolution                                        | Every measured target is gating; the quick informational manifest is ignored                                                      | A confirmed regression exits nonzero                                 |
+| `make bench-gate`                                                    | The current checkout against the `perf-baselines` branch, full resolution | Every measured result is gating; the quick informational manifest is ignored                                                      | A confirmed regression exits nonzero                                 |
+
+Informational classification does not skip measurement or remove results from the report. It only
+excludes a quick-mode target from the regression verdict. Use a full-resolution command when a
+quick-mode informational target must contribute to an enforcing decision.
+
 ### Embedding SIMD operations (no model download required)
 
 ```sh


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Add a user-facing comparison of the three local regression-gate modes: quick `make bench-compare`, full enforcing `bench-compare`, and `make bench-gate` against `perf-baselines`.
- State exactly when the target-qualified quick informational manifest applies, when every measurement is classified as gating, and when a gate verdict is propagated as a nonzero exit.
- Clarify that informational classification still measures and reports the target; it changes only the quick-mode verdict.

Fixes #1206.

## Why documentation is the right resolution

Merged #1178 made quick classification target-qualified and fail-closed. The remaining difference is intentional: quick A/B runs may demote reviewed noise-dominated targets, while both full-resolution paths gate every measured result. The issue explicitly allows documenting that distinction instead of forcing the paths to share classification, and `docs/benchmarks.md` is the user-facing command reference that was missing it.

## Validation

- `./scripts/lint-docs.sh` — passed across all 179 tracked Markdown files, recursive discovery self-test, and capability-matrix fixture check.
- Repository pre-commit hook — passed, including formatting, workspace Clippy, and documentation lint.
- `git diff --check` — passed.
- The production manifest helper identifies `lattice-embed:simd` as informational and `lattice-inference:elementwise_cpu_bench` as gating in quick mode.
- Source-contract audit verified the table against `Makefile`, `scripts/lib/bench-compare-impl.sh`, `scripts/lib/bench-informational-targets.sh`, and `scripts/perf-bench-gate.py`.
- Independent read-only review — APPROVE, zero blockers.

## bench-compare disposition

Not run. This is a documentation-only change; benchmark binaries, measurement orchestration, target classification, and gate behavior are unchanged.