### PR TITLE
chore(repo): reject developer-specific paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
         with:
           components: rustfmt, clippy
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
       - name: Pin the real toolchain bin on PATH
         # Some macos-latest runner images ship ~/.cargo/bin/cargo as a copy of
         # rustup-init rather than the rustup proxy, so `cargo fmt` fails with

--- a/apps/macos/docs/INSTRUMENT_SCOPE.md
+++ b/apps/macos/docs/INSTRUMENT_SCOPE.md
@@ -438,6 +438,6 @@ Files: `AppStore.swift`, `ChatScreen.swift`, `FaderToggle.swift`, `DomainModels.
 
 ---
 
-_Document generated from source reads. All file paths are absolute within the lattice repo at
-`/Users/lion/projects/khive/lattice/`. No build was run. All claims cite specific file and
-line numbers verified in the research phase._
+_Document generated from source reads. All file paths are relative to the lattice repository
+root. No build was run. All claims cite specific file and line numbers verified in the research
+phase._

--- a/crates/inference/examples/bench_gdn_state.rs
+++ b/crates/inference/examples/bench_gdn_state.rs
@@ -18,12 +18,12 @@
 /// `model.safetensors` → f16 weights.
 ///
 /// Usage (f16):
-///   LATTICE_MODEL_DIR=/Users/lion/.lattice/models/qwen3.5-0.8b \
+///   LATTICE_MODEL_DIR="${LATTICE_MODEL_CACHE:-$HOME/.lattice/models}/qwen3.5-0.8b" \
 ///   cargo run --release --example bench_gdn_state -p lattice-inference \
 ///     --features "f16,metal-gpu,gdn-state-counters"
 ///
 /// Usage (Q4):
-///   LATTICE_MODEL_DIR=/Users/lion/.lattice/models/qwen3.5-0.8b-q4 \
+///   LATTICE_MODEL_DIR="${LATTICE_MODEL_CACHE:-$HOME/.lattice/models}/qwen3.5-0.8b-q4" \
 ///   cargo run --release --example bench_gdn_state -p lattice-inference \
 ///     --features "f16,metal-gpu,gdn-state-counters"
 ///

--- a/crates/inference/examples/decode_profile.rs
+++ b/crates/inference/examples/decode_profile.rs
@@ -8,11 +8,11 @@
 /// `model.safetensors` → f16 weights.
 ///
 /// Usage (f16):
-///   LATTICE_MODEL_DIR=/Users/lion/.lattice/models/qwen3.5-0.8b \
+///   LATTICE_MODEL_DIR="${LATTICE_MODEL_CACHE:-$HOME/.lattice/models}/qwen3.5-0.8b" \
 ///   cargo run --release --example decode_profile -p lattice-inference --features "f16,metal-gpu"
 ///
 /// Usage (Q4):
-///   LATTICE_MODEL_DIR=/Users/lion/.lattice/models/qwen3.5-0.8b-q4 \
+///   LATTICE_MODEL_DIR="${LATTICE_MODEL_CACHE:-$HOME/.lattice/models}/qwen3.5-0.8b-q4" \
 ///   cargo run --release --example decode_profile -p lattice-inference --features "f16,metal-gpu"
 fn main() {
     #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -11,11 +11,7 @@ echo "=== Clippy ==="
 cargo clippy --workspace -- -D warnings
 
 echo "=== Doc Lint ==="
-if command -v deno >/dev/null 2>&1; then
-    ./scripts/lint-docs.sh
-else
-    echo "deno not found, skipping doc lint"
-fi
+./scripts/lint-docs.sh
 
 echo "=== Tests ==="
 # gemma4_e2e_forward_test.rs fails closed by default on a missing checkpoint

--- a/scripts/lint-absolute-paths.sh
+++ b/scripts/lint-absolute-paths.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# Reject developer-specific home paths from tracked documentation, Rust,
+# manifests, scripts, workflows, and JSON.
+#
+# Swift remains outside this check until its existing preview literals are
+# normalized under #1102.
+#
+# The historical benchmark evidence directory is intentionally excluded: those
+# immutable reports preserve the exact commands and paths used for their runs.
+#
+# Exit status:
+#   0 = clean
+#   1 = developer-specific paths found
+#   2 = checker failure
+#
+# Usage:
+#   scripts/lint-absolute-paths.sh
+#   scripts/lint-absolute-paths.sh --selftest
+
+set -u
+
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE
+
+SCRIPT_DIR=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd "$SCRIPT_DIR/.." && pwd)
+HOME_DIR_NAMES='Users|home'
+ABSOLUTE_PATH_RE="/(${HOME_DIR_NAMES})/[^/[:space:]]+/"
+
+run_check() {
+    check_root=$1
+    matches_file=$(mktemp "${TMPDIR:-/tmp}/lattice-absolute-path-matches.XXXXXX")
+    matches_rc=$?
+    if [ "$matches_rc" -ne 0 ] || [ -z "$matches_file" ]; then
+        echo "lint-absolute-paths: failed to create matches tempfile" >&2
+        return 2
+    fi
+
+    errors_file=$(mktemp "${TMPDIR:-/tmp}/lattice-absolute-path-errors.XXXXXX")
+    errors_rc=$?
+    if [ "$errors_rc" -ne 0 ] || [ -z "$errors_file" ]; then
+        echo "lint-absolute-paths: failed to create errors tempfile" >&2
+        rm -f "$matches_file"
+        return 2
+    fi
+
+    git -C "$check_root" grep -n -I -E "$ABSOLUTE_PATH_RE" -- \
+        '*.md' \
+        '*.rs' \
+        '*.toml' \
+        '*.sh' \
+        '*.py' \
+        '*.yml' \
+        '*.yaml' \
+        '*.json' \
+        ':(exclude)scripts/bench_evidence/**' \
+        >"$matches_file" 2>"$errors_file"
+    grep_rc=$?
+
+    case "$grep_rc" in
+        0)
+            echo "lint-absolute-paths: found developer-specific home paths:" >&2
+            if ! cat "$matches_file" >&2; then
+                echo "lint-absolute-paths: failed to report findings" >&2
+                rm -f "$matches_file" "$errors_file"
+                return 2
+            fi
+            rm -f "$matches_file" "$errors_file"
+            return 1
+            ;;
+        1)
+            if [ -s "$errors_file" ]; then
+                echo "lint-absolute-paths: git grep reported an error:" >&2
+                cat "$errors_file" >&2
+                rm -f "$matches_file" "$errors_file"
+                return 2
+            fi
+            rm -f "$matches_file" "$errors_file"
+            return 0
+            ;;
+        *)
+            echo "lint-absolute-paths: git grep failed (exit $grep_rc):" >&2
+            cat "$errors_file" >&2
+            rm -f "$matches_file" "$errors_file"
+            return 2
+            ;;
+    esac
+}
+
+selftest() {
+    sandbox=$(mktemp -d "${TMPDIR:-/tmp}/lattice-absolute-path-selftest.XXXXXX")
+    sandbox_rc=$?
+    case "$sandbox_rc:$sandbox" in
+        0:"${TMPDIR:-/tmp}"/lattice-absolute-path-selftest.*) ;;
+        *)
+            echo "lint-absolute-paths selftest: failed to create safe sandbox" >&2
+            return 2
+            ;;
+    esac
+    trap 'rm -rf "$sandbox"' 0 1 2 3 15
+
+    mkdir -p "$sandbox/docs" "$sandbox/crates/demo/src" "$sandbox/scripts/bench_evidence/run"
+    printf 'Use $%s/model-name.\n' 'LATTICE_MODEL_CACHE' >"$sandbox/docs/clean.md"
+    printf '%s\n' 'fn main() {}' >"$sandbox/crates/demo/src/main.rs"
+    printf '/%s/%s/projects/archive/model\n' 'Users' 'archived-runner' \
+        >"$sandbox/scripts/bench_evidence/run/report.json"
+    git -C "$sandbox" init -q
+    git -C "$sandbox" add docs crates scripts
+
+    clean_output="$sandbox/clean.out"
+    run_check "$sandbox" >"$clean_output" 2>&1
+    clean_rc=$?
+    if [ "$clean_rc" -ne 0 ]; then
+        echo "lint-absolute-paths selftest: clean tree returned $clean_rc" >&2
+        cat "$clean_output" >&2
+        return 1
+    fi
+
+    printf '/%s/%s/projects/demo\n' 'Users' 'developer' >"$sandbox/docs/dirty.md"
+    printf '// /%s/%s/src/demo\n' 'home' 'developer' \
+        >"$sandbox/crates/demo/src/dirty.rs"
+    git -C "$sandbox" add docs/dirty.md crates/demo/src/dirty.rs
+    dirty_output="$sandbox/dirty.out"
+    run_check "$sandbox" >"$dirty_output" 2>&1
+    dirty_rc=$?
+    if [ "$dirty_rc" -ne 1 ]; then
+        echo "lint-absolute-paths selftest: dirty tree returned $dirty_rc, expected 1" >&2
+        cat "$dirty_output" >&2
+        return 1
+    fi
+    if ! grep -F 'docs/dirty.md:1:' "$dirty_output" >/dev/null; then
+        echo "lint-absolute-paths selftest: macOS-style dirty finding was not reported" >&2
+        cat "$dirty_output" >&2
+        return 1
+    fi
+    if ! grep -F 'crates/demo/src/dirty.rs:1:' "$dirty_output" >/dev/null; then
+        echo "lint-absolute-paths selftest: Linux-style dirty finding was not reported" >&2
+        cat "$dirty_output" >&2
+        return 1
+    fi
+
+    missing_output="$sandbox/missing.out"
+    run_check "$sandbox/not-a-repository" >"$missing_output" 2>&1
+    missing_rc=$?
+    if [ "$missing_rc" -ne 2 ]; then
+        echo "lint-absolute-paths selftest: discovery failure returned $missing_rc, expected 2" >&2
+        cat "$missing_output" >&2
+        return 1
+    fi
+
+    echo "lint-absolute-paths selftest: clean, dirty, and failure fixtures passed"
+}
+
+case "${1:-}" in
+    "")
+        run_check "$REPO_ROOT"
+        rc=$?
+        if [ "$rc" -eq 0 ]; then
+            echo "lint-absolute-paths: clean"
+        fi
+        exit "$rc"
+        ;;
+    --selftest)
+        selftest
+        exit $?
+        ;;
+    *)
+        echo "usage: $0 [--selftest]" >&2
+        exit 64
+        ;;
+esac

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -102,31 +102,50 @@ esac
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
-markdown_list=$(mktemp "${TMPDIR:-/tmp}/lattice-markdown-files.XXXXXX")
-trap 'rm -f "$markdown_list"' 0 1 2 3 15
-git ls-files -z -- '*.md' >"$markdown_list"
-markdown_count=$(tr -cd '\000' <"$markdown_list" | wc -c | tr -d '[:space:]')
-if [ "$markdown_count" -eq 0 ]; then
-    echo "lint-docs: tracked Markdown discovery returned zero files" >&2
-    exit 1
-fi
 
 if [ "$mode" = "--format" ]; then
+    if ! command -v deno >/dev/null 2>&1; then
+        echo "lint-docs: deno not found; cannot format Markdown" >&2
+        exit 127
+    fi
+    markdown_list=$(mktemp "${TMPDIR:-/tmp}/lattice-markdown-files.XXXXXX")
+    trap 'rm -f "$markdown_list"' 0 1 2 3 15
+    git ls-files -z -- '*.md' >"$markdown_list"
+    markdown_count=$(tr -cd '\000' <"$markdown_list" | wc -c | tr -d '[:space:]')
+    if [ "$markdown_count" -eq 0 ]; then
+        echo "lint-docs: tracked Markdown discovery returned zero files" >&2
+        exit 1
+    fi
     echo "=== Formatting $markdown_count tracked Markdown files (deno) ==="
     xargs -0 deno fmt <"$markdown_list"
     exit 0
 fi
 
-echo "=== Doc Linting $markdown_count tracked Markdown files (deno) ==="
-xargs -0 deno fmt --check <"$markdown_list"
-xargs -0 deno lint <"$markdown_list" 2>/dev/null || true
+if command -v deno >/dev/null 2>&1; then
+    markdown_list=$(mktemp "${TMPDIR:-/tmp}/lattice-markdown-files.XXXXXX")
+    trap 'rm -f "$markdown_list"' 0 1 2 3 15
+    git ls-files -z -- '*.md' >"$markdown_list"
+    markdown_count=$(tr -cd '\000' <"$markdown_list" | wc -c | tr -d '[:space:]')
+    if [ "$markdown_count" -eq 0 ]; then
+        echo "lint-docs: tracked Markdown discovery returned zero files" >&2
+        exit 1
+    fi
+    echo "=== Doc Linting $markdown_count tracked Markdown files (deno) ==="
+    xargs -0 deno fmt --check <"$markdown_list"
+    xargs -0 deno lint <"$markdown_list" 2>/dev/null || true
 
-if [ "$mode" = "--markdown-only" ]; then
-    exit 0
+    if [ "$mode" = "--markdown-only" ]; then
+        exit 0
+    fi
+
+    echo "=== Recursive Markdown Discovery Self-Test (#1148) ==="
+    "$script_path" --selftest
+elif [ "$mode" = "--markdown-only" ]; then
+    echo "lint-docs: deno not found; cannot lint Markdown" >&2
+    exit 127
+else
+    echo "lint-docs: deno not found; skipping Markdown format, lint, and discovery self-test"
 fi
-
-echo "=== Recursive Markdown Discovery Self-Test (#1148) ==="
-"$script_path" --selftest
 
 echo "=== Capability Matrix Fixture Check (#654) ==="
 "$script_dir/check-capability-matrix.sh" --selftest

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -132,4 +132,8 @@ echo "=== Capability Matrix Fixture Check (#654) ==="
 "$script_dir/check-capability-matrix.sh" --selftest
 "$script_dir/check-capability-matrix.sh"
 
+echo "=== Absolute Developer Path Check (#1102) ==="
+"$script_dir/lint-absolute-paths.sh" --selftest
+"$script_dir/lint-absolute-paths.sh"
+
 echo "=== Doc Lint Passed ==="


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- replace the remaining developer-specific macOS paths in tracked documentation and Rust examples with repository-relative or cache-relative forms
- add a fail-closed checker for tracked Markdown, Rust, manifest, script, workflow, and JSON files on both macOS- and Linux-style home paths
- run the check and its hermetic clean/dirty/failure fixtures from the existing documentation lint gate

Refs #1102. This is a deliberately narrow stage: Swift preview literals and the issue's broader personal-name/process-language audit remain open. Immutable files under `scripts/bench_evidence/` are excluded because they preserve the exact commands and paths from historical runs.

## Validation

- `./scripts/lint-absolute-paths.sh --selftest`
- `./scripts/lint-absolute-paths.sh`
- `sh -n scripts/lint-absolute-paths.sh scripts/lint-docs.sh`
- `shellcheck -s sh scripts/lint-absolute-paths.sh`
- `./scripts/lint-docs.sh` (179 tracked Markdown files)
- `cargo check -p lattice-inference --examples`
- `cargo clippy -p lattice-inference --examples -- -D warnings`
- repository pre-commit hook
- `git diff --check`

Mutation proof: temporarily restoring `/Users/mutation/lattice/` in a tracked example made the live checker report the exact file and line and exit 1; restoring the cache-relative path returned the tree to green.

## bench-compare disposition

Not run: this changes documentation, example usage text, and an offline lint gate only; it does not change an inference hot path or benchmark behavior.