### PR TITLE
fix(tune): avoid feature-gated rustdoc link

### DIFF
--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -159,7 +159,7 @@ impl LoraAdapter {
     /// length mismatch. This is the single construction chokepoint
     /// (safetensors loading, blending, and training all route through it),
     /// so downstream code — including
-    /// [`validate_against`](Self::validate_against) and `apply` — can rely
+    /// `validate_against` and `apply` — can rely
     /// on the invariant without re-checking it. `apply_lora` itself also
     /// verifies its input against the layer's declared geometry before
     /// indexing, as a second boundary for adapter data built by other means.


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- Render `validate_against` as code in the unconditional `LoraAdapter` constructor documentation instead of linking it as an always-present associated method.
- Preserve the useful method reference without making rustdoc resolve an API that exists only when `inference-hook` is enabled.

## Root cause

`LoraAdapter::validate_against` is compiled behind `#[cfg(feature = "inference-hook")]`, while the constructor documentation is unconditional. Building docs with `train-backward` but without `inference-hook` therefore made warning-denied rustdoc reject `Self::validate_against` as a broken intra-doc link.

## Validation

- `RUSTDOCFLAGS=-Dwarnings cargo doc -p lattice-tune --features train-backward --no-deps` — passed.
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p lattice-tune --no-deps` — passed.
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p lattice-tune --features train-backward,inference-hook --no-deps` — passed.
- Repository pre-commit hook — passed, including workspace Clippy, formatting, recursive Markdown lint, and capability-matrix fixture checks.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

## Mutation proof

Restoring the conditional intra-doc link made the exact warning-denied `train-backward` rustdoc command fail with `unresolved link to Self::validate_against`. Restoring the code-span wording made the same command pass.

## bench-compare disposition
## bench-compare disposition

Structural waiver: the change is compiled out of both default bench binaries.

The default bench targets are `lattice-inference:elementwise_cpu_bench` (inference default features
`["std", "download", "serve"]`) and `lattice-embed:simd`. The changed file is
`crates/tune/src/lora/mod.rs`. Neither `crates/inference/Cargo.toml` nor `crates/embed/Cargo.toml`
declares a dependency on `lattice-tune`; the dependency runs the other way, `lattice-tune` gaining an
optional `dep:lattice-inference` behind its `inference-hook` feature. So no bench binary links this
crate and the effective bench source is identical between base and head.

Independently of that, the changed lines are a doc comment, which rustdoc consumes and rustc does
not codegen.

## Re-verification after rebase onto current main

The mutation proof above was re-run, scoped to the crate that contains the change:

```
RUSTDOCFLAGS='-D warnings -D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links'
cargo doc -p lattice-tune --no-deps

with the fix     -> exit 0, lattice-tune documented
fix reverted     -> exit 101, "unresolved link to `Self::validate_against`"
                    at crates/tune/src/lora/mod.rs:162
```

One note for whoever runs the workspace-wide form: `cargo doc --workspace --no-deps` under those
flags currently fails on `main` for unrelated reasons, in
`crates/inference/src/speculative.rs` (private-item links at lines 1358, 1359, and 1561). The
workspace doc build aborts in `lattice-inference` before reaching `lattice-tune`, so it cannot
observe this fix either way. That is why the verification above is crate-scoped. The
`rustdoc-lint` CI job is declared informational, which is why those pre-existing errors are not
blocking; they are tracked separately and are not in this PR's scope.
