### PR TITLE
fix(grammar): reject malformed runtime rule ids

### DIFF
--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -257,7 +257,9 @@ fn try_advance_stack(stack: &mut Vec<StackFrame>, grammar: &CompiledGrammar, b: 
 
         let frame_idx = stack.len() - 1;
         let frame = &stack[frame_idx];
-        let rule = &grammar.rules[frame.rule_id];
+        let Some(rule) = grammar.rules.get(frame.rule_id) else {
+            return false;
+        };
 
         // Rule with no alternatives: dead end → reject via next-alt or backtrack.
         if rule.alts.is_empty() {
@@ -321,7 +323,10 @@ fn try_advance_stack(stack: &mut Vec<StackFrame>, grammar: &CompiledGrammar, b: 
                 let rid = *rule_id;
                 // Push a new frame for the non-terminal's first alt.
                 // Before pushing, check if the referenced rule has any alts.
-                if grammar.rules[rid].alts.is_empty() {
+                let Some(referenced_rule) = grammar.rules.get(rid) else {
+                    return false;
+                };
+                if referenced_rule.alts.is_empty() {
                     // Empty rule = epsilon; advance past the non-terminal.
                     stack[frame_idx].sym_pos += 1;
                     continue;
@@ -1042,5 +1047,40 @@ mod tests {
         let id1 = builder.reserve("foo");
         let id2 = builder.reserve("foo");
         assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn empty_direct_grammar_rejects_without_panicking() {
+        let grammar = CompiledGrammar { rules: Vec::new() };
+        let mut state = GrammarState::initial();
+        let before = state.clone();
+
+        assert_eq!(
+            advance_byte(&mut state, &grammar, b'x'),
+            StepResult::Rejected
+        );
+        assert_eq!(state.stack, before.stack);
+        assert_eq!(state.partial_token_bytes, before.partial_token_bytes);
+        assert_eq!(state.complete, before.complete);
+    }
+
+    #[test]
+    fn dangling_non_terminal_rejects_without_panicking() {
+        let grammar = CompiledGrammar {
+            rules: vec![Rule {
+                name: "root".to_string(),
+                alts: vec![vec![Symbol::NonTerminal(1)]],
+            }],
+        };
+        let mut state = GrammarState::initial();
+        let before = state.clone();
+
+        assert_eq!(
+            advance_byte(&mut state, &grammar, b'x'),
+            StepResult::Rejected
+        );
+        assert_eq!(state.stack, before.stack);
+        assert_eq!(state.partial_token_bytes, before.partial_token_bytes);
+        assert_eq!(state.complete, before.complete);
     }
 }


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- bounds-check the active PDA rule before reading it
- reject dangling `NonTerminal` rule IDs instead of indexing past the compiled rule table
- preserve the complete `GrammarState` when either malformed runtime shape is rejected

This is the narrow malformed-`CompiledGrammar` runtime-index half of F5 in #322. It does not claim to harden `GrammarBuilder::set_alts`, `CompiledGrammar::root`, or caller-constructed malformed `GrammarState` frame indices.

Refs #322.

## Stack

Depends on #1235 and intentionally targets `codex/322-iterative-alt` because both changes touch the PDA alternative-walk implementation. The one-commit diff here is only the two guards and their regressions.

## Validation

- independent review: APPROVE, no findings
- fail-first mutation: the empty rule table panicked at the former direct index; restored guard makes it reject
- fail-first mutation: the dangling non-terminal panicked at the former direct index; restored guard makes it reject
- focused combined PDA suite: 21 passed
- full combined inference library suite: 2,417 passed, 20 ignored
- `cargo clippy -p lattice-inference --lib -- -D warnings`: passed
- pre-commit hook: passed (workspace check plus 179-file documentation lint)
- `cargo fmt --check` / `git diff --check`: passed

## bench-compare disposition

Required because the PDA implementation is compiled into the default inference crate, even though the new branches are malformed-input rejection paths only.

Attempted the exact-SHA command:

```text
CARGO_TARGET_DIR=/Users/lion/khive-work/target make bench-compare BASE=c124144cb62b5676b9d878ea2f1bfc84abc0bc7a HEAD=a721349800dab19e4c272f776f0f7a1b6e253c7c
```

The harness refused before measuring base because machine idle was 0.2% versus the required 70% floor; active `kkernel`/`rustc` processes made the host uncertifiable. I did not lower the floor. This draft makes no performance claim; a certified A/B remains pending on a quiet host.